### PR TITLE
kmod: Add --with-bashcompletiondir option

### DIFF
--- a/var/spack/repos/builtin/packages/kmod/package.py
+++ b/var/spack/repos/builtin/packages/kmod/package.py
@@ -28,3 +28,9 @@ class Kmod(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         bash = which("bash")
         bash('autogen.sh')
+
+    def configure_args(self):
+        args = ["--with-bashcompletiondir=" +
+                join_path(self.spec['kmod'].prefix, 'share',
+                          'bash-completion', 'completions')]
+        return args


### PR DESCRIPTION
I fixed the following error.
286 /usr/bin/install: cannot remove '/usr/share/bash-completion/completions/kmod': Permission denied