### PR TITLE
Add explicit dependency with 'gl' in 'fltk' package

### DIFF
--- a/var/spack/repos/builtin/packages/fltk/package.py
+++ b/var/spack/repos/builtin/packages/fltk/package.py
@@ -38,6 +38,12 @@ class Fltk(Package):
     variant('shared', default=True,
             description='Enables the build of shared libraries')
 
+    variant('gl', default=True,
+            description='Enables opengl support')
+
+    # variant dependencies
+    depends_on('gl', when='+gl')
+
     def install(self, spec, prefix):
         options = ['--prefix=%s' % prefix,
                    '--enable-localjpeg',

--- a/var/spack/repos/builtin/packages/fltk/package.py
+++ b/var/spack/repos/builtin/packages/fltk/package.py
@@ -53,6 +53,9 @@ class Fltk(Package):
         if '+shared' in spec:
             options.append('--enable-shared')
 
+        if '~gl' in spec:
+            options.append('--disable-gl')
+
         # FLTK needs to be built in-source
         configure(*options)
         make()


### PR DESCRIPTION
The fltk package can build libraries with opengl support. By default, the configure script looks for opengl headers in the sytem include paths. If 'devel' packages have not been installed on the system, it omits the `ftlk_gl.so` library. This can break packages like 'octave' which expects 'fltk' to have opengl support and looks for the library 'fltk_gl'.

Make opengl support explicit in fltk by adding a dependency on 'gl' and adding a new variant of the same name 'gl' (default On).

With these modifications, I was able to build `fltk_gl` and `octave` successfully on CentOS8.

Build instructions: https://www.fltk.org/doc-1.3/intro.html