### PR TITLE
Expand relative dev paths in environment files

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -157,6 +157,10 @@ def env_create_setup_parser(subparser):
     subparser.add_argument(
         '-d', '--dir', action='store_true',
         help='create an environment in a specific directory')
+    subparser.add_argument(
+        '--keep-relative', action='store_true',
+        help='copy relative develop paths verbatim into the new environment'
+             ' when initializing from envfile')
     view_opts = subparser.add_mutually_exclusive_group()
     view_opts.add_argument(
         '--without-view', action='store_true',
@@ -184,13 +188,14 @@ def env_create(args):
     if args.envfile:
         with open(args.envfile) as f:
             _env_create(args.create_env, f, args.dir,
-                        with_view=with_view)
+                        with_view=with_view, keep_relative=args.keep_relative)
     else:
         _env_create(args.create_env, None, args.dir,
                     with_view=with_view)
 
 
-def _env_create(name_or_path, init_file=None, dir=False, with_view=None):
+def _env_create(name_or_path, init_file=None, dir=False, with_view=None,
+                keep_relative=False):
     """Create a new environment, with an optional yaml description.
 
     Arguments:
@@ -199,15 +204,18 @@ def _env_create(name_or_path, init_file=None, dir=False, with_view=None):
             spack.yaml or spack.lock
         dir (bool): if True, create an environment in a directory instead
             of a named environment
+        keep_relative (bool): if True, develop paths are copied verbatim into
+            the new environment file, otherwise they may be made absolute if the
+            new environment is in a different location
     """
     if dir:
-        env = ev.Environment(name_or_path, init_file, with_view)
+        env = ev.Environment(name_or_path, init_file, with_view, keep_relative)
         env.write()
         tty.msg("Created environment in %s" % env.path)
         tty.msg("You can activate this environment with:")
         tty.msg("  spack env activate %s" % env.path)
     else:
-        env = ev.create(name_or_path, init_file, with_view)
+        env = ev.create(name_or_path, init_file, with_view, keep_relative)
         env.write()
         tty.msg("Created environment '%s' in %s" % (name_or_path, env.path))
         tty.msg("You can activate this environment with:")

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -73,9 +73,7 @@ class Concretizer(object):
         if not dev_info:
             return False
 
-        path = dev_info['path']
-        path = path if os.path.isabs(path) else os.path.join(
-            env.path, path)
+        path = os.path.normpath(os.path.join(env.path, dev_info['path']))
 
         if 'dev_path' in spec.variants:
             assert spec.variants['dev_path'].value == path

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1044,8 +1044,7 @@ class Environment(object):
 
         if clone:
             # "steal" the source code via staging API
-            abspath = path if os.path.isabs(path) else os.path.join(
-                self.path, path)
+            abspath = os.path.normpath(os.path.join(self.path, path))
 
             stage = spec.package.stage
             stage.steal_source(abspath)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -621,6 +621,14 @@ class Environment(object):
                     self._set_user_specs_from_lockfile()
                 else:
                     self._read_manifest(f, raw_yaml=default_manifest_yaml)
+
+                # Make paths absolute in case since we might save the environment
+                # file in self.path instead of init_file_path.
+                if hasattr(f, 'name') and f.name.endswith('.yaml'):
+                    env_dir = os.path.abspath(os.path.dirname(f.name))
+                    for name, entry in self.dev_specs.items():
+                        self.dev_specs[name]['path'] = os.path.normpath(
+                            os.path.join(env_dir, entry['path']))
         else:
             with lk.ReadTransaction(self.txlock):
                 self._read()

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -132,7 +132,7 @@ def activate(
     if use_env_repo:
         spack.repo.path.put_first(_active_environment.repo)
 
-    tty.debug("Using environmennt '%s'" % _active_environment.name)
+    tty.debug("Using environment '%s'" % _active_environment.name)
 
     # Construct the commands to run
     cmds = ''

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -622,8 +622,8 @@ class Environment(object):
                 else:
                     self._read_manifest(f, raw_yaml=default_manifest_yaml)
 
-                # Make paths absolute in case since we might save the environment
-                # file in self.path instead of init_file_path.
+                # Make develop paths absolute in case the environment is
+                # relocated from init_file to self.path
                 if hasattr(f, 'name') and f.name.endswith('.yaml'):
                     env_dir = os.path.abspath(os.path.dirname(f.name))
                     for name, entry in self.dev_specs.items():

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1599,8 +1599,7 @@ def _develop_specs_from_env(spec, env):
     if not dev_info:
         return
 
-    path = dev_info['path']
-    path = path if os.path.isabs(path) else os.path.join(env.path, path)
+    path = os.path.normpath(os.path.join(env.path, dev_info['path']))
 
     if 'dev_path' in spec.variants:
         assert spec.variants['dev_path'].value == path

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -328,7 +328,7 @@ env:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
       path: %s
-""" % build_dir)
+""" % os.path.relpath(build_dir, start=envdir))
 
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
@@ -343,7 +343,7 @@ env:
     assert dep_spec.package.filename in os.listdir(dep_spec.prefix)
     assert os.path.exists(spec.prefix)
 
