### PR TITLE
Show useful error in build-env

### DIFF
--- a/lib/spack/spack/cmd/common/env_utility.py
+++ b/lib/spack/spack/cmd/common/env_utility.py
@@ -53,6 +53,9 @@ def emulate_env_utility(cmd_name, context, args):
         spec = args.spec[0]
         cmd = args.spec[1:]
 
+    if not spec:
+        tty.die("spack %s requires a spec." % cmd_name)
+
     specs = spack.cmd.parse_specs(spec, concretize=False)
     if len(specs) > 1:
         tty.die("spack %s only takes one spec." % cmd_name)

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -6,9 +6,9 @@
 from six.moves import cPickle
 import pytest
 
-from spack.main import SpackCommand, SpackCommandError
+from spack.main import SpackCommand
 
-info = SpackCommand('build-env')
+build_env = SpackCommand('build-env')
 
 
 @pytest.mark.parametrize('pkg', [
@@ -17,17 +17,24 @@ info = SpackCommand('build-env')
 ])
 @pytest.mark.usefixtures('config')
 def test_it_just_runs(pkg):
-    info(*pkg)
+    build_env(*pkg)
 
 
-@pytest.mark.parametrize('pkg,error_cls', [
-    ('zlib libszip', SpackCommandError),
-    ('', IndexError)
+@pytest.mark.usefixtures('config')
+def test_error_when_multiple_specs_are_given():
+    output = build_env('libelf libdwarf', fail_on_error=False)
+    assert 'only takes one spec' in output
+
+
+@pytest.mark.parametrize('args', [
+    ('--', '/bin/bash', '-c', 'echo test'),
+    ('--',),
+    (),
 ])
 @pytest.mark.usefixtures('config')
-def test_it_just_fails(pkg, error_cls):
-    with pytest.raises(error_cls):
-        info(pkg)
+def test_build_env_requires_a_spec(args):
+    output = build_env(*args, fail_on_error=False)
+    assert 'requires a spec' in output
 
 
 _out_file = 'env.out'
@@ -36,7 +43,7 @@ _out_file = 'env.out'
 @pytest.mark.usefixtures('config')
 def test_dump(tmpdir):
     with tmpdir.as_cwd():
-        info('--dump', _out_file, 'zlib')
+        build_env('--dump', _out_file, 'zlib')
         with open(_out_file) as f:
             assert(any(line.startswith('PATH=') for line in f.readlines()))
 
@@ -44,7 +51,7 @@ def test_dump(tmpdir):
 @pytest.mark.usefixtures('config')
 def test_pickle(tmpdir):
     with tmpdir.as_cwd():
-        info('--pickle', _out_file, 'zlib')
+        build_env('--pickle', _out_file, 'zlib')
         environment = cPickle.load(open(_out_file, 'rb'))
         assert(type(environment) == dict)
         assert('PATH' in environment)


### PR DESCRIPTION
Instead of an out of bounds error tell the user to provide a spec.

Previous behavior

```
$ spack build-env -- /bin/bash
==> Error: list index out of range
```

This PR:

```
$ spack build-env -- /bin/bash
==> Error: spack build-env requires a spec.
```
