### PR TITLE
py-numpy: check if execute commands are feasible.

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/check_executables.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/check_executables.patch
@@ -1,0 +1,16 @@
+--- numpy-1.20.0/numpy/distutils/fcompiler/__init__.py.org	2021-02-04 17:38:42.000000000 +0900
++++ numpy-1.20.0/numpy/distutils/fcompiler/__init__.py	2021-02-04 18:29:21.000000000 +0900
+@@ -314,7 +314,12 @@
+             if not exe_from_environ:
+                 possibles = [f90, f77] + self.possible_executables
+             else:
+-                possibles = [exe_from_environ] + self.possible_executables
++                matching_executables = []
++                for e in exe_from_environ:
++                    for p in self.possible_executables:
++                        if p in e:
++                            matching_executables.append(e)
++                possibles = [matching_executables] + self.possible_executables
+
+             seen = set()
+             unique_possibles = []

--- a/var/spack/repos/builtin/packages/py-numpy/check_executables2.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/check_executables2.patch
@@ -1,0 +1,16 @@
+--- spack-src/numpy/distutils/fcompiler/__init__.py.orig	2021-01-04 15:16:38.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/__init__.py	2021-02-12 17:20:07.327563118 +0900
+@@ -316,7 +316,12 @@
+             if not exe_from_environ:
+                 possibles = [f90, f77] + self.possible_executables
+             else:
+-                possibles = [exe_from_environ] + self.possible_executables
++                matching_executables = []
++                for e in exe_from_environ:
++                    for p in self.possible_executables:
++                        if p in e:
++                            matching_executables.append(e)
++                possibles = [matching_executables] + self.possible_executables
+ 
+             seen = set()
+             unique_possibles = []

--- a/var/spack/repos/builtin/packages/py-numpy/check_executables3.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/check_executables3.patch
@@ -1,0 +1,16 @@
+--- spack-src/numpy/distutils/fcompiler/__init__.py.orig	2020-06-02 17:24:58.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/__init__.py	2021-02-12 17:33:11.483728471 +0900
+@@ -320,7 +320,12 @@
+             if not exe_from_environ:
+                 possibles = [f90, f77] + self.possible_executables
+             else:
+-                possibles = [exe_from_environ] + self.possible_executables
++                matching_executables = []
++                for e in exe_from_environ:
++                    for p in self.possible_executables:
++                        if p in e:
++                            matching_executables.append(e)
++                possibles = [matching_executables] + self.possible_executables
+ 
+             seen = set()
+             unique_possibles = []

--- a/var/spack/repos/builtin/packages/py-numpy/check_executables4.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/check_executables4.patch
@@ -1,0 +1,16 @@
+--- spack-src/numpy/distutils/fcompiler/__init__.py.orig	2018-11-03 10:49:58.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/__init__.py	2021-02-12 17:57:50.632263931 +0900
+@@ -318,7 +318,12 @@
+             if not exe_from_environ:
+                 possibles = [f90, f77] + self.possible_executables
+             else:
+-                possibles = [exe_from_environ] + self.possible_executables
++                matching_executables = []
++                for e in exe_from_environ:
++                    for p in self.possible_executables:
++                        if p in e:
++                            matching_executables.append(e)
++                possibles = [matching_executables] + self.possible_executables
+ 
+             seen = set()
+             unique_possibles = []

--- a/var/spack/repos/builtin/packages/py-numpy/check_executables5.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/check_executables5.patch
@@ -1,0 +1,16 @@
+--- spack-src/numpy/distutils/fcompiler/__init__.py.orig	2017-09-29 13:31:46.000000000 +0900
++++ spack-src/numpy/distutils/fcompiler/__init__.py	2021-02-12 18:06:12.001479417 +0900
+@@ -322,7 +322,12 @@
+             if not exe_from_environ:
+                 possibles = [f90, f77] + self.possible_executables
+             else:
+-                possibles = [exe_from_environ] + self.possible_executables
++                matching_executables = []
++                for e in exe_from_environ:
++                    for p in self.possible_executables:
++                        if p in e:
++                            matching_executables.append(e)
++                possibles = [matching_executables] + self.possible_executables
+ 
+             seen = set()
+             unique_possibles = []

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -106,6 +106,8 @@ class PyNumpy(PythonPackage):
     patch('add_fj_compiler3.patch', when='@1.14.0:1.18.5%fj')
     patch('add_fj_compiler4.patch', when='@:1.13.3%fj')
 
+    patch('check_executables.patch')
+
     # GCC 4.8 is the minimum version that works
     conflicts('%gcc@:4.7', msg='GCC 4.8+ required')
 

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -106,7 +106,11 @@ class PyNumpy(PythonPackage):
     patch('add_fj_compiler3.patch', when='@1.14.0:1.18.5%fj')
     patch('add_fj_compiler4.patch', when='@:1.13.3%fj')
 
-    patch('check_executables.patch')
+    patch('check_executables.patch', when='@1.20.0:')
+    patch('check_executables2.patch', when='@1.19.0:1.19.5')
+    patch('check_executables3.patch', when='@1.16.0:1.18.5')
+    patch('check_executables4.patch', when='@1.14.0:1.15.4')
+    patch('check_executables5.patch', when='@:1.13.3')
 
     # GCC 4.8 is the minimum version that works
     conflicts('%gcc@:4.7', msg='GCC 4.8+ required')


### PR DESCRIPTION
With the fix in the pull request below, `F90` is now always set :
https://github.com/spack/spack/pull/19818

However, I got a following error.
```
  File "/home/users/ea01/ea0114/spack/oss-job/spack/spack/opt/spack/linux-rhel8-a64fx/fj-4.2.1a/py-numpy-1.19.4-2xiwdvcjbqhbjvs6oj7gp2repg5xufpt/lib/python3.8/site-packages/numpy/distutils/ccompiler.py", line 657, in CCompiler_get_version
    version = matcher(output)
  File "/home/users/ea01/ea0114/spack/oss-job/spack/spack/opt/spack/linux-rhel8-a64fx/fj-4.2.1a/py-numpy-1.19.4-2xiwdvcjbqhbjvs6oj7gp2repg5xufpt/lib/python3.8/site-packages/numpy/distutils/fcompiler/gnu.py", line 278, in version_match
    v = self.gnu_version_match(version_string)
  File "/home/users/ea01/ea0114/spack/oss-job/spack/spack/opt/spack/linux-rhel8-a64fx/fj-4.2.1a/py-numpy-1.19.4-2xiwdvcjbqhbjvs6oj7gp2repg5xufpt/lib/python3.8/site-packages/numpy/distutils/fcompiler/gnu.py", line 80, in gnu_version_match
    raise ValueError(err + version_string)
ValueError: A valid Fortran version was not found in this string:
frt: warning: -dumpversion is unrecognized option.
usage: frt [options] files.
```

`numpy` checks which compiler is currently used by the process described for each compiler.
```
・numpy/distutils/fcompiler/gnu.py
    executables = {
        'version_cmd'  : ["<F90>", "-dumpversion"],
```
This is a command to check the version written for gcc. If the environment variable `F90` is set, the command is imported as it is. For example, if you are using the Fujitsu compiler, the it uses `frt -dumpversion` to try getting the version, but an error will occur because the "-dumpversion" option cannot be recognized.

Therefore, in the process of selecting the command to be used in the process for each compiler, I fixed to compare the command set in `F77` and `F90` and the command specified for each compiler(e.g. `possible_executables = ['gfortran', 'f95']` in gnu.py).


