### PR TITLE
eospac: add cpuinfo_comp_flags_key.patch

### DIFF
--- a/var/spack/repos/builtin/packages/eospac/cpuinfo_comp_flags_key.patch
+++ b/var/spack/repos/builtin/packages/eospac/cpuinfo_comp_flags_key.patch
@@ -1,0 +1,23 @@
+--- a/Source/config/Makefile.-linux-gnu.hashes	2019-10-12 12:16:17.000000000 -0600
++++ b/Source/config/Makefile.-linux-gnu.hashes	2020-09-25 15:14:45.990734000 -0600
+@@ -267,9 +267,9 @@
+ ifneq ($(strip $(CPUFLAGS)),)
+ 
+   KEYLIST = $(call keys,_F90-CPUINFO_COMP_FLAGS)
+-  MYKEYS = $(addprefix $(F90)-$(_F90_MAJOR_VERSION)-,$(CPUFLAGS))
++  MYKEYS = $(addprefix $(notdir $(F90))-$(_F90_MAJOR_VERSION)-,$(CPUFLAGS))
+   SHORTCUT = $(filter $(MYKEYS),$(KEYLIST))
+-  OTHER = $(subst $(F90)-$(_F90_MAJOR_VERSION)-,,$(filter-out $(SHORTCUT),$(MYKEYS)))
++  OTHER = $(subst $(notdir $(F90))-$(_F90_MAJOR_VERSION)-,,$(filter-out $(SHORTCUT),$(MYKEYS)))
+   # $(warning CPUFLAGS : "$(CPUFLAGS)")
+   # $(warning KEYLIST : $(KEYLIST))
+   # $(warning MYKEYS : $(MYKEYS))
+@@ -284,7 +284,7 @@
+ 
+   ifeq ($(ALT_SUBDIR_Key1),craype-mic-knl)
+     # define the default _CPUINFO_FLAGS for the craype-mic-knl
+-    _CPUINFO_FLAGS += $(call get,_F90-CPUINFO_COMP_FLAGS,$(F90)-$(_F90_MAJOR_VERSION)-knl)
++    _CPUINFO_FLAGS += $(call get,_F90-CPUINFO_COMP_FLAGS,$(notdir $(F90))-$(_F90_MAJOR_VERSION)-knl)
+   else
+     # define the default _CPUINFO_FLAGS
+     _CPUINFO_FLAGS += $(call get,_F90-CPUINFO_COMP_FLAGS,$(notdir $(F90)-$(_F90_MAJOR_VERSION)-$(lastword $(_SUPPORTED_CPUINFO_FLAGS))))

--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -46,6 +46,8 @@ class Eospac(Package):
     # This patch allows the use of spack's compile wrapper 'flang'
     patch('flang.patch', when='@:6.4.0beta.2%clang')
     patch('frt.patch', when='%fj')
+    # This patch corrects EOSPAC's selection of compiler flags when
+    # compilers are specified using absolute pathnames.
     patch('cpuinfo_comp_flags_key.patch', when='@:6.4.1,6.4.2beta')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -46,6 +46,7 @@ class Eospac(Package):
     # This patch allows the use of spack's compile wrapper 'flang'
     patch('flang.patch', when='@:6.4.0beta.2%clang')
     patch('frt.patch', when='%fj')
+    patch('cpuinfo_comp_flags_key.patch', when='@:6.4.1,6.4.2beta')
 
     def install(self, spec, prefix):
         with working_dir('Source'):


### PR DESCRIPTION
Patch eospac's Makefile.-linux-gnu.hashes to consider only `$(notdir $(F90))` when constructing a key to look up compiler flags in the _F90-CPUINFO_COMP_FLAGS associative array.

This patch was accepted into eospac itself after the release of 6.4.2beta, so apply it only to 6.4.2beta and earlier releases.