### PR TITLE
More dbcsr fixes

### DIFF
--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -65,6 +65,8 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('^openblas threads=pthreads', when='+openmp')
     conflicts('^openblas threads=none', when='+openmp')
 
+    conflicts('smm=blas', when='+opencl')
+
     generator = 'Ninja'
     depends_on('ninja@1.10:', type='build')
 

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -60,7 +60,6 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
             conflicts('+rocm', when='amdgpu_target={0}'.format(arch), msg=amd_msg)
 
     conflicts('+cuda', when='+rocm', msg="CUDA and ROCm are mutually exclusive")
-    conflicts('+rocm', when='@:2.0', msg="ROCm support is available in DBCSR v2.1 and later")
 
     # Require openmp threading for OpenBLAS by making other options conflict
     conflicts('^openblas threads=pthreads', when='+openmp')

--- a/var/spack/repos/builtin/packages/dbcsr/package.py
+++ b/var/spack/repos/builtin/packages/dbcsr/package.py
@@ -33,8 +33,9 @@ class Dbcsr(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('cmake@3.12:', type='build')
     depends_on('py-fypp', type='build')
-    depends_on('pkgconfig', type='build')
     depends_on('python@3.6:', type='build', when='+cuda')
+    depends_on('python@3.6:', type='build', when='+rocm')
+    depends_on('pkgconfig', type='build', when='smm=libxsmm')
 
     depends_on('hipblas', when='+rocm')
 


### PR DESCRIPTION
Ping @dev-zero

- pkgconfig only necessary to find libxsmm, so depend on it conditionally (this is true since a few minutes)
- dbcsr doesn't have versions yet, so no need to add the rocm conflict
- OpenCL implementation requires libxsmm, so conflict with blas
