### PR TITLE
mpas-model: add a necessary resource

### DIFF
--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -81,7 +81,6 @@ class MpasModel(MakefilePackage):
         return targets
 
     def build(self, spec, prefix):
-
         copy_tree(join_path('MPAS-Data', 'atmosphere'),
                   join_path('src', 'core_atmosphere', 'physics'))
         make(*self.target('init_atmosphere', 'all'))

--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -26,6 +26,15 @@ class MpasModel(MakefilePackage):
 
     parallel = False
 
+    resource(when='@6.2:6.3',
+             name='MPAS-Data',
+             git='https://github.com/MPAS-Dev/MPAS-Data.git',
+             commit='33561790de8b43087ab850be833f51a4e605f1bb')
+    resource(when='@7.0',
+             name='MPAS-Data',
+             git='https://github.com/MPAS-Dev/MPAS-Data.git',
+             tag='v7.0')
+
     def target(self, model, action):
         spec = self.spec
         satisfies = spec.satisfies
@@ -72,6 +81,7 @@ class MpasModel(MakefilePackage):
         return targets
 
     def build(self, spec, prefix):
+        copy_tree('MPAS-Data/atmosphere', 'src/core_atmosphere/physics')
         make(*self.target('init_atmosphere', 'all'))
         mkdir('bin')
         copy('init_atmosphere_model', 'bin')

--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -81,7 +81,9 @@ class MpasModel(MakefilePackage):
         return targets
 
     def build(self, spec, prefix):
-        copy_tree('MPAS-Data/atmosphere', 'src/core_atmosphere/physics')
+
+        copy_tree(join_path('MPAS-Data', 'atmosphere'),
+                  join_path('src', 'core_atmosphere', 'physics'))
         make(*self.target('init_atmosphere', 'all'))
         mkdir('bin')
         copy('init_atmosphere_model', 'bin')


### PR DESCRIPTION
The current mpas-model package requires fetching an additional resource from the Internet if we don't have it.
This PR adds the resource so that we don't need Internet access during the building procedure.
