### PR TITLE
Add ncurses to hwloc take 2

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -90,6 +90,7 @@ class Hwloc(AutotoolsPackage):
     depends_on('libxml2', when='+libxml2')
     depends_on('cairo', when='+cairo')
     depends_on('numactl', when='@:1.11.11 platform=linux')
+    depends_on('ncurses')
 
     # When mpi=openmpi, this introduces an unresolvable dependency.
     # See https://github.com/spack/spack/issues/15836 for details

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -90,6 +90,9 @@ class Hwloc(AutotoolsPackage):
     depends_on('libxml2', when='+libxml2')
     depends_on('cairo', when='+cairo')
     depends_on('numactl', when='@:1.11.11 platform=linux')
+
+    # see https://github.com/open-mpi/hwloc/pull/417
+    depends_on('ncurses ~termlib', when='@:2.2')
     depends_on('ncurses')
 
     # When mpi=openmpi, this introduces an unresolvable dependency.


### PR DESCRIPTION
closes #18207

- Added missing ncurses dependency for hwloc
- Fix ncurses issue with termlib for hwloc@:2.2

Supersedes https://github.com/spack/spack/pull/18207 since I couldn't push commits there.

ncurses is a hard dependency for more than 10 years according to git blame.
