### PR TITLE
petsc@3.15.0, py-petsc4py@3.15.0

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -12,13 +12,16 @@ class Petsc(Package):
     """
 
     homepage = "http://www.mcs.anl.gov/petsc/index.html"
-    url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.13.1.tar.gz"
+    url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.15.0.tar.gz"
     git = "https://gitlab.com/petsc/petsc.git"
     maintainers = ['balay', 'barrysmith', 'jedbrown']
 
     version('main', branch='main')
     version('xsdk-0.2.0', tag='xsdk-0.2.0')
 
+    version('3.15.0', sha256='ac46db6bfcaaec8cd28335231076815bd5438f401a4a05e33736b4f9ff12e59a')
+    version('3.14.6', sha256='4de0c8820419fb15bc683b780127ff57067b62ca18749e864a87c6d7c93f1230')
+    version('3.14.5', sha256='8b8ff5c4e10468f696803b354a502d690c7d25c19d694a7e10008a302fdbb048')
     version('3.14.4', sha256='b030969816e02c251a6d010c07a90b69ade44932f9ddfac3090ff5e95ab97d5c')
     version('3.14.3', sha256='63ed7e3440f2bbc732a6c44aa878364f88f5016ab375d9b36d742893a049053d')
     version('3.14.2', sha256='87a04fd05cac20a2ec47094b7d18b96e0651257d8c768ced2ef7db270ecfb9cb')
@@ -269,9 +272,12 @@ class Petsc(Package):
     depends_on('saws', when='+saws')
     depends_on('libyaml', when='+libyaml')
 
+    # Using the following tarballs
+    # * petsc-3.12 (and older) - includes docs
+    # * petsc-lite-3.13, petsc-lite-3.14 (without docs)
+    # * petsc-3.15 and newer (without docs)
     def url_for_version(self, version):
-        if version >= Version('3.13.0'):
-            # petsc-lite tarballs are smaller by skipping docs
+        if version >= Version('3.13.0') and version < Version('3.15.0'):
             return "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-{0}.tar.gz".format(version)
         else:
             return "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-{0}.tar.gz".format(version)

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -277,7 +277,7 @@ class Petsc(Package):
     # * petsc-lite-3.13, petsc-lite-3.14 (without docs)
     # * petsc-3.15 and newer (without docs)
     def url_for_version(self, version):
-        if version >= Version('3.13.0') and version < Version('3.15.0'):
+        if self.spec.satisfies('@3.13.0:3.14.6'):
             return "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-{0}.tar.gz".format(version)
         else:
             return "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-{0}.tar.gz".format(version)

--- a/var/spack/repos/builtin/packages/py-petsc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-petsc4py/package.py
@@ -11,12 +11,13 @@ class PyPetsc4py(PythonPackage):
     """
 
     homepage = "https://gitlab.com/petsc/petsc4py"
-    pypi = "petsc4py/petsc4py-3.14.0.tar.gz"
+    url      = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc4py-3.15.0.tar.gz"
     git      = "https://gitlab.com/petsc/petsc.git"
 
     maintainers = ['dalcinl', 'balay']
 
     version('main', branch='main')
+    version('3.15.0', sha256='87dcc5ef63a1f0e1a963619f7527e623f52341b2806056b0ef5fdfb0b8b287ad')
     version('3.14.1', sha256='f5f8daf3a4cd1dfc945876b0d83a05b25f3c54e08046312eaa3e3036b24139c0')
     version('3.14.0', sha256='33ac9fb55a541e4c1deabd6e2144da96d5ae70e70c830a55de558000cf3f0ec5')
     version('3.13.0', sha256='0e11679353c0c2938336a3c8d1a439b853e20d3bccd7d614ad1dbea3ec5cb31f')
@@ -44,6 +45,7 @@ class PyPetsc4py(PythonPackage):
     depends_on('petsc+mpi', when='+mpi')
     depends_on('petsc~mpi', when='~mpi')
     depends_on('petsc@main', when='@main')
+    depends_on('petsc@3.15.0:3.15.99', when='@3.15.0:3.15.99')
     depends_on('petsc@3.14.2:3.14.99', when='@3.14.1:3.14.99')
     depends_on('petsc@3.14.0:3.14.1', when='@3.14.0')
     depends_on('petsc@3.13:3.13.99', when='@3.13:3.13.99')


### PR DESCRIPTION
Notes:
- since petsc and petsc4py tarballs are now spun together and hosted together - I've changed the download URL for petsc4py [copied over the older version tarballs to this location]
- petsc changed the role of petsc.tar.gz vs petsc-lite.tar.gz - so updated accordingly.

cc: @dalcinl @joseeroman @s-sajid-ali 