### PR TITLE
simplify glfw pkg build on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/glfw/package.py
+++ b/var/spack/repos/builtin/packages/glfw/package.py
@@ -26,14 +26,22 @@ class Glfw(CMakePackage):
     version('3.0.4', sha256='a4e7c57db2086803de4fc853bd472ff8b6d2639b9aa16e6ac6b19ffb53958caf')
     version('3.0.3', sha256='7a182047ba6b1fdcda778b79aac249bb2328b6d141188cb5df29560715d01693')
 
-    depends_on('libxrandr')
-    depends_on('libxinerama')
-    depends_on('libxcursor')
-    depends_on('libxdamage')
-    depends_on('libxft')
-    depends_on('libxi')
-    depends_on('libxmu')
-    depends_on('freetype')
-    depends_on('fontconfig')
-    depends_on('doxygen', type='build')
-    depends_on('pkgconfig', type='build')
+    variant("doc", default=False, description="Build documentation")
+
+    # dependencies
+    depends_on('doxygen', type='build', when="+doc")
+
+    # linux only dependencies
+    depends_on('libxrandr', when='platform=linux')
+    depends_on('libxinerama', when='platform=linux')
+    depends_on('libxcursor', when='platform=linux')
+    depends_on('libxdamage', when='platform=linux')
+    depends_on('libxft', when='platform=linux')
+    depends_on('libxi', when='platform=linux')
+    depends_on('libxmu', when='platform=linux')
+    depends_on('freetype', when='platform=linux')
+    depends_on('fontconfig', when='platform=linux')
+    depends_on('pkgconfig', type='build', when='platform=linux')
+
+
+

--- a/var/spack/repos/builtin/packages/glfw/package.py
+++ b/var/spack/repos/builtin/packages/glfw/package.py
@@ -42,6 +42,3 @@ class Glfw(CMakePackage):
     depends_on('freetype', when='platform=linux')
     depends_on('fontconfig', when='platform=linux')
     depends_on('pkgconfig', type='build', when='platform=linux')
-
-
-


### PR DESCRIPTION

- adds `+doc` variant 
- makes doxygen dep conditional on `+doc`
- makes x11-based deps conditional on `platform=linux`

I built on macOS with these changes, and successful tested the spack-built glfw lib in another project