### PR TITLE
Bugfix: not providing fftw-api@3

### DIFF
--- a/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-fftw/package.py
@@ -41,7 +41,7 @@ class FujitsuFftw(FftwBase):
 
     depends_on('texinfo')
 
-    provides('fftw-api@3', when='@2:')
+    provides('fftw-api@3')
 
     conflicts('precision=quad', when='%fj', msg="Fujitsu Compiler doesn't support quad precision")
     conflicts('precision=long_double', when='%fj', msg="ARM-SVE vector instructions only works in single or double precision")


### PR DESCRIPTION
There is a line `provides('fftw-api@3', when='@2:')` while only fujitsu-fftw@1 is available. Actually, fujitsu-fftw is based on fftw3 and able  to provide fftw-api@3.