### PR TITLE
py-llvmlite: Changing build options when using the FUJITSU compiler

### DIFF
--- a/var/spack/repos/builtin/packages/py-llvmlite/package.py
+++ b/var/spack/repos/builtin/packages/py-llvmlite/package.py
@@ -37,6 +37,10 @@ class PyLlvmlite(PythonPackage):
     depends_on('binutils', type='build')
 
     def setup_build_environment(self, env):
-        # Need to set PIC flag since this is linking statically with LLVM
-        env.set('CXX_FLTO_FLAGS', '-flto {0}'.format(
-            self.compiler.cxx_pic_flag))
+        if self.spec.satisfies('%fj'):
+            env.set('CXX_FLTO_FLAGS', '{0}'.format(self.compiler.cxx_pic_flag))
+            env.set('LD_FLTO_FLAGS', '-Wl,--exclude-libs=ALL')
+        else:
+            # Need to set PIC flag since this is linking statically with LLVM
+            env.set('CXX_FLTO_FLAGS', '-flto {0}'.format(
+                self.compiler.cxx_pic_flag))


### PR DESCRIPTION
If you build with -flto (optimization option) when using the FUJITSU compiler, the combination of the mpi library and clang mode will cause GNU LD problems, resulting in a build error.
When using the FUJITSU compiler, it corresponds to remove -flto (optimization option).