### PR TITLE
MDSplus

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -379,9 +379,9 @@ _sp_multi_pathadd MODULEPATH "$_sp_tcl_roots"
 
 # Add programmable tab completion for Bash
 #
-if test "$_sp_shell" = bash || test -n "${ZSH_VERSION:-}"; then
-    source $_sp_share_dir/spack-completion.bash
-fi
+# if test "$_sp_shell" = bash || test -n "${ZSH_VERSION:-}"; then
+#     source $_sp_share_dir/spack-completion.bash
+# fi
 
 # done: unset sentinel variable as we're no longer initializing
 unset _sp_initializing

--- a/var/spack/repos/builtin/packages/mdsplus/package.py
+++ b/var/spack/repos/builtin/packages/mdsplus/package.py
@@ -1,0 +1,43 @@
+from spack import *
+
+
+class Mdsplus(AutotoolsPackage):
+    """A set of software tools for data acquisition and storage and a
+    methodology for management of complex scientific data."""
+    homepage = "https://mdsplus.org"
+    git      = "https://github.com/MDSplus/mdsplus.git"
+
+    maintainers = ['wmvanvliet']
+
+    parallel = False
+
+    version('stable', commit='83928a157ee0a5875135aeee0996634ecb802523',
+            submodules=True)
+
+    # Autotools needed for building
+    depends_on('autoconf', type='build')
+    depends_on('autoconf-archive', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+    depends_on('m4', type='build')
+    depends_on('pkgconfig', type='build')
+
+    # Libs needed for building and linking
+    depends_on('libxml2')
+    depends_on('readline')
+
+    # GUI bindings
+    depends_on('motif')
+
+    # Language bindings
+    depends_on('java', type=('build', 'run'))
+    depends_on('python', type='run')
+    depends_on('py-numpy', type='run')
+
+    def autoreconf(self, spec, prefix):
+        bash = which('bash')
+        bash('./bootstrap')
+
+    def setup_run_environment(self, env):
+        env.set('MDSPLUS_DIR', self.prefix)
+        env.prepend_path('PYTHONPATH', '{0}/python'.format(self.prefix))

--- a/var/spack/repos/builtin/packages/mdsplus/package.py
+++ b/var/spack/repos/builtin/packages/mdsplus/package.py
@@ -36,8 +36,6 @@ class Mdsplus(AutotoolsPackage):
 
     # Language bindings
     depends_on('java', type=('build', 'run'), when='+java')
-    depends_on('python', type='run', when='+python')
-    depends_on('py-numpy', type='run', when='+python')
 
     def configure_args(self):
         return self.enable_or_disable('java')

--- a/var/spack/repos/builtin/packages/mdsplus/package.py
+++ b/var/spack/repos/builtin/packages/mdsplus/package.py
@@ -11,8 +11,13 @@ class Mdsplus(AutotoolsPackage):
 
     parallel = False
 
-    version('stable', commit='83928a157ee0a5875135aeee0996634ecb802523',
+    version('stable_release-7-96-17', tag='stable_release-7-96-17',
             submodules=True)
+
+    variant('java', default=True,
+            description='build java libraries and applications')
+    variant('python', default=True,
+            description='install python module')
 
     # Autotools needed for building
     depends_on('autoconf', type='build')
@@ -30,9 +35,12 @@ class Mdsplus(AutotoolsPackage):
     depends_on('motif')
 
     # Language bindings
-    depends_on('java', type=('build', 'run'))
-    depends_on('python', type='run')
-    depends_on('py-numpy', type='run')
+    depends_on('java', type=('build', 'run'), when='+java')
+    depends_on('python', type='run', when='+python')
+    depends_on('py-numpy', type='run', when='+python')
+
+    def configure_args(self):
+        return self.enable_or_disable('java')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')
@@ -40,4 +48,5 @@ class Mdsplus(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         env.set('MDSPLUS_DIR', self.prefix)
-        env.prepend_path('PYTHONPATH', '{0}/python'.format(self.prefix))
+        if '+python' in self.spec:
+            env.prepend_path('PYTHONPATH', '{0}/python'.format(self.prefix))


### PR DESCRIPTION
The MDSplus database for fusion research. Needed by our fusion group to manage their data, and they want to use it on triton. An older `mdsplus` is available, but not working great. This is my attempt at making an spack package for it with all the bells and whistles enabled.

Todo:

 - [X] Get base package compiling and installing
 - [X] Java bindings
 - [ ] Python bindings
 - [ ] Matlab bindings
 - [ ] Motif GUI components