### PR TITLE
Bump spack's binary deps

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -15,6 +15,7 @@ class Curl(AutotoolsPackage):
     # URL must remain http:// so Spack can bootstrap curl
     url      = "http://curl.haxx.se/download/curl-7.74.0.tar.bz2"
 
+    version('7.76.1', sha256='7a8e184d7d31312c4ebf6a8cb59cd757e61b2b2833a9ed4f9bf708066e7695e9')
     version('7.76.0', sha256='e29bfe3633701590d75b0071bbb649ee5ca4ca73f00649268bd389639531c49a')
     version('7.75.0', sha256='50552d4501c178e4cc68baaecc487f466a3d6d19bbf4e50a01869effb316d026')
     version('7.74.0', sha256='0f4d63e6681636539dc88fa8e929f934cd3a840c46e0bf28c73be11e521b77a5')

--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -13,12 +13,13 @@ class Expat(AutotoolsPackage):
     homepage = "https://libexpat.github.io/"
     url      = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
+    version('2.3.0', sha256='f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586')
     version('2.2.10', sha256='b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5')
     version('2.2.9', sha256='f1063084dc4302a427dabcca499c8312b3a32a29b7d2506653ecc8f950a9a237')
-    version('2.2.6', sha256='17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2')
-    version('2.2.5', sha256='d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6')
-    version('2.2.2', sha256='4376911fcf81a23ebd821bbabc26fd933f3ac74833f74924342c29aad2c86046')
-    version('2.2.0', sha256='d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff')
+    version('2.2.6', sha256='17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2', deprecated=True)
+    version('2.2.5', sha256='d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6', deprecated=True)
+    version('2.2.2', sha256='4376911fcf81a23ebd821bbabc26fd933f3ac74833f74924342c29aad2c86046', deprecated=True)
+    version('2.2.0', sha256='d9e50ff2d19b3538bd2127902a89987474e1a4db8e43a66a4d1a712ab9a504ff', deprecated=True)
 
     # Version 2.2.2 introduced a requirement for a high quality
     # entropy source.  "Older" linux systems (aka CentOS 7) do not

--- a/var/spack/repos/builtin/packages/file/package.py
+++ b/var/spack/repos/builtin/packages/file/package.py
@@ -12,4 +12,7 @@ class File(AutotoolsPackage):
     homepage = "http://www.darwinsys.com/file/"
     url      = "https://astron.com/pub/file/file-5.37.tar.gz"
 
+    version('5.40', sha256='167321f43c148a553f68a0ea7f579821ef3b11c27b8cbe158e4df897e4a5dd57')
+    version('5.39', sha256='f05d286a76d9556243d0cb05814929c2ecf3a5ba07963f8f70bfaaa70517fad1')
+    version('5.38', sha256='593c2ffc2ab349c5aea0f55fedfe4d681737b6b62376a9b3ad1e77b2cc19fa34')
     version('5.37', sha256='e9c13967f7dd339a3c241b7710ba093560b9a33013491318e88e6b8b57bae07f')

--- a/var/spack/repos/builtin/packages/libbsd/package.py
+++ b/var/spack/repos/builtin/packages/libbsd/package.py
@@ -19,6 +19,10 @@ class Libbsd(AutotoolsPackage):
         "https://mirrors.dotsrc.org/pub/mirrors/exherbo/libbsd-0.9.1.tar.xz"
     ]
 
+    version('0.11.3', sha256='ff95cf8184151dacae4247832f8d4ea8800fa127dbd15033ecfe839f285b42a1')
+    version('0.11.2', sha256='9a7fbe60924d40ce4322a00b6f70be07b3704479b2bca1210dd1564924930ff5')
+    version('0.11.1', sha256='0d018e78f85d7d724740a28408f0bf346b7bbe5dc1c7256fb21e640e2a3d5205')
+    version('0.11.0', sha256='9043e24f5898eae6e0ce97bea4f2d15197e90f6e9b91d0c6a8d10fb1405fd562')
     version('0.10.0', sha256='34b8adc726883d0e85b3118fa13605e179a62b31ba51f676136ecb2d0bc1a887')
     version('0.9.1', sha256='56d835742327d69faccd16955a60b6dcf30684a8da518c4eca0ac713b9e0a7a4')
     version('0.9.0', sha256='8a469afd1bab340992cf99e1e6b7ae4f4c54882d663d8a2c5ea52250617afb01')

