### PR TITLE
[WIP -- do not review] reimplement the BinaryCacheIndex to wrap a list of Databases

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -178,7 +178,7 @@ def memoized(func):
     """Decorator that caches the results of a function, storing them in
     an attribute of that function.
     """
-    func.cache = {}
+    cache = {}
 
     @functools.wraps(func)
     def _memoized_function(*args):
@@ -186,10 +186,11 @@ def memoized(func):
             # Not hashable, so just call the function.
             return func(*args)
 
-        if args not in func.cache:
-            func.cache[args] = func(*args)
+        if args not in cache:
+            cache[args] = func(*args)
 
-        return func.cache[args]
+        return cache[args]
+    _memoized_function.cache = cache
 
     return _memoized_function
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -532,7 +532,7 @@ def remove_pr_mirror():
 
 def generate_gitlab_ci_yaml(env, print_summary, output_file, prune_dag=False,
                             check_index_only=False, run_optimizer=False,
-                            use_dependencies=False):
+                            use_dependencies=False, artifacts_root=None):
     # FIXME: What's the difference between one that opens with 'spack'
     # and one that opens with 'env'?  This will only handle the former.
     with spack.concretize.disable_compiler_existence_check():

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -219,8 +219,8 @@ def _add_dependency(spec_label, dep_label, deps):
     deps[spec_label].add(dep_label)
 
 
-def get_spec_dependencies(specs, deps, spec_labels, check_index_only=False):
-    spec_deps_obj = compute_spec_deps(specs, check_index_only=check_index_only)
+def get_spec_dependencies(specs, deps, spec_labels):
+    spec_deps_obj = compute_spec_deps(specs)
 
     if spec_deps_obj:
         dependencies = spec_deps_obj['dependencies']
@@ -237,18 +237,13 @@ def get_spec_dependencies(specs, deps, spec_labels, check_index_only=False):
             _add_dependency(entry['spec'], entry['depends'], deps)
 
 
-def stage_spec_jobs(specs, check_index_only=False):
+def stage_spec_jobs(specs):
     """Take a set of release specs and generate a list of "stages", where the
         jobs in any stage are dependent only on jobs in previous stages.  This
         allows us to maximize build parallelism within the gitlab-ci framework.
 
     Arguments:
         specs (Iterable): Specs to build
-        check_index_only (bool): Regardless of whether DAG pruning is enabled,
-            all configured mirrors are searched to see if binaries for specs
-            are up to date on those mirrors.  This flag limits that search to
-            the binary cache indices on those mirrors to speed the process up,
-            even though there is no garantee the index is up to date.
 
     Returns: A tuple of information objects describing the specs, dependencies
         and stages:
@@ -285,8 +280,7 @@ def stage_spec_jobs(specs, check_index_only=False):
     deps = {}
     spec_labels = {}
 
-    get_spec_dependencies(
-        specs, deps, spec_labels, check_index_only=check_index_only)
+    get_spec_dependencies(specs, deps, spec_labels)
 
     # Save the original deps, as we need to return them at the end of the
     # function.  In the while loop below, the "dependencies" variable is
@@ -331,7 +325,7 @@ def print_staging_summary(spec_labels, dependencies, stages):
         stage_index += 1
 
 
-def compute_spec_deps(spec_list, check_index_only=False):
+def compute_spec_deps(spec_list):
     """
     Computes all the dependencies for the spec(s) and generates a JSON
     object which provides both a list of unique spec names as well as a
@@ -395,6 +389,7 @@ def compute_spec_deps(spec_list, check_index_only=False):
             'depends': d,
         })
 
+    bindist.binary_index.refresh_mirrors()
     for spec in spec_list:
         root_spec = spec
 
@@ -403,8 +398,8 @@ def compute_spec_deps(spec_list, check_index_only=False):
                 tty.msg('Will not stage external pkg: {0}'.format(s))
                 continue
 
