### PR TITLE
ruby: set JIT compiler path

### DIFF
--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -94,6 +94,9 @@ class Ruby(Package):
             args.append('--disable-dtrace')
         return args
 
+    def setup_build_environment(self, env):
+        env.set('MJIT_CC', self.compiler.cc)
+
     def setup_dependent_build_environment(self, env, dependent_spec):
         # TODO: do this only for actual extensions.
         # Set GEM_PATH to include dependent gem directories


### PR DESCRIPTION
ruby-JIT needs callable MJIT_CC path in runtime.

Normally JIT uses CC path with compiled.  [ruby configure.ac](https://github.com/ruby/ruby/blob/dfd029c9627b96f5bfc7ece2b61d5019131d83b2/configure.ac#L336)
but `lib/spack/spack/env/cc` can't call directly.


current:

```
$ ruby --jit --jit-verbose=1 /tmp/bench.rb
Spack compiler must be run from Spack! Input 'SPACK_ENV_PATH' is missing.
MJIT warning: Making precompiled header failed on compilation. Stopping MJIT worker...
```

fixed:
```
$ ruby --jit --jit-verbose=1 /tmp/bench.rb
JIT success (53.3ms): block (4 levels) in <main>@/tmp/bench.rb:9 -> /tmp/_ruby_mjit_p13565u1.c
JIT success (95.1ms): block (3 levels) in <main>@/tmp/bench.rb:8 -> /tmp/_ruby_mjit_p13565u2.c
JIT success (58.6ms): block (5 levels) in <main>@/tmp/bench.rb:16 -> /tmp/_ruby_mjit_p13565u3.c
JIT success (848.0ms): @<internal:kernel>:89 -> /tmp/_ruby_mjit_p13565u4.c
Successful MJIT finish
```