### PR TITLE
The action to detect changes needs a repository to be checked out on push event

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -77,6 +77,10 @@ jobs:
       packages: ${{ steps.filter.outputs.packages }}
       with_coverage: ${{ steps.coverage.outputs.with_coverage }}
     steps:
+    - uses: actions/checkout@v2
+      if: ${{ github.event_name == 'push' }}
+      with:
+        fetch-depth: 0
     # For pull requests it's not necessary to checkout the code
     - uses: dorny/paths-filter@v2
       id: filter


### PR DESCRIPTION
#22247 broke CI on `develop` since the action that compute changes fails on push events. Apparently a checkout of the repository is needed in that case.