### PR TITLE
Add libs property to mariadb-c-client

### DIFF
--- a/var/spack/repos/builtin/packages/mariadb-c-client/package.py
+++ b/var/spack/repos/builtin/packages/mariadb-c-client/package.py
@@ -64,3 +64,9 @@ class MariadbCClient(CMakePackage):
     def cmake_args(self):
         args = ['-DWITH_EXTERNAL_ZLIB=ON', '-DWITH_MYSQLCOMPAT=ON']
         return args
+
+    @property
+    def libs(self):
+        return find_libraries(
+            ['libmariadb'], root=self.prefix, recursive=True, shared=True
+        )


### PR DESCRIPTION
Since the libraries are in {prefix}/mariadb-c-client-{spec}/lib/mariadb
the path winds up not being in the rpath list for packages linking to
the library. Add a libs property to address that.