### PR TITLE
py-azureml-train-restclients-hyperdrive: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-azureml-train-restclients-hyperdrive/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-train-restclients-hyperdrive/package.py
@@ -11,6 +11,7 @@ class PyAzuremlTrainRestclientsHyperdrive(Package):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url      = "https://pypi.io/packages/py3/a/azureml_train_restclients_hyperdrive/azureml_train_restclients_hyperdrive-1.11.0-py3-none-any.whl"
 
+    version('1.23.0', sha256='8ecee0cdb92a4a431b778ebcc7f9fe7c5bf63ea4cae9caa687980bc34ae3a42c', expand=False)
     version('1.11.0', sha256='8bc6f9676a9f75e6ee06d201c418ea904c24e854f26cf799b08c259c3ac92d13', expand=False)
     version('1.8.0',  sha256='1633c7eb0fd96714f54f72072ccf1c5ee1ef0a8ba52680793f20d27e0fd43c87', expand=False)
 


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.