### PR TITLE
py-matplotlib: add v3.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -24,6 +24,7 @@ class PyMatplotlib(PythonPackage):
         'matplotlib.testing.jpl_units', 'pylab'
     ]
 
+    version('3.4.0', sha256='424ddb3422c65b284a38a97eb48f5cb64b66a44a773e0c71281a347f1738f146')
     version('3.3.4', sha256='3e477db76c22929e4c6876c44f88d790aacdf3c3f8f3a90cb1975c0bf37825b0')
     version('3.3.3', sha256='b1b60c6476c4cfe9e5cf8ab0d3127476fd3d5f05de0f343a452badaad0e4bdec')
     version('3.3.2', sha256='3d2edbf59367f03cd9daf42939ca06383a7d7803e3993eb5ff1bee8e8a3fbb6b')
@@ -86,19 +87,22 @@ class PyMatplotlib(PythonPackage):
     depends_on('python@2.7:2.8,3.4:', when='@:2', type=('build', 'link', 'run'))
     depends_on('python@3.5:', when='@3:', type=('build', 'link', 'run'))
     depends_on('python@3.6:', when='@3.1:', type=('build', 'link', 'run'))
+    depends_on('python@3.7:', when='@3.4:', type=('build', 'link', 'run'))
     depends_on('freetype@2.3:')  # freetype 2.6.1 needed for tests to pass
     depends_on('qhull@2015.2:', when='@3.3:')
     depends_on('libpng@1.2:')
-    depends_on('py-certifi@2020.6.20:', when='@3.3.1:3.3.2', type=('build', 'run'))
-    depends_on('py-certifi@2020.6.20:', when='@3.3.3:', type='build')
+    depends_on('py-setuptools', type=('build', 'run'))  # See #3813
+    depends_on('py-certifi@2020.6.20:', when='@3.3.1:', type='build')
     depends_on('py-numpy@1.11:', type=('build', 'run'))
     depends_on('py-numpy@1.15:', when='@3.3:', type=('build', 'run'))
-    depends_on('py-setuptools', type=('build', 'run'))  # See #3813
+    depends_on('py-numpy@1.16:', when='@3.4:', type=('build', 'run'))
     depends_on('py-cycler@0.10:', type=('build', 'run'))
-    depends_on('py-python-dateutil@2.1:', type=('build', 'run'))
     depends_on('py-kiwisolver@1.0.1:', type=('build', 'run'), when='@2.2.0:')
-    depends_on('py-pyparsing@2.0.3,2.0.5:2.1.1,2.1.3:2.1.5,2.1.7:', type=('build', 'run'))
     depends_on('pil@6.2.0:', when='@3.3:', type=('build', 'run'))
+    depends_on('py-pyparsing@2.0.3,2.0.5:2.1.1,2.1.3:2.1.5,2.1.7:', type=('build', 'run'))
+    depends_on('py-pyparsing@2.2.1:', when='@3.4:', type=('build', 'run'))
+    depends_on('py-python-dateutil@2.1:', type=('build', 'run'))
+    depends_on('py-python-dateutil@2.7:', when='@3.4:', type=('build', 'run'))
     depends_on('py-pytz', type=('build', 'run'), when='@:2')
     depends_on('py-subprocess32', type=('build', 'run'), when='^python@:2.7')
     depends_on('py-functools32', type=('build', 'run'), when='@:2.0.999 ^python@:2.7')
@@ -134,7 +138,7 @@ class PyMatplotlib(PythonPackage):
     depends_on('imagemagick', when='+animation')
     depends_on('pil@3.4:', when='+image', type=('build', 'run'))
     depends_on('texlive', when='+latex', type='run')
-    depends_on('ghostscript@0.9:', when='+latex', type='run')
+    depends_on('ghostscript@9.0:', when='+latex', type='run')
     depends_on('fontconfig@2.7:', when='+fonts')
     depends_on('pkgconfig', type='build')
 


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.8 and Apple Clang 12.0.0.

https://github.com/matplotlib/matplotlib/releases/tag/v3.4.0