### PR TITLE
Combine URLFetchStrategy and CurlFetchStrategy into one class

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -262,265 +262,12 @@ class URLFetchStrategy(FetchStrategy):
 
         self.expand_archive = kwargs.get('expand', True)
         self.extra_options = kwargs.get('fetch_options', {})
-
-        self.extension = kwargs.get('extension', None)
-
-        if not self.url:
-            raise ValueError("URLFetchStrategy requires a url for fetching.")
-
-    def source_id(self):
-        return self.digest
-
-    def mirror_id(self):
-        if not self.digest:
-            return None
-        # The filename is the digest. A directory is also created based on
-        # truncating the digest to avoid creating a directory with too many
-        # entries
-        return os.path.sep.join(
-            ['archive', self.digest[:2], self.digest])
-
-    @property
-    def candidate_urls(self):
-        return [self.url] + (self.mirrors or [])
-
-    @_needs_stage
-    def fetch(self):
-        if self.archive_file:
-            tty.debug('Already downloaded {0}'.format(self.archive_file))
-            return
-        url = None
-        errors = []
-        for url in self.candidate_urls:
-            if not self._existing_url(url):
-                continue
-
-            try:
-                partial_file, save_file = self._fetch_from_url(url)
-                if save_file:
-                    os.rename(partial_file, save_file)
-                break
-            except FailedDownloadError as e:
-                errors.append(str(e))
-
-        for msg in errors:
-            tty.debug(msg)
-
-        if not self.archive_file:
-            raise FailedDownloadError(url)
-
-    def _existing_url(self, url):
-        tty.debug('Checking existence of {0}'.format(url))
-        # Telling urllib to check if url is accessible
-        try:
-            url, headers, response = web_util.read_from_url(url)
-        except web_util.SpackWebError:
-            msg = "Urllib fetch failed to verify url {0}".format(url)
-            raise FailedDownloadError(url, msg)
-        return (response.getcode() is None or response.getcode() == 200)
-
-    def _fetch_from_url(self, url):
-        save_file = None
-        partial_file = None
-        if self.stage.save_filename:
-            save_file = self.stage.save_filename
-            partial_file = self.stage.save_filename + '.part'
-        tty.msg('Fetching {0}'.format(url))
-
-        # Run urllib but grab the mime type from the http headers
-        try:
-            url, headers, response = web_util.read_from_url(url)
-        except web_util.SpackWebError as e:
-            # clean up archive on failure.
-            if self.archive_file:
-                os.remove(self.archive_file)
-            if partial_file and os.path.exists(partial_file):
-                os.remove(partial_file)
-            msg = 'urllib failed to fetch with error {0}'.format(e)
-            raise FailedDownloadError(url, msg)
-        _data = response.read()
-        open(partial_file, 'wb').write(_data)
-        headers = _data.decode('utf-8', 'ignore')
-
-        # Check if we somehow got an HTML file rather than the archive we
-        # asked for.  We only look at the last content type, to handle
-        # redirects properly.
-        content_types = re.findall(r'Content-Type:[^\r\n]+', headers,
-                                   flags=re.IGNORECASE)
-        if content_types and 'text/html' in content_types[-1]:
-            warn_content_type_mismatch(self.archive_file or "the archive")
-        return partial_file, save_file
-
-    @property  # type: ignore # decorated properties unsupported in mypy
-    @_needs_stage
-    def archive_file(self):
-        """Path to the source archive within this stage directory."""
-        return self.stage.archive_file
-
-    @property
-    def cachable(self):
-        return self.cache_enabled and bool(self.digest)
-
-    @_needs_stage
-    def expand(self):
-        if not self.expand_archive:
-            tty.debug('Staging unexpanded archive {0} in {1}'
-                      .format(self.archive_file, self.stage.source_path))
-            if not self.stage.expanded:
-                mkdirp(self.stage.source_path)
-            dest = os.path.join(self.stage.source_path,
-                                os.path.basename(self.archive_file))
-            shutil.move(self.archive_file, dest)
-            return
-
-        tty.debug('Staging archive: {0}'.format(self.archive_file))
-
-        if not self.archive_file:
-            raise NoArchiveFileError(
-                "Couldn't find archive file",
-                "Failed on expand() for URL %s" % self.url)
-
-        if not self.extension:
-            self.extension = extension(self.archive_file)
-
-        if self.stage.expanded:
-            tty.debug('Source already staged to %s' % self.stage.source_path)
-            return
-
-        decompress = decompressor_for(self.archive_file, self.extension)
-
-        # Expand all tarballs in their own directory to contain
-        # exploding tarballs.
-        tarball_container = os.path.join(self.stage.path,
-                                         "spack-expanded-archive")
-
-        mkdirp(tarball_container)
-        with working_dir(tarball_container):
-            decompress(self.archive_file)
-
-        # Check for an exploding tarball, i.e. one that doesn't expand to
-        # a single directory.  If the tarball *didn't* explode, move its
-        # contents to the staging source directory & remove the container
-        # directory.  If the tarball did explode, just rename the tarball
-        # directory to the staging source directory.
-        #
-        # NOTE: The tar program on Mac OS X will encode HFS metadata in
-        # hidden files, which can end up *alongside* a single top-level
-        # directory.  We initially ignore presence of hidden files to
-        # accomodate these "semi-exploding" tarballs but ensure the files
-        # are copied to the source directory.
-        files = os.listdir(tarball_container)
-        non_hidden = [f for f in files if not f.startswith('.')]
-        if len(non_hidden) == 1:
-            src = os.path.join(tarball_container, non_hidden[0])
-            if os.path.isdir(src):
-                self.stage.srcdir = non_hidden[0]
-                shutil.move(src, self.stage.source_path)
-                if len(files) > 1:
-                    files.remove(non_hidden[0])
-                    for f in files:
-                        src = os.path.join(tarball_container, f)
-                        dest = os.path.join(self.stage.path, f)
-                        shutil.move(src, dest)
-                os.rmdir(tarball_container)
-            else:
-                # This is a non-directory entry (e.g., a patch file) so simply
-                # rename the tarball container to be the source path.
-                shutil.move(tarball_container, self.stage.source_path)
-
-        else:
-            shutil.move(tarball_container, self.stage.source_path)
-
-    def archive(self, destination):
-        """Just moves this archive to the destination."""
-        if not self.archive_file:
-            raise NoArchiveFileError("Cannot call archive() before fetching.")
-
-        web_util.push_to_url(
-            self.archive_file,
-            destination,
-            keep_original=True)
-
-    @_needs_stage
-    def check(self):
-        """Check the downloaded archive against a checksum digest.
-           No-op if this stage checks code out of a repository."""
-        if not self.digest:
-            raise NoDigestError(
-                "Attempt to check URLFetchStrategy with no digest.")
-
-        checker = crypto.Checker(self.digest)
-        if not checker.check(self.archive_file):
-            raise ChecksumError(
-                "%s checksum failed for %s" %
-                (checker.hash_name, self.archive_file),
-                "Expected %s but got %s" % (self.digest, checker.sum))
-
-    @_needs_stage
-    def reset(self):
-        """
-        Removes the source path if it exists, then re-expands the archive.
-        """
-        if not self.archive_file:
-            raise NoArchiveFileError(
-                "Tried to reset URLFetchStrategy before fetching",
-                "Failed on reset() for URL %s" % self.url)
-
-        # Remove everything but the archive from the stage
-        for filename in os.listdir(self.stage.path):
-            abspath = os.path.join(self.stage.path, filename)
-            if abspath != self.archive_file:
-                shutil.rmtree(abspath, ignore_errors=True)
-
-        # Expand the archive again
-        self.expand()
-
-    def __repr__(self):
-        url = self.url if self.url else "no url"
-        return "%s<%s>" % (self.__class__.__name__, url)
-
-    def __str__(self):
-        if self.url:
-            return self.url
-        else:
-            return "[no url]"
-
-
-@fetcher
-class CurlFetchStrategy(FetchStrategy):
-    """CurlFetchStrategy pulls source code from a URL for an archive, check the
-    archive against a checksum, and decompresses the archive.
-
-    The destination for the resulting file(s) is the standard stage path.
-    """
-    url_attr = 'url'
-
-    # these are checksum types. The generic 'checksum' is deprecated for
-    # specific hash names, but we need it for backward compatibility
-    optional_attrs = list(crypto.hashes.keys()) + ['checksum']
-
-    def __init__(self, url=None, checksum=None, **kwargs):
-        super(CurlFetchStrategy, self).__init__(**kwargs)
-
-        # Prefer values in kwargs to the positionals.
-        self.url = kwargs.get('url', url)
-        self.mirrors = kwargs.get('mirrors', [])
-
-        # digest can be set as the first argument, or from an explicit
-        # kwarg by the hash name.
-        self.digest = kwargs.get('checksum', checksum)
-        for h in self.optional_attrs:
-            if h in kwargs:
-                self.digest = kwargs[h]
-
-        self.expand_archive = kwargs.get('expand', True)
-        self.extra_options = kwargs.get('fetch_options', {})
         self._curl = None
 
         self.extension = kwargs.get('extension', None)
 
         if not self.url:
