### PR TITLE
doxygen: add version restriction

### DIFF
--- a/var/spack/repos/builtin/packages/doxygen/package.py
+++ b/var/spack/repos/builtin/packages/doxygen/package.py
@@ -63,10 +63,11 @@ class Doxygen(CMakePackage):
     depends_on("python", type='build')  # 2 or 3 OK; used in CMake build
     depends_on("iconv")
     depends_on("flex", type='build')
+    depends_on("bison", type='build')
     # code.l just checks subminor version <=2.5.4 or >=2.5.33
     # but does not recognize 2.6.x as newer...could be patched if needed
     depends_on("flex@2.5.39", type='build', when='@1.8.10')
-    depends_on("bison", type='build')
+    depends_on("bison@2.7:", type='build', when='@1.8.10:')
 
     # optional dependencies
     depends_on("graphviz", when="+graphviz", type='run')


### PR DESCRIPTION
This triggered on my mac because clingo seems to have bootstrapped a very old version distributed by apple.

```
    'cmake' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:STRING=/rnsdhpc/code/spack/opt/spack/apple-clang/doxygen/qi3msaz' '-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo' '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_FIND_FRAMEWORK:STRING=LAST' '-DCMAKE_FIND_APPBUNDLE:STRING=LAST' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF' '-DCMAKE_INSTALL_RPATH:STRING=/rnsdhpc/code/spack/opt/spack/apple-clang/doxygen/qi3msaz/lib;/rnsdhpc/code/spack/opt/spack/apple-clang/doxygen/qi3msaz/lib64;/rnsdhpc/code/spack/opt/spack/apple-clang/libiconv/tj3twqm/lib' '-DCMAKE_PREFIX_PATH:STRING=/usr/local/Cellar/cmake/3.20.0;/rnsdhpc/code/spack/opt/spack/apple-clang/flex/ephtsaz;/rnsdhpc/code/spack/opt/spack/apple-clang/libiconv/tj3twqm;/rnsdhpc/code/spack/opt/spack/apple-clang/python/caziios' '/var/folders/gy/mrg1ffts2h945qj9k29s1l1dvvmbqb/T/s3j/spack-stage/spack-stage-doxygen-1.9.1-qi3msazkuiypgj3pvzsoe4qaxtl6klfe/spack-src'

1 error found in build log:
     12    -- Check for working CXX compiler: /rnsdhpc/code/spack/lib/spack/env/clang/clang++ - skippe
           d
     13    -- Detecting CXX compile features
     14    -- Detecting CXX compile features - done
     15    -- Found PythonInterp: /rnsdhpc/code/spack/opt/spack/apple-clang/python/caziios/bin/python
           (found version "3.8.8")
     16    -- Found FLEX: /rnsdhpc/code/spack/opt/spack/apple-clang/flex/ephtsaz/bin/flex (found versi
           on "2.6.4")
     17    -- Found BISON: /usr/bin/bison (found version "2.3")
  >> 18    CMake Error at CMakeLists.txt:108 (message):
     19      Doxygen requires at least bison version 2.7 (installed: 2.3)
     20
     21
     22    -- Looking for pthread.h
     23    -- Looking for pthread.h - found
     24    -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
```