### PR TITLE
bootstrap: account for platform specific configuration scopes

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -171,16 +171,27 @@ def get_executable(exe, spec=None, install=False):
     _raise_error(exe, spec)
 
 
+def _bootstrap_config_scopes():
+    config_scopes = []
+    for name, path in spack.config.configuration_paths:
+        platform = spack.architecture.platform().name
+        platform_scope = spack.config.ConfigScope(
+            '/'.join([name, platform]), os.path.join(path, platform)
+        )
+        generic_scope = spack.config.ConfigScope(name, path)
+        config_scopes.extend([generic_scope, platform_scope])
+        msg = '[BOOSTRAP CONFIG SCOPE] name={0}, path={1}'
+        tty.debug(msg.format(generic_scope.name, generic_scope.path))
+        tty.debug(msg.format(platform_scope.name, platform_scope.path))
+    return config_scopes
+
+
 @contextlib.contextmanager
 def ensure_bootstrap_configuration():
-    # Default configuration scopes excluding command
-    # line and builtin
-    config_scopes = [
-        spack.config.ConfigScope(name, path)
-        for name, path in spack.config.configuration_paths
-    ]
-
     with spack.architecture.use_platform(spack.architecture.real_platform()):
+        # Default configuration scopes excluding command line and builtin
+        # but accounting for platform specific scopes
+        config_scopes = _bootstrap_config_scopes()
         with spack.config.use_configuration(*config_scopes):
             with spack.repo.use_repositories(spack.paths.packages_path):
                 with spack.store.use_store(spack.paths.user_bootstrap_store):


### PR DESCRIPTION
This change accounts for platform specific configuration scopes, like ~/.spack/linux, during bootstrapping. These scopes were
previously not accounted for and that was causing issues e.g. when searching for compilers.