### PR TITLE
package for the latest Elk Code 

### DIFF
--- a/var/spack/repos/builtin/packages/elk/package.py
+++ b/var/spack/repos/builtin/packages/elk/package.py
@@ -3,130 +3,75 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install elk
+#
+# You can edit this file again by typing:
+#
+#     spack edit elk
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
 from spack import *
 
 
 class Elk(MakefilePackage):
-    """An all-electron full-potential linearised augmented-plane wave
-    (FP-LAPW) code with many advanced features."""
+    """Elk code is a plane wave dft code aimed at material discovery"""
 
-    homepage = 'http://elk.sourceforge.net/'
-    url      = 'https://sourceforge.net/projects/elk/files/elk-3.3.17.tgz'
+    # FIXME: Add a proper url for your package's homepage here.
+    homepage = "https://elk.sourceforge.io/"
+    url      = "https://sourceforge.net/projects/elk/files/elk-7.1.14.tgz/download"
 
-    version('3.3.17', sha256='c9b87ae4ef367ed43afc2d43eb961745668e40670995e8e24c13db41b7e85d73')
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ['github_user1', 'github_user2']
 
-    # Elk provides these libraries, but allows you to specify your own
-    variant('blas',   default=True,
-            description='Build with custom BLAS library')
-    variant('lapack', default=True,
-            description='Build with custom LAPACK library')
-    variant('fft',    default=True,
-            description='Build with custom FFT library')
+    version('7.1.14', sha256='7c2ff30f4b1d72d5dc116de9d70761f2c206700c69d85dd82a17a5a6374453d2')
 
-    # Elk does not provide these libraries, but allows you to use them
-    variant('mpi',    default=True,
-            description='Enable MPI parallelism')
-    variant('openmp', default=True,
-            description='Enable OpenMP support')
-    variant('libxc',  default=True,
-            description='Link to Libxc functional library')
+    #mpi support is optional, it is possible to use openmp parallelist only
+    variant('mpi', default='False')
+    depends_on('mpi', when='+mpi')
 
-    depends_on('blas',   when='+blas')
-    depends_on('lapack', when='+lapack')
-    depends_on('fftw',   when='+fft')
-    depends_on('mpi@2:', when='+mpi')
-    depends_on('libxc',  when='+libxc')
+    #Elk comes with internal blas and lapack. Only supported external 
+    #implementations are openblas and mkl, plus unknown type use of BLIS
+    # All requires changes in make.inc Add MKL and BLIS support if possible. 
+    variant('linal', default='internal'
+            , description='linear algebra libraries to use'
+            , values=('internal', 'openblas')
+            , multi=False
+            )
+    depends_on('openblas', when='linal=openblas')
+    
+    #Add MKL FFTW support if possible
+    variant('fft', default='fftw'
+            , description='fft library to use;'
+            , values=('internal','fftw')
+            , multi=False
+            )
+    depends_on('fftw@3:', when='fft=fftw')
 
-    # Cannot be built in parallel
-    parallel = False
+    variant('wannier90', default=False
+            , description="support for wannier code. requires wannier library"
+            )
+    depends_on('wannier90', when="+wannier90")
+    
+    variant('libxc', default=False
+            , description="libxc DFT functional library support"
+            )
+    #Note! libxc changed API around v5, 
+    #Linking with older version might not work
+    depends_on('libxc@5:', when='+libxc')
 
