### PR TITLE
py-adb-enhanced: update version to fix runtime error

### DIFF
--- a/var/spack/repos/builtin/packages/py-adb-enhanced/package.py
+++ b/var/spack/repos/builtin/packages/py-adb-enhanced/package.py
@@ -15,6 +15,7 @@ class PyAdbEnhanced(PythonPackage):
     homepage = "https://opencollective.com/ashishb"
     url      = "https://github.com/ashishb/adb-enhanced/archive/2.5.4.tar.gz"
 
+    version('2.5.10', sha256='9e913d09814ce99974c455a766c5b616a92bca551e657517d6e079882eb19bdb')
     version('2.5.4', sha256='329ee2e0cfceaa41c591398b365d9acdfd45ffe913c64ac06e1538041986fffb')
     version('2.5.3', sha256='5a1d5182d1a073b440e862e5481c7a21073eccc3cda7a4774a2aa311fee9bbdc')
     version('2.5.2', sha256='055676156c1566b8d952b9fdfdd89fc09f2d5d1e3b90b4cdf40858ce9947e2ca')
@@ -24,4 +25,4 @@ class PyAdbEnhanced(PythonPackage):
     depends_on('py-docopt', type=('build', 'run'))
     depends_on('py-future', type=('build', 'run'))
     depends_on('py-psutil', type=('build', 'run'))
-    depends_on('py-asyncio', type=('build', 'run'))
+    depends_on('py-asyncio', type=('build', 'run'), when='@:2.5.4')

--- a/var/spack/repos/builtin/packages/py-adb-enhanced/package.py
+++ b/var/spack/repos/builtin/packages/py-adb-enhanced/package.py
@@ -21,8 +21,9 @@ class PyAdbEnhanced(PythonPackage):
     version('2.5.2', sha256='055676156c1566b8d952b9fdfdd89fc09f2d5d1e3b90b4cdf40858ce9947e2ca')
 
     depends_on('python@3:', type=('build', 'run'))
+    depends_on('python@3.4:', when='@2.5.10:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-docopt', type=('build', 'run'))
-    depends_on('py-future', type=('build', 'run'))
+    depends_on('py-future', when='@:2.5.4', type=('build', 'run'))
     depends_on('py-psutil', type=('build', 'run'))
-    depends_on('py-asyncio', type=('build', 'run'), when='@:2.5.4')
+    depends_on('py-asyncio', when='@:2.5.4', type=('build', 'run'))


### PR DESCRIPTION
run `python -m unittest` failed on `py-adb-enhanced`:
![image](https://user-images.githubusercontent.com/29532367/109589204-ed0d5a80-7b44-11eb-8622-be8b7eca8af2.png)

That issue is caused by `py-asyncio`, and it's not a dependency in the latest `py-adb-enhanced` version.