### PR TITLE
Per pipeline temporary storage

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -763,6 +763,10 @@ def generate_package_index(cache_prefix):
             url_util.join(cache_prefix, 'index.json.hash'),
             keep_original=False,
             extra_args={'ContentType': 'text/plain'})
+    except Exception as err:
+        msg = 'Encountered problem pushing package index to {0}: {1}'.format(
+            cache_prefix, err)
+        tty.warn(msg)
     finally:
         shutil.rmtree(tmpdir)
 
@@ -823,6 +827,10 @@ def generate_key_index(key_prefix, tmpdir=None):
                 url_util.join(key_prefix, 'index.json'),
                 keep_original=False,
                 extra_args={'ContentType': 'application/json'})
+        except Exception as err:
+            msg = 'Encountered problem pushing key index to {0}: {1}'.format(
+                key_prefix, err)
+            tty.warn(msg)
         finally:
             if remove_tmpdir:
                 shutil.rmtree(tmpdir)

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -67,6 +67,19 @@ def setup_parser(subparser):
              " retrieve all versions of each package")
     arguments.add_common_arguments(create_parser, ['specs'])
 
+    # Destroy
+    destroy_parser = sp.add_parser('destroy', help=mirror_destroy.__doc__)
+
+    destroy_target = destroy_parser.add_mutually_exclusive_group(required=True)
+    destroy_target.add_argument('-m', '--mirror-name',
+                                metavar='mirror_name',
+                                type=str,
+                                help="find mirror to destroy by name")
+    destroy_target.add_argument('--mirror-url',
+                                metavar='mirror_url',
+                                type=str,
+                                help="find mirror to destroy by url")
+
     # used to construct scope arguments below
     scopes = spack.config.scopes()
     scopes_metavar = spack.config.scopes_metavar
@@ -360,8 +373,22 @@ def mirror_create(args):
         sys.exit(1)
 
 
