### PR TITLE
nalu-wind: Remove SuperLU dependency from Trilinos and simplify

### DIFF
--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -44,6 +44,8 @@ class NaluWind(CMakePackage, CudaPackage):
             description='Compile with Catalyst support')
     variant('fftw', default=False,
             description='Compile with FFTW support')
+    variant('boost', default=False,
+            description='Enable Boost integration')
     variant('wind-utils', default=False,
             description='Build wind-utils')
 
@@ -64,6 +66,7 @@ class NaluWind(CMakePackage, CudaPackage):
                    when='+hypre+cuda cuda_arch={0}'.format(_arch))
     depends_on('trilinos-catalyst-ioss-adapter', when='+catalyst')
     depends_on('fftw+mpi', when='+fftw')
+    depends_on('boost cxxstd=14', when='+boost')
 
     def cmake_args(self):
         spec = self.spec
@@ -77,6 +80,7 @@ class NaluWind(CMakePackage, CudaPackage):
             self.define('YAML_DIR', spec['yaml-cpp'].prefix),
             self.define_from_variant('ENABLE_CUDA', 'cuda'),
             self.define_from_variant('ENABLE_WIND_UTILS', 'wind-utils'),
+            self.define_from_variant('ENABLE_BOOST', 'boost'),
         ]
 
         args.append(self.define_from_variant('ENABLE_OPENFAST', 'openfast'))

--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -20,15 +20,12 @@ class NaluWind(CMakePackage, CudaPackage):
     homepage = "https://nalu-wind.readthedocs.io"
     git      = "https://github.com/exawind/nalu-wind.git"
 
-    maintainers = ['jrood-nrel', 'sayerhs']
+    maintainers = ['jrood-nrel']
 
     tags = ['ecp', 'ecp-apps']
 
     version('master', branch='master')
 
