### PR TITLE
Add defaults to spack.config.get("config:...")

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -429,7 +429,7 @@ def set_build_environment_variables(pkg, env, dirty):
     env.set_path(SPACK_ENV_PATH, env_paths)
 
     # Working directory for the spack command itself, for debug logs.
-    if spack.config.get('config:debug'):
+    if spack.config.get('config:debug', False):
         env.set(SPACK_DEBUG, 'TRUE')
     env.set(SPACK_SHORT_SPEC, pkg.spec.short_spec)
     env.set(SPACK_DEBUG_LOG_ID, pkg.spec.format('{name}-{hash:7}'))

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -90,7 +90,7 @@ def report(args):
     print('* **Python:**', platform.python_version())
     print('* **Platform:**', architecture.Arch(
         architecture.platform(), 'frontend', 'frontend'))
-    print('* **Concretizer:**', spack.config.get('config:concretizer'))
+    print('* **Concretizer:**', spack.config.get('config:concretizer', 'original'))
 
 
 def debug(parser, args):

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -61,7 +61,7 @@ def graph(parser, args):
         graph_dot(specs, static=args.static, deptype=args.deptype)
 
     elif specs:  # ascii is default: user doesn't need to provide it explicitly
-        debug = spack.config.get('config:debug')
+        debug = spack.config.get('config:debug', False)
         graph_ascii(specs[0], debug=debug, deptype=args.deptype)
         for spec in specs[1:]:
             print()  # extra line bt/w independent graphs

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -253,7 +253,7 @@ class YamlDirectoryLayout(DirectoryLayout):
             with open(path) as f:
                 spec = spack.spec.Spec.from_yaml(f)
         except Exception as e:
-            if spack.config.get('config:debug'):
+            if spack.config.get('config:debug', False):
                 raise
             raise SpecReadError(
                 'Unable to read file: %s' % path, 'Cause: ' + str(e))

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -326,7 +326,7 @@ class URLFetchStrategy(FetchStrategy):
         # Telling curl to fetch the first byte (-r 0-0) is supposed to be
         # portable.
         curl_args = ['--stderr', '-', '-s', '-f', '-r', '0-0', url]
-        if not spack.config.get('config:verify_ssl'):
+        if not spack.config.get('config:verify_ssl', True):
             curl_args.append('-k')
         _ = curl(*curl_args, fail_on_error=False, output=os.devnull)
         return curl.returncode == 0
@@ -354,7 +354,7 @@ class URLFetchStrategy(FetchStrategy):
             url,
         ]
 
-        if not spack.config.get('config:verify_ssl'):
+        if not spack.config.get('config:verify_ssl', True):
             curl_args.append('-k')
 
         if sys.stdout.isatty() and tty.msg_enabled():
@@ -786,7 +786,7 @@ class GitFetchStrategy(VCSFetchStrategy):
 
             # If the user asked for insecure fetching, make that work
             # with git as well.
-            if not spack.config.get('config:verify_ssl'):
+            if not spack.config.get('config:verify_ssl', True):
                 self._git.add_default_env('GIT_SSL_NO_VERIFY', 'true')
 
         return self._git
@@ -829,7 +829,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         if self.commit:
             # Need to do a regular clone and check out everything if
             # they asked for a particular commit.
-            debug = spack.config.get('config:debug')
+            debug = spack.config.get('config:debug', False)
 
             clone_args = ['clone', self.url]
             if not debug:
@@ -849,7 +849,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         else:
             # Can be more efficient if not checking out a specific commit.
             args = ['clone']
-            if not spack.config.get('config:debug'):
+            if not spack.config.get('config:debug', False):
                 args.append('--quiet')
 
             # If we want a particular branch ask for it.
@@ -891,7 +891,7 @@ class GitFetchStrategy(VCSFetchStrategy):
                     # see: https://github.com/git/git/commit/19d122b
                     pull_args = ['pull', '--tags']
                     co_args = ['checkout', self.tag]
