### PR TITLE
New version libnetworkit/py-networkit 8.0 -> 8.1

### DIFF
--- a/var/spack/repos/builtin/packages/libnetworkit/package.py
+++ b/var/spack/repos/builtin/packages/libnetworkit/package.py
@@ -22,6 +22,7 @@ class Libnetworkit(CMakePackage):
 
     maintainers = ['fabratu']
 
+    version('8.1', sha256='0a22eb839606b9fabfa68c7add12c4de5eee735c6f8bb34420e5916ce5d7f829')
     version('8.0', sha256='cdf9571043edbe76c447622ed33efe9cba2880f887ca231d98f6d3c22027e20e')
     version('7.1', sha256='60026c3be581ae9d5c919c861605082fcb9c8205758b3ddfcde2408153ae166e')
     version('7.0', sha256='4faf16c5fae3e14d3c1b6f30e25c6e093dcf6a3dbf021235f3161ac2a527f682')

--- a/var/spack/repos/builtin/packages/py-networkit/package.py
+++ b/var/spack/repos/builtin/packages/py-networkit/package.py
@@ -22,6 +22,7 @@ class PyNetworkit(PythonPackage):
 
     maintainers = ['fabratu']
 
+    version('8.1', sha256='5ff9e61496259280df4f913b1e37f51ca6f94974c4b9f623851f4d518f5ce0d5')
     version('8.0', sha256='36c30e894e835bf93f0aa0fb0b526758234e74318150820911e024ffe5ec1fd2')
     version('7.1', sha256='8609dc7a574a8a82d8880b8b1e3dfdd9c59ad67cd02135628e675c482fe98a96')
     version('7.0', sha256='eea4b5e565d6990b674e1c7f4d598be9377d57b61d0d82883ecc39edabaf3631')
@@ -29,6 +30,7 @@ class PyNetworkit(PythonPackage):
 
     # Required dependencies
     depends_on('cmake', type='build')
+    depends_on('libnetworkit@8.1', type=('build', 'link'), when='@8.1')
     depends_on('libnetworkit@8.0', type=('build', 'link'), when='@8.0')
     depends_on('libnetworkit@7.1', type=('build', 'link'), when='@7.1')
     depends_on('libnetworkit@7.0', type=('build', 'link'), when='@7.0')


### PR DESCRIPTION
This updates both packages `libnetworkit` and `py-networkit` to 8.1.