### PR TITLE
Fix intersection if a version is a prefix of another

### DIFF
--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -373,6 +373,9 @@ def test_intersect_with_containment():
     check_intersection('1.6:1.6.5', ':1.6.5', '1.6')
     check_intersection('1.6:1.6.5', '1.6', ':1.6.5')
 
+    check_intersection('11.2', '11', '11.2')
+    check_intersection('11.2', '11.2', '11')
+
 
 def test_union_with_containment():
     check_union(':1.6', '1.6.5', ':1.6')

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -372,7 +372,7 @@ class Version(object):
 
     @coerced
     def intersection(self, other):
-        if self in other: # also covers `self == other`
+        if self in other:  # also covers `self == other`
             return self
         elif other in self:
             return other

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -372,8 +372,10 @@ class Version(object):
 
     @coerced
     def intersection(self, other):
-        if self == other:
+        if self in other: # also covers `self == other`
             return self
+        elif other in self:
+            return other
         else:
             return VersionList()
 


### PR DESCRIPTION
Intersection of versions currently seems broken for cases where one version is a prefix of another:

```bash
$ spack python
Spack version 0.16.1
Python 3.9.2, Linux x86_64
>>> from spack.version import ver
>>> ver("11.2").satisfies(ver("11"))
True
>>> ver("11").satisfies(ver("11.2"))
False
>>> ver("11.2") in ver("11")
True
>>> ver("11") in ver("11.2")
False
>>> ver("11").overlaps(ver("11.2"))
True
>>> ver("11.2").overlaps(ver("11"))
True
>>> ver("11").intersection(ver("11.2"))
[]
>>> ver("11.2").intersection(ver("11"))
[]
>>> exit()
```

Even though, '11' and '11.2' overlap, they don't intersect. Also, while '11.2' satisfies '11', they don't intersect.