### PR TITLE
Fix groff build with long interpeter line

### DIFF
--- a/var/spack/repos/builtin/packages/groff/BuildFoundries.patch
+++ b/var/spack/repos/builtin/packages/groff/BuildFoundries.patch
@@ -1,0 +1,11 @@
+--- a/font/devpdf/Makefile.sub	2014-11-04 02:38:35.427521472 -0600
++++ b/font/devpdf/Makefile.sub	2021-02-08 14:28:51.194111775 -0600
+@@ -95,7 +95,7 @@
+ 	chmod +x util/BuildFoundries
+ 	echo "# foundry	ps name	psfile" > $(top_builddir)/font/devpdf/download
+ 	PATH="$(top_builddir)/src/utils/afmtodit:$(GROFF_PATH_SEPARATOR)$(PATH)" \
+-	  util/BuildFoundries $(top_builddir)/font/devpdf \
++	  $(PERL) util/BuildFoundries $(top_builddir)/font/devpdf \
+ 	    '$(top_srcdir)/font/devps : $(top_builddir)/font/devps' \
+ 	   >> $(top_builddir)/font/devpdf/download
+ 

--- a/var/spack/repos/builtin/packages/groff/package.py
+++ b/var/spack/repos/builtin/packages/groff/package.py
@@ -35,6 +35,11 @@ class Groff(AutotoolsPackage, GNUMirrorPackage):
     # patch('gropdf.patch')
     parallel = False
 
+    # The perl interpreter line in scripts might be too long as it has
+    # not been transformed yet. Call scripts with spack perl explicitly.
+    patch('BuildFoundries.patch')
+    patch('pdfmom.patch')
+
     def configure_args(self):
         args = [
             "--without-x"

--- a/var/spack/repos/builtin/packages/groff/pdfmom.patch
+++ b/var/spack/repos/builtin/packages/groff/pdfmom.patch
@@ -1,0 +1,11 @@
+--- a/contrib/mom/Makefile.sub	2014-11-04 02:38:35.502520534 -0600
++++ b/contrib/mom/Makefile.sub	2021-02-08 14:51:57.131553432 -0600
+@@ -41,7 +41,7 @@
+   GROFF_COMMAND_PREFIX= \
+   GROFF_BIN_PATH="$(GROFF_BIN_PATH)" \
+   PDFMOM_BIN_PATH="$(top_builddir)/src/devices/gropdf" \
+-  $(PDFMOMBIN) $(FFLAG) $(TFLAG) $(KFLAG)
++  $(PERL) $(PDFMOMBIN) $(FFLAG) $(TFLAG) $(KFLAG)
+ 
+ MAN7=\
+   groff_mom.n


### PR DESCRIPTION
This PR fixes the case where groff fails to build if the spack install
path is really long. There are a couple of perl scripts that get built,
and used, during the build phase that will fail when the perl
interpreter line is too long. Filtering the lines will not work because
the files don not exist after the configure phase and patching after the
build phase is too late.  This PR runs the scripts explicitly with the
spack perl via the $(PERL) variable in the call to the script.