### PR TITLE
visit-cgns: better sets VISIT_PLUGIN_DIR to fit VisIt dir struct

### DIFF
--- a/var/spack/repos/builtin/packages/visit-cgns/package.py
+++ b/var/spack/repos/builtin/packages/visit-cgns/package.py
@@ -17,7 +17,7 @@ class VisitCgns(CMakePackage):
     # These settings are exactly those of VisIt
     homepage = "https://wci.llnl.gov/simulation/computer-codes/visit/"
     git      = "https://github.com/visit-dav/visit.git"
-    url = "https://github.com/visit-dav/visit/releases/download/v3.1.1/visit3.1.1.tar.gz"
+    url      = "https://github.com/visit-dav/visit/releases/download/v3.1.1/visit3.1.1.tar.gz"
 
     maintainers = ['cyrush', 'cessenat']
 
@@ -25,6 +25,7 @@ class VisitCgns(CMakePackage):
     version('local', url='file://{0}/visit-CGNS.tgz'.format(os.getcwd()))
     # Below we copy the VisIt paths:
     version('develop', branch='develop')
+    version('3.2.0', sha256='7328fd8592f9aaf17bf79ffcffd7eaec77773926b0843d9053f39c2190dbe1c0')
     version('3.1.4', sha256='be20d9acf56f0599e3c511709f48d8d3b232a57425f69d2bd1e2df1eccb84c93')
     version('3.1.1', sha256='0b60ac52fd00aff3cf212a310e36e32e13ae3ca0ddd1ea3f54f75e4d9b6c6cf0')
     version('3.0.1', sha256='a506d4d83b8973829e68787d8d721199523ce7ec73e7594e93333c214c2c12bd')
@@ -37,7 +38,7 @@ class VisitCgns(CMakePackage):
     version('2.10.1', sha256='6b53dea89a241fd03300a7a3a50c0f773e2fb8458cd3ad06816e9bd2f0337cd8')
 
     depends_on('cmake', type='build')
-    depends_on('cgns@3.3.1+int64~scoping~legacy', when='@2.10.1:3.1.14')
+    depends_on('cgns@3.3.1+int64~scoping~legacy', when='@2.10.1:3.1.4')
     depends_on('cgns+int64~scoping~legacy')
     depends_on('visit')
 
@@ -45,11 +46,12 @@ class VisitCgns(CMakePackage):
 
     build_targets = ['VERBOSE=1']
     phases = ['cmake', 'build']
+    extname = 'CGNS'
 
     @property
     def root_cmakelists_dir(self):
         if '@local' not in self.spec:
-            return join_path('src', 'databases', 'CGNS')
+            return join_path('src', 'databases', self.extname)
         else:
             return '.'
 
@@ -59,9 +61,8 @@ class VisitCgns(CMakePackage):
 
     @run_before('cmake')
     def run_xml2cmake(self):
-        spec = self.spec
-        visit = spec['visit']
-        args = ['-v', str(visit.version), '-clobber', '-public', 'CGNS.xml']
+        visit = self.spec['visit']
+        args = ['-v', str(visit.version), '-clobber', '-public', self.extname + '.xml']
         with working_dir(self.root_cmakelists_dir):
             # Regenerate the public cmake files
             if os.path.exists("CMakeLists.txt"):
@@ -70,22 +71,20 @@ class VisitCgns(CMakePackage):
             # spack extension activate : alter VISIT_PLUGIN_DIR ;
             # xml2cmake should have set it to visit prefix but it can
             # happen the directory is an alias.
-            f = 0
-            mstr = r'^SET[(]VISIT_PLUGIN_DIR\s+\"{0}(.+)\"[)]'.format(visit.prefix)
+            # In that case we match version/smth/plugins.
+            mstr = None
+            mstr1 = r'^SET[(]VISIT_PLUGIN_DIR\s+\"{0}(.+)\"[)]'.format(visit.prefix)
+            mstr2 = r'^SET[(]VISIT_PLUGIN_DIR\s+\".+({0}.+?{1})\"[)]'.format(
+                join_path(os.sep, visit.version, ''), join_path(os.sep, 'plugins'))
             with open('CMakeLists.txt', 'r') as file:
                 for line in file:
-                    if re.search(mstr, line):
-                        f = 1
-                    elif re.search(r'^SET\(VISIT_PLUGIN_DIR\s+\"(.+)\"\)', line):
-                        f = 2
-            cmf = FileFilter('CMakeLists.txt')
-            if f == 1:
-                cmf.filter(mstr, r'SET(VISIT_PLUGIN_DIR "{0}\1")'.format(prefix))
-            elif f == 2:
-                vis = join_path(prefix, spec.platform + '_'
-                                + str(spec.target.family), 'plugins')
-                cmf.filter(r'^SET\(VISIT_PLUGIN_DIR\s+\"(.+)\"\)',
-                           r'SET(VISIT_PLUGIN_DIR "{0}")'.format(vis))
+                    if re.search(mstr1, line):
+                        mstr = mstr1
+                    elif re.search(mstr2, line):
+                        mstr = mstr2
+            if mstr is not None:
+                filter_file(mstr, r'SET(VISIT_PLUGIN_DIR "{0}\1")'.format(prefix),
+                            'CMakeLists.txt')
 
     def cmake_args(self):
         cgns = self.spec['cgns']

--- a/var/spack/repos/builtin/packages/visit-cgns/package.py
+++ b/var/spack/repos/builtin/packages/visit-cgns/package.py
@@ -40,6 +40,7 @@ class VisitCgns(CMakePackage):
     depends_on('cmake', type='build')
     depends_on('cgns@3.3.1+int64~scoping~legacy', when='@2.10.1:3.1.4')
     depends_on('cgns+int64~scoping~legacy')
+    depends_on('visit@3.2.0:', when='@3.2.0:')
     depends_on('visit')
 
     extends('visit')


### PR DESCRIPTION
Improve the way we set the path for the VisIt plugin target directory : we do not assume knowing about the "platform" name VisIt uses. This can be useful since xml2cmake may not set the visit.prefix path as expected.
So now the setting of VISIT_PLUGIN_DIR should be coherent with VisIt, which is a condition for this package to properly extend visit.
Adds the version 3.2.0 of the plugin which works with the latest cgns lib (and with VisIt 3.2.0 at least).
