### PR TITLE
Improve error message for inconsistencies in package.py

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1098,3 +1098,15 @@ class TestConcretize(object):
         # dependency type declared to infer that the dependency holds.
         s = Spec('test-dep-with-imposed-conditions').concretized()
         assert 'c' not in s
+
+    @pytest.mark.parametrize('spec_str', [
+        'wrong-variant-in-conflicts',
+        'wrong-variant-in-depends-on'
+    ])
+    def test_error_message_for_inconsistent_variants(self, spec_str):
+        if spack.config.get('config:concretizer') == 'original':
+            pytest.xfail('Known failure of the original concretizer')
+
+        s = Spec(spec_str)
+        with pytest.raises(RuntimeError, match='not found in package'):
+            s.concretize()

--- a/var/spack/repos/builtin.mock/packages/wrong-variant-in-conflicts/package.py
+++ b/var/spack/repos/builtin.mock/packages/wrong-variant-in-conflicts/package.py
@@ -1,0 +1,13 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class WrongVariantInConflicts(Package):
+    """This package has a wrong variant spelled in a conflict."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/b-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    conflicts('+foo', when='@1.0')

--- a/var/spack/repos/builtin.mock/packages/wrong-variant-in-depends-on/package.py
+++ b/var/spack/repos/builtin.mock/packages/wrong-variant-in-depends-on/package.py
@@ -1,0 +1,13 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class WrongVariantInDependsOn(Package):
+    """This package has a wrong variant spelled in a depends_on."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/b-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    depends_on('b+doesnotexist')


### PR DESCRIPTION
refers to https://github.com/spack/spack/pull/21787#issuecomment-781920135

Sometimes directives refer to variants that do not exist. Make it such that:

1. The name of the variant
2. The name of the package which is supposed to have such variant
3. The name of the package making this assumption

are all printed in the error message for easier debugging.

**Before this PR**
```console
% spack solve warpx
==> Error: 'pic'
```

**After this PR**
```console
% spack solve warpx
==> Error: variant "pic" not found in package "vtk-m"
```