### PR TITLE
Compiling package qgis

### DIFF
--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -25,7 +25,7 @@ class Qgis(CMakePackage):
     version('3.12.1',   sha256='a7dc7af768b8960c08ce72a06c1f4ca4664f4197ce29c7fe238429e48b2881a8')
     version('3.12.0',   sha256='19e9c185dfe88cad7ee6e0dcf5ab7b0bbfe1672307868a53bf771e0c8f9d5e9c')
     # Prefer latest long term release
-    # 3.16.4 does not find PyQt5
+    # Last LTR 3.16.4 does not find PyQt5
     version('3.16.4',   sha256='a31b4aa9b54a47f5dce3d944c32b4609348fa2ffdd1b533bdffb935f62b7049f')
     version('3.10.10',  sha256='e21a778139823fb6cf12e4a38f00984fcc060f41abcd4f0af83642d566883839', preferred=True)
     version('3.10.7',   sha256='f6c02489e065bae355d2f4374b84a1624379634c34a770b6d65bf38eb7e71564')


### PR DESCRIPTION
- qgis spec failed when asling for qgis@3.10.10 explicitly saying qscintilla needs py-pyqt+qsci_api
and qgis spec is py-pyqt5~qsci_api
- cmake was unable to find GDAL_INCLUDE (despite finding GDAL_INCLUDE_DIR)
     23    GDAL_LIBRARY=GDAL_LIBRARY-NOTFOUND
  >> 24    CMake Error at cmake/FindGDAL.cmake:205 (MESSAGE):
     25      Could not find GDAL
     26    Call Stack (most recent call first):
     27      CMakeLists.txt:333 (FIND_PACKAGE)
- path to /lib/libqscintilla2.qt5.so mostly replace with spack variables such as dso_suffix
- adding Last LTR 3.16.4 but is not the default since it does not find PyQt5 and I did not manage to get over
Hope someone will try that and find a solution