### PR TITLE
Revert "Bootstrap with -O3 in cmake"

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -230,8 +230,6 @@ class Cmake(Package):
     def bootstrap_args(self):
         spec = self.spec
         args = [
-            'CFLAGS=-O3',
-            'CXXFLAGS=-O3',
             '--prefix={0}'.format(self.prefix),
             '--parallel={0}'.format(make_jobs)
         ]


### PR DESCRIPTION
Reverts spack/spack#23147

Closes #24159

Reading https://github.com/spack/spack/issues/24159#issuecomment-855407439 it seems hard to believe that adding these -O3 flags to the cmake bootstrap phase could really make a difference. After checking out the system I ran the benchmarks on I realized it had https://xalt.readthedocs.io/en/latest/ enabled by default, which slows down compilation tremendously. When I disable xalt, the bootstrap phase is much faster and adding -O3 flags does not make a significant change, so I'm happy to revert this.