### PR TITLE
Python: fix +tkinter+tix support

### DIFF
--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -94,7 +94,8 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         """
         # When using tkinter from within spack provided python+tkinter,
         # python will not be able to find Tcl unless TCL_LIBRARY is set.
-        env.set('TCL_LIBRARY', os.path.dirname(find(self.prefix, 'init.tcl')[0]))
+        env.set('TCL_LIBRARY', os.path.dirname(
+            sorted(find(self.prefix, 'init.tcl'))[0]))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TCL_LIBRARY to the directory containing init.tcl.
@@ -106,7 +107,8 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         * https://wiki.tcl-lang.org/page/TCL_LIBRARY
         * https://wiki.tcl-lang.org/page/TCLLIBPATH
         """
-        env.set('TCL_LIBRARY', os.path.dirname(find(self.prefix, 'init.tcl')[0]))
+        env.set('TCL_LIBRARY', os.path.dirname(
+            sorted(find(self.prefix, 'init.tcl'))[0]))
 
         # If we set TCLLIBPATH, we must also ensure that the corresponding
         # tcl is found in the build environment. This to prevent cases

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -9,14 +9,13 @@ from spack.util.environment import is_system_path
 
 
 class Tcl(AutotoolsPackage, SourceforgePackage):
-    """Tcl (Tool Command Language) is a very powerful but easy to
-       learn dynamic programming language, suitable for a very wide
-       range of uses, including web and desktop applications,
-       networking, administration, testing and many more. Open source
-       and business-friendly, Tcl is a mature yet evolving language
-       that is truly cross platform, easily deployed and highly
-       extensible."""
-    homepage = "http://www.tcl.tk"
+    """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic
+    programming language, suitable for a very wide range of uses, including web and
+    desktop applications, networking, administration, testing and many more. Open source
+    and business-friendly, Tcl is a mature yet evolving language that is truly cross
+    platform, easily deployed and highly extensible."""
+
+    homepage = "https://www.tcl.tk/"
     sourceforge_mirror_path = "tcl/tcl8.6.11-src.tar.gz"
 
     version('8.6.11', sha256='8c0486668586672c5693d7d95817cb05a18c5ecca2f40e2836b9578064088258')
@@ -38,7 +37,7 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         with working_dir(self.build_directory):
             make('install')
 
-            # http://wiki.tcl.tk/17463
+            # https://wiki.tcl-lang.org/page/kitgen
             if self.spec.satisfies('@8.6:'):
                 make('install-headers')
 
@@ -81,21 +80,32 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
     def command(self):
         """Returns the tclsh command.
 
-        :returns: The tclsh command
-        :rtype: Executable
+        Returns:
+            Executable: the tclsh command
         """
         return Executable(os.path.realpath(self.prefix.bin.tclsh))
 
     def setup_run_environment(self, env):
+        """Set TCL_LIBRARY to the directory containing init.tcl.
+
+        For further info see:
+
+        * https://wiki.tcl-lang.org/page/TCL_LIBRARY
+        """
         # When using Tkinter from within spack provided python+tkinter, python
         # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.
         env.set('TCL_LIBRARY', self.spec['tcl'].libs.directories[0])
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        """Set TCLLIBPATH to include the tcl-shipped directory for
+        """Set TCL_LIBRARY to the directory containing init.tcl.
+        Set TCLLIBPATH to include the tcl-shipped directory for
         extensions and any other tcl extension it depends on.
-        For further info see: https://wiki.tcl.tk/1787"""
 
