### PR TITLE
BLT version lockdown

### DIFF
--- a/var/spack/repos/builtin/packages/blt/package.py
+++ b/var/spack/repos/builtin/packages/blt/package.py
@@ -24,7 +24,8 @@ class Blt(Package):
     #  https://llnl-blt.readthedocs.io/en/develop/tutorial/exporting_targets.html
     version('0.4.0', sha256='f3bc45d28b9b2eb6df43b75d4f6f89a1557d73d012da7b75bac1be0574767193')
 
-    # 0.3.6 + a specific fix for rocm, that is before 0.4.0's breaking change
+    # 0.3.6 + a specific fix for versions of packages that rely on rocm and
+    # cannot move completely forward in BLT to the breaking change in 0.4.0
     version('0.3.6rocm', commit='a98a5836c7a9e34b75a54eb46212812796fe5557')
 
     version('0.3.6', sha256='6276317c29e7ff8524fbea47d9288ddb40ac06e9f9da5e878bf9011e2c99bf71')

--- a/var/spack/repos/builtin/packages/blt/package.py
+++ b/var/spack/repos/builtin/packages/blt/package.py
@@ -18,7 +18,15 @@ class Blt(Package):
 
     version('develop', branch='develop')
     version('main', branch='main')
+    # Note: 0.4.0 contains a breaking change to BLT created targets
+    #  if you export targets this could cause problems in downstream
+    #  projects if not handled properly. More info here:
+    #  https://llnl-blt.readthedocs.io/en/develop/tutorial/exporting_targets.html
     version('0.4.0', sha256='f3bc45d28b9b2eb6df43b75d4f6f89a1557d73d012da7b75bac1be0574767193')
+
+    # 0.3.6 + a specific fix for rocm, that is before 0.4.0's breaking change
+    version('0.3.6rocm', commit='a98a5836c7a9e34b75a54eb46212812796fe5557')
+
     version('0.3.6', sha256='6276317c29e7ff8524fbea47d9288ddb40ac06e9f9da5e878bf9011e2c99bf71')
     version('0.3.5', sha256='68a1c224bb9203461ae6f5ab0ff3c50b4a58dcce6c2d2799489a1811f425fb84')
     version('0.3.0', sha256='bb917a67cb7335d6721c997ba9c5dca70506006d7bba5e0e50033dd0836481a5')

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -22,15 +22,12 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
     # TODO: figure out gtest dependency and then set this default True.
     variant('tests', default=False, description='Build tests')
 
-    depends_on('blt', type='build')
-    depends_on('blt@0.3.7:', type='build', when='+rocm')
     depends_on('cub', when='+cuda')
 
     def cmake_args(self):
         spec = self.spec
 
         options = []
-        options.append('-DBLT_SOURCE_DIR={0}'.format(spec['blt'].prefix))
 
         if '+cuda' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -28,7 +28,7 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
     variant('tests', default=False, description='Build tests')
     variant('loop_fuser', default=False, description='Enable loop fusion capability')
 
-    depends_on('blt', type='build')
+    depends_on('blt', type='build', when='care@0.3.1:')
     depends_on('blt@0.3.6', type='build', when='care@:0.3.0')
     # 0.3.6 + specific fix for rocm
     depends_on('blt@0.3.6rocm', type='build', when='+rocm')

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -29,7 +29,9 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
     variant('loop_fuser', default=False, description='Enable loop fusion capability')
 
     depends_on('blt', type='build')
-    depends_on('blt@0.3.7:', type='build', when='+rocm')
+    depends_on('blt@0.3.6', type='build', when='care@:0.3.0')
+    # 0.3.6 + specific fix for rocm
+    depends_on('blt@0.3.6rocm', type='build', when='+rocm')
 
     depends_on('camp')
     depends_on('umpire@develop')

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -28,10 +28,10 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
     variant('tests', default=False, description='Build tests')
     variant('loop_fuser', default=False, description='Enable loop fusion capability')
 
-    depends_on('blt', type='build', when='care@0.3.1:')
-    depends_on('blt@0.3.6', type='build', when='care@:0.3.0')
+    depends_on('blt', type='build', when='@0.3.1:')
+    depends_on('blt@:0.3.6', type='build', when='@:0.3.0')
     # 0.3.6 + specific fix for rocm
-    depends_on('blt@0.3.6rocm', type='build', when='+rocm')
+    depends_on('blt@0.3.6rocm', type='build', when='@:0.3.0+rocm')
 
     depends_on('camp')
     depends_on('umpire@develop')

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -35,8 +35,12 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', type='build', when="+cuda")
+
     depends_on('blt', type='build')
-    depends_on('blt@0.3.7:', type='build', when='+rocm')
+    depends_on('blt@0.3.6', type='build', when='chai@:2.3.0')
+    # 0.3.6 + specific fix for rocm
+    depends_on('blt@0.3.6rocm', type='build', when='+rocm')
+
     depends_on('umpire')
     depends_on('raja', when="+raja")
 

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -36,7 +36,7 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', type='build', when="+cuda")
 
