### PR TITLE
make location --build-dir return build directory (take 2)

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -109,4 +109,16 @@ def location(parser, args):
                         tty.die("Build directory does not exist yet. "
                                 "Run this to create it:",
                                 "spack stage " + " ".join(args.spec))
-                    print(pkg.stage.source_path)
+
+                    # Out of source builds have build_directory defined
+                    if hasattr(pkg, 'build_directory'):
+                        # build_directory can be either absolute or relative
+                        # to the stage path in either case os.path.join makes it
+                        # absolute
+                        print(os.path.normpath(os.path.join(
+                            pkg.stage.path,
+                            pkg.build_directory
+                        )))
+                    else:
+                        # Otherwise assume in-source builds
+                        return print(pkg.stage.source_path)


### PR DESCRIPTION
Same as #22321 except it doesn't introduce new features (like --source-dir) so that we can merge this faster as a bugfix
