### PR TITLE
monitor: check if code before retry

### DIFF
--- a/lib/spack/spack/monitor.py
+++ b/lib/spack/spack/monitor.py
@@ -228,7 +228,7 @@ class SpackMonitorClient:
         except URLError as e:
 
             # If we have an authorization request, retry once with auth
-            if e.code == 401 and retry:
+            if hasattr(e, "code") and e.code == 401 and retry:
                 if self.authenticate_request(e):
                     request = self.prepare_request(
                         e.url,


### PR DESCRIPTION
This is a tiny bug fix to ensure that the response has a code attribute before attempting to check its value. I am testing running spack monitor from inside a container and hit this bug, so I'll need this integrated into spack (in one of the base containers used for containerize) before I can continue developing. cc @alecbcs.

The branch I'm testing is at https://github.com/spack/spack/compare/develop...vsoch:add/containerize-monitor?expand=1. I've been able to get the environment variables in, but it exits with an error that this e object has no attribute "code" and the server is never hit. I suspect something else is going on - and I'll need this fix to see the error message.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>