### PR TITLE
Add context managers to swap parts of Spack in code

### DIFF
--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -23,6 +23,7 @@ install trees to define their own layouts with some per-tree
 configuration.
 
 """
+import contextlib
 import os
 import re
 import six
@@ -227,3 +228,28 @@ def _construct_upstream_dbs_from_install_roots(
         accumulated_upstream_dbs.insert(0, next_db)
 
     return accumulated_upstream_dbs
+
+
+@contextlib.contextmanager
+def use_store(store_or_path):
+    """Use the store passed as argument within the context manager.
+
+    Args:
+        store_or_path: either a Store object ot a path to where the store resides
+
+    Returns:
+        Store object associated with the context manager's store
+    """
+    global store
+
+    # Normalize input arguments
+    temporary_store = store_or_path
+    if not isinstance(store_or_path, Store):
+        temporary_store = Store(store_or_path)
+
+    # Swap the store with the one just constructed and return it
+    original_store, store = store, temporary_store
+    yield temporary_store
+
+    # Restore the original store
+    store = original_store

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -6,6 +6,7 @@
 """ Test checks if the architecture class is created correctly and also that
     the functions are looking for the correct architecture name
 """
+import itertools
 import os
 import platform as py_platform
 
@@ -116,20 +117,26 @@ def test_user_defaults(config):
     assert default_target == default_spec.architecture.target
 
 
-@pytest.mark.parametrize('operating_system', [
-    x for x in spack.architecture.platform().operating_sys
-] + ["fe", "be", "frontend", "backend"])
-@pytest.mark.parametrize('target', [
-    x for x in spack.architecture.platform().targets
-] + ["fe", "be", "frontend", "backend"])
-def test_user_input_combination(config, operating_system, target):
-    platform = spack.architecture.platform()
-    spec = Spec("libelf os=%s target=%s" % (operating_system, target))
-    spec.concretize()
-    assert spec.architecture.os == str(
-        platform.operating_system(operating_system)
-    )
-    assert spec.architecture.target == platform.target(target)
+def test_user_input_combination(config):
+    valid_keywords = ["fe", "be", "frontend", "backend"]
+
+    possible_targets = ([x for x in spack.architecture.platform().targets]
+                        + valid_keywords)
+
+    possible_os = ([x for x in spack.architecture.platform().operating_sys]
+                   + valid_keywords)
+
+    for target, operating_system in itertools.product(
+        possible_targets, possible_os
+    ):
+        platform = spack.architecture.platform()
+        spec_str = "libelf os={0} target={1}".format(operating_system, target)
+        spec = Spec(spec_str)
+        spec.concretize()
+        assert spec.architecture.os == str(
+            platform.operating_system(operating_system)
+        )
+        assert spec.architecture.target == platform.target(target)
 
 
 def test_operating_system_conversion_to_dict():

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -73,7 +73,7 @@ and then 'd', 'b', and 'a' to be put in the next three stages, respectively.
     b = mock_repo.add_package('b', [d, e], [default, default])
     mock_repo.add_package('a', [b, c], [default, default])
 
-    with repo.swap(mock_repo):
+    with repo.use_repositories(mock_repo):
         spec_a = Spec('a')
         spec_a.concretize()
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -330,7 +330,7 @@ def test_env_status_broken_view(
         # switch to a new repo that doesn't include the installed package
         # test that Spack detects the missing package and warns the user
         new_repo = MockPackageMultiRepo()
-        with spack.repo.swap(new_repo):
+        with spack.repo.use_repositories(new_repo):
             output = env('status')
             assert 'In environment test' in output
             assert 'Environment test includes out of date' in output
@@ -351,7 +351,7 @@ def test_env_activate_broken_view(
     # switch to a new repo that doesn't include the installed package
     # test that Spack detects the missing package and fails gracefully
     new_repo = MockPackageMultiRepo()
-    with spack.repo.swap(new_repo):
+    with spack.repo.use_repositories(new_repo):
         with pytest.raises(SpackCommandError):
             env('activate', '--sh', 'test')
 
@@ -929,7 +929,7 @@ def test_read_old_lock_and_write_new(tmpdir):
     y = mock_repo.add_package('y', [], [])
     mock_repo.add_package('x', [y], [build_only])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         x = Spec('x')
         x.concretize()
 
@@ -960,7 +960,7 @@ def test_read_old_lock_creates_backup(tmpdir):
     mock_repo = MockPackageMultiRepo()
     y = mock_repo.add_package('y', [], [])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         y = Spec('y')
         y.concretize()
 
@@ -997,7 +997,7 @@ def test_indirect_build_dep():
         pass
     setattr(mock_repo, 'dump_provenance', noop)
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         x_spec = Spec('x')
         x_concretized = x_spec.concretized()
 
@@ -1038,7 +1038,7 @@ def test_store_different_build_deps():
         pass
     setattr(mock_repo, 'dump_provenance', noop)
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         y_spec = Spec('y ^z@3')
         y_concretized = y_spec.concretized()
 

--- a/lib/spack/spack/test/cmd/extensions.py
+++ b/lib/spack/spack/test/cmd/extensions.py
@@ -27,7 +27,7 @@ def python_database(mock_packages, mutable_database):
 
 
 @pytest.mark.db
-def test_extensions(mock_packages, python_database, capsys):
+def test_extensions(mock_packages, python_database, config, capsys):
     ext2   = Spec("py-extension2").concretized()
 
     def check_output(ni, na):

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -8,10 +8,10 @@ import re
 
 import pytest
 
+import spack.config
 import spack.main
 import spack.modules
 import spack.store
-from spack.test.conftest import use_configuration
 
 module = spack.main.SpackCommand('module')
 
@@ -19,11 +19,12 @@ module = spack.main.SpackCommand('module')
 #: make sure module files are generated for all the tests here
 @pytest.fixture(scope='module', autouse=True)
 def ensure_module_files_are_there(
-        mock_repo_path, mock_store, mock_configuration):
+        mock_repo_path, mock_store, mock_configuration_scopes
+):
     """Generate module files for module tests."""
     module = spack.main.SpackCommand('module')
     with spack.store.use_store(mock_store):
-        with use_configuration(mock_configuration):
+        with spack.config.use_configuration(*mock_configuration_scopes):
             with spack.repo.use_repositories(mock_repo_path):
                 module('tcl', 'refresh', '-y')
 

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -10,7 +10,8 @@ import pytest
 
 import spack.main
 import spack.modules
-from spack.test.conftest import use_store, use_configuration
+import spack.store
+from spack.test.conftest import use_configuration
 
 module = spack.main.SpackCommand('module')
 
@@ -21,7 +22,7 @@ def ensure_module_files_are_there(
         mock_repo_path, mock_store, mock_configuration):
     """Generate module files for module tests."""
     module = spack.main.SpackCommand('module')
-    with use_store(mock_store):
+    with spack.store.use_store(mock_store):
         with use_configuration(mock_configuration):
             with spack.repo.use_repositories(mock_repo_path):
                 module('tcl', 'refresh', '-y')

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -10,7 +10,7 @@ import pytest
 
 import spack.main
 import spack.modules
-from spack.test.conftest import use_store, use_configuration, use_repo
+from spack.test.conftest import use_store, use_configuration
 
 module = spack.main.SpackCommand('module')
 
@@ -23,7 +23,7 @@ def ensure_module_files_are_there(
     module = spack.main.SpackCommand('module')
     with use_store(mock_store):
         with use_configuration(mock_configuration):
-            with use_repo(mock_repo_path):
+            with spack.repo.use_repositories(mock_repo_path):
                 module('tcl', 'refresh', '-y')
 
 

--- a/lib/spack/spack/test/cmd/pkg.py
+++ b/lib/spack/spack/test/cmd/pkg.py
@@ -82,7 +82,7 @@ def mock_pkg_git_repo(tmpdir_factory):
         git('-c', 'commit.gpgsign=false', 'commit',
             '-m', 'change pkg-b, remove pkg-c, add pkg-d')
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         yield mock_repo_packages
 
 

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -12,7 +12,7 @@ env = SpackCommand('env')
 concretize = SpackCommand('concretize')
 
 
-def test_undevelop(tmpdir, mock_packages, mutable_mock_env_path):
+def test_undevelop(tmpdir, config, mock_packages, mutable_mock_env_path):
     # setup environment
     envdir = tmpdir.mkdir('env')
     with envdir.as_cwd():
@@ -39,7 +39,7 @@ env:
     assert not after.satisfies('dev_path=*')
 
 
-def test_undevelop_nonexistent(tmpdir, mock_packages, mutable_mock_env_path):
+def test_undevelop_nonexistent(tmpdir, config, mock_packages, mutable_mock_env_path):
     # setup environment
     envdir = tmpdir.mkdir('env')
     with envdir.as_cwd():

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -304,7 +304,7 @@ class TestConcretize(object):
         barpkg = mock_repo.add_package('barpkg', [bazpkg], [default_dep])
         mock_repo.add_package('foopkg', [barpkg], [default_dep])
 
-        with spack.repo.swap(mock_repo):
+        with spack.repo.use_repositories(mock_repo):
             spec = Spec('foopkg %gcc@4.5.0 os=CNL target=nocona' +
                         ' ^barpkg os=SuSE11 ^bazpkg os=be')
             spec.concretize()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -35,6 +35,7 @@ import spack.paths
 import spack.platforms.test
 import spack.repo
 import spack.stage
+import spack.store
 import spack.util.executable
 import spack.util.gpg
 import spack.subprocess_context
@@ -373,15 +374,6 @@ def use_configuration(config):
     spack.compilers._cache_config_file = saved_compiler_cache
 
 
-@contextlib.contextmanager
-def use_store(store):
-    """Context manager to swap out the global Spack store."""
-    saved = spack.store.store
-    spack.store.store = store
-    yield
-    spack.store.store = saved
-
-
 #
 # Test-specific fixtures
 #
@@ -630,12 +622,11 @@ def mock_store(tmpdir_factory, mock_repo_path, mock_configuration,
 
     """
     store_path, store_cache = _store_dir_and_cache
