### PR TITLE
Updata package.py of ioapi

### DIFF
--- a/var/spack/repos/builtin/packages/ioapi/package.py
+++ b/var/spack/repos/builtin/packages/ioapi/package.py
@@ -11,7 +11,7 @@ class Ioapi(MakefilePackage):
 
     homepage = "https://www.cmascenter.org/ioapi/"
     url      = "https://www.cmascenter.org/ioapi/download/ioapi-3.2.tar.gz"
-    version('3.2', sha256='56771ff0053d47f2445e00ff369bca7bfc484325a2816b2c648744e523134fe9')
+    version('3.2', sha256='0a3cbf236ffbd9fb5f6509e35308c3353f1f53096efe0c51b84883d2da86924b')
     depends_on('netcdf-c@4:')
     depends_on('netcdf-fortran@4:')
     depends_on('sed', type='build')


### PR DESCRIPTION
The sha256 of [ioapi-3.2](https://www.cmascenter.org/ioapi/download/ioapi-3.2.tar.gz) should be `0a3cbf236ffbd9fb5f6509e35308c3353f1f53096efe0c51b84883d2da86924b`