### PR TITLE
claw: support for gcc10

### DIFF
--- a/var/spack/repos/builtin/packages/claw/package.py
+++ b/var/spack/repos/builtin/packages/claw/package.py
@@ -47,6 +47,13 @@ class Claw(CMakePackage):
 
     filter_compiler_wrappers('claw_f.conf', relative_root='etc')
 
+    def flag_handler(self, name, flags):
+        # https://gcc.gnu.org/gcc-10/porting_to.html
+        if name == 'cflags' and self.spec.satisfies('%gcc@10:'):
+            flags.append('-fcommon')
+
+        return flags, None, None
+
     def cmake_args(self):
         args = [
             '-DOMNI_CONF_OPTION=--with-libxml2=%s' %


### PR DESCRIPTION
We need to build with `-fcommon` when building with `gcc@10:` (as described [here](https://gcc.gnu.org/gcc-10/porting_to.html)).

Otherwise, we get:
```console
/path/to/spack/lib/spack/env/gcc/gcc -DGNU_INTRINSIC_EXTENSION -DNDEBUG -DBUGFIX -D__XCODEML__ -DYYDEBUG -I/path/to/spack/opt/spack/linux-debian9-haswell/gcc-10.2.0/libxml2-2.9.10-j477kg7qyyejzp3vpxalinoim6vrnhqt/include//libxml2 -I../../include -o F_Front F95-main.o C-expr-mem.o C-exprcode.o F-datatype.o F-ident.o F95-parser.o F-mem.o F-compile.o F-compile-decl.o F-compile-expr.o F-opt-expv.o F-output-xcodeml.o F-io-xcodeml.o F-data.o F-datasub.o F-equiv.o F-varutil.o F-intrinsic.o F-intrinsics-table.o F-OMP.o F-ACC.o F-XMP.o xcodeml-node.o xcodeml-parse.o xcodeml-util.o xcodeml-type.o xcodeml-traverse.o xcodeml-output-F.o F-dump.o F-type-attr-tbl.o module-manager.o hash.o F-input-xmod.o F-module-procedure.o F-second-pass.o -L/path/to/spack/opt/spack/linux-debian9-haswell/gcc-10.2.0/libxml2-2.9.10-j477kg7qyyejzp3vpxalinoim6vrnhqt/lib -lxml2 -lm
xcodeml-parse.o:(.bss+0x0): multiple definition of `current_symbol_stack'
xcodeml-node.o:(.bss+0x0): first defined here
xcodeml-util.o:(.bss+0x0): multiple definition of `current_symbol_stack'
xcodeml-node.o:(.bss+0x0): first defined here
xcodeml-type.o:(.bss+0x0): multiple definition of `current_symbol_stack'
xcodeml-node.o:(.bss+0x0): first defined here
xcodeml-traverse.o:(.bss+0x0): multiple definition of `current_symbol_stack'
xcodeml-node.o:(.bss+0x0): first defined here
xcodeml-output-F.o:(.bss+0x0): multiple definition of `current_symbol_stack'
xcodeml-node.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
Makefile:52: recipe for target 'F_Front' failed
```

@clementval