### PR TITLE
py-python-certifi-win32: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-certifi-win32/package.py
+++ b/var/spack/repos/builtin/packages/py-python-certifi-win32/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPythonCertifiWin32(PythonPackage):
+    """This package patches certifi at runtime to also include certificates from the
+    windows certificate store."""
+
+    homepage = "https://gitlab.com/alelec/python-certifi-win32"
+    git      = "https://gitlab.com/alelec/python-certifi-win32.git"
+
+    # Tarball missing version information, need to use git checkout
+    version('1.6', tag='v1.6')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools-scm', type='build')
+    depends_on('py-wrapt@1.10.4:', type=('build', 'run'))
+    depends_on('py-wincertstore', type=('build', 'run'), when='^python@:3.3.999')
+    depends_on('py-certifi', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.8 and Apple Clang 12.0.0.

Not sure if it's actually useful/needed on non-Windows, but at least it builds.