### PR TITLE
ncurses: add determine abi version variant

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -69,6 +69,15 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
                     break
             if usingSymlinks:
                 variants += '+symlinks'
+
+            abiVersion = 'none'
+            output = Executable(exe)('--abi-version', output=str, error=str)
+            if '6' in output:
+                abiVersion = '6'
+            elif '5' in output:
+                abiVersion = '5'
+            variants += ' abi=' + abiVersion
+
             results.append(variants)
         return results
 


### PR DESCRIPTION
As follow up to #22536 , with this the `abi` version variant from `ncurses` can be determine