### PR TITLE
installation: make install output more useful

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -275,11 +275,11 @@ def _install_from_cache(pkg, cache_only, explicit, unsigned=False,
         pkg, explicit, unsigned=unsigned, full_hash_match=full_hash_match)
     pkg_id = package_id(pkg)
     if not installed_from_cache:
-        pre = 'No binary for {0} found'.format(pkg_id)
+        pre = 'No binary found'
         if cache_only:
-            tty.die('{0} when cache-only specified'.format(pre))
+            tty.die('{0}, but you asked for cache-only.'.format(pre))
 
-        tty.msg('{0}: installing from source'.format(pre))
+        tty.msg('{0}, installing from source'.format(pre))
         return False
 
     tty.debug('Successfully extracted {0} from binary cache'.format(pkg_id))

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -821,10 +821,15 @@ class BaseModuleFileWriter(object):
         # Print a warning in case I am accidentally overwriting
         # a module file that is already there (name clash)
         if not overwrite and os.path.exists(self.layout.filename):
-            message = 'Module file already exists : skipping creation\n'
-            message += 'file : {0.filename}\n'
-            message += 'spec : {0.spec}'
-            tty.warn(message.format(self.layout))
+            msg = "Module file exists; won't overwrite. Use `spack module` to refresh."
+            if not tty.is_debug():
+                tty.msg(msg)
+            else:
+                tty.debug(
+                    msg,
+                    'file : {0.filename}\n'.format(self.layout),
+                    'spec : {0.spec}'.format(self.layout)
+                )
             return
 
         # If we are here it means it's ok to write the module file

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1397,6 +1397,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             # Support for post-install hooks requires a stage.source_path
             fsys.mkdirp(self.stage.source_path)
 
+        tty.msg("Source code staged at: %s" % self.stage.path)
+
     def do_patch(self):
         """Applies patches if they haven't been applied already."""
         if not self.spec.concrete:

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1010,9 +1010,7 @@ def test_cache_install_full_hash_match(
     # Finally, make sure that if we insist on the full hash match, spack
     # installs from source.
     install_output = install('--require-full-hash-match', s.name, output=str)
-    expect_msg = 'No binary for {0} found: installing from source'.format(
-        package_id)
-
+    expect_msg = 'No binary found, installing from source'
     assert expect_msg in install_output
 
     uninstall('-y', s.name)


### PR DESCRIPTION
- [x] We used to print out where source code was staged. Bring this back.
- [x] Simplify message when binaries are not found (we don't need the name/hash)
- [x] Clean up warning when modules are not regenerated. Users are distracted by this; they think there is an issue. Make it a simple message with instructions to regenerate.

Before:

```
==> Installing zlib-1.2.11-f7owbzfu4zsr6yn7x7hljransoof6ach
==> No binary for zlib-1.2.11-f7owbzfu4zsr6yn7x7hljransoof6ach found: installing from source
==> Using cached archive: /Users/gamblin2/Workspace/spack/var/spack/cache/_source-cache/archive/c3/c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1.tar.gz
==> No patches needed for zlib
==> zlib: Executing phase: 'install'
==> Warning: Module file already exists : skipping creation
file : /Users/gamblin2/Workspace/spack/share/spack/modules/darwin-catalina-skylake/zlib-1.2.11-apple-clang-12.0.0-f7owbzf
spec : zlib@1.2.11%apple-clang@12.0.0+optimize+pic+shared arch=darwin-catalina-skylake
==> zlib: Successfully installed zlib-1.2.11-f7owbzfu4zsr6yn7x7hljransoof6ach
  Fetch: 0.00s.  Build: 3.65s.  Total: 3.66s.
[+] /Users/gamblin2/Workspace/spack/opt/spack/darwin-catalina-skylake/apple-clang-12.0.0/zlib-1.2.11-f7owbzfu4zsr6yn7x7hljransoof6ach
```

After:

```
==> Installing zlib-1.2.11-f7owbzfu4zsr6yn7x7hljransoof6ach
==> No binary found, installing from source
==> Using cached archive: /Users/gamblin2/Workspace/spack/var/spack/cache/_source-cache/archive/c3/c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1.tar.gz
==> Source code staged at: /var/folders/0s/q_y0zhfj6xdd5n7rn780zz6h001qr7/T/gamblin2/spack-stage/spack-stage-zlib-1.2.11-f7owbzfu4zsr6yn7x7hljransoof6ach
==> No patches needed for zlib
==> zlib: Executing phase: 'install'
==> Module file exists; won't overwrite. Use `spack module` to refresh.
==> zlib: Successfully installed zlib-1.2.11-f7owbzfu4zsr6yn7x7hljransoof6ach
  Fetch: 0.00s.  Build: 3.22s.  Total: 3.22s.
[+] /Users/gamblin2/Workspace/spack/opt/spack/darwin-catalina-skylake/apple-clang-12.0.0/zlib-1.2.11-f7owbzfu4zsr6yn7x7hljransoof6ach
```