### PR TITLE
xfsprogs: add 5.11.0 and fix build with newer versions of gcc

### DIFF
--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -12,15 +12,23 @@ class Xfsprogs(AutotoolsPackage):
     homepage = "http://oss.sgi.com/projects/xfs/"
     url      = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-4.17.0.tar.xz"
 
-    version('5.8.0', sha256='8ef46ed9e6bb927f407f541dc4324857c908ddf1374265edc910d23724048c6b')
-    version('5.7.0', sha256='8f2348a68a686a3f4491dda5d62dd32d885fbc52d32875edd41e2c296e7b4f35')
-    version('5.6.0', sha256='0aba2aac5d80d07646dde868437fc337af2c7326edadcc6d6a7c0bfd3190c1e6')
+    version('5.11.0', sha256='0e9c390fcdbb8a79e1b8f5e6e25fd529fc9f9c2ef8f2d5e647b3556b82d1b353')
+    version('5.8.0',  sha256='8ef46ed9e6bb927f407f541dc4324857c908ddf1374265edc910d23724048c6b')
+    version('5.7.0',  sha256='8f2348a68a686a3f4491dda5d62dd32d885fbc52d32875edd41e2c296e7b4f35')
+    version('5.6.0',  sha256='0aba2aac5d80d07646dde868437fc337af2c7326edadcc6d6a7c0bfd3190c1e6')
 
     version('4.20.0', sha256='beafdfd080352a8c9d543491e0874d0e8809cb643a3b9d352d5feed38d77022a')
 
     depends_on('gettext')
     depends_on('uuid')
     depends_on('util-linux')
+
+    def flag_handler(self, name, flags):
+        iflags = []
+        if name == 'cflags':
+            if self.spec.satisfies('@:5.4.0 %gcc@10:'):
+                iflags.append('-fcommon')
+        return (iflags, None, flags)
 
     def setup_build_environment(self, env):
         env.append_path('C_INCLUDE_PATH',


### PR DESCRIPTION
xfsdump depends on an older version of xfsprogs that does not build with recent versions of gcc.