### PR TITLE
Pipelines: Fix generation when dep and pkg arch differ

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -507,7 +507,7 @@ def format_job_needs(phase_name, strip_compilers, dep_jobs,
                 'job': get_job_name(phase_name,
                                     strip_compilers,
                                     dep_job,
-                                    osname,
+                                    dep_job.architecture,
                                     build_group),
                 'artifacts': enable_artifacts_buildcache,
             })


### PR DESCRIPTION
This PR fixes a problem where `spack ci generate` could generate invalid yaml because the `needs` of some jobs did not appear as job names in the file.  The following example spec, due to how a package and its dependency have different architectures, would previously cause such a breakage:

```
readline@8.1%gcc@9.2.0 target=skylake ^pkgconf target=x86_64
```
