### PR TITLE
[paraview]: Replace FT_CALLBACK_DEF in vtk shipped with paraview

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -158,6 +158,12 @@ class Paraview(CMakePackage, CudaPackage):
     # Broken downstream FindMPI
     patch('vtkm-findmpi-downstream.patch', when='@5.9.0')
 
+    # Freetype@2.10.3 no longer exports FT_CALLBACK_DEF, this
+    # patch replaces FT_CALLBACK_DEF with simple extern "C"
+    # See https://gitlab.kitware.com/vtk/vtk/-/issues/18033
+    patch('pv-vtk-freetype-2.10.3-replace-FT_CALLBACK_DEF.patch',
+          when='^freetype@2.10.3:')
+
     def url_for_version(self, version):
         _urlfmt  = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.{3}'
         """Handle ParaView version-based custom URLs."""

--- a/var/spack/repos/builtin/packages/paraview/pv-vtk-freetype-2.10.3-replace-FT_CALLBACK_DEF.patch
+++ b/var/spack/repos/builtin/packages/paraview/pv-vtk-freetype-2.10.3-replace-FT_CALLBACK_DEF.patch
@@ -1,0 +1,35 @@
+diff -Naur --exclude .git spack-src/VTK/Rendering/FreeType/vtkFreeTypeTools.cxx spack-src.patched/VTK/Rendering/FreeType/vtkFreeTypeTools.cxx
+--- spack-src/VTK/Rendering/FreeType/vtkFreeTypeTools.cxx	2021-06-10 11:42:57.000000000 -0400
++++ spack-src.patched/VTK/Rendering/FreeType/vtkFreeTypeTools.cxx	2021-06-10 13:27:56.000000000 -0400
+@@ -378,7 +378,7 @@
+ }
+ 
+ //----------------------------------------------------------------------------
+-FT_CALLBACK_DEF(FT_Error)
++extern "C" FT_Error
+ vtkFreeTypeToolsFaceRequester(
+   FTC_FaceID face_id, FT_Library lib, FT_Pointer request_data, FT_Face* face)
+ {
+diff -Naur --exclude .git spack-src/VTK/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx spack-src.patched/VTK/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx
+--- spack-src/VTK/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx	2020-02-17 22:44:50.000000000 -0500
++++ spack-src.patched/VTK/Rendering/FreeTypeFontConfig/vtkFontConfigFreeTypeTools.cxx	2021-06-10 13:29:11.000000000 -0400
+@@ -26,10 +26,8 @@
+ 
+ vtkStandardNewMacro(vtkFontConfigFreeTypeTools);
+ 
+-namespace
+-{
+ // The FreeType face requester callback:
+-FT_CALLBACK_DEF(FT_Error)
++extern "C" FT_Error
+ vtkFontConfigFreeTypeToolsFaceRequester(
+   FTC_FaceID face_id, FT_Library lib, FT_Pointer request_data, FT_Face* face)
+ {
+@@ -71,7 +69,6 @@
+ 
+   return static_cast<FT_Error>(0);
+ }
+-} // end anon namespace
+ 
+ void vtkFontConfigFreeTypeTools::PrintSelf(ostream& os, vtkIndent indent)
+ {


### PR DESCRIPTION
Should fix issue #24255
freetype@2.10.3 stopped exporting FT_CALLBACK_DEF, which causes problems in vtk.
See #24238 which patches vtk to remove references to FT_CALLBACK_DEF

Paraview ships its own version of vtk which also needs to be patched.
(Slight differences in at least on file to be patched so cannot directly
grab patch from remote in this case).