### PR TITLE
cray:  fix parsing of module list

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -169,6 +169,7 @@ class Cray(Platform):
             for mod in modules:
                 if 'craype-' in mod:
                     name = mod[7:]
+                    name = name.split()[0]
                     _n = name.replace('-', '_')  # test for mic-knl/mic_knl
                     is_target_name = (name in archspec.cpu.TARGETS or
                                       _n in archspec.cpu.TARGETS)


### PR DESCRIPTION
The code for guessing cpu archtype based on craype modules names got confused,
at least on LLNL RZ prototype systems.  In particular a (L) or (D) at the end of a craype-x86-xxx or other
cpu architecture module was geting the logic confused.

With this patch, any white space + remaining characters in the moduel name are removed.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>