### PR TITLE
Bugfixes in LBANN software stack identified by clingo

### DIFF
--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -55,19 +55,6 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
     variant('blas', default='openblas', values=('openblas', 'mkl', 'accelerate', 'essl'),
             description='Enable the use of OpenBlas/MKL/Accelerate/ESSL')
 
-    # Override the default set of CUDA architectures with the relevant
-    # subset from lib/spack/spack/build_systems/cuda.py
-    cuda_arch_values = [
-        '30', '32', '35', '37',
-        '50', '52', '53',
-        '60', '61', '62',
-        '70', '72', '75',
-        '80'
-    ]
-    variant('cuda_arch',
-            description='CUDA architecture',
-            values=spack.variant.auto_or_any_combination_of(*cuda_arch_values))
-
     conflicts('~cuda', when='+nvshmem')
 
     depends_on('mpi')
@@ -75,7 +62,8 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
 
     # Specify the correct version of Aluminum
     depends_on('aluminum@0.4:0.4.99', when='@0.1:0.1.99 +al')
-    depends_on('aluminum@0.5.0:', when='@:0.0,0.2: +al')
+    depends_on('aluminum@0.5.0:0.7.99', when='@0.2.0:0.2.1 +al')
+    depends_on('aluminum@0.5.0:1.0.99', when='@:0.0,0.2.1: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')
@@ -89,32 +77,29 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
     for val in ROCmPackage.amdgpu_targets:
         depends_on('aluminum amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
 
-    depends_on('cuda', when=('+cuda' or '+legacy'))
-    depends_on('cudnn', when=('+cuda' or '+legacy'))
+    depends_on('cuda', when=('+cuda' or '+distconv'))
+    depends_on('cudnn', when=('+cuda' or '+distconv'))
     depends_on('cub', when='^cuda@:10.99')
 
     # Note that #1712 forces us to enumerate the different blas variants
-    depends_on('openblas', when='blas=openblas ~openmp_blas ~int64_blas')
-    depends_on('openblas +ilp64', when='blas=openblas ~openmp_blas +int64_blas')
-    depends_on('openblas threads=openmp', when='blas=openblas +openmp_blas ~int64_blas')
-    depends_on('openblas threads=openmp +lip64', when='blas=openblas +openmp_blas +int64_blas')
+    depends_on('openblas', when='blas=openblas')
+    depends_on('openblas +ilp64', when='blas=openblas +int64_blas')
+    depends_on('openblas threads=openmp', when='blas=openblas +openmp_blas')
 
-    depends_on('intel-mkl', when="blas=mkl ~openmp_blas ~int64_blas")
-    depends_on('intel-mkl +ilp64', when="blas=mkl ~openmp_blas +int64_blas")
-    depends_on('intel-mkl threads=openmp', when='blas=mkl +openmp_blas ~int64_blas')
-    depends_on('intel-mkl@2017.1 +openmp +ilp64', when='blas=mkl +openmp_blas +int64_blas')
+    depends_on('intel-mkl', when="blas=mkl")
+    depends_on('intel-mkl +ilp64', when="blas=mkl +int64_blas")
+    depends_on('intel-mkl threads=openmp', when='blas=mkl +openmp_blas')
 
     depends_on('veclibfort', when='blas=accelerate')
     conflicts('blas=accelerate +openmp_blas')
 
-    depends_on('essl -cuda', when='blas=essl -openmp_blas ~int64_blas')
-    depends_on('essl -cuda +ilp64', when='blas=essl -openmp_blas +int64_blas')
-    depends_on('essl threads=openmp', when='blas=essl +openmp_blas ~int64_blas')
-    depends_on('essl threads=openmp +ilp64', when='blas=essl +openmp_blas +int64_blas')
+    depends_on('essl', when='blas=essl')
+    depends_on('essl +ilp64', when='blas=essl +int64_blas')
+    depends_on('essl threads=openmp', when='blas=essl +openmp_blas')
     depends_on('netlib-lapack +external-blas', when='blas=essl')
 
-    # Legacy builds require cuda
-    conflicts('~cuda', when='+legacy')
+    # Distconv builds require cuda
+    conflicts('~cuda', when='+distconv')
 
     conflicts('+distconv', when='+half')
     conflicts('+rocm', when='+half')
@@ -132,6 +117,8 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('nvshmem', when='+nvshmem')
 
+    # Idenfity versions of cuda_arch that are too old
+    # from lib/spack/spack/build_systems/cuda.py
     illegal_cuda_arch_values = [
         '10', '11', '12', '13',
         '20', '21',
@@ -179,12 +166,12 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
                         ' '.join(self.cuda_flags(cuda_arch))
                     ))
 
-        if '+cuda' in spec or '+legacy' in spec:
+        if '+cuda' in spec or '+distconv' in spec:
             args.append('-DcuDNN_DIR={0}'.format(
                 spec['cudnn'].prefix))
 
         if spec.satisfies('^cuda@:10.99'):
-            if '+cuda' in spec or '+legacy' in spec:
+            if '+cuda' in spec or '+distconv' in spec:
                 args.append('-DCUB_DIR={0}'.format(
                     spec['cub'].prefix))
 

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -63,7 +63,7 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
     # Specify the correct version of Aluminum
     depends_on('aluminum@0.4:0.4.99', when='@0.1:0.1.99 +al')
     depends_on('aluminum@0.5.0:0.7.99', when='@0.2.0:0.2.1 +al')
