### PR TITLE
fix setup-env.sh local array declaration on older linux bash

### DIFF
--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -55,7 +55,7 @@ _bash_completion_spack() {
     # For our purposes, flags should not affect tab completion. For instance,
     # `spack install []` and `spack -d install --jobs 8 []` should both give the same
     # possible completions. Therefore, we need to ignore any flags in COMP_WORDS.
-    local COMP_WORDS_NO_FLAGS=()
+    local -a COMP_WORDS_NO_FLAGS
     local index=0
     while [[ "$index" -lt "$COMP_CWORD" ]]
     do

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -55,7 +55,7 @@ _bash_completion_spack() {
     # For our purposes, flags should not affect tab completion. For instance,
     # `spack install []` and `spack -d install --jobs 8 []` should both give the same
     # possible completions. Therefore, we need to ignore any flags in COMP_WORDS.
-    local COMP_WORDS_NO_FLAGS=()
+    local -a COMP_WORDS_NO_FLAGS
     local index=0
     while [[ "$index" -lt "$COMP_CWORD" ]]
     do


### PR DESCRIPTION
The following error is detected when attempting to setup the spack shell environment on a linux host (some information is redacted with `...`):
```bash
~% /bin/bash --version
GNU bash, version 4.2.46 (x86_64-redhat-linux-gnu)
Copyright (C) 2011 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
~% uname -a
Linux borax5 3.10...
~% . spack/share/spack/setup-env.sh
.../spack/share/spack/spack-completion.bash:58: parse error near `()'
```

The error is readily fixed, as `local -a` already defaults to initializing the variable to an empty array.