### PR TITLE
Config prefer upstream

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -495,7 +495,7 @@ def config_prefer_upstream(args):
             # set across all versions/compilers.
             if existing_variants is not None and existing_variants != variants:
                 conflicting_variants.add(spec.name)
-                del pkg['variants']
+                pkg.pop('variants')
             elif variants:
                 pkg['variants'] = variants
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -17,6 +17,8 @@ import spack.environment as ev
 import spack.schema.packages
 import spack.util.spack_yaml as syaml
 from spack.util.editor import editor
+from spack.database import InstallStatuses
+import spack.store
 
 description = "get and set configuration options"
 section = "config"
@@ -71,6 +73,15 @@ def setup_parser(subparser):
     add_parser.add_argument(
         '-f', '--file',
         help="file from which to set all config values"
+    )
+
+    prefer_upstream_parser = sp.add_parser(
+        'prefer-upstream',
+        help='generate package preferences from upstream, and write them in the given '
+             'config scope.')
+    prefer_upstream_parser.add_argument(
+        '--dest', required=False,
+        help="Instead of writing updating current configs, write a new config at this path."
     )
 
     remove_parser = sp.add_parser('remove', aliases=['rm'],
@@ -431,6 +442,19 @@ def config_revert(args):
         tty.msg(msg.format(cfg_file))
 
 
+def config_prefer_upstream(args):
+    """m"""
+
+    if getattr(args, 'env', None) is not None:
+        msg = 'Environment {} specified, but prefer-upstream operates ' \
+              'outside of all environments.'.format(args.env)
+        tty.die(msg)
+
+    results = spack.store.db.query(installed=[InstallStatuses.INSTALLED])
+
+    print(results)
+
+
 def config(parser, args):
     action = {
         'get': config_get,
@@ -441,6 +465,7 @@ def config(parser, args):
         'rm': config_remove,
         'remove': config_remove,
         'update': config_update,
-        'revert': config_revert
+        'revert': config_revert,
+        'prefer-upstream': config_prefer_upstream,
     }
     action[args.config_command](args)

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -495,7 +495,7 @@ def config_prefer_upstream(args):
             # set across all versions/compilers.
             if existing_variants is not None and existing_variants != variants:
                 conflicting_variants.add(spec.name)
-                pkg.pop('variants')
+                pkg.pop('variants', None)
             elif variants:
                 pkg['variants'] = variants
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -453,7 +453,7 @@ def config_prefer_upstream(args):
 
     all_specs = set(spack.store.db.query(installed=True))
     local_specs = set(spack.store.db.query_local(installed=True))
-    pref_specs = local_specs if args.local else all_specs - local_spec
+    pref_specs = local_specs if args.local else all_specs - local_specs
 
     conflicting_variants = set()
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -456,7 +456,7 @@ def config_prefer_upstream(args):
                 upstream_specs.append(spec)
         except spack.repo.UnknownNamespaceError as err:
             tty.die(
-                "Could not find package when checking spec {} ({}). "
+                "Could not find package when checking spec {0} ({1}). "
                 "This is usually due to your Spack instance not being "
                 "configured to know about the upstream's repositories."
                 .format(spec.name, err.message)
@@ -514,7 +514,7 @@ def config_prefer_upstream(args):
             "The following packages have multiple conflicting upstream "
             "specs. You may have to specify, by "
             "concretized hash, which spec you want when building "
-            "packages that depend on them:\n - {}"
+            "packages that depend on them:\n - {0}"
             .format("\n - ".join(sorted(conflicting_variants))))
 
     # Simply write the config to the specified file.
@@ -523,7 +523,7 @@ def config_prefer_upstream(args):
     spack.config.set('packages', new, scope)
     config_file = spack.config.config.get_config_filename(scope, section)
 
-    tty.msg("Updated config at {}".format(config_file))
+    tty.msg("Updated config at {0}".format(config_file))
 
 
 def config(parser, args):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -445,14 +445,40 @@ def config_revert(args):
 def config_prefer_upstream(args):
     """m"""
 
+    scope = args.scope
+
     if getattr(args, 'env', None) is not None:
         msg = 'Environment {} specified, but prefer-upstream operates ' \
               'outside of all environments.'.format(args.env)
         tty.die(msg)
 
-    results = spack.store.db.query(installed=[InstallStatuses.INSTALLED])
+    if args.dest is not None and args.scope is not None:
+        tty.die("You can specify a scope or a destination config file, "
+                "not both")
+    elif args.scope:
+        pkgs = spack.config.config.get_config('packages', scope=args.scope)
+    elif args.dest:
+        pkgs = {}
+    else:
+        tty.die(
+            "You must specify either a scope or a destination config file.")
 
-    print(results)
+    specs = spack.store.db.query(installed=[InstallStatuses.INSTALLED])
+
+    # Get only our upstream specs
+    specs = [spec for spec in specs if spec.package.installed_upstream]
+
+    cfg_file = spack.config.config.get_config_filename(
+        scope.name, args.section
+    )
+
+    base_path = ['packages']
+    for spec in specs:
+        path = base_path + [spec.name]
+
+        spec.version
+
+
 
 
 def config(parser, args):

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -17,7 +17,6 @@ import spack.environment as ev
 import spack.schema.packages
 import spack.util.spack_yaml as syaml
 from spack.util.editor import editor
-from spack.database import InstallStatuses
 import spack.store
 import spack.repo
 
@@ -452,7 +451,7 @@ def config_prefer_upstream(args):
     if scope is None:
         scope = spack.config.default_modify_scope('packages')
 
-    specs = spack.store.db.query(installed=[InstallStatuses.INSTALLED])
+    specs = spack.store.db.query(installed=True)
 
     pref_specs = []
     for spec in specs:

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -452,22 +452,9 @@ def config_prefer_upstream(args):
     if scope is None:
         scope = spack.config.default_modify_scope('packages')
 
-    specs = spack.store.db.query(installed=[InstallStatuses.INSTALLED])
-
-    pref_specs = []
-    for spec in specs:
-        upstream = None
-        try:
-            upstream = spec.package.installed_upstream
-        except spack.repo.UnknownNamespaceError as err:
-            tty.die(
-                "Could not find package when checking spec {0} ({1}). "
-                "This is usually due to your Spack instance not being "
-                "configured to know about the upstream's repositories."
-                .format(spec.name, err.message)
-            )
-        if (upstream and not args.local) or (not upstream and args.local):
-            pref_specs.append(spec)
+    all_specs = set(spack.store.db.query(installed=True))
+    local_specs = set(spack.store.db.query_local(installed=True))
+    pref_specs = local_specs if args.local else all_specs - local_spec
 
     conflicting_variants = set()
 

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -203,6 +203,9 @@ def find(parser, args):
     q_args = query_arguments(args)
     results = args.specs(**q_args)
 
+    print('args', args)
+    print('specs', args.specs)
+
     decorator = lambda s, f: f
     added = set()
     removed = set()

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -203,9 +203,6 @@ def find(parser, args):
     q_args = query_arguments(args)
     results = args.specs(**q_args)
 
-    print('args', args)
-    print('specs', args.specs)
-
     decorator = lambda s, f: f
     added = set()
     removed = set()

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -551,7 +551,7 @@ class Configuration(object):
 
         If ``scope`` is ``None`` or not provided, return the merged contents
         of all of Spack's configuration scopes.  If ``scope`` is provided,
-        return only the confiugration as specified in that scope.
+        return only the configuration as specified in that scope.
 
         This off the top-level name from the YAML section.  That is, for a
         YAML config file that looks like this::

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -11,6 +11,9 @@ import spack.config
 import spack.environment as ev
 import spack.main
 import spack.util.spack_yaml as syaml
+import spack.spec
+import spack.database
+import spack.store
 
 config = spack.main.SpackCommand('config')
 env = spack.main.SpackCommand('env')
@@ -645,3 +648,44 @@ def check_config_updated(data):
     assert isinstance(data['install_tree'], dict)
     assert data['install_tree']['root'] == '/fake/path'
     assert data['install_tree']['projections'] == {'all': '{name}-{version}'}
+
+
+def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
+                                gen_mock_layout, monkeypatch):
+    """Check that when a dependency package is recorded as installed in
+       an upstream database that it is not reinstalled.
+    """
+    mock_db_root = str(tmpdir_factory.mktemp('mock_db_root'))
+    prepared_db = spack.database.Database(mock_db_root)
+
+    upstream_layout = gen_mock_layout('/a/')
+
+    for spec in [
+            'hdf5 +mpi',
+            'hdf5 ~mpi',
+            'boost+debug~icu+graph',
+            'dependency-install']:
+        dep = spack.spec.Spec(spec)
+        dep.concretize()
+        prepared_db.add(dep, upstream_layout)
+
+    downstream_db_root = str(
+        tmpdir_factory.mktemp('mock_downstream_db_root'))
+    db_for_test = spack.database.Database(
+        downstream_db_root, upstream_dbs=[prepared_db])
+    monkeypatch.setattr(spack.store, 'db', db_for_test)
+
+    output = config('prefer-upstream')
+    scope = spack.config.default_modify_scope('packages')
+    cfg_file = spack.config.config.get_config_filename(scope, 'packages')
+    packages = syaml.load(open(cfg_file))['packages']
+    assert packages['boost'] == {
+        'compiler': ['gcc@4.5.0'],
+        'variants': '+debug +graph',
+        'version': ['1.63.0']}
+    assert packages['dependency-install'] == {
+        'compiler': ['gcc@4.5.0'], 'version': ['2.0']}
+    assert packages['hdf5'] == {
+        'compiler': ['gcc@4.5.0'], 'version': ['2.3']}
+
+    assert '- hdf5' in output

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -655,6 +655,7 @@ def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
     """Check that when a dependency package is recorded as installed in
        an upstream database that it is not reinstalled.
     """
