### PR TITLE
Bug fix in neuron spack recipe

### DIFF
--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -104,7 +104,7 @@ class Neuron(CMakePackage):
                                      "./bin/nrnmech_makefile")
 
         # assign_operator is changed to fix wheel support
-        if self.spec.satisfies("+cmake") and self.spec.satisfies("@:7.99"):
+        if self.spec.satisfies("@:7.99"):
             assign_operator = "?="
         else:
             assign_operator = "="

--- a/var/spack/repos/builtin/packages/neuron/package.py
+++ b/var/spack/repos/builtin/packages/neuron/package.py
@@ -103,7 +103,12 @@ class Neuron(CMakePackage):
         nrnmech_makefile = join_path(self.prefix,
                                      "./bin/nrnmech_makefile")
 
-        assign_operator = "?="
+        # assign_operator is changed to fix wheel support
+        if self.spec.satisfies("+cmake") and self.spec.satisfies("@:7.99"):
+            assign_operator = "?="
+        else:
+            assign_operator = "="
+
         filter_file("CC {0} {1}".format(assign_operator, env["CC"]),
                     "CC = {0}".format(cc_compiler),
                     nrnmech_makefile,


### PR DESCRIPTION
  - compiler was not correctly filtered
  - fixes neuronsimulator/nrn/issues/1058