### PR TITLE
bird: add build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/bird/package.py
+++ b/var/spack/repos/builtin/packages/bird/package.py
@@ -23,5 +23,7 @@ class Bird(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('flex',     type='build')
+    depends_on('bison',    type='build')
     depends_on('ncurses')
     depends_on('readline')


### PR DESCRIPTION
`bird` need `flex` and `bison` in `build` phase.

```
==> bird: Executing phase: 'configure'
==> [2020-12-22-17:11:05.101041] '/home/spack-stage/root/spack-stage-bird-2.0.2-mlp3dlo33fewzxmni55dfvkk266nzsyl/spack-src/configure' '--prefix=/home/spack-develop/opt/spack/linux-ubuntu18.04-aarch64/gcc-7.5.0/bird-2.0.2-mlp3dlo33fewzxmni55dfvkk266nzsyl'
checking for gcc... /home/spack-develop/lib/spack/env/gcc/gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether /home/spack-develop/lib/spack/env/gcc/gcc accepts -g... yes
checking for /home/spack-develop/lib/spack/env/gcc/gcc option to accept ISO C89... none needed
checking for library containing clock_gettime... none required
checking build system type... aarch64-unknown-linux-gnu
checking host system type... aarch64-unknown-linux-gnu
checking for gcc... (cached) /home/spack-develop/lib/spack/env/gcc/gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether /home/spack-develop/lib/spack/env/gcc/gcc accepts -g... (cached) yes
checking for /home/spack-develop/lib/spack/env/gcc/gcc option to accept ISO C89... (cached) none needed
checking for /home/spack-develop/lib/spack/env/gcc/gcc option to accept ISO C99... none needed
checking whether POSIX threads are available... yes
checking whether CC supports -Wno-pointer-sign... yes
checking whether CC supports -Wno-missing-field-initializers... yes
checking whether CC supports -fno-strict-aliasing... yes
checking whether CC supports -fno-strict-overflow... yes
checking CFLAGS... -g -O2 -pthread -Wall -Wextra -Wstrict-prototypes -Wno-parentheses -Wno-pointer-sign -Wno-missing-field-initializers -fno-strict-aliasing -fno-strict-overflow
checking how to run the C preprocessor... /home/spack-develop/lib/spack/env/gcc/gcc -E
checking for a BSD-compatible install... /usr/bin/install -c
checking for ranlib... ranlib
checking for flex... no
checking for bison... no
checking for gm4... no
checking for m4... m4
configure: error: Flex is missing.
```