### PR TITLE
py-pyfftw: add LDFLAGS to fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -24,4 +24,4 @@ class PyPyfftw(PythonPackage):
     depends_on('py-numpy@1.10:1.999',  type=('build', 'run'), when='@0.11.0:')
 
     def setup_build_environment(self, env):
-        env.append_flags('LDFLAGS', '-L{0}'.format(self.spec['fftw'].prefix.lib))
+        env.append_flags('LDFLAGS', self.spec['fftw'].libs.search_flags)

--- a/var/spack/repos/builtin/packages/py-pyfftw/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfftw/package.py
@@ -22,3 +22,6 @@ class PyPyfftw(PythonPackage):
     depends_on('py-cython@0.29:0.999', type='build')
     depends_on('py-numpy@1.6:',        type=('build', 'run'), when='@:0.10.4')
     depends_on('py-numpy@1.10:1.999',  type=('build', 'run'), when='@0.11.0:')
+
+    def setup_build_environment(self, env):
+        env.append_flags('LDFLAGS', '-L{0}'.format(self.spec['fftw'].prefix.lib))


### PR DESCRIPTION
Fix build error in `SUSE` like that:
```
-L/home/spack-develop/opt/spack/linux-sles15-aarch64/gcc-7.4.0/python-3.8.5-rorem3cm2r77h2xde3l23x6uejq2hhyw/lib -lfftw3f_threads -lfftw3f -lfftw3_threads -lfftw3 -lm -o build/lib.linux-aarch64-3.8/pyfftw/pyfftw.cpython-38-aarch64-linux-gnu.so
/usr/lib64/gcc/aarch64-suse-linux/7/../../../../aarch64-suse-linux/bin/ld: cannot find -lfftw3f_threads
/usr/lib64/gcc/aarch64-suse-linux/7/../../../../aarch64-suse-linux/bin/ld: cannot find -lfftw3f
/usr/lib64/gcc/aarch64-suse-linux/7/../../../../aarch64-suse-linux/bin/ld: cannot find -lfftw3_threads
/usr/lib64/gcc/aarch64-suse-linux/7/../../../../aarch64-suse-linux/bin/ld: cannot find -lfftw3
```