### PR TITLE
py-ujson: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-ujson/package.py
+++ b/var/spack/repos/builtin/packages/py-ujson/package.py
@@ -13,6 +13,9 @@ class PyUjson(PythonPackage):
     homepage = "https://github.com/esnme/ultrajson"
     pypi = "ujson/ujson-1.35.tar.gz"
 
+    version('4.0.2', sha256='c615a9e9e378a7383b756b7e7a73c38b22aeb8967a8bfbffd4741f7ffd043c4d')
     version('1.35', sha256='f66073e5506e91d204ab0c614a148d5aa938bdbf104751be66f8ad7a222f5f86')
 
+    depends_on('python@3.6:', type=('build', 'run'), when='@4:')
     depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools-scm', type='build', when='@4:')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.8 and Apple Clang 12.0.0.