### PR TITLE
Update findutils package for nvhpc

### DIFF
--- a/var/spack/repos/builtin/packages/findutils/nvhpc-long-width.patch
+++ b/var/spack/repos/builtin/packages/findutils/nvhpc-long-width.patch
@@ -1,0 +1,17 @@
+--- a/gl/lib/regex_internal.h
++++ b/gl/lib/regex_internal.h
+@@ -36,6 +36,14 @@
+ #include <intprops.h>
+ #include <verify.h>
+ 
++#ifndef __LONG_WIDTH__
++#if LONG_WIDTH
++#define __LONG_WIDTH__ LONG_WIDTH
++#else
++#define __LONG_WIDTH__ __WORDSIZE
++#endif
++#endif
++
+ #if defined DEBUG && DEBUG != 0
+ # include <assert.h>
+ # define DEBUG_ASSERT(x) assert (x)

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -45,7 +45,8 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
     version('4.1.20', sha256='8c5dd50a5ca54367fa186f6294b81ec7a365e36d670d9feac62227cb513e63ab')
     version('4.1',    sha256='487ecc0a6c8c90634a11158f360977e5ce0a9a6701502da6cb96a5a7ec143fac')
 
-    patch('nvhpc.patch', when='%nvhpc')
+    patch('nvhpc.patch', when='@4.6.0 %nvhpc')
+    patch('nvhpc-long-width.patch', when='@4.8.0:4.8.99 %nvhpc')
 
     build_directory = 'spack-build'
 

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -45,7 +45,10 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
     version('4.1.20', sha256='8c5dd50a5ca54367fa186f6294b81ec7a365e36d670d9feac62227cb513e63ab')
     version('4.1',    sha256='487ecc0a6c8c90634a11158f360977e5ce0a9a6701502da6cb96a5a7ec143fac')
 
+    # The NVIDIA compilers do not currently support some GNU builtins.
+    # Detect this case and use the fallback path.
     patch('nvhpc.patch', when='@4.6.0 %nvhpc')
+    # Workaround bug where __LONG_WIDTH__ is not defined
     patch('nvhpc-long-width.patch', when='@4.8.0:4.8.99 %nvhpc')
 
     build_directory = 'spack-build'


### PR DESCRIPTION
The previous nvhpc patch to the findutils package does not cleanly apply for version 4.7 and later.

Add a workaround for a missing constant for findutils 4.8.