### PR TITLE
kvtree: flag_handler: fix incorrect indent on return statement

### DIFF
--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -34,7 +34,7 @@ class Kvtree(CMakePackage):
         if self.spec.satisfies('%cce'):
             if name == 'ldflags':
                 flags.append('-Wl,-z,muldefs')
-            return (flags, None, None)
+        return (flags, None, None)
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
Fix incorrect indentation in `flag_handler` return statement, as introduced by d549e3a60020b085af980cd2ce3a02cc3333ba72

@lukebroskop @tldahlgren 