### PR TITLE
py-warpx: Fix aarch64 builds

### DIFF
--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -36,11 +36,6 @@ class PyWarpx(PythonPackage):
     depends_on('py-wheel', type='build')
     depends_on('warpx +lib ~mpi +shared', type=('build', 'link'), when='~mpi')
     depends_on('warpx +lib +mpi +shared', type=('build', 'link'), when='+mpi')
-    depends_on('cmake@3.15.0:', type='build')
 
-    @property
-    def libs(self):
-        shared = '+shared' in self.spec
-        return find_libraries(
-            ['libwarpx.3d'], root=self.prefix, recursive=True, shared=shared
-        )
+    def setup_build_environment(self, env):
+        env.set('PYWARPX_LIB_DIR', self.spec['warpx'].libs.directories[0])

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -38,4 +38,4 @@ class PyWarpx(PythonPackage):
     depends_on('warpx +lib +mpi +shared', type=('build', 'link'), when='+mpi')
 
     def setup_build_environment(self, env):
-        env.set('PYWARPX_LIB_DIR', self.spec['warpx'].libs.directories[0])
+        env.set('PYWARPX_LIB_DIR', self.spec['warpx'].prefix.lib)

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -38,4 +38,7 @@ class PyWarpx(PythonPackage):
     depends_on('warpx +lib +mpi +shared', type=('build', 'link'), when='+mpi')
 
     def setup_build_environment(self, env):
-        env.set('PYWARPX_LIB_DIR', self.spec['warpx'].prefix.lib)
+        if find(self.spec['warpx'].prefix.lib64, 'libwarpx.3d.so'):
+            env.set('PYWARPX_LIB_DIR', self.spec['warpx'].prefix.lib64)
+        else:
+            env.set('PYWARPX_LIB_DIR', self.spec['warpx'].prefix.lib)

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -36,9 +36,11 @@ class PyWarpx(PythonPackage):
     depends_on('py-wheel', type='build')
     depends_on('warpx +lib ~mpi +shared', type=('build', 'link'), when='~mpi')
     depends_on('warpx +lib +mpi +shared', type=('build', 'link'), when='+mpi')
+    depends_on('cmake@3.15.0:', type='build')
 
-    def setup_build_environment(self, env):
-        if find(self.spec['warpx'].prefix.lib64, 'libwarpx.3d.so'):
-            env.set('PYWARPX_LIB_DIR', self.spec['warpx'].prefix.lib64)
-        else:
-            env.set('PYWARPX_LIB_DIR', self.spec['warpx'].prefix.lib)
+    @property
+    def libs(self):
+        shared = '+shared' in self.spec
+        return find_libraries(
+            ['libwarpx.3d'], root=self.prefix, recursive=True, shared=shared
+        )

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -93,6 +93,7 @@ class Warpx(CMakePackage):
         args = [
             '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
                 'ON' if '+shared' in spec else 'OFF'),
+            '-DCMAKE_INSTALL_LIBDIR=lib',
             # variants
             '-DWarpX_APP:BOOL={0}'.format(
                 'ON' if '+app' in spec else 'OFF'),

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -67,6 +67,7 @@ class Warpx(CMakePackage):
     depends_on('ascent +cuda', when='+ascent compute=cuda')
     depends_on('ascent +mpi', when='+ascent +mpi')
     depends_on('blaspp', when='+psatd dims=rz')
+    depends_on('blaspp +cuda', when='+psatd dims=rz compute=cuda')
     depends_on('boost@1.66.0: +math', when='+qedtablegen')
     depends_on('cmake@3.15.0:', type='build')
     depends_on('cuda@9.2.88:', when='compute=cuda')
@@ -122,3 +123,19 @@ class Warpx(CMakePackage):
         ]
 
         return args
+
+    @property
+    def libs(self):
+        shared = '+shared' in self.spec
+        if 'dims=2' in self.spec:
+            return find_libraries(
+                ['libwarpx.2d'], root=self.prefix, recursive=True, shared=shared
+            )
+        if 'dims=3' in self.spec:
+            return find_libraries(
+                ['libwarpx.3d'], root=self.prefix, recursive=True, shared=shared
+            )
+        if 'dims=rz' in self.spec:
+            return find_libraries(
+                ['libwarpx.rz'], root=self.prefix, recursive=True, shared=shared
+            )

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -126,16 +126,9 @@ class Warpx(CMakePackage):
 
     @property
     def libs(self):
-        shared = '+shared' in self.spec
-        if 'dims=2' in self.spec:
-            return find_libraries(
-                ['libwarpx.2d'], root=self.prefix, recursive=True, shared=shared
-            )
-        if 'dims=3' in self.spec:
-            return find_libraries(
-                ['libwarpx.3d'], root=self.prefix, recursive=True, shared=shared
-            )
-        if 'dims=rz' in self.spec:
-            return find_libraries(
-                ['libwarpx.rz'], root=self.prefix, recursive=True, shared=shared
-            )
+        libsuffix = {'2': '2d', '3': '3d', 'rz': 'rz'}
+        dims = self.spec.variants['dims'].value
+        return find_libraries(
+            ['libwarpx.' + libsuffix[dims]], root=self.prefix, recursive=True,
+            shared=True
+        )


### PR DESCRIPTION
I have fixed the following issues:
 44    RuntimeError: Error: no pre-build WarpX libraries found in PYWARPX_LIB_DIR='./spack/opt/spack/linux-rhel8-thunderx2/gcc-8.3.1/warpx-develop-6otpehojdmxb437spstmedhwilae45z5/lib'