### PR TITLE
amrex: add gcc 8 conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -91,6 +91,11 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('%apple-clang')
     conflicts('%clang')
 
+    # these versions of gcc have lambda function issues
+    # see https://github.com/spack/spack/issues/22310
+    conflicts('%gcc@8.1.0:8.3.0', when='@21.03')
+    conflicts('%gcc@8.1.0:8.2.0', when='@21.01:21.02')
+
     # Check options compatibility
     conflicts('+sundials', when='~fortran',
               msg='AMReX SUNDIALS support needs AMReX Fortran API (+fortran)')


### PR DESCRIPTION
GCC 8.1-8.3 are known to have some lambda function related issues that can cause segfaults when building certain versions of `amrex`. This PR adds conflict statements to identify these.

|       | 8.1.0    | 8.2.0    | 8.3.0    |
|-------|----------|----------|----------|
| 21.03 | SEGFAULT | SEGFAULT | SEGFAULT |
| 21.02 | SEGFAULT | SEGFAULT | OK       |
| 21.01 | SEGFAULT | SEGFAULT | OK       |

*Top row is GCC version
*Left column is Amrex version

Fixes https://github.com/spack/spack/issues/22310

See also https://github.com/AMReX-Codes/amrex/issues/1870

@mic84 @sethrj 