### PR TITLE
Refactor oneapi packages to align with standalone installers

### DIFF
--- a/lib/spack/docs/build_systems.rst
+++ b/lib/spack/docs/build_systems.rst
@@ -59,6 +59,7 @@ on these ideas for each distinct build system that Spack supports:
 
    build_systems/bundlepackage
    build_systems/cudapackage
+   build_systems/inteloneapipackage
    build_systems/intelpackage
    build_systems/rocmpackage
    build_systems/custompackage

--- a/lib/spack/docs/build_systems/inteloneapipackage.rst
+++ b/lib/spack/docs/build_systems/inteloneapipackage.rst
@@ -1,0 +1,237 @@
+.. Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+   Spack Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. _inteloneapipackage:
+
+
+====================
+ IntelOneapiPackage
+====================
+
+
+.. contents::
+
+
+oneAPI packages in Spack
+========================
+
+Spack can install and use the Intel oneAPI products. You may either
+use spack to install the oneAPI tools or use the `Intel
+installers`_. After installation, you may use the tools directly, or
+use Spack to build packages with the tools.
+
+The Spack Python class ``IntelOneapiPackage`` is a base class that is
+used by ``IntelOneapiCompilers``, ``IntelOneapiMkl``,
+``IntelOneapiTbb`` and other classes to implement the oneAPI
+packages. See the `Spack package list`_ for the full list of available
+oneAPI packages.
+
+
+Unrelated packages
+------------------
+
+The following packages use a different installer and are not discussed
+here:
+
+* ``intel-gpu-tools`` -- Test suite and low-level tools for the Linux `Direct
+  Rendering Manager <https://en.wikipedia.org/wiki/Direct_Rendering_Manager>`_
+* ``intel-mkl-dnn`` -- Math Kernel Library for Deep Neural Networks (``CMakePackage``)
+* ``intel-xed`` -- X86 machine instructions encoder/decoder
+* ``intel-tbb`` -- Standalone version of Intel Threading Building Blocks. Note that
+  a TBB runtime version is included with ``intel-mkl``, and development
+  versions are provided by the packages ``intel-parallel-studio`` (all
+  editions) and its ``intel`` subset.
+
+Example
+=======
+
+We start with a simple example that will be sufficient for most
+users. Install the oneAPI compilers::
+
+  spack install intel-oneapi-compilers
+
+Add the oneAPI compilers to the set of compilers that Spack can use::
+
+  spack compiler add `spack location -i intel-oneapi-compilers`/latest/linux/bin/intel64
+  spack compiler add `spack location -i intel-oneapi-compilers`/latest/linux/bin
+
+This adds the compilers to your ``compilers.yaml``. Verify that the
+compilers are available::
+
+  spack compiler list
+
+The ``intel-oneapi-compilers`` package includes 2 families of
+compilers:
+
+* ``intel``: ``icc``, ``icpc``, ``ifort``. Intel's *classic*
+  compilers.
+* ``oneapi``: ``icx``, ``icpx``, ``ifx``. Intel's new generation of
+  compilers based on LLVM.
+
+To build the ``patchelf`` Spack package with ``icc``, do::
+
+  spack install patchelf%intel
+
+To build with with ``icx``, do ::
+
+  spack install patchelf%oneapi
+
+In addition to compilers, oneAPI contains many libraries. The ``hdf5``
+package works with any compatible MPI implementation. To build
+``hdf5`` with Intel oneAPI MPI do::
+
+  spack install hdf5 +mpi ^intel-oneapi-mpi
+
+Using an Externally Installed oneAPI
+====================================
+
+Spack can also use oneAPI tools that are manually installed with
+`Intel Installers`_.  The procedures for configuring Spack to use
+external compilers and libraries are different.
+
+Compilers
+---------
+
+To use the compilers, add some information about the installation to
+``compilers.yaml``. For most users, it is sufficient to do::
+
+  spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin/intel64
+  spack compiler add /opt/intel/oneapi/compiler/latest/linux/bin
+
+Adapt the paths above if you did not install the tools in the default
+location. After adding the compilers, using them in Spack will be
+exactly the same as if you had installed the
+``intel-oneapi-compilers`` package.  Another option is to manually add
+the configuration to ``compilers.yaml`` as described in :ref:`Compiler
+configuration <compiler-config>`.
+
+
+Libraries
+---------
+
+Configure external library packages by editing ``packages.yaml``,
+following the Spack documentation under :ref:`External Packages
+<sec-external-packages>`.
+
+Similar to ``compilers.yaml``, the ``packages.yaml`` files define a
+package external to Spack in terms of a Spack spec and resolve each
+such spec via veither the ``paths`` or ``modules`` tokens to a
+specific pre-installed package version on the system.  Since Intel
+tools generally need environment variables to interoperate, which
+cannot be conveyed in a mere ``paths`` specification, the ``modules``
+token will be more sensible to use. It resolves the Spack-side spec to
+a modulefile generated and managed outside of Spack's purview, which
+Spack will load internally and transiently when the corresponding spec
+is called upon to compile client packages.
+
+Unlike compilers, Spack does not offer a command to generate an
+entirely new ``packages.yaml`` entry.  You must create new entries
+yourself in a text editor, though the command ``spack config
+[--scope=...] edit packages`` can help with selecting the proper file.
+See section :ref:`Configuration Scopes <configuration-scopes>` for an
+explanation about the different files and section :ref:`Build
+customization <build-settings>` for specifics and examples for
+``packages.yaml`` files.
+
+
+Using oneAPI Tools Installed by Spack
+=====================================
+
+Spack can be a convenient way to install and configure compilers and
+libaries, even if you do not intend to build a Spack package. If you
+want to build a Makefile project using Spack-installed oneAPI compilers,
+then use spack to configure your environment::
+
+  spack load intel-oneapi-compilers
+
+And then you can build with::
+
+  CXX=icpx make
+
+You can also use Spack-installed libraries. For example::
+
+  spack load intel-oneapi-mkl
+
+Will update your environment CPATH, LIBRARY_PATH, and other
+environment variables for building an application with MKL.
+
+
+Selecting libraries to satisfy virtual packages
+===============================================
+
+Intel packages, whether integrated into Spack as external packages or
+installed within Spack, can be called upon to satisfy the requirement
+of a client package for a library that is available from different
+providers.  The relevant virtual packages for Intel are ``blas``,
+``lapack``, ``scalapack``, and ``mpi``.
+
+
+
+Tips for configuring client packages to use MKL
+===============================================
+
+* To use MKL as provider for BLAS, LAPACK, or ScaLAPACK:
+
+  The packages that provide ``mkl`` also provide the narrower
+  virtual ``blas``, ``lapack``, and ``scalapack`` packages.
+  See the relevant :ref:`Packaging Guide section <blas_lapack_scalapack>`
+  for an introduction.
+  To portably use these virtual packages, construct preprocessor and linker
+  option strings in your package configuration code using the package functions
+  ``.headers`` and ``.libs`` in conjunction with utility functions from the
+  following classes:
+
+  * :py:class:`llnl.util.filesystem.FileList`,
+  * :py:class:`llnl.util.filesystem.HeaderList`,
+  * :py:class:`llnl.util.filesystem.LibraryList`.
+
+  .. tip::
+     *Do not* use constructs like ``.prefix.include`` or ``.prefix.lib``, with
+     Intel or any other implementation of ``blas``, ``lapack``, and
+     ``scalapack``.
+
+  For example, for an
+  :ref:`AutotoolsPackage <autotoolspackage>`
+  use ``.libs.ld_flags`` to transform the library file list into linker options
+  passed to ``./configure``:
+
+  .. code-block:: python
+
+      def configure_args(self):
+          args = []
+          ...
+          args.append('--with-blas=%s' % self.spec['blas'].libs.ld_flags)
+          args.append('--with-lapack=%s' % self.spec['lapack'].libs.ld_flags)
+          ...
+
+  .. tip::
+     Even though ``.ld_flags`` will return a string of multiple words, *do not*
+     use quotes for options like ``--with-blas=...`` because Spack passes them
+     to ``./configure`` without invoking a shell.
+
+  Likewise, in a :ref:`MakefilePackage <makefilepackage>` or similar
+  package that does not use AutoTools you may need to provide include
+  and link options for use on command lines or in environment
+  variables.  For example, to generate an option string of the form
+  ``-I<dir>``, use:
+
+  .. code-block:: python
+
+    self.spec['blas'].headers.include_flags
+
+  and to generate linker options (``-L<dir> -llibname ...``), use the
+  same as above,
+
+  .. code-block:: python
+
+    self.spec['blas'].libs.ld_flags
+
+  See :ref:`MakefilePackage <makefilepackage>` and more generally the
+  :ref:`Packaging Guide <blas_lapack_scalapack>` for background and
+  further examples.
+
+
+.. _`Intel installers`: https://software.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-linux/top.html
+.. _`Spack package list`: https://spack.readthedocs.io/en/latest/package_list.html#intel-oneapi-ccl

