### PR TITLE
py-tensorflow: continue to constrain h5py version

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -156,9 +156,8 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-google-pasta@0.1.6:', type=('build', 'run'), when='@1.14:2.0')
     depends_on('py-google-pasta@0.1.2:', type=('build', 'run'), when='@1.12.1')
     # propagate the mpi variant setting for h5py/hdf5 to avoid unexpected crashes
-    depends_on('py-h5py@2.10.0:2.10.999', type=('build', 'run'), when='@2.2:+mpi')
-    depends_on('py-h5py+mpi', type=('build', 'run'), when='@2.2:+mpi')
-    depends_on('py-h5py~mpi', type=('build', 'run'), when='@2.2:~mpi')
+    depends_on('py-h5py@2.10.0:2.10.999+mpi', type=('build', 'run'), when='@2.2:+mpi')
+    depends_on('py-h5py@2.10.0:2.10.999~mpi', type=('build', 'run'), when='@2.2:~mpi')
     depends_on('hdf5+mpi', type='build', when='@2.2:+mpi')
     depends_on('hdf5~mpi', type='build', when='@2.2:~mpi')
     depends_on('py-keras-applications@1.0.8:', type=('build', 'run'), when='@1.15:2.1')


### PR DESCRIPTION
cleanup from #23386