### PR TITLE
xfsdump: Fix install error

### DIFF
--- a/var/spack/repos/builtin/packages/xfsdump/package.py
+++ b/var/spack/repos/builtin/packages/xfsdump/package.py
@@ -39,6 +39,7 @@ class Xfsdump(MakefilePackage):
              'MSGFMT={0}'.format(self.spec['gettext'].prefix.bin.msgfmt),
              'MSGMERGE={0}'.format(self.spec['gettext'].prefix.bin.msgmerge),
              'XGETTEXT={0}'.format(self.spec['gettext'].prefix.bin.xgettext),
+             'PKG_ROOT_SBIN_DIR={0}'.format(self.spec.prefix),
              'install')
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
I fixed the following install error:
Building include
Building librmt
Building common
Building inventory
Building m4
Building man
Building doc
Building po
Building debian
Building invutil
Building dump
Building restore
Building man8
chmod: changing permissions of '//sbin': Operation not permitted
chmod: gmake[1]: *** [Makefile:100: install] Error 1

The cause is that / sbin is specified in the variable PKG_ROOT_SBIN_DIR specified in the Makefile.