### PR TITLE
Apply compiler filters to GROMACS installation.

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 
 class Gromacs(CMakePackage):
     """GROMACS (GROningen MAchine for Chemical Simulations) is a molecular
@@ -110,6 +112,13 @@ class Gromacs(CMakePackage):
 
     patch('gmxDetectCpu-cmake-3.14.patch', when='@2018:2019.3^cmake@3.14.0:')
     patch('gmxDetectSimd-cmake-3.14.patch', when='@:2017.99^cmake@3.14.0:')
+
+    filter_compiler_wrappers(
+        '*.cmake',
+        relative_root=os.path.join('share', 'cmake', 'gromacs_mpi'))
+    filter_compiler_wrappers(
+        '*.cmake',
+        relative_root=os.path.join('share', 'cmake', 'gromacs'))
 
     def patch(self):
         if '+plumed' in self.spec:


### PR DESCRIPTION
The GROMACS package embeds references to its build tool chain.
Use the Spack utilities to make sure these references are correct
outside of the isolated Spack build environment.