-            up_to_date_mirrors = bindist.get_mirrors_for_spec(
-                spec=s, full_hash_match=True, index_only=check_index_only)
+            up_to_date_mirrors = bindist.binary_index.get_mirrors_for_spec(
+                spec=s, full_hash_match=True)
 
             skey = spec_deps_key(s)
             spec_labels[skey] = {
@@ -514,10 +509,26 @@ def format_job_needs(phase_name, strip_compilers, dep_jobs,
     return needs_list
 
 
-def generate_gitlab_ci_yaml(env, print_summary, output_file,
-                            prune_dag=False, check_index_only=False,
-                            run_optimizer=False, use_dependencies=False,
-                            artifacts_root=None):
+def add_pr_mirror(url):
+    cfg_scope = cfg.default_modify_scope()
+    mirrors = cfg.get('mirrors', scope=cfg_scope)
+    items = [(n, u) for n, u in mirrors.items()]
+    items.insert(0, ('ci_pr_mirror', url))
+    cfg.set('mirrors', syaml.syaml_dict(items), scope=cfg_scope)
+
+
+def remove_pr_mirror():
+    cfg_scope = cfg.default_modify_scope()
+    mirrors = cfg.get('mirrors', scope=cfg_scope)
+    mirrors.pop('ci_pr_mirror')
+    cfg.set('mirrors', mirrors, scope=cfg_scope)
+
+
+def generate_gitlab_ci_yaml(env, print_summary, output_file, prune_dag=False,
+                            run_optimizer=False,
+                            use_dependencies=False):
+    # FIXME: What's the difference between one that opens with 'spack'
+    # and one that opens with 'env'?  This will only handle the former.
     with spack.concretize.disable_compiler_existence_check():
         with env.write_transaction():
             env.concretize()
@@ -665,35 +676,15 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
 
     # Speed up staging by first fetching binary indices from all mirrors
     # (including the per-PR mirror we may have just added above).
-    try:
-        bindist.binary_index.update()
-    except bindist.FetchCacheError as e:
-        tty.error(e)
+    bindist.binary_index.refresh_mirrors()
 
     staged_phases = {}
     try:
         for phase in phases:
             phase_name = phase['name']
-            if phase_name == 'specs':
-                # Anything in the "specs" of the environment are already
-                # concretized by the block at the top of this method, so we
-                # only need to find the concrete versions, and then avoid
-                # re-concretizing them needlessly later on.
-                concrete_phase_specs = [
-                    concrete for abstract, concrete in env.concretized_specs()
-                    if abstract in env.spec_lists[phase_name]
-                ]
-            else:
-                # Any specs lists in other definitions (but not in the
-                # "specs") of the environment are not yet concretized so we
-                # have to concretize them explicitly here.
-                concrete_phase_specs = env.spec_lists[phase_name]
-                with spack.concretize.disable_compiler_existence_check():
-                    for phase_spec in concrete_phase_specs:
-                        phase_spec.concretize()
-            staged_phases[phase_name] = stage_spec_jobs(
-                concrete_phase_specs,
-                check_index_only=check_index_only)
+            with spack.concretize.disable_compiler_existence_check():
+                staged_phases[phase_name] = stage_spec_jobs(
+                    env.spec_lists[phase_name])
     finally:
         # Clean up PR mirror if enabled
         if pr_mirror_url:

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -219,8 +219,8 @@ def _add_dependency(spec_label, dep_label, deps):
     deps[spec_label].add(dep_label)
 
 
-def get_spec_dependencies(specs, deps, spec_labels):
-    spec_deps_obj = compute_spec_deps(specs)
+def get_spec_dependencies(specs, deps, spec_labels, check_index_only=False):
+    spec_deps_obj = compute_spec_deps(specs, check_index_only=check_index_only)
 
     if spec_deps_obj:
         dependencies = spec_deps_obj['dependencies']
@@ -237,13 +237,18 @@ def get_spec_dependencies(specs, deps, spec_labels):
             _add_dependency(entry['spec'], entry['depends'], deps)
 
 
-def stage_spec_jobs(specs):
+def stage_spec_jobs(specs, check_index_only=False):
     """Take a set of release specs and generate a list of "stages", where the
         jobs in any stage are dependent only on jobs in previous stages.  This
         allows us to maximize build parallelism within the gitlab-ci framework.
 
     Arguments:
         specs (Iterable): Specs to build
+        check_index_only (bool): Regardless of whether DAG pruning is enabled,
+            all configured mirrors are searched to see if binaries for specs
+            are up to date on those mirrors.  This flag limits that search to
+            the binary cache indices on those mirrors to speed the process up,
+            even though there is no garantee the index is up to date.
 
     Returns: A tuple of information objects describing the specs, dependencies
         and stages:
@@ -280,7 +285,8 @@ def stage_spec_jobs(specs):
     deps = {}
     spec_labels = {}
 
-    get_spec_dependencies(specs, deps, spec_labels)
+    get_spec_dependencies(
+        specs, deps, spec_labels, check_index_only=check_index_only)
 
     # Save the original deps, as we need to return them at the end of the
     # function.  In the while loop below, the "dependencies" variable is
@@ -325,7 +331,7 @@ def print_staging_summary(spec_labels, dependencies, stages):
         stage_index += 1
 
 
-def compute_spec_deps(spec_list):
+def compute_spec_deps(spec_list, check_index_only=False):
     """
     Computes all the dependencies for the spec(s) and generates a JSON
     object which provides both a list of unique spec names as well as a
@@ -399,7 +405,7 @@ def compute_spec_deps(spec_list):
                 continue
 
             up_to_date_mirrors = bindist.binary_index.get_mirrors_for_spec(
-                spec=s, full_hash_match=True)
+                spec=s, full_hash_match=True, index_only=check_index_only)
 
             skey = spec_deps_key(s)
             spec_labels[skey] = {
@@ -525,7 +531,7 @@ def remove_pr_mirror():
 
 
 def generate_gitlab_ci_yaml(env, print_summary, output_file, prune_dag=False,
-                            run_optimizer=False,
+                            check_index_only=False, run_optimizer=False,
                             use_dependencies=False):
     # FIXME: What's the difference between one that opens with 'spack'
     # and one that opens with 'env'?  This will only handle the former.
@@ -684,7 +690,8 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file, prune_dag=False,
             phase_name = phase['name']
             with spack.concretize.disable_compiler_existence_check():
                 staged_phases[phase_name] = stage_spec_jobs(
-                    env.spec_lists[phase_name])
+                    env.spec_lists[phase_name],
+                    check_index_only=check_index_only)
     finally:
         # Clean up PR mirror if enabled
         if pr_mirror_url:

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -589,6 +589,9 @@ def install_tarball(spec, args):
 
 def listspecs(args):
     """list binary packages available from mirrors"""
+    # Ensure the local databases for the configured mirrors are up to date.
+    bindist.binary_index.refresh_mirrors()
+
     # A None spec will produce all concrete specs from all mirrors.
     specs = bindist.binary_index.query_remote_dbs(None)
     if not args.allarch:

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -64,6 +64,9 @@ def setup_parser(subparser):
         '--dependencies', action='store_true', default=False,
         help="(Experimental) disable DAG scheduling; use "
              ' "plain" dependencies.')
