### PR TITLE
Bugfixes for the HIP package on new versions of ROCm

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -78,7 +78,10 @@ class Hip(CMakePackage):
                 msg += "a workaround."
                 raise RuntimeError(msg)
 
-            rocm_dev_libs_fallback = fallback_prefix.lib if self.spec.satisfies('@:3.8.0') else fallback_prefix.amdgcn.bitcode
+            if self.spec.satisfies('@:3.8.0'):
+                rocm_dev_libs_fallback = fallback_prefix.lib
+            else:
+                rocm_dev_libs_fallback = fallback_prefix.amdgcn.bitcode
 
             return {
                 'rocm-path': fallback_prefix,
@@ -123,7 +126,7 @@ class Hip(CMakePackage):
         env.set('HIPCC_COMPILE_FLAGS_APPEND',
                 '--rocm-path={0}'.format(rocm_prefixes['rocm-path']))
         env.set('HIP_CLANG_INCLUDE_PATH', '{0}/lib/clang/{1}/include'.format(
-                    rocm_prefixes['llvm-amdgpu'], self.compiler.get_real_version()))
+            rocm_prefixes['llvm-amdgpu'], self.compiler.get_real_version()))
 
     def setup_run_environment(self, env):
         self.set_variables(env)


### PR DESCRIPTION
Fixed the rocm-dev-libs path when HIP is an external package for newer
versions of HIP.  Fixed rocm-path environment variable to point to the
ROCm path rather than the rocm-dev-libs variable.  Added a definition
of the HIP_CLANG_INCLUDE_PATH, which is not properly identified
because Spack wraps the compiler up in a Spack specific path, which
prevents proper detection of the Clang compiler headers.