### PR TITLE
Document unzip as required spack dependency

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -19,7 +19,7 @@ before Spack is run:
 #. Python 2 (2.6 or 2.7) or 3 (3.5 - 3.9) to run Spack
 #. A C/C++ compiler for building
 #. The ``make`` executable for building
-#. The ``tar``, ``gzip``, ``bzip2``, ``xz`` and optionally ``zstd``
+#. The ``tar``, ``gzip``, ``unzip``, ``bzip2``, ``xz`` and optionally ``zstd``
    executables for extracting source code
 #. The ``patch`` command to apply patches
 #. The ``git`` and ``curl`` commands for fetching


### PR DESCRIPTION
Should we just install unzip as a build dep?

It seems to not link to anything at all

```
==> Installing py-setuptools-50.3.2-qophasd7ompj7f2jiiklj4yib2eix4vj
==> No binary for py-setuptools-50.3.2-qophasd7ompj7f2jiiklj4yib2eix4vj found: installing from source
==> Using cached archive: /home/harmen/spack/var/spack/cache/_source-cache/archive/ed/ed0519d27a243843b05d82a5e9d01b0b083d9934eaa3d02779a23da18077bd3c.zip
==> Error: CommandNotFoundError: spack requires 'unzip'. Make sure it is in your path.
```
