### PR TITLE
Add manual_download attribute to packages

### DIFF
--- a/var/spack/repos/builtin/packages/adf/package.py
+++ b/var/spack/repos/builtin/packages/adf/package.py
@@ -13,6 +13,8 @@ class Adf(Package):
     theory."""
 
     homepage = "https://www.scm.com/product/adf/"
+    manual_download = True
+
     version('2017.113', '666ef15d253b74c707dd14da35e7cf283ca20e21e24ed43cb953fb9d1f2f1e15')
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/amber/package.py
+++ b/var/spack/repos/builtin/packages/amber/package.py
@@ -22,6 +22,8 @@ class Amber(Package, CudaPackage):
 
     homepage = "http://ambermd.org/"
     url = "file://{0}/Amber18.tar.bz2".format(os.getcwd())
+    manual_download = True
+
     maintainers = ['hseara']
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/avizo/package.py
+++ b/var/spack/repos/builtin/packages/avizo/package.py
@@ -18,6 +18,8 @@ class Avizo(Package):
 
     homepage = "https://www.thermofisher.com/sa/en/home/industrial/electron-microscopy/electron-microscopy-instruments-workflow-solutions/3d-visualization-analysis-software.html"
 
+    manual_download = True
+
     version('2020.1',
             sha256='9321aaa276567eebf116e268353c33a4c930d768d22793f921338e1d8cefe991',
             url="file://{0}/Avizo-20201-Linux64-gcc48.bin".format(os.getcwd()),

--- a/var/spack/repos/builtin/packages/chlorop/package.py
+++ b/var/spack/repos/builtin/packages/chlorop/package.py
@@ -19,6 +19,7 @@ class Chlorop(Package):
 
     homepage = "http://www.cbs.dtu.dk/services/ChloroP/"
     url      = "file://{0}/chlorop-1.1.Linux.tar.gz".format(os.getcwd())
+    manual_download = True
 
     version('1.1', 'eb0ba6b28dfa735163ad5fc70e30139e46e33f6ae27f87666a7167a4ac5f71d9')
 

--- a/var/spack/repos/builtin/packages/coinhsl/package.py
+++ b/var/spack/repos/builtin/packages/coinhsl/package.py
@@ -24,6 +24,7 @@ class Coinhsl(AutotoolsPackage):
     # exist
     homepage = "http://www.hsl.rl.ac.uk/ipopt/"
     url = "file://{0}/coinhsl-archive-2014.01.17.tar.gz".format(os.getcwd())
+    manual_download = True
 
     # CoinHSL has a few versions that vary with respect to stability/features
     # and licensing terms.

--- a/var/spack/repos/builtin/packages/cpmd/package.py
+++ b/var/spack/repos/builtin/packages/cpmd/package.py
@@ -17,6 +17,7 @@ class Cpmd(MakefilePackage):
     homepage = "https://www.cpmd.org/wordpress/"
     basedir = os.getcwd()
     url = "file://{0}/cpmd-v4.3.tar.gz".format(basedir)
+    manual_download = True
 
     version('4.3', sha256='4f31ddf045f1ae5d6f25559d85ddbdab4d7a6200362849df833632976d095df4')
 

--- a/var/spack/repos/builtin/packages/dock/package.py
+++ b/var/spack/repos/builtin/packages/dock/package.py
@@ -16,6 +16,7 @@ class Dock(Package):
 
     homepage = "http://dock.compbio.ucsf.edu/DOCK_6/index.htm"
     url      = "file://{0}/dock.6.9_source.tar.gz".format(os.getcwd())
+    manual_download = True
 
     version('6.9', sha256='c2caef9b4bb47bb0cb437f6dc21f4c605fd3d0d9cc817fa13748c050dc87a5a8')
 

--- a/var/spack/repos/builtin/packages/ffb/package.py
+++ b/var/spack/repos/builtin/packages/ffb/package.py
@@ -12,6 +12,8 @@ class Ffb(MakefilePackage):
 
     homepage = "http://www.ciss.iis.u-tokyo.ac.jp/dl/index.php"
     url      = "file://{0}/FrontFlow_blue.8.1.tar.gz".format(os.getcwd())
+    manual_download = True
+
     version('8.1', sha256='1ad008c909152b6c27668bafbad820da3e6ec3309c7e858ddb785f0a3d6e43ae')
 
     patch('revocap_refiner.patch')

--- a/var/spack/repos/builtin/packages/ffr/package.py
+++ b/var/spack/repos/builtin/packages/ffr/package.py
@@ -14,6 +14,7 @@ class Ffr(MakefilePackage):
     JAPAN."""
 
     homepage = "http://www.ciss.iis.u-tokyo.ac.jp/rss21/theme/multi/fluid/fluid_softwareinfo.html"
