### PR TITLE
[WIP] Introduce directive 'requires' (negative 'conflicts')

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -18,6 +18,7 @@ definition to modify the package, for example:
 The available directives are:
 
   * ``conflicts``
+  * ``requires``
   * ``depends_on``
   * ``extends``
   * ``patch``
@@ -369,6 +370,15 @@ def conflicts(conflict_spec, when=None, msg=None):
         when (Spec): optional constraint that triggers the conflict
         msg (str): optional user defined message
     """
+    return _conflicts(conflict_spec, when, msg, False)
+
+
+@directive('requires')
+def requires(conflict_spec, when=None, msg=None):
+    return _conflicts(conflict_spec, when, msg, True)
+
+
+def _conflicts(conflict_spec, when, msg, negate):
     def _execute_conflicts(pkg):
         # If when is not specified the conflict always holds
         when_spec = make_when_spec(when)
@@ -377,7 +387,7 @@ def conflicts(conflict_spec, when=None, msg=None):
 
         # Save in a list the conflicts and the associated custom messages
         when_spec_list = pkg.conflicts.setdefault(conflict_spec, [])
-        when_spec_list.append((when_spec, msg))
+        when_spec_list.append((when_spec, msg, negate))
     return _execute_conflicts
 
 


### PR DESCRIPTION
This is mainly a feature request with an example of how it can be implemented. I will write tests and update the documentation if there is a decision that this is the way to go.

There are at least two cases when the existing `conflicts` directive is not expressive enough:
1. There are packages (e.g. Linux kernel modules) that must be built with `%gcc`. A way to express this restriction is to specify multiple `conflicts` directives:
    https://github.com/spack/spack/blob/3364e5550ffa7f4af1728ae3b97d2be5781041a3/var/spack/repos/builtin/packages/knem/package.py#L45-L49
    This PR introduces the following alternative:
    ```python
    requires('%gcc', msg='Linux kernel module must be compiled with gcc')
    ```
    ```console
    $ spack spec somepackage%intel
    ==> Error: Conflicts in concretized spec ...
    ...
    1. "somepackage" requires "%gcc" [Linux kernel module must be compiled with gcc]
    ```
2. Say, we have a package with two variants:
    ```python
    variant('var1', default=False)
    variant('var2', multi=True, default='none', values=('none', 'A', 'B', 'C', 'D'))
    ```
    It looks like there is currently no way to specify a conflict `+var1` when `'B' not in var2`. I asked about this in Slack and @becker33 suggested this:
    ```python
    var2_options_no_enable_var1 = ('A', 'C', 'D')
    combinations = itertools.chain.from_iterable(itertools.combinations(var2_options_no_enable_var1, r) for r in range(len(var2_options_no_enable_var1) + 1))
    conflict_variants = map(lambda x: 'none' if not x else ','.join(x), combinations)
    for var in conflict_variants:
        conflicts(+var2, when=var)
    ```
    The code doesn't work for me as is, so I did not manage to test this solution:
    ```console
    ==> Error: name 'var2_options_no_enable_var1' is not defined
    ```
    Anyway, the alternative could be:
    ```python
    requires('var2=B', when='+var1')
    ```
    ```console
    $ spack spec somepackage+var1
    ==> Error: Conflicts in concretized spec ...
    ...
    1. "somepackage+var1" requires "var2=B"
    ```