### PR TITLE
moosefs: Add --with-systemdsystemunitdir option

### DIFF
--- a/var/spack/repos/builtin/packages/moosefs/package.py
+++ b/var/spack/repos/builtin/packages/moosefs/package.py
@@ -22,3 +22,8 @@ class Moosefs(AutotoolsPackage):
     version('3.0.105', sha256='12a5bb265d774da8fc6f051c51de08105ddeaa162b2d972d491caa542e01164f')
     version('3.0.104', sha256='b3209ecd8366038ba898c4642dd6fdf2fa5d50a37345f01ed209e078700db5bb')
     version('3.0.103', sha256='c5f1f6f78c2b7d8d6563000deed704ead3deac77279cb13f9f16d7ee56ee7ff7')
+
+    def configure_args(self):
+        args = ["--with-systemdsystemunitdir=" +
+                self.spec['moosefs'].prefix.lib.systemd.system]
+        return args


### PR DESCRIPTION
I fixed the following error.
  747    /usr/bin/install: cannot create regular file '/usr/lib/systemd/syst
            em/moosefs-cgiserv.service': Permission denied
  748    /usr/bin/install: cannot create regular file '/usr/lib/systemd/syst
            em/moosefs-chunkserver.service': Permission denied
  749    /usr/bin/install: cannot create regular file '/usr/lib/systemd/syst
            em/moosefs-chunkserver@@.service': Permission denied
  750    /usr/bin/install: cannot create regular file '/usr/lib/systemd/syst
            em/moosefs-master.service': Permission denied
  751    /usr/bin/install: cannot create regular file '/usr/lib/systemd/syst
            em/moosefs-master@@.service': Permission denied
  752    /usr/bin/install: cannot create regular file '/usr/lib/systemd/syst
            em/moosefs-metalogger.service': Permission denied
  753    /usr/bin/install: cannot create regular file '/usr/lib/systemd/syst
            em/moosefs-metalogger@@.service': Permission denied