### PR TITLE
Add windows compatible test paths

### DIFF
--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -5,6 +5,7 @@
 
 import pytest
 import stat
+import os
 
 import spack.config
 import spack.package_prefs
@@ -229,7 +230,7 @@ mpich:
         # ensure that once config is in place, external is used
         spec = Spec('mpi')
         spec.concretize()
-        assert spec['mpich'].external_path == '/dummy/path'
+        assert spec['mpich'].external_path == os.sep+'dummy'+os.sep+'path'
 
     def test_external_module(self, monkeypatch):
         """Test that packages can find externals specified by module

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -230,7 +230,7 @@ mpich:
         # ensure that once config is in place, external is used
         spec = Spec('mpi')
         spec.concretize()
-        assert spec['mpich'].external_path == os.sep+'dummy'+os.sep+'path'
+        assert spec['mpich'].external_path == os.sep+os.path.join('dummy','path')
 
     def test_external_module(self, monkeypatch):
         """Test that packages can find externals specified by module

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -265,14 +265,14 @@ def test_searching_order(search_fn, search_list, root, kwargs):
 
 @pytest.mark.parametrize('root,search_list,kwargs,expected', [
     (search_dir, '*/*bar.tx?', {'recursive': False}, [
-        os.path.join(search_dir, 'a/foobar.txt'),
-        os.path.join(search_dir, 'b/bar.txp'),
-        os.path.join(search_dir, 'c/bar.txt'),
+        os.path.join(search_dir, 'a'+os.sep+'foobar.txt'),
+        os.path.join(search_dir, 'b'+os.sep+'bar.txp'),
+        os.path.join(search_dir, 'c'+os.sep+'bar.txt'),
     ]),
     (search_dir, '*/*bar.tx?', {'recursive': True}, [
-        os.path.join(search_dir, 'a/foobar.txt'),
-        os.path.join(search_dir, 'b/bar.txp'),
-        os.path.join(search_dir, 'c/bar.txt'),
+        os.path.join(search_dir, 'a'+os.sep+'foobar.txt'),
+        os.path.join(search_dir, 'b'+os.sep+'bar.txp'),
+        os.path.join(search_dir, 'c'+os.sep+'bar.txt'),
     ])
 ])
 def test_find_with_globbing(root, search_list, kwargs, expected):

--- a/lib/spack/spack/test/llnl/util/file_list.py
+++ b/lib/spack/spack/test/llnl/util/file_list.py
@@ -265,14 +265,14 @@ def test_searching_order(search_fn, search_list, root, kwargs):
 
 @pytest.mark.parametrize('root,search_list,kwargs,expected', [
     (search_dir, '*/*bar.tx?', {'recursive': False}, [
-        os.path.join(search_dir, 'a'+os.sep+'foobar.txt'),
-        os.path.join(search_dir, 'b'+os.sep+'bar.txp'),
-        os.path.join(search_dir, 'c'+os.sep+'bar.txt'),
+        os.path.join(search_dir, os.path.join('a', 'foobar.txt')),
+        os.path.join(search_dir, os.path.join('b', 'bar.txp')),
+        os.path.join(search_dir, os.path.join('c', 'bar.txt')),
     ]),
     (search_dir, '*/*bar.tx?', {'recursive': True}, [
-        os.path.join(search_dir, 'a'+os.sep+'foobar.txt'),
-        os.path.join(search_dir, 'b'+os.sep+'bar.txp'),
-        os.path.join(search_dir, 'c'+os.sep+'bar.txt'),
+        os.path.join(search_dir, os.path.join('a', 'foobar.txt')),
+        os.path.join(search_dir, os.path.join('b', 'bar.txp')),
+        os.path.join(search_dir, os.path.join('c', 'bar.txt')),
     ])
 ])
 def test_find_with_globbing(root, search_list, kwargs, expected):

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -7,6 +7,7 @@ import os.path
 import platform
 import re
 import shutil
+import os
 
 import llnl.util.filesystem
 import pytest
