### PR TITLE
fix weird failure in variant values

### DIFF
--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -282,8 +282,21 @@ class AbstractVariant(object):
         # to a set
         self._value = tuple(sorted(set(value)))
 
+    def _cmp_value(self):
+        """Returns a tuple of strings containing the values stored in
+        the variant.
+
+        Returns:
+            tuple of str: values stored in the variant
+        """
+        value = self._value
+        if not isinstance(value, tuple):
+            value = (value,)
+        stringified = tuple(str(x) for x in value)
+        return stringified
+
     def _cmp_key(self):
-        return self.name, self.value
+        return self.name, self._cmp_value()
 
     def copy(self):
         """Returns an instance of a variant equivalent to self


### PR DESCRIPTION
This failure occurs on python 3, and occurs when a value is `None`, which gets stringified, instead of tuplified. We may be able to use mypy types in a followup PR to help ensure that we return `Tuple[Hashable, ...]` instead of possibly just `None`.