### PR TITLE
Create a gpg2 -> gpg symlink on install

### DIFF
--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -44,9 +44,9 @@ class Gnupg(AutotoolsPackage):
     depends_on('zlib')
 
     @run_after('install')
-    @when('@2.0:2.999')
     def add_gpg2_symlink(self):
-        symlink('gpg', join_path(self.prefix, 'bin', 'gpg2'))
+        if self.spec.satisfies("@2.0:2.999"):
+            symlink('gpg', self.prefix.bin.gpg2)
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/gnupg/package.py
+++ b/var/spack/repos/builtin/packages/gnupg/package.py
@@ -43,6 +43,11 @@ class Gnupg(AutotoolsPackage):
     depends_on('iconv')
     depends_on('zlib')
 
+    @run_after('install')
+    @when('@2.0:2.999')
+    def add_gpg2_symlink(self):
+        symlink('gpg', join_path(self.prefix, 'bin', 'gpg2'))
+
     def configure_args(self):
         args = [
             '--disable-bzip2',


### PR DESCRIPTION
gpg2 is what spack (incorrectly?) uses to call gpg. As far as I
understand it is legacy and package managers on different distros
continued this legacy behavior. Let's also do it then.

gpg has a config option that creates a gpg2 binary, but then gpg is
gone, so manually creating it seems the way to go.
