### PR TITLE
dbow2: added depends_on('eigen', type='link')

### DIFF
--- a/var/spack/repos/builtin/packages/dbow2/package.py
+++ b/var/spack/repos/builtin/packages/dbow2/package.py
@@ -19,3 +19,4 @@ class Dbow2(CMakePackage):
     depends_on('opencv+calib3d+core+features2d+highgui+imgproc')
     depends_on('boost')
     depends_on('dlib')
+    depends_on('eigen', type='link')


### PR DESCRIPTION
The installation of dbow2 failed.
The following error message was displayed.
I thought the eigen dependency was missing.

```
1 error found in build log:
     9     -- Detecting CXX compile features - done
     10    -- Detecting C compiler ABI info
     11    -- Detecting C compiler ABI info - done
     12    -- Check for working C compiler: /fefs/home/r1059/spack/lib/spack/en
           v/gcc/gcc - skipped
     13    -- Detecting C compile features
     14    -- Detecting C compile features - done
  >> 15    CMake Error at CMakeLists.txt:25 (find_package):
     16      By not providing "FindEigen3.cmake" in CMAKE_MODULE_PATH this proj
           ect has
     17      asked CMake to find a package configuration file provided by "Eige
           n3", but
     18      CMake did not find one.
     19
     20      Could not find a package configuration file provided by "Eigen3" (
           requested
     21      version 3.3) with any of the following names:
```