### PR TITLE
openmpi: more straightforward handling for '~legacylaunchers'

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/nolegacylaunchers.sh
+++ b/var/spack/repos/builtin/packages/openmpi/nolegacylaunchers.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-echo "This version of Spack (openmpi ~legacylaunchers schedulers=slurm) "
-echo "is installed without the mpiexec/mpirun commands to prevent "
-echo "unintended performance issues. See https://github.com/spack/spack/pull/10340 "
-echo "for more details."
-echo "If you understand the potential consequences of a misconfigured mpirun, you can"
-echo "use spack to install 'openmpi+legacylaunchers' to restore the executables."
-echo "Otherwise, use srun to launch your MPI executables."
+cat <<_EOF >&2
+The users are strongly discouraged from using
+'$0'.
+
+Please, refer to your site's user guide for the recommended way to launch MPI
+applications.
+
+_EOF
 exit 2

--- a/var/spack/repos/builtin/packages/openmpi/nolegacylaunchers.sh
+++ b/var/spack/repos/builtin/packages/openmpi/nolegacylaunchers.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 cat <<_EOF >&2
-The users are strongly discouraged from using
-'$0'.
-
-Please, refer to your site's user guide for the recommended way to launch MPI
+error: '$0' is disabled in this MPI installation.
+Please refer to your site's user guide for the recommended way to launch MPI
 applications.
 
 _EOF

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -491,8 +491,8 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     variant(
         "legacylaunchers",
-        default=False,
-        description="Do not remove mpirun/mpiexec when building with slurm",
+        default=True,
+        description="Keep mpirun/mpiexec launchers after installation",
     )
     # Variants to use internal packages
     variant("internal-hwloc", default=False, description="Use internal hwloc")
@@ -906,6 +906,15 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         perl("autogen.pl")
 
     def configure_args(self):
+        if self.spec.satisfies("+legacylaunchers schedulers=slurm"):
+            tty.warn(
+                self.spec.format(
+                    "The preferred way to run an application when Slurm is the scheduler is to "
+                    "let Slurm manage process spawning via PMI: consider building {name} with "
+                    "'~legacylaunchers'"
+                )
+            )
+
         spec = self.spec
         config_args = ["--enable-shared", "--disable-silent-rules"]
 
@@ -1114,21 +1123,24 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         # applications via mpirun or mpiexec, and leaves srun as the
         # only sensible choice (orterun is still present, but normal
         # users don't know about that).
-        if "@1.6: ~legacylaunchers schedulers=slurm" in self.spec:
-            exe_list = [
+        if "~legacylaunchers" in self.spec:
+            stub_name = "nolegacylaunchers.sh"
+            stub_src = join_path(os.path.dirname(__file__), stub_name)
+            stub_dst = join_path(spack.store.layout.metadata_path(self.spec), stub_name)
+            install(stub_src, stub_dst)
+
+            for exe in [
                 self.prefix.bin.mpirun,
                 self.prefix.bin.mpiexec,
                 self.prefix.bin.shmemrun,
                 self.prefix.bin.oshrun,
-            ]
-            script_stub = join_path(os.path.dirname(__file__), "nolegacylaunchers.sh")
-            for exe in exe_list:
+            ]:
                 try:
                     os.remove(exe)
                 except OSError:
                     tty.debug("File not present: " + exe)
                 else:
-                    copy(script_stub, exe)
+                    os.symlink(stub_dst, exe)
 
     @run_after("install")
     def setup_install_tests(self):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -907,6 +907,10 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
     def configure_args(self):
         if self.spec.satisfies("+legacylaunchers schedulers=slurm"):
+            # Deleting the links to orterun avoids users running their applications via mpirun or
+            # mpiexec, and leaves srun as the only sensible choice (orterun is still present, but
+            # normal users don't know about that). See https://github.com/spack/spack/pull/10340
+            # for more details.
             tty.warn(
                 self.spec.format(
                     "The preferred way to run an application when Slurm is the scheduler is to "

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -914,7 +914,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
             tty.warn(
                 self.spec.format(
                     "The preferred way to run an application when Slurm is the scheduler is to "
-                    "let Slurm manage process spawning via PMI: consider building {name} with "
+                    "let Slurm manage process spawning: consider building {name} with"
                     "'~legacylaunchers'"
                 )
             )


### PR DESCRIPTION
This is an attempt to make the logic related to the `legacylaunchers` a bit more straightforward:
1. Currently, two different specs — `openmpi+legacylaunchers` and `openmpi~legacylaunchers` — produce identical installations. As far as I know, we usually try to avoid that.
2. The message of the stub script is meant for the application users (i.e. the users of the software stack). They don't have to know anything about Spack. Therefore, I think that the message should be more generic. Also, symlinking `mpirun` and friends to a single file makes it easier to modify the message manually after the installation if needed.
3. Inexperienced Spack users might find it very confusing that they don't get what they usually get when installing the package manually. I think `+legacylaunchers` should be the default but produce a warning when `schedulers=slurm`. More experienced users can simply add `~legacylaunchers` to their `packages.yaml` (the most experienced ones already have it :).