### PR TITLE
SLATE: Add e4s testsuite-inspired smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -63,11 +63,11 @@ class Slate(CMakePackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        if '@master' in self.spec:
+        if self.spec.satisfies('@master'):
             self.cache_extra_test_sources([self.examples_src_dir])
 
     def test(self):
-        if '@master' in self.spec and '+mpi' in self.spec:
+        if self.spec.satisfies('@master') and '+mpi' in self.spec:
             test_dir = join_path(self.install_test_root,
                                  self.examples_src_dir)
             test_bld_dir = join_path(test_dir, 'build')

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -67,16 +67,18 @@ class Slate(CMakePackage):
             self.cache_extra_test_sources([self.examples_src_dir])
 
     def test(self):
-        if self.spec.satisfies('@master') and '+mpi' in self.spec:
-            test_dir = join_path(self.install_test_root,
-                                 self.examples_src_dir)
-            test_bld_dir = join_path(test_dir, 'build')
-            with working_dir(test_bld_dir, create=True):
-                cmake('..')
-                make()
-                test_args = ['-n', '4', './ex05_blas']
-                mpiexe_f = which('srun', 'mpirun', 'mpiexec')
-                if mpiexe_f:
-                    self.run_test(mpiexe_f.command, test_args,
-                                  purpose='SLATE smoke test')
-                make('clean')
+        if not self.spec.satisfies('@master') or '+mpi' not in self.spec:
+            print('Skipping: stand-alone tests only run on master with +mpi')
+            return
+
+        test_dir = join_path(self.install_test_root, self.examples_src_dir)
+        test_bld_dir = join_path(test_dir, 'build')
+        with working_dir(test_bld_dir, create=True):
+            cmake('..')
+            make()
+            test_args = ['-n', '4', './ex05_blas']
+            mpiexe_f = which('srun', 'mpirun', 'mpiexec')
+            if mpiexe_f:
+                self.run_test(mpiexe_f.command, test_args,
+                              purpose='SLATE smoke test')
+            make('clean')


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `slate` package and is intended to serve the following purposes:

- leverage the current E4S test suite for the software; and
- demonstrate to package maintainers how to start a Spack smoke test.