### PR TITLE
New Package: hevea

### DIFF
--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -16,7 +16,7 @@ class Hevea(MakefilePackage):
     maintainers = ['scemama', 'cessenat']
 
     version('develop', branch='master')
-    version('2.35', sha256='f189bada5d3e5b35855dfdfdb5b270c994fc7a2366b01250d761359ad66c9ecb')
+    version('2.35', sha256='78f834cc7a8112ec59d0b8acdfbed0c8ac7dbb85f964d0be1f4eed04f25cdf54')
     version('2.34', sha256='f505a2a5bafdc2ea389ec521876844e6fdcb5c1b656396b7e8421c1631469ea2')
     version('2.33', sha256='122f9023f9cfe8b41dd8965b7d9669df21bf41e419bcf5e9de5314f428380d0f')
     version('2.32', sha256='f0c12ee3936364a3aa26da384e3d2ad2344be0091f04f9531f04ecb1dca98aca')

--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -30,6 +30,3 @@ class Hevea(MakefilePackage):
 
     def edit(self, spec, prefix):
         env['PREFIX'] = self.spec.prefix
-
-    def build(self, spec, prefix):
-        make()

--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Hevea(MakefilePackage):
+    """Hevea a fast Latex to HTML translator"""
+
+    # Add a proper url for your package's homepage here.
+    homepage = "http://hevea.inria.fr/"
+    url      = "https://github.com/maranget/hevea/archive/v2.35.tar.gz"
+    git      = "https://github.com/maranget/hevea.git"
+
+    # Add a list of GitHub accounts to
+    # notify when the package is updated.
+    maintainers = ['scemama', 'cessenat']
+
+    # Add proper versions here.
+    version('develop', branch='master')
+    version('2.35', sha256='f189bada5d3e5b35855dfdfdb5b270c994fc7a2366b01250d761359ad66c9ecb')
+    version('2.34', sha256='f505a2a5bafdc2ea389ec521876844e6fdcb5c1b656396b7e8421c1631469ea2')
+    version('2.33', sha256='122f9023f9cfe8b41dd8965b7d9669df21bf41e419bcf5e9de5314f428380d0f')
+
+    # Dependency demands ocamlbuild
+    depends_on('ocaml')
+    depends_on('ocamlbuild')
+
+    def edit(self, spec, prefix):
+        env['PREFIX'] = self.spec.prefix
+
+    def build(self, spec, prefix):
+        make()

--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -9,16 +9,12 @@ from spack import *
 class Hevea(MakefilePackage):
     """Hevea a fast Latex to HTML translator"""
 
-    # Add a proper url for your package's homepage here.
     homepage = "http://hevea.inria.fr/"
     url      = "https://github.com/maranget/hevea/archive/v2.35.tar.gz"
     git      = "https://github.com/maranget/hevea.git"
 
-    # Add a list of GitHub accounts to
-    # notify when the package is updated.
     maintainers = ['scemama', 'cessenat']
 
-    # Add proper versions here.
     version('develop', branch='master')
     version('2.35', sha256='f189bada5d3e5b35855dfdfdb5b270c994fc7a2366b01250d761359ad66c9ecb')
     version('2.34', sha256='f505a2a5bafdc2ea389ec521876844e6fdcb5c1b656396b7e8421c1631469ea2')

--- a/var/spack/repos/builtin/packages/hevea/package.py
+++ b/var/spack/repos/builtin/packages/hevea/package.py
@@ -23,6 +23,7 @@ class Hevea(MakefilePackage):
     version('2.35', sha256='f189bada5d3e5b35855dfdfdb5b270c994fc7a2366b01250d761359ad66c9ecb')
     version('2.34', sha256='f505a2a5bafdc2ea389ec521876844e6fdcb5c1b656396b7e8421c1631469ea2')
     version('2.33', sha256='122f9023f9cfe8b41dd8965b7d9669df21bf41e419bcf5e9de5314f428380d0f')
+    version('2.32', sha256='f0c12ee3936364a3aa26da384e3d2ad2344be0091f04f9531f04ecb1dca98aca')
 
     # Dependency demands ocamlbuild
     depends_on('ocaml')


### PR DESCRIPTION
Hevea is a (very) fast Latex to HTML translator written in ocaml and compiled using ocamlbuild.