### PR TITLE
llvm-doe+lldb: @doe: fix improper set of LLDB_ENABLE_PYTHON

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -410,12 +410,12 @@ class LlvmDoe(CMakePackage, CudaPackage):
         if "+python" in spec and "+lldb" in spec:
             cmake_args.append("-DLLDB_USE_SYSTEM_SIX:Bool=TRUE")
 
+        if "+lldb" in spec and spec.satisfies("@10.0.0:,doe"):
+            cmake_args.append("-DLLDB_ENABLE_PYTHON:Bool={0}".format(
+                'ON' if '+python' in spec else 'OFF'))
         if "+lldb" in spec and spec.satisfies("@:9.9.9"):
             cmake_args.append("-DLLDB_DISABLE_PYTHON:Bool={0}".format(
                 'ON' if '~python' in spec else 'OFF'))
-        if "+lldb" in spec and spec.satisfies("@10.0.0:"):
-            cmake_args.append("-DLLDB_ENABLE_PYTHON:Bool={0}".format(
-                'ON' if '+python' in spec else 'OFF'))
 
         if "+gold" in spec:
             cmake_args.append(


### PR DESCRIPTION
`llvm-doe@doe +lldb` isn't setting `LLDB_ENABLE_PYTHON` properly because of non-standard, non-numeric `@doe` version string. This PR fixes this.

Without this PR, `llvm-doe@doe +lldb ~python` fails to build on `RHEL7` and `Ubuntu 18.04`

@shintaro-iwasaki @naromero77 