### PR TITLE
CrayPE fix for kvtree

### DIFF
--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -35,7 +35,7 @@ class Kvtree(CMakePackage):
             if name == 'ldflags':
                 flags.append('-Wl,-z,muldefs')
             return (flags, None, None)
-    
+
     def cmake_args(self):
         args = []
         if self.spec.satisfies('+mpi'):

--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -31,7 +31,7 @@ class Kvtree(CMakePackage):
             description='File locking style for KVTree.')
 
     def flag_handler(self, name, flags):
-        if '%cce' in self.spec:
+        if self.spec.satisfies('%cce'):
             if name == 'ldflags':
                 flags.append('-Wl,-z,muldefs')
             return (flags, None, None)

--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -30,6 +30,12 @@ class Kvtree(CMakePackage):
             multi=False,
             description='File locking style for KVTree.')
 
+    def flag_handler(self, name, flags):
+        if '%cce' in self.spec:
+            if name == 'ldflags':
+                flags.append('-Wl,-z,muldefs')
+            return (flags, None, None)
+    
     def cmake_args(self):
         args = []
         if self.spec.satisfies('+mpi'):


### PR DESCRIPTION
allow for multiple definitions at link time (with cce's linker)