+        For further info see:
+
+        * https://wiki.tcl-lang.org/page/TCL_LIBRARY
+        * https://wiki.tcl-lang.org/page/TCLLIBPATH
+        """
         env.set('TCL_LIBRARY', self.spec['tcl'].libs.directories[0])
 
         # If we set TCLLIBPATH, we must also ensure that the corresponding
@@ -106,35 +116,39 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         if not is_system_path(self.prefix.bin):
             env.prepend_path('PATH', self.prefix.bin)
 
-        tcl_paths = [join_path(self.spec['tcl'].libs.directories[0],
-                               'tcl{0}'.format(self.version.up_to(2)))]
+        # WARNING: paths in $TCLLIBPATH must be *space* separated,
+        # its value is meant to be a Tcl list, *not* an env list
+        # as explained here: https://wiki.tcl-lang.org/page/TCLLIBPATH:
+        # "TCLLIBPATH is a Tcl list, not some platform-specific
+        # colon-separated or semi-colon separated format"
+
+        # WARNING: Tcl and Tcl extensions like Tk install their configuration files
+        # in subdirectories like `<prefix>/lib/tcl8.6`. However, Tcl is aware of this,
+        # and $TCLLIBPATH should only contain `<prefix>/lib`.
+        env.prepend_path(
+            'TCLLIBPATH', self.spec['tcl'].libs.directories[0], separator=' ')
 
         for d in dependent_spec.traverse(deptype=('build', 'run', 'test')):
             if d.package.extends(self.spec):
                 # Tcl libraries may be installed in lib or lib64, see #19546
                 for lib in ['lib', 'lib64']:
-                    tcl_paths.append(join_path(
-                        d.prefix, lib, 'tcl{0}'.format(self.version.up_to(2))))
-
-        # WARNING: paths in $TCLLIBPATH must be *space* separated,
-        # its value is meant to be a Tcl list, *not* an env list
-        # as explained here: https://wiki.tcl.tk/1787:
-        # "TCLLIBPATH is a Tcl list, not some platform-specific
-        # colon-separated or semi-colon separated format"
-        tcllibpath = ' '.join(tcl_paths)
-        env.set('TCLLIBPATH', tcllibpath)
+                    tcllibpath = join_path(self.prefix, lib)
+                    if os.path.exists(tcllibpath):
+                        env.prepend_path('TCLLIBPATH', tcllibpath, separator=' ')
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         """Set TCLLIBPATH to include the tcl-shipped directory for
         extensions and any other tcl extension it depends on.
-        For further info see: https://wiki.tcl.tk/1787"""
 
+        For further info see:
+
+        * https://wiki.tcl-lang.org/page/TCLLIBPATH
+        """
         # For run time environment set only the path for
         # dependent_spec and prepend it to TCLLIBPATH
         if dependent_spec.package.extends(self.spec):
             # Tcl libraries may be installed in lib or lib64, see #19546
             for lib in ['lib', 'lib64']:
-                tcllibpath = join_path(
-                    self.prefix, lib, 'tcl{0}'.format(self.version.up_to(2)))
+                tcllibpath = join_path(self.prefix, lib)
                 if os.path.exists(tcllibpath):
                     env.prepend_path('TCLLIBPATH', tcllibpath, separator=' ')

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -92,9 +92,10 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
 
         * https://wiki.tcl-lang.org/page/TCL_LIBRARY
         """
