### PR TITLE
gatk Updated Archives links for 3.X

### DIFF
--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -78,15 +78,15 @@ class Gatk(Package):
     )
     version(
         "3.8-1",
-        sha256="a0829534d2d0ca3ebfbd3b524a9b50427ff238e0db400d6e9e479242d98cbe5c",
+        sha256='a0829534d2d0ca3ebfbd3b524a9b50427ff238e0db400d6e9e479242d98cbe5c',
         extension="tar.bz2",
-        url="https://software.broadinstitute.org/gatk/download/auth?package=GATK-archive&version=3.8-1-0-gf15c1c3ef",
+        url="https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.8-1-0-gf15c1c3ef.tar.bz2",
     )
     version(
         "3.8-0",
         sha256="d1017b851f0cc6442b75ac88dd438e58203fa3ef1d1c38eb280071ae3803b9f1",
-        extension="tar.gz",
-        url="https://software.broadinstitute.org/gatk/download/auth?package=GATK",
+        extension="tar.bz2",
+        url="https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.8-0-ge9d806836.tar.bz2"
     )
 
     depends_on("java@8", type="run")


### PR DESCRIPTION
the Gatk team moved their archives from their own servers to Google. This update accounts for that.