### PR TITLE
wget: add new version, fix macOS build

### DIFF
--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -15,6 +15,7 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
     homepage = "http://www.gnu.org/software/wget/"
     gnu_mirror_path = "wget/wget-1.19.1.tar.gz"
 
+    version('1.21.1', sha256='59ba0bdade9ad135eda581ae4e59a7a9f25e3a4bde6a5419632b31906120e26e')
     version('1.21',   sha256='b3bc1a9bd0c19836c9709c318d41c19c11215a07514f49f89b40b9d50ab49325')
     version('1.20.3', sha256='31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e')
     version('1.19.1', sha256='9e4f12da38cc6167d0752d934abe27c7b1599a9af294e73829be7ac7b5b4da40')
@@ -55,6 +56,7 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
 
         args = [
             '--with-ssl={0}'.format(spec.variants['ssl'].value),
+            '--without-included-regex',
         ]
 
         if '+zlib' in spec:


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.10 and Apple Clang 12.0.0.

Without the `--without-included-regex` flag, the build hits part of the source code that doesn't build with Apple Clang 12. Both Homebrew and Macports add this flag.