### PR TITLE
Fix makefile filter suggestions

### DIFF
--- a/lib/spack/docs/build_systems/makefilepackage.rst
+++ b/lib/spack/docs/build_systems/makefilepackage.rst
@@ -147,8 +147,10 @@ and a ``filter_file`` method to help with this. For example:
    def edit(self, spec, prefix):
        makefile = FileFilter('Makefile')
 
-       makefile.filter('CC = gcc',  'CC = cc')
-       makefile.filter('CXX = g++', 'CC = c++')
+       makefile.filter(r'^\s*CC\s*=.*',  'CC = '  + spack_cc)
+       makefile.filter(r'^\s*CXX\s*=.*', 'CXX = ' + spack_cxx)
+       makefile.filter(r'^\s*F77\s*=.*', 'F77 = ' + spack_f77)
+       makefile.filter(r'^\s*FC\s*=.*',  'FC = '  + spack_fc)
 
 
 `stream <https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/stream/package.py>`_

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -4800,10 +4800,10 @@ Filtering functions
 
      .. code-block:: python
 
-        filter_file(r'^CC\s*=.*',  spack_cc,  'Makefile')
-        filter_file(r'^CXX\s*=.*', spack_cxx, 'Makefile')
-        filter_file(r'^F77\s*=.*', spack_f77, 'Makefile')
-        filter_file(r'^FC\s*=.*',  spack_fc,  'Makefile')
+        filter_file(r'^\s*CC\s*=.*',  'CC = '  + spack_cc,  'Makefile')
+        filter_file(r'^\s*CXX\s*=.*', 'CXX = ' + spack_cxx, 'Makefile')
+        filter_file(r'^\s*F77\s*=.*', 'F77 = ' + spack_f77, 'Makefile')
+        filter_file(r'^\s*FC\s*=.*',  'FC = '  + spack_fc,  'Makefile')
 
   #. Replacing ``#!/usr/bin/perl`` with ``#!/usr/bin/env perl`` in ``bib2xhtml``:
 


### PR DESCRIPTION
Bash has a builtin `fc` that will override the compiler if you use "fc", so it's better to use the full spack-supplied compiler path.

Additionally, the filter regex in the docs was wrong: it replaced the entire assignment operation with the RHS.

See https://github.com/spack/spack/pull/23848#discussion_r637430286 for context.