### PR TITLE
hdf: Add setup_build_environment, Fix for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/hdf/for_aarch64.patch
@@ -1,0 +1,56 @@
+--- spack-src/hdf/src/hdfi.h.bak	2018-06-27 13:42:58.000000000 +0900
++++ spack-src/hdf/src/hdfi.h	2021-02-10 12:48:08.597069536 +0900
+@@ -1111,6 +1111,53 @@
+ 
+ #endif /* IA64 */
+ 
++/* Aarch 64 */
++#if defined(__linux__) && defined __aarch64__  && !(defined  SUN)  /* i.e. 64-bit Linux  but not SunOS on aarch64 */
++
++#ifdef GOT_MACHINE
++If you get an error on this line more than one machine type has been defined.
++Please check your Makefile.
++#endif
++#define GOT_MACHINE
++
++#include <sys/file.h>               /* for unbuffered i/o stuff */
++#include <sys/stat.h>
++#define DF_MT             DFMT_LINUX64
++typedef void              VOID;
++typedef void              *VOIDP;
++typedef char              *_fcd;
++typedef char              char8;
++typedef unsigned char     uchar8;
++typedef char              int8;
++typedef unsigned char     uint8;
++typedef short int         int16;
++typedef unsigned short int uint16;
++typedef int               int32;
++typedef unsigned int      uint32;
++typedef int               intn;
++typedef unsigned int      uintn;
++typedef int               intf;     /* size of INTEGERs in Fortran compiler */
++typedef float             float32;
++typedef double            float64;
++typedef long              hdf_pint_t;   /* an integer the same size as a pointer */
++#define FNAME_POST_UNDERSCORE
++#define _fcdtocp(desc) (desc)
++#define FILELIB UNIXBUFIO
++
++/* JPEG #define's - Look in the JPEG docs before changing - (Q) */
++
++/* Determine the memory manager we are going to use. Valid values are: */
++/*  MEM_DOS, MEM_ANSI, MEM_NAME, MEM_NOBS.  See the JPEG docs for details on */
++/*  what each does */
++#define JMEMSYS         MEM_ANSI
++
++#ifdef __GNUC__
++#define HAVE_STDC
++#define INCLUDES_ARE_ANSI
++#endif
++
++#endif /*Aarch 64 */
++
+ #ifndef GOT_MACHINE
+ No machine type has been defined.  Your Makefile needs to have someing like
+ -DSUN or -DUNICOS in order for the HDF internal structures to be defined

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -48,6 +48,8 @@ class Hdf(AutotoolsPackage):
     # https://forum.hdfgroup.org/t/cant-build-hdf-4-2-14-with-jdk-11-and-enable-java/5702
     patch('disable_doclint.patch', when='@:4.2.14^java@9:')
 
+    patch('for_aarch64.patch', when='target=aarch64:')
+
     conflicts('^libjpeg@:6a')
 
     # configure: error: Cannot build shared fortran libraries.
@@ -121,6 +123,9 @@ class Hdf(AutotoolsPackage):
                 flags.append(self.compiler.f77_pic_flag)
 
         return flags, None, None
+
+    def setup_build_environment(self, env):
+        env.prepend_path('CPATH', self.spec['libtirpc'].prefix.include.tirpc)
 
     def configure_args(self):
         config_args = ['--enable-production',


### PR DESCRIPTION
I have fixed the following error detected on x86_64 and aarch64 machines:
3 errors found in build log:
     25     checking for config unknown-linux-gnu... no
     26     checking for config unknown-linux-gnu... no
     27     checking for config aarch64-linux-gnu... no
     28     checking for config aarch64-linux-gnu... no
     29     checking for config aarch64-unknown... no
     30     checking for config linux-gnu... found
  >> 31     gfortran: error: unrecognized command line option '-V'
  >> 32     gfortran: fatal error: no input files
     33     compilation terminated.
     34     checking whether make sets $(MAKE)... (cached) yes
     35     checking for gcc... /fefs/home/r1059/spack/lib/spack/env/gcc/gcc
     36     checking whether the C compiler works... yes
     37     checking for C compiler default output file name... a.out
     38     checking for suffix of executables...

     ...

     140    checking for jpeg_start_decompress in -ljpeg... yes
     141    checking for szlib... suppressed
     142    checking for xdr library support... checking rpc/rpc.h usability... no
     143    checking rpc/rpc.h presence... no
     144    checking for rpc/rpc.h... no
     145    checking for rpc/rpc.h... (cached) no
  >> 146    configure: error: couldn't find rpc headers

This error also occurred in versions 4.2.11 to 4.2.14, so we have confirmed that this fix will solve it.