### PR TITLE
most windows style and vermin issues addressed

### DIFF
--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -29,6 +29,7 @@ def symlink(real_path, link_path):
             # If all else fails, fall back to copying files
             shutil.copyfile(real_path, link_path)
 
+
 # Based on https://github.com/Erotemic/ubelt/blob/master/ubelt/util_links.py
 def _win32_junction(path, link):
     # junctions require absolute paths

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -22,6 +22,10 @@ from spack.package import PackageBase, run_after
 _primary_generator_extractor = re.compile(r'(?:.* - )?(.*)')
 
 
+def generator_default():
+    return 'Make' if sys.platform != 'win32' else 'Ninja'
+
+
 def _extract_primary_generator(generator):
     """Use the compiled regex _primary_generator_extractor to extract the
     primary generator from the generator string which may contain an
@@ -90,9 +94,7 @@ class CMakePackage(PackageBase):
     #: See https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html
     #: for more information.
 
-    def generator_default():
-        return 'Make' if sys.platform != 'win32' else 'Ninja'
-
+    @staticmethod
     def generator_options():
         return ('Make', 'Ninja') if sys.platform != 'win32' else ('Ninja')
 

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -267,7 +267,7 @@ def _get_external_packages(packages_to_check, system_path_to_exe=None):
         if hasattr(pkg, 'executables'):
             for exe in pkg.executables:
                 if sys.platform == 'win32':
-                    exe = exe.replace('$', '\.exe$')
+                    exe = exe.replace('$', r'\.exe$')
                 exe_pattern_to_pkgs[exe].append(pkg)
 
     pkg_to_found_exes = defaultdict(set)

--- a/lib/spack/spack/cmd/make_installer.py
+++ b/lib/spack/spack/cmd/make_installer.py
@@ -56,7 +56,7 @@ def make_installer(parser, args):
         spack_license = posixpath.join(posix_root, "LICENSE-APACHE")
 
         spack_logo = posixpath.join(posix_root,
-                                  "share/spack/logo/favicon.ico")
+                                    "share/spack/logo/favicon.ico")
 
         try:
             subprocess.check_call(
@@ -79,14 +79,16 @@ def make_installer(parser, args):
             return
         try:
             subprocess.check_call(
-                '"%s/bin/candle.exe" -ext WixBalExtension "%s/bundle.wxs" -out "%s/bundle.wixobj"'
+                '"%s/bin/candle.exe" -ext WixBalExtension "%s/bundle.wxs"'
+                ' -out "%s/bundle.wixobj"'
                 % (os.environ.get('WIX'), output_dir, output_dir), shell=True)
         except subprocess.CalledProcessError:
             print("Failed to generate installer chain")
             return
         try:
             subprocess.check_call(
-                '"%s/bin/light.exe" -sw1134 -ext WixBalExtension "%s/bundle.wixobj" -out "%s/Spack.exe"'
+                '"%s/bin/light.exe" -sw1134 -ext WixBalExtension "%s/bundle.wixobj"'
+                ' -out "%s/Spack.exe"'
                 % (os.environ.get('WIX'), output_dir, output_dir), shell=True)
         except subprocess.CalledProcessError:
             print("Failed to generate installer chain")

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -33,7 +33,7 @@ class Msvc(Compiler):
     version_argument = ''
 
     #: Regex used to extract version from compiler's output
-    version_regex = '([1-9][0-9]*\.[0-9]*\.[0-9]*)'
+    version_regex = r'([1-9][0-9]*\.[0-9]*\.[0-9]*)'
 
     # Initialize, deferring to base class but then adding the vcvarsallfile
     # file based on compiler executable path.
@@ -56,13 +56,15 @@ class Msvc(Compiler):
     def setup_custom_environment(self, pkg, env):
         """Set environment variables for MSVC using the Microsoft-provided
         script."""
-
+        if sys.version_info[:2] > (2, 6):
         # Capture output from batch script and DOS environment dump
-        out = subprocess.check_output(
-            'cmd /u /c "{}" {} && set'.format(self.vcvarsallfile, 'amd64'),
-            stderr=subprocess.STDOUT)
-        if sys.version_info[0] >= 3:
-            out = out.decode('utf-16le', errors='replace')
+            out = subprocess.check_output(
+                'cmd /u /c "{0}" {1} && set'.format(self.vcvarsallfile, 'amd64'),
+                stderr=subprocess.STDOUT)
+            if sys.version_info[0] >= 3:
+                out = out.decode('utf-16le', errors='replace')
+        else:
+            print("Cannot pull msvc compiler information in Python 2.6 or below")
 
         # Process in to nice Python dictionary
         vc_env = {

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1786,7 +1786,8 @@ def build_process(pkg, kwargs):
                         # We assume loggers share echo True/False
                         echo = logger.echo
 
-                    # After log, we can get all output/error files from the package stage
+                    # After log, we can get all output/error files from
+                    # the package stage
                     combine_phase_logs(pkg.phase_log_files, pkg.log_path)
                     log(pkg)
                 else:

--- a/lib/spack/spack/test/cmd/blame.py
+++ b/lib/spack/spack/test/cmd/blame.py
@@ -45,6 +45,7 @@ def test_blame_file(mock_packages):
     assert 'AUTHOR' in out
     assert 'EMAIL' in out
 
+
 def test_blame_json(mock_packages):
     """Ensure that we can output json as a blame."""
     with working_dir(spack.paths.prefix):
@@ -68,7 +69,7 @@ def test_blame_json(mock_packages):
         assert key in loaded['authors'][0]
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason = "git hangs")
+@pytest.mark.skipif(sys.platform == 'win32', reason="git hangs")
 def test_blame_by_git(mock_packages, capfd):
     """Sanity check the blame command to make sure it works."""
     with capfd.disabled():

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -46,6 +46,7 @@ if sys.platform == 'win32':
 else:
     sep = os.sep
 
+
 def check_mpileaks_and_deps_in_view(viewdir):
     """Check that the expected install directories exist."""
     assert os.path.exists(str(viewdir.join('.spack', 'mpileaks')))
@@ -611,7 +612,7 @@ env:
         e.concretize()
 
     assert any(x.satisfies('mpileaks@2.2')
-                for x in e._get_environment_specs())
+               for x in e._get_environment_specs())
 
 
 def test_with_config_bad_include(env_deactivate, capfd, win_locks):
@@ -699,7 +700,7 @@ packages:
         e.concretize()
 
     assert any(x.satisfies('mpileaks@2.2')
-                for x in e._get_environment_specs())
+               for x in e._get_environment_specs())
 
 
 def test_env_with_included_config_scope(win_locks):
@@ -728,7 +729,7 @@ packages:
         e.concretize()
 
     assert any(x.satisfies('mpileaks@2.2')
-                for x in e._get_environment_specs())
+               for x in e._get_environment_specs())
 
 
 def test_env_with_included_config_var_path(win_locks):
@@ -757,7 +758,7 @@ packages:
         e.concretize()
 
     assert any(x.satisfies('mpileaks@2.2')
-                for x in e._get_environment_specs())
+               for x in e._get_environment_specs())
 
 
 def test_env_config_precedence(win_locks):
@@ -2462,7 +2463,8 @@ def test_rewrite_rel_dev_path_new_dir(tmpdir):
     env('create', '-d', str(dest_env), str(spack_yaml))
     with ev.Environment(str(dest_env)) as e:
         assert e.dev_specs['mypkg1']['path'] == str(build_folder)
-        assert e.dev_specs['mypkg2']['path'] == sep+os.path.join('some', 'other', 'path')
+        assert e.dev_specs['mypkg2']['path'] == sep + os.path.join('some',
+                                                                   'other', 'path')
 
 
 def test_rewrite_rel_dev_path_named_env(tmpdir):
@@ -2472,7 +2474,8 @@ def test_rewrite_rel_dev_path_named_env(tmpdir):
     env('create', 'named_env', str(spack_yaml))
     with ev.read('named_env') as e:
         assert e.dev_specs['mypkg1']['path'] == str(build_folder)
-        assert e.dev_specs['mypkg2']['path'] == sep+os.path.join('some', 'other', 'path')
+        assert e.dev_specs['mypkg2']['path'] == sep + os.path.join('some',
+                                                                   'other', 'path')
 
 
 def test_rewrite_rel_dev_path_original_dir(tmpdir):

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -61,7 +61,8 @@ def test_install_package_and_dependency(
 
 
 @pytest.mark.disable_clean_stage_check
-def test_install_runtests_notests(monkeypatch, mock_packages, install_mockery, win_locks):
+def test_install_runtests_notests(monkeypatch, mock_packages,
+                                  install_mockery, win_locks):
     def check(pkg):
         assert not pkg.run_tests
     monkeypatch.setattr(spack.package.PackageBase, 'unit_test_check', check)
@@ -502,7 +503,8 @@ def test_cdash_upload_build_error(tmpdir, mock_fetch, install_mockery,
 
 
 @pytest.mark.disable_clean_stage_check
-def test_cdash_upload_clean_build(tmpdir, mock_fetch, install_mockery, capfd, win_locks):
+def test_cdash_upload_clean_build(tmpdir, mock_fetch, install_mockery,
+                                  capfd, win_locks):
     # capfd interferes with Spack's capturing of e.g., Build.xml output
     with capfd.disabled():
         with tmpdir.as_cwd():
@@ -520,7 +522,8 @@ def test_cdash_upload_clean_build(tmpdir, mock_fetch, install_mockery, capfd, wi
 
 
 @pytest.mark.disable_clean_stage_check
-def test_cdash_upload_extra_params(tmpdir, mock_fetch, install_mockery, capfd, win_locks):
+def test_cdash_upload_extra_params(tmpdir, mock_fetch, install_mockery,
+                                   capfd, win_locks):
     # capfd interferes with Spack's capture of e.g., Build.xml output
     with capfd.disabled():
         with tmpdir.as_cwd():

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -86,7 +86,8 @@ def test_load_includes_run_env(install_mockery, mock_fetch, mock_archive,
     assert 'setenv FOOBAR mpileaks' in csh_out
 
 
-def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages, win_locks):
+def test_load_first(install_mockery, mock_fetch, mock_archive,
+                    mock_packages, win_locks):
     """Test with and without the --first option"""
     install('libelf@0.8.12')
     install('libelf@0.8.13')

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -230,7 +230,7 @@ mpich:
         # ensure that once config is in place, external is used
         spec = Spec('mpi')
         spec.concretize()
-        assert spec['mpich'].external_path == os.sep+os.path.join('dummy','path')
+        assert spec['mpich'].external_path == os.sep + os.path.join('dummy', 'path')
 
     def test_external_module(self, monkeypatch):
         """Test that packages can find externals specified by module

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -593,6 +593,7 @@ def _populate(mock_db):
 
     _install('trivial-smoke-test')
 
