### PR TITLE
ants: add version 2.3.5

### DIFF
--- a/var/spack/repos/builtin/packages/ants/package.py
+++ b/var/spack/repos/builtin/packages/ants/package.py
@@ -15,12 +15,20 @@ class Ants(CMakePackage):
        processing library to which ANTs developers contribute.
     """
 
-    homepage = "http://stnava.github.io/ANTs/"
+    homepage = "https://stnava.github.io/ANTs/"
     url      = "https://github.com/ANTsX/ANTs/archive/v2.2.0.tar.gz"
 
+    version('2.3.5', sha256='2fddfd5f274a47f1c383e734a7e763b627c4a8383d2d3b9971561f335016bb0a')
     version('2.2.0', sha256='62f8f9ae141cb45025f4bb59277c053acf658d4a3ba868c9e0f609af72e66b4a')
 
     depends_on('zlib', type='link')
+
+    variant('minc', default=True, description='Build ITK with MINC support')
+
+    def cmake_args(self):
+        return [
+            self.define_from_variant('ITK_BUILD_MINC_SUPPORT', 'minc')
+        ]
 
     def install(self, spec, prefix):
         with working_dir(


### PR DESCRIPTION
- enabled option to build with MINC support (default True)
- changed homepage url to https://