### PR TITLE
gpg: permit to specify the location of binaries

### DIFF
--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -278,7 +278,7 @@ class Executable(object):
 @system_path_filter
 def which_string(*args, **kwargs):
     """Like ``which()``, but return a string instead of an ``Executable``."""
-    path = kwargs.get('path', os.environ.get('PATH', ''))
+    path = kwargs.get('path') or os.environ.get('PATH', '')
     required = kwargs.get('required', False)
 
     if isinstance(path, string_types):

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -343,7 +343,10 @@ def _verify_exe_or_raise(exe):
 
 
 def _gpgconf():
-    exe = spack.util.executable.which('gpgconf', 'gpg2conf', 'gpgconf2')
+    exe = spack.util.executable.which(
+        'gpgconf', 'gpg2conf', 'gpgconf2',
+        path=os.environ.get('SPACK_GNUPGBIN')
+    )
     _verify_exe_or_raise(exe)
 
     # ensure that the gpgconf we found can run "gpgconf --create-socketdir"
@@ -357,7 +360,9 @@ def _gpgconf():
 
 
 def _gpg():
-    exe = spack.util.executable.which('gpg2', 'gpg')
+    exe = spack.util.executable.which(
+        'gpg2', 'gpg', path=os.environ.get('SPACK_GNUPGBIN')
+    )
     _verify_exe_or_raise(exe)
     return exe
 


### PR DESCRIPTION
fixes #23813

Modifications:
- [x] Allow `SPACK_GNUPGBIN` to specify the location of GnuPG binaries
- [ ] Add docs for the environment variable