### PR TITLE
concretizer: re-factor version_satisfies

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -28,10 +28,13 @@ version_weight(Package, Weight)
 
 % version_satisfies implies that exactly one of the satisfying versions
 % is the package's version, and vice versa.
-1 { version(Package, Version) : version_satisfies(Package, Constraint, Version) } 1
-  :- version_satisfies(Package, Constraint).
-version_satisfies(Package, Constraint)
+attr("version_satisfies", Package, Constraint)
   :- version(Package, Version), version_satisfies(Package, Constraint, Version).
+
+:- version(Package, Version),
+   attr("version_satisfies", Package, Constraint),
+   not version_satisfies(Package, Constraint, Version).
+
 
 #defined preferred_version_declared/3.
 #defined version_satisfies/3.
@@ -245,7 +248,6 @@ provider_weight(Package, 100)
 % without enumerating all spec attributes every time.
 node(Package)                          :- attr("node", Package).
 version(Package, Version)              :- attr("version", Package, Version).
-version_satisfies(Package, Constraint) :- attr("version_satisfies", Package, Constraint).
 node_platform(Package, Platform)       :- attr("node_platform", Package, Platform).
 node_os(Package, OS)                   :- attr("node_os", Package, OS).
 node_target(Package, Target)           :- attr("node_target", Package, Target).
@@ -261,7 +263,6 @@ node_compiler_version_satisfies(Package, Compiler, Version)
 
 attr("node", Package)                          :- node(Package).
 attr("version", Package, Version)              :- version(Package, Version).
-attr("version_satisfies", Package, Constraint) :- version_satisfies(Package, Constraint).
 attr("node_platform", Package, Platform)       :- node_platform(Package, Platform).
 attr("node_os", Package, OS)                   :- node_os(Package, OS).
 attr("node_target", Package, Target)           :- node_target(Package, Target).
@@ -288,7 +289,6 @@ attr("node_compiler_version_satisfies", Package, Compiler, Version)
 #defined external_only/1.
 #defined pkg_provider_preference/4.
 #defined default_provider_preference/3.
-#defined version_satisfies/2.
 #defined node_compiler_version_satisfies/3.
 #defined root/1.
 


### PR DESCRIPTION
Switches version_satisfies/2 from a choice rule to a constraint.

Additionally removes version_satisfies/2 and replaces it directly with
its attr/3 form.  The two together give up to a 10% performance
increase for solving some specs.  It's not consistently 10% faster, but it is an improvement in most cases for larger specs, and seems to be in the noise for smaller ones.

Some statistics over five runs of each:
```
                       time
                       mean        min        max
spec     version
cmake    new       5.636458   5.516505   5.827439
         old       5.591296   5.564995   5.622272
hdf5     new       7.165604   6.871578   7.663545
         old       7.428869   7.181592   8.099485
mfem     new      12.460401  11.995617  12.897159
         old      13.206967  12.617030  14.053291
r-rminer new      12.824955  12.015022  13.875045
         old      13.888093  13.279633  14.693949
trilinos new       9.825734   9.179029  10.977134
         old      10.520997   9.816091  12.840642

```