### PR TITLE
Update augustus package

### DIFF
--- a/var/spack/repos/builtin/packages/augustus/bam2wig_Makefile.patch
+++ b/var/spack/repos/builtin/packages/augustus/bam2wig_Makefile.patch
@@ -1,0 +1,23 @@
+--- a/auxprogs/bam2wig/Makefile	2020-12-11 09:40:21.000000000 -0600
++++ b/auxprogs/bam2wig/Makefile	2021-04-07 15:20:59.573957969 -0500
+@@ -19,18 +19,8 @@
+ SOURCES = $(PROGRAM)
+ OBJECTS = $(SOURCES:.c=.o)
+ 
+-ifneq ($(wildcard ${TOOLDIR}/htslib/htslib/.),) # if TOOLDIR exists and contains htslib
+-	INCLUDES=-I$(TOOLDIR)/htslib -I$(TOOLDIR)/htslib/htslib
+-	HTSLIBS=-L$(TOOLDIR)/htslib -Wl,-rpath,$(TOOLDIR)/htslib -lhts -lcurses -lm -lz -lpthread -lcurl -lssl -lcrypto -lbz2 -llzma
+-	HTSERRHINT="Check if the installed HTSlib is of version 1.10 or higher - see README.txt"
+-else
+-	INCLUDES=-I/usr/include/htslib
+-	HTSLIBS=-lhts -lz -lpthread
+-	ifdef DEF_TOOLDIR
+-		HTSERRHINT="There is no htslib folder in directory $(TOOLDIR) \n"
+-	endif
+-	HTSERRHINT:=$(HTSERRHINT)"Check if HTSlib is installed and of version 1.10 or higher - see README.txt"
+-endif
++INCLUDES=-I$(HTSLIBDIR)/include/htslib
++HTSLIBS=-L$(HTSLIBDIR)/lib -Wl,-rpath,$(HTSLIBDIR)/lib -lhts -lcurses -lm -lz -lpthread -lcurl -lssl -lcrypto -lbz2 -llzma
+ 
+ CFLAGS:=-Wall -O2 $(CFLAGS)
+ CC?=gcc

--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -139,7 +139,7 @@ class Augustus(MakefilePackage):
 
             with working_dir('src'):
                 makefile = FileFilter('Makefile')
