### PR TITLE
Features/windows support failing tests

### DIFF
--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -47,24 +47,20 @@ def test_which_relative_path_with_slash(tmpdir, working_env):
     tmpdir.ensure("exe")
     path = str(tmpdir.join("exe"))
 
-    
     os.environ['PATH'] = ''
 
     with tmpdir.as_cwd():
         no_exe = ex.which('.{0}exe'.format(os.path.sep))
         assert no_exe is None
-
-
-        with tmpdir.as_cwd():
-            fs.touch("exe.exe")
-
         if sys.platform == "win32":
-            exe = ex.which('.{0}exe'.format(os.path.sep))
-            assert exe.path == path + ".exe"
+            # For Windows, need to create files with .exe after any assert is none tests
+            tmpdir.ensure("exe.exe")
+            path += ".exe"
         else:
             fs.set_executable(path)
-            exe = ex.which('.{0}exe'.format(os.path.sep))
-            assert exe.path == path
+
+        exe = ex.which('.{0}exe'.format(os.path.sep))
+        assert exe.path == path
 
 
 def test_which_with_slash_ignores_path(tmpdir, working_env):
@@ -75,22 +71,19 @@ def test_which_with_slash_ignores_path(tmpdir, working_env):
     wrong_path = str(tmpdir.join('bin', 'exe'))
     os.environ['PATH'] = os.path.dirname(wrong_path)
 
-    if sys.platform == "win32":
-        with tmpdir.as_cwd():
-            fs.touch("exe.exe")
-            fs.touch('bin{0}exe'.format(os.path.sep))
+    with tmpdir.as_cwd():
+        if sys.platform == "win32":
+            # For Windows, need to create files with .exe after any assert is none tests
+            tmpdir.ensure('exe.exe')
+            tmpdir.ensure('bin{0}exe.exe'.format(os.path.sep))
             path = path + ".exe"
             wrong_path = wrong_path + ".exe"
-            exe = ex.which('.{0}exe'.format(os.path.sep))
-            assert exe.path == path
+        else:
+            fs.set_executable(path)
+            fs.set_executable(wrong_path)
 
-    else:
-        fs.set_executable(path)
-        fs.set_executable(wrong_path)
-
-        with tmpdir.as_cwd():
-            exe = ex.which('.{0}exe'.format(os.path.sep))
-            assert exe.path == path
+        exe = ex.which('.{0}exe'.format(os.path.sep))
+        assert exe.path == path
 
 
 def test_which(tmpdir):
@@ -100,24 +93,17 @@ def test_which(tmpdir):
     with pytest.raises(ex.CommandNotFoundError):
         ex.which("spack-test-exe", required=True)
 
-    
+    path = str(tmpdir.join("spack-test-exe"))
 
-    if sys.platform == "win32":
-        with tmpdir.as_cwd():
-            fs.touch("spack-test-exe.exe")
-
-        exe = ex.which("spack-test-exe")
-
-        assert exe is not None
-        assert exe.path == str(tmpdir.join("spack-test-exe.exe"))
-    else:
-        with tmpdir.as_cwd():
+    with tmpdir.as_cwd():
+        if sys.platform == "win32":
+            # For Windows, need to create files with .exe after any assert is none tests
+            tmpdir.ensure("spack-test-exe.exe")
+            path += ".exe"
+        else:
             fs.touch("spack-test-exe")
             fs.set_executable("spack-test-exe")
 
         exe = ex.which("spack-test-exe")
         assert exe is not None
-        assert exe.path == str(tmpdir.join("spack-test-exe"))
-
-
-   
+        assert exe.path == path

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -54,8 +54,12 @@ def test_which_relative_path_with_slash(tmpdir, working_env):
         no_exe = ex.which('.{0}exe'.format(os.path.sep))
         assert no_exe is None
 
+
+        with tmpdir.as_cwd():
+            fs.touch("exe.exe")
+
         if sys.platform == "win32":
-            exe = ex.which('.{0}exe.exe'.format(os.path.sep))
+            exe = ex.which('.{0}exe'.format(os.path.sep))
             assert exe.path == path + ".exe"
         else:
             fs.set_executable(path)
@@ -73,9 +77,11 @@ def test_which_with_slash_ignores_path(tmpdir, working_env):
 
     if sys.platform == "win32":
         with tmpdir.as_cwd():
