### PR TITLE
Fix mumps compilation with gcc@10 (i.e., gfortran)

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -155,7 +155,7 @@ class Mumps(Package):
                 makefile_conf.extend([
                     'OPTF = %s -O  -DALLOW_NON_INIT %s' % (
                         fpic,
-                        '-fdefault-integer-8' if using_gcc else '-i8'), #noqa
+                        '-fdefault-integer-8' if using_gcc else '-i8'),  #noqa
                 ])
 
             makefile_conf.extend([

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -155,7 +155,7 @@ class Mumps(Package):
                 makefile_conf.extend([
                     'OPTF = %s -O  -DALLOW_NON_INIT %s' % (
                         fpic,
-                        '-fdefault-integer-8' if using_gcc else '-i8'),  #noqa
+                        '-fdefault-integer-8' if using_gcc else '-i8'),  # noqa
                 ])
 
             makefile_conf.extend([

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -145,11 +145,6 @@ class Mumps(Package):
 
         opt_level = '3' if using_xl else ''
 
-        if self.spec.satisfies("%gcc@10"):
-            fortran_flags = "-fallow-argument-mismatch"
-        else:
-            fortran_flags = ""
-
         if '+int64' in self.spec:
             if using_xlf:
                 makefile_conf.append('OPTF = -O%s %s' % opt_level)

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -145,7 +145,10 @@ class Mumps(Package):
 
         opt_level = '3' if using_xl else ''
 
-        fortran_flags = "-fallow-argument-mismatch" if self.spec.satisfies("%gcc@10") else ""
+        if self.spec.satisfies("%gcc@10"):
+            fortran_flags = "-fallow-argument-mismatch"
+        else:
+            fortran_flags = ""
 
         if '+int64' in self.spec:
             if using_xlf:

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -160,8 +160,7 @@ class Mumps(Package):
                 makefile_conf.extend([
                     'OPTF = %s -O  -DALLOW_NON_INIT %s %s' % (
                         fpic,
-                        '-fdefault-integer-8' if using_gcc
-                                              else '-i8',
+                        '-fdefault-integer-8' if using_gcc else '-i8',
                         fortran_flags),  # noqa
                 ])
 

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -147,7 +147,7 @@ class Mumps(Package):
 
         if '+int64' in self.spec:
             if using_xlf:
-                makefile_conf.append('OPTF = -O%s %s' % opt_level)
+                makefile_conf.append('OPTF = -O%s' % opt_level)
             else:
                 # the fortran compilation flags most probably are
                 # working only for intel and gnu compilers this is
@@ -276,7 +276,6 @@ class Mumps(Package):
 
     def flag_handler(self, name, flags):
         if name == 'fflags':
-            # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
             if self.spec.satisfies('%gcc@10:'):
                 if flags is None:
                     flags = []

--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -145,18 +145,21 @@ class Mumps(Package):
 
         opt_level = '3' if using_xl else ''
 
+        fortran_flags = "-fallow-argument-mismatch" if self.spec.satisfies("%gcc@10") else ""
+
         if '+int64' in self.spec:
             if using_xlf:
-                makefile_conf.append('OPTF = -O%s' % opt_level)
+                makefile_conf.append('OPTF = -O%s %s' % (opt_level, fortran_flags))
             else:
                 # the fortran compilation flags most probably are
                 # working only for intel and gnu compilers this is
                 # perhaps something the compiler should provide
                 makefile_conf.extend([
-                    'OPTF = %s -O  -DALLOW_NON_INIT %s' % (
+                    'OPTF = %s -O  -DALLOW_NON_INIT %s %s' % (
                         fpic,
                         '-fdefault-integer-8' if using_gcc
-                                              else '-i8'),  # noqa
+                                              else '-i8',
+                        fortran_flags),  # noqa
                 ])
 
             makefile_conf.extend([
@@ -167,8 +170,8 @@ class Mumps(Package):
             if using_xlf:
                 makefile_conf.append('OPTF = -O%s -qfixed' % opt_level)
             else:
-                makefile_conf.append('OPTF = %s -O%s -DALLOW_NON_INIT' % (
-                    fpic, opt_level))
+                makefile_conf.append('OPTF = %s -O%s -DALLOW_NON_INIT %s' % (
+                    fpic, opt_level, fortran_flags))
 
             makefile_conf.extend([
                 'OPTL = %s -O%s' % (cpic, opt_level),


### PR DESCRIPTION
* new flag when compiling mumps with %gcc@10.
* closes #21303 