-                    if not spack.config.get('config:debug'):
+                    if not spack.config.get('config:debug', False):
                         pull_args.insert(1, '--quiet')
                         co_args.insert(1, '--quiet')
 
@@ -902,7 +902,7 @@ class GitFetchStrategy(VCSFetchStrategy):
             with working_dir(self.stage.source_path):
                 for submodule_to_delete in self.submodules_delete:
                     args = ['rm', submodule_to_delete]
-                    if not spack.config.get('config:debug'):
+                    if not spack.config.get('config:debug', False):
                         args.insert(1, '--quiet')
                     git(*args)
 
@@ -910,7 +910,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         if self.submodules:
             with working_dir(self.stage.source_path):
                 args = ['submodule', 'update', '--init', '--recursive']
-                if not spack.config.get('config:debug'):
+                if not spack.config.get('config:debug', False):
                     args.insert(1, '--quiet')
                 git(*args)
 
@@ -922,7 +922,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         with working_dir(self.stage.source_path):
             co_args = ['checkout', '.']
             clean_args = ['clean', '-f']
-            if spack.config.get('config:debug'):
+            if spack.config.get('config:debug', False):
                 co_args.insert(1, '--quiet')
                 clean_args.insert(1, '--quiet')
 
@@ -1111,7 +1111,7 @@ class HgFetchStrategy(VCSFetchStrategy):
 
         args = ['clone']
 
-        if not spack.config.get('config:verify_ssl'):
+        if not spack.config.get('config:verify_ssl', True):
             args.append('--insecure')
 
         if self.revision:

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -772,18 +772,18 @@ def main(argv=None):
         e.die()  # gracefully die on any SpackErrors
 
     except Exception as e:
-        if spack.config.get('config:debug'):
+        if spack.config.get('config:debug', False):
             raise
         tty.die(e)
 
     except KeyboardInterrupt:
-        if spack.config.get('config:debug'):
+        if spack.config.get('config:debug', False):
             raise
         sys.stderr.write('\n')
         tty.die("Keyboard interrupt.")
 
     except SystemExit as e:
-        if spack.config.get('config:debug'):
+        if spack.config.get('config:debug', False):
             traceback.print_exc()
         return e.code
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -517,7 +517,7 @@ def _add_single_spec(spec, mirror, mirror_stats):
         num_retries -= 1
 
     if exception:
