### PR TITLE
med: add HDF5 support and other variants

### DIFF
--- a/var/spack/repos/builtin/packages/med/package.py
+++ b/var/spack/repos/builtin/packages/med/package.py
@@ -40,11 +40,10 @@ class Med(CMakePackage):
         spec = self.spec
 
         options = [
-            '-DHDF5_ROOT_DIR=%s' % spec['hdf5'].prefix,
-            '-DMEDFILE_BUILD_TESTS={0}'.format(
-                'ON' if self.run_tests else 'OFF'),
-            '-DMEDFILE_BUILD_PYTHON=OFF',
-            '-DMEDFILE_INSTALL_DOC=OFF',
+            self.define('HDF5_ROOT_DIR', spec['hdf5'].prefix),
+            self.define('MEDFILE_BUILD_TESTS', self.run_tests),
+            self.define('MEDFILE_BUILD_PYTHON', False),
+            self.define('MEDFILE_INSTALL_DOC', False),
         ]
         if '~fortran' in spec:
             options.append('-DCMAKE_Fortran_COMPILER=')

--- a/var/spack/repos/builtin/packages/med/package.py
+++ b/var/spack/repos/builtin/packages/med/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack import *
 
 
@@ -11,28 +10,44 @@ class Med(CMakePackage):
     """The MED file format is a specialization of the HDF5 standard."""
 
     homepage = "http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html"
-    url = "http://files.salome-platform.org/Salome/other/med-3.2.0.tar.gz"
+    url = "https://files.salome-platform.org/Salome/other/med-3.2.0.tar.gz"
 
     maintainers = ['likask']
 
-    version('4.0.0', sha256='a474e90b5882ce69c5e9f66f6359c53b8b73eb448c5f631fa96e8cd2c14df004')
+    # 4.1.0 does not compile in static mode
+    version('4.1.0', sha256='847db5d6fbc9ce6924cb4aea86362812c9a5ef6b9684377e4dd6879627651fce')
+    version('4.0.0', sha256='a474e90b5882ce69c5e9f66f6359c53b8b73eb448c5f631fa96e8cd2c14df004', preferred=True)
     version('3.2.0', sha256='d52e9a1bdd10f31aa154c34a5799b48d4266dc6b4a5ee05a9ceda525f2c6c138')
 
     variant('api23', default=True, description='Enable API2.3')
+    variant('mpi', default=True, description='Enable MPI')
+    variant('shared', default=False,
+            description='Builds a shared version of the library')
+    variant('fortran', default=False, description='Enable Fortran support')
 
-    depends_on('mpi')
-    depends_on('hdf5@:1.8.19+mpi', when='@3.2.0')
-    depends_on('hdf5@:1.10.2+mpi', when='@4.0.0')
+    depends_on('mpi', when='+mpi')
+    depends_on('hdf5@:1.8.22+mpi', when='@3.2.0+mpi')
+    depends_on('hdf5@1.10.2:1.10.7+mpi', when='@4.0.0:+mpi')
+    depends_on('hdf5@:1.8.22~mpi', when='@3.2.0~mpi')
+    depends_on('hdf5@1.10.2:1.10.7~mpi', when='@4.0.0:~mpi')
+
+    conflicts("@4.1.0", when="~shared", msg="Link error when static")
 
     # C++11 requires a space between literal and identifier
     patch('add_space.patch', when='@3.2.0')
 
-    # FIXME This is minimal installation.
-
     def cmake_args(self):
         spec = self.spec
 
-        options = []
+        options = [
+            '-DHDF5_ROOT_DIR=%s' % spec['hdf5'].prefix,
+            '-DMEDFILE_BUILD_TESTS={0}'.format(
+                'ON' if self.run_tests else 'OFF'),
+            '-DMEDFILE_BUILD_PYTHON=OFF',
+            '-DMEDFILE_INSTALL_DOC=OFF',
+        ]
+        if '~fortran' in spec:
+            options.append('-DCMAKE_Fortran_COMPILER=')
 
         if '+api23' in spec:
             options.extend([
@@ -40,18 +55,19 @@ class Med(CMakePackage):
                 '-DCMAKE_C_FLAGS:STRING=-DMED_API_23=1',
                 '-DMED_API_23=1'])
 
-        options.extend([
-            '-DMEDFILE_USE_MPI=YES'
-            '-DMEDFILE_BUILD_TESTS={0}'.format(
-                'ON' if self.run_tests else 'OFF'),
-            '-DMEDFILE_BUILD_PYTHON=OFF',
-            '-DMEDFILE_INSTALL_DOC=OFF',
-            '-DMEDFILE_BUILD_SHARED_LIBS=OFF',
-            '-DMEDFILE_BUILD_STATIC_LIBS=ON',
-            '-DCMAKE_Fortran_COMPILER='])
+        if '+shared' in spec:
+            options.extend([
+                '-DMEDFILE_BUILD_SHARED_LIBS=ON',
+                '-DMEDFILE_BUILD_STATIC_LIBS=OFF',
+            ])
+        else:
+            options.extend([
+                '-DMEDFILE_BUILD_SHARED_LIBS=OFF',
+                '-DMEDFILE_BUILD_STATIC_LIBS=ON',
+            ])
 
-        options.extend([
-            '-DHDF5_ROOT_DIR=%s' % spec['hdf5'].prefix,
-            '-DMPI_ROOT_DIR=%s' % spec['mpi'].prefix])
+        if '+mpi' in spec:
+            options.extend(['-DMEDFILE_USE_MPI=YES',
+                            '-DMPI_ROOT_DIR=%s' % spec['mpi'].prefix])
 
         return options


### PR DESCRIPTION
HDF5 compatibility was tight ; it has been checked that med-4 can accept HDF5 1.10 series starting at 1.10.2, despite these releases are generally not compatible, for med-4 they are.
Also med-3 accepts all 1.8 HDF5 releases since these are compatible [refer to https://portal.hdfgroup.org/display/HDF5/Software+Changes+from+Release+to+Release+for+HDF5-1.8]
A new release is added, 4.1.0 (thanks to @bfovet), but not set as the default since it fails to link when using static.
MPI dependency is now conditional.
Options added are 'shared' (especially useful for 4.1.0 since it does not link otherwise) and 'fortran'.
These enhancement should allow gmsh to have a proper med dependency without too narrow an HDF5 compatibility, as well as mofem-cephas.