### PR TITLE
Silo: adding the library spec for dependents

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -119,3 +119,10 @@ class Silo(AutotoolsPackage):
             config_args.append('FC=%s' % spec['mpi'].mpifc)
 
         return config_args
+
+    @property
+    def libs(self):
+        shared = "+shared" in self.spec
+        return find_libraries(
+            "libsilo*", root=self.prefix, shared=shared, recursive=True
+        )


### PR DESCRIPTION
Adding an access to the spec for the silo libs.link_flags for the dependents since Silo+hdf5 provides libsiloh5.so not libsilo.so
Following reference :
https://spack-tutorial.readthedocs.io/en/latest/tutorial_advanced_packaging.html#retrieving-library-information
"If you do need access to the spec, you can create a property like so"
This PR replaces "lib2deps_package_silo" where I got confused commits.