### PR TITLE
py-rasterio: add v1.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-rasterio/package.py
+++ b/var/spack/repos/builtin/packages/py-rasterio/package.py
@@ -21,12 +21,13 @@ class PyRasterio(PythonPackage):
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('1.2.3',  sha256='d8c345e01052b70ac3bbbe100c83def813c0ab19f7412c2c98e553d03720c1c5')
     version('1.1.8',  sha256='f7cac7e2ecf65b4b1eb78c994c63bd429b67dc679b0bc0ecfe487d3d5bf88fd5')
     version('1.1.5',  sha256='ebe75c71f9257c780615caaec8ef81fa4602702cf9290a65c213e1639284acc9')
     version('1.0.24', sha256='4839479621045211f66868ec49625979693450bc2e476f23e7e8ac4804eaf452')
     version('1.0a12', sha256='47d460326e04c64590ff56952271a184a6307f814efc34fb319c12e690585f3c')
 
-    depends_on('python@3.5:', type=('build', 'link', 'run'), when='@1.2:')
+    depends_on('python@3.6:3.9', type=('build', 'link', 'run'), when='@1.2:')
     depends_on('python@2.7:2.8,3.5:3.8', type=('build', 'link', 'run'), when='@1.1.0:1.1.999')
     depends_on('python@2.7:2.8,3.5:3.7', type=('build', 'link', 'run'), when='@:1.0')
     depends_on('py-setuptools', type=('build', 'run'))
@@ -35,11 +36,12 @@ class PyRasterio(PythonPackage):
     depends_on('py-attrs', type=('build', 'run'))
     depends_on('py-click@4:7', type=('build', 'run'))
     depends_on('py-cligj@0.5:', type=('build', 'run'))
+    depends_on('py-numpy@1.15:', type=('build', 'link', 'run'), when='@1.2:')
     depends_on('py-numpy', type=('build', 'link', 'run'))
     depends_on('py-snuggs@1.4.1:', type=('build', 'run'))
     depends_on('py-click-plugins', type=('build', 'run'))
     depends_on('py-enum34', type='run', when='^python@:3.3')
-    depends_on('gdal@3.0:', when='@1.2.0:')
+    depends_on('gdal@2.3:3.2', when='@1.2.0:')
     depends_on('gdal@1.11:3.2', when='@1.1.0:1.1.999')
     depends_on('gdal@1.11:3.0', when='@1.0.25:1.0.999')
     depends_on('gdal@1.11:2', when='@:1.0.24')


### PR DESCRIPTION
Successfully installs and passes all import tests on macOS 10.15.7 with Python 3.8.10 and Apple Clang 12.0.0.