### PR TITLE
Fix git_version on macOS

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -780,8 +780,9 @@ class GitFetchStrategy(VCSFetchStrategy):
 
     @property
     def git_version(self):
-        vstring = self.git('--version', output=str).lstrip('git version ')
-        return Version(vstring)
+        output = self.git('--version', output=str, error=str)
+        match = re.search(r'git version (\S+)', output)
+        return Version(match.group(1)) if match else None
 
     @property
     def git(self):


### PR DESCRIPTION
On macOS, the system git returns:
```console
$ git --version
git version 2.24.3 (Apple Git-128)
```
Because of this, builds that fetch from git can fail with:
```console
$ spack --debug install libtool@develop
...
Traceback (most recent call last):
  File "/Users/Adam/spack/lib/spack/spack/build_environment.py", line 921, in _setup_pkg_and_run
    return_value = function(pkg, kwargs)
  File "/Users/Adam/spack/lib/spack/spack/installer.py", line 1691, in build_process
    pkg.do_patch()
  File "/Users/Adam/spack/lib/spack/spack/package.py", line 1408, in do_patch
    self.do_stage()
  File "/Users/Adam/spack/lib/spack/spack/package.py", line 1393, in do_stage
    self.do_fetch(mirror_only)
  File "/Users/Adam/spack/lib/spack/spack/package.py", line 1372, in do_fetch
    self.stage.fetch(mirror_only, err_msg=err_msg)
  File "/Users/Adam/spack/lib/spack/spack/util/pattern.py", line 23, in __call__
    return [getattr(item, self.name)(*args, **kwargs)
  File "/Users/Adam/spack/lib/spack/spack/util/pattern.py", line 23, in <listcomp>
    return [getattr(item, self.name)(*args, **kwargs)
  File "/Users/Adam/spack/lib/spack/spack/stage.py", line 490, in fetch
    self.fetcher.fetch()
  File "/Users/Adam/spack/lib/spack/spack/fetch_strategy.py", line 73, in wrapper
    return fun(self, *args, **kwargs)
  File "/Users/Adam/spack/lib/spack/spack/fetch_strategy.py", line 838, in fetch
    git = self.git
  File "/Users/Adam/spack/lib/spack/spack/fetch_strategy.py", line 793, in git
    if self.git_version >= Version('1.7.2'):
  File "/Users/Adam/spack/lib/spack/spack/fetch_strategy.py", line 784, in git_version
    return Version(vstring)
  File "/Users/Adam/spack/lib/spack/spack/version.py", line 165, in __init__
    raise ValueError("Bad characters in version string: %s" % string)
ValueError: Bad characters in version string: 2.24.3 (Apple Git-128)
```
This PR uses the same regex we use in our `git` package for external package detection. I don't think there's an easy way to use the `determine_version` function directly and avoid circular imports, but I haven't tried.