### PR TITLE
Adds vtk-m release 1.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -26,8 +26,8 @@ class VtkM(CMakePackage, CudaPackage):
 
     version('master', branch='master')
     version('release', branch='release')
-    version('1.6.0-rc2', sha256="81d757b03deda28985d552198731e9b43e9db55eb79c23f81b939ebd84f3aeea")
-    version('1.5.5', commit="d2d1c854adc8c0518802f153b48afd17646b6252", preferred=True)
+    version('1.6.0', sha256="14e62d306dd33f82eb9ddb1d5cee987b7a0b91bf08a7a02ca3bce3968c95fd76", preferred=True)
+    version('1.5.5', commit="d2d1c854adc8c0518802f153b48afd17646b6252")
     version('1.5.4', commit="bbba2a1967b271cc393abd043716d957bca97972")
     version('1.5.3', commit="a3b8525ef97d94996ae843db0dd4f675c38e8b1e")
     version('1.5.2', commit="c49390f2537c5ba8cf25bd39aa5c212d6eafcf61")


### PR DESCRIPTION
Finally! Shortly after the last release candidate, VTK-m v1.6.0 final release is out :tada: :tada: :tada:

I have also updated the preferred version of VTK-m to 1.6.0.

Let me know if we need to change anything else in the package

ViB