### PR TITLE
ascent: add version v0.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -41,6 +41,9 @@ class Ascent(Package, CudaPackage):
 
     version('develop',
             branch='develop',
+            submodules=True)
+    version('0.6.0',
+            tag='v0.6.0',
             submodules=True,
             preferred=True)
 


### PR DESCRIPTION
Ascent: add version `0.6.0` and make it the preferred version.

@cyrush 