-        # When using Tkinter from within spack provided python+tkinter, python
-        # will not be able to find Tcl/Tk unless TCL_LIBRARY is set.
-        env.set('TCL_LIBRARY', self.spec['tcl'].libs.directories[0])
+        # When using tkinter from within spack provided python+tkinter,
+        # python will not be able to find Tcl unless TCL_LIBRARY is set.
+        env.set('TCL_LIBRARY', join_path(self.spec['tcl'].libs.directories[0],
+                                         'tcl{0}'.format(self.version.up_to(2))))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TCL_LIBRARY to the directory containing init.tcl.
@@ -106,7 +107,8 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         * https://wiki.tcl-lang.org/page/TCL_LIBRARY
         * https://wiki.tcl-lang.org/page/TCLLIBPATH
         """
-        env.set('TCL_LIBRARY', self.spec['tcl'].libs.directories[0])
+        env.set('TCL_LIBRARY', join_path(self.spec['tcl'].libs.directories[0],
+                                         'tcl{0}'.format(self.version.up_to(2))))
 
         # If we set TCLLIBPATH, we must also ensure that the corresponding
         # tcl is found in the build environment. This to prevent cases
@@ -132,7 +134,7 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
             if d.package.extends(self.spec):
                 # Tcl libraries may be installed in lib or lib64, see #19546
                 for lib in ['lib', 'lib64']:
-                    tcllibpath = join_path(self.prefix, lib)
+                    tcllibpath = join_path(dependent_spec.prefix, lib)
                     if os.path.exists(tcllibpath):
                         env.prepend_path('TCLLIBPATH', tcllibpath, separator=' ')
 
@@ -149,6 +151,6 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         if dependent_spec.package.extends(self.spec):
             # Tcl libraries may be installed in lib or lib64, see #19546
             for lib in ['lib', 'lib64']:
-                tcllibpath = join_path(self.prefix, lib)
+                tcllibpath = join_path(dependent_spec.prefix, lib)
                 if os.path.exists(tcllibpath):
                     env.prepend_path('TCLLIBPATH', tcllibpath, separator=' ')

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -83,7 +83,11 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         Returns:
             Executable: the tclsh command
         """
-        return Executable(os.path.realpath(self.prefix.bin.tclsh))
+        # Although we symlink tclshX.Y to tclsh, we also need to support external
+        # installations that may not have this symlink, or may have multiple versions
+        # of Tcl installed in the same directory.
+        return Executable(os.path.realpath(self.prefix.bin.join(
+            'tclsh{0}'.format(self.version.up_to(2)))))
 
     def setup_run_environment(self, env):
         """Set TCL_LIBRARY to the directory containing init.tcl.
@@ -126,7 +130,9 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
 
         # WARNING: Tcl and Tcl extensions like Tk install their configuration files
         # in subdirectories like `<prefix>/lib/tcl8.6`. However, Tcl is aware of this,
-        # and $TCLLIBPATH should only contain `<prefix>/lib`.
+        # and $TCLLIBPATH should only contain `<prefix>/lib`. $TCLLIBPATH is only needed
+        # because we install Tcl extensions to different directories than Tcl. See:
+        # https://core.tcl-lang.org/tk/tktview/447bd3e4abe17452d19a80e6840dcc8a2603fcbc
         env.prepend_path(
             'TCLLIBPATH', self.spec['tcl'].libs.directories[0], separator=' ')
 

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -94,8 +94,7 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         """
         # When using tkinter from within spack provided python+tkinter,
         # python will not be able to find Tcl unless TCL_LIBRARY is set.
-        env.set('TCL_LIBRARY', join_path(self.spec['tcl'].libs.directories[0],
-                                         'tcl{0}'.format(self.version.up_to(2))))
+        env.set('TCL_LIBRARY', os.path.dirname(find(self.prefix, 'init.tcl')[0]))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TCL_LIBRARY to the directory containing init.tcl.
@@ -107,8 +106,7 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
         * https://wiki.tcl-lang.org/page/TCL_LIBRARY
         * https://wiki.tcl-lang.org/page/TCLLIBPATH
         """
-        env.set('TCL_LIBRARY', join_path(self.spec['tcl'].libs.directories[0],
-                                         'tcl{0}'.format(self.version.up_to(2))))
+        env.set('TCL_LIBRARY', os.path.dirname(find(self.prefix, 'init.tcl')[0]))
 
         # If we set TCLLIBPATH, we must also ensure that the corresponding
         # tcl is found in the build environment. This to prevent cases

--- a/var/spack/repos/builtin/packages/tcl/package.py
+++ b/var/spack/repos/builtin/packages/tcl/package.py
@@ -140,7 +140,7 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
             if d.package.extends(self.spec):
                 # Tcl libraries may be installed in lib or lib64, see #19546
                 for lib in ['lib', 'lib64']:
-                    tcllibpath = join_path(dependent_spec.prefix, lib)
+                    tcllibpath = join_path(d.prefix, lib)
                     if os.path.exists(tcllibpath):
                         env.prepend_path('TCLLIBPATH', tcllibpath, separator=' ')
 
@@ -152,11 +152,10 @@ class Tcl(AutotoolsPackage, SourceforgePackage):
 
         * https://wiki.tcl-lang.org/page/TCLLIBPATH
         """
