### PR TITLE
py-rich/py-dvc: Fixed when clause when including Python

### DIFF
--- a/var/spack/repos/builtin/packages/py-dvc/package.py
+++ b/var/spack/repos/builtin/packages/py-dvc/package.py
@@ -45,7 +45,7 @@ class PyDvc(PythonPackage):
     depends_on('py-networkx@2.1:2.4', when='@:1.11.6', type=('build', 'run'))
     depends_on('py-networkx@2.1:', when='@1.11.7:', type=('build', 'run'))
     depends_on('py-pydot@1.2.4:', type=('build', 'run'))
-    depends_on('py-dataclasses@0.7', when='python@:3.6.999', type=('build', 'run'))
+    depends_on('py-dataclasses@0.7', when='^python@:3.6.999', type=('build', 'run'))
     depends_on('py-flatten-dict@0.3.0:0.99', type=('build', 'run'))
     depends_on('py-tabulate@0.8.7:', type=('build', 'run'))
     depends_on('py-pygtrie@2.3.2', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-rich/package.py
+++ b/var/spack/repos/builtin/packages/py-rich/package.py
@@ -29,7 +29,7 @@ class PyRich(PythonPackage):
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-typing-extensions@3.7.4:3.99', type=('build', 'run'))
-    depends_on('py-dataclasses@0.7:0.8', when='python@:3.6', type=('build', 'run'))
+    depends_on('py-dataclasses@0.7:0.8', when='^python@:3.6', type=('build', 'run'))
     depends_on('py-pygments@2.6:2.99', type=('build', 'run'))
     depends_on('py-commonmark@0.9.0:0.9.999', type=('build', 'run'))
     depends_on('py-colorama@0.4.0:0.4.999', type=('build', 'run'))


### PR DESCRIPTION
Fixed missing ^ in when clause for py-rich and py-dvc. Only would affect python 3.6 builds.