### PR TITLE
Use default compilers for pure build dependencies.

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -614,8 +614,20 @@ compiler_match(Package, Dependency)
      node_compiler_version(Package, Compiler, Version),
      node_compiler_version(Dependency, Compiler, Version).
 
+% these deptypes imply compiler matching
+link_reachable_deptype("link").
+link_reachable_deptype("run").
+link_reachable_deptype("test").
+
+link_reachable(Package) :- root(Package).
+link_reachable(Dependency) :-
+    depends_on(Package, Dependency, Type),
+    link_reachable(Package),
+    link_reachable_deptype(Type).
+
 compiler_mismatch(Package, Dependency)
   :- depends_on(Package, Dependency),
+     link_reachable(Dependency),
      not compiler_match(Package, Dependency).
 
 #defined node_compiler_set/2.


### PR DESCRIPTION
This is a draft for now, as I want to evaluate it a bit first.  But it occurred to me that it wouldn't take much to implement and I wanted to get @eugeneswalker to try it.

This does not do fully separate concretization of build dependencies (i.e., a dependency of a build dependency must still be consistent with other dependencies in the same DAG), but it relaxes the compiler matching constraint for pure build dependencies so that we tend to compile build dependencies (and their dependencies) with the default compiler.

Consider this graph:

```
$ spack install A %intel

   A %intel
   |
   +-[l]- B % intel
   |
   +-[b]- C % gcc
        |
        +-[l]- D % gcc
```

The `%intel` constraint on `A` will cause Spack to prefer `%intel` for `B` because it is a `link` dependency, but Spack will no longer try to force `C` to use `%intel`, as it is a pure build dependency (i.e., not also a `link`, `run`, or `test` dependnency. `C` will fall back to the default compiler (here, `gcc`). Because `D` is not reachable from any root via a chain of non-`build` dependencies, it also falls back to the default.

Now consider a diamond instead:

```
$ spack install A %intel

   A %intel
   |
   +-[l]--------------- B % intel
   |                    |
   +-[b]- C % gcc      [l]
          |             |
          +-----[l]---- D % intel
```

Now there are two link dependencies for `D`, and one of them (`B -> D`) has a path of all `link` dependencies back to the root (`A`). `D` is "`link`-reachable", so Spack tries to build it with `%intel`. Because the path `A -> C -> D` has a pure build dependency, nothing after the build dependency is forced to match with another compiler.