### PR TITLE
pocl: modified depends_on

### DIFF
--- a/var/spack/repos/builtin/packages/pocl/package.py
+++ b/var/spack/repos/builtin/packages/pocl/package.py
@@ -56,7 +56,7 @@ class Pocl(CMakePackage):
     # (see #1616)
     # These are the supported LLVM versions
     depends_on("llvm +clang @6.0:11.0", when="@master")
-    depends_on("llvm +clang +shared_libs @6.0:11.0", when="@1.6")
+    depends_on("llvm +clang +shared_libs -flang @6.0:11.0", when="@1.6")
     depends_on("llvm +clang @6.0:10.0", when="@1.5")
     depends_on("llvm +clang @6.0:9.0", when="@1.4")
     depends_on("llvm +clang @5.0:8.0", when="@1.3")


### PR DESCRIPTION
modifyed depends_on("llvm +clang +shared_libs -flang @6.0:11.0", when="@1.6")

The following error occurred during installation.
Previously, no variants of flang existed.

```
3 errors found in build log:
     50148    make  -f tools/mlir/include/mlir/Dialect/Linalg/IR/CMakeFiles/MLIRLinalgNamedStructuredOpsIncGen.dir
              /build.make tools/mlir/include/mlir/Dialect/Linalg/IR/CMakeFiles/MLIRLinalgNamedStructuredOpsIncGen.
              dir/build
     50149    make[2]: Entering directory '/tmp/spack-test1/spack-stage/spack-stage-llvm-11.0.1-vy7sthmcqwnphq5iqc
              76gvm7okmls22m/spack-build-vy7sthm'
     50150    [ 56%] Generating LinalgNamedStructuredOps.td, LinalgNamedStructuredOps.cpp.inc
     50151    cd /tmp/spack-test1/spack-stage/spack-stage-llvm-11.0.1-vy7sthmcqwnphq5iqc76gvm7okmls22m/spack-build
              -vy7sthm/tools/mlir/include/mlir/Dialect/Linalg/IR && ../../../../../../../bin/mlir-linalg-ods-gen -
              gen-ods-decl /tmp/spack-test1/spack-stage/spack-stage-llvm-11.0.1-vy7sthmcqwnphq5iqc76gvm7okmls22m/s
              pack-src/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOpsSpec.tc > /tmp/spack-test1/spac
              k-stage/spack-stage-llvm-11.0.1-vy7sthmcqwnphq5iqc76gvm7okmls22m/spack-build-vy7sthm/tools/mlir/incl
              ude/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.td
     50152    [ 56%] Linking CXX static library ../../../../lib/liblldbHost.a
     50153    cd /tmp/spack-test1/spack-stage/spack-stage-llvm-11.0.1-vy7sthmcqwnphq5iqc76gvm7okmls22m/spack-build
              -vy7sthm/tools/lldb/source/Host && /data/test-1/spack/opt/spack/linux-rhel8-haswell/gcc-8.3.1/cmake-
              3.19.2-tr6y5pamguvjizmeqfxzggubrd346exo/bin/cmake -P CMakeFiles/lldbHost.dir/cmake_clean_target.cmak
              e
  >> 50154    ../../../../../../../bin/mlir-linalg-ods-gen: error while loading shared libraries: libLLVMCore.so.1
              1: cannot open shared object file: No such file or directory
  >> 50155    make[2]: *** [tools/mlir/include/mlir/Dialect/Linalg/IR/CMakeFiles/MLIRLinalgNamedStructuredOpsIncGe
              n.dir/build.make:86: tools/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.td] Error 12
              7
     50156    make[2]: *** Deleting file 'tools/mlir/include/mlir/Dialect/Linalg/IR/LinalgNamedStructuredOps.td'
     50157    make[2]: Leaving directory '/tmp/spack-test1/spack-stage/spack-stage-llvm-11.0.1-vy7sthmcqwnphq5iqc7
              6gvm7okmls22m/spack-build-vy7sthm'
  >> 50158    make[1]: *** [CMakeFiles/Makefile2:126889: tools/mlir/include/mlir/Dialect/Linalg/IR/CMakeFiles/MLIR
              LinalgNamedStructuredOpsIncGen.dir/all] Error 2
     50159    make[1]: *** Waiting for unfinished jobs....
```