### PR TITLE
Fix graph when deptypes are filtered

### DIFF
--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -62,16 +62,15 @@ def topological_sort(spec, reverse=False, deptype='all'):
     """
     deptype = canonical_deptype(deptype)
 
-    if not reverse:
-        parents = lambda s: s.dependents()
-        children = lambda s: s.dependencies()
-    else:
-        parents = lambda s: s.dependencies()
-        children = lambda s: s.dependents()
-
     # Work on a copy so this is nondestructive.
     spec = spec.copy(deps=deptype)
     nodes = spec.index(deptype=deptype)
+
+    parents = lambda s: [p for p in s.dependents() if p.name in nodes]
+    children = lambda s: s.dependencies()
+
+    if reverse:
+        parents, children = children, parents
 
     topo_order = []
     par = dict((name, parents(nodes[name])) for name in nodes.keys())

--- a/lib/spack/spack/test/directory_layout.py
+++ b/lib/spack/spack/test/directory_layout.py
@@ -120,7 +120,7 @@ def test_read_and_write_spec(temporary_store, config, mock_packages):
         # TODO: fix this when we can concretize more loosely based on
         # TODO: what is installed. We currently omit these to
         # TODO: increase reuse of build dependencies.
-        stored_deptypes = ('link', 'run')
+        stored_deptypes = spack.hash_types.full_hash
         expected = spec.copy(deps=stored_deptypes)
         expected._mark_concrete()
 

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -122,3 +122,11 @@ o  dyninst
 |/
 o  libelf
 '''
+
+def test_topo_sort_filtered(mock_packages):
+    """Test topo sort gives correct order when filtering link deps."""
+    s = Spec('both-link-and-build-dep-a').normalized()
+
+    topo = topological_sort(s, deptype=('link',))
+
+    assert topo == ['both-link-and-build-dep-a', 'both-link-and-build-dep-c']

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -123,6 +123,7 @@ o  dyninst
 o  libelf
 '''
 
+
 def test_topo_sort_filtered(mock_packages):
     """Test topo sort gives correct order when filtering link deps."""
     s = Spec('both-link-and-build-dep-a').normalized()

--- a/var/spack/repos/builtin.mock/packages/both-link-and-build-dep-a/package.py
+++ b/var/spack/repos/builtin.mock/packages/both-link-and-build-dep-a/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class BothLinkAndBuildDepA(Package):
+    """
+        Structure where c occurs as a build dep down the line and as a direct
+        link dep. Useful for testing situations where you copy the parent spec
+        just with link deps, and you want to make sure b is not part of that.
+        a <--build-- b <-link-- c
+        a <--link--- c
+    """
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    depends_on('both-link-and-build-dep-b', type='build')
+    depends_on('both-link-and-build-dep-c', type='link')

--- a/var/spack/repos/builtin.mock/packages/both-link-and-build-dep-b/package.py
+++ b/var/spack/repos/builtin.mock/packages/both-link-and-build-dep-b/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class BothLinkAndBuildDepB(Package):
+    """
+        Structure where c occurs as a build dep down the line and as a direct
+        link dep. Useful for testing situations where you copy the parent spec
+        just with link deps, and you want to make sure b is not part of that.
+        a <--build-- b <-link-- c
+        a <--link--- c
+    """
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    depends_on('both-link-and-build-dep-c', type='link')

--- a/var/spack/repos/builtin.mock/packages/both-link-and-build-dep-c/package.py
+++ b/var/spack/repos/builtin.mock/packages/both-link-and-build-dep-c/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class BothLinkAndBuildDepC(Package):
+    """
+        Structure where c occurs as a build dep down the line and as a direct
+        link dep. Useful for testing situations where you copy the parent spec
+        just with link deps, and you want to make sure b is not part of that.
+        a <--build-- b <-link-- c
+        a <--link--- c
+    """
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')


### PR DESCRIPTION
Fix that adds a simple workaround for the issue explained in https://github.com/spack/spack/issues/22118

When we have this structure:

```
a <-- build -- b <-- link -- c
a <-- link -- c
```

And we run `spack graph --deptype=link a` it fails with spack believing there are cycles.

But the issue is that topo sorts does not drop `b` as a parent of `c` (as in, c.dependents() contains b still) even though it is a build dep of `a`.

This PR adds the above example as a test and basically just adds a filter to the parent function in topological_sort to skip non-`deptype`-parents.

This fixes the problem found when adding openssh as a 'run' dep to openmpi: https://github.com/spack/spack/pull/22115
