### PR TITLE
Add connection specification to mirror creation

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -341,7 +341,7 @@ def add_s3_connection_args(subparser, add_help):
         '--s3-access-token',
         help="Access Token to use to connect to this S3 mirror")
     subparser.add_argument(
-        '--s3-access-profile',
+        '--s3-profile',
         help="S3 profile name to use to connect to this S3 mirror",
         default=None)
     subparser.add_argument(

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -328,3 +328,22 @@ def reuse():
         '--reuse', action='store_true', default=False,
         help='reuse installed dependencies'
     )
+
+
+def add_s3_connection_args(subparser, add_help):
+    subparser.add_argument(
+        '--s3-access-key-id',
+        help="ID string to use to connect to this S3 mirror")
+    subparser.add_argument(
+        '--s3-access-key-secret',
+        help="Secret string to use to connect to this S3 mirror")
+    subparser.add_argument(
+        '--s3-access-token',
+        help="Access Token to use to connect to this S3 mirror")
+    subparser.add_argument(
+        '--s3-access-profile',
+        help="S3 profile name to use to connect to this S3 mirror",
+        default=None)
+    subparser.add_argument(
+        '--s3-endpoint-url',
+        help="Access Token to use to connect to this S3 mirror")

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -6,7 +6,6 @@
 import sys
 
 import llnl.util.tty as tty
-from llnl.util.tty.colify import colify
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
@@ -93,7 +92,18 @@ def setup_parser(subparser):
         '--scope', choices=scopes, metavar=scopes_metavar,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
-
+    add_parser.add_argument(
+        '--s3-access-key-id',
+        help="ID string to use to connect to this S3 mirror")
+    add_parser.add_argument(
+        '--s3-access-key-secret',
+        help="Secret string to use to connect to this S3 mirror")
+    add_parser.add_argument(
+        '--s3-access-token',
+        help="Access Token to use to connect to this S3 mirror")
+    add_parser.add_argument(
+        '--s3-endpoint-url',
+        help="Access Token to use to connect to this S3 mirror")
     # Remove
     remove_parser = sp.add_parser('remove', aliases=['rm'],
                                   help=mirror_remove.__doc__)
@@ -129,7 +139,7 @@ def setup_parser(subparser):
 def mirror_add(args):
     """Add a mirror to Spack."""
     url = url_util.format(args.url)
-    spack.mirror.add(args.name, url, args.scope)
+    spack.mirror.add(args.name, url, args.scope, args)
 
 
 def mirror_remove(args):
@@ -330,7 +340,7 @@ def mirror_create(args):
         "  %-4d failed to fetch." % e)
     if error:
         tty.error("Failed downloads:")
-        colify(s.cformat("{name}{@version}") for s in error)
+        tty.colify(s.cformat("{name}{@version}") for s in error)
         sys.exit(1)
 
 

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -148,14 +148,14 @@ def mirror_set_url(args):
         tty.die("No mirror found with name %s." % args.name)
 
     entry = mirrors[args.name]
-    key_values = ["s3_access_key_id", "s3_access_token", "s3_access_profile"]
+    key_values = ["s3_access_key_id", "s3_access_token", "s3_profile"]
 
     if any(value for value in key_values if value in args):
         incoming_data = {"url": url,
                          "access_pair": (args.s3_access_key_id,
                                          args.s3_access_key_secret),
                          "access_token": args.s3_access_token,
-                         "access_profile": args.s3_access_profile,
+                         "profile": args.s3_profile,
                          "endpoint_url": args.s3_endpoint_url}
     try:
         fetch_url = entry['fetch']

--- a/lib/spack/spack/cmd/mirror.py
+++ b/lib/spack/spack/cmd/mirror.py
@@ -92,18 +92,7 @@ def setup_parser(subparser):
         '--scope', choices=scopes, metavar=scopes_metavar,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
-    add_parser.add_argument(
-        '--s3-access-key-id',
-        help="ID string to use to connect to this S3 mirror")
-    add_parser.add_argument(
-        '--s3-access-key-secret',
-        help="Secret string to use to connect to this S3 mirror")
-    add_parser.add_argument(
-        '--s3-access-token',
-        help="Access Token to use to connect to this S3 mirror")
-    add_parser.add_argument(
-        '--s3-endpoint-url',
-        help="Access Token to use to connect to this S3 mirror")
+    arguments.add_s3_connection_args(add_parser, False)
     # Remove
     remove_parser = sp.add_parser('remove', aliases=['rm'],
                                   help=mirror_remove.__doc__)
