### PR TITLE
openfoam: update to OpenFOAM-v2012_210414 (patch release)

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -265,6 +265,7 @@ class Openfoam(Package):
 
     version('develop', branch='develop', submodules='True')
     version('master', branch='master', submodules='True')
+    version('2012_210414', sha256='5260aaa79f91aad58a3a305c1a12d0d48b10f12e37cd99a6fa561969b15ea09d')
     version('2012', sha256='3d6e39e39e7ae61d321fbc6db6c3748e6e5e1c4886454207a7f1a7321469e65a')
     version('2006_201012', sha256='9afb7eee072bfddcf7f3e58420c93463027db2394997ac4c3b87a8b07c707fb0')
     version('2006', sha256='30c6376d6f403985fc2ab381d364522d1420dd58a42cb270d2ad86f8af227edc')
@@ -864,7 +865,8 @@ class OpenfoamArch(object):
 
     #: Map spack compiler names to OpenFOAM compiler names
     #  By default, simply capitalize the first letter
-    compiler_mapping = {'intel': 'Icc', 'fj': 'Fujitsu', 'aocc': 'Amd'}
+    compiler_mapping = {'aocc': 'Amd', 'fj': 'Fujitsu',
+                        'intel': 'Icc', 'oneapi': 'Icx'}
 
     def __init__(self, spec, **kwargs):
         # Some user settings, to be adjusted manually or via variants


### PR DESCRIPTION
- add provision for intel oneapi compiler mapping