### PR TITLE
py-python-ldap: Add cyrus-sasl depend

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-ldap/package.py
+++ b/var/spack/repos/builtin/packages/py-python-ldap/package.py
@@ -22,3 +22,4 @@ class PyPythonLdap(PythonPackage):
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-pyasn1@0.3.7:', type=('build', 'run'))
     depends_on('py-pyasn1-modules@0.1.5:', type=('build', 'run'))
+    depends_on('cyrus-sasl', type='link')


### PR DESCRIPTION
I fixed the following error.
    77    Modules/LDAPObject.c:16:10: fatal error: sasl/sasl.h: No such file or directory
    78     #include <sasl/sasl.h>