### PR TITLE
Ensure uniqueness of install prefixes in the database

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -23,11 +23,12 @@ filesystem.
 import contextlib
 import datetime
 import os
-import six
 import socket
 import sys
 import time
 from typing import Dict  # novm
+
+import six
 
 try:
     import uuid
@@ -38,7 +39,6 @@ except ImportError:
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
-
 import spack.repo
 import spack.spec
 import spack.store

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -385,7 +385,7 @@ class Database(object):
         # For every installed spec we keep track of its install prefix, so that
         # we can answer the simple query whether a given path is already taken
         # before installing a different spec.
-        self._prefixes = set()
+        self._installed_prefixes = set()
 
         self.upstream_dbs = list(upstream_dbs) if upstream_dbs else []
 
@@ -779,7 +779,7 @@ class Database(object):
 
         # Pass 1: Iterate through database and build specs w/o dependencies
         data = {}
-        prefixes = set()
+        installed_prefixes = set()
         for hash_key, rec in installs.items():
             try:
                 # This constructs a spec DAG from the list of all installs
@@ -791,9 +791,8 @@ class Database(object):
                 #       this?
                 data[hash_key] = InstallRecord.from_dict(spec, rec)
 
-                # Only mark a path as taken when the spec is installed
                 if not spec.external and 'installed' in rec and rec['installed']:
-                    prefixes.add(rec['path'])
+                    installed_prefixes.add(rec['path'])
             except Exception as e:
                 invalid_record(hash_key, e)
 
@@ -815,7 +814,7 @@ class Database(object):
             rec.spec._mark_root_concrete()
 
         self._data = data