+    manual_download = True
 
     version('3.1.004', sha256='2b396f66bb6437366721fac987f9c6e8b830638c3e4cb5df6a08ff41633f8481', url="file://{0}/FFR_V3.1.004.zip".format(os.getcwd()))
     version('3.0_000', sha256='edc69fb1fd9dbdb3f531a8f2b9533a9b3c1a28768bb4029b84a6b35c95db0b48', url="file://{0}/open_FrontFlowRed_3.0_000.tar.gz".format(os.getcwd()))

--- a/var/spack/repos/builtin/packages/libspatialite/package.py
+++ b/var/spack/repos/builtin/packages/libspatialite/package.py
@@ -13,6 +13,7 @@ class Libspatialite(AutotoolsPackage):
 
     homepage = "http://www.gaia-gis.it"
     url      = "http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz"
+    manual_download = True
 
     version('5.0.0', preferred=True, sha256='7b7fd70243f5a0b175696d87c46dde0ace030eacc27f39241c24bac5dfac6dac')
     # Must download manually from:

--- a/var/spack/repos/builtin/packages/maker/package.py
+++ b/var/spack/repos/builtin/packages/maker/package.py
@@ -31,6 +31,7 @@ class Maker(Package):
     http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "http://www.yandell-lab.org/software/maker.html"
+    manual_download = True
 
     version('2.31.10',      sha256='d3979af9710d61754a3b53f6682d0e2052c6c3f36be6f2df2286d2587406f07d')
 

--- a/var/spack/repos/builtin/packages/mark/package.py
+++ b/var/spack/repos/builtin/packages/mark/package.py
@@ -20,6 +20,7 @@ class Mark(Package):
     http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "http://www.phidot.org/software/mark/index.html"
+    manual_download = True
 
     version('1.0', sha256='5422c9444d5fa6b3b22f4a9f2ce41af2072a1a7283f6f9099dc02cc5282696bc',
             expand=False)

--- a/var/spack/repos/builtin/packages/mathematica/package.py
+++ b/var/spack/repos/builtin/packages/mathematica/package.py
@@ -19,6 +19,7 @@ class Mathematica(Package):
 
     homepage = "https://www.wolfram.com/mathematica/"
     url = 'file://{0}/Mathematica_12.0.0_LINUX.sh'.format(os.getcwd())
