### PR TITLE
Do not install environment variables

### DIFF
--- a/lib/spack/spack/analyzers/environment_variables.py
+++ b/lib/spack/spack/analyzers/environment_variables.py
@@ -10,6 +10,8 @@ an index of key, value pairs for environment variables."""
 
 import os
 
+import llnl.util.tty as tty
+
 from spack.util.environment import EnvironmentModifications
 
 from .analyzer_base import AnalyzerBase
@@ -43,6 +45,7 @@ class EnvironmentVariables(AnalyzerBase):
         to remove path prefixes specific to user systems.
         """
         if not os.path.exists(filename):
+            tty.warn("No environment file available")
             return
 
         mods = EnvironmentModifications.from_sourcing_file(filename)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -73,6 +73,9 @@ _spack_build_logfile = 'spack-build-out.txt'
 # Filename for the Spack build/install environment file.
 _spack_build_envfile = 'spack-build-env.txt'
 
+# Filename for the Spack build/install environment modifications file.
+_spack_build_envmodsfile = 'spack-build-env-mods.txt'
+
 # Filename of json with total build and phase times (seconds)
 _spack_times_log = 'install_times.json'
 
@@ -1040,6 +1043,14 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             return old_filename
         else:
             return os.path.join(self.stage.path, _spack_build_envfile)
+
+    @property
+    def env_mods_path(self):
+        """
+        Return the build environment modifications file path associated with
+        staging.
+        """
+        return os.path.join(self.stage.path, _spack_build_envmodsfile)
 
     @property
     def metadata_dir(self):

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -175,6 +175,15 @@ def test_install_with_source(
                        os.path.join(src, 'configure'))
 
 
+def test_install_env_variables(
+    mock_packages, mock_archive, mock_fetch, config, install_mockery
+):
+    spec = Spec('libdwarf')
+    spec.concretize()
+    install('libdwarf')
+    assert os.path.isfile(spec.package.install_env_path)
+
+
 @pytest.mark.disable_clean_stage_check
 def test_show_log_on_error(mock_packages, mock_archive, mock_fetch,
                            config, install_mockery, capfd):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -543,6 +543,7 @@ def test_log_install_with_build_files(install_mockery, monkeypatch):
     with fs.working_dir(log_dir):
         fs.touch(log_path)
         fs.touch(spec.package.env_path)
+        fs.touch(spec.package.env_mods_path)
         fs.touch(spec.package.configure_args_path)
 
     install_path = os.path.dirname(spec.package.install_log_path)


### PR DESCRIPTION
Edit:

Instead of installing the full `env` to `<install prefix>/.spack/spack-build-env.txt` only install variables that have been changed in the build environment. This is to avoid "installing" secret tokens, passwords and keys often set in CI.

Halfway this PR the original behavior of installing all variables was still available through `spack install --env-variables`, but that flag is now dropped (67e2bea01dd04c07161c53f587440071fd2c6f38).

<details>
 <summary>Original description:</summary>

We shouldn't persist environment variables to disk by default, and we should definitely not install them on shared instances and pipelines.

This PR ensures that we do not have a `<install prefix>/.spack/spack-build-env.txt` file and that the `<stage dir>/spack-build-env.txt` file has 600 permissions (that is read-write for the user only: `-rw-------`)

The only potentially safe thing to do is to store the environment *modifications* of spack's build environment, but until that is figured out, it's better to drop this entirely.
</details>