### PR TITLE
tk: add new version, add macOS patch

### DIFF
--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -17,6 +17,7 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     homepage = "http://www.tcl.tk"
     sourceforge_mirror_path = "tcl/tk8.6.5-src.tar.gz"
 
+    version('8.6.11', sha256='5228a8187a7f70fa0791ef0f975270f068ba9557f57456f51eb02d9d4ea31282')
     version('8.6.10', sha256='63df418a859d0a463347f95ded5cd88a3dd3aaa1ceecaeee362194bc30f3e386')
     version('8.6.8',  sha256='49e7bca08dde95195a27f594f7c850b088be357a7c7096e44e1158c7a5fd7b33')
     version('8.6.6',  sha256='d62c371a71b4744ed830e3c21d27968c31dba74dd2c45f36b9b071e6d88eb19d')
@@ -37,6 +38,13 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     depends_on('libxscrnsaver', when='+xss')
 
     configure_directory = 'unix'
+
+    # https://core.tcl-lang.org/tk/tktview/3598664fffffffffffff
+    # https://core.tcl-lang.org/tk/info/8b679f597b1d17ad
+    # https://core.tcl-lang.org/tk/info/997b17c343444e48
+    patch('https://github.com/macports/macports-ports/blob/master/x11/tk/files/patch-unix-Makefile.in.diff',
+          sha256='54bba3d2b3550b7e2c636881c1a3acaf6e1eb743f314449a132864ff47fd0010',
+          level=0, when='@:8.6.11 platform=darwin')
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0. The patch I added fixes a bug in library linking (see below) and was just merged into tk.

### Before

```console
$ otool -L lib/libtk8.6.dylib 
lib/libtk8.6.dylib:
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/tk-8.6.11-idpaccz2phzi2jjaclr7maqhvd6b6dnb/lib:/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/tcl-8.6.11-n7nea33urrk25rkoqpsc2tdcgai5u4z2/lib:/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/libx11-1.7.0-vcsch4cw5xcbjepmtfhkto24me356zj5/lib/libtk8.6.dylib (compatibility version 8.6.0, current version 8.6.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1677.104.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/libx11-1.7.0-vcsch4cw5xcbjepmtfhkto24me356zj5/lib/libX11.6.dylib (compatibility version 11.0.0, current version 11.0.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/libxscrnsaver-1.2.2-pmikcsrah6qmsqa5ydwqse245byho3rb/lib/libXss.1.dylib (compatibility version 2.0.0, current version 2.0.0, weak)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/libxext-1.3.3-dpw3fi3s423crfns3ss37cbv66ledu2g/lib/libXext.6.dylib (compatibility version 11.0.0, current version 11.0.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/zlib-1.2.11-x2anksgssxsxa7pcnhzg5k3dhgacglze/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
```

### After
```console
$ otool -L lib/libtk8.6.dylib 
lib/libtk8.6.dylib:
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/tk-8.6.11-ydmhrbboheucxsuhrnyoxqaihgna5dfe/lib/libtk8.6.dylib (compatibility version 8.6.0, current version 8.6.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.100.1)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1677.104.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/libx11-1.7.0-vcsch4cw5xcbjepmtfhkto24me356zj5/lib/libX11.6.dylib (compatibility version 11.0.0, current version 11.0.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/libxscrnsaver-1.2.2-pmikcsrah6qmsqa5ydwqse245byho3rb/lib/libXss.1.dylib (compatibility version 2.0.0, current version 2.0.0, weak)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/libxext-1.3.3-dpw3fi3s423crfns3ss37cbv66ledu2g/lib/libXext.6.dylib (compatibility version 11.0.0, current version 11.0.0)
	/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/zlib-1.2.11-x2anksgssxsxa7pcnhzg5k3dhgacglze/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
```