### PR TITLE
adds flag to turn off NLOPT_OCTAVE in CMAKE when -octave

### DIFF
--- a/var/spack/repos/builtin/packages/nlopt/package.py
+++ b/var/spack/repos/builtin/packages/nlopt/package.py
@@ -54,7 +54,7 @@ class Nlopt(CMakePackage):
         # On is default
         if '-shared' in spec:
             args.append('-DBUILD_SHARED_LIBS:Bool=OFF')
-            
+
         # On is default
         if '-octave' in spec:
             args.append('-DNLOPT_OCTAVE:Bool=OFF')

--- a/var/spack/repos/builtin/packages/nlopt/package.py
+++ b/var/spack/repos/builtin/packages/nlopt/package.py
@@ -54,6 +54,10 @@ class Nlopt(CMakePackage):
         # On is default
         if '-shared' in spec:
             args.append('-DBUILD_SHARED_LIBS:Bool=OFF')
+            
+        # On is default
+        if '-octave' in spec:
+            args.append('-DNLOPT_OCTAVE:Bool=OFF')
 
         if '+cxx' in spec:
             args.append('-DNLOPT_CXX:BOOL=ON')


### PR DESCRIPTION
Apparently nlopt now builds with octave bindings by default, but the spack package has ~octave as default so the dependency is never pulled. Rather than change the spack default, I added these lines to not try to build with octave on when it spack has it set to ~octave