@@ -127,6 +116,7 @@ def setup_parser(subparser):
         '--scope', choices=scopes, metavar=scopes_metavar,
         default=spack.config.default_modify_scope(),
         help="configuration scope to modify")
+    arguments.add_s3_connection_args(set_url_parser, False)
 
     # List
     list_parser = sp.add_parser('list', help=mirror_list.__doc__)
@@ -150,7 +140,6 @@ def mirror_remove(args):
 def mirror_set_url(args):
     """Change the URL of a mirror."""
     url = url_util.format(args.url)
-
     mirrors = spack.config.get('mirrors', scope=args.scope)
     if not mirrors:
         mirrors = syaml_dict()
@@ -159,7 +148,15 @@ def mirror_set_url(args):
         tty.die("No mirror found with name %s." % args.name)
 
     entry = mirrors[args.name]
+    key_values = ["s3_access_key_id", "s3_access_token", "s3_access_profile"]
 
+    if any(value for value in key_values if value in args):
+        incoming_data = {"url": url,
+                         "access_pair": (args.s3_access_key_id,
+                                         args.s3_access_key_secret),
+                         "access_token": args.s3_access_token,
+                         "access_profile": args.s3_access_profile,
+                         "endpoint_url": args.s3_endpoint_url}
     try:
         fetch_url = entry['fetch']
         push_url = entry['push']
@@ -169,20 +166,28 @@ def mirror_set_url(args):
     changes_made = False
 
     if args.push:
-        changes_made = changes_made or push_url != url
-        push_url = url
+        if isinstance(push_url, dict):
+            changes_made = changes_made or push_url != incoming_data
+            push_url = incoming_data
+        else:
+            changes_made = changes_made or push_url != url
+            push_url = url
     else:
-        changes_made = (
-            changes_made or fetch_url != push_url or push_url != url)
-
-        fetch_url, push_url = url, url
+        if isinstance(push_url, dict):
+            changes_made = (changes_made or push_url != incoming_data
+                            or push_url != incoming_data)
+            fetch_url, push_url = incoming_data, incoming_data
+        else:
+            changes_made = changes_made or push_url != url
+            fetch_url, push_url = url, url
 
     items = [
         (
             (n, u)
             if n != args.name else (
                 (n, {"fetch": fetch_url, "push": push_url})
-                if fetch_url != push_url else (n, fetch_url)
+                if fetch_url != push_url else (n, {"fetch": fetch_url,
+                                                   "push": fetch_url})
             )
         )
         for n, u in mirrors.items()
@@ -193,10 +198,10 @@ def mirror_set_url(args):
 
     if changes_made:
         tty.msg(
-            "Changed%s url for mirror %s." %
+            "Changed%s url or connection information for mirror %s." %
             ((" (push)" if args.push else ""), args.name))
     else:
-        tty.msg("Url already set for mirror %s." % args.name)
+        tty.msg("No changes made to mirror %s." % args.name)
 
 
 def mirror_list(args):

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1365,9 +1365,6 @@ class S3FetchStrategy(URLFetchStrategy):
     url_attr = 's3'
 
     def __init__(self, *args, **kwargs):
-        self.connection = {}
-        if "connection" in kwargs:
-            self.connection = kwargs["connection"]
         try:
             super(S3FetchStrategy, self).__init__(*args, **kwargs)
         except ValueError:
@@ -1442,10 +1439,11 @@ class GCSFetchStrategy(URLFetchStrategy):
         with working_dir(self.stage.path):
             import spack.util.s3 as s3_util
             s3 = s3_util.create_s3_session(self.url,
-                                           connection=self.connection)
+                                           connection=s3_util.get_mirror_connection(parsed_url), url_type="fetch")  # noqa: E501
+
             headers = s3.get_object(Bucket=parsed_url.netloc,
                                     Key=parsed_url.path.lstrip("/"))
-            stream = headers.StreamingBody()
+            stream = headers["Body"]
 
             with open(basename, 'wb') as f:
                 shutil.copyfileobj(stream, f)

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -145,16 +145,16 @@ class Mirror(object):
     def get_profile(self, url_type):
         if isinstance(self._fetch_url, dict):
             if url_type == "push":
