### PR TITLE
fix issue #18853 build of gdk-pixbuf

### DIFF
--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -25,6 +25,8 @@ class GdkPixbuf(Package):
     version('2.31.2', sha256='9e467ed09894c802499fb2399cd9a89ed21c81700ce8f27f970a833efb1e47aa', deprecated=True)
 
     variant('x11', default=False, description="Enable X11 support")
+    # Man page creation was getting docbook errors, see issue #18853
+    variant('man', default=False, description="Enable man page creation")
 
     depends_on('meson@0.55.3:', type='build', when='@2.42.2:')
     depends_on('meson@0.46.0:', type='build', when='@2.37.92:')
@@ -34,8 +36,8 @@ class GdkPixbuf(Package):
     depends_on('shared-mime-info', type='build', when='@2.36.8: platform=cray')
     depends_on('pkgconfig', type='build')
     # Building the man pages requires libxslt and the Docbook stylesheets
-    depends_on('libxslt', type='build')
-    depends_on('docbook-xsl', type='build')
+    depends_on('libxslt', type='build', when='+man')
+    depends_on('docbook-xsl@1.79.2:', type='build', when='+man')
     depends_on('gettext')
     depends_on('glib@2.38.0:')
     depends_on('jpeg')
@@ -47,7 +49,7 @@ class GdkPixbuf(Package):
 
     # Replace the docbook stylesheet URL with the one that our
     # docbook-xsl package uses/recognizes.
-    patch('docbook-cdn.patch')
+    patch('docbook-cdn.patch', when='+man')
 
     def url_for_version(self, version):
         url = "https://ftp.acc.umu.se/pub/gnome/sources/gdk-pixbuf/{0}/gdk-pixbuf-{1}.tar.xz"
@@ -71,6 +73,8 @@ class GdkPixbuf(Package):
         with working_dir('spack-build', create=True):
             meson_args = std_meson_args
             meson_args += ['-Dx11={0}'.format('+x11' in spec)]
+            if '~man' in spec:
+                meson_args += ['-Dman=false']
             meson('..', *meson_args)
             ninja('-v')
             if self.run_tests:

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -72,9 +72,10 @@ class GdkPixbuf(Package):
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):
             meson_args = std_meson_args
-            meson_args += ['-Dx11={0}'.format('+x11' in spec)]
-            if '~man' in spec:
-                meson_args += ['-Dman=false']
+            meson_args += [
+                '-Dx11={0}'.format('+x11' in spec),
+                '-Dman={0}'.format('+man' in spec),
+            ]
             meson('..', *meson_args)
             ninja('-v')
             if self.run_tests:


### PR DESCRIPTION
Fixes #18853
Fixes #22487

The issue started with #22228. In that PR, we found that gtk-doc requires docbook-xsl to be pinned at 1.78.1. However, gdk-pixbuf requires version 1.79.2 in order to parse the style sheet for its man pages. The fix/workaround here is to make man page generation for gdk-pixbuf optional and default to turning off man page generation. 

The consequence here is that we cannot build gdk-pixbuf with man pages when it is a dependency of gtk-doc. I think this will be an issue until gtk-doc moves forward and supports the newer version of docbook-xsl.