### PR TITLE
start of work to add debugedit to change DW_TAG_comp_dir

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -602,6 +602,8 @@ def write_buildinfo_file(spec, workdir, rel=False):
     import spack.hooks.sbang as sbang
     buildinfo = {}
     buildinfo['sbang_install_path'] = sbang.sbang_install_path()
+    buildinfo['stage_path'] = spec.package.stage.path
+    buildinfo['install_prefix'] = str(spec.package.prefix)
     buildinfo['relative_rpaths'] = rel
     buildinfo['buildpath'] = spack.store.layout.root
     buildinfo['spackprefix'] = spack.paths.prefix

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1176,6 +1176,7 @@ def relocate_package(spec, allow_root):
                                              old_prefix,
                                              new_prefix)
         if 'elf' in platform.binary_formats:
+            # Relocate the elf binaries, including debugedit to change dwarfinfo
             relocate.relocate_elf_binaries(files_to_relocate,
                                            old_layout_root,
                                            new_layout_root,

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -64,3 +64,5 @@ post_install = HookRunner('post_install')
 
 pre_uninstall = HookRunner('pre_uninstall')
 post_uninstall = HookRunner('post_uninstall')
+
+on_install_success = HookRunner('on_install_success')

--- a/lib/spack/spack/hooks/change_comp_dirs.py
+++ b/lib/spack/spack/hooks/change_comp_dirs.py
@@ -14,6 +14,10 @@ def on_install_success(spec):
     """
     After successful install, use debugedit to change DW_TAG_comp_dir paths.
     """
+    # Don't run in CI
+    if os.environ.get("CI"):
+        return
+
     tty.debug("Running post_install debugedit for %s" % spec)
 
     # create info for later relocation

--- a/lib/spack/spack/hooks/change_comp_dirs.py
+++ b/lib/spack/spack/hooks/change_comp_dirs.py
@@ -10,9 +10,9 @@ import spack.binary_distribution
 import os
 
 
-def post_install(spec):
+def on_install_success(spec):
     """
-    After install of a spec, use debugedit to change DW_TAG_comp_dir paths.
+    After successful install, use debugedit to change DW_TAG_comp_dir paths.
     """
     tty.debug("Running post_install debugedit for %s" % spec)
 

--- a/lib/spack/spack/hooks/change_comp_dirs.py
+++ b/lib/spack/spack/hooks/change_comp_dirs.py
@@ -23,13 +23,11 @@ def post_install(spec):
     # read in the buildinfo file to get stage and install prefix
     buildinfo = spack.binary_distribution.read_buildinfo_file(workdir)
 
-    # Ensure that we update stage paths to install path
-    binaries = [os.path.join(buildinfo['install_prefix'], x)
-                for x in buildinfo['relocate_binaries']]
-
-    # The old prefix is the stage path plus spack-src
+    # Derive list of binaries, old prefix (staging) and new prefix (install)
     old_prefix = os.path.join(buildinfo['stage_path'], 'spack-src')
     new_prefix = buildinfo['install_prefix']
+    binaries = [os.path.join(buildinfo['install_prefix'], x)
+                for x in buildinfo['relocate_binaries']]
 
     # Change the stage directory to install for DW_AT_comp_dir with debugedit
     spack.relocate.run_debugedit(binaries, new_prefix, comp_dirs=[old_prefix])

--- a/lib/spack/spack/hooks/change_comp_dirs.py
+++ b/lib/spack/spack/hooks/change_comp_dirs.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import llnl.util.tty as tty
+import spack.bootstrap
+import spack.relocate
+import spack.binary_distribution
+import os
+
+
+def post_install(spec):
+    """
+    After install of a spec, use debugedit to change DW_TAG_comp_dir paths.
+    """
+    tty.debug("Running post_install debugedit for %s" % spec)
+
+    # create info for later relocation
+    workdir = str(spec.prefix)
+    spack.binary_distribution.write_buildinfo_file(spec, workdir)
+
+    # read in the buildinfo file to get stage and install prefix
+    buildinfo = spack.binary_distribution.read_buildinfo_file(workdir)
+
+    # Ensure that we update stage paths to install path
+    binaries = [os.path.join(buildinfo['install_prefix'], x)
+                for x in buildinfo['relocate_binaries']]
+
+    # The old prefix is the stage path plus spack-src
+    old_prefix = os.path.join(buildinfo['stage_path'], 'spack-src')
+    new_prefix = buildinfo['install_prefix']
+
+    # Change the stage directory to install for DW_AT_comp_dir with debugedit
+    spack.relocate.run_debugedit(binaries, new_prefix, comp_dirs=[old_prefix])

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1733,6 +1733,9 @@ def build_process(pkg, kwargs):
                     _hms(pkg._total_time)))
     _print_installed_pkg(pkg.prefix)
 
