### PR TITLE
do not validate variants of concrete specs in solver setup

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -900,7 +900,7 @@ class SpackSolverSetup(object):
             raise RuntimeError(msg)
         return clauses
 
-    def spec_clauses(self, spec, body=False, transitive=True, force_check=False):
+    def spec_clauses(self, spec, body=False, transitive=True):
         """Return a list of clauses for a spec mandates are true.
 
         Arguments:
@@ -909,7 +909,6 @@ class SpackSolverSetup(object):
                 (final values) instead of rule heads (setters).
             transitive (bool): if False, don't generate clauses from
                  dependencies (default True)
-            force_check (bool): if the spec is concrete, force checking variants.
         """
         clauses = []
 
@@ -967,8 +966,8 @@ class SpackSolverSetup(object):
                 if value == '*':
                     continue
 
-                # validate variant value only if spec not concrete, or asked for
-                if not spec.concrete or force_check:
+                # validate variant value only if spec not concrete
+                if not spec.concrete:
                     reserved_names = spack.directives.reserved_names
                     if not spec.virtual and vname not in reserved_names:
                         try:


### PR DESCRIPTION
Currently, regardless of a spec being concrete or not, we validate its variants in `spec_clauses` (part of `SpackSolverSetup`).  

This PR skips the check if the spec is concrete.

The reason we want to do this is so that the solver setup class (really, `spec_clauses`) can be used for cases when we just want the logic statements / facts (is that what they are called?) and we don't need to re-validate an already concrete spec.  We can't change existing concrete specs, and we have to be able to handle them *even if they violate constraints in the current spack*.  This happens in practice if we are doing the validation for a spec produced by a different spack install.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>