### PR TITLE
py-azureml-train-core: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-azureml-train-core/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-train-core/package.py
@@ -11,12 +11,17 @@ class PyAzuremlTrainCore(Package):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url      = "https://pypi.io/packages/py3/a/azureml_train_core/azureml_train_core-1.11.0-py3-none-any.whl"
 
+    version('1.23.0', sha256='5c384ea0bea3ecd8bf2a1832dda906fd183cf2a03ad3372cb824ce8fa417979e', expand=False)
     version('1.11.0', sha256='1b5fd813d21e75cd522d3a078eba779333980a309bcff6fc72b74ddc8e7a26f1', expand=False)
     version('1.8.0',  sha256='5a8d90a08d4477527049d793feb40d07dc32fafc0e4e57b4f0729d3c50b408a2', expand=False)
 
     extends('python')
     depends_on('python@3.5:3.999', type=('build', 'run'))
     depends_on('py-pip', type='build')
+
+    depends_on('py-azureml-train-restclients-hyperdrive@1.23.0:1.23.999', when='@1.23.0', type=('build', 'run'))
+    depends_on('py-azureml-core@1.23.0:1.23.999', when='@1.23.0', type=('build', 'run'))
+    depends_on('py-azureml-telemetry@1.23.0:1.23.999', when='@1.23.0', type=('build', 'run'))
 
     depends_on('py-azureml-train-restclients-hyperdrive@1.11.0:1.11.999', when='@1.11.0', type=('build', 'run'))
     depends_on('py-azureml-core@1.11.0:1.11.999', when='@1.11.0', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.