+def mirror_destroy(args):
+    """Given a url, recursively delete everything under it."""
+    mirror_url = None
+
+    if args.mirror_name:
+        result = spack.mirror.MirrorCollection().lookup(args.mirror_name)
+        mirror_url = result.push_url
+    elif args.mirror_url:
+        mirror_url = args.mirror_url
+
+    web_util.remove_url(mirror_url, recursive=True)
+
+
 def mirror(parser, args):
     action = {'create': mirror_create,
+              'destroy': mirror_destroy,
               'add': mirror_add,
               'remove': mirror_remove,
               'rm': mirror_remove,

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -65,66 +65,90 @@ runner_selector_schema = {
     'properties': runner_attributes_schema_items,
 }
 
-#: Properties for inclusion in other schemas
-properties = {
-    'gitlab-ci': {
-        'type': 'object',
-        'additionalProperties': False,
-        'required': ['mappings'],
-        'patternProperties': union_dicts(
-            runner_attributes_schema_items,
-            {
-                'bootstrap': {
-                    'type': 'array',
-                    'items': {
-                        'anyOf': [
-                            {
-                                'type': 'string',
-                            }, {
-                                'type': 'object',
-                                'additionalProperties': False,
-                                'required': ['name'],
-                                'properties': {
-                                    'name': {
-                                        'type': 'string',
-                                    },
-                                    'compiler-agnostic': {
-                                        'type': 'boolean',
-                                        'default': False,
-                                    },
-                                },
-                            },
-                        ],
-                    },
-                },
-                'mappings': {
-                    'type': 'array',
-                    'items': {
+
+core_shared_properties = union_dicts(
+    runner_attributes_schema_items,
+    {
+        'bootstrap': {
+            'type': 'array',
+            'items': {
+                'anyOf': [
+                    {
+                        'type': 'string',
+                    }, {
                         'type': 'object',
                         'additionalProperties': False,
-                        'required': ['match'],
+                        'required': ['name'],
                         'properties': {
-                            'match': {
-                                'type': 'array',
-                                'items': {
-                                    'type': 'string',
-                                },
+                            'name': {
+                                'type': 'string',
                             },
-                            'runner-attributes': runner_selector_schema,
+                            'compiler-agnostic': {
+                                'type': 'boolean',
+                                'default': False,
+                            },
                         },
                     },
+                ],
+            },
+        },
+        'mappings': {
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'additionalProperties': False,
+                'required': ['match'],
+                'properties': {
+                    'match': {
+                        'type': 'array',
+                        'items': {
+                            'type': 'string',
+                        },
+                    },
+                    'runner-attributes': runner_selector_schema,
                 },
-                'enable-artifacts-buildcache': {
-                    'type': 'boolean',
-                    'default': False,
-                },
-                'service-job-attributes': runner_selector_schema,
-                'rebuild-index': {'type': 'boolean'},
-            }
-        ),
+            },
+        },
+        'service-job-attributes': runner_selector_schema,
+        'rebuild-index': {'type': 'boolean'},
     },
+)
+
+gitlab_ci_properties = {
+    'anyOf': [
+        {
+            'type': 'object',
+            'additionalProperties': False,
+            'required': ['mappings'],
+            'properties': union_dicts(
+                core_shared_properties,
+                {
+                    'enable-artifacts-buildcache': {
+                        'type': 'boolean',
+                    },
+                },
+            ),
+        },
+        {
+            'type': 'object',
+            'additionalProperties': False,
+            'required': ['mappings'],
+            'properties': union_dicts(
+                core_shared_properties,
+                {
+                    'temporary-storage-url-prefix': {
+                        'type': 'string',
+                    },
+                },
+            ),
+        },
+    ]
 }
 
+#: Properties for inclusion in other schemas
+properties = {
+    'gitlab-ci': gitlab_ci_properties,
+}
 
 #: Full schema with metadata
 schema = {

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -14,6 +14,9 @@ mirror = SpackCommand('mirror')
 env = SpackCommand('env')
 add = SpackCommand('add')
 concretize = SpackCommand('concretize')
+install = SpackCommand('install')
+buildcache = SpackCommand('buildcache')
+uninstall = SpackCommand('uninstall')
 
 
 @pytest.fixture
@@ -183,3 +186,39 @@ def test_mirror_name_collision(tmp_scope):
 
     with pytest.raises(SpackCommandError):
         mirror('add', '--scope', tmp_scope, 'first', '1')
+
+
+def test_mirror_destroy(install_mockery_mutable_config,
+                        mock_packages, mock_fetch, mock_archive,
+                        mutable_config, monkeypatch, tmpdir):
+    # Create a temp mirror directory for buildcache usage
+    mirror_dir = tmpdir.join('mirror_dir')
+    mirror_url = 'file://{0}'.format(mirror_dir.strpath)
+    mirror('add', 'atest', mirror_url)
+
+    spec_name = 'libdwarf'
+
+    # Put a binary package in a buildcache
+    install('--no-cache', spec_name)
+    buildcache('create', '-u', '-a', '-f', '-d', mirror_dir.strpath, spec_name)
+
+    contents = os.listdir(mirror_dir.strpath)
+    assert('build_cache' in contents)
+
+    # Destroy mirror by name
+    mirror('destroy', '-m', 'atest')
+
+    assert(not os.path.exists(mirror_dir.strpath))
+
+    buildcache('create', '-u', '-a', '-f', '-d', mirror_dir.strpath, spec_name)
+
+    contents = os.listdir(mirror_dir.strpath)
+    assert('build_cache' in contents)
+
+    # Destroy mirror by url
+    mirror('destroy', '--mirror-url', mirror_url)
+
+    assert(not os.path.exists(mirror_dir.strpath))
+
+    uninstall('-y', spec_name)
+    mirror('remove', 'atest')

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -6,9 +6,13 @@ import os
 
 import ordereddict_backport
 import pytest
+import spack.config
 import spack.paths
 import spack.util.web
+import spack.util.s3
 from spack.version import ver
+
+import llnl.util.tty as tty
 
 
 def _create_url(relative_url):
@@ -195,3 +199,58 @@ def test_list_url(tmpdir):
                               'file-0.txt',
                               'file-1.txt',
                               'file-2.txt']
+
+
+class MockPages(object):
+    def search(self, *args, **kwargs):
+        return [
+            {'Key': 'keyone'},
+            {'Key': 'keytwo'},
+            {'Key': 'keythree'},
+        ]
+
+
+class MockPaginator(object):
+    def paginate(self, *args, **kwargs):
+        return MockPages()
+
+
+class MockS3Client(object):
+    def get_paginator(self, *args, **kwargs):
+        return MockPaginator()
+
+    def delete_objects(self, *args, **kwargs):
+        return {
+            'Errors': [
+                {'Key': 'keyone', 'Message': 'Access Denied'}
+            ],
+            'Deleted': [
+                {'Key': 'keytwo'},
+                {'Key': 'keythree'}
+            ],
+        }
+
+    def delete_object(self, *args, **kwargs):
+        pass
+
+
+def test_remove_s3_url(monkeypatch, capfd):
+    fake_s3_url = 's3://my-bucket/subdirectory/mirror'
+
+    def mock_create_s3_session(url):
+        return MockS3Client()
+
+    monkeypatch.setattr(
+        spack.util.s3, 'create_s3_session', mock_create_s3_session)
+
+    current_debug_level = tty.debug_level()
+    tty.set_debug(1)
+
+    spack.util.web.remove_url(fake_s3_url, recursive=True)
+    err = capfd.readouterr()[1]
+
+    tty.set_debug(current_debug_level)
+
+    assert('Failed to delete keyone (Access Denied)' in err)
+    assert('Deleted keythree' in err)
+    assert('Deleted keytwo' in err)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -229,17 +229,57 @@ def url_exists(url):
         return False
 
 
-def remove_url(url):
+def _debug_print_delete_results(result):
+    if 'Deleted' in result:
+        for d in result['Deleted']:
+            tty.debug('Deleted {0}'.format(d['Key']))
+    if 'Errors' in result:
+        for e in result['Errors']:
+            tty.debug('Failed to delete {0} ({1})'.format(
+                e['Key'], e['Message']))
+
+
+def remove_url(url, recursive=False):
     url = url_util.parse(url)
 
     local_path = url_util.local_file_path(url)
     if local_path:
-        os.remove(local_path)
+        if recursive:
+            shutil.rmtree(local_path)
+        else:
+            os.remove(local_path)
         return
 
     if url.scheme == 's3':
         s3 = s3_util.create_s3_session(url)
-        s3.delete_object(Bucket=url.netloc, Key=url.path)
+        bucket = url.netloc
+        if recursive:
+            # Because list_objects_v2 can only return up to 1000 items
+            # at a time, we have to paginate to make sure we get it all
+            prefix = url.path.strip('/')
+            paginator = s3.get_paginator('list_objects_v2')
+            pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
+
+            delete_request = {'Objects': []}
+            for item in pages.search('Contents'):
+                if not item:
+                    continue
+
+                delete_request['Objects'].append({'Key': item['Key']})
+
+                # Make sure we do not try to hit S3 with a list of more
+                # than 1000 items
+                if len(delete_request['Objects']) >= 1000:
+                    r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
+                    _debug_print_delete_results(r)
+                    delete_request = {'Objects': []}
+
+            # Delete any items that remain
+            if len(delete_request['Objects']):
+                r = s3.delete_objects(Bucket=bucket, Delete=delete_request)
+                _debug_print_delete_results(r)
+        else:
+            s3.delete_object(Bucket=bucket, Key=url.path)
         return
 
     # Don't even try for other URL schemes.

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1123,7 +1123,7 @@ _spack_mirror() {
     then
         SPACK_COMPREPLY="-h --help -n --no-checksum --deprecated"
     else
-        SPACK_COMPREPLY="create add remove rm set-url list"
+        SPACK_COMPREPLY="create destroy add remove rm set-url list"
     fi
 }
 
@@ -1134,6 +1134,10 @@ _spack_mirror_create() {
     else
         _all_packages
     fi
+}
+
+_spack_mirror_destroy() {
+    SPACK_COMPREPLY="-h --help -m --mirror-name --mirror-url"
 }
 
 _spack_mirror_add() {


### PR DESCRIPTION
Provide the ability to specify a per-pipeline temporary storage location where build jobs can store and retrieve buildcache entries.  

Until now, we have used `enable-artifacts-buildcache` for this purpose, and when enabled, this feature would pick some location within the repo, and jobs would create extra buildcache copies here, mentioning the files they create in their `artifacts`.  Downstream jobs would then be sure to `need` all their dependency jobs (both direct and transitive) to be sure that gitlab would download all those files to the runner before the job ran, thus providing a "custom" binary mirror for the job containing precisely those binary dependencies the job would need to install before building its target spec from source.

However, this approach requires that the runners can upload large binary artifacts back to gitlab, which poses some problems (e.g. when many jobs try to upload large files to gitlab simultaneously).

At the same time, when running "untrusted" pipelines (e.g. against PRs to spack), the pipeline cannot simply push binaries to the main remote mirror, as that location should only ever be populated with binaries built from a trusted ref such as `develop` or a release branch.

This PR adds another optional key (`temporary-storage-url-prefix`) to the `gitlab-ci` section of the spack environment file (`spack.yaml`).  The value of this key is a string which will be used by generated pipeline jobs as a url prefix, and treated as the root url under which per-pipeline mirrors can be created, so each pipeline will have a dedicated temporary storage location.  If this feature is enabled, an extra job will be scheduled at the end of each non-empty pipeline to clean up the temporary, dedicated mirror.  For this reason, this PR adds a `spack mirror destroy` command, to abstract away the differences between `s3://` and `file://` mirror url prefixes, either of which can be used with `temporary-storage-url-prefix`.

Users can now option choose one of two forms of per-pipeline temporary storage (via either `enable-artifacts-buildcache` or `temporary-storage-url-prefix`), but cannot choose both simultaneously, as this is prevented by the schema.

This change is based on #20435 due to the way it builds on the updated `gitlab-ci` schema in that PR.  For example, the mirror cleanup job mentioned above is assigned runner attributes from the `service-job-attributes` section introduced in that change.