### PR TITLE
otf2: patch for uninitialized variable

### DIFF
--- a/var/spack/repos/builtin/packages/otf2/collective_callbacks.patch
+++ b/var/spack/repos/builtin/packages/otf2/collective_callbacks.patch
@@ -1,0 +1,13 @@
+diff --git a/src/otf2_archive_int.c b/src/otf2_archive_int.c
+index db9b7a9..68f1694 100644
+--- a/src/otf2_archive_int.c
++++ b/src/otf2_archive_int.c
+@@ -1083,7 +1083,7 @@ otf2_archive_set_collective_callbacks( OTF2_Archive*                   archive,
+     archive->global_comm_context  = globalCommContext;
+     archive->local_comm_context   = localCommContext;
+ 
+-    OTF2_ErrorCode status;
++    OTF2_ErrorCode status = OTF2_SUCCESS;
+ 
+     /* It is time to create the directories by the root rank. */
+     if ( archive->file_mode == OTF2_FILEMODE_WRITE )

--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -24,6 +24,8 @@ class Otf2(AutotoolsPackage):
     version('1.3.1', sha256='c4605ace845d89fb1a19223137b92cc503b01e3db5eda8c9e0715d0cfcf2e4b9')
     version('1.2.1', sha256='1db9fb0789de4a9c3c96042495e4212a22cb581f734a1593813adaf84f2288e4')
 
+    # Fix missing initialization of variable resulting in issues when used by
+    # APEX/HPX: https://github.com/STEllAR-GROUP/hpx/issues/5239
     patch('collective_callbacks.patch', when='@2.1:2.2')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -24,6 +24,8 @@ class Otf2(AutotoolsPackage):
     version('1.3.1', sha256='c4605ace845d89fb1a19223137b92cc503b01e3db5eda8c9e0715d0cfcf2e4b9')
     version('1.2.1', sha256='1db9fb0789de4a9c3c96042495e4212a22cb581f734a1593813adaf84f2288e4')
 
+    patch('collective_callbacks.patch', when='@2.1:2.2')
+
     def configure_args(self):
         return [
             '--enable-shared',


### PR DESCRIPTION
As pointed out in https://github.com/STEllAR-GROUP/hpx/issues/5239#issuecomment-805957484,
there is an issues in OTF2 2.2 where a variable is not properly
initialized. As currently no release of OTF2 is available fixing this,
the patch should be applied.