### PR TITLE
build_systems: Default to build system flags for autotools packages

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -83,6 +83,10 @@ class AutotoolsPackage(PackageBase):
     #: after the installation. If True instead it installs them.
     install_libtool_archives = False
 
+    #: Pass flags to configure by default
+    # Need to work around mypy issue: https://github.com/python/mypy/issues/708
+    flag_handler = PackageBase.build_system_flags  # type: ignore
+
     @property
     def _removed_la_files_log(self):
         """File containing the list of remove libtool archives"""

--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -30,12 +30,13 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
 
     def flag_handler(self, name, flags):
         spec = self.spec
+        iflags = []
 
         if name == 'cflags':
             if '%intel@:17.999' in spec:
-                flags.append('-no-gcc')
+                iflags.append('-no-gcc')
 
             elif '%clang' in spec or '%fj' in spec:
-                flags.append('--rtlib=compiler-rt')
+                iflags.append('--rtlib=compiler-rt')
 
-        return (flags, None, None)
+        return (iflags, None, flags)

--- a/var/spack/repos/builtin/packages/elfutils/package.py
+++ b/var/spack/repos/builtin/packages/elfutils/package.py
@@ -85,8 +85,6 @@ class Elfutils(AutotoolsPackage, SourcewarePackage):
         files = glob.glob(os.path.join('*', 'Makefile.in'))
         filter_file('-Werror', '', *files)
 
-    flag_handler = AutotoolsPackage.build_system_flags
-
     def configure_args(self):
         spec = self.spec
         args = []

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -168,18 +168,15 @@ class FluxCore(AutotoolsPackage):
         return args
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'cflags':
             # https://github.com/flux-framework/flux-core/issues/3482
             if self.spec.satisfies('%gcc@10:') and \
                self.spec.satisfies('@0.23.0:0.23.99'):
-                if flags is None:
-                    flags = []
-                flags.append('-Wno-error=stringop-truncation')
+                iflags.append('-Wno-error=stringop-truncation')
 
             if self.spec.satisfies('%gcc@8:') and \
                self.spec.satisfies('@0.23.0'):
-                if flags is None:
-                    flags = []
-                flags.append('-Wno-error=maybe-uninitialized')
+                iflags.append('-Wno-error=maybe-uninitialized')
 
-        return (flags, None, None)
+        return (iflags, None, flags)

--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -32,14 +32,15 @@ class Gmp(AutotoolsPackage, GNUMirrorPackage):
     force_autoreconf = True
 
     def flag_handler(self, name, flags):
+        iflags = []
         # Work around macOS Catalina / Xcode 11 code generation bug
         # (test failure t-toom53, due to wrong code in mpn/toom53_mul.o)
         if self.spec.satisfies('os=catalina') and name == 'cflags':
-            flags.append('-fno-stack-check')
+            iflags.append('-fno-stack-check')
         # This flag is necessary for the Intel build to pass `make check`
         elif self.spec.satisfies('%intel') and name == 'cxxflags':
-            flags.append('-no-ftz')
-        return (flags, None, None)
+            iflags.append('-no-ftz')
+        return (iflags, None, flags)
 
     def configure_args(self):
         return ['--enable-cxx']

--- a/var/spack/repos/builtin/packages/harfbuzz/package.py
+++ b/var/spack/repos/builtin/packages/harfbuzz/package.py
@@ -42,13 +42,13 @@ class Harfbuzz(AutotoolsPackage):
 
     # Function borrowed from superlu
     def flag_handler(self, name, flags):
-        flags = list(flags)
+        iflags = []
         if name == 'cxxflags':
-            flags.append(self.compiler.cxx11_flag)
+            iflags.append(self.compiler.cxx11_flag)
         if name == 'cflags':
             if '%pgi' not in self.spec and self.spec.satisfies('%gcc@:5.1'):
-                flags.append('-std=gnu99')
-        return (None, None, flags)
+                iflags.append('-std=gnu99')
+        return (iflags, None, flags)
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -114,13 +114,14 @@ class Hdf(AutotoolsPackage):
         return libs
 
     def flag_handler(self, name, flags):
+        iflags = []
         if '+pic' in self.spec:
             if name == 'cflags':
-                flags.append(self.compiler.cc_pic_flag)
+                iflags.append(self.compiler.cc_pic_flag)
             elif name == 'fflags':
-                flags.append(self.compiler.f77_pic_flag)
+                iflags.append(self.compiler.f77_pic_flag)
 
