### PR TITLE
Add new openmp flag for oneapi

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -49,7 +49,7 @@ class Oneapi(Compiler):
 
     @property
     def openmp_flag(self):
-        return "-qopenmp"
+        return "-fiopenmp"
     # There may be some additional options here for offload, e.g. :
     #  -fopenmp-simd           Emit OpenMP code only for SIMD-based constructs.
     #  -fopenmp-targets=<value>

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -550,7 +550,7 @@ def test_intel_flags():
 
 
 def test_oneapi_flags():
-    supported_flag_test("openmp_flag", "-qopenmp", "oneapi@2020.8.0.0827")
+    supported_flag_test("openmp_flag", "-fiopenmp", "oneapi@2020.8.0.0827")
     supported_flag_test("cxx11_flag", "-std=c++11", "oneapi@2020.8.0.0827")
     supported_flag_test("cxx14_flag", "-std=c++14", "oneapi@2020.8.0.0827")
     supported_flag_test("c99_flag", "-std=c99", "oneapi@2020.8.0.0827")


### PR DESCRIPTION
This will add the flag -fiopenmp when building codes with oneapi that have the openmp variant. 

There is an additional flag -fopenmp-target=spir64 which is needed to build device code (only builds host code without this) and I propose this as a variant +spir to be added to packages (e.g. kokkos: https://github.com/spack/spack/pull/23770) as needed. 