### PR TITLE
cub: update repo & add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/cub/package.py
+++ b/var/spack/repos/builtin/packages/cub/package.py
@@ -11,9 +11,14 @@ class Cub(Package):
     and other utilities for CUDA kernel programming."""
 
     homepage = "https://nvlabs.github.com/cub"
-    url      = "https://github.com/NVlabs/cub/archive/1.7.1.zip"
-    git      = "https://github.com/NVlabs/cub.git"
+    url      = "https://github.com/NVIDIA/cub/archive/1.12.0.zip"
+    git      = "https://github.com/NVIDIA/cub.git"
 
+    version('1.12.0',  sha256='92f0f39235db787f4850d5c4ffdaa7d5367a2f153bdd3b4a1161a6a2fefb7bfc')
+    version('1.12.0-rc0',  sha256='c9470cb5a23849e3143a3b2f07fe4d48ed3c8e0ec862b4d4c02ec15afb4fc331')
+    version('1.11.0',  sha256='4c5d6a42350e010273be33f72af8c9b6253cfe55e2a0584fe7bf9f84dc338d00')
+    version('1.10.0',  sha256='d6be1acfa65be4e25be40f576687fed19c00896390cbc6205888c69ac2f150de')
+    version('1.9.10-1',  sha256='6f0e6a6b2996000cefbe9bff1716689fd71c2cd4004d23b238a9cb90c4421bdc')
     version('1.9.10',  sha256='063fea7c9bf87677a5fc5889e3fcd51582b77a2b3af9fa599d846a9c98ce9407')
     version('1.9.9',   sha256='162514b3cc264ac89d91898b58450190b8192e2af1142cf8ccac2d59aa160dda')
     version('1.9.8-1', sha256='f61d05367bd8fe8bfb0eafa20f7b14d27deb8b25a398c53d8a97a01a2399431b')


### PR DESCRIPTION
* Update the `url` and `git` of cub, since the old git repo of cub has moved to github.com/nvidia/cub
* Add new cub releases