### PR TITLE
findutils: problem building it on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -45,6 +45,10 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
     version('4.1.20', sha256='8c5dd50a5ca54367fa186f6294b81ec7a365e36d670d9feac62227cb513e63ab')
     version('4.1',    sha256='487ecc0a6c8c90634a11158f360977e5ce0a9a6701502da6cb96a5a7ec143fac')
 
+    # https://www.mail-archive.com/bug-findutils@gnu.org/msg06290.html
+    # not just on Catalina, same problem on Mojave with apple-clang@10.0.1
+    conflicts('@4.8.0', when='%apple-clang')
+
     # The NVIDIA compilers do not currently support some GNU builtins.
     # Detect this case and use the fallback path.
     patch('nvhpc.patch', when='@4.6.0 %nvhpc')


### PR DESCRIPTION
As reported also here https://www.mail-archive.com/bug-findutils@gnu.org/msg06290.html there is a problem building 4.8.0 version on macOS (not just Catalina).

Extent of errors reported (for future reference)
```
gl/lib/regex_internal.h:835:23: note: expanded from macro 'FALLTHROUGH'
#  define FALLTHROUGH __attribute__ ((__fallthrough__))
```

```
gl/lib/malloc/dynarray-skeleton.c:195:13: error: expected identifier or '('
__nonnull ((1))
```

The problem may affect other packages too (see https://www.mail-archive.com/bug-wget@gnu.org/msg09940.html)

Thanks @haampie for the support.