### PR TITLE
amp: cleanup of the recipe

### DIFF
--- a/var/spack/repos/builtin/packages/amp/package.py
+++ b/var/spack/repos/builtin/packages/amp/package.py
@@ -2,41 +2,47 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 from spack import *
 
 
 class Amp(CMakePackage):
-    """The Advanced Multi-Physics (AMP) package is an open source parallel
+    """The Advanced Multi-Physics (AMP) package.
+
+    The Advanced Multi-Physics (AMP) package is an open source parallel
     object-oriented computational framework that is designed with single
-    and multi-domain multi-physics applications in mind. AMP can be used
-    to build powerful and flexible multi-physics simulation algorithms
-    from lightweight operator, solver, linear algebra, material database,
-    discretization, and meshing components. The AMP design is meant to
-    enable existing investments in application codes to be leveraged without
-    having to adopt dramatically different data structures while developing
-    new computational science applications. Application components are
-    represented as discrete mathematical operators that only require a
-    minimal interface and through operator composition the incremental
-    development of complex parallel applications is enabled. AMP is meant
-    to allow application domain scientists, computer scientists and
-    mathematicians to simulate, collaborate, and conduct research on
-    various aspects of massively parallel simulation algorithms."""
+    and multi-domain multi-physics applications in mind.
+    """
 
     homepage = "https://bitbucket.org/AdvancedMultiPhysics/amp"
-    hg       = homepage
+    hg = homepage
 
     version('develop')
+
+    variant('boost', default=True, description='Build with support for Boost')
+    variant('hdf5', default=True, description='Build with support for HDF5')
+    variant('hypre', default=True, description='Build with support for hypre')
+    variant('libmesh', default=True, description='Build with libmesh support')
+    variant('mpi', default=True, description='Build with MPI support')
+    variant('netcdf', default=True, description='Build with NetCDF support')
+    variant('petsc', default=True, description='Build with Petsc support')
+    variant('shared', default=True, description='Build shared libraries')
+    variant('silo', default=True, description='Build with support for Silo')
+    variant('sundials', default=True, description='Build with support for Sundials')
+    variant('trilinos', default=True, description='Build with support for Trilinos')
+    variant('zlib', default=True, description='Build with support for zlib')
 
     # Everything should be compiled position independent (-fpic)
     depends_on('blas')
     depends_on('lapack')
     depends_on('boost', when='+boost')
-    depends_on('petsc', when='+petsc')
-    depends_on('trilinos', when='+trilinos')
     depends_on('hdf5', when='+hdf5')
-    depends_on('hdf5', when='+silo')
+    depends_on('hypre', when='+hypre')
+    depends_on('libmesh', when='+libmesh')
+    depends_on('netcdf-c', when='+netcdf')
+    depends_on('petsc', when='+petsc')
     depends_on('silo', when='+silo')
+    depends_on('sundials', when='+sundials')
+    depends_on('trilinos', when='+trilinos')
     depends_on('zlib', when="+zlib")
 
     # MPI related dependencies
