### PR TITLE
rsyslog: Fix install error

### DIFF
--- a/var/spack/repos/builtin/packages/rsyslog/package.py
+++ b/var/spack/repos/builtin/packages/rsyslog/package.py
@@ -31,3 +31,8 @@ class Rsyslog(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         env.prepend_path('PATH', self.prefix.sbin)
+
+    def configure_args(self):
+        args = ["--with-systemdsystemunitdir=" +
+                self.spec['rsyslog'].prefix.lib.systemd.system]
+        return args


### PR DESCRIPTION
I fixed the following install error.
  815    /usr/bin/install: cannot remove '/usr/lib/systemd/system/rsyslog.service': Permission denied