### PR TITLE
trilinos: add compile definition to solve build error when +stk and on a Mac

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -885,6 +885,8 @@ class Trilinos(CMakePackage, CudaPackage):
 
         if sys.platform == 'darwin':
             options.append(define('Trilinos_ENABLE_FEI', False))
+            if '+stk' in spec:
+                cxx_flags.extend(['-DSTK_NO_BOOST_STACKTRACE'])
 
         if sys.platform == 'darwin' and macos_version() >= Version('10.12'):
             # use @rpath on Sierra due to limit of dynamic loader


### PR DESCRIPTION
@eugeneswalker I noticed `trilinos` already had a mechanism for adding `cxx_flags` so I just used that. It might be better to use a flag handler in the future.