### PR TITLE
adding aocc 3.0 support for WRF 3.9.1.1 and 4.2

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -105,7 +105,8 @@ class Wrf(Package):
     patch("patches/3.9/netcdf_backport.patch", when="@3.9.1.1")
     patch("patches/3.9/tirpc_detect.patch", when="@3.9.1.1")
     patch("patches/3.9/add_aarch64.patch", when="@3.9.1.1")
-    patch("patches/3.9/configure_aocc.patch", when="@3.9.1.1 %aocc@:3.0")
+    patch("patches/3.9/configure_aocc_2.3.patch", when="@3.9.1.1 %aocc@:2.4.0")
+    patch("patches/3.9/configure_aocc_3.0.patch", when="@3.9.1.1 %aocc@3.0.0")
 
     # These patches deal with netcdf & netcdf-fortran being two diff things
     # Patches are based on:
@@ -130,8 +131,9 @@ class Wrf(Package):
     patch("patches/4.2/Makefile.patch", when="@4.2")
     patch("patches/4.2/tirpc_detect.patch", when="@4.2")
     patch("patches/4.2/add_aarch64.patch", when="@4.2")
-    patch("patches/4.2/configure4.2_aocc.patch", when="@4.2 %aocc@:3.0")
-    patch("patches/4.2/derf_fix.patch", when="@4.2 %aocc@:3.0")
+    patch("patches/4.2/configure_aocc_2.3.patch", when="@4.2 %aocc@:2.4.0")
+    patch("patches/4.2/configure_aocc_3.0.patch", when="@4.2 %aocc@3.0.0")
+    patch("patches/4.2/derf_fix.patch", when="@4.2 %aocc")
 
     depends_on("pkgconfig", type=("build"))
     depends_on("libtirpc")

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_2.3.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_2.3.patch
@@ -1,0 +1,53 @@
+--- WRF-3.9.1.1/arch/configure_new.defaults	2021-03-10 10:08:07.885236847 +0530
++++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-03-13 18:48:16.981385006 +0530
+@@ -1917,6 +1917,50 @@
+ CC_TOOLS        =      $(SCC) 
+ 
+ #insert new stanza here
++#############################################################
++#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
++#
++DESCRIPTION     =       AMD AOCC ($SFC/$SCC): EPYC
++DMPARALLEL      =       1
++OMPCPP          =       -D_OPENMP
++OMP             =       -fopenmp
++OMPCC           =       -fopenmp -Mpreprocess
++SFC             =       flang
++SCC             =       clang
++CCOMP           =       clang
++DM_FC           =       mpif90 -DMPI2_SUPPORT
++DM_CC           =       mpicc -DMPI2_SUPPORT
++FC              =       $(DM_FC)
++CC              =       $(DM_CC) -DFSEEKO64_OK
++LD              =       $(FC)
++RWORDSIZE       =       $(NATIVE_RWORDSIZE)
++PROMOTION       =
++ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
++LIBMVEC         =       -mllvm -vector-library=LIBMVEC -mllvm -enable-boscc -Mstack_arrays
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math
++CFLAGS_LOCAL    =       -w $(AOCCOPT)
++LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
++CPLUSPLUSLIB    =
++ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
++FCOPTIM         =       $(AOCCOPT) -fopenmp
++FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
++FCNOOPT         =       -O0 -DFCNOOPT -fopenmp
++FCDEBUG         =       #-g
++FORMAT_FIXED    =       -Mfixed
++FORMAT_FREE     =       -Mfreeform
++FCSUFFIX        =
++BYTESWAPIO      =       -Mbyteswapio
++FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) -fopenmp
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS -fopenmp
++MODULE_SRCH_FLAG =
++TRADFLAG        =       -traditional
++CPP             =       /lib/cpp -P
++AR              =       llvm-ar
++ARFLAGS         =       ru
++M4              =       m4
++RANLIB          =       llvm-ranlib
++RLFLAGS         =
++CC_TOOLS        =       $(SCC)
+ 
+ ###########################################################
+ #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_3.0.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_3.0.patch
@@ -1,7 +1,7 @@
---- WRF-4.2/arch/configure.defaults	2020-04-23 22:38:37.000000000 +0530
-+++ WRF-4.2/arch/configure_42_aocc22.defaults	2020-12-28 08:22:49.253214150 +0530
-@@ -1975,6 +1975,51 @@
-                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
+--- WRF-3.9.1.1/arch/configure_new.defaults	2021-03-10 10:08:07.885236847 +0530
++++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-03-13 18:30:42.191344515 +0530
+@@ -1917,6 +1917,50 @@
+ CC_TOOLS        =      $(SCC) 
  
  #insert new stanza here
 +#############################################################
