### PR TITLE
emacs: add texinfo build dependency on master

### DIFF
--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -54,6 +54,7 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     depends_on('autoconf', type='build', when="@master:")
     depends_on('automake', type='build', when="@master:")
     depends_on('libtool', type='build', when="@master:")
+    depends_on('texinfo', type='build', when="@master:")
     depends_on('gcc@11: +strip languages=jit', when="+native")
 
     conflicts('@:26.3', when='platform=darwin os=catalina')


### PR DESCRIPTION
It seems that building unreleased versions requires makeinfo, which is part of texinfo.