### PR TITLE
New Package: octave-arduino

### DIFF
--- a/var/spack/repos/builtin/packages/octave-arduino/package.py
+++ b/var/spack/repos/builtin/packages/octave-arduino/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class OctaveArduino(OctavePackage, SourceforgePackage):
+    """Provides an Octave look-alike implementation of the
+       Arduino extension for Matlab."""
+
+    homepage = "https://octave.sourceforge.io/arduino/"
+    sourceforge_mirror_path = "octave/arduino-0.2.0.tar.gz"
+
+    version('0.2.0', sha256='0562ff48ea4b2cef28e2e03ccc4678dafa16f91d1580245bb7f9f488c4f56238')
+
+    depends_on('octave-instrctl')
+    extends('octave@3.6.0:')


### PR DESCRIPTION
Provides an Octave look-alike implementation of the
Arduino extension for Matlab