### PR TITLE
boost: Switch download URL

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -287,7 +287,7 @@ class Boost(Package):
 
     def url_for_version(self, version):
         if version >= Version('1.63.0'):
-            url = "https://dl.bintray.com/boostorg/release/{0}/source/boost_{1}.tar.bz2"
+            url = "https://boostorg.jfrog.io/artifactory/main/release/{0}/source/boost_{1}.tar.bz2"
         else:
             url = "http://downloads.sourceforge.net/project/boost/boost/{0}/boost_{1}.tar.bz2"
 


### PR DESCRIPTION
boost has moved its downloads from a bintray URL to a jfrog URL.

See: https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html

Maintainer-Ping: @hainest