-        # For run time environment set only the path for
-        # dependent_spec and prepend it to TCLLIBPATH
-        if dependent_spec.package.extends(self.spec):
-            # Tcl libraries may be installed in lib or lib64, see #19546
-            for lib in ['lib', 'lib64']:
-                tcllibpath = join_path(dependent_spec.prefix, lib)
-                if os.path.exists(tcllibpath):
-                    env.prepend_path('TCLLIBPATH', tcllibpath, separator=' ')
+        for d in dependent_spec.traverse(deptype=('build', 'run', 'test')):
+            if d.package.extends(self.spec):
+                # Tcl libraries may be installed in lib or lib64, see #19546
+                for lib in ['lib', 'lib64']:
+                    tcllibpath = join_path(d.prefix, lib)
+                    if os.path.exists(tcllibpath):
+                        env.prepend_path('TCLLIBPATH', tcllibpath, separator=' ')

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -59,6 +59,12 @@ class Tix(AutotoolsPackage):
         if 'platform=darwin' in self.spec:
             fix_darwin_install_name(self.prefix.lib.Tix + str(self.version))
 
+    def test(self):
+        test_data_dir = self.test_suite.current_test_data_dir
+        test_file = test_data_dir.join('test.tcl')
+        self.run_test(self.spec['tcl'].command.path, test_file,
+                      purpose='test that tix can be loaded')
+
     @property
     def libs(self):
         return find_libraries(['libTix{0}'.format(self.version)],

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack import *
 
 
@@ -53,7 +55,7 @@ class Tix(AutotoolsPackage):
         """
         # When using tkinter.tix from within spack provided python+tkinter+tix,
         # python will not be able to find Tix unless TIX_LIBRARY is set.
-        env.set('TIX_LIBRARY', self.spec['tix'].libs.directories[0])
+        env.set('TIX_LIBRARY', os.path.dirname(find(self.prefix, 'Tix.tcl')[0]))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TIX_LIBRARY to the directory containing Tix.tcl.
@@ -62,4 +64,4 @@ class Tix(AutotoolsPackage):
 
         * http://tix.sourceforge.net/docs/pdf/TixUser.pdf
         """
-        env.set('TIX_LIBRARY', self.spec['tix'].libs.directories[0])
+        env.set('TIX_LIBRARY', os.path.dirname(find(self.prefix, 'Tix.tcl')[0]))

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -19,8 +19,8 @@ class Tix(AutotoolsPackage):
 
     version('8.4.3', sha256='562f040ff7657e10b5cffc2c41935f1a53c6402eb3d5f3189113d734fd6c03cb')
 
-    extends('tcl')
-    depends_on('tk')
+    extends('tcl', type=('build', 'link', 'run'))
+    depends_on('tk', type=('build', 'link', 'run'))
 
     patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/panic.patch',
           sha256='1be1a1c7453f6ab8771f90d7e7c0f8959490104752a16a8755bbb7287a841a96',
@@ -53,6 +53,12 @@ class Tix(AutotoolsPackage):
         ]
         return args
 
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if 'platform=darwin' in self.spec:
+            fix_darwin_install_name(self.prefix.lib.Tix + str(self.version))
+
     @property
     def libs(self):
         return find_libraries(['libTix{0}'.format(self.version)],
@@ -77,9 +83,3 @@ class Tix(AutotoolsPackage):
         * http://tix.sourceforge.net/docs/pdf/TixUser.pdf
         """
         env.set('TIX_LIBRARY', os.path.dirname(find(self.prefix, 'Tix.tcl')[0]))
-
-    @run_after('install')
-    def darwin_fix(self):
-        # The shared library is not installed correctly on Darwin; fix this
-        if 'platform=darwin' in self.spec:
-            fix_darwin_install_name(self.prefix.lib.Tix + str(self.version))

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -25,12 +25,24 @@ class Tix(AutotoolsPackage):
     patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/panic.patch',
           sha256='1be1a1c7453f6ab8771f90d7e7c0f8959490104752a16a8755bbb7287a841a96',
           level=0)
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-generic-tixGrSort.c.diff',
-          sha256='99b33cc307f71bcf9cc6f5a44b588f22956884ce3f1e4c716ad64c79cf9c5f41',
-          level=0)
     patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/implicit.patch',
           sha256='8a2720368c7757896814684147029d8318b9aa3b0914b3f37dd5e8a8603a61d3',
           level=0)
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-generic-tixGrSort.c.diff',
+          sha256='99b33cc307f71bcf9cc6f5a44b588f22956884ce3f1e4c716ad64c79cf9c5f41',
+          level=0)
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-missing-headers.diff',
+          sha256='d9f789dcfe5f4c5ee4589a18f9f410cdf162e41d35d00648c1ef37831f4a2b2b',
+          level=0)
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-tk_x11.diff',
+          sha256='1e28d8eee1aaa956a00571cf495a4775e72a993958dff1cabfbc5f102e327a6f',
+          level=0)
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-tk_aqua.diff',
+          sha256='41a717f5d95f61b4b8196ca6f14ece8f4764d4ba58fb2e1ae15e3240ee5ac534',
+          level=0, when='platform=darwin')
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-dyld_variable.diff',
+          sha256='719eb2e4d8c5d6aae897e5f676cf5ed1a0005c1bd07fd9b18705d81a005f592b',
+          level=0, when='platform=darwin')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -7,16 +7,28 @@ from spack import *
 
 
 class Tix(AutotoolsPackage):
-    """Tix is a powerful high-level widget set that expands the capabilities
-       of your Tk/Tcl and Python applications."""
+    """Tix, the Tk Interface eXtension, is a powerful set of user interface components
+    that expands the capabilities of your Tcl/Tk and Python applications. Using Tix
+    together with Tk will greatly enhance the appearance and functionality of your
+    application."""
 
     homepage = "https://sourceforge.net/projects/tix/"
     url      = "https://sourceforge.net/projects/tix/files/tix/8.4.3/Tix8.4.3-src.tar.gz/download"
+
     version('8.4.3', sha256='562f040ff7657e10b5cffc2c41935f1a53c6402eb3d5f3189113d734fd6c03cb')
 
     extends('tcl')
-    depends_on('tk@:8.5.99')
-    depends_on('tcl@:8.5.99')
+    depends_on('tk')
+
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/panic.patch',
+          sha256='1be1a1c7453f6ab8771f90d7e7c0f8959490104752a16a8755bbb7287a841a96',
+          level=0)
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-generic-tixGrSort.c.diff',
+          sha256='99b33cc307f71bcf9cc6f5a44b588f22956884ce3f1e4c716ad64c79cf9c5f41',
+          level=0)
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/implicit.patch',
+          sha256='8a2720368c7757896814684147029d8318b9aa3b0914b3f37dd5e8a8603a61d3',
+          level=0)
 
     def configure_args(self):
         spec = self.spec
@@ -31,3 +43,23 @@ class Tix(AutotoolsPackage):
     def libs(self):
         return find_libraries(['libTix{0}'.format(self.version)],
                               root=self.prefix, recursive=True)
+
+    def setup_run_environment(self, env):
+        """Set TIX_LIBRARY to the directory containing Tix.tcl.
+
+        For further info, see:
+
+        * http://tix.sourceforge.net/docs/pdf/TixUser.pdf
+        """
+        # When using tkinter.tix from within spack provided python+tkinter+tix,
+        # python will not be able to find Tix unless TIX_LIBRARY is set.
+        env.set('TIX_LIBRARY', self.spec['tix'].libs.directories[0])
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        """Set TIX_LIBRARY to the directory containing Tix.tcl.
+
+        For further info, see:
+
+        * http://tix.sourceforge.net/docs/pdf/TixUser.pdf
+        """
+        env.set('TIX_LIBRARY', self.spec['tix'].libs.directories[0])

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -77,3 +77,9 @@ class Tix(AutotoolsPackage):
         * http://tix.sourceforge.net/docs/pdf/TixUser.pdf
         """
         env.set('TIX_LIBRARY', os.path.dirname(find(self.prefix, 'Tix.tcl')[0]))
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if 'platform=darwin' in self.spec:
+            fix_darwin_install_name(self.prefix.lib.Tix + str(self.version))

--- a/var/spack/repos/builtin/packages/tix/test/test.tcl
+++ b/var/spack/repos/builtin/packages/tix/test/test.tcl
@@ -1,0 +1,5 @@
+#!/usr/bin/env tclsh
+
+package require Tix
+
+exit

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -25,14 +25,12 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     version('8.6.3',  sha256='ba15d56ac27d8c0a7b1a983915a47e0f635199b9473cf6e10fbce1fc73fd8333')
     version('8.5.19', sha256='407af1de167477d598bd6166d84459a3bdccc2fb349360706154e646a9620ffa')
 
-    variant('xft', default=True,
-            description='Enable X FreeType')
-    variant('xss', default=True,
-            description='Enable X Screen Saver')
+    variant('xft', default=True, description='Enable X FreeType')
+    variant('xss', default=True, description='Enable X Screen Saver')
 
-    extends('tcl')
+    extends('tcl', type=('build', 'link', 'run'))
 
-    depends_on('tcl@8.6:', when='@8.6:')
+    depends_on('tcl@8.6:', type=('build', 'link', 'run'), when='@8.6:')
     depends_on('libx11')
     depends_on('libxft', when='+xft')
     depends_on('libxscrnsaver', when='+xss')
@@ -45,6 +43,21 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     patch('https://github.com/macports/macports-ports/blob/master/x11/tk/files/patch-unix-Makefile.in.diff',
           sha256='54bba3d2b3550b7e2c636881c1a3acaf6e1eb743f314449a132864ff47fd0010',
           level=0, when='@:8.6.11 platform=darwin')
+    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tk/files/patch-dyld_fallback_library_path.diff',
+          sha256='9ce6512f1928db9987986f4d3540207c39429395d5234bd6489ba9d86a6d9c31',
+          level=0, when='platform=darwin')
+
+    def configure_args(self):
+        spec = self.spec
+        config_args = [
+            '--with-tcl={0}'.format(spec['tcl'].libs.directories[0]),
+            '--x-includes={0}'.format(spec['libx11'].headers.directories[0]),
+            '--x-libraries={0}'.format(spec['libx11'].libs.directories[0])
+        ]
+        config_args += self.enable_or_disable('xft')
+        config_args += self.enable_or_disable('xss')
+
+        return config_args
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):
@@ -63,6 +76,28 @@ class Tk(AutotoolsPackage, SourceforgePackage):
             filter_file(
                 stage_src, installed_src,
                 join_path(self.spec['tk'].libs.directories[0], 'tkConfig.sh'))
