### PR TITLE
VTK-m: No `pic` variant

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -84,7 +84,6 @@ class VtkM(CMakePackage, CudaPackage):
     depends_on("hip@3.7:", when="+hip")
 
     conflicts("+hip", when="+cuda")
-    conflicts("~shared", when="~pic")
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -61,11 +61,6 @@ class VtkM(CMakePackage, CudaPackage):
     amdgpu_targets = (
         'gfx900', 'gfx906', 'gfx908'
     )
-    kokkos_amd_gpu_map = {
-        'gfx900': 'vega900',
-        'gfx906': 'vega906',
-        'gfx908': 'vega908'
-    }
 
     variant('amdgpu_target', default='none', multi=True, values=('none',) + amdgpu_targets)
     conflicts("+hip", when="amdgpu_target=none")
@@ -77,8 +72,8 @@ class VtkM(CMakePackage, CudaPackage):
     depends_on("tbb", when="+tbb")
     depends_on("mpi", when="+mpi")
 
-    for kokkos_value in kokkos_amd_gpu_map:
-        depends_on("kokkos@develop +hip amd_gpu_arch=%s" % kokkos_amd_gpu_map[kokkos_value], when="amdgpu_target=%s" % kokkos_value)
+    for amdgpu_value in amdgpu_targets:
+        depends_on("kokkos@develop +rocm amdgpu_target=%s" % amdgpu_value, when="amdgpu_target=%s" % amdgpu_value)
 
     depends_on("rocm-cmake@3.7:", when="+hip")
     depends_on("hip@3.7:", when="+hip")


### PR DESCRIPTION
A leftover conflict between `shared` and `pic` variants, the latter is not part of the package anymore, leads to a solver error with clingo.

This removes the outdated conflict section.

```bash
spack solve vtk-m
```

Also updates the changed HIP/rocM architecture options and variants in Kokkos (not runtime tested by me).

### Fixes
- [x] `==> Error: 'pic'`
- [x] `==> Error: 'amd_gpu_arch'`

## Background

- https://github.com/spack/spack/pull/21787#issuecomment-782103993
- #21811

cc @robertmaynard @kmorel @vicentebolea