-    def edit(self, spec, prefix):
-        # Dictionary of configuration options
-        config = {
-            'MAKE': 'make',
-            'AR':   'ar'
-        }
-
-        # Compiler-specific flags
-        flags = ''
-        if self.compiler.name == 'intel':
-            flags = '-O3 -ip -unroll -no-prec-div'
-        elif self.compiler.name == 'gcc':
-            flags = '-O3 -ffast-math -funroll-loops'
-        elif self.compiler.name == 'pgi':
-            flags = '-O3 -lpthread'
-        elif self.compiler.name == 'g95':
-            flags = '-O3 -fno-second-underscore'
-        elif self.compiler.name == 'nag':
-            flags = '-O4 -kind=byte -dusty -dcfuns'
-        elif self.compiler.name == 'xl':
-            flags = '-O3'
-        config['F90_OPTS'] = flags
-        config['F77_OPTS'] = flags
-
-        # BLAS/LAPACK support
-        # Note: BLAS/LAPACK must be compiled with OpenMP support
-        # if the +openmp variant is chosen
-        blas = 'blas.a'
-        lapack = 'lapack.a'
-        if '+blas' in spec:
-            blas = spec['blas'].libs.joined()
-        if '+lapack' in spec:
-            lapack = spec['lapack'].libs.joined()
-        # lapack must come before blas
-        config['LIB_LPK'] = ' '.join([lapack, blas])
-
-        # FFT support
-        if '+fft' in spec:
-            config['LIB_FFT'] = join_path(spec['fftw'].prefix.lib,
-                                          'libfftw3.so')
-            config['SRC_FFT'] = 'zfftifc_fftw.f90'
-        else:
-            config['LIB_FFT'] = 'fftlib.a'
-            config['SRC_FFT'] = 'zfftifc.f90'
-
-        # MPI support
-        if '+mpi' in spec:
-            config['F90'] = spec['mpi'].mpifc
-            config['F77'] = spec['mpi'].mpif77
-        else:
-            config['F90'] = spack_fc
-            config['F77'] = spack_f77
-            config['SRC_MPI'] = 'mpi_stub.f90'
-
-        # OpenMP support
-        if '+openmp' in spec:
-            config['F90_OPTS'] += ' ' + self.compiler.openmp_flag
-            config['F77_OPTS'] += ' ' + self.compiler.openmp_flag
-        else:
-            config['SRC_OMP'] = 'omp_stub.f90'
-
-        # Libxc support
-        if '+libxc' in spec:
-            config['LIB_libxc'] = ' '.join([
-                join_path(spec['libxc'].prefix.lib, 'libxcf90.so'),
-                join_path(spec['libxc'].prefix.lib, 'libxc.so')
-            ])
-            config['SRC_libxc'] = ' '.join([
-                'libxc_funcs.f90',
-                'libxc.f90',
-                'libxcifc.f90'
-            ])
-        else:
-            config['SRC_libxc'] = 'libxcifc_stub.f90'
-
-        # Write configuration options to include file
-        with open('make.inc', 'w') as inc:
-            for key in config:
-                inc.write('{0} = {1}\n'.format(key, config[key]))
-
-    def install(self, spec, prefix):
-        # The Elk Makefile does not provide an install target
-        mkdir(prefix.bin)
-
-        install('src/elk',                   prefix.bin)
-        install('src/eos/eos',               prefix.bin)
-        install('src/spacegroup/spacegroup', prefix.bin)
-
-        install_tree('examples', join_path(prefix, 'examples'))
-        install_tree('species',  join_path(prefix, 'species'))
+#   def edit(self, spec, prefix):
+        # FIXME: Edit the Makefile if necessary
+        # FIXME: If not needed delete this function
+        # makefile = FileFilter('Makefile')
+        # makefile.filter('CC = .*', 'CC = cc')

--- a/var/spack/repos/builtin/packages/elk/package.py
+++ b/var/spack/repos/builtin/packages/elk/package.py
@@ -3,30 +3,31 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install elk
-#
-# You can edit this file again by typing:
-#
-#     spack edit elk
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
+
+# TODO: respect the spack-profided compiler flags if any
+
+# TODO: add MKL and BLIS support
+# Attention! MKL and BLIS are NOT JUST drop-in replacements
+# for blas/lapack!
+
+# TODO: Check that spack-provided  compiler flags 
+# are respected
+
+# Attention!
+# Dynamic linking *appears* to work fine, but
+# Elk is expected to be linked statically. 
+
+# TODO: check if it is possible/reasonable to disable OpenMP
+# It doesn't appear to be this way, but check anyway
+
 
 from spack import *
 
 
 class Elk(MakefilePackage):
-    """Elk code is a plane wave dft code aimed at material discovery"""
+    """Elk code is an advanced dft code aimed at material discovery
+    """
 