+            fs.touch("exe.exe")
+            fs.touch('bin{0}exe'.format(os.path.sep))
             path = path + ".exe"
             wrong_path = wrong_path + ".exe"
-            exe = ex.which('.{0}exe.exe'.format(os.path.sep))
+            exe = ex.which('.{0}exe'.format(os.path.sep))
             assert exe.path == path
 
     else:
@@ -94,8 +100,13 @@ def test_which(tmpdir):
     with pytest.raises(ex.CommandNotFoundError):
         ex.which("spack-test-exe", required=True)
 
+    
+
     if sys.platform == "win32":
-        exe = ex.which("spack-test-exe.exe")
+        with tmpdir.as_cwd():
+            fs.touch("spack-test-exe.exe")
+
+        exe = ex.which("spack-test-exe")
 
         assert exe is not None
         assert exe.path == str(tmpdir.join("spack-test-exe.exe"))
@@ -105,7 +116,6 @@ def test_which(tmpdir):
             fs.set_executable("spack-test-exe")
 
         exe = ex.which("spack-test-exe")
-
         assert exe is not None
         assert exe.path == str(tmpdir.join("spack-test-exe"))
 

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -15,89 +15,99 @@ import spack.util.executable as ex
 from spack.hooks.sbang import filter_shebangs_in_directory
 
 
-# def test_read_unicode(tmpdir, working_env):
-#     script_name = 'print_unicode.py'
-#     with tmpdir.as_cwd():
-#         os.environ['LD_LIBRARY_PATH'] = spack.main.spack_ld_library_path
-#         # make a script that prints some unicode
-#         with open(script_name, 'w') as f:
-#             f.write('''#!{0}
-# from __future__ import print_function
-# import sys
-# if sys.version_info < (3, 0, 0):
-#     reload(sys)
-#     sys.setdefaultencoding('utf8')
-# print(u'\\xc3')
-# '''.format(sys.executable))
+def test_read_unicode(tmpdir, working_env):
+    script_name = 'print_unicode.py'
+    with tmpdir.as_cwd():
+        os.environ['LD_LIBRARY_PATH'] = spack.main.spack_ld_library_path
+        # make a script that prints some unicode
+        with open(script_name, 'w') as f:
+            f.write('''#!{0}
+from __future__ import print_function
+import sys
+if sys.version_info < (3, 0, 0):
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+print(u'\\xc3')
+'''.format(sys.executable))
 
-#         # make it executable
-#         fs.set_executable(script_name)
-#         filter_shebangs_in_directory('.', [script_name])
+        # make it executable
+        fs.set_executable(script_name)
+        filter_shebangs_in_directory('.', [script_name])
 
-#         # read the unicode back in and see whether things work
-#         if sys.platform == 'win32':
-#             script = ex.Executable('%s %s' % (sys.executable, script_name))
-#         else:
-#             script = ex.Executable('./%s' % script_name)
+        # read the unicode back in and see whether things work
+        if sys.platform == 'win32':
+            script = ex.Executable('%s %s' % (sys.executable, script_name))
+        else:
+            script = ex.Executable('./%s' % script_name)
 
-#         assert u'\xc3' == script(output=str).strip()
+        assert u'\xc3' == script(output=str).strip()
 
 
 def test_which_relative_path_with_slash(tmpdir, working_env):
-    if sys.platform == "win32":
-        filename = "exe.exe"
-    else:
-        filename = "exe"
-    tmpdir.ensure(filename)
-    path = str(tmpdir.join(filename))
+    tmpdir.ensure("exe")
+    path = str(tmpdir.join("exe"))
 
-    print(os.listdir(tmpdir))
     
     os.environ['PATH'] = ''
 
     with tmpdir.as_cwd():
-        if sys.platform == "win32":
-           no_exe = ex.which('.\\%s' % filename) 
-        else:
-            no_exe = ex.which('./exe')
-        
+        no_exe = ex.which('.{0}exe'.format(os.path.sep))
         assert no_exe is None
 
