### PR TITLE
Make cuda conflicts useful for cray too

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -78,6 +78,14 @@ class CudaPackage(PackageBase):
 
     depends_on('cuda@11.0:',    when='cuda_arch=80')
     depends_on('cuda@11.1:',    when='cuda_arch=86')
+    
+    # From the NVIDIA install guide we know of conflicts for
+    # particular platforms (linux, darwin), architectures
+    # (x86, powerpc) and compilers (gcc, clang).
+    # We don't restrict %gcc and %clang conflicts to platform=linux,
+    # since they should also apply to platform=cray, and may
+    # apply to platform=darwin. We currently do not provide
+    # conflicts for platform=darwin with %apple-clang.
 
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -79,47 +79,39 @@ class CudaPackage(PackageBase):
     depends_on('cuda@11.0:',    when='cuda_arch=80')
     depends_on('cuda@11.1:',    when='cuda_arch=86')
 
-    # There are at least three cases to be aware of for compiler conflicts
-    # 1. Linux x86_64
-    # 2. Linux ppc64le
-    # 3. Mac OS X
-    # CUDA-compiler conflicts are version-to-version specific and are
-    # difficult to express with the current Spack conflict syntax
-
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132
-    arch_platform = ' target=x86_64: platform=linux'
-    conflicts('%gcc@5:', when='+cuda ^cuda@:7.5' + arch_platform)
-    conflicts('%gcc@6:', when='+cuda ^cuda@:8' + arch_platform)
-    conflicts('%gcc@7:', when='+cuda ^cuda@:9.1' + arch_platform)
-    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130' + arch_platform)
-    conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89' + arch_platform)
-    conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
-    conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27' + arch_platform)
-    conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5' + arch_platform)
-    conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8' + arch_platform)
-    conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1' + arch_platform)
-    conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10' + arch_platform)
+    conflicts('%gcc@5:', when='+cuda ^cuda@:7.5 target=x86_64:')
+    conflicts('%gcc@6:', when='+cuda ^cuda@:8 target=x86_64:')
+    conflicts('%gcc@7:', when='+cuda ^cuda@:9.1 target=x86_64:')
+    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=x86_64:')
+    conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89 target=x86_64:')
+    conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2: target=x86_64:')
+    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2 target=x86_64:')
+    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
+    conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27 target=x86_64:')
+    conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5 target=x86_64:')
+    conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8 target=x86_64:')
+    conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1 target=x86_64:')
+    conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10 target=x86_64:')
     conflicts('%pgi@:17,20:',
-              when='+cuda ^cuda@10.1.105:10.2.89' + arch_platform)
+              when='+cuda ^cuda@10.1.105:10.2.89 target=x86_64:')
     conflicts('%pgi@:17,21:',
-              when='+cuda ^cuda@11.0.2:11.1.0' + arch_platform)
-    conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5' + arch_platform)
+              when='+cuda ^cuda@11.0.2:11.1.0 target=x86_64:')
+    conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5 target=x86_64:')
     conflicts('%clang@:3.7,4:',
-              when='+cuda ^cuda@8.0:9.0' + arch_platform)
+              when='+cuda ^cuda@8.0:9.0 target=x86_64:')
     conflicts('%clang@:3.7,4.1:',
-              when='+cuda ^cuda@9.1' + arch_platform)
-    conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2' + arch_platform)
-    conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130' + arch_platform)
-    conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105' + arch_platform)
+              when='+cuda ^cuda@9.1 target=x86_64:')
+    conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2 target=x86_64:')
+    conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130 target=x86_64:')
+    conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105 target=x86_64:')
     conflicts('%clang@:3.7,8.1:',
-              when='+cuda ^cuda@10.1.105:10.1.243' + arch_platform)
-    conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89' + arch_platform)
-    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
+              when='+cuda ^cuda@10.1.105:10.1.243 target=x86_64:')
+    conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89 target=x86_64:')
+    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=x86_64:')
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=x86_64:')
+    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
 
     # x86_64 vs. ppc64le differ according to NVidia docs
     # Linux ppc64le compiler conflicts from Table from the docs below:
@@ -129,27 +121,26 @@ class CudaPackage(PackageBase):
     # https://docs.nvidia.com/cuda/archive/9.0/cuda-installation-guide-linux/index.html
     # https://docs.nvidia.com/cuda/archive/8.0/cuda-installation-guide-linux/index.html
 
