### PR TITLE
py-xarray: add v0.16.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -12,6 +12,7 @@ class PyXarray(PythonPackage):
     homepage = "https://github.com/pydata/xarray"
     pypi = "xarray/xarray-0.9.1.tar.gz"
 
+    version('0.16.2', sha256='38e8439d6c91bcd5b7c0fca349daf8e0643ac68850c987262d53526e9d7d01e4')
     version('0.14.0', sha256='a8b93e1b0af27fa7de199a2d36933f1f5acc9854783646b0f1b37fed9b4da091')
     version('0.13.0', sha256='80e5746ffdebb96b997dba0430ff02d98028ef3828e6db6106cbbd6d62e32825')
     version('0.12.0', sha256='856fd062c55208a248ac3784cac8d3524b355585387043efc92a4188eede57f3')
@@ -23,12 +24,16 @@ class PyXarray(PythonPackage):
     depends_on('python@3.5.3:',         when='@0.13',   type=('build', 'run'))
     depends_on('python@3.6:',           when='@0.14:',  type=('build', 'run'))
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools',       when='@:0.15', type='build')
+    depends_on('py-setuptools@38.4:', when='@0.16:', type=('build', 'run'))
+    depends_on('py-setuptools-scm',   when='@0.15:', type='build')
 
     depends_on('py-pandas@0.15.0:', when='@0.9.1',      type=('build', 'run'))
     depends_on('py-pandas@0.19.2:', when='@0.11:0.13',  type=('build', 'run'))
-    depends_on('py-pandas@0.24:',   when='@0.14:',      type=('build', 'run'))
+    depends_on('py-pandas@0.24:',   when='@0.14.0',     type=('build', 'run'))
+    depends_on('py-pandas@0.25:',   when='@0.15:',      type=('build', 'run'))
 
     depends_on('py-numpy@1.7:',     when='@0.9.1',      type=('build', 'run'))
     depends_on('py-numpy@1.12:',    when='@0.11:0.13',  type=('build', 'run'))
-    depends_on('py-numpy@1.14:',    when='@0.14:',      type=('build', 'run'))
+    depends_on('py-numpy@1.14:',    when='@0.14.0',     type=('build', 'run'))
+    depends_on('py-numpy@1.15:',    when='@0.15:',      type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.