### PR TITLE
Adding MPIRunner for mpi providers

### DIFF
--- a/lib/spack/spack/test/util/mpi.py
+++ b/lib/spack/spack/test/util/mpi.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import llnl.util.filesystem as fs
+import spack.util.mpi as mpi
+
+
+def test_mpirunner(tmpdir):
+    tmpdir_str = str(tmpdir)
+    os.environ["PATH"] = tmpdir_str
+    assert mpi.MPIRunner.query_mgr_pref('srun', tmpdir_str) is None
+
+    with tmpdir.as_cwd():
+        fs.touch("srun")
+        fs.set_executable('srun')
+        runner = mpi.MPIRunner.query_mgr_pref('srun', tmpdir_str)
+        assert runner.manager == 'slurm'
+        assert runner.exe is not None
+
+        fs.touch("mpirun")
+        fs.set_executable('mpirun')
+        runner = mpi.MPIRunner.query_mpi_pref(tmpdir_str)
+        assert runner.manager == 'mpirun'
+        assert runner.exe is not None
+
+        fs.touch("mpiexec")
+        fs.set_executable('mpiexec')
+        runner = mpi.MPIRunner.query_mpi_pref(tmpdir_str)
+        assert runner.manager == 'mpiexec'
+        assert runner.exe is not None

--- a/lib/spack/spack/test/util/mpi.py
+++ b/lib/spack/spack/test/util/mpi.py
@@ -6,29 +6,92 @@
 import os
 
 import llnl.util.filesystem as fs
-import spack.util.mpi as mpi
+from spack.util.mpi import MPIRunner
+import spack.config
+
+
+runner_conf_specific = {
+    'mpirunner_cfg': {
+        'mpi_runner_cmd': 'srun',
+        'mpi_runner_np_flags': '--sflags',
+        'mpi_runner_pre_np_flags': '--pre',
+        'mpi_runner_post_np_flags': '--post'
+    }
+}
+
+runner_conf_general = {
+    'mpi_runner_cmd': 'mpirunrun',
+    'mpi_runner_pre_np_flags': '-p'
+}
 
 
 def test_mpirunner(tmpdir):
+    with spack.config.override('config', runner_conf_specific):
+        runner = MPIRunner.create_from_conf_key('mpirunner_cfg')
+
+        cfg_dict = runner_conf_specific['mpirunner_cfg']
+        assert runner.cmd == cfg_dict['mpi_runner_cmd']
+        assert runner.np_flags == cfg_dict['mpi_runner_np_flags']
+        assert runner.pre_np_flags == cfg_dict['mpi_runner_pre_np_flags']
+        assert runner.post_np_flags == cfg_dict['mpi_runner_post_np_flags']
+        assert runner.full_cmd(2) == 'srun --pre --sflags 2 --post'
+        assert runner.full_cmd(1) == 'srun --pre --sflags 1 --post'
+
+    with spack.config.override('config', runner_conf_general):
+        runner = MPIRunner.create_from_conf_key('nonexistent_conf')
+
+        assert runner.cmd == runner_conf_general['mpi_runner_cmd']
+        assert runner.np_flags == MPIRunner.default_np_flags
+        assert runner.pre_np_flags == runner_conf_general['mpi_runner_pre_np_flags']
+        assert runner.post_np_flags == ''
+
+        opts = runner.full_opts()
+        assert len(opts) == 3
+        assert opts[0] == runner.pre_np_flags
+        assert opts[1] == runner.np_flags
+        assert opts[2] == '1'
+
+        runner_2 = MPIRunner.create_from_conf(runner_conf_general)
+
+        assert runner.cmd == runner_2.cmd
+        assert runner.np_flags == runner_2.np_flags
+        assert runner.pre_np_flags == runner_2.pre_np_flags
+        assert runner.post_np_flags == runner_2.post_np_flags
+
     tmpdir_str = str(tmpdir)
     os.environ["PATH"] = tmpdir_str
-    assert mpi.MPIRunner.query_mgr_pref('srun', tmpdir_str) is None
+
+    runner = MPIRunner.query_res_manager('srun', tmpdir_str)
+
+    assert runner.cmd == fs.join_path(tmpdir_str, 'mpiexec')
+    assert runner.np_flags == MPIRunner.default_np_flags
+    assert runner.pre_np_flags == ''
+    assert runner.post_np_flags == ''
 
     with tmpdir.as_cwd():
-        fs.touch("srun")
+        fs.touch('srun')
         fs.set_executable('srun')
-        runner = mpi.MPIRunner.query_mgr_pref('srun', tmpdir_str)
-        assert runner.manager == 'slurm'
-        assert runner.exe is not None
+        runner = MPIRunner.query_res_manager('srun', tmpdir_str)
+        assert runner.cmd.split('/')[-1] == 'srun'
+        assert runner.np_flags == MPIRunner.default_np_flags
+        assert runner.pre_np_flags == ''
+        assert runner.post_np_flags == ''
 
-        fs.touch("mpirun")
-        fs.set_executable('mpirun')
-        runner = mpi.MPIRunner.query_mpi_pref(tmpdir_str)
-        assert runner.manager == 'mpirun'
-        assert runner.exe is not None
+        with spack.config.override('config', runner_conf_specific):
+            runner = MPIRunner.create_def_runner(
+                'test.mpirunner_cfg', tmpdir_str)
 
