### PR TITLE
Minor wordsmithing re `spack add ...`

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -248,7 +248,7 @@ Users can add abstract specs to an Environment using the ``spack add``
 command. The most important component of an Environment is a list of
 abstract specs.
 
-Adding a spec adds to the manifest (the ``spack.yaml`` file) which is
+Adding a spec adds to the manifest (the ``spack.yaml`` file), which is
 used to define the roots of the Environment, but does not affect the
 concrete specs in the lockfile, nor does it install the spec.
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -248,9 +248,9 @@ Users can add abstract specs to an Environment using the ``spack add``
 command. The most important component of an Environment is a list of
 abstract specs.
 
-Adding a spec adds to the manifest (the ``spack.yaml`` file) and to
-the roots of the Environment, but does not affect the concrete specs
-in the lockfile, nor does it install the spec.
+Adding a spec adds to the manifest (the ``spack.yaml`` file) which is
+used to define the roots of the Environment, but does not affect the
+concrete specs in the lockfile, nor does it install the spec.
 
 The ``spack add`` command is environment aware. It adds to the
 currently active environment. All environment aware commands can also


### PR DESCRIPTION
This is as much a question as it is a minor fine-tuning of the docs.  I've been known to add things to an environment by editing the `spack.yaml` file directly.  When I read the previous version of this sentence, I was afraid that `spack add` was actually doing *two* things, modifying the `spack.yaml` and updating something else that defined the roots of the Environment.  A bit of experimentation suggests that editing the `spack.yaml` file is sufficient to change the roots.

If I'm correct, this version of the sentence is a bit more explicit.