### PR TITLE
Adjust weights for default/non-default variant options

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -374,13 +374,13 @@ variant_value(Package, Variant, Value)
     variant_set(Package, Variant, Value).
 
 % prefer default values.
-variant_not_default(Package, Variant, Value, 1)
+variant_not_default(Package, Variant, Value, 2)
  :- variant_value(Package, Variant, Value),
     not variant_default_value(Package, Variant, Value),
     not variant_set(Package, Variant, Value),
     node(Package).
 
-variant_not_default(Package, Variant, Value, 0)
+variant_not_default(Package, Variant, Value, 1)
  :- variant_value(Package, Variant, Value),
     variant_default_value(Package, Variant, Value),
     node(Package).
@@ -389,7 +389,6 @@ variant_not_default(Package, Variant, Value, 0)
  :- variant_value(Package, Variant, Value),
     variant_set(Package, Variant, Value),
     node(Package).
-
 
 % The default value for a variant in a package is what is written
 % in the package.py file, unless some preference is set in packages.yaml

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -390,6 +390,7 @@ variant_not_default(Package, Variant, Value, 0)
     variant_set(Package, Variant, Value),
     node(Package).
 
+
 % The default value for a variant in a package is what is written
 % in the package.py file, unless some preference is set in packages.yaml
 variant_default_value(Package, Variant, Value)

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1111,7 +1111,6 @@ class TestConcretize(object):
         with pytest.raises(RuntimeError, match='not found in package'):
             s.concretize()
 
-
     @pytest.mark.regression('21911')
     def test_variant_disjoint_set_default(self):
         s1 = Spec('dep-with-variants-disjoint').concretized()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1110,3 +1110,18 @@ class TestConcretize(object):
         s = Spec(spec_str)
         with pytest.raises(RuntimeError, match='not found in package'):
             s.concretize()
+
+
+    @pytest.mark.regression('21911')
+    def test_variant_disjoint_set_default(self):
+        s1 = Spec('dep-with-variants-disjoint').concretized()
+        # Make sure the default works when left unspecified
+        assert 'foo=bar' in s1
+
+        s2 = Spec('dep-with-variants-disjoint foo=bar').concretized()
+        # Make sure the default works when explicitly specified
+        assert 'foo=bar' in s2
+
+        s3 = Spec('dep-with-variants-disjoint foo=baz').concretized()
+        # Make sure a non-default option works when explicitly specified
+        assert 'foo=baz' in s3

--- a/var/spack/repos/builtin.mock/packages/dep-with-variants-disjoint/package.py
+++ b/var/spack/repos/builtin.mock/packages/dep-with-variants-disjoint/package.py
@@ -1,0 +1,14 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class DepWithVariantsDisjoint(Package):
+    """Package that has a variant that is a disjoint set
+    with a default value
+    """
+    homepage = "https://dev.null"
+
+    version('1.0')
+
+    variant('foo', description='nope',
+            values=disjoint_sets(('bar',), ('baz',)).with_default('bar'))


### PR DESCRIPTION
I'm not completely confident that this fix is correct but appears to work for the examples I describe in the issue and for a simple test package.  This PR adjusts the `variant_not_default` rule as follows:
* the "set" variant value has the highest priority
* the default variant value has the next highest priority
* other variant values have lowest priority
