### PR TITLE
Patch gdbm when using Arm compiler 21.0+

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -32,6 +32,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     patch('gdbm.patch', when='@:1.18 %cce@11:')
     patch('gdbm.patch', when='@:1.18 %aocc@2:')
     patch('gdbm.patch', when='@:1.18 %oneapi')
+    patch('gdbm.patch', when='@:1.18 %arm@21:')
 
     def configure_args(self):
 


### PR DESCRIPTION
ACfL 21.0 is based on Clang 11. As with the other Clang-based compilers, we need to patch gdbm to avoid linking errors (#16394).