### PR TITLE
aspcud: update version to fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/aspcud/package.py
+++ b/var/spack/repos/builtin/packages/aspcud/package.py
@@ -18,9 +18,10 @@ class Aspcud(CMakePackage):
     homepage = "https://potassco.org/aspcud"
     url      = "https://github.com/potassco/aspcud/archive/v1.9.4.tar.gz"
 
+    version('1.9.5', sha256='9cd3a9490d377163d87b16fa1a10cc7254bc2dbb9f60e846961ac8233f3835cf')
     version('1.9.4', sha256='3645f08b079e1cc80e24cd2d7ae5172a52476d84e3ec5e6a6c0034492a6ea885')
 
-    depends_on('boost', type=('build'))
+    depends_on('boost@1.74:', type=('build'), when='@1.9.5:')
     depends_on('cmake', type=('build'))
     depends_on('re2c', type=('build'))
     depends_on('clingo')


### PR DESCRIPTION
update `aspcud` version and `boost` constraintion to fix error:
https://github.com/potassco/aspcud/issues/7