### PR TITLE
py-lazy-object-proxy: add missing py-setuptools-scm dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-lazy-object-proxy/package.py
+++ b/var/spack/repos/builtin/packages/py-lazy-object-proxy/package.py
@@ -17,4 +17,5 @@ class PyLazyObjectProxy(PythonPackage):
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
+    depends_on('py-setuptools-scm@3.3.1:', type='build', when='@1.4.0:')
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Part of our recent merge and upstream effort.