### PR TITLE
pfunit: fix gcc10 +mpi

### DIFF
--- a/var/spack/repos/builtin/packages/pfunit/package.py
+++ b/var/spack/repos/builtin/packages/pfunit/package.py
@@ -49,7 +49,6 @@ class Pfunit(CMakePackage):
     # See https://github.com/Goddard-Fortran-Ecosystem/pFUnit/pull/179
     conflicts("+shared", when="@4.0.0:")
     conflicts("+use_comm_world", when="~mpi")
-    conflicts('+mpi', when='@:3.99.99 %gcc@10.0.0:')
     patch("mpi-test.patch", when="@:3.99.99 +use_comm_world")
 
     def patch(self):
@@ -77,6 +76,9 @@ class Pfunit(CMakePackage):
             self.define_from_variant('BUILD_DOCS', 'docs'),
             self.define_from_variant('OPENMP', 'openmp'),
             '-DMAX_RANK=%s' % spec.variants['max_array_rank'].value]
+
+        if self.spec.satisfies('%gcc@10:'):
+            args.append('-DCMAKE_Fortran_FLAGS_DEBUG=-g -O2 -fallow-argument-mismatch')
 
         if spec.satisfies('@4.0.0:'):
             args.append('-DSKIP_MPI=%s' % ('YES' if '~mpi' in spec else 'NO'))


### PR DESCRIPTION
Instead of refusing to build +mpi with gcc10, add what I guess is now
the standard workaround, ie., `-fallow-argument-mismatch`.

@citibeth 