### PR TITLE
Add select mkl libs

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -33,3 +33,9 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     @property
     def component_dir(self):
         return 'mkl'
+
+    @property
+    def libs(self):
+        lib_path = '{0}/{1}/latest/lib/intel64'.format(self.prefix, self.component_dir)
+        mkl_libs = ['libmkl_intel_ilp64', 'libmkl_sequential', 'libmkl_core']
+        return find_libraries(mkl_libs, root=lib_path, shared=True, recursive=False)


### PR DESCRIPTION
I was including all the mkl libs all the time, but this is never the right thing to do because MKL has libraries to support different threading models and distributed computing. I changed it to do the right thing for sequential, which is the most common case.

I need to add some variants to allow users to choose but want to do this in a separate commit.

Resolves #21724.