-                makefile.filter('/usr/include/mysql\+\+',
+                makefile.filter(r'/usr/include/mysql\+\+',
                                 '{0}/include/mysql++'.format(mysqlpp))
                 if '^mariadb-c-client' in spec:
                     makefile.filter('/usr/include/mysql',

--- a/var/spack/repos/builtin/packages/augustus/package.py
+++ b/var/spack/repos/builtin/packages/augustus/package.py
@@ -12,9 +12,10 @@ class Augustus(MakefilePackage):
        genomic sequences"""
 
     homepage = "http://bioinf.uni-greifswald.de/augustus/"
-    url      = "https://github.com/Gaius-Augustus/Augustus/archive/3.3.2.tar.gz"
-    # Releases have moved to github
+    url      = "https://github.com/Gaius-Augustus/Augustus/archive/v3.3.4.tar.gz"
 
+    # Releases have moved to github
+    version('3.4.0', sha256='2c06cf5953da5afdce1478fa10fcd3c280a3b050f1b2367bf3e731d7374d9bb8')
     version('3.3.2', sha256='d09f972cfd88deb34b19b69878eb8af3bbbe4f1cde1434b69cedc2aa6247a0f2')
     version('3.3.1-tag1', sha256='011379606f381ee21b9716f83e8a1a57b2aaa01aefeebd2748104efa08c47cab',
             url='https://github.com/Gaius-Augustus/Augustus/archive/v3.3.1-tag1.tar.gz')
@@ -24,14 +25,24 @@ class Augustus(MakefilePackage):
             url='http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz')
 
     depends_on('perl', type=('build', 'run'))
+    depends_on('python', when='@3.3.1:', type=('build', 'run'))
     depends_on('bamtools')
     depends_on('gsl')
     depends_on('boost')
     depends_on('zlib')
-    depends_on('htslib', when='@3.3.1:')
-    depends_on('bcftools', when='@3.3.1:')
-    depends_on('samtools', when='@3.3.1:')
+    depends_on('htslib')
+    depends_on('bcftools')
+    depends_on('samtools')
     depends_on('curl', when='@3.3.1:')
+    depends_on('sqlite', when='@3.4.0:')
+    depends_on('mysql-client', when='@3.4.0:')
+    depends_on('mysqlpp', when='@3.4.0:')
+    depends_on('lp-solve', when='@3.4.0:')
+    depends_on('suite-sparse', when='@3.4.0:')
+
+    # Trying to use filter_file here got too complicated so use a patch with a
+    # corresponding environment variable
+    patch('bam2wig_Makefile.patch', when='@3.4.0:')
 
     def edit(self, spec, prefix):
         # Set compile commands for each compiler and
@@ -44,30 +55,42 @@ class Augustus(MakefilePackage):
                                     self.spec['boost'].prefix.include),
                             'src/subdir.mk', string=True)
 
-        # Set compile commands to all makefiles.
+        # Makefiles to set spack compiler over gcc/g++
         makefiles = [
             'auxprogs/aln2wig/Makefile',
             'auxprogs/bam2hints/Makefile',
             'auxprogs/bam2wig/Makefile',
-            'auxprogs/checkTargetSortedness/Makefile',
             'auxprogs/compileSpliceCands/Makefile',
             'auxprogs/homGeneMapping/src/Makefile',
             'auxprogs/joingenes/Makefile',
-            'src/Makefile'
+            'src/Makefile',
         ]
+        if self.version < Version('3.4.0'):
+            makefiles.append('auxprogs/checkTargetSortedness/Makefile')
+
+        if self.version >= Version('3.4.0'):
+            makefiles.extend([
+                'auxprogs/filterBam/src/Makefile',
+                'src/unittests/Makefile',
+            ])
+
         for makefile in makefiles:
             filter_file('gcc', spack_cc, makefile, string=True)
             filter_file('g++', spack_cxx, makefile, string=True)
 
+        bamtools = self.spec['bamtools'].prefix
+        bcftools = self.spec['bcftools'].prefix
+        htslib = self.spec['htslib'].prefix
+        samtools = self.spec['samtools'].prefix
+
         with working_dir(join_path('auxprogs', 'filterBam', 'src')):
             makefile = FileFilter('Makefile')
-            makefile.filter('BAMTOOLS = .*', 'BAMTOOLS = %s' % self.spec[
-                            'bamtools'].prefix)
+            makefile.filter('BAMTOOLS = .*', 'BAMTOOLS = {0}'.format(bamtools))
             makefile.filter('INCLUDES = *',
                             'INCLUDES = -I$(BAMTOOLS)/include/bamtools ')
             if 'bamtools@2.5:' in spec:
                 makefile.filter('LIBS = -lbamtools -lz',
-                                'LIBS = $(BAMTOOLS)/lib64/'
+                                'LIBS = $(BAMTOOLS)/lib64'
                                 '/libbamtools.a -lz')
             if 'bamtools@:2.4' in spec:
                 makefile.filter('LIBS = -lbamtools -lz',
@@ -75,39 +98,57 @@ class Augustus(MakefilePackage):
                                 '/libbamtools.a -lz')
         with working_dir(join_path('auxprogs', 'bam2hints')):
             makefile = FileFilter('Makefile')
-            makefile.filter('# Variable definition',
-                            'BAMTOOLS = %s' % self.spec['bamtools'].prefix)
-            makefile.filter('INCLUDES = /usr/include/bamtools',
-                            'INCLUDES = $(BAMTOOLS)/include/bamtools')
+            makefile.filter('/usr/include/bamtools',
+                            '{0}/include/bamtools'.format(bamtools))
             if 'bamtools@2.5:' in spec:
                 makefile.filter('LIBS = -lbamtools -lz',
-                                'LIBS = $(BAMTOOLS)/lib64/'
-                                '/libbamtools.a -lz')
+                                'LIBS = {0}/lib64'
+                                '/libbamtools.a -lz'.format(bamtools))
             if 'bamtools@:2.4' in spec:
                 makefile.filter('LIBS = -lbamtools -lz',
-                                'LIBS = $(BAMTOOLS)/lib/bamtools'
-                                '/libbamtools.a -lz')
-        with working_dir(join_path('auxprogs', 'bam2wig')):
-            makefile = FileFilter('Makefile')
-            # point tools to spack installations
-            if 'bcftools' in spec:
-                bcftools = self.spec['bcftools'].prefix.include
-                makefile.filter('BCFTOOLS=.*$',
-                                'BCFTOOLS=%s' % bcftools)
-            if 'samtools' in spec:
-                samtools = self.spec['samtools'].prefix.include
-                makefile.filter('SAMTOOLS=.*$',
-                                'SAMTOOLS=%s' % samtools)
-            if 'htslib' in spec:
-                htslib = self.spec['htslib'].prefix.include
-                makefile.filter('HTSLIB=.*$',
-                                'HTSLIB=%s' % htslib)
+                                'LIBS = {0}/lib/bamtools'
+                                '/libbamtools.a -lz'.format(bamtools))
 
-            # fix bad linking dirs
-            makefile.filter('$(SAMTOOLS)/libbam.a',
-                            '$(SAMTOOLS)/../lib/libbam.a', string=True)
-            makefile.filter('$(HTSLIB)/libhts.a',
-                            '$(HTSLIB)/../lib/libhts.a', string=True)
+        if self.version < Version('3.4.0'):
+            with working_dir(join_path('auxprogs', 'bam2wig')):
+                makefile = FileFilter('Makefile')
+                # point tools to spack installations
+                makefile.filter('BCFTOOLS=.*$',
+                                'BCFTOOLS={0}/include'.format(bcftools))
+                makefile.filter('SAMTOOLS=.*$',
+                                'SAMTOOLS={0}/include'.format(samtools))
+                makefile.filter('HTSLIB=.*$',
+                                'HTSLIB={0}/include'.format(htslib))
+
+                # fix bad linking dirs
+                makefile.filter('$(SAMTOOLS)/libbam.a',
+                                '$(SAMTOOLS)/../lib/libbam.a', string=True)
+                makefile.filter('$(HTSLIB)/libhts.a',
+                                '$(HTSLIB)/../lib/libhts.a', string=True)
+            with working_dir(join_path('auxprogs', 'checkTargetSortedness')):
+                makefile = FileFilter('Makefile')
+                makefile.filter('SAMTOOLS.*=.*$',
+                                'SAMTOOLS={0}/include'.format(samtools))
+                makefile.filter('LIBS=-lbam',
+                                'LIBS=$(SAMTOOLS)/../lib/libbam.a',
+                                string=True)
+        else:
+            mysql = self.spec['mysql-client'].prefix
+            mysqlpp = self.spec['mysqlpp'].prefix
+            lpsolve = self.spec['lp-solve'].prefix
+
+            with working_dir('src'):
+                makefile = FileFilter('Makefile')
+                makefile.filter('/usr/include/mysql\+\+',
+                                '{0}/include/mysql++'.format(mysqlpp))
+                if '^mariadb-c-client' in spec:
+                    makefile.filter('/usr/include/mysql',
+                                    '{0}/include/mariadb'.format(mysql))
+                else:
+                    makefile.filter('/usr/include/mysql',
+                                    '{0}/include/mysql'.format(mysql))
+                makefile.filter('/usr/include/lpsolve',
+                                '{0}/include/lpsolve'.format(lpsolve))
 
     def install(self, spec, prefix):
         install_tree('bin', join_path(self.spec.prefix, 'bin'))
@@ -117,11 +158,21 @@ class Augustus(MakefilePackage):
     @run_after('install')
     def filter_sbang(self):
         with working_dir(self.prefix.scripts):
-            pattern = '^#!.*/usr/bin/perl'
+            pattern = '^#!.*'
             repl = '#!{0}'.format(self.spec['perl'].command.path)
-            files = glob.iglob("*.pl")
+            files = glob.glob("*.pl")
             for file in files:
                 filter_file(pattern, repl, *files, backup=False)
+
+            repl = '#!{0}'.format(self.spec['python'].command.path)
+            files = glob.glob("*.py")
+            for file in files:
+                filter_file(pattern, repl, *files, backup=False)
+
+    def setup_build_environment(self, env):
+        if self.version >= Version('3.4.0'):
+            htslib = self.spec['htslib'].prefix
+            env.set('HTSLIBDIR', htslib)
 
     def setup_run_environment(self, env):
         env.set('AUGUSTUS_CONFIG_PATH', join_path(


### PR DESCRIPTION
Depends on:
#22876
#22877 
#22873 if using mariadb-c-client

- add version 3.4.0
- add patch for bam2wig when version 3.4.0
- url format changed again, hopefully stable now
- added missing python dependency when version >3.3.1
- have older version compile with htslib, samtools ,bcftools
- new dependencies for version 3.4.0
    - sqlite
    - mysql-client
    - mysqlpp
    - lp-solve
    - suite-sparse
- refactored filtering code
- set python interpreter in scripts