### PR TITLE
Fix ELPA < 2020 with GCC >= 10

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -29,7 +29,6 @@ class Elpa(AutotoolsPackage, CudaPackage):
     version('2015.11.001', sha256='c0761a92a31c08a4009c9688c85fc3fc8fde9b6ce05e514c3e1587cf045e9eba')
 
     variant('openmp', default=False, description='Activates OpenMP support')
-    variant('optflags', default=True, description='Build with -O2 optimization flags. GCC only.')
 
     depends_on('mpi')
     depends_on('blas')
@@ -91,10 +90,6 @@ class Elpa(AutotoolsPackage, CudaPackage):
         if self.compiler.name == "gcc":
             gcc_options = []
             gfortran_options = ['-ffree-line-length-none']
-
-            if '+optflags' in spec:
-                gcc_options.append('-O2')
-                gfortran_options.append('-O2')
 
             if self.compiler.version >= Version("10.0.0") \
                and spec.version <= Version("2019.11.001"):

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -29,7 +29,7 @@ class Elpa(AutotoolsPackage, CudaPackage):
     version('2015.11.001', sha256='c0761a92a31c08a4009c9688c85fc3fc8fde9b6ce05e514c3e1587cf045e9eba')
 
     variant('openmp', default=False, description='Activates OpenMP support')
-    variant('optflags', default=True, description='Build with optimization flags')
+    variant('optflags', default=True, description='Build with -O2 optimization flags. GCC only.')
 
     depends_on('mpi')
     depends_on('blas')
@@ -88,10 +88,22 @@ class Elpa(AutotoolsPackage, CudaPackage):
         if not any(f in spec.target for f in simd_features):
             options.append('--enable-generic')
 
-        if '+optflags' in spec:
+        if self.compiler.name == "gcc":
+            gcc_options = []
+            gfortran_options = ['-ffree-line-length-none']
+
+            if '+optflags' in spec:
+                gcc_options.append('-O2')
+                gfortran_options.append('-O2')
+
+            if self.compiler.version >= Version("10.0.0") \
+               and spec.version <= Version("2019.11.001"):
+                gfortran_options.append('-fallow-argument-mismatch')
+
+            space_separator = ' '
             options.extend([
-                'FCFLAGS=-O2 -ffree-line-length-none',
-                'CFLAGS=-O2'
+                'CFLAGS=' + space_separator.join(gcc_options),
+                'FCFLAGS=' + space_separator.join(gfortran_options),
             ])
 
         if '%aocc' in spec:


### PR DESCRIPTION
1. -O2 and -ffree-line-length-none are GCC specific. Moved under gcc compiler guard.
2. Make ELPA < 2020 releases to be built by GCC >=10 by adding '-fallow-argument-mismatch'