### PR TITLE
update package: genemark-et

### DIFF
--- a/var/spack/repos/builtin/packages/genemark-et/package.py
+++ b/var/spack/repos/builtin/packages/genemark-et/package.py
@@ -20,17 +20,24 @@ class GenemarkEt(Package):
     homepage = "http://topaz.gatech.edu/GeneMark"
     manual_download = True
 
+    version('4.65', sha256='62ea2dfa1954ab25edcc118dbeaeacf15924274fb9ed47bc54716cfd15ad04fe')
     version('4.46', sha256='856b0b6c7cbd12835e140ff04ecd9124376348efd65f76bfd8b8e08c1834eac0')
     version('4.38', sha256='cee3bd73d331be44159eac15469560d0b07ffa2c98ac764c37219e1f3b7d3146')
 
     depends_on('perl', type=('build', 'run'))
     depends_on('perl-yaml', type=('build', 'run'))
     depends_on('perl-hash-merge', type=('build', 'run'))
-    depends_on('perl-logger-simple', type=('build', 'run'))
     depends_on('perl-parallel-forkmanager', type=('build', 'run'))
+    depends_on('perl-logger-simple', when='@:4.46', type=('build', 'run'))
+    depends_on('perl-mce', when='@4.65:', type=('build', 'run'))
+    depends_on('perl-thread-queue', when='@4.65:', type=('build', 'run'))
+    depends_on('perl-threads', when='@4.65:', type=('build', 'run'))
 
     def url_for_version(self, version):
-        return "file://{0}/gm_et_linux_64.tar.gz".format(os.getcwd())
+        if version >= Version('4.65'):
+            return "file://{0}/gmes_linux_64.tar.gz".format(os.getcwd())
+        else:
+            return "file://{0}/gm_et_linux_64.tar.gz".format(os.getcwd())
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/perl-mce/package.py
+++ b/var/spack/repos/builtin/packages/perl-mce/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PerlMce(PerlPackage):
+    """MCE - Many-Core Engine for Perl providing parallel processing
+    capabilities.
+
+    MCE spawns a pool of workers and therefore does not fork a new process per
+    each element of data. Instead, MCE follows a bank queuing model. Imagine
+    the line being the data and bank-tellers the parallel workers. MCE enhances
+    that model by adding the ability to chunk the next n elements from the
+    input stream to the next available worker."""
+
+    homepage = "https://github.com/marioroy/mce-perl"
+    url      = "https://cpan.metacpan.org/authors/id/M/MA/MARIOROY/MCE-1.874.tar.gz"
+
+    version('1.874', sha256='d809e3018475115ad7eccb8bef49bde3bf3e75abbbcd80564728bbcfab86d3d0')

--- a/var/spack/repos/builtin/packages/perl-thread-queue/package.py
+++ b/var/spack/repos/builtin/packages/perl-thread-queue/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PerlThreadQueue(PerlPackage):
+    """Thread::Queue - Thread-safe queues.
+
+    This module provides thread-safe FIFO queues that can be accessed safely by
+    any number of threads."""
+
+    homepage = "https://metacpan.org/pod/Thread::Queue"
+    url      = "https://cpan.metacpan.org/authors/id/J/JD/JDHEDDEN/Thread-Queue-3.13.tar.gz"
+
+    version('3.13', sha256='6ba3dacddd2fbb66822b4aa1d11a0a5273cd04c825cb3ff31c20d7037cbfdce8')

--- a/var/spack/repos/builtin/packages/perl-threads/package.py
+++ b/var/spack/repos/builtin/packages/perl-threads/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PerlThreads(PerlPackage):
+    """threads - Perl interpreter-based threads"""
+
+    homepage = "https://metacpan.org/pod/threads"
+    url      = "https://cpan.metacpan.org/authors/id/J/JD/JDHEDDEN/threads-2.21.tar.gz"
+
+    version('2.21', sha256='28394c98a2bcae6f20ffb8a3d965a1c194b764c650169e2050ee38dbaa10f110')


### PR DESCRIPTION
- add version 4.65
- add new perl dependencies
  - perl-mce
  - perl-threads
  - perl-thread-queue