### PR TITLE
iozone: adds 3.491 and fixes permissions

### DIFF
--- a/var/spack/repos/builtin/packages/iozone/package.py
+++ b/var/spack/repos/builtin/packages/iozone/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-
+import os
 
 class Iozone(MakefilePackage):
     """IOzone is a filesystem benchmark tool. The benchmark generates and
@@ -23,8 +23,11 @@ class Iozone(MakefilePackage):
     build_directory = 'src/current'
 
     def edit(self, spec, prefix):
-        chmod = which('chmod')
-        chmod('-R', '755', self.stage.source_path)
+        for dirpath, dirnames, filenames in os.walk(self.stage.source_path):
+            for filename in filenames:
+                path = os.path.join(dirpath, filename)
+                os.chmod(path, 0o644)
+
         with working_dir(self.build_directory):
             filter_file(r'^CC\t= cc',
                         r'CC\t= {0}'.format(spack_cc),

--- a/var/spack/repos/builtin/packages/iozone/package.py
+++ b/var/spack/repos/builtin/packages/iozone/package.py
@@ -14,6 +14,7 @@ class Iozone(MakefilePackage):
     homepage = "http://www.iozone.org/"
     url      = "http://www.iozone.org/src/current/iozone3_465.tar"
 
+    version('3_491', sha256='2cc4842d382e46a585d1df9ae1e255695480dcc0fc05c3b1cb32ef3493d0ec9a')
     version('3_465', sha256='2e3d72916e7d7340a7c505fc0c3d28553fcc5ff2daf41d811368e55bd4e6a293')
 
     # TODO: Add support for other architectures as necessary
@@ -22,6 +23,8 @@ class Iozone(MakefilePackage):
     build_directory = 'src/current'
 
     def edit(self, spec, prefix):
+        chmod = which('chmod')
+        chmod('-R', '755', self.stage.source_path)
         with working_dir(self.build_directory):
             filter_file(r'^CC\t= cc',
                         r'CC\t= {0}'.format(spack_cc),

--- a/var/spack/repos/builtin/packages/iozone/package.py
+++ b/var/spack/repos/builtin/packages/iozone/package.py
@@ -6,6 +6,7 @@
 from spack import *
 import os
 
+
 class Iozone(MakefilePackage):
     """IOzone is a filesystem benchmark tool. The benchmark generates and
     measures a variety of file operations. Iozone has been ported to many


### PR DESCRIPTION
- New version supports GCC >10
- Fixes #17134