### PR TITLE
Use define_from_variant in numerous CMakePackages

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -141,45 +141,29 @@ class Adios2(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DADIOS2_BUILD_EXAMPLES=OFF',
-            '-DADIOS2_USE_MPI={0}'.format(
-                'ON' if '+mpi' in spec else 'OFF'),
+            self.define_from_variant('ADIOS2_USE_MPI', 'mpi'),
             '-DADIOS2_USE_MGARD=OFF',
-            '-DADIOS2_USE_ZFP={0}'.format(
-                'ON' if '+zfp' in spec else 'OFF'),
-            '-DADIOS2_USE_SZ={0}'.format(
-                'ON' if '+sz' in spec else 'OFF'),
-            '-DADIOS2_USE_DataMan={0}'.format(
-                'ON' if '+dataman' in spec else 'OFF'),
-            '-DADIOS2_USE_SST={0}'.format(
-                'ON' if '+sst' in spec else 'OFF'),
-            '-DADIOS2_USE_HDF5={0}'.format(
-                'ON' if '+hdf5' in spec else 'OFF'),
-            '-DADIOS2_USE_Python={0}'.format(
-                'ON' if '+python' in spec else 'OFF'),
-            '-DADIOS2_USE_Fortran={0}'.format(
-                'ON' if '+fortran' in spec else 'OFF'),
-            '-DADIOS2_USE_Endian_Reverse={0}'.format(
-                'ON' if '+endian_reverse' in spec else 'OFF'),
-            '-DBUILD_TESTING:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF'),
+            self.define_from_variant('ADIOS2_USE_ZFP', 'zfp'),
+            self.define_from_variant('ADIOS2_USE_SZ', 'sz'),
+            self.define_from_variant('ADIOS2_USE_DataMan', 'dataman'),
+            self.define_from_variant('ADIOS2_USE_SST', 'sst'),
+            self.define_from_variant('ADIOS2_USE_HDF5', 'hdf5'),
+            self.define_from_variant('ADIOS2_USE_Python', 'python'),
+            self.define_from_variant('ADIOS2_USE_Fortran', 'fortran'),
+            self.define_from_variant('ADIOS2_USE_Endian_Reverse', 'endian_reverse'),
+            self.define('BUILD_TESTING', self.run_tests),
         ]
 
         if spec.version >= Version('2.4.0'):
-            args.append('-DADIOS2_USE_Blosc={0}'.format(
-                'ON' if '+blosc' in spec else 'OFF'))
-            args.append('-DADIOS2_USE_BZip2={0}'.format(
-                'ON' if '+bzip2' in spec else 'OFF'))
-            args.append('-DADIOS2_USE_PNG={0}'.format(
-                'ON' if '+png' in spec else 'OFF'))
-            args.append('-DADIOS2_USE_SSC={0}'.format(
-                'ON' if '+ssc' in spec else 'OFF'))
+            args.append(self.define_from_variant('ADIOS2_USE_Blosc', 'blosc'))
+            args.append(self.define_from_variant('ADIOS2_USE_BZip2', 'bzip2'))
+            args.append(self.define_from_variant('ADIOS2_USE_PNG', 'png'))
+            args.append(self.define_from_variant('ADIOS2_USE_SSC', 'ssc'))
 
         if spec.version >= Version('2.5.0'):
-            args.append('-DADIOS2_USE_DataSpaces={0}'.format(
-                'ON' if '+dataspaces' in spec else 'OFF'))
+            args.append(self.define_from_variant('ADIOS2_USE_DataSpaces', 'dataspaces'))
 
         if spec.version >= Version('2.6.0'):
             args.append('-DADIOS2_USE_IME=OFF')
@@ -197,8 +181,7 @@ class Adios2(CMakePackage):
             ])
 
         if spec.satisfies('~shared'):
