### PR TITLE
texlive: update live version to 2021

### DIFF
--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -29,8 +29,8 @@ class Texlive(AutotoolsPackage):
     # connection at install time and the package versions could change over
     # time. It is better to use a version built from tarballs, as defined with
     # the "releases" below.
-    version('live', sha256='7c90a50e55533d57170cbc7c0370a010019946eb18570282948e1af6f809382d',
-            url='ftp://tug.org/historic/systems/texlive/2020/install-tl-unx.tar.gz')
+    version('live', sha256='74eac0855e1e40c8db4f28b24ef354bd7263c1f76031bdc02b52156b572b7a1d',
+            url='ftp://tug.org/historic/systems/texlive/2021/install-tl-unx.tar.gz')
 
     # Add information for new versions below.
     releases = [


### PR DESCRIPTION
The 'live' version of texlive is currently using the 2020 installer, but tries to install from the 2021 repos, which fails.

This PR updates the installer for the 'live' version to the 2021 installer.