### PR TITLE
Bundle git in windows installer

### DIFF
--- a/lib/spack/spack/cmd/installer/CMakeLists.txt
+++ b/lib/spack/spack/cmd/installer/CMakeLists.txt
@@ -40,11 +40,11 @@ endif()
 
 
 # GIT DOWNLOAD----------------------------------------------------
-set(GIT_FILENAME, "Git-2.31.1-64-bit.exe")
+set(GIT_FILENAME "Git-2.31.1-64-bit.exe")
 file(DOWNLOAD "https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/Git-2.31.1-64-bit.exe"
     "${CMAKE_CURRENT_BINARY_DIR}/${GIT_FILENAME}"
     STATUS download_status
-    EXPECTED_HASH "SHA256=6abc8c83945ee8046c7337d2376c4dcb1e4d63ed9614e161b42a30a5fe9dc6ec"
+    EXPECTED_HASH "SHA256=c43611eb73ad1f17f5c8cc82ae51c3041a2e7279e0197ccf5f739e9129ce426e"
 )
 list(GET download_status 0 res)
 if(res)
@@ -108,6 +108,7 @@ set(CPACK_WIX_PATCH_FILE "${CMAKE_CURRENT_SOURCE_DIR}/patch.xml")
 # Set full path to icon, shortcut in spack.wxs
 set(SPACK_SHORTCUT "${CMAKE_CURRENT_SOURCE_DIR}/spack_cmd.bat")
 configure_file("spack.wxs.in" "${CMAKE_CURRENT_BINARY_DIR}/spack.wxs")
+configure_file("bundle.wxs.in" "${CMAKE_CURRENT_BINARY_DIR}/bundle.wxs")
 set(CPACK_WIX_EXTRA_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/spack.wxs")
 
 include(CPack)

--- a/lib/spack/spack/cmd/installer/CMakeLists.txt
+++ b/lib/spack/spack/cmd/installer/CMakeLists.txt
@@ -39,6 +39,21 @@ else()
 endif()
 
 
+# GIT DOWNLOAD----------------------------------------------------
+set(GIT_FILENAME, "Git-2.31.1-64-bit.exe")
+file(DOWNLOAD "https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/Git-2.31.1-64-bit.exe"
+    "${CMAKE_CURRENT_BINARY_DIR}/${GIT_FILENAME}"
+    STATUS download_status
+    EXPECTED_HASH "SHA256=6abc8c83945ee8046c7337d2376c4dcb1e4d63ed9614e161b42a30a5fe9dc6ec"
+)
+list(GET download_status 0 res)
+if(res)
+  list(GET download_status 1 err)
+  message(FATAL_ERROR "Failed to download ${GIT_FILENAME} ${err}")
+endif()
+message(STATUS "Successfully downloaded ${GIT_FILENAME}")
+
+
 # PYTHON DOWLOAD AND EXTRACTION-----------------------------------
 file(DOWNLOAD "${PY_DOWNLOAD_LINK}/${PY_FILENAME}"
   "${CMAKE_CURRENT_BINARY_DIR}/${PY_FILENAME}"

--- a/lib/spack/spack/cmd/installer/bundle.wxs.in
+++ b/lib/spack/spack/cmd/installer/bundle.wxs.in
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+	 xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+  <Bundle Version="1.0.0.0" UpgradeCode="63C4E213-0297-4CFE-BB7B-7A77EB68E966"
+          IconSourceFile="@CPACK_WIX_PRODUCT_ICON@.ico"
+		  Name="Spack Package Manager"
+		  Manufacturer="Lawrence Livermore National Laboratory">
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
+		<bal:WixStandardBootstrapperApplication LicenseFile="@CPACK_RESOURCE_FILE_LICENSE@"/>
+    </BootstrapperApplicationRef>
+    <Chain>
+        <MsiPackage 
+          SourceFile="Spack.msi"
+          DisplayInternalUI="yes"/>
+        <ExePackage 
+          SourceFile="Git-2.31.1-64-bit.exe"
+          DetectCondition="ExeDetectedVariable"
+          InstallCommand="/q /ACTION=Install"
+          RepairCommand="/q ACTION=Repair /hideconsole"
+          UninstallCommand="/q ACTION=Uninstall /hideconsole" />
+    </Chain>
+  </Bundle>
+</Wix>

--- a/lib/spack/spack/cmd/installer/bundle.wxs.in
+++ b/lib/spack/spack/cmd/installer/bundle.wxs.in
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
 	 xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
   <Bundle Version="1.0.0.0" UpgradeCode="63C4E213-0297-4CFE-BB7B-7A77EB68E966"
-          IconSourceFile="@CPACK_WIX_PRODUCT_ICON@.ico"
+          IconSourceFile="@CPACK_WIX_PRODUCT_ICON@"
 		  Name="Spack Package Manager"
 		  Manufacturer="Lawrence Livermore National Laboratory">
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">

--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -72,5 +72,19 @@ def make_installer(parser, args):
         except subprocess.CalledProcessError:
             print("Failed to generate installer")
             return
+        try:
+            subprocess.check_call(
+                '"%s/bin/candle.exe" -ext WixBalExtension "%s/bundle.wxs" -out "%s/bundle.wixobj"'
+                % (os.environ.get('WIX'), output_dir, output_dir), shell=True)
+        except subprocess.CalledProcessError:
+            print("Failed to generate installer chain")
+            return
+        try:
+            subprocess.check_call(
+                '"%s/bin/light.exe" -ext WixBalExtension "%s/bundle.wixobj" -out "%s/Spack.exe"'
+                % (os.environ.get('WIX'), output_dir, output_dir), shell=True)
+        except subprocess.CalledProcessError:
+            print("Failed to generate installer chain")
+            return
     else:
-        print('The generate command is currently only supported on Windows.')
+        print('The make-installer command is currently only supported on Windows.')


### PR DESCRIPTION
`make-installer` command now runs a wix bundle command to download git and generate Spack.exe, which contains Spack and Git for Windows.

Resulting installer is now `Spack.exe`, not an .msi