### PR TITLE
intel-tbb: explicitly set OS var and pass to TBB

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -135,6 +135,11 @@ class IntelTbb(Package):
             name = '{0}'.format(version)
         return url.format(name)
 
+    # We set OS here in case the user has it set to something else
+    # that TBB doesn't expect.
+    def setup_build_environment(self, env):
+        env.set('OS', platform.system())
+
     def coerce_to_spack(self, tbb_build_subdir):
         for compiler in ["icc", "gcc", "clang"]:
             fs = glob.glob(join_path(tbb_build_subdir,


### PR DESCRIPTION
The common.inc script in TBB uses the environ var 'OS' to determine
the platform it's on.  On Linux, this is normally empty and TBB falls
back to uname.  But some systems set this to 'CentOS Linux 8' which is
descriptive, but not exactly what common.inc is looking for.

Instead, take the value from python and explicitly set OS to what TBB
expects to avoid this problem.

----------

I've built intel-tbb for 4 years without this problem until ONE system
actually sets OS to 'CentOS Linux 8'.  Blech  :-)
