### PR TITLE
Pipelines: Fix default generated rebuild job script

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -746,8 +746,7 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
                     job_script.insert(0, 'cd {0}'.format(concrete_env_dir))
 
                 job_script.extend([
-                    'spack ci rebuild --prepare',
-                    './install.sh'
+                    'spack ci rebuild'
                 ])
 
                 if 'script' in runner_attribs:


### PR DESCRIPTION
Fix the default generated job script so it doesn't pass the invalid `--prepare` option to `spack ci rebuild`.  Also remove the `install.sh` invocation, as that is invoked internally within `spack ci rebuild`.