### PR TITLE
Some improvements to gate package

### DIFF
--- a/var/spack/repos/builtin/packages/gate/package.py
+++ b/var/spack/repos/builtin/packages/gate/package.py
@@ -37,7 +37,7 @@ class Gate(CMakePackage):
             values=('SGE', 'condor', 'openPBS', 'openmosix', 'slurm', 'xgrid'),
             multi=False)
 
-    depends_on('geant4~threads')  # Gate needs a non-threaded geant4
+    depends_on('geant4@:10.6~threads')  # Gate needs a non-threaded geant4
     depends_on('root')
     depends_on('itk+rtk', when='+rtk')
 
@@ -49,9 +49,15 @@ class Gate(CMakePackage):
         args = []
 
         if '+rtk' in self.spec:
-            args.append('-DGATE_USE_RTK=ON')
+            args.extend([
+                '-DGATE_USE_ITK=ON',
+                '-DGATE_USE_RTK=ON',
+            ])
         else:
-            args.append('-DGATE_USE_RTK=OFF')
+            args.extend([
+                '-DGATE_USE_ITK=OFF',
+                '-DGATE_USE_RTK=OFF',
+            ])
 
         return args
 


### PR DESCRIPTION
- set constraint for geant4 to version 10.6 as gate does not work with
  geant-10.7+
- set GATE_USE_ITK: Although RTK is built under ITK, there are some ITK
  macros that need to be set explicitly.