### PR TITLE
[tutorials] match object syntax.

### DIFF
--- a/var/spack/repos/tutorial/packages/hdf5/package.py
+++ b/var/spack/repos/tutorial/packages/hdf5/package.py
@@ -220,8 +220,11 @@ class Hdf5(AutotoolsPackage):
             extra_args.append('--enable-static-exec')
 
         if '+pic' in self.spec:
-            extra_args += ['%s=%s' % (f, self.compiler.pic_flag)
-                           for f in ['CFLAGS', 'CXXFLAGS', 'FCFLAGS']]
+            extra_args.extend([
+                'CFLAGS='   + self.compiler.cc_pic_flag,
+                'CXXFLAGS=' + self.compiler.cxx_pic_flag,
+                'FCFLAGS='  + self.compiler.fc_pic_flag,
+            ])
 
         if '+mpi' in self.spec:
             # The HDF5 configure script warns if cxx and mpi are enabled

--- a/var/spack/repos/tutorial/packages/hdf5/package.py
+++ b/var/spack/repos/tutorial/packages/hdf5/package.py
@@ -221,9 +221,9 @@ class Hdf5(AutotoolsPackage):
 
         if '+pic' in self.spec:
             extra_args.extend([
-                'CFLAGS='   + self.compiler.cc_pic_flag,
-                'CXXFLAGS=' + self.compiler.cxx_pic_flag,
-                'FCFLAGS='  + self.compiler.fc_pic_flag,
+                'CFLAGS=%s' % self.compiler.cc_pic_flag,
+                'CXXFLAGS=%s' % self.compiler.cxx_pic_flag,
+                'FCFLAGS=%s' % self.compiler.fc_pic_flag,
             ])
 
         if '+mpi' in self.spec:


### PR DESCRIPTION
self.compiler doe not have attribute pic_flag, instead
self.compiler.{cc,cxx,fc}_pic_flag exist.