### PR TITLE
Modification to R environment

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -130,9 +130,8 @@ list of environment modifications.
   to the corresponding environment variables:
 
   ================== =================================
-   LIBRARY_PATH       ``self.prefix/rlib/R/lib``
    LD_LIBRARY_PATH    ``self.prefix/rlib/R/lib``
-   CPATH              ``self.prefix/rlib/R/include``
+   PKG_CONFIG_PATH    ``self.prefix/rlib/pkgconfig``
   ================== =================================
 
   with the following snippet:

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -218,6 +218,16 @@ class R(AutotoolsPackage):
             env.prepend_path('R_LIBS', join_path(
                 dependent_spec.prefix, self.r_lib_dir))
 
+    def setup_run_environment(self, env):
+        env.prepend_path('LD_LIBRARY_PATH',
+                         join_path(self.prefix, 'rlib', 'R', 'lib'))
+        env.prepend_path('PKG_CONFIG_PATH',
+                         join_path(self.prefix, 'rlib', 'pkgconfig'))
+
+        if '+rmath' in self.spec:
+            env.prepend_path('LD_LIBRARY_PATH',
+                             join_path(self.prefix, 'rlib'))
+
     def setup_dependent_package(self, module, dependent_spec):
         """Called before R modules' install() methods. In most cases,
         extensions will only need to have one line:

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -108,17 +108,12 @@ class R(AutotoolsPackage):
     def etcdir(self):
         return join_path(prefix, 'rlib', 'R', 'etc')
 
-    @run_after('build')
-    def build_rmath(self):
-        if '+rmath' in self.spec:
-            with working_dir('src/nmath/standalone'):
-                make()
-
     @run_after('install')
     def install_rmath(self):
         if '+rmath' in self.spec:
             with working_dir('src/nmath/standalone'):
-                make('install')
+                make()
+                make('install', parallel=False)
 
     def configure_args(self):
         spec   = self.spec
@@ -222,14 +217,6 @@ class R(AutotoolsPackage):
         if dependent_spec.package.extends(self.spec):
             env.prepend_path('R_LIBS', join_path(
                 dependent_spec.prefix, self.r_lib_dir))
-
-    def setup_run_environment(self, env):
-        env.prepend_path('LIBRARY_PATH',
-                         join_path(self.prefix, 'rlib', 'R', 'lib'))
-        env.prepend_path('LD_LIBRARY_PATH',
-                         join_path(self.prefix, 'rlib', 'R', 'lib'))
-        env.prepend_path('CPATH',
-                         join_path(self.prefix, 'rlib', 'R', 'include'))
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before R modules' install() methods. In most cases,


### PR DESCRIPTION
This PR modifies how the R environmnet is presented, and fixes
installing the standalone Rmath library.

- The Rmath build and install methods are combined into one
- Set parallel=False when installing Rmath
- remove the run environment that set up variables for libraries and
  headers that are not really needed, and pollute the environment.