### PR TITLE
Overhaul xgboost packages

### DIFF
--- a/var/spack/repos/builtin/packages/py-dask-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/py-dask-xgboost/package.py
@@ -7,12 +7,15 @@ from spack import *
 
 
 class PyDaskXgboost(PythonPackage):
-    """Distributed training with XGBoost and Dask.distributed."""
+    """Distributed training with XGBoost and Dask.distributed.
+
+    Deprecated: use `py-xgboost+dask` instead."""
 
     homepage = "https://github.com/dask/dask-xgboost/"
     pypi = "dask-xgboost/dask-xgboost-0.1.11.tar.gz"
 
-    version('0.1.11', sha256='3fbe1bf4344dc74edfbe9f928c7e3e6acc26dc57cefd8da8ae56a15469c6941c')
+    # Deprecated, see https://github.com/dask/dask-xgboost/issues/80
+    version('0.1.11', sha256='3fbe1bf4344dc74edfbe9f928c7e3e6acc26dc57cefd8da8ae56a15469c6941c', deprecated=True)
 
     variant('sparse', default=False, description='Add sparse support')
 

--- a/var/spack/repos/builtin/packages/py-xgboost/package.py
+++ b/var/spack/repos/builtin/packages/py-xgboost/package.py
@@ -49,6 +49,11 @@ class PyXgboost(PythonPackage):
     depends_on('py-graphviz',   when='+plotting', type=('build', 'run'))
     depends_on('py-matplotlib', when='+plotting', type=('build', 'run'))
 
+    conflicts('+pandas', when='@:0.999')
+    conflicts('+scikit-learn', when='@:0.999')
+    conflicts('+dask', when='@:0.999')
+    conflicts('+plotting', when='@:0.999')
+
     # `--use-system-libxgboost` is only valid for the 'install' phase, but we want to
     # skip building of the C++ library and rely on an external dependency
     phases = ['install']

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -7,25 +7,49 @@ from spack import *
 
 
 class Xgboost(CMakePackage, CudaPackage):
-    """Scalable, Portable and Distributed Gradient Boosting (GBDT, GBRT or GBM)
-       Library, for Python, R, Java, Scala, C++ and more. Runs on single
-       machine, Hadoop, Spark, Flink and DataFlow"""
+    """XGBoost is an optimized distributed gradient boosting library designed to be
+    highly efficient, flexible and portable. It implements machine learning algorithms
+    under the Gradient Boosting framework. XGBoost provides a parallel tree boosting
+    (also known as GBDT, GBM) that solve many data science problems in a fast and
+    accurate way. The same code runs on major distributed environment (Hadoop, SGE, MPI)
+    and can solve problems beyond billions of examples."""
 
     homepage = "https://xgboost.ai/"
-    url      = "https://github.com/dmlc/xgboost/releases/download/v0.81/xgboost-0.81.tar.bz2"
     git      = "https://github.com/dmlc/xgboost.git"
 
-    version('0.90', tag='v0.90', submodules=True)
-    version('0.81', sha256='9d8ff161699111d45c96bd15229aa6d80eb1cab7cbbef7e8eaa60ccfb5a4f806')
+    maintainers = ['adamjstewart']
+
+    version('master', branch='master', submodules=True)
+    version('1.3.3', tag='v1.3.3', submodules=True)
+    version('0.90', tag='v0.90', submodules=True, deprecated=True)
+    version('0.81', tag='v0.81', submodules=True, deprecated=True)
+
+    variant('nccl', default=False, description='Build with NCCL to enable distributed GPU support')
+    variant('openmp', default=True, description='Build with OpenMP support')
+
+    depends_on('cmake@3.13:', type='build')
+    depends_on('cmake@3.16:', when='platform=darwin', type='build')
+    depends_on('ninja', type='build')
+    depends_on('cuda@10:', when='+cuda')
+    depends_on('nccl', when='+nccl')
+    depends_on('llvm-openmp', when='%apple-clang +openmp')
+
+    conflicts('%gcc@:4.999', msg='GCC version must be at least 5.0!')
+    conflicts('+nccl', when='~cuda', msg='NCCL requires CUDA')
+    conflicts('+cuda', when='~openmp', msg='CUDA requires OpenMP')
+
+    generator = 'Ninja'
 
     def cmake_args(self):
