### PR TITLE
darshan-runtime, darshan-util: darshan 3.3.0 release + other additions

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -20,7 +20,7 @@ class DarshanRuntime(Package):
 
     maintainers = ['shanedsnyder', 'carns']
 
-    version('develop', branch='master', submodules=True)
+    version('master', branch='master', submodules=True)
     version('3.3.0',      sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a', preferred=True)
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -34,16 +34,20 @@ class DarshanRuntime(Package):
 
     depends_on('mpi', when='+mpi')
     depends_on('zlib')
+    depends_on('hdf5', when='+hdf5')
     depends_on('papi', when='+apxc')
 
     variant('slurm', default=False, description='Use Slurm Job ID')
     variant('cobalt', default=False, description='Use Coblat Job Id')
     variant('pbs', default=False, description='Use PBS Job Id')
     variant('mpi', default=True, description='Compile with MPI support')
+    variant('hdf5', default=False, description='Compile with HDF5 module')
     variant('apmpi', default=False, description='Compile with AutoPerf MPI module')
     variant('apmpi_sync', default=False, description='Compile with AutoPerf MPI module (with collective synchronization timing)')
     variant('apxc', default=False, description='Compile with AutoPerf XC module')
 
+    conflicts('+hdf5', when='@:3.1.8',
+              msg='+hdf5 variant only available starting from version 3.3.0')
     conflicts('+apmpi', when='@:3.2.1',
               msg='+apmpi variant only available starting from version 3.3.0')
     conflicts('+apmpi_sync', when='@:3.2.1',
@@ -67,6 +71,9 @@ class DarshanRuntime(Package):
             options = ['CC=%s' % spec['mpi'].mpicc]
         else:
             options = ['--without-mpi']
+
+        if '+hdf5' in spec:
+            options.extend(['--enable-hdf5-mod=%s' % spec['hdf5'].prefix])
 
         if '+apmpi' in spec:
             options.extend(['--enable-apmpi-mod'])

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -47,7 +47,7 @@ class DarshanRuntime(Package):
     variant('apxc', default=False, description='Compile with AutoPerf XC module')
 
     conflicts('+hdf5', when='@:3.1.8',
-              msg='+hdf5 variant only available starting from version 3.3.0')
+              msg='+hdf5 variant only available starting from version 3.2.0')
     conflicts('+apmpi', when='@:3.2.1',
               msg='+apmpi variant only available starting from version 3.3.0')
     conflicts('+apmpi_sync', when='@:3.2.1',

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -21,9 +21,10 @@ class DarshanRuntime(Package):
     maintainers = ['shanedsnyder', 'carns']
 
     version('develop', branch='master')
+    version('3.3.0',      sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a', preferred=True)
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')
-    version('3.2.1', sha256='d63048b7a3d1c4de939875943e3e7a2468a9034fcb68585edbc87f57f622e7f7', preferred=True)
+    version('3.2.1', sha256='d63048b7a3d1c4de939875943e3e7a2468a9034fcb68585edbc87f57f622e7f7')
     version('3.2.0', sha256='4035435bdc0fa2a678247fbf8d5a31dfeb3a133baf06577786b1fe8d00a31b7e')
     version('3.1.8', sha256='3ed51c8d5d93b4a8cbb7d53d13052140a9dffe0bc1a3e1ebfc44a36a184b5c82')
     version('3.1.7', sha256='9ba535df292727ac1e8025bdf2dc42942715205cad8319d925723fd88709e8d6')

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -20,7 +20,7 @@ class DarshanRuntime(Package):
 
     maintainers = ['shanedsnyder', 'carns']
 
-    version('develop', branch='master')
+    version('develop', branch='master', submodules=True)
     version('3.3.0',      sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a', preferred=True)
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -34,6 +34,7 @@ class DarshanRuntime(Package):
 
     depends_on('mpi', when='+mpi')
     depends_on('zlib')
+    depends_on('papi', when='+apxc')
 
     variant('slurm', default=False, description='Use Slurm Job ID')
     variant('cobalt', default=False, description='Use Coblat Job Id')
@@ -41,11 +42,14 @@ class DarshanRuntime(Package):
     variant('mpi', default=True, description='Compile with MPI support')
     variant('apmpi', default=False, description='Compile with AutoPerf MPI module')
     variant('apmpi_sync', default=False, description='Compile with AutoPerf MPI module (with collective synchronization timing)')
+    variant('apxc', default=False, description='Compile with AutoPerf XC module')
 
     conflicts('+apmpi', when='@:3.2.1',
               msg='+apmpi variant only available starting from version 3.3.0')
     conflicts('+apmpi_sync', when='@:3.2.1',
               msg='+apmpi variant only available starting from version 3.3.0')
+    conflicts('+apxc', when='@:3.2.1',
+              msg='+apxc variant only available starting from version 3.3.0')
 
     def install(self, spec, prefix):
 
@@ -69,6 +73,8 @@ class DarshanRuntime(Package):
         if '+apmpi_sync' in spec:
             options.extend(['--enable-apmpi-mod',
                             '--enable-apmpi-coll-sync'])
+        if '+apxc' in spec:
+            options.extend(['--enable-apxc-mod'])
 
         options.extend(['--with-mem-align=8',
                         '--with-log-path-by-env=DARSHAN_LOG_DIR_PATH',

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -39,6 +39,13 @@ class DarshanRuntime(Package):
     variant('cobalt', default=False, description='Use Coblat Job Id')
     variant('pbs', default=False, description='Use PBS Job Id')
     variant('mpi', default=True, description='Compile with MPI support')
+    variant('apmpi', default=False, description='Compile with AutoPerf MPI module')
+    variant('apmpi_sync', default=False, description='Compile with AutoPerf MPI module (with collective synchronization timing)')
+
+    conflicts('+apmpi', when='@:3.2.1',
+              msg='+apmpi variant only available starting from version 3.3.0')
+    conflicts('+apmpi_sync', when='@:3.2.1',
+              msg='+apmpi variant only available starting from version 3.3.0')
 
     def install(self, spec, prefix):
 
@@ -56,6 +63,13 @@ class DarshanRuntime(Package):
             options = ['CC=%s' % spec['mpi'].mpicc]
         else:
             options = ['--without-mpi']
+
+        if '+apmpi' in spec:
+            options.extend(['--enable-apmpi-mod'])
+        if '+apmpi_sync' in spec:
+            options.extend(['--enable-apmpi-mod',
+                            '--enable-apmpi-coll-sync'])
+
         options.extend(['--with-mem-align=8',
                         '--with-log-path-by-env=DARSHAN_LOG_DIR_PATH',
                         '--with-jobid-env=%s' % job_id,

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -33,6 +33,7 @@ class DarshanUtil(Package):
     variant('bzip2', default=False, description="Enable bzip2 compression")
     variant('shared', default=True, description='Build shared libraries')
     variant('apmpi', default=False, description='Compile with AutoPerf MPI module support')
+    variant('apxc', default=False, description='Compile with AutoPerf XC module support')
 
     depends_on('zlib')
     depends_on('bzip2', when="+bzip2", type=("build", "link", "run"))
@@ -41,6 +42,8 @@ class DarshanUtil(Package):
 
     conflicts('+apmpi', when='@:3.2.1',
               msg='+apmpi variant only available starting from version 3.3.0')
+    conflicts('+apxc', when='@:3.2.1',
+              msg='+apxc variant only available starting from version 3.3.0')
 
     def install(self, spec, prefix):
 
@@ -51,6 +54,8 @@ class DarshanUtil(Package):
 
         if '+apmpi' in spec:
             options.extend(['--enable-autoperf-apmpi'])
+        if '+apxc' in spec:
+            options.extend(['--enable-autoperf-apxc'])
 
         with working_dir('spack-build', create=True):
             configure = Executable('../darshan-util/configure')

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -18,7 +18,7 @@ class DarshanUtil(Package):
 
     maintainers = ['shanedsnyder', 'carns']
 
-    version('develop', branch='master', submodules='True')
+    version('master', branch='master', submodules='True')
     version('3.3.0',      sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a', preferred=True)
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -18,7 +18,7 @@ class DarshanUtil(Package):
 
     maintainers = ['shanedsnyder', 'carns']
 
-    version('develop', branch='master')
+    version('develop', branch='master', submodules='True')
     version('3.3.0',      sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a', preferred=True)
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -32,11 +32,15 @@ class DarshanUtil(Package):
 
     variant('bzip2', default=False, description="Enable bzip2 compression")
     variant('shared', default=True, description='Build shared libraries')
+    variant('apmpi', default=False, description='Compile with AutoPerf MPI module support')
 
     depends_on('zlib')
     depends_on('bzip2', when="+bzip2", type=("build", "link", "run"))
 
     patch('retvoid.patch', when='@3.2.0:3.2.1')
+
+    conflicts('+apmpi', when='@:3.2.1',
+              msg='+apmpi variant only available starting from version 3.3.0')
 
     def install(self, spec, prefix):
 
@@ -44,6 +48,9 @@ class DarshanUtil(Package):
                    '--with-zlib=%s' % spec['zlib'].prefix]
         if '+shared' in spec:
             options.extend(['--enable-shared'])
+
+        if '+apmpi' in spec:
+            options.extend(['--enable-autoperf-apmpi'])
 
         with working_dir('spack-build', create=True):
             configure = Executable('../darshan-util/configure')

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -19,9 +19,10 @@ class DarshanUtil(Package):
     maintainers = ['shanedsnyder', 'carns']
 
     version('develop', branch='master')
+    version('3.3.0',      sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a', preferred=True)
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')
-    version('3.2.1', sha256='d63048b7a3d1c4de939875943e3e7a2468a9034fcb68585edbc87f57f622e7f7', preferred=True)
+    version('3.2.1', sha256='d63048b7a3d1c4de939875943e3e7a2468a9034fcb68585edbc87f57f622e7f7')
     version('3.2.0', sha256='4035435bdc0fa2a678247fbf8d5a31dfeb3a133baf06577786b1fe8d00a31b7e')
     version('3.1.8', sha256='3ed51c8d5d93b4a8cbb7d53d13052140a9dffe0bc1a3e1ebfc44a36a184b5c82')
     version('3.1.7', sha256='9ba535df292727ac1e8025bdf2dc42942715205cad8319d925723fd88709e8d6')


### PR DESCRIPTION
This PR adds the following to darshan-runtime/darshan-util packages:
- Darshan 3.3.0 release version and checksum, also made the preferred version
- added necessary Git submodule support for builds from Darshan's source repo
- variants for new AutoPerf instrumentation modules in in both Darshan packages
- variant for HDF5 module in darshan-runtime