### PR TITLE
Add Windows to architecture tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,5 @@ lib/spack/spack/test/.cache
 .pydevproject
 
 # VSCode files
-.vs
 .vscode
 .devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ lib/spack/spack/test/.cache
 .pydevproject
 
 # VSCode files
+.vs
 .vscode
 .devcontainer

--- a/lib/spack/spack/test/architecture.py
+++ b/lib/spack/spack/test/architecture.py
@@ -17,6 +17,7 @@ from spack.spec import Spec
 from spack.platforms.cray import Cray
 from spack.platforms.linux import Linux
 from spack.platforms.darwin import Darwin
+from spack.platforms.windows import Windows
 
 
 def test_dict_functions_for_architecture():
@@ -46,6 +47,8 @@ def test_platform():
         my_platform_class = Linux()
     elif 'Darwin' in py_platform.system():
         my_platform_class = Darwin()
+    elif 'Windows' in py_platform.system():
+        my_platform_class = Windows()
 
     assert str(output_platform_class) == str(my_platform_class)
 


### PR DESCRIPTION
Add Windows to architecture test code run by
`spack unit-test lib/spack/spack/test/architecture.py`