### PR TITLE
[dd4hep] Add new version and patch for cmake problems

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/cmake_language.patch
+++ b/var/spack/repos/builtin/packages/dd4hep/cmake_language.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d800190..121fa7fe 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,6 +46,7 @@ ENDIF()
+ #############################################################
+ 
+ ENABLE_LANGUAGE(CXX)
++ENABLE_LANGUAGE(C)
+ 
+ # Set C++ standard
+ set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard used for compiling")

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -24,6 +24,7 @@ class Dd4hep(CMakePackage):
     tags = ['hep']
 
     version('master', branch='master')
+    version('01-17-00', sha256='e56071ce5497517fe56af813828b1a5fab90f0b602b86961a277ca22be215232')
     version('1.16.1', sha256='c8b1312aa88283986f89cc008d317b3476027fd146fdb586f9f1fbbb47763f1a')
     version('1.16', sha256='ea9755cd255cf1b058e0e3cd743101ca9ca5ff79f4c60be89f9ba72b1ae5ec69')
     version('1.15', sha256='992a24bd4b3dfaffecec9d1c09e8cde2c7f89d38756879a47b23208242f4e352')
@@ -44,6 +45,7 @@ class Dd4hep(CMakePackage):
     # See https://github.com/AIDASoft/DD4hep/pull/613 .
     patch('tbb-workarounds.patch', when='@1.11')
     patch('tbb2.patch', when='@1.12.1')
+    patch('cmake_language.patch', when='@:1.17')
 
     variant('xercesc', default=False, description="Enable 'Detector Builders' based on XercesC")
     variant('geant4', default=False, description="Enable the simulation part based on Geant4")
@@ -67,6 +69,10 @@ class Dd4hep(CMakePackage):
     depends_on('hepmc3', when="+hepmc3")
     depends_on('lcio', when="+lcio")
     depends_on('edm4hep', when="+edm4hep")
+
+    # See https://github.com/AIDASoft/DD4hep/pull/771
+    conflicts('^cmake@3.16:3.17.2', when='@1.15:1.16.1',
+              msg='cmake version with buggy FindPython breaks dd4hep cmake config')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -71,7 +71,7 @@ class Dd4hep(CMakePackage):
     depends_on('edm4hep', when="+edm4hep")
 
     # See https://github.com/AIDASoft/DD4hep/pull/771
-    conflicts('^cmake@3.16:3.17.2', when='@1.15:1.16.1',
+    conflicts('^cmake@3.16:3.17.0', when='@1.15:1.16.1',
               msg='cmake version with buggy FindPython breaks dd4hep cmake config')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -24,7 +24,7 @@ class Dd4hep(CMakePackage):
     tags = ['hep']
 
     version('master', branch='master')
-    version('01-17-00', sha256='e56071ce5497517fe56af813828b1a5fab90f0b602b86961a277ca22be215232')
+    version('1.17', sha256='e56071ce5497517fe56af813828b1a5fab90f0b602b86961a277ca22be215232')
     version('1.16.1', sha256='c8b1312aa88283986f89cc008d317b3476027fd146fdb586f9f1fbbb47763f1a')
     version('1.16', sha256='ea9755cd255cf1b058e0e3cd743101ca9ca5ff79f4c60be89f9ba72b1ae5ec69')
     version('1.15', sha256='992a24bd4b3dfaffecec9d1c09e8cde2c7f89d38756879a47b23208242f4e352')
@@ -45,6 +45,8 @@ class Dd4hep(CMakePackage):
     # See https://github.com/AIDASoft/DD4hep/pull/613 .
     patch('tbb-workarounds.patch', when='@1.11')
     patch('tbb2.patch', when='@1.12.1')
+    # Workaround for failing build file generation in some cases
+    # See https://github.com/spack/spack/issues/24232
     patch('cmake_language.patch', when='@:1.17')
 
     variant('xercesc', default=False, description="Enable 'Detector Builders' based on XercesC")
@@ -71,7 +73,7 @@ class Dd4hep(CMakePackage):
     depends_on('edm4hep', when="+edm4hep")
 
     # See https://github.com/AIDASoft/DD4hep/pull/771
-    conflicts('^cmake@3.16:3.17.0', when='@1.15:1.16.1',
+    conflicts('^cmake@3.16:3.17.0', when='@1.15',
               msg='cmake version with buggy FindPython breaks dd4hep cmake config')
 
     def cmake_args(self):


### PR DESCRIPTION
- Add newest dd4hep version.
- Add patch for adding `C` to cmake languages to work around problem in certain environments (See #24232). The patch is also submitted upstream to dd4hep, so that it should become available with the next release.
- Also adding a conflict for certain cmake and dd4hep versions, because for some time the matching of python versions to root was broken, and fixing this would require a few different patches to be applied depending on the dd4hep version.

Fixes #24232 

@vvolkl @andresailer does this look reasonable to you?