### PR TITLE
kvtree: updated checksums

### DIFF
--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -17,10 +17,10 @@ class Kvtree(CMakePackage):
     tags = ['ecp']
 
     version('master', branch='master')
-    version('1.1.1', sha256='e3c652fa69e6f31da48fab57c302a9deb3e33ea41f96b6b4480a78eeb71e7659')
-    version('1.1.0', sha256='34182f8e6c8f3c089376579cce3d18cfd93b59caf83649b204ed8456ac97400f')
-    version('1.0.3', sha256='b892cf6c270ca6c15c0a816549bd5f8575a9ad2fca287d36e1116bd4cfe5c391')
-    version('1.0.2', sha256='6b54f4658e5ebab747c0c2472b1505ac1905eefc8a0b2a97d8776f800ee737a3')
+    version('1.1.1', sha256='4776bd55a559b7f9bb594454ae6b14ebff0087c93c3d59ac7d1ab27df4aa4d74')
+    version('1.1.0', sha256='3e6c003e7b8094d7c2d1529a973d68a68f953ffa63dcde5f4c7c7e81ddf06564')
+    version('1.0.3', sha256='c742cdb1241ef4cb13767019204d5350a3c4383384bed9fb66680b93ff44b0d4')
+    version('1.0.2', sha256='56fb5b747758c24a907a8380e8748d296900d94de9547bc15f6b427ac4ae2ec4')
 
     variant('mpi', default=True, description="Build with MPI message packing")
     depends_on('mpi', when='+mpi')


### PR DESCRIPTION
The remote checksum for `kvtree@1.1.1` changed.

Kinda sketch that the checksum on a versioned release tarball would change -- Anyone know about this?

@CamStan @frankwillmore 