### PR TITLE
Add special case to allow lmod to generate hierarchy with %intel 

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -190,6 +190,11 @@ class LmodConfiguration(BaseConfiguration):
             provides['compiler'] = spack.spec.CompilerSpec(str(self.spec))
             provides['compiler'].name = 'clang'
 
+        # Special case for OneAPI to allow a hierarchy with %intel
+        if self.spec.name == 'intel-oneapi-compilers':
+            provides['compiler'] = spack.spec.CompilerSpec(str(self.spec))
+            provides['compiler'].name = 'intel'
+
         # All the other tokens in the hierarchy must be virtual dependencies
         for x in self.hierarchy_tokens:
             if self.spec.package.provides(x):


### PR DESCRIPTION
This is a hack to allow lmod to generate a hierarchy when the compilers are provided by `intel-oneapi-compilers`

Note that it breaks things as `%oneapi` is provided by the same package.

A proper fix will involve allowing a single spec to provide multiple compilers.

As discussed with @alalazo and @becker33 