### PR TITLE
bind9: Fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/bind9/package.py
+++ b/var/spack/repos/builtin/packages/bind9/package.py
@@ -16,6 +16,8 @@ class Bind9(AutotoolsPackage):
 
     version('9_14_6', sha256='98be7a7b6d614b519f6c8d6ec7a8a39759ae9604d87228d9dc7c034471e5433e')
 
+    depends_on('libuv', type='link')
+    depends_on('pkgconfig', type='build')
     depends_on('openssl', type='link')
     depends_on('libiconv', type='link')
 

--- a/var/spack/repos/builtin/packages/bind9/package.py
+++ b/var/spack/repos/builtin/packages/bind9/package.py
@@ -16,6 +16,10 @@ class Bind9(AutotoolsPackage):
 
     version('9_14_6', sha256='98be7a7b6d614b519f6c8d6ec7a8a39759ae9604d87228d9dc7c034471e5433e')
 
+    depends_on('openssl', type='link')
+    depends_on('libiconv', type='link')
+
     def configure_args(self):
-        args = ["--without-python", "--disable-linux-caps"]
+        args = ["--without-python", "--disable-linux-caps",
+                '--with-openssl={0}'.format(self.spec['openssl'].prefix)]
         return args


### PR DESCRIPTION
I fixed the following build error.
 186    configure: error: OpenSSL/LibreSSL not found

After handling the above error, the following error was output, so I added the depend of libiconv.
./gen: error while loading shared libraries: libiconv.so.2: cannot open shared object file: No such file or directory

OSS isc-dhcp cannot be built because bind9 cannot be built.
I have also confirmed that the fix for bind9 can build isc-dhcp.