### PR TITLE
r-v8: Fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/r-v8/package.py
+++ b/var/spack/repos/builtin/packages/r-v8/package.py
@@ -18,3 +18,11 @@ class RV8(RPackage):
     depends_on('r-curl@1.0:', type=('build', 'run'))
     depends_on('r-jsonlite@1.0:', type=('build', 'run'))
     depends_on('r-rcpp@0.12.12:', type=('build', 'run'))
+
+    conflicts('@3.4.0', when='target=aarch64:')
+
+    def setup_build_environment(self, env):
+        spec = self.spec
+        if ((spec.platform == 'darwin') or
+            (spec.platform == 'linux' and spec.target.family == 'x86_64')):
+            env.append_flags('DOWNLOAD_STATIC_LIBV8', '1')


### PR DESCRIPTION
I have fixed the following issues:

1 error found in build log:
     146    Alternatively, on Linux (x86_64) or MacOS you can set environment v
            ariable:
     147        DOWNLOAD_STATIC_LIBV8=1
     148    to automatically download a static version of libv8.
     149    To use a custom libv8, set INCLUDE_DIR and LIB_DIR manually via:
     150    R CMD INSTALL --configure-vars='INCLUDE_DIR=... LIB_DIR=...'
     151    ---------------------------[ ERROR MESSAGE ]-----------------------


