### PR TITLE
Fix overloaded -e flag in spack -e env location ..

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -56,7 +56,7 @@ def setup_parser(subparser):
         help="build directory for a spec "
              "(requires it to be staged first)")
     directories.add_argument(
-        '-e', '--env', action='store',
+        '-e', '--env', action='store', dest='location_env',
         help="location of an environment managed by spack")
 
     arguments.add_common_arguments(subparser, ['spec'])
@@ -71,10 +71,10 @@ def location(parser, args):
         print(spack.paths.prefix)
         return
 
-    if args.env:
-        path = spack.environment.root(args.env)
+    if args.location_env:
+        path = spack.environment.root(args.location_env)
         if not os.path.isdir(path):
-            tty.die("no such environment: '%s'" % args.env)
+            tty.die("no such environment: '%s'" % args.location_env)
         print(path)
         return
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -528,6 +528,8 @@ class SpackCommand(object):
 
         Keyword Args:
             fail_on_error (optional bool): Don't raise an exception on error
+            prepend_flags (optional list): List of flags to add before command:
+                simulates spack [prepend_flags] [command] [*argv]
 
         Returns:
             (str): combined output and error as a string
@@ -540,8 +542,10 @@ class SpackCommand(object):
         self.returncode = None
         self.error = None
 
+        prepend = kwargs['prepend_flags'] if 'prepend_flags' in kwargs else []
+
         args, unknown = self.parser.parse_known_args(
-            [self.command_name] + list(argv))
+            prepend + [self.command_name] + list(argv))
 
         fail_on_error = kwargs.get('fail_on_error', True)
 

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -528,8 +528,8 @@ class SpackCommand(object):
 
         Keyword Args:
             fail_on_error (optional bool): Don't raise an exception on error
-            prepend_flags (optional list): List of flags to add before command:
-                simulates spack [prepend_flags] [command] [*argv]
+            global_args (optional list): List of global spack arguments:
+                simulates ``spack [global_args] [command] [*argv]``
 
         Returns:
             (str): combined output and error as a string
@@ -542,7 +542,7 @@ class SpackCommand(object):
         self.returncode = None
         self.error = None
 
-        prepend = kwargs['prepend_flags'] if 'prepend_flags' in kwargs else []
+        prepend = kwargs['global_args'] if 'global_args' in kwargs else []
 
         args, unknown = self.parser.parse_known_args(
             prepend + [self.command_name] + list(argv))

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -95,7 +95,7 @@ def test_location_env_flag_interference(mock_test_env, tmpdir):
     env('create', '-d', other_env)
 
     assert location('-e', test_env_name,
-                    prepend_flags=['-e', 'other_env']).strip() == env_dir
+                    global_args=['-e', 'other_env']).strip() == env_dir
 
 
 def test_location_env_missing():

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -19,6 +19,7 @@ pytestmark = pytest.mark.usefixtures('config', 'database')
 
 # location prints out "locations of packages and spack directories"
 location = SpackCommand('location')
+env = SpackCommand('env')
 
 
 @pytest.fixture
@@ -82,6 +83,19 @@ def test_location_env(mock_test_env):
     """Tests spack location --env."""
     test_env_name, env_dir = mock_test_env
     assert location('--env', test_env_name).strip() == env_dir
+
+
+def test_location_env_flag_interference(mock_test_env, tmpdir):
+    """Tests that spack -e x location -e y gives the location of y."""
+    test_env_name, env_dir = mock_test_env
+
+    # create another anonymous environment
+    other_env = str(tmpdir.join('other_env'))
+    mkdirp(other_env)
+    env('create', '-d', other_env)
+
+    assert location('-e', test_env_name,
+                    prepend_flags=['-e', 'other_env']).strip() == env_dir
 
 
 def test_location_env_missing():

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -85,17 +85,25 @@ def test_location_env(mock_test_env):
     assert location('--env', test_env_name).strip() == env_dir
 
 
-def test_location_env_flag_interference(mock_test_env, tmpdir):
-    """Tests that spack -e x location -e y gives the location of y."""
-    test_env_name, env_dir = mock_test_env
+def test_location_env_flag_interference(mutable_mock_env_path, tmpdir):
+    """
+    Tests that specifying an active environment using `spack -e x location ...`
+    does not interfere with the location command flags.
+    """
 
-    # create another anonymous environment
-    other_env = str(tmpdir.join('other_env'))
-    mkdirp(other_env)
-    env('create', '-d', other_env)
+    # create two environments
+    env('create', 'first_env')
+    env('create', 'second_env')
 
-    assert location('-e', test_env_name,
-                    global_args=['-e', 'other_env']).strip() == env_dir
+    global_args = ['-e', 'first_env']
+
+    # `spack -e first_env location -e second_env` should print the env
+    # path of second_env
+    assert 'first_env' not in location('-e', 'second_env', global_args=global_args)
+
+    # `spack -e first_env location --packages` should not print
+    # the environment path of first_env.
+    assert 'first_env' not in location('--packages', global_args=global_args)
 
 
 def test_location_env_missing():


### PR DESCRIPTION
Fixes an issue where running

```spack -e . location -b some_package```

ends up printing the name of the environment instead of the build
directory of the package, because the location arg parser also stores
its `-e` flag as `arg.env`, just like the top-level arg parser.