### PR TITLE
mapnik: now compiles smoothly on recent gcc thanks to harfbuzz package altered

### DIFF
--- a/var/spack/repos/builtin/packages/mapnik/package.py
+++ b/var/spack/repos/builtin/packages/mapnik/package.py
@@ -36,8 +36,6 @@ class Mapnik(AutotoolsPackage):
     depends_on('sqlite+rtree', type=('build', 'link', 'run'))
     depends_on('libwebp')
 
-    conflicts('%gcc@9.0.0:9.0.2')
-
     def setup_build_environment(self, env):
         spec = self.spec
         env.set('GDAL_DATA', spec['gdal'].prefix.share.gdal)

--- a/var/spack/repos/builtin/packages/mapnik/package.py
+++ b/var/spack/repos/builtin/packages/mapnik/package.py
@@ -36,7 +36,7 @@ class Mapnik(AutotoolsPackage):
     depends_on('sqlite+rtree', type=('build', 'link', 'run'))
     depends_on('libwebp')
 
-    conflicts('%gcc@9.0.0:')
+    conflicts('%gcc@9.0.0:9.0.2')
 
     def setup_build_environment(self, env):
         spec = self.spec


### PR DESCRIPTION
Mapnik could not compile when harfbuzz was in error on some platforms.
Now that harfbuzz is corrrected it works at least with gcc 9.3.0