### PR TITLE
AML: Add E4S testsuite stand alone test

### DIFF
--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -45,8 +45,9 @@ class Aml(AutotoolsPackage):
 
         self.run_test('gcc',
                       options=['-o', exe, join_path(test_dir, 'test_area.c'),
-                               '-I{0}'.format(join_path(self.test_suite.current_test_cache_dir,
-                                                        'include')),
+                               '-I{0}'.format(join_path(
+                                       self.test_suite.current_test_cache_dir,
+                                       'include')),
                                '-I{0}'.format(self.prefix.include),
                                '-I{0}'.format(self.spec['numactl'].prefix.include),
                                '-L{0}'.format(self.prefix.lib),

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -30,7 +30,7 @@ class Aml(AutotoolsPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(['tests', 'include/config.h'])
 
-    def run_test(self):
+    def run_area_test(self):
         """Run stand alone test: test_area"""
 
         test_dir = join_path(self.prefix, '.spack/test/tests/area')
@@ -53,11 +53,8 @@ class Aml(AutotoolsPackage):
                       work_dir=test_dir)
 
         self.run_test(exe,
-                      options=[],
-                      expected=[0],
                       purpose='test: run {0} example'.format(exe),
                       work_dir=test_dir)
-        print(other)
 
     def test(self):
-        self.run_test()
+        self.run_area_test()

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -35,7 +35,7 @@ class Aml(AutotoolsPackage):
     def run_area_test(self):
         """Run stand alone test: test_area"""
 
-        test_dir = join_path(self.install_test_root, 'tests', 'area')
+        test_dir = join_path(self.test_suite.current_test_cache_dir, 'tests', 'area')
 
         if not os.path.exists(test_dir):
             print('Skipping aml test')
@@ -45,7 +45,7 @@ class Aml(AutotoolsPackage):
 
         self.run_test('gcc',
                       options=['-o', exe, join_path(test_dir, 'test_area.c'),
-                               '-I{0}'.format(join_path(self.install_test_root,
+                               '-I{0}'.format(join_path(self.test_suite.current_test_cache_dir,
                                                         'include')),
                                '-I{0}'.format(self.prefix.include),
                                '-I{0}'.format(self.spec['numactl'].prefix.include),

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -35,7 +35,7 @@ class Aml(AutotoolsPackage):
     def run_area_test(self):
         """Run stand alone test: test_area"""
 
-        test_dir = join_path(self.prefix, '.spack', 'test', 'tests', 'area')
+        test_dir = join_path(self.install_test_root, 'tests', 'area')
 
         if not os.path.exists(test_dir):
             print('Skipping aml test')
@@ -45,9 +45,7 @@ class Aml(AutotoolsPackage):
 
         self.run_test('gcc',
                       options=['-o', exe, join_path(test_dir, 'test_area.c'),
-                               '-I{0}'.format(join_path(self.prefix,
-                                                        '.spack',
-                                                        'test',
+                               '-I{0}'.format(join_path(self.install_test_root,
                                                         'include')),
                                '-I{0}'.format(self.prefix.include),
                                '-I{0}'.format(self.spec['numactl'].prefix.include),

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -23,3 +23,41 @@ class Aml(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources(['tests', 'include/config.h'])
+
+    def run_test(self):
+        """Run stand alone test: test_area"""
+
+        test_dir = join_path(self.prefix, '.spack/test/tests/area')
+
+        if not os.path.exists(test_dir):
+            print('Skipping aml test')
+            return
+
+        exe = 'test_area'
+
+        self.run_test('gcc',
+                      options=['-o', exe, join_path(test_dir, 'test_area.c'),
+                               '-I{0}'.format(join_path(self.prefix,
+                                                        '.spack/test/include')),
+                               '-I{0}'.format(self.prefix.include),
+                               '-I{0}'.format(self.spec['numactl'].prefix.include),
+                               '-L{0}'.format(self.prefix.lib),
+                               '-laml', '-lexcit', '-lpthread'],
+                      purpose='test: compile {0} example'.format(exe),
+                      work_dir=test_dir)
+
+        self.run_test(exe,
+                      options=[],
+                      expected=[0],
+                      purpose='test: run {0} example'.format(exe),
+                      work_dir=test_dir)
+        print(other)
+
+    def test(self):
+        self.run_test()

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -46,8 +46,8 @@ class Aml(AutotoolsPackage):
         self.run_test('gcc',
                       options=['-o', exe, join_path(test_dir, 'test_area.c'),
                                '-I{0}'.format(join_path(
-                                       self.test_suite.current_test_cache_dir,
-                                       'include')),
+                                   self.test_suite.current_test_cache_dir,
+                                   'include')),
                                '-I{0}'.format(self.prefix.include),
                                '-I{0}'.format(self.spec['numactl'].prefix.include),
                                '-L{0}'.format(self.prefix.lib),

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -15,6 +15,8 @@ class Aml(AutotoolsPackage):
     url = "https://www.mcs.anl.gov/research/projects/argo/downloads/aml-0.1.0.tar.gz"
     git = "https://xgitlab.cels.anl.gov/argo/aml.git"
 
+    test_requires_compiler = True
+
     version('0.1.0', sha256='cc89a8768693f1f11539378b21cdca9f0ce3fc5cb564f9b3e4154a051dcea69b')
     version('develop', branch='staging', submodules=True)
     version('master', branch='master', submodules=True)

--- a/var/spack/repos/builtin/packages/aml/package.py
+++ b/var/spack/repos/builtin/packages/aml/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 from spack import *
 
 
@@ -28,12 +29,12 @@ class Aml(AutotoolsPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(['tests', 'include/config.h'])
+        self.cache_extra_test_sources(['tests', join_path('include', 'config.h')])
 
     def run_area_test(self):
         """Run stand alone test: test_area"""
 
-        test_dir = join_path(self.prefix, '.spack/test/tests/area')
+        test_dir = join_path(self.prefix, '.spack', 'test', 'tests', 'area')
 
         if not os.path.exists(test_dir):
             print('Skipping aml test')
@@ -44,7 +45,9 @@ class Aml(AutotoolsPackage):
         self.run_test('gcc',
                       options=['-o', exe, join_path(test_dir, 'test_area.c'),
                                '-I{0}'.format(join_path(self.prefix,
-                                                        '.spack/test/include')),
+                                                        '.spack',
+                                                        'test',
+                                                        'include')),
                                '-I{0}'.format(self.prefix.include),
                                '-I{0}'.format(self.spec['numactl'].prefix.include),
                                '-L{0}'.format(self.prefix.lib),


### PR DESCRIPTION
This PR represents a preliminary stand alone test for the `aml` package and is intended to serve the following purposes:

1. Leverage the current E4S test suite for the software
2. Demonstrate to package maintainers how to start a Spack stand alone test.