### PR TITLE
CrayPE fix for libcircle

### DIFF
--- a/var/spack/repos/builtin/packages/libcircle/CrayPE_configure-ac.patch
+++ b/var/spack/repos/builtin/packages/libcircle/CrayPE_configure-ac.patch
@@ -1,0 +1,17 @@
+diff --git a/configure.ac b/configure.ac_new
+index 49fcc1c..f0d3d2a 100644
+--- a/configure.ac
++++ b/configure.ac_new
+@@ -59,9 +59,9 @@ AC_SUBST([LIBCIRCLE_SO_VERSION], [3:1:1])
+ AC_SUBST([LIBCIRCLE_API_VERSION], [0.3.0])
+ 
+ # Check for MPI
+-LX_FIND_MPI
+-test "x$have_C_mpi" = xyes || \
+-    AC_MSG_ERROR([You should check to see if MPI is setup properly.])
++#LX_FIND_MPI
++#test "x$have_C_mpi" = xyes || \
++#    AC_MSG_ERROR([You should check to see if MPI is setup properly.])
+ AM_CONDITIONAL(HAVE_MPI, [test "x$have_C_mpi" = xyes])
+ 
+ echo

--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -29,7 +29,7 @@ class Libcircle(AutotoolsPackage):
     @property
     def force_autoreconf(self):
         return self.spec.satisfies('%cce')
-        
+
     @when('@master')
     def autoreconf(self, spec, prefix):
         with working_dir(self.configure_directory):

--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -22,6 +22,12 @@ class Libcircle(AutotoolsPackage):
     depends_on('pkgconfig', type='build')
     depends_on('libpciaccess', type='link')
 
+    patch('CrayPE_configure-ac.patch', when='%cce')
+
+    @when('%cce')
+    def autoreconf(self, spec, prefix):
+        which('autoreconf')('--force',  '--verbose', '--install')
+
     @when('@master')
     def autoreconf(self, spec, prefix):
         with working_dir(self.configure_directory):

--- a/var/spack/repos/builtin/packages/libcircle/package.py
+++ b/var/spack/repos/builtin/packages/libcircle/package.py
@@ -21,13 +21,15 @@ class Libcircle(AutotoolsPackage):
     depends_on('mpi')
     depends_on('pkgconfig', type='build')
     depends_on('libpciaccess', type='link')
+    depends_on('autoconf', when='%cce')
+    depends_on('automake', when='%cce')
 
     patch('CrayPE_configure-ac.patch', when='%cce')
 
-    @when('%cce')
-    def autoreconf(self, spec, prefix):
-        which('autoreconf')('--force',  '--verbose', '--install')
-
+    @property
+    def force_autoreconf(self):
+        return self.spec.satisfies('%cce')
+        
     @when('@master')
     def autoreconf(self, spec, prefix):
         with working_dir(self.configure_directory):


### PR DESCRIPTION
disable mpi search when using cce (the CCE compiler wrappers do not behave like the conventional mpi compiler wrappers)