### PR TITLE
bugfix in module error message

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -155,7 +155,7 @@ def path_from_modules(modules):
 
         if candidate_path and not os.path.exists(candidate_path):
             msg = ("Extracted path from module does not exist "
-                   "[module={0}, path={0}]")
+                   "[module={0}, path={1}]")
             tty.warn(msg.format(module_name, candidate_path))
 
         # If anything is found, then it's the best choice. This means


### PR DESCRIPTION
The error message when the path extracted from a module does not exist has a typo bug. Fixed here.