### PR TITLE
Package hdf5 compilation with szip when LD_LIBRARY_PATH is set

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -166,7 +166,7 @@ class Hdf5(AutotoolsPackage):
             'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
             'fortran/src/H5Fff_F03.f90',
             string=True, ignore_absent=True)
-
+            
     filter_compiler_wrappers('h5cc', 'h5c++', 'h5fc', relative_root='bin')
 
     def url_for_version(self, version):
@@ -335,6 +335,15 @@ class Hdf5(AutotoolsPackage):
 
         return extra_args
 
+    @run_after('configure')
+    def patch_makefile(self):
+        with working_dir('examples'):
+            filter_file(
+                'LD_LIBRARY_PATH =',
+                '#LD_LIBRARY_PATH :=',
+                'Makefile',
+            string=True, ignore_absent=True)
+ 
     @run_after('configure')
     def patch_postdeps(self):
         if '@:1.8.14' in self.spec:

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -166,7 +166,7 @@ class Hdf5(AutotoolsPackage):
             'INTEGER(SIZE_T), INTENT(OUT) :: buf_size',
             'fortran/src/H5Fff_F03.f90',
             string=True, ignore_absent=True)
-            
+
     filter_compiler_wrappers('h5cc', 'h5c++', 'h5fc', relative_root='bin')
 
     def url_for_version(self, version):
@@ -342,8 +342,8 @@ class Hdf5(AutotoolsPackage):
                 'LD_LIBRARY_PATH =',
                 '#LD_LIBRARY_PATH :=',
                 'Makefile',
-            string=True, ignore_absent=True)
- 
+                string=True, ignore_absent=True)
+
     @run_after('configure')
     def patch_postdeps(self):
         if '@:1.8.14' in self.spec:


### PR DESCRIPTION
This solves the issue #23283.
This is a workaround since the recursive variable setting (LL_PATH set from LD_LIBRARY_PATH and then LD_LIBRARY_PATH set from LL_PATH) is due to the configure script.
Also, there might be smarter ways to correct that.