### PR TITLE
llvm: add patch for gcc11

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -188,7 +188,7 @@ class Llvm(CMakePackage, CudaPackage):
     conflicts("+flang", when="@:10.999")
 
     # Older LLVM do not build with newer GCC
-    conflicts("%gcc@11:", when="@:10")
+    conflicts("%gcc@11:", when="@:7")
     conflicts("%gcc@8:", when="@:5")
     conflicts("%gcc@:5.0.999", when="@8:")
 
@@ -221,6 +221,12 @@ class Llvm(CMakePackage, CudaPackage):
 
     # Github issue #4986
     patch("llvm_gcc7.patch", when="@4.0.0:4.0.1+lldb %gcc@7.0:")
+
+    # https://github.com/spack/spack/issues/24270
+    patch('https://src.fedoraproject.org/rpms/llvm10/raw/7ce7ebd066955ea95ba2b491c41fbc6e4ee0643a/f/llvm10-gcc11.patch',
+          sha256='958c64838c9d469be514eef195eca0f8c3ab069bc4b64a48fad59991c626bab8',
+          when='@8:10 %gcc@11:')
+
     # Backport from llvm master + additional fix
     # see  https://bugs.llvm.org/show_bug.cgi?id=39696
     # for a bug report about this problem in llvm master.


### PR DESCRIPTION
llvm10 was not compiling with gcc11 due to a missing header (see #24270)