### PR TITLE
Removed MPI variant from ebms

### DIFF
--- a/var/spack/repos/builtin/packages/ebms/package.py
+++ b/var/spack/repos/builtin/packages/ebms/package.py
@@ -22,9 +22,7 @@ class Ebms(MakefilePackage):
 
     version('develop')
 
-    variant('mpi', default=True, description='Build with MPI support')
-
-    depends_on('mpi@2:', when='+mpi')
+    depends_on('mpi@2:')
 
     tags = ['proxy-app']
 


### PR DESCRIPTION
Removed MPI variant from EBMS as MPI is a dependency that cannot be
toggled off