### PR TITLE
py-chainer: Add test method for ChainerMN (continued #21848, #21940)

### DIFF
--- a/var/spack/repos/builtin/packages/py-chainer/package.py
+++ b/var/spack/repos/builtin/packages/py-chainer/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 import json
 
 

--- a/var/spack/repos/builtin/packages/py-chainer/package.py
+++ b/var/spack/repos/builtin/packages/py-chainer/package.py
@@ -78,7 +78,7 @@ class PyChainer(PythonPackage):
             # check results
             json_open = open(join_path(test_dir, 'log'), 'r')
             json_load = json.load(json_open)
-            v = {d.get('epoch'): d.get('main/accuracy') for d in json_load}
+            v = dict([(d.get('epoch'), d.get('main/accuracy')) for d in json_load])
             if 1 not in v or 20 not in v:
                 raise RuntimeError('Cannot find epoch 1 or epoch 20')
             if abs(1.0 - v[1]) < abs(1.0 - v[20]):

--- a/var/spack/repos/builtin/packages/py-chainer/package.py
+++ b/var/spack/repos/builtin/packages/py-chainer/package.py
@@ -81,6 +81,6 @@ class PyChainer(PythonPackage):
             json_load = json.load(json_open)
             v = {d.get('epoch'): d.get('main/accuracy') for d in json_load}
             if 1 not in v or 20 not in v:
-                raise RuntimeError('Cannot found epoch 1 or epoch 20')
+                raise RuntimeError('Cannot find epoch 1 or epoch 20')
             if abs(1.0 - v[1]) < abs(1.0 - v[20]):
                 raise RuntimeError('ChainerMN Test Failed !')

--- a/var/spack/repos/builtin/packages/py-chainer/package.py
+++ b/var/spack/repos/builtin/packages/py-chainer/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
+import json
 
 
 class PyChainer(PythonPackage):
@@ -25,6 +27,8 @@ class PyChainer(PythonPackage):
     version('7.2.0', sha256='6e2fba648cc5b8a5421e494385b76fe5ec154f1028a1c5908557f5d16c04f0b3')
     version('6.7.0', sha256='87cb3378a35e7c5c695028ec91d58dc062356bc91412384ea939d71374610389')
 
+    variant("mn", default=False, description="run with ChainerMN")
+
     depends_on('python@3.5.1:', when='@7:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-numpy@1.9:', type=('build', 'run'))
@@ -34,3 +38,49 @@ class PyChainer(PythonPackage):
     depends_on('py-filelock', type=('build', 'run'))
     depends_on('py-protobuf@3:', type=('build', 'run'))
     depends_on('py-typing@:3.6.6', when='@:6', type=('build', 'run'))
+
+    # Dependencies only required for test of ChainerMN
+    depends_on('py-matplotlib', type=('build', 'run'), when='+mn')
+    depends_on('py-mpi4py', type=('build', 'run'), when='+mn')
+    depends_on("mpi", type=("build", "run"), when='+mn')
+
+    @run_after('install')
+    def cache_test_sources(self):
+        if '+mn' in self.spec:
+            self.cache_extra_test_sources("examples")
+
+    def test(self):
+        if "+mn" in self.spec:
+            # Run test of ChainerMN
+            test_dir = self.test_suite.current_test_data_dir
+
+            mnist_dir = join_path(
+                self.install_test_root, "examples", "chainermn", "mnist"
+            )
+            mnist_file = join_path(mnist_dir, "train_mnist.py")
+            mpi_name = self.spec["mpi"].prefix.bin.mpirun
+            python_exe = self.spec["python"].command.path
+            opts = [
+                "-n",
+                "4",
+                python_exe,
+                mnist_file,
+                "-o",
+                test_dir,
+            ]
+            env["OMP_NUM_THREADS"] = "4"
+
+            self.run_test(
+                mpi_name,
+                options=opts,
+                work_dir=test_dir,
+            )
+
+            # check results
+            json_open = open(join_path(test_dir, 'log'), 'r')
+            json_load = json.load(json_open)
+            v = {d.get('epoch'): d.get('main/accuracy') for d in json_load}
+            if 1 not in v or 20 not in v:
+                raise RuntimeError('Cannot found epoch 1 or epoch 20')
+            if abs(1.0 - v[1]) < abs(1.0 - v[20]):
+                raise RuntimeError('ChainerMN Test Failed !')


### PR DESCRIPTION
continued #21848, #21940
Add test method for ChainerMN .
Removed the environment variable settings in the Fugaku file pointed out in #21940.