### PR TITLE
Add spack-named-env to the docker entrypoint wrapper

### DIFF
--- a/share/spack/docker/amazonlinux-2.dockerfile
+++ b/share/spack/docker/amazonlinux-2.dockerfile
@@ -46,6 +46,8 @@ RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/interactive-shell \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-named-env
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/spack-env
 
 RUN mkdir -p /root/.spack \

--- a/share/spack/docker/centos-6.dockerfile
+++ b/share/spack/docker/centos-6.dockerfile
@@ -48,6 +48,8 @@ RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/interactive-shell \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-named-env
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/spack-env
 
 RUN mkdir -p /root/.spack \

--- a/share/spack/docker/centos-7.dockerfile
+++ b/share/spack/docker/centos-7.dockerfile
@@ -48,6 +48,8 @@ RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/interactive-shell \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-named-env
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/spack-env
 
 RUN mkdir -p /root/.spack \

--- a/share/spack/docker/leap-15.dockerfile
+++ b/share/spack/docker/leap-15.dockerfile
@@ -34,6 +34,8 @@ RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/interactive-shell \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-named-env
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/spack-env
 
 RUN mkdir -p /root/.spack \

--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -46,6 +46,8 @@ RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/interactive-shell \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-named-env
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/spack-env
 
 # Add LANG default to en_US.UTF-8

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -46,6 +46,8 @@ RUN ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/interactive-shell \
  && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
+          /usr/local/bin/spack-named-env
+ && ln -s $SPACK_ROOT/share/spack/docker/entrypoint.bash \
           /usr/local/bin/spack-env
 
 # Add LANG default to en_US.UTF-8


### PR DESCRIPTION
This provides a docker entrypoint with a specified environment already active.  This is particularly useful for building spack based containers for a pre-defined application stack.

As an example, building a spack based container for adios might use a `Dockerfile` that looks something like this:
```
FROM spack/ubuntu-bionic

ENV SPACK_PYTHON=/usr/bin/python3.6

COPY adios2-env.yml /root/adios2-env.yml
RUN spack env create adios2 /root/adios2-env.yml && \
    rm -f /root/adios2-env.yml
SHELL ["/usr/local/bin/spack-named-env", "adios2", "/bin/bash", "-c"]

RUN spack install -v && \
    spack clean -a

ENTRYPOINT ["/usr/local/bin/spack-named-env", "adios2"]
CMD ["/bin/bash" ]
```

This is particularly useful for building CI environments with pre-packaged dependencies where the environment might just contain the target package and the CI image would be built with `spack install --only dependencies`.