### PR TITLE
Qscintilla: 3 bugs corrected, new version added

### DIFF
--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -15,23 +15,37 @@ class Qscintilla(QMakePackage):
     homepage = "https://www.riverbankcomputing.com/software/qscintilla/intro"
     url      = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.2/QScintilla_gpl-2.11.2.tar.gz"
 
+    # Directory structure is changed in latest release, logic is lost
+    version('2.12.0', sha256='a4cc9e7d2130ecfcdb18afb43b813ef122473f6f35deff747415fbc2fe0c60ed')
+
+    # Last standard release dates back to 2021/11/23
+    version('2.11.6', sha256='e7346057db47d2fb384467fafccfcb13aa0741373c5d593bc72b55b2f0dd20a7', preferred=True)
     version('2.11.2', sha256='029bdc476a069fda2cea3cd937ba19cc7fa614fb90578caef98ed703b658f4a1')
-    # Newer versions of Qscintilla won't build, so prefer the following version
-    version('2.10.2', sha256='14b31d20717eed95ea9bea4cd16e5e1b72cee7ebac647cba878e0f6db6a65ed0', preferred=True)
+    version('2.10.2', sha256='14b31d20717eed95ea9bea4cd16e5e1b72cee7ebac647cba878e0f6db6a65ed0')
 
     variant('designer', default=False, description="Enable pluging for Qt-Designer")
     variant('python', default=False, description="Build python bindings")
 
+    depends_on('qt+opengl',  when='+python')
     depends_on('qt')
     depends_on('py-pyqt5 +qsci_api', type=('build', 'run'),  when='+python ^qt@5')
     depends_on('py-pyqt4 +qsci_api', type=('build', 'run'),  when='+python ^qt@4')
     depends_on('python',   type=('build', 'run'),  when='+python')
+    # adter install inquires py-sip variant : so we need to have it
+    depends_on('py-sip',   type='build',  when='~python')
 
     extends('python', when='+python')
+    build_directory = 'Qt4Qt5'
 
-    @run_before('qmake')
-    def chdir(self):
-        os.chdir(str(self.stage.source_path) + '/Qt4Qt5')
+    def url_for_version(self, version):
+        if version >= Version('2.12.0'):
+            url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/{0}/QScintilla_src-{0}.tar.gz"
+        elif version <= Version('2.11.2'):
+            url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/{0}/QScintilla_gpl-{0}.tar.gz"
+        else:
+            url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/{0}/QScintilla-{0}.tar.gz"
+
+        return url.format(version)
 
     def qmake_args(self):
         # below, DEFINES ... gets rid of ...regex...errors during build
@@ -50,7 +64,7 @@ class Qscintilla(QMakePackage):
     # Fix install prefix
     @run_after('qmake')
     def fix_install_path(self):
-        makefile = FileFilter('Makefile')
+        makefile = FileFilter(join_path('Qt4Qt5', 'Makefile'))
         makefile.filter(r'\$\(INSTALL_ROOT\)' +
                         self.spec['qt'].prefix, '$(INSTALL_ROOT)')
 
@@ -128,7 +142,10 @@ class Qscintilla(QMakePackage):
                 makefile = FileFilter('Qsci/Makefile')
                 makefile.filter(r'\$\(INSTALL_ROOT\)', '')
 