-    # Ensure variants set properly
+    # Ensure variants set properly; ensure build_dir is absolute and normalized
     for dep in (dep_spec, spec['dev-build-test-install']):
         assert dep.satisfies('dev_path=%s' % build_dir)
     assert spec.satisfies('^dev_path=*')

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -202,7 +202,7 @@ env:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
       path: %s
-""" % os.path.relpath(build_dir, start=envdir))
+""" % os.path.relpath(str(build_dir), start=str(envdir)))
 
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
@@ -328,7 +328,7 @@ env:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
       path: %s
-""" % os.path.relpath(build_dir, start=envdir))
+""" % os.path.relpath(str(build_dir), start=str(envdir)))
 
         env('create', 'test', './spack.yaml')
         with ev.read('test'):

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -202,7 +202,7 @@ env:
     dev-build-test-install:
       spec: dev-build-test-install@0.0.0
       path: %s
-""" % build_dir)
+""" % os.path.relpath(build_dir, start=envdir))
 
         env('create', 'test', './spack.yaml')
         with ev.read('test'):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2441,3 +2441,14 @@ def test_rewrite_rel_dev_path_create_original_dir(tmpdir):
     with ev.Environment(str(init_env)) as e:
         assert e.dev_specs['mypkg1']['path'] == '../build_folder'
         assert e.dev_specs['mypkg2']['path'] == '/some/other/path'
