### PR TITLE
Workarounds for install errors on Windows

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -105,7 +105,7 @@ class Lock(object):
             self.LOCK_EX = win32con.LOCKFILE_EXCLUSIVE_LOCK  # exclusive lock
             self.LOCK_SH = 0  # shared lock, default
             self.LOCK_NB = win32con.LOCKFILE_FAIL_IMMEDIATELY  # non-blocking
-            self.win_overlapped = pywintypes.OVERLAPPED()
+            self.win_overlapped = None #pywintypes.OVERLAPPED()
         else:
             self.LOCK_EX = fcntl.LOCK_EX
             self.LOCK_SH = fcntl.LOCK_SH

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -946,7 +946,7 @@ def start_build_process(pkg, function, kwargs):
 
     try:
         # Forward sys.stdin when appropriate, to allow toggling verbosity
-        if sys.stdin.isatty() and hasattr(sys.stdin, 'fileno'):
+        if sys.platform != "win32" and sys.stdin.isatty() and hasattr(sys.stdin, 'fileno'):
             input_fd = os.dup(sys.stdin.fileno())
             input_multiprocess_fd = MultiProcessFd(input_fd)
 

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -24,8 +24,7 @@ import multiprocessing
 import spack.architecture
 import spack.config
 
-
-_serialize = sys.version_info >= (3, 8) and sys.platform == 'darwin'
+_serialize = sys.platform == 'win32' or (sys.version_info >= (3, 8) and sys.platform == 'darwin')
 
 
 patches = None


### PR DESCRIPTION
1. Forwarding sys.stdin, e.g. use input_multiprocess_fd,
gives an error on Windows. Skipping for now

2. pywintypes.OVERLAPPED in the Windows lock implementation cannot be
pickled. Commenting out (for now).

3.  subprocess_context needs to serialize for Windows, like it does
for Mac.