-    # FIXME: Add a proper url for your package's homepage here.
     homepage = "https://elk.sourceforge.io/"
     url      = "https://sourceforge.net/projects/elk/files/elk-7.1.14.tgz/download"
 
@@ -35,14 +36,21 @@ class Elk(MakefilePackage):
     # maintainers = ['github_user1', 'github_user2']
 
     version('7.1.14', sha256='7c2ff30f4b1d72d5dc116de9d70761f2c206700c69d85dd82a17a5a6374453d2')
+ 
 
+    #parallel builds might fail
+    parallel = False
     #mpi support is optional, it is possible to use openmp parallelist only
     variant('mpi', default='False')
     depends_on('mpi', when='+mpi')
 
-    #Elk comes with internal blas and lapack. Only supported external 
-    #implementations are openblas and mkl, plus unknown type use of BLIS
-    # All requires changes in make.inc Add MKL and BLIS support if possible. 
+    #Elk comes with internal blas and lapack. It also can
+    #integrate with openblas and mkl, but requires special code
+    #to do so. I've no idea if generic externals like blas-atlas
+    #are supported, and besides MKL also interacts with fft capabilities
+    #so the only supported options ATM are 'internal' and 'openblas'
+    #Consult upstream before changing this.
+
     variant('linal', default='internal'
             , description='linear algebra libraries to use'
             , values=('internal', 'openblas')
@@ -50,8 +58,8 @@ class Elk(MakefilePackage):
             )
     depends_on('openblas', when='linal=openblas')
     
