### PR TITLE
boost: fixed detect system icu bug on version 1.65.0 or older.

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -545,10 +545,7 @@ class Boost(Package):
 
         threading_opts = self.determine_b2_options(spec, b2_options)
 
-        if spec.satisfies('@:1.65'):
-            b2('--clean', *b2_options)
-        else:
-            b2('--clean')
+        b2('--clean', *b2_options)
 
         # In theory it could be done on one call but it fails on
         # Boost.MPI if the threading options are not separated.

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -545,7 +545,10 @@ class Boost(Package):
 
         threading_opts = self.determine_b2_options(spec, b2_options)
 
-        b2('--clean')
+        if spec.satisfies('@:1.65'):
+            b2('--clean', *b2_options)
+        else:
+            b2('--clean')
 
         # In theory it could be done on one call but it fails on
         # Boost.MPI if the threading options are not separated.


### PR DESCRIPTION
The boost 1.65.0 or older, `b2 --clean`  create cache, and following `b2 install` use the cache.
If icu4c is installed by system and we specifies `~icu`, `b2 --clean` detect system's icu, and `b2 install` use the icu.

This PR add `b2 options` to `b2 --install` to avoid add cache to system installed icu.