### PR TITLE
Do not install berkeley-db docs by default

### DIFF
--- a/var/spack/repos/builtin/packages/berkeley-db/drop-docs.patch
+++ b/var/spack/repos/builtin/packages/berkeley-db/drop-docs.patch
@@ -1,0 +1,25 @@
+From 310ecb91e619192fd7097a24889485526315667a Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Thu, 25 Feb 2021 16:32:30 +0100
+Subject: [PATCH] remove smth
+
+---
+ dist/Makefile.in | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/dist/Makefile.in b/dist/Makefile.in
+index e90c0c2..d041d47 100644
+--- a/dist/Makefile.in
++++ b/dist/Makefile.in
+@@ -1160,6 +1160,8 @@ DOCLIST=api_reference articles bdb-sql collections csharp \
+ 	gsg gsg_db_rep gsg_txn index.html installation java \
+ 	license porting programmer_reference upgrading
+ 
++DOCLIST=index.html
++
+ install_docs:
+ 	@echo "Installing documentation: $(DESTDIR)$(docdir) ..."
+ 	@test -d $(DESTDIR)$(docdir) || \
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -18,8 +18,12 @@ class BerkeleyDb(AutotoolsPackage):
     version('6.0.35', sha256='24421affa8ae436fe427ae4f5f2d1634da83d3d55a5ad6354a98eeedb825de55')
     version('5.3.28', sha256='e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628')
 
+    variant('docs', default=False)
+
     configure_directory = 'dist'
     build_directory = 'build_unix'
+
+    patch("drop-docs.patch", when='~docs')
 
     def patch(self):
         # some of the docs are missing in 18.1.40

--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -12,10 +12,10 @@ class BerkeleyDb(AutotoolsPackage):
     url      = "http://download.oracle.com/berkeley-db/db-18.1.40.tar.gz"
 
     version("18.1.40", sha256="0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8")
-    version('18.1.32', sha256='fa1fe7de9ba91ad472c25d026f931802597c29f28ae951960685cde487c8d654')
+    version('18.1.32', sha256='fa1fe7de9ba91ad472c25d026f931802597c29f28ae951960685cde487c8d654', deprecated=True)
     version('6.2.32', sha256='a9c5e2b004a5777aa03510cfe5cd766a4a3b777713406b02809c17c8e0e7a8fb')
     version('6.1.29', sha256='b3c18180e4160d97dd197ba1d37c19f6ea2ec91d31bbfaf8972d99ba097af17d')
-    version('6.0.35', sha256='24421affa8ae436fe427ae4f5f2d1634da83d3d55a5ad6354a98eeedb825de55')
+    version('6.0.35', sha256='24421affa8ae436fe427ae4f5f2d1634da83d3d55a5ad6354a98eeedb825de55', deprecated=True)
     version('5.3.28', sha256='e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628')
 
     variant('docs', default=False)
@@ -24,6 +24,9 @@ class BerkeleyDb(AutotoolsPackage):
     build_directory = 'build_unix'
 
     patch("drop-docs.patch", when='~docs')
+
+    conflicts('%clang@7:', when='@5.3.28')
+    conflicts('%gcc@8:', when='@5.3.28')
 
     def patch(self):
         # some of the docs are missing in 18.1.40


### PR DESCRIPTION
It's a link dep of perl, which is a build dep of cmake, and it's just annoyingly big for containers and slow to install on lustre filesystems.

Install size goes down from 100MB -> 8MB.

Tested it real quick, works on 6.1.29, 6.2.32, 18.1.40. Versions 18.1.32 and 6.0.35 are not available for download anymore, and 5.3.28 does not compile with GCC 10 but the patch applies alright. It's out of the scope of this PR to fix these build / download struggles.