### PR TITLE
sollve: deprecate sollve package

### DIFF
--- a/var/spack/repos/builtin/packages/sollve/package.py
+++ b/var/spack/repos/builtin/packages/sollve/package.py
@@ -72,7 +72,7 @@ class Sollve(CMakePackage):
     depends_on('binutils+gold', when='+gold')
 
     # develop version.
-    version("develop")
+    version("develop", deprecated=True)
     resource(name='compiler-rt',
              svn='http://llvm.org/svn/llvm-project/compiler-rt/trunk',
              destination='projects', when='@develop+compiler-rt',
@@ -99,7 +99,8 @@ class Sollve(CMakePackage):
              placement='libunwind')
 
     # 1.0a2 based on LLVM 9.0+
-    version("1.0a2", commit="cb4343bda9e57076a74dee23236ac9737e07594f")
+    version("1.0a2", commit="cb4343bda9e57076a74dee23236ac9737e07594f",
+            deprecated=True)
     resource(name='compiler-rt',
              svn='https://llvm.org/svn/llvm-project/compiler-rt/trunk',
              revision=373130, destination='projects',


### PR DESCRIPTION
This PR deprecates `sollve` instead of removing it (#20944). This `sollve` package is superseded by `llvm-doe` (#20719).

@adamjstewart I'd be happy if you could review this PR.
