### PR TITLE
modules: allow user to remove arch dir

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -213,6 +213,18 @@ location). The set ``my_custom_lmod_modules`` will install its lmod
 modules to ``/path/to/install/custom/lmod/modules`` (and still install
 its tcl modules, if any, to the default location).
 
+By default, an architecture-specific directory is added to the root
+directory. A module set may override that behavior by setting the
+``arch_folder`` config value to ``False``.
+
+.. code-block:: yaml
+
+   modules:
+     default:
+       roots:
+         tcl: /path/to/install/tcl/modules
+       arch_folder: false
+
 Obviously, having multiple module sets install modules to the default
 location could be confusing to users of your modules. In the next
 section, we will discuss enabling and disabling module types (module

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -612,10 +612,14 @@ class BaseFileLayout(object):
         if self.extension:
             filename = '{0}.{1}'.format(self.use_name, self.extension)
         # Architecture sub-folder
-        arch_folder = str(self.spec.architecture)
+        arch_folder_conf = spack.config.get(
+            'modules:%s:arch_folder' % self.conf.name, True)
+        if arch_folder_conf:
+            # include an arch specific folder between root and filename
+            arch_folder = str(self.spec.architecture)
+            filename = os.path.join(arch_folder, filename)
         # Return the absolute path
-        return os.path.join(self.dirname(), arch_folder, filename)
-
+        return os.path.join(self.dirname(), filename)
 
 class BaseContext(tengine.Context):
     """Provides the base context needed for template rendering.

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -621,6 +621,7 @@ class BaseFileLayout(object):
         # Return the absolute path
         return os.path.join(self.dirname(), filename)
 
+
 class BaseContext(tengine.Context):
     """Provides the base context needed for template rendering.
 

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -222,15 +222,18 @@ class LmodFileLayout(BaseFileLayout):
     @property
     def arch_dirname(self):
         """Returns the root folder for THIS architecture"""
-        arch_folder = '-'.join([
-            str(self.spec.platform),
-            str(self.spec.os),
-            str(self.spec.target.family)
-        ])
-        return os.path.join(
-            self.dirname(),  # root for lmod module files
-            arch_folder,  # architecture relative path
-        )
+        # Architecture sub-folder
+        arch_folder_conf = spack.config.get(
+            'modules:%s:arch_folder' % self.conf.name, True)
+        if arch_folder_conf:
+            # include an arch specific folder between root and filename
+            arch_folder = '-'.join([
+                str(self.spec.platform),
+                str(self.spec.os),
+                str(self.spec.target.family)
+            ])
+            return os.path.join(self.dirname(), arch_folder)
+        return self.dirname()
 
     @property
     def filename(self):

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -125,6 +125,7 @@ module_config_properties = {
         {'type': 'string'},
         {'type': 'boolean'}
     ]},
+    'arch_folder': {'type': 'boolean'},
     'prefix_inspections': {
         'type': 'object',
         'additionalProperties': False,

--- a/lib/spack/spack/test/data/modules/lmod/no_arch.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/no_arch.yaml
@@ -1,0 +1,6 @@
+enable:
+  - lmod
+arch_folder: false
+lmod:
+  core_compilers:
+    - 'clang@3.3'

--- a/lib/spack/spack/test/data/modules/tcl/no_arch.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/no_arch.yaml
@@ -1,0 +1,6 @@
+enable:
+  - tcl
+arch_folder: false
+tcl:
+  projections:
+    all: ''

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -354,3 +354,10 @@ class TestLmod(object):
             # point to the right one
             assert any(expected in line for line in content)
             assert not any(spec.prefix in line for line in content)
+
+    def test_modules_no_arch(self, factory, module_configuration):
+        module_configuration('no_arch')
+        module, spec = factory(mpileaks_spec_string)
+        path = module.layout.filename
+
+        assert str(spec.os) not in path

--- a/lib/spack/spack/test/modules/tcl.py
+++ b/lib/spack/spack/test/modules/tcl.py
@@ -404,3 +404,10 @@ class TestTcl(object):
 
         assert old_format == new_format
         assert old_format == settings['tcl']
+
+    def test_modules_no_arch(self, factory, module_configuration):
+        module_configuration('no_arch')
+        module, spec = factory(mpileaks_spec_string)
+        path = module.layout.filename
+
+        assert str(spec.os) not in path


### PR DESCRIPTION
Spack modules append an architecture-specific dir to the module root (between the root and `Core`/etc for lmod).

This PR provides a module configuration option which allows the user to remove this directory. It does not change the default behavior.