### PR TITLE
etsf-io: added missing `mpi` variant

### DIFF
--- a/var/spack/repos/builtin/packages/etsf-io/package.py
+++ b/var/spack/repos/builtin/packages/etsf-io/package.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 from spack import *
 
 
@@ -21,6 +19,8 @@ class EtsfIo(Package):
     url = "https://launchpad.net/etsf-io/1.0/1.0.4/+download/etsf_io-1.0.4.tar.gz"
 
     version('1.0.4', sha256='3140c2cde17f578a0e6b63acb27a5f6e9352257a1371a17b9c15c3d0ef078fa4')
+
+    variant('mpi', default=True, description='Add MPI support')
 
     depends_on("netcdf-fortran")
     depends_on("hdf5+mpi~cxx", when='+mpi')  # required for NetCDF-4 support


### PR DESCRIPTION
The variant was mentioned in a depends_on directive, but never declared. Spotted using #23053 