### PR TITLE
libflame: Fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -127,3 +127,5 @@ class Libflame(LibflameBase):
 
     provides('flame@5.2', when='@5.2.0')
     provides('flame@5.1', when='@5.1.0')
+
+    depends_on('python', type='build')


### PR DESCRIPTION
I got the following error when building this OSS in an environment where python is not installed on the system.
251    Generating monolithic include/x86_64-unknown-linux-gnu/FLAME.h/usr/bin/env: 'python': No such file or directory
252    make: *** [Makefile:446: include/x86_64-unknown-linux-gnu/FLAME.h]

I thought it would be better to add a python depend, so I'll fix it.