### PR TITLE
netcdf-c: patch detection of pnetcdf for spectrum-mpi

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/4.7.3-spectrum-mpi-pnetcdf-detect.patch
+++ b/var/spack/repos/builtin/packages/netcdf-c/4.7.3-spectrum-mpi-pnetcdf-detect.patch
@@ -1,0 +1,44 @@
+--- a/configure 2019-11-20 18:59:25.000000000 -0500
++++ b/configure 13:20:48.088873402 -0500
+@@ -18459,12 +18459,12 @@
+ $as_echo_n "checking Is libpnetcdf version 1.6.0 or later?... " >&6; }
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <pnetcdf.h>
+ 
+ int
+ main ()
+ {
+ 
+-#include <pnetcdf.h>
+ #if (PNETCDF_VERSION_MAJOR*1000 + PNETCDF_VERSION_MINOR < 1006)
+       choke me
+ #endif
+@@ -18584,12 +18584,12 @@
+ $as_echo_n "checking if erange-fill is enabled in PnetCDF... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <pnetcdf.h>
+ 
+ int
+ main ()
+ {
+ 
+-#include <pnetcdf.h>
+ #if !defined(PNETCDF_ERANGE_FILL) || PNETCDF_ERANGE_FILL == 0
+       choke me
+ #endif
+@@ -18619,12 +18619,12 @@
+ $as_echo_n "checking if relax-coord-bound is enabled in PnetCDF... " >&6; }
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
++#include <pnetcdf.h>
+ 
+ int
+ main ()
+ {
+ 
+-#include <pnetcdf.h>
+ #if !defined(PNETCDF_RELAX_COORD_BOUND) || PNETCDF_RELAX_COORD_BOUND == 0
+       choke me
+ #endif

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -53,6 +53,9 @@ class NetcdfC(AutotoolsPackage):
     patch('https://github.com/Unidata/netcdf-c/pull/1505.patch', sha256='f52db13c61b9c19aafe03c2a865163b540e9f6dee36e3a5f808f05fac59f2030', when='@4.7.2')
     patch('https://github.com/Unidata/netcdf-c/pull/1508.patch', sha256='56532470875b9a97f3cf2a7d9ed16ef1612df3265ee38880c109428322ff3a40', when='@4.7.2')
 
+    # See https://github.com/Unidata/netcdf-c/pull/1752
+    patch('4.7.3-spectrum-mpi-pnetcdf-detect.patch', when='@4.7.3:4.7.4 +parallel-netcdf')
+
     variant('mpi', default=True,
             description='Enable parallel I/O for netcdf-4')
     variant('parallel-netcdf', default=False,


### PR DESCRIPTION
`netcdf-c@4.7.3:4.7.4+parallel-netcdf` can't detect `parallel-netcdf` with `spectrum-mpi`. This has been fixed in `netcdf-c@master`.

This PR patches `netcdf-c@4.7.3:4.7.4+parallel-netcdf`.

https://github.com/Unidata/netcdf-c/pull/1752

@sayerhs @jrood-nrel @skosukhin @WardF