### PR TITLE
Specify xerces path for GridlabD configure

### DIFF
--- a/var/spack/repos/builtin/packages/gridlab-d/package.py
+++ b/var/spack/repos/builtin/packages/gridlab-d/package.py
@@ -50,6 +50,7 @@ class GridlabD(AutotoolsPackage):
             args.append('CFLAGS=-g -O0 -w')
             args.append('CXXFLAGS=-g -O0 -w -std=c++14')
             args.append('LDFLAGS=-g -O0 -w')
+            args.append('--with-xerces=' + self.spec['xerces-c'].prefix)
 
         return args
 


### PR DESCRIPTION
GridlabD fails to compile due to Xerces dependency not being found.   Fixed by specifying the installation location using "--with-xerces-c' configure option.