### PR TITLE
ASP-based solver: suppress warnings when constructing facts

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -12,6 +12,7 @@ import pprint
 import sys
 import time
 import types
+import warnings
 from six import string_types
 
 import archspec.cpu
@@ -1040,7 +1041,9 @@ class SpackSolverSetup(object):
 
         for target in targets:
             try:
-                target.optimization_flags(compiler_name, compiler_version)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    target.optimization_flags(compiler_name, compiler_version)
                 supported.append(target)
             except archspec.cpu.UnsupportedMicroarchitecture:
                 continue


### PR DESCRIPTION
fixes #22786

Trying to get optimization flags for a specific target from a compiler may trigger warnings. In the context of constructing facts for the ASP-based solver we don't want to show these warnings to the user, so here we simply ignore them.