### PR TITLE
let intel consider cray-mpich as mpich

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -815,6 +815,7 @@ class IntelPackage(PackageBase):
             # Was supported only up to 2015.
             blacs_lib = 'libmkl_blacs'
         elif ('^mpich@2:' in spec_root or
+              '^cray-mpich' in spec_root or
               '^mvapich2' in spec_root or
               '^intel-mpi' in spec_root or
               '^intel-parallel-studio' in spec_root):


### PR DESCRIPTION
It looks a bit weird, but it seems the right place where to fix this.