--- a/lib/spack/docs/build_systems/inteloneapipackage.rst
+++ b/lib/spack/docs/build_systems/inteloneapipackage.rst
@@ -48,8 +48,8 @@ users. Install the oneAPI compilers::
 
 Add the oneAPI compilers to the set of compilers that Spack can use::
 
-  spack compiler add `spack location -i intel-oneapi-compilers`/latest/linux/bin/intel64
-  spack compiler add `spack location -i intel-oneapi-compilers`/latest/linux/bin
+  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/linux/bin/intel64
+  spack compiler add `spack location -i intel-oneapi-compilers`/compiler/latest/linux/bin
 
 This adds the compilers to your ``compilers.yaml``. Verify that the
 compilers are available::

--- a/lib/spack/docs/build_systems/inteloneapipackage.rst
+++ b/lib/spack/docs/build_systems/inteloneapipackage.rst
@@ -25,24 +25,18 @@ use Spack to build packages with the tools.
 The Spack Python class ``IntelOneapiPackage`` is a base class that is
 used by ``IntelOneapiCompilers``, ``IntelOneapiMkl``,
 ``IntelOneapiTbb`` and other classes to implement the oneAPI
-packages. See the `Spack package list`_ for the full list of available
-oneAPI packages.
+packages. See the :ref:<package-list> for the full list of available
+oneAPI packages or use::
 