+    generate.add_argument(
+        '--check-index-only', action='store_true', default=False,
+        help='(Deprecated) <has no effect>')
     prune_group = generate.add_mutually_exclusive_group()
     prune_group.add_argument(
         '--prune-dag', action='store_true', dest='prune_dag',
@@ -107,6 +110,10 @@ def ci_generate(args):
        for creating a build group for the generated workload and registering
        all generated jobs under that build group.  If this environment
        variable is not set, no build group will be created on CDash."""
+    if args.check_index_only:
+        tty.warn('--check-index-only is deprecated and no longer has any effect. '
+                 'See https://github.com/spack/spack/pull/22634 for details.')
+
     env = spack.cmd.require_active_env(cmd_name='ci generate')
 
     output_file = args.output_file

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -64,9 +64,6 @@ def setup_parser(subparser):
         '--dependencies', action='store_true', default=False,
         help="(Experimental) disable DAG scheduling; use "
              ' "plain" dependencies.')
-    generate.add_argument(
-        '--check-index-only', action='store_true', default=False,
-        help='(Deprecated) <has no effect>')
     prune_group = generate.add_mutually_exclusive_group()
     prune_group.add_argument(
         '--prune-dag', action='store_true', dest='prune_dag',
@@ -76,6 +73,17 @@ date on the mirror""")
         '--no-prune-dag', action='store_false', dest='prune_dag',
         default=True, help="""Generate jobs for specs already up to date
 on the mirror""")
