### PR TITLE
setup-env: fix inverted logic for modules check

### DIFF
--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -702,9 +702,9 @@ set -xg _sp_shell "fish"
 #
 # Check whether we need environment-variables (module) <= `use` is not available
 #
-set -l need_module "no"
+set -l need_module "yes"
 if not functions -q use; and not functions -q module
-    set need_module "yes"
+    set need_module "no"
 end
 
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -306,9 +306,9 @@ _spack_fn_exists() {
     LANG= type $1 2>&1 | grep -q 'function'
 }
 
-need_module="no"
+need_module="yes"
 if ! _spack_fn_exists use && ! _spack_fn_exists module; then
-    need_module="yes"
+    need_module="no"
 fi;
 
 # Define the spack shell function with some informative no-ops, so when users


### PR DESCRIPTION
Sourcing `setup-env.sh` upon startup takes ~10 sec for me on my laptop, where modules are not installed. With the following change, this now take ~1 sec. I believe the logic was inverted, as there's no reason to set `MODULEPATH` if modules isn't installed.

Also fixed the `setup-env.fish` file. The `setup-env.csh` file doesn't seem to have support for this. Should we add it? We should also add tests for this.