### PR TITLE
arm-forge: Add variant to detect PMU counters

### DIFF
--- a/var/spack/repos/builtin/packages/arm-forge/package.py
+++ b/var/spack/repos/builtin/packages/arm-forge/package.py
@@ -21,11 +21,19 @@ class ArmForge(Package):
     #       versions (and checksums) based on the target platform shows up
 
     if platform.machine() == "aarch64":
-        version("21.0", sha256="2bcc745d0049d6b25c77c97b2d7bad7b4f804180972a2306a8599ce41f6a4573")
+        version("21.0.2", sha256="ca547d11086ddd2704468166ad01f34132fcfa8d416239ad85c87a6c5f042298")
+        version("21.0",   sha256="2bcc745d0049d6b25c77c97b2d7bad7b4f804180972a2306a8599ce41f6a4573")
     elif platform.machine() == "ppc64le":
-        version("21.0", sha256="60cfa7dd1cd131ec85e67cb660f2f84cf30bb700d8979cae1f5f88af658fd249")
+        version("21.0.2", sha256="302cadf6c6ddd6f41fafb0d490a92ae0919a7b24d6c212228311253cec2ff1b7")
+        version("21.0",   sha256="60cfa7dd1cd131ec85e67cb660f2f84cf30bb700d8979cae1f5f88af658fd249")
     elif platform.machine() == "x86_64":
-        version("21.0", sha256="71b713a05d431a3c26bd83cc4d0b65a0afd7d7f5bf57aa11edfb41da90f01774")
+        version("21.0.2", sha256="741ff2a995c8cf7ce5d346a3f7d2a552ec602b995e477e9a5a3a6319d3907980")
+        version("21.0",   sha256="71b713a05d431a3c26bd83cc4d0b65a0afd7d7f5bf57aa11edfb41da90f01774")
+
+    variant('probe', default=False, description='Detect available PMU counters via "forge-probe" during install')
+
+    # forge-probe executes with "/usr/bin/env python"
+    depends_on('python@2.7:2.9.9', type='build', when='+probe')
 
     # Licensing
     license_required = True
@@ -44,6 +52,9 @@ class ArmForge(Package):
 
     def install(self, spec, prefix):
         subprocess.call(["./textinstall.sh", "--accept-licence", prefix])
+        if spec.satisfies('+probe'):
+            probe = join_path(prefix, "bin", "forge-probe")
+            subprocess.call([probe, "--install", "global"])
 
     def setup_run_environment(self, env):
         # Only PATH is needed for Forge.


### PR DESCRIPTION
* "probe" variant runs forge-probe post-install to detect available PMU
counters.
* Add hashes for version 21.0.2