### PR TITLE
fontconfig: resolve tarball issue fcobjshash.h

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -23,6 +23,12 @@ class Fontconfig(AutotoolsPackage):
     depends_on('font-util')
     depends_on('uuid', when='@2.13.1:')
 
+    # Resolve known issue with tarballs 2.12.3 - 2.13.0 plus
+    # https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/10
+    @run_before('configure')
+    def _rm_offending_header(self):
+        force_remove(join_path('src', 'fcobjshash.h'))
+
     def configure_args(self):
         font_path = join_path(self.spec['font-util'].prefix, 'share', 'fonts')
 


### PR DESCRIPTION
Fixes #23189 

The software tarballs for several versions of the package are known to ship with an extraneous header file -- `src/fcobjshash.h` -- that gets generated.  The work-around reported at https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/10 is to delete the file before (re-) running configure.

This PR force-removes the file if it exists.  I have confirmed it resolves the aforementioned build issue.
