### PR TITLE
Speed up `spack buildcache list`

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -795,7 +795,7 @@ class Database(object):
         # do it *while* we're constructing specs,it causes hashes to be
         # cached prematurely.
         for hash_key, rec in data.items():
-            rec.spec._mark_concrete()
+            rec.spec._mark_root_concrete()
 
         self._data = data
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1454,11 +1454,12 @@ class Database(object):
                     rec.spec.name) != known:
                 continue
 
-            inst_date = datetime.datetime.fromtimestamp(
-                rec.installation_time
-            )
-            if not (start_date < inst_date < end_date):
-                continue
+            if start_date or end_date:
+                inst_date = datetime.datetime.fromtimestamp(
+                    rec.installation_time
+                )
+                if not (start_date < inst_date < end_date):
+                    continue
 
             if (query_spec is any or
                 rec.spec.satisfies(query_spec, strict=True)):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2538,6 +2538,13 @@ class Spec(object):
         else:
             self._old_concretize(tests)
 
+    def _mark_root_concrete(self, value=True):
+        """Mark just this spec (not dependencies) concrete."""
+        if (not value) and self.concrete and self.package.installed:
+            return
+        self._normal = value
+        self._concrete = value
+
     def _mark_concrete(self, value=True):
         """Mark this spec and its dependencies as concrete.
 
@@ -2545,10 +2552,7 @@ class Spec(object):
         unless there is a need to force a spec to be concrete.
         """
         for s in self.traverse():
-            if (not value) and s.concrete and s.package.installed:
-                continue
-            s._normal = value
-            s._concrete = value
+            s._mark_root_concrete(value)
 
     def concretized(self, tests=False):
         """This is a non-destructive version of concretize().

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1786,10 +1786,12 @@ class Spec(object):
         name = next(iter(node))
         node = node[name]
 
-        spec = Spec(name, full_hash=node.get('full_hash', None))
+        spec = Spec()
+        spec.name = name
         spec.namespace = node.get('namespace', None)
         spec._hash = node.get('hash', None)
         spec._build_hash = node.get('build_hash', None)
+        spec._full_hash = node.get('full_hash', None)
 
         if 'version' in node or 'versions' in node:
             spec.versions = vn.VersionList.from_dict(node)

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -38,10 +38,14 @@ def dump(data, stream=None):
 
 
 def _strify(data, ignore_dicts=False):
+    """Converts python 2 unicodes to str in JSON data."""
+    # this is a no-op in python 3
+    if sys.version_info[0] >= 3:
+        return data
+
     # if this is a unicode string in python 2, return its string representation
-    if sys.version_info[0] < 3:
-        if isinstance(data, string_types):
-            return data.encode('utf-8')
+    if isinstance(data, string_types):
+        return data.encode('utf-8')
 
     # if this is a list of values, return list of byteified values
     if isinstance(data, list):

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -37,7 +37,10 @@ from spack.util.spack_yaml import syaml_dict
 __all__ = ['Version', 'VersionRange', 'VersionList', 'ver']
 
 # Valid version characters
-VALID_VERSION = r'[A-Za-z0-9_.-]'
+VALID_VERSION = re.compile(r'[A-Za-z0-9_.-]')
+
+# regex for version segments
+SEGMENT_REGEX = re.compile(r'[a-zA-Z]+|[0-9]+')
 
 # Infinity-like versions. The order in the list implies the comparison rules
 infinity_versions = ['develop', 'main', 'master', 'head', 'trunk']
@@ -97,9 +100,10 @@ class Version(object):
     """Class to represent versions"""
 
     def __init__(self, string):
-        string = str(string)
+        if not isinstance(string, str):
+            string = str(string)
 
-        if not re.match(VALID_VERSION, string):
+        if not VALID_VERSION.match(string):
             raise ValueError("Bad characters in version string: %s" % string)
 
         # preserve the original string, but trimmed.
@@ -107,12 +111,11 @@ class Version(object):
         self.string = string
 
         # Split version into alphabetical and numeric segments
-        segment_regex = r'[a-zA-Z]+|[0-9]+'
-        segments = re.findall(segment_regex, string)
+        segments = SEGMENT_REGEX.findall(string)
         self.version = tuple(int_if_int(seg) for seg in segments)
 
         # Store the separators from the original version string as well.
-        self.separators = tuple(re.split(segment_regex, string)[1:])
+        self.separators = tuple(SEGMENT_REGEX.split(string)[1:])
 
     @property
     def dotted(self):


### PR DESCRIPTION
This fixes a few simple things to make `spack buildcache list` ~30-35% faster.  On my mac, it takes 19s to list https://cache.e4s.io (which has 27k specs or so in the index) without this, and 12-13s with it.  

The optimizations are:
- [x] Avoid expensive parsing in `Spec.from_node_dict()`.  It was calling `Spec(name)`, when it could just call `Spec()` and set the name.
- [x] Avoid redundant marks when `_mark_concrete()` is called from `Database.read_from_file()`.  `_mark_concrete()` traverses the whole spec, but we don't need to do that in `Database` b/c we know we'll hit all the nodes just iterating over the DB itself.  Introduce `_mark_root_concrete()` and use that instead.
- [x] In Python 2, we had to traverse all JSON  structures and convert `unicode` to strings, but we don't have to do that in Python 3.  Make the `spack_json._strify` a no-op in Python 3.
- [x] Precompile some regular expressions in `version.py`
- [x] don't construct a date object for every database query.