### PR TITLE
Use junctions when symlinks aren't supported on Windows

### DIFF
--- a/lib/spack/external/macholib/util.py
+++ b/lib/spack/external/macholib/util.py
@@ -6,6 +6,8 @@ import shutil
 
 from macholib import mach_o
 
+from llnl.util.symlink import symlink
+
 MAGIC = [
     struct.pack('!L', getattr(mach_o, 'MH_' + _))
     for _ in ['MAGIC', 'CIGAM', 'MAGIC_64', 'CIGAM_64']
@@ -140,7 +142,7 @@ def mergetree(src, dst, condition=None, copyfn=mergecopy, srcbase=None):
             if os.path.islink(srcname):
                 # XXX: This is naive at best, should check srcbase(?)
                 realsrc = os.readlink(srcname)
-                os.symlink(realsrc, dstname)
+                symlink(realsrc, dstname)
             elif os.path.isdir(srcname):
                 mergetree(
                     srcname, dstname,

--- a/lib/spack/external/py/_path/local.py
+++ b/lib/spack/external/py/_path/local.py
@@ -12,6 +12,8 @@ from stat import S_ISLNK, S_ISDIR, S_ISREG
 
 from os.path import abspath, normcase, normpath, isabs, exists, isdir, isfile, islink, dirname
 
+from llnl.util.symlink import symlink
+
 if sys.version_info > (3,0):
     def map_as_list(func, iter):
         return list(map(func, iter))
@@ -79,7 +81,7 @@ class PosixPath(common.PathBase):
     def mksymlinkto(self, value, absolute=1):
         """ create a symbolic link with the given value (pointing to another name). """
         if absolute:
-            py.error.checked_call(os.symlink, str(value), self.strpath)
+            py.error.checked_call(symlink, str(value), self.strpath)
         else:
             base = self.common(value)
             # with posix local paths '/' is always a common base
@@ -87,7 +89,7 @@ class PosixPath(common.PathBase):
             reldest = self.relto(base)
             n = reldest.count(self.sep)
             target = self.sep.join(('..', )*n + (relsource, ))
-            py.error.checked_call(os.symlink, target, self.strpath)
+            py.error.checked_call(symlink, target, self.strpath)
 
 def getuserid(user):
     import pwd
@@ -892,7 +894,7 @@ class LocalPath(FSBase):
         except OSError:
             pass
         try:
-            os.symlink(src, dest)
+            symlink(src, dest)
         except (OSError, AttributeError, NotImplementedError):
             pass
 

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -14,6 +14,8 @@ import filecmp
 from llnl.util.filesystem import traverse_tree, mkdirp, touch
 import llnl.util.tty as tty
 
+from llnl.util.symlink import symlink
+
 __all__ = ['LinkTree']
 
 empty_file_name = '.spack-empty'
@@ -113,7 +115,7 @@ class LinkTree(object):
                     os.remove(marker)
 
     def merge(self, dest_root, ignore_conflicts=False, ignore=None,
-              link=os.symlink, relative=False):
+              link=symlink, relative=False):
         """Link all files in src into dest, creating directories
            if necessary.
 
@@ -125,7 +127,7 @@ class LinkTree(object):
         ignore (callable): callable that returns True if a file is to be
             ignored in the merge (by default ignore nothing)
 
-        link (callable): function to create links with (defaults to os.symlink)
+        link (callable): function to create links with (defaults to llnl.util.symlink)
 
         relative (bool): create all symlinks relative to the target
             (default False)

--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -1,0 +1,100 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from os.path import exists, join, islink
+import os
+import tempfile
+import shutil
+import six
+import sys
+
+import llnl.util.filesystem as fs
+
+__win32_can_symlink__ = None
+
+def symlink(real_path, link_path):
+    """
+    Create a symbolic link.
+
+    On Windows, use junctions if os.symlink fails.
+    """
+    if sys.platform != "win32" or _win32_can_symlink():
+        os.symlink(real_path, link_path)
+    else:
+        # Use junctions
+        _win32_junction(real_path, link_path)
+
+# Based on https://github.com/Erotemic/ubelt/blob/master/ubelt/util_links.py
+def _win32_junction(path, link):
+    # junctions require absolute paths
+    if not os.path.isabs(link):
+        link = os.path.abspath(link)
+
+    # os.symlink will fail if link exists, emulate the behavior here
+    if exists(link):
+        raise FileExistsError('File  exists: {} -> {}'.format(link, path))
+
+    if not os.path.isabs(path):
+        parent = os.path.join(link, os.pardir)
+        path = os.path.join(parent, path)
+        path = os.path.abspath(path)
+
+    if os.path.isdir(path):
+        # try using a junction (directory hard link)
+        command = 'mklink /J "{}" "{}"'.format(link, path)
+    else:
+        # try using a hard link
+        command = 'mklink /H "{}" "{}"'.format(link, path)
+
+    _cmd(command)
+
+def _win32_can_symlink():
+    global __win32_can_symlink__
+    if __win32_can_symlink__ is not None:
+        return __win32_can_symlink__
+
+    tempdir = tempfile.mkdtemp()
+
+    dpath = join(tempdir, 'dpath')
+    fpath = join(tempdir, 'fpath.txt')
+
+    dlink = join(tempdir, 'dlink')
+    flink = join(tempdir, 'flink.txt')
+
+    fs.touchp(fpath)
+
+    try:
+        os.symlink(dpath, dlink)
+        can_symlink_directories = os.path.islink(dlink)
+    except OSError:
+        can_symlink_directories = False
+
+    try:
+        os.symlink(fpath, flink)
+        can_symlink_files = os.path.islink(flink)
+    except OSError:
+        can_symlink_files = False
+
+    # Cleanup the test directory
+    shutil.rmtree(tempdir)
+
+    __win32_can_symlink__ = can_symlink_directories and can_symlink_files
+
+    return __win32_can_symlink__
+
+# Based on https://github.com/Erotemic/ubelt/blob/master/ubelt/util_cmd.py
+def _cmd(command):
+    import subprocess
+    # Create a new process to execute the command
+    def make_proc():
+        # delay the creation of the process until we validate all args
+        proc = subprocess.Popen(command, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, shell=True,
+                                universal_newlines=True, cwd=None, env=None)
+        return proc
+
+    proc = make_proc()
+    (out, err) = proc.communicate()
+    if proc.wait() != 0 :
+        raise OSError(str(info))

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -70,6 +70,7 @@ from spack.error import NoLibrariesError, NoHeadersError
 from spack.util.executable import Executable
 from spack.util.module_cmd import load_module, path_from_modules, module
 from spack.util.log_parse import parse_log_events, make_log_context
+from llnl.util.symlink import symlink
 
 
 #
@@ -502,7 +503,7 @@ def _set_variables_for_single_module(pkg, module):
     m.makedirs = os.makedirs
     m.remove = os.remove
     m.removedirs = os.removedirs
-    m.symlink = os.symlink
+    m.symlink = symlink
 
     m.mkdirp = mkdirp
     m.install = install
@@ -625,11 +626,11 @@ def _static_to_shared_library(arch, compiler, static_lib, shared_lib=None,
     shared_lib_link = os.path.basename(shared_lib)
 
     if version or compat_version:
-        os.symlink(shared_lib_link, shared_lib_base)
+        symlink(shared_lib_link, shared_lib_base)
 
     if compat_version and compat_version != version:
-        os.symlink(shared_lib_link, '{0}.{1}'.format(shared_lib_base,
-                                                     compat_version))
+        symlink(shared_lib_link, '{0}.{1}'.format(shared_lib_base,
+                                                  compat_version))
 
     return compiler(*compiler_args, output=compiler_output)
 

--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -16,6 +16,7 @@ import spack.fetch_strategy
 import spack.util.file_cache
 import spack.util.path
 
+from llnl.util.symlink import symlink
 
 def _misc_cache():
     """The ``misc_cache`` is Spack's cache for small data.
@@ -80,7 +81,7 @@ class MirrorCache(object):
                 # to https://github.com/spack/spack/pull/13908)
                 os.unlink(cosmetic_path)
             mkdirp(os.path.dirname(cosmetic_path))
-            os.symlink(relative_dst, cosmetic_path)
+            symlink(relative_dst, cosmetic_path)
 
 
 #: Spack's local cache for downloaded source archives

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -26,6 +26,7 @@ import spack.environment as ev
 
 from spack.error import SpackError
 from spack.database import InstallStatuses
+from llnl.util.symlink import symlink
 
 description = "Replace one package with another via symlinks"
 section = "admin"
@@ -123,7 +124,7 @@ def deprecate(parser, args):
         if not answer:
             tty.die('Will not deprecate any packages.')
 
-    link_fn = os.link if args.link_type == 'hard' else os.symlink
+    link_fn = os.link if args.link_type == 'hard' else symlink
 
     for dcate, dcator in zip(all_deprecate, all_deprecators):
         dcate.package.do_deprecate(dcator, link_fn)

--- a/lib/spack/spack/cmd/modules/lmod.py
+++ b/lib/spack/spack/cmd/modules/lmod.py
@@ -10,6 +10,8 @@ import llnl.util.filesystem
 import spack.cmd.common.arguments
 import spack.cmd.modules
 
+from llnl.util.symlink import symlink
+
 
 def add_command(parser, command_dict):
     lmod_parser = parser.add_parser(
@@ -47,4 +49,4 @@ def setdefault(module_type, specs, args):
     with llnl.util.filesystem.working_dir(module_folder):
         if os.path.exists('default') and os.path.islink('default'):
             os.remove('default')
-        os.symlink(module_basename, 'default')
+        symlink(module_basename, 'default')

--- a/lib/spack/spack/compilers/apple_clang.py
+++ b/lib/spack/spack/compilers/apple_clang.py
@@ -12,6 +12,7 @@ import spack.compiler
 import spack.compilers.clang
 import spack.util.executable
 import spack.version
+from llnl.util.symlink import symlink
 
 
 class AppleClang(spack.compilers.clang.Clang):
@@ -161,10 +162,10 @@ class AppleClang(spack.compilers.clang.Clang):
                 for fname in os.listdir(dev_dir):
                     if fname in bins:
                         os.unlink(os.path.join(dev_dir, fname))
-                        os.symlink(
+                        symlink(
                             os.path.join(spack.paths.build_env_path, 'cc'),
                             os.path.join(dev_dir, fname))
 
-            os.symlink(developer_root, xcode_link)
+            symlink(developer_root, xcode_link)
 
         env.set('DEVELOPER_DIR', xcode_link)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -41,6 +41,8 @@ import spack.util.lock as lk
 from spack.util.path import substitute_path_variables
 from spack.installer import PackageInstaller
 import spack.util.path
+from llnl.util.symlink import symlink
+
 
 #: environment variable used to indicate the active environment
 spack_env_var = 'SPACK_ENV'
@@ -1436,7 +1438,7 @@ class Environment(object):
                     log_path, '%s-%s.log' % (spec.name, spec.dag_hash(7)))
                 if os.path.lexists(build_log_link):
                     os.remove(build_log_link)
-                os.symlink(spec.package.build_log_path, build_log_link)
+                symlink(spec.package.build_log_path, build_log_link)
 
     def uninstalled_specs(self):
         """Return a list of all uninstalled (and non-dev) specs."""

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -46,6 +46,7 @@ from spack.util.compression import decompressor_for, extension
 from spack.util.executable import which, CommandNotFoundError
 from spack.util.string import comma_and, quote
 from spack.version import Version, ver
+from llnl.util.symlink import symlink
 
 #: List of all fetch strategies, created by FetchStrategy metaclass.
 all_strategies = []
@@ -624,11 +625,8 @@ class CacheURLFetchStrategy(URLFetchStrategy):
         if os.path.exists(filename):
             os.remove(filename)
 
-        if sys.platform == "win32":
-            shutil.copyfile(path, filename)
-        else:
-            # Symlink to local cached archive.
-            os.symlink(path, filename)
+        # Symlink to local cached archive.
+        symlink(path, filename)
 
         # Remove link if checksum fails, or subsequent fetchers
         # will assume they don't need to download.

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -29,6 +29,7 @@ import spack.relocate
 from spack.error import SpackError
 from spack.directory_layout import ExtensionAlreadyInstalledError
 from spack.directory_layout import YamlViewExtensionsLayout
+from llnl.util.symlink import symlink
 
 
 # compatability
@@ -46,7 +47,7 @@ _projections_path = '.spack/projections.yaml'
 def view_symlink(src, dst, **kwargs):
     # keyword arguments are irrelevant
     # here to fit required call signature
-    os.symlink(src, dst)
+    symlink(src, dst)
 
 
 def view_hardlink(src, dst, **kwargs):
@@ -116,7 +117,7 @@ class FilesystemView(object):
             Initialize a filesystem view under the given `root` directory with
             corresponding directory `layout`.
 
-            Files are linked by method `link` (os.symlink by default).
+            Files are linked by method `link` (llnl.util.symlink by default).
         """
         self._root = root
         self.layout = layout

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -10,6 +10,7 @@ from llnl.util.filesystem import mkdirp
 
 from spack.util.editor import editor
 from spack.util.executable import Executable, which
+from llnl.util.symlink import symlink
 
 
 def pre_install(spec):
@@ -179,6 +180,6 @@ def symlink_license(pkg):
             os.remove(link_name)
 
         if os.path.exists(target):
-            os.symlink(target, link_name)
+            symlink(target, link_name)
             tty.msg("Added local symlink %s to global license file" %
                     link_name)

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -18,6 +18,7 @@ import spack.cmd
 import spack.repo
 import spack.spec
 import spack.util.executable as executable
+from llnl.util.symlink import symlink
 
 
 class InstallRootStringError(spack.error.SpackError):
@@ -684,7 +685,7 @@ def make_link_relative(new_links, orig_links):
         target = os.readlink(orig_link)
         relative_target = os.path.relpath(target, os.path.dirname(orig_link))
         os.unlink(new_link)
-        os.symlink(relative_target, new_link)
+        symlink(relative_target, new_link)
 
 
 def make_macho_binaries_relative(cur_path_names, orig_path_names,
@@ -768,7 +769,7 @@ def relocate_links(links, orig_layout_root,
                 orig_install_prefix, new_install_prefix, link_target
             )
             os.unlink(abs_link)
-            os.symlink(link_target, abs_link)
+            symlink(link_target, abs_link)
 
         # If the link is absolute and has not been relocated then
         # warn the user about that

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -30,6 +30,7 @@ from spack.relocate import macho_make_paths_relative
 from spack.relocate import macho_make_paths_normal
 from spack.relocate import _placeholder, macho_find_paths
 from spack.relocate import file_is_relocatable
+from llnl.util.symlink import symlink
 
 
 def fake_fetchify(url, pkg):
@@ -74,7 +75,7 @@ echo $PATH"""
 
     # Create an absolute symlink
     linkname = os.path.join(spec.prefix, "link_to_dummy.txt")
-    os.symlink(filename, linkname)
+    symlink(filename, linkname)
 
     # Create the build cache  and
     # put it directly into the mirror
@@ -227,8 +228,8 @@ def test_relocate_links(tmpdir):
         with open(new_binname, 'w') as f:
             f.write('\n')
         os.utime(new_binname, None)
-        os.symlink(old_binname, new_linkname)
-        os.symlink('/usr/lib/libc.so', new_linkname2)
+        symlink(old_binname, new_linkname)
+        symlink('/usr/lib/libc.so', new_linkname2)
         relocate_links(filenames, old_layout_root,
                        old_install_prefix, new_install_prefix)
         assert os.readlink(new_linkname) == new_binname

--- a/lib/spack/spack/test/verification.py
+++ b/lib/spack/spack/test/verification.py
@@ -13,6 +13,7 @@ import spack.util.spack_json as sjson
 import spack.verify
 import spack.spec
 import spack.store
+from llnl.util.symlink import symlink
 
 
 def test_link_manifest_entry(tmpdir):
@@ -21,7 +22,7 @@ def test_link_manifest_entry(tmpdir):
     file = str(tmpdir.join('file'))
     open(file, 'a').close()
     link = str(tmpdir.join('link'))
-    os.symlink(file, link)
+    symlink(file, link)
 
     data = spack.verify.create_manifest_entry(link)
     assert data['type'] == 'link'
@@ -43,7 +44,7 @@ def test_link_manifest_entry(tmpdir):
     file2 = str(tmpdir.join('file2'))
     open(file2, 'a').close()
     os.remove(link)
-    os.symlink(file2, link)
+    symlink(file2, link)
 
     results = spack.verify.check_entry(link, data)
     assert results.has_errors()
@@ -157,7 +158,7 @@ def test_check_prefix_manifest(tmpdir):
         f.write("I'm a little file short and stout")
 
     link = os.path.join(bin_dir, 'run')
-    os.symlink(file, link)
+    symlink(file, link)
 
     spack.verify.write_manifest(spec)
     results = spack.verify.check_spec_manifest(spec)


### PR DESCRIPTION
To provide Windows-compatible functionality, spack code should use
llnl.util.symlink instead of os.symlink. On non-Windows platforms
and on Windows where supported, os.symlink will still be used.

Fix filesystem tests on Windows by:
* Using '/' as path separator on Windows.
* Recognizing that Windows paths start with '<Letter>:/' instead of '/'
* Updating tests to use valid Windows paths