### PR TITLE
leptonica: update and add missing dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/leptonica/package.py
+++ b/var/spack/repos/builtin/packages/leptonica/package.py
@@ -13,12 +13,20 @@ class Leptonica(CMakePackage):
     homepage = "http://www.leptonica.org/"
     url      = "https://github.com/DanBloomberg/leptonica/archive/1.80.0.tar.gz"
 
+    version('1.81.0', sha256='70ebc04ff8b9684205bd1d01843c635a8521255b74813bf7cce9a33368f7952c')
     version('1.80.0', sha256='3952b974ec057d24267aae48c54bca68ead8275604bf084a73a4b953ff79196e')
     version('1.79.0', sha256='bf9716f91a4844c2682a07ef21eaf68b6f1077af1f63f27c438394fd66218e17')
     version('1.78.0', sha256='f8ac4d93cc76b524c2c81d27850bfc342e68b91368aa7a1f7d69e34ce13adbb4')
 
+    depends_on('giflib')
+    depends_on('jpeg')
+    depends_on('libpng')
+    depends_on('libtiff')
     depends_on('zlib')
+    depends_on('libwebp+libwebpmux+libwebpdemux')
+    depends_on('openjpeg')
 
     def cmake_args(self):
-        args = ['-DCMAKE_C_FLAGS=' + self.compiler.cc_pic_flag]
+        args = ['-DBUILD_SHARED_LIBS=ON']
+
         return args


### PR DESCRIPTION
Depends on #24301 

This PR updates and adds dependencies to the leptonica package.
- add version 1.81.0
- add dependencies
  - giflib
  - jpeg
  - libpng
  - libtiff
  - libwebp
  - openjpeg
- build shared libs