### PR TITLE
clingo: modify recipe for bootstrapping

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -5,7 +5,11 @@
 import contextlib
 import os
 import sys
-import sysconfig
+try:
+    import sysconfig  # novm
+except ImportError:
+    # Not supported on Python 2.6
+    pass
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -32,7 +36,7 @@ def spec_for_current_python():
     """
     version_str = '.'.join(str(x) for x in sys.version_info[:2])
     variant_str = ''
-    if sys.version_info[0] == 2:
+    if sys.version_info[0] == 2 and sys.version_info[1] == 7:
         unicode_size = sysconfig.get_config_var('Py_UNICODE_SIZE')
         variant_str = '+ucs4' if unicode_size == 4 else '~ucs4'
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -83,9 +83,10 @@ def make_module_available(module, spec=None, install=False):
     # We can constrain by a shortened version in place of a version range
     # because this spec is only used for querying or as a placeholder to be
     # replaced by an external that already has a concrete version. This syntax
-    # is not suffucient when concretizing without an external, as it will
+    # is not sufficient when concretizing without an external, as it will
     # concretize to python@X.Y instead of python@X.Y.Z
-    spec.constrain('^python@%d.%d' % sys.version_info[:2])
+    python_requirement = '^' + spec_for_current_python()
+    spec.constrain(python_requirement)
     installed_specs = spack.store.db.query(spec, installed=True)
 
     for ispec in installed_specs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -253,14 +253,11 @@ class PyclingoDriver(object):
             # TODO: Find a way to vendor the concrete spec
             # in a cross-platform way
             with spack.bootstrap.ensure_bootstrap_configuration():
-                generic_target = archspec.cpu.host().family
-                spec_str = 'clingo-bootstrap@spack+python target={0}'.format(
-                    str(generic_target)
-                )
-                clingo_spec = spack.spec.Spec(spec_str)
+                clingo_spec = spack.bootstrap.clingo_root_spec()
                 clingo_spec._old_concretize()
                 spack.bootstrap.make_module_available(
-                    'clingo', spec=clingo_spec, install=True)
+                    'clingo', spec=clingo_spec, install=True
+                )
                 import clingo
         self.out = asp or llnl.util.lang.Devnull()
         self.cores = cores

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -9,6 +9,9 @@ import spack.compilers
 
 class ClingoBootstrap(Clingo):
     """Clingo with some options used for bootstrapping"""
+
+    maintainers = ['alalazo']
+
     variant('build_type', default='Release', values=('Release',),
             description='CMake build type')
 
@@ -40,6 +43,16 @@ class ClingoBootstrap(Clingo):
 
     # Clingo needs the Python module to be usable by Spack
     conflicts('~python', msg='Python support is required to bootstrap Spack')
+
+    def cmake_args(self):
+        args = super(ClingoBootstrap, self).cmake_args()
+        args.extend([
+            # Avoid building the clingo executable
+            self.define('CLINGO_BUILD_APPS', 'OFF'),
+            # Do not link to libpython
+            self.define('PYCLINGO_DYNAMIC_LOOKUP', 'ON')
+        ])
+        return args
 
     def setup_build_environment(self, env):
         if '%apple-clang platform=darwin' in self.spec:

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -44,6 +44,10 @@ class ClingoBootstrap(Clingo):
     # Clingo needs the Python module to be usable by Spack
     conflicts('~python', msg='Python support is required to bootstrap Spack')
 
+    @property
+    def cmake_py_shared(self):
+        return self.define('CLINGO_BUILD_PY_SHARED', 'OFF')
+
     def cmake_args(self):
         args = super(ClingoBootstrap, self).cmake_args()
         args.extend([

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -49,8 +49,6 @@ class ClingoBootstrap(Clingo):
         args.extend([
             # Avoid building the clingo executable
             self.define('CLINGO_BUILD_APPS', 'OFF'),
-            # Do not link to libpython
-            self.define('PYCLINGO_DYNAMIC_LOOKUP', 'ON')
         ])
         return args
 

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -56,8 +56,13 @@ class Clingo(CMakePackage):
         """Return standard CMake defines to ensure that the
         current spec is the one found by CMake find_package(Python, ...)
         """
+        python_spec = self.spec['python']
+        library_dir = python_spec.package.get_python_lib()
+        include_dir = python_spec.package.get_python_inc()
         return [
-            '-DPython_EXECUTABLE={0}'.format(str(self.spec['python'].command))
+            self.define('Python_EXECUTABLE', str(python_spec.command)),
+            self.define('Python_LIBRARY', library_dir),
+            self.define('Python_INCLUDE_DIR', include_dir)
         ]
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -21,7 +21,7 @@ class Clingo(CMakePackage):
     url      = "https://github.com/potassco/clingo/archive/v5.2.2.tar.gz"
     git      = 'https://github.com/potassco/clingo.git'
 
-    maintainers = ["tgamblin"]
+    maintainers = ["tgamblin", "alalazo"]
 
     version('master', branch='master', submodules=True, preferred=True)
     version('spack', commit='2a025667090d71b2c9dce60fe924feb6bde8f667', submodules=True)
@@ -69,12 +69,15 @@ class Clingo(CMakePackage):
         args = [
             '-DCLINGO_REQUIRE_PYTHON=ON',
             '-DCLINGO_BUILD_WITH_PYTHON=ON',
-            '-DCLINGO_BUILD_PY_SHARED=ON',
             '-DPYCLINGO_USER_INSTALL=OFF',
             '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
             '-DCLINGO_BUILD_WITH_LUA=OFF'
         ]
         if self.spec['cmake'].satisfies('@3.16.0:'):
             args += self.cmake_python_hints
+
+        args.append(self.define(
+            'CLINGO_BUILD_PY_SHARED', self.spec['python'].satisfies('+shared')
+        ))
 
         return args

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -57,13 +57,15 @@ class Clingo(CMakePackage):
         current spec is the one found by CMake find_package(Python, ...)
         """
         python_spec = self.spec['python']
-        library_dir = python_spec.package.get_python_lib()
         include_dir = python_spec.package.get_python_inc()
         return [
             self.define('Python_EXECUTABLE', str(python_spec.command)),
-            self.define('Python_LIBRARY', library_dir),
             self.define('Python_INCLUDE_DIR', include_dir)
         ]
+
+    @property
+    def cmake_py_shared(self):
+        return self.define('CLINGO_BUILD_PY_SHARED', 'ON')
 
     def cmake_args(self):
         try:
@@ -76,13 +78,10 @@ class Clingo(CMakePackage):
             '-DCLINGO_BUILD_WITH_PYTHON=ON',
             '-DPYCLINGO_USER_INSTALL=OFF',
             '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
-            '-DCLINGO_BUILD_WITH_LUA=OFF'
+            '-DCLINGO_BUILD_WITH_LUA=OFF',
+            self.cmake_py_shared
         ]
         if self.spec['cmake'].satisfies('@3.16.0:'):
             args += self.cmake_python_hints
-
-        args.append(self.define(
-            'CLINGO_BUILD_PY_SHARED', self.spec['python'].satisfies('+shared')
-        ))
 
         return args


### PR DESCRIPTION
fixes #22463 

Modifications:
- [x] infer Python spec for bootstrapping using the `sys` module instead of `external find` (faster)
- [x] give hints to find Python headers
- [x] avoid building the clingo app and libpyclingo when bootstrapping
- [x] hint compiler to be used and operating system 
