### PR TITLE
vtk: fix Python 3.7 version range

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -53,7 +53,7 @@ class Vtk(CMakePackage):
     # We need vtk at least 8.0.1 for python@3,
     # and at least 9.0 for python@3.8
     depends_on('python@2.7:2.9', when='@:8.0 +python', type=('build', 'run'))
-    depends_on('python@2.7:3.7.10', when='@8.0.1:8.9 +python',
+    depends_on('python@2.7:3.7.99', when='@8.0.1:8.9 +python',
                type=('build', 'run'))
     depends_on('python@2.7:', when='@9.0: +python', type=('build', 'run'))
 


### PR DESCRIPTION
When installing VTK version 8, Python was restricted to max 3.7.9. This PR changes this to allow any 3.7 patch version for VTK version 8.