### PR TITLE
Update the CCE compiler module's CXX standard flags

### DIFF
--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -68,10 +68,9 @@ class Cce(Compiler):
     @property
     def cxx14_flag(self):
         if self.is_clang_based:
-            if self.real_version < ver('3.5'):
+            if self.real_version < ver('3.4'):
                 raise UnsupportedCompilerFlag(
-                    self, "the C++14 standard", "cxx14_flag", "< 3.5"
-                )
+                    self, "the C++14 standard", "cxx14_flag", "< 3.5")
             return '-std=c++14'
         # Raise an error because I don't know
         # modern CCE is clang-based, so it's likely old CCE

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -70,7 +70,7 @@ class Cce(Compiler):
         if self.is_clang_based:
             if self.real_version < ver('3.4'):
                 raise UnsupportedCompilerFlag(
-                    self, "the C++14 standard", "cxx14_flag", "< 3.5")
+                    self, "the C++14 standard", "cxx14_flag", "< 3.4")
             return '-std=c++14'
         # Raise an error because I don't know
         # modern CCE is clang-based, so it's likely old CCE

--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -66,6 +66,33 @@ class Cce(Compiler):
         return "-h std=c++11"
 
     @property
+    def cxx14_flag(self):
+        if self.is_clang_based:
+            if self.real_version < ver('3.5'):
+                raise UnsupportedCompilerFlag(
+                    self, "the C++14 standard", "cxx14_flag", "< 3.5"
+                )
+            return '-std=c++14'
+        # Raise an error because I don't know
+        # modern CCE is clang-based, so it's likely old CCE
+        # only supports up to C++11
+        raise UnsupportedCompilerFlag(
+            self, "the C++14 standard", "cxx14_flag", "< unknown")
+
+    @property
+    def cxx17_flag(self):
+        if self.is_clang_based:
+            if self.real_version < ver('5.0'):
+                raise UnsupportedCompilerFlag(
+                    self, "the C++17 standard", "cxx17_flag", "< 5")
+            return '-std=c++17'
+        # Raise an error because I don't know
+        # modern CCE is clang-based, so it's likely old CCE
+        # only supports up to C++11
+        raise UnsupportedCompilerFlag(
+            self, "the C++17 standard", "cxx17_flag", "< unknown")
+
+    @property
     def c99_flag(self):
         if self.is_clang_based:
             return '-std=c99'


### PR DESCRIPTION
This adds definitions for clang-based CCE up to what I know is officially supported.

The logic will throw for non-clang CCE, as I don't know what that supports (probably stopped at C++11)

Tested on Cray platform using CCE 12

Closes #23443