### PR TITLE
move the BinaryCacheIndex location into the user home dir

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -37,12 +37,10 @@ import spack.util.spack_yaml as syaml
 import spack.mirror
 import spack.util.url as url_util
 import spack.util.web as web_util
+from spack.caches import misc_cache_location
 from spack.spec import Spec
 from spack.stage import Stage
 
-
-#: default root, relative to the Spack install path
-default_binary_index_root = os.path.join(spack.paths.opt_path, 'spack')
 
 _build_cache_relative_path = 'build_cache'
 _build_cache_keys_relative_path = '_pgp'
@@ -67,9 +65,8 @@ class BinaryCacheIndex(object):
     mean we should have paid the price to update the cache earlier?
     """
 
-    def __init__(self, cache_root=None):
-        self._cache_root = cache_root or default_binary_index_root
-        self._index_cache_root = os.path.join(self._cache_root, 'indices')
+    def __init__(self, cache_root):
+        self._index_cache_root = cache_root
 
         # the key associated with the serialized _local_index_cache
         self._index_contents_key = 'contents.json'
@@ -440,13 +437,15 @@ class BinaryCacheIndex(object):
         return True
 
 
+def binary_index_location():
+    """Set up a BinaryCacheIndex for remote buildcache dbs in the user's homedir."""
+    cache_root = os.path.join(misc_cache_location(), 'indices')
+    return spack.util.path.canonicalize_path(cache_root)
+
+
 def _binary_index():
     """Get the singleton store instance."""
-    cache_root = spack.config.get(
-        'config:binary_index_root', default_binary_index_root)
-    cache_root = spack.util.path.canonicalize_path(cache_root)
-
-    return BinaryCacheIndex(cache_root)
+    return BinaryCacheIndex(binary_index_location())
 
 
 #: Singleton binary_index instance

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -17,7 +17,7 @@ import spack.util.file_cache
 import spack.util.path
 
 
-def _misc_cache():
+def misc_cache_location():
     """The ``misc_cache`` is Spack's cache for small data.
 
     Currently the ``misc_cache`` stores indexes for virtual dependency
@@ -27,7 +27,11 @@ def _misc_cache():
     if not path:
         path = os.path.join(spack.paths.user_config_path, 'cache')
     path = spack.util.path.canonicalize_path(path)
+    return path
 
+
+def _misc_cache():
+    path = misc_cache_location()
     return spack.util.file_cache.FileCache(path)
 
 
@@ -35,7 +39,7 @@ def _misc_cache():
 misc_cache = llnl.util.lang.Singleton(_misc_cache)
 
 
-def _fetch_cache():
+def fetch_cache_location():
     """Filesystem cache of downloaded archives.
 
     This prevents Spack from repeatedly fetch the same files when
@@ -45,7 +49,11 @@ def _fetch_cache():
     if not path:
         path = os.path.join(spack.paths.var_path, "cache")
     path = spack.util.path.canonicalize_path(path)
+    return path
 
+
+def _fetch_cache():
+    path = fetch_cache_location()
     return spack.fetch_strategy.FsCache(path)
 
 


### PR DESCRIPTION
### Problem
`BinaryCacheIndex` will pull down `index.json` files from mirrors, then create a `Database` from it in a temporary directory to list remote specs. We would like this location to be shared among Spack instances which may share mirrors. Additionally, we would like to ensure that the default location for these `Database` instances is definitely a user-writable directory.

This is step 1 of addressing #19085, for which we plan to eventually create a separate `Database` with its own TTL for "all specs Spack has ever seen", including the results of `spack spec` and `spack solve`.

### Solution
- For our fetch cache, misc cache, and binary index cache, separate public `*_cache_location()` methods (which return the cache's filesystem path) from private `_*_cache()` methods (which return the python object representing the cache).
    - This allows creating caches in subdirectories of other cache directories.
- If `config:binary_index_root` is unset, use a subdirectory of `config:misc_cache` (which defaults to `~/.spack/cache`).
    - This ensures that the location is definitely writable by the current user.

### Result
After running `spack buildcache list`, we now find a new directory `~/.spack/cache/indices` has been created, with the following contents:
```bash
# mcclanahan7@turingtarpit: ~/tools/spack 18:14:30
; ls ~/.spack/cache/indices
total 48M
-rwxr-xr-x 1 mcclanahan7 34309   0 Mar 23 18:13 .714ed82990_c1df2b37cf.json.lock*
-rwxr-xr-x 1 mcclanahan7 34309   0 Mar 23 18:13 .contents.json.lock*
-rw-r--r-- 1 mcclanahan7 34309 48M Mar 23 18:13 714ed82990_c1df2b37cf.json
-rw-r--r-- 1 mcclanahan7 34309 152 Mar 23 18:13 contents.json
# mcclanahan7@turingtarpit: ~/tools/spack 18:14:51
; jq <~/.spack/cache/indices/714ed82990_c1df2b37cf.json | head -n10
{
  "database": {
    "installs": {
      "fkoyyzocpyqsx26aswd63cg3leadscoy": {
        "spec": {
          "libpciaccess": {
            "version": "0.16",
            "arch": {
              "platform": "linux",
              "platform_os": "rhel8",
```