### PR TITLE
Update scotch package for int32

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -105,10 +105,11 @@ class Scotch(Package):
         ]
 
         if '+int64' in self.spec:
-            cflags.append('-DINTSIZE64') # SCOTCH_Num typedef: size of integers in arguments
-            cflags.append('-DIDXSIZE64') # SCOTCH_Idx typedef: indices for addressing
+            # SCOTCH_Num typedef: size of integers in arguments
+            cflags.append('-DINTSIZE64')
+            cflags.append('-DIDXSIZE64')  # SCOTCH_Idx typedef: indices for addressing
         else:
-            cflags.append('-DIDXSIZE32') # SCOTCH_Idx typedef: indices for addressing
+            cflags.append('-DIDXSIZE32')  # SCOTCH_Idx typedef: indices for addressing
 
         if self.spec.satisfies('platform=darwin'):
             cflags.extend([

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -103,14 +103,12 @@ class Scotch(Package):
             '-DSCOTCH_DETERMINISTIC',
             '-DSCOTCH_RENAME',
         ]
-        
+
         if '+int64' in self.spec:
             cflags.append('-DINTSIZE64') # SCOTCH_Num typedef: size of integers in arguments
             cflags.append('-DIDXSIZE64') # SCOTCH_Idx typedef: indices for addressing
         else:
             cflags.append('-DIDXSIZE32') # SCOTCH_Idx typedef: indices for addressing
-
-
 
         if self.spec.satisfies('platform=darwin'):
             cflags.extend([

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -102,12 +102,15 @@ class Scotch(Package):
             '-DCOMMON_RANDOM_FIXED_SEED',
             '-DSCOTCH_DETERMINISTIC',
             '-DSCOTCH_RENAME',
-            '-DIDXSIZE64',  # SCOTCH_Idx typedef: indices for addressing
         ]
-
-        # SCOTCH_Num typedef: size of integers in arguments
+        
         if '+int64' in self.spec:
-            cflags.append('-DINTSIZE64')
+            cflags.append('-DINTSIZE64') # SCOTCH_Num typedef: size of integers in arguments
+            cflags.append('-DIDXSIZE64') # SCOTCH_Idx typedef: indices for addressing
+        else:
+            cflags.append('-DIDXSIZE32') # SCOTCH_Idx typedef: indices for addressing
+
+
 
         if self.spec.satisfies('platform=darwin'):
             cflags.extend([


### PR DESCRIPTION
Scotch has two flags for integers : for indices (IDXSIZE32/IDXSIZE64) and for sizes (INTSIZE32/INTSIZE64). When compiling for 32bits (no int64 flag), the index size was forced to IDXSIZE64. This PR corrects this behavior.

Note : maybe it was intended to use **INT**SIZE32 but still with **IDX**SIZE64. But it seems strange, especially as the default. If this was the case however, please tell me so I can amend the PR to keep the current default behavior, but add an option to force compilation for the **IDX**SIZE32/**INT**SIZE32 set of flags.