### PR TITLE
Make SingleFileScope able to repopulate the cache after clearing it

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -241,11 +241,18 @@ class SingleFileScope(ConfigScope):
         #      }
         #   }
         # }
+
+        # This bit ensures we have read the file and have
+        # the raw data in memory
         if self._raw_data is None:
             self._raw_data = read_config_file(self.path, self.schema)
             if self._raw_data is None:
                 return None
 
+        # Here we know we have the raw data and ensure we
+        # populate the sections dictionary, which may be
+        # cleared by the clear() method
+        if not self.sections:
             section_data = self._raw_data
             for key in self.yaml_path:
                 if section_data is None:
@@ -254,6 +261,7 @@ class SingleFileScope(ConfigScope):
 
             for section_key, data in section_data.items():
                 self.sections[section_key] = {section_key: data}
+
         return self.sections.get(section, None)
 
     def _write_section(self, section):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -73,6 +73,25 @@ def write_config_file(tmpdir):
     return _write
 
 
+@pytest.fixture()
+def env_yaml(tmpdir):
+    """Return a sample env.yaml for test purposes"""
+    env_yaml = str(tmpdir.join("env.yaml"))
+    with open(env_yaml, 'w') as f:
+        f.write("""\
+env:
+    config:
+        verify_ssl: False
+        dirty: False
+    packages:
+        libelf:
+            compiler: [ 'gcc@4.5.3' ]
+    repos:
+        - /x/y/z
+""")
+    return env_yaml
+
+
 def check_compiler_config(comps, *compiler_names):
     """Check that named compilers in comps match Spack's config."""
     config = spack.config.get('compilers')
@@ -861,23 +880,10 @@ config:
         scope._write_section('config')
 
 
-def test_single_file_scope(tmpdir, config):
-    env_yaml = str(tmpdir.join("env.yaml"))
-    with open(env_yaml, 'w') as f:
-        f.write("""\
-env:
-    config:
-        verify_ssl: False
-        dirty: False
-    packages:
-        libelf:
-            compiler: [ 'gcc@4.5.3' ]
-    repos:
-        - /x/y/z
-""")
-
+def test_single_file_scope(config, env_yaml):
     scope = spack.config.SingleFileScope(
-        'env', env_yaml, spack.schema.env.schema, ['env'])
+        'env', env_yaml, spack.schema.env.schema, ['env']
+    )
 
     with spack.config.override(scope):
         # from the single-file config
@@ -1109,3 +1115,20 @@ def test_bad_path_double_override(config):
                        match='Meaningless second override'):
         with spack.config.override('bad::double:override::directive', ''):
             pass
+
+
+@pytest.mark.regression('22547')
+def test_single_file_scope_cache_clearing(env_yaml):
+    scope = spack.config.SingleFileScope(
+        'env', env_yaml, spack.schema.env.schema, ['env']
+    )
+    # Check that we can retrieve data from the single file scope
+    before = scope.get_section('config')
+    assert before
+    # Clear the cache of the Single file scope
+    scope.clear()
+    # Check that the section can be retireved again and it's
+    # the same as before
+    after = scope.get_section('config')
+    assert after
+    assert before == after


### PR DESCRIPTION
fixes #22547

SingleFileScope was not able to repopulate its cache before this change. This was affecting the configuration seen by  environments using clingo bootstrapped from sources, since the bootstrapping operation involved a few cache invalidation for  config files.