### PR TITLE
hdf5: libtool patch for NAG compiler

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/nag.mpi.libtool.patch
+++ b/var/spack/repos/builtin/packages/hdf5/nag.mpi.libtool.patch
@@ -1,0 +1,62 @@
+--- a/bin/ltmain.sh
++++ b/bin/ltmain.sh
+@@ -8881,7 +8881,8 @@ func_mode_link ()
+ 	  xlcverstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+ 	  verstring="-compatibility_version $minor_current -current_version $minor_current.$revision"
+           # On Darwin other compilers
+-          case $CC in
++          func_cc_basename $CC
++          case $func_cc_basename_result in
+               nagfor*)
+                   verstring="$wl-compatibility_version $wl$minor_current $wl-current_version $wl$minor_current.$revision"
+                   ;;
+--- a/configure
++++ b/configure
+@@ -12817,6 +12817,15 @@ func_cc_basename ()
+         compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
+         distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
+         \-*) ;;
++        mpicc | *[\\/]mpicc | \
++        mpic++ | *[\\/]mpic++ | mpicxx | *[\\/]mpicxx | mpiCC | *[\\/]mpiCC | \
++        mpif77 | *[\\/]mpif77 | mpif90 | *[\\/]mpif90 | mpifort | *[\\/]mpifort )
++          # OpenMPI or MPICH wrapper
++          mpi_cc_temp=
++          mpi_show=`$cc_temp -show 2>/dev/null`
++          test $? -eq 0 && mpi_cc_temp=`$ECHO "$mpi_show" | cut -d' ' -f1`
++          test -z $mpi_cc_temp >/dev/null 2>&1 || cc_temp=$mpi_cc_temp
++          break;;
+         *) break;;
+       esac
+     done
+@@ -33230,6 +33239,15 @@ func_cc_basename ()
+         compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
+         distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
+         \-*) ;;
++        mpicc | *[\\/]mpicc | \
++        mpic++ | *[\\/]mpic++ | mpicxx | *[\\/]mpicxx | mpiCC | *[\\/]mpiCC | \
++        mpif77 | *[\\/]mpif77 | mpif90 | *[\\/]mpif90 | mpifort | *[\\/]mpifort )
++          # OpenMPI or MPICH wrapper
++          mpi_cc_temp=
++          mpi_show=`$cc_temp -show 2>/dev/null`
++          test $? -eq 0 && mpi_cc_temp=`$ECHO "$mpi_show" | cut -d' ' -f1`
++          test -z $mpi_cc_temp >/dev/null 2>&1 || cc_temp=$mpi_cc_temp
++          break;;
+         *) break;;
+       esac
+     done
+@@ -36300,6 +36318,15 @@ func_cc_basename ()
+         compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
+         distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
+         \-*) ;;
++        mpicc | *[\\/]mpicc | \
++        mpic++ | *[\\/]mpic++ | mpicxx | *[\\/]mpicxx | mpiCC | *[\\/]mpiCC | \
++        mpif77 | *[\\/]mpif77 | mpif90 | *[\\/]mpif90 | mpifort | *[\\/]mpifort )
++          # OpenMPI or MPICH wrapper
++          mpi_cc_temp=
++          mpi_show=`$cc_temp -show 2>/dev/null`
++          test $? -eq 0 && mpi_cc_temp=`$ECHO "$mpi_show" | cut -d' ' -f1`
++          test -z $mpi_cc_temp >/dev/null 2>&1 || cc_temp=$mpi_cc_temp
++          break;;
+         *) break;;
+       esac
+     done

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -146,6 +146,11 @@ class Hdf5(AutotoolsPackage):
     patch('hdf5_1.8_gcc10.patch', when='@:1.8.21',
           sha256='0e20187cda3980a4fdff410da92358b63de7ebef2df1d7a425371af78e50f666')
 
+    # Libtool fails to recognize NAG compiler behind the MPI wrappers and apply
+    # correct linker flags enabling shared libraries. # We support only versions
+    # based on Libtool 2.4.6.
+    patch('nag.mpi.libtool.patch', when='@1.8.18:%nag+fortran+mpi+shared')
+
     # The argument 'buf_size' of the C function 'h5fget_file_image_c' is
     # declared as intent(in) though it is modified by the invocation. As a
     # result, aggressive compilers such as Fujitsu's may do a wrong


### PR DESCRIPTION
We will switch to CMake someday (#18937). Until then, this enables building when `%nag+fortran+mpi+shared`.