@@ -17,29 +17,28 @@
 +CCOMP           =       clang
 +DM_FC           =       mpif90 -DMPI2_SUPPORT
 +DM_CC           =       mpicc -DMPI2_SUPPORT
-+FC              =       time $(DM_FC)
++FC              =       $(DM_FC)
 +CC              =       $(DM_CC) -DFSEEKO64_OK
 +LD              =       $(FC)
 +RWORDSIZE       =       $(NATIVE_RWORDSIZE)
 +PROMOTION       =
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
-+LIBMVEC         =       -mllvm -vector-library=LIBMVEC
-+AMDARCHOPT      =       -march=native
-+AOCCOPT         =       -O3 -m64 -Ofast -ffast-math -g $(AMDARCHOPT)
++LIBMVEC         =       -mllvm -vector-library=LIBMVEC-X86 -mllvm -enable-boscc -Mstack_arrays
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math
 +CFLAGS_LOCAL    =       -w $(AOCCOPT)
 +LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
 +CPLUSPLUSLIB    =
 +ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
 +FCOPTIM         =       $(AOCCOPT) -fopenmp
 +FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
-+FCNOOPT         =       -O0 -ffast-math
++FCNOOPT         =       -O0 -DFCNOOPT -fopenmp
 +FCDEBUG         =       #-g
 +FORMAT_FIXED    =       -Mfixed
 +FORMAT_FREE     =       -Mfreeform
 +FCSUFFIX        =
 +BYTESWAPIO      =       -Mbyteswapio
-+FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) -ffast-math
-+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
++FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) -fopenmp
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS -fopenmp
 +MODULE_SRCH_FLAG =
 +TRADFLAG        =       -traditional
 +CPP             =       /lib/cpp -P

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/configure_aocc_2.3.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/configure_aocc_2.3.patch
@@ -1,0 +1,53 @@
+--- WRF-4.2/arch/configure.defaults	2020-04-23 22:38:37.000000000 +0530
++++ WRF-4.2/arch/configure_aocc.defaults	2021-03-13 19:13:26.626442958 +0530
+@@ -1975,6 +1975,50 @@
+                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
+ 
+ #insert new stanza here
++##############################################################
++#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
++#
++DESCRIPTION     =       AMD AOCC ($SFC/$SCC): EPYC
++DMPARALLEL      =       1
++OMPCPP          =       -D_OPENMP
++OMP             =       -fopenmp
++OMPCC           =       -fopenmp -Mpreprocess
++SFC             =       flang
++SCC             =       clang
++CCOMP           =       clang
++DM_FC           =       mpif90 -DMPI2_SUPPORT
++DM_CC           =       mpicc -DMPI2_SUPPORT
++FC              =       time $(DM_FC)
++CC              =       $(DM_CC) -DFSEEKO64_OK
++LD              =       $(FC)
++RWORDSIZE       =       $(NATIVE_RWORDSIZE)
++PROMOTION       =
++ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
++LIBMVEC         =       -mllvm -vector-library=LIBMVEC
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math -g
++CFLAGS_LOCAL    =       -w $(AOCCOPT)
++LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
++CPLUSPLUSLIB    =
++ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
++FCOPTIM         =       $(AOCCOPT) -fopenmp
++FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
++FCNOOPT         =       -O0 -ffast-math
++FCDEBUG         =       #-g
++FORMAT_FIXED    =       -Mfixed
++FORMAT_FREE     =       -Mfreeform
++FCSUFFIX        =
++BYTESWAPIO      =       -Mbyteswapio
++FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) -ffast-math
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
++MODULE_SRCH_FLAG =
++TRADFLAG        =       -traditional
++CPP             =       /lib/cpp -P
++AR              =       llvm-ar
++ARFLAGS         =       ru
++M4              =       m4
++RANLIB          =       llvm-ranlib
++RLFLAGS         =
++CC_TOOLS        =       $(SCC)
+ 
+ ###########################################################
+ #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/configure_aocc_3.0.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/configure_aocc_3.0.patch
@@ -1,10 +1,10 @@
---- WRF-3.9.1.1/arch/configure_new.defaults	2017-08-29 01:59:47.000000000 +0530
-+++ WRF-3.9.1.1/arch/configure_391_aocc22.defaults	2020-12-23 10:06:29.764955610 +0530
-@@ -1917,6 +1917,52 @@
- CC_TOOLS        =      $(SCC) 
+--- WRF-4.2/arch/configure.defaults	2020-04-23 22:38:37.000000000 +0530
++++ WRF-4.2/arch/configure_aocc.defaults	2021-03-13 19:16:59.115451115 +0530
+@@ -1975,6 +1975,50 @@
+                      $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
  
  #insert new stanza here
