### PR TITLE
Reduce the scope of qt-5.12 patch

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -118,7 +118,7 @@ class Qt(Package):
     patch('qt5-11-intel-overflow.patch', when='@5.11 %intel')
     patch('qt5-12-intel-overflow.patch', when='@5.12:5.14.0 %intel')
     # https://bugreports.qt.io/browse/QTBUG-78937
-    patch('qt5-12-configure.patch', when='@5.12')
+    patch('qt5-12-configure.patch', when='@5.12.7')
     # https://bugreports.qt.io/browse/QTBUG-93402
     patch('qt5-15-gcc-10.patch', when='@5.12.7:5.15 %gcc@8:')
     patch('qt514.patch', when='@5.14')


### PR DESCRIPTION
This patch only applies to qt@5.12.7. Older versions (tested on 5.12.5) get patch failed.

Related to https://github.com/spack/spack/pull/16220