### PR TITLE
Add `spack [cd|location] --source-dir`

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -48,7 +48,7 @@ def setup_parser(subparser):
         '-S', '--stages', action='store_true',
         help="top level stage directory")
     directories.add_argument(
-        '-c', '--source-dir', action='store_true',
+        '--source-dir', action='store_true',
         help="source directory for a spec "
              "(requires it to be staged first)")
     directories.add_argument(

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -48,8 +48,12 @@ def setup_parser(subparser):
         '-S', '--stages', action='store_true',
         help="top level stage directory")
     directories.add_argument(
+        '-c', '--source-dir', action='store_true',
+        help="source directory for a spec "
+             "(requires it to be staged first)")
+    directories.add_argument(
         '-b', '--build-dir', action='store_true',
-        help="checked out or expanded source directory for a spec "
+        help="build directory for a spec "
              "(requires it to be staged first)")
     directories.add_argument(
         '-e', '--env', action='store',
@@ -60,65 +64,68 @@ def setup_parser(subparser):
 
 def location(parser, args):
     if args.module_dir:
-        print(spack.paths.module_path)
+        return print(spack.paths.module_path)
 
-    elif args.spack_root:
-        print(spack.paths.prefix)
+    if args.spack_root:
+        return print(spack.paths.prefix)
 
-    elif args.env:
+    if args.env:
         path = spack.environment.root(args.env)
         if not os.path.isdir(path):
             tty.die("no such environment: '%s'" % args.env)
-        print(path)
+        return print(path)
 
-    elif args.packages:
-        print(spack.repo.path.first_repo().root)
+    if args.packages:
+        return print(spack.repo.path.first_repo().root)
 
-    elif args.stages:
-        print(spack.stage.get_stage_root())
+    if args.stages:
+        return print(spack.stage.get_stage_root())
 
-    else:
-        specs = spack.cmd.parse_specs(args.spec)
-        if not specs:
-            tty.die("You must supply a spec.")
-        if len(specs) != 1:
-            tty.die("Too many specs.  Supply only one.")
+    specs = spack.cmd.parse_specs(args.spec)
 
-        if args.install_dir:
-            # install_dir command matches against installed specs.
-            env = ev.get_env(args, 'location')
-            spec = spack.cmd.disambiguate_spec(specs[0], env)
-            print(spec.prefix)
+    if not specs:
+        tty.die("You must supply a spec.")
 
-        else:
-            spec = specs[0]
+    if len(specs) != 1:
+        tty.die("Too many specs.  Supply only one.")
 
-            if args.package_dir:
-                # This one just needs the spec name.
-                print(spack.repo.path.dirname_for_package_name(spec.name))
+    # install_dir command matches against installed specs.
+    if args.install_dir:
+        env = ev.get_env(args, 'location')
+        spec = spack.cmd.disambiguate_spec(specs[0], env)
+        return print(spec.prefix)
 
-            else:
-                spec = spack.cmd.matching_spec_from_env(spec)
-                pkg = spec.package
+    spec = specs[0]
 
-                if args.stage_dir:
-                    print(pkg.stage.path)
+    # Package dir just needs the spec name
+    if args.package_dir:
+        return print(spack.repo.path.dirname_for_package_name(spec.name))
 
-                else:  # args.build_dir is the default.
-                    if not pkg.stage.expanded:
-                        tty.die("Build directory does not exist yet. "
-                                "Run this to create it:",
-                                "spack stage " + " ".join(args.spec))
+    # Either concretize or filter from already concretized environment
+    spec = spack.cmd.matching_spec_from_env(spec)
+    pkg = spec.package
 
-                    # Out of source builds have build_directory defined
-                    if hasattr(pkg, 'build_directory'):
-                        # build_directory can be either absolute or relative
-                        # to the stage path in either case os.path.join makes it
-                        # absolute
-                        print(os.path.normpath(os.path.join(
-                            pkg.stage.path,
-                            pkg.build_directory
-                        )))
-                    else:
-                        # Otherwise assume in-source builds
-                        return print(pkg.stage.source_path)
+    if args.stage_dir:
+        return print(pkg.stage.path)
+
+    if args.build_dir:
+        # Out of source builds have build_directory defined
+        if hasattr(pkg, 'build_directory'):
+            # build_directory can be either absolute or relative to the stage path
+            # in either case os.path.join makes it absolute
+            return print(os.path.normpath(os.path.join(
+                pkg.stage.path,
+                pkg.build_directory
+            )))
+
+        # Otherwise assume in-source builds
+        return print(pkg.stage.source_path)
+
+    # source and build dir remain, they require the spec to be staged
+    if not pkg.stage.expanded:
+        tty.die("Source directory does not exist yet. "
+                "Run this to create it:",
+                "spack stage " + " ".join(args.spec))
+
+    if args.source_dir:
+        return print(pkg.stage.source_path)

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -64,22 +64,27 @@ def setup_parser(subparser):
 
 def location(parser, args):
     if args.module_dir:
-        return print(spack.paths.module_path)
+        print(spack.paths.module_path)
+        return
 
     if args.spack_root:
-        return print(spack.paths.prefix)
+        print(spack.paths.prefix)
+        return
 
     if args.env:
         path = spack.environment.root(args.env)
         if not os.path.isdir(path):
             tty.die("no such environment: '%s'" % args.env)
-        return print(path)
+        print(path)
+        return
 
     if args.packages:
-        return print(spack.repo.path.first_repo().root)
+        print(spack.repo.path.first_repo().root)
+        return
 
     if args.stages:
-        return print(spack.stage.get_stage_root())
+        print(spack.stage.get_stage_root())
+        return
 
     specs = spack.cmd.parse_specs(args.spec)
 
@@ -93,33 +98,38 @@ def location(parser, args):
     if args.install_dir:
         env = ev.get_env(args, 'location')
         spec = spack.cmd.disambiguate_spec(specs[0], env)
-        return print(spec.prefix)
+        print(spec.prefix)
+        return
 
     spec = specs[0]
 
     # Package dir just needs the spec name
     if args.package_dir:
-        return print(spack.repo.path.dirname_for_package_name(spec.name))
+        print(spack.repo.path.dirname_for_package_name(spec.name))
+        return
 
     # Either concretize or filter from already concretized environment
     spec = spack.cmd.matching_spec_from_env(spec)
     pkg = spec.package
 
     if args.stage_dir:
-        return print(pkg.stage.path)
+        print(pkg.stage.path)
+        return
 
     if args.build_dir:
         # Out of source builds have build_directory defined
         if hasattr(pkg, 'build_directory'):
             # build_directory can be either absolute or relative to the stage path
             # in either case os.path.join makes it absolute
-            return print(os.path.normpath(os.path.join(
+            print(os.path.normpath(os.path.join(
                 pkg.stage.path,
                 pkg.build_directory
             )))
+            return
 
         # Otherwise assume in-source builds
-        return print(pkg.stage.source_path)
+        print(pkg.stage.source_path)
+        return
 
     # source and build dir remain, they require the spec to be staged
     if not pkg.stage.expanded:
@@ -128,4 +138,5 @@ def location(parser, args):
                 "spack stage " + " ".join(args.spec))
 
     if args.source_dir:
-        return print(pkg.stage.source_path)
+        print(pkg.stage.source_path)
+        return

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -52,18 +52,24 @@ def test_location_build_dir(mock_spec):
     assert location('--build-dir', spec.name).strip() == pkg.stage.source_path
 
 
-def test_location_build_dir_missing():
-    """Tests spack location --build-dir with a missing build directory."""
+def test_location_source_dir(mock_spec):
+    """Tests spack location --source-dir."""
+    spec, pkg = mock_spec
+    assert location('--source-dir', spec.name).strip() == pkg.stage.source_path
+
+
+def test_location_source_dir_missing():
+    """Tests spack location --source-dir with a missing source directory."""
     spec = 'mpileaks'
     prefix = "==> Error: "
-    expected = "%sBuild directory does not exist yet. Run this to create it:"\
+    expected = "%sSource directory does not exist yet. Run this to create it:"\
                "%s  spack stage %s" % (prefix, os.linesep, spec)
-    out = location('--build-dir', spec, fail_on_error=False).strip()
+    out = location('--source-dir', spec, fail_on_error=False).strip()
     assert out == expected
 
 
 @pytest.mark.parametrize('options', [([]),
-                                     (['--build-dir', 'mpileaks']),
+                                     (['--source-dir', 'mpileaks']),
                                      (['--env', 'missing-env']),
                                      (['spec1', 'spec2'])])
 def test_location_cmd_error(options):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -453,7 +453,7 @@ _spack_buildcache_update_index() {
 _spack_cd() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -b --build-dir -e --env"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env"
     else
         _all_packages
     fi
@@ -1089,7 +1089,7 @@ _spack_load() {
 _spack_location() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -b --build-dir -e --env"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -453,7 +453,7 @@ _spack_buildcache_update_index() {
 _spack_cd() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env"
     else
         _all_packages
     fi
@@ -1089,7 +1089,7 @@ _spack_load() {
 _spack_location() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages -c --source-dir -b --build-dir -e --env"
+        SPACK_COMPREPLY="-h --help -m --module-dir -r --spack-root -i --install-dir -p --package-dir -P --packages -s --stage-dir -S --stages --source-dir -b --build-dir -e --env"
     else
         _all_packages
     fi


### PR DESCRIPTION
Edit: this pr was split into two. #22348 was merged as a bug fix to make
`--build-dir` do the sensible thing for out of source builds.

And this PR now just adds `--source-dir` as an additional option without a short-hand since both -s and -S are taken.
