### PR TITLE
mesa18: Do not deprecate for now

### DIFF
--- a/var/spack/repos/builtin/packages/mesa18/package.py
+++ b/var/spack/repos/builtin/packages/mesa18/package.py
@@ -13,7 +13,7 @@ class Mesa18(AutotoolsPackage):
      - a system for rendering interactive 3D graphics."""
 
     homepage = "http://www.mesa3d.org"
-    maintainers = ['v-dobrev', 'chuckatkins']
+    maintainers = ['v-dobrev', 'chuckatkins', 'ChristianTackeGSI']
 
     # Note that we always want to build from the git repo instead of a
     # tarball since the tarball has pre-generated files for certain versions
@@ -21,7 +21,7 @@ class Mesa18(AutotoolsPackage):
     # whatever version of LLVM you're using.
     git      = "https://gitlab.freedesktop.org/mesa/mesa.git"
 
-    version('18.3.6', tag='mesa-18.3.6', preferred=True, deprecated=True)
+    version('18.3.6', tag='mesa-18.3.6')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')


### PR DESCRIPTION
We still need mesa18 for some of our builds.
Those builds require python@2, normal mesa only works with python@3.

* Remove the deprecation tag
* Add myself as a maintainer: I volunteer to help with this package for the time being.
* There is only one version, no need to prefer it.

Maintainer-Ping: @v-dobrev, @chuckatkins
Ping for adding the deprecation: @adamjstewart #20767