### PR TITLE
spack module_cmd: set PYTHONHOME and PYTHONPATH for python in subshell.

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -91,7 +91,9 @@ required_command_properties = ['level', 'section', 'description']
 
 #: Recorded directory where spack command was originally invoked
 spack_working_dir = None
-spack_ld_library_path = os.environ.get('LD_LIBRARY_PATH', '')
+#: Recorded environment variables that affect sys.executable
+spack_python_env = [(var, os.environ.get(var, None))
+                    for var in ('LD_LIBRARY_PATH', 'PYTHONHOME', 'PYTHONPATH')]
 
 
 def set_working_dir():

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -19,7 +19,11 @@ def test_read_unicode(tmpdir, working_env):
     script_name = 'print_unicode.py'
 
     with tmpdir.as_cwd():
-        os.environ['LD_LIBRARY_PATH'] = spack.main.spack_ld_library_path
+        for var, val in spack.main.spack_python_env:
+            if val is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = val
         # make a script that prints some unicode
         with open(script_name, 'w') as f:
             f.write('''#!{0}


### PR DESCRIPTION
This is a follow up on #16827.
It all started with a package that has `python` as a `build` dependency and needs the `openmp_flag`:
```python
...
depends_on('python', type='build')
...
def configure_args(self):
    ...
    cflags.append(self.compiler.openmp_flag)
    ...
```
The problem occurred when I tried to install the package with `intel` compiler. In this case, the result of `self.compiler.openmp_flag` depends on the version of the compiler. Getting the version requires running the compiler in a modified environment. The modifications imply module loading. The module loading function runs `sys.executable`. In my case, `sys.executable` is Python 3.6.10 from `/usr/bin` and the version of Python from the dependencies is an external installation of Python 3.8.2, which gets enabled with the environment module. As a result, the [command](https://github.com/spack/spack/blob/29d1e1ba87edeee3daea941d11adc67a03fcc1dd/lib/spack/spack/util/module_cmd.py#L22) that is run by the module loading function fails with the following message:
```console
Fatal Python error: Py_Initialize: Unable to get the locale encoding
ModuleNotFoundError: No module named 'encodings'
```
The reason is that  `PYTHONHOME` points to the prefix of the `python` from the dependency tree and is incompatible with `sys.executable`. The solution is to run `sys.executable` with the original value of `PYTHONHOME`. This is what we already have for `LD_LIBRARY_PATH`. I also think that we should do the same for `PYTHONPATH`.

I also found and fixed a couple of things that bother me in the current implementation:
1. The current implementation [overwrites](https://github.com/spack/spack/blob/29d1e1ba87edeee3daea941d11adc67a03fcc1dd/lib/spack/spack/util/module_cmd.py#L36) `SPACK_LD_LIBRARY_PATH` that is set here (to the same value but still): https://github.com/spack/spack/blob/29d1e1ba87edeee3daea941d11adc67a03fcc1dd/lib/spack/spack/main.py#L697-L703
2. There is often a difference between an empty environment variable and an environment variable that is not set.
3. A side effect of the current implementation is `SPACK_NEW_LD_LIBRARY_PATH` in the building environment.

To be fair, all of this doesn't seem to be important when there is only `LD_LIBRARY_PATH` to take care of.