### PR TITLE
py-torchvision: add v0.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -15,6 +15,7 @@ class PyTorchvision(PythonPackage):
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('0.9.0', sha256='9351ed92aded632f8c7f59dfadac13c191a834babe682f5785ea47e6fcf6b472')
     version('0.8.2', sha256='9a866c3c8feb23b3221ce261e6153fc65a98ce9ceaa71ccad017016945c178bf')
     version('0.8.1', sha256='c46734c679c99f93e5c06654f4295a05a6afe6c00a35ebd26a2cce507ae1ccbd')
     version('0.8.0', sha256='b5f040faffbfc7bac8d4687d8665bd1196937334589b3fb5fcf15bb69ca25391')
@@ -32,10 +33,10 @@ class PyTorchvision(PythonPackage):
             values=('pil', 'accimage', 'png', 'jpeg'), multi=False)
 
     # https://github.com/pytorch/vision#installation
-    depends_on('python@3.6:', when='@0.7:', type=('build', 'run'))
-    depends_on('python@3.5:', when='@0.6.0:0.6.999', type=('build', 'run'))
-    depends_on('python@2.7:2.8,3.5:3.8', when='@0.5.0', type=('build', 'run'))
-    depends_on('python@2.7:2.8,3.5:3.7', when='@:0.4', type=('build', 'run'))
+    depends_on('python@3.6:', when='@0.7:', type=('build', 'link', 'run'))
+    depends_on('python@3.5:', when='@0.6.0:0.6.999', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2.8,3.5:3.8', when='@0.5.0', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2.8,3.5:3.7', when='@:0.4', type=('build', 'link', 'run'))
 
     depends_on('py-setuptools', type='build')
     depends_on('ninja', type='build')
@@ -44,6 +45,7 @@ class PyTorchvision(PythonPackage):
 
     # https://github.com/pytorch/vision#installation
     depends_on('py-torch@master', when='@master', type=('build', 'link', 'run'))
+    depends_on('py-torch@1.8.0', when='@0.9.0', type=('build', 'link', 'run'))
     depends_on('py-torch@1.7.1', when='@0.8.2', type=('build', 'link', 'run'))
     depends_on('py-torch@1.7.0', when='@0.8.1', type=('build', 'link', 'run'))
     depends_on('py-torch@1.7.0', when='@0.8.0', type=('build', 'link', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.8.8 and Apple Clang 12.0.0.

Depends on #22101 

https://github.com/pytorch/vision/releases/tag/v0.9.0