### PR TITLE
drop gettext dep from help2man

### DIFF
--- a/var/spack/repos/builtin/packages/help2man/package.py
+++ b/var/spack/repos/builtin/packages/help2man/package.py
@@ -18,5 +18,4 @@ class Help2man(AutotoolsPackage, GNUMirrorPackage):
     version('1.47.8', sha256='528f6a81ad34cbc76aa7dce5a82f8b3d2078ef065271ab81fda033842018a8dc')
     version('1.47.4', sha256='d4ecf697d13f14dd1a78c5995f06459bff706fd1ce593d1c02d81667c0207753')
 
-    depends_on('gettext', type='build')
     depends_on('perl', type=('build', 'run'))


### PR DESCRIPTION
help2man is a perl script, it only needs gettext as an optional build dependency, and at runtime it'll try to use perl-gettext (which we don't even have).

The issue is that gettext does not configure out of the box on arm/aarch64/fujitsu, and I can't do anything about it because gettext has to be built to build help2man which is needed for autotools
