### PR TITLE
Set JAVAH for r-rjava

### DIFF
--- a/var/spack/repos/builtin/packages/r-rjava/package.py
+++ b/var/spack/repos/builtin/packages/r-rjava/package.py
@@ -33,5 +33,5 @@ class RRjava(RPackage):
 
     def setup_build_environment(self, env):
         spec = self.spec
-        env.append_flags('JAVAH', '{0}/bin/javah'.format(
+        env.append_flags('JAVAH', '{0}/javah'.format(
             join_path(spec['java'].prefix.bin)))

--- a/var/spack/repos/builtin/packages/r-rjava/package.py
+++ b/var/spack/repos/builtin/packages/r-rjava/package.py
@@ -30,3 +30,8 @@ class RRjava(RPackage):
     depends_on('libiconv')
     depends_on('pcre2')
     depends_on('xz')
+
+    def setup_build_environment(self, env):
+        spec = self.spec
+        env.append_flags('JAVAH', '{0}/bin/javah'.format(
+            join_path(spec['java'].prefix.bin)))


### PR DESCRIPTION
Set the path to javah via the JAVAH environment variable. If it is
a version of java that does not have javah it will fall back to `javac
-h`. Without specifying this the build could pick up a javah from the
system.