### PR TITLE
py-hdf5: restore py-h5py~mpi ^hdf5+mpi

### DIFF
--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -59,7 +59,6 @@ class PyH5py(PythonPackage):
 
     # MPI dependencies
     depends_on('hdf5+mpi', when='+mpi')
-    depends_on('hdf5~mpi', when='~mpi')
     depends_on('mpi', when='+mpi')
     depends_on('py-mpi4py', when='@:2.99 +mpi', type=('build', 'run'))
     depends_on('py-mpi4py@3.0.0:', when='@3.0.0:+mpi^python@3.0.0:3.7.99', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -155,7 +155,12 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-google-pasta@0.1.8:', type=('build', 'run'), when='@2.1:2.3')
     depends_on('py-google-pasta@0.1.6:', type=('build', 'run'), when='@1.14:2.0')
     depends_on('py-google-pasta@0.1.2:', type=('build', 'run'), when='@1.12.1')
-    depends_on('py-h5py@2.10.0:2.10.999', type=('build', 'run'), when='@2.2:')
+    # propagate the mpi variant setting for h5py/hdf5 to avoid unexpected crashes
+    depends_on('py-h5py@2.10.0:2.10.999', type=('build', 'run'), when='@2.2:+mpi')
+    depends_on('py-h5py+mpi', type=('build', 'run'), when='@2.2:+mpi')
+    depends_on('py-h5py~mpi', type=('build', 'run'), when='@2.2:~mpi')
+    depends_on('hdf5+mpi', type='build', when='@2.2:+mpi')
+    depends_on('hdf5~mpi', type='build', when='@2.2:~mpi')
     depends_on('py-keras-applications@1.0.8:', type=('build', 'run'), when='@1.15:2.1')
     depends_on('py-keras-applications@1.0.6:', type=('build', 'run'), when='@1.12:1.14')
     depends_on('py-keras-applications@1.0.5:', type=('build', 'run'), when='@1.11.0:1.11.999')

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -155,9 +155,7 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-google-pasta@0.1.8:', type=('build', 'run'), when='@2.1:2.3')
     depends_on('py-google-pasta@0.1.6:', type=('build', 'run'), when='@1.14:2.0')
     depends_on('py-google-pasta@0.1.2:', type=('build', 'run'), when='@1.12.1')
-    # propagate the mpi variant setting for h5py/hdf5 to avoid unexpected crashes
-    depends_on('py-h5py@2.10.0:2.10.999', type=('build', 'run'), when='@2.2:+mpi')
-    depends_on('py-h5py~mpi@2.10.0:2.10.999', type=('build', 'run'), when='@2.2:~mpi')
+    depends_on('py-h5py@2.10.0:2.10.999', type=('build', 'run'), when='@2.2:')
     depends_on('py-keras-applications@1.0.8:', type=('build', 'run'), when='@1.15:2.1')
     depends_on('py-keras-applications@1.0.6:', type=('build', 'run'), when='@1.12:1.14')
     depends_on('py-keras-applications@1.0.5:', type=('build', 'run'), when='@1.11.0:1.11.999')


### PR DESCRIPTION
Reverts spack/spack#21955, which
- was not a change to py-tensorflow but rather to py-h5py
- breaks the ability to build `py-h5py~mpi ^hdf5+mpi` which is valid and works in my experience.