### PR TITLE
harfbuzz: allows compilation standard being set properly for gcc

### DIFF
--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -40,12 +40,21 @@ class Harfbuzz(AutotoolsPackage):
 
         return url.format(version)
 
+    # Function borrowed from superlu
+    def flag_handler(self, name, flags):
+        flags = list(flags)
+        if name == 'cxxflags':
+            flags.append(self.compiler.cxx11_flag)
+        if name == 'cflags':
+            if '%pgi' not in self.spec and self.spec.satisfies('%gcc@:5.1'):
+                flags.append('-std=gnu99')
+        return (None, None, flags)
+
     def configure_args(self):
         args = []
         # disable building of gtk-doc files following #9771
         args.append('--disable-gtk-doc-html')
         true = which('true')
-        args.append('CXXFLAGS={0}'.format(self.compiler.cxx11_flag))
         args.append('GTKDOC_CHECK={0}'.format(true))
         args.append('GTKDOC_CHECK_PATH={0}'.format(true))
         args.append('GTKDOC_MKPDF={0}'.format(true))


### PR DESCRIPTION
Package could not compile with gcc 9.3.0 CentOS 7.7 with message:
==> Error: JSONDecodeError: Expecting value: line 1 column 1 (char 0)
  >>     48        args.append('CXXFLAGS={0}'.format(self.compiler.cxx11_flag))
We now use flag_handler as in package superlu so that CXXFLAGS is set before, and cflags to -std=gnu99
as MAP_ANON error was related to it -std=c99 for older versions of gcc as stated in package libflame.
With this correction, package 'mapnik' now compiles with gcc 9.* compilers.