### PR TITLE
Use flake8-import-order to enforce PEP-8 compliance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -66,6 +66,10 @@ exclude =
 
 format = spack
 
+# flake8-import-order settings
+application-import-names = llnl,spack
+import-order-style = google
+
 [flake8:local-plugins]
 report =
   spack = flake8_formatter:SpackFormatter

--- a/.flake8
+++ b/.flake8
@@ -68,7 +68,7 @@ format = spack
 
 # flake8-import-order settings
 application-import-names = llnl,spack
-import-order-style = google
+import-order-style = pycharm
 
 [flake8:local-plugins]
 report =

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -39,7 +39,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-        pip install --upgrade pip six setuptools flake8 mypy>=0.800 black types-six types-python-dateutil
+        pip install --upgrade pip six setuptools flake8 flake8-import-order mypy>=0.800 black types-six types-python-dateutil
     - name: Setup git configuration
       run: |
         # Need this for the git tests to succeed.
@@ -366,7 +366,7 @@ jobs:
       run: |
           pip install --upgrade pip six setuptools
           pip install --upgrade codecov coverage
-          pip install --upgrade flake8 pep8-naming mypy
+          pip install --upgrade flake8 flake8-import-order pep8-naming mypy
           pip install --upgrade python-dateutil
     - name: Setup Homebrew packages
       run: |

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -28,12 +28,10 @@ import traceback
 import types
 from typing import Any, Callable, Dict, List, Optional  # novm
 
-from ordereddict_backport import OrderedDict
 import six
+from ordereddict_backport import OrderedDict
 
 import llnl.util.filesystem as fsys
-from llnl.util.lang import memoized
-from llnl.util.link_tree import LinkTree
 import llnl.util.tty as tty
 import spack.compilers
 import spack.config
@@ -42,23 +40,25 @@ import spack.directives
 import spack.directory_layout
 import spack.error
 import spack.fetch_strategy as fs
-from spack.filesystem_view import YamlFilesystemView
 import spack.hooks
-from spack.install_test import TestFailure, TestSuite
-from spack.installer import InstallError, PackageInstaller
 import spack.mirror
 import spack.mixins
 import spack.multimethod
 import spack.paths
 import spack.repo
-from spack.stage import ResourceStage, Stage, stage_prefix, StageComposite
 import spack.store
 import spack.url
 import spack.util.environment
+import spack.util.web
+from llnl.util.lang import memoized
+from llnl.util.link_tree import LinkTree
+from spack.filesystem_view import YamlFilesystemView
+from spack.install_test import TestFailure, TestSuite
+from spack.installer import InstallError, PackageInstaller
+from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
 from spack.util.prefix import Prefix
-import spack.util.web
 from spack.version import Version
 
 """Allowed URL schemes for spack packages."""

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -10,6 +10,7 @@ The spack package class structure is based strongly on Homebrew
 packages.
 
 """
+
 import base64
 import collections
 import contextlib

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -8,7 +8,6 @@
 The spack package class structure is based strongly on Homebrew
 (http://brew.sh/), mainly because Homebrew makes it very easy to create
 packages.
-
 """
 
 import base64
@@ -26,13 +25,16 @@ import sys
 import textwrap
 import time
 import traceback
-import six
 import types
-from typing import Optional, List, Dict, Any, Callable  # novm
+from typing import Any, Callable, Dict, List, Optional  # novm
+
+from ordereddict_backport import OrderedDict
+import six
 
 import llnl.util.filesystem as fsys
+from llnl.util.lang import memoized
+from llnl.util.link_tree import LinkTree
 import llnl.util.tty as tty
-
 import spack.compilers
 import spack.config
 import spack.dependency
@@ -40,26 +42,23 @@ import spack.directives
 import spack.directory_layout
 import spack.error
 import spack.fetch_strategy as fs
+from spack.filesystem_view import YamlFilesystemView
 import spack.hooks
+from spack.install_test import TestFailure, TestSuite
+from spack.installer import InstallError, PackageInstaller
 import spack.mirror
 import spack.mixins
 import spack.multimethod
 import spack.paths
 import spack.repo
+from spack.stage import ResourceStage, Stage, stage_prefix, StageComposite
 import spack.store
 import spack.url
 import spack.util.environment
-import spack.util.web
-from llnl.util.lang import memoized
-from llnl.util.link_tree import LinkTree
-from ordereddict_backport import OrderedDict
-from spack.filesystem_view import YamlFilesystemView
-from spack.installer import PackageInstaller, InstallError
-from spack.install_test import TestFailure, TestSuite
-from spack.util.executable import which, ProcessError
-from spack.util.prefix import Prefix
-from spack.stage import stage_prefix, Stage, ResourceStage, StageComposite
+from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
+from spack.util.prefix import Prefix
+import spack.util.web
 from spack.version import Version
 
 """Allowed URL schemes for spack packages."""


### PR DESCRIPTION
### Description

This PR introduces `flake8-import-order` to Spack's style checking CI tests. [`flake8-import-order`](https://github.com/PyCQA/flake8-import-order) is a tool made by PyCQA, the same people who maintain `flake8` and all of its dependencies. It enforces proper ordering of imports according to the guidelines set by PEP-8.

### Rationale

According to https://www.python.org/dev/peps/pep-0008/#imports:

> Imports should be grouped in the following order:
>
> 1. Standard library imports.
> 2. Related third party imports.
> 3. Local application/library specific imports.
>
> You should put a blank line between each group of imports.

However, `flake8` and `black` on their own do not enforce this at all. 

The reason we originally added `flake8` was to end "edit wars" (mostly between @alalazo and me) where we would edit a file back and forth because we're both OCD about style and disagreed on some style things. This would lead to dozens of lines of code change for trivial changes, making reviewing difficult. With tools like `flake8` and `black`, we can set an agreed upon standard for code style by always going with whatever PEP-8 says to do.

In a lot of recent PRs that modify core, much of the PR is reordering of imports. But without any tool to enforce this, we're again at the mercy of personal opinion. With `flake8-import-order`, we can enforce this.

### Discussion

If we choose to use `flake8-import-order`, the only decision we need to make is which style to enforce. The PEP-8 guidelines don't specify anything about imports within each group (for example, within standard library imports), but there are various styles you can choose from with the tool. See https://github.com/PyCQA/flake8-import-order#styles for a complete list of supported styles. Personally, I prefer `google` style, but I'll let others comment and/or vote.

I edited a core Spack file with a lot of imports so we can see what the new `flake8` output will be. I'll modify these imports once we agree on a style to use so that the tests pass.