### PR TITLE
Fix brittle unit-test on providers

### DIFF
--- a/lib/spack/spack/test/cmd/providers.py
+++ b/lib/spack/spack/test/cmd/providers.py
@@ -25,8 +25,6 @@ def test_it_just_runs(pkg):
     (('mpi',), ['intel-mpi',
                 'intel-parallel-studio',
                 'mpich',
-                'mpich@1:',
-                'mpich@3:',
                 'mpilander',
                 'mvapich2',
                 'openmpi',


### PR DESCRIPTION
These tests were broken by #24176 (the PR adjusted `mpich` provides directives, the unit test asserts presence of wrong output).