### PR TITLE
Docs: fix missing backtick in Environments docs

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -363,7 +363,7 @@ to ``spack install`` on the command line, ``--no-add`` is the default,
 while for dependency specs on the other hand, it is optional.  In other
 words, if there is an unambiguous match in the active concrete environment
 for a root spec provided to ``spack install`` on the command line, spack
-does not require you to specify the ``--no-add` option to prevent the spec
+does not require you to specify the ``--no-add`` option to prevent the spec
 from being added again.  At the same time, a spec that already exists in the
 environment, but only as a dependency, will be added to the environment as a
 root spec without the ``--no-add`` option.


### PR DESCRIPTION
Noticed this while reading the docs: https://spack.readthedocs.io/en/latest/environments.html#installing-an-environment