### PR TITLE
New package: CORAL

### DIFF
--- a/var/spack/repos/builtin/packages/coral/package.py
+++ b/var/spack/repos/builtin/packages/coral/package.py
@@ -39,9 +39,9 @@ class Coral(CMakePackage):
         if self.spec.variants['binary_tag'].value != 'auto':
             return
         
-        binary_tag = self.spec.target.family +
-            '-' + self.spec.os.name + self.spec.version.joined +
-            '-' + self.spec.compiler.version.joined() +
+        binary_tag = self.spec.target.family + \
+            '-' + self.spec.os.name + self.spec.version.joined + \
+            '-' + self.spec.compiler.version.joined() + \
             ('-opt' if 'Rel' in self.spec.variants['build_type'] else '-dbg')
             
         self.variants['binary_tag'].value = binary_tag

--- a/var/spack/repos/builtin/packages/coral/package.py
+++ b/var/spack/repos/builtin/packages/coral/package.py
@@ -15,7 +15,7 @@ class Coral(CMakePackage):
     git      = "https://gitlab.cern.ch/lcgcoral/coral.git"
 
     version('3.3.3', tag='CORAL_3_3_3')
-    variant('binary_tag', default='x86_64-centos7-gcc8-opt')
+    variant('binary_tag', default='auto')
 
     depends_on('ninja')
     depends_on('ccache')
@@ -35,7 +35,19 @@ class Coral(CMakePackage):
     depends_on('valgrind')
     depends_on('sqlplus')
 
+    def determine_binary_tag(self):
+        if self.spec.variants['binary_tag'].value != 'auto':
+            return
+        
+        binary_tag = self.spec.target.family +
+            '-' + self.spec.os.name + self.spec.version.joined +
+            '-' + self.spec.compiler.version.joined() +
+            ('-opt' if 'Rel' in self.spec.variants['build_type'] else '-dbg')
+            
+        self.variants['binary_tag'].value = binary_tag
+
     def cmake_args(self):
+        self.determine_binary_tag()
         args = ['-DBINARY_TAG=' + self.spec.variants['binary_tag'].value]
         if self.spec['python'].version >= Version("3.0.0"):
             args.append('-DLCG_python3=on')

--- a/var/spack/repos/builtin/packages/coral/package.py
+++ b/var/spack/repos/builtin/packages/coral/package.py
@@ -7,9 +7,9 @@ from spack import *
 
 
 class Coral(CMakePackage):
-    """CORAL is an abstraction layer with an SQL-free API to access data stored using relational
-       database technologies. It is used directly by experiment-specific applications and
-       internally by COOL."""
+    """CORAL is an abstraction layer with an SQL-free API to access data stored
+       using relational database technologies. It is used directly by
+       experiment-specific applications and internally by COOL."""
 
     homepage = "https://coral-cool.docs.cern.ch/"
     git      = "https://gitlab.cern.ch/lcgcoral/coral.git"
@@ -36,19 +36,20 @@ class Coral(CMakePackage):
     depends_on('oracle-instant-client')
 
     def determine_binary_tag(self):
-        # As far as I can tell from reading the source code, `binary_tag` can be almost arbitrary
-        # The only real difference it makes is disabling oracle dependency in 
+        # As far as I can tell from reading the source code, `binary_tag`
+        # can be almost arbitraryThe only real difference it makes is
+        # disabling oracle dependency for non-x86 platforms
         if self.spec.variants['binary_tag'].value != 'auto':
             return self.spec.variants['binary_tag'].value
-        
+
         binary_tag = str(self.spec.target.family) + \
             '-' + self.spec.os + \
             '-' + self.spec.compiler.name + str(self.spec.compiler.version.joined) + \
             ('-opt' if 'Rel' in self.spec.variants['build_type'].value else '-dbg')
-            
+
         return binary_tag
 