+
+    @run_after('install')
+    def symlink_wish(self):
+        with working_dir(self.prefix.bin):
+            symlink('wish{0}'.format(self.version.up_to(2)), 'wish')
+
+    def test(self):
+        self.run_test(self.spec['tk'].command.path, ['-h'],
+                      purpose='test wish command')
+
+    @property
+    def command(self):
+        """Returns the wish command.
+
+        Returns:
+            Executable: the wish command
+        """
+        # Although we symlink wishX.Y to wish, we also need to support external
+        # installations that may not have this symlink, or may have multiple versions
+        # of Tk installed in the same directory.
+        return Executable(os.path.realpath(self.prefix.bin.join(
+            'wish{0}'.format(self.version.up_to(2)))))
 
     @property
     def libs(self):
@@ -88,20 +123,3 @@ class Tk(AutotoolsPackage, SourceforgePackage):
         * https://www.tcl-lang.org/man/tcl/TkCmd/tkvars.htm
         """
         env.set('TK_LIBRARY', os.path.dirname(sorted(find(self.prefix, 'tk.tcl'))[0]))
-
-    def configure_args(self):
-        spec = self.spec
-        config_args = [
-            '--with-tcl={0}'.format(spec['tcl'].libs.directories[0]),
-            '--x-includes={0}'.format(spec['libx11'].headers.directories[0]),
-            '--x-libraries={0}'.format(spec['libx11'].libs.directories[0])
-        ]
-        config_args += self.enable_or_disable('xft')
-        config_args += self.enable_or_disable('xss')
-
-        return config_args
-
-    @run_after('install')
-    def symlink_wish(self):
-        with working_dir(self.prefix.bin):
-            symlink('wish{0}'.format(self.version.up_to(2)), 'wish')

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -86,6 +86,11 @@ class Tk(AutotoolsPackage, SourceforgePackage):
         self.run_test(self.spec['tk'].command.path, ['-h'],
                       purpose='test wish command')
 
+        test_data_dir = self.test_suite.current_test_data_dir
+        test_file = test_data_dir.join('test.tcl')
+        self.run_test(self.spec['tcl'].command.path, test_file,
+                      purpose='test that tk can be loaded')
+
     @property
     def command(self):
         """Returns the wish command.

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
+
+from spack import *
 
 
 class Tk(AutotoolsPackage, SourceforgePackage):
