### PR TITLE
cmd: improve shell support help message

### DIFF
--- a/lib/spack/spack/cmd/common/__init__.py
+++ b/lib/spack/spack/cmd/common/__init__.py
@@ -22,7 +22,7 @@ def shell_init_instructions(cmd, equivalent):
     shell_specific = "{sh_arg}" in equivalent
 
     msg = [
-        "`%s` requires spack's shell support." % cmd,
+        "`%s` requires Spack's shell support." % cmd,
         "",
         "To set up shell support, run the command below for your shell.",
         "",
@@ -48,6 +48,13 @@ def shell_init_instructions(cmd, equivalent):
         ]
     else:
         msg += ["  " + equivalent]
+
+    msg += [
+        "",
+        "If you have already set up Spack's shell support but still receive",
+        "this message, please make sure to call Spack via the `spack` command",
+        "without any path components (such as `bin/spack`).",
+    ]
 
     msg += ['']
     tty.error(*msg)


### PR DESCRIPTION
Users sometimes set up Spack's shell support but still call `bin/spack`, which results in the help message showing up again.