### PR TITLE
root/intel-oneapi-tbb interaction

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -251,6 +251,8 @@ class Root(CMakePackage):
     # See: https://github.com/root-project/root/issues/6933
     conflicts('^intel-tbb@2021.1:', when='@:6.22',
               msg='Please use an older intel-tbb version')
+    conflicts('^intel-oneapi-tbb@2021.1:', when='@:6.22',
+              msg='Please use an older intel-tbb/intel-oneapi-tbb version')
     # depends_on('intel-tbb@:2021.0', when='@:6.22 ^intel-tbb')
     depends_on('unuran',    when='+unuran')
     depends_on('vc',        when='+vc')


### PR DESCRIPTION
This is a follow up of #22366
And should fix: #22616

As originally noted, ROOT 6.22 does not work with intel's TBB >= 2021.1. So we need to also conflict with the newer package (intel-oneapi-tbb)

Maintainer-Ping: @chissg, @HadrienG2, @drbenmorgan, @vvolkl
cc: @glennpj , @AlexVeprev