### PR TITLE
Squashfuse: Enable or disable static and shared libs, and allow min size builds too, useful for appimages

### DIFF
--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -19,11 +19,17 @@ class Squashfuse(AutotoolsPackage):
     version('0.1.104', sha256='aa52460559e0d0b1753f6b1af5c68cfb777ca5a13913285e93f4f9b7aa894b3a')
     version('0.1.103', sha256='42d4dfd17ed186745117cfd427023eb81effff3832bab09067823492b6b982e7')
 
+    variant('shared', default=True, description='Enable shared libraries')
+    variant('static', default=True, description='Enable static libraries')
+    variant('min_size', default=False, description='Build small binaries')
+
     variant('zlib', default=True, description='Enable zlib/gzip compression support')
     variant('lz4', default=True, description='Enable LZ4 compression support')
     variant('lzo', default=True, description='Enable LZO compression support')
     variant('xz', default=True, description='Enable xz compression support')
     variant('zstd', default=True, description='Enable Zstandard/zstd support')
+
+    conflicts('~shared', when='~static', msg="Enable shared, static or both")
 
     depends_on('libfuse@2.5:')
     depends_on('libfuse@:2.99', when='@:0.1.103')
@@ -45,8 +51,18 @@ class Squashfuse(AutotoolsPackage):
     depends_on('automake', type='build', when='master')
     depends_on('libtool',  type='build', when='master')
 
+    def flag_handler(self, name, flags):
+        if name == 'cflags' and '+min_size' in self.spec:
+            if '-Os' in self.compiler.opt_flags:
+                flags.append('-Os')
+                return (None, None, flags)
+
+        return (flags, None, None)
+
     def configure_args(self):
         args = ['--disable-demo']
+        args += self.enable_or_disable('shared')
+        args += self.enable_or_disable('static')
         args += self.with_or_without('zlib', activation_value='prefix')
         args += self.with_or_without('lz4', activation_value='prefix')
         args += self.with_or_without('lzo', activation_value='prefix')

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -46,10 +46,10 @@ class Squashfuse(AutotoolsPackage):
     depends_on('xz', when='+xz')
     depends_on('zstd', when='+zstd')
 
-    depends_on('m4',       type='build', when='master')
-    depends_on('autoconf', type='build', when='master')
-    depends_on('automake', type='build', when='master')
-    depends_on('libtool',  type='build', when='master')
+    depends_on('m4',       type='build', when='@master')
+    depends_on('autoconf', type='build', when='@master')
+    depends_on('automake', type='build', when='@master')
+    depends_on('libtool',  type='build', when='@master')
 
     def flag_handler(self, name, flags):
         if name == 'cflags' and '+min_size' in self.spec:


### PR DESCRIPTION
This together with the zstd pr allows one to get minimal binaries for squashfuse, which would allow one to create small self-extracting executables (e.g. appimages):

```console
$ spack install squashfuse +min_size ~shared ~xz ~zlib ~lzo ~lz4 +zstd ^zstd ~shared build_type=MinSizeRel
...

$ du -sh squashfuse_ll
112K	squashfuse_ll

$ libtree squashfuse_ll
squashfuse_ll
└── libfuse3.so.3 [rpath]
```

