### PR TITLE
py-vermin: add latest version 1.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-vermin/package.py
+++ b/var/spack/repos/builtin/packages/py-vermin/package.py
@@ -8,10 +8,11 @@ class PyVermin(PythonPackage):
     """Concurrently detect the minimum Python versions needed to run code."""
 
     homepage = "https://github.com/netromdk/vermin"
-    url      = "https://github.com/netromdk/vermin/archive/v1.1.1.tar.gz"
+    url      = "https://github.com/netromdk/vermin/archive/v1.2.0.tar.gz"
 
     maintainers = ['netromdk']
 
+    version('1.2.0', sha256='a3ab6dc6608b859f301b9a77d5cc0d03335aae10c49d47a91b82be5be48c4f1f')
     version('1.1.1', sha256='d13b2281ba16c9d5b0913646483771789552230a9ed625e2cd92c5a112e4ae80')
     version('1.1.0', sha256='62d9f1b6694f50c22343cead2ddb6e2b007d24243fb583f61ceed7540fbe660b')
     version('1.0.3', sha256='1503be05b55cacde1278a1fe55304d8ee889ddef8ba16e120ac6686259bec95c')


### PR DESCRIPTION
Released [v1.2.0](https://github.com/netromdk/vermin/releases/tag/v1.2.0).

@adamjstewart @alalazo 