### PR TITLE
Update fuse packages

### DIFF
--- a/var/spack/repos/builtin/packages/fuse-overlayfs/package.py
+++ b/var/spack/repos/builtin/packages/fuse-overlayfs/package.py
@@ -12,6 +12,9 @@ class FuseOverlayfs(AutotoolsPackage):
     homepage = "https://github.com/containers/fuse-overlayfs"
     url      = "https://github.com/containers/fuse-overlayfs/archive/v1.1.2.tar.gz"
 
+    version('1.4.0', sha256='7e5666aef4f2047e6a5202d6438b08c2d314dba5b40e431014e7dbb8168d9018')
+    version('1.3.0', sha256='91e78a93aac7698c65083deea04952bc86af6abbb0830785ef1dd4a8707ad8bf')
+    version('1.2.0', sha256='5df218732244059057686194b0e1fef66fb822d4087db48af88e1bc29bb1afde')
     version('1.1.2', sha256='1c0fa67f806c44d5c51f4bce02fdcb546137a2688a8de76d93d07b79defc9cac')
     version('1.1.1', sha256='9a1c4221a82059fd9686dd8b519d432bae126c08f9d891fb722bcb51ba4933ec')
     version('1.1.0', sha256='060168c2d5a8c6cc768b4542eba9953b7ff4a31f94bfb2e05b3d1051390838b1')

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -13,6 +13,21 @@ class Libfuse(MesonPackage):
     homepage = "https://github.com/libfuse/libfuse"
     url      = "https://github.com/libfuse/libfuse/archive/fuse-3.9.3.tar.gz"
 
-    version('3.9.4', sha256='9e076ae757a09cac9ce1beb50b3361ae83a831e5abc0f1bf5cdf771cd1320338')
-    version('3.9.3', sha256='0f8f7ad9cc6667c6751efa425dd0a665dcc9d75f0b7fc0cb5b85141a514110e9')
-    version('3.9.2', sha256='b4409255cbda6f6975ca330f5b04cb335b823a95ddd8c812c3d224ec53478fc0')
+    version('3.10.2', sha256='a16f93cc083264afd0d2958a0dc88f24c6c5d40a9f3842c645b1909e13edb75f')
+    version('3.10.1', sha256='d8954e7b4c022c651aa80db3bb4a161437dd285cd5f1a23d0e25f055dcebe00d')
+    version('3.10.0', sha256='52bbb52035f7eeaa54d139e21805d357f848f6e02ac956831d04988165a92c7b')
+    version('3.9.4',  sha256='9e076ae757a09cac9ce1beb50b3361ae83a831e5abc0f1bf5cdf771cd1320338')
+    version('3.9.3',  sha256='0f8f7ad9cc6667c6751efa425dd0a665dcc9d75f0b7fc0cb5b85141a514110e9')
+    version('3.9.2',  sha256='b4409255cbda6f6975ca330f5b04cb335b823a95ddd8c812c3d224ec53478fc0')
+
+    variant('useroot', default=False)
+
+    def meson_args(self):
+        args = []
+
+        if '+useroot' in self.spec:
+            args.append('-Duseroot=true')
+        else:
+            args.append('-Duseroot=false')
+
+        return args


### PR DESCRIPTION
Allow libfuse to build without setuid binary and bump versions of both
libfuse and fuse-overlayfs.

Still doesn't solve the issue where this package tries to install things
into /etc/init.d though.
