### PR TITLE
py-ray needs exact bazel dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-ray/package.py
+++ b/var/spack/repos/builtin/packages/py-ray/package.py
@@ -16,7 +16,7 @@ class PyRay(PythonPackage):
     build_directory = 'python'
 
     depends_on('python@3.6:', type=('build', 'run'))
-    depends_on('bazel@3.2.0:', type='build')
+    depends_on('bazel@3.2.0', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-cython@0.29.14:', type='build')
     depends_on('py-wheel', type='build')


### PR DESCRIPTION
As stated at:

https://github.com/ray-project/ray/issues/11237

The py-ray package needs bazel@3.2.0 (exact version) since the "--experimental_ui_deduplicate" has disappeared in recent versions.