### PR TITLE
swig: add smoke tests

### DIFF
--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -71,7 +71,6 @@ class Swig(AutotoolsPackage, SourceforgePackage):
         def autoreconf(self, spec, prefix):
             which('sh')('./autogen.sh')
 
-
     @property
     def _installed_exe(self):
         return join_path(self.prefix, 'bin', 'swig')
@@ -89,11 +88,16 @@ class Swig(AutotoolsPackage, SourceforgePackage):
                       purpose="test: version")
 
     def _test_swiglib(self):
+        # Get SWIG's alleged path to library files
         swig = Executable(self._installed_exe)
         swiglib = swig('-swiglib', output=str).strip()
+
+        # Check that the lib dir exists
         if not os.path.isdir(swiglib):
             msg = "SWIG library does not exist at '{0}'".format(swiglib)
             self.test_failures.append([None, msg])
+
+        # Check for existence of other critical SWIG library files
         swigfile = join_path(swiglib, 'swig.swg')
         if not os.path.exists(swigfile):
             msg = "SWIG runtime does not exist at '{0}'".format(swigfile)

--- a/var/spack/repos/builtin/packages/swig/package.py
+++ b/var/spack/repos/builtin/packages/swig/package.py
@@ -70,3 +70,41 @@ class Swig(AutotoolsPackage, SourceforgePackage):
         @when(_version)
         def autoreconf(self, spec, prefix):
             which('sh')('./autogen.sh')
+
+
+    @property
+    def _installed_exe(self):
+        return join_path(self.prefix, 'bin', 'swig')
+
+    def _test_version(self):
+        version = str(self.version)
+        if version.endswith('-fortran'):
+            version = version.replace('-', r'\+')
+        elif version in ('fortran', 'master'):
+            version = r'.*'
+
+        self.run_test(self._installed_exe,
+                      '-version',
+                      expected=[r'SWIG Version {0}'.format(version)],
+                      purpose="test: version")
+
+    def _test_swiglib(self):
+        swig = Executable(self._installed_exe)
+        swiglib = swig('-swiglib', output=str).strip()
+        if not os.path.isdir(swiglib):
+            msg = "SWIG library does not exist at '{0}'".format(swiglib)
+            self.test_failures.append([None, msg])
+        swigfile = join_path(swiglib, 'swig.swg')
+        if not os.path.exists(swigfile):
+            msg = "SWIG runtime does not exist at '{0}'".format(swigfile)
+            self.test_failures.append([None, msg])
+        if 'fortran' in str(self.version):
+            swigfile = join_path(swiglib, 'fortran', 'fortran.swg')
+            if not os.path.exists(swigfile):
+                msg = "SWIG+Fortran runtime does not exist at '{0}'".format(
+                    swigfile)
+                self.test_failures.append([None, msg])
+
+    def test(self):
+        self._test_version()
+        self._test_swiglib()


### PR DESCRIPTION
Notes for @tldahlgren for future improvements to the testing system:
- It was surprising behavior to me that `self.run_tests('swig', installed=True, ...` did *not* work since the documentation reads  as though the search for the `swig` exe should consider the package's install prefix. I think the HDF5 smoke tests need to be fixed since they also use this option (and they might be silently failing because they also pass `skip_missing=True`).
- A non-fatal assertion `self.check_test_result(assertion, msg)` (or similar) would be good to encapsulate `self.test_failures`.
- To avoid overcomplicating the `Package` class even further, maybe a `PackageTest` class instance could be passed as part of the `test` call, so testing methods like `run_test` and `assert_equal` would get added to that helper class.