@@ -224,7 +225,8 @@ def test_existing_rpaths(patchelf_behavior, expected, mock_patchelf):
 
 @pytest.mark.parametrize('start_path,path_root,paths,expected', [
     ('/usr/bin/test', '/usr', ['/usr/lib', '/usr/lib64', '/opt/local/lib'],
-     ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'])
+     ['$ORIGIN'+os.sep+'..'+os.sep+'lib', '$ORIGIN'+os.sep+'..'+os.sep+'lib64',
+     '/opt/local/lib'])
 ])
 def test_make_relative_paths(start_path, path_root, paths, expected):
     relatives = spack.relocate._make_relative(start_path, path_root, paths)
@@ -236,7 +238,7 @@ def test_make_relative_paths(start_path, path_root, paths, expected):
     # and then normalized
     ('/usr/bin/test',
      ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'],
-     ['/usr/lib', '/usr/lib64', '/opt/local/lib']),
+     [os.sep+'usr'+os.sep+'lib', os.sep+'usr'+os.sep+'lib64', '/opt/local/lib']),
     # Relative path without $ORIGIN
     ('/usr/bin/test', ['../local/lib'], ['../local/lib']),
 ])

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -225,7 +225,7 @@ def test_existing_rpaths(patchelf_behavior, expected, mock_patchelf):
 
 @pytest.mark.parametrize('start_path,path_root,paths,expected', [
     ('/usr/bin/test', '/usr', ['/usr/lib', '/usr/lib64', '/opt/local/lib'],
-     ['$ORIGIN'+os.sep+'..'+os.sep+'lib', '$ORIGIN'+os.sep+'..'+os.sep+'lib64',
+     [os.path.join('$ORIGIN', '..', 'lib'), os.path.join('$ORIGIN', '..', 'lib64'),
      '/opt/local/lib'])
 ])
 def test_make_relative_paths(start_path, path_root, paths, expected):
@@ -238,7 +238,8 @@ def test_make_relative_paths(start_path, path_root, paths, expected):
     # and then normalized
     ('/usr/bin/test',
      ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'],
-     [os.sep+'usr'+os.sep+'lib', os.sep+'usr'+os.sep+'lib64', '/opt/local/lib']),
+     [os.sep+os.path.join('usr', 'lib'), os.sep+os.path.join('usr','lib64'),
+      '/opt/local/lib']),
     # Relative path without $ORIGIN
     ('/usr/bin/test', ['../local/lib'], ['../local/lib']),
 ])

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -46,7 +46,7 @@ last_line  = "last!\n"
 
 @pytest.fixture  # type: ignore[no-redef]
 def sbang_line():
-    yield '#!/bin/sh %s/bin/sbang\n' % spack.store.layout.root
+    yield '#!/bin/sh {0}{1}bin{1}sbang\n'.format(spack.store.layout.root, os.sep)
 
 
 class ScriptDirectory(object):

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -112,8 +112,8 @@ def test_dump_environment(prepare_environment_for_tests, tmpdir):
 
 def test_reverse_environment_modifications(working_env):
     start_env = {
-        'PREPEND_PATH': os.sep+'path'+os.sep+'to'+os.sep+'prepend'+os.sep+'to',
-        'APPEND_PATH': os.sep+'path'+os.sep+'to'+os.sep+'append'+os.sep+'to',
+        'PREPEND_PATH': os.sep+os.path.join('path', 'to', 'prepend', 'to'),
+        'APPEND_PATH': os.sep+os.path.join('path', 'to', 'append', 'to'),
         'UNSET': 'var_to_unset',
         'APPEND_FLAGS': 'flags to append to',
     }

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -6,6 +6,7 @@
 """Test Spack's environment utility functions."""
 import pytest
 import os
+import sys
 import spack.util.environment as envutil
 
 
@@ -29,6 +30,10 @@ test_paths = ['/usr/bin',
               '/nonsense_path/extra/bin',
               '/usr/lib64']
 
+if sys.platform == "win32":
+    path_sep = ";"
+else:
+    path_sep = ":"
 
 def test_filter_system_paths():
     expected = [p for p in test_paths if p.startswith('/nonsense_path')]
@@ -84,7 +89,7 @@ def test_env_flag(prepare_environment_for_tests):
 
 def test_path_set(prepare_environment_for_tests):
     envutil.path_set('TEST_ENV_VAR', ['/a', '/a/b', '/a/a'])
