### PR TITLE
rempi: depends on libpciaccess

### DIFF
--- a/var/spack/repos/builtin/packages/rempi/package.py
+++ b/var/spack/repos/builtin/packages/rempi/package.py
@@ -19,3 +19,4 @@ class Rempi(AutotoolsPackage):
     depends_on("autoconf", type='build')
     depends_on("automake", type='build')
     depends_on("libtool", type='build')
+    depends_on("libpciaccess", type='link')


### PR DESCRIPTION
`rempi` depends on `libpciaccess` for link

fyi @wspear @coti @lee218llnl