### PR TITLE
bugfix: relax racy test in fg/bg output

### DIFF
--- a/lib/spack/spack/test/llnl/util/tty/log.py
+++ b/lib/spack/spack/test/llnl/util/tty/log.py
@@ -437,20 +437,14 @@ def test_foreground_background_output(
     with open(log_path) as log:
         log = log.read().strip().split("\n")
 
-    # Controller and minion process coordinate with locks such that the minion
-    # writes "off" when echo is off, and "on" when echo is on.  The
-    # output should contain mostly "on" lines, but may contain an "off"
-    # or two. This is because the controller toggles echo by sending "v" on
-    # stdin to the minion, but this is not synchronized with our locks.
-    # It's good enough for a test, though.  We allow at most 4 "off"'s in
-    # the output to account for the race.
-    #
-    # Originally we only allowed 2, but GitHub's macOS runners seem to be
-    # very slow, and frequently we get 3 "off"'s. Increased limit to 4 to
-    # account for this. Real errors should still be caught with this limit.
+    # Controller and minion process coordinate with locks such that the
+    # minion writes "off" when echo is off, and "on" when echo is on. The
+    # output should contain mostly "on" lines, but may contain "off"
+    # lines if the controller is slow. The important thing to observe
+    # here is that we started seeing 'on' in the end.
     assert (
         ['forced output', 'on'] == uniq(output) or
-        output.count("off") <= 4  # if controller_fd is a bit slow
+        ['forced output', 'off', 'on'] == uniq(output)
     )
 
     # log should be off for a while, then on, then off


### PR DESCRIPTION
Since signals are fundamentally racy, We can't bound the amount of time that the `test_foreground_background_output` test will take to get to 'on', we can only observe that it transitions to 'on'. So instead of using an arbitrary limit, just adjust the test to allow either 'on', or 'off' followed by 'on'.

This should eliminate the spurious errors we see in CI (for example, [here](https://github.com/spack/spack/runs/1923243564?check_suite_focus=true)).