-    assert(os.environ['TEST_ENV_VAR'] == '/a:/a/b:/a/a')
+    assert(os.environ['TEST_ENV_VAR'] == '/a'+path_sep+'/a/b'+path_sep+'/a/a')
 
 
 def test_path_put_first(prepare_environment_for_tests):
@@ -107,8 +112,8 @@ def test_dump_environment(prepare_environment_for_tests, tmpdir):
 
 def test_reverse_environment_modifications(working_env):
     start_env = {
-        'PREPEND_PATH': '/path/to/prepend/to',
-        'APPEND_PATH': '/path/to/append/to',
+        'PREPEND_PATH': os.sep+'path'+os.sep+'to'+os.sep+'prepend'+os.sep+'to',
+        'APPEND_PATH': os.sep+'path'+os.sep+'to'+os.sep+'append'+os.sep+'to',
         'UNSET': 'var_to_unset',
         'APPEND_FLAGS': 'flags to append to',
     }

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -13,9 +13,9 @@ def test_prefix_attributes():
     """Test normal prefix attributes like ``prefix.bin``"""
     prefix = Prefix(os.sep+'usr')
 
-    assert prefix.bin     == os.sep+'usr'+os.sep+'bin'
-    assert prefix.lib     == os.sep+'usr'+os.sep+'lib'
-    assert prefix.include == os.sep+'usr'+os.sep+'include'
+    assert prefix.bin     == os.sep+os.path.join('usr', 'bin')
+    assert prefix.lib     == os.sep+os.path.join('usr', 'lib')
+    assert prefix.include == os.sep+os.path.join('usr', 'include')
 
 
 def test_prefix_join():
@@ -26,9 +26,9 @@ def test_prefix_join():
     a2 = prefix.join('a-{0}'.format(1)).lib64
     a3 = prefix.join('a.{0}'.format(1)).lib64
 
-    assert a1 == os.sep+'usr'+os.sep+'a_1'+os.sep+'lib64'
-    assert a2 == os.sep+'usr'+os.sep+'a-1'+os.sep+'lib64'
-    assert a3 == os.sep+'usr'+os.sep+'a.1'+os.sep+'lib64'
+    assert a1 == os.sep+os.path.join('usr', 'a_1', 'lib64')
+    assert a2 == os.sep+os.path.join('usr', 'a-1', 'lib64')
+    assert a3 == os.sep+os.path.join('usr', 'a.1', 'lib64')
 
     assert isinstance(a1, Prefix)
     assert isinstance(a2, Prefix)
@@ -38,9 +38,9 @@ def test_prefix_join():
     p2 = prefix.share.join('pkg-config').join('foo.pc')
     p3 = prefix.join('dashed-directory').foo
 
-    assert p1 == os.sep+'usr'+os.sep+'bin'+os.sep+'executable.sh'
-    assert p2 == os.sep+'usr'+os.sep+'share'+os.sep+'pkg-config'+os.sep+'foo.pc'
-    assert p3 == os.sep+'usr'+os.sep+'dashed-directory'+os.sep+'foo'
+    assert p1 == os.sep+os.path.join('usr', 'bin', 'executable.sh')
+    assert p2 == os.sep+os.path.join('usr', 'share', 'pkg-config', 'foo.pc')
+    assert p3 == os.sep+os.path.join('usr', 'dashed-directory', 'foo')
 
     assert isinstance(p1, Prefix)
     assert isinstance(p2, Prefix)
@@ -51,14 +51,14 @@ def test_multilevel_attributes():
     """Test attributes of attributes, like ``prefix.share.man``"""
     prefix = Prefix(os.sep+'usr'+os.sep)
 
-    assert prefix.share.man   == os.sep+'usr'+os.sep+'share'+os.sep+'man'
-    assert prefix.man.man8    == os.sep+'usr'+os.sep+'man'+os.sep+'man8'
-    assert prefix.foo.bar.baz == os.sep+'usr'+os.sep+'foo'+os.sep+'bar'+os.sep+'baz'
+    assert prefix.share.man   == os.sep+os.path.join('usr', 'share', 'man')
+    assert prefix.man.man8    == os.sep+os.path.join('usr', 'man', 'man8')
+    assert prefix.foo.bar.baz == os.sep+os.path.join('usr', 'foo', 'bar', 'baz')
 
     share = prefix.share
 
     assert isinstance(share, Prefix)
