### PR TITLE
libcircle: needs libpciaccess

### DIFF
--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -20,6 +20,7 @@ class Libcircle(AutotoolsPackage):
 
     depends_on('mpi')
     depends_on('pkgconfig', type='build')
+    depends_on('libpciaccess', type='link')
 
     @when('@master')
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
`libcircle` needs `libpciaccess` for link

fyi @wspear @coti @adammoody @gonsie 