### PR TITLE
netcdf-c@4.8.0 needs hdf5 api=v18 when built against hdf5@1.12.0

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -103,7 +103,7 @@ class NetcdfC(AutotoolsPackage):
     # High-level API of HDF5 1.8.9 or later is required for netCDF-4 support:
     # http://www.unidata.ucar.edu/software/netcdf/docs/getting_and_building_netcdf.html
     depends_on('hdf5@1.8.9:+hl api=v18', when='@4.8.0:')
-    depends_on('hdf5@1.8.9:+hl', when='@:4.8.0')
+    depends_on('hdf5@1.8.9:+hl')
 
     # Starting version 4.4.0, it became possible to disable parallel I/O even
     # if HDF5 supports it. For previous versions of the library we need

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -102,7 +102,8 @@ class NetcdfC(AutotoolsPackage):
 
     # High-level API of HDF5 1.8.9 or later is required for netCDF-4 support:
     # http://www.unidata.ucar.edu/software/netcdf/docs/getting_and_building_netcdf.html
-    depends_on('hdf5@1.8.9:+hl')
+    depends_on('hdf5@1.8.9:+hl api=v18', when='@4.8.0:')
+    depends_on('hdf5@1.8.9:+hl', when='@:4.8.0')
 
     # Starting version 4.4.0, it became possible to disable parallel I/O even
     # if HDF5 supports it. For previous versions of the library we need


### PR DESCRIPTION
`netcdf-c@4.8.0` needs `hdf5 api=v18` when built against `hdf5@1.12.0`

Not sure this is the best way to express the requirement. Please let me know if you think this should be handled differently.

Fixes https://github.com/spack/spack/issues/24312

@skosukhin @WardF @gsjaardema