-    assert share.man == os.sep+'usr'+os.sep+'share'+os.sep+'man'
+    assert share.man == os.sep+os.path.join('usr', 'share', 'man')
 
 
 def test_string_like_behavior():

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -6,28 +6,29 @@
 """Tests various features of :py:class:`spack.util.prefix.Prefix`"""
 
 from spack.util.prefix import Prefix
+import os
 
 
 def test_prefix_attributes():
     """Test normal prefix attributes like ``prefix.bin``"""
-    prefix = Prefix('/usr')
+    prefix = Prefix(os.sep+'usr')
 
-    assert prefix.bin     == '/usr/bin'
-    assert prefix.lib     == '/usr/lib'
-    assert prefix.include == '/usr/include'
+    assert prefix.bin     == os.sep+'usr'+os.sep+'bin'
+    assert prefix.lib     == os.sep+'usr'+os.sep+'lib'
+    assert prefix.include == os.sep+'usr'+os.sep+'include'
 
 
 def test_prefix_join():
     """Test prefix join  ``prefix.join(...)``"""
-    prefix = Prefix('/usr')
+    prefix = Prefix(os.sep+'usr')
 
     a1 = prefix.join('a_{0}'.format(1)).lib64
     a2 = prefix.join('a-{0}'.format(1)).lib64
     a3 = prefix.join('a.{0}'.format(1)).lib64
 
-    assert a1 == '/usr/a_1/lib64'
-    assert a2 == '/usr/a-1/lib64'
-    assert a3 == '/usr/a.1/lib64'
+    assert a1 == os.sep+'usr'+os.sep+'a_1'+os.sep+'lib64'
+    assert a2 == os.sep+'usr'+os.sep+'a-1'+os.sep+'lib64'
+    assert a3 == os.sep+'usr'+os.sep+'a.1'+os.sep+'lib64'
 
     assert isinstance(a1, Prefix)
     assert isinstance(a2, Prefix)
@@ -37,9 +38,9 @@ def test_prefix_join():
     p2 = prefix.share.join('pkg-config').join('foo.pc')
     p3 = prefix.join('dashed-directory').foo
 
-    assert p1 == '/usr/bin/executable.sh'
-    assert p2 == '/usr/share/pkg-config/foo.pc'
-    assert p3 == '/usr/dashed-directory/foo'
+    assert p1 == os.sep+'usr'+os.sep+'bin'+os.sep+'executable.sh'
+    assert p2 == os.sep+'usr'+os.sep+'share'+os.sep+'pkg-config'+os.sep+'foo.pc'
+    assert p3 == os.sep+'usr'+os.sep+'dashed-directory'+os.sep+'foo'
 
     assert isinstance(p1, Prefix)
     assert isinstance(p2, Prefix)
@@ -48,16 +49,16 @@ def test_prefix_join():
 
 def test_multilevel_attributes():
     """Test attributes of attributes, like ``prefix.share.man``"""
-    prefix = Prefix('/usr/')
+    prefix = Prefix(os.sep+'usr'+os.sep)
 
-    assert prefix.share.man   == '/usr/share/man'
-    assert prefix.man.man8    == '/usr/man/man8'
-    assert prefix.foo.bar.baz == '/usr/foo/bar/baz'
+    assert prefix.share.man   == os.sep+'usr'+os.sep+'share'+os.sep+'man'
+    assert prefix.man.man8    == os.sep+'usr'+os.sep+'man'+os.sep+'man8'
+    assert prefix.foo.bar.baz == os.sep+'usr'+os.sep+'foo'+os.sep+'bar'+os.sep+'baz'
 
     share = prefix.share
 
     assert isinstance(share, Prefix)
-    assert share.man == '/usr/share/man'
+    assert share.man == os.sep+'usr'+os.sep+'share'+os.sep+'man'
 
 
 def test_string_like_behavior():


### PR DESCRIPTION
Use of os.sep to translate expected paths in tests from linux to windows format
Test with `spack unit-test lib\spack\spack\test\<file>`
Where `<file>` is one of util\file_list.py, relocate.py, concretize_preferences.py, util\prefix.py, util\environment.py or sbang.py