### PR TITLE
ASP-based solver: minimize target mismatches

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -535,29 +535,19 @@ node_target_weight(Package, Weight)
     node_target(Package, Target),
     target_weight(Target, Package, Weight).
 
-% compatibility rules for targets among nodes
-node_target_match_pref(Dependency, Target)
-  :- depends_on(Package, Dependency),
-     node_target_match_pref(Package, Target),
-     not node_target_set(Dependency, _).
-
-node_target_match_pref(Dependency, Target)
-  :- depends_on(Package, Dependency),
-     node_target_set(Package, Target),
-     not node_target_match_pref(Package, Target),
-     not node_target_set(Dependency, _).
-
-node_target_match_pref(Dependency, Target)
-  :- depends_on(Package, Dependency),
-     root(Package), node_target(Package, Target),
-     not node_target_match_pref(Package, _).
-
-node_target_match(Package, 1)
-  :- node_target(Package, Target), node_target_match_pref(Package, Target).
-
 derive_target_from_parent(Parent, Package)
-  :- depends_on(Parent, Package), not package_target_weight(_, Package, _).
+  :- depends_on(Parent, Package),
+     not package_target_weight(_, Package, _).
 
+% compatibility rules for targets among nodes
+node_target_match(Parent, Dependency)
+  :- depends_on(Parent, Dependency),
+     node_target(Parent, Target),
+     node_target(Dependency, Target).
+
+node_target_mismatch(Parent, Dependency)
+  :- depends_on(Parent, Dependency),
+     not node_target_match(Parent, Dependency).
 
 #defined node_target_set/2.
 #defined package_target_weight/3.
@@ -605,17 +595,14 @@ node_compiler_version(Package, Compiler, Version) :- node_compiler_version_set(P
 
 % If a package and one of its dependencies don't have the
 % same compiler there's a mismatch.
-compiler_mismatch(Package, Dependency)
+compiler_match(Package, Dependency)
   :- depends_on(Package, Dependency),
-     node_compiler_version(Package, Compiler1, _),
-     node_compiler_version(Dependency, Compiler2, _),
-     Compiler1 != Compiler2.
+     node_compiler_version(Package, Compiler, Version),
+     node_compiler_version(Dependency, Compiler, Version).
 
 compiler_mismatch(Package, Dependency)
   :- depends_on(Package, Dependency),
-     node_compiler_version(Package, Compiler, Version1),
-     node_compiler_version(Dependency, Compiler, Version2),
-     Version1 != Version2.
+     not compiler_match(Package, Dependency).
 
 #defined node_compiler_set/2.
 #defined node_compiler_version_set/3.
@@ -754,7 +741,7 @@ opt_criterion(8, "count of non-root multi-valued variants").
 #minimize{ 0@8 : #true }.
 #maximize {
     1@8,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, Weight),
+    : variant_not_default(Package, Variant, Value, _),
     not variant_single_value(Package, Variant),
     not root(Package)
 }.
@@ -776,11 +763,11 @@ opt_criterion(5, "non-preferred compilers").
 #minimize{ 0@5 : #true }.
 #minimize{ Weight@5,Package : compiler_weight(Package, Weight) }.
 
-% Maximize the number of matches for targets in the DAG, try
+% Minimize the number of mismatches for targets in the DAG, try
 % to select the preferred target.
-opt_criterion(4, "target matches").
+opt_criterion(4, "target mismatches").
 #minimize{ 0@4 : #true }.
-#maximize{ Weight@4,Package : node_target_match(Package, Weight) }.
+#minimize{ 1@4,Package,Dependency : node_target_mismatch(Package, Dependency) }.
 
 opt_criterion(3, "non-preferred targets").
 #minimize{ 0@3 : #true }.


### PR DESCRIPTION
Like compilers,  targets now try to minimize mismatches instead of maximizing matches. Deduction of mismatches is reworked to be the opposite of a match, since computing that is faster.