### PR TITLE
Spack: Address issues with external packages that use modules

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2490,18 +2490,30 @@ class Spec(object):
 
     @staticmethod
     def ensure_external_path_if_external(external_spec):
+
         if external_spec.external_modules and not external_spec.external_path:
+            pre = '{s.name}@{s.version} :'.format(s=external_spec)
+            tty.debug('External Package {0} Has modules but no representative `path`'
+                      ' has been chosen to serve as the `external_path`'
+                      ''.format(pre))
             compiler = spack.compilers.compiler_for_spec(
                 external_spec.compiler, external_spec.architecture)
             for mod in compiler.modules:
                 md.load_module(mod)
 
+            tty.debug('External Package {0} Searching modules for a suitable path.'
+                      ' Priority is given to modules with names containing the'
+                      ' package name.'
+                      ''.format(pre))
             # get the path from the module
             # the package can override the default
             external_spec.external_path = getattr(
                 external_spec.package, 'external_prefix',
-                md.path_from_modules(external_spec.external_modules)
+                md.path_from_modules(external_spec.external_modules,
+                                     hint_name=external_spec.name)
             )
+            tty.debug('External Package {0} Selected external_path = {1}'
+                      ''.format(pre, external_spec.external_path))
 
     @staticmethod
     def ensure_no_deprecated(root):

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -12,7 +12,7 @@ import os
 import sys
 import json
 import re
-
+import six  # used for string types check
 import spack
 import llnl.util.tty as tty
 
@@ -135,18 +135,14 @@ def get_path_args_from_module_line(line):
     return paths
 
 
-def path_from_modules(modules):
-    """Inspect a list of TCL modules for entries that indicate the absolute
-    path at which the library supported by said module can be found.
-
-    Args:
-        modules (list): module files to be loaded to get an external package
-
-    Returns:
-        Guess of the prefix path where the package
+def _path_from_modules_helper(modules):
     """
-    assert isinstance(modules, list), 'the "modules" argument must be a list'
+       Helper for path_from_modules
+       Given a list of modules search for a path
 
+       Keep semantics of prior code which returns the last
+       possible path found for a given list of modules
+    """
     best_choice = None
     for module_name in modules:
         # Read the current module and return a candidate path
@@ -162,6 +158,49 @@ def path_from_modules(modules):
         # that we give preference to the last module to be loaded
         # for packages requiring to load multiple modules in sequence
         best_choice = candidate_path or best_choice
+
+    # if we found something return it
+    return best_choice
+
+
+def path_from_modules(modules, hint_name=None):
+    """Inspect a list of TCL modules for entries that indicate the absolute
+    path at which the library supported by said module can be found.
+
+    Args:
+        modules (list): module files to be loaded to get an external package
+        hint_name (str): optional hint giving a name that likely maps
+                         is a better choice than choosing the last
+                         possible path.
+                         A good choice is the package name.
+                         E.g., if operating on an external mvapich,
+                         then give priority to modules with '.*mvapich.*'
+                         in their name. From these, always choose the last
+
+    Returns:
+        Guess of the prefix path where the package
+    """
+    # try to assert that modules need to be strings... we do compare them
+    if isinstance(modules, six.string_types):
+        modules = [modules]
+    else:
+        # this seems to hope for the best
+        modules = list(modules)  # defensive copy for generators
+
+    # hint is None by default, so this logic can be sidestepped
+    # for original behavior.
+    if hint_name:
+        # first choices are those that have the hint in their names
+        first_choice_modules = [m for m in modules if hint_name in m]
+        best_choice = _path_from_modules_helper(first_choice_modules)
+        # if we found something return it
+        if best_choice:
+            return best_choice
+        # if we didn't succeed, then compute the remaining modules
+        modules = [m for m in modules if m not in first_choice_modules]
+
+    # search the final set of modules
+    best_choice = _path_from_modules_helper(modules)
     return best_choice
 
 


### PR DESCRIPTION
This patch presents a change to selecting a `path` (`external_path`) for an external package that depends on modules.

One issue with such packages is that spack needs to resolve a `path` to provide to build systems (among others). For example, spack needs to resolve what `path/to/mpi` is to provide something like `--with-mpi=/path/to/mpi`.  Given a list of modules, how does one choose a path from whatever attributes those modules define?

The current process has caused me digital indigestion.

The current process simply picks whatever module happens to be the last module that will have a suitable path defined.

E.g., for a compiler, `modules = [ gcc/5.3.1, intel/17.0.1 ]` This may make sense, since Intel typically depends on an underlying GCC for headers/stl.

The problem with arbitrarily choosing a position in the module list is that users likely will not know this and it is unintuitive. For example, an external MPI from cray may need `modules = [ slurm, craype-network-of-awesome, cray-mvapich2 ]` Or, a Cray compiler will depend on many modules, e.g., `modules = [ cce, craype-arch-of-awesome, craype, shared, gcc/8.3.1 ]`. These dependent modules may be somewhat hidden by some wrapper module, e.g., `PrgEnv-cray`, but that is not a given.

I propose either add a field to external packages that use modules to declare what path or module should be chosen.

Or, use the logic proposed:
1.  When considering an external package `foo`, first search for modules containing `foo`. From those modules attempt to find a suitable path - if none is found, then search through the remaining modules choosing whatever (currently defined to be the *last* path found)

This is by no means robust. E.g., if someone declared an external package `go` with `modules= [ go/5.0, mango-fun/1.0, hugo/6]` the logic would choose `hugo` (if it has a path, or `mango` if hugo lacked one.

A more robust solution would be add a field to externals declaring which `module name` is the core. Or allow the user to specify an ENV name that would be unique out of all modules loaded, e.g., `SLURM_ROOT` should only be declared in a single module.

Either way - the modifications presented do two things:
1. They add some needed verbose output so the user can get an idea of what SPACK is trying to do
2. The logic of using the package name as a hint to find the best module appears to work pretty well (but as stated, neither the current impl nor this one are necessarily robust - this impl is simply more verbose about what it is doing, and the logic of package name = priority seems intuitive and seems to resolve some problems I have.

This issue is related to oddball behavior reported in #22222 - It accounts for a piece of the behavior I observed there.
I didn't intend to hunt this, but a mixture of #22732 and #22222 and weird problems with `parallel-netcdf` somehow using native `mvapich` compilers drove me over the cliff.

@alalazo @becker33 