### PR TITLE
CUDA fix : Add CUPTI libraries to LD_LIBRARY_PATH

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -131,6 +131,7 @@ class Cuda(Package):
 
     def setup_run_environment(self, env):
         env.set('CUDA_HOME', self.prefix)
+        env.append_path('LD_LIBRARY_PATH', self.prefix.extras.CUPTI.lib64)
 
     def install(self, spec, prefix):
         if os.path.exists('/tmp/cuda-installer.log'):


### PR DESCRIPTION
 * In order to use pc_sampling feature with nvprof
   or ncu, CUPTI must be in LD_LIBRARY_PATH
 * This issue was debugged with Max Kartz from NVIDIA