### PR TITLE
pkgconf: disable check due to missing dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/pkgconf/package.py
+++ b/var/spack/repos/builtin/packages/pkgconf/package.py
@@ -58,6 +58,12 @@ class Pkgconf(AutotoolsPackage):
         """Adds the ACLOCAL path for autotools."""
         env.append_path('ACLOCAL_PATH', self.prefix.share.aclocal)
 
+    def check(self):
+        # TODO: running the checks needs kyua (a package not yet in spack)
+        # see TODO above
+        # thus disable the tests to be able to run --test=all for other specs
+        pass
+
     @run_after('install')
     def link_pkg_config(self):
         symlink('pkgconf', '{0}/pkg-config'.format(self.prefix.bin))


### PR DESCRIPTION
I had a quick look at adding kyua and lutok, but that'll take more time, meanwhile it'll be good to have this to run --test=all on specs that depend on pkgconf