### PR TITLE
"spack build-env" searches env for relevant spec

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -184,18 +184,14 @@ def parse_specs(args, **kwargs):
 def matching_spec_from_env(spec):
     """
     Returns a concrete spec, matching what is available in the environment.
-    If no matching spec is found in the environment, this will return the
-    given spec but concretized.
+    If no matching spec is found in the environment (or if no environment is
+    active), this will return the given spec but concretized.
     """
     env = spack.environment.get_env({}, cmd_name)
-    spec_from_env = None
     if env:
-        spec_from_env = env.matching_spec(spec)
-    if spec_from_env:
-        spec = spec_from_env
+        return env.matching_spec(spec) or spec.concretized()
     else:
-        spec.concretize()
-    return spec
+        return spec.concretized()
 
 
 def elide_list(line_list, max_num=10):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -181,6 +181,23 @@ def parse_specs(args, **kwargs):
         raise spack.error.SpackError(msg)
 
 
+def matching_spec_from_env(spec):
+    """
+    Returns a concrete spec, matching what is available in the environment.
+    If no matching spec is found in the environment, this will return the
+    given spec but concretized.
+    """
+    env = spack.environment.get_env({}, cmd_name)
+    spec_from_env = None
+    if env:
+        spec_from_env = env.matching_spec(spec)
+    if spec_from_env:
+        spec = spec_from_env
+    else:
+        spec.concretize()
+    return spec
+
+
 def elide_list(line_list, max_num=10):
     """Takes a long list and limits it to a smaller number of elements,
        replacing intervening elements with '...'.  For example::

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -12,6 +12,7 @@ import spack.build_environment as build_environment
 import spack.paths
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.environment as ev
 from spack.util.environment import dump_environment, pickle_environment
 
 
@@ -53,10 +54,28 @@ def emulate_env_utility(cmd_name, context, args):
         spec = args.spec[0]
         cmd = args.spec[1:]
 
-    specs = spack.cmd.parse_specs(spec, concretize=True)
+    specs = spack.cmd.parse_specs(spec, concretize=False)
     if len(specs) > 1:
         tty.die("spack %s only takes one spec." % cmd_name)
     spec = specs[0]
+
+    # If the user requests a spec that matches a concretized spec in the
+    # environment, we implicitly use that.
+    env = ev.get_env(args, cmd_name)
+    spec_from_env = None
+    if env:
+        dep_spec = None
+        for user_spec, concretized_user_spec in env.concretized_specs():
+            for dep_spec in concretized_user_spec.traverse():
+                if dep_spec.satisfies(spec):
+                    spec_from_env = dep_spec
+                    break
+            if spec_from_env:
+                break
+    if spec_from_env:
+        spec = spec_from_env
+    else:
+        spec.concretize()
 
     build_environment.setup_package(spec.package, args.dirty, context)
 

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -12,7 +12,6 @@ import spack.build_environment as build_environment
 import spack.paths
 import spack.cmd
 import spack.cmd.common.arguments as arguments
-import spack.environment as ev
 from spack.util.environment import dump_environment, pickle_environment
 
 

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -64,14 +64,7 @@ def emulate_env_utility(cmd_name, context, args):
     env = ev.get_env(args, cmd_name)
     spec_from_env = None
     if env:
-        dep_spec = None
-        for user_spec, concretized_user_spec in env.concretized_specs():
-            for dep_spec in concretized_user_spec.traverse():
-                if dep_spec.satisfies(spec):
-                    spec_from_env = dep_spec
-                    break
-            if spec_from_env:
-                break
+        spec_from_env = env.matching_spec(spec)
     if spec_from_env:
         spec = spec_from_env
     else:

--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -59,16 +59,7 @@ def emulate_env_utility(cmd_name, context, args):
         tty.die("spack %s only takes one spec." % cmd_name)
     spec = specs[0]
 
-    # If the user requests a spec that matches a concretized spec in the
-    # environment, we implicitly use that.
-    env = ev.get_env(args, cmd_name)
-    spec_from_env = None
-    if env:
-        spec_from_env = env.matching_spec(spec)
-    if spec_from_env:
-        spec = spec_from_env
-    else:
-        spec.concretize()
+    spec = spack.cmd.matching_spec_from_env(spec)
 
     build_environment.setup_package(spec.package, args.dirty, context)
 

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -98,15 +98,7 @@ def location(parser, args):
                 print(spack.repo.path.dirname_for_package_name(spec.name))
 
             else:
-                # These versions need concretized specs.
-                env = ev.get_env(args, 'location')
-                spec_from_env = None
-                if env:
-                    spec_from_env = env.matching_spec(spec)
-                if spec_from_env:
-                    spec = spec_from_env
-                else:
-                    spec.concretize()
+                spec = spack.cmd.matching_spec_from_env(spec)
                 pkg = spec.package
 
                 if args.stage_dir:

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -99,8 +99,15 @@ def location(parser, args):
 
             else:
                 # These versions need concretized specs.
-                spec.concretize()
-                pkg = spack.repo.get(spec)
+                env = ev.get_env(args, 'location')
+                spec_from_env = None
+                if env:
+                    spec_from_env = env.matching_spec(spec)
+                if spec_from_env:
+                    spec = spec_from_env
+                else:
+                    spec.concretize()
+                pkg = spec.package
 
                 if args.stage_dir:
                     print(pkg.stage.path)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1509,6 +1509,17 @@ class Environment(object):
         for s, h in zip(self.concretized_user_specs, self.concretized_order):
             yield (s, self.specs_by_hash[h])
 
+    def matching_spec(self, spec):
+        """
+        Given a spec (likely not concretized), find a matching concretized
+        spec in the environment. The matching spec does not have to be
+        installed in the environment.
+        """
+        for user_spec, concretized_user_spec in self.concretized_specs():
+            for dep_spec in concretized_user_spec.traverse():
+                if dep_spec.satisfies(spec):
+                    return dep_spec
+
     def removed_specs(self):
         """Tuples of (user spec, concrete spec) for all specs that will be
            removed on nexg concretize."""

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1515,10 +1515,23 @@ class Environment(object):
         spec in the environment. The matching spec does not have to be
         installed in the environment.
         """
