### PR TITLE
Add xxd for hsa-rocr-dev build script

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -17,15 +17,16 @@ packages:
   all:
     compiler: [gcc, intel, pgi, clang, xl, nag, fj, aocc]
     providers:
-      D: [ldc]
       awk: [gawk]
       blas: [openblas, amdblis]
+      D: [ldc]
       daal: [intel-daal]
       elf: [elfutils]
       fftw-api: [fftw, amdfftw]
+      flame: [libflame, amdlibflame]
       gl: [mesa+opengl, mesa18, opengl]
-      glx: [mesa+glx, mesa18+glx, opengl]
       glu: [mesa-glu, openglu]
+      glx: [mesa+glx, mesa18+glx, opengl]
       golang: [gcc]
       iconv: [libiconv]
       ipp: [intel-ipp]
@@ -47,9 +48,8 @@ packages:
       szip: [libszip, libaec]
       tbb: [intel-tbb]
       unwind: [libunwind]
-      yacc: [bison, byacc]
-      flame: [libflame, amdlibflame]
       uuid: [util-linux-uuid, libuuid]
+      yacc: [bison, byacc]
       ziglang: [zig]
     permissions:
       read: world

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -49,6 +49,7 @@ packages:
       tbb: [intel-tbb]
       unwind: [libunwind]
       uuid: [util-linux-uuid, libuuid]
+      xxd: [xxd-standalone, vim]
       yacc: [bison, byacc]
       ziglang: [zig]
     permissions:

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -34,6 +34,7 @@ class HsaRocrDev(CMakePackage):
     variant('image', default=True, description='build with or without image support')
 
     depends_on('cmake@3:', type="build")
+    depends_on('xxd', when='@4.2:', type='build')
     depends_on('libelf@0.8:', type='link')
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -34,8 +34,9 @@ class HsaRocrDev(CMakePackage):
     variant('image', default=True, description='build with or without image support')
 
     depends_on('cmake@3:', type="build")
-    depends_on('xxd', when='@4.2:', type='build')
+    depends_on('xxd', when='@3.7: +image', type='build')
     depends_on('libelf@0.8:', type='link')
+
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
         depends_on('hsakmt-roct@' + ver, type=('link', 'run'), when='@' + ver)
@@ -52,12 +53,13 @@ class HsaRocrDev(CMakePackage):
 
     def cmake_args(self):
         libelf_include = self.spec['libelf'].prefix.include.libelf
-        args = ['-DLIBELF_INCLUDE_DIRS=%s' % libelf_include]
-
-        self.define_from_variant('BUILD_SHARED_LIBS', 'shared')
+        args = [
+            self.define('LIBELF_INCLUDE_DIRS', libelf_include),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')
+        ]
 
         if '@3.7.0:' in self.spec:
-            self.define_from_variant('IMAGE_SUPPORT', 'image')
+            args.append(self.define_from_variant('IMAGE_SUPPORT', 'image'))
 
         if '@4.2.0:' in self.spec:
             bitcode_dir = self.spec['rocm-device-libs'].prefix.amdgcn.bitcode

--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -49,6 +49,8 @@ class Vim(AutotoolsPackage):
     variant('cscope', default=False, description="build with cscope support")
     depends_on('cscope', when='+cscope', type='run')
 
+    provides('xxd')
+
     # TODO: Once better support for multi-valued variants is added, add
     # support for auto/no/gtk2/gnome2/gtk3/motif/athena/neXtaw/photon/carbon
     variant('gui', default=False, description="build with gui (gvim)")

--- a/var/spack/repos/builtin/packages/xxd-standalone/package.py
+++ b/var/spack/repos/builtin/packages/xxd-standalone/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import os
+
+
+class XxdStandalone(MakefilePackage):
+    """xxd creates a hex dump of a given file or standard input.
+    It is bundled with vim, but as xxd is used in build scripts,
+    it makes sense to have it available as a standalone package."""
+
+    homepage = "https://www.vim.org/"
+    url      = "https://github.com/vim/vim/archive/v8.2.1201.tar.gz"
+
+    maintainers = ['haampie']
+    build_targets = ['-C', os.path.join('src', 'xxd')]
+
+    version('8.2.1201', sha256='39032fe866f44724b104468038dc9ac4ff2c00a4b18c9a1e2c27064ab1f1143d')
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install(os.path.join(self.build_directory, 'src', 'xxd', 'xxd'), prefix.bin)

--- a/var/spack/repos/builtin/packages/xxd-standalone/package.py
+++ b/var/spack/repos/builtin/packages/xxd-standalone/package.py
@@ -18,6 +18,8 @@ class XxdStandalone(MakefilePackage):
     maintainers = ['haampie']
     build_targets = ['-C', os.path.join('src', 'xxd')]
 
+    provides('xxd')
+
     version('8.2.1201', sha256='39032fe866f44724b104468038dc9ac4ff2c00a4b18c9a1e2c27064ab1f1143d')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Vim provides xxd, and xxd is used as a build dep in hsa-rocr-dev which is part of the ROCm ecosystem. That currently fails to build for me because it's missing xxd.

It would be weird to add vim as a build dependency to hsa-rocr-dev, so I've made xxd-standalone a standalone provider for xxd, this is how it's done on in debian and the aur too.

- Add xxd standalone package
- Sort the providers by package name
- Add xxd providers
- Add xxd as a build tool for hsa-rocr-dev