-    #Add MKL FFTW support if possible
-    variant('fft', default='fftw'
+    #Add MKL FFT support if possible but see the previous comment.
+    variant('fft', default='internal'
             , description='fft library to use;'
             , values=('internal','fftw')
             , multi=False
@@ -64,14 +72,94 @@ class Elk(MakefilePackage):
     depends_on('wannier90', when="+wannier90")
     
     variant('libxc', default=False
-            , description="libxc DFT functional library support"
+            , description="support for libxc library of functionals for DFT"
             )
-    #Note! libxc changed API around v5, 
+    #Note! libxc changed API/ABI around v5, 
     #Linking with older version might not work
     depends_on('libxc@5:', when='+libxc')
 
-#   def edit(self, spec, prefix):
-        # FIXME: Edit the Makefile if necessary
-        # FIXME: If not needed delete this function
-        # makefile = FileFilter('Makefile')
-        # makefile.filter('CC = .*', 'CC = cc')
+   
+    #setup is done in make.inc
+    #Elk has setup script to generate templates, 
+    #you should consult it before changing how we
+    #generate make.inc.
+    def edit(self, spec, prefix):
+        #Defult configuration
+        #this appears to be configurable, for whatever reason
+        elk_make = 'make'
+        #default linear algebra libs
+        lib_lpk   = 'lapack.a blas.a' #
+        #we do not support linking against mkl yet, activate stub
+        src_mkl = 'mkl_stub.f90'
+        #we do not support linking against blis yet, activate stub
+        src_blis = 'blis_stub.f90'
+        #we will overwrite this if we detect request for 
+        #openblas support. ATM activate stub
+        src_oblas = 'oblas_stub.f90'
+        #we will overwrite this if we detect request for 
+        #libxc support. ATM activate stub
+        src_libxc = 'libxcifc_stub.f90'
+        lib_libxc = '  '
+        #we will overwrite this if we detect request for 
+        #fftw support. ATM activate stub
+        src_fft = 'zfftifc.f90'
+        lib_fft = 'fftlib.a' 
+        #we will overwrite this if we detect request for 
+        #wannier90 support. ATM activate stub
+        src_w90s = 'w90_stub.f90'
+        lib_w90  = '  '
+        #default compiler flags used in elk
+        dfflags  = "-O3 -ffast-math -funroll-loops -fopenmp"
+        #elkFC = mpiCC/FC fi +mpi of CC/FC otherwise
+        #elk uses a stub module in case MPI is absent.
+        if '+mpi' in spec :
+            elk_f77     = spec['mpi'].mpif77
+            elk_f90     = spec['mpi'].mpifc
+            elk_src_mpi = ' '
+        else :
+            elk_f77     = spec.f77
+            elk_f90     = spec.fc
+            elk_src_mpi = 'mpi_stub.f90'
+        #elk blas+lapack
+        #elk requires specific stubs for missing openblas and mkl
+        #we do not support linking against mkl yet.
+        if 'linal=openblas' in spec :
+            lib_lpk   = '-lopenblas'
+            src_oblas = '  '
+        if  'fft=fftw' in spec :
+            lib_fft = '-lfftw3'
+            src_fft = 'zfftifc_fftw.f90'
+        if '+libxc' in spec :
+            src_libxc = 'libxcf90.f90 libxcifc.f90'
+            lib_libxc = '-lxcf90 -lxc'
+        if '+wannier90' in spec :
+            src_w90s = '  '
+            lib_w90  = '-lwannier'
+        #write generated config into make.inc
+        with open('make.inc', 'w') as inc :
+            inc.write('{0} = {1} \n'.format('MAKE',      'make' ))
+            inc.write('{0} = {1} \n'.format('F77',       elk_f77))
+            inc.write('{0} = {1} \n'.format('F90',       elk_f90 ))
+            inc.write('{0} = {1} \n'.format('LIB_LPK',   lib_lpk ))
+            inc.write('{0} = {1} \n'.format('LIB_FFT',   lib_fft ))
+            inc.write('{0} = {1} \n'.format('SRC_FFT',   src_fft ))
+            inc.write('{0} = {1} \n'.format('SRC_MPI',   src_mpi ))
+            inc.write('{0} = {1} \n'.format('SRC_MKL',   src_mkl))
+            inc.write('{0} = {1} \n'.format('SRC_OBLAS', src_oblas ))
+            inc.write('{0} = {1} \n'.format('SRC_BLIS',  src_blis ))
+            inc.write('{0} = {1} \n'.format('LIB_libxc', lib_libxc ))
+            inc.write('{0} = {1} \n'.format('SRC_libxc', src_libxc ))
+            inc.write('{0} = {1} \n'.format('SRC_W90S',  src_w90s ))
+            inc.write('{0} = {1} \n'.format('LIB_W90',   lib_w90))
+#            inc.write('{0} = {1} \n'.format('', ))
+            #end def edit
+
+        def install(self, spec, prefix):
+            mkdir(prefix.bin)
+            install('src/elk',                   prefix.bin)
+            install('src/eos/eos',               prefix.bin)
+            install('src/spacegroup/spacegroup', prefix.bin)
+
+            install_tree('examples', join_path(prefix, 'examples'))
+            install_tree('species',  join_path(prefix, 'species'))
+

--- a/var/spack/repos/builtin/packages/elk/package.py
+++ b/var/spack/repos/builtin/packages/elk/package.py
@@ -37,9 +37,8 @@ class Elk(MakefilePackage):
     homepage = "https://elk.sourceforge.io/"
     url      = "https://downloads.sourceforge.net/project/elk/elk-7.1.14.tgz"
 
-# FIXME: Add a list of GitHub accounts to
-# notify when the package is updated.
-# maintainers = ['github_user1', 'github_user2']
+# NOTE: This is a community package, it doesn't have dedicated maintainers
+
     version('7.1.14', sha256='7c2ff30f4b1d72d5dc116de9d70761f2c206700c69d85dd82a17a5a6374453d2')
 
 # parallel builds might fail

--- a/var/spack/repos/builtin/packages/elk/package.py
+++ b/var/spack/repos/builtin/packages/elk/package.py
@@ -10,12 +10,12 @@
 # Attention! MKL and BLIS are NOT JUST drop-in replacements
 # for blas/lapack!
 
-# TODO: Check that spack-provided  compiler flags 
+# TODO: Check that spack-provided  compiler flags
 # are respected
 
 # Attention!
 # Dynamic linking *appears* to work fine, but
-# Elk is expected to be linked statically. 
+# Elk is expected to be linked statically.
 
 # TODO: check if it is possible/reasonable to disable OpenMP
 # It doesn't appear to be this way, but check anyway
@@ -25,139 +25,157 @@ from spack import *
 
 
 class Elk(MakefilePackage):
-    """Elk code is an advanced dft code aimed at material discovery
+    """An all-electron full-potential linearised augmented-plane wave (LAPW)
+    code with many advanced features. Written originally at
+    Karl-Franzens-Universität Graz as a milestone of the EXCITING EU Research
+    and Training Network, the code is designed to be as simple as possible so
+    that new developments in the field of density functional theory (DFT) can
+    be added quickly and reliably. The code is freely available under the GNU
+    General Public License.
     """
 
     homepage = "https://elk.sourceforge.io/"
     url      = "https://downloads.sourceforge.net/project/elk/elk-7.1.14.tgz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ['github_user1', 'github_user2']
+# FIXME: Add a list of GitHub accounts to
+# notify when the package is updated.
+# maintainers = ['github_user1', 'github_user2']
     version('7.1.14', sha256='7c2ff30f4b1d72d5dc116de9d70761f2c206700c69d85dd82a17a5a6374453d2')
- 
 
-    #parallel builds might fail
+# parallel builds might fail
     parallel = False
-    #mpi support is optional, it is possible to use openmp parallelist only
+
+# mpi support is optional, it is possible to use openmp parallelism only
     variant('mpi', default='False')
     depends_on('mpi', when='+mpi')
 
-    #Elk comes with internal blas and lapack. It also can
-    #integrate with openblas and mkl, but requires special code
-    #to do so. I've no idea if generic externals like blas-atlas
-    #are supported, and besides MKL also interacts with fft capabilities
-    #so the only supported options ATM are 'internal' and 'openblas'
-    #Consult upstream before changing this.
-    #NOTE: weird messages about illegal preprocessing instructions 
-    #were observed during compilation of internal linal libs. Didn't test
-    variant('linal', default='internal'
-            , description='linear algebra libraries to use'
-            , values=('internal', 'openblas')
-            , multi=False
+# Elk comes with internal blas and lapack. It also can integrate with openblas
+# and mkl, but requires special code to do so. I've no idea if generic
+# externals like blas-atlas are supported, and besides MKL also interacts with
+# fft capabilities so the only supported options ATM are 'internal' and
+# 'openblas' Consult upstream before changing this.
+
+# NOTE: weird messages about illegal preprocessing instructions
+# were observed during compilation of internal linal libs. Didn't test
+    variant('linal', default='internal',
+            description='linear algebra libraries to use',
+            values=('internal', 'openblas'), multi=False
             )
     depends_on('openblas', when='linal=openblas')
-    
-    #elk comes with internal FFT lib. It also can use libfftw and MKL FFT
-    #currently only internal fft and fftw libs are supported
-    #TODO:Add MKL FFT support if possible but see the previous comment.
-    variant('fft', default='internal'
-            , description='fft library to use;'
-            , values=('internal','fftw')
-            , multi=False
+
+# elk comes with internal FFT lib. It also can use libfftw and MKL FFT
+# currently only internal fft and fftw libs are supported
+# TODO:Add MKL FFT support if possible but see the previous comment.
+    variant('fft', default='internal',
+            description='fft library to use;',
+            values=('internal', 'fftw'),
+            multi=False
             )
     depends_on('fftw@3:', when='fft=fftw')
 
-    variant('wannier90', default=False
-            , description="support for wannier code. requires wannier library"
+    variant('wannier90', default=False,
+            description="support for wannier code. requires wannier library"
             )
     depends_on('wannier90', when="+wannier90")
-    
-    variant('libxc', default=False
-            , description="support for libxc library of functionals for DFT"
+
+    variant('libxc', default=False,
+            description="support for libxc library of functionals for DFT"
             )
-    #Note! libxc changed API/ABI around v5, 
-    #Linking with older version might not work
+# NOTE: libxc dropped f03 interface in v5.0
+# in favor of f90 interface
+# Linking with older version might not work
     depends_on('libxc@5:', when='+libxc')
 
-   
-    #setup is done in make.inc
-    #Elk has setup script to generate templates, 
-    #you should consult it before changing how we
-    #generate make.inc.
+# setup is done in make.inc
+# Elk has setup script to generate templates,
+# you should consult it before changing how we
+# generate make.inc.
     def edit(self, spec, prefix):
-        #Defult configuration
-        #this appears to be configurable, for whatever reason
+        # Defult configuration
+        # this appears to be configurable, for whatever reason
         elk_make = 'make'
-        #default linear algebra libs
-        lib_lpk   = 'lapack.a blas.a' #
-        #we do not support linking against mkl yet, activate stub
+
+        # default linear algebra libs
+        lib_lpk   = 'lapack.a blas.a'
+
+        # we do not support linking against mkl yet, activate stub
         src_mkl = 'mkl_stub.f90'
-        #we do not support linking against blis yet, activate stub
+
+        # we do not support linking against blis yet, activate stub
         src_blis = 'blis_stub.f90'
-        #we will overwrite this if we detect request for 
-        #openblas support. ATM activate stub
+
+        # we will overwrite this if we detect request for
+        # openblas support. ATM activate stub
         src_oblas = 'oblas_stub.f90'
-        #we will overwrite this if we detect request for 
-        #libxc support. ATM activate stub
+
+        # we will overwrite this if we detect request for
+        # libxc support. ATM activate stub
         src_libxc = 'libxcifc_stub.f90'
         lib_libxc = '  '
-        #we will overwrite this if we detect request for 
-        #fftw support. ATM activate stub
+
+        # we will overwrite this if we detect request for
+        # fftw support. ATM activate stub
         src_fft = 'zfftifc.f90'
-        lib_fft = 'fftlib.a' 
-        #we will overwrite this if we detect request for 
-        #wannier90 support. ATM activate stub
+        lib_fft = 'fftlib.a'
+
+        # we will overwrite this if we detect request for
+        # wannier90 support. ATM activate stub
+
         src_w90s = 'w90_stub.f90'
         lib_w90  = '  '
-        #default compiler flags used in elk
+
+        # default compiler flags used in elk
         dfflags  = "-O3 -ffast-math -funroll-loops -fopenmp"
-        #elkFC = mpiCC/FC fi +mpi of CC/FC otherwise
-        #elk uses a stub module in case MPI is absent.
-        if '+mpi' in spec :
+
+        # elkFC = mpiCC/FC fi +mpi of CC/FC otherwise
+        # elk uses a stub module in case MPI is absent.
+        if '+mpi' in spec:
             elk_f77     = spec['mpi'].mpif77
             elk_f90     = spec['mpi'].mpifc
             src_mpi     = ' '
-        else :
+        else:
             elk_f77     = spack_f77
             elk_f90     = spack_fc
             src_mpi     = 'mpi_stub.f90'
-        #elk blas+lapack
-        #elk requires specific stubs for missing openblas and mkl
-        #we do not support linking against mkl yet.
-        if 'linal=openblas' in spec :
+
+        # elk blas+lapack
+        # elk requires specific stubs for missing openblas and mkl
+        # we do not support linking against mkl yet.
+        if 'linal=openblas' in spec:
             lib_lpk   = '-lopenblas'
             src_oblas = '  '
-        if  'fft=fftw' in spec :
+        if 'fft=fftw' in spec:
             lib_fft = '-lfftw3'
             src_fft = 'zfftifc_fftw.f90'
-        if '+libxc' in spec :
+        if '+libxc' in spec:
             src_libxc = 'libxcf90.f90 libxcifc.f90'
             lib_libxc = '-lxcf90 -lxc'
-        if '+wannier90' in spec :
+        if '+wannier90' in spec:
             src_w90s = '  '
             lib_w90  = '-lwannier'
-        #write generated config into make.inc
-        with open('make.inc', 'w') as inc :
-            inc.write('{0} = {1} \n'.format('MAKE',      'make' ))
-            inc.write('{0} = {1} \n'.format('F77',       elk_f77))
-            inc.write('{0} = {1} \n'.format('F90',       elk_f90 ))
-            inc.write('{0} = {1} \n'.format('F77_OPTS',  dfflags ))
-            inc.write('{0} = {1} \n'.format('F90_OPTS',  dfflags ))
-            inc.write('{0} = {1} \n'.format('LIB_LPK',   lib_lpk ))
-            inc.write('{0} = {1} \n'.format('LIB_FFT',   lib_fft ))
-            inc.write('{0} = {1} \n'.format('SRC_FFT',   src_fft ))
-            inc.write('{0} = {1} \n'.format('SRC_MPI',   src_mpi ))
-            inc.write('{0} = {1} \n'.format('SRC_MKL',   src_mkl))
-            inc.write('{0} = {1} \n'.format('SRC_OBLAS', src_oblas ))
-            inc.write('{0} = {1} \n'.format('SRC_BLIS',  src_blis ))
-            inc.write('{0} = {1} \n'.format('LIB_libxc', lib_libxc ))
-            inc.write('{0} = {1} \n'.format('SRC_libxc', src_libxc ))
-            inc.write('{0} = {1} \n'.format('SRC_W90S',  src_w90s ))
-            inc.write('{0} = {1} \n'.format('LIB_W90',   lib_w90))
-#            inc.write('{0} = {1} \n'.format('', ))
-        #end with open
-    #end def edit
+
+        # write generated config into make.inc
+        with open('make.inc', 'w') as inc:
+            fst = '{0} = {1} \n'
+            inc.write(fst.format('MAKE',      elk_make))
+            inc.write(fst.format('F77',       elk_f77))
+            inc.write(fst.format('F90',       elk_f90))
+            inc.write(fst.format('F77_OPTS',  dfflags))
+            inc.write(fst.format('F90_OPTS',  dfflags))
+            inc.write(fst.format('LIB_LPK',   lib_lpk))
+            inc.write(fst.format('LIB_FFT',   lib_fft))
+            inc.write(fst.format('SRC_FFT',   src_fft))
+            inc.write(fst.format('SRC_MPI',   src_mpi))
+            inc.write(fst.format('SRC_MKL',   src_mkl))
+            inc.write(fst.format('SRC_OBLAS', src_oblas))
+            inc.write(fst.format('SRC_BLIS',  src_blis))
+            inc.write(fst.format('LIB_libxc', lib_libxc))
+            inc.write(fst.format('SRC_libxc', src_libxc))
+            inc.write(fst.format('SRC_W90S',  src_w90s))
+            inc.write(fst.format('LIB_W90',   lib_w90))
+        #    inc.write(fst.format('', ))
+        # end with open
+# end def edit
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
@@ -166,4 +184,4 @@ class Elk(MakefilePackage):
         install('src/spacegroup/spacegroup', prefix.bin)
         install_tree('examples', join_path(prefix, 'examples'))
         install_tree('species',  join_path(prefix, 'species'))
-
+# end

--- a/var/spack/repos/builtin/packages/elk/package.py
+++ b/var/spack/repos/builtin/packages/elk/package.py
@@ -27,7 +27,7 @@ from spack import *
 class Elk(MakefilePackage):
     """An all-electron full-potential linearised augmented-plane wave (LAPW)
     code with many advanced features. Written originally at
-    Karl-Franzens-Universität Graz as a milestone of the EXCITING EU Research
+    Karl-Franzens-Universitat Graz as a milestone of the EXCITING EU Research
     and Training Network, the code is designed to be as simple as possible so
     that new developments in the field of density functional theory (DFT) can
     be added quickly and reliably. The code is freely available under the GNU


### PR DESCRIPTION
 this is a first try on the elk code package, written from scratch. Please, review. I don't expect it to be merged, but I ask for a code review.

I didn't use official spack blas/lapack virtual packages, because elk doesn't appear to like linking against 'generic' blas/lapack and wants to tune its own code somewhat for linking with supported openblas, mkl and blis.

Additionally, there might be some dirty secrets in mkl/blis integration AND mkl can be also used to provide fft. Since I only really wanted openblas+fftw3, I didn't bother with mkl/blis

wannier90 and MPI variants are provided and appear to work

It appears that Elk is meant to compile with openMP no mater what, so didn't do openMP variant. 

I tested if it builds with gradually turned on variants. Didn't test how the resulting elk works yet, but I tested earlier dynamically linked elk built without spack and it worked fine, so I think this one should work well too.
