### PR TITLE
versions cmd: bugfix, incorrect use of versionlist

### DIFF
--- a/lib/spack/spack/cmd/versions.py
+++ b/lib/spack/spack/cmd/versions.py
@@ -12,7 +12,7 @@ import llnl.util.tty as tty
 
 import spack.cmd.common.arguments as arguments
 import spack.repo
-from spack.version import VersionList, ver
+from spack.version import ver, infinity_versions
 
 description = "list available versions of a package"
 section = "packaging"
@@ -66,7 +66,10 @@ def versions(parser, args):
     if args.new:
         if sys.stdout.isatty():
             tty.msg('New remote versions (not yet checksummed):')
-        highest_safe_version = VersionList(safe_versions).highest_numeric()
+        numeric_safe_versions = list(filter(
+            lambda v: str(v) not in infinity_versions,
+            safe_versions))
+        highest_safe_version = max(numeric_safe_versions)
         remote_versions  = set([ver(v) for v in set(fetched_versions)
                                 if v > highest_safe_version])
     else:

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -6,6 +6,7 @@
 import pytest
 
 from spack.main import SpackCommand
+from spack.version import Version
 
 versions = SpackCommand('versions')
 
@@ -37,12 +38,32 @@ def test_remote_versions_only():
     versions('--remote', 'zlib')
 
 
-@pytest.mark.maybeslow
 @pytest.mark.usefixtures('mock_packages')
-def test_new_versions_only():
+def test_new_versions_only(monkeypatch):
     """Test a package for which new versions should be available."""
+    from spack.pkg.builtin.mock.brillig import Brillig
 
-    versions('--new', 'brillig')
+    def mock_fetch_remote_versions(*args, **kwargs):
+        mock_remote_versions = {
+            # new version, we expect this to be in output:
+            Version('99.99.99'): {},
+            # some packages use '3.2' equivalently to '3.2.0'
+            # thus '3.2.1' is considered to be a new version
+            # and expected in the output also
+            Version('3.2.1'): {},  # new version, we expect this to be in output
+            Version('3.2'): {},
+            Version('1.0.0'): {},
+        }
+        return mock_remote_versions
+    mock_versions = {
+        # already checksummed versions:
+        Version('3.2'): {},
+        Version('1.0.0'): {},
+    }
+    monkeypatch.setattr(Brillig, 'versions', mock_versions)
+    monkeypatch.setattr(Brillig, 'fetch_remote_versions', mock_fetch_remote_versions)
+    v = versions('--new', 'brillig')
+    assert(v.strip(' \n\t') == "99.99.99\n  3.2.1")
 
 
 @pytest.mark.maybeslow


### PR DESCRIPTION
I incorrectly used `VersionList` here (just in order to use `highest_numeric`) but this usage will drop e.g. `1.14.1` from the list if `1.14` is already in there. 

Fixes #23206 