### PR TITLE
parallelio: add necessary resources

### DIFF
--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -41,8 +41,8 @@ class Parallelio(CMakePackage):
         args = [
             define('NetCDF_C_PATH', spec['netcdf-c'].prefix),
             define('NetCDF_Fortran_PATH', spec['netcdf-fortran'].prefix),
-            define('USER_CMAKE_MODULE_PATH', '{0}/CMake_Fortran_utils'.format(src)),
-            define('GENF90_PATH', '{0}/genf90'.format(src)),
+            define('USER_CMAKE_MODULE_PATH', join_path(src, 'CMake_Fortran_utils')),
+            define('GENF90_PATH', join_path(src, 'genf90')),
         ]
         if spec.satisfies('+pnetcdf'):
             args.extend([

--- a/var/spack/repos/builtin/packages/parallelio/package.py
+++ b/var/spack/repos/builtin/packages/parallelio/package.py
@@ -25,14 +25,24 @@ class Parallelio(CMakePackage):
     depends_on('netcdf-fortran', type='link')
     depends_on('parallel-netcdf', type='link', when='+pnetcdf')
 
+    resource(name='CMake_Fortran_utils',
+             git='https://github.com/CESM-Development/CMake_Fortran_utils.git',
+             tag='master')
+    resource(name='genf90',
+             git='https://github.com/PARALLELIO/genf90.git',
+             tag='genf90_200608')
+
     def cmake_args(self):
         define = self.define
         spec = self.spec
         env['CC'] = spec['mpi'].mpicc
         env['FC'] = spec['mpi'].mpifc
+        src = self.stage.source_path
         args = [
             define('NetCDF_C_PATH', spec['netcdf-c'].prefix),
             define('NetCDF_Fortran_PATH', spec['netcdf-fortran'].prefix),
+            define('USER_CMAKE_MODULE_PATH', '{0}/CMake_Fortran_utils'.format(src)),
+            define('GENF90_PATH', '{0}/genf90'.format(src)),
         ]
         if spec.satisfies('+pnetcdf'):
             args.extend([


### PR DESCRIPTION
The current parallelio package requires fetching additional resources from the Internet if we don't have them.
This PR adds the resources so that we don't need the Internet access during the building procedure.