### PR TITLE
Paraview 5.9.1-RC2 release

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -20,6 +20,7 @@ class Paraview(CMakePackage, CudaPackage):
     maintainers = ['chuckatkins', 'danlipsa', 'vicentebolea']
 
     version('master', branch='master', submodules=True)
+    version('5.9.1-RC2', sha256='87395d7d65e96d2a5f8a8086b5da52a78c7929397a03170cbd04c1e3b3bb501c')
     version('5.9.1-RC1', sha256='bb3f12bd3d31bcb52455e1393e45f81a18754d3c3e8199d51532b0c067dc1595')
     version('5.9.0', sha256='b03258b7cddb77f0ee142e3e77b377e5b1f503bcabc02bfa578298c99a06980d', preferred=True)
     version('5.8.1', sha256='7653950392a0d7c0287c26f1d3a25cdbaa11baa7524b0af0e6a1a0d7d487d034')


### PR DESCRIPTION
Hi there! ParaView second release candidate of 5.9.1! :tada: :tada: 

This morning we have just released our latest ParaView version which came very shortly after our previous release candidate release. 

I have made the changes in the ParaView Spack package which adds this new version.

Note that this is a release candidate.

This PR does not change the preferred version