### PR TITLE
[py-ippython]: Start py-backcall dependency to start at py-ipython@7.…

### DIFF
--- a/var/spack/repos/builtin/packages/py-ipython/package.py
+++ b/var/spack/repos/builtin/packages/py-ipython/package.py
@@ -48,7 +48,7 @@ class PyIpython(PythonPackage):
     depends_on('py-prompt-toolkit@2.0.0:2.0.999', when='@7.5.0', type=('build', 'run'))
     depends_on('py-prompt-toolkit@3.0.2:3.0.999', when='@7.18:', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))
-    depends_on('py-backcall', type=('build', 'run'), when='@7.5.0:')
+    depends_on('py-backcall', type=('build', 'run'), when='@7.3.0:')
     depends_on('py-pexpect', type=('build', 'run'))
     depends_on('py-pexpect@4.3:', type=('build', 'run'), when='@7.18:')
     depends_on('py-appnope', type=('build', 'run'), when='platform=darwin')


### PR DESCRIPTION
…3.0:

This should fix #24278
$INSTALLDIR/lib/python3.7/site-packages/IPython/core/events.py contains an
import from backcall even in @7.3.0, so dependency on py-backcall needs
to start earlier.