### PR TITLE
hypre: Add a variant for unified memory support

### DIFF
--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -60,6 +60,7 @@ class Hypre(Package, CudaPackage):
     variant('openmp', default=False, description='Enable OpenMP support')
     variant('debug', default=False,
             description='Build debug instead of optimized version')
+    variant('unified-memory', default=False, description='Use unified memory')
 
     # Patch to add ppc64le in config.guess
     patch('ibm-ppc64le.patch', when='@:2.11.1')
@@ -177,6 +178,9 @@ class Hypre(Package, CudaPackage):
                 '--disable-curand',
                 '--disable-cub'
             ])
+
+        if '+unified-memory' in self.spec:
+            configure_args.append('--enable-unified-memory')
 
         return configure_args
 

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -80,6 +80,7 @@ class Hypre(Package, CudaPackage):
     depends_on('superlu-dist', when='+superlu-dist+mpi')
 
     conflicts('+cuda', when='+int64')
+    conflicts('+unified-memory', when='~cuda')
 
     # Patch to build shared libraries on Darwin does not apply to
     # versions before 2.13.0


### PR DESCRIPTION
Hypre has a configuration option for unified memory support (https://hypre.readthedocs.io/en/latest/ch-misc.html#gpu-build). This PR exposed that as a Spack variant.