### PR TITLE
genesis: Update stand-alone tests to use test stage work directory

### DIFF
--- a/var/spack/repos/builtin/packages/genesis/package.py
+++ b/var/spack/repos/builtin/packages/genesis/package.py
@@ -92,21 +92,37 @@ class Genesis(AutotoolsPackage, CudaPackage):
         make("install")
         install_tree("doc", prefix.share.doc)
 
+    @property
+    def cached_tests_work_dir(self):
+        """The working directory for cached test sources."""
+        return join_path(self.test_suite.current_test_cache_dir,
+                         "tests")
+
     @run_after("install")
     def cache_test_sources(self):
+        """Copy test files after the package is installed for test()."""
         if self.spec.satisfies("@master"):
             self.cache_extra_test_sources(["tests"])
 
     def test(self):
-        if self.spec.satisfies("@master"):
-            exe_name = self.spec["python"].command.path
-            test_name = join_path(
-                self.install_test_root, "tests", "regression_test", "test.py"
-            )
-            bin_name = join_path(self.prefix.bin, "spdyn")
-            opts = [
-                test_name,
-                self.spec["mpi"].prefix.bin.mpirun + " -np 8 " + bin_name,
-            ]
-            env["OMP_NUM_THREADS"] = "1"
-            self.run_test(exe_name, options=opts, expected="Passed  53 / 53")
+        """Perform stand-alone/smoke tests using installed package."""
+        if not self.spec.satisfies("@master"):
+            print('Skipping: Tests are only available for the master branch')
+            return
+
+        test_name = join_path(
+            self.cached_tests_work_dir, "regression_test", "test.py"
+        )
+        bin_name = join_path(self.prefix.bin, "spdyn")
+        opts = [
+            test_name,
+            self.spec["mpi"].prefix.bin.mpirun + " -np 8 " + bin_name,
+        ]
+        env["OMP_NUM_THREADS"] = "1"
+        self.run_test(
+            self.spec["python"].command.path,
+            options=opts,
+            expected="Passed  53 / 53",
+            purpose="test: running regression test",
+            work_dir=self.cached_tests_work_dir
+        )


### PR DESCRIPTION
Change the stand-alone/smoke tests to use the (new) test stage work directory automatically created for cached test sources versus building them under the package's install prefix.

This PR also prints a message when the tests are being skipped (i.e., if not running against `master` branch).

@takanori-ihara 