### PR TITLE
CI: treat push to develop in the same way as PRs

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -98,14 +98,12 @@ jobs:
     # setting environment variables from earlier steps: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
     #
     - id: coverage
-      # Run the subsequent jobs with coverage if this is a PR and core has been modified
-      # or if this workflow is triggered by a push event (this means that once a PR is
-      # merged we'll perform a full run with CI on develop even though the PR was only
-      # modifying packages)
+      # Run the subsequent jobs with coverage if core has been modified,
+      # regardless of whether this is a pull request or a push to a branch
       run: |
         echo Core changes: ${{ steps.filter.outputs.core }}
         echo Event name: ${{ github.event_name }}
-        if [ "${{ steps.filter.outputs.core }}" == "true" ] || [ "${{ github.event_name }}" == 'push' ]
+        if [ "${{ steps.filter.outputs.core }}" == "true" ]
         then
           echo "::set-output name=with_coverage::true"
         else


### PR DESCRIPTION
This change will make pushes to develop behave the same as the corresponding PR for CI:
-  If we merge to develop only changes to packages we'll run a reduced set of unit tests with no coverage
-  If we change anything outside the built-in repository we'll run the full unit-test suite with coverage

Given the ratio of package only PRs / core changes this should have a great impact on the cpu-time required for CI.