+        if sys.platform == "win32":
+            exe = ex.which('.{0}exe.exe'.format(os.path.sep))
+            assert exe.path == path + ".exe"
+        else:
+            fs.set_executable(path)
+            exe = ex.which('.{0}exe'.format(os.path.sep))
+            assert exe.path == path
+
+
+def test_which_with_slash_ignores_path(tmpdir, working_env):
+    tmpdir.ensure('exe')
+    tmpdir.ensure('bin{0}exe'.format(os.path.sep))
+
+    path = str(tmpdir.join('exe'))
+    wrong_path = str(tmpdir.join('bin', 'exe'))
+    os.environ['PATH'] = os.path.dirname(wrong_path)
+
+    if sys.platform == "win32":
+        with tmpdir.as_cwd():
+            path = path + ".exe"
+            wrong_path = wrong_path + ".exe"
+            exe = ex.which('.{0}exe.exe'.format(os.path.sep))
+            assert exe.path == path
+
+    else:
         fs.set_executable(path)
-        exe = ex.which('.\\%s' % filename)
-        assert exe.path == path
+        fs.set_executable(wrong_path)
 
-
-# def test_which_with_slash_ignores_path(tmpdir, working_env):
-#     tmpdir.ensure('exe')
-#     tmpdir.ensure('bin{0}exe'.format(os.path.sep))
-
-#     path = str(tmpdir.join('exe'))
-#     wrong_path = str(tmpdir.join('bin', 'exe'))
-#     os.environ['PATH'] = os.path.dirname(wrong_path)
-
-#     fs.set_executable(path)
-#     fs.set_executable(wrong_path)
-
-#     with tmpdir.as_cwd():
-#         exe = ex.which('./exe')
-#         assert exe.path == path
+        with tmpdir.as_cwd():
+            exe = ex.which('.{0}exe'.format(os.path.sep))
+            assert exe.path == path
 
 
 def test_which(tmpdir):
-    if sys.platform == "win32":
-        filename = "spack-test-exe.exe"
-    else:
-        filename = "spack-test-exe"
     os.environ["PATH"] = str(tmpdir)
-    assert ex.which(filename) is None
+    assert ex.which("spack-test-exe") is None
+
     with pytest.raises(ex.CommandNotFoundError):
-        ex.which(filename, required=True)
+        ex.which("spack-test-exe", required=True)
 
-    with tmpdir.as_cwd():
-        fs.touch(filename)
-        fs.set_executable(filename)
+    if sys.platform == "win32":
+        exe = ex.which("spack-test-exe.exe")
 
-    exe = ex.which(filename)
-    assert exe is not None
-    assert exe.path == str(tmpdir.join(filename))
+        assert exe is not None
+        assert exe.path == str(tmpdir.join("spack-test-exe.exe"))
+    else:
+        with tmpdir.as_cwd():
+            fs.touch("spack-test-exe")
+            fs.set_executable("spack-test-exe")
+
+        exe = ex.which("spack-test-exe")
+
+        assert exe is not None
+        assert exe.path == str(tmpdir.join("spack-test-exe"))
+
+
+   

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -15,71 +15,89 @@ import spack.util.executable as ex
 from spack.hooks.sbang import filter_shebangs_in_directory
 
 
-def test_read_unicode(tmpdir, working_env):
-    script_name = 'print_unicode.py'
+# def test_read_unicode(tmpdir, working_env):
+#     script_name = 'print_unicode.py'
+#     with tmpdir.as_cwd():
+#         os.environ['LD_LIBRARY_PATH'] = spack.main.spack_ld_library_path
+#         # make a script that prints some unicode
+#         with open(script_name, 'w') as f:
+#             f.write('''#!{0}
+# from __future__ import print_function
+# import sys
+# if sys.version_info < (3, 0, 0):
+#     reload(sys)
+#     sys.setdefaultencoding('utf8')
+# print(u'\\xc3')
+# '''.format(sys.executable))
 
-    with tmpdir.as_cwd():
-        os.environ['LD_LIBRARY_PATH'] = spack.main.spack_ld_library_path
-        # make a script that prints some unicode
-        with open(script_name, 'w') as f:
-            f.write('''#!{0}
-from __future__ import print_function
-import sys
-if sys.version_info < (3, 0, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
-print(u'\\xc3')
-'''.format(sys.executable))
+#         # make it executable
+#         fs.set_executable(script_name)
+#         filter_shebangs_in_directory('.', [script_name])
 
