### PR TITLE
paraver: rename package to wxparaver, add new versions and fix installation

### DIFF
--- a/var/spack/repos/builtin/packages/paraver/package.py
+++ b/var/spack/repos/builtin/packages/paraver/package.py
@@ -7,25 +7,18 @@ from spack import *
 import os
 
 
-class Paraver(AutotoolsPackage):
+class Paraver(Package):
     """"A very powerful performance visualization and analysis tool
         based on traces that can be used to analyse any information that
         is expressed on its input trace format.  Traces for parallel MPI,
-        OpenMP and other programs can be genereated with Extrae."""
+        OpenMP and other programs can be genereated with Extrae.
+
+        Note: This package is deprecated in favor of wxparaver"""
     homepage = "https://tools.bsc.es/paraver"
     url = "https://ftp.tools.bsc.es/wxparaver/wxparaver-4.6.3-src.tar.bz2"
 
     # NOTE: Paraver provides only latest version for download.
     #       Don't keep/add older versions.
-    version('4.9.2',     sha256='83289584040bcedf8cab1b2ae3545191c8bdef0e11ab62b06e54cbf111f2127a', deprecated=True)
-    version('4.9.1',     sha256='e89fdf563d1fc73ed0018cf0e25b458b6617ec33325ed3fdbf06397c556f3a8e', deprecated=True)
-    version('4.9.0',     sha256='1f9964d7987032d01a354327845bf53ae369be5d8acf7d4e85bec81699a6ddf6', deprecated=True)
-    version('4.8.2',     sha256='0d22ec362e4798d7ed21b15b607859e9bda9579e3d5b23af3812c1e32ccc192d', deprecated=True)
-    version('4.8.1',     sha256='d03b04254bd3015d61374b95aeda6888f593be67286c5268849623baa2ae6e2e', deprecated=True)
-    version('4.8.0',     sha256='780af8fff7cb40d1325260fb9f79210f6676f07357bc9b95b1b838862f2d1e5b', deprecated=True)
-    version('4.7.2',     sha256='90107797d6af6fc3ebd9505445bb518d673edecbe5d08d1b7af01695d53241ae', deprecated=True)
-    version('4.7.1',     sha256='8cbec0c5e0f8a849820f6682cbb0920ea234bb7f20d1483e38ea5d0b0ee045cd', deprecated=True)
-    version('4.7.0',     sha256='81e02bcc1853455b13435172a4336ba85ba05020887d322c9678c97def03d76f', deprecated=True)
     version('4.6.3',     sha256='ac6025eec5419e1060967eab71dfd123e585be5b5f3ac3241085895dbeca255a', deprecated=True)
     version('4.6.2',     sha256='74b85bf9e6570001d372b376b58643526e349b1d2f1e7633ca38bb0800ecf929', deprecated=True)
 
@@ -35,33 +28,6 @@ class Paraver(AutotoolsPackage):
     depends_on('libxml2')
     depends_on('zlib')
 
-    def configure_args(self):
-        spec = self.spec
-        args = []
-
-        if spec.satisfies('@4.6.3'):
-            args.append('--with-paraver=%s' % self.prefix)
-            args.append('--with-ptools-common-files=%s' % self.prefix)
-        args.append('--with-boost=%s' % spec['boost'].prefix)
-        args.append('--with-wx-config=%s/wx-config' % spec['wxwidgets'].prefix.bin)
-        if spec['wxwidgets'].satisfies('@:2'):
-            args.append('--with-wxpropgrid=%s' % spec['wxpropgrid'].prefix)
-
-        return args
-
-    @when('@4.6.2')  # do not have global build system
-    def autoreconf(self, spec, prefix):
-        pass
-
-    @when('@4.6.2')  # do not have global build system
-    def configure(self, spec, prefix):
-        pass
-
-    # use make install directly as expected by Paraver
-    def build(self, spec, prefix):
-        pass
-
-    @when('@4.6.2')  # do not have global build system
     def install(self, spec, prefix):
         os.chdir("ptools_common_files")
         configure("--prefix=%s" % prefix)

--- a/var/spack/repos/builtin/packages/paraver/package.py
+++ b/var/spack/repos/builtin/packages/paraver/package.py
@@ -7,24 +7,61 @@ from spack import *
 import os
 
 
-class Paraver(Package):
+class Paraver(AutotoolsPackage):
     """"A very powerful performance visualization and analysis tool
         based on traces that can be used to analyse any information that
         is expressed on its input trace format.  Traces for parallel MPI,
         OpenMP and other programs can be genereated with Extrae."""
     homepage = "https://tools.bsc.es/paraver"
-    url = "https://ftp.tools.bsc.es/paraver/wxparaver-4.6.3-src.tar.bz2"
+    url = "https://ftp.tools.bsc.es/wxparaver/wxparaver-4.6.3-src.tar.bz2"
 
     # NOTE: Paraver provides only latest version for download.
     #       Don't keep/add older versions.
-    version('4.6.3', sha256='ac6025eec5419e1060967eab71dfd123e585be5b5f3ac3241085895dbeca255a')
-    version('4.6.2', sha256='74b85bf9e6570001d372b376b58643526e349b1d2f1e7633ca38bb0800ecf929')
+    version('4.9.2',     sha256='83289584040bcedf8cab1b2ae3545191c8bdef0e11ab62b06e54cbf111f2127a')
+    version('4.9.1',     sha256='e89fdf563d1fc73ed0018cf0e25b458b6617ec33325ed3fdbf06397c556f3a8e')
+    version('4.9.0',     sha256='1f9964d7987032d01a354327845bf53ae369be5d8acf7d4e85bec81699a6ddf6')
+    version('4.8.2',     sha256='0d22ec362e4798d7ed21b15b607859e9bda9579e3d5b23af3812c1e32ccc192d')
+    version('4.8.1',     sha256='d03b04254bd3015d61374b95aeda6888f593be67286c5268849623baa2ae6e2e')
+    version('4.8.0',     sha256='780af8fff7cb40d1325260fb9f79210f6676f07357bc9b95b1b838862f2d1e5b')
+    version('4.7.2',     sha256='90107797d6af6fc3ebd9505445bb518d673edecbe5d08d1b7af01695d53241ae')
+    version('4.7.1',     sha256='8cbec0c5e0f8a849820f6682cbb0920ea234bb7f20d1483e38ea5d0b0ee045cd')
+    version('4.7.0',     sha256='81e02bcc1853455b13435172a4336ba85ba05020887d322c9678c97def03d76f')
+    version('4.6.3',     sha256='ac6025eec5419e1060967eab71dfd123e585be5b5f3ac3241085895dbeca255a')
+    version('4.6.2',     sha256='74b85bf9e6570001d372b376b58643526e349b1d2f1e7633ca38bb0800ecf929', deprecated=True)
 
-    depends_on("boost")
-    # depends_on("extrae")
-    depends_on("wxwidgets")
-    depends_on("wxpropgrid")
+    depends_on('boost@1.36: +serialization')
+    depends_on('wxwidgets@2.8:')  # NOTE: using external for this one is usually simpler
+    depends_on('wxpropgrid@1.4:')
+    depends_on('libxml2')
+    depends_on('zlib')
 
+    def configure_args(self):
+        spec = self.spec
+        args = []
+
+        if spec.satisfies('@4.6.3'):
+            args.append('--with-paraver=%s' % self.prefix)
+            args.append('--with-ptools-common-files=%s' % self.prefix)
+        args.append('--with-boost=%s' % spec['boost'].prefix)
+        args.append('--with-wx-config=%s/wx-config' % spec['wxwidgets'].prefix.bin)
+        if spec['wxwidgets'].satisfies('@:2'):
+            args.append('--with-wxpropgrid=%s' % spec['wxpropgrid'].prefix)
+
+        return args
+
+    @when('@4.6.2')  # do not have global build system
+    def autoreconf(self, spec, prefix):
+        pass
+
+    @when('@4.6.2')  # do not have global build system
+    def configure(self, spec, prefix):
+        pass
+
+    # use make install directly as expected by Paraver
+    def build(self, spec, prefix):
+        pass
+
+    @when('@4.6.2')  # do not have global build system
     def install(self, spec, prefix):
         os.chdir("ptools_common_files")
         configure("--prefix=%s" % prefix)

--- a/var/spack/repos/builtin/packages/wxparaver/package.py
+++ b/var/spack/repos/builtin/packages/wxparaver/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import os
 
 
 class Wxparaver(AutotoolsPackage):
@@ -15,8 +14,6 @@ class Wxparaver(AutotoolsPackage):
     homepage = "https://tools.bsc.es/paraver"
     url = "https://ftp.tools.bsc.es/wxparaver/wxparaver-4.6.3-src.tar.bz2"
 
-    # NOTE: Paraver provides only latest version for download.
-    #       Don't keep/add older versions.
     version('4.9.2',     sha256='83289584040bcedf8cab1b2ae3545191c8bdef0e11ab62b06e54cbf111f2127a')
     version('4.9.1',     sha256='e89fdf563d1fc73ed0018cf0e25b458b6617ec33325ed3fdbf06397c556f3a8e')
     version('4.9.0',     sha256='1f9964d7987032d01a354327845bf53ae369be5d8acf7d4e85bec81699a6ddf6')
@@ -26,8 +23,6 @@ class Wxparaver(AutotoolsPackage):
     version('4.7.2',     sha256='90107797d6af6fc3ebd9505445bb518d673edecbe5d08d1b7af01695d53241ae')
     version('4.7.1',     sha256='8cbec0c5e0f8a849820f6682cbb0920ea234bb7f20d1483e38ea5d0b0ee045cd')
     version('4.7.0',     sha256='81e02bcc1853455b13435172a4336ba85ba05020887d322c9678c97def03d76f')
-    version('4.6.3',     sha256='ac6025eec5419e1060967eab71dfd123e585be5b5f3ac3241085895dbeca255a')
-    version('4.6.2',     sha256='74b85bf9e6570001d372b376b58643526e349b1d2f1e7633ca38bb0800ecf929', deprecated=True)
 
     depends_on('boost@1.36: +serialization')
     depends_on('wxwidgets@2.8:')  # NOTE: using external for this one is usually simpler
@@ -39,55 +34,13 @@ class Wxparaver(AutotoolsPackage):
         spec = self.spec
         args = []
 
-        if spec.satisfies('@4.6.3'):
-            args.append('--with-paraver=%s' % self.prefix)
-            args.append('--with-ptools-common-files=%s' % self.prefix)
         args.append('--with-boost=%s' % spec['boost'].prefix)
         args.append('--with-wx-config=%s/wx-config' % spec['wxwidgets'].prefix.bin)
-        if spec['wxwidgets'].satisfies('@:2'):
+        if spec['wxwidgets'].satisfies('@:2.999'):
             args.append('--with-wxpropgrid=%s' % spec['wxpropgrid'].prefix)
 
         return args
 
-    @when('@4.6.2')  # do not have global build system
-    def autoreconf(self, spec, prefix):
-        pass
-
-    @when('@4.6.2')  # do not have global build system
-    def configure(self, spec, prefix):
-        pass
-
-    # use make install directly as expected by Paraver
+    # use make install directly as expected by Paraver (See README)
     def build(self, spec, prefix):
         pass
-
-    @when('@4.6.2')  # do not have global build system
-    def install(self, spec, prefix):
-        os.chdir("ptools_common_files")
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")
-
-        os.chdir("../paraver-kernel")
-        # "--with-extrae=%s" % spec['extrae'].prefix,
-        configure("--prefix=%s" % prefix,
-                  "--with-ptools-common-files=%s" % prefix,
-                  "--with-boost=%s" % spec['boost'].prefix,
-                  "--with-boost-serialization=boost_serialization")
-        make()
-        make("install")
-
-        os.chdir("../paraver-toolset")
-        configure("--prefix=%s" % prefix)
-        make()
-        make("install")
-
-        os.chdir("../wxparaver")
-        # "--with-extrae=%s" % spec['extrae'].prefix,
-        configure("--prefix=%s" % prefix,
-                  "--with-paraver=%s" % prefix,
-                  "--with-boost=%s" % spec['boost'].prefix,
-                  "--with-boost-serialization=boost_serialization",
-                  "--with-wxdir=%s" % spec['wxwidgets'].prefix.bin)
-        make()
-        make("install")

--- a/var/spack/repos/builtin/packages/wxparaver/package.py
+++ b/var/spack/repos/builtin/packages/wxparaver/package.py
@@ -12,7 +12,7 @@ class Wxparaver(AutotoolsPackage):
         is expressed on its input trace format.  Traces for parallel MPI,
         OpenMP and other programs can be genereated with Extrae."""
     homepage = "https://tools.bsc.es/paraver"
