### PR TITLE
OpenFOAM-org: Fix compilation of version 2.4.0.

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/isnan.patch
+++ b/var/spack/repos/builtin/packages/openfoam-org/isnan.patch
@@ -1,0 +1,31 @@
+--- a/src/conversion/ensight/part/ensightPart.C 2021-01-07 15:37:26.650557806 +0100
++++ b/src/conversion/ensight/part/ensightPart.C 2021-01-07 15:38:04.148140312 +0100
+@@ -51,7 +51,7 @@
+         {
+             const label id = idList[i];
+ 
+-            if (id >= field.size() || isnan(field[id]))
++            if (id >= field.size() || std::isnan(field[id]))
+             {
+                 return false;
+             }
+--- a/src/conversion/ensight/part/ensightPartIO.C 2021-01-07 15:37:26.650557806 +0100
++++ b/src/conversion/ensight/part/ensightPartIO.C 2021-01-07 15:38:38.580675503 +0100
+@@ -63,7 +63,7 @@
+     {
+         forAll(idList, i)
+         {
+-            if (idList[i] >= field.size() || isnan(field[idList[i]]))
++            if (idList[i] >= field.size() || std::isnan(field[idList[i]]))
+             {
+                 os.writeUndef();
+             }
+@@ -80,7 +80,7 @@
+         // no idList => perNode
+         forAll(field, i)
+         {
+-            if (isnan(field[i]))
++            if (std::isnan(field[i]))
+             {
+                 os.writeUndef();
+             }

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -110,6 +110,7 @@ class OpenfoamOrg(Package):
     patch('41-etc.patch', when='@4.1')
     patch('41-site.patch', when='@4.1:')
     patch('240-etc.patch', when='@2.4.0')
+    patch('isnan.patch', when='@:2.4.0')
 
     # The openfoam architecture, compiler information etc
     _foam_arch = None


### PR DESCRIPTION
Fix "isnan" errors when compiling version 2.4.0 with recent compilers.