### PR TITLE
py-awkward: add version 1.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/dlpack/package.py
+++ b/var/spack/repos/builtin/packages/dlpack/package.py
@@ -10,10 +10,16 @@ class Dlpack(Package):
     """DLPack is an RFC for common tensor and operator guidelines
     in deep learning systems."""
 
-    homepage = "https://github.com/sjtuhpcc/dlpack"
+    homepage = "https://github.com/dmlc/dlpack"
     git      = "https://github.com/dmlc/dlpack.git"
+    url      = "https://github.com/dmlc/dlpack/archive/refs/tags/v0.5.tar.gz"
 
     version('master', branch='master')
+    version('0.5', sha256='9209ac194a175aaab4381313891fba047cb173b2bdd15ac934f83f567f9cd514')
+    version('0.4', sha256='d0a533189ecd45a033b72e276fccaa2122cfd76de125e0a5e126bdea0fec2d24')
+    version('0.3', sha256='703149f5b39ead42cc734c03c7c4bd581fcad1c5a3939e7a4b5bc82f54c3c32a')
+    version('0.2', sha256='419f76ef723d21b72b704b2c4bf718dcd9d2ecd44cd28c8a71798389b7932ae5')
+    version('0.1', sha256='c69b06bfe03711e9d9d3f4d3f307d6dfd7e21d4864a053cca26296d5d05c175c')
 
     def install(self, spec, prefix):
         install_tree('include', prefix.include)

--- a/var/spack/repos/builtin/packages/py-awkward/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward/package.py
@@ -15,10 +15,12 @@ class PyAwkward(PythonPackage):
 
     maintainers = ['vvolkl']
 
+    version('1.2.3', sha256='7d727542927a926f488fa62d04e2c5728c72660f17f822e627f349285f295063')
     version('1.2.2', sha256='89f126a072d3a6eee091e1afeed87e0b2ed3c34ed31a1814062174de3cab8d9b')
     version('1.1.2', sha256='4ae8371d9e6d5bd3e90f3686b433cebc0541c88072655d2c75ec58e79b5d6943')
 
-    patch('pybind11.patch')
+    patch('pybind11.patch', when="@:1.2.2")
+    patch('pybind11_02.patch', when="@1.2.3:")
 
     depends_on('py-setuptools', type='build')
 

--- a/var/spack/repos/builtin/packages/py-awkward/pybind11_02.patch
+++ b/var/spack/repos/builtin/packages/py-awkward/pybind11_02.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ba2c37f..bd7f268 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -96,7 +96,7 @@ option(PYBUILD "Build Python modules")
+ 
+ # Third tier: Python modules.
+ if(PYBUILD)
+-  add_subdirectory(pybind11)
++  find_package(pybind11)
+ 
+   file(GLOB LAYOUT_SOURCES "src/python/*.cpp")
+   pybind11_add_module(_ext ${LAYOUT_SOURCES})
+

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -38,6 +38,7 @@ class PyPybind11(CMakePackage):
     version('2.1.0', sha256='2860f2b8d0c9f65f0698289a161385f59d099b7ead1bf64e8993c486f2b93ee0')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-pytest', type='test')
 
     extends('python')
 


### PR DESCRIPTION
... and fix some issues I noticed while doing a test build.

dlpack: was trying to install master even though released versions available, so I added those
py-pybind11: missing a test dependency (maintainer ping: @ax3l )