### PR TITLE
make @llnl.util.lang.memoized support kwargs

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -166,6 +166,20 @@ def union_dicts(*dicts):
     return result
 
 
+# Used as a sentinel that disambiguates tuples passed in *args from coincidentally
+# matching tuples formed from kwargs item pairs.
+_kwargs_separator = (object(),)
+
+
+def equal_args(*args, **kwargs):
+    """A memoized key factory that compares the equality (`==`) of a stable sort of the
+    parameters."""
+    key = args
+    if kwargs:
+        key += _kwargs_separator + tuple(sorted(kwargs.items()))
+    return key
+
+
 def memoized(func):
     """Decorator that caches the results of a function, storing them in
     an attribute of that function.
@@ -174,7 +188,7 @@ def memoized(func):
 
     @functools.wraps(func)
     def _memoized_function(*args, **kwargs):
-        key = args + tuple(kwargs.items())
+        key = equal_args(*args, **kwargs)
 
         try:
             return func.cache[key]

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -171,9 +171,8 @@ def union_dicts(*dicts):
 _kwargs_separator = (object(),)
 
 
-def equal_args(*args, **kwargs):
-    """A memoized key factory that compares the equality (`==`) of a stable sort of the
-    parameters."""
+def stable_args(*args, **kwargs):
+    """A key factory that performs a stable sort of the parameters."""
     key = args
     if kwargs:
         key += _kwargs_separator + tuple(sorted(kwargs.items()))
@@ -188,7 +187,7 @@ def memoized(func):
 
     @functools.wraps(func)
     def _memoized_function(*args, **kwargs):
-        key = equal_args(*args, **kwargs)
+        key = stable_args(*args, **kwargs)
 
         try:
             return func.cache[key]

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 import pytest
 
 import llnl.util.lang
-from llnl.util.lang import equal_args, match_predicate, memoized, pretty_date
+from llnl.util.lang import match_predicate, memoized, pretty_date, stable_args
 
 
 @pytest.fixture()
@@ -215,7 +215,7 @@ def test_key_ordering():
     ],
 )
 def test_unequal_args(args1, kwargs1, args2, kwargs2):
-    assert equal_args(*args1, **kwargs1) != equal_args(*args2, **kwargs2)
+    assert stable_args(*args1, **kwargs1) != stable_args(*args2, **kwargs2)
 
 
 @pytest.mark.parametrize(
@@ -226,7 +226,7 @@ def test_unequal_args(args1, kwargs1, args2, kwargs2):
     ],
 )
 def test_equal_args(args1, kwargs1, args2, kwargs2):
-    assert equal_args(*args1, **kwargs1) == equal_args(*args2, **kwargs2)
+    assert stable_args(*args1, **kwargs1) == stable_args(*args2, **kwargs2)
 
 
 @pytest.mark.parametrize(
@@ -242,7 +242,7 @@ def test_memoized(args, kwargs):
     def f(*args, **kwargs):
         return 'return-value'
     assert f(*args, **kwargs) == 'return-value'
-    key = equal_args(*args, **kwargs)
+    key = stable_args(*args, **kwargs)
     assert list(f.cache.keys()) == [key]
     assert f.cache[key] == 'return-value'
 
@@ -262,6 +262,6 @@ def test_memoized_unhashable(args, kwargs):
     with pytest.raises(llnl.util.lang.UnhashableArguments) as exc_info:
         f(*args, **kwargs)
     exc_msg = str(exc_info.value)
-    key = equal_args(*args, **kwargs)
+    key = stable_args(*args, **kwargs)
     assert str(key) in exc_msg
     assert "function 'f'" in exc_msg


### PR DESCRIPTION
### Problem

Functions annotated with `@llnl.util.lang.memoized` cannot accept keyword arguments. Separately, memoized functions that are called with unhashable arguments are simply called directly, without being memoized. I think this is incorrect behavior -- we should require that arguments to memoized functions are hashable.

### Solution

- Support keyword arguments in methods annotated by `@memoized`.
- Raise an `UnhashableArguments` exception if the arguments to a memoized function are unhashable instead of silently failing to memoize.

#### Note

It's possible to dive much much deeper into memoization configuration: see e.g. https://github.com/pantsbuild/pants/blob/c0d68a8d7523e54b98a0751854f9f84b3641144c/src/python/pants/util/memo.py#L20-L26. For now, we just emulate the linked `equal_args()` construct.