### PR TITLE
hack for paraview clingo issue

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -51,9 +51,12 @@ class Paraview(CMakePackage, CudaPackage):
             description='Builds a shared version of the library')
     variant('kits', default=True,
             description='Use module kits')
+
+    legacy_cuda_values=['native', 'fermi', 'kepler', 'maxwell',
+                        'pascal', 'volta', 'turing', 'all', 'none']
+    cuda_values = legacy_cuda_values.extend(CudaPackage.cuda_arch_values)
     variant('cuda_arch', default='native', multi=False,
-            values=('native', 'fermi', 'kepler', 'maxwell',
-                    'pascal', 'volta', 'turing', 'all', 'none'),
+            values=cuda_values,
             description='CUDA architecture')
 
     conflicts('+python', when='+python3')


### PR DESCRIPTION
This is a hack to deal with the legacy cuda families for `paraview` as noted in #22970.  I haven't tested this on a cuda build, but it at least allows clingo to concretize.

I imagine we will need to add in some of the logic like vtk-m to get this to work.  Ideally it would be nice to just drop this cuda family stuff in `paraview` and move to the gencode like the vast majority of other packages. Looking at `vtk-m` it seems that they use the gencode for defining the variant and then use a map to fulfill their own cmake args.  It would be nice if `paraview` would pursue the same model (assuming it's the same requirement), but I'm not sure how much of a burden that would be on the users. 

To support both the quickest thing I could think of was to append the list of values. I guess we could also do an inverse of the  map `vtk-m` has and then change the spec value for the `cuda_arch` variant.