### PR TITLE
Adds Paraview 5.9.1-RC1, 5.9.0

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -20,7 +20,8 @@ class Paraview(CMakePackage, CudaPackage):
     maintainers = ['chuckatkins', 'danlipsa', 'vicentebolea']
 
     version('master', branch='master', submodules=True)
-    version('5.9.0', sha256='b03258b7cddb77f0ee142e3e77b377e5b1f503bcabc02bfa578298c99a06980d')
+    version('5.9.0-RC1', sha256='bb3f12bd3d31bcb52455e1393e45f81a18754d3c3e8199d51532b0c067dc1595')
+    version('5.9.0', sha256='b03258b7cddb77f0ee142e3e77b377e5b1f503bcabc02bfa578298c99a06980d', preferred=True)
     version('5.8.1', sha256='7653950392a0d7c0287c26f1d3a25cdbaa11baa7524b0af0e6a1a0d7d487d034')
     version('5.8.0', sha256='219e4107abf40317ce054408e9c3b22fb935d464238c1c00c0161f1c8697a3f9')
     version('5.7.0', sha256='e41e597e1be462974a03031380d9e5ba9a7efcdb22e4ca2f3fec50361f310874')

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -20,7 +20,7 @@ class Paraview(CMakePackage, CudaPackage):
     maintainers = ['chuckatkins', 'danlipsa', 'vicentebolea']
 
     version('master', branch='master', submodules=True)
-    version('5.9.0-RC1', sha256='bb3f12bd3d31bcb52455e1393e45f81a18754d3c3e8199d51532b0c067dc1595')
+    version('5.9.1-RC1', sha256='bb3f12bd3d31bcb52455e1393e45f81a18754d3c3e8199d51532b0c067dc1595')
     version('5.9.0', sha256='b03258b7cddb77f0ee142e3e77b377e5b1f503bcabc02bfa578298c99a06980d', preferred=True)
     version('5.8.1', sha256='7653950392a0d7c0287c26f1d3a25cdbaa11baa7524b0af0e6a1a0d7d487d034')
     version('5.8.0', sha256='219e4107abf40317ce054408e9c3b22fb935d464238c1c00c0161f1c8697a3f9')


### PR DESCRIPTION
Hi there, first release candidate of 5.9.1!

This morning we have just released the latest ParaView version.

I have made that changes in the ParaView Spack package which adds this new version .

I have also set explicitly the preferred version to 5.9.0 so that the default version does not change with this addition.

Note that this is a release candidate.