### PR TITLE
root: Add variants: dcache and oracle

### DIFF
--- a/var/spack/repos/builtin/packages/root/README.md
+++ b/var/spack/repos/builtin/packages/root/README.md
@@ -12,10 +12,6 @@ The following configuration options are unsupported (set to `OFF`) due to missin
 
 Requires `libgapiUI` from ALICE.
 
-#### `dcache`
-
-DCache support depends on `libdcap` from DESY.
-
 #### `gfal`
 
 #### `http`
@@ -28,11 +24,7 @@ Monitoring with Monalisa depends on `libapmoncpp`.
 
 #### `odbc`
 
-#### `oracle`
-
 #### `tcmalloc`
-
-#### `veccore`
 
 #### `xinetd`
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -129,6 +129,8 @@ class Root(CMakePackage):
     variant('mysql', default=False)
     variant('opengl', default=True,
             description='Enable OpenGL support')
+    variant('oracle', default=True,
+            description='Enable support for Oracle databases')
     variant('postgres', default=False,
             description='Enable postgres support')
     variant('pythia6', default=False,
@@ -245,6 +247,7 @@ class Root(CMakePackage):
     depends_on('mysql-client',   when='+mysql')
     depends_on('openssl',   when='+ssl')
     depends_on('openssl',   when='+davix')  # Also with davix
+    depends_on('oracle-instant-client', when='+oracle')
     depends_on('postgresql', when='+postgres')
     depends_on('pythia6+root', when='+pythia6')
     depends_on('pythia8',   when='+pythia8')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -129,7 +129,7 @@ class Root(CMakePackage):
     variant('mysql', default=False)
     variant('opengl', default=True,
             description='Enable OpenGL support')
-    variant('oracle', default=True,
+    variant('oracle', default=False,
             description='Enable support for Oracle databases')
     variant('postgres', default=False,
             description='Enable postgres support')
@@ -141,6 +141,7 @@ class Root(CMakePackage):
             description='Enable Python ROOT bindings')
     variant('qt4', default=False,
             description='Enable Qt graphics backend')
+    variant('r', default=False,
     variant('r', default=False,
             description='Enable R ROOT bindings')
     variant('rpath', default=True,
@@ -405,7 +406,7 @@ class Root(CMakePackage):
             define_from_variant('mysql'),
             define('odbc', False),
             define_from_variant('opengl'),
-            define('oracle', False),
+            define_from_variant('oracle'),
             define_from_variant('pgsql', 'postgres'),
             define_from_variant('pythia6'),
             define_from_variant('pythia8'),

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -142,7 +142,6 @@ class Root(CMakePackage):
     variant('qt4', default=False,
             description='Enable Qt graphics backend')
     variant('r', default=False,
-    variant('r', default=False,
             description='Enable R ROOT bindings')
     variant('rpath', default=True,
             description='Enable RPATH')

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -90,6 +90,8 @@ class Root(CMakePackage):
             description='Enable Aqua interface')
     variant('davix', default=True,
             description='Compile with external Davix')
+    variant('dcache', default=False,
+            description='Enable support for dCache')
     variant('emacs', default=False,
             description='Enable Emacs support')
     variant('examples', default=True,
@@ -234,6 +236,7 @@ class Root(CMakePackage):
 
     # Optional dependencies
     depends_on('davix @0.7.1:', when='+davix')
+    depends_on('dcap',      when='+dcache')
     depends_on('cfitsio',   when='+fits')
     depends_on('fftw',      when='+fftw')
     depends_on('graphviz',  when='+graphviz')
@@ -370,7 +373,7 @@ class Root(CMakePackage):
             define_from_variant('cocoa', 'aqua'),
             define('dataframe', True),
             define_from_variant('davix'),
-            define('dcache', False),
+            define_from_variant('dcache'),
             define_from_variant('fftw3', 'fftw'),
             define_from_variant('fitsio', 'fits'),
             define_from_variant('ftgl', 'opengl'),

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -247,7 +247,7 @@ class Root(CMakePackage):
     depends_on('mysql-client',   when='+mysql')
     depends_on('openssl',   when='+ssl')
     depends_on('openssl',   when='+davix')  # Also with davix
-    depends_on('oracle-instant-client', when='+oracle')
+    depends_on('oracle-instant-client@19.10.0.0.0', when='+oracle @:6.24.01')
     depends_on('postgresql', when='+postgres')
     depends_on('pythia6+root', when='+pythia6')
     depends_on('pythia8',   when='+pythia8')


### PR DESCRIPTION
Notice: veccore variant was added earlier, I have just updated the README to reflect that