### PR TITLE
er: new release

### DIFF
--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -10,16 +10,18 @@ class Er(CMakePackage):
     """Encoding and redundancy on a file set"""
 
     homepage = "https://github.com/ecp-veloc/er"
-    url      = "https://github.com/ecp-veloc/er/archive/v0.0.3.zip"
+    url      = "https://github.com/ecp-veloc/er/archive/v0.0.3.tar.gz"
     git      = "https://github.com/ecp-veloc/er.git"
 
     tags = ['ecp']
 
     version('master', branch='master')
-    version('0.0.3', sha256='9aa08f9fe70e42f0da27a5d90d4643b520d61f24742303bf016322823b3c4d26')
+    version('0.0.4', sha256='c456d34719bb57774adf6d7bc2fa9917ecb4a9de442091023c931a2cb83dfd37')
+    version('0.0.3', sha256='243b2b46ea274e17417ef5873c3ed7ba16dacdfdaf7053d1de5434e300de796b')
 
     depends_on('mpi')
-    depends_on('kvtree')
+    depends_on('kvtree+mpi')
+    depends_on('rankstr', when='@0.0.4:')
     depends_on('redset')
     depends_on('shuffile')
 
@@ -29,6 +31,7 @@ class Er(CMakePackage):
         if self.spec.satisfies('platform=cray'):
             args.append("-DER_LINK_STATIC=ON")
         args.append("-DWITH_KVTREE_PREFIX=%s" % self.spec['kvtree'].prefix)
+        args.append("-DWITH_RANKSTR_PREFIX=%s" % self.spec['rankstr'].prefix)
         args.append("-DWITH_REDSET_PREFIX=%s" % self.spec['redset'].prefix)
         args.append("-DWITH_SHUFFILE_PREFIX=%s" % self.spec['shuffile'].prefix)
         return args

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -26,12 +26,14 @@ class Er(CMakePackage):
     depends_on('shuffile')
 
     def cmake_args(self):
+        spec = self.spec
         args = []
-        args.append("-DMPI_C_COMPILER=%s" % self.spec['mpi'].mpicc)
-        if self.spec.satisfies('platform=cray'):
+        args.append("-DMPI_C_COMPILER=%s" % spec['mpi'].mpicc)
+        if spec.satisfies('platform=cray'):
             args.append("-DER_LINK_STATIC=ON")
-        args.append("-DWITH_KVTREE_PREFIX=%s" % self.spec['kvtree'].prefix)
-        args.append("-DWITH_RANKSTR_PREFIX=%s" % self.spec['rankstr'].prefix)
-        args.append("-DWITH_REDSET_PREFIX=%s" % self.spec['redset'].prefix)
-        args.append("-DWITH_SHUFFILE_PREFIX=%s" % self.spec['shuffile'].prefix)
+        args.append("-DWITH_KVTREE_PREFIX=%s" % spec['kvtree'].prefix)
+        args.append("-DWITH_REDSET_PREFIX=%s" % spec['redset'].prefix)
+        args.append("-DWITH_SHUFFILE_PREFIX=%s" % spec['shuffile'].prefix)
+        if spec.satisfies('@0.0.4:'):
+            args.append("-DWITH_RANKSTR_PREFIX=%s" % spec['rankstr'].prefix)
         return args


### PR DESCRIPTION
er now has a new release, v0.0.4

This adds that new version to the package, updates the url, and updates the hash of v0.0.3 for the new url.

This also updates the KVTree dependency as MPI is required to be enabled in KVTree for er to work.
rankstr is now also required by er for recently added tests.