-    # Options
-    variant('shared', default=(sys.platform != 'darwin'),
-            description='Build dependencies as shared libraries')
     variant('pic', default=True,
             description='Position independent code')
     variant('abs_tol', default=1.0e-15,
@@ -37,7 +34,6 @@ class NaluWind(CMakePackage, CudaPackage):
     variant('rel_tol', default=1.0e-12,
             values=_parse_float,
             description='Relative tolerance for regression tests')
-    # Third party libraries
     variant('openfast', default=False,
             description='Compile with OpenFAST support')
     variant('tioga', default=False,
@@ -48,50 +44,31 @@ class NaluWind(CMakePackage, CudaPackage):
             description='Compile with Catalyst support')
     variant('fftw', default=False,
             description='Compile with FFTW support')
-    variant('openmp', default=False,
-            description='Compile with OpenMP support')
-    variant('boost', default=False,
-            description='Enable Boost integration')
-
     variant('wind-utils', default=False,
             description='Build wind-utils')
 
-    # Required dependencies
     depends_on('mpi')
-    depends_on('yaml-cpp@0.5.3:', when='+shared')
-    depends_on('yaml-cpp~shared@0.5.3:', when='~shared')
+    depends_on('yaml-cpp@0.5.3:')
+    depends_on('trilinos@master,develop ~cuda~wrapper+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+pnetcdf+shards~hypre', when='~cuda')
     # Cannot build Trilinos as a shared library with STK on Darwin
-    # which is why we have a 'shared' variant for Nalu-Wind
     # https://github.com/trilinos/Trilinos/issues/2994
-    depends_on('trilinos@master,develop ~cuda~wrapper+shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre', when='~cuda+shared')
-    depends_on('trilinos@master,develop ~cuda~wrapper~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre', when='~cuda~shared')
-    # Optional dependencies
-    depends_on('openfast@develop +cxx+shared', when='+openfast+shared')
-    depends_on('openfast@develop +cxx~shared', when='+openfast~shared')
-    depends_on('tioga@master +shared', when='+tioga+shared~cuda')
-    depends_on('tioga@master ~shared', when='+tioga~shared~cuda')
-    depends_on('tioga@develop ~shared', when='+tioga~shared+cuda')
-    depends_on('hypre@2.18.2: +mpi~cuda+int64~superlu-dist+shared', when='+hypre~cuda+shared')
-    depends_on('hypre@2.18.2: +mpi~cuda+int64~superlu-dist~shared', when='+hypre~cuda~shared')
+    depends_on('trilinos@master,develop ~cuda~wrapper+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+pnetcdf+shards~hypre~shared', when=(sys.platform == 'darwin'))
+    depends_on('openfast@develop +cxx', when='+openfast')
+    depends_on('tioga@develop', when='+tioga')
+    depends_on('hypre@2.18.2: +mpi~superlu-dist', when='+hypre')
     depends_on('kokkos-nvcc-wrapper', type='build', when='+cuda')
     for _arch in CudaPackage.cuda_arch_values:
-        depends_on('trilinos@master,develop ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre+cuda+cuda_rdc+wrapper cuda_arch={0}'.format(_arch),
+        depends_on('trilinos@master,develop ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+pnetcdf+shards~hypre+cuda+cuda_rdc+wrapper cuda_arch={0}'.format(_arch),
                    when='+cuda cuda_arch={0}'.format(_arch))
         depends_on('hypre@develop +mpi+cuda~int64~superlu-dist cuda_arch={0}'.format(_arch),
                    when='+hypre+cuda cuda_arch={0}'.format(_arch))
     depends_on('trilinos-catalyst-ioss-adapter', when='+catalyst')
-    # FFTW doesn't have a 'shared' variant at this moment
     depends_on('fftw+mpi', when='+fftw')
-
-    depends_on('boost cxxstd=14', when='+boost')
-
-    conflicts('+cuda', when='+shared')
 
     def cmake_args(self):
         spec = self.spec
 
         args = [
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'),
             self.define('CMAKE_CXX_COMPILER', spec['mpi'].mpicxx),
             self.define('CMAKE_C_COMPILER', spec['mpi'].mpicc),
@@ -100,8 +77,6 @@ class NaluWind(CMakePackage, CudaPackage):
             self.define('YAML_DIR', spec['yaml-cpp'].prefix),
             self.define_from_variant('ENABLE_CUDA', 'cuda'),
             self.define_from_variant('ENABLE_WIND_UTILS', 'wind-utils'),
-            self.define_from_variant('ENABLE_BOOST', 'boost'),
-            self.define_from_variant('ENABLE_OPENMP', 'openmp'),
         ]
 
         args.append(self.define_from_variant('ENABLE_OPENFAST', 'openfast'))

--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -55,9 +55,9 @@ class NaluWind(CMakePackage, CudaPackage):
     # Cannot build Trilinos as a shared library with STK on Darwin
     # https://github.com/trilinos/Trilinos/issues/2994
     depends_on('trilinos@master,develop ~cuda~wrapper+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+pnetcdf+shards~hypre~shared', when=(sys.platform == 'darwin'))
-    depends_on('openfast@develop +cxx', when='+openfast')
-    depends_on('tioga@develop', when='+tioga')
-    depends_on('hypre@2.18.2: +mpi~superlu-dist', when='+hypre')
+    depends_on('openfast@master,develop +cxx', when='+openfast')
+    depends_on('tioga@master,develop', when='+tioga')
+    depends_on('hypre@develop,2.18.2: +mpi~superlu-dist', when='+hypre')
     depends_on('kokkos-nvcc-wrapper', type='build', when='+cuda')
     for _arch in CudaPackage.cuda_arch_values:
         depends_on('trilinos@master,develop ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+pnetcdf+shards~hypre+cuda+cuda_rdc+wrapper cuda_arch={0}'.format(_arch),

--- a/var/spack/repos/builtin/packages/openfast/package.py
+++ b/var/spack/repos/builtin/packages/openfast/package.py
@@ -15,7 +15,7 @@ class Openfast(CMakePackage):
     maintainers = ['jrood-nrel']
 
     version('develop', branch='dev')
-    version('master', branch='master')
+    version('master', branch='main')
 
     variant('shared', default=True,
             description="Build shared libraries")


### PR DESCRIPTION
This change removes SuperLU from our Trilinos requirement. By default KLU2 will be used from Trilinos instead which allows us one less dependency.

We also simplify the package by removing the `shared` variant which was used to force static builds for Darwin. It appears we only need to build Trilinos with static libraries on Darwin after testing these changes and the option for that was reduced to only Trilinos.

Lastly, we remove the `openmp` variant since after the Xeon Phi was discontinued, we never test with this option, and Shreyas has left the project.