### PR TITLE
Replace os.getuid for windows

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -6,6 +6,7 @@ import collections
 import errno
 import hashlib
 import glob
+import ctypes
 
 from sys import platform as _platform
 if _platform != "win32":
@@ -70,6 +71,15 @@ __all__ = [
     'unset_executable_mode',
     'working_dir'
 ]
+
+
+def getuid(): 
+    if _platform == "win32":
+        if ctypes.windll.shell32.IsUserAnAdmin() == 0:
+            return 1
+        return 0
+    else:
+        return os.getuid()
 
 
 def path_contains_subdirectory(path, root):
@@ -298,7 +308,7 @@ def group_ids(uid=None):
         return []
 
     if uid is None:
-        uid = os.getuid()
+        uid = getuid()
     user = pwd.getpwuid(uid).pw_name
     return [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import stat
 import sys
+import ctypes
 import tempfile
 from six import string_types
 from six import iteritems
@@ -44,13 +45,22 @@ _source_path_subdir = 'spack-src'
 stage_prefix = 'spack-stage-'
 
 
+def getuid(): 
+    if sys.platform == "win32":
+        if ctypes.windll.shell32.IsUserAnAdmin() == 0:
+            return 1
+        return 0
+    else:
+        return os.getuid()
+
+
 def _create_stage_root(path):
     """Create the stage root directory and ensure appropriate access perms."""
     assert path.startswith(os.path.sep) and len(path.strip()) > 1
 
     err_msg = 'Cannot create stage root {0}: Access to {1} is denied'
 
-    user_uid = os.getuid()
+    user_uid = getuid()
 
     # Obtain lists of ancestor and descendant paths of the $user node, if any.
     group_paths, user_node, user_paths = partition_path(path,

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -8,6 +8,8 @@ import collections
 import getpass
 import tempfile
 from six import StringIO
+import sys
+import ctypes
 
 from llnl.util.filesystem import touch, mkdirp
 
@@ -24,6 +26,15 @@ import spack.schema.mirrors
 import spack.schema.repos
 import spack.util.spack_yaml as syaml
 import spack.util.path as spack_path
+
+
+def getuid(): 
+    if sys.platform == "win32":
+        if ctypes.windll.shell32.IsUserAnAdmin() == 0:
+            return 1
+        return 0
+    else:
+        return os.getuid()
 
 
 # sample config data
@@ -702,7 +713,7 @@ def test_bad_config_section(mock_low_high_config):
         spack.config.get('foobar')
 
 
-@pytest.mark.skipif(os.getuid() == 0, reason='user is root')
+@pytest.mark.skipif(getuid() == 0, reason='user is root')
 def test_bad_command_line_scopes(tmpdir, mock_low_high_config):
     cfg = spack.config.Configuration()
 

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -52,6 +52,7 @@ import tempfile
 import traceback
 import glob
 import getpass
+import ctypes
 from contextlib import contextmanager
 from multiprocessing import Process, Queue
 from sys import platform as _platform
@@ -120,6 +121,15 @@ barrier_timeout = 5
 """This is the lock timeout for expected failures.
 This may need to be higher for some filesystems."""
 lock_fail_timeout = 0.1
+
+
+def getuid(): 
+    if _platform == "win32":
+        if ctypes.windll.shell32.IsUserAnAdmin() == 0:
+            return 1
+        return 0
+    else:
+        return os.getuid()
 
 
 def make_readable(*paths):
@@ -635,7 +645,7 @@ def test_write_lock_timeout_with_multiple_readers_3_2_ranges(lock_path):
         TimeoutWrite(lock_path, 5, 1))
 
 
-@pytest.mark.skipif(_platform != 'win32' and os.getuid() == 0, reason='user is root')
+@pytest.mark.skipif(getuid() == 0, reason='user is root')
 def test_read_lock_on_read_only_lockfile(lock_dir, lock_path):
     """read-only directory, read-only lockfile."""
     touch(lock_path)
@@ -663,7 +673,7 @@ def test_read_lock_read_only_dir_writable_lockfile(lock_dir, lock_path):
             pass
 
 
-@pytest.mark.skipif(_platform == 'win32' or os.getuid() == 0, reason='user is root')
+@pytest.mark.skipif(_platform == 'win32' or getuid() == 0, reason='user is root')
 def test_read_lock_no_lockfile(lock_dir, lock_path):
     """read-only directory, no lockfile (so can't create)."""
     with read_only(lock_dir):

--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -11,7 +11,8 @@ import shutil
 import stat
 import tempfile
 import getpass
-
+import sys
+import ctypes
 import pytest
 
 from llnl.util.filesystem import mkdirp, partition_path, touch, working_dir
@@ -40,6 +41,15 @@ _readme_contents = 'hello world!\n'
 _include_readme = 1
 _include_hidden = 2
 _include_extra = 3
+
+
+def getuid(): 
+    if sys.platform == "win32":
+        if ctypes.windll.shell32.IsUserAnAdmin() == 0:
+            return 1
+        return 0
+    else:
+        return os.getuid()
 
 
 # Mock fetch directories are expected to appear as follows:
@@ -359,7 +369,7 @@ def check_stage_dir_perms(prefix, path):
 
     user = getpass.getuser()
     prefix_status = os.stat(prefix)
-    uid = os.getuid()
+    uid = getuid()
 
     # Obtain lists of ancestor and descendant paths of the $user node, if any.
     #
@@ -659,7 +669,7 @@ class TestStage(object):
         assert source_path.endswith(spack.stage._source_path_subdir)
         assert not os.path.exists(source_path)
 
-    @pytest.mark.skipif(os.getuid() == 0, reason='user is root')
+    @pytest.mark.skipif(getuid() == 0, reason='user is root')
     def test_first_accessible_path(self, tmpdir):
         """Test _first_accessible_path names."""
         spack_dir = tmpdir.join('paths')
@@ -755,7 +765,7 @@ class TestStage(object):
 
         # The following check depends on the patched os.stat as a poor
         # substitute for confirming the generated warnings.
-        assert os.stat(user_path).st_uid != os.getuid()
+        assert os.stat(user_path).st_uid != getuid()
 
     def test_resolve_paths(self):
         """Test _resolve_paths."""
@@ -790,7 +800,7 @@ class TestStage(object):
 
         assert spack.stage._resolve_paths(paths) == res_paths
 
-    @pytest.mark.skipif(os.getuid() == 0, reason='user is root')
+    @pytest.mark.skipif(getuid() == 0, reason='user is root')
     def test_get_stage_root_bad_path(self, clear_stage_root):
         """Ensure an invalid stage path root raises a StageError."""
         with spack.config.override('config:build_stage', '/no/such/path'):


### PR DESCRIPTION
Replace all instances where os.getuid() is used to determine if user is root with ctypes.windll.shell32.IsUserAnAdmin() for Windows