### PR TITLE
perl-cgi: new version 4.53

### DIFF
--- a/var/spack/repos/builtin/packages/perl-cgi/package.py
+++ b/var/spack/repos/builtin/packages/perl-cgi/package.py
@@ -15,6 +15,7 @@ class PerlCgi(PerlPackage):
     homepage = "https://metacpan.org/pod/CGI"
     url      = "https://cpan.metacpan.org/authors/id/L/LE/LEEJO/CGI-4.40.tar.gz"
 
+    version('4.53', sha256='c67e732f3c96bcb505405fd944f131fe5c57b46e5d02885c00714c452bf14e60')
     version('4.40', sha256='10efff3061b3c31a33b3cc59f955aef9c88d57d12dbac46389758cef92f24f56')
     version('4.39', sha256='7e73417072445f24e03d63802ed3a9e368c9b103ddc96e2a9bcb6a251215fb76')
     version('4.38', sha256='8c58f4a529bb92a914b22b7e64c5e31185c9854a4070a6dfad44fe5cc248e7d4')


### PR DESCRIPTION
Just update that mainly corrrects bugs, see
https://metacpan.org/dist/CGI/changes