### PR TITLE
py-torch: add v1.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -20,6 +20,7 @@ class PyTorch(PythonPackage, CudaPackage):
     import_modules = ['torch', 'torch.autograd', 'torch.nn', 'torch.utils']
 
     version('master', branch='master', submodules=True)
+    version('1.8.0', tag='v1.8.0', submodules=True)
     version('1.7.1', tag='v1.7.1', submodules=True)
     version('1.7.0', tag='v1.7.0', submodules=True)
     version('1.6.0', tag='v1.6.0', submodules=True)
@@ -93,9 +94,10 @@ class PyTorch(PythonPackage, CudaPackage):
     # Use Ninja generator to speed up build times
     # Automatically used if found
     depends_on('ninja@1.5:', type='build')
-    depends_on('python@3.6.1:', when='@1.6:', type=('build', 'run'))
-    depends_on('python@3.5:', when='@1.5:', type=('build', 'run'))
-    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('python@3.6.2:', when='@1.7.1:', type=('build', 'link', 'run'))
+    depends_on('python@3.6.1:', when='@1.6:', type=('build', 'link', 'run'))
+    depends_on('python@3.5:', when='@1.5:', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'link', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-future', when='@1.5:', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.8.8 and Apple Clang 12.0.0.

https://github.com/pytorch/pytorch/releases/tag/v1.8.0