### PR TITLE
py-vermin: add latest version 1.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-vermin/package.py
+++ b/var/spack/repos/builtin/packages/py-vermin/package.py
@@ -8,10 +8,11 @@ class PyVermin(PythonPackage):
     """Concurrently detect the minimum Python versions needed to run code."""
 
     homepage = "https://github.com/netromdk/vermin"
-    url      = "https://github.com/netromdk/vermin/archive/v1.1.0.tar.gz"
+    url      = "https://github.com/netromdk/vermin/archive/v1.1.1.tar.gz"
 
     maintainers = ['netromdk']
 
+    version('1.1.1', sha256='d13b2281ba16c9d5b0913646483771789552230a9ed625e2cd92c5a112e4ae80')
     version('1.1.0', sha256='62d9f1b6694f50c22343cead2ddb6e2b007d24243fb583f61ceed7540fbe660b')
     version('1.0.3', sha256='1503be05b55cacde1278a1fe55304d8ee889ddef8ba16e120ac6686259bec95c')
     version('1.0.2', sha256='e999d5f5455e1116b366cd1dcc6fecd254c7ae3606549a61bc044216f9bb5b55')


### PR DESCRIPTION
[v1.1.1](https://github.com/netromdk/vermin/releases/tag/v1.1.1): Detecting user function decorators, fixed 3 advisories, and made improvements to annotations evaluations.
@adamjstewart @alalazo