### PR TITLE
spack recipe for AOCC 3.0 release

### DIFF
--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -9,6 +9,7 @@ import sys
 import llnl.util.lang
 
 from spack.compiler import Compiler
+from spack.version import ver
 
 
 class Aocc(Compiler):
@@ -118,3 +119,18 @@ class Aocc(Compiler):
     @property
     def stdcxx_libs(self):
         return ('-lstdc++', )
+
+    @property
+    def cflags(self):
+        if self.real_version == ver('3.0.0'):
+            return "-mllvm -eliminate-similar-expr=false"
+
+    @property
+    def cxxflags(self):
+        if self.real_version == ver('3.0.0'):
+            return "-mllvm -eliminate-similar-expr=false"
+
+    @property
+    def fflags(self):
+        if self.real_version == ver('3.0.0'):
+            return "-mllvm -eliminate-similar-expr=false"

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -152,4 +152,4 @@ class Aocc(Compiler):
         cflags, cxxflags and fflags member functions.
         """
         if self.real_version == ver('3.0.0'):
-            return "-mllvm -eliminate-similar-expr=false"
+            return " -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false "

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -152,4 +152,4 @@ class Aocc(Compiler):
         cflags, cxxflags and fflags member functions.
         """
         if self.real_version == ver('3.0.0'):
