### PR TITLE
Bootstrap fix compiler flags being passed to linker

### DIFF
--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -67,4 +67,3 @@ class ClingoBootstrap(Clingo):
             raise RuntimeError(msg)
 
         env.set('CXXFLAGS', opts)
-        env.set('LDFLAGS', opts)


### PR DESCRIPTION
These flags are not linker flags but gcc flags:

```
$ ld -static-libstdc++
ld: unrecognized -a option `tic-libstdc++'
```