+
 @pytest.fixture(scope='session')
 def _store_dir_and_cache(tmpdir_factory):
     """Returns the directory where to build the mock database and

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -5,7 +5,6 @@
 
 import copy
 import os
-import sys
 import shutil
 
 import pytest
@@ -137,7 +136,8 @@ def test_fetch(type_of_test,
 
 
 @pytest.mark.parametrize("type_of_test", ['branch', 'commit'])
-def test_debug_fetch(mock_packages, type_of_test, mock_git_repository, config, win_locks):
+def test_debug_fetch(mock_packages, type_of_test, mock_git_repository,
+                     config, win_locks):
     """Fetch the repo with debug enabled."""
     # Retrieve the right test parameters
     t = mock_git_repository.checks[type_of_test]

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import sys
 import py
 import pytest
 
@@ -404,7 +403,8 @@ def test_ensure_locked_new_lock(
         assert lock._writes == writes
 
 
-def test_ensure_locked_new_warn(install_mockery, monkeypatch, tmpdir, capsys, win_locks):
+def test_ensure_locked_new_warn(install_mockery, monkeypatch, tmpdir,
+                                capsys, win_locks):
     orig_pl = spack.database.Database.prefix_lock
 
     def _pl(db, spec, timeout):

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -238,7 +238,7 @@ def test_make_relative_paths(start_path, path_root, paths, expected):
     # and then normalized
     ('/usr/bin/test',
      ['$ORIGIN/../lib', '$ORIGIN/../lib64', '/opt/local/lib'],
-     [os.sep+os.path.join('usr', 'lib'), os.sep+os.path.join('usr','lib64'),
+     [os.sep + os.path.join('usr', 'lib'), os.sep + os.path.join('usr', 'lib64'),
       '/opt/local/lib']),
     # Relative path without $ORIGIN
     ('/usr/bin/test', ['../local/lib'], ['../local/lib']),

--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -35,6 +35,7 @@ if sys.platform == "win32":
 else:
     path_sep = ":"
 
+
 def test_filter_system_paths():
     expected = [p for p in test_paths if p.startswith('/nonsense_path')]
     filtered = envutil.filter_system_paths(test_paths)
@@ -89,7 +90,7 @@ def test_env_flag(prepare_environment_for_tests):
 
 def test_path_set(prepare_environment_for_tests):
     envutil.path_set('TEST_ENV_VAR', ['/a', '/a/b', '/a/a'])
-    assert(os.environ['TEST_ENV_VAR'] == '/a'+path_sep+'/a/b'+path_sep+'/a/a')
+    assert(os.environ['TEST_ENV_VAR'] == '/a' + path_sep + '/a/b' + path_sep + '/a/a')
 
 
 def test_path_put_first(prepare_environment_for_tests):
@@ -112,8 +113,8 @@ def test_dump_environment(prepare_environment_for_tests, tmpdir):
 
 def test_reverse_environment_modifications(working_env):
     start_env = {
-        'PREPEND_PATH': os.sep+os.path.join('path', 'to', 'prepend', 'to'),
-        'APPEND_PATH': os.sep+os.path.join('path', 'to', 'append', 'to'),
+        'PREPEND_PATH': os.sep + os.path.join('path', 'to', 'prepend', 'to'),
+        'APPEND_PATH': os.sep + os.path.join('path', 'to', 'append', 'to'),
         'UNSET': 'var_to_unset',
         'APPEND_FLAGS': 'flags to append to',
     }

--- a/lib/spack/spack/test/util/prefix.py
+++ b/lib/spack/spack/test/util/prefix.py
@@ -11,24 +11,24 @@ import os
 
 def test_prefix_attributes():
     """Test normal prefix attributes like ``prefix.bin``"""
-    prefix = Prefix(os.sep+'usr')
+    prefix = Prefix(os.sep + 'usr')
 
-    assert prefix.bin     == os.sep+os.path.join('usr', 'bin')
-    assert prefix.lib     == os.sep+os.path.join('usr', 'lib')
-    assert prefix.include == os.sep+os.path.join('usr', 'include')
+    assert prefix.bin     == os.sep + os.path.join('usr', 'bin')
+    assert prefix.lib     == os.sep + os.path.join('usr', 'lib')
+    assert prefix.include == os.sep + os.path.join('usr', 'include')
 
 
 def test_prefix_join():
     """Test prefix join  ``prefix.join(...)``"""
-    prefix = Prefix(os.sep+'usr')
+    prefix = Prefix(os.sep + 'usr')
 
     a1 = prefix.join('a_{0}'.format(1)).lib64
     a2 = prefix.join('a-{0}'.format(1)).lib64
     a3 = prefix.join('a.{0}'.format(1)).lib64
 
-    assert a1 == os.sep+os.path.join('usr', 'a_1', 'lib64')
-    assert a2 == os.sep+os.path.join('usr', 'a-1', 'lib64')
-    assert a3 == os.sep+os.path.join('usr', 'a.1', 'lib64')
+    assert a1 == os.sep + os.path.join('usr', 'a_1', 'lib64')
+    assert a2 == os.sep + os.path.join('usr', 'a-1', 'lib64')
+    assert a3 == os.sep + os.path.join('usr', 'a.1', 'lib64')
 
     assert isinstance(a1, Prefix)
     assert isinstance(a2, Prefix)
@@ -38,9 +38,9 @@ def test_prefix_join():
     p2 = prefix.share.join('pkg-config').join('foo.pc')
     p3 = prefix.join('dashed-directory').foo
 
-    assert p1 == os.sep+os.path.join('usr', 'bin', 'executable.sh')
-    assert p2 == os.sep+os.path.join('usr', 'share', 'pkg-config', 'foo.pc')
-    assert p3 == os.sep+os.path.join('usr', 'dashed-directory', 'foo')
+    assert p1 == os.sep + os.path.join('usr', 'bin', 'executable.sh')
+    assert p2 == os.sep + os.path.join('usr', 'share', 'pkg-config', 'foo.pc')
+    assert p3 == os.sep + os.path.join('usr', 'dashed-directory', 'foo')
 
     assert isinstance(p1, Prefix)
     assert isinstance(p2, Prefix)
@@ -49,16 +49,16 @@ def test_prefix_join():
 
 def test_multilevel_attributes():
     """Test attributes of attributes, like ``prefix.share.man``"""
-    prefix = Prefix(os.sep+'usr'+os.sep)
+    prefix = Prefix(os.sep + 'usr' + os.sep)
 
-    assert prefix.share.man   == os.sep+os.path.join('usr', 'share', 'man')
-    assert prefix.man.man8    == os.sep+os.path.join('usr', 'man', 'man8')
-    assert prefix.foo.bar.baz == os.sep+os.path.join('usr', 'foo', 'bar', 'baz')
+    assert prefix.share.man   == os.sep + os.path.join('usr', 'share', 'man')
+    assert prefix.man.man8    == os.sep + os.path.join('usr', 'man', 'man8')
+    assert prefix.foo.bar.baz == os.sep + os.path.join('usr', 'foo', 'bar', 'baz')
 
     share = prefix.share
 
     assert isinstance(share, Prefix)
-    assert share.man == os.sep+os.path.join('usr', 'share', 'man')
+    assert share.man == os.sep + os.path.join('usr', 'share', 'man')
 
 
 def test_string_like_behavior():

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import sys
 
+
 class Ninja(Package):
     """Ninja is a small build system with a focus on speed. It differs from
     other build systems in two major respects: it is designed to have its input


### PR DESCRIPTION
OUTSTANDING ISSUES: 

- `msvc.py:61` : subprocess.check_output is introduced in 2.7, but essential to how data is extracted from vsvars.bat
- `operating_systems\windows_os.py:37`: subprocess.check_output is introduced in 2.7, but essential to how data is extracted from vsvars.bat
- `operating_systems\windows_os.py:37`: subprocess.check_output cannot have Dict[str,str] as second argument