### PR TITLE
env views: make view updates atomic

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -626,7 +626,7 @@ class ViewDescriptor(object):
             # mv symlink atomically over root symlink to old_root
             if os.path.exists(self.root) and not os.path.islink(self.root):
                 msg = "Cannot create view: "
-                msg += "file already exists and is not a link: %" % self.root
+                msg += "file already exists and is not a link: %s" % self.root
                 raise SpackEnvironmentViewError(msg)
             os.rename(tmp_symlink_name, self.root)
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -510,7 +510,7 @@ class ViewDescriptor(object):
         content_hash = self.content_hash(specs)
         root_dir = os.path.dirname(self.root)
         root_name = os.path.basename(self.root)
-        return os.path.join(root_dir, '._%s_%s' % (root_name, content_hash))
+        return os.path.join(root_dir, '._%s' % root_name, content_hash)
 
     def content_hash(self, specs):
         d = syaml.syaml_dict([

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -616,7 +616,7 @@ class ViewDescriptor(object):
             old_root = self._current_root
 
             if new_root == old_root:
-                tty.msg("View at %s does not need regeneration." % self.root)
+                tty.debug("View at %s does not need regeneration." % self.root)
                 return
 
             # construct view at new_root
@@ -645,8 +645,10 @@ class ViewDescriptor(object):
             if old_root and os.path.exists(old_root):
                 try:
                     shutil.rmtree(old_root)
-                except (IOError, OSError):
-                    tty.warn("Failed to remove old view at %s" % old_root)
+                except (IOError, OSError) as e:
+                    msg = "Failed to remove old view at %s\n" % old_root
+                    msg += str(e)
+                    tty.warn(msg)
 
 
 class Environment(object):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -532,11 +532,20 @@ class ViewDescriptor(object):
         rel_path = os.path.relpath(view_path, self._current_root)
         return os.path.join(self.root, rel_path)
 
-    def view(self, new=False):
-        # new option to generate a view for a new underlying root
-        # during regeneration, should not be used to access specs.
-        # Otherwise, give the current view if there is one.
-        # Raise if there is no current view
+    def view(self, new=None):
+        """
+        Generate the FilesystemView object for this ViewDescriptor
+
+        By default, this method returns a FilesystemView object rooted at the
+        current underlying root of this ViewDescriptor (self._current_root)
+
+        Raise if new is None and there is no current view
+
+        Arguments:
+            new (string or None): If a string, create a FilesystemView
+                rooted at that path. Default None. This should only be used to
+                regenerate the view, and cannot be used to access specs.
+        """
         root = self._current_root
         if new:
             root = new

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -544,7 +544,7 @@ class ViewDescriptor(object):
             # This can only be hit if we write a future bug
             msg = ("Attempting to get nonexistent view from environment. "
                    "View root is at %s" % self.root)
-            raise RuntimeError(msg)
+            raise SpackEnvironmentViewError(msg)
         return YamlFilesystemView(root, spack.store.layout,
                                   ignore_conflicts=True,
                                   projections=self.projections)
@@ -625,7 +625,9 @@ class ViewDescriptor(object):
 
             # mv symlink atomically over root symlink to old_root
             if os.path.exists(self.root) and not os.path.islink(self.root):
-                raise RuntimeError("Cannot create view: file already exists")
+                msg = "Cannot create view: "
+                msg += "file already exists and is not a link: %" % self.root
+                raise SpackEnvironmentViewError(msg)
             os.rename(tmp_symlink_name, self.root)
 
             # remove old_root
@@ -2143,3 +2145,7 @@ def is_latest_format(manifest):
 
 class SpackEnvironmentError(spack.error.SpackError):
     """Superclass for all errors to do with Spack environments."""
+
+
+class SpackEnvironmentViewError(SpackEnvironmentError):
+    """Class for errors regarding view generation."""

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -630,6 +630,8 @@ class ViewDescriptor(object):
             # create symlink from tmpname to new_root
             root_dirname = os.path.dirname(self.root)
             tmp_symlink_name = os.path.join(root_dirname, '._view_link')
+            if os.path.exists(tmp_symlink_name):
+                os.unlink(tmp_symlink_name)
             os.symlink(new_root, tmp_symlink_name)
 
             # mv symlink atomically over root symlink to old_root

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -630,7 +630,10 @@ class ViewDescriptor(object):
 
             # remove old_root
             if old_root and os.path.exists(old_root):
-                shutil.rmtree(old_root)
+                try:
+                    shutil.rmtree(old_root)
+                except (IOError, OSError):
+                    tty.warn("Failed to remove old view at %s" % old_root)
 
 
 class Environment(object):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -2,9 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import base64
 import collections
-import hashlib
 import os
 import re
 import sys
@@ -35,6 +33,7 @@ import spack.util.environment
 from spack.spec import Spec
 from spack.spec_list import SpecList, InvalidSpecConstraintError
 from spack.variant import UnknownVariantError
+import spack.util.hash
 import spack.util.lock as lk
 from spack.util.path import substitute_path_variables
 import spack.util.path
@@ -519,13 +518,7 @@ class ViewDescriptor(object):
             ('specs', [(spec.full_hash(), spec.prefix) for spec in sorted(specs)])
         ])
         contents = sjson.dump(d)
