### PR TITLE
Update regex to correctly identify quoted args

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -178,7 +178,7 @@ class Executable(object):
         istream, close_istream = streamify(input,  'r')
 
         if not ignore_quotes:
-            quoted_args = [arg for arg in args if re.search(r'^"|^\'|"$|\'$', arg)]
+            quoted_args = [arg for arg in args if re.search(r'^".*"$|^\'.*\'$', arg)]
             if quoted_args:
                 tty.warn(
                     "Quotes in command arguments can confuse scripts like"


### PR DESCRIPTION
Previously the regex was only checking for presence of quotes as a beginning
or end character and not a matching set.  This erroneously identified the
following *single* argument as being quoted:

    source bashenvfile &> /dev/null && python3 -c "import os, json; print(json.dumps(dict(os.environ)))"