### PR TITLE
cpmd: add expected smoke test check output

### DIFF
--- a/var/spack/repos/builtin/packages/cpmd/package.py
+++ b/var/spack/repos/builtin/packages/cpmd/package.py
@@ -97,4 +97,8 @@ class Cpmd(MakefilePackage):
             exe_name = 'cpmd.x'
         opts.append(test_file)
         opts.append(test_dir)
-        self.run_test(exe_name, options=opts)
+        expected = ['2       1        H        O              1.84444     0.97604',
+                    '3       1        H        O              1.84444     0.97604',
+                    '2   1   3         H     O     H              103.8663'
+                    ]
+        self.run_test(exe_name, options=opts, expected=expected)


### PR DESCRIPTION
Add `expected` value to test function.