### PR TITLE
py-matplotlib: clarify backend variant description

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -65,7 +65,9 @@ class PyMatplotlib(PythonPackage):
     if sys.platform == 'darwin':
         default_backend = 'macosx'
 
-    variant('backend', default=default_backend, description='Default backend',
+    variant('backend', default=default_backend,
+            description='Default backend. All backends are installed and ' +
+            'functional as long as dependencies are found at run-time',
             values=all_backends, multi=False)
     variant('movies', default=False,
             description='Enable support for saving movies')


### PR DESCRIPTION
Fixes #21511 

```console
$ spack info py-matplotlib
...
Variants:
    Name [Default]      Allowed values          Description
    ================    ====================    ==============================

    animation [off]     on, off                 Enable animation support
    backend [macosx]    gtk3agg, gtk3cairo,     Default backend. All backends
                        macosx, nbagg,          are installed and functional
                        qt4agg, qt4cairo,       as long as dependencies are
                        qt5agg, qt5cairo,       found at run-time
                        tkagg, tkcairo,         
                        webagg, wx, wxagg,      
                        wxcairo, agg, cairo,    
                        pdf, pgf, ps, svg,      
                        template                
    fonts [off]         on, off                 Enable support for system font
                                                detection
    image [on]          on, off                 Enable reading/saving JPEG,
                                                BMP and TIFF files
    latex [off]         on, off                 Enable LaTeX text rendering
                                                support
    movies [off]        on, off                 Enable support for saving
                                                movies
```

@lrtfm does this look good to you?