### PR TITLE
openblas: fix older versions

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -220,8 +220,13 @@ class Openblas(MakefilePackage):
             # match for the requested one. Allow OpenBLAS to determine
             # an optimized kernel at run time, including older CPUs, while
             # forcing it not to add flags for the current host compiler.
-            args.extend(['DYNAMIC_ARCH=1', 'DYNAMIC_OLDER=1',
-                         'TARGET=GENERIC'])
+            args.append('DYNAMIC_ARCH=1')
+            if self.spec.version >= Version('0.3.12'):
+                # These are necessary to prevent OpenBLAS from targeting the
+                # host architecture on newer version of OpenBLAS, but they
+                # cause build errors on 0.3.5 .
+                args.extend(['DYNAMIC_OLDER=1', 'TARGET=GENERIC'])
+
         elif microarch.name in skylake:
             # Special case for renaming skylake family
             args.append('TARGET=SKYLAKEX')


### PR DESCRIPTION
Fixes OpenBLAS 0.3.5 build,  #22342 . Confirmed it fails on develop and passes after this fix.