### PR TITLE
[cmd.spec] add tests command line  argument similar to `spack install`

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -50,7 +50,7 @@ for further documentation regarding the spec syntax, see:
         '--test', default=None,
         choices=['all', 'root'],
         help=""" If 'all' is chosen, concretize with test dependencies for all packages.
-                 If 'root' is chosen, concretiz with test dependencies only for the root
+                 If 'root' is chosen, concretize with test dependencies only for the root
                  spec(s). If nothing is chosen, don't add test dependencies for any packages."""
     )
     subparser.add_argument(

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -51,7 +51,8 @@ for further documentation regarding the spec syntax, see:
         choices=['all', 'root'],
         help=""" If 'all' is chosen, concretize with test dependencies for all packages.
                  If 'root' is chosen, concretiz with test dependencies only for the root
-                 spec(s). If nothing is chosen, don't add test dependencies for any packages."""
+                 spec(s). If nothing is chosen, don't add test dependencies
+                 for any packages."""
     )
     subparser.add_argument(
         '-t', '--types', action='store_true', default=False,
@@ -117,8 +118,8 @@ def spec(parser, args):
             if not args.test:
                 add_test_deps = False
             elif args.test == 'all':
-              add_test_deps = True
+                add_test_deps = True
             elif args.test == 'root':
-              add_test_deps = spec.name
+                add_test_deps = spec.name
             spec.concretize(tests=add_test_deps)
             print(spec.tree(**kwargs))

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -47,6 +47,13 @@ for further documentation regarding the spec syntax, see:
         choices=['build_hash', 'full_hash', 'dag_hash'],
         help='generate spec with a particular hash type.')
     subparser.add_argument(
+        '--test', default=None,
+        choices=['all', 'root'],
+        help=""" If 'all' is chosen, concretize with test dependencies for all packages.
+                 If 'root' is chosen, concretiz with test dependencies only for the root
+                 spec(s). If nothing is chosen, don't add test dependencies for any packages."""
+    )
+    subparser.add_argument(
         '-t', '--types', action='store_true', default=False,
         help='show dependency types')
     arguments.add_common_arguments(subparser, ['specs'])
@@ -106,5 +113,12 @@ def spec(parser, args):
             kwargs['hashes'] = args.long or args.very_long
             print("Concretized")
             print("--------------------------------")
-            spec.concretize()
+            # setup add_test_deps from arguments
+            if not args.test:
+                add_test_deps = False
+            elif args.test == 'all':
+              add_test_deps = True
+            elif args.test == 'root':
+              add_test_deps = spec.name
+            spec.concretize(tests=add_test_deps)
             print(spec.tree(**kwargs))


### PR DESCRIPTION
This allows to 'preview' what test dependencies would  be installed by `spack install --test=all`.

example:

```
~/r/spack/lib/spack/spack (spec-I-test *)$ spack spec -t --test=root  -I flann
Input spec
--------------------------------
 -   [    ]  flann

Concretized
--------------------------------
flann
 -   [    ]  flann@1.9.1%gcc@9.3.0+c~cuda~doc~examples+hdf5~ipo~matlab+mpi+openmp~python build_type=RelWithDebInfo patches=c50dedac4a9223c7353eb0b773da39b5b631ce7d3fd9e1f6e5f87eda6faf3fdb arch=linux-ubuntu20.04-skylake
 -   [bl  ]      ^boost@1.63.0%gcc@9.3.0+atomic+chrono+date_time~debug+filesystem~graph~icu+iostreams+locale+log+math+mpi+multithreaded+program_options+python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer+wave arch=linux-ubuntu20.04-skylake
[+]  [b   ]      ^cmake@3.12%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [   t]      ^googletest@1.10.0%gcc@9.3.0~gmock~ipo+pthreads+shared build_type=RelWithDebInfo arch=linux-ubuntu20.04-skylake
 -   [bl t]      ^hdf5@2.3%gcc@9.3.0+mpi arch=linux-ubuntu20.04-skylake
 -   [bl  ]          ^openmpi@4.0.5%gcc@9.3.0~atomics~cuda~cxx~cxx_exceptions+gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none patches=60ce20bc14d98c572ef7883b9fcd254c3f232c2f3a13377480f96466169ac4c8 schedulers=none arch=linux-ubuntu20.04-skylake
 -   [bl  ]              ^hwloc@2.4.1%gcc@9.3.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^libpciaccess@0.16%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b   ]                      ^libtool@2.4.6%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b r ]                          ^m4@1.4.18%gcc@9.3.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu20.04-skylake
 -   [bl  ]                              ^libsigsegv@2.13%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
[+]  [b   ]                      ^pkgconf@1.7.4%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b   ]                      ^util-macros@1.19.1%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^libxml2@2.9.10%gcc@9.3.0~python arch=linux-ubuntu20.04-skylake
 -   [bl  ]                      ^libiconv@1.16%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [bl  ]                      ^xz@5.2.5%gcc@9.3.0~pic libs=shared,static arch=linux-ubuntu20.04-skylake
[+]  [bl  ]                      ^zlib@1.2.11%gcc@9.3.0+optimize+pic+shared arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^ncurses@6.2%gcc@9.3.0~symlinks+termlib abi=none arch=linux-ubuntu20.04-skylake
 -   [bl  ]              ^libevent@2.1.12%gcc@9.3.0+openssl arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^openssl@1.1.1f%gcc@9.3.0~docs+systemcerts arch=linux-ubuntu20.04-skylake
 -   [bl  ]              ^numactl@2.0.14%gcc@9.3.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006 arch=linux-ubuntu20.04-skylake
 -   [b   ]                  ^autoconf@2.69%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b r ]                      ^perl@5.30.0%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b   ]                  ^automake@1.16.3%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [  r ]              ^openssh@8.5p1%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^libedit@3.1-20210216%gcc@9.3.0 arch=linux-ubuntu20.04-skylake

```

