### PR TITLE
changes to installer to shorten the setup process

### DIFF
--- a/lib/spack/spack/cmd/installer/CMakeLists.txt
+++ b/lib/spack/spack/cmd/installer/CMakeLists.txt
@@ -1,5 +1,5 @@
 ﻿cmake_minimum_required (VERSION 3.13)
-project(spack_installer)
+project(spack_installer NONE)
 
 set(PYTHON_VERSION "3.9.0" CACHE STRING "Version of Python to build.")
 set(PY_DOWNLOAD_LINK "https://www.paraview.org/files/dependencies")

--- a/lib/spack/spack/cmd/installer/spack_cmd.bat
+++ b/lib/spack/spack/cmd/installer/spack_cmd.bat
@@ -49,6 +49,7 @@ if defined py_path (
 
 if defined py_exe (
     "%py_exe%" "%spackinstdir%\scripts\haspywin.py"
+    "%py_exe%" "%SPACK_ROOT%\bin\spack" external find python >NUL
 )
 
 set "EDITOR=notepad"

--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -45,6 +45,7 @@ def make_installer(parser, args):
                 return
             else:
                 spack_source = posixpath.abspath(spack_source)
+                spack_source = spack_source.replace('\\', '/')
 
         spack_version = args.spack_version
 

--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -44,6 +44,7 @@ def make_installer(parser, args):
                 print("%s does not exist" % spack_source)
                 return
             else:
+                spack_source = posixpath.abspath(spack_source)
                 spack_source = spack_source.replace('\\', '/')
 
         spack_version = args.spack_version

--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -44,7 +44,6 @@ def make_installer(parser, args):
                 print("%s does not exist" % spack_source)
                 return
             else:
-                spack_source = posixpath.abspath(spack_source)
                 spack_source = spack_source.replace('\\', '/')
 
         spack_version = args.spack_version
@@ -85,7 +84,7 @@ def make_installer(parser, args):
             return
         try:
             subprocess.check_call(
-                '"%s/bin/light.exe" -ext WixBalExtension "%s/bundle.wixobj" -out "%s/Spack.exe"'
+                '"%s/bin/light.exe" -sw1134 -ext WixBalExtension "%s/bundle.wixobj" -out "%s/Spack.exe"'
                 % (os.environ.get('WIX'), output_dir, output_dir), shell=True)
         except subprocess.CalledProcessError:
             print("Failed to generate installer chain")


### PR DESCRIPTION
- if python is found in setup, add python as an external, so it can be used in builds
- remove unnecessary compiler step from build
- fix spack path in installer generation