### PR TITLE
doxygen: Fix gcc getting stuck in an infinite loop

### DIFF
--- a/var/spack/repos/builtin/packages/doxygen/gcc-partial-inlining-bug.patch
+++ b/var/spack/repos/builtin/packages/doxygen/gcc-partial-inlining-bug.patch
@@ -1,0 +1,14 @@
+--- a/src/CMakeLists.txt	2021-02-10 22:55:14.766411242 -0500
++++ b/src/CMakeLists.txt	2021-02-10 23:10:17.651541580 -0500
+@@ -305,6 +305,11 @@
+     xmldocvisitor.cpp
+     xmlgen.cpp
+ )
++# Work aroung for GCC bug getting stuck in an infinite loop
++if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
++set_source_files_properties(doxygen.cpp PROPERTIES COMPILE_FLAGS -fno-partial-inlining)
++endif()
++
+ add_sanitizers(doxymain)
+ 
+ # LLVM/clang headers give a lot of warnings with -Wshadow and -Wcast-align so we disable them for

--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -75,6 +75,9 @@ class Doxygen(CMakePackage):
     # Also - https://github.com/doxygen/doxygen/pull/6588
     patch('shared_ptr.patch', when='@1.8.14')
 
+    # Workaround for gcc getting stuck in an infinite loop
+    patch('gcc-partial-inlining-bug.patch', when='@1.8.20: %gcc@7')
+
     def patch(self):
         if self.spec['iconv'].name == 'libc':
             return


### PR DESCRIPTION
Building `doxygen` on Ubuntu 18.04 causes gcc to hang in an infinite loop.  Explicitly disabling partial inlining in the one file it hangs on seems to address the issue. To the best I can determine the problem is isolated to `gcc 7.x` and `doxygen @1.8.20:` since both Ubuntu 20.0.4 with `%gcc@9` and RHEL8 with `%gcc@8.3` successfully compile as is and `doxygen @1.8.17` on Ubuntu 18.0.4 with `%gcc@7.5` does as well.