### PR TITLE
fix: replace I_MPI_SUBSTITUTE_INSTALLDIR with actual installation prefix in mpicc and related scripts

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -78,9 +78,13 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
             file = join_path(self.component_path, 'lib', lib_version, 'libmpi.so')
             subprocess.call(['patchelf', '--set-rpath', libfabric_rpath, file])
 
-        # fix I_MPI_SUBSTITUTE_INSTALLDIR and __EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__ 
-        for script in [ "mpif77", "mpif90", "mpigcc", "mpigxx", "mpiicc", "mpiicpc", "mpiifort", ]:
+        # fix I_MPI_SUBSTITUTE_INSTALLDIR and
+        #   __EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__
+        scripts = ["mpif77", "mpif90", "mpigcc", "mpigxx", "mpiicc", "mpiicpc",
+                   "mpiifort"]
+        for script in scripts:
             file = join_path(self.component_path, 'bin', script)
-            filter_file('I_MPI_SUBSTITUTE_INSTALLDIR',  self.component_path, file, backup=False)
-            filter_file('__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__',  self.component_path, file, backup=False)
-
+            filter_file('I_MPI_SUBSTITUTE_INSTALLDIR',
+                        self.component_path, file, backup=False)
+            filter_file('__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__',
+                        self.component_path, file, backup=False)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -77,3 +77,10 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         for lib_version in ['debug', 'release', 'release_mt', 'debug_mt']:
             file = join_path(self.component_path, 'lib', lib_version, 'libmpi.so')
             subprocess.call(['patchelf', '--set-rpath', libfabric_rpath, file])
+
+        # fix I_MPI_SUBSTITUTE_INSTALLDIR and __EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__ 
+        for script in [ "mpif77", "mpif90", "mpigcc", "mpigxx", "mpiicc", "mpiicpc", "mpiifort", ]:
+            file = join_path(self.component_path, 'bin', script)
+            filter_file('I_MPI_SUBSTITUTE_INSTALLDIR',  self.component_path, file, backup=False)
+            filter_file('__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__',  self.component_path, file, backup=False)
+


### PR DESCRIPTION
If you do not do this `mpicc -compile-info` will contain flags with `I_MPI_SUBSTITUTE_INSTALLDIR` instead of the actual path.