### PR TITLE
Use AWS CloudFront for source mirror

### DIFF
--- a/etc/spack/defaults/mirrors.yaml
+++ b/etc/spack/defaults/mirrors.yaml
@@ -1,2 +1,2 @@
 mirrors:
-  spack-public: https://spack-llnl-mirror.s3-us-west-2.amazonaws.com/
+  spack-public: https://mirror.spack.io


### PR DESCRIPTION
Fixes #23062.

Spack's source mirror was previously in a plain old S3 bucket. That will still work, but we can do better. This switches to AWS's CloudFront CDN for hosting the mirror.

CloudFront is 16x faster (or more) than the old bucket.

- [x] change mirror to https://mirror.spack.io