### PR TITLE
Quick and dirty global debug flags

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -785,6 +785,38 @@ Unit tests
 Unit testing
 ------------
 
+---------------------
+Developer environment
+---------------------
+
+.. warning::
+
+    This is an experimental feature. It is expected to change and you should
+    not use it in a production environment.
+
+
+When installing a package, we currently have support to export environment
+variables to specify adding debug flags to the build. By default, a package
+install will build without any debug flag. However, if you want to add them,
+you can export:
+
+.. code-block:: console
+
+   export SPACK_ADD_DEBUG_FLAGS=true
+   spack install zlib
+
+
+If you want to add custom flags, you should export an additional variable:
+
+.. code-block:: console
+
+   export SPACK_ADD_DEBUG_FLAGS=true
+   export SPACK_DEBUG_FLAGS="-g"
+   spack install zlib
+
+These environment variables will eventually be integrated into spack so
+they are set from the command line.
+
 ------------------
 Developer commands
 ------------------

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -40,6 +40,14 @@ parameters=(
     SPACK_SYSTEM_DIRS
 )
 
+# Optional parameters that aren't required to be set
+
+# Boolean (true/false/custom) if we want to add debug flags
+# SPACK_ADD_DEBUG_FLAGS
+
+# If a custom flag is requested, it will be defined
+# SPACK_DEBUG_FLAGS
+
 # The compiler input variables are checked for sanity later:
 #   SPACK_CC, SPACK_CXX, SPACK_F77, SPACK_FC
 # The default compiler flags are passed from these variables:
@@ -87,6 +95,25 @@ for param in "${parameters[@]}"; do
     fi
 done
 
+# Check if optional parameters are defined
+# If we aren't asking for debug flags, don't add them
+if [[ -z ${SPACK_ADD_DEBUG_FLAGS+x} ]]; then
+    SPACK_ADD_DEBUG_FLAGS="false"
+fi
+
+# SPACK_ADD_DEBUG_FLAGS must be true/false/custom
+is_valid="false"
+for param in "true" "false" "custom"; do
+  if [ "$param" == "$SPACK_ADD_DEBUG_FLAGS" ];  then
+      is_valid="true"
+  fi
+done
+
+# Exit with error if we are given an incorrect value
+if [ "$is_valid" == "false" ]; then
+    die "SPACK_ADD_DEBUG_FLAGS, if defined, must be one of 'true' 'false' or 'custom'"
+fi
+
 # Figure out the type of compiler, the language, and the mode so that
 # the compiler script knows what to do.
 #
@@ -106,30 +133,35 @@ comp="CC"
 case "$command" in
     cpp)
         mode=cpp
+        debug_flags="-g"
         ;;
     cc|c89|c99|gcc|clang|armclang|icc|icx|pgcc|nvc|xlc|xlc_r|fcc)
         command="$SPACK_CC"
         language="C"
         comp="CC"
         lang_flags=C
+        debug_flags="-g"
         ;;
     c++|CC|g++|clang++|armclang++|icpc|icpx|pgc++|nvc++|xlc++|xlc++_r|FCC)
         command="$SPACK_CXX"
         language="C++"
         comp="CXX"
         lang_flags=CXX
+        debug_flags="-g"
         ;;
     ftn|f90|fc|f95|gfortran|flang|armflang|ifort|ifx|pgfortran|nvfortran|xlf90|xlf90_r|nagfor|frt)
         command="$SPACK_FC"
         language="Fortran 90"
         comp="FC"
         lang_flags=F
+        debug_flags="-g"
         ;;
     f77|xlf|xlf_r|pgf77)
         command="$SPACK_F77"
         language="Fortran 77"
         comp="F77"
         lang_flags=F
+        debug_flags="-g"
         ;;
     ld)
         mode=ld
@@ -414,6 +446,16 @@ done
 # https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
 #
 flags=()
+
+# Add debug flags
+if [ "${SPACK_ADD_DEBUG_FLAGS}" == "true" ]; then
+    flags=("${flags[@]}" "${debug_flags}")
+
+# If a custom flag is requested, derive from environment
+elif [ "$SPACK_ADD_DEBUG_FLAGS" == "custom" ]; then
+    IFS=' ' read -ra SPACK_DEBUG_FLAGS <<< "$SPACK_DEBUG_FLAGS"
+    flags=("${flags[@]}" "${SPACK_DEBUG_FLAGS[@]}")
+fi
 
 # Fortran flags come before CPPFLAGS
 case "$mode" in


### PR DESCRIPTION
This is a quick and dirty way to add support for global debug flags, currently via environment variables that then are seen by the compiler wrapper and added. It will hopefully be much more useful than #23231. We probably eventually want to make it possible to derive these envars starting from the command line, but talking with @trws it sounds like the traditional flag system / build environment variables that are set has a hook that runs after where a package can muck with the flags, meaning a user might request something and it never gets there. So we would need a different strategy.

## Questions to discuss

 - Did I add the flags in the right place (at the beginning, only because I've seen them there)?
 - How can we test this? I can test locally manually and confirm that debug symbols show up, but I'm not sure how that fits into the spack testing system

ping @trws  ! This was so much easier than the other way!


Signed-off-by: vsoch <vsoch@users.noreply.github.com>