### PR TITLE
binutils: fix NameError from commit de8027

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -78,7 +78,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
         if self.spec.satisfies('%cce'):
             env.append_flags('LDFLAGS', '-Wl,-z,muldefs')
 
-        if '+nls' in spec:
+        if '+nls' in self.spec:
             env.append_flags('LDFLAGS', '-lintl')
 
     def configure_args(self):


### PR DESCRIPTION
Fixes `NameError` in `binutils` introduced via de8027a820fb24354a06946eb3c6c05cc45ad3a5

```
$> spack install binutils@2.33.1
...
==> Installing binutils-2.33.1-iksgnl2krxqpq7gudfr7h2i2meonhewg
==> Error: NameError: name 'spec' is not defined

/spack/var/spack/repos/builtin/packages/binutils/package.py:81, in setup_build_environment:
         78        if self.spec.satisfies('%cce'):
         79            env.append_flags('LDFLAGS', '-Wl,-z,muldefs')
         80
  >>     81        if '+nls' in spec:
         82            env.append_flags('LDFLAGS', '-lintl')
```

@lukebroskop @tldahlgren 