### PR TITLE
small fix to allow filepaths with drives like "C:" to pass

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -783,7 +783,7 @@ def setup_package(pkg, dirty, context='build'):
         # kludge to handle cray libsci being automatically loaded by PrgEnv
         # modules on cray platform. Module unload does no damage when
         # unnecessary
-        module('unload', 'cray-libsci')
+        #module('unload', 'cray-libsci')
 
         if pkg.architecture.target.module_name:
             load_module(pkg.architecture.target.module_name)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -157,6 +157,9 @@ def warn_no_ssl_cert_checking():
 
 def push_to_url(
         local_file_path, remote_path, keep_original=True, extra_args=None):
+    if sys.platform == "win32":
+        if remote_path[1] == ':':
+            remote_path = "file://" + remote_path
     remote_url = url_util.parse(remote_path)
     verify_ssl = spack.config.get('config:verify_ssl')
 


### PR DESCRIPTION
Small patch by Bill, allows filepaths with drives to be processed properly by url parser