### PR TITLE
specs: Add an abstraction to keep track of all known concrete specs

### DIFF
--- a/lib/spack/spack/concrete_specs.py
+++ b/lib/spack/spack/concrete_specs.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import llnl.util.lang
+import llnl.util.tty as tty
 
 
 class ConcreteSpecRegistry(object):
@@ -19,17 +20,29 @@ class ConcreteSpecRegistry(object):
         import spack.environment as ev
         import spack.store
 
+        tty.debug('ConcreteSpecRegistry: populating')
+        tty.debug('  db specs:')
         for key, spec in spack.store.db.all_specs():
+            tty.debug('    {0} -> {1}'.format(key, spec.name))
             self._registry[key] = spec
 
+        tty.debug('  buildcache specs:')
         bindist.binary_index.update()
         for spec in bindist.binary_index.get_all_built_specs():
+            tty.debug('    {0} -> {1}'.format(spec.dag_hash(), spec.name))
             self._registry[spec.dag_hash()] = spec
 
         active_env = ev.get_env(None, None)
         if active_env:
+            tty.debug('  environment specs:')
             for s in active_env.all_specs():
+                tty.debug('    {0} -> {1}'.format(s.dag_hash(), s.name))
                 self._registry[s.dag_hash()] = s
+
+    def clear(self):
+        # Seems to be needed by testing infrastructure so we are
+        # forced to repopulate with relevant specs.
+        self._registry = {}
 
     def get_by_hash(self, dag_hash):
         if not self._registry:

--- a/lib/spack/spack/concrete_specs.py
+++ b/lib/spack/spack/concrete_specs.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import llnl.util.lang
+
+
+class ConcreteSpecRegistry(object):
+    """
+    The ConcreteSpecRegistry is just a dictionary containing all known
+    concrete specs ever seen by spack, keyed by dag hash.
+    """
+    def __init__(self):
+        self._registry = {}
+
+    def populate(self):
+        import spack.binary_distribution as bindist
+        import spack.environment as ev
+        import spack.store
+
+        for key, spec in spack.store.db.all_specs():
+            self._registry[key] = spec
+
+        bindist.binary_index.update()
+        for spec in bindist.binary_index.get_all_built_specs():
+            self._registry[spec.dag_hash()] = spec
+
+        active_env = ev.get_env(None, None)
+        if active_env:
+            for s in active_env.all_specs():
+                self._registry[s.dag_hash()] = s
+
+    def get_by_hash(self, dag_hash):
+        if not self._registry:
+            self.populate()
+
+        matches = [spec for h, spec in self._registry.items()
+                   if h.startswith(dag_hash)]
+
+        return matches
+
+
+def _specs():
+    return ConcreteSpecRegistry()
+
+
+specs = llnl.util.lang.Singleton(_specs)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -394,6 +394,10 @@ class Database(object):
 
         self._record_fields = record_fields
 
