### PR TITLE
mpich: post-configure patch for cce

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -190,6 +190,17 @@ spack package at this time.''',
     # see https://github.com/pmodels/mpich/pull/5031
     conflicts('%clang@:7', when='@3.4:')
 
+    @run_after('configure')
+    def patch_cce(self):
+        # Configure misinterprets output from the cce compiler
+        # Patching configure instead should be possible, but a first
+        # implementation failed in obscure ways that were not worth
+        # tracking down when this worked
+        if self.spec.satisfies('%cce'):
+            filter_file('-L -L', '', 'config.lt', string=True)
+            filter_file('-L -L', '', 'libtool', string=True)
+            filter_file('-L -L', '', 'config.status', string=True)
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)(output=str, error=str)


### PR DESCRIPTION
The cce fortran compiler outputs `-L /path/to/foo` flags with a space between them. The configure script for `mpich` parses these flags incorrectly, leading to a blank `-L` flag on the compile line which causes an error.

This could be resolved by patching pre-configure, but I was unable to make such a patch work and resorted to a post-configure patch.