### PR TITLE
arborx: kokkos hip backend is actually now called rocm

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -26,7 +26,7 @@ class Arborx(CMakePackage):
         'serial': (True,  "enable Serial backend (default)"),
         'cuda': (False,  "enable Cuda backend"),
         'openmp': (False,  "enable OpenMP backend"),
-        'hip': (False,  "enable HIP backend")
+        'rocm': (False,  "enable HIP backend")
     }
 
     variant('mpi', default=True, description='enable MPI')


### PR DESCRIPTION
The kokkos hip backend is actually called `rocm`

Here's the error you would get without this PR:

```
$> spack spec arborx+hip
Input spec
--------------------------------
 -   arborx+hip

Concretized
--------------------------------
==> Error: trying to set variant "hip" in package "kokkos", but the package has no such variant ...
```

@aprokop @jjwilke @aweits @masterleinad 