### PR TITLE
qa: install clingo-cffi from pip

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -305,7 +305,21 @@ jobs:
           sudo apt-get -y update
           # Needed for unit tests
           sudo apt-get install -y coreutils gfortran graphviz gnupg2 mercurial
-          sudo apt-get install -y ninja-build patchelf kcov
+          sudo apt-get install -y ninja-build patchelf
+          # Needed for kcov
+          sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev
+          sudo apt-get -y install zlib1g-dev libdw-dev libiberty-dev
+    - name: Install kcov for bash script coverage
+      if: ${{ needs.changes.outputs.with_coverage == 'true' }}
+      env:
+          KCOV_VERSION: 34
+      run: |
+          KCOV_ROOT=$(mktemp -d)
+          wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz
+          tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz
+          mkdir -p ${KCOV_ROOT}/build
+          cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd -
+          make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools codecov coverage clingo

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -293,30 +293,47 @@ jobs:
   clingo-cffi:
     needs: [ validate, style, documentation, changes ]
     runs-on: ubuntu-latest
-    container: spack/github-actions:clingo-cffi
     steps:
-      - name: Run unit tests
-        run: |
-          whoami && echo PWD=$PWD && echo HOME=$HOME && echo SPACK_TEST_SOLVER=$SPACK_TEST_SOLVER
-          python3 -c "import clingo; print(hasattr(clingo.Symbol, '_rep'), clingo.__version__)"
-          git clone https://github.com/spack/spack.git && cd spack
-          git fetch origin ${{ github.ref }}:test-branch
-          git checkout test-branch
-          . share/spack/setup-env.sh
-          spack compiler find
-          spack solve mpileaks%gcc
-          if [ "${{ needs.changes.outputs.with_coverage }}" == "true" ]
-          then
-            coverage run $(which spack) unit-test -v -x
-            coverage combine
-            coverage xml
-          else
-            $(which spack) unit-test -m "not maybeslow" -k "package_sanity"
-          fi
-      - uses: codecov/codecov-action@v1
-        if: ${{ needs.changes.outputs.with_coverage == 'true' }}
-        with:
-          flags: unittests,linux,clingo
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install System packages
+      run: |
+          sudo apt-get -y update
+          # Needed for unit tests
+          sudo apt-get install -y coreutils gfortran graphviz gnupg2 mercurial
+          sudo apt-get install -y ninja-build patchelf kcov
+    - name: Install Python packages
+      run: |
+          pip install --upgrade pip six setuptools codecov coverage clingo
+    - name: Setup git configuration
+      run: |
+          # Need this for the git tests to succeed.
+          git --version
+          . .github/workflows/setup_git.sh
+    - name: Run unit tests (full suite with coverage)
+      if: ${{ needs.changes.outputs.with_coverage == 'true' }}
+      env:
+          COVERAGE: true
+          SPACK_TEST_SOLVER: clingo
+      run: |
+          share/spack/qa/run-unit-tests
+          coverage combine
+          coverage xml
+    - name: Run unit tests (reduced suite without coverage)
+      if: ${{ needs.changes.outputs.with_coverage == 'false' }}
+      env:
+          ONLY_PACKAGES: true
+          SPACK_TEST_SOLVER: clingo
+      run: |
+          share/spack/qa/run-unit-tests
+    - uses: codecov/codecov-action@v1
+      if: ${{ needs.changes.outputs.with_coverage == 'true' }}
+      with:
+        flags: unittests,linux,clingo
   # Run unit tests on MacOS
   build:
     needs: [ validate, style, documentation, changes ]


### PR DESCRIPTION
Clingo has been released yesterday, so there are no more concerns on our CI depending on `pypy.test` for installing the wheel.