### PR TITLE
angsd: fix typo in variants

### DIFF
--- a/var/spack/repos/builtin/packages/angsd/package.py
+++ b/var/spack/repos/builtin/packages/angsd/package.py
@@ -2,19 +2,20 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 from spack import *
 
 
 class Angsd(MakefilePackage):
-    """Angsd is a program for analysing NGS data. The software can handle a
-       number of different input types from mapped reads to imputed genotype
-       probabilities. Most methods take genotype uncertainty into account
-       instead of basing the analysis on called genotypes. This is especially
-       useful for low and medium depth data."""
+    """Angsd is a program for analysing NGS data.
+
+    The software can handle a number of different input types from mapped
+    reads to imputed genotype probabilities. Most methods take genotype
+    uncertainty into account instead of basing the analysis on called
+    genotypes. This is especially useful for low and medium depth data.
+    """
 
     homepage = "https://github.com/ANGSD/angsd"
-    url      = "https://github.com/ANGSD/angsd/archive/0.919.tar.gz"
+    url = "https://github.com/ANGSD/angsd/archive/0.919.tar.gz"
 
     version('0.933', sha256='2f992325dc08fa25ac525d9300ef6bd61808e74c521b4cc72a2ce00d98f402bb')
     version('0.921', sha256='8892d279ce1804f9e17fe2fc65a47e5498e78fc1c1cb84d2ca2527fd5c198772')
@@ -29,7 +30,7 @@ class Angsd(MakefilePackage):
     depends_on('lzma')
     depends_on('curl')
 
-    depends_on('r', type='run', when='+rlib')
+    depends_on('r', type='run', when='+r')
 
     def setup_run_environment(self, env):
         env.set('R_LIBS', self.prefix.R)


### PR DESCRIPTION
See #23053 
```console
$ spack  audit packages --name=angsd
PKG-DIRECTIVES: 1 issue found
1. angsd: wrong variant in "depends_on" directive
    'rlib'
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/angsd/package.py
```