### PR TITLE
cc: Add -pipe when possible

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -449,6 +449,16 @@ case "$mode" in
         flags=("${flags[@]}" "${SPACK_LDFLAGS[@]}") ;;
 esac
 
+# Add -pipe for gcc and clang
+case "$SPACK_COMPILER_SPEC" in
+	*gcc*|*clang*)
+		case "$mode" in
+			cc|ccld)
+				flags=("${flags[@]}" "-pipe") ;;
+		esac
+		;;
+esac
+
 # On macOS insert headerpad_max_install_names linker flag
 if [[ ($mode == ld || $mode == ccld) && "$SPACK_SHORT_SPEC" =~ "darwin" ]];
 then


### PR DESCRIPTION
`-pipe` causes the compiler to use pipes instead of temporary files to
communicate between different phases of compilation. This might make a
significant difference on network file systems.

Using `spack_stage` on an NFS home leads to the following differences:
Without `-pipe`:
```
==> m4: Successfully installed m4-1.4.18-g3os2y6zu6esmx5zxt4i5irgfg6cghcp
  Fetch: 0.01s.  Build: 58.44s.  Total: 58.46s.
```
With `-pipe`:
```
==> m4: Successfully installed m4-1.4.18-g3os2y6zu6esmx5zxt4i5irgfg6cghcp
  Fetch: 0.01s.  Build: 51.40s.  Total: 51.42s.
```

Edit: The above numbers were obtained with GCC, it doesn't seem to make much of a difference with Clang for me.