### PR TITLE
Display proper message when patch checksum doesn't match

### DIFF
--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -291,7 +291,7 @@ def from_dict(dictionary):
         if not checker.check(patch.path):
             raise fs.ChecksumError(
                 "sha256 checksum failed for %s" % patch.path,
-                "Expected %s but got %s" % (sha256, checker.sum),
+                "Expected %s but got %s " % (sha256, checker.sum) + 
                 "Patch may have changed since concretization.")
         return patch
     else:

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -291,7 +291,7 @@ def from_dict(dictionary):
         if not checker.check(patch.path):
             raise fs.ChecksumError(
                 "sha256 checksum failed for %s" % patch.path,
-                "Expected %s but got %s " % (sha256, checker.sum) + 
+                "Expected %s but got %s " % (sha256, checker.sum) +
                 "Patch may have changed since concretization.")
         return patch
     else:


### PR DESCRIPTION
`fs.ChecksumError()` takes two arguments (message and longmessage), not three.