### PR TITLE
asciidoc: sourceforge a2x needs python2, adds more recent for py3

### DIFF
--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -16,19 +16,20 @@ class Asciidoc(AutotoolsPackage):
     git      = "https://github.com/asciidoc-py/asciidoc-py.git"
 
     version('master', branch='master')
-    version('9.1.0', sha256='5056c20157349f8dc74f005b6e88ccbf1078c4e26068876f13ca3d1d7d045fe7')
-    version('9.0.5', sha256='edc8328c3682a8568172656f6fc309b189f65219a49517966c7ea144cb25f8b2')
-    version('9.0.4', sha256='fb0e683ae6a4baf34a8969c3af764ca729526196576729ee9275b9f39fd8b79c')
-    version('9.0.3', sha256='b6ef4accd7959f51b532ab4d3aaa211e15f18fd544c4c3cc3ed712f5590a50de')
-    version('9.0.2', sha256='93fbe32d56380afee2f26389d8ebfdf33de72536449d53308120d3c20d2c1e17')
-    version('8.6.9', sha256='45e95bed1e341980f7de0a66fdc467090956fe55d4625bdad8057cd926e0c6c6')
+    version('9.1.0',  sha256='5056c20157349f8dc74f005b6e88ccbf1078c4e26068876f13ca3d1d7d045fe7')
+    version('9.0.5',  sha256='edc8328c3682a8568172656f6fc309b189f65219a49517966c7ea144cb25f8b2')
+    version('9.0.4',  sha256='fb0e683ae6a4baf34a8969c3af764ca729526196576729ee9275b9f39fd8b79c')
+    version('9.0.3',  sha256='b6ef4accd7959f51b532ab4d3aaa211e15f18fd544c4c3cc3ed712f5590a50de')
+    version('9.0.2',  sha256='93fbe32d56380afee2f26389d8ebfdf33de72536449d53308120d3c20d2c1e17')
+    version('8.6.10', sha256='22d6793d4f48cefb4a6963853212a214591a591ece1bcbc56af3c67c642003ea')
+    version('8.6.9',  sha256='45e95bed1e341980f7de0a66fdc467090956fe55d4625bdad8057cd926e0c6c6')
 
     depends_on('libxml2',     type=('build', 'run'))
     depends_on('libxslt',     type=('build', 'run'))
     depends_on('docbook-xml', type=('build', 'run'))
     depends_on('docbook-xsl', type=('build', 'run'))
-    depends_on('python@2.3.0:2.7.99', when='@:8.6.9')
-    depends_on('python@3.5:',         when='@9.0.2:')
+    depends_on('python@2.3.0:2.7.99', when='@:8.6.9', type=('build', 'run'))
+    depends_on('python@3.5:',         when='@9.0.2:', type=('build', 'run'))
 
     @when('@:8.6.9')
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -19,6 +19,7 @@ class Asciidoc(AutotoolsPackage):
     version('master', branch='master')
     version('9.1.0', sha256='fd499fcf51317b1aaf27336fb5e919c44c1f867f1ae6681ee197365d3065238b')
     version('9.0.5', sha256='edc8328c3682a8568172656f6fc309b189f65219a49517966c7ea144cb25f8b2')
+    version('9.0.4', sha256='400368a43f3eee656d7f197382cd3554b50fb370ef2aea6534f431692a356c66')
     version('9.0.3', sha256='d99c8be8e8a9232742253c2d87c547b2efd4bbd3f0c1e23ef14898ad0fff77c4')
     version('9.0.2', sha256='185fd68e47034c4dd892e1d4ae64c81152bc049e9bdc7d1ad63f927d35810a3b')
     version('8.6.9', sha256='78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0')
@@ -27,7 +28,7 @@ class Asciidoc(AutotoolsPackage):
     depends_on('libxslt',     type=('build', 'run'))
     depends_on('docbook-xml', type=('build', 'run'))
     depends_on('docbook-xsl', type=('build', 'run'))
