### PR TITLE
berkeley-db: making +cxx and +stl default to True

### DIFF
--- a/var/spack/repos/builtin/packages/berkeley-db/package.py
+++ b/var/spack/repos/builtin/packages/berkeley-db/package.py
@@ -19,8 +19,8 @@ class BerkeleyDb(AutotoolsPackage):
     version('5.3.28', sha256='e0a992d740709892e81f9d93f06daf305cf73fb81b545afe72478043172c3628')
 
     variant('docs', default=False)
-    variant('cxx', default=False, description='Build with C++ API')
-    variant('stl', default=False, description='Build with C++ STL API')
+    variant('cxx', default=True, description='Build with C++ API')
+    variant('stl', default=True, description='Build with C++ STL API')
 
     configure_directory = 'dist'
     build_directory = 'build_unix'


### PR DESCRIPTION
This PR makes the +cxx and +stl variants in the berkeley-db package default to True.
See discussion here https://github.com/spack/spack/pull/22899 for the reason behind this change.