### PR TITLE
ASP-based solver: assign OS correctly with inheritance from parent

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -478,6 +478,8 @@ node_os_inherit(Dependency, OS)
      not node_os_set(Dependency).
 node_os_inherit(Package) :- node_os_inherit(Package, _).
 
+node_os(Package, OS) :- node_os_inherit(Package, OS).
+
 % fall back to default if not set or inherited
 node_os(Package, OS)
   :- node(Package),

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1183,3 +1183,19 @@ class TestConcretize(object):
         assert '~foo' in s['external-non-default-variant']
         assert '~bar' in s['external-non-default-variant']
         assert s['external-non-default-variant'].external
+
+    @pytest.mark.regression('22871')
+    @pytest.mark.parametrize('spec_str,expected_os', [
+        ('mpileaks', 'os=debian6'),
+        # To trigger the bug in 22871 we need to have the same compiler
+        # spec available on both operating systems
+        ('mpileaks%gcc@4.5.0 platform=test os=debian6', 'os=debian6'),
+        ('mpileaks%gcc@4.5.0 platform=test os=redhat6', 'os=redhat6')
+    ])
+    def test_os_selection_when_multiple_choices_are_possible(
+            self, spec_str, expected_os
+    ):
+        s = Spec(spec_str).concretized()
+
+        for node in s.traverse():
+            assert node.satisfies(expected_os)

--- a/lib/spack/spack/test/data/config/compilers.yaml
+++ b/lib/spack/spack/test/data/config/compilers.yaml
@@ -20,6 +20,16 @@ compilers:
     modules: 'None'
     target: x86_64
 - compiler:
+    spec: gcc@4.5.0
+    operating_system: redhat6
+    paths:
+      cc: /path/to/gcc
+      cxx: /path/to/g++
+      f77: None
+      fc: None
+    modules: 'None'
+    target: x86_64
+- compiler:
     spec: clang@3.3
     operating_system: CNL
     paths:


### PR DESCRIPTION
fixes #22871

When in presence of multiple choices for the operating system we were lacking a rule to derive the node OS if it was inherited.