### PR TITLE
flibcpp: Activate SWIG rebuild when +swig

### DIFF
--- a/var/spack/repos/builtin/packages/flibcpp/package.py
+++ b/var/spack/repos/builtin/packages/flibcpp/package.py
@@ -44,6 +44,7 @@ class Flibcpp(CMakePackage):
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             self.define_from_variant('FLIBCPP_BUILD_DOCS', 'doc'),
             self.define_from_variant('FLIBCPP_FORTRAN_STD', 'fstd'),
+            self.define_from_variant('FLIBCPP_USE_SWIG', 'swig'),
             self.define('FLIBCPP_BUILD_TESTS', bool(self.run_tests)),
             self.define('FLIBCPP_BUILD_EXAMPLES', bool(self.run_tests)),
         ]


### PR DESCRIPTION
This option allows downstream packages to build with SWIG and the flibcpp-exported SWIG interfaces.