### PR TITLE
axl: Don't deprecate v0.3.0 as it's still actively required by veloc

### DIFF
--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -27,7 +27,7 @@ class Axl(CMakePackage):
 
     version('master', branch='master')
     version('0.4.0', sha256='0530142629d77406a00643be32492760c2cf12d1b56c6b6416791c8ff5298db2')
-    version('0.3.0', sha256='737d616b669109805f7aed1858baac36c97bf0016e1115b5c56ded05d792613e', deprecated=True)
+    version('0.3.0', sha256='737d616b669109805f7aed1858baac36c97bf0016e1115b5c56ded05d792613e')
     version('0.2.0', sha256='d04a445f102b438fe96a1ff3429790b0c035f0d23c2797bb5601a00b582a71fc', deprecated=True)
     version('0.1.1', sha256='36edac007938fe47d979679414c5c27938944d32536e2e149f642916c5c08eaa', deprecated=True)
 


### PR DESCRIPTION
This is a follow up to #24157