### PR TITLE
concretizer: improve display of optimization criteria

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -207,6 +207,9 @@ class Result(object):
         self.answers = []
         self.cores = []
 
+        # names of optimization criteria
+        self.criteria = []
+
     def print_cores(self):
         for core in self.cores:
             tty.msg(
@@ -357,6 +360,7 @@ class PyclingoDriver(object):
                 return x.string or str(x)
 
         if result.satisfiable:
+            # build spec from the best model
             builder = SpecBuilder(specs)
             min_cost, best_model = min(models)
             tuples = [
@@ -364,7 +368,19 @@ class PyclingoDriver(object):
                 for sym in best_model
             ]
             answers = builder.build_specs(tuples)
+
+            # add best spec to the results
             result.answers.append((list(min_cost), 0, answers))
+
+            # pull optimization criteria names out of the solution
+            criteria = [
+                (int(args[0]), args[1]) for name, args in tuples
+                if name == "opt_criterion"
+            ]
+            result.criteria = [t[1] for t in sorted(criteria, reverse=True)]
+
+            # record the number of models the solver considered
+            result.nmodels = len(models)
 
         elif cores:
             symbols = dict(

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -676,19 +676,31 @@ no_flags(Package, FlagType)
 %-----------------------------------------------------------------------------
 % How to optimize the spec (high to low priority)
 %-----------------------------------------------------------------------------
+% Each criterion below has:
+%   1. an opt_criterion(ID, Name) fact that describes the criterion, and
+%   2. a `#minimize{ 0@2 : #true }.` statement that ensures the criterion
+%      is displayed (clingo doesn't display sums over empty sets by default)
 
 % The highest priority is to minimize the:
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root(Package)
-#minimize { Weight@15 : root(Package),version_weight(Package, Weight)}.
+opt_criterion(15, "version weight").
+#minimize{ 0@15 : #true }.
+#minimize { Weight@15 : root(Package),version_weight(Package, Weight) }.
+
+opt_criterion(14, "number of non-default variants (roots)").
+#minimize{ 0@14 : #true }.
 #minimize {
     Weight@14,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight), root(Package)
 }.
+
 % If the value is a multivalued variant there could be multiple
 % values set as default. Since a default value has a weight of 0 we
 % need to maximize their number below to ensure they're all set
+opt_criterion(13, "multi-valued variants + preferred providers for roots").
+#minimize{ 0@13 : #true }.
 #maximize {
     1@13,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight),
@@ -701,19 +713,27 @@ no_flags(Package, FlagType)
 }.
 
 % Try to use default variants or variants that have been set
+opt_criterion(11, "number of non-default variants (non-roots)").
+#minimize{ 0@11 : #true }.
 #minimize {
     Weight@11,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight), not root(Package)
 }.
+
 % Minimize the weights of the providers, i.e. use as much as
 % possible the most preferred providers
+opt_criterion(9, "number of non-default providers (non-roots)").
+#minimize{ 0@9 : #true }.
 #minimize{
     Weight@9,Provider
     : provider_weight(Provider, Weight), not root(Provider)
 }.
+
 % If the value is a multivalued variant there could be multiple
 % values set as default. Since a default value has a weight of 0 we
 % need to maximize their number below to ensure they're all set
+opt_criterion(8, "count of non-root multi-valued variants").
+#minimize{ 0@8 : #true }.
 #maximize {
     1@8,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight),
@@ -725,18 +745,29 @@ no_flags(Package, FlagType)
 % while minimizing the number of nodes. This is done because
 % a maximization on the number of matches for compilers is highly
 % correlated to a preference to have as many nodes as possible
+opt_criterion(7, "compiler matches + number of nodes").
+#minimize{ 0@7 : #true }.
 #minimize{ 1@7,Package : node(Package) }.
 #maximize{ Weight@7,Package : compiler_version_match(Package, Weight) }.
 
 % Choose more recent versions for nodes
+opt_criterion(6, "version badness").
+#minimize{ 0@6 : #true }.
 #minimize{
     Weight@6,Package : version_weight(Package, Weight)
 }.
 
 % Try to use preferred compilers
+opt_criterion(5, "non-preferred compilers").
+#minimize{ 0@5 : #true }.
 #minimize{ Weight@5,Package : compiler_weight(Package, Weight) }.
 
 % Maximize the number of matches for targets in the DAG, try
 % to select the preferred target.
+opt_criterion(4, "target matches").
+#minimize{ 0@4 : #true }.
 #maximize{ Weight@4,Package : node_target_match(Package, Weight) }.
+
+opt_criterion(3, "non-preferred targets").
+#minimize{ 0@3 : #true }.
 #minimize{ Weight@3,Package : node_target_weight(Package, Weight) }.

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -8,6 +8,9 @@
 %
 % This section determines what parts of the model are printed at the end
 %==============================================================================
+
+% Spec-related functions.
+% Used to build the result of the solve.
 #show node/1.
 #show depends_on/3.
 #show version/2.
@@ -21,12 +24,7 @@
 #show node_flag_compiler_default/1.
 #show node_flag_source/2.
 #show no_flags/2.
-
-#show variant_not_default/4.
-#show provider_weight/2.
-#show version_weight/2.
-#show compiler_version_match/2.
-#show compiler_weight/2.
-#show node_target_match/2.
-#show node_target_weight/2.
 #show external_spec_selected/2.
+
+% names of optimization criteria
+#show opt_criterion/2.


### PR DESCRIPTION
By default, clingo doesn't show any optimization criteria (maximized or minimized sums) if the set they aggregate is empty. Per the clingo mailing list, we can get around that by adding, e.g.:

```
#minimize{ 0@2 : #true }.
```

for the 2nd criterion. This forces clingo to print out the criterion but does not affect the optimization.

This PR adds directives as above for all of our optimization criteria, as well as facts with descriptions of each criterion,like this:

```
opt_criterion(2, "number of non-default variants")
```

We use facts in `concretize.lp` rather than hard-coding these in `asp.py` so that the names can be maintained in the same place as the other optimization criteria.

The now-displayed weights and the names are used to display optimization output like this:

```console
(spackle):solver> spack solve --show opt zlib
==> Best of 0 answers.
==> Optimization Criteria:
  Priority  Criterion                                            Value
  1         version weight                                           0
  2         number of non-default variants (roots)                   0
  3         multi-valued variants + preferred providers for roots    0
  4         number of non-default variants (non-roots)               0
  5         number of non-default providers (non-roots)              0
  6         count of non-root multi-valued variants                  0
  7         compiler matches + number of nodes                       1
  8         version badness                                          0
  9         non-preferred compilers                                  0
  10        target matches                                           0
  11        non-preferred targets                                    0

zlib@1.2.11%apple-clang@12.0.0+optimize+pic+shared arch=darwin-catalina-skylake
```

Note that this is all hidden behind a `--show opt` option to `spack solve`. Optimization weights are no longer shown by default, but you can at least inspect them and more easily understand what is going on.

- [x] always show optimization criteria in `clingo` output
- [x] add `opt_criterion()` facts for all optimizationc criteria
- [x] make display of opt criteria optional in `spack solve`
- [x] rework how optimization criteria are displayed, and add a `--show opt`ddoptiong to `spack solve`