### PR TITLE
macOS: Add monterey as macOS version 12.

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -55,7 +55,8 @@ class MacOs(OperatingSystem):
             '10.14': 'mojave',
             '10.15': 'catalina',
             '10.16': 'bigsur',
-            '11':  'bigsur',
+            '11': 'bigsur',
+            '12': 'monterey',
         }
 
         # Big Sur versions go 11.0, 11.0.1, 11.1 (vs. prior versions that


### PR DESCRIPTION
Monterey was just announced today and will be released in the fall.  It will be macOS version 12.  Adding support for it in `mac_os.py`.