### PR TITLE
CrayPE fix for otf2

### DIFF
--- a/var/spack/repos/builtin/packages/otf2/cray_ac_scorep_sys_detection-m4.patch
+++ b/var/spack/repos/builtin/packages/otf2/cray_ac_scorep_sys_detection-m4.patch
@@ -1,0 +1,11 @@
+--- a/vendor/common/build-config/m4/ac_scorep_sys_detection.m4	2019-07-19 01:31:13.409311556 -0500
++++ b/vendor/common/build-config/m4/ac_scorep_sys_detection.m4	2021-03-04 22:11:30.278313559 -0600
+@@ -100,6 +100,8 @@
+                   [test "x${build_cpu}" = "xpowerpc64" && test -d /bgsys],
+                       [ac_scorep_platform="bgp"],
+                   [(test "x${build_cpu}" = "xx86_64" || test "x${build_cpu}" = "xaarch64") && test -d /opt/cray],
++                      [AS_IF([test -d /opt/cray/cs-prgenv],
++                           [ac_scorep_platform="crayxc"])]
+                       [AS_IF([test -L /opt/cray/pmi/default],
+                            [AS_IF([test "x`readlink -f /opt/cray/pmi/default | grep -o --regexp=[[a-z]]*$ | grep -q ss && echo TRUE`" = "xTRUE"],
+                                    [ac_scorep_platform="crayxt"],

--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -35,12 +35,12 @@ class Otf2(AutotoolsPackage):
     patch('collective_callbacks.patch', when='@2.1:2.2')
 
     # when using Cray's cs-prgenv, allow the build system to detect the systems as an XC
-    patch('cray_ac_scorep_sys_detection-m4.patch',when='%cce')
+    patch('cray_ac_scorep_sys_detection-m4.patch', when='%cce')
 
     @property
     def force_autoreconf(self):
         return self.spec.satisfies('%cce')
-        
+
     def configure_args(self):
         return [
             '--enable-shared',

--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -25,10 +25,22 @@ class Otf2(AutotoolsPackage):
     version('1.3.1', sha256='c4605ace845d89fb1a19223137b92cc503b01e3db5eda8c9e0715d0cfcf2e4b9')
     version('1.2.1', sha256='1db9fb0789de4a9c3c96042495e4212a22cb581f734a1593813adaf84f2288e4')
 
+    depends_on('autoconf', type='build', when='%cce')
+    depends_on('automake', type='build', when='%cce')
+    depends_on('libtool', type='build', when='%cce')
+    depends_on('m4', type='build', when='%cce')
+
     # Fix missing initialization of variable resulting in issues when used by
     # APEX/HPX: https://github.com/STEllAR-GROUP/hpx/issues/5239
     patch('collective_callbacks.patch', when='@2.1:2.2')
 
+    # when using Cray's cs-prgenv, allow the build system to detect the systems as an XC
+    patch('cray_ac_scorep_sys_detection-m4.patch',when='%cce')
+
+    @property
+    def force_autoreconf(self):
+        return self.spec.satisfies('%cce')
+        
     def configure_args(self):
         return [
             '--enable-shared',


### PR DESCRIPTION
when using Cray's cs-prgenv, allow the build system to detect the systems as an XC