### PR TITLE
argobots: changed 'no' into 'none' for variant

### DIFF
--- a/var/spack/repos/builtin/packages/argobots/package.py
+++ b/var/spack/repos/builtin/packages/argobots/package.py
@@ -29,8 +29,8 @@ class Argobots(AutotoolsPackage):
     variant("valgrind", default=False, description="Enable Valgrind")
     variant("debug", default=False, description="Compiled with debugging symbols")
     variant("stackunwind", default=False, description="Enable function stack unwinding")
-    variant("stackguard", default="no", description="Enable stack guard",
-            values=('no', 'canary-32', 'mprotect', 'mprotect-strict'), multi=False)
+    variant("stackguard", default="none", description="Enable stack guard",
+            values=('none', 'canary-32', 'mprotect', 'mprotect-strict'), multi=False)
     variant("tool", default=False, description="Enable ABT_tool interface")
     variant("affinity", default=False, description="Enable affinity setting")
 

--- a/var/spack/repos/builtin/packages/argobots/package.py
+++ b/var/spack/repos/builtin/packages/argobots/package.py
@@ -61,7 +61,7 @@ class Argobots(AutotoolsPackage):
             args.append('--with-libunwind={0}'.format(self.spec['libunwind'].prefix))
 
         stackguard = self.spec.variants['stackguard'].value
-        if stackguard != 'no':
+        if stackguard != 'none':
             args.append('--enable-stack-overflow-check={0}'.format(stackguard))
 
         if '+tool' in self.spec:


### PR DESCRIPTION
This PR fixes a problem (see https://github.com/spack/spack/issues/23168) introduced by a recent change to the Argobots package (https://github.com/spack/spack/pull/23133). The PR replaces the value `no` with `none` for the `stackguard` variant, as `no` seems to produce a faulty behavior from Spack.

@shintaro-iwasaki