### PR TITLE
gearshifft: Add version 0.4.0, remove faulty version 0.2.0-lw

### DIFF
--- a/var/spack/repos/builtin/packages/gearshifft/gearshifft-v0.4.0-cmake-variable-name.patch
+++ b/var/spack/repos/builtin/packages/gearshifft/gearshifft-v0.4.0-cmake-variable-name.patch
@@ -1,18 +1,22 @@
-diff --git spack-src/cmake/init_build_type.cmake.org spack-src/cmake/init_build_type.cmake
-index c826f5d..4239dd0 100644
---- spack-src/cmake/init_build_type.cmake.org
-+++ spack-src/cmake/init_build_type.cmake
-@@ -1,6 +1,6 @@
+diff --git a/cmake/init_build_type.cmake b/cmake/init_build_type.cmake
+index c826f5d..131c77b 100644
+--- a/cmake/init_build_type.cmake
++++ b/cmake/init_build_type.cmake
+@@ -1,9 +1,9 @@
  # Default build type to use if none was specified
 -if(NOT DEFINED CMAKE_DEFAULT_BUILD_TYPE)
 -  set(CMAKE_DEFAULT_BUILD_TYPE "Release")
 +if(NOT DEFINED GEARSHIFFT_DEFAULT_BUILD_TYPE)
 +  set(GEARSHIFFT_DEFAULT_BUILD_TYPE "Release")
  endif()
-
- set(CMAKE_BUILD_TYPE ${CMAKE_DEFAULT_BUILD_TYPE} CACHE STRING "Build type")
+ 
+-set(CMAKE_BUILD_TYPE ${CMAKE_DEFAULT_BUILD_TYPE} CACHE STRING "Build type")
++set(CMAKE_BUILD_TYPE ${GEARSHIFFT_DEFAULT_BUILD_TYPE} CACHE STRING "Build type")
+ # Set the possible values of build type for cmake-gui
+ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+   "Debug"
 @@ -14,6 +14,6 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-
+ 
  # sets default build type if none was specified
  if(NOT CMAKE_BUILD_TYPE)
 -  message(STATUS "No build type selected, default to ${CMAKE_DEFAULT_BUILD_TYPE}")

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -51,23 +51,14 @@ class Gearshifft(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DGEARSHIFFT_FLOAT16_SUPPORT:BOOL=OFF',
-            '-DGEARSHIFFT_BACKEND_HCFFT:BOOL=OFF',
+            self.define('GEARSHIFFT_FLOAT16_SUPPORT', False),
+            self.define('GEARSHIFFT_BACKEND_HCFFT', False),
+            self.define_from_variant('GEARSHIFFT_BACKEND_FFTW', 'fftw'),
+            self.define('GEARSHIFFT_BACKEND_FFTW_PTHREADS', '~openmp' in spec),
+            self.define_from_variant('GEARSHIFFT_BACKEND_FFTW_OPENMP', 'openmp'),
+            self.define_from_variant('GEARSHIFFT_BACKEND_CUFFT', 'cufft'),
+            self.define_from_variant('GEARSHIFFT_BACKEND_CLFFT', 'clfft'),
+            self.define_from_variant('GEARSHIFFT_BACKEND_FFTWWRAPPERS', 'mkl'),
+            self.define_from_variant('GEARSHIFFT_BACKEND_ROCFFT', 'rocfft')
         ]
-        args.extend([
-            '-DGEARSHIFFT_BACKEND_FFTW:BOOL={0}'.format(
-                'ON' if '+fftw' in spec else 'OFF'),
-            '-DGEARSHIFFT_BACKEND_FFTW_PTHREADS:BOOL={0}'.format(
-                'ON' if '~openmp' in spec else 'OFF'),
-            '-DGEARSHIFFT_BACKEND_FFTW_OPENMP:BOOL={0}'.format(
-                'ON' if '+openmp' in spec else 'OFF'),
-            '-DGEARSHIFFT_BACKEND_CUFFT:BOOL={0}'.format(
-                'ON' if '+cufft' in spec else 'OFF'),
-            '-DGEARSHIFFT_BACKEND_CLFFT:BOOL={0}'.format(
-                'ON' if '+clfft' in spec else 'OFF'),
-            '-DGEARSHIFFT_BACKEND_FFTWWRAPPERS:BOOL={0}'.format(
-                'ON' if '+mkl' in spec else 'OFF'),
-            '-DGEARSHIFFT_BACKEND_ROCFFT:BOOL={0}'.format(
-                'ON' if '+rocfft' in spec else 'OFF')
-        ])
         return args

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -28,32 +28,43 @@ class Gearshifft(CMakePackage):
             description='use OpenMP parallel fftw libraries')
     # variant('hcfft', default=True,
     #         description='Not implemented yet')
