### PR TITLE
Generate modules separately per-environment

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -806,6 +806,14 @@ def _config():
 config = llnl.util.lang.Singleton(_config)
 
 
+def no_env_config():
+    no_env_config = copy.deepcopy(config)
+    for scope_name in list(no_env_config.scopes.keys()):
+        if scope_name.startswith('env'):
+            no_env_config.remove_scope(scope_name)
+    return no_env_config
+
+
 def add_from_file(filename, scope=None):
     """Add updates to a config from a filename
     """

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -847,6 +847,12 @@ class Environment(object):
         return os.path.join(self.env_subdir_path, 'view')
 
     @property
+    def module_path_defaults(self):
+        lmod = os.path.join(self.env_subdir_path, 'lmod')
+        tcl = os.path.join(self.env_subdir_path, 'modules')
+        return {'lmod': lmod, 'tcl': tcl}
+
+    @property
     def repo(self):
         if self._repo is None:
             self._repo = make_repo_path(self.repos_path)

--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.config
+import spack.environment as ev
 import spack.modules
 import spack.modules.common
 import llnl.util.tty as tty
@@ -16,14 +17,32 @@ def _for_each_enabled(spec, method_name):
         tty.debug('NO MODULE WRITTEN: list of enabled module files is empty')
         return
 
-    for name in enabled:
-        generator = spack.modules.module_types[name](spec)
-        try:
-            getattr(generator, method_name)()
-        except RuntimeError as e:
-            msg = 'cannot perform the requested {0} operation on module files'
-            msg += ' [{1}]'
-            tty.warn(msg.format(method_name, str(e)))
+    # We do this once automatically, and an extra time for the environment
+    # If no environment, the set has a single element
+    # If the element is not None, it is an Environment
+    for env in set([None, ev.get_env({}, '')]):
+        if env:
+            # If the environment defines module roots, use those
+            # Otherwise, add the default module roots
+            module_roots = env.module_path_defaults
+            full_roots = spack.config.get('config:module_roots')
+            no_env_roots = spack.config.no_env_config().get(
+                'config:module_roots')
+            for mtype, path in module_roots.items():
+                if full_roots[mtype] != no_env_roots[mtype]:
+                    module_roots[mtype] = full_roots[mtype]
+        else:
+            module_roots = spack.config.get('config:module_roots')
+
+        with spack.config.override('config:module_roots', module_roots):
+            for name in enabled:
+                generator = spack.modules.module_types[name](spec, env)
+                try:
+                    getattr(generator, method_name)()
+                except RuntimeError as e:
+                    msg = 'cannot perform the requested {0} operation on '
+                    msg += 'module files [{1}]'
+                    tty.warn(msg.format(method_name, str(e)))
 
 
 def post_install(spec):

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -57,6 +57,7 @@ def configuration(env=None):
         return spack.config.get('modules', {})
     return spack.config.no_env_config().get('modules', {})
 
