### PR TITLE
intel-tbb: install pkgconfig file

### DIFF
--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -305,7 +305,7 @@ class IntelTbb(CMakePackage):
         # It must not be overwritten by spack-generated tbb.pc.
         # https://github.com/oneapi-src/oneTBB/commit/478de5b1887c928e52f029d706af6ea640a877be
         if self.spec.satisfies('@:2021.2.0', strict=True):
-            libdir = self.spec['intel-tbb'].libs.directories[0]
+            libdir = self.libs.directories[0]
             pkg_path = join_path(libdir, 'pkgconfig')
             mkdirp(pkg_path)
 

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -298,6 +298,7 @@ class IntelTbb(CMakePackage):
             options.append('-DCMAKE_CXX_STANDARD=%s' %
                            spec.variants['cxxstd'].value)
         return options
+
     @run_after('install')
     def install_pkgconfig(self):
         # pkg-config generation is introduced in May 5, 2021.

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -300,18 +300,22 @@ class IntelTbb(CMakePackage):
         return options
     @run_after('install')
     def install_pkgconfig(self):
-        libdir = self.spec['tbb'].libs.directories[0]
-        pkg_path = join_path(libdir, 'pkgconfig')
-        mkdirp(pkg_path)
+        # pkg-config generation is introduced in May 5, 2021.
+        # It must not be overwritten by spack-generated tbb.pc.
+        # https://github.com/oneapi-src/oneTBB/commit/478de5b1887c928e52f029d706af6ea640a877be
+        if self.spec.satisfies('@:2021.2.0', strict=True):
+            libdir = self.spec['tbb'].libs.directories[0]
+            pkg_path = join_path(libdir, 'pkgconfig')
+            mkdirp(pkg_path)
 
-        with open(join_path(pkg_path, 'tbb.pc'), 'w') as f:
-            f.write('prefix={0}\n'.format(self.prefix))
-            f.write('exec_prefix=${prefix}\n')
-            f.write('libdir={0}\n'.format(libdir))
-            f.write('includedir={0}\n'.format(self.prefix.include))
-            f.write('\n')
-            f.write('Name: Threading Building Blocks\n')
-            f.write('Description: Intel\'s parallelism library for C++\n')
-            f.write('Version: {0}\n'.format(self.spec.version))
-            f.write('Cflags: -I${includedir}\n')
-            f.write('Libs: -L${libdir} -ltbb -latomic\n')
+            with open(join_path(pkg_path, 'tbb.pc'), 'w') as f:
+                f.write('prefix={0}\n'.format(self.prefix))
+                f.write('exec_prefix=${prefix}\n')
+                f.write('libdir={0}\n'.format(libdir))
+                f.write('includedir={0}\n'.format(self.prefix.include))
+                f.write('\n')
+                f.write('Name: Threading Building Blocks\n')
+                f.write('Description: Intel\'s parallelism library for C++\n')
+                f.write('Version: {0}\n'.format(self.spec.version))
+                f.write('Cflags: -I${includedir}\n')
+                f.write('Libs: -L${libdir} -ltbb -latomic\n')

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -305,7 +305,7 @@ class IntelTbb(CMakePackage):
         # It must not be overwritten by spack-generated tbb.pc.
         # https://github.com/oneapi-src/oneTBB/commit/478de5b1887c928e52f029d706af6ea640a877be
         if self.spec.satisfies('@:2021.2.0', strict=True):
-            libdir = self.spec['tbb'].libs.directories[0]
+            libdir = self.spec['intel-tbb'].libs.directories[0]
             pkg_path = join_path(libdir, 'pkgconfig')
             mkdirp(pkg_path)
 

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -298,3 +298,20 @@ class IntelTbb(CMakePackage):
             options.append('-DCMAKE_CXX_STANDARD=%s' %
                            spec.variants['cxxstd'].value)
         return options
