### PR TITLE
Disable dependency tracking in autotools-based packages

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -83,6 +83,8 @@ class AutotoolsPackage(PackageBase):
     #: after the installation. If True instead it installs them.
     install_libtool_archives = False
 
+    track_dependencies = False
+
     @property
     def _removed_la_files_log(self):
         """File containing the list of remove libtool archives"""
@@ -336,6 +338,11 @@ class AutotoolsPackage(PackageBase):
         """
         options = getattr(self, 'configure_flag_args', [])
         options += ['--prefix={0}'.format(prefix)]
+        if self.track_dependencies:
+            options += ['--enable-dependency-tracking']
+        else:
+            options += ['--disable-dependency-tracking']
+
         options += self.configure_args()
 
         with working_dir(self.build_directory, create=True):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -338,10 +338,11 @@ class AutotoolsPackage(PackageBase):
         """
         options = getattr(self, 'configure_flag_args', [])
         options += ['--prefix={0}'.format(prefix)]
-        if self.track_dependencies:
-            options += ['--enable-dependency-tracking']
-        else:
-            options += ['--disable-dependency-tracking']
+        if self.track_dependencies is not None:
+            if self.track_dependencies:
+                options += ['--enable-dependency-tracking']
+            else:
+                options += ['--disable-dependency-tracking']
 
         options += self.configure_args()
 


### PR DESCRIPTION
According to [autotools documentation](https://www.gnu.org/software/automake/manual/html_node/Dependency-Tracking.html), this speeds up one-time builds (and spack builds are one-time)