### PR TITLE
Fix unicode bugs in boost/package.py

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -159,7 +159,13 @@ class Boost(Package):
             description='Default symbol visibility in compiled libraries '
             '(1.69.0 or later)')
 
+    # Unicode support
     depends_on('icu4c', when='+icu')
+    depends_on('icu4c cxxstd=11', when='+icu cxxstd=11')
+    depends_on('icu4c cxxstd=14', when='+icu cxxstd=14')
+    depends_on('icu4c cxxstd=17', when='+icu cxxstd=17')
+    conflicts('cxxstd=98', when='+icu')  # Requires c++11 at least
+
     depends_on('python', when='+python')
     depends_on('mpi', when='+mpi')
     depends_on('bzip2', when='+iostreams')
@@ -331,6 +337,11 @@ class Boost(Package):
         if '+python' in spec:
             options.append('--with-python=%s' % spec['python'].command.path)
 
+        if '~icu' in spec:
+            options.append('--without-icu')
+        else:
+            options.append('--with-icu')
+
         with open('user-config.jam', 'w') as f:
             # Boost may end up using gcc even though clang+gfortran is set in
             # compilers.yaml. Make sure this does not happen:
@@ -366,8 +377,10 @@ class Boost(Package):
         else:
             options.append('variant=release')
 
-        if '+icu_support' in spec:
-            options.extend(['-s', 'ICU_PATH=%s' % spec['icu'].prefix])
+        if '+icu' in spec:
+            options.extend(['-s', 'ICU_PATH=%s' % spec['icu4c'].prefix])
+        else:
+            options.append('--disable-icu')
 
         if '+iostreams' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -337,10 +337,10 @@ class Boost(Package):
         if '+python' in spec:
             options.append('--with-python=%s' % spec['python'].command.path)
 
-        if '~icu' in spec:
-            options.append('--without-icu')
-        else:
+        if '+icu' in spec:
             options.append('--with-icu')
+        else:
+            options.append('--without-icu')
 
         with open('user-config.jam', 'w') as f:
             # Boost may end up using gcc even though clang+gfortran is set in


### PR DESCRIPTION
Closes https://github.com/spack/spack/issues/22291

Forces ICU off when ~icu is provided (otherwise it'll fall back to searching system paths as in #22291)

Forces the correct cxxstd when +icu is provided (otherwise boost disables it silently)

