### PR TITLE
tioga: add variants: +cuda and more

### DIFF
--- a/var/spack/repos/builtin/packages/tioga/package.py
+++ b/var/spack/repos/builtin/packages/tioga/package.py
@@ -2,24 +2,37 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
+import sys
 from spack import *
 
 
-class Tioga(CMakePackage):
+class Tioga(CMakePackage, CudaPackage):
     """Topology Independent Overset Grid Assembly (TIOGA)"""
 
     homepage = "https://github.com/jsitaraman/tioga"
     git      = "https://github.com/jsitaraman/tioga.git"
 
+    maintainers = ['jsitaraman', 'sayerhs']
+
+    version('develop', branch='exawind')
     version('master', branch='master')
 
-    variant('shared', default=True,
-            description="Enable building shared libraries")
+    variant('shared', default=sys.platform != 'darwin',
+            description="Build shared libraries")
     variant('pic', default=True,
             description="Position independent code")
+    variant('nodegid', default=True,
+            description="Enable support for global Node IDs")
+    variant('timers', default=False,
+            description="Enable timers")
+    variant('stats', default=False,
+            description="Enable output of holecut stats")
+    variant('cxxstd', default='11',
+            values=('11', '14'), multi=False,
+            description="C++ standard to use")
 
     depends_on('mpi')
+    depends_on('cuda@9.0.0:', when='+cuda')
 
     # Tioga has the fortran module file problem with parallel builds
     parallel = False
@@ -27,20 +40,26 @@ class Tioga(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        options = [
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
-            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
-                'ON' if '+pic' in spec else 'OFF'),
-            '-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
-            '-DCMAKE_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
-            '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
-            '-DMPI_CXX_COMPILER:PATH=%s' % spec['mpi'].mpicxx,
-            '-DMPI_C_COMPILER:PATH=%s' % spec['mpi'].mpicc,
-            '-DMPI_Fortran_COMPILER:PATH=%s' % spec['mpi'].mpifc
+        args = [
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'),
+            self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'),
+            self.define_from_variant('TIOGA_HAS_NODEGID', 'nodegid'),
+            self.define_from_variant('TIOGA_ENABLE_TIMERS', 'timers'),
+            self.define_from_variant('TIOGA_OUTPUT_STATS', 'stats'),
+            self.define_from_variant('TIOGA_ENABLE_CUDA', 'cuda'),
         ]
 
-        if 'darwin' in spec.architecture:
-            options.append('-DCMAKE_MACOSX_RPATH:BOOL=ON')
+        if '+cuda' in self.spec:
+            args.append(self.define('CMAKE_CUDA_SEPARABLE_COMPILATION', True))
 
-        return options
+            # Currently TIOGA only supports one device arch during specialization
+            cuda_arch = self.spec.variants['cuda_arch'].value
+            if cuda_arch:
+                arch_sorted = list(sorted(cuda_arch, reverse=True))
+                args.append(self.define('TIOGA_CUDA_SM', arch_sorted[0]))
+
+        if 'darwin' in spec.architecture:
+            args.append(self.define('CMAKE_MACOSX_RPATH', True))
+
+        return args


### PR DESCRIPTION
Incorporate `tioga+cuda` and other variants from
https://github.com/Exawind/exawind-builder/blob/main/etc/repos/exawind/packages/tioga/package.py

@sayerhs @jrood-nrel @jsitaraman