### PR TITLE
Add an audit system to Spack

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1734,29 +1734,26 @@ A nicer error message is TBD in future versions of Spack.
 Troubleshooting
 ---------------
 
-When dealing with a large stack of software or with the development of complex
-applications, users may face issues that are very specific to their use case.
-These issues are usually too expensive to track down during normal Spack operations
-or difficult to resolve automatically.
-
-For instance a user may, during development, change the name or values of a
-variant in a package and miss to update all of the dependents. Scanning all the
-packages all of the time to look for inconsistencies would be detrimental to
-the performance and usability of Spack so, to troubleshoot issues of this kind
-Spack provides the ``spack audit`` command:
+The ``spack audit`` command:
 
 .. command-output:: spack audit -h
 
-This command is meant to run sanity checks on various aspects of Spack,
-such as configuration files, package recipes, etc. A detailed list
-of the checks currently implemented for each subcommand can be
+can be used to detect a number of configuration issues. This command detects
+configuration settings which might not be strictly wrong but are not likely
+to be useful outside of special cases.
+
+It can also be used to detect dependency issues with packages - for example
+cases where a package constrains a dependency with a variant that doesn't
+exist (in this case Spack could report the problem ahead of time but
+automatically performing the check would slow down most runs of Spack).
+
+A detailed list of the checks currently implemented for each subcommand can be
 printed with:
 
 .. command-output:: spack -v audit list
 
-Depending on the use case, users might run the appropriate
-subcommands to obtain diagnostics. Issues, if found, are
-reported to stdout:
+Depending on the use case, users might run the appropriate subcommands to obtain
+diagnostics. Issues, if found, are reported to stdout:
 
 .. code-block:: console
 

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1734,11 +1734,20 @@ A nicer error message is TBD in future versions of Spack.
 Troubleshooting
 ---------------
 
-To troubleshoot issues, Spack provides the ``spack audit`` command:
+When dealing with a large stack of software or with the development of complex
+applications, users may face issues that are very specific to their use case.
+These issues are usually too expensive to track down during normal Spack operations
+or difficult to resolve automatically.
+
+For instance a user may, during development, change the name or values of a
+variant in a package and miss to update all of the dependents. Scanning all the
+packages all of the time to look for inconsistencies would be detrimental to
+the performance and usability of Spack so, to troubleshoot issues of this kind
+Spack provides the ``spack audit`` command:
 
 .. command-output:: spack audit -h
 
-that is meant to run sanity checks on various aspects of Spack,
+This command is meant to run sanity checks on various aspects of Spack,
 such as configuration files, package recipes, etc. A detailed list
 of the checks currently implemented for each subcommand can be
 printed with:

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1730,6 +1730,33 @@ This issue typically manifests with the error below:
 
 A nicer error message is TBD in future versions of Spack.
 
+---------------
+Troubleshooting
+---------------
+
+To troubleshoot issues, Spack provides the ``spack audit`` command:
+
+.. command-output:: spack audit -h
+
+that is meant to run sanity checks on various aspects of Spack,
+such as configuration files, package recipes, etc. A detailed list
+of the checks currently implemented for each subcommand can be
+printed with:
+
+.. command-output:: spack -v audit list
+
+Depending on the use case, users might run the appropriate
+subcommands to obtain diagnostics. Issues, if found, are
+reported to stdout:
+
+.. code-block:: console
+
+   % spack audit packages --name=lammps
+   PKG-DIRECTIVES: 1 issue found
+   1. lammps: wrong variant in "conflicts" directive
+       the variant 'adios' does not exist
+       in /home/spack/spack/var/spack/repos/builtin/packages/lammps/package.py
+
 
 ------------
 Getting Help

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -1760,7 +1760,7 @@ reported to stdout:
 
 .. code-block:: console
 
