### PR TITLE
Add dev variant to cuda to make cuda-gdb useable

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -103,7 +103,12 @@ class Cuda(Package):
     # Mojave support -- only macOS High Sierra 10.13 is supported.
     conflicts('arch=darwin-mojave-x86_64')
 
+    variant('dev', default=False, description='Enable development dependencies, i.e to use cuda-gdb')
+
     depends_on('libxml2', when='@10.1.243:')
+    # cuda-gdb needs libncurses.so.5
+    # see https://docs.nvidia.com/cuda/cuda-gdb/index.html#common-issues-oss
+    depends_on('ncurses+abi5', type='run', when='+dev')
 
     provides('opencl@:1.2', when='@7:')
     provides('opencl@:1.1', when='@:6')

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -108,7 +108,7 @@ class Cuda(Package):
     depends_on('libxml2', when='@10.1.243:')
     # cuda-gdb needs libncurses.so.5
     # see https://docs.nvidia.com/cuda/cuda-gdb/index.html#common-issues-oss
-    depends_on('ncurses+abi5', type='run', when='+dev')
+    depends_on('ncurses abi=5', type='run', when='+dev')
 
     provides('opencl@:1.2', when='@7:')
     provides('opencl@:1.1', when='@:6')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -31,6 +31,9 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
     variant('termlib', default=True,
             description='Enables termlib features. This is an extra '
                         'lib and optional internal dependency.')
+    variant('abi5', default=False,
+            description='Use application binary interface (ABI) for '
+                        'ncurses version 5')
 
     depends_on('pkgconfig', type='build')
 
@@ -107,6 +110,8 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
                          '--enable-getcap',
                          '--enable-tcap-names',
                          '--with-versioned-syms'))
+        if '+abi5' in self.spec:
+            opts.append('--with-abi-version=5')
 
         prefix = '--prefix={0}'.format(prefix)
 

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -31,9 +31,10 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
     variant('termlib', default=True,
             description='Enables termlib features. This is an extra '
                         'lib and optional internal dependency.')
-    variant('abi5', default=False,
-            description='Use application binary interface (ABI) for '
-                        'ncurses version 5')
+    # Build ncurses with ABI compaitibility.
+    variant('abi', default='none', description='choose abi compatibility', values=('none', '5', '6'), multi=False)
+
+    conflicts('abi=6', when='@:5.9', msg='6 is not compatible with this release')
 
     depends_on('pkgconfig', type='build')
 
@@ -110,8 +111,10 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
                          '--enable-getcap',
                          '--enable-tcap-names',
                          '--with-versioned-syms'))
-        if '+abi5' in self.spec:
-            opts.append('--with-abi-version=5')
+
+        abi = self.spec.variants['abi'].value
+        if abi != 'none':
+            opts.append('--with-abi-version=' + abi)
 
         prefix = '--prefix={0}'.format(prefix)
 


### PR DESCRIPTION
`cuda-gdb` needs `libncurses.so.5`, ( see https://docs.nvidia.com/cuda/cuda-gdb/index.html#common-issues-oss ). 
Hence I first add a new variant to `ncurses` to build the ABI for version 5 and add this as runtime dependency for a 'dev' variant for `cuda`, which is useful for developing cuda apps.