### PR TITLE
spack: update archspec

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -11,7 +11,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.1.2 (commit a15485ab632478c15fadc65a00cd88b75ef7528a)
+* Version: 0.1.2 (commit 130607c373fd88cd3c43da94c0d3afd3a44084b0)
 
 argparse
 --------

--- a/lib/spack/external/archspec/cpu/detect.py
+++ b/lib/spack/external/archspec/cpu/detect.py
@@ -185,6 +185,11 @@ def compatible_microarchitectures(info):
         info (dict): dictionary containing information on the host cpu
     """
     architecture_family = platform.machine()
+    # On Apple M1 platform.machine() returns "arm64" instead of "aarch64"
+    # so we should normalize the name here
+    if architecture_family == "arm64":
+        architecture_family = "aarch64"
+
     # If a tester is not registered, be conservative and assume no known
     # target is compatible with the host
     tester = COMPATIBILITY_CHECKS.get(architecture_family, lambda x, y: False)

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -91,6 +91,166 @@
         ]
       }
     },
+    "x86_64_v2": {
+      "from": ["x86_64"],
+      "vendor": "generic",
+      "features": [
+        "cx16",
+        "lahf_lm",
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v2",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "4.6:11.0",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v2",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
+          }
+        ]
+      }
+    },
+    "x86_64_v3": {
+      "from": ["x86_64_v2"],
+      "vendor": "generic",
+      "features": [
+        "cx16",
+        "lahf_lm",
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "avx",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "f16c",
+        "fma",
+        "abm",
+        "movbe",
+        "xsave"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v3",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "4.8:11.0",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v3",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ]
+      }
+    },
+    "x86_64_v4": {
+      "from": ["x86_64_v3"],
+      "vendor": "generic",
+      "features": [
+        "cx16",
+        "lahf_lm",
+        "mmx",
+        "sse",
+        "sse2",
+        "ssse3",
+        "sse4_1",
+        "sse4_2",
+        "popcnt",
+        "avx",
+        "avx2",
+        "bmi1",
+        "bmi2",
+        "f16c",
+        "fma",
+        "abm",
+        "movbe",
+        "xsave",
+        "avx512f",
+        "avx512bw",
+        "avx512cd",
+        "avx512dq",
+        "avx512vl"
+      ],
+      "compilers": {
+        "gcc": [
+          {
+            "versions": "11.1:",
+            "name": "x86-64-v4",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "6.0:11.0",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ],
+        "clang": [
+          {
+            "versions": "12.0:",
+            "name": "x86-64-v4",
+            "flags": "-march={name} -mtune=generic"
+          },
+          {
+            "versions": "3.9:11.1",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ],
+        "apple-clang": [
+          {
+            "versions": "8.0:",
+            "name": "x86-64",
+            "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
+          }
+        ]
+      }
+    },
     "nocona": {
       "from": ["x86_64"],
       "vendor": "GenuineIntel",
@@ -177,7 +337,7 @@
       }
     },
     "nehalem": {
-      "from": ["core2"],
+      "from": ["core2", "x86_64_v2"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -394,7 +554,7 @@
       }
     },
     "haswell": {
-      "from": ["ivybridge"],
+      "from": ["ivybridge", "x86_64_v3"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -642,7 +802,7 @@
       }
     },
     "skylake_avx512": {
-      "from": ["skylake"],
+      "from": ["skylake", "x86_64_v4"],
       "vendor": "GenuineIntel",
       "features": [
         "mmx",
@@ -986,7 +1146,7 @@
       }
     },
     "bulldozer": {
-      "from": ["x86_64"],
+      "from": ["x86_64_v2"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -1145,7 +1305,7 @@
       }
     },
     "excavator": {
-      "from": ["steamroller"],
+      "from": ["steamroller", "x86_64_v3"],
       "vendor": "AuthenticAMD",
       "features": [
         "mmx",
@@ -1204,7 +1364,7 @@
       }
     },
     "zen": {
-      "from": ["x86_64"],
+      "from": ["x86_64_v3"],
       "vendor": "AuthenticAMD",
       "features": [
         "bmi1",


### PR DESCRIPTION
This fixes the detection of Apple M1 and adds virtual levels for x86_64 architectures