### PR TITLE
TensorPipe: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/tensorpipe/package.py
+++ b/var/spack/repos/builtin/packages/tensorpipe/package.py
@@ -21,6 +21,6 @@ class Tensorpipe(CMakePackage):
 
     depends_on('cmake@3.5:', type='build')
     depends_on('ninja', type='build')
-    depends_on('libuv')
+    depends_on('libuv@1.26:')
 
     generator = 'Ninja'

--- a/var/spack/repos/builtin/packages/tensorpipe/package.py
+++ b/var/spack/repos/builtin/packages/tensorpipe/package.py
@@ -21,5 +21,6 @@ class Tensorpipe(CMakePackage):
 
     depends_on('cmake@3.5:', type='build')
     depends_on('ninja', type='build')
+    depends_on('libuv')
 
     generator = 'Ninja'

--- a/var/spack/repos/builtin/packages/tensorpipe/package.py
+++ b/var/spack/repos/builtin/packages/tensorpipe/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Tensorpipe(CMakePackage):
+    """A tensor-aware point-to-point communication primitive for machine learning."""
+
+    homepage = "https://github.com/pytorch/tensorpipe"
+    git      = "https://github.com/pytorch/tensorpipe.git"
+
+    version('master', branch='master', submodules=True)
+    version('2021-05-13', commit='05e4c890d4bd5f8ac9a4ba8f3c21e2eba3f66eda', submodules=True)  # py-torch@1.9
+    version('2021-03-04', commit='369e855ea82fc71f45cfab277863b86747202c92', submodules=True)  # py-torch@1.8.1
+    version('2021-02-09', commit='05467ba9bc164f06722986b615c4495901747c58', submodules=True)  # py-torch@1.8.0
+    version('2020-09-28', commit='95ff9319161fcdb3c674d2bb63fac3e94095b343', submodules=True)  # py-torch@1.7
+    version('2020-06-26', commit='3b8089c9c6717038cff44b70b881d0ad6c93e679', submodules=True)  # py-torch@1.6
+
+    depends_on('cmake@3.5:', type='build')
+    depends_on('ninja', type='build')
+
+    generator = 'Ninja'


### PR DESCRIPTION
Successfully builds on Ubuntu 180.04 with GCC 7.5.0 and on macOS 10.15.7 with Apple Clang 12.0.0.