### PR TITLE
Update SLEPc and slepc4py to version 3.15

### DIFF
--- a/var/spack/repos/builtin/packages/py-slepc4py/ldshared-dev.patch
+++ b/var/spack/repos/builtin/packages/py-slepc4py/ldshared-dev.patch
@@ -1,0 +1,13 @@
+diff --git a/src/binding/slepc4py/conf/baseconf.py b/src/binding/slepc4py/conf/baseconf.py
+index b0707a65a..44ba8f194 100644
+--- a/src/binding/slepc4py/conf/baseconf.py
++++ b/src/binding/slepc4py/conf/baseconf.py
+@@ -213,7 +213,7 @@ class PetscConfig:
+         ldshared = getenv('LDSHARED', ldshared)
+         ldflags = getenv('LDFLAGS', cflags + ' ' + (ldflags or ''))
+         ldcmd = split_quoted(ld) + split_quoted(ldflags)
+-        ldshared = [flg for flg in split_quoted(ldshared) if flg not in ldcmd]
++        ldshared = [flg for flg in split_quoted(ldshared) if flg not in ldcmd and (flg.find('/lib/spack/env')<0)]
+         ldshared = str.join(' ', ldshared)
+         #
+         def get_flags(cmd):

--- a/var/spack/repos/builtin/packages/py-slepc4py/ldshared.patch
+++ b/var/spack/repos/builtin/packages/py-slepc4py/ldshared.patch
@@ -1,0 +1,13 @@
+diff --git a/src/binding/slepc4py/conf/baseconf.py b/src/binding/slepc4py/conf/baseconf.py
+index b0707a65a..44ba8f194 100644
+--- a/conf/baseconf.py
++++ b/conf/baseconf.py
+@@ -213,7 +213,7 @@ class PetscConfig:
+         ldshared = getenv('LDSHARED', ldshared)
+         ldflags = getenv('LDFLAGS', cflags + ' ' + (ldflags or ''))
+         ldcmd = split_quoted(ld) + split_quoted(ldflags)
+-        ldshared = [flg for flg in split_quoted(ldshared) if flg not in ldcmd]
++        ldshared = [flg for flg in split_quoted(ldshared) if flg not in ldcmd and (flg.find('/lib/spack/env')<0)]
+         ldshared = str.join(' ', ldshared)
+         #
+         def get_flags(cmd):

--- a/var/spack/repos/builtin/packages/py-slepc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-slepc4py/package.py
@@ -16,6 +16,7 @@ class PySlepc4py(PythonPackage):
 
     maintainers = ['dalcinl', 'joseeroman', 'balay']
 
+    version('main', branch='main')
     version('3.15.0', sha256='b1948a325f61e7acebc8a79eae4f31991dd1d4eb508437aced1085c4f76918ce')
     version('3.13.0', sha256='780eff0eea1a5217642d23cd563786ef22df27e1d772a1b0bb4ccc5701df5ea5')
     version('3.12.0', sha256='d8c06953b7d00f529a9a7fd016dfa8efdf1d05995baeea7688d1d59611f424f7')
@@ -25,6 +26,10 @@ class PySlepc4py(PythonPackage):
     version('3.8.0',  sha256='988815b3650b69373be9abbf2355df512dfd200aa74b1785b50a484d6dfee971')
     version('3.7.0',  sha256='139f8bb325dad00a0e8dbe5b3e054050c82547936c1b6e7812fb1a3171c9ad0b')
 
+    patch('ldshared.patch', when='@:99')
+    patch('ldshared-dev.patch', when='@main')
+
+    depends_on('py-cython', type='build', when='@main')
     depends_on('py-setuptools', type='build')
 
     depends_on('py-petsc4py', type=('build', 'run'))
@@ -48,3 +53,11 @@ class PySlepc4py(PythonPackage):
     depends_on('slepc@3.8:3.8.99', when='@3.8:3.8.99')
     depends_on('slepc@3.7:3.7.99', when='@3.7:3.7.99')
     depends_on('slepc@3.6:3.6.99', when='@3.6:3.6.99')
+
+    @property
+    def build_directory(self):
+        import os
+        if self.spec.satisfies('@main'):
+            return os.path.join(self.stage.source_path, 'src', 'binding', 'slepc4py')
+        else:
+            return self.stage.source_path

--- a/var/spack/repos/builtin/packages/py-slepc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-slepc4py/package.py
@@ -17,7 +17,7 @@ class PySlepc4py(PythonPackage):
     maintainers = ['dalcinl', 'joseeroman', 'balay']
 
     version('main', branch='main')
-    version('3.15.0', sha256='b1948a325f61e7acebc8a79eae4f31991dd1d4eb508437aced1085c4f76918ce')
+    version('3.15.0', sha256='dd190b8dfd21cc69ac1d208e0d6784fc3a3141d5c4a0e433af26e20bfa5e917a')
     version('3.13.0', sha256='780eff0eea1a5217642d23cd563786ef22df27e1d772a1b0bb4ccc5701df5ea5')
     version('3.12.0', sha256='d8c06953b7d00f529a9a7fd016dfa8efdf1d05995baeea7688d1d59611f424f7')
     version('3.11.0', sha256='1e591056beee209f585cd781e5fe88174cd2a61215716a71d9eaaf9411b6a775')