--- a/var/spack/repos/builtin/packages/libbsd/package.py
+++ b/var/spack/repos/builtin/packages/libbsd/package.py
@@ -36,6 +36,8 @@ class Libbsd(AutotoolsPackage):
     # https://gitlab.freedesktop.org/libbsd/libbsd/issues/1
     conflicts('platform=darwin')
 
+    depends_on('libmd', when='@0.11:')
+
     def patch(self):
         # Remove flags not recognized by the NVIDIA compiler
         if self.spec.satisfies('%pgi') or self.spec.satisfies('%nvhpc'):

--- a/var/spack/repos/builtin/packages/libmd/package.py
+++ b/var/spack/repos/builtin/packages/libmd/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libmd(AutotoolsPackage):
+    """This library provides message digest functions found on BSD systems
+       either on their libc (NetBSD, OpenBSD) or libmd (FreeBSD, DragonflyBSD,
+       macOS, Solaris) libraries and lacking on others like GNU systems."""
+
+    homepage = "https://www.hadrons.org/software/libmd/"
+    url      = "https://archive.hadrons.org/software/libmd/libmd-1.0.3.tar.xz"
+
+    maintainers = ['haampie']
+
+    version('1.0.3', sha256='5a02097f95cc250a3f1001865e4dbba5f1d15554120f95693c0541923c52af4a')
+    version('1.0.2', sha256='dc66b8278f82e7e1bf774fbd4bc83a0348e8f27afa185b2c2779cfcb3da25013')
+    version('1.0.1', sha256='e14eeb931cf85330f95ff822262d3033125488dfb2f867441e36e2d2c4a34c71')
+    version('1.0.0', sha256='f21aea69f6411cb4307cda1f6378c7ed07830202b5f4cb9e64f681fdaf2d64c7')

--- a/var/spack/repos/builtin/packages/pcre2/package.py
+++ b/var/spack/repos/builtin/packages/pcre2/package.py
@@ -14,6 +14,7 @@ class Pcre2(AutotoolsPackage):
     homepage = "http://www.pcre.org"
     url      = "https://ftp.pcre.org/pub/pcre/pcre2-10.31.tar.bz2"
 
+    version('10.36', sha256='a9ef39278113542968c7c73a31cfcb81aca1faa64690f400b907e8ab6b4a665c')
     version('10.35', sha256='9ccba8e02b0ce78046cdfb52e5c177f0f445e421059e43becca4359c669d4613')
     version('10.31', sha256='e07d538704aa65e477b6a392b32ff9fc5edf75ab9a40ddfc876186c4ff4d68ac')
     version('10.20', sha256='332e287101c9e9567d1ed55391b338b32f1f72c5b5ee7cc81ef2274a53ad487a')

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -13,6 +13,7 @@ class Sqlite(AutotoolsPackage):
     """
     homepage = "https://www.sqlite.org"
 
+    version('3.35.4', sha256='7771525dff0185bfe9638ccce23faa0e1451757ddbda5a6c853bb80b923a512d')
     version('3.35.3', sha256='ecbccdd440bdf32c0e1bb3611d635239e3b5af268248d130d0445a32daf0274b')
     version('3.34.0', sha256='bf6db7fae37d51754737747aaaf413b4d6b3b5fbacd52bdb2d0d6e5b2edd9aee')
     version('3.33.0', sha256='106a2c48c7f75a298a7557bcc0d5f4f454e5b43811cc738b7ca294d6956bbb15')


### PR DESCRIPTION
- Bump curl
- Bump expat and mark deprecated versions deprecated
- Bump file
- Bump libbsd
- Bump pcre2
- Bump sqlite
