### PR TITLE
Allow user to customize the config path

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -11,7 +11,7 @@
 #   $SPACK_ROOT/etc/spack/config.yaml
 #
 # Per-user settings (overrides default and site settings):
-#   ~/.spack/config.yaml
+#   $user_config/config.yaml
 # -------------------------------------------------------------------------
 config:
   # This is the path to the root of the Spack install tree.
@@ -67,7 +67,7 @@ config:
   # identifies Spack staging to avoid accidentally wiping out non-Spack work.
   build_stage:
     - $tempdir/$user/spack-stage
-    - ~/.spack/stage
+    - $user_config/stage
   # - $spack/var/spack/stage
 
   # Directory in which to run tests and store test results.
@@ -82,7 +82,7 @@ config:
 
   # Cache directory for miscellaneous files, like the package index.
   # This can be purged with `spack clean --misc-cache`
-  misc_cache: ~/.spack/cache
+  misc_cache: $user_config/cache
 
 
   # Timeout in seconds used for downloading sources etc. This only applies

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -402,13 +402,13 @@ Spack-specific variables
 
 Spack understands several special variables. These are:
 
-* ``$spack``: path to the prefix of this Spack installation
-* ``$tempdir``: default system temporary directory (as specified in
+* ``$spack``: Path to the prefix of this Spack installation
+* ``$tempdir``: Default system temporary directory (as specified in
   Python's `tempfile.tempdir
   <https://docs.python.org/2/library/tempfile.html#tempfile.tempdir>`_
   variable.
-* ``$user``: name of the current user
-* ``$user_config``: name of the current user
+* ``$user``: Name of the current user
+* ``$user_config``: User configuration directory
 
 Note that, as with shell variables, you can write these as ``$varname``
 or with braces to distinguish the variable from surrounding characters:

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -408,6 +408,7 @@ Spack understands several special variables. These are:
   <https://docs.python.org/2/library/tempfile.html#tempfile.tempdir>`_
   variable.
 * ``$user``: name of the current user
+* ``$user_config``: name of the current user
 
 Note that, as with shell variables, you can write these as ``$varname``
 or with braces to distinguish the variable from surrounding characters:

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -50,11 +50,8 @@ packages_path      = os.path.join(repos_path, "builtin")
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
 #: User configuration location
-__SPACK_USER_CONFIG = os.environ.get('SPACK_USER_CONFIG')
-if __SPACK_USER_CONFIG:
-    user_config_path = os.path.expanduser(__SPACK_USER_CONFIG)
-else:
-    user_config_path = os.path.expanduser('~/.spack')
+user_config_path = os.path.expanduser(os.environ.get('SPACK_USER_CONFIG',
+                                                     '~/.spack'))
 
 user_bootstrap_path = os.path.join(user_config_path, 'bootstrap')
 user_bootstrap_store = os.path.join(user_bootstrap_path, 'store')

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -10,6 +10,7 @@ throughout Spack and should bring in a minimal number of external
 dependencies.
 """
 import os
+import re
 from llnl.util.filesystem import ancestor
 
 #: This file lives in $prefix/lib/spack/spack/__file__
@@ -50,8 +51,12 @@ packages_path      = os.path.join(repos_path, "builtin")
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
 #: User configuration location
-user_config_path = os.path.expanduser(os.environ.get('SPACK_USER_CONFIG',
-                                                     '~/.spack'))
+user_config_path = re.sub(r'\$(?:spack\b|\{spack\})',
+                          spack_root,
+                          os.path.expanduser(
+                              os.environ.get(
+                                  'SPACK_USER_CONFIG',
+                                  '~/.spack')))
 
 user_bootstrap_path = os.path.join(user_config_path, 'bootstrap')
 user_bootstrap_store = os.path.join(user_bootstrap_path, 'store')

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -50,7 +50,12 @@ packages_path      = os.path.join(repos_path, "builtin")
 mock_packages_path = os.path.join(repos_path, "builtin.mock")
 
 #: User configuration location
-user_config_path = os.path.expanduser('~/.spack')
+__SPACK_USER_CONFIG = os.environ.get('SPACK_USER_CONFIG')
+if __SPACK_USER_CONFIG:
+    user_config_path = os.path.expanduser(__SPACK_USER_CONFIG)
+else:
+    user_config_path = os.path.expanduser('~/.spack')
+
 user_bootstrap_path = os.path.join(user_config_path, 'bootstrap')
 user_bootstrap_store = os.path.join(user_bootstrap_path, 'store')
 reports_path = os.path.join(user_config_path, "reports")

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -29,6 +29,7 @@ replacements = {
     'spack': spack.paths.prefix,
     'user': getpass.getuser(),
     'tempdir': tempfile.gettempdir(),
+    'user_config': spack.paths.user_config_path,
 }
 
 # This is intended to be longer than the part of the install path
@@ -73,6 +74,7 @@ def substitute_config_variables(path):
     - $user      The current user's username
     - $tempdir   Default temporary directory returned by tempfile.gettempdir()
     - $env       The active Spack environment.
+    - $user_config User configuration directory
 
     These are substituted case-insensitively into the path, and users can
     use either ``$var`` or ``${var}`` syntax for the variables. $env is only


### PR DESCRIPTION
This is the most basic possible way to do this.  XDG support might be nice, etc. etc. but at a minimum this seems to allow a user to specify where they want the user_config_directory to reside, and makes it possible to support having separate ones a bit more easily on shared filesystems or with multiple instances of spack.