### PR TITLE
Allow relative paths in config files (relative to file dirname)

### DIFF
--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -317,6 +317,20 @@ def test_substitute_config_variables(mock_low_high_config, monkeypatch):
         '$env/foo/bar/baz'
     ) == os.path.join(fake_env_path, 'foo/bar/baz')
 
+    # relative paths without source information are relative to cwd
+    assert spack_path.canonicalize_path(
+        'foo/bar/baz'
+    ) == os.path.abspath('foo/bar/baz')
+
+    # relative paths with source information are relative to the file
+    spack.config.set(
+        'config:module_roots', {'lmod': 'foo/bar/baz'}, scope='low')
+    spack.config.config.clear_caches()
+    path = spack.config.get('config:module_roots:lmod')
+    assert spack_path.canonicalize_path(path) == os.path.normpath(
+        os.path.join(mock_low_high_config.scopes['low'].path,
+                     'foo/bar/baz'))
+
 
 packages_merge_low = {
     'packages': {

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -95,6 +95,7 @@ def substitute_config_variables(path):
     # Replace $var or ${var}.
     return re.sub(r'(\$\w+\b|\$\{\w+\})', repl, path)
 
+
 def substitute_path_variables(path):
     """Substitute config vars, expand environment vars, expand user home."""
     path = substitute_config_variables(path)


### PR DESCRIPTION
This allows users to use relative paths for mirrors and repos and other things that may be part of a Spack environment.  There are two ways to do it.

1. Relative to the file

    ```yaml
    spack:
      repos:
      - local_dir/my_repository
    ```

    Which will refer to a repository like this in the directory where `spack.yaml` lives:

    ```
    env/
      spack.yaml  <-- the config file above
      local_dir/
        my_repository/  <-- this repository
          repo.yaml
          packages/
    ```

2. Relative to the environment

    ```yaml
    spack:
      repos:
      - $env/local_dir/my_repository
    ```

Both of these would refer to the same directory, but they differ for included files.  For example, if you had this layout:

```
env/
    spack.yaml
    repository/
    includes/
        repos.yaml
        repository/
```

And this `spack.yaml`:

```yaml
spack:
    include: includes/repos.yaml
```

Then, these two `repos.yaml` files are functionally different:

```yaml
repos:
    - $env/repository    # refers to env/repository/ above

repos:
    - repository    # refers to env/includes/repository/ above
```
    
The $env variable will not be evaluated if there is no active environment. This generally means that it should not be used outside of an environment's spack.yaml file. However, if other aspects of your workflow guarantee that there is always an active environment, it may be used in other config scopes.