### PR TITLE
[flux-core] add -Wno-errpr=maybe-uninitialized

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -176,4 +176,10 @@ class FluxCore(AutotoolsPackage):
                     flags = []
                 flags.append('-Wno-error=stringop-truncation')
 
+            if self.spec.satisfies('%gcc@8:') and \
+               self.spec.satisfies('@0.23.0:0.23.99'):
+                if flags is None:
+                    flags = []
+                flags.append('-Wno-error=maybe-uninitialized')
+
         return (flags, None, None)

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -177,7 +177,7 @@ class FluxCore(AutotoolsPackage):
                 flags.append('-Wno-error=stringop-truncation')
 
             if self.spec.satisfies('%gcc@8:') and \
-               self.spec.satisfies('@0.23.0:0.23.99'):
+               self.spec.satisfies('@0.23.0'):
                 if flags is None:
                     flags = []
                 flags.append('-Wno-error=maybe-uninitialized')


### PR DESCRIPTION
With GCC 8.3 the flux-core build fails with:

```
5 errors found in build log:
     664      CC       getattr.lo
     665      CC       prioritize.lo
     666      CC       jobtap.lo
     667      CC       plugins/default.lo
     668      CC       plugins/hold.lo
     669    /tmp/vchuravy/spack-stage/spack-stage-flux-core-0.23.0-uewqtzpecw64sbgtdatppluaw6pumtex/spack-src/src/modules/job-manager/jobtap.c: In function 'jobtap_get_priority':
  >> 670    /tmp/vchuravy/spack-stage/spack-stage-flux-core-0.23.0-uewqtzpecw64sbgtdatppluaw6pumtex/spack-src/src/modules/job-manager/jobtap.c:147:18: error: 'ap' may be used uninitialized in this function 
            [-Werror=maybe-uninitialized]
     671         if (!(args = jobtap_args_vcreate (jobtap, job, NULL, ap)))
     672                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     673    cc1: all warnings being treated as errors
  >> 674    make[3]: *** [jobtap.lo] Error 1
     675    make[3]: *** Waiting for unfinished jobs....
     676    make[3]: Leaving directory `/tmp/vchuravy/spack-stage/spack-stage-flux-core-0.23.0-uewqtzpecw64sbgtdatppluaw6pumtex/spack-src/spack-build/src/modules/job-manager'
  >> 677    make[2]: *** [all-recursive] Error 1
     678    make[2]: Leaving directory `/tmp/vchuravy/spack-stage/spack-stage-flux-core-0.23.0-uewqtzpecw64sbgtdatppluaw6pumtex/spack-src/spack-build/src/modules'
  >> 679    make[1]: *** [all-recursive] Error 1
     680    make[1]: Leaving directory `/tmp/vchuravy/spack-stage/spack-stage-flux-core-0.23.0-uewqtzpecw64sbgtdatppluaw6pumtex/spack-src/spack-build/src'
  >> 681    make: *** [all-recursive] Error 1

See build log for details:
  /tmp/vchuravy/spack-stage/spack-stage-flux-core-0.23.0-uewqtzpecw64sbgtdatppluaw6pumtex/spack-build-out.txt
  ```


cc: @SteVwonder