### PR TITLE
shell support: prepend Spack path in init scripts

### DIFF
--- a/share/spack/csh/pathadd.csh
+++ b/share/spack/csh/pathadd.csh
@@ -25,13 +25,23 @@ if ($_pa_set == 1) then
     eval set _pa_old_value='$'$_pa_varname
 endif
 
-# Do the actual prepending here, if it is a dir and not already in the path
-if ( -d $_pa_new_path && \:$_pa_old_value\: !~ *\:$_pa_new_path\:* ) then
-    if ("x$_pa_old_value" == "x") then
-        setenv $_pa_varname $_pa_new_path
+# Do the actual prepending here, if it is a dir
+if ( -d $_pa_new_path) then
+    if ( "x$_pa_old_value" != "x" ) then
+        set _pa_canonical = ':'$_pa_old_value':'
+
+        # strip new value if it's present
+        set _pa_canonical_removed = `echo $_pa_canonical | sed "s#:${_pa_new_path}:#:#"`
+
+        # remove trailing colon. Keep the leading colon since we will prepend next
+        set _pa_removed = `echo $_pa_canonical_removed | rev | cut -c 2- | rev`
+
+        # Add the new path
+        setenv $_pa_varname "${_pa_new_path}${_pa_removed}"
     else
-        setenv $_pa_varname $_pa_new_path\:$_pa_old_value
+        setenv $_pa_varname $_pa_new_path
     endif
 endif
 
 unset _pa_args _pa_new_path _pa_old_value _pa_set _pa_varname
+unset _pa_canonical _pa_canonical_removed _pa_removed

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -625,21 +625,14 @@ function spack_pathadd -d "Add path to specified variable (defaults to PATH)"
     # skip path is not existing directory
     #  -> Notes: [1] (cf. EOF).
     if test -d "$pa_new_path"
+        # remove path if it is already present to move to front
+        set -l pa_removed (string match --invert $pa_new_path $pa_oldvalue)
 
-        # combine argument array into single string (space seperated), to be
-        # passed to regular expression matching (`string match -r`)
-        set -l _a "$pa_oldvalue"
-
-        # skip path if it is already contained in the variable
-        # note spaces in regular expression: we're matching to a space delimited
-        # list of paths
-        if not echo $_a | string match -q -r " *$pa_new_path *"
-            if test -n "$pa_oldvalue"
-                set $pa_varname $pa_new_path $pa_oldvalue
-            else
-                true # this is a bit of a strange hack! Notes: [3] (cf. EOF)
-                set $pa_varname $pa_new_path
-            end
+        if test -n "$pa_removed"
+            set $pa_varname $pa_new_path $pa_removed
+        else
+            true # this is a bit of a strange hack! Nodes: [3] (cf. EOF)
+            set $pa_varname $pa_new_path
         end
     end
 end

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -224,18 +224,18 @@ _spack_pathadd() {
 	    # Remove value from variable if it is present
 	    # This ensures we prepend
 	    _pa_canonical=":$_pa_oldvalue:"
-	    _pa_canonical_removed=`echo $_pa_canonical | sed "/:$_pa_new_path:/:/"`
+	    _pa_canonical_removed=`echo $_pa_canonical | sed "s/:\$_pa_new_path:/:/"`
 
 	    # Strip trailing colon. Leave starting colon since we prepend next
 	    # Use a wildcard because colons have meaning for some shells
 	    _pa_removed=${_pa_canonical_removed%?}
 
 	    # Set new value
-	    export $_pa_varname="${_pa_new_path}{$_pa_removed}"
+	    export $_pa_varname="${_pa_new_path}${_pa_removed}"
 	else
 	    # Set the value
 	    export $_pa_varname="$_pa_new_path"
-
+        fi
     fi
 }
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -224,7 +224,7 @@ _spack_pathadd() {
 	    # Remove value from variable if it is present
 	    # This ensures we prepend
 	    _pa_canonical=":$_pa_oldvalue:"
-	    _pa_canonical_removed=$(echo $_pa_canonical | sed "s/:\$_pa_new_path:/:/")
+	    _pa_canonical_removed=$(echo $_pa_canonical | sed "s#:\$_pa_new_path:#:#")
 	    # Strip trailing colon. Leave starting colon since we prepend next
 	    # Use a wildcard because colons have meaning for some shells
 	    _pa_removed=${_pa_canonical_removed%?}

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -224,8 +224,7 @@ _spack_pathadd() {
 	    # Remove value from variable if it is present
 	    # This ensures we prepend
 	    _pa_canonical=":$_pa_oldvalue:"
-	    _pa_canonical_removed=`echo $_pa_canonical | sed "s/:\$_pa_new_path:/:/"`
-
+	    _pa_canonical_removed=$(echo $_pa_canonical | sed "s/:\$_pa_new_path:/:/")
 	    # Strip trailing colon. Leave starting colon since we prepend next
 	    # Use a wildcard because colons have meaning for some shells
 	    _pa_removed=${_pa_canonical_removed%?}


### PR DESCRIPTION
Fixes an issue reported on slack. When spack is already in the path, the init scripts do not move it to the front. This is a problem for users switching among multiple Spack instances.

I've tried to make the function more readable while I'm at it, bash can be illegible at times.