### PR TITLE
Adding a retry decorator

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -62,7 +62,7 @@ class Lock(object):
         always ``os.SEEK_SET`` and ``start`` is always evaluated from the
         beginning of the file.
 
-        Args:
+        Arguments:
             path (str): path to the lock
             start (int): optional byte offset at which the lock starts
             length (int): optional number of bytes to lock

--- a/lib/spack/llnl/util/retry.py
+++ b/lib/spack/llnl/util/retry.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Retry decorators for web requests
+"""
+
+import time
+import llnl.util.tty as tty
+
+
+def retry(function):
+    """
+    Retry decorator with Exponential backoff.
+    """
+    def retry_function(*args, **kwargs):
+        attempts = 4
+        delay = 2
+        while attempts:
+            try:
+                return function(*args, **kwargs)
+            except Exception as e:
+                tty.info("%s, retrying in %s seconds" % (str(e), delay))
+                time.sleep(delay)
+                attempts -= 1
+                delay *= 2
+        return function(*args, **kwargs)
+    return retry_function

--- a/lib/spack/spack/monitor.py
+++ b/lib/spack/spack/monitor.py
@@ -24,6 +24,7 @@ import spack.store
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
 import llnl.util.tty as tty
+import llnl.util.retry
 from copy import deepcopy
 
 
@@ -231,6 +232,7 @@ class SpackMonitorClient:
 
         return response
 
+    @llnl.util.retry.retry
     def do_request(self, endpoint, data=None, headers=None, url=None):
         """Do a request. If data is provided, it is POST, otherwise GET.
         If an entire URL is provided, don't use the endpoint

--- a/lib/spack/spack/test/util/retry.py
+++ b/lib/spack/spack/test/util/retry.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Wrapper for ``llnl.util.retry``"""
+
+import pytest
+import llnl.util.retry
+
+try:
+    import urllib.request as urllib
+except ImportError:
+    import urllib2 as urllib  # type: ignore  # novm
+
+
+# keep track of how many retries done
+count = 0
+
+
+class MockFailureResponse(object):
+
+    def __init__(self):
+        global count
+        count += 1
+        raise Exception("This is a mocked failure.")
+
+
+def test_retry(monkeypatch):
+    """Test that retry works as expected
+    """
+    global count
+
+    def mock_fail(*args, **kwargs):
+        return MockFailureResponse()
+
+    # apply the monkeypatch for urlopen to mock_fail
+    monkeypatch.setattr(urllib, "urlopen", mock_fail)
+    request = urllib.Request("https://google.com")
+
+    # This first request must fail
+    with pytest.raises(Exception):
+        urllib.urlopen(request)
+
+    # Now do function with retry
+    @llnl.util.retry.retry
+    def mock_fail(*args, **kwargs):
+        return MockFailureResponse()
+
+    count = 0
+    monkeypatch.setattr(urllib, "urlopen", mock_fail)
+    with pytest.raises(Exception):
+        urllib.urlopen(request)
+
+    assert count == 5


### PR DESCRIPTION
this adds a simply llnl util, a retry decorator for spack monitor (and any other future requests) to use to ensure we have exponential
backoff for requests. Servers can be flaky and retrying is generally good practice.

@trws you should be able to test this out with spack monitor!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>