### PR TITLE
Remove minimum version for casacore cfitsio dependency

### DIFF
--- a/var/spack/repos/builtin/packages/casacore/package.py
+++ b/var/spack/repos/builtin/packages/casacore/package.py
@@ -42,7 +42,7 @@ class Casacore(CMakePackage):
     depends_on('bison', type='build')
     depends_on('blas')
     depends_on('lapack')
-    depends_on('cfitsio@3.181:')
+    depends_on('cfitsio')
     depends_on('wcslib@4.20:+cfitsio')
     depends_on('fftw@3.0.0:~mpi precision=float,double', when='+fftw')
     # SOFA dependency suffers the same problem in CMakeLists.txt as readline;


### PR DESCRIPTION
The actual, documented minimum version of the cfitsio dependency,
v3.181, is now neither available for (easy) download from NASA, nor as
a Spack package. No upper bound on version number exists (at this time).