### PR TITLE
Fix pythia6 install (issue #22330)

### DIFF
--- a/var/spack/repos/builtin/packages/pythia6/pythia6.patch
+++ b/var/spack/repos/builtin/packages/pythia6/pythia6.patch
@@ -276,8 +276,8 @@ diff -Naur upveto.f upveto.f
        RETURN
        END
 + 
---- src/pystrf.f.orig	2014-05-14 18:12:02.000000001 +0200
-+++ src/pystrf.f	2014-05-14 18:10:23.000000001 +0200
+--- pystrf.f.orig	2014-05-14 18:12:02.000000001 +0200
++++ pystrf.f	2014-05-14 18:10:23.000000001 +0200
 @@ -805,7 +805,9 @@
   
  C...Closed string: random initial breakup flavour, pT and vertex.


### PR DESCRIPTION
fixes #22330 

Fixes incorrect path in `pythia6/pythia6.patch`.