### PR TITLE
cgal: fix concretization

### DIFF
--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -31,7 +31,7 @@ class Cgal(CMakePackage):
     variant('build_type', default='Release',
             description='The build type to build',
             values=('Debug', 'Release'))
-    variant('header-only', default=False,
+    variant('header_only', default=False,
             description='Install in header only mode')
 
     # ---- See "7 CGAL Libraries" at:


### PR DESCRIPTION
Fixes #22997 @Nandinihpc

### Before

```console
$ spack spec cgal
Input spec
--------------------------------
cgal

Concretized
--------------------------------
==> Error: variant "header_only" not found in package "cgal" [required from package "cgal"]
```

### After

Successful concretization with the new concretizer.