### PR TITLE
OpenFOAM: Depend on CGAL 4.X.

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -316,7 +316,8 @@ class Openfoam(Package):
     depends_on('zlib')
     depends_on('fftw-api')
     depends_on('boost')
-    depends_on('cgal')
+    # OpenFOAM does not play nice with CGAL 5.X
+    depends_on('cgal@:4.99')
     # The flex restriction is ONLY to deal with a spec resolution clash
     # introduced by the restriction within scotch!
     depends_on('flex@:2.6.1,2.6.4:')


### PR DESCRIPTION
CGAL 5.X is currently not supported.