### PR TITLE
llvm: add patches for missing includes in older versions

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/limits_include.patch
+++ b/var/spack/repos/builtin/packages/llvm/limits_include.patch
@@ -1,0 +1,20 @@
+--- a/libcxx/utils/google-benchmark/src/benchmark_register.h
++++ b/libcxx/utils/google-benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -245,6 +245,12 @@ class Llvm(CMakePackage, CudaPackage):
     # Workaround for issue https://github.com/spack/spack/issues/18197
     patch('llvm7_intel.patch', when='@7 %intel@18.0.2,19.0.4')
 
+    # workaround for missing include: https://reviews.llvm.org/D89450
+    patch("limits_include.patch", when="@8:11.999")
+
+    # https://reviews.llvm.org/D64937
+    patch("uint8_t_typedef.patch", when="@8")
+
     # The functions and attributes below implement external package
     # detection for LLVM. See:
     #

--- a/var/spack/repos/builtin/packages/llvm/uint8_t_typedef.patch
+++ b/var/spack/repos/builtin/packages/llvm/uint8_t_typedef.patch
@@ -1,0 +1,34 @@
+From b288d90b39f4b905c02092a9bfcfd6d78f99b191 Mon Sep 17 00:00:00 2001
+From: Than McIntosh <thanm@google.com>
+Date: Fri, 19 Jul 2019 13:13:54 +0000
+Subject: [PATCH] [NFC] include cstdint/string prior to using uint8_t/string
+
+Summary: include proper header prior to use of uint8_t typedef
+and std::string.
+
+Subscribers: llvm-commits
+
+Reviewers: cherry
+
+Tags: #llvm
+
+Differential Revision: https://reviews.llvm.org/D64937
+
+llvm-svn: 366572
+---
+ llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+index da9d9d5bfdc0c..3d47471f0ef0e 100644
+--- a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
++++ b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+@@ -16,6 +16,8 @@
+ #include "llvm/Demangle/DemangleConfig.h"
+ #include "llvm/Demangle/StringView.h"
+ #include <array>
++#include <cstdint>
++#include <string>
+ 
+ namespace llvm {
+ namespace itanium_demangle {


### PR DESCRIPTION
This pull request uses official `llvm` patches to fix compilation errors with old `llvm` versions (8-11).