### PR TITLE
modules: configurable module defaults

### DIFF
--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -464,9 +464,10 @@ configuration:
 
   modules:
     my-module-set:
-      defaults:
-      - gcc@10.2.1
-      - hdf5@1.2.10+mpi+hl%gcc
+      tcl:
+        defaults:
+        - gcc@10.2.1
+        - hdf5@1.2.10+mpi+hl%gcc
 
 These defaults may be arbitrarily specific. For any package that
 satisfies a default, Spack will generate the module file in the

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -461,6 +461,7 @@ default modules with Spack, add a ``defaults`` key to your modules
 configuration:
 
 .. code-block:: yaml
+
   modules:
     my-module-set:
       defaults:

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -449,6 +449,34 @@ that are already in the LMod hierarchy.
    For hierarchies that are deeper than three layers ``lmod spider`` may have some issues.
    See `this discussion on the LMod project <https://github.com/TACC/Lmod/issues/114>`_.
 
+""""""""""""""""""""""
+Select default modules
+""""""""""""""""""""""
+
+By default, when multiple modules of the same name share a directory,
+the highest version number will be the default module. This behavior
+of the ``module`` command can be overridden with a symlink named
+``default`` to the desired default module. If you wish to configure
+default modules with Spack, add a ``defaults`` key to your modules
+configuration:
+
+.. code-block:: yaml
+  modules:
+    my-module-set:
+      defaults:
+      - gcc@10.2.1
+      - hdf5@1.2.10+mpi+hl%gcc
+
+These defaults may be arbitrarily specific. For any package that
+satisfies a default, Spack will generate the module file in the
+appropriate path, and will generate a default symlink to the module
+file as well.
+
+.. warning:: 
+  If Spack is configured to generate multiple default packages in the
+  same directory, the last modulefile to be generated will be the
+  default module.
+
 .. _customize-env-modifications:
 
 """""""""""""""""""""""""""""""""""

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -455,6 +455,11 @@ class BaseConfiguration(object):
         return self.conf.get('template', None)
 
     @property
+    def defaults(self):
+        """Returns the specs configured as defaults or []."""
+        return self.conf.get('defaults', [])
+
+    @property
     def env(self):
         """List of environment modifications that should be done in the
         module.
@@ -892,6 +897,13 @@ class BaseModuleFileWriter(object):
         # Set the file permissions of the module to match that of the package
         if os.path.exists(self.layout.filename):
             fp.set_permissions_by_spec(self.layout.filename, self.spec)
+
+        # Symlink defaults if needed
+        if any(self.spec.satisfies(default) for default in self.conf.defaults):
+            # This spec matches a default, it needs to be symlinked to default
+            default_path = os.path.join(os.path.dirname(self.layout.filename),
+                                        'default')
+            os.symlink(self.layout.filename, default_path)
 
     def remove(self):
         """Deletes the module file."""

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -908,7 +908,7 @@ class BaseModuleFileWriter(object):
             default_tmp = os.path.join(os.path.dirname(self.layout.filename),
                                        '.tmp_spack_default')
             os.symlink(self.layout.filename, default_tmp)
-            os.renaame(default_tmp, default_path)
+            os.rename(default_tmp, default_path)
 
     def remove(self):
         """Deletes the module file."""

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -210,6 +210,10 @@ def merge_config_rules(configuration, spec):
     verbose = module_specific_configuration.get('verbose', False)
     spec_configuration['verbose'] = verbose
 
+    # module defaults per-package
+    defaults = module_specific_configuration.get('defaults', [])
+    spec_configuration['defaults'] = defaults
+
     return spec_configuration
 
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -901,9 +901,14 @@ class BaseModuleFileWriter(object):
         # Symlink defaults if needed
         if any(self.spec.satisfies(default) for default in self.conf.defaults):
             # This spec matches a default, it needs to be symlinked to default
+            # Symlink to a tmp location first and move, so that existing
+            # symlinks do not cause an error.
             default_path = os.path.join(os.path.dirname(self.layout.filename),
                                         'default')
-            os.symlink(self.layout.filename, default_path)
+            default_tmp = os.path.join(os.path.dirname(self.layout.filename),
+                                       '.tmp_spack_default')
+            os.symlink(self.layout.filename, default_tmp)
+            os.renaame(default_tmp, default_path)
 
     def remove(self):
         """Deletes the module file."""

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -99,6 +99,7 @@ module_type_configuration = {
                 'type': 'boolean',
                 'default': False
             },
