### PR TITLE
Docker: ignore `var/spack/cache` (source caches) when creating container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,4 @@ share/spack/dotkit/*
 share/spack/lmod/*
 share/spack/modules/*
 lib/spack/spack/test/*
-
+var/spack/cache/*


### PR DESCRIPTION
When building a container in the $SPACK context using the dockerfiles in `share/spack/docker`, it can pull in the source caches in var/spack/cache (unless you are on a fresh spack clone). Adding `var/spack/cache` to dockerignore will avoid increasing the container with source cache files.