### PR TITLE
hotfix: make `ifx` work with `autoconf` <= 2.69 in spack

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -311,6 +311,14 @@ while [ -n "$1" ]; do
             fi
             ;;
         -l*)
+            # -loopopt=0 is passed to the linker erroneously in
+            # autoconf <= 2.69. Filter it out.
+            # TODO: generalize filtering of args with an env var, so that
+            # TODO: we do not have to special case this here.
+            if [ "$mode" = "ld" ] && [ "$1" != "${1#-loopopt}" ]; then
+                shift
+                continue
+            fi
             arg="${1#-l}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             other_args+=("-l$arg")

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -622,3 +622,17 @@ def test_filter_enable_new_dtags(wrapper_flags):
         result = cc(*(test_args + ['-Wl,--enable-new-dtags']), output=str)
         result = result.strip().split('\n')
         assert '-Wl,--enable-new-dtags' not in result
+
+
+@pytest.mark.regression('22643')
+def test_linker_strips_loopopt(wrapper_flags):
+    with set_env(SPACK_TEST_COMMAND='dump-args'):
+        # ensure that -loopopt=0 is not present in ld mode
+        result = ld(*(test_args + ["-loopopt=0"]), output=str)
+        result = result.strip().split('\n')
+        assert '-loopopt=0' not in result
+
+        # ensure that -loopopt=0 is present in compile mode
+        result = cc(*(test_args + ["-loopopt=0"]), output=str)
+        result = result.strip().split('\n')
+        assert '-loopopt=0' in result


### PR DESCRIPTION
Fixes #22643.

Autoconf before 2.70 will erroneously pass `ifx`'s -loopopt argument to the linker, requiring all packages to use autoconf 2.70 or newer to use `ifx`.

This is a hotfix enabling `ifx` to be used in Spack. Instead of bothering to upgrade autoconf for every package, we'll just strip out the problematic flag if we're in `ld` mode.

- [x] Add a conditional to the `cc` wrapper to skip `-loopopt` in `ld` mode. This can probably be generalized in the future to strip more things (e.g., via an environment variable we can constrol from Spack) but it's good enough for now.

- [x] Add a test ensuring that `-loopopt` arguments are stripped in link mode, but not in compile mode.