### PR TITLE
Fixed conditional in fish env setup

### DIFF
--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -253,7 +253,7 @@ function match_flag -d "checks all combinations of flags ocurring inside of a st
     set -l _a (string sub -s 2 (string trim "x$argv[1]"))
     set -l _b (string sub -s 2 (string trim "x$argv[2]"))
 
-    if test -z "$_a" or test -z "$_b"
+    if test -z "$_a"; or test -z "$_b"
         return 0
     end
 


### PR DESCRIPTION
An attempt to fix the conditional was made in 5a771bc8ad, yet this broke the conditional completely.