### PR TITLE
Bootstrap with -O3 in cmake

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -228,6 +228,8 @@ class Cmake(Package):
     def bootstrap_args(self):
         spec = self.spec
         args = [
+            'CFLAGS=-O3',
+            'CXXFLAGS=-O3',
             '--prefix={0}'.format(self.prefix),
             '--parallel={0}'.format(make_jobs)
         ]


### PR DESCRIPTION
For some reason bootstrapping cmake on a cray machine with lustre filesystem is laughably slow (8 minutes!)

Turns out setting -O3 flags for the initial bootstrap itself helps a lot (5 minutes, still 5x slower than my desktop).

Note that this -O3 is just for the initial tools it compiles to detect system stuff, so it's unrelated to `build_type=Release` (which is used during `make`)

On my desktop (amd cpu) the improved runtime is exactly offset by the increased compile time by adding -O3, so no change. 

Thanks to https://github.com/spack/spack/issues/10385 for the suggestion!