+    manual_download = True
 
     version('12.1.1',
             sha256='ad47b886be4a9864d70f523f792615a051d4ebc987d9a0f654b645b4eb43b30a',

--- a/var/spack/repos/builtin/packages/modylas/package.py
+++ b/var/spack/repos/builtin/packages/modylas/package.py
@@ -17,6 +17,7 @@ class Modylas(AutotoolsPackage):
 
     homepage = "https://www.modylas.org"
     url      = "file://{0}/MODYLAS_1.0.4.tar.gz".format(os.getcwd())
+    manual_download = True
 
     version('1.0.4', 'e0b5cccf8e363c1182eced37aa31b06b1c5b1526da7d449a6142424ac4ea6311')
 

--- a/var/spack/repos/builtin/packages/orca/package.py
+++ b/var/spack/repos/builtin/packages/orca/package.py
@@ -18,6 +18,7 @@ class Orca(Package):
 
     homepage = "https://cec.mpg.de"
     url      = "file://{0}/orca_4_0_1_2_linux_x86-64_openmpi202.tar.zst".format(os.getcwd())
+    manual_download = True
 
     version('4.2.1', sha256='9bbb3bfdca8220b417ee898b27b2885508d8c82799adfa63dde9e72eab49a6b2',
             expand=False)

--- a/var/spack/repos/builtin/packages/pgi/package.py
+++ b/var/spack/repos/builtin/packages/pgi/package.py
@@ -19,6 +19,7 @@ class Pgi(Package):
     set up a mirror, see http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "http://www.pgroup.com/"
+    manual_download = True
 
     version('20.4',  sha256='f3ecc2104b304cd5c8b20e3ffdb5da88f2b5f7cc148e8daf00561928a5cbbc2e')
     version('19.10', sha256='ac9db73ba80a66fe3bc875f63aaa9e16f54674a4e88b25416432430ba8cf203d')

--- a/var/spack/repos/builtin/packages/phrap-crossmatch-swat/package.py
+++ b/var/spack/repos/builtin/packages/phrap-crossmatch-swat/package.py
@@ -16,6 +16,7 @@ class PhrapCrossmatchSwat(MakefilePackage):
 
     homepage = "http://www.phrap.org/phredphrapconsed.html"
     url      = "file://{0}/phrap-crossmatch-swat-1.090518.tar.gz".format(os.getcwd())
+    manual_download = True
 
     version('1.090518', sha256='81f50c4410e8604cdefcc34ef6dc7b037be3bb45b94c439611a5590c1cf83665')
 

--- a/var/spack/repos/builtin/packages/phred/package.py
+++ b/var/spack/repos/builtin/packages/phred/package.py
@@ -13,6 +13,7 @@ class Phred(MakefilePackage):
 
     homepage = "http://www.phrap.org/phredphrapconsed.html"
     url      = "file://{0}/phred.tar.gz".format(os.getcwd())
+    manual_download = True
 
     version('071220', sha256='26212f13fa906c1ca0af61f48d52a5f2c1aacba802bf729ba65ca5222463abce')
 

--- a/var/spack/repos/builtin/packages/revocap-coupler/package.py
+++ b/var/spack/repos/builtin/packages/revocap-coupler/package.py
@@ -14,6 +14,8 @@ class RevocapCoupler(AutotoolsPackage):
 
     homepage = "http://www.ciss.iis.u-tokyo.ac.jp/dl/index.php"
     url      = "file://{0}/REVOCAP_Coupler-2.1.tar.gz".format(os.getcwd())
+    manual_download = True
+
     version('2.1', sha256='9e7612d5c508ccdce23bff9ccbf62aeb635877bc2276cdc05c109de40f609f49')
 
     depends_on('mpi')

--- a/var/spack/repos/builtin/packages/sentieon-genomics/package.py
+++ b/var/spack/repos/builtin/packages/sentieon-genomics/package.py
@@ -23,6 +23,7 @@ class SentieonGenomics(Package):
 
     homepage = "https://www.sentieon.com/"
     url      = "file://{0}/sentieon-genomics-201808.01.tar.gz".format(os.getcwd())
+    manual_download = True
 
     version('201808.07', sha256='fb66b18a7b99e44968eb2c3a6a5b761d6b1e70fba9f7dfc4e5db3a74ab3d3dd9')
     version('201808.01', sha256='6d77bcd5a35539549b28eccae07b19a3b353d027720536e68f46dcf4b980d5f7')

--- a/var/spack/repos/builtin/packages/simmetrix-simmodsuite/package.py
+++ b/var/spack/repos/builtin/packages/simmetrix-simmodsuite/package.py
@@ -138,6 +138,7 @@ class SimmetrixSimmodsuite(Package):
     """
 
     homepage = "http://www.simmetrix.com/products/SimulationModelingSuite/main.html"
+    manual_download = True
 
     license_required = True
     license_vars     = ['SIM_LICENSE_FILE']

--- a/var/spack/repos/builtin/packages/stata/package.py
+++ b/var/spack/repos/builtin/packages/stata/package.py
@@ -25,6 +25,7 @@ class Stata(Package):
 # * I haven't tested any installer version but 15.
 
     homepage = "https://www.stata.com/"
+    manual_download = True
     # url      = "stata"
 
     version('16', 'a13a6a92558eeb3c6cb3013c458a6777e54c21af43599df6b0a924f5f5c2d5d2')

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -17,6 +17,7 @@ class Vasp(MakefilePackage):
 
     homepage = "http://vasp.at"
     url      = "file://{0}/vasp.5.4.4.pl2.tgz".format(os.getcwd())
+    manual_download = True
 
     version('6.1.1', sha256='e37a4dfad09d3ad0410833bcd55af6b599179a085299026992c2d8e319bf6927')
     version('5.4.4.pl2', sha256='98f75fd75399a23d76d060a6155f4416b340a1704f256a00146f89024035bc8e')

--- a/var/spack/repos/builtin/packages/vmd/package.py
+++ b/var/spack/repos/builtin/packages/vmd/package.py
@@ -23,6 +23,7 @@ class Vmd(Package):
     homepage = "https://www.ks.uiuc.edu/Research/vmd/"
     version('1.9.3', sha256='145b4d0cc10b56cadeb71e16c54ab8be713e268f11491714cd617422758ec643',
             url='file://{0}/vmd-1.9.3.bin.LINUXAMD64-CUDA8-OptiX4-OSPRay111p1.opengl.tar.gz'.format(os.getcwd()))
+    manual_download = True
 
     phases = ['configure', 'install']
 


### PR DESCRIPTION
Add `manual_download = True` to packages that need to do manual
downloads but do not have the `manual_download attribute set. This
provides a message when installing these packages rather than a generic
fetch error.