### PR TITLE
Add patch for latest hwloc@:1 to locate ncurses

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/0001-Try-linking-to-libtinfo.patch
+++ b/var/spack/repos/builtin/packages/hwloc/0001-Try-linking-to-libtinfo.patch
@@ -1,0 +1,25 @@
+From 0847b85eb65f7648f9104ae1e69e0c657d836031 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Mon, 5 Apr 2021 12:51:38 +0200
+Subject: [PATCH] Try linking to libtinfo
+
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index b775477..fb89d30 100755
+--- a/configure
++++ b/configure
+@@ -16811,7 +16811,7 @@ done
+     chosen_curses=""
+     for curses in ncurses curses
+     do
+-      for lib in "" -ltermcap -l${curses}w -l$curses
++      for lib in "" -ltermcap -l${curses}w -l$curses -ltinfo
+       do
+         { $as_echo "$as_me:${as_lineno-$LINENO}: checking termcap support using $curses and $lib" >&5
+ $as_echo_n "checking termcap support using $curses and $lib... " >&6; }
+-- 
+2.31.1
+

--- a/var/spack/repos/builtin/packages/hwloc/0001-Try-linking-to-libtinfo.patch
+++ b/var/spack/repos/builtin/packages/hwloc/0001-Try-linking-to-libtinfo.patch
@@ -16,7 +16,7 @@ index b775477..fb89d30 100755
      for curses in ncurses curses
      do
 -      for lib in "" -ltermcap -l${curses}w -l$curses
-+      for lib in "" -ltermcap -l${curses}w -l$curses -ltinfo
++      for lib in "" -l${curses}w -l$curses -ltinfo -ltermcap
        do
          { $as_echo "$as_me:${as_lineno-$LINENO}: checking termcap support using $curses and $lib" >&5
  $as_echo_n "checking termcap support using $curses and $lib... " >&6; }

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -90,10 +90,19 @@ class Hwloc(AutotoolsPackage):
     depends_on('libxml2', when='+libxml2')
     depends_on('cairo', when='+cairo')
     depends_on('numactl', when='@:1.11.11 platform=linux')
-
-    # see https://github.com/open-mpi/hwloc/pull/417
-    depends_on('ncurses ~termlib', when='@:2.2')
     depends_on('ncurses')
+
+    # Before 2.2 hwloc does not consider linking to libtinfo
+    # to detect ncurses, which is considered a bug.
+    # For older versions this can be fixed by depending on
+    # ncurses~termlib, but this could lead to insatisfiable
+    # constraints (e.g. llvm explicitly depends on ncurses+termlib)
+    # Therefore we patch the latest 1.x configure script to make
+    # it consider libtinfo too.
+    # see https://github.com/open-mpi/hwloc/pull/417
+    patch('0001-Try-linking-to-libtinfo.patch', when='@1.11.13')
+    depends_on('ncurses ~termlib', when='@2.0:2.2')
+    depends_on('ncurses ~termlib', when='@1.0:1.11.12')
 
     # When mpi=openmpi, this introduces an unresolvable dependency.
     # See https://github.com/spack/spack/issues/15836 for details


### PR DESCRIPTION
This way we don't have to depend on ncurses~termlib, which may run into
issues when another package explicitly depends on ncurses+termlib

Fixes https://github.com/spack/spack/pull/15039#issuecomment-813125432, ping @amaji.

FWIW, on my macbook hwloc ends up linking to system `/usr/lib/libncurses.5.4.dylib` that's a separate issue I guess:

```
$ ls -al /usr/lib/libtermcap.dylib 
lrwxr-xr-x  1 root  wheel  20 22 Dez  2019 /usr/lib/libtermcap.dylib -> libncurses.5.4.dylib
```

Edit: fixed in last commit