### PR TITLE
libwebp: update version and add dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/libwebp/package.py
+++ b/var/spack/repos/builtin/packages/libwebp/package.py
@@ -14,48 +14,42 @@ class Libwebp(AutotoolsPackage):
     homepage = "https://developers.google.com/speed/webp/"
     url      = "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.0.3.tar.gz"
 
+    version('1.2.0', sha256='2fc8bbde9f97f2ab403c0224fb9ca62b2e6852cbc519e91ceaa7c153ffd88a0c')
     version('1.0.3', sha256='e20a07865c8697bba00aebccc6f54912d6bc333bb4d604e6b07491c1a226b34f')
 
-    variant('libwebpmux',     default=False, description='Build libwebpmux')
-    variant('libwebpdemux',   default=False, description='Build libwebpdemux')
+    variant('libwebpmux', default=False, description='Build libwebpmux')
+    variant('libwebpdemux', default=False, description='Build libwebpdemux')
     variant('libwebpdecoder', default=False, description='Build libwebpdecoder')
-    variant('libwebpextras',  default=False, description='Build libwebpextras')
+    variant('libwebpextras', default=False, description='Build libwebpextras')
+    variant('gif', default=False, description='GIF support')
+    variant('jpeg', default=False, description='JPEG support')
+    variant('png', default=False, description='PNG support')
+    variant('tiff', default=False, description='TIFF support')
 
     depends_on('automake', type='build')
     depends_on('autoconf', type='build')
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
+    depends_on('giflib', when='+gif')
+    depends_on('jpeg', when='+jpeg')
+    depends_on('libpng', when='+png')
+    depends_on('libtiff', when='+tiff')
 
     def configure_args(self):
         # TODO: add variants and dependencies for these
         args = [
             '--disable-gl',
             '--disable-sdl',
-            '--disable-png',
-            '--disable-jpeg',
-            '--disable-tiff',
-            '--disable-gif',
             '--disable-wic',
         ]
 
-        if '+libwebpmux' in self.spec:
-            args.append('--enable-libwebpmux')
-        else:
-            args.append('--disable-libwebpmux')
-
-        if '+libwebpdemux' in self.spec:
-            args.append('--enable-libwebpdemux')
-        else:
-            args.append('--disable-libwebpdemux')
-
-        if '+libwebpdecoder' in self.spec:
-            args.append('--enable-libwebpdecoder')
-        else:
-            args.append('--disable-libwebpdecoder')
-
-        if '+libwebpextras' in self.spec:
-            args.append('--enable-libwebpextras')
-        else:
-            args.append('--disable-libwebpextras')
+        args += self.enable_or_disable('gif')
+        args += self.enable_or_disable('jpeg')
+        args += self.enable_or_disable('png')
+        args += self.enable_or_disable('tiff')
+        args += self.enable_or_disable('libwebpmux')
+        args += self.enable_or_disable('libwebpdemux')
+        args += self.enable_or_disable('libwebpdecoder')
+        args += self.enable_or_disable('libwebpextras')
 
         return args


### PR DESCRIPTION
This PR updates the libwebp package.
- add version 1.2.0
- add variants
    - giflib
    - jpeg
    - libpng
    - libtiff
- use enable_or_disable method for variants.