### PR TITLE
Fix python interpreter line for bowtie2

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -33,6 +33,7 @@ class Bowtie2(MakefilePackage):
 
     # seems to have trouble with 6's -std=gnu++14
     conflicts('%gcc@6:', when='@:2.3.1')
+    conflicts('^intel-oneapi-tbb', when='@:2.3.5.1')
     conflicts('@:2.3.5.0', when='target=aarch64:')
     conflicts('@2.4.1', when='target=aarch64:')
 
@@ -45,7 +46,7 @@ class Bowtie2(MakefilePackage):
         files = ['bowtie2', ]
         filter_file(match, substitute, *files, **kwargs)
 
-        match = '^#!/usr/bin/env python'
+        match = '^#!/usr/bin/env python.*'
         python = spec['python'].command
         substitute = "#!{python}".format(python=python)
         files = ['bowtie2-build', 'bowtie2-inspect']


### PR DESCRIPTION
Beginning with version 2.4.1, the python interpreter line changed from

"#!/usr/bin/env python" to "#!/usr/bin/env python3"

That caused the bowtie2-build and bowtie2-inspect scripts to have a
trailing '3' at the end of the interpreter line. This PR fixes that. I
also observed that older versions do not build with intel-oneapi-tbb
so added a conflicts statement for that.