### PR TITLE
Make mesonpackage default_library composable

### DIFF
--- a/lib/spack/docs/build_systems/mesonpackage.rst
+++ b/lib/spack/docs/build_systems/mesonpackage.rst
@@ -127,7 +127,7 @@ override the ``meson_args`` method like so:
 This method can be used to pass flags as well as variables.
 
 Note that the ``MesonPackage`` base class already defines variants for
-``buildtype``, ``libs`` and ``strip``, which are mapped to default
+``buildtype``, ``default_library`` and ``strip``, which are mapped to default
 Meson arguments, meaning that you don't have to specify these.
 
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/build_systems/mesonpackage.rst
+++ b/lib/spack/docs/build_systems/mesonpackage.rst
@@ -127,7 +127,7 @@ override the ``meson_args`` method like so:
 This method can be used to pass flags as well as variables.
 
 Note that the ``MesonPackage`` base class already defines variants for
-``buildtype``, ``default_library`` and ``strip``, which are mapped to default
+``buildtype``, ``shared``, ``static`` and ``strip``, which are mapped to default
 Meson arguments, meaning that you don't have to specify these.
 
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/build_systems/mesonpackage.rst
+++ b/lib/spack/docs/build_systems/mesonpackage.rst
@@ -127,7 +127,7 @@ override the ``meson_args`` method like so:
 This method can be used to pass flags as well as variables.
 
 Note that the ``MesonPackage`` base class already defines variants for
-``buildtype``, ``shared``, ``static`` and ``strip``, which are mapped to default
+``buildtype``, ``libs`` and ``strip``, which are mapped to default
 Meson arguments, meaning that you don't have to specify these.
 
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -9,7 +9,7 @@ import os
 from typing import List  # novm
 
 from llnl.util.filesystem import working_dir
-from spack.directives import depends_on, variant, conflicts
+from spack.directives import depends_on, variant
 from spack.package import PackageBase, run_after
 
 

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -55,7 +55,7 @@ class MesonPackage(PackageBase):
     variant('buildtype', default='debugoptimized',
             description='Meson build type',
             values=('plain', 'debug', 'debugoptimized', 'release', 'minsize'))
-    variant('libs', default='shared,static', values=('shared', 'static'),
+    variant('default_library', default='shared', values=('shared', 'static'),
             multi=True, description='Build shared libs, static libs or both')
     variant('strip', default=False, description='Strip targets on install')
 

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -55,14 +55,12 @@ class MesonPackage(PackageBase):
     variant('buildtype', default='debugoptimized',
             description='Meson build type',
             values=('plain', 'debug', 'debugoptimized', 'release', 'minsize'))
-    variant('shared', default=True, description='Build shared libraries')
-    variant('static', default=False, description='Build static libraries')
+    variant('libs', default='shared,static', values=('shared', 'static'),
+            multi=True, description='Build shared libs, static libs or both')
     variant('strip', default=False, description='Strip targets on install')
 
     depends_on('meson', type='build')
     depends_on('ninja', type='build')
-
-    conflicts('~shared', when='~static', msg='Enable shared or static libraries')
 
     @property
     def archive_files(self):
@@ -103,11 +101,10 @@ class MesonPackage(PackageBase):
 
         strip = 'true' if '+strip' in pkg.spec else 'false'
 
-        if '+static' in pkg.spec:
-            if '+shared' in pkg.spec:
-                default_library = 'both'
-            else:
-                default_library = 'static'
+        if 'libs=static,shared' in pkg.spec:
+            default_library = 'both'
+        elif 'libs=static' in pkg.spec:
+            default_library = 'static'
         else:
             default_library = 'shared'
 

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -66,8 +66,10 @@ class Libfuse(MesonPackage):
             "INIT_D_PATH={0}".format(self.prefix.etc),
         ]
 
-        args.append('--enable-static' if 'libs=static' in self.spec else '--disable-static')
-        args.append('--enable-shared' if 'libs=shared' in self.spec else '--disable-shared')
+        args.append('--enable-static' if 'libs=static' in self.spec
+                    else '--disable-static')
+        args.append('--enable-shared' if 'libs=shared' in self.spec
+                    else '--disable-shared')
 
         configure(*args)
 

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -66,8 +66,8 @@ class Libfuse(MesonPackage):
             "INIT_D_PATH={0}".format(self.prefix.etc),
         ]
 
-        args.append('--enable-static' if '+static' in self.spec else '--disable-static')
-        args.append('--enable-shared' if '+shared' in self.spec else '--disable-shared')
+        args.append('--enable-static' if 'libs=static' in self.spec else '--disable-static')
+        args.append('--enable-shared' if 'libs=shared' in self.spec else '--disable-shared')
 
         configure(*args)
 

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -66,12 +66,8 @@ class Libfuse(MesonPackage):
             "INIT_D_PATH={0}".format(self.prefix.etc),
         ]
 
-        if 'default_library=shared' in self.spec:
-            args.extend(['--enable-shared', '--disable-static'])
-        elif 'default_library=static' in self.spec:
-            args.extend(['--disable-shared', '--enable-static'])
-        else:
-            args.extend(['--enable-shared', '--enable-static'])
+        args.append('--enable-static' if '+static' in self.spec else '--disable-static')
+        args.append('--enable-shared' if '+shared' in self.spec else '--disable-shared')
 
         configure(*args)
 


### PR DESCRIPTION
Currently if one package does `depends_on('pkg default_library=shared')`
and another does `depends_on('pkg default_library=both')`, you'd get a
concretization error.

With this PR one package can do `depends_on('pkg +shared')` and another
depends_on('pkg +static'), and it would concretize to `pkg +shared
+static`.
