### PR TITLE
meson: remove cmake dependency

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -26,6 +26,7 @@ class Mesa(MesonPackage):
     depends_on('pkgconfig', type='build')
     depends_on('binutils', when=(sys.platform != 'darwin'), type='build')
     depends_on('bison', type='build')
+    depends_on('cmake', type='build')
     depends_on('flex', type='build')
     depends_on('gettext', type='build')
     depends_on('python@3:', type='build')

--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -35,7 +35,6 @@ class Meson(PythonPackage):
     depends_on('python@3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('ninja', type='run')
-    depends_on('cmake', type='run')
 
     # By default, Meson strips the rpath on installation. This patch disables
     # rpath modification completely to make sure that Spack's rpath changes


### PR DESCRIPTION
cmake was added as a runtime dependency to meson in #20449. This introduces an unnecessary implicit cmake dependency, which increases build time for meson considerably. cmake is only one of many methods for finding dependencies (pkg-config, qmake etc.), which are also not runtime dependencies of meson. Add cmake as a build dependency to mesa instead.

cc @chuckatkins