### PR TITLE
New Package: octave-quaternion

### DIFF
--- a/var/spack/repos/builtin/packages/octave-quaternion/package.py
+++ b/var/spack/repos/builtin/packages/octave-quaternion/package.py
@@ -16,5 +16,5 @@ class OctaveQuaternion(OctavePackage, SourceforgePackage):
     version('2.4.0', sha256='4c2d4dd8f1d213f080519c6f9dfbbdca068087ee0411122b16e377e0f4641610')
     version('2.2.2', sha256='261d51657bc729c8f9fe915532d91e75e48dce2af2b298781e78cc93a5067cbd')
 
-    conflics('octave@6:')
+    conflicts('octave@6:')
     extends('octave@3.8.0:5.2.0')

--- a/var/spack/repos/builtin/packages/octave-quaternion/package.py
+++ b/var/spack/repos/builtin/packages/octave-quaternion/package.py
@@ -14,5 +14,7 @@ class OctaveQuaternion(OctavePackage, SourceforgePackage):
     sourceforge_mirror_path = "octave/quaternion-2.4.0.tar.gz"
 
     version('2.4.0', sha256='4c2d4dd8f1d213f080519c6f9dfbbdca068087ee0411122b16e377e0f4641610')
+    version('2.2.2', sha256='261d51657bc729c8f9fe915532d91e75e48dce2af2b298781e78cc93a5067cbd')
 
-    extends('octave@3.8.0:')
+    conflics('octave@6:')
+    extends('octave@3.8.0:5.2.0')

--- a/var/spack/repos/builtin/packages/octave-quaternion/package.py
+++ b/var/spack/repos/builtin/packages/octave-quaternion/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class OctaveQuaternion(OctavePackage, SourceforgePackage):
+    """Quaternion package for GNU Octave,
+   includes a quaternion class with overloaded operators."""
+
+    homepage = "https://octave.sourceforge.io/quaternion/"
+    sourceforge_mirror_path = "octave/quaternion-2.4.0.tar.gz"
+
+    version('2.4.0', sha256='4c2d4dd8f1d213f080519c6f9dfbbdca068087ee0411122b16e377e0f4641610')
+
+    extends('octave@3.8.0:')


### PR DESCRIPTION
Quaternion package for GNU Octave,
includes a quaternion class with overloaded operators.