### PR TITLE
netdata: add 1.30.1

### DIFF
--- a/var/spack/repos/builtin/packages/netdata/package.py
+++ b/var/spack/repos/builtin/packages/netdata/package.py
@@ -10,13 +10,19 @@ class Netdata(AutotoolsPackage):
     """Real-time performance monitoring, done right!"""
 
     homepage = "https://www.netdata.cloud/"
-    url      = "https://github.com/netdata/netdata/archive/v1.22.1.tar.gz"
+    url      = "https://github.com/netdata/netdata/releases/download/v1.30.1/netdata-v1.30.1.tar.gz"
 
-    version('1.22.1', sha256='6efd785eab82f98892b4b4017cadfa4ce1688985915499bc75f2f888765a3446')
+    version('1.30.1', sha256='3df188ac04f17094cb929e2990841ba77f68aa6af484e0509b99db298fa206c9')
+    version('1.22.1', sha256='f169c8615a6823448c2f1923c87c286d798132ea29d26f366e96d26e0aec3697')
 
-    depends_on('m4',       type='build')
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('libuv')
     depends_on('uuid')
+    depends_on('zlib')
+
+    @run_after('install')
+    def setup_dirs(self):
+        # netdata requires the following directories to be able to run.
+        mkdirp(self.prefix.var.cache.netdata)
+        mkdirp(self.prefix.var.lib.netdata)
+        mkdirp(self.prefix.var.log.netdata)


### PR DESCRIPTION
This also changes the checksum for 1.22.1 because I switched the package to use the proper upstream tarballs to get rid of the autotools dependencies. Moreover, a few dependencies were missing. netdata also requires a few directories to be created in its prefix to actually work.