### PR TITLE
root: add first `spack external find` support

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -16,6 +16,8 @@ class Root(CMakePackage):
     url      = "https://root.cern/download/root_v6.16.00.source.tar.gz"
     git      = "https://github.com/root-project/root.git"
 
+    executables = ['^root$', '^root-config$']
+
     tags = ['hep']
 
     maintainers = ['chissg', 'HadrienG2', 'drbenmorgan', 'vvolkl']
@@ -296,6 +298,25 @@ class Root(CMakePackage):
     for pkg in ('memstat', 'qt4', 'table'):
         conflicts('+' + pkg, when='@6.18.00:',
                   msg='Obsolete option +{0} selected.'.format(pkg))
+
+    @classmethod
+    def filter_detected_exes(cls, prefix, exes_in_prefix):
+        result = []
+        for exe in exes_in_prefix:
+            # no need to check the root executable itself
+            # we can get all information from root-config
+            if exe.endswith('root'):
+                continue
+            result.append(exe)
+        return result
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        # turn the output of root-config --version
+        # (something like 6.22/06)
+        # into the format used in this recipe (6.22.06)
+        return output.strip().replace('/', '.')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
only parses the version, variant parsing will follow in a future pr. But I think this is already useful

Maintainer ping: @chissg @HadrienG2 @drbenmorgan