### PR TITLE
Update LIGGGHTS package.py to only use VTK 6 to VTK 8

### DIFF
--- a/var/spack/repos/builtin/packages/liggghts/package.py
+++ b/var/spack/repos/builtin/packages/liggghts/package.py
@@ -27,7 +27,7 @@ class Liggghts(MakefilePackage):
     variant('profile', default=False,
             description='Generate profiling code')
 
-    depends_on('vtk')
+    depends_on('vtk@6.1.0:8.2.0')
     depends_on('mpi', when='+mpi')
     depends_on('jpeg', when='+jpeg')
     depends_on('zlib', when="+gzip")


### PR DESCRIPTION
LIGGGHTS makefile throws error when using vtk versions greater than 8. Sets vtk to the ranges 6.1.0 to 8.2.0