### PR TITLE
rocksdb: update pkg-config patch

### DIFF
--- a/var/spack/repos/builtin/packages/rocksdb/pkg-config.patch
+++ b/var/spack/repos/builtin/packages/rocksdb/pkg-config.patch
@@ -1,8 +1,11 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -1919,7 +1919,7 @@ gen-pc:
+@@ -1917,9 +1917,9 @@ gen-pc:
+ 	-echo 'Name: rocksdb' >> rocksdb.pc
+ 	-echo 'Description: An embeddable persistent key-value store for fast storage' >> rocksdb.pc
  	-echo Version: $(shell ./build_tools/version.sh full) >> rocksdb.pc
- 	-echo 'Libs: -L$${libdir} $(EXEC_LDFLAGS) -lrocksdb' >> rocksdb.pc
+-	-echo 'Libs: -L$${libdir} $(EXEC_LDFLAGS) -lrocksdb' >> rocksdb.pc
++	-echo 'Libs: -L$${libdir} $(subst ','\'',$(EXEC_LDFLAGS)) -lrocksdb' >> rocksdb.pc
  	-echo 'Libs.private: $(PLATFORM_LDFLAGS)' >> rocksdb.pc
 -	-echo 'Cflags: -I$${includedir} $(PLATFORM_CXXFLAGS)' >> rocksdb.pc
 +	-echo 'Cflags: -I$${includedir}' >> rocksdb.pc


### PR DESCRIPTION
The previous version did not fix an error that only occured with clang.