### PR TITLE
Channelflow: Fix the package.

### DIFF
--- a/var/spack/repos/builtin/packages/channelflow/package.py
+++ b/var/spack/repos/builtin/packages/channelflow/package.py
@@ -69,7 +69,7 @@ class Channelflow(CMakePackage):
         }
 
         args.append('-DWITH_NETCDF:STRING={0}'.format(
-            netcdf_str[spec.variants['netcdf-c'].value]
+            netcdf_str[spec.variants['netcdf'].value]
         ))
 
         # Set an MPI compiler for parallel builds


### PR DESCRIPTION
A search and replace went wrong in 2264e30d99d8b9fbdec8fa69b594e53d8ced15a1.

Thanks to @wadudmiah who reported this issue.

/cc @adamjstewart 