### PR TITLE
py-fenics-ufl: inclusion of version 2016.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-fenics-fiat/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-fiat/package.py
@@ -27,11 +27,8 @@ class PyFenicsFiat(PythonPackage):
     version('2017.2.0',       sha256='e4d3ffc86a0a717b3f17b9bb2d922214c342be27e5bdfbe50f110030bfff9729')
     version('2017.1.0.post1', sha256='1784fe1cb9479ca7cd85f63b0afa6e07634feec8d8e82fa8be4c480649cb9621')
     version('2017.1.0',       sha256='d4288401ad16c4598720f9db0810a522f7f0eadad35d8211bac7120bce5fde94')
-    version('2016.2.0', tag='fiat-2016.2.0')
 
     depends_on('python@3:', type=('build', 'run'))
     depends_on('py-setuptools', type="build")
     depends_on('py-numpy', type=("build", "run"))
-    depends_on('py-sympy', type=("build", "run"), when='@2019.1.0:')
-    # avoid compilation error of dolfin (ffc fails with latests sympy)
-    depends_on('py-sympy@1.0', type=("build", "run"), when='@:2018.1.0')
+    depends_on('py-sympy', type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-fenics-fiat/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-fiat/package.py
@@ -27,8 +27,11 @@ class PyFenicsFiat(PythonPackage):
     version('2017.2.0',       sha256='e4d3ffc86a0a717b3f17b9bb2d922214c342be27e5bdfbe50f110030bfff9729')
     version('2017.1.0.post1', sha256='1784fe1cb9479ca7cd85f63b0afa6e07634feec8d8e82fa8be4c480649cb9621')
     version('2017.1.0',       sha256='d4288401ad16c4598720f9db0810a522f7f0eadad35d8211bac7120bce5fde94')
+    version('2016.2.0', tag='fiat-2016.2.0')
 
     depends_on('python@3:', type=('build', 'run'))
     depends_on('py-setuptools', type="build")
     depends_on('py-numpy', type=("build", "run"))
-    depends_on('py-sympy', type=("build", "run"))
+    depends_on('py-sympy', type=("build", "run"), when='@2019.1.0:')
+    # avoid compilation error of dolfin (ffc fails with latests sympy)
+    depends_on('py-sympy@1.0', type=("build", "run"), when='@:2018.1.0')

--- a/var/spack/repos/builtin/packages/py-fenics-ufl/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-ufl/package.py
@@ -24,6 +24,7 @@ class PyFenicsUfl(PythonPackage):
     version('2017.2.0.post0', sha256='111e77707cd6731584b1041f405c2fd3f1752a86c51fd9c430524bd396f293b0')
     version('2017.2.0',       sha256='0adff7a511185b20c38ddaccdeed6c1b2ecafe4b163c688bfd1316d5c3b1c00d')
     version('2017.1.0.post1', sha256='82c8170f44c2392c7e60aa86495df22cc209af50735af8115dc35aeda4b0ca96')
+    version('2016.2.0', tag='ufl-2016.2.0')
 
     depends_on("python@3.5:", type=('build', 'run'))
     depends_on("py-setuptools", type="build")


### PR DESCRIPTION
Inclusion of UFL version `2016.2.0` for retro `dolfin` support.

Outsourced PR from [FEniCS 2019.1.0 PR.](https://github.com/spack/spack/pull/21207)