### PR TITLE
root: 6.22.04 works with xrootd 5

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -251,7 +251,8 @@ class Root(CMakePackage):
     depends_on('vc',        when='+vc')
     depends_on('vdt',       when='+vdt')
     depends_on('libxml2',   when='+xml')
-    depends_on('xrootd@:4.99.99',    when='+xrootd')
+    depends_on('xrootd',          when='+xrootd')
+    depends_on('xrootd@:4.99.99', when='@:6.22.03 +xrootd')
 
     # ###################### Conflicts ######################
 


### PR DESCRIPTION
ROOT version 6.22.04 has been ported to support xrootd 5.
So let's support that.

See: https://github.com/root-project/root/commit/a33b156e3bf809343eda08150666154a

Maintainer-Ping: @chissg, @HadrienG2, @drbenmorgan, @vvolkl