-    depends_on('python@2.7.0:2.7.99', when='@:8.6.9')
+    depends_on('python@2.3.0:2.7.99', when='@:8.6.9')
     depends_on('python@3.5:',         when='@9.0.2:')
 
     def url_for_version(self, version):
@@ -41,7 +42,7 @@ class Asciidoc(AutotoolsPackage):
     @when('@:8.6.9')
     def install(self, spec, prefix):
         # Old release demands python2
-        python = which('python2.7')
+        python = which(spec['python'].command.path)
         if os.path.isfile(str(python)):
             exes = ['asciidoc', 'a2x']
             for exe in exes:

--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class Asciidoc(AutotoolsPackage):
@@ -11,11 +12,35 @@ class Asciidoc(AutotoolsPackage):
     pages and other small to medium sized documents."""
 
     homepage = "http://asciidoc.org"
-    url      = "http://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz"
+    # Always working URL but strangely with another checksum
+    url      = "https://github.com/asciidoc-py/asciidoc-py/archive/8.6.10.tar.gz"
+    git      = "https://github.com/asciidoc-py/asciidoc-py.git"
 
+    version('master', branch='master')
+    version('9.1.0', sha256='fd499fcf51317b1aaf27336fb5e919c44c1f867f1ae6681ee197365d3065238b')
     version('8.6.9', sha256='78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0')
 
     depends_on('libxml2')
     depends_on('libxslt')
     depends_on('docbook-xml')
     depends_on('docbook-xsl')
+    depends_on('python@2.7.0:2.7.99', when='@:8.6.9')
+
+    def url_for_version(self, version):
+        if version > Version('8.6.9'):
+            url = "https://github.com/asciidoc-py/asciidoc-py/releases/download/{0}/asciidoc-{0}.tar.gz"
+        else:
+            url = "http://downloads.sourceforge.net/project/asciidoc/asciidoc/{0}/asciidoc-{0}.tar.gz"
+
+        return url.format(version)
+
+    @when('@:8.6.9')
+    def install(self, spec, prefix):
+        # Old release demands python2
+        python = which('python2.7')
+        if os.path.isfile(str(python)):
+            exes = ['asciidoc', 'a2x']
+            for exe in exes:
+                fthfile = FileFilter(exe + '.py')
+                fthfile.filter('#!/usr/bin/env python', '#!/usr/bin/env python2.7')
+        make('install')

--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -42,10 +42,11 @@ class Asciidoc(AutotoolsPackage):
     @when('@:8.6.9')
     def install(self, spec, prefix):
         # Old release demands python2
-        python = which(spec['python'].command.path)
-        if os.path.isfile(str(python)):
+        mpythpath = spec['python'].command.path
+        if os.path.isfile(mpythpath):
             exes = ['asciidoc', 'a2x']
             for exe in exes:
                 fthfile = FileFilter(exe + '.py')
-                fthfile.filter('#!/usr/bin/env python', '#!/usr/bin/env python2.7')
-        make('install')
+                fthfile.filter('#!/usr/bin/env python', '#!' + mpythpath)
+
+            make('install')

--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class Asciidoc(AutotoolsPackage):
@@ -43,10 +42,9 @@ class Asciidoc(AutotoolsPackage):
     def install(self, spec, prefix):
         # Old release demands python2
         mpythpath = spec['python'].command.path
-        if os.path.isfile(mpythpath):
-            exes = ['asciidoc', 'a2x']
-            for exe in exes:
-                fthfile = FileFilter(exe + '.py')
-                fthfile.filter('#!/usr/bin/env python', '#!' + mpythpath)
+        exes = ['asciidoc', 'a2x']
+        for exe in exes:
+            fthfile = FileFilter(exe + '.py')
+            fthfile.filter('#!/usr/bin/env python', '#!' + mpythpath)
 
-            make('install')
+        make('install')

--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -18,13 +18,17 @@ class Asciidoc(AutotoolsPackage):
 
     version('master', branch='master')
     version('9.1.0', sha256='fd499fcf51317b1aaf27336fb5e919c44c1f867f1ae6681ee197365d3065238b')
+    version('9.0.5', sha256='edc8328c3682a8568172656f6fc309b189f65219a49517966c7ea144cb25f8b2')
+    version('9.0.3', sha256='d99c8be8e8a9232742253c2d87c547b2efd4bbd3f0c1e23ef14898ad0fff77c4')
+    version('9.0.2', sha256='185fd68e47034c4dd892e1d4ae64c81152bc049e9bdc7d1ad63f927d35810a3b')
     version('8.6.9', sha256='78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0')
 
-    depends_on('libxml2')
-    depends_on('libxslt')
-    depends_on('docbook-xml')
-    depends_on('docbook-xsl')
+    depends_on('libxml2',     type=('build', 'run'))
+    depends_on('libxslt',     type=('build', 'run'))
+    depends_on('docbook-xml', type=('build', 'run'))
+    depends_on('docbook-xsl', type=('build', 'run'))
     depends_on('python@2.7.0:2.7.99', when='@:8.6.9')
+    depends_on('python@3.5:',         when='@9.0.2:')
 
     def url_for_version(self, version):
         if version > Version('8.6.9'):

--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -16,12 +16,12 @@ class Asciidoc(AutotoolsPackage):
     git      = "https://github.com/asciidoc-py/asciidoc-py.git"
 
     version('master', branch='master')
-    version('9.1.0', sha256='fd499fcf51317b1aaf27336fb5e919c44c1f867f1ae6681ee197365d3065238b')
+    version('9.1.0', sha256='5056c20157349f8dc74f005b6e88ccbf1078c4e26068876f13ca3d1d7d045fe7')
     version('9.0.5', sha256='edc8328c3682a8568172656f6fc309b189f65219a49517966c7ea144cb25f8b2')
-    version('9.0.4', sha256='400368a43f3eee656d7f197382cd3554b50fb370ef2aea6534f431692a356c66')
-    version('9.0.3', sha256='d99c8be8e8a9232742253c2d87c547b2efd4bbd3f0c1e23ef14898ad0fff77c4')
-    version('9.0.2', sha256='185fd68e47034c4dd892e1d4ae64c81152bc049e9bdc7d1ad63f927d35810a3b')
-    version('8.6.9', sha256='78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0')
+    version('9.0.4', sha256='fb0e683ae6a4baf34a8969c3af764ca729526196576729ee9275b9f39fd8b79c')
+    version('9.0.3', sha256='b6ef4accd7959f51b532ab4d3aaa211e15f18fd544c4c3cc3ed712f5590a50de')
+    version('9.0.2', sha256='93fbe32d56380afee2f26389d8ebfdf33de72536449d53308120d3c20d2c1e17')
+    version('8.6.9', sha256='45e95bed1e341980f7de0a66fdc467090956fe55d4625bdad8057cd926e0c6c6')
 
     depends_on('libxml2',     type=('build', 'run'))
     depends_on('libxslt',     type=('build', 'run'))
@@ -29,14 +29,6 @@ class Asciidoc(AutotoolsPackage):
     depends_on('docbook-xsl', type=('build', 'run'))
     depends_on('python@2.3.0:2.7.99', when='@:8.6.9')
     depends_on('python@3.5:',         when='@9.0.2:')
-
-    def url_for_version(self, version):
-        if version > Version('8.6.9'):
-            url = "https://github.com/asciidoc-py/asciidoc-py/releases/download/{0}/asciidoc-{0}.tar.gz"
-        else:
-            url = "http://downloads.sourceforge.net/project/asciidoc/asciidoc/{0}/asciidoc-{0}.tar.gz"
-
-        return url.format(version)
 
     @when('@:8.6.9')
     def install(self, spec, prefix):


### PR DESCRIPTION
Current asciidoc package provides the sourceforge version 8.6.9 made for python2, we add the github location for release 9.1.0
that is made for python3. It is important to make asccidoc@8.6.9 depend on python2, not python.
It could be merged with asciidoc-py3 which is also based on 9 series, although it is not yet updated.