+    generate.add_argument(
+        '--check-index-only', action='store_true', dest='index_only',
+        default=False, help="""Spack always check specs against configured
+binary mirrors when generating the pipeline, regardless of whether or not
+DAG pruning is enabled.  This flag controls whether it might attempt to
+fetch remote spec.yaml files directly (ensuring no spec is rebuilt if it is
+present on the mirror), or whether it should reduce pipeline generation time
+by assuming all remote buildcache indices are up to date and only use those
+to determine whether a given spec is up to date on mirrors.  In the latter
+case, specs might be needlessly rebuilt if remote buildcache indices are out
+of date.""")
     generate.add_argument(
         '--artifacts-root', default=None,
         help="""Path to root of artifacts directory.  If provided, concrete

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -22,6 +22,7 @@ import spack.config as cfg
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.mirror
+import spack.util.executable as exe
 import spack.util.spack_yaml as syaml
 import spack.util.url as url_util
 import spack.util.web as web_util
@@ -577,7 +578,7 @@ def ci_rebuild(args):
             tty.debug(fd.read())
 
         # DEBUG the root spec
-        root_spec_yaml_path = os.path.join(spec_dir, 'root.yaml')
+        root_spec_yaml_path = os.path.join(repro_dir, 'root.yaml')
         with open(root_spec_yaml_path, 'w') as fd:
             fd.write(spec_map['root'].to_yaml(hash=ht.build_hash))
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -745,6 +745,8 @@ class Database(object):
         # type: (str) -> None
         """Fill database from file, do not maintain old data.
         Translate the spec portions from node-dict form to spec form."""
+        if not os.path.isabs(filename):
+            raise TypeError('Expected absolute path, received {0}'.format(filename))
         try:
             with open(filename, 'r') as f:
                 fdata = sjson.load(f)
@@ -752,6 +754,14 @@ class Database(object):
             raise CorruptDatabaseError("error parsing database:", str(e))
 
         self.fill_from_json(fdata)
+
+    @classmethod
+    def from_file(cls, filename):
+        # type: (str) -> Database
+        """Return a Database instance purely from a json file, without any db_dir."""
+        db = cls(None, is_upstream=True, enable_transaction_locking=False)
+        db.fill_from_file(filename)
+        return db
 
     def fill_from_json(self, fdata):
         # type: (Optional[Dict]) -> None

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -401,7 +401,7 @@ def _try_install_from_binary_cache(pkg, explicit, unsigned=False,
     """
     pkg_id = package_id(pkg)
     tty.debug('Searching for binary cache of {0}'.format(pkg_id))
-    matches = binary_distribution.get_mirrors_for_spec(
+    matches = binary_distribution.binary_index.get_mirrors_for_spec(
         pkg.spec, full_hash_match=full_hash_match)
 
     if not matches:

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -297,6 +297,9 @@ class MirrorCollection(Mapping):
     def __len__(self):
         return len(self._mirrors)
 
+    def __bool__(self):
+        return len(self) > 0
+
 
 def _determine_extension(fetcher):
     if isinstance(fetcher, fs.URLFetchStrategy):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -674,7 +674,7 @@ class RepoPath(object):
         Set `use_index` False when calling from a code block that could
         be run during the computation of the provider index."""
         have_name = pkg_name is not None
-        if have_name and not isinstance(pkg_name, str):
+        if have_name and not isinstance(pkg_name, six.string_types):
             raise ValueError(
                 "is_virtual(): expected package name, got %s" % type(pkg_name))
         if use_index:

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -396,7 +396,7 @@ def test_built_spec_cache(mirror_dir):
         'corge': cspec.full_hash(),
     }
 
-    gspec_results = bindist.get_mirrors_for_spec(gspec)
+    gspec_results = bindist.binary_index.get_mirrors_for_spec(gspec)
 
     gspec_mirrors = {}
     for result in gspec_results:
@@ -405,7 +405,8 @@ def test_built_spec_cache(mirror_dir):
         assert(result['mirror_url'] not in gspec_mirrors)
         gspec_mirrors[result['mirror_url']] = True
 
-    cspec_results = bindist.get_mirrors_for_spec(cspec, full_hash_match=True)
+    cspec_results = bindist.binary_index.get_mirrors_for_spec(
+        cspec, full_hash_match=True)
 
     cspec_mirrors = {}
     for result in cspec_results:
@@ -568,6 +569,8 @@ def test_update_sbang(tmpdir, test_mirror):
 
     # Need to force an update of the buildcache index
     buildcache_cmd('update-index', '-d', mirror_url)
+
+    bindist.binary_index.refresh_mirrors()
 
     # Uninstall the original package.
     uninstall_cmd('-y', old_spec_hash_str)

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -252,6 +252,12 @@ def test_default_rpaths_install_nondefault_layout(mirror_dir):
     # This guy tests for symlink relocation
     sy_spec = Spec('symly').concretized()
 
+    # Install 'corge' into the buildcache.
+    install_cmd('--no-cache', cspec.name)
+    buildcache_cmd('create', '-au', '--rebuild-index', '-d', mirror_dir, cspec.name)
+    bindist.binary_index.refresh_mirrors()
+    uninstall_cmd('-y', cspec.name)
+
     # Install some packages with dependent packages
     # test install in non-default install path scheme
     buildcache_cmd('install', '-au', cspec.name, sy_spec.name)

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1403,8 +1403,8 @@ spack:
     # nothing in the environment needs rebuilding.  With the monkeypatch, the
     # process sees the compiler as needing a rebuild, which should then result
     # in the specs built with that compiler needing a rebuild too.
-    def fake_get_mirrors_for_spec(spec=None, full_hash_match=False,
-                                  mirrors_to_check=None, index_only=False):
+    def fake_get_mirrors_for_spec(self, spec=None, full_hash_match=False,
+                                  index_only=False):
         if spec.name == 'gcc':
             return []
         else:
@@ -1434,7 +1434,7 @@ spack:
             assert(original_yaml_contents)
             assert('no-specs-to-rebuild' in original_yaml_contents)
 
-            monkeypatch.setattr(spack.binary_distribution,
+            monkeypatch.setattr(spack.binary_distribution.BinaryCacheIndex,
                                 'get_mirrors_for_spec',
                                 fake_get_mirrors_for_spec)
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1540,4 +1540,4 @@ def mock_test_stage(mutable_config, tmpdir):
 def brand_new_binary_cache():
     yield
     spack.binary_distribution.binary_index = llnl.util.lang.Singleton(
-        spack.binary_distribution._binary_index)
+        spack.binary_distribution.BinaryCacheIndex)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -139,6 +139,8 @@ def test_install_msg(monkeypatch):
     pid = 123456
     install_msg = 'Installing {0}'.format(name)
 
+    monkeypatch.setattr(tty.color, 'get_color_when', lambda: False)
+
     monkeypatch.setattr(tty, '_debug', 0)
     assert inst.install_msg(name, pid) == install_msg
 
@@ -230,24 +232,21 @@ def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
 
 
 def test_try_install_from_binary_cache(install_mockery, mock_packages,
-                                       monkeypatch):
-    """Tests SystemExit path for_try_install_from_binary_cache.
-
-       This test does not make sense.  We tell spack there is a mirror
-       with a binary for this spec and then expect it to die because there
-       are no mirrors configured."""
-    # def _mirrors_for_spec(spec, full_hash_match=False):
-    #     spec = spack.spec.Spec('mpi').concretized()
-    #     return [{
-    #         'mirror_url': 'notused',
-    #         'spec': spec,
-    #     }]
+                                       monkeypatch, capsys):
+    """Tests SystemExit path for_try_install_from_binary_cache."""
+    def _mirrors_for_spec(self, spec, full_hash_match=False):
+        spec = spack.spec.Spec('mpi').concretized()
+        return [{
+            'mirror_url': 'notused',
+            'spec': spec,
+        }]
 
     spec = spack.spec.Spec('mpich')
     spec.concretize()
 
-    # monkeypatch.setattr(
-    #     spack.binary_distribution, 'get_mirrors_for_spec', _mirrors_for_spec)
+    monkeypatch.setattr(spack.binary_distribution.BinaryCacheIndex,
+                        'get_mirrors_for_spec',
+                        _mirrors_for_spec)
 
     # with pytest.raises(SystemExit):
     #     inst._try_install_from_binary_cache(spec.package, False, False)

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -7,10 +7,6 @@
 This test checks the binary packaging infrastructure
 """
 import os
-import stat
-import shutil
-import pytest
-import re
 import platform
 import re
 import shutil
@@ -20,10 +16,10 @@ import pytest
 
 from llnl.util.filesystem import mkdirp
 
+import spack.binary_distribution as bindist
 import spack.main
 import spack.repo
 import spack.store
-import spack.binary_distribution as bindist
 import spack.util.gpg
 from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
 from spack.paths import mock_gpg_keys_path
@@ -39,7 +35,6 @@ from spack.relocate import (
     relocate_text,
 )
 from spack.spec import Spec
-
 
 buildcache_cmd = spack.main.SpackCommand('buildcache')
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -595,7 +595,7 @@ _spack_ci() {
 }
 
 _spack_ci_generate() {
-    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies --prune-dag --no-prune-dag --check-index-only --artifacts-root"
+    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies --prune-dag --no-prune-dag --artifacts-root"
 }
 
 _spack_ci_rebuild_index() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -595,11 +595,7 @@ _spack_ci() {
 }
 
 _spack_ci_generate() {
-    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies --prune-dag --no-prune-dag --artifacts-root"
-}
-
-_spack_ci_rebuild_index() {
-    SPACK_COMPREPLY="-h --help"
+    SPACK_COMPREPLY="-h --help --output-file --copy-to --optimize --dependencies --prune-dag --no-prune-dag --check-index-only --artifacts-root"
 }
 
 _spack_ci_rebuild() {


### PR DESCRIPTION
### Problem
This is a corollary to #22503. We want users to be able to specify hash prefixes on the command line that match concrete specs from remote mirrors as a convenience, but the implementation in #22503 will take a full minute to look up any such remote specs. This is mysterious and annoying. **We do not solve that performance issue in this PR, but we do make it easier to do that in a followup by vastly simplifying the implementation.**

Separately, @eugeneswalker reported an extremely strange issue over Slack today where `spack concretize` was still returning results from a mirror (e4s) that had been removed with `spack mirror rm`! The caching logic in the current `BinaryCacheIndex` struck me as over time having become haphazard and difficult to follow, so this is part 1/2 of an attempt to fix this mysterious behavior. Part 2 will introduce a common interface for looking up either local, remote, or local and remote specs which requires explicitly annotating which locations to pull from (similar to the `SpecIndex` of #21538).

### Solution
Rip out most of the `BinaryCacheIndex` implementation:
1. Instead of creating `Database` instances in a temporary directory, persist them in `~/.spack/cache/indices` (which was added in #22500).
1. Separate the `fetch_index()` and `fetch_index_hash()` methods from the `BinaryCacheIndex` class, which allows those fetch methods to be written without implementing any caching logic, while letting the `BinaryCacheIndex` handle all of the stateful stuff.
1. Remove all methods which try to go behind the back of `BinaryCacheIndex` by fetching indices directly, and explicitly annotate where we read the mirrors to fetch from the spack config by introducing the `with_spack_configured_mirrors()` classmethod.
    - Of all components of this change, this one is most likely to fix the behavior @eugeneswalker was seeing.

### Result
The places where `BinaryCacheIndex` pulls down mirrors are much more obvious and much less numerous, as are as the places where `BinaryCacheIndex` reads in the mirrors to fetch.