### PR TITLE
py-psycopg2: need link dep on postgresql

### DIFF
--- a/var/spack/repos/builtin/packages/py-psycopg2/package.py
+++ b/var/spack/repos/builtin/packages/py-psycopg2/package.py
@@ -9,13 +9,14 @@ from spack import *
 class PyPsycopg2(PythonPackage):
     """Python interface to PostgreSQL databases"""
 
-    homepage = "http://initd.org/psycopg/"
-    url = "http://initd.org/psycopg/tarballs/PSYCOPG-2-7/psycopg2-2.7.5.tar.gz"
+    homepage = "https://psycopg.org/"
+    pypi = "psycopg2/psycopg2-2.8.6.tar.gz"
 
     version('2.8.6', sha256='fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543')
     version('2.7.5', sha256='eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e')
 
-    depends_on('python@2.7:2.8,3.4:3.8', type=('build', 'run'), when='@2.8:')
-    depends_on('python@2.6:2.8,3.2:3.7', type=('build', 'run'), when='@2.7')
+    # https://www.psycopg.org/docs/install.html#prerequisites
+    depends_on('python@2.7:2.8,3.4:3.8', type=('build', 'link', 'run'), when='@2.8:')
+    depends_on('python@2.6:2.8,3.2:3.7', type=('build', 'link', 'run'), when='@2.7')
     depends_on('py-setuptools', type='build')
-    depends_on('postgresql', type=('build', 'run'))
+    depends_on('postgresql@9.1:12', type=('build', 'link', 'run'))


### PR DESCRIPTION
Without this link dep and Spack's compiler wrappers, psycopg2 can pick up postgresql from the system at run-time and have missing symbols.

Also changed download to PyPI so that `spack versions` and `spack checksum` works, checksums appears to be the same.

Successfully installs and passes import tests on CentOS 7 with Python 3.8.10 and GCC 9.3.0.