+
 #: Valid tokens for naming scheme and env variable names
 _valid_tokens = (
     'name',

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -8,7 +8,7 @@ import os.path
 import llnl.util.lang as lang
 import itertools
 import collections
-from typing import Dict, Any  # novm
+from typing import Dict, Tuple, Any  # novm
 
 import spack.config
 import spack.compilers
@@ -29,7 +29,7 @@ def configuration(env=None):
 
 
 #: Caches the configuration {spec_hash: configuration}
-configuration_registry = {}  # type: Dict[Tuple(str, str), Any]
+configuration_registry = {}  # type: Dict[Tuple[str, str], Any]
 
 
 def make_configuration(spec, env=None):

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -29,12 +29,12 @@ def configuration(env=None):
 
 
 #: Caches the configuration {spec_hash: configuration}
-configuration_registry = {}  # type: Dict[str, Any]
+configuration_registry = {}  # type: Dict[Tuple(str, str), Any]
 
 
 def make_configuration(spec, env=None):
     """Returns the lmod configuration for spec"""
-    key = (spec.dag_hash(), env)
+    key = (spec.dag_hash(), env.name)
     try:
         return configuration_registry[key]
     except KeyError:

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -27,6 +27,7 @@ def configuration(env=None):
         return spack.config.get('modules:lmod', {})
     return spack.config.no_env_config().get('modules:lmod', {})
 
+
 #: Caches the configuration {spec_hash: configuration}
 configuration_registry = {}  # type: Dict[str, Any]
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -34,7 +34,7 @@ configuration_registry = {}  # type: Dict[Tuple(str, str), Any]
 
 def make_configuration(spec, env=None):
     """Returns the lmod configuration for spec"""
-    key = (spec.dag_hash(), env.name)
+    key = (spec.dag_hash(), env.name if env else '')
     try:
         return configuration_registry[key]
     except KeyError:

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -32,7 +32,7 @@ configuration_registry = {}  # type: Dict[Tuple(str, str), Any]
 
 def make_configuration(spec, env=None):
     """Returns the tcl configuration for spec"""
-    key = (spec.dag_hash(), env.name)
+    key = (spec.dag_hash(), env.name if env else '')
     try:
         return configuration_registry[key]
     except KeyError:

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -20,21 +20,24 @@ from .common import BaseContext, BaseModuleFileWriter
 
 
 #: TCL specific part of the configuration
-def configuration():
-    return spack.config.get('modules:tcl', {})
+def configuration(env=None):
+    if env:
+        return spack.config.get('modules:tcl', {})
+    return spack.config.no_env_config().get('modules:tcl', {})
 
 
 #: Caches the configuration {spec_hash: configuration}
-configuration_registry = {}  # type: Dict[str, Any]
+configuration_registry = {}  # type: Dict[(str, str), Any]
 
 
-def make_configuration(spec):
+def make_configuration(spec, env=None):
     """Returns the tcl configuration for spec"""
-    key = spec.dag_hash()
+    key = (spec.dag_hash(), env)
     try:
         return configuration_registry[key]
     except KeyError:
-        return configuration_registry.setdefault(key, TclConfiguration(spec))
+        return configuration_registry.setdefault(
+            key, TclConfiguration(spec, env))
 
 
 def make_layout(spec):

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -27,12 +27,12 @@ def configuration(env=None):
 
 
 #: Caches the configuration {spec_hash: configuration}
-configuration_registry = {}  # type: Dict[(str, str), Any]
+configuration_registry = {}  # type: Dict[Tuple(str, str), Any]
 
 
 def make_configuration(spec, env=None):
     """Returns the tcl configuration for spec"""
-    key = (spec.dag_hash(), env)
+    key = (spec.dag_hash(), env.name)
     try:
         return configuration_registry[key]
     except KeyError:

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -8,7 +8,7 @@ non-hierarchical modules.
 """
 import os.path
 import string
-from typing import Dict, Any  # novm
+from typing import Dict, Tuple, Any  # novm
 
 import llnl.util.tty as tty
 
@@ -27,7 +27,7 @@ def configuration(env=None):
 
 
 #: Caches the configuration {spec_hash: configuration}
-configuration_registry = {}  # type: Dict[Tuple(str, str), Any]
+configuration_registry = {}  # type: Dict[Tuple[str, str], Any]
 
 
 def make_configuration(spec, env=None):

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -17,7 +17,8 @@ import spack.schema.projections
 #: THIS NEEDS TO BE UPDATED FOR EVERY NEW KEYWORD THAT
 #: IS ADDED IMMEDIATELY BELOW THE MODULE TYPE ATTRIBUTE
 spec_regex = r'(?!hierarchy|core_specs|verbose|hash_length|whitelist|' \
-             r'blacklist|projections|naming_scheme|core_compilers|all)' \
+             r'blacklist|projections|naming_scheme|env_modules_use_view|' \
+             r'core_compilers|all)' \
              r'(^\w[\w-]*)'
 
 #: Matches an anonymous spec, i.e. a spec without a root name
@@ -99,6 +100,9 @@ module_type_configuration = {
                 'type': 'string'  # Can we be more specific here?
             },
             'projections': projections_scheme,
+            'env_modules_use_view': {
+                'type': 'string'
+            },
             'all': module_file_configuration,
         }
         },

--- a/lib/spack/spack/test/data/modules/lmod/alter_environment.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/alter_environment.yaml
@@ -9,7 +9,7 @@ lmod:
 
   all:
     filter:
-      environment_blacklist':
+      environment_blacklist:
         - CMAKE_PREFIX_PATH
     environment:
       set:

--- a/lib/spack/spack/test/data/modules/lmod/use_view.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/use_view.yaml
@@ -1,0 +1,3 @@
+lmod:
+  env_modules_use_view: default
+  core_compilers: ['%gcc']

--- a/lib/spack/spack/test/data/modules/tcl/alter_environment.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/alter_environment.yaml
@@ -3,7 +3,7 @@ enable:
 tcl:
   all:
     filter:
-      environment_blacklist':
+      environment_blacklist:
         - CMAKE_PREFIX_PATH
     environment:
       set:

--- a/lib/spack/spack/test/data/modules/tcl/invalid_token_in_env_var_name.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/invalid_token_in_env_var_name.yaml
@@ -3,7 +3,7 @@ enable:
 tcl:
   all:
     filter:
-      environment_blacklist':
+      environment_blacklist:
         - CMAKE_PREFIX_PATH
     environment:
       set:

--- a/lib/spack/spack/test/modules/conftest.py
+++ b/lib/spack/spack/test/modules/conftest.py
@@ -56,9 +56,11 @@ def factory(request):
     # Class of the module file writer
     writer_cls = getattr(request.module, 'writer_cls')
 
-    def _mock(spec_string):
+    def _mock(spec_string, env=None):
         spec = spack.spec.Spec(spec_string)
         spec.concretize()
-        return writer_cls(spec), spec
+        writer = writer_cls(spec)
+        writer.conf._env = env
+        return writer, spec
 
     return _mock


### PR DESCRIPTION
**Superseded by #22588.**

Currently, module configurations are inconsistent because modulefiles are generated with the configs for the active environment, but are shared among all environments (and spack outside any environment).

This PR fixes that by generating modulefiles separately for Spack inside and outside the environment when an install is done within an environment.

Additionally, it adds a feature that the modulefiles for an environment can be configured to be relative to an environment view rather than the underlying prefix. This will not be enabled by default, as it should only be enabled for non-default views constructed with separate projections per-spec.