### PR TITLE
[z3]: Update package to use CMake build system (#24336)

### DIFF
--- a/var/spack/repos/builtin/packages/z3/package.py
+++ b/var/spack/repos/builtin/packages/z3/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class Z3(MakefilePackage):
+class Z3(CMakePackage):
     """Z3 is a theorem prover from Microsoft Research.
     It is licensed under the MIT license."""
 
@@ -18,37 +18,26 @@ class Z3(MakefilePackage):
     version('4.8.8', sha256='6962facdcdea287c5eeb1583debe33ee23043144d0e5308344e6a8ee4503bcff')
     version('4.8.7', sha256='8c1c49a1eccf5d8b952dadadba3552b0eac67482b8a29eaad62aa7343a0732c3')
     version('4.5.0', sha256='aeae1d239c5e06ac183be7dd853775b84698db1265cb2258e5918a28372d4a0c')
-    version('4.4.1', sha256='50967cca12c5c6e1612d0ccf8b6ebf5f99840a783d6cf5216336a2b59c37c0ce')
-    version('4.4.0', sha256='65b72f9eb0af50949e504b47080fb3fc95f11c435633041d9a534473f3142cba')
-
-    phases = ['bootstrap', 'build', 'install']
 
     variant('python', default=True, description='Enable python binding')
-    depends_on('python', type=('build', 'run'))
+    depends_on('python', type='build', when='~python')
+    depends_on('python', type=('build', 'run'), when='+python')
     depends_on('py-setuptools', type=('run'), when='+python')
     extends('python', when='+python')
 
+    variant('gmp', default=False, description='GNU multiple precision library support')
+    depends_on('cmake@3.4:', type='build')
+    depends_on('gmp', when='+gmp', type=('build', 'link'))
+
     # Referenced: https://github.com/Z3Prover/z3/issues/1016
-    patch('fix_1016_1.patch', when='@:4.4.1')
     patch('fix_1016_2.patch', when='@4.5.0')
 
     build_directory = 'build'
 
-    def configure_args(self):
-        spec = self.spec
-
-        args = []
-
-        if spec.satisfies('+python'):
-            args.append('--python')
-            args.append(
-                '--pypkgdir=%s' % join_path(
-                    prefix.lib,
-                    'python%s' % spec['python'].version.up_to(2),
-                    'site-packages'))
-
+    def cmake_args(self):
+        args = [
+            self.define_from_variant('Z3_USE_LIB_GMP', 'gmp'),
+            self.define_from_variant('Z3_BUILD_PYTHON_BINDINGS', 'python'),
+            self.define_from_variant('Z3_INSTALL_PYTHON_BINDINGS', 'python')
+        ]
         return args
-
-    def bootstrap(self, spec, prefix):
-        options = ['--prefix={0}'.format(prefix)] + self.configure_args()
-        spec['python'].command('scripts/mk_make.py', *options)


### PR DESCRIPTION
fixes #24336

The Z3 solver provides a Z3Config.cmake file when built using the CMake build
system. This submission changes the package build system to inherit the
CMakePackage type. In addition to changing the build system, this submission:

- Adds the GMP variant
- Removes v4.4.0 and v4.4.1 as CMake was implemented starting with v4.5.0