### PR TITLE
nss: add nssutil3 library to pkg-config

### DIFF
--- a/var/spack/repos/builtin/packages/nss/package.py
+++ b/var/spack/repos/builtin/packages/nss/package.py
@@ -66,4 +66,4 @@ class Nss(MakefilePackage):
             f.write('Version: {0}\n'.format(self.spec.version))
             f.write('Requires: nspr\n')
             f.write('Cflags: -I${includedir}\n')
-            f.write('Libs: -L${libdir} -lssl3 -lsmime3 -lnss3\n')
+            f.write('Libs: -L${libdir} -lssl3 -lsmime3 -lnss3 -lnssutil3\n')


### PR DESCRIPTION
This is needed for qt+webkit to build correctly.
As reference the debian package was taken:
https://salsa.debian.org/mozilla-team/nss/-/blob/master/debian/nss.pc.in