### PR TITLE
vigra: update version to fix some issue

### DIFF
--- a/var/spack/repos/builtin/packages/vigra/package.py
+++ b/var/spack/repos/builtin/packages/vigra/package.py
@@ -15,7 +15,7 @@ class Vigra(CMakePackage):
     git = "https://github.com/ukoethe/vigra.git"
     url = "https://github.com/ukoethe/vigra/releases/download/Version-1-11-1/vigra-1.11.1-src.tar.gz"
 
-    version('master', branch='master', preferred=True)
+    version('master', branch='master')
     version('1.11.1', sha256='a5564e1083f6af6a885431c1ee718bad77d11f117198b277557f8558fa461aaf')
 
     variant('png', default=False, description='Include support for PNG images')

--- a/var/spack/repos/builtin/packages/vigra/package.py
+++ b/var/spack/repos/builtin/packages/vigra/package.py
@@ -12,8 +12,10 @@ class Vigra(CMakePackage):
        customizable algorithms and data structures"""
 
     homepage = "https://ukoethe.github.io/vigra/"
+    git = "https://github.com/ukoethe/vigra.git"
     url = "https://github.com/ukoethe/vigra/releases/download/Version-1-11-1/vigra-1.11.1-src.tar.gz"
 
+    version('master', branch='master', preferred=True)
     version('1.11.1', sha256='a5564e1083f6af6a885431c1ee718bad77d11f117198b277557f8558fa461aaf')
 
     variant('png', default=False, description='Include support for PNG images')


### PR DESCRIPTION
update `vigra` to fix this issue: https://github.com/ukoethe/vigra/issues/414

And there's no more release version for `vigra` since 2017.
According to https://ukoethe.github.io/vigra/, it says:
```
It is generally safe to use the 'master' branch of the development snapshot, as we avoid uploading untested or incompatible changes to this branch. This also means that one should never develop in the 'master' branch directly -- always create a new branch and issue a merge request. This is made very easy by the 'fork' and 'pull request' functionality of GitHub. Please make ample use of the powerful features provided by GitHub (including issue tracking and change discussion).
```