### PR TITLE
bzip2: add pic/debug options

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -25,6 +25,8 @@ class Bzip2(Package, SourcewarePackage):
     version('1.0.6', sha256='a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd')
 
     variant('shared', default=True, description='Enables the build of shared libraries.')
+    variant('pic', default=False, description='Build static libraries with PIC')
+    variant('debug', default=False, description='Enable debug symbols and disable optimization')
 
     depends_on('diffutils', type='build')
 
@@ -43,7 +45,17 @@ class Bzip2(Package, SourcewarePackage):
             'libbz2', root=self.prefix, shared=shared, recursive=True
         )
 
+    def flag_handler(self, name, flags):
+        if name == 'cflags' and '+pic' in self.spec:
+            flags.append(self.compiler.cc_pic_flag)
+        return(flags, None, None)
+
     def patch(self):
+        if spec.satisfies('+debug'):
+            for makefile in ['Makefile', 'Makefile-libbz2_so']:
+                filter_file(r'-O ', '-O0 ', makefile)
+                filter_file(r'-O2 ', '-O0 ', makefile)
+
         # bzip2 comes with two separate Makefiles for static and dynamic builds
         # Tell both to use Spack's compiler wrapper instead of GCC
         filter_file(r'^CC=gcc', 'CC={0}'.format(spack_cc), 'Makefile')

--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -46,8 +46,11 @@ class Bzip2(Package, SourcewarePackage):
         )
 
     def flag_handler(self, name, flags):
-        if name == 'cflags' and '+pic' in self.spec:
-            flags.append(self.compiler.cc_pic_flag)
+        if name == 'cflags':
+            if '+pic' in self.spec:
+                flags.append(self.compiler.cc_pic_flag)
+            if '+debug' in self.spec:
+                flags.append('-g')
         return(flags, None, None)
 
     def patch(self):


### PR DESCRIPTION
This adds options to:

* Build bzip2 with less optimization (may help with debugging)
* Build static bzip2 libraries with `pic` (shared libs were already built with `pic`)