### PR TITLE
adding support for export of private gpg key

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1127,6 +1127,25 @@ Here is an example of creating a key. Note that we provide a name for the key fi
     $ spack gpg create dinosaur dinosaur@thedinosaurthings.com
 
 
+If you want to export the key as you create it:
+
+
+.. code-block:: console
+
+    $ spack gpg create --export key.pub dinosaur dinosaur@thedinosaurthings.com
+
+Or the private key:
+
+
+.. code-block:: console
+
+    $ spack gpg create --export-secret key.priv dinosaur dinosaur@thedinosaurthings.com
+
+
+You can include both ``--export`` and ``--export-secret``, each with
+an output file of choice, to export both.
+
+
 ^^^^^^^^^^^^
 Listing keys
 ^^^^^^^^^^^^

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -1119,6 +1119,14 @@ Secret keys may also be later exported using the
       <https://www.digitalocean.com/community/tutorials/how-to-setup-additional-entropy-for-cloud-servers-using-haveged>`_
       provides a good overview of sources of randomness.
 
+Here is an example of creating a key. Note that we provide a name for the key first
+(which we can use to reference the key later) and an email address:
+
+.. code-block:: console
+
+    $ spack gpg create dinosaur dinosaur@thedinosaurthings.com
+
+
 ^^^^^^^^^^^^
 Listing keys
 ^^^^^^^^^^^^
@@ -1127,7 +1135,22 @@ In order to list the keys available in the keyring, the
 ``spack gpg list`` command will list trusted keys with the ``--trusted`` flag
 and keys available for signing using ``--signing``. If you would like to
 remove keys from your keyring, ``spack gpg untrust <keyid>``. Key IDs can be
-email addresses, names, or (best) fingerprints.
+email addresses, names, or (best) fingerprints. Here is an example of listing
+the key that we just created:
+
+.. code-block:: console
+
+    gpgconf: socketdir is '/run/user/1000/gnupg'
+    /home/spackuser/spack/opt/spack/gpg/pubring.kbx
+    ----------------------------------------------------------
+    pub   rsa4096 2021-03-25 [SC]
+          60D2685DAB647AD4DB54125961E09BB6F2A0ADCB
+    uid           [ultimate] dinosaur (GPG created for Spack) <dinosaur@thedinosaurthings.com>
+
+    
+Note that the name "dinosaur" can be seen under the uid, which is the unique
+id. We might need this reference if we want to export or otherwise reference the key.
+
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Signing and Verifying Packages
@@ -1141,6 +1164,38 @@ must be specified using the ``--key <keyid>`` flag. The ``--clearsign`` flag
 may also be used to create a signed file which contains the contents, but it
 is not recommended. Signed packages may be verified by using
 ``spack gpg verify <file>``.
+
+
+^^^^^^^^^^^^^^
+Exporting Keys
+^^^^^^^^^^^^^^
+
+You likely might want to export a public key, and that looks like this. Let's
+use the previous example and ask spack to export the key with uid "dinosaur."
+We will provide an output location (typically a `*.pub` file) and the name of
+the key.
+
+.. code-block:: console
+
+    $ spack gpg export dinosaur.pub dinosaur
+
+You can then look at the created file, `dinosaur.pub`, to see the exported key.
+If you want to include the private key, then just add `--secret`:
+
+.. code-block:: console
+
+    $ spack gpg export --secret dinosaur.priv dinosaur
+
+This will write the private key to the file `dinosaur.priv`. 
+
+.. warning::
+
+    You should be very careful about exporting private keys. You likely would
+    only want to do this in the context of moving your spack installation to
+    a different server, and wanting to preserve keys for a buildcache. If you
+    are unsure about exporting, you can ask your local system administrator
+    or for help on an issue or the Spack slack.
+
 
 .. _cray-support:
 

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1542,7 +1542,7 @@ def push_keys(*mirrors, **kwargs):
                 export_target = os.path.join(prefix, filename)
 
                 # Export public keys (private is set to False)
-                spack.util.gpg.export_keys(export_target, False, fingerprint)
+                spack.util.gpg.export_keys(export_target, [fingerprint])
 
                 # If mirror is local, the above export writes directly to the
                 # mirror (export_target points directly to the mirror).

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1540,7 +1540,9 @@ def push_keys(*mirrors, **kwargs):
                 filename = fingerprint + '.pub'
 
                 export_target = os.path.join(prefix, filename)
