### PR TITLE
metall: new versions: 0.12, 0.11

### DIFF
--- a/var/spack/repos/builtin/packages/metall/package.py
+++ b/var/spack/repos/builtin/packages/metall/package.py
@@ -16,6 +16,8 @@ class Metall(CMakePackage):
     version('master', branch='master')
     version('develop', branch='develop')
 
+    version('0.12', sha256='b757b354b355e866bd6d42da53b0160442f3b7f663a19ba113da1ffc1a76176e')
+    version('0.11', sha256='7cfa6a7eaaeb7fd11ecfbe43a172a36c8cde200601d6cd3b309d7a0acf752f3c')
     version('0.10', sha256='58b4b5507d4db5baca315b1bed2b728981755d755b91ef63bd0b6dfaf320f46b')
     version('0.9', sha256='2d7bd9ea2f1e04136050f210884445a9e3dcb96c992cf42ff9ea4b392f85f927')
 


### PR DESCRIPTION
New versions of `metall`: 0.12, 0.11

@KIwabuchi @rogerpearce @mayagokhale