### PR TITLE
Add SquashFUSE and libfuse detection

### DIFF
--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import re
 
 
 class Libfuse(MesonPackage):
@@ -21,6 +22,15 @@ class Libfuse(MesonPackage):
     version('3.9.2',  sha256='b4409255cbda6f6975ca330f5b04cb335b823a95ddd8c812c3d224ec53478fc0')
 
     variant('useroot', default=False)
+
+    executables = ['fusermount']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'^fusermount.*version: (\S+)', output)
+        return match.group(1) if match else None
+
 
     def meson_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -23,7 +23,7 @@ class Libfuse(MesonPackage):
 
     variant('useroot', default=False)
 
-    executables = ['fusermount']
+    executables = ['^fusermount$']
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -31,7 +31,6 @@ class Libfuse(MesonPackage):
         match = re.search(r'^fusermount.*version: (\S+)', output)
         return match.group(1) if match else None
 
-
     def meson_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Squashfuse(AutotoolsPackage):
+    """squashfuse - Mount SquashFS archives using FUSE"""
+
+    homepage = "https://github.com/vasi/squashfuse"
+    url      = "https://github.com/vasi/squashfuse/releases/download/0.1.103/squashfuse-0.1.103.tar.gz"
+    git      = "https://github.com/vasi/squashfuse.git"
+
+    maintainers = ['haampie']
+
+    # there hasn't been a release for a while, and the master branch introduces
+    # support for fuse@3:, so we have our own spack version here (46 commits
+    # after 0.1.103)
+    version('master', branch='master')
+    version('0.1.103-46', commit='e5dddbfc6e402c82f5fbba115b0eb3476684f50d')
+
+    # official releases
+    version('0.1.103', sha256='42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7')
+
+    depends_on('libfuse@2.5:')
+    depends_on('libfuse@:2.99', when='@:0.1.103')
+
+    # NOTE: pkg-config is used to detect fuse/fuse3, but libfuse is typically
+    # external (as fusermount is a setuid binary).
+    # When depending on spack's pkg-config, fuse/fuse3 is not found, so we avoid
+    # that.
+    # depends_on('pkg-config', type='build')
+
+    # compression libs
+    depends_on('zlib')
+    depends_on('lz4')
+    depends_on('lzo')
+    depends_on('xz')
+    depends_on('zstd')
+
+    # build deps for non-tarball versions
+    depends_on('m4',       type='build', when='@master,0.1.103-46')
+    depends_on('autoconf', type='build', when='@master,0.1.103-46')
+    depends_on('automake', type='build', when='@master,0.1.103-46')
+    depends_on('libtool',  type='build', when='@master,0.1.103-46')

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -19,19 +19,18 @@ class Squashfuse(AutotoolsPackage):
     # support for fuse@3:, so we have our own spack version here (46 commits
     # after 0.1.103)
     version('master', branch='master')
-    version('0.1.103-46', commit='e5dddbfc6e402c82f5fbba115b0eb3476684f50d')
+    version('0.1.103-46', commit='e5dddbfc6e402c82f5fbba115b0eb3476684f50d', preferred=True)
 
     # official releases
     version('0.1.103', sha256='42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7')
 
     depends_on('libfuse@2.5:')
-    depends_on('libfuse@:2.99', when='@:0.1.103')
+    depends_on('libfuse@:2.99', when='@0.1.103')
 
-    # NOTE: pkg-config is used to detect fuse/fuse3, but libfuse is typically
-    # external (as fusermount is a setuid binary).
-    # When depending on spack's pkg-config, fuse/fuse3 is not found, so we avoid
-    # that.
-    # depends_on('pkg-config', type='build')
+    # Note: typically libfuse is external, but this implies that you have to make
+    # pkg-config external too, because spack's pkg-config doesn't know how to
+    # locate system pkg-config's fuse.pc/fuse3.pc
+    depends_on('pkg-config', type='build')
 
     # compression libs
     depends_on('zlib')
@@ -45,3 +44,6 @@ class Squashfuse(AutotoolsPackage):
     depends_on('autoconf', type='build', when='@master,0.1.103-46')
     depends_on('automake', type='build', when='@master,0.1.103-46')
     depends_on('libtool',  type='build', when='@master,0.1.103-46')
+
+    def configure_args(self):
+        return ['--disable-demo']


### PR DESCRIPTION
- Add SquashFUSE
- Add libfuse detection though fusermount

Note: I could only make squashfuse compile by relying on system pkg-config to locate system-libfuse. Seems like pkg-config has search paths compiled right into the binary which obviously are missing in spack's version of pkg-config.

I don't expect it's sensible to build libfuse with spack since it wants to touch a bunch of system paths and create a setuid binary fusermount.