-    arch_platform = ' target=ppc64le: platform=linux'
     # information prior to CUDA 9 difficult to find
-    conflicts('%gcc@6:', when='+cuda ^cuda@:9' + arch_platform)
-    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130' + arch_platform)
-    conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243' + arch_platform)
+    conflicts('%gcc@6:', when='+cuda ^cuda@:9 target=ppc64le:')
+    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=ppc64le:')
+    conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243 target=ppc64le:')
     # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
-    conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
-    conflicts('%pgi', when='+cuda ^cuda@:8' + arch_platform)
-    conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185' + arch_platform)
-    conflicts('%pgi@:17', when='+cuda ^cuda@:10' + arch_platform)
-    conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176' + arch_platform)
-    conflicts('%clang@5:', when='+cuda ^cuda@:9.1' + arch_platform)
-    conflicts('%clang@6:', when='+cuda ^cuda@:9.2' + arch_platform)
-    conflicts('%clang@7:', when='+cuda ^cuda@10.0.130' + arch_platform)
-    conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105' + arch_platform)
-    conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89' + arch_platform)
-    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2:' + arch_platform)
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2' + arch_platform)
-    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0' + arch_platform)
+    conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2: target=ppc64le:')
+    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
+    conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
+    conflicts('%pgi', when='+cuda ^cuda@:8 target=ppc64le:')
+    conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185 target=ppc64le:')
+    conflicts('%pgi@:17', when='+cuda ^cuda@:10 target=ppc64le:')
+    conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176 target=ppc64le:')
+    conflicts('%clang@5:', when='+cuda ^cuda@:9.1 target=ppc64le:')
+    conflicts('%clang@6:', when='+cuda ^cuda@:9.2 target=ppc64le:')
+    conflicts('%clang@7:', when='+cuda ^cuda@10.0.130 target=ppc64le:')
+    conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105 target=ppc64le:')
+    conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89 target=ppc64le:')
+    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=ppc64le:')
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
+    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
 
     # Intel is mostly relevant for x86_64 Linux, even though it also
     # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -162,15 +162,8 @@ class CudaPackage(PackageBase):
     conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
     conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.1.0')
 
-    # Mac OS X
-    # platform = ' platform=darwin'
-    # Apple XCode clang vs. LLVM clang are difficult to specify
-    # with spack syntax. Xcode clang name is `clang@x.y.z-apple`
-    # which precludes ranges being specified. We have proposed
-    # rename XCode clang to `clang@apple-x.y.z` or even
-    # `clang-apple@x.y.z as a possible fix.
-    # Compiler conflicts will be eventual taken from here:
-    # https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#abstract
+    # Darwin.
+    # TODO: add missing conflicts for %apple-clang cuda@:10
     conflicts('platform=darwin', when='+cuda ^cuda@11.0.2:')
 
     # Make sure cuda_arch can not be used without +cuda

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -78,14 +78,13 @@ class CudaPackage(PackageBase):
 
     depends_on('cuda@11.0:',    when='cuda_arch=80')
     depends_on('cuda@11.1:',    when='cuda_arch=86')
-    
-    # From the NVIDIA install guide we know of conflicts for
-    # particular platforms (linux, darwin), architectures
-    # (x86, powerpc) and compilers (gcc, clang).
-    # We don't restrict %gcc and %clang conflicts to platform=linux,
-    # since they should also apply to platform=cray, and may
-    # apply to platform=darwin. We currently do not provide
-    # conflicts for platform=darwin with %apple-clang.
+
+    # From the NVIDIA install guide we know of conflicts for particular
+    # platforms (linux, darwin), architectures (x86, powerpc) and compilers
+    # (gcc, clang). We don't restrict %gcc and %clang conflicts to
+    # platform=linux, since they should also apply to platform=cray, and may
+    # apply to platform=darwin. We currently do not provide conflicts for
+    # platform=darwin with %apple-clang.
 
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132


### PR DESCRIPTION
The CUDA compiler conflicts are valid on Cray too, and likely on Darwin x86_64 with %gcc and %clang in case you'd build these compilers instead of using apple-clang, so drop platform=linux in the conflicts entirely.

Also add a note about missing conflicts for %apple-clang on Darwin; the comment there was a bit outdated.

This PR is not meant to add more conflicts for %apple-clang, since I don't have access to these macos+nvidia machines at all.