-        fs.touch("mpiexec")
-        fs.set_executable('mpiexec')
-        runner = mpi.MPIRunner.query_mpi_pref(tmpdir_str)
-        assert runner.manager == 'mpiexec'
-        assert runner.exe is not None
+            cfg_dict = runner_conf_specific['mpirunner_cfg']
+            assert runner.cmd == cfg_dict['mpi_runner_cmd']
+            assert runner.np_flags == cfg_dict['mpi_runner_np_flags']
+            assert runner.pre_np_flags == cfg_dict['mpi_runner_pre_np_flags']
+            assert runner.post_np_flags == cfg_dict['mpi_runner_post_np_flags']
+            assert runner.full_cmd(2) == 'srun --pre --sflags 2 --post'
+            assert runner.full_cmd(1) == 'srun --pre --sflags 1 --post'
+
+        runner = MPIRunner.create_def_runner('test.mpirunner_cfg', tmpdir_str)
+
+        assert runner.cmd.split('/')[-1] == 'srun'
+        assert runner.np_flags == MPIRunner.default_np_flags
+        assert runner.pre_np_flags == ''
+        assert runner.post_np_flags == ''

--- a/lib/spack/spack/test/util/mpi.py
+++ b/lib/spack/spack/test/util/mpi.py
@@ -37,6 +37,13 @@ def test_mpirunner(tmpdir):
         assert runner.full_cmd(2) == 'srun --pre --sflags 2 --post'
         assert runner.full_cmd(1) == 'srun --pre --sflags 1 --post'
 
+        opts = runner.full_opts(2)
+        assert len(opts) == 4
+        assert opts[0] == runner.pre_np_flags
+        assert opts[1] == runner.np_flags
+        assert opts[2] == '2'
+        assert opts[3] == runner.post_np_flags
+
     with spack.config.override('config', runner_conf_general):
         runner = MPIRunner.create_from_conf_key('nonexistent_conf')
 

--- a/lib/spack/spack/util/mpi.py
+++ b/lib/spack/spack/util/mpi.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.util.executable import Executable, which
+from llnl.util.filesystem import join_path
+
+
+class MPIRunner(object):
+    """ Class representing a resource manager command to run MPI-based code."""
+
+    def __init__(self, cmd, mgr_type):
+        self.exe = Executable(cmd)
+        self.manager = mgr_type
+
+    @property
+    def command(self):
+        """The command-line string for the resource manager.
+
+        Returns:
+            str: The executable and default arguments
+        """
+        return self.exe.command
+
+    @staticmethod
+    def query_mpi_pref(mpi_bin_dir):
+        """Constructs a new MPIRunner object by querying the given path.
+
+        Returns:
+            MPIRunner: MPIRunner object
+        """
+        runner_cmd = which(join_path(mpi_bin_dir, 'mpiexec'),
+                           join_path(mpi_bin_dir, 'mpirun'))
+        if not runner_cmd:
+            return None
+        else:
+            return MPIRunner(runner_cmd.command, runner_cmd.name)
+
+    @staticmethod
+    def query_mgr_pref(mgr, mpi_bin_dir):
+        """Constructs a new MPIRunner object by first querying the given resource
+        manager and if unsuccessful querying the given mpi path.
+
+        Returns:
+            MPIRunner: MPIRunner object
+        """
+        mgr_names = ['slurm']   # Add other process managers in the future
+        mgr_exes = ['srun']
+        mgr_sel = [p[1] for p in zip(mgr_exes, mgr_names) if p[0] == mgr][0]
+
+        mgr_cmd = which(mgr)
+        if mgr_cmd:
+            return MPIRunner(mgr_cmd.command, mgr_sel)
+        else:
+            return MPIRunner.query_mpi_pref(mpi_bin_dir)

--- a/lib/spack/spack/util/mpi.py
+++ b/lib/spack/spack/util/mpi.py
@@ -7,24 +7,26 @@ from llnl.util.filesystem import join_path
 import spack.config
 
 
-class MPIRunner(object):
-    """Class representing a resource manager command to run MPI-based code.
+# Class representing a resource manager command to run MPI-based code.
+#
+# A number of static methods are provided to help create MPIRunner's in
+# different ways. Users can set parameters in config files and create a
+# runner from these parameters. For example, the following section in
+# config.yaml provides special params for 'mvapich2' package:
+# 'mvapich2': {
+#     'mpi_runner_cmd': 'mpiexec',
+#     'mpi_runner_np_flags': '--npflags',
+#     'mpi_runner_pre_np_flags': '--pre',
+#     'mpi_runner_post_np_flags': '--post'
+# }
+# Users can also set parameters in a top level config section:
+# 'mpi_runner_cmd': 'srun',
+# 'mpi_runner_pre_np_flags': '-np'
+# The static function 'create_from_conf_key' first tries the provided
+# config section and then goes to the top level conf params.
 
-    A number of static methods are provided to help create MPIRunner's in
-    different ways. Users can set parameters in config files and create a
-    runner from these parameters. For example, the following section in
-    config.yaml provides special params for 'mvapich2' package:
-    'mvapich2': {
-        'mpi_runner_cmd': 'mpiexec',
-        'mpi_runner_np_flags': '--npflags',
-        'mpi_runner_pre_np_flags': '--pre',
-        'mpi_runner_post_np_flags': '--post'
-    }
-    Users can also set parameters in a top level config section:
-    'mpi_runner_cmd': 'srun',
-    'mpi_runner_pre_np_flags': '-np'
-    The static function 'create_from_conf_key' first tries the provided
-    config section and then goes to the top level conf params."""
+class MPIRunner(object):
+    """Class representing a resource manager command to run MPI-based code."""
 
     default_np_flags = '-n'
 
