### PR TITLE
py-nilearn: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-nilearn/package.py
+++ b/var/spack/repos/builtin/packages/py-nilearn/package.py
@@ -17,7 +17,7 @@ class PyNilearn(PythonPackage):
     depends_on('python@3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
 
-    variant('plotting', default=True, description='Enable plotting functionalities')
+    variant('plotting', default=False, description='Enable plotting functionalities')
 
     depends_on('py-numpy@1.11:', type=('build', 'run'))
     depends_on('py-scipy@0.19:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-nilearn/package.py
+++ b/var/spack/repos/builtin/packages/py-nilearn/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyNilearn(PythonPackage):
+    """Statistical learning for neuroimaging in Python."""
+
+    homepage = "http://nilearn.github.io/"
+    pypi     = "nilearn/nilearn-0.7.1.tar.gz"
+
+    version('0.7.1', sha256='8b1409a5e1f0f6d1a1f02555c2f11115a2364f45f1e57bcb5fb3c9ea11f346fa')
+
+    depends_on('python@3.5:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+
+    variant('plotting', default=True, description='Enable plotting functionalities')
+
+    depends_on('py-numpy@1.11:', type=('build', 'run'))
+    depends_on('py-scipy@0.19:', type=('build', 'run'))
+    depends_on('py-scikit-learn@0.19:', type=('build', 'run'))
+    depends_on('py-joblib@0.12:', type=('build', 'run'))
+    depends_on('py-nibabel@2.0.2:', type=('build', 'run'))
+    depends_on('py-pandas@0.18.0:', type=('build', 'run'))
+    depends_on('py-requests@2:', type=('build', 'run'))
+    depends_on('py-matplotlib@2.0:', type=('build', 'run'), when='+plotting')


### PR DESCRIPTION
The dependency documentation does not seem up to date anymore. In the source code [1] there are additional dependencies to pandas and requests as well as to a different matplotlib version.

[1] https://github.com/nilearn/nilearn/blob/0.7.1/nilearn/version.py