### PR TITLE
CGNS: set parallel build to False to fix cp error

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -16,6 +16,8 @@ class Cgns(CMakePackage):
     url      = "https://github.com/CGNS/CGNS/archive/v3.3.0.tar.gz"
     git      = "https://github.com/CGNS/CGNS"
 
+    parallel = False
+
     version('develop', branch='develop')
     version('master',  branch='master')
     version('4.1.1',   sha256='055d345c3569df3ae832fb2611cd7e0bc61d56da41b2be1533407e949581e226')


### PR DESCRIPTION
When building CGNS with 4 cores, the following error was some times encountered:

```
[ 12%] Building C object src/CMakeFiles/cgns_shared.dir/cgns_io.c.o
cd /tmp/bherman/spack-stage/spack-stage-cgns-4.1.1-e6lye4cpaks5oz2mo57qolnu4u5s4m7v/spack-build-e6lye4c/src && /opt/spack/install/linux-centos7-x86_64/gcc-10.2.0/openmpi-3.1.6-bjtbd4j4/bin/mpicc -DH5_BUILT_AS_STATIC_LIB -Dcgns_shared_EXPORTS -I/tmp/bherman/spack-stage/spack-stage-cgns-4.1.1-e6lye4cpaks5oz2mo57qolnu4u5s4m7v/spack-build-e6lye4c/src -I/tmp/bherman/spack-stage/spack-stage-cgns-4.1.1-e6lye4cpaks5oz2mo57qolnu4u5s4m7v/spack-src/src -I/opt/spack/install/linux-centos7-x86_64/gcc-10.2.0/hdf5-1.10.7-eegw7wms/include -I/opt/spack/install/linux-centos7-x86_64/gcc-10.2.0/zlib-1.2.11-apt6zkja/include -I/opt/spack/install/linux-centos7-x86_64/gcc-10.2.0/libszip-2.1.1-hrholadp/include -O2 -g -DNDEBUG -fPIC -o CMakeFiles/cgns_shared.dir/cgns_io.c.o -c /tmp/bherman/spack-stage/spack-stage-cgns-4.1.1-e6lye4cpaks5oz2mo57qolnu4u5s4m7v/spack-src/src/cgns_io.c
f951: Fatal Error: Cannot rename module file 'cgns.mod0' to 'cgns.mod': No such file or directory
compilation terminated.
```

There is likely an issue in the way CMake is being leveraged resulting in a race condition. Instead of digging into CGNS's CMake process, setting ``parallel = False`` fixes the problem in the short term. The package does not take too long to build on a single core.