-            raise ValueError("CurlFetchStrategy requires a url for fetching.")
+            raise ValueError("URLFetchStrategy requires a url for fetching.")
 
     @property
     def curl(self):
@@ -564,7 +311,7 @@ class CurlFetchStrategy(FetchStrategy):
                 if save_file:
                     os.rename(partial_file, save_file)
                 break
-            except FetchError as e:
+            except FailedDownloadError as e:
                 errors.append(str(e))
 
         for msg in errors:
@@ -575,14 +322,65 @@ class CurlFetchStrategy(FetchStrategy):
 
     def _existing_url(self, url):
         tty.debug('Checking existence of {0}'.format(url))
-        curl = self.curl
-        # Telling curl to fetch the first byte (-r 0-0) is supposed to be
-        # portable.
-        curl_args = ['--stderr', '-', '-s', '-f', '-r', '0-0', url]
-        _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
-        return curl.returncode == 0
+        if spack.config.get('config:use_curl'):
+            curl = self.curl
+            # Telling curl to fetch the first byte (-r 0-0) is supposed to be
+            # portable.
+            curl_args = ['--stderr', '-', '-s', '-f', '-r', '0-0', url]
+            if not spack.config.get('config:verify_ssl'):
+                curl_args.append('-k')
+            _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
+            return curl.returncode == 0
+        else:
+            # Telling urllib to check if url is accessible
+            try:
+                url, headers, response = web_util.read_from_url(url)
+            except web_util.SpackWebError:
+                msg = "Urllib fetch failed to verify url {0}".format(url)
+                raise FailedDownloadError(url, msg)
+            return (response.getcode() is None or response.getcode() == 200)
 
     def _fetch_from_url(self, url):
