### PR TITLE
spack core: allow non UTF8 scripts

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -66,7 +66,18 @@ def filter_shebang(path):
     with open(path, 'rb') as original_file:
         original = original_file.read()
         if sys.version_info >= (2, 7):
-            original = original.decode(encoding='UTF-8')
+            try:
+                original = original.decode(encoding='UTF-8')
+            except Exception:
+                try:
+                    original = original.rstrip("\n").decode("UTF-16")
+                except Exception:
+                    tty.debug('Encoding not UTF, trying latin')
+                    try:
+                        original = original.decode(encoding='latin-1')
+                    except Exception:
+                        raise Exception("Failed to detect encoding "
+                                        "file={0}".format(path))
         else:
             original = original.decode('UTF-8')
 


### PR DESCRIPTION
Some typically European (Continental) scripts are in some variant of ISO-8859.
This lead filter_shebang to raise an error on utf-8 decoding.
Now, such files are converted to UTF-8, when posssible ;  if not, there still is an exception.
This was occuring to perl-tk (in develop) and perl-fth (on a branch).
The negative impact of this commit is to add a try/except around the decode function.

