### PR TITLE
rrdtool: Add --with-systemdsystemunitdir option

### DIFF
--- a/var/spack/repos/builtin/packages/rrdtool/package.py
+++ b/var/spack/repos/builtin/packages/rrdtool/package.py
@@ -22,5 +22,7 @@ class Rrdtool(AutotoolsPackage):
     depends_on('perl-extutils-makemaker')
 
     def configure_args(self):
-        args = ['LDFLAGS=-lintl']
+        args = ['LDFLAGS=-lintl',
+                "--with-systemdsystemunitdir=" +
+                self.spec['rrdtool'].prefix.lib.systemd.system]
         return args


### PR DESCRIPTION
I fixed the following error.
  1144    /usr/bin/install: cannot create regular file '/usr/lib/systemd/sys
             tem/rrdcached.socket': Permission denied
  1145    /usr/bin/install: cannot create regular file '/usr/lib/systemd/sys
             tem/rrdcached.service': Permission denied