+    # hook for when install finished, stage is cleaned up
+    spack.hooks.on_install_success(pkg.spec)
+
     # preserve verbosity across runs
     return echo
 

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -20,6 +20,12 @@ import spack.spec
 import spack.util.executable as executable
 
 
+try:
+    import elftools
+except ImportError:
+    elftools = None  # type: ignore
+
+
 class InstallRootStringError(spack.error.SpackError):
     def __init__(self, file_path, root_path):
         """Signal that the relocated binary still has the original
@@ -618,12 +624,85 @@ def _transform_rpaths(orig_rpaths, orig_root, new_prefixes):
     return new_rpaths
 
 
+def _get_elf_attribute(binary, attr_name):
+    """
+    Read DW_AT_comp_dirs from a binary, if present.
+
+    We assume that we want the value defined for the attribute,
+    and that it's bytes.
+
+    Args:
+        binary (str): binary to get attribute for.
+    """
+    import spack.bootstrap
+    import archspec.cpu
+
+    # Note: this does not work.
+    global elftools
+    if not elftools:
+        with spack.bootstrap.ensure_bootstrap_configuration():
+            generic_target = archspec.cpu.host().family
+            spec_str = 'py-pyelftools target={0}'.format(
+                str(generic_target)
+            )
+            elftools_spec = spack.spec.Spec(spec_str)
+            elftools_spec.concretize()
+            spack.bootstrap.make_module_available('elftools',
+                                                  spec=elftools_spec, install=True)
+            import elftools
+
+    # Derive the old DW_AT_comp_dir
+    comp_dirs = set()
+
+    with open(binary, "rb") as fd:
+        elffile = elftools.elf.elffile.ELFFile(fd)
+
+        # Get the dwarf info
+        if elffile.has_dwarf_info():
+            dwarfinfo = elffile.get_dwarf_info()
+            for cu in dwarfinfo.iter_CUs():
+                die = cu.get_top_DIE()
+                if attr_name in die.attributes:
+                    comp_dir = die.attributes[attr_name].value
+                    comp_dirs.add(elftools.common.py3compat.bytes2str(comp_dir))
+    return comp_dirs
+
+
+def _debugedit(binaries, new_prefix):
+    """
+    Edit debuginfo section of elf files, specifically the base-dir info.
+
+    This function requires 1) pyelftools to get all previous DW_AT_comp_dir,
+    and 2) debugedit to then change these paths in the binary to the new
+    location.
+
+    Args:
+        binaries (list): list of binaries that might need relocation, located
+            in the new prefix
+        new_prefix (str): prefix where we want to relocate the executables
+    """
+    import spack.bootstrap
+
+    # Use debugedit to change the prefix in the binary
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        spec = spack.spec.Spec("debugedit")
+        spec.concretize()
+        debugedit = spack.bootstrap.get_executable(
+            "debugedit", spec=spec, install=True)
+
+        # Change the base-dir information with debugedit!
+        for binary in binaries:
+            for comp_dir in _get_elf_attribute(binary, "DW_AT_comp_dir"):
+                debugedit('-b', comp_dir, '-d', new_prefix, binary)
+
+
 def relocate_elf_binaries(binaries, orig_root, new_root,
                           new_prefixes, rel, orig_prefix, new_prefix):
     """Relocate the binaries passed as arguments by changing their RPATHs.
 
     Use patchelf to get the original RPATHs and then replace them with
-    rpaths in the new directory layout.
+    rpaths in the new directory layout. Use bootstrapped debugedit to edit
+    the filepaths in the binary headers too.
 
     New RPATHs are determined from a dictionary mapping the prefixes in the
     old directory layout to the prefixes in the new directory layout if the