-        return [
-            '-DUSE_CUDA={0}'.format('YES' if '+cuda' in self.spec else 'NO')
+        # https://xgboost.readthedocs.io/en/latest/build.html
+        args = [
+            self.define_from_variant('USE_CUDA', 'cuda'),
+            self.define_from_variant('USE_NCCL', 'nccl'),
+            self.define_from_variant('USE_OPENMP', 'openmp'),
         ]
 
-    def install(self, spec, prefix):
-        install_tree(str(self.stage.source_path), prefix)
-        # create a bin directory for executable "xgboost" which is possibly
-        # used in functional testing of the compilation target "libxgboost"
-        mkdirp(prefix.bin)
-        install('xgboost', prefix.bin)
+        if '+cuda' in self.spec and 'cuda_arch=none' not in self.spec:
+            args.append(self.define('GPU_COMPUTE_VER', ';'.join(
+                self.spec.variants['cuda_arch'].value)))
+
+        return args

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -21,7 +21,7 @@ class Xgboost(CMakePackage, CudaPackage):
 
     version('master', branch='master', submodules=True)
     version('1.3.3', tag='v1.3.3', submodules=True)
-    version('0.90', tag='v0.90', submodules=True, deprecated=True)
+    version('0.90', tag='v0.90', submodules=True)
     version('0.81', tag='v0.81', submodules=True, deprecated=True)
 
     variant('nccl', default=False, description='Build with NCCL to enable distributed GPU support')

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -49,7 +49,7 @@ class Xgboost(CMakePackage, CudaPackage):
         ]
 
         if '+cuda' in self.spec and 'cuda_arch=none' not in self.spec:
-            args.append(self.define('GPU_COMPUTE_VER',
-                self.spec.variants['cuda_arch'].value))
+            args.append(self.define(
+                'GPU_COMPUTE_VER', self.spec.variants['cuda_arch'].value))
 
         return args

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -21,7 +21,7 @@ class Xgboost(CMakePackage, CudaPackage):
 
     version('master', branch='master', submodules=True)
     version('1.3.3', tag='v1.3.3', submodules=True)
-    version('0.90', tag='v0.90', submodules=True)
+    version('0.90', tag='v0.90', submodules=True, deprecated=True)
     version('0.81', tag='v0.81', submodules=True, deprecated=True)
 
     variant('nccl', default=False, description='Build with NCCL to enable distributed GPU support')

--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -49,7 +49,7 @@ class Xgboost(CMakePackage, CudaPackage):
         ]
 
         if '+cuda' in self.spec and 'cuda_arch=none' not in self.spec:
-            args.append(self.define('GPU_COMPUTE_VER', ';'.join(
-                self.spec.variants['cuda_arch'].value)))
+            args.append(self.define('GPU_COMPUTE_VER',
+                self.spec.variants['cuda_arch'].value))
 
         return args


### PR DESCRIPTION
This PR includes the following changes:

- [x] Add new version of xgboost
- [x] Deprecate old versions of xgboost
- [x] Add new `+nccl` and `+openmp` variants to xgboost
- [x] Fix Apple Clang build of xgboost (requires libomp dependency)
- [x] Set `GPU_COMPUTE_VER` based on `cuda_arch`
- [x] Add myself as a maintainer for our xgboost packages
- [x] Build `py-xgboost` using `xgboost` as a dependency
- [ ] Build `r-xgboost` using `xgboost` as a dependency (apparently not possible)

Successfully builds and passes all tests on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.

The last change in particular may be a bit controversial. The way I see it, there are 3 possibilities:

1. A single `xgboost` packages with `+python` and `+r` variants. This is how `gdal` works, for example.
2. Separate `py-xgboost` and `r-xgboost` packages that depend on `xgboost`. This is what I'm trying to do in this PR.
3. Separate `py-xgboost` and `r-xgboost` packages that build their own copy of `xgboost`. This is the current behavior.

I don't love 3 because if, for whatever reason, I need to build all 3 packages, the build takes 3 times longer. It also means we'll need to include all variants, config options, and patches 3 times instead of once. Code duplication is bad, and longer build times are also bad.

I don't love 1 because it conflicts with the idea that if a Python or R package depends on `foo`, the package name will be `py-foo` or `r-foo`. This is true for 99% of Python/R deps and I would like to maintain this. Also, we can't take advantage of build system base classes.

The only problem with 2 is that it currently requires a lot of hacks. See https://github.com/dmlc/xgboost/issues/6706, which may change in the future depending on what the developers think. I'm willing to maintain these packages pretty closely, so I'm not super worried about things breaking.

Pinging @codeandkey, @Sinan81, and @scheibelp who have written/modified the `xgboost` package
Pinging @kean-smullen-nnl who recently added the `py-xgboost` package
Pinging @JavierCVilla and @glennpj who wrote and maintain the `r-xgboost` package