-        self._prefixes = prefixes
+        self._installed_prefixes = installed_prefixes
 
     def reindex(self, directory_layout):
         """Build database index from scratch based on a directory layout.
@@ -835,7 +834,7 @@ class Database(object):
             except CorruptDatabaseError as e:
                 self._error = e
                 self._data = {}
-                self._prefixes = set()
+                self._installed_prefixes = set()
 
         transaction = lk.WriteTransaction(
             self.lock, acquire=_read_suppress_error, release=self._write
@@ -850,14 +849,14 @@ class Database(object):
                 self._error = None
 
             old_data = self._data
-            old_prefixes = self._prefixes
+            old_installed_prefixes = self._installed_prefixes
             try:
                 self._construct_from_directory_layout(
                     directory_layout, old_data)
             except BaseException:
                 # If anything explodes, restore old data, skip write.
                 self._data = old_data
-                self._prefixes = old_prefixes
+                self._installed_prefixes = old_installed_prefixes
                 raise
 
     def _construct_entry_from_directory_layout(self, directory_layout,
@@ -894,7 +893,7 @@ class Database(object):
         with directory_layout.disable_upstream_check():
             # Initialize data in the reconstructed DB
             self._data = {}
-            self._prefixes = set()
+            self._installed_prefixes = set()
 
             # Start inspecting the installed prefixes
             processed_specs = set()
@@ -1102,7 +1101,7 @@ class Database(object):
             path = None
             if not spec.external and directory_layout:
                 path = directory_layout.path_for_spec(spec)
-                if path in self._prefixes:
+                if path in self._installed_prefixes:
                     raise Exception("Install prefix collision.")
                 try:
                     directory_layout.check_installed(spec)
@@ -1111,7 +1110,7 @@ class Database(object):
                     tty.warn(
                         'Dependency missing: may be deprecated or corrupted:',
                         path, str(e))
-                self._prefixes.add(path)
+                self._installed_prefixes.add(path)
             elif spec.external_path:
                 path = spec.external_path
 
@@ -1190,7 +1189,6 @@ class Database(object):
         rec.ref_count -= 1
 
         if rec.ref_count == 0 and not rec.installed:
-            # The install prefix has already been removed from self._prefixes
             del self._data[key]
 
             for dep in spec.dependencies(_tracked_deps):
@@ -1213,7 +1211,7 @@ class Database(object):
         # This install prefix is now free for other specs to use, even if the
         # spec is only marked uninstalled.
         if not rec.spec.external:
-            self._prefixes.remove(rec.path)
+            self._installed_prefixes.remove(rec.path)
 
         if rec.ref_count > 0:
             rec.installed = False
@@ -1566,7 +1564,7 @@ class Database(object):
 
     def is_occupied_install_prefix(self, path):
         with self.read_transaction():
-            return path in self._prefixes
+            return path in self._installed_prefixes
 
     @property
     def unused_specs(self):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -833,7 +833,7 @@ class PackageInstaller(object):
         if restage and task.pkg.stage.managed_by_spack:
             task.pkg.stage.destroy()
 
-        if not partial and self.layout.check_installed(task.pkg.spec) and (
+        if not partial and installed_in_db and (
                 rec.spec.dag_hash() not in task.request.overwrite or
                 rec.installation_time > task.request.overwrite_time
         ):

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -814,6 +814,10 @@ class PackageInstaller(object):
         # Determine if the spec is flagged as installed in the database
         rec, installed_in_db = self._check_db(task.pkg.spec)
 
+        # Check for an install prefix collision
+        if not installed_in_db and self.store.db.has_path(task.pkg.spec.prefix):
+            raise Exception("<not overwriting install prefix from different spec>")
+
         # Make sure the installation directory is in the desired state
         # for uninstalled specs.
         partial = False

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -33,11 +33,12 @@ import heapq
 import itertools
 import os
 import shutil
-import six
 import sys
 import time
-
 from collections import defaultdict
+
+import six
+
 
 import llnl.util.filesystem as fs
 import llnl.util.lock as lk
@@ -51,7 +52,6 @@ import spack.package
 import spack.package_prefs as prefs
 import spack.repo
 import spack.store
-
 from llnl.util.tty.color import colorize
 from llnl.util.tty.log import log_output
 from spack.util.environment import dump_environment

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -815,7 +815,10 @@ class PackageInstaller(object):
         rec, installed_in_db = self._check_db(task.pkg.spec)
 
         # Check for an install prefix collision
-        if not installed_in_db and self.store.db.has_path(task.pkg.spec.prefix):
+        available = spack.store.db.is_occupied_install_prefix(task.pkg.spec.prefix)
+
+        # TODO: nicer error handling.
+        if not installed_in_db and available:
             raise Exception("<not overwriting install prefix from different spec>")
 
         # Make sure the installation directory is in the desired state

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -814,31 +814,29 @@ class PackageInstaller(object):
         # Determine if the spec is flagged as installed in the database
         rec, installed_in_db = self._check_db(task.pkg.spec)
 
-        # Check for an install prefix collision
-        available = spack.store.db.is_occupied_install_prefix(task.pkg.spec.prefix)
+        if not installed_in_db:
+            # Ensure there is no other installed spec with the same prefix dir
+            if spack.store.db.is_occupied_install_prefix(task.pkg.spec.prefix):
+                raise InstallError(
+                    "Install prefix collision for {0}".format(task.pkg_id),
+                    long_msg="Prefix directory {0} already used by another "
+                             "installed spec.".format(task.pkg.spec.prefix))
 
-        # TODO: nicer error handling.
-        if not installed_in_db and available:
-            raise Exception("<not overwriting install prefix from different spec>")
-
-        # Make sure the installation directory is in the desired state
-        # for uninstalled specs.
-        partial = False
-        if not installed_in_db and os.path.isdir(task.pkg.spec.prefix):
-            if not keep_prefix:
-                task.pkg.remove_prefix()
-            else:
-                tty.debug('{0} is partially installed'
-                          .format(task.pkg_id))
-                partial = True
+            # Make sure the installation directory is in the desired state
+            # for uninstalled specs.
+            if os.path.isdir(task.pkg.spec.prefix):
+                if not keep_prefix:
+                    task.pkg.remove_prefix()
+                else:
+                    tty.debug('{0} is partially installed'.format(task.pkg_id))
 
         # Destroy the stage for a locally installed, non-DIYStage, package
         if restage and task.pkg.stage.managed_by_spack:
             task.pkg.stage.destroy()
 
-        if not partial and installed_in_db and (
-                rec.spec.dag_hash() not in task.request.overwrite or
-                rec.installation_time > task.request.overwrite_time
+        if installed_in_db and (
+            rec.spec.dag_hash() not in task.request.overwrite or
+            rec.installation_time > task.request.overwrite_time
         ):
             self._update_installed(task)
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -767,7 +767,7 @@ class MockLayout(object):
         self.root = root
 
     def path_for_spec(self, spec):
-        return '/'.join([self.root, spec.name])
+        return '/'.join([self.root, spec.name + '-' + spec.dag_hash()])
 
     def check_installed(self, spec):
         return True

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -26,17 +26,15 @@ except ImportError:
     def parse_date(string):  # type: ignore
         pytest.skip("dateutil package not available")
 
+import archspec.cpu.microarchitecture
+import archspec.cpu.schema
 import py
 import pytest
 
-import archspec.cpu.microarchitecture
-import archspec.cpu.schema
-from llnl.util.filesystem import mkdirp, remove_linked_tree, working_dir
-
 import spack.architecture
+import spack.caches
 import spack.compilers
 import spack.config
-import spack.caches
 import spack.database
 import spack.directory_layout
 import spack.environment as ev
@@ -47,14 +45,14 @@ import spack.platforms.test
 import spack.repo
 import spack.stage
 import spack.store
+import spack.subprocess_context
 import spack.util.executable
 import spack.util.gpg
-import spack.subprocess_context
 import spack.util.spack_yaml as syaml
-
-from spack.util.pattern import Bunch
-from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
+from llnl.util.filesystem import mkdirp, remove_linked_tree, working_dir
 from spack.fetch_strategy import FetchError
+from spack.fetch_strategy import FetchStrategyComposite, URLFetchStrategy
+from spack.util.pattern import Bunch
 
 
 #

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -4,20 +4,20 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import pytest
 import shutil
 
-import llnl.util.filesystem as fs
+import pytest
 
-from spack.package import InstallError, PackageBase, PackageStillNeededError
+import llnl.util.filesystem as fs
 import spack.error
 import spack.patch
 import spack.repo
 import spack.store
-from spack.spec import Spec
 import spack.util.spack_json as sjson
+from spack.package import InstallError, PackageBase, PackageStillNeededError
 from spack.package import (_spack_build_envfile, _spack_build_logfile,
                            _spack_configure_argsfile)
+from spack.spec import Spec
 
 
 def find_nothing(*args):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -325,6 +325,23 @@ def test_second_install_no_overwrite_first(install_mockery, mock_fetch):
         spack.package.Package.remove_prefix = remove_prefix
 
 
+def test_install_prefix_collision_fails(config, mock_fetch, mock_packages, tmpdir):
+    """
+    Test that different specs with coinciding install prefixes will fail
+    to install.
+    """
+    projections = {'all': 'all-specs-project-to-this-prefix'}
+    store = spack.store.Store(str(tmpdir), projections=projections)
+    with spack.store.use_store(store):
+        with spack.config.override('config:checksum', False):
+            pkg_a = Spec('libelf@0.8.13').concretized().package
+            pkg_b = Spec('libelf@0.8.12').concretized().package
+            pkg_a.do_install()
+
+            with pytest.raises(InstallError, match="Install prefix collision"):
+                pkg_b.do_install()
+
+
 def test_store(install_mockery, mock_fetch):
     spec = Spec('cmake-client').concretized()
     pkg = spec.package

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
+
+from spack import *
 
 
 class Gdb(AutotoolsPackage, GNUMirrorPackage):


### PR DESCRIPTION
This pr handles install prefix collisions slightly better, and makes it such that the database can be used better as the 'source of truth' for what packages are installed.

With this PR if you install 2 packages `zlib~shared` and `zlib+shared` with projections that map these packages to the same directory, you get this:

```
$ spack -c "config:install_tree:root:$PWD" -c 'config:install_tree:projections:all:${PACKAGE}' install zlib~shared
...
==> zlib: Successfully installed zlib-1.2.11-k5l7ccyobzhdyxt3wpzzxgyy5va636sq
  Fetch: 0.16s.  Build: 0.58s.  Total: 0.74s.
[+] /tmp/tmp.EvXHRNxOxj/zlib

$ spack -c "config:install_tree:root:$PWD" -c 'config:install_tree:projections:all:${PACKAGE}' install zlib+shared
==> Error: <not overwriting install prefix from different spec>
```

Previously spack would delete the prefix directory of `zlib~shared` without warning, and you would end up with a missing install and a corrupted database where two zlib's would share the same install prefix.

This PR still handles partial installs (running spack install --keep-prefix xyz multiple times for a failing build where the build touches the install dir and you want to keep all that), since in that case the spec is not marked installed in the db, nor is the prefix path listed as available.

Finally it supersedes https://github.com/spack/spack/pull/24005, since with the install prefix collision check, we can discriminate between "the directory looks like a spack install of some package" and "the directory belongs to an installed spec".

Edit: would be nice to get some feedback to see if this is going in the right direction before adding better error handling and tests.
