### PR TITLE
minor modifications to Spec.__repr__

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -82,6 +82,7 @@ import operator
 import os
 import re
 import warnings
+from typing import Iterable, Optional, Union  # novm
 
 import ruamel.yaml as yaml
 import six
@@ -1034,15 +1035,16 @@ class Spec(object):
     #: Cache for spec's prefix, computed lazily in the corresponding property
     _prefix = None
 
-    @staticmethod
-    def default_arch():
-        """Return an anonymous spec for the default architecture"""
-        s = Spec()
-        s.architecture = ArchSpec.default_arch()
-        return s
-
-    def __init__(self, spec_like=None, normal=False,
-                 concrete=False, external_path=None, external_modules=None):
+    def __init__(
+        self,
+        spec_like=None,         # type: Optional[Union[str, Spec]]
+        normal=False,           # type: bool
+        concrete=False,         # type: bool
+        external_path=None,     # type: Optional[str]
+        external_modules=None,  # type: Optional[Iterable[str]]
+        full_hash=None,         # type: Optional[str]
+    ):
+        # type: (...) -> None
         """Create a new Spec.
 
         Arguments:
@@ -1120,6 +1122,11 @@ class Spec(object):
 
         elif spec_like is not None:
             raise TypeError("Can't make spec out of %s" % type(spec_like))
+
+    @classmethod
+    def default_arch(cls):
+        """Return a spec matching the default architecture."""
+        return cls('arch={}'.format(ArchSpec.default_arch()))
 
     @staticmethod
     def _format_module_list(modules):
@@ -3470,6 +3477,7 @@ class Spec(object):
         # We don't count dependencies as changes here
         changed = True
         if hasattr(self, 'name'):
+            # TODO: what does 'changed' mean here?
             changed = (self.name != other.name and
                        self.versions != other.versions and
                        self.architecture != other.architecture and
@@ -4233,6 +4241,9 @@ class Spec(object):
         spec_str = " ^".join(d.format() for d in sorted_nodes)
         return spec_str.strip()
 
+    def __repr__(self):
+        return 'Spec({0!r})'.format(str(self))
+
     def install_status(self):
         """Helper for tree to print DB install status."""
         if not self.concrete:
@@ -4321,9 +4332,6 @@ class Spec(object):
                 break
 
         return out
-
-    def __repr__(self):
-        return str(self)
 
     @property
     def platform(self):


### PR DESCRIPTION
This PR is composed of two minor changes to the `Spec` class, along with two further distinct changes which I would like some review on:
1. Add type annotations to `Spec.__init__()`.
2. Correctly implement `Spec.__repr__()` to return a string which can be `eval()`ed to produce the same object.

### Desired Feedback
- [ ] Are these types correct?
- [ ] Is this `repr()` impl more correct? Is there a specific reason we were breaking the `repr()` contract by calling `str()` before?