### PR TITLE
v0.9.1 release of mochi-margo

### DIFF
--- a/var/spack/repos/builtin/packages/margo/package.py
+++ b/var/spack/repos/builtin/packages/margo/package.py
@@ -11,13 +11,14 @@ class Margo(AutotoolsPackage):
     implementation.  This name will be deprecated soon; please use the
     mochi-margo package instead."""
 
-    homepage = 'https://xgitlab.cels.anl.gov/sds/margo'
-    git = 'https://xgitlab.cels.anl.gov/sds/margo.git'
-    url = 'https://xgitlab.cels.anl.gov/sds/margo/-/archive/v0.9/margo-v0.9.tar.gz'
+    homepage = 'https://github.com/mochi-hpc/mochi-margo'
+    git = 'https://github.com/mochi-hpc/mochi-margo.git'
+    url = 'https://github.com/mochi-hpc/mochi-margo/archive/v0.9.tar.gz'
 
     maintainers = ['carns', 'mdorier', 'fbudin69500', 'chuckatkins']
 
     version('master', branch='master', deprecated=True)
+    version('0.9.1', sha256='3fe933f2d758ef23d582bc776e4f8cfae9bf9d0849b8b1f9d73ee024e218f2bc')
     version('0.9', sha256='a24376f66450cc8fd7a43043e189f8efce5a931585e53c1e2e41894a3e99b517', deprecated=True)
     version('0.7', sha256='492d1afe2e7984fa638614a5d34486d2ff761f5599b5984efd5ae3f55cafde54', deprecated=True)
     version('0.7.2', sha256='0ca796abdb82084813a5de033d92364910b5ad1a0df135534d6b1c36ef627859', deprecated=True)

--- a/var/spack/repos/builtin/packages/mochi-margo/package.py
+++ b/var/spack/repos/builtin/packages/mochi-margo/package.py
@@ -17,6 +17,7 @@ class MochiMargo(AutotoolsPackage):
     maintainers = ['carns', 'mdorier', 'fbudin69500', 'chuckatkins']
 
     version('main', branch='main')
+    version('0.9.1', sha256='3fe933f2d758ef23d582bc776e4f8cfae9bf9d0849b8b1f9d73ee024e218f2bc')
     version('0.9', sha256='a24376f66450cc8fd7a43043e189f8efce5a931585e53c1e2e41894a3e99b517')
     version('0.7', sha256='492d1afe2e7984fa638614a5d34486d2ff761f5599b5984efd5ae3f55cafde54')
     version('0.7.2', sha256='0ca796abdb82084813a5de033d92364910b5ad1a0df135534d6b1c36ef627859')


### PR DESCRIPTION
- also bring deprecated margo pkg in sync with mochi-margo (official repo has moved to github)