### PR TITLE
freeipmi: Add --with-systemdsystemunitdir option

### DIFF
--- a/var/spack/repos/builtin/packages/freeipmi/package.py
+++ b/var/spack/repos/builtin/packages/freeipmi/package.py
@@ -35,6 +35,8 @@ class Freeipmi(AutotoolsPackage):
         tty.warn("Requires 'root' for bmc-watchdog.service installation to"
                  " /lib/systemd/system/ !")
 
-        args = ['--prefix={0}'.format(prefix)]
+        args = ['--prefix={0}'.format(prefix),
+                "--with-systemdsystemunitdir=" +
+                self.spec['freeipmi'].prefix.lib.systemd.system]
 
         return args


### PR DESCRIPTION
I fixed the following error.
2367 /usr/bin/install: cannot create regular file '/usr/lib/systemd/system/bmc-watchdog.service': Permission denied