### PR TITLE
py-slurm-pipeline: add new version 3.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
+++ b/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
@@ -12,6 +12,7 @@ class PySlurmPipeline(PythonPackage):
     homepage = "https://github.com/acorg/slurm-pipeline"
     pypi = "slurm-pipeline/slurm-pipeline-1.1.13.tar.gz"
 
+    version('3.0.2',  sha256='28e07eb93e846b395a16e6778fd3fc8344a82d115a6a8420276ec68f67f7131c')
     version('2.0.9',  sha256='2360e43965ecfa3701f287b7d597c99b4accd4dc8faf9d55cfdcc2228c4054cc')
     version('1.1.13', sha256='6d6ca2e96a16780fd9520957166afd06272c57abd962e76bfe74c4d394b38da1')
 


### PR DESCRIPTION
Part of our recent merge and upstream effort.