### PR TITLE
Fix bug where cmake prefix path on the command line does not include transitive deps

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -314,6 +314,9 @@ def _place_externals_last(spec_container):
     they should be deprioritized for any search order (i.e. in PATH, or
     for a set of -L entries in a compiler invocation).
     """
+    # Establish an arbitrary but fixed ordering of specs so that resulting
+    # environment variable values are stable
+    spec_container = sorted(spec_container, key=lambda x: x.name)
     first = list(x for x in spec_container if not x.external)
     second = list(x for x in spec_container if x.external)
     return first + second
@@ -343,22 +346,17 @@ def set_build_environment_variables(pkg, env, dirty):
     for build_dep in build_deps:
         build_and_supporting_deps.update(build_dep.traverse(deptype='run'))
 
-    # Establish an arbitrary but fixed ordering of specs so that resulting
-    # environment variable values are stable
-    def _order(specs):
-        return sorted(specs, key=lambda x: x.name)
-
     # External packages may be installed in a prefix which contains many other
     # package installs. To avoid having those installations override
     # Spack-installed packages, they are placed at the end of search paths.
     # System prefixes are removed entirely later on since they are already
     # searched.
-    build_deps = _place_externals_last(_order(build_deps))
-    link_deps = _place_externals_last(_order(link_deps))
-    build_link_deps = _place_externals_last(_order(build_link_deps))
-    rpath_deps = _place_externals_last(_order(rpath_deps))
+    build_deps = _place_externals_last(build_deps)
+    link_deps = _place_externals_last(link_deps)
+    build_link_deps = _place_externals_last(build_link_deps)
+    rpath_deps = _place_externals_last(rpath_deps)
     build_and_supporting_deps = _place_externals_last(
-        _order(build_and_supporting_deps))
+        build_and_supporting_deps)
 
     link_dirs = []
     include_dirs = []
@@ -411,7 +409,7 @@ def set_build_environment_variables(pkg, env, dirty):
         x.prefix for x in build_link_deps)
 
     # Add dependencies to CMAKE_PREFIX_PATH
-    env.set_path('CMAKE_PREFIX_PATH', build_link_prefixes)
+    env.set_path('CMAKE_PREFIX_PATH', get_cmake_prefix_path(pkg))
 
     # Set environment variables if specified for
     # the given compiler
@@ -712,6 +710,15 @@ def get_rpaths(pkg):
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:
         rpaths.append(path_from_modules([pkg.compiler.modules[1]]))
     return list(dedupe(filter_system_paths(rpaths)))
+
+
+def get_cmake_prefix_path(pkg):
+    build_deps      = set(pkg.spec.dependencies(deptype=('build', 'test')))
+    link_deps       = set(pkg.spec.traverse(root=False, deptype=('link')))
+    build_link_deps = build_deps | link_deps
+    build_link_deps = _place_externals_last(build_link_deps)
+    build_link_prefixes = filter_system_paths(x.prefix for x in build_link_deps)
+    return build_link_prefixes
 
 
 def get_std_cmake_args(pkg):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -12,7 +12,6 @@ from typing import List  # novm
 
 import spack.build_environment
 from llnl.util.filesystem import working_dir
-from spack.util.environment import filter_system_paths
 from spack.directives import depends_on, variant, conflicts
 from spack.package import PackageBase, InstallError, run_after
 
@@ -185,13 +184,9 @@ class CMakePackage(PackageBase):
             define('CMAKE_INSTALL_RPATH_USE_LINK_PATH', False),
             define('CMAKE_INSTALL_RPATH',
                    spack.build_environment.get_rpaths(pkg)),
+            define('CMAKE_PREFIX_PATH',
+                   spack.build_environment.get_cmake_prefix_path(pkg))
         ])
-        # CMake's find_package() looks in CMAKE_PREFIX_PATH first, help CMake
-        # to find immediate link dependencies in right places:
-        deps = [d.prefix for d in
-                pkg.spec.dependencies(deptype=('build', 'link'))]
-        deps = filter_system_paths(deps)
-        args.append(define('CMAKE_PREFIX_PATH', deps))
         return args
 
     @staticmethod


### PR DESCRIPTION
Transitive link deps were not added in the CMAKE_PREFIX_PATH causing the rocm overhaul PR to pick up system installs of deps of deps of deps during a spack build.
