### PR TITLE
Adding spell checking for docs and spack root

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -53,6 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Check for typos in docs
+      uses: crate-ci/typos@592b36d23c62cb378f6097a292bc902ee73f93ef # version 1.0.4
+      with: 
+        files: ./lib/spack/docs/ ./lib/spack/spack/*.py
     - uses: actions/setup-python@v2
       with:
         python-version: 3.9

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -777,6 +777,32 @@ This is not to say that this would be the best way to implement an integration
 with the logger (you'd probably want to write a custom logger, or you could
 have the hook defined within the logger) but serves as an example of writing a hook. 
 
+.. _documentation:
+
+-------------
+Documentation
+-------------
+
+Documentation can be found in ``lib/spack/docs``, and consists of rendered 
+restructured syntax files (extension .rst). To write documentation, you
+should first decide where it best fits. Developer documentation can
+go into this file that you are currently reading, and user documentation
+generally goes into ``basic_usage.rst``. If you have a question about where to
+put something, ask someone on the spack Slack.
+
+^^^^^^^^^^^
+Spell Check
+^^^^^^^^^^^
+
+Spelling is checked with `crate-ci/typos <https://github.com/marketplace/actions/typos-action>`_,
+a GitHub action that makes it easy to see that there are spelling errors. If your
+contribution has errors, they will be printed clearly in the CI output along
+with suggested changes. If you need to add custom words, you can use
+a `_typos.toml <https://github.com/marketplace/actions/typos-action#false-positives>`_
+file.
+
+
+
 ----------
 Unit tests
 ----------

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -799,7 +799,17 @@ a GitHub action that makes it easy to see that there are spelling errors. If you
 contribution has errors, they will be printed clearly in the CI output along
 with suggested changes. If you need to add custom words, you can use
 a `_typos.toml <https://github.com/marketplace/actions/typos-action#false-positives>`_
-file.
+file. When you see an error, you can fix locally manually, or you can `install
+typos <https://github.com/crate-ci/typos#install>`_ and have it correct for you!
+
+.. code-block:: console
+
+    # preview changes first!
+    typos ./lib/spack/docs
+
+    # write changes
+    typos ./lib/spack/docs --write-changes
+    
 
 
 

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -163,7 +163,7 @@ your site.
 Mirror environment
 ^^^^^^^^^^^^^^^^^^
 
-To create a mirror of all packages required by a concerte environment, activate the environment and call ``spack mirror create -a``.
+To create a mirror of all packages required by a concrete environment, activate the environment and call ``spack mirror create -a``.
 This is especially useful to create a mirror of an environment concretized on another machine.
 
 .. code-block:: console

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -429,7 +429,7 @@ Note about "no-op" jobs
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 If no specs in an environment need to be rebuilt during a given pipeline run
-(meaning all are already up to date on the mirror), a single succesful job
+(meaning all are already up to date on the mirror), a single successful job
 (a NO-OP) is still generated to avoid an empty pipeline (which GitLab
 considers to be an error).  An optional ``service-job-attributes`` section
 can be added to your ``spack.yaml`` where you can provide ``tags`` and

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1116,7 +1116,7 @@ def get_package_context(traceback, context=3):
 class InstallError(spack.error.SpackError):
     """Raised by packages when a package fails to install.
 
-    Any subclass of InstallError will be annotated by Spack wtih a
+    Any subclass of InstallError will be annotated by Spack with a
     ``pkg`` attribute on failure, which the caller can use to get the
     package for which the exception was raised.
     """

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -245,7 +245,7 @@ def stage_spec_jobs(specs, check_index_only=False):
             all configured mirrors are searched to see if binaries for specs
             are up to date on those mirrors.  This flag limits that search to
             the binary cache indices on those mirrors to speed the process up,
-            even though there is no garantee the index is up to date.
+            even though there is no guarantee the index is up to date.
 
     Returns: A tuple of information objects describing the specs, dependencies
         and stages:
@@ -1358,7 +1358,7 @@ def push_mirror_contents(env, spec, yaml_path, mirror_url, build_id,
             # that exception type here, since users of the
             # `spack ci rebuild' may not need or want any dependency
             # on boto3.  So we use the first non-boto exception type
-            # in the heirarchy:
+            # in the hierarchy:
             #     boto3.exceptions.S3UploadFailedError
             #     boto3.exceptions.Boto3Error
             #     Exception

--- a/lib/spack/spack/ci_optimization.py
+++ b/lib/spack/spack/ci_optimization.py
@@ -273,7 +273,7 @@ def build_histogram(iterator, key):
     Returns a list of tuples (hash, count, proportion, value), where
 
       - "hash" is a sha1sum hash of the value.
-      - "count" is the number of occurences of values that hash to "hash".
+      - "count" is the number of occurrences of values that hash to "hash".
       - "proportion" is the proportion of all values considered above that
         hash to "hash".
       - "value" is one of the values considered above that hash to "hash".
@@ -281,7 +281,7 @@ def build_histogram(iterator, key):
         undefined.
 
     The list is sorted in descending order by count, yielding the most
-    frequently occuring hashes first.
+    frequently occurring hashes first.
     """
     buckets = collections.defaultdict(int)
     values = {}

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -168,7 +168,7 @@ class Concretizer(object):
            TODO: In many cases we probably want to look for installed
                  versions of each package and use an installed version
                  if we can link to it.  The policy implemented here will
-                 tend to rebuild a lot of stuff becasue it will prefer
+                 tend to rebuild a lot of stuff because it will prefer
                  a compiler in the spec to any compiler already-
                  installed things were built with.  There is likely
                  some better policy that finds some middle ground

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -245,7 +245,7 @@ class YamlDirectoryLayout(DirectoryLayout):
         _check_concrete(spec)
         with open(path, 'w') as f:
             # The hash the the projection is the DAG hash but we write out the
-            # full provenance by full hash so it's availabe if we want it later
+            # full provenance by full hash so it's available if we want it later
             spec.to_yaml(f, hash=ht.full_hash)
 
     def write_host_environment(self, spec):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -75,7 +75,7 @@ spack:
   specs: []
   view: true
 """
-#: regex for validating enviroment names
+#: regex for validating environment names
 valid_environment_name_re = r'^\w[\w-]*$'
 
 #: version of the lockfile format. Must increase monotonically.
@@ -272,7 +272,7 @@ def find_environment(args):
     If an environment is found, read it in.  If not, return None.
 
     Arguments:
-        args (Namespace): argparse namespace wtih command arguments
+        args (Namespace): argparse namespace with command arguments
 
     Returns:
         (Environment): a found environment, or ``None``
@@ -322,7 +322,7 @@ def get_env(args, cmd_name, required=False):
     message that says the calling command *needs* an active environment.
 
     Arguments:
-        args (Namespace): argparse namespace wtih command arguments
+        args (Namespace): argparse namespace with command arguments
         cmd_name (str): name of calling command
         required (bool): if ``True``, raise an exception when no environment
             is found; if ``False``, just return ``None``
@@ -1889,7 +1889,7 @@ class Environment(object):
         # TODO: rethink where this needs to happen along with
         # writing. For some of the commands (like install, which write
         # concrete specs AND regen) this might as well be a separate
-        # call.  But, having it here makes the views consistent witht the
+        # call.  But, having it here makes the views consistent with the
         # concretized environment for most operations.  Which is the
         # special case?
         if regenerate:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -490,7 +490,7 @@ class URLFetchStrategy(FetchStrategy):
         # NOTE: The tar program on Mac OS X will encode HFS metadata in
         # hidden files, which can end up *alongside* a single top-level
         # directory.  We initially ignore presence of hidden files to
-        # accomodate these "semi-exploding" tarballs but ensure the files
+        # accommodate these "semi-exploding" tarballs but ensure the files
         # are copied to the source directory.
         files = os.listdir(tarball_container)
         non_hidden = [f for f in files if not f.startswith('.')]

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -31,7 +31,7 @@ from spack.directory_layout import ExtensionAlreadyInstalledError
 from spack.directory_layout import YamlViewExtensionsLayout
 
 
-# compatability
+# compatibility
 if sys.version_info < (3, 0):
     from itertools import imap as map
     from itertools import ifilter as filter
@@ -103,9 +103,9 @@ class FilesystemView(object):
         Governs a filesystem view that is located at certain root-directory.
 
         Packages are linked from their install directories into a common file
-        hierachy.
+        hierarchy.
 
-        In distributed filesystems, loading each installed package seperately
+        In distributed filesystems, loading each installed package separately
         can lead to slow-downs due to too many directories being traversed.
         This can be circumvented by loading all needed modules into a common
         directory structure.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -73,7 +73,7 @@ STATUS_FAILED = 'failed'
 #: process)
 STATUS_INSTALLING = 'installing'
 
-#: Build status indicating the spec was sucessfully installed
+#: Build status indicating the spec was successfully installed
 STATUS_INSTALLED = 'installed'
 
 #: Build status indicating the task has been popped from the queue

--- a/lib/spack/spack/monitor.py
+++ b/lib/spack/spack/monitor.py
@@ -526,7 +526,7 @@ class SpackMonitorClient:
         """
         # We load as json just to validate it
         spec = read_json(filename)
-        data = {"spec": spec, "spack_verison": self.spack_version}
+        data = {"spec": spec, "spack_version": self.spack_version}
 
         if self.save_local:
             filename = "spec-%s-%s.json" % (spec.name, spec.version)

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -180,7 +180,7 @@ class when(object):
 
        This allows each package to have a default version of install() AND
        specialized versions for particular platforms.  The version that is
-       called depends on the architecutre of the instantiated package.
+       called depends on the architecture of the instantiated package.
 
        Note that this works for methods other than install, as well.  So,
        if you only have part of the install that is platform specific, you

--- a/lib/spack/spack/package_test.py
+++ b/lib/spack/spack/package_test.py
@@ -35,7 +35,7 @@ def compare_output(current_output, blessed_output):
         print('-' * 80)
         print(current_output)
         print('-' * 80)
-        raise RuntimeError("Ouput check failed.",
+        raise RuntimeError("Output check failed.",
                            "See spack_output.log for details")
 
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -153,7 +153,7 @@ compiler_color = '@g'          #: color for highlighting compilers
 version_color = '@c'           #: color for highlighting versions
 architecture_color = '@m'      #: color for highlighting architectures
 enabled_variant_color = '@B'   #: color for highlighting enabled variants
-disabled_variant_color = '@r'  #: color for highlighting disabled varaints
+disabled_variant_color = '@r'  #: color for highlighting disabled variants
 dependency_color = '@.'        #: color for highlighting dependencies
 hash_color = '@K'              #: color for highlighting package hashes
 

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -197,7 +197,7 @@ class Stage(object):
 
     When used as a context manager, the stage is automatically
     destroyed if no exception is raised by the context. If an
-    excpetion is raised, the stage is left in the filesystem and NOT
+    exception is raised, the stage is left in the filesystem and NOT
     destroyed, for potential reuse later.
 
     You can also use the stage's create/destroy functions manually,


### PR DESCRIPTION
Spack has a lot of spelling errors! And it's because we're human :laughing: But maybe we can help with some automation?

I found this tool typos (a rust library) and created a GitHub action for it this weekend. If we run it during CI, it can alert us to spelling errors! I am currently running for the spack docs and spack root, and we can add other spack subfolders when --exclude is supported (see issue https://github.com/crate-ci/typos/issues/269) 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>