### PR TITLE
mercury: flag_handler: fix incorrect indent on return statement

### DIFF
--- a/var/spack/repos/builtin/packages/mercury/package.py
+++ b/var/spack/repos/builtin/packages/mercury/package.py
@@ -63,7 +63,7 @@ class Mercury(CMakePackage):
         if self.spec.satisfies('%cce'):
             if name == 'ldflags':
                 flags.append('-Wl,-z,muldefs')
-            return (None, None, flags)
+        return (None, None, flags)
 
     def cmake_args(self):
         """Populate cmake arguments for Mercury."""


### PR DESCRIPTION
Fix incorrect indentation in `flag_handler` return statement, as introduced by a011564b19263140c3b411d647091e47c36a5a08

@lukebroskop @tldahlgren 