### PR TITLE
config: (darwin only) change prefix of external libuuid

### DIFF
--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -40,4 +40,4 @@ packages:
     # Apple bundles libuuid in libsystem_c version 1353.100.2,
     # although the version number used here isn't critical
     - spec: apple-libuuid@1353.100.2
-      prefix: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr
+      prefix: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk


### PR DESCRIPTION
Fixes #21265. Basically using the full Xcode path to MacOSX.sdk and not just the command line version in the apple-libuuid external prefix. 