### PR TITLE
openpmd-api: conflicts w hdf5@1.12 api=v110, v16, v18

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -61,9 +61,9 @@ class OpenpmdApi(CMakePackage):
     depends_on('py-mpi4py@2.1.0:', when='+python +mpi', type=['test', 'run'])
     depends_on('python@3.6:', when='+python', type=['link', 'test', 'run'])
 
-    conflicts('^hdf5 api=v18')
-    conflicts('^hdf5 api=v16')
-    conflicts('^hdf5 api=v110')
+    conflicts('^hdf5 api=v16', msg='openPMD-api required HDF5 APIs for 1.8+')
+    conflicts('^hdf5@1.12: api=v18')  # compat macro is weird
+    conflicts('^hdf5@1.12: api=v110')  # compat macro is weird
 
     extends('python', when='+python')
 

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -61,6 +61,10 @@ class OpenpmdApi(CMakePackage):
     depends_on('py-mpi4py@2.1.0:', when='+python +mpi', type=['test', 'run'])
     depends_on('python@3.6:', when='+python', type=['link', 'test', 'run'])
 
+    conflicts('^hdf5 api=v18')
+    conflicts('^hdf5 api=v16')
+    conflicts('^hdf5 api=v110')
+
     extends('python', when='+python')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -61,9 +61,11 @@ class OpenpmdApi(CMakePackage):
     depends_on('py-mpi4py@2.1.0:', when='+python +mpi', type=['test', 'run'])
     depends_on('python@3.6:', when='+python', type=['link', 'test', 'run'])
 
-    conflicts('^hdf5 api=v16', msg='openPMD-api required HDF5 APIs for 1.8+')
-    conflicts('^hdf5@1.12: api=v18')  # compat macro is weird
-    conflicts('^hdf5@1.12: api=v110')  # compat macro is weird
+    conflicts('^hdf5 api=v16', msg='openPMD-api requires HDF5 APIs for 1.8+')
+    # compatibility macros are unclear:
+    # https://github.com/HDFGroup/hdf5/issues/754
+    conflicts('^hdf5@1.12: api=v18')
+    conflicts('^hdf5@1.12: api=v110')
 
     extends('python', when='+python')
 


### PR DESCRIPTION
`openpmd-api` versions
* `@0.13.4`
* `@0.13.0`
* `@0.12.0`

won't build against `hdf5@1.12.0` with variants
* `api=v18`
* `api=v16`
* `api=v110`

I did not try these api variants with older hdf5 versions -- I'm assuming (based on minimal knowledge) that older hdf5 but with same `api=` variants will have the same issue ?

@ax3l 