### PR TITLE
`spack create` skip gh archive prerelease

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -728,9 +728,17 @@ def get_versions(args, name):
             tty.warn("Couldn't detect version in: {0}".format(args.url))
             return hashed_versions, guesser
 
+        # Exclude "newer" than requested (e.g., skip GitHub pre-release).
+        version = parse_version(args.url)
+        flag = []
+        for v in url_dict:
+            if v > version:
+                flag.append(v)
+        for f in flag:
+            url_dict.pop(f)
+
         if not url_dict:
             # If no versions were found, revert to what the user provided
-            version = parse_version(args.url)
             url_dict = {version: args.url}
 
         versions = spack.stage.get_checksums_for_versions(


### PR DESCRIPTION
The current implementation is a hack.  I was bundling something:

```console
$ spack create https://github.com/IntelRealSense/librealsense/archive/refs/tags/v2.44.0.tar.gz
```

Right now, v2.45.0 is Pre-Release.  So when I do the above, trying to skip 2.45, I'll ultimately be required to select the non-default of hash 2 versions to then delete 2.45.0.  I feel like spack already has some fancy stuff elsewhere in the library that either already has or could have the capability to gain additional information from GitHub archive urls.  I think skipping pre-releases specifically, if attainable and relatively straightforward is appropriate.  My current implementation was just a curiosity :slightly_smiling_face:  This can just as easily be closed since hopefully whoever is issuing `spack create` is paying attention.  But in theory, it could be done.  Should it?