### PR TITLE
Module template format for windows

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -436,7 +436,7 @@ class LmodContext(BaseContext):
 
 class LmodModulefileWriter(BaseModuleFileWriter):
     """Writer class for lmod module files."""
-    default_template = os.path.join('modules', 'modulefile.lua')
+    default_template = posixpath.join('modules', 'modulefile.lua')
 
 
 class CoreCompilersNotFoundError(spack.error.SpackError, KeyError):

--- a/lib/spack/spack/modules/tcl.py
+++ b/lib/spack/spack/modules/tcl.py
@@ -6,8 +6,8 @@
 """This module implements the classes necessary to generate TCL
 non-hierarchical modules.
 """
-import os.path
 import string
+import posixpath
 from typing import Dict, Any  # novm
 
 import llnl.util.tty as tty
@@ -100,4 +100,4 @@ class TclContext(BaseContext):
 
 class TclModulefileWriter(BaseModuleFileWriter):
     """Writer class for tcl module files."""
-    default_template = os.path.join('modules', 'modulefile.tcl')
+    default_template = posixpath.join('modules', 'modulefile.tcl')


### PR DESCRIPTION
fixes install error "Warning: cannot perform the requested write operation on module files [template 'modules\modulefile.tcl' was not found for 'TclModulefileWriter']" and ModuleTemplateNotFoundError in modules tests