### PR TITLE
Package update: Slate

### DIFF
--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -20,7 +20,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     url      = 'https://bitbucket.org/icl/slate/downloads/slate-2020.10.00.tar.gz'
     maintainers = ['G-Ragghianti', 'mgates3']
 
-    version('master', git='https://bitbucket.org/icl/slate-dev', branch='cmake-fix')
+    version('master', branch='master')
     version('2021.05.01', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94ed910d8387c221183654218')
     version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -35,6 +35,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('blaspp ~rocm', when='~rocm')
     for val in ROCmPackage.amdgpu_targets:
         depends_on('blaspp +rocm amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
+    depends_on('rocblas', when='+rocm')
     depends_on('lapackpp@2021.04.00:', when='@2021.05.01:')
     depends_on('lapackpp@2020.10.02', when='@2020.10.00')
     depends_on('lapackpp@master', when='@master')

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -20,8 +20,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     url      = 'https://bitbucket.org/icl/slate/downloads/slate-2020.10.00.tar.gz'
     maintainers = ['G-Ragghianti', 'mgates3']
 
-    version('master', branch='master')
-    version('dev', git='https://bitbucket.org/icl/slate-dev', branch='cmake-fixes') 
+    version('master', git='https://bitbucket.org/icl/slate-dev', branch='cmake-fixes')
     version('2021.05.01', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94ed910d8387c221183654218')
     version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -24,7 +24,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     version('2021.05.01', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94ed910d8387c221183654218')
     version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 
-    variant('mpi',    default=True, description='Build with MPI support.')
+    variant('mpi',    default=True, description='Build with MPI support (without MPI is experimental).')
     variant('openmp', default=True, description='Build with OpenMP support.')
     variant('shared', default=True, description='Build shared library')
 

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -21,6 +21,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     maintainers = ['G-Ragghianti', 'mgates3']
 
     version('master', branch='master')
+    version('dev', git='https://bitbucket.org/icl/slate-dev', branch='cmake-fixes') 
     version('2021.05.01', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94ed910d8387c221183654218')
     version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -35,7 +35,6 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('blaspp ~rocm', when='~rocm')
     for val in ROCmPackage.amdgpu_targets:
         depends_on('blaspp +rocm amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
-    depends_on('rocblas', when='+rocm')
     depends_on('lapackpp@2021.04.00:', when='@2021.05.01:')
     depends_on('lapackpp@2020.10.02', when='@2020.10.00')
     depends_on('lapackpp@master', when='@master')

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -22,7 +22,6 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
 
     version('master', branch='master')
     version('2021.05.01', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94ed910d8387c221183654218')
-    version('2021.05.00', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94e9910d8387c221183654218')
     version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 
     variant('mpi',    default=True, description='Build with MPI support.')
@@ -36,7 +35,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('blaspp ~rocm', when='~rocm')
     for val in ROCmPackage.amdgpu_targets:
         depends_on('blaspp +rocm amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
-    depends_on('lapackpp@2021.04.00:', when='@2021.05.00:')
+    depends_on('lapackpp@2021.04.00:', when='@2021.05.01:')
     depends_on('lapackpp@2020.10.02', when='@2020.10.00')
     depends_on('lapackpp@master', when='@master')
     depends_on('scalapack')
@@ -52,7 +51,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         spec = self.spec
         backend_config = '-Duse_cuda=%s' % ('+cuda' in spec)
-        if self.version >= Version('2021.05.00'):
+        if self.version >= Version('2021.05.01'):
             backend = 'none'
             if '+cuda' in spec:
                 backend = 'cuda'

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -20,7 +20,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     url      = 'https://bitbucket.org/icl/slate/downloads/slate-2020.10.00.tar.gz'
     maintainers = ['G-Ragghianti', 'mgates3']
 
-    version('master', git='https://bitbucket.org/icl/slate-dev', branch='cmake-fixes')
+    version('master', git='https://bitbucket.org/icl/slate-dev', branch='cmake-fix')
     version('2021.05.01', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94ed910d8387c221183654218')
     version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -21,7 +21,8 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     maintainers = ['G-Ragghianti', 'mgates3']
 
     version('master', branch='master')
-    version('2021.05.00', sha256='ad03f21a8cbab1535822656be9e2ca198590757f2cb7445f719374de2634bd07')
+    version('2021.05.01', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94ed910d8387c221183654218')
+    version('2021.05.00', sha256='d9db2595f305eb5b1b49a77cc8e8c8e43c3faab94e9910d8387c221183654218')
     version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 
     variant('mpi',    default=True, description='Build with MPI support.')
@@ -33,9 +34,10 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('blaspp ~cuda', when='~cuda')
     depends_on('blaspp +cuda', when='+cuda')
     depends_on('blaspp ~rocm', when='~rocm')
-    depends_on('blaspp +rocm', when='+rocm')
-    depends_on('lapackpp@2021.04.00:', when='@2021.05.00')
-    depends_on('lapackpp@2020.10.02:', when='@2020.10.00')
+    for val in ROCmPackage.amdgpu_targets:
+        depends_on('blaspp +rocm amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
+    depends_on('lapackpp@2021.04.00:', when='@2021.05.00:')
+    depends_on('lapackpp@2020.10.02', when='@2020.10.00')
     depends_on('lapackpp@master', when='@master')
     depends_on('scalapack')
 
@@ -44,7 +46,7 @@ class Slate(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('%xl', msg=cpp_17_msg)
     conflicts('%xl_r', msg=cpp_17_msg)
     conflicts('%intel@19:', msg='Does not currently build with icpc >= 2019')
-    conflicts('+rocm', when='@:2020.10.00', msg='ROCm support requires SLATE 2021.05.00 or greater')
+    conflicts('+rocm', when='@:2020.10.00', msg='ROCm support requires SLATE 2021.05.01 or greater')
     conflicts('+rocm', when='+cuda', msg='SLATE only supports one GPU backend at a time')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/slate/package.py
+++ b/var/spack/repos/builtin/packages/slate/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Slate(CMakePackage):
+class Slate(CMakePackage, CudaPackage, ROCmPackage):
     """The Software for Linear Algebra Targeting Exascale (SLATE) project is
     to provide fundamental dense linear algebra capabilities to the US
     Department of Energy and to the high-performance computing (HPC) community
@@ -21,19 +21,20 @@ class Slate(CMakePackage):
     maintainers = ['G-Ragghianti', 'mgates3']
 
     version('master', branch='master')
+    version('2021.05.00', sha256='ad03f21a8cbab1535822656be9e2ca198590757f2cb7445f719374de2634bd07')
     version('2020.10.00', sha256='ff58840cdbae2991d100dfbaf3ef2f133fc2f43fc05f207dc5e38a41137882ab')
 
-    variant('cuda',   default=False, description='Build with CUDA support.')
     variant('mpi',    default=True, description='Build with MPI support.')
     variant('openmp', default=True, description='Build with OpenMP support.')
     variant('shared', default=True, description='Build shared library')
 
-    depends_on('cuda', when='+cuda')
     depends_on('mpi', when='+mpi')
     depends_on('blas')
     depends_on('blaspp ~cuda', when='~cuda')
     depends_on('blaspp +cuda', when='+cuda')
-    depends_on('lapackpp')
+    depends_on('blaspp ~rocm', when='~rocm')
+    depends_on('blaspp +rocm', when='+rocm')
+    depends_on('lapackpp@2021.04.00:', when='@2021.05.00')
     depends_on('lapackpp@2020.10.02:', when='@2020.10.00')
     depends_on('lapackpp@master', when='@master')
     depends_on('scalapack')
@@ -43,14 +44,25 @@ class Slate(CMakePackage):
     conflicts('%xl', msg=cpp_17_msg)
     conflicts('%xl_r', msg=cpp_17_msg)
     conflicts('%intel@19:', msg='Does not currently build with icpc >= 2019')
+    conflicts('+rocm', when='@:2020.10.00', msg='ROCm support requires SLATE 2021.05.00 or greater')
+    conflicts('+rocm', when='+cuda', msg='SLATE only supports one GPU backend at a time')
 
     def cmake_args(self):
         spec = self.spec
+        backend_config = '-Duse_cuda=%s' % ('+cuda' in spec)
+        if self.version >= Version('2021.05.00'):
+            backend = 'none'
+            if '+cuda' in spec:
+                backend = 'cuda'
+            if '+rocm' in spec:
+                backend = 'hip'
+            backend_config = '-Dgpu_backend=%s' % backend
+
         return [
             '-Dbuild_tests=%s'       % self.run_tests,
             '-Duse_openmp=%s'        % ('+openmp' in spec),
             '-DBUILD_SHARED_LIBS=%s' % ('+shared' in spec),
-            '-Duse_cuda=%s'          % ('+cuda' in spec),
+            backend_config,
             '-Duse_mpi=%s'           % ('+mpi' in spec),
             '-DSCALAPACK_LIBRARIES=%s'    % spec['scalapack'].libs.joined(';')
         ]


### PR DESCRIPTION
Adds a new release version for SLATE and includes HIP/ROCm backend support. Now can build with either CUDA or ROCm support.