### PR TITLE
Externals with merged prefixes

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -343,17 +343,22 @@ def set_build_environment_variables(pkg, env, dirty):
     for build_dep in build_deps:
         build_and_supporting_deps.update(build_dep.traverse(deptype='run'))
 
+    # Establish an arbitrary but fixed ordering of specs so that resulting
+    # environment variable values are stable
+    def _order(specs):
+        return sorted(specs, key=lambda x: x.name)
+
     # External packages may be installed in a prefix which contains many other
     # package installs. To avoid having those installations override
     # Spack-installed packages, they are placed at the end of search paths.
     # System prefixes are removed entirely later on since they are already
     # searched.
-    build_deps = _place_externals_last(build_deps)
-    link_deps = _place_externals_last(link_deps)
-    build_link_deps = _place_externals_last(build_link_deps)
-    rpath_deps = _place_externals_last(rpath_deps)
+    build_deps = _place_externals_last(_order(build_deps))
+    link_deps = _place_externals_last(_order(link_deps))
+    build_link_deps = _place_externals_last(_order(build_link_deps))
+    rpath_deps = _place_externals_last(_order(rpath_deps))
     build_and_supporting_deps = _place_externals_last(
-        build_and_supporting_deps)
+        _order(build_and_supporting_deps))
 
     link_dirs = []
     include_dirs = []

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -306,13 +306,11 @@ def test_external_prefixes_last(mutable_config, mock_packages, working_env,
 dt-diamond-left:
   externals:
   - spec: dt-diamond-left
-    prefix: /fake/path
+    prefix: /fake/path1
   buildable: false
 """)
     spack.config.set("packages", cfg_data)
-
-    top = spack.spec.Spec('dt-diamond')
-    top.concretize()
+    top = spack.spec.Spec('dt-diamond').concretized()
 
     def _trust_me_its_a_dir(path):
         return True
@@ -327,13 +325,16 @@ dt-diamond-left:
     env_mods.apply_modifications()
     link_dir_var = os.environ['SPACK_LINK_DIRS']
     link_dirs = link_dir_var.split(':')
-    external_lib_paths = set(['/fake/path/lib', '/fake/path/lib64'])
+    external_lib_paths = set(['/fake/path1/lib', '/fake/path1/lib64'])
     # The external lib paths should be the last two entries of the list and
     # should not appear anywhere before the last two entries
     assert (set(os.path.normpath(x) for x in link_dirs[-2:]) ==
             external_lib_paths)
     assert not (set(os.path.normpath(x) for x in link_dirs[:-2]) &
                 external_lib_paths)
+    # Sanity check: under normal circumstances paths associated with
+    # dt-diamond-left would appear first
+    assert 'dt-diamond-left' < 'dt-diamond-right'
 
 
 def test_parallel_false_is_not_propagating(config, mock_packages):

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -302,6 +302,11 @@ def test_set_build_environment_variables(
 
 def test_external_prefixes_last(mutable_config, mock_packages, working_env,
                                 monkeypatch):
+    # Sanity check: under normal circumstances paths associated with
+    # dt-diamond-left would appear first. We'll mark it as external in
+    # the test to check if the associated paths are placed last.
+    assert 'dt-diamond-left' < 'dt-diamond-right'
+
     cfg_data = syaml.load_config("""\
 dt-diamond-left:
   externals:
@@ -332,9 +337,6 @@ dt-diamond-left:
             external_lib_paths)
     assert not (set(os.path.normpath(x) for x in link_dirs[:-2]) &
                 external_lib_paths)
-    # Sanity check: under normal circumstances paths associated with
-    # dt-diamond-left would appear first
-    assert 'dt-diamond-left' < 'dt-diamond-right'
 
 
 def test_parallel_false_is_not_propagating(config, mock_packages):

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -310,7 +310,7 @@ def test_external_prefixes_last(mutable_config, mock_packages, working_env,
     cfg_data = syaml.load_config("""\
 dt-diamond-left:
   externals:
-  - spec: dt-diamond-left
+  - spec: dt-diamond-left@1.0
     prefix: /fake/path1
   buildable: false
 """)

--- a/lib/spack/spack/test/build_environment.py
+++ b/lib/spack/spack/test/build_environment.py
@@ -11,6 +11,7 @@ import pytest
 import spack.build_environment
 import spack.config
 import spack.spec
+import spack.util.spack_yaml as syaml
 from spack.paths import build_env_path
 from spack.build_environment import dso_suffix, _static_to_shared_library
 from spack.build_environment import determine_number_of_jobs
@@ -297,6 +298,42 @@ def test_set_build_environment_variables(
 
     finally:
         delattr(dep_pkg, 'libs')
+
+
+def test_external_prefixes_last(mutable_config, mock_packages, working_env,
+                                monkeypatch):
+    cfg_data = syaml.load_config("""\
+dt-diamond-left:
+  externals:
+  - spec: dt-diamond-left
+    prefix: /fake/path
+  buildable: false
+""")
+    spack.config.set("packages", cfg_data)
+
+    top = spack.spec.Spec('dt-diamond')
+    top.concretize()
+
+    def _trust_me_its_a_dir(path):
+        return True
+    monkeypatch.setattr(
+        os.path, 'isdir', _trust_me_its_a_dir
+    )
+
+    env_mods = EnvironmentModifications()
+    spack.build_environment.set_build_environment_variables(
+        top.package, env_mods, False)
+
+    env_mods.apply_modifications()
+    link_dir_var = os.environ['SPACK_LINK_DIRS']
+    link_dirs = link_dir_var.split(':')
+    external_lib_paths = set(['/fake/path/lib', '/fake/path/lib64'])
+    # The external lib paths should be the last two entries of the list and
+    # should not appear anywhere before the last two entries
+    assert (set(os.path.normpath(x) for x in link_dirs[-2:]) ==
+            external_lib_paths)
+    assert not (set(os.path.normpath(x) for x in link_dirs[:-2]) &
+                external_lib_paths)
 
 
 def test_parallel_false_is_not_propagating(config, mock_packages):


### PR DESCRIPTION
Closes https://github.com/spack/spack/pull/22628
Fixes #22627

@bvanessen would you be able to check if this addresses your issue?

We remove system paths from search variables like PATH and from `-L` options because they may contain many packages and could interfere with Spack-built packages. External packages may be installed to prefixes that are not actually system paths but are still "merged" in the sense that many other packages are installed there. To avoid conflicts, this PR places all external packages at the end of search paths.

Note: if there are multiple external packages, and each is installed to a separate merged prefix, this PR does not address conflicts which may arise (in general it may not be possible to resolve the resulting conflicts so I think it might make sense to recommend against this).