### PR TITLE
Make py-boto3 installable again with old concretizer

### DIFF
--- a/var/spack/repos/builtin/packages/py-boto3/package.py
+++ b/var/spack/repos/builtin/packages/py-boto3/package.py
@@ -12,13 +12,18 @@ class PyBoto3(PythonPackage):
     homepage = "https://github.com/boto/boto3"
     pypi = "boto3/boto3-1.10.44.tar.gz"
 
+    version('1.17.27', sha256='fa41987f9f71368013767306d9522b627946a01b4843938a26fb19cc8adb06c0')
     version('1.10.44', sha256='adc0c0269bd65967fd528d7cd826304f381d40d94f2bf2b09f58167e5ac05d86')
     version('1.10.38', sha256='6cdb063b2ae5ac7b93ded6b6b17e3da1325b32232d5ff56e6800018d4786bba6')
     version('1.9.169', sha256='9d8bd0ca309b01265793b7e8d7b88c1df439737d77c8725988f0277bbf58d169')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-botocore@1.20.27:1.20.999',  when='@1.17.27', type=('build', 'run'))
     depends_on('py-botocore@1.13.44:1.13.999',  when='@1.10.44', type=('build', 'run'))
     depends_on('py-botocore@1.13.38:1.13.999',  when='@1.10.38', type=('build', 'run'))
     depends_on('py-botocore@1.12.169:1.12.999', when='@1.9.169', type=('build', 'run'))
+
     depends_on('py-jmespath@0.7.1:0.999', type=('build', 'run'))
-    depends_on('py-s3transfer@0.2.0:0.2.999', type=('build', 'run'))
+
+    depends_on('py-s3transfer@0.3.0:0.3.999', when='@1.17.27', type=('build', 'run'))
+    depends_on('py-s3transfer@0.2.0:0.2.999', when='@:1.10', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-botocore/package.py
+++ b/var/spack/repos/builtin/packages/py-botocore/package.py
@@ -12,6 +12,7 @@ class PyBotocore(PythonPackage):
     homepage = "https://github.com/boto/botocore"
     pypi = "botocore/botocore-1.13.44.tar.gz"
 
+    version('1.20.27', sha256='4477803f07649f4d80b17d054820e7a09bb2cb0792d0decc2812108bc3759c4a')
     version('1.19.52',  sha256='dc5ec23deadbe9327d3c81d03fddf80805c549059baabd80dea605941fe6a221')
     version('1.13.44',  sha256='a4409008c32a3305b9c469c5cc92edb5b79d6fcbf6f56fe126886b545f0a4f3f')
     version('1.13.38',  sha256='15766a367f39dba9de3c6296aaa7da31030f08a0117fd12685e7df682d8acee2')

--- a/var/spack/repos/builtin/packages/py-jmespath/package.py
+++ b/var/spack/repos/builtin/packages/py-jmespath/package.py
@@ -12,6 +12,7 @@ class PyJmespath(PythonPackage):
     homepage = "https://github.com/jmespath/jmespath.py"
     pypi = "jmespath/jmespath-0.9.4.tar.gz"
 
+    version('0.10.0', sha256='b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9')
     version('0.9.4', sha256='bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-python-dateutil/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dateutil/package.py
@@ -12,6 +12,7 @@ class PyPythonDateutil(PythonPackage):
     homepage = "https://dateutil.readthedocs.io/"
     pypi = "python-dateutil/python-dateutil-2.8.0.tar.gz"
 
+    version('2.8.1', sha256='73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c')
     version('2.8.0', sha256='c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e')
     version('2.7.5', sha256='88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02')
     version('2.5.2', sha256='063907ef47f6e187b8fe0728952e4effb587a34f2dc356888646f9b71fbb2e4b')

--- a/var/spack/repos/builtin/packages/py-s3transfer/package.py
+++ b/var/spack/repos/builtin/packages/py-s3transfer/package.py
@@ -12,6 +12,7 @@ class PyS3transfer(PythonPackage):
     homepage = "https://github.com/boto/s3transfer"
     pypi = "s3transfer/s3transfer-0.2.1.tar.gz"
 
+    version('0.3.4', sha256='7fdddb4f22275cf1d32129e21f056337fd2a80b6ccef1664528145b72c49e6d2')
     version('0.2.1', sha256='6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Currently `spack install py-boto3` just errors with an unsatisfiable version requirement because py-botocore's version was bumped but not py-boto3.

I've checked the dependencies by hand (looking in setup.py files and requirements.txt and what not, the state of python is very sad...) and they should be correct.
