### PR TITLE
Ascent: CUDA ~shared

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -166,6 +166,12 @@ class Ascent(Package, CudaPackage):
     depends_on("py-sphinx", when="+python+doc", type='build')
     depends_on("py-sphinx-rtd-theme", when="+python+doc", type='build')
 
+    ###########
+    # Conflicts
+    ###########
+    conflicts("+shared", when="+cuda",
+              msg="Ascent needs to be built with ~shared for CUDA builds.")
+
     def setup_build_environment(self, env):
         env.set('CTEST_OUTPUT_ON_FAILURE', '1')
 

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -66,7 +66,10 @@ class Warpx(CMakePackage):
             description='Enable tiny profiling features')
 
     depends_on('ascent', when='+ascent')
-    depends_on('ascent +cuda', when='+ascent compute=cuda')
+    # note: ~shared is only needed until the new concretizer is in and
+    #       honors the conflict inside the Ascent package to find this
+    #       automatically
+    depends_on('ascent +cuda ~shared', when='+ascent compute=cuda')
     depends_on('ascent +mpi', when='+ascent +mpi')
     depends_on('blaspp', when='+psatd dims=rz')
     depends_on('blaspp +cuda', when='+psatd dims=rz compute=cuda')


### PR DESCRIPTION
Add a conflict for CUDA and shared libraries in Ascent.

The new concretizer will automatically change the default for Ascent in that case. Until then, dependencies like WarpX need to hint the `~shared` wish explicitly.