### PR TITLE
Feature: Loop over known AWS credentials for S3

### DIFF
--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -46,6 +46,14 @@ def create_s3_session(url):
 
         s3_client_args["config"] = Config(signature_version=UNSIGNED)
 
-    client = session.client('s3', **s3_client_args)
+    for auth_name in session.available_profiles:
+        try:
+            client = Session(profile_name=auth_name).client('s3', **s3_client_args)
+            client.list_buckets()
+            break
+        except ClientError:
+            continue
+    else:
+        client = Session().client('s3', **s3_client_args)
     client.ClientError = ClientError
     return client


### PR DESCRIPTION
When connecting to an S3 mirror, loop over the connection profiles
found on the system to determine which can be used to connect.