### PR TITLE
bugfix: respect -k/verify-ssl-false in _existing_url method

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -326,6 +326,8 @@ class URLFetchStrategy(FetchStrategy):
         # Telling curl to fetch the first byte (-r 0-0) is supposed to be
         # portable.
         curl_args = ['--stderr', '-', '-s', '-f', '-r', '0-0', url]
+        if not spack.config.get('config:verify_ssl'):
+            curl_args.append('-k')
         _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
         return curl.returncode == 0
 


### PR DESCRIPTION
@mwkrentel reported a bug in slack that Spack does not respect its own `-k` flag.

It turns out we added a step to check the existence of the url, and did not propagate the `-k` flag to the curl command in that method.

This PR fixes the oversight.