### PR TITLE
cc: fix verbose compiler output

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -139,9 +139,13 @@ case "$command" in
         ;;
 esac
 
-# If any of the arguments below are present, then the mode is vcheck.
-# In vcheck mode, nothing is added in terms of extra search paths or
-# libraries.
+# Look for option to print version (in which case the mode is vcheck). For ld
+# this is -v. For most other compiler binaries it is -V, --version, or
+# -dumpversion. In vcheck mode, nothing is added in terms of extra search paths
+# or libraries.
+# TODO: For the xl compiler, -V indicates verbose output, so we should not
+#  enable vcheck mode for -V when using xl
+#  see https://github.com/spack/spack/pull/23224#discussion_r656450014
 for arg in "$@"; do
     case $arg in
         -v)

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -142,16 +142,17 @@ esac
 # If any of the arguments below are present, then the mode is vcheck.
 # In vcheck mode, nothing is added in terms of extra search paths or
 # libraries.
-if [[ -z $mode ]] || [[ $mode == ld ]]; then
-    for arg in "$@"; do
-        case $arg in
-            -v|-V|--version|-dumpversion)
-                mode=vcheck
-                break
-                ;;
-        esac
-    done
-fi
+for arg in "$@"; do
+    case $arg in
+        -v)
+            [[ $mode == ld ]] && mode=vcheck && break
+            ;;
+        -V|--version|-dumpversion)
+            mode=vcheck
+            break
+            ;;
+    esac
+done
 
 # Finish setting up the mode.
 if [[ -z $mode ]]; then

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -145,7 +145,10 @@ esac
 for arg in "$@"; do
     case $arg in
         -v)
-            [[ $mode == ld ]] && mode=vcheck && break
+            if [[ $mode == ld ]]; then
+                mode=vcheck
+                break
+            fi
             ;;
         -V|--version|-dumpversion)
             mode=vcheck

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -8,10 +8,11 @@ This test checks that the Spack cc compiler wrapper is parsing
 arguments correctly.
 """
 import os
+
 import pytest
 
 from spack.paths import build_env_path
-from spack.util.environment import system_dirs, set_env
+from spack.util.environment import set_env, system_dirs
 from spack.util.executable import Executable
 
 #

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -147,9 +147,10 @@ def dump_mode(cc, args):
 
 
 def test_vcheck_mode():
+    assert dump_mode(cpp, ['-I/include', '--version']) == 'vcheck'
+    assert dump_mode(ld, ['-rpath foo', '-v']) == 'vcheck'
     assert dump_mode(cc, ['-I/include', '--version']) == 'vcheck'
     assert dump_mode(cc, ['-I/include', '-V']) == 'vcheck'
-    assert dump_mode(cc, ['-I/include', '-v']) == 'vcheck'
     assert dump_mode(cc, ['-I/include', '-dumpversion']) == 'vcheck'
     assert dump_mode(cc, ['-I/include', '--version', '-c']) == 'vcheck'
     assert dump_mode(cc, ['-I/include', '-V', '-o', 'output']) == 'vcheck'
@@ -167,6 +168,7 @@ def test_as_mode():
 
 def test_ccld_mode():
     assert dump_mode(cc, []) == 'ccld'
+    assert dump_mode(cc, ['-I/include', '-v']) == 'ccld'
     assert dump_mode(cc, ['foo.c', '-o', 'foo']) == 'ccld'
     assert dump_mode(cc, ['foo.c', '-o', 'foo', '-Wl,-rpath,foo']) == 'ccld'
     assert dump_mode(cc, [


### PR DESCRIPTION
It looks like none of the supported compilers interprets `-v` flag as a request for its version. What is more important is that most of the compilers (except for `xl` and `xl_r`, if I am not mistaken) interpret it as a request for verbose output. Therefore, we should switch to `vcheck` mode when `-v` is present in the command-line arguments only when the linker is called directly (one of the reasons why we should do it for `ld` is explained in #2501). There are at least two reasons why we should not switch to `vcheck` in other cases:
1. The building systems (e.g. CMake and Autotools) often call compilers with `-v` and expect verbose output. In the `vcheck` mode of the compiler wrapper they do not get the real picture: `gcc ./test.c` and `gcc -v ./test.c` might do significantly different things since the compiler wrapper does not inject extra flags in the latter case.
2. I often debug packages with `spack build-env ... -- bash` and it is very annoying that I cannot simply copy/paste the compilation command reported by make, prepend `-v` to the list of command-line arguments and see the real verbose output of the compiler.

This PR should fix the problem. I have two comments on it though:
1. This does not solve the problem for `xl` and `xl_r`. We should have an exception for `-V` too when one of those is in use. However, it looks like that would require more changes and refactoring. We should probably expose `verbose_flag` to the compiler wrapper and switch to `vcheck` mode only if that flag is present in the command-line arguments.
2. It is intended (for the consistency) that the `cpp` mode can now switch to `vcheck` mode too.