### PR TITLE
Use Ninja as generator in HPX package

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -27,6 +27,9 @@ class Hpx(CMakePackage, CudaPackage):
     version('1.2.0', sha256='20942314bd90064d9775f63b0e58a8ea146af5260a4c84d0854f9f968077c170')
     version('1.1.0', sha256='1f28bbe58d8f0da600d60c3a74a644d75ac777b20a018a5c1c6030a470e8a1c9')
 
+    generator = 'Ninja'
+    depends_on('ninja', type='build')
+
     variant('cxxstd',
             default='17',
             values=('11', '14', '17'),


### PR DESCRIPTION
Due to limitations in Make or CMake's Makefile generation, using Make as the generator significantly limits the parallelism available for building HPX. CMake+Ninja does a much better job of exposing parallelism, and as such I think it's worth changing the default generator.

I couldn't tell from other packages if this needs an additional `depends_on('ninja', type='build')` as well. It works without it so I assume it's fine like this, but please let me know if it's preferable for some reason to have it there.