-   % spack audit packages --name=lammps
+   % spack audit packages lammps
    PKG-DIRECTIVES: 1 issue found
    1. lammps: wrong variant in "conflicts" directive
        the variant 'adios' does not exist

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -5,8 +5,35 @@
 """Classes and functions to register audit checks for various parts of
 Spack and run them on-demand.
 
-- Each tag has a well defined call signature
-- Only callable via kwargs
+To register a new class of sanity checks (e.g. sanity checks for
+compilers.yaml), the first action required is to create a new AuditClass
+object:
+
+.. code-block:: python
+
+   audit_cfgcmp = AuditClass(
+       tag='CFG-COMPILER',
+       description='Sanity checks on compilers.yaml',
+       kwargs=()
+   )
+
+This object is to be used as a decorator to register functions
+that will perform each a single check:
+
+.. code-block:: python
+
+   @audit_cfgcmp
+   def _search_duplicate_compilers(error_cls):
+       pass
+
+These functions need to take as argument the keywords declared when
+creating the decorator object plus an ``error_cls`` argument at the
+end, acting as a factory to create Error objects. It should return a
+(possibly empty) list of errors.
+
+Calls to each of these functions are triggered by the ``run`` method of
+the decorator object, that will forward the keyword arguments passed
+as input.
 """
 import itertools
 try:
@@ -96,9 +123,7 @@ audit_cfgcmp = AuditClass(
 
 @audit_cfgcmp
 def _search_duplicate_compilers(error_cls):
-    """Search and report copmilers with the same spec and two
-    different definitions.
-    """
+    """Report compilers with the same spec and two different definitions"""
     import spack.config
     errors = []
 
@@ -132,7 +157,7 @@ audit_pkgdirectives = AuditClass(
 
 @audit_pkgdirectives
 def _unknown_variants_in_directives(pkgs, error_cls):
-    """Search and report the use of unknown or wrong variants in directives."""
+    """Report unknown or wrong variants in directives for this package"""
     import llnl.util.lang
     import spack.repo
     import spack.spec
@@ -178,7 +203,7 @@ def _unknown_variants_in_directives(pkgs, error_cls):
 
 @audit_pkgdirectives
 def _unknown_variants_in_dependencies(pkgs, error_cls):
-    """Search and report use of wrong variants for dependencies"""
+    """Report unknown dependencies and wrong variants for dependencies"""
     import spack.repo
     import spack.spec
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -157,7 +157,7 @@ audit_cfgpkg = AuditClass(
 
 @audit_cfgpkg
 def _search_duplicate_specs_in_externals(error_cls):
-    """Search for duplicate specs declared as externals."""
+    """Search for duplicate specs declared as externals"""
     import spack.config
 
     errors, externals = [], collections.defaultdict(list)

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -2,7 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-"""Auditing for various subsystems in Spack.
+"""Classes and functions to register audit checks for various parts of
+Spack and run them on-demand.
 
 - Each tag has a well defined call signature
 - Only callable via kwargs
@@ -18,18 +19,38 @@ CALLBACKS = {}
 
 
 class Error(object):
+    """Information on an error reported in a test."""
     def __init__(self, summary, details):
         self.summary = summary
-        self.details = details
+        self.details = tuple(details)
 
     def __str__(self):
         return self.summary + '\n' + '\n'.join([
             '    ' + detail for detail in self.details
         ])
 
+    def __eq__(self, other):
+        if self.summary != other.summary or self.details != other.details:
+            return False
+        return True
+
+    def __hash__(self):
+        value = (self.summary, self.details)
+        return hash(value)
+
 
 class AuditClass(Sequence):
     def __init__(self, tag, description, kwargs):
+        """Return an object that acts as a decorator to register functions
+        associated with a specific class of sanity checks.
+
+        Args:
+            tag (str): tag uniquely identifying the class of sanity checks
+            description (str): description of the sanity checks performed
+                by this tag
+            kwargs (tuple of str): keyword arguments that each registered
+                function needs to accept
+        """
         if tag in CALLBACKS:
             msg = 'audit class "{0}" already registered'
             raise ValueError(msg.format(tag))
@@ -62,12 +83,10 @@ class AuditClass(Sequence):
         for fn in self.callbacks:
             errors.extend(fn(**kwargs))
 
-        for e in errors:
-            e.tag = self.tag
-
         return errors
 
 
+#: Sanity checks on compilers.yaml
 audit_cfgcmp = AuditClass(
     tag='CFG-COMPILER',
     description='Sanity checks on compilers.yaml',
@@ -77,6 +96,9 @@ audit_cfgcmp = AuditClass(
 
 @audit_cfgcmp
 def _search_duplicate_compilers(error_cls):
+    """Search and report copmilers with the same spec and two
+    different definitions.
+    """
     import spack.config
     errors = []
 
@@ -96,5 +118,89 @@ def _search_duplicate_compilers(error_cls):
                 str(x._start_mark).strip() for x in group
             ])
         )
+
+    return errors
+
+
+#: Sanity checks on package directives
+audit_pkgdirectives = AuditClass(
+    tag='PKG-DIRECTIVES',
+    description='Sanity checks on specs used in directives',
+    kwargs=('pkgs',)
+)
+
+
+@audit_pkgdirectives
+def _unknown_variants_in_directives(pkgs, error_cls):
+    """Search and report the use of unknown or wrong variants in directives."""
+    import llnl.util.lang
+    import spack.repo
+    import spack.spec
+
+    errors = []
+    for pkg_name in pkgs:
+        pkg = spack.repo.get(pkg_name)
+
+        # Check "conflicts" directive
+        for conflict, triggers in pkg.conflicts.items():
+            for trigger, _ in triggers:
+                vrn = spack.spec.Spec(conflict)
+                vrn.constrain(trigger)
+                errors.extend(_analyze_variants_in_directive(
+                    pkg, vrn, directive='conflicts', error_cls=error_cls
+                ))
+
+        # Check "depends_on" directive
+        for _, triggers in pkg.dependencies.items():
+            triggers = list(triggers)
+            for trigger in list(triggers):
+                vrn = spack.spec.Spec(trigger)
+                errors.extend(_analyze_variants_in_directive(
+                    pkg, vrn, directive='depends_on', error_cls=error_cls
+                ))
+
+        # Check "patch" directive
+        for _, triggers in pkg.provided.items():
+            triggers = [spack.spec.Spec(x) for x in triggers]
+            for vrn in triggers:
+                errors.extend(_analyze_variants_in_directive(
+                    pkg, vrn, directive='patch', error_cls=error_cls
+                ))
+
+        # Check "resource" directive
+        for vrn in pkg.resources:
+            errors.extend(_analyze_variants_in_directive(
+                pkg, vrn, directive='resource', error_cls=error_cls
+            ))
+
+    return llnl.util.lang.dedupe(errors)
+
+
+def _analyze_variants_in_directive(pkg, constraint, directive, error_cls):
+    import spack.variant
+    variant_exceptions = (
+        spack.variant.InconsistentValidationError,
+        spack.variant.MultipleValuesInExclusiveVariantError,
+        spack.variant.InvalidVariantValueError,
+        KeyError
+    )
+    errors = []
+    for name, v in constraint.variants.items():
+        try:
+            pkg.variants[name].validate_or_raise(v, pkg=pkg)
+        except variant_exceptions as e:
+            summary = pkg.name + ': wrong variant in "{0}" directive'
+            summary = summary.format(directive)
+            filename = spack.repo.path.filename_for_package_name(pkg.name)
+
+            error_msg = str(e).strip()
+            if isinstance(e, KeyError):
+                error_msg = 'the variant {0} does not exist'.format(error_msg)
+
+            err = error_cls(summary=summary, details=[
+                error_msg, 'in ' + filename
+            ])
+
+            errors.append(err)
 
     return errors

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -151,6 +151,9 @@ def run_check(tag, **kwargs):
     return CALLBACKS[tag].run(**kwargs)
 
 
+# TODO: For the generic check to be useful for end users,
+# TODO: we need to implement hooks like described in
+# TODO: https://github.com/spack/spack/pull/23053/files#r630265011
 #: Generic checks relying on global state
 generic = AuditClass(
     group='generic',

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -217,7 +217,12 @@ def _unknown_variants_in_directives(pkgs, error_cls):
         for conflict, triggers in pkg.conflicts.items():
             for trigger, _ in triggers:
                 vrn = spack.spec.Spec(conflict)
-                vrn.constrain(trigger)
+                try:
+                    vrn.constrain(trigger)
+                except Exception as e:
+                    msg = 'Generic error in conflict for package "{0}": '
+                    errors.append(error_cls(msg.format(pkg.name), [str(e)]))
+                    continue
                 errors.extend(_analyze_variants_in_directive(
                     pkg, vrn, directive='conflicts', error_cls=error_cls
                 ))

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -1,0 +1,100 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""Auditing for various subsystems in Spack.
+
+- Each tag has a well defined call signature
+- Only callable via kwargs
+"""
+import itertools
+try:
+    from collections.abc import Sequence  # novm
+except ImportError:
+    from collections import Sequence
+
+#: Map an audit tag to a list of callables implementing checks
+CALLBACKS = {}
+
+
+class Error(object):
+    def __init__(self, summary, details):
+        self.summary = summary
+        self.details = details
+
+    def __str__(self):
+        return self.summary + '\n' + '\n'.join([
+            '    ' + detail for detail in self.details
+        ])
+
+
+class AuditClass(Sequence):
+    def __init__(self, tag, description, kwargs):
+        if tag in CALLBACKS:
+            msg = 'audit class "{0}" already registered'
+            raise ValueError(msg.format(tag))
+
+        self.tag = tag
+        self.description = description
+        self.kwargs = kwargs
+        self.callbacks = []
+
+        # Init the list of hooks
+        CALLBACKS[self.tag] = self
+
+    def __call__(self, func):
+        # TODO: Check function signature
+        self.callbacks.append(func)
+
+    def __getitem__(self, item):
+        return self.callbacks[item]
+
+    def __len__(self):
+        return len(self.callbacks)
+
+    def run(self, **kwargs):
+        msg = 'please pass "{0}" as keyword arguments'
+        msg = msg.format(', '.join(self.kwargs))
+        assert set(self.kwargs) == set(kwargs), msg
+
+        errors = []
+        kwargs['error_cls'] = Error
+        for fn in self.callbacks:
+            errors.extend(fn(**kwargs))
+
+        for e in errors:
+            e.tag = self.tag
+
+        return errors
+
+
+audit_cfgcmp = AuditClass(
+    tag='CFG-COMPILER',
+    description='Sanity checks on compilers.yaml',
+    kwargs=()
+)
+
+
+@audit_cfgcmp
+def _search_duplicate_compilers(error_cls):
+    import spack.config
+    errors = []
+
+    compilers = list(sorted(
+        spack.config.get('compilers'), key=lambda x: x['compiler']['spec']
+    ))
+    for spec, group in itertools.groupby(
+            compilers, key=lambda x: x['compiler']['spec']
+    ):
+        group = list(group)
+        if len(group) == 1:
+            continue
+
+        error_msg = 'Compiler defined multiple times: {0}'
+        errors.append(error_cls(
+            summary=error_msg.format(spec), details=[
+                str(x._start_mark).strip() for x in group
+            ])
+        )
+
+    return errors

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -189,11 +189,13 @@ def _search_duplicate_compilers(error_cls):
             continue
 
         error_msg = 'Compiler defined multiple times: {0}'
+        try:
+            details = [str(x._start_mark).strip() for x in group]
+        except Exception:
+            details = []
         errors.append(error_cls(
-            summary=error_msg.format(spec), details=[
-                str(x._start_mark).strip() for x in group
-            ])
-        )
+            summary=error_msg.format(spec), details=details
+        ))
 
     return errors
 
@@ -235,11 +237,15 @@ def _search_duplicate_specs_in_externals(error_cls):
 
         # Otherwise wwe need to report an error
         error_msg = 'Multiple externals share the same spec: {0}'.format(spec)
-        details = [
-            'Please remove all but one of the following entries:'
-        ] + [str(x._start_mark).strip() for x in entries] + [
-            'as they might result in non-deterministic hashes'
-        ]
+        try:
+            lines = [str(x._start_mark).strip() for x in entries]
+            details = [
+                'Please remove all but one of the following entries:'
+            ] + lines + [
+                'as they might result in non-deterministic hashes'
+            ]
+        except TypeError:
+            details = []
 
         errors.append(error_cls(summary=error_msg, details=details))
 

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -151,6 +151,15 @@ def run_check(tag, **kwargs):
     return CALLBACKS[tag].run(**kwargs)
 
 
+#: Generic checks relying on global state
+generic = AuditClass(
+    group='generic',
+    tag='GENERIC',
+    description='Generic checks relying on global variables',
+    kwargs=()
+)
+
+
 #: Sanity checks on compilers.yaml
 config_compiler = AuditClass(
     group='configs',

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -27,9 +27,8 @@ def setup_parser(subparser):
     # Audit package recipes
     pkg_parser = sp.add_parser('packages', help='audit package recipes')
     pkg_parser.add_argument(
-        '--name',
-        help='restrict which packages to analyze (may be given multiple times)',
-        action='append'
+        'name', metavar='PKG', nargs='*',
+        help='package to be analyzed (if none all packages will be processed)',
     )
 
     # List all checks

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -11,11 +11,6 @@ description = "audit configuration files, packages, etc."
 section = "system"
 level = "short"
 
-CHECKS = {
-    'configs': ['CFG-COMPILER', 'CFG-PACKAGES'],
-    'packages': ['PKG-DIRECTIVES']
-}
-
 
 def setup_parser(subparser):
     # Top level flags, valid for every audit class
@@ -36,21 +31,18 @@ def setup_parser(subparser):
 
 
 def configs(parser, args):
-    checks = CHECKS[args.subcommand]
-    reports = _run_checks(checks)
+    reports = spack.audit.run_group(args.subcommand)
     _process_reports(reports)
 
 
 def packages(parser, args):
-    checks = CHECKS[args.subcommand]
     pkgs = args.name or spack.repo.path.all_package_names()
-
-    reports = _run_checks(checks, pkgs=pkgs)
+    reports = spack.audit.run_group(args.subcommand, pkgs=pkgs)
     _process_reports(reports)
 
 
 def list(parser, args):
-    for subcommand, check_tags in CHECKS.items():
+    for subcommand, check_tags in spack.audit.GROUPS.items():
         print(cl.colorize('@*b{' + subcommand + '}:'))
         for tag in check_tags:
             audit_obj = spack.audit.CALLBACKS[tag]
@@ -69,14 +61,6 @@ def audit(parser, args):
         'list': list
     }
     subcommands[args.subcommand](parser, args)
-
-
-def _run_checks(checks, **kwargs):
-    reports = []
-    for check in checks:
-        errors = spack.audit.CALLBACKS[check].run(**kwargs)
-        reports.append((check, errors))
-    return reports
 
 
 def _process_reports(reports):

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -12,7 +12,7 @@ section = "system"
 level = "short"
 
 CHECKS = {
-    'configs': ['CFG-COMPILER'],
+    'configs': ['CFG-COMPILER', 'CFG-PACKAGES'],
     'packages': ['PKG-DIRECTIVES']
 }
 

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -58,7 +58,8 @@ def list(parser, args):
             print('  ' + audit_obj.description)
             if args.verbose:
                 for idx, fn in enumerate(audit_obj.callbacks):
-                    print('    {0}.'.format(idx + 1) + fn.__doc__)
+                    print('    {0}. '.format(idx + 1) + fn.__doc__)
+                print()
         print()
 
 

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -73,6 +73,7 @@ def _process_reports(reports):
             print(cl.colorize(header))
             for idx, error in enumerate(errors):
                 print(str(idx + 1) + '. ' + str(error))
+            raise SystemExit(1)
         else:
             msg = '{0}: 0 issues found.'.format(check)
             header = '@*b{' + msg + '}'

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import llnl.util.tty.color as cl
+import spack.audit
+
+
+description = "audit configuration files, packages, etc."
+section = "system"
+level = "short"
+
+
+def setup_parser(subparser):
+    # Top level flags, valid for every audit class
+    sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='subcommand')
+
+    # Audit configuration files
+    sp.add_parser(
+        'configuration',
+        help='audit configuration files'
+    )
+
+
+def audit(parser, args):
+    # FIXME: trigger subcommands
+    errors = spack.audit.audit_cfgcmp.run()
+    if errors:
+        msg = '{0}: {1} issue{2} found'.format(
+            spack.audit.audit_cfgcmp.tag, len(errors),
+            '' if len(errors) == 1 else 's'
+        )
+        header = '@*b{' + msg + '}'
+        print(cl.colorize(header))
+        for idx, error in enumerate(errors):
+            print(str(idx + 1) + '. ' + str(error))

--- a/lib/spack/spack/cmd/audit.py
+++ b/lib/spack/spack/cmd/audit.py
@@ -32,6 +32,9 @@ def setup_parser(subparser):
         action='append'
     )
 
+    # List all checks
+    sp.add_parser('list', help='list available checks and exits')
+
 
 def configs(parser, args):
     checks = CHECKS[args.subcommand]
@@ -47,10 +50,23 @@ def packages(parser, args):
     _process_reports(reports)
 
 
+def list(parser, args):
+    for subcommand, check_tags in CHECKS.items():
+        print(cl.colorize('@*b{' + subcommand + '}:'))
+        for tag in check_tags:
+            audit_obj = spack.audit.CALLBACKS[tag]
+            print('  ' + audit_obj.description)
+            if args.verbose:
+                for idx, fn in enumerate(audit_obj.callbacks):
+                    print('    {0}.'.format(idx + 1) + fn.__doc__)
+        print()
+
+
 def audit(parser, args):
     subcommands = {
         'configs': configs,
-        'packages': packages
+        'packages': packages,
+        'list': list
     }
     subcommands[args.subcommand](parser, args)
 

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -31,40 +31,44 @@ def test_package_audits(packages, failing_check, mock_packages):
             assert not errors
 
 
+# Data used in the test below to audit the double definition of a compiler
+_double_compiler_definition = [
+    {'compiler': {
+        'spec': 'gcc@9.0.1',
+        'paths': {
+            'cc': '/usr/bin/gcc-9',
+            'cxx': '/usr/bin/g++-9',
+            'f77': '/usr/bin/gfortran-9',
+            'fc': '/usr/bin/gfortran-9'
+        },
+        'flags': {},
+        'operating_system': 'ubuntu18.04',
+        'target': 'x86_64',
+        'modules': [],
+        'environment': {},
+        'extra_rpaths': []
+    }},
+    {'compiler': {
+        'spec': 'gcc@9.0.1',
+        'paths': {
+            'cc': '/usr/bin/gcc-9',
+            'cxx': '/usr/bin/g++-9',
+            'f77': '/usr/bin/gfortran-9',
+            'fc': '/usr/bin/gfortran-9'
+        },
+        'flags': {"cflags": "-O3"},
+        'operating_system': 'ubuntu18.04',
+        'target': 'x86_64',
+        'modules': [],
+        'environment': {},
+        'extra_rpaths': []
+    }}
+]
+
+
 @pytest.mark.parametrize('config_section,data,failing_check', [
     # Double compiler definitions in compilers.yaml
-    ('compilers', [
-        {'compiler': {
-            'spec': 'gcc@9.0.1',
-            'paths': {
-                'cc': '/usr/bin/gcc-9',
-                'cxx': '/usr/bin/g++-9',
-                'f77': '/usr/bin/gfortran-9',
-                'fc': '/usr/bin/gfortran-9'
-            },
-            'flags': {},
-            'operating_system': 'ubuntu18.04',
-            'target': 'x86_64',
-            'modules': [],
-            'environment': {},
-            'extra_rpaths': []
-        }},
-        {'compiler': {
-            'spec': 'gcc@9.0.1',
-            'paths': {
-                'cc': '/usr/bin/gcc-9',
-                'cxx': '/usr/bin/g++-9',
-                'f77': '/usr/bin/gfortran-9',
-                'fc': '/usr/bin/gfortran-9'
-            },
-            'flags': {"cflags": "-O3"},
-            'operating_system': 'ubuntu18.04',
-            'target': 'x86_64',
-            'modules': [],
-            'environment': {},
-            'extra_rpaths': []
-        }}
-    ], 'CFG-COMPILER'),
+    ('compilers', _double_compiler_definition, 'CFG-COMPILER'),
     # Multiple definitions of the same external spec in packages.yaml
     ('packages', {
         "mpileaks": {"externals": [

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -1,0 +1,81 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+
+import spack.audit
+import spack.config
+
+
+@pytest.mark.parametrize('packages,failing_check', [
+    # A non existing variant is used in a conflict directive
+    (['wrong-variant-in-conflicts'], 'PKG-DIRECTIVES'),
+    # The package declares a non-existing dependency
+    (['missing-dependency'], 'PKG-DIRECTIVES'),
+    # The package use a non existing variant in a depends_on directive
+    (['wrong-variant-in-depends-on'], 'PKG-DIRECTIVES'),
+    # This package has no issues
+    (['mpileaks'], None)
+])
+def test_package_audits(packages, failing_check, mock_packages):
+    reports = spack.audit.run_group('packages', pkgs=packages)
+
+    for check, errors in reports:
+        # Check that we have errors only if there is an expected failure
+        # and that the tag matches our expectations
+        if bool(failing_check):
+            assert check == failing_check
+            assert errors
+        else:
+            assert not errors
+
+
+@pytest.mark.parametrize('config_section,data,failing_check', [
+    # Double compiler definitions in compilers.yaml
+    ('compilers', [
+        {'compiler': {
+            'spec': 'gcc@9.0.1',
+            'paths': {
+                'cc': '/usr/bin/gcc-9',
+                'cxx': '/usr/bin/g++-9',
+                'f77': '/usr/bin/gfortran-9',
+                'fc': '/usr/bin/gfortran-9'
+            },
+            'flags': {},
+            'operating_system': 'ubuntu18.04',
+            'target': 'x86_64',
+            'modules': [],
+            'environment': {},
+            'extra_rpaths': []
+        }},
+        {'compiler': {
+            'spec': 'gcc@9.0.1',
+            'paths': {
+                'cc': '/usr/bin/gcc-9',
+                'cxx': '/usr/bin/g++-9',
+                'f77': '/usr/bin/gfortran-9',
+                'fc': '/usr/bin/gfortran-9'
+            },
+            'flags': {"cflags": "-O3"},
+            'operating_system': 'ubuntu18.04',
+            'target': 'x86_64',
+            'modules': [],
+            'environment': {},
+            'extra_rpaths': []
+        }}
+    ], 'CFG-COMPILER'),
+    # Multiple definitions of the same external spec in packages.yaml
+    ('packages', {
+        "mpileaks": {"externals": [
+            {"spec": "mpileaks@1.0.0", "prefix": "/"},
+            {"spec": "mpileaks@1.0.0", "prefix": "/usr"},
+        ]}
+    }, 'CFG-PACKAGES')
+])
+def test_config_audits(config_section, data, failing_check):
+    with spack.config.override(config_section, data):
+        reports = spack.audit.run_group('configs')
+        assert any(
+            (check == failing_check) and errors for check, errors in reports
+        )

--- a/lib/spack/spack/test/cmd/audit.py
+++ b/lib/spack/spack/test/cmd/audit.py
@@ -2,19 +2,29 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+
 from spack.main import SpackCommand
 
 
 audit = SpackCommand('audit')
 
 
-def test_audit_packages(mutable_config, mock_packages):
+@pytest.mark.parametrize('pkgs,expected_returncode', [
+    # A single package with issues, should exit 1
+    (['wrong-variant-in-conflicts'], 1),
+    # A "sane" package should exit 0
+    (['mpileaks'], 0),
+    # A package with issues and a package without should exit 1
+    (['wrong-variant-in-conflicts', 'mpileaks'], 1),
+    (['mpileaks', 'wrong-variant-in-conflicts'], 1),
+])
+def test_audit_packages(
+        pkgs, expected_returncode, mutable_config, mock_packages
+):
     """Sanity check ``spack audit packages`` to make sure it works."""
-    audit('packages', fail_on_error=False)
-    # Some mock packages have issues by design, to check what would
-    # be Spack behavior in those cases. Ensure that the command returns
-    # non-zero exit code
-    assert audit.returncode == 1
+    audit('packages', *pkgs, fail_on_error=False)
+    assert audit.returncode == expected_returncode
 
 
 def test_audit_configs(mutable_config, mock_packages):

--- a/lib/spack/spack/test/cmd/audit.py
+++ b/lib/spack/spack/test/cmd/audit.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.main import SpackCommand
+
+
+audit = SpackCommand('audit')
+
+
+def test_audit_packages(mutable_config, mock_packages):
+    """Sanity check ``spack audit packages`` to make sure it works."""
+    audit('packages', fail_on_error=False)
+    # Some mock packages have issues by design, to check what would
+    # be Spack behavior in those cases. Ensure that the command returns
+    # non-zero exit code
+    assert audit.returncode == 1
+
+
+def test_audit_configs(mutable_config, mock_packages):
+    """Sanity check ``spack audit packages`` to make sure it works."""
+    audit('configs', fail_on_error=False)
+    # The mock configuration has duplicate definitions of some compilers
+    assert audit.returncode == 1

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -333,7 +333,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="activate add analyze arch blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mark mirror module monitor patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="activate add analyze arch audit blame build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mark mirror module monitor patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -379,6 +379,23 @@ _spack_analyze_run() {
 
 _spack_arch() {
     SPACK_COMPREPLY="-h --help --known-targets -p --platform -o --operating-system -t --target -f --frontend -b --backend"
+}
+
+_spack_audit() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY="configs packages"
+    fi
+}
+
+_spack_audit_configs() {
+    SPACK_COMPREPLY="-h --help"
+}
+
+_spack_audit_packages() {
+    SPACK_COMPREPLY="-h --help --name"
 }
 
 _spack_blame() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -395,7 +395,12 @@ _spack_audit_configs() {
 }
 
 _spack_audit_packages() {
-    SPACK_COMPREPLY="-h --help --name"
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY=""
+    fi
 }
 
 _spack_audit_list() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -386,7 +386,7 @@ _spack_audit() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="configs packages"
+        SPACK_COMPREPLY="configs packages list"
     fi
 }
 
@@ -396,6 +396,10 @@ _spack_audit_configs() {
 
 _spack_audit_packages() {
     SPACK_COMPREPLY="-h --help --name"
+}
+
+_spack_audit_list() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_blame() {


### PR DESCRIPTION

This PR adds a way to check various parts of Spack from the command line. The motivation to start this has been seeing a few issues where errors / inconsistencies in package recipes where mistaken for bugs in the new concretizer, due to poor reporting, and a debug session with @jjellio  in which after much struggle we understood that an issue was due to a compiler being defined multiple times in the configuration (which is not allowed but Spack was not clear at all on what was the problem).

The PR should introduce:
- [x] A way to declare new class of audits (e.g. audits for compiler configuration, audits for package directives etc.)
- [x] A way to register functions as part of those audits 
- [x] A command to drive this from the terminal
- [x] Documentation of the new feature
- [x] Tests for the `spack.audit` module 

As a first example, recreating a case like the one debugged with @jjellio we can obtain with this PR:
```console
culpo@MacBook-Pro bootstrap % cat spack.yaml             
spack:
  specs:
  - zlib
  compilers:
  - compiler:
      spec: gcc@10.2.0
      paths:
        cc: /Users/culpo/PycharmProjects/spack/opt/spack/darwin-bigsur-cannonlake/apple-clang-12.0.0/gcc-10.2.0-zm6u6otbxbacpvsbx6lugzo6qeb2hd7v/bin/gcc
        cxx: /Users/culpo/PycharmProjects/spack/opt/spack/darwin-bigsur-cannonlake/apple-clang-12.0.0/gcc-10.2.0-zm6u6otbxbacpvsbx6lugzo6qeb2hd7v/bin/g++
        f77: /Users/culpo/PycharmProjects/spack/opt/spack/darwin-bigsur-cannonlake/apple-clang-12.0.0/gcc-10.2.0-zm6u6otbxbacpvsbx6lugzo6qeb2hd7v/bin/gfortran
        fc: /Users/culpo/PycharmProjects/spack/opt/spack/darwin-bigsur-cannonlake/apple-clang-12.0.0/gcc-10.2.0-zm6u6otbxbacpvsbx6lugzo6qeb2hd7v/bin/gfortran
      flags:
        cflags: '-O3'
      operating_system: bigsur
      target: x86_64
      modules: []
      environment: {}
      extra_rpaths: []
culpo@MacBook-Pro bootstrap % spack audit configuration     
culpo@MacBook-Pro bootstrap % spack -e . audit configuration
CFG-COMPILER: 1 issue found
1. Compiler defined multiple times: gcc@10.2.0
    in "/Users/culpo/spack/bootstrap/spack.yaml", line 5, column 5
    in "/Users/culpo/.spack/darwin/compilers.yaml", line 2, column 3
```