+
     mock_db_root = str(tmpdir_factory.mktemp('mock_db_root'))
     prepared_db = spack.database.Database(mock_db_root)
 
@@ -680,6 +681,9 @@ def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
     scope = spack.config.default_modify_scope('packages')
     cfg_file = spack.config.config.get_config_filename(scope, 'packages')
     packages = syaml.load(open(cfg_file))['packages']
+    # Cleanup the config file we added, so it doesn't break other unit tests.
+    os.unlink(cfg_file)
+
     assert packages['boost'] == {
         'compiler': ['gcc@4.5.0'],
         'variants': '+debug +graph',

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -681,8 +681,6 @@ def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
     scope = spack.config.default_modify_scope('packages')
     cfg_file = spack.config.config.get_config_filename(scope, 'packages')
     packages = syaml.load(open(cfg_file))['packages']
-    # Cleanup the config file we added, so it doesn't break other unit tests.
-    os.unlink(cfg_file)
 
     # Make sure only the non-default variants are set.
     assert packages['boost'] == {

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -651,7 +651,7 @@ def check_config_updated(data):
 
 
 def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
-                                gen_mock_layout, monkeypatch):
+                                mutable_config, gen_mock_layout, monkeypatch):
     """Check that when a dependency package is recorded as installed in
        an upstream database that it is not reinstalled.
     """
