### PR TITLE
py-python-benedict - py-ftfy dep when fixed

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-benedict/package.py
+++ b/var/spack/repos/builtin/packages/py-python-benedict/package.py
@@ -17,8 +17,8 @@ class PyPythonBenedict(PythonPackage):
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-ftfy@4.4.3', when='python@:3.3.999', type=('build', 'run'))
-    depends_on('py-ftfy', when='python@3.4:', type=('build', 'run'))
+    depends_on('py-ftfy@4.4.3', when='^python@:3.3.999', type=('build', 'run'))
+    depends_on('py-ftfy', when='^python@3.4:', type=('build', 'run'))
     depends_on('py-mailchecker', type=('build', 'run'))
     depends_on('py-phonenumbers', type=('build', 'run'))
     depends_on('py-python-dateutil', type=('build', 'run'))


### PR DESCRIPTION
For the py-ftfy dependency of py-python-benedict, the when argument originally stated "python...". Because Python is a dependency it should have had a ^ in front it. This PR addresses this issue. Now py-ftfy is in the concretized spec.