### PR TITLE
Updates to LBANN software stack

### DIFF
--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -22,6 +22,7 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
     maintainers = ['bvanessen']
 
     version('master', branch='master')
+    version('1.0.0', sha256='028d12e271817214db5c07c77b0528f88862139c3e442e1b12f58717290f414a')
     version('0.7.0', sha256='bbb73d2847c56efbe6f99e46b41d837763938483f2e2d1982ccf8350d1148caa')
     version('0.6.0', sha256='6ca329951f4c7ea52670e46e5020e7e7879d9b56fed5ff8c5df6e624b313e925')
     version('0.5.0', sha256='dc365a5849eaba925355a8efb27005c5f22bcd1dca94aaed8d0d29c265c064c1')

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -23,6 +23,8 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
     version('develop', branch='develop')
     version('master', branch='master')
 
+    version('0.2.1', sha256='11e2c0f8a94ffa22e816deff0357dde6f82cc8eac21b587c800a346afb5c49ac')
+    version('0.2.0', sha256='e1f597e80f93cf49a0cb2dbc079a1f348641178c49558b28438963bd4a0bdaa4')
     version('0.1', sha256='171d4b8adda1e501c38177ec966e6f11f8980bf71345e5f6d87d0a988fef4c4e')
 
     variant('al', default=True,
@@ -73,7 +75,7 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
 
     # Specify the correct version of Aluminum
     depends_on('aluminum@0.4:0.4.99', when='@0.1:0.1.99 +al')
-    depends_on('aluminum@0.5:', when='@:0.0,0.2: +al')
+    depends_on('aluminum@0.5.0:', when='@:0.0,0.2: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')
@@ -151,6 +153,7 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
             '-DCMAKE_CXX_STANDARD=17',
             '-DCMAKE_INSTALL_MESSAGE:STRING=LAZY',
             '-DBUILD_SHARED_LIBS:BOOL=%s'      % ('+shared' in spec),
+            '-DH2_ENABLE_ALUMINUM=%s' % ('+al' in spec),
             '-DH2_ENABLE_CUDA=%s' % ('+cuda' in spec),
             '-DH2_ENABLE_DISTCONV_LEGACY=%s' % ('+distconv' in spec),
             '-DH2_ENABLE_OPENMP=%s' % ('+openmp' in spec),

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -93,8 +93,8 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     # Specify the correct version of Aluminum
     depends_on('aluminum@:0.3.99', when='@:1.3.99 +al')
     depends_on('aluminum@0.4:0.4.99', when='@1.4:1.4.99 +al')
-    depends_on('aluminum@0.5:', when='@1.5.0:1.5.1 +al')
-    depends_on('aluminum@0.7:', when='@:1.0,1.5.2: +al')
+    depends_on('aluminum@0.5.0:0.5.99', when='@1.5.0:1.5.1 +al')
+    depends_on('aluminum@0.7.0:', when='@:1.0,1.5.2: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -105,12 +105,13 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     # Specify the correct version of Aluminum
     depends_on('aluminum@:0.3.99', when='@0.95:0.100 +al')
     depends_on('aluminum@0.4:0.4.99', when='@0.101:0.101.99 +al')
-    depends_on('aluminum@0.5:', when='@:0.90,0.102: +al')
+    depends_on('aluminum@0.5.0:', when='@:0.90,0.102: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')
     depends_on('aluminum +rocm +rccl +ht', when='+al +rocm')
 
+    depends_on('dihydrogen@0.2.0:', when='@:0.90,0.102:')
     depends_on('dihydrogen +openmp', when='+dihydrogen')
     depends_on('dihydrogen ~cuda', when='+dihydrogen ~cuda')
     depends_on('dihydrogen +cuda', when='+dihydrogen +cuda')
@@ -128,9 +129,9 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('~dihydrogen', when='+distconv')
 
     for arch in CudaPackage.cuda_arch_values:
-        depends_on('hydrogen cuda_arch=%s' % arch, when='cuda_arch=%s' % arch)
+        depends_on('hydrogen cuda_arch=%s' % arch, when='+cuda cuda_arch=%s' % arch)
         depends_on('aluminum cuda_arch=%s' % arch, when='+al +cuda cuda_arch=%s' % arch)
-        depends_on('dihydrogen cuda_arch=%s' % arch, when='+dihydrogen cuda_arch=%s' % arch)
+        depends_on('dihydrogen cuda_arch=%s' % arch, when='+dihydrogen +cuda cuda_arch=%s' % arch)
         depends_on('nccl cuda_arch=%s' % arch, when='+cuda cuda_arch=%s' % arch)
 
     # variants +rocm and amdgpu_targets are not automatically passed to


### PR DESCRIPTION
Updated the versions for DiHydrogen and Aluminum.  Added new
constraints on versions of Aluminum that are used across the software
stack.  Cleaned up the dependency on DiHydrogen for LBANN.