### PR TITLE
Log performance improvement

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -858,6 +858,4 @@ def _retry(function):
 
 
 def _input_available(f):
-    if f.readable():
-        return f in select.select([f], [], [], 0)[0]
-    return False
+    return f in select.select([f], [], [], 0)[0]

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -771,28 +771,34 @@ def _writer_daemon(stdin_multiprocess_fd, read_multiprocess_fd, write_fd, echo,
                                 raise
 
                 if in_pipe in rlist:
-                    # Handle output from the calling process.
-                    line = _retry(in_pipe.readline)()
-                    if not line:
-                        break
+                    line_count = 0
+                    while line_count < 100:
+                        # Handle output from the calling process.
+                        line = _retry(in_pipe.readline)()
+                        if not line:
+                            return
+                        line_count += 1
 
-                    # find control characters and strip them.
-                    controls = control.findall(line)
-                    line = control.sub('', line)
+                        # find control characters and strip them.
+                        controls = control.findall(line)
+                        line = control.sub('', line)
 
-                    # Echo to stdout if requested or forced.
-                    if echo or force_echo:
-                        sys.stdout.write(line)
-                        sys.stdout.flush()
+                        # Echo to stdout if requested or forced.
+                        if echo or force_echo:
+                            sys.stdout.write(line)
+                            sys.stdout.flush()
 
-                    # Stripped output to log file.
-                    log_file.write(_strip(line))
-                    log_file.flush()
+                        # Stripped output to log file.
+                        log_file.write(_strip(line))
+                        log_file.flush()
 
-                    if xon in controls:
-                        force_echo = True
-                    if xoff in controls:
-                        force_echo = False
+                        if xon in controls:
+                            force_echo = True
+                        if xoff in controls:
+                            force_echo = False
+
+                        if not _input_available(in_pipe):
+                            break
 
     except BaseException:
         tty.error("Exception occurred in writer daemon!")
@@ -844,3 +850,9 @@ def _retry(function):
                     continue
                 raise
     return wrapped
+
+
+def _input_available(f):
+    if f.readable():
+        return f in select.select([f], [], [], 0)[0]
+    return False

--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -781,20 +781,21 @@ def _writer_daemon(stdin_multiprocess_fd, read_multiprocess_fd, write_fd, echo,
                             line_count += 1
 
                             # find control characters and strip them.
-                            controls = control.findall(line)
-                            line = control.sub('', line)
+                            clean_line, num_controls = control.subn('', line)
 
                             # Echo to stdout if requested or forced.
                             if echo or force_echo:
-                                sys.stdout.write(line)
+                                sys.stdout.write(clean_line)
 
                             # Stripped output to log file.
-                            log_file.write(_strip(line))
+                            log_file.write(_strip(clean_line))
 
-                            if xon in controls:
-                                force_echo = True
-                            if xoff in controls:
-                                force_echo = False
+                            if num_controls > 0:
+                                controls = control.findall(line)
+                                if xon in controls:
+                                    force_echo = True
+                                if xoff in controls:
+                                    force_echo = False
 
                             if not _input_available(in_pipe):
                                 break


### PR DESCRIPTION
Running some builds with a substantial amount of output, I was noticing an entire core being burned by the log handler and some delay in output handling.  This is an attempt to address that while preserving the responsive behavior of input on standard input.

Summary of changes:
* When reading from in_pipe read as much as possible (polling with select to determine whether more is available) up to 100 lines before re-entering the blocking select, avoiding having to repeatedly set up and tear down signal handlers and so-forth
* Only scan the input line once in the common case, using subn to avoid the findall (which should be changed to either using a function on the sub, or just using "in" or similar since we don't care how many just which, leaving that for later since it's a small perf difference)
* Always flush, but flush *after* writing all input that got read in this block rather than on every line