### PR TITLE
openmpi: allow to build with slurm and ~pmi for >3.0.0 with PMIx

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -337,7 +337,7 @@ class Openmpi(AutotoolsPackage):
     # knem support was added in 1.5
     conflicts('fabrics=knem', when='@:1.4')
 
-    conflicts('schedulers=slurm ~pmi', when='@1.5.4:',
+    conflicts('schedulers=slurm ~pmi', when='@1.5.4:2.999.999',
               msg='+pmi is required for openmpi(>=1.5.5) to work with SLURM.')
     conflicts('schedulers=loadleveler', when='@3.0.0:',
               msg='The loadleveler scheduler is not supported with '
@@ -631,7 +631,11 @@ class Openmpi(AutotoolsPackage):
         # for versions older than 3.0.3,3.1.3,4.0.0
         # Presumably future versions after 11/2018 should support slurm+static
         if spec.satisfies('schedulers=slurm'):
-            config_args.append('--with-pmi={0}'.format(spec['slurm'].prefix))
+            if spec.satisfies('+pmi'):
+                config_args.append('--with-pmi={0}'.format(
+                    spec['slurm'].prefix))
+            else:
+                config_args.extend(self.with_or_without('pmi'))
             if spec.satisfies('@3.1.3:') or spec.satisfies('@3.0.3'):
                 if '+static' in spec:
                     config_args.append('--enable-static')


### PR DESCRIPTION
--with-pmi is causing problems in our 4.0.5/4.1.0 builds.

@hppritcha 

more detail: when building openmpi@4.1.0+pmi, we see errors like this at runtime:

```shell
[skl-a-00.rc.rit.edu:13428] PMI_Get_clique_size [pmix_s1.c:281:s1_init]: Operation failed
--------------------------------------------------------------------------
The application appears to have been direct launched using "srun",
but OMPI was not built with SLURM's PMI support and therefore cannot
execute. There are several options for building PMI support under
SLURM, depending upon the SLURM version you are using:
  
  version 16.05 or later: you can use SLURM's PMIx support. This
  requires that you configure and build SLURM --with-pmix.
  
  Versions earlier than 16.05: you must use either SLURM's PMI-1 or
  PMI-2 support. SLURM builds PMI-1 by default, or you can manually
  install PMI-2. You must then build Open MPI using --with-pmi pointing
  to the SLURM PMI library location.

Please configure as appropriate and try again.
--------------------------------------------------------------------------

```
These errors do not occur if we compile --without-pmi and just rely on pmix. Suggestions as to alternatives welcome.