### PR TITLE
upcxx: Install the example files

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -25,7 +25,7 @@ class Upcxx(Package):
     homepage = "https://upcxx.lbl.gov"
     maintainers = ['bonachea']
 
-    git = 'https://bonachea@bitbucket.org/berkeleylab/upcxx.git'
+    git = 'https://bitbucket.org/berkeleylab/upcxx.git'
     version('develop', branch='develop')
     version('master',  branch='master')
 
@@ -169,6 +169,8 @@ class Upcxx(Package):
             make()
 
             make('install')
+
+        install_tree('example', prefix.example)
 
     @run_after('install')
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
This installs the example source files into $prefix/example,
for use by the E4S Testsuite and other end users.

Also fix a harmless copy/paste error.