### PR TITLE
py-dulwich: Fix python depend

### DIFF
--- a/var/spack/repos/builtin/packages/py-dulwich/package.py
+++ b/var/spack/repos/builtin/packages/py-dulwich/package.py
@@ -18,7 +18,7 @@ class PyDulwich(PythonPackage):
     version('0.20.15', sha256='fb1773373ec2af896031f8312af6962a1b8b0176a2de3fb3d84a84ec04498888')
     version('0.20.14', sha256='21d6ee82708f7c67ce3fdcaf1f1407e524f7f4f7411a410a972faa2176baec0d')
 
-    depends_on('python@3.5', type=('build', 'run'))
+    depends_on('python@3.5.0:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-certifi', type=('build', 'run'))
     depends_on('py-urllib3@1.24.1:', type=('build', 'run'))


### PR DESCRIPTION
I have fixed the following issues:
Warning: There is no checksum on file to fetch python@3.5 safely.