### PR TITLE
only apply boostrap-toolset.patch for version 1.75

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -270,7 +270,7 @@ class Boost(Package):
     # Fix B2 bootstrap toolset during installation
     # See https://github.com/spack/spack/issues/20757
     # and https://github.com/spack/spack/pull/21408
-    patch("bootstrap-toolset.patch", when="@1.75:")
+    patch("bootstrap-toolset.patch", when="@1.75")
 
     def patch(self):
         # Disable SSSE3 and AVX2 when using the NVIDIA compiler


### PR DESCRIPTION
To address issue mentioned in #23118

`1 out of 1 hunk FAILED -- saving rejects to file bootstrap.sh.rej ==> Patch /usr/WS2/lee218/src/spack/var/spack/repos/builtin/packages/boost/bootstrap-toolset.patch failed. ==> Error: ProcessError: Command exited with status 1: '/usr/bin/patch' '-s' '-p' '1' '-i' '/usr/WS2/lee218/src/spack/var/spack/repos/builtin/packages/boost/bootstrap-toolset.patch' '-d' '.'`