### PR TITLE
umpire: preliminary stand-alone test simplification

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.lang as lang
+import os
+
 import llnl.util.tty as tty
 
 
@@ -141,188 +142,33 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
 
         return options
 
-    @property
-    def build_relpath(self):
-        """Relative path to the cmake build subdirectory."""
-        return join_path('..', self.build_dirname)
-
-    @run_after('install')
-    def setup_build_tests(self):
-        """Copy the build test files after the package is installed to an
-        install test subdirectory for use during `spack test run`."""
-        # Now copy the relative files
-        self.cache_extra_test_sources(self.build_relpath)
-
-        # Ensure the path exists since relying on a relative path at the
-        # same level as the normal stage source path.
-        mkdirp(self.install_test_root)
-
-    @property
-    @lang.memoized
-    def _extra_tests_path(self):
-        # TODO: The tests should be converted to re-build and run examples
-        # TODO: using the installed libraries.
-        return join_path(self.install_test_root, self.build_relpath)
-
-    @property
-    @lang.memoized
-    def _has_bad_strategy(self):
-        return self.spec.satisfies('@0.2.0:0.2.3')
-
-    def _run_checks(self, dirs, checks):
-        """Run the specified checks in the provided directories."""
-
-        if not dirs or not checks:
+    def test(self):
+        """Perform stand-alone checks on the installed package."""
+        if self.spec.satisfies('@:1') or \
+                not os.path.isdir(self.prefix.bin):
+            tty.info('Skipping: checks not installed in bin for v{0}'.
+                     format(self.version))
             return
 
+        # Run a subset of examples PROVIDED installed
+        # tutorials with readily checkable outputs.
+        checks = {
+            'malloc': ['99 should be 99'],
+            'recipe_dynamic_pool_heuristic': ['in the pool', 'releas'],
+            'recipe_no_introspection': ['has allocated', 'used'],
+            'strategy_example': ['Available allocators', 'HOST'],
+            'tut_copy': ['Copied source data'],
+            'tut_introspection':
+                ['Allocator used is HOST', 'size of the allocation'],
+            'tut_memset': ['Set data from HOST'],
+            'tut_move': ['Moved source data', 'HOST'],
+            'tut_reallocate': ['Reallocated data'],
+            'vector_allocator': [''],
+        }
+
         for exe in checks:
