### PR TITLE
Adding reference to UCX devel branch v1.10.x

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -17,7 +17,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
     maintainers = ['hppritcha']
 
     # Development
-    version('1.9-dev', branch='v1.9.x')
+    version('1.10-dev', branch='v1.10.x')
 
     # Current
     version('1.9.0', sha256='a7a2c8841dc0d5444088a4373dc9b9cc68dbffcd917c1eba92ca8ed8e5e635fb', preferred=True)


### PR DESCRIPTION
Adding reference to UCX devel branch v1.10.x. 

Some release candidates for v1.10 are already available for direct download on UCX GitHub page. 

Adding support for devel branch to enable more testing with packages while stable release.