### PR TITLE
Windows Logging Class

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -670,7 +670,7 @@ class log_output(object):
 
 
 class StreamWrapper:
-    ''' Wrapper class to handle redirection of io streams '''
+    """ Wrapper class to handle redirection of io streams """
     def __init__(self, sys_attr):
         self.sys_attr = sys_attr
         self.saved_stream = None
@@ -732,7 +732,7 @@ class StreamWrapper:
         self.sys_stream.flush()
 
     def close(self):
-        '''Redirect back to the original system stream, and close stream'''
+        """Redirect back to the original system stream, and close stream"""
         try:
             if self.saved_stream is not None:
                 self.redirect_stream(self.saved_stream)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -53,7 +53,7 @@ import spack.repo
 import spack.store
 
 from llnl.util.tty.color import colorize
-from llnl.util.tty.log import log_output, logwin32_output
+from llnl.util.tty.log import log_output, winlog
 from spack.util.environment import dump_environment
 from spack.util.executable import which
 
@@ -1697,7 +1697,7 @@ def build_process(pkg, kwargs):
                 # Spawn a daemon that reads from a pipe and redirects
                 # everything to log_path
                 if sys.platform == 'win32':
-                    with logwin32_output(pkg.log_path, echo, True,
+                    with winlog(pkg.log_path, True, True,
                                     env=unmodified_env) as logger:
 
                         # Debug this child process from here

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -25,7 +25,7 @@ import archspec.cpu
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
-from llnl.util.tty.log import log_output
+from llnl.util.tty.log import log_output, winlog
 
 import spack
 import spack.architecture
@@ -541,9 +541,14 @@ class SpackCommand(object):
 
         out = StringIO()
         try:
-            with log_output(out):
-                self.returncode = _invoke_command(
-                    self.command, self.parser, args, unknown)
+            if sys.platform == 'win32':
+                with winlog(out):
+                    self.returncode = _invoke_command(
+                        self.command, self.parser, args, unknown)
+            else:
+                with log_output(out):
+                    self.returncode = _invoke_command(
+                        self.command, self.parser, args, unknown)
 
         except SystemExit as e:
             self.returncode = e.code


### PR DESCRIPTION
Add `winlog` class to log.py, a context manager which redirects stdout and stderr to a logfile, then uses a thread to read line-by-line the output, and optionally display it to the user, if echo is True. Output to user's stdout should be displayed in almost real time as a process executes. 
Unit tests which depend on logging can now be executed (many may still not pass, but they are running on Windows)
To test: 
`spack install cpuinfo` (or another package known to be windows compatible)
`spack unit-test lib\spack\spack\test\views.py` (or git_fetch, spec_dag, spec_yaml, test_activations, etc)