### PR TITLE
Configure docbook packages

### DIFF
--- a/var/spack/repos/builtin/packages/docbook-xml/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xml/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 from spack import *
 
 
@@ -18,17 +17,183 @@ class DocbookXml(Package):
     version('4.5', sha256='4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4')
     version('4.3', sha256='23068a94ea6fd484b004c5a73ec36a66aa47ea8f0d6b62cc1695931f5c143464')
 
+    depends_on('libxml2', type='build')
+
     def install(self, spec, prefix):
         install_tree('.', prefix)
 
     @property
     def catalog(self):
-        return os.path.join(self.prefix, 'catalog.xml')
+        return join_path(self.prefix, 'catalog')
+
+    @run_after('install')
+    def config_docbook(self):
+        catalog = self.catalog
+        version = self.version
+        docbook = join_path(prefix, 'docbook')
+        ent_dir = join_path(prefix, 'ent')
+        xmlcatalog = which('xmlcatalog')
+
+        # create docbook
+        xmlcatalog('--noout', '--create', docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//DTD DocBook XML CALS Table Model '
+                   'V{0}//EN'.format(version),
+                   'file://{0}/calstblx.dtd'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//DTD DocBook XML V{0}//EN'.format(version),
+                   'file://{0}/docbookx.dtd'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//DTD XML Exchange Table Model 19990315//EN',
+                   'file://{0}/soextblx.dtd'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//ENTITIES DocBook XML Character Entities '
+                   'V{0}//EN'.format(version),
+                   'file://{0}/dbcentx.mod'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//ENTITIES DocBook XML Additional General Entities '
+                   'V{0}//EN'.format(version),
+                   'file://{0}/dbgenent.mod'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//ELEMENTS DocBook XML Document Hierarchy '
+                   'V{0}//EN'.format(version),
+                   'file://{0}/dbhierx.mod'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//ENTITIES DocBook XML Notations '
+                   'V{0}//EN'.format(version),
+                   'file://{0}/dbnotnx.mod'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//ELEMENTS DocBook XML Information Pool '
+                   'V{0}//EN'.format(version),
+                   'file://{0}/dbpoolx.mod'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   '-//OASIS//ELEMENTS DocBook XML HTML Tables '
+                   'V{0}//EN'.format(version),
+                   'file://{0}/htmltblx.mod'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Added Math Symbols: Arrow '
+                   'Relations//EN',
+                   'file://{0}/isoamsa.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Added Math Symbols: Binary '
+                   'Operators//EN',
+                   'file://{0}/isoamsb.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Added Math Symbols: Delimiters//EN',
+                   'file://{0}/isoamsc.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Added Math Symbols: '
+                   'Negated Relations//EN',
+                   'file://{0}/isoamsn.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Added Math Symbols: Ordinary//EN',
+                   'file://{0}/isoamso.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Added Math Symbols: Relations//EN',
+                   'file://{0}/isoamsr.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Box and Line Drawing//EN',
+                   'file://{0}/isobox.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Russian Cyrillic//EN',
+                   'file://{0}/isocyr1.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Non-Russian Cyrillic//EN',
+                   'file://{0}/isocyr2.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Diacritical Marks//EN',
+                   'file://{0}/isodia.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Greek Letters//EN',
+                   'file://{0}/isogrk1.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Monotoniko Greek//EN',
+                   'file://{0}/isogrk2.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Greek Symbols//EN',
+                   'file://{0}/isogrk3.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Alternative Greek Symbols//EN',
+                   'file://{0}/isogrk4.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Added Latin 1//EN',
+                   'file://{0}/isolat1.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Added Latin 2//EN',
+                   'file://{0}/isolat2.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Numeric and Special Graphic//EN',
+                   'file://{0}/isonum.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES Publishing//EN',
+                   'file://{0}/isopub.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'public',
+                   'ISO 8879:1986//ENTITIES General Technical//EN',
+                   'file://{0}/isotech.ent'.format(ent_dir),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'rewriteSystem',
+                   'http://www.oasis-open.org/docbook/xml/{0}'.format(version),
+                   'file://{0}'.format(prefix),
+                   docbook)
+        xmlcatalog('--noout', '--add', 'rewriteURI',
+                   'http://www.oasis-open.org/docbook/xml/{0}'.format(version),
+                   'file://{0}'.format(prefix),
+                   docbook)
+
+        # create catalog
+        xmlcatalog('--noout', '--create', catalog)
+        xmlcatalog('--noout', '--add', 'delegatePublic',
+                   '-//OASIS//ENTITIES DocBook XML',
+                   'file://{0}'.format(docbook),
+                   catalog)
+        xmlcatalog('--noout', '--add', 'delegatePublic',
+                   '-//OASIS//DTD DocBook XML',
+                   'file://{0}'.format(docbook),
+                   catalog)
+        xmlcatalog('--noout', '--add', 'delegatePublic',
+                   'ISO 8879:1986',
+                   'file://{0}'.format(docbook),
+                   catalog)
+        xmlcatalog('--noout', '--add', 'delegateSystem',
+                   'http://www.oasis-open.org/docbook/',
+                   'file://{0}'.format(docbook),
+                   catalog)
+        xmlcatalog('--noout', '--add', 'delegateURI',
+                   'http://www.oasis-open.org/docbook/',
+                   'file://{0}'.format(docbook),
+                   catalog)
 
     def setup_run_environment(self, env):
         catalog = self.catalog
