### PR TITLE
Cmake: Update Cmake 3.19.x to support crayftn preprocessing (cce 11+)

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/5882-enable-cce-fortran-preprocessing.patch
+++ b/var/spack/repos/builtin/packages/cmake/5882-enable-cce-fortran-preprocessing.patch
@@ -1,0 +1,31 @@
+From ef513fe3d1d864d865d7143699834228988a7cd7 Mon Sep 17 00:00:00 2001
+From: Brad King <brad.king@kitware.com>
+Date: Fri, 5 Mar 2021 08:08:16 -0500
+Subject: [PATCH] Cray: Enable explicit Fortran preprocessing for Ninja
+ generator
+
+Cray 11.0 adds support for preprocessing with output written to a
+specified file (instead of always next to the source).  Use it to
+enable Cray Fortran with the Ninja generator.
+
+Patch-by: James Elliott
+Fixes: #20731
+---
+ Modules/Compiler/Cray-Fortran.cmake | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Modules/Compiler/Cray-Fortran.cmake b/Modules/Compiler/Cray-Fortran.cmake
+index 696ae76074..0d5e1c7679 100644
+--- a/Modules/Compiler/Cray-Fortran.cmake
++++ b/Modules/Compiler/Cray-Fortran.cmake
+@@ -19,3 +19,7 @@ else()
+   set(CMAKE_Fortran_COMPILE_OPTIONS_PREPROCESS_ON "-eZ")
+   set(CMAKE_Fortran_COMPILE_OPTIONS_PREPROCESS_OFF "-dZ")
+ endif()
++
++if (NOT CMAKE_Fortran_COMPILER_VERSION VERSION_LESS 11.0)
++  set(CMAKE_Fortran_PREPROCESS_SOURCE "<CMAKE_Fortran_COMPILER> -o <PREPROCESSED_SOURCE> <DEFINES> <INCLUDES> <FLAGS> -eP <SOURCE>")
++endif()
+-- 
+GitLab
+

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -183,6 +183,13 @@ class Cmake(Package):
     # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5025
     patch('pgi-cxx-ansi.patch', when='@3.15:3.18.99')
 
+    # Adds CCE v11+ fortran preprocessing definition.
+    # requires Cmake 3.19+
+    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5882
+    patch('5882-enable-cce-fortran-preprocessing.patch',
+          sha256='b48396c0e4f61756248156b6cebe9bc0d7a22228639b47b5aa77c9330588ce88',
+          when='@3.19.0:3.19.99')
+
     conflicts('+qt', when='^qt@5.4.0')  # qt-5.4.0 has broken CMake modules
 
     # https://gitlab.kitware.com/cmake/cmake/issues/18166


### PR DESCRIPTION
Cray added necessary functionality for CMake to support fortran preprocessing using `crayftn` (with output in a way that Cmake can process).

This patch is necessary for the current release of cmake (3.19), with the patch expected to be in the 3.20 release of Cmake. The included patch is from kitware.

see https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5882