### PR TITLE
geos: Fix config issues with python bindings using python3 (#23479)

### DIFF
--- a/var/spack/repos/builtin/packages/geos/geos_python3_config.patch
+++ b/var/spack/repos/builtin/packages/geos/geos_python3_config.patch
@@ -1,4 +1,4 @@
-diff -Naur spack-src/configure spack-src.patched/configure
+diff -Naur spack-src/configure spack-src.patched/configure 
 --- spack-src/configure	2020-03-10 13:55:53.000000000 -0400
 +++ spack-src.patched/configure	2021-05-06 11:33:59.062284048 -0400
 @@ -19263,10 +19263,11 @@

--- a/var/spack/repos/builtin/packages/geos/geos_python3_config.patch
+++ b/var/spack/repos/builtin/packages/geos/geos_python3_config.patch
@@ -1,0 +1,67 @@
+diff -Naur spack-src/configure spack-src.patched/configure
+--- spack-src/configure	2020-03-10 13:55:53.000000000 -0400
++++ spack-src.patched/configure	2021-05-06 11:33:59.062284048 -0400
+@@ -19263,10 +19263,11 @@
+ 
+ 
+         # Check for Python library path
++        PYTHON_MAJOR=`echo $PYTHON_VERSION | sed "s,\..*$,,"`
+         { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python library path" >&5
+ $as_echo_n "checking for Python library path... " >&6; }
+         for i in "$base_python_path/lib/python$PYTHON_VERSION/config/" "$base_python_path/lib/python$PYTHON_VERSION/" "$base_python_path/lib/python/config/" "$base_python_path/lib/python/" "$base_python_path/" "$base_python_path/libs/" ; do
+-                python_path=`find $i -name libpython$PYTHON_VERSION.* -print 2> /dev/null | sed "1q"`
++                python_path=`find $i -name libpython$PYTHON_MAJOR.* -print 2> /dev/null | sed "1q"`
+                 if test -n "$python_path" ; then
+                         break
+                 fi
+@@ -19277,7 +19278,7 @@
+         if test -z "$python_path" ; then
+                 as_fn_error $? "cannot find Python library path" "$LINENO" 5
+         fi
+-        PYTHON_LDFLAGS="-L$python_path -lpython$PYTHON_VERSION"
++        PYTHON_LDFLAGS="-L$python_path -lpython$PYTHON_MAJOR"
+ 
+         #
+         python_site=`echo $base_python_path | sed "s/config/site-packages/"`
+@@ -19290,7 +19291,7 @@
+ $as_echo_n "checking python extra libraries... " >&6; }
+         PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
+                 conf = distutils.sysconfig.get_config_var; \
+-                print (conf('LOCALMODLIBS') or '')+' '+(conf('LIBS') or '')"
++		print((conf('LOCALMODLIBS') or '')+' '+(conf('LIBS') or ''))"
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_EXTRA_LIBS" >&5
+ $as_echo "$PYTHON_EXTRA_LIBS" >&6; }`
+ 
+diff -Naur spack-src/macros/ac_python_devel.m4 spack-src.patched/macros/ac_python_devel.m4
+--- spack-src/macros/ac_python_devel.m4	2017-09-06 09:48:30.000000000 -0400
++++ spack-src.patched/macros/ac_python_devel.m4	2021-05-06 11:32:59.545478100 -0400
+@@ -43,9 +43,10 @@
+         AC_SUBST([PYTHON_CPPFLAGS],[-I$python_path])
+ 
+         # Check for Python library path
++        PYTHON_MAJOR=`echo $PYTHON_VERSION | sed "s,\..*$,,"`
+         AC_MSG_CHECKING([for Python library path])
+         for i in "$base_python_path/lib/python$PYTHON_VERSION/config/" "$base_python_path/lib/python$PYTHON_VERSION/" "$base_python_path/lib/python/config/" "$base_python_path/lib/python/" "$base_python_path/" "$base_python_path/libs/" ; do
+-                python_path=`find $i -name libpython$PYTHON_VERSION.* -print 2> /dev/null | sed "1q"`
++                python_path=`find $i -name libpython$PYTHON_MAJOR.* -print 2> /dev/null | sed "1q"`
+                 if test -n "$python_path" ; then
+                         break
+                 fi
+@@ -55,7 +56,7 @@
+         if test -z "$python_path" ; then
+                 AC_MSG_ERROR([cannot find Python library path])
+         fi
+-        AC_SUBST([PYTHON_LDFLAGS],["-L$python_path -lpython$PYTHON_VERSION"])
++        AC_SUBST([PYTHON_LDFLAGS],["-L$python_path -lpython$PYTHON_MAJOR"])
+         #
+         python_site=`echo $base_python_path | sed "s/config/site-packages/"`
+         AC_SUBST([PYTHON_SITE_PKG],[$python_site])
+@@ -65,7 +66,7 @@
+         AC_MSG_CHECKING(python extra libraries)
+         PYTHON_EXTRA_LIBS=`$PYTHON -c "import distutils.sysconfig; \
+                 conf = distutils.sysconfig.get_config_var; \
+-                print (conf('LOCALMODLIBS') or '')+' '+(conf('LIBS') or '')"
++                print((conf('LOCALMODLIBS') or '')+' '+(conf('LIBS') or ''))"
+         AC_MSG_RESULT($PYTHON_EXTRA_LIBS)`
+         AC_SUBST(PYTHON_EXTRA_LIBS)
+ ])

--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -46,9 +46,16 @@ class Geos(AutotoolsPackage):
     extends('ruby', when='+ruby')
     extends('python', when='+python')
 
+    # SWIG bindings dropped in 3.9, so no python/ruby bindings
+    conflicts('+python', when='@3.9:', msg='SWIG bindings dropped in 3.9')
+    conflicts('+ruby', when='@3.9:', msg='SWIG bindings dropped in 3.9')
+
     # Python 3 is supposedly supported, but I couldn't get it to work
     # https://trac.osgeo.org/geos/ticket/774
     depends_on('python@:2', when='@:3.5')
+    # This patch should fix above issue.
+    # Only tested on 3.8.1, but patch at least applies on 3.5
+    patch('geos_python3_config.patch', when='+python @3.5:3.8.99')
 
     depends_on('swig', type='build', when='+ruby')
     depends_on('swig', type='build', when='+python')


### PR DESCRIPTION
This should fix some config issues when building geos with python
bindings and using python3 --- the geos configuration scripts had
a few python2-isms.

I only tested (lightly; geos built and I can import geos in python3)
on 3.8.1, but I did check that the patch can at least be applied
in 3.5.

I belatedly discovered that geos dropped all the SWIG bindings
in @3.9, so I also added some conflicts on the +python and +ruby
options to note that they are not supported in 3.9.

Fixes #23479