### PR TITLE
hpctoolkit: update recipe, add version 2021.05.15

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -21,6 +21,7 @@ class Hpctoolkit(AutotoolsPackage):
 
     version('develop', branch='develop')
     version('master',  branch='master')
+    version('2021.05.15', commit='004ea0c2aea6a261e7d5d216c24f8a703fc6c408')
     version('2021.03.01', commit='68a051044c952f0f4dac459d9941875c700039e7')
     version('2020.08.03', commit='d9d13c705d81e5de38e624254cf0875cce6add9a')
     version('2020.07.21', commit='4e56c780cffc53875aca67d6472a2fb3678970eb')
@@ -61,6 +62,11 @@ class Hpctoolkit(AutotoolsPackage):
             description='Support ROCM on AMD GPUs, requires ROCM as '
             'external packages (2021.03.01 or later).')
 
+    variant('debug', default=False,
+            description='Build in debug (develop) mode.')
+
+    variant('viewer', default=True, description='Include hpcviewer.')
+
     boost_libs = (
         '+atomic +chrono +date_time +filesystem +system +thread +timer'
         ' +graph +regex +shared +multithreaded visibility=global'
@@ -87,9 +93,11 @@ class Hpctoolkit(AutotoolsPackage):
 
     depends_on('cuda', when='+cuda')
     depends_on('intel-xed', when='target=x86_64:')
+    depends_on('memkind', type=('build', 'run'), when='@2021.05.01:')
     depends_on('papi', when='+papi')
     depends_on('libpfm4', when='~papi')
     depends_on('mpi', when='+mpi')
+    depends_on('hpcviewer', type='run', when='+viewer')
 
     depends_on('hip', when='+rocm')
     depends_on('rocm-dbgapi', when='+rocm')
@@ -115,6 +123,10 @@ class Hpctoolkit(AutotoolsPackage):
 
     # Fix the build for old revs with gcc 10.x.
     patch('gcc10-enum.patch', when='@2020.01.01:2020.08.99 %gcc@10.0:')
+
+    patch('https://github.com/HPCToolkit/hpctoolkit/commit/511afd95b01d743edc5940c84e0079f462b2c23e.patch',
+          sha256='fd0fd7419f66a1feba8046cff9df7f27abce8629ee2708b8a9daa12c1b51243c',
+          when='@2019.08.01:2021.03.99 %gcc@11.0:')
 
     flag_handler = AutotoolsPackage.build_system_flags
 
@@ -144,7 +156,10 @@ class Hpctoolkit(AutotoolsPackage):
         if spec.target.family == 'x86_64':
             args.append('--with-xed=%s' % spec['intel-xed'].prefix)
 
-        if '+papi' in spec:
+        if spec.satisfies('@2021.05.01:'):
+            args.append('--with-memkind=%s' % spec['memkind'].prefix)
+
+        if spec.satisfies('+papi'):
             args.append('--with-papi=%s' % spec['papi'].prefix)
         else:
             args.append('--with-perfmon=%s' % spec['libpfm4'].prefix)
@@ -168,19 +183,20 @@ class Hpctoolkit(AutotoolsPackage):
         if '+all-static' in spec:
             args.append('--enable-all-static')
 
+        if spec.satisfies('+debug'):
+            args.append('--enable-develop')
+
         return args
 
-    # Remove setenv of ROCM, HIP, etc from the module file.  Loading
-    # the hpctoolkit module is not relevant to building a GPU app and
-    # some variables (HIP_PATH) intefere with building the app.
+    # We only want hpctoolkit and hpcviewer paths and man paths in the
+    # module file.  The run dependencies are all curried into hpctoolkit
+    # and we don't want to risk exposing a package if the application
+    # uses a different version of the same package.
     def setup_run_environment(self, env):
-        keeplist = []
-        for elt in env.env_modifications:
-            if not (isinstance(elt, SetEnv)
-                    and (elt.name.find('ROCM') >= 0
-                         or elt.name.find('HIP') >= 0
-                         or elt.name.find('CUDA') >= 0)):
-                keeplist.append(elt)
-
+        spec = self.spec
         env.clear()
-        env.env_modifications = keeplist
+        env.prepend_path('PATH', spec.prefix.bin)
+        env.prepend_path('MANPATH', spec.prefix.share.man)
+        if '+viewer' in spec:
+            env.prepend_path('PATH', spec['hpcviewer'].prefix.bin)
+            env.prepend_path('MANPATH', spec['hpcviewer'].prefix.share.man)

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.util.environment import SetEnv
 
 
 class Hpctoolkit(AutotoolsPackage):


### PR DESCRIPTION
1. add version 2021.05.15.

2. add patch to build old revs with gcc 11.x, version 2021.15.05
already has patch integrated, fixes #23667.

3. add variant +debug to build unoptimized, debug version.

4. add variant +viewer to include hpcviewer and add viewer path to
hpctoolkit module.

5. add dependency on memkind to workaround a glibc problem found on
some Cray platforms.