### PR TITLE
Fix meson defaults

### DIFF
--- a/lib/spack/docs/build_systems/mesonpackage.rst
+++ b/lib/spack/docs/build_systems/mesonpackage.rst
@@ -121,10 +121,14 @@ override the ``meson_args`` method like so:
 .. code-block:: python
 
    def meson_args(self):
-       return ['--default-library=both']
+       return ['--warnlevel=3']
 
 
 This method can be used to pass flags as well as variables.
+
+Note that the ``MesonPackage`` base class already defines variants for
+``buildtype``, ``default_library`` and ``strip``, which are mapped to default
+Meson arguments, meaning that you don't have to specify these.
 
 ^^^^^^^^^^^^^^^^^^^^^^
 External documentation

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -55,6 +55,10 @@ class MesonPackage(PackageBase):
     variant('buildtype', default='debugoptimized',
             description='Meson build type',
             values=('plain', 'debug', 'debugoptimized', 'release', 'minsize'))
+    variant('default_library', default='shared',
+            description=' Default library type',
+            values=('shared', 'static', 'both'))
+    variant('strip', default=False, description='Strip targets on install')
 
     depends_on('meson', type='build')
     depends_on('ninja', type='build')
@@ -96,6 +100,16 @@ class MesonPackage(PackageBase):
         except KeyError:
             build_type = 'release'
 
+        try:
+            strip = 'true' if pkg.spec.variants['strip'].value else 'false'
+        except KeyError:
+            strip = 'false'
+
+        try:
+            default_library = pkg.spec.variants['default_library'].value
+        except KeyError:
+            default_library = 'shared'
+
         args = [
             '--prefix={0}'.format(pkg.prefix),
             # If we do not specify libdir explicitly, Meson chooses something
@@ -103,8 +117,9 @@ class MesonPackage(PackageBase):
             # find libraries and pkg-config files.
             # See https://github.com/mesonbuild/meson/issues/2197
             '--libdir={0}'.format(pkg.prefix.lib),
-            '--buildtype={0}'.format(build_type),
-            '--strip',
+            '-Dbuildtype={0}'.format(build_type),
+            '-Dstrip={0}'.format(strip),
+            '-Ddefault_library={0}'.format(default_library)
         ]
 
         return args
@@ -131,6 +146,7 @@ class MesonPackage(PackageBase):
         * ``--libdir``
         * ``--buildtype``
         * ``--strip``
+        * ``--default_library``
 
         which will be set automatically.
 

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -52,7 +52,7 @@ class MesonPackage(PackageBase):
 
     build_time_test_callbacks = ['check']
 
-    variant('buildtype', default='release',
+    variant('buildtype', default='debugoptimized',
             description='Meson build type',
             values=('plain', 'debug', 'debugoptimized', 'release', 'minsize'))
 

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -100,10 +100,7 @@ class MesonPackage(PackageBase):
         except KeyError:
             build_type = 'release'
 
-        try:
-            strip = 'true' if pkg.spec.variants['strip'].value else 'false'
-        except KeyError:
-            strip = 'false'
+        strip = 'true' if '+strip' in pkg.spec else 'false'
 
         try:
             default_library = pkg.spec.variants['default_library'].value


### PR DESCRIPTION
Use `debugoptimized` aka `-O2 -g` as a default, just like CMake's `RelWithDebInfo` default

Do not add `--strip` unconditionally, cause it strips debug symbols :(

Add a variant for `default_library`, which conveniently supports `both` too.

