### PR TITLE
yoda: add version 1.9.0 and compiler conflict for earlier versions

### DIFF
--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -81,9 +81,9 @@ class Yoda(AutotoolsPackage):
     patch('yoda-1.6.6.patch', level=0, when='@1.6.6')
     patch('yoda-1.6.7.patch', level=0, when='@1.6.7')
 
-    conflicts("%gcc@10:", when="@:1.8.5", 
-              msg="yoda up to 1.8.5 is missing a <limits> header include in AnalysisObject.h."
-              "Use version 1.9.0 or later, or add a patch to earlier versions if needed.")
+    conflicts("%gcc@10:", when="@:1.8.5",
+              msg="yoda up to 1.8.5 is missing a <limits> include in AnalysisObject.h."
+              "Use version 1.9.0 or later, or patch earlier versions if needed.")
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -14,6 +14,7 @@ class Yoda(AutotoolsPackage):
 
     tags = ['hep']
 
+    version('1.9.0', sha256='9a55de12ffebbe41d1704459c5c9289eeaf0f0eb6a4d0104ea222d7ab889fdf4')
     version('1.8.5', sha256='4c2e6b8571fc176271515a309b45687a2981af1b07ff3f00d0b035a597aa32fd')
     version('1.8.4', sha256='9d24a41c9b7cc6eb14cab0a48f65d2fca7ec9d794afe0922ceb158d0153c150e')
     version('1.8.3', sha256='d9dd0ea5e0f630cdf4893c09a40c78bd44455777c2125385ecc26fa9a2acba8a')
@@ -79,6 +80,10 @@ class Yoda(AutotoolsPackage):
     patch('yoda-1.6.5.patch', level=0, when='@1.6.5')
     patch('yoda-1.6.6.patch', level=0, when='@1.6.6')
     patch('yoda-1.6.7.patch', level=0, when='@1.6.7')
+
+    conflicts("%gcc@10:", when="@:1.8.5", 
+              msg="yoda up to 1.8.5 is missing a <limits> header include in AnalysisObject.h."
+              "Use version 1.9.0 or later, or add a patch to earlier versions if needed.")
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
@alalazo this is also an example where the new concretizer fails to give a meaningful error message (although it switches to clang if available, which is great!)

old:
```
k4-arch-01: ~/spack (develop *)$ spack spec -I yoda@1.8.5%gcc@10.2.0
Input spec
--------------------------------
 -   yoda@1.8.5%gcc@10.2.0

Concretized
--------------------------------
==> Error: Conflicts in concretized spec "yoda@1.8.5%gcc@10.2.0~root arch=linux-archrolling-broadwell/6thpk3b"

List of matching conflicts for spec:

    yoda@1.8.5%gcc@10.2.0~root arch=linux-archrolling-broadwell
        ^py-cython@0.29.22%gcc@10.2.0 arch=linux-archrolling-broadwell
            ^py-setuptools@50.3.2%gcc@10.2.0 arch=linux-archrolling-broadwell
                ^python@3.9.5%gcc@10.2.0+bz2+ctypes+dbm~debug+libxml2+lzma+nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87 arch=linux-archrolling-broadwell
        ^py-future@0.18.2%gcc@10.2.0 arch=linux-archrolling-broadwell
        ^py-matplotlib@3.4.2%gcc@10.2.0~animation~fonts+image~latex~movies backend=agg arch=linux-archrolling-broadwell
            ^freetype@2.10.4%gcc@10.2.0 arch=linux-archrolling-broadwell
                ^bzip2@1.0.8%gcc@10.2.0~debug~pic+shared arch=linux-archrolling-broadwell
                ^libpng@1.6.37%gcc@10.2.0 arch=linux-archrolling-broadwell
                    ^zlib@1.2.11%gcc@10.2.0+optimize+pic+shared arch=linux-archrolling-broadwell
                ^pkgconf@1.7.4%gcc@10.2.0 arch=linux-archrolling-broadwell
            ^py-certifi@2020.6.20%gcc@10.2.0 arch=linux-archrolling-broadwell
            ^py-cycler@0.10.0%gcc@10.2.0 arch=linux-archrolling-broadwell
                ^py-six@1.15.0%gcc@10.2.0 arch=linux-archrolling-broadwell
            ^py-kiwisolver@1.1.0%gcc@10.2.0 arch=linux-archrolling-broadwell
            ^py-numpy@1.20.0%gcc@10.2.0+blas+lapack patches=873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604 arch=linux-archrolling-broadwell
            ^py-pillow@8.0.0%gcc@10.2.0~freetype~imagequant+jpeg~jpeg2000~lcms~tiff~webp~webpmux~xcb+zlib arch=linux-archrolling-broadwell
                ^libjpeg-turbo@2.0.6%gcc@10.2.0 arch=linux-archrolling-broadwell
                    ^cmake@3.20.2%gcc@10.2.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=linux-archrolling-broadwell
                    ^nasm@2.15.05%gcc@10.2.0 arch=linux-archrolling-broadwell
            ^py-pyparsing@2.4.7%gcc@10.2.0 arch=linux-archrolling-broadwell
            ^py-python-dateutil@2.8.1%gcc@10.2.0 arch=linux-archrolling-broadwell
                ^py-setuptools-scm@4.1.2%gcc@10.2.0~toml arch=linux-archrolling-broadwell
            ^qhull@2020.1%gcc@10.2.0~ipo build_type=RelWithDebInfo arch=linux-archrolling-broadwell

1. "%gcc@10:" conflicts with "yoda@:1.8.5" [yoda up to 1.8.5 is missing a <limits> header include in AnalysisObject.h.Use version 1.9.0 or later, or add a patch to earlier versions if needed.]
```

new:
```
... many lines
  version_satisfies("zlib","1.1.2:","1.2.8")
  version_satisfies("zlib","1.1.3:","1.2.11")
  version_satisfies("zlib","1.1.3:","1.2.3")
  version_satisfies("zlib","1.1.3:","1.2.8")
  version_satisfies("zlib","1.2.3:","1.2.11")
  version_satisfies("zlib","1.2.3:","1.2.3")
  version_satisfies("zlib","1.2.3:","1.2.8")
  version_satisfies("zlib","1.2.5:","1.2.11")
  version_satisfies("zlib","1.2.5:","1.2.8")
  virtual("awk")
  virtual("blas")
  virtual("gl")
  virtual("glu")
  virtual("iconv")
  virtual("java")
  virtual("jpeg")
  virtual("lapack")
  virtual("mpi")
  virtual("mysql-client")
  virtual("pil")
  virtual("pkgconfig")
  virtual("szip")
  virtual("tbb")
  virtual("uuid")
  virtual("yacc")
==> Error: yoda@1.8.5%gcc@10.2.0 does not satisfy unknown
```