### PR TITLE
Current SIRIUS and SpFFT versions need ROCm < 4.1

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -115,6 +115,9 @@ class Sirius(CMakePackage, CudaPackage):
     depends_on('hsa-rocr-dev', when='+rocm', type='link')
     depends_on('rocblas', when='+rocm')
 
+    # FindHIP cmake script only works for < 4.1
+    depends_on('hip@:4.0', when='@:7.2.0 +rocm')
+
     extends('python', when='+python')
 
     conflicts('+shared', when='@6.3.0:6.4.999')

--- a/var/spack/repos/builtin/packages/spfft/package.py
+++ b/var/spack/repos/builtin/packages/spfft/package.py
@@ -55,6 +55,9 @@ class Spfft(CMakePackage, CudaPackage):
 
     depends_on('cuda@:10', when='@:0.9.11 +cuda')
 
+    # FindHIP cmake script only works for < 4.1
+    depends_on('hip@:4.0', when='@:1.0.1 +rocm')
+
     def cmake_args(self):
         spec = self.spec
         args = [


### PR DESCRIPTION
FindHIP.cmake script is not working for both 4.0 and 4.1.

It's fixed in their develop branches
