### PR TITLE
Adding save of build times on install

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -71,6 +71,9 @@ _spack_build_logfile = 'spack-build-out.txt'
 # Filename for the Spack build/install environment file.
 _spack_build_envfile = 'spack-build-env.txt'
 
+# Filename of json with total build and phase times (seconds)
+_spack_times_log = 'install_times.json'
+
 # Filename for the Spack configure args file.
 _spack_configure_argsfile = 'spack-configure-args.txt'
 
@@ -699,7 +702,6 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # Set up timing variables
         self._fetch_time = 0.0
-        self._total_time = 0.0
 
         if self.is_extension:
             spack.repo.get(self.extendee_spec)._check_extendable()
@@ -1091,6 +1093,11 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     def configure_args_path(self):
         """Return the configure args file path associated with staging."""
         return os.path.join(self.stage.path, _spack_configure_argsfile)
+
+    @property
+    def times_log_path(self):
+        """Return the times log json file."""
+        return os.path.join(self.metadata_dir, _spack_times_log)
 
     @property
     def install_configure_args_path(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -10,7 +10,6 @@ import itertools
 import os
 import pprint
 import sys
-import time
 import types
 import warnings
 from six import string_types
@@ -43,33 +42,12 @@ import spack.repo
 import spack.bootstrap
 import spack.variant
 import spack.version
-
+import spack.util.timer
 
 if sys.version_info >= (3, 3):
     from collections.abc import Sequence  # novm
 else:
     from collections import Sequence
-
-
-class Timer(object):
-    """Simple timer for timing phases of a solve"""
-    def __init__(self):
-        self.start = time.time()
-        self.last = self.start
-        self.phases = {}
-
-    def phase(self, name):
-        last = self.last
-        now = time.time()
-        self.phases[name] = now - last
-        self.last = now
-
-    def write(self, out=sys.stdout):
-        now = time.time()
-        out.write("Time:\n")
-        for phase, t in self.phases.items():
-            out.write("    %-15s%.4f\n" % (phase + ":", t))
-        out.write("Total: %.4f\n" % (now - self.start))
 
 
 def issequence(obj):
@@ -331,7 +309,7 @@ class PyclingoDriver(object):
             self, solver_setup, specs, dump=None, nmodels=0,
             timers=False, stats=False, tests=False
     ):
-        timer = Timer()
+        timer = spack.util.timer.Timer()
 
         # Initialize the control object for the solver
         self.control = clingo.Control()
@@ -428,7 +406,7 @@ class PyclingoDriver(object):
                 result.cores.append(core_symbols)
 
         if timers:
-            timer.write()
+            timer.write_tty()
             print()
         if stats:
             print("Statistics:")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -201,26 +201,28 @@ def test_install_overwrite(
 
     install('libdwarf')
 
+    # Ignore manifest and install times
     manifest = os.path.join(spec.prefix, spack.store.layout.metadata_dir,
                             spack.store.layout.manifest_file_name)
+    ignores = [manifest, spec.package.times_log_path]
 
     assert os.path.exists(spec.prefix)
-    expected_md5 = fs.hash_directory(spec.prefix, ignore=[manifest])
+    expected_md5 = fs.hash_directory(spec.prefix, ignore=ignores)
 
     # Modify the first installation to be sure the content is not the same
     # as the one after we reinstalled
     with open(os.path.join(spec.prefix, 'only_in_old'), 'w') as f:
         f.write('This content is here to differentiate installations.')
 
-    bad_md5 = fs.hash_directory(spec.prefix, ignore=[manifest])
+    bad_md5 = fs.hash_directory(spec.prefix, ignore=ignores)
 
     assert bad_md5 != expected_md5
 
     install('--overwrite', '-y', 'libdwarf')
 
     assert os.path.exists(spec.prefix)
-    assert fs.hash_directory(spec.prefix, ignore=[manifest]) == expected_md5
-    assert fs.hash_directory(spec.prefix, ignore=[manifest]) != bad_md5
+    assert fs.hash_directory(spec.prefix, ignore=ignores) == expected_md5
+    assert fs.hash_directory(spec.prefix, ignore=ignores) != bad_md5
 
 
 def test_install_overwrite_not_installed(
@@ -254,16 +256,19 @@ def test_install_overwrite_multiple(
                                spack.store.layout.metadata_dir,
                                spack.store.layout.manifest_file_name)
 
+    ld_ignores = [ld_manifest, libdwarf.package.times_log_path]
+
     assert os.path.exists(libdwarf.prefix)
     expected_libdwarf_md5 = fs.hash_directory(libdwarf.prefix,
-                                              ignore=[ld_manifest])
+                                              ignore=ld_ignores)
 
     cm_manifest = os.path.join(cmake.prefix,
                                spack.store.layout.metadata_dir,
                                spack.store.layout.manifest_file_name)
 
+    cm_ignores = [cm_manifest, cmake.package.times_log_path]
     assert os.path.exists(cmake.prefix)
-    expected_cmake_md5 = fs.hash_directory(cmake.prefix, ignore=[cm_manifest])
+    expected_cmake_md5 = fs.hash_directory(cmake.prefix, ignore=cm_ignores)
 
     # Modify the first installation to be sure the content is not the same
     # as the one after we reinstalled
@@ -272,8 +277,8 @@ def test_install_overwrite_multiple(
     with open(os.path.join(cmake.prefix, 'only_in_old'), 'w') as f:
         f.write('This content is here to differentiate installations.')
 
-    bad_libdwarf_md5 = fs.hash_directory(libdwarf.prefix, ignore=[ld_manifest])
-    bad_cmake_md5 = fs.hash_directory(cmake.prefix, ignore=[cm_manifest])
+    bad_libdwarf_md5 = fs.hash_directory(libdwarf.prefix, ignore=ld_ignores)
+    bad_cmake_md5 = fs.hash_directory(cmake.prefix, ignore=cm_ignores)
 
     assert bad_libdwarf_md5 != expected_libdwarf_md5
     assert bad_cmake_md5 != expected_cmake_md5
@@ -282,8 +287,8 @@ def test_install_overwrite_multiple(
     assert os.path.exists(libdwarf.prefix)
     assert os.path.exists(cmake.prefix)
 
-    ld_hash = fs.hash_directory(libdwarf.prefix, ignore=[ld_manifest])
-    cm_hash = fs.hash_directory(cmake.prefix, ignore=[cm_manifest])
+    ld_hash = fs.hash_directory(libdwarf.prefix, ignore=ld_ignores)
+    cm_hash = fs.hash_directory(cmake.prefix, ignore=cm_ignores)
     assert ld_hash == expected_libdwarf_md5
     assert cm_hash == expected_cmake_md5
     assert ld_hash != bad_libdwarf_md5

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -15,6 +15,7 @@ import spack.patch
 import spack.repo
 import spack.store
 from spack.spec import Spec
+import spack.util.spack_json as sjson
 from spack.package import (_spack_build_envfile, _spack_build_logfile,
                            _spack_configure_argsfile)
 
@@ -159,6 +160,32 @@ def test_install_dependency_symlinks_pkg(
     # Ensure dependency directory exists after the installation.
     dependency_dir = os.path.join(pkg.prefix, 'dependency-install')
     assert os.path.isdir(dependency_dir)
+
+
+def test_install_times(
+        install_mockery, mock_fetch, mutable_mock_repo):
+    """Test install times added."""
+    spec = Spec('dev-build-test-install-phases')
+    spec.concretize()
+    pkg = spec.package
+    pkg.do_install()
+
+    # Ensure dependency directory exists after the installation.
+    install_times = os.path.join(pkg.prefix, ".spack", 'install_times.json')
+    assert os.path.isfile(install_times)
+
+    # Ensure the phases are included
+    with open(install_times, 'r') as timefile:
+        times = sjson.load(timefile.read())
+
+    # The order should be maintained
+    phases = [x['name'] for x in times['phases']]
+    total = sum([x['seconds'] for x in times['phases']])
+    for name in ['one', 'two', 'three', 'install']:
+        assert name in phases
+
+    # Give a generous difference threshold
+    assert abs(total - times['total']['seconds']) < 5
 
 
 def test_flatten_deps(

--- a/lib/spack/spack/util/timer.py
+++ b/lib/spack/spack/util/timer.py
@@ -1,0 +1,60 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Debug signal handler: prints a stack trace and enters interpreter.
+
+``register_interrupt_handler()`` enables a ctrl-C handler that prints
+a stack trace and drops the user into an interpreter.
+
+"""
+import spack.util.spack_json as sjson
+import time
+import sys
+
+
+class Timer(object):
+    """
+    Simple timer for timing phases of a solve or install
+    """
+    def __init__(self):
+        self.start = time.time()
+        self.last = self.start
+        self.phases = {}
+        self.end = None
+
+    def phase(self, name):
+        last = self.last
+        now = time.time()
+        self.phases[name] = now - last
+        self.last = now
+
+    @property
+    def total(self):
+        """Return the total time
+        """
+        if self.end:
+            return self.end - self.start
+        return time.time() - self.start
+
+    def stop(self):
+        """
+        Stop the timer to record a total time, if desired.
+        """
+        self.end = time.time()
+
+    def write_json(self, out=sys.stdout):
+        """
+        Write a json object with times to file
+        """
+        phases = [{"name": p, "seconds": s} for p, s in self.phases.items()]
+        times = {"phases": phases, "total": {"seconds": self.total}}
+        out.write(sjson.dump(times))
+
+    def write_tty(self, out=sys.stdout):
+        now = time.time()
+        out.write("Time:\n")
+        for phase, t in self.phases.items():
+            out.write("    %-15s%.4f\n" % (phase + ":", t))
+        out.write("Total: %.4f\n" % (now - self.start))

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from time import sleep
+
+
+class DevBuildTestInstallPhases(Package):
+    homepage = "example.com"
+    url = "fake.com"
+
+    version('0.0.0', sha256='0123456789abcdefgh')
+
+    phases = ['one', 'two', 'three', 'install']
+
+    def one(self, spec, prefix):
+        sleep(1)
+        print("One locomoco")
+
+    def two(self, spec, prefix):
+        sleep(2)
+        print("Two locomoco")
+
+    def three(self, spec, prefix):
+        sleep(3)
+        print("Three locomoco")
+
+    def install(self, spec, prefix):
+        print("install")


### PR DESCRIPTION
Here we are adding an install_times.json into the spack install metadata folder. We record a total global time, along with the times for each phase. The type of phase or install start / end is included (e.g., build or fail). This is implemented by way of hooks, and since we are certain to always have a start/end for each phase and build, I think it's safe to be using global variables in the hook timing.py file to be able to easily record results into a single data structure over time.

here we see the install_times.json file in the build metadata folder:

```bash
$ ls opt/spack/linux-ubuntu20.04-skylake/gcc-9.3.0/python-3.8.10-5nmbzkki6zhnsk2p3ycuinh3al5fmeto/.spack/
archived-files           *install_times.json*                 spack-build-02-configure-out.txt  spack-build-env.txt       spec.yaml
install_environment.json  repos                              spack-build-03-build-out.txt      spack-build-out.txt
install_manifest.json     spack-build-01-autoreconf-out.txt  spack-build-04-install-out.txt    spack-configure-args.txt
```
And the content

```bash
$ cat install_times.json 
{
  "phases": [
    {
      "name": "autoreconf",
      "seconds": 0.013715267181396484
    },
    {
      "name": "configure",
      "seconds": 6.446059465408325
    },
    {
      "name": "build",
      "seconds": 2.842390775680542
    },
    {
      "name": "install",
      "seconds": 3.0660362243652344
    }
  ],
  "total": {
    "seconds": 12.69503927230835
  }
}
```
If there is a time recorded from an error, the labels switch to say that. Times will obviously be different between success/error and we should record that. 

The sum of the phases does not equal the total time (it's about three seconds shy) because there are steps in between the start of the install and running any particular phase (logging, combining phase logs, etc.). But I think we should record the total time of build from the start to stop hooks of the install and not disclude these times.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>