### PR TITLE
py-wincertstore: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-wincertstore/package.py
+++ b/var/spack/repos/builtin/packages/py-wincertstore/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class PyWincertstore(PythonPackage):
-    """wincertstore provides an interface to access Windows’ CA and CRL certificates.
+    """wincertstore provides an interface to access Windows' CA and CRL certificates.
     It uses ctypes and Windows's sytem cert store API through crypt32.dll."""
 
     homepage = "https://bitbucket.org/tiran/wincertstore"

--- a/var/spack/repos/builtin/packages/py-wincertstore/package.py
+++ b/var/spack/repos/builtin/packages/py-wincertstore/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyWincertstore(PythonPackage):
+    """wincertstore provides an interface to access Windows’ CA and CRL certificates.
+    It uses ctypes and Windows’s sytem cert store API through crypt32.dll."""
+
+    homepage = "https://bitbucket.org/tiran/wincertstore"
+    pypi     = "wincertstore/wincertstore-0.2.zip"
+
+    version('0.2', sha256='780bd1557c9185c15d9f4221ea7f905cb20b93f7151ca8ccaed9714dce4b327a')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-wincertstore/package.py
+++ b/var/spack/repos/builtin/packages/py-wincertstore/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class PyWincertstore(PythonPackage):
     """wincertstore provides an interface to access Windows’ CA and CRL certificates.
-    It uses ctypes and Windows’s sytem cert store API through crypt32.dll."""
+    It uses ctypes and Windows's sytem cert store API through crypt32.dll."""
 
     homepage = "https://bitbucket.org/tiran/wincertstore"
     pypi     = "wincertstore/wincertstore-0.2.zip"


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.8 and Apple Clang 12.0.0.

Not sure if it's actually useful/needed on non-Windows, but at least it builds.