### PR TITLE
bump up version for rccl for rocm-4.1.0 release

### DIFF
--- a/var/spack/repos/builtin/packages/hip/0003-Improve-compilation-without-git-repo.4.1.0.patch
+++ b/var/spack/repos/builtin/packages/hip/0003-Improve-compilation-without-git-repo.4.1.0.patch
@@ -1,0 +1,44 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 483f8c9..8ddf76e 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,7 +52,16 @@ string(REPLACE "." ";" VERSION_LIST ${HIP_BASE_VERSION})
+ list(GET VERSION_LIST 0 HIP_VERSION_MAJOR)
+ list(GET VERSION_LIST 1 HIP_VERSION_MINOR)
+ 
+-find_package(Git)
++# only look for git when we have a git repo
++if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
++  find_package(Git)
++endif()
++
++# FIXME: Two different version strings used.
++
++set(HIP_PACKAGING_VERSION_PATCH "0")
++set(HIP_VERSION_GITDATE "0")
++set(HIP_VERSION_PATCH "0")
+ 
+ # FIXME: Two different version strings used.
+ if(GIT_FOUND)
+@@ -98,9 +107,6 @@ if(GIT_FOUND)
+   else()
+     set(HIP_PACKAGING_VERSION_PATCH ${HIP_VERSION_GITDATE}.${HIP_VERSION_GITCOUNT}-${HIP_VERSION_GITHASH})
+   endif()
+-else()
+-  # FIXME: Some parts depend on this being set.
+-  set(HIP_PACKAGING_VERSION_PATCH "0")
+ endif()
+ 
+ ## Debian package specific variables
+@@ -295,10 +301,6 @@ file(WRITE "${PROJECT_BINARY_DIR}/.hipInfo" ${_buildInfo})
+ # Generate .hipVersion
+ file(WRITE "${PROJECT_BINARY_DIR}/.hipVersion" ${_versionInfo})
+ 
+-if(NOT DEFINED HIP_VERSION_GITDATE)
+-    set(HIP_VERSION_GITDATE 0)
+-endif()
+-
+ # Build doxygen documentation
+ find_program(DOXYGEN_EXE doxygen)
+ if(DOXYGEN_EXE)
+

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -58,6 +58,7 @@ class Hip(CMakePackage):
     # See https://github.com/ROCm-Developer-Tools/HIP/pull/2218
     patch('0003-Improve-compilation-without-git-repo.3.7.0.patch', when='@3.7.0:3.9.0')
     patch('0003-Improve-compilation-without-git-repo.3.10.0.patch', when='@3.10.0:4.0.0')
+    patch('0003-Improve-compilation-without-git-repo.4.1.0.patch', when='@4.1.0')
 
     # See https://github.com/ROCm-Developer-Tools/HIP/pull/2219
     patch('0004-Drop-clang-rt-builtins-linking-on-hip-host.3.7.0.patch', when='@3.7.0:3.9.0')
@@ -85,7 +86,6 @@ class Hip(CMakePackage):
                 'hsa-rocr-dev': rocm_prefix.hsa,
                 'rocminfo': rocm_prefix,
                 'rocm-device-libs': rocm_prefix,
-                'hip-rocclr': rocm_prefix
             }
         else:
             paths = {
@@ -94,7 +94,6 @@ class Hip(CMakePackage):
                 'hsa-rocr-dev': self.spec['hsa-rocr-dev'].prefix,
                 'rocminfo': self.spec['rocminfo'].prefix,
                 'rocm-device-libs': self.spec['rocm-device-libs'].prefix,
-                'hip-rocclr': self.spec['hip-rocclr'].prefix
             }
 
         # `device_lib_path` is the path to the bitcode directory
@@ -150,9 +149,6 @@ class Hip(CMakePackage):
         # https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/blob/rocm-4.0.0/lib/comgr/src/comgr-env.cpp
         env.set('LLVM_PATH', paths['llvm-amdgpu'])
 
-        if self.spec.satisfies('@4.1.0:'):
-            env.set('HIP_ROCCLR_HOME', paths['hip-rocclr'])
-
         # Finally we have to set --rocm-path=<prefix> ourselves, which is not
         # the same as --hip-device-lib-path (set by hipcc). It's used to set
         # default bin, include and lib folders in clang. If it's not set it is
@@ -206,7 +202,7 @@ class Hip(CMakePackage):
                 files = [
                     'hipify-perl', 'hipcc', 'roc-obj-extract',
                     'hipconfig', 'hipify-cmakefile',
-                    'roc-obj-ls'
+                    'roc-obj-ls','hipvars.pm'
                 ]
 
             filter_file(match, substitute, *files, **kwargs)
