### PR TITLE
main, modules: fix module roots not being found

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -32,6 +32,7 @@ import spack.architecture
 import spack.config
 import spack.cmd
 import spack.environment as ev
+import spack.modules
 import spack.paths
 import spack.repo
 import spack.store
@@ -647,14 +648,8 @@ def print_setup_info(*info):
         'tcl': list(),
         'lmod': list()
     }
-    module_roots = spack.config.get('modules:default:roots', {})
-    module_roots = spack.config.merge_yaml(
-        module_roots, spack.config.get('config:module_roots', {}))
-    module_roots = dict(
-        (k, v) for k, v in module_roots.items() if k in module_to_roots
-    )
-    for name, path in module_roots.items():
-        path = spack.util.path.canonicalize_path(path)
+    for name in module_to_roots.keys():
+        path = spack.modules.common.root_path(name, 'default')
         module_to_roots[name].append(path)
 
     other_spack_instances = spack.config.get(

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -221,8 +221,8 @@ def root_path(name, module_set_name):
         root folder for module file installation
     """
     defaults = {
-        'lmod': '$spack/share/spack/modules',
-        'tcl': '$spack/share/spack/lmod',
+        'lmod': '$spack/share/spack/lmod',
+        'tcl': '$spack/share/spack/modules',
     }
     # Root folders where the various module files should be written
     roots = spack.config.get('modules:%s:roots' % module_set_name, {})


### PR DESCRIPTION
Since the module roots were removed from the config file, `--print-shell-vars` cannot find the module roots anymore. Fix it by using the new `root_path` function. Moreover, the roots for lmod and modules seems to have been flipped by accident.

Fixes #24067 