### PR TITLE
use link/run deps only to compare extensions

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -429,8 +429,8 @@ class YamlViewExtensionsLayout(ExtensionsLayout):
     def check_extension_conflict(self, spec, ext_spec):
         exts = self._extension_map(spec)
         if ext_spec.name in exts:
-            installed_spec = exts[ext_spec.name]
-            if ext_spec == installed_spec:
+            installed_spec = exts[ext_spec.name].copy(deps=('link', 'run'))
+            if ext_spec.copy(deps=('link', 'run')) == installed_spec:
                 raise ExtensionAlreadyInstalledError(spec, ext_spec)
             else:
                 raise ExtensionConflictError(spec, ext_spec, installed_spec)


### PR DESCRIPTION
Fixes #22392

When spack compares extensions, some specs may include or strip build dependencies. Since we use the dag_hash to compare for install purposes, the dag_hash (link/run deps only) is the correct granularity of equivalence check in this case.