### PR TITLE
AutoTools: Improve user flag handling

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -844,6 +844,11 @@ class AutotoolsPackage(PackageBase):
                                 }
         # get the build type as lower case
         build_type = spec.variants['build_type'].value.lower()
+
+        # always do nothing
+        if build_type == 'undefined':
+            return
+
         # create a list from the string
         build_type_flags = build_type_flags_map[build_type].split()
 
@@ -958,7 +963,8 @@ class AutotoolsPackage(PackageBase):
         # DISABLED initially - included to demostrate why the prior effort
         # make this clean to implement
         #
-        self._configure_apply_build_type(spec, final_flags)
+        if spec.variants['build_type'].value != 'Undefiend':
+            self._configure_apply_build_type(spec, final_flags)
 
         # we now have the final flag map, prepare to set the flags
         # based on the prefered locations. If the flag var was discovered

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -599,10 +599,21 @@ class AutotoolsPackage(PackageBase):
         '''
         global env
 
-        all_same_src = set([src for _, src in flag_src.items()])
+        # if we encounter a variable we lack source info for
+        # then send then set the flag in this location
         unknown_use_src = src_mapping['default']
+
+        # find how many unique sources we have
+        # we query `flag_src` because that is populated based
+        # variables the package set. E.g., not from build_type
+        # or anything that automatically adds flags
+        all_same_src = set([src for _, src in flag_src.items()])
+        # if we found all flags from a single source (as set by the package)
+        # then we will set unknown sources in that same space
         if len(all_same_src) == 1:
-            unknown_use_src = all_same_src.pop()
+            # if the set has a single value, then use that location
+            # but make sure to *lookup* the mapping.
+            unknown_use_src = src_mapping[all_same_src.pop()]
 
         return_map = {}
         for var_name, var_value in unified_flags.items():

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -493,6 +493,13 @@ class AutotoolsPackage(PackageBase):
             # collect the spack flags from the spec
             spack_flag_name = var_to_spack_map[env_flag_var_name]
             spack_flags = spec.compiler_flags[spack_flag_name]
+            # now check that there is a spack variable to set
+            if not spack_flags:
+                tty.debug("{0} NOT adding: {1}={2} to configure args"
+                          "".format("enforce_user_flags: ",
+                                    env_flag_var_name,
+                                    ' '.join(spack_flags)))
+                continue
             # should be a list, but be safe
             if isinstance(spack_flags, six.string_types):
                 spack_flags = [spack_flags]
@@ -741,7 +748,7 @@ class AutotoolsPackage(PackageBase):
         # is not declared.
         for flag_env_var_name in flag_variables:
             # add the variable and flags if it doens't exist.
-            # subjust to `add_if_var_undefined`
+            # subject to `add_if_var_undefined`
             if flag_env_var_name not in flag_map and add_if_var_undefined:
                 flag_map[flag_env_var_name] = ' '.join(build_type_flags)
 

--- a/var/spack/repos/builtin/packages/autotools-test-compiler-flags/package.py
+++ b/var/spack/repos/builtin/packages/autotools-test-compiler-flags/package.py
@@ -3,32 +3,17 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install autotools-test-compiler-flags
-#
-# You can edit this file again by typing:
-#
-#     spack edit autotools-test-compiler-flags
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
 
 from spack import *
 import llnl.util.tty as tty
 
 
 class AutotoolsTestCompilerFlags(AutotoolsPackage):
-    """FIXME: Put a proper description of your package here."""
+    """Misery and Suffering await you (this package should be a test... but there
+    isn't a 'test' directory for pacakges.
+    """
 
-    # FIXME: Add a proper url for your package's homepage here.
-    homepage = "https://www.example.com"
+    homepage = "https://www.blah.com"
     url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
 
     version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825')
@@ -52,7 +37,6 @@ class AutotoolsTestCompilerFlags(AutotoolsPackage):
                         " Pipe because single valued variants won't allow"
                         " commas, semicolons, or spaces")
 
-    # FIXME: Add dependencies if required.
     depends_on('mpi')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/autotools-test-compiler-flags/package.py
+++ b/var/spack/repos/builtin/packages/autotools-test-compiler-flags/package.py
@@ -1,0 +1,83 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install autotools-test-compiler-flags
+#
+# You can edit this file again by typing:
+#
+#     spack edit autotools-test-compiler-flags
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+import llnl.util.tty as tty
+
+
+class AutotoolsTestCompilerFlags(AutotoolsPackage):
+    """FIXME: Put a proper description of your package here."""
+
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://www.example.com"
+    url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
+
+    version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825')
+
+    # notify when the package is updated.
+    maintainers = ['jjellio']
+
+    variant('set_in_build_env',
+            default='Undefined',
+            multi=False,
+            description='Pipe (|) separated lists of VAR=VAL you wish set in'
+                        ' setup_build_environment-'
+                        " Pipe because single valued variants won't allow"
+                        " commas, semicolons, or spaces")
+
+    variant('set_in_configure_args',
+            default='Undefined',
+            multi=False,
+            description='Pipe (|) separated lists of VAR=VAL you wish set in'
+                        ' configure_args -'
+                        " Pipe because single valued variants won't allow"
+                        " commas, semicolons, or spaces")
+
+    # FIXME: Add dependencies if required.
+    depends_on('mpi')
+
+    def configure_args(self):
+        spec = self.spec
+        args = []
+
+        args_to_set = spec.variants['set_in_configure_args'].value
+        if args_to_set == 'Undefined':
+            return args
+
+        # do whatever was passed in
+        args = [var_val for var_val in args_to_set.split('|')]
+        for name, _, val in [arg.partition('=') for arg in args]:
+            tty.msg('[configure_args] Setting {0}={1}'.format(name, val))
+        return args
+
+    def setup_build_environment(self, spack_env):
+        spec = self.spec
+
+        args_to_set = spec.variants['set_in_build_env'].value
+        if args_to_set == 'Undefined':
+            return
+
+        # do whatever was passed in
+        for name, _, val in [var_val.partition('=')
+                             for var_val in args_to_set.split('|')]:
+            spack_env.set(name, val)
+            tty.msg('[setup_build_environment] Setting {0}={1}'.format(name, val))


### PR DESCRIPTION
AutoTool packages are inconconsistent in handling user flags. Some use `set_build_environment` to declare `VAR=VAL` arguments, or declare those variables in `configure_args`. When doing this, the package usually does not append `spec.compiler[cflags]` or other relevant spack flags.

Spack provides some tooling to handling variables set in `setup_build_environment`, but because of the flexibility in Autotools, this does not result in consistent behavior

E.g., See Issue #14430. And Related #19052

This patch provides some sanity checking to configure arguments and enforces that user flags get added.

This patch does not (yet) attempt to remove duplicate flags.

This patch lays the ground work for supporting a CMake-like `build_type` parameter - and having those args consistently applied.

For now, this patch has the variant for `build_type` declared, but the flag handling is not added (Given the code, adding these flags would be simple)