@@ -77,8 +78,7 @@ class Tk(AutotoolsPackage, SourceforgePackage):
         """
         # When using tkinter from within spack provided python+tkinter,
         # python will not be able to find Tk unless TK_LIBRARY is set.
-        env.set('TK_LIBRARY', join_path(self.spec['tk'].libs.directories[0],
-                                        'tk{0}'.format(self.version.up_to(2))))
+        env.set('TK_LIBRARY', os.path.dirname(find(self.prefix, 'tk.tcl')[0]))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TK_LIBRARY to the directory containing tk.tcl.
@@ -87,8 +87,7 @@ class Tk(AutotoolsPackage, SourceforgePackage):
 
         * https://www.tcl-lang.org/man/tcl/TkCmd/tkvars.htm
         """
-        env.set('TK_LIBRARY', join_path(self.spec['tk'].libs.directories[0],
-                                        'tk{0}'.format(self.version.up_to(2))))
+        env.set('TK_LIBRARY', os.path.dirname(find(self.prefix, 'tk.tcl')[0]))
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -8,13 +8,12 @@ import os
 
 
 class Tk(AutotoolsPackage, SourceforgePackage):
-    """Tk is a graphical user interface toolkit that takes developing
-       desktop applications to a higher level than conventional
-       approaches. Tk is the standard GUI not only for Tcl, but for
-       many other dynamic languages, and can produce rich, native
-       applications that run unchanged across Windows, Mac OS X, Linux
-       and more."""
-    homepage = "http://www.tcl.tk"
+    """Tk is a graphical user interface toolkit that takes developing desktop
+    applications to a higher level than conventional approaches. Tk is the standard GUI
+    not only for Tcl, but for many other dynamic languages, and can produce rich, native
+    applications that run unchanged across Windows, Mac OS X, Linux and more."""
+
+    homepage = "https://www.tcl.tk"
     sourceforge_mirror_path = "tcl/tk8.6.5-src.tar.gz"
 
     version('8.6.11', sha256='5228a8187a7f70fa0791ef0f975270f068ba9557f57456f51eb02d9d4ea31282')
