### PR TITLE
Make CMake a bit smaller

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -103,6 +103,10 @@ class Cmake(Package):
     version('3.0.2',    sha256='6b4ea61eadbbd9bec0ccb383c29d1f4496eacc121ef7acf37c7a24777805693e')
     version('2.8.10.2', sha256='ce524fb39da06ee6d47534bbcec6e0b50422e18b62abc4781a4ba72ea2910eb1')
 
+    variant('build_type', default='Release',
+            description='CMake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+
     # Revert the change that introduced a regression when parsing mpi link
     # flags, see: https://gitlab.kitware.com/cmake/cmake/issues/19516
     patch('cmake-revert-findmpi-link-flag-list.patch', when='@3.15.0')
@@ -240,8 +244,8 @@ class Cmake(Package):
         # Now for CMake arguments to pass after the initial bootstrap
         args.append('--')
 
-        # Make sure to create an optimized release build
-        args.append('-DCMAKE_BUILD_TYPE=MinSizeRel')
+        args.append('-DCMAKE_BUILD_TYPE={0}'.format(
+            self.spec.variants['build_type'].value))
 
         # Install CMake correctly, even if `spack install` runs
         # inside a ctest environment

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -241,7 +241,7 @@ class Cmake(Package):
         args.append('--')
 
         # Make sure to create an optimized release build
-        args.append('-DCMAKE_BUILD_TYPE=Release')
+        args.append('-DCMAKE_BUILD_TYPE=MinSizeRel')
 
         # Install CMake correctly, even if `spack install` runs
         # inside a ctest environment


### PR DESCRIPTION
Use MinSizeRel `-Os` instead of Release as build type, which reduces the size by 30% on my machine and makes it a bit lighter for use in containers
