### PR TITLE
IQ-TREE: Add version 2.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/iq-tree/package.py
+++ b/var/spack/repos/builtin/packages/iq-tree/package.py
@@ -19,7 +19,7 @@ class IqTree(CMakePackage):
 
     variant('openmp', default=True, description='Enable OpenMP support.')
     variant('mpi',    default=False, description='Enable MPI support.')
-    variant('lsd2',   default=True,  description='Axctivate Least Squares Dating.')
+    variant('lsd2',   default=True,  description='Activate Least Squares Dating.')
 
     maintainers = ['ilbiondo']
 

--- a/var/spack/repos/builtin/packages/iq-tree/package.py
+++ b/var/spack/repos/builtin/packages/iq-tree/package.py
@@ -14,6 +14,7 @@ class IqTree(CMakePackage):
     git      = "https://github.com/iqtree/iqtree2.git"
     url      = "https://github.com/Cibiv/IQ-TREE/archive/v1.6.12.tar.gz"
 
+    version('2.1.3',    tag='v2.1.3', submodules=True)
     version('2.0.6',    tag='v2.0.6', submodules=True)
     version('1.6.12',   sha256='9614092de7a157de82c9cc402b19cc8bfa0cb0ffc93b91817875c2b4bb46a284')
 

--- a/var/spack/repos/builtin/packages/iq-tree/package.py
+++ b/var/spack/repos/builtin/packages/iq-tree/package.py
@@ -11,7 +11,7 @@ class IqTree(CMakePackage):
     """IQ-TREE Efficient software for phylogenomic inference"""
 
     homepage = "http://www.iqtree.org"
-    git      = "https://github.com/Cibiv/IQ-TREE.git"
+    git      = "https://github.com/iqtree/iqtree2.git"
     url      = "https://github.com/Cibiv/IQ-TREE/archive/v1.6.12.tar.gz"
 
     version('2.0.6',    tag='v2.0.6', submodules=True)


### PR DESCRIPTION
Switch to the new git repository URL and add version 2.1.3.

Also fix a minor typo.

/CC @ilbiondo 