### PR TITLE
bolt: new versions 2.0 and 1.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/bolt/package.py
+++ b/var/spack/repos/builtin/packages/bolt/package.py
@@ -23,6 +23,8 @@ class Bolt(CMakePackage):
     maintainers = ['shintaro-iwasaki']
 
     version("main", branch="main")
+    version("2.0", sha256="f84b6a525953edbaa5d28748ef3ab172a3b6f6899b07092065ba7d1ccc6eb5ac")
+    version("1.0.1", sha256="769e30dfc4042cee7ebbdadd23cf08796c03bcd8b335f516dc8cbc3f8adfa597")
     version("1.0", sha256="1c0d2f75597485ca36335d313a73736594e75c8a36123c5a6f54d01b5ba5c384")
 
     depends_on('argobots')


### PR DESCRIPTION
This PR adds new versions 2.0 and 1.0.1 to the BOLT package.
 