### PR TITLE
[acts] Add version 7

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -37,6 +37,7 @@ class Acts(CMakePackage, CudaPackage):
 
     # Supported Acts versions
     version('master', branch='master')
+    version('7.00.0', commit='e663df7ab023bdb5ef206202efc2e54ccb71d416')
     version('6.00.0', commit='a5cf04acd4b1a2c625e0826189109472a3392558')
     version('5.00.0', commit='df77b91a7d37b8db6ed028a4d737014b5ad86bb7')
     version('4.01.0', commit='c383bf434ef69939b47e840e0eac0ba632e6af9f')


### PR DESCRIPTION
This adds support for [ACTS v7](https://github.com/acts-project/acts/releases/tag/v7.0.0) ~~(pending a test build on my side).~~