### PR TITLE
Added version patch for 1.4.0 tag on mpark-variant

### DIFF
--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 
+
 class MparkVariant(CMakePackage):
     """C++17 `std::variant` for C++11/14/17"""
 
@@ -12,8 +13,8 @@ class MparkVariant(CMakePackage):
     git     = "https://github.com/mpark/variant.git"
     maintainers = ['ax3l']
 
-    version('1.4.0', tag='v1.4.0')
-    version('1.3.0', tag='v1.3.0')
+    version('1.4.0', commit='4988879a9f5a95d72308eca2b1779db6ed9b135d')
+    version('1.3.0', commit='29319715a1f0eb0980d380db8a2fda5af8d58feb')
 
     # Ref.: https://github.com/mpark/variant/pull/73
     patch('nvcc.patch', when='@:1.4.0')

--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -5,19 +5,19 @@
 
 from spack import *
 
-
 class MparkVariant(CMakePackage):
     """C++17 `std::variant` for C++11/14/17"""
 
-    homepage = "https://mpark.github.io/variant"
-    url      = "https://github.com/mpark/variant/archive/v1.3.0.tar.gz"
+    homepage = "https://github.com/mpark/variant"
+    git     = "https://github.com/mpark/variant.git"
     maintainers = ['ax3l']
 
-    version('1.4.0', sha256='8f6b28ab3640b5d76d5b6664dda7257a4405ce59179220431b8fd196c79b2ecb')
-    version('1.3.0', sha256='d0f7e41f818fcc839797a8017e76b8b66b323651c304cff641a83a56ae9943c6')
+    version('1.4.0', tag='v1.4.0')
+    version('1.3.0', tag='v1.3.0')
 
     # Ref.: https://github.com/mpark/variant/pull/73
     patch('nvcc.patch', when='@:1.4.0')
+    patch('version.patch', when='@:1.4.0')
 
     cxx11_msg = 'MPark.Variant needs a C++11-capable compiler. ' \
                 'See https://github.com/mpark/variant#requirements'

--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -10,7 +10,8 @@ class MparkVariant(CMakePackage):
     """C++17 `std::variant` for C++11/14/17"""
 
     homepage = "https://github.com/mpark/variant"
-    git     = "https://github.com/mpark/variant.git"
+    url      = "https://github.com/mpark/variant/archive/v1.4.0.tar.gz"
+    git      = "https://github.com/mpark/variant.git"
     maintainers = ['ax3l']
 
     version('1.4.0', sha256='8f6b28ab3640b5d76d5b6664dda7257a4405ce59179220431b8fd196c79b2ecb')

--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -18,7 +18,7 @@ class MparkVariant(CMakePackage):
 
     # Ref.: https://github.com/mpark/variant/pull/73
     patch('nvcc.patch', when='@:1.4.0')
-    patch('version.patch', when='@:1.4.0')
+    patch('version.patch', when='@1.4.0')
 
     cxx11_msg = 'MPark.Variant needs a C++11-capable compiler. ' \
                 'See https://github.com/mpark/variant#requirements'

--- a/var/spack/repos/builtin/packages/mpark-variant/package.py
+++ b/var/spack/repos/builtin/packages/mpark-variant/package.py
@@ -13,8 +13,8 @@ class MparkVariant(CMakePackage):
     git     = "https://github.com/mpark/variant.git"
     maintainers = ['ax3l']
 
-    version('1.4.0', commit='4988879a9f5a95d72308eca2b1779db6ed9b135d')
-    version('1.3.0', commit='29319715a1f0eb0980d380db8a2fda5af8d58feb')
+    version('1.4.0', sha256='8f6b28ab3640b5d76d5b6664dda7257a4405ce59179220431b8fd196c79b2ecb')
+    version('1.3.0', sha256='d0f7e41f818fcc839797a8017e76b8b66b323651c304cff641a83a56ae9943c6')
 
     # Ref.: https://github.com/mpark/variant/pull/73
     patch('nvcc.patch', when='@:1.4.0')

--- a/var/spack/repos/builtin/packages/mpark-variant/version.patch
+++ b/var/spack/repos/builtin/packages/mpark-variant/version.patch
@@ -1,0 +1,11 @@
+--- ./CMakeLists.txt	2021-02-21 17:27:04.709115800 -0700
++++ ./CMakeLists.txt.new	2021-02-21 17:27:35.589115800 -0700
+@@ -7,7 +7,7 @@
+ 
+ cmake_minimum_required(VERSION 3.6.3)
+ 
+-project(MPark.Variant VERSION 1.3.0 LANGUAGES CXX)
++project(MPark.Variant VERSION 1.4.0 LANGUAGES CXX)
+ 
+ # Option.
+ set(MPARK_VARIANT_INCLUDE_TESTS "" CACHE STRING


### PR DESCRIPTION
~~Redirected urls to git and github tags.~~

Update URLs, add patches:
- [x] CMake version for 1.4.0: https://github.com/mpark/variant/issues/60
- [x] ICC on macOS: https://github.com/mpark/variant/issues/77