### PR TITLE
axl: new release and variant updates

### DIFF
--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -4,22 +4,37 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.error import SpackError
+
+
+def async_api_validator(pkg_name, variant_name, values):
+    if 'none' in values and len(values) != 1:
+        raise SpackError("The value 'none' is not usable"
+                         " with other async_api values.")
+    if 'intel_cppr' in values and 'cray_dw' in values:
+        raise SpackError("The 'intel_cppr' and 'cray_dw' asynchronous"
+                         " APIs are incompatible.")
 
 
 class Axl(CMakePackage):
     """Asynchronous transfer library"""
 
     homepage = "https://github.com/ecp-veloc/AXL"
-    url      = "https://github.com/ecp-veloc/AXL/arceive/v0.4.0.tar.gz"
+    url      = "https://github.com/ecp-veloc/AXL/archive/v0.4.0.tar.gz"
     git      = "https://github.com/ecp-veloc/axl.git"
 
     tags = ['ecp']
 
     version('master', branch='master')
     version('0.4.0', sha256='0530142629d77406a00643be32492760c2cf12d1b56c6b6416791c8ff5298db2')
-    version('0.3.0', sha256='3f5efff87be700a5792a0ee9a7aeae45c640e2936623b024e8bc1056f7952a46', deprecated=True)
-    version('0.2.0', sha256='a0babe3576da30919f89df2f83c76bd01d06345919f2e54d4dddcd6f73faedcc', deprecated=True)
-    version('0.1.1', sha256='ebbf231bb542a6c91efb79fce05d4c8a346d5506d88ae1899fb670be52e81933', deprecated=True)
+    version('0.3.0', sha256='737d616b669109805f7aed1858baac36c97bf0016e1115b5c56ded05d792613e', deprecated=True)
+    version('0.2.0', sha256='d04a445f102b438fe96a1ff3429790b0c035f0d23c2797bb5601a00b582a71fc', deprecated=True)
+    version('0.1.1', sha256='36edac007938fe47d979679414c5c27938944d32536e2e149f642916c5c08eaa', deprecated=True)
+
+    variant('async_api', default='daemon',
+            description="Set of async transfer APIs to enable",
+            values=['cray_dw', 'intel_cppr', 'daemon', 'none'], multi=True,
+            validator=async_api_validator)
 
     variant('bbapi_fallback', default='False',
             description='Using BBAPI, if source or destination don\'t support \
@@ -33,9 +48,19 @@ class Axl(CMakePackage):
             args.append("-DAXL_LINK_STATIC=ON")
         args.append("-DWITH_KVTREE_PREFIX=%s" % self.spec['kvtree'].prefix)
 
-        if '+bbapi_fallback' in self.spec:
-            args.append('-DENABLE_BBAPI_FALLBACK=ON')
-        else:
-            args.append('-DENABLE_BBAPI_FALLBACK=OFF')
+        if self.spec.satisfies('@:0.3.0'):
+            apis = list(self.spec.variants['async_api'].value)
+            if 'daemon' in apis:
+                args.append('-DAXL_ASYNC_DAEMON=ON')
+                apis.remove('daemon')
+
+            for api in apis:
+                args.append('-DAXL_ASYNC_API={0}'.format(api.upper()))
+
+        if self.spec.satisfies('@0.4.0:'):
+            if '+bbapi_fallback' in self.spec:
+                args.append('-DENABLE_BBAPI_FALLBACK=ON')
+            else:
+                args.append('-DENABLE_BBAPI_FALLBACK=OFF')
 
         return args

--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -4,40 +4,26 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.error import SpackError
-
-
-def async_api_validator(pkg_name, variant_name, values):
-    if 'none' in values and len(values) != 1:
-        raise SpackError("The value 'none' is not usable"
-                         " with other async_api values.")
-    if 'ibm_bbapi' in values and 'cray_dw' in values:
-        raise SpackError("The 'ibm_bbapi' and 'cray_dw' asynchronous"
-                         " APIs are incompatible.")
 
 
 class Axl(CMakePackage):
     """Asynchronous transfer library"""
 
     homepage = "https://github.com/ecp-veloc/AXL"
-    url      = "https://github.com/ecp-veloc/AXL/archive/v0.1.1.zip"
+    url      = "https://github.com/ecp-veloc/AXL/arceive/v0.4.0.tar.gz"
     git      = "https://github.com/ecp-veloc/axl.git"
 
     tags = ['ecp']
 
     version('master', branch='master')
-    version('0.3.0', sha256='3f5efff87be700a5792a0ee9a7aeae45c640e2936623b024e8bc1056f7952a46')
-    version('0.2.0', sha256='a0babe3576da30919f89df2f83c76bd01d06345919f2e54d4dddcd6f73faedcc')
-    version('0.1.1', sha256='ebbf231bb542a6c91efb79fce05d4c8a346d5506d88ae1899fb670be52e81933')
+    version('0.4.0', sha256='0530142629d77406a00643be32492760c2cf12d1b56c6b6416791c8ff5298db2')
+    version('0.3.0', sha256='3f5efff87be700a5792a0ee9a7aeae45c640e2936623b024e8bc1056f7952a46', deprecated=True)
+    version('0.2.0', sha256='a0babe3576da30919f89df2f83c76bd01d06345919f2e54d4dddcd6f73faedcc', deprecated=True)
+    version('0.1.1', sha256='ebbf231bb542a6c91efb79fce05d4c8a346d5506d88ae1899fb670be52e81933', deprecated=True)
 
-    variant('async_api', default='daemon',
-            description="Set of async transfer APIs to enable",
-            values=['cray_dw', 'ibm_bbapi', 'daemon', 'none'], multi=True,
-            validator=async_api_validator)
-
-    # not-yet implemented functionality
-    conflicts('async_api=cray_dw', when='@0.1.0')
-    conflicts('async_api=ibm_bbapi', when='@0.1.0')
+    variant('bbapi_fallback', default='False',
+            description='Using BBAPI, if source or destination don\'t support \
+            file extents then fallback to pthreads')
 
     depends_on('kvtree')
 
@@ -47,12 +33,9 @@ class Axl(CMakePackage):
             args.append("-DAXL_LINK_STATIC=ON")
         args.append("-DWITH_KVTREE_PREFIX=%s" % self.spec['kvtree'].prefix)
 
-        apis = list(self.spec.variants['async_api'].value)
-        if 'daemon' in apis:
-            args.append('-DAXL_ASYNC_DAEMON=ON')
-            apis.remove('daemon')
-
-        for api in apis:
-            args.append('-DAXL_ASYNC_API={0}'.format(api))
+        if '+bbapi_fallback' in self.spec:
+            args.append('-DENABLE_BBAPI_FALLBACK=ON')
+        else:
+            args.append('-DENABLE_BBAPI_FALLBACK=OFF')
 
         return args


### PR DESCRIPTION
AXL now has a new release, v0.4.0.

This deprecates the older versions as, since AXL has changed a lot since its last release, it was decided to get users onto the new version because support won't be maintained for previous ones. Current users had already been informed to use the main branch up to this point, rather than a previous release.
This allows for dropping the `async_api` variant and related function, as the options it provided are now being removed or
automated and it is now useless in its current state.

Adds a new variant for customizing AXL to error or fallback to an alternate async method when on a system using BBAPI.