-        # make it executable
-        fs.set_executable(script_name)
-        filter_shebangs_in_directory('.', [script_name])
+#         # read the unicode back in and see whether things work
+#         if sys.platform == 'win32':
+#             script = ex.Executable('%s %s' % (sys.executable, script_name))
+#         else:
+#             script = ex.Executable('./%s' % script_name)
 
-        # read the unicode back in and see whether things work
-        script = ex.Executable('./%s' % script_name)
-        assert u'\xc3' == script(output=str).strip()
+#         assert u'\xc3' == script(output=str).strip()
 
 
 def test_which_relative_path_with_slash(tmpdir, working_env):
-    tmpdir.ensure('exe')
-    path = str(tmpdir.join('exe'))
+    if sys.platform == "win32":
+        filename = "exe.exe"
+    else:
+        filename = "exe"
+    tmpdir.ensure(filename)
+    path = str(tmpdir.join(filename))
+
+    print(os.listdir(tmpdir))
+    
     os.environ['PATH'] = ''
 
     with tmpdir.as_cwd():
-        no_exe = ex.which('./exe')
+        if sys.platform == "win32":
+           no_exe = ex.which('.\\%s' % filename) 
+        else:
+            no_exe = ex.which('./exe')
+        
         assert no_exe is None
 
         fs.set_executable(path)
-        exe = ex.which('./exe')
+        exe = ex.which('.\\%s' % filename)
         assert exe.path == path
 
 
-def test_which_with_slash_ignores_path(tmpdir, working_env):
-    tmpdir.ensure('exe')
-    tmpdir.ensure('bin{0}exe'.format(os.path.sep))
+# def test_which_with_slash_ignores_path(tmpdir, working_env):
+#     tmpdir.ensure('exe')
+#     tmpdir.ensure('bin{0}exe'.format(os.path.sep))
 
-    path = str(tmpdir.join('exe'))
-    wrong_path = str(tmpdir.join('bin', 'exe'))
-    os.environ['PATH'] = os.path.dirname(wrong_path)
+#     path = str(tmpdir.join('exe'))
+#     wrong_path = str(tmpdir.join('bin', 'exe'))
+#     os.environ['PATH'] = os.path.dirname(wrong_path)
 
-    fs.set_executable(path)
-    fs.set_executable(wrong_path)
+#     fs.set_executable(path)
+#     fs.set_executable(wrong_path)
 
-    with tmpdir.as_cwd():
-        exe = ex.which('./exe')
-        assert exe.path == path
+#     with tmpdir.as_cwd():
+#         exe = ex.which('./exe')
+#         assert exe.path == path
 
 
 def test_which(tmpdir):
+    if sys.platform == "win32":
+        filename = "spack-test-exe.exe"
+    else:
+        filename = "spack-test-exe"
     os.environ["PATH"] = str(tmpdir)
-    assert ex.which("spack-test-exe") is None
+    assert ex.which(filename) is None
     with pytest.raises(ex.CommandNotFoundError):
-        ex.which("spack-test-exe", required=True)
+        ex.which(filename, required=True)
 
     with tmpdir.as_cwd():
-        fs.touch("spack-test-exe")
-        fs.set_executable('spack-test-exe')
+        fs.touch(filename)
+        fs.set_executable(filename)
 
-    exe = ex.which("spack-test-exe")
+    exe = ex.which(filename)
     assert exe is not None
-    assert exe.path == str(tmpdir.join("spack-test-exe"))
+    assert exe.path == str(tmpdir.join(filename))

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -278,13 +278,12 @@ def which_string(*args, **kwargs):
     if isinstance(path, string_types):
         path = path.split(os.pathsep)
 
-
-
     for name in args:
         if sys.platform == "win32":
             name += '.exe'
         if os.path.sep in name:
             exe = os.path.abspath(name)
+            print(exe)
             if os.path.isfile(exe) and os.access(exe, os.X_OK):
                 return exe.replace('\\', '/')
         else:

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -73,7 +73,10 @@ class Executable(object):
         Returns:
             str: The path to the executable
         """
-        return self.exe[0]
+        if sys.platform == "win32":
+            return self.exe[0].replace('/', '\\')
+        else:
+            return self.exe[0]
 
     def __call__(self, *args, **kwargs):
         """Run this executable in a subprocess.
