### PR TITLE
py-nbconvert: add function 'setup_dependent_build_environment'.

### DIFF
--- a/var/spack/repos/builtin/packages/py-nbconvert/package.py
+++ b/var/spack/repos/builtin/packages/py-nbconvert/package.py
@@ -52,3 +52,6 @@ class PyNbconvert(PythonPackage):
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("JUPYTER_PATH", self.prefix.share.jupyter)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        self.setup_dependent_build_environment(env, dependent_spec)

--- a/var/spack/repos/builtin/packages/py-nbconvert/package.py
+++ b/var/spack/repos/builtin/packages/py-nbconvert/package.py
@@ -49,3 +49,6 @@ class PyNbconvert(PythonPackage):
         # doesn't try to download it.
         install(join_path(self.package_dir, 'style.min.css'),
                 join_path('nbconvert', 'resources', 'style.min.css'))
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path("JUPYTER_PATH", self.prefix.share.jupyter)

--- a/var/spack/repos/builtin/packages/py-nbconvert/package.py
+++ b/var/spack/repos/builtin/packages/py-nbconvert/package.py
@@ -50,8 +50,11 @@ class PyNbconvert(PythonPackage):
         install(join_path(self.package_dir, 'style.min.css'),
                 join_path('nbconvert', 'resources', 'style.min.css'))
 
+    def setup_run_environment(self, env):
+        env.prepend_path("JUPYTER_PATH", self.prefix.share.jupyter)
+
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.prepend_path("JUPYTER_PATH", self.prefix.share.jupyter)
 
     def setup_dependent_run_environment(self, env, dependent_spec):
-        self.setup_dependent_build_environment(env, dependent_spec)
+        env.prepend_path("JUPYTER_PATH", self.prefix.share.jupyter)


### PR DESCRIPTION
```
Exception occurred:
  File "/spack/a-saitoh/spack/spack/opt/spack/linux-rhel8-a64fx/gcc-8.3.1/py-nbconvert-6.0.7-asymoummz5thrbum3y5oia2c42fmucao/lib/python3.8/site-packages/nbconvert/exporters/templateexporter.py", line 601, in get_template_names
    raise ValueError('No template sub-directory with name %r found in the following paths:\n\t%s' % (base_template, paths))
ValueError: No template sub-directory with name 'rst' found in the following paths:
        /spack/a-saitoh/.local/share/jupyter
        /spack/a-saitoh/spack/spack/opt/spack/linux-rhel8-a64fx/gcc-8.3.1/python-3.8.7-zxyihcxyc4iy2g2ha7yltrjyq3l7iz4t/share/jupyter
        /usr/local/share/jupyter
        /usr/share/jupyter
The full traceback has been saved in /spack/a-saitoh/sphinx-err-_2w_19j2.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:20: html] Error 2
```
There was a problem that the jupyter template could not be loaded. I fixed to add the path where the file exists to `JUPYTER_PATH`.