### PR TITLE
Heffte: Add e4s testsuite-inspired smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -15,6 +15,8 @@ class Heffte(CMakePackage):
 
     maintainers = ['mkstoyanov']
 
+    test_requires_compiler = True
+
     version('develop', branch='master')
     version('2.0.0', sha256='12f2b49a1a36c416eac174cf0cc50e729d56d68a9f68886d8c34bd45a0be26b6')
     version('1.0', sha256='0902479fb5b1bad01438ca0a72efd577a3529c3d8bad0028f3c18d3a4935ca74')
@@ -65,3 +67,61 @@ class Heffte(CMakePackage):
             '-DBUILD_GPU={0:1s}'.format(
                 'ON' if ('+cuda' in self.spec and
                          '+fftw' in self.spec) else 'OFF'), ]
+
+    examples_src_dir = 'examples'
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources([self.examples_src_dir])
+
+    def test(self):
+        cmake_file = join_path(self.install_test_root, 'CMakeLists.txt')
+        test_bld_dir = join_path(self.install_test_root, '_build')
+        exe_files = []
+        mpi_procs = []
+
+        with open(cmake_file, 'w') as cmkf:
+            cmkf.write('cmake_minimum_required(VERSION 3.13)\n\n')
+            cmkf.write('project(heffte_example LANGUAGES CXX)\n\n')
+            cmkf.write('find_package(Heffte REQUIRED)\n\n')
+            if '+fftw' in self.spec:
+                src_file = '{0}/heffte_example_fftw.cpp'.format(
+                    self.examples_src_dir)
+                cmkf.write(
+                    'add_executable(hf_fftw {0})\n'.format(src_file))
+                cmkf.write(
+                    'target_link_libraries(hf_fftw Heffte::Heffte)\n')
+                exe_files.append('./hf_fftw')
+                mpi_procs.append(4)
+            if '+cuda' in self.spec:
+                src_file = '{0}/heffte_example_cuda.cpp'.format(
+                    self.examples_src_dir)
+                cmkf.write(
+                    'add_executable(hf_cuda {0})\n'.format(src_file))
+                cmkf.write(
+                    'target_link_libraries(hf_cuda Heffte::Heffte)\n')
+                exe_files.append('./hf_cuda')
+                mpi_procs.append(4)
+            if '+fortran' in self.spec:
+                src_file = '{0}/heffte_example_fftw.f90'.format(
+                    self.examples_src_dir)
+                cmkf.write(
+                    'add_executable(hf_ft {0})\n'.format(src_file))
+                cmkf.write(
+                    'target_link_libraries(hf_ft Heffte::Fortran)\n')
+                exe_files.append('./hf_ft')
+                mpi_procs.append(2)
+
+        with working_dir(test_bld_dir, create=True):
+            cmake('..')
+            make()
+            test_args = ['-n', '4', ' ']
+            mpiexe_f = which('srun', 'mpirun', 'mpiexec')
+            if mpiexe_f:
+                for exf, procs in zip(exe_files, mpi_procs):
+                    test_args[-1] = exf
+                    test_args[-2] = str(procs)
+                    self.run_test(mpiexe_f.command, test_args,
+                                  purpose='heffte smoke test')

--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -108,10 +108,10 @@ class Heffte(CMakePackage):
                 src_file = '{0}/heffte_example_fftw.f90'.format(
                     self.examples_src_dir)
                 cmkf.write(
-                    'add_executable(hf_ft {0})\n'.format(src_file))
+                    'add_executable(hf_fort {0})\n'.format(src_file))
                 cmkf.write(
-                    'target_link_libraries(hf_ft Heffte::Fortran)\n')
-                exe_files.append('./hf_ft')
+                    'target_link_libraries(hf_fort Heffte::Fortran)\n')
+                exe_files.append('./hf_fort')
                 mpi_procs.append(2)
 
         with working_dir(test_bld_dir, create=True):
@@ -123,5 +123,6 @@ class Heffte(CMakePackage):
                 for exf, procs in zip(exe_files, mpi_procs):
                     test_args[-1] = exf
                     test_args[-2] = str(procs)
+                    reason_str = 'Heffte smoke test, exe: {0}'.format(exf)
                     self.run_test(mpiexe_f.command, test_args,
-                                  purpose='heffte smoke test')
+                                  purpose=reason_str)


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `heffte` package and is intended to serve the following purposes:

- leverage the current E4S test suite for the software; and
- demonstrate to package maintainers how to start a Spack smoke test.
