### PR TITLE
Fix GCC with zstd on CentOS 7 where it doesn't consider the lib64 directory

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -464,7 +464,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             options.append('--with-system-zlib')
 
         if 'zstd' in spec:
-            options.append('--with-zstd={0}'.format(spec['zstd'].prefix))
+            options.append('--with-zstd-include={0}'.format(
+                spec['zstd'].headers.directories[0]))
+            options.append('--with-zstd-lib={0}'.format(
+                spec['zstd'].libs.directories[0]))
 
         # Enabling language "jit" requires --enable-host-shared.
         if 'languages=jit' in spec:


### PR DESCRIPTION
Part 2 of fixing GCC with zstd.

On CentOS 7 I'm ending up with `<prefix>/lib64/libzstd.a`, but GCC only considers `<prefix>/lib`.
