### PR TITLE
cmd/stage: print stage path

### DIFF
--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -31,6 +31,8 @@ def stage(parser, args):
             for spec in env.specs_by_hash.values():
                 for dep in spec.traverse():
                     dep.package.do_stage()
+                    tty.msg("Staged {0} in {1}".format(dep.package.name,
+                                                       dep.package.stage.path))
             return
         else:
             tty.die("`spack stage` requires a spec or an active environment")
@@ -53,3 +55,4 @@ def stage(parser, args):
         if args.path:
             package.path = args.path
         package.do_stage()
+        tty.msg("Staged {0} in {1}".format(package.name, package.stage.path))


### PR DESCRIPTION
This is a small quality of life improvement so that users can easily copy and paste the stage path after executing `spack stage spec`.