### PR TITLE
variorum: new versions: 0.4.1, 0.4.0, 0.3.0, 0.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/variorum/package.py
+++ b/var/spack/repos/builtin/packages/variorum/package.py
@@ -17,6 +17,10 @@ class Variorum(CMakePackage):
 
     maintainers = ["slabasan", "rountree"]
 
+    version('0.4.1', sha256='be7407b856bc2239ecaa27d3df80aee2f541bb721fbfa183612bd9c0ce061f28')
+    version('0.4.0', sha256='70ff1c5a3ae15d0bd07d409ab6f3c128e69528703a829cb18ecb4a50adeaea34')
+    version('0.3.0', sha256='f79563f09b8fe796283c879b05f7730c36d79ca0346c12995b7bccc823653f42')
+    version('0.2.0', sha256='b8c010b26aad8acc75d146c4461532cf5d9d3d24d6fc30ee68f6330a68e65744')
     version("0.1.0", tag="v0.1.0")
 
     ############


### PR DESCRIPTION
New versions for `variorum`

@slabasan @rountree