### PR TITLE
Use a temporary command_line scope valid only during SpackCommand invocation

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -560,6 +560,7 @@ class SpackCommand(object):
             """
             scopes = spack.config.scopes()
             if 'command_line' not in scopes:
+                yield
                 return
             command_line = spack.config.config.pop_scope()
             spack.config.config.push_scope(

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -905,3 +905,10 @@ def test_install_env_with_tests_root(tmpdir, mock_packages, mock_fetch,
         add('depb')
         install('--test', 'root')
         assert not os.path.exists(test_dep.prefix)
+
+
+def test_spack_install_does_not_persist_command_line_config(
+        mock_packages, mock_fetch, install_mockery, mutable_mock_env_path):
+    assert spack.config.get('config:checksum', scope='command_line') is not False
+    install('--no-checksum', 'libdwarf')
+    assert spack.config.get('config:checksum', scope='command_line') is not False


### PR DESCRIPTION
Attempts to fix https://github.com/spack/spack/issues/22535

Invoking a SpackCommand should create a temporary `command_line` scope config that should not outlive the command invocation. That would solve most of the leaky config issues (but not all, cause there are more side effects than setting config).
