### PR TITLE
updating singularity packages

### DIFF
--- a/var/spack/repos/builtin/packages/singularity-legacy/package.py
+++ b/var/spack/repos/builtin/packages/singularity-legacy/package.py
@@ -13,9 +13,9 @@ class SingularityLegacy(AutotoolsPackage):
        legacy package is pre-version 3.0.0
     """
 
-    homepage = "https://www.sylabs.io/singularity/"
-    url      = "https://github.com/sylabs/singularity/releases/download/2.5.2/singularity-2.5.2.tar.gz"
-    git      = "https://github.com/sylabs/singularity.git"
+    homepage = "https://sylabs.io/singularity/"
+    url      = "https://github.com/hpcng/singularity/releases/download/2.5.2/singularity-2.5.2.tar.gz"
+    git      = "https://github.com/hpcng/singularity.git"
 
     # Versions before 2.5.2 suffer from a serious security problem.
     # https://nvd.nist.gov/vuln/detail/CVE-2018-12021

--- a/var/spack/repos/builtin/packages/singularity/package.py
+++ b/var/spack/repos/builtin/packages/singularity/package.py
@@ -23,13 +23,15 @@ class Singularity(MakefilePackage):
        tail -15 $(spack location -i singularity)/.spack/spack-build-out.txt
     '''
 
-    homepage = "https://www.sylabs.io/singularity/"
-    url      = "https://github.com/sylabs/singularity/releases/download/v3.6.4/singularity-3.6.4.tar.gz"
-    git      = "https://github.com/sylabs/singularity.git"
+    homepage = "https://sylabs.io/singularity/"
+    url      = "https://github.com/hpcng/singularity/releases/download/v3.6.4/singularity-3.6.4.tar.gz"
+    git      = "https://github.com/hpcng/singularity.git"
 
     maintainers = ['alalazo']
     version('master', branch='master')
 
+    version('3.7.2', sha256='36916222e26fb934404f0766e0ff368edac36d7fc31ca571f5f609466609066b')
+    version('3.7.1', sha256='82d2c65063560195ec34551931be3c325b95e8e2009e92755fd7daad346e083c')
     version('3.7.0', sha256='fb96aaf5f462a56a4a5bd2951287bcbbefe8cf543e228e4e955428f386a8d478')
     version('3.6.4', sha256='71233a81d6bb4d686d8dc636b3e3e962a372f54001921c89a12b062cefd9e79f')
     version('3.6.3', sha256='b1a985757a9907d8db0f102fc170a25387e715f7ff31957be964bf47914ea2fd')


### PR DESCRIPTION
This PR will update the Singularity packages to include:

- removing the www from the urls (not needed),
- changing the repository to hpcng (no longer hosted at sylabs). GitHub maintains the old links but this might not be forever)
- Adding 3.7.1 and 3.7.2 versions of Singularity, newly released

Signed-off-by: vsoch <vsoch@users.noreply.github.com>