### PR TITLE
adding debugedit package.

### DIFF
--- a/var/spack/repos/builtin/packages/debugedit/package.py
+++ b/var/spack/repos/builtin/packages/debugedit/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import os
+
+
+class Debugedit(AutotoolsPackage):
+    """
+    Debugedit was originally part of the rpm project, and is currently
+    being refactored to be provided outside of it. This source will
+    eventually be moved to sourceware or similar, as it is being maintained
+    by RedHat.
+    """
+
+    homepage = "https://code.wildebeest.org/git/user/mjw/debugedit"
+    git      = "git://code.wildebeest.org/user/mjw/debugedit"
+
+    version('develop', branch='main')
+
+    depends_on('pkgconfig', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('elfutils')  # requires libdw
+    depends_on('libiberty')
+
+    def build(self, spec, prefix):
+
+        # requires libiberty
+        libiberty = spec['libiberty'].prefix.include
+        include_path = os.path.join(libiberty, "libiberty")
+        make('CPPFLAGS=-I%s' % include_path, 'PREFIX=' + prefix)

--- a/var/spack/repos/builtin/packages/debugedit/package.py
+++ b/var/spack/repos/builtin/packages/debugedit/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class Debugedit(AutotoolsPackage):
@@ -29,6 +28,5 @@ class Debugedit(AutotoolsPackage):
 
     def build(self, spec, prefix):
         # requires libiberty
-        libiberty = spec['libiberty'].prefix.include
-        include_path = os.path.join(libiberty, "libiberty")
-        make('CPPFLAGS=-I%s' % include_path, 'PREFIX=' + prefix)
+        libiberty = spec['libiberty'].prefix.include.libiberty
+        make('CPPFLAGS=-I%s' % libiberty)

--- a/var/spack/repos/builtin/packages/debugedit/package.py
+++ b/var/spack/repos/builtin/packages/debugedit/package.py
@@ -28,7 +28,6 @@ class Debugedit(AutotoolsPackage):
     depends_on('libiberty')
 
     def build(self, spec, prefix):
-
         # requires libiberty
         libiberty = spec['libiberty'].prefix.include
         include_path = os.path.join(libiberty, "libiberty")


### PR DESCRIPTION
The debubedit package used to be a part of rpm, but now is being developed separately. It will supposedly be moved to a sourceware repository (it is maintained by redhat) but I do not know if this will happen soon. We need it in order to change locations in binaries that are built in /tmp and then moved elsewhere. I will ping @woodard who might be able to give us an estimate if we should include this development repository or wait for it to be moved elsewhere. Once this is merged, we will want to use the bootstrap approach to install and use the library from spack.

Note that it requires libdw and not libdwarf, which I believe is provided by elfutils. The whole story behind that is weird and confusing (for anyone interested -> http://crtags.blogspot.com/2013/11/libdwarf-vs-libdw-revisited.html)

Update 3/23: we probably need to wait for this to be in sourceware, so I'm going to work on adding the bootstrap tomorrow to use it when we install a binary package (in binary_distribution.py). I think that's the only place we need it, because an install proper would have the correct install prefix on compile.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>