### PR TITLE
Respect compiler preferences when choosing externals (original concretizer)

### DIFF
--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -132,19 +132,18 @@ class Concretizer(object):
                 usable.append(cspec)
 
             externals = spec_externals(cspec)
-            if externals:
-                for ext in externals:
-                    if ext.satisfies(spec):
-                        # Check whether we have compilers that can satisfy the
-                        # external spec and ignore it if that is not the case.
-                        accept_compiler = (
-                            not self.check_for_compiler_existence or
-                            ext.compiler is None or
-                            any(ext.compiler.satisfies(c)
-                                for c in spack.compilers.all_compiler_specs()))
-                        # TODO: account for the architecture too
-                        if accept_compiler:
-                            usable.append(ext)
+            for ext in externals:
+                if ext.satisfies(spec):
+                    # Check whether we have compilers that can satisfy the
+                    # external spec and ignore it if that is not the case.
+                    accept_compiler = (
+                        not self.check_for_compiler_existence or
+                        ext.compiler is None or
+                        any(ext.compiler.satisfies(c)
+                            for c in spack.compilers.all_compiler_specs()))
+                    # TODO: account for the architecture too
+                    if accept_compiler:
+                        usable.append(ext)
 
         # If nothing is in the usable list now, it's because we aren't
         # allowed to build anything.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2283,6 +2283,16 @@ class Spec(object):
                         changed = True
                         spec._dependencies = DependencyMap()
                     replacement._dependencies = DependencyMap()
+                    if not replacement.compiler:
+                        # Keep the compiler if the external does not have it.
+                        replacement.compiler = self.compiler
+                    elif self.compiler:
+                        # Keep the compiler constraint (e.g. the version)
+                        # if possible.
+                        try:
+                            replacement.compiler.constrain(self.compiler)
+                        except UnsatisfiableCompilerSpecError:
+                            pass
                     replacement.architecture = self.architecture
 
                 # TODO: could this and the stuff in _dup be cleaned up?

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1094,6 +1094,28 @@ class TestConcretize(object):
         assert s.external == is_external
         assert s.satisfies(expected)
 
+    def test_external_package_without_version(self):
+        # Check that the version from package.py is set if an external is
+        # specified without a version.
+
+        if spack.config.get('config:concretizer') == 'clingo':
+            pytest.xfail('This is not supported with the ASP-based concretizer')
+
+        packages_yaml = {
+            'externaltool': {
+                'externals': [
+                    {'spec': 'externaltool',
+                     'prefix': '/prefix'}
+                ]
+            },
+        }
+
+        for k, v in packages_yaml.items():
+            spack.config.set('packages::{0}'.format(k), v)
+
+        s = Spec('externaltool').concretized()
+        assert s.satisfies('externaltool@1.0')
+
     @pytest.mark.regression('20292')
     @pytest.mark.parametrize('context', [
         {'add_variant': True, 'delete_variant': False},

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -815,30 +815,29 @@ class TestConcretize(object):
             assert s.satisfies(constraint)
 
     @pytest.mark.regression('4635')
-    @pytest.mark.parametrize('spec_str,expected', [
-        ('cmake', ['%clang']),
-        ('cmake %gcc', ['%gcc']),
-        ('cmake %clang', ['%clang'])
+    @pytest.mark.parametrize('comp_spec,ext_comp_spec,expected', [
+        ('', '', ['%clang']),
+        ('%gcc', '', ['%gcc']),
+        ('%gcc@4.4.0', '%gcc', ['%gcc@4.4.0']),
+        ('%clang', '', ['%clang'])
     ])
     def test_external_package_and_compiler_preferences(
-            self, spec_str, expected
+            self, comp_spec, ext_comp_spec, expected
     ):
-        if spack.config.get('config:concretizer') == 'original':
-            pytest.xfail('Known failure of the original concretizer')
-
         packages_yaml = {
             'all': {
                 'compiler': ['clang', 'gcc'],
             },
             'cmake': {
                 'externals': [
-                    {'spec': 'cmake@3.4.3', 'prefix': '/usr'}
+                    {'spec': 'cmake@3.4.3{0}'.format(ext_comp_spec),
+                     'prefix': '/usr'}
                 ],
                 'buildable': False
             }
         }
         spack.config.set('packages', packages_yaml)
-        s = Spec(spec_str).concretized()
+        s = Spec('cmake {0}'.format(comp_spec)).concretized()
 
         assert s.external
         for condition in expected:

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -235,6 +235,8 @@ class TestConcretizePreferences(object):
     @pytest.mark.parametrize(
         'compiler,unsupported',
         [('gcc@bad', ['clingo']),
+         # We have gcc@4.5.0, not gcc@4.5
+         ('gcc@4.5', ['clingo']),
          ('gcc@4.5.0 target=bad', ['clingo', 'original'])])
     def test_ignore_externals_with_invalid_compilers(
             self, compiler, unsupported):

--- a/lib/spack/spack/test/data/config/compilers.yaml
+++ b/lib/spack/spack/test/data/config/compilers.yaml
@@ -20,6 +20,16 @@ compilers:
     modules: 'None'
     target: x86_64
 - compiler:
+    spec: gcc@4.4.0
+    operating_system: {0.name}{0.version}
+    paths:
+      cc: /path/to/gcc
+      cxx: /path/to/g++
+      f77: None
+      fc: None
+    modules: 'None'
+    target: x86_64
+- compiler:
     spec: clang@3.3
     operating_system: CNL
     paths:


### PR DESCRIPTION
Fixes (for the original concretizer) #21311 #4635 #5110 #8082
Supersedes my previous attempt to fix this #4956


Introduces a number of tests:
1. `test_external_package_and_compiler_preferences` extended and enabled for the `original` concretizer;
2. `test_external_package_without_version` not related directly to the modifications of this PR but shows a bug in the ASP-based concretizer;
3. `test_preferred_compiler_with_externals` checks that we respect the compiler preferences when the input spec does not specify a compiler;
4. `test_preferred_compiler_latest_version_with_externals` checks that we repect the preferred version of the compiler and take the latest one if the compiler preference list does not specify versions;
5. `test_preferred_compiler_with_lesser_external_version` checks that we prefer an older version of an external with the preferred compiler over a newer version with less preferred compiler (the ASP-based concretizer does not agree with that);
6. `test_ignore_externals_with_non_preferred_compilers` checks that we prefer to build a buildable external if none of its specs satisfies the preferred compiler (not supported yet by both concretizers);
7. `test_ignore_externals_with_invalid_compilers` checks that we ignore externals with compilers/arcitechtures that are not listed in `compilers.yaml` (partially implemented for the `original` concretizer, not supported by the ASP-based one);
8. `test_preferred_external_without_compiler_version`, `test_preferred_external_without_compiler` and `test_preferred_external_without_version` check that we prefer a less conctrained (in terms of compiler and version) external (the last one is not supported by the ASP-based concretizer);
9. `test_preferred_external_version` checks that we respect the version preference list when choosing an external.

This obviously needs a discussion.

@alalazo