### PR TITLE
Updates to the LBANN software stack

### DIFF
--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -22,6 +22,7 @@ class Aluminum(CMakePackage, CudaPackage):
     maintainers = ['bvanessen']
 
     version('master', branch='master')
+    version('0.7.0', sha256='bbb73d2847c56efbe6f99e46b41d837763938483f2e2d1982ccf8350d1148caa')
     version('0.6.0', sha256='6ca329951f4c7ea52670e46e5020e7e7879d9b56fed5ff8c5df6e624b313e925')
     version('0.5.0', sha256='dc365a5849eaba925355a8efb27005c5f22bcd1dca94aaed8d0d29c265c064c1')
     version('0.4.0', sha256='4d6fab5481cc7c994b32fb23a37e9ee44041a9f91acf78f981a97cb8ef57bb7d')
@@ -51,10 +52,14 @@ class Aluminum(CMakePackage, CudaPackage):
     def cmake_args(self):
         spec = self.spec
         args = [
+            '-DCMAKE_CXX_STANDARD=14',
             '-DALUMINUM_ENABLE_CUDA:BOOL=%s' % ('+cuda' in spec),
             '-DALUMINUM_ENABLE_NCCL:BOOL=%s' % ('+nccl' in spec)]
 
-        if '@0.5:':
+        if '+cuda' in spec:
+            args.append('-DCMAKE_CUDA_STANDARD=14')
+
+        if spec.satisfies('@0.5:'):
             args.extend([
                 '-DALUMINUM_ENABLE_HOST_TRANSFER:BOOL=%s' % ('+ht' in spec),
                 '-DALUMINUM_ENABLE_MPI_CUDA:BOOL=%s' %

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -142,6 +142,7 @@ class Dihydrogen(CMakePackage, CudaPackage):
         spec = self.spec
 
         args = [
+            '-DCMAKE_CXX_STANDARD=17',
             '-DCMAKE_INSTALL_MESSAGE:STRING=LAZY',
             '-DBUILD_SHARED_LIBS:BOOL=%s'      % ('+shared' in spec),
             '-DH2_ENABLE_CUDA=%s' % ('+cuda' in spec),
@@ -153,6 +154,11 @@ class Dihydrogen(CMakePackage, CudaPackage):
         ]
 
         if '+cuda' in spec:
+            if spec.satisfies('^cuda@11.0:'):
+                args.append('-DCMAKE_CUDA_STANDARD=17')
+            else:
+                args.append('-DCMAKE_CUDA_STANDARD=14')
+
             cuda_arch = spec.variants['cuda_arch'].value
             if len(cuda_arch) == 1 and cuda_arch[0] == 'auto':
                 args.append('-DCMAKE_CUDA_FLAGS=-arch=sm_60')

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -18,6 +18,7 @@ class Hydrogen(CMakePackage, CudaPackage):
     maintainers = ['bvanessen']
 
     version('develop', branch='hydrogen')
+    version('1.5.1', sha256='447da564278f98366906d561d9c8bc4d31678c56d761679c2ff3e59ee7a2895c')
     version('1.5.0', sha256='03dd487fb23b9fdbc715554a8ea48c3196a1021502e61b0172ef3fdfbee75180')
     version('1.4.0', sha256='c13374ff4a6c4d1076e47ba8c8d91a7082588b9958d1ed89cffb12f1d2e1452e')
     version('1.3.4', sha256='7979f6656f698f0bbad6798b39d4b569835b3013ff548d98089fce7c283c6741')
@@ -90,7 +91,8 @@ class Hydrogen(CMakePackage, CudaPackage):
     # Specify the correct version of Aluminum
     depends_on('aluminum@:0.3.99', when='@:1.3.99 +al')
     depends_on('aluminum@0.4:0.4.99', when='@1.4:1.4.99 +al')
-    depends_on('aluminum@0.5:', when='@:1.0,1.5.0: +al')
+    depends_on('aluminum@0.5:', when='@1.5.0:1.5.1 +al')
+    depends_on('aluminum@0.7:', when='@:1.0,1.5.2: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')
@@ -131,6 +133,7 @@ class Hydrogen(CMakePackage, CudaPackage):
         enable_gpu_fp16 = ('+cuda' in spec and '+half' in spec)
 
         args = [
+            '-DCMAKE_CXX_STANDARD=14',
             '-DCMAKE_INSTALL_MESSAGE:STRING=LAZY',
             '-DBUILD_SHARED_LIBS:BOOL=%s'      % ('+shared' in spec),
             '-DHydrogen_ENABLE_OPENMP:BOOL=%s'       % ('+openmp' in spec),
@@ -146,6 +149,9 @@ class Hydrogen(CMakePackage, CudaPackage):
             '-DHydrogen_ENABLE_HALF=%s' % ('+half' in spec),
             '-DHydrogen_ENABLE_GPU_FP16=%s' % enable_gpu_fp16,
         ]
+
+        if '+cuda' in spec:
+            args.append('-DCMAKE_CUDA_STANDARD=14')
 
         # Add support for OS X to find OpenMP (LLVM installed via brew)
         if self.spec.satisfies('%clang +openmp platform=darwin'):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -222,9 +222,9 @@ class Lbann(CMakePackage, CudaPackage):
             env.append_flags(
                 'LDFLAGS', self.spec['llvm-openmp'].libs.ld_flags)
 
-
     # Get any recent versions or non-numeric version
     # Note that develop > numeric and non-develop < numeric
+
     @when('@:0.90,0.94:')
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -64,6 +64,8 @@ class Lbann(CMakePackage, CudaPackage):
     variant('vtune', default=False, description='Builds with support for Intel VTune')
     variant('onednn', default=False, description='Support for OneDNN')
     variant('nvshmem', default=False, description='Support for NVSHMEM')
+    variant('python_dr', default=False, description='Support for generic Python Data Reader')
+    variant('pfe', default=True, description='Python Frontend for generating and launching models')
 
     # Variant Conflicts
     conflicts('@:0.90,0.99:', when='~conduit')
@@ -186,7 +188,7 @@ class Lbann(CMakePackage, CudaPackage):
         spec = self.spec
         # Environment variables
         cppflags = []
-        cppflags.append('-DLBANN_SET_EL_RNG -ldl')
+        cppflags.append('-DLBANN_SET_EL_RNG')
         args = []
         args.extend([
             '-DCMAKE_CXX_FLAGS=%s' % ' '.join(cppflags),
@@ -197,6 +199,15 @@ class Lbann(CMakePackage, CudaPackage):
             args.append(
                 '-DCNPY_DIR={0}'.format(spec['cnpy'].prefix),
             )
+        # Use a high performance linker
+        if self.spec.satisfies('%clang'):
+            args.extend([
+                '-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld',
+                '-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld'])
+        elif self.spec.satisfies('%gcc'):
+            args.extend([
+                '-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold',
+                '-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=gold'])
 
         return args
 
@@ -211,6 +222,7 @@ class Lbann(CMakePackage, CudaPackage):
             env.append_flags(
                 'LDFLAGS', self.spec['llvm-openmp'].libs.ld_flags)
 
+
     # Get any recent versions or non-numeric version
     # Note that develop > numeric and non-develop < numeric
     @when('@:0.90,0.94:')
@@ -218,8 +230,7 @@ class Lbann(CMakePackage, CudaPackage):
         spec = self.spec
         args = self.common_config_args
         args.extend([
-            '-DCMAKE_CXX_STANDARD=14',
-            '-DCMAKE_CUDA_STANDARD=14',
+            '-DCMAKE_CXX_STANDARD=17',
             '-DLBANN_WITH_CNPY=%s' % ('+numpy' in spec),
             '-DLBANN_DETERMINISTIC:BOOL=%s' % ('+deterministic' in spec),
             '-DLBANN_WITH_HWLOC=%s' % ('+hwloc' in spec),
@@ -230,6 +241,8 @@ class Lbann(CMakePackage, CudaPackage):
             '-DLBANN_WITH_NVSHMEM:BOOL=%s' % ('+nvshmem' in spec),
             '-DLBANN_WITH_FFT:BOOL=%s' % ('+fft' in spec),
             '-DLBANN_WITH_ONEDNN:BOOL=%s' % ('+onednn' in spec),
+            '-DLBANN_WITH_EMBEDDED_PYTHON:BOOL=%s' % ('+python_dr' in spec),
+            '-DLBANN_WITH_PYTHON:BOOL=%s' % ('+pfe' in spec),
             '-DLBANN_WITH_TBINF=OFF',
             '-DLBANN_WITH_UNIT_TESTING:BOOL=%s' % (self.run_tests),
             '-DLBANN_WITH_VISION:BOOL=%s' % ('+vision' in spec),
@@ -239,6 +252,12 @@ class Lbann(CMakePackage, CudaPackage):
             # protobuf is included by py-protobuf+cpp
             '-DProtobuf_DIR={0}'.format(spec['protobuf'].prefix),
             '-Dprotobuf_MODULE_COMPATIBLE=ON'])
+
+        if '+cuda' in spec:
+            if spec.satisfies('^cuda@11.0:'):
+                args.append('-DCMAKE_CUDA_STANDARD=17')
+            else:
+                args.append('-DCMAKE_CUDA_STANDARD=14')
 
         if spec.satisfies('@:0.90') or spec.satisfies('@0.95:'):
             args.append(


### PR DESCRIPTION
Set the minimun C++ standard for LBANN, Hydrogen, and DiHydrogen to
C++17.  The minumim C++ standard for Aluminum is C++14.  Add new
versions for Aluminum, Hydrogen, and DiHydrogen.  Added support for
high performance linkers in LBANN recipe (gold and lld).  Added
variants to LBANN for enabling embedded Python support independently
from the Python front end.