### PR TITLE
spfft: add version 1.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/spfft/0001-fix-missing-limits-include.patch
+++ b/var/spack/repos/builtin/packages/spfft/0001-fix-missing-limits-include.patch
@@ -1,0 +1,37 @@
+From 237ed848e8cca208334c352f09caa85101a634c6 Mon Sep 17 00:00:00 2001
+From: Simon Frasch <simon.frasch@cscs.ch>
+Date: Tue, 11 May 2021 11:53:13 +0200
+Subject: [PATCH] fix missing <limits> include
+
+---
+ src/memory/array_view_utility.hpp | 1 +
+ src/spfft/grid_internal.cpp       | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/memory/array_view_utility.hpp b/src/memory/array_view_utility.hpp
+index 51ccef0..0095842 100644
+--- a/src/memory/array_view_utility.hpp
++++ b/src/memory/array_view_utility.hpp
+@@ -34,6 +34,7 @@
+ #include <complex>
+ #include <cstdint>
+ #include <utility>
++#include <limits>
+ #include "memory/gpu_array_view.hpp"
+ #include "memory/host_array_view.hpp"
+ #include "memory/memory_type_trait.hpp"
+diff --git a/src/spfft/grid_internal.cpp b/src/spfft/grid_internal.cpp
+index e95e7f6..4a1483a 100644
+--- a/src/spfft/grid_internal.cpp
++++ b/src/spfft/grid_internal.cpp
+@@ -29,6 +29,7 @@
+ 
+ #include <complex>
+ #include <memory>
++#include <limits>
+ #include "spfft/grid_internal.hpp"
+ 
+ #ifdef SPFFT_MPI
+-- 
+2.24.3 (Apple Git-128)
+

--- a/var/spack/repos/builtin/packages/spfft/package.py
+++ b/var/spack/repos/builtin/packages/spfft/package.py
@@ -17,6 +17,7 @@ class Spfft(CMakePackage, CudaPackage):
     version('develop', branch='develop')
     version('master', branch='master')
 
+    version('1.0.3', sha256='4f87734e3582ef96ddc0402d0db78cfc173bed9cab3e0d9c6a6bf8b660d69559')
     version('1.0.2', sha256='9b1296bda0b9ec3d37c74fd64354a01ebc6e2da7cb026c1f821882160b03c692')
     version('1.0.1', sha256='f8ab706309776cfbd2bfd8e29a6a9ffb5c8f3cd62399bf82db1e416ae5c490c8')
     version('1.0.0', sha256='bd98897aa6734563ec63cd84168e731ef2e2bbc01a574c6dc59b74475742b6ee')
@@ -58,6 +59,10 @@ class Spfft(CMakePackage, CudaPackage):
 
     # FindHIP cmake script only works for < 4.1
     depends_on('hip@:4.0', when='@:1.0.1 +rocm')
+
+    # Fix compilation error in some cases due to missing include statement
+    # before version 1.0.3
+    patch('0001-fix-missing-limits-include.patch', when='@:1.0.2')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Also includes patch to add missing include statement, fixing a compilation error with GCC 11 (and possibly other compilers).