### PR TITLE
texlive: setup dependent build environment

### DIFF
--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -186,6 +186,9 @@ class Texlive(AutotoolsPackage):
     def setup_run_environment(self, env):
         env.prepend_path('PATH', join_path(self.prefix.bin, self.tex_arch()))
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+
     @when('@live')
     def autoreconf(self, spec, prefix):
         touch('configure')


### PR DESCRIPTION
Texlive did not set a dependent build env ; gl2ps for instance (with the doc option) was using the default pdflatex which was not the proper one - which must be the one set by spack. Typically, the system pdflatex was used, instead of the one from texlive spack package.