+    variant('mkl', default=True,
+            description='Compile gearshifft_fftwwrappers')
+    variant('rocfft', default=True,
+            description='Compile gearshifft_rocfft')
 
     # depends_on C++14 compiler, e.g. GCC 5.0+
     depends_on('cmake@2.8.0:', type='build')
-    depends_on('boost@1.56.0:')
+    depends_on('boost@1.59.0:')
     depends_on('cuda@8.0:', when='+cufft')
     depends_on('opencl@1.2:', when='+clfft')
     depends_on('clfft@2.12.0:', when='+clfft')
     depends_on('fftw@3.3.4:~mpi~openmp', when='+fftw~openmp')
     depends_on('fftw@3.3.4:~mpi+openmp', when='+fftw+openmp')
+    depends_on('intel-mkl threads=openmp', when='+mkl')
+    depends_on('rocfft', when='+rocfft')
 
     def cmake_args(self):
         spec = self.spec
 
         args = [
-            '-DGEARSHIFFT_HCFFT:BOOL=OFF',
-            '-DGEARSHIFFT_FFTW_PTHREADS:BOOL=ON',
-            '-DGEARSHIFFT_CLFFT:BOOL=OFF'
+            '-DGEARSHIFFT_FLOAT16_SUPPORT:BOOL=OFF',
+            '-DGEARSHIFFT_BACKEND_HCFFT:BOOL=OFF',
         ]
         args.extend([
-            '-DGEARSHIFFT_FFTW:BOOL={0}'.format(
+            '-DGEARSHIFFT_BACKEND_FFTW:BOOL={0}'.format(
                 'ON' if '+fftw' in spec else 'OFF'),
-            '-DGEARSHIFFT_FFTW_OPENMP:BOOL={0}'.format(
+            '-DGEARSHIFFT_BACKEND_FFTW_PTHREADS:BOOL={0}'.format(
+                'ON' if '~openmp' in spec else 'OFF'),
+            '-DGEARSHIFFT_BACKEND_FFTW_OPENMP:BOOL={0}'.format(
                 'ON' if '+openmp' in spec else 'OFF'),
-            '-DGEARSHIFFT_CUFFT:BOOL={0}'.format(
+            '-DGEARSHIFFT_BACKEND_CUFFT:BOOL={0}'.format(
                 'ON' if '+cufft' in spec else 'OFF'),
-            '-DGEARSHIFFT_CLFFT:BOOL={0}'.format(
-                'ON' if '+clfft' in spec else 'OFF')
+            '-DGEARSHIFFT_BACKEND_CLFFT:BOOL={0}'.format(
+                'ON' if '+clfft' in spec else 'OFF'),
+            '-DGEARSHIFFT_BACKEND_FFTWWRAPPERS:BOOL={0}'.format(
+                'ON' if '+mkl' in spec else 'OFF'),
+            '-DGEARSHIFFT_BACKEND_ROCFFT:BOOL={0}'.format(
+                'ON' if '+rocfft' in spec else 'OFF')
         ])
         return args

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -16,6 +16,9 @@ class Gearshifft(CMakePackage):
 
     version('0.4.0', sha256='15b9e4bfa1d9b4fe4ae316f289c67b7be0774cdada5bd7310df4d0e026d9d227')
 
+    # gearshifft used the variable name `CMAKE_DEFAULT_BUILD_TYPE` which was
+    # later introduced by CMake leading to an error in newer CMake versions.
+    # This patch renames the variable to `GEARSHIFFT_DEFAULT_BUILD_TYPE`.
     patch('gearshifft-v0.4.0-cmake-variable-name.patch', when='@0.4.0')
 
     variant('cufft', default=True,


### PR DESCRIPTION
- Change maintainer
- Change gearshifft version
- Add patch to rename CMake variable that already exists in newer CMake
  versions
- Take renamed CMake variables for different backends into account
  (`-DGEARSHIFFT_BACKEND_*`)
- Only use GEARSHIFFT_BACKEND_FFTW_PTHREADS if ~openmp
- Explicitly disable float16 support
- Use correct minimum required Boost version
- Add variants for Intel MKL and ROCm rocfft

CC: @psteinb @ax3l @haampie @h-denpo @tldahlgren 

My follow-up to #21437. Installing `gearshifft~cufft~clfft~rocfft~mkl+openmp` and `gearshifft~cufft~clfft~rocfft~mkl~openmp` seems to work fine. The other variants were not tested, yet.