### PR TITLE
Numpy: Ensure Spack finds Numpy's headers.

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -316,3 +316,8 @@ class PyNumpy(PythonPackage):
     def install_test(self):
         with working_dir('spack-test', create=True):
             python('-c', 'import numpy; numpy.test("full", verbose=2)')
+
+    @property
+    def headers(self):
+        headers = find_all_headers(self.prefix.lib)
+        return headers


### PR DESCRIPTION
The mpi4py package does the same thing.