### PR TITLE
Extrae: fix import and issue with pthread

### DIFF
--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -110,9 +110,12 @@ class Extrae(AutotoolsPackage):
             make.add_default_arg("CXXFLAGS=%s" % self.compiler.cxx11_flag)
             args.append("CXXFLAGS=%s" % self.compiler.cxx11_flag)
 
-        # This was added due to configure failure
+        # This was added due to:
+        # - configure failure
         # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
-        args.append('LDFLAGS=-lintl')
+        # - linking error
+        # https://github.com/bsc-performance-tools/extrae/issues/57
+        args.append('LDFLAGS=-lintl -pthread')
 
         return(args)
 

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 from spack import *
 
 # typical working line with extrae 3.0.1


### PR DESCRIPTION
This PR fixes 
- import of os when using cupti
- linking with pthread on some configuration