### PR TITLE
ctpl: add dependency

### DIFF
--- a/var/spack/repos/builtin/packages/ctpl/package.py
+++ b/var/spack/repos/builtin/packages/ctpl/package.py
@@ -19,6 +19,7 @@ class Ctpl(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('gettext',  type='build')
     depends_on('gtk-doc')
     depends_on('glib@2.10:')
 


### PR DESCRIPTION
`ctpl` should depend on `gettext` to avoid this issue:

![image](https://user-images.githubusercontent.com/29532367/108303032-18f11d80-71e0-11eb-84b1-315a1c21b9b0.png)
