### PR TITLE
libceed: bugfix: Update the hip-related variant

### DIFF
--- a/var/spack/repos/builtin/packages/libceed/package.py
+++ b/var/spack/repos/builtin/packages/libceed/package.py
@@ -30,7 +30,7 @@ class Libceed(Package, CudaPackage, ROCmPackage):
 
     conflicts('+libxsmm', when='@:0.2')
     conflicts('+magma', when='@:0.5')
-    conflicts('+hip', when='@:0.6')
+    conflicts('+rocm', when='@:0.6')
 
     depends_on('cuda', when='+cuda')
     depends_on('hip@3.8.0', when='@0.7:0.7.99+rocm')


### PR DESCRIPTION
PR #22735 Switched to using `ROCmPackage` but forgot to fix the the `hip`-related variant conflict.

This PR corrects the conflict.