### PR TITLE
build_systems: Make autotools builds verbose

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -345,8 +345,11 @@ class AutotoolsPackage(PackageBase):
         """Makes the build targets specified by
         :py:attr:``~.AutotoolsPackage.build_targets``
         """
+        # See https://autotools.io/automake/silent.html
+        params = ['V=1']
+        params += self.build_targets
         with working_dir(self.build_directory):
-            inspect.getmodule(self).make(*self.build_targets)
+            inspect.getmodule(self).make(*params)
 
     def install(self, spec, prefix):
         """Makes the install targets specified by


### PR DESCRIPTION
This is also what our other build systems are doing.