### PR TITLE
uchardet: new release + lib image was not found on Mac OSX

### DIFF
--- a/var/spack/repos/builtin/packages/uchardet/package.py
+++ b/var/spack/repos/builtin/packages/uchardet/package.py
@@ -14,7 +14,10 @@ class Uchardet(CMakePackage):
 
     homepage = "https://www.freedesktop.org/wiki/Software/uchardet/"
     url      = "https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.6.tar.xz"
+    git      = "https://gitlab.freedesktop.org/uchardet/uchardet.git"
 
+    version('master', branch='master')
+    version('0.0.7', sha256='8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61')
     version('0.0.6', sha256='8351328cdfbcb2432e63938721dd781eb8c11ebc56e3a89d0f84576b96002c61')
     version('0.0.5', sha256='7c5569c8ee1a129959347f5340655897e6a8f81ec3344de0012a243f868eabd1')
     version('0.0.4', sha256='9dbe41fc73ba6a70676c04b1f0dd812914c0bbb65940283f2d54c5a2338a2acd')
@@ -27,3 +30,12 @@ class Uchardet(CMakePackage):
         else:
             url = "https://github.com/BYVoid/uchardet/archive/v0.0.5.tar.gz"
         return url
+
+    @when('platform=darwin')
+    def cmake_args(self):
+        args = []
+        # From https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/uchardet.rb
+        args.append('-DCMAKE_INSTALL_NAME_DIR={0}'.format(self.prefix.lib))
+        # From https://github.com/mutationpp/Mutationpp/issues/26
+        args.append('-DCMAKE_MACOSX_RPATH=ON')
+        return args

--- a/var/spack/repos/builtin/packages/uchardet/package.py
+++ b/var/spack/repos/builtin/packages/uchardet/package.py
@@ -31,11 +31,13 @@ class Uchardet(CMakePackage):
             url = "https://github.com/BYVoid/uchardet/archive/v0.0.5.tar.gz"
         return url
 
-    @when('platform=darwin')
     def cmake_args(self):
         args = []
-        # From https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/uchardet.rb
-        args.append('-DCMAKE_INSTALL_NAME_DIR={0}'.format(self.prefix.lib))
-        # From https://github.com/mutationpp/Mutationpp/issues/26
-        args.append('-DCMAKE_MACOSX_RPATH=ON')
+        if self.spec.satisfies('platform=darwin'):
+            args += [
+                # From https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/uchardet.rb
+                self.define('CMAKE_INSTALL_NAME_DIR', self.prefix.lib),
+                # From https://github.com/mutationpp/Mutationpp/issues/26
+                self.define('CMAKE_MACOSX_RPATH', 'ON')
+            ]
         return args


### PR DESCRIPTION
On Mac OS BigSur, cmake complained about CMAKE_MACOSX_RPATH not being set and when linking with uchardet lib from another package it was not found (there will be a PR #24213 for groff new release 1.22.4 where this was problematic).
Added new release 0.0.7 and git location.