### PR TITLE
Drastically improve YamlFilesystemView file removal performance via batching 

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -393,11 +393,15 @@ class PythonPackage(PackageBase):
                 self.spec
             )
         )
+
+        to_remove = []
         for src, dst in merge_map.items():
             if ignore_namespace and namespace_init(dst):
                 continue
 
             if global_view or not path_contains_subdirectory(src, bin_dir):
-                view.remove_file(src, dst)
+                to_remove.append(dst)
             else:
                 os.remove(dst)
+
+        view.remove_files(to_remove)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -467,7 +467,7 @@ class YamlFilesystemView(FilesystemView):
             if not os.path.lexists(file):
                 tty.warn("Tried to remove %s which does not exist" % file)
                 continue
-                
+
             # remove if file is not owned by any other package in the view
             # This will only be false if two packages are merged into a prefix
             # and have a conflicting file

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -464,10 +464,6 @@ class YamlFilesystemView(FilesystemView):
         specs = self.get_all_specs()
 
         for file in files:
-            if not os.path.lexists(file):
-                tty.warn("Tried to remove %s which does not exist" % file)
-                continue
-
             # remove if file is not owned by any other package in the view
             # This will only be false if two packages are merged into a prefix
             # and have a conflicting file
@@ -477,7 +473,10 @@ class YamlFilesystemView(FilesystemView):
             # metadata directory.
             if len([s for s in specs if needs_file(s, file)]) <= 1:
                 tty.debug("Removing file " + file)
-                os.remove(file)
+                try:
+                    os.remove(file)
+                except FileNotFoundError:
+                    tty.warn("Tried to remove %s which does not exist" % file)
 
     def check_added(self, spec):
         assert spec.concrete

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -464,6 +464,10 @@ class YamlFilesystemView(FilesystemView):
         specs = self.get_all_specs()
 
         for file in files:
+            if not os.path.lexists(file):
+                tty.warn("Tried to remove %s which does not exist" % file)
+                continue
+                
             # remove if file is not owned by any other package in the view
             # This will only be false if two packages are merged into a prefix
             # and have a conflicting file
@@ -473,10 +477,7 @@ class YamlFilesystemView(FilesystemView):
             # metadata directory.
             if len([s for s in specs if needs_file(s, file)]) <= 1:
                 tty.debug("Removing file " + file)
-                try:
-                    os.remove(file)
-                except FileNotFoundError:
-                    tty.warn("Tried to remove %s which does not exist" % file)
+                os.remove(file)
 
     def check_added(self, spec):
         assert spec.concrete

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -641,6 +641,7 @@ def _profile_wrapper(command, parser, args, unknown_args):
 
     finally:
         pr.disable()
+        pr.dump_stats('spack.profile')
 
         # print out profile stats.
         stats = pstats.Stats(pr)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -641,7 +641,6 @@ def _profile_wrapper(command, parser, args, unknown_args):
 
     finally:
         pr.disable()
-        pr.dump_stats('spack.profile')
 
         # print out profile stats.
         stats = pstats.Stats(pr)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -469,8 +469,7 @@ class PackageViewMixin(object):
         example if two packages include the same file, it should only be
         removed when both packages are removed.
         """
-        for src, dst in merge_map.items():
-            view.remove_file(src, dst)
+        view.remove_files(merge_map.values())
 
 
 def test_log_pathname(test_stage, spec):


### PR DESCRIPTION
The `YamlFilesystemView.remove_file` routine has to check if the file is owned by multiple packages, so it doesn't  remove necessary files. This is done by the `YamlFilesystemView.get_all_specs` routine, which walks the entire package tree. With large numbers of packages on shared file systems, this can take O(seconds) time per file tree traversal, which adds up extremely quickly. For example, a single deactivate of a largish python package in our software stack on GPFS took approximately 40 minutes.

This patch replaces `remove_file` with a batch `remove_files` routine. This routine removes a list of files rather than a single file, requiring only one tree traversal per batch. In practice this means a package can be removed in O(seconds) time, rather than potentially hours, resulting in essentially a ~1000x speedup (ignoring initial deactivation logic, which takes about 2 minutes in our test setup).