### PR TITLE
py-tensorflow: remove bazel restriction to /tmp

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -548,7 +548,7 @@ class PyTensorflow(Package, CudaPackage):
         #       ])
         #       to not be nfs. This is only valid for Linux and we'd like to
         #       stay at least also OSX compatible
-        tmp_path = tempfile.mkdtemp(dir='/tmp', prefix='spack')
+        tmp_path = tempfile.mkdtemp(prefix='spack')
         env.set('TEST_TMPDIR', tmp_path)
 
         env.set('TF_SYSTEM_LIBS', 'com_google_protobuf')


### PR DESCRIPTION
Currently, the temporary directory of bazel is hardcoded to `/tmp`. If you are building on a system with low disk space on root, this can prevent you from building (and so it did for me). In my opinion, it is cleaner to let `tempfile.mkdtemp` decide on an appropriate file location instead of hardcoding `/tmp`. This allows users to define other partitions that are better fitted for compiling large projects.

From the documentation of `tempfile.mkdtemp` ([link](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp)):
> If dir is not None, the file will be created in that directory; otherwise, a default directory is used. The default directory is chosen from a platform-dependent list, but **the user of the application can control the directory location by setting the TMPDIR, TEMP or TMP environment variables.** There is thus no guarantee that the generated filename will have any nice properties, such as not requiring quoting when passed to external commands via os.popen().

Related to  #20212