### PR TITLE
Fix homepage url for relion package

### DIFF
--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -12,7 +12,7 @@ class Relion(CMakePackage, CudaPackage):
     refinement of (multiple) 3D reconstructions or 2D class averages in
     electron cryo-microscopy (cryo-EM)."""
 
-    homepage = "http://http://www2.mrc-lmb.cam.ac.uk/relion"
+    homepage = "http://www2.mrc-lmb.cam.ac.uk/relion"
     git      = "https://github.com/3dem/relion.git"
     url      = "https://github.com/3dem/relion/archive/3.1.0.zip"
 


### PR DESCRIPTION
The Relion package recipe had an extra "http://" in the url for the
homepage.