### PR TITLE
Adding test for "on the fly" config args with -c

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -487,7 +487,8 @@ def allows_unknown_args(command):
 
 
 def _invoke_command(command, parser, args, unknown_args):
-    """Run a spack command *without* setting spack global options."""
+    """Run a spack command."""
+    setup_main_options(args)
     if allows_unknown_args(command):
         return_val = command(parser, args, unknown_args)
     else:

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -212,9 +212,10 @@ def test_config_add_update_dict(mutable_empty_config):
     assert output == expected
 
 
-def test_config_with_c_argument(mutable_empty_config):
-
-    # I don't know how to add a spack argument to a Spack Command, so we test this way
+def test_config_with_c_argument_parser(mutable_empty_config):
+    """
+    Test config add with the parser directly.
+    """
     config_file = 'config:install_root:root:/path/to/config.yaml'
     parser = spack.main.make_argument_parser()
     args = parser.parse_args(['-c', config_file])
@@ -223,6 +224,20 @@ def test_config_with_c_argument(mutable_empty_config):
     # Add the path to the config
     config("add", args.config_vars[0], scope='command_line')
     output = config("get", 'config')
+    assert "config:\n  install_root:\n  - root: /path/to/config.yaml" in output
+
+
+def test_config_with_c_argument(mutable_empty_config):
+    """
+    Test config add with the command directly.
+    """
+    config_file = 'config:install_root:root:/path/to/config.yaml'
+
+    # Global args are prepended to the command (spack <global args> ...)
+    global_args = ['-c', config_file]
+
+    # Do a get with the argument
+    output = config("get", 'config', global_args=global_args)
     assert "config:\n  install_root:\n  - root: /path/to/config.yaml" in output
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -521,7 +521,7 @@ def mutable_empty_config(tmpdir_factory, configuration_dir):
     """Empty configuration that can be modified by the tests."""
     mutable_dir = tmpdir_factory.mktemp('mutable_config').join('tmp')
     scopes = [spack.config.ConfigScope(name, str(mutable_dir.join(name)))
-              for name in ['site', 'system', 'user']]
+              for name in ['site', 'system', 'user', 'command_line']]
 
     with spack.config.use_configuration(*scopes) as cfg:
         yield cfg


### PR DESCRIPTION
To follow up with https://github.com/spack/spack/pull/22318#issuecomment-803626368, this will add an extra test to ensure that we can run a SpackCommand with global_args for config, meaning that a one off config argument is preserved with a SpackCommand. There was a bug in missing a call to setup_main_options(args) that will now ensure that it works. Thanks to @haampie for the slack discussion about fixing the bug! Note that we decided to add "command_line" to the set of scopes for the `mutable_empty_config` fixture, since not having it was probably an oversight.



Signed-off-by: vsoch <vsoch@users.noreply.github.com>