### PR TITLE
New version scorep 7.0 based on opari2-2.0.6, otf2-2.3 +cubex-4.6

### DIFF
--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -15,6 +15,7 @@ class Scorep(AutotoolsPackage):
     homepage = "http://www.vi-hps.org/projects/score-p"
     url      = "https://www.vi-hps.org/cms/upload/packages/scorep/scorep-4.1.tar.gz"
 
+    version('7.0',   sha256='68f24a68eb6f94eaecf500e17448f566031946deab74f2cba072ee8368af0996', url='https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-7.0/scorep-7.0.tar.gz')
     version('6.0',   sha256='5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8')
     version('5.0',   sha256='0651614eacfc92ffbe5264a3efebd0803527ae6e8b11f7df99a56a02c37633e1')
     version('4.1',   sha256='7bb6c1eecdd699b4a3207caf202866778ee01f15ff39a9ec198fcd872578fe63')
@@ -26,7 +27,7 @@ class Scorep(AutotoolsPackage):
     version('1.3',   sha256='dcfd42bd05f387748eeefbdf421cb3cd98ed905e009303d70b5f75b217fd1254')
 
     patch('gcc7.patch', when='@1.4:3')
-    patch('gcc10.patch', when='@3.1:')
+    patch('gcc10.patch', when='@3.1:6.0')
 
     variant('mpi', default=True, description="Enable MPI support")
     variant('papi', default=True, description="Enable PAPI")
@@ -39,25 +40,29 @@ class Scorep(AutotoolsPackage):
     # information. Starting with scorep 4.0 / cube 4.4, Score-P only depends on
     # two components of cube -- cubew and cubelib.
 
+    # SCOREP 7
+    depends_on('otf2@2.3:', when='@7:')
+    depends_on('cubew@4.6:', when='@7:')
+    depends_on('cubelib@4.6:', when='@7:')
+    depends_on('opari2@2.0.6:', when='@7:')
     # SCOREP 6
     depends_on('otf2@2.2:', when='@6:')
     # SCOREP 4 and 5
     depends_on('otf2@2.1:', when='@4:')
-    depends_on('opari2@2.0:', when='@4:')
-    depends_on('cubew@4.4:', when='@4:')
-    depends_on('cubelib@4.4:', when='@4:')
+    depends_on('cubew@4.4:4.5', when='@4:6.99')
+    depends_on('cubelib@4.4:4.5', when='@4:6.99')
     # SCOREP 3
     depends_on('otf2@2:', when='@3:3.99')
-    depends_on('opari2@2:', when='@3:3.99')
-    depends_on('cube@4.3:', when='@3:3.99')
+    depends_on('opari2@2.0:2.0.5', when='@3:6.99')
+    depends_on('cube@4.3:4.3.5', when='@3:3.99')
     # SCOREP 2.0.2
     depends_on('otf2@2.0', when='@2.0.2')
     depends_on('opari2@2.0', when='@2.0.2')
-    depends_on('cube@4.3:4.4', when='@2.0.2')
+    depends_on('cube@4.3:4.3.5', when='@2.0.2')
     # SCOREP 1.4.2
     depends_on('otf2@1.5:1.6', when='@1.4.2')
     depends_on('opari2@1.1.4', when='@1.4.2')
-    depends_on('cube@4.3:4.4', when='@1.4.2')
+    depends_on('cube@4.2.3:4.3.5', when='@1.4.2')
     # SCOREP 1.3
     depends_on("otf2@1.4", when='@1.3')
     depends_on("opari2@1.1.4", when='@1.3')


### PR DESCRIPTION
Previous releases dependencies are made tighter since they were too large leading to compilation failures.
I was able to compile all previous releases, except 1.4.2 and 1.3.
Url for scorep 7 is new.