### PR TITLE
py-numpy: Fix for new version of numpy with Fujitsu compiler.

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler.patch
@@ -1,13 +1,13 @@
-diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/distutils/fcompiler/fj.py
---- numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
-+++ numpy-1.19.4/numpy/distutils/fcompiler/fj.py	2020-11-10 17:21:43.324928283 +0900
+diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fujitsu.py numpy-1.19.4/numpy/distutils/fcompiler/fujitsu.py
+--- numpy-1.19.4.org/numpy/distutils/fcompiler/fujitsu.py	1970-01-01 09:00:00.000000000 +0900
++++ numpy-1.19.4/numpy/distutils/fcompiler/fujitsu.py	2020-11-10 17:21:43.324928283 +0900
 @@ -0,0 +1,40 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
-+compilers = ['FJFCompiler']
++compilers = ['FujitsuFCompiler']
 +
-+class FJFCompiler(FCompiler):
-+    compiler_type = 'fj'
++class FujitsuFCompiler(FCompiler):
++    compiler_type = 'fujitsu'
 +    description = 'Fujitsu Fortran Compiler'
 +
 +    possible_executables = ['frt']
@@ -41,7 +41,7 @@ diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/fj.py numpy-1.19.4/numpy/di
 +    from distutils import log
 +    from numpy.distutils import customized_fcompiler
 +    log.set_verbosity(2)
-+    print(customized_fcompiler('fj').get_version())
++    print(customized_fcompiler('fujitsu').get_version())
 diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py numpy-1.19.4/numpy/distutils/fcompiler/__init__.py
 --- numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py	2020-11-09 10:51:35.693490207 +0900
 +++ numpy-1.19.4/numpy/distutils/fcompiler/__init__.py	2020-11-16 17:48:49.316744476 +0900
@@ -50,7 +50,7 @@ diff -urN numpy-1.19.4.org/numpy/distutils/fcompiler/__init__.py numpy-1.19.4/nu
      ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
      ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'nv', 'absoft', 'nag', 'vast', 'compaq',
 -                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
-+                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fj')),
++                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fujitsu')),
      ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),
      ('sunos.*', ('sun', 'gnu', 'gnu95', 'g95')),
      ('irix.*', ('mips', 'gnu', 'gnu95',)),

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler2.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler2.patch
@@ -1,13 +1,13 @@
-diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
---- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
-+++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 17:55:57.608802456 +0900
+diff -urN spack-src.org/numpy/distutils/fcompiler/fujitsu.py spack-src/numpy/distutils/fcompiler/fujitsu.py
+--- spack-src.org/numpy/distutils/fcompiler/fujitsu.py	1970-01-01 09:00:00.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/fujitsu.py	2020-11-16 17:55:57.608802456 +0900
 @@ -0,0 +1,40 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
-+compilers = ['FJFCompiler']
++compilers = ['FujitsuFCompiler']
 +
-+class FJFCompiler(FCompiler):
-+    compiler_type = 'fj'
++class FujitsuFCompiler(FCompiler):
++    compiler_type = 'fujitsu'
 +    description = 'Fujitsu Fortran Compiler'
 +
 +    possible_executables = ['frt']
@@ -41,7 +41,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +    from distutils import log
 +    from numpy.distutils import customized_fcompiler
 +    log.set_verbosity(2)
-+    print(customized_fcompiler('fj').get_version())
++    print(customized_fcompiler('fujitsu').get_version())
 diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/distutils/fcompiler/__init__.py
 --- spack-src.org/numpy/distutils/fcompiler/__init__.py	2020-11-16 17:55:31.638677631 +0900
 +++ spack-src/numpy/distutils/fcompiler/__init__.py	2020-11-16 17:56:29.978957954 +0900
@@ -50,7 +50,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/di
      ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
      ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
 -                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
-+                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fj')),
++                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fujitsu')),
      ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),
      ('sunos.*', ('sun', 'gnu', 'gnu95', 'g95')),
      ('irix.*', ('mips', 'gnu', 'gnu95',)),

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler3.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler3.patch
@@ -1,13 +1,13 @@
-diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
---- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
-+++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 18:30:06.698641953 +0900
+diff -urN spack-src.org/numpy/distutils/fcompiler/fujitsu.py spack-src/numpy/distutils/fcompiler/fujitsu.py
+--- spack-src.org/numpy/distutils/fcompiler/fujitsu.py	1970-01-01 09:00:00.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/fujitsu.py	2020-11-16 18:30:06.698641953 +0900
 @@ -0,0 +1,40 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
-+compilers = ['FJFCompiler']
++compilers = ['FujitsuFCompiler']
 +
-+class FJFCompiler(FCompiler):
-+    compiler_type = 'fj'
++class FujitsuFCompiler(FCompiler):
++    compiler_type = 'fujitsu'
 +    description = 'Fujitsu Fortran Compiler'
 +
 +    possible_executables = ['frt']
@@ -41,7 +41,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +    from distutils import log
 +    from numpy.distutils import customized_fcompiler
 +    log.set_verbosity(2)
