### PR TITLE
sandbox: add dependency

### DIFF
--- a/var/spack/repos/builtin/packages/sandbox/package.py
+++ b/var/spack/repos/builtin/packages/sandbox/package.py
@@ -13,3 +13,5 @@ class Sandbox(AutotoolsPackage):
     url      = "https://dev.gentoo.org/~mgorny/dist/sandbox-2.12.tar.xz"
 
     version('2.12', sha256='265a490a8c528237c55ad26dfd7f62336fa5727c82358fc9cfbaa2e52c47fc50')
+
+    depends_on('gawk', type='build')


### PR DESCRIPTION
add `gawk ` as dependency to fix this issue:
![image](https://user-images.githubusercontent.com/29532367/113392696-1cbfb480-93c8-11eb-83a8-c2d54dbee938.png)