-            if exe == 'strategy_example' and self._has_bad_strategy:
-                # Skip this test until install testing can properly capture
-                # the abort associated with this version.
-                # (An umpire::util::Exception is thrown; status value is -6.)
-                tty.warn('Skipping {0} test until Spack can handle core dump'
-                         .format(exe))
-                continue
-
-            expected, status = checks[exe]
-            for work_dir in dirs:
-                src = 'from build ' if 'spack-build' in work_dir else ''
-                reason = 'test {0} {1}output'.format(exe, src)
-                self.run_test(exe, [], expected, status, installed=False,
-                              purpose=reason, skip_missing=True,
-                              work_dir=work_dir)
-
-    def _run_bench_checks(self):
-        """Run the benchmark smoke test checks."""
-        tty.info('Running benchmark checks')
-
-        dirs = []
-        if self.spec.satisfies('@0.3.3:1.0.1'):
-            dirs.append(join_path(self._extra_tests_path, 'benchmarks'))
-        elif self.spec.satisfies('@1.1.0:'):
-            dirs.append(self.prefix.bin)
-
-        checks = {
-            # Versions 0.3.3:1.0.1  (spack-build/bin/benchmarks)
-            # Versions 1.1.0:2.1.0  (spack-build/bin)
-            'allocator_benchmarks': (
-                ['Malloc/malloc', 'Malloc/free', 'ns',
-                 'Host/allocate', 'Host/deallocate',
-                 'FixedPoolHost/allocate',
-                 'FixedPoolHost/deallocate'], 0),
-            'copy_benchmarks': (['benchmark_copy/host_host', 'ns'], 0),
-            'debuglog_benchmarks': (['benchmark_DebugLogger', 'ns'], 0),
-        }
-        self._run_checks(dirs, checks)
-
-    def _run_cookbook_checks(self):
-        """Run the cookbook smoke test checks."""
-        tty.info('Running cookbook checks')
-
-        dirs = []
-        cb_subdir = join_path('examples', 'cookbook')
-        if self.spec.satisfies('@0.3.3:1.0.1'):
-            dirs.append(join_path(self._extra_tests_path, cb_subdir))
-        elif self.spec.satisfies('@1.1.0'):
-            dirs.append(join_path(self.prefix.bin, cb_subdir))
-        elif self.spec.satisfies('@2.0.0:'):
-            dirs.append(self.prefix.bin)
-
-        checks = {
-            # Versions 0.3.3:1.0.1  (spack-build/bin/examples/cookbook)
-            # Versions 2.0.0:2.1.0  (spack-build/bin)
-            # Versions 1.1.0        (prefix.bin/examples/cookbook)
-            # Versions 2.0.0:2.1.0  (prefix.bin)
-            'recipe_dynamic_pool_heuristic': (['in the pool', 'releas'], 0),
-            'recipe_no_introspection': (['has allocated', 'used'], 0),
-        }
-        self._run_checks(dirs, checks)
-
-    def _run_example_checks(self):
-        """Run the example smoke test checks."""
-        tty.info('Running example checks')
-
-        dirs = []
-        if self.spec.satisfies('@0.1.3:0.3.1'):
-            dirs.append(self._extra_tests_path)
-        elif self.spec.satisfies('@0.3.3:1.0.1'):
-            dirs.append(join_path(self._extra_tests_path, 'examples'))
-        elif self.spec.satisfies('@1.1.0'):
-            dirs.append(join_path(self.prefix.bin, 'examples'))
-        elif self.spec.satisfies('@2.0.0:'):
-            dirs.append(self.prefix.bin)
-
-        # Check the results from a subset of the (potentially) available
-        # executables
-        checks = {
-            # Versions 0.1.3:0.3.1  (spack-build/bin)
-            # Versions 0.3.3:1.0.1  (spack-build/bin/examples)
-            # Versions 2.0.0:2.1.0  (spack-build/bin)
-            # Version  1.1.0        (prefix.bin/examples)
-            # Versions 2.0.0:2.1.0  (prefix.bin)
-            'malloc': (['99 should be 99'], 0),
-            'strategy_example': (['Available allocators', 'HOST'], 0),
-            'vector_allocator': ([''], 0),
-        }
-        self._run_checks(dirs, checks)
-
-    def _run_plots_checks(self):
-        """Run the plots smoke test checks."""
-        tty.info('Running plots checks')
-
-        dirs = [self.prefix.bin] if self.spec.satisfies('@0.3.3:0.3.5') else []
-        checks = {
-            # Versions 0.3.3:0.3.5  (prefix.bin)
-            'plot_allocations': ([''], 0),
-        }
-        self._run_checks(dirs, checks)
-
-    def _run_tools_checks(self):
-        """Run the tools smoke test checks."""
-        tty.info('Running tools checks')
-
-        dirs = [self.prefix.bin] if self.spec.satisfies('@0.3.3:0.3.5') else []
-        checks = {
-            # Versions 0.3.3:0.3.5  (spack-build/bin/tools)
-            'replay': (['No input file'], 0),
-        }
-        self._run_checks(dirs, checks)
-
-    def _run_tut_checks(self):
-        """Run the tutorial smoke test checks."""
-        tty.info('Running tutorials checks')
-
-        dirs = []
-        tut_subdir = join_path('examples', 'tutorial')
-        if self.spec.satisfies('@0.2.4:0.3.1'):
-            dirs.append(self._extra_tests_path)
-        elif self.spec.satisfies('@0.3.3:1.0.1'):
-            dirs.append(join_path(self._extra_tests_path, tut_subdir))
-        elif self.spec.satisfies('@1.1.0'):
-            dirs.append(join_path(self.prefix.bin, tut_subdir))
-        elif self.spec.satisfies('@2.0.0:'):
-            dirs.append(self.prefix.bin)
-
-        checks = {
-            # Versions 0.2.4:0.3.1  (spack-build/bin)
-            # Versions 0.3.3:1.0.1  (spack-build/bin/examples/tutorial)
-            # Versions 2.0.0:2.1.0  (spack-build/bin)
-            # Version  1.1.0        (prefix.bin/examples/tutorial)
-            # Versions 2.0.0:2.1.0  (prefix.bin)
-            'tut_copy': (['Copied source data'], 0),
-            'tut_introspection': (
-                ['Allocator used is HOST', 'size of the allocation'], 0),
-            'tut_memset': (['Set data from HOST'], 0),
-            'tut_move': (['Moved source data', 'HOST'], 0),
-            'tut_reallocate': (['Reallocated data'], 0),
-        }
-        self._run_checks(dirs, checks)
-
-    def test(self):
-        """Perform smoke tests on the installed package."""
-        self._run_bench_checks()
-        self._run_cookbook_checks()
-        self._run_example_checks()
-        self._run_plots_checks()
-        self._run_tools_checks()
-        self._run_tut_checks()
+            expected = checks[exe]
+            reason = 'test: checking output from {0}'.format(exe)
+            self.run_test(exe, [], expected, 0, installed=False,
+                          purpose=reason, skip_missing=True,
+                          work_dir=self.prefix.bin)


### PR DESCRIPTION
This PR is intended to simplify Umpire's smoke/stand-alone tests through the following initial changes:

- Remove attempts to test installations prior to v2.0.0, reporting them as 'Skipped';
- Reports tests as 'skipped' if the `bin` directory is not create (i.e., if the package is not installed with examples enabled, which is not the default).

@davidbeckingsale 