### PR TITLE
py-scipy: add v1.6.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -13,11 +13,12 @@ class PyScipy(PythonPackage):
 
     homepage = "https://www.scipy.org/"
     pypi = "scipy/scipy-1.5.4.tar.gz"
-    git      = "https://github.com/scipy/scipy.git"
+    git = "https://github.com/scipy/scipy.git"
 
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('1.6.2',  sha256='e9da33e21c9bc1b92c20b5328adb13e5f193b924c9b969cd700c8908f315aa59')
     version('1.6.1',  sha256='c4fceb864890b6168e79b0e714c585dbe2fd4222768ee90bc1aa0f8218691b11')
     version('1.6.0',  sha256='cb6dc9f82dfd95f6b9032a8d7ea70efeeb15d5b5fd6ed4e8537bb3c673580566')
     version('1.5.4',  sha256='4a453d5e5689de62e5d38edf40af3f17560bfd63c9c5bd228c18c1f99afa155b')
@@ -42,22 +43,26 @@ class PyScipy(PythonPackage):
     version('0.15.1', sha256='a212cbc3b79e9a563aa45fc5c517b3499198bd7eb7e7be1e047568a5f48c259a')
     version('0.15.0', sha256='0c74e31e08acc8bf9b6ceb9bced73df2ae0cc76003e0366350bc7b26292bf8b1')
 
-    depends_on('python@2.6:2.8,3.2:', type=('build', 'link', 'run'))
-    depends_on('python@2.7:2.8,3.4:', when='@0.18:', type=('build', 'link', 'run'))
-    depends_on('python@3.5:', when='@1.3:', type=('build', 'link', 'run'))
-    depends_on('python@3.6:', when='@1.5:', type=('build', 'link', 'run'))
-    depends_on('python@3.7:', when='@1.6:', type=('build', 'link', 'run'))
-    depends_on('py-setuptools', type='build')
-    depends_on('py-pybind11@2.2.4:', when='@1.4.0:', type=('build', 'link'))
-    depends_on('py-pybind11@2.4.0:', when='@1.4.1:', type=('build', 'link'))
-    depends_on('py-pybind11@2.4.3:', when='@1.5.0:', type=('build', 'link'))
-    depends_on('py-numpy@1.5.1:+blas+lapack', type=('build', 'link', 'run'))
-    depends_on('py-numpy@1.6.2:+blas+lapack', when='@0.16:', type=('build', 'link', 'run'))
-    depends_on('py-numpy@1.7.1:+blas+lapack', when='@0.18:', type=('build', 'link', 'run'))
-    depends_on('py-numpy@1.8.2:+blas+lapack', when='@0.19:', type=('build', 'link', 'run'))
-    depends_on('py-numpy@1.13.3:+blas+lapack', when='@1.3:', type=('build', 'link', 'run'))
-    depends_on('py-numpy@1.14.5:+blas+lapack', when='@1.5:', type=('build', 'link', 'run'))
-    depends_on('py-numpy@1.16.5:+blas+lapack', when='@1.6:', type=('build', 'link', 'run'))
+    depends_on('python@2.6:2.8,3.2:', when='@:0.17.999', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2.8,3.4:', when='@0.18:1.2.999', type=('build', 'link', 'run'))
+    depends_on('python@3.5:', when='@1.3:1.4.999', type=('build', 'link', 'run'))
+    depends_on('python@3.6:', when='@1.5:1.5.999', type=('build', 'link', 'run'))
+    depends_on('python@3.7:', when='@1.6:1.6.1', type=('build', 'link', 'run'))
+    depends_on('python@3.7:3.9.999', when='@1.6.2:', type=('build', 'link', 'run'))
+    depends_on('py-setuptools', when='@:1.6.1', type='build')
+    depends_on('py-setuptools@:51.0.0', when='@1.6.2:', type='build')
+    depends_on('py-pybind11@2.2.4:', when='@1.4.0', type=('build', 'link'))
+    depends_on('py-pybind11@2.4.0:', when='@1.4.1:1.4.999', type=('build', 'link'))
+    depends_on('py-pybind11@2.4.3:', when='@1.5:1.6.1', type=('build', 'link'))
+    depends_on('py-pybind11@2.4.3:2.6.999', when='@1.6.2:', type=('build', 'link'))
+    depends_on('py-numpy@1.5.1:+blas+lapack', when='@:0.15.999', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.6.2:+blas+lapack', when='@0.16:0.17.999', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.7.1:+blas+lapack', when='@0.18:0.18.999', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.8.2:+blas+lapack', when='@0.19:1.2.999', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.13.3:+blas+lapack', when='@1.3:1.4.999', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.14.5:+blas+lapack', when='@1.5:1.5.999', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.16.5:+blas+lapack', when='@1.6:1.6.1', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.16.5:1.22.999+blas+lapack', when='@1.6.2:', type=('build', 'link', 'run'))
     depends_on('py-pytest', type='test')
 
     # NOTE: scipy picks up Blas/Lapack from numpy, see


### PR DESCRIPTION
Scipy now explicitly lists an upper bound for supported versions, which is great for pip but a little annoying to keep track of in Spack.

https://github.com/scipy/scipy/releases/tag/v1.6.2