### PR TITLE
git: use external gettext properly on systems that include libintl in libc

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -253,8 +253,9 @@ class Git(AutotoolsPackage):
         # In that case the node in the DAG gets truncated and git DOES NOT
         # have a gettext dependency.
         if 'gettext' in self.spec:
-            env.append_flags('EXTLIBS', '-L{0} -lintl'.format(
-                self.spec['gettext'].prefix.lib))
+            if 'intl' in self.spec['gettext'].libs.names:
+                env.append_flags('EXTLIBS', '-L{0} -lintl'.format(
+                    self.spec['gettext'].prefix.lib))
             env.append_flags('CFLAGS', '-I{0}'.format(
                 self.spec['gettext'].prefix.include))
 


### PR DESCRIPTION
Git needs libintl, which is typically provided by gettext. However, on some systems (including rhel8) the system gettext does not provide libintl, because libintl is included in libc. This causes the Spack git package to fail to build against external gettext. This PR fixes git to check whether gettext includes libintl before trying to link against it.

