### PR TITLE
py-importlib: Python 2.7 is needed to build.

### DIFF
--- a/var/spack/repos/builtin/packages/py-importlib/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib/package.py
@@ -13,3 +13,5 @@ class PyImportlib(PythonPackage):
     pypi = "importlib/importlib-1.0.4.zip"
 
     version('1.0.4', sha256='b6ee7066fea66e35f8d0acee24d98006de1a0a8a94a8ce6efe73a9a23c8d9826')
+
+    depends_on('python@2.7.0:2.7.99')

--- a/var/spack/repos/builtin/packages/py-importlib/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib/package.py
@@ -14,4 +14,4 @@ class PyImportlib(PythonPackage):
 
     version('1.0.4', sha256='b6ee7066fea66e35f8d0acee24d98006de1a0a8a94a8ce6efe73a9a23c8d9826')
 
-    depends_on('python@2.7.0:2.7.99')
+    depends_on('python@:2.6.999,3.0.0:3.0.999', type=('build', 'run'))


### PR DESCRIPTION
added     depends_on('python@2.7.0:2.7.99')