### PR TITLE
hdf-eos5: Fix hdf5 depend, Del szip

### DIFF
--- a/var/spack/repos/builtin/packages/hdf-eos5/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos5/package.py
@@ -47,7 +47,7 @@ class HdfEos5(AutotoolsPackage):
               msg='At least one of +static or +shared must be set')
 
     # Build dependencies
-    depends_on('hdf5')
+    depends_on('hdf5+hl')
 
     # The standard Makefile.am, etc. add a --single_module flag to LDFLAGS
     # to pass to the linker.
@@ -95,8 +95,5 @@ class HdfEos5(AutotoolsPackage):
         if self.spec['zlib']:
             extra_args.append('--with-zlib={0}'.format(
                 self.spec['zlib'].prefix))
-        if self.spec['szip']:
-            extra_args.append('--with-szlib={0}'.format(
-                self.spec['szip'].prefix))
 
         return extra_args


### PR DESCRIPTION
I have detected the following error on x86_64 and aarch64 machines:
==> Error: KeyError: 'No spec with name szip in hdf-eos5
./spack/var/spack/repos/builtin/packages/hdf-eos2/package.py:96, in configure_args:
         93        if self.spec['zlib']:
         94            extra_args.append('--with-zlib={0}'.format(
         95                self.spec['zlib'].prefix))
         96        if self.spec['szip']:
         97            extra_args.append('--with-szlib={0}'.format(
         98                self.spec['szip'].prefix))

This issue was resolved by adding szip's depends_on, but then I got the following error:
     120    checking for hdf5.h... yes
     121    checking for H5Fcreate in -lhdf5... no
     122    configure: error: can't link against HDF5 library

This issue was resolved by fixing the hdf5 depend, but I got the following error:
1 error found in build log:
     115    checking hdf5.h presence... yes
     116    checking for hdf5.h... yes
     117    checking for H5Fcreate in -lhdf5... yes
     118    checking if HDF5 threadsafe mode is enabled... no
     119    checking for hdf5 szip decoding filter... no
     120    checking for hdf5 szip encoding filter... no
     121    configure: error: HDF5 was linked without SZIP, but --with-szlib was given

I don't think it is necessary to specify --with-szlib from this error.

To build this OSS, you need PR for #19837.