### PR TITLE
spec: simplify __str__ implementation

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3573,11 +3573,6 @@ class Spec(object):
         else:
             return any(s.satisfies(spec) for s in self.traverse(root=False))
 
-    def sorted_deps(self):
-        """Return a list of all dependencies sorted by name."""
-        deps = self.flat_dependencies()
-        return tuple(deps[name] for name in sorted(deps))
-
     def eq_dag(self, other, deptypes=True, vs=None, vo=None):
         """True if the full dependency DAGs of specs are equal."""
         if vs is None:
@@ -3887,7 +3882,9 @@ class Spec(object):
                 'Format string terminated while reading attribute.'
                 'Missing terminating }.'
             )
-        return out.getvalue()
+
+        formatted_spec = out.getvalue()
+        return formatted_spec.strip()
 
     def old_format(self, format_string='$_$@$%@+$+$=', **kwargs):
         """
@@ -4143,12 +4140,13 @@ class Spec(object):
         kwargs.setdefault('color', None)
         return self.format(*args, **kwargs)
 
-    def dep_string(self):
-        return ''.join(" ^" + dep.format() for dep in self.sorted_deps())
-
     def __str__(self):
-        ret = self.format() + self.dep_string()
-        return ret.strip()
+        spec_str = self.format()
+        dependencies = [x for x in self.traverse(root=False)]
+        dependencies.sort(key=lambda x: x.name)
+        for current_dependency in dependencies:
+            spec_str += " ^" + current_dependency.format()
+        return spec_str.strip()
 
     def install_status(self):
         """Helper for tree to print DB install status."""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4141,11 +4141,10 @@ class Spec(object):
         return self.format(*args, **kwargs)
 
     def __str__(self):
-        spec_str = self.format()
-        dependencies = [x for x in self.traverse(root=False)]
-        dependencies.sort(key=lambda x: x.name)
-        for current_dependency in dependencies:
-            spec_str += " ^" + current_dependency.format()
+        sorted_nodes = [self] + sorted(
+            self.traverse(root=False), key=lambda x: x.name
+        )
+        spec_str = " ^".join(d.format() for d in sorted_nodes)
         return spec_str.strip()
 
     def install_status(self):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -776,7 +776,7 @@ class TestSpecSematics(object):
         sigil_package_segments = [("{@VERSIONS}", '@' + str(spec.version)),
                                   ("{%compiler}", '%' + str(spec.compiler)),
                                   ("{arch=architecture}",
-                                   ' arch=' + str(spec.architecture))]
+                                   'arch=' + str(spec.architecture))]
 
         compiler_segments = [("{compiler.name}", "name"),
                              ("{compiler.version}", "versions")]
@@ -798,7 +798,7 @@ class TestSpecSematics(object):
         for named_str, prop in package_segments:
             expected = getattr(spec, prop, "")
             actual = spec.format(named_str)
-            assert str(expected) == actual
+            assert str(expected).strip() == actual
 
         for named_str, expected in sigil_package_segments:
             actual = spec.format(named_str)


### PR DESCRIPTION
fixes #23166

The implementation for `__str__` has been simplified to traverse the spec directly, and doesn't call anymore the `flat_dependencies` method. Dead code has been removed.