### PR TITLE
openblas: +locking

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -29,8 +29,13 @@ class Blaspp(CMakePackage, CudaPackage):
     depends_on('cmake@3.15.0:', type='build')
     depends_on('blas')
 
+    # only supported with clingo solver: virtual dependency preferences
+    # depends_on('openblas threads=openmp', when='+openmp ^openblas')
+
     # BLASpp tests will fail when using openblas > 0.3.5 without multithreading support
-    conflicts('^openblas@0.3.6: threads=none', msg='BLASpp requires openblas multithreading support')
+    # locking is only supported in openblas 3.7+
+    conflicts('^openblas@0.3.6 threads=none', msg='BLASpp requires a threadsafe openblas')
+    conflicts('^openblas@0.3.7: ~locking', msg='BLASpp requires a threadsafe openblas')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
BlasPP by ECP SLATE will fail to install by default (`spack install blaspp`) because
- the default BLAS installation in Spack is OpenBLAS
- BlasPP conflicts with `threads=none` for all recent OpenBLAS releases

Luckily, for OpenBLAS itself introduced a threadsafe compile option with 0.3.7+ aka `USE_LOCKING`:
```
   61 # If you want to build a single-threaded OpenBLAS, but expect to call this
   62 # from several concurrent threads in some other program, comment this in for
   63 # thread safety. (This is done automatically for USE_THREAD=1 , and should not
   64 # be necessary when USE_OPENMP=1)
   65 # USE_LOCKING = 1
```

According to my tests, with `spack install --test root blaspp`, this exactly addresses the issues in BlasPP tests.

It also seems to be a good option to set by default for OpenBLAS and users that do not need this safety net can always disable it.

cc @G-Ragghianti @mgates3

Follow-up to #20956