### PR TITLE
mozjs: add zip as a build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/mozjs/package.py
+++ b/var/spack/repos/builtin/packages/mozjs/package.py
@@ -23,6 +23,7 @@ class Mozjs(AutotoolsPackage):
     depends_on('perl@5.6:', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('python@2.7.3:2.8', type='build')
+    depends_on('zip',  type='build')
     depends_on('nspr', when='@:27')
     depends_on('libffi@3.0.9:')
     depends_on('readline', when='@17.0.0:')

--- a/var/spack/repos/builtin/packages/mozjs/package.py
+++ b/var/spack/repos/builtin/packages/mozjs/package.py
@@ -24,6 +24,7 @@ class Mozjs(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
     depends_on('python@2.7.3:2.8', type='build')
     depends_on('zip',  type='build')
+    depends_on('unzip', type='build')
     depends_on('nspr', when='@:27')
     depends_on('libffi@3.0.9:')
     depends_on('readline', when='@17.0.0:')


### PR DESCRIPTION
`mozjs` report error due to cannot find `zip` and `unzip` command.

```
==> Installing mozjs
==> No binary for mozjs found: installing from source
==> Fetching http://172.19.16.223/spack_mirror/_source-cache/archive/5d/5d12f7e1f5b4a99436685d97b9b7b75f094d33580227aa998c406bbae6f2a687.tar.gz
==> mozjs: Executing phase: 'autoreconf'
==> mozjs: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/home/spack-stage/root/spack-stage-mozjs-1.8.5-fnymn2dya4bd55aqljb2slkqbmgry7xx/spack-src/js/src/configure' '--prefix=/home/spack-develop/opt/spack/linux-ubuntu19.10-aarch64/gcc-9.2.1/mozjs-1.8.5-fnymn2dya4bd55aqljb2slkqbmgry7xx' '--enable-readline' '--enable-threadsafe' '--enable-system-ffi' '--with-system-zlib=/home/spack-develop/opt/spack/linux-ubuntu19.10-aarch64/gcc-9.2.1/zlib-1.2.3-6tp4fbigfscw2c5soh6m2kni44cgkgdm' '--with-system-nspr' '--with-nspr-prefix=/home/spack-develop/opt/spack/linux-ubuntu19.10-aarch64/gcc-9.2.1/nspr-4.13.1-y3nohkcpyts7dhhufyrdvgjqsyhyzehi' '--host=aarch64-linux-gnu' '--disable-readline'
1 error found in build log:
     40    checking for full perl installation... yes
     41    checking for python2.7... /home/spack-develop/opt/spack/linux-ubuntu
           19.10-aarch64/gcc-9.2.1/python-2.7.18-chk2wacavcmltnjr7dmpc75qxfbw6t
           5k/bin/python2.7
     42    checking for doxygen... :
     43    checking for autoconf... /usr/bin/autoconf
     44    checking for unzip... /usr/bin/unzip
     45    checking for zip... no
  >> 46    configure: error: zip not found in $PATH
```