### PR TITLE
openssl: Architecture check modification for NVHPC on Arm

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -6,7 +6,6 @@
 import llnl.util.tty as tty
 
 from spack import *
-import spack.architecture
 
 import os
 import re

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -115,7 +115,7 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
             options.append('no-krb5')
         # clang does not support the .arch directive in assembly files.
         if ('clang' in self.compiler.cc or 'nvc' in self.compiler.cc) and \
-           'aarch64' in spack.architecture.sys_type():
+           spec.target.family == 'aarch64':
             options.append('no-asm')
 
         # The default glibc provided by CentOS 7 does not provide proper


### PR DESCRIPTION
'no-asm' option wasn't being triggered on AWS Graviton2 with NVHPC - causing a build failure.
Slight modification in how we perform the architecture check.
Please feel free to modify if there is a better way of performing the check.