### PR TITLE
[Umpire] Fix compilation with gcc@11 and clang@12

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/missing_header_for_numeric_limits.patch
+++ b/var/spack/repos/builtin/packages/umpire/missing_header_for_numeric_limits.patch
@@ -1,0 +1,12 @@
+diff --git a/src/umpire/util/allocation_statistics.cpp b/src/umpire/util/allocation_statistics.cpp
+index 597ae61f..0c3f7865 100644
+--- a/src/umpire/util/allocation_statistics.cpp
++++ b/src/umpire/util/allocation_statistics.cpp
+@@ -8,6 +8,7 @@
+ #include "umpire/util/allocation_statistics.hpp"
+ 
+ #include <algorithm>
++#include <limits>
+ 
+ namespace umpire {
+ namespace util {

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -48,6 +48,7 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
 
     patch('camp_target_umpire_3.0.0.patch', when='@3.0.0')
     patch('cmake_version_check.patch', when='@4.1')
+    patch('missing_header_for_numeric_limits.patch', when='@4.1:5.0.1')
 
     variant('fortran', default=False, description='Build C/Fortran API')
     variant('c', default=True, description='Build C API')


### PR DESCRIPTION
Patches missing includes.

The develop branch seems to have them, so the patch should not be needed for future versions.