### PR TITLE
Cache compiler lookup per package

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1269,7 +1269,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             raise ValueError("Can only get the arch for concrete package.")
         return spack.architecture.arch_for_spec(self.spec.architecture)
 
-    @property
+    @property  # type: ignore
     @memoized
     def compiler(self):
         """Get the spack.compiler.Compiler object used to build this package"""

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1274,8 +1274,14 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         """Get the spack.compiler.Compiler object used to build this package"""
         if not self.spec.concrete:
             raise ValueError("Can only get a compiler for a concrete package.")
-        return spack.compilers.compiler_for_spec(self.spec.compiler,
-                                                 self.spec.architecture)
+
+        if not hasattr(self, '_compiler'):
+            self._compiler = spack.compilers.compiler_for_spec(
+                self.spec.compiler,
+                self.spec.architecture
+            )
+
+        return self._compiler
 
     def url_version(self, version):
         """

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1270,18 +1270,14 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         return spack.architecture.arch_for_spec(self.spec.architecture)
 
     @property
+    @memoized
     def compiler(self):
         """Get the spack.compiler.Compiler object used to build this package"""
         if not self.spec.concrete:
             raise ValueError("Can only get a compiler for a concrete package.")
 
-        if not hasattr(self, '_compiler'):
-            self._compiler = spack.compilers.compiler_for_spec(
-                self.spec.compiler,
-                self.spec.architecture
-            )
-
-        return self._compiler
+        return spack.compilers.compiler_for_spec(self.spec.compiler,
+                                                 self.spec.architecture)
 
     def url_version(self, version):
         """


### PR DESCRIPTION
Before:

```
$ hyperfine '~/spack/bin/spack -e . build-env rocfft'
Benchmark #1: ~/spack/bin/spack -e . build-env rocfft
  Time (mean ± σ):      1.593 s ±  0.016 s    [User: 1.468 s, System: 0.126 s]
  Range (min … max):    1.575 s …  1.628 s    10 runs
```

After:

```
$ hyperfine '~/spack/bin/spack -e . build-env rocfft'
Benchmark #1: ~/spack/bin/spack -e . build-env rocfft
  Time (mean ± σ):      1.407 s ±  0.020 s    [User: 1.280 s, System: 0.127 s]
  Range (min … max):    1.393 s …  1.455 s    10 runs
```

This method would be called over 300 times during `build-env`