### PR TITLE
Clean up DiHydrogen and Hydrogen interaction with Aluminum

### DIFF
--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -62,8 +62,9 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
 
     # Specify the correct version of Aluminum
     depends_on('aluminum@0.4:0.4.99', when='@0.1:0.1.99 +al')
-    depends_on('aluminum@0.5.0:0.7.99', when='@0.2.0:0.2.1 +al')
-    depends_on('aluminum@0.5.0:', when='@:0.0,0.2.1: +al')
+    depends_on('aluminum@0.5.0:0.5.99', when='@0.2.0 +al')
+    depends_on('aluminum@0.7.0:0.7.99', when='@0.2.1 +al')
+    depends_on('aluminum@0.7.0:', when='@:0.0,0.2.1: +al')
 
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +ht +cuda_rma', when='+al +cuda')
@@ -155,17 +156,6 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
                 args.append('-DCMAKE_CUDA_STANDARD=17')
             else:
                 args.append('-DCMAKE_CUDA_STANDARD=14')
-
-            cuda_arch = spec.variants['cuda_arch'].value
-            if len(cuda_arch) == 1 and cuda_arch[0] == 'auto':
-                args.append('-DCMAKE_CUDA_FLAGS=-arch=sm_60')
-            else:
-                cuda_arch = [x for x in spec.variants['cuda_arch'].value
-                             if x != 'auto']
-                if cuda_arch:
-                    args.append('-DCMAKE_CUDA_FLAGS={0}'.format(
-                        ' '.join(self.cuda_flags(cuda_arch))
-                    ))
 
         if '+cuda' in spec or '+distconv' in spec:
             args.append('-DcuDNN_DIR={0}'.format(

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -92,7 +92,7 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     # Specify the correct version of Aluminum
     depends_on('aluminum@:0.3.99', when='@:1.3.99 +al')
     depends_on('aluminum@0.4:0.4.99', when='@1.4:1.4.99 +al')
-    depends_on('aluminum@0.5.0:0.5.99', when='@1.5.0:1.5.1 +al')
+    depends_on('aluminum@0.6.0:0.6.99', when='@1.5.0:1.5.1 +al')
     depends_on('aluminum@0.7.0:', when='@:1.0,1.5.2: +al')
 
     # Add Aluminum variants


### PR DESCRIPTION
Removed unnecessary code to put values in the cuda_arch flags in
DiHydrogen. These were deprecated when the custom cuda_arch list was
removed.  Also fixed up the Aluminum dependencies for Hydrogen and
DiHydrogen.  Turns out that Aluminum v0.6.0 didn't have a correct
version in CMake and thus the interaction with older versions of
Hydrogen and DiHydrogen needed to be corrected.