### PR TITLE
Fix bootstrapping clingo in ubuntu docker image

### DIFF
--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -21,11 +21,13 @@ RUN apt-get -yqq update \
         git \
         gnupg2 \
         iproute2 \
+        libpython3-dev \
         lmod \
         locales \
         lua-posix \
         make \
         python3 \
+        python3-distutils \
         python3-pip \
         python3-setuptools \
         tcl \

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -21,11 +21,13 @@ RUN apt-get -yqq update \
         git \
         gnupg2 \
         iproute2 \
+        libpython3-dev \
         lmod \
         locales \
         lua-posix \
         make \
         python3 \
+        python3-distutils \
         python3-pip \
         python3-setuptools \
         tcl \


### PR DESCRIPTION
Just setting `concretizer: clingo` doesn't work on the ubuntu images I've tried
