### PR TITLE
py-azureml-train-automl-client: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-azureml-train-automl-client/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-train-automl-client/package.py
@@ -12,12 +12,18 @@ class PyAzuremlTrainAutomlClient(Package):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url      = "https://pypi.io/packages/py3/a/azureml_train_automl_client/azureml_train_automl_client-1.11.0-py3-none-any.whl"
 
+    version('1.23.0', sha256='ac5f1ce9b04b4e61e2e28e0fa8d2d8e47937a546f624d1cd3aa6bc4f9110ecbe', expand=False)
     version('1.11.0', sha256='3184df60a46917e92140a299aecb54591b19df490a3f4f571ff1f92c5e70a715', expand=False)
     version('1.8.0',  sha256='562300095db6c4dea7b052e255c53dd95c4c3d0589a828b545497fe1ca7e9677', expand=False)
 
     extends('python')
     depends_on('python@3.5:3.999', type=('build', 'run'))
     depends_on('py-pip', type='build')
+
+    depends_on('py-azureml-automl-core@1.23.0:1.23.999', when='@1.23.0', type=('build', 'run'))
+    depends_on('py-azureml-core@1.23.0:1.23.999', when='@1.23.0', type=('build', 'run'))
+    depends_on('py-azureml-dataset-runtime@1.23.0:1.23.999', when='@1.23.0', type=('build', 'run'))
+    depends_on('py-azureml-telemetry@1.23.0:1.23.999', when='@1.23.0', type=('build', 'run'))
 
     depends_on('py-azureml-automl-core@1.11.0:1.11.999', when='@1.11.0', type=('build', 'run'))
     depends_on('py-azureml-core@1.11.0:1.11.999', when='@1.11.0', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.