### PR TITLE
Use a container to test clingo-cffi

### DIFF
--- a/.github/workflows/linux_unit_tests.yaml
+++ b/.github/workflows/linux_unit_tests.yaml
@@ -166,47 +166,17 @@ jobs:
         with:
           flags: unittests,linux,clingo
   clingo-cffi:
-    # Test for the clingo based solver using the CFFI package
+    # Test for the clingo based solver (using clingo-cffi)
     runs-on: ubuntu-latest
+    container: spack/github-actions:clingo-cffi
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Install System packages
-        run: |
-            sudo apt-get -y update
-            # Needed for unit tests
-            sudo apt-get install -y coreutils gfortran graphviz gnupg2 mercurial
-            sudo apt-get install -y ninja-build patchelf
-            # Needed for kcov
-            sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev
-            sudo apt-get -y install zlib1g-dev libdw-dev libiberty-dev
-      - name: Install Python packages
-        run: |
-            pip install --upgrade pip six setuptools codecov coverage cffi
-            pip install -i https://test.pypi.org/simple/ clingo-cffi
-      - name: Setup git configuration
-        run: |
-            # Need this for the git tests to succeed.
-            git --version
-            . .github/workflows/setup_git.sh
-      - name: Install kcov for bash script coverage
-        env:
-            KCOV_VERSION: 34
-        run: |
-            KCOV_ROOT=$(mktemp -d)
-            wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz
-            tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz
-            mkdir -p ${KCOV_ROOT}/build
-            cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd -
-            make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install
       - name: Run unit tests
         run: |
           whoami && echo PWD=$PWD && echo HOME=$HOME && echo SPACK_TEST_SOLVER=$SPACK_TEST_SOLVER
-          python -c "import clingo; print(hasattr(clingo.Symbol, '_rep'), clingo.__version__)"
+          python3 -c "import clingo; print(hasattr(clingo.Symbol, '_rep'), clingo.__version__)"
+          git clone https://github.com/spack/spack.git && cd spack
+          git fetch origin ${{ github.ref }}:test-branch
+          git checkout test-branch
           . share/spack/setup-env.sh
           spack compiler find
           spack solve mpileaks%gcc


### PR DESCRIPTION
closes #21912 

There clingo-cffi job has two issues to be solved:

1. It uses the default concretizer
2. It requires a package from https://test.pypi.org/simple/

The former can be fixed by setting the `SPACK_TEST_SOLVER` environment variable to `clingo`.

The latter though requires clingo-cffi to be pushed to a more stable package index (since `https://test.pypi.org/simple/` is meant as a scratch version of PyPI that can be wiped at any time).

For the time being we can resort to using a container for this test and switch back to the usual Github Action VMs when `clingo-cffi` will be uploaded to PyPI.