### PR TITLE
Bugfix/Docs: Correct force_autoreconf method syntax

### DIFF
--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -155,7 +155,7 @@ version, this can be done like so:
 
    @property
    def force_autoreconf(self):
-       return self.version == Version('1.2.3'):
+       return self.version == Version('1.2.3')
 
 ^^^^^^^^^^^^^^^^^^^^^^^
 Finding configure flags


### PR DESCRIPTION
Removed erroneous colon at the end of a `return` statement in the `force_autoreconf` property example.

See https://spack.readthedocs.io/en/latest/build_systems/autotoolspackage.html?highlight=def%20autoreconf#force-autoreconf.