### PR TITLE
spack.database.Database._query() will now apply filters to concrete specs

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1424,23 +1424,19 @@ class Database(object):
         # TODO: like installed and known that can be queried?  Or are
         # TODO: these really special cases that only belong here?
 
-        # Just look up concrete specs with hashes; no fancy search.
+        # Use hash of concrete spec to index into dict, else each record must be tested.
         if isinstance(query_spec, spack.spec.Spec) and query_spec.concrete:
-            # TODO: handling of hashes restriction is not particularly elegant.
             hash_key = query_spec.dag_hash()
-            if (hash_key in self._data and
-                    (not hashes or hash_key in hashes)):
-                return [self._data[hash_key].spec]
-            else:
-                return []
+            record = self._data.get(hash_key, None)
+            records = (record,) if record else ()
+        else:
+            records = self._data.values()
 
-        # Abstract specs require more work -- currently we test
-        # against everything.
         results = []
         start_date = start_date or datetime.datetime.min
         end_date = end_date or datetime.datetime.max
 
-        for key, rec in self._data.items():
+        for rec in records:
             if hashes is not None and rec.spec.dag_hash() not in hashes:
                 continue
 

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -902,20 +902,24 @@ def test_prefix_write_lock_error(mutable_database, monkeypatch):
             assert False
 
 
-@pytest.mark.parametrize("spec, is_explicit", [("mpich@3.0.4", False), ("mpileaks@2.3", True)])
+@pytest.mark.parametrize("spec, is_explicit", [("mpich@3.0.4", False),
+                                               ("mpileaks@2.3", True)])
 @pytest.mark.parametrize("concretize", [True, False])
 @pytest.mark.parametrize("query_explicit", [True, False, any])
-def test_query_explicit(mutable_database, spec, is_explicit, concretize, query_explicit):
+def test_query_explicit(mutable_database, spec, is_explicit, concretize,
+                        query_explicit):
     # Test that Database.query() respects the explicit parameter
     s = spack.spec.Spec(spec)
     if concretize:
         s.concretize()
     expect_result = is_explicit == query_explicit or query_explicit is any
-    assert expect_result == bool(spack.store.db.query(query_spec=s, explicit=query_explicit))
+    assert expect_result == bool(spack.store.db.query(query_spec=s,
+                                                      explicit=query_explicit))
 
 
 @pytest.mark.parametrize("concretize", [True, False])
-@pytest.mark.parametrize("hashes, expect_result", [(None, True), ({"nonsense"}, False)])
+@pytest.mark.parametrize("hashes, expect_result", [(None, True),
+                                                   ({"nonsense"}, False)])
 def test_query_hashes(mutable_database, concretize, hashes, expect_result):
     # Test that Database.query() respects the hashes parameter
     s = spack.spec.Spec("mpich@3.0.4")
@@ -931,7 +935,8 @@ def test_query_installed(mutable_database, concretize, query_installed):
     s = spack.spec.Spec("mpich@3.0.4")
     if concretize:
         s.concretize()
-    assert query_installed == bool(spack.store.db.query(query_spec=s, installed=query_installed))
+    assert query_installed == bool(spack.store.db.query(query_spec=s,
+                                                        installed=query_installed))
 
 
 @pytest.mark.parametrize("concretize", [True, False])
@@ -941,7 +946,8 @@ def test_query_known(mutable_database, concretize, query_known):
     s = spack.spec.Spec("mpich@3.0.4")
     if concretize:
         s.concretize()
-    assert bool(query_known) == bool(spack.store.db.query(query_spec=s, known=query_known))
+    assert bool(query_known) == bool(spack.store.db.query(query_spec=s,
+                                                          known=query_known))
 
 
 @pytest.mark.parametrize("concretize", [True, False])
@@ -953,5 +959,5 @@ def test_query_date(mutable_database, concretize, start, end):
     if concretize:
         s.concretize()
     expect_result = start != datetime.datetime.max and end != datetime.datetime.min
