### PR TITLE
defaults/cray: use modules.yaml from defaults/linux

### DIFF
--- a/etc/spack/defaults/cray/modules.yaml
+++ b/etc/spack/defaults/cray/modules.yaml
@@ -1,0 +1,21 @@
+# -------------------------------------------------------------------------
+# This is the default configuration for Spack's module file generation.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing the following files.
+#
+# Per-spack-instance settings (overrides defaults):
+#   $SPACK_ROOT/etc/spack/modules.yaml
+#
+# Per-user settings (overrides default and site settings):
+#   ~/.spack/modules.yaml
+# -------------------------------------------------------------------------
+modules:
+  prefix_inspections:
+    lib:
+      - LD_LIBRARY_PATH
+    lib64:
+      - LD_LIBRARY_PATH


### PR DESCRIPTION
Setup default modules on cray using the defaults for linux

@becker33 