### PR TITLE
Add libfuse2

### DIFF
--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -20,6 +20,7 @@ class Libfuse(MesonPackage):
     version('3.9.4',  sha256='9e076ae757a09cac9ce1beb50b3361ae83a831e5abc0f1bf5cdf771cd1320338')
     version('3.9.3',  sha256='0f8f7ad9cc6667c6751efa425dd0a665dcc9d75f0b7fc0cb5b85141a514110e9')
     version('3.9.2',  sha256='b4409255cbda6f6975ca330f5b04cb335b823a95ddd8c812c3d224ec53478fc0')
+    version('2.9.9',  sha256='d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5')
 
     variant('useroot', default=False, description="Use root privileges to make fusermount a setuid binary after installation")
     variant('system_install', default=False, description=(
@@ -30,7 +31,7 @@ class Libfuse(MesonPackage):
     conflicts("+useroot", when='~system_install', msg="useroot requires system_install")
 
     # Drops the install script which does system configuration
-    patch('0001-Do-not-run-install-script.patch', when='~system_install')
+    patch('0001-Do-not-run-install-script.patch', when='@3: ~system_install')
 
     executables = ['^fusermount3?$']
 
@@ -49,3 +50,30 @@ class Libfuse(MesonPackage):
             args.append('-Duseroot=false')
 
         return args
+
+    # Before libfuse 3.x this was an autotools package
+    @when('@:2')
+    def meson(self, spec, prefix):
+        args = [
+            "--prefix={0}".format(prefix),
+            "MOUNT_FUSE_PATH={0}".format(self.prefix.sbin),
+            "UDEV_RULES_PATH={0}".format(self.prefix.etc),
+            "INIT_D_PATH={0}".format(self.prefix.etc),
+        ]
+
+        if 'default_library=shared' in self.spec:
+            args.extend(['--enable-shared', '--disable-static'])
+        elif 'default_library=static' in self.spec:
+            args.extend(['--disable-shared', '--enable-static'])
+        else:
+            args.extend(['--enable-shared', '--enable-static'])
+
+        configure(*args)
+
+    @when('@:2')
+    def build(self, spec, prefix):
+        make()
+
+    @when('@:2')
+    def install(self, spec, prefix):
+        make("install")

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -12,7 +12,7 @@ class Libfuse(MesonPackage):
     Userspace) interface"""
 
     homepage = "https://github.com/libfuse/libfuse"
-    url      = "https://github.com/libfuse/libfuse/archive/fuse-3.9.3.tar.gz"
+    url      = "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz"
 
     version('3.10.2', sha256='a16f93cc083264afd0d2958a0dc88f24c6c5d40a9f3842c645b1909e13edb75f')
     version('3.10.1', sha256='d8954e7b4c022c651aa80db3bb4a161437dd285cd5f1a23d0e25f055dcebe00d')
@@ -21,6 +21,11 @@ class Libfuse(MesonPackage):
     version('3.9.3',  sha256='0f8f7ad9cc6667c6751efa425dd0a665dcc9d75f0b7fc0cb5b85141a514110e9')
     version('3.9.2',  sha256='b4409255cbda6f6975ca330f5b04cb335b823a95ddd8c812c3d224ec53478fc0')
     version('2.9.9',  sha256='d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5')
+
+    def url_for_version(self, version):
+        if version < Version("3.0.0"):
+            return "https://github.com/libfuse/libfuse/releases/download/fuse-{0}/fuse-{1}.tar.gz".format(version, version)
+        return "https://github.com/libfuse/libfuse/archive/refs/tags/fuse-{0}.tar.gz".format(version)
 
     variant('useroot', default=False, description="Use root privileges to make fusermount a setuid binary after installation")
     variant('system_install', default=False, description=(


### PR DESCRIPTION
Between libfuse 2 and 3 the build system changed from autotools to meson. Some packages like `squashfuse` support both fuse 2 and fuse 3, and many distro's have libfuse.so (= 2.x) but not libfuse3.so