### PR TITLE
spack info: make sections optional; add build/stand-alone test information

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -46,14 +46,14 @@ def setup_parser(subparser):
     )
 
     options = [
-        ('--dependencies', print_dependencies.__doc__),
         ('--detectable', print_detectable.__doc__),
         ('--maintainers', print_maintainers.__doc__),
+        ('--no-dependencies', 'do not ' + print_dependencies.__doc__),
+        ('--no-variants', 'do not ' + print_variants.__doc__),
+        ('--no-versions', 'do not ' + print_versions.__doc__),
         ('--phases', print_phases.__doc__),
         ('--tags', print_tags.__doc__),
         ('--tests', print_tests.__doc__),
-        ('--variants', print_variants.__doc__),
-        ('--versions', print_versions.__doc__),
         ('--virtuals', print_virtuals.__doc__),
     ]
     for opt, help_comment in options:
@@ -166,7 +166,7 @@ class VariantFormatter(object):
 
 
 def print_dependencies(pkg):
-    """output any build, link, and run package dependencies"""
+    """output build, link, and run package dependencies"""
 
     for deptype in ('build', 'link', 'run'):
         color.cprint('')
@@ -203,7 +203,7 @@ def print_detectable(pkg):
 
 
 def print_maintainers(pkg):
-    """output any package maintainers"""
+    """output package maintainers"""
 
     if len(pkg.maintainers) > 0:
         mnt = " ".join(['@@' + m for m in pkg.maintainers])
@@ -212,7 +212,7 @@ def print_maintainers(pkg):
 
 
 def print_phases(pkg):
-    """output any installation phases"""
+    """output installation phases"""
 
     if hasattr(pkg, 'phases') and pkg.phases:
         color.cprint('')
@@ -224,7 +224,7 @@ def print_phases(pkg):
 
 
 def print_tags(pkg):
-    """output any package tags"""
+    """output package tags"""
 
     color.cprint('')
     color.cprint(section_title("Tags: "))
@@ -305,7 +305,7 @@ def print_tests(pkg):
 
 
 def print_variants(pkg):
-    """output any variants"""
+    """output variants"""
 
     color.cprint('')
     color.cprint(section_title('Variants:'))
@@ -316,7 +316,7 @@ def print_variants(pkg):
 
 
 def print_versions(pkg):
-    """output any versions"""
+    """output versions"""
 
     color.cprint('')
     color.cprint(section_title('Preferred version:  '))
@@ -363,7 +363,7 @@ def print_versions(pkg):
 
 
 def print_virtuals(pkg):
-    """output any virtual packages"""
+    """output virtual packages"""
 
     color.cprint('')
     color.cprint(section_title('Virtual Packages: '))
@@ -407,10 +407,10 @@ def info(parser, args):
         (args.all or args.maintainers, print_maintainers),
         (args.all or args.detectable, print_detectable),
         (args.all or args.tags, print_tags),
-        (args.all or args.versions, print_versions),
-        (args.all or args.variants, print_variants),
+        (args.all or not args.no_versions, print_versions),
+        (args.all or not args.no_variants, print_variants),
         (args.all or args.phases, print_phases),
-        (args.all or args.dependencies, print_dependencies),
+        (args.all or not args.no_dependencies, print_dependencies),
         (args.all or args.virtuals, print_virtuals),
         (args.all or args.tests, print_tests),
     ]

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -84,6 +84,16 @@ _spack_configure_argsfile = 'spack-configure-args.txt'
 
 
 def has_test_method(pkg):
+    """Determine if the package has an associated stand-alone `test` method.
+    The default, empty method provided by PackageBase is not included.
+
+    Args:
+        pkg (str): the package being checked
+
+    Returns:
+        (bool): ``True`` if the package overrides the default method; else
+            ``False``
+    """
     if not inspect.isclass(pkg):
         tty.die('{0}: is not a class, it is {1}'.format(pkg, type(pkg)))
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -83,26 +83,6 @@ _spack_times_log = 'install_times.json'
 _spack_configure_argsfile = 'spack-configure-args.txt'
 
 
-def has_test_method(pkg):
-    """Determine if the package has an associated stand-alone `test` method.
-    The default, empty method provided by PackageBase is not included.
-
-    Args:
-        pkg (str): the package being checked
-
-    Returns:
-        (bool): ``True`` if the package overrides the default method; else
-            ``False``
-    """
-    if not inspect.isclass(pkg):
-        tty.die('{0}: is not a class, it is {1}'.format(pkg, type(pkg)))
-
-    return (
-        (issubclass(pkg, PackageBase) and pkg.test != PackageBase.test) or
-        (isinstance(pkg, PackageBase) and pkg.test.__func__ != PackageBase.test)
-    )
-
-
 def preferred_version(pkg):
     """
     Returns a sorted list of the preferred versions of the package.
@@ -2730,7 +2710,15 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
 
 def has_test_method(pkg):
-    """Returns True if the package defines its own stand-alone test method."""
+    """Determine if the package defines its own stand-alone test method.
+
+    Args:
+        pkg (str): the package being checked
+
+    Returns:
+        (bool): ``True`` if the package overrides the default method; else
+            ``False``
+    """
     if not inspect.isclass(pkg):
         tty.die('{0}: is not a class, it is {1}'.format(pkg, type(pkg)))
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -83,6 +83,16 @@ _spack_times_log = 'install_times.json'
 _spack_configure_argsfile = 'spack-configure-args.txt'
 
 
+def has_test_method(pkg):
+    if not inspect.isclass(pkg):
+        tty.die('{0}: is not a class, it is {1}'.format(pkg, type(pkg)))
+
+    return (
+        (issubclass(pkg, PackageBase) and pkg.test != PackageBase.test) or
+        (isinstance(pkg, PackageBase) and pkg.test.__func__ != PackageBase.test)
+    )
+
+
 def preferred_version(pkg):
     """
     Returns a sorted list of the preferred versions of the package.

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -54,7 +54,7 @@ def test_it_just_runs(pkg):
 
 def test_info_noversion(mock_packages, info_lines, mock_print):
     """Check that a mock package with no versions or variants outputs None."""
