### PR TITLE
py-numcodecs: add new version, apple clang patch

### DIFF
--- a/var/spack/repos/builtin/packages/py-numcodecs/apple-clang-12.patch
+++ b/var/spack/repos/builtin/packages/py-numcodecs/apple-clang-12.patch
@@ -1,0 +1,14 @@
+https://github.com/Blosc/c-blosc/issues/316
+diff --git a/c-blosc/internal-complibs/zlib-1.2.8/gzguts.h b/c-blosc/internal-complibs/zlib-1.2.8/gzguts.h
+index d87659d..f6823ed 100644
+--- a/c-blosc/internal-complibs/zlib-1.2.8/gzguts.h
++++ b/c-blosc/internal-complibs/zlib-1.2.8/gzguts.h
+@@ -26,6 +26,7 @@
+ #  include <limits.h>
+ #endif
+ #include <fcntl.h>
++#include <unistd.h>
+
+ #ifdef _WIN32
+ #  include <stddef.h>
+

--- a/var/spack/repos/builtin/packages/py-numcodecs/package.py
+++ b/var/spack/repos/builtin/packages/py-numcodecs/package.py
@@ -14,12 +14,20 @@ class PyNumcodecs(PythonPackage):
 
     homepage = "https://github.com/zarr-developers/numcodecs"
     pypi = "numcodecs/numcodecs-0.6.4.tar.gz"
+    git = "https://github.com/zarr-developers/numcodecs.git"
 
+    version('master', branch='master', submodules=True)
+    version('0.7.3', sha256='022b12ad83eb623ec53f154859d49f6ec43b15c36052fa864eaf2d9ee786dd85')
     version('0.6.4', sha256='ef4843d5db4d074e607e9b85156835c10d006afc10e175bda62ff5412fca6e4d')
 
     variant('msgpack', default=False, description='Codec to encode data as msgpacked bytes.')
 
-    depends_on('py-setuptools@18.0:',       type='build')
-    depends_on('py-setuptools-scm@1.5.4:',  type=('build', 'run'))
-    depends_on('py-numpy@1.7:',             type=('build', 'run'))
+    depends_on('python@3.6:3.999', when='@0.7:', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2.8,3.5:', when='@:0.6.999', type=('build', 'link', 'run'))
+    depends_on('py-setuptools@18.1:', type='build')
+    depends_on('py-setuptools-scm@1.5.5:', type='build')
+    depends_on('py-cython', type='build')
+    depends_on('py-numpy@1.7:', type=('build', 'run'))
     depends_on('py-msgpack', type=('build', 'run'), when='+msgpack')
+
+    patch('apple-clang-12.patch', when='%apple-clang@12:')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.7 and Apple Clang 12.0.0.