### PR TITLE
BLAS++: OpenMP for AppleClang

### DIFF
--- a/var/spack/repos/builtin/packages/blaspp/package.py
+++ b/var/spack/repos/builtin/packages/blaspp/package.py
@@ -28,6 +28,7 @@ class Blaspp(CMakePackage, CudaPackage):
 
     depends_on('cmake@3.15.0:', type='build')
     depends_on('blas')
+    depends_on('llvm-openmp', when='%apple-clang +openmp')
 
     # only supported with clingo solver: virtual dependency preferences
     # depends_on('openblas threads=openmp', when='+openmp ^openblas')


### PR DESCRIPTION
We need to install OpenMP for Apple's Clang.

Related to https://bitbucket.org/icl/blaspp/pull-requests/34

cc @Ragghianti @mgates3
