### PR TITLE
blast2go: build only x86_64

### DIFF
--- a/var/spack/repos/builtin/packages/blast2go/package.py
+++ b/var/spack/repos/builtin/packages/blast2go/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import archspec
 
 
 class Blast2go(Package):
@@ -14,10 +15,9 @@ class Blast2go(Package):
 
     version('5.2.5', sha256='c37aeda25f96ac0553b52da6b5af3167d50671ddbfb3b39bcb11afe5d0643891')
 
-    for t in ['aarch64', 'arm', 'ppc', 'ppc64', 'ppc64le',
-              'ppcle', 'sparc', 'sparc64', 'x86']:
-        conflicts('target={0}:'.format(t),
-                  msg='blast2go is available x86_64 only')
+    for t in set([str(x.family) for x in archspec.cpu.TARGETS.values()
+                 if str(x.family) != 'x86_64']):
+        conflicts('target={0}:'.format(t), msg='blast2go is available x86_64 only')
 
     depends_on('bash', type='build')
     depends_on('blast-plus', type='run')

--- a/var/spack/repos/builtin/packages/blast2go/package.py
+++ b/var/spack/repos/builtin/packages/blast2go/package.py
@@ -13,6 +13,12 @@ class Blast2go(Package):
     homepage = "https://www.blast2go.com/"
 
     version('5.2.5', sha256='c37aeda25f96ac0553b52da6b5af3167d50671ddbfb3b39bcb11afe5d0643891')
+    version('5.2.5', sha256='c37aeda25f96ac0553b52da6b5af3167d50671ddbfb3b39bcb11afe5d0643891')
+
+    for t in ['aarch64', 'arm', 'ppc', 'ppc64', 'ppc64le',
+              'ppcle', 'sparc', 'sparc64', 'x86']:
+        conflicts('target={0}:'.format(t),
+                  msg='blast2go is available x86_64 only')
 
     depends_on('bash', type='build')
     depends_on('blast-plus', type='run')

--- a/var/spack/repos/builtin/packages/blast2go/package.py
+++ b/var/spack/repos/builtin/packages/blast2go/package.py
@@ -13,7 +13,6 @@ class Blast2go(Package):
     homepage = "https://www.blast2go.com/"
 
     version('5.2.5', sha256='c37aeda25f96ac0553b52da6b5af3167d50671ddbfb3b39bcb11afe5d0643891')
-    version('5.2.5', sha256='c37aeda25f96ac0553b52da6b5af3167d50671ddbfb3b39bcb11afe5d0643891')
 
     for t in ['aarch64', 'arm', 'ppc', 'ppc64', 'ppc64le',
               'ppcle', 'sparc', 'sparc64', 'x86']:


### PR DESCRIPTION
blast2go: build only x86_64