### PR TITLE
fix building suite-sparse with CUDA-11

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/fix_cuda11.patch
+++ b/var/spack/repos/builtin/packages/suite-sparse/fix_cuda11.patch
@@ -1,0 +1,10 @@
+--- spack-src.orig/SuiteSparse_config/SuiteSparse_config.mk	2021-03-03 22:04:33.000000000 +0000
++++ spack-src/SuiteSparse_config/SuiteSparse_config.mk	2021-04-13 16:21:57.426166357 +0000
+@@ -259,7 +259,6 @@
+                 MAGMA_LIB     = -L/opt/magma-2.4.0/lib/ -lmagma
+         NVCC          = $(CUDA_PATH)/bin/nvcc
+         NVCCFLAGS     = -Xcompiler -fPIC -O3 \
+-                            -gencode=arch=compute_30,code=sm_30 \
+                             -gencode=arch=compute_35,code=sm_35 \
+                             -gencode=arch=compute_50,code=sm_50 \
+                             -gencode=arch=compute_53,code=sm_53 \

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -60,6 +60,11 @@ class SuiteSparse(Package):
     # Fixes 'libgraphblas.so.2.0.1: undefined reference to `__fpclassify''
     patch('graphblas_libm_dep.patch', when='@5.2.0:5.2.99%clang')
 
+    # CUDA-11 dropped sm_30 code generation, remove hardcoded sm_30 from makefile
+    # open issue: https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/56
+    # Tested only with 5.9.0, previous versions probably work too
+    patch('fix_cuda11.patch', when='@5.9.0:+cuda ^cuda@11:')
+
     conflicts('%gcc@:4.8', when='@5.2.0:', msg='gcc version must be at least 4.9 for suite-sparse@5.2.0:')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
I tested building suite-sparse@5.9.0. I do not expect problems with older versions, but I did not test it, that is why I did not include older versions for patching, but feel free to add also older versions