+
+
+def test_does_not_rewrite_rel_dev_path_when_keep_relative_is_set(tmpdir):
+    """Relative develop paths should not be rewritten when --keep-relative is
+       passed to create"""
+    _, _, _, spack_yaml = _setup_develop_packages(tmpdir)
+    env('create', '--keep-relative', 'named_env', str(spack_yaml))
+    with ev.read('named_env') as e:
+        print(e.dev_specs)
+        assert e.dev_specs['mypkg1']['path'] == '../build_folder'
+        assert e.dev_specs['mypkg2']['path'] == '/some/other/path'

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2119,6 +2119,7 @@ def test_env_activate_default_view_root_unconditional(env_deactivate,
            ("export PATH='" % viewdir_bin in out) or \
            ('export PATH="' % viewdir_bin in out)
 
+
 def test_concretize_user_specs_together():
     e = ev.create('coconcretization')
     e.concretization = 'together'

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2373,3 +2373,51 @@ spack:
             e.clear()
             e.write()
     assert os.path.exists(str(spack_lock))
+
+
+def test_relative_dev_paths_are_expanded(tmpdir):
+    build_folder = tmpdir.join('build_folder')
+    init_env = tmpdir.join('init_env')
+    dest_env = tmpdir.join('dest_env')
+
+    fs.mkdirp(build_folder)
+    fs.mkdirp(init_env)
+    fs.mkdirp(dest_env)
+
+    raw_yaml = """
+spack:
+  specs:
+  - mypkg1
+  - mypkg2
+  develop:
+    mypkg1:
+      path: ../build_folder
+      spec: mypkg@main
+    mypkg2:
+      path: /some/other/path
+      spec: mypkg@main
+"""
+    spack_yaml = init_env.join('spack.yaml')
+    spack_yaml.write(raw_yaml)
+
+    # Create new environment in different directory; should rewrite rel paths
+    env('create', '-d', str(dest_env), str(spack_yaml))
+    with ev.Environment(str(dest_env)) as e:
+        assert e.dev_specs['mypkg1']['path'] == build_folder
+        assert e.dev_specs['mypkg2']['path'] == '/some/other/path'
+
+    # Create new environment in var/share/environments; should rewrite rel paths
+    env('create', 'named_env', str(spack_yaml))
+    with ev.read('named_env') as e:
+        assert e.dev_specs['mypkg1']['path'] == build_folder
+        assert e.dev_specs['mypkg2']['path'] == '/some/other/path'
+
+    # "Create" environment in original directory; should not rewrite rel paths
+    with ev.Environment(str(init_env), str(spack_yaml)) as e:
+        assert e.dev_specs['mypkg1']['path'] == '../build_folder'
+        assert e.dev_specs['mypkg2']['path'] == '/some/other/path'
+
+    env('create', '-d', str(init_env), str(spack_yaml))
+    with ev.Environment(str(init_env)) as e:
+        assert e.dev_specs['mypkg1']['path'] == '../build_folder'
+        assert e.dev_specs['mypkg2']['path'] == '/some/other/path'

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2380,9 +2380,9 @@ def test_relative_dev_paths_are_expanded(tmpdir):
     init_env = tmpdir.join('init_env')
     dest_env = tmpdir.join('dest_env')
 
-    fs.mkdirp(build_folder)
-    fs.mkdirp(init_env)
-    fs.mkdirp(dest_env)
+    fs.mkdirp(str(build_folder))
+    fs.mkdirp(str(init_env))
+    fs.mkdirp(str(dest_env))
 
     raw_yaml = """
 spack:
@@ -2403,13 +2403,13 @@ spack:
     # Create new environment in different directory; should rewrite rel paths
     env('create', '-d', str(dest_env), str(spack_yaml))
     with ev.Environment(str(dest_env)) as e:
-        assert e.dev_specs['mypkg1']['path'] == build_folder
+        assert e.dev_specs['mypkg1']['path'] == str(build_folder)
         assert e.dev_specs['mypkg2']['path'] == '/some/other/path'
 
     # Create new environment in var/share/environments; should rewrite rel paths
     env('create', 'named_env', str(spack_yaml))
     with ev.read('named_env') as e:
-        assert e.dev_specs['mypkg1']['path'] == build_folder
+        assert e.dev_specs['mypkg1']['path'] == str(build_folder)
         assert e.dev_specs['mypkg2']['path'] == '/some/other/path'
 
     # "Create" environment in original directory; should not rewrite rel paths

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2115,9 +2115,9 @@ def test_env_activate_default_view_root_unconditional(env_deactivate,
     out = env('activate', '--sh', 'test')
     viewdir_bin = os.path.join(viewdir, 'bin')
 
-    assert ("export PATH=" % viewdir_bin in out) or \
-           ("export PATH='" % viewdir_bin in out) or \
-           ('export PATH="' % viewdir_bin in out)
+    assert "export PATH={0}".format(viewdir_bin) in out or \
+           "export PATH='{0}".format(viewdir_bin) in out or \
+           'export PATH="{0}'.format(viewdir_bin) in out
 
 
 def test_concretize_user_specs_together():

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2113,8 +2113,11 @@ def test_env_activate_default_view_root_unconditional(env_deactivate,
         viewdir = e.default_view.root
 
     out = env('activate', '--sh', 'test')
-    assert 'PATH=%s' % os.path.join(viewdir, 'bin') in out
+    viewdir_bin = os.path.join(viewdir, 'bin')
 
+    assert ("export PATH=" % viewdir_bin in out) or \
+           ("export PATH='" % viewdir_bin in out) or \
+           ('export PATH="' % viewdir_bin in out)
 
 def test_concretize_user_specs_together():
     e = ev.create('coconcretization')

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -793,7 +793,7 @@ _spack_env_deactivate() {
 _spack_env_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -d --dir --without-view --with-view"
+        SPACK_COMPREPLY="-h --help -d --dir --keep-relative --without-view --with-view"
     else
         _environments
     fi


### PR DESCRIPTION
Solves an issue where `spack env create [name] [path]` followed by `spack -e [name] install` fails when there are relative paths in `develop:spec:path`.

The problem is caused by spack relocating the spack.yaml file to `<spack>/var/environments/<name>/spack.yaml`.

This PR expands the relative paths to their normalized absolute path after reading the spack.yaml file.

Also fixes an issue for anonymous environments where relative paths ended up properly expanded in the `dev_path` variant of specs, but they were not normalized, leading to variants like `myspec dev_path=/path/to/env/dir/../sources`.
