### PR TITLE
hdf-eos2: Fix for #23345

### DIFF
--- a/var/spack/repos/builtin/packages/hdf-eos2/package.py
+++ b/var/spack/repos/builtin/packages/hdf-eos2/package.py
@@ -86,10 +86,13 @@ class HdfEos2(AutotoolsPackage):
 
         # Provide config args for dependencies
         extra_args.append('--with-hdf4={0}'.format(self.spec['hdf'].prefix))
-        if self.spec['jpeg']:
+        if 'jpeg' in self.spec:
             extra_args.append('--with-jpeg={0}'.format(
                 self.spec['jpeg'].prefix))
-        if self.spec['zlib']:
+        if 'libszip' in self.spec:
+            extra_args.append('--with-szlib={0}'.format(
+                self.spec['libszip'].prefix))
+        if 'zlib' in self.spec:
             extra_args.append('--with-zlib={0}'.format(
                 self.spec['zlib'].prefix))
 


### PR DESCRIPTION
fixes #23345

Add support for hdf+szip

Fix problematic checks for zlib and jpeg packages in specs, use
if 'zlib' in spec:
instead of
if spec['zlib']:
to avoid problems if zlib not in the spec.