### PR TITLE
Enhance error reporting in package.py for failed fetches

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1373,7 +1373,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         try:
             self.stage.fetch(mirror_only, err_msg=err_msg)
         except fs.FetchError:
-            tty.error('Failed to fetch {0}'.format(self.spec.cformat('{name}{@version}')))
+            spec_str = self.spec.cformat('{name}{@version}')
+            tty.error('Failed to fetch {0}'.format(spec_str))
             raise
         self._fetch_time = time.time() - start_time
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1368,8 +1368,13 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         self.stage.create()
         err_msg = None if not self.manual_download else self.download_instr
+
         start_time = time.time()
-        self.stage.fetch(mirror_only, err_msg=err_msg)
+        try:
+            self.stage.fetch(mirror_only, err_msg=err_msg)
+        except fs.FetchError:
+            tty.error('Failed to fetch {0}'.format(self.spec.cformat('{name}{@version}')))
+            raise
         self._fetch_time = time.time() - start_time
 
         if checksum and self.version in self.versions:


### PR DESCRIPTION
Part of our recent merge and upstream effort.

Commit message:

Before this patch, in case of a total fetch failure no information
_which_ package failed to fetch was reported:
```
$ spack fetch libedit@3.2
==> Error: All fetchers failed
```

Now we add the failed package's name:
```
$ spack fetch libedit@3.2
==> Error: Failed to fetch libedit@3.2
==> Error: All fetchers failed