### PR TITLE
ASP-based solver: permit to use virtual specs in environments

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -116,9 +116,7 @@ def solve(parser, args):
 
     # dump the solutions as concretized specs
     if 'solutions' in dump:
-        best = min(result.answers)
-
-        opt, _, answer = best
+        opt, _, _ = min(result.answers)
         if ("opt" in dump) and (not args.format):
             tty.msg("Best of %d considered solutions." % result.nmodels)
             tty.msg("Optimization Criteria:")
@@ -132,16 +130,7 @@ def solve(parser, args):
                 color.cprint(fmt % (i + 1, name, val))
             print()
 
-        # iterate over roots from command line
-        for input_spec in specs:
-            key = input_spec.name
-            if input_spec.virtual:
-                providers = [spec.name for spec in answer.values()
-                             if spec.package.provides(key)]
-                key = providers[0]
-
-            spec = answer[key]
-
+        for spec in result.specs:
             # With -y, just print YAML to output.
             if args.format == 'yaml':
                 # use write because to_yaml already has a newline.

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -737,7 +737,7 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
         result.print_cores()
         tty.die("Unsatisfiable spec.")
 
-    return result.specs
+    return [s.copy() for s in result.specs]
 
 
 def _concretize_specs_together_original(*abstract_specs, **kwargs):

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -737,8 +737,7 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
         result.print_cores()
         tty.die("Unsatisfiable spec.")
 
-    opt, i, answer = min(result.answers)
-    return [answer[s.name].copy() for s in abstract_specs]
+    return result.specs
 
 
 def _concretize_specs_together_original(*abstract_specs, **kwargs):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2561,3 +2561,15 @@ spack:
 
     assert view_prefix not in full_contents
     assert spec.prefix in full_contents
+
+
+@pytest.mark.regression('24148')
+def test_virtual_spec_concretize_together(tmpdir):
+    # An environment should permit to concretize "mpi"
+    e = ev.create('virtual_spec')
+    e.concretization = 'together'
+
+    e.add('mpi')
+    e.concretize()
+
+    assert any(s.package.provides('mpi') for _, s in e.concretized_specs())


### PR DESCRIPTION
fixes #24148

Extracting specs for the result of a solve has been factored as a method into the `asp.Result` class. The method accounts for virtual specs being passed as initial requests.