### PR TITLE
superlu-dist: Add e4s testsuite-inspired smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.util.executable import which
 
 
 class SuperluDist(CMakePackage, CudaPackage):
@@ -102,3 +103,53 @@ class SuperluDist(CMakePackage, CudaPackage):
         if name == 'cflags' and '%pgi' not in self.spec:
             flags.append('-std=c99')
         return (None, None, flags)
+
+    examples_src_dir = 'EXAMPLE'
+    mk_hdr = 'make.inc'
+    mk_hdr_in = mk_hdr + '.in'
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources([self.examples_src_dir, self.mk_hdr])
+
+    def test(self):
+        mk_file = join_path(self.install_test_root, self.mk_hdr)
+        # Replace 'SRC' with 'lib' in the library's path
+        filter_file(r'^(DSUPERLULIB.+)SRC(.+)', '\\1lib\\2', mk_file)
+        # Set library flags for all libraries superlu-dist depends on
+        filter_file(r'^LIBS.+\+=.+', '', mk_file)
+        filter_file(r'^LIBS[^\+]+=.+', 'LIBS = $(DSUPERLULIB)' +
+                    ' {0}'.format(self.spec['blas'].libs.ld_flags) +
+                    ' {0}'.format(self.spec['lapack'].libs.ld_flags) +
+                    ' {0}'.format(self.spec['parmetis'].libs.ld_flags) +
+                    ' {0}'.format(self.spec['metis'].libs.ld_flags) +
+                    ' $(CUDALIBS)',
+                    mk_file)
+        cuda_lib_opts = ''
+        if '+cuda' in self.spec:
+            cuda_lib_opts = ',-rpath,{0}'.format(
+                            self.spec['cuda'].libs.directories[0])
+        # Set the rpath for all the libs
+        filter_file(r'^LOADOPTS.+', 'LOADOPTS = -Wl' +
+                    ',-rpath,{0}'.format(self.prefix.lib) +
+                    ',-rpath,{0}'.format(self.spec['blas'].prefix.lib) +
+                    ',-rpath,{0}'.format(self.spec['lapack'].prefix.lib) +
+                    ',-rpath,{0}'.format(self.spec['parmetis'].prefix.lib) +
+                    ',-rpath,{0}'.format(self.spec['metis'].prefix.lib) +
+                    cuda_lib_opts,
+                    mk_file)
+
+        test_dir = join_path(self.install_test_root, self.examples_src_dir)
+        test_exe = 'pddrive'
+        with working_dir(test_dir, create=False):
+            make(test_exe)
+            # Smoke test input parameters: -r 2 -c 2 g20.rua
+            test_args = ['-n', '4', test_exe, '-r', '2', '-c', '2', 'g20.rua']
+            # Find the correct mpirun command
+            mpiexe_f = which('mpirun', 'mpiexec', 'srun')
+            if mpiexe_f is not None:
+                self.run_test(mpiexe_f.command, test_args, work_dir='.',
+                              purpose='superlu-dist smoke test')
+            make('clean')

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.util.executable import which
 
 
 class SuperluDist(CMakePackage, CudaPackage):
@@ -148,8 +147,8 @@ class SuperluDist(CMakePackage, CudaPackage):
             # Smoke test input parameters: -r 2 -c 2 g20.rua
             test_args = ['-n', '4', test_exe, '-r', '2', '-c', '2', 'g20.rua']
             # Find the correct mpirun command
-            mpiexe_f = which('mpirun', 'mpiexec', 'srun')
-            if mpiexe_f is not None:
+            mpiexe_f = which('srun', 'mpirun', 'mpiexec')
+            if mpiexe_f:
                 self.run_test(mpiexe_f.command, test_args, work_dir='.',
                               purpose='superlu-dist smoke test')
             make('clean')


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `superlu-dist` package and is intended to serve the following purposes:

- leverage the current E4S test suite for the software; and
- demonstrate to package maintainers how to start a Spack smoke test.

This PR is instead of the one I closed (#22236) because of some mistakes I did.
