### PR TITLE
add intel oneapi to compiler/pkg translations

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -41,7 +41,8 @@ _cache_config_file = []
 _compiler_cache = {}  # type: Dict[str, spack.compiler.Compiler]
 
 _compiler_to_pkg = {
-    'clang': 'llvm+clang'
+    'clang': 'llvm+clang',
+    'oneapi': 'intel-oneapi-compilers'
 }
 
 


### PR DESCRIPTION
Compilers that have a different package name than the compiler name (like llvm+clang vs %clang or intel-oneapi-compilers vs %oneapi) require entries in a private dictionary in spack.compilers to do translations. This updates the dictionary for the intel oneapi compiler.