### PR TITLE
Minor fix to example for different container base images

### DIFF
--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -227,7 +227,7 @@ following ``spack.yaml``:
 
      container:
        images:
-         os: centos/7
+         os: centos:7
          spack: 0.15.4
 
 uses ``spack/centos7:0.15.4``  and ``centos:7`` for the stages where the


### PR DESCRIPTION
[Example link on readthedocs](https://spack.readthedocs.io/en/latest/containers.html#use-official-spack-images-from-dockerhub).

Before this fix, `spack containerize` complains that `centos/7` is invalid (with spack 0.16.1).
```
==> Error: {'os': 'centos/7', 'spack': '0.15.4'} is not valid under any of the given schemas

Failed validating 'anyOf' in schema['patternProperties']['^env|spack$']['properties']['container']['properties']['images']:
    {'anyOf': [{'additionalProperties': False,
                'properties': {'os': {'enum': ['ubuntu:18.04',
                                               'ubuntu:16.04',
                                               'centos:7',
                                               'centos:6'],
                                      'type': 'string'},
                               'spack': {'type': 'string'}},
                'required': ['os', 'spack'],
                'type': 'object'},
               {'additionalProperties': False,
                'properties': {'build': {'type': 'string'},
                               'final': {'type': 'string'}},
                'required': ['build', 'final'],
                'type': 'object'}]}

On instance['spack']['container']['images']:
    {'os': 'centos/7', 'spack': '0.15.4'}
```