### PR TITLE
hdf-eos2: Del szip

### DIFF
--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -92,8 +92,5 @@ class HdfEos2(AutotoolsPackage):
         if self.spec['zlib']:
             extra_args.append('--with-zlib={0}'.format(
                 self.spec['zlib'].prefix))
-        if self.spec['szip']:
-            extra_args.append('--with-szlib={0}'.format(
-                self.spec['szip'].prefix))
 
         return extra_args


### PR DESCRIPTION
I have detected the following error on x86_64 and aarch64 machines:
==> Error: KeyError: 'No spec with name szip in hdf-eos2
./spack/var/spack/repos/builtin/packages/hdf-eos2/package.py:96, in configure_args:
         93        if self.spec['zlib']:
         94            extra_args.append('--with-zlib={0}'.format(
         95                self.spec['zlib'].prefix))
         96        if self.spec['szip']:
         97            extra_args.append('--with-szlib={0}'.format(
         98                self.spec['szip'].prefix))

This issue was resolved by adding szip's depends_on, but then I got the following error:
1 error found in build log:
     123    checking mfhdf.h presence... yes
     124    checking for mfhdf.h... yes
     125    checking for main in -ldf... yes
     126    checking for main in -lmfhdf... yes
     127    checking for hdf4 szip decoding filter... no
     128    checking for hdf4 szip encoding filter... no
     129    configure: error: HDF4 was linked without SZIP, but --with-szlib was given

I don't think it is necessary to specify --with-szlib from this error.

To build this OSS, you need PR for #21587 and #19837.