@@ -684,13 +684,16 @@ def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
     # Cleanup the config file we added, so it doesn't break other unit tests.
     os.unlink(cfg_file)
 
+    # Make sure only the non-default variants are set.
     assert packages['boost'] == {
         'compiler': ['gcc@4.5.0'],
         'variants': '+debug +graph',
         'version': ['1.63.0']}
     assert packages['dependency-install'] == {
         'compiler': ['gcc@4.5.0'], 'version': ['2.0']}
+    # Ensure that neither variant gets listed for hdf5, since they conflict
     assert packages['hdf5'] == {
         'compiler': ['gcc@4.5.0'], 'version': ['2.3']}
 
+    # Make sure a message about the conflicting hdf5's was given.
     assert '- hdf5' in output

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -664,7 +664,8 @@ def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
             'hdf5 +mpi',
             'hdf5 ~mpi',
             'boost+debug~icu+graph',
-            'dependency-install']:
+            'dependency-install',
+            'patch-several-dependencies']:
         dep = spack.spec.Spec(spec)
         dep.concretize()
         prepared_db.add(dep, upstream_layout)

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -666,7 +666,7 @@ def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
             'hdf5 ~mpi',
             'boost+debug~icu+graph',
             'dependency-install',
-            'patch-several-dependencies']:
+            'patch']:
         dep = spack.spec.Spec(spec)
         dep.concretize()
         prepared_db.add(dep, upstream_layout)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -628,7 +628,7 @@ _spack_config_add() {
 }
 
 _spack_config_prefer_upstream() {
-    SPACK_COMPREPLY="-h --help"
+    SPACK_COMPREPLY="-h --help --local"
 }
 
 _spack_config_remove() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -583,7 +583,7 @@ _spack_config() {
     then
         SPACK_COMPREPLY="-h --help --scope"
     else
-        SPACK_COMPREPLY="get blame edit list add remove rm update revert"
+        SPACK_COMPREPLY="get blame edit list add prefer-upstream remove rm update revert"
     fi
 }
 
@@ -625,6 +625,10 @@ _spack_config_add() {
     else
         SPACK_COMPREPLY=""
     fi
+}
+
+_spack_config_prefer_upstream() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_config_remove() {


### PR DESCRIPTION
This allows for quickly configuring a spack install/env to use upstream packages by default. This is particularly important when upstreaming from a set of officially supported spack installs on a production cluster. By configuring such that package preferences match the upstream, you ensure maximal reuse of existing package installations.