-        return flags, None, None
+        return (iflags, None, flags)
 
     def configure_args(self):
         config_args = ['--enable-production',

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -175,20 +175,21 @@ class Hdf5(AutotoolsPackage):
         return url.format(version.up_to(2), version)
 
     def flag_handler(self, name, flags):
+        iflags = []
         if '+pic' in self.spec:
             if name == "cflags":
-                flags.append(self.compiler.cc_pic_flag)
+                iflags.append(self.compiler.cc_pic_flag)
             elif name == "cxxflags":
-                flags.append(self.compiler.cxx_pic_flag)
+                iflags.append(self.compiler.cxx_pic_flag)
             elif name == "fflags":
-                flags.append(self.compiler.fc_pic_flag)
+                iflags.append(self.compiler.fc_pic_flag)
 
         # Quiet warnings/errors about implicit declaration of functions in C99
         if name == "cflags":
             if "clang" in self.compiler.cc or "gcc" in self.compiler.cc:
-                flags.append("-Wno-implicit-function-declaration")
+                iflags.append("-Wno-implicit-function-declaration")
 
-        return (None, None, flags)
+        return (iflags, None, flags)
 
     @when('@develop')
     def autoreconf(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/herwig3/package.py
+++ b/var/spack/repos/builtin/packages/herwig3/package.py
@@ -68,13 +68,11 @@ class Herwig3(AutotoolsPackage):
         return args
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'fcflags':
-            flags.append('-std=legacy')
-            return (None, flags, None)
-        elif name in ['cflags', 'cxxflags', 'cppflags']:
-            return (None, flags, None)
+            iflags.append('-std=legacy')
 
-        return (flags, None, None)
+        return (iflags, None, flags)
 
     def setup_build_environment(self, env):
         thepeg_home = self.spec['thepeg'].prefix

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -127,8 +127,6 @@ class Hpctoolkit(AutotoolsPackage):
           sha256='fd0fd7419f66a1feba8046cff9df7f27abce8629ee2708b8a9daa12c1b51243c',
           when='@2019.08.01:2021.03.99 %gcc@11.0:')
 
-    flag_handler = AutotoolsPackage.build_system_flags
-
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -49,13 +49,14 @@ class Icu4c(AutotoolsPackage):
         return url.format(version.dashed, version.underscored)
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'cxxflags':
             # Control of the C++ Standard is via adding the required "-std"
             # flag to CXXFLAGS in env
-            flags.append(getattr(self.compiler,
-                         'cxx{0}_flag'.format(
-                             self.spec.variants['cxxstd'].value)))
-        return (None, flags, None)
+            iflags.append(getattr(self.compiler,
+                          'cxx{0}_flag'.format(
+                              self.spec.variants['cxxstd'].value)))
+        return (iflags, None, flags)
 
     # Need to make sure that locale is UTF-8 in order to process source
     # files in UTF-8.

--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -45,7 +45,6 @@ class Ipopt(AutotoolsPackage):
 
     patch('ipopt_ppc_build.patch', when='arch=ppc64le')
 
-    flag_handler = build_system_flags
     build_directory = 'spack-build'
 
     # IPOPT does not build correctly in parallel on OS X

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -52,10 +52,11 @@ class LibflameBase(AutotoolsPackage):
     patch('Makefile_5.2.0_darwin.patch', when='@5.2.0')
 
     def flag_handler(self, name, flags):
+        iflags = []
         # -std=gnu99 at least required, old versions of GCC default to -std=c90
         if self.spec.satisfies('%gcc@:5.1') and name == 'cflags':
-            flags.append('-std=gnu99')
-        return (flags, None, None)
+            iflags.append('-std=gnu99')
+        return (iflags, None, flags)
 
     def enable_or_disable_threads(self):
         opt_val = self.spec.variants['threads'].value

--- a/var/spack/repos/builtin/packages/libiberty/package.py
+++ b/var/spack/repos/builtin/packages/libiberty/package.py
@@ -35,22 +35,11 @@ class Libiberty(AutotoolsPackage, GNUMirrorPackage):
     # Set default cflags (-g -O2), add -fPIC if requested, and move to
     # the configure line.
     def flag_handler(self, name, flags):
-        if name != 'cflags':
-            return (flags, None, None)
-
-        if '-g' not in flags:
-            flags.append('-g')
-
-        for flag in flags:
-            if flag.startswith('-O'):
-                break
-        else:
-            flags.append('-O2')
-
+        iflags = []
         if '+pic' in self.spec:
-            flags.append(self.compiler.cc_pic_flag)
+            iflags.append(self.compiler.cc_pic_flag)
 
-        return (None, None, flags)
+        return (iflags, None, flags)
 
     def configure_args(self):
         args = ['--enable-install-libiberty']

--- a/var/spack/repos/builtin/packages/libmonitor/package.py
+++ b/var/spack/repos/builtin/packages/libmonitor/package.py
@@ -41,21 +41,6 @@ class Libmonitor(AutotoolsPackage):
 
     signals = 'SIGBUS, SIGSEGV, SIGPROF, 36, 37, 38'
 
-    # Set default cflags (-g -O2) and move to the configure line.
-    def flag_handler(self, name, flags):
-        if name != 'cflags':
-            return (flags, None, None)
-
-        if '-g' not in flags:
-            flags.append('-g')
-        for flag in flags:
-            if flag.startswith('-O'):
-                break
-        else:
-            flags.append('-O2')
-
-        return (None, None, flags)
-
     def configure_args(self):
         args = []
 

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -53,11 +53,12 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
               when='@' + ver, sha256=checksum)
 
     def flag_handler(self, name, flags):
