### PR TITLE
Exclude Python 3.5 3.6 3.7 3.8 from PRs

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -120,6 +120,13 @@ jobs:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
         concretizer: ['original', 'clingo']
+        is_pr:
+        - ${{ github.event_name == 'pull_request' }}
+        exclude:
+        - {is_pr: true, python-version: 3.5}
+        - {is_pr: true, python-version: 3.6}
+        - {is_pr: true, python-version: 3.7}
+        - {is_pr: true, python-version: 3.8}
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
CI runs unbearably slow, so why don't stick to testing newest and oldest supported python in PRs, and test all supported versions when merged.
