### PR TITLE
Integrate oneAPI 2021.2.0 release

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -11,16 +11,20 @@ from spack import *
 class IntelOneapiCcl(IntelOneApiLibraryPackage):
     """Intel oneAPI CCL."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/oneccl.html'
 
     depends_on('intel-oneapi-mpi')
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17731/l_oneapi_ccl_p_2021.2.0.269_offline.sh',
+                sha256='18b7875030243295b75471e235e91e5f7b4fc15caf18c07d941a6d47fba378d7',
+                expand=False)
         version('2021.1.1',
-                sha256='de732df57a03763a286106c8b885fd60e83d17906936a8897a384b874e773f49',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17391/l_oneapi_ccl_p_2021.1.1.54_offline.sh',
+                sha256='de732df57a03763a286106c8b885fd60e83d17906936a8897a384b874e773f49',
                 expand=False)
 
     @property

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -15,15 +15,26 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     """Intel OneAPI compilers
 
     Provides Classic and Beta compilers for: Fortran, C, C++"""
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
 
     depends_on('patchelf', type='build')
 
     if platform == 'linux':
+        version('2021.2.0',
+                sha256='5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh',
+                expand=False)
+        resource(name='fortran-installer',
+                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh',
+                 sha256='a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1',
+                 expand=False,
+                 placement='fortran-installer',
+                 when='@2021.2.0')
         version('2021.1.2',
-                sha256='68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh',
+                sha256='68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a',
                 expand=False)
         resource(name='fortran-installer',
                  url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -12,14 +12,18 @@ from spack import *
 class IntelOneapiDal(IntelOneApiLibraryPackage):
     """Intel oneAPI DAL."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onedal.html'
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17747/l_daal_oneapi_p_2021.2.0.358_offline.sh',
+                sha256='cbf4e64dbd21c10179f2d1d7e8b8b0f12eeffe6921602df33276cd0ebd1f8e34',
+                expand=False)
         version('2021.1.1',
-                sha256='6e0e24bba462e80f0fba5a46e95cf0cca6cf17948a7753f8e396ddedd637544e',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17443/l_daal_oneapi_p_2021.1.1.79_offline.sh',
+                sha256='6e0e24bba462e80f0fba5a46e95cf0cca6cf17948a7753f8e396ddedd637544e',
                 expand=False)
 
     depends_on('intel-oneapi-tbb')

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -12,14 +12,18 @@ from spack import *
 class IntelOneapiDnn(IntelOneApiLibraryPackage):
     """Intel oneAPI DNN."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onednn.html'
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17751/l_onednn_p_2021.2.0.228_offline.sh',
+                sha256='62121a3355298211a124ff4e71c42fc172bf1061019be6c6120830a1a502aa88',
+                expand=False)
         version('2021.1.1',
-                sha256='24002c57bb8931a74057a471a5859d275516c331fd8420bee4cae90989e77dc3',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17385/l_onednn_p_2021.1.1.55_offline.sh',
+                sha256='24002c57bb8931a74057a471a5859d275516c331fd8420bee4cae90989e77dc3',
                 expand=False)
 
     depends_on('intel-oneapi-tbb')

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -11,14 +11,18 @@ from spack import *
 class IntelOneapiIpp(IntelOneApiLibraryPackage):
     """Intel oneAPI IPP."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17758/l_ipp_oneapi_p_2021.2.0.233_offline.sh',