+  spack list -d oneAPI
 
-Unrelated packages
-------------------
+For more information on a specific package, do::
 
-The following packages use a different installer and are not discussed
-here:
+  spack info <package-name>
 
-* ``intel-gpu-tools`` -- Test suite and low-level tools for the Linux `Direct
-  Rendering Manager <https://en.wikipedia.org/wiki/Direct_Rendering_Manager>`_
-* ``intel-mkl-dnn`` -- Math Kernel Library for Deep Neural Networks (``CMakePackage``)
-* ``intel-xed`` -- X86 machine instructions encoder/decoder
-* ``intel-tbb`` -- Standalone version of Intel Threading Building Blocks. Note that
-  a TBB runtime version is included with ``intel-mkl``, and development
-  versions are provided by the packages ``intel-parallel-studio`` (all
-  editions) and its ``intel`` subset.
+Intel no longer releases new versions of Parallel Studio, which can be
+used in Spack via the :ref:<intelpackage>. All of its components can
+now be found in oneAPI. 
 
 Example
 =======
@@ -108,34 +102,6 @@ the configuration to ``compilers.yaml`` as described in :ref:`Compiler
 configuration <compiler-config>`.
 
 
-Libraries
----------
-
-Configure external library packages by editing ``packages.yaml``,
-following the Spack documentation under :ref:`External Packages
-<sec-external-packages>`.
-
-Similar to ``compilers.yaml``, the ``packages.yaml`` files define a
-package external to Spack in terms of a Spack spec and resolve each
-such spec via veither the ``paths`` or ``modules`` tokens to a
-specific pre-installed package version on the system.  Since Intel
-tools generally need environment variables to interoperate, which
-cannot be conveyed in a mere ``paths`` specification, the ``modules``
-token will be more sensible to use. It resolves the Spack-side spec to
-a modulefile generated and managed outside of Spack's purview, which
-Spack will load internally and transiently when the corresponding spec
-is called upon to compile client packages.
-
-Unlike compilers, Spack does not offer a command to generate an
-entirely new ``packages.yaml`` entry.  You must create new entries
-yourself in a text editor, though the command ``spack config
-[--scope=...] edit packages`` can help with selecting the proper file.
-See section :ref:`Configuration Scopes <configuration-scopes>` for an
-explanation about the different files and section :ref:`Build
-customization <build-settings>` for specifics and examples for
-``packages.yaml`` files.
-
-
 Using oneAPI Tools Installed by Spack
 =====================================
 
@@ -157,81 +123,15 @@ You can also use Spack-installed libraries. For example::
 Will update your environment CPATH, LIBRARY_PATH, and other
 environment variables for building an application with MKL.
 
+More information
+================
 
-Selecting libraries to satisfy virtual packages
-===============================================
-
-Intel packages, whether integrated into Spack as external packages or
-installed within Spack, can be called upon to satisfy the requirement
-of a client package for a library that is available from different
-providers.  The relevant virtual packages for Intel are ``blas``,
-``lapack``, ``scalapack``, and ``mpi``.
-
-
-
-Tips for configuring client packages to use MKL
-===============================================
-
-* To use MKL as provider for BLAS, LAPACK, or ScaLAPACK:
-
-  The packages that provide ``mkl`` also provide the narrower
-  virtual ``blas``, ``lapack``, and ``scalapack`` packages.
-  See the relevant :ref:`Packaging Guide section <blas_lapack_scalapack>`
-  for an introduction.
-  To portably use these virtual packages, construct preprocessor and linker
-  option strings in your package configuration code using the package functions
-  ``.headers`` and ``.libs`` in conjunction with utility functions from the
-  following classes:
-
-  * :py:class:`llnl.util.filesystem.FileList`,
-  * :py:class:`llnl.util.filesystem.HeaderList`,
-  * :py:class:`llnl.util.filesystem.LibraryList`.
-
-  .. tip::
-     *Do not* use constructs like ``.prefix.include`` or ``.prefix.lib``, with
-     Intel or any other implementation of ``blas``, ``lapack``, and
-     ``scalapack``.
-
-  For example, for an
-  :ref:`AutotoolsPackage <autotoolspackage>`
-  use ``.libs.ld_flags`` to transform the library file list into linker options
-  passed to ``./configure``:
-
-  .. code-block:: python
-
-      def configure_args(self):
-          args = []
-          ...
-          args.append('--with-blas=%s' % self.spec['blas'].libs.ld_flags)
-          args.append('--with-lapack=%s' % self.spec['lapack'].libs.ld_flags)
-          ...
-
-  .. tip::
-     Even though ``.ld_flags`` will return a string of multiple words, *do not*
-     use quotes for options like ``--with-blas=...`` because Spack passes them
-     to ``./configure`` without invoking a shell.
-
-  Likewise, in a :ref:`MakefilePackage <makefilepackage>` or similar
-  package that does not use AutoTools you may need to provide include
-  and link options for use on command lines or in environment
-  variables.  For example, to generate an option string of the form
-  ``-I<dir>``, use:
-
-  .. code-block:: python
-
-    self.spec['blas'].headers.include_flags
-
-  and to generate linker options (``-L<dir> -llibname ...``), use the
-  same as above,
-
-  .. code-block:: python
-
-    self.spec['blas'].libs.ld_flags
-
-  See :ref:`MakefilePackage <makefilepackage>` and more generally the
-  :ref:`Packaging Guide <blas_lapack_scalapack>` for background and
-  further examples.
+This section describes basic use of oneAPI, especially if it has
+changed compared to Parallel Studio. See :ref:<intelpackage> for more
+information on :ref:<intel-virtual-packages>,
+:ref:<intel-unrelated-packages>,
+:ref:<intel-integrating-external-libraries>, and
+:ref:<using-mkl-tips>.
 
 
 .. _`Intel installers`: https://software.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-linux/top.html
