### PR TITLE
Drop help2man in autoconf & bison

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -27,7 +27,6 @@ class Autoconf(AutotoolsPackage, GNUMirrorPackage):
 
     # Note: m4 is not a pure build-time dependency of autoconf. m4 is
     # needed when autoconf runs, not only when autoconf is built.
-    depends_on('help2man', type='build')
     depends_on('m4@1.4.6:', type=('build', 'run'))
     depends_on('perl', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/bison/package.py
+++ b/var/spack/repos/builtin/packages/bison/package.py
@@ -48,7 +48,6 @@ class Bison(AutotoolsPackage, GNUMirrorPackage):
     depends_on('diffutils', type='build')
     depends_on('m4', type=('build', 'run'))
     depends_on('perl', type='build')
-    depends_on('help2man', type='build')
 
     patch('pgi.patch', when='@3.0.4')
     # The NVIDIA compilers do not currently support some GNU builtins.


### PR DESCRIPTION
It's already shipping its man pages by default, we don't have to generate them

This reduces the number of prerequisite packages from 18 to 9 when trying to build anything with autotools