### PR TITLE
mesa18: depends on binutils+plugins for build

### DIFF
--- a/var/spack/repos/builtin/packages/mesa18/package.py
+++ b/var/spack/repos/builtin/packages/mesa18/package.py
@@ -28,7 +28,7 @@ class Mesa18(AutotoolsPackage):
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
     depends_on('pkgconfig', type='build')
-    depends_on('binutils', when=(sys.platform != 'darwin'), type='build')
+    depends_on('binutils+plugins', when=(sys.platform != 'darwin'), type='build')
     depends_on('bison', type='build')
     depends_on('flex', type='build')
     depends_on('gettext', type='build')


### PR DESCRIPTION
I think `mesa18` needs `binutils+plugins` -- it's not building for me otherwise. Can someone check me on this?

Here's the error I see when trying to build `mesa18 ^binutils~plugins`:

Concrete spec: [mesa18-kgrn2o.spec.yaml.txt](https://github.com/spack/spack/files/6385826/mesa18-kgrn2o.spec.yaml.txt)
Container used: `ecpe4s/ubuntu20.04-runner-x86_64:2021-03-10`

```
$> spack install -f ./mesa18-kgrn2o.spec.yaml
...
==> Installing mesa18-18.3.6-kgrn2ooedrobqfri4ehkcfr6hyumensd
==> Using cached archive: /spack/var/spack/cache/_source-cache/git//mesa/mesa.git/mesa-18.3.6.tar.gz
==> Warning: Fetching from mirror without a checksum!
  This package is normally checked out from a version control system, but it has been archived on a spack mirror.  This means we cannot know a checksum for the tarball in advance. Be sure that your connection to this mirror is secure!
==> Applied patch /spack/var/spack/repos/builtin/packages/mesa18/autotools-x11-nodri.patch
==> mesa18: Executing phase: 'autoreconf'
==> mesa18: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 77:
    '/tmp/root/spack-stage/spack-stage-mesa18-18.3.6-kgrn2ooedrobqfri4ehkcfr6hyumensd/spack-src/configure' '--prefix=/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/mesa18-18.3.6-kgrn2ooedrobqfri4ehkcfr6hyumensd' 'LDFLAGS=-L/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/ncurses-6.2-n5vhymfigwg6e45k7thdfyeswuhxojtx/lib' '--enable-shared' '--disable-static' '--disable-libglvnd' '--disable-nine' '--disable-omx-bellagio' '--disable-omx-tizonia' '--disable-opencl' '--disable-opencl-icd' '--disable-va' '--disable-vdpau' '--disable-xa' '--disable-xvmc' '--disable-osmesa' '--with-vulkan-drivers=' '--disable-egl' '--disable-gbm' '--disable-dri' '--enable-opengl' '--enable-gallium-osmesa' '--enable-glx=gallium-xlib' '--disable-gles1' '--disable-gles2' '--enable-shared-glapi' '--disable-llvm' '--with-platforms=x11' '--with-gallium-drivers=swrast' '--with-dri-drivers='

2 errors found in build log:
     41    checking whether GID '0' is supported by ustar format... yes
     42    checking how to create a ustar tar archive... gnutar
     43    checking whether make supports nested variables... (cached) yes
     44    checking whether make supports the include directive... yes (GNU style)
     45    checking for gcc... /spack/lib/spack/env/gcc/gcc
     46    checking whether the C compiler works... no
  >> 47    configure: error: in `/tmp/root/spack-stage/spack-stage-mesa18-18.3.6-kgrn2ooedrobqfri4ehkcfr6hyumensd/spack-src':
  >> 48    configure: error: C compiler cannot create executables
     49    See `config.log' for more details

See build log for details:
  /tmp/root/spack-stage/spack-stage-mesa18-18.3.6-kgrn2ooedrobqfri4ehkcfr6hyumensd/spack-build-out.txt
```

Config.log excerpt:
```
configure:4697: checking whether the C compiler works
configure:4719: /spack/lib/spack/env/gcc/gcc   -L/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/ncurses-6.2-n5vhymfigwg6e45k7thdfyeswuhxojtx/lib conftest.c  >&5
/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/binutils-2.33.1-anrzgmmeofq33lbws3zhrmblqxjhjnum/bin/ld: fatal error: cannot use --plugin: /spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/binutils-2.33.1-anrzgmmeofq33lbws3zhrmblqxjhjnum/bin/ld was compiled without plugin support
collect2: error: ld returned 1 exit status
configure:4723: $? = 1
configure:4761: result: no
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "Mesa"
| #define PACKAGE_TARNAME "mesa"
| #define PACKAGE_VERSION "18.3.6"
| #define PACKAGE_STRING "Mesa 18.3.6"
| #define PACKAGE_BUGREPORT "https://bugs.freedesktop.org/enter_bug.cgi?product=Mesa"
| #define PACKAGE_URL ""
| #define PACKAGE "mesa"
| #define VERSION "18.3.6"
| /* end confdefs.h.  */
|
| int
| main ()
| {
|
|   ;
|   return 0;
| }
configure:4766: error: in `/tmp/root/spack-stage/spack-stage-mesa18-18.3.6-kgrn2ooedrobqfri4ehkcfr6hyumensd/spack-src':
configure:4768: error: C compiler cannot create executables
See `config.log' for more details
```

Thoughts?

@chuckatkins @v-dobrev @ChristianTackeGSI 