### PR TITLE
flecsi: fix legion dependency specification so variants actually exist

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -62,7 +62,7 @@ class Flecsi(CMakePackage):
     depends_on('mpi', when='backend=mpi')
     depends_on('mpi', when='backend=legion')
     depends_on('mpi', when='backend=hpx')
-    depends_on('legion+shared+mpi', when='backend=legion')
+    depends_on('legion+shared_libs', when='backend=legion')
     depends_on('legion+hdf5', when='backend=legion +hdf5')
     depends_on('legion build_type=Debug', when='backend=legion +debug_backend')
     depends_on('hpx@1.4.1 cxxstd=17 malloc=system max_cpu_count=128', when='backend=hpx')

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -62,7 +62,7 @@ class Flecsi(CMakePackage):
     depends_on('mpi', when='backend=mpi')
     depends_on('mpi', when='backend=legion')
     depends_on('mpi', when='backend=hpx')
-    depends_on('legion+shared_libs', when='backend=legion')
+    depends_on('legion+shared', when='backend=legion')
     depends_on('legion+hdf5', when='backend=legion +hdf5')
     depends_on('legion build_type=Debug', when='backend=legion +debug_backend')
     depends_on('hpx@1.4.1 cxxstd=17 malloc=system max_cpu_count=128', when='backend=hpx')

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -116,7 +116,7 @@ class Legion(CMakePackage):
     conflicts('+gasnet_debug', when='network=mpi')
     conflicts('+gasnet_debug', when='network=none')
 
-    variant('shared_libs', default=False,
+    variant('shared', default=False,
             description="Build shared libraries.")
 
     variant('bounds_checks', default=False,
@@ -221,7 +221,7 @@ class Legion(CMakePackage):
                 raise InstallError("'gasnet_root' is only valid when 'network=gasnet'.")
             options.append('-DLegion_EMBED_GASNet=OFF')
 
-        if '+shared_libs' in spec:
+        if '+shared' in spec:
             options.append('-DBUILD_SHARED_LIBS=ON')
         else:
             options.append('-DBUILD_SHARED_LIBS=OFF')


### PR DESCRIPTION
`legion`:
* does not have a `+mpi` variant
* does not have a `+shared` variant -- instead it is called `+shared_libs` 

Without this PR, using the new clingo-based concretizer:

```
$> spack spec flecsi+cinch
Input spec
--------------------------------
 -   flecsi+cinch

Concretized
--------------------------------
==> Error: variant "mpi" not found in package "legion" [required from package "flecsi"]
```

and if you plug that one:

```
$> spack spec flecsi+cinch
Input spec
--------------------------------
 -   flecsi+cinch

Concretized
--------------------------------
==> Error: variant "shared" not found in package "legion" [required from package "flecsi"]
```

@ktsai7 @JulienLoiseau @rspavel 