@@ -97,7 +99,7 @@ class MPIRunner(object):
     def create_def_runner(full_pkg_name, mpi_bindir):
         """First try specific runner config corresponding to the package name
         and then top level config; if neither is defined initialize the runner
-        with 'srun' or 'mpiexec'
+        with 'srun' or 'mpiexec'.
 
         Returns:
             MPIRunner: runner or None if conf is not defined
@@ -113,7 +115,7 @@ class MPIRunner(object):
     @staticmethod
     def query_res_manager(res_mgr, mpi_bindir):
         """Creates a runner for given resource manager; if resource manager
-        was not found, falls back to 'mpiexec' at given directory
+        was not found, falls back to 'mpiexec' at given directory.
 
         Returns:
             MPIRunner:

--- a/lib/spack/spack/util/mpi.py
+++ b/lib/spack/spack/util/mpi.py
@@ -2,54 +2,125 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from spack.util.executable import Executable, which
+from spack.util.executable import which
 from llnl.util.filesystem import join_path
+import spack.config
 
 
 class MPIRunner(object):
-    """ Class representing a resource manager command to run MPI-based code."""
+    """ Class representing a resource manager command to run MPI-based code.
 
-    def __init__(self, cmd, mgr_type):
-        self.exe = Executable(cmd)
-        self.manager = mgr_type
+    A number of static methods are provided to help create MPIRunner's in
+    different ways. Users can set parameters in config files and create a
+    runner from these parameters. For example, the following section in
+    config.yaml provides special params for 'mvapich2' package:
+    'mvapich2': {
+        'mpi_runner_cmd': 'mpiexec',
+        'mpi_runner_np_flags': '--npflags',
+        'mpi_runner_pre_np_flags': '--pre',
+        'mpi_runner_post_np_flags': '--post'
+    }
+    Users can also set parameters in a top level config section:
+    'mpi_runner_cmd': 'srun',
+    'mpi_runner_pre_np_flags': '-np'
+    The static function 'create_from_conf_key' first tries the provided
+    config section and then goes to the top level conf params.
+    """
 
-    @property
-    def command(self):
+    default_np_flags = '-n'
+
+    def __init__(self, cmd, np_flags=default_np_flags, pre_np_flags='',
+                 post_np_flags=''):
+        self.cmd = cmd
+        self.np_flags = np_flags
+        self.pre_np_flags = pre_np_flags
+        self.post_np_flags = post_np_flags
+
+    def full_cmd(self, np=1):
         """The command-line string for the resource manager.
 
         Returns:
             str: The executable and default arguments
         """
-        return self.exe.command
+        complete_cmd = '{0} {1} {2} {3} {4}'.format(
+            self.cmd,
+            self.pre_np_flags,
+            self.np_flags,
+            np,
+            self.post_np_flags)
+        return complete_cmd
 
-    @staticmethod
-    def query_mpi_pref(mpi_bin_dir):
-        """Constructs a new MPIRunner object by querying the given path.
-
-        Returns:
-            MPIRunner: MPIRunner object
-        """
-        runner_cmd = which(join_path(mpi_bin_dir, 'mpiexec'),
-                           join_path(mpi_bin_dir, 'mpirun'))
-        if not runner_cmd:
-            return None
-        else:
-            return MPIRunner(runner_cmd.command, runner_cmd.name)
-
-    @staticmethod
-    def query_mgr_pref(mgr, mpi_bin_dir):
-        """Constructs a new MPIRunner object by first querying the given resource
-        manager and if unsuccessful querying the given mpi path.
+    def full_opts(self, np=1):
+        """The list of options for the resource manager.
 
         Returns:
