### PR TITLE
FastJet: Add new package versions for FastJet and contrib

### DIFF
--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -19,6 +19,7 @@ class Fastjet(AutotoolsPackage):
 
     maintainers = ['drbenmorgan', 'vvolkl']
 
+    version('3.3.4', sha256='432b51401e1335697c9248519ce3737809808fc1f6d1644bfae948716dddfc03')
     version('3.3.3', sha256='30b0a0282ce5aeac9e45862314f5966f0be941ce118a83ee4805d39b827d732b')
     version('3.3.2', sha256='3f59af13bfc54182c6bb0b0a6a8541b409c6fda5d105f17e03c4cce8db9963c2')
     version('3.3.1', sha256='76bfed9b87e5efdb93bcd0f7779e27427fbe38e05fe908c2a2e80a9ca0876c53')

--- a/var/spack/repos/builtin/packages/fjcontrib/package.py
+++ b/var/spack/repos/builtin/packages/fjcontrib/package.py
@@ -16,6 +16,7 @@ class Fjcontrib(AutotoolsPackage):
 
     tags = ['hep']
 
+    version('1.045', sha256='667f15556ca371cfaf185086fb41ac579658a233c18fb1e5153382114f9785f8')
     version('1.044', sha256='de3f45c2c1bed6d7567483e4a774575a504de8ddc214678bac7f64e9d2e7e7a7')
     version('1.043', sha256='ef0f586b19ffd12f392b7facc890a73d31fc11b9f5bb727cf3743d6eb59e9993')
     version('1.042', sha256='5b052e93a371c557557fa4a293cca4b08f88ccfb6c43a4df15b2a9f38c6d8831')


### PR DESCRIPTION
Newest versions of FastJet and FastJet contrib packages.

Due to the server configuration of fastjet fetching from them currently fails: see #20050 and #20064 for a possible fix.