-    assert expect_result == bool(spack.store.db.query(query_spec=s, start_date=start, end_date=end))
-
+    assert expect_result == bool(spack.store.db.query(query_spec=s,
+                                                      start_date=start, end_date=end))

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -919,7 +919,7 @@ def test_query_explicit(mutable_database, spec, is_explicit, concretize,
 
 @pytest.mark.parametrize("concretize", [True, False])
 @pytest.mark.parametrize("hashes, expect_result", [(None, True),
-                                                   ({"nonsense"}, False)])
+                                                   (["nonsense"], False)])
 def test_query_hashes(mutable_database, concretize, hashes, expect_result):
     # Test that Database.query() respects the hashes parameter
     s = spack.spec.Spec("mpich@3.0.4")

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -900,3 +900,58 @@ def test_prefix_write_lock_error(mutable_database, monkeypatch):
     with pytest.raises(Exception):
         with spack.store.db.prefix_write_lock(s):
             assert False
+
+
+@pytest.mark.parametrize("spec, is_explicit", [("mpich@3.0.4", False), ("mpileaks@2.3", True)])
+@pytest.mark.parametrize("concretize", [True, False])
+@pytest.mark.parametrize("query_explicit", [True, False, any])
+def test_query_explicit(mutable_database, spec, is_explicit, concretize, query_explicit):
+    # Test that Database.query() respects the explicit parameter
+    s = spack.spec.Spec(spec)
+    if concretize:
+        s.concretize()
+    expect_result = is_explicit == query_explicit or query_explicit is any
+    assert expect_result == bool(spack.store.db.query(query_spec=s, explicit=query_explicit))
+
+
+@pytest.mark.parametrize("concretize", [True, False])
+@pytest.mark.parametrize("hashes, expect_result", [(None, True), ({"nonsense"}, False)])
+def test_query_hashes(mutable_database, concretize, hashes, expect_result):
+    # Test that Database.query() respects the hashes parameter
+    s = spack.spec.Spec("mpich@3.0.4")
+    if concretize:
+        s.concretize()
+    assert expect_result == bool(spack.store.db.query(query_spec=s, hashes=hashes))
+
+
+@pytest.mark.parametrize("concretize", [True, False])
+@pytest.mark.parametrize("query_installed", [True, False])
+def test_query_installed(mutable_database, concretize, query_installed):
+    # Test that Database.query() respects the installed parameter
+    s = spack.spec.Spec("mpich@3.0.4")
+    if concretize:
+        s.concretize()
+    assert query_installed == bool(spack.store.db.query(query_spec=s, installed=query_installed))
+
+
+@pytest.mark.parametrize("concretize", [True, False])
+@pytest.mark.parametrize("query_known", [True, False, any])
+def test_query_known(mutable_database, concretize, query_known):
+    # Test that Database.query() respects the known parameter
+    s = spack.spec.Spec("mpich@3.0.4")
+    if concretize:
+        s.concretize()
+    assert bool(query_known) == bool(spack.store.db.query(query_spec=s, known=query_known))
+
+
+@pytest.mark.parametrize("concretize", [True, False])
+@pytest.mark.parametrize("start", [None, datetime.datetime.min, datetime.datetime.max])
+@pytest.mark.parametrize("end", [None, datetime.datetime.min, datetime.datetime.max])
+def test_query_date(mutable_database, concretize, start, end):
+    # Test that Database.query() respects the start/end date parameter
+    s = spack.spec.Spec("mpich@3.0.4")
+    if concretize:
+        s.concretize()
+    expect_result = start != datetime.datetime.max and end != datetime.datetime.min
+    assert expect_result == bool(spack.store.db.query(query_spec=s, start_date=start, end_date=end))
+


### PR DESCRIPTION
Currently, if a concrete spec is passed to `spack.database.Database._query()` only the `hashes` filter is applied. This PR applies the same logic to concrete and abstract specs and adds tests for all `_query()` parameters.

Example use case where false positives are returned:
```python
concrete_spec = ...  # a concrete spec based on result of 'spack find -X'
spack.store.db.query(query_spec=concrete_spec, explicit=True)  # returns implicit and explicit specs with same hash as concrete_spec
```
