### PR TITLE
codecov: disable inline annotations on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,3 +14,8 @@ ignore:
   - share/spack/qa/.*
 
 comment: off
+
+# Inline codecov annotations make the code hard to read, and they add
+# annotations in files that seemingly have nothing to do with the PR.
+github_checks:
+    annotations: false


### PR DESCRIPTION
Inline codecov annotations make the code hard to read, and they add annotations in files that seemingly have nothing to do with the PR. Sadly, they add a whole lot of noise and not a lot of benefit over looking at the PR on codecov. We should just have people look at the coverage on codecov itself.

This PR adds the lines documented [here](https://docs.codecov.com/docs/github-checks#disabling-github-checks-patch-annotations-via-yaml) to `.codecov.yml`.