### PR TITLE
Enable +plugins in binutils by default

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -30,7 +30,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     version('2.23.2', sha256='fe914e56fed7a9ec2eb45274b1f2e14b0d8b4f41906a5194eac6883cfe5c1097')
     version('2.20.1', sha256='71d37c96451333c5c0b84b170169fdcb138bbb27397dc06281905d9717c8ed64')
 
-    variant('plugins', default=False,
+    variant('plugins', default=True,
             description="enable plugins, needed for gold linker")
     variant('gold', default=(sys.platform != 'darwin'),
             description="build the gold linker")


### PR DESCRIPTION
fixes #23275

There are many reports of packages failing due to binutils default of ~plugins.

Either concretizer issues (because some packages now depend on binutils+plugins and some just on binutils -- the latter defaults to ~plugins, and the old concretizer is not enough to toggle that) or actual compilation issues.

Previously ~plugins did not map to the --disable-plugins, and you would still get plugins even if you didn't ask for it, so a previous pr just uncovered that a bunch of packages weren't configured properly.

This PR is to make the old concretizer happy, but doesn't solve the actual problem that packages should depend on binutils+plugins if they require plugins.


