### PR TITLE
mlperf-deepcam: fixed issue with cuda variant and deps

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 from spack import *
 
 
@@ -32,7 +31,7 @@ class Arrow(CMakePackage, CudaPackage):
     depends_on('rapidjson')
     depends_on('snappy~shared')
     depends_on('zlib+pic')
-    depends_on('zstd+pic')
+    depends_on('zstd')
     depends_on('thrift+pic', when='+parquet')
     depends_on('orc', when='+orc')
 

--- a/var/spack/repos/builtin/packages/mlperf-deepcam/package.py
+++ b/var/spack/repos/builtin/packages/mlperf-deepcam/package.py
@@ -2,12 +2,10 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 from spack import *
 
 
-class MlperfDeepcam(Package):
+class MlperfDeepcam(Package, CudaPackage):
     """PyTorch implementation for the climate segmentation benchmark,
        based on the Exascale Deep Learning for Climate Analytics"""
 

--- a/var/spack/repos/builtin/packages/py-apache-beam/package.py
+++ b/var/spack/repos/builtin/packages/py-apache-beam/package.py
@@ -18,7 +18,6 @@ class PyApacheBeam(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-pip@7.0.0:', type=('build', 'run'))
     depends_on('py-cython@0.28.1:', type=('build', 'run'))
-    depends_on('py-avro@1.8.1:1.10.8', type=('build', 'run'), when='^python@:2.9')
     depends_on('py-avro-python3@1.8.1:1.10.0', type=('build', 'run'), when='^python@3.0:')
     depends_on('py-crcmod@1.7:', type=('build', 'run'))
     depends_on('py-dill@0.3.1:0.3.2', type=('build', 'run'))
@@ -42,5 +41,3 @@ class PyApacheBeam(PythonPackage):
     depends_on('py-requests@2.24.0:3.0.0', type=('build', 'run'))
     depends_on('py-typing@3.7.0:3.8.0', type=('build', 'run'), when='^python@:3.5')
     depends_on('py-typing-extensions@3.7.0:3.8.0', type=('build', 'run'))
-
-    conflicts('+py-avro-python3', when='@1.9.2')


### PR DESCRIPTION
Some directives were referring to a non-existing "cuda" variant. Some dependencies were referring non-existing variants in their metadata. Spotted using #23053 