### PR TITLE
hdf5: fix link error in dependent packages.

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -287,6 +287,10 @@ class Hdf5(AutotoolsPackage):
                 'FCFLAGS='  + self.compiler.fc_pic_flag,
             ])
 
+        # Fujitsu Compiler dose not add  Fortran runtime in rpath.
+        if self.spec.satisfies('%fj') and '+fortran' in self.spec:
+            extra_args.append('LDFLAGS=-lfj90i -lfj90f -lfjsrcinfo -lelf')
+
         if '+mpi' in self.spec:
             # The HDF5 configure script warns if cxx and mpi are enabled
             # together. There doesn't seem to be a real reason for this, except

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -288,7 +288,7 @@ class Hdf5(AutotoolsPackage):
             ])
 
         # Fujitsu Compiler dose not add  Fortran runtime in rpath.
-        if self.spec.satisfies('%fj') and '+fortran' in self.spec:
+        if '+fortran %fj' in self.spec:
             extra_args.append('LDFLAGS=-lfj90i -lfj90f -lfjsrcinfo -lelf')
 
         if '+mpi' in self.spec:


### PR DESCRIPTION
Fujitsu Compiler does not add Fortran runtime in rpath.
This PR add LDFLAGS to fortan rantime libraries to add rpath on a hdf5 fortran library.
Referenced #21561