### PR TITLE
Testing fix for lock on github runners

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -264,7 +264,7 @@ class Lock(object):
         self.old_host = self.host
 
         self.pid = os.getpid()
-        self.host = socket.gethostname()
+        self.host = socket.getfqdn()
 
         # write pid, host to disk to sync over FS
         self._file.seek(0)

--- a/lib/spack/spack/test/llnl/util/lock.py
+++ b/lib/spack/spack/test/llnl/util/lock.py
@@ -1192,7 +1192,7 @@ def test_nested_reads(lock_path):
 class LockDebugOutput(object):
     def __init__(self, lock_path):
         self.lock_path = lock_path
-        self.host = socket.gethostname()
+        self.host = socket.getfqdn()
 
     def p1(self, barrier, q1, q2):
         # exchange pids


### PR DESCRIPTION
The previous issue with lock/hostnames is reported to be resolved, e.g., see https://github.com/actions/virtual-environments/issues/3185 and I want to test if it indeed is.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>