### PR TITLE
[pkg][new version] Provide draco@7.9.1

### DIFF
--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -18,6 +18,8 @@ class Draco(CMakePackage):
     maintainers = ['KineticTheory']
 
     version('develop', branch='develop')
+    version('7.9.1',  sha256='c8fd029d5b74afc68670f7d449d60c24f2d284c9d6a944a2d3dce6efeb6ad097')
+    version('7.9.0',  sha256='17b54301897da0d4f9b91fef15cc2ec5e6c65a8e8c1c09e6e7b516c0fb82b50f')
     version('7.8.0',  sha256='f6de794457441f69025619be58810bca432f3e0dd773ea9b9a7977b1dc09530d')
     version('7.7.0',  sha256='eb7fffbcba48e16524f619d261192ead129f968c59f3581f3217b89590812ddf')
     version('7.6.0',  sha256='c2c6b329620d7bcb0f2fc14371f105dfb80a84e7c5adbb34620777034b15c7c9')
@@ -41,6 +43,7 @@ class Draco(CMakePackage):
     variant('lapack',   default=True,  description='Enable LAPACK wrapper')
     variant('libquo',   default=True,  description='Enable Quo wrapper')
     variant('parmetis', default=True,  description='Enable Parmetis support')
+    variant('pythontools', default=False,  description='Enable support for extra python tools')
     variant('qt',       default=False, description='Enable Qt support')
     variant('superlu_dist', default=True, description='Enable SuperLU-DIST support')
 
@@ -48,6 +51,7 @@ class Draco(CMakePackage):
     depends_on('cmake@3.11:', when='@7.0.0:7.1.99', type='build')
     depends_on('cmake@3.14:', when='@7.2.0:7.6.99', type='build')
     depends_on('cmake@3.17:', when='@7.7:',         type='build')
+    depends_on('cmake@3.18:', when='@7.9:',         type='build')
     depends_on('gsl')
     depends_on('mpi@3:',         type=('build', 'link', 'run'))
     depends_on('numdiff',        type='build')
@@ -66,6 +70,7 @@ class Draco(CMakePackage):
     depends_on('qt',          when='+qt',
                type=('build', 'link', 'run'))
     depends_on('superlu-dist@:5.99', when='@:7.6.99+superlu_dist')
+    depends_on('py-matplotlib', when='+pythontools', type=('run'))
 
     conflicts('+cuda', when='@:7.6.99')
     conflicts('+caliper', when='@:7.7.99')
@@ -87,7 +92,8 @@ class Draco(CMakePackage):
         options.extend([
             '-Wno-dev',
             '-DBUILD_TESTING={0}'.format('ON' if self.run_tests else 'OFF'),
-            '-DUSE_CUDA={0}'.format('ON' if '+cuda' in self.spec else 'OFF')
+            '-DUSE_CUDA={0}'.format('ON' if '+cuda' in self.spec else 'OFF'),
+            '-DUSE_QT={0}'.format('ON' if '+qt' in self.spec else 'OFF')
         ])
         return options
 


### PR DESCRIPTION
+ Provide optional variant `pythontools` (default `False`) that adds a run-time dependency on `py-matplotlib`.
+ Latest versions require `cmake@3.18:` to support cuda features.
+ Enable a cmake build option that forcibly disables qt support.  Previously, draco would enable qt support if it was available in the local build environment (outside of spack).
