### PR TITLE
[tau]: Use compiler name instead of basename

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -135,8 +135,8 @@ class Tau(Package):
         compiler_path = os.path.dirname(self.compiler.cc)
         os.environ['PATH'] = ':'.join([compiler_path, os.environ['PATH']])
 
-        compiler_options = ['-c++=%s' % os.path.basename(self.compiler.cxx),
-                            '-cc=%s' % os.path.basename(self.compiler.cc)]
+        compiler_options = ['-c++=%s' % self.compiler.cxx_names[0],
+                            '-cc=%s' % self.compiler.cc_names[0]]
 
         if '+fortran' in spec and self.compiler.fc:
             compiler_options.append('-fortran=%s' % self.compiler.fc_names[0])
@@ -224,6 +224,8 @@ class Tau(Package):
             env['CXX'] = spec['mpi'].mpicxx
             env['F77'] = spec['mpi'].mpif77
             env['FC'] = spec['mpi'].mpifc
+            options.append("-mpiinc=%s" % spec['mpi'].prefix.include)
+            options.append("-mpilib=%s" % spec['mpi'].prefix.lib)
 
             options.append('-mpi')
             if '+comm' in spec:


### PR DESCRIPTION
Previously the tau package got the cxx and cc names from
os.path.basename(self.compiler.cxx), however if the path to the compiler
looks like "/usr/bin/g++-10.2.0" then tau's custom build system doesn't
recognize it.  What we want instead is something that looks like "g++"
which is exactly what cxx_names[0] gives us.  We already did this for
fortran, so I am not sure why we didn't do it here.  Not doing this
causes a build failure when tau tries to use a polyfill (vector.h,
iostream.h) that doesn't seem to be packaged with tau.

Additionally, tau needs some help finding mpi include directories when
building with MPI, so we provide them.  Unfortunately, we can't just say
that the compilers are mpicc and mpicxx in the previous fix to have
these things found automatically.  This is because tau assumes we always
need the polyfill when the compilers are set to these values which again
causes a build failure.

CC maintainers: @eugeneswalker  @khuck  @sameershende  @wspear
@sameershende you did the original change away from `cxx_names[0]`; is there a reason why this was done that I missed?

