### PR TITLE
root: disable afterimage when ~x

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -359,7 +359,7 @@ class Root(CMakePackage):
         # Options related to ROOT's ability to download and build its own
         # dependencies. Per Spack convention, this should generally be avoided.
         options += [
-            define('builtin_afterimage', True),
+            define_from_variant('builtin_afterimage', 'x'),
             define('builtin_cfitsio', False),
             define('builtin_davix', False),
             define('builtin_fftw3', False),


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/23958 thanks to @pcanal's suggestion. Successfully configures and builds now.

```
-- darwin-bigsur-x86_64 / apple-clang@12.0.5 --------------------
x2yzovj root@6.24.00~aqua~davix~dcache~emacs~examples~fftw~fits~fortran+gdml+gminimal~graphviz~gsl~http~ipo~jemalloc~math~memstat+minuit~mlp~mysql~opengl~oracle~postgres~pythia6~pythia8+python~qt4~r+roofit~root7+rpath~shadow~spectrum~sqlite~ssl~table~tbb+threads~tmva+unuran~vc+vdt~veccore~vmc~x+xml~xrootd build_type=RelWithDebInfo cxxstd=14 patches=22af3471f3fd87c0fe8917bf9c811c6d806de6c8b9867d30a1e3d383a1b929d7
y5qdlej     freetype@2.10.4
5rkbg67         bzip2@1.0.8~debug~pic+shared
2vvkloa         libpng@1.6.37
w2ka2t3             zlib@1.2.11+optimize+pic+shared
6tu2pm6     libice@1.0.9
qqqpwu6         xproto@7.0.31
xpgytns         xtrans@1.3.5
7mraakx     libjpeg-turbo@2.0.6
atohmwo     libx11@1.7.0
uegtjni         inputproto@2.3.2
qmxndan         kbproto@1.0.7
kvinbm7         libxcb@1.14
rikmm2l             libpthread-stubs@0.4
a46bgbf             libxau@1.0.8
isld2ks             libxdmcp@1.1.2
avr2egs             xcb-proto@1.14.1
q4fu7bm         xextproto@7.3.0
sxahmdq     libxml2@2.9.10~python
cvtwddx         libiconv@1.16
2lfwfzj         xz@5.2.5~pic libs=shared,static
23num3u     lz4@1.9.3 libs=shared,static
dyy2civ     ncurses@6.2~symlinks+termlib abi=none
bpaildk     nlohmann-json@3.9.1~ipo+single_header build_type=RelWithDebInfo
dhshvq2     openblas@0.3.15~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none
fedpild     pcre@8.44+jit+multibyte+utf
bgwzclk     python@3.8.10+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87
grybb7j         apple-libuuid@1353.100.2
gtbk7yb         expat@2.3.0~libbsd
5batqmm         gdbm@1.19
lnlezei             readline@8.1
3gj3usv         gettext@0.21+bzip2+curses+git~libunistring+libxml2+tar+xz
vlfgvim             tar@1.34
qnaaicn         libffi@3.3 patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0
qavtpzm         openssl@1.1.1k~docs+systemcerts
conigxv         sqlite@3.35.5+column_metadata+fts~functions~rtree
b4xgrvh     unuran@1.8.1~gsl+rngstreams+shared
njgzx2d         rngstreams@1.0.1
h56xbxt     vdt@0.4.3~ipo build_type=RelWithDebInfo
rzdvob7     xxhash@0.7.4
i66nf5p     zstd@1.5.0~ipo~legacy~lz4~lzma+multithread+programs+shared+static~zlib build_type=RelWithDebInfo
```