### PR TITLE
Add go version constraint to mumax

### DIFF
--- a/var/spack/repos/builtin/packages/mumax/package.py
+++ b/var/spack/repos/builtin/packages/mumax/package.py
@@ -29,7 +29,7 @@ class Mumax(MakefilePackage, CudaPackage):
             description='Use gnuplot for graphs')
 
     depends_on('cuda')
-    depends_on('go', type='build')
+    depends_on('go@:1.15', type='build')
     depends_on('gnuplot', type='run', when='+gnuplot')
 
     conflicts('~cuda', msg='mumax requires cuda')


### PR DESCRIPTION
Mumax will not build with go-1.16.