### PR TITLE
Spack recipes for AOCL 3.0

### DIFF
--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -29,7 +29,7 @@ class Amdblis(BlisBase):
         spec = self.spec
         args = super(Amdblis, self).configure_args()
 
-        if spec.satisfies('@3.0%aocc'):
+        if spec.satisfies('@3.0 %aocc'):
             """ To enabled Fortran to C calling convention for
             complex types when compiling with aocc flang"""
             args.append('CFLAGS={0}'.format("-DAOCL_F2C"))

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -29,9 +29,10 @@ class Amdblis(BlisBase):
         spec = self.spec
         args = super(Amdblis, self).configure_args()
 
-        if "@3.0%aocc@3.0.0" in spec:
+        if spec.satisfies('@3.0%aocc'):
             """ To enabled Fortran to C calling convention for
             complex types when compiling with aocc flang"""
             args.append('CFLAGS={0}'.format("-DAOCL_F2C"))
             args.append('CXXFLAGS={0}'.format("-DAOCL_F2C"))
+
         return args

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -17,9 +17,21 @@ class Amdblis(BlisBase):
 
     _name = 'amdblis'
     homepage = "https://developer.amd.com/amd-aocl/blas-library/"
-    url = "https://github.com/amd/blis/archive/2.2.tar.gz"
+    url = "https://github.com/amd/blis/archive/3.0.tar.gz"
     git = "https://github.com/amd/blis.git"
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.0', sha256='ac848c040cd6c3550fe49148dbdf109216cad72d3235763ee7ee8134e1528517')
     version('2.2', sha256='e1feb60ac919cf6d233c43c424f6a8a11eab2c62c2c6e3f2652c15ee9063c0c9')
+
+    def configure_args(self):
+        spec = self.spec
+        args = super(Amdblis, self).configure_args()
+
+        if "@3.0%aocc@3.0.0" in spec:
+            """ To enabled Fortran to C calling convention for
+            complex types when compiling with aocc flang"""
+            args.append('CFLAGS={0}'.format("-DAOCL_F2C"))
+            args.append('CXXFLAGS={0}'.format("-DAOCL_F2C"))
+        return args

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -25,11 +25,12 @@ class Amdfftw(FftwBase):
 
     _name = 'amdfftw'
     homepage = "https://developer.amd.com/amd-aocl/fftw/"
-    url = "https://github.com/amd/amd-fftw/archive/2.2.tar.gz"
+    url = "https://github.com/amd/amd-fftw/archive/3.0.tar.gz"
     git = "https://github.com/amd/amd-fftw.git"
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.0', sha256='a69deaf45478a59a69f77c4f7e9872967f1cfe996592dd12beb6318f18ea0bcd')
     version('2.2', sha256='de9d777236fb290c335860b458131678f75aa0799c641490c644c843f0e246f8')
 
     variant('shared', default=True, description='Builds a shared version of the library')

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -31,14 +31,13 @@ class Amdlibflame(LibflameBase):
 
     _name = 'amdlibflame'
     homepage = "http://developer.amd.com/amd-cpu-libraries/blas-library/#libflame"
-    url = "https://github.com/amd/libflame/archive/2.2.tar.gz"
+    url = "https://github.com/amd/libflame/archive/3.0.tar.gz"
     git = "https://github.com/amd/libflame.git"
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.0', sha256='d94e08b688539748571e6d4c1ec1ce42732eac18bd75de989234983c33f01ced')
     version('2.2', sha256='12b9c1f92d2c2fa637305aaa15cf706652406f210eaa5cbc17aaea9fcfa576dc')
-
-    depends_on('python', type='build')
 
     patch('aocc-2.2.0.patch', when="@:2.999", level=1)
 
@@ -56,6 +55,12 @@ class Amdlibflame(LibflameBase):
         """configure_args function"""
         args = super(Amdlibflame, self).configure_args()
         args.append("--enable-external-lapack-interfaces")
