### PR TITLE
kokkos+cuda requires +wrapper

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -217,6 +217,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     def cmake_args(self):
         spec = self.spec
+
+        if spec.satisfies('~wrapper+cuda') and not spec.satisfies('%clang'):
+            raise InstallError("Kokkos requires +wrapper when using +cuda"
+                               "without clang")
+
         options = []
 
         isdiy = "+diy" in spec


### PR DESCRIPTION
`kokkos+cuda` requires `+wrapper` 

Fixes https://github.com/spack/spack/issues/20347

@scheibelp 