### PR TITLE
fix header/lib paths for onednn

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -31,3 +31,13 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     @property
     def component_dir(self):
         return 'dnnl'
+
+    @property
+    def headers(self):
+        include_path = join_path(self.component_path, 'cpu_dpcpp_gpu_dpcpp', 'include')
+        return find_headers('dnnl', include_path)
+
+    @property
+    def libs(self):
+        lib_path = join_path(self.component_path, 'cpu_dpcpp_gpu_dpcpp', 'lib')
+        return find_libraries(['libdnnl', 'libmkldnn'], root=lib_path, shared=True)


### PR DESCRIPTION
Resolves fail from https://github.com/rscohn2/oneapi-spack-tests/pull/9

@scheibelp: onednn has a need for variants, similar to MKL. For MKL, we need to control the library names, for onednn, we need to control the directory path for lib & include. In this PR, cpu_cpdpp_gpu_dpcpp should also allow: cpu_gomp, cpu_iomp, cpu_tbb