### PR TITLE
gdal package needs to import the 'os' module

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 
 class Gdal(AutotoolsPackage):
     """GDAL (Geospatial Data Abstraction Library) is a translator library for

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -5,6 +5,7 @@
 
 import os
 
+
 class Gdal(AutotoolsPackage):
     """GDAL (Geospatial Data Abstraction Library) is a translator library for
     raster and vector geospatial data formats that is released under an X/MIT


### PR DESCRIPTION
Building `gdal+java` uses `os.pathsep` (line 191). If `os` is not imported, we get unknown method.