### PR TITLE
pandoc:  Addition of conflicts conditions

### DIFF
--- a/var/spack/repos/builtin/packages/pandoc/package.py
+++ b/var/spack/repos/builtin/packages/pandoc/package.py
@@ -28,6 +28,8 @@ class Pandoc(Package):
 
     variant('texlive', default=True, description='Use TeX Live to enable PDF output')
 
+    conflicts('target=aarch64:', msg='aarch64 is not supported.')
+
     depends_on('texlive', when='+texlive')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
I set conflicts because there is no pandoc binary that supports aarch64