-    depends_on('blt', type='build')
+    depends_on('blt', type='build', when='chai@2.3.1')
     depends_on('blt@0.3.6', type='build', when='chai@:2.3.0')
     # 0.3.6 + specific fix for rocm
     depends_on('blt@0.3.6rocm', type='build', when='+rocm')

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -36,7 +36,7 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', type='build', when="+cuda")
 
-    depends_on('blt', type='build', when='chai@2.3.1')
+    depends_on('blt', type='build', when='chai@2.3.1:')
     depends_on('blt@0.3.6', type='build', when='chai@:2.3.0')
     # 0.3.6 + specific fix for rocm
     depends_on('blt@0.3.6rocm', type='build', when='+rocm')

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -36,10 +36,10 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', type='build', when="+cuda")
 
-    depends_on('blt', type='build', when='chai@2.3.1:')
-    depends_on('blt@0.3.6', type='build', when='chai@:2.3.0')
+    depends_on('blt', type='build', when='@2.3.1:')
+    depends_on('blt@:0.3.6', type='build', when='@:2.3.0')
     # 0.3.6 + specific fix for rocm
-    depends_on('blt@0.3.6rocm', type='build', when='+rocm')
+    depends_on('blt@0.3.6rocm', type='build', when='@:2.3.0+rocm')
 
     depends_on('umpire')
     depends_on('raja', when="+raja")

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -37,10 +37,10 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
     # and remove the +tests conflict below.
     variant('tests', default=False, description='Build tests')
 
-    depends_on('blt', type='build', when='raja@0.13.1:')
-    depends_on('blt@0.3.6', type='build', when='raja@:0.13.0')
+    depends_on('blt', type='build', when='@0.13.1:')
+    depends_on('blt@:0.3.6', type='build', when='@:0.13.0')
     # 0.3.6 + specific fix for rocm
-    depends_on('blt@0.3.6rocm', type='build', when='+rocm')
+    depends_on('blt@0.3.6rocm', type='build', when='@:0.13.0+rocm')
 
     depends_on('camp')
     depends_on('camp+cuda', when='+cuda')

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -38,7 +38,9 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
     variant('tests', default=False, description='Build tests')
 
     depends_on('blt', type='build')
-    depends_on('blt@0.3.7:', type='build', when='+rocm')
+    depends_on('blt@0.3.6', type='build', when='raja@:0.13.0')
+    # 0.3.6 + specific fix for rocm
+    depends_on('blt@0.3.6rocm', type='build', when='+rocm')
 
     depends_on('camp')
     depends_on('camp+cuda', when='+cuda')

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -37,7 +37,7 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
     # and remove the +tests conflict below.
     variant('tests', default=False, description='Build tests')
 
-    depends_on('blt', type='build')
+    depends_on('blt', type='build', when='raja@0.13.1:')
     depends_on('blt@0.3.6', type='build', when='raja@:0.13.0')
     # 0.3.6 + specific fix for rocm
     depends_on('blt@0.3.6rocm', type='build', when='+rocm')

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -60,7 +60,7 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', when='+cuda', type='build')
 
-    depends_on('blt', type='build')
+    depends_on('blt', type='build', when='umpire@4.1.3:')
     depends_on('blt@0.3.6', type='build', when='umpire@:4.1.2')
     # 0.3.6 + specific fix for rocm
     depends_on('blt@0.3.6rocm', type='build', when='+rocm')

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -60,10 +60,10 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', when='+cuda', type='build')
 
-    depends_on('blt', type='build', when='umpire@4.1.3:')
-    depends_on('blt@0.3.6', type='build', when='umpire@:4.1.2')
+    depends_on('blt', type='build', when='@4.1.3:')
+    depends_on('blt@:0.3.6', type='build', when='@:4.1.2')
     # 0.3.6 + specific fix for rocm
-    depends_on('blt@0.3.6rocm', type='build', when='+rocm')
+    depends_on('blt@0.3.6rocm', type='build', when='@:4.1.2+rocm')
 
     # variants +rocm and amdgpu_targets are not automatically passed to
     # dependencies, so do it manually.

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -61,7 +61,9 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.9:', when='+cuda', type='build')
 
     depends_on('blt', type='build')
-    depends_on('blt@0.3.7:', type='build', when='+rocm')
+    depends_on('blt@0.3.6', type='build', when='umpire@:4.1.2')
+    # 0.3.6 + specific fix for rocm
+    depends_on('blt@0.3.6rocm', type='build', when='+rocm')
 
     # variants +rocm and amdgpu_targets are not automatically passed to
     # dependencies, so do it manually.


### PR DESCRIPTION
* Several packages were tracking blt@develop unintentionally when +rocm.  0.4.0+ has breaking changes that need to be addressed before moving forward if you are exporting your CMake targets.

* CAMP doesn't depend on BLT so that was removed.

* Added a rocm specific version of BLT that is pre-0.4.0.

@dtaller @becker33 @davidbeckingsale 

Attempts to fix https://github.com/spack/spack/issues/23339