+
+        """To enabled Fortran to C calling convention for
+        complex types when compiling with aocc flang"""
+        if "@3.0: %aocc" in self.spec:
+            args.append("--enable-f2c-dotc")
+
         return args
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/amdlibm/package.py
+++ b/var/spack/repos/builtin/packages/amdlibm/package.py
@@ -24,10 +24,8 @@ class Amdlibm(SConsPackage):
     # of master branch.
     # To install amdlibm from latest master branch:
     # spack install amdlibm ^amdlibm@master
-    version("master", branch="master")
-    version("20201104",
-            commit="4033e022da428125747e118ccd6fdd9cee21c470",
-            preferred=True)
+    version("3.0", branch="aocl-3.0")
+    version("2.2", commit="4033e022da428125747e118ccd6fdd9cee21c470")
 
     variant("verbose", default=False,
             description="Building with verbosity")
@@ -37,8 +35,8 @@ class Amdlibm(SConsPackage):
     depends_on("scons@3.1.2:", type=("build"))
     depends_on("mpfr", type=("link"))
 
-    patch('0001-libm-ose-Scripts-cleanup-pyc-files.patch')
-    patch('0002-libm-ose-prevent-log-v3.c-from-building.patch')
+    patch("0001-libm-ose-Scripts-cleanup-pyc-files.patch", when="@2.2")
+    patch("0002-libm-ose-prevent-log-v3.c-from-building.patch", when="@2.2")
 
     conflicts("%gcc@:9.1.999", msg="Minimum required GCC version is 9.2.0")
 

--- a/var/spack/repos/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/builtin/packages/amdscalapack/package.py
@@ -39,13 +39,13 @@ class Amdscalapack(ScalapackBase):
         args = super(Amdscalapack, self).cmake_args()
         spec = self.spec
 
-        if "%gcc@10:" in spec:
+        if spec.satisfies('%gcc@10:'):
             args.extend(['-DCMAKE_Fortran_FLAGS={0}'.format(
                         "-fallow-argument-mismatch")])
 
