### PR TITLE
change mode to ccld for loopopt edit

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -167,9 +167,8 @@ config:
   #
   # 'clingo' currently requires the clingo ASP solver to be installed and
   # built with python bindings. 'original' is built in.
-  # concretizer: original
-  concretizer: clingo
-
+  concretizer: original
+  
 
   # How long to wait to lock the Spack installation database. This lock is used
   # when Spack needs to manage its own package metadata and all operations are

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -167,7 +167,8 @@ config:
   #
   # 'clingo' currently requires the clingo ASP solver to be installed and
   # built with python bindings. 'original' is built in.
-  concretizer: original
+  # concretizer: original
+  concretizer: clingo
 
 
   # How long to wait to lock the Spack installation database. This lock is used

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -168,7 +168,7 @@ config:
   # 'clingo' currently requires the clingo ASP solver to be installed and
   # built with python bindings. 'original' is built in.
   concretizer: original
-  
+
 
   # How long to wait to lock the Spack installation database. This lock is used
   # when Spack needs to manage its own package metadata and all operations are

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -319,11 +319,12 @@ while [ $# -ne 0 ]; do
             fi
             ;;
         -l*)
-            # -loopopt=0 is passed to the linker erroneously in
-            # autoconf <= 2.69. Filter it out.
+            # -loopopt=0 is generated erroneously in autoconf <= 2.69,
+            # and passed by ifx to the linker, which confuses it with a 
+            # library. Filter it out.
             # TODO: generalize filtering of args with an env var, so that
             # TODO: we do not have to special case this here.
-            if [ "$mode" = "ld" ] && [ "$1" != "${1#-loopopt}" ]; then
+            if [ "$mode" = "ccld" ] && [ "$1" != "${1#-loopopt}" ]; then
                 shift
                 continue
             fi

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -324,7 +324,7 @@ while [ $# -ne 0 ]; do
             # library. Filter it out.
             # TODO: generalize filtering of args with an env var, so that
             # TODO: we do not have to special case this here.
-            if { [ "$mode" = "ccld" ] || [ "$mode" = "ld" ]; } \
+            if { [ "$mode" = "ccld" ] || [ $mode = "ld" ]; } \
                 && [ "$1" != "${1#-loopopt}" ]; then
                 shift
                 continue

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -324,7 +324,8 @@ while [ $# -ne 0 ]; do
             # library. Filter it out.
             # TODO: generalize filtering of args with an env var, so that
             # TODO: we do not have to special case this here.
-            if [ "$mode" = "ccld" ] && [ "$1" != "${1#-loopopt}" ]; then
+            if { [ "$mode" = "ccld" ] || [ "$mode" = "ld" ]; } \
+                && [ "$1" != "${1#-loopopt}" ]; then
                 shift
                 continue
             fi

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -636,10 +636,10 @@ def test_linker_strips_loopopt(wrapper_flags):
         result = cc(*(test_args + ["-loopopt=0"]), output=str)
         result = result.strip().split('\n')
         assert '-loopopt=0' not in result
-        
+
         # ensure that -loopopt=0 *is* present in cc mode
         # The "-c" argument is needed for cc to be detected
-        # as compile only (cc) mode. 
+        # as compile only (cc) mode.
         result = cc(*(test_args + ["-loopopt=0", "-c", "x.c"]), output=str)
         result = result.strip().split('\n')
         assert '-loopopt=0' in result

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -67,6 +67,7 @@ pkg_prefix = '/spack-test-prefix'
 # Compilers to use during tests
 cc = Executable(os.path.join(build_env_path, "cc"))
 ld = Executable(os.path.join(build_env_path, "ld"))
+#FTWccld = Executable(os.path.join(build_env_path, "cc"))
 cpp = Executable(os.path.join(build_env_path, "cpp"))
 cxx = Executable(os.path.join(build_env_path, "c++"))
 fc = Executable(os.path.join(build_env_path, "fc"))
@@ -633,11 +634,13 @@ def test_linker_strips_loopopt(wrapper_flags):
         assert '-loopopt=0' not in result
 
         # ensure that -loopopt=0 is not present in ccld mode
-        result = ccld(*(test_args + ["-loopopt=0"]), output=str)
+        result = cc(*(test_args + ["-loopopt=0"]), output=str)
         result = result.strip().split('\n')
         assert '-loopopt=0' not in result
         
-        # ensure that -loopopt=0 is present in compile mode
-        result = cc(*(test_args + ["-loopopt=0"]), output=str)
+        # ensure that -loopopt=0 *is* present in cc mode
+        # The "-c" argument is needed for cc to be detected
+        # as compile only (cc) mode. 
+        result = cc(*(test_args + ["-loopopt=0", "-c", "x.c"]), output=str)
         result = result.strip().split('\n')
         assert '-loopopt=0' in result

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -67,7 +67,6 @@ pkg_prefix = '/spack-test-prefix'
 # Compilers to use during tests
 cc = Executable(os.path.join(build_env_path, "cc"))
 ld = Executable(os.path.join(build_env_path, "ld"))
-#FTWccld = Executable(os.path.join(build_env_path, "cc"))
 cpp = Executable(os.path.join(build_env_path, "cpp"))
 cxx = Executable(os.path.join(build_env_path, "c++"))
 fc = Executable(os.path.join(build_env_path, "fc"))

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -632,6 +632,11 @@ def test_linker_strips_loopopt(wrapper_flags):
         result = result.strip().split('\n')
         assert '-loopopt=0' not in result
 
+        # ensure that -loopopt=0 is not present in ccld mode
+        result = ccld(*(test_args + ["-loopopt=0"]), output=str)
+        result = result.strip().split('\n')
+        assert '-loopopt=0' not in result
+        
         # ensure that -loopopt=0 is present in compile mode
         result = cc(*(test_args + ["-loopopt=0"]), output=str)
         result = result.strip().split('\n')


### PR DESCRIPTION
For configure (e.g. for hdf5) to pass, this option needs to be pulled out when invoked in ccld mode. It's not clear whether it also still needs to be done in ld mode.