### PR TITLE
py-h5py: offline installation and deps fix

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/h5py-3-setuprequires.patch
+++ b/var/spack/repos/builtin/packages/py-h5py/h5py-3-setuprequires.patch
@@ -1,0 +1,21 @@
+diff -Naur h5py-3.1.0/setup.py h5py-3.1.0.patch/setup.py
+--- h5py-3.1.0/setup.py	2020-11-06 14:25:11.000000000 +0000
++++ h5py-3.1.0.patch/setup.py	2021-03-04 20:12:19.913405154 +0000
+@@ -49,14 +49,14 @@
+     f"Cython >=0.29; python_version<'3.8'",
+     f"Cython >=0.29.14; python_version>='3.8'",
+ ] + [
+-    f"numpy =={np_min}; python_version{py_condition}"
++    f"numpy >={np_min}; python_version{py_condition}"
+     for np_min, py_condition in NUMPY_MIN_VERSIONS
+ ]
+ 
+ if setup_configure.mpi_enabled():
+     RUN_REQUIRES.append('mpi4py >=3.0.0')
+-    SETUP_REQUIRES.append("mpi4py ==3.0.0; python_version<'3.8'")
+-    SETUP_REQUIRES.append("mpi4py ==3.0.3; python_version>='3.8'")
++    SETUP_REQUIRES.append("mpi4py >=3.0.0; python_version<'3.8'")
++    SETUP_REQUIRES.append("mpi4py >=3.0.3; python_version>='3.8'")
+ 
+ # Set the environment variable H5PY_SETUP_REQUIRES=0 if we need to skip
+ # setup_requires for any reason.

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -36,15 +36,20 @@ class PyH5py(PythonPackage):
 
     # Build dependencies
     depends_on('py-cython@0.23:', type='build', when='@:2.99')
-    depends_on('py-cython@0.29:', type=('build'), when='@3.0.0:')
+    depends_on('py-cython@0.29:', type=('build'), when='@3.0.0:^python@:3.7.99')
+    depends_on('py-cython@0.29.14:', type=('build'), when='@3.0.0:^python@3.8.0:3.8.99')
+    depends_on('py-cython@0.29.15:', type=('build'), when='@3.0.0:^python@3.9.0:')
     depends_on('py-pkgconfig', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-wheel', type='build', when='@3.0.0:')
 
     # Build and runtime dependencies
-    depends_on('py-cached-property@1.5:', type=('build', 'run'), when='python@:3.7.999')
-    depends_on('py-numpy@1.7:', type=('build', 'run'), when='@:3.1.99')
-    depends_on('py-numpy@1.14.5:', type=('build', 'run'), when='@3.2.0:')
+    depends_on('py-cached-property@1.5:', type=('build', 'run'), when='^python@:3.7.99')
+    depends_on('py-numpy@1.7:', type=('build', 'run'), when='@:2.99')
+    depends_on('py-numpy@1.12:', type=('build', 'run'), when='@3.0.0:^python@3.6.0:3.6.99')
+    depends_on('py-numpy@1.14.5:', type=('build', 'run'), when='@3.0.0:^python@3.7.0:3.7.99')
+    depends_on('py-numpy@1.17.5:', type=('build', 'run'), when='@3.0.0:^python@3.8.0:3.8.99')
+    depends_on('py-numpy@1.19.3:', type=('build', 'run'), when='@3.0.0:^python@3.9.0:')
     depends_on('py-six', type=('build', 'run'), when='@:2.99')
 
     # Link dependencies
@@ -56,7 +61,12 @@ class PyH5py(PythonPackage):
     depends_on('hdf5~mpi', when='~mpi')
     depends_on('mpi', when='+mpi')
     depends_on('py-mpi4py', when='@:2.99 +mpi', type=('build', 'run'))
-    depends_on('py-mpi4py@3.0.0:', when='@3.0.0: +mpi', type=('build', 'run'))
+    depends_on('py-mpi4py@3.0.0:', when='@3.0.0:+mpi^python@3.0.0:3.7.99', type=('build', 'run'))
+    depends_on('py-mpi4py@3.0.3:', when='@3.0.0:+mpi^python@3.8.0:', type=('build', 'run'))
+
+    # For version 3+, patch setup.py to allow setup_requires list to be more abstract.
+    # Required for offline installations with version 3+
+    patch('h5py-3-setuprequires.patch', when="@3.0.0:")
 
     phases = ['configure', 'install']
 


### PR DESCRIPTION
Since h5py v3, offline installations have not worked. This is because of how h5py developers changed the structure of setup.py (https://github.com/h5py/h5py/blob/3.2.1/setup.py). If you look carefully, the SETUP_REQUIRES is using very strict version dependencies for numpy that are allowed to be different than the RUN_REQUIRES. This causes a problem in Spack because it expects them to be the same version. So there are two options: use the strict versions for setup requires for runtime deps as well, or patch h5py's setup.py to loosen the == restriction for setup_requires. I chose to do the latter because h5py built fine. I will work with h5py developers separately to understand why they went that route, but I wanted to get something into Spack that works for offline installations. If one looks at the Spack build output, if the following warning appears, you know that offline installation wont work:

```
WARNING: The pip package is not available, falling back to EasyInstall for handling setup_requires/test_requires; this is deprecated and will be removed in a future version.
```

In addition to supporting offline installation, additional fixes were made:

- the python dependency listed in py-cached-property did not have a ^
- Cython version deps didn't match setup.py
- NumPy version deps didn't match setup.py
- MPI4Py version deps didn't match setup.py