### PR TITLE
correctly handle #! prefix which is not part of an actual shebang

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -56,6 +56,11 @@ def shebang_too_long(path):
         bytes = script.read(2)
         if bytes != b'#!':
             return False
+        bytes = bytes + script.read(1)
+        while bytes.endswith(b' ') or bytes.endswith(b'\t'):
+            bytes = bytes + script.read(1)
+        if not bytes.endswith(b'/'):
+            return False
 
         line = bytes + script.readline()
         return len(line) > shebang_limit


### PR DESCRIPTION
Tecplot (https://www.tecplot.com/) generates files with suffix .plt.
Such files are e.g. distributed with Spack's foam-extend package.
They begin with #!TDV<version>. The current implementation interprets
this as a shebang, however it is not intended to be a shebang.
Unfortunately, this can trigger errors (e.g. unprintable character
in my case).

According to https://en.wikipedia.org/wiki/Shebang_(Unix), shebangs
are available on unixoid systems only. We hence can assume a slash
to follow the first two characters. However, according to the same
reference, at least one whitespace may follow the first two
characters.

This pull request tries to improve the detection of actual shebangs
following the reference mentioned above.