### PR TITLE
add model-traits package

### DIFF
--- a/var/spack/repos/builtin/packages/model-traits/package.py
+++ b/var/spack/repos/builtin/packages/model-traits/package.py
@@ -1,0 +1,56 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class ModelTraits(CMakePackage):
+    """ Model setup and querying in C++. """
+
+    homepage = "https://github.com/jacobmerson/model-traits/"
+    url      = "https://github.com/jacobmerson/model-traits/archive/refs/tags/v0.1.0.tar.gz"
+    git      = "https://github.com/jacobmerson/model-traits.git"
+
+    maintainers = ['jacobmerson']
+
+    version('0.1.1', sha256='75af53b4f576071570fdcfa7a4ce150b935cf21368da41d16d8377c5b3b93713')
+    version('0.1.0', sha256='ff7c1c5be6977f1d3dc592e8b6c5bff5a8b7ea80d0f059d85c02300bdb8faf2c')
+    version('main', branch='main')
+
+    variant('yaml', default=True, description='build the Yaml IO backend')
+    variant('simmetrix', default=False, description='build the Simmetrix backend')
+    variant('pumi', default=False, description='build the pumi examples')
+
+    depends_on('yaml-cpp@0.6.3:', when='+yaml')
+    depends_on('catch2@3.0.0-preview3:', type='test')
+    depends_on('pumi', when='+pumi')
+    depends_on('simmetrix-simmodsuite', when='+simmetrix')
+    depends_on('fmt@7.1.3')
+    depends_on('cmake@3.14.0:', type='build')
+    depends_on('mpi', when='+simmetrix')
+    depends_on('mpi', when='+pumi')
+
+    def cmake_args(self):
+        args = [self.define('BUILD_TESTING', self.run_tests)]
+        if self.spec.satisfies('@:0.1.1'):
+            args.extend([self.define('BUILD_EXTERNAL', False),
+                        self.define_from_variant('ENABLE_SCOREC', 'pumi'),
+                        self.define_from_variant('ENABLE_SIMMETRIX', 'simmetrix'),
+                        self.define_from_variant('ENABLE_YAML', 'yaml')])
+        else:
+            args.extend([self.define('MODEL_TRAITS_BUILD_EXTERNAL', False),
+                        self.define_from_variant('MODEL_TRAITS_ENABLE_SCOREC', 'pumi'),
+                        self.define_from_variant('MODEL_TRAITS_ENABLE_SIMMETRIX',
+                                                 'simmetrix'),
+                        self.define_from_variant('MODEL_TRAITS_ENABLE_YAML', 'yaml')])
+        if "+simmetrix" in self.spec:
+            args.append(self.define('SIM_MPI', self.spec['mpi'].name +
+                        self.spec['mpi'].version.string))
+            args.append(self.define('SKIP_SIMMETRIX_VERSION_CHECK', True))
+        if '+pumi' in self.spec or "+simmetrix" in self.spec:
+            args.extend([self.define("CMAKE_CXX_COMPILER", self.spec['mpi'].mpicxx),
+                        self.define("CMAKE_C_COMPILER", self.spec['mpi'].mpicc),
+                        self.define("CMAKE_Fortran_COMPILER", self.spec['mpi'].mpif77)])
+        return args


### PR DESCRIPTION
Add model traits package.

This is a relatively new package that is an add-on to the SCOREC ecosystem. It is used to support two applications that are in the process of being open sourced. Currently I distribute this via an external repo, but I'd like to add it to the main spack repo.