### PR TITLE
py-ase: Depend on py-setuptools so an egg isn't built

### DIFF
--- a/var/spack/repos/builtin/packages/py-ase/package.py
+++ b/var/spack/repos/builtin/packages/py-ase/package.py
@@ -25,3 +25,4 @@ class PyAse(PythonPackage):
     depends_on('py-matplotlib', type=('build', 'run'))
     depends_on('py-scipy', type=('build', 'run'))
     depends_on('py-flask', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
ase is supposed to be able to run using
```bash
python3 -m ase
```
or imported into a Python script using
```python
import ase
```
However, these failed with "No module named ase" with py-ase from spack. The py-ase package was installing into an egg, but the above commands assume that ase is installed as a "normal" Python package.

By adding py-setuptools as a dependency at build time, py-ase installs into a normal directory tree. Similar changes have been required in the past on other packages (e.g. #10964, #11961).