### PR TITLE
fix openjdk build error: Prefix import was missing

### DIFF
--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -7,6 +7,7 @@ import os
 import platform
 import re
 
+from spack.util.prefix import Prefix
 
 # If you need to add a new version, please be aware that:
 #  - versions in the following dict are automatically added to the package


### PR DESCRIPTION
fixes #23013