### PR TITLE
Allow for saving local results with spack monitor

### DIFF
--- a/lib/spack/docs/monitoring.rst
+++ b/lib/spack/docs/monitoring.rst
@@ -102,3 +102,19 @@ more tags to your build, you can do:
     # Add two tags, "pizza" and "pasta"
     $ spack install --monitor --monitor-tags pizza,pasta hdf5
 
+
+------------------
+Monitoring Offline
+------------------
+
+In the case that you want to save monitor results to your filesystem
+and then upload them later (perhaps you are in an environment where you don't
+have credentials or it isn't safe to use them) you can use the ``--monitor-save-local``
+flag.
+
+.. code-block:: console
+
+    $ spack install --monitor --monitor-save-local hdf5 
+
+This will save results in a subfolder, "monitor" in your designated spack
+reports folder, which defaults to ``$HOME/.spack/reports/monitor``.

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -306,6 +306,7 @@ environment variables:
             prefix=args.monitor_prefix,
             disable_auth=args.monitor_disable_auth,
             tags=args.monitor_tags,
+            save_local=args.monitor_save_local,
         )
 
     reporter = spack.report.collect_info(

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -54,7 +54,7 @@ user_config_path = os.path.expanduser('~/.spack')
 user_bootstrap_path = os.path.join(user_config_path, 'bootstrap')
 user_bootstrap_store = os.path.join(user_bootstrap_path, 'store')
 reports_path = os.path.join(user_config_path, "reports")
-
+monitor_path = os.path.join(reports_path, "monitor")
 
 opt_path        = os.path.join(prefix, "opt")
 etc_path        = os.path.join(prefix, "etc")

--- a/lib/spack/spack/test/monitor.py
+++ b/lib/spack/spack/test/monitor.py
@@ -1,0 +1,42 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack.config
+import spack.spec
+from spack.main import SpackCommand
+import pytest
+import os
+
+install = SpackCommand('install')
+
+
+@pytest.fixture(scope='session')
+def test_install_monitor_save_local(install_mockery_mutable_config,
+                                    mock_fetch, tmpdir_factory):
+    """
+    Mock installing and saving monitor results to file.
+    """
+    reports_dir = tmpdir_factory.mktemp('reports')
+    spack.config.set('config:monitor_dir', str(reports_dir))
+    out = install('--monitor', '--monitor-save-local', 'dttop')
+    assert "Successfully installed dttop" in out
+
+    # The reports directory should not be empty (timestamped folders)
+    assert os.listdir(str(reports_dir))
+
+    # Get the spec name
+    spec = spack.spec.Spec("dttop")
+    spec.concretize()
+    full_hash = spec.full_hash()
+
+    # Ensure we have monitor results saved
+    for dirname in os.listdir(str(reports_dir)):
+        dated_dir = os.path.join(str(reports_dir), dirname)
+        build_metadata = "build-metadata-%s.json" % full_hash
+        assert build_metadata in os.listdir(dated_dir)
+        spec_file = "spec-dttop-%s-config.json" % spec.version
+        assert spec_file in os.listdir(dated_dir)
+
+    spack.config.set('config:monitor_dir', "~/.spack/reports/monitor")

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -358,7 +358,7 @@ _spack_add() {
 _spack_analyze() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --monitor --monitor-no-auth --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix"
+        SPACK_COMPREPLY="-h --help --monitor --monitor-save-local --monitor-no-auth --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix"
     else
         SPACK_COMPREPLY="list-analyzers run"
     fi
@@ -1063,7 +1063,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-no-auth --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-save-local --monitor-no-auth --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
     else
         _all_packages
     fi


### PR DESCRIPTION
We would want to be able to run monitoring, and generate all metadata that can be updated to a monitor server later. This is the goal of this PR, and the work will come in two phases. The first here is to allow saving of a local result with spack monitor, and the second will add a spack monitor command so the user can do spack monitor upload. You would run like:

```bash
$ spack install --monitor --monitor-save-local zlib
```
And then upload later (probably with a little more granularity but the gist is:

```bash
$ spack monitor upload <some identifier>
```
I'm wondering what the best way is to organize these builds in .spack/reports/monitor. Right now I have based on timestamp, and we will only be able to tell if a result has already been uploaded by providing the server with the same information we use to generate a build id (e.g., look up a build) so arguably the user could just provide some match string of dates to upload, and we would check them all. E.g.,

```bash
$ spack monitor upload 2021-05-19
```
To upload all results from today. Here is an example save:

```
 tree /home/vanessa/.spack/reports/monitor/2021-05-19-18-40-58-1621471258/
/home/vanessa/.spack/reports/monitor/2021-05-19-18-40-58-1621471258/
├── build-a2f7cad8ba1c7c7242b8eca4700b62b8-phase-autoreconf.json
├── build-a2f7cad8ba1c7c7242b8eca4700b62b8-phase-build.json
├── build-a2f7cad8ba1c7c7242b8eca4700b62b8-phase-configure.json
├── build-a2f7cad8ba1c7c7242b8eca4700b62b8-phase-install.json
├── build-a2f7cad8ba1c7c7242b8eca4700b62b8-status.json
├── build-c400d10c94e88f8fbd92d0c858d1e0dd-phase-autoreconf.json
├── build-c400d10c94e88f8fbd92d0c858d1e0dd-phase-build.json
├── build-c400d10c94e88f8fbd92d0c858d1e0dd-phase-configure.json
├── build-c400d10c94e88f8fbd92d0c858d1e0dd-phase-install.json
├── build-c400d10c94e88f8fbd92d0c858d1e0dd-status.json
├── build-metadata-6p56pf7j6bgi36akjsiur53ynst3idun.json
├── build-metadata-mgdfbpj36meas7alzf7sgbsuntpid2ob.json
└── spec-rpm-4.16.1.2-config.json
```
The PR also adds a new flag to clean up reports as requested by @tgamblin.

```bash
$ spack clean --reports
```
cc @alecbcs

Signed-off-by: vsoch <vsoch@users.noreply.github.com>