### PR TITLE
CrayPE fixes for MAGMA

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -74,6 +74,9 @@ class Magma(CMakePackage, CudaPackage):
         options += ['-DBUILD_SHARED_LIBS=%s' %
                     ('ON' if ('+shared' in spec) else 'OFF')]
 
+        if spec.satisfies('%cce'):
+            options += [('-DCUDA_NVCC_FLAGS=-allow-unsupported-compiler')]
+
         if '+fortran' in spec:
             options.extend([
                 '-DUSE_FORTRAN=yes'
@@ -82,6 +85,9 @@ class Magma(CMakePackage, CudaPackage):
                 options.extend([
                     '-DCMAKE_Fortran_COMPILER=%s' % self.compiler.f77
                 ])
+
+            if spec.satisfies('%cce'):
+                options.append('-DCMAKE_Fortran_FLAGS=-ef')
 
         if spec.satisfies('^cuda'):
             cuda_arch = self.spec.variants['cuda_arch'].value

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -75,7 +75,7 @@ class Magma(CMakePackage, CudaPackage):
                     ('ON' if ('+shared' in spec) else 'OFF')]
 
         if spec.satisfies('%cce'):
-            options += [('-DCUDA_NVCC_FLAGS=-allow-unsupported-compiler')]
+            options += ['-DCUDA_NVCC_FLAGS=-allow-unsupported-compiler']
 
         if '+fortran' in spec:
             options.extend([


### PR DESCRIPTION
Force CCE to compile fortran modules with lower case names
Allow for CCE to be the host compuiler with nvcc