--- a/var/spack/repos/builtin/packages/py-slepc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-slepc4py/package.py
@@ -17,7 +17,7 @@ class PySlepc4py(PythonPackage):
     maintainers = ['dalcinl', 'joseeroman', 'balay']
 
     version('main', branch='main')
-    version('3.15.0', sha256='dd190b8dfd21cc69ac1d208e0d6784fc3a3141d5c4a0e433af26e20bfa5e917a')
+    version('3.15.0', sha256='2f5f5cc25ab4dd3782046c65e97265b39be0cf9cc74c5c0100c3c580c3c32395')
     version('3.13.0', sha256='780eff0eea1a5217642d23cd563786ef22df27e1d772a1b0bb4ccc5701df5ea5')
     version('3.12.0', sha256='d8c06953b7d00f529a9a7fd016dfa8efdf1d05995baeea7688d1d59611f424f7')
     version('3.11.0', sha256='1e591056beee209f585cd781e5fe88174cd2a61215716a71d9eaaf9411b6a775')

--- a/var/spack/repos/builtin/packages/py-slepc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-slepc4py/package.py
@@ -11,11 +11,12 @@ class PySlepc4py(PythonPackage):
     """
 
     homepage = "https://gitlab.com/slepc/slepc4py"
-    url      = "https://gitlab.com/slepc/slepc4py/-/archive/3.12.0/slepc4py-3.12.0.tar.gz"
-    git      = "https://gitlab.com/slepc/slepc4py.git"
+    url      = "https://slepc.upv.es/download/distrib/slepc4py-3.15.0.tar.gz"
+    git      = "https://gitlab.com/slepc/slepc.git"
 
     maintainers = ['dalcinl', 'joseeroman', 'balay']
 
+    version('3.15.0', sha256='b1948a325f61e7acebc8a79eae4f31991dd1d4eb508437aced1085c4f76918ce')
     version('3.13.0', sha256='780eff0eea1a5217642d23cd563786ef22df27e1d772a1b0bb4ccc5701df5ea5')
     version('3.12.0', sha256='d8c06953b7d00f529a9a7fd016dfa8efdf1d05995baeea7688d1d59611f424f7')
     version('3.11.0', sha256='1e591056beee209f585cd781e5fe88174cd2a61215716a71d9eaaf9411b6a775')
@@ -27,6 +28,7 @@ class PySlepc4py(PythonPackage):
     depends_on('py-setuptools', type='build')
 
     depends_on('py-petsc4py', type=('build', 'run'))
+    depends_on('py-petsc4py@3.15:3.15.99', when='@3.15:3.15.99', type=('build', 'run'))
     depends_on('py-petsc4py@3.13:3.13.99', when='@3.13:3.13.99', type=('build', 'run'))
     depends_on('py-petsc4py@3.12:3.12.99', when='@3.12:3.12.99', type=('build', 'run'))
     depends_on('py-petsc4py@3.11:3.11.99', when='@3.11:3.11.99', type=('build', 'run'))
@@ -37,6 +39,8 @@ class PySlepc4py(PythonPackage):
     depends_on('py-petsc4py@3.6:3.6.99', when='@3.6:3.6.99', type=('build', 'run'))
 
     depends_on('slepc')
+    depends_on('slepc@3.15:3.15.99', when='@3.15:3.15.99')
+    depends_on('slepc@3.13:3.13.99', when='@3.13:3.13.99')
     depends_on('slepc@3.12:3.12.99', when='@3.12:3.12.99')
     depends_on('slepc@3.11:3.11.99', when='@3.11:3.11.99')
     depends_on('slepc@3.10:3.10.99', when='@3.10:3.10.99')

--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -18,6 +18,7 @@ class Slepc(Package):
     maintainers = ['joseeroman', 'balay']
 
     version('main', branch='main')
+    version('3.15.0', sha256='e53783ae13acadce274ea65c67186b5ab12332cf17125a694e21d598aa6b5f00')
     version('3.14.2', sha256='3e54578dda1f4c54d35ac27d02f70a43f6837906cb7604dbcec0e033cfb264c8')
     version('3.14.1', sha256='cc78a15e34d26b3e6dde003d4a30064e595225f6185c1975bbd460cb5edd99c7')
     version('3.14.0', sha256='37f8bb270169d1d3f5d43756ac8929d56204e596bd7a78a7daff707513472e46')
@@ -55,6 +56,7 @@ class Slepc(Package):
 
     # Cannot mix release and development versions of SLEPc and PETSc:
     depends_on('petsc@main', when='@main')
+    depends_on('petsc@3.15:3.15.99', when='@3.15:3.15.99')
     depends_on('petsc@3.14:3.14.99', when='@3.14:3.14.99')
     depends_on('petsc@3.13:3.13.99', when='@3.13:3.13.99')
     depends_on('petsc@3.12:3.12.99', when='@3.12:3.12.99')


### PR DESCRIPTION
Similar to PETSc update #22688

cc: @dalcinl @balay 