### PR TITLE
Use threading.TIMEOUT_MAX when available

### DIFF
--- a/lib/spack/external/ctest_log_parser.py
+++ b/lib/spack/external/ctest_log_parser.py
@@ -71,6 +71,8 @@ from __future__ import division
 import re
 import math
 import multiprocessing
+import sys
+import threading
 import time
 from contextlib import contextmanager
 
@@ -448,7 +450,12 @@ class CTestLogParser(object):
             pool = multiprocessing.Pool(jobs)
             try:
                 # this is a workaround for a Python bug in Pool with ctrl-C
-                results = pool.map_async(_parse_unpack, args, 1).get(9999999)
+                if sys.version_info >= (3, 2):
+                    max_timeout = threading.TIMEOUT_MAX
+                else:
+                    max_timeout = 9999999
+                results = pool.map_async(_parse_unpack, args, 1).get(max_timeout)
+
                 errors, warnings, timings = zip(*results)
             finally:
                 pool.terminate()


### PR DESCRIPTION
This value was introduced in Python 3.2. Specifying a timeout greater than
this value will raise an OverflowError.