### PR TITLE
Allow DataTransferKit to be built with external ArborX package

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -16,7 +16,7 @@ class Arborx(CMakePackage):
     maintainers = ['aprokop']
 
     version('master',   branch='master')
-    version('1.0',      commit='41dff19c319bcc23e3917fa9ed22cec3e67e5c93')
+    version('1.0',      sha256='9b5f45c8180622c907ef0b7cc27cb18ba272ac6558725d9e460c3f3e764f1075')
     version('0.9-beta', sha256='b349b5708d1aa00e8c20c209ac75dc2d164ff9bf1b85adb5437346d194ba6c0d')
 
     # ArborX relies on Kokkos to provide devices, providing one-to-one matching

--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -15,7 +15,8 @@ class Arborx(CMakePackage):
 
     maintainers = ['aprokop']
 
-    version('master', branch='master')
+    version('master',   branch='master')
+    version('1.0',      commit='41dff19c319bcc23e3917fa9ed22cec3e67e5c93')
     version('0.9-beta', sha256='b349b5708d1aa00e8c20c209ac75dc2d164ff9bf1b85adb5437346d194ba6c0d')
 
     # ArborX relies on Kokkos to provide devices, providing one-to-one matching

--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -20,7 +20,7 @@ class Datatransferkit(CMakePackage):
     version('3.1-rc2', commit='1abc1a43b33dffc7a16d7497b4185d09d865e36a', submodules=True)
 
     variant('external-arborx', default=False,
-            description='use externally ArborX library instead of pulling it')
+            description='use an external ArborX library instead of the submodule')
     variant('openmp', default=False, description='enable OpenMP backend')
     variant('serial', default=True, description='enable Serial backend (default)')
     variant('shared', default=True,

--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -19,11 +19,14 @@ class Datatransferkit(CMakePackage):
     version('master', branch='master', submodules=True)
     version('3.1-rc2', commit='1abc1a43b33dffc7a16d7497b4185d09d865e36a', submodules=True)
 
+    variant('external-arborx', default=False,
+            description='use externally ArborX library instead of pulling it')
     variant('openmp', default=False, description='enable OpenMP backend')
     variant('serial', default=True, description='enable Serial backend (default)')
     variant('shared', default=True,
             description='enable the build of shared lib')
 
+    depends_on('arborx@1.0:', when='+external-arborx')
     depends_on('cmake', type='build')
     depends_on('trilinos+intrepid2+shards~dtk', when='+serial')
     depends_on('trilinos+intrepid2+shards+openmp~dtk', when='+openmp')
@@ -37,6 +40,8 @@ class Datatransferkit(CMakePackage):
             '-DBUILD_SHARED_LIBS:BOOL=%s' % (
                 'ON' if '+shared' in spec else 'OFF'),
             '-DDataTransferKit_ENABLE_DataTransferKit=ON',
+            '-DDataTransferKit_ENABLE_ArborX_TPL=%s' % (
+                'ON' if '+external-arborx' in spec else 'OFF'),
             '-DDataTransferKit_ENABLE_TESTS=OFF',
             '-DDataTransferKit_ENABLE_EXAMPLES=OFF',
             '-DCMAKE_CXX_EXTENSIONS=OFF',


### PR DESCRIPTION
This pull request allows using an external `ArborX` installation instead of building it in-tree to be in accordance with https://github.com/xsdk-project/xsdk-community-policies/blob/master/package_policies/M12.md.