### PR TITLE
CrayPE fix for unifyfs

### DIFF
--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -113,5 +113,5 @@ class Unifyfs(AutotoolsPackage):
 
     @when('%cce@11.0.3:')
     def patch(self):
-        filter_file('-Werror','','client/src/Makefile.in')
-        filter_file('-Werror','','client/src/Makefile.am')
+        filter_file('-Werror', '', 'client/src/Makefile.in')
+        filter_file('-Werror', '', 'client/src/Makefile.am')

--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -110,3 +110,8 @@ class Unifyfs(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         bash = which('bash')
         bash('./autogen.sh')
+
+    @when('%cce@11.0.3:')
+    def patch(self):
+        filter_file('-Werror','','client/src/Makefile.in')
+        filter_file('-Werror','','client/src/Makefile.am')


### PR DESCRIPTION
When building with CCE, do not use the -Werror flag