### PR TITLE
hdf5: filter compiler wrapper: h5pcc, h5pfc

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -167,7 +167,8 @@ class Hdf5(AutotoolsPackage):
             'fortran/src/H5Fff_F03.f90',
             string=True, ignore_absent=True)
 
-    filter_compiler_wrappers('h5cc', 'h5c++', 'h5fc', relative_root='bin')
+    filter_compiler_wrappers('h5cc', 'h5c++', 'h5fc',
+                             'h5pcc', 'h5pfc', relative_root='bin')
 
     def url_for_version(self, version):
         url = "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-{0}/hdf5-{1}/src/hdf5-{1}.tar.gz"


### PR DESCRIPTION
Run filter_compiler_wrapper on:
1. h5pcc
2. h5pfc

Without this, on Cray systems, you end up with:

```
$> grep CCBASE $(spack location -i hdf5)/bin/h5pcc
CCBASE="/global/cfs/cdirs/m3503/e4s/21.05/spack/lib/spack/env/intel/icc"

$> grep FCBASE $(spack location -i hdf5)/bin/h5pfc
FCBASE="/global/cfs/cdirs/m3503/e4s/21.05/spack/lib/spack/env/intel/ifort"
```

This would make it so that:
```
$> grep CCBASE $(spack location -i hdf5)/bin/h5pcc
CCBASE="cc"

...
```
@becker33 @lrknox @skosukhin @shahzebsiddiqui 