### PR TITLE
notify and error out on more unsupported versions

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -29,10 +29,13 @@ from __future__ import print_function
 import os
 import sys
 
-if sys.version_info[:2] < (2, 6):
+if sys.version_info[:2] < (2, 6) or (
+        sys.version_info[:2] >= (3, 0)
+    and sys.version_info[:2] < (3, 5)
+    ):
     v_info = sys.version_info[:3]
-    sys.exit("Spack requires Python 2.6 or higher."
-             "This is Python %d.%d.%d." % v_info)
+    sys.exit("Spack requires Python 2.6, 2.7 or 3.5-3.9"
+             "You are running spack with Python %d.%d.%d." % v_info)
 
 # Find spack's location and its prefix.
 spack_file = os.path.realpath(os.path.expanduser(__file__))

--- a/bin/spack
+++ b/bin/spack
@@ -32,9 +32,8 @@ import sys
 min_python3 = (3, 5)
 
 if sys.version_info[:2] < (2, 6) or (
-        sys.version_info[:2] >= (3, 0)
-    and sys.version_info[:2] < min_python3
-    ):
+    sys.version_info[:2] >= (3, 0) and sys.version_info[:2] < min_python3
+):
     v_info = sys.version_info[:3]
     msg = "Spack requires Python 2.6, 2.7 or %d.%d or higher " % min_python3
     msg += "You are running spack with Python %d.%d.%d." % v_info
@@ -52,9 +51,9 @@ sys.path.insert(0, spack_lib_path)
 spack_external_libs = os.path.join(spack_lib_path, "external")
 
 if sys.version_info[:2] <= (2, 7):
-    sys.path.insert(0, os.path.join(spack_external_libs, 'py2'))
+    sys.path.insert(0, os.path.join(spack_external_libs, "py2"))
 if sys.version_info[:2] == (2, 6):
-    sys.path.insert(0, os.path.join(spack_external_libs, 'py26'))
+    sys.path.insert(0, os.path.join(spack_external_libs, "py26"))
 
 sys.path.insert(0, spack_external_libs)
 
@@ -64,11 +63,11 @@ sys.path.insert(0, spack_external_libs)
 # Briefly: ruamel.yaml produces a .pth file when installed with pip that
 # makes the site installed package the preferred one, even though sys.path
 # is modified to point to another version of ruamel.yaml.
-if 'ruamel.yaml' in sys.modules:
-    del sys.modules['ruamel.yaml']
+if "ruamel.yaml" in sys.modules:
+    del sys.modules["ruamel.yaml"]
 
-if 'ruamel' in sys.modules:
-    del sys.modules['ruamel']
+if "ruamel" in sys.modules:
+    del sys.modules["ruamel"]
 
 import spack.main  # noqa
 

--- a/bin/spack
+++ b/bin/spack
@@ -36,8 +36,9 @@ if sys.version_info[:2] < (2, 6) or (
     and sys.version_info[:2] < min_python3
     ):
     v_info = sys.version_info[:3]
-    sys.exit("Spack requires Python 2.6, 2.7 or %d.%d or higher" % min_python3
-             "You are running spack with Python %d.%d.%d." % v_info)
+    msg = "Spack requires Python 2.6, 2.7 or %d.%d or higher " % min_python3
+    msg += "You are running spack with Python %d.%d.%d." % v_info
+    sys.exit(msg)
 
 # Find spack's location and its prefix.
 spack_file = os.path.realpath(os.path.expanduser(__file__))

--- a/bin/spack
+++ b/bin/spack
@@ -29,12 +29,14 @@ from __future__ import print_function
 import os
 import sys
 
+min_python3 = (3, 5)
+
 if sys.version_info[:2] < (2, 6) or (
         sys.version_info[:2] >= (3, 0)
-    and sys.version_info[:2] < (3, 5)
+    and sys.version_info[:2] < min_python3
     ):
     v_info = sys.version_info[:3]
-    sys.exit("Spack requires Python 2.6, 2.7 or 3.5-3.9"
+    sys.exit("Spack requires Python 2.6, 2.7 or %d.%d or higher" % min_python3
              "You are running spack with Python %d.%d.%d." % v_info)
 
 # Find spack's location and its prefix.


### PR DESCRIPTION
This is to help debug situations like #22383, where python3.4 is
accidentally preferred over python2.  It will also help on systems where
there is no python2 available or some other issue.