### PR TITLE
Remove erroneous warnings about quotes for from_source_file

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -942,7 +942,9 @@ def environment_after_sourcing_files(*files, **kwargs):
             source_file, suppress_output,
             concatenate_on_success, dump_environment,
         ])
-        output = shell(source_file_arguments, output=str, env=environment)
+        output = shell(
+            source_file_arguments, output=str, env=environment, ignore_quotes=True
+        )
         environment = json.loads(output)
 
         # If we're in python2, convert to str objects instead of unicode


### PR DESCRIPTION
Fixes #22766 
Fixes #22775 
Fixes #22774 

### Before

```console
$ spack load intel-mkl
==> Warning: Quotes in command arguments can confuse scripts like configure.
  The following arguments may cause problems when executed:
      source /dev/null &> /dev/null && python3 -c "import os, json; print(json.dumps(dict(os.environ)))"
  Quotes aren't needed because spack doesn't use a shell.
  Consider removing them
==> Warning: Quotes in command arguments can confuse scripts like configure.
  The following arguments may cause problems when executed:
      source /opt/intel/compilers_and_libraries_2020.0.166/mac/mkl/bin/mklvars.sh intel64 &> /dev/null && python3 -c "import os, json; print(json.dumps(dict(os.environ)))"
  Quotes aren't needed because spack doesn't use a shell.
  Consider removing them
```

### After

```console
$ spack load intel-mkl
```

See #22766 for a more detailed diagnosis of why we were raising this warning message and why it was a red herring.