### PR TITLE
[py-cvxpy]: Add new version, fix depends_on versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-cvxpy/package.py
+++ b/var/spack/repos/builtin/packages/py-cvxpy/package.py
@@ -13,13 +13,18 @@ class PyCvxpy(PythonPackage):
     homepage = "https://www.cvxpy.org/index.html"
     pypi = "cvxpy/cvxpy-1.0.25.tar.gz"
 
+    version('1.1.13', sha256='a9c781e74ad76097b47b86456cb3a943898f7ec9ac8f47bcefc922051cdc4a04')
     version('1.0.25', sha256='8535529ddb807067b0d59661dce1d9a6ddb2a218398a38ea7772328ad8a6ea13')
 
+    # Dependency versions based on README.md in python packages
+    depends_on('python@3.4:', type=('build', 'run'), when='@1.1:')
+    depends_on('python@3.6:', type=('build', 'run'), when='@1.1.13:')
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy@1.15:',        type=('build', 'run'))
     depends_on('py-scipy@1.1.0:',        type=('build', 'run'))
     depends_on('py-ecos@2:',        type=('build', 'run'))
     depends_on('py-scs@1.1.3:',        type=('build', 'run'))
-    depends_on('py-osqp@0.4.1',        type=('build', 'run'))
+    depends_on('py-scs@1.1.6:',        type=('build', 'run'), when='@1.1.13:')
+    depends_on('py-osqp@0.4.1:',        type=('build', 'run'))
     depends_on('py-multiprocess', type=('build', 'run'))
-    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-six', type=('build', 'run'), when='@:1.0.99')


### PR DESCRIPTION
Added version 1.1.13

Fixed versions for dependencies based on README.md for package
In particular:
   * versions 1.1.x require python@3, at least 3.4 and for 1.1.13 at least 3.6
   * py-osqp had been pinned to version 0.4.1, but README.md either shows
        no version restriction, of 0.4.1 and higher
   * @1.1.13 requires at least 1.1.6 of py-scs
   * I am assuming since 1.1.x is python@3 only, py-six no longer required
        (it was not explicitly showing up in README.md for these versions)