### PR TITLE
fast-global-file-status: depends on libtool for build

### DIFF
--- a/var/spack/repos/builtin/packages/fast-global-file-status/package.py
+++ b/var/spack/repos/builtin/packages/fast-global-file-status/package.py
@@ -25,6 +25,7 @@ class FastGlobalFileStatus(AutotoolsPackage):
     depends_on('mpi')
     depends_on('openssl')
     depends_on('elf')
+    depends_on('libtool', type='build')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
`fast-global-file-status` depends on `libtool` for build

@lee218llnl 