### PR TITLE
llvm-amdgpu: Fixes "UnboundLocalError: local variable referenced before assignment"

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -67,7 +67,7 @@ class LlvmAmdgpu(CMakePackage):
         if self.compiler.name == "gcc":
             compiler = Executable(self.compiler.cc)
             gcc_output = compiler('-print-search-dirs', output=str, error=str)
-            
+
             gcc_prefix = ""
             for line in gcc_output.splitlines():
                 if line.startswith("install:"):

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -67,7 +67,8 @@ class LlvmAmdgpu(CMakePackage):
         if self.compiler.name == "gcc":
             compiler = Executable(self.compiler.cc)
             gcc_output = compiler('-print-search-dirs', output=str, error=str)
-
+            
+            gcc_prefix = ""
             for line in gcc_output.splitlines():
                 if line.startswith("install:"):
                     # Get path and strip any whitespace


### PR DESCRIPTION
Fixes "UnboundLocalError: local variable 'gcc_prefix' referenced before assignment" error.