### PR TITLE
rtags: update version to fix test issue

### DIFF
--- a/var/spack/repos/builtin/packages/rtags/package.py
+++ b/var/spack/repos/builtin/packages/rtags/package.py
@@ -12,6 +12,7 @@ class Rtags(CMakePackage):
     homepage = "https://github.com/Andersbakken/rtags/"
     url      = "https://andersbakken.github.io/rtags-releases/rtags-2.17.tar.gz"
 
+    version('2.20', sha256='dceab009194bcfa4265950dac16832bae7883e95d3bc41b215e90bc888db9cb1')
     version('2.17', sha256='cde8882aceb09d65690007e214cc1979e0105842beb7747d49f79e33ed37d383')
 
     depends_on("llvm@3.3: +clang")


### PR DESCRIPTION
`rtags` test error as below:
![image](https://user-images.githubusercontent.com/29532367/109902754-dc401e80-7cd5-11eb-862c-c6964e7bd887.png)

So we need to update version to fix this issue.