### PR TITLE
Introduce SPACK_STACKTRACE

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -416,6 +416,7 @@ def make_argument_parser(**kwargs):
         help="print additional output during builds")
     parser.add_argument(
         '--stacktrace', action='store_true',
+        default='SPACK_STACKTRACE' in os.environ,
         help="add stacktraces to all printed statements")
     parser.add_argument(
         '-V', '--version', action='store_true',


### PR DESCRIPTION
In CI I'm hitting this useful error message:

```
==> Error: Invalid character
```

Would be nice to get at least *some* more feedback by default without having to enable `-d` everywhere
