### PR TITLE
Fix: environment spec inference multiple matches

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1574,7 +1574,7 @@ class Environment(object):
                             if abstract)
 
         if len(root_matches) == 1:
-            return root_matches[0][1]
+            return list(root_matches.items())[0][1]
 
         # More than one spec matched, and either multiple roots matched or
         # none of the matches were roots

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1574,7 +1574,7 @@ class Environment(object):
                             if abstract)
 
         if len(root_matches) == 1:
-            return list(root_matches.items())[0][1]
+            return list(root_matches.items())[0][0]
 
         # More than one spec matched, and either multiple roots matched or
         # none of the matches were roots

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -96,3 +96,21 @@ def test_multiple_env_match_raises_error(mock_packages, mutable_mock_env_path):
             spack.cmd.matching_spec_from_env(spack.cmd.parse_specs(['a'])[0])
 
     assert 'matches multiple specs' in exc_info.value.message
+
+
+@pytest.mark.usefixtures('config')
+def test_root_and_dep_match_returns_root(mock_packages, mutable_mock_env_path):
+    e = ev.create('test')
+    e.add('b@0.9')
+    e.add('a foobar=bar')  # Depends on b, should choose b@1.0
+    e.concretize()
+    with e:
+        # This query matches the root b and b as a dependency of a. In that
+        # case the root instance should be preferred.
+        env_spec1 = spack.cmd.matching_spec_from_env(
+            spack.cmd.parse_specs(['b'])[0])
+        assert env_spec1.satisfies('@0.9')
+
+        env_spec2 = spack.cmd.matching_spec_from_env(
+            spack.cmd.parse_specs(['b@1.0'])[0])
+        assert env_spec2

--- a/var/spack/repos/builtin.mock/packages/b/package.py
+++ b/var/spack/repos/builtin.mock/packages/b/package.py
@@ -13,5 +13,6 @@ class B(Package):
     url      = "http://www.example.com/b-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
+    version('0.9', 'abcd456789abcdef0123456789abcdef')
 
     depends_on('test-dependency', type='test')


### PR DESCRIPTION
Fixes #23333

Fix check when retrieving matching spec from environment when there is a match with a root spec as well as with a dependency of a (different) root spec.

Also add a test.