### PR TITLE
Update the GASNet package

### DIFF
--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -6,98 +6,133 @@
 from spack import *
 
 
-class Gasnet(AutotoolsPackage):
-    """GASNet is a language-independent, low-level networking layer
-       that provides network-independent, high-performance communication
-       primitives tailored for implementing parallel global address space
-       SPMD languages and libraries such as UPC, Co-Array Fortran, SHMEM,
-       Cray Chapel, and Titanium.
+class Gasnet(Package):
+    """GASNet is a language-independent, networking middleware layer that
+       provides network-independent, high-performance communication primitives
+       including Remote Memory Access (RMA) and Active Messages (AM). It has been
+       used to implement parallel programming models and libraries such as UPC,
+       UPC++, Co-Array Fortran, Legion, Chapel, and many others. The interface is
+       primarily intended as a compilation target and for use by runtime library
+       writers (as opposed to end users), and the primary goals are high
+       performance, interface portability, and expressiveness.
+
+       ***NOTICE***: The GASNet library built by this Spack package is ONLY intended for
+       unit-testing purposes, and is generally UNSUITABLE FOR PRODUCTION USE.
+       The RECOMMENDED way to build GASNet is as an embedded library as configured
+       by the higher-level client runtime package (UPC++, Legion, etc), including
+       system-specific configuration.
     """
     homepage = "https://gasnet.lbl.gov"
-    url      = "https://gasnet.lbl.gov/EX/GASNet-2020.3.0.tar.gz"
+    url      = "https://gasnet.lbl.gov/EX/GASNet-2021.3.0.tar.gz"
+    git      = "https://bitbucket.org/berkeleylab/gasnet.git"
 
     maintainers = ['PHHargrove', 'bonachea']
 
-    version('2020.3.0', sha256='019eb2d2284856e6fabe6c8c0061c874f10e95fa0265245f227fd3497f1bb274')
-    version('2019.9.0', sha256='117f5fdb16e53d0fa8a47a1e28cccab1d8020ed4f6e50163d985dc90226aaa2c')
-    version('2019.6.0', sha256='839ba115bfb48083c66b4c1c27703d73063b75d2f1e0501d5eab2ad7f0f776c8')
-    version('2019.3.2', sha256='9e2175047879f1e8c7c4b0a9db3c2cd20c978371cd7f209cf669d402119b6fdb')
-    version('2019.3.0', sha256='97fe19bb5ab32d14a96d2dd19d0f03048f68bb20ca83abe0c00cdab40e86eba5')
-    version('1.32.0', sha256='42e4774b3bbc7c142f77c41b6ce86b594f579073f46c31f47f424c7e31ee1511')
-    version('1.30.0', sha256='b5d8c98c53174a98a41efb4ec9dedb62c0a9e8fa111bb6460cd4493beb80d497')
-    version('1.28.2', sha256='7903fd8ebdd03bcda20a66e3fcedef2f8b384324591aa91b8370f3360f6384eb')
-    version('1.28.0', sha256='a7999fbaa1f220c2eb9657279c7e7cccd1b21865d5383c9a5685cfe05a0702bc')
-    version('1.24.0', sha256='76b4d897d5e2261ef83d0885c192e8ac039e32cb2464f11eb64eb3f9f2df38c0')
+    version('develop', branch='develop')
+    version('main',    branch='stable')
+    version('master',  branch='master')
 
-    variant('mpi', default=True, description="Support MPI")
-    variant('ibv', default=False, description="Support InfiniBand")
-    variant('udp', default=False, description="Support UDP")
-    variant('aligned-segments', default=False,
-            description="Requirement to achieve aligned VM segments")
-    variant('pshm', default=True,
-            description="Support inter-process shared memory support")
-    variant('segment-mmap-max', default='16GB',
-            description="Upper bound for mmap-based GASNet segments")
+    version('2021.3.0',  sha256='8a40fb3fa8bacc3922cd4d45217816fcb60100357ab97fb622a245567ea31747')
+    version('2020.10.0', sha256='ed17baf7fce90499b539857ee37b3eea961aa475cffbde77e4c607a34ece06a0')
+    version('2020.3.0',  sha256='019eb2d2284856e6fabe6c8c0061c874f10e95fa0265245f227fd3497f1bb274')
+    version('2019.9.0',  sha256='117f5fdb16e53d0fa8a47a1e28cccab1d8020ed4f6e50163d985dc90226aaa2c')
+    # Do NOT add older versions here.
+    # GASNet-EX releases over 2 years old are not supported.
 
-    conflicts('+aligned-segments', when='+pshm')
+    # The optional network backends:
+    variant('smp', default=True, description="SMP conduit for single-node operation")
+    variant('mpi', default=False, description="Low-performance/portable MPI conduit")
+    variant('ibv', default=False, description="Native InfiniBand verbs conduit")
+    variant('udp', default=False, description="Portable UDP conduit, for Ethernet networks")
+
+    variant('debug', default=False, description="Enable library debugging mode")
 
     depends_on('mpi', when='+mpi')
 
-    def url_for_version(self, version):
-        url = "https://gasnet.lbl.gov/"
-        if version >= Version('2019'):
-            url += "EX/GASNet-{0}.tar.gz".format(version)
+    depends_on('autoconf@2.69', type='build', when='@master:')
+    depends_on('automake@1.16:', type='build', when='@master:')
+
+    def conduits(self):
+        return [c for c in ['smp', 'mpi', 'ibv', 'udp'] if "+" + c in self.spec]
+
+    def install(self, spec, prefix):
+        if spec.satisfies('@master:'):
+            bootstrapsh = Executable("./Bootstrap")
+            bootstrapsh()
+
+        # The GASNet-EX library has a highly multi-dimensional configure space,
+        # to accomodate the varying behavioral requirements of each client runtime.
+        # The library's ABI/link compatibility is strongly dependent on these
+        # client-specific build-time settings, and that variability is deliberately NOT
+        # encoded in the variants of this package. The recommended way to build/deploy
+        # GASNet is as an EMBEDDED library within the build of the client package
+        # (eg. Berkeley UPC, UPC++, Legion, etc), some of which provide build-time
+        # selection of the GASNet library sources. This spack package provides
+        # the GASNet-EX sources, for use by appropriate client packages.
+        install_tree('.', prefix + "/src")
+
+        # Library build is provided for unit-testing purposes only (see notice above)
+        if len(self.conduits()) > 0:
+            options = ["--prefix=%s" % prefix]
+
+            if '+debug' in spec:
+                options.append("--enable-debug")
+
+            if '+mpi' in spec:
+                options.append("--enable-mpi-compat")
+            else:
+                options.append("--disable-mpi-compat")
+
+            options.append("--disable-auto-conduit-detect")
+            for c in self.conduits():
+                options.append("--enable-" + c)
+
+            configure(*options)
+            make()
+            make('install')
+
+            for c in self.conduits():
+                testdir = join_path(prefix, 'tests', c)
+                mkdirp(testdir)
+                make('-C', c + '-conduit', 'testgasnet-par')
+                install(c + "-conduit/testgasnet", testdir)
+            make('-C', c + '-conduit', 'testtools-par')
+            install(c + "-conduit/testtools", join_path(prefix, 'tests'))
+
+    @run_after('install')
+    @on_package_attributes(run_tests=True)
+    def test_install(self):
+        if '+smp' in self.spec:
+            make('-C', 'smp-conduit', 'run-tests')
+        if len(self.conduits()) > 0:
+            self.run_test(join_path(prefix, 'tests', 'testtools'),
+                          expected=['Done.'], status=0,
+                          installed=True, purpose="Running testtools")
+
+    def test(self):
+        ranks = '4'
+        spawner = {
+            'smp': ['env', 'GASNET_PSHM_NODES=' + ranks],
+            'mpi': [join_path(self.prefix.bin, 'gasnetrun_mpi'), '-n', ranks],
+            'ibv': [join_path(self.prefix.bin, 'gasnetrun_ibv'), '-n', ranks],
+            'udp': [join_path(self.prefix.bin, 'amudprun'), '-spawn', 'L', '-np', ranks]
+        }
+
+        env['GASNET_VERBOSEENV'] = '1'  # include diagnostic info
+        if 'GASNET_SSH_SERVERS' not in env:
+            env['GASNET_SSH_SERVERS'] = "localhost " * 4
+
+        if len(self.conduits()) > 0:
+            self.run_test(join_path(prefix, 'tests', 'testtools'),
+                          expected=['Done.'], status=0,
+                          installed=True, purpose="Running testtools")
         else:
-            url += "download/GASNet-{0}.tar.gz".format(version)
+            spack.main.send_warning_to_tty("No conduit libraries built -- SKIPPED")
 
-        return url
-
-    def configure_args(self):
-        args = [
-            # TODO: factor IB suport out into architecture description.
-            '--enable-par',
-            '--enable-mpi-compat',
-            '--enable-segment-fast',
-            '--disable-parsync',
-            '--with-segment-mmap-max=%s '
-            % (self.spec.variants['segment-mmap-max'].value),
-            # for consumers with shared libs
-            "CC=%s %s" % (spack_cc, self.compiler.cc_pic_flag),
-            "CXX=%s %s" % (spack_cxx, self.compiler.cxx_pic_flag),
-        ]
-
-        if '+aligned-segments' in self.spec:
-            args.append('--enable-aligned-segments')
-        else:
-            args.append('--disable-aligned-segments')
-
-        if '+pshm' in self.spec:
-            args.append('--enable-pshm')
-        else:
-            args.append('--disable-pshm')
-
-        if '+mpi' in self.spec:
-            args.extend(['--enable-mpi',
-                         '--disable-udp',
-                         '--disable-ibv',
-                         '--disable-seq',
-                         'MPI_CC=%s %s'
-                        % (self.spec['mpi'].mpicc, self.compiler.cc_pic_flag)])
-
-        if '+ibv' in self.spec:
-            args.extend(['--enable-ibv',
-                         '--with-ibv-max-hcas=1',
-                         '--enable-pthreads',
-                         '--disable-udp',
-                         '--disable-mpi',
-                         '--disable-seq',
-                         '--disable-smp',
-                         '--disable-portals'])
-
-        if '+udp' in self.spec:
-            args.extend(['--enable-udp',
-                         '--disable-ibv',
-                         '--disable-mpi',
-                         '--disable-seq'])
-
-        return args
+        for c in self.conduits():
+            env['GASNET_SUPERNODE_MAXSIZE'] = '0' if (c == 'smp') else '1'
+            test = join_path(self.prefix, 'tests', c, 'testgasnet')
+            self.run_test(spawner[c][0], spawner[c][1:] + [test],
+                          expected=['done.'], status=0,
+                          installed=(c != 'smp'),
+                          purpose="Running %s-conduit/testgasnet" % c)

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -162,7 +162,7 @@ class Upcxx(Package):
             options = ["--prefix=%s" % prefix]
 
             if '+gasnet' in self.spec:
-                options.append('--with-gasnet=%s/src' % spec['gasnet'].prefix)
+                options.append('--with-gasnet=' + spec['gasnet'].prefix.src)
 
             configure(*options)
 

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -50,6 +50,13 @@ class Upcxx(Package):
               msg='cross=none is unacceptable on Cray.' +
                   'Please specify an appropriate "cross" value')
 
+    # UPC++ always relies on GASNet-EX.
+    # The default (and recommendation) is to use the implicit, embedded version.
+    # This variant allows overriding with a particular version of GASNet-EX sources.
+    variant('gasnet', default=False,
+            description="Override embedded GASNet-EX version")
+    depends_on('gasnet~smp', when='+gasnet')
+
     depends_on('mpi', when='+mpi')
     depends_on('cuda', when='+cuda')
     # Require Python2 2.7.5+ up to v2019.9.0
@@ -120,6 +127,8 @@ class Upcxx(Package):
                     env['CXX'] = spec['mpi'].mpicxx
             else:
                 env['CXX'] = self.compiler.cxx
+            if '+gasnet' in self.spec:
+                env['GASNET'] = join_path(spec['gasnet'].prefix, 'src')
             installsh = Executable("./install")
             installsh(prefix)
         else:
@@ -150,8 +159,12 @@ class Upcxx(Package):
             env['CC'] = real_cc
             env['CXX'] = real_cxx
 
-            installsh = Executable("./configure")
-            installsh('--prefix=' + prefix)
+            options = ["--prefix=%s" % prefix]
+
+            if '+gasnet' in self.spec:
+                options.append('--with-gasnet=%s/src' % spec['gasnet'].prefix)
+
+            configure(*options)
 
             make()
 

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -128,7 +128,7 @@ class Upcxx(Package):
             else:
                 env['CXX'] = self.compiler.cxx
             if '+gasnet' in self.spec:
-                env['GASNET'] = join_path(spec['gasnet'].prefix, 'src')
+                env['GASNET'] = spec['gasnet'].prefix.src
             installsh = Executable("./install")
             installsh(prefix)
         else:

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -55,7 +55,7 @@ class Upcxx(Package):
     # This variant allows overriding with a particular version of GASNet-EX sources.
     variant('gasnet', default=False,
             description="Override embedded GASNet-EX version")
-    depends_on('gasnet~smp', when='+gasnet')
+    depends_on('gasnet conduits=none', when='+gasnet')
 
     depends_on('mpi', when='+mpi')
     depends_on('cuda', when='+cuda')


### PR DESCRIPTION
The previous `gasnet` spack package was not vetted/approved by the
GASNet library maintainers. This one is.

Notably adds build-time testing and smoke-testing.