-            return "-mllvm -eliminate-similar-expr=false"
+            return "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false"

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -152,4 +152,4 @@ class Aocc(Compiler):
         cflags, cxxflags and fflags member functions.
         """
         if self.real_version == ver('3.0.0'):
-            return " -Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false "
+            return "-mllvm -eliminate-similar-expr=false"

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -122,15 +122,34 @@ class Aocc(Compiler):
 
     @property
     def cflags(self):
-        if self.real_version == ver('3.0.0'):
-            return "-mllvm -eliminate-similar-expr=false"
+        return self.__handle_default_flag_addtions()
 
     @property
     def cxxflags(self):
-        if self.real_version == ver('3.0.0'):
-            return "-mllvm -eliminate-similar-expr=false"
+        return self.__handle_default_flag_addtions()
 
     @property
     def fflags(self):
+        return self.__handle_default_flag_addtions()
+
+    def __handle_default_flag_addtions(self):
+        """
+        We have found a compilation issue which was
+        exposed during last minute in our validation.
+        Hence we could not accommodate its fix in
+        our AOCC-3.0.0 release and planning to fix only in
+        our next release of AOCC.
+
+        Workaround for this issue is the use of default flag
+        for AOCC-3.0.0 in function defined below.
+
+        We are mentioning about this issue and its workaround option
+        under *known issue* section in
+        our user guide of AOCC-3.0.0
+
+        This function is private as
+        it is only meant to be called from
+        cflags, cxxflags and fflags member functions.
+        """
         if self.real_version == ver('3.0.0'):
             return "-mllvm -eliminate-similar-expr=false"

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -136,4 +136,5 @@ class Aocc(Compiler):
         # This is a known issue for AOCC 3.0 see:
         # https://developer.amd.com/wp-content/resources/AOCC-3.0-Install-Guide.pdf
         if self.real_version == ver('3.0.0'):
-            return "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false"
+            return ("-Wno-unused-command-line-argument "
+                    "-mllvm -eliminate-similar-expr=false")

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -122,34 +122,18 @@ class Aocc(Compiler):
 
     @property
     def cflags(self):
-        return self.__handle_default_flag_addtions()
+        return self._handle_default_flag_addtions()
 
     @property
     def cxxflags(self):
-        return self.__handle_default_flag_addtions()
+        return self._handle_default_flag_addtions()
 
     @property
     def fflags(self):
-        return self.__handle_default_flag_addtions()
+        return self._handle_default_flag_addtions()
 
-    def __handle_default_flag_addtions(self):
-        """
-        We have found a compilation issue which was
-        exposed during last minute in our validation.
-        Hence we could not accommodate its fix in
-        our AOCC-3.0.0 release and planning to fix only in
-        our next release of AOCC.
-
-        Workaround for this issue is the use of default flag
-        for AOCC-3.0.0 in function defined below.
-
-        We are mentioning about this issue and its workaround option
-        under *known issue* section in
-        our user guide of AOCC-3.0.0
-
-        This function is private as
-        it is only meant to be called from
-        cflags, cxxflags and fflags member functions.
-        """
+    def _handle_default_flag_addtions(self):
+        # This is a known issue for AOCC 3.0 see:
+        # https://developer.amd.com/wp-content/resources/AOCC-3.0-Install-Guide.pdf
         if self.real_version == ver('3.0.0'):
             return "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false"

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -466,6 +466,9 @@ def test_aocc_flags():
     supported_flag_test("f77_pic_flag", "-fPIC", "aocc@2.2.0")
     supported_flag_test("fc_pic_flag", "-fPIC", "aocc@2.2.0")
     supported_flag_test("version_argument", "--version", "aocc@2.2.0")
+    supported_flag_test("cflags", "-mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
+    supported_flag_test("cxxflags", "-mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
+    supported_flag_test("fflags", "-mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
 
 
 def test_fj_flags():

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -466,9 +466,10 @@ def test_aocc_flags():
     supported_flag_test("f77_pic_flag", "-fPIC", "aocc@2.2.0")
     supported_flag_test("fc_pic_flag", "-fPIC", "aocc@2.2.0")
     supported_flag_test("version_argument", "--version", "aocc@2.2.0")
-    supported_flag_test("cflags", "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
-    supported_flag_test("cxxflags", "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
-    supported_flag_test("fflags", "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
+    flg = "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false"
+    supported_flag_test("cflags", flg, "aocc@3.0.0")
+    supported_flag_test("cxxflags", flg, "aocc@3.0.0")
+    supported_flag_test("fflags", flg, "aocc@3.0.0")
 
 
 def test_fj_flags():

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -466,9 +466,9 @@ def test_aocc_flags():
     supported_flag_test("f77_pic_flag", "-fPIC", "aocc@2.2.0")
     supported_flag_test("fc_pic_flag", "-fPIC", "aocc@2.2.0")
     supported_flag_test("version_argument", "--version", "aocc@2.2.0")
-    supported_flag_test("cflags", "-mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
-    supported_flag_test("cxxflags", "-mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
-    supported_flag_test("fflags", "-mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
+    supported_flag_test("cflags", "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
+    supported_flag_test("cxxflags", "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
+    supported_flag_test("fflags", "-Wno-unused-command-line-argument -mllvm -eliminate-similar-expr=false", "aocc@3.0.0")
 
 
 def test_fj_flags():

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -321,6 +321,11 @@ def test_cray_frontend_compiler_detection(
 
 @pytest.mark.parametrize('version_str,expected_version', [
     # This applies to C,C++ and FORTRAN compiler
+    ('AMD clang version 12.0.0 (CLANG: AOCC_3.0.0-Build#78 2020_12_10)'
+     '(based on LLVM Mirror.Version.12.0.0)\n'
+     'Target: x86_64-unknown-linux-gnu\n'
+     'Thread model: posix\n', '3.0.0'
+     ),
     ('AMD clang version 11.0.0 (CLANG: AOCC_2.3.0-Build#85 2020_11_10)'
      '(based on LLVM Mirror.Version.11.0.0)\n'
      'Target: x86_64-unknown-linux-gnu\n'

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -32,6 +32,8 @@ class Aocc(Package):
 
     maintainers = ['amd-toolchain-support']
 
+    version(ver="3.0.0", sha256='4ff269b1693856b9920f57e3c85ce488c8b81123ddc88682a3ff283979362227',
+            url='http://developer.amd.com/wordpress/media/files/aocc-compiler-3.0.0.tar')
     version(ver="2.3.0", sha256='9f8a1544a5268a7fb8cd21ac4bdb3f8d1571949d1de5ca48e2d3309928fc3d15',
             url='http://developer.amd.com/wordpress/media/files/aocc-compiler-2.3.0.tar')
     version(ver="2.2.0", sha256='500940ce36c19297dfba3aa56dcef33b6145867a1f34890945172ac2be83b286',


### PR DESCRIPTION
This pull request has been created to add AOCC-3.0.0 to SPACK community.
AMD Optimizing C/C++ Compiler (AOCC) is a highly optimized C, C++, and Fortran compiler for x86 targets, especially for Zen based AMD processors.
It supports Flang as the default Fortran front-end compiler.


In AOCC-3.0.0 we have identified a last minute compilation issue against SQLite and we found that workaround is to have an additional default compiler flag for AOCC-3.0.0 only using ‘spack/lib/spack/spack/compilers/aocc.py’. 

This workaround avoids manual modification of compilers.yaml file using command "spack config edit compilers". 

Please note that we have tested the same and the behavior is as expected.

File:spack/lib/spack/spack/compilers/aocc.py
--snip—
    @property
    def cflags(self):
        if self.real_version == ver('3.0.0'):
            return "-mllvm -eliminate-similar-expr=false"

    @property
    def cxxflags(self):
        if self.real_version == ver('3.0.0'):
            return "-mllvm -eliminate-similar-expr=false"

    @property
    def fflags(self):
        if self.real_version == ver('3.0.0'):
            return "-mllvm -eliminate-similar-expr=false"
--snip—