### PR TITLE
hdf5: fix typo

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -180,7 +180,7 @@ class Hdf5(AutotoolsPackage):
             elif name == "cxxflags":
                 flags.append(self.compiler.cxx_pic_flag)
             elif name == "fflags":
-                flags.append(elf.compiler.fc_pic_flag)
+                flags.append(self.compiler.fc_pic_flag)
 
         # Quiet warnings/errors about implicit declaration of functions in C99
         if name == "cflags":


### PR DESCRIPTION
i have nothing. im terrible.  A local package was overriding this when i tested it.