### PR TITLE
OpenMPI requires perl as build dep

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -264,8 +264,8 @@ class Openmpi(AutotoolsPackage):
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool',  type='build', when='@develop')
     depends_on('m4',       type='build', when='@develop')
-    depends_on('perl',     type='build', when='@develop')
 
+    depends_on('perl',     type='build')
     depends_on('pkgconfig', type='build')
 
     depends_on('libevent@2.0:', when='@4:')


### PR DESCRIPTION
See https://github.com/open-mpi/ompi/blob/a10b45bb9bc9a80e895845baea73e0463de1639f/configure.ac#L82
