### PR TITLE
Enforcing PETSc version [3.13, 3.15) in ExaGO Package

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -55,7 +55,8 @@ class Exago(CMakePackage, CudaPackage):
     depends_on('hiop~mpi', when='+hiop~mpi')
     depends_on('hiop+mpi', when='+hiop+mpi')
 
-    depends_on('petsc', when='+petsc')
+    # Require PETSc < 3.15 per ExaGO issue #199
+    depends_on('petsc@3.13:3.14', when='+petsc')
     depends_on('petsc~mpi', when='+petsc~mpi')
     depends_on('ipopt', when='+ipopt')
 


### PR DESCRIPTION
Enforcing a specific version of PETSc per ExaGO issue 199

cc @haampie as you have so generously reviewed a few previous PRs
cc @ashermancinelli 