### PR TITLE
hpctoolkit: fix patch from #22864

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/gcc10-enum.patch
+++ b/var/spack/repos/builtin/packages/hpctoolkit/gcc10-enum.patch
@@ -1,0 +1,15 @@
+See: https://github.com/HPCToolkit/hpctoolkit/issues/309
+
+diff --git a/src/tool/hpcrun/gpu/gpu-metrics.h b/src/tool/hpcrun/gpu/gpu-metrics.h
+index ea0958156..fa3bceab1 100644
+--- a/src/tool/hpcrun/gpu/gpu-metrics.h
++++ b/src/tool/hpcrun/gpu/gpu-metrics.h
+@@ -61,7 +61,7 @@
+ //*****************************************************************************
+ 
+ 
+-enum {
++typedef enum {
+   GPU_INST_STALL_ANY                   = 0
+ } gpu_inst_stall_all_t;
+ 

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -113,12 +113,8 @@ class Hpctoolkit(AutotoolsPackage):
     conflicts('^binutils@2.35:2.35.1',
               msg='avoid binutils 2.35 and 2.35.1 (spews errors)')
 
-    # Fixes multiple definition error with GCC 10.
-    # https://github.com/HPCToolkit/hpctoolkit/issues/309
-    patch('https://github.com/blue42u/hpctoolkit/commit/'
-          'b3f6f9e4846d9256cf0d841465ff89d78c6bf422.patch',
-          when='%gcc@10',
-          sha256='f8507c3ce9672c70c2db9f9deb5766c8120ea06e20866d0f553a17866e810b91')
+    # Fix the build for old revs with gcc 10.x.
+    patch('gcc10-enum.patch', when='@2020.01.01:2020.08.99 %gcc@10.0:')
 
     flag_handler = AutotoolsPackage.build_system_flags
 


### PR DESCRIPTION
PR #22864 added a patch to hpctoolkit to fix an issue with gcc 10.x,
and the patch was applied to all revs unconditionally.  But this was
fixed in hpctoolkit master on Aug 11, 2020, so the patch should only
apply to old revs.

Fixes #22951.