### PR TITLE
arrow: zstd+pic variant does not exist anymore

### DIFF
--- a/var/spack/repos/builtin/packages/arrow/package.py
+++ b/var/spack/repos/builtin/packages/arrow/package.py
@@ -32,7 +32,7 @@ class Arrow(CMakePackage, CudaPackage):
     depends_on('rapidjson')
     depends_on('snappy~shared')
     depends_on('zlib+pic')
-    depends_on('zstd+pic')
+    depends_on('zstd')
     depends_on('thrift+pic', when='+parquet')
     depends_on('orc', when='+orc')
 


### PR DESCRIPTION
Trying to fix a concretization error here; The zstd+pic variant has been remove and arrow builds fine with `depends_on('zstd')` so I assume this is ok. 

Maybe zstd maintainer @haampie can comment.