### PR TITLE
symlink and build-environment style changes

### DIFF
--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -101,4 +101,4 @@ def _cmd(command):
     proc = make_proc()
     (out, err) = proc.communicate()
     if proc.wait() != 0:
-        raise OSError(str(info))
+        raise OSError(str(err))

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -817,7 +817,8 @@ def setup_package(pkg, dirty, context='build'):
         # kludge to handle cray libsci being automatically loaded by PrgEnv
         # modules on cray platform. Module unload does no damage when
         # unnecessary
-        # module('unload', 'cray-libsci')
+        if sys.platform != 'win32':
+            module('unload', 'cray-libsci')
 
         if pkg.architecture.target.module_name:
             load_module(pkg.architecture.target.module_name)


### PR DESCRIPTION
Issues found by spack style:
-symlink 104: undefined 'info'
-build_environment 71: import unused 'module' 