### PR TITLE
CGNS: New versions; remove conflicting variant

### DIFF
--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -20,6 +20,8 @@ class Cgns(CMakePackage):
 
     version('develop', branch='develop')
     version('master',  branch='master')
+    version('4.2.0',   sha256='090ec6cb0916d90c16790183fc7c2bd2bd7e9a5e3764b36c8196ba37bf1dc817')
+    version('4.1.2',   sha256='951653956f509b8a64040f1440c77f5ee0e6e2bf0a9eef1248d370f60a400050')
     version('4.1.1',   sha256='055d345c3569df3ae832fb2611cd7e0bc61d56da41b2be1533407e949581e226')
     version('4.1.0',   sha256='4674de1fac3c47998248725fd670377be497f568312c5903d1bb8090a3cf4da0')
     version('4.0.0',   sha256='748585a8e52dff4d250d6b603e6b847d05498e4566aba2dc3d7a7d85c4d55849')
@@ -38,7 +40,6 @@ class Cgns(CMakePackage):
     variant('static',     default=False, description='Build static libraries')
     variant('testing',    default=False, description='Build CGNS testing')
     variant('legacy',     default=False, description='Enable legacy options')
-    variant('parallel',   default=False, description='Enable parallel features')
     variant('mem_debug',  default=False, description='Enable memory debugging option')
 
     depends_on('hdf5~mpi', when='+hdf5~mpi')
@@ -68,8 +69,6 @@ class Cgns(CMakePackage):
                 'ON' if '+base_scope' in spec else 'OFF'),
             '-DCGNS_ENABLE_LEGACY:BOOL=%s' % (
                 'ON' if '+legacy' in spec else 'OFF'),
-            '-DCGNS_ENABLE_PARALLEL:BOOL=%s' % (
-                'ON' if '+parallel' in spec else 'OFF'),
             '-DCGNS_ENABLE_MEM_DEBUG:BOOL=%s' % (
                 'ON' if '+mem_debug' in spec else 'OFF')
         ])


### PR DESCRIPTION
Added the checksum for versions 4.1.2 and 4.2.0

The `parallel` variant  did the exact same behavior as the `mpi` variant, but they had different default values than each other.  Both variants set the value of `-DCGNS_ENABLE_PARALLEL`, so it was unclear which variant was "winning" and could definitely result in a non-intuitive build.   Did a grep of the spack packages and none of them where using the `parallel` variant to control the cgns options.  Retained the `mpi` variant as that one is being used by multiple packages.

One issue that remains to be solved is that the default integer size has changed from 32-bit to 64-bit for the 4.2.0 release.  This is controlled by the `int64` variant which currently defaults to `OFF`.  There should maybe be some thought about changing the default to match the default of the current release, or maybe having a version-specific default...  For now, left the behavior as it has been for previous versions.