### PR TITLE
py-lxml: add 4.6.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-lxml/package.py
+++ b/var/spack/repos/builtin/packages/py-lxml/package.py
@@ -30,7 +30,6 @@ class PyLxml(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('libxml2@2.9.2:', type=('build', 'link', 'run'))
     depends_on('libxslt@1.1.27:', type=('build', 'link', 'run'))
-    depends_on('py-cython@0.29.7:', type=('build', 'run'))
     depends_on('py-html5lib', when='+html5', type=('build', 'run'))
     depends_on('py-beautifulsoup4', when='+htmlsoup', type=('build', 'run'))
     depends_on('py-cssselect@0.7:', when='+cssselect', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-lxml/package.py
+++ b/var/spack/repos/builtin/packages/py-lxml/package.py
@@ -13,6 +13,7 @@ class PyLxml(PythonPackage):
     homepage = "https://lxml.de/"
     pypi = "lxml/lxml-4.6.1.tar.gz"
 
+    version('4.6.3', sha256='39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468')
     version('4.6.1', sha256='c152b2e93b639d1f36ec5a8ca24cde4a8eefb2b6b83668fcd8e83a67badcb367')
     version('4.5.2', sha256='cdc13a1682b2a6241080745b1953719e7fe0850b40a5c71ca574f090a1391df6')
     version('4.4.1', sha256='c81cb40bff373ab7a7446d6bbca0190bccc5be3448b47b51d729e37799bb5692')
@@ -27,8 +28,9 @@ class PyLxml(PythonPackage):
 
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('libxml2', type=('build', 'link', 'run'))
-    depends_on('libxslt', type=('build', 'link', 'run'))
+    depends_on('libxml2@2.9.2:', type=('build', 'link', 'run'))
+    depends_on('libxslt@1.1.28:', type=('build', 'link', 'run'))
+    depends_on('py-cython@0.29.7:', type=('build', 'run'))
     depends_on('py-html5lib', when='+html5', type=('build', 'run'))
     depends_on('py-beautifulsoup4', when='+htmlsoup', type=('build', 'run'))
     depends_on('py-cssselect@0.7:', when='+cssselect', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-lxml/package.py
+++ b/var/spack/repos/builtin/packages/py-lxml/package.py
@@ -29,7 +29,7 @@ class PyLxml(PythonPackage):
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('libxml2@2.9.2:', type=('build', 'link', 'run'))
-    depends_on('libxslt@1.1.28:', type=('build', 'link', 'run'))
+    depends_on('libxslt@1.1.27:', type=('build', 'link', 'run'))
     depends_on('py-cython@0.29.7:', type=('build', 'run'))
     depends_on('py-html5lib', when='+html5', type=('build', 'run'))
     depends_on('py-beautifulsoup4', when='+htmlsoup', type=('build', 'run'))


### PR DESCRIPTION
Also add missing py-cython dependency [1] and missing libxml2 and libxslt
versions dependencies [2]

[1] https://github.com/lxml/lxml/blob/lxml-4.6.3/requirements.txt
[2] https://github.com/lxml/lxml/blob/lxml-4.6.3/INSTALL.txt