### PR TITLE
Make gettext find libxml2

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -73,10 +73,8 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
             config_args.append('--disable-curses')
 
         if '+libxml2' in spec:
-            config_args.append('CPPFLAGS=-I{0}/include'.format(
+            config_args.append('--with-libxml2-prefix={0}'.format(
                 spec['libxml2'].prefix))
-            config_args.append('LDFLAGS=-L{0} -Wl,-rpath,{0}'.format(
-                spec['libxml2'].libs.directories[0]))
         else:
             config_args.append('--with-included-libxml')
 

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -48,7 +48,7 @@ class Libxml2(AutotoolsPackage):
     def headers(self):
         include_dir = self.spec.prefix.include.libxml2
         hl = find_all_headers(include_dir)
-        hl.directories = include_dir
+        hl.directories = [include_dir, self.spec.prefix.include]
         return hl
 
     def configure_args(self):


### PR DESCRIPTION
gettext uses a test with <libxml2/libxml/someheader.h> to locate a header,
and libxml2 itself includes <libxml/otherheader.h>, so both have to be
in the include path.

```
$ ldd `spack location -i gettext`/bin/xgettext | grep xml
	libxml2.so.2 => /path/to/spack/linux-ubuntu20.04-zen2/gcc-10.2.0/libxml2-2.9.10-hyfpqr2gjbhnzo4sdz4y55lzog5rkk7q/lib/libxml2.so.2 (0x00007f7ee2e8d000)
```