### PR TITLE
hdf5: drop support for libtool files

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -22,7 +22,9 @@ class Hdf5(AutotoolsPackage):
 
     test_requires_compiler = True
 
-    # See https://github.com/spack/spack/pull/21900
+    # We rely on the *.la files to be removed and, therefore, do not try to make
+    # sure that they are correct. The following is a precaution against someone
+    # blindly changing the value to True, either here or in the baseclass.
     install_libtool_archives = False
 
     version('develop', branch='develop')

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -22,6 +22,9 @@ class Hdf5(AutotoolsPackage):
 
     test_requires_compiler = True
 
+    # See https://github.com/spack/spack/pull/21900
+    install_libtool_archives = False
+
     version('develop', branch='develop')
 
     version('1.12.0', sha256='a62dcb276658cb78e6795dd29bf926ed7a9bc4edf6e77025cd2c689a8f97c17a')
@@ -229,39 +232,27 @@ class Hdf5(AutotoolsPackage):
             msg = 'cannot build a Fortran variant without a Fortran compiler'
             raise RuntimeError(msg)
 
+    def with_or_without_szip(self, activated):
+        return '--{0}-szlib'.format('with' if activated else 'without')
+
     def configure_args(self):
         # Always enable this option. This does not actually enable any
         # features: it only *allows* the user to specify certain
         # combinations of other arguments. Enabling it just skips a
         # sanity check in configure, so this doesn't merit a variant.
-        extra_args = ['--enable-unsupported']
-        extra_args += ['--enable-symbols=yes']
+        extra_args = ['--enable-unsupported',
+                      '--enable-symbols=yes',
+                      '--with-zlib']
         extra_args += self.enable_or_disable('threadsafe')
         extra_args += self.enable_or_disable('cxx')
         extra_args += self.enable_or_disable('hl')
         extra_args += self.enable_or_disable('fortran')
         extra_args += self.enable_or_disable('java')
+        extra_args += self.with_or_without('szip')
 
         api = self.spec.variants['api'].value
         if api != 'none':
             extra_args.append('--with-default-api-version=' + api)
-
-        if '+szip' in self.spec:
-            szip_spec = self.spec['szip']
-            # The configure script of HDF5 accepts a comma-separated tuple of
-            # two paths: the first one points to the directory with include
-            # files, the second one points to the directory with library files.
-            # If the second path is not specified, the configure script assumes
-            # that it equals to prefix/lib. However, the correct directory
-            # might be prefix/lib64. It is not a problem when the building is
-            # done with Spack's compiler wrapper but it makes the Libtool
-            # files (*.la) invalid, which makes it problematic to use the
-            # installed library outside of Spack environment.
-            extra_args.append('--with-szlib=%s,%s' %
-                              (szip_spec.headers.directories[0],
-                               szip_spec.libs.directories[0]))
-        else:
-            extra_args.append('--without-szlib')
 
         if self.spec.satisfies('@1.10:'):
             if '+debug' in self.spec:
@@ -307,8 +298,6 @@ class Hdf5(AutotoolsPackage):
 
             if '+fortran' in self.spec:
                 extra_args.append('FC=%s' % self.spec['mpi'].mpifc)
-
-        extra_args.append('--with-zlib=%s' % self.spec['zlib'].prefix)
 
         return extra_args
 


### PR DESCRIPTION
If `zlib` is an external package from `/usr`, `hdf5` is compiled with `-I/usr/include`, which breaks the include order of system headers on some systems. This is because we provide the installation prefix of `zlib` to the configure script of `hdf5` unconditionally. However, the only reason to provide the prefixes is to make sure that the libtool `*.la` files are correct.

Since it was decided to remove libtool files for all packages by default (see #18850) and I don't see any reason to make an exception for `hdf5`, we can drop the related logic. This way, we don't have to introduce special treatment for external dependencies from the system directories. Instead, we rely on the Spack compiler wrapper to inject the required `-I` and `-L` flags when needed.