### PR TITLE
Adding support to tag a build

### DIFF
--- a/lib/spack/docs/monitoring.rst
+++ b/lib/spack/docs/monitoring.rst
@@ -91,4 +91,14 @@ This could mean that if a request fails, you only have partial or no data
 added to your monitoring database. This setting will not be applied to the
 first request to check if the server is running, but to subsequent requests.
 If you don't have a monitor server running and you want to build, simply
-don't provide the ``--monitor`` flag!
+don't provide the ``--monitor`` flag! Finally, if you want to provide one or
+more tags to your build, you can do:
+
+.. code-block:: console
+
+    # Add one tag, "pizza"
+    $ spack install --monitor --monitor-tags pizza hdf5
+
+    # Add two tags, "pizza" and "pasta"
+    $ spack install --monitor --monitor-tags pizza,pasta hdf5
+

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -305,6 +305,7 @@ environment variables:
             host=args.monitor_host,
             prefix=args.monitor_prefix,
             disable_auth=args.monitor_disable_auth,
+            tags=args.monitor_tags,
         )
 
     reporter = spack.report.collect_info(

--- a/lib/spack/spack/monitor.py
+++ b/lib/spack/spack/monitor.py
@@ -31,7 +31,7 @@ from copy import deepcopy
 cli = None
 
 
-def get_client(host, prefix="ms1", disable_auth=False, allow_fail=False):
+def get_client(host, prefix="ms1", disable_auth=False, allow_fail=False, tags=None):
     """
     Get a monitor client for a particular host and prefix.
 
@@ -46,7 +46,8 @@ def get_client(host, prefix="ms1", disable_auth=False, allow_fail=False):
     the monitor use it.
     """
     global cli
-    cli = SpackMonitorClient(host=host, prefix=prefix, allow_fail=allow_fail)
+    cli = SpackMonitorClient(host=host, prefix=prefix, allow_fail=allow_fail,
+                             tags=tags)
 
     # If we don't disable auth, environment credentials are required
     if not disable_auth:
@@ -85,6 +86,9 @@ def get_monitor_group(subparser):
         '--monitor-no-auth', action='store_true', dest='monitor_disable_auth',
         default=False, help="the monitoring server does not require auth.")
     monitor_group.add_argument(
+        '--monitor-tags', dest='monitor_tags', default=None,
+        help="One or more (comma separated) tags for a build.")
+    monitor_group.add_argument(
         '--monitor-keep-going', action='store_true', dest='monitor_keep_going',
         default=False, help="continue the build if a request to monitor fails.")
     monitor_group.add_argument(
@@ -106,7 +110,7 @@ class SpackMonitorClient:
     to the client on init.
     """
 
-    def __init__(self, host=None, prefix="ms1", allow_fail=False):
+    def __init__(self, host=None, prefix="ms1", allow_fail=False, tags=None):
         self.host = host or "http://127.0.0.1"
         self.baseurl = "%s/%s" % (self.host, prefix.strip("/"))
         self.token = os.environ.get("SPACKMON_TOKEN")
@@ -115,6 +119,7 @@ class SpackMonitorClient:
         self.allow_fail = allow_fail
         self.spack_version = spack.main.get_version()
         self.capture_build_environment()
+        self.tags = tags
 
         # We keey lookup of build_id by full_hash
         self.build_ids = {}
@@ -201,7 +206,8 @@ class SpackMonitorClient:
         # Always reset headers for new request.
         self.reset()
 
-        headers = headers or {}
+        # Preserve previously used auth token
+        headers = headers or self.headers
 
         # The calling function can provide a full or partial url
         if not endpoint.startswith("http"):
@@ -366,6 +372,10 @@ class SpackMonitorClient:
         # Prepare build environment data (including spack version)
         data = self.build_environment.copy()
         data['full_hash'] = full_hash
+
+        # If the build should be tagged, add it
+        if self.tags:
+            data['tags'] = self.tags
 
         # If we allow the spec to not exist (meaning we create it) we need to
         # include the full spec.yaml here

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -358,7 +358,7 @@ _spack_add() {
 _spack_analyze() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --monitor --monitor-no-auth --monitor-keep-going --monitor-host --monitor-prefix"
+        SPACK_COMPREPLY="-h --help --monitor --monitor-no-auth --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix"
     else
         SPACK_COMPREPLY="list-analyzers run"
     fi
@@ -1063,7 +1063,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-no-auth --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-no-auth --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
     else
         _all_packages
     fi


### PR DESCRIPTION
This will be useful to run multiple build experiments and organize by name. cc @trws - I'll let you know when the monitor server is updated to support testing this.

Related: https://github.com/spack/spack-monitor/pull/23

Signed-off-by: vsoch <vsoch@users.noreply.github.com>