### PR TITLE
rankstr: new release

### DIFF
--- a/var/spack/repos/builtin/packages/rankstr/package.py
+++ b/var/spack/repos/builtin/packages/rankstr/package.py
@@ -10,12 +10,13 @@ class Rankstr(CMakePackage):
     """Assign one-to-one mapping of MPI ranks to strings"""
 
     homepage = "https://github.com/ecp-veloc/rankstr"
-    url      = "https://github.com/ecp-veloc/rankstr/archive/v0.0.2.zip"
+    url      = "https://github.com/ecp-veloc/rankstr/archive/v0.0.3.tar.gz"
     git      = "https://github.com/ecp-veloc/rankstr.git"
 
     tags = ['ecp']
 
     version('master', branch='master')
+    version('0.0.3', sha256='d32052fbecd44299e13e69bf2dd7e5737c346404ccd784b8c2100ceed99d8cd3')
     version('0.0.2', sha256='c16d53aa9bb79934cbe2dcd8612e2db7d59de80be500c104e39e8623d4eacd8e')
 
     depends_on('mpi')


### PR DESCRIPTION
rankstr now has a new release, v0.0.3.

This adds that version to the package and updates the url.