### PR TITLE
Merge py-uproot4 into py-uproot

### DIFF
--- a/var/spack/repos/builtin/packages/py-uproot/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class PyUproot(PythonPackage):
-    """ROOT I/O in pure Python and NumPy
+    """ROOT I/O in pure Python and NumPy.
 
     Uproot is a reader and a writer of the ROOT file format using only Python
     and Numpy. Unlike the standard C++ ROOT implementation, Uproot is only an

--- a/var/spack/repos/builtin/packages/py-uproot/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot/package.py
@@ -25,7 +25,7 @@ class PyUproot(PythonPackage):
     tags = ['hep']
 
     version('master', branch='master')
-    version('4.0.6', sha256='1bea2ccc899c6959fb2af69d7e5d1e2df210caab30d3510e26f3fc07c143c37e')
+    version('4.0.6', sha256='359eba307dfbf40b26a2da67ec829bd82cce67aad8c22120e02df3401be2870d')
     version('4.0.2', sha256='8145af29788cbe6bf0ee279a7f176159f3eee801641ead4ad6e627f8c4dff0a9')
     version('0.1.2', sha256='b32dbffadc87bc5707ee0093964d2ce4a5ccfd521b17bbf10732afc25b820d82')
     version('0.0.27', sha256='de87555937332998b476f3e310392962bc983bddc008ed2b3c07a25c0379c4c9')

--- a/var/spack/repos/builtin/packages/py-uproot/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class PyUproot(PythonPackage):
-    """ROOT I/O in pure Python and NumPy.
+    """ROOT I/O in pure Python and NumPy
 
     Uproot is a reader and a writer of the ROOT file format using only Python
     and Numpy. Unlike the standard C++ ROOT implementation, Uproot is only an
@@ -16,11 +16,36 @@ class PyUproot(PythonPackage):
     on C++ ROOT. Instead, it uses Numpy to cast blocks of data from the ROOT
     file as Numpy arrays."""
 
-    homepage = "https://github.com/scikit-hep/uproot4"
-    pypi     = "uproot/uproot-4.0.6.tar.gz"
+    homepage = "https://uproot4.readthedocs.io"
+    git      = "https://github.com/scikit-hep/uproot4"
+    url      = "https://github.com/scikit-hep/uproot4/archive/0.0.27.tar.gz"
 
+    maintainers = ['vvolkl']
+
+    tags = ['hep']
+
+    version('master', branch='master')
     version('4.0.6', sha256='1bea2ccc899c6959fb2af69d7e5d1e2df210caab30d3510e26f3fc07c143c37e')
+    version('4.0.2', sha256='8145af29788cbe6bf0ee279a7f176159f3eee801641ead4ad6e627f8c4dff0a9')
+    version('0.1.2', sha256='b32dbffadc87bc5707ee0093964d2ce4a5ccfd521b17bbf10732afc25b820d82')
+    version('0.0.27', sha256='de87555937332998b476f3e310392962bc983bddc008ed2b3c07a25c0379c4c9')
 
-    depends_on('python@2.6:2.999,3.5:', type=('build', 'run'))
+    variant('xrootd', default=True,
+            description='Build with xrootd support ')
+    variant('lz4', default=True,
+            description='Build with support for reading '
+                        'lz4-compressed rootfiles ')
+
+    variant('zstd', default=True,
+            description='Build with support for reading '
+                        'zstd-compressed rootfiles ')
+
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=('build', 'run'))
+
+    depends_on('xrootd', when="+xrootd")
+
+    depends_on('lz4', when="+lz4")
+    depends_on('xxhash', when="+lz4")
+
+    depends_on('zstd', when="+zstd")

--- a/var/spack/repos/builtin/packages/py-uproot/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot/package.py
@@ -16,19 +16,14 @@ class PyUproot(PythonPackage):
     on C++ ROOT. Instead, it uses Numpy to cast blocks of data from the ROOT
     file as Numpy arrays."""
 
-    homepage = "https://uproot4.readthedocs.io"
-    git      = "https://github.com/scikit-hep/uproot4"
-    url      = "https://github.com/scikit-hep/uproot4/archive/0.0.27.tar.gz"
+    homepage = "homepage = https://github.com/scikit-hep/uproot4"
+    pypi     = "uproot/uproot-4.0.6.tar.gz"
 
     maintainers = ['vvolkl']
 
     tags = ['hep']
 
