### PR TITLE
jbigkit: adding the library spec for dependents

### DIFF
--- a/var/spack/repos/builtin/packages/jbigkit/package.py
+++ b/var/spack/repos/builtin/packages/jbigkit/package.py
@@ -33,3 +33,9 @@ class Jbigkit(MakefilePackage):
             mkdir(prefix.bin)
             for f in ['tstcodec', 'tstcodec85']:
                 install(f, prefix.bin)
+
+    @property
+    def libs(self):
+        return find_libraries(
+            "libjbig*", root=self.prefix, shared=False, recursive=True
+        )


### PR DESCRIPTION
Since this package offers two libs, both with names that differ from the package name, adding the library spec for dependents permits to use the proper link flags using spack logic. This shall be needed by netpbm so that netpbm uses jbigkit rather than its self shipped-in package.
This follows guidelines:
https://spack-tutorial.readthedocs.io/en/latest/tutorial_advanced_packaging.html#providing-libraries-to-dependents