### PR TITLE
Spec parsing fix

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import posixpath
 import shutil
 import glob
 import tempfile
@@ -20,7 +21,7 @@ import spack.spec
 from spack.error import SpackError
 
 
-default_projections = {'all': os.path.join(
+default_projections = {'all': posixpath.join(
     '{architecture}', '{compiler.name}-{compiler.version}',
     '{name}-{version}-{hash}')}
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os.path
-
+import posixpath
 import llnl.util.lang as lang
 import itertools
 import collections
@@ -93,7 +93,7 @@ def guess_core_compilers(store=False):
 
 class LmodConfiguration(BaseConfiguration):
     """Configuration class for lmod module files."""
-    default_projections = {'all': os.path.join('{name}', '{version}')}
+    default_projections = {'all': posixpath.join('{name}', '{version}')}
 
     @property
     def core_compilers(self):


### PR DESCRIPTION
Fix to windows spec parsing - specs may only be written in posix path style.