### PR TITLE
py-applicationinsights: fix import tests

### DIFF
--- a/var/spack/repos/builtin/packages/py-applicationinsights/package.py
+++ b/var/spack/repos/builtin/packages/py-applicationinsights/package.py
@@ -11,6 +11,14 @@ class PyApplicationinsights(PythonPackage):
     homepage = "https://github.com/Microsoft/ApplicationInsights-Python"
     pypi = "applicationinsights/applicationinsights-0.11.9.tar.gz"
 
+    # 'applicationinsights.django' requires 'django'
+    import_modules = [
+        'applicationinsights', 'applicationinsights.flask',
+        'applicationinsights.exceptions', 'applicationinsights.requests',
+        'applicationinsights.channel', 'applicationinsights.channel.contracts',
+        'applicationinsights.logging'
+    ]
+
     version('0.11.9', sha256='30a11aafacea34f8b160fbdc35254c9029c7e325267874e3c68f6bdbcd6ed2c3')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-applicationinsights/package.py
+++ b/var/spack/repos/builtin/packages/py-applicationinsights/package.py
@@ -11,7 +11,8 @@ class PyApplicationinsights(PythonPackage):
     homepage = "https://github.com/Microsoft/ApplicationInsights-Python"
     pypi = "applicationinsights/applicationinsights-0.11.9.tar.gz"
 
-    # 'applicationinsights.django' requires 'django'
+    # 'applicationinsights.django' requires 'django', but 'django' isn't listed as a
+    # dependency. Leave out of 'import_modules' list to avoid unnecessary dependency.
     import_modules = [
         'applicationinsights', 'applicationinsights.flask',
         'applicationinsights.exceptions', 'applicationinsights.requests',


### PR DESCRIPTION
Successfully builds and passes all import tests on macOS 10.15.7 with Python 3.8.10 and Apple Clang 12.0.0.