### PR TITLE
update mochi-margo package to reflect that official repo has migrated to github

### DIFF
--- a/var/spack/repos/builtin/packages/mochi-margo/package.py
+++ b/var/spack/repos/builtin/packages/mochi-margo/package.py
@@ -10,13 +10,13 @@ class MochiMargo(AutotoolsPackage):
     """A library that provides Argobots bindings to the Mercury RPC
     implementation."""
 
-    homepage = 'https://xgitlab.cels.anl.gov/sds/margo'
-    git = 'https://xgitlab.cels.anl.gov/sds/margo.git'
-    url = 'https://xgitlab.cels.anl.gov/sds/margo/-/archive/v0.9/margo-v0.9.tar.gz'
+    homepage = 'https://github.com/mochi-hpc/mochi-margo'
+    git = 'https://github.com/mochi-hpc/mochi-margo.git'
+    url = 'https://github.com/mochi-hpc/mochi-margo/archive/v0.9.tar.gz'
 
     maintainers = ['carns', 'mdorier', 'fbudin69500', 'chuckatkins']
 
-    version('master', branch='master')
+    version('main', branch='main')
     version('0.9', sha256='a24376f66450cc8fd7a43043e189f8efce5a931585e53c1e2e41894a3e99b517')
     version('0.7', sha256='492d1afe2e7984fa638614a5d34486d2ff761f5599b5984efd5ae3f55cafde54')
     version('0.7.2', sha256='0ca796abdb82084813a5de033d92364910b5ad1a0df135534d6b1c36ef627859')
@@ -46,9 +46,6 @@ class MochiMargo(AutotoolsPackage):
     # "breadcrumb" support not available in mercury-1.0
     depends_on('mercury@1.0.0:', type=("build", "link", "run"), when='@:0.5.1')
     depends_on('mercury@2.0.0:', type=("build", "link", "run"), when='@0.5.2:')
-
-    # dependencies for develop version
-    depends_on('mercury@master', type=("build", "link", "run"), when='@develop')
 
     def autoreconf(self, spec, prefix):
         sh = which('sh')


### PR DESCRIPTION
Also:
* rename default branch to "main"
* remove a stale dependency statement