### PR TITLE
Don't search for Python when SPACK_PYTHON is set

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -12,12 +12,16 @@
 """:"
 # prefer SPACK_PYTHON environment variable, python3, python, then python2
 SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
-for cmd in "${SPACK_PYTHON:-}" ${SPACK_PREFERRED_PYTHONS}; do
-    if command -v > /dev/null "$cmd"; then
-        export SPACK_PYTHON="$(command -v "$cmd")"
-        exec "${SPACK_PYTHON}" "$0" "$@"
-    fi
-done
+if [ -n "${SPACK_PYTHON:-}" ]; then
+    exec "${SPACK_PYTHON}" "$0" "$@"
+else
+    for cmd in ${SPACK_PREFERRED_PYTHONS}; do
+        if command -v > /dev/null "$cmd"; then
+            export SPACK_PYTHON=$(command -v "$cmd")
+            exec "${SPACK_PYTHON}" "$0" "$@"
+        fi
+    done
+fi
 
 echo "==> Error: spack could not find a python interpreter!" >&2
 exit 1

--- a/share/spack/setup-env.csh
+++ b/share/spack/setup-env.csh
@@ -60,15 +60,14 @@ alias _spack_pathadd 'set _pa_args = (\!*) && source $_spack_share_dir/csh/patha
 
 # Identify and lock the python interpreter
 if (! $?SPACK_PYTHON) then
-    setenv SPACK_PYTHON ""
+    foreach cmd (python3 python python2 /usr/libexec/platform-python)
+        command -v "$cmd" >& /dev/null
+        if ($status == 0) then
+            setenv SPACK_PYTHON `command -v "$cmd"`
+            break
+        endif
+    end
 endif
-foreach cmd ("$SPACK_PYTHON" python3 python python2)
-    command -v "$cmd" >& /dev/null
-    if ($status == 0) then
-        setenv SPACK_PYTHON `command -v "$cmd"`
-        break
-    endif
-end
 
 # Set variables needed by this script
 _spack_pathadd PATH "$SPACK_ROOT/bin"

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -670,11 +670,13 @@ set -l sp_source_file (status -f)  # name of current file
 #
 # Identify and lock the python interpreter
 #
-for cmd in "$SPACK_PYTHON" python3 python python2
-    set -l _sp_python (command -v "$cmd")
-    if test $status -eq 0
-        set -x SPACK_PYTHON $_sp_python
-        break
+if not set -q SPACK_PYTHON
+    for cmd in python3 python python2 /usr/libexec/platform-python
+        set -l _sp_python (command -v "$cmd")
+        if test $status -eq 0
+            set -x SPACK_PYTHON $_sp_python
+            break
+        end
     end
 end
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -327,12 +327,14 @@ if [ "$_sp_shell" = bash ]; then
 fi
 
 # Identify and lock the python interpreter
-for cmd in "${SPACK_PYTHON:-}" python3 python python2; do
-    if command -v > /dev/null "$cmd"; then
-        export SPACK_PYTHON="$(command -v "$cmd")"
-        break
-    fi
-done
+if [ -z "${SPACK_PYTHON:-}" ]; then
+    for cmd in python3 python python2 /usr/libexec/platform-python; do
+        if command -v > /dev/null "$cmd"; then
+            export SPACK_PYTHON=$(command -v "$cmd")
+            break
+        fi
+    done
+fi
 
 #
 # make available environment-modules


### PR DESCRIPTION
I propose to not search for Python if `SPACK_PYTHON` is set.
I also synced up lists of Python interpreters in `setup-env.*` scripts with that in `bin/spack`.