### PR TITLE
Fixes for cray-mpich on Alps/Eiger

### DIFF
--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -25,6 +25,9 @@ class Aocc(Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['flang']
 
+    PrgEnv = 'PrgEnv-aocc'
+    PrgEnv_compiler = 'aocc'
+
     version_argument = '--version'
 
     @property

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -220,6 +220,9 @@ class Cp2k(MakefilePackage, CudaPackage):
                 if os.path.exists(incdir):
                     fftw_header_dir = incdir
                     break
+        elif '^cray-fftw' in spec:
+            fftw = spec['cray-fftw']
+            fftw_header_dir = fftw.headers.directories[0]
 
         optimization_flags = {
             'gcc': [

--- a/var/spack/repos/builtin/packages/cray-fftw/package.py
+++ b/var/spack/repos/builtin/packages/cray-fftw/package.py
@@ -28,7 +28,6 @@ class CrayFftw(Package):
 
     provides('fftw-api@3')
 
-
     variant(
         'precision', values=any_combination_of(
             'float', 'double'

--- a/var/spack/repos/builtin/packages/cray-fftw/package.py
+++ b/var/spack/repos/builtin/packages/cray-fftw/package.py
@@ -28,7 +28,49 @@ class CrayFftw(Package):
 
     provides('fftw-api@3')
 
+
+    variant(
+        'precision', values=any_combination_of(
+            'float', 'double'
+        ).prohibit_empty_set().with_default('float,double'),
+        description='Build the selected floating-point precision libraries'
+    )
+
+    variant('openmp', default=False, description="Enable OpenMP support.")
+    variant('mpi', default=True, description='Activate MPI support')
+    depends_on('mpi', when='+mpi')
+
     def install(self, spec, prefix):
         raise InstallError(
             self.spec.format('{name} is not installable, you need to specify '
                              'it as an external package in packages.yaml'))
+
+    @property
+    def libs(self):
+
+        # Reduce repetitions of entries
+        query_parameters = list(llnl.util.lang.dedupe(
+            self.spec.last_query.extra_parameters
+        ))
+
+        # List of all the suffixes associated with float precisions
+        precisions = [
+            ('float', 'f'),
+            ('double', ''),
+        ]
+
+        # Retrieve the correct suffixes, or use double as a default
+        suffixes = [v for k, v in precisions if k in query_parameters] or ['']
+
+        # Construct the list of libraries that needs to be found
+        libraries = []
+        for sfx in suffixes:
+            if 'mpi' in query_parameters and '+mpi' in self.spec:
+                libraries.append('libfftw3' + sfx + '_mpi')
+
+            if 'openmp' in query_parameters and '+openmp' in self.spec:
+                libraries.append('libfftw3' + sfx + '_omp')
+
+            libraries.append('libfftw3' + sfx)
+
+        return find_libraries(libraries, root=self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -35,7 +35,8 @@ class CrayLibsci(Package):
         'gcc': 'GNU',
         'cce': 'CRAY',
         'intel': 'INTEL',
-        'clang': 'ALLINEA'
+        'clang': 'ALLINEA',
+        'aocc': 'AOCC'
     }
 
     @property

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.util.module_cmd import module
+from spack.util.module_cmd import get_path_args_from_module_line
 
 
 class CrayMpich(Package):

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -6,6 +6,7 @@
 from spack import *
 from spack.util.module_cmd import module
 from spack.util.module_cmd import get_path_args_from_module_line
+import os
 
 
 class CrayMpich(Package):
@@ -79,7 +80,7 @@ class CrayMpich(Package):
     def headers(self):
         hdrs = find_headers('mpi', self.prefix.include, recursive=True)
         hdrs.directories = os.path.dirname(hdrs[0])
-        return hdrs or None
+        return hdrs
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -27,6 +27,26 @@ class CrayMpich(Package):
 
     provides('mpi@3')
 
+    canonical_names = {
+        'gcc': 'GNU',
+        'cce': 'CRAY',
+        'intel': 'INTEL',
+        'clang': 'ALLINEA',
+        'aocc': 'AOCC'
+    }
+
+    @property
+    def modname(self):
+        return "cray-mpich/{0}".format(self.version)
+
+    @property
+    def external_prefix(self):
+        mpich_module = module("show", self.modname).splitlines()
+
+        for line in mpich_module:
+            if "CRAY_MPICH_DIR" in line:
+                return get_path_args_from_module_line(line)[0]
+
     def setup_run_environment(self, env):
         env.set('MPICC', spack_cc)
         env.set('MPICXX', spack_cxx)
@@ -49,12 +69,33 @@ class CrayMpich(Package):
         spec.mpifc = spack_fc
         spec.mpif77 = spack_f77
 
-        spec.mpicxx_shared_libs = [
-            join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
-            join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
-        ]
-
     def install(self, spec, prefix):
         raise InstallError(
             self.spec.format('{name} is not installable, you need to specify '
                              'it as an external package in packages.yaml'))
+    @property
+    def headers(self):
+        hdrs = find_headers('mpi', self.prefix.include, recursive=True)
+        hdrs.directories = os.path.dirname(hdrs[0])
+        return hdrs or None
+
+    @property
+    def libs(self):
+        query_parameters = self.spec.last_query.extra_parameters
+
+        libraries = ['libmpich']
+
+        if 'cxx' in query_parameters:
+            libraries.append('libmpicxx', 'libmpichcxx')
+
+        if 'f77' in query_parameters:
+            libraries.extend(['libmpifort', 'libmpichfort',
+                              'libfmpi', 'libfmpich'])
+
+        if 'f90' in query_parameters:
+            libraries.extend(['libmpif90', 'libmpichf90'])
+
+        libs = find_libraries(libraries, root=self.prefix.lib, recursive=True)
+        libs += find_libraries(libraries, root=self.prefix.lib64, recursive=True)
+
+        return libs

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -89,7 +89,7 @@ class CrayMpich(Package):
         libraries = ['libmpich']
 
         if 'cxx' in query_parameters:
-            libraries.append('libmpicxx', 'libmpichcxx')
+            libraries.extend(['libmpicxx', 'libmpichcxx'])
 
         if 'f77' in query_parameters:
             libraries.extend(['libmpifort', 'libmpichfort',

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -76,6 +76,7 @@ class CrayMpich(Package):
         raise InstallError(
             self.spec.format('{name} is not installable, you need to specify '
                              'it as an external package in packages.yaml'))
+
     @property
     def headers(self):
         hdrs = find_headers('mpi', self.prefix.include, recursive=True)


### PR DESCRIPTION
Ping @dev-zero

Note that this does not fix the warning mentioned in #23445, but it gets the right path through the `external_prefix` property (similar to cray-libsci/package.py).

```
$ ./spack/bin/spack -e . python -c "from spack.spec import Spec; x = Spec('cray-mpich'); x.concretize(); x['cray-mpich:f90'].libs"
==> Warning: Extracted path from module does not exist [module=cray-mpich/8.1.4, path=/opt/cray/pe/mpich/8.1.4/gtl/lib")]
LibraryList(['/opt/cray/pe/mpich/8.1.4/ofi/aocc/2.2/lib/libmpich.so', '/opt/cray/pe/mpich/8.1.4/ofi/aocc/2.2/lib/libmpichf90.so'])
```

The above warning is gone after #23472