### PR TITLE
gchp: patch for aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/gchp/for_aarch64.patch
+++ b/var/spack/repos/builtin/packages/gchp/for_aarch64.patch
@@ -1,0 +1,24 @@
+diff -uprN spack-src.org/ESMA_cmake/GNU.cmake spack-src/ESMA_cmake/GNU.cmake
+--- spack-src.org/ESMA_cmake/GNU.cmake  2021-02-25 11:28:42.856054566 +0900
++++ spack-src/ESMA_cmake/GNU.cmake      2021-02-25 10:38:06.556356960 +0900
+@@ -125,7 +125,7 @@ set (GEOS_Fortran_Debug_FPE_Flags "${com
+
+ # GEOS Release
+ # ------------
+-set (GEOS_Fortran_Release_Flags "${FOPT3} -march=westmere -mtune=generic -funroll-loops ${DEBINFO}")
++set (GEOS_Fortran_Release_Flags "${FOPT3} -funroll-loops ${DEBINFO}")
+ set (GEOS_Fortran_Release_FPE_Flags "${common_Fortran_fpe_flags}")
+
+ # GEOS Vectorize
+diff -uprN spack-src.org/src/GCHP_GridComp/HEMCO_GridComp/HEMCO/CMakeLists.txt spack-src/src/GCHP_GridComp/HEMCO_GridComp/HEMCO/CMakeLists.txt
+--- spack-src.org/src/GCHP_GridComp/HEMCO_GridComp/HEMCO/CMakeLists.txt 2021-02-25 11:33:57.897033867 +0900
++++ spack-src/src/GCHP_GridComp/HEMCO_GridComp/HEMCO/CMakeLists.txt     2021-02-25 11:22:06.224802880 +0900
+@@ -64,7 +64,7 @@ set(HEMCO_Fortran_FLAGS_DEBUG_Intel
+
+ set(HEMCO_Fortran_FLAGS_GNU
+    -cpp -w -std=legacy -fautomatic -fno-align-commons -fconvert=big-endian
+-   -fno-range-check -mcmodel=medium -fbacktrace -g -DLINUX_GFORTRAN
++   -fno-range-check -mcmodel=small -fbacktrace -g -DLINUX_GFORTRAN
+    -ffree-line-length-none
+    CACHE STRING "HEMCO compiler flags for all build types with GNU compilers"
+ )

--- a/var/spack/repos/builtin/packages/gchp/package.py
+++ b/var/spack/repos/builtin/packages/gchp/package.py
@@ -17,6 +17,9 @@ class Gchp(CMakePackage):
 
     version('13.0.0-rc.0', git='https://github.com/geoschem/GCHP.git',
             commit='4bd15316faf4e5f06517d3a6b1df1986b1126d90',  submodules=True)
+
+    patch('for_aarch64.patch', when='target=aarch64:')
+
     # NOTE: Post-13.0.0-rc.0 versions will have fix that
     # allows these ESMF variants to be enabled
     depends_on('esmf@8.0.1: -lapack -pio -pnetcdf -xerces')


### PR DESCRIPTION
I was having installation failures with aarch64.
Therefore, I created a patch for aarch64.

```
     833    cd /tmp/r1059/spack-stage/spack-stage-gchp-13.0.0-rc.0-hsrscx4khwxvw7fifovxrxn3royigho
            r/spack-build-hsrscx4/src/yaFyaml/src && /fefs/home/r1059/spack/lib/spack/env/gcc/gfor
            tran -DFORTRAN_COMPILER_SUPPORTS_ASSUMED_TYPE -D__GFORTRAN__ -I/tmp/r1059/spack-stage/
            spack-stage-gchp-13.0.0-rc.0-hsrscx4khwxvw7fifovxrxn3royighor/spack-build-hsrscx4/src/
            yaFyaml/include -I/tmp/r1059/spack-stage/spack-stage-gchp-13.0.0-rc.0-hsrscx4khwxvw7fi
            fovxrxn3royighor/spack-build-hsrscx4/src/gFTL-shared/mod -I/tmp/r1059/spack-stage/spac
            k-stage-gchp-13.0.0-rc.0-hsrscx4khwxvw7fifovxrxn3royighor/spack-build-hsrscx4/src/gFTL
            -shared/extern/gFTL/include -ffree-line-length-none -O2 -g -DNDEBUG -J../include -fPIC
             -c /tmp/r1059/spack-stage/spack-stage-gchp-13.0.0-rc.0-hsrscx4khwxvw7fifovxrxn3royigh
            or/spack-src/src/yaFyaml/src/AbstractTextStream.F90 -o CMakeFiles/yafyaml.dir/Abstract
            TextStream.F90.o
  >> 834    f951: Error: unknown value 'westmere' for -march
     835    f951: note: valid arguments are: armv8-a armv8.1-a armv8.2-a armv8.3-a armv8.4-a native
```
            