### PR TITLE
dos2unix: gettext needed for linking

### DIFF
--- a/var/spack/repos/builtin/packages/dos2unix/package.py
+++ b/var/spack/repos/builtin/packages/dos2unix/package.py
@@ -14,7 +14,7 @@ class Dos2unix(MakefilePackage):
 
     version('7.3.4', sha256='8ccda7bbc5a2f903dafd95900abb5bf5e77a769b572ef25150fde4056c5f30c5')
 
-    depends_on('gettext', type='build')
+    depends_on('gettext')
 
     def install(self, spec, prefix):
         make('prefix={0}'.format(prefix), 'install')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0.

Fixes the following build error:
```
6 errors found in build log:
     4     ==> [2021-03-14-17:13:51.912367] 'make' '-j4'
     5     /Users/Adam/spack/lib/spack/env/clang/clang   -DVER_REVISION=\"7.3.4\" -DVER_DATE=\"2016-05-24\" -DVER_AUTHOR=\"'Erwin Waterlander'\" -DDEBUG=0 -I/usr/local/i
           nclude  -DD2U_UNICODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DENABLE_NLS -DLOCALEDIR=\"/usr/share/locale\" -DPACKAGE=\"dos2unix\" -O2 -Wall -Wextra -Wcon
           version    -c dos2unix.c -o dos2unix.o
     6     /Users/Adam/spack/lib/spack/env/clang/clang   -DVER_REVISION=\"7.3.4\" -DVER_DATE=\"2016-05-24\" -DVER_AUTHOR=\"'Erwin Waterlander'\" -DDEBUG=0 -I/usr/local/i
           nclude  -DD2U_UNICODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DENABLE_NLS -DLOCALEDIR=\"/usr/share/locale\" -DPACKAGE=\"dos2unix\" -O2 -Wall -Wextra -Wcon
           version    -c querycp.c -o querycp.o
     7     /Users/Adam/spack/lib/spack/env/clang/clang   -DVER_REVISION=\"7.3.4\" -DVER_DATE=\"2016-05-24\" -DVER_AUTHOR=\"'Erwin Waterlander'\" -DDEBUG=0 -I/usr/local/i
           nclude  -DD2U_UNICODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DENABLE_NLS -DLOCALEDIR=\"/usr/share/locale\" -DPACKAGE=\"dos2unix\" -O2 -Wall -Wextra -Wcon
           version    -c common.c -o common.o
     8     /Users/Adam/spack/lib/spack/env/clang/clang   -DVER_REVISION=\"7.3.4\" -DVER_DATE=\"2016-05-24\" -DVER_AUTHOR=\"'Erwin Waterlander'\" -DDEBUG=0 -I/usr/local/i
           nclude  -DD2U_UNICODE -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DENABLE_NLS -DLOCALEDIR=\"/usr/share/locale\" -DPACKAGE=\"dos2unix\" -O2 -Wall -Wextra -Wcon
           version    -c unix2dos.c -o unix2dos.o
     9     In file included from dos2unix.c:66:
  >> 10    ./common.h:45:10: fatal error: 'libintl.h' file not found
     11    In file included from common.c:27:
  >> 12    ./common.h:45:10: fatal error: 'libintl.h' file not found
     13    #include <libintl.h>
     14             ^~~~~~~~~~~
     15    #include <libintl.h>
     16             ^~~~~~~~~~~
     17    In file included from unix2dos.c:56:
  >> 18    ./common.h:45:10: fatal error: 'libintl.h' file not found
     19    #include <libintl.h>
     20             ^~~~~~~~~~~
     21    msgfmt -c po/da.po -o po/da.mo
     22    msgfmt -c po/de.po -o po/de.mo
     23    msgfmt -c po/eo.po -o po/eo.mo
     24    msgfmt -c po/es.po -o po/es.mo
     25    msgfmt -c po/fr.po -o po/fr.mo
     26    msgfmt -c po/hu.po -o po/hu.mo
     27    1 error generated.
     28    1 error generated.
  >> 29    make: *** [unix2dos.o] Error 1
     30    make: *** Waiting for unfinished jobs....
  >> 31    make: *** [dos2unix.o] Error 1
     32    1 error generated.
  >> 33    make: *** [common.o] Error 1
```