-    version('master', branch='master')
-    version('4.0.6', sha256='359eba307dfbf40b26a2da67ec829bd82cce67aad8c22120e02df3401be2870d')
-    version('4.0.2', sha256='8145af29788cbe6bf0ee279a7f176159f3eee801641ead4ad6e627f8c4dff0a9')
-    version('0.1.2', sha256='b32dbffadc87bc5707ee0093964d2ce4a5ccfd521b17bbf10732afc25b820d82')
-    version('0.0.27', sha256='de87555937332998b476f3e310392962bc983bddc008ed2b3c07a25c0379c4c9')
+    version('4.0.6', sha256='1bea2ccc899c6959fb2af69d7e5d1e2df210caab30d3510e26f3fc07c143c37e')
 
     variant('xrootd', default=True,
             description='Build with xrootd support ')
@@ -40,6 +35,7 @@ class PyUproot(PythonPackage):
             description='Build with support for reading '
                         'zstd-compressed rootfiles ')
 
+    depends_on('python@2.6:2.999,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-uproot/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot/package.py
@@ -16,7 +16,7 @@ class PyUproot(PythonPackage):
     on C++ ROOT. Instead, it uses Numpy to cast blocks of data from the ROOT
     file as Numpy arrays."""
 
-    homepage = "homepage = https://github.com/scikit-hep/uproot4"
+    homepage = "https://github.com/scikit-hep/uproot4"
     pypi     = "uproot/uproot-4.0.6.tar.gz"
 
     maintainers = ['vvolkl']

--- a/var/spack/repos/builtin/packages/py-uproot4/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot4/package.py
@@ -19,10 +19,16 @@ class PyUproot4(PythonPackage):
 
     tags = ['hep']
 
-    version('master', branch='master')
-    version('4.0.2',    sha256='8145af29788cbe6bf0ee279a7f176159f3eee801641ead4ad6e627f8c4dff0a9')
-    version('0.1.2', sha256='b32dbffadc87bc5707ee0093964d2ce4a5ccfd521b17bbf10732afc25b820d82')
-    version('0.0.27', sha256='de87555937332998b476f3e310392962bc983bddc008ed2b3c07a25c0379c4c9')
+    version('master', branch='master', deprecated=True)
+    version('4.0.2',
+            sha256='8145af29788cbe6bf0ee279a7f176159f3eee801641ead4ad6e627f8c4dff0a9',
+            deprecated=True)
+    version('0.1.2',
+            sha256='b32dbffadc87bc5707ee0093964d2ce4a5ccfd521b17bbf10732afc25b820d82',
+           deprecated=True)
+    version('0.0.27',
+            sha256='de87555937332998b476f3e310392962bc983bddc008ed2b3c07a25c0379c4c9',
+           deprecated=True)
 
     variant('xrootd', default=True,
             description='Build with xrootd support ')

--- a/var/spack/repos/builtin/packages/py-uproot4/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot4/package.py
@@ -7,7 +7,9 @@ from spack import *
 
 
 class PyUproot4(PythonPackage):
-    """ROOT I/O in pure Python and NumPy."""
+    """DEPRECATED! This package was renamed to py-uproot.
+
+    ROOT I/O in pure Python and NumPy."""
 
     homepage = "https://uproot4.readthedocs.io"
     git      = "https://github.com/scikit-hep/uproot4"

--- a/var/spack/repos/builtin/packages/py-uproot4/package.py
+++ b/var/spack/repos/builtin/packages/py-uproot4/package.py
@@ -25,10 +25,10 @@ class PyUproot4(PythonPackage):
             deprecated=True)
     version('0.1.2',
             sha256='b32dbffadc87bc5707ee0093964d2ce4a5ccfd521b17bbf10732afc25b820d82',
-           deprecated=True)
+            deprecated=True)
     version('0.0.27',
             sha256='de87555937332998b476f3e310392962bc983bddc008ed2b3c07a25c0379c4c9',
-           deprecated=True)
+            deprecated=True)
 
     variant('xrootd', default=True,
             description='Build with xrootd support ')


### PR DESCRIPTION
This PR merges the py-uproot4 package into the py-uproot package.
- Added DEPRECATED comment to py-uproot4
- copied py-uproot4/package.py to py-uproot/package.py
- kept comment from py-uproot
- kept newer version from py-uproot

@vvolkl 