-+############################################################
++##############################################################
 +#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
 +#
 +DESCRIPTION     =       AMD AOCC ($SFC/$SCC): EPYC
@@ -17,29 +17,28 @@
 +CCOMP           =       clang
 +DM_FC           =       mpif90 -DMPI2_SUPPORT
 +DM_CC           =       mpicc -DMPI2_SUPPORT
-+FC              =       $(DM_FC)
++FC              =       time $(DM_FC)
 +CC              =       $(DM_CC) -DFSEEKO64_OK
 +LD              =       $(FC)
 +RWORDSIZE       =       $(NATIVE_RWORDSIZE)
 +PROMOTION       =
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
-+LIBMVEC         =       -mllvm -vector-library=LIBMVEC
-+AMDARCHOPT      =       -march=native
-+AOCCOPT         =       -O3 -m64 -Ofast -ffast-math $(AMDARCHOPT)
++LIBMVEC         =       -mllvm -vector-library=LIBMVEC-X86
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math -g
 +CFLAGS_LOCAL    =       -w $(AOCCOPT)
 +LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
 +CPLUSPLUSLIB    =
 +ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
 +FCOPTIM         =       $(AOCCOPT) -fopenmp
 +FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
-+FCNOOPT         =       -O0 -DFCNOOPT -fopenmp
++FCNOOPT         =       -O0 -ffast-math
 +FCDEBUG         =       #-g
 +FORMAT_FIXED    =       -Mfixed
 +FORMAT_FREE     =       -Mfreeform
 +FCSUFFIX        =
 +BYTESWAPIO      =       -Mbyteswapio
-+FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) -fopenmp
-+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS -fopenmp
++FCBASEOPTS_NO_G =       -w $(FORMAT_FREE) $(BYTESWAPIO) -ffast-math
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG)
 +MODULE_SRCH_FLAG =
 +TRADFLAG        =       -traditional
 +CPP             =       /lib/cpp -P
@@ -49,7 +48,6 @@
 +RANLIB          =       llvm-ranlib
 +RLFLAGS         =
 +CC_TOOLS        =       $(SCC)
-+
  
  ###########################################################
  #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm


### PR DESCRIPTION
- Added 2 new configure patch files to extend support of AOCC to WRF v3.9.1.1 and v4.2
- Renamed 2 configure patch files to maintain the readability
- Updated package.py to accommodate above 2 changes