### PR TITLE
Bootstrapping: swap store before configuration

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -213,12 +213,12 @@ def _bootstrap_config_scopes():
 @contextlib.contextmanager
 def ensure_bootstrap_configuration():
     with spack.architecture.use_platform(spack.architecture.real_platform()):
-        # Default configuration scopes excluding command line and builtin
-        # but accounting for platform specific scopes
-        config_scopes = _bootstrap_config_scopes()
-        with spack.config.use_configuration(*config_scopes):
-            with spack.repo.use_repositories(spack.paths.packages_path):
-                with spack.store.use_store(spack.paths.user_bootstrap_store):
+        with spack.repo.use_repositories(spack.paths.packages_path):
+            with spack.store.use_store(spack.paths.user_bootstrap_store):
+                # Default configuration scopes excluding command line
+                # and builtin but accounting for platform specific scopes
+                config_scopes = _bootstrap_config_scopes()
+                with spack.config.use_configuration(*config_scopes):
                     with spack_python_interpreter():
                         yield
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -239,6 +239,19 @@ db = llnl.util.lang.LazyReference(_store_db)
 layout = llnl.util.lang.LazyReference(_store_layout)
 
 
+def reinitialize():
+    """Restore globals to the same state they would have at start-up"""
+    global store
+    global root, unpadded_root, db, layout
+
+    store = llnl.util.lang.Singleton(_store)
+
+    root = llnl.util.lang.LazyReference(_store_root)
+    unpadded_root = llnl.util.lang.LazyReference(_store_unpadded_root)
+    db = llnl.util.lang.LazyReference(_store_db)
+    layout = llnl.util.lang.LazyReference(_store_layout)
+
+
 def retrieve_upstream_dbs():
     other_spack_instances = spack.config.get('upstreams', {})
 

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+
+import spack.bootstrap
+import spack.store
+
+
+@pytest.mark.regression('22294')
+def test_store_is_restored_correctly_after_bootstrap(mutable_config, tmpdir):
+    # Prepare a custom store path. This should be in a writeable location
+    # since Spack needs to initialize the DB.
+    user_path = str(tmpdir.join('store'))
+    # Reassign global variables in spack.store to the value
+    # they would have at Spack startup.
+    spack.store.reinitialize()
+    # Set the custom user path
+    spack.config.set('config:install_tree:root', user_path)
+
+    # Test that within the context manager we use the bootstrap store
+    # and that outside we restore the correct location
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        assert spack.store.root == spack.paths.user_bootstrap_store
+    assert spack.store.root == user_path


### PR DESCRIPTION
fixes #22294

A combination of the swapping order for global variables and the fact that most of them are lazily evaluated resulted in custom install tree not being taken into account if clingo had to be bootstrapped. This PR fixes that particular issue, but a broader refactor may be needed to ensure that similar situations won't affect us in the future.