### PR TITLE
gdrcopy: install prefix needs lowercase for 2.2 upward

### DIFF
--- a/var/spack/repos/builtin/packages/gdrcopy/package.py
+++ b/var/spack/repos/builtin/packages/gdrcopy/package.py
@@ -26,4 +26,9 @@ class Gdrcopy(MakefilePackage):
     def install(self, spec, prefix):
         mkdir(prefix.include)
         mkdir(prefix.lib64)
-        make('lib_install', 'PREFIX={0}'.format(self.prefix))
+        if spec.satisfies('@2.2:'):
+            make('lib_install',
+                 'prefix={0}'.format(self.prefix))
+        else:
+            make('lib_install',
+                 'PREFIX={0}'.format(self.prefix))


### PR DESCRIPTION
fixes #22865