-+    print(customized_fcompiler('fj').get_version())
++    print(customized_fcompiler('fujitsu').get_version())
 diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/distutils/fcompiler/__init__.py
 --- spack-src.org/numpy/distutils/fcompiler/__init__.py	2020-11-16 18:25:26.087294181 +0900
 +++ spack-src/numpy/distutils/fcompiler/__init__.py	2020-11-16 18:26:19.987553070 +0900
@@ -50,7 +50,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/di
      ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
      ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
 -                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor')),
-+                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fj')),
++                 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fujitsu')),
      ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),
      ('sunos.*', ('sun', 'gnu', 'gnu95', 'g95')),
      ('irix.*', ('mips', 'gnu', 'gnu95',)),

--- a/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler4.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/add_fj_compiler4.patch
@@ -1,13 +1,13 @@
-diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutils/fcompiler/fj.py
---- spack-src.org/numpy/distutils/fcompiler/fj.py	1970-01-01 09:00:00.000000000 +0900
-+++ spack-src/numpy/distutils/fcompiler/fj.py	2020-11-16 18:42:47.672297372 +0900
+diff -urN spack-src.org/numpy/distutils/fcompiler/fujitsu.py spack-src/numpy/distutils/fcompiler/fujitsu.py
+--- spack-src.org/numpy/distutils/fcompiler/fujitsu.py	1970-01-01 09:00:00.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/fujitsu.py	2020-11-16 18:42:47.672297372 +0900
 @@ -0,0 +1,40 @@
 +from numpy.distutils.fcompiler import FCompiler
 +
-+compilers = ['FJFCompiler']
++compilers = ['FujitsuFCompiler']
 +
-+class FJFCompiler(FCompiler):
-+    compiler_type = 'fj'
++class FujitsuFCompiler(FCompiler):
++    compiler_type = 'fujitsu'
 +    description = 'Fujitsu Fortran Compiler'
 +
 +    possible_executables = ['frt']
@@ -41,7 +41,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/fj.py spack-src/numpy/distutil
 +    from distutils import log
 +    from numpy.distutils import customized_fcompiler
 +    log.set_verbosity(2)
-+    print(customized_fcompiler('fj').get_version())
++    print(customized_fcompiler('fujitsu').get_version())
 diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/distutils/fcompiler/__init__.py
 --- spack-src.org/numpy/distutils/fcompiler/__init__.py	2020-11-16 18:43:18.112443626 +0900
 +++ spack-src/numpy/distutils/fcompiler/__init__.py	2020-11-16 18:44:54.062904636 +0900
@@ -50,7 +50,7 @@ diff -urN spack-src.org/numpy/distutils/fcompiler/__init__.py spack-src/numpy/di
      ('cygwin.*', ('gnu', 'intelv', 'absoft', 'compaqv', 'intelev', 'gnu95', 'g95')),
      ('linux.*', ('gnu95', 'intel', 'lahey', 'pg', 'absoft', 'nag', 'vast', 'compaq',
 -                'intele', 'intelem', 'gnu', 'g95', 'pathf95')),
-+                'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'fj')),
++                'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'fujitsu')),
      ('darwin.*', ('gnu95', 'nag', 'absoft', 'ibm', 'intel', 'gnu', 'g95', 'pg')),
      ('sunos.*', ('sun', 'gnu', 'gnu95', 'g95')),
      ('irix.*', ('mips', 'gnu', 'gnu95',)),

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -100,7 +100,7 @@ class PyNumpy(PythonPackage):
     patch('blas-lapack-order.patch', when='@1.15:1.16')
 
     # Add Fujitsu Fortran compiler
-    patch('add_fj_compiler.patch', when='@1.19.3:%fj')
+    patch('add_fj_compiler.patch', when='@1.19.3:1.19.5%fj')
     patch('add_fj_compiler2.patch', when='@1.19.0:1.19.2%fj')
     patch('add_fj_compiler3.patch', when='@1.14.0:1.18.5%fj')
     patch('add_fj_compiler4.patch', when='@:1.13.3%fj')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -85,7 +85,7 @@ class PyScipy(PythonPackage):
     def build_args(self, spec, prefix):
         args = []
         if spec.satisfies('%fj'):
-            args.extend(['config_fc', '--fcompiler=fj'])
+            args.extend(['config_fc', '--fcompiler=fujitsu'])
 
         # Build in parallel
         # Known problems with Python 3.5+


### PR DESCRIPTION
* Change the version to apply patches.
Fixes of adition Fujitsu compiler is involved in version 1.20.0. So, I fixed to apply add_fj_compiler.patch only up to version 1.19.5.

* Change the name of the Fujitsu compiler to 'fujitsu' in numpy.
In upstream of `numpy`, Setting name of Fujitsu compiler is `fujitsu`. So, I changed the setting name of the Fujitsu compiler used in the patch of `py-numpy` and the setting value of `config_fc` specified in `py-scipy`.

Fixes #21482