### PR TITLE
rocksdb: fix typo in dependency condition

### DIFF
--- a/var/spack/repos/builtin/packages/rocksdb/package.py
+++ b/var/spack/repos/builtin/packages/rocksdb/package.py
@@ -33,7 +33,7 @@ class Rocksdb(MakefilePackage):
     variant('zstd', default=False, description='Enable zstandard compression support')
     variant('tbb', default=False, description='Enable Intel TBB support')
 
-    depends_on('bzip2', when='+bzip2')
+    depends_on('bzip2', when='+bz2')
     depends_on('gflags')
     depends_on('lz4', when='+lz4')
     depends_on('snappy', when='+snappy')


### PR DESCRIPTION
refers #23053

`spack audit` caught that the "bzip2" variant was not defined.