### PR TITLE
libtirpc: Fix directories returned for header files

### DIFF
--- a/var/spack/repos/builtin/packages/libtirpc/package.py
+++ b/var/spack/repos/builtin/packages/libtirpc/package.py
@@ -11,7 +11,7 @@ class Libtirpc(AutotoolsPackage):
     """
 
     homepage = "https://sourceforge.net/projects/libtirpc/"
-    url      = "https://sourceforge.net/projects/libtirpc/files/libtirpc/1.1.4/libtirpc-1.1.4.tar.bz2/download"
+    url = "https://sourceforge.net/projects/libtirpc/files/libtirpc/1.1.4/libtirpc-1.1.4.tar.bz2/download"
 
     version('1.2.6', sha256='4278e9a5181d5af9cd7885322fdecebc444f9a3da87c526e7d47f7a12a37d1cc')
     version('1.1.4', sha256='2ca529f02292e10c158562295a1ffd95d2ce8af97820e3534fe1b0e3aec7561d')
@@ -23,3 +23,13 @@ class Libtirpc(AutotoolsPackage):
     # FIXME: build error on macOS
     # auth_none.c:81:9: error: unknown type name 'mutex_t'
     conflicts('platform=darwin', msg='Does not build on macOS')
+
+    @property
+    def headers(self):
+        hdrs = find_all_headers(self.prefix.include)
+        # libtirpc puts headers under include/tirpc, but some codes (e.g. hdf)
+        # do not expect a tirpc component.  Since some might, we return
+        # both prefix.include.tirpc and prefix.include as header paths
+        if hdrs:
+            hdrs.directories = [self.prefix.include.tirpc, self.prefix.include]
+        return hdrs or None


### PR DESCRIPTION
Fix for #23328
libtirpc puts its header files under prefix/include/tirpc, but
spack was returning just prefix/include for location of headers.

This will cause spack to return both prefix/include and
prefix/include/tirpc for headers, so both
include <rpc/xdr.h>
or
include <tirpc/rpc/xdr.h>
should work.