+        if spack.config.get('config:use_curl'):
+            return self._fetch_curl(url)
+        else:
+            return self._fetch_urllib(url)
+
+    @_needs_stage
+    def _fetch_urllib(self, url):
+        save_file = None
+        partial_file = None
+        if self.stage.save_filename:
+            save_file = self.stage.save_filename
+            partial_file = self.stage.save_filename + '.part'
+        tty.msg('Fetching {0}'.format(url))
+
+        # Run urllib but grab the mime type from the http headers
+        try:
+            url, headers, response = web_util.read_from_url(url)
+        except web_util.SpackWebError as e:
+            # clean up archive on failure.
+            if self.archive_file:
+                os.remove(self.archive_file)
+            if partial_file and os.path.exists(partial_file):
+                os.remove(partial_file)
+            msg = 'urllib failed to fetch with error {0}'.format(e)
+            raise FailedDownloadError(url, msg)
+        _data = response.read()
+        open(partial_file, 'wb').write(_data)
+        headers = _data.decode('utf-8', 'ignore')
+
+        # Check if we somehow got an HTML file rather than the archive we
+        # asked for.  We only look at the last content type, to handle
+        # redirects properly.
+        content_types = re.findall(r'Content-Type:[^\r\n]+', headers,
+                                   flags=re.IGNORECASE)
+        if content_types and 'text/html' in content_types[-1]:
+            warn_content_type_mismatch(self.archive_file or "the archive")
+        return partial_file, save_file
+
+    @_needs_stage
+    def _fetch_curl(self, url):
         save_file = None
         partial_file = None
         if self.stage.save_filename:
@@ -771,7 +569,7 @@ class CurlFetchStrategy(FetchStrategy):
            No-op if this stage checks code out of a repository."""
         if not self.digest:
             raise NoDigestError(
-                "Attempt to check CurlFetchStrategy with no digest.")
+                "Attempt to check URLFetchStrategy with no digest.")
 
         checker = crypto.Checker(self.digest)
         if not checker.check(self.archive_file):
@@ -787,7 +585,7 @@ class CurlFetchStrategy(FetchStrategy):
         """
         if not self.archive_file:
             raise NoArchiveFileError(
-                "Tried to reset CurlFetchStrategy before fetching",
+                "Tried to reset URLFetchStrategy before fetching",
                 "Failed on reset() for URL %s" % self.url)
 
         # Remove everything but the archive from the stage
