### PR TITLE
check remote mirrors for hashes provided by the user

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -82,6 +82,7 @@ import operator
 import os
 import re
 import warnings
+from typing import Iterable, Optional, Union  # novm
 
 import ruamel.yaml as yaml
 import six
@@ -1034,15 +1035,16 @@ class Spec(object):
     #: Cache for spec's prefix, computed lazily in the corresponding property
     _prefix = None
 
-    @staticmethod
-    def default_arch():
-        """Return an anonymous spec for the default architecture"""
-        s = Spec()
-        s.architecture = ArchSpec.default_arch()
-        return s
-
-    def __init__(self, spec_like=None, normal=False,
-                 concrete=False, external_path=None, external_modules=None):
+    def __init__(
+        self,
+        spec_like=None,         # type: Optional[Union[str, Spec]]
+        normal=False,           # type: bool
+        concrete=False,         # type: bool
+        external_path=None,     # type: Optional[str]
+        external_modules=None,  # type: Optional[Iterable[str]]
+        full_hash=None,         # type: Optional[str]
+    ):
+        # type: (...) -> None
         """Create a new Spec.
 
         Arguments:
@@ -1120,6 +1122,11 @@ class Spec(object):
 
         elif spec_like is not None:
             raise TypeError("Can't make spec out of %s" % type(spec_like))
+
+    @classmethod
+    def default_arch(cls):
+        """Return a spec matching the default architecture."""
+        return cls('arch={}'.format(ArchSpec.default_arch()))
 
     @staticmethod
     def _format_module_list(modules):
@@ -3470,6 +3477,7 @@ class Spec(object):
         # We don't count dependencies as changes here
         changed = True
         if hasattr(self, 'name'):
+            # TODO: what does 'changed' mean here?
             changed = (self.name != other.name and
                        self.versions != other.versions and
                        self.architecture != other.architecture and
@@ -4233,6 +4241,9 @@ class Spec(object):
         spec_str = " ^".join(d.format() for d in sorted_nodes)
         return spec_str.strip()
 
+    def __repr__(self):
+        return 'Spec({0!r})'.format(str(self))
+
     def install_status(self):
         """Helper for tree to print DB install status."""
         if not self.concrete:
@@ -4321,9 +4332,6 @@ class Spec(object):
                 break
 
         return out
-
-    def __repr__(self):
-        return str(self)
 
     @property
     def platform(self):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -21,9 +21,6 @@ from six.moves import shlex_quote as cmd_quote
 import llnl.util.tty as tty
 from llnl.util.lang import dedupe
 
-import spack.config
-import spack.platforms
-import spack.spec
 import spack.util.executable as executable
 import spack.util.spack_json as sjson
 
@@ -165,6 +162,7 @@ def get_host_environment():
     """Return a dictionary (lookup) with host information (not including the
     os.environ).
     """
+    import spack.platforms
     host_platform = spack.platforms.host()
     host_target = host_platform.target('default_target')
     host_os = host_platform.operating_system('default_os')


### PR DESCRIPTION
### Problem
This is a *partial* solution to #19085. Users would like to be able to use spec hash prefixes on the command line that they've seen from remote mirrors, e.g. from the output of `spack buildcache list -l --allarch`. Right now, hash prefixes are converted into a single concrete `Spec` instance within `SpecParser`, and they only check the local `Database` instance for that.

This is step 2 of a solution to #19085, after #22500. This is only a partial solution to it because in addition to `spack buildcache list`, we would also like to ensure that hash prefixes from the output of e.g. `spack spec` can be provided to the spack command line. We plan to create a separate `Database` instance with its own TTL for that later feature.

This requires #21723 to work for some reason.

### Solution
1. Add `find_prefix_hash()` to `BinaryCacheIndex` to trawl through all its known specs and match hash prefixes.
1. Add `_lookup_local_or_remote_hash()` to `SpecParser` to check both the local and remote databases for a hash prefix specified on the command line.

### Result
We can now perform the following set of commands:
```bash
# mcclanahan7@turingtarpit: ~/tools/spack 18:43:43
; spack buildcache list -l --allarch xz
... # lots of output...
-- linux-ubuntu20.04-x86_64 / gcc@9.3.0 -------------------------
ighzjcu xz@5.2.5  kamfyq4 xz@5.2.5~pic  jc3ghdk xz@5.2.5+pic
# mcclanahan7@turingtarpit: ~/tools/spack 18:50:13
; spack spec -l xz/ighzjcu # hash prefix specified from the buildcache output
Input spec
--------------------------------
xz@5.2.5%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64

Concretized
--------------------------------
ighzjcu  xz@5.2.5%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64
```

**HOWEVER,** it takes 1 full minute to run the above command, which traverses remote databases for a hash prefix after fetching them. We plan to follow up on this PR with a third one that uses an auxiliary local `Database` instance to store specs from buildcaches, which is expected to make matching remote spec prefixes as fast as local spec prefixes.