### PR TITLE
xsdk: fix build wrt strumpack change

### DIFF
--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -156,10 +156,10 @@ class Xsdk(BundlePackage):
     depends_on('omega-h@9.19.1', when='@0.4.0 +omega-h')
 
     depends_on('strumpack ~cuda', when='~cuda @0.6.0: +strumpack')
-    depends_on('strumpack@master~slate', when='@develop +strumpack')
-    depends_on('strumpack@5.0.0~slate', when='@0.6.0 +strumpack')
-    depends_on('strumpack@3.3.0~slate', when='@0.5.0 +strumpack')
-    depends_on('strumpack@3.1.1~slate', when='@0.4.0 +strumpack')
+    depends_on('strumpack@master~slate~openmp', when='@develop +strumpack')
+    depends_on('strumpack@5.0.0~slate~openmp', when='@0.6.0 +strumpack')
+    depends_on('strumpack@3.3.0~slate~openmp', when='@0.5.0 +strumpack')
+    depends_on('strumpack@3.1.1~slate~openmp', when='@0.4.0 +strumpack')
 
     depends_on('pumi@master', when='@develop')
     depends_on('pumi@2.2.5', when='@0.6.0')


### PR DESCRIPTION
in 671f0ff32b3ee2fdf7cae71864073e974b804c23