### PR TITLE
hpctoolkit: pre-release update

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.util.environment import SetEnv
 
 
 class Hpctoolkit(AutotoolsPackage):
@@ -20,6 +21,7 @@ class Hpctoolkit(AutotoolsPackage):
 
     version('develop', branch='develop')
     version('master',  branch='master')
+    # version('2021.02.10', commit='9eea97d9aaff38f6460f25957cd1588093fb19c7')
     version('2020.08.03', commit='d9d13c705d81e5de38e624254cf0875cce6add9a')
     version('2020.07.21', commit='4e56c780cffc53875aca67d6472a2fb3678970eb')
     version('2020.06.12', commit='ac6ae1156e77d35596fea743ed8ae768f7222f19')
@@ -56,16 +58,17 @@ class Hpctoolkit(AutotoolsPackage):
             description='Support CUDA on NVIDIA GPUs (2020.03.01 or later).')
 
     variant('rocm', default=False,
-            description='Support ROCM on AMD GPUs (develop branch only, '
-            'requires ROCM as external packages.')
+            description='Support ROCM on AMD GPUs, requires ROCM as '
+            'external packages (2021.02.10 or later).')
 
     boost_libs = (
         '+atomic +chrono +date_time +filesystem +system +thread +timer'
         ' +graph +regex +shared +multithreaded visibility=global'
     )
 
-    depends_on('binutils+libiberty~nls', type='link', when='@2020.04.00:')
-    depends_on('binutils@:2.33.1+libiberty~nls', type='link', when='@:2020.03.99')
+    depends_on('binutils@:2.34 +libiberty', type='link', when='@2021.00:')
+    depends_on('binutils@:2.34 +libiberty~nls', type='link', when='@2020.04:2020.99')
+    depends_on('binutils@:2.33.1 +libiberty~nls', type='link', when='@:2020.03.99')
     depends_on('boost' + boost_libs)
     depends_on('bzip2+shared', type='link')
     depends_on('dyninst@9.3.2:')
@@ -73,7 +76,8 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on('gotcha@1.0.3:')
     depends_on('intel-tbb+shared')
     depends_on('libdwarf')
-    depends_on('libmonitor+hpctoolkit')
+    depends_on('libmonitor+hpctoolkit~dlopen', when='@2021.00:')
+    depends_on('libmonitor+hpctoolkit', when='@:2020.99')
     depends_on('libunwind@1.4: +xz+pic', when='@2020.09.00:')
     depends_on('libunwind@1.4: +xz', when='@:2020.08.99')
     depends_on('mbedtls+pic')
@@ -88,9 +92,9 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on('libpfm4', when='~papi')
     depends_on('mpi', when='+mpi')
 
-    depends_on('hip', when='@develop+rocm')
-    depends_on('rocm-dbgapi', when='@develop+rocm')
-    depends_on('roctracer-dev', when='@develop+rocm')
+    depends_on('hip', when='+rocm')
+    depends_on('rocm-dbgapi', when='+rocm')
+    depends_on('roctracer-dev', when='+rocm')
 
     conflicts('%gcc@:4.7.99', when='^dyninst@10.0.0:',
               msg='hpctoolkit requires gnu gcc 4.8.x or later')
@@ -98,8 +102,11 @@ class Hpctoolkit(AutotoolsPackage):
     conflicts('%gcc@:4.99.99', when='@2020.03.01:',
               msg='hpctoolkit requires gnu gcc 5.x or later')
 
-    conflicts('+cuda', when='@2018.0.0:2019.99.99',
+    conflicts('+cuda', when='@:2019.99.99',
               msg='cuda requires 2020.03.01 or later')
+
+    conflicts('+rocm', when='@:2020.99.99',
+              msg='rocm requires 2021.02.10 or later')
 
     flag_handler = AutotoolsPackage.build_system_flags
 
@@ -134,7 +141,7 @@ class Hpctoolkit(AutotoolsPackage):
         else:
             args.append('--with-perfmon=%s' % spec['libpfm4'].prefix)
 
-        if spec.satisfies('@develop+rocm'):
+        if spec.satisfies('+rocm'):
             args.extend([
                 '--with-rocm-hip=%s'    % spec['hip'].prefix,
                 '--with-rocm-dbgapi=%s' % spec['rocm-dbgapi'].prefix,
@@ -154,3 +161,18 @@ class Hpctoolkit(AutotoolsPackage):
             args.append('--enable-all-static')
 
         return args
+
+    # Remove setenv of ROCM, HIP, etc from the module file.  Loading
+    # the hpctoolkit module is not relevant to building a GPU app and
+    # some variables (HIP_PATH) intefere with building the app.
+    def setup_run_environment(self, env):
+        keeplist = []
+        for elt in env.env_modifications:
+            if not (isinstance(elt, SetEnv)
+                    and (elt.name.find('ROCM') >= 0
+                         or elt.name.find('HIP') >= 0
+                         or elt.name.find('CUDA') >= 0)):
+                keeplist.append(elt)
+
+        env.clear()
+        env.env_modifications = keeplist


### PR DESCRIPTION
Update some things in hpctoolkit to prepare for a 2021.02.x release:

  1. allow binutils to be built with +nls.
  2. require libmonitor to be built with +dlopen.
  3. allow rocm in more than just develop branch.
  4. remove some conflicting setenv's in hpctoolkit module.
  
----------

I have a little bit of a chicken and egg problem.  We're heading to a
release and I need to merge our develop branch into master, but the
new master won't build without these changes.  (don't ask)

My plan is to make these updates and merge hpctoolkit develop into
master.  Then I can fully test with everything in place.  Finally,
when ready, I can tag the next release and update package.py with
minimal changes.  But it takes two commits.

----------

We do need to modify the module environment to remove some setenvs.
I didn't want to dig into the internals of a spack env_modifications,
but I couldn't find a more structured way of doing this.