### PR TITLE
kbd: fix dependencies and config phase

### DIFF
--- a/var/spack/repos/builtin/packages/kbd/package.py
+++ b/var/spack/repos/builtin/packages/kbd/package.py
@@ -22,4 +22,15 @@ class Kbd(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('gettext',  type='build')
+    depends_on('yacc',     type='build')
+    depends_on('flex',     type='build')
     depends_on('libpam')
+
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./autogen.sh')
+
+    def configure_args(self):
+        args = ['--with-libintl-prefix={0}'.format(self.spec['gettext'].prefix)]
+        return args


### PR DESCRIPTION
kbd build failed on `SUSE`:
```
==> kbd: Executing phase: 'autoreconf'
==> [2020-12-12-15:55:19.457350] Configure script not found: trying to generate it
==> [2020-12-12-15:55:19.457501] Warning: *********************************************************
==> [2020-12-12-15:55:19.457555] Warning: * If the default procedure fails, consider implementing *
==> [2020-12-12-15:55:19.457596] Warning: *        a custom AUTORECONF phase in the package       *
==> [2020-12-12-15:55:19.457634] Warning: *********************************************************
==> [2020-12-12-15:55:19.458326] '/home/spack-develop/opt/spack/linux-sles15-aarch64/gcc-7.4.0/autoconf-2.69-jg44afikddsjy7thn23jcaq3are2sk5t/bin/autoreconf' '-ivf' '-I' '/home/spack-develop/opt/spack/linux-sles15-aarch64/gcc-7.4.0/automake-1.16.2-4wmfdqjqd7upy7my3evelquksrvmlezw/share/aclocal' '-I' '/home/spack-develop/opt/spack/linux-sles15-aarch64/gcc-7.4.0/libtool-2.4.6-642gizlyjpkvm56odjurf34f2hfrcmxx/share/aclocal'
autoreconf: Entering directory `.'
autoreconf: running: autopoint --force
Can't exec "autopoint": No such file or directory at /home/spack-develop/opt/spack/linux-sles15-aarch64/gcc-7.4.0/autoconf-2.69-jg44afikddsjy7thn23jcaq3are2sk5t/share/autoconf/Autom4te/FileUtils.pm line 345.
autoreconf: failed to run autopoint: No such file or directory
autoreconf: autopoint is needed because this package uses Gettext
```

And it need run `autogen.sh` in `SUSE`.