### PR TITLE
font-util: fix typo in default fonts

### DIFF
--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -75,7 +75,7 @@ class FontUtil(AutotoolsPackage, XorgPackage):
         conflicts('fonts=font-bh-ttf', when='platform=cray')
         conflicts('fonts=font-bh-ttf', when='arch=linux-rhel7-broadwell')
 
-        if f != 'font-bh-tff':
+        if f != 'font-bh-ttf':
             default_fonts.append(f)
 
         fonts.append(f)


### PR DESCRIPTION
Bug reported by @lee218llnl in #21914.