### PR TITLE
gcc: fix nvptx conflict

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -212,7 +212,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     conflicts('languages=objc', when='+nvptx')
     conflicts('languages=obj-c++', when='+nvptx')
     # NVPTX build disables bootstrap
-    conflicts('+binutils', when='+nvptx')
+    conflicts('+bootstrap', when='+nvptx')
 
     # Binutils can't build ld on macOS
     conflicts('+binutils', when='platform=darwin')


### PR DESCRIPTION
In the past, we only had the binutils variant, which included the bootstrapping flag. Now that we have a separate bootstrap variant, fix the nvptx conflict accordingly.