-    store = spack.store.Store(str(store_path))
 
     # If the cache does not exist populate the store and create it
     if not os.path.exists(str(store_cache.join('.spack-db'))):
         with use_configuration(mock_configuration):
-            with use_store(store):
+            with spack.store.use_store(str(store_path)) as store:
                 with spack.repo.use_repositories(mock_repo_path):
                     _populate(store.db)
         store_path.copy(store_cache, mode=True, stat=True)
@@ -660,12 +651,11 @@ def mutable_mock_store(tmpdir_factory, mock_repo_path, mock_configuration,
 
     """
     store_path, store_cache = _store_dir_and_cache
-    store = spack.store.Store(str(store_path))
 
     # If the cache does not exist populate the store and create it
     if not os.path.exists(str(store_cache.join('.spack-db'))):
         with use_configuration(mock_configuration):
-            with use_store(store):
+            with spack.store.use_store(str(store_path)) as store:
                 with spack.repo.use_repositories(mock_repo_path):
                     _populate(store.db)
         store_path.copy(store_cache, mode=True, stat=True)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import collections
-import contextlib
 import errno
 import inspect
 import itertools
@@ -336,7 +335,7 @@ spack.config.config = spack.config._config()
 
 
 #
-# Context managers used by fixtures
+# Note on context managers used by fixtures
 #
 # Because these context managers modify global state, they should really
 # ONLY be used persistently (i.e., around yield statements) in
@@ -356,23 +355,6 @@ spack.config.config = spack.config._config()
 # these global objects, but we shouldn't module- or session-scope their
 # *USE*, or things can get really confusing.
 #
-
-@contextlib.contextmanager
-def use_configuration(config):
-    """Context manager to swap out the global Spack configuration."""
-    saved = spack.config.replace_config(config)
-
-    # Avoid using real spack configuration that has been cached by other
-    # tests, and avoid polluting the cache with spack test configuration
-    # (including modified configuration)
-    saved_compiler_cache = spack.compilers._cache_config_file
-    spack.compilers._cache_config_file = []
-
-    yield
-
-    spack.config.replace_config(saved)
-    spack.compilers._cache_config_file = saved_compiler_cache
-
 
 #
 # Test-specific fixtures
@@ -430,9 +412,7 @@ def default_config():
     This ensures we can test the real default configuration without having
     tests fail when the user overrides the defaults that we test against."""
     defaults_path = os.path.join(spack.paths.etc_path, 'spack', 'defaults')
-    defaults_scope = spack.config.ConfigScope('defaults', defaults_path)
-    defaults_config = spack.config.Configuration(defaults_scope)
-    with use_configuration(defaults_config):
+    with spack.config.use_configuration(defaults_path) as defaults_config:
         yield defaults_config
 
 
@@ -507,7 +487,7 @@ def configuration_dir(tmpdir_factory, linux_os):
 
 
 @pytest.fixture(scope='session')
-def mock_configuration(configuration_dir):
+def mock_configuration_scopes(configuration_dir):
     """Create a persistent Configuration object from the configuration_dir."""
     defaults = spack.config.InternalConfigScope(
         '_builtin', spack.config.config_defaults
@@ -518,14 +498,14 @@ def mock_configuration(configuration_dir):
         for name in ['site', 'system', 'user']]
     test_scopes.append(spack.config.InternalConfigScope('command_line'))
 
-    yield spack.config.Configuration(*test_scopes)
+    yield test_scopes
 
 
 @pytest.fixture(scope='function')
-def config(mock_configuration):
+def config(mock_configuration_scopes):
     """This fixture activates/deactivates the mock configuration."""
-    with use_configuration(mock_configuration):
-        yield mock_configuration
+    with spack.config.use_configuration(*mock_configuration_scopes) as config:
+        yield config
 
 
 @pytest.fixture(scope='function')
@@ -534,11 +514,10 @@ def mutable_config(tmpdir_factory, configuration_dir):
     mutable_dir = tmpdir_factory.mktemp('mutable_config').join('tmp')
     configuration_dir.copy(mutable_dir)
 
-    cfg = spack.config.Configuration(
-        *[spack.config.ConfigScope(name, str(mutable_dir.join(name)))
-          for name in ['site', 'system', 'user']])
+    scopes = [spack.config.ConfigScope(name, str(mutable_dir.join(name)))
+              for name in ['site', 'system', 'user']]
 
-    with use_configuration(cfg):
+    with spack.config.use_configuration(*scopes) as cfg:
         yield cfg
 
 
@@ -546,23 +525,20 @@ def mutable_config(tmpdir_factory, configuration_dir):
 def mutable_empty_config(tmpdir_factory, configuration_dir):
     """Empty configuration that can be modified by the tests."""
     mutable_dir = tmpdir_factory.mktemp('mutable_config').join('tmp')
+    scopes = [spack.config.ConfigScope(name, str(mutable_dir.join(name)))
+              for name in ['site', 'system', 'user']]
 
-    cfg = spack.config.Configuration(
-        *[spack.config.ConfigScope(name, str(mutable_dir.join(name)))
-          for name in ['site', 'system', 'user']])
-
-    with use_configuration(cfg):
+    with spack.config.use_configuration(*scopes) as cfg:
         yield cfg
 
 
 @pytest.fixture()
 def mock_low_high_config(tmpdir):
     """Mocks two configuration scopes: 'low' and 'high'."""
-    config = spack.config.Configuration(
-        *[spack.config.ConfigScope(name, str(tmpdir.join(name)))
-          for name in ['low', 'high']])
+    scopes = [spack.config.ConfigScope(name, str(tmpdir.join(name)))
+              for name in ['low', 'high']]
 
-    with use_configuration(config):
+    with spack.config.use_configuration(*scopes) as config:
         yield config
 
 
@@ -611,7 +587,7 @@ def _store_dir_and_cache(tmpdir_factory):
 
 
 @pytest.fixture(scope='session')
-def mock_store(tmpdir_factory, mock_repo_path, mock_configuration,
+def mock_store(tmpdir_factory, mock_repo_path, mock_configuration_scopes,
                _store_dir_and_cache):
     """Creates a read-only mock database with some packages installed note
     that the ref count for dyninst here will be 3, as it's recycled
@@ -625,7 +601,7 @@ def mock_store(tmpdir_factory, mock_repo_path, mock_configuration,
 
     # If the cache does not exist populate the store and create it
     if not os.path.exists(str(store_cache.join('.spack-db'))):
-        with use_configuration(mock_configuration):
+        with spack.config.use_configuration(*mock_configuration_scopes):
             with spack.store.use_store(str(store_path)) as store:
                 with spack.repo.use_repositories(mock_repo_path):
                     _populate(store.db)
@@ -640,8 +616,10 @@ def mock_store(tmpdir_factory, mock_repo_path, mock_configuration,
 
 
 @pytest.fixture(scope='function')
-def mutable_mock_store(tmpdir_factory, mock_repo_path, mock_configuration,
-                       _store_dir_and_cache):
+def mutable_mock_store(
+        tmpdir_factory, mock_repo_path, mock_configuration_scopes,
+        _store_dir_and_cache
+):
     """Creates a read-only mock database with some packages installed note
     that the ref count for dyninst here will be 3, as it's recycled
     across each install.
@@ -654,7 +632,7 @@ def mutable_mock_store(tmpdir_factory, mock_repo_path, mock_configuration,
 
     # If the cache does not exist populate the store and create it
     if not os.path.exists(str(store_cache.join('.spack-db'))):
-        with use_configuration(mock_configuration):
+        with spack.config.use_configuration(*mock_configuration_scopes):
             with spack.store.use_store(str(store_path)) as store:
                 with spack.repo.use_repositories(mock_repo_path):
                     _populate(store.db)

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -81,7 +81,7 @@ def test_installed_upstream(upstream_and_downstream_db):
     y = mock_repo.add_package('y', [z], [default])
     mock_repo.add_package('w', [x, y], [default, default])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         spec = spack.spec.Spec('w')
         spec.concretize()
 
@@ -122,7 +122,7 @@ def test_removed_upstream_dep(upstream_and_downstream_db):
     z = mock_repo.add_package('z', [], [])
     mock_repo.add_package('y', [z], [default])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         spec = spack.spec.Spec('y')
         spec.concretize()
 
@@ -155,7 +155,7 @@ def test_add_to_upstream_after_downstream(upstream_and_downstream_db):
     mock_repo = MockPackageMultiRepo()
     mock_repo.add_package('x', [], [])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         spec = spack.spec.Spec('x')
         spec.concretize()
 
@@ -197,7 +197,7 @@ def test_cannot_write_upstream(tmpdir_factory, test_store, gen_mock_layout):
     upstream_dbs = spack.store._construct_upstream_dbs_from_install_roots(
         [roots[1]], _test=True)
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         spec = spack.spec.Spec('x')
         spec.concretize()
 
@@ -216,7 +216,7 @@ def test_recursive_upstream_dbs(tmpdir_factory, test_store, gen_mock_layout):
     y = mock_repo.add_package('y', [z], [default])
     mock_repo.add_package('x', [y], [default])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         spec = spack.spec.Spec('x')
         spec.concretize()
         db_c = spack.database.Database(roots[2])
@@ -694,7 +694,7 @@ def test_115_reindex_with_packages_not_in_repo(mutable_database):
     # Dont add any package definitions to this repository, the idea is that
     # packages should not have to be defined in the repository once they
     # are installed
-    with spack.repo.swap(MockPackageMultiRepo()):
+    with spack.repo.use_repositories(MockPackageMultiRepo()):
         spack.store.store.reindex()
         _check_db_sanity(mutable_database)
 

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -194,7 +194,7 @@ def test_handle_unknown_package(layout_and_dir, config, mock_packages):
         layout.create_install_directory(spec)
         installed_specs[spec] = layout.path_for_spec(spec)
 
-    with spack.repo.swap(mock_db):
+    with spack.repo.use_repositories(mock_db):
         # Now check that even without the package files, we know
         # enough to read a spec from the spec file.
         for spec, path in installed_specs.items():

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -474,14 +474,14 @@ def test_packages_needed_to_bootstrap_compiler_packages(install_mockery,
     assert packages
 
 
-def test_dump_packages_deps_ok(install_mockery, tmpdir, mock_repo_path):
+def test_dump_packages_deps_ok(install_mockery, tmpdir, mock_packages):
     """Test happy path for dump_packages with dependencies."""
 
     spec_name = 'simple-inheritance'
     spec = spack.spec.Spec(spec_name).concretized()
     inst.dump_packages(spec, str(tmpdir))
 
-    repo = mock_repo_path.repos[0]
+    repo = mock_packages.repos[0]
     dest_pkg = repo.filename_for_package_name(spec_name)
     assert os.path.isfile(dest_pkg)
 

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -73,7 +73,7 @@ def test_repo_getpkg_names_and_classes():
 def test_get_all_mock_packages():
     """Get the mock packages once each too."""
     db = spack.repo.RepoPath(spack.paths.mock_packages_path)
-    with spack.repo.swap(db):
+    with spack.repo.use_repositories(db):
         check_repo()
 
 

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -75,7 +75,7 @@ w->y deptypes are (link, build), w->x and y->z deptypes are (test)
     y = mock_repo.add_package('y', [z], [test_only])
     w = mock_repo.add_package('w', [x, y], [test_only, default])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         spec = Spec('w')
         spec.concretize(tests=(w.name,))
 
@@ -114,7 +114,7 @@ def test_installed_deps():
     b = mock_repo.add_package('b', [d, e], [default, default])
     mock_repo.add_package('a', [b, c], [default, default])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         c_spec = Spec('c')
         c_spec.concretize()
         assert c_spec['d'].version == spack.version.Version('2')
@@ -143,7 +143,7 @@ def test_specify_preinstalled_dep():
     b = mock_repo.add_package('b', [c], [default])
     mock_repo.add_package('a', [b], [default])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         b_spec = Spec('b')
         b_spec.concretize()
         for spec in b_spec.traverse():
@@ -186,7 +186,7 @@ def test_conditional_dep_with_user_constraints(spec_str, expr_str, expected):
     }
     mock_repo.add_package('x', [y], [default], conditions=x_on_y_conditions)
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         spec = Spec(spec_str)
         spec.concretize()
 

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -310,7 +310,7 @@ def test_save_dependency_spec_yamls_subset(tmpdir, config):
     b = mock_repo.add_package('b', [d, e], [default, default])
     mock_repo.add_package('a', [b, c], [default, default])
 
-    with repo.swap(mock_repo):
+    with repo.use_repositories(mock_repo):
         spec_a = Spec('a')
         spec_a.concretize()
         b_spec = spec_a['b']

--- a/lib/spack/spack/test/test_activations.py
+++ b/lib/spack/spack/test/test_activations.py
@@ -54,7 +54,7 @@ def builtin_and_mock_packages():
     repo_dirs = [spack.paths.packages_path, spack.paths.mock_packages_path]
     path = RepoPath(*repo_dirs)
 
-    with spack.repo.swap(path):
+    with spack.repo.use_repositories(path):
         yield
 
 

--- a/lib/spack/spack/test/util/mock_package.py
+++ b/lib/spack/spack/test/util/mock_package.py
@@ -15,7 +15,7 @@ def test_mock_package_possible_dependencies():
     b = mock_repo.add_package('b', [d])
     a = mock_repo.add_package('a', [b, c])
 
-    with spack.repo.swap(mock_repo):
+    with spack.repo.use_repositories(mock_repo):
         assert set(a.possible_dependencies()) == set(['a', 'b', 'c', 'd', 'e'])
         assert set(b.possible_dependencies()) == set(['b', 'd', 'e'])
         assert set(c.possible_dependencies()) == set(['c', 'd', 'e'])

--- a/lib/spack/spack/util/mock_package.py
+++ b/lib/spack/spack/util/mock_package.py
@@ -8,6 +8,7 @@
 import ordereddict_backport
 
 import spack.util.naming
+import spack.provider_index
 from spack.dependency import Dependency
 from spack.spec import Spec
 from spack.version import Version
@@ -80,6 +81,8 @@ class MockPackageMultiRepo(object):
 
     def __init__(self):
         self.spec_to_pkg = {}
+        self.namespace = ''
+        self.full_namespace = 'spack.pkg.mock'
 
     def get(self, spec):
         if not isinstance(spec, spack.spec.Spec):
@@ -171,3 +174,7 @@ class MockPackageMultiRepo(object):
         self.spec_to_pkg["mockrepo." + name] = mock_package
 
         return mock_package
+
+    @property
+    def provider_index(self):
+        return spack.provider_index.ProviderIndex()


### PR DESCRIPTION
Fixes #17966

This PR adds several context managers to the current API of Spack. These context managers may be used to swap part of the current configuration within the context. For instance:
```python
with spack.repo.use_repositories(*paths_to_repos) as repo_path:
    pass
```
can be used to swap the repositories that are hooked into Spack for the duration of the context. Context managers are currently provided for:
- [x] Package repositories
- [x] Configuration scopes
- [x] Store
- [x] Platform   

and others may be added as needed.

These context managers are used in this PR to resolve a longstanding issue with our testing framework, which was modifying global variables in `conftest.py` to avoid later failures. Now these modifications are done in fixtures and can be undone during tests, if need be, by nested context managers.

Another use of these context managers is in #20207 (or derived PRs) to fix a few aspects of the configuration for bootstrapping Spack, regardless of the use case under consideration. This permits, for instance, to use a bootstrapped clingo to run unit tests (where a mock "test" platform is substituted to the host platform) or to bootstrap clingo a single time when trying to concretize environments defining a custom store location.