### PR TITLE
Expand compiler paths: allow $variable substitutions in compiler path config

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -27,6 +27,7 @@ import spack.architecture
 
 from spack.util.environment import get_path
 from spack.util.naming import mod_to_class
+from spack.util.path import substitute_path_variables
 
 _path_instance_vars = ['cc', 'cxx', 'f77', 'fc']
 _flags_instance_vars = ['cflags', 'cppflags', 'cxxflags', 'fflags']
@@ -342,8 +343,8 @@ def compiler_from_dict(items):
     compiler_paths = []
     for c in _path_instance_vars:
         compiler_path = items['paths'][c]
-        if compiler_path != 'None':
-            compiler_paths.append(compiler_path)
+        if compiler_path is not None and compiler_path != 'None':
+            compiler_paths.append(substitute_path_variables(compiler_path))
         else:
             compiler_paths.append(None)
 


### PR DESCRIPTION
This makes it easier to bootstrap compilers by specifying paths relative to the spack install or environment view. This way we can commit a portable bootstrapped compiler config.  (We've tried used `install_missing_compilers` but couldn't get it to work very well. The goal is to be able to clone our custom spack repo and build everything without additional configuration changes.)