### PR TITLE
Add cuda as opencl provider

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -97,6 +97,9 @@ class Cuda(Package):
 
     depends_on('libxml2', when='@10.1.243:')
 
+    provides('opencl@:1.2', when='@7:')
+    provides('opencl@:1.1', when='@:6')
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('--version', output=str, error=str)


### PR DESCRIPTION
Ping @ax3l @Rombur

Seems like cuda provides opencl:

```
$ find $(spack location -i cuda) -iname libOpenCL.so
/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.3.0/cuda-11.0.2-ntccyyogx3gp23d3v6lwq3sk3janvn5m/targets/x86_64-linux/lib/libOpenCL.so
```

I've determined the versions by running a recent cmake w/ find_package(OpenCL) on old cuda docker images, only cuda 6 has opencl 1.1, the rest is at 1.2._
