### PR TITLE
bugfix for active when pkg is already active error

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2319,8 +2319,13 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         extensions_layout = view.extensions_layout
 
-        extensions_layout.check_extension_conflict(
-            self.extendee_spec, self.spec)
+        try:
+            extensions_layout.check_extension_conflict(
+                    self.extendee_spec, self.spec)
+        except spack.directory_layout.ExtensionAlreadyInstalledError as e:
+            # already installed, let caller know
+            tty.msg(e.message)
+            return
 
         # Activate any package dependencies that are also extensions.
         if with_dependencies:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2321,7 +2321,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         try:
             extensions_layout.check_extension_conflict(
-                    self.extendee_spec, self.spec)
+               self.extendee_spec, self.spec)
         except spack.directory_layout.ExtensionAlreadyInstalledError as e:
             # already installed, let caller know
             tty.msg(e.message)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2321,7 +2321,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         try:
             extensions_layout.check_extension_conflict(
-               self.extendee_spec, self.spec)
+                self.extendee_spec, self.spec)
         except spack.directory_layout.ExtensionAlreadyInstalledError as e:
             # already installed, let caller know
             tty.msg(e.message)


### PR DESCRIPTION
resolves #22530

instead of throwing an error for an already active package, prints a message and returns to avoid an attempt to re-activate.  