@@ -45,96 +51,58 @@ class Amp(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        options = []
-
-        # #################### Base Settings #######################
-
-        options.extend([
-            '-DTPL_URL=https://bitbucket.org/AdvancedMultiPhysics/tpl-builder',
-            '-DAMP_DATA_URL=https://bitbucket.org/AdvancedMultiPhysics/amp/downloads/AMP-Data.tar.gz',
-            '-DAMP_ENABLE_TESTS:BOOL=OFF',
-            '-DAMP_ENABLE_EXAMPLES:BOOL=OFF',
-            '-DAMP_ENABLE_CXX11:BOOL=ON',
-            '-DCXX_STD=11',
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
-        ])
-
-        # #################### Compiler Settings #######################
+        options = [
+            self.define('TPL_URL', 'https://bitbucket.org/AdvancedMultiPhysics/tpl-builder'),
+            self.define('AMP_DATA_URL', 'https://bitbucket.org/AdvancedMultiPhysics/amp/downloads/AMP-Data.tar.gz'),
+            self.define('AMP_ENABLE_TESTS', 'OFF'),
+            self.define('AMP_ENABLE_EXAMPLES', 'OFF'),
+            self.define('AMP_ENABLE_CXX11', 'ON'),
+            self.define('CXX_STD', '11'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define('USE_MPI', '0'),
+        ]
 
         if '+mpi' in spec:
             options.extend([
-                '-DCMAKE_C_COMPILER=%s'       % spec['mpi'].mpicc,
-                '-DCMAKE_CXX_COMPILER=%s'     % spec['mpi'].mpicxx,
-                '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
-                '-DUSE_MPI=0',
-                '-DMPI_COMPILER=1',
-                '-DMPIEXEC=$s'                % spec['mpi'].prefix.bin,
+                self.define('CMAKE_C_COMPILER', spec['mpi'].mpicc),
+                self.define('CMAKE_CXX_COMPILER', spec['mpi'].mpicxx),
+                self.define('CMAKE_Fortran_COMPILER', spec['mpi'].mpifc),
+                self.define('MPI_COMPILER', '1'),
+                self.define('MPIEXEC', spec['mpi'].prefix.bin),
             ])
         else:
             options.extend([
-                '-DCMAKE_C_COMPILER=%s'       % self.compiler.cc,
-                '-DCMAKE_CXX_COMPILER=%s'     % self.compiler.cxx,
-                '-DCMAKE_Fortran_COMPILER=%s' % self.compiler.fc,
-                '-DUSE_MPI=0',
+                self.define('CMAKE_C_COMPILER', self.compiler.cc),
+                self.define('CMAKE_CXX_COMPILER', self.compiler.cxx),
+                self.define('CMAKE_Fortran_COMPILER', self.compiler.fc),
             ])
 
-        # ################## Third Party Libraries #####################
-
-        tpl_list = "LAPACK"
-        blas = spec['blas'].libs
-        lapack = spec['lapack'].libs
+        tpl_list = ["LAPACK"]
+        blas, lapack = spec['blas'].libs, spec['lapack'].libs
         options.extend([
-            '-DTPL_LAPACK_INSTALL_DIR=%s' % spec['lapack'].prefix,
-            '-DTPL_BLAS_LIBRARY_NAMES=%s' % ';'.join(blas.names),
-            '-DTPL_BLAS_LIBRARY_DIRS=%s' % ';'.join(blas.directories),
-            '-DTPL_LAPACK_LIBRARY_NAMES=%s' % ';'.join(lapack.names),
-            '-DTPL_LAPACK_LIBRARY_DIRS=%s' % ';'.join(lapack.directories),
+            self.define('TPL_LAPACK_INSTALL_DIR', spec['lapack'].prefix),
+            self.define('TPL_BLAS_LIBRARY_NAMES', ';'.join(blas.names)),
+            self.define('TPL_BLAS_LIBRARY_DIRS', ';'.join(blas.directories)),
+            self.define('TPL_LAPACK_LIBRARY_NAMES', ';'.join(lapack.names)),
+            self.define('TPL_LAPACK_LIBRARY_DIRS', ';'.join(lapack.directories)),
         ])
-        if '+boost' in spec:
-            tpl_list = tpl_list + ";BOOST"
-            options.extend(['-DTPL_BOOST_INSTALL_DIR=%s' %
-                            spec['boost'].prefix, ])
-        if '+zlib' in spec:
-            tpl_list = tpl_list + ";ZLIB"
-            options.extend(['-DTPL_ZLIB_INSTALL_DIR=%s' %
-                            spec['zlib'].prefix, ])
-        if '+hdf5' in spec:
-            tpl_list = tpl_list + ";HDF5"
-            options.extend(['-DTPL_HDF5_INSTALL_DIR=%s' %
-                            spec['hdf5'].prefix, ])
-        if '+silo' in spec:
-            tpl_list = tpl_list + ";SILO"
-            options.extend(['-DTPL_SILO_INSTALL_DIR=%s' %
-                            spec['silo'].prefix, ])
-        if '+netcdf' in spec:
-            tpl_list = tpl_list + ";NETCDF"
-            options.extend(['-DTPL_NETCDF_INSTALL_DIR=%s' %
-                            spec['netcdf-c'].prefix, ])
-        if '+hypre' in spec:
-            tpl_list = tpl_list + ";HYPRE"
-            options.extend(['-DTPL_HYPRE_INSTALL_DIR=%s' %
-                            spec['hypre'].prefix, ])
-        if '+petsc' in spec:
-            tpl_list = tpl_list + ";PETSC"
-            options.extend(['-DTPL_PETSC_INSTALL_DIR=%s' %
-                            spec['petsc'].prefix, ])
-        if '+trilinos' in spec:
-            tpl_list = tpl_list + ";TRILINOS"
-            options.extend(['-DTPL_TRILINOS_INSTALL_DIR=%s' %
-                            spec['trilinos'].prefix, ])
-        if '+libmesh' in spec:
-            tpl_list = tpl_list + ";LIBMESH"
-            options.extend(['-DTPL_LIBMESH_INSTALL_DIR=%s' %
-                            spec['libmesh'].prefix, ])
-        if '+sundials' in spec:
-            tpl_list = tpl_list + ";SUNDIALS"
-            options.extend(['-DTPL_SUNDIALS_INSTALL_DIR=%s' %
-                            spec['sundials'].prefix, ])
-        if '+amp-timer' in spec:
-            tpl_list = tpl_list + ";TIMER"
-            options.extend(['-DTPL_TIMER_INSTALL_DIR=%s' %
-                            spec['amp-timer'].prefix, ])
-        options.extend(['-DTPL_LIST=%s' % tpl_list, ])
 
+        for vname in (
+            'boost', 'hdf5', 'hypre', 'libmesh', 'petsc',
+            'silo', 'sundials', 'trilinos', 'zlib',
+        ):
+            if '+' + vname in spec:
+                tpl_list.append(vname.upper())
+                options.append(self.define(
+                    'TPL_{0}_INSTALL_DIR'.format(vname.upper()),
+                    spec[vname].prefix
+                ))
+
+        if '+netcdf' in spec:
+            tpl_list.append("NETCDF")
+            options.append(self.define(
+                'TPL_NETCDF_INSTALL_DIR', spec['netcdf-c'].prefix
+            ))
+
+        options.append(self.define('TPL_LIST', ';'.join(tpl_list)))
         return options


### PR DESCRIPTION
Recipe was not verified with a build, but it was wrong in many ways, e.g. referring to non-existing variants or missing dependencies.

Issues have been found by using the prototype tool in #23053 which returns:
```console
% spack  audit packages --name=amp
PKG-DIRECTIVES: 7 issues found
1. amp: wrong variant in "depends_on" directive
    'boost'
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/amp/package.py
2. amp: wrong variant in "depends_on" directive
    'petsc'
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/amp/package.py
3. amp: wrong variant in "depends_on" directive
    'trilinos'
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/amp/package.py
4. amp: wrong variant in "depends_on" directive
    'hdf5'
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/amp/package.py
5. amp: wrong variant in "depends_on" directive
    'silo'
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/amp/package.py
6. amp: wrong variant in "depends_on" directive
    'zlib'
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/amp/package.py
7. amp: wrong variant in "depends_on" directive
    'mpi'
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/amp/package.py
``` 