### PR TITLE
Drop *_INCLUDE_PATH in prefix_inspections:include

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -25,14 +25,6 @@ modules:
       - MANPATH
     share/aclocal:
       - ACLOCAL_PATH
-    lib:
-      - LIBRARY_PATH
-    lib64:
-      - LIBRARY_PATH
-    include:
-      # The INCLUDE env variable specifies paths to look for
-      # .mod file for Intel Fortran compilers
-      - INCLUDE
     lib/pkgconfig:
       - PKG_CONFIG_PATH
     lib64/pkgconfig:

--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -30,8 +30,6 @@ modules:
     lib64:
       - LIBRARY_PATH
     include:
-      - C_INCLUDE_PATH
-      - CPLUS_INCLUDE_PATH
       # The INCLUDE env variable specifies paths to look for
       # .mod file for Intel Fortran compilers
       - INCLUDE

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -109,7 +109,6 @@ succeeds spack -m load b
 fails spack -m load -l
 # test a variable MacOS clears and one it doesn't for recursive loads
 contains "export LD_LIBRARY_PATH=$(spack -m location -i a)/lib:$(spack -m location -i b)/lib" spack -m load --sh a
-contains "export LIBRARY_PATH=$(spack -m location -i a)/lib:$(spack -m location -i b)/lib" spack -m load --sh a
 succeeds spack -m load --only dependencies a
 succeeds spack -m load --only package a
 fails spack -m load d


### PR DESCRIPTION
1. None of the currently enabled env variables apply to Fortran (at least on linux/mac), so the user still has to set -I flags regardless; this is because we don't set CPATH for reasons in other issues.
2. The Cray compiler has a bug where it does not set `-I` flags for its own packages when the path is in C_INCLUDE_PATH (ref https://github.com/spack/spack/issues/21696). This means that `spack load cray-mpich` makes `ftn mpiprogram.f90` fail to compile.