### PR TITLE
Propagate openmp to blas for sirius and spla

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -94,11 +94,11 @@ class Sirius(CMakePackage, CudaPackage):
     depends_on('magma', when='+magma')
     depends_on('boost cxxstd=14 +filesystem', when='+boost_filesystem')
 
-    depends_on('spfft@1.0.3:', when='@6.4.0:')
+    depends_on('spfft', when='@6.4.0:')
     depends_on('spfft+cuda', when='@6.4.0:+cuda')
     depends_on('spfft+rocm', when='@6.4.0:+rocm')
 
-    depends_on('spla@1.4.0:', when='@7.0.0:')
+    depends_on('spla', when='@7.0.0:')
     depends_on('spla+cuda', when='@7.0.0:+cuda')
     depends_on('spla+rocm', when='@7.0.0:+rocm')
 

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -94,13 +94,15 @@ class Sirius(CMakePackage, CudaPackage):
     depends_on('magma', when='+magma')
     depends_on('boost cxxstd=14 +filesystem', when='+boost_filesystem')
 
-    depends_on('spfft', when='@6.4.0:')
-    depends_on('spfft+cuda', when='@6.4.0:+cuda')
-    depends_on('spfft+rocm', when='@6.4.0:+rocm')
+    depends_on('spfft+mpi', when='@6.4.0:')
+    depends_on('spfft+cuda', when='+cuda ^spfft')
+    depends_on('spfft+rocm', when='+rocm ^spfft')
+    depends_on('spfft+openmp', when='+openmp ^spfft')
 
     depends_on('spla', when='@7.0.0:')
-    depends_on('spla+cuda', when='@7.0.0:+cuda')
-    depends_on('spla+rocm', when='@7.0.0:+rocm')
+    depends_on('spla+cuda', when='+cuda ^spla')
+    depends_on('spla+rocm', when='+rocm ^spla')
+    depends_on('spla+openmp', when='+openmp ^spla')
 
     depends_on('nlcglib', when='+nlcglib')
 
@@ -123,12 +125,12 @@ class Sirius(CMakePackage, CudaPackage):
     conflicts('+boost_filesystem', when='~apps')
     conflicts('^libxc@5.0.0')  # known to produce incorrect results
 
-    # Propagate openmp
+    # Propagate openmp to blas
     depends_on('openblas threads=openmp', when='+openmp ^openblas')
     depends_on('amdblis threads=openmp', when='+openmp ^amdblis')
     depends_on('blis threads=openmp', when='+openmp ^blis')
     depends_on('intel-mkl threads=openmp', when='+openmp ^intel-mkl')
-    depends_on('spfft+openmp', when='+openmp')
+
     depends_on('elpa+openmp', when='+elpa+openmp')
     depends_on('elpa~openmp', when='+elpa~openmp')
 

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -134,7 +134,6 @@ class Sirius(CMakePackage, CudaPackage):
     depends_on('elpa+openmp', when='+elpa+openmp')
     depends_on('elpa~openmp', when='+elpa~openmp')
 
-
     # TODO:
     # add support for CRAY_LIBSCI, testing
 

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -102,9 +102,6 @@ class Sirius(CMakePackage, CudaPackage):
     depends_on('spla+cuda', when='@7.0.0:+cuda')
     depends_on('spla+rocm', when='@7.0.0:+rocm')
 
-    depends_on('elpa+openmp', when='+elpa+openmp')
-    depends_on('elpa~openmp', when='+elpa~openmp')
-
     depends_on('nlcglib', when='+nlcglib')
 
     depends_on('libvdwxc+mpi', when='+vdwxc')
@@ -125,6 +122,16 @@ class Sirius(CMakePackage, CudaPackage):
     conflicts('+shared', when='@6.3.0:6.4.999')
     conflicts('+boost_filesystem', when='~apps')
     conflicts('^libxc@5.0.0')  # known to produce incorrect results
+
+    # Propagate openmp
+    depends_on('openblas threads=openmp', when='+openmp ^openblas')
+    depends_on('amdblis threads=openmp', when='+openmp ^amdblis')
+    depends_on('blis threads=openmp', when='+openmp ^blis')
+    depends_on('intel-mkl threads=openmp', when='+openmp ^intel-mkl')
+    depends_on('spfft+openmp', when='+openmp')
+    depends_on('elpa+openmp', when='+elpa+openmp')
+    depends_on('elpa~openmp', when='+elpa~openmp')
+
 
     # TODO:
     # add support for CRAY_LIBSCI, testing

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -79,7 +79,8 @@ class Sirius(CMakePackage, CudaPackage):
     depends_on('gsl')
     depends_on('lapack')
     depends_on('fftw-api@3')
-    depends_on('libxc')
+    depends_on('libxc@3.0.0:')
+    depends_on('libxc@4.0.0:', when='@7.2.0:')
     depends_on('spglib')
     depends_on('hdf5+hl')
     depends_on('pkgconfig', type='build')
@@ -94,19 +95,20 @@ class Sirius(CMakePackage, CudaPackage):
     depends_on('magma', when='+magma')
     depends_on('boost cxxstd=14 +filesystem', when='+boost_filesystem')
 
-    depends_on('spfft+mpi', when='@6.4.0:')
+    depends_on('spfft@0.9.6: +mpi', when='@6.4.0:')
+    depends_on('spfft@0.9.13:', when='@7.0.1:')
     depends_on('spfft+cuda', when='+cuda ^spfft')
     depends_on('spfft+rocm', when='+rocm ^spfft')
     depends_on('spfft+openmp', when='+openmp ^spfft')
 
-    depends_on('spla', when='@7.0.0:')
+    depends_on('spla@1.1.0:', when='@7.0.2:')
     depends_on('spla+cuda', when='+cuda ^spla')
     depends_on('spla+rocm', when='+rocm ^spla')
     depends_on('spla+openmp', when='+openmp ^spla')
 
     depends_on('nlcglib', when='+nlcglib')
 
-    depends_on('libvdwxc+mpi', when='+vdwxc')
+    depends_on('libvdwxc@0.3.0:+mpi', when='+vdwxc')
 
     depends_on('scalapack', when='+scalapack')
 

--- a/var/spack/repos/builtin/packages/spfft/package.py
+++ b/var/spack/repos/builtin/packages/spfft/package.py
@@ -60,12 +60,6 @@ class Spfft(CMakePackage, CudaPackage):
     # FindHIP cmake script only works for < 4.1
     depends_on('hip@:4.0', when='@:1.0.1 +rocm')
 
-    # Propagate openmp to blas
-    depends_on('openblas threads=openmp', when='+openmp ^openblas')
-    depends_on('amdblis threads=openmp', when='+openmp ^amdblis')
-    depends_on('blis threads=openmp', when='+openmp ^blis')
-    depends_on('intel-mkl threads=openmp', when='+openmp ^intel-mkl')
-
     # Fix compilation error in some cases due to missing include statement
     # before version 1.0.3
     patch('0001-fix-missing-limits-include.patch', when='@:1.0.2')

--- a/var/spack/repos/builtin/packages/spfft/package.py
+++ b/var/spack/repos/builtin/packages/spfft/package.py
@@ -60,6 +60,12 @@ class Spfft(CMakePackage, CudaPackage):
     # FindHIP cmake script only works for < 4.1
     depends_on('hip@:4.0', when='@:1.0.1 +rocm')
 
+    # Propagate openmp to blas
+    depends_on('openblas threads=openmp', when='+openmp ^openblas')
+    depends_on('amdblis threads=openmp', when='+openmp ^amdblis')
+    depends_on('blis threads=openmp', when='+openmp ^blis')
+    depends_on('intel-mkl threads=openmp', when='+openmp ^intel-mkl')
+
     # Fix compilation error in some cases due to missing include statement
     # before version 1.0.3
     patch('0001-fix-missing-limits-include.patch', when='@:1.0.2')

--- a/var/spack/repos/builtin/packages/spla/package.py
+++ b/var/spack/repos/builtin/packages/spla/package.py
@@ -43,6 +43,12 @@ class Spla(CMakePackage):
     depends_on('hsakmt-roct', when='+rocm', type='link')
     depends_on('hsa-rocr-dev', when='+rocm', type='link')
 
+    # Propagate openmp to blas
+    depends_on('openblas threads=openmp', when='+openmp ^openblas')
+    depends_on('amdblis threads=openmp', when='+openmp ^amdblis')
+    depends_on('blis threads=openmp', when='+openmp ^blis')
+    depends_on('intel-mkl threads=openmp', when='+openmp ^intel-mkl')
+
     def cmake_args(self):
         args = [
             self.define_from_variant('SPLA_OMP', 'openmp'),


### PR DESCRIPTION
This requires the clingo concretizer, with the old concretizer you run
into

```
sirius requires openblas variant threads=openmp, but spec asked for threads=none
```

because it's not smart enough to handle self-referential dependencies.
At this point the new concretizer can be enabled through

```
spack config edit config
```

by adding `concretizer: clingo`.

See also https://spack.readthedocs.io/en/latest/getting_started.html#optional-bootstrapping-clingo
