### PR TITLE
unifyfs: Fix strncpy build error of version 0.9.1

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -54,6 +54,8 @@ class Unifyfs(AutotoolsPackage):
     depends_on('gotcha@0.0.2', when='@:0.9.0')
     depends_on('leveldb', when='@:0.9.0')
 
+    patch('unifyfs-sysio.c.patch', when='@0.9.1')
+
     conflicts('^mercury~bmi')
     conflicts('^mercury~sm')
     # Known compatibility issues with ifort and xlf. Fixes coming.

--- a/var/spack/repos/builtin/packages/unifyfs/unifyfs-sysio.c.patch
+++ b/var/spack/repos/builtin/packages/unifyfs/unifyfs-sysio.c.patch
@@ -1,0 +1,11 @@
+--- spack-src/client/src/unifyfs-sysio.c.bak	2020-12-03 09:04:41.197202000 +0900
++++ spack-src/client/src/unifyfs-sysio.c	2021-03-04 10:06:32.626989637 +0900
+@@ -245,7 +245,7 @@
+          * that is big enough */
+         buf = (char*) malloc(len);
+         if (buf != NULL) {
+-            strncpy(buf, unifyfs_cwd, len);
++            memcpy(buf, unifyfs_cwd, strlen(unifyfs_cwd));
+         } else {
+             errno = ENOMEM;
+         }


### PR DESCRIPTION
I have fixed the following issues:
      349    ./spack-stage/spack-stage-unifyfs-0.9.1-5yrndwau6kzqyfo4ev62fpwzcodchfro/spack-src/client/src/unifyfs-sysio.c:248:13: error:
            'strncpy' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
     350                 strncpy(buf, unifyfs_cwd, len);
     351                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     352    ./spack-stage/spack-stage-unifyfs-0.9.1-5yrndwau6kzqyfo4ev62fpwzcodchfro/spack-src/client/src/unifyfs-sysio.c:216:18: note: l
            ength computed here
     353         size_t len = strlen(unifyfs_cwd) + 1;

The location of the error is as follows.
I think the error is occurring because the length of len specified in strncpy is longer than unifyfs_cwd.
         buf = (char*) malloc(len);
         if (buf != NULL) {
            strncpy(buf, unifyfs_cwd, len);

I thought I could fix it by changing len to strlen (unifyfs_cwd), but I couldn't avoid the error so I decided to use memcpy.
I'm thinking of upstream this fix patch.