@@ -70,12 +69,26 @@ class Tk(AutotoolsPackage, SourceforgePackage):
                               root=self.prefix, recursive=True)
 
     def setup_run_environment(self, env):
-        # When using Tkinter from within spack provided python+tkinter, python
-        # will not be able to find Tcl/Tk unless TK_LIBRARY is set.
-        env.set('TK_LIBRARY', self.spec['tk'].libs.directories[0])
+        """Set TK_LIBRARY to the directory containing tk.tcl.
+
+        For further info, see:
+
+        * https://www.tcl-lang.org/man/tcl/TkCmd/tkvars.htm
+        """
+        # When using tkinter from within spack provided python+tkinter,
+        # python will not be able to find Tk unless TK_LIBRARY is set.
+        env.set('TK_LIBRARY', join_path(self.spec['tk'].libs.directories[0],
+                                        'tk{0}'.format(self.version.up_to(2))))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set('TK_LIBRARY', self.spec['tk'].libs.directories[0])
+        """Set TK_LIBRARY to the directory containing tk.tcl.
+
+        For further info, see:
+
+        * https://www.tcl-lang.org/man/tcl/TkCmd/tkvars.htm
+        """
+        env.set('TK_LIBRARY', join_path(self.spec['tk'].libs.directories[0],
+                                        'tk{0}'.format(self.version.up_to(2))))
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -78,7 +78,7 @@ class Tk(AutotoolsPackage, SourceforgePackage):
         """
         # When using tkinter from within spack provided python+tkinter,
         # python will not be able to find Tk unless TK_LIBRARY is set.
-        env.set('TK_LIBRARY', os.path.dirname(find(self.prefix, 'tk.tcl')[0]))
+        env.set('TK_LIBRARY', os.path.dirname(sorted(find(self.prefix, 'tk.tcl'))[0]))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Set TK_LIBRARY to the directory containing tk.tcl.
@@ -87,7 +87,7 @@ class Tk(AutotoolsPackage, SourceforgePackage):
 
         * https://www.tcl-lang.org/man/tcl/TkCmd/tkvars.htm
         """