-                return self._push_url['access_profile']
-            return self._fetch_url['access_profile']
+                return self._push_url['profile']
+            return self._fetch_url['profile']
         else:
             return None
 
     def set_profile(self, url_type, profile):
         if url_type == "push":
-            self._push_url["access_profile"] = profile
+            self._push_url["profile"] = profile
         else:
-            self._fetch_url["access_profile"] = profile
+            self._fetch_url["profile"] = profile
 
     def get_access_pair(self, url_type):
         if isinstance(self._fetch_url, dict):
@@ -528,13 +528,13 @@ def add(name, url, scope, args={}):
 
     items = [(n, u) for n, u in mirrors.items()]
     mirror_data = url
-    key_values = ["s3_access_key_id", "s3_access_token", "s3_access_profile"]
+    key_values = ["s3_access_key_id", "s3_access_token", "s3_profile"]
     # On creation, assume connection data is set for both
     if any(value for value in key_values if value in args):
         url_dict = {"url": url,
                     "access_pair": (args.s3_access_key_id, args.s3_access_key_secret),
                     "access_token": args.s3_access_token,
-                    "access_profile": args.s3_access_profile,
+                    "profile": args.s3_profile,
                     "endpoint_url": args.s3_endpoint_url}
         mirror_data = {"fetch": url_dict, "push": url_dict}
 

--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -41,7 +41,8 @@ class WrapStream(BufferedReader):
 
 def _s3_open(url):
     parsed = url_util.parse(url)
-    s3 = s3_util.create_s3_session(parsed)
+    s3 = s3_util.create_s3_session(parsed,
+                                   connection=s3_util.get_mirror_connection(parsed))  # noqa: E501
 
     bucket = parsed.netloc
     key = parsed.path

--- a/lib/spack/spack/schema/mirrors.py
+++ b/lib/spack/spack/schema/mirrors.py
@@ -24,8 +24,8 @@ properties = {
                         'type': 'object',
                         'required': ['fetch', 'push'],
                         'properties': {
-                            'fetch': {'type': 'string'},
-                            'push': {'type': 'string'}
+                            'fetch': {'type': ['string', 'object']},
+                            'push': {'type': ['string', 'object']}
                         }
                     }
                 ]

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -442,9 +442,15 @@ class Stage(object):
                 for rel_path in self.mirror_paths:
                     mirror_url = url_util.join(mirror.fetch_url, rel_path)
                     mirror_urls[mirror_url] = {}
-                    if mirror.access_pair or mirror.access_token:
-                        mirror_urls[mirror_url] = {"token": mirror.access_token,
-                                                   "pair": mirror.access_pair}
+                    if mirror.get_access_pair("fetch") or \
+                       mirror.get_access_token("fetch") or \
+                       mirror.get_profile("fetch"):
+                        mirror_urls[mirror_url] = {
+                            "access_token": mirror.get_access_token("fetch"),
+                            "access_pair": mirror.get_access_pair("fetch"),
+                            "access_profile": mirror.get_profile("fetch"),
+                            "endpoint_url": mirror.get_endpoint_url("fetch")
+                        }
 
             # If this archive is normally fetched from a tarball URL,
             # then use the same digest.  `spack mirror` ensures that

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -169,6 +169,31 @@ def test_mirror_crud(tmp_scope, capsys):
         output = mirror('remove', '--scope', tmp_scope, 'mirror')
         assert 'Removed mirror' in output
 
+        # Test S3 connection info token
+        mirror('add', '--scope', tmp_scope,
+               '--s3-access-token', 'aaaaaazzzzz',
+               'mirror', 's3://spack-public')
+
+        output = mirror('remove', '--scope', tmp_scope, 'mirror')
+        assert 'Removed mirror' in output
+
+        # Test S3 connection info id/key
+        mirror('add', '--scope', tmp_scope,
+               '--s3-access-key-id', 'foo', '--s3-access-key-secret', 'bar',
+               'mirror', 's3://spack-public')
+
+        output = mirror('remove', '--scope', tmp_scope, 'mirror')
+        assert 'Removed mirror' in output
+
+        # Test S3 connection info with endpoint URL
+        mirror('add', '--scope', tmp_scope,
+               '--s3-access-token', 'aaaaaazzzzz',
+               '--s3-endpoint-url', 'http://localhost/',
+               'mirror', 's3://spack-public')
+
+        output = mirror('remove', '--scope', tmp_scope, 'mirror')
+        assert 'Removed mirror' in output
+
         output = mirror('list', '--scope', tmp_scope)
         assert 'No mirrors configured' in output
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -155,7 +155,7 @@ def test_mirror_crud(tmp_scope, capsys):
         # no-op
         output = mirror('set-url', '--scope', tmp_scope,
                         'mirror', 'http://spack.io')
