### PR TITLE
add debug variant for paraview

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -55,7 +55,7 @@ class Paraview(CMakePackage, CudaPackage):
             values=('native', 'fermi', 'kepler', 'maxwell',
                     'pascal', 'volta', 'turing', 'ampere', 'all', 'none'),
             description='CUDA architecture')
-    variant('debug', default=False, description="Enable debug flags")
+    variant('advanced_debug', default=False, description="Enable all other debug flags beside build_type, such as VTK_DEBUG_LEAK")
 
     conflicts('+python', when='+python3')
     # Python 2 support dropped with 5.9.0
@@ -398,8 +398,7 @@ class Paraview(CMakePackage, CudaPackage):
                 )
             )
 
-        if '+debug' in spec:
-            cmake_args.append('-DCMAKE_BUILD_TYPE=Debug')
+        if '+advanced_debug' in spec:
             cmake_args.append('-DVTK_DEBUG_LEAKS:BOOL=ON')
 
         return cmake_args

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -55,6 +55,7 @@ class Paraview(CMakePackage, CudaPackage):
             values=('native', 'fermi', 'kepler', 'maxwell',
                     'pascal', 'volta', 'turing', 'ampere', 'all', 'none'),
             description='CUDA architecture')
+    variant('debug', default=False, description="Enable debug flags")
 
     conflicts('+python', when='+python3')
     # Python 2 support dropped with 5.9.0
@@ -396,5 +397,9 @@ class Paraview(CMakePackage, CudaPackage):
                     ":".join(self.rpath + pylibdirs)
                 )
             )
+
+        if '+debug' in spec:
+            cmake_args.append('-DCMAKE_BUILD_TYPE=Debug')
+            cmake_args.append('-DVTK_DEBUG_LEAKS:BOOL=ON')
 
         return cmake_args


### PR DESCRIPTION
this variant set the Cmake build_type for debug and add debugs flags. For now, I only add the VTK_DEBUG_LEAK, but feel free to give me other usefull flag to add in this variant.

@danlipsa @vicentebolea  which flags are needed in the debug mode ?

Eloïse