### PR TITLE
Clarify GROMACS relaxed double option

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -74,7 +74,7 @@ class Gromacs(CMakePackage):
     variant('openmp', default=True,
             description='Enables OpenMP at configure time')
     variant('relaxed_double_precision', default=False,
-            description='GMX_RELAXED_DOUBLE_PRECISION, intended only for Fujitsu PRIMEHPC')
+            description='GMX_RELAXED_DOUBLE_PRECISION, use only for Fujitsu PRIMEHPC')
     variant('hwloc', default=True,
             description='Use the hwloc portable hardware locality library')
     variant('lapack', default=False,

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -66,7 +66,7 @@ class Gromacs(CMakePackage):
     variant('nosuffix', default=False, description='Disable default suffixes')
     variant('build_type', default='RelWithDebInfo',
             description='The build type to build',
-            values=('Debug', 'Release', 'RelWith?filepath=tutorial.ipynbDebInfo', 'MinSizeRel',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel',
                     'Reference', 'RelWithAssert', 'Profile'))
     variant('mdrun_only', default=False,
             description='Enables the build of a cut-down version'

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -66,15 +66,15 @@ class Gromacs(CMakePackage):
     variant('nosuffix', default=False, description='Disable default suffixes')
     variant('build_type', default='RelWithDebInfo',
             description='The build type to build',
-            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel',
+            values=('Debug', 'Release', 'RelWith?filepath=tutorial.ipynbDebInfo', 'MinSizeRel',
                     'Reference', 'RelWithAssert', 'Profile'))
     variant('mdrun_only', default=False,
             description='Enables the build of a cut-down version'
             ' of libgromacs and/or the mdrun program')
     variant('openmp', default=True,
             description='Enables OpenMP at configure time')
-    variant('double_precision', default=False,
-            description='GMX_RELAXED_DOUBLE_PRECISION for Fujitsu PRIMEHPC')
+    variant('relaxed_double_precision', default=False,
+            description='GMX_RELAXED_DOUBLE_PRECISION, intended only for Fujitsu PRIMEHPC')
     variant('hwloc', default=True,
             description='Use the hwloc portable hardware locality library')
     variant('lapack', default=False,
@@ -251,7 +251,7 @@ class Gromacs(CMakePackage):
         else:
             options.append('-DGMX_OPENMP:BOOL=ON')
 
-        if '+double_precision' in self.spec:
+        if '+relaxed_double_precision' in self.spec:
             options.append('-DGMX_RELAXED_DOUBLE_PRECISION:BOOL=ON')
         else:
             options.append('-DGMX_RELAXED_DOUBLE_PRECISION:BOOL=OFF')


### PR DESCRIPTION
This is only intended for use on the Fujitsu PRIMEHPC platform (ie former K computer, not Fugaku)