### PR TITLE
Fix #23029 (ROOT 6.20.00 pyroot build failure)

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -430,7 +430,7 @@ class Root(CMakePackage):
         ]
 
         # Some special features
-        if self.spec.satisfies('@6.20:'):
+        if self.spec.satisfies('@6.20.02:'):
             options.append(define_from_variant('pyroot', 'python'))
         else:
             options.append(define_from_variant('python'))


### PR DESCRIPTION
Fix version numbers for ROOT CMake build option "python" -> "pyroot".