### PR TITLE
Spack can Use RHEL8's `platform-python` if nothing else is available.

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -283,8 +283,6 @@ jobs:
           useradd spack-test
           chown -R spack-test .
     - name: Run unit tests
-      env:
-          SPACK_PYTHON: /usr/libexec/platform-python
       shell: runuser -u spack-test -- bash {0}
       run: |
           source share/spack/setup-env.sh

--- a/bin/spack
+++ b/bin/spack
@@ -11,7 +11,8 @@
 # See https://stackoverflow.com/a/47886254
 """:"
 # prefer SPACK_PYTHON environment variable, python3, python, then python2
-for cmd in "${SPACK_PYTHON:-}" python3 python python2; do
+SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
+for cmd in "${SPACK_PYTHON:-}" ${SPACK_PREFERRED_PYTHONS}; do
     if command -v > /dev/null "$cmd"; then
         export SPACK_PYTHON="$(command -v "$cmd")"
         exec "${SPACK_PYTHON}" "$0" "$@"


### PR DESCRIPTION
This adds RHEL8's `/usr/libexec/platform-python` to Spack's list of preferred pythons. It will only be used if no other `python` is available in the `PATH`.

We have been testing with this python for a while now, and it seems to do all that we need. If Spack one day isn't able to work with it, we'll take it out, but for now it is useful to allow Spack to be used on RHEL8 without a dedicated `python` installation.

- [x] add `platform-python` to list of pythons tried by `bin/spack`
- [x] don't set `SPACK_PYTHON` in the `platform-python` test anymore