-        env.set('TK_LIBRARY', os.path.dirname(find(self.prefix, 'tk.tcl')[0]))
+        env.set('TK_LIBRARY', os.path.dirname(sorted(find(self.prefix, 'tk.tcl'))[0]))
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/tk/test/test.tcl
+++ b/var/spack/repos/builtin/packages/tk/test/test.tcl
@@ -1,0 +1,5 @@
+#!/usr/bin/env tclsh
+
+package require Tk
+
+exit


### PR DESCRIPTION
Previously, we were setting `TCLLIBPATH` to `prefix/lib/tcl8.6`. With this PR, we are now setting `TCLLIBPATH` to `prefix/lib`. As far as I can tell from reading https://wiki.tcl-lang.org/page/TCLLIBPATH, this is the correct way to do things.

We are also now setting `(TCL|TK|TIX)_LIBRARY` correctly. Tix now builds for me.

Fixes #23780. The following commands successfully run:
```console
$ spack install python+tkinter
$ spack load python+tkinter
$ python -c 'import tkinter; tkinter._test()'
```

@skosukhin you can check Python if you want to but I think I have it thoroughly tested.

@glennpj can you make sure this doesn't break R?

We DESPERATELY need an official maintainer for the Tcl/Tk packages, as evidenced by the dozens of comments in the package from lessons hard learned. Pinging some people who have contributed to our Tcl/Tk recipes in the past:
@nazavode @zzzoom @xdelaruelle @gardner48 @lee218llnl @sknigh @citibeth @erimar77 @mjwoods @michaelkuhn 

Also see:

* https://core.tcl-lang.org/tk/tktview/447bd3e4abe17452d19a80e6840dcc8a2603fcbc
* https://bugs.python.org/issue44253