### PR TITLE
metall: fix incorrect use of setup_build_environment

### DIFF
--- a/var/spack/repos/builtin/packages/metall/package.py
+++ b/var/spack/repos/builtin/packages/metall/package.py
@@ -41,10 +41,10 @@ class Metall(CMakePackage):
     # (https://github.com/spack/spack/pull/11115)
     # This page has not been updated?
     # https://spack-tutorial.readthedocs.io/en/latest/tutorial_advanced_packaging.html
-    def setup_build_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         # Configure the directories for test
         if self.run_tests:
-            spack_env.set(
+            env.set(
                 'METALL_TEST_DIR',
                 join_path(self.build_directory, 'build_test')
             )


### PR DESCRIPTION
`metall`: fix incorrect use of `setup_build_environment()`

without this PR:
```
$> spack install metall
...
==> Installing metall-0.13-bc2qkrnik36shqydtqjvp4nx5tc575dv
==> Error: TypeError: setup_build_environment() missing 1 required positional argument: 'run_env'

/e4s-develop/spack/lib/spack/spack/build_environment.py:930, in _setup_pkg_and_run:
        927        tb_string = traceback.format_exc()
        928
        929        # build up some context from the offending package so we can
  >>    930        # show that, too.
        931        package_context = get_package_context(tb)
        932
        933        logfile = None
```

@KIwabuchi @rogerpearce @mayagokhale