### PR TITLE
SCR: Specify @master for component libraries as dependencies for scr@develop

### DIFF
--- a/var/spack/repos/builtin/packages/hpl/package.py
+++ b/var/spack/repos/builtin/packages/hpl/package.py
@@ -112,6 +112,7 @@ class Hpl(AutotoolsPackage):
             config = ['CFLAGS=-O3']
 
         if (self.spec.satisfies('^intel-mkl') or
+            self.spec.satisfies('^intel-oneapi-mkl') or
             self.spec.satisfies('^intel-parallel-studio+mkl')):
             config.append('LDFLAGS={0}'.format(
                 self.spec['blas'].libs.ld_flags))

--- a/var/spack/repos/builtin/packages/py-uproot/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyUproot(PythonPackage):
+    """ROOT I/O in pure Python and NumPy.
+
+    Uproot is a reader and a writer of the ROOT file format using only Python
+    and Numpy. Unlike the standard C++ ROOT implementation, Uproot is only an
+    I/O library, primarily intended to stream data into machine learning
+    libraries in Python. Unlike PyROOT and root_numpy, Uproot does not depend
+    on C++ ROOT. Instead, it uses Numpy to cast blocks of data from the ROOT
+    file as Numpy arrays."""
+
+    homepage = "https://github.com/scikit-hep/uproot4"
+    pypi     = "uproot/uproot-4.0.6.tar.gz"
+
+    version('4.0.6', sha256='1bea2ccc899c6959fb2af69d7e5d1e2df210caab30d3510e26f3fc07c143c37e')
+
+    depends_on('python@2.6:2.999,3.5:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-numpy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/quantum-espresso/configure_aocc.patch
+++ b/var/spack/repos/builtin/packages/quantum-espresso/configure_aocc.patch
@@ -1,0 +1,58 @@
+--- spack-src/install/configure.orig	2021-02-11 13:56:58.900212951 +0530
++++ spack-src/install/configure	2021-02-11 15:19:54.726403962 +0530
+@@ -3203,6 +3203,7 @@
+         nagfor_version=`$mpif90 -v 2>&1 | grep "NAG Fortran"`
+         xlf_version=`$mpif90 -v 2>&1 | grep "xlf"`
+         armflang_version=`$mpif90 -v 2>&1 | grep "Arm C/C++/Fortran Compiler version"`
++		aoccflang_version=`$mpif90 -v 2>&1 | grep "AMD clang version"`
+         #
+         if test "$ifort_version" != ""
+         then
+@@ -3227,6 +3228,12 @@
+                 f90_minor_version=`echo $version | cut -d. -f2`
+                 echo "${ECHO_T}gfortran $f90_major_version.$f90_minor_version"
+                 f90_in_mpif90="gfortran"
++		elif test "$aoccflang_version" != ""
++		then
++				version=`echo $aoccflang_version | cut -d" " -f 5`
++				echo "${ECHO_T}mpif90 $version"
++				f90_in_mpif90="mpif90"
++				try_foxflags="-D__PGI"
+         elif test "$nagfor_version" != ""
+         then
+                 # NAG 6.0 has the codename attached to version number... annoying
+@@ -3327,6 +3334,8 @@
+         f90_flavor=ifort
+     elif $f90 -V 2>&1 | grep -q "^pgf" ; then
+         f90_flavor=pgf
++	elif $f90 -v 2>&1 | grep -q "AMD clang version" ; then
++		f90_flavor=mpif90
+     elif $f90 -v 2>&1 | grep -q "gcc version" ; then
+         f90_flavor=gfortran
+     elif $f90 -V 2>&1 | grep -q "Cray Fortran" ; then
+@@ -3385,6 +3394,9 @@
+ *:pgf90 )
+         try_cc="pgcc $try_cc"
+         ;;
++*:mpif90 )
++		try_cc="mpicc $try_cc"
++		;;
+ cray*:* )
+         try_cc="cc"
+         ;;
+@@ -4017,6 +4029,15 @@
+         try_dflags="$try_dflags -D__PGI"
+         have_cpp=1
+         ;;
++*:*mpif90 )
++	try_fflags="-O3 -g"
++		try_fflags_openmp="-fopenmp"
++		try_f90flags="\$(FFLAGS) -cpp"
++		try_fflags_noopt="-O0 -g"
++		try_ldflags="-g"
++		try_ldflags_openmp="-pthread -fopenmp"
++		try_ldflags_static="-static"
++		;;
+ *:*gfortran )
+ 	try_fflags="-O3 -g"
+         if test "$f90_major_version" -ge "10"; then

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -266,6 +266,9 @@ class QuantumEspresso(Package):
           sha256='bbceba1fb08d01d548d4393bbcaeae966def13f75884268a0f84448457b8eaa3',
           when='+patch@6.4.1:6.5.0')
 