-        env.set('XML_CATALOG_FILES', catalog, separator=' ')
+        env.prepend_path('XML_CATALOG_FILES', catalog, separator=' ')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         catalog = self.catalog
-        env.set("XML_CATALOG_FILES", catalog, separator=' ')
+        env.prepend_path("XML_CATALOG_FILES", catalog, separator=' ')

--- a/var/spack/repos/builtin/packages/docbook-xsl/package.py
+++ b/var/spack/repos/builtin/packages/docbook-xsl/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
 from spack import *
 
 
@@ -17,6 +16,7 @@ class DocbookXsl(Package):
     version('1.78.1', sha256='c98f7296ab5c8ccd2e0bc07634976a37f50847df2d8a59bdb1e157664700b467', url='https://sourceforge.net/projects/docbook/files/docbook-xsl/1.78.1/docbook-xsl-1.78.1.tar.bz2')
 
     depends_on('docbook-xml')
+    depends_on('libxml2', type='build')
 
     patch('docbook-xsl-1.79.2-stack_fix-1.patch', when='@1.79.2')
 
@@ -25,7 +25,36 @@ class DocbookXsl(Package):
 
     @property
     def catalog(self):
-        return os.path.join(self.prefix, 'catalog.xml')
+        return join_path(self.prefix, 'catalog')
+
+    @run_after('install')
+    def config_docbook(self):
+        catalog = self.catalog
+        version = self.version
+        xml_xsd = join_path(prefix, 'slides', 'schema', 'xsd', 'xml.xsd')
+        xmlcatalog = which('xmlcatalog')
+
+        # create catalog
+        xmlcatalog('--noout', '--create', catalog)
+        xmlcatalog('--noout', '--add', 'system',
+                   'http://www.w3.org/2001/xml.xsd', xml_xsd, catalog)
+        xmlcatalog('--noout', '--add', 'system',
+                   'http://www.w3.org/2009/01/xml.xsd', xml_xsd, catalog)
+        xmlcatalog('--noout', '--add', 'uri',
+                   'http://www.w3.org/2001/xml.xsd', xml_xsd, catalog)
+        xmlcatalog('--noout', '--add', 'uri',
+                   'http://www.w3.org/2009/01/xml.xsd', xml_xsd, catalog)
+
+        docbook_urls = ['docbook.sourceforge.net', 'cdn.docbook.org']
+        docbook_rewrites = ['rewriteSystem', 'rewriteURI']
+        docbook_versions = ['current', version]
+        for docbook_url in docbook_urls:
+            for docbook_rewrite in docbook_rewrites:
+                for docbook_version in docbook_versions:
+                    xmlcatalog('--noout', '--add', docbook_rewrite,
+                               'http://{0}/release/xsl/{1}'.format(docbook_url,
+                                                                   docbook_version),
+                               prefix, catalog)
 
     def setup_run_environment(self, env):
         catalog = self.catalog


### PR DESCRIPTION
This PR configures the spack docbook packages
- docbook-xsl
- docbook-xml

The public entities are now mapped to the locally installed files of the
respective packages. The example catalogs are left in place and
XML_CATALOG_FILES points to the newly created catalogs.

- Fixed environment reference in docbook-xml
- added libxml2 as a build dependency