### PR TITLE
gcc: Explicitly disable bootstrapping

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -509,6 +509,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             options.extend([
                 '--enable-bootstrap',
             ])
+        else:
+            options.extend([
+                '--disable-bootstrap',
+            ])
 
         # Configure include and lib directories explicitly for these
         # dependencies since the short GCC option assumes that libraries


### PR DESCRIPTION
We need to explicitly disable bootstrapping when `~bootstrap` since GCC bootstraps by default.

This might correct (or might just help not trigger) https://github.com/spack/spack/issues/23296 .