### PR TITLE
xfsprogs: Add --with-systemd-unit-dir option

### DIFF
--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -28,7 +28,8 @@ class Xfsprogs(AutotoolsPackage):
 
     def configure_args(self):
         args = ['LDFLAGS=-lintl',
-                "--with-systemd-unit-dir=" + self.spec['xfsprogs'].prefix.lib.systemd.system]
+                "--with-systemd-unit-dir=" +
+                self.spec['xfsprogs'].prefix.lib.systemd.system]
         return args
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -27,7 +27,8 @@ class Xfsprogs(AutotoolsPackage):
                         self.spec['util-linux'].prefix.include.blkid)
 
     def configure_args(self):
-        args = ['LDFLAGS=-lintl']
+        args = ['LDFLAGS=-lintl',
+                "--with-systemd-unit-dir=" + self.spec['xfsprogs'].prefix.lib.systemd.system]
         return args
 
     def install(self, spec, prefix):


### PR DESCRIPTION
I fixed the following error.
　chmod: changing permissions of '//usr/lib/systemd/system': Operation not permitted

I have confirmed that I can install from version 5.8.0 to 4.20.0.