### PR TITLE
gromacs: build several flavors (parallel x precision) in the same pac…

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -26,6 +26,7 @@ class Gromacs(CMakePackage):
     maintainers = ['junghans', 'marvinbernhardt']
 
     version('master', branch='master')
+    version('2021.4', sha256='cb708a3e3e83abef5ba475fdb62ef8d42ce8868d68f52dafdb6702dc9742ba1d')
     version('2021.3', sha256='e109856ec444768dfbde41f3059e3123abdb8fe56ca33b1a83f31ed4575a1cc6')
     version('2021.2', sha256='d940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb')
     version('2021.1', sha256='bc1d0a75c134e1fb003202262fe10d3d32c59bbb40d714bc3e5015c71effe1e5')


### PR DESCRIPTION
…kage

add two new variants :
 - precision = { single, double, all }
 - parallel = { thread-mpi, mpi, all }
and remove the existing variants :
 - double
 - mpi

End users can easily be confused when several GROMACS package with
the same version and compiler are available, for example when they
are used to do some light pre/post processing with the sequential
version (e.g. gmx ...) and the heavy computation with the MPI version
(e.g. mpirun gmx_mpi ...)

Per the feedback to https://mailman-1.sys.kth.se/pipermail/gromacs.org_gmx-developers/2021-April/011061.html,
this enhancement allows to build several parallelization paradigm (thread-mpi and/or mpi)
and precisions (single vs double) with the same package.
For example
spack install gromacs parallel=all precision=all
will make the four binaries available with a single
spack load gromacs
command :
 - gmx (single precision, thread-mpi)
 - gmx_mpi (single_precision, mpi)
 - gmx_d (double precision, thread-mpi)
 - gmx_mpi_d (double precision, mpi)