### PR TITLE
vcsh: add bin as a directory

### DIFF
--- a/var/spack/repos/builtin/packages/vcsh/package.py
+++ b/var/spack/repos/builtin/packages/vcsh/package.py
@@ -22,4 +22,5 @@ class Vcsh(Package):
 
     # vcsh provides a makefile, if needed the install method should be adapted
     def install(self, spec, prefix):
+        mkdirp(prefix.bin)
         install('vcsh', prefix.bin)


### PR DESCRIPTION
There's no bin directory when `install` `vcsh`, so we need make a dir to avoid `vcsh` binary become a `bin` binary file.