+    @run_after('install')
+    def install_pkgconfig(self):
+        libdir = self.spec['tbb'].libs.directories[0]
+        pkg_path = join_path(libdir, 'pkgconfig')
+        mkdirp(pkg_path)
+
+        with open(join_path(pkg_path, 'tbb.pc'), 'w') as f:
+            f.write('prefix={0}\n'.format(self.prefix))
+            f.write('exec_prefix=${prefix}\n')
+            f.write('libdir={0}\n'.format(libdir))
+            f.write('includedir={0}\n'.format(self.prefix.include))
+            f.write('\n')
+            f.write('Name: Threading Building Blocks\n')
+            f.write('Description: Intel\'s parallelism library for C++\n')
+            f.write('Version: {0}\n'.format(self.spec.version))
+            f.write('Cflags: -I${includedir}\n')
+            f.write('Libs: -L${libdir} -ltbb -latomic\n')

--- a/var/spack/repos/builtin/packages/intel-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-tbb/package.py
@@ -305,14 +305,12 @@ class IntelTbb(CMakePackage):
         # It must not be overwritten by spack-generated tbb.pc.
         # https://github.com/oneapi-src/oneTBB/commit/478de5b1887c928e52f029d706af6ea640a877be
         if self.spec.satisfies('@:2021.2.0', strict=True):
-            libdir = self.libs.directories[0]
-            pkg_path = join_path(libdir, 'pkgconfig')
-            mkdirp(pkg_path)
+            mkdirp(self.prefix.lib.pkgconfig)
 
-            with open(join_path(pkg_path, 'tbb.pc'), 'w') as f:
+            with open(join_path(self.prefix.lib.pkgconfig, 'tbb.pc'), 'w') as f:
                 f.write('prefix={0}\n'.format(self.prefix))
                 f.write('exec_prefix=${prefix}\n')
-                f.write('libdir={0}\n'.format(libdir))
+                f.write('libdir={0}\n'.format(self.prefix.lib))
                 f.write('includedir={0}\n'.format(self.prefix.include))
                 f.write('\n')
                 f.write('Name: Threading Building Blocks\n')


### PR DESCRIPTION
Currently, `intel-tbb` doesn't export `tbb.pc` files, and cannot be referenced from dependents by pkg-config.

pkg-config generation [may be introduced](https://github.com/oneapi-src/oneTBB/issues/5), but not available in now or earlier versions (e.g. version 2020.3). 

This changes allows to export  `tbb.pc` , like [leveldb do](https://github.com/spack/spack/pull/3441).

I'll explain how it will affect `intel-tbb` users.

---

[pmemkv](https://github.com/spack/spack/blob/4e8d87e5cc9c6cc536e4bd919e5f53aa7c3a7c75/var/spack/repos/builtin/packages/pmemkv/package.py#L47) is one of packages which want to use  `intel-tbb` 's  `tbb.pc`.

`pmemkv` finds `tbb` from [pkg-config](https://github.com/pmem/pmemkv/blob/4ab5a4608d44c534e713f9f644fe117a0d6b9bda/CMakeLists.txt#L281), deb, rpm, or [`TBB_DIR`](https://github.com/pmem/pmemkv/blob/4ab5a4608d44c534e713f9f644fe117a0d6b9bda/cmake/tbb.cmake#L19).

So `pmemkv` cannot reference `intel-tbb` now ( and I want to fix that ).

For `pmemkv`, generating `tbb.pc` in `intel-tbb` is the easiest way since `pmemkv` doesn't have to know where `intel-tbb` is installed.

To set `TBB_DIR`, we need to write complicated patch. It is not a good solution.


---
[xtensor](https://github.com/spack/spack/blob/3d2cd480486648cd60c2400b9771df34e7aca684/var/spack/repos/builtin/packages/xtensor/package.py#L41) is one of packages which uses [FindTBB](https://github.com/justusc/FindTBB) to find TBB with [find_path](https://github.com/justusc/FindTBB/blob/25ecdea817b3af4a26d74ddcd439642dbd706acb/FindTBB.cmake#L177).

xtensor doesn't use `pkg_check_modules` and pkg-config, so there is no effect for xtensor.

[As far as I can find](https://github.com/spack/spack/search?l=Python&q=tbb), most packages take this approach.

