### PR TITLE
charmpp: avoid setting MPICC for mpi backend

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -370,7 +370,7 @@ class Charmpp(Package):
              'test', 'TESTOPTS=++local', parallel=False)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        if not("backend=mpi" in self.spec):
+        if not self.spec.satisfies("backend=mpi"):
             env.set('MPICC',  self.prefix.bin.ampicc)
             env.set('MPICXX', self.prefix.bin.ampicxx)
             env.set('MPIF77', self.prefix.bin.ampif77)

--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -370,10 +370,11 @@ class Charmpp(Package):
              'test', 'TESTOPTS=++local', parallel=False)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set('MPICC',  self.prefix.bin.ampicc)
-        env.set('MPICXX', self.prefix.bin.ampicxx)
-        env.set('MPIF77', self.prefix.bin.ampif77)
-        env.set('MPIF90', self.prefix.bin.ampif90)
+        if not("backend=mpi" in self.spec):
+            env.set('MPICC',  self.prefix.bin.ampicc)
+            env.set('MPICXX', self.prefix.bin.ampicxx)
+            env.set('MPIF77', self.prefix.bin.ampif77)
+            env.set('MPIF90', self.prefix.bin.ampif90)
 
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.mpicc     = self.prefix.bin.ampicc


### PR DESCRIPTION
Fixes #18535

xref https://github.com/payerle/spack/commit/ca162800a8790ff8d578ed3cd7815e6d8052812a

This might also be a bug in spack itself - why would `setup_dependent_build_environment` be called for building charmpp?