### PR TITLE
py-rarfile: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-rarfile/package.py
+++ b/var/spack/repos/builtin/packages/py-rarfile/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyRarfile(PythonPackage):
+    """RAR archive reader for Python."""
+
+    homepage = "https://github.com/markokr/rarfile"
+    pypi     = "rarfile/rarfile-4.0.tar.gz"
+
+    version('4.0', sha256='67548769229c5bda0827c1663dce3f54644f9dbfba4ae86d4da2b2afd3e602a1')
+
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('unrar', type='run')


### PR DESCRIPTION
Successfully installs and passes import tests on macOS 10.15.7 with Python 3.8.10 and Apple Clang 12.0.0.