### PR TITLE
Fix mpip package to depends_on libunwind when the libunwind variant is set to true

### DIFF
--- a/var/spack/repos/builtin/packages/mpip/package.py
+++ b/var/spack/repos/builtin/packages/mpip/package.py
@@ -60,7 +60,7 @@ class Mpip(AutotoolsPackage):
     depends_on('mpi')
 
     #  '+setjmp' adds '--disable-libunwind' to the confiure args
-    depends_on('libunwind', when='@3.5: +libunwind ~setjmp')
+    depends_on('unwind', when='@3.5: +libunwind ~setjmp')
 
     @when('@3.5:')
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/mpip/package.py
+++ b/var/spack/repos/builtin/packages/mpip/package.py
@@ -59,11 +59,6 @@ class Mpip(AutotoolsPackage):
     depends_on('python@:2', when='@3.4.1', type='build')
     depends_on('mpi')
 
-    #  Ideally would use libunwind, but provide backtrace and
-    #    setjmp functionality, if needed
-    #  depends_on('unwind')
-
-    # The '~sethmp' when criteria is from below
     #  '+setjmp' adds '--disable-libunwind' to the confiure args
     depends_on('libunwind', when='@3.5: +libunwind ~setjmp')
 

--- a/var/spack/repos/builtin/packages/mpip/package.py
+++ b/var/spack/repos/builtin/packages/mpip/package.py
@@ -62,6 +62,7 @@ class Mpip(AutotoolsPackage):
     #  Ideally would use libunwind, but provide backtrace and
     #    setjmp functionality, if needed
     #  depends_on('unwind')
+    depends_on('libunwind', when='+libunwind')
 
     @when('@3.5:')
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/mpip/package.py
+++ b/var/spack/repos/builtin/packages/mpip/package.py
@@ -62,7 +62,10 @@ class Mpip(AutotoolsPackage):
     #  Ideally would use libunwind, but provide backtrace and
     #    setjmp functionality, if needed
     #  depends_on('unwind')
-    depends_on('libunwind', when='@3.5: +libunwind')
+
+    # The '~sethmp' when criteria is from below
+    #  '+setjmp' adds '--disable-libunwind' to the confiure args
+    depends_on('libunwind', when='@3.5: +libunwind ~setjmp')
 
     @when('@3.5:')
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/mpip/package.py
+++ b/var/spack/repos/builtin/packages/mpip/package.py
@@ -62,7 +62,7 @@ class Mpip(AutotoolsPackage):
     #  Ideally would use libunwind, but provide backtrace and
     #    setjmp functionality, if needed
     #  depends_on('unwind')
-    depends_on('libunwind', when='+libunwind')
+    depends_on('libunwind', when='@3.5: +libunwind')
 
     @when('@3.5:')
     def configure_args(self):


### PR DESCRIPTION
fixes #23203

Fix mpip package to depends_on libunwind when the libunwind variant is set to true
    
The libunwind dependency is used for `mpip@3.5:` the `libunwind` variant is set to true (default)
and the `setjmp` variant is false (default).