### PR TITLE
hdf5: avoid compilation with -I/usr/include

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -6,6 +6,8 @@
 import shutil
 import sys
 
+from spack.util.environment import is_system_path
+
 
 class Hdf5(AutotoolsPackage):
     """HDF5 is a data model, library, and file format for storing and managing
@@ -249,8 +251,14 @@ class Hdf5(AutotoolsPackage):
         # combinations of other arguments. Enabling it just skips a
         # sanity check in configure, so this doesn't merit a variant.
         extra_args = ['--enable-unsupported',
-                      '--enable-symbols=yes',
-                      '--with-zlib=%s' % self.spec['zlib'].prefix]
+                      '--enable-symbols=yes']
+
+        # Do not specify the prefix of zlib if it is in a system directory
+        # (see https://github.com/spack/spack/pull/21900).
+        zlib_prefix = self.spec['zlib'].prefix
+        extra_args.append('--with-zlib=%s' %
+                          'yes' if is_system_path(zlib_prefix) else zlib_prefix)
+
         extra_args += self.enable_or_disable('threadsafe')
         extra_args += self.enable_or_disable('cxx')
         extra_args += self.enable_or_disable('hl')

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -256,8 +256,8 @@ class Hdf5(AutotoolsPackage):
         # Do not specify the prefix of zlib if it is in a system directory
         # (see https://github.com/spack/spack/pull/21900).
         zlib_prefix = self.spec['zlib'].prefix
-        extra_args.append('--with-zlib=%s' %
-                          'yes' if is_system_path(zlib_prefix) else zlib_prefix)
+        extra_args.append('--with-zlib={0}'.format(
+            'yes' if is_system_path(zlib_prefix) else zlib_prefix))
 
         extra_args += self.enable_or_disable('threadsafe')
         extra_args += self.enable_or_disable('cxx')


### PR DESCRIPTION
The problem that was reported and fixed in #21900 has been reintroduced in #22737 (#19316).

It looks like the quick fix mentioned in https://github.com/spack/spack/pull/21900#issuecomment-810741473 was a bit too quick. This PR should cover both cases.

@becker33 @white238 I am very curious why `axom` requires `hdf5` to be configured with `--with-zlib=/zlib/prefix`. Could you, please, give some details on that? Thank you.

The only explanation I can come up with is that there is a `libz.la` file somewhere on the system, which would be strange since `zlib` is not a libtool package.