+            'defaults': array_of_strings,
             'naming_scheme': {
                 'type': 'string'  # Can we be more specific here?
             },

--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -17,8 +17,8 @@ import spack.schema.projections
 #: THIS NEEDS TO BE UPDATED FOR EVERY NEW KEYWORD THAT
 #: IS ADDED IMMEDIATELY BELOW THE MODULE TYPE ATTRIBUTE
 spec_regex = r'(?!hierarchy|core_specs|verbose|hash_length|whitelist|' \
-             r'blacklist|projections|naming_scheme|core_compilers|all)' \
-             r'(^\w[\w-]*)'
+             r'blacklist|projections|naming_scheme|core_compilers|all|' \
+             r'defaults)(^\w[\w-]*)'
 
 #: Matches a valid name for a module set
 # Banned names are valid entries at that level in the previous schema

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -56,6 +56,7 @@ def mock_module_filename(monkeypatch, tmpdir):
 
     yield filename
 
+
 @pytest.fixture()
 def mock_module_defaults(monkeypatch):
     def impl(*args):

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -46,11 +46,25 @@ def test_update_dictionary_extending_list():
 @pytest.fixture()
 def mock_module_filename(monkeypatch, tmpdir):
     filename = str(tmpdir.join('module'))
-    monkeypatch.setattr(spack.modules.common.BaseFileLayout,
+    # Set for both module types so we can test both
+    monkeypatch.setattr(spack.modules.lmod.LmodFileLayout,
+                        'filename',
+                        filename)
+    monkeypatch.setattr(spack.modules.tcl.TclFileLayout,
                         'filename',
                         filename)
 
     yield filename
+
+@pytest.fixture()
+def mock_module_defaults(monkeypatch):
+    def impl(*args):
+        # No need to patch both types because neither override base
+        monkeypatch.setattr(spack.modules.common.BaseConfiguration,
+                            'defaults',
+                            [arg for arg in args])
+
+    return impl
 
 
 @pytest.fixture()
@@ -75,6 +89,22 @@ def test_modules_written_with_proper_permissions(mock_module_filename,
 
     assert mock_package_perms & os.stat(
         mock_module_filename).st_mode == mock_package_perms
+
+
+@pytest.mark.parametrize('module_type', ['tcl', 'lmod'])
+def test_modules_default_symlink(
+        module_type, mock_packages, mock_module_filename, mock_module_defaults
+):
+    spec = spack.spec.Spec('mpileaks@2.3').concretized()
+    mock_module_defaults(spec.format('{name}{@version}'))
+
+    generator_cls = spack.modules.module_types[module_type]
+    generator = generator_cls(spec, 'default')
+    generator.write()
+
+    link_path = os.path.join(os.path.dirname(mock_module_filename), 'default')
+    assert os.path.islink(link_path)
+    assert os.readlink(link_path) == mock_module_filename
 
 
 class MockDb(object):

--- a/lib/spack/spack/test/modules/common.py
+++ b/lib/spack/spack/test/modules/common.py
@@ -94,7 +94,7 @@ def test_modules_written_with_proper_permissions(mock_module_filename,
 
 @pytest.mark.parametrize('module_type', ['tcl', 'lmod'])
 def test_modules_default_symlink(
-        module_type, mock_packages, mock_module_filename, mock_module_defaults
+        module_type, mock_packages, mock_module_filename, mock_module_defaults, config
 ):
     spec = spack.spec.Spec('mpileaks@2.3').concretized()
     mock_module_defaults(spec.format('{name}{@version}'))


### PR DESCRIPTION
Spack currently allows manual manipulation of the default modules, but does not allow module defaults as a configurable option.

This PR makes module defaults configurable from the modules yaml section. It adds a per-module-set key "defaults", which takes a list of spec strings. Any spec that satisfies any default spec is considered a default, and a symlink named default is created next to, and pointing to, its modulefile. (Note: if multiple packages have modulefiles in the same directory and are listed as defaults, the last one installed will be left as the default).

This will allow facility staff greater flexibility with advanced module configuration.

Includes testing and documentation.