+    def all_specs(self):
+        with self.read_transaction():
+            return [(h_key, rec.spec) for h_key, rec in self._data.items()]
+
     def write_transaction(self):
         """Get a write lock context manager for use in a `with` block."""
         return self._write_transaction_impl(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -97,6 +97,7 @@ import spack.paths
 import spack.architecture
 import spack.compiler
 import spack.compilers as compilers
+import spack.concrete_specs
 import spack.config
 import spack.dependency as dp
 import spack.error
@@ -4586,7 +4587,7 @@ class SpecParser(spack.parse.Parser):
         self.expect(ID)
 
         dag_hash = self.token.value
-        matches = spack.store.db.get_by_hash(dag_hash)
+        matches = spack.concrete_specs.specs.get_by_hash(dag_hash)
         if not matches:
             raise NoSuchHashError(dag_hash)
 
@@ -4922,7 +4923,7 @@ class InvalidHashError(spack.error.SpecError):
 class NoSuchHashError(spack.error.SpecError):
     def __init__(self, hash):
         super(NoSuchHashError, self).__init__(
-            "No installed spec matches the hash: '%s'"
+            "No known spec matches the hash: '%s'"
             % hash)
 
 

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -483,7 +483,8 @@ def test_generate_indices_exception(monkeypatch, capfd):
     assert expect in err
 
 
-@pytest.mark.usefixtures('mock_fetch', 'install_mockery')
+@pytest.mark.usefixtures(
+    'mock_fetch', 'install_mockery', 'clear_concrete_spec_registry')
 def test_update_sbang(tmpdir, test_mirror):
     """Test the creation and installation of buildcaches with default rpaths
     into the non-default directory layout scheme, triggering an update of the

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -732,7 +732,8 @@ spack:
                     reason='This test requires gpg')
 def test_push_mirror_contents(tmpdir, mutable_mock_env_path, env_deactivate,
                               install_mockery, mock_packages, mock_fetch,
-                              mock_stage, mock_gnupghome):
+                              mock_stage, mock_gnupghome,
+                              clear_concrete_spec_registry):
     working_dir = tmpdir.join('working_dir')
 
     mirror_dir = working_dir.join('mirror')

--- a/lib/spack/spack/test/cmd/uninstall.py
+++ b/lib/spack/spack/test/cmd/uninstall.py
@@ -81,7 +81,8 @@ def test_force_uninstall_spec_with_ref_count_not_zero(
 
 
 @pytest.mark.db
-def test_force_uninstall_and_reinstall_by_hash(mutable_database):
+def test_force_uninstall_and_reinstall_by_hash(
+        mutable_database, clear_concrete_spec_registry):
     """Test forced uninstall and reinstall of old specs."""
     # this is the spec to be removed
     callpath_spec = spack.store.db.query_one('callpath ^mpich')

--- a/lib/spack/spack/test/cmd/verify.py
+++ b/lib/spack/spack/test/cmd/verify.py
@@ -65,7 +65,8 @@ def test_single_file_verify_cmd(tmpdir):
 
 
 def test_single_spec_verify_cmd(tmpdir, mock_packages, mock_archive,
-                                mock_fetch, config, install_mockery):
+                                mock_fetch, config, install_mockery,
+                                clear_concrete_spec_registry):
     # Test the verify command interface to verify a single spec
     install('libelf')
     s = spack.spec.Spec('libelf').concretized()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1105,7 +1105,8 @@ class TestConcretize(object):
     ])
     @pytest.mark.xfail()
     def test_reuse_installed_packages(
-            self, context, mutable_database, repo_with_changing_recipe
+            self, context, mutable_database, repo_with_changing_recipe,
+            clear_concrete_spec_registry
     ):
         # Install a spec
         root = Spec('root').concretized()

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -24,6 +24,7 @@ from llnl.util.filesystem import mkdirp, remove_linked_tree
 import spack.architecture
 import spack.compilers
 import spack.config
+import spack.concrete_specs
 import spack.caches
 import spack.database
 import spack.directory_layout
@@ -733,6 +734,20 @@ def mock_fetch(mock_archive, monkeypatch):
 
     monkeypatch.setattr(
         spack.package.PackageBase, 'fetcher', mock_fetcher)
+
+
+@pytest.fixture()
+def clear_concrete_spec_registry():
+    """Clears the concrete spec registry
+
+    The concrete spec registry (lib/spack/spack/concrete_specs.py) contains
+    a module-level singleton which has a lazy-initialized dictionary mapping
+    DAG hashes to concrete specs.  The initialization happens when the spec
+    parser needs to parse a hash, so any tests that involve parsing cli specs
+    by hash need this fixture.
+    """
+    yield
+    spack.concrete_specs.specs.clear()
 
 
 class MockLayout(object):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -119,7 +119,8 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch):
         pkg.remove_prefix = instance_rm_prefix
 
 
-def test_dont_add_patches_to_installed_package(install_mockery, mock_fetch):
+def test_dont_add_patches_to_installed_package(
+        install_mockery, mock_fetch, clear_concrete_spec_registry):
     dependency = Spec('dependency-install')
     dependency.concretize()
     dependency.package.do_install()
@@ -136,7 +137,8 @@ def test_dont_add_patches_to_installed_package(install_mockery, mock_fetch):
 
 
 def test_installed_dependency_request_conflicts(
-        install_mockery, mock_fetch, mutable_mock_repo):
+        install_mockery, mock_fetch, mutable_mock_repo,
+        clear_concrete_spec_registry):
     dependency = Spec('dependency-install')
     dependency.concretize()
     dependency.package.do_install()

--- a/lib/spack/spack/test/packaging.py
+++ b/lib/spack/spack/test/packaging.py
@@ -41,7 +41,8 @@ def fake_fetchify(url, pkg):
 
 @pytest.mark.skipif(not spack.util.gpg.has_gpg(),
                     reason='This test requires gpg')
-@pytest.mark.usefixtures('install_mockery', 'mock_gnupghome')
+@pytest.mark.usefixtures(
+    'install_mockery', 'mock_gnupghome', 'clear_concrete_spec_registry')
 def test_buildcache(mock_archive, tmpdir):
     # tweak patchelf to only do a download
     pspec = Spec("patchelf")

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -23,6 +23,10 @@ from spack.spec import SpecFilenameError, NoSuchSpecFileError
 from spack.spec import MultipleVersionError
 from spack.variant import DuplicateVariantError
 
+# everything here needs to clear the concrete spec registry when it's done
+pytestmark = [
+    pytest.mark.usefixtures('clear_concrete_spec_registry')
+]
 
 # Sample output for a complex lexing.
 complex_lex = [Token(sp.ID, 'mvapich_foo'),


### PR DESCRIPTION
This is a (maybe naive) first take at teaching spack to recognize all known concrete specs from:

- the active (concrete) environment
- buildcaches in configured mirrors
- the installation database

Similar in spirit to #22503 but considers active concrete environment as well, and searches all three sources listed above simultaneously, rather than sequentially.