### PR TITLE
dotnet-core-sdk: add version 5.0.4 and 3.1.13.

### DIFF
--- a/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
+++ b/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
@@ -13,6 +13,15 @@ class DotnetCoreSdk(Package):
 
     homepage = "https://www.microsoft.com/net/"
 
+    version('5.0.4',
+            url='https://download.visualstudio.microsoft.com/download/pr/73a9cb2a-1acd-4d20-b864-d12797ca3d40/075dbe1dc3bba4aa85ca420167b861b6/dotnet-sdk-5.0.201-linux-x64.tar.gz',
+            sha256='9ff77087831e8ca32719566ec9ef537e136cfc02c5ff565e53f5509cc6e7b341')
+
+    version('3.1.13',
+            url='https://download.visualstudio.microsoft.com/download/pr/ab82011d-25'
+                '49-4e23-a8a9-a2b522a31f27/6e615d6177e49c3e874d05ee3566e8bf/dotnet-sdk-3.1.407-linux-x64.tar.gz',
+            sha256='a744359910206fe657c3a02dfa54092f288a44c63c7c86891e866f0678a7e911')
+
     version('2.1.300',
             url='https://download.microsoft.com/download/8/8/5/88544F33-836A-49A5-8B67-451C24709A8F/dotnet-sdk-2.1.300-linux-x64.tar.gz',
             sha256='fabca4c8825182ff18e5a2f82dfe75aecd10260ee9e7c85a8c4b3d108e5d8e1b')

--- a/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
+++ b/var/spack/repos/builtin/packages/dotnet-core-sdk/package.py
@@ -18,8 +18,7 @@ class DotnetCoreSdk(Package):
             sha256='9ff77087831e8ca32719566ec9ef537e136cfc02c5ff565e53f5509cc6e7b341')
 
     version('3.1.13',
-            url='https://download.visualstudio.microsoft.com/download/pr/ab82011d-25'
-                '49-4e23-a8a9-a2b522a31f27/6e615d6177e49c3e874d05ee3566e8bf/dotnet-sdk-3.1.407-linux-x64.tar.gz',
+            url='https://download.visualstudio.microsoft.com/download/pr/ab82011d-2549-4e23-a8a9-a2b522a31f27/6e615d6177e49c3e874d05ee3566e8bf/dotnet-sdk-3.1.407-linux-x64.tar.gz',
             sha256='a744359910206fe657c3a02dfa54092f288a44c63c7c86891e866f0678a7e911')
 
     version('2.1.300',


### PR DESCRIPTION
Add recent versions of '.Net Core'.