-    def cmake_args(self):        
+    def cmake_args(self):
         args = ['-DBINARY_TAG=' + self.determine_binary_tag()]
         if self.spec['python'].version >= Version("3.0.0"):
             args.append('-DLCG_python3=on')

--- a/var/spack/repos/builtin/packages/coral/package.py
+++ b/var/spack/repos/builtin/packages/coral/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Coral(CMakePackage):
+    """CORAL is an abstraction layer with an SQL-free API to access data stored using relational
+       database technologies. It is used directly by experiment-specific applications and
+       internally by COOL."""
+
+    homepage = "https://coral-cool.docs.cern.ch/"
+    git      = "https://gitlab.cern.ch/lcgcoral/coral.git"
+
+    version('3.3.3', tag='CORAL_3_3_3')
+    variant('binary_tag', default='x86_64-centos7-gcc8-opt')
+
+    depends_on('ninja')
+    depends_on('ccache')
+    depends_on('boost')
+    depends_on('cppunit')
+    depends_on('expat')
+    depends_on('frontier-client')
+    depends_on('libaio')
+    depends_on('mariadb')
+    depends_on('python')
+#    depends_on('qmtest')
+    depends_on('xerces-c')
+    depends_on('sqlite')
+    depends_on('gperftools')
+    depends_on('igprof')
+    depends_on('libunwind')
+    depends_on('valgrind')
+    depends_on('sqlplus')
+
+    def cmake_args(self):
+        args = ['-DBINARY_TAG=' + self.spec.variants['binary_tag'].value]
+        if self.spec['python'].version >= Version("3.0.0"):
+            args.append('-DLCG_python3=on')
+
+        return args

--- a/var/spack/repos/builtin/packages/coral/package.py
+++ b/var/spack/repos/builtin/packages/coral/package.py
@@ -33,22 +33,23 @@ class Coral(CMakePackage):
     depends_on('igprof')
     depends_on('libunwind')
     depends_on('valgrind')
-    depends_on('sqlplus')
+    depends_on('oracle-instant-client')
 
     def determine_binary_tag(self):
+        # As far as I can tell from reading the source code, `binary_tag` can be almost arbitrary
+        # The only real difference it makes is disabling oracle dependency in 
         if self.spec.variants['binary_tag'].value != 'auto':
-            return
+            return self.spec.variants['binary_tag'].value
         
-        binary_tag = self.spec.target.family + \
-            '-' + self.spec.os.name + self.spec.version.joined + \
-            '-' + self.spec.compiler.version.joined() + \
-            ('-opt' if 'Rel' in self.spec.variants['build_type'] else '-dbg')
+        binary_tag = str(self.spec.target.family) + \
+            '-' + self.spec.os + \
+            '-' + self.spec.compiler.name + str(self.spec.compiler.version.joined) + \
+            ('-opt' if 'Rel' in self.spec.variants['build_type'].value else '-dbg')
             
-        self.variants['binary_tag'].value = binary_tag
+        return binary_tag
 
-    def cmake_args(self):
-        self.determine_binary_tag()
-        args = ['-DBINARY_TAG=' + self.spec.variants['binary_tag'].value]
+    def cmake_args(self):        
+        args = ['-DBINARY_TAG=' + self.determine_binary_tag()]
         if self.spec['python'].version >= Version("3.0.0"):
             args.append('-DLCG_python3=on')
 

--- a/var/spack/repos/builtin/packages/coral/package.py
+++ b/var/spack/repos/builtin/packages/coral/package.py
@@ -14,6 +14,8 @@ class Coral(CMakePackage):
     homepage = "https://coral-cool.docs.cern.ch/"
     git      = "https://gitlab.cern.ch/lcgcoral/coral.git"
 
+    tags = ['hep']
+
     version('3.3.3', tag='CORAL_3_3_3')
     variant('binary_tag', default='auto')
 


### PR DESCRIPTION
Notice: while it may seem that valgrind, igprof and gperftools dependencies should be test-only, they are not (i.e. they are marked as required).