### PR TITLE
Break llvm-amdgpu circular dependency with rocm-device-libs

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -50,10 +50,7 @@ packages:
       tbb: [intel-tbb]
       unwind: [libunwind]
       uuid: [util-linux-uuid, libuuid]
-<<<<<<< HEAD
       xxd: [xxd-standalone, vim]
-=======
->>>>>>> Sort the providers by package name
       yacc: [bison, byacc]
       ziglang: [zig]
     permissions:

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -50,7 +50,10 @@ packages:
       tbb: [intel-tbb]
       unwind: [libunwind]
       uuid: [util-linux-uuid, libuuid]
+<<<<<<< HEAD
       xxd: [xxd-standalone, vim]
+=======
+>>>>>>> Sort the providers by package name
       yacc: [bison, byacc]
       ziglang: [zig]
     permissions:

--- a/var/spack/repos/builtin/packages/aomp/package.py
+++ b/var/spack/repos/builtin/packages/aomp/package.py
@@ -119,20 +119,17 @@ class Aomp(Package):
     depends_on('libffi', type=('build', 'link'))
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0']:
-        depends_on('hsakmt-roct@' + ver, type=('build', 'run'), when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type=('build', 'run'),
-                   when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type=('build', 'run'),
-                   when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('rocm-device-libs@' + ver, when='@' + ver)
 
         if ver != '3.5.0':
-            depends_on('hip@' + ver, type=('build', 'run'), when='@' + ver)
-            depends_on('hip-rocclr@' + ver, type='build', when='@' + ver)
+            depends_on('hip@' + ver, when='@' + ver)
+            depends_on('hip-rocclr@' + ver, when='@' + ver)
 
         if ver == '3.9.0' or ver == '3.10.0':
-            depends_on('rocm-gdb@' + ver, type=('build', 'run'),
-                       when='@' + ver)
+            depends_on('rocm-gdb@' + ver, when='@' + ver)
 
         resource(
             name='rocm-device-libs',

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -15,7 +15,7 @@ class Comgr(CMakePackage):
     git      = "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport.git"
     url      = "https://github.com/RadeonOpenCompute/ROCm-CompilerSupport/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('master', branch='amd-stg-open')
 
@@ -43,8 +43,7 @@ class Comgr(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     root_cmakelists_dir = join_path('lib', 'comgr')

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -48,7 +48,7 @@ class Comgr(CMakePackage):
 
         # aomp may not build rocm-device-libs as part of llvm-amdgpu, so make
         # that a conditional dependency
-        depends_on('rocm-device-libs@' + ver, type='build', when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))
+        depends_on('rocm-device-libs@' + ver, when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     root_cmakelists_dir = join_path('lib', 'comgr')

--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -43,7 +43,12 @@ class Comgr(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
-        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
+        # llvm libs are linked statically, so this *could* be a build dep
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
+
+        # aomp may not build rocm-device-libs as part of llvm-amdgpu, so make
+        # that a conditional dependency
+        depends_on('rocm-device-libs@' + ver, type='build', when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     root_cmakelists_dir = join_path('lib', 'comgr')

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -43,9 +43,9 @@ class HipRocclr(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
-        depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
 
     # See: https://github.com/ROCm-Developer-Tools/ROCclr/pull/16
     # In 3.7.0 the find opengl things have changed slightly.

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -95,11 +95,11 @@ class Hip(CMakePackage):
                 'rocminfo': self.spec['rocminfo'].prefix,
             }
 
-        # `device_lib_path` is the path to the bitcode directory
+        # `device-lib-path` is the path to the bitcode directory
         if '@:3.8.0' in self.spec:
-            paths['device_lib_path'] = paths['llvm-amdgpu'].lib
+            paths['device-lib-path'] = paths['llvm-amdgpu'].lib
         else:
-            paths['device_lib_path'] = paths['llvm-amdgpu'].amdgcn.bitcode
+            paths['device-lib-path'] = paths['llvm-amdgpu'].amdgcn.bitcode
 
         return paths
 
@@ -134,11 +134,11 @@ class Hip(CMakePackage):
         env.set('ROCMINFO_PATH', paths['rocminfo'])
 
         # This one is used in hipcc to run `hipcc --hip-device-lib-path=...`
-        env.set('DEVICE_LIB_PATH', paths['device_lib_path'])
+        env.set('DEVICE_LIB_PATH', paths['device-lib-path'])
 
         # And this is used in clang whenever the --hip-device-lib-path is not
         # used (e.g. when clang is invoked directly)
-        env.set('HIP_DEVICE_LIB_PATH', paths['device_lib_path'])
+        env.set('HIP_DEVICE_LIB_PATH', paths['device-lib-path'])
 
         # Just the prefix of hip (used in hipcc)
         env.set('HIP_PATH', paths['rocm-path'])
@@ -161,6 +161,9 @@ class Hip(CMakePackage):
             env.append_path('HIPCC_COMPILE_FLAGS_APPEND',
                             '--rocm-path={0}'.format(paths['rocm-path']),
                             separator=' ')
+
+    def setup_build_environment(self, env):
+        self.set_variables(env)
 
     def setup_run_environment(self, env):
         self.set_variables(env)

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -17,7 +17,7 @@ class Hip(CMakePackage):
     git      = "https://github.com/ROCm-Developer-Tools/HIP.git"
     url      = "https://github.com/ROCm-Developer-Tools/HIP/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('4.2.0', sha256='ecb929e0fc2eaaf7bbd16a1446a876a15baf72419c723734f456ee62e70b4c24')
     version('4.1.0', sha256='e21c10b62868ece7aa3c8413ec0921245612d16d86d81fe61797bf9a64bc37eb')
@@ -38,8 +38,7 @@ class Hip(CMakePackage):
         depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
         depends_on('comgr@' + ver, type=('build', 'link', 'run'), when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type=('build', 'link', 'run'), when='@' + ver)
+        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
         depends_on('rocminfo@' + ver, type=('build', 'run'), when='@' + ver)
 
     # hipcc likes to add `-lnuma` by default :(
@@ -86,8 +85,7 @@ class Hip(CMakePackage):
                 'rocm-path': rocm_prefix,
                 'llvm-amdgpu': rocm_prefix.llvm,
                 'hsa-rocr-dev': rocm_prefix.hsa,
-                'rocminfo': rocm_prefix,
-                'rocm-device-libs': rocm_prefix,
+                'rocminfo': rocm_prefix
             }
         else:
             paths = {
@@ -95,14 +93,13 @@ class Hip(CMakePackage):
                 'llvm-amdgpu': self.spec['llvm-amdgpu'].prefix,
                 'hsa-rocr-dev': self.spec['hsa-rocr-dev'].prefix,
                 'rocminfo': self.spec['rocminfo'].prefix,
-                'rocm-device-libs': self.spec['rocm-device-libs'].prefix,
             }
 
         # `device_lib_path` is the path to the bitcode directory
         if '@:3.8.0' in self.spec:
-            paths['device_lib_path'] = paths['rocm-device-libs'].lib
+            paths['device_lib_path'] = paths['llvm-amdgpu'].lib
         else:
-            paths['device_lib_path'] = paths['rocm-device-libs'].amdgcn.bitcode
+            paths['device_lib_path'] = paths['llvm-amdgpu'].amdgcn.bitcode
 
         return paths
 

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -38,8 +38,7 @@ class Hip(CMakePackage):
         depends_on('hsakmt-roct@' + ver, when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))
+        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
         depends_on('rocminfo@' + ver, when='@' + ver)
 
     # hipcc likes to add `-lnuma` by default :(
@@ -95,13 +94,8 @@ class Hip(CMakePackage):
                 'llvm-amdgpu': self.spec['llvm-amdgpu'].prefix,
                 'hsa-rocr-dev': self.spec['hsa-rocr-dev'].prefix,
                 'rocminfo': self.spec['rocminfo'].prefix,
+                'rocm-device-libs': self.spec['llvm-amdgpu'].prefix
             }
-
-            # Allow bundled and standalone device libs
-            if '^rocm-device-libs' in self.spec:
-                paths['rocm-device-libs'] = self.spec['rocm-device-libs'].prefix
-            else:
-                paths['rocm-device-libs'] = self.spec['llvm-amdgpu'].prefix
 
         if '@:3.8.0' in self.spec:
             paths['bitcode'] = paths['rocm-device-libs'].lib

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -38,7 +38,7 @@ class Hip(CMakePackage):
         depends_on('hsakmt-roct@' + ver, when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), when='@' + ver)
         depends_on('rocminfo@' + ver, when='@' + ver)
 
     # hipcc likes to add `-lnuma` by default :(

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -23,29 +23,28 @@ class Hipblas(CMakePackage):
     version('3.7.0', sha256='9840a493ab4838c86696ceb33ce07c34b5f59f62db4f88cb3af62b69d84f8729')
     version('3.5.0', sha256='d451da80beb048767da71a090afceed2e111d01b3e95a7044deada5054d6e7b1')
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('rocsolver@' + ver, when='@' + ver)
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
 
     def cmake_args(self):
         args = [
-            '-DBUILD_CLIENTS_SAMPLES=OFF',
-            '-DBUILD_CLIENTS_TESTS=OFF'
+            self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
+            self.define('BUILD_CLIENTS_TESTS', 'OFF')
         ]
 
         # hipblas actually prefers CUDA over AMD GPUs when you have it
         # installed...
         if self.spec.satisfies('@:3.9.0'):
-            args.append('-DTRY_CUDA=OFF')
+            args.append(self.define('TRY_CUDA', 'OFF'))
 
         else:
-            args.append('-DUSE_CUDA=OFF')
+            args.append(self.define('USE_CUDA', 'OFF'))
 
         return args
 

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -28,7 +28,6 @@ class Hipblas(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocsolver@' + ver, when='@' + ver)
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -28,6 +28,7 @@ class Hipblas(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocsolver@' + ver, when='@' + ver)
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -32,7 +32,6 @@ class Hipcub(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -31,12 +31,11 @@ class Hipcub(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
-        depends_on('rocprim@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver, when='@' + ver)
+        depends_on('rocprim@' + ver, when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -32,7 +32,6 @@ class Hipcub(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)
@@ -43,10 +42,6 @@ class Hipcub(CMakePackage):
         env.set('CXX', self.spec['hip'].hipcc)
 
     def cmake_args(self):
-        spec = self.spec
-
-        args = [
-            '-DCMAKE_MODULE_PATH={0}/cmake'.format(spec['hip'].prefix)
+        return [
+            self.define('CMAKE_MODULE_PATH', self.spec['hip'].prefix.cmake)
         ]
-
-        return args

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -32,6 +32,7 @@ class Hipcub(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -32,10 +32,7 @@ class Hipsparse(CMakePackage):
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
         depends_on('rocsparse@' + ver,                when='@' + ver)
-        depends_on('comgr@' + ver,                    when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver,             when='@' + ver)
 
     for ver in ['3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
         depends_on('rocprim@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -30,18 +30,18 @@ class Hipsparse(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('rocsparse@' + ver, type='link', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
+        depends_on('hip@' + ver,                      when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
+        depends_on('rocsparse@' + ver,                when='@' + ver)
+        depends_on('comgr@' + ver,                    when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver,             when='@' + ver)
 
     for ver in ['3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
-        depends_on('rocprim@' + ver, type='link', when='@' + ver)
+        depends_on('rocprim@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     patch('e79985dccde22d826aceb3badfc643a3227979d2.patch', when='@3.5.0')
     patch('530047af4a0f437dafc02f76b3a17e3b1536c7ec.patch', when='@3.5.0')

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -14,7 +14,7 @@ class Hipsparse(CMakePackage):
     git      = "https://github.com/ROCmSoftwarePlatform/hipSPARSE.git"
     url      = "https://github.com/ROCmSoftwarePlatform/hipSPARSE/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('4.2.0', sha256='cdedf3766c10200d3ebabe86cbb9c0fe6504e4b3317dccca289327d7c189bb3f')
     version('4.1.0', sha256='66710c390489922f0bd1ac38fd8c32fcfb5b7760b92c2d282f7d1abf214742ee')
@@ -31,7 +31,6 @@ class Hipsparse(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('rocsparse@' + ver, type='link', when='@' + ver)
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
@@ -39,6 +38,7 @@ class Hipsparse(CMakePackage):
 
     for ver in ['3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
         depends_on('rocprim@' + ver, type='link', when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
@@ -46,12 +46,11 @@ class Hipsparse(CMakePackage):
     patch('530047af4a0f437dafc02f76b3a17e3b1536c7ec.patch', when='@3.5.0')
 
     def cmake_args(self):
-        args = [
-            '-DCMAKE_CXX_STANDARD=14',
-            '-DBUILD_CLIENTS_SAMPLES=OFF',
-            '-DBUILD_CLIENTS_TESTS=OFF',
+        return [
+            self.define('CMAKE_CXX_STANDARD', '14'),
+            self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
+            self.define('BUILD_CLIENTS_TESTS', 'OFF'),
         ]
-        return args
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -30,9 +30,10 @@ class Hipsparse(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
+        depends_on('hip@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('rocsparse@' + ver, type='link', when='@' + ver)
-        depends_on('hip@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -59,7 +59,7 @@ class HsaRocrDev(CMakePackage):
             args.append(self.define_from_variant('IMAGE_SUPPORT', 'image'))
 
         if '@4.2.0:' in self.spec:
-            bitcode_dir = self.spec['rocm-device-libs'].prefix.amdgcn.bitcode
+            bitcode_dir = self.spec['llvm-amdgpu'].prefix.amdgcn.bitcode
             args.append(self.define('BITCODE_DIR', bitcode_dir))
 
         return args

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -34,7 +34,10 @@ class HsaRocrDev(CMakePackage):
     variant('image', default=True, description='build with or without image support')
 
     depends_on('cmake@3:', type="build")
-    depends_on('xxd', when='@3.7: +image', type='build')
+
+    # Note, technically only necessary when='@3.7: +image', but added to all
+    # to work around https://github.com/spack/spack/issues/23951
+    depends_on('xxd', when='+image', type='build')
     depends_on('libelf@0.8:', type='link')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -54,17 +54,24 @@ class HsaRocrDev(CMakePackage):
     root_cmakelists_dir = 'src'
 
     def cmake_args(self):
-        libelf_include = self.spec['libelf'].prefix.include.libelf
+        spec = self.spec
+
+        libelf_include = spec['libelf'].prefix.include.libelf
         args = [
             self.define('LIBELF_INCLUDE_DIRS', libelf_include),
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared')
         ]
 
-        if '@3.7.0:' in self.spec:
+        if '@3.7.0:' in spec:
             args.append(self.define_from_variant('IMAGE_SUPPORT', 'image'))
 
-        if '@4.2.0:' in self.spec:
-            bitcode_dir = self.spec['llvm-amdgpu'].prefix.amdgcn.bitcode
+        if '@4.2.0:' in spec:
+            # device libs is bundled with llvm-amdgpu (default) or standalone
+            if '^rocm-device-libs' in spec:
+                bitcode_dir = spec['rocm-device-libs'].prefix.amdgcn.bitcode
+            else:
+                bitcode_dir = spec['llvm-amdgpu'].prefix.amdgcn.bitcode
+
             args.append(self.define('BITCODE_DIR', bitcode_dir))
 
         return args

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -39,8 +39,10 @@ class HsaRocrDev(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
-        depends_on('hsakmt-roct@' + ver, type=('link', 'run'), when='@' + ver)
-        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type=('link', 'run'), when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
+        # allow standalone rocm-device-libs (useful for aomp)
+        depends_on('rocm-device-libs@' + ver, when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))
 
     # Both 3.5.0 and 3.7.0 force INSTALL_RPATH in different ways
     patch('0001-Do-not-set-an-explicit-rpath-by-default-since-packag.patch', when='@3.5.0')

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -65,7 +65,6 @@ class HsaRocrDev(CMakePackage):
         if '@3.7.0:' in spec:
             args.append(self.define_from_variant('IMAGE_SUPPORT', 'image'))
 
-        if '@4.2.0:' in spec:
             # device libs is bundled with llvm-amdgpu (default) or standalone
             if '^rocm-device-libs' in spec:
                 bitcode_dir = spec['rocm-device-libs'].prefix.amdgcn.bitcode

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -17,7 +17,7 @@ class HsaRocrDev(CMakePackage):
     git      = "https://github.com/RadeonOpenCompute/ROCR-Runtime.git"
     url      = "https://github.com/RadeonOpenCompute/ROCR-Runtime/archive/rocm-4.1.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('master', branch='master')
     version('4.2.0', sha256='fa0e7bcd64e97cbff7c39c9e87c84a49d2184dc977b341794770805ec3f896cc')
@@ -40,10 +40,7 @@ class HsaRocrDev(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
         depends_on('hsakmt-roct@' + ver, type=('link', 'run'), when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type=('build', 'link'), when='@' + ver)
-
-    for ver in ['3.7.0', '3.8.0', '3.9.0', '4.0.0', '4.1.0', '4.2.0', 'master']:
-        depends_on('llvm-amdgpu@' + ver, type=('link', 'run'), when='@' + ver)
+        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type=('link', 'run'), when='@' + ver)
 
     # Both 3.5.0 and 3.7.0 force INSTALL_RPATH in different ways
     patch('0001-Do-not-set-an-explicit-rpath-by-default-since-packag.patch', when='@3.5.0')
@@ -63,6 +60,6 @@ class HsaRocrDev(CMakePackage):
 
         if '@4.2.0:' in self.spec:
             bitcode_dir = self.spec['rocm-device-libs'].prefix.amdgcn.bitcode
-            args.append('-DBITCODE_DIR={0}'.format(bitcode_dir))
+            args.append(self.define('BITCODE_DIR', bitcode_dir))
 
         return args

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -75,6 +75,13 @@ class LlvmAmdgpu(CMakePackage):
             when='@{0} +rocm-device-libs'.format(d_version)
         )
 
+    resource(
+        name='rocm-device-libs',
+        placement='rocm-device-libs',
+        git='https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git',
+        when='@master +rocm-device-libs'
+    )
+
     def cmake_args(self):
         llvm_projects = [
             'clang',

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -79,6 +79,7 @@ class LlvmAmdgpu(CMakePackage):
         name='rocm-device-libs',
         placement='rocm-device-libs',
         git='https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git',
+        branch='amd-stg-open',
         when='@master +rocm-device-libs'
     )
 

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+import os
 
 
 class LlvmAmdgpu(CMakePackage):
@@ -15,7 +16,7 @@ class LlvmAmdgpu(CMakePackage):
     git      = "https://github.com/RadeonOpenCompute/llvm-project.git"
     url      = "https://github.com/RadeonOpenCompute/llvm-project/archive/rocm-4.1.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('master', branch='amd-stg-open')
     version('4.2.0', sha256='751eca1d18595b565cfafa01c3cb43efb9107874865a60c80d6760ba83edb661')
@@ -28,7 +29,7 @@ class LlvmAmdgpu(CMakePackage):
     version('3.5.0', sha256='4878fa85473b24d88edcc89938441edc85d2e8a785e567b7bd7ce274ecc2fd9c')
 
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
-
+    variant('rocm-device-libs', default=True, description='Build ROCm device libs as external LLVM project instead of a standalone spack package.')
     variant('openmp', default=True, description='Enable OpenMP')
 
     depends_on('cmake@3.4.3:',  type='build', when='@:3.8.99')
@@ -37,6 +38,7 @@ class LlvmAmdgpu(CMakePackage):
     depends_on('z3', type='link')
     depends_on('zlib', type='link')
     depends_on('ncurses+termlib', type='link')
+
     # openmp dependencies
     depends_on("perl-data-dumper", type=("build"), when='+openmp')
     depends_on("hwloc", when='+openmp')
@@ -52,8 +54,26 @@ class LlvmAmdgpu(CMakePackage):
     conflicts('^cmake@3.19.0')
 
     root_cmakelists_dir = 'llvm'
-
     install_targets = ['clang-tidy', 'install']
+
+    # Add device libs sources so they can be an external LLVM project
+    for d_version, d_shasum in [
+        ('4.2.0',  '34a2ac39b9bb7cfa8175cbab05d30e7f3c06aaffce99eed5f79c616d0f910f5f'),
+        ('4.1.0',  'f5f5aa6bfbd83ff80a968fa332f80220256447c4ccb71c36f1fbd2b4a8e9fc1b'),
+        ('4.0.0',  'd0aa495f9b63f6d8cf8ac668f4dc61831d996e9ae3f15280052a37b9d7670d2a'),
+        ('3.10.0', 'bca9291385d6bdc91a8b39a46f0fd816157d38abb1725ff5222e6a0daa0834cc'),
+        ('3.9.0',  'c99f45dacf5967aef9a31e3731011b9c142446d4a12bac69774998976f2576d7'),
+        ('3.8.0',  'e82cc9a8eb7d92de02cabb856583e28f17a05c8cf9c97aec5275608ef1a38574'),
+        ('3.7.0',  'b3a114180bf184b3b829c356067bc6a98021d52c1c6f9db6bc57272ebafc5f1d'),
+        ('3.5.0',  'dce3a4ba672c4a2da4c2260ee4dc96ff6dd51877f5e7e1993cb107372a35a378')
+    ]:
+        resource(
+            name='rocm-device-libs',
+            placement='rocm-device-libs',
+            url='https://github.com/RadeonOpenCompute/ROCm-Device-Libs/archive/rocm-{0}.tar.gz'.format(d_version),
+            sha256=d_shasum,
+            when='@{0} +rocm-device-libs'.format(d_version)
+        )
 
     def cmake_args(self):
         llvm_projects = [
@@ -67,10 +87,18 @@ class LlvmAmdgpu(CMakePackage):
             llvm_projects.append('openmp')
 
         args = [
-            '-DLLVM_ENABLE_PROJECTS={0}'.format(';'.join(llvm_projects)),
-            '-DLLVM_ENABLE_ASSERTIONS=1'
+            self.define('LLVM_ENABLE_PROJECTS', ';'.join(llvm_projects))
         ]
 
+        # Enable rocm-device-libs as a external project
+        if '+rocm-device-libs' in self.spec:
+            dir = os.path.join(self.stage.source_path, 'rocm-device-libs')
+            args.extend([
+                self.define('LLVM_EXTERNAL_PROJECTS', 'device-libs'),
+                self.define('LLVM_EXTERNAL_DEVICE_LIBS_SOURCE_DIR', dir)
+            ])
+
+        # Get the GCC prefix for LLVM.
         if self.compiler.name == "gcc":
             compiler = Executable(self.compiler.cc)
             gcc_output = compiler('-print-search-dirs', output=str, error=str)
@@ -83,6 +111,6 @@ class LlvmAmdgpu(CMakePackage):
                     gcc_prefix = line.split(":")[1].strip()
                     gcc_prefix = ancestor(gcc_prefix, 4)
                     break
-            args.append("-DGCC_INSTALL_PREFIX=" + gcc_prefix)
+            args.append(self.define('GCC_INSTALL_PREFIX', gcc_prefix))
 
         return args

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -48,11 +48,11 @@ class Migraphx(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        depends_on('rocblas@' + ver, type='link', when='@' + ver)
-        depends_on('miopen-hip@' + ver, type='link', when='@' + ver)
+        depends_on('hip@' + ver,                      when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
+        depends_on('rocblas@' + ver,                  when='@' + ver)
+        depends_on('miopen-hip@' + ver,               when='@' + ver)
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -41,8 +41,6 @@ class MiopenHip(CMakePackage):
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
-        depends_on('comgr@' + ver,                    when='@' + ver)
         depends_on('rocm-clang-ocl@' + ver,           when='@' + ver)
         depends_on('rocblas@' + ver,                  when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -40,11 +40,9 @@ class MiopenHip(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
-        # support both builtin and standalone device libs
-        depends_on('rocm-device-libs@' + ver, when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))
         depends_on('rocm-clang-ocl@' + ver, when='@' + ver)
         depends_on('rocblas@' + ver, when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -56,17 +56,11 @@ class MiopenHip(CMakePackage):
     def get_bitcode_dir(self):
         spec = self.spec
 
-        # device libs is bundled with llvm-amdgpu (default) or standalone
-        if '^rocm-device-libs' in spec:
-            bitcode_prefix = spec['rocm-device-libs'].prefix
-        else:
-            bitcode_prefix = spec['llvm-amdgpu'].prefix
-
         # and the exact location of its bitcode depends on the version
         if spec.version >= Version('3.9.0'):
-            return bitcode_prefix.amdgcn.bitcode
+            return spec['llvm-amdgpu'].prefix.amdgcn.bitcode
         else:
-            return bitcode_prefix.lib
+            return spec['llvm-amdgpu'].prefix.lib
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -39,12 +39,12 @@ class MiopenHip(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-cmake@' + ver, when='@' + ver)
-        depends_on('comgr@' + ver, when='@' + ver)
-        depends_on('rocm-clang-ocl@' + ver, when='@' + ver)
-        depends_on('rocblas@' + ver, when='@' + ver)
+        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                      when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
+        depends_on('comgr@' + ver,                    when='@' + ver)
+        depends_on('rocm-clang-ocl@' + ver,           when='@' + ver)
+        depends_on('rocblas@' + ver,                  when='@' + ver)
 
     def setup_build_environment(self, env):
         if '@3.9.0:' in self.spec:

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -28,42 +28,57 @@ class MiopenHip(CMakePackage):
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
-    depends_on('boost@1.67.0:1.73.0', type='link')
     depends_on('pkgconfig', type='build')
-    depends_on('bzip2', type='link')
-    depends_on('sqlite', type='link')
-    depends_on('half', type='build')
-    depends_on('zlib', type='link', when='@3.9.0:')
+    depends_on('boost@1.67.0:1.73.0')
+    depends_on('bzip2')
+    depends_on('sqlite')
+    depends_on('half')
+    depends_on('zlib', when='@3.9.0:')
 
     patch('0001-Add-rocm-path-and-rocm-device-lib-path-flags.patch', when='@3.9.0:')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='link', when='@' + ver)
-        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
-        depends_on('rocm-clang-ocl@' + ver, type='build', when='@' + ver)
-        depends_on('rocblas@' + ver, type='link', when='@' + ver)
+        depends_on('hip@' + ver, when='@' + ver)
+        depends_on('rocm-cmake@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
+        # support both builtin and standalone device libs
+        depends_on('rocm-device-libs@' + ver, when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))
+        depends_on('rocm-clang-ocl@' + ver, when='@' + ver)
+        depends_on('rocblas@' + ver, when='@' + ver)
 
     def setup_build_environment(self, env):
         if '@3.9.0:' in self.spec:
             lib_dir = self.spec['zlib'].libs.directories[0]
             env.prepend_path('LIBRARY_PATH', lib_dir)
 
-    def cmake_args(self):
-        if self.spec.version >= Version('3.9.0'):
-            bitcode_dir = self.spec['llvm-amdgpu'].prefix.amdgcn.bitcode
+    def get_bitcode_dir(self):
+        spec = self.spec
+
+        # device libs is bundled with llvm-amdgpu (default) or standalone
+        if '^rocm-device-libs' in spec:
+            bitcode_prefix = spec['rocm-device-libs'].prefix
         else:
-            bitcode_dir = self.spec['llvm-amdgpu'].prefix.lib
+            bitcode_prefix = spec['llvm-amdgpu'].prefix
+
+        # and the exact location of its bitcode depends on the version
+        if spec.version >= Version('3.9.0'):
+            return bitcode_prefix.amdgcn.bitcode
+        else:
+            return bitcode_prefix.lib
+
+    def cmake_args(self):
+        spec = self.spec
+
         args = [
             self.define('MIOPEN_BACKEND', 'HIP'),
             self.define(
                 'CMAKE_CXX_COMPILER',
-                '{0}/bin/clang++'.format(self.spec['llvm-amdgpu'].prefix)
+                '{0}/bin/clang++'.format(spec['llvm-amdgpu'].prefix)
             ),
             self.define('Boost_USE_STATIC_LIBS', 'Off'),
-            self.define('HIP_PREFIX_PATH', self.spec['hip'].prefix),
-            self.define('DEVICELIBS_PREFIX_PATH', bitcode_dir)
+            self.define('HIP_PREFIX_PATH', spec['hip'].prefix),
+            self.define('DEVICELIBS_PREFIX_PATH', self.get_bitcode_dir())
         ]
         return args

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -40,7 +40,7 @@ class MiopenOpencl(CMakePackage):
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='link', when='@' + ver)
-        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-opencl@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -40,23 +40,28 @@ class MiopenOpencl(CMakePackage):
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='link', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
         depends_on('rocm-opencl@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='link', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
+
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('miopengemm@' + ver, type='link', when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
     def cmake_args(self):
         args = [
-            '-DMIOPEN_BACKEND=OpenCL',
-            '-DMIOPEN_HIP_COMPILER={0}/bin/clang++'
-            .format(self.spec['llvm-amdgpu'].prefix),
-            '-DHIP_CXX_COMPILER={0}/bin/clang++'
-            .format(self.spec['llvm-amdgpu'].prefix),
-            '-DBoost_USE_STATIC_LIBS=Off'
+            self.define('MIOPEN_BACKEND', 'OpenCL'),
+            self.define(
+                'MIOPEN_HIP_COMPILER',
+                '{0}/bin/clang++'.format(self.spec['llvm-amdgpu'].prefix)
+            ),
+            self.define(
+                'HIP_CXX_COMPILER',
+                '{0}/bin/clang++'.format(self.spec['llvm-amdgpu'].prefix)
+            ),
+            self.define('Boost_USE_STATIC_LIBS', 'Off')
         ]
         return args

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -40,7 +40,7 @@ class MiopenOpencl(CMakePackage):
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver,                      when='@' + ver)
         depends_on('rocm-opencl@' + ver,              when='@' + ver)
-        
+
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('miopengemm@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -38,9 +38,9 @@ class MiopenOpencl(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='link', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-opencl@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -37,19 +37,19 @@ class MiopenOpencl(CMakePackage):
     depends_on('miopengemm@1.1.6', type='link', when='@3.5.0')
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='link', when='@' + ver)
-        depends_on('rocm-opencl@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
+        depends_on('hip@' + ver,                      when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
+        depends_on('comgr@' + ver,                    when='@' + ver)
+        depends_on('rocm-opencl@' + ver,              when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver,             when='@' + ver)
 
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('miopengemm@' + ver, type='link', when='@' + ver)
+        depends_on('miopengemm@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -39,11 +39,8 @@ class MiopenOpencl(CMakePackage):
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
-        depends_on('comgr@' + ver,                    when='@' + ver)
         depends_on('rocm-opencl@' + ver,              when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver,             when='@' + ver)
-
+        
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('miopengemm@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/miopengemm/package.py
+++ b/var/spack/repos/builtin/packages/miopengemm/package.py
@@ -35,9 +35,9 @@ class Miopengemm(CMakePackage):
 
     depends_on('cmake@3:', type='build')
     depends_on('rocm-cmake@3.5.0', type='build', when='@1.1.6')
-    depends_on('rocm-opencl@3.5.0', type='build', when='@1.1.6')
+    depends_on('rocm-opencl@3.5.0',              when='@1.1.6')
 
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-opencl@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-opencl@' + ver,              when='@' + ver)

--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -67,6 +67,6 @@ class Mivisionx(CMakePackage):
         spec = self.spec
         protobuf = spec['protobuf'].prefix.include
         args = [
-            '-DCMAKE_CXX_FLAGS:String=-I{0}'.format(protobuf)
+            self.define('CMAKE_CXX_FLAGS', '-I{0}'.format(protobuf))
         ]
         return args

--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -53,15 +53,16 @@ class Mivisionx(CMakePackage):
     depends_on('ffmpeg@:4', type='build')
     depends_on('protobuf@:3', type='build')
     depends_on('opencv@:3.4 +calib3d+core+features2d+highgui+imgcodecs+imgproc+video+videoio+flann+photo+objdetect', type='build')
-    depends_on('rocm-opencl@3.5.0', type='build', when='@1.7')
+    depends_on('rocm-opencl@3.5.0', when='@1.7')
     depends_on('rocm-cmake@3.5.0', type='build', when='@1.7')
-    depends_on('miopen-opencl@3.5.0', type=('build', 'run', 'link'), when='@1.7')
-    depends_on('miopengemm@1.1.6', type=('build', 'run', 'link'), when='@1.7')
-    depends_on('openssl', type=('build', 'link'), when='@4.0.0:4.2.0')
+    depends_on('miopen-opencl@3.5.0', when='@1.7')
+    depends_on('miopengemm@1.1.6', when='@1.7')
+    depends_on('openssl', when='@4.0.0:4.2.0')
+
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
-        depends_on('rocm-opencl@' + ver, type='build', when='@' + ver)
-        depends_on('miopengemm@' + ver, type=('build', 'run', 'link'), when='@' + ver)
-        depends_on('miopen-opencl@' + ver, type=('build', 'link'), when='@' + ver)
+        depends_on('rocm-opencl@' + ver,   when='@' + ver)
+        depends_on('miopengemm@' + ver,    when='@' + ver)
+        depends_on('miopen-opencl@' + ver, when='@' + ver)
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -34,11 +34,12 @@ class Rccl(CMakePackage):
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, type=('build', 'run'), when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type=('build', 'run'), when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
+
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
         depends_on('numactl@2:', type=('build', 'link'), when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
@@ -48,6 +49,8 @@ class Rccl(CMakePackage):
     def cmake_args(self):
         args = []
         if '@3.7.0:' in self.spec:
-            numactl_prefix = self.spec['numactl'].prefix
-            args.append('-DNUMACTL_DIR={0}'.format(numactl_prefix))
+            args.append(self.define(
+                'NUMACTL_DIR',
+                self.spec['numactl'].prefix
+            ))
         return args

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -32,16 +32,16 @@ class Rccl(CMakePackage):
     depends_on('cmake@3:', type='build')
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('hip@' + ver, type=('build', 'run'), when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@' + ver,   type='build', when='@' + ver)
+        depends_on('hip@' + ver,                        when='@' + ver)
+        depends_on('comgr@' + ver,                      when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver,               when='@' + ver)
 
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
-        depends_on('numactl@2:', type=('build', 'link'), when='@' + ver)
+        depends_on('numactl@2:', when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -34,11 +34,11 @@ class Rocalution(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocblas@' + ver, when='@' + ver)
         depends_on('rocprim@' + ver, when='@' + ver)
         depends_on('rocsparse@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
 
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
         depends_on('rocrand@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -37,9 +37,8 @@ class Rocalution(CMakePackage):
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
         depends_on('rocprim@' + ver, type='link', when='@' + ver)
         depends_on('rocsparse@' + ver, type='link', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
 
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
         depends_on('rocrand@' + ver, type='link', when='@' + ver)
@@ -63,9 +62,8 @@ class Rocalution(CMakePackage):
                 filter_file(match, substitute, *files, **kwargs)
 
     def cmake_args(self):
-        args = [
-            '-DSUPPORT_HIP=ON',
-            '-DSUPPORT_MPI=OFF',
-            '-DBUILD_CLIENTS_SAMPLES=OFF'
+        return [
+            self.define('SUPPORT_HIP', 'ON'),
+            self.define('SUPPORT_MPI', 'OFF'),
+            self.define('BUILD_CLIENTS_SAMPLES', 'OFF')
         ]
-        return args

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -34,11 +34,11 @@ class Rocalution(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocblas@' + ver, when='@' + ver)
         depends_on('rocprim@' + ver, when='@' + ver)
         depends_on('rocsparse@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
 
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
         depends_on('rocrand@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -33,18 +33,18 @@ class Rocalution(CMakePackage):
     depends_on('cmake@3.5:', type='build')
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver,  when='@' + ver)
-        depends_on('rocblas@' + ver, type='link', when='@' + ver)
-        depends_on('rocprim@' + ver, type='link', when='@' + ver)
-        depends_on('rocsparse@' + ver, type='link', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
+        depends_on('hip@' + ver, when='@' + ver)
+        depends_on('rocblas@' + ver, when='@' + ver)
+        depends_on('rocprim@' + ver, when='@' + ver)
+        depends_on('rocsparse@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
 
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
-        depends_on('rocrand@' + ver, type='link', when='@' + ver)
+        depends_on('rocrand@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     patch('0001-fix-hip-build-error.patch')
 

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -67,7 +67,7 @@ class Rocblas(CMakePackage):
     ]:
         resource(name='Tensile',
                  git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-                 commit=t_version,
+                 commit=t_commit,
                  when='@{0}'.format(t_version))
 
     # Status: https://github.com/ROCmSoftwarePlatform/Tensile/commit/a488f7dadba34f84b9658ba92ce9ec5a0615a087

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -34,12 +34,15 @@ class Rocblas(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver,                       when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,               when='@' + ver)
         depends_on('rocm-cmake@' + ver,  type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocminfo@' + ver,    type='build', when='@' + ver)
 
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
-        depends_on('rocm-smi@' + ver, when='@' + ver)
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0']:
+        depends_on('rocm-smi@' + ver, type='build', when='@' + ver)
+
+    for ver in ['4.0.0', '4.1.0', '4.2.0']:
+        depends_on('rocm-smi-lib@' + ver, type='build', when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -33,11 +33,10 @@ class Rocblas(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        # used in Tensile
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('comgr@' + ver, type='build', when='@' + ver)
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
         depends_on('rocm-smi@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -75,7 +75,6 @@ class Rocblas(CMakePackage):
     patch('0001-Fix-compilation-error-with-StringRef-to-basic-string.patch', when='@:3.8')
 
     def setup_build_environment(self, env):
-        env.set('TENSILE_ROCM_ASSEMBLER_PATH', join_path(self.spec['llvm-amdgpu'].prefix, 'bin', 'clang++'))
         env.set('CXX', self.spec['hip'].hipcc)
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -51,6 +51,7 @@ class Rocblas(CMakePackage):
     depends_on('py-pyyaml', type='build')
     depends_on('py-wheel', type='build')
     depends_on('py-msgpack', type='build')
+    depends_on('py-pip', type='build')
 
     for t_version, t_commit in [
         ('@3.5.0',  'f842a1a4427624eff6cbddb2405c36dec9a210cd'),

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -33,16 +33,14 @@ class Rocblas(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                      when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
-        depends_on('rocm-smi@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-smi@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     # This is the default library format since 3.7.0
     depends_on('msgpack-c@3:', when='@3.7:')
@@ -55,19 +53,19 @@ class Rocblas(CMakePackage):
     depends_on('py-msgpack', type='build')
 
     for t_version, t_commit in [
-        ('3.5.0',  'f842a1a4427624eff6cbddb2405c36dec9a210cd'),
-        ('3.7.0',  'af71ea890a893e647bf2cf4571a90297d65689ca'),
-        ('3.8.0',  '9123205f9b5f95c96ff955695e942d2c3b321cbf'),
-        ('3.9.0',  'b68edc65aaeed08c71b2b8622f69f83498b57d7a'),
-        ('3.10.0', 'ab44bf46b609b5a40053f310bef2ab7511f726ae'),
-        ('4.0.0',  'ab44bf46b609b5a40053f310bef2ab7511f726ae'),
-        ('4.1.0',  'd175277084d3253401583aa030aba121e8875bfd'),
-        ('4.2.0',  '3438af228dc812768b20a068b0285122f327fa5b')
+        ('@3.5.0',  'f842a1a4427624eff6cbddb2405c36dec9a210cd'),
+        ('@3.7.0',  'af71ea890a893e647bf2cf4571a90297d65689ca'),
+        ('@3.8.0',  '9123205f9b5f95c96ff955695e942d2c3b321cbf'),
+        ('@3.9.0',  'b68edc65aaeed08c71b2b8622f69f83498b57d7a'),
+        ('@3.10.0', 'ab44bf46b609b5a40053f310bef2ab7511f726ae'),
+        ('@4.0.0',  'ab44bf46b609b5a40053f310bef2ab7511f726ae'),
+        ('@4.1.0',  'd175277084d3253401583aa030aba121e8875bfd'),
+        ('@4.2.0',  '3438af228dc812768b20a068b0285122f327fa5b')
     ]:
         resource(name='Tensile',
                  git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
                  commit=t_commit,
-                 when='@{0}'.format(t_version))
+                 when=t_version)
 
     # Status: https://github.com/ROCmSoftwarePlatform/Tensile/commit/a488f7dadba34f84b9658ba92ce9ec5a0615a087
     # Not yet landed in 3.7.0, nor 3.8.0.
@@ -82,27 +80,24 @@ class Rocblas(CMakePackage):
         tensile = join_path(self.stage.source_path, 'Tensile')
 
         args = [
-            '-Damd_comgr_DIR={0}'.format(self.spec['comgr'].prefix),
-            '-DBUILD_CLIENTS_TESTS=OFF',
-            '-DBUILD_CLIENTS_BENCHMARKS=OFF',
-            '-DBUILD_CLIENTS_SAMPLES=OFF',
-            '-DRUN_HEADER_TESTING=OFF',
-            '-DBUILD_WITH_TENSILE=ON',
-            '-DTensile_TEST_LOCAL_PATH={0}'.format(tensile),
-            '-DTensile_COMPILER=hipcc',
-            '-DTensile_LOGIC=asm_full',
-            '-DTensile_CODE_OBJECT_VERSION=V3',
-            '-DBUILD_WITH_TENSILE_HOST={0}'.format(
-                'ON' if '@3.7.0:' in self.spec else 'OFF'
-            )
+            self.define('BUILD_CLIENTS_TESTS', 'OFF'),
+            self.define('BUILD_CLIENTS_BENCHMARKS', 'OFF'),
+            self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
+            self.define('RUN_HEADER_TESTING', 'OFF'),
+            self.define('BUILD_WITH_TENSILE', 'ON'),
+            self.define('Tensile_TEST_LOCAL_PATH', tensile),
+            self.define('Tensile_COMPILER', 'hipcc'),
+            self.define('Tensile_LOGIC', 'asm_full'),
+            self.define('Tensile_CODE_OBJECT_VERSION', 'V3'),
+            self.define('BUILD_WITH_TENSILE_HOST', 'ON' if '@3.7.0:' in self.spec else 'OFF')
         ]
 
         if '@3.7.0:' in self.spec:
-            args.append('-DTensile_LIBRARY_FORMAT=msgpack')
+            args.append(self.define('Tensile_LIBRARY_FORMAT', 'msgpack'))
 
         if self.spec.satisfies('@4.1.0:'):
             if arch == 'gfx906' or arch == 'gfx908':
                 arch = arch + ':xnack-'
-        args.append('-DTensile_ARCHITECTURE={0}'.format(arch))
+        args.append(self.define('Tensile_ARCHITECTURE', arch))
 
         return args

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -33,8 +33,10 @@ class Rocblas(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                       when='@' + ver)
+        depends_on('rocm-cmake@' + ver,  type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('rocminfo@' + ver,    type='build', when='@' + ver)
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
         depends_on('rocm-smi@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -33,16 +33,8 @@ class Rocblas(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-<<<<<<< HEAD
         depends_on('hip@' + ver,                      when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-=======
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('hip@' + ver, when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        # used in Tensile
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
->>>>>>> parent of f2ece830ae... Bring back dep on llvm-amdgpu s.t. spack passes CMAKE_PREFIX_PATH to these packages for it to locate device libs
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
         depends_on('rocm-smi@' + ver, when='@' + ver)
@@ -97,7 +89,10 @@ class Rocblas(CMakePackage):
             self.define('Tensile_COMPILER', 'hipcc'),
             self.define('Tensile_LOGIC', 'asm_full'),
             self.define('Tensile_CODE_OBJECT_VERSION', 'V3'),
-            self.define('BUILD_WITH_TENSILE_HOST', 'ON' if '@3.7.0:' in self.spec else 'OFF')
+            self.define(
+                'BUILD_WITH_TENSILE_HOST',
+                'ON' if '@3.7.0:' in self.spec else 'OFF'
+            )
         ]
 
         if '@3.7.0:' in self.spec:

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -73,6 +73,7 @@ class Rocblas(CMakePackage):
     patch('0001-Fix-compilation-error-with-StringRef-to-basic-string.patch', when='@:3.8')
 
     def setup_build_environment(self, env):
+        env.set('TENSILE_ROCM_ASSEMBLER_PATH', join_path(self.spec['llvm-amdgpu'].prefix, 'bin', 'clang++'))
         env.set('CXX', self.spec['hip'].hipcc)
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -14,7 +14,7 @@ class Rocblas(CMakePackage):
     git      = "https://github.com/ROCmSoftwarePlatform/rocBLAS.git"
     url      = "https://github.com/ROCmSoftwarePlatform/rocBLAS/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('4.2.0', sha256='547f6d5d38a41786839f01c5bfa46ffe9937b389193a8891f251e276a1a47fb0')
     version('4.1.0', sha256='8be20c722bab169bc4badd79a9eab9a1aa338e0e5ff58ad85ba6bf09e8ac60f4')
@@ -34,7 +34,6 @@ class Rocblas(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         # used in Tensile
@@ -42,6 +41,7 @@ class Rocblas(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
         depends_on('rocm-smi@' + ver, type='build', when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
@@ -55,44 +55,20 @@ class Rocblas(CMakePackage):
     depends_on('py-wheel', type='build')
     depends_on('py-msgpack', type='build')
 
-    resource(name='Tensile',
-             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-             commit='f842a1a4427624eff6cbddb2405c36dec9a210cd',
-             when='@3.5.0')
-
-    resource(name='Tensile',
-             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-             commit='af71ea890a893e647bf2cf4571a90297d65689ca',
-             when='@3.7.0')
-
-    resource(name='Tensile',
-             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-             commit='9123205f9b5f95c96ff955695e942d2c3b321cbf',
-             when='@3.8.0')
-
-    resource(name='Tensile',
-             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-             commit='b68edc65aaeed08c71b2b8622f69f83498b57d7a',
-             when='@3.9.0')
-
-    resource(name='Tensile',
-             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-             commit='ab44bf46b609b5a40053f310bef2ab7511f726ae',
-             when='@3.10.0')
-
-    resource(name='Tensile',
-             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-             commit='ab44bf46b609b5a40053f310bef2ab7511f726ae',
-             when='@4.0.0')
-
-    resource(name='Tensile',
-             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-             commit='d175277084d3253401583aa030aba121e8875bfd',
-             when='@4.1.0')
-    resource(name='Tensile',
-             git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
-             commit='3438af228dc812768b20a068b0285122f327fa5b',
-             when='@4.2.0')
+    for t_version, t_commit in [
+        ('3.5.0',  'f842a1a4427624eff6cbddb2405c36dec9a210cd'),
+        ('3.7.0',  'af71ea890a893e647bf2cf4571a90297d65689ca'),
+        ('3.8.0',  '9123205f9b5f95c96ff955695e942d2c3b321cbf'),
+        ('3.9.0',  'b68edc65aaeed08c71b2b8622f69f83498b57d7a'),
+        ('3.10.0', 'ab44bf46b609b5a40053f310bef2ab7511f726ae'),
+        ('4.0.0',  'ab44bf46b609b5a40053f310bef2ab7511f726ae'),
+        ('4.1.0',  'd175277084d3253401583aa030aba121e8875bfd'),
+        ('4.2.0',  '3438af228dc812768b20a068b0285122f327fa5b')
+    ]:
+        resource(name='Tensile',
+                 git='https://github.com/ROCmSoftwarePlatform/Tensile.git',
+                 commit=t_version,
+                 when='@{0}'.format(t_version))
 
     # Status: https://github.com/ROCmSoftwarePlatform/Tensile/commit/a488f7dadba34f84b9658ba92ce9ec5a0615a087
     # Not yet landed in 3.7.0, nor 3.8.0.

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -33,8 +33,16 @@ class Rocblas(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
+<<<<<<< HEAD
         depends_on('hip@' + ver,                      when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+=======
+        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, type='build', when='@' + ver)
+        # used in Tensile
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+>>>>>>> parent of f2ece830ae... Bring back dep on llvm-amdgpu s.t. spack passes CMAKE_PREFIX_PATH to these packages for it to locate device libs
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
         depends_on('rocm-smi@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -39,10 +39,8 @@ class Rocfft(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                      when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type=('build', 'link'), when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -39,8 +39,9 @@ class Rocfft(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type=('build', 'link'), when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -14,7 +14,7 @@ class Rocfft(CMakePackage):
     git      = "https://github.com/ROCmSoftwarePlatform/rocFFT.git"
     url      = "https://github.com/ROCmSoftwarePlatform/rocfft/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('4.2.0', sha256='db29c9067f0cfa98bddd3574f6aa7200cfc790cc6da352d19e4696c3f3982163')
     version('4.1.0', sha256='df23fcb05aae72557461ae3687be7e3b8b78be4132daf1aa9dc07339f4eba0cc')
@@ -40,9 +40,9 @@ class Rocfft(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, type=('build', 'link'), when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/rocm-bandwidth-test/package.py
+++ b/var/spack/repos/builtin/packages/rocm-bandwidth-test/package.py
@@ -33,7 +33,7 @@ class RocmBandwidthTest(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
-        depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
-        depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
 
     build_targets = ['package']

--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -32,7 +32,7 @@ class RocmClangOcl(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
 
         # support both builtin and standalone device libs
         depends_on('rocm-device-libs@' + ver, when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))

--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -32,8 +32,4 @@ class RocmClangOcl(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-
-    for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
-                '4.2.0', 'master']:
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -32,4 +32,7 @@ class RocmClangOcl(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@{0} +rocm-device-libs'.format(ver), type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
+
+        # support both builtin and standalone device libs
+        depends_on('rocm-device-libs@' + ver, when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))

--- a/var/spack/repos/builtin/packages/rocm-debug-agent/package.py
+++ b/var/spack/repos/builtin/packages/rocm-debug-agent/package.py
@@ -41,11 +41,11 @@ class RocmDebugAgent(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
-        depends_on('hsakmt-roct@' + ver, type='link', when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
 
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
-        depends_on('rocm-dbgapi@' + ver, type='link', when='@' + ver)
+        depends_on('rocm-dbgapi@' + ver, when='@' + ver)
         depends_on('hip@' + ver, when='@' + ver)
 
     # https://github.com/ROCm-Developer-Tools/rocr_debug_agent/pull/4

--- a/var/spack/repos/builtin/packages/rocm-device-libs/package.py
+++ b/var/spack/repos/builtin/packages/rocm-device-libs/package.py
@@ -14,7 +14,7 @@ class RocmDeviceLibs(CMakePackage):
     git      = "https://github.com/RadeonOpenCompute/ROCm-Device-Libs.git"
     url      = "https://github.com/RadeonOpenCompute/ROCm-Device-Libs/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('master', branch='amd-stg-open')
     version('4.2.0', sha256='34a2ac39b9bb7cfa8175cbab05d30e7f3c06aaffce99eed5f79c616d0f910f5f')
@@ -32,6 +32,10 @@ class RocmDeviceLibs(CMakePackage):
     depends_on('zlib', type='link', when='@3.9.0:')
     depends_on('texinfo', type='link', when='@3.9.0:')
 
+    # Make sure llvm is not built with rocm-device-libs (that is, it's already
+    # built with rocm-device-libs as an external project).
+    depends_on('llvm-amdgpu ~rocm-device-libs')
+
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
         depends_on('llvm-amdgpu@' + ver, type=('build', 'link'), when='@' + ver)
@@ -39,8 +43,7 @@ class RocmDeviceLibs(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        args = ['-DLLVM_DIR={0}'.format(spec['llvm-amdgpu'].prefix),
-                '-DCMAKE_C_COMPILER={0}/bin/clang'.format(
-                    spec['llvm-amdgpu'].prefix),
-                ]
-        return args
+        return [
+            self.define('LLVM_DIR', spec['llvm-amdgpu'].prefix),
+            self.define('CMAKE_C_COMPILER', spec['llvm-amdgpu'].prefix.bin.clang)
+        ]

--- a/var/spack/repos/builtin/packages/rocm-device-libs/package.py
+++ b/var/spack/repos/builtin/packages/rocm-device-libs/package.py
@@ -38,8 +38,8 @@ class RocmDeviceLibs(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
-        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/rocm-device-libs/package.py
+++ b/var/spack/repos/builtin/packages/rocm-device-libs/package.py
@@ -38,7 +38,7 @@ class RocmDeviceLibs(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
-        depends_on('llvm-amdgpu@' + ver, type=('build', 'link'), when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/rocm-opencl-runtime/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl-runtime/package.py
@@ -31,10 +31,10 @@ class RocmOpenclRuntime(CMakePackage):
     depends_on('numactl', type='link', when="@3.7.0:")
 
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', 'master']:
-        depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hip-rocclr@' + ver, type='build', when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     def flag_handler(self, name, flags):
         if name == 'cxxflags' and '@3.7.0:' in self.spec:

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -88,14 +88,12 @@ class RocmOpenmpExtras(Package):
     depends_on('libffi', type=('build', 'link'))
 
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0']:
-        depends_on('hsakmt-roct@' + ver, type=('build', 'run'), when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type=('build', 'run'),
-                   when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
         # standalone rocm-device-libs
-        depends_on('rocm-device-libs@' + ver, type=('build', 'run'),
-                   when='@' + ver)
-        depends_on('llvm-amdgpu@{0} ~rocm-device-libs ~openmp'.format(ver), type=('build', 'run'),
+        depends_on('rocm-device-libs@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@{0} ~rocm-device-libs ~openmp'.format(ver),
                    when='@' + ver)
 
         # tag changed to 'rocm-' in 4.0.0

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -92,9 +92,10 @@ class RocmOpenmpExtras(Package):
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type=('build', 'run'),
                    when='@' + ver)
+        # standalone rocm-device-libs
         depends_on('rocm-device-libs@' + ver, type=('build', 'run'),
                    when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver + ' ~openmp', type=('build', 'run'),
+        depends_on('llvm-amdgpu@{0} ~rocm-device-libs ~openmp'.format(ver), type=('build', 'run'),
                    when='@' + ver)
 
         # tag changed to 'rocm-' in 4.0.0

--- a/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
@@ -32,6 +32,7 @@ class RocmSmiLib(CMakePackage):
     variant('shared', default=True, description='Build shared or static library')
 
     depends_on('cmake@3:', type='build')
+    depends_on('python@3:', type=('build', 'run'), when='@3.9.0:')
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -37,15 +37,15 @@ class RocmTensile(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('comgr@' + ver,                    when='@' + ver)
-        depends_on('rocm-smi-lib@' + ver,             when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,              when='@' + ver + '+openmp')
-        depends_on('llvm-amdgpu@' + ver + '~openmp',  when='@' + ver + '~openmp')
-
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
-        depends_on('rocm-smi@' + ver, when='@' + ver)
+        depends_on('rocm-cmake@' + ver, type='build',  when='@' + ver)
+        depends_on('hip@' + ver,                       when='@' + ver)
+        depends_on('comgr@' + ver,                     when='@' + ver)
+        depends_on('rocm-smi@' + ver,                  when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,               when='@' + ver + '+openmp')
+        depends_on('llvm-amdgpu@' + ver + '~openmp',   when='@' + ver + '~openmp')
+        depends_on('rocm-cmake@' + ver,  type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('rocminfo@' + ver,    type='build', when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -40,12 +40,15 @@ class RocmTensile(CMakePackage):
         depends_on('rocm-cmake@' + ver, type='build',  when='@' + ver)
         depends_on('hip@' + ver,                       when='@' + ver)
         depends_on('comgr@' + ver,                     when='@' + ver)
-        depends_on('rocm-smi@' + ver,                  when='@' + ver)
         depends_on('llvm-amdgpu@' + ver,               when='@' + ver + '+openmp')
         depends_on('llvm-amdgpu@' + ver + '~openmp',   when='@' + ver + '~openmp')
-        depends_on('rocm-cmake@' + ver,  type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocminfo@' + ver,    type='build', when='@' + ver)
+
+    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0']:
+        depends_on('rocm-smi@' + ver, type='build', when='@' + ver)
+
+    for ver in ['4.0.0', '4.1.0', '4.2.0']:
+        depends_on('rocm-smi-lib@' + ver, type='build', when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -14,7 +14,7 @@ class RocmTensile(CMakePackage):
     git      = "https://github.com/ROCmSoftwarePlatform/Tensile.git"
     url      = "https://github.com/ROCmSoftwarePlatform/Tensile/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('4.2.0', sha256='198e357a14a79366b27b1097856d4821996bc36163be0cd2668910b253721060')
     version('4.1.0', sha256='92b8ee13dfc11a67d5136227ee985622685790fd3f0f0e1ec6db411d4e9a3419')
@@ -38,7 +38,6 @@ class RocmTensile(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         # used in Tensile
@@ -48,6 +47,7 @@ class RocmTensile(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
         depends_on('rocm-smi@' + ver, type='build', when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
@@ -63,24 +63,25 @@ class RocmTensile(CMakePackage):
     def cmake_args(self):
         arch = self.spec.variants['tensile_architecture'].value
         args = [
-            '-Damd_comgr_DIR={0}'.format(self.spec['comgr'].prefix),
-            '-DTensile_COMPILER=hipcc',
-            '-DTensile_LOGIC=asm_full',
-            '-DTensile_CODE_OBJECT_VERSION=V3',
-            '-DBoost_USE_STATIC_LIBS=OFF',
-            '-DTENSILE_USE_OPENMP=ON',
-            '-DBUILD_WITH_TENSILE_HOST={0}'.format(
+            self.define('amd_comgr_DIR', self.spec['comgr'].prefix),
+            self.define('Tensile_COMPILER', 'hipcc'),
+            self.define('Tensile_LOGIC', 'asm_full'),
+            self.define('Tensile_CODE_OBJECT_VERSION', 'V3'),
+            self.define('Boost_USE_STATIC_LIBS', 'OFF'),
+            self.define('TENSILE_USE_OPENMP', 'ON'),
+            self.define(
+                'BUILD_WITH_TENSILE_HOST',
                 'ON' if '@3.7.0:' in self.spec else 'OFF'
             )
         ]
 
         if '@3.7.0:' in self.spec:
-            args.append('-DTensile_LIBRARY_FORMAT=msgpack')
+            args.append(self.define('Tensile_LIBRARY_FORMAT', 'msgpack'))
 
         if self.spec.satisfies('@4.1.0:'):
             if arch == 'gfx906' or arch == 'gfx908':
                 arch = arch + ':xnack-'
-        args.append('-DTensile_ARCHITECTURE={0}'.format(arch))
+        args.append(self.define('Tensile_ARCHITECTURE', arch))
 
         return args
 

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -38,18 +38,17 @@ class RocmTensile(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('hip@' + ver, when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        # used in Tensile
-        depends_on('rocm-smi-lib@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver + '+openmp')
-        depends_on('llvm-amdgpu@' + ver + '~openmp', type='build', when='@' + ver + '~openmp')
+        depends_on('hip@' + ver,                      when='@' + ver)
+        depends_on('comgr@' + ver,                    when='@' + ver)
+        depends_on('rocm-smi-lib@' + ver,             when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,              when='@' + ver + '+openmp')
+        depends_on('llvm-amdgpu@' + ver + '~openmp',  when='@' + ver + '~openmp')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0']:
-        depends_on('rocm-smi@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-smi@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     root_cmakelists_dir = 'Tensile/Source'
     # Status: https://github.com/ROCmSoftwarePlatform/Tensile/commit/a488f7dadba34f84b9658ba92ce9ec5a0615a087

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -43,11 +43,7 @@ class RocmValidationSuite(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
-        depends_on('comgr@' + ver, when='@' + ver)
         depends_on('hip-rocclr@' + ver, when='@' + ver)
-        depends_on('hsakmt-roct@' + ver, when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
         depends_on('rocminfo@' + ver, when='@' + ver)
         depends_on('rocblas@' + ver, when='@' + ver)
         depends_on('rocm-smi-lib@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -42,15 +42,15 @@ class RocmValidationSuite(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hip-rocclr@' + ver, type='build', when='@' + ver)
-        depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
-        depends_on('rocminfo@' + ver, type='build', when='@' + ver)
-        depends_on('rocblas@' + ver, type='link', when='@' + ver)
-        depends_on('rocm-smi-lib@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('rocminfo@' + ver, when='@' + ver)
+        depends_on('rocblas@' + ver, when='@' + ver)
+        depends_on('rocm-smi-lib@' + ver, when='@' + ver)
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -43,7 +43,6 @@ class RocmValidationSuite(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hip-rocclr@' + ver, type='build', when='@' + ver)
         depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
@@ -53,8 +52,8 @@ class RocmValidationSuite(CMakePackage):
         depends_on('rocm-smi-lib@' + ver, type='build', when='@' + ver)
 
     def cmake_args(self):
-        spec = self.spec
-        args = ['-DHIP_INC_DIR={0}'.format(spec['hip'].prefix),
-                '-DROCM_SMI_DIR={0}'.format(spec['rocm-smi-lib'].prefix),
-                '-DROCBLAS_DIR={0}'.format(spec['rocblas'].prefix)]
-        return args
+        return [
+            self.define('HIP_INC_DIR', self.spec['hip'].prefix),
+            self.define('ROCM_SMI_DIR', self.spec['rocm-smi-lib'].prefix),
+            self.define('ROCBLAS_DIR', self.spec['rocblas'].prefix)
+        ]

--- a/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
+++ b/var/spack/repos/builtin/packages/rocm-validation-suite/package.py
@@ -43,6 +43,7 @@ class RocmValidationSuite(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hip-rocclr@' + ver, type='build', when='@' + ver)
         depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocminfo/package.py
+++ b/var/spack/repos/builtin/packages/rocminfo/package.py
@@ -31,8 +31,8 @@ class Rocminfo(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', 'master']:
-        depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
 
     def cmake_args(self):
         return [self.define('ROCM_DIR', self.spec['hsa-rocr-dev'].prefix)]

--- a/var/spack/repos/builtin/packages/rocminfo/package.py
+++ b/var/spack/repos/builtin/packages/rocminfo/package.py
@@ -14,7 +14,7 @@ class Rocminfo(CMakePackage):
     git      = "https://github.com/RadeonOpenCompute/rocminfo.git"
     url      = "https://github.com/RadeonOpenCompute/rocminfo/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     version('master', branch='master')
 
@@ -35,5 +35,4 @@ class Rocminfo(CMakePackage):
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
 
     def cmake_args(self):
-        args = ['-DROCM_DIR={0}'.format(self.spec['hsa-rocr-dev'].prefix)]
-        return args
+        return [self.define('ROCM_DIR', self.spec['hsa-rocr-dev'].prefix)]

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -32,7 +32,6 @@ class Rocprim(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -31,9 +31,10 @@ class Rocprim(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -32,9 +32,9 @@ class Rocprim(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='build', when='@' + ver)
 
@@ -42,14 +42,10 @@ class Rocprim(CMakePackage):
         env.set('CXX', self.spec['hip'].hipcc)
 
     def cmake_args(self):
-        spec = self.spec
-
-        args = [
-            '-DCMAKE_MODULE_PATH={0}/cmake'.format(spec['hip'].prefix),
-            '-DONLY_INSTALL=ON',
-            '-DBUILD_TEST=OFF',
-            '-DBUILD_BENCHMARK=OFF',
-            '-DBUILD_EXAMPLE=OFF'
+        return [
+            self.define('CMAKE_MODULE_PATH', self.spec['hip'].prefix.cmake),
+            self.define('ONLY_INSTALL', 'ON'),
+            self.define('BUILD_TEST', 'OFF'),
+            self.define('BUILD_BENCHMARK', 'OFF'),
+            self.define('BUILD_EXAMPLE', 'OFF')
         ]
-
-        return args

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -32,6 +32,7 @@ class Rocprim(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/rocprofiler-dev/package.py
+++ b/var/spack/repos/builtin/packages/rocprofiler-dev/package.py
@@ -28,9 +28,9 @@ class RocprofilerDev(CMakePackage):
     depends_on('cmake@3:', type='build')
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
-        depends_on('rocminfo@' + ver, type='build', when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('rocminfo@' + ver, when='@' + ver)
 
     resource(name='roctracer-dev',
              url='https://github.com/ROCm-Developer-Tools/roctracer/archive/rocm-3.5.0.tar.gz',

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -35,7 +35,6 @@ class Rocrand(CMakePackage):
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocminfo@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -34,8 +34,8 @@ class Rocrand(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocminfo@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
     for ver in ['4.1.0', '4.2.0']:

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -34,8 +34,8 @@ class Rocrand(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
+        depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocminfo@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
     for ver in ['4.1.0', '4.2.0']:

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -14,7 +14,7 @@ class Rocsolver(CMakePackage):
     git      = "https://github.com/ROCmSoftwarePlatform/rocSOLVER.git"
     url      = "https://github.com/ROCmSoftwarePlatform/rocSOLVER/archive/rocm-4.2.0.tar.gz"
 
-    maintainers = ['srekolam', 'arjun-raj-kuppala']
+    maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     variant('optimal', default=True,
             description='This option improves performance at the cost of increased binary \
@@ -39,19 +39,21 @@ class Rocsolver(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
 
     def cmake_args(self):
-        incl = self.spec['rocblas'].prefix
         args = [
-            '-DBUILD_CLIENTS_SAMPLES=OFF',
-            '-DBUILD_CLIENTS_TESTS=OFF',
-            '-DBUILD_CLIENTS_BENCHMARKS=OFF'
+            self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
+            self.define('BUILD_CLIENTS_TESTS', 'OFF'),
+            self.define('BUILD_CLIENTS_BENCHMARKS', 'OFF')
         ]
         if self.spec.satisfies('@4.1.0:'):
-            args.append('-DCMAKE_CXX_FLAGS:String=-I{0}/rocblas/include'.format(incl))
+            incl = self.spec['rocblas'].prefix
+            args.append(self.define(
+                'CMAKE_CXX_FLAGS',
+                '-I{0}/rocblas/include'.format(incl)
+            ))
 
         if self.spec.satisfies('@3.7.0:'):
             args.append(self.define_from_variant('OPTIMAL', 'optimal'))

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -39,7 +39,6 @@ class Rocsolver(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -39,6 +39,7 @@ class Rocsolver(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -33,11 +33,11 @@ class Rocsparse(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)
         depends_on('hsakmt-roct@' + ver, type='link', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -33,6 +33,7 @@ class Rocsparse(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)
         depends_on('hsakmt-roct@' + ver, type='link', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -33,14 +33,14 @@ class Rocsparse(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('rocprim@' + ver, type='build', when='@' + ver)
-        depends_on('hsakmt-roct@' + ver, type='link', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='link', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
+        depends_on('comgr@' + ver, when='@' + ver)
+        depends_on('rocprim@' + ver, when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -33,11 +33,7 @@ class Rocsparse(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
-        depends_on('comgr@' + ver, when='@' + ver)
         depends_on('rocprim@' + ver, when='@' + ver)
-        depends_on('hsakmt-roct@' + ver, when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -36,7 +36,6 @@ class Rocthrust(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -36,10 +36,10 @@ class Rocthrust(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-device-libs@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)
+
     for ver in ['4.1.0', '4.2.0']:
         depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
 
@@ -49,8 +49,9 @@ class Rocthrust(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        args = [
-            '-DCMAKE_MODULE_PATH={0}/cmake'.format(spec['hip'].prefix)
+        return [
+            self.define(
+                'CMAKE_MODULE_PATH',
+                '{0}/cmake'.format(spec['hip'].prefix)
+            )
         ]
-
-        return args

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -36,6 +36,7 @@ class Rocthrust(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
         depends_on('rocprim@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -35,13 +35,11 @@ class Rocthrust(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
-        depends_on('rocprim@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver, when='@' + ver)
+        depends_on('rocprim@' + ver, when='@' + ver)
 
     for ver in ['4.1.0', '4.2.0']:
-        depends_on('hip-rocclr@' + ver, type='link', when='@' + ver)
+        depends_on('hip-rocclr@' + ver, when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/roctracer-dev/package.py
+++ b/var/spack/repos/builtin/packages/roctracer-dev/package.py
@@ -35,12 +35,13 @@ class RoctracerDev(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0']:
-        depends_on('hsakmt-roct@' + ver, type='build', when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver, type='build', when='@' + ver)
-        depends_on('rocminfo@' + ver, type='build', when='@' + ver)
-        depends_on('hip@' + ver, type='build', when='@' + ver)
-        if ver in ['4.2.0']:
-            depends_on('rocprofiler-dev@' + ver, type='link', when='@' + ver)
+        depends_on('hsakmt-roct@' + ver, when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
+        depends_on('rocminfo@' + ver, when='@' + ver)
+        depends_on('hip@' + ver, when='@' + ver)
+
+    for ver in ['4.2.0']:
+        depends_on('rocprofiler-dev@' + ver, when='@' + ver)
 
     def setup_build_environment(self, build_env):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -114,8 +114,6 @@ class Sirius(CMakePackage, CudaPackage):
 
     # rocm
     depends_on('hip', when='+rocm')
-    depends_on('hsakmt-roct', when='+rocm', type='link')
-    depends_on('hsa-rocr-dev', when='+rocm', type='link')
     depends_on('rocblas', when='+rocm')
 
     # FindHIP cmake script only works for < 4.1

--- a/var/spack/repos/builtin/packages/spfft/package.py
+++ b/var/spack/repos/builtin/packages/spfft/package.py
@@ -51,8 +51,6 @@ class Spfft(CMakePackage, CudaPackage):
 
     depends_on('rocfft', when='+rocm')
     depends_on('hip', when='+rocm')
-    depends_on('hsakmt-roct', when='+rocm', type='link')
-    depends_on('hsa-rocr-dev', when='+rocm', type='link')
     variant('amdgpu_target', default='gfx803,gfx900,gfx906', multi=True, values=amdgpu_targets)
 
     depends_on('cuda@:10', when='@:0.9.11 +cuda')

--- a/var/spack/repos/builtin/packages/spla/package.py
+++ b/var/spack/repos/builtin/packages/spla/package.py
@@ -40,8 +40,6 @@ class Spla(CMakePackage):
     depends_on('cuda', when='+cuda')
     depends_on('rocblas', when='+rocm')
     depends_on('hip', when='+rocm')
-    depends_on('hsakmt-roct', when='+rocm', type='link')
-    depends_on('hsa-rocr-dev', when='+rocm', type='link')
 
     # Propagate openmp to blas
     depends_on('openblas threads=openmp', when='+openmp ^openblas')

--- a/var/spack/repos/builtin/packages/xxd-standalone/package.py
+++ b/var/spack/repos/builtin/packages/xxd-standalone/package.py
@@ -18,11 +18,8 @@ class XxdStandalone(MakefilePackage):
     maintainers = ['haampie']
     build_targets = ['-C', os.path.join('src', 'xxd')]
 
-<<<<<<< HEAD
     provides('xxd')
 
-=======
->>>>>>> Add xxd standalone package
     version('8.2.1201', sha256='39032fe866f44724b104468038dc9ac4ff2c00a4b18c9a1e2c27064ab1f1143d')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/xxd-standalone/package.py
+++ b/var/spack/repos/builtin/packages/xxd-standalone/package.py
@@ -18,8 +18,11 @@ class XxdStandalone(MakefilePackage):
     maintainers = ['haampie']
     build_targets = ['-C', os.path.join('src', 'xxd')]
 
+<<<<<<< HEAD
     provides('xxd')
 
+=======
+>>>>>>> Add xxd standalone package
     version('8.2.1201', sha256='39032fe866f44724b104468038dc9ac4ff2c00a4b18c9a1e2c27064ab1f1143d')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
There's a circular dependency where clang of llvm-amdgpu needs bitcode of rocm-device-libs, but rocm-device-libs needs llvm-amdgpu to compile.

AMD has written a piece of code that special-cases spack in the way they detect the bitcode from clang, and it's flawed. See https://reviews.llvm.org/D97340.

This PR makes that part redundant by building rocm-device-libs as an LLVM external project as part of llvm-amdgpu, using spack's `resource` to pull in the the device lib sources.

It also removes `rocm-device-libs` from the deps of some packages, which I believe was redundant already before this pr.

Apart from that it fixes some issues in packages that slipped through review (e.g. unused `self.define_from_variant(...)`), cleans a couple things up, and adds myself as maintainer to package I frequently use.

Note that this PR is on top of #23855.

Ping @srekolam, @arjun-raj-kuppala 