### PR TITLE
Specs: support string variants with implied boolean values in YAML 1.1

### DIFF
--- a/lib/spack/external/ruamel/yaml/loader.py
+++ b/lib/spack/external/ruamel/yaml/loader.py
@@ -40,14 +40,14 @@ class SafeLoader(Reader, Scanner, Parser, Composer, SafeConstructor, Resolver):
         Resolver.__init__(self)
 
 
-class Loader(Reader, Scanner, Parser, Composer, Constructor, Resolver):
+class Loader(Reader, Scanner, Parser, Composer, Constructor, VersionedResolver):
     def __init__(self, stream, version=None, preserve_quotes=None):
         Reader.__init__(self, stream)
         Scanner.__init__(self)
         Parser.__init__(self)
         Composer.__init__(self)
         Constructor.__init__(self)
-        Resolver.__init__(self)
+        VersionedResolver.__init__(self)
 
 
 class RoundTripLoader(Reader, RoundTripScanner, RoundTripParser, Composer,

--- a/lib/spack/spack/test/spack_yaml.py
+++ b/lib/spack/spack/test/spack_yaml.py
@@ -8,6 +8,7 @@
 import pytest
 
 import spack.util.spack_yaml as syaml
+import spack
 
 
 @pytest.fixture()
@@ -89,3 +90,9 @@ def test_yaml_aliases():
 
     # ensure no YAML aliases appear in syaml dumps.
     assert '*id' not in string
+
+
+def test_yaml_1_1_implied_booleans(config, mock_packages):
+    spec = spack.spec.Spec('implied-boolean v1=no').concretized()
+    reconstituted = spack.spec.Spec.from_yaml(spec.to_yaml())
+    assert spec == reconstituted

--- a/var/spack/repos/builtin.mock/packages/implied-boolean/package.py
+++ b/var/spack/repos/builtin.mock/packages/implied-boolean/package.py
@@ -7,7 +7,10 @@ from spack import *
 
 
 class ImpliedBoolean(AutotoolsPackage):
-    """Simple package with one optional dependency"""
+    """This package declares a single-valued variant where one of the
+       possible values is interpreted as a boolean in YAML 1.1. This is
+       used to test Spec conversions to/from YAML.
+    """
 
     homepage = "http://www.example.com"
     url      = "http://www.example.com/a-1.0.tar.gz"

--- a/var/spack/repos/builtin.mock/packages/implied-boolean/package.py
+++ b/var/spack/repos/builtin.mock/packages/implied-boolean/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class ImpliedBoolean(AutotoolsPackage):
+    """Simple package with one optional dependency"""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/a-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    variant("v1", default="no",
+            description="One choice is an implied boolean value in YAML 1.1",
+            values=('no', 'foo1', 'foo2', 'foo3'), multi=False)
+
+    def install(self, spec, prefix):
+        pass


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/23168

As of d670f3aa409, the following fails:

```
x = Spec('argobots')
x.concretize()
y = Spec.from_yaml(x.to_yaml())
print(str(x))
print(str(y))
```

Yielding

```
argobots@1.1%apple-clang@10.0.1~affinity~debug+perf~stackunwind~tool~valgrind stackguard=no arch=darwin-mojave-skylake
argobots@1.1%apple-clang@10.0.1~affinity~debug+perf~stackguard~stackunwind~tool~valgrind arch=darwin-mojave-skylake
```

the `stackguard` variant has been interpreted as a boolean variant when read back. This is because we use different overall strategies to `dump` vs. `load`: `syaml.dump` uses `RoundTripDumper`, which defaults to YAML 1.2 specification implicit values (so a string value like "no" doesn't get interpreted as a boolean false value, and therefore is not enclosed in quotes) while `Spec.from_yaml` (and `syaml.load`) does not. This backports 0.12.17 fix (we use 0.11.15, the last version supporting Python 2.6) that uses YAML version 1.2 rules for default loader used by `ruamel.yaml.load`.

Another possible fix is to enclose all string values in quotes: this would change the hashes of all current specs (this solution doesn't).

TODOs

- [x] Add test