### PR TITLE
graphite2: add python@3.6: as dependency

### DIFF
--- a/var/spack/repos/builtin/packages/graphite2/package.py
+++ b/var/spack/repos/builtin/packages/graphite2/package.py
@@ -17,4 +17,6 @@ class Graphite2(CMakePackage):
 
     version('1.3.13', sha256='dd63e169b0d3cf954b397c122551ab9343e0696fb2045e1b326db0202d875f06')
 
+    depends_on('python@3.6:')
+
     patch('regparm.patch')

--- a/var/spack/repos/builtin/packages/graphite2/package.py
+++ b/var/spack/repos/builtin/packages/graphite2/package.py
@@ -17,6 +17,6 @@ class Graphite2(CMakePackage):
 
     version('1.3.13', sha256='dd63e169b0d3cf954b397c122551ab9343e0696fb2045e1b326db0202d875f06')
 
-    depends_on('python@3.6:')
+    depends_on('python@3.6:', type='run')
 
     patch('regparm.patch')

--- a/var/spack/repos/builtin/packages/graphite2/package.py
+++ b/var/spack/repos/builtin/packages/graphite2/package.py
@@ -17,6 +17,6 @@ class Graphite2(CMakePackage):
 
     version('1.3.13', sha256='dd63e169b0d3cf954b397c122551ab9343e0696fb2045e1b326db0202d875f06')
 
-    depends_on('python@3.6:', type='run')
+    depends_on('python@3.6:', type='test')
 
     patch('regparm.patch')


### PR DESCRIPTION
Some test failed because missing `python`:
```
The following tests FAILED:
	 70 - padaukcmp1 (Failed)
	 71 - chariscmp1 (Failed)
	 72 - chariscmp2 (Failed)
	 73 - annacmp1 (Failed)
	 74 - schercmp1 (Failed)
	 75 - awamicmp1 (Failed)
	 76 - awamicmp2 (Failed)
	 77 - awamicmp3 (Failed)
Errors while running CTest
make: *** [Makefile:95: test] Error 8
```