### PR TITLE
FBGEMM: GCC 5+ and AVX2 required

### DIFF
--- a/var/spack/repos/builtin/packages/fbgemm/package.py
+++ b/var/spack/repos/builtin/packages/fbgemm/package.py
@@ -35,4 +35,12 @@ class Fbgemm(CMakePackage):
     depends_on('python', type='build')
     depends_on('llvm-openmp', when='%apple-clang')
 
+    conflicts('%gcc@:4', msg='FBGEMM requires GCC 5+')
+
     generator = 'Ninja'
+
+    @run_before('cmake')
+    def check_requirements(self):
+        if 'avx2' not in self.spec.target:
+            raise RuntimeError(
+                'FBGEMM requires a CPU with support for AVX2 instruction set or higher')


### PR DESCRIPTION
https://github.com/pytorch/FBGEMM#dependencies

@dskhudia