### PR TITLE
Adding package adms

### DIFF
--- a/var/spack/repos/builtin/packages/adms/package.py
+++ b/var/spack/repos/builtin/packages/adms/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class Adms(AutotoolsPackage):
+    """ADMS is a code generator that converts electrical compact device models
+       specified in high-level description language into ready-to-compile c code
+       for the API of spice simulators."""
+
+    homepage = "https://sourceforge.net/projects/mot-adms/"
+    url      = "https://github.com/Qucs/ADMS/releases/download/release-2.3.7/adms-2.3.7.tar.gz"
+    git      = "https://github.com/Qucs/ADMS.git"
+
+    maintainers = ['cessenat']
+
+    version('master', branch='master')
+    version('2.3.7', sha256='3a78e1283ecdc3f356410474b3ff44c4dcc82cb89772087fd3bbde8a1038ce08')
+
+    depends_on('bison@2.5:', type='build')
+    depends_on('flex', type='build')
+
+    @when('@master')
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('./bootstrap.sh')

--- a/var/spack/repos/builtin/packages/adms/package.py
+++ b/var/spack/repos/builtin/packages/adms/package.py
@@ -20,6 +20,7 @@ class Adms(AutotoolsPackage):
 
     depends_on('bison@2.5:', type='build')
     depends_on('flex', type='build')
+    depends_on('perl-xml-libxml', type='build')
 
     @when('@master')
     def autoreconf(self, spec, prefix):


### PR DESCRIPTION
ADMS is a code generator that converts electrical compact device models
specified in high-level description language into ready-to-compile c code
for the API of spice simulators.
This package is an option to ngspice.
https://sourceforge.net/projects/mot-adms/
https://github.com/Qucs/ADMS