### PR TITLE
Fix: bash shell wrapper can't handle spack flag arguments

### DIFF
--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -97,7 +97,7 @@ title 'Testing `spack cd`'
 contains "usage: spack cd " spack cd -h
 contains "usage: spack cd " spack cd --help
 contains "cd $b_install" spack cd -i b
-contains "cd $b_install" spack -k -c config:ccache:true -cconfig:ccache:false --color always cd -i b
+contains "cd $b_install" spack -kc config:ccache:true -cconfig:ccache:false --color always cd -i b
 
 title 'Testing `spack module`'
 contains "usage: spack module " spack -m module -h
@@ -136,20 +136,20 @@ contains "usage: spack env " spack env --help
 
 title 'Testing `spack env list`'
 contains " spack env list " spack env list -h
-contains " spack env list " spack -k -c config:ccache:true -cconfig:ccache:false --color always env list -h
+contains " spack env list " spack -kc config:ccache:true -cconfig:ccache:false --color always env list -h
 contains " spack env list " spack env list --help
 
 title 'Testing `spack env activate`'
 contains "No such environment:" spack env activate no_such_environment
 contains "usage: spack env activate " spack env activate
-contains "usage: spack env activate " spack -k -c config:ccache:true -cconfig:ccache:false --color always env activate
+contains "usage: spack env activate " spack -kc config:ccache:true -cconfig:ccache:false --color always env activate
 contains "usage: spack env activate " spack env activate -h
 contains "usage: spack env activate " spack env activate --help
 
 title 'Testing `spack env deactivate`'
 contains "Error: No environment is currently active" spack env deactivate
 contains "usage: spack env deactivate " spack env deactivate no_such_environment
-contains "usage: spack env deactivate " spack -k -c config:ccache:true -cconfig:ccache:false --color always env deactivate no_such_environment
+contains "usage: spack env deactivate " spack -kc config:ccache:true -cconfig:ccache:false --color always env deactivate no_such_environment
 contains "usage: spack env deactivate " spack env deactivate -h
 contains "usage: spack env deactivate " spack env deactivate --help
 

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -97,6 +97,7 @@ title 'Testing `spack cd`'
 contains "usage: spack cd " spack cd -h
 contains "usage: spack cd " spack cd --help
 contains "cd $b_install" spack cd -i b
+contains "cd $b_install" spack -k -c config:ccache:true -cconfig:ccache:false --color always cd -i b
 
 title 'Testing `spack module`'
 contains "usage: spack module " spack -m module -h
@@ -111,6 +112,7 @@ fails spack -m load -l
 contains "export LD_LIBRARY_PATH=$(spack -m location -i a)/lib:$(spack -m location -i b)/lib" spack -m load --sh a
 succeeds spack -m load --only dependencies a
 succeeds spack -m load --only package a
+succeeds spack -m -c config:ccache:true -cconfig:ccache:false --color always load --only package a
 fails spack -m load d
 contains "usage: spack load " spack -m load -h
 contains "usage: spack load " spack -m load -h d
@@ -120,6 +122,7 @@ title 'Testing `spack unload`'
 spack -m load b a  # setup
 succeeds spack -m unload b
 succeeds spack -m unload --all
+succeeds spack -m -c config:ccache:true -cconfig:ccache:false --color always unload --all
 spack -m unload --all # cleanup
 fails spack -m unload -l
 fails spack -m unload d
@@ -133,17 +136,20 @@ contains "usage: spack env " spack env --help
 
 title 'Testing `spack env list`'
 contains " spack env list " spack env list -h
+contains " spack env list " spack -k -c config:ccache:true -cconfig:ccache:false --color always env list -h
 contains " spack env list " spack env list --help
 
 title 'Testing `spack env activate`'
 contains "No such environment:" spack env activate no_such_environment
 contains "usage: spack env activate " spack env activate
+contains "usage: spack env activate " spack -k -c config:ccache:true -cconfig:ccache:false --color always env activate
 contains "usage: spack env activate " spack env activate -h
 contains "usage: spack env activate " spack env activate --help
 
 title 'Testing `spack env deactivate`'
 contains "Error: No environment is currently active" spack env deactivate
 contains "usage: spack env deactivate " spack env deactivate no_such_environment
+contains "usage: spack env deactivate " spack -k -c config:ccache:true -cconfig:ccache:false --color always env deactivate no_such_environment
 contains "usage: spack env deactivate " spack env deactivate -h
 contains "usage: spack env deactivate " spack env deactivate --help
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -70,22 +70,41 @@ _spack_shell_wrapper() {
                 _sp_flags="$_sp_flags $1 $2"
                 shift 2
                 ;;
-            -c*|-e*|-D*)
-                # short flags taking values
-                flag="${1:0:2}"
-                arg="${1:2}"
-                if [ -z "$arg" ]; then shift; arg="$1"; fi
-                _sp_flags="$_sp_flags $flag $arg"
-                shift
-                ;;
-            -h|--help|-V|--version)
+            --help|--version)
+                # special early return flags
                 help_or_version_was_used=1
                 _sp_flags="$_sp_flags $1"
                 shift
                 ;;
-            -*)
-                # flags that take no values
+            --*)
+                # long flags taking no value
                 _sp_flags="$_sp_flags $1"
+                shift
+                ;;
+            -*)
+                # loop over all single character flags (e.g. -kle[env]), but
+                # skip the dash before the flag, so start at 1
+                for (( i=1 ; i<${#1}; i++ )); do
+                    flag="${1:$i:1}"
+                    case "$flag" in
+                        c|C|e|D)
+                            # flags with required values
+                            val="${1:((i+1))}"
+                            if [ -z "$val" ]; then shift; val="$1"; fi
+                            _sp_flags="$_sp_flags -$flag $val"
+                            break
+                            ;;
+                        h|V)
+                            # special early return flags
+                            help_or_version_was_used=1
+                            _sp_flags="$_sp_flags -$flag"
+                            ;;
+                        *)
+                            # flags not taking a value
+                            _sp_flags="$_sp_flags -$flag"
+                            ;;
+                    esac
+                done
                 shift
                 ;;
             *)


### PR DESCRIPTION
Currently `spack -e . cd spec_from_env_in_current_working_dir` fails
because the `-e .` flag is not passed to the `location` command in the
shell wrapper.

More generally some spack flags allow for values (color, config, env,
env-dir + their short hand versions) and spack mistakenly uses the value
of these flags as a command (for instance `spack --env cd spec x`
changes directories instead of showing `spec x`...).

So we should simply handle values better by parsing the args

Closes #22359