### PR TITLE
precice: Fix build error with missing pkg-config 

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -43,6 +43,7 @@ class Precice(CMakePackage):
 
     depends_on('cmake@3.5:', type='build')
     depends_on('cmake@3.10.2:', type='build', when='@1.4:')
+    depends_on('pkgconfig', type='build', when='@2.2:')
     depends_on('boost@1.60.0:')
     depends_on('boost@1.65.1:', when='@1.4:')
     depends_on('boost@:1.72.99', when='@:2.0.2')


### PR DESCRIPTION
This PR fixes a build error when using preCICE version 2.2.0 with `+petsc` due to `pkg-config` missing.

Closes #22058