### PR TITLE
lm-sensors: Fix the build error with linking libiconv

### DIFF
--- a/var/spack/repos/builtin/packages/lm-sensors/lm-sensors-link-iconv.patch
+++ b/var/spack/repos/builtin/packages/lm-sensors/lm-sensors-link-iconv.patch
@@ -1,0 +1,11 @@
+--- spack-src/Makefile	2021-03-14 19:07:07.999802127 +0800
++++ spack-src.patched/Makefile	2021-03-14 19:06:00.970806212 +0800
+@@ -55,7 +55,7 @@
+ # library files (both static and shared) will be installed.
+ LIBDIR := $(PREFIX)/lib
+ 
+-EXLDFLAGS := -Wl,-rpath,$(LIBDIR)
++EXLDFLAGS := -Wl,-rpath,$(LIBDIR) -liconv
+ 
+ # You should not need to change this. It is the directory into which the
+ # executable program files will be installed. BINDIR for programs that are

--- a/var/spack/repos/builtin/packages/lm-sensors/package.py
+++ b/var/spack/repos/builtin/packages/lm-sensors/package.py
@@ -26,7 +26,9 @@ class LmSensors(MakefilePackage):
     version('3-2-0', sha256='ff54bee654f9f317224489fa64aeb659425d58ac3d031fe019c2c072ba19ee9a')
     version('3-1-2', sha256='a587f4f37c0f32ac48575338013ee443a0152d87543e8e702db6161ec0ca1161')
     version('3-1-1', sha256='22b5ab0bab853c34298ff617efb292c5dde7b254596b31ce4c6e90b1d1cf8ad8')
+    patch('lm-sensors-link-iconv.patch')
 
+    depends_on('libiconv', type='link')
     depends_on('bison', type='build')
     depends_on('flex', type='build')
     depends_on('perl', type='run')


### PR DESCRIPTION
When I execute this command using the newest spack as below

```
spack install lm-sensors@3-6-0
```

I encounter the error below:

```
==> Installing lm-sensors-3-6-0-pr63xaffxdnnwrbwzpqrta3bteg7yrib
==> No binary for lm-sensors-3-6-0-pr63xaffxdnnwrbwzpqrta3bteg7yrib found: installing from source
==> Fetching https://spack-llnl-mirror.s3-us-west-2.amazonaws.com/_source-cache/archive/05/0591f9fa0339f0d15e75326d0365871c2d4e2ed8aa1ff759b3a55d3734b7d197.tar.gz
######################################################################## 100.0%
==> lm-sensors: Executing phase: 'edit'
==> lm-sensors: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16'

5 errors found in build log:
     112    rm -f lib/libsensors.so.5
     113    rm -f lib/libsensors.so
     114    ln -sf libsensors.so.5.0.0 lib/libsensors.so.5
     115    ln -sf libsensors.so.5.0.0 lib/libsensors.so
     116    gcc -Wl,-rpath,/usr/local/lib -o prog/sensors/sensors prog/sensors/main.ro prog/sensors/chips.ro  -Llib -lsensors
     117    prog/sensors/main.ro: In function `main':
  >> 118    main.c:(.text.startup+0x23c): undefined reference to `libiconv_open'
  >> 119    main.c:(.text.startup+0x265): undefined reference to `libiconv'
  >> 120    main.c:(.text.startup+0x270): undefined reference to `libiconv_close'
  >> 121    collect2: error: ld returned 1 exit status
  >> 122    make: *** [prog/sensors/sensors] Error 1

See build log for details:
  /tmp/wyf/spack-stage/spack-stage-lm-sensors-3-6-0-pr63xaffxdnnwrbwzpqrta3bteg7yrib/spack-build-out.txt
```

This PR is my solution.