### PR TITLE
Apply fallow-argument-mismatch parameter to mpich in clang

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -311,6 +311,8 @@ spack package at this time.''',
         # Same fix but for macOS - avoids issue #17934
         if self.spec.satisfies('%apple-clang@11:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
+        if self.spec.satisfies('%clang@11:'):
+            env.set('FFLAGS', '-fallow-argument-mismatch')
 
     def setup_run_environment(self, env):
         # Because MPI implementations provide compilers, they have to add to


### PR DESCRIPTION
I was getting errors building mpich for clang, and saw that the problem had already been found and addressed for gcc and apple-clang. I'm applying the same fix for standard clang.