### PR TITLE
package: bug with xfsprogs missing ini.h

### DIFF
--- a/var/spack/repos/builtin/packages/libinih/package.py
+++ b/var/spack/repos/builtin/packages/libinih/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libinih(MesonPackage):
+    """
+    inih (INI Not Invented Here) is a simple .INI file parser written in C.
+    """
+
+    homepage = "https://github.com/benhoyt/inih"
+    url      = "https://github.com/benhoyt/inih/archive/refs/tags/r53.tar.gz"
+    git      = "https://github.com/benhoyt/inih.git"
+
+    version('master', branch="master")

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -19,6 +19,7 @@ class Xfsprogs(AutotoolsPackage):
 
     version('4.20.0', sha256='beafdfd080352a8c9d543491e0874d0e8809cb643a3b9d352d5feed38d77022a')
 
+    depends_on('libinih')
     depends_on('gettext')
     depends_on('uuid')
     depends_on('util-linux')


### PR DESCRIPTION
I stumbled on this issue that xfsprogs currently does not install with error message:

```
FATAL ERROR: could not find a valid ini.h header.
```
:warning: :warning: :warning: 

(The warnings I added for greater effect :laughing: 

Anyway, adding this package libinih, and including it as a dependency for xfsprogs seems to fix the issue. 

## For Discussion

- It looks like libinih doesn't have .tar.gz releases so I only added the master branch (it failed to install from the archive url that is under releases) so we might need to discuss that.
- It could be that we only need to add it for newer versions (if it worked before) and maybe a maintainer can comment on that.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>