### PR TITLE
py-rioxarray: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-rioxarray/package.py
+++ b/var/spack/repos/builtin/packages/py-rioxarray/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyRioxarray(PythonPackage):
+    """rasterio xarray extension."""
+
+    homepage = "https://github.com/corteva/rioxarray"
+    pypi     = "rioxarray/rioxarray-0.4.1.post0.tar.gz"
+
+    maintainers = ['adamjstewart']
+
+    version('0.4.1.post0', sha256='f043f846724a58518f87dd3fa84acbe39e15a1fac7e64244be3d5dacac7fe62b')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-rasterio', type=('build', 'run'))
+    depends_on('py-scipy', type=('build', 'run'))
+    depends_on('py-xarray@0.17:', type=('build', 'run'))
+    depends_on('py-pyproj@2.2:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds and passes all import tests on macOS 10.15.7 with Python 3.8.10 and Apple Clang 12.0.0.