### PR TITLE
cmake: patches for HPE/Cray apollo PE

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/fixes-for-HPE-apollo80-CCE-configuration.patch
+++ b/var/spack/repos/builtin/packages/cmake/fixes-for-HPE-apollo80-CCE-configuration.patch
@@ -1,0 +1,51 @@
+diff --git a/Modules/CMakeCCompilerId.c.in b/Modules/CMakeCCompilerId.c.in
+index 2f6bdb4a..474d05b6 100644
+--- a/Modules/CMakeCCompilerId.c.in
++++ b/Modules/CMakeCCompilerId.c.in
+@@ -26,7 +26,7 @@ char const* info_simulate = "INFO" ":" "simulate[" SIMULATE_ID "]";
+ char const* qnxnto = "INFO" ":" "qnxnto[]";
+ #endif
+ 
+-#if defined(__CRAYXE) || defined(__CRAYXC)
++#if defined(__CRAYXE) || defined(__CRAYXC) || defined(__cray__)
+ char const *info_cray = "INFO" ":" "compiler_wrapper[CrayPrgEnv]";
+ #endif
+ 
+@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
+ #ifdef SIMULATE_VERSION_MAJOR
+   require += info_simulate_version[argc];
+ #endif
+-#if defined(__CRAYXE) || defined(__CRAYXC)
++#if defined(__CRAYXE) || defined(__CRAYXC) || defined(__cray__)
+   require += info_cray[argc];
+ #endif
+   require += info_language_dialect_default[argc];
+diff --git a/Modules/CMakeCXXCompilerId.cpp.in b/Modules/CMakeCXXCompilerId.cpp.in
+index a743ce78..e8170648 100644
+--- a/Modules/CMakeCXXCompilerId.cpp.in
++++ b/Modules/CMakeCXXCompilerId.cpp.in
+@@ -20,7 +20,7 @@ char const* info_simulate = "INFO" ":" "simulate[" SIMULATE_ID "]";
+ char const* qnxnto = "INFO" ":" "qnxnto[]";
+ #endif
+ 
+-#if defined(__CRAYXE) || defined(__CRAYXC)
++#if defined(__CRAYXE) || defined(__CRAYXC) || defined(__cray__)
+ char const *info_cray = "INFO" ":" "compiler_wrapper[CrayPrgEnv]";
+ #endif
+ 
+diff --git a/Modules/CMakeFortranCompilerId.F.in b/Modules/CMakeFortranCompilerId.F.in
+index 30f8d4c4..5e0ca11f 100644
+--- a/Modules/CMakeFortranCompilerId.F.in
++++ b/Modules/CMakeFortranCompilerId.F.in
+@@ -108,7 +108,7 @@
+ #else
+         PRINT *, 'INFO:compiler[]'
+ #endif
+-#if defined(__CRAYXE) || defined(__CRAYXC)
++#if defined(__CRAYXE) || defined(__CRAYXC) || defined(_CRAYFTN)
+         PRINT *, 'INFO:compiler_wrapper[CrayPrgEnv]'
+ #endif
+ 
+-- 
+1.8.3.1
+

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -113,6 +113,9 @@ class Cmake(Package):
     # https://gitlab.kitware.com/cmake/cmake/merge_requests/4075
     patch('fix-xlf-ninja-mr-4075.patch', sha256="42d8b2163a2f37a745800ec13a96c08a3a20d5e67af51031e51f63313d0dedd1", when="@3.15.5")
 
+    # HPE apollo80 support patch - fix appears in release 3.19.2
+    patch('fixes-for-HPE-apollo80-CCE-configuration.patch', when='@3.19.0:3.19.1%cce@10:')
+
     # We default ownlibs to true because it greatly speeds up the CMake
     # build, and CMake is built frequently. Also, CMake is almost always
     # a build dependency, and its libs will not interfere with others in


### PR DESCRIPTION
patches to enable use of cmake 3.19.0,1 with CCE compilers on HPE apollo Programming Environment.

In the course of testing this patch, by the way, I discovered that cmake 3.19.3 and 3.19.4 are not available for download.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>