### PR TITLE
Windows: url_fetch test passes

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -242,15 +242,17 @@ def which_string(*args, **kwargs):
         path = path.split(os.pathsep)
 
     for name in args:
+        if sys.platform == "win32":
+            name += '.exe'
         if os.path.sep in name:
             exe = os.path.abspath(name)
             if os.path.isfile(exe) and os.access(exe, os.X_OK):
-                return exe
+                return exe.replace('\\', '/')
         else:
             for directory in path:
                 exe = os.path.join(directory, name)
                 if os.path.isfile(exe) and os.access(exe, os.X_OK):
-                    return exe
+                    return exe.replace('\\', '/')
 
     if required:
         raise CommandNotFoundError(

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -10,9 +10,11 @@ Utility functions for parsing, formatting, and manipulating URLs.
 import itertools
 import os.path
 import re
+import sys
 
 from six import string_types
 import six.moves.urllib.parse as urllib_parse
+from six.moves.urllib.request import url2pathname
 
 import spack.util.path
 
@@ -69,6 +71,8 @@ def parse(url, scheme='file'):
     scheme = (scheme or 'file').lower()
 
     if scheme == 'file':
+        if sys.platform == "win32":
+            path = url2pathname(path)
         path = spack.util.path.canonicalize_path(netloc + path)
         path = re.sub(r'^/+', '/', path)
         netloc = ''
@@ -231,7 +235,10 @@ def _join(base_url, path, *extra, **kwargs):
         base_path_args = [new_base_path]
 
     base_path_args.extend(path_tokens)
-    base_path = os.path.relpath(os.path.join(*base_path_args), '/fake-root')
+    if sys.platform == "win32":
+        base_path = os.path.join(*base_path_args)
+    else:
+        base_path = os.path.relpath(os.path.join(*base_path_args), '/fake-root')
 
     if scheme == 's3':
         path_tokens = [

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -524,15 +524,15 @@ def find_versions_of_archive(
     # Scrape them for archive URLs
     regexes = []
     for aurl in archive_urls:
+        # We'll be a bit more liberal and just look for the archive
+        # part, not the full path.
+        url_regex = os.path.basename(aurl)
+
         # This creates a regex from the URL with a capture group for
         # the version part of the URL.  The capture group is converted
         # to a generic wildcard, so we can use this to extract things
         # on a page that look like archive URLs.
-        url_regex = spack.url.wildcard_version(aurl)
-
-        # We'll be a bit more liberal and just look for the archive
-        # part, not the full path.
-        url_regex = os.path.basename(url_regex)
+        url_regex = spack.url.wildcard_version(url_regex)
 
         # We need to add a / to the beginning of the regex to prevent
         # Spack from picking up similarly named packages like:
@@ -561,6 +561,7 @@ def find_versions_of_archive(
     # Any conflicting versions will be overwritten by the list_url links.
     versions = {}
     for url in archive_urls + sorted(links):
+        url = url.replace("\\", "/")
         if any(re.search(r, url) for r in regexes):
             try:
                 ver = spack.url.parse_version(url)


### PR DESCRIPTION
url_fetch tests pass on Windows (if curl is available), requires #20412.
    
On Windows, locks are disabled for many tests as locking by range is not currently supported.

With these changes and #21398, url_fetch tests should also pass with urllib on Windows.


Note: After ensuring that tests pass, will change base branch to be merged onto **features/windows-support**