-    info('--versions', '--variants', 'noversion')
+    info('noversion')
 
     line_iter = info_lines.__iter__()
     for line in line_iter:
@@ -87,7 +87,8 @@ def test_is_externally_detectable(pkg_query, expected, parser, info_lines):
 @pytest.mark.parametrize('pkg_query', [
     'hdf5',
     'cloverleaf3d',
-    'trilinos'
+    'trilinos',
+    'gcc'    # This should ensure --test's c_names processing loop covered
 ])
 @pytest.mark.usefixtures('mock_print')
 def test_info_fields(pkg_query, parser, info_lines):

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -54,7 +54,7 @@ def test_it_just_runs(pkg):
 
 def test_info_noversion(mock_packages, info_lines, mock_print):
     """Check that a mock package with no versions or variants outputs None."""
-    info('noversion')
+    info('--versions', '--variants', 'noversion')
 
     line_iter = info_lines.__iter__()
     for line in line_iter:
@@ -74,7 +74,7 @@ def test_info_noversion(mock_packages, info_lines, mock_print):
 ])
 @pytest.mark.usefixtures('mock_print')
 def test_is_externally_detectable(pkg_query, expected, parser, info_lines):
-    args = parser.parse_args([pkg_query])
+    args = parser.parse_args(['--detectable', pkg_query])
     spack.cmd.info.info(parser, args)
 
     line_iter = info_lines.__iter__()
@@ -103,7 +103,7 @@ def test_info_fields(pkg_query, parser, info_lines):
         'Tags:'
     )
 
