### PR TITLE
Use xz instead of lzma. XZ utils provides lzma dev files

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -127,7 +127,7 @@ class Paraview(CMakePackage, CudaPackage):
     depends_on('protobuf@3.4:')
     depends_on('libxml2')
     depends_on('lz4')
-    depends_on('lzma')
+    depends_on('xz')
     depends_on('zlib')
 
     # Older builds of pugi export their symbols differently,


### PR DESCRIPTION
@chuckatkins @danlipsa This fixes #22736 

Switch to use XZ-utils package instead of LZMA. The LZMA spack package does not provide the files paraview needs (`liblzma.so` and `lzma.h`)