-            args.append('-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL={0}'.format(
-                'ON' if '+pic' in spec else 'OFF'))
+            args.append(self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'))
 
         if spec.satisfies('%fj'):
             args.extend([

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -139,31 +139,32 @@ class Adios2(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+        from_variant = self.define_from_variant
 
         args = [
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DADIOS2_BUILD_EXAMPLES=OFF',
-            self.define_from_variant('ADIOS2_USE_MPI', 'mpi'),
+            from_variant('ADIOS2_USE_MPI', 'mpi'),
             '-DADIOS2_USE_MGARD=OFF',
-            self.define_from_variant('ADIOS2_USE_ZFP', 'zfp'),
-            self.define_from_variant('ADIOS2_USE_SZ', 'sz'),
-            self.define_from_variant('ADIOS2_USE_DataMan', 'dataman'),
-            self.define_from_variant('ADIOS2_USE_SST', 'sst'),
-            self.define_from_variant('ADIOS2_USE_HDF5', 'hdf5'),
-            self.define_from_variant('ADIOS2_USE_Python', 'python'),
-            self.define_from_variant('ADIOS2_USE_Fortran', 'fortran'),
-            self.define_from_variant('ADIOS2_USE_Endian_Reverse', 'endian_reverse'),
+            from_variant('ADIOS2_USE_ZFP', 'zfp'),
+            from_variant('ADIOS2_USE_SZ', 'sz'),
+            from_variant('ADIOS2_USE_DataMan', 'dataman'),
+            from_variant('ADIOS2_USE_SST', 'sst'),
+            from_variant('ADIOS2_USE_HDF5', 'hdf5'),
+            from_variant('ADIOS2_USE_Python', 'python'),
+            from_variant('ADIOS2_USE_Fortran', 'fortran'),
+            from_variant('ADIOS2_USE_Endian_Reverse', 'endian_reverse'),
             self.define('BUILD_TESTING', self.run_tests),
         ]
 
         if spec.version >= Version('2.4.0'):
-            args.append(self.define_from_variant('ADIOS2_USE_Blosc', 'blosc'))
-            args.append(self.define_from_variant('ADIOS2_USE_BZip2', 'bzip2'))
-            args.append(self.define_from_variant('ADIOS2_USE_PNG', 'png'))
-            args.append(self.define_from_variant('ADIOS2_USE_SSC', 'ssc'))
+            args.append(from_variant('ADIOS2_USE_Blosc', 'blosc'))
+            args.append(from_variant('ADIOS2_USE_BZip2', 'bzip2'))
+            args.append(from_variant('ADIOS2_USE_PNG', 'png'))
+            args.append(from_variant('ADIOS2_USE_SSC', 'ssc'))
 
         if spec.version >= Version('2.5.0'):
-            args.append(self.define_from_variant('ADIOS2_USE_DataSpaces', 'dataspaces'))
+            args.append(from_variant('ADIOS2_USE_DataSpaces', 'dataspaces'))
 
         if spec.version >= Version('2.6.0'):
             args.append('-DADIOS2_USE_IME=OFF')
@@ -181,7 +182,7 @@ class Adios2(CMakePackage):
             ])
 
         if spec.satisfies('~shared'):
-            args.append(self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'))
+            args.append(from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'))
 
         if spec.satisfies('%fj'):
             args.extend([

--- a/var/spack/repos/builtin/packages/albany/package.py
+++ b/var/spack/repos/builtin/packages/albany/package.py
@@ -67,36 +67,21 @@ class Albany(CMakePackage):
         ])
 
         options.extend([
-                       '-DENABLE_LCM:BOOL=%s' % (
-                           'ON' if '+lcm' in spec else 'OFF'),
-                       '-DENABLE_AERAS:BOOL=%s' % (
-                           'ON' if '+aeras' in spec else 'OFF'),
-                       '-DENABLE_QCAD:BOOL=%s' % (
-                           'ON' if '+qcad' in spec else 'OFF'),
-                       '-DENABLE_HYDRIDE:BOOL=%s' % (
-                           'ON' if '+hydride' in spec else 'OFF'),
-                       '-DENABLE_LCM_SPECULATIVE:BOOL=%s' % (
-                           'ON' if '+lcm_spec' in spec else 'OFF'),
-                       '-DENABLE_LAME:BOOL=%s' % (
-                           'ON' if '+lame' in spec else 'OFF'),
-                       '-DENABLE_DEBUGGING:BOOL=%s' % (
-                           'ON' if '+debug' in spec else 'OFF'),
-                       '-DENABLE_CHECK_FPE:BOOL=%s' % (
-                           'ON' if '+fpe' in spec else 'OFF'),
-                       '-DENABLE_SCOREC:BOOL=%s' % (
-                           'ON' if '+scorec' in spec else 'OFF'),
-                       '-DENABLE_FELIX:BOOL=%s' % (
-                           'ON' if '+felix' in spec else 'OFF'),
-                       '-DENABLE_MOR:BOOL=%s' % (
-                           'ON' if '+mor' in spec else 'OFF'),
-                       '-DENABLE_ALBANY_CI:BOOL=%s' % (
-                           'ON' if '+ci' in spec else 'OFF'),
-                       '-DENABLE_ASCR:BOOL=%s' % (
-                           'ON' if '+ascr' in spec else 'OFF'),
-                       '-DENABLE_PERFORMANCE_TESTS:BOOL=%s' % (
-                           'ON' if '+perf' in spec else 'OFF'),
-                       '-DENABLE_64BIT_INT:BOOL=%s' % (
-                           'ON' if '+64bit' in spec else 'OFF')
+                       self.define_from_variant('ENABLE_LCM', 'lcm'),
+                       self.define_from_variant('ENABLE_AERAS', 'aeras'),
+                       self.define_from_variant('ENABLE_QCAD', 'qcad'),
+                       self.define_from_variant('ENABLE_HYDRIDE', 'hydride'),
+                       self.define_from_variant('ENABLE_LCM_SPECULATIVE', 'lcm_spec'),
+                       self.define_from_variant('ENABLE_LAME', 'lame'),
+                       self.define_from_variant('ENABLE_DEBUGGING', 'debug'),
+                       self.define_from_variant('ENABLE_CHECK_FPE', 'fpe'),
+                       self.define_from_variant('ENABLE_SCOREC', 'scorec'),
+                       self.define_from_variant('ENABLE_FELIX', 'felix'),
+                       self.define_from_variant('ENABLE_MOR', 'mor'),
+                       self.define_from_variant('ENABLE_ALBANY_CI', 'ci'),
+                       self.define_from_variant('ENABLE_ASCR', 'ascr'),
+                       self.define_from_variant('ENABLE_PERFORMANCE_TESTS', 'perf'),
+                       self.define_from_variant('ENABLE_64BIT_INT', '64bit')
                        ])
 
         return options

--- a/var/spack/repos/builtin/packages/alquimia/package.py
+++ b/var/spack/repos/builtin/packages/alquimia/package.py
@@ -44,8 +44,7 @@ class Alquimia(CMakePackage):
         options = ['-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
                    '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
                    '-DUSE_XSDK_DEFAULTS=YES',
-                   '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                       'ON' if '+shared' in spec else 'OFF'),
+                   self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
                    '-DTPL_ENABLE_MPI:BOOL=ON',
                    '-DMPI_BASE_DIR:PATH=%s' % spec['mpi'].prefix,
                    '-DTPL_ENABLE_HDF5:BOOL=ON',

--- a/var/spack/repos/builtin/packages/aocl-sparse/package.py
+++ b/var/spack/repos/builtin/packages/aocl-sparse/package.py
@@ -66,8 +66,7 @@ class AoclSparse(CMakePackage):
             args.append("-DCMAKE_BUILD_TYPE=Release")
 
         args.extend([
-            "-DBUILD_SHARED_LIBS:BOOL=%s" % (
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
 
             "-DBUILD_CLIENTS_BENCHMARKS:BOOL=%s" % (
                 'ON' if self.run_tests else 'OFF')
@@ -75,8 +74,7 @@ class AoclSparse(CMakePackage):
 
         if spec.satisfies('@3.0:'):
             args.extend([
-                "-DBUILD_ILP64:BOOL=%s" % (
-                    'ON' if '+ilp64' in spec else 'OFF')
+                self.define_from_variant('BUILD_ILP64', 'ilp64')
             ])
 
         return args

--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -61,7 +61,7 @@ class Arborx(CMakePackage):
         options = [
             '-DKokkos_ROOT=%s' % (spec['kokkos'].prefix if '~trilinos' in spec
                                   else spec['trilinos'].prefix),
-            '-DARBORX_ENABLE_MPI=%s' % ('ON' if '+mpi' in spec else 'OFF')
+            self.define_from_variant('ARBORX_ENABLE_MPI', 'mpi')
         ]
 
         if '+cuda' in spec:

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -55,12 +55,9 @@ class Arrayfire(CMakePackage, CudaPackage):
     def cmake_args(self):
         args = []
         args.extend([
-            '-DAF_BUILD_CUDA={0}'.format(
-                'ON' if '+cuda' in self.spec else 'OFF'),
-            '-DAF_BUILD_FORGE={0}'.format(
-                'ON' if '+forge' in self.spec else 'OFF'),
-            '-DAF_BUILD_OPENCL={0}'.format(
-                'ON' if '+opencl' in self.spec else 'OFF'),
+            self.define_from_variant('AF_BUILD_CUDA', 'cuda'),
+            self.define_from_variant('AF_BUILD_FORGE', 'forge'),
+            self.define_from_variant('AF_BUILD_OPENCL', 'opencl'),
         ])
         if '^mkl' in self.spec:
             args.append('-DUSE_CPU_MKL=ON')

--- a/var/spack/repos/builtin/packages/asagi/package.py
+++ b/var/spack/repos/builtin/packages/asagi/package.py
@@ -59,15 +59,13 @@ class Asagi(CMakePackage):
         args = ['-DMAX_DIMENSIONS=' + spec.variants['max_dimensions'].value,
                 '-DSHARED_LIB=' + ('ON' if 'shared' in link_type else 'OFF'),
                 '-DSTATIC_LIB=' + ('ON' if 'static' in link_type else 'OFF'),
-                '-DFORTRAN_SUPPORT=' + ('ON' if '+fortran' in spec else 'OFF'),
-                '-DTHREADSAFE=' + ('ON' if '+threadsafe' in spec else 'OFF'),
+                self.define_from_variant('FORTRAN_SUPPORT', 'fortran'),
+                self.define_from_variant('THREADSAFE', 'threadsafe'),
                 '-DNOMPI=' + ('ON' if '~mpi' in spec else 'OFF'),
-                '-DMPI3=' + ('ON' if '+mpi3' in spec else 'OFF'),
+                self.define_from_variant('MPI3', 'mpi3'),
                 '-DNONUMA=' + ('ON' if '~numa' in spec else 'OFF'),
-                '-DTESTS=' + ('ON' if '+tests' in spec else 'OFF'),
-                '-DEXAMPLES=' + ('ON' if '+examples' in spec else 'OFF'),
-                '-DTHREADSAFE_COUNTER='
-                + ('ON' if '+threadsafe_counter' in spec else 'OFF'),
-                '-DTHREADSAFE_MPI='
-                + ('ON' if '+threadsafe_mpi' in spec else 'OFF'), ]
+                self.define_from_variant('TESTS', 'tests'),
+                self.define_from_variant('EXAMPLES', 'examples'),
+                self.define_from_variant('THREADSAFE_COUNTER', 'threadsafe_counter'),
+                self.define_from_variant('THREADSAFE_MPI', 'threadsafe_mpi'), ]
         return args

--- a/var/spack/repos/builtin/packages/aspect/package.py
+++ b/var/spack/repos/builtin/packages/aspect/package.py
@@ -35,8 +35,7 @@ class Aspect(CMakePackage):
 
     def cmake_args(self):
         return [
-            '-DASPECT_USE_FP_EXCEPTIONS=%s' %
-            ('ON' if '+fpe' in self.spec else 'OFF')
+            self.define_from_variant('ASPECT_USE_FP_EXCEPTIONS', 'fpe')
         ]
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -26,8 +26,7 @@ class Assimp(CMakePackage):
     def cmake_args(self):
         args = [
             '-DASSIMP_BUILD_TESTS=OFF',
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in self.spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]
         return args
 

--- a/var/spack/repos/builtin/packages/babelflow/package.py
+++ b/var/spack/repos/builtin/packages/babelflow/package.py
@@ -25,7 +25,5 @@ class Babelflow(CMakePackage):
     variant("shared", default=True, description="Build Babelflow as shared libs")
 
     def cmake_args(self):
-        spec = self.spec
-        args = [
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]
+        args = [self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]
         return args

--- a/var/spack/repos/builtin/packages/babelflow/package.py
+++ b/var/spack/repos/builtin/packages/babelflow/package.py
@@ -27,6 +27,5 @@ class Babelflow(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         args = [
-            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in spec else 'OFF')]
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]
         return args

--- a/var/spack/repos/builtin/packages/bml/package.py
+++ b/var/spack/repos/builtin/packages/bml/package.py
@@ -34,8 +34,7 @@ class Bml(CMakePackage):
 
     def cmake_args(self):
         args = [
-            '-DBUILD_SHARED_LIBS={0}'.format(
-                'ON' if '+shared' in self.spec else 'OFF')
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')
         ]
         spec = self.spec
         if '+mpi' in spec:

--- a/var/spack/repos/builtin/packages/butterflypack/package.py
+++ b/var/spack/repos/builtin/packages/butterflypack/package.py
@@ -48,9 +48,6 @@ class Butterflypack(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        def on_off(varstr):
-            return 'ON' if varstr in spec else 'OFF'
-
         args = [
             '-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
             '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
@@ -60,7 +57,7 @@ class Butterflypack(CMakePackage):
             '-DTPL_SCALAPACK_LIBRARIES=%s' % spec['scalapack'].
             libs.joined(";"),
             '-DTPL_ARPACK_LIBRARIES=%s' % spec['arpack-ng'].libs.joined(";"),
-            '-DBUILD_SHARED_LIBS=%s' % on_off('+shared'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/c-blosc2/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc2/package.py
@@ -58,12 +58,9 @@ class CBlosc2(CMakePackage):
             '-DPREFER_EXTERNAL_ZSTD=ON',
             '-DDEACTIVATE_AVX2={0}'.format(
                 'ON' if '~avx2' in spec else 'OFF'),
-            '-DBUILD_TESTS={0}'.format(
-                'ON' if self.run_tests else 'OFF'),
-            '-DBUILD_BENCHMARKS={0}'.format(
-                'ON' if self.run_tests else 'OFF'),
-            '-DBUILD_EXAMPLES={0}'.format(
-                'ON' if self.run_tests else 'OFF')
+            self.define('BUILD_TESTS', self.run_tests),
+            self.define('BUILD_BENCHMARKS', self.run_tests),
+            self.define('BUILD_EXAMPLES', self.run_tests)
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -56,7 +56,6 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
         else:
             options.append('-DENABLE_HIP=OFF')
 
-        options.append('-DENABLE_TESTS={0}'.format(
-            'ON' if '+tests' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_TESTS', 'tests'))
 
         return options

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -98,11 +98,9 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
         else:
             options.append('-DENABLE_HIP=OFF')
 
-        options.append('-DCARE_ENABLE_IMPLICIT_CONVERSIONS={0}'.format(
-            'ON' if '+implicit_conversions' in spec else 'OFF'))
+        options.append(self.define_from_variant('CARE_ENABLE_IMPLICIT_CONVERSIONS', 'implicit_conversions'))
 
-        options.append('-DCARE_ENABLE_LOOP_FUSER={0}'.format(
-            'ON' if '+loop_fuser' in spec else 'OFF'))
+        options.append(self.define_from_variant('CARE_ENABLE_LOOP_FUSER', 'loop_fuser'))
 
         options.append('-DCAMP_DIR:PATH='
                        + spec['camp'].prefix.share.camp.cmake)
@@ -113,31 +111,23 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
         options.append('-DCHAI_DIR:PATH='
                        + spec['chai'].prefix.share.chai.cmake)
 
-        options.append('-DCARE_ENABLE_TESTS={0}'.format(
-            'ON' if '+tests' in spec else 'OFF'))
+        options.append(self.define_from_variant('CARE_ENABLE_TESTS', 'tests'))
         # For tests to work, we also need BLT_ENABLE_TESTS to be on.
         # This will take care of the gtest dependency. CARE developers should
         # consider consolidating these flags in the future.
-        options.append('-DBLT_ENABLE_TESTS={0}'.format(
-            'ON' if '+tests' in spec else 'OFF'))
+        options.append(self.define_from_variant('BLT_ENABLE_TESTS', 'tests'))
 
         # There are both CARE_ENABLE_* and ENABLE_* variables in here because
         # one controls the BLT infrastructure and the other controls the CARE
         # infrastructure. The goal is to just be able to use the CARE_ENABLE_*
         # variables, but CARE isn't set up correctly for that yet.
-        options.append('-DENABLE_BENCHMARKS={0}'.format(
-            'ON' if '+benchmarks' in spec else 'OFF'))
-        options.append('-DCARE_ENABLE_BENCHMARKS={0}'.format(
-            'ON' if '+benchmarks' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_BENCHMARKS', 'benchmarks'))
+        options.append(self.define_from_variant('CARE_ENABLE_BENCHMARKS', 'benchmarks'))
 
-        options.append('-DENABLE_EXAMPLES={0}'.format(
-            'ON' if '+examples' in spec else 'OFF'))
-        options.append('-DCARE_ENABLE_EXAMPLES={0}'.format(
-            'ON' if '+examples' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_EXAMPLES', 'examples'))
+        options.append(self.define_from_variant('CARE_ENABLE_EXAMPLES', 'examples'))
 
-        options.append('-DENABLE_DOCS={0}'.format(
-            'ON' if '+docs' in spec else 'OFF'))
-        options.append('-DCARE_ENABLE_DOCS={0}'.format(
-            'ON' if '+docs' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_DOCS', 'docs'))
+        options.append(self.define_from_variant('CARE_ENABLE_DOCS', 'docs'))
 
         return options

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -63,6 +63,7 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
 
     def cmake_args(self):
         spec = self.spec
+        from_variant = self.define_from_variant
 
         options = []
         options.append('-DBLT_SOURCE_DIR={0}'.format(spec['blt'].prefix))
@@ -98,36 +99,33 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
         else:
             options.append('-DENABLE_HIP=OFF')
 
-        options.append(self.define_from_variant('CARE_ENABLE_IMPLICIT_CONVERSIONS', 'implicit_conversions'))
+        options.extend([
+            from_variant('CARE_ENABLE_IMPLICIT_CONVERSIONS',
+                         'implicit_conversions'),
+            from_variant('CARE_ENABLE_LOOP_FUSER', 'loop_fuser'),
+            self.define('CAMP_DIR', spec['camp'].prefix.share.camp.cmake),
+            self.define('UMPIRE_DIR', spec['umpire'].prefix.share.umpire.cmake),
+            self.define('RAJA_DIR', spec['raja'].prefix.share.raja.cmake),
+            self.define('CHAI_DIR', spec['chai'].prefix.share.chai.cmake),
+            from_variant('CARE_ENABLE_TESTS', 'tests'),
+        ])
 
-        options.append(self.define_from_variant('CARE_ENABLE_LOOP_FUSER', 'loop_fuser'))
-
-        options.append('-DCAMP_DIR:PATH='
-                       + spec['camp'].prefix.share.camp.cmake)
-        options.append('-DUMPIRE_DIR:PATH='
-                       + spec['umpire'].prefix.share.umpire.cmake)
-        options.append('-DRAJA_DIR:PATH='
-                       + spec['raja'].prefix.share.raja.cmake)
-        options.append('-DCHAI_DIR:PATH='
-                       + spec['chai'].prefix.share.chai.cmake)
-
-        options.append(self.define_from_variant('CARE_ENABLE_TESTS', 'tests'))
         # For tests to work, we also need BLT_ENABLE_TESTS to be on.
         # This will take care of the gtest dependency. CARE developers should
         # consider consolidating these flags in the future.
-        options.append(self.define_from_variant('BLT_ENABLE_TESTS', 'tests'))
+        options.append(from_variant('BLT_ENABLE_TESTS', 'tests'))
 
         # There are both CARE_ENABLE_* and ENABLE_* variables in here because
         # one controls the BLT infrastructure and the other controls the CARE
         # infrastructure. The goal is to just be able to use the CARE_ENABLE_*
         # variables, but CARE isn't set up correctly for that yet.
-        options.append(self.define_from_variant('ENABLE_BENCHMARKS', 'benchmarks'))
-        options.append(self.define_from_variant('CARE_ENABLE_BENCHMARKS', 'benchmarks'))
+        options.append(from_variant('ENABLE_BENCHMARKS', 'benchmarks'))
+        options.append(from_variant('CARE_ENABLE_BENCHMARKS', 'benchmarks'))
 
-        options.append(self.define_from_variant('ENABLE_EXAMPLES', 'examples'))
-        options.append(self.define_from_variant('CARE_ENABLE_EXAMPLES', 'examples'))
+        options.append(from_variant('ENABLE_EXAMPLES', 'examples'))
+        options.append(from_variant('CARE_ENABLE_EXAMPLES', 'examples'))
 
-        options.append(self.define_from_variant('ENABLE_DOCS', 'docs'))
-        options.append(self.define_from_variant('CARE_ENABLE_DOCS', 'docs'))
+        options.append(from_variant('ENABLE_DOCS', 'docs'))
+        options.append(from_variant('CARE_ENABLE_DOCS', 'docs'))
 
         return options

--- a/var/spack/repos/builtin/packages/catch2/package.py
+++ b/var/spack/repos/builtin/packages/catch2/package.py
@@ -93,8 +93,7 @@ class Catch2(CMakePackage):
             args.append('-DNO_SELFTEST={0}'.format(
                 'OFF' if self.run_tests else 'ON'))
         elif spec.satisfies('@2.1.1:'):
-            args.append('-DBUILD_TESTING:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF'))
+            args.append(self.define('BUILD_TESTING', self.run_tests))
         return args
 
     @when('@:1.6.99')

--- a/var/spack/repos/builtin/packages/cgns/package.py
+++ b/var/spack/repos/builtin/packages/cgns/package.py
@@ -51,26 +51,17 @@ class Cgns(CMakePackage):
         options = []
 
         options.extend([
-            '-DCGNS_ENABLE_FORTRAN:BOOL=%s' % (
-                'ON' if '+fortran' in spec else 'OFF'),
-            '-DCGNS_ENABLE_SCOPING:BOOL=%s' % (
-                'ON' if '+scoping' in spec else 'OFF'),
-            '-DCGNS_ENABLE_PARALLEL:BOOL=%s' % (
-                'ON' if '+mpi' in spec else 'OFF'),
+            self.define_from_variant('CGNS_ENABLE_FORTRAN', 'fortran'),
+            self.define_from_variant('CGNS_ENABLE_SCOPING', 'scoping'),
+            self.define_from_variant('CGNS_ENABLE_PARALLEL', 'mpi'),
             '-DCGNS_ENABLE_TESTS:BOOL=OFF',
-            '-DCGNS_BUILD_TESTING:BOOL=%s' % (
-                'ON' if '+testing' in spec else 'OFF'),
+            self.define_from_variant('CGNS_BUILD_TESTING', 'testing'),
             '-DCGNS_BUILD_CGNSTOOLS:BOOL=OFF',
-            '-DCGNS_BUILD_SHARED:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
-            '-DCGNS_BUILD_STATIC:BOOL=%s' % (
-                'ON' if '+static' in spec else 'OFF'),
-            '-DCGNS_ENABLE_BASE_SCOPE:BOOL=%s' % (
-                'ON' if '+base_scope' in spec else 'OFF'),
-            '-DCGNS_ENABLE_LEGACY:BOOL=%s' % (
-                'ON' if '+legacy' in spec else 'OFF'),
-            '-DCGNS_ENABLE_MEM_DEBUG:BOOL=%s' % (
-                'ON' if '+mem_debug' in spec else 'OFF')
+            self.define_from_variant('CGNS_BUILD_SHARED', 'shared'),
+            self.define_from_variant('CGNS_BUILD_STATIC', 'static'),
+            self.define_from_variant('CGNS_ENABLE_BASE_SCOPE', 'base_scope'),
+            self.define_from_variant('CGNS_ENABLE_LEGACY', 'legacy'),
+            self.define_from_variant('CGNS_ENABLE_MEM_DEBUG', 'mem_debug')
         ])
 
         if '+mpi' in spec:
@@ -81,8 +72,7 @@ class Cgns(CMakePackage):
             ])
 
         options.append(
-            '-DCGNS_ENABLE_64BIT:BOOL={0}'.format(
-                'ON' if '+int64' in spec else 'OFF'))
+            self.define_from_variant('CGNS_ENABLE_64BIT', 'int64'))
 
         if '+hdf5' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -92,8 +92,7 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
             options.extend(['-DENABLE_RAJA_PLUGIN=ON',
                             '-DRAJA_DIR=' + spec['raja'].prefix])
 
-        options.append('-DENABLE_PICK={0}'.format(
-            'ON' if '+enable_pick' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_PICK', 'enable_pick'))
 
         options.append('-Dumpire_DIR:PATH='
                        + spec['umpire'].prefix.share.umpire.cmake)
@@ -101,10 +100,8 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
         options.append('-DENABLE_TESTS={0}'.format(
             'ON' if '+tests' in spec  else 'OFF'))
 
-        options.append('-DENABLE_BENCHMARKS={0}'.format(
-            'ON' if '+benchmarks' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_BENCHMARKS', 'benchmarks'))
 
-        options.append('-DENABLE_EXAMPLES={0}'.format(
-            'ON' if '+examples' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_EXAMPLES', 'examples'))
 
         return options

--- a/var/spack/repos/builtin/packages/clfft/package.py
+++ b/var/spack/repos/builtin/packages/clfft/package.py
@@ -26,8 +26,6 @@ class Clfft(CMakePackage):
     root_cmakelists_dir = 'src'
 
     def cmake_args(self):
-        spec = self.spec
-
         args = [
             self.define_from_variant('BUILD_CLIENT', 'client'),
             self.define_from_variant('BUILD_CALLBACK_CLIENT', 'client')

--- a/var/spack/repos/builtin/packages/clfft/package.py
+++ b/var/spack/repos/builtin/packages/clfft/package.py
@@ -29,7 +29,7 @@ class Clfft(CMakePackage):
         spec = self.spec
 
         args = [
-            self.define('BUILD_CLIENT', 'client'),
-            self.define('BUILD_CALLBACK_CLIENT', 'client')
+            self.define_from_variant('BUILD_CLIENT', 'client'),
+            self.define_from_variant('BUILD_CALLBACK_CLIENT', 'client')
         ]
         return args

--- a/var/spack/repos/builtin/packages/clfft/package.py
+++ b/var/spack/repos/builtin/packages/clfft/package.py
@@ -29,9 +29,7 @@ class Clfft(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DBUILD_CLIENT:BOOL={0}'.format((
-                'ON' if '+client' in spec else 'OFF')),
-            '-DBUILD_CALLBACK_CLIENT:BOOL={0}'.format((
-                'ON' if '+client' in spec else 'OFF'))
+            self.define('BUILD_CLIENT', 'client'),
+            self.define('BUILD_CALLBACK_CLIENT', 'client')
         ]
         return args

--- a/var/spack/repos/builtin/packages/cminpack/package.py
+++ b/var/spack/repos/builtin/packages/cminpack/package.py
@@ -30,8 +30,7 @@ class Cminpack(CMakePackage):
 
     def cmake_args(self):
         args = [
-            '-DBUILD_SHARED_LIBS=%s' % (
-                'ON' if '+shared' in self.spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DUSE_BLAS=%s' % (
                 'ON' if 'blas' in self.spec else 'OFF')
         ]

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -52,8 +52,7 @@ class Dakota(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]
 
         if '+mpi' in spec:

--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -35,11 +35,12 @@ class Datatransferkit(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+        from_variant = self.define_from_variant
 
         options = [
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DDataTransferKit_ENABLE_DataTransferKit=ON',
-            self.define_from_variant('DataTransferKit_ENABLE_ArborX_TPL', 'external-arborx'),
+            from_variant('DataTransferKit_ENABLE_ArborX_TPL', 'external-arborx'),
             '-DDataTransferKit_ENABLE_TESTS=OFF',
             '-DDataTransferKit_ENABLE_EXAMPLES=OFF',
             '-DCMAKE_CXX_EXTENSIONS=OFF',

--- a/var/spack/repos/builtin/packages/datatransferkit/package.py
+++ b/var/spack/repos/builtin/packages/datatransferkit/package.py
@@ -37,11 +37,9 @@ class Datatransferkit(CMakePackage):
         spec = self.spec
 
         options = [
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DDataTransferKit_ENABLE_DataTransferKit=ON',
-            '-DDataTransferKit_ENABLE_ArborX_TPL=%s' % (
-                'ON' if '+external-arborx' in spec else 'OFF'),
+            self.define_from_variant('DataTransferKit_ENABLE_ArborX_TPL', 'external-arborx'),
             '-DDataTransferKit_ENABLE_TESTS=OFF',
             '-DDataTransferKit_ENABLE_EXAMPLES=OFF',
             '-DCMAKE_CXX_EXTENSIONS=OFF',

--- a/var/spack/repos/builtin/packages/dmlc-core/package.py
+++ b/var/spack/repos/builtin/packages/dmlc-core/package.py
@@ -33,5 +33,5 @@ class DmlcCore(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         return [
-            '-DUSE_OPENMP=%s' % ('ON' if '+openmp' in spec else 'OFF'),
+            self.define_from_variant('USE_OPENMP', 'openmp'),
         ]

--- a/var/spack/repos/builtin/packages/dmlc-core/package.py
+++ b/var/spack/repos/builtin/packages/dmlc-core/package.py
@@ -31,7 +31,6 @@ class DmlcCore(CMakePackage):
                     'make/config.mk')
 
     def cmake_args(self):
-        spec = self.spec
         return [
             self.define_from_variant('USE_OPENMP', 'openmp'),
         ]

--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -92,7 +92,7 @@ class Draco(CMakePackage):
         options = []
         options.extend([
             '-Wno-dev',
-            '-DBUILD_TESTING={0}'.format('ON' if self.run_tests else 'OFF'),
+            self.define('BUILD_TESTING', self.run_tests),
             '-DUSE_CUDA={0}'.format('ON' if '+cuda' in self.spec else 'OFF'),
             '-DUSE_QT={0}'.format('ON' if '+qt' in self.spec else 'OFF')
         ])

--- a/var/spack/repos/builtin/packages/ethminer/package.py
+++ b/var/spack/repos/builtin/packages/ethminer/package.py
@@ -30,6 +30,6 @@ class Ethminer(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         return [
-            '-DETHASHCL=%s' % ('YES' if '+opencl' in spec else 'NO'),
-            '-DETHASHCUDA=%s' % ('YES' if '+cuda' in spec else 'NO'),
-            '-DETHSTRATUM=%s' % ('YES' if '+stratum' in spec else 'NO')]
+            self.define_from_variant('ETHASHCL', 'opencl'),
+            self.define_from_variant('ETHASHCUDA', 'cuda'),
+            self.define_from_variant('ETHSTRATUM', 'stratum')]

--- a/var/spack/repos/builtin/packages/ethminer/package.py
+++ b/var/spack/repos/builtin/packages/ethminer/package.py
@@ -28,8 +28,8 @@ class Ethminer(CMakePackage):
     depends_on('mesa', when='+opencl')
 
     def cmake_args(self):
-        spec = self.spec
         return [
             self.define_from_variant('ETHASHCL', 'opencl'),
             self.define_from_variant('ETHASHCUDA', 'cuda'),
-            self.define_from_variant('ETHSTRATUM', 'stratum')]
+            self.define_from_variant('ETHSTRATUM', 'stratum')
+        ]

--- a/var/spack/repos/builtin/packages/everytrace/package.py
+++ b/var/spack/repos/builtin/packages/everytrace/package.py
@@ -26,7 +26,6 @@ class Everytrace(CMakePackage):
     depends_on('mpi', when='+mpi')
 
     def cmake_args(self):
-        spec = self.spec
         return [
             self.define_from_variant('USE_MPI', 'mpi'),
             self.define_from_variant('USE_FORTRAN', 'fortran'),

--- a/var/spack/repos/builtin/packages/everytrace/package.py
+++ b/var/spack/repos/builtin/packages/everytrace/package.py
@@ -28,6 +28,6 @@ class Everytrace(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         return [
-            '-DUSE_MPI=%s' % ('YES' if '+mpi' in spec else 'NO'),
-            '-DUSE_FORTRAN=%s' % ('YES' if '+fortran' in spec else 'NO'),
-            '-DUSE_CXX=%s' % ('YES' if '+cxx' in spec else 'NO')]
+            self.define_from_variant('USE_MPI', 'mpi'),
+            self.define_from_variant('USE_FORTRAN', 'fortran'),
+            self.define_from_variant('USE_CXX', 'cxx')]

--- a/var/spack/repos/builtin/packages/fairlogger/package.py
+++ b/var/spack/repos/builtin/packages/fairlogger/package.py
@@ -68,8 +68,7 @@ class Fairlogger(CMakePackage):
         if cxxstd != 'default':
             args.append('-DCMAKE_CXX_STANDARD=%s' % cxxstd)
         if self.spec.satisfies('@1.4:'):
-            args.append('-DUSE_BOOST_PRETTY_FUNCTION=%s' %
-                        ('ON' if '+pretty' in self.spec else 'OFF'))
+            args.append(self.define_from_variant('USE_BOOST_PRETTY_FUNCTION', 'pretty'))
         if self.spec.satisfies('@1.6:'):
             args.append('-DUSE_EXTERNAL_FMT=ON')
         if self.spec.satisfies('^boost@:1.69.99'):

--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -63,26 +63,19 @@ class Faodel(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in spec else 'OFF'),
-            '-DBUILD_TESTS:BOOL={0}'.format(
-                'ON' if '+mpi' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('BUILD_TESTS', 'mpi'),
             '-DBOOST_ROOT:PATH={0}'.format(spec['boost'].prefix),
             '-DGTEST_ROOT:PATH={0}'.format(spec['googletest'].prefix),
             '-DBUILD_DOCS:BOOL=OFF',
-            '-DFaodel_ENABLE_IOM_HDF5:BOOL={0}'.format(
-                'ON' if '+hdf5' in spec else 'OFF'),
-            '-DFaodel_ENABLE_IOM_LEVELDB:BOOL={0}'.format(
-                'ON' if '+leveldb' in spec else 'OFF'),
-            '-DFaodel_ENABLE_MPI_SUPPORT:BOOL={0}'.format(
-                'ON' if '+mpi' in spec else 'OFF'),
-            '-DFaodel_ENABLE_TCMALLOC:BOOL={0}'.format(
-                'ON' if '+tcmalloc' in spec else 'OFF'),
+            self.define_from_variant('Faodel_ENABLE_IOM_HDF5', 'hdf5'),
+            self.define_from_variant('Faodel_ENABLE_IOM_LEVELDB', 'leveldb'),
+            self.define_from_variant('Faodel_ENABLE_MPI_SUPPORT', 'mpi'),
+            self.define_from_variant('Faodel_ENABLE_TCMALLOC', 'tcmalloc'),
             '-DFaodel_LOGGING_METHOD:STRING={0}'.format(
                 spec.variants['logging'].value),
             '-DFaodel_NETWORK_LIBRARY:STRING={0}'.format(
                 spec.variants['network'].value),
-            '-DFaodel_ENABLE_CEREAL:BOOL={0}'.format(
-                'ON' if '+cereal' in spec else 'OFF')
+            self.define_from_variant('Faodel_ENABLE_CEREAL', 'cereal')
         ]
         return args

--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -69,7 +69,7 @@ class Faodel(CMakePackage):
             '-DGTEST_ROOT:PATH={0}'.format(spec['googletest'].prefix),
             '-DBUILD_DOCS:BOOL=OFF',
             self.define_from_variant('Faodel_ENABLE_IOM_HDF5', 'hdf5'),
-            self.define_from_variant('Faodel_ENABLE_IOM_LEVELDB', 'leveldb'),
+            # self.define_from_variant('Faodel_ENABLE_IOM_LEVELDB', 'leveldb'),
             self.define_from_variant('Faodel_ENABLE_MPI_SUPPORT', 'mpi'),
             self.define_from_variant('Faodel_ENABLE_TCMALLOC', 'tcmalloc'),
             '-DFaodel_LOGGING_METHOD:STRING={0}'.format(

--- a/var/spack/repos/builtin/packages/flatbuffers/package.py
+++ b/var/spack/repos/builtin/packages/flatbuffers/package.py
@@ -54,8 +54,7 @@ class Flatbuffers(CMakePackage):
 
     def cmake_args(self):
         args = []
-        args.append('-DFLATBUFFERS_BUILD_SHAREDLIB={0}'.format(
-            'ON' if '+shared' in self.spec else 'OFF'))
+        args.append(self.define_from_variant('FLATBUFFERS_BUILD_SHAREDLIB', 'shared'))
         args.append('-DFLATBUFFERS_BUILD_FLATLIB={0}'.format(
             'ON' if '+shared' not in self.spec else 'OFF'))
         if 'darwin' in self.spec.architecture:

--- a/var/spack/repos/builtin/packages/flcl/package.py
+++ b/var/spack/repos/builtin/packages/flcl/package.py
@@ -23,7 +23,6 @@ class Flcl(CMakePackage):
 
     def cmake_args(self):
         args = []
-        args.append('-DBUILD_TESTING:BOOL={0}'.format(
-                    'ON' if self.run_tests else 'OFF'))
+        args.append(self.define('BUILD_TESTING', self.run_tests))
 
         return args

--- a/var/spack/repos/builtin/packages/ghost/package.py
+++ b/var/spack/repos/builtin/packages/ghost/package.py
@@ -44,16 +44,11 @@ class Ghost(CMakePackage, CudaPackage):
         # note: we require the cblas_include_dir property from the blas
         # provider, this is implemented at least for intel-mkl and
         # netlib-lapack
-        args = ['-DGHOST_ENABLE_MPI:BOOL=%s'
-                % ('ON' if '+mpi' in spec else 'OFF'),
-                '-DGHOST_USE_CUDA:BOOL=%s'
-                % ('ON' if '+cuda' in spec else 'OFF'),
-                '-DGHOST_USE_SCOTCH:BOOL=%s'
-                % ('ON' if '+scotch' in spec else 'OFF'),
-                '-DGHOST_USE_ZOLTAN:BOOL=%s'
-                % ('ON' if '+zoltan' in spec else 'OFF'),
-                '-DBUILD_SHARED_LIBS:BOOL=%s'
-                % ('ON' if '+shared' in spec else 'OFF'),
+        args = [self.define_from_variant('GHOST_ENABLE_MPI', 'mpi'),
+                self.define_from_variant('GHOST_USE_CUDA', 'cuda'),
+                self.define_from_variant('GHOST_USE_SCOTCH', 'scotch'),
+                self.define_from_variant('GHOST_USE_ZOLTAN', 'zoltan'),
+                self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
                 '-DCBLAS_INCLUDE_DIR:STRING=%s'
                 % format(spec['blas'].headers.directories[0]),
                 '-DBLAS_LIBRARIES=%s'

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -73,14 +73,15 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
                 InstallError('Ginkgo requires a C++14-compliant C++ compiler')
 
         spec = self.spec
+        from_variant = self.define_from_variant
         args = [
-            self.define_from_variant('GINKGO_BUILD_CUDA', 'cuda'),
-            self.define_from_variant('GINKGO_BUILD_HIP', 'rocm'),
-            self.define_from_variant('GINKGO_BUILD_OMP', 'openmp'),
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
-            self.define_from_variant('GINKGO_JACOBI_FULL_OPTIMIZATIONS', 'full_optimizations'),
-            self.define_from_variant('GINKGO_BUILD_HWLOC', 'hwloc'),
-            self.define_from_variant('GINKGO_DEVEL_TOOLS', 'develtools'),
+            from_variant('GINKGO_BUILD_CUDA', 'cuda'),
+            from_variant('GINKGO_BUILD_HIP', 'rocm'),
+            from_variant('GINKGO_BUILD_OMP', 'openmp'),
+            from_variant('BUILD_SHARED_LIBS', 'shared'),
+            from_variant('GINKGO_JACOBI_FULL_OPTIMIZATIONS', 'full_optimizations'),
+            from_variant('GINKGO_BUILD_HWLOC', 'hwloc'),
+            from_variant('GINKGO_DEVEL_TOOLS', 'develtools'),
             # As we are not exposing benchmarks, examples, tests nor doc
             # as part of the installation, disable building them altogether.
             '-DGINKGO_BUILD_BENCHMARKS=OFF',

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -74,21 +74,19 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
 
         spec = self.spec
         args = [
-            '-DGINKGO_BUILD_CUDA=%s' % ('ON' if '+cuda' in spec else 'OFF'),
-            '-DGINKGO_BUILD_HIP=%s' % ('ON' if '+rocm' in spec else 'OFF'),
-            '-DGINKGO_BUILD_OMP=%s' % ('ON' if '+openmp' in spec else 'OFF'),
-            '-DBUILD_SHARED_LIBS=%s' % ('ON' if '+shared' in spec else 'OFF'),
-            '-DGINKGO_JACOBI_FULL_OPTIMIZATIONS=%s' % (
-                'ON' if '+full_optimizations' in spec else 'OFF'),
-            '-DGINKGO_BUILD_HWLOC=%s' % ('ON' if '+hwloc' in spec else 'OFF'),
-            '-DGINKGO_DEVEL_TOOLS=%s' % (
-                'ON' if '+develtools' in spec else 'OFF'),
+            self.define_from_variant('GINKGO_BUILD_CUDA', 'cuda'),
+            self.define_from_variant('GINKGO_BUILD_HIP', 'rocm'),
+            self.define_from_variant('GINKGO_BUILD_OMP', 'openmp'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('GINKGO_JACOBI_FULL_OPTIMIZATIONS', 'full_optimizations'),
+            self.define_from_variant('GINKGO_BUILD_HWLOC', 'hwloc'),
+            self.define_from_variant('GINKGO_DEVEL_TOOLS', 'develtools'),
             # As we are not exposing benchmarks, examples, tests nor doc
             # as part of the installation, disable building them altogether.
             '-DGINKGO_BUILD_BENCHMARKS=OFF',
             '-DGINKGO_BUILD_DOC=OFF',
             '-DGINKGO_BUILD_EXAMPLES=OFF',
-            '-DGINKGO_BUILD_TESTS=%s' % ('ON' if self.run_tests else 'OFF'),
+            self.define('GINKGO_BUILD_TESTS', self.run_tests),
             # Let spack handle the RPATH
             '-DGINKGO_INSTALL_RPATH=OFF'
         ]

--- a/var/spack/repos/builtin/packages/gl2ps/package.py
+++ b/var/spack/repos/builtin/packages/gl2ps/package.py
@@ -50,8 +50,8 @@ class Gl2ps(CMakePackage):
 
     def cmake_args(self):
         options = [
-            '-DENABLE_PNG={0}'.format(self.variant_to_bool('+png')),
-            '-DENABLE_ZLIB={0}'.format(self.variant_to_bool('+zlib')),
+            self.define_from_variant('ENABLE_PNG', 'png'),
+            self.define_from_variant('ENABLE_ZLIB', 'zlib'),
         ]
         if '~doc' in self.spec:
             # Make sure we don't look.

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -40,8 +40,7 @@ class Googletest(CMakePackage):
 
         options.append('-Dgtest_disable_pthreads={0}'.format(
             'OFF' if '+pthreads' in spec else 'ON'))
-        options.append('-DBUILD_SHARED_LIBS={0}'.format(
-            'ON' if '+shared' in spec else 'OFF'))
+        options.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
         return options
 
     @when('@:1.7.0')

--- a/var/spack/repos/builtin/packages/gotcha/package.py
+++ b/var/spack/repos/builtin/packages/gotcha/package.py
@@ -28,5 +28,5 @@ class Gotcha(CMakePackage):
     def configure_args(self):
         spec = self.spec
         return [
-            '-DGOTCHA_ENABLE_TESTS=%s' % ('ON' if '+test' in spec else 'OFF')
+            self.define_from_variant('GOTCHA_ENABLE_TESTS', 'test')
         ]

--- a/var/spack/repos/builtin/packages/gotcha/package.py
+++ b/var/spack/repos/builtin/packages/gotcha/package.py
@@ -26,7 +26,6 @@ class Gotcha(CMakePackage):
         when='@0.0.2:1.0.2')
 
     def configure_args(self):
-        spec = self.spec
         return [
             self.define_from_variant('GOTCHA_ENABLE_TESTS', 'test')
         ]

--- a/var/spack/repos/builtin/packages/gunrock/package.py
+++ b/var/spack/repos/builtin/packages/gunrock/package.py
@@ -60,16 +60,17 @@ See "spack info gunrock"')
 
     def cmake_args(self):
         spec = self.spec
-        args = []
-        args.extend([
-                    self.define_from_variant('GUNROCK_BUILD_LIB', 'lib'),
-                    self.define_from_variant('GUNROCK_BUILD_SHARED_LIBS', 'shared_libs'),
-                    self.define_from_variant('GUNROCK_BUILD_TESTS', 'tests'),
-                    self.define_from_variant('GUNROCK_MGPU_TESTS', 'mgpu_tests'),
-                    self.define_from_variant('CUDA_VERBOSE_PTXAS', 'cuda_verbose_ptxas'),
-                    self.define_from_variant('GUNROCK_GOOGLE_TESTS', 'google_tests'),
-                    self.define_from_variant('GUNROCK_CODE_COVERAGE', 'code_coverage'),
-                    ])
+        from_variant = self.define_from_variant
+
+        args = [
+            from_variant('GUNROCK_BUILD_LIB', 'lib'),
+            from_variant('GUNROCK_BUILD_SHARED_LIBS', 'shared_libs'),
+            from_variant('GUNROCK_BUILD_TESTS', 'tests'),
+            from_variant('GUNROCK_MGPU_TESTS', 'mgpu_tests'),
+            from_variant('CUDA_VERBOSE_PTXAS', 'cuda_verbose_ptxas'),
+            from_variant('GUNROCK_GOOGLE_TESTS', 'google_tests'),
+            from_variant('GUNROCK_CODE_COVERAGE', 'code_coverage'),
+        ]
 
         # turn off auto detect, which undoes custom cuda arch options
         args.append('-DCUDA_AUTODETECT_GENCODE=OFF')

--- a/var/spack/repos/builtin/packages/gunrock/package.py
+++ b/var/spack/repos/builtin/packages/gunrock/package.py
@@ -62,20 +62,13 @@ See "spack info gunrock"')
         spec = self.spec
         args = []
         args.extend([
-                    '-DGUNROCK_BUILD_LIB={0}'.format(
-                        'ON' if '+lib' in spec else 'OFF'),
-                    '-DGUNROCK_BUILD_SHARED_LIBS={0}'.format(
-                        'ON' if '+shared_libs' in spec else 'OFF'),
-                    '-DGUNROCK_BUILD_TESTS={0}'.format(
-                        'ON' if '+tests' in spec else 'OFF'),
-                    '-DGUNROCK_MGPU_TESTS={0}'.format(
-                        'ON' if '+mgpu_tests' in spec else 'OFF'),
-                    '-DCUDA_VERBOSE_PTXAS={0}'.format(
-                        'ON' if '+cuda_verbose_ptxas' in spec else 'OFF'),
-                    '-DGUNROCK_GOOGLE_TESTS={0}'.format(
-                        'ON' if '+google_tests' in spec else 'OFF'),
-                    '-DGUNROCK_CODE_COVERAGE={0}'.format(
-                        'ON' if '+code_coverage' in spec else 'OFF'),
+                    self.define_from_variant('GUNROCK_BUILD_LIB', 'lib'),
+                    self.define_from_variant('GUNROCK_BUILD_SHARED_LIBS', 'shared_libs'),
+                    self.define_from_variant('GUNROCK_BUILD_TESTS', 'tests'),
+                    self.define_from_variant('GUNROCK_MGPU_TESTS', 'mgpu_tests'),
+                    self.define_from_variant('CUDA_VERBOSE_PTXAS', 'cuda_verbose_ptxas'),
+                    self.define_from_variant('GUNROCK_GOOGLE_TESTS', 'google_tests'),
+                    self.define_from_variant('GUNROCK_CODE_COVERAGE', 'code_coverage'),
                     ])
 
         # turn off auto detect, which undoes custom cuda arch options

--- a/var/spack/repos/builtin/packages/helics/package.py
+++ b/var/spack/repos/builtin/packages/helics/package.py
@@ -72,29 +72,30 @@ class Helics(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+        from_variant = self.define_from_variant
         args = [
             '-DHELICS_BUILD_EXAMPLES=OFF',
             '-DHELICS_BUILD_TESTS=OFF',
         ]
 
         # HELICS core type CMake options
-        args.append(self.define_from_variant('ENABLE_ZMQ_CORE', 'zmq'))
-        args.append(self.define_from_variant('ENABLE_TCP_CORE', 'tcp'))
-        args.append(self.define_from_variant('ENABLE_UDP_CORE', 'udp'))
-        args.append(self.define_from_variant('ENABLE_IPC_CORE', 'ipc'))
-        args.append(self.define_from_variant('ENABLE_INPROC_CORE', 'inproc'))
-        args.append(self.define_from_variant('ENABLE_MPI_CORE', 'mpi'))
+        args.append(from_variant('ENABLE_ZMQ_CORE', 'zmq'))
+        args.append(from_variant('ENABLE_TCP_CORE', 'tcp'))
+        args.append(from_variant('ENABLE_UDP_CORE', 'udp'))
+        args.append(from_variant('ENABLE_IPC_CORE', 'ipc'))
+        args.append(from_variant('ENABLE_INPROC_CORE', 'inproc'))
+        args.append(from_variant('ENABLE_MPI_CORE', 'mpi'))
 
         # HELICS shared library options
         args.append('-DHELICS_DISABLE_C_SHARED_LIB={0}'.format(
             'OFF' if '+c_shared' in spec else 'ON'))
-        args.append(self.define_from_variant('HELICS_BUILD_CXX_SHARED_LIB', 'cxx_shared'))
+        args.append(from_variant('HELICS_BUILD_CXX_SHARED_LIB', 'cxx_shared'))
 
         # HELICS executable app options
-        args.append(self.define_from_variant('HELICS_BUILD_APP_EXECUTABLES', 'apps'))
+        args.append(from_variant('HELICS_BUILD_APP_EXECUTABLES', 'apps'))
         args.append('-DHELICS_DISABLE_WEBSERVER={0}'.format(
             'OFF' if '+webserver' in spec else 'ON'))
-        args.append(self.define_from_variant('HELICS_BUILD_BENCHMARKS', 'benchmarks'))
+        args.append(from_variant('HELICS_BUILD_BENCHMARKS', 'benchmarks'))
 
         # Extra HELICS library dependencies
         args.append('-DHELICS_DISABLE_BOOST={0}'.format(
@@ -103,10 +104,10 @@ class Helics(CMakePackage):
             'OFF' if '+asio' in spec else 'ON'))
 
         # SWIG
-        args.append(self.define_from_variant('HELICS_ENABLE_SWIG', 'swig'))
+        args.append(from_variant('HELICS_ENABLE_SWIG', 'swig'))
 
         # Python
-        args.append(self.define_from_variant('BUILD_PYTHON_INTERFACE', 'python'))
+        args.append(from_variant('BUILD_PYTHON_INTERFACE', 'python'))
 
         return args
 

--- a/var/spack/repos/builtin/packages/helics/package.py
+++ b/var/spack/repos/builtin/packages/helics/package.py
@@ -78,32 +78,23 @@ class Helics(CMakePackage):
         ]
 
         # HELICS core type CMake options
-        args.append('-DENABLE_ZMQ_CORE={0}'.format(
-            'ON' if '+zmq' in spec else 'OFF'))
-        args.append('-DENABLE_TCP_CORE={0}'.format(
-            'ON' if '+tcp' in spec else 'OFF'))
-        args.append('-DENABLE_UDP_CORE={0}'.format(
-            'ON' if '+udp' in spec else 'OFF'))
-        args.append('-DENABLE_IPC_CORE={0}'.format(
-            'ON' if '+ipc' in spec else 'OFF'))
-        args.append('-DENABLE_INPROC_CORE={0}'.format(
-            'ON' if '+inproc' in spec else 'OFF'))
-        args.append('-DENABLE_MPI_CORE={0}'.format(
-            'ON' if '+mpi' in spec else 'OFF'))
+        args.append(self.define_from_variant('ENABLE_ZMQ_CORE', 'zmq'))
+        args.append(self.define_from_variant('ENABLE_TCP_CORE', 'tcp'))
+        args.append(self.define_from_variant('ENABLE_UDP_CORE', 'udp'))
+        args.append(self.define_from_variant('ENABLE_IPC_CORE', 'ipc'))
+        args.append(self.define_from_variant('ENABLE_INPROC_CORE', 'inproc'))
+        args.append(self.define_from_variant('ENABLE_MPI_CORE', 'mpi'))
 
         # HELICS shared library options
         args.append('-DHELICS_DISABLE_C_SHARED_LIB={0}'.format(
             'OFF' if '+c_shared' in spec else 'ON'))
-        args.append('-DHELICS_BUILD_CXX_SHARED_LIB={0}'.format(
-            'ON' if '+cxx_shared' in spec else 'OFF'))
+        args.append(self.define_from_variant('HELICS_BUILD_CXX_SHARED_LIB', 'cxx_shared'))
 
         # HELICS executable app options
-        args.append('-DHELICS_BUILD_APP_EXECUTABLES={0}'.format(
-            'ON' if '+apps' in spec else 'OFF'))
+        args.append(self.define_from_variant('HELICS_BUILD_APP_EXECUTABLES', 'apps'))
         args.append('-DHELICS_DISABLE_WEBSERVER={0}'.format(
             'OFF' if '+webserver' in spec else 'ON'))
-        args.append('-DHELICS_BUILD_BENCHMARKS={0}'.format(
-            'ON' if '+benchmarks' in spec else 'OFF'))
+        args.append(self.define_from_variant('HELICS_BUILD_BENCHMARKS', 'benchmarks'))
 
         # Extra HELICS library dependencies
         args.append('-DHELICS_DISABLE_BOOST={0}'.format(
@@ -112,12 +103,10 @@ class Helics(CMakePackage):
             'OFF' if '+asio' in spec else 'ON'))
 
         # SWIG
-        args.append('-DHELICS_ENABLE_SWIG={0}'.format(
-            'ON' if '+swig' in spec else 'OFF'))
+        args.append(self.define_from_variant('HELICS_ENABLE_SWIG', 'swig'))
 
         # Python
-        args.append('-DBUILD_PYTHON_INTERFACE={0}'.format(
-            'ON' if '+python' in spec else 'OFF'))
+        args.append(self.define_from_variant('BUILD_PYTHON_INTERFACE', 'python'))
 
         return args
 

--- a/var/spack/repos/builtin/packages/ibmisc/package.py
+++ b/var/spack/repos/builtin/packages/ibmisc/package.py
@@ -52,10 +52,10 @@ class Ibmisc(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         return [
-            '-DUSE_EVERYTRACE=%s' % ('YES' if '+everytrace' in spec else 'NO'),
-            '-DUSE_PROJ4=%s' % ('YES' if '+proj' in spec else 'NO'),
-            '-DUSE_BLITZ=%s' % ('YES' if '+blitz' in spec else 'NO'),
-            '-DUSE_NETCDF=%s' % ('YES' if '+netcdf' in spec else 'NO'),
-            '-DUSE_BOOST=%s' % ('YES' if '+boost' in spec else 'NO'),
-            '-DUSE_UDUNITS2=%s' % ('YES' if '+udunits2' in spec else 'NO'),
-            '-DUSE_GTEST=%s' % ('YES' if '+googletest' in spec else 'NO')]
+            self.define_from_variant('USE_EVERYTRACE', 'everytrace'),
+            self.define_from_variant('USE_PROJ4', 'proj'),
+            self.define_from_variant('USE_BLITZ', 'blitz'),
+            self.define_from_variant('USE_NETCDF', 'netcdf'),
+            self.define_from_variant('USE_BOOST', 'boost'),
+            self.define_from_variant('USE_UDUNITS2', 'udunits2'),
+            self.define_from_variant('USE_GTEST', 'googletest')]

--- a/var/spack/repos/builtin/packages/ibmisc/package.py
+++ b/var/spack/repos/builtin/packages/ibmisc/package.py
@@ -50,7 +50,6 @@ class Ibmisc(CMakePackage):
     depends_on('doxygen', type='build')
 
     def cmake_args(self):
-        spec = self.spec
         return [
             self.define_from_variant('USE_EVERYTRACE', 'everytrace'),
             self.define_from_variant('USE_PROJ4', 'proj'),
@@ -58,4 +57,5 @@ class Ibmisc(CMakePackage):
             self.define_from_variant('USE_NETCDF', 'netcdf'),
             self.define_from_variant('USE_BOOST', 'boost'),
             self.define_from_variant('USE_UDUNITS2', 'udunits2'),
-            self.define_from_variant('USE_GTEST', 'googletest')]
+            self.define_from_variant('USE_GTEST', 'googletest'),
+        ]

--- a/var/spack/repos/builtin/packages/jansson/package.py
+++ b/var/spack/repos/builtin/packages/jansson/package.py
@@ -26,6 +26,5 @@ class Jansson(CMakePackage):
 
     def cmake_args(self):
         return [
-            '-DJANSSON_BUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in self.spec else 'OFF'),
+            self.define_from_variant('JANSSON_BUILD_SHARED_LIBS', 'shared'),
         ]

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -172,15 +172,12 @@ class Lammps(CMakePackage, CudaPackage):
             pkg_prefix = 'PKG'
 
         args = [
-            '-DBUILD_SHARED_LIBS={0}'.format(
-                'ON' if '+lib' in spec else 'OFF'),
-            '-DLAMMPS_EXCEPTIONS={0}'.format(
-                'ON' if '+exceptions' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'lib'),
+            self.define_from_variant('LAMMPS_EXCEPTIONS', 'exceptions'),
             '-D{0}_MPI={1}'.format(
                 mpi_prefix,
                 'ON' if '+mpi' in spec else 'OFF'),
-            '-DBUILD_OMP={0}'.format(
-                'ON' if '+openmp' in spec else 'OFF'),
+            self.define_from_variant('BUILD_OMP', 'openmp'),
         ]
         if spec.satisfies('+cuda'):
             args.append('-DPKG_GPU=ON')
@@ -188,8 +185,7 @@ class Lammps(CMakePackage, CudaPackage):
             cuda_arch = spec.variants['cuda_arch'].value
             if cuda_arch != 'none':
                 args.append('-DGPU_ARCH=sm_{0}'.format(cuda_arch[0]))
-            args.append('-DCUDA_MPS_SUPPORT={0}'.format(
-                'ON' if '+cuda_mps' in spec else 'OFF'))
+            args.append(self.define_from_variant('CUDA_MPS_SUPPORT', 'cuda_mps'))
         elif spec.satisfies('+opencl'):
             args.append('-DPKG_GPU=ON')
             args.append('-DGPU_API=opencl')
@@ -199,12 +195,9 @@ class Lammps(CMakePackage, CudaPackage):
         if spec.satisfies('@20180629:+lib'):
             args.append('-DBUILD_LIB=ON')
 
-        args.append('-DWITH_JPEG={0}'.format(
-            'ON' if '+jpeg' in spec else 'OFF'))
-        args.append('-DWITH_PNG={0}'.format(
-            'ON' if '+png' in spec else 'OFF'))
-        args.append('-DWITH_FFMPEG={0}'.format(
-            'ON' if '+ffmpeg' in spec else 'OFF'))
+        args.append(self.define_from_variant('WITH_JPEG', 'jpeg'))
+        args.append(self.define_from_variant('WITH_PNG', 'png'))
+        args.append(self.define_from_variant('WITH_FFMPEG', 'ffmpeg'))
 
         for pkg in self.supported_packages:
             opt = '-D{0}_{1}'.format(pkg_prefix, pkg.upper())

--- a/var/spack/repos/builtin/packages/libgit2/package.py
+++ b/var/spack/repos/builtin/packages/libgit2/package.py
@@ -96,6 +96,6 @@ class Libgit2(CMakePackage):
 
         # Control tests
         args.append(
-            '-DBUILD_CLAR={0}'.format('ON' if self.run_tests else 'OFF'))
+            self.define('BUILD_CLAR', self.run_tests))
 
         return args

--- a/var/spack/repos/builtin/packages/libnetworkit/package.py
+++ b/var/spack/repos/builtin/packages/libnetworkit/package.py
@@ -42,7 +42,6 @@ class Libnetworkit(CMakePackage):
         tlx_libs = spec['libtlx'].prefix
 
         args = ['-DNETWORKIT_EXT_TLX=%s' % tlx_libs,
-                '-DNETWORKIT_STATIC=%s' %
-                ('ON' if '+static' in spec else 'OFF')]
+                self.define_from_variant('NETWORKIT_STATIC', 'static')]
 
         return args

--- a/var/spack/repos/builtin/packages/libsplash/package.py
+++ b/var/spack/repos/builtin/packages/libsplash/package.py
@@ -45,10 +45,8 @@ class Libsplash(CMakePackage):
 
         if spec.satisfies('@1.7.0:'):
             args += [
-                '-DSplash_USE_MPI:BOOL={0}'.format(
-                    'ON' if '+mpi' in spec else 'OFF'),
-                '-DSplash_USE_PARALLEL:BOOL={0}'.format(
-                    'ON' if '+mpi' in spec else 'OFF')
+                self.define_from_variant('Splash_USE_MPI', 'mpi'),
+                self.define_from_variant('Splash_USE_PARALLEL', 'mpi')
             ]
 
         return args

--- a/var/spack/repos/builtin/packages/libssh/package.py
+++ b/var/spack/repos/builtin/packages/libssh/package.py
@@ -26,6 +26,5 @@ class Libssh(CMakePackage):
         return url.format(version.up_to(2), version)
 
     def cmake_args(self):
-        args = ['-DWITH_GSSAPI=%s' %
-                ('ON' if '+gssapi' in self.spec else 'OFF')]
+        args = [self.define_from_variant('WITH_GSSAPI', 'gssapi')]
         return args

--- a/var/spack/repos/builtin/packages/libssh2/package.py
+++ b/var/spack/repos/builtin/packages/libssh2/package.py
@@ -25,9 +25,7 @@ class Libssh2(CMakePackage):
     depends_on('xz')
 
     def cmake_args(self):
-        spec = self.spec
-        return [
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]
+        return [self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]
 
     @run_after('install')
     def darwin_fix(self):

--- a/var/spack/repos/builtin/packages/libssh2/package.py
+++ b/var/spack/repos/builtin/packages/libssh2/package.py
@@ -27,7 +27,7 @@ class Libssh2(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         return [
-            '-DBUILD_SHARED_LIBS=%s' % ('YES' if '+shared' in spec else 'NO')]
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]
 
     @run_after('install')
     def darwin_fix(self):

--- a/var/spack/repos/builtin/packages/modern-wheel/package.py
+++ b/var/spack/repos/builtin/packages/modern-wheel/package.py
@@ -40,7 +40,6 @@ class ModernWheel(CMakePackage):
     patch('add_virtual_destructor.patch')
 
     def cmake_args(self):
-        spec = self.spec
         return [
             self.define_from_variant('BUILD_UNIT_TEST', 'test'),
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),

--- a/var/spack/repos/builtin/packages/modern-wheel/package.py
+++ b/var/spack/repos/builtin/packages/modern-wheel/package.py
@@ -42,8 +42,6 @@ class ModernWheel(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         return [
-            '-DBUILD_UNIT_TEST:BOOL={0}'.format(
-                'ON' if '+test' in spec else 'OFF'),
-            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('BUILD_UNIT_TEST', 'test'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]

--- a/var/spack/repos/builtin/packages/mofem-cephas/package.py
+++ b/var/spack/repos/builtin/packages/mofem-cephas/package.py
@@ -69,8 +69,7 @@ class MofemCephas(CMakePackage):
             '-DBOOST_DIR=%s' % spec['boost'].prefix])
 
         # build tests
-        options.append('-DMOFEM_BUILD_TESTS={0}'.format(
-            'ON' if self.run_tests else 'OFF'))
+        options.append(self.define('MOFEM_BUILD_TESTS', self.run_tests))
 
         # variant packages
         if '+adol-c' in spec:
@@ -87,6 +86,5 @@ class MofemCephas(CMakePackage):
 
         # copy users modules, i.e. stand alone vs linked users modules
         options.append(
-            '-DSTAND_ALLONE_USERS_MODULES=%s' %
-            ('YES' if '+copy_user_modules' in spec else 'NO'))
+            self.define_from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules'))
         return options

--- a/var/spack/repos/builtin/packages/mofem-fracture-module/package.py
+++ b/var/spack/repos/builtin/packages/mofem-fracture-module/package.py
@@ -54,17 +54,17 @@ class MofemFractureModule(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        source = self.stage.source_path
-
-        options = []
 
         # obligatory options
-        options.extend([
-            '-DWITH_SPACK=YES',
-            '-DEXTERNAL_MODULES_BUILD=YES',
-            '-DUM_INSTALL_BREFIX=%s' % spec['mofem-users-modules'].prefix,
-            '-DEXTERNAL_MODULE_SOURCE_DIRS=%s' % source,
-            self.define_from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules')])
+        options = [
+            self.define('WITH_SPACK', True),
+            self.define('EXTERNAL_MODULES_BUILD', True),
+            self.define('UM_INSTALL_BREFIX',
+                        spec['mofem-users-modules'].prefix),
+            self.define('EXTERNAL_MODULE_SOURCE_DIRS', self.stage.source_path),
+            self.define_from_variant('STAND_ALLONE_USERS_MODULES',
+                                     'copy_user_modules')
+        ]
 
         # Set module version
         if self.spec.version == Version('develop'):

--- a/var/spack/repos/builtin/packages/mofem-fracture-module/package.py
+++ b/var/spack/repos/builtin/packages/mofem-fracture-module/package.py
@@ -64,8 +64,7 @@ class MofemFractureModule(CMakePackage):
             '-DEXTERNAL_MODULES_BUILD=YES',
             '-DUM_INSTALL_BREFIX=%s' % spec['mofem-users-modules'].prefix,
             '-DEXTERNAL_MODULE_SOURCE_DIRS=%s' % source,
-            '-DSTAND_ALLONE_USERS_MODULES=%s' %
-            ('YES' if '+copy_user_modules' in spec else 'NO')])
+            self.define_from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules')])
 
         # Set module version
         if self.spec.version == Version('develop'):
@@ -80,8 +79,7 @@ class MofemFractureModule(CMakePackage):
                 '-DFM_VERSION_BUILD=%s' % self.spec.version[2]])
 
         # build tests
-        options.append('-DMOFEM_UM_BUILD_TESTS={0}'.format(
-            'ON' if self.run_tests else 'OFF'))
+        options.append(self.define('MOFEM_UM_BUILD_TESTS', self.run_tests))
 
         return options
 

--- a/var/spack/repos/builtin/packages/mofem-minimal-surface-equation/package.py
+++ b/var/spack/repos/builtin/packages/mofem-minimal-surface-equation/package.py
@@ -55,12 +55,10 @@ class MofemMinimalSurfaceEquation(CMakePackage):
             '-DEXTERNAL_MODULES_BUILD=YES',
             '-DUM_INSTALL_BREFIX=%s' % spec['mofem-users-modules'].prefix,
             '-DEXTERNAL_MODULE_SOURCE_DIRS=%s' % source,
-            '-DSTAND_ALLONE_USERS_MODULES=%s' %
-            ('YES' if '+copy_user_modules' in spec else 'NO')])
+            self.define_from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules')])
 
         # build tests
-        options.append('-DMOFEM_UM_BUILD_TESTS={0}'.format(
-            'ON' if self.run_tests else 'OFF'))
+        options.append(self.define('MOFEM_UM_BUILD_TESTS', self.run_tests))
 
         return options
 

--- a/var/spack/repos/builtin/packages/mofem-minimal-surface-equation/package.py
+++ b/var/spack/repos/builtin/packages/mofem-minimal-surface-equation/package.py
@@ -45,6 +45,7 @@ class MofemMinimalSurfaceEquation(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+        from_variant = self.define_from_variant
         source = self.stage.source_path
 
         options = []
@@ -55,7 +56,7 @@ class MofemMinimalSurfaceEquation(CMakePackage):
             '-DEXTERNAL_MODULES_BUILD=YES',
             '-DUM_INSTALL_BREFIX=%s' % spec['mofem-users-modules'].prefix,
             '-DEXTERNAL_MODULE_SOURCE_DIRS=%s' % source,
-            self.define_from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules')])
+            from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules')])
 
         # build tests
         options.append(self.define('MOFEM_UM_BUILD_TESTS', self.run_tests))

--- a/var/spack/repos/builtin/packages/mofem-users-modules/package.py
+++ b/var/spack/repos/builtin/packages/mofem-users-modules/package.py
@@ -53,12 +53,10 @@ class MofemUsersModules(CMakePackage):
         options.extend([
             '-DMOFEM_DIR=%s' % spec['mofem-cephas'].prefix.users_module,
             '-DWITH_SPACK=YES',
-            '-DSTAND_ALLONE_USERS_MODULES=%s' %
-            ('YES' if '+copy_user_modules' in spec else 'NO')])
+            self.define_from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules')])
 
         # build tests
-        options.append('-DMOFEM_UM_BUILD_TESTS={0}'.format(
-            'ON' if self.run_tests else 'OFF'))
+        options.append(self.define('MOFEM_UM_BUILD_TESTS', self.run_tests))
 
         return options
 

--- a/var/spack/repos/builtin/packages/mofem-users-modules/package.py
+++ b/var/spack/repos/builtin/packages/mofem-users-modules/package.py
@@ -46,6 +46,7 @@ class MofemUsersModules(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+        from_variant = self.define_from_variant
 
         options = []
 
@@ -53,7 +54,7 @@ class MofemUsersModules(CMakePackage):
         options.extend([
             '-DMOFEM_DIR=%s' % spec['mofem-cephas'].prefix.users_module,
             '-DWITH_SPACK=YES',
-            self.define_from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules')])
+            from_variant('STAND_ALLONE_USERS_MODULES', 'copy_user_modules')])
 
         # build tests
         options.append(self.define('MOFEM_UM_BUILD_TESTS', self.run_tests))

--- a/var/spack/repos/builtin/packages/mpilander/package.py
+++ b/var/spack/repos/builtin/packages/mpilander/package.py
@@ -37,10 +37,8 @@ class Mpilander(CMakePackage):
     def cmake_args(self):
         args = [
             # tests and examples
-            '-DBUILD_TESTING:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF'),
-            '-DBUILD_EXAMPLES:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF'),
+            self.define('BUILD_TESTING', self.run_tests),
+            self.define('BUILD_EXAMPLES', self.run_tests),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/msgpack-c/package.py
+++ b/var/spack/repos/builtin/packages/msgpack-c/package.py
@@ -22,7 +22,6 @@ class MsgpackC(CMakePackage):
         args = [
             "-DCMAKE_CXX_FLAGS=-Wno-implicit-fallthrough",
             "-DCMAKE_C_FLAGS=-Wno-implicit-fallthrough",
-            '-DMSGPACK_BUILD_TESTS:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF')
+            self.define('MSGPACK_BUILD_TESTS', self.run_tests)
         ]
         return args

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -53,8 +53,7 @@ class Nalu(CMakePackage):
             '-DMPI_C_COMPILER=%s' % spec['mpi'].mpicc,
             '-DMPI_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
             '-DMPI_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
-            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
-                'ON' if '+pic' in spec else 'OFF'),
+            self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'),
         ])
 
         if '+tioga' in spec:

--- a/var/spack/repos/builtin/packages/nnvm/package.py
+++ b/var/spack/repos/builtin/packages/nnvm/package.py
@@ -26,6 +26,6 @@ class Nnvm(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         return [
-            '-DUSE_SHARED_NNVM=%s' % ('ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('USE_SHARED_NNVM', 'shared'),
             '-DUSE_STATIC_NNVM=%s' % ('ON' if '~shared' in spec else 'OFF'),
         ]

--- a/var/spack/repos/builtin/packages/openfast/package.py
+++ b/var/spack/repos/builtin/packages/openfast/package.py
@@ -47,16 +47,11 @@ class Openfast(CMakePackage):
         options.extend([
             '-DBUILD_DOCUMENTATION:BOOL=OFF',
             '-DBUILD_TESTING:BOOL=OFF',
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
-            '-DDOUBLE_PRECISION:BOOL=%s' % (
-                'ON' if '+double-precision' in spec else 'OFF'),
-            '-DUSE_DLL_INTERFACE:BOOL=%s' % (
-                'ON' if '+dll-interface' in spec else 'OFF'),
-            '-DBUILD_OPENFAST_CPP_API:BOOL=%s' % (
-                'ON' if '+cxx' in spec else 'OFF'),
-            '-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=%s' % (
-                'ON' if '+pic' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('DOUBLE_PRECISION', 'double-precision'),
+            self.define_from_variant('USE_DLL_INTERFACE', 'dll-interface'),
+            self.define_from_variant('BUILD_OPENFAST_CPP_API', 'cxx'),
+            self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'),
         ])
 
         # Make sure we use Spack's blas/lapack:

--- a/var/spack/repos/builtin/packages/opennurbs/package.py
+++ b/var/spack/repos/builtin/packages/opennurbs/package.py
@@ -25,8 +25,7 @@ class Opennurbs(Package):
     # CMake installation method
     def install(self, spec, prefix):
         cmake_args = [
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF')
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')
         ]
 
         cmake_args.extend(std_cmake_args)

--- a/var/spack/repos/builtin/packages/pagmo/package.py
+++ b/var/spack/repos/builtin/packages/pagmo/package.py
@@ -74,18 +74,18 @@ class Pagmo(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DBUILD_EXAMPLES={0}'.format(self.variant_to_bool('+examples')),
-            '-DBUILD_MAIN={0}'.format(self.variant_to_bool('+cxx')),
-            '-DBUILD_PYGMO={0}'.format(self.variant_to_bool('+python')),
-            '-DENABLE_GSL={0}'.format(self.variant_to_bool('+gsl')),
-            '-DENABLE_GTOP_DATABASE={0}'.format(self.variant_to_bool('+gtop')),
-            '-DENABLE_IPOPT={0}'.format(self.variant_to_bool('+ipopt')),
-            '-DENABLE_MPI={0}'.format(self.variant_to_bool('+mpi')),
-            '-DENABLE_NLOPT={0}'.format(self.variant_to_bool('+nlopt')),
-            '-DENABLE_SNOPT={0}'.format(self.variant_to_bool('+snopt')),
-            '-DENABLE_WORHP={0}'.format(self.variant_to_bool('+worhp')),
-            '-DINSTALL_HEADERS={0}'.format(self.variant_to_bool('+headers')),
-            '-DENABLE_TESTS={0}'.format('ON' if self.run_tests else 'OFF'),
+            self.define_from_variant('BUILD_EXAMPLES', 'examples'),
+            self.define_from_variant('BUILD_MAIN', 'cxx'),
+            self.define_from_variant('BUILD_PYGMO', 'python'),
+            self.define_from_variant('ENABLE_GSL', 'gsl'),
+            self.define_from_variant('ENABLE_GTOP_DATABASE', 'gtop'),
+            self.define_from_variant('ENABLE_IPOPT', 'ipopt'),
+            self.define_from_variant('ENABLE_MPI', 'mpi'),
+            self.define_from_variant('ENABLE_NLOPT', 'nlopt'),
+            self.define_from_variant('ENABLE_SNOPT', 'snopt'),
+            self.define_from_variant('ENABLE_WORHP', 'worhp'),
+            self.define_from_variant('INSTALL_HEADERS', 'headers'),
+            self.define('ENABLE_TESTS', self.run_tests),
         ]
 
         if '+python' in spec:

--- a/var/spack/repos/builtin/packages/paradiseo/package.py
+++ b/var/spack/repos/builtin/packages/paradiseo/package.py
@@ -53,8 +53,6 @@ class Paradiseo(CMakePackage):
     patch('fix_tutorials.patch')
 
     def cmake_args(self):
-        spec = self.spec
-
         return [
             '-DINSTALL_TYPE:STRING=MIN',
             self.define_from_variant('MPI', 'mpi'),

--- a/var/spack/repos/builtin/packages/paradiseo/package.py
+++ b/var/spack/repos/builtin/packages/paradiseo/package.py
@@ -57,14 +57,11 @@ class Paradiseo(CMakePackage):
 
         return [
             '-DINSTALL_TYPE:STRING=MIN',
-            '-DMPI:BOOL=%s' % ('TRUE' if '+mpi' in spec else 'FALSE'),
+            self.define_from_variant('MPI', 'mpi'),
             # Note: This requires a C++11 compatible compiler
-            '-DSMP:BOOL=%s' % ('TRUE' if '+smp' in spec else 'FALSE'),
-            '-DEDO:BOOL=%s' % ('TRUE' if '+edo' in spec else 'FALSE'),
-            '-DENABLE_CMAKE_TESTING:BOOL=%s' % (
-                'TRUE' if self.run_tests else 'FALSE'),
-            '-DENABLE_OPENMP:BOOL=%s' % (
-                'TRUE' if '+openmp' in spec else 'FALSE'),
-            '-DENABLE_GNUPLOT:BOOL=%s' % (
-                'TRUE' if '+gnuplot' in spec else 'FALSE')
+            self.define_from_variant('SMP', 'smp'),
+            self.define_from_variant('EDO', 'edo'),
+            self.define('ENABLE_CMAKE_TESTING', self.run_tests),
+            self.define_from_variant('ENABLE_OPENMP', 'openmp'),
+            self.define_from_variant('ENABLE_GNUPLOT', 'gnuplot')
         ]

--- a/var/spack/repos/builtin/packages/perfstubs/package.py
+++ b/var/spack/repos/builtin/packages/perfstubs/package.py
@@ -25,8 +25,6 @@ class Perfstubs(CMakePackage):
     variant('static', default=False, description='Build static executable support')
 
     def cmake_args(self):
-        spec = self.spec
-
         args = [
             self.define_from_variant('PERFSTUBS_USE_STATIC', 'static')
         ]

--- a/var/spack/repos/builtin/packages/perfstubs/package.py
+++ b/var/spack/repos/builtin/packages/perfstubs/package.py
@@ -28,7 +28,6 @@ class Perfstubs(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DPERFSTUBS_USE_STATIC:BOOL={0}'.format(
-                'ON' if '+static' in spec else 'OFF')
+            self.define_from_variant('PERFSTUBS_USE_STATIC', 'static')
         ]
         return args

--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -72,16 +72,16 @@ class Pfunit(CMakePackage):
         spec = self.spec
         args = [
             '-DPYTHON_EXECUTABLE=%s' % spec['python'].command,
-            '-DBUILD_SHARED=%s' % ('YES' if '+shared' in spec else 'NO'),
+            self.define_from_variant('BUILD_SHARED', 'shared'),
             '-DCMAKE_Fortran_MODULE_DIRECTORY=%s' % spec.prefix.include,
-            '-DBUILD_DOCS=%s' % ('YES' if '+docs' in spec else 'NO'),
-            '-DOPENMP=%s' % ('YES' if '+openmp' in spec else 'NO'),
+            self.define_from_variant('BUILD_DOCS', 'docs'),
+            self.define_from_variant('OPENMP', 'openmp'),
             '-DMAX_RANK=%s' % spec.variants['max_array_rank'].value]
 
         if spec.satisfies('@4.0.0:'):
             args.append('-DSKIP_MPI=%s' % ('YES' if '~mpi' in spec else 'NO'))
         else:
-            args.append('-DMPI=%s' % ('YES' if '+mpi' in spec else 'NO'))
+            args.append(self.define_from_variant('MPI', 'mpi'))
 
         if spec.satisfies('+mpi'):
             args.extend(['-DMPI_USE_MPIEXEC=YES',

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -154,26 +154,20 @@ class Phist(CMakePackage):
                 '-DPHIST_OUTLEV=%s' % outlev,
                 '-DTPL_LAPACKE_LIBRARIES=%s' % lapacke_libs,
                 '-DTPL_LAPACKE_INCLUDE_DIRS=%s' % lapacke_include_dir,
-                '-DPHIST_ENABLE_MPI:BOOL=%s'
-                % ('ON' if '+mpi' in spec else 'OFF'),
-                '-DPHIST_ENABLE_OPENMP=%s'
-                % ('ON' if '+openmp' in spec else 'OFF'),
-                '-DBUILD_SHARED_LIBS:BOOL=%s'
-                % ('ON' if '+shared' in spec else 'OFF'),
-                '-DPHIST_ENABLE_SCAMAC:BOOL=%s'
-                % ('ON' if '+scamac' in spec else 'OFF'),
+                self.define_from_variant('PHIST_ENABLE_MPI', 'mpi'),
+                self.define_from_variant('PHIST_ENABLE_OPENMP', 'openmp'),
+                self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+                self.define_from_variant('PHIST_ENABLE_SCAMAC', 'scamac'),
                 '-DPHIST_USE_TRILINOS_TPLS:BOOL=%s'
                 % ('ON' if '^trilinos' in spec else 'OFF'),
                 '-DPHIST_USE_SOLVER_TPLS:BOOL=%s'
                 % ('ON' if '^trilinos+belos+anasazi' in spec else 'OFF'),
                 '-DPHIST_USE_PRECON_TPLS:BOOL=%s'
                 % ('ON' if '^trilinos' in spec else 'OFF'),
-                '-DXSDK_ENABLE_Fortran:BOOL=%s'
-                % ('ON' if '+fortran' in spec else 'OFF'),
+                self.define_from_variant('XSDK_ENABLE_Fortran', 'fortran'),
                 '-DXSDK_INDEX_SIZE=%s'
                 % ('64' if '+int64' in spec else '32'),
-                '-DPHIST_HOST_OPTIMIZE:BOOL=%s'
-                % ('ON' if '+host' in spec else 'OFF'),
+                self.define_from_variant('PHIST_HOST_OPTIMIZE', 'host'),
                 ]
 
         return args

--- a/var/spack/repos/builtin/packages/piranha/package.py
+++ b/var/spack/repos/builtin/packages/piranha/package.py
@@ -37,6 +37,6 @@ class Piranha(CMakePackage):
 
     def cmake_args(self):
         return [
-            '-DBUILD_PYRANHA=%s' % ('ON' if '+python' in self.spec else 'OFF'),
+            self.define_from_variant('BUILD_PYRANHA', 'python'),
             '-DBUILD_TESTS:BOOL=ON',
         ]

--- a/var/spack/repos/builtin/packages/pism/package.py
+++ b/var/spack/repos/builtin/packages/pism/package.py
@@ -93,28 +93,17 @@ class Pism(CMakePackage):
             '-DCMAKE_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
             # Fortran not needed for PISM...
             # '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
-            '-DPism_BUILD_EXTRA_EXECS=%s' %
-            ('YES' if '+extra' in spec else 'NO'),
-            '-DBUILD_SHARED_LIBS=%s' %
-            ('YES' if '+shared' in spec else 'NO'),
-            '-DPism_BUILD_PYTHON_BINDINGS=%s' %
-            ('YES' if '+python' in spec else 'NO'),
-            '-DPism_BUILD_ICEBIN=%s' %
-            ('YES' if '+icebin' in spec else 'NO'),
-            '-DPism_USE_PROJ4=%s' %
-            ('YES' if '+proj' in spec else 'NO'),
-            '-DPism_USE_PARALLEL_NETCDF4=%s' %
-            ('YES' if '+parallel-netcdf4' in spec else 'NO'),
-            '-DPism_USE_PNETCDF=%s' %
-            ('YES' if '+parallel-netcdf3' in spec else 'NO'),
-            '-DPism_USE_PARALLEL_HDF5=%s' %
-            ('YES' if '+parallel-hdf5' in spec else 'NO'),
-            '-DPism_BUILD_PDFS=%s' %
-            ('YES' if '+doc' in spec else 'NO'),
-            '-DPism_INSTALL_EXAMPLES=%s' %
-            ('YES' if '+examples' in spec else 'NO'),
-            '-DPism_USE_EVERYTRACE=%s' %
-            ('YES' if '+everytrace' in spec else 'NO')]
+            self.define_from_variant('Pism_BUILD_EXTRA_EXECS', 'extra'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('Pism_BUILD_PYTHON_BINDINGS', 'python'),
+            self.define_from_variant('Pism_BUILD_ICEBIN', 'icebin'),
+            self.define_from_variant('Pism_USE_PROJ4', 'proj'),
+            self.define_from_variant('Pism_USE_PARALLEL_NETCDF4', 'parallel-netcdf4'),
+            self.define_from_variant('Pism_USE_PNETCDF', 'parallel-netcdf3'),
+            self.define_from_variant('Pism_USE_PARALLEL_HDF5', 'parallel-hdf5'),
+            self.define_from_variant('Pism_BUILD_PDFS', 'doc'),
+            self.define_from_variant('Pism_INSTALL_EXAMPLES', 'examples'),
+            self.define_from_variant('Pism_USE_EVERYTRACE', 'everytrace')]
 
     def setup_run_environment(self, env):
         env.set('PISM_PREFIX', self.prefix)

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -67,13 +67,12 @@ class Pumi(CMakePackage):
 
         args = [
             '-DSCOREC_CXX_WARNINGS=OFF',
-            '-DENABLE_ZOLTAN=%s' % ('ON' if '+zoltan' in spec else 'OFF'),
+            self.define_from_variant('ENABLE_ZOLTAN', 'zoltan'),
             '-DCMAKE_C_COMPILER=%s' % spec['mpi'].mpicc,
             '-DCMAKE_CXX_COMPILER=%s' % spec['mpi'].mpicxx,
-            '-DBUILD_SHARED_LIBS=%s' % ('ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc,
-            '-DPUMI_FORTRAN_INTERFACE=%s' %
-            ('ON' if '+fortran' in spec else 'OFF'),
+            self.define_from_variant('PUMI_FORTRAN_INTERFACE', 'fortran'),
             '-DMDS_ID_TYPE=%s' % ('long' if '+int64' in spec else 'int'),
             '-DSKIP_SIMMETRIX_VERSION_CHECK=%s' %
             ('ON' if '~simmodsuite_version_check' in spec else 'OFF'),

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -51,8 +51,7 @@ class PyPybind11(CMakePackage):
         args.append('-DPYTHON_EXECUTABLE:FILEPATH=%s'
                     % self.spec['python'].command.path)
         args += [
-            '-DPYBIND11_TEST:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF')
+            self.define('PYBIND11_TEST', self.run_tests)
         ]
         return args
 

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -191,8 +191,7 @@ class Qgis(CMakePackage):
                 'TRUE' if '+gui' in spec else 'FALSE'),
             '-DWITH_INTERNAL_MDAL={0}'.format(
                 'TRUE' if '+internal_mdal' in spec else 'FALSE'),
-            '-DWITH_INTERNAL_O2={0}'.format(
-                'ON' if '+internal_o2' in spec else 'OFF'),
+            self.define_from_variant('WITH_INTERNAL_O2', 'internal_o2'),
             '-DWITH_OAUTH2_PLUGIN={0}'.format(
                 'TRUE' if '+oauth2_plugin' in spec else 'FALSE'),
             '-DWITH_ORACLE={0}'.format(
@@ -203,14 +202,12 @@ class Qgis(CMakePackage):
                 'TRUE' if '+py_compile' in spec else 'FALSE'),
             '-DWITH_QSCIAPI={0}'.format(
                 'TRUE' if '+qsciapi' in spec else 'FALSE'),
-            '-DWITH_QSPATIALITE={0}'.format(
-                'ON' if '+qspatialite' in spec else 'OFF'),
+            self.define_from_variant('WITH_QSPATIALITE', 'qspatialite'),
             '-DWITH_QT5SERIALPORT={0}'.format(
                 'TRUE' if '+qt5serialport' in spec else 'FALSE'),
             '-DWITH_QTMOBILITY={0}'.format(
                 'TRUE' if '+qtmobility' in spec else 'FALSE'),
-            '-DWITH_QTWEBKIT={0}'.format(
-                'ON' if '+qtwebkit' in spec else 'OFF'),
+            self.define_from_variant('WITH_QTWEBKIT', 'qtwebkit'),
             '-DWITH_QUICK={0}'.format(
                 'TRUE' if '+quick' in spec else 'FALSE'),
             '-DWITH_QWTPOLAR={0}'.format(

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -58,8 +58,7 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
 
         options.append('-DBLT_SOURCE_DIR={0}'.format(spec['blt'].prefix))
 
-        options.append('-DENABLE_OPENMP={0}'.format(
-            'ON' if '+openmp' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_OPENMP', 'openmp'))
 
         if '+cuda' in spec:
             options.extend([
@@ -85,14 +84,11 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
         else:
             options.append('-DENABLE_HIP=OFF')
 
-        options.append('-DBUILD_SHARED_LIBS={0}'.format(
-            'ON' if '+shared' in spec else 'OFF'))
+        options.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
 
-        options.append('-DENABLE_EXAMPLES={0}'.format(
-            'ON' if '+examples' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_EXAMPLES', 'examples'))
 
-        options.append('-DENABLE_EXERCISES={0}'.format(
-            'ON' if '+exercises' in spec else 'OFF'))
+        options.append(self.define_from_variant('ENABLE_EXERCISES', 'exercises'))
 
         # Work around spack adding -march=ppc64le to SPACK_TARGET_ARGS which
         # is used by the spack compiler wrapper.  This can go away when BLT
@@ -100,8 +96,7 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
         if self.spec.satisfies('%clang target=ppc64le:') or not self.run_tests:
             options.append('-DENABLE_TESTS=OFF')
         else:
-            options.append('-DENABLE_TESTS={0}'.format(
-                'ON' if '+tests' in spec else 'OFF'))
+            options.append(self.define_from_variant('ENABLE_TESTS', 'tests'))
 
         return options
 

--- a/var/spack/repos/builtin/packages/rmlab/package.py
+++ b/var/spack/repos/builtin/packages/rmlab/package.py
@@ -32,7 +32,6 @@ class Rmlab(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DRmlab_USE_PNG={0}'.format(
-                'ON' if '+png' in spec else 'OFF')
+            self.define_from_variant('Rmlab_USE_PNG', 'png')
         ]
         return args

--- a/var/spack/repos/builtin/packages/rmlab/package.py
+++ b/var/spack/repos/builtin/packages/rmlab/package.py
@@ -29,8 +29,6 @@ class Rmlab(CMakePackage):
     depends_on('pngwriter@0.6.0:', when='+png')
 
     def cmake_args(self):
-        spec = self.spec
-
         args = [
             self.define_from_variant('Rmlab_USE_PNG', 'png')
         ]

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -99,6 +99,7 @@ class Seacas(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
+        from_variant = self.define_from_variant
 
         options = []
 
@@ -116,14 +117,14 @@ class Seacas(CMakePackage):
         options.extend([
             '-DSEACASProj_ENABLE_TESTS:BOOL=ON',
             '-DSEACASProj_ENABLE_CXX11:BOOL=ON',
-            self.define_from_variant('CMAKE_INSTALL_RPATH_USE_LINK_PATH', 'shared'),
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            from_variant('CMAKE_INSTALL_RPATH_USE_LINK_PATH', 'shared'),
+            from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DSEACASProj_ENABLE_Kokkos:BOOL=OFF',
             '-DSEACASProj_HIDE_DEPRECATED_CODE:BOOL=OFF',
-            self.define_from_variant('SEACASExodus_ENABLE_THREADSAFE', 'thread_safe'),
-            self.define_from_variant('SEACASIoss_ENABLE_THREADSAFE', 'thread_safe'),
-            self.define_from_variant('SEACASProj_ENABLE_Fortran', 'fortran'),
-            self.define_from_variant('TPL_ENABLE_X11', 'x11'),
+            from_variant('SEACASExodus_ENABLE_THREADSAFE', 'thread_safe'),
+            from_variant('SEACASIoss_ENABLE_THREADSAFE', 'thread_safe'),
+            from_variant('SEACASProj_ENABLE_Fortran', 'fortran'),
+            from_variant('TPL_ENABLE_X11', 'x11'),
         ])
 
         # ########## What applications should be built #############
@@ -142,8 +143,8 @@ class Seacas(CMakePackage):
                 '-DSEACASProj_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF',
                 '-DSEACASProj_ENABLE_SEACASIoss:BOOL=ON',
                 '-DSEACASProj_ENABLE_SEACASExodus:BOOL=ON',
-                self.define_from_variant('SEACASProj_ENABLE_SEACASExodus_for', 'fortran'),
-                self.define_from_variant('SEACASProj_ENABLE_SEACASExoIIv2for32', 'fortran'),
+                from_variant('SEACASProj_ENABLE_SEACASExodus_for', 'fortran'),
+                from_variant('SEACASProj_ENABLE_SEACASExoIIv2for32', 'fortran'),
             ])
 
             if '+applications' in spec:
@@ -156,8 +157,8 @@ class Seacas(CMakePackage):
                     '-DSEACASProj_ENABLE_SEACASExo2mat:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASExo_format:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASExodiff:BOOL=ON',
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASExplore', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASGrepos', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASExplore', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASGrepos', 'fortran'),
                     '-DSEACASProj_ENABLE_SEACASMat2exo:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASNas2exo:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASNemslice:BOOL=ON',
@@ -167,23 +168,23 @@ class Seacas(CMakePackage):
 
             if '+legacy' in spec:
                 options.extend([
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASAlgebra', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASBlot', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASEx1ex2v2', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASEx2ex1v2', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASExomatlab', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASExotec2', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASExotxt', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASFastq', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASGen3D', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASGenshell', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASGjoin', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASMapvar', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASAlgebra', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASBlot', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASEx1ex2v2', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASEx2ex1v2', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASExomatlab', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASExotec2', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASExotxt', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASFastq', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASGen3D', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASGenshell', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASGjoin', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASMapvar', 'fortran'),
                     '-DSEACASProj_ENABLE_SEACASMapvar-kd:BOOL=%s' % (
                         'ON' if '+fortran' in spec else 'OFF'),
                     '-DSEACASProj_ENABLE_SEACASNemesis:BOOL=ON',
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASNumbers', 'fortran'),
-                    self.define_from_variant('SEACASProj_ENABLE_SEACASTxtexo', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASNumbers', 'fortran'),
+                    from_variant('SEACASProj_ENABLE_SEACASTxtexo', 'fortran'),
                 ])
 
         # ##################### Dependencies ##########################

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -116,20 +116,14 @@ class Seacas(CMakePackage):
         options.extend([
             '-DSEACASProj_ENABLE_TESTS:BOOL=ON',
             '-DSEACASProj_ENABLE_CXX11:BOOL=ON',
-            '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('CMAKE_INSTALL_RPATH_USE_LINK_PATH', 'shared'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DSEACASProj_ENABLE_Kokkos:BOOL=OFF',
             '-DSEACASProj_HIDE_DEPRECATED_CODE:BOOL=OFF',
-            '-DSEACASExodus_ENABLE_THREADSAFE:BOOL=%s' % (
-                'ON' if '+thread_safe' in spec else 'OFF'),
-            '-DSEACASIoss_ENABLE_THREADSAFE:BOOL=%s' % (
-                'ON' if '+thread_safe' in spec else 'OFF'),
-            '-DSEACASProj_ENABLE_Fortran:BOOL=%s' % (
-                'ON' if '+fortran' in spec else 'OFF'),
-            '-DTPL_ENABLE_X11:BOOL=%s' % (
-                'ON' if '+x11' in spec else 'OFF'),
+            self.define_from_variant('SEACASExodus_ENABLE_THREADSAFE', 'thread_safe'),
+            self.define_from_variant('SEACASIoss_ENABLE_THREADSAFE', 'thread_safe'),
+            self.define_from_variant('SEACASProj_ENABLE_Fortran', 'fortran'),
+            self.define_from_variant('TPL_ENABLE_X11', 'x11'),
         ])
 
         # ########## What applications should be built #############
@@ -148,10 +142,8 @@ class Seacas(CMakePackage):
                 '-DSEACASProj_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF',
                 '-DSEACASProj_ENABLE_SEACASIoss:BOOL=ON',
                 '-DSEACASProj_ENABLE_SEACASExodus:BOOL=ON',
-                '-DSEACASProj_ENABLE_SEACASExodus_for:BOOL=%s' % (
-                    'ON' if '+fortran' in spec else 'OFF'),
-                '-DSEACASProj_ENABLE_SEACASExoIIv2for32:BOOL=%s' % (
-                    'ON' if '+fortran' in spec else 'OFF'),
+                self.define_from_variant('SEACASProj_ENABLE_SEACASExodus_for', 'fortran'),
+                self.define_from_variant('SEACASProj_ENABLE_SEACASExoIIv2for32', 'fortran'),
             ])
 
             if '+applications' in spec:
@@ -164,10 +156,8 @@ class Seacas(CMakePackage):
                     '-DSEACASProj_ENABLE_SEACASExo2mat:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASExo_format:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASExodiff:BOOL=ON',
-                    '-DSEACASProj_ENABLE_SEACASExplore:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASGrepos:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASExplore', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASGrepos', 'fortran'),
                     '-DSEACASProj_ENABLE_SEACASMat2exo:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASNas2exo:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASNemslice:BOOL=ON',
@@ -177,37 +167,23 @@ class Seacas(CMakePackage):
 
             if '+legacy' in spec:
                 options.extend([
-                    '-DSEACASProj_ENABLE_SEACASAlgebra:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASBlot:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASEx1ex2v2:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASEx2ex1v2:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASExomatlab:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASExotec2:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASExotxt:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASFastq:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASGen3D:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASGenshell:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASGjoin:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASMapvar:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASAlgebra', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASBlot', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASEx1ex2v2', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASEx2ex1v2', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASExomatlab', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASExotec2', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASExotxt', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASFastq', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASGen3D', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASGenshell', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASGjoin', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASMapvar', 'fortran'),
                     '-DSEACASProj_ENABLE_SEACASMapvar-kd:BOOL=%s' % (
                         'ON' if '+fortran' in spec else 'OFF'),
                     '-DSEACASProj_ENABLE_SEACASNemesis:BOOL=ON',
-                    '-DSEACASProj_ENABLE_SEACASNumbers:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
-                    '-DSEACASProj_ENABLE_SEACASTxtexo:BOOL=%s' % (
-                        'ON' if '+fortran' in spec else 'OFF'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASNumbers', 'fortran'),
+                    self.define_from_variant('SEACASProj_ENABLE_SEACASTxtexo', 'fortran'),
                 ])
 
         # ##################### Dependencies ##########################

--- a/var/spack/repos/builtin/packages/snappy/package.py
+++ b/var/spack/repos/builtin/packages/snappy/package.py
@@ -23,16 +23,11 @@ class Snappy(CMakePackage):
     patch('link_gtest.patch')
 
     def cmake_args(self):
-        spec = self.spec
-
-        args = [
-            '-DCMAKE_INSTALL_LIBDIR:PATH={0}'.format(
-                self.prefix.lib),
+        return [
+            self.define('CMAKE_INSTALL_LIBDIR', self.prefix.lib),
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
-            self.define('SNAPPY_BUILD_TESTS', self.run_tests)
+            self.define('SNAPPY_BUILD_TESTS', self.run_tests),
         ]
-
-        return args
 
     def flag_handler(self, name, flags):
         flags = list(flags)

--- a/var/spack/repos/builtin/packages/snappy/package.py
+++ b/var/spack/repos/builtin/packages/snappy/package.py
@@ -28,10 +28,8 @@ class Snappy(CMakePackage):
         args = [
             '-DCMAKE_INSTALL_LIBDIR:PATH={0}'.format(
                 self.prefix.lib),
-            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in spec else 'OFF'),
-            '-DSNAPPY_BUILD_TESTS:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF')
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define('SNAPPY_BUILD_TESTS', self.run_tests)
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -48,13 +48,10 @@ class Spdlog(CMakePackage):
 
         if self.spec.version >= Version('1.4.0'):
             args.extend([
-                '-DSPDLOG_BUILD_SHARED:BOOL={0}'.format(
-                    'ON' if '+shared' in spec else 'OFF'),
+                self.define_from_variant('SPDLOG_BUILD_SHARED', 'shared'),
                 # tests and examples
-                '-DSPDLOG_BUILD_TESTS:BOOL={0}'.format(
-                    'ON' if self.run_tests else 'OFF'),
-                '-DSPDLOG_BUILD_EXAMPLE:BOOL={0}'.format(
-                    'ON' if self.run_tests else 'OFF')
+                self.define('SPDLOG_BUILD_TESTS', self.run_tests),
+                self.define('SPDLOG_BUILD_EXAMPLE', self.run_tests)
             ])
 
         return args

--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -42,8 +42,6 @@ class Spdlog(CMakePackage):
     depends_on('cmake@3.2:', type='build')
 
     def cmake_args(self):
-        spec = self.spec
-
         args = []
 
         if self.spec.version >= Version('1.4.0'):

--- a/var/spack/repos/builtin/packages/strumpack/package.py
+++ b/var/spack/repos/builtin/packages/strumpack/package.py
@@ -97,24 +97,21 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
     def cmake_args(self):
         spec = self.spec
 
-        def on_off(varstr):
-            return 'ON' if varstr in spec else 'OFF'
-
         args = [
-            '-DSTRUMPACK_USE_MPI=%s' % on_off('+mpi'),
-            '-DSTRUMPACK_USE_OPENMP=%s' % on_off('+openmp'),
-            '-DSTRUMPACK_USE_CUDA=%s' % on_off('+cuda'),
-            '-DSTRUMPACK_USE_HIP=%s' % on_off('+rocm'),
-            '-DTPL_ENABLE_PARMETIS=%s' % on_off('+parmetis'),
-            '-DTPL_ENABLE_SCOTCH=%s' % on_off('+scotch'),
-            '-DTPL_ENABLE_BPACK=%s' % on_off('+butterflypack'),
-            '-DSTRUMPACK_COUNT_FLOPS=%s' % on_off('+count_flops'),
-            '-DSTRUMPACK_TASK_TIMERS=%s' % on_off('+task_timers'),
-            '-DSTRUMPACK_DEV_TESTING=%s' % on_off('+build_dev_tests'),
-            '-DSTRUMPACK_BUILD_TESTS=%s' % on_off('+build_tests'),
+            self.define_from_variant('STRUMPACK_USE_MPI', 'mpi'),
+            self.define_from_variant('STRUMPACK_USE_OPENMP', 'openmp'),
+            self.define_from_variant('STRUMPACK_USE_CUDA', 'cuda'),
+            self.define_from_variant('STRUMPACK_USE_HIP', 'rocm'),
+            self.define_from_variant('TPL_ENABLE_PARMETIS', 'parmetis'),
+            self.define_from_variant('TPL_ENABLE_SCOTCH', 'scotch'),
+            self.define_from_variant('TPL_ENABLE_BPACK', 'butterflypack'),
+            self.define_from_variant('STRUMPACK_COUNT_FLOPS', 'count_flops'),
+            self.define_from_variant('STRUMPACK_TASK_TIMERS', 'task_timers'),
+            self.define_from_variant('STRUMPACK_DEV_TESTING', 'build_dev_tests'),
+            self.define_from_variant('STRUMPACK_BUILD_TESTS', 'build_tests'),
             '-DTPL_BLAS_LIBRARIES=%s' % spec['blas'].libs.joined(";"),
             '-DTPL_LAPACK_LIBRARIES=%s' % spec['lapack'].libs.joined(";"),
-            '-DBUILD_SHARED_LIBS=%s' % on_off('+shared')
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')
         ]
 
         if '+mpi' in spec:
@@ -130,7 +127,7 @@ class Strumpack(CMakePackage, CudaPackage, ROCmPackage):
                     '-DCMAKE_Fortran_COMPILER=%s' % spec['mpi'].mpifc
                 ])
             args.extend([
-                '-DSTRUMPACK_C_INTERFACE=%s' % on_off('+c_interface'),
+                self.define_from_variant('STRUMPACK_C_INTERFACE', 'c_interface'),
             ])
 
         if '+cuda' in spec:

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -226,7 +226,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
         # SUNDIALS solvers
         for pkg in self.sun_solvers:
-            args.extend(['-DBUILD_%s=%s' % (pkg, on_off('+' + pkg))])
+            args.append(self.define_from_variant('BUILD_' + pkg, pkg))
 
         # precision
         args.extend([
@@ -243,13 +243,13 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
                 args.extend(['-DSUNDIALS_INDEX_TYPE=int32_t'])
 
         # Fortran interface
-        args.extend(['-DF77_INTERFACE_ENABLE=%s' % on_off('+fcmix')])
-        args.extend(['-DF2003_INTERFACE_ENABLE=%s' % on_off('+f2003')])
+        args.extend([self.define_from_variant('F77_INTERFACE_ENABLE', 'fcmix')])
+        args.extend([self.define_from_variant('F2003_INTERFACE_ENABLE', 'f2003')])
 
         # library type
         args.extend([
-            '-DBUILD_SHARED_LIBS=%s' % on_off('+shared'),
-            '-DBUILD_STATIC_LIBS=%s' % on_off('+static')
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('BUILD_STATIC_LIBS', 'static')
         ])
 
         # generic (std-c) math libraries
@@ -259,14 +259,14 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
         # Monitoring
         args.extend([
-            '-DSUNDIALS_BUILD_WITH_MONITORING=%s' % on_off('+monitoring')
+            self.define_from_variant('SUNDIALS_BUILD_WITH_MONITORING', 'monitoring')
         ])
 
         # parallelism
         args.extend([
-            '-DMPI_ENABLE=%s'     % on_off('+mpi'),
-            '-DOPENMP_ENABLE=%s'  % on_off('+openmp'),
-            '-DPTHREAD_ENABLE=%s' % on_off('+pthread')
+            self.define_from_variant('MPI_ENABLE', 'mpi'),
+            self.define_from_variant('OPENMP_ENABLE', 'openmp'),
+            self.define_from_variant('PTHREAD_ENABLE', 'pthread')
         ])
 
         if '+cuda' in spec:
@@ -423,8 +423,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
         # Examples
         if spec.satisfies('@3.0.0:'):
             args.extend([
-                '-DEXAMPLES_ENABLE_C=%s'      % on_off('+examples'),
-                '-DEXAMPLES_ENABLE_CXX=%s'    % on_off('+examples'),
+                self.define_from_variant('EXAMPLES_ENABLE_C', 'examples'),
+                self.define_from_variant('EXAMPLES_ENABLE_CXX', 'examples'),
                 '-DEXAMPLES_ENABLE_CUDA=%s'   % on_off('+examples+cuda'),
                 '-DEXAMPLES_ENABLE_F77=%s'    % on_off('+examples+fcmix'),
                 '-DEXAMPLES_ENABLE_F90=%s'    % on_off('+examples+fcmix'),
@@ -432,8 +432,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
             ])
         else:
             args.extend([
-                '-DEXAMPLES_ENABLE=%s' % on_off('+examples'),
-                '-DCXX_ENABLE=%s'      % on_off('+examples'),
+                self.define_from_variant('EXAMPLES_ENABLE', 'examples'),
+                self.define_from_variant('CXX_ENABLE', 'examples'),
                 '-DF90_ENABLE=%s'      % on_off('+examples+fcmix')
             ])
 

--- a/var/spack/repos/builtin/packages/symengine/package.py
+++ b/var/spack/repos/builtin/packages/symengine/package.py
@@ -66,15 +66,11 @@ class Symengine(CMakePackage):
             '-DWITH_SYMENGINE_RCP:BOOL=ON',
             '-DWITH_SYMENGINE_THREAD_SAFE:BOOL=%s' % (
                 'ON' if ('+thread_safe' or '+openmp') in spec else 'OFF'),
-            '-DBUILD_TESTS:BOOL=%s' % (
-                'ON' if self.run_tests else 'OFF'),
+            self.define('BUILD_TESTS', self.run_tests),
             '-DBUILD_BENCHMARKS:BOOL=ON',
-            '-DWITH_LLVM:BOOL=%s' % (
-                'ON' if '+llvm' in spec else 'OFF'),
-            '-DWITH_OPENMP:BOOL=%s' % (
-                'ON' if '+openmp' in spec else 'OFF'),
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('WITH_LLVM', 'llvm'),
+            self.define_from_variant('WITH_OPENMP', 'openmp'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ])
 
         if sys.platform == 'darwin':
@@ -91,10 +87,8 @@ class Symengine(CMakePackage):
             ])
         else:
             options.extend([
-                '-DWITH_MPC:BOOL=%s' % (
-                    'ON' if '+mpc' in spec else 'OFF'),
-                '-DWITH_MPFR:BOOL=%s' % (
-                    'ON' if '+mpfr' in spec else 'OFF'),
+                self.define_from_variant('WITH_MPC', 'mpc'),
+                self.define_from_variant('WITH_MPFR', 'mpfr'),
             ])
             if '+flint' in spec:
                 options.extend([

--- a/var/spack/repos/builtin/packages/tasmanian/package.py
+++ b/var/spack/repos/builtin/packages/tasmanian/package.py
@@ -111,20 +111,13 @@ class Tasmanian(CMakePackage, CudaPackage, ROCmPackage):
         if '+xsdkflags' in spec and spec.satisfies('@:7.1'):
             args = [
                 '-DUSE_XSDK_DEFAULTS:BOOL=ON',
-                '-DXSDK_ENABLE_PYTHON:BOOL={0}'.format(
-                    'ON' if '+python' in spec else 'OFF'),
-                '-DTPL_ENABLE_MPI:BOOL={0}'.format(
-                    'ON' if '+mpi' in spec else 'OFF'),
-                '-DXSDK_ENABLE_OPENMP:BOOL={0}'.format(
-                    'ON' if '+openmp' in spec else 'OFF'),
-                '-DTPL_ENABLE_BLAS:BOOL={0}'.format(
-                    'ON' if '+blas' in spec else 'OFF'),
-                '-DXSDK_ENABLE_CUDA:BOOL={0}'.format(
-                    'ON' if '+cuda' in spec else 'OFF'),
-                '-DTPL_ENABLE_MAGMA:BOOL={0}'.format(
-                    'ON' if '+magma' in spec else 'OFF'),
-                '-DXSDK_ENABLE_FORTRAN:BOOL={0}'.format(
-                    'ON' if '+fortran' in spec else 'OFF'), ]
+                self.define_from_variant('XSDK_ENABLE_PYTHON', 'python'),
+                self.define_from_variant('TPL_ENABLE_MPI', 'mpi'),
+                self.define_from_variant('XSDK_ENABLE_OPENMP', 'openmp'),
+                self.define_from_variant('TPL_ENABLE_BLAS', 'blas'),
+                self.define_from_variant('XSDK_ENABLE_CUDA', 'cuda'),
+                self.define_from_variant('TPL_ENABLE_MAGMA', 'magma'),
+                self.define_from_variant('XSDK_ENABLE_FORTRAN', 'fortran'), ]
         else:
             args = [
                 self.define_from_variant('Tasmanian_ENABLE_OPENMP', 'openmp'),
@@ -150,7 +143,6 @@ class Tasmanian(CMakePackage, CudaPackage, ROCmPackage):
         # _CUBLAS and _CUDA were separate options prior to 6.0
         # skipping _CUBLAS leads to peformance regression
         if spec.satisfies('@:5.1'):
-            args.append('-DTasmanian_ENABLE_CUBLAS={0}'.format(
-                        'ON' if '+cuda' in spec else 'OFF'))
+            args.append(self.define_from_variant('Tasmanian_ENABLE_CUBLAS', 'cuda'))
 
         return args

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -26,6 +26,4 @@ class Tinyxml(CMakePackage):
              "CMakeLists.txt"), "CMakeLists.txt")
 
     def cmake_args(self):
-        spec = self.spec
-        return [
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]
+        return [self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]

--- a/var/spack/repos/builtin/packages/tinyxml/package.py
+++ b/var/spack/repos/builtin/packages/tinyxml/package.py
@@ -28,4 +28,4 @@ class Tinyxml(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         return [
-            '-DBUILD_SHARED_LIBS=%s' % ('YES' if '+shared' in spec else 'NO')]
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]

--- a/var/spack/repos/builtin/packages/umap/package.py
+++ b/var/spack/repos/builtin/packages/umap/package.py
@@ -30,7 +30,7 @@ class Umap(CMakePackage):
     def cmake_args(self):
         spec = self.spec
         args = [
-            "-DENABLE_LOGGING=%s" % ('On' if '+logging' in spec else 'Off'),
-            "-DENABLE_TESTS=%s"   % ('On' if '+tests' in spec else 'Off'),
+            self.define_from_variant('ENABLE_LOGGING', 'logging'),
+            self.define_from_variant('ENABLE_TESTS', 'tests'),
         ]
         return args

--- a/var/spack/repos/builtin/packages/umap/package.py
+++ b/var/spack/repos/builtin/packages/umap/package.py
@@ -28,7 +28,6 @@ class Umap(CMakePackage):
     variant('tests', default=False, description='Build test programs.')
 
     def cmake_args(self):
-        spec = self.spec
         args = [
             self.define_from_variant('ENABLE_LOGGING', 'logging'),
             self.define_from_variant('ENABLE_TESTS', 'tests'),

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -99,36 +99,25 @@ class Warpx(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DBUILD_SHARED_LIBS:BOOL={0}'.format(
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DCMAKE_INSTALL_LIBDIR=lib',
             # variants
-            '-DWarpX_APP:BOOL={0}'.format(
-                'ON' if '+app' in spec else 'OFF'),
-            '-DWarpX_ASCENT:BOOL={0}'.format(
-                'ON' if '+ascent' in spec else 'OFF'),
+            self.define_from_variant('WarpX_APP', 'app'),
+            self.define_from_variant('WarpX_ASCENT', 'ascent'),
             '-DWarpX_COMPUTE={0}'.format(
                 spec.variants['compute'].value.upper()),
             '-DWarpX_DIMS={0}'.format(
                 spec.variants['dims'].value.upper()),
-            '-DWarpX_EB:BOOL={0}'.format(
-                'ON' if '+eb' in spec else 'OFF'),
-            '-DWarpX_LIB:BOOL={0}'.format(
-                'ON' if '+lib' in spec else 'OFF'),
-            '-DWarpX_MPI:BOOL={0}'.format(
-                'ON' if '+mpi' in spec else 'OFF'),
-            '-DWarpX_MPI_THREAD_MULTIPLE:BOOL={0}'.format(
-                'ON' if '+mpithreadmultiple' in spec else 'OFF'),
-            '-DWarpX_OPENPMD:BOOL={0}'.format(
-                'ON' if '+openpmd' in spec else 'OFF'),
+            self.define_from_variant('WarpX_EB', 'eb'),
+            self.define_from_variant('WarpX_LIB', 'lib'),
+            self.define_from_variant('WarpX_MPI', 'mpi'),
+            self.define_from_variant('WarpX_MPI_THREAD_MULTIPLE', 'mpithreadmultiple'),
+            self.define_from_variant('WarpX_OPENPMD', 'openpmd'),
             '-DWarpX_PRECISION={0}'.format(
                 spec.variants['precision'].value.upper()),
-            '-DWarpX_PSATD:BOOL={0}'.format(
-                'ON' if '+psatd' in spec else 'OFF'),
-            '-DWarpX_QED:BOOL={0}'.format(
-                'ON' if '+qed' in spec else 'OFF'),
-            '-DWarpX_QED_TABLE_GEN:BOOL={0}'.format(
-                'ON' if '+qedtablegen' in spec else 'OFF'),
+            self.define_from_variant('WarpX_PSATD', 'psatd'),
+            self.define_from_variant('WarpX_QED', 'qed'),
+            self.define_from_variant('WarpX_QED_TABLE_GEN', 'qedtablegen'),
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/wt/package.py
+++ b/var/spack/repos/builtin/packages/wt/package.py
@@ -61,17 +61,11 @@ class Wt(CMakePackage):
             '-DENABLE_QT4:BOOL=OFF'
         ]
         cmake_args.extend([
-            '-DENABLE_SSL:BOOL={0}'.format((
-                'ON' if '+openssl' in spec else 'OFF')),
-            '-DENABLE_HARU:BOOL={0}'.format((
-                'ON' if '+libharu' in spec else 'OFF')),
-            '-DENABLE_PANGO:BOOL={0}'.format((
-                'ON' if '+pango' in spec else 'OFF')),
-            '-DENABLE_SQLITE:BOOL={0}'.format((
-                'ON' if '+sqlite' in spec else 'OFF')),
-            '-DENABLE_MYSQL:BOOL={0}'.format((
-                'ON' if '+mariadb' in spec else 'OFF')),
-            '-DENABLE_POSTGRES:BOOL={0}'.format((
-                'ON' if '+postgres' in spec else 'OFF'))
+            self.define('ENABLE_SSL', 'openssl'),
+            self.define('ENABLE_HARU', 'libharu'),
+            self.define('ENABLE_PANGO', 'pango'),
+            self.define('ENABLE_SQLITE', 'sqlite'),
+            self.define('ENABLE_MYSQL', 'mariadb'),
+            self.define('ENABLE_POSTGRES', 'postgres')
         ])
         return cmake_args

--- a/var/spack/repos/builtin/packages/wt/package.py
+++ b/var/spack/repos/builtin/packages/wt/package.py
@@ -61,11 +61,11 @@ class Wt(CMakePackage):
             '-DENABLE_QT4:BOOL=OFF'
         ]
         cmake_args.extend([
-            self.define('ENABLE_SSL', 'openssl'),
-            self.define('ENABLE_HARU', 'libharu'),
-            self.define('ENABLE_PANGO', 'pango'),
-            self.define('ENABLE_SQLITE', 'sqlite'),
-            self.define('ENABLE_MYSQL', 'mariadb'),
-            self.define('ENABLE_POSTGRES', 'postgres')
+            self.define_from_variant('ENABLE_SSL', 'openssl'),
+            self.define_from_variant('ENABLE_HARU', 'libharu'),
+            self.define_from_variant('ENABLE_PANGO', 'pango'),
+            self.define_from_variant('ENABLE_SQLITE', 'sqlite'),
+            self.define_from_variant('ENABLE_MYSQL', 'mariadb'),
+            self.define_from_variant('ENABLE_POSTGRES', 'postgresql')
         ])
         return cmake_args

--- a/var/spack/repos/builtin/packages/wt/package.py
+++ b/var/spack/repos/builtin/packages/wt/package.py
@@ -52,8 +52,6 @@ class Wt(CMakePackage):
     depends_on('zlib', when='+zlib')
 
     def cmake_args(self):
-        spec = self.spec
-
         cmake_args = [
             '-DBUILD_EXAMPLES:BOOL=OFF',
             '-DCONNECTOR_FCGI:BOOL=OFF',

--- a/var/spack/repos/builtin/packages/xeus/package.py
+++ b/var/spack/repos/builtin/packages/xeus/package.py
@@ -37,8 +37,7 @@ class Xeus(CMakePackage):
 
     def cmake_args(self):
         args = [
-            '-DBUILD_EXAMPLES:BOOL=%s' % (
-                'ON' if '+examples' in self.spec else 'OFF')
+            self.define_from_variant('BUILD_EXAMPLES', 'examples')
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/xsdktrilinos/package.py
+++ b/var/spack/repos/builtin/packages/xsdktrilinos/package.py
@@ -52,15 +52,12 @@ class Xsdktrilinos(CMakePackage):
             '-DxSDKTrilinos_ENABLE_TESTS:BOOL=ON',
             '-DxSDKTrilinos_ENABLE_EXAMPLES:BOOL=ON',
             '-DTrilinos_INSTALL_DIR=%s' % spec['trilinos'].prefix,
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % (
-                'ON' if '+shared' in spec else 'OFF'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             '-DTPL_ENABLE_MPI:BOOL=ON',
             '-DMPI_BASE_DIR:PATH=%s' % spec['mpi'].prefix,
             '-DxSDKTrilinos_ENABLE_CXX11:BOOL=ON',
-            '-DTPL_ENABLE_HYPRE:BOOL=%s' % (
-                'ON' if '+hypre' in spec else 'OFF'),
-            '-DTPL_ENABLE_PETSC:BOOL=%s' % (
-                'ON' if '+petsc' in spec else 'OFF'),
+            self.define_from_variant('TPL_ENABLE_HYPRE', 'hypre'),
+            self.define_from_variant('TPL_ENABLE_PETSC', 'petsc'),
             '-DCMAKE_INSTALL_NAME_DIR:PATH=%s/lib' % self.prefix
         ])
 

--- a/var/spack/repos/builtin/packages/xsimd/package.py
+++ b/var/spack/repos/builtin/packages/xsimd/package.py
@@ -32,8 +32,7 @@ class Xsimd(CMakePackage):
 
     def cmake_args(self):
         args = [
-            '-DBUILD_TESTS:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF')
+            self.define('BUILD_TESTS', self.run_tests)
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/xtensor/package.py
+++ b/var/spack/repos/builtin/packages/xtensor/package.py
@@ -50,12 +50,9 @@ class Xtensor(CMakePackage):
         spec = self.spec
 
         args = [
-            '-DBUILD_TESTS:BOOL={0}'.format(
-                'ON' if self.run_tests else 'OFF'),
-            '-DXTENSOR_USE_XSIMD:BOOL={0}'.format(
-                'ON' if '+xsimd' in spec else 'OFF'),
-            '-DXTENSOR_USE_TBB:BOOL={0}'.format(
-                'ON' if '+tbb' in spec else 'OFF')
+            self.define('BUILD_TESTS', self.run_tests),
+            self.define_from_variant('XTENSOR_USE_XSIMD', 'xsimd'),
+            self.define_from_variant('XTENSOR_USE_TBB', 'tbb')
         ]
 
         return args

--- a/var/spack/repos/builtin/packages/xtensor/package.py
+++ b/var/spack/repos/builtin/packages/xtensor/package.py
@@ -47,8 +47,6 @@ class Xtensor(CMakePackage):
     # untested: conflicts('%pgi@:14')
 
     def cmake_args(self):
-        spec = self.spec
-
         args = [
             self.define('BUILD_TESTS', self.run_tests),
             self.define_from_variant('XTENSOR_USE_XSIMD', 'xsimd'),


### PR DESCRIPTION
This is a find-replace job for a lot of different ways to express `self.define_from_variant('foo', 'bar')`. I'm not sure if the best approach to this is to do one huge merge request and try to ping all 83 packages that this touched... or to just have a couple people spot check and address potential issues as they crop up.

There's a possibility that this will cause some package recipes to fail by exposing previously hidden typos due to `'+nonexistent_variant' in spec` returning `False` rather than raising an error.