+        iflags = []
         # Work around macOS Catalina / Xcode 11 code generation bug
         # (test failure t-toom53, due to wrong code in mpn/toom53_mul.o)
         if self.spec.satisfies('os=catalina') and name == 'cflags':
-            flags.append('-fno-stack-check')
-        return (flags, None, None)
+            iflags.append('-fno-stack-check')
+        return (iflags, None, flags)
 
     def configure_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -316,14 +316,13 @@ class Mvapich2(AutotoolsPackage):
         return opts
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'fflags':
             # https://bugzilla.redhat.com/show_bug.cgi?id=1795817
             if self.spec.satisfies('%gcc@10:'):
-                if flags is None:
-                    flags = []
-                flags.append('-fallow-argument-mismatch')
+                iflags.append('-fallow-argument-mismatch')
 
-        return (flags, None, None)
+        return (iflags, None, flags)
 
     def setup_build_environment(self, env):
         # mvapich2 configure fails when F90 and F90FLAGS are set

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -85,12 +85,13 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         env.unset('TERMINFO')
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'cflags':
-            flags.append(self.compiler.cc_pic_flag)
+            iflags.append(self.compiler.cc_pic_flag)
         elif name == 'cxxflags':
-            flags.append(self.compiler.cxx_pic_flag)
+            iflags.append(self.compiler.cxx_pic_flag)
 
