### PR TITLE
Add ExaGO develop branch

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -18,6 +18,7 @@ class Exago(CMakePackage, CudaPackage):
     version('0.99.2', tag='v0.99.2')
     version('0.99.1', tag='v0.99.1')
     version('master', branch='master')
+    version('develop', branch='develop')
 
     # Progrmming model options
     variant('mpi', default=True, description='Enable/Disable MPI')


### PR DESCRIPTION
We now use develop branch instead of master for most of our development.

CC @haampie 