### PR TITLE
chapel: fix old checksum & update url and versions

### DIFF
--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -11,8 +11,14 @@ class Chapel(AutotoolsPackage):
        portable, scalable and open-source."""
 
     homepage = "https://chapel-lang.org/"
-    url      = "https://github.com/chapel-lang/chapel/releases/download/1.20.0/chapel-1.20.0.tar.gz"
+    url      = "https://github.com/chapel-lang/chapel/archive/refs/tags/1.24.1.tar.gz"
 
-    version('1.20.0', sha256='08bc86df13e4ad56d0447f52628b0f8e36b0476db4e19a90eeb2bd5f260baece')
-    version('1.19.0', sha256='c2b68a20d87cc382c2f73dd1ecc6a4f42fb2f590b0b10fbc577382dd35c9e9bd')
-    version('1.18.0', sha256='68471e1f398b074edcc28cae0be26a481078adc3edea4df663f01c6bd3b6ae0d')
+    version('1.24.1', sha256='9250824b8efa038941bc08314bbdddf6368e0b86a66a0e8c86169a0eb425e536')
+    version('1.24.0', sha256='c54882b21f2c79e47156e1bd512b2460a2934e38d5edd081c93cf410a266e536')
+    version('1.23.0', sha256='9350261afd9421254c516bcdd899ca5a431c011b79893029625c8d70fa157452')
+    version('1.22.1', sha256='dc3afeb2a873059ac6cdc25e2167d9d677f96ce247bf66ec589c577db05fba5b')
+    version('1.22.0', sha256='b0a4d25ee38483d172678bec9a28d267d5da04a2fcaa2e8d9d399f88cc8bf170')
+    version('1.21.0', sha256='38914b0765836fda0f2ad4dbd0c1ec95ea4cb4bac7238a3f82640239c3c196fa')
+    version('1.20.0', sha256='723283f3d6cecb8f7a1c53ec688864c24f299cf960f3ab6b5d7d580c64e662d4')
+    version('1.19.0', sha256='702390a9b6b8a5c03ddaad94b92273a153e9bd7801fd735e3e63252ee3527e38')
+    version('1.18.0', sha256='5640b9e8206781a06aa71e77d216c6673ad41ef8b5d225100800457f534e4cf4')

--- a/var/spack/repos/builtin/packages/chapel/package.py
+++ b/var/spack/repos/builtin/packages/chapel/package.py
@@ -11,14 +11,14 @@ class Chapel(AutotoolsPackage):
        portable, scalable and open-source."""
 
     homepage = "https://chapel-lang.org/"
-    url      = "https://github.com/chapel-lang/chapel/archive/refs/tags/1.24.1.tar.gz"
+    url      = "https://github.com/chapel-lang/chapel/releases/download/1.24.1/chapel-1.24.1.tar.gz"
 
-    version('1.24.1', sha256='9250824b8efa038941bc08314bbdddf6368e0b86a66a0e8c86169a0eb425e536')
-    version('1.24.0', sha256='c54882b21f2c79e47156e1bd512b2460a2934e38d5edd081c93cf410a266e536')
-    version('1.23.0', sha256='9350261afd9421254c516bcdd899ca5a431c011b79893029625c8d70fa157452')
-    version('1.22.1', sha256='dc3afeb2a873059ac6cdc25e2167d9d677f96ce247bf66ec589c577db05fba5b')
-    version('1.22.0', sha256='b0a4d25ee38483d172678bec9a28d267d5da04a2fcaa2e8d9d399f88cc8bf170')
-    version('1.21.0', sha256='38914b0765836fda0f2ad4dbd0c1ec95ea4cb4bac7238a3f82640239c3c196fa')
-    version('1.20.0', sha256='723283f3d6cecb8f7a1c53ec688864c24f299cf960f3ab6b5d7d580c64e662d4')
-    version('1.19.0', sha256='702390a9b6b8a5c03ddaad94b92273a153e9bd7801fd735e3e63252ee3527e38')
-    version('1.18.0', sha256='5640b9e8206781a06aa71e77d216c6673ad41ef8b5d225100800457f534e4cf4')
+    version('1.24.1', sha256='f898f266fccaa34d937b38730a361d42efb20753ba43a95e5682816e008ce5e4')
+    version('1.24.0', sha256='77c6087f3e0837268470915f2ad260d49cf7ac4adf16f5b44862ae624c1be801')
+    version('1.23.0', sha256='7ae2c8f17a7b98ac68378e94a842cf16d4ab0bcfeabc0fee5ab4aaa07b205661')
+    version('1.22.1', sha256='8235eb0869c9b04256f2e5ce3ac4f9eff558401582fba0eba05f254449a24989')
+    version('1.22.0', sha256='57ba6ee5dfc36efcd66854ecb4307e1c054700ea201eff73012bd8b4572c2ce6')
+    version('1.21.0', sha256='886f7ba0e0e86c86dba99417e3165f90b1d3eca59c8cd5a7f645ce28cb5d82a0')
+    version('1.20.0', sha256='08bc86df13e4ad56d0447f52628b0f8e36b0476db4e19a90eeb2bd5f260baece')
+    version('1.19.0', sha256='c2b68a20d87cc382c2f73dd1ecc6a4f42fb2f590b0b10fbc577382dd35c9e9bd')
+    version('1.18.0', sha256='68471e1f398b074edcc28cae0be26a481078adc3edea4df663f01c6bd3b6ae0d')


### PR DESCRIPTION
* Fix old 1.20.0, 1.19.0, 1.18.0 checksum, since they are the checksum of binary tarball instead of source codes
* Update url of chapel to the latest source codes tarball
* Add new chapel releases