@@ -202,12 +205,18 @@ class Executable(object):
             if output in (str, str.split) or error in (str, str.split):
                 result = ''
                 if output in (str, str.split):
-                    outstr = text_type(out.decode('utf-8'))
+                    if sys.platform == 'win32':
+                        outstr = text_type(out.decode('ISO-8859-1'))
+                    else:
+                        outstr = text_type(err.decode('utf-8'))
                     result += outstr
                     if output is str.split:
                         sys.stdout.write(outstr)
                 if error in (str, str.split):
-                    errstr = text_type(err.decode('utf-8'))
+                    if sys.platform == 'win32':
+                        errstr = text_type(out.decode('ISO-8859-1'))
+                    else:
+                        errstr = text_type(err.decode('utf-8'))
                     result += errstr
                     if error is str.split:
                         sys.stderr.write(errstr)
@@ -270,16 +279,20 @@ def which_string(*args, **kwargs):
         path = path.split(os.pathsep)
 
     for name in args:
-        if sys.platform == "win32":
-            name += '.exe'
         if os.path.sep in name:
             exe = os.path.abspath(name)
+            print( os.access(exe, os.X_OK))
             if os.path.isfile(exe) and os.access(exe, os.X_OK):
+                if sys.platform == "win32":
+                    return os.path.abspath(exe)
                 return exe.replace('\\', '/')
         else:
             for directory in path:
                 exe = os.path.join(directory, name)
+                print(exe)
                 if os.path.isfile(exe) and os.access(exe, os.X_OK):
+                    if sys.platform == "win32":
+                        return os.path.abspath(exe)
                     return exe.replace('\\', '/')
 
     if required:

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -281,18 +281,16 @@ def which_string(*args, **kwargs):
 
 
     for name in args:
+        if sys.platform == "win32":
+            name += '.exe'
         if os.path.sep in name:
             exe = os.path.abspath(name)
-            if sys.platform == "win32" and os.path.splitext(exe)[1] == ".exe":
-                return os.path.abspath(exe).replace('\\', '/')
-            elif sys.platform != "win32" and os.path.isfile(exe) and os.access(exe, os.X_OK):
+            if os.path.isfile(exe) and os.access(exe, os.X_OK):
                 return exe.replace('\\', '/')
         else:
             for directory in path:
                 exe = os.path.join(directory, name)
-                if sys.platform == "win32" and os.path.splitext(exe)[1] == ".exe":
-                    return os.path.abspath(exe).replace('\\', '/')
-                elif sys.platform != "win32" and os.path.isfile(exe) and os.access(exe, os.X_OK):
+                if os.path.isfile(exe) and os.access(exe, os.X_OK):
                     return exe.replace('\\', '/')
 
     if required:

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -278,21 +278,21 @@ def which_string(*args, **kwargs):
     if isinstance(path, string_types):
         path = path.split(os.pathsep)
 
+
+
     for name in args:
         if os.path.sep in name:
             exe = os.path.abspath(name)
-            print( os.access(exe, os.X_OK))
-            if os.path.isfile(exe) and os.access(exe, os.X_OK):
-                if sys.platform == "win32":
-                    return os.path.abspath(exe)
+            if sys.platform == "win32" and os.path.splitext(exe)[1] == ".exe":
+                return os.path.abspath(exe).replace('\\', '/')
+            elif sys.platform != "win32" and os.path.isfile(exe) and os.access(exe, os.X_OK):
                 return exe.replace('\\', '/')
         else:
             for directory in path:
                 exe = os.path.join(directory, name)
-                print(exe)
-                if os.path.isfile(exe) and os.access(exe, os.X_OK):
-                    if sys.platform == "win32":
-                        return os.path.abspath(exe)
+                if sys.platform == "win32" and os.path.splitext(exe)[1] == ".exe":
+                    return os.path.abspath(exe).replace('\\', '/')
+                elif sys.platform != "win32" and os.path.isfile(exe) and os.access(exe, os.X_OK):
                     return exe.replace('\\', '/')
 
     if required:


### PR DESCRIPTION
Added Windows support for the tests. 

test_read_unicode: changed encoding and the way the executable is run
test_which: Added alternative flow that changes the extension of a file instead of using set_executable. The which function also checks for a .exe extension instead.

Changed the Executable.path output to print out a path with \ chars on Windows.