### PR TITLE
HDF5: Suppress promoted warning that causes build failure on clang and gcc

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -329,7 +329,7 @@ class Hdf5(AutotoolsPackage):
 
         # Quiet warnings/errors about implicit declaration of functions in C99
         if "clang" in self.compiler.cc or "gcc" in self.compiler.cc:
-            cflags += " -Wno-implicit-function-declaration" 
+            cflags += " -Wno-implicit-function-declaration"
 
         if cflags:
             extra_args.append('CFLAGS={0}'.format(cflags))

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -298,22 +298,6 @@ class Hdf5(AutotoolsPackage):
             extra_args.append('--disable-shared')
             extra_args.append('--enable-static-exec')
 
-        if '+pic' in self.spec:
-            # use global spack compiler flags
-            _flags = self.compiler.cc_pic_flag
-            _flags += " " + ' '.join(self.spec.compiler_flags['cflags'])
-            extra_args.append('CFLAGS={0}'.format(_flags))
-
-            if '+cxx' in self.spec:
-                _flags = self.compiler.cxx_pic_flag
-                _flags += " " + ' '.join(self.spec.compiler_flags['cxxflags'])
-                extra_args.append('CXXFLAGS={0}'.format(_flags))
-
-            if '+fortran' in self.spec:
-                _flags = self.compiler.fc_pic_flag
-                _flags += " " + ' '.join(self.spec.compiler_flags['fflags'])
-                extra_args.append('FCFLAGS={0}'.format(_flags))
-
         # Fujitsu Compiler does not add Fortran runtime in rpath.
         if '+fortran %fj' in self.spec:
             extra_args.append('LDFLAGS=-lfj90i -lfj90f -lfjsrcinfo -lelf')
@@ -332,6 +316,27 @@ class Hdf5(AutotoolsPackage):
 
             if '+fortran' in self.spec:
                 extra_args.append('FC=%s' % self.spec['mpi'].mpifc)
+
+        # Append package specific compiler flags to the global ones
+        cflags = ' '.join(self.spec.compiler_flags['cflags'])
+        cxxflags = ' '.join(self.spec.compiler_flags['cxxflags'])
+        fflags = ' '.join(self.spec.compiler_flags['fflags'])
+
+        if '+pic' in self.spec:
+            cflags += " " + self.compiler.cc_pic_flag
+            cxxflags += " " + self.compiler.cxx_pic_flag
+            fflags += " " + self.compiler.fc_pic_flag
+
+        # Quiet warnings/errors about implicit declaration of functions in C99
+        if "clang" in self.compiler.cc or "gcc" in self.compiler.cc:
+            cflags += " -Wno-implicit-function-declaration" 
+
+        if cflags:
+            extra_args.append('CFLAGS={0}'.format(cflags))
+        if cxxflags and '+cxx' in self.spec:
+            extra_args.append('CXXFLAGS={0}'.format(cxxflags))
+        if fflags and '+fortran' in self.spec:
+            extra_args.append('FCFLAGS={0}'.format(fflags))
 
         return extra_args
 


### PR DESCRIPTION
Moves this fix into the package instead of required every compiler spec to define this flag:

https://github.com/LLNL/serac/pull/456/files#r623250393

This is just one of the many errors that is produced:

```
cache_api.c:261:16: error: implicit declaration of function 'resize_configs_are_equal' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if ( ! resize_configs_are_equal(&default_auto_size_ctl, \
               ^
```