### PR TITLE
arborx: trilinos 13.0 ships the right version of kokkos

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -47,10 +47,9 @@ class Arborx(CMakePackage):
 
     # Trilinos/Kokkos
     # Notes:
-    # - there is no Trilinos release with Kokkos 3.1 yet
     # - current version of Trilinos package does not allow disabling Serial
     # - current version of Trilinos package does not allow enabling CUDA
-    depends_on('trilinos+kokkos@develop', when='+trilinos')
+    depends_on('trilinos+kokkos', when='+trilinos')
     depends_on('trilinos+openmp', when='+trilinos+openmp')
     conflicts('~serial', when='+trilinos')
     conflicts('+cuda', when='+trilinos')


### PR DESCRIPTION
Remove the need to link with trilinos@develop, since latest version of trilinos supports the required version of kokkos.