### PR TITLE
New version 0.65 and xsltproc(libxslt) dependency added

### DIFF
--- a/var/spack/repos/builtin/packages/moreutils/package.py
+++ b/var/spack/repos/builtin/packages/moreutils/package.py
@@ -16,11 +16,13 @@ class Moreutils(MakefilePackage):
 
     maintainers = ['matthiasdiener']
 
+    version('0.65', sha256='ba0cfaa1ff6ead2b15c62a67292de66a366f9b815a09697b54677f7e15f5a2b2')
     version('0.63', sha256='01f0b331e07e62c70d58c2dabbb68f5c4ddae4ee6f2d8f070fd1e316108af72c')
 
     depends_on('perl', type='build')
     depends_on('docbook-xsl', type='build')
     depends_on('libxml2', type='build')
+    depends_on('libxslt', type='build')
 
     def edit(self, spec, prefix):
         isutf8_makefile = FileFilter('is_utf8/Makefile')


### PR DESCRIPTION
Moreutils called xsltproc in build phase but dependency to libxslt was missing.
BTW added release 0.65 see https://joeyh.name/code/moreutils/news/version_0.65/
