### PR TITLE
Added Perl workaround for CUDA <= 8

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -174,9 +174,10 @@ class Cuda(Package):
 
         if self.spec.satisfies('@:8.0.61'):
             # Perl 5.26 removed current directory from module search path.
-            # We are addressing this by exporting `PERL5LIB` earlier, but for some reason, it is not enough.
-            # One more file needs to be extracted before running actual installer. This solution is one of
-            # the commonly found in the Internet, when people try to install older CUDA manually.
+            # We are addressing this by exporting `PERL5LIB` earlier, but for some
+            # reason, it is not enough. One more file needs to be extracted before
+            # running actual installer. This solution is one of the commonly found
+            # in the Internet, when people try to install CUDA <= 8 manually.
             arguments = [runfile, '--tar', 'mxvf', './InstallUtils.pm']
             install_shell = which('sh')
             install_shell(*arguments)

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -132,7 +132,7 @@ class Cuda(Package):
         if self.spec.satisfies('@:8.0.61'):
             # Perl 5.26 removed current directory from module search path,
             # CUDA 9 has a fix for this, but CUDA 8 and lower don't.
-            env.set('PERL5LIB', self.stage.source_path)
+            env.append_path('PERL5LIB', self.stage.source_path)
 
         if self.spec.satisfies('@10.1.243:'):
             libxml2_home = self.spec['libxml2'].prefix

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -178,6 +178,7 @@ class Cuda(Package):
             # reason, it is not enough. One more file needs to be extracted before
             # running the actual installer. This solution is one of the commonly
             # found on the Internet, when people try to install CUDA <= 8 manually.
+            # For example: https://askubuntu.com/a/1087842
             arguments = [runfile, '--tar', 'mxvf', './InstallUtils.pm']
             install_shell = which('sh')
             install_shell(*arguments)

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -172,6 +172,8 @@ class Cuda(Package):
             os.makedirs(os.path.join(prefix, "src"))
             os.symlink(includedir, os.path.join(prefix, "include"))
 
+        install_shell = which('sh')
+
         if self.spec.satisfies('@:8.0.61'):
             # Perl 5.26 removed current directory from module search path.
             # We are addressing this by exporting `PERL5LIB` earlier, but for some
@@ -180,7 +182,6 @@ class Cuda(Package):
             # found on the Internet, when people try to install CUDA <= 8 manually.
             # For example: https://askubuntu.com/a/1087842
             arguments = [runfile, '--tar', 'mxvf', './InstallUtils.pm']
-            install_shell = which('sh')
             install_shell(*arguments)
 
         # CUDA 10.1+ has different cmdline options for the installer
@@ -190,13 +191,15 @@ class Cuda(Package):
             '--override',       # override compiler version checks
             '--toolkit',        # install CUDA Toolkit
         ]
+
         if spec.satisfies('@10.1:'):
             arguments.append('--installpath=%s' % prefix)   # Where to install
         else:
             arguments.append('--verbose')                   # Verbose log file
             arguments.append('--toolkitpath=%s' % prefix)   # Where to install
-        install_shell = which('sh')
+
         install_shell(*arguments)
+
         try:
             os.remove('/tmp/cuda-installer.log')
         except OSError:

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -176,8 +176,8 @@ class Cuda(Package):
             # Perl 5.26 removed current directory from module search path.
             # We are addressing this by exporting `PERL5LIB` earlier, but for some
             # reason, it is not enough. One more file needs to be extracted before
-            # running actual installer. This solution is one of the commonly found
-            # in the Internet, when people try to install CUDA <= 8 manually.
+            # running the actual installer. This solution is one of the commonly
+            # found on the Internet, when people try to install CUDA <= 8 manually.
             arguments = [runfile, '--tar', 'mxvf', './InstallUtils.pm']
             install_shell = which('sh')
             install_shell(*arguments)


### PR DESCRIPTION
@Rombur @ax3l

Resolves https://github.com/spack/spack/issues/23402

How it was tested:

```sh
$ spack install cuda@8.0.61
$ spack install cuda@8.0.44
$ spack install cuda@7.5.18
$ spack install cuda@6.5.14
```

Previously the installation folder was almost empty, now CUDA files are present.

More details in the linked issue.