-                make('install')
+                if '@2.11:' in self.spec:
+                    make('install', parallel=False)
+                else:
+                    make('install')
 
     @run_after('install')
     def extend_path_setup(self):

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -13,7 +13,7 @@ class Qscintilla(QMakePackage):
     """
 
     homepage = "https://www.riverbankcomputing.com/software/qscintilla/intro"
-    url      = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.2/QScintilla_gpl-2.11.2.tar.gz"
+    url      = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz"
 
     # Directory structure is changed in latest release, logic is lost
     version('2.12.0', sha256='a4cc9e7d2130ecfcdb18afb43b813ef122473f6f35deff747415fbc2fe0c60ed', url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz')

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -16,10 +16,10 @@ class Qscintilla(QMakePackage):
     url      = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.2/QScintilla_gpl-2.11.2.tar.gz"
 
     # Directory structure is changed in latest release, logic is lost
-    version('2.12.0', sha256='a4cc9e7d2130ecfcdb18afb43b813ef122473f6f35deff747415fbc2fe0c60ed', url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.6/QScintilla_src-2.12.0.tar.gz')
+    version('2.12.0', sha256='a4cc9e7d2130ecfcdb18afb43b813ef122473f6f35deff747415fbc2fe0c60ed', url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.12.0/QScintilla_src-2.12.0.tar.gz')
 
     # Last standard release dates back to 2021/11/23
-    version('2.11.6', sha256='e7346057db47d2fb384467fafccfcb13aa0741373c5d593bc72b55b2f0dd20a7', preferred=True, url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.6/QScintilla_gpl-2.12.0.tar.gz')
+    version('2.11.6', sha256='e7346057db47d2fb384467fafccfcb13aa0741373c5d593bc72b55b2f0dd20a7', preferred=True, url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.6/QScintilla-2.11.6.tar.gz')
     version('2.11.2', sha256='029bdc476a069fda2cea3cd937ba19cc7fa614fb90578caef98ed703b658f4a1', url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.2/QScintilla_gpl-2.11.2.tar.gz')
     version('2.10.2', sha256='14b31d20717eed95ea9bea4cd16e5e1b72cee7ebac647cba878e0f6db6a65ed0', url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.10.2/QScintilla-2.10.2.tar.gz')
 

--- a/var/spack/repos/builtin/packages/qscintilla/package.py
+++ b/var/spack/repos/builtin/packages/qscintilla/package.py
@@ -16,12 +16,12 @@ class Qscintilla(QMakePackage):
     url      = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.2/QScintilla_gpl-2.11.2.tar.gz"
 
     # Directory structure is changed in latest release, logic is lost
-    version('2.12.0', sha256='a4cc9e7d2130ecfcdb18afb43b813ef122473f6f35deff747415fbc2fe0c60ed')
+    version('2.12.0', sha256='a4cc9e7d2130ecfcdb18afb43b813ef122473f6f35deff747415fbc2fe0c60ed', url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.6/QScintilla_src-2.12.0.tar.gz')
 
     # Last standard release dates back to 2021/11/23
-    version('2.11.6', sha256='e7346057db47d2fb384467fafccfcb13aa0741373c5d593bc72b55b2f0dd20a7', preferred=True)
-    version('2.11.2', sha256='029bdc476a069fda2cea3cd937ba19cc7fa614fb90578caef98ed703b658f4a1')
-    version('2.10.2', sha256='14b31d20717eed95ea9bea4cd16e5e1b72cee7ebac647cba878e0f6db6a65ed0')
+    version('2.11.6', sha256='e7346057db47d2fb384467fafccfcb13aa0741373c5d593bc72b55b2f0dd20a7', preferred=True, url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.6/QScintilla_gpl-2.12.0.tar.gz')
+    version('2.11.2', sha256='029bdc476a069fda2cea3cd937ba19cc7fa614fb90578caef98ed703b658f4a1', url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.11.2/QScintilla_gpl-2.11.2.tar.gz')
+    version('2.10.2', sha256='14b31d20717eed95ea9bea4cd16e5e1b72cee7ebac647cba878e0f6db6a65ed0', url='https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.10.2/QScintilla-2.10.2.tar.gz')
 
     variant('designer', default=False, description="Enable pluging for Qt-Designer")
     variant('python', default=False, description="Build python bindings")
@@ -36,16 +36,6 @@ class Qscintilla(QMakePackage):
 
     extends('python', when='+python')
     build_directory = 'Qt4Qt5'
-
-    def url_for_version(self, version):
-        if version >= Version('2.12.0'):
-            url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/{0}/QScintilla_src-{0}.tar.gz"
-        elif version <= Version('2.11.2'):
-            url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/{0}/QScintilla_gpl-{0}.tar.gz"
-        else:
-            url = "https://www.riverbankcomputing.com/static/Downloads/QScintilla/{0}/QScintilla-{0}.tar.gz"
-
-        return url.format(version)
 
     def qmake_args(self):
         # below, DEFINES ... gets rid of ...regex...errors during build


### PR DESCRIPTION
- qscintilla after install phase failed on self.spec['py-sip'] error when not installed with +python
- build_directory was not set and qmake was not run on Qt4Qt5, as well 'Makefile' was not found.
- When +python, qt was not compiled with opengl.
- It also now compiles with recent releases 2.11.2 and 2.11.6 but fails on 2.12.0 (directory structure is altered).
With 2.11+python it cannot commpile in parallel.
These changes are necessary in order to add qscintilla into octave. 