### PR TITLE
Added Conflict for macsio@1.1 ~mpi

### DIFF
--- a/var/spack/repos/builtin/packages/macsio/package.py
+++ b/var/spack/repos/builtin/packages/macsio/package.py
@@ -41,6 +41,8 @@ class Macsio(CMakePackage):
     depends_on('silo', when="+pdb")
     depends_on('typhonio', when="+typhonio")
     depends_on('scr', when="+scr")
+    # macsio@1.1 has bug with ~mpi configuration
+    conflicts('~mpi', when='@1.1')
 
     # Ref: https://github.com/LLNL/MACSio/commit/51b8c40cd9813adec5dd4dd6cee948bb9ddb7ee1
     patch('cast.patch', when='@1.1')


### PR DESCRIPTION
Added conflict for macsio@1.1~mpi after investigating source code. As of
1.1 tag macsio does not properly guard out MPI commands. This is
verified as corrected in @develop