### PR TITLE
Squashfuse new version and variants

### DIFF
--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -40,7 +40,6 @@ class Squashfuse(AutotoolsPackage):
     depends_on('xz', when='+xz')
     depends_on('zstd', when='+zstd')
 
-    # not all releases have a configure script
     depends_on('m4',       type='build', when='master')
     depends_on('autoconf', type='build', when='master')
     depends_on('automake', type='build', when='master')

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -10,22 +10,23 @@ class Squashfuse(AutotoolsPackage):
     """squashfuse - Mount SquashFS archives using FUSE"""
 
     homepage = "https://github.com/vasi/squashfuse"
-    url      = "https://github.com/vasi/squashfuse/releases/download/0.1.103/squashfuse-0.1.103.tar.gz"
+    url      = "https://github.com/vasi/squashfuse/archive/refs/tags/0.1.104.tar.gz"
     git      = "https://github.com/vasi/squashfuse.git"
 
     maintainers = ['haampie']
 
-    # there hasn't been a release for a while, and the master branch introduces
-    # support for fuse@3:, so we have our own spack version here (46 commits
-    # after 0.1.103)
     version('master', branch='master')
-    version('0.1.103-46', commit='e5dddbfc6e402c82f5fbba115b0eb3476684f50d', preferred=True)
+    version('0.1.104', sha256='9e6f4fb65bb3e5de60c8714bb7f5cbb08b5534f7915d6a4aeea008e1c669bd35')
+    version('0.1.103', sha256='bba530fe435d8f9195a32c295147677c58b060e2c63d2d4204ed8a6c9621d0dd')
 
-    # official releases
-    version('0.1.103', sha256='42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7')
+    variant('zlib', default=True, description='Enable zlib/gzip compression support')
+    variant('lz4', default=True, description='Enable LZ4 compression support')
+    variant('lzo', default=True, description='Enable LZO compression support')
+    variant('xz', default=True, description='Enable xz compression support')
+    variant('zstd', default=True, description='Enable Zstandard/zstd support')
 
     depends_on('libfuse@2.5:')
-    depends_on('libfuse@:2.99', when='@0.1.103')
+    depends_on('libfuse@:2.99', when='@:0.1.103')
 
     # Note: typically libfuse is external, but this implies that you have to make
     # pkg-config external too, because spack's pkg-config doesn't know how to
@@ -33,17 +34,23 @@ class Squashfuse(AutotoolsPackage):
     depends_on('pkg-config', type='build')
 
     # compression libs
-    depends_on('zlib')
-    depends_on('lz4')
-    depends_on('lzo')
-    depends_on('xz')
-    depends_on('zstd')
+    depends_on('zlib', when='+zlib')
+    depends_on('lz4', when='+lz4')
+    depends_on('lzo', when='+lzo')
+    depends_on('xz', when='+xz')
+    depends_on('zstd', when='+zstd')
 
-    # build deps for non-tarball versions
-    depends_on('m4',       type='build', when='@master,0.1.103-46')
-    depends_on('autoconf', type='build', when='@master,0.1.103-46')
-    depends_on('automake', type='build', when='@master,0.1.103-46')
-    depends_on('libtool',  type='build', when='@master,0.1.103-46')
+    # not all releases have a configure script
+    depends_on('m4',       type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
 
     def configure_args(self):
-        return ['--disable-demo']
+        args = ['--disable-demo']
+        args += self.with_or_without('zlib', activation_value='prefix')
+        args += self.with_or_without('lz4', activation_value='prefix')
+        args += self.with_or_without('lzo', activation_value='prefix')
+        args += self.with_or_without('xz', activation_value='prefix')
+        args += self.with_or_without('zstd', activation_value='prefix')
+        return args

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -10,14 +10,14 @@ class Squashfuse(AutotoolsPackage):
     """squashfuse - Mount SquashFS archives using FUSE"""
 
     homepage = "https://github.com/vasi/squashfuse"
-    url      = "https://github.com/vasi/squashfuse/archive/refs/tags/0.1.104.tar.gz"
+    url      = "https://github.com/vasi/squashfuse/releases/download/0.1.104/squashfuse-0.1.104.tar.gz"
     git      = "https://github.com/vasi/squashfuse.git"
 
     maintainers = ['haampie']
 
     version('master', branch='master')
-    version('0.1.104', sha256='9e6f4fb65bb3e5de60c8714bb7f5cbb08b5534f7915d6a4aeea008e1c669bd35')
-    version('0.1.103', sha256='bba530fe435d8f9195a32c295147677c58b060e2c63d2d4204ed8a6c9621d0dd')
+    version('0.1.104', sha256='aa52460559e0d0b1753f6b1af5c68cfb777ca5a13913285e93f4f9b7aa894b3a')
+    version('0.1.103', sha256='42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7')
 
     variant('zlib', default=True, description='Enable zlib/gzip compression support')
     variant('lz4', default=True, description='Enable LZ4 compression support')
@@ -41,10 +41,10 @@ class Squashfuse(AutotoolsPackage):
     depends_on('zstd', when='+zstd')
 
     # not all releases have a configure script
-    depends_on('m4',       type='build')
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build', when='master')
+    depends_on('autoconf', type='build', when='master')
+    depends_on('automake', type='build', when='master')
+    depends_on('libtool',  type='build', when='master')
 
     def configure_args(self):
         args = ['--disable-demo']


### PR DESCRIPTION
~The latest version doesn't have a configure script, so I just switched to using the standard GitHub release for now and depend on the autotools packages.

When https://github.com/vasi/squashfuse/issues/50#issuecomment-809176217 is addressed we can switch back to simple configure scripts and optional dependencies on autotools stuff.~ 

edit: this was fixed today. 
