### PR TITLE
Use the database to check if a package was installed or not

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -829,7 +829,7 @@ class PackageInstaller(object):
         if restage and task.pkg.stage.managed_by_spack:
             task.pkg.stage.destroy()
 
-        if not partial and self.layout.check_installed(task.pkg.spec) and (
+        if not partial and task.pkg.installed and (
                 rec.spec.dag_hash() not in task.request.overwrite or
                 rec.installation_time > task.request.overwrite_time
         ):


### PR DESCRIPTION
If we can use the database as a source of truth we can avoid having to parse the spec.yaml.

before:

```
$ hyperfine '~/spack/bin/spack -e . install --only=dependencies'
Benchmark #1: ~/spack/bin/spack -e . install --fail-fast --only-concrete --only=dependencies
  Time (mean ± σ):      2.307 s ±  0.028 s    [User: 2.227 s, System: 0.055 s]
  Range (min … max):    2.268 s …  2.361 s    10 runs
```

after:

```
$ hyperfine '~/spack/bin/spack -e . install --only=dependencies'
Benchmark #1: ~/spack/bin/spack -e . install --fail-fast --only-concrete --only=dependencies
  Time (mean ± σ):      1.300 s ±  0.023 s    [User: 1.224 s, System: 0.059 s]
  Range (min … max):    1.264 s …  1.342 s    10 runs
```

this environment has 20+ dependencies already installed, only the root spec is not, so it's just benchmarking the time it would take to get to the point of installing the root spec.