-                spack.util.gpg.export_keys(export_target, fingerprint)
+
+                # Export public keys (private is set to False)
+                spack.util.gpg.export_keys(export_target, False, fingerprint)
 
                 # If mirror is local, the above export writes directly to the
                 # mirror (export_target points directly to the mirror).

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -127,11 +127,10 @@ def gpg_create(args):
         new_sec_keys = set(spack.util.gpg.signing_keys())
         new_keys = new_sec_keys.difference(old_sec_keys)
 
-    # False/True indicates public/secret key to export
     if args.export:
-        spack.util.gpg.export_keys(args.export, False, *new_keys)
+        spack.util.gpg.export_keys(args.export, new_keys)
     if args.secret:
-        spack.util.gpg.export_keys(args.secret, True, *new_keys)
+        spack.util.gpg.export_keys(args.secret, new_keys, secret=True)
 
 
 def gpg_export(args):
@@ -139,7 +138,7 @@ def gpg_export(args):
     keys = args.keys
     if not keys:
         keys = spack.util.gpg.signing_keys()
-    spack.util.gpg.export_keys(args.location, args.secret, *keys)
+    spack.util.gpg.export_keys(args.location, keys, args.secret)
 
 
 def gpg_list(args):

--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -79,7 +79,9 @@ def setup_parser(subparser):
                         help='where to export keys')
     export.add_argument('keys', nargs='*',
                         help='the keys to export; '
-                             'all secret keys if unspecified')
+                             'all public keys if unspecified')
+    export.add_argument('--secret', action='store_true',
+                        help='include secret keys')
     export.set_defaults(func=gpg_export)
 
     publish = subparsers.add_parser('publish', help=gpg_publish.__doc__)
@@ -119,15 +121,17 @@ def gpg_create(args):
     if args.export:
         new_sec_keys = set(spack.util.gpg.signing_keys())
         new_keys = new_sec_keys.difference(old_sec_keys)
-        spack.util.gpg.export_keys(args.export, *new_keys)
+
+        # False indicates we are not exporting secret
+        spack.util.gpg.export_keys(args.export, False, *new_keys)
 
 
 def gpg_export(args):
-    """export a secret key"""
+    """export a gpg key, optionally including secret key."""
     keys = args.keys
     if not keys:
         keys = spack.util.gpg.signing_keys()
-    spack.util.gpg.export_keys(args.location, *keys)
+    spack.util.gpg.export_keys(args.location, args.secret, *keys)
 
 
 def gpg_list(args):

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -117,6 +117,20 @@ def test_gpg(tmpdir, mock_gnupghome):
     export_path = tmpdir.join('export.testing.key')
     gpg('export', str(export_path))
 
+    # Test exporting the private key
+    private_export_path = tmpdir.join('export-secret.testing.key')
+    gpg('export', '--secret', str(private_export_path))
+
+    # Ensure we exported the right content!
+    with open(str(private_export_path), 'r') as fd:
+        content = fd.read()
+    assert "BEGIN PGP PRIVATE KEY BLOCK" in content
+
+    # and for the public key
+    with open(str(export_path), 'r') as fd:
+        content = fd.read()
+    assert "BEGIN PGP PUBLIC KEY BLOCK" in content
+
     # Create a second key for use in the tests.
     gpg('create',
         '--comment', 'Spack testing key',

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -336,10 +336,12 @@ class Gpg(object):
                       *args, output=str)
         return parse_public_keys_output(output)
 
-    def export_keys(self, location, *keys):
-        self('--batch', '--yes',
-             '--armor', '--export',
-             '--output', location, *keys)
+    def export_keys(self, location, secret, *keys):
+        if secret:
+            self("--export-secret-keys", "--armor", "--output", location, *keys)
+        else:
+            self('--batch', '--yes', '--armor', '--export', '--output',
+                 location, *keys)
 
     def trust(self, keyfile):
         self('--import', keyfile)

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -336,7 +336,7 @@ class Gpg(object):
                       *args, output=str)
         return parse_public_keys_output(output)
 
-    def export_keys(self, location, secret, *keys):
+    def export_keys(self, location, keys, secret=False):
         if secret:
             self("--export-secret-keys", "--armor", "--output", location, *keys)
         else:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -996,7 +996,7 @@ _spack_gpg_init() {
 _spack_gpg_export() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help --secret"
     else
         _keys
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -979,7 +979,7 @@ _spack_gpg_sign() {
 _spack_gpg_create() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --comment --expires --export"
+        SPACK_COMPREPLY="-h --help --comment --expires --export --export-secret"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
Fixes #14721.

This PR adds a flag, --secret to spack gpg export to allow the user to export a secret key. The docs are updated that include a warning that this usually does not need to be done.

This addresses an issue brought up in slack, and also represented in #14721.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>