### PR TITLE
patches to apply when using oneapi compiler

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -30,6 +30,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     patch('gdbm.patch', when='%clang@11:')
     patch('gdbm.patch', when='%cce@11:')
     patch('gdbm.patch', when='%aocc@2:')
+    patch('gdbm.patch', when='%oneapi')
 
     def configure_args(self):
 

--- a/var/spack/repos/builtin/packages/m4/oneapi.patch
+++ b/var/spack/repos/builtin/packages/m4/oneapi.patch
@@ -1,0 +1,18 @@
+--- a/lib/xalloc-oversized.h	2020-08-07 11:04:56.154698639 -0700
++++ b/lib/xalloc-oversized.h	2020-08-07 11:06:11.667997389 -0700
+@@ -46,13 +46,13 @@
+    positive and N must be nonnegative.  This is a macro, not a
+    function, so that it works correctly even when SIZE_MAX < N.  */
+ 
+-#if 7 <= __GNUC__ || __has_builtin (__builtin_add_overflow_p)
++#if ((7 <= __GNUC__ || __has_builtin (__builtin_add_overflow_p)) && !defined __INTEL_LLVM_COMPILER)
+ # define xalloc_oversized(n, s) \
+    __builtin_mul_overflow_p (n, s, (__xalloc_count_type) 1)
+ #elif ((5 <= __GNUC__ \
+         || (__has_builtin (__builtin_mul_overflow) \
+             && __has_builtin (__builtin_constant_p))) \
+-       && !__STRICT_ANSI__)
++       && !__STRICT_ANSI__ && !defined __INTEL_LLVM_COMPILER)
+ # define xalloc_oversized(n, s) \
+    (__builtin_constant_p (n) && __builtin_constant_p (s) \
+     ? __xalloc_oversized (n, s) \

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -18,6 +18,7 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     patch('gnulib-pgi.patch', when='@1.4.18')
     patch('pgi.patch', when='@1.4.17')
     patch('nvhpc.patch', when='%nvhpc')
+    patch('oneapi.patch', when='%oneapi')
     # from: https://github.com/Homebrew/homebrew-core/blob/master/Formula/m4.rb
     # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
     patch('secure_snprintf.patch', when='os = highsierra')


### PR DESCRIPTION
m4 was failing with:

>   >> 647    /var/tmp/lee218/spack-stage/spack-stage-m4-1.4.18-yxi7rqp3sdmpprlgm
>             5dytbb3jkvtopbo/spack-src/lib/xalloc.h:107: undefined reference to 
>             `__muloti4'

gdbm was failing with:

> 
>      242    ./libgdbmapp.a(parseopt.o): In function `parseopt_first':
>      243    /tmp/lee218/spack-stage/spack-stage-gdbm-1.18.1-yhernq5c76uc2ikqsvy
>             vultbhs2xexkv/spack-src/src/parseopt.c:203: multiple definition of 
>             `parseopt_program_doc'
>      244    gdbmtool.o:/tmp/lee218/spack-stage/spack-stage-gdbm-1.18.1-yhernq5c
>             76uc2ikqsvyvultbhs2xexkv/spack-src/src/gdbmtool.c:821: first define
>             d here
>   >> 245    clang: error: linker command failed with exit code 1 (use -v to see
>              invocation)
