### PR TITLE
satsuma2: Fix install error

### DIFF
--- a/var/spack/repos/builtin/packages/satsuma2/package.py
+++ b/var/spack/repos/builtin/packages/satsuma2/package.py
@@ -19,4 +19,4 @@ class Satsuma2(CMakePackage):
     version('2016-11-22', commit='da694aeecf352e344b790bea4a7aaa529f5b69e6')
 
     def install(self, spec, prefix):
-        install_tree(join_path('spack-build', 'bin'), prefix.bin)
+        install_tree(join_path(self.build_directory, 'bin'), prefix.bin)


### PR DESCRIPTION
I fixed the following install error.

Error: OSError: No such file or directory: 'spack-build/bin'

./all-test/gcc/spack/var/spack/repos/builtin/packages/satsuma2/package.py:22, in install:
21 def install(self, spec, prefix):
22 install_tree(join_path('spack-build', 'bin'), prefix.bin)