### PR TITLE
Make boost minimal and composable

### DIFF
--- a/var/spack/repos/builtin/packages/akantu/package.py
+++ b/var/spack/repos/builtin/packages/akantu/package.py
@@ -29,8 +29,12 @@ class Akantu(CMakePackage):
     variant('python', default=False,
             description="Activates python bindings")
 
+<<<<<<< HEAD
     depends_on('boost@:1.66', when='@:3.0')
     depends_on('boost')
+=======
+    depends_on('boost@:1.66', when='@:3.0.99')
+>>>>>>> 1a2332cdf4 (Make boost composable)
     depends_on('lapack')
     depends_on('cmake@3.5.1:', type='build')
     depends_on('python', when='+python', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/akantu/package.py
+++ b/var/spack/repos/builtin/packages/akantu/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Akantu(CMakePackage):
@@ -29,12 +30,8 @@ class Akantu(CMakePackage):
     variant('python', default=False,
             description="Activates python bindings")
 
-<<<<<<< HEAD
     depends_on('boost@:1.66', when='@:3.0')
-    depends_on('boost')
-=======
-    depends_on('boost@:1.66', when='@:3.0.99')
->>>>>>> 1a2332cdf4 (Make boost composable)
+    depends_on(Boost.with_default_variants) 
     depends_on('lapack')
     depends_on('cmake@3.5.1:', type='build')
     depends_on('python', when='+python', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/amp/package.py
+++ b/var/spack/repos/builtin/packages/amp/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Amp(CMakePackage):
@@ -34,7 +35,11 @@ class Amp(CMakePackage):
     # Everything should be compiled position independent (-fpic)
     depends_on('blas')
     depends_on('lapack')
-    depends_on('boost', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('hdf5', when='+hdf5')
     depends_on('hypre', when='+hypre')
     depends_on('libmesh', when='+libmesh')

--- a/var/spack/repos/builtin/packages/aoflagger/package.py
+++ b/var/spack/repos/builtin/packages/aoflagger/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Aoflagger(CMakePackage):
@@ -18,6 +19,11 @@ class Aoflagger(CMakePackage):
     depends_on('casacore+python~fftpack@1.10:')
     depends_on('fftw~mpi@3.0:')
     depends_on('boost+python@:1.66.99')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('libxml2')
     depends_on('lapack')
     depends_on('cfitsio')

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -6,6 +6,7 @@
 import sys
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Apex(CMakePackage):
@@ -65,6 +66,11 @@ class Apex(CMakePackage):
     depends_on('hip', when='+hip')
     depends_on('roctracer-dev', when='+hip')
     depends_on('rocm-smi-lib', when='+hip')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('boost@1.54:', when='+boost')
 
     # Conflicts

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Arrayfire(CMakePackage, CudaPackage):
@@ -24,6 +25,11 @@ class Arrayfire(CMakePackage, CudaPackage):
     variant('opencl', default=False, description='Enable OpenCL backend')
 
     depends_on('boost@1.65:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('fftw-api@3:')
     depends_on('blas')
     depends_on('cuda@7.5:', when='+cuda')

--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Arrow(CMakePackage, CudaPackage):
@@ -26,6 +27,11 @@ class Arrow(CMakePackage, CudaPackage):
     version('0.8.0', sha256='c61a60c298c30546fc0b418a35be66ef330fb81b06c49928acca7f1a34671d54')
 
     depends_on('boost@1.60:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cmake@3.2.0:', type='build')
     depends_on('flatbuffers build_type=Release')  # only Release contains flatc
     depends_on('python', when='+python')

--- a/var/spack/repos/builtin/packages/aspcud/package.py
+++ b/var/spack/repos/builtin/packages/aspcud/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Aspcud(CMakePackage):
@@ -22,6 +23,11 @@ class Aspcud(CMakePackage):
     version('1.9.4', sha256='3645f08b079e1cc80e24cd2d7ae5172a52476d84e3ec5e6a6c0034492a6ea885')
 
     depends_on('boost@1.74:', type=('build'), when='@1.9.5:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type=('build'), when='@1.9.5:')
     depends_on('cmake', type=('build'))
     depends_on('re2c', type=('build'))
     depends_on('clingo')

--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Assimp(CMakePackage):
@@ -26,7 +27,10 @@ class Assimp(CMakePackage):
             description='Enables the build of shared libraries')
 
     depends_on('zlib')
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -6,6 +6,7 @@
 import glob
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Augustus(MakefilePackage):
@@ -29,7 +30,11 @@ class Augustus(MakefilePackage):
     depends_on('python', when='@3.3.1:', type=('build', 'run'))
     depends_on('bamtools')
     depends_on('gsl')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('zlib')
     depends_on('htslib')
     depends_on('bcftools')

--- a/var/spack/repos/builtin/packages/autodock-vina/package.py
+++ b/var/spack/repos/builtin/packages/autodock-vina/package.py
@@ -3,9 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+
 import sys
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class AutodockVina(MakefilePackage):
@@ -17,6 +19,11 @@ class AutodockVina(MakefilePackage):
     version('1_1_2', sha256='b86412d316960b1e4e319401719daf57ff009229d91654d623c3cf09339f6776')
 
     depends_on('boost@1.65.0')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # Replacing depecrated function call of boost with current function call
     patch('main.patch')

--- a/var/spack/repos/builtin/packages/automaded/package.py
+++ b/var/spack/repos/builtin/packages/automaded/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Automaded(CMakePackage):
@@ -24,7 +25,11 @@ class Automaded(CMakePackage):
     version('1.0', sha256='600740cdd594cc6968c7bcb285d0829eb0ddbd5597c32c06c6ae5d9929a2625d')
 
     depends_on('mpi')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('callpath')
     depends_on('cmake@2.8:', type='build')
 

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -3,13 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import glob
 import os
 
 import llnl.util.tty as tty
 
 from spack import *
-
+from spack.pkg.builtin.boost import Boost
 
 # This application uses cmake to build, but they wrap it with a
 # configure script that performs dark magic.  This package does it
@@ -28,6 +29,11 @@ class Bcl2fastq2(Package):
               msg='malloc.h/etc requirements break build on macs')
 
     depends_on('boost@1.54.0:1.55')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cmake@2.8.9:', type='build')
     depends_on('libxml2@2.7.8')
     depends_on('libxslt@1.1.26~crypto')

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import glob
 import os
 
@@ -11,6 +10,7 @@ import llnl.util.tty as tty
 
 from spack import *
 from spack.pkg.builtin.boost import Boost
+
 
 # This application uses cmake to build, but they wrap it with a
 # configure script that performs dark magic.  This package does it

--- a/var/spack/repos/builtin/packages/biobloom/package.py
+++ b/var/spack/repos/builtin/packages/biobloom/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Biobloom(AutotoolsPackage):
@@ -15,7 +16,10 @@ class Biobloom(AutotoolsPackage):
 
     version('2.2.0', sha256='5d09f8690f0b6402f967ac09c5b0f769961f3fe3791000f8f73af6af7324f02c')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('sdsl-lite')
     depends_on('sparsehash')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/blasr/package.py
+++ b/var/spack/repos/builtin/packages/blasr/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Blasr(Package):
@@ -20,7 +21,11 @@ class Blasr(Package):
     depends_on('hdf5+cxx@1.8.12:1.8')
     depends_on('htslib')
     depends_on('zlib')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('pbbam')
     depends_on('blasr-libcpp')
     depends_on('python', type='build')

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -8,8 +8,8 @@ import os
 import llnl.util.tty as tty
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 from spack.package_test import compare_output
+from spack.pkg.builtin.boost import Boost
 from spack.util.executable import Executable
 
 

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -8,6 +8,7 @@ import os
 import llnl.util.tty as tty
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 from spack.package_test import compare_output
 from spack.util.executable import Executable
 
@@ -75,6 +76,11 @@ class Bohrium(CMakePackage, CudaPackage):
     #
     depends_on('cmake@2.8:', type="build")
     depends_on('boost+system+serialization+filesystem+regex')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # cuda dependencies managed by CudaPackage class
     depends_on('opencl', when="+opencl")

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -79,26 +79,10 @@ class Boost(Package):
     version('1.34.1', sha256='0f866c75b025a4f1340117a106595cc0675f48ba1e5a9b5c221ec7f19e96ec4c')
     version('1.34.0', sha256='455cb8fa41b759272768257c2e7bdc5c47ec113245dfa533f275e787a855efd2')
 
-    default_install_libs = set(['atomic',
-                                'chrono',
-                                'date_time',
-                                'exception',
-                                'filesystem',
-                                'graph',
-                                'iostreams',
-                                'locale',
-                                'log',
-                                'math',
-                                'program_options',
-                                'random',
-                                'regex',
-                                'serialization',
-                                'signals',
-                                'system',
-                                'test',
-                                'thread',
-                                'timer',
-                                'wave'])
+    with_default_variants = ("boost+atomic+chrono+date_time+exception+filesystem"
+                             "+graph+iostreams+locale+log+math+program_options"
+                             "+random+regex+serialization+signals+system+test"
+                             "+thread+timer+wave")
 
     # mpi/python are not installed by default because they pull in many
     # dependencies and/or because there is a great deal of customization
@@ -107,13 +91,37 @@ class Boost(Package):
     # Boost.Container can be both header-only and compiled. '+container'
     # indicates the compiled version which requires Extended Allocator
     # support. The header-only library is installed when no variant is given.
-    default_noinstall_libs\
-        = set(['container', 'context', 'coroutine', 'fiber', 'mpi', 'python'])
-
-    all_libs = default_install_libs | default_noinstall_libs
+    all_libs = [
+        'atomic',
+        'chrono',
+        'container',
+        'context',
+        'coroutine',
+        'date_time',
+        'exception',
+        'fiber',
+        'filesystem',
+        'graph',
+        'iostreams',
+        'locale',
+        'log',
+        'math',
+        'mpi',
+        'program_options',
+        'python',
+        'random',
+        'regex',
+        'serialization',
+        'signals',
+        'system',
+        'test',
+        'thread',
+        'timer',
+        'wave'
+    ]
 
     for lib in all_libs:
-        variant(lib, default=(lib not in default_noinstall_libs),
+        variant(lib, default=False,
                 description="Compile with {0} library".format(lib))
 
     @property

--- a/var/spack/repos/builtin/packages/branson/package.py
+++ b/var/spack/repos/builtin/packages/branson/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Branson(CMakePackage):
@@ -25,7 +26,11 @@ class Branson(CMakePackage):
     version('0.8',  sha256='85ffee110f89be00c37798700508b66b0d15de1d98c54328b6d02a9eb2cf1cb8')
 
     depends_on('mpi@2:')
-    depends_on('boost', when='@:0.81')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@:0.81')
     depends_on('metis')
     depends_on('parmetis', when='@:0.81')
 

--- a/var/spack/repos/builtin/packages/bridger/package.py
+++ b/var/spack/repos/builtin/packages/bridger/package.py
@@ -8,6 +8,7 @@ from os import symlink
 from spack import *
 from spack.pkg.builtin.boost import Boost
 
+
 class Bridger(MakefilePackage, SourceforgePackage):
     """Bridger : An Efficient De novo Transcriptome Assembler For
        RNA-Seq Data"""

--- a/var/spack/repos/builtin/packages/bridger/package.py
+++ b/var/spack/repos/builtin/packages/bridger/package.py
@@ -6,7 +6,7 @@
 from os import symlink
 
 from spack import *
-
+from spack.pkg.builtin.boost import Boost
 
 class Bridger(MakefilePackage, SourceforgePackage):
     """Bridger : An Efficient De novo Transcriptome Assembler For
@@ -17,7 +17,10 @@ class Bridger(MakefilePackage, SourceforgePackage):
 
     version('2014-12-01', sha256='8fbec8603ea8ad2162cbd0c658e4e0a4af6453bdb53310b4b7e0d112e40b5737')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('perl', type='run')
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/caffe/package.py
+++ b/var/spack/repos/builtin/packages/caffe/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Caffe(CMakePackage, CudaPackage):
@@ -33,8 +34,12 @@ class Caffe(CMakePackage, CudaPackage):
     variant('matlab', default=False,
             description='Build Matlab wrapper')
 
-    depends_on('boost')
     depends_on('boost +python', when='+python')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+python')
     depends_on('cuda', when='+cuda')
     depends_on('blas')
     depends_on('protobuf')

--- a/var/spack/repos/builtin/packages/cantera/package.py
+++ b/var/spack/repos/builtin/packages/cantera/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Cantera(SConsPackage):
@@ -31,7 +32,11 @@ class Cantera(SConsPackage):
     depends_on('fmt@3.0.0:3.0.2', when='@2.3.0:')
     depends_on('googletest+gmock', when='@2.3.0:')
     depends_on('eigen',           when='@2.3.0:')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('sundials@:3.1.2+lapack', when='+sundials')  # must be compiled with -fPIC
     depends_on('blas')
     depends_on('lapack')

--- a/var/spack/repos/builtin/packages/canu/package.py
+++ b/var/spack/repos/builtin/packages/canu/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Canu(MakefilePackage):
@@ -24,6 +25,11 @@ class Canu(MakefilePackage):
     depends_on('perl', type='run')
     # build fail when using boost@1.71.0:1.73.0 by canu@1.8:2.0
     depends_on('boost@:1.70.0')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     build_directory = 'src'
     build_targets = ['clean']

--- a/var/spack/repos/builtin/packages/casacore/package.py
+++ b/var/spack/repos/builtin/packages/casacore/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Casacore(CMakePackage):
@@ -60,6 +61,11 @@ class Casacore(CMakePackage):
     depends_on('mpi', when='+adios2')
     depends_on('python@2.6:', when='+python')
     depends_on('boost+python', when='+python')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+python')
     depends_on('py-numpy', when='+python')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/casper/package.py
+++ b/var/spack/repos/builtin/packages/casper/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Casper(MakefilePackage):
@@ -18,7 +19,11 @@ class Casper(MakefilePackage):
     version('0.8.2', sha256='3005e165cebf8ce4e12815b7660a833e0733441b5c7e5ecbfdccef7414b0c914')
 
     depends_on('jellyfish@2.2.3:')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     conflicts('%gcc@7.1.0')
 

--- a/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
@@ -6,7 +6,7 @@
 import os
 
 from spack import *
-
+from spack.pkg.builtin.boost import Boost
 
 class CbtfArgonavisGui(QMakePackage):
     """CBTF Argo Navis GUI project contains the GUI that views OpenSpeedShop
@@ -23,6 +23,11 @@ class CbtfArgonavisGui(QMakePackage):
     depends_on('qt@5.10.0:')
 
     depends_on("boost@1.66.0:1.69.0")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')

--- a/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis-gui/package.py
@@ -8,6 +8,7 @@ import os
 from spack import *
 from spack.pkg.builtin.boost import Boost
 
+
 class CbtfArgonavisGui(QMakePackage):
     """CBTF Argo Navis GUI project contains the GUI that views OpenSpeedShop
        performance information by loading in the Sqlite database files.

--- a/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class CbtfArgonavis(CMakePackage):
@@ -37,6 +38,11 @@ class CbtfArgonavis(CMakePackage):
 
     # For boost
     depends_on("boost@1.70.0:")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop', type=('build', 'link', 'run'))

--- a/var/spack/repos/builtin/packages/cbtf-krell/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-krell/package.py
@@ -6,6 +6,7 @@
 import spack
 import spack.store
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class CbtfKrell(CMakePackage):
@@ -54,6 +55,11 @@ class CbtfKrell(CMakePackage):
 
     # For boost
     depends_on("boost@1.70.0:")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # For Dyninst
     depends_on("dyninst@10.1.0", when='@develop')

--- a/var/spack/repos/builtin/packages/cbtf/package.py
+++ b/var/spack/repos/builtin/packages/cbtf/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Cbtf(CMakePackage):
@@ -37,6 +38,11 @@ class Cbtf(CMakePackage):
     depends_on("libtirpc", type='link')
 
     depends_on("boost@1.70.0:")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # For MRNet
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Cgal(CMakePackage):
@@ -53,6 +54,11 @@ class Cgal(CMakePackage):
 
     # Essential Third Party Libraries
     depends_on('boost+thread+system')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('gmp')
     depends_on('mpfr')
 
@@ -76,7 +82,7 @@ class Cgal(CMakePackage):
     # depends_on('esbtl')
     # depends_on('intel-tbb')
 
-    conflicts('~header_only', when='@:4.9',
+    conflicts('~header-only', when='@:4.9',
               msg="Header only builds became optional in 4.9,"
                   " default thereafter")
 

--- a/var/spack/repos/builtin/packages/channelflow/package.py
+++ b/var/spack/repos/builtin/packages/channelflow/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Channelflow(CMakePackage):
@@ -39,6 +40,11 @@ class Channelflow(CMakePackage):
 
     # Python bindings
     depends_on('boost+python', when='+python')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+python')
 
     conflicts('~mpi', when='netcdf=parallel', msg='Parallel NetCDF requires MPI')
     conflicts(

--- a/var/spack/repos/builtin/packages/chill/package.py
+++ b/var/spack/repos/builtin/packages/chill/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Chill(AutotoolsPackage):
@@ -19,6 +20,11 @@ class Chill(AutotoolsPackage):
     version('0.3', sha256='574b622368a6bfaadbe9c1fa02fabefdc6c006069246f67d299f943b7e1d8aa3', deprecated=True)
 
     depends_on('boost@1.66.0 cxxstd=11', type='build')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type='build')
     depends_on('rose@0.9.13.0: +cxx11', type=('build', 'run'))
     depends_on('autoconf', type='build')
     depends_on('automake@1.14:',  type='build')

--- a/var/spack/repos/builtin/packages/cleverleaf/package.py
+++ b/var/spack/repos/builtin/packages/cleverleaf/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Cleverleaf(CMakePackage):
@@ -21,7 +22,11 @@ class Cleverleaf(CMakePackage):
 
     depends_on('samrai@3.8.0:')
     depends_on('hdf5+mpi')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cmake@3.1:', type='build')
 
     # The Fujitsu compiler requires the '--linkfortran'

--- a/var/spack/repos/builtin/packages/clfft/package.py
+++ b/var/spack/repos/builtin/packages/clfft/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Clfft(CMakePackage):
@@ -19,6 +20,11 @@ class Clfft(CMakePackage):
 
     depends_on('opencl@1.2:')
     depends_on('boost@1.33.0:', when='+client')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+client')
 
     patch('https://github.com/clMathLibraries/clFFT/commit/eea7dbc888367b8dbea602ba539eb1a9cbc118d9.patch',
           sha256='3148d5937077def301b30b913bc2437df869204fca1de4385ccd46e3b98b13aa', when='@2.12.2')

--- a/var/spack/repos/builtin/packages/cntk/package.py
+++ b/var/spack/repos/builtin/packages/cntk/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Cntk(Package):
@@ -28,7 +29,11 @@ class Cntk(Package):
     depends_on('libzip')
     depends_on('openblas')
     depends_on('mpi')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('protobuf')
     # CNTK depends on kaldi@c02e8.
     # See https://github.com/Microsoft/CNTK/blob/master/Tools/docker/CNTK-CPUOnly-Image/Dockerfile#L105-L125

--- a/var/spack/repos/builtin/packages/coin3d/package.py
+++ b/var/spack/repos/builtin/packages/coin3d/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Coin3d(AutotoolsPackage):
@@ -18,6 +19,11 @@ class Coin3d(AutotoolsPackage):
     version('2.0.0', sha256='6d26435aa962d085b7accd306a0b478069a7de1bc5ca24e22344971852dd097c')
 
     depends_on('boost@1.45.0:', type='build')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type='build')
     depends_on('doxygen', when='+html', type='build')
     depends_on('perl', when='+html', type='build')
     depends_on('glu', type='link')

--- a/var/spack/repos/builtin/packages/cpprestsdk/package.py
+++ b/var/spack/repos/builtin/packages/cpprestsdk/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Cpprestsdk(CMakePackage):
@@ -19,6 +20,11 @@ class Cpprestsdk(CMakePackage):
     version('2.9.1', sha256='537358760acd782f4d2ed3a85d92247b4fc423aff9c85347dc31dbb0ab9bab16')
 
     depends_on('boost@:1.69.0')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('openssl')
 
     # Ref: https://github.com/microsoft/cpprestsdk/commit/f9f518e4ad84577eb684ad8235181e4495299af4

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Dakota(CMakePackage):
@@ -46,6 +47,11 @@ class Dakota(CMakePackage):
     depends_on('python')
     depends_on('perl-data-dumper', type='build', when='@6.12:')
     depends_on('boost@:1.68.0', when='@:6.12')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@:6.12')
     depends_on('cmake@2.8.9:', type='build')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/damaris/package.py
+++ b/var/spack/repos/builtin/packages/damaris/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Damaris(CMakePackage):
@@ -29,6 +30,11 @@ class Damaris(CMakePackage):
     depends_on('mpi')
     depends_on('cmake@3.18.0:', type=('build'))
     depends_on('boost +thread+log+filesystem+date_time @1.67:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('xsd')
     depends_on('xerces-c')
     depends_on('hdf5@1.8.20:', when='+hdf5')

--- a/var/spack/repos/builtin/packages/dbow2/package.py
+++ b/var/spack/repos/builtin/packages/dbow2/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.pkg.builtin.boost import Boost
+
 
 class Dbow2(CMakePackage):
     """DBoW2 is an improved version of the DBow library, an open source C++
@@ -17,6 +19,10 @@ class Dbow2(CMakePackage):
 
     depends_on('cmake@3.0:', type='build')
     depends_on('opencv+calib3d+core+features2d+highgui+imgproc')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('dlib')
     depends_on('eigen', type='link')

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Dd4hep(CMakePackage):
@@ -79,8 +80,13 @@ class Dd4hep(CMakePackage):
     depends_on('cmake @3.12:', type='build')
     depends_on('ninja', type='build')
     depends_on('boost @1.49:')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('root @6.08: +gdml +math +python')
     depends_on('root @6.08: +gdml +math +python +x +opengl', when="+ddeve")
+
     extends('python')
     depends_on('xerces-c', when='+xercesc')
     depends_on('geant4@10.2.2:', when='+ddg4')

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -8,6 +8,7 @@ import os
 from spack import *
 from spack.pkg.builtin.boost import Boost
 
+
 class Dealii(CMakePackage, CudaPackage):
     """C++ software library providing well-documented tools to build finite
     element codes for a broad variety of PDEs."""

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -6,7 +6,7 @@
 import os
 
 from spack import *
-
+from spack.pkg.builtin.boost import Boost
 
 class Dealii(CMakePackage, CudaPackage):
     """C++ software library providing well-documented tools to build finite
@@ -150,6 +150,11 @@ class Dealii(CMakePackage, CudaPackage):
     depends_on('boost cxxstd=14', when='cxxstd=14')
     depends_on('boost cxxstd=17', when='cxxstd=17')
     depends_on('bzip2',           when='@:8')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('lapack')
     depends_on('ninja',           type='build')
     depends_on('suite-sparse')

--- a/var/spack/repos/builtin/packages/delly2/package.py
+++ b/var/spack/repos/builtin/packages/delly2/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Delly2(MakefilePackage):
@@ -22,6 +23,10 @@ class Delly2(MakefilePackage):
 
     depends_on('htslib', type=('build', 'link'))
     depends_on('boost', type=('build', 'link'))
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('bcftools', type='run')
 
     def edit(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/denovogear/package.py
+++ b/var/spack/repos/builtin/packages/denovogear/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Denovogear(CMakePackage):
@@ -20,6 +21,11 @@ class Denovogear(CMakePackage):
 
     depends_on('cmake@3.1:', type=('build'))
     depends_on('boost@1.47:1.60', type=('build'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type=('build'))
     depends_on('htslib@1.2:', type=('build'))
     depends_on('eigen', type=('build'))
     depends_on('zlib', type=('link'))

--- a/var/spack/repos/builtin/packages/dimemas/package.py
+++ b/var/spack/repos/builtin/packages/dimemas/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Dimemas(AutotoolsPackage):
@@ -22,6 +23,11 @@ class Dimemas(AutotoolsPackage):
     depends_on('bison', type=('build', 'link', 'run'))
     depends_on('flex', type=('build', 'link', 'run'))
     depends_on('boost@1.65.0+program_options cxxstd=11', type=('build', 'link'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type=('build', 'link'))
 
     def autoreconf(self, spec, prefix):
         autoreconf('--install', '--verbose', '--force')

--- a/var/spack/repos/builtin/packages/dire/package.py
+++ b/var/spack/repos/builtin/packages/dire/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Dire(Package):
@@ -23,7 +24,11 @@ class Dire(Package):
     version('2.004', sha256='8cc1213b58fec744fdaa50834560a14b141de99efb2c3e3d3d47f3d6d84b179f')
 
     depends_on('zlib')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('lhapdf')
     depends_on('hepmc')
     depends_on('pythia8@8.226:')

--- a/var/spack/repos/builtin/packages/dssp/package.py
+++ b/var/spack/repos/builtin/packages/dssp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Dssp(AutotoolsPackage):
@@ -20,6 +21,11 @@ class Dssp(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('boost@1.48:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # pdb data download.
     # 1ALK.pdb - PDB (protein data bank) : https://www.rcsb.org/

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -6,7 +6,6 @@
 import os.path
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Dyninst(CMakePackage):

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -6,6 +6,7 @@
 import os.path
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Dyninst(CMakePackage):

--- a/var/spack/repos/builtin/packages/dysco/package.py
+++ b/var/spack/repos/builtin/packages/dysco/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Dysco(CMakePackage):
@@ -17,3 +18,8 @@ class Dysco(CMakePackage):
     depends_on('casacore')
     depends_on('gsl')
     depends_on('boost+date_time+python')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)

--- a/var/spack/repos/builtin/packages/ecflow/package.py
+++ b/var/spack/repos/builtin/packages/ecflow/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Ecflow(CMakePackage):
@@ -30,6 +31,11 @@ class Ecflow(CMakePackage):
     # Boost-1.7X release not working well on serialization
     depends_on('boost@1.53:1.69+python')
     depends_on('boost@1.53:1.69+pic', when='+static_boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('qt@5:', when='+ui')
     depends_on('cmake@2.12.11:', type='build')
 

--- a/var/spack/repos/builtin/packages/erne/package.py
+++ b/var/spack/repos/builtin/packages/erne/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Erne(AutotoolsPackage):
@@ -18,6 +19,11 @@ class Erne(AutotoolsPackage):
             description='Build with OpenMPI support')
 
     depends_on('boost@1.40.0:', type=('build', 'link', 'run'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type=('build', 'link', 'run'))
     depends_on('openmpi', type=('build', 'run'), when='+mpi')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/ethminer/package.py
+++ b/var/spack/repos/builtin/packages/ethminer/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Ethminer(CMakePackage):
@@ -20,7 +21,11 @@ class Ethminer(CMakePackage):
             description='Build with Stratum protocol support.')
 
     depends_on('python')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('json-c')
     depends_on('curl')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/express/package.py
+++ b/var/spack/repos/builtin/packages/express/package.py
@@ -7,6 +7,7 @@ import glob
 import os.path
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Express(CMakePackage):
@@ -21,7 +22,10 @@ class Express(CMakePackage):
     version('1.5.2', sha256='25a63cca3dac6bd0daf04d2f0b2275e47d2190c90522bd231b1d7a875a59a52e')
     version('1.5.1', sha256='fa3522de9cc25f1ede22fa196928912a6da2a2038681911115ec3e4da3d61293')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('bamtools')
     depends_on('zlib')
 

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 # typical working line with extrae 3.0.1
 # ./configure
@@ -50,7 +51,11 @@ class Extrae(AutotoolsPackage):
 
     depends_on("mpi")
     depends_on("libunwind")
-    depends_on("boost")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("libdwarf")
     depends_on("papi")
     depends_on("elf", type="link")

--- a/var/spack/repos/builtin/packages/fairlogger/package.py
+++ b/var/spack/repos/builtin/packages/fairlogger/package.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Fairlogger(CMakePackage):
@@ -48,6 +49,11 @@ class Fairlogger(CMakePackage):
     depends_on('git', type='build', when='@develop')
 
     depends_on('boost', when='+pretty')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+pretty')
     conflicts('^boost@1.70:', when='^cmake@:3.14')
     depends_on('fmt@5.3.0:5', when='@1.6.0:1.6.1')
     depends_on('fmt@5.3.0:', when='@1.6.2:')

--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Faodel(CMakePackage):
@@ -37,6 +38,11 @@ class Faodel(CMakePackage):
 
     depends_on('mpi', when='+mpi')
     depends_on('boost@1.60.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cmake@3.8.0:', type='build')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('hdf5~mpi', when='+hdf5~mpi')

--- a/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
@@ -29,6 +29,7 @@ class FenicsDolfinx(CMakePackage):
     depends_on("mpi")
     depends_on("hdf5+mpi")
     depends_on("boost@1.7.0:+filesystem+program_options+timer")
+
     depends_on("petsc+mpi+shared")
     depends_on("petsc+mpi+shared@3.15.0:", when="@0.1.0")
     depends_on("scotch+mpi")

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Fenics(CMakePackage):
@@ -98,6 +99,11 @@ class Fenics(CMakePackage):
 
     depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono')
     depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono@1.68.0', when='@:2018')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     depends_on('mpi', when='+mpi')
     depends_on('hdf5+hl+fortran', when='+hdf5+petsc')

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Flann(CMakePackage):
@@ -66,6 +67,11 @@ class Flann(CMakePackage):
     # HDF5_IS_PARALLEL actually comes from hdf5+mpi
     # https://github.com/mariusmuja/flann/blob/06a49513138009d19a1f4e0ace67fbff13270c69/CMakeLists.txt#L108-L112
     depends_on("boost+mpi+system+serialization+thread", when="+mpi ^hdf5+mpi")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when="+mpi ^hdf5+mpi")
 
     # Doc deps
     depends_on("texlive", when="+doc")

--- a/var/spack/repos/builtin/packages/flecsale/package.py
+++ b/var/spack/repos/builtin/packages/flecsale/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Flecsale(CMakePackage):
@@ -26,6 +27,11 @@ class Flecsale(CMakePackage):
     depends_on("openssl")
     depends_on("boost~mpi", when='~mpi')
     depends_on("boost+mpi", when='+mpi')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("exodusii~mpi", when='~mpi')
     depends_on("exodusii+mpi", when='+mpi')
 

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/flecsph/package.py
+++ b/var/spack/repos/builtin/packages/flecsph/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Flecsph(CMakePackage):
@@ -22,7 +23,13 @@ class Flecsph(CMakePackage):
     variant('test', default=True, description='Adding tests')
 
     depends_on('cmake@3.15:', type='build')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('boost@1.70.0: cxxstd=17 +program_options')
+
     depends_on('mpi')
     depends_on('hdf5+hl@1.8:')
     depends_on('flecsi@1.4.2 +external_cinch backend=mpi')

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class FluxSched(AutotoolsPackage):
@@ -42,6 +43,11 @@ class FluxSched(AutotoolsPackage):
     depends_on("boost+graph@1.53.0,1.59.0:")
     depends_on("py-pyyaml@3.10:", type=('build', 'run'))
     depends_on("py-jsonschema@2.3:", type=('build', 'run'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    # depends_on(Boost.with_default_variants)
     depends_on("libedit")
     depends_on("libxml2@2.9.1:")
     # pin yaml-cpp to 0.6.3 due to issue #886

--- a/var/spack/repos/builtin/packages/folly/package.py
+++ b/var/spack/repos/builtin/packages/folly/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Folly(CMakePackage):
@@ -25,8 +26,11 @@ class Folly(CMakePackage):
     depends_on('pkgconfig', type='build')
 
     # folly requires gcc 4.9+ and a version of boost compiled with >= C++14
-    # TODO: Specify the boost components
     variant('cxxstd', default='14', values=('14', '17'), multi=False, description='Use the specified C++ standard when building.')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('boost+context+container cxxstd=14', when='cxxstd=14')
     depends_on('boost+context+container cxxstd=17', when='cxxstd=17')
 

--- a/var/spack/repos/builtin/packages/folly/package.py
+++ b/var/spack/repos/builtin/packages/folly/package.py
@@ -25,14 +25,13 @@ class Folly(CMakePackage):
     # CMakePackage Dependency
     depends_on('pkgconfig', type='build')
 
-    # folly requires gcc 4.9+ and a version of boost compiled with >= C++14
+    # folly requires gcc 5+ and a version of boost compiled with >= C++14
     variant('cxxstd', default='14', values=('14', '17'), multi=False, description='Use the specified C++ standard when building.')
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
+    # Boost library dependencies:
+    # CMake threw errors when program_options and thread were not included.
     # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
-    depends_on('boost+context+container cxxstd=14', when='cxxstd=14')
-    depends_on('boost+context+container cxxstd=17', when='cxxstd=17')
+    depends_on('boost+container+context+exception+filesystem+program_options+regex+serialization+system+thread cxxstd=14', when='cxxstd=14')
+    depends_on('boost+container+context+exception+filesystem+program_options+regex+serialization+system+thread cxxstd=17', when='cxxstd=17')
 
     # required dependencies
     depends_on('gflags')

--- a/var/spack/repos/builtin/packages/foundationdb/package.py
+++ b/var/spack/repos/builtin/packages/foundationdb/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Foundationdb(CMakePackage):
@@ -24,7 +25,11 @@ class Foundationdb(CMakePackage):
 
     depends_on('cmake@3.13.0:', type='build')
     depends_on('mono')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     generator = 'Ninja'
     depends_on('ninja', type='build')
 

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Gaudi(CMakePackage):
@@ -44,6 +45,11 @@ class Gaudi(CMakePackage):
     # These dependencies are needed for a minimal Gaudi build
     depends_on('aida')
     depends_on('boost@1.67.0: +python')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('clhep')
     depends_on('cmake', type='build')
     depends_on('cppgsl')

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Geant4(CMakePackage):
@@ -114,6 +115,11 @@ class Geant4(CMakePackage):
         # Boost.python, conflict handled earlier
         depends_on('boost@1.70: +python cxxstd=' + std,
                    when='+python cxxstd=' + std)
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+python')
 
     # Visualization driver dependencies
     depends_on("gl", when='+opengl')

--- a/var/spack/repos/builtin/packages/gearshifft/package.py
+++ b/var/spack/repos/builtin/packages/gearshifft/package.py
@@ -38,7 +38,7 @@ class Gearshifft(CMakePackage):
 
     # depends_on C++14 compiler, e.g. GCC 5.0+
     depends_on('cmake@2.8.0:', type='build')
-    depends_on('boost@1.59.0:')
+    depends_on('boost@1.59.0:+system+test+program_options+thread')
     depends_on('cuda@8.0:', when='+cufft')
     depends_on('opencl@1.2:', when='+clfft')
     depends_on('clfft@2.12.0:', when='+clfft')

--- a/var/spack/repos/builtin/packages/gnuradio/package.py
+++ b/var/spack/repos/builtin/packages/gnuradio/package.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+from spack.pkg.builtin.boost import Boost
+
+
 class Gnuradio(CMakePackage):
     """GNU Radio is a free & open-source software development toolkit
     that provides signal processing blocks to implement software
@@ -30,6 +33,11 @@ class Gnuradio(CMakePackage):
     depends_on('log4cpp@1.0:')
     # https://github.com/gnuradio/gnuradio/pull/3566
     depends_on('boost@1.53:1.72')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-click', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/gource/package.py
+++ b/var/spack/repos/builtin/packages/gource/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Gource(AutotoolsPackage):
@@ -23,6 +24,11 @@ class Gource(AutotoolsPackage):
     depends_on('freetype@2.0:')
     depends_on('pcre')
     depends_on('boost@1.46:+filesystem+system')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('glew')
     depends_on('jpeg')
     depends_on('libpng')

--- a/var/spack/repos/builtin/packages/gplates/package.py
+++ b/var/spack/repos/builtin/packages/gplates/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Gplates(CMakePackage):
@@ -37,6 +38,10 @@ class Gplates(CMakePackage):
     # There were changes to Boost's optional in 1.61 that make the build fail.
     depends_on('boost+python@1.34:1.60')
     depends_on('python@2.0:2')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # When built in parallel, headers are not generated before they are used
     # (specifically, ViewportWindowUi.h) with the Makefiles generator.

--- a/var/spack/repos/builtin/packages/graphblast/package.py
+++ b/var/spack/repos/builtin/packages/graphblast/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Graphblast(MakefilePackage, CudaPackage):
@@ -18,6 +19,11 @@ class Graphblast(MakefilePackage, CudaPackage):
     variant('cuda', default=True, description="Build with Cuda support")
 
     depends_on('boost +program_options')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # This package is confirmed to compile with:
     #   gcc@:5.4.0,7.5.0 , boost@1.58.0:1.60.0 , cuda@9:

--- a/var/spack/repos/builtin/packages/gunrock/package.py
+++ b/var/spack/repos/builtin/packages/gunrock/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Gunrock(CMakePackage, CudaPackage):
@@ -52,6 +53,11 @@ class Gunrock(CMakePackage, CudaPackage):
     depends_on('googletest', when='+google_tests')
     depends_on('lcov', when='+code_coverage')
     depends_on('boost@1.58.0:', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('metis', when='+metis')
 
     conflicts('cuda_arch=none', when='+cuda',

--- a/var/spack/repos/builtin/packages/heaptrack/package.py
+++ b/var/spack/repos/builtin/packages/heaptrack/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Heaptrack(CMakePackage):
@@ -16,6 +17,11 @@ class Heaptrack(CMakePackage):
     version('1.1.0', sha256='bd247ac67d1ecf023ec7e2a2888764bfc03e2f8b24876928ca6aa0cdb3a07309')
 
     depends_on('boost@1.41:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cmake@2.8.9:', type='build')
     depends_on('elfutils')
     depends_on('libunwind')

--- a/var/spack/repos/builtin/packages/helics/package.py
+++ b/var/spack/repos/builtin/packages/helics/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Helics(CMakePackage):
@@ -56,6 +57,11 @@ class Helics(CMakePackage):
     depends_on('git', type='build', when='@master:')
     depends_on('cmake@3.4:', type='build')
     depends_on('boost@1.70:', type='build', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type='build', when='+boost')
     depends_on('swig@3.0:', type='build', when='+swig')
 
     depends_on('libzmq@4.3:', when='+zmq')

--- a/var/spack/repos/builtin/packages/herwig3/package.py
+++ b/var/spack/repos/builtin/packages/herwig3/package.py
@@ -6,6 +6,7 @@
 import shutil
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Herwig3(AutotoolsPackage):
@@ -24,7 +25,11 @@ class Herwig3(AutotoolsPackage):
     depends_on('m4',       type='build')
     depends_on('lhapdf',   type='link')
     depends_on('thepeg@2.2.1', when='@7.2.1', type='link')
-    depends_on('boost', type='link')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type='link')
     depends_on('python', type=('build', 'run'))
     depends_on('gsl', type='link')
     depends_on('fastjet', type='link')

--- a/var/spack/repos/builtin/packages/herwigpp/package.py
+++ b/var/spack/repos/builtin/packages/herwigpp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Herwigpp(AutotoolsPackage):
@@ -19,7 +20,11 @@ class Herwigpp(AutotoolsPackage):
     patch('herwig++-2.7.1.patch', when='@2.7.1', level=0)
 
     depends_on('gsl')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('fastjet')
     depends_on('thepeg@1.9.2', when='@2.7.1')
 

--- a/var/spack/repos/builtin/packages/highfive/package.py
+++ b/var/spack/repos/builtin/packages/highfive/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Highfive(CMakePackage):
@@ -28,6 +29,11 @@ class Highfive(CMakePackage):
     variant('mpi', default=True, description='Support MPI')
 
     depends_on('boost @1.41:', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('hdf5')
     depends_on('hdf5 +mpi', when='+mpi')
 

--- a/var/spack/repos/builtin/packages/hisea/package.py
+++ b/var/spack/repos/builtin/packages/hisea/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Hisea(MakefilePackage):
@@ -16,7 +17,10 @@ class Hisea(MakefilePackage):
     version('2017.12.26', sha256='3c6ddfb8490a327cc5f9e45f64cd4312abc6ef5719661ce8892db8a20a1e9c5e',
             url='https://github.com/lucian-ilie/HISEA/tarball/39e01e98caa0f2101da806ca59306296effe789c')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     def patch(self):
         if self.spec.target.family == 'aarch64':

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -6,6 +6,7 @@
 import llnl.util.tty as tty
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Hpctoolkit(AutotoolsPackage):
@@ -83,6 +84,11 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on('binutils +libiberty~nls', type='link', when='@2020.04:2020')
     depends_on('binutils@:2.33.1 +libiberty~nls', type='link', when='@:2020.03')
     depends_on('boost' + boost_libs)
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('bzip2+shared', type='link')
     depends_on('dyninst@10.2.0:', when='@2021.00:')
     depends_on('dyninst@9.3.2:', when='@:2020')

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -7,6 +7,7 @@
 import sys
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Hpx(CMakePackage, CudaPackage, ROCmPackage):
@@ -83,7 +84,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     # Other dependecies
     depends_on('hwloc')
-    depends_on('boost')
+    depends_on(Boost.with_default_variants)
     for cxxstd in cxxstds:
         depends_on(
             "boost cxxstd={0}".format(map_cxxstd(cxxstd)),

--- a/var/spack/repos/builtin/packages/hssp/package.py
+++ b/var/spack/repos/builtin/packages/hssp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Hssp(AutotoolsPackage):
@@ -34,6 +35,11 @@ class Hssp(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('boost@1.48:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/hybrid-lambda/package.py
+++ b/var/spack/repos/builtin/packages/hybrid-lambda/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class HybridLambda(AutotoolsPackage):
@@ -27,7 +28,11 @@ class HybridLambda(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cppunit', type='test')
 
     build_directory = 'src'

--- a/var/spack/repos/builtin/packages/hyperscan/package.py
+++ b/var/spack/repos/builtin/packages/hyperscan/package.py
@@ -6,6 +6,7 @@
 import platform
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 _versions = {
     'v5.2.1': {
@@ -27,6 +28,9 @@ class Hyperscan(CMakePackage):
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('pcre')
     depends_on('ragel', type='build')

--- a/var/spack/repos/builtin/packages/ibmisc/package.py
+++ b/var/spack/repos/builtin/packages/ibmisc/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Ibmisc(CMakePackage):
@@ -45,6 +46,11 @@ class Ibmisc(CMakePackage):
     depends_on('py-cython', when='+python', type=('build', 'run'))
     depends_on('py-numpy', when='+python', type=('build', 'run'))
     depends_on('boost', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
 
     # Build dependencies
     depends_on('doxygen', type='build')

--- a/var/spack/repos/builtin/packages/imp/package.py
+++ b/var/spack/repos/builtin/packages/imp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Imp(CMakePackage):
@@ -17,5 +18,10 @@ class Imp(CMakePackage):
     depends_on('python@2.7:')
     depends_on('swig')
     depends_on('boost@1.40:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('hdf5')
     depends_on('eigen')

--- a/var/spack/repos/builtin/packages/iq-tree/package.py
+++ b/var/spack/repos/builtin/packages/iq-tree/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class IqTree(CMakePackage):
@@ -26,7 +27,10 @@ class IqTree(CMakePackage):
 
     # Depends on Eigen3 and zlib
 
-    depends_on("boost")
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("eigen")
     depends_on("zlib")
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/jali/package.py
+++ b/var/spack/repos/builtin/packages/jali/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Jali(CMakePackage):
@@ -31,7 +32,10 @@ class Jali(CMakePackage):
 
     depends_on('mpi')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     depends_on('mstk@3.3.5: +exodusii+parallel~use_markers partitioner=all', when='+mstk')
 

--- a/var/spack/repos/builtin/packages/kea/package.py
+++ b/var/spack/repos/builtin/packages/kea/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Kea(AutotoolsPackage):
@@ -19,4 +20,8 @@ class Kea(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('log4cplus')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)

--- a/var/spack/repos/builtin/packages/kicad/package.py
+++ b/var/spack/repos/builtin/packages/kicad/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.pkg.builtin.boost import Boost
+
 
 class Kicad(CMakePackage):
     """KiCad is an open source software suite for Electronic Design
@@ -24,6 +26,11 @@ class Kicad(CMakePackage):
     depends_on('gl')
     depends_on('glm')
     depends_on('boost@1.56:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('oce+X11')
     depends_on('swig', type='build')
     depends_on('curl')

--- a/var/spack/repos/builtin/packages/launchmon/package.py
+++ b/var/spack/repos/builtin/packages/launchmon/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Launchmon(AutotoolsPackage):
@@ -24,7 +25,11 @@ class Launchmon(AutotoolsPackage):
     depends_on('libgcrypt')
     depends_on('libgpg-error')
     depends_on("elf", type='link')
-    depends_on("boost")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("spectrum-mpi", when='arch=ppc64le')
 
     patch('launchmon-char-conv.patch', when='@1.0.2')

--- a/var/spack/repos/builtin/packages/libcudf/package.py
+++ b/var/spack/repos/builtin/packages/libcudf/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Libcudf(CMakePackage):
@@ -18,7 +19,11 @@ class Libcudf(CMakePackage):
 
     depends_on('cmake@3.14:', type='build')
     depends_on('cuda@10.0:')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('arrow+cuda+orc+parquet')
     depends_on('librmm')
     depends_on('dlpack')

--- a/var/spack/repos/builtin/packages/libfive/package.py
+++ b/var/spack/repos/builtin/packages/libfive/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Libfive(CMakePackage):
@@ -19,6 +20,11 @@ class Libfive(CMakePackage):
     depends_on('pkgconfig', type='build')
     depends_on('cmake@3.12:', type='build')
     depends_on('boost@1.65:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('eigen@3.3.0:')
     depends_on('libpng')
     depends_on('python@3:',         when='+python', type=('link', 'run'))

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 TUNE_VARIANTS = (
     'none',
@@ -56,7 +57,11 @@ class Libint(AutotoolsPackage):
     depends_on('libtool', type='build')
 
     # Libint 2 dependencies
-    depends_on('boost', when='@2:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@2:')
     depends_on('gmp', when='@2:')
 
     for tvariant in TUNE_VARIANTS[1:]:

--- a/var/spack/repos/builtin/packages/libkml/package.py
+++ b/var/spack/repos/builtin/packages/libkml/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Libkml(CMakePackage):
@@ -26,6 +27,11 @@ class Libkml(CMakePackage):
     # See DEPENDENCIES
     depends_on('cmake@2.8:', type='build')
     depends_on('boost@1.44.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('expat@2.1.0:')
     depends_on('minizip@1.2.8:')
     depends_on('uriparser')

--- a/var/spack/repos/builtin/packages/liblas/package.py
+++ b/var/spack/repos/builtin/packages/liblas/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Liblas(CMakePackage):
@@ -26,6 +27,11 @@ class Liblas(CMakePackage):
 
     depends_on('libgeotiff')
     depends_on('boost@:1.69.0')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('laszip', when='+laszip')
     depends_on('gdal', when='+gdal')
 

--- a/var/spack/repos/builtin/packages/libmesh/package.py
+++ b/var/spack/repos/builtin/packages/libmesh/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Libmesh(AutotoolsPackage):
@@ -79,6 +80,11 @@ class Libmesh(AutotoolsPackage):
               'variant.')
 
     depends_on('boost', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('eigen', when='+eigen')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/libpulsar/package.py
+++ b/var/spack/repos/builtin/packages/libpulsar/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Libpulsar(CMakePackage):
@@ -19,7 +20,11 @@ class Libpulsar(CMakePackage):
             sha256='5bf8e5115075e12c848a9e4474cd47067c3200f7ff13c45f624f7383287e8e5e')
 
     depends_on('zstd')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('protobuf')
     depends_on('pkgconfig')
     depends_on('openssl')

--- a/var/spack/repos/builtin/packages/librom/package.py
+++ b/var/spack/repos/builtin/packages/librom/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.pkg.builtin.boost import Boost
+
 
 class Librom(AutotoolsPackage):
     """libROM: library for computing large-scale reduced order models"""
@@ -20,7 +22,11 @@ class Librom(AutotoolsPackage):
     depends_on('perl')
     depends_on('graphviz')
     depends_on('doxygen')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/lordec/package.py
+++ b/var/spack/repos/builtin/packages/lordec/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Lordec(MakefilePackage):
@@ -24,6 +25,10 @@ class Lordec(MakefilePackage):
             return "https://gite.lirmm.fr/lordec/lordec-releases/uploads/800a96d81b3348e368a0ff3a260a88e1/lordec-src_0.9.tar.bz2"
 
     depends_on('boost@1.48.0:1.64.0', type=['build', 'link'])
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('gatb-core@1.4.1:', type=['build', 'link', 'run'])
     depends_on('zlib', type=['build', 'link'])
 

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -7,6 +7,7 @@ import glob
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Magics(CMakePackage):
@@ -72,7 +73,11 @@ class Magics(CMakePackage):
     # https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status
     depends_on('proj@:5', when='@:4.2.6')
     depends_on('proj@6:', when='@4.3:')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('expat')
 
     # Magics (at least up to version 2.34.3) should directly and

--- a/var/spack/repos/builtin/packages/mallocmc/package.py
+++ b/var/spack/repos/builtin/packages/mallocmc/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mallocmc(CMakePackage):
@@ -34,4 +35,9 @@ class Mallocmc(CMakePackage):
 
     depends_on('cmake@2.8.12.2:', type='build')
     depends_on('boost@1.48.0:', type='link')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type='link')
     depends_on('cuda@5.0:', type='link')

--- a/var/spack/repos/builtin/packages/mapnik/package.py
+++ b/var/spack/repos/builtin/packages/mapnik/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mapnik(AutotoolsPackage):
@@ -21,6 +22,11 @@ class Mapnik(AutotoolsPackage):
     depends_on('python', type=('build', 'run'))
     depends_on('boost@:1.72.0 +regex+filesystem+system+icu+program_options cxxstd=11', when='@3.0.23')
     depends_on('boost@:1.69.0 +regex+filesystem+system+icu+program_options cxxstd=11', when='@3.0.22')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('icu4c')
     depends_on('zlib')
     depends_on('freetype')

--- a/var/spack/repos/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/builtin/packages/mariadb/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mariadb(CMakePackage):
@@ -35,7 +36,10 @@ class Mariadb(CMakePackage):
     provides('mariadb-client')
     provides('mysql-client')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cmake@2.6:', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('bison', type='build')

--- a/var/spack/repos/builtin/packages/masurca/package.py
+++ b/var/spack/repos/builtin/packages/masurca/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Masurca(Package):
@@ -20,7 +21,11 @@ class Masurca(Package):
     version('3.2.9', sha256='795ad4bd42e15cf3ef2e5329aa7e4f2cdeb7e186ce2e350a45127e319db2904b')
 
     depends_on('perl', type=('build', 'run'))
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('zlib')
     patch('arm.patch', when='target=aarch64:')
 

--- a/var/spack/repos/builtin/packages/meraculous/package.py
+++ b/var/spack/repos/builtin/packages/meraculous/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Meraculous(CMakePackage, SourceforgePackage):
@@ -19,6 +20,11 @@ class Meraculous(CMakePackage, SourceforgePackage):
 
     depends_on('perl', type=('build', 'run'))
     depends_on('boost@1.5.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('gnuplot@3.7:')
     depends_on('perl-log-log4perl', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/mercury/package.py
+++ b/var/spack/repos/builtin/packages/mercury/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mercury(CMakePackage):
@@ -53,7 +54,16 @@ class Mercury(CMakePackage):
     # openpa dependency is removed in 2.1.0
     depends_on('openpa@1.0.3:', when='@:2.0.1%gcc@:4.8')
     depends_on('boost@1.48:', when='+boostsys')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boostsys')
     depends_on('boost', when='@:0.9')  # internal boost headers were added in 1.0.0
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@:0.9')
     depends_on('ucx+thread_multiple', when='+ucx')
 
     # Fix CMake check_symbol_exists

--- a/var/spack/repos/builtin/packages/metabat/package.py
+++ b/var/spack/repos/builtin/packages/metabat/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Metabat(SConsPackage):
@@ -19,6 +20,11 @@ class Metabat(SConsPackage):
     version('2.11.2', sha256='9baf81b385e503e71792706237c308a21ff9177a3211c79057dcecf8434e9a67')
 
     depends_on('boost@1.55.0:', type=('build', 'run'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type=('build', 'run'))
     depends_on('perl', type='run')
     depends_on('zlib', type='link')
     depends_on('ncurses', type='link')

--- a/var/spack/repos/builtin/packages/metall/package.py
+++ b/var/spack/repos/builtin/packages/metall/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.pkg.builtin.boost import Boost
+
 
 class Metall(CMakePackage):
     """A Persistent Memory Allocator For Data-Centric Analytics"""
@@ -36,6 +38,11 @@ class Metall(CMakePackage):
     # Hint: Use 'spack install --test=root metall' or 'spack install --test=all metall'
     # to run test (adds a call to 'make test' to the build)
     depends_on('googletest %gcc@8.1.0:', type=('test'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type=('build', 'link'))
 
     def cmake_args(self):
         if self.run_tests:

--- a/var/spack/repos/builtin/packages/mgis/package.py
+++ b/var/spack/repos/builtin/packages/mgis/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mgis(CMakePackage):
@@ -63,6 +64,11 @@ class Mgis(CMakePackage):
     depends_on('tfel@rliv-3.2', when="@rliv-1.0")
     depends_on('tfel@master', when="@master")
     depends_on('boost+python+numpy', when='+python')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+python')
     extends('python', when='+python')
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class MiopenHip(CMakePackage):
@@ -33,6 +34,11 @@ class MiopenHip(CMakePackage):
 
     depends_on('cmake@3:', type='build')
     depends_on('pkgconfig', type='build')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('boost@1.67.0:1.73.0')
     depends_on('bzip2')
     depends_on('sqlite')

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class MiopenOpencl(CMakePackage):
@@ -33,6 +34,11 @@ class MiopenOpencl(CMakePackage):
 
     depends_on('cmake@3:', type='build')
     depends_on('boost@1.67.0:1.73.0', type='link')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type='link')
     depends_on('pkgconfig', type='build')
     depends_on('bzip2', type='link')
     depends_on('sqlite', type='link')

--- a/var/spack/repos/builtin/packages/mira/package.py
+++ b/var/spack/repos/builtin/packages/mira/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mira(AutotoolsPackage):
@@ -16,6 +17,11 @@ class Mira(AutotoolsPackage):
     version('4.0.2', sha256='a32cb2b21e0968a5536446287c895fe9e03d11d78957554e355c1080b7b92a80')
 
     depends_on('boost@1.46:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('expat@2.0.1:')
     depends_on('gperftools')
 

--- a/var/spack/repos/builtin/packages/modern-wheel/package.py
+++ b/var/spack/repos/builtin/packages/modern-wheel/package.py
@@ -6,6 +6,7 @@
 import sys
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class ModernWheel(CMakePackage):
@@ -36,6 +37,11 @@ class ModernWheel(CMakePackage):
     # ModernWheel with Boost >= 1.66.0.
     depends_on('boost           +system +filesystem', when='@:1.1')
     depends_on('boost@:1.65 +system +filesystem', when='@1.2:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # add virtual destructor to BaseMultiParms class.
     patch('add_virtual_destructor.patch')

--- a/var/spack/repos/builtin/packages/mofem-cephas/package.py
+++ b/var/spack/repos/builtin/packages/mofem-cephas/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class MofemCephas(CMakePackage):
@@ -39,6 +40,11 @@ class MofemCephas(CMakePackage):
 
     depends_on("mpi")
     depends_on("boost@:1.68")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("parmetis")
     # Fixed version of hdf5, to remove some problems with dependent
     # packages, f.e. MED format

--- a/var/spack/repos/builtin/packages/mothur/package.py
+++ b/var/spack/repos/builtin/packages/mothur/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mothur(MakefilePackage):
@@ -22,7 +23,10 @@ class Mothur(MakefilePackage):
 
     variant('vsearch', default=False,  description='Use vsearch')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('readline')
     depends_on('vsearch@2.13.3',  when='+vsearch', type='run')
 

--- a/var/spack/repos/builtin/packages/mrnet/package.py
+++ b/var/spack/repos/builtin/packages/mrnet/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mrnet(AutotoolsPackage):
@@ -24,7 +25,10 @@ class Mrnet(AutotoolsPackage):
             description="Also build the MRNet LW threadsafe libraries")
     parallel = False
 
-    depends_on("boost")
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/multiverso/package.py
+++ b/var/spack/repos/builtin/packages/multiverso/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Multiverso(CMakePackage):
@@ -19,7 +20,11 @@ class Multiverso(CMakePackage):
     version('0.2', sha256='40e86543968faa2fe203cf0b004a4c7905303db0c860efe4ce4e1f27e46394fc')
 
     depends_on('mpi')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     patch('cmake-143187.patch', when='@143187')
 

--- a/var/spack/repos/builtin/packages/muster/package.py
+++ b/var/spack/repos/builtin/packages/muster/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Muster(CMakePackage):
@@ -19,6 +20,9 @@ class Muster(CMakePackage):
     version('1.0.1', sha256='71e2fcdd7abf7ae5cc648a5f310e1c5369e4889718eab2a045e747c590d2dd71')
     version('1.0',   sha256='370a670419e391494fcca0294882ee5f83c5d8af94ca91ac4182235332bd56d6')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('mpi')
     depends_on('cmake@2.8:', type='build')

--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -2,10 +2,12 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 import os
 import tempfile
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Mysql(CMakePackage):
@@ -109,6 +111,11 @@ class Mysql(CMakePackage):
     depends_on('boost@1.59.0 cxxstd=11', when='@5.7.0:5.7 cxxstd=11')
     depends_on('boost@1.59.0 cxxstd=14', when='@5.7.0:5.7 cxxstd=14')
     depends_on('boost@1.59.0 cxxstd=17', when='@5.7.0:5.7 cxxstd=17')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@5.7:')
 
     depends_on('rpcsvc-proto')
     depends_on('ncurses')

--- a/var/spack/repos/builtin/packages/n2p2/package.py
+++ b/var/spack/repos/builtin/packages/n2p2/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class N2p2(MakefilePackage):
@@ -46,7 +47,10 @@ class N2p2(MakefilePackage):
     depends_on("py-sphinx", type="build", when="+doc")
     depends_on("py-sphinx-rtd-theme", type="build", when="+doc")
 
-    depends_on("boost", type="link")
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type="link")
     depends_on("lcov", type=("build", "run"))
     depends_on("py-pytest", type=("build", "run"))
     depends_on("py-pytest-cov", type="run")

--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -67,10 +67,10 @@ class NaluWind(CMakePackage, CudaPackage):
                    when='+hypre+cuda cuda_arch={0}'.format(_arch))
     depends_on('trilinos-catalyst-ioss-adapter', when='+catalyst')
     depends_on('fftw+mpi', when='+fftw')
-    depends_on('boost cxxstd=14', when='+boost')
     depends_on('nccmp')
     # indirect dependency needed to make original concretizer work
     depends_on('netcdf-c+parallel-netcdf')
+    depends_on('boost +filesystem +iostreams cxxstd=14', when='+boost')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-toolkit/package.py
@@ -6,6 +6,7 @@
 from glob import glob
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class NcbiToolkit(AutotoolsPackage):
@@ -23,6 +24,11 @@ class NcbiToolkit(AutotoolsPackage):
             description='Build debug versions of libs and apps')
 
     depends_on('boost@1.35.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('bzip2')
     depends_on('jpeg')
     depends_on('libpng')

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Nektar(CMakePackage):
@@ -28,6 +29,11 @@ class Nektar(CMakePackage):
     depends_on('blas')
     depends_on('lapack')
     depends_on('boost@1.56.0: +iostreams')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('tinyxml', when='platform=darwin')
 
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/nix/package.py
+++ b/var/spack/repos/builtin/packages/nix/package.py
@@ -8,6 +8,7 @@ import stat
 import tempfile
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Nix(AutotoolsPackage):
@@ -44,6 +45,11 @@ class Nix(AutotoolsPackage):
 
     depends_on('boost@1.66.0:+coroutine+context cxxstd=14', when='@2.2.0:')
     depends_on('boost@1.61.0:+coroutine+context cxxstd=14', when='@2.0.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@2.0.0:')
     depends_on('brotli')
     depends_on('editline')
 

--- a/var/spack/repos/builtin/packages/ns-3-dev/package.py
+++ b/var/spack/repos/builtin/packages/ns-3-dev/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Ns3Dev(WafPackage):
@@ -32,7 +33,11 @@ class Ns3Dev(WafPackage):
 
     # Build dependency
     depends_on('helics', when='+helics')
-    depends_on('boost', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('pkgconfig', type='build')
 
     resource(name='helics',

--- a/var/spack/repos/builtin/packages/openbabel/package.py
+++ b/var/spack/repos/builtin/packages/openbabel/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Openbabel(CMakePackage):
@@ -29,7 +30,11 @@ class Openbabel(CMakePackage):
     depends_on('cmake@3.1:', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('swig@2.0:', type='build', when='+python')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cairo')       # required to support PNG depiction
     depends_on('pango')       # custom cairo requires custom pango
     depends_on('eigen@3.0:')  # required if using the language bindings

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -47,8 +47,8 @@ import re
 import llnl.util.tty as tty
 
 from spack import *
-from spack.util.environment import EnvironmentModifications
 from spack.pkg.builtin.boost import Boost
+from spack.util.environment import EnvironmentModifications
 
 # Not the nice way of doing things, but is a start for refactoring
 __all__ = [

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -48,6 +48,7 @@ import llnl.util.tty as tty
 
 from spack import *
 from spack.util.environment import EnvironmentModifications
+from spack.pkg.builtin.boost import Boost
 
 # Not the nice way of doing things, but is a start for refactoring
 __all__ = [
@@ -319,7 +320,12 @@ class Openfoam(Package):
 
     depends_on('zlib')
     depends_on('fftw-api')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
+
     # OpenFOAM does not play nice with CGAL 5.X
     depends_on('cgal@:4')
     # The flex restriction is ONLY to deal with a spec resolution clash

--- a/var/spack/repos/builtin/packages/openimageio/package.py
+++ b/var/spack/repos/builtin/packages/openimageio/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Openimageio(CMakePackage):
@@ -19,6 +20,11 @@ class Openimageio(CMakePackage):
     # Core dependencies
     depends_on('cmake@3.2.2:', type='build')
     depends_on('boost@1.53:', type=('build', 'link'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type=('build', 'link'))
     depends_on('libtiff@4.0:', type=('build', 'link'))
     depends_on('openexr@2.3:', type=('build', 'link'))
     depends_on('libpng@1.6:', type=('build', 'link'))

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -3,12 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-import os.path
-
 import spack
 import spack.store
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class OpenspeedshopUtils(CMakePackage):
@@ -81,6 +79,10 @@ class OpenspeedshopUtils(CMakePackage):
 
     # For boost
     depends_on("boost@1.66.0:1.69.0")
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     depends_on("dyninst@master", when='@develop')
     depends_on("dyninst@10:", when='@2.4.0:9999')

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -3,10 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 import spack.store
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Openspeedshop(CMakePackage):
@@ -77,6 +76,10 @@ class Openspeedshop(CMakePackage):
 
     # For boost
     depends_on("boost@1.70.0:")
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     depends_on("dyninst@master", when='@develop')
     depends_on("dyninst@10:", when='@2.4.0:9999')

--- a/var/spack/repos/builtin/packages/pagmo/package.py
+++ b/var/spack/repos/builtin/packages/pagmo/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Pagmo(CMakePackage):
@@ -50,6 +51,11 @@ class Pagmo(CMakePackage):
     depends_on('boost+system+serialization+thread+python',           when='+python~gtop')
     depends_on('boost+system+serialization+thread+date_time',        when='~python+gtop')
     depends_on('boost+system+serialization+thread+python+date_time', when='+python+gtop')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     depends_on('gsl@1.15:',       when='+gsl')
     depends_on('ipopt',           when='+ipopt')

--- a/var/spack/repos/builtin/packages/paradiseo/package.py
+++ b/var/spack/repos/builtin/packages/paradiseo/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Paradiseo(CMakePackage):
@@ -43,6 +44,11 @@ class Paradiseo(CMakePackage):
     depends_on("eigen", when='+edo', type='build')
     depends_on("boost~mpi", when='+edo~mpi')
     depends_on("boost+mpi", when='+edo+mpi')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+edo')
 
     # Patches
     patch('enable_eoserial.patch')

--- a/var/spack/repos/builtin/packages/parquet-cpp/package.py
+++ b/var/spack/repos/builtin/packages/parquet-cpp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class ParquetCpp(CMakePackage):
@@ -16,7 +17,11 @@ class ParquetCpp(CMakePackage):
     version('1.4.0', sha256='52899be6c9dc49a14976d4ad84597243696c3fa2882e5c802b56e912bfbcc7ce')
 
     depends_on('arrow')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('cmake@3.2.0:', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('thrift+pic')

--- a/var/spack/repos/builtin/packages/parsplice/package.py
+++ b/var/spack/repos/builtin/packages/parsplice/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Parsplice(CMakePackage):
@@ -24,6 +25,11 @@ class Parsplice(CMakePackage):
     depends_on("berkeley-db")
     depends_on("nauty")
     depends_on("boost cxxstd=11")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("mpi")
     depends_on("eigen@3:")
     depends_on("lammps+lib@20170901:")

--- a/var/spack/repos/builtin/packages/pbbam/package.py
+++ b/var/spack/repos/builtin/packages/pbbam/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Pbbam(CMakePackage):
@@ -19,6 +20,11 @@ class Pbbam(CMakePackage):
 
     depends_on('zlib')
     depends_on('boost@1.55.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('htslib@1.3.1:')
     depends_on('doxygen+graphviz')
 

--- a/var/spack/repos/builtin/packages/pcl/package.py
+++ b/var/spack/repos/builtin/packages/pcl/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Pcl(CMakePackage):
@@ -19,3 +20,8 @@ class Pcl(CMakePackage):
     depends_on('eigen@3.1:')
     depends_on('flann@1.7:')
     depends_on('boost@1.55:+filesystem+date_time+iostreams+system')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)

--- a/var/spack/repos/builtin/packages/percept/package.py
+++ b/var/spack/repos/builtin/packages/percept/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Percept(CMakePackage):
@@ -24,6 +25,11 @@ class Percept(CMakePackage):
     depends_on('googletest~shared')
     depends_on('opennurbs@percept')
     depends_on('boost+graph+mpi')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('yaml-cpp+pic~shared@0.5.3:')
     depends_on('trilinos~shared+exodus+mpi+tpetra+epetra+epetraext+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+aztec+sacado~openmp+shards+intrepid@master,12.14.1:')
 

--- a/var/spack/repos/builtin/packages/percona-server/package.py
+++ b/var/spack/repos/builtin/packages/percona-server/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class PerconaServer(CMakePackage):
@@ -18,6 +19,11 @@ class PerconaServer(CMakePackage):
     version('8.0.18-9',  sha256='e79a8c1ae5f2271c0b344494a299a9bbbada88d3bce87449b7de274d17d1ccd0')
 
     depends_on('boost@1.70.0')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('openssl')
     depends_on('ncurses')
     depends_on('readline')

--- a/var/spack/repos/builtin/packages/piranha/package.py
+++ b/var/spack/repos/builtin/packages/piranha/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Piranha(CMakePackage):
@@ -31,6 +32,11 @@ class Piranha(CMakePackage):
                when='~python')
     depends_on('boost+iostreams+regex+serialization+python',
                when='+python')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('bzip2')
     depends_on('gmp')   # mpir is a drop-in replacement for this
     depends_on('mpfr')  # Could also be built against mpir

--- a/var/spack/repos/builtin/packages/pktools/package.py
+++ b/var/spack/repos/builtin/packages/pktools/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Pktools(CMakePackage):
@@ -23,7 +24,11 @@ class Pktools(CMakePackage):
     depends_on('gsl')
     depends_on('armadillo')
     depends_on('nlopt')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('fann', when='+fann')
     depends_on('liblas', when='+liblas')
 

--- a/var/spack/repos/builtin/packages/polymake/package.py
+++ b/var/spack/repos/builtin/packages/polymake/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Polymake(Package):
@@ -16,7 +17,11 @@ class Polymake(Package):
 
     # Note: Could also be built with nauty instead of bliss
     depends_on("bliss")
-    depends_on("boost")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("cddlib")
     depends_on("gmp")
     depends_on("lrslib")

--- a/var/spack/repos/builtin/packages/povray/package.py
+++ b/var/spack/repos/builtin/packages/povray/package.py
@@ -10,6 +10,7 @@ import getpass
 import socket
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Povray(AutotoolsPackage):
@@ -61,6 +62,11 @@ class Povray(AutotoolsPackage):
     depends_on('perl', type='build')
     depends_on('m4', type='build')
     depends_on('boost@1.37:', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('zlib@1.2.1:', when='+zlib')
     depends_on('libpng@1.2.5:', when='+libpng')
     depends_on('jpeg', when='+jpeg')

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Precice(CMakePackage):
@@ -52,6 +53,11 @@ class Precice(CMakePackage):
     depends_on('boost@1.65.1:', when='@1.4:')
     depends_on('boost@:1.72', when='@:2.0.2')
     depends_on('boost@:1.74', when='@:2.1.1')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('eigen@3.2:')
     depends_on('eigen@:3.3.7', type='build', when='@:1.5')  # bug in prettyprint
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/psi4/package.py
+++ b/var/spack/repos/builtin/packages/psi4/package.py
@@ -6,7 +6,6 @@
 import os
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Psi4(CMakePackage):

--- a/var/spack/repos/builtin/packages/psi4/package.py
+++ b/var/spack/repos/builtin/packages/psi4/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Psi4(CMakePackage):

--- a/var/spack/repos/builtin/packages/py-espresso/package.py
+++ b/var/spack/repos/builtin/packages/py-espresso/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class PyEspresso(CMakePackage):
@@ -33,6 +34,11 @@ class PyEspresso(CMakePackage):
     depends_on("cmake@3.0:", type='build')
     depends_on("mpi")
     depends_on("boost+serialization+filesystem+system+python+mpi")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     extends("python")
     depends_on("py-cython@0.23:", type="build")
     depends_on("py-numpy", type=("build", "run"))

--- a/var/spack/repos/builtin/packages/py-pycuda/package.py
+++ b/var/spack/repos/builtin/packages/py-pycuda/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class PyPycuda(PythonPackage):
@@ -34,6 +35,10 @@ class PyPycuda(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('cuda')
     depends_on('boost+python')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('python@3.6:3', type=('build', 'run'), when='@2020.1:')
     depends_on('py-numpy@1.6:', type=('build', 'run'))
     depends_on('py-pytools@2011.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-python-mapnik/package.py
+++ b/var/spack/repos/builtin/packages/py-python-mapnik/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class PyPythonMapnik(PythonPackage):
@@ -20,6 +21,11 @@ class PyPythonMapnik(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('mapnik', type=('build', 'link', 'run'))
     depends_on('boost +python+thread')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     # py-pycairo is need by mapnik.printing
     depends_on('py-pycairo', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-quast/package.py
+++ b/var/spack/repos/builtin/packages/py-quast/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class PyQuast(PythonPackage):
@@ -17,6 +18,11 @@ class PyQuast(PythonPackage):
     version('4.6.0', sha256='6bee86654b457a981718a19acacffca6a3e74f30997ad06162a70fd2a181ca2e')
 
     depends_on('boost@1.56.0')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('perl@5.6.0:')
     depends_on('python@2.5:,3.3:')
     depends_on('py-setuptools',    type='build')

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -6,6 +6,7 @@
 import llnl.util.tty as tty
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Qmcpack(CMakePackage, CudaPackage):
@@ -153,7 +154,11 @@ class Qmcpack(CMakePackage, CudaPackage):
     depends_on('cmake@3.4.3:', when='@:3.5.0', type='build')
     depends_on('cmake@3.6.0:', when='@3.6.0:', type='build')
     depends_on('cmake@3.14.0:', when='@3.10.0:', type='build')
-    depends_on('boost', type='build')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type='build')
     depends_on('boost@1.61.0:', when='@3.6.0:', type='build')
     depends_on('libxml2')
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/quinoa/package.py
+++ b/var/spack/repos/builtin/packages/quinoa/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Quinoa(CMakePackage):
@@ -22,7 +23,10 @@ class Quinoa(CMakePackage):
     depends_on('hdf5+mpi')
     depends_on("charmpp backend=mpi")
     depends_on("trilinos+exodus+mpi")
-    depends_on("boost")
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("hypre~internal-superlu")
     depends_on("random123")
     depends_on("netlib-lapack+lapacke")

--- a/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
+++ b/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class RPhantompeakqualtools(RPackage):
@@ -18,6 +19,11 @@ class RPhantompeakqualtools(RPackage):
     version('1.14', sha256='d03be6163e82aed72298e54a92c181570f9975a395f57a69b21ac02b1001520b')
 
     depends_on('boost@1.41.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('r-catools', type=('build', 'run'))
     depends_on('r-snow', type=('build', 'run'))
     depends_on('r-snowfall', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/range-v3/package.py
+++ b/var/spack/repos/builtin/packages/range-v3/package.py
@@ -7,6 +7,7 @@ import os
 import shutil
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class RangeV3(CMakePackage):
@@ -73,6 +74,11 @@ class RangeV3(CMakePackage):
                when='+examples cxxstd=14')
     depends_on('boost@1.59.0: cxxstd=17', type='build',
                when='+examples cxxstd=17')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type='build')
 
     # Fix reported upstream issue
     # https://github.com/ericniebler/range-v3/issues/1196 per PR

--- a/var/spack/repos/builtin/packages/revbayes/package.py
+++ b/var/spack/repos/builtin/packages/revbayes/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Revbayes(CMakePackage):
@@ -24,7 +25,10 @@ class Revbayes(CMakePackage):
 
     variant('mpi', default=True, description='Enable MPI parallel support')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('mpi', when='+mpi')
 
     conflicts('%gcc@7.1.0:', when='@:1.0.12')

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -6,6 +6,7 @@
 import os
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Rivet(AutotoolsPackage):
@@ -109,6 +110,11 @@ class Rivet(AutotoolsPackage):
     depends_on('hepmc',  type=('build', 'link', 'run'), when='hepmc=2')
     depends_on('hepmc3', type=('build', 'link', 'run'), when='hepmc=3')
     depends_on('boost', when='@:2.5.0', type=('build', 'run'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@:2.5.0', type=('build', 'run'))
     depends_on('fastjet', type=('build', 'run'))
     depends_on('fjcontrib', type=('build', 'run'), when='@3.0.0:')
     depends_on('gsl', type=('build', 'run'), when='@:2.6.0,2.6.2:2')

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class RocmTensile(CMakePackage):
@@ -42,6 +43,7 @@ class RocmTensile(CMakePackage):
     # This is the default library format since 3.7.0
     depends_on('msgpack-c@3:', when='@3.7:')
     depends_on('boost', type=('build', 'link'))
+    depends_on(Boost.with_default_variants)
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2']:

--- a/var/spack/repos/builtin/packages/rose/package.py
+++ b/var/spack/repos/builtin/packages/rose/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Rose(AutotoolsPackage):
@@ -68,6 +69,11 @@ class Rose(AutotoolsPackage):
     # C++11 compatible boost and gcc versions required for +cxx11 variant:
     depends_on("boost@1.60.0:1.64.0,1.65.1,1.66.0:1.67.0 cxxstd=11", when="+cxx11")
     depends_on("boost@1.60.0:1.64.0,1.65.1,1.66.0:1.67.0",           when="~cxx11")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # --------------------------------------------------------------------------
     # Variants

--- a/var/spack/repos/builtin/packages/sailfish/package.py
+++ b/var/spack/repos/builtin/packages/sailfish/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Sailfish(CMakePackage):
@@ -15,4 +16,9 @@ class Sailfish(CMakePackage):
     version('0.10.1', sha256='a0d6d944382f2e07ffbfd0371132588e2f22bb846ecfc3d3435ff3d81b30d6c6')
 
     depends_on('boost@1.55:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('tbb')

--- a/var/spack/repos/builtin/packages/salmon/package.py
+++ b/var/spack/repos/builtin/packages/salmon/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.pkg.builtin.boost import Boost
+
 
 class Salmon(CMakePackage):
     """Salmon is a tool for quantifying the expression of transcripts using
@@ -22,8 +24,14 @@ class Salmon(CMakePackage):
             values=('DEBUG', 'RELEASE'))
 
     depends_on('tbb')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('boost@:1.66.0', when='@:0.14.1')
     depends_on('boost@1.72.0:', when='@1.4.0:')
+
     depends_on('cereal')
     depends_on('jemalloc')
     depends_on('xz')

--- a/var/spack/repos/builtin/packages/samrai/package.py
+++ b/var/spack/repos/builtin/packages/samrai/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Samrai(AutotoolsPackage):
@@ -50,6 +51,10 @@ class Samrai(AutotoolsPackage):
     depends_on('hdf5+mpi')
     depends_on('m4', type='build')
     depends_on('boost@:1.64.0', when='@3.0.0:3.11', type='build')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@3.0.0:3.11.99', type='build')
     depends_on('silo+mpi', when='+silo')
 
     # don't build SAMRAI 3+ with tools with gcc

--- a/var/spack/repos/builtin/packages/scallop/package.py
+++ b/var/spack/repos/builtin/packages/scallop/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Scallop(AutotoolsPackage):
@@ -16,7 +17,11 @@ class Scallop(AutotoolsPackage):
     version('0.10.3', sha256='04eb3ab27ed8c7ae38e1780d6b2af16b6a2c01807ffafd59e819d33bfeff58a0')
 
     depends_on('clp')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('htslib@1.5:')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/scantailor/package.py
+++ b/var/spack/repos/builtin/packages/scantailor/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Scantailor(CMakePackage):
@@ -28,4 +29,9 @@ class Scantailor(CMakePackage):
     depends_on("libpng")
     depends_on("libtiff")
     depends_on("boost@1.35:")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("libxrender")

--- a/var/spack/repos/builtin/packages/seqan/package.py
+++ b/var/spack/repos/builtin/packages/seqan/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Seqan(CMakePackage):
@@ -25,6 +26,11 @@ class Seqan(CMakePackage):
     depends_on('py-nose', type='build')
     depends_on('py-sphinx', type='build')
     depends_on('boost', type=('build', 'link'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('zlib', type=('build', 'link'))
     depends_on('bzip2', type=('build', 'link'))
 

--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Sfcgal(CMakePackage):
@@ -24,6 +25,11 @@ class Sfcgal(CMakePackage):
     # Ref: https://oslandia.github.io/SFCGAL/installation.html, but starts to work @4.7:
     depends_on('cgal@4.7: +core')
     depends_on('boost@1.54.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('mpfr@2.2.1:')
     depends_on('gmp@4.2:')
 

--- a/var/spack/repos/builtin/packages/sgpp/package.py
+++ b/var/spack/repos/builtin/packages/sgpp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Sgpp(SConsPackage):
@@ -100,6 +101,11 @@ class Sgpp(SConsPackage):
     depends_on('mpi', when='+mpi', type=('build', 'run'))
     # Testing requires boost test
     depends_on('boost+test', type=('test'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, type=('test'))
 
     # Compiler with C++11 support is required
     conflicts('%gcc@:4.8.4', msg='Compiler with c++11 support is required!')

--- a/var/spack/repos/builtin/packages/shapeit4/package.py
+++ b/var/spack/repos/builtin/packages/shapeit4/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Shapeit4(MakefilePackage):
@@ -18,7 +19,11 @@ class Shapeit4(MakefilePackage):
     maintainers = ['ilbiondo']
 
     depends_on('htslib')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('bzip2')
     depends_on('xz')
 

--- a/var/spack/repos/builtin/packages/shark/package.py
+++ b/var/spack/repos/builtin/packages/shark/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Shark(CMakePackage):
@@ -17,7 +18,10 @@ class Shark(CMakePackage):
     version('4.0.0', sha256='19d4099776327d5f8a2e2be286818c6081c61eb13ca279c1e438c86e70d90210')
     version('3.1.4', sha256='160c35ddeae3f6aeac3ce132ea4ba2611ece39eee347de2faa3ca52639dc6311')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     def cmake_args(self):
         args = ["-DBoost_USE_STATIC_LIBS=ON", "-DBOOST_ROOT={0}".format(

--- a/var/spack/repos/builtin/packages/simgrid/package.py
+++ b/var/spack/repos/builtin/packages/simgrid/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Simgrid(CMakePackage):
@@ -70,7 +71,11 @@ class Simgrid(CMakePackage):
     variant('mc', default=False, description='Model checker')
 
     # does not build correctly with some old compilers -> rely on packages
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@:3.21')
     depends_on('boost@:1.69.0', when='@:3.21')
 
     conflicts('%gcc@10:', when='@:3.23',

--- a/var/spack/repos/builtin/packages/snap-korf/package.py
+++ b/var/spack/repos/builtin/packages/snap-korf/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 class SnapKorf(MakefilePackage):
     """SNAP is a general purpose gene finding program suitable for both
        eukaryotic and prokaryotic genomes."""

--- a/var/spack/repos/builtin/packages/source-highlight/package.py
+++ b/var/spack/repos/builtin/packages/source-highlight/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
@@ -25,7 +26,10 @@ class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
           sha256='45087b174b2b128a8dc81b0728f8ae63213d255ceef6dabfcba27c94e2a75ce9',
           when='%gcc@11:')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     # git version needs autotools
     depends_on('m4', when='@master')

--- a/var/spack/repos/builtin/packages/spot/package.py
+++ b/var/spack/repos/builtin/packages/spot/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Spot(AutotoolsPackage):
@@ -22,3 +23,8 @@ class Spot(AutotoolsPackage):
     depends_on("python@3.2:", when='@1.99: +python')
     depends_on("python@2:", when='+python')
     depends_on('boost', when='@:1.2.6')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@:1.2.6')

--- a/var/spack/repos/builtin/packages/stat/package.py
+++ b/var/spack/repos/builtin/packages/stat/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Stat(AutotoolsPackage):
@@ -63,7 +64,11 @@ class Stat(AutotoolsPackage):
     depends_on('py-xdot@1.0', when='@4.0.1: +gui')
     depends_on('swig')
     depends_on('mpi', when='+examples')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     patch('configure_mpicxx.patch', when='@2.1.0')
 

--- a/var/spack/repos/builtin/packages/strelka/package.py
+++ b/var/spack/repos/builtin/packages/strelka/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Strelka(CMakePackage):
@@ -33,3 +34,8 @@ class Strelka(CMakePackage):
     depends_on('bzip2')
     depends_on('cmake@2.8.5:', type='build')
     depends_on('boost@1.56.0:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)

--- a/var/spack/repos/builtin/packages/symengine/package.py
+++ b/var/spack/repos/builtin/packages/symengine/package.py
@@ -6,6 +6,7 @@
 import sys
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Symengine(CMakePackage):
@@ -51,6 +52,11 @@ class Symengine(CMakePackage):
     # NOTE: mpir is a drop-in replacement for gmp
     # NOTE: [mpc,mpfr,flint,piranha] could also be built against mpir
     depends_on('boost',    when='+boostmp')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boostmp')
     depends_on('gmp',      when='~boostmp')
     depends_on('llvm',     when='+llvm')
     depends_on('mpc',      when='+mpc~boostmp')

--- a/var/spack/repos/builtin/packages/sympol/package.py
+++ b/var/spack/repos/builtin/packages/sympol/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Sympol(CMakePackage):
@@ -17,7 +18,11 @@ class Sympol(CMakePackage):
     depends_on("cmake@2.6:", type="build")
 
     depends_on("bliss")
-    depends_on("boost")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("gmp")
     depends_on("lrslib")
 

--- a/var/spack/repos/builtin/packages/templight-tools/package.py
+++ b/var/spack/repos/builtin/packages/templight-tools/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class TemplightTools(CMakePackage):
@@ -16,3 +17,8 @@ class TemplightTools(CMakePackage):
 
     depends_on('cmake @2.8.7:', type='build')
     depends_on('boost @1.48.1: +filesystem +graph +program_options +test')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)

--- a/var/spack/repos/builtin/packages/tfel/package.py
+++ b/var/spack/repos/builtin/packages/tfel/package.py
@@ -7,6 +7,7 @@
 # 18/12/2018: fix python detection
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Tfel(CMakePackage):
@@ -131,6 +132,11 @@ class Tfel(CMakePackage):
     # As boost+py has py runtime dependency, boost+py needs types link and run as well:
     depends_on('boost+python+numpy', when='+python_bindings',
                type=('build', 'link', 'run'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+python_bindings')
 
     extends('python', when='+python_bindings')
 

--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Thepeg(AutotoolsPackage):
@@ -66,6 +67,11 @@ class Thepeg(AutotoolsPackage):
     depends_on('fastjet', when='@2.0.0:')
     depends_on('rivet', when='@2.0.3:')
     depends_on('boost', when='@2.1.1:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')

--- a/var/spack/repos/builtin/packages/thrift/package.py
+++ b/var/spack/repos/builtin/packages/thrift/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Thrift(Package):
@@ -39,6 +40,11 @@ class Thrift(Package):
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
     depends_on('boost@1.53:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('bison', type='build')
     depends_on('flex', type='build')
     depends_on('openssl')

--- a/var/spack/repos/builtin/packages/tophat/package.py
+++ b/var/spack/repos/builtin/packages/tophat/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Tophat(AutotoolsPackage):
@@ -25,6 +26,11 @@ class Tophat(AutotoolsPackage):
     depends_on('m4',       type='build')
 
     depends_on('boost@1.47:')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('bowtie2', type='run')
 
     parallel = False

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -11,6 +11,7 @@ from spack.build_environment import dso_suffix
 from spack.error import NoHeadersError
 from spack.pkg.builtin.boost import Boost
 from spack.operating_systems.mac_os import macos_version
+from spack.pkg.builtin.boost import Boost
 from spack.pkg.builtin.kokkos import Kokkos
 
 # Trilinos is complicated to build, as an inspiration a couple of links to

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -9,6 +9,7 @@ import sys
 from spack import *
 from spack.build_environment import dso_suffix
 from spack.error import NoHeadersError
+from spack.pkg.builtin.boost import Boost
 from spack.operating_systems.mac_os import macos_version
 from spack.pkg.builtin.kokkos import Kokkos
 
@@ -293,6 +294,10 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('blas')
     depends_on('boost', when='+boost')
     depends_on('cgns', when='+exodus')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('hdf5+hl', when='+hdf5')
     depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('kokkos-nvcc-wrapper', when='+wrapper')

--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -7,6 +7,7 @@ import glob
 import sys
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Valgrind(AutotoolsPackage, SourcewarePackage):
@@ -51,6 +52,11 @@ clang: error: unknown argument: '-static-libubsan'
 """)
     depends_on('mpi', when='+mpi')
     depends_on('boost', when='+boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+boost')
 
     depends_on("autoconf", type='build', when='@develop')
     depends_on("automake", type='build', when='@develop')

--- a/var/spack/repos/builtin/packages/veloc/package.py
+++ b/var/spack/repos/builtin/packages/veloc/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Veloc(CMakePackage):
@@ -24,7 +25,10 @@ class Veloc(CMakePackage):
     version('1.1', sha256='2bbdacf3e0ce4e7c9e360874d8d85b405525bdc7bd992bdb1f1ba49218072160')
     version('1.0', sha256='d594b73d6549a61fce8e67b8984a17cebc3e766fc520ed1636ae3683cdde77cb')
 
-    depends_on('boost')
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('libpthread-stubs')
     depends_on('mpi')
     depends_on('er')

--- a/var/spack/repos/builtin/packages/vigra/package.py
+++ b/var/spack/repos/builtin/packages/vigra/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Vigra(CMakePackage):
@@ -35,6 +36,11 @@ class Vigra(CMakePackage):
     depends_on('openexr', when='+exr')
     depends_on('py-numpy', type=('build', 'run'), when='+python')
     depends_on('boost+python+numpy', when='+python')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+python')
     depends_on('py-sphinx', type='build', when='+python')
     depends_on('doxygen', type='build', when='+cxxdoc')
     depends_on('python', type='build', when='+cxxdoc')

--- a/var/spack/repos/builtin/packages/votca-csg-tutorials/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg-tutorials/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class VotcaCsgTutorials(CMakePackage):
@@ -37,4 +38,8 @@ class VotcaCsgTutorials(CMakePackage):
     for v in ["1.4", "1.4.1", "1.5", "1.5.1", "1.6", "1.6.1", "1.6.2",
               "1.6.3", "1.6.4", "2021", "2021.1", "2021.2", "stable"]:
         depends_on('votca-csg@%s' % v, when="@%s:%s.0" % (v, v))
-    depends_on("boost")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)

--- a/var/spack/repos/builtin/packages/votca-csg/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class VotcaCsg(CMakePackage):
@@ -38,6 +39,9 @@ class VotcaCsg(CMakePackage):
     for v in ["1.4", "1.4.1", "1.5", "1.5.1", "1.6", "1.6.1", "1.6.2",
               "1.6.3", "1.6.4", "2021", "2021.1", "2021.2", "stable"]:
         depends_on('votca-tools@%s' % v, when="@%s:%s.0" % (v, v))
-    depends_on("boost")
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("gromacs~mpi@5.1:2019")
     depends_on("hdf5~mpi")

--- a/var/spack/repos/builtin/packages/votca-csgapps/package.py
+++ b/var/spack/repos/builtin/packages/votca-csgapps/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class VotcaCsgapps(CMakePackage):
@@ -33,4 +34,8 @@ class VotcaCsgapps(CMakePackage):
     for v in ["1.4", "1.4.1", "1.5", "1.5.1", "1.6", "1.6.1", "1.6.2",
               "1.6.3", "1.6.4"]:
         depends_on('votca-csg@%s' % v, when="@%s:%s.0" % (v, v))
-    depends_on("boost")
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)

--- a/var/spack/repos/builtin/packages/votca-tools/package.py
+++ b/var/spack/repos/builtin/packages/votca-tools/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class VotcaTools(CMakePackage):
@@ -47,7 +48,10 @@ class VotcaTools(CMakePackage):
     depends_on("fftw-api@3")
     depends_on("gsl", when="@1.4:1.4.9999")
     depends_on("eigen@3.3:", when="@stable,1.5:")
-    depends_on("boost")
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on("sqlite", when="@1.4:1.5")
     depends_on('mkl', when='+mkl')
 

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -8,6 +8,7 @@ import os
 import sys
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Vtk(CMakePackage):
@@ -99,6 +100,11 @@ class Vtk(CMakePackage):
 
     depends_on('boost', when='+xdmf')
     depends_on('boost+mpi', when='+xdmf +mpi')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='+xdmf')
     depends_on('ffmpeg', when='+ffmpeg')
     depends_on('mpi', when='+mpi')
 

--- a/var/spack/repos/builtin/packages/wcs/package.py
+++ b/var/spack/repos/builtin/packages/wcs/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Wcs(CMakePackage):
@@ -17,6 +18,11 @@ class Wcs(CMakePackage):
     version('develop', branch='devel')
 
     depends_on('boost+graph+filesystem+regex+system')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('sbml@5.18.0:+cpp')
     depends_on('cmake@3.12:', type='build')
     depends_on('cereal', type='build')

--- a/var/spack/repos/builtin/packages/wonton/package.py
+++ b/var/spack/repos/builtin/packages/wonton/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Wonton(CMakePackage):
@@ -54,6 +55,11 @@ class Wonton(CMakePackage):
 
     # We need boost only when no thrust option
     depends_on('boost', when='~thrust')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='~thrust')
 
     # NVidia thrust library
     depends_on('thrust@1.8.3', when='+thrust')

--- a/var/spack/repos/builtin/packages/wt/package.py
+++ b/var/spack/repos/builtin/packages/wt/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Wt(CMakePackage):
@@ -43,6 +44,11 @@ class Wt(CMakePackage):
 
     depends_on('pkgconfig', type='build')
     depends_on('boost@1.46.1:1.65')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('openssl', when='+openssl')
     depends_on('libharu', when='+libharu')
     depends_on('sqlite', when='+sqlite')

--- a/var/spack/repos/builtin/packages/xdmf3/package.py
+++ b/var/spack/repos/builtin/packages/xdmf3/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Xdmf3(CMakePackage):
@@ -23,7 +24,11 @@ class Xdmf3(CMakePackage):
     variant('mpi', default=True, description='Enable MPI')
 
     depends_on('libxml2')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('mpi', when='+mpi')
     depends_on('hdf5+mpi', when='+mpi')
     depends_on('hdf5~mpi', when='~mpi')

--- a/var/spack/repos/builtin/packages/xios/package.py
+++ b/var/spack/repos/builtin/packages/xios/package.py
@@ -7,6 +7,7 @@ import os
 
 #
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Xios(Package):
@@ -39,7 +40,11 @@ class Xios(Package):
     depends_on('netcdf-fortran')
     depends_on('hdf5+mpi')
     depends_on('mpi')
-    depends_on('boost')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants)
     depends_on('blitz')
     depends_on('perl', type='build')
     depends_on('perl-uri', type='build')

--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.spec import ConflictsInSpecError
+from spack.pkg.builtin.boost import Boost
 
 yaml_cpp_tests_libcxx_error_msg = 'yaml-cpp tests incompatible with libc++'
 
@@ -31,6 +32,11 @@ class YamlCpp(CMakePackage):
             description='Build yaml-cpp tests using internal gtest')
 
     depends_on('boost@:1.66', when='@0.5.0:0.5.3')
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@0.5.0:0.5.3')
 
     conflicts('%gcc@:4.7', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")
     conflicts('%clang@:3.3.0', when='@0.6.0:', msg="versions 0.6.0: require c++11 support")

--- a/var/spack/repos/builtin/packages/yaml-cpp/package.py
+++ b/var/spack/repos/builtin/packages/yaml-cpp/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.spec import ConflictsInSpecError
 from spack.pkg.builtin.boost import Boost
+from spack.spec import ConflictsInSpecError
 
 yaml_cpp_tests_libcxx_error_msg = 'yaml-cpp tests incompatible with libc++'
 

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.pkg.builtin.boost import Boost
 
 
 class Yoda(AutotoolsPackage):
@@ -65,6 +66,11 @@ class Yoda(AutotoolsPackage):
     depends_on('py-future', type=('build', 'run'))
     depends_on('zlib')
     depends_on('boost', when='@:1.6.0', type=('build', 'run'))
+
+    # TODO: replace this with an explicit list of components of Boost,
+    # for instance depends_on('boost +filesystem')
+    # See https://github.com/spack/spack/pull/22303 for reference
+    depends_on(Boost.with_default_variants, when='@:1.6.0', type=('build', 'run'))
     depends_on('py-cython@0.18:', type='build', when='@:1.4.0')
     depends_on('py-cython@0.20:', type='build', when='@1.4.0:1.6.5')
     depends_on('py-cython@0.23.5:', type='build', when='@1.6.5:1.8.0')


### PR DESCRIPTION
Make boost composable

Currently Boost enables a few components through variants by default,
which means that if you want to use only what you need and no more, you
have to explicitly disable these variants, leading to concretization
errors whenever a second package explicitly needs those components.

For instance if package A only needs `+component_a` it might depend on
`boost +component_a ~component_b`. And if packge B only needs
`+component_b` it might depend on `boost ~component_a +component_b`. If
package C now depends on both A and B, this leads to unsatisfiable
variants and hence a concretization error.

However, if we default to disabling all components, package A can simply
depend on `boost +component_a` and package B on `boost +component_b` and
package C will concretize to `^boost +component_a
+component_b`, 
and whatever you install, you get the bare minimum.


---

I've just restored the originally enabled variants by default for 5 of
the 200+ dependents of boost, but not pursuing that until this gets
feedback.
