### PR TITLE
ELPA: Add missing Python build dependency.

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -35,6 +35,10 @@ class Elpa(AutotoolsPackage, CudaPackage):
     depends_on('lapack')
     depends_on('scalapack')
     depends_on('libtool', type='build')
+    depends_on('python@:2', type='build', when='@:2020.05.001')
+    depends_on('python@3:', type='build', when='@2020.11.001:')
+
+    patch('python_shebang.patch', when='@:2020.05.001')
 
     def url_for_version(self, version):
         t = 'https://elpa.mpcdf.mpg.de/html/Releases/{0}/elpa-{0}.tar.gz'

--- a/var/spack/repos/builtin/packages/elpa/python_shebang.patch
+++ b/var/spack/repos/builtin/packages/elpa/python_shebang.patch
@@ -1,0 +1,8 @@
+--- a/manual_cpp  2021-01-27 20:21:23.897206207 +0100
++++ b/manual_cpp  2021-01-27 20:13:08.743822289 +0100
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python
+ from __future__ import print_function
+ import os
+ import sys


### PR DESCRIPTION
Also patch the "manual_cpp" Python script with proper shebang to ensure the Spack provided Python is used instead of the system Python.