+                sha256='ccdfc81f77203822d80151b40ce9e8fd82bb2de85a9b132ceed12d24d3f3ff52',
+                expand=False)
         version('2021.1.1',
-                sha256='2656a3a7f1f9f1438cbdf98fd472a213c452754ef9476dd65190a7d46618ba86',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17436/l_ipp_oneapi_p_2021.1.1.47_offline.sh',
+                sha256='2656a3a7f1f9f1438cbdf98fd472a213c452754ef9476dd65190a7d46618ba86',
                 expand=False)
 
     depends_on('intel-oneapi-tbb')

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -12,14 +12,18 @@ from spack import *
 class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     """Intel oneAPI IPP Crypto."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17684/l_ippcp_oneapi_p_2021.2.0.231_offline.sh',
+                sha256='64cd5924b42f924b6a8128a8bf8e686f5dc52b98f586ffac6c2e2f1585e3aba9',
+                expand=False)
         version('2021.1.1',
-                sha256='c0967afae22c7a223ec42542bcc702121064cd3d8f680eff36169c94f964a936',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17415/l_ippcp_oneapi_p_2021.1.1.54_offline.sh',
+                sha256='c0967afae22c7a223ec42542bcc702121064cd3d8f680eff36169c94f964a936',
                 expand=False)
 
     @property

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -12,14 +12,18 @@ from spack import *
 class IntelOneapiMkl(IntelOneApiLibraryPackage):
     """Intel oneAPI MKL."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html'
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17757/l_onemkl_p_2021.2.0.296_offline.sh',
+                sha256='816e9df26ff331d6c0751b86ed5f7d243f9f172e76f14e83b32bf4d1d619dbae',
+                expand=False)
         version('2021.1.1',
-                sha256='818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17402/l_onemkl_p_2021.1.1.52_offline.sh',
+                sha256='818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c',
                 expand=False)
 
     depends_on('intel-oneapi-tbb')

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -15,14 +15,18 @@ from spack import *
 class IntelOneapiMpi(IntelOneApiLibraryPackage):
     """Intel oneAPI MPI."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html'
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17729/l_mpi_oneapi_p_2021.2.0.215_offline.sh',
+                sha256='d0d4cdd11edaff2e7285e38f537defccff38e37a3067c02f4af43a3629ad4aa3',
+                expand=False)
         version('2021.1.1',
-                sha256='8b7693a156c6fc6269637bef586a8fd3ea6610cac2aae4e7f48c1fbb601625fe',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17397/l_mpi_oneapi_p_2021.1.1.76_offline.sh',
+                sha256='8b7693a156c6fc6269637bef586a8fd3ea6610cac2aae4e7f48c1fbb601625fe',
                 expand=False)
 
     provides('mpi@:3')

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -12,14 +12,18 @@ from spack import *
 class IntelOneapiTbb(IntelOneApiLibraryPackage):
     """Intel oneAPI TBB."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onetbb.html'
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17759/l_tbb_oneapi_p_2021.2.0.357_offline.sh',
+                sha256='c1c3623c5bef547b30eac009e7a444611bf714c758d7472c114e9be9d5700eba',
+                expand=False)
         version('2021.1.1',
-                sha256='535290e3910a9d906a730b24af212afa231523cf13a668d480bade5f2a01b53b',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17378/l_tbb_oneapi_p_2021.1.1.119_offline.sh',
+                sha256='535290e3910a9d906a730b24af212afa231523cf13a668d480bade5f2a01b53b',
                 expand=False)
 
     provides('tbb')

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -11,14 +11,18 @@ from spack import *
 class IntelOneapiVpl(IntelOneApiLibraryPackage):
     """Intel oneAPI VPL."""
 
-    maintainers = ['rscohn2']
+    maintainers = ['rscohn2', 'danvev']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onevpl.html'
 
     if platform == 'linux':
+        version('2021.2.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17733/l_oneVPL_p_2021.2.2.212_offline.sh',
+                sha256='21106ba5cde22f3e31fd55280fbccf263508fa054030f12d5dff4a5379ef3bb7',
+                expand=False)
         version('2021.1.1',
-                sha256='0fec42545b30b7bb2e4e33deb12ab27a02900f5703153d9601673a8ce43082ed',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17418/l_oneVPL_p_2021.1.1.66_offline.sh',
+                sha256='0fec42545b30b7bb2e4e33deb12ab27a02900f5703153d9601673a8ce43082ed',
                 expand=False)
 
     @property

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -16,7 +16,7 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onevpl.html'
 
     if platform == 'linux':
-        version('2021.2.0',
+        version('2021.2.2',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17733/l_oneVPL_p_2021.2.2.212_offline.sh',
                 sha256='21106ba5cde22f3e31fd55280fbccf263508fa054030f12d5dff4a5379ef3bb7',
                 expand=False)


### PR DESCRIPTION
Add oneAPI packages from the 2021.2 release

I did manual checks of units test, style checking and oneapi-tests on the local machine. 
oneapi-test CI results: https://github.com/DanVev/oneapi-spack-tests/actions/runs/725842061  
All is good except VPL issue, but it a package-wide problem and it might be release-noted etc. 
I'll update the VPL package in case it will be repackaged.

FYI: @rscohn2 