### PR TITLE
openmolcas: new version and adding in mpi variant

### DIFF
--- a/var/spack/repos/builtin/packages/openmolcas/package.py
+++ b/var/spack/repos/builtin/packages/openmolcas/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import os
 
 
 class Openmolcas(CMakePackage):
@@ -14,7 +15,10 @@ class Openmolcas(CMakePackage):
     homepage = "https://gitlab.com/Molcas/OpenMolcas"
     url      = "https://github.com/Molcas/OpenMolcas/archive/v19.11.tar.gz"
 
+    version('21.02', sha256='d0b9731a011562ff4740c0e67e48d9af74bf2a266601a38b37640f72190519ca')
     version('19.11', sha256='8ebd1dcce98fc3f554f96e54e34f1e8ad566c601196ee68153763b6c0a04c7b9')
+
+    variant('mpi', default=False, description='Build with mpi support.')
 
     depends_on('hdf5')
     depends_on('lapack')
@@ -22,6 +26,8 @@ class Openmolcas(CMakePackage):
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-pyparsing', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
+    depends_on('mpi', when='+mpi')
+    depends_on('globalarrays', when='+mpi')
 
     patch('CMakeLists.txt.patch', when='target=aarch64:')
 
@@ -30,10 +36,23 @@ class Openmolcas(CMakePackage):
 
     def setup_run_environment(self, env):
         env.set('MOLCAS', self.prefix)
+        if self.spec.version >= Version('21.02'):
+            env.append_path('PATH', self.prefix)
 
     def cmake_args(self):
-        return [
+        args = [
             '-DLINALG=OpenBLAS',
             '-DOPENBLASROOT=%s' % self.spec['openblas'].prefix,
-            '-DPYTHON_EXECUTABLE=%s' % self.spec['python'].command.path,
+            '-DPYTHON_EXECUTABLE=%s' % self.spec['python'].command.path
         ]
+        if '+mpi' in self.spec:
+            mpi_args = [
+                '-DMPI=ON', '-DGA=ON',
+                '-DGA_INCLUDE_PATH=%s' % self.spec['globalarrays'].prefix.include,
+                '-DLIBGA=%s' %
+                os.path.join(self.spec['globalarrays'].prefix.lib, 'libga.so'),
+                '-DLIBARMCI=%s' %
+                os.path.join(self.spec['globalarrays'].prefix.lib, 'libarmci.so')
+            ]
+            args.extend(mpi_args)
+        return args


### PR DESCRIPTION
This PR updates openmolcas to the latest release. It also adds in an mpi variant that adds mpi support.