### PR TITLE
bzip2: fix typo in package

### DIFF
--- a/var/spack/repos/builtin/packages/bzip2/package.py
+++ b/var/spack/repos/builtin/packages/bzip2/package.py
@@ -54,7 +54,7 @@ class Bzip2(Package, SourcewarePackage):
         return(flags, None, None)
 
     def patch(self):
-        if spec.satisfies('+debug'):
+        if self.spec.satisfies('+debug'):
             for makefile in ['Makefile', 'Makefile-libbz2_so']:
                 filter_file(r'-O ', '-O0 ', makefile)
                 filter_file(r'-O2 ', '-O0 ', makefile)


### PR DESCRIPTION
A recently merged PR had a typo that slipped through CI. Here's a fix.