-.. _`Spack package list`: https://spack.readthedocs.io/en/latest/package_list.html#intel-oneapi-ccl

--- a/lib/spack/docs/build_systems/intelpackage.rst
+++ b/lib/spack/docs/build_systems/intelpackage.rst
@@ -137,6 +137,7 @@ If you need to save disk space or installation time, you could install the
 ``intel`` compilers-only subset (0.6 GB) and just the library packages you
 need, for example ``intel-mpi`` (0.5 GB) and ``intel-mkl`` (2.5 GB).
 
+.. _intel-unrelated-packages:
 
 """"""""""""""""""""
 Unrelated packages
@@ -357,6 +358,8 @@ affected by an advanced third method:
 
 Next, visit section `Selecting Intel Compilers`_ to learn how to tell
 Spack to use the newly configured compilers.
+
+.. _intel-integrating-external-libraries:
 
 """"""""""""""""""""""""""""""""""
 Integrating external libraries
@@ -834,6 +837,7 @@ for example:
       compiler: [ intel@18, intel@17, gcc@4.4.7, gcc@4.9.3, gcc@7.3.0, ]
 
 
+.. _intel-virtual-packages:
 
 """"""""""""""""""""""""""""""""""""""""""""""""
 Selecting libraries to satisfy virtual packages
@@ -907,6 +911,7 @@ With the proper installation as detailed above, no special steps should be
 required when a client package specifically (and thus deliberately) requests an
 Intel package as dependency, this being one of the target use cases for Spack.
 
+.. _using-mkl-tips:
 
 """""""""""""""""""""""""""""""""""""""""""""""
 Tips for configuring client packages to use MKL

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -24,7 +24,15 @@ class IntelOneApiPackage(Package):
 
     phases = ['install']
 
+    # oneAPI license does not allow mirroring outside of the
+    # organization (e.g. University/Company).
+    redistribute_source = False
+    
     def component_info(self, dir_name):
+        """Define the expected installation directory. After the install script runs,
+           IntelOneApiPackage will look for this directory to make sure the install
+           was successful.
+        """
         self._dir_name = dir_name
 
     def install(self, spec, prefix, installer_path=None):

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -3,11 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from sys import platform
 
 from spack import *
-
-releases = {
-    '2021.1.1': {'irc_id': '17391', 'build': '54'}}
 
 
 class IntelOneapiCcl(IntelOneApiLibraryPackage):
@@ -17,11 +15,14 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/oneccl.html'
 
-    version('2021.1.1', sha256='de732df57a03763a286106c8b885fd60e83d17906936a8897a384b874e773f49', expand=False)
+    depends_on('intel-oneapi-mpi')
+
+    if platform == 'linux':
+        version('2021.1.1',
+                sha256='de732df57a03763a286106c8b885fd60e83d17906936a8897a384b874e773f49',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh',
+                expand=False)
 
     def __init__(self, spec):
-        self.component_info(dir_name='ccl',
-                            components='intel.oneapi.lin.ccl.devel',
-                            releases=releases,
-                            url_name='oneapi_ccl')
+        self.component_info(dir_name='ccl',)
         super(IntelOneapiCcl, self).__init__(spec)

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -23,6 +23,6 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh',
                 expand=False)
 
-    def __init__(self, spec):
-        self.component_info(dir_name='ccl',)
-        super(IntelOneapiCcl, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'ccl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -23,6 +23,8 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh',
                 expand=False)
 
+    provides('oneccl')
+
     @property
     def component_dir(self):
         return 'ccl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -23,8 +23,6 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh',
                 expand=False)
 
-    provides('oneccl')
-
     @property
     def component_dir(self):
         return 'ccl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -37,16 +37,16 @@ class IntelOneapiCompilers(IntelOneApiPackage):
         super(IntelOneapiCompilers, self).__init__(spec)
 
     def _join_prefix(self, p):
