### PR TITLE
gatk: make r a variant

### DIFF
--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -89,9 +89,20 @@ class Gatk(Package):
         url="https://storage.googleapis.com/gatk-software/package-archive/gatk/GenomeAnalysisTK-3.8-0-ge9d806836.tar.bz2"
     )
 
+    # Make r a variant. According to the gatk docs it is not essential and not
+    # tested.
+    # https://github.com/broadinstitute/gatk#R
+    # Using R to generate plots
+    # Certain GATK tools may optionally generate plots using the R installation
+    # provided within the conda environment. If you are uninterested in plotting,
+    # R is still required by several of the unit tests. Plotting is currently
+    # untested and should be viewed as a convenience rather than a primary
+    # output.
+    variant('r', default=False, description='Use R for plotting')
+
     depends_on("java@8", type="run")
     depends_on("python@2.6:2.8,3.6:", type="run", when="@4.0:")
-    depends_on("r@3.2:", type="run", when="@4.0:")
+    depends_on("r@3.2:", type="run", when="@4.0: +r")
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
According to the docs, r is needed for plotting, but plotting is
untested. In addition, the specific version requirement of java for gatk
could lead to multiple installations of r being triggered in an
environment. That might cause people to have to be deliberate about
java in a deployment. All in all, it seems that r is better as a
variant for gatk.