### PR TITLE
make oneapi ifx version_regex tolerant to wrappers

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -29,7 +29,7 @@ class Oneapi(Compiler):
     PrgEnv_compiler = 'oneapi'
 
     version_argument = '--version'
-    version_regex = r'(?:(?:oneAPI DPC\+\+ Compiler)|(?:ifx \(IFORT\))) (\S+)'
+    version_regex = r'(?:(?:oneAPI DPC\+\+ Compiler)|(?:\(IFORT\))) (\S+)'
 
     @property
     def verbose_flag(self):


### PR DESCRIPTION
We wrap our ifx compiler, such that the original binary is renamed ifx_orig. This causes the `ifx --version` command to produce:

$ ifx --version
ifx_orig (IFORT) 2021.1 Beta 20201113
Copyright (C) 1985-2020 Intel Corporation. All rights reserved.

The regex for ifx currently expects the output to begin with "ifx (IFORT)..." I think in general, the Intel compiler regexes do not include the invoked executable name (i.e., ifort, icc, icx, etc.), so I think this PR would make ifx more consistent in that sense.