### PR TITLE
add maintainers to legacy intel product packages

### DIFF
--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -11,6 +11,8 @@ class IntelParallelStudio(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
 
+    maintainers = ['rscohn2', 'danvev']
+
     # As of 2016, the product comes in three "editions" that vary by scope.
     #
     # In Spack, select the edition via the version number in the spec, e.g.:

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -12,6 +12,8 @@ class Intel(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
 
+    maintainers = ['rscohn2', 'danvev']
+
     # Same as in ../intel-parallel-studio/package.py, Composer Edition,
     # but the version numbering in Spack differs.
     version('20.0.4',              sha256='ac1efeff608a8c3a416e6dfe20364061e8abf62d35fbaacdffe3fc9676fc1aa3', url='http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17117/parallel_studio_xe_2020_update4_composer_edition.tgz')


### PR DESCRIPTION
Adding @DanVev and me since there are no maintainers. If someone else wants that role, please volunteer.

@DanVev and I were not involved in writing or maintenance of the parallel studio packages. There will not be any more product updates so they probably won't need any maintenance.