### PR TITLE
bowtie2: Adding in constraints for the simde dependency

### DIFF
--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -53,8 +53,8 @@ class Bowtie2(MakefilePackage):
         files = ['bowtie2-build', 'bowtie2-inspect']
         filter_file(match, substitute, *files, **kwargs)
 
-        if (self.spec.satisfies('@2.4.0: target=aarch64:') or
-            self.spec.satisfies('@2.4.0: target=ppc64le:')):
+        if (self.spec.satisfies('@2.4.0:2.4.2 target=aarch64:') or
+            self.spec.satisfies('@2.4.0:2.4.2 target=ppc64le:')):
             match = '-Ithird_party/simde'
             simdepath = spec['simde'].prefix.include
             substitute = "-I{simdepath}".format(simdepath=simdepath)

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -25,8 +25,8 @@ class Bowtie2(MakefilePackage):
     depends_on('perl', type='run')
     depends_on('python', type='run')
     depends_on('zlib', when='@2.3.1:')
-    depends_on('simde', when='target=aarch64:', type='link')
-    depends_on('simde', when='target=ppc64le:', type='link')
+    depends_on('simde', when='@2.4.0: target=aarch64:', type='link')
+    depends_on('simde', when='@2.4.0: target=ppc64le:', type='link')
 
     patch('bowtie2-2.2.5.patch', when='@2.2.5', level=0)
     patch('bowtie2-2.3.1.patch', when='@2.3.1', level=0)
@@ -53,7 +53,8 @@ class Bowtie2(MakefilePackage):
         files = ['bowtie2-build', 'bowtie2-inspect']
         filter_file(match, substitute, *files, **kwargs)
 
-        if 'aarch64' in spec.target.family or 'ppc64' in spec.target.family:
+        if (self.spec.satisfies('@2.4.0: target=aarch64:') or
+            self.spec.satisfies('@2.4.0: target=ppc64le')):
             match = '-Ithird_party/simde'
             simdepath = spec['simde'].prefix.include
             substitute = "-I{simdepath}".format(simdepath=simdepath)

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -54,7 +54,7 @@ class Bowtie2(MakefilePackage):
         filter_file(match, substitute, *files, **kwargs)
 
         if (self.spec.satisfies('@2.4.0: target=aarch64:') or
-            self.spec.satisfies('@2.4.0: target=ppc64le')):
+            self.spec.satisfies('@2.4.0: target=ppc64le:')):
             match = '-Ithird_party/simde'
             simdepath = spec['simde'].prefix.include
             substitute = "-I{simdepath}".format(simdepath=simdepath)

--- a/var/spack/repos/builtin/packages/bowtie2/package.py
+++ b/var/spack/repos/builtin/packages/bowtie2/package.py
@@ -25,7 +25,8 @@ class Bowtie2(MakefilePackage):
     depends_on('perl', type='run')
     depends_on('python', type='run')
     depends_on('zlib', when='@2.3.1:')
-    depends_on('simde', type='link')
+    depends_on('simde', when='target=aarch64:', type='link')
+    depends_on('simde', when='target=ppc64le:', type='link')
 
     patch('bowtie2-2.2.5.patch', when='@2.2.5', level=0)
     patch('bowtie2-2.3.1.patch', when='@2.3.1', level=0)
@@ -52,11 +53,12 @@ class Bowtie2(MakefilePackage):
         files = ['bowtie2-build', 'bowtie2-inspect']
         filter_file(match, substitute, *files, **kwargs)
 
-        match = '-Ithird_party/simde'
-        simdepath = spec['simde'].prefix.include
-        substitute = "-I{simdepath}".format(simdepath=simdepath)
-        files = ['Makefile']
-        filter_file(match, substitute, *files, **kwargs)
+        if 'aarch64' in spec.target.family or 'ppc64' in spec.target.family:
+            match = '-Ithird_party/simde'
+            simdepath = spec['simde'].prefix.include
+            substitute = "-I{simdepath}".format(simdepath=simdepath)
+            files = ['Makefile']
+            filter_file(match, substitute, *files, **kwargs)
 
     @property
     def build_targets(self):


### PR DESCRIPTION
Currently the bowtie2 package has the simde package listed as a dependency. However it's only used for specific architectures and only with newer versions of bowtie2. I was running into compiler errors that I didn't want to chase down for code that's not really relevant on my platform.

This PR adds version and target checks to the simde dependencies.