### PR TITLE
ForTrilinos: add smoke test

### DIFF
--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -29,6 +29,8 @@ class Fortrilinos(CMakePackage):
 
     maintainers = ['sethrj', 'aprokop']
 
+    test_requires_compiler = True
+
     version('2.0.0', sha256='9af3b3eea9934e44d74654a5fa822de08bd0efa43e06e4a4e35a777781f542d6')
     # Note: spack version comparison implies Version('2.0.0') <
     # Version('2.0.0-dev1'), so this is the best workaround I could find.
@@ -72,3 +74,28 @@ class Fortrilinos(CMakePackage):
             self.define('ForTrilinos_EXAMPLES', self.run_tests),
             self.define('ForTrilinos_TESTING', self.run_tests),
         ]
+
+    examples_src_dir = 'example/test-installation'
+
+    @run_after('install')
+    def setup_smoke_tests(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources([self.examples_src_dir])
+
+    def test(self):
+        test_build_dir = join_path(self.install_test_root,
+                                   self.examples_src_dir, 'build')
+        mkdirp(test_build_dir)
+        with working_dir(test_build_dir):
+            cmake(
+                self.define('CMAKE_PREFIX_PATH', self.prefix),
+                self.define('CMAKE_CXX_COMPILER', self.compiler.cxx),
+                self.define('CMAKE_Fortran_COMPILER', self.compiler.fc),
+                '..'
+            )
+            make()
+
+        with working_dir(test_build_dir):
+            self.run_test('ctest', ['-V'], [], installed=False,
+                          purpose='test: installation')

--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -86,7 +86,8 @@ class Fortrilinos(CMakePackage):
     def test(self):
         example_src_dir = join_path(self.install_test_root,
                                     self.examples_src_dir)
-        test_build_dir = join_path(self.install_test_root, 'build')
+        test_build_dir = join_path(self.test_suite.current_test_data_dir,
+                                   'build_example')
         with working_dir(test_build_dir, create=True):
             cmake(
                 self.define('CMAKE_PREFIX_PATH', self.prefix),
@@ -97,8 +98,3 @@ class Fortrilinos(CMakePackage):
             make()
             self.run_test('ctest', ['-V'], [], installed=False,
                           purpose='test: installation')
-
-        # TODO: spack might be updated to use a temporary directory for
-        # building/running tests, at which point this will no longer be neededd
-        import shutil
-        shutil.rmtree(test_build_dir)

--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -86,7 +86,7 @@ class Fortrilinos(CMakePackage):
     def test(self):
         example_src_dir = join_path(self.install_test_root,
                                     self.examples_src_dir)
-        test_build_dir = join_path(self.test_suite.current_test_data_dir,
+        test_build_dir = join_path(self.test_suite.stage,
                                    'build_example')
         with working_dir(test_build_dir, create=True):
             cmake(

--- a/var/spack/repos/builtin/packages/fortrilinos/package.py
+++ b/var/spack/repos/builtin/packages/fortrilinos/package.py
@@ -84,18 +84,21 @@ class Fortrilinos(CMakePackage):
         self.cache_extra_test_sources([self.examples_src_dir])
 
     def test(self):
-        test_build_dir = join_path(self.install_test_root,
-                                   self.examples_src_dir, 'build')
-        mkdirp(test_build_dir)
-        with working_dir(test_build_dir):
+        example_src_dir = join_path(self.install_test_root,
+                                    self.examples_src_dir)
+        test_build_dir = join_path(self.install_test_root, 'build')
+        with working_dir(test_build_dir, create=True):
             cmake(
                 self.define('CMAKE_PREFIX_PATH', self.prefix),
                 self.define('CMAKE_CXX_COMPILER', self.compiler.cxx),
                 self.define('CMAKE_Fortran_COMPILER', self.compiler.fc),
-                '..'
+                example_src_dir
             )
             make()
-
-        with working_dir(test_build_dir):
             self.run_test('ctest', ['-V'], [], installed=False,
                           purpose='test: installation')
+
+        # TODO: spack might be updated to use a temporary directory for
+        # building/running tests, at which point this will no longer be neededd
+        import shutil
+        shutil.rmtree(test_build_dir)


### PR DESCRIPTION
I based this off the arborx test, which creates a build directory underneath the install prefix. It looks like some of the other test packages (e.g. openmpi) do this as well. I think that to avoid contaminating the installation, and to allow non-installing users to test, *and* to improve reproducibility, it would be good to add a facility to generate a temporary testing prefix inside the spack temporary directory if possible.