### PR TITLE
archspec: updated external dependency

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -11,7 +11,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.1.2 (commit 0389e83e87d3dc5043a7ac08172bd970706524d6)
+* Version: 0.1.2 (commit a15485ab632478c15fadc65a00cd88b75ef7528a)
 
 argparse
 --------

--- a/lib/spack/external/archspec/cpu/detect.py
+++ b/lib/spack/external/archspec/cpu/detect.py
@@ -99,17 +99,29 @@ def sysctl_info_dict():
     def sysctl(*args):
         return _check_output(["sysctl"] + list(args), env=child_environment).strip()
 
-    flags = (
-        sysctl("-n", "machdep.cpu.features").lower()
-        + " "
-        + sysctl("-n", "machdep.cpu.leaf7_features").lower()
-    )
-    info = {
-        "vendor_id": sysctl("-n", "machdep.cpu.vendor"),
-        "flags": flags,
-        "model": sysctl("-n", "machdep.cpu.model"),
-        "model name": sysctl("-n", "machdep.cpu.brand_string"),
-    }
+    if platform.machine() == "x86_64":
+        flags = (
+            sysctl("-n", "machdep.cpu.features").lower()
+            + " "
+            + sysctl("-n", "machdep.cpu.leaf7_features").lower()
+        )
+        info = {
+            "vendor_id": sysctl("-n", "machdep.cpu.vendor"),
+            "flags": flags,
+            "model": sysctl("-n", "machdep.cpu.model"),
+            "model name": sysctl("-n", "machdep.cpu.brand_string"),
+        }
+    else:
+        model = (
+            "m1" if "Apple" in sysctl("-n", "machdep.cpu.brand_string") else "unknown"
+        )
+        info = {
+            "vendor_id": "Apple",
+            "flags": [],
+            "model": model,
+            "CPU implementer": "Apple",
+            "model name": sysctl("-n", "machdep.cpu.brand_string"),
+        }
     return info
 
 

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -1359,9 +1359,24 @@
         "popcnt",
         "clwb",
         "vaes",
-        "vpclmulqdq"
+        "vpclmulqdq",
+        "pku"
       ],
       "compilers": {
+        "gcc": [
+          {
+            "versions": "10.3:",
+            "name": "znver3",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "znver3",
+            "flags": "-march={name} -mtune={name}"
+          }
+        ],
         "aocc": [
           {
             "versions": "3.0:",
@@ -1540,6 +1555,12 @@
           }
         ],
         "clang": [
+          {
+            "versions": ":",
+            "flags": "-march=armv8-a -mtune=generic"
+          }
+        ],
+        "apple-clang": [
           {
             "versions": ":",
             "flags": "-march=armv8-a -mtune=generic"
@@ -1750,6 +1771,31 @@
                   "flags" : "-march=armv8.2-a+fp16+rcpc+dotprod+crypto"
               }
           ]
+      }
+    },
+    "m1": {
+      "from": ["aarch64"],
+      "vendor": "Apple",
+      "features": [],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "8.0:",
+            "flags" : "-march=armv8.4-a -mtune=generic"
+          }
+        ],
+        "clang" : [
+          {
+            "versions": "9.0:",
+            "flags" : "-march=armv8.4-a"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "11.0:",
+            "flags" : "-march=armv8.4-a"
+          }
+        ]
       }
     },
     "arm": {


### PR DESCRIPTION
fixes #22088

Modifications:
- [x] Added initial support for Apple M1
- [x] Extended support for zen3 with more compiler flags