### PR TITLE
gmsh: add variants and new version

### DIFF
--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -16,8 +16,8 @@ class Gmsh(CMakePackage):
     files using Gmsh's own scripting language.
     """
 
-    homepage = 'http://gmsh.info'
-    url = 'http://gmsh.info/src/gmsh-4.4.1-source.tgz'
+    homepage = 'https://gmsh.info'
+    url = 'https://gmsh.info/src/gmsh-4.4.1-source.tgz'
     git = 'https://gitlab.onelab.info/gmsh/gmsh.git'
 
     version('develop', branch='master')

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -144,10 +144,7 @@ class Gmsh(CMakePackage):
             env['NETGEN_DIR'] = spec['netgen'].prefix
 
         if '@:4.6' in spec:
-            if '+mmg' in spec:
-                options.append('-DENABLE_MMG3D=ON')
-            else:
-                options.append('-DENABLE_MMG3D=OFF')
+            options.append(self.define_from_variant('ENABLE_MMG3D', 'mmg'))
 
         if '+slepc' in spec:
             env['SLEPC_DIR'] = spec['slepc'].prefix

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -20,7 +20,7 @@ class Gmsh(CMakePackage):
     url = 'https://gmsh.info/src/gmsh-4.4.1-source.tgz'
     git = 'https://gitlab.onelab.info/gmsh/gmsh.git'
 
-    version('develop', branch='master')
+    version('master', branch='master')
     version('4.8.4', sha256='760dbdc072eaa3c82d066c5ba3b06eacdd3304eb2a97373fe4ada9509f0b6ace')
     version('4.7.1', sha256='c984c295116c757ed165d77149bd5fdd1068cbd7835e9bcd077358b503891c6a')
     version('4.7.0', sha256='e27f32f92b374ba2a746a9d9c496401c13f66ac6e3e70753e16fa4012d14320e')
@@ -71,7 +71,6 @@ class Gmsh(CMakePackage):
     depends_on('mmg',     when='+mmg')
     depends_on('netgen',  when='+netgen')
     depends_on('opencascade', when='+opencascade')
-    depends_on('mmg',     when='+mmg')
     depends_on('oce',     when='+oce')
     depends_on('petsc+mpi', when='+petsc+mpi')
     depends_on('petsc',   when='+petsc~mpi')
@@ -107,7 +106,7 @@ class Gmsh(CMakePackage):
         # Make sure native file dialogs are used
         options.append('-DENABLE_NATIVE_FILE_CHOOSER=ON')
 
-        options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % self.prefix)
+        options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s' % self.prefix.lib)
 
         # Prevent GMsh from using its own strange directory structure on OSX
         options.append('-DENABLE_OS_SPECIFIC_INSTALL=OFF')

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -78,7 +78,6 @@ class Gmsh(CMakePackage):
     depends_on('tetgen',  when='+tetgen')
     depends_on('zlib',    when='+compression')
     depends_on('metis',   when='+metis')
-    depends_on('eigen',   when='+eigen')
     depends_on('cgns',    when='+cgns')
     # Gmsh's high quality vector PostScript, PDF and SVG output is produced by GL2PS.
     depends_on('gl2ps')
@@ -92,10 +91,13 @@ class Gmsh(CMakePackage):
         options = [
             self.define_from_variant('CAIRO'),
             self.define_from_variant('CGNS'),
+            self.define_from_variant('EIGEN'),
             self.define_from_variant('FLTK'),
-            self.define_from_variant('GMP') ,
+            self.define_from_variant('GMP'),
             self.define_from_variant('METIS'),
+            self.define_from_variant('MMG'),
             self.define_from_variant('MPI'),
+            self.define_from_variant('NETGEN'),
             self.define_from_variant('OPENMP'),
             self.define_from_variant('PRIVATE_API', 'privateapi'),
         ]
@@ -109,10 +111,7 @@ class Gmsh(CMakePackage):
         options.append('-DENABLE_OS_SPECIFIC_INSTALL=OFF')
 
         # Make sure GMSH picks up correct BlasLapack by providing linker flags
-        if '+eigen' in spec:
-            options.append('-DENABLE_EIGEN=ON')
-        else:
-            options.append('-DENABLE_EIGEN=OFF')
+        if '~eigen' in spec:
             options.append('-DENABLE_BLAS_LAPACK=ON')
             blas_lapack = spec['lapack'].libs + spec['blas'].libs
             options.append(
@@ -133,24 +132,19 @@ class Gmsh(CMakePackage):
         else:
             options.append('-DENABLE_PETSC=OFF')
 
-        if '+tetgen' in spec:
-            env['TETGEN_DIR'] = spec['tetgen'].prefix
-            options.append('-DENABLE_TETGEN=ON')
-        else:
-            options.append('-DENABLE_TETGEN=OFF')
+        if '@:3.0.6' in spec:
+            if '+tetgen' in spec:
+                env['TETGEN_DIR'] = spec['tetgen'].prefix
+            options.append(self.define_from_variant('tetgen'))
 
         if '+netgen' in spec:
             env['NETGEN_DIR'] = spec['netgen'].prefix
-            options.append('-DENABLE_NETGEN=ON')
-        else:
-            options.append('-DENABLE_NETGEN=OFF')
 
-        if '+mmg' in spec:
-            options.append('-DENABLE_MMG3D=ON')
-            options.append('-DENABLE_MMG=ON')
-        else:
-            options.append('-DENABLE_MMG3D=OFF')
-            options.append('-DENABLE_MMG=OFF')
+        if '@:4.6' in spec:
+            if '+mmg' in spec:
+                options.append('-DENABLE_MMG3D=ON')
+            else:
+                options.append('-DENABLE_MMG3D=OFF')
 
         if '+slepc' in spec:
             env['SLEPC_DIR'] = spec['slepc'].prefix

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -71,13 +71,11 @@ class Gmsh(CMakePackage):
     depends_on('hdf5',    when='+hdf5')
     depends_on('med',     when='+med')
     depends_on('mmg',     when='+mmg')
-    depends_on('netgen',  when='+netgen')
     depends_on('opencascade', when='+opencascade')
     depends_on('oce',     when='+oce')
     depends_on('petsc+mpi', when='+petsc+mpi')
     depends_on('petsc~mpi', when='+petsc~mpi')
     depends_on('slepc',   when='+slepc+petsc')
-    depends_on('tetgen',  when='+tetgen')
     depends_on('zlib',    when='+compression')
     depends_on('metis',   when='+metis')
     depends_on('cgns',    when='+cgns')
@@ -102,7 +100,9 @@ class Gmsh(CMakePackage):
             self.define_from_variant('MPI'),
             self.define_from_variant('NETGEN'),
             self.define_from_variant('OPENMP'),
+            self.define_from_variant('PETSC'),
             self.define_from_variant('PRIVATE_API', 'privateapi'),
+            self.define_from_variant('SLEPC'),
         ]
 
         # Make sure native file dialogs are used
@@ -121,36 +121,17 @@ class Gmsh(CMakePackage):
                 '-DBLAS_LAPACK_LIBRARIES={0}'.format(blas_lapack.ld_flags))
 
         if '+oce' in spec:
-            env['CASROOT'] = spec['oce'].prefix
             options.append('-DENABLE_OCC=ON')
         elif '+opencascade' in spec:
-            env['CASROOT'] = spec['opencascade'].prefix
             options.append('-DENABLE_OCC=ON')
         else:
             options.append('-DENABLE_OCC=OFF')
 
-        if '+petsc' in spec:
-            env['PETSC_DIR'] = spec['petsc'].prefix
-            options.append('-DENABLE_PETSC=ON')
-        else:
-            options.append('-DENABLE_PETSC=OFF')
-
         if '@:3.0.6' in spec:
-            if '+tetgen' in spec:
-                env['TETGEN_DIR'] = spec['tetgen'].prefix
             options.append(self.define_from_variant('tetgen'))
-
-        if '+netgen' in spec:
-            env['NETGEN_DIR'] = spec['netgen'].prefix
 
         if '@:4.6' in spec:
             options.append(self.define_from_variant('ENABLE_MMG3D', 'mmg'))
-
-        if '+slepc' in spec:
-            env['SLEPC_DIR'] = spec['slepc'].prefix
-            options.append('-DENABLE_SLEPC=ON')
-        else:
-            options.append('-DENABLE_SLEPC=OFF')
 
         if '+shared' in spec:
             # Builds dynamic executable and installs shared library

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -45,6 +45,7 @@ class Gmsh(CMakePackage):
     variant('gmp',         default=True,  description='Enable GMP for Kbipack (advanced)')
     variant('cairo',       default=False, description='Enable Cairo to render fonts (experimental)')
     variant('compression', default=True,  description='Enables IO compression through zlib')
+    variant('med',         default=True,  description='Build with MED(HDF5)')
     variant('mmg',         default=True,  description='Build with Mmg3d')
     variant('netgen',      default=True,  description='Build with Netgen')
     variant('opencascade', default=False, description='Build with OpenCASCADE')
@@ -68,12 +69,13 @@ class Gmsh(CMakePackage):
     depends_on('fltk+gl', when='+fltk')
     depends_on('cairo',   when='+cairo')
     depends_on('hdf5',    when='+hdf5')
+    depends_on('med',     when='+med')
     depends_on('mmg',     when='+mmg')
     depends_on('netgen',  when='+netgen')
     depends_on('opencascade', when='+opencascade')
     depends_on('oce',     when='+oce')
     depends_on('petsc+mpi', when='+petsc+mpi')
-    depends_on('petsc',   when='+petsc~mpi')
+    depends_on('petsc~mpi', when='+petsc~mpi')
     depends_on('slepc',   when='+slepc+petsc')
     depends_on('tetgen',  when='+tetgen')
     depends_on('zlib',    when='+compression')
@@ -94,6 +96,7 @@ class Gmsh(CMakePackage):
             self.define_from_variant('EIGEN'),
             self.define_from_variant('FLTK'),
             self.define_from_variant('GMP'),
+            self.define_from_variant('MED'),
             self.define_from_variant('METIS'),
             self.define_from_variant('MMG'),
             self.define_from_variant('MPI'),

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -18,7 +18,10 @@ class Gmsh(CMakePackage):
 
     homepage = 'http://gmsh.info'
     url = 'http://gmsh.info/src/gmsh-4.4.1-source.tgz'
+    git = 'https://gitlab.onelab.info/gmsh/gmsh.git'
 
+    version('develop', branch='master')
+    version('4.8.4', sha256='760dbdc072eaa3c82d066c5ba3b06eacdd3304eb2a97373fe4ada9509f0b6ace')
     version('4.7.1', sha256='c984c295116c757ed165d77149bd5fdd1068cbd7835e9bcd077358b503891c6a')
     version('4.7.0', sha256='e27f32f92b374ba2a746a9d9c496401c13f66ac6e3e70753e16fa4012d14320e')
     version('4.6.0', sha256='0f2c55e50fb6c478ebc8977f6341c223754cbf3493b7b0d683b4395ae9f2ad1c')
@@ -33,105 +36,128 @@ class Gmsh(CMakePackage):
     version('2.16.0', sha256='e829eaf32ea02350a385202cc749341f2a3217c464719384b18f653edd028eea')
     version('2.15.0', sha256='992a4b580454105f719f5bc05441d3d392ab0b4b80d4ea07b61ca3bdc974070a')
     version('2.12.0', sha256='7fbd2ec8071e79725266e72744d21e902d4fe6fa9e7c52340ad5f4be5c159d09')
-    version('develop', branch='master', git='https://gitlab.onelab.info/gmsh/gmsh.git')
 
     variant('shared',      default=True,  description='Enables the build of shared libraries')
-    variant('mpi',         default=True,  description='Builds MPI support for parser and solver')
+    variant('mpi',         default=False, description='Builds MPI support for parser and solver')
     variant('openmp',      default=False, description='Enable OpenMP support')
-    variant('fltk',        default=False, description='Enables the build of the FLTK GUI')
+    variant('fltk',        default=True,  description='Enables the build of the FLTK GUI')
     variant('hdf5',        default=False, description='Enables HDF5 support')
+    variant('gmp',         default=True,  description='Enable GMP for Kbipack (advanced)')
+    variant('cairo',       default=False, description='Enable Cairo to render fonts (experimental)')
     variant('compression', default=True,  description='Enables IO compression through zlib')
-    variant('netgen',      default=False, description='Build with Netgen')
+    variant('mmg',         default=True,  description='Build with Mmg3d')
+    variant('netgen',      default=True,  description='Build with Netgen')
     variant('opencascade', default=False, description='Build with OpenCASCADE')
     variant('oce',         default=False, description='Build with OCE')
     variant('petsc',       default=False, description='Build with PETSc')
     variant('slepc',       default=False, description='Build with SLEPc (only when PETSc is enabled)')
     variant('tetgen',      default=False, description='Build with Tetgen')
-    variant('metis',       default=False, description='Build with Metis')
+    variant('metis',       default=True,  description='Build with Metis')
     variant('privateapi',  default=False, description='Enable the private API')
+    variant('eigen',       default=False, description='Build with Eigen')
+    variant('cgns',        default=True,  description='Build with CGNS')
 
-    depends_on('blas')
-    depends_on('lapack')
+    # https://gmsh.info/doc/texinfo/gmsh.html#Compiling-the-source-code
+    # We make changes to the GMSH default, such as external blas.
+    depends_on('blas',    when='~eigen')
+    depends_on('lapack',  when='~eigen')
     depends_on('cmake@2.8:', type='build')
-    depends_on('gmp')
+    depends_on('gmp',  when='+gmp')
     depends_on('mpi',  when='+mpi')
     # Assumes OpenGL with GLU is already provided by the system:
-    depends_on('fltk', when='+fltk')
-    depends_on('hdf5', when='+hdf5')
-    depends_on('netgen', when='+netgen')
+    depends_on('fltk+gl', when='+fltk')
+    depends_on('cairo',   when='+cairo')
+    depends_on('hdf5',    when='+hdf5')
+    depends_on('mmg',     when='+mmg')
+    depends_on('netgen',  when='+netgen')
     depends_on('opencascade', when='+opencascade')
-    depends_on('oce',  when='+oce')
+    depends_on('mmg',     when='+mmg')
+    depends_on('oce',     when='+oce')
     depends_on('petsc+mpi', when='+petsc+mpi')
-    depends_on('petsc', when='+petsc~mpi')
-    depends_on('slepc', when='+slepc+petsc')
-    depends_on('tetgen', when='+tetgen')
-    depends_on('zlib',  when='+compression')
-    depends_on('metis', when='+metis')
+    depends_on('petsc',   when='+petsc~mpi')
+    depends_on('slepc',   when='+slepc+petsc')
+    depends_on('tetgen',  when='+tetgen')
+    depends_on('zlib',    when='+compression')
+    depends_on('metis',   when='+metis')
+    depends_on('eigen',   when='+eigen')
+    depends_on('cgns',    when='+cgns')
+    # Gmsh's high quality vector PostScript, PDF and SVG output is produced by GL2PS.
+    depends_on('gl2ps')
 
     conflicts('+slepc', when='~petsc')
     conflicts('+oce', when='+opencascade')
 
     def cmake_args(self):
         spec = self.spec
-        prefix = self.prefix
 
-        options = []
+        var_opt_list = [
+            ('+cairo', 'CAIRO'),
+            ('+cgns', 'CGNS'),
+            ('+fltk', 'FLTK'),
+            ('+gmp', 'GMP'),
+            ('+metis', 'METIS'),
+            ('+mpi', 'MPI'),
+            ('+openmp', 'OPENMP'),
+            ('+privateapi', 'PRIVATE_API'),
+        ]
+        # options setting copied from gribapi
+        options = ['-DENABLE_%s=%s' % (opt, 'ON' if var in spec else 'OFF')
+                   for var, opt in var_opt_list]
 
         # Make sure native file dialogs are used
-        options.extend(['-DENABLE_NATIVE_FILE_CHOOSER=ON'])
+        options.append('-DENABLE_NATIVE_FILE_CHOOSER=ON')
 
-        options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % prefix)
+        options.append('-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % self.prefix)
 
         # Prevent GMsh from using its own strange directory structure on OSX
         options.append('-DENABLE_OS_SPECIFIC_INSTALL=OFF')
 
         # Make sure GMSH picks up correct BlasLapack by providing linker flags
-        blas_lapack = spec['lapack'].libs + spec['blas'].libs
-        options.append(
-            '-DBLAS_LAPACK_LIBRARIES={0}'.format(blas_lapack.ld_flags))
-
-        # Gmsh does not have an option to compile against external metis.
-        # Its own Metis, however, fails to build.
-        # However, Metis is needed for the Hxt library.
-        if '+metis' in spec:
-            options.append('-DENABLE_METIS=ON')
+        if '+eigen' in spec:
+            options.append('-DENABLE_EIGEN=ON')
         else:
-            options.append('-DENABLE_METIS=OFF')
-
-        if '+fltk' in spec:
-            options.append('-DENABLE_FLTK=ON')
-        else:
-            options.append('-DENABLE_FLTK=OFF')
+            options.append('-DENABLE_EIGEN=OFF')
+            options.append('-DENABLE_BLAS_LAPACK=ON')
+            blas_lapack = spec['lapack'].libs + spec['blas'].libs
+            options.append(
+                '-DBLAS_LAPACK_LIBRARIES={0}'.format(blas_lapack.ld_flags))
 
         if '+oce' in spec:
-            env['CASROOT'] = self.spec['oce'].prefix
+            env['CASROOT'] = spec['oce'].prefix
             options.append('-DENABLE_OCC=ON')
         elif '+opencascade' in spec:
-            env['CASROOT'] = self.spec['opencascade'].prefix
+            env['CASROOT'] = spec['opencascade'].prefix
             options.append('-DENABLE_OCC=ON')
         else:
             options.append('-DENABLE_OCC=OFF')
 
         if '+petsc' in spec:
-            env['PETSC_DIR'] = self.spec['petsc'].prefix
+            env['PETSC_DIR'] = spec['petsc'].prefix
             options.append('-DENABLE_PETSC=ON')
         else:
             options.append('-DENABLE_PETSC=OFF')
 
         if '+tetgen' in spec:
-            env['TETGEN_DIR'] = self.spec['tetgen'].prefix
+            env['TETGEN_DIR'] = spec['tetgen'].prefix
             options.append('-DENABLE_TETGEN=ON')
         else:
             options.append('-DENABLE_TETGEN=OFF')
 
         if '+netgen' in spec:
-            env['NETGEN_DIR'] = self.spec['netgen'].prefix
+            env['NETGEN_DIR'] = spec['netgen'].prefix
             options.append('-DENABLE_NETGEN=ON')
         else:
             options.append('-DENABLE_NETGEN=OFF')
 
+        if '+mmg' in spec:
+            options.append('-DENABLE_MMG3D=ON')
+            options.append('-DENABLE_MMG=ON')
+        else:
+            options.append('-DENABLE_MMG3D=OFF')
+            options.append('-DENABLE_MMG=OFF')
+
         if '+slepc' in spec:
-            env['SLEPC_DIR'] = self.spec['slepc'].prefix
+            env['SLEPC_DIR'] = spec['slepc'].prefix
             options.append('-DENABLE_SLEPC=ON')
         else:
             options.append('-DENABLE_SLEPC=OFF')
@@ -144,20 +170,7 @@ class Gmsh(CMakePackage):
             # Builds and installs static library
             options.append('-DENABLE_BUILD_LIB:BOOL=ON')
 
-        if '+openmp' in spec:
-            options.append('-DENABLE_OPENMP=ON')
-        else:
-            options.append('-DENABLE_OPENMP=OFF')
-
-        if '+mpi' in spec:
-            options.append('-DENABLE_MPI:BOOL=ON')
-
         if '+compression' in spec:
             options.append('-DENABLE_COMPRESSED_IO:BOOL=ON')
-
-        if '+privateapi' in spec:
-            options.append('-DENABLE_PRIVATE_API=ON')
-        else:
-            options.append('-DENABLE_PRIVATE_API=OFF')
 
         return options

--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -89,19 +89,16 @@ class Gmsh(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        var_opt_list = [
-            ('+cairo', 'CAIRO'),
-            ('+cgns', 'CGNS'),
-            ('+fltk', 'FLTK'),
-            ('+gmp', 'GMP'),
-            ('+metis', 'METIS'),
-            ('+mpi', 'MPI'),
-            ('+openmp', 'OPENMP'),
-            ('+privateapi', 'PRIVATE_API'),
+        options = [
+            self.define_from_variant('CAIRO'),
+            self.define_from_variant('CGNS'),
+            self.define_from_variant('FLTK'),
+            self.define_from_variant('GMP') ,
+            self.define_from_variant('METIS'),
+            self.define_from_variant('MPI'),
+            self.define_from_variant('OPENMP'),
+            self.define_from_variant('PRIVATE_API', 'privateapi'),
         ]
-        # options setting copied from gribapi
-        options = ['-DENABLE_%s=%s' % (opt, 'ON' if var in spec else 'OFF')
-                   for var, opt in var_opt_list]
 
         # Make sure native file dialogs are used
         options.append('-DENABLE_NATIVE_FILE_CHOOSER=ON')


### PR DESCRIPTION
CGNS dependency was forgotten, defaults were very far from those of the pre-compiled packages for Linux distros such as Ubuntu, more options from the gmsh web page https://gmsh.info/doc/texinfo/gmsh.html#Compiling-the-source-code are added, new version 4.8.4 as well.