### PR TITLE
Arborx: Update stand-alone tests to use test stage work directory

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -79,32 +79,41 @@ class Arborx(CMakePackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([self.examples_src_dir])
 
-    def build_tests(self):
-        """Build test."""
-        cmake_build_path = join_path(self.install_test_root,
-                                     self.examples_src_dir, "build")
-        cmake_prefix_path = "-DCMAKE_PREFIX_PATH={0}".format(self.spec['arborx'].prefix)
+    @property
+    def cached_tests_work_dir(self):
+        """The working directory for cached test sources."""
+        return join_path(self.test_suite.current_test_cache_dir,
+                         self.examples_src_dir)
 
-        # We don't need to append the path to Kokkos to CMAKE_PREFIX_PATH
-        # since a hint is already hardcoded inside the CMake ArborX configuration.
+    def build_tests(self):
+        """Build the stand-alone/smoke test."""
+
+        # We don't need to append the path to Kokkos to CMAKE_PREFIX_PATH since
+        # a hint is already hardcoded inside the CMake ArborX configuration.
         # Omitting it here allows us to avoid to distinguish between Kokkos
         # being installed as a standalone or as part of Trilinos.
+        arborx_dir = self.spec['arborx'].prefix
+        cmake_prefix_path = "-DCMAKE_PREFIX_PATH={0}".format(arborx_dir)
         if '+mpi' in self.spec:
             cmake_prefix_path += ";{0}".format(self.spec['mpi'].prefix)
-        with working_dir(cmake_build_path, create=True):
-            cmake_args = ["..",
-                          cmake_prefix_path,
-                          "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx)]
-            cmake(*cmake_args)
-            make()
 
-    def run_tests(self):
-        """Run test."""
-        reason = 'Checking ability to execute.'
-        run_path = join_path(self.install_test_root, self.examples_src_dir, 'build')
-        with working_dir(run_path):
-            self.run_test('ctest', ['-V'], [], installed=False, purpose=reason)
+        cmake_args = [".",
+                      cmake_prefix_path,
+                      "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx)]
+
+        self.run_test("cmake", cmake_args,
+                      purpose="test: calling cmake",
+                      work_dir=self.cached_tests_work_dir)
+
+        self.run_test("make", [],
+                      purpose="test: building the tests",
+                      work_dir=self.cached_tests_work_dir)
 
     def test(self):
+        """Perform stand-alone/smoke tests on the installed package."""
         self.build_tests()
-        self.run_tests()
+
+        self.run_test("ctest", ["-V"],
+                      purpose="test: running the tests",
+                      installed=False,
+                      work_dir=self.cached_tests_work_dir)


### PR DESCRIPTION
Change the stand-alone/smoke tests to use the (new) test stage work directory automatically created for cached test sources versus building them under the package's install prefix.