### PR TITLE
catalyst: mpi variant was never declared

### DIFF
--- a/var/spack/repos/builtin/packages/catalyst/package.py
+++ b/var/spack/repos/builtin/packages/catalyst/package.py
@@ -66,8 +66,8 @@ class Catalyst(CMakePackage):
 
     depends_on('py-numpy', when='+python', type=('build', 'run'))
     depends_on('py-numpy', when='+python3', type=('build', 'run'))
-    depends_on('py-mpi4py', when='+python+mpi', type=('build', 'run'))
-    depends_on('py-mpi4py', when='+python3+mpi', type=('build', 'run'))
+    depends_on('py-mpi4py', when='+python', type=('build', 'run'))
+    depends_on('py-mpi4py', when='+python3', type=('build', 'run'))
 
     depends_on('gl@3.2:', when='+rendering')
     depends_on('osmesa', when='+rendering+osmesa')
@@ -226,7 +226,7 @@ class Catalyst(CMakePackage):
                 '-DPARAVIEW_ENABLE_PYTHON:BOOL=ON',
                 '-DPYTHON_EXECUTABLE:FILEPATH=%s' %
                 spec['python'].command.path,
-                '-DVTK_USE_SYSTEM_MPI4PY:BOOL=%s' % variant_bool('+mpi')
+                '-DVTK_USE_SYSTEM_MPI4PY:BOOL=ON'
             ])
         else:
             cmake_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=OFF')


### PR DESCRIPTION
Using #23053 
```console
$ spack  audit packages --name=catalyst
PKG-DIRECTIVES: 1 issue found
1. catalyst: wrong variant in "depends_on" directive
    the variant 'mpi' does not exist
    in /Users/culpo/PycharmProjects/spack/var/spack/repos/builtin/packages/catalyst/package.py
```