### PR TITLE
Fix typo in error message for spack load

### DIFF
--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -63,7 +63,7 @@ def load(parser, args):
         specs_str = ' '.join(args.specs) or "SPECS"
         spack.cmd.common.shell_init_instructions(
             "spack load",
-            "    eval `spack load {sh_arg}` %s" % specs_str,
+            "    eval `spack load {sh_arg} %s`" % specs_str,
         )
         return 1
 


### PR DESCRIPTION
the package specification(s) are argument(s) to spack, not to eval