+    # Configure updated to work with AOCC compilers
+    patch('configure_aocc.patch', when='@6.7 %aocc')
+
     # Configure updated to work with NVIDIA compilers
     patch('nvhpc.patch', when='@6.5 %nvhpc')
 
@@ -346,6 +349,15 @@ class QuantumEspresso(Package):
             fftw_ld_flags = spec['fftw'].libs.ld_flags
             options.append('FFT_LIBS={0}'.format(fftw_ld_flags))
 
+        if '^amdfftw' in spec:
+            fftw_prefix = spec['amdfftw'].prefix
+            options.append('FFTW_INCLUDE={0}'.format(fftw_prefix.include))
+            if '+openmp' in spec:
+                fftw_ld_flags = spec['amdfftw:openmp'].libs.ld_flags
+            else:
+                fftw_ld_flags = spec['amdfftw'].libs.ld_flags
+            options.append('FFT_LIBS={0}'.format(fftw_ld_flags))
+
         # External BLAS and LAPACK requires the correct link line into
         # BLAS_LIBS, do no use LAPACK_LIBS as the autoconf scripts indicate
         # that this variable is largely ignored/obsolete.
@@ -394,8 +406,23 @@ class QuantumEspresso(Package):
 
             options.extend([
                 '--with-elpa-include={0}'.format(elpa_include),
-                '--with-elpa-lib={0}'.format(elpa.libs[0])
+                '--with-elpa-version={0}'.format(elpa.version.version[0]),
             ])
+
+            elpa_suffix = '_openmp' if '+openmp' in elpa else ''
+
+            # Currently AOCC support only static libraries of ELPA
+            if '%aocc' in spec:
+                options.extend([
+                    '--with-elpa-lib={0}'.format(
+                        join_path(elpa.prefix.lib,
+                                  'libelpa{elpa_suffix}.a'
+                                  .format(elpa_suffix=elpa_suffix)))
+                ])
+            else:
+                options.extend([
+                    '--with-elpa-lib={0}'.format(elpa.libs[0])
+                ])
 
         if spec.variants['hdf5'].value != 'none':
             options.append('--with-hdf5={0}'.format(spec['hdf5'].prefix))

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -37,13 +37,15 @@ class Scr(CMakePackage):
     depends_on('axl@master', when="@develop")
     depends_on('kvtree@master', when="@develop")
     depends_on('redset@master', when="@develop")
+    depends_on('rankstr@master', when="@develop")
+    depends_on('shuffile@master', when="@develop")
 
     # SCR legacy is anything 2.x.x or earlier
     # SCR components is anything 3.x.x or later
     depends_on('er', when="@3:")
     depends_on('kvtree', when="@3:")
     depends_on('rankstr', when="@3:")
-    depends_on('filo', when="@3:")
+    depends_on('filo', when="@3")
     depends_on('spath', when="@3:")
 
     # DTCMP is an optional dependency up until 3.x

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -15,6 +15,7 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
     homepage = "http://www.gnu.org/software/wget/"
     gnu_mirror_path = "wget/wget-1.19.1.tar.gz"
 
+    version('1.21',   sha256='b3bc1a9bd0c19836c9709c318d41c19c11215a07514f49f89b40b9d50ab49325')
     version('1.20.3', sha256='31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e')
     version('1.19.1', sha256='9e4f12da38cc6167d0752d934abe27c7b1599a9af294e73829be7ac7b5b4da40')
     version('1.17',   sha256='3e04ad027c5b6ebd67c616eec13e66fbedb3d4d8cbe19cc29dadde44b92bda55')


### PR DESCRIPTION
The scr@develop branch now requires er@master and shuffile@master to build correctly. It currently still builds with the default specs for the rankstr, filo, and spath component libraries, but those specs may eventually need to be changed as well. Update just these two, of fix the whole batch at once?
