### PR TITLE
py-radiant-mlhub: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-radiant-mlhub/package.py
+++ b/var/spack/repos/builtin/packages/py-radiant-mlhub/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyRadiantMlhub(PythonPackage):
+    """A Python client for Radiant MLHub."""
+
+    homepage = "https://github.com/radiantearth/radiant-mlhub"
+    pypi     = "radiant-mlhub/radiant_mlhub-0.2.1.tar.gz"
+
+    maintainers = ['adamjstewart']
+
+    version('0.2.1', sha256='75a2f096b09a87191238fe557dc64dda8c44156351b4026c784c848c7d84b6fb')
+
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-requests@2.25.1:2.25.999', type=('build', 'run'))
+    depends_on('py-pystac@0.5.4', type=('build', 'run'))
+    depends_on('py-click@7.1.2:7.1.999', type=('build', 'run'))
+    depends_on('py-tqdm@4.56.0:4.56.999', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs and passes all import tests on macOS 10.15.7 with Python 3.8.10 and Apple Clang 12.0.0.

Depends on #24165 and #24166

@calebrob6