### PR TITLE
improve relocation logic: allow relocation when relative_prefixes change

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1178,7 +1178,7 @@ def relocate_package(spec, allow_root):
             text_names.append(text_name)
 
     # If we are not installing back to the same install tree do the relocation
-    if old_layout_root != new_layout_root:
+    if old_prefix != new_prefix:
         files_to_relocate = [os.path.join(workdir, filename)
                              for filename in buildinfo.get('relocate_binaries')
                              ]


### PR DESCRIPTION
Improve build cache relocation logic to allow for all of the following:

1. Same layout roots, different relative prefixes
```
old_layout: /build/spack
old_relative_prefix: morepadding/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.32.1-n2pw22r5futf4hhxxuc44uh6qr5rwpgs

new_layout: /build/spack
new_relative_prefix: linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.32.1-n2pw22r5futf4hhxxuc44uh6qr5rwpgs
```

2. Different layout roots, same relative prefixes
```
old_layout: /build/spack-old
old_relative_prefix: linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.32.1-n2pw22r5futf4hhxxuc44uh6qr5rwpgs

new_layout: /build/spack-new
new_relative_prefix: linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.32.1-n2pw22r5futf4hhxxuc44uh6qr5rwpgs
```

3. Different layout roots, different relative prefixes
```
old_layout: /build/spack-old
old_relative_prefix: morepadding/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.32.1-n2pw22r5futf4hhxxuc44uh6qr5rwpgs

new_layout: /build/spack-new
new_relative_prefix: linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.32.1-n2pw22r5futf4hhxxuc44uh6qr5rwpgs
```

@scottwittenburg @tgamblin this resolved the autoconf issue we talked about today