### PR TITLE
kcov: elfutils not needed on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/kcov/package.py
+++ b/var/spack/repos/builtin/packages/kcov/package.py
@@ -19,8 +19,8 @@ class Kcov(CMakePackage):
     depends_on('cmake@2.8.4:', type='build')
     depends_on('zlib')
     depends_on('curl')
-    depends_on('elfutils')
-    depends_on('binutils +libiberty', type='link')
+    depends_on('elfutils', when='platform=linux')
+    depends_on('binutils +libiberty', when='platform=linux', type='link')
 
     def cmake_args(self):
         # Necessary at least on macOS, fixes linking error to LLDB


### PR DESCRIPTION
Follow-up to #21932 and #21875.

`elfutils` cannot be built on macOS. I'm unable to build it with either Apple Clang or GCC. `kcov` builds just fine for me without this dependency. If you look at https://github.com/SimonKagstrom/kcov/blob/master/INSTALL.md, `elfutils` and `libiberty` are only recommended on Linux, not on macOS. I don't know CMake well enough to figure out how this works, but the build doesn't seem to link to these things on macOS.