### PR TITLE
Don't report configure errors to CDash for successful packages

### DIFF
--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -743,6 +743,25 @@ def test_cdash_auth_token(tmpdir, install_mockery, capfd):
             assert 'Using CDash auth token from environment' in out
 
 
+@pytest.mark.disable_clean_stage_check
+def test_cdash_configure_warning(tmpdir, mock_fetch, install_mockery, capfd):
+    # capfd interferes with Spack's capturing of e.g., Build.xml output
+    with capfd.disabled():
+        with tmpdir.as_cwd():
+            # Test would fail if install raised an error.
+            install(
+                '--log-file=cdash_reports',
+                '--log-format=cdash',
+                'configure-warning')
+            # Verify Configure.xml exists with expected contents.
+            report_dir = tmpdir.join('cdash_reports')
+            assert report_dir in tmpdir.listdir()
+            report_file = report_dir.join('Configure.xml')
+            assert report_file in report_dir.listdir()
+            content = report_file.open().read()
+            assert 'foo: No such file or directory' in content
+
+
 def test_compiler_bootstrap(
         install_mockery_mutable_config, mock_packages, mock_fetch,
         mock_archive, mutable_config, monkeypatch):

--- a/var/spack/repos/builtin.mock/packages/configure-warning/package.py
+++ b/var/spack/repos/builtin.mock/packages/configure-warning/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class ConfigureWarning(AutotoolsPackage):
+    """This package prints output that looks like an error during configure, but
+       it actually installs successfully."""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/configure-warning-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    parallel = False
+
+    def autoreconf(self, spec, prefix):
+        pass
+
+    def configure(self, spec, prefix):
+        print('foo: No such file or directory')
+        return 0
+
+    def build(self, spec, prefix):
+        pass
+
+    def install(self, spec, prefix):
+        # sanity_check_prefix requires something in the install directory
+        # Test requires overriding the one provided by `AutotoolsPackage`
+        mkdirp(prefix.bin)


### PR DESCRIPTION
Convert configure errors detected by our log scraper into warnings when
the package being installed reports that it was successful.