-        return path.join(self.prefix, 'compiler/latest/linux', p)
+        return path.join(self.prefix, 'compiler', 'latest', 'linux', p)
 
     def _ld_library_path(self):
         dirs = ['lib',
-                'lib/x64',
-                'lib/emu',
-                'lib/oclfpga/host/linux64/lib',
-                'lib/oclfpga/linux64/lib',
-                'compiler/lib/intel64_lin',
-                'compiler/lib']
+                path.join('lib', 'x64'),
+                path.join('lib', 'emu'),
+                path.join('lib', 'oclfpga', 'host', 'linux64', 'lib'),
+                path.join('lib', 'oclfpga', 'linux64', 'lib'),
+                path.join('compiler', 'lib', 'intel64_lin'),
+                path.join('compiler', 'lib')]
         for dir in dirs:
             yield self._join_prefix(dir)
 
@@ -60,22 +60,21 @@ class IntelOneapiCompilers(IntelOneApiPackage):
         super(IntelOneapiCompilers, self).install(
             spec,
             prefix,
-            installer_path=glob.glob('fortran-installer/*')[0])
+            installer_path=glob.glob(path.join('fortran-installer', '*'))[0])
 
         # Some installers have a bug and do not return an error code when failing
-        if not path.isfile(path.join(prefix,
-                                     'compiler/latest/linux/bin/intel64/ifort')):
+        if not path.isfile(path.join(prefix, 'compiler', 'latest', 'linux', 'bin', 'intel64', 'ifort')):
             raise RuntimeError('install failed')
 
         # set rpath so 'spack compiler add' can check version strings
         # without setting LD_LIBRARY_PATH
         rpath = ':'.join(self._ld_library_path())
