### PR TITLE
gtkplus: add new version, convert to meson

### DIFF
--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -6,42 +6,50 @@
 from spack import *
 
 
-class Gtkplus(AutotoolsPackage):
-    """The GTK+ 2 package contains libraries used for creating graphical user
+class Gtkplus(MesonPackage):
+    """The GTK+ package contains libraries used for creating graphical user
        interfaces for applications."""
-    homepage = "http://www.gtk.org"
-    url = "http://ftp.gnome.org/pub/gnome/sources/gtk+/2.24/gtk+-2.24.31.tar.xz"
-    version('3.20.10', sha256='e81da1af1c5c1fee87ba439770e17272fa5c06e64572939814da406859e56b70')
-    version('2.24.32', sha256='b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e')
-    version('2.24.31', sha256='68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658')
-    version('2.24.25', sha256='38af1020cb8ff3d10dda2c8807f11e92af9d2fa4045de61c62eedb7fbc7ea5b3')
+
+    homepage = "https://www.gtk.org/"
+    url      = "https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.26.tar.xz"
+
+    version('3.24.26', sha256='2cc1b2dc5cad15d25b6abd115c55ffd8331e8d4677745dd3ce6db725b4fff1e9')
+    version('3.20.10', sha256='e81da1af1c5c1fee87ba439770e17272fa5c06e64572939814da406859e56b70', deprecated=True)
+    version('2.24.32', sha256='b6c8a93ddda5eabe3bfee1eb39636c9a03d2a56c7b62828b359bf197943c582e', deprecated=True)
+    version('2.24.31', sha256='68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658', deprecated=True)
+    version('2.24.25', sha256='38af1020cb8ff3d10dda2c8807f11e92af9d2fa4045de61c62eedb7fbc7ea5b3', deprecated=True)
 
     variant('cups', default='False', description='enable cups support')
 
+    # See meson.build for version requirements
+    depends_on('meson@0.48.0:', when='@3.24:', type='build')
+    depends_on('ninja', when='@3.24:', type='build')
+    # Needed to build man pages:
+    # depends_on('docbook-xml', when='@3.24:', type='build')
+    # depends_on('docbook-xsl', when='@3.24:', type='build')
+    # depends_on('libxslt', when='@3.24:', type='build')
     depends_on('pkgconfig', type='build')
-
-    depends_on('atk')
-    depends_on('gdk-pixbuf')
-    depends_on('glib')
+    depends_on('glib@2.57.2:')
+    depends_on('pango@1.41.0:+X')
+    depends_on('fribidi@0.19.7:')
+    depends_on('atk@2.35.1:')
+    depends_on('at-spi2-atk@2.15.1:', when='@3:')
+    depends_on('cairo@1.14.0:+X+pdf+gobject')
+    depends_on('gdk-pixbuf@2.30.0:')
+    depends_on('gobject-introspection@1.39.0:')
     depends_on('shared-mime-info')
-    # Hardcode X11 support (former +X variant),
-    # see #6940 for rationale:
-    depends_on('pango+X')
-    depends_on('cairo+X+pdf+gobject')
-    depends_on('gobject-introspection')
     depends_on('libepoxy', when='@3:')
     depends_on('libxi', when='@3:')
     depends_on('inputproto', when='@3:')
     depends_on('fixesproto', when='@3:')
-    depends_on('at-spi2-atk', when='@3:')
     depends_on('gettext', when='@3:')
     depends_on('cups', when='+cups')
 
     patch('no-demos.patch', when='@2:2.99')
 
     def url_for_version(self, version):
-        url = 'http://ftp.gnome.org/pub/gnome/sources/gtk+'
-        return url + '/%s/gtk+-%s.tar.xz' % (version.up_to(2), version)
+        url = 'https://download.gnome.org/sources/gtk+/{0}/gtk+-{1}.tar.xz'
+        return url.format(version.up_to(2), version)
 
     def patch(self):
         # remove disable deprecated flag.
@@ -62,15 +70,46 @@ class Gtkplus(AutotoolsPackage):
         env.prepend_path("GI_TYPELIB_PATH",
                          join_path(self.prefix.lib, 'girepository-1.0'))
 
+    def meson_args(self):
+        args = std_meson_args
+
+        if self.spec.satisfies('platform=darwin'):
+            args.extend([
+                '-Dx11_backend=false',
+                '-Dquartz_backend=true',
+            ])
+
+        args.extend([
+            '-Dgtk_doc=false',
+            '-Dman=false',
+            '-Dintrospection=true',
+        ])
+
+        return args
+
     def configure_args(self):
-        args = []
-        # disable building of gtk-doc files following #9771
-        args.append('--disable-gtk-doc-html')
         true = which('true')
-        args.append('GTKDOC_CHECK={0}'.format(true))
-        args.append('GTKDOC_CHECK_PATH={0}'.format(true))
-        args.append('GTKDOC_MKPDF={0}'.format(true))
-        args.append('GTKDOC_REBASE={0}'.format(true))
+        args = [
+            '--prefix={0}'.format(self.prefix),
+            # disable building of gtk-doc files following #9771
+            '--disable-gtk-doc-html',
+            'GTKDOC_CHECK={0}'.format(true),
+            'GTKDOC_CHECK_PATH={0}'.format(true),
+            'GTKDOC_MKPDF={0}'.format(true),
+            'GTKDOC_REBASE={0}'.format(true),
+        ]
         if '~cups' in self.spec:
             args.append('--disable-cups')
         return args
+
+    @when('@:3.20.10')
+    def meson(self, spec, prefix):
+        configure(*self.configure_args)
+
+    @when('@:3.20.10')
+    def build(self, spec, prefix):
+        make()
+
+    @when('@:3.20.10')
+    def install(self, spec, prefix):
+        make('install')

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -38,6 +38,8 @@ class Gtkplus(MesonPackage):
     depends_on('gdk-pixbuf@2.30.0:')
     depends_on('gobject-introspection@1.39.0:')
     depends_on('shared-mime-info')
+    depends_on('libxkbcommon')
+    depends_on('xrandr')
     depends_on('libepoxy', when='@3:')
     depends_on('libxi', when='@3:')
     depends_on('inputproto', when='@3:')
@@ -83,6 +85,7 @@ class Gtkplus(MesonPackage):
             '-Dgtk_doc=false',
             '-Dman=false',
             '-Dintrospection=true',
+            '-Dwayland_backend=false',
         ])
 
         return args


### PR DESCRIPTION
This PR converts the `gtkplus` package to use the new Meson build system. It is loosely based on [Homebrew's gtk+3](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gtk%2B3.rb) recipe. Older versions that don't support Meson have been deprecated.

Unfortunately, I haven't managed to get this to build on macOS. I also wasn't able to get the previous version to build either. Help wanted 😄 

This package has seen a lot of churn and could really use an official maintainer. According to `spack blame`, @aweits @michaelkuhn @Sinan81 @lee218llnl @mjwoods have modified this package in the past.