### PR TITLE
Add support to fetch from specfiles

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -934,7 +934,7 @@ _spack_external_list() {
 _spack_fetch() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -n --no-checksum --deprecated -m --missing -D --dependencies"
+        SPACK_COMPREPLY="-h --help -n --no-checksum --deprecated -m --missing -D --dependencies -f --file"
     else
         _all_packages
     fi


### PR DESCRIPTION
This change mirrors the `install` command's ability to take spec-input
via specfiles.

Same as for `install` they can be supplied via `--file`.