-        sha = hashlib.sha1(contents.encode('utf-8'))
-        b32_hash = base64.b32encode(sha.digest()).lower()
-
-        if sys.version_info[0] >= 3:
-            b32_hash = b32_hash.decode('utf-8')
-
-        return b32_hash
+        return spack.util.hash.b32_hash(contents)
 
     def get_projection_for_spec(self, spec):
         """Get projection for spec relative to view root

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -9,6 +9,7 @@ from six import StringIO
 import pytest
 
 import llnl.util.filesystem as fs
+import llnl.util.link_tree
 
 import spack.hash_types as ht
 import spack.modules
@@ -1084,7 +1085,7 @@ def test_store_different_build_deps():
 
 def test_env_updates_view_install(
         tmpdir, mock_stage, mock_fetch, install_mockery):
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):
         add('mpileaks')
@@ -1095,12 +1096,13 @@ def test_env_updates_view_install(
 
 def test_env_view_fails(
         tmpdir, mock_packages, mock_stage, mock_fetch, install_mockery):
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):
         add('libelf')
         add('libelf cflags=-g')
-        with pytest.raises(RuntimeError, match='merge blocked by file'):
+        with pytest.raises(llnl.util.link_tree.MergeConflictError,
+                           match='merge blocked by file'):
             install('--fake')
 
 
@@ -1113,7 +1115,7 @@ def test_env_without_view_install(
     with pytest.raises(spack.environment.SpackEnvironmentError):
         test_env.default_view
 
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
 
     with ev.read('test'):
         add('mpileaks')
@@ -1148,7 +1150,7 @@ env:
 
 def test_env_updates_view_install_package(
         tmpdir, mock_stage, mock_fetch, install_mockery):
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):
         install('--fake', 'mpileaks')
@@ -1158,7 +1160,7 @@ def test_env_updates_view_install_package(
 
 def test_env_updates_view_add_concretize(
         tmpdir, mock_stage, mock_fetch, install_mockery):
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     install('--fake', 'mpileaks')
     with ev.read('test'):
@@ -1170,7 +1172,7 @@ def test_env_updates_view_add_concretize(
 
 def test_env_updates_view_uninstall(
         tmpdir, mock_stage, mock_fetch, install_mockery):
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):
         install('--fake', 'mpileaks')
@@ -1185,7 +1187,7 @@ def test_env_updates_view_uninstall(
 
 def test_env_updates_view_uninstall_referenced_elsewhere(
         tmpdir, mock_stage, mock_fetch, install_mockery):
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     install('--fake', 'mpileaks')
     with ev.read('test'):
@@ -1202,7 +1204,7 @@ def test_env_updates_view_uninstall_referenced_elsewhere(
 
 def test_env_updates_view_remove_concretize(
         tmpdir, mock_stage, mock_fetch, install_mockery):
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     install('--fake', 'mpileaks')
     with ev.read('test'):
@@ -1220,7 +1222,7 @@ def test_env_updates_view_remove_concretize(
 
 def test_env_updates_view_force_remove(
         tmpdir, mock_stage, mock_fetch, install_mockery):
-    view_dir = tmpdir.mkdir('view')
+    view_dir = tmpdir.join('view')
     env('create', '--with-view=%s' % view_dir, 'test')
     with ev.read('test'):
         install('--fake', 'mpileaks')

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -13,6 +13,7 @@ import spack.package
 from spack.spec import Spec
 from spack.dependency import all_deptypes, Dependency, canonical_deptype
 from spack.util.mock_package import MockPackageMultiRepo
+import spack.util.hash as hashutil
 
 
 def check_links(spec_to_check):
@@ -705,17 +706,17 @@ class TestSpecDag(object):
                                 for c in test_hash])
 
             for bits in (1, 2, 3, 4, 7, 8, 9, 16, 64, 117, 128, 160):
-                actual_int = spack.spec.base32_prefix_bits(test_hash, bits)
+                actual_int = hashutil.base32_prefix_bits(test_hash, bits)
                 fmt = "#0%sb" % (bits + 2)
                 actual = format(actual_int, fmt).replace('0b', '')
 
                 assert expected[:bits] == actual
 
             with pytest.raises(ValueError):
-                spack.spec.base32_prefix_bits(test_hash, 161)
+                hashutil.base32_prefix_bits(test_hash, 161)
 
             with pytest.raises(ValueError):
-                spack.spec.base32_prefix_bits(test_hash, 256)
+                hashutil.base32_prefix_bits(test_hash, 256)
 
     def test_traversal_directions(self):
         """Make sure child and parent traversals of specs work."""

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -72,7 +72,7 @@ def environment_modifications_for_spec(spec, view=None):
     the view."""
     spec = spec.copy()
     if view and not spec.external:
-        spec.prefix = prefix.Prefix(view.view().get_projection_for_spec(spec))
+        spec.prefix = prefix.Prefix(view.get_projection_for_spec(spec))
 
     # generic environment modifications determined by inspecting the spec
     # prefix

--- a/lib/spack/spack/util/hash.py
+++ b/lib/spack/spack/util/hash.py
@@ -11,6 +11,7 @@ import spack.util.crypto
 
 
 def b32_hash(content):
+    """Return the b32 encoded sha1 hash of the input string as a string."""
     sha = hashlib.sha1(content.encode('utf-8'))
     b32_hash = base64.b32encode(sha.digest()).lower()
 

--- a/lib/spack/spack/util/hash.py
+++ b/lib/spack/spack/util/hash.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import base64
+import hashlib
+import sys
+
+import spack.util.crypto
+
+def b32_hash(content):
+    sha = hashlib.sha1(content.encode('utf-8'))
+    b32_hash = base64.b32encode(sha.digest()).lower()
+
+    if sys.version_info[0] >= 3:
+        b32_hash = b32_hash.decode('utf-8')
+
+    return b32_hash
+
+
+def base32_prefix_bits(hash_string, bits):
+    """Return the first <bits> bits of a base32 string as an integer."""
+    if bits > len(hash_string) * 5:
+        raise ValueError("Too many bits! Requested %d bit prefix of '%s'."
+                         % (bits, hash_string))
+
+    hash_bytes = base64.b32decode(hash_string, casefold=True)
+    return spack.util.crypto.prefix_bits(hash_bytes, bits)

--- a/lib/spack/spack/util/hash.py
+++ b/lib/spack/spack/util/hash.py
@@ -9,6 +9,7 @@ import sys
 
 import spack.util.crypto
 
+
 def b32_hash(content):
     sha = hashlib.sha1(content.encode('utf-8'))
     b32_hash = base64.b32encode(sha.digest()).lower()


### PR DESCRIPTION
Currently, environment views blink out of existence during the view regeneration, and are slowly built back up to their new and improved state. This is not good if other processes attempt to access the view -- they can see it in an inconsistent state.

This PR fixes makes environment view updates atomic. This requires a level of indirection (via symlink, similar to nix or guix) from the view root to the underlying implementation on the filesystem. 

Now, an environment view at `/path/to/foo` is a symlink to `/path/to/._foo/<hash>`, where `<hash>` is a hash of the contents of the view.  We construct the view in its content-keyed hash directory, create a new symlink to this directory, and atomically replace the symlink with one to the new view.

This PR also future-proofs environment views so that we can implement rollback.

For background:
* there is no atomic operation in posix that allows for a non-empty directory to be replaced.
* There is an atomic `renameat2` in the linux kernel starting in version 3.15, but many filesystems don't support the system call, including NFS3 and NFS4, which makes it a poor implementation choice for an HPC tool, so we use the symlink approach that others tools like nix and guix have used successfully.