### PR TITLE
Update trf package

### DIFF
--- a/var/spack/repos/builtin/packages/trf/package.py
+++ b/var/spack/repos/builtin/packages/trf/package.py
@@ -7,7 +7,7 @@ from spack import *
 import os
 
 
-class Trf(Package):
+class Trf(AutotoolsPackage):
     """Tandem Repeats Finder is a program to locate and display tandem repeats
        in DNA sequences.
 
@@ -18,13 +18,34 @@ class Trf(Package):
        http://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://tandem.bu.edu/trf/trf.html"
+    url      = "https://github.com/Benson-Genomics-Lab/TRF/archive/refs/tags/v4.09.1.tar.gz"
+
+    version('4.09.1',      sha256='516015b625473350c3d1c9b83cac86baea620c8418498ab64c0a67029c3fb28a')
+    version('4.09',        sha256='9332155384bef82f6c7c449c038d27f1a14b984b2e93000bfcf125f4d44d6aca')
+
+    # Beginning with version 4.09, trf is open source and available via github.
+    # Only version 4.07b needs to be installed as a binary.
     manual_download = True
 
-    version('4.09', '0c594fe666e0332db1df9d160d7fabc8', expand=False,
-            url='file://{0}/trf409.linux64'.format(os.getcwd()))
-    version('4.07b', sha256='a3a760c7b74c9603fbc08d95e8fa696c00f35a2f179b0bd63b2b13757ad3b471', expand=False,
-            url='file://{0}/trf407b.linux64'.format(os.getcwd()))
+    version('4.07b',
+            sha256='a3a760c7b74c9603fbc08d95e8fa696c00f35a2f179b0bd63b2b13757ad3b471',
+            expand=False,
+            url='file://{0}/trf407b.linux64'.format(os.getcwd()),
+            deprecated=True)
 
+    @when('@4.07b')
+    def autoreconf(self, spec, prefix):
+        touch('configure')
+
+    @when('@4.07b')
+    def configure(self, spec, prefix):
+        pass
+
+    @when('@4.07b')
+    def build(self, spec, prefix):
+        pass
+
+    @when('@4.07b')
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 


### PR DESCRIPTION
- add new version, 4.09.1
- use github url
- convert to autotools package
- deprecate version 4.07b: This version requires manual download and is
  a binary only installation.