### PR TITLE
py-distributed: restrict py-contextvars dep to newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-distributed/package.py
+++ b/var/spack/repos/builtin/packages/py-distributed/package.py
@@ -24,7 +24,7 @@ class PyDistributed(PythonPackage):
     depends_on('py-cloudpickle@0.2.2:', type=('build', 'run'), when='@:2.16.0')
     depends_on('py-cloudpickle@1.3.0:', type=('build', 'run'), when='@2.17.0:2.20.0')
     depends_on('py-cloudpickle@1.5.0:', type=('build', 'run'), when='@2.21.0:')
-    depends_on('py-contextvars', type=('build', 'run'), when='^python@:3.6')
+    depends_on('py-contextvars', type=('build', 'run'), when='@2: ^python@:3.6')
     depends_on('py-msgpack', type=('build', 'run'), when='@:2.10.0')
     depends_on('py-msgpack@0.6.0:', type=('build', 'run'), when='@2.11.0:')
     depends_on('py-psutil@5.0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-distributed/package.py
+++ b/var/spack/repos/builtin/packages/py-distributed/package.py
@@ -24,7 +24,7 @@ class PyDistributed(PythonPackage):
     depends_on('py-cloudpickle@0.2.2:', type=('build', 'run'), when='@:2.16.0')
     depends_on('py-cloudpickle@1.3.0:', type=('build', 'run'), when='@2.17.0:2.20.0')
     depends_on('py-cloudpickle@1.5.0:', type=('build', 'run'), when='@2.21.0:')
-    depends_on('py-contextvars', type=('build', 'run'), when='@2: ^python@:3.6')
+    depends_on('py-contextvars', type=('build', 'run'), when='@2020: ^python@:3.6')
     depends_on('py-msgpack', type=('build', 'run'), when='@:2.10.0')
     depends_on('py-msgpack@0.6.0:', type=('build', 'run'), when='@2.11.0:')
     depends_on('py-psutil@5.0:', type=('build', 'run'))


### PR DESCRIPTION
Part of our recent merge and upstream effort.