### PR TITLE
Axom: don't require hdf5~shared

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -94,7 +94,7 @@ class Axom(CachedCMakePackage, CudaPackage):
     depends_on("conduit~hdf5", when="~hdf5")
 
     # HDF5 needs to be the same as Conduit's
-    depends_on("hdf5@1.8.19:1.8.999~cxx~shared~fortran", when="+hdf5")
+    depends_on("hdf5@1.8.19:1.8.999~cxx~fortran", when="+hdf5")
 
     depends_on("lua", when="+lua")
 


### PR DESCRIPTION
This is not required by conduit in all cases (which is the original reason this constraint was added, to avoid concretization failures), so the constraint is relaxed to allow for building `hdf5+shared`