-    depends_on('aluminum@0.5.0:1.0.99', when='@:0.0,0.2.1: +al')
+    depends_on('aluminum@0.5.0:', when='@:0.0,0.2.1: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -77,8 +77,9 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
     for val in ROCmPackage.amdgpu_targets:
         depends_on('aluminum amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
 
-    depends_on('cuda', when=('+cuda' or '+distconv'))
-    depends_on('cudnn', when=('+cuda' or '+distconv'))
+    for when in ['+cuda', '+distconv']:
+        depends_on('cuda', when=when)
+        depends_on('cudnn', when=when)
     depends_on('cub', when='^cuda@:10.99')
 
     # Note that #1712 forces us to enumerate the different blas variants

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -61,14 +61,14 @@ class Elemental(CMakePackage):
     # Allow Elemental to build internally when using 8-byte ints
     depends_on('openblas threads=openmp', when='blas=openblas +openmp_blas ~int64_blas')
 
-    depends_on('intel-mkl', when="blas=mkl ~openmp_blas ~int64_blas")
-    depends_on('intel-mkl threads=openmp', when='blas=mkl +openmp_blas ~int64_blas')
-    depends_on('intel-mkl@2017.1 +openmp +ilp64', when='blas=mkl +openmp_blas +int64_blas')
+    depends_on('intel-mkl', when="blas=mkl")
+    depends_on('intel-mkl threads=openmp', when='blas=mkl +openmp_blas')
+    depends_on('intel-mkl@2017.1 +ilp64', when='blas=mkl +int64_blas')
 
     depends_on('veclibfort', when='blas=accelerate')
 
-    depends_on('essl ~cuda', when='blas=essl ~openmp_blas ~int64_blas')
-    depends_on('essl threads=openmp', when='blas=essl +openmp_blas ~int64_blas')
+    depends_on('essl', when='blas=essl')
+    depends_on('essl threads=openmp', when='blas=essl +openmp_blas')
 
     # Note that this forces us to use OpenBLAS until #1712 is fixed
     depends_on('lapack', when='blas=openblas ~openmp_blas')

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -85,7 +85,6 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('blas=accelerate +openmp_blas')
 
     depends_on('essl', when='blas=essl')
-    depends_on('essl -cuda', when='blas=essl -openmp_blas')
     depends_on('essl +ilp64', when='blas=essl +int64_blas')
     depends_on('essl threads=openmp', when='blas=essl +openmp_blas')
     depends_on('netlib-lapack +external-blas', when='blas=essl')
@@ -94,7 +93,7 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('aluminum@:0.3.99', when='@:1.3.99 +al')
     depends_on('aluminum@0.4:0.4.99', when='@1.4:1.4.99 +al')
     depends_on('aluminum@0.5.0:0.5.99', when='@1.5.0:1.5.1 +al')
-    depends_on('aluminum@0.7.0:', when='@:1.0,1.5.2: +al')
+    depends_on('aluminum@0.7.0:1.0.99', when='@:1.0,1.5.2: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -93,7 +93,7 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('aluminum@:0.3.99', when='@:1.3.99 +al')
     depends_on('aluminum@0.4:0.4.99', when='@1.4:1.4.99 +al')
     depends_on('aluminum@0.5.0:0.5.99', when='@1.5.0:1.5.1 +al')
-    depends_on('aluminum@0.7.0:1.0.99', when='@:1.0,1.5.2: +al')
+    depends_on('aluminum@0.7.0:', when='@:1.0,1.5.2: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -105,7 +105,7 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     # Specify the correct version of Aluminum
     depends_on('aluminum@:0.3.99', when='@0.95:0.100 +al')
     depends_on('aluminum@0.4:0.4.99', when='@0.101:0.101.99 +al')
-    depends_on('aluminum@0.5.0:1.0.99', when='@:0.90,0.102: +al')
+    depends_on('aluminum@0.5.0:', when='@:0.90,0.102: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -105,7 +105,7 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     # Specify the correct version of Aluminum
     depends_on('aluminum@:0.3.99', when='@0.95:0.100 +al')
     depends_on('aluminum@0.4:0.4.99', when='@0.101:0.101.99 +al')
-    depends_on('aluminum@0.5.0:', when='@:0.90,0.102: +al')
+    depends_on('aluminum@0.5.0:1.0.99', when='@:0.90,0.102: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')
@@ -182,7 +182,7 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('python@3: +shared', type=('build', 'run'), when='@:0.90,0.99: +pfe')
     extends("python", when='+pfe')
     depends_on('py-setuptools', type='build', when='+pfe')
-    depends_on('py-argparse', type='run', when='@:0.90,0.99: ^python@:2.6 +pfe')
+    depends_on('py-argparse', type='run', when='@:0.90,0.99: +pfe ^python@:2.6')
     depends_on('py-configparser', type='run', when='@:0.90,0.99: +pfe +extras')
     depends_on('py-graphviz@0.10.1:', type='run', when='@:0.90,0.99: +pfe +extras')
     depends_on('py-matplotlib@3.0.0:', type='run', when='@:0.90,0.99: +pfe +extras')


### PR DESCRIPTION
Fixed a bug in the DiHydrogen package where the variant legacy was
changed to distconv and wasn't fully propagated.  Cleaned up the
openmp variants on the blas library packages in DiHydrogen and
Elemental.  Extended support for Aluminum v1.0 in LBANN, Hydrogen, and
DiHydrogen.  Fixed a when clause in the LBANN dependencies.