### PR TITLE
py-absl-py: add missing py-setuptools dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-absl-py/package.py
+++ b/var/spack/repos/builtin/packages/py-absl-py/package.py
@@ -25,3 +25,4 @@ class PyAbslPy(PythonPackage):
     depends_on('py-setuptools', type=('build'))
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-enum34', type=('build', 'run'), when='^python@:3.3.99')
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
at least in newer versions py-absl-py can use setup tools