-        return (flags, None, None)
+        return (iflags, None, flags)
 
     def configure(self, spec, prefix):
         opts = [

--- a/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-cxx4/package.py
@@ -39,12 +39,13 @@ class NetcdfCxx4(AutotoolsPackage):
     force_autoreconf = True
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'cflags' and '+pic' in self.spec:
-            flags.append(self.compiler.cc_pic_flag)
+            iflags.append(self.compiler.cc_pic_flag)
         elif name == 'cppflags':
-            flags.append('-I' + self.spec['netcdf-c'].prefix.include)
+            iflags.append('-I' + self.spec['netcdf-c'].prefix.include)
 
-        return (None, None, flags)
+        return (iflags, None, flags)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -61,17 +61,17 @@ class NetcdfFortran(AutotoolsPackage):
     patch('no_parallel_build.patch', when='@4.5.2')
 
     def flag_handler(self, name, flags):
-        config_flags = None
+        iflags = []
 
         if name == 'cflags':
             if '+pic' in self.spec:
-                flags.append(self.compiler.cc_pic_flag)
+                iflags.append(self.compiler.cc_pic_flag)
         elif name == 'fflags':
             if '+pic' in self.spec:
-                flags.append(self.compiler.f77_pic_flag)
+                iflags.append(self.compiler.f77_pic_flag)
             if self.spec.satisfies('%gcc@10:'):
                 # https://github.com/Unidata/netcdf-fortran/issues/212
-                flags.append('-fallow-argument-mismatch')
+                iflags.append('-fallow-argument-mismatch')
             elif self.compiler.name == 'cce':
                 # Cray compiler generates module files with uppercase names by
                 # default, which is not handled by the makefiles of
@@ -79,16 +79,16 @@ class NetcdfFortran(AutotoolsPackage):
                 # https://github.com/Unidata/netcdf-fortran/pull/221.
                 # The following flag forces the compiler to produce module
                 # files with lowercase names.
-                flags.append('-ef')
+                iflags.append('-ef')
         elif name == 'ldflags':
             # We need to specify LDFLAGS to get correct dependency_libs
             # in libnetcdff.la, so packages that use libtool for linking
             # could correctly link to all the dependencies even when the
             # building takes place outside of Spack environment, i.e.
             # without Spack's compiler wrappers.
-            config_flags = [self.spec['netcdf-c'].libs.search_flags]
+            flags.append(self.spec['netcdf-c'].libs.search_flags)
 
-        return flags, None, config_flags
+        return (iflags, None, flags)
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/ngspice/package.py
+++ b/var/spack/repos/builtin/packages/ngspice/package.py
@@ -124,9 +124,10 @@ class Ngspice(AutotoolsPackage):
         return args
 
     def flag_handler(self, name, flags):
+        iflags = []
         if self.spec.satisfies('%nvhpc') and name == 'cflags':
-            flags.append('-Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes')
-            flags.append('-Wnested-externs -Wredundant-decls')
+            iflags.append('-Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes')
+            iflags.append('-Wnested-externs -Wredundant-decls')
             if 'debug=yes' in self.spec:
-                flags.append('-g')
-        return (None, None, flags)
+                iflags.append('-g')
+        return (iflags, None, flags)

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -43,13 +43,14 @@ OpenCL ICD loaders."""
     provides('opencl@:2.0', when='@2.2.3:2.2.7+headers')
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'cflags' and self.spec.satisfies('@:2.2.12'):
             # https://github.com/OCL-dev/ocl-icd/issues/8
             # this is fixed in version grater than 2.2.12
-            flags.append('-O2')
+            iflags.append('-O2')
             # gcc-10 change the default from -fcommon to fno-common
             # This is fixed in versions greater than 2.2.12:
             # https://github.com/OCL-dev/ocl-icd/commit/4667bddd365bcc1dc66c483835971f0083b44b1d
             if self.spec.satisfies('%gcc@10:'):
-                flags.append('-fcommon')
-        return (flags, None, None)
+                iflags.append('-fcommon')
+        return (iflags, None, flags)

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -372,13 +372,14 @@ class Python(AutotoolsPackage):
         env.unset('PYTHONHOME')
 
     def flag_handler(self, name, flags):
+        iflags = []
         # python 3.8 requires -fwrapv when compiled with intel
         if self.spec.satisfies('@3.8: %intel'):
             if name == 'cflags':
-                flags.append('-fwrapv')
+                iflags.append('-fwrapv')
 
         # allow flags to be passed through compiler wrapper
-        return (flags, None, None)
+        return (iflags, None, flags)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/regcm/package.py
+++ b/var/spack/repos/builtin/packages/regcm/package.py
@@ -61,11 +61,12 @@ class Regcm(AutotoolsPackage):
     parallel = False
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'fflags' and self.compiler.fc.endswith('gfortran'):
-            flags.extend(['-Wall', '-Wextra', '-Warray-temporaries',
-                          '-Wconversion', '-fimplicit-none', '-fbacktrace',
-                          '-ffree-line-length-0', '-finit-real=nan',
-                          '-ffpe-trap=zero,overflow,underflow', '-fcheck=all'])
+            iflags.extend(['-Wall', '-Wextra', '-Warray-temporaries',
+                           '-Wconversion', '-fimplicit-none', '-fbacktrace',
+                           '-ffree-line-length-0', '-finit-real=nan',
+                           '-ffpe-trap=zero,overflow,underflow', '-fcheck=all'])
 
         elif name == 'ldlibs':
             flags.extend(['-lnetcdff', '-lnetcdf'])
@@ -74,7 +75,7 @@ class Regcm(AutotoolsPackage):
             else:
                 flags.extend(['-lhdf5_hl', '-lhdf5', '-lz'])
 
-        return (None, None, flags)
+        return (iflags, None, flags)
 
     def configure_args(self):
         args = ['--enable-shared']

--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -156,10 +156,10 @@ class Rivet(AutotoolsPackage):
         env.prepend_path('LD_LIBRARY_PATH', fjcontrib_home.lib)
 
     def flag_handler(self, name, flags):
+        iflags = []
         if self.spec.satisfies('@3.1.2:') and name == 'cxxflags':
-            flags.append('-faligned-new')
-            return (None, None, flags)
-        return (flags, None, None)
+            iflags.append('-faligned-new')
+        return (iflags, None, flags)
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -50,21 +50,22 @@ class Silo(AutotoolsPackage):
     patch('H5FD_class_t-terminate.patch', when='^hdf5@1.10.0:')
 
     def flag_handler(self, name, flags):
+        iflags = []
         spec = self.spec
         if name == 'ldflags':
             if '+hdf5' in spec:
                 if spec['hdf5'].satisfies('~shared'):
-                    flags.append('-ldl')
-            flags.append(spec['readline'].libs.search_flags)
+                    iflags.append('-ldl')
+            iflags.append(spec['readline'].libs.search_flags)
 
         if '+pic' in spec:
             if name == 'cflags':
-                flags.append(self.compiler.cc_pic_flag)
+                iflags.append(self.compiler.cc_pic_flag)
             elif name == 'cxxflags':
-                flags.append(self.compiler.cxx_pic_flag)
+                iflags.append(self.compiler.cxx_pic_flag)
             elif name == 'fcflags':
-                flags.append(self.compiler.fc_pic_flag)
-        return (flags, None, None)
+                iflags.append(self.compiler.fc_pic_flag)
+        return (iflags, None, flags)
 
     @when('%clang@9:')
     def patch(self):

--- a/var/spack/repos/builtin/packages/squashfuse/package.py
+++ b/var/spack/repos/builtin/packages/squashfuse/package.py
@@ -55,9 +55,8 @@ class Squashfuse(AutotoolsPackage):
         if name == 'cflags' and '+min_size' in self.spec:
             if '-Os' in self.compiler.opt_flags:
                 flags.append('-Os')
-                return (None, None, flags)
 
-        return (flags, None, None)
+        return (None, None, flags)
 
     def configure_args(self):
         args = ['--disable-demo']

--- a/var/spack/repos/builtin/packages/xerces-c/package.py
+++ b/var/spack/repos/builtin/packages/xerces-c/package.py
@@ -62,18 +62,19 @@ class XercesC(AutotoolsPackage):
     # the xerces default will override the spack wrapper.
     def flag_handler(self, name, flags):
         spec = self.spec
+        iflags = []
 
         # Need to pass -std flag explicitly
         if name == 'cxxflags' and spec.variants['cxxstd'].value != 'default':
-            flags.append(getattr(self.compiler,
-                         'cxx{0}_flag'.format(
-                             spec.variants['cxxstd'].value)))
+            iflags.append(getattr(self.compiler,
+                          'cxx{0}_flag'.format(
+                              spec.variants['cxxstd'].value)))
 
         # There is no --with-pkg for gnuiconv.
         if name == 'ldflags' and 'transcoder=gnuiconv' in spec:
-            flags.append(spec['iconv'].libs.ld_flags)
+            iflags.append(spec['iconv'].libs.ld_flags)
 
-        return (None, None, flags)
+        return (iflags, None, flags)
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/xfd/package.py
+++ b/var/spack/repos/builtin/packages/xfd/package.py
@@ -31,10 +31,11 @@ class Xfd(AutotoolsPackage, XorgPackage):
     # Xfd requires libintl (gettext), but does not test for it
     # correctly, so add it here.
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'ldlibs':
-            flags.append('-lintl')
+            iflags.append('-lintl')
 
-        return (flags, None, None)
+        return (iflags, None, flags)
 
     def configure_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -36,9 +36,10 @@ class Xz(AutotoolsPackage, SourceforgePackage):
         return self.enable_or_disable('libs')
 
     def flag_handler(self, name, flags):
+        iflags = []
         if name == 'cflags' and '+pic' in self.spec:
-            flags.append(self.compiler.cc_pic_flag)
-        return (flags, None, None)
+            iflags.append(self.compiler.cc_pic_flag)
+        return (iflags, None, flags)
 
     @property
     def libs(self):


### PR DESCRIPTION
Currently, autotools packages use the inject flag handler, essentially ignoring the provided flags most of the time. For example, `spack install coreutils cflags=-Os cxxflags=-Os` simply builds `coreutils` with the default flags of `-O2 -g`.

Moreover, packages providing their own `flag_handler` often provide build system flags, overriding the defaults. For instance, `xerces-c` sets std flags, disabling any optimizations.

This PR uses a hybrid approach by using the build system flag handler by default and, in case packages provide their own `flag_handler`, pass workaround flags via the injection mechanism and passing explicit flags via the build system flags.

I haven't tested all modified packages yet but the ones that I tested seemed to build fine.