### PR TITLE
variorum: unpin hwloc dependency

### DIFF
--- a/var/spack/repos/builtin/packages/variorum/package.py
+++ b/var/spack/repos/builtin/packages/variorum/package.py
@@ -38,7 +38,7 @@ class Variorum(CMakePackage):
     # Package dependencies #
     ########################
     depends_on("cmake@2.8:", type="build")
-    depends_on("hwloc@1.11.9")
+    depends_on("hwloc")
 
     #########################
     # Documentation related #


### PR DESCRIPTION
`variorum`: allow newer versions of `hwloc` instead of requiring `@1.11.9`

@slabasan @rountree