@@ -640,6 +719,9 @@ def relocate_elf_binaries(binaries, orig_root, new_root,
         orig_prefix (str): prefix where the executable was originally located
         new_prefix (str): prefix where we want to relocate the executable
     """
+    # Use debugedit to change the prefix in the binary
+    _debugedit(binaries, new_prefix)
+
     for new_binary in binaries:
         orig_rpaths = _elf_rpaths_for(new_binary)
         # TODO: Can we deduce `rel` from the original RPATHs?

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -632,6 +632,10 @@ def run_debugedit(binaries, new_prefix, comp_dirs):
         new_prefix (str): prefix where we want to relocate the executables
         comp_dirs (list): if known, list of compile directories to change,
     """
+    # Don't run in CI
+    if os.environ.get("CI"):
+        return
+
     import spack.bootstrap
     comp_dirs = comp_dirs or []
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -266,6 +266,7 @@ def check_for_leftover_stage_files(request, mock_stage, ignore_stage_files):
         else:
             raise
 
+    print(stage_files)
     if 'disable_clean_stage_check' in request.keywords:
         # clean up after tests that are expected to be dirty
         for f in files_in_stage:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -266,7 +266,6 @@ def check_for_leftover_stage_files(request, mock_stage, ignore_stage_files):
         else:
             raise
 
-    print(stage_files)
     if 'disable_clean_stage_check' in request.keywords:
         # clean up after tests that are expected to be dirty
         for f in files_in_stage:

--- a/var/spack/repos/builtin/packages/py-pyelftools/package.py
+++ b/var/spack/repos/builtin/packages/py-pyelftools/package.py
@@ -7,12 +7,13 @@ from spack import *
 
 
 class PyPyelftools(PythonPackage):
-    """Library for analyzing ELF files and DWARF debugging information"""
-
-    homepage = "https://github.com/eliben/pyelftools"
+    """A pure-Python library for parsing and analyzing ELF files and DWARF
+       debugging information"""
     pypi = "pyelftools/pyelftools-0.27.tar.gz"
+    homepage = "https://github.com/eliben/pyelftools"
 
     version('0.27', sha256='cde854e662774c5457d688ca41615f6594187ba7067af101232df889a6b7a66b')
+    version('0.26', sha256='86ac6cee19f6c945e8dedf78c6ee74f1112bd14da5a658d8c9d4103aed5756a2')
+    version('0.23', sha256='fc57aadd096e8f9b9b03f1a9578f673ee645e1513a5ff0192ef439e77eab21de')
 
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools', when='@0.25:', type='build')

--- a/var/spack/repos/builtin/packages/py-pyelftools/package.py
+++ b/var/spack/repos/builtin/packages/py-pyelftools/package.py
@@ -7,11 +7,12 @@ from spack import *
 
 
 class PyPyelftools(PythonPackage):
-    """A pure-Python library for parsing and analyzing ELF files and DWARF
-       debugging information"""
-    pypi = "pyelftools/pyelftools-0.26.tar.gz"
+    """Library for analyzing ELF files and DWARF debugging information"""
 
-    version('0.26', sha256='86ac6cee19f6c945e8dedf78c6ee74f1112bd14da5a658d8c9d4103aed5756a2')
-    version('0.23', sha256='fc57aadd096e8f9b9b03f1a9578f673ee645e1513a5ff0192ef439e77eab21de')
+    homepage = "https://github.com/eliben/pyelftools"
+    pypi = "pyelftools/pyelftools-0.27.tar.gz"
 
-    depends_on('py-setuptools', when='@0.25:', type='build')
+    version('0.27', sha256='cde854e662774c5457d688ca41615f6594187ba7067af101232df889a6b7a66b')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Update: we no longer need to dynamically read the `DW_AT_comp_dir` so the description below the line is no longer needed. The questions that I now have for this PR are:

 - should the function to run_debugedit be somewhere else?
 - what tests should we have (and given that we would need to read the attribute, how should we go about it?)
 - what about all the functions that assert that a binary is not relocatable - were they because of this issue and we can remove them? Which ones/parts?

--------------------
This PR is not ready for an actual review, but I'm running into issues with using pyelftools to bootstrap and I'm opening it so we have a place for discussion. I'll provide complete details next.

We want to add debugedit (bootstrapped) to spack so that we can take a buildcache (compiled somewhere else) and use a tool called debugedit (recently added) to change the `DW_TAG_comp_dir` attributes in the dwarf_str section. Debugedit itself works fine to bootstrap - but in order for the command to work we first need to retrieve the previous path that is set in the binary (in practice I've seen it's the spack stage temporary directory). I tried to test different system tools that we might bootstrap (e.g., objdump, readelf, nm, reading abidw output) but all of the ideas I had were sort of hacks with awk or grep. This (I don't think) is something we want to introduce into spack.

For my next effort, I was able to write a small python script with [pyelftools](https://github.com/eliben/pyelftools) (in the code in this PR) to grab all these paths (in practice it's just one, but I suspect there could be cases when there are more than one). I would then need to bootstrap this library too, so I tried following the same strategy of clingo-bootstrap. I tried a lot of things, but nothing seemed to work. The error I see is that the encoding of the filesystem cannot be determined (and there is no encoding module). Here is what happens when we try to do the bootstrap:

```bash
[+] /home/vanessa/Desktop/Code/spack/env (external python-3.8.3-ulizfw5ii43bt57ht3zq4leowl44qndi)
==> Installing py-setuptools-50.3.2-dc2giw5s32vulagtupoy5dhkyl3cjows
==> No binary for py-setuptools-50.3.2-dc2giw5s32vulagtupoy5dhkyl3cjows found: installing from source
==> Using cached archive: /home/vanessa/Desktop/Code/spack-dev/var/spack/cache/_source-cache/archive/ed/ed0519d27a243843b05d82a5e9d01b0b083d9934eaa3d02779a23da18077bd3c.zip
==> No patches needed for py-setuptools
==> py-setuptools: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 1:
    '/home/vanessa/Desktop/Code/spack/env/bin/python3' '-s' 'setup.py' '--no-user-cfg' 'build'
1 error found in build log:
     18        '/home/vanessa/.spack/bootstrap/store/linux-ubuntu20.04-x86_64/gcc-9.3.0/py-setuptools-50.3.2-dc2giw5s32vulagtupoy5dhkyl3cjows
           /lib/python3.8/site-packages',
     19        '/home/vanessa/.spack/bootstrap/store/linux-ubuntu20.04-x86_64/gcc-9.3.0/py-setuptools-50.3.2-dc2giw5s32vulagtupoy5dhkyl3cjows
           /lib64/python3.8/site-packages',
     20        '/home/vanessa/Desktop/Code/spack/env/lib/python38.zip',
     21        '/home/vanessa/Desktop/Code/spack/env/lib/python3.8',
     22        '/home/vanessa/Desktop/Code/spack/env/lib/python3.8/lib-dynload',
     23      ]
  >> 24    Fatal Python error: init_fs_encoding: failed to get the Python codec of the filesystem encoding
     25    Python runtime state: core initialized
     26    ModuleNotFoundError: No module named 'encodings'
     27    
     28    Current thread 0x00007facd6249740 (most recent call first):
     29    <no Python frame>
See build log for details:
  /tmp/vanessa/spack-stage/spack-stage-py-setuptools-50.3.2-dc2giw5s32vulagtupoy5dhkyl3cjows/spack-build-out.txt
==> Warning: Skipping build of py-pyelftools-0.27-aevd74hltmxatwcfqoqxwsjfyuoy2cir since py-setuptools-50.3.2-dc2giw5s32vulagtupoy5dhkyl3cjows failed
==> Error: py-pyelftools-0.27-aevd74hltmxatwcfqoqxwsjfyuoy2cir: Package was not installed
```
I've tried both using the wheel with pip and the included here with setup.py, and I've also tried unsetting the sys.path so that other python isn't found, along with the PATH.  I can't seem to get around generating this error, although installing the package on the command line works fine.

## How to work on this

This function will be triggered if we are installing from a binarycache, so I created one to do this:

```bash
# You need the package installed to create a buildcache
spack install swig

# Create a folder, create a cache for swig
mkdir -p ./spack-cache
spack buildcache create -d ./spack-cache swig

# add the mirror and update the index
spack mirror add mymirror ./spack-cache
spack buildcache update-index -d spack-cache/

# remove the package so it's not installed
spack uninstall swig

# install from buildcache
spack buildcache install swig
```
I'm actually setting [this line](https://github.com/spack/spack/blob/develop/lib/spack/spack/binary_distribution.py#L1164) to be `==` so that the relocation triggers (for development only) because the paths are the same, but you could change your buildcache / environment / spack install if you want them to be different and not need to change this line. 

I pinged @alalazo in slack, and am providing this so he can reproduce my issue (and others can ping in to help too!)

Other alternatives:
 - we could use a different method to get the path
 - we could store the path with the build cache so we don't need to parse the binary

Signed-off-by: vsoch <vsoch@users.noreply.github.com>