-            MPIRunner: MPIRunner object
+            str: The executable and default arguments
         """
-        mgr_names = ['slurm']   # Add other process managers in the future
-        mgr_exes = ['srun']
-        mgr_sel = [p[1] for p in zip(mgr_exes, mgr_names) if p[0] == mgr][0]
+        opts = []
+        if self.pre_np_flags != '':
+            opts.extend([self.pre_np_flags])
+        if self.np_flags != '':
+            opts.extend([self.np_flags])
+            opts.extend([str(np)])
+        if self.post_np_flags != '':
+            opts.extend([self.post_np_flags])
+        return opts
 
-        mgr_cmd = which(mgr)
-        if mgr_cmd:
-            return MPIRunner(mgr_cmd.command, mgr_sel)
+    @staticmethod
+    def create_from_conf(cfg):
+        if cfg and 'mpi_runner_cmd' in cfg:
+            return MPIRunner(
+                cfg['mpi_runner_cmd'],
+                cfg.get('mpi_runner_np_flags', MPIRunner.default_np_flags),
+                cfg.get('mpi_runner_pre_np_flags', ''),
+                cfg.get('mpi_runner_post_np_flags', ''))
+        return None
+
+    @staticmethod
+    def create_from_conf_key(cfg_key):
+        """Creates a runner from config parameters; first tries the given
+        specific config key and then the top level conf.
+
+        Returns:
+            MPIRunner: runner or None if conf is not defined
+        """
+        runner = None
+        cfg = spack.config.get('config:{0}'.format(cfg_key))  # Specific conf
+        if cfg:
+            runner = MPIRunner.create_from_conf(cfg)
         else:
-            return MPIRunner.query_mpi_pref(mpi_bin_dir)
+            cfg = spack.config.get('config')  # Top level
+            runner = MPIRunner.create_from_conf(cfg)
+
+        return runner
+
+    @staticmethod
+    def create_def_runner(full_pkg_name, mpi_bindir):
+        """First try specific runner config corresponding to the package name
+        and then top level config; if neither is defined initialize the runner
+        with 'srun' or 'mpiexec'
+
+        Returns:
+            MPIRunner: runner or None if conf is not defined
+        """
+        pkg_name = full_pkg_name.split('.')[-1]
+        runner = MPIRunner.create_from_conf_key(pkg_name)
+
+        if not runner:
+            return MPIRunner.query_res_manager('srun', mpi_bindir)
+
+        return runner
+
+    @staticmethod
+    def query_res_manager(res_mgr, mpi_bindir):
+        """Creates a runner for given resource manager; if resource manager
+        was not found, falls back to 'mpiexec' at given directory
+
+        Returns:
+            MPIRunner:
+        """
+        mgr_exe = which(res_mgr)
+        if mgr_exe:
+            return MPIRunner(mgr_exe.command)
+        else:
+            return MPIRunner(join_path(mpi_bindir, 'mpiexec'))

--- a/lib/spack/spack/util/mpi.py
+++ b/lib/spack/spack/util/mpi.py
@@ -8,7 +8,7 @@ import spack.config
 
 
 class MPIRunner(object):
-    """ Class representing a resource manager command to run MPI-based code.
+    """Class representing a resource manager command to run MPI-based code.
 
     A number of static methods are provided to help create MPIRunner's in
     different ways. Users can set parameters in config files and create a
@@ -24,8 +24,7 @@ class MPIRunner(object):
     'mpi_runner_cmd': 'srun',
     'mpi_runner_pre_np_flags': '-np'
     The static function 'create_from_conf_key' first tries the provided
-    config section and then goes to the top level conf params.
-    """
+    config section and then goes to the top level conf params."""
 
     default_np_flags = '-n'
 

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.util.mpi import MPIRunner
 
 
 class CrayMpich(Package):
@@ -53,6 +54,11 @@ class CrayMpich(Package):
             join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
+
+        spec.runner = MPIRunner.query_mgr_pref(
+            'srun',
+            self.prefix.bin
+        )
 
     def install(self, spec, prefix):
         raise InstallError(

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -55,12 +55,8 @@ class CrayMpich(Package):
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        # First query for 'srun' in the environment and if it doesn't exist
-        # use either 'mpirun' or 'mpiexec'
-        spec.runner = MPIRunner.query_mgr_pref(
-            'srun',
-            self.prefix.bin
-        )
+        self.spec.mpirunner = MPIRunner.create_def_runner(
+            __name__, self.prefix.bin)
 
     def install(self, spec, prefix):
         raise InstallError(

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -55,6 +55,8 @@ class CrayMpich(Package):
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
+        # First query for 'srun' in the environment and if it doesn't exist
+        # use either 'mpirun' or 'mpiexec'
         spec.runner = MPIRunner.query_mgr_pref(
             'srun',
             self.prefix.bin

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.util.mpi import MPIRunner
 import os
 
 
@@ -52,6 +53,11 @@ class FujitsuMpi(Package):
         self.spec.mpicxx = self.prefix.bin.mpiFCC
         self.spec.mpif77 = self.prefix.bin.mpifrt
         self.spec.mpifc = self.prefix.bin.mpifrt
+
+        self.spec.runner = MPIRunner.query_mgr_pref(
+            'srun',
+            self.prefix.bin
+        )
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -54,12 +54,8 @@ class FujitsuMpi(Package):
         self.spec.mpif77 = self.prefix.bin.mpifrt
         self.spec.mpifc = self.prefix.bin.mpifrt
 
-        # First query for 'srun' in the environment and if it doesn't exist
-        # use either 'mpirun' or 'mpiexec'
-        self.spec.runner = MPIRunner.query_mgr_pref(
-            'srun',
-            self.prefix.bin
-        )
+        self.spec.mpirunner = MPIRunner.create_def_runner(
+            __name__, self.prefix.bin)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)

--- a/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-mpi/package.py
@@ -54,6 +54,8 @@ class FujitsuMpi(Package):
         self.spec.mpif77 = self.prefix.bin.mpifrt
         self.spec.mpifc = self.prefix.bin.mpifrt
 
+        # First query for 'srun' in the environment and if it doesn't exist
+        # use either 'mpirun' or 'mpiexec'
         self.spec.runner = MPIRunner.query_mgr_pref(
             'srun',
             self.prefix.bin

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
+from spack.util.mpi import MPIRunner
 
 
 class IntelMpi(IntelPackage):
@@ -69,6 +71,19 @@ class IntelMpi(IntelPackage):
             'F90':  spack_fc,
             'FC':   spack_fc,
         })
+
+    def setup_dependent_package(self, module, dependent_spec):
+        mpiroot_dir = os.environ['I_MPI_ROOT']
+        mpibin_dir = join_path(mpiroot_dir, 'intel64', 'bin')
+        self.spec.runner = MPIRunner.query_mgr_pref(
+            'srun',
+            mpibin_dir
+        )
+        if not self.spec.runner:
+            mpibin_dir = join_path(mpiroot_dir, 'ia32', 'bin')
+            self.spec.runner = MPIRunner.query_mpi_pref(
+                mpibin_dir
+            )
 
     def setup_run_environment(self, env):
         super(IntelMpi, self).setup_run_environment(env)

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -73,6 +73,9 @@ class IntelMpi(IntelPackage):
         })
 
     def setup_dependent_package(self, module, dependent_spec):
+        # First query for 'srun' in the environment and if it doesn't exist
+        # use either 'mpirun' or 'mpiexec', both of which could be either in
+        # $I_MPI_ROOT/intel64 or $I_MPI_ROOT/ia32
         mpiroot_dir = os.environ['I_MPI_ROOT']
         mpibin_dir = join_path(mpiroot_dir, 'intel64', 'bin')
         self.spec.runner = MPIRunner.query_mgr_pref(

--- a/var/spack/repos/builtin/packages/intel-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-mpi/package.py
@@ -73,20 +73,21 @@ class IntelMpi(IntelPackage):
         })
 
     def setup_dependent_package(self, module, dependent_spec):
-        # First query for 'srun' in the environment and if it doesn't exist
-        # use either 'mpirun' or 'mpiexec', both of which could be either in
-        # $I_MPI_ROOT/intel64 or $I_MPI_ROOT/ia32
-        mpiroot_dir = os.environ['I_MPI_ROOT']
-        mpibin_dir = join_path(mpiroot_dir, 'intel64', 'bin')
-        self.spec.runner = MPIRunner.query_mgr_pref(
-            'srun',
-            mpibin_dir
-        )
-        if not self.spec.runner:
-            mpibin_dir = join_path(mpiroot_dir, 'ia32', 'bin')
-            self.spec.runner = MPIRunner.query_mpi_pref(
-                mpibin_dir
-            )
+        # First try specific runner config and then top level config;
+        # if neither is defined initialize the runner with 'srun' or 'mpiexec'.
+        # The latter could be either in $I_MPI_ROOT/intel64 or $I_MPI_ROOT/ia32
+        pkg_name = __name__.split('.')[-1]
+        self.spec.mpirunner = MPIRunner.create_from_conf_key(pkg_name)
+
+        if not self.spec.mpirunner:
+            mpiroot_dir = os.environ['I_MPI_ROOT']
+            mpibin_dir = join_path(mpiroot_dir, 'intel64', 'bin')
+            self.spec.mpirunner = MPIRunner.query_res_manager(
+                'srun', mpibin_dir)
+            if not self.spec.runner:
+                mpibin_dir = join_path(mpiroot_dir, 'ia32', 'bin')
+                self.spec.mpirunner = MPIRunner.query_res_manager(
+                    'srun', mpibin_dir)
 
     def setup_run_environment(self, env):
         super(IntelMpi, self).setup_run_environment(env)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -43,7 +43,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         self.spec.mpif77 = join_path(dir, 'mpif77')
         self.spec.mpifc  = join_path(dir, 'mpifc')
 
-        self.spec.runner = MPIRunner.query_mpi_pref(dir)
+        self.spec.mpirunner = MPIRunner.create_def_runner(__name__, dir)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('MPICH_CC', spack_cc)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -7,8 +7,8 @@
 import subprocess
 from sys import platform
 
-
 from spack import *
+from spack.util.mpi import MPIRunner
 
 
 class IntelOneapiMpi(IntelOneApiLibraryPackage):
@@ -42,6 +42,8 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         self.spec.mpicxx = join_path(dir, 'mpicxx')
         self.spec.mpif77 = join_path(dir, 'mpif77')
         self.spec.mpifc  = join_path(dir, 'mpifc')
+
+        self.spec.runner = MPIRunner.query_mpi_pref(dir)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('MPICH_CC', spack_cc)

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -246,6 +246,9 @@ class IntelParallelStudio(IntelPackage):
             env.set(name, value)
 
     def setup_dependent_package(self, module, dependent_spec):
+        # First query for 'srun' in the environment and if it doesn't exist
+        # use either 'mpirun' or 'mpiexec', both of which could be either in
+        # $I_MPI_ROOT/intel64 or $I_MPI_ROOT/ia32
         mpiroot_dir = os.environ['I_MPI_ROOT']
         mpibin_dir = join_path(mpiroot_dir, 'intel64', 'bin')
         self.spec.runner = MPIRunner.query_mgr_pref(

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.util.mpi import MPIRunner
 
 
 class IntelParallelStudio(IntelPackage):
@@ -243,3 +244,16 @@ class IntelParallelStudio(IntelPackage):
 
         for name, value in self.mpi_compiler_wrappers.items():
             env.set(name, value)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        mpiroot_dir = os.environ['I_MPI_ROOT']
+        mpibin_dir = join_path(mpiroot_dir, 'intel64', 'bin')
+        self.spec.runner = MPIRunner.query_mgr_pref(
+            'srun',
+            mpibin_dir
+        )
+        if not self.spec.runner:
+            mpibin_dir = join_path(mpiroot_dir, 'ia32', 'bin')
+            self.spec.runner = MPIRunner.query_mpi_pref(
+                mpibin_dir
+            )

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -367,15 +367,18 @@ spack package at this time.''',
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        if '+slurm' in spec:
+        # If we have slurm in spec use that as the resource manager, otherwise
+        # query for 'srun' in the environment and if it doesn't exist use
+        # either 'mpirun' or 'mpiexec'
+        if '+slurm' in spec and 'slurm' in spec:
             spec.runner = MPIRunner(
                 spec['slurm'].prefix.bin.srun,
                 'slurm'
             )
         else:
-            spec.runner = MPIRunner(
-                spec.prefix.bin.mpirun,
-                'mpirun'
+            self.spec.runner = MPIRunner.query_mgr_pref(
+                'srun',
+                self.prefix.bin
             )
 
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.util.mpi import MPIRunner
 import os
 import sys
 import re
@@ -365,6 +366,17 @@ spack package at this time.''',
             join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
+
+        if '+slurm' in spec:
+            spec.runner = MPIRunner(
+                spec['slurm'].prefix.bin.srun,
+                'slurm'
+            )
+        else:
+            spec.runner = MPIRunner(
+                spec.prefix.bin.mpirun,
+                'mpirun'
+            )
 
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""

--- a/var/spack/repos/builtin/packages/mpt/package.py
+++ b/var/spack/repos/builtin/packages/mpt/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.util.mpi import MPIRunner
 
 
 class Mpt(Package):
@@ -65,6 +66,11 @@ class Mpt(Package):
             self.spec.mpicxx = self.prefix.bin.mpicxx
             self.spec.mpifc = self.prefix.bin.mpif90
             self.spec.mpif77 = self.prefix.bin.mpif77
+
+        self.spec.runner = MPIRunner.query_mgr_pref(
+            'srun',
+            self.prefix.bin
+        )
 
     @property
     def fetcher(self):

--- a/var/spack/repos/builtin/packages/mpt/package.py
+++ b/var/spack/repos/builtin/packages/mpt/package.py
@@ -67,12 +67,8 @@ class Mpt(Package):
             self.spec.mpifc = self.prefix.bin.mpif90
             self.spec.mpif77 = self.prefix.bin.mpif77
 
-        # First query for 'srun' in the environment and if it doesn't exist
-        # use either 'mpirun' or 'mpiexec'
-        self.spec.runner = MPIRunner.query_mgr_pref(
-            'srun',
-            self.prefix.bin
-        )
+        self.spec.mpirunner = MPIRunner.create_def_runner(
+            __name__, self.prefix.bin)
 
     @property
     def fetcher(self):

--- a/var/spack/repos/builtin/packages/mpt/package.py
+++ b/var/spack/repos/builtin/packages/mpt/package.py
@@ -67,6 +67,8 @@ class Mpt(Package):
             self.spec.mpifc = self.prefix.bin.mpif90
             self.spec.mpif77 = self.prefix.bin.mpif77
 
+        # First query for 'srun' in the environment and if it doesn't exist
+        # use either 'mpirun' or 'mpiexec'
         self.spec.runner = MPIRunner.query_mgr_pref(
             'srun',
             self.prefix.bin

--- a/var/spack/repos/builtin/packages/mvapich2-gdr/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2-gdr/package.py
@@ -5,6 +5,7 @@
 
 import os.path
 import sys
+from spack.util.mpi import MPIRunner
 
 
 class Mvapich2Gdr(AutotoolsPackage):
@@ -202,6 +203,17 @@ class Mvapich2Gdr(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
+
+        if 'process_managers=slurm' in self.spec:
+            self.spec.runner = MPIRunner(
+                self.spec['slurm'].prefix.bin.srun,
+                'slurm'
+            )
+        else:
+            self.spec.runner = MPIRunner(
+                self.spec.prefix.bin.mpirun,
+                'mpirun'
+            )
 
     def configure_args(self):
         args = ['--disable-hybrid',

--- a/var/spack/repos/builtin/packages/mvapich2-gdr/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2-gdr/package.py
@@ -204,19 +204,21 @@ class Mvapich2Gdr(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        # If we have slurm in spec use that as the resource manager, otherwise
-        # query for 'srun' in the environment and if it doesn't exist use
-        # either 'mpirun' or 'mpiexec'
-        if 'process_managers=slurm' in self.spec and 'slurm' in self.spec:
-            self.spec.runner = MPIRunner(
-                self.spec['slurm'].prefix.bin.srun,
-                'slurm'
-            )
-        else:
-            self.spec.runner = MPIRunner.query_mgr_pref(
-                'srun',
-                self.prefix.bin
-            )
+        # First try specific runner config and then top level config;
+        # if neither is defined initialize the runner according to spec
+        pkg_name = __name__.split('.')[-1]
+        self.spec.mpirunner = MPIRunner.create_from_conf_key(pkg_name)
+
+        if not self.spec.mpirunner:
+            if 'process_managers=slurm' in self.spec:
+                if 'slurm' in self.spec:
+                    self.spec.mpirunner = MPIRunner(
+                        self.spec['slurm'].prefix.bin.srun)
+                else:   # external package
+                    self.spec.mpirunner = MPIRunner.query_res_manager(
+                        'srun', self.prefix.bin)
+            else:
+                self.spec.mpirunner = MPIRunner(self.prefix.bin.mpiexec)
 
     def configure_args(self):
         args = ['--disable-hybrid',

--- a/var/spack/repos/builtin/packages/mvapich2-gdr/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2-gdr/package.py
@@ -204,15 +204,18 @@ class Mvapich2Gdr(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        if 'process_managers=slurm' in self.spec:
+        # If we have slurm in spec use that as the resource manager, otherwise
+        # query for 'srun' in the environment and if it doesn't exist use
+        # either 'mpirun' or 'mpiexec'
+        if 'process_managers=slurm' in self.spec and 'slurm' in self.spec:
             self.spec.runner = MPIRunner(
                 self.spec['slurm'].prefix.bin.srun,
                 'slurm'
             )
         else:
-            self.spec.runner = MPIRunner(
-                self.spec.prefix.bin.mpirun,
-                'mpirun'
+            self.spec.runner = MPIRunner.query_mgr_pref(
+                'srun',
+                self.prefix.bin
             )
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -6,6 +6,7 @@
 import re
 import os.path
 import sys
+from spack.util.mpi import MPIRunner
 
 
 class Mvapich2(AutotoolsPackage):
@@ -381,6 +382,17 @@ class Mvapich2(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
+
+        if 'process_managers=slurm' in self.spec:
+            self.spec.runner = MPIRunner(
+                self.spec['slurm'].prefix.bin.srun,
+                'slurm'
+            )
+        else:
+            self.spec.runner = MPIRunner(
+                self.spec.prefix.bin.mpirun,
+                'mpirun'
+            )
 
     @run_before('configure')
     def die_without_fortran(self):

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -383,19 +383,21 @@ class Mvapich2(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        # If we have slurm in spec use that as the resource manager, otherwise
-        # query for 'srun' in the environment and if it doesn't exist use
-        # either 'mpirun' or 'mpiexec'
-        if 'process_managers=slurm' in self.spec and 'slurm' in self.spec:
-            self.spec.runner = MPIRunner(
-                self.spec['slurm'].prefix.bin.srun,
-                'slurm'
-            )
-        else:
-            self.spec.runner = MPIRunner.query_mgr_pref(
-                'srun',
-                self.prefix.bin
-            )
+        # First try specific runner config and then top level config;
+        # if neither is defined initialize the runner according to spec
+        pkg_name = __name__.split('.')[-1]
+        self.spec.mpirunner = MPIRunner.create_from_conf_key(pkg_name)
+
+        if not self.spec.mpirunner:
+            if 'process_managers=slurm' in self.spec:
+                if 'slurm' in self.spec:
+                    self.spec.mpirunner = MPIRunner(
+                        self.spec['slurm'].prefix.bin.srun)
+                else:   # external package
+                    self.spec.mpirunner = MPIRunner.query_res_manager(
+                        'srun', self.prefix.bin)
+            else:
+                self.spec.mpirunner = MPIRunner(self.prefix.bin.mpiexec)
 
     @run_before('configure')
     def die_without_fortran(self):

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -383,15 +383,18 @@ class Mvapich2(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        if 'process_managers=slurm' in self.spec:
+        # If we have slurm in spec use that as the resource manager, otherwise
+        # query for 'srun' in the environment and if it doesn't exist use
+        # either 'mpirun' or 'mpiexec'
+        if 'process_managers=slurm' in self.spec and 'slurm' in self.spec:
             self.spec.runner = MPIRunner(
                 self.spec['slurm'].prefix.bin.srun,
                 'slurm'
             )
         else:
-            self.spec.runner = MPIRunner(
-                self.spec.prefix.bin.mpirun,
-                'mpirun'
+            self.spec.runner = MPIRunner.query_mgr_pref(
+                'srun',
+                self.prefix.bin
             )
 
     @run_before('configure')

--- a/var/spack/repos/builtin/packages/mvapich2x/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2x/package.py
@@ -5,6 +5,7 @@
 
 import os.path
 import sys
+from spack.util.mpi import MPIRunner
 
 
 class Mvapich2x(AutotoolsPackage):
@@ -211,6 +212,17 @@ class Mvapich2x(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
+
+        if 'process_managers=slurm' in self.spec:
+            self.spec.runner = MPIRunner(
+                self.spec['slurm'].prefix.bin.srun,
+                'slurm'
+            )
+        else:
+            self.spec.runner = MPIRunner(
+                self.spec.prefix.bin.mpirun,
+                'mpirun'
+            )
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/mvapich2x/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2x/package.py
@@ -213,19 +213,21 @@ class Mvapich2x(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        # If we have slurm in spec use that as the resource manager, otherwise
-        # query for 'srun' in the environment and if it doesn't exist use
-        # either 'mpirun' or 'mpiexec'
-        if 'process_managers=slurm' in self.spec and 'slurm' in self.spec:
-            self.spec.runner = MPIRunner(
-                self.spec['slurm'].prefix.bin.srun,
-                'slurm'
-            )
-        else:
-            self.spec.runner = MPIRunner.query_mgr_pref(
-                'srun',
-                self.prefix.bin
-            )
+        # First try specific runner config and then top level config;
+        # if neither is defined initialize the runner according to spec
+        pkg_name = __name__.split('.')[-1]
+        self.spec.mpirunner = MPIRunner.create_from_conf_key(pkg_name)
+
+        if not self.spec.mpirunner:
+            if 'process_managers=slurm' in self.spec:
+                if 'slurm' in self.spec:
+                    self.spec.mpirunner = MPIRunner(
+                        self.spec['slurm'].prefix.bin.srun)
+                else:   # external package
+                    self.spec.mpirunner = MPIRunner.query_res_manager(
+                        'srun', self.prefix.bin)
+            else:
+                self.spec.mpirunner = MPIRunner(self.prefix.bin.mpiexec)
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/mvapich2x/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2x/package.py
@@ -213,15 +213,18 @@ class Mvapich2x(AutotoolsPackage):
             os.path.join(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        if 'process_managers=slurm' in self.spec:
+        # If we have slurm in spec use that as the resource manager, otherwise
+        # query for 'srun' in the environment and if it doesn't exist use
+        # either 'mpirun' or 'mpiexec'
+        if 'process_managers=slurm' in self.spec and 'slurm' in self.spec:
             self.spec.runner = MPIRunner(
                 self.spec['slurm'].prefix.bin.srun,
                 'slurm'
             )
         else:
-            self.spec.runner = MPIRunner(
-                self.spec.prefix.bin.mpirun,
-                'mpirun'
+            self.spec.runner = MPIRunner.query_mgr_pref(
+                'srun',
+                self.prefix.bin
             )
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -153,6 +153,8 @@ class Nvhpc(Package):
             self.spec.mpif77 = join_path(mpi_prefix.bin, 'mpif77')
             self.spec.mpifc  = join_path(mpi_prefix.bin, 'mpif90')
 
+            # First query for 'srun' in the environment and if it doesn't
+            # exist use either 'mpirun' or 'mpiexec'
             self.spec.runner = MPIRunner.query_mgr_pref(
                 'srun',
                 mpi_prefix.bin

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -153,12 +153,8 @@ class Nvhpc(Package):
             self.spec.mpif77 = join_path(mpi_prefix.bin, 'mpif77')
             self.spec.mpifc  = join_path(mpi_prefix.bin, 'mpif90')
 
-            # First query for 'srun' in the environment and if it doesn't
-            # exist use either 'mpirun' or 'mpiexec'
-            self.spec.runner = MPIRunner.query_mgr_pref(
-                'srun',
-                mpi_prefix.bin
-            )
+            self.spec.mpirunner = MPIRunner.create_def_runner(
+                __name__, mpi_prefix.bin)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -7,8 +7,10 @@
 
 from spack import *
 from spack.util.prefix import Prefix
+from spack.util.mpi import MPIRunner
 import os
 import platform
+
 
 # FIXME Remove hack for polymorphic versions
 # This package uses a ugly hack to be able to dispatch, given the same
@@ -150,6 +152,11 @@ class Nvhpc(Package):
             self.spec.mpicxx = join_path(mpi_prefix.bin, 'mpicxx')
             self.spec.mpif77 = join_path(mpi_prefix.bin, 'mpif77')
             self.spec.mpifc  = join_path(mpi_prefix.bin, 'mpif90')
+
+            self.spec.runner = MPIRunner.query_mgr_pref(
+                'srun',
+                mpi_prefix.bin
+            )
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -9,6 +9,7 @@ import re
 import os
 import sys
 import llnl.util.tty as tty
+from spack.util.mpi import MPIRunner
 
 
 class Openmpi(AutotoolsPackage):
@@ -519,6 +520,16 @@ class Openmpi(AutotoolsPackage):
             join_path(self.prefix.lib, 'libmpi_cxx.{0}'.format(dso_suffix)),
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
+
+        if 'schedulers=slurm' in self.spec:
+            self.spec.runner = MPIRunner(
+                self.spec['slurm'].prefix.bin.srun,
+                'slurm'
+            )
+        else:
+            self.spec.runner = MPIRunner.query_mpi_pref(
+                self.prefix.bin
+            )
 
     # Most of the following with_or_without methods might seem redundant
     # because Spack compiler wrapper adds the required -I and -L flags, which

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -521,13 +521,17 @@ class Openmpi(AutotoolsPackage):
             join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
         ]
 
-        if 'schedulers=slurm' in self.spec:
+        # If we have slurm in spec use that as the resource manager, otherwise
+        # query for 'srun' in the environment and if it doesn't exist use
+        # either 'mpirun' or 'mpiexec'
+        if 'schedulers=slurm' in self.spec and 'slurm' in self.spec:
             self.spec.runner = MPIRunner(
                 self.spec['slurm'].prefix.bin.srun,
                 'slurm'
             )
         else:
-            self.spec.runner = MPIRunner.query_mpi_pref(
+            self.spec.runner = MPIRunner.query_mgr_pref(
+                'srun',
                 self.prefix.bin
             )
 

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 import re
+from spack.util.mpi import MPIRunner
 
 
 class SpectrumMpi(Package):
@@ -111,6 +112,11 @@ class SpectrumMpi(Package):
             self.spec.mpicxx = os.path.join(self.prefix.bin, 'mpicxx')
             self.spec.mpif77 = os.path.join(self.prefix.bin, 'mpif77')
             self.spec.mpifc = os.path.join(self.prefix.bin, 'mpif90')
+
+        self.spec.runner = MPIRunner.query_mgr_pref(
+            'srun',
+            self.prefix.bin
+        )
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         if '%xl' in dependent_spec or '%xl_r' in dependent_spec:

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -113,12 +113,8 @@ class SpectrumMpi(Package):
             self.spec.mpif77 = os.path.join(self.prefix.bin, 'mpif77')
             self.spec.mpifc = os.path.join(self.prefix.bin, 'mpif90')
 
-        # First query for 'srun' in the environment and if it doesn't exist
-        # use either 'mpirun' or 'mpiexec'
-        self.spec.runner = MPIRunner.query_mgr_pref(
-            'srun',
-            self.prefix.bin
-        )
+        self.spec.mpirunner = MPIRunner.create_def_runner(
+            __name__, self.prefix.bin)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         if '%xl' in dependent_spec or '%xl_r' in dependent_spec:

--- a/var/spack/repos/builtin/packages/spectrum-mpi/package.py
+++ b/var/spack/repos/builtin/packages/spectrum-mpi/package.py
@@ -113,6 +113,8 @@ class SpectrumMpi(Package):
             self.spec.mpif77 = os.path.join(self.prefix.bin, 'mpif77')
             self.spec.mpifc = os.path.join(self.prefix.bin, 'mpif90')
 
+        # First query for 'srun' in the environment and if it doesn't exist
+        # use either 'mpirun' or 'mpiexec'
         self.spec.runner = MPIRunner.query_mgr_pref(
             'srun',
             self.prefix.bin


### PR DESCRIPTION
This is a simple functionality to set a resource manager runner (Slurm, mpirun, etc.) for MPI providers. The immediate use for this feature will be in smoke tests where we need to run distributed code. This PR replaces #22699 which is closed due to some mistakes (had to rebase the branch before PR).