### PR TITLE
Don't run system install script for libfuse

### DIFF
--- a/var/spack/repos/builtin/packages/libfuse/0001-Do-not-run-install-script.patch
+++ b/var/spack/repos/builtin/packages/libfuse/0001-Do-not-run-install-script.patch
@@ -1,0 +1,27 @@
+From daf0c12d13791978bd7eab2ef44c432802fbcc95 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Wed, 24 Mar 2021 17:29:10 +0100
+Subject: [PATCH] Do not run install script by default
+
+---
+ util/meson.build | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/util/meson.build b/util/meson.build
+index 577668f..ef0bc81 100644
+--- a/util/meson.build
++++ b/util/meson.build
+@@ -20,10 +20,4 @@ if udevrulesdir == ''
+   udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
+ endif
+ 
+-meson.add_install_script('install_helper.sh',
+-                         join_paths(get_option('prefix'), get_option('sysconfdir')),
+-                         join_paths(get_option('prefix'), get_option('bindir')),
+-                         udevrulesdir,
+-                         '@0@'.format(get_option('useroot')))
+-
+ 
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -29,6 +29,7 @@ class Libfuse(MesonPackage):
 
     conflicts("+useroot", when='~system_install', msg="useroot requires system_install")
 
+    # Drops the install script which does system configuration
     patch('0001-Do-not-run-install-script.patch', when='~system_install')
 
     executables = ['^fusermount$']

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -21,8 +21,13 @@ class Libfuse(MesonPackage):
     version('3.9.3',  sha256='0f8f7ad9cc6667c6751efa425dd0a665dcc9d75f0b7fc0cb5b85141a514110e9')
     version('3.9.2',  sha256='b4409255cbda6f6975ca330f5b04cb335b823a95ddd8c812c3d224ec53478fc0')
 
-    variant('useroot', default=False)
-    variant('system_install', default=False)
+    variant('useroot', default=False, description="Use root privileges to make fusermount a setuid binary after installation")
+    variant('system_install', default=False, description=(
+        "Do not run the post-install script "
+        "which typically sets up udev rules and "
+        "and init script in /etc/init.d"))
+
+    conflicts("+useroot", when='~system_install', msg="useroot requires system_install")
 
     patch('0001-Do-not-run-install-script.patch', when='~system_install')
 

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -22,6 +22,9 @@ class Libfuse(MesonPackage):
     version('3.9.2',  sha256='b4409255cbda6f6975ca330f5b04cb335b823a95ddd8c812c3d224ec53478fc0')
 
     variant('useroot', default=False)
+    variant('system_install', default=False)
+
+    patch('0001-Do-not-run-install-script.patch', when='~system_install')
 
     executables = ['^fusermount$']
 


### PR DESCRIPTION
Previously I just disabled the part that needed sudo access during install, but maybe it's better to just disable the whole post-install script that tries to touch `/etc/init.d`, `/etc/fuse`, `/dev/fuse`, etc.
