### PR TITLE
geopm: allow py-tables versions past 3.5.2 (build+run dependency)

### DIFF
--- a/var/spack/repos/builtin/packages/geopm/package.py
+++ b/var/spack/repos/builtin/packages/geopm/package.py
@@ -61,7 +61,7 @@ class Geopm(AutotoolsPackage):
     depends_on('json-c', when='@:0.9.9')
     depends_on('py-cycler@0.10.0:', when="@1.0.0:", type=('build', 'run'))
     depends_on('py-pandas@0.22.0:', type=('build', 'run'))
-    depends_on('py-tables@3.4.3:3.5.2', when="@1.0.0:", type=('build', 'run'))
+    depends_on('py-tables@3.4.3:', when="@1.0.0:", type=('build', 'run'))
     depends_on('py-cffi@1.6.0:', when="@1.1.0:", type=('build', 'run'))
     depends_on('py-pyyaml@5.1.0:', when="@1.1.0:", type=('build', 'run'))
     depends_on('py-mock@3.0.0:', when="@1.1.0:", type=('build', 'run'))


### PR DESCRIPTION
`geopm`: depend on `py-tables@3.4.3:` instead of `@3.4.3:3.5.2` 

I was able to build `geopm@1.1` with `py-tables@3.6.1` on x86_64 and ppc6l4e using:
* Ubuntu 18.04, GCC 7.5.0
* Ubuntu 20.04, GCC 9.3.0
* RHEL 7, GCC 9.3.0
* RHEL 8, GCC 8.3.1

@maiterth 