### PR TITLE
e4s ci: specs: add datatransferkit

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -220,6 +220,7 @@ spack:
     - conduit
     - darshan-runtime
     - darshan-util
+    - datatransferkit
     - dyninst
     - faodel
     - flecsi@1.4.2 +external_cinch


### PR DESCRIPTION
E4S CI Spack environment: add `datatransferkit` to spec list