### PR TITLE
Avoid spurious warning from clingo

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -227,6 +227,7 @@ provider_weight(Package, 100)
     provider(Package, Virtual),
     not default_provider_preference(Virtual, Package, _).
 
+#defined possible_provider/2.
 #defined provider_condition/3.
 #defined required_provider_condition/3.
 #defined required_provider_condition/4.


### PR DESCRIPTION
There's a spurious warning that occurs whenever a spec being concretized does not depend on a virtual provider under any possible configuration.

**Before this PR**

```console
$ spack solve zlib
/home/culpo/PycharmProjects/spack/lib/spack/spack/solver/concretize.lp:153:42-77: info: atom does not occur in any rule head:
  possible_provider(Package,Virtual)

==> Best of 0 answers.
==> Optimization: [0, 0, 0, 0, 0, 1, 0, 0, 0]
``` 

**After this PR**

```console
$ spack solve zlib
==> Best of 0 answers.
==> Optimization: [0, 0, 0, 0, 0, 1, 0, 0, 0]
zlib@1.2.11%gcc@10.1.0+optimize+pic+shared arch=linux-ubuntu18.04-broadwell
```