### PR TITLE
openblas: compile 0.3.15 with Intel

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -66,8 +66,8 @@ class Openblas(MakefilePackage):
     #  UPD: the patch has been merged starting version 0.2.20
     patch('openblas_icc.patch', when='@:0.2.19%intel')
     patch('openblas_icc_openmp.patch', when='@:0.2.20%intel@16.0:')
-    patch('openblas_icc_fortran.patch', when='%intel@16.0:')
-    patch('openblas_icc_fortran2.patch', when='%intel@18.0:')
+    patch('openblas_icc_fortran.patch', when='@:0.3.14%intel@16.0:')
+    patch('openblas_icc_fortran2.patch', when='@:0.3.14%intel@18.0:')
     # See https://github.com/spack/spack/issues/15385
     patch('lapack-0.3.9-xerbl.patch', when='@0.3.8:0.3.9 %intel')
 


### PR DESCRIPTION
Patches openblas_icc_fortran.patch and openblas_icc_fortran2.patch are rejected with openblas 0.3.15 while it compiles smoothly without the patch.
Just a notice, I have not managed to compile 0.3.14 with any Intel compiler (Intel 17, 20 and 2021.2).
