### PR TITLE
m4: Apply macOS patch also on Big Sur

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -24,6 +24,7 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     patch('secure_snprintf.patch', when='os = highsierra')
     patch('secure_snprintf.patch', when='os = mojave')
     patch('secure_snprintf.patch', when='os = catalina')
+    patch('secure_snprintf.patch', when='os = bigsur')
     # https://bugzilla.redhat.com/show_bug.cgi?id=1573342
     patch('https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch', sha256='fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8', when='@1.4.18')
 


### PR DESCRIPTION
Without this patch, `m4` aborts on startup, as for the previous macOS releases.