### PR TITLE
fixing the perf regression issues with OpenMPI v4.0.x till v4.1.0 for x86_64

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/opal_assembly_arch.patch
+++ b/var/spack/repos/builtin/packages/openmpi/opal_assembly_arch.patch
@@ -1,0 +1,27 @@
+diff --git a/opal/include/opal/sys/gcc_builtin/atomic.h b/opal/include/opal/sys/gcc_builtin/atomic.h
+index d85ff02bd6a..a465fdae5db 100644
+--- a/opal/include/opal/sys/gcc_builtin/atomic.h
++++ b/opal/include/opal/sys/gcc_builtin/atomic.h
+@@ -13,8 +13,8 @@
+  * Copyright (c) 2011      Sandia National Laboratories. All rights reserved.
+  * Copyright (c) 2014-2017 Los Alamos National Security, LLC. All rights
+  *                         reserved.
+- * Copyright (c) 2016-2017 Research Organization for Information Science
+- *                         and Technology (RIST). All rights reserved.
++ * Copyright (c) 2016-2021 Research Organization for Information Science
++ *                         and Technology (RIST).  All rights reserved.
+  * Copyright (c) 2018      Triad National Security, LLC. All rights
+  *                         reserved.
+  * $COPYRIGHT$
+@@ -61,9 +61,8 @@ static inline void opal_atomic_rmb(void)
+ {
+ #if OPAL_ASSEMBLY_ARCH == OPAL_X86_64
+     /* work around a bug in older gcc versions where ACQUIRE seems to get
+-     * treated as a no-op instead of being equivalent to
+-     * __asm__ __volatile__("": : :"memory") */
+-    __atomic_thread_fence (__ATOMIC_SEQ_CST);
++     * treated as a no-op instead */
++    __asm__ __volatile__("": : :"memory");
+ #else
+     __atomic_thread_fence (__ATOMIC_ACQUIRE);
+ #endif

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -188,13 +188,8 @@ class Openmpi(AutotoolsPackage):
     # The second patch was applied starting version v4.0.0 and backported to
     # v2.x, v3.0.x, and v3.1.x.
     patch('use_mpi_tkr_sizeof/step_2.patch', when='@1.8.4:2.1.3,3:3.0.1')
-    # in order to work around a bug in older gcc versions on x86_64,
-    # __atomic_thread_fence (__ATOMIC_SEQ_CST)
-    # was replaced with
-    # __atomic_thread_fence (__ATOMIC_ACQUIRE)
-    # based on the asumption that this did not introduce performance regressions.
-    # Refs. open-mpi/ompi#8603
-    # It was recently found that this did introduce some performance regression.
+    # To fix performance regressions introduced while fixing a bug in older
+    # gcc versions on x86_64, Refs. open-mpi/ompi#8603
     patch('opal_assembly_arch.patch', when='@4.0.0:4.1.1')
 
     variant(

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -188,6 +188,14 @@ class Openmpi(AutotoolsPackage):
     # The second patch was applied starting version v4.0.0 and backported to
     # v2.x, v3.0.x, and v3.1.x.
     patch('use_mpi_tkr_sizeof/step_2.patch', when='@1.8.4:2.1.3,3:3.0.1')
+    # in order to work around a bug in older gcc versions on x86_64,
+    # __atomic_thread_fence (__ATOMIC_SEQ_CST)
+    # was replaced with
+    # __atomic_thread_fence (__ATOMIC_ACQUIRE)
+    # based on the asumption that this did not introduce performance regressions.
+    # Refs. open-mpi/ompi#8603
+    # It was recently found that this did introduce some performance regression.
+    patch('opal_assembly_arch.patch', when='@4.0.0:4.1.1')
 
     variant(
         'fabrics',


### PR DESCRIPTION
in order to work around a bug in older gcc versions on x86_64,
__atomic_thread_fence (__ATOMIC_SEQ_CST)
was replaced with
__atomic_thread_fence (__ATOMIC_ACQUIRE)
based on the asumption that this did not introduce performance regressions.

It was recently found that this did introduce some performance regression,
mainly at scale on fat nodes.

So simply use an asm memory globber to both workaround older gcc bugs
and fix the performance regression.

Thanks S. Biplab Raut for bringing this issue to our attention.

Refs. open-mpi/ompi#8603

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>