### PR TITLE
bugfix: ensure spack test list still works

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import os
 import argparse
 import textwrap
+import inspect
 import fnmatch
 import re
 import shutil
@@ -194,6 +195,9 @@ environment variables:
 
 
 def has_test_method(pkg):
+    if not inspect.isclass(pkg):
+        tty.die('{0}: is not a class, it is {1}'.format(pkg, type(pkg)))
+
     pkg_base = spack.package.PackageBase
     return (
         (issubclass(pkg, pkg_base) and pkg.test != pkg_base.test) or
@@ -220,7 +224,7 @@ def test_list(args):
     hashes = env.all_hashes() if env else None
 
     specs = spack.store.db.query(hashes=hashes)
-    specs = list(filter(lambda s: has_test_method(s.package), specs))
+    specs = list(filter(lambda s: has_test_method(s.package_class), specs))
 
     spack.cmd.display_specs(specs, long=True)
 

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -11,6 +11,8 @@ import pytest
 import spack.config
 import spack.package
 import spack.cmd.install
+
+from spack.cmd.test import has_test_method
 from spack.main import SpackCommand
 
 install = SpackCommand('install')
@@ -202,3 +204,11 @@ def test_test_list(
     install(pkg_with_tests)
     output = spack_test("list")
     assert pkg_with_tests in output
+
+
+def test_has_test_method_fails(capsys):
+    with pytest.raises(SystemExit):
+        has_test_method('printing-package')
+
+    captured = capsys.readouterr()[1]
+    assert 'is not a class' in captured

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -183,7 +183,7 @@ def test_test_help_cdash(mock_test_stage):
     assert 'CDash URL' in out
 
 
-def test_list_all(mock_packages):
+def test_test_list_all(mock_packages):
     """make sure `spack test list --all` returns all packages with tests"""
     pkgs = spack_test("list", "--all").strip().split()
     assert set(pkgs) == set([
@@ -193,3 +193,12 @@ def test_list_all(mock_packages):
         "test-error",
         "test-fail",
     ])
+
+
+def test_test_list(
+    mock_packages, mock_archive, mock_fetch, install_mockery_mutable_config
+):
+    pkg_with_tests = 'printing-package'
+    install(pkg_with_tests)
+    output = spack_test("list")
+    assert pkg_with_tests in output


### PR DESCRIPTION
Was getting the following error:

```
$ spack test list
==> Error: issubclass() arg 1 must be a class
```

This PR adds a check in `has_test_method` (in case it is re-used elsewhere such as #22097) and ensures a class is passed to the method from `spack test list`.