### PR TITLE
BLAS++: CUDA default (false)

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -23,7 +23,7 @@ class Blaspp(CMakePackage, CudaPackage):
     version('2020.10.00', sha256='ce148cfe397428d507c72d7d9eba5e9d3f55ad4cd842e6e873c670183dcb7795')
 
     variant('openmp', default=True, description='Use OpenMP internally.')
-    variant('cuda',   default=True, description='Build with CUDA')
+    variant('cuda',   default=False, description='Build with CUDA')
     variant('shared', default=True, description='Build shared libraries')
 
     depends_on('cmake@3.15.0:', type='build')

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -67,6 +67,7 @@ class Warpx(CMakePackage):
     depends_on('ascent +cuda', when='+ascent compute=cuda')
     depends_on('ascent +mpi', when='+ascent +mpi')
     depends_on('blaspp', when='+psatd dims=rz')
+    depends_on('blaspp +cuda', when='+psatd dims=rz compute=cuda')
     depends_on('boost@1.66.0: +math', when='+qedtablegen')
     depends_on('cmake@3.15.0:', type='build')
     depends_on('cuda@9.2.88:', when='compute=cuda')


### PR DESCRIPTION
For opt-in packages in Spack, its common that the `cuda` variant is disabled by default. (See e.g. `CudaPackage` mixin class.)

This also simplifies downstream usage in multi-variants for backends in user code.
Also, `blaspp` will not fail to build on macOS by default (no CUDA anymore on macOS).

The other BLAS++ dependent in Spack at the moment, `slate`, controls the BLAS++ variant in `depends_on` explicitly and needs no change.

cc @G-Ragghianti @mgates3