### PR TITLE
binutils: Improve flag_handler

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -127,17 +127,20 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
                     extradir)
 
     def flag_handler(self, name, flags):
+        # Use a separate variable for injecting flags. This way, installing
+        # `binutils cflags='-O2'` will still work as expected.
+        iflags = []
         # To ignore the errors of narrowing conversions for
         # the Fujitsu compiler
         if name == 'cxxflags' and (
             self.spec.satisfies('@:2.31.1') and
             self.compiler.name in ('fj', 'clang', 'apple-clang')
         ):
-            flags.append('-Wno-narrowing')
+            iflags.append('-Wno-narrowing')
         elif name == 'cflags':
             if self.spec.satisfies('@:2.34 %gcc@10:'):
-                flags.append('-fcommon')
-        return (flags, None, None)
+                iflags.append('-fcommon')
+        return (iflags, None, flags)
 
     def test(self):
         spec_vers = str(self.spec.version)


### PR DESCRIPTION
`flag_handler` currently passes all flags via injection. This makes it impossible to override the default flags provided by autotools (for instance, `binutils cflags='-O2'` will still build with `-O2 -g`). Instead, use injection for our workaround flags and pass other flags to the build system.

@haampie Would this work for you as an alternative to #18123?