### PR TITLE
casacore: Change FFT variants for correct, version dependent, FFT choices

### DIFF
--- a/var/spack/repos/builtin/packages/casacore/package.py
+++ b/var/spack/repos/builtin/packages/casacore/package.py
@@ -31,7 +31,7 @@ class Casacore(CMakePackage):
     variant('readline', default=True, description='Build readline support')
     # see note below about the reason for disabling the "sofa" variant
     # variant('sofa', default=False, description='Build SOFA support')
-    variant('fftw', default=True, description='Build FFTW3 support')
+    variant('fftpack', default=False, description='Build FFTPack')
     variant('hdf5', default=False, description='Build HDF5 support')
     variant('python', default=False, description='Build python support')
 
@@ -48,7 +48,8 @@ class Casacore(CMakePackage):
     depends_on('lapack')
     depends_on('cfitsio')
     depends_on('wcslib@4.20:+cfitsio')
-    depends_on('fftw@3.0.0: precision=float,double', when='+fftw')
+    depends_on('fftw@3.0.0: precision=float,double', when='@3.4.0:')
+    depends_on('fftw@3.0.0: precision=float,double', when='~fftpack')
     # SOFA dependency suffers the same problem in CMakeLists.txt as readline;
     # force a dependency when building unit tests
     depends_on('sofa-c', type='test')
@@ -66,14 +67,17 @@ class Casacore(CMakePackage):
         args.append(self.define_from_variant('USE_READLINE', 'readline'))
         args.append(self.define_from_variant('USE_HDF5', 'hdf5'))
 
-        # fftw3 is used by casacore as the default starting with
-        # v3.4.0 (although we use fftw3 by default in this Spack
-        # package), but the old fftpack is still available
+        # fftw3 is required by casacore starting with v3.4.0, but the
+        # old fftpack is still available. For v3.4.0 and later, we
+        # always require FFTW3 dependency with the optional addition
+        # of FFTPack. In older casacore versions, only one of FFTW3 or
+        # FFTPack can be selected.
         if spec.satisfies('@3.4.0:'):
-            if spec.satisfies('~fftw'):
+            if spec.satisfies('+fftpack'):
                 args.append('-DBUILD_FFTPACK_DEPRECATED=YES')
+            args.append(self.define('USE_FFTW3', True))
         else:
-            args.append(self.define_from_variant('USE_FFTW3', 'fftw'))
+            args.append(self.define('USE_FFTW3', spec.satisfies('~fftpack')))
 
         # Python2 and Python3 binding
         if spec.satisfies('~python'):


### PR DESCRIPTION
Required dependency on FFTW for casacore@3.4.0:; optional for
casacore@:3.4.0, depending on selection of FFTPack