### PR TITLE
add new package: alpaka

### DIFF
--- a/var/spack/repos/builtin/packages/alpaka/package.py
+++ b/var/spack/repos/builtin/packages/alpaka/package.py
@@ -27,6 +27,7 @@ class Alpaka(CMakePackage, CudaPackage):
     variant("examples", default=False, description="Build alpaka examples")
 
     depends_on('boost')
+    depends_on('boost+fiber', when="backend=fiber")
 
     # make sure no other backend is enabled if using cuda_only or hip_only
     for v in ('serial', 'threads', 'fiber', 'tbb', 'oacc',

--- a/var/spack/repos/builtin/packages/alpaka/package.py
+++ b/var/spack/repos/builtin/packages/alpaka/package.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class Alpaka(CMakePackage):
+    """Abstraction Library for Parallel Kernel Acceleration."""
+
+    homepage = "https://alpaka.readthedocs.io"
+    url      = "https://github.com/alpaka-group/alpaka/archive/refs/tags/0.6.0.tar.gz"
+    git      = "https://github.com/alpaka-group/alpaka.git"
+
+    maintainers = ['vvolkl']
+
+    version('develop', branch='develop')
+    version('0.6.0', sha256='7424ecaee3af15e587b327e983998410fa379c61d987bfe923c7e95d65db11a3')
+
+    variant("acc_cpu_b_seq_t_seq", default=True, description="Enable the serial CPU back-end")
+    variant("acc_cpu_b_seq_t_threads", default=True,
+            description="Enable the threads CPU block thread back-end")
+    variant("acc_cpu_b_seq_t_fibers", default=False, description="Enable the fibers CPU block thread back-end")
+    variant("acc_cpu_b_tbb_t_seq", default=False, description="Enable the TBB CPU grid block back-end")
+    variant("acc_cpu_b_omp2_t_seq", default=False, description="Enable the OpenMP 2.0 CPU grid block back-end")
+    variant("acc_cpu_b_seq_t_omp2", default=False, description="Enable the OpenMP 2.0 CPU block thread back-end")
+    variant("acc_any_bt_omp5", default=False, description="Enable the OpenMP 5.0 CPU block and block thread back-end")
+    variant("acc_any_bt_oacc", default=False, description="Enable the OpenACC block and block thread back-end")
+    variant("examples", default=False, description="Build alpaka examples")
+
+    depends_on('boost')
+
+    def cmake_args(self):
+        args = [self.define_from_variant("ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE",
+                                         "acc_cpu_b_seq_t_seq"),
+                self.define_from_variant("ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE",
+                                         "acc_cpu_b_seq_t_threads"),
+                self.define_from_variant("ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE",
+                                         "acc_cpu_b_seq_t_fibers"),
+                self.define_from_variant("ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE",
+                                         "acc_cpu_b_tbb_t_seq"),
+                self.define_from_variant("ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE",
+                                         "acc_cpu_b_omp2_t_seq"),
+                self.define_from_variant("ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE",
+                                         "acc_cpu_b_seq_t_omp2"),
+                self.define_from_variant("ALPAKA_ACC_ANY_BT_OMP5_ENABLE",
+                                         "acc_any_bt_omp5"),
+                self.define_from_variant("ALPAKA_ACC_ANY_BT_OACC_ENABLE",
+                                         "acc_any_bt_oacc"),
+                self.define_from_variant("alpaka_BUILD_EXAMPLES",
+                                         "examples"),
+                # need to define, as it is explicitly declared as an option by alpaka:
+                self.define("BUILD_TESTING", self.run_tests),
+                ]
+        return args

--- a/var/spack/repos/builtin/packages/alpaka/package.py
+++ b/var/spack/repos/builtin/packages/alpaka/package.py
@@ -18,6 +18,9 @@ class Alpaka(CMakePackage, CudaPackage):
 
     version('develop', branch='develop')
     version('0.6.0', sha256='7424ecaee3af15e587b327e983998410fa379c61d987bfe923c7e95d65db11a3')
+    version('0.5.0', sha256='0ba08ea19961dd986160219ba00d6162fe7758980d88a606eff6494d7b3a6cd1')
+    version('0.4.0', sha256='ad7905b13c22abcee4344ba225a65078e3f452ad45a9eda907e7d27c08315e46')
+
 
     variant("backend", multi=True, values=('serial', 'threads', 'fibers', 'tbb', 'omp2_gridblock', 'omp2_blockthread', 'cuda', 'cuda_only', 'hip', 'hip_only'), description="Backends to enable", default='serial')
 

--- a/var/spack/repos/builtin/packages/alpaka/package.py
+++ b/var/spack/repos/builtin/packages/alpaka/package.py
@@ -22,17 +22,23 @@ class Alpaka(CMakePackage, CudaPackage):
     version('0.4.0', sha256='ad7905b13c22abcee4344ba225a65078e3f452ad45a9eda907e7d27c08315e46')
 
 
-    variant("backend", multi=True, values=('serial', 'threads', 'fibers', 'tbb', 'omp2_gridblock', 'omp2_blockthread', 'cuda', 'cuda_only', 'hip', 'hip_only'), description="Backends to enable", default='serial')
+    variant("backend", multi=True, values=('serial', 'threads', 'fiber', 'tbb', 'omp2_gridblock', 'omp2_blockthread', 'omp5', 'oacc', 'cuda', 'cuda_only', 'hip', 'hip_only'), description="Backends to enable", default='serial')
 
     variant("examples", default=False, description="Build alpaka examples")
 
     depends_on('boost')
 
     # make sure no other backend is enabled if using cuda_only or hip_only
-    for v in ('serial', 'threads', 'fibers', 'tbb',
-              'omp2_gridblock', 'omp2_blockthread',):
-        conflicts('backend=cuda_only backend=%s' % v)
-    conflicts('backend=cuda_only backend=hip_only')
+    for v in ('serial', 'threads', 'fiber', 'tbb', 'oacc',
+              'omp2_gridblock', 'omp2_blockthread', 'omp5', 'cuda', 'hip'):
+        conflicts('backend=cuda_only,%s' % v)
+        conflicts('backend=hip_only,%s' % v)
+    conflicts('backend=cuda_only,hip_only')
+    for v in ('omp2_blockthread', 'omp2_blockthread', 'omp5'):
+      conflicts('backend=oacc,%s' % v)
+
+    # todo: add conflict between cuda 11.3 and gcc 10.3.0
+    # see https://github.com/alpaka-group/alpaka/issues/1297
 
     def cmake_args(self):
         spec = self.spec
@@ -67,5 +73,5 @@ class Alpaka(CMakePackage, CudaPackage):
         args.append(self.define_from_variant("alpaka_BUILD_EXAMPLES",
                                              "examples"))
         # need to define, as it is explicitly declared as an option by alpaka:
-        ags.append(self.define("BUILD_TESTING", self.run_tests))
+        args.append(self.define("BUILD_TESTING", self.run_tests))
         return args

--- a/var/spack/repos/builtin/packages/alpaka/package.py
+++ b/var/spack/repos/builtin/packages/alpaka/package.py
@@ -21,7 +21,6 @@ class Alpaka(CMakePackage, CudaPackage):
     version('0.5.0', sha256='0ba08ea19961dd986160219ba00d6162fe7758980d88a606eff6494d7b3a6cd1')
     version('0.4.0', sha256='ad7905b13c22abcee4344ba225a65078e3f452ad45a9eda907e7d27c08315e46')
 
-
     variant("backend", multi=True, values=('serial', 'threads', 'fiber', 'tbb', 'omp2_gridblock', 'omp2_blockthread', 'omp5', 'oacc', 'cuda', 'cuda_only', 'hip', 'hip_only'), description="Backends to enable", default='serial')
 
     variant("examples", default=False, description="Build alpaka examples")
@@ -36,7 +35,7 @@ class Alpaka(CMakePackage, CudaPackage):
         conflicts('backend=hip_only,%s' % v)
     conflicts('backend=cuda_only,hip_only')
     for v in ('omp2_blockthread', 'omp2_blockthread', 'omp5'):
-      conflicts('backend=oacc,%s' % v)
+        conflicts('backend=oacc,%s' % v)
 
     # todo: add conflict between cuda 11.3 and gcc 10.3.0
     # see https://github.com/alpaka-group/alpaka/issues/1297

--- a/var/spack/repos/builtin/packages/alpaka/package.py
+++ b/var/spack/repos/builtin/packages/alpaka/package.py
@@ -19,7 +19,7 @@ class Alpaka(CMakePackage, CudaPackage):
     version('develop', branch='develop')
     version('0.6.0', sha256='7424ecaee3af15e587b327e983998410fa379c61d987bfe923c7e95d65db11a3')
 
-    variant("backend", multi=True, values=('serial', 'threads', 'fibers', 'tbb', 'omp2_gridblock', 'omp2_blockthread', 'cuda', 'cuda_only', 'hip', 'hip_only'), description="Backends to enable")
+    variant("backend", multi=True, values=('serial', 'threads', 'fibers', 'tbb', 'omp2_gridblock', 'omp2_blockthread', 'cuda', 'cuda_only', 'hip', 'hip_only'), description="Backends to enable", default='serial')
 
     variant("examples", default=False, description="Build alpaka examples")
 


### PR DESCRIPTION
only tested the default options for now. OpenACC option likely still needs a dependency, and GPU accelerators are also todo.