### PR TITLE
bugfix url path use for S3 access

### DIFF
--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -213,7 +213,7 @@ def url_exists(url):
         s3 = s3_util.create_s3_session(url)
         from botocore.exceptions import ClientError
         try:
-            s3.get_object(Bucket=url.netloc, Key=url.path)
+            s3.get_object(Bucket=url.netloc, Key=url.path[1:])
             return True
         except ClientError as err:
             if err.response['Error']['Code'] == 'NoSuchKey':
@@ -239,7 +239,7 @@ def remove_url(url):
 
     if url.scheme == 's3':
         s3 = s3_util.create_s3_session(url)
-        s3.delete_object(Bucket=url.netloc, Key=url.path)
+        s3.delete_object(Bucket=url.netloc, Key=url.path[1:])
         return
 
     # Don't even try for other URL schemes.


### PR DESCRIPTION
@opadron for your consideration.

Without this PR, I'm unable to create a build cache on a S3 bucket that is _not_ an AWS one (but a Linode one), getting a SignatureDoesNotMatch error : 

```
~$ spack buildcache create --rebuild-index -a -f -m aphecetche zlib
==> Buildcache files will be output to s3://spack-aphecetche-mirror/build_cache
==> Error: An error occurred (SignatureDoesNotMatch) when calling the GetObject operation: Unknown
```

Seems the key must not start with a slash ? 
Note that with this PR I'm able to use either kind of S3 bucket.
But I'm certainly not a S3 expert, so please x-check ;-)  
 