### PR TITLE
Pipelines: Remove exception handling around install script invocation

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -877,11 +877,13 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
                 if prune_dag and not rebuild_spec:
                     continue
 
-                if artifacts_root:
-                    job_dependencies.append({
-                        'job': generate_job_name,
-                        'pipeline': '{0}'.format(parent_pipeline_id)
-                    })
+                # We depend on the pipeline generation job in the upstream
+                # pipeline so we get the concrete environment directory as an
+                # artifact.
+                job_dependencies.append({
+                    'job': generate_job_name,
+                    'pipeline': '{0}'.format(parent_pipeline_id)
+                })
 
                 job_vars['SPACK_SPEC_NEEDS_REBUILD'] = str(rebuild_spec)
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -480,13 +480,9 @@ def ci_rebuild(args):
 
     # Run the generated install.sh shell script as if it were being run in
     # a login shell.
-    try:
-        install_process  = subprocess.Popen(['bash', '-l', './install.sh'])
-        install_process.wait()
-        install_exit_code = install_process.returncode
-    except (ValueError, subprocess.CalledProcessError, OSError) as inst:
-        tty.error('Encountered error running install script')
-        tty.error(inst)
+    install_process  = subprocess.Popen(['bash', '-l', './install.sh'])
+    install_process.wait()
+    install_exit_code = install_process.returncode
 
     # Now do the post-install tasks
     tty.debug('spack install exited {0}'.format(install_exit_code))


### PR DESCRIPTION
The documentation for subprocess.popen constructor and wait method says the
only exceptions that will be raised to the parent process happen in cases
when the sub-process (which runs "spack install" in this case) cannot actually
be started.  In all of those cases, we want to avoid doing any of the normal
post-processing, and instead just let those exceptions bubble up to be reported
in the job trace.

Also fix a bug that required specifying --artifacts-root in order to get the
concrete environment directory as an artifact.