### PR TITLE
casacore: remove ~mpi variant from fftw dependency

### DIFF
--- a/var/spack/repos/builtin/packages/casacore/package.py
+++ b/var/spack/repos/builtin/packages/casacore/package.py
@@ -48,7 +48,7 @@ class Casacore(CMakePackage):
     depends_on('lapack')
     depends_on('cfitsio')
     depends_on('wcslib@4.20:+cfitsio')
-    depends_on('fftw@3.0.0:~mpi precision=float,double', when='+fftw')
+    depends_on('fftw@3.0.0: precision=float,double', when='+fftw')
     # SOFA dependency suffers the same problem in CMakeLists.txt as readline;
     # force a dependency when building unit tests
     depends_on('sofa-c', type='test')


### PR DESCRIPTION
Fixes over-specification of FFTW dependency