### PR TITLE
patch: Escape URLPatch names

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -292,7 +292,15 @@ class URLFetchStrategy(FetchStrategy):
 
     @property
     def candidate_urls(self):
-        return [self.url] + (self.mirrors or [])
+        urls = []
+
+        for url in [self.url] + (self.mirrors or []):
+            if url.startswith('file://'):
+                path = urllib_parse.quote(url[len('file://'):])
+                url = 'file://' + path
+            urls.append(url)
+
+        return urls
 
     @_needs_stage
     def fetch(self):


### PR DESCRIPTION
When trying to set up a mirror, URLPatches containing special characters can fail in surprising ways. For instance:

```console
$ spack mirror add local file://$PWD/mirror
$ mkdir mirror
$ spack mirror create -d mirror autoconf@2.70
==> Adding package autoconf@2.70 to mirror
[...]
==> Fetching file://$SPACK/mirror/autoconf/?id=05972f49ee632cd98057a3caf82ebfb9574846da-eaa3f69

==> Warning: Error while fetching autoconf@2.70
  sha256 checksum failed for $STAGE/spack-stage-elc1z7pd/?id=05972f49ee632cd98057a3caf82ebfb9574846da
```

This seems to be due to `os.path.basename` returning `?id=05972f49ee632cd98057a3caf82ebfb9574846da` for the patch name. curl then returns that the patch already exists because the directory does indeed exist (and the part after `?` is interpreted as a query parameter). This causes Spack to try to fetch the non-existing file.