### PR TITLE
Add documentation for creating mirror of environment

### DIFF
--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -159,6 +159,27 @@ can supply a file with specs in it, one per line:
 This is useful if there is a specific suite of software managed by
 your site.
 
+^^^^^^^^^^^^^^^^^^
+Mirror environment
+^^^^^^^^^^^^^^^^^^
+
+To create a mirror of all packages required by a concerte environment, activate the environment and call ``spack mirror create -a``.
+This is especially useful to create a mirror of an environment concretized on another machine.
+
+.. code-block:: console
+
+   [remote] $ spack env create myenv
+   [remote] $ spack env activate myenv
+   [remote] $ spack add ...
+   [remote] $ spack concretize
+   
+   $ sftp remote:/spack/var/environment/myenv/spack.lock
+   $ spack env create myenv spack.lock
+   $ spack env activate myenv
+   $ spack mirror create -a
+  
+
+
 .. _cmd-spack-mirror-add:
 
 --------------------


### PR DESCRIPTION
This PR adds a section to the documentation of `mirror create` explaining how to create a mirror of a whole environment.
This is especially useful for creating a mirror of an environment, which was generated on another system which:
* may have system specific constraints on packages, and
* does not have internet access.

The example explain how to create a mirror based on a remote lockfile produced by `spack concretize`.
Thanks to @becker33 for the help on Slack.