### PR TITLE
CARE and dependencies fixed to work with +cuda

### DIFF
--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -24,6 +24,7 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('blt', type='build')
     depends_on('blt@0.3.7:', type='build', when='+rocm')
+    depends_on('cub', when='+cuda')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -75,9 +75,11 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
 
             if not spec.satisfies('cuda_arch=none'):
                 cuda_arch = spec.variants['cuda_arch'].value
+                # Please note that within care, CUDA_ARCH is assigned to -code
+                # and likewise CUDA_CODE is assigned to -arch, so these are
+                # intentionally flipped here.
                 options.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
-                flag = '-arch sm_{0}'.format(cuda_arch[0])
-                options.append('-DCMAKE_CUDA_FLAGS:STRING={0}'.format(flag))
+                options.append('-DCUDA_CODE=compute_{0}'.format(cuda_arch[0]))
         else:
             options.append('-DENABLE_CUDA=OFF')
 

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -42,6 +42,7 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
     # cub package.
     depends_on('camp+cuda', when='+cuda')
     depends_on('umpire+cuda', when='+cuda')
+    depends_on('cub', when='+cuda')
     depends_on('raja+cuda~openmp', when='+cuda')
     depends_on('chai+cuda', when='+cuda')
 
@@ -69,7 +70,8 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
         if '+cuda' in spec:
             options.extend([
                 '-DENABLE_CUDA=ON',
-                '-DCUDA_TOOLKIT_ROOT_DIR=' + spec['cuda'].prefix])
+                '-DCUDA_TOOLKIT_ROOT_DIR=' + spec['cuda'].prefix,
+                '-DCUB_DIR=' + spec['cub'].prefix])
 
             if not spec.satisfies('cuda_arch=none'):
                 cuda_arch = spec.variants['cuda_arch'].value

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -71,6 +71,7 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
             options.extend([
                 '-DENABLE_CUDA=ON',
                 '-DCUDA_TOOLKIT_ROOT_DIR=' + spec['cuda'].prefix,
+                '-DNVTOOLSEXT_DIR=' + spec['cuda'].prefix,
                 '-DCUB_DIR=' + spec['cub'].prefix])
 
             if not spec.satisfies('cuda_arch=none'):

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -41,10 +41,10 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
     # package that uses cub. TODO: have all packages point to the same external
     # cub package.
     depends_on('camp+cuda', when='+cuda')
-    depends_on('umpire+cuda', when='+cuda')
+    depends_on('umpire+cuda~shared', when='+cuda')
     depends_on('cub', when='+cuda')
     depends_on('raja+cuda~openmp', when='+cuda')
-    depends_on('chai+cuda', when='+cuda')
+    depends_on('chai+cuda~shared', when='+cuda')
 
     # variants +rocm and amdgpu_targets are not automatically passed to
     # dependencies, so do it manually.


### PR DESCRIPTION
This PR allows us to build care and its dependencies with +cuda (targetting nvidia GPUs). 

NOTE: David Beckinsale advises that many "untested" architectures are fine to run with cuda, see his branch here: https://github.com/davidbeckingsale/spack/commit/a991a5f3fa98a14857bd1ad8ea3c8ed53ae1b320 . Those changes will remain on David's separate branch and have not been merged in as part of this PR