### PR TITLE
Reduce strictness of directory layout spec-equality check

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -347,7 +347,13 @@ class YamlDirectoryLayout(DirectoryLayout):
         #
         # TODO: remove this when we do better concretization and don't
         # ignore build-only deps in hashes.
-        elif installed_spec == spec.copy(deps=('link', 'run')):
+        elif (installed_spec.copy(deps=('link', 'run')) ==
+              spec.copy(deps=('link', 'run'))):
+            # The directory layout prefix is based on the dag hash, so among
+            # specs with differing full-hash but matching dag-hash, only one
+            # may be installed. This means for example that for two instances
+            # that differ only in CMake version used to build, only one will
+            # be installed.
             return path
 
         if spec.dag_hash() == installed_spec.dag_hash():


### PR DESCRIPTION
fixes https://github.com/spack/spack/issues/21839

https://github.com/spack/spack/pull/21735 increased the amount of spec data written (including build deps) which may trigger arguably-erroneous spec-hash collision errors. This reduces the strictness of the spec comparison check.