-        assert 'Url already set' in output
+        assert 'No changes made' in output
 
         output = mirror('set-url', '--scope', tmp_scope,
                         '--push', 'mirror', 's3://spack-public')
@@ -164,7 +164,7 @@ def test_mirror_crud(tmp_scope, capsys):
         # no-op
         output = mirror('set-url', '--scope', tmp_scope,
                         '--push', 'mirror', 's3://spack-public')
-        assert 'Url already set' in output
+        assert 'No changes made' in output
 
         output = mirror('remove', '--scope', tmp_scope, 'mirror')
         assert 'Removed mirror' in output

--- a/lib/spack/spack/test/web.py
+++ b/lib/spack/spack/test/web.py
@@ -249,7 +249,7 @@ class MockS3Client(object):
 def test_remove_s3_url(monkeypatch, capfd):
     fake_s3_url = 's3://my-bucket/subdirectory/mirror'
 
-    def mock_create_s3_session(url):
+    def mock_create_s3_session(url, connection={}):
         return MockS3Client()
 
     monkeypatch.setattr(
@@ -269,7 +269,7 @@ def test_remove_s3_url(monkeypatch, capfd):
 
 
 def test_s3_url_exists(monkeypatch, capfd):
-    def mock_create_s3_session(url):
+    def mock_create_s3_session(url, connection={}):
         return MockS3Client()
     monkeypatch.setattr(
         spack.util.s3, 'create_s3_session', mock_create_s3_session)

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -11,6 +11,15 @@ import spack
 import spack.util.url as url_util
 
 
+def get_mirror_connection(url, url_type="push"):
+    connection = {}
+    # Try to find a mirror for potential connection information
+    for mirror in spack.mirror.MirrorCollection().values():
+        if "%s://%s" % (url.scheme, url.netloc) == mirror.push_url:
+            connection = mirror.to_dict()[url_type]
+    return connection
+
+
 def _parse_s3_endpoint_url(endpoint_url):
     if not urllib_parse.urlparse(endpoint_url, scheme='').scheme:
         endpoint_url = '://'.join(('https', endpoint_url))
@@ -34,13 +43,13 @@ def create_s3_session(url, connection={}):
     s3_connection = {}
 
     if connection:
-        if connection['token']:
-            s3_connection["aws_session_token"] = connection["token"]
-        if connection["pair"][0]:
-            s3_connection["aws_access_key_id"] = connection["pair"][0]
-            s3_connection["aws_secret_access_key"] = connection["pair"][1]
-        if connection['endpoint_url']:
-            s3_connection["endpoint_url"] = connection["endpoint_url"]
+        if connection['access_token']:
+            s3_connection["aws_session_token"] = connection["access_token"]
+        if connection["access_pair"][0]:
+            s3_connection["aws_access_key_id"] = connection["access_pair"][0]
+            s3_connection["aws_secret_access_key"] = connection["access_pair"][1]
+        if connection["access_profile"]:
+            s3_connection["profile_name"] = connection["access_profile"]
 
     session = Session(**s3_connection)
     s3_client_args = {"use_ssl": spack.config.get('config:verify_ssl')}
@@ -48,7 +57,8 @@ def create_s3_session(url, connection={}):
     endpoint_url = os.environ.get('S3_ENDPOINT_URL')
     if endpoint_url:
         s3_client_args['endpoint_url'] = _parse_s3_endpoint_url(endpoint_url)
-
+    elif connection and 'endpoint_url' in connection:
+        s3_client_args["endpoint_url"] = _parse_s3_endpoint_url(connection["endpoint_url"])  # noqa: E501
     # if no access credentials provided above, then access anonymously
     if not session.get_credentials():
         from botocore import UNSIGNED

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -48,8 +48,8 @@ def create_s3_session(url, connection={}):
         if connection["access_pair"][0]:
             s3_connection["aws_access_key_id"] = connection["access_pair"][0]
             s3_connection["aws_secret_access_key"] = connection["access_pair"][1]
-        if connection["access_profile"]:
-            s3_connection["profile_name"] = connection["access_profile"]
+        if connection["profile"]:
+            s3_connection["profile_name"] = connection["profile"]
 
     session = Session(**s3_connection)
     s3_client_args = {"use_ssl": spack.config.get('config:verify_ssl')}

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -18,7 +18,7 @@ def _parse_s3_endpoint_url(endpoint_url):
     return endpoint_url
 
 
-def create_s3_session(url):
+def create_s3_session(url, connection={}):
     url = url_util.parse(url)
     if url.scheme != 's3':
         raise ValueError(
@@ -31,8 +31,18 @@ def create_s3_session(url):
     from boto3 import Session
     from botocore.exceptions import ClientError
 
-    session = Session()
+    s3_connection = {}
 
+    if connection:
+        if connection['token']:
+            s3_connection["aws_session_token"] = connection["token"]
+        if connection["pair"][0]:
+            s3_connection["aws_access_key_id"] = connection["pair"][0]
+            s3_connection["aws_secret_access_key"] = connection["pair"][1]
+        if connection['endpoint_url']:
+            s3_connection["endpoint_url"] = connection["endpoint_url"]
+
+    session = Session(**s3_connection)
     s3_client_args = {"use_ssl": spack.config.get('config:verify_ssl')}
 
     endpoint_url = os.environ.get('S3_ENDPOINT_URL')

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -193,7 +193,8 @@ def push_to_url(
         while remote_path.startswith('/'):
             remote_path = remote_path[1:]
 
-        s3 = s3_util.create_s3_session(remote_url)
+        s3 = s3_util.create_s3_session(remote_url,
+                                       connection=s3_util.get_mirror_connection(remote_url))   # noqa: E501
         s3.upload_file(local_file_path, remote_url.netloc,
                        remote_path, ExtraArgs=extra_args)
 
@@ -219,7 +220,9 @@ def url_exists(url):
         return os.path.exists(local_path)
 
     if url.scheme == 's3':
-        s3 = s3_util.create_s3_session(url)
+        # Check for URL specific connection information
+        s3 = s3_util.create_s3_session(url, connection=s3_util.get_mirror_connection(url))  # noqa: E501
+
         try:
             s3.get_object(Bucket=url.netloc, Key=url.path.lstrip('/'))
             return True
@@ -263,7 +266,8 @@ def remove_url(url, recursive=False):
         return
 
     if url.scheme == 's3':
-        s3 = s3_util.create_s3_session(url)
+        # Try to find a mirror for potential connection information
+        s3 = s3_util.create_s3_session(url, connection=s3_util.get_mirror_connection(url))  # noqa: E501
         bucket = url.netloc
         if recursive:
             # Because list_objects_v2 can only return up to 1000 items

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1277,7 +1277,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-endpoint-url"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1277,7 +1277,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-endpoint-url"
+        SPACK_COMPREPLY="-h --help --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-access-profile --s3-endpoint-url"
     else
         _mirrors
     fi
@@ -1304,7 +1304,7 @@ _spack_mirror_rm() {
 _spack_mirror_set_url() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --push --scope"
+        SPACK_COMPREPLY="-h --help --push --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-access-profile --s3-endpoint-url"
     else
         _mirrors
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1277,7 +1277,7 @@ _spack_mirror_destroy() {
 _spack_mirror_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-access-profile --s3-endpoint-url"
+        SPACK_COMPREPLY="-h --help --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-profile --s3-endpoint-url"
     else
         _mirrors
     fi
@@ -1304,7 +1304,7 @@ _spack_mirror_rm() {
 _spack_mirror_set_url() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --push --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-access-profile --s3-endpoint-url"
+        SPACK_COMPREPLY="-h --help --push --scope --s3-access-key-id --s3-access-key-secret --s3-access-token --s3-profile --s3-endpoint-url"
     else
         _mirrors
     fi


### PR DESCRIPTION
This allows each mirror to contain information about the credentials
used to access it.