### PR TITLE
py-fenics-ffc: new package to support fenics

### DIFF
--- a/var/spack/repos/builtin/packages/py-fenics-ffc/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-ffc/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyFenicsFfc(PythonPackage):
+    """The FEniCS Form Compiler FFC is a compiler for finite element
+    variational forms, translating high-level mathematical descriptions
+    of variational forms into efficient low-level C++ code for finite
+    element assembly."""
+
+    homepage = "https://fenicsproject.org/"
+    git      = "https://bitbucket.org/fenics-project/ffc.git"
+    url      = "https://bitbucket.org/fenics-project/ffc/downloads/ffc-2019.1.0.post0.tar.gz"
+    maintainers = ['emai-imcs']
+
+    version('2019.1.0.post0', sha256='306e1179630200a34202975a5369194939b3482eebfc34bc44ad74dab1f109e8')
+    version('2018.1.0',       sha256='c5a6511693106d1cd2fc013148d0cd01cd1b99fc65dab461ca0b95851a9ea271')
+    version('2017.2.0.post0',       sha256='1969a5460cb866c478df64874ce213f81cb5c893b89f991a578e258b1a64fee5')
+    version('2016.2.0',       sha256='916c94c18047e1281d08e67c515aa1d4175320723609fbbfb0fc498ab4d41bb6')
+
+    depends_on('python@3.5:', type=('build', 'run'))
+
+    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+
+    for ver in ['2019.1.0.post0', '2018.1.0', '2017.2.0.post0', '2016.2.0']:
+        if ver in ['2019.1.0.post0', '2017.2.0.post0']:
+            ver = ver[:ver.rfind('.post')]
+        wver = '@' + ver
+        depends_on('py-fenics-fiat{0}'.format(wver), type=('build', 'run'), when=wver)
+        if(Version(ver) < Version('2018.1.0')):
+            depends_on('py-fenics-instant{0}'.format(wver), type=('build', 'run'), when=wver)
+        depends_on('py-fenics-ufl{0}'.format(wver), type=('build', 'run'), when=wver)


### PR DESCRIPTION
New package, required to support the FEniCS 2018 and 2019 versions in the `fenics` package.

Predecessor of `py-fenics-ffcx` package (used for `fenics-dolfinx`).

Outsourced PR from [FEniCS 2019.1.0 PR.](https://github.com/spack/spack/pull/21207)