-        if spack.config.get('config:debug'):
+        if spack.config.get('config:debug', False):
             traceback.print_exception(file=sys.stderr, *exc_tuple)
         else:
             tty.warn(

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1309,7 +1309,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             tty.debug('No fetch required for {0}: package has no code.'
                       .format(self.name))
 
-        checksum = spack.config.get('config:checksum')
+        checksum = spack.config.get('config:checksum', True)
         fetch = self.stage.managed_by_spack
         if checksum and fetch and self.version not in self.versions:
             tty.warn("There is no checksum on file to fetch %s safely." %

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -215,7 +215,7 @@ class UrlPatch(Patch):
 
         # for a compressed archive, Need to check the patch sha256 again
         # and the patch is in a directory, not in the same place
-        if self.archive_sha256 and spack.config.get('config:checksum'):
+        if self.archive_sha256 and spack.config.get('config:checksum', True):
             checker = Checker(self.sha256)
             if not checker.check(self.path):
                 raise fs.ChecksumError(

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -935,7 +935,7 @@ class Repo(object):
 
             # Make sure other errors in constructors hit the error
             # handler by wrapping them
-            if spack.config.get('config:debug'):
+            if spack.config.get('config:debug', False):
                 sys.excepthook(*sys.exc_info())
             raise FailedConstructorError(spec.fullname, *sys.exc_info())
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2548,7 +2548,7 @@ class Spec(object):
                 if a list of names activate them for the packages in the list,
                 if True activate 'test' dependencies for all packages.
         """
-        if spack.config.get('config:concretizer') == "clingo":
+        if spack.config.get('config:concretizer', 'original') == "clingo":
             self._new_concretize(tests)
         else:
             self._old_concretize(tests)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -156,7 +156,7 @@ def get_stage_root():
     global _stage_root
 
     if _stage_root is None:
-        candidates = spack.config.get('config:build_stage')
+        candidates = spack.config.get('config:build_stage', '$tempdir/spack-stage')
         if isinstance(candidates, string_types):
             candidates = [candidates]
 
@@ -540,7 +540,7 @@ class Stage(object):
                      "mirror.  This means we cannot know a checksum for the "
                      "tarball in advance. Be sure that your connection to "
                      "this mirror is secure!")
-        elif spack.config.get('config:checksum'):
+        elif spack.config.get('config:checksum', True):
             self.fetcher.check()
 
     def cache_local(self):

--- a/lib/spack/spack/test/cmd/debug.py
+++ b/lib/spack/spack/test/cmd/debug.py
@@ -54,4 +54,4 @@ def test_report():
     assert get_version() in out
     assert platform.python_version() in out
     assert str(arch) in out
-    assert spack.config.get('config:concretizer') in out
+    assert spack.config.get('config:concretizer', 'original') in out

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1459,7 +1459,7 @@ env:
 def test_stack_concretize_extraneous_deps(tmpdir, config, mock_packages):
     # FIXME: The new concretizer doesn't handle yet soft
     # FIXME: constraints for stacks
-    if spack.config.get('config:concretizer') == 'clingo':
+    if spack.config.get('config:concretizer', 'original') == 'clingo':
         pytest.skip('Clingo concretizer does not support soft constraints')
 
     filename = str(tmpdir.join('spack.yaml'))

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -740,7 +740,7 @@ class TestConcretize(object):
         ('bowtie@1.2.2 os=redhat6', '%gcc@4.7.2'),
     ])
     def test_compiler_conflicts_in_package_py(self, spec_str, expected_str):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.skip('Original concretizer cannot work around conflicts')
 
         s = Spec(spec_str).concretized()
@@ -805,7 +805,7 @@ class TestConcretize(object):
         ('quantum-espresso~veritas', ['^libelf@0.8.13'])
     ])
     def test_working_around_conflicting_defaults(self, spec_str, expected):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         s = Spec(spec_str).concretized()
@@ -823,7 +823,7 @@ class TestConcretize(object):
     def test_external_package_and_compiler_preferences(
             self, spec_str, expected
     ):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         packages_yaml = {
@@ -852,7 +852,7 @@ class TestConcretize(object):
         packages.yaml, but our spec doesn't allow X.Y as a version, then
         a new version of A is built that meets the requirements.
         """
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         packages_yaml = {
@@ -871,7 +871,7 @@ class TestConcretize(object):
 
     @pytest.mark.regression('9744')
     def test_cumulative_version_ranges_with_different_length(self):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         s = Spec('cumulative-vrange-root').concretized()
@@ -907,7 +907,7 @@ class TestConcretize(object):
     def test_compiler_constraint_with_external_package(
             self, spec_str, expected
     ):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         packages_yaml = {
@@ -948,13 +948,14 @@ class TestConcretize(object):
         spack.config.set('packages', packages_yaml)
 
         s = Spec(spec_str).concretized()
-        if xfailold and spack.config.get('config:concretizer') == 'original':
+        is_original = spack.config.get('config:concretizer', 'original') == 'original'
+        if xfailold and is_original:
             pytest.xfail('This only works on the ASP-based concretizer')
         assert s.satisfies(expected)
         assert 'external-common-perl' not in [d.name for d in s.dependencies()]
 
     def test_external_packages_have_consistent_hash(self):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.skip('This tests needs the ASP-based concretizer')
 
         s, t = Spec('externaltool'), Spec('externaltool')
@@ -983,7 +984,7 @@ class TestConcretize(object):
 
     @pytest.mark.regression('20040')
     def test_conditional_provides_or_depends_on(self):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         # Check that we can concretize correctly a spec that can either
@@ -1023,7 +1024,7 @@ class TestConcretize(object):
 
     @pytest.mark.regression('20019')
     def test_compiler_match_is_preferred_to_newer_version(self):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         # This spec depends on openblas. Openblas has a conflict
@@ -1054,7 +1055,7 @@ class TestConcretize(object):
 
     @pytest.mark.regression('20055')
     def test_custom_compiler_version(self):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         s = Spec('a %gcc@foo os=redhat6').concretized()
@@ -1135,7 +1136,7 @@ class TestConcretize(object):
         'wrong-variant-in-depends-on'
     ])
     def test_error_message_for_inconsistent_variants(self, spec_str):
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known failure of the original concretizer')
 
         s = Spec(spec_str)

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -125,7 +125,7 @@ class TestConcretizePreferences(object):
         """Test preferred targets are applied correctly"""
         # FIXME: This test was a false negative, since the default and
         # FIXME: the preferred target were the same
-        if spack.config.get('config:concretizer') == 'original':
+        if spack.config.get('config:concretizer', 'original') == 'original':
             pytest.xfail('Known bug in the original concretizer')
 
         spec = concretize('mpich')

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -92,7 +92,7 @@ def test_installed_deps():
     """
     # FIXME: this requires to concretize build deps separately if we are
     # FIXME: using the clingo based concretizer
-    if spack.config.get('config:concretizer') == 'clingo':
+    if spack.config.get('config:concretizer', 'original') == 'clingo':
         pytest.xfail('requires separate concretization of build dependencies')
 
     default = ('build', 'link')
@@ -172,7 +172,7 @@ def test_conditional_dep_with_user_constraints(spec_str, expr_str, expected):
     # FIXME: We need to tweak optimization rules to make this test
     # FIXME: not prefer a DAG with fewer nodes wrt more recent
     # FIXME: versions of the package
-    if spack.config.get('config:concretizer') == 'clingo':
+    if spack.config.get('config:concretizer', 'original') == 'clingo':
         pytest.xfail('Clingo optimization rules prefer to trim a node')
 
     default = ('build', 'link')

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -86,7 +86,7 @@ def editor(*args, **kwargs):
             return True
 
         except OSError as e:
-            if spack.config.get('config:debug'):
+            if spack.config.get('config:debug', False):
                 raise
 
             # Show variable we were trying to use, if it's from one

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -25,7 +25,7 @@ def create_s3_session(url):
 
     session = Session()
 
-    s3_client_args = {"use_ssl": spack.config.get('config:verify_ssl')}
+    s3_client_args = {"use_ssl": spack.config.get('config:verify_ssl', True)}
 
     endpoint_url = os.environ.get('S3_ENDPOINT_URL')
     if endpoint_url:

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -91,7 +91,7 @@ def read_from_url(url, accept_content_type=None):
     url = url_util.parse(url)
     context = None
 
-    verify_ssl = spack.config.get('config:verify_ssl')
+    verify_ssl = spack.config.get('config:verify_ssl', True)
 
     # Don't even bother with a context unless the URL scheme is one that uses
     # SSL certs.
@@ -158,7 +158,7 @@ def warn_no_ssl_cert_checking():
 def push_to_url(
         local_file_path, remote_path, keep_original=True, extra_args=None):
     remote_url = url_util.parse(remote_path)
-    verify_ssl = spack.config.get('config:verify_ssl')
+    verify_ssl = spack.config.get('config:verify_ssl', True)
 
     if __UNABLE_TO_VERIFY_SSL and verify_ssl and uses_ssl(remote_url):
         warn_no_ssl_cert_checking()


### PR DESCRIPTION
Sometimes there is no default config scope, for instance when

```python
with spack.config.use_config(tmp_config):
  install('xyz')
```
and spack.config.config_defaults is not used in tmp_config. It's easy to
forget.

This might inadvertently result in security issues, such as fetching
without ssl:

```python
if not spack.config.get('config:verify_ssl'):
   curl_args.append('-k')
```

This branch is followed when config:verify_ssl is not set and the get
function returns None.
