### PR TITLE
gsl: compile 2.6 with external-cblas

### DIFF
--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -29,9 +29,10 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
     variant('external-cblas', default=False, description='Build against external blas')
 
     # from https://dev.gentoo.org/~mgorny/dist/gsl-2.3-cblas.patch.bz2
-    patch('gsl-2.3-cblas.patch', when="+external-cblas")
+    patch('gsl-2.3-cblas.patch', when="@2.3:2.5.99+external-cblas")
 
-    conflicts('+external-cblas', when="@:2.2.9999")
+    conflicts('+external-cblas', when="@:2.2.99")
+
     depends_on('m4',       type='build', when='+external-cblas')
     depends_on('autoconf', type='build', when='+external-cblas')
     depends_on('automake', type='build', when='+external-cblas')


### PR DESCRIPTION
The external-cblas patch works fine for 2.3.
It is rejected for 2.6.
