### PR TITLE
openfst: fix conflicts version for gcc

### DIFF
--- a/var/spack/repos/builtin/packages/openfst/package.py
+++ b/var/spack/repos/builtin/packages/openfst/package.py
@@ -31,7 +31,7 @@ class Openfst(AutotoolsPackage):
     version('1.4.0',  sha256='eb557f37560438f03912b4e43335c4c9e72aa486d4f2046127131185eb88f17a')
 
     conflicts('%intel@16:')
-    conflicts('%gcc@6:', when='@:1.6.7')
+    conflicts('%gcc@6:', when='@:1.6.1')
 
     variant('far', default=False, description="Enable FAR support")
 


### PR DESCRIPTION
I think I made a mistake on that patch:
```
commit 52858be668f44eb29ca9e40495fb4d11aa3509de
Author: darmac <xiaojun2@hisilicon.com>
Date:   Sun Aug 2 00:41:12 2020 +0800

    Openfst: upgrade version and gcc constraint (#17830)
    
    * openfst: upgrade version and gcc constraint
    
    * refine version format
```

openfst@1.6.7 looks like having no conflict on `gcc@6:`