### PR TITLE
py-pyprecice: Add version 2.1.1.2 and 2.2.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -28,9 +28,6 @@ class PyPyprecice(PythonPackage):
     version("2.0.0.2", sha256="5f055d809d65ec2e81f4d001812a250f50418de59990b47d6bcb12b88da5f5d7")
     version("2.0.0.1", sha256="96eafdf421ec61ad6fcf0ab1d3cf210831a815272984c470b2aea57d4d0c9e0e")
 
-    # Import module as a test
-    import_modules = ["precice"]
-
     # Older versions of the bindings checked versions via pip. This patch
     # removes the pip dependency.
     # See also https://github.com/spack/spack/pull/19558
@@ -46,8 +43,6 @@ class PyPyprecice(PythonPackage):
 
     depends_on("python@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    # py-wheel dependency is specified in pyproject.toml of pyprecice
-    depends_on("py-wheel", type="build")
     depends_on("py-numpy", type=("build", "run"))
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type=("build"))

--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -47,7 +47,7 @@ class PyPyprecice(PythonPackage):
     depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type=("build"))
 
-    phases = ['install_lib','build_ext', 'install']
+    phases = ['install_lib', 'build_ext', 'install']
 
     def build_ext_args(self, spec, prefix):
         return [

--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -33,7 +33,7 @@ class PyPyprecice(PythonPackage):
     # See also https://github.com/spack/spack/pull/19558
     patch("deactivate-version-check-via-pip.patch", when="@:2.1.1.1")
 
-    depends_on("precice", when="@develop")
+    depends_on("precice@develop", when="@develop")
     depends_on("precice@2.2.0", when="@2.2.0.1:2.2.0.99")
     depends_on("precice@2.1.1", when="@2.1.1.1:2.1.1.99")
     depends_on("precice@2.1.0", when="@2.1.0.1:2.1.0.99")

--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -19,6 +19,8 @@ class PyPyprecice(PythonPackage):
 
     # Always prefer final version of release candidate
     version("develop", branch="develop")
+    version('2.2.0.1', sha256='032fa58193cfa69e3be37557977056e8f507d89b40c490a351d17271269b25ad')
+    version('2.1.1.2', sha256='363eb3eeccf964fd5ee87012c1032353dd1518662868f2b51f04a6d8a7154045')
     version("2.1.1.1", sha256="972f574549344b6155a8dd415b6d82512e00fa154ca25ae7e36b68d4d2ed2cf4")
     version("2.1.0.1", sha256="ac5cb7412c6b96b08a04fa86ea38e52d91ea739a3bd1c209baa93a8275e4e01a")
     version("2.0.2.1", sha256="c6fca26332316de041f559aecbf23122a85d6348baa5d3252be4ddcd5e94c09a")
@@ -26,11 +28,16 @@ class PyPyprecice(PythonPackage):
     version("2.0.0.2", sha256="5f055d809d65ec2e81f4d001812a250f50418de59990b47d6bcb12b88da5f5d7")
     version("2.0.0.1", sha256="96eafdf421ec61ad6fcf0ab1d3cf210831a815272984c470b2aea57d4d0c9e0e")
 
-    patch("deactivate-version-check-via-pip.patch")
+    # Import module as a test
+    import_modules = ["precice"]
 
-    variant("mpi", default=True, description="Enables MPI support")
+    # Older versions of the bindings checked versions via pip. This patch
+    # removes the pip dependency.
+    # See also https://github.com/spack/spack/pull/19558
+    patch("deactivate-version-check-via-pip.patch", when="@:2.1.1.1")
 
-    depends_on("mpi", when="+mpi")
+    depends_on("precice", when="@develop")
+    depends_on("precice@2.2.0", when="@2.2.0.1:2.2.0.99")
     depends_on("precice@2.1.1", when="@2.1.1.1:2.1.1.99")
     depends_on("precice@2.1.0", when="@2.1.0.1:2.1.0.99")
     depends_on("precice@2.0.2", when="@2.0.2.1:2.0.2.99")
@@ -39,12 +46,13 @@ class PyPyprecice(PythonPackage):
 
     depends_on("python@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    # py-wheel dependency is specified in pyproject.toml of pyprecice
     depends_on("py-wheel", type="build")
     depends_on("py-numpy", type=("build", "run"))
-    depends_on("py-mpi4py", type=("build", "run"), when="+mpi")
+    depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type=("build"))
 
-    phases = ['build_ext', 'install']
+    phases = ['install_lib','build_ext', 'install']
 
     def build_ext_args(self, spec, prefix):
         return [
@@ -53,4 +61,7 @@ class PyPyprecice(PythonPackage):
         ]
 
     def install(self, spec, prefix):
-        self.setup_py("install", "--prefix={0}".format(prefix))
+        # Older versions of the bindings had a non-standard installation routine
+        # See also https://github.com/spack/spack/pull/19558#discussion_r513123239
+        if self.version <= Version("2.1.1.1"):
+            self.setup_py("install", "--prefix={0}".format(prefix))

--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -19,6 +19,8 @@ class PyPyprecice(PythonPackage):
 
     # Always prefer final version of release candidate
     version("develop", branch="develop")
+    version('2.2.0.1', sha256='032fa58193cfa69e3be37557977056e8f507d89b40c490a351d17271269b25ad')
+    version('2.1.1.2', sha256='363eb3eeccf964fd5ee87012c1032353dd1518662868f2b51f04a6d8a7154045')
     version("2.1.1.1", sha256="972f574549344b6155a8dd415b6d82512e00fa154ca25ae7e36b68d4d2ed2cf4")
     version("2.1.0.1", sha256="ac5cb7412c6b96b08a04fa86ea38e52d91ea739a3bd1c209baa93a8275e4e01a")
     version("2.0.2.1", sha256="c6fca26332316de041f559aecbf23122a85d6348baa5d3252be4ddcd5e94c09a")
@@ -26,11 +28,16 @@ class PyPyprecice(PythonPackage):
     version("2.0.0.2", sha256="5f055d809d65ec2e81f4d001812a250f50418de59990b47d6bcb12b88da5f5d7")
     version("2.0.0.1", sha256="96eafdf421ec61ad6fcf0ab1d3cf210831a815272984c470b2aea57d4d0c9e0e")
 
-    patch("deactivate-version-check-via-pip.patch")
+    # Import module as a test
+    import_modules = ["precice"]
+
+    patch("deactivate-version-check-via-pip.patch", when="@:2.1.1.1")
 
     variant("mpi", default=True, description="Enables MPI support")
 
     depends_on("mpi", when="+mpi")
+    depends_on("precice", when="@develop")
+    depends_on("precice@2.2.0", when="@2.2.0.1:2.2.0.99")
     depends_on("precice@2.1.1", when="@2.1.1.1:2.1.1.99")
     depends_on("precice@2.1.0", when="@2.1.0.1:2.1.0.99")
     depends_on("precice@2.0.2", when="@2.0.2.1:2.0.2.99")
@@ -44,7 +51,7 @@ class PyPyprecice(PythonPackage):
     depends_on("py-mpi4py", type=("build", "run"), when="+mpi")
     depends_on("py-cython@0.29:", type=("build"))
 
-    phases = ['build_ext', 'install']
+    phases = ['install_lib', 'build_ext', 'install']
 
     def build_ext_args(self, spec, prefix):
         return [
@@ -53,4 +60,5 @@ class PyPyprecice(PythonPackage):
         ]
 
     def install(self, spec, prefix):
-        self.setup_py("install", "--prefix={0}".format(prefix))
+        if self.version <= Version("2.1.1.1"):
+            self.setup_py("install", "--prefix={0}".format(prefix))

--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -15,7 +15,7 @@ class PyPyprecice(PythonPackage):
     homepage = "https://www.precice.org"
     git = "https://github.com/precice/python-bindings.git"
     url = "https://github.com/precice/python-bindings/archive/v2.0.0.1.tar.gz"
-    maintainers = ["ajaust", "BenjaminRueth"]
+    maintainers = ["ajaust", "BenjaminRodenberg"]
 
     # Always prefer final version of release candidate
     version("develop", branch="develop")
@@ -65,5 +65,3 @@ class PyPyprecice(PythonPackage):
         # See also https://github.com/spack/spack/pull/19558#discussion_r513123239
         if self.version <= Version("2.1.1.1"):
             self.setup_py("install", "--prefix={0}".format(prefix))
-        else:
-            super.install(spec, prefix)

--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -31,11 +31,11 @@ class PyPyprecice(PythonPackage):
     # Import module as a test
     import_modules = ["precice"]
 
+    # Older versions of the bindings checked versions via pip. This patch
+    # removes the pip dependency.
+    # See also https://github.com/spack/spack/pull/19558
     patch("deactivate-version-check-via-pip.patch", when="@:2.1.1.1")
 
-    variant("mpi", default=True, description="Enables MPI support")
-
-    depends_on("mpi", when="+mpi")
     depends_on("precice", when="@develop")
     depends_on("precice@2.2.0", when="@2.2.0.1:2.2.0.99")
     depends_on("precice@2.1.1", when="@2.1.1.1:2.1.1.99")
@@ -46,12 +46,13 @@ class PyPyprecice(PythonPackage):
 
     depends_on("python@3:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
+    # py-wheel dependency is specified in pyproject.toml of pyprecice
     depends_on("py-wheel", type="build")
     depends_on("py-numpy", type=("build", "run"))
-    depends_on("py-mpi4py", type=("build", "run"), when="+mpi")
+    depends_on("py-mpi4py", type=("build", "run"))
     depends_on("py-cython@0.29:", type=("build"))
 
-    phases = ['install_lib', 'build_ext', 'install']
+    phases = ['build_ext', 'install']
 
     def build_ext_args(self, spec, prefix):
         return [
@@ -60,5 +61,9 @@ class PyPyprecice(PythonPackage):
         ]
 
     def install(self, spec, prefix):
+        # Older versions of the bindings had a non-standard installation routine
+        # See also https://github.com/spack/spack/pull/19558#discussion_r513123239
         if self.version <= Version("2.1.1.1"):
             self.setup_py("install", "--prefix={0}".format(prefix))
+        else:
+            super.install(spec, prefix)


### PR DESCRIPTION
This PR adds the updated Python bindings for the current versions preCICE (#19264 and #21166) 
The PR has been reopened due to a bad merge in the previous PR (see https://github.com/spack/spack/pull/21881)

The following changes have been made to the recipe:
- Handle of maintainer has been updated: `BenjaminRueth` -> `BenjaminRodenberg`
- Added `py-precice` versions 2.1.1.2 and 2.2.0.1
- The installation procedure of `pyprecice` has been improved which made changes to the Spack package necessary:
    - Now, the patch `deactivate-version-check-via-pip.patch` is only needed for versions <= 2.1.1.1 of the pyprecice. This is reflected accordingly in the Spack recipe. 
    - For these old versions (<= 2.1.1.1) the `install` routine of Spack had to be overwritten (see https://github.com/spack/spack/pull/19558) due to non-standard installation procedures of `pyprecice`. This is not needed for the newer releases anymore.
    - Added phase `install_lib`. This is needed since new versions of `pyprecice` use versioneer to create the `__version__` property of the package. This needs the `install_lib` step such that necessary files (e.g. `_version.py`) are created for compiling `pyprecice` in  the `build_ext` step. The phase `install_lib` is not needed for the old versions (<= 2.1.1.1), but I did not find a way to have version dependent phases. I tested that the old version still worked after adding `install_lib` as phase and they do. (See also explanations by @BenjaminRodenberg  in https://github.com/spack/spack/pull/21881)
- We added some comments to the Spack recipe to make some decisions/dependencies more clear, e.g., that the dependency of `py-wheel` is specified in `pyproject.toml`. However, not all dependencies listed in `pyproject.toml` are needed to build `pyprecice` with Spack, i.e. `pip` is not needed.
- Removed the `mpi` variant and made `mpi4py` a mandatory dependency as pointed out it https://github.com/spack/spack/pull/21881
- Adding `import_modules` for testing installation of the module.

Adding @BenjaminRodenberg  for reference.