### PR TITLE
googletest: add v1.11 (default) and "live at head"

### DIFF
--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -37,7 +37,7 @@ class Faodel(CMakePackage):
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('hdf5~mpi', when='+hdf5~mpi')
     depends_on('libfabric@1.5.3:', when='network=libfabric')
-    depends_on('googletest@1.7.0:1.10', type='build')
+    depends_on('googletest@1.7.0:1.10', type='test')
 
     # FAODEL requires C++11 support which starts with gcc 4.8.1
     conflicts('%gcc@:4.8.0')
@@ -62,20 +62,24 @@ class Faodel(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
+        build_tests = self.run_tests and '+mpi' in spec
+
         args = [
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
-            self.define_from_variant('BUILD_TESTS', 'mpi'),
-            '-DBOOST_ROOT:PATH={0}'.format(spec['boost'].prefix),
-            '-DGTEST_ROOT:PATH={0}'.format(spec['googletest'].prefix),
-            '-DBUILD_DOCS:BOOL=OFF',
+            self.define('BOOST_ROOT', spec['boost'].prefix),
+            self.define('BUILD_DOCS', False),
+            self.define('BUILD_TESTS', build_tests),
             self.define_from_variant('Faodel_ENABLE_IOM_HDF5', 'hdf5'),
             # self.define_from_variant('Faodel_ENABLE_IOM_LEVELDB', 'leveldb'),
             self.define_from_variant('Faodel_ENABLE_MPI_SUPPORT', 'mpi'),
             self.define_from_variant('Faodel_ENABLE_TCMALLOC', 'tcmalloc'),
-            '-DFaodel_LOGGING_METHOD:STRING={0}'.format(
-                spec.variants['logging'].value),
-            '-DFaodel_NETWORK_LIBRARY:STRING={0}'.format(
-                spec.variants['network'].value),
-            self.define_from_variant('Faodel_ENABLE_CEREAL', 'cereal')
+            self.define_from_variant('Faodel_LOGGING_METHOD', 'logging'),
+            self.define_from_variant('Faodel_NETWORK_LIBRARY', 'network'),
+            self.define_from_variant('Faodel_ENABLE_CEREAL', 'cereal'),
         ]
+        if build_tests:
+            args.extend([
+                self.define('GTEST_ROOT', spec['googletest'].prefix)
+            ])
+
         return args

--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -37,7 +37,7 @@ class Faodel(CMakePackage):
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('hdf5~mpi', when='+hdf5~mpi')
     depends_on('libfabric@1.5.3:', when='network=libfabric')
-    depends_on('googletest@1.7.0:', type='build')
+    depends_on('googletest@1.7.0:1.10', type='build')
 
     # FAODEL requires C++11 support which starts with gcc 4.8.1
     conflicts('%gcc@:4.8.0')

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -10,7 +10,10 @@ class Googletest(CMakePackage):
     """Google test framework for C++.  Also called gtest."""
     homepage = "https://github.com/google/googletest"
     url      = "https://github.com/google/googletest/tarball/release-1.10.0"
+    git      = "https://github.com/google/googletest"
 
+    version('master', branch='master')
+    version('1.11.0', sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
     version('1.10.0', sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9')
     version('1.8.1',  sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
     version('1.8.0',  sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -14,7 +14,7 @@ class Googletest(CMakePackage):
 
     version('master', branch='master')
     version('1.11.0', sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
-    version('1.10.0', sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9')
+    version('1.10.0', sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9', preferred=True)
     version('1.8.1',  sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
     version('1.8.0',  sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')
     version('1.7.0',  sha256='9639cf8b7f37a4d0c6575f52c01ef167c5f11faee65252296b3ffc2d9acd421b')


### PR DESCRIPTION
Add v1.11, and a "master" version for people who want to live at head like googletest now suggests.

EDIT: prefer v1.10 because 1.11  seems  to  break some  packages.