### PR TITLE
m4: export environment variable for autoconf etc

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -48,6 +48,14 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
         match = re.search(r'GNU M4\)?\s+(\S+)', output)
         return match.group(1) if match else None
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        # Inform autom4te if it wasn't built correctly (some external
+        # installations such as homebrew)
+        env.set('M4', self.prefix.bin.m4)
+
+    def setup_run_environment(self, env):
+        env.set('M4', self.prefix.bin.m4)
+
     def configure_args(self):
         spec = self.spec
         args = ['--enable-c++']

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -50,7 +50,8 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         # Inform autom4te if it wasn't built correctly (some external
-        # installations such as homebrew)
+        # installations such as homebrew). See
+        # https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/autom4te-Invocation.html
         env.set('M4', self.prefix.bin.m4)
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
I have the autotools  packages (m4, autoconf, etc.) loaded as externals through homebrew. To my consternation, a clean build of my toolchain with a clean homebrew+spack fails during any autotools package:
```
+ aclocal -I Tools/config
autom4te: error: need GNU m4 1.4 or later: /usr/local/opt/m4/bin/m4
aclocal: error: autom4te failed with exit status: 1
```
digging into this I found that the brew-installed autoconf (specifically `autom4te`) has the wrong default prefix, since Homebrew no longer symlinks m4 to `opt/`:
```perl
my $m4 = $ENV{"M4"} || '/usr/local/opt/m4/bin/m4';
```

So I've added code in the `m4` spack package to export this environment variable.

I'm not sure where the right place in homebrew is to report the error, since it seems like an installation with Homebrew. (It's definitely not spack's fault.) Regardless, exporting the M4 environment variable should make spack's autotools toolchain more robust, and it fixes my problem without waiting for a homebrew update.