### PR TITLE
Windows locks: PyOVERLAPPED may not be a class member

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -105,7 +105,6 @@ class Lock(object):
             self.LOCK_EX = win32con.LOCKFILE_EXCLUSIVE_LOCK  # exclusive lock
             self.LOCK_SH = 0  # shared lock, default
             self.LOCK_NB = win32con.LOCKFILE_FAIL_IMMEDIATELY  # non-blocking
-            self.win_overlapped = None #pywintypes.OVERLAPPED()
         else:
             self.LOCK_EX = fcntl.LOCK_EX
             self.LOCK_SH = fcntl.LOCK_SH
@@ -271,7 +270,7 @@ class Lock(object):
                                      op | self.LOCK_NB,
                                      0,
                                      0,
-                                     self.win_overlapped)
+                                     pywintypes.OVERLAPPED())
             else:
                 fcntl.lockf(self._file, op | self.LOCK_NB,
                             self._length, self._start, os.SEEK_SET)
@@ -365,7 +364,7 @@ class Lock(object):
             win32file.UnlockFileEx(self._file,
                                    0,
                                    0,
-                                   self.win_overlapped)
+                                   pywintypes.OVERLAPPED())
         else:
             fcntl.lockf(self._file, self.LOCK_UN,
                         self._length, self._start, os.SEEK_SET)


### PR DESCRIPTION
To test, try `spack install zlib`
