### PR TITLE
[texlive]: Restrict poppler version

### DIFF
--- a/var/spack/repos/builtin/packages/texlive/package.py
+++ b/var/spack/repos/builtin/packages/texlive/package.py
@@ -113,7 +113,7 @@ class Texlive(AutotoolsPackage):
     depends_on('mpfr', when='@2019:')
     depends_on('perl', when='@2019:')
     depends_on('pixman', when='@2019:')
-    depends_on('poppler', when='@2019:')
+    depends_on('poppler@:0.84', when='@2019:')
     depends_on('teckit', when='@2019:')
     depends_on('zlib', when='@2019:')
     depends_on('zziplib', when='@2019:')


### PR DESCRIPTION
Restrict poppler version for texlive to poppler@:0.84
Should fix #19946

See also https://github.com/NixOS/nixpkgs/issues/79170
Looks like poppler@0.84 upgraded their header files to use the C++ cstdio
instead of the C stdio.h.  Since TeX is using C, not C++. this causes problems.