### PR TITLE
quantum-espresso: fix ldflags for scalapack

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -377,7 +377,7 @@ class QuantumEspresso(Package):
                 scalapack_option = 'yes'
             options.append('--with-scalapack={0}'.format(scalapack_option))
             scalapack_lib = spec['scalapack'].libs
-            options.append('SCALAPACK_LIBS={0}'.format(scalapack_lib))
+            options.append('SCALAPACK_LIBS={0}'.format(scalapack_lib.ld_flags))
 
         if '+elpa' in spec:
 


### PR DESCRIPTION
This PR modifies ldflags for ScaLAPACK according to the notation of other dependent libraries.