### PR TITLE
ParaView: add variant to enable/disable vtkm, default is deferred to build_edition

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -12,7 +12,7 @@ from spack import *
 class Paraview(CMakePackage, CudaPackage):
     """ParaView is an open-source, multi-platform data analysis and
     visualization application. This package includes the Catalyst
-    in-situ library for versions 5.7 and greater, othewise use the
+    in-situ library for versions 5.7 and greater, otherwise use the
     catalyst package.
 
     """
@@ -70,6 +70,10 @@ class Paraview(CMakePackage, CudaPackage):
                     'catalyst', 'rendering', 'core'),
             description='Build editions include only certain modules. '
             'Editions are listed in decreasing order of size.')
+    variant('use_vtkm', default='default', multi=False, values=('default', 'on', 'off'),
+            description='Build VTK-m with ParaView by setting PARAVIEW_USE_VTKM=ON,OFF.'
+                        ' "default" lets the build_edition make the decision.'
+                        ' "on" or "off" will always override the build_edition.')
 
     conflicts('+adios2', when='@:5.10 ~mpi')
     conflicts('+python', when='+python3')
@@ -85,6 +89,8 @@ class Paraview(CMakePackage, CudaPackage):
     conflicts('build_edition=catalyst', when='@:5.7')
     conflicts('build_edition=rendering', when='@:5.7')
     conflicts('build_edition=core', when='@:5.7')
+    # before 5.3.0, ParaView didn't have VTK-m
+    conflicts('use_vtkm=on', when='@:5.3')
 
     # We only support one single Architecture
     for _arch, _other_arch in itertools.permutations(CudaPackage.cuda_arch_values, 2):
@@ -417,6 +423,11 @@ class Paraview(CMakePackage, CudaPackage):
 
         cmake_args.append(
             '-DPARAVIEW_BUILD_SHARED_LIBS:BOOL=%s' % variant_bool('+shared'))
+
+        # VTK-m added to ParaView in 5.3.0 and up
+        if spec.satisfies('@5.3.0:') and spec.variants['use_vtkm'].value != 'default':
+            cmake_args.append('-DPARAVIEW_USE_VTKM:BOOL=%s' %
+                              spec.variants['use_vtkm'].value.upper())
 
         if spec.satisfies('@5.8:'):
             cmake_args.append('-DPARAVIEW_USE_CUDA:BOOL=%s' %


### PR DESCRIPTION
@danlipsa @chuckatkins 

Sometimes it is needed to build paraview without vtkm. This PR adds a variant for doing this (default is building vtkm). Luckily all of the versions use the same cmake flag 'PARAVIEW_USE_VTKM'.