### PR TITLE
py-azure-identity: fix import tests

### DIFF
--- a/var/spack/repos/builtin/packages/py-azure-identity/package.py
+++ b/var/spack/repos/builtin/packages/py-azure-identity/package.py
@@ -10,7 +10,8 @@ class PyAzureIdentity(PythonPackage):
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity"
     pypi = "azure-identity/azure-identity-1.3.1.zip"
 
-    # 'azure.identity.aio' import doesn't work for some reason
+    # 'azure.identity.aio' import doesn't work for some reason, leave out of
+    # 'import_modules' list to ensure that tests still pass for other imports.
     import_modules = [
         'azure.identity', 'azure.identity._internal', 'azure.identity._credentials'
     ]

--- a/var/spack/repos/builtin/packages/py-azure-identity/package.py
+++ b/var/spack/repos/builtin/packages/py-azure-identity/package.py
@@ -10,6 +10,11 @@ class PyAzureIdentity(PythonPackage):
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/identity/azure-identity"
     pypi = "azure-identity/azure-identity-1.3.1.zip"
 
+    # 'azure.identity.aio' import doesn't work for some reason
+    import_modules = [
+        'azure.identity', 'azure.identity._internal', 'azure.identity._credentials'
+    ]
+
     version('1.3.1', sha256='5a59c36b4b05bdaec455c390feda71b6495fc828246593404351b9a41c2e877a')
     version('1.2.0', sha256='b32acd1cdb6202bfe10d9a0858dc463d8960295da70ae18097eb3b85ab12cb91')
 


### PR DESCRIPTION
Successfully builds and passes all import tests on macOS 10.15.7 with Python 3.8.10 and Apple Clang 12.0.0.