### PR TITLE
Depend on binutils with ld and plugins in GCC

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -126,7 +126,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('diffutils', type='build')
     depends_on('iconv', when='platform=darwin')
     depends_on('gnat', when='languages=ada')
-    depends_on('binutils~libiberty', when='+binutils', type=('build', 'link', 'run'))
+    depends_on('binutils+ld+plugins~libiberty', when='+binutils', type=('build', 'link', 'run'))
     depends_on('zip', type='build', when='languages=java')
     depends_on('cuda@:10', when='+nvptx')
 


### PR DESCRIPTION
Ping @michaelkuhn, I haven't rebuild gcc nor tested ld, but pressumably gcc needs ld with plugin support like llvm.

Note that the default variant has always been binutils~ld but ld was built nonetheless, see https://github.com/spack/spack/pull/22959
