### PR TITLE
cdo: help libtool to find the correct paths to libraries

### DIFF
--- a/var/spack/repos/builtin/packages/cdo/package.py
+++ b/var/spack/repos/builtin/packages/cdo/package.py
@@ -15,7 +15,7 @@ class Cdo(AutotoolsPackage):
     url = 'https://code.mpimet.mpg.de/attachments/download/12760/cdo-1.7.2.tar.gz'
     list_url = 'https://code.mpimet.mpg.de/projects/cdo/files'
 
-    maintainers = ['skosukhin']
+    maintainers = ['skosukhin', 'Try2Code']
 
     version('1.9.10', sha256='cc39c89bbb481d7b3945a06c56a8492047235f46ac363c4f0d980fccdde6677e', url='https://code.mpimet.mpg.de/attachments/download/24638/cdo-1.9.10.tar.gz')
     version('1.9.9', sha256='959b5b58f495d521a7fd1daa84644888ec87d6a0df43f22ad950d17aee5ba98d', url='https://code.mpimet.mpg.de/attachments/download/23323/cdo-1.9.9.tar.gz')


### PR DESCRIPTION
1. Add @Try2Code as a maintainer.
2. Help Libtool to find the correct `hdf5` library (we relied on the `netcdf.la` before #18850).
3. Avoid `-I` and `-L` flags with system paths.
4. Enable `eccodes` GRIB2 backend for older versions of `cdo`.