### PR TITLE
Fixes to flex

### DIFF
--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -32,6 +32,7 @@ class Flex(AutotoolsPackage):
 
     depends_on('bison',         type='build')
     depends_on('gettext@0.19:', type='build', when='+nls')
+    depends_on('gettext@0.19:', type='build', when='@:2.6.0,2.6.4')
     depends_on('help2man',      type='build', when='@:2.6.0,2.6.4')
     depends_on('findutils',     type='build')
     depends_on('diffutils',     type='build')

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -19,19 +19,20 @@ class Flex(AutotoolsPackage):
     executables = ['^flex$']
 
     version('2.6.4', sha256='e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995')
-    version('2.6.3', sha256='68b2742233e747c462f781462a2a1e299dc6207401dac8f0bbb316f48565c2aa')
+    version('2.6.3', sha256='68b2742233e747c462f781462a2a1e299dc6207401dac8f0bbb316f48565c2aa', preferred=True)
     # Avoid flex '2.6.2' (major bug)
     # See issue #2554; https://github.com/westes/flex/issues/113
     version('2.6.1', sha256='3c43f9e658e45e8aae3cf69fa11803d60550865f023852830d557c5f0623c13b')
     version('2.6.0', sha256='cde6e46064a941a3810f7bbc612a2c39cb3aa29ce7eb775089c2515d0adfa7e9')
     version('2.5.39', sha256='258d3c9c38cae05932fb470db58b6a288a361c448399e6bda2694ef72a76e7cd')
 
+    variant('nls', default=False, description="Enable native language support")
     variant('lex', default=True,
             description="Provide symlinks for lex and libl")
 
     depends_on('bison',         type='build')
-    depends_on('gettext@0.19:', type='build')
-    depends_on('help2man',      type='build')
+    depends_on('gettext@0.19:', type='build', when='+nls')
+    depends_on('help2man',      type='build', when='@:2.6.0,2.6.4')
     depends_on('findutils',     type='build')
     depends_on('diffutils',     type='build')
 
@@ -89,6 +90,11 @@ class Flex(AutotoolsPackage):
             url += "/archive/flex-{0}.tar.gz".format(version.dashed)
 
         return url
+
+    def configure_args(self):
+        args = []
+        args += self.enable_or_disable('nls')
+        return args
 
     @run_after('install')
     def symlink_lex(self):


### PR DESCRIPTION
- Prefer the version that doesn't need all the patches and extra build
tools
- Make dependency on gettext optional under the nls variant (off by
default)
- Drop the dependency on help2man if we don't have to regenerate the man
pages (when no patches are necessary)
