### PR TITLE
Extended hipsycl to version 0.9.1 

### DIFF
--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -23,6 +23,10 @@ class Hipsycl(CMakePackage):
 
     version("stable", branch="stable", submodules=True)
     version(
+        "0.9.1",
+        commit="fe8465cd5399a932f7221343c07c9942b0fe644c",
+        submodules=True)
+    version(
         "0.8.0",
         commit="2daf8407e49dd32ebd1c266e8e944e390d28b22a",
         submodules=True,
@@ -35,7 +39,8 @@ class Hipsycl(CMakePackage):
     )
 
     depends_on("cmake@3.5:", type="build")
-    depends_on("boost +filesystem")
+    depends_on("boost +filesystem", when="@:0.8.99")
+    depends_on("boost@1.67.0:1.69.0 +filesystem +fiber +context cxxstd=17", when='@0.9.1:')
     depends_on("python@3:")
     depends_on("llvm@8: +clang", when="~cuda")
     depends_on("llvm@9: +clang", when="+cuda")
@@ -46,8 +51,13 @@ class Hipsycl(CMakePackage):
 
     conflicts(
         "%gcc@:4.9999",
+        when='@:0.9.0',
         msg="hipSYCL needs proper C++14 support to be built, %gcc is too old",
     )
+    conflicts(
+        "%gcc@:8.9999",
+        when='@0.9.1:',
+        msg="hipSYCL needs proper C++17 support to be built, %gcc is too old")
     conflicts(
         "^llvm build_type=Debug",
         when="+cuda",


### PR DESCRIPTION
hipsycl@0.9.1 partially implements SYCL 2020 standard which provides support for Unified Shared Memory