### PR TITLE
libsakura: Change precision for fftw dependency depending on libsakura version

### DIFF
--- a/var/spack/repos/builtin/packages/libsakura/package.py
+++ b/var/spack/repos/builtin/packages/libsakura/package.py
@@ -21,7 +21,7 @@ class Libsakura(CMakePackage):
     depends_on('cmake@2.8:', type='build')
 
     depends_on('eigen@3.2:')
-    depends_on('fftw@3.3.2: precision=float', when='@:4.0.0')
+    depends_on('fftw@3.3.2: precision=float', when='@:3.99')
     depends_on('fftw@3.3.2: precision=double', when='@4.0.0:')
     depends_on('log4cxx')
 

--- a/var/spack/repos/builtin/packages/libsakura/package.py
+++ b/var/spack/repos/builtin/packages/libsakura/package.py
@@ -21,7 +21,8 @@ class Libsakura(CMakePackage):
     depends_on('cmake@2.8:', type='build')
 
     depends_on('eigen@3.2:')
-    depends_on('fftw@3.3.2:')
+    depends_on('fftw@3.3.2: precision=float', when='@:4.0.0')
+    depends_on('fftw@3.3.2: precision=double', when='@4.0.0:')
     depends_on('log4cxx')
 
     patch('cmakelists.patch')


### PR DESCRIPTION
libsakura version determines whether FFTW dependency needs single or double precision variant