-        patch_dirs = ['compiler/lib/intel64_lin',
-                      'compiler/lib/intel64',
+        patch_dirs = [path.join('compiler', 'lib', 'intel64_lin'),
+                      path.join('compiler', 'lib', 'intel64'),
                       'bin']
         for pd in patch_dirs:
             patchables = glob.glob(self._join_prefix(path.join(pd, '*')))
-            patchables.append(self._join_prefix('lib/icx-lto.so'))
+            patchables.append(self._join_prefix(path.join('lib', 'icx-lto.so')))
             for file in patchables:
                 # Try to patch all files, patchelf will do nothing if
                 # file should not be patched

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -5,40 +5,39 @@
 
 import glob
 import subprocess
+from os import path
+from sys import platform
 
 from spack import *
 
 
-releases = {'2021.1.0':
-            {'irc_id': '17427', 'build': '2684'}}
-
-
 class IntelOneapiCompilers(IntelOneApiPackage):
-    """Intel oneAPI compilers.
+    """Intel OneAPI compilers
 
-    Contains icc, icpc, icx, icpx, dpcpp, ifort, ifx.
+    Provides Classic and Beta compilers for: Fortran, C, C++"""
 
-    """
-
-    maintainers = ['rscohn2']
-
-    homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html'
-
-    version('2021.1.0', sha256='666b1002de3eab4b6f3770c42bcf708743ac74efeba4c05b0834095ef27a11b9', expand=False)
+    homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
 
     depends_on('patchelf', type='build')
 
+    if platform == 'linux':
+        version('2021.1.2',
+                sha256='68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh',
+                expand=False)
+        resource(name='fortran-installer',
+                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh',
+                 sha256='29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829',
+                 expand=False,
+                 placement='fortran-installer',
+                 when='@2021.1.2')
+
     def __init__(self, spec):
-        self.component_info(
-            dir_name='compiler',
-            components=('intel.oneapi.lin.dpcpp-cpp-compiler-pro'
-                        ':intel.oneapi.lin.ifort-compiler'),
-            releases=releases,
-            url_name='HPCKit')
+        self.component_info(dir_name='compiler')
         super(IntelOneapiCompilers, self).__init__(spec)
 
-    def _join_prefix(self, path):
-        return join_path(self.prefix, 'compiler', 'latest', 'linux', path)
+    def _join_prefix(self, p):
+        return path.join(self.prefix, 'compiler/latest/linux', p)
 
     def _ld_library_path(self):
         dirs = ['lib',
@@ -52,35 +51,32 @@ class IntelOneapiCompilers(IntelOneApiPackage):
             yield self._join_prefix(dir)
 
     def install(self, spec, prefix):
-        # For quick turnaround debugging, comment out line below and
-        # use the copy instead
+        # install cpp
+        # Copy instead of install to speed up debugging
+        # subprocess.run(f'cp -r /opt/intel/oneapi/compiler {prefix}', shell=True)
         super(IntelOneapiCompilers, self).install(spec, prefix)
-        # Copy installed compiler instead of running the installer
-        # from shutil import copytree
-        # copytree('/opt/intel/oneapi/compiler', join_path(prefix, 'compiler'),
-        #         symlinks=True)
 
+        # install fortran
+        super(IntelOneapiCompilers, self).install(
+            spec,
+            prefix,
+            installer_path=glob.glob('fortran-installer/*')[0])
+
+        # Some installers have a bug and do not return an error code when failing
+        if not path.isfile(path.join(prefix,
+                                     'compiler/latest/linux/bin/intel64/ifort')):
+            raise RuntimeError('install failed')
+
+        # set rpath so 'spack compiler add' can check version strings
+        # without setting LD_LIBRARY_PATH
         rpath = ':'.join(self._ld_library_path())
         patch_dirs = ['compiler/lib/intel64_lin',
                       'compiler/lib/intel64',
                       'bin']
         for pd in patch_dirs:
-            for file in glob.glob(self._join_prefix(join_path(pd, '*'))):
+            patchables = glob.glob(self._join_prefix(path.join(pd, '*')))
+            patchables.append(self._join_prefix('lib/icx-lto.so'))
+            for file in patchables:
                 # Try to patch all files, patchelf will do nothing if
                 # file should not be patched
                 subprocess.call(['patchelf', '--set-rpath', rpath, file])
-
-    def setup_run_environment(self, env):
-        env.prepend_path('PATH', self._join_prefix('bin'))
-        env.prepend_path('CPATH', self._join_prefix('include'))
-        env.prepend_path('LIBRARY_PATH', self._join_prefix('lib'))
-        for dir in self._ld_library_path():
-            env.prepend_path('LD_LIBRARY_PATH', dir)
-        env.set('CC', self._join_prefix('bin/icx'))
-        env.set('CXX', self._join_prefix('bin/icpx'))
-        env.set('FC', self._join_prefix('bin/ifx'))
-        # Set these so that MPI wrappers will pick up these compilers
-        # when this module is loaded.
-        env.set('I_MPI_CC', 'icx')
-        env.set('I_MPI_CXX', 'icpx')
-        env.set('I_MPI_FC', 'ifx')

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -32,9 +32,9 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                  placement='fortran-installer',
                  when='@2021.1.2')
 
-    def __init__(self, spec):
-        self.component_info(dir_name='compiler')
-        super(IntelOneapiCompilers, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'compiler'
 
     def _join_prefix(self, p):
         return path.join(self.prefix, 'compiler', 'latest', 'linux', p)
@@ -63,7 +63,8 @@ class IntelOneapiCompilers(IntelOneApiPackage):
             installer_path=glob.glob(path.join('fortran-installer', '*'))[0])
 
         # Some installers have a bug and do not return an error code when failing
-        if not path.isfile(path.join(prefix, 'compiler', 'latest', 'linux', 'bin', 'intel64', 'ifort')):
+        if not path.isfile(path.join(prefix, 'compiler', 'latest', 'linux',
+                                     'bin', 'intel64', 'ifort')):
             raise RuntimeError('install failed')
 
         # set rpath so 'spack compiler add' can check version strings

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -24,6 +24,9 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
 
     depends_on('intel-oneapi-tbb')
 
+    provides('daal')
+    provides('onedal')
+
     @property
     def component_dir(self):
         return 'dal'

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -25,7 +25,6 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     depends_on('intel-oneapi-tbb')
 
     provides('daal')
-    provides('onedal')
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -24,6 +24,6 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
 
     depends_on('intel-oneapi-tbb')
 
-    def __init__(self, spec):
-        self.component_info(dir_name='dal',)
-        super(IntelOneapiDal, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'dal'

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
+from sys import platform
 
-releases = {
-    '2021.1.1': {'irc_id': '17443', 'build': '79'}}
+from spack import *
 
 
 class IntelOneapiDal(IntelOneApiLibraryPackage):
@@ -17,11 +16,14 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onedal.html'
 
-    version('2021.1.1', sha256='6e0e24bba462e80f0fba5a46e95cf0cca6cf17948a7753f8e396ddedd637544e', expand=False)
+    if platform == 'linux':
+        version('2021.1.1',
+                sha256='6e0e24bba462e80f0fba5a46e95cf0cca6cf17948a7753f8e396ddedd637544e',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17443/l_daal_oneapi_p_2021.1.1.79_offline.sh',
+                expand=False)
+
+    depends_on('intel-oneapi-tbb')
 
     def __init__(self, spec):
-        self.component_info(dir_name='dal',
-                            components='intel.oneapi.lin.dal.devel',
-                            releases=releases,
-                            url_name='daal_oneapi')
+        self.component_info(dir_name='dal',)
         super(IntelOneapiDal, self).__init__(spec)

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
+from sys import platform
 
-releases = {
-    '2021.1.1': {'irc_id': '17385', 'build': '55'}}
+from spack import *
 
 
 class IntelOneapiDnn(IntelOneApiLibraryPackage):
@@ -17,11 +16,14 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onednn.html'
 
-    version('2021.1.1', sha256='24002c57bb8931a74057a471a5859d275516c331fd8420bee4cae90989e77dc3', expand=False)
+    if platform == 'linux':
+        version('2021.1.1',
+                sha256='24002c57bb8931a74057a471a5859d275516c331fd8420bee4cae90989e77dc3',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17385/l_onednn_p_2021.1.1.55_offline.sh',
+                expand=False)
+
+    depends_on('intel-oneapi-tbb')
 
     def __init__(self, spec):
-        self.component_info(dir_name='dnn',
-                            components='intel.oneapi.lin.dnnl.devel',
-                            releases=releases,
-                            url_name='onednn')
+        self.component_info(dir_name='dnnl')
         super(IntelOneapiDnn, self).__init__(spec)

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -24,8 +24,6 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
 
     depends_on('intel-oneapi-tbb')
 
-    provides('onednn')
-
     @property
     def component_dir(self):
         return 'dnnl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -24,6 +24,6 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
 
     depends_on('intel-oneapi-tbb')
 
-    def __init__(self, spec):
-        self.component_info(dir_name='dnnl')
-        super(IntelOneapiDnn, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'dnnl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -24,6 +24,8 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
 
     depends_on('intel-oneapi-tbb')
 
+    provides('onednn')
+
     @property
     def component_dir(self):
         return 'dnnl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -3,11 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from sys import platform
 
 from spack import *
-
-releases = {
-    '2021.1.1': {'irc_id': '17436', 'build': '47'}}
 
 
 class IntelOneapiIpp(IntelOneApiLibraryPackage):
@@ -17,13 +15,16 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
-    version('2021.1.1', sha256='2656a3a7f1f9f1438cbdf98fd472a213c452754ef9476dd65190a7d46618ba86', expand=False)
+    if platform == 'linux':
+        version('2021.1.1',
+                sha256='2656a3a7f1f9f1438cbdf98fd472a213c452754ef9476dd65190a7d46618ba86',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17436/l_ipp_oneapi_p_2021.1.1.47_offline.sh',
+                expand=False)
+
+    depends_on('intel-oneapi-tbb')
 
     provides('ipp')
 
     def __init__(self, spec):
-        self.component_info(dir_name='ipp',
-                            components='intel.oneapi.lin.ipp.devel',
-                            releases=releases,
-                            url_name='ipp_oneapi')
+        self.component_info(dir_name='ipp')
         super(IntelOneapiIpp, self).__init__(spec)

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -25,6 +25,6 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
 
     provides('ipp')
 
-    def __init__(self, spec):
-        self.component_info(dir_name='ipp')
-        super(IntelOneapiIpp, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'ipp'

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -22,6 +22,6 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17415/l_ippcp_oneapi_p_2021.1.1.54_offline.sh',
                 expand=False)
 
-    def __init__(self, spec):
-        self.component_info(dir_name='ippcp')
-        super(IntelOneapiIppcp, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'ippcp'

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
+from sys import platform
 
-releases = {
-    '2021.1.1': {'irc_id': '17415', 'build': '54'}}
+from spack import *
 
 
 class IntelOneapiIppcp(IntelOneApiLibraryPackage):
@@ -17,11 +16,12 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
-    version('2021.1.1', sha256='c0967afae22c7a223ec42542bcc702121064cd3d8f680eff36169c94f964a936', expand=False)
+    if platform == 'linux':
+        version('2021.1.1',
+                sha256='c0967afae22c7a223ec42542bcc702121064cd3d8f680eff36169c94f964a936',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17415/l_ippcp_oneapi_p_2021.1.1.54_offline.sh',
+                expand=False)
 
     def __init__(self, spec):
-        self.component_info(dir_name='ippcp',
-                            components='intel.oneapi.lin.ippcp.devel',
-                            releases=releases,
-                            url_name='ippcp_oneapi')
+        self.component_info(dir_name='ippcp')
         super(IntelOneapiIppcp, self).__init__(spec)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
+from sys import platform
 
-releases = {
-    '2021.1.1': {'irc_id': '17402', 'build': '52'}}
+from spack import *
 
 
 class IntelOneapiMkl(IntelOneApiLibraryPackage):
@@ -17,7 +16,13 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html'
 
-    version('2021.1.1', sha256='818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c', expand=False)
+    if platform == 'linux':
+        version('2021.1.1',
+                sha256='818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17402/l_onemkl_p_2021.1.1.52_offline.sh',
+                expand=False)
+
+    depends_on('intel-oneapi-tbb')
 
     provides('fftw-api@3')
     provides('scalapack')
@@ -26,30 +31,5 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     provides('blas')
 
     def __init__(self, spec):
-        self.component_info(dir_name='mkl',
-                            components='intel.oneapi.lin.mkl.devel',
-                            releases=releases,
-                            url_name='onemkl')
+        self.component_info(dir_name='mkl')
         super(IntelOneapiMkl, self).__init__(spec)
-
-    def _join_prefix(self, path):
-        return join_path(self.prefix, 'mkl', 'latest', path)
-
-    def _ld_library_path(self):
-        dirs = ['lib/intel64']
-        for dir in dirs:
-            yield self._join_prefix(dir)
-
-    def _library_path(self):
-        dirs = ['lib/intel64']
-        for dir in dirs:
-            yield self._join_prefix(dir)
-
-    def setup_run_environment(self, env):
-        env.prepend_path('PATH', self._join_prefix('bin/intel64'))
-        env.prepend_path('CPATH', self._join_prefix('include'))
-        for dir in self._library_path():
-            env.prepend_path('LIBRARY_PATH', dir)
-        for dir in self._ld_library_path():
-            env.prepend_path('LD_LIBRARY_PATH', dir)
-        env.set('MKLROOT', join_path(self.prefix, 'mkl', 'latest'))

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -30,6 +30,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     provides('lapack')
     provides('blas')
 
-    def __init__(self, spec):
-        self.component_info(dir_name='mkl')
-        super(IntelOneapiMkl, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'mkl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -29,6 +29,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     provides('mkl')
     provides('lapack')
     provides('blas')
+    provides('onemkl')
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -29,7 +29,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     provides('mkl')
     provides('lapack')
     provides('blas')
-    provides('onemkl')
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -23,6 +23,7 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
                 expand=False)
 
     provides('tbb')
+    provides('onetbb')
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -24,6 +24,6 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
 
     provides('tbb')
 
-    def __init__(self, spec):
-        self.component_info(dir_name='tbb')
-        super(IntelOneapiTbb, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'tbb'

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-from spack import *
+from sys import platform
 
-releases = {
-    '2021.1.1': {'irc_id': '17378', 'build': '119'}}
+from spack import *
 
 
 class IntelOneapiTbb(IntelOneApiLibraryPackage):
@@ -17,33 +16,14 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onetbb.html'
 
-    version('2021.1.1', sha256='535290e3910a9d906a730b24af212afa231523cf13a668d480bade5f2a01b53b', expand=False)
+    if platform == 'linux':
+        version('2021.1.1',
+                sha256='535290e3910a9d906a730b24af212afa231523cf13a668d480bade5f2a01b53b',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17378/l_tbb_oneapi_p_2021.1.1.119_offline.sh',
+                expand=False)
 
     provides('tbb')
 
     def __init__(self, spec):
-        self.component_info(dir_name='tbb',
-                            components='intel.oneapi.lin.tbb.devel',
-                            releases=releases,
-                            url_name='tbb_oneapi')
+        self.component_info(dir_name='tbb')
         super(IntelOneapiTbb, self).__init__(spec)
-
-    def _join_prefix(self, path):
-        return join_path(self.prefix, 'tbb', 'latest', path)
-
-    def _ld_library_path(self):
-        dirs = ['lib/intel64/gcc4.8']
-        for dir in dirs:
-            yield self._join_prefix(dir)
-
-    def _library_path(self):
-        dirs = ['lib/intel64/gcc4.8']
-        for dir in dirs:
-            yield self._join_prefix(dir)
-
-    def setup_run_environment(self, env):
-        for dir in self._library_path():
-            env.prepend_path('LIBRARY_PATH', dir)
-        for dir in self._ld_library_path():
-            env.prepend_path('LD_LIBRARY_PATH', dir)
-        env.set('TBBROOT', join_path(self.prefix, 'tbb', 'latest'))

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -23,7 +23,6 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
                 expand=False)
 
     provides('tbb')
-    provides('onetbb')
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -3,11 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from sys import platform
 
 from spack import *
-
-releases = {
-    '2021.1.1': {'irc_id': '17418', 'build': '66'}}
 
 
 class IntelOneapiVpl(IntelOneApiLibraryPackage):
@@ -17,11 +15,12 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onevpl.html'
 
-    version('2021.1.1', sha256='0fec42545b30b7bb2e4e33deb12ab27a02900f5703153d9601673a8ce43082ed', expand=False)
+    if platform == 'linux':
+        version('2021.1.1',
+                sha256='0fec42545b30b7bb2e4e33deb12ab27a02900f5703153d9601673a8ce43082ed',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17418/l_oneVPL_p_2021.1.1.66_offline.sh',
+                expand=False)
 
     def __init__(self, spec):
-        self.component_info(dir_name='vpl',
-                            components='intel.oneapi.lin.vpl.devel',
-                            releases=releases,
-                            url_name='oneVPL')
+        self.component_info(dir_name='vpl')
         super(IntelOneapiVpl, self).__init__(spec)

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -21,6 +21,8 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17418/l_oneVPL_p_2021.1.1.66_offline.sh',
                 expand=False)
 
+    provides('onetbb')
+
     @property
     def component_dir(self):
         return 'vpl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -21,6 +21,6 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17418/l_oneVPL_p_2021.1.1.66_offline.sh',
                 expand=False)
 
-    def __init__(self, spec):
-        self.component_info(dir_name='vpl')
-        super(IntelOneapiVpl, self).__init__(spec)
+    @property
+    def component_dir(self):
+        return 'vpl'

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -21,8 +21,6 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17418/l_oneVPL_p_2021.1.1.66_offline.sh',
                 expand=False)
 
-    provides('onetbb')
-
     @property
     def component_dir(self):
         return 'vpl'


### PR DESCRIPTION
This is a continuation of #21904 . I could not reopen because I did a force push.

* Align spack packages to oneapi standalone packages: https://software.intel.com/content/www/us/en/develop/articles/oneapi-standalone-components.html
* Use the vars.sh to setup the environment
* eliminate a lot of complicated code that centralized generating the URL's. I found it is easier to implement and understand if you cut and paste the versions and URLs from https://software.intel.com/content/www/us/en/develop/articles/oneapi-standalone-components.html into the package.
* add some documentation

I attempted to add macos support for #22178, but ran into some problems--the installer requires sudo and I don't know how to manage that. I removed all the mac code, but saved it in this branch: https://github.com/rscohn2/spack/tree/dev/mac.

@scheibelp: ready for final review. It might be easier to look at the full files then the diffs