### PR TITLE
lxc: Fix install error

### DIFF
--- a/var/spack/repos/builtin/packages/lxc/package.py
+++ b/var/spack/repos/builtin/packages/lxc/package.py
@@ -35,5 +35,5 @@ class Lxc(AutotoolsPackage):
     def configure_args(self):
         args = ["bashcompdir=" +
                 join_path(self.spec['lxc'].prefix, 'share',
-                'bash-completion', 'completions')]
+                          'bash-completion', 'completions')]
         return args

--- a/var/spack/repos/builtin/packages/lxc/package.py
+++ b/var/spack/repos/builtin/packages/lxc/package.py
@@ -31,3 +31,9 @@ class Lxc(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+
+    def configure_args(self):
+        args = ["bashcompdir=" +
+                join_path(self.spec['lxc'].prefix, 'share',
+                'bash-completion', 'completions')]
+        return args


### PR DESCRIPTION
I fixed the following install error.
1075 /usr/bin/install: cannot create regular file '/usr/share/bash-completion/completions/lxc': Permission denied