### PR TITLE
scr: new release and dependency updates

### DIFF
--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -11,6 +11,14 @@ import os
 import sys
 
 
+def detect_scheduler():
+    if which('aprun'):
+        return 'APRUN'
+    if which('jsrun'):
+        return 'LSF'
+    return 'SLURM'
+
+
 class Scr(CMakePackage):
     """SCR caches checkpoint data in storage on the compute nodes of a
        Linux cluster to provide a fast, scalable checkpoint/restart
@@ -21,33 +29,36 @@ class Scr(CMakePackage):
     git      = "https://github.com/llnl/scr.git"
 
     version('develop', branch='develop')
-    version('legacy', branch='legacy')
+    version('legacy', branch='legacy', deprecated=True)
 
-    version('2.0.0', sha256='471978ae0afb56a20847d3989b994fbd680d1dea21e77a5a46a964b6e3deed6b')
-    version('1.2.2', sha256='764a85638a9e8762667ec1f39fa5f7da7496fca78de379a22198607b3e027847')
-    version('1.2.1', sha256='23acab2dc7203e9514455a5168f2fd57bc590affb7a1876912b58201513628fe')
-    version('1.2.0', sha256='e3338ab2fa6e9332d2326c59092b584949a083a876adf5a19d4d5c7a1bbae047')
+    version('3.0rc1', sha256='bd31548a986f050024429d8ee3644eb135f047f98a3d503a40c5bd4a85291308')
+    version('2.0.0', sha256='471978ae0afb56a20847d3989b994fbd680d1dea21e77a5a46a964b6e3deed6b', deprecated=True)
+    version('1.2.2', sha256='764a85638a9e8762667ec1f39fa5f7da7496fca78de379a22198607b3e027847', deprecated=True)
+    version('1.2.1', sha256='23acab2dc7203e9514455a5168f2fd57bc590affb7a1876912b58201513628fe', deprecated=True)
+    version('1.2.0', sha256='e3338ab2fa6e9332d2326c59092b584949a083a876adf5a19d4d5c7a1bbae047', deprecated=True)
 
     depends_on('pdsh+static_modules', type=('build', 'run'))
     depends_on('zlib')
     depends_on('mpi')
 
-    # As of mid-2020, develop requires the "master" branch
-    # of a few component libraries
-    depends_on('axl@master', when="@develop")
-    depends_on('kvtree@master', when="@develop")
-    depends_on('redset@master', when="@develop")
-    depends_on('er@master', when="@develop")
-    depends_on('rankstr@master', when="@develop")
+    # Use the latest iteration of the components when installing scr@develop
+    depends_on('axl@master',      when="@develop")
+    depends_on('er@master',       when="@develop")
+    depends_on('kvtree@master',   when="@develop")
+    depends_on('rankstr@master',  when="@develop")
+    depends_on('redset@master',   when="@develop")
     depends_on('shuffile@master', when="@develop")
+    depends_on('spath@master',    when="@develop")
 
     # SCR legacy is anything 2.x.x or earlier
     # SCR components is anything 3.x.x or later
-    depends_on('er', when="@3:")
-    depends_on('kvtree', when="@3:")
-    depends_on('rankstr', when="@3:")
-    depends_on('filo', when="@3")
-    depends_on('spath', when="@3:")
+    depends_on('axl@0.4.0:',      when="@3:")
+    depends_on('er@0.0.4:',       when="@3:")
+    depends_on('kvtree@1.1.1:',   when="@3:")
+    depends_on('rankstr@0.0.3:',  when="@3:")
+    depends_on('redset@0.0.5:',   when="@3:")
+    depends_on('shuffile@0.0.4:', when="@3:")
+    depends_on('spath@0.0.2:',    when="@3:")
 
     # DTCMP is an optional dependency up until 3.x
     variant('dtcmp', default=True,
@@ -65,7 +76,7 @@ class Scr(CMakePackage):
     depends_on('libyogrt scheduler=lsf', when="+libyogrt resource_manager=LSF")
     depends_on('libyogrt', when="+libyogrt")
 
-    # MySQL not yet in spack
+    # Enabling SCR logging is a WIP, for which this will be needed
     # variant('mysql', default=True, decription="MySQL database for logging")
     # depends_on('mysql', when="+mysql")
 
@@ -79,20 +90,29 @@ class Scr(CMakePackage):
     variant('fortran', default=True,
             description="Build SCR with fortran bindings")
 
-    variant('resource_manager', default='SLURM',
+    variant('resource_manager', default=detect_scheduler(),
             values=('SLURM', 'APRUN', 'PMIX', 'LSF', 'NONE'),
             multi=False,
             description="Resource manager for which to configure SCR.")
 
+    # SCR_ASYNC_API in process of being automated. Only applying this to :2.x.x
     variant('async_api', default='NONE',
             values=('NONE', 'CRAY_DW', 'IBM_BBAPI', 'INTEL_CPPR'),
             multi=False,
             description="Asynchronous data transfer API to use with SCR.")
 
+    variant('bbapi_fallback', default='False',
+            description='Using BBAPI, if source or destination don\'t support \
+            file extents then fallback to pthreads')
+    depends_on('axl+bbapi_fallback', when="@3: +bbapi_fallback")
+
     variant('file_lock', default='FLOCK',
             values=('FLOCK', 'FNCTL', 'NONE'),
             multi=False,
             description='File locking style for SCR.')
+    depends_on('kvtree file_lock=FLOCK', when='@3: file_lock=FLOCK')
+    depends_on('kvtree file_lock=FNCTL', when='@3: file_lock=FNCTL')
+    depends_on('kvtree file_lock=NONE',  when='@3: file_lock=NONE')
 
     # The default cache and control directories should be placed in tmpfs if available.
     # On Linux, /dev/shm is a common tmpfs location.  Other platforms, like macOS,
@@ -121,14 +141,15 @@ class Scr(CMakePackage):
 
         conf_path = self.get_abs_path_rel_prefix(
             self.spec.variants['scr_config'].value)
-        args.append('-DCMAKE_SCR_CONFIG_FILE={0}'.format(conf_path))
+        args.append('-DSCR_CONFIG_FILE={0}'.format(conf_path))
 
         # We uppercase the values for these to avoid unnecessary user error.
         args.append('-DSCR_RESOURCE_MANAGER={0}'.format(
             spec.variants['resource_manager'].value.upper()))
 
-        args.append('-DSCR_ASYNC_API={0}'.format(
-            spec.variants['async_api'].value.upper()))
+        if spec.satisfies('@:2.999'):
+            args.append('-DSCR_ASYNC_API={0}'.format(
+                spec.variants['async_api'].value.upper()))
 
         args.append('-DSCR_FILE_LOCK={0}'.format(
             spec.variants['file_lock'].value.upper()))


### PR DESCRIPTION
SCR moved to a component version some time ago, but never had a
release associated with these changes. SCR v2 is a legacy version
that is no longer being developed/supported. In preparation for an
upcoming SCR v3 release, there is now a 3.0rc1 release available to
users.
This adds the 3.0rc1 release to the spack package and deprecates the
older versions.

Additional changes include:
- Enforce using the main branches of the components when installing
scr@develop
- Enforce SCR v3 uses at least the recently released versions of each
of the components
- Use a simple `detect_scheduler()` function in an attempt to be
smarter about setting the default resource manager and not require
users to always manually provide the variant
- Add/update variants that were recently added to AXL and KVTree
components
- Fix cmake arg naming bug of setting `SCR_CONFIG_FILE`
- `SCR_ASYNC_API` is now being handled by a component and is only
needed by the legacy versions.

We're wanting to expose SCR's logging through Spack as well, but currently
unsure how much to expose. There is an open discussion about this (https://github.com/LLNL/scr/issues/315)
but it can be added in a future PR if a decision hasn't been made before this
PR has been approved.