### PR TITLE
QNNPACK: add py-torch submodule commits

### DIFF
--- a/var/spack/repos/builtin/packages/qnnpack/package.py
+++ b/var/spack/repos/builtin/packages/qnnpack/package.py
@@ -16,7 +16,7 @@ class Qnnpack(CMakePackage):
     git      = "https://github.com/pytorch/QNNPACK.git"
 
     version('master', branch='master')
-    version('2019-08-28', commit='7d2a4e9931a82adc3814275b6219a03e24e36b4c')  # py-torch@1.3:1.8
+    version('2019-08-28', commit='7d2a4e9931a82adc3814275b6219a03e24e36b4c')  # py-torch@1.3:1.9
     version('2018-12-27', commit='6c62fddc6d15602be27e9e4cbb9e985151d2fa82')  # py-torch@1.2
     version('2018-12-04', commit='ef05e87cef6b8e719989ce875b5e1c9fdb304c05')  # py-torch@1.0:1.1
 

--- a/var/spack/repos/builtin/packages/qnnpack/package.py
+++ b/var/spack/repos/builtin/packages/qnnpack/package.py
@@ -22,6 +22,7 @@ class Qnnpack(CMakePackage):
 
     depends_on('cmake@3.5:', type='build')
     depends_on('ninja', type='build')
+    depends_on('python', type='build')
 
     resource(
         name='cpuinfo',
@@ -72,18 +73,18 @@ class Qnnpack(CMakePackage):
 
     def cmake_args(self):
         return [
-            '-DCPUINFO_SOURCE_DIR={0}'.format(
-                join_path(self.stage.source_path, 'deps/cpuinfo')),
-            '-DFP16_SOURCE_DIR={0}'.format(
-                join_path(self.stage.source_path, 'deps/fp16')),
-            '-DFXDIV_SOURCE_DIR={0}'.format(
-                join_path(self.stage.source_path, 'deps/fxdiv')),
-            '-DPSIMD_SOURCE_DIR={0}'.format(
-                join_path(self.stage.source_path, 'deps/psimd')),
-            '-DPTHREADPOOL_SOURCE_DIR={0}'.format(
-                join_path(self.stage.source_path, 'deps/pthreadpool')),
-            '-DGOOGLEBENCHMARK_SOURCE_DIR={0}'.format(
-                join_path(self.stage.source_path, 'deps/googlebenchmark')),
-            '-DGOOGLETEST_SOURCE_DIR={0}'.format(
-                join_path(self.stage.source_path, 'deps/googletest')),
+            self.define('CPUINFO_SOURCE_DIR',
+                        join_path(self.stage.source_path, 'deps', 'cpuinfo')),
+            self.define('FP16_SOURCE_DIR',
+                        join_path(self.stage.source_path, 'deps', 'fp16')),
+            self.define('FXDIV_SOURCE_DIR',
+                        join_path(self.stage.source_path, 'deps', 'fxdiv')),
+            self.define('PSIMD_SOURCE_DIR',
+                        join_path(self.stage.source_path, 'deps', 'psimd')),
+            self.define('PTHREADPOOL_SOURCE_DIR',
+                        join_path(self.stage.source_path, 'deps', 'pthreadpool')),
+            self.define('GOOGLEBENCHMARK_SOURCE_DIR',
+                        join_path(self.stage.source_path, 'deps', 'googlebenchmark')),
+            self.define('GOOGLETEST_SOURCE_DIR',
+                        join_path(self.stage.source_path, 'deps', 'googletest')),
         ]

--- a/var/spack/repos/builtin/packages/qnnpack/package.py
+++ b/var/spack/repos/builtin/packages/qnnpack/package.py
@@ -21,6 +21,7 @@ class Qnnpack(CMakePackage):
     version('2018-12-04', commit='ef05e87cef6b8e719989ce875b5e1c9fdb304c05')  # py-torch@1.0:1.1
 
     depends_on('cmake@3.5:', type='build')
+    depends_on('ninja', type='build')
 
     resource(
         name='cpuinfo',
@@ -66,6 +67,8 @@ class Qnnpack(CMakePackage):
         destination='deps',
         placement='pthreadpool'
     )
+
+    generator = 'Ninja'
 
     def cmake_args(self):
         return [

--- a/var/spack/repos/builtin/packages/qnnpack/package.py
+++ b/var/spack/repos/builtin/packages/qnnpack/package.py
@@ -16,6 +16,9 @@ class Qnnpack(CMakePackage):
     git      = "https://github.com/pytorch/QNNPACK.git"
 
     version('master', branch='master')
+    version('2019-08-28', commit='7d2a4e9931a82adc3814275b6219a03e24e36b4c')  # py-torch@1.3:1.8
+    version('2018-12-27', commit='6c62fddc6d15602be27e9e4cbb9e985151d2fa82')  # py-torch@1.2
+    version('2018-12-04', commit='ef05e87cef6b8e719989ce875b5e1c9fdb304c05')  # py-torch@1.0:1.1
 
     depends_on('cmake@3.5:', type='build')
 


### PR DESCRIPTION
Successfully builds and passes all unit tests on Ubuntu 18.04 with GCC 7.5.0 and on macOS 10.15.7 with Apple Clang 12.0.0.