### PR TITLE
Minizip: making it link against self zlib, porting to linux

### DIFF
--- a/var/spack/repos/builtin/packages/minizip/package.py
+++ b/var/spack/repos/builtin/packages/minizip/package.py
@@ -28,7 +28,7 @@ class Minizip(AutotoolsPackage):
 
     # statically link to libz.a
     # https://github.com/Homebrew/homebrew-core/blob/master/Formula/minizip.rb
-    patch('static.patch')
+    patch('static.patch', when='%apple-clang@12:')
 
     # build minizip and miniunz
     @run_before('autoreconf')
@@ -37,15 +37,6 @@ class Minizip(AutotoolsPackage):
         make()
         with working_dir(self.configure_directory):
             make()
-
-    # Building a shared lib against a static one is not portable
-    # so we link against the PIC independent lib
-    def build(self, spec, prefix):
-        with working_dir(self.configure_directory):
-            makefile = FileFilter('Makefile')
-            makefile.filter('libz.a', 'libz.so')
-
-        make()
 
     # install minizip and miniunz
     @run_after('install')

--- a/var/spack/repos/builtin/packages/minizip/package.py
+++ b/var/spack/repos/builtin/packages/minizip/package.py
@@ -24,6 +24,7 @@ class Minizip(AutotoolsPackage):
 
     # error: implicit declaration of function 'mkdir' is invalid in C99
     patch('implicit.patch', when='%apple-clang@12:')
+    patch('implicit.patch', when='%gcc@7.3.0:')
 
     # statically link to libz.a
     # https://github.com/Homebrew/homebrew-core/blob/master/Formula/minizip.rb
@@ -36,6 +37,15 @@ class Minizip(AutotoolsPackage):
         make()
         with working_dir(self.configure_directory):
             make()
+
+    # Building a shared lib against a static one is not portable
+    # so we link against the PIC independent lib
+    def build(self, spec, prefix):
+        with working_dir(self.configure_directory):
+            makefile = FileFilter('Makefile')
+            makefile.filter('libz.a', 'libz.so')
+
+        make()
 
     # install minizip and miniunz
     @run_after('install')


### PR DESCRIPTION
minizip was not compiling with gcc due to link agaist the self brought-in non PIC lib ../../libsz.a
It is replaced by ../../libsz.so so as to work with gcc/linux, not only apple/clang
fixes #21898
