### PR TITLE
Fix broken spack -c flag

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -467,7 +467,7 @@ def setup_main_options(args):
 
     # Use the spack config command to handle parsing the config strings
     for config_var in (args.config_vars or []):
-        spack.config.add(path=config_var, scope="command_line")
+        spack.config.add(fullpath=config_var, scope="command_line")
 
     # when to use color (takes always, auto, or never)
     color.set_color_when(args.color)


### PR DESCRIPTION
This one line was missed according to codecov from #22251 and also has a bug. The comments from the PR say

> ```# I don't know how to add a spack argument to a Spack Command, so we test this way```

So we better make that possible. That's done in https://github.com/spack/spack/pull/22318. That PR would make testing https://github.com/spack/spack/pull/22353 easier too...
