### PR TITLE
perl-tk: new release + ptked converted to UTF-8

### DIFF
--- a/var/spack/repos/builtin/packages/perl-tk/package.py
+++ b/var/spack/repos/builtin/packages/perl-tk/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+
 import llnl.util.tty as tty
 
 from spack import *

--- a/var/spack/repos/builtin/packages/perl-tk/package.py
+++ b/var/spack/repos/builtin/packages/perl-tk/package.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import sys
 import llnl.util.tty as tty
+
+from spack import *
 
 
 class PerlTk(PerlPackage):

--- a/var/spack/repos/builtin/packages/perl-tk/package.py
+++ b/var/spack/repos/builtin/packages/perl-tk/package.py
@@ -15,6 +15,8 @@ class PerlTk(PerlPackage):
     url      = "https://cpan.metacpan.org/authors/id/S/SR/SREZIC/Tk-804.035.tar.gz"
     git      = "https://github.com/eserte/perl-tk.git"
 
+    maintainers = ['cessenat']
+
     version('master', branch='master')
     version('804.036', sha256='32aa7271a6bdfedc3330119b3825daddd0aa4b5c936f84ad74eabb932a200a5e')
     version('804.035', sha256='4d2b80291ba6de34d8ec886a085a6dbd2b790b926035a087e99025614c5ffdd4')

--- a/var/spack/repos/builtin/packages/perl-tk/package.py
+++ b/var/spack/repos/builtin/packages/perl-tk/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import sys
+import llnl.util.tty as tty
 
 
 class PerlTk(PerlPackage):
@@ -11,8 +13,27 @@ class PerlTk(PerlPackage):
 
     homepage = "https://metacpan.org/pod/distribution/Tk/Tk.pod"
     url      = "https://cpan.metacpan.org/authors/id/S/SR/SREZIC/Tk-804.035.tar.gz"
+    git      = "https://github.com/eserte/perl-tk.git"
 
+    version('master', branch='master')
+    version('804.036', sha256='32aa7271a6bdfedc3330119b3825daddd0aa4b5c936f84ad74eabb932a200a5e')
     version('804.035', sha256='4d2b80291ba6de34d8ec886a085a6dbd2b790b926035a087e99025614c5ffdd4')
     version('804.033', sha256='84756e9b07a2555c8eecf88e63d5cbbba9b1aa97b1e71a3d4aa524a7995a88ad')
 
     depends_on('perl-extutils-makemaker', type='build')
+
+    @run_before('install')
+    def filter_nonutf8(self):
+        path = 'ptked'
+        with open(path, 'rb') as original_file:
+            original = original_file.read()
+            if sys.version_info >= (2, 7):
+                try:
+                    original = original.decode(encoding='UTF-8')
+                except Exception:
+                    try:
+                        original = original.decode(encoding='latin-1')
+                        with open(path, 'wb') as new_file:
+                            new_file.write(original.encode(encoding='UTF-8'))
+                    except Exception:
+                        tty.warn('Encoding not detected file={0}'.format(path))


### PR DESCRIPTION
In perl-tk, file ptked uses a copyright symbol (&copy;) that is not UTF-8, leading the post-install hook in spack/lib/spack/spack/test/sbang.py to fail.
One could modify the spack core file sbang.py (PR #24231) or modify the ptked file in package perl-tk.
One can also do both, in case other packages were concerned.
At least for perl-tk, this current PR solves the problem.
Also added git repo https://github.com/eserte/perl-tk.git and a new version 804.036.
I will add myself as maintainer following recommandations from @tldahlgren in 
https://www.youtube.com/watch?v=RlczUgwFCJg&t=21125s
If I may, I think @alalazo is used to deal with the UTF-8 aspect so I would be happy to be reviewed by him.