### PR TITLE
libpulsar:added depends_on('curl', type=('build', 'link'))

### DIFF
--- a/var/spack/repos/builtin/packages/libpulsar/package.py
+++ b/var/spack/repos/builtin/packages/libpulsar/package.py
@@ -24,6 +24,7 @@ class Libpulsar(CMakePackage):
     depends_on('pkg-config')
     depends_on('openssl')
     depends_on('cmake @3.14:', type='build')
+    depends_on('curl', type=('build', 'link'))
 
     root_cmakelists_dir = 'pulsar-client-cpp'
 


### PR DESCRIPTION
I got the following error when installing libpulsar.
It seems that the curl dependency is missing.

 ```
     51    -- HAS_ZSTD: 1
     52    -- HAS_SNAPPY: 0
     53    clang-tidy not found
     54    clang-format not found
     55    -- Configuring done
  >> 56    CMake Error: The following variables are used in this project, but t
           hey are set to NOTFOUND.
     57    Please set them or make sure they are set and tested correctly in th
           e CMake files:
     58    CURL
```_LIBRARIES