### PR TITLE
py-pyprecice: Fix checksum of 2.2.0.1 and 2.2.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -19,7 +19,7 @@ class PyPyprecice(PythonPackage):
 
     # Always prefer final version of release candidate
     version("develop", branch="develop")
-    version('2.2.1.1', sha256='481715c9e90660d3d97e63ee590a3b74a17564cd5cac3bfceceb59788fd11b14')
+    version('2.2.1.1', sha256='d96674f1ff91761c29efce34f8e09e2ec29a4862227b7204439e865dbe755a86')
     version('2.2.0.2', sha256='2287185f9ad7500dced53459543d27bb66bd2438c2e4bf81ee3317e6a00513d5')
     version('2.2.0.1', sha256='032fa58193cfa69e3be37557977056e8f507d89b40c490a351d17271269b25ad')
     version('2.1.1.2', sha256='363eb3eeccf964fd5ee87012c1032353dd1518662868f2b51f04a6d8a7154045')

--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -21,7 +21,7 @@ class PyPyprecice(PythonPackage):
     version("develop", branch="develop")
     version('2.2.1.1', sha256='d96674f1ff91761c29efce34f8e09e2ec29a4862227b7204439e865dbe755a86')
     version('2.2.0.2', sha256='2287185f9ad7500dced53459543d27bb66bd2438c2e4bf81ee3317e6a00513d5')
-    version('2.2.0.1', sha256='032fa58193cfa69e3be37557977056e8f507d89b40c490a351d17271269b25ad')
+    version('2.2.0.1', sha256='229625e2e6df03987ababce5abe2021b0974cbe5a588b936a9cba653f4908d4b')
     version('2.1.1.2', sha256='363eb3eeccf964fd5ee87012c1032353dd1518662868f2b51f04a6d8a7154045')
     version("2.1.1.1", sha256="972f574549344b6155a8dd415b6d82512e00fa154ca25ae7e36b68d4d2ed2cf4")
     version("2.1.0.1", sha256="ac5cb7412c6b96b08a04fa86ea38e52d91ea739a3bd1c209baa93a8275e4e01a")


### PR DESCRIPTION
This PR fixes the sha256 checksums of `pyprecice` 2.2.0.1 and 2.2.1.1.

Adding @BenjaminRodenberg and @IshaanDesai for reference.