@@ -239,12 +235,9 @@ class Hip(CMakePackage):
         ]
         if self.spec.satisfies('@:4.0.0'):
             args.append(self.define('HIP_RUNTIME', 'ROCclr'))
-        else:
-            args.append(self.define('HIP_RUNTIME', 'rocclr'))
-
-        if self.spec.satisfies('@:4.0.0'):
             args.append(self.define('HIP_PLATFORM', 'rocclr'))
         else:
+            args.append(self.define('HIP_RUNTIME', 'rocclr'))
             args.append(self.define('HIP_PLATFORM', 'amd'))
 
         # LIBROCclr_STATIC_DIR is unused from 3.6.0 and above

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -202,7 +202,7 @@ class Hip(CMakePackage):
                 files = [
                     'hipify-perl', 'hipcc', 'roc-obj-extract',
                     'hipconfig', 'hipify-cmakefile',
-                    'roc-obj-ls','hipvars.pm'
+                    'roc-obj-ls', 'hipvars.pm'
                 ]
 
             filter_file(match, substitute, *files, **kwargs)

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -34,7 +34,6 @@ class Hipcub(CMakePackage):
         depends_on('rocprim@' + ver, type='build', when='@' + ver)
     for ver in ['4.1.0']:
         depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
-   
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -13,7 +13,7 @@ class Hipcub(CMakePackage):
     url      = "https://github.com/ROCmSoftwarePlatform/hipCUB/archive/rocm-4.0.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
-
+    version('4.1.0', sha256='6d33cc371b9a5ac9c0ab9853bac736f6cea0d2192f4dc9e6d8175d207ee4b4f2')
     version('4.0.0', sha256='656bd6ec547810fd74bcebba41453e6e729f3fdb7346f5564ab71fc0346c3fb5')
     version('3.10.0', sha256='759da5c6ef0cc1e4ecf2083659e78b8bbaa015f0bb360177674e0feb3032c5be')
     version('3.9.0', sha256='c46995f9f18733ec18e370c21d7c0d6ac719e8e9d3254c6303a20ba90831e12e')
@@ -26,12 +26,15 @@ class Hipcub(CMakePackage):
     depends_on('cmake@3:', type='build')
     depends_on('numactl', type='link', when='@3.7.0:')
 
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)
+    for ver in ['4.1.0']:
+        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+   
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -16,6 +16,7 @@ class Hipsparse(CMakePackage):
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
+    version('4.1.0', sha256='66710c390489922f0bd1ac38fd8c32fcfb5b7760b92c2d282f7d1abf214742ee')
     version('4.0.0', sha256='fc3736b2ea203209021616b2ffbcdd664781d692b07b8e8bb7f78b42dabbd5e5')
     version('3.10.0', sha256='7fd863ebf6eed09325c23ba06d9008b2f2c1345283d1a331e329e1a512b602f7')
     version('3.9.0', sha256='ab0ea3dd9b68a126291ed5a35e50fc85d0aeb35fe862f5d9e544435e4262c435')
@@ -26,7 +27,7 @@ class Hipsparse(CMakePackage):
     depends_on('cmake@3:', type='build')
     depends_on('git', type='build')
 
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('rocsparse@' + ver, type='build', when='@' + ver)
@@ -34,8 +35,10 @@ class Hipsparse(CMakePackage):
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
 
