### PR TITLE
py-numpydoc: Add new version, and care for old version.

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpydoc/package.py
+++ b/var/spack/repos/builtin/packages/py-numpydoc/package.py
@@ -12,8 +12,11 @@ class PyNumpydoc(PythonPackage):
     homepage = "https://github.com/numpy/numpydoc"
     pypi = "numpydoc/numpydoc-0.6.0.tar.gz"
 
+    version('1.1.0', sha256='c36fd6cb7ffdc9b4e165a43f67bf6271a7b024d0bb6b00ac468c9e2bfc76448e')
     version('0.6.0', sha256='1ec573e91f6d868a9940d90a6599f3e834a2d6c064030fbe078d922ee21dcfa1')
 
-    depends_on('python@2.6:2.8,3.3:')
+    depends_on('python@2.6:2.8,3.3:', when='@0.6.0')
+    depends_on('python@3.5:', when='@1.1.0')
     depends_on('py-setuptools',    type='build')
-    depends_on('py-sphinx@1.0.1:', type='build')
+    depends_on('py-sphinx@1.0.1:1.6.7', type='build', when='@0.6.0')
+    depends_on('py-sphinx@1.6.5:', type='build', when='@1.1.0')

--- a/var/spack/repos/builtin/packages/py-numpydoc/package.py
+++ b/var/spack/repos/builtin/packages/py-numpydoc/package.py
@@ -20,3 +20,4 @@ class PyNumpydoc(PythonPackage):
     depends_on('py-setuptools',    type='build')
     depends_on('py-sphinx@1.0.1:1.6.7', type='build', when='@0.6.0')
     depends_on('py-sphinx@1.6.5:', type='build', when='@1.1.0')
+    depends_on('py-jinja2@2.3:', type='build', when='@1.1.0')


### PR DESCRIPTION
- Add new version 1.1.0. 
- Solve the problem for version 0.6.0.
In version 0.6.0, the following error occurred when using `py-numpydoc`.
```
Extension error:
Could not import extension numpydoc (exception: cannot import name 'Directive' from 'sphinx.util.compat' (/home/tkaratsu/work/x86/spack/opt/spack/linux-rhel8-skylake_avx512/gcc-8.3.1/py-sphinx-3.2.0-hbnpadlcsr7wbt6y6wuz5ve7zu4fcixy/lib/python3.8/site-packages/sphinx/util/compat.py))
```
https://github.com/readthedocs/readthedocs.org/issues/4057
According to this issue, `Directive` is no longer available from version 1.7.0 of `py-sphinx`.
So, in version 0.6.0, Limit `py-sphinx` version to `1.6.7`.