### PR TITLE
fortrilinos: Fix trilinos depend

### DIFF
--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -47,7 +47,7 @@ class Fortrilinos(CMakePackage):
     variant('shared', default=True, description='Build shared libraries')
 
     # Trilinos version dependencies
-    depends_on('trilinos@13', when='@2.0.0:')
+    depends_on('trilinos@13.0.0:', when='@2.0.0:')
     depends_on('trilinos@12.18.1', when='@2.0.dev3')
     depends_on('trilinos@12.18.1', when='@2.0.dev2')
     depends_on('trilinos@12.17.1', when='@2.0.dev1')


### PR DESCRIPTION
I have fixed the following issues with conflicts detection::

fortrilinos requires trilinos version 13, but spec asked for