### PR TITLE
Remove LazyReference objects from code

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -780,27 +780,6 @@ class Singleton(object):
         return repr(self.instance)
 
 
-class LazyReference(object):
-    """Lazily evaluated reference to part of a singleton."""
-
-    def __init__(self, ref_function):
-        self.ref_function = ref_function
-
-    def __getattr__(self, name):
-        if name == 'ref_function':
-            raise AttributeError()
-        return getattr(self.ref_function(), name)
-
-    def __getitem__(self, name):
-        return self.ref_function()[name]
-
-    def __str__(self):
-        return str(self.ref_function())
-
-    def __repr__(self):
-        return repr(self.ref_function())
-
-
 def load_module_from_file(module_name, module_path):
     """Loads a python module from the path of the corresponding file.
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -87,7 +87,7 @@ def make_module_available(module, spec=None, install=False):
     # concretize to python@X.Y instead of python@X.Y.Z
     python_requirement = '^' + spec_for_current_python()
     spec.constrain(python_requirement)
-    installed_specs = spack.store.db.query(spec, installed=True)
+    installed_specs = spack.store.store.db.query(spec, installed=True)
 
     for ispec in installed_specs:
         # TODO: make sure run-environment is appropriate
@@ -150,7 +150,7 @@ def get_executable(exe, spec=None, install=False):
 
     # Check whether it's already installed
     spec = spack.spec.Spec(spec or exe)
-    installed_specs = spack.store.db.query(spec, installed=True)
+    installed_specs = spack.store.store.db.query(spec, installed=True)
     for ispec in installed_specs:
         # filter out directories of the same name as the executable
         exe_path = [exe_p for exe_p in fs.find(ispec.prefix, exe)

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -56,7 +56,6 @@ import spack.paths
 import spack.package
 import spack.repo
 import spack.schema.environment
-import spack.store
 import spack.install_test
 import spack.subprocess_context
 import spack.architecture as arch

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -239,11 +239,14 @@ def disambiguate_spec_from_hashes(spec, hashes, local=False,
             database query. See ``spack.database.Database._query`` for details.
     """
     if local:
-        matching_specs = spack.store.db.query_local(spec, hashes=hashes,
-                                                    installed=installed)
+        matching_specs = spack.store.store.db.query_local(
+            spec, hashes=hashes, installed=installed
+        )
     else:
-        matching_specs = spack.store.db.query(spec, hashes=hashes,
-                                              installed=installed)
+        matching_specs = spack.store.store.db.query(
+            spec, hashes=hashes, installed=installed
+        )
+
     if not matching_specs:
         tty.die("Spec '%s' matches no installed packages." % spec)
 
@@ -431,7 +434,7 @@ def display_specs(specs, args=None, **kwargs):
         out = ''
         # getting lots of prefixes requires DB lookups. Ensure
         # all spec.prefix calls are in one transaction.
-        with spack.store.db.read_transaction():
+        with spack.store.store.db.read_transaction():
             for string, spec in formatted:
                 if not string:
                     # print newline from above

--- a/lib/spack/spack/cmd/activate.py
+++ b/lib/spack/spack/cmd/activate.py
@@ -40,7 +40,7 @@ def activate(parser, args):
     else:
         target = spec.package.extendee_spec.prefix
 
-    view = YamlFilesystemView(target, spack.store.layout)
+    view = YamlFilesystemView(target, spack.store.store.layout)
 
     if spec.package.is_activated(view):
         tty.msg("Package %s is already activated." % specs[0].short_spec)

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -12,6 +12,7 @@ import spack.architecture
 import spack.binary_distribution as bindist
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.config
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.mirror
@@ -19,16 +20,11 @@ import spack.relocate
 import spack.repo
 import spack.spec
 import spack.store
-import spack.config
-import spack.repo
-import spack.store
 import spack.util.url as url_util
-
+from spack.cmd import display_specs
 from spack.error import SpecError
 from spack.spec import Spec, save_dependency_spec_yamls
 from spack.util.string import plural
-
-from spack.cmd import display_specs
 
 description = "create, download and install binary packages"
 section = "packaging"
@@ -257,7 +253,7 @@ def find_matching_specs(pkgs, allow_multiple_matches=False, env=None):
     tty.debug('find_matching_specs: about to parse specs for {0}'.format(pkgs))
     specs = spack.cmd.parse_specs(pkgs)
     for spec in specs:
-        matching = spack.store.db.query(spec, hashes=hashes)
+        matching = spack.store.store.db.query(spec, hashes=hashes)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:
@@ -372,7 +368,7 @@ def _createtarball(env, spec_yaml=None, packages=None, add_spec=True,
             tty.debug('skipping external or virtual spec %s' %
                       match.format())
         else:
-            lookup = spack.store.db.query_one(match)
+            lookup = spack.store.store.db.query_one(match)
 
             if not add_spec:
                 tty.debug('skipping matching root spec %s' % match.format())
@@ -394,7 +390,7 @@ def _createtarball(env, spec_yaml=None, packages=None, add_spec=True,
                 if d == 0:
                     continue
 
-                lookup = spack.store.db.query_one(node)
+                lookup = spack.store.store.db.query_one(node)
 
                 if node.external or node.virtual:
                     tty.debug('skipping external or virtual dependency %s' %
@@ -501,7 +497,7 @@ def install_tarball(spec, args):
             bindist.extract_tarball(spec, tarball, args.allow_root,
                                     args.unsigned, args.force)
             spack.hooks.post_install(spec)
-            spack.store.db.add(spec, spack.store.layout)
+            spack.store.store.db.add(spec, spack.store.store.layout)
         else:
             tty.die('Download of binary cache file for spec %s failed.' %
                     spec.format())

--- a/lib/spack/spack/cmd/clean.py
+++ b/lib/spack/spack/cmd/clean.py
@@ -8,16 +8,15 @@ import os
 import shutil
 
 import llnl.util.tty as tty
-
 import spack.caches
-import spack.config
-import spack.cmd.test
 import spack.cmd.common.arguments as arguments
+import spack.cmd.test
+import spack.config
 import spack.main
 import spack.repo
 import spack.stage
+import spack.store
 from spack.paths import lib_path, var_path
-
 
 description = "remove temporary build files and/or downloaded archives"
 section = "build"

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -75,12 +75,12 @@ class ConstraintAction(argparse.Action):
 
         # return everything for an empty query.
         if not qspecs:
-            return spack.store.db.query(**kwargs)
+            return spack.store.store.db.query(**kwargs)
 
         # Return only matching stuff otherwise.
         specs = {}
         for spec in qspecs:
-            for s in spack.store.db.query(spec, **kwargs):
+            for s in spack.store.store.db.query(spec, **kwargs):
                 # This is fast for already-concrete specs
                 specs[s.dag_hash()] = s
 

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -391,8 +391,9 @@ def config_prefer_upstream(args):
     if scope is None:
         scope = spack.config.default_modify_scope('packages')
 
-    all_specs = set(spack.store.db.query(installed=True))
-    local_specs = set(spack.store.db.query_local(installed=True))
+    store = spack.store.store
+    all_specs = set(store.db.query(installed=True))
+    local_specs = set(store.db.query_local(installed=True))
     pref_specs = local_specs if args.local else all_specs - local_specs
 
     conflicting_variants = set()

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -47,12 +47,12 @@ def deactivate(parser, args):
     elif pkg.extendable:
         target = spec.prefix
 
-    view = YamlFilesystemView(target, spack.store.layout)
+    view = YamlFilesystemView(target, spack.store.store.layout)
 
     if args.all:
         if pkg.extendable:
             tty.msg("Deactivating all extensions of %s" % pkg.spec.short_spec)
-            ext_pkgs = spack.store.db.activated_extensions_for(
+            ext_pkgs = spack.store.store.db.activated_extensions_for(
                 spec, view.extensions_layout)
 
             for ext_pkg in ext_pkgs:

--- a/lib/spack/spack/cmd/debug.py
+++ b/lib/spack/spack/cmd/debug.py
@@ -12,11 +12,11 @@ from datetime import datetime
 from glob import glob
 
 import llnl.util.tty as tty
-from llnl.util.filesystem import working_dir
-
 import spack.architecture as architecture
 import spack.config
 import spack.paths
+import spack.store
+from llnl.util.filesystem import working_dir
 from spack.main import get_version
 from spack.util.executable import which
 
@@ -64,16 +64,17 @@ def create_db_tarball(args):
     tarball_name = "spack-db.%s.tar.gz" % _debug_tarball_suffix()
     tarball_path = os.path.abspath(tarball_name)
 
-    base = os.path.basename(str(spack.store.root))
+    store = spack.store.store
+    base = os.path.basename(str(store.root))
     transform_args = []
     if 'GNU' in tar('--version', output=str):
         transform_args = ['--transform', 's/^%s/%s/' % (base, tarball_name)]
     else:
         transform_args = ['-s', '/^%s/%s/' % (base, tarball_name)]
 
-    wd = os.path.dirname(str(spack.store.root))
+    wd = os.path.dirname(str(store.root))
     with working_dir(wd):
-        files = [spack.store.db._index_path]
+        files = [store.db._index_path]
         files += glob('%s/*/*/*/.spack/spec.yaml' % base)
         files = [os.path.relpath(f) for f in files]
 

--- a/lib/spack/spack/cmd/dependencies.py
+++ b/lib/spack/spack/cmd/dependencies.py
@@ -48,7 +48,7 @@ def dependencies(parser, args):
         if sys.stdout.isatty():
             tty.msg(
                 "Dependencies of %s" % spec.format(format_string, color=True))
-        deps = spack.store.db.installed_relatives(
+        deps = spack.store.store.db.installed_relatives(
             spec, 'children', args.transitive, deptype=args.deptype)
         if deps:
             spack.cmd.display_specs(deps, long=True)

--- a/lib/spack/spack/cmd/dependents.py
+++ b/lib/spack/spack/cmd/dependents.py
@@ -88,7 +88,7 @@ def dependents(parser, args):
         format_string = '{name}{@version}{%compiler}{/hash:7}'
         if sys.stdout.isatty():
             tty.msg("Dependents of %s" % spec.cformat(format_string))
-        deps = spack.store.db.installed_relatives(
+        deps = spack.store.store.db.installed_relatives(
             spec, 'parents', args.transitive)
         if deps:
             spack.cmd.display_specs(deps, long=True)

--- a/lib/spack/spack/cmd/deprecate.py
+++ b/lib/spack/spack/cmd/deprecate.py
@@ -109,7 +109,7 @@ def deprecate(parser, args):
         already_deprecated = []
         already_deprecated_for = []
         for spec in all_deprecate:
-            deprecated_for = spack.store.db.deprecator(spec)
+            deprecated_for = spack.store.store.db.deprecator(spec)
             if deprecated_for:
                 already_deprecated.append(spec)
                 already_deprecated_for.append(deprecated_for)

--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -88,12 +88,12 @@ def extensions(parser, args):
     else:
         target = spec.prefix
 
-    view = YamlFilesystemView(target, spack.store.layout)
+    view = YamlFilesystemView(target, spack.store.store.layout)
 
     if args.show in ("installed", "all"):
         # List specs of installed extensions.
         installed = [
-            s.spec for s in spack.store.db.installed_extensions_for(spec)]
+            s.spec for s in spack.store.store.db.installed_extensions_for(spec)]
 
         if args.show == "all":
             print

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -15,6 +15,7 @@ import llnl.util.lang
 
 import spack.environment as ev
 import spack.repo
+import spack.store
 import spack.cmd as cmd
 import spack.cmd.common.arguments as arguments
 import spack.user_environment as uenv

--- a/lib/spack/spack/cmd/gc.py
+++ b/lib/spack/spack/cmd/gc.py
@@ -20,7 +20,7 @@ def setup_parser(subparser):
 
 
 def gc(parser, args):
-    specs = spack.store.db.unused_specs
+    specs = spack.store.store.db.unused_specs
 
     # Restrict garbage collection to the active environment
     # speculating over roots that are yet to be installed

--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -45,7 +45,7 @@ def graph(parser, args):
         if args.specs:
             tty.die("Can't specify specs with --installed")
         args.dot = True
-        specs = spack.store.db.query()
+        specs = spack.store.store.db.query()
 
     else:
         specs = spack.cmd.parse_specs(args.specs, concretize=not args.static)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -11,7 +11,6 @@ import textwrap
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
-
 import spack.build_environment
 import spack.cmd
 import spack.cmd.common.arguments as arguments
@@ -19,9 +18,9 @@ import spack.environment as ev
 import spack.fetch_strategy
 import spack.paths
 import spack.report
+import spack.store
 from spack.error import SpackError
 from spack.installer import PackageInstaller
-
 
 description = "build and install packages"
 section = "build"
@@ -346,8 +345,9 @@ environment variables:
     with reporter('build'):
         if args.overwrite:
 
-            installed = list(filter(lambda x: x,
-                                    map(spack.store.db.query_one, specs)))
+            installed = list(filter(
+                lambda x: x, map(spack.store.store.db.query_one, specs))
+            )
             if not args.yes_to_all:
                 display_args = {
                     'long': True,

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -67,7 +67,7 @@ def load(parser, args):
         )
         return 1
 
-    with spack.store.db.read_transaction():
+    with spack.store.store.db.read_transaction():
         if 'dependencies' in args.things_to_load:
             include_roots = 'package' in args.things_to_load
             specs = [dep for spec in specs

--- a/lib/spack/spack/cmd/mark.py
+++ b/lib/spack/spack/cmd/mark.py
@@ -70,7 +70,7 @@ def find_matching_specs(specs, allow_multiple_matches=False):
 
     for spec in specs:
         install_query = [InstallStatuses.INSTALLED]
-        matching = spack.store.db.query_local(spec, installed=install_query)
+        matching = spack.store.store.db.query_local(spec, installed=install_query)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:
@@ -102,7 +102,7 @@ def do_mark(specs, explicit):
         explicit (bool): whether to mark specs as explicitly installed
     """
     for spec in specs:
-        spack.store.db.update_explicit(spec, explicit)
+        spack.store.store.db.update_explicit(spec, explicit)
 
 
 def mark_specs(args, specs):

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -72,7 +72,7 @@ def spec(parser, args):
     # spec in the DAG.  This avoids repeatedly querying the DB.
     tree_context = nullcontext
     if args.install_status:
-        tree_context = spack.store.db.read_transaction
+        tree_context = spack.store.store.db.read_transaction
 
     if not args.specs:
         tty.die("spack spec requires at least one spec")

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -23,6 +23,7 @@ import spack.cmd.common.arguments as arguments
 import spack.package
 import spack.repo
 import spack.report
+import spack.store
 
 description = "run spack's tests for an install"
 section = "admin"
@@ -160,7 +161,7 @@ environment variables:
     specs = spack.cmd.parse_specs(args.specs) if args.specs else [None]
     specs_to_test = []
     for spec in specs:
-        matching = spack.store.db.query_local(spec, hashes=hashes)
+        matching = spack.store.store.db.query_local(spec, hashes=hashes)
         if spec and not matching:
             tty.warn("No installed packages match spec %s" % spec)
         specs_to_test.extend(matching)
@@ -223,7 +224,7 @@ def test_list(args):
     env = ev.get_env(args, 'test')
     hashes = env.all_hashes() if env else None
 
-    specs = spack.store.db.query(hashes=hashes)
+    specs = spack.store.store.db.query(hashes=hashes)
     specs = list(filter(lambda s: has_test_method(s.package_class), specs))
 
     spack.cmd.display_specs(specs, long=True)
@@ -296,7 +297,7 @@ def _report_suite_results(test_suite, args, constraints):
         qspecs = spack.cmd.parse_specs(constraints)
         specs = {}
         for spec in qspecs:
-            for s in spack.store.db.query(spec, installed=True):
+            for s in spack.store.store.db.query(spec, installed=True):
                 specs[s.dag_hash()] = s
         specs = sorted(specs.values())
         test_specs = dict((test_suite.test_pkg_id(s), s) for s in

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -84,8 +84,9 @@ def find_matching_specs(env, specs, allow_multiple_matches=False, force=False):
     has_errors = False
     for spec in specs:
         install_query = [InstallStatuses.INSTALLED, InstallStatuses.DEPRECATED]
-        matching = spack.store.db.query_local(spec, hashes=hashes,
-                                              installed=install_query)
+        matching = spack.store.store.db.query_local(
+            spec, hashes=hashes, installed=install_query
+        )
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:
@@ -133,7 +134,7 @@ def installed_dependents(specs, env):
 
     env_hashes = set(env.all_hashes()) if env else set()
 
-    all_specs_in_db = spack.store.db.query()
+    all_specs_in_db = spack.store.store.db.query()
 
     for spec in specs:
         installed = [x for x in all_specs_in_db if spec in x]
@@ -219,7 +220,7 @@ def do_uninstall(env, specs, force):
 
     # A package is ready to be uninstalled when nothing else references it,
     # unless we are requested to force uninstall it.
-    is_ready = lambda x: not spack.store.db.query_by_spec_hash(x)[1].ref_count
+    is_ready = lambda x: not spack.store.store.db.query_by_spec_hash(x)[1].ref_count
     if force:
         is_ready = lambda x: True
 

--- a/lib/spack/spack/cmd/unload.py
+++ b/lib/spack/spack/cmd/unload.py
@@ -2,15 +2,15 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-import sys
 import os
+import sys
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
-import spack.util.environment
-import spack.user_environment as uenv
 import spack.error
+import spack.store
+import spack.user_environment as uenv
+import spack.util.environment
 
 description = "remove package from the user environment"
 section = "user environment"
@@ -48,7 +48,7 @@ def unload(parser, args):
         specs = [spack.cmd.disambiguate_spec_from_hashes(spec, hashes)
                  for spec in spack.cmd.parse_specs(args.specs)]
     else:
-        specs = spack.store.db.query(hashes=hashes)
+        specs = spack.store.store.db.query(hashes=hashes)
 
     if not args.shell:
         specs_str = ' '.join(args.specs) or "SPECS"

--- a/lib/spack/spack/cmd/verify.py
+++ b/lib/spack/spack/cmd/verify.py
@@ -60,7 +60,8 @@ def verify(parser, args):
         spec_args = spack.cmd.parse_specs(args.specs_or_files)
 
     if args.all:
-        query = spack.store.db.query_local if local else spack.store.db.query
+        store = spack.store.store
+        query = store.db.query_local if local else store.db.query
 
         # construct spec list
         if spec_args:

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -81,7 +81,7 @@ def disambiguate_in_view(specs, view):
         return matching_in_view[0] if matching_in_view else matching_specs[0]
 
     # make function always return a list to keep consistency between py2/3
-    return list(map(squash, map(spack.store.db.query, specs)))
+    return list(map(squash, map(spack.store.store.db.query, specs)))
 
 
 def setup_parser(sp):
@@ -191,7 +191,7 @@ def view(parser, args):
         link_fn = view_symlink
 
     view = YamlFilesystemView(
-        path, spack.store.layout,
+        path, spack.store.store.layout,
         projections=ordered_projections,
         ignore_conflicts=getattr(args, "ignore_conflicts", False),
         link=link_fn,

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -476,7 +476,7 @@ class Database(object):
         containing the spec, in a subdirectory of the database to enable
         persistence across overlapping but separate related build processes.
 
-        The failure lock file, ``spack.store.db.prefix_failures``, lives
+        The failure lock file, ``spack.store.store.db.prefix_failures``, lives
         alongside the install DB. ``n`` is the sys.maxsize-bit prefix of the
         associated DAG hash to make the likelihood of collision very low with
         no cleanup required.
@@ -549,7 +549,7 @@ class Database(object):
 
         Prefix lock is a byte range lock on the nth byte of a file.
 
-        The lock file is ``spack.store.db.prefix_lock`` -- the DB
+        The lock file is ``spack.store.store.db.prefix_lock`` -- the DB
         tells us what to call it and it lives alongside the install DB.
 
         n is the sys.maxsize-bit prefix of the DAG hash.  This makes
@@ -744,7 +744,7 @@ class Database(object):
                     % (version, _db_version)
                 )
 
-                self.reindex(spack.store.layout)
+                self.reindex(spack.store.store.layout)
                 installs = dict(
                     (k, v.to_dict(include_fields=self._record_fields))
                     for k, v in self._data.items()
@@ -905,7 +905,7 @@ class Database(object):
                 tty.debug(
                     'RECONSTRUCTING FROM OLD DB: {0}'.format(entry.spec))
                 try:
-                    layout = spack.store.layout
+                    layout = spack.store.store.layout
                     if entry.spec.external:
                         layout = None
                         install_check = True
@@ -1021,7 +1021,7 @@ class Database(object):
         # reindex() takes its own write lock, so no lock here.
         with lk.WriteTransaction(self.lock):
             self._write(None, None, None)
-        self.reindex(spack.store.layout)
+        self.reindex(spack.store.store.layout)
 
     def _add(
             self,
@@ -1314,7 +1314,7 @@ class Database(object):
         the given spec
         """
         if extensions_layout is None:
-            view = YamlFilesystemView(extendee_spec.prefix, spack.store.layout)
+            view = YamlFilesystemView(extendee_spec.prefix, spack.store.store.layout)
             extensions_layout = view.extensions_layout
         for spec in self.query():
             try:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -85,7 +85,7 @@ class DirectoryLayout(object):
         if spec.external:
             return spec.external_path
         if self.check_upstream:
-            upstream, record = spack.store.db.query_by_spec_hash(
+            upstream, record = spack.store.store.db.query_by_spec_hash(
                 spec.dag_hash())
             if upstream:
                 raise SpackError(

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -90,7 +90,7 @@ def view_copy(src, dst, view, spec=None):
                 prefixes=prefix_to_projection
             )
         else:
-            prefix_to_projection[spack.store.layout.root] = view._root
+            prefix_to_projection[spack.store.store.layout.root] = view._root
             prefix_to_projection[orig_sbang] = new_sbang
             spack.relocate.relocate_text(
                 files=[dst],
@@ -350,8 +350,10 @@ class YamlFilesystemView(FilesystemView):
         if spec.package.extendable:
             # Check for globally activated extensions in the extendee that
             # we're looking at.
-            activated = [p.spec for p in
-                         spack.store.db.activated_extensions_for(spec)]
+            activated = [
+                p.spec for p in
+                spack.store.store.db.activated_extensions_for(spec)
+            ]
             if activated:
                 tty.error("Globally activated extensions cannot be used in "
                           "conjunction with filesystem views. "
@@ -424,8 +426,9 @@ class YamlFilesystemView(FilesystemView):
 
             # check if this spec owns a file of that name (through the
             # manifest in the metadata dir, which we have in the view).
-            manifest_file = os.path.join(self.get_path_meta_folder(spec),
-                                         spack.store.layout.manifest_file_name)
+            manifest_file = os.path.join(
+                self.get_path_meta_folder(spec),
+                spack.store.store.layout.manifest_file_name)
             try:
                 with open(manifest_file, 'r') as f:
                     manifest = s_json.load(f)
@@ -560,17 +563,18 @@ class YamlFilesystemView(FilesystemView):
 
     def get_all_specs(self):
         md_dirs = []
+        layout = spack.store.store.layout
         for root, dirs, files in os.walk(self._root):
-            if spack.store.layout.metadata_dir in dirs:
-                md_dirs.append(os.path.join(root,
-                                            spack.store.layout.metadata_dir))
+            if layout.metadata_dir in dirs:
+                md_dirs.append(os.path.join(root, layout.metadata_dir))
 
         specs = []
         for md_dir in md_dirs:
             if os.path.exists(md_dir):
                 for name_dir in os.listdir(md_dir):
-                    filename = os.path.join(md_dir, name_dir,
-                                            spack.store.layout.spec_file_name)
+                    filename = os.path.join(
+                        md_dir, name_dir, layout.spec_file_name
+                    )
                     spec = get_spec_from_file(filename)
                     if spec:
                         specs.append(spec)
@@ -588,18 +592,18 @@ class YamlFilesystemView(FilesystemView):
     def get_path_meta_folder(self, spec):
         "Get path to meta folder for either spec or spec name."
         return os.path.join(self.get_projection_for_spec(spec),
-                            spack.store.layout.metadata_dir,
+                            spack.store.store.layout.metadata_dir,
                             getattr(spec, "name", spec))
 
     def get_spec(self, spec):
         dotspack = self.get_path_meta_folder(spec)
         filename = os.path.join(dotspack,
-                                spack.store.layout.spec_file_name)
+                                spack.store.store.layout.spec_file_name)
 
         return get_spec_from_file(filename)
 
     def link_meta_folder(self, spec):
-        src = spack.store.layout.metadata_path(spec)
+        src = spack.store.store.layout.metadata_path(spec)
         tgt = self.get_path_meta_folder(spec)
 
         tree = LinkTree(src)

--- a/lib/spack/spack/hooks/extensions.py
+++ b/lib/spack/spack/hooks/extensions.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack
-from spack.filesystem_view import YamlFilesystemView
+import spack.store
+import spack.filesystem_view as fs_view
 
 
 def pre_uninstall(spec):
@@ -13,7 +14,7 @@ def pre_uninstall(spec):
 
     if pkg.is_extension:
         target = pkg.extendee_spec.prefix
-        view = YamlFilesystemView(target, spack.store.layout)
+        view = fs_view.YamlFilesystemView(target, spack.store.store.layout)
 
         if pkg.is_activated(view):
             # deactivate globally

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -27,7 +27,7 @@ else:
 
 def sbang_install_path():
     """Location sbang should be installed within Spack's ``install_tree``."""
-    sbang_root = str(spack.store.unpadded_root)
+    sbang_root = str(spack.store.store.unpadded_root)
     install_path = os.path.join(sbang_root, "bin", "sbang")
     if len(install_path) > shebang_limit:
         raise SbangPathError(

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -676,7 +676,7 @@ def print_setup_info(*info):
     if 'modules' in info:
         generic_arch = archspec.cpu.host().family
         module_spec = 'environment-modules target={0}'.format(generic_arch)
-        specs = spack.store.db.query(module_spec)
+        specs = spack.store.store.db.query(module_spec)
         if specs:
             shell_set('_sp_module_prefix', specs[-1].prefix)
         else:

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -37,18 +37,19 @@ import re
 from typing import Optional  # novm
 
 import llnl.util.filesystem
-from llnl.util.lang import dedupe
 import llnl.util.tty as tty
 import spack.build_environment as build_environment
 import spack.error
 import spack.paths
-import spack.schema.environment
 import spack.projections as proj
+import spack.schema.environment
+import spack.store
 import spack.tengine as tengine
 import spack.util.environment
 import spack.util.file_permissions as fp
 import spack.util.path
 import spack.util.spack_yaml as syaml
+from llnl.util.lang import dedupe
 
 
 #: config section for this file
@@ -243,7 +244,7 @@ def generate_module_index(root, modules, overwrite=False):
 def _generate_upstream_module_index():
     module_indices = read_module_indices()
 
-    return UpstreamModuleIndex(spack.store.db, module_indices)
+    return UpstreamModuleIndex(spack.store.store.db, module_indices)
 
 
 upstream_module_index = llnl.util.lang.Singleton(
@@ -350,7 +351,7 @@ def get_module(module_type, spec, get_full_path, required=True):
     try:
         upstream = spec.package.installed_upstream
     except spack.repo.UnknownPackageError:
-        upstream, record = spack.store.db.query_by_spec_hash(spec.dag_hash())
+        upstream, record = spack.store.store.db.query_by_spec_hash(spec.dag_hash())
     if upstream:
         module = (spack.modules.common.upstream_module_index
                   .upstream_module(spec, module_type))

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -17,6 +17,7 @@ import spack.architecture
 import spack.cmd
 import spack.repo
 import spack.spec
+import spack.store
 import spack.util.executable as executable
 
 
@@ -737,7 +738,7 @@ def raise_if_not_relocatable(binaries, allow_root):
     """
     for binary in binaries:
         if not (allow_root or file_is_relocatable(binary)):
-            raise InstallRootStringError(binary, spack.store.layout.root)
+            raise InstallRootStringError(binary, spack.store.store.layout.root)
 
 
 def relocate_links(links, orig_layout_root,
@@ -909,7 +910,7 @@ def file_is_relocatable(filename, paths_to_relocate=None):
 
         ValueError: if the filename does not exist or the path is not absolute
     """
-    default_paths_to_relocate = [spack.store.layout.root, spack.paths.prefix]
+    default_paths_to_relocate = [spack.store.store.layout.root, spack.paths.prefix]
     paths_to_relocate = paths_to_relocate or default_paths_to_relocate
 
     if not (platform.system().lower() == 'darwin'

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1482,13 +1482,13 @@ class Spec(object):
         if not self._concrete:
             raise spack.error.SpecError("Spec is not concrete: " + str(self))
 
+        store = spack.store.store
         if self._prefix is None:
-            upstream, record = spack.store.db.query_by_spec_hash(
-                self.dag_hash())
+            upstream, record = store.db.query_by_spec_hash(self.dag_hash())
             if record and record.path:
                 self.prefix = record.path
             else:
-                self.prefix = spack.store.layout.path_for_spec(self)
+                self.prefix = store.layout.path_for_spec(self)
         return self._prefix
 
     @prefix.setter
@@ -2514,9 +2514,10 @@ class Spec(object):
             SpecDeprecatedError: is any deprecated spec is found
         """
         deprecated = []
-        with spack.store.db.read_transaction():
+        store = spack.store.store
+        with store.db.read_transaction():
             for x in root.traverse():
-                _, rec = spack.store.db.query_by_spec_hash(x.dag_hash())
+                _, rec = store.db.query_by_spec_hash(x.dag_hash())
                 if rec and rec.deprecated_for:
                     deprecated.append(rec)
         if deprecated:
@@ -3783,7 +3784,7 @@ class Spec(object):
                 write(morph(spec, spack.paths.spack_root))
                 return
             elif attribute == 'spack_install':
-                write(morph(spec, spack.store.layout.root))
+                write(morph(spec, spack.store.store.layout.root))
                 return
             elif re.match(r'hash(:\d)?', attribute):
                 col = '#'
@@ -4101,7 +4102,7 @@ class Spec(object):
                 elif named_str == 'SPACK_ROOT':
                     out.write(fmt % transform(self, spack.paths.prefix))
                 elif named_str == 'SPACK_INSTALL':
-                    out.write(fmt % transform(self, spack.store.root))
+                    out.write(fmt % transform(self, spack.store.store.root))
                 elif named_str == 'PREFIX':
                     out.write(fmt % transform(self, self.prefix))
                 elif named_str.startswith('HASH'):
@@ -4149,7 +4150,7 @@ class Spec(object):
         if not self.concrete:
             return None
         try:
-            record = spack.store.db.get_record(self)
+            record = spack.store.store.db.get_record(self)
             return record.installed
         except KeyError:
             return None
@@ -4159,7 +4160,7 @@ class Spec(object):
         if not self.concrete:
             return None
         try:
-            record = spack.store.db.get_record(self)
+            record = spack.store.store.db.get_record(self)
             return record.explicit
         except KeyError:
             return None
@@ -4580,7 +4581,7 @@ class SpecParser(spack.parse.Parser):
         self.expect(ID)
 
         dag_hash = self.token.value
-        matches = spack.store.db.get_by_hash(dag_hash)
+        matches = spack.store.store.db.get_by_hash(dag_hash)
         if not matches:
             raise NoSuchHashError(dag_hash)
 

--- a/lib/spack/spack/store.py
+++ b/lib/spack/spack/store.py
@@ -232,24 +232,11 @@ def _store_layout():
     return store.layout
 
 
-# convenience accessors for parts of the singleton store
-root = llnl.util.lang.LazyReference(_store_root)
-unpadded_root = llnl.util.lang.LazyReference(_store_unpadded_root)
-db = llnl.util.lang.LazyReference(_store_db)
-layout = llnl.util.lang.LazyReference(_store_layout)
-
-
 def reinitialize():
     """Restore globals to the same state they would have at start-up"""
     global store
-    global root, unpadded_root, db, layout
 
     store = llnl.util.lang.Singleton(_store)
-
-    root = llnl.util.lang.LazyReference(_store_root)
-    unpadded_root = llnl.util.lang.LazyReference(_store_unpadded_root)
-    db = llnl.util.lang.LazyReference(_store_db)
-    layout = llnl.util.lang.LazyReference(_store_layout)
 
 
 def retrieve_upstream_dbs():
@@ -286,7 +273,7 @@ def use_store(store_or_path):
     Returns:
         Store object associated with the context manager's store
     """
-    global store, db, layout, root, unpadded_root
+    global store
 
     # Normalize input arguments
     temporary_store = store_or_path
@@ -296,12 +283,8 @@ def use_store(store_or_path):
     # Swap the store with the one just constructed and return it
     _ = store.db
     original_store, store = store, temporary_store
-    db, layout = store.db, store.layout
-    root, unpadded_root = store.root, store.unpadded_root
 
     yield temporary_store
 
     # Restore the original store
     store = original_store
-    db, layout = original_store.db, original_store.layout
-    root, unpadded_root = original_store.root, original_store.unpadded_root

--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -103,10 +103,6 @@ class TestState(object):
 
             new_store = spack.store.Store.deserialize(self.store_token)
             spack.store.store = new_store
-            spack.store.root = new_store.root
-            spack.store.unpadded_root = new_store.unpadded_root
-            spack.store.db = new_store.db
-            spack.store.layout = new_store.layout
 
             self.test_patches.restore()
 

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -135,15 +135,14 @@ def install_dir_default_layout(tmpdir):
         '${compiler.name}-${compiler.version}',
         '${name}-${version}-${hash}'
     )
-    real_store, real_layout = spack.store.store, spack.store.layout
+    real_store = spack.store.store
     opt_dir = tmpdir.join('opt')
     spack.store.store = spack.store.Store(str(opt_dir))
-    spack.store.layout = YamlDirectoryLayout(str(opt_dir), path_scheme=scheme)
+    spack.store.store.layout = YamlDirectoryLayout(str(opt_dir), path_scheme=scheme)
     try:
         yield spack.store
     finally:
         spack.store.store = real_store
-        spack.store.layout = real_layout
 
 
 @pytest.fixture(scope='function')
@@ -153,15 +152,14 @@ def install_dir_non_default_layout(tmpdir):
         '${name}', '${version}',
         '${architecture}-${compiler.name}-${compiler.version}-${hash}'
     )
-    real_store, real_layout = spack.store.store, spack.store.layout
+    real_store = spack.store.store
     opt_dir = tmpdir.join('opt')
     spack.store.store = spack.store.Store(str(opt_dir))
-    spack.store.layout = YamlDirectoryLayout(str(opt_dir), path_scheme=scheme)
+    spack.store.store.layout = YamlDirectoryLayout(str(opt_dir), path_scheme=scheme)
     try:
         yield spack.store
     finally:
         spack.store.store = real_store
-        spack.store.layout = real_layout
 
 
 args = ['strings', 'file']

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -22,5 +22,5 @@ def test_store_is_restored_correctly_after_bootstrap(mutable_config, tmpdir):
     # Test that within the context manager we use the bootstrap store
     # and that outside we restore the correct location
     with spack.bootstrap.ensure_bootstrap_configuration():
-        assert spack.store.root == spack.paths.user_bootstrap_store
-    assert spack.store.root == user_path
+        assert spack.store.store.root == spack.paths.user_bootstrap_store
+    assert spack.store.store.root == user_path

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -683,7 +683,7 @@ def test_config_prefer_upstream(tmpdir_factory, install_mockery, mock_fetch,
         tmpdir_factory.mktemp('mock_downstream_db_root'))
     db_for_test = spack.database.Database(
         downstream_db_root, upstream_dbs=[prepared_db])
-    monkeypatch.setattr(spack.store, 'db', db_for_test)
+    monkeypatch.setattr(spack.store.store, 'db', db_for_test)
 
     output = config('prefer-upstream')
     scope = spack.config.default_modify_scope('packages')

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -57,7 +57,7 @@ def test_direct_installed_dependencies(mock_packages, database):
     ]
     hashes = set([re.split(r'\s+', line)[0] for line in lines])
 
-    expected = set([spack.store.db.query_one(s).dag_hash(7)
+    expected = set([spack.store.store.db.query_one(s).dag_hash(7)
                     for s in ['mpich', 'callpath^mpich']])
 
     assert expected == hashes
@@ -74,7 +74,7 @@ def test_transitive_installed_dependencies(mock_packages, database):
     ]
     hashes = set([re.split(r'\s+', line)[0] for line in lines])
 
-    expected = set([spack.store.db.query_one(s).dag_hash(7)
+    expected = set([spack.store.store.db.query_one(s).dag_hash(7)
                     for s in ['zmpi', 'callpath^zmpi', 'fake',
                               'dyninst', 'libdwarf', 'libelf']])
 

--- a/lib/spack/spack/test/cmd/dependents.py
+++ b/lib/spack/spack/test/cmd/dependents.py
@@ -52,10 +52,10 @@ def test_immediate_installed_dependents(mock_packages, database):
     lines = [li for li in out.strip().split('\n') if not li.startswith('--')]
     hashes = set([re.split(r'\s+', li)[0] for li in lines])
 
-    expected = set([spack.store.db.query_one(s).dag_hash(7)
+    expected = set([spack.store.store.db.query_one(s).dag_hash(7)
                     for s in ['dyninst', 'libdwarf']])
 
-    libelf = spack.store.db.query_one('libelf')
+    libelf = spack.store.store.db.query_one('libelf')
     expected = set([d.dag_hash(7) for d in libelf.dependents()])
 
     assert expected == hashes
@@ -69,7 +69,7 @@ def test_transitive_installed_dependents(mock_packages, database):
     lines = [li for li in out.strip().split('\n') if not li.startswith('--')]
     hashes = set([re.split(r'\s+', li)[0] for li in lines])
 
-    expected = set([spack.store.db.query_one(s).dag_hash(7)
+    expected = set([spack.store.store.db.query_one(s).dag_hash(7)
                     for s in ['zmpi', 'callpath^zmpi', 'mpileaks^zmpi']])
 
     assert expected == hashes

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -18,15 +18,15 @@ def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
     install('libelf@0.8.13')
     install('libelf@0.8.10')
 
-    all_installed = spack.store.db.query()
+    all_installed = spack.store.store.db.query()
     assert len(all_installed) == 2
 
     deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13')
 
-    non_deprecated = spack.store.db.query()
-    all_available = spack.store.db.query(installed=any)
+    non_deprecated = spack.store.store.db.query()
+    all_available = spack.store.store.db.query(installed=any)
     assert all_available == all_installed
-    assert non_deprecated == spack.store.db.query('libelf@0.8.13')
+    assert non_deprecated == spack.store.store.db.query('libelf@0.8.13')
 
 
 def test_deprecate_fails_no_such_package(mock_packages, mock_archive,
@@ -52,13 +52,13 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch,
     that is not yet installed."""
     install('libelf@0.8.10')
 
-    to_deprecate = spack.store.db.query()
+    to_deprecate = spack.store.store.db.query()
     assert len(to_deprecate) == 1
 
     deprecate('-y', '-i', 'libelf@0.8.10', 'libelf@0.8.13')
 
-    non_deprecated = spack.store.db.query()
-    deprecated = spack.store.db.query(installed=InstallStatuses.DEPRECATED)
+    non_deprecated = spack.store.store.db.query()
+    deprecated = spack.store.store.db.query(installed=InstallStatuses.DEPRECATED)
     assert deprecated == to_deprecate
     assert len(non_deprecated) == 1
     assert non_deprecated[0].satisfies('libelf@0.8.13')
@@ -73,13 +73,13 @@ def test_deprecate_deps(mock_packages, mock_archive, mock_fetch,
     new_spec = spack.spec.Spec('libdwarf@20130729^libelf@0.8.13').concretized()
     old_spec = spack.spec.Spec('libdwarf@20130207^libelf@0.8.10').concretized()
 
-    all_installed = spack.store.db.query()
+    all_installed = spack.store.store.db.query()
 
     deprecate('-y', '-d', 'libdwarf@20130207', 'libdwarf@20130729')
 
-    non_deprecated = spack.store.db.query()
-    all_available = spack.store.db.query(installed=any)
-    deprecated = spack.store.db.query(installed=InstallStatuses.DEPRECATED)
+    non_deprecated = spack.store.store.db.query()
+    all_available = spack.store.store.db.query(installed=any)
+    deprecated = spack.store.store.db.query(installed=InstallStatuses.DEPRECATED)
 
     assert all_available == all_installed
     assert sorted(all_available) == sorted(deprecated + non_deprecated)
@@ -115,12 +115,12 @@ def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch,
 
     deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13')
 
-    non_deprecated = spack.store.db.query()
+    non_deprecated = spack.store.store.db.query()
 
     uninstall('-y', 'libelf@0.8.10')
 
-    assert spack.store.db.query() == spack.store.db.query(installed=any)
-    assert spack.store.db.query() == non_deprecated
+    assert spack.store.store.db.query() == spack.store.store.db.query(installed=any)
+    assert spack.store.store.db.query() == non_deprecated
 
 
 def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch,
@@ -134,17 +134,17 @@ def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch,
 
     deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.12')
 
-    deprecator = spack.store.db.deprecator(deprecated_spec)
+    deprecator = spack.store.store.db.deprecator(deprecated_spec)
     assert deprecator == spack.spec.Spec('libelf@0.8.12').concretized()
 
     deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13')
 
-    non_deprecated = spack.store.db.query()
-    all_available = spack.store.db.query(installed=any)
+    non_deprecated = spack.store.store.db.query()
+    all_available = spack.store.store.db.query(installed=any)
     assert len(non_deprecated) == 2
     assert len(all_available) == 3
 
-    deprecator = spack.store.db.deprecator(deprecated_spec)
+    deprecator = spack.store.store.db.deprecator(deprecated_spec)
     assert deprecator == spack.spec.Spec('libelf@0.8.13').concretized()
 
 
@@ -162,19 +162,19 @@ def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch,
 
     deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.12')
 
-    deprecator = spack.store.db.deprecator(first_deprecated_spec)
+    deprecator = spack.store.store.db.deprecator(first_deprecated_spec)
     assert deprecator == second_deprecated_spec
 
     deprecate('-y', 'libelf@0.8.12', 'libelf@0.8.13')
 
-    non_deprecated = spack.store.db.query()
-    all_available = spack.store.db.query(installed=any)
+    non_deprecated = spack.store.store.db.query()
+    all_available = spack.store.store.db.query(installed=any)
     assert len(non_deprecated) == 1
     assert len(all_available) == 3
 
-    first_deprecator = spack.store.db.deprecator(first_deprecated_spec)
+    first_deprecator = spack.store.store.db.deprecator(first_deprecated_spec)
     assert first_deprecator == final_deprecator
-    second_deprecator = spack.store.db.deprecator(second_deprecated_spec)
+    second_deprecator = spack.store.store.db.deprecator(second_deprecated_spec)
     assert second_deprecator == final_deprecator
 
 

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -4,10 +4,12 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import pytest
-import spack.spec
+
 import llnl.util.filesystem as fs
+import pytest
 import spack.environment as ev
+import spack.spec
+import spack.store
 from spack.main import SpackCommand
 
 dev_build = SpackCommand('dev-build')
@@ -66,7 +68,7 @@ def test_dev_build_until(tmpdir, mock_packages, install_mockery):
             assert f.read() == spec.package.replacement_string
 
     assert not os.path.exists(spec.prefix)
-    assert not spack.store.db.query(spec, installed=True)
+    assert not spack.store.store.db.query(spec, installed=True)
 
 
 def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
@@ -85,7 +87,7 @@ def test_dev_build_until_last_phase(tmpdir, mock_packages, install_mockery):
             assert f.read() == spec.package.replacement_string
 
     assert os.path.exists(spec.prefix)
-    assert spack.store.db.query(spec, installed=True)
+    assert spack.store.store.db.query(spec, installed=True)
     assert os.path.exists(str(tmpdir))
 
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -10,12 +10,12 @@ import os
 import pytest
 import spack.cmd as cmd
 import spack.cmd.find
+import spack.environment as ev
+import spack.store
 import spack.user_environment as uenv
 from spack.main import SpackCommand
 from spack.spec import Spec
 from spack.util.pattern import Bunch
-import spack.environment as ev
-
 
 find = SpackCommand('find')
 env = SpackCommand('env')
@@ -328,7 +328,7 @@ def test_find_loaded(database, working_env):
     assert output == ''
 
     os.environ[uenv.spack_loaded_hashes_var] = ':'.join(
-        [x.dag_hash() for x in spack.store.db.query()])
+        [x.dag_hash() for x in spack.store.store.db.query()])
     output = find('--loaded')
     expected = find()
     assert output == expected

--- a/lib/spack/spack/test/cmd/mark.py
+++ b/lib/spack/spack/test/cmd/mark.py
@@ -29,7 +29,7 @@ def test_mark_spec_required(mutable_database):
 def test_mark_all_explicit(mutable_database):
     mark('-e', '-a')
     gc('-y')
-    all_specs = spack.store.layout.all_specs()
+    all_specs = spack.store.store.layout.all_specs()
     assert len(all_specs) == 14
 
 
@@ -37,7 +37,7 @@ def test_mark_all_explicit(mutable_database):
 def test_mark_all_implicit(mutable_database):
     mark('-i', '-a')
     gc('-y')
-    all_specs = spack.store.layout.all_specs()
+    all_specs = spack.store.store.layout.all_specs()
     assert len(all_specs) == 0
 
 
@@ -46,7 +46,7 @@ def test_mark_one_explicit(mutable_database):
     mark('-e', 'libelf')
     uninstall('-y', '-a', 'mpileaks')
     gc('-y')
-    all_specs = spack.store.layout.all_specs()
+    all_specs = spack.store.store.layout.all_specs()
     assert len(all_specs) == 2
 
 
@@ -54,7 +54,7 @@ def test_mark_one_explicit(mutable_database):
 def test_mark_one_implicit(mutable_database):
     mark('-i', 'externaltest')
     gc('-y')
-    all_specs = spack.store.layout.all_specs()
+    all_specs = spack.store.store.layout.all_specs()
     assert len(all_specs) == 13
 
 
@@ -63,5 +63,5 @@ def test_mark_all_implicit_then_explicit(mutable_database):
     mark('-i', '-a')
     mark('-e', '-a')
     gc('-y')
-    all_specs = spack.store.layout.all_specs()
+    all_specs = spack.store.store.layout.all_specs()
     assert len(all_specs) == 14

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -16,11 +16,11 @@ def test_reindex_basic(mock_packages, mock_archive, mock_fetch,
     install('libelf@0.8.13')
     install('libelf@0.8.12')
 
-    all_installed = spack.store.db.query()
+    all_installed = spack.store.store.db.query()
 
     reindex()
 
-    assert spack.store.db.query() == all_installed
+    assert spack.store.store.db.query() == all_installed
 
 
 def test_reindex_db_deleted(mock_packages, mock_archive, mock_fetch,
@@ -28,12 +28,12 @@ def test_reindex_db_deleted(mock_packages, mock_archive, mock_fetch,
     install('libelf@0.8.13')
     install('libelf@0.8.12')
 
-    all_installed = spack.store.db.query()
+    all_installed = spack.store.store.db.query()
 
-    os.remove(spack.store.db._index_path)
+    os.remove(spack.store.store.db._index_path)
     reindex()
 
-    assert spack.store.db.query() == all_installed
+    assert spack.store.store.db.query() == all_installed
 
 
 def test_reindex_with_deprecated_packages(mock_packages, mock_archive,
@@ -43,11 +43,11 @@ def test_reindex_with_deprecated_packages(mock_packages, mock_archive,
 
     deprecate('-y', 'libelf@0.8.12', 'libelf@0.8.13')
 
-    all_installed = spack.store.db.query(installed=any)
-    non_deprecated = spack.store.db.query(installed=True)
+    all_installed = spack.store.store.db.query(installed=any)
+    non_deprecated = spack.store.store.db.query(installed=True)
 
-    os.remove(spack.store.db._index_path)
+    os.remove(spack.store.store.db._index_path)
     reindex()
 
-    assert spack.store.db.query(installed=any) == all_installed
-    assert spack.store.db.query(installed=True) == non_deprecated
+    assert spack.store.store.db.query(installed=any) == all_installed
+    assert spack.store.store.db.query(installed=True) == non_deprecated

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -41,7 +41,7 @@ def test_recursive_uninstall(mutable_database):
     """Test recursive uninstall."""
     uninstall('-y', '-a', '--dependents', 'callpath')
 
-    all_specs = spack.store.layout.all_specs()
+    all_specs = spack.store.store.layout.all_specs()
     assert len(all_specs) == 8
     # query specs with multiple configurations
     mpileaks_specs = [s for s in all_specs if s.satisfies('mpileaks')]
@@ -63,7 +63,7 @@ def test_uninstall_spec_with_multiple_roots(
 ):
     uninstall('-y', '-a', '--dependents', constraint)
 
-    all_specs = spack.store.layout.all_specs()
+    all_specs = spack.store.store.layout.all_specs()
     assert len(all_specs) == expected_number_of_specs
 
 
@@ -76,7 +76,7 @@ def test_force_uninstall_spec_with_ref_count_not_zero(
 ):
     uninstall('-f', '-y', constraint)
 
-    all_specs = spack.store.layout.all_specs()
+    all_specs = spack.store.store.layout.all_specs()
     assert len(all_specs) == expected_number_of_specs
 
 
@@ -84,43 +84,43 @@ def test_force_uninstall_spec_with_ref_count_not_zero(
 def test_force_uninstall_and_reinstall_by_hash(mutable_database):
     """Test forced uninstall and reinstall of old specs."""
     # this is the spec to be removed
-    callpath_spec = spack.store.db.query_one('callpath ^mpich')
+    callpath_spec = spack.store.store.db.query_one('callpath ^mpich')
     dag_hash = callpath_spec.dag_hash()
 
     # ensure can look up by hash and that it's a dependent of mpileaks
     def validate_callpath_spec(installed):
         assert installed is True or installed is False
 
-        specs = spack.store.db.get_by_hash(dag_hash, installed=installed)
+        store = spack.store.store
+
+        specs = store.db.get_by_hash(dag_hash, installed=installed)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.db.get_by_hash(dag_hash[:7], installed=installed)
+        specs = store.db.get_by_hash(dag_hash[:7], installed=installed)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.db.get_by_hash(dag_hash, installed=any)
+        specs = store.db.get_by_hash(dag_hash, installed=any)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.db.get_by_hash(dag_hash[:7], installed=any)
+        specs = store.db.get_by_hash(dag_hash[:7], installed=any)
         assert len(specs) == 1 and specs[0] == callpath_spec
 
-        specs = spack.store.db.get_by_hash(dag_hash, installed=not installed)
+        specs = store.db.get_by_hash(dag_hash, installed=not installed)
         assert specs is None
 
-        specs = spack.store.db.get_by_hash(dag_hash[:7],
-                                           installed=not installed)
+        specs = store.db.get_by_hash(dag_hash[:7], installed=not installed)
         assert specs is None
 
-        mpileaks_spec = spack.store.db.query_one('mpileaks ^mpich')
+        mpileaks_spec = store.db.query_one('mpileaks ^mpich')
         assert callpath_spec in mpileaks_spec
 
-        spec = spack.store.db.query_one('callpath ^mpich', installed=installed)
+        spec = store.db.query_one('callpath ^mpich', installed=installed)
         assert spec == callpath_spec
 
-        spec = spack.store.db.query_one('callpath ^mpich', installed=any)
+        spec = store.db.query_one('callpath ^mpich', installed=any)
         assert spec == callpath_spec
 
-        spec = spack.store.db.query_one('callpath ^mpich',
-                                        installed=not installed)
+        spec = store.db.query_one('callpath ^mpich', installed=not installed)
         assert spec is None
 
     validate_callpath_spec(True)
@@ -133,7 +133,7 @@ def test_force_uninstall_and_reinstall_by_hash(mutable_database):
 
     # BUT, make sure that the removed callpath spec is not in queries
     def db_specs():
-        all_specs = spack.store.layout.all_specs()
+        all_specs = spack.store.store.layout.all_specs()
         return (
             all_specs,
             [s for s in all_specs if s.satisfies('mpileaks')],

--- a/lib/spack/spack/test/cmd/verify.py
+++ b/lib/spack/spack/test/cmd/verify.py
@@ -22,7 +22,7 @@ def test_single_file_verify_cmd(tmpdir):
     # Test the verify command interface to verifying a single file.
     filedir = os.path.join(str(tmpdir), 'a', 'b', 'c', 'd')
     filepath = os.path.join(filedir, 'file')
-    metadir = os.path.join(str(tmpdir), spack.store.layout.metadata_dir)
+    metadir = os.path.join(str(tmpdir), spack.store.store.layout.metadata_dir)
 
     fs.mkdirp(filedir)
     fs.mkdirp(metadir)
@@ -33,7 +33,7 @@ def test_single_file_verify_cmd(tmpdir):
     data = spack.verify.create_manifest_entry(filepath)
 
     manifest_file = os.path.join(metadir,
-                                 spack.store.layout.manifest_file_name)
+                                 spack.store.store.layout.manifest_file_name)
 
     with open(manifest_file, 'w') as f:
         sjson.dump({filepath: data}, f)

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -3,29 +3,28 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 import collections
 import getpass
+import os
 import tempfile
-from six import StringIO
-
-from llnl.util.filesystem import touch, mkdirp
 
 import pytest
-
-import spack.paths
 import spack.config
-import spack.main
 import spack.environment
+import spack.main
+import spack.paths
 import spack.schema.compilers
 import spack.schema.config
 import spack.schema.env
-import spack.schema.packages
 import spack.schema.mirrors
+import spack.schema.packages
 import spack.schema.repos
-import spack.util.spack_yaml as syaml
+import spack.store
 import spack.util.path as spack_path
+import spack.util.spack_yaml as syaml
+from six import StringIO
 
+from llnl.util.filesystem import touch, mkdirp
 
 # sample config data
 config_low = {

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -693,7 +693,7 @@ def install_mockery(temporary_store, config, mock_packages):
     # Also wipe out any cached prefix failure locks (associated with
     # the session-scoped mock archive).
     for pkg_id in list(temporary_store.db._prefix_failures.keys()):
-        lock = spack.store.db._prefix_failures.pop(pkg_id, None)
+        lock = spack.store.store.db._prefix_failures.pop(pkg_id, None)
         if lock:
             try:
                 lock.release_write()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -105,7 +105,7 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch):
         pkg.remove_prefix = rm_prefix_checker.remove_prefix
 
         # must clear failure markings for the package before re-installing it
-        spack.store.db.clear_failure(spec, True)
+        spack.store.store.db.clear_failure(spec, True)
 
         pkg.succeed = True
         pkg.stage = MockStage(pkg.stage)
@@ -267,7 +267,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch):
         assert os.path.exists(pkg.prefix)
 
         # must clear failure markings for the package before re-installing it
-        spack.store.db.clear_failure(spec, True)
+        spack.store.store.db.clear_failure(spec, True)
 
         pkg.succeed = True   # make the build succeed
         pkg.stage = MockStage(pkg.stage)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -488,7 +488,7 @@ def test_dump_packages_deps_ok(install_mockery, tmpdir, mock_packages):
 
 def test_dump_packages_deps_errs(install_mockery, tmpdir, monkeypatch, capsys):
     """Test error paths for dump_packages with dependencies."""
-    orig_bpp = spack.store.layout.build_packages_path
+    orig_bpp = spack.store.store.layout.build_packages_path
     orig_dirname = spack.repo.Repo.dirname_for_package_name
     repo_err_msg = "Mock dirname_for_package_name"
 
@@ -507,7 +507,7 @@ def test_dump_packages_deps_errs(install_mockery, tmpdir, monkeypatch, capsys):
 
     # Now mock the creation of the required directory structure to cover
     # the try-except block
-    monkeypatch.setattr(spack.store.layout, 'build_packages_path', bpp_path)
+    monkeypatch.setattr(spack.store.store.layout, 'build_packages_path', bpp_path)
 
     spec = spack.spec.Spec('simple-inheritance').concretized()
     path = str(tmpdir)
@@ -531,27 +531,27 @@ def test_clear_failures_success(install_mockery):
     """Test the clear_failures happy path."""
 
     # Set up a test prefix failure lock
-    lock = lk.Lock(spack.store.db.prefix_fail_path, start=1, length=1,
+    lock = lk.Lock(spack.store.store.db.prefix_fail_path, start=1, length=1,
                    default_timeout=1e-9, desc='test')
     try:
         lock.acquire_write()
     except lk.LockTimeoutError:
         tty.warn('Failed to write lock the test install failure')
-    spack.store.db._prefix_failures['test'] = lock
+    spack.store.store.db._prefix_failures['test'] = lock
 
     # Set up a fake failure mark (or file)
-    fs.touch(os.path.join(spack.store.db._failure_dir, 'test'))
+    fs.touch(os.path.join(spack.store.store.db._failure_dir, 'test'))
 
     # Now clear failure tracking
     inst.clear_failures()
 
     # Ensure there are no cached failure locks or failure marks
-    assert len(spack.store.db._prefix_failures) == 0
-    assert len(os.listdir(spack.store.db._failure_dir)) == 0
+    assert len(spack.store.store.db._prefix_failures) == 0
+    assert len(os.listdir(spack.store.store.db._failure_dir)) == 0
 
     # Ensure the core directory and failure lock file still exist
-    assert os.path.isdir(spack.store.db._failure_dir)
-    assert os.path.isfile(spack.store.db.prefix_fail_path)
+    assert os.path.isdir(spack.store.store.db._failure_dir)
+    assert os.path.isfile(spack.store.store.db.prefix_fail_path)
 
 
 def test_clear_failures_errs(install_mockery, monkeypatch, capsys):
@@ -563,7 +563,7 @@ def test_clear_failures_errs(install_mockery, monkeypatch, capsys):
         raise OSError(err_msg)
 
     # Set up a fake failure mark (or file)
-    fs.touch(os.path.join(spack.store.db._failure_dir, 'test'))
+    fs.touch(os.path.join(spack.store.store.db._failure_dir, 'test'))
 
     monkeypatch.setattr(os, 'remove', _raise_except)
 
@@ -808,7 +808,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     spec = installer.build_requests[0].pkg.spec
 
     fs.touchp(spec.prefix)
-    metadatadir = spack.store.layout.metadata_path(spec)
+    metadatadir = spack.store.store.layout.metadata_path(spec)
     # Should fail with a "not a directory" error
     with pytest.raises(OSError, match=metadatadir):
         installer._setup_install_dir(spec.package)

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -57,7 +57,7 @@ def source_file(tmpdir, is_relocatable):
         ]
         env = spack.tengine.make_environment(template_dirs)
         template = env.get_template('non_relocatable.c')
-        text = template.render({'prefix': spack.store.layout.root})
+        text = template.render({'prefix': spack.store.store.layout.root})
 
         src = tmpdir.join('non_relocatable.c')
         src.write(text)

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -46,7 +46,7 @@ last_line  = "last!\n"
 
 @pytest.fixture  # type: ignore[no-redef]
 def sbang_line():
-    yield '#!/bin/sh %s/bin/sbang\n' % spack.store.layout.root
+    yield '#!/bin/sh %s/bin/sbang\n' % spack.store.store.layout.root
 
 
 class ScriptDirectory(object):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -791,7 +791,7 @@ class TestSpecSematics(object):
                                  ("{architecture.target}", "target")]
 
         other_segments = [('{spack_root}', spack.paths.spack_root),
-                          ('{spack_install}', spack.store.layout.root),
+                          ('{spack_install}', spack.store.store.layout.root),
                           ('{hash:7}', spec.dag_hash(7)),
                           ('{/hash}', '/' + spec.dag_hash())]
 

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -357,8 +357,8 @@ class TestSpecSyntax(object):
         x2.concretize()
         x2._hash = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 
-        mutable_database.add(x1, spack.store.layout)
-        mutable_database.add(x2, spack.store.layout)
+        mutable_database.add(x1, spack.store.store.layout)
+        mutable_database.add(x2, spack.store.store.layout)
 
         # ambiguity in first hash character
         self._check_raises(AmbiguousHashError, ['/x'])

--- a/lib/spack/spack/test/verification.py
+++ b/lib/spack/spack/test/verification.py
@@ -177,8 +177,8 @@ def test_check_prefix_manifest(tmpdir):
     assert results.errors[malware] == ['added']
 
     manifest_file = os.path.join(spec.prefix,
-                                 spack.store.layout.metadata_dir,
-                                 spack.store.layout.manifest_file_name)
+                                 spack.store.store.layout.metadata_dir,
+                                 spack.store.store.layout.manifest_file_name)
     with open(manifest_file, 'w') as f:
         f.write("{This) string is not proper json")
 
@@ -192,7 +192,7 @@ def test_single_file_verification(tmpdir):
     # to which it belongs
     filedir = os.path.join(str(tmpdir), 'a', 'b', 'c', 'd')
     filepath = os.path.join(filedir, 'file')
-    metadir = os.path.join(str(tmpdir), spack.store.layout.metadata_dir)
+    metadir = os.path.join(str(tmpdir), spack.store.store.layout.metadata_dir)
 
     fs.mkdirp(filedir)
     fs.mkdirp(metadir)
@@ -203,7 +203,7 @@ def test_single_file_verification(tmpdir):
     data = spack.verify.create_manifest_entry(filepath)
 
     manifest_file = os.path.join(metadir,
-                                 spack.store.layout.manifest_file_name)
+                                 spack.store.store.layout.manifest_file_name)
 
     with open(manifest_file, 'w') as f:
         sjson.dump({filepath: data}, f)

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -53,9 +53,10 @@ def create_manifest_entry(path):
 
 
 def write_manifest(spec):
-    manifest_file = os.path.join(spec.prefix,
-                                 spack.store.layout.metadata_dir,
-                                 spack.store.layout.manifest_file_name)
+    store = spack.store.store
+    manifest_file = os.path.join(
+        spec.prefix, store.layout.metadata_dir, store.layout.manifest_file_name
+    )
 
     if not os.path.exists(manifest_file):
         tty.debug("Writing manifest file: No manifest from binary")
@@ -121,15 +122,16 @@ def check_file_manifest(filename):
     dirname = os.path.dirname(filename)
 
     results = VerificationResults()
-    while spack.store.layout.metadata_dir not in os.listdir(dirname):
+    store = spack.store.store
+    while store.layout.metadata_dir not in os.listdir(dirname):
         if dirname == os.path.sep:
             results.add_error(filename, 'not owned by any package')
             return results
         dirname = os.path.dirname(dirname)
 
-    manifest_file = os.path.join(dirname,
-                                 spack.store.layout.metadata_dir,
-                                 spack.store.layout.manifest_file_name)
+    manifest_file = os.path.join(
+        dirname, store.layout.metadata_dir, store.layout.manifest_file_name
+    )
 
     if not os.path.exists(manifest_file):
         results.add_error(filename, "manifest missing")
@@ -152,10 +154,11 @@ def check_file_manifest(filename):
 def check_spec_manifest(spec):
     prefix = spec.prefix
 
+    store = spack.store.store
     results = VerificationResults()
-    manifest_file = os.path.join(prefix,
-                                 spack.store.layout.metadata_dir,
-                                 spack.store.layout.manifest_file_name)
+    manifest_file = os.path.join(
+        prefix, store.layout.metadata_dir, store.layout.manifest_file_name
+    )
 
     if not os.path.exists(manifest_file):
         results.add_error(prefix, "manifest missing")
@@ -169,8 +172,9 @@ def check_spec_manifest(spec):
         return results
 
     # Get extensions active in spec
-    view = spack.filesystem_view.YamlFilesystemView(prefix,
-                                                    spack.store.layout)
+    view = spack.filesystem_view.YamlFilesystemView(
+        prefix, spack.store.store.layout
+    )
     active_exts = view.extensions_layout.extension_map(spec).values()
     ext_file = ''
     if active_exts:

--- a/var/spack/repos/builtin.mock/packages/old-sbang/package.py
+++ b/var/spack/repos/builtin.mock/packages/old-sbang/package.py
@@ -28,7 +28,7 @@ class OldSbang(Package):
 #!/usr/bin/env python
 
 {1}
-'''.format(spack.store.unpadded_root, prefix.bin)
+'''.format(spack.store.store.unpadded_root, prefix.bin)
         with open('%s/sbang-style-1.sh' % self.prefix.bin, 'w') as f:
             f.write(sbang_style_1)
 


### PR DESCRIPTION
LazyReference objects were meant as a convenience to access attributes of the current store, but may increase the risk of having an inconsistent state since they are swapped and monkey-patched separately.

This commit gets rid of the LazyReference class and makes "spack.store.store" the only point of access for Spack's store attributes.