+        matches = list()
         for user_spec, concretized_user_spec in self.concretized_specs():
             for dep_spec in concretized_user_spec.traverse():
                 if dep_spec.satisfies(spec):
-                    return dep_spec
+                    matches.append((user_spec, dep_spec))
+
+        if len(matches) == 1:
+            return matches[0][1]
+        elif len(matches) > 1:
+            match_instance_format_str = "Abstract spec: {0}\n\Full spec: {1}"
+            matches_str = '\n\n'.join(
+                match_instance_format_str.format(x, y) for x, y in matches
+            )
+            msg = ("{0} matches multiple specs in the environment {1}: \n"
+                   "{2}".format(str(spec), self.name, matches_str))
+            raise SpackEnvironmentError(msg)
+        # If there are no matches, return nothing
 
     def removed_specs(self):
         """Tuples of (user spec, concrete spec) for all specs that will be

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1542,7 +1542,7 @@ class Environment(object):
         if not matches:
             return None
         elif len(matches) == 1:
-            return list(matches.values())[0]
+            return list(matches.keys())[0]
 
         root_matches = dict((concrete, abstract)
                             for concrete, abstract in matches.items()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1526,7 +1526,7 @@ class Environment(object):
                 all_matches.append(concretized_user_spec)
             for dep_spec in concretized_user_spec.traverse(root=False):
                 if dep_spec.satisfies(spec):
-                    matches.append(dep_spec)
+                    dep_matches.append(dep_spec)
                     all_matches.append(dep_spec)
 
         if len(all_matches) == 1:

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1556,13 +1556,14 @@ class Environment(object):
         # If multiple root specs match, it is assumed that the abstract
         # spec will most-succinctly summarize the difference between them
         # (and the user can enter one of these to disambiguate)
-        root_fmt_str = 'Root spec %s\n  '
-        no_root_str = 'Dependency spec\n  '
-        match_strings = [
-            (root_fmt_str % abstract.format() if abstract else no_root_str) +
-            concrete.format('{hash:7}  ' + spack.spec.default_format)
-            for concrete, abstract in matches.items()
-        ]
+        match_strings = []
+        fmt_str = '{hash:7}  ' + spack.spec.default_format
+        for concrete, abstract in matches.items():
+            if abstract:
+                s = 'Root spec %s\n  %s' % (abstract, concrete.format(fmt_str))
+            else:
+                s = 'Dependency spec\n  %s' % concrete.format(fmt_str)
+            match_strings.append(s)
         matches_str = '\n'.join(match_strings)
 
         msg = ("{0} matches multiple specs in the environment {1}: \n"

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1537,7 +1537,7 @@ class Environment(object):
                 if dep_spec.satisfies(spec):
                     # Don't overwrite the abstract spec if present
                     # If not present already, set to None
-                    matches[dep_spec] = matches.get(dep_spec)
+                    matches[dep_spec] = matches.get(dep_spec, None)
 
         if not matches:
             return None

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -103,3 +103,19 @@ def test_match_spec_env(mock_packages, mutable_mock_env_path):
         env_spec = spack.cmd.matching_spec_from_env(
             spack.cmd.parse_specs(['a'])[0])
         assert env_spec.satisfies('foobar=baz')
+
+
+@pytest.mark.usefixtures('config')
+def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
+    e = ev.create('test')
+    e.add('a foobar=baz')
+    e.add('a foobar=fee')
+    e.concretize()
+    with e:
+        with pytest.raises(
+                spack.environment.SpackEnvironmentError) as exc_info:
+
+            env_spec = spack.cmd.matching_spec_from_env(
+                spack.cmd.parse_specs(['a'])[0])
+
+    assert 'matches multiple specs' in exc_info.value.message

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -12,6 +12,7 @@ import pytest
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.config
+import spack.environment as ev
 
 
 @pytest.fixture()
@@ -81,3 +82,24 @@ def test_parse_spec_flags_with_spaces(
 
     assert all(x not in s.variants for x in unexpected_variants)
     assert all(x in s.variants for x in expected_variants)
+
+
+@pytest.mark.usefixtures('config')
+def test_match_spec_env(mock_packages, mutable_mock_env_path):
+    """
+    Concretize a spec with non-default options in an environment. Make
+    sure that when we ask for a matching spec when the environment is
+    active that we get the instance concretized in the environment.
+    """
+    # Initial sanity check: we are planning on choosing a non-default
+    # value, so make sure that is in fact not the default.
+    check_defaults = spack.cmd.parse_specs(['a'], concretize=True)[0]
+    assert not check_defaults.satisfies('foobar=baz')
+
+    e = ev.create('test')
+    e.add('a foobar=baz')
+    e.concretize()
+    with e:
+        env_spec = spack.cmd.matching_spec_from_env(
+            spack.cmd.parse_specs(['a'])[0])
+        assert env_spec.satisfies('foobar=baz')

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -103,6 +103,7 @@ def test_match_spec_env(mock_packages, mutable_mock_env_path):
         env_spec = spack.cmd.matching_spec_from_env(
             spack.cmd.parse_specs(['a'])[0])
         assert env_spec.satisfies('foobar=baz')
+        assert env_spec.concrete
 
 
 @pytest.mark.usefixtures('config')

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -115,7 +115,6 @@ def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
         with pytest.raises(
                 spack.environment.SpackEnvironmentError) as exc_info:
 
-            env_spec = spack.cmd.matching_spec_from_env(
-                spack.cmd.parse_specs(['a'])[0])
+            spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(['a'])[0])
 
     assert 'matches multiple specs' in exc_info.value.message


### PR DESCRIPTION
If you install packages using `spack install` in an environment with complex spec constraints, and the install fails, you may want to test out the build using `spack build-env`; one issue (particularly if you use `concretize: together`) is that it may be hard to pass the appropriate spec that matches what the environment is attempting to install.

This updates the `build-env` command to default to pulling a matching spec from the environment rather than concretizing what the user provides on the command line independently.

This makes a similar change to `spack cd`.

If the user-provided spec matches multiple specs in the environment, then these commands will now report an error and display all matching specs (to help the user specify).

@bvanessen I'm wondering if this helps you with your work