### PR TITLE
Allow develop per spec instead of per package

### DIFF
--- a/lib/spack/spack/cmd/develop.py
+++ b/lib/spack/spack/cmd/develop.py
@@ -43,8 +43,8 @@ def develop(parser, args):
             raise SpackError("No spec provided to spack develop command")
 
         # download all dev specs
-        for name, entry in env.dev_specs.items():
-            path = entry.get('path', name)
+        for entry in env.dev_specs:
+            path = entry.get('path', spack.spec.Spec(entry['spec']).name)
             abspath = path if os.path.isabs(path) else os.path.join(
                 env.path, path)
 

--- a/lib/spack/spack/cmd/undevelop.py
+++ b/lib/spack/spack/cmd/undevelop.py
@@ -24,7 +24,7 @@ def undevelop(parser, args):
     env = spack.cmd.require_active_env(cmd_name='undevelop')
 
     if args.all:
-        specs = env.dev_specs.keys()
+        specs = [spack.spec.Spec(entry['spec']) for entry in env.dev_specs]
     else:
         specs = spack.cmd.parse_specs(args.specs)
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -69,8 +69,17 @@ class Concretizer(object):
         Add ``dev_path=*`` variant to packages built from local source.
         """
         env = spack.environment.active_environment()
-        dev_info = env.dev_specs.get(spec.name, {}) if env else {}
-        if not dev_info:
+
+        if not env:
+            return False
+
+        # Note: we could to a topological sort of the dev_spec array, but since
+        # that is not unique we prefer to just take the first match and assume
+        # the user has ordered the specs properly in the manifest file
+        dev_info = next((dev for dev in env.dev_specs
+                         if spack.spec.Spec(dev['spec']).satisfies(spec)), None)
+
+        if dev_info is None:
             return False
 
         path = os.path.normpath(os.path.join(env.path, dev_info['path']))

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -662,7 +662,7 @@ class Environment(object):
         if init_file_dir == self.path:
             return
 
-        for name, entry in self.dev_specs.items():
+        for entry in self.dev_specs:
             dev_path = entry['path']
             expanded_path = os.path.normpath(os.path.join(
                 init_file_dir, entry['path']))
@@ -672,9 +672,9 @@ class Environment(object):
                 continue
 
             tty.debug("Expanding develop path for {0} to {1}".format(
-                name, expanded_path))
+                entry['spec'], expanded_path))
 
-            self.dev_specs[name]['path'] = expanded_path
+            entry['path'] = expanded_path
 
     def _re_read(self):
         """Reinitialize the environment object if it has been written (this
@@ -760,13 +760,12 @@ class Environment(object):
         self.concretization = configuration.get('concretization', 'separately')
 
         # Retrieve dev-build packages:
-        self.dev_specs = configuration.get('develop', {})
-        for name, entry in self.dev_specs.items():
-            # spec must include a concrete version
-            assert Spec(entry['spec']).version.concrete
+        self.dev_specs = configuration.get('develop', [])
+        for entry in self.dev_specs:
+            spec = Spec(entry['spec'])
             # default path is the spec name
             if 'path' not in entry:
-                self.dev_specs[name]['path'] = name
+                entry['path'] = spec.name
 
     @property
     def user_specs(self):
@@ -1070,27 +1069,33 @@ class Environment(object):
             raise SpackEnvironmentError(
                 'Cannot develop spec %s without a concrete version' % spec)
 
-        for name, entry in self.dev_specs.items():
-            if name == spec.name:
-                e_spec = Spec(entry['spec'])
-                e_path = entry['path']
+        # Filter already dev'd specs that are more generic than the provided one
+        # e.g. you can't add pkg@1.0.0 if pkg@1.0 is already developed.
+        matching = [dev for dev in self.dev_specs if Spec(dev['spec']) in spec]
 
-                if e_spec == spec:
-                    if path == e_path:
-                        tty.msg("Spec %s already configured for development" %
-                                spec)
-                        return False
-                    else:
-                        tty.msg("Updating development path for spec %s" % spec)
-                        break
-                else:
-                    msg = "Updating development spec for package "
-                    msg += "%s with path %s" % (spec.name, path)
-                    tty.msg(msg)
-                    break
+        # Search for an exact match
+        exact_match = next((dev for dev in matching if Spec(dev['spec']) == spec), None)
+
+        # If we have an exact match, we should update it
+        if exact_match:
+            if exact_match['path'] == path:
+                tty.msg("Spec %s already configured for development" % spec)
+                return False
+            else:
+                tty.msg("Updating development path for spec %s" % spec)
+                exact_match['path'] = path
+
+        # If we have an inclusion of this spec into others without an exact
+        # match, we error, because the spec can never be matched when appended
+        elif matching:
+            raise SpackEnvironmentError(
+                'Spec %s is included in %s' % (spec, matching[0]['spec']))
+
+        # Otherwise we have a truly new spec
         else:
             tty.msg("Configuring spec %s for development at path %s" %
                     (spec, path))
+            self.dev_specs.append({'path': path, 'spec': str(spec)})
 
         if clone:
             # "steal" the source code via staging API
@@ -1099,8 +1104,6 @@ class Environment(object):
             stage = spec.package.stage
             stage.steal_source(abspath)
 
-        # If it wasn't already in the list, append it
-        self.dev_specs[spec.name] = {'path': path, 'spec': str(spec)}
         return True
 
     def undevelop(self, spec):
@@ -1108,14 +1111,15 @@ class Environment(object):
 
         returns True on success, False if no entry existed."""
         spec = Spec(spec)  # In case it's a spec object
-        if spec.name in self.dev_specs:
-            del self.dev_specs[spec.name]
-            return True
-        return False
 
-    def is_develop(self, spec):
-        """Returns true when the spec is built from local sources"""
-        return spec.name in self.dev_specs
+        filtered_specs = [entry for entry in self.dev_specs
+                          if not Spec(entry['spec']).satisfies(spec)]
+
+        if len(filtered_specs) != len(self.dev_specs):
+            self.dev_specs = filtered_specs
+            return True
+
+        return False
 
     def concretize(self, force=False, tests=False):
         """Concretize user_specs in this environment.
@@ -1918,8 +1922,8 @@ class Environment(object):
         if self.dev_specs:
             # Remove entries that are mirroring defaults
             write_dev_specs = copy.deepcopy(self.dev_specs)
-            for name, entry in write_dev_specs.items():
-                if entry['path'] == name:
+            for entry in write_dev_specs:
+                if entry['path'] == Spec(entry['spec']).name:
                     del entry['path']
             yaml_dict['develop'] = write_dev_specs
         else:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1534,9 +1534,10 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             # should this attempt to download the source and set one? This
             # probably only happens for source repositories which are
             # referenced by branch name rather than tag or commit ID.
-            env = spack.environment.active_environment()
-            from_local_sources = env and env.is_develop(self.spec)
-            if not self.spec.external and not from_local_sources:
+
+            # Do not warn for external packages and packages built from local
+            # sources.
+            if not self.spec.external and 'dev_path' not in self.spec.variants:
                 message = 'Missing a source id for {s.name}@{s.version}'
                 tty.warn(message.format(s=self))
             hash_content.append(''.encode('utf-8'))

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -74,23 +74,16 @@ schema = {
                         },
                     },
                     'develop': {
-                        'type': 'object',
-                        'default': {},
-                        'additionalProperties': False,
-                        'patternProperties': {
-                            r'\w[\w-]*': {
-                                'type': 'object',
-                                'additionalProperties': False,
-                                'properties': {
-                                    'spec': {
-                                        'type': 'string'
-                                    },
-                                    'path': {
-                                        'type': 'string'
-                                    },
-                                },
+                        'type': 'array',
+                        'items': {
+                            'type': 'object',
+                            'properties': {
+                                'spec': {'type': 'string'},
+                                'path': {'type': 'string'}
                             },
-                        },
+                            'additionalProperties': False,
+                            'required': ['spec']
+                        }
                     },
                     'definitions': {
                         'type': 'array',

--- a/lib/spack/spack/test/cmd/undevelop.py
+++ b/lib/spack/spack/test/cmd/undevelop.py
@@ -23,9 +23,8 @@ env:
   - mpich
 
   develop:
-    mpich:
-      spec: mpich@1.0
-      path: /fake/path
+  - spec: mpich@1.0
+    path: /fake/path
 """)
 
         env('create', 'test', './spack.yaml')
@@ -50,9 +49,8 @@ env:
   - mpich
 
   develop:
-    mpich:
-      spec: mpich@1.0
-      path: /fake/path
+  - spec: mpich@1.0
+    path: /fake/path
 """)
 
         env('create', 'test', './spack.yaml')


### PR DESCRIPTION
Environments can contain the same package multiple times, but `develop`
only allows for one package to be developed (= built from local sources)
at a time.

This commit allows one develop entry per spec, and also makes the
develop yaml syntax equivalent to externals in packages. The new syntax
is:

```
develop:
- spec: mypkg@develop-a
- spec: mypkg@develop-b
  path: some/path
```

With this change the following use cases are covered:

- Updating a dependency of a package where you want to keep both the
stable version and the develop version around, and easily check if
tests of the parent still pass both for stable and dev version of the
dependency from a single environment (so, parent is also dev'd)
- Building different variants of the same package from the same local
sources (so you can make your changes in 1 place and test multiple
versions of it provided you can do out of source builds of course)
- Easily comparing two implementations of something, where you dev the
same package twice in different folders and you mark them with
`@develop-feature-a` and `@develop-feature-b`.
