### PR TITLE
environment-modules: add version 4.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -10,10 +10,11 @@ class EnvironmentModules(Package):
     """
 
     homepage = 'https://cea-hpc.github.io/modules/'
-    url = 'https://github.com/cea-hpc/modules/releases/download/v4.6.1/modules-4.6.1.tar.gz'
+    url = 'https://github.com/cea-hpc/modules/releases/download/v4.7.0/modules-4.7.0.tar.gz'
 
     maintainers = ['xdelaruelle']
 
+    version('4.7.0', sha256='3ab0a649e23b4dd00963e4cae60e573b449194ecb4035c5ce487330b272b4d06')
     version('4.6.1', sha256='3445df39abe5838b94552b53e7dbff56ada8347b9fdc6c04a72297d5b04af76f')
     version('4.6.0', sha256='b42b14bb696bf1075ade1ecaefe7735dbe411db4c29031a1dae549435eafa946')
     version('4.5.3', sha256='7cbd9c61e6dcd82a3f81b5ced92c3cf84ecc5489639bdfc94869256383a2c915')


### PR DESCRIPTION
New feature release in the v4 series.

Major new features included: https://modules.readthedocs.io/en/stable/MIGRATING.html#from-v4-6-to-v4-7