-    args = parser.parse_args([pkg_query])
+    args = parser.parse_args(['--all', pkg_query])
     spack.cmd.info.info(parser, args)
 
     for text in expected_fields:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1157,7 +1157,7 @@ _spack_help() {
 _spack_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help -a --all --dependencies --detectable --maintainers --phases --tags --tests --variants --versions --virtuals"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1157,7 +1157,7 @@ _spack_help() {
 _spack_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -a --all --dependencies --detectable --maintainers --phases --tags --tests --variants --versions --virtuals"
+        SPACK_COMPREPLY="-h --help -a --all --detectable --maintainers --no-dependencies --no-variants --no-versions --phases --tags --tests --virtuals"
     else
         _all_packages
     fi


### PR DESCRIPTION
This PR adds information about package tests to the `info` command output.  The titles are based on #22210 distinctions between installation phase-time tests and stand-alone/smoke tests.

Based on feedback, this PR also makes most sections optional and provides an `--all` option.  The core sections are the type and package name, package description, and home page.  All other sections are optional and, when included, are reported in their original  order.

The new help output is:
```
usage: spack info [-ha] [--detectable] [--maintainers] [--no-dependencies]
                  [--no-variants] [--no-versions] [--phases] [--tags]
                  [--tests] [--virtuals]
                  package

get detailed information on a particular package

positional arguments:
  package            package name

optional arguments:
  --detectable       output information on external detection
  --maintainers      output package maintainers
  --no-dependencies  do not output build, link, and run package dependencies
  --no-variants      do not output variants
  --no-versions      do not output versions
  --phases           output installation phases
  --tags             output package tags
  --tests            output relevant build-time and stand-alone tests
  --virtuals         output virtual packages
  -a, --all          output all package information
  -h, --help         show this help message and exit
```

An example with default information:
```
$ spack info mpich
AutotoolsPackage:   mpich

Description:
    MPICH is a high performance and widely portable implementation of the
    Message Passing Interface (MPI) standard.

Homepage: https://www.mpich.org

Preferred version:  
    3.4.2      https://www.mpich.org/static/downloads/3.4.2/mpich-3.4.2.tar.gz

Safe versions:  
    develop    [git] https://github.com/pmodels/mpich.git
    3.4.2      https://www.mpich.org/static/downloads/3.4.2/mpich-3.4.2.tar.gz
    3.4.1      https://www.mpich.org/static/downloads/3.4.1/mpich-3.4.1.tar.gz
    3.4        https://www.mpich.org/static/downloads/3.4/mpich-3.4.tar.gz
    3.3.2      https://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz
    3.3.1      https://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz
    3.3        https://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz
    3.2.1      https://www.mpich.org/static/downloads/3.2.1/mpich-3.2.1.tar.gz
    3.2        https://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz
    3.1.4      https://www.mpich.org/static/downloads/3.1.4/mpich-3.1.4.tar.gz
    3.1.3      https://www.mpich.org/static/downloads/3.1.3/mpich-3.1.3.tar.gz
    3.1.2      https://www.mpich.org/static/downloads/3.1.2/mpich-3.1.2.tar.gz
    3.1.1      https://www.mpich.org/static/downloads/3.1.1/mpich-3.1.1.tar.gz
    3.1        https://www.mpich.org/static/downloads/3.1/mpich-3.1.tar.gz
    3.0.4      https://www.mpich.org/static/downloads/3.0.4/mpich-3.0.4.tar.gz

Deprecated versions:  
    None

Variants:
    Name [Default]               When    Allowed values          Description
    =========================    ====    ====================    ===============================================================================

    argobots [off]               --      on, off                 Enable Argobots support
    device [ch4]                 --      ch3, ch4                Abstract Device Interface (ADI)
                                                                 implementation. The ch4 device is in experimental state for versions
                                                                 before 3.4.
    fortran [on]                 --      on, off                 Enable Fortran support
    hwloc [on]                   --      on, off                 Use external hwloc package
    hydra [on]                   --      on, off                 Build the hydra process manager
    libxml2 [on]                 --      on, off                 Use libxml2 for XML support instead of the custom minimalistic implementation
    netmod [ofi]                 --      tcp, mxm, ofi, ucx      Network module. Only single netmod builds are
                                                                 supported. For ch3 device configurations, this presumes the
                                                                 ch3:nemesis communication channel. ch3:sock is not supported by this
                                                                 spack package at this time.
    pci [on]                     --      on, off                 Support analyzing devices on PCI bus
    pmi [pmi]                    --      off, pmi, pmi2,         PMI interface.
                                         pmix, cray              
    romio [on]                   --      on, off                 Enable ROMIO MPI I/O implementation
    slurm [off]                  --      on, off                 Enable SLURM support
    two_level_namespace [off]    --      on, off                 Build shared libraries and programs
                                                                 built with the mpicc/mpifort/etc. compiler wrappers
                                                                 with '-Wl,-commons,use_dylibs' and without
                                                                 '-Wl,-flat_namespace'.
    verbs [off]                  --      on, off                 Build support for OpenFabrics verbs.
    wrapperrpath [on]            --      on, off                 Enable wrapper rpath

Build Dependencies:
    argobots  automake  findutils  hwloc      libpciaccess  libxml2  pkgconfig  python  ucx
    autoconf  cray-pmi  gnuconfig  libfabric  libtool       m4       pmix       slurm

Link Dependencies:
    argobots  cray-pmi  hwloc  libfabric  libpciaccess  libxml2  pmix  slurm  ucx

Run Dependencies:
    None

```
and with no dependencies, variants, or versions:
```
$ spack info --no-dependencies --no-variants --no-versions mpich
AutotoolsPackage:   mpich

Description:
    MPICH is a high performance and widely portable implementation of the
    Message Passing Interface (MPI) standard.

Homepage: https://www.mpich.org
```

Examples of only showing the test output are:

```
$ spack info --no-dependencies --no-variants --no-versions --tests mpich
AutotoolsPackage:   mpich

Description:
    MPICH is a high performance and widely portable implementation of the
    Message Passing Interface (MPI) standard.

Homepage: https://www.mpich.org

Available Build Phase Test Methods:
    check

Available Install Phase Test Methods:
    installcheck

Stand-Alone/Smoke Test Methods:
    mpi.test  mpich.test

$ spack info --no-dependencies --no-variants --no-versions --tests py-numpy
PythonPackage:   py-numpy

Description:
    NumPy is the fundamental package for scientific computing with Python.
    It contains among other things: a powerful N-dimensional array object,
    sophisticated (broadcasting) functions, tools for integrating C/C++ and
    Fortran code, and useful linear algebra, Fourier transform, and random
    number capabilities

Homepage: https://numpy.org/

Available Build Phase Test Methods:
    None

Available Install Phase Test Methods:
    test

Stand-Alone/Smoke Test Methods:
    pythonpackage.test

$ spack info --no-dependencies --no-variants --no-versions --tests intel-parallel-studio
IntelPackage:   intel-parallel-studio

Description:
    Intel Parallel Studio.

Homepage: https://software.intel.com/en-us/intel-parallel-studio-xe

Available Build Phase Test Methods:
    None

Available Install Phase Test Methods:
    None

Stand-Alone/Smoke Test Methods:
    c.test  cxx.test  fortran.test  mpi.test
```

An outstanding issue is whether the approach taken above adequately conveys the fact that `build_time_test_callbacks` and `install_time_test_callbacks` in packages, such as `AutotoolsPackage` and `MakefilePackage`, are automatically run after the correspondingly named phases *IF* the corresponding standard targets are available.  Unfortunately, we don't readily have a way to confirm that those targets are actually implemented in the packages.