### PR TITLE
ecp-data-vis-sdk: Disable +fortran for unifyfs

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -92,7 +92,7 @@ class EcpDataVisSdk(BundlePackage):
 
     depends_on('parallel-netcdf+shared+fortran', when='+pnetcdf')
 
-    variants2deps('unifyfs+fortran', '+unifyfs', ['hdf5'])
+    variants2deps('unifyfs', '+unifyfs ', ['hdf5'])
 
     depends_on('veloc', when='+veloc')
 


### PR DESCRIPTION
Since unifyfs only supports fortran on a subset of compilers then the sdk shouldn't be enabling it universally