### PR TITLE
openblas: prevent microarch flags for generic targets

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -218,8 +218,10 @@ class Openblas(MakefilePackage):
         if microarch.vendor == 'generic':
             # User requested a generic platform, or we couldn't find a good
             # match for the requested one. Allow OpenBLAS to determine
-            # an optimized kernel at run time.
-            args.append('DYNAMIC_ARCH=1')
+            # an optimized kernel at run time, including older CPUs, while
+            # forcing it not to add flags for the current host compiler.
+            args.extend(['DYNAMIC_ARCH=1', 'DYNAMIC_OLDER=1',
+                         'TARGET=GENERIC'])
         elif microarch.name in skylake:
             # Special case for renaming skylake family
             args.append('TARGET=SKYLAKEX')


### PR DESCRIPTION
As of OpenBLAS 0.3.13, leaving off `TARGET` by default optimizes most
code for the host system -- adding flags that cause the resulting
library to fail (SIGILL) on older systems.  This change should ensure
that a "x86_64" target for example will work across deployment systems.

See https://github.com/xianyi/OpenBLAS/issues/3139