### PR TITLE
Eospac 6.5.0alpha.1 and offload support

### DIFF
--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -20,6 +20,8 @@ class Eospac(Package):
     # current EOSPAC release procedure, even a release that only fixes
     # known bugs in a previous stable release will appear first as a
     # new beta.
+    version('6.5.0alpha.1',   sha256='c7334342dd2e071e17c60d8fabb11d2908c9d48c9b49ea83c3609a10b7b8877b',
+            url="http://laws.lanl.gov/projects/data/eos/get_file.php?package=eospac&filename=eospac_v6.5.0alpha.1_62053188b9842842e41508c54196c533e0b91e51.tgz")
     version('6.4.2',       sha256='13627a5c94d3a456659d1bba0f3cec157380933fbd401e13e25906166150a252',
             url="https://laws.lanl.gov/projects/data/eos/get_file.php?package=eospac&filename=eospac_v6.4.2_e2f7906a0863932e3d65d329f789c4b90c6be58d.tgz")
     version('6.4.2beta',   sha256='635b94f1ec7558deca92a3858c92db0f4437170252bb114cbdb809b74b6ee870', preferred=True,
@@ -47,6 +49,8 @@ class Eospac(Package):
     patch('flang.patch', when='@:6.4.0beta.2%clang')
     patch('frt.patch', when='%fj')
 
+    variant("offload", default=False, description="Build GPU offload library instead of standard")
+
     def install(self, spec, prefix):
         with working_dir('Source'):
             compilerArgs = []
@@ -54,6 +58,11 @@ class Eospac(Package):
             compilerArgs.append('CXX={0}'.format(spack_cxx))
             compilerArgs.append('F77={0}'.format(spack_f77))
             compilerArgs.append('F90={0}'.format(spack_fc))
+            # This looks goofy because eospac does not actually respect the 
+            # value of DO_OFFLOAD and instead only attempts to check for its 
+            # existence; a quirk of eospac.
+            if "+offload" in spec:
+                compilerArgs.append('DO_OFFLOAD=1')
             # Eospac depends on fcommon behavior
             #   but gcc@10 flipped to default fno-common
             if "%gcc@10:" in spec:

--- a/var/spack/repos/builtin/packages/eospac/package.py
+++ b/var/spack/repos/builtin/packages/eospac/package.py
@@ -58,8 +58,8 @@ class Eospac(Package):
             compilerArgs.append('CXX={0}'.format(spack_cxx))
             compilerArgs.append('F77={0}'.format(spack_f77))
             compilerArgs.append('F90={0}'.format(spack_fc))
-            # This looks goofy because eospac does not actually respect the 
-            # value of DO_OFFLOAD and instead only attempts to check for its 
+            # This looks goofy because eospac does not actually respect the
+            # value of DO_OFFLOAD and instead only attempts to check for its
             # existence; a quirk of eospac.
             if "+offload" in spec:
                 compilerArgs.append('DO_OFFLOAD=1')


### PR DESCRIPTION
* Introduces 6.5.0alpha.1
* Introduces a new variant supported by eospac for GPU offloading