### PR TITLE
py-mo-pack: add LDFLAGS to fix build error

### DIFF
--- a/var/spack/repos/builtin/packages/py-mo-pack/package.py
+++ b/var/spack/repos/builtin/packages/py-mo-pack/package.py
@@ -18,3 +18,7 @@ class PyMoPack(PythonPackage):
     depends_on('libmo-unpack')
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-cython', type=('build', 'run'))
+
+    def setup_build_environment(self, env):
+        env.append_flags('LDFLAGS', '-L{0}'.format(
+            self.spec['libmo-unpack'].prefix.lib))

--- a/var/spack/repos/builtin/packages/py-mo-pack/package.py
+++ b/var/spack/repos/builtin/packages/py-mo-pack/package.py
@@ -20,5 +20,4 @@ class PyMoPack(PythonPackage):
     depends_on('py-cython', type=('build', 'run'))
 
     def setup_build_environment(self, env):
-        env.append_flags('LDFLAGS', '-L{0}'.format(
-            self.spec['libmo-unpack'].prefix.lib))
+        env.append_flags('LDFLAGS', self.spec['libmo-unpack'].libs.search_flags)


### PR DESCRIPTION
add LDFLAGS to fix this error in `SUSE`:
```
/usr/lib64/gcc/aarch64-suse-linux/7/../../../../aarch64-suse-linux/bin/ld: cannot find -lmo_unpack
collect2: error: ld returned 1 exit status
/home/spack-develop/opt/spack/linux-sles15-aarch64/gcc-7.4.0/py-cython-0.29.21-whxyzywlh5a6tz6iil5pgzdsp3wjwjbo/lib/python3.8/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /home/spack-stage/root/spack-stage-py-mo-pack-0.2.0-wrnpnrmbhd3l7w2zs3e5qzegvjjc7tlp/spack-src/lib/mo_pack/_packing.pyx
  tree = Parsing.p_module(s, pxd, full_module_name)
error: command '/usr/bin/gcc-7' failed with exit status 1
```
