### PR TITLE
commands: some fixes for command help strings

### DIFF
--- a/lib/spack/spack/cmd/analyze.py
+++ b/lib/spack/spack/cmd/analyze.py
@@ -18,9 +18,9 @@ import spack.paths
 import spack.report
 
 
-description = "analyze installed packages"
-section = "extensions"
-level = "short"
+description = "run analyzers on installed packages"
+section = "analysis"
+level = "long"
 
 
 def setup_parser(subparser):

--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -11,7 +11,7 @@ import llnl.util.tty as tty
 import spack.cmd.modules.lmod
 import spack.cmd.modules.tcl
 
-description = "manipulate module files"
+description = "generate/manage module files"
 section = "user environment"
 level = "short"
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -24,10 +24,7 @@ else:
     from itertools import zip_longest  # novm
 
 
-description = (
-    "runs source code style checks on Spack. Requires flake8, mypy, black for "
-    + "their respective checks"
-)
+description = "runs source code style checks on spack"
 section = "developer"
 level = "long"
 


### PR DESCRIPTION
- [x] `analyze` isn't commonly used; move it to long help
      (`spack -H` vs `spack -h`). Give it its own section.

- [x] make it clear from `spack -h` that `spack module` can generate
      module files

- [x] shorten help for `spack style`