### PR TITLE
Add caret/hat to spack spec help documentation

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -254,6 +254,7 @@ def install_status():
         '-I', '--install-status', action='store_true', default=False,
         help='show install status of packages. packages can be: '
         'installed [+], missing and needed by an installed package [-], '
+        'installed in and upstream instance [^], '
         'or not installed (no annotation)')
 
 


### PR DESCRIPTION
Adds explanation to `spack spec -h` for the `[^]` symbol present when using an upstream spack instance.