### PR TITLE
Add a command to list external packages (#24082)

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -37,6 +37,9 @@ def setup_parser(subparser):
         'find', help='add external packages to packages.yaml'
     )
     find_parser.add_argument(
+        '--in-config', action='store_true', default=False,
+        help="list all external specs currently configured")
+    find_parser.add_argument(
         '--not-buildable', action='store_true', default=False,
         help="packages with detected externals won't be built with Spack")
     find_parser.add_argument(
@@ -150,6 +153,25 @@ def _spec_is_valid(spec):
 
 
 def external_find(args):
+    if args.in_config:
+        _external_find_config(args)
+    else:
+        _external_find_add(args)
+
+
+def _external_find_config(args):
+    predefined_external_specs = _get_predefined_externals()
+    path = spack.config.config.get_config_filename(args.scope, 'packages')
+    if predefined_external_specs:
+        msg = 'The following external specs are defined in {0}'
+        tty.msg(msg.format(path))
+        spack.cmd.display_specs(predefined_external_specs)
+    else:
+        msg = 'No predefined external specs found in {0}'
+        tty.msg(msg.format(path))
+
+
+def _external_find_add(args):
     # Construct the list of possible packages to be detected
     packages_to_check = []
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -246,7 +246,7 @@ def test_new_entries_are_reported_correctly(
     assert 'No new external packages detected' in output
 
 
-def test_find_with_in_config_option(
+def test_show(
         mock_executable, mutable_config, monkeypatch
 ):
     # Prepare an environment to detect a fake gcc
@@ -259,7 +259,7 @@ def test_find_with_in_config_option(
     assert 'The following specs have been' in output
 
     # Check for an external gcc
-    output = external('find', '--in-config')
+    output = external('show')
     assert 'The following external specs are defined' in output
     assert 'gcc@4.2.1' in output
 

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -246,6 +246,24 @@ def test_new_entries_are_reported_correctly(
     assert 'No new external packages detected' in output
 
 
+def test_find_with_in_config_option(
+        mock_executable, mutable_config, monkeypatch
+):
+    # Prepare an environment to detect a fake gcc
+    gcc_exe = mock_executable('gcc', output="echo 4.2.1")
+    prefix = os.path.dirname(gcc_exe)
+    monkeypatch.setenv('PATH', prefix)
+
+    # Add the external gcc
+    output = external('find', 'gcc')
+    assert 'The following specs have been' in output
+
+    # Check for an external gcc
+    output = external('find', '--in-config')
+    assert 'The following external specs are defined' in output
+    assert 'gcc@4.2.1' in output
+
+
 @pytest.mark.parametrize('command_args', [
     ('-t', 'build-tools'),
     ('-t', 'build-tools', 'cmake'),

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -914,14 +914,14 @@ _spack_external() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="find list"
+        SPACK_COMPREPLY="find list show"
     fi
 }
 
 _spack_external_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --in-config --not-buildable --scope -t --tag"
+        SPACK_COMPREPLY="-h --help --not-buildable --scope -t --tag"
     else
         _all_packages
     fi
@@ -929,6 +929,10 @@ _spack_external_find() {
 
 _spack_external_list() {
     SPACK_COMPREPLY="-h --help"
+}
+
+_spack_external_show() {
+    SPACK_COMPREPLY="-h --help --scope"
 }
 
 _spack_fetch() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -921,7 +921,7 @@ _spack_external() {
 _spack_external_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --not-buildable --scope -t --tag"
+        SPACK_COMPREPLY="-h --help --in-config --not-buildable --scope -t --tag"
     else
         _all_packages
     fi


### PR DESCRIPTION
fixes #24082 

This commit adds an option to the:
```
spack external find
```

command that allows it to list already-configured external packages. This allows the display of packages that have external specs without having to manually parse the `packages.yaml` file.

Example of use:

```
% spack external find --in-config
==> The following external specs are defined in /home/jjolly/.spack/packages.yaml
bison@3.0.4  cmake@3.19.1  flex@2.5.35
```