### PR TITLE
Documentation fix: for #21760

### DIFF
--- a/lib/spack/docs/build_systems/rpackage.rst
+++ b/lib/spack/docs/build_systems/rpackage.rst
@@ -297,8 +297,8 @@ like so:
 
 .. code-block:: python
 
-   def configure_args(self, spec, prefix):
-       mpi_name = spec['mpi'].name
+   def configure_args(self):
+       mpi_name = self.spec['mpi'].name
 
        # The type of MPI. Supported values are:
        # OPENMPI, LAM, MPICH, MPICH2, or CRAY


### PR DESCRIPTION
Corrects the signature for configure_args (and therefore configure_vars)
in documentation on RPackage build system to match the code
See issue #21760