### PR TITLE
biobambam2: Update stand-alone tests to use test stage work directory

### DIFF
--- a/var/spack/repos/builtin/packages/biobambam2/package.py
+++ b/var/spack/repos/builtin/packages/biobambam2/package.py
@@ -40,7 +40,10 @@ class Biobambam2(AutotoolsPackage):
         self._fix_shortsort()
 
     def test(self):
-        test_dir = join_path(self.install_test_root, self.test_src_dir)
+        """Perform stand-alone/smoke test on installed package."""
+        test_dir = join_path(self.test_suite.current_test_cache_dir,
+                             self.test_src_dir)
         self.run_test('sh', ['testshortsort.sh'],
                       expected='Alignments sorted by coordinate.',
+                      purpose='test: checking alignments',
                       work_dir=test_dir)


### PR DESCRIPTION
Change the stand-alone/smoke tests to use the (new) test stage work directory automatically created for cached test sources versus building them under the package's install prefix.

@takanori-ihara 