### PR TITLE
Import compilers using Python's built-in machinery

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -24,11 +24,10 @@ import spack.spec
 import spack.config
 import spack.compiler
 import spack.architecture
-import spack.util.imp as simp
+
 from spack.util.environment import get_path
 from spack.util.naming import mod_to_class
 
-_imported_compilers_module = 'spack.compilers'
 _path_instance_vars = ['cc', 'cxx', 'f77', 'fc']
 _flags_instance_vars = ['cflags', 'cppflags', 'cxxflags', 'fflags']
 _other_instance_vars = ['modules', 'operating_system', 'environment',
@@ -472,17 +471,17 @@ def get_compiler_duplicates(compiler_spec, arch_spec):
 @llnl.util.lang.memoized
 def class_for_compiler_name(compiler_name):
     """Given a compiler module name, get the corresponding Compiler class."""
-    assert(supported(compiler_name))
+    assert supported(compiler_name)
 
     # Hack to be able to call the compiler `apple-clang` while still
     # using a valid python name for the module
-    module_name = compiler_name
+    submodule_name = compiler_name
     if compiler_name == 'apple-clang':
-        module_name = compiler_name.replace('-', '_')
+        submodule_name = compiler_name.replace('-', '_')
 
-    file_path = os.path.join(spack.paths.compilers_path, module_name + ".py")
-    compiler_mod = simp.load_source(_imported_compilers_module, file_path)
-    cls = getattr(compiler_mod, mod_to_class(compiler_name))
+    module_name = '.'.join(['spack', 'compilers', submodule_name])
+    module_obj = __import__(module_name, fromlist=[None])
+    cls = getattr(module_obj, mod_to_class(compiler_name))
 
     # make a note of the name in the module so we can get to it easily.
     cls.name = compiler_name


### PR DESCRIPTION
To retrieve the correct classes from a given compiler name we can use Python `__import__` function instead of our own function that loads a module from a file and binds it to an arbitrary name.