### PR TITLE
bugfix: `spack config blame` should print all lines of config

### DIFF
--- a/lib/spack/spack/test/util/spack_yaml.py
+++ b/lib/spack/spack/test/util/spack_yaml.py
@@ -65,3 +65,31 @@ def test_config_blame_with_override(config):
         check_blame('verify_ssl', config_file, 13)
         check_blame('checksum', config_file, 14)
         check_blame('dirty', config_file, 15)
+
+
+def test_config_blame_defaults():
+    """check blame for an element from an override scope"""
+    files = {}
+
+    def get_file_lines(filename):
+        if filename not in files:
+            with open(filename, "r") as f:
+                files[filename] = [""] + f.read().split("\n")
+        return files[filename]
+
+    config_blame = config_cmd("blame", "config")
+    for line in config_blame.split("\n"):
+        # currently checking only simple lines with dict keys
+        match = re.match(r"^([^:]+):(\d+)\s+([^:]+):\s+(.*)", line)
+
+        # check that matches are on the lines they say they are
+        if match:
+            filename, line, key, val = match.groups()
+            line = int(line)
+
+            if val.lower() in ("true", "false"):
+                val = val.lower()
+
+            lines = get_file_lines(filename)
+            assert key in lines[line]
+            assert val in lines[line]

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -185,6 +185,12 @@ class OrderedLineDumper(RoundTripDumper):
         """Make the dumper NEVER print YAML aliases."""
         return True
 
+    def represent_data(self, data):
+        result = super(OrderedLineDumper, self).represent_data(data)
+        if data is None:
+            result.value = syaml_str("null")
+        return result
+
     def represent_str(self, data):
         if hasattr(data, 'override') and data.override:
             data = data + ':'
@@ -262,7 +268,9 @@ class LineAnnotationDumper(OrderedLineDumper):
     def represent_data(self, data):
         """Force syaml_str to be passed through with marks."""
         result = super(LineAnnotationDumper, self).represent_data(data)
-        if isinstance(result.value, string_types):
+        if data is None:
+            result.value = syaml_str("null")
+        elif isinstance(result.value, string_types):
             result.value = syaml_str(data)
         if markable(result.value):
             mark(result.value, data)


### PR DESCRIPTION
Fixes #22436.

`spack config blame` was not printing all lines of configuration because there were no annotations for empty lines in the YAML dump output.

- [x] Fix by removing empty lines. It doesn't seem like Ruamel YAML allows us many other options.
- [x] Add a better test that checks that line numbers are correct
- [x] Also fix printing of `null` values in YAML output while we're at it.