### PR TITLE
libdrm: fix one error, mark another conflict

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-import sys
 
 
 class Libdrm(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -22,13 +22,16 @@ class Libdrm(AutotoolsPackage):
     version('2.4.33',  sha256='bd2a8fecf28616f2157ca33ede691c139cc294ed2d0c4244b62ca7d22e98e5a4')
 
     depends_on('pkgconfig', type='build')
-    depends_on('libpciaccess@0.10:', when=(sys.platform != 'darwin'))
+    depends_on('libpciaccess@0.10:')
     depends_on('libpthread-stubs')
 
     def configure_args(self):
         args = []
         args.append('--enable-static')
-        args.append('LIBS=-lrt')  # This fixes a bug with `make check`
+        if self.version <= Version('2.4.70'):
+            # Needed to fix build for spack/spack#1740, but breaks newer
+            # builds/compilers
+            args.append('LIBS=-lrt')
         if self.spec.satisfies('%gcc@10.0.0:'):
             args.append('CFLAGS=-fcommon')
         return args

--- a/var/spack/repos/builtin/packages/libpciaccess/package.py
+++ b/var/spack/repos/builtin/packages/libpciaccess/package.py
@@ -31,6 +31,8 @@ class Libpciaccess(AutotoolsPackage, XorgPackage):
     # libpciaccess built by gcc should be usable by PGI builds.
     conflicts('%pgi')
 
+    conflicts('platform=darwin')
+
     def configure_args(self):
         config_args = []
 


### PR DESCRIPTION
Trying to help @stognini build ROOT with spack, concretizing with +x+opengl requires `gl2ps` which requires `libdrm`  which requires `libpciaccess`.  `libdrm` failed due to a missing `-ldl` causing the C compiler check to fail, then failed due to missing libpciaccess, which completely fails on macOS.

This change will at least  move errors into concretization instead of build-time.