### PR TITLE
Compiler CCE: enable std c++14

### DIFF
--- a/lib/spack/spack/compilers/cce.py
+++ b/lib/spack/spack/compilers/cce.py
@@ -66,6 +66,12 @@ class Cce(Compiler):
         return "-h std=c++11"
 
     @property
+    def cxx14_flag(self):
+        if self.is_clang_based:
+            return '-std=c++14'
+        return "-h std=c++14"
+
+    @property
     def c99_flag(self):
         if self.is_clang_based:
             return '-std=c99'


### PR DESCRIPTION
Cray Compiling Environment supports C++14

I encountered the following error:
```
==> Error: UnsupportedCompilerFlag: cce (11.0.1) does not support the C++14 standard (as compiler.cxx14_flag).
    If you think it should, please edit the compiler.cce subclass to implement the cxx14_flag property and submit a pull request or issue.
```

The compilation succeeded after enabling c++14 support.