-        if "@2.2" in spec:
+        if spec.satisfies('@2.2'):
             args.extend(['-DUSE_DOTC_WRAPPER:BOOL=%s' % (
-                        'ON' if '%aocc ^amdblis' in spec else 'OFF')])
+                        'ON' if spec.satisfies('%aocc ^amdblis') else 'OFF')])
 
         args.extend([
             '-DUSE_F2C=ON',

--- a/var/spack/repos/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/builtin/packages/amdscalapack/package.py
@@ -20,11 +20,12 @@ class Amdscalapack(ScalapackBase):
 
     _name = 'amdscalapack'
     homepage = "https://developer.amd.com/amd-aocl/scalapack/"
-    url = "https://github.com/amd/scalapack/archive/2.2.tar.gz"
+    url = "https://github.com/amd/scalapack/archive/3.0.tar.gz"
     git = "https://github.com/amd/scalapack.git"
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.0', sha256='6e6f3578f44a8e64518d276e7580530599ecfa8729f568303ed2590688e7096f')
     version('2.2', sha256='2d64926864fc6d12157b86e3f88eb1a5205e7fc157bf67e7577d0f18b9a7484c')
 
     variant(
@@ -38,11 +39,13 @@ class Amdscalapack(ScalapackBase):
         args = super(Amdscalapack, self).cmake_args()
         spec = self.spec
 
-        args.extend([
-            "-DUSE_DOTC_WRAPPER:BOOL=%s" % (
-                'ON' if '%aocc ^amdblis' in spec else 'OFF'
-            )
-        ])
+        if "%gcc@10:" in spec:
+            args.extend(['-DCMAKE_Fortran_FLAGS={0}'.format(
+                        "-fallow-argument-mismatch")])
+
+        if "@2.2" in spec:
+            args.extend(['-DUSE_DOTC_WRAPPER:BOOL=%s' % (
+                        'ON' if '%aocc ^amdblis' in spec else 'OFF')])
 
         args.extend([
             '-DUSE_F2C=ON',

--- a/var/spack/repos/builtin/packages/aocl-sparse/package.py
+++ b/var/spack/repos/builtin/packages/aocl-sparse/package.py
@@ -73,7 +73,7 @@ class AoclSparse(CMakePackage):
                 'ON' if self.run_tests else 'OFF')
         ])
 
-        if "@3.0:" in spec:
+        if spec.satisfies('@3.0:'):
             args.extend([
                 "-DBUILD_ILP64:BOOL=%s" % (
                     'ON' if '+ilp64' in spec else 'OFF')
@@ -81,11 +81,10 @@ class AoclSparse(CMakePackage):
 
         return args
 
-    # Check that self.prefix is there after installation
     @run_after('build')
     @on_package_attributes(run_tests=True)
     def check(self):
-        """ Simple test to test the installation by running
+        """ Simple test to test the built library by running
         one of the aocl-sparse examples, after compiling the
         library with benchmarks.
         """

--- a/var/spack/repos/builtin/packages/aocl-sparse/package.py
+++ b/var/spack/repos/builtin/packages/aocl-sparse/package.py
@@ -5,7 +5,6 @@
 
 from spack import *
 import os
-import inspect
 
 
 class AoclSparse(CMakePackage):
@@ -15,11 +14,12 @@ class AoclSparse(CMakePackage):
     library supports SPMV function with CSR and ELLPACK formats."""
 
     homepage = "https://developer.amd.com/amd-aocl/aocl-sparse/"
-    url = "https://github.com/amd/aocl-sparse/archive/2.2.tar.gz"
+    url = "https://github.com/amd/aocl-sparse/archive/3.0.tar.gz"
     git = "https://github.com/amd/aocl-sparse.git"
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.0',  sha256='1d04ba16e04c065051af916b1ed9afce50296edfa9b1513211a7378e1d6b952e')
     version('2.2',  sha256='33c2ed6622cda61d2613ee63ff12c116a6cd209c62e54307b8fde986cd65f664')
 
     conflicts("%gcc@:9.1.999", msg="Minimum required GCC version is 9.2.0")
@@ -29,8 +29,10 @@ class AoclSparse(CMakePackage):
             values=('Debug', 'Release'))
     variant('shared', default=True,
             description='Build shared library')
+    variant('ilp64', default=False,
+            description='Build with ILP64 support')
 
-    depends_on('boost')
+    depends_on('boost', when='@2.2')
 
     @property
     def build_directory(self):
@@ -39,18 +41,19 @@ class AoclSparse(CMakePackage):
         :return: directory where to build the package
         """
 
-        builddir = self.stage.source_path
+        build_directory = self.stage.source_path
 
         if self.spec.variants['build_type'].value == 'Debug':
-            builddir = join_path(self.stage.source_path, 'build', 'debug')
+            build_directory = join_path(build_directory, 'build', 'debug')
         else:
-            builddir = join_path(self.stage.source_path, 'build', 'release')
+            build_directory = join_path(build_directory, 'build', 'release')
 
-        mkdirp(builddir)
-        return builddir
+        return build_directory
 
-    def cmake(self, spec, prefix):
+    def cmake_args(self):
         """Runs ``cmake`` in the build directory"""
+        spec = self.spec
+
         args = [
             "../..",
             "-DCMAKE_INSTALL_PREFIX:PATH={0}".format(spec.prefix),
@@ -64,18 +67,19 @@ class AoclSparse(CMakePackage):
 
         args.extend([
             "-DBUILD_SHARED_LIBS:BOOL=%s" % (
-                'ON' if '+shared' in spec else 'OFF'
-            )
-        ])
+                'ON' if '+shared' in spec else 'OFF'),
 
-        args.extend([
             "-DBUILD_CLIENTS_BENCHMARKS:BOOL=%s" % (
-                'ON' if self.run_tests else 'OFF'
-            )
+                'ON' if self.run_tests else 'OFF')
         ])
 
-        with working_dir(self.build_directory, create=True):
-            inspect.getmodule(self).cmake(*args)
+        if "@3.0:" in spec:
+            args.extend([
+                "-DBUILD_ILP64:BOOL=%s" % (
+                    'ON' if '+ilp64' in spec else 'OFF')
+            ])
+
+        return args
 
     # Check that self.prefix is there after installation
     @run_after('build')
@@ -88,19 +92,16 @@ class AoclSparse(CMakePackage):
         dso_suffix = 'so' if '+shared' in self.spec else 'a'
 
         if self.spec.variants['build_type'].value == 'Debug':
-            build_path = join_path(self.stage.source_path, 'build', 'debug')
-            lib_path = join_path(build_path,
+            lib_path = join_path(self.build_directory,
                                  'library',
                                  'libaoclsparse-d.{0}'.format(dso_suffix))
         else:
-            build_path = join_path(self.stage.source_path, 'build', 'release')
-            lib_path = join_path(build_path,
+            lib_path = join_path(self.build_directory,
                                  'library',
                                  'libaoclsparse.{0}'.format(dso_suffix))
 
-        # with working_dir(join_path(build_path, 'tests', 'staging')):
-        bin_path = join_path(build_path, 'tests', 'staging', 'aoclsparse-bench')
-        bin_args = " --function=csrmv --precision=d "
-        bin_args = bin_args + "--sizem=1000 --sizen=1000 --sizennz=4000 --verify=1 "
-        unit_test = bin_path + bin_args + lib_path
-        os.system(unit_test)
+        test_bench_bin = join_path(self.build_directory, 'tests',
+                                   'staging', 'aoclsparse-bench')
+        test_args = " --function=csrmv --precision=d "
+        test_args += "--sizem=1000 --sizen=1000 --sizennz=4000 --verify=1 "
+        os.system(test_bench_bin + test_args + lib_path)

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -80,14 +80,17 @@ class BlisBase(Package):
         else:
             config_args.append("--disable-static")
 
-        # FIXME: add cpu isa variants.
-        config_args.append("auto")
-
         return config_args
 
     def configure(self, spec, prefix):
+        config_args = self.configure_args()
+
+        # To ensure auto should always be the
+        # last argument for base and derived class
+        config_args.append("auto")
+
         configure("--prefix=" + prefix,
-                  *self.configure_args())
+                  *config_args)
 
     def build(self, spec, prefix):
         make()

--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -53,7 +53,8 @@ class BlisBase(Package):
 
     phases = ['configure', 'build', 'install']
 
-    def configure(self, spec, prefix):
+    def configure_args(self):
+        spec = self.spec
         config_args = []
 
         config_args.append("--enable-threading=" +
@@ -82,8 +83,11 @@ class BlisBase(Package):
         # FIXME: add cpu isa variants.
         config_args.append("auto")
 
+        return config_args
+
+    def configure(self, spec, prefix):
         configure("--prefix=" + prefix,
-                  *config_args)
+                  *self.configure_args())
 
     def build(self, spec, prefix):
         make()


### PR DESCRIPTION
(1) blis - changed configure function with configure_args name which
    will return args to configure function

(2) amdblis - reused configure_args from blis package using super
    function and updated the amdblis specific flags for 3.0 version

(3) amdlibflame - Enabling '--enable-f2c-dotc' flags from version 3.0
    onwards

(4) amdlibm - Added reference to 3.0 release branch

(5) amdscalapack - Added reference to 3.0 release

(6) aocl-sparse - Added suport for ilp64 variant from version 3.0
   Incorporated review comments from previous below pull request
   https://github.com/spack/spack/pull/22276