### PR TITLE
py-azureml-train: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-azureml-train/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-train/package.py
@@ -12,12 +12,15 @@ class PyAzuremlTrain(Package):
     homepage = "https://docs.microsoft.com/en-us/azure/machine-learning/service/"
     url      = "https://pypi.io/packages/py3/a/azureml_train/azureml_train-1.11.0-py3-none-any.whl"
 
+    version('1.23.0', sha256='e16cb8673d9c9c70966c37c7362ceed3514e9797b0816c0aa449730da3b9c857', expand=False)
     version('1.11.0', sha256='7800a3067979972b976c81082dc509e23c04405129cc1fdef0f9cd7895bcafc7', expand=False)
     version('1.8.0',  sha256='124e5b7d8d64bac61db022f305bd31c25e57fdcb4be93eefd4244a04a13deab3', expand=False)
 
     extends('python')
     depends_on('python@3.5:3.999', type=('build', 'run'))
     depends_on('py-pip', type='build')
+
+    depends_on('py-azureml-train-core@1.23.0:1.23.999', when='@1.23.0', type=('build', 'run'))
 
     depends_on('py-azureml-train-core@1.11.0:1.11.999', when='@1.11.0', type=('build', 'run'))
 


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.