@@ -1447,12 +1245,8 @@ def stable_target(fetcher):
     """Returns whether the fetcher target is expected to have a stable
        checksum. This is only true if the target is a preexisting archive
        file."""
-    if spack.config.get('config:use_curl'):
-        if isinstance(fetcher, CurlFetchStrategy) and fetcher.cachable:
-            return True
-    else:
-        if isinstance(fetcher, URLFetchStrategy) and fetcher.cachable:
-            return True
+    if isinstance(fetcher, URLFetchStrategy) and fetcher.cachable:
+        return True
     return False
 
 
@@ -1463,8 +1257,6 @@ def from_url(url):
        TODO: make this return appropriate fetch strategies for other
              types of URLs.
     """
-    if spack.config.get('config:use_curl'):
-        return CurlFetchStrategy(url)
     return URLFetchStrategy(url)
 
 
@@ -1535,12 +1327,8 @@ def _check_version_attributes(fetcher, pkg, version):
 def _extrapolate(pkg, version):
     """Create a fetcher from an extrapolated URL for this version."""
     try:
-        if spack.config.get('config:use_curl'):
-            return CurlFetchStrategy(pkg.url_for_version(version),
-                                     fetch_options=pkg.fetch_options)
-        else:
-            return URLFetchStrategy(pkg.url_for_version(version),
-                                    fetch_options=pkg.fetch_options)
+        return URLFetchStrategy(pkg.url_for_version(version),
+                                fetch_options=pkg.fetch_options)
     except spack.package.NoURLError:
         msg = ("Can't extrapolate a URL for version %s "
                "because package %s defines no URLs")
@@ -1666,12 +1454,8 @@ def from_list_url(pkg):
                         args.get('checksum'))
 
                 # construct a fetcher
-                if spack.config.get('config:use_curl'):
-                    return CurlFetchStrategy(url_from_list, checksum,
-                                             fetch_options=pkg.fetch_options)
-                else:
-                    return URLFetchStrategy(url_from_list, checksum,
-                                            fetch_options=pkg.fetch_options)
+                return URLFetchStrategy(url_from_list, checksum,
+                                        fetch_options=pkg.fetch_options)
             except KeyError as e:
                 tty.debug(e)
                 tty.msg("Cannot find version %s in url_list" % pkg.version)

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -237,8 +237,7 @@ class MirrorCollection(Mapping):
 
 
 def _determine_extension(fetcher):
-    if (isinstance(fetcher, fs.URLFetchStrategy) or
-        isinstance(fetcher, fs.CurlFetchStrategy)):
+    if isinstance(fetcher, fs.URLFetchStrategy):
         if fetcher.expand_archive:
             # If we fetch with a URLFetchStrategy, use URL's archive type
             ext = url.determine_url_file_extension(fetcher.url)

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -11,7 +11,6 @@ import inspect
 import llnl.util.filesystem
 import llnl.util.lang
 
-import spack.config
 import spack.error
 import spack.fetch_strategy as fs
 import spack.repo
@@ -232,12 +231,9 @@ class UrlPatch(Patch):
         fetch_digest = self.sha256
         if self.archive_sha256:
             fetch_digest = self.archive_sha256
-        if spack.config.get('config:use_curl'):
-            fetcher = fs.CurlFetchStrategy(self.url, fetch_digest,
-                                           expand=bool(self.archive_sha256))
-        else:
-            fetcher = fs.URLFetchStrategy(self.url, fetch_digest,
-                                          expand=bool(self.archive_sha256))
+
+        fetcher = fs.URLFetchStrategy(self.url, fetch_digest,
+                                      expand=bool(self.archive_sha256))
 
         # The same package can have multiple patches with the same name but
         # with different contents, therefore apply a subset of the hash.

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -373,9 +373,7 @@ class Stage(object):
         if isinstance(self.default_fetcher, fs.URLFetchStrategy):
             expanded = self.default_fetcher.expand_archive
             fnames.append(os.path.basename(self.default_fetcher.url))
-        elif isinstance(self.default_fetcher, fs.CurlFetchStrategy):
-            expanded = self.default_fetcher.expand_archive
-            fnames.append(os.path.basename(self.default_fetcher.url))
+
         if self.mirror_paths:
             fnames.extend(os.path.basename(x) for x in self.mirror_paths)
 
@@ -448,10 +446,6 @@ class Stage(object):
             expand = True
             extension = None
             if isinstance(self.default_fetcher, fs.URLFetchStrategy):
-                digest = self.default_fetcher.digest
-                expand = self.default_fetcher.expand_archive
-                extension = self.default_fetcher.extension
-            elif isinstance(self.default_fetcher, fs.CurlFetchStrategy):
                 digest = self.default_fetcher.digest
                 expand = self.default_fetcher.expand_archive
                 extension = self.default_fetcher.extension
@@ -882,12 +876,8 @@ def get_checksums_for_versions(
     for url, version in zip(urls, versions):
         try:
             if fetch_options:
-                if spack.config.get('config:use_curl'):
-                    url_or_fs = fs.CurlFetchStrategy(
-                        url, fetch_options=fetch_options)
-                else:
-                    url_or_fs = fs.URLFetchStrategy(
-                        url, fetch_options=fetch_options)
+                url_or_fs = fs.URLFetchStrategy(
+                    url, fetch_options=fetch_options)
             else:
                 url_or_fs = url
             with Stage(url_or_fs, keep=keep_stage) as stage:

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -5,32 +5,39 @@
 
 import os
 import pytest
+import sys
 
 from llnl.util.filesystem import mkdirp, touch
+
+import spack.config
 
 from spack.stage import Stage
 from spack.fetch_strategy import CacheURLFetchStrategy, NoCacheError
 
 
-def test_fetch_missing_cache(tmpdir):
+@pytest.mark.parametrize('use_curl', [True, False])
+def test_fetch_missing_cache(tmpdir, use_curl):
     """Ensure raise a missing cache file."""
     testpath = str(tmpdir)
+    with spack.config.override('config:locks', sys.platform != "win32"):
+        with spack.config.override('config:use_curl', True):
+            fetcher = CacheURLFetchStrategy(url='file:///not-a-real-cache-file')
+            with Stage(fetcher, path=testpath):
+                with pytest.raises(NoCacheError, match=r'No cache'):
+                    fetcher.fetch()
 
-    fetcher = CacheURLFetchStrategy(url='file:///not-a-real-cache-file')
-    with Stage(fetcher, path=testpath):
-        with pytest.raises(NoCacheError, match=r'No cache'):
-            fetcher.fetch()
 
-
-def test_fetch(tmpdir):
+@pytest.mark.parametrize('use_curl', [True, False])
+def test_fetch(tmpdir, use_curl):
     """Ensure a fetch after expanding is effectively a no-op."""
     testpath = str(tmpdir)
     cache = os.path.join(testpath, 'cache.tar.gz')
     touch(cache)
     url = 'file:///{0}'.format(cache)
-
-    fetcher = CacheURLFetchStrategy(url=url)
-    with Stage(fetcher, path=testpath) as stage:
-        source_path = stage.source_path
-        mkdirp(source_path)
-        fetcher.fetch()
+    with spack.config.override('config:locks', sys.platform != "win32"):
+        with spack.config.override('config:use_curl', True):
+            fetcher = CacheURLFetchStrategy(url=url)
+            with Stage(fetcher, path=testpath) as stage:
+                source_path = stage.source_path
+                mkdirp(source_path)
+                fetcher.fetch()

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -20,7 +20,7 @@ def test_fetch_missing_cache(tmpdir, use_curl):
     """Ensure raise a missing cache file."""
     testpath = str(tmpdir)
     with spack.config.override('config:locks', sys.platform != "win32"):
-        with spack.config.override('config:use_curl', True):
+        with spack.config.override('config:use_curl', use_curl):
             fetcher = CacheURLFetchStrategy(url='file:///not-a-real-cache-file')
             with Stage(fetcher, path=testpath):
                 with pytest.raises(NoCacheError, match=r'No cache'):
@@ -35,7 +35,7 @@ def test_fetch(tmpdir, use_curl):
     touch(cache)
     url = 'file:///{0}'.format(cache)
     with spack.config.override('config:locks', sys.platform != "win32"):
-        with spack.config.override('config:use_curl', True):
+        with spack.config.override('config:use_curl', use_curl):
             fetcher = CacheURLFetchStrategy(url=url)
             with Stage(fetcher, path=testpath) as stage:
                 source_path = stage.source_path

--- a/lib/spack/spack/test/s3_fetch.py
+++ b/lib/spack/spack/test/s3_fetch.py
@@ -16,7 +16,7 @@ import spack.stage as spack_stage
 @pytest.mark.parametrize('use_curl', [True, False])
 def test_s3fetchstrategy_sans_url(use_curl):
     """Ensure constructor with no URL fails."""
-    with spack_config.override('config:use_curl', True):
+    with spack_config.override('config:use_curl', use_curl):
         with pytest.raises(ValueError):
             spack_fs.S3FetchStrategy(None)
 
@@ -27,7 +27,7 @@ def test_s3fetchstrategy_bad_url(tmpdir, use_curl):
     testpath = str(tmpdir)
 
     with spack_config.override('config:locks', sys.platform != "win32"):
-        with spack_config.override('config:use_curl', True):
+        with spack_config.override('config:use_curl', use_curl):
             fetcher = spack_fs.S3FetchStrategy(url='file:///does-not-exist')
             assert fetcher is not None
 
@@ -45,7 +45,7 @@ def test_s3fetchstrategy_downloaded(tmpdir, use_curl):
     archive = os.path.join(testpath, 's3.tar.gz')
 
     with spack_config.override('config:locks', sys.platform != "win32"):
-        with spack_config.override('config:use_curl', True):
+        with spack_config.override('config:use_curl', use_curl):
             class Archived_S3FS(spack_fs.S3FetchStrategy):
                 @property
                 def archive_file(self):

--- a/lib/spack/spack/test/s3_fetch.py
+++ b/lib/spack/spack/test/s3_fetch.py
@@ -8,7 +8,6 @@ import pytest
 import sys
 
 import spack.config as spack_config
-import spack.config as spack_config
 import spack.fetch_strategy as spack_fs
 import spack.stage as spack_stage
 

--- a/lib/spack/spack/test/s3_fetch.py
+++ b/lib/spack/spack/test/s3_fetch.py
@@ -5,42 +5,53 @@
 
 import os
 import pytest
+import sys
 
+import spack.config as spack_config
+import spack.config as spack_config
 import spack.fetch_strategy as spack_fs
 import spack.stage as spack_stage
 
 
-def test_s3fetchstrategy_sans_url():
+@pytest.mark.parametrize('use_curl', [True, False])
+def test_s3fetchstrategy_sans_url(use_curl):
     """Ensure constructor with no URL fails."""
-    with pytest.raises(ValueError):
-        spack_fs.S3FetchStrategy(None)
+    with spack_config.override('config:use_curl', True):
+        with pytest.raises(ValueError):
+            spack_fs.S3FetchStrategy(None)
 
 
-def test_s3fetchstrategy_bad_url(tmpdir):
+@pytest.mark.parametrize('use_curl', [True, False])
+def test_s3fetchstrategy_bad_url(tmpdir, use_curl):
     """Ensure fetch with bad URL fails as expected."""
     testpath = str(tmpdir)
 
-    fetcher = spack_fs.S3FetchStrategy(url='file:///does-not-exist')
-    assert fetcher is not None
+    with spack_config.override('config:locks', sys.platform != "win32"):
+        with spack_config.override('config:use_curl', True):
+            fetcher = spack_fs.S3FetchStrategy(url='file:///does-not-exist')
+            assert fetcher is not None
 
-    with spack_stage.Stage(fetcher, path=testpath) as stage:
-        assert stage is not None
-        assert fetcher.archive_file is None
-        with pytest.raises(spack_fs.FetchError):
-            fetcher.fetch()
+            with spack_stage.Stage(fetcher, path=testpath) as stage:
+                assert stage is not None
+                assert fetcher.archive_file is None
+                with pytest.raises(spack_fs.FetchError):
+                    fetcher.fetch()
 
 
-def test_s3fetchstrategy_downloaded(tmpdir):
+@pytest.mark.parametrize('use_curl', [True, False])
+def test_s3fetchstrategy_downloaded(tmpdir, use_curl):
     """Ensure fetch with archive file already downloaded is a noop."""
     testpath = str(tmpdir)
     archive = os.path.join(testpath, 's3.tar.gz')
 
-    class Archived_S3FS(spack_fs.S3FetchStrategy):
-        @property
-        def archive_file(self):
-            return archive
+    with spack_config.override('config:locks', sys.platform != "win32"):
+        with spack_config.override('config:use_curl', True):
+            class Archived_S3FS(spack_fs.S3FetchStrategy):
+                @property
+                def archive_file(self):
+                    return archive
 
-    url = 's3:///{0}'.format(archive)
-    fetcher = Archived_S3FS(url=url)
-    with spack_stage.Stage(fetcher, path=testpath):
-        fetcher.fetch()
+            url = 's3:///{0}'.format(archive)
+            fetcher = Archived_S3FS(url=url)
+            with spack_stage.Stage(fetcher, path=testpath):
+                fetcher.fetch()

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -53,12 +53,8 @@ def test_urlfetchstrategy_sans_url(use_curl):
     """Ensure constructor with no URL fails."""
     with spack.config.override('config:use_curl', use_curl):
         with pytest.raises(ValueError):
-            if use_curl:
-                with fs.CurlFetchStrategy(None):
-                    pass
-            else:
-                with fs.URLFetchStrategy(None):
-                    pass
+            with fs.URLFetchStrategy(None):
+                pass
 
 
 @pytest.mark.parametrize('use_curl', [True, False])
@@ -68,10 +64,7 @@ def test_urlfetchstrategy_bad_url(tmpdir, use_curl):
     with spack.config.override('config:locks', sys.platform != "win32"):
         with spack.config.override('config:use_curl', use_curl):
             with pytest.raises(fs.FailedDownloadError):
-                if use_curl:
-                    fetcher = fs.CurlFetchStrategy(url='file:///does-not-exist')
-                else:
-                    fetcher = fs.URLFetchStrategy(url='file:///does-not-exist')
+                fetcher = fs.URLFetchStrategy(url='file:///does-not-exist')
                 assert fetcher is not None
 
                 with Stage(fetcher, path=testpath) as stage:
@@ -84,9 +77,9 @@ def test_fetch_options(tmpdir, mock_archive):
     testpath = str(tmpdir)
     with spack.config.override('config:locks', sys.platform != "win32"):
         with spack.config.override('config:use_curl', True):
-            fetcher = fs.CurlFetchStrategy(url=mock_archive.url,
-                                           fetch_options={'cookie': 'True',
-                                                          'timeout': 10})
+            fetcher = fs.URLFetchStrategy(url=mock_archive.url,
+                                          fetch_options={'cookie': 'True',
+                                                         'timeout': 10})
             assert fetcher is not None
 
             with Stage(fetcher, path=testpath) as stage:
@@ -101,10 +94,7 @@ def test_archive_file_errors(tmpdir, mock_archive, use_curl):
     testpath = str(tmpdir)
     with spack.config.override('config:locks', sys.platform != "win32"):
         with spack.config.override('config:use_curl', use_curl):
-            if use_curl:
-                fetcher = fs.CurlFetchStrategy(url=mock_archive.url)
-            else:
-                fetcher = fs.URLFetchStrategy(url=mock_archive.url)
+            fetcher = fs.URLFetchStrategy(url=mock_archive.url)
             assert fetcher is not None
             with pytest.raises(fs.FailedDownloadError):
                 with Stage(fetcher, path=testpath) as stage:
@@ -196,10 +186,7 @@ def test_from_list_url(mock_packages, config, spec, url, digest, use_curl):
         specification = Spec(spec).concretized()
         pkg = spack.repo.get(specification)
         fetch_strategy = fs.from_list_url(pkg)
-        if use_curl:
-            assert isinstance(fetch_strategy, fs.CurlFetchStrategy)
-        else:
-            assert isinstance(fetch_strategy, fs.URLFetchStrategy)
+        assert isinstance(fetch_strategy, fs.URLFetchStrategy)
         assert os.path.basename(fetch_strategy.url) == url
         assert fetch_strategy.digest == digest
         assert fetch_strategy.extra_options == {}
@@ -217,10 +204,7 @@ def test_from_list_url_unspecified(mock_packages, config, use_curl):
         spec = Spec('url-list-test @2.0.0').concretized()
         pkg = spack.repo.get(spec)
         fetch_strategy = fs.from_list_url(pkg)
-        if use_curl:
-            assert isinstance(fetch_strategy, fs.CurlFetchStrategy)
-        else:
-            assert isinstance(fetch_strategy, fs.URLFetchStrategy)
+        assert isinstance(fetch_strategy, fs.URLFetchStrategy)
         assert os.path.basename(fetch_strategy.url) == 'foo-2.0.0.tar.gz'
         assert fetch_strategy.digest is None
         assert fetch_strategy.extra_options == {}
@@ -260,15 +244,16 @@ def test_url_with_status_bar(tmpdir, mock_archive, monkeypatch, capfd):
 
     monkeypatch.setattr(sys.stdout, 'isatty', is_true)
     monkeypatch.setattr(tty, 'msg_enabled', is_true)
-
     with spack.config.override('config:locks', sys.platform != "win32"):
-        fetcher = fs.CurlFetchStrategy(mock_archive.url)
-        with Stage(fetcher, path=testpath) as stage:
-            assert fetcher.archive_file is None
-            stage.fetch()
+        with spack.config.override('config:use_curl', True):
+            fetcher = fs.URLFetchStrategy(mock_archive.url)
 
-        status = capfd.readouterr()[1]
-        assert '##### 100' in status
+            with Stage(fetcher, path=testpath) as stage:
+                assert fetcher.archive_file is None
+                stage.fetch()
+
+            status = capfd.readouterr()[1]
+            assert '##### 100' in status
 
 
 @pytest.mark.parametrize('use_curl', [True, False])
@@ -277,10 +262,7 @@ def test_url_extra_fetch(tmpdir, mock_archive, use_curl):
     with spack.config.override('config:locks', sys.platform != "win32"):
         with spack.config.override('config:use_curl', use_curl):
             testpath = str(tmpdir)
-            if use_curl:
-                fetcher = fs.CurlFetchStrategy(mock_archive.url)
-            else:
-                fetcher = fs.URLFetchStrategy(mock_archive.url)
+            fetcher = fs.URLFetchStrategy(mock_archive.url)
             with Stage(fetcher, path=testpath) as stage:
                 assert fetcher.archive_file is None
                 stage.fetch()
@@ -303,17 +285,11 @@ def test_candidate_urls(pkg_factory, url, urls, version, expected, use_curl):
     """
     with spack.config.override('config:use_curl', use_curl):
         pkg = pkg_factory(url, urls)
-        if use_curl:
-            f = fs._from_merged_attrs(fs.CurlFetchStrategy, pkg, version)
-        else:
-            f = fs._from_merged_attrs(fs.URLFetchStrategy, pkg, version)
+        f = fs._from_merged_attrs(fs.URLFetchStrategy, pkg, version)
         assert f.candidate_urls == expected
         assert f.extra_options == {}
         pkg = pkg_factory(url, urls, fetch_options={'timeout': 60})
-        if use_curl:
-            f = fs._from_merged_attrs(fs.CurlFetchStrategy, pkg, version)
-        else:
-            f = fs._from_merged_attrs(fs.URLFetchStrategy, pkg, version)
+        f = fs._from_merged_attrs(fs.URLFetchStrategy, pkg, version)
         assert f.extra_options == {'timeout': 60}
 
 
@@ -334,10 +310,10 @@ def test_missing_curl(tmpdir, monkeypatch):
     with spack.config.override('config:locks', sys.platform != "win32"):
         testpath = str(tmpdir)
         url = 'http://github.com/spack/spack'
-        fetcher = fs.CurlFetchStrategy(url=url)
-        assert fetcher is not None
-        with pytest.raises(TypeError, match='object is not callable'):
-            with Stage(fetcher, path=testpath) as stage:
-                out = stage.fetch()
-
-            assert err_fmt.format('curl') in out
+        with spack.config.override('config:use_curl', True):
+            fetcher = fs.URLFetchStrategy(url=url)
+            assert fetcher is not None
+            with pytest.raises(TypeError, match='object is not callable'):
+                with Stage(fetcher, path=testpath) as stage:
+                    out = stage.fetch()
+                assert err_fmt.format('curl') in out


### PR DESCRIPTION
This simplifies the logic in other files and ensures that the intended
fetch strategy is used.

Note that cache_fetch::fetch currently fails on Windows