### PR TITLE
Add `--vanilla` flag to r build system

### DIFF
--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -84,6 +84,7 @@ class RPackage(PackageBase):
         config_vars = self.configure_vars()
 
         args = [
+            '--vanilla',
             'CMD',
             'INSTALL'
         ]


### PR DESCRIPTION
Unlike the other commands of the `R CMD` interface, the `INSTALL` command
will read `Renviron` files. This can potentially break builds of r-
packages, depending on what is set in the `Renviron` file. This PR adds
the `--vanilla` flag to ensure that neither `Rprofile` nor `Renviron` files
are read during Spack builds of r- packages.