### PR TITLE
adding AOCC support for CP2K 7.1

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -272,6 +272,7 @@ class Cp2k(MakefilePackage, CudaPackage):
         elif '%aocc' in spec:
             fcflags += [
                 '-ffree-form',
+                '-Mbackslash',
             ]
         elif '%pgi' in spec or '%nvhpc' in spec:
             fcflags += ['-Mfreeform', '-Mextend']

--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -80,6 +80,9 @@ class Libxc(AutotoolsPackage, CudaPackage):
         if '%intel' in self.spec and which('xiar'):
             env.set('AR', 'xiar')
 
+        if '%aocc' in self.spec:
+            env.append_flags('FCFLAGS', '-fPIC')
+
         if '+cuda' in self.spec:
             nvcc = self.spec['cuda'].prefix.bin.nvcc
             env.set('CCLD', '{0} -ccbin {1}'.format(nvcc, spack_cc))
@@ -99,6 +102,15 @@ class Libxc(AutotoolsPackage, CudaPackage):
         ]
 
         return args
+
+    @run_after('configure')
+    def patch_libtool(self):
+        """AOCC support for LIBXC"""
+        if '%aocc' in self.spec:
+            filter_file(
+                r'\$wl-soname \$wl\$soname',
+                r'-fuse-ld=ld -Wl,-soname,\$soname',
+                'libtool', string=True)
 
     def check(self):
         # libxc provides a testsuite, but many tests fail


### PR DESCRIPTION
LIBXC
- Provided `shared` library build support with `aocc`

CP2K
- added "-Mbackslash" to `fcflags` to avoid build failures