### PR TITLE
Avoid picking up system cert paths in curl

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -82,4 +82,5 @@ class Curl(AutotoolsPackage):
         args += self.with_or_without('nghttp2')
         args += self.with_or_without('libssh2')
         args += self.with_or_without('libssh')
+        args += ['--without-ca-bundle', '--without-ca-path']
         return args


### PR DESCRIPTION
When compiling curl on ubuntu the configure script detects this path:

/etc/ssl/certs/ca-certificates.crt

And compiles it into the binary, which doesn't work on other systems when using a buildcache.

On some cray system I get `curl-config --ca` to be an empty string, so I guess it can't hurt to disable these options.
