### PR TITLE
Another binutils fix

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
-
 
 class Binutils(AutotoolsPackage, GNUMirrorPackage):
     """GNU binutils, which contain the linker, assembler, objdump and others"""

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -32,7 +32,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
 
     variant('plugins', default=True,
             description="enable plugins, needed for gold linker")
-    variant('gold', default=(sys.platform != 'darwin'),
+    variant('gold', default=False,
             description="build the gold linker")
     variant('libiberty', default=False, description='Also install libiberty.')
     variant('nls', default=True, description='Enable Native Language Support')
@@ -68,6 +68,10 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     # "unable to initialize decompress status for section .debug_info"
     # when compiling with debug symbols on gcc.
     conflicts('+gas', '~ld', msg="Assembler not always compatible with system ld")
+
+    # When you build ld.gold you automatically get ld, even when you add the
+    # --disable-ld flag
+    conflicts('~ld', '+gold')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -131,7 +131,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('diffutils', type='build')
     depends_on('iconv', when='platform=darwin')
     depends_on('gnat', when='languages=ada')
-    depends_on('binutils+ld+plugins~libiberty', when='+binutils', type=('build', 'link', 'run'))
+    depends_on('binutils+gas+ld+plugins~libiberty', when='+binutils', type=('build', 'link', 'run'))
     depends_on('zip', type='build', when='languages=java')
     depends_on('cuda', when='+nvptx')
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -172,7 +172,7 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("py-six", when="@5.0.0: +lldb +python")
 
     # gold support, required for some features
-    depends_on("binutils+gold+plugins", when="+gold")
+    depends_on("binutils+gold+ld+plugins", when="+gold")
 
     # polly plugin
     depends_on("gmp", when="@:3.6.999 +polly")


### PR DESCRIPTION
- Building binutils with gold implies building ld
- add +ld to llvm to make the old concretizer happy and add +gas to gcc since that's used in the package.py

Now `spack spec mesa` still breaks with the old concretizer... but I think it's not really meant to depend on `binutils`?


I leave that for another PR.
