### PR TITLE
bump mochi-margo to 0.9.2

### DIFF
--- a/var/spack/repos/builtin/packages/margo/package.py
+++ b/var/spack/repos/builtin/packages/margo/package.py
@@ -18,7 +18,7 @@ class Margo(AutotoolsPackage):
     maintainers = ['carns', 'mdorier', 'fbudin69500', 'chuckatkins']
 
     version('master', branch='master', deprecated=True)
-    version('0.9.1', sha256='3fe933f2d758ef23d582bc776e4f8cfae9bf9d0849b8b1f9d73ee024e218f2bc')
+    version('0.9.1', sha256='3fe933f2d758ef23d582bc776e4f8cfae9bf9d0849b8b1f9d73ee024e218f2bc', deprecated=True)
     version('0.9', sha256='a24376f66450cc8fd7a43043e189f8efce5a931585e53c1e2e41894a3e99b517', deprecated=True)
     version('0.7', sha256='492d1afe2e7984fa638614a5d34486d2ff761f5599b5984efd5ae3f55cafde54', deprecated=True)
     version('0.7.2', sha256='0ca796abdb82084813a5de033d92364910b5ad1a0df135534d6b1c36ef627859', deprecated=True)

--- a/var/spack/repos/builtin/packages/mochi-margo/package.py
+++ b/var/spack/repos/builtin/packages/mochi-margo/package.py
@@ -17,6 +17,9 @@ class MochiMargo(AutotoolsPackage):
     maintainers = ['carns', 'mdorier', 'fbudin69500', 'chuckatkins']
 
     version('main', branch='main')
+    version('0.9.4', sha256='4292e083c8375ab07bc6dd0b3b1ea2ce9c9dd864c27ac7f07c6913dcccecc746')
+    version('0.9.3', sha256='1331423d4864349c3a9ec52b2114122659da310d5270fa1aea652e8ee48a0b3a')
+    version('0.9.2', sha256='de88cd725c8ff3ec63412f3f5ed22ad1a56cb367c31b842c816ce40cba777f7c')
     version('0.9.1', sha256='3fe933f2d758ef23d582bc776e4f8cfae9bf9d0849b8b1f9d73ee024e218f2bc')
     version('0.9', sha256='a24376f66450cc8fd7a43043e189f8efce5a931585e53c1e2e41894a3e99b517')
     version('0.7', sha256='492d1afe2e7984fa638614a5d34486d2ff761f5599b5984efd5ae3f55cafde54')


### PR DESCRIPTION
Adds new version 0.9.2 to mochi-margo and deprecated margo packages.