### PR TITLE
ImageMagick: specify how to find libraries

### DIFF
--- a/var/spack/repos/builtin/packages/imagemagick/package.py
+++ b/var/spack/repos/builtin/packages/imagemagick/package.py
@@ -36,3 +36,7 @@ class Imagemagick(AutotoolsPackage):
         return [
             '--with-gs-font-dir={0}'.format(gs_font_dir)
         ]
+
+    @property
+    def libs(self):
+        return find_libraries('libMagick*', root=self.prefix, recursive=True)


### PR DESCRIPTION
@robert-mijakovic can you see if this fixes #22828? `gtkplus` doesn't build on macOS so I can't test this myself.