### PR TITLE
[gnutls] added dependency libidn2 without restrictions

### DIFF
--- a/var/spack/repos/builtin/packages/gnutls/package.py
+++ b/var/spack/repos/builtin/packages/gnutls/package.py
@@ -39,6 +39,7 @@ class Gnutls(AutotoolsPackage):
     depends_on('nettle@:2.9', when='@3.3.9')
     depends_on('nettle', when='@3.5:')
     depends_on('libidn2@:2.0.99', when='@:3.5.99')
+    depends_on('libidn2')
     depends_on('zlib', when='+zlib')
     depends_on('gettext')
 


### PR DESCRIPTION
Adding libidn2 as a dependency of gnutls in all cases. Unknown why this was version limited in the first place. Leaving that limitation in place just incase there was a good reason. See: #11257.