-    for ver in ['3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('rocprim@' + ver, type='link', when='@' + ver)
+    for ver in ['4.1.0']:
+        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
     patch('e79985dccde22d826aceb3badfc643a3227979d2.patch', when='@3.5.0')
     patch('530047af4a0f437dafc02f76b3a17e3b1536c7ec.patch', when='@3.5.0')

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -13,10 +13,12 @@ class Rccl(CMakePackage):
     and reduce-scatter."""
 
     homepage = "https://github.com/RadeonOpenCompute/rccl"
-    url      = "https://github.com/ROCmSoftwarePlatform/rccl/archive/rocm-4.0.0.tar.gz"
+    git      = "https://github.com/RadeonOpenCompute/rccl.git"
+    url      = "https://github.com/ROCmSoftwarePlatform/rccl/archive/rocm-4.1.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
+    version('4.1.0', sha256='88ec9b43c31cb054fe6aa28bcc0f4b510213635268f951939d6980eee5bb3680')
     version('4.0.0', sha256='0632a15b3d6b5981c05377cf4aeb51546f4c4901fd7c37fb0c98071851ad531a')
     version('3.10.0', sha256='d9dd0b0d8b9d056fc5e6c7b814520800190952acd30dac3a7c462c4cb6f42bb3')
     version('3.9.0', sha256='ff9d03154d668093309ff814a33788f2cc093b3c627e78e42ae246e6017408b0')
@@ -27,13 +29,13 @@ class Rccl(CMakePackage):
     patch('0001-Fix-numactl-path-issue.patch', when='@3.7.0:')
 
     depends_on('cmake@3:', type='build')
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, type=('build', 'run'), when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type=('build', 'run'), when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
-        if ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+        if ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0' '4.1.0']:
             depends_on('numactl@2.0.12', type=('build', 'link'), when='@' + ver)
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -37,6 +37,8 @@ class Rccl(CMakePackage):
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         if ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0' '4.1.0']:
             depends_on('numactl@2.0.12', type=('build', 'link'), when='@' + ver)
+        if ver in ['4.1.0']:
+            depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -16,10 +16,12 @@ class Rocalution(CMakePackage):
        other scientific software packages."""
 
     homepage = "https://github.com/ROCmSoftwarePlatform/rocALUTION"
+    git      = "https://github.com/ROCmSoftwarePlatform/rocALUTION.git"
     url      = "https://github.com/ROCmSoftwarePlatform/rocALUTION/archive/rocm-4.0.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
+    version('4.1.0', sha256='3f61be18a02dff0c152a0ad7eb4779c43dd744b0ba172aa6a4267fc596d582e4')
     version('4.0.0', sha256='80a224a5c19dea290e6edc0e170c3dff2e726c2b3105d599ec6858cc66f076a9')
     version('3.10.0', sha256='c24cb9d1a8a1a3118040b8b16dec7c06268bcf157424d3378256cc9eb93f1b58')
     version('3.9.0', sha256='1ce36801fe1d44f743b46b43345c0cd90d76b73911b2ec97be763f93a35396fb')
@@ -28,7 +30,7 @@ class Rocalution(CMakePackage):
     version('3.5.0', sha256='be2f78c10c100d7fd9df5dd2403a44700219c2cbabaacf2ea50a6e2241df7bfe')
 
     depends_on('cmake@3.5:', type='build')
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('hip@' + ver,  when='@' + ver)
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
         depends_on('rocprim@' + ver, type='link', when='@' + ver)
@@ -36,8 +38,10 @@ class Rocalution(CMakePackage):
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        if ver in ['3.9.0', '3.10.0', '4.0.0']:
+        if ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0']:
             depends_on('rocrand@' + ver, type='link', when='@' + ver)
+        if ver in ['4.1.0']:
+            depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
     patch('0001-fix-hip-build-error.patch')
 

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -10,10 +10,11 @@ class Rocprim(CMakePackage):
     """ Radeon Open Compute Parallel Primitives Library"""
 
     homepage = "https://github.com/ROCmSoftwarePlatform/rocPRIM"
-    url      = "https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/rocm-4.0.0.tar.gz"
+    git      = "https://github.com/ROCmSoftwarePlatform/rocPRIM.git"
+    url      = "https://github.com/ROCmSoftwarePlatform/rocPRIM/archive/rocm-4.1.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
-
+    version('4.1.0', sha256='c46d789f85d15f8ec97f90d67b9d49fb87239912fe8d5f60a7b4c59f9d0e3da8')
     version('4.0.0', sha256='61abf4d51853ae71e54258f43936bbbb096bf06f5891d224d359bfe3104015d0')
     version('3.10.0', sha256='b406956b27d1c06b749e991a250d4ad3eb26e20c6bebf121e2ca6051597b4fa4')
     version('3.9.0', sha256='ace6b4ee4b641280807028375cb0e6fa7b296edba9e9fc09177a5d8d075a716e')
@@ -26,11 +27,13 @@ class Rocprim(CMakePackage):
     depends_on('cmake@3:', type='build')
     depends_on('numactl', type='link', when='@3.7.0:')
 
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
+    for ver in ['4.1.0']:
+        depends_on('hip-rocclr@' + ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -12,10 +12,12 @@ class Rocrand(CMakePackage):
        pseudo-random and quasi-random numbers."""
 
     homepage = "https://github.com/ROCmSoftwarePlatform/rocRAND"
-    url      = "https://github.com/ROCmSoftwarePlatform/rocRAND/archive/rocm-4.0.0.tar.gz"
+    git      = "https://github.com/ROCmSoftwarePlatform/rocRAND.git"
+    url      = "https://github.com/ROCmSoftwarePlatform/rocRAND/archive/rocm-4.1.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
+    version('4.1.0', sha256='94327e38739030ab6719a257f5a928a35842694750c7f46d9e11ff2164c2baed')
     version('4.0.0', sha256='1cafdbfa15cde635bd424d2a858dc5cc94d668f9a211ff39606ee01ed1715f41')
     version('3.10.0', sha256='f55e2b49b4dfd887e46eea049f3359ae03c60bae366ffc979667d364205bc99c')
     version('3.9.0', sha256='a500a3a83be36b6c91aa062dc6eef1f9fc1d9ee62422d541cc279513d98efa91')
@@ -26,14 +28,16 @@ class Rocrand(CMakePackage):
     depends_on('cmake@3.5.1:', type='build')
     depends_on('numactl', when='@3.7.0:')
 
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocminfo@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
-
+    for ver in ['4.1.0']:
+        depends_on('hip-rocclr@'+ ver, type='link', when='@' + ver)
+        
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)
 

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -36,8 +36,8 @@ class Rocrand(CMakePackage):
         depends_on('rocminfo@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
     for ver in ['4.1.0']:
-        depends_on('hip-rocclr@'+ ver, type='link', when='@' + ver)
-        
+        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)
 

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -14,10 +14,12 @@ class Rocsparse(CMakePackage):
     language and optimized for AMD's latest discrete GPUs."""
 
     homepage = "https://github.com/ROCmSoftwarePlatform/rocSPARSE"
-    url      = "https://github.com/ROCmSoftwarePlatform/rocSPARSE/archive/rocm-4.0.0.tar.gz"
+    git      = "https://github.com/ROCmSoftwarePlatform/rocSPARSE.git"
+    url      = "https://github.com/ROCmSoftwarePlatform/rocSPARSE/archive/rocm-4.1.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
+    version('4.1.0', sha256='7514968ed2342dc274acce8b269c128a6aa96cce769a37fd3880b5269c2ed17f')
     version('4.0.0', sha256='2b41bc6623d204ad7f351a902810f34cd32b762d1bf59081dbb00f83e689a794')
     version('3.10.0', sha256='8325828c5d7818dfb45e03b5f1572a573cc21964d596aaaa33b7469817b03abd')
     version('3.9.0', sha256='7b8f952d0c7f8ac2f3bb60879ab420fabbfafb0885a3d8464d5b4c191e97dec6')
@@ -27,13 +29,15 @@ class Rocsparse(CMakePackage):
 
     depends_on('cmake@3:', type='build')
 
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)
         depends_on('hsakmt-roct@' + ver, type='link', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
+    for ver in ['4.1.0']:
+        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -13,10 +13,12 @@ class Rocthrust(CMakePackage):
        library works on HIP/ROCm platforms"""
 
     homepage = "https://github.com/ROCmSoftwarePlatform/rocThrust"
-    url      = "https://github.com/ROCmSoftwarePlatform/rocThrust/archive/rocm-4.0.0.tar.gz"
+    git      = "https://github.com/ROCmSoftwarePlatform/rocThrust.git"
+    url      = "https://github.com/ROCmSoftwarePlatform/rocThrust/archive/rocm-4.1.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
+    version('4.1.0', sha256='e3d06c0387a2a6880776c7423b1acf0808fb8833bc822be75793da8c2f521efd')
     version('4.0.0', sha256='120c87316f44ce8e8975e57c9b9bf1246b1ffc00879d31d744289ba9438a976c')
     version('3.10.0', sha256='31bea6cd19a0ffa15e4ab50ecde2402ea5aaa182149cfab98242357e41f1805b')
     version('3.9.0', sha256='65f5e74d72c5aaee90459468d693b212af7d56e31098ee8237b18d1b4d620eb0')
@@ -30,12 +32,14 @@ class Rocthrust(CMakePackage):
     depends_on('cmake@3:', type='build')
     depends_on('numactl', when='@3.7.0:')
 
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)
+    for ver in ['4.1.0']:
+        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)


### PR DESCRIPTION
@haampie  , while updating the version for rccl package for rocm-4.1.0 i see an error as below. I see similar error with respect to few other packages for rocm-4.1.0  eg -hipcub, rocprim,rocrand etc..
Any thoughts ?
[rccl_4.1.0_spack-build-out.txt](https://github.com/spack/spack/files/6251375/rccl_4.1.0_spack-build-out.txt)
