### PR TITLE
bugfix: `spack find -p --bootstrap` reports incorrect paths

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -638,7 +638,7 @@ class Database(object):
         Does not do any locking.
         """
         spec_dict = installs[hash_key]['spec']
-        spec_path = installs[hash_key]['path']
+        spec_path = installs[hash_key].get('path', None)
         # Install records don't include hash with spec, so we add it in here
         # to ensure it is read properly.
         for name in spec_dict:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -638,7 +638,7 @@ class Database(object):
         Does not do any locking.
         """
         spec_dict = installs[hash_key]['spec']
-
+        spec_path = installs[hash_key]['path']
         # Install records don't include hash with spec, so we add it in here
         # to ensure it is read properly.
         for name in spec_dict:
@@ -646,6 +646,10 @@ class Database(object):
 
         # Build spec from dict first.
         spec = spack.spec.Spec.from_node_dict(spec_dict)
+
+        # Make sure prefix doesn't change
+        if spec_path and spec_path != 'None':
+            spec.prefix = spec_path
         return spec
 
     def db_for_spec_hash(self, hash_key):


### PR DESCRIPTION
problem: if you read a spec from the bootstrap db and don't query the prefix until after swapping back to the normal store, the spec reports a prefix from the normal store

solution: attach db record paths to specs at read time, so the prefix method will not fall back on spack.store.layout ever for specs read from a database.