### PR TITLE
Add additional header search path for libtirpc/rpc package

### DIFF
--- a/var/spack/repos/builtin/packages/libtirpc/package.py
+++ b/var/spack/repos/builtin/packages/libtirpc/package.py
@@ -23,3 +23,6 @@ class Libtirpc(AutotoolsPackage):
     # FIXME: build error on macOS
     # auth_none.c:81:9: error: unknown type name 'mutex_t'
     conflicts('platform=darwin', msg='Does not build on macOS')
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.append_path('CPATH', '{0}'.format(join_path(self.prefix.include, 'tirpc')))

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -156,7 +156,7 @@ class Mesa(MesonPackage):
         if '+llvm' in spec:
             args.append('-Dllvm=enabled')
             args.append(opt_enable(
-                '+link_dylib' in spec['llvm'], 'shared-llvm'))
+                '+llvm_dylib' in spec['llvm'], 'shared-llvm'))
         else:
             args.append('-Dllvm=disabled')
 


### PR DESCRIPTION
Packages that depend on the virtual package `rpc` often expect to find `rpc.h` in `$prefix/include/rpc`. But the `libtirpc` package installs the headers one level deeper in `$prefix/include/tirpc/rpc`. An example of a package that breaks is `hdf+external-xdr`.

To avoid this, we add `$prefix/include/tirpc` in the search path for dependent packages. This should not break any existing packages, since `$prefix/include` will still be in search path.

I was debating whether to use CPATH or CFLAGS and decided to use the former. 

The patch has been tested on CentOS8 with Spack-0.16.1