the googletest dependency is not present without `--test`
```
~/r/spack/lib/spack/spack (spec-I-test)$ spack spec -t   -I flann
Input spec
--------------------------------
 -   [    ]  flann

Concretized
--------------------------------
 -   [    ]  flann@1.9.1%gcc@9.3.0+c~cuda~doc~examples+hdf5~ipo~matlab+mpi+openmp~python build_type=RelWithDebInfo patches=c50dedac4a9223c7353eb0b773da39b5b631ce7d3fd9e1f6e5f87eda6faf3fdb arch=linux-ubuntu20.04-skylake
 -   [bl  ]      ^boost@1.63.0%gcc@9.3.0+atomic+chrono+date_time~debug+filesystem~graph~icu+iostreams+locale+log+math+mpi+multithreaded+program_options+python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer+wave arch=linux-ubuntu20.04-skylake
[+]  [b   ]      ^cmake@3.12%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [bl t]      ^hdf5@2.3%gcc@9.3.0+mpi arch=linux-ubuntu20.04-skylake
 -   [bl  ]          ^openmpi@4.0.5%gcc@9.3.0~atomics~cuda~cxx~cxx_exceptions+gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none patches=60ce20bc14d98c572ef7883b9fcd254c3f232c2f3a13377480f96466169ac4c8 schedulers=none arch=linux-ubuntu20.04-skylake
 -   [bl  ]              ^hwloc@2.4.1%gcc@9.3.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^libpciaccess@0.16%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b   ]                      ^libtool@2.4.6%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b r ]                          ^m4@1.4.18%gcc@9.3.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu20.04-skylake
 -   [bl  ]                              ^libsigsegv@2.13%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
[+]  [b   ]                      ^pkgconf@1.7.4%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b   ]                      ^util-macros@1.19.1%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^libxml2@2.9.10%gcc@9.3.0~python arch=linux-ubuntu20.04-skylake
 -   [bl  ]                      ^libiconv@1.16%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [bl  ]                      ^xz@5.2.5%gcc@9.3.0~pic libs=shared,static arch=linux-ubuntu20.04-skylake
[+]  [bl  ]                      ^zlib@1.2.11%gcc@9.3.0+optimize+pic+shared arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^ncurses@6.2%gcc@9.3.0~symlinks+termlib abi=none arch=linux-ubuntu20.04-skylake
 -   [bl  ]              ^libevent@2.1.12%gcc@9.3.0+openssl arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^openssl@1.1.1f%gcc@9.3.0~docs+systemcerts arch=linux-ubuntu20.04-skylake
 -   [bl  ]              ^numactl@2.0.14%gcc@9.3.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006 arch=linux-ubuntu20.04-skylake
 -   [b   ]                  ^autoconf@2.69%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b r ]                      ^perl@5.30.0%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [b   ]                  ^automake@1.16.3%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [  r ]              ^openssh@8.5p1%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
 -   [bl  ]                  ^libedit@3.1-20210216%gcc@9.3.0 arch=linux-ubuntu20.04-skylake
```