### PR TITLE
py-sip: fix for missing flex/bison

### DIFF
--- a/var/spack/repos/builtin/packages/py-sip/package.py
+++ b/var/spack/repos/builtin/packages/py-sip/package.py
@@ -29,8 +29,8 @@ class PySip(Package):
 
     extends('python')
 
-    depends_on('flex', type='build', when='@develop')
-    depends_on('bison', type='build', when='@develop')
+    depends_on('flex', type='build')
+    depends_on('bison', type='build')
 
     # https://www.riverbankcomputing.com/static/Docs/sip/installation.html
     phases = ['configure', 'build', 'install']


### PR DESCRIPTION
Flex/Bison are necessary independently of the develop branch.