### PR TITLE
Add fuse virtual dependency, new macfuse package

### DIFF
--- a/etc/spack/defaults/darwin/packages.yaml
+++ b/etc/spack/defaults/darwin/packages.yaml
@@ -21,12 +21,10 @@ packages:
     - gcc
     - intel
     providers:
-      elf:
-      - libelf
-      unwind:
-      - apple-libunwind
-      uuid:
-      - apple-libuuid
+      elf: [libelf]
+      fuse: [macfuse]
+      unwind: [apple-libunwind]
+      uuid: [apple-libuuid]
   apple-libunwind:
     buildable: false
     externals:

--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -24,6 +24,7 @@ packages:
       elf: [elfutils]
       fftw-api: [fftw, amdfftw]
       flame: [libflame, amdlibflame]
+      fuse: [libfuse]
       gl: [mesa+opengl, mesa18, opengl]
       glu: [mesa-glu, openglu]
       glx: [mesa+glx, mesa18+glx, opengl]

--- a/var/spack/repos/builtin/packages/fuse-overlayfs/package.py
+++ b/var/spack/repos/builtin/packages/fuse-overlayfs/package.py
@@ -24,4 +24,4 @@ class FuseOverlayfs(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
-    depends_on('libfuse')
+    depends_on('fuse')

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -34,6 +34,7 @@ class Libfuse(MesonPackage):
         "which typically sets up udev rules and "
         "and init script in /etc/init.d"))
 
+    provides('fuse')
     conflicts("+useroot", when='~system_install', msg="useroot requires system_install")
     conflicts('platform=darwin', msg='libfuse does not support OS-X, use macfuse instead')
 

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -35,6 +35,7 @@ class Libfuse(MesonPackage):
         "and init script in /etc/init.d"))
 
     conflicts("+useroot", when='~system_install', msg="useroot requires system_install")
+    conflicts('platform=darwin', msg='libfuse does not support OS-X, use macfuse instead')
 
     # Drops the install script which does system configuration
     patch('0001-Do-not-run-install-script.patch', when='@3: ~system_install')

--- a/var/spack/repos/builtin/packages/macfuse/package.py
+++ b/var/spack/repos/builtin/packages/macfuse/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Macfuse(Package):
+    """FUSE for macOS allows you to extend macOS via third party file systems."""
+
+    homepage = "https://osxfuse.github.io/"
+    git      = "https://github.com/osxfuse/osxfuse.git"
+    has_code = False  # only distributed in binary form
+
+    version('4.1.2')
+
+    conflicts('platform=linux', msg='macfuse does not support linux, use libfuse instead')
+    conflicts('platform=cray', msg='macfuse does not support cray, use libfuse instead')
+
+    def install(self, spec, prefix):
+        msg = """
+macFUSE is only distributed in binary form.
+To use macFUSE with Spack, manually download the .dmg from:
+
+    https://github.com/osxfuse/osxfuse/releases
+
+and double-click to install. Once macFUSE is installed,
+add it as an external package by running:
+
+    $ spack config edit packages
+
+and add an entry like so:
+
+    packages:
+      macfuse:
+        buildable: false
+        externals:
+        - spec: macfuse@4.1.2
+          prefix: /Library/Frameworks/macFUSE.framework"""
+
+        raise InstallError(msg)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        env.set('FUSE_LIBRARY_PATH', self.prefix.macFUSE)

--- a/var/spack/repos/builtin/packages/macfuse/package.py
+++ b/var/spack/repos/builtin/packages/macfuse/package.py
@@ -15,6 +15,7 @@ class Macfuse(Package):
 
     version('4.1.2')
 
+    provides('fuse')
     conflicts('platform=linux', msg='macfuse does not support linux, use libfuse instead')
     conflicts('platform=cray', msg='macfuse does not support cray, use libfuse instead')
 

--- a/var/spack/repos/builtin/packages/py-fusepy/package.py
+++ b/var/spack/repos/builtin/packages/py-fusepy/package.py
@@ -17,3 +17,6 @@ class PyFusepy(PythonPackage):
     version('2.0.4', sha256='10f5c7f5414241bffecdc333c4d3a725f1d6605cae6b4eaf86a838ff49cdaf6c')
 
     depends_on('py-setuptools', type='build')
+    depends_on('libfuse@2.6:', when='platform=linux')
+    depends_on('libfuse@2.6:', when='platform=cray')
+    depends_on('macfuse@2.6:', when='platform=darwin')

--- a/var/spack/repos/builtin/packages/py-fusepy/package.py
+++ b/var/spack/repos/builtin/packages/py-fusepy/package.py
@@ -17,6 +17,4 @@ class PyFusepy(PythonPackage):
     version('2.0.4', sha256='10f5c7f5414241bffecdc333c4d3a725f1d6605cae6b4eaf86a838ff49cdaf6c')
 
     depends_on('py-setuptools', type='build')
-    depends_on('libfuse@2.6:', when='platform=linux')
-    depends_on('libfuse@2.6:', when='platform=cray')
-    depends_on('macfuse@2.6:', when='platform=darwin')
+    depends_on('fuse@2.6:')

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -31,8 +31,8 @@ class Squashfuse(AutotoolsPackage):
 
     conflicts('~shared', when='~static', msg="Enable shared, static or both")
 
-    depends_on('libfuse@2.5:')
-    depends_on('libfuse@:2.99', when='@:0.1.103')
+    depends_on('fuse@2.5:')
+    depends_on('fuse@:2.99', when='@:0.1.103')
 
     # Note: typically libfuse is external, but this implies that you have to make
     # pkg-config external too, because spack's pkg-config doesn't know how to

--- a/var/spack/repos/builtin/packages/sshfs/package.py
+++ b/var/spack/repos/builtin/packages/sshfs/package.py
@@ -18,7 +18,7 @@ class Sshfs(MesonPackage):
     version('3.7.1', sha256='fe5d3436d61b46974889e0c4515899c21a9d67851e3793c209989f72353d7750')
 
     depends_on('glib')
-    depends_on('libfuse@3.1.0:')
+    depends_on('fuse@3.1.0:')
 
     # used for libfuse; when libfuse is external, make sure that pkgconfig is
     # external too, since spack's pkgconfig might not be able to locate libfuse.


### PR DESCRIPTION
When I try to import `py-fusepy`, it complains that it can't find `libfuse`. When I add a dependency on `libfuse`, it tells me that `libfuse` only supports Linux and that I need `macFUSE` instead. So I added a `macfuse` package that requires users to manually install a DMG, then added a virtual dependency that depends on the OS. Also updated existing packages that depend on `libfuse`.