### PR TITLE
spath: zlib is a link dependency

### DIFF
--- a/var/spack/repos/builtin/packages/spath/package.py
+++ b/var/spack/repos/builtin/packages/spath/package.py
@@ -21,6 +21,7 @@ class Spath(CMakePackage):
 
     variant('mpi', default=True, description="Build with MPI support.")
     depends_on('mpi', when='+mpi')
+    depends_on('zlib', type='link')
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
It looks like `spath` needs `zlib` as a link dep ?

Discovered this because I was trying to build `spath@0.0.2` and wasn't able to because:

```
$> spack install spath
...
1 error found in build log:
...
     24      Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
...
```

@CamStan @gonsie 

