### PR TITLE
Explicitly move LLNL TCE system paths to the back of the PATH

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -23,7 +23,7 @@ from llnl.util.lang import dedupe
 from six.moves import shlex_quote as cmd_quote
 from six.moves import cPickle
 
-system_paths = ['/', '/usr', '/usr/local']
+system_paths = ['/', '/usr', '/usr/local', '/usr/tcetmp', '/usr/tce']
 suffixes = ['bin', 'bin64', 'include', 'lib', 'lib64']
 system_dirs = [os.path.join(p, s) for s in suffixes for p in system_paths] + \
     system_paths


### PR DESCRIPTION
environment variable, just like, /usr and /usr/local to avoid system
versions of tools from preempting Spack installed packages.