### PR TITLE
Handle invalid unicode while logging.

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -780,7 +780,12 @@ def _writer_daemon(stdin_multiprocess_fd, read_multiprocess_fd, write_fd, echo,
                     try:
                         while line_count < 100:
                             # Handle output from the calling process.
-                            line = _retry(in_pipe.readline)()
+                            try:
+                                line = _retry(in_pipe.readline)()
+                            except UnicodeDecodeError:
+                                # installs like --test=root gpgme produce non-UTF8 logs
+                                line = '<line lost: output was not encoded as UTF-8>\n'
+
                             if not line:
                                 return
                             line_count += 1


### PR DESCRIPTION
Sometimes build processes will emit invalid unicode. In my case,
I ran into while building libtheora. (See merge request for traceback.)

This simply catches those errors and continues processes the log. I
normally wouldn't catch and release like this, but:

 1. This problem is obviously not endemic
 2. The alternative is to read in binary mode,
    and then decode while ignoring errors. If that's the solution that's
    prefered, it shouldn't be too big of a deal to tackle it.

One more thing
#############

An error like this might cascade; One invalid read puts the cursor at a bad position for reading the next unicode bytes, which cause the error again, and so on. With UTF8, this is pretty unlikely unless the text is very unicode heavy, as most characters should be readable as a single byte. 

```
==> Error: Exception occurred in writer daemon!
Traceback (most recent call last):
  File "/yellow/users/pflarr/repos/spack/lib/spack/llnl/util/tty/log.py", line 768, in _writer_daemon
    line = _retry(in_pipe.readline)()
  File "/yellow/users/pflarr/repos/spack/lib/spack/llnl/util/tty/log.py", line 830, in wrapped
    return function(*args, **kwargs)
  File "/var/lib/perceus/vnfs/asc-fe/rootfs/usr/lib64/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x97 in position 145: invalid start byte
```