### PR TITLE
m4: secure_snprintf.patch is no longer needed

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -22,10 +22,10 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     patch('oneapi.patch', when='%oneapi')
     # from: https://github.com/Homebrew/homebrew-core/blob/master/Formula/m4.rb
     # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>
-    patch('secure_snprintf.patch', when='os = highsierra')
-    patch('secure_snprintf.patch', when='os = mojave')
-    patch('secure_snprintf.patch', when='os = catalina')
-    patch('secure_snprintf.patch', when='os = bigsur')
+    patch('secure_snprintf.patch', when='@:1.4.18 os=highsierra')
+    patch('secure_snprintf.patch', when='@:1.4.18 os=mojave')
+    patch('secure_snprintf.patch', when='@:1.4.18 os=catalina')
+    patch('secure_snprintf.patch', when='@:1.4.18 os=bigsur')
     # https://bugzilla.redhat.com/show_bug.cgi?id=1573342
     patch('https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch', sha256='fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8', when='@1.4.18')
 


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Apple Clang 12.0.0.

#24099 added the latest version of m4, but the macOS patch no longer applies correctly to this version. According to https://github.com/Homebrew/homebrew-core/pull/78294, the patch is no longer needed for m4 1.4.19, so I added a version requirement.

@robert-mijakovic @alalazo 