### PR TITLE
qt: skip multimedia when ~opengl

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -602,6 +602,7 @@ class Qt(Package):
             config_args.extend(['-skip', 'wayland'])
 
         if '~opengl' in spec:
+            config_args.extend(['-skip', 'multimedia'])
             if version >= Version('5.10'):
                 config_args.extend([
                     '-skip', 'webglplugin',

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -579,6 +579,10 @@ class Qt(Package):
                 config_args.append('-no-xcb-xlib')
             if version < Version('5.12'):
                 config_args.append('-no-xinput2')
+            if spec.satisfies('@5.9'):
+                # Errors on bluetooth even when bluetooth is disabled...
+                # at least on apple-clang%12
+                config_args.extend(['-skip', 'connectivity'])
         elif version < Version('5.15') and '+gui' in spec:
             # Linux-only QT5 dependencies
             config_args.append('-system-xcb')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -199,7 +199,7 @@ class Qt(Package):
         conflicts('+framework',
                   msg="QT cannot be built as a framework except on macOS.")
     else:
-        conflicts('platform=darwin', when='@4.8.6',
+        conflicts('platform=darwin', when='@:4.8.6',
                   msg="QT 4 for macOS is only patched for 4.8.7")
 
     use_xcode = True
@@ -412,6 +412,13 @@ class Qt(Package):
 
         with open(conf_file, 'a') as f:
             f.write("QMAKE_CXXFLAGS += -std=gnu++98\n")
+
+    @when('@5.9 platform=darwin')
+    def patch(self):
+        # 'javascriptcore' is in the include path, so its file named 'version'
+        # interferes with the standard library
+        os.unlink(join_path(self.stage.source_path,
+                            'qtscript/src/3rdparty/javascriptcore/version'))
 
     @property
     def common_config_args(self):

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -575,11 +575,8 @@ class Qt(Package):
         ])
 
         if MACOS_VERSION:
-            config_args.extend([
-                '-no-xcb-xlib',
-                '-no-pulseaudio',
-                '-no-alsa',
-            ])
+            if version < Version('5.9'):
+                config_args.append('-no-xcb-xlib')
             if version < Version('5.12'):
                 config_args.append('-no-xinput2')
         elif version < Version('5.15') and '+gui' in spec:
@@ -614,6 +611,14 @@ class Qt(Package):
 
             if version >= Version('5.15'):
                 config_args.extend(['-skip', 'qtlocation'])
+        elif MACOS_VERSION:
+            # These options are only valid if 'multimedia' is enabled, i.e.
+            # +opengl is selected. Force them to be off on macOS, but let other
+            # platforms decide for themselves.
+            config_args.extend([
+                '-no-pulseaudio',
+                '-no-alsa',
+            ])
 
         configure(*config_args)
 


### PR DESCRIPTION
On 5.9 on macOS the multimedia option causes build errors; on other platforms and versions it should probably be assumed inoperative anyway.

---

Build with ~opengl %apple-clang@10:
```
Undefined symbols for architecture x86_64:
  "AVFVideoRendererControl::staticMetaObject", referenced from:
      AVFMediaPlayerService::releaseControl(QMediaControl*) in avfmediaplayerservice.o
  "AVFVideoRendererControl::AVFVideoRendererControl(QObject*)", referenced from:
      AVFMediaPlayerService::requestControl(char const*) in avfmediaplayerservice.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[5]: *** [../../../../plugins/mediaservice/libqavfmediaplayer.dylib] Error 1
```

---

Qt 5.9 multimedia might be entirely broken period on clang@12:
```
avfvideowindowcontrol.mm:203:14: error: cannot initialize a variable of type 'CALayer *' with an rvalue of type 'NSInteger' (aka 'long')
    CALayer *nativeLayer = [m_nativeView layer];
             ^             ~~~~~~~~~~~~~~~~~~~~
3 warnings and 1 error generated.
make[5]: *** [.obj/avfvideowindowcontrol.o] Error 1
make[5]: *** Waiting for unfinished jobs....
```