### PR TITLE
Remove dead code in installer

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -586,14 +586,6 @@ class InconsistentInstallDirectoryError(DirectoryLayoutError):
             message, long_msg)
 
 
-class InstallDirectoryAlreadyExistsError(DirectoryLayoutError):
-    """Raised when create_install_directory is called unnecessarily."""
-
-    def __init__(self, path):
-        super(InstallDirectoryAlreadyExistsError, self).__init__(
-            "Install path %s already exists!" % path)
-
-
 class SpecReadError(DirectoryLayoutError):
     """Raised when directory layout can't read a spec."""
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -320,10 +320,6 @@ class YamlDirectoryLayout(DirectoryLayout):
     def create_install_directory(self, spec):
         _check_concrete(spec)
 
-        prefix = self.check_installed(spec)
-        if prefix:
-            raise InstallDirectoryAlreadyExistsError(prefix)
-
         # Create install directory with properly configured permissions
         # Cannot import at top of file
         from spack.package_prefs import get_package_dir_permissions, get_package_group

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1587,21 +1587,6 @@ class PackageInstaller(object):
                 keep_prefix = keep_prefix or \
                     (stop_before_phase is None and last_phase is None)
 
-            except spack.directory_layout.InstallDirectoryAlreadyExistsError \
-                    as exc:
-                tty.debug('Install prefix for {0} exists, keeping {1} in '
-                          'place.'.format(pkg.name, pkg.prefix))
-                self._update_installed(task)
-
-                # Only terminate at this point if a single build request was
-                # made.
-                if task.explicit and single_explicit_spec:
-                    spack.hooks.on_install_failure(task.request.pkg.spec)
-                    raise
-
-                if task.explicit:
-                    exists_errors.append((pkg_id, str(exc)))
-
             except KeyboardInterrupt as exc:
                 # The build has been terminated with a Ctrl-C so terminate
                 # regardless of the number of remaining specs.

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -14,7 +14,6 @@ import llnl.util.tty as tty
 
 import spack.binary_distribution
 import spack.compilers
-import spack.directory_layout as dl
 import spack.installer as inst
 import spack.package_prefs as prefs
 import spack.repo
@@ -1165,47 +1164,6 @@ def test_install_read_locked_requeue(install_mockery, monkeypatch, capfd):
     expected = ['write->read locked', 'preparing', 'requeued']
     for exp, ln in zip(expected, out.split('\n')):
         assert exp in ln
-
-
-def test_install_dir_exists(install_mockery, monkeypatch):
-    """Cover capture of install directory exists error."""
-    def _install(installer, task):
-        raise dl.InstallDirectoryAlreadyExistsError(task.pkg.prefix)
-
-    # Ensure raise the desired exception
-    monkeypatch.setattr(inst.PackageInstaller, '_install_task', _install)
-
-    const_arg = installer_args(['b'], {})
-    installer = create_installer(const_arg)
-
-    err = 'already exists'
-    with pytest.raises(dl.InstallDirectoryAlreadyExistsError, match=err):
-        installer.install()
-
-    b, _ = const_arg[0]
-    assert inst.package_id(b.package) in installer.installed
-
-
-def test_install_dir_exists_multi(install_mockery, monkeypatch, capfd):
-    """Cover capture of install directory exists error for multiple specs."""
-    def _install(installer, task):
-        raise dl.InstallDirectoryAlreadyExistsError(task.pkg.prefix)
-
-    # Skip the actual installation though should never reach it
-    monkeypatch.setattr(inst.PackageInstaller, '_install_task', _install)
-
-    # Use two packages to ensure multiple specs
-    const_arg = installer_args(['b', 'c'], {})
-    installer = create_installer(const_arg)
-
-    with pytest.raises(inst.InstallError, match='Installation request failed'):
-        installer.install()
-
-    err = capfd.readouterr()[1]
-    assert 'already exists' in err
-    for spec, install_args in const_arg:
-        pkg_id = inst.package_id(spec.package)
-        assert pkg_id in installer.installed
 
 
 def test_install_skip_patch(install_mockery, mock_fetch):


### PR DESCRIPTION
The `InstallDirectoryAlreadyExistsError` exception is never raised since the code path only ever happens when the install directory does not exist.

See https://github.com/spack/spack/blob/develop/lib/spack/spack/installer.py#L1294-L1297, this the only call site of create_install_directory, except for the tests in lib/spack/spack/test/directory_layout.py, but they use the function as a helper where the install prefix indeed does not exist.