### PR TITLE
Disable multithreaded version of zstd by default

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -122,7 +122,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('isl@0.15:0.20', when='@9:9.9 +graphite')
     depends_on('isl@0.15:', when='@10: +graphite')
     depends_on('zlib', when='@6:')
-    depends_on('zstd', when='@10:')
+    # GCC only tries to link with -lzstd but it requires
+    # -pthread too when linking against libzstd.a, so
+    # disable multithreading by default
+    depends_on('zstd ~multithread', when='@10:')
     depends_on('diffutils', type='build')
     depends_on('iconv', when='platform=darwin')
     depends_on('gnat', when='languages=ada')

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -39,6 +39,7 @@ class Zstd(CMakePackage):
     variant('zlib', default=False, description='Build programs with zlib support')
     variant('lzma', default=False, description='Build programs with lzma support')
     variant('lz4', default=False, description='Build programs with zlib support')
+    variant('multithread', default=False, description='Build with pthread support')
 
     conflicts('+zlib', when='~programs', msg="zlib requires programs to be built")
     conflicts('+lzma', when='~programs', msg="lzma requires programs to be built")
@@ -53,5 +54,6 @@ class Zstd(CMakePackage):
             self.define_from_variant('ZSTD_BUILD_PROGRAMS', 'programs'),
             self.define_from_variant('ZSTD_BUILD_STATIC', 'static'),
             self.define_from_variant('ZSTD_BUILD_SHARED', 'shared'),
-            self.define_from_variant('ZSTD_LEGACY_SUPPORT', 'legacy')
+            self.define_from_variant('ZSTD_LEGACY_SUPPORT', 'legacy'),
+            self.define_from_variant('ZSTD_MULTITHREAD_SUPPORT', 'multithread')
         ]

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -39,7 +39,7 @@ class Zstd(CMakePackage):
     variant('zlib', default=False, description='Build programs with zlib support')
     variant('lzma', default=False, description='Build programs with lzma support')
     variant('lz4', default=False, description='Build programs with zlib support')
-    variant('multithread', default=False, description='Build with pthread support')
+    variant('multithread', default=True, description='Build with pthread support')
 
     conflicts('+zlib', when='~programs', msg="zlib requires programs to be built")
     conflicts('+lzma', when='~programs', msg="lzma requires programs to be built")


### PR DESCRIPTION
Previously the makefile didn't enable zstd with pthreads by default, the cmake version does.

Some pieces of software don't expect the threaded version (e.g. gcc@10); they don't work with the static lib as they only add -lzstd not -lzstd -pthread

So let's just disable this by default (also the default on ubuntu, it seems)