-    url = "https://ftp.tools.bsc.es/wxparaver/wxparaver-4.6.3-src.tar.bz2"
+    url = "https://ftp.tools.bsc.es/wxparaver/wxparaver-4.9.2-src.tar.bz2"
 
     version('4.9.2',     sha256='83289584040bcedf8cab1b2ae3545191c8bdef0e11ab62b06e54cbf111f2127a')
     version('4.9.1',     sha256='e89fdf563d1fc73ed0018cf0e25b458b6617ec33325ed3fdbf06397c556f3a8e')

--- a/var/spack/repos/builtin/packages/wxparaver/package.py
+++ b/var/spack/repos/builtin/packages/wxparaver/package.py
@@ -7,7 +7,7 @@ from spack import *
 import os
 
 
-class Paraver(AutotoolsPackage):
+class Wxparaver(AutotoolsPackage):
     """"A very powerful performance visualization and analysis tool
         based on traces that can be used to analyse any information that
         is expressed on its input trace format.  Traces for parallel MPI,
@@ -17,16 +17,16 @@ class Paraver(AutotoolsPackage):
 
     # NOTE: Paraver provides only latest version for download.
     #       Don't keep/add older versions.
-    version('4.9.2',     sha256='83289584040bcedf8cab1b2ae3545191c8bdef0e11ab62b06e54cbf111f2127a', deprecated=True)
-    version('4.9.1',     sha256='e89fdf563d1fc73ed0018cf0e25b458b6617ec33325ed3fdbf06397c556f3a8e', deprecated=True)
-    version('4.9.0',     sha256='1f9964d7987032d01a354327845bf53ae369be5d8acf7d4e85bec81699a6ddf6', deprecated=True)
-    version('4.8.2',     sha256='0d22ec362e4798d7ed21b15b607859e9bda9579e3d5b23af3812c1e32ccc192d', deprecated=True)
-    version('4.8.1',     sha256='d03b04254bd3015d61374b95aeda6888f593be67286c5268849623baa2ae6e2e', deprecated=True)
-    version('4.8.0',     sha256='780af8fff7cb40d1325260fb9f79210f6676f07357bc9b95b1b838862f2d1e5b', deprecated=True)
-    version('4.7.2',     sha256='90107797d6af6fc3ebd9505445bb518d673edecbe5d08d1b7af01695d53241ae', deprecated=True)
-    version('4.7.1',     sha256='8cbec0c5e0f8a849820f6682cbb0920ea234bb7f20d1483e38ea5d0b0ee045cd', deprecated=True)
-    version('4.7.0',     sha256='81e02bcc1853455b13435172a4336ba85ba05020887d322c9678c97def03d76f', deprecated=True)
-    version('4.6.3',     sha256='ac6025eec5419e1060967eab71dfd123e585be5b5f3ac3241085895dbeca255a', deprecated=True)
+    version('4.9.2',     sha256='83289584040bcedf8cab1b2ae3545191c8bdef0e11ab62b06e54cbf111f2127a')
+    version('4.9.1',     sha256='e89fdf563d1fc73ed0018cf0e25b458b6617ec33325ed3fdbf06397c556f3a8e')
+    version('4.9.0',     sha256='1f9964d7987032d01a354327845bf53ae369be5d8acf7d4e85bec81699a6ddf6')
+    version('4.8.2',     sha256='0d22ec362e4798d7ed21b15b607859e9bda9579e3d5b23af3812c1e32ccc192d')
+    version('4.8.1',     sha256='d03b04254bd3015d61374b95aeda6888f593be67286c5268849623baa2ae6e2e')
+    version('4.8.0',     sha256='780af8fff7cb40d1325260fb9f79210f6676f07357bc9b95b1b838862f2d1e5b')
+    version('4.7.2',     sha256='90107797d6af6fc3ebd9505445bb518d673edecbe5d08d1b7af01695d53241ae')
+    version('4.7.1',     sha256='8cbec0c5e0f8a849820f6682cbb0920ea234bb7f20d1483e38ea5d0b0ee045cd')
+    version('4.7.0',     sha256='81e02bcc1853455b13435172a4336ba85ba05020887d322c9678c97def03d76f')
+    version('4.6.3',     sha256='ac6025eec5419e1060967eab71dfd123e585be5b5f3ac3241085895dbeca255a')
     version('4.6.2',     sha256='74b85bf9e6570001d372b376b58643526e349b1d2f1e7633ca38bb0800ecf929', deprecated=True)
 
     depends_on('boost@1.36: +serialization')


### PR DESCRIPTION
Installation is working fine on my system for all versions except for v4.6.2 that does not have a global configure file. If someone could help me to write a specific configuration for this version bypassing basic verification of AutotoolsPackage. I already tried several things without success. Here is the current error:
```
/home/hyviquel/Workspace/repos/spack/lib/spack/spack/build_systems/autotools.py:300, in set_configure_or_die:
        297        """
        298        # Check if a configure script is there. If not raise a RuntimeError.
        299        if not os.path.exists(self.configure_abs_path):
  >>    300            msg = 'configure script not found in {0}'
        301            raise RuntimeError(msg.format(self.configure_directory))
        302
        303        # Monkey-patch the configure script in the corresponding module
```

An alternative would be to remove this version from the list.

Closes #13643