### PR TITLE
spack python: add --path option

### DIFF
--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -34,6 +34,9 @@ def setup_parser(subparser):
         '-m', dest='module', action='store',
         help='run library module as a script')
     subparser.add_argument(
+        '--path', action='store_true', dest='show_path',
+        help='show path to python interpreter that spack uses')
+    subparser.add_argument(
         'python_args', nargs=argparse.REMAINDER,
         help="file to run plus arguments")
 
@@ -41,6 +44,10 @@ def setup_parser(subparser):
 def python(parser, args, unknown_args):
     if args.version:
         print('Python', platform.python_version())
+        return
+
+    if args.show_path:
+        print(sys.executable)
         return
 
     if args.module:

--- a/lib/spack/spack/test/cmd/python.py
+++ b/lib/spack/spack/test/cmd/python.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import platform
+import sys
 
 import pytest
 
@@ -16,6 +17,11 @@ python = SpackCommand('python')
 def test_python():
     out = python('-c', 'import spack; print(spack.spack_version)')
     assert out.strip() == spack.spack_version
+
+
+def test_python_interpreter_path():
+    out = python('--path')
+    assert out.strip() == sys.executable
 
 
 def test_python_version():

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1385,7 +1385,7 @@ _spack_pydoc() {
 _spack_python() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -V --version -c -i -m"
+        SPACK_COMPREPLY="-h --help -V --version -c -i -m --path"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
This adds a `--path` option to `spack python` that shows the `python` interpreter that Spack is using.

e.g.:

```console
$ spack python --path
/Users/gamblin2/src/spack/var/spack/environments/default/.spack-env/view/bin/python
```

This is useful for debugging, and we can ask users to run it to understand what python Spack is picking up via preferences in `bin/spack` and via the `SPACK_PYTHON` environment variable introduced in #21222.