### PR TITLE
dlib: added imgcodecs

### DIFF
--- a/var/spack/repos/builtin/packages/dlib/package.py
+++ b/var/spack/repos/builtin/packages/dlib/package.py
@@ -15,7 +15,7 @@ class Dlib(CMakePackage):
     version('master', branch='master')
 
     depends_on('cmake@3.0:', type='build')
-    depends_on('opencv+calib3d+core+features2d+highgui+imgproc')
+    depends_on('opencv+calib3d+core+features2d+highgui+imgproc+imgcodecs')
     # Because concretizer is broken...
     # TODO: remove when original concretizer is obsolete
     depends_on('opencv+flann')


### PR DESCRIPTION
Since a variant (imgcodecs,default=False) has been added to opencv,
+imgcodecs is now required in dlib's opencv dependency.

```
  >> 69    /tmp/denpo/spack-stage/spack-stage-dlib-master-aohosnmtozxzidqcxwatj4gse2lfgzsw/spack-src/src/DVision/Mat[29/1911]
           :15:10: fatal error: opencv2/highgui/highgui.hpp: No such file or directory
     70     #include <opencv2/highgui/highgui.hpp>
     71              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     72    compilation terminated.
  >> 73    /tmp/denpo/spack-stage/spack-stage-dlib-master-aohosnmtozxzidqcxwatj4gse2lfgzsw/spack-src/src/DUtilsCV/Drawing.cp
           p:13:10: fatal error: opencv2/highgui/highgui.hpp: No such file or directory
     74     #include <opencv2/highgui/highgui.hpp>
     75              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     76    compilation terminated.
  >> 77    make[2]: *** [CMakeFiles/DLib.dir/build.make:163: CMakeFiles/DLib.dir/src/DVision/Matches.cpp.o] Error 1
     78    make[2]: *** Waiting for unfinished jobs....
  >> 79    make[2]: *** [CMakeFiles/DLib.dir/build.make:202: CMakeFiles/DLib.dir/src/DUtilsCV/Drawing.cpp.o] Error 1
  >> 80    /tmp/denpo/spack-stage/spack-stage-dlib-master-aohosnmtozxzidqcxwatj4gse2lfgzsw/spack-src/src/DUtilsCV/IO.cpp:14:
           10: fatal error: opencv2/highgui/highgui.hpp: No such file or directory
     81     #include <opencv2/highgui/highgui.hpp>
     82              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     83    compilation terminated.
  >> 84    make[2]: *** [CMakeFiles/DLib.dir/build.make:267: CMakeFiles/DLib.dir/src/DUtilsCV/IO.cpp.o] Error 1
  >> 85    /tmp/denpo/spack-stage/spack-stage-dlib-master-aohosnmtozxzidqcxwatj4gse2lfgzsw/spack-src/src/DUtilsCV/GUI.cpp:14
           :10: fatal error: opencv2/highgui/highgui.hpp: No such file or directory
     86     #include <opencv2/highgui/highgui.hpp>
```
