### PR TITLE
libffi: Set target triplet to aarch64-apple-darwin on Mac M1.

### DIFF
--- a/var/spack/repos/builtin/packages/libffi/package.py
+++ b/var/spack/repos/builtin/packages/libffi/package.py
@@ -32,4 +32,9 @@ class Libffi(AutotoolsPackage, SourcewarePackage):
             # Spack adds its own target flags, so tell libffi not to
             # second-guess us
             args.append('--without-gcc-arch')
+        # At the moment, build scripts accept 'aarch64-apple-darwin'
+        # but not 'arm64-apple-darwin'.
+        # See: https://github.com/libffi/libffi/issues/571
+        if self.spec.satisfies('platform=darwin target=aarch64:'):
+            args.append('--build=aarch64-apple-darwin')
         return args


### PR DESCRIPTION
Re: #23749 

In the discussion at libffi/libffi#571, @rsfinn mentioned this fix.

I just need libffi as a dependency of Python. I think there is much more work happening upstream, but I can confirm libffi at least builds and Python can import the ctypes module and do a printf hello world.