### PR TITLE
Follow symlinks during external find

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -74,7 +74,7 @@ def _get_system_executables():
     # entry overrides later entries
     for search_path in reversed(search_paths):
         for exe in os.listdir(search_path):
-            exe_path = os.path.join(search_path, exe)
+            exe_path = os.path.realpath(os.path.join(search_path, exe))
             if is_executable(exe_path):
                 path_to_exe[exe_path] = exe
     return path_to_exe

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -74,7 +74,7 @@ def _get_system_executables():
     # entry overrides later entries
     for search_path in reversed(search_paths):
         for exe in os.listdir(search_path):
-            exe_path = os.path.realpath(os.path.join(search_path, exe))
+            exe_path = os.path.join(search_path, exe)
             if is_executable(exe_path):
                 path_to_exe[exe_path] = exe
     return path_to_exe
@@ -189,8 +189,11 @@ def external_find(args):
 
 
 def _group_by_prefix(paths):
+    """Group a list of executables by prefix, canonicalizing symlinks."""
     groups = defaultdict(set)
     for p in paths:
+        # Canonicalize symlinks
+        p = os.path.realpath(p)
         groups[os.path.dirname(p)].add(p)
     return groups.items()
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -80,20 +80,20 @@ def test_get_executables(working_env, mock_executable):
     assert path_to_exe[cmake_path1] == 'cmake'
 
 
-def test_get_executables_follows_symlink(working_env, mock_executable, tmpdir):
+def test_group_by_prefix_follows_symlinks(mock_executable, tmpdir):
     """Test whether symlinks to executables are followed when collecting"""
-    cmake_path = mock_executable("cmake", output="echo cmake version 1.foo")
+    cmake = mock_executable("cmake", output="echo cmake version 1.foo")
+    cmake_dir = os.path.dirname(cmake)
 
     # Create a symlink to cmake in a different directory
     symlink_dir = tmpdir.join("other_path")
-    symlink = symlink_dir.join("cmake")
+    symlink = str(symlink_dir.join("cmake"))
     mkdirp(str(symlink_dir))
-    os.symlink(cmake_path, str(symlink))
-    os.environ['PATH'] = str(symlink_dir)
-    path_to_exe = spack.cmd.external._get_system_executables()
+    os.symlink(cmake, symlink)
 
-    # Make sure the path is the realpath, not the dirname of the symlink
-    assert path_to_exe[cmake_path] == 'cmake'
+    # Test whether the cmake executable is found instead of the symlink
+    path_to_exe = spack.cmd.external._group_by_prefix([symlink])
+    assert (cmake_dir, {cmake}) in path_to_exe
 
 
 external = SpackCommand('external')

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -85,12 +85,11 @@ def test_get_executables_follows_symlink(working_env, mock_executable, tmpdir):
     cmake_path = mock_executable("cmake", output="echo cmake version 1.foo")
 
     # Create a symlink to cmake in a different directory
-    symlink_dir = str(os.path.join(tmpdir, "other_path"))
-    symlink = str(os.path.join(symlink_dir, "cmake"))
-    mkdirp(symlink_dir)
-    os.symlink(cmake_path, symlink)
-
-    os.environ['PATH'] = symlink_dir
+    symlink_dir = tmpdir.join("other_path")
+    symlink = symlink_dir.join("cmake")
+    mkdirp(str(symlink_dir))
+    os.symlink(cmake_path, str(symlink))
+    os.environ['PATH'] = str(symlink_dir)
     path_to_exe = spack.cmd.external._get_system_executables()
 
     # Make sure the path is the realpath, not the dirname of the symlink

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -85,11 +85,12 @@ def test_get_executables_follows_symlink(working_env, mock_executable, tmpdir):
     cmake_path = mock_executable("cmake", output="echo cmake version 1.foo")
 
     # Create a symlink to cmake in a different directory
-    symlink_path = os.path.join(tmpdir, "other_path")
-    mkdirp(symlink_path)
-    os.symlink(cmake_path, os.path.join(symlink_path, "cmake"))
+    symlink_dir = str(os.path.join(tmpdir, "other_path"))
+    symlink = str(os.path.join(symlink_dir, "cmake"))
+    mkdirp(symlink_dir)
+    os.symlink(cmake_path, symlink)
 
-    os.environ['PATH'] = symlink_path
+    os.environ['PATH'] = symlink_dir
     path_to_exe = spack.cmd.external._get_system_executables()
 
     # Make sure the path is the realpath, not the dirname of the symlink

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -93,7 +93,7 @@ def test_group_by_prefix_follows_symlinks(mock_executable, tmpdir):
 
     # Test whether the cmake executable is found instead of the symlink
     path_to_exe = spack.cmd.external._group_by_prefix([symlink])
-    assert (cmake_dir, {cmake}) in path_to_exe
+    assert (cmake_dir, set([cmake])) in path_to_exe
 
 
 external = SpackCommand('external')


### PR DESCRIPTION
This supports the use case where you have some sort of a view (like /usr/local/bin or /opt/rocm/bin or spack environment installs) which contain just symlinks, and you run spack external find with the bin folder in your PATH -- you don't want to have all the unrelated libs as part of your prefix, you just want /actual/path/to/specific/package/prefix to be your prefix.

Closes #23007
Closes #24452 
Closes #24418