### PR TITLE
CI: drastically reduce the number of tests for package only PRs

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -73,8 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
-      core: ${{ steps.filter.outputs.core }}
-      packages: ${{ steps.filter.outputs.packages }}
+      packages: ${{ steps.filter.outputs.core }}
+      core: ${{ steps.filter.outputs.packages }}
       with_coverage: ${{ steps.coverage.outputs.with_coverage }}
     steps:
     - uses: actions/checkout@v2
@@ -332,7 +332,7 @@ jobs:
           coverage xml
         else
           echo "ONLY PACKAGE RECIPES CHANGED [skipping coverage]"
-          $(which spack) unit-test -x -m "not maybeslow"
+          $(which spack) unit-test -x -m "not maybeslow" -k "package_sanity"
         fi
     - uses: codecov/codecov-action@v1
       if: ${{ needs.changes.outputs.with_coverage == 'true' }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -73,8 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
-      packages: ${{ steps.filter.outputs.core }}
-      core: ${{ steps.filter.outputs.packages }}
+      core: ${{ steps.filter.outputs.core }}
+      packages: ${{ steps.filter.outputs.packages }}
       with_coverage: ${{ steps.coverage.outputs.with_coverage }}
     steps:
     - uses: actions/checkout@v2
@@ -87,9 +87,9 @@ jobs:
       with:
         # See https://github.com/dorny/paths-filter/issues/56 for the syntax used below
         filters: |
-          core:
-          - './!(var/**)/**'
           packages:
+          - './!(var/**)/**'
+          core:
           - 'var/**'
     # Some links for easier reference:
     #

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -87,9 +87,9 @@ jobs:
       with:
         # See https://github.com/dorny/paths-filter/issues/56 for the syntax used below
         filters: |
-          packages:
-          - './!(var/**)/**'
           core:
+          - './!(var/**)/**'
+          packages:
           - 'var/**'
     # Some links for easier reference:
     #

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -44,7 +44,7 @@ spack -p --lines 20 spec mpileaks%gcc ^elfutils@0.170
 #-----------------------------------------------------------
 if [[ "$ONLY_PACKAGES" == "true" ]]; then
   echo "ONLY PACKAGE RECIPES CHANGED [skipping slow unit tests]"
-  export PYTEST_ADDOPTS='-m "not maybeslow"'
+  export PYTEST_ADDOPTS='-k "package_sanity" -m "not maybeslow"'
 fi
 
 $coverage_run $(which spack) unit-test -x --verbose


### PR DESCRIPTION
PRs that change only package recipes will only run tests under `package_sanity.py` and without coverage. This should result in a huge drop the cpu-time spent in CI for most PRs.