### PR TITLE
Adding error messages for spack monitor

### DIFF
--- a/lib/spack/spack/cmd/analyze.py
+++ b/lib/spack/spack/cmd/analyze.py
@@ -112,6 +112,7 @@ def analyze(parser, args, **kwargs):
             host=args.monitor_host,
             prefix=args.monitor_prefix,
             disable_auth=args.monitor_disable_auth,
+            allow_fail=args.monitor_keep_going,
         )
 
     # Run the analysis

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -307,6 +307,7 @@ environment variables:
             disable_auth=args.monitor_disable_auth,
             tags=args.monitor_tags,
             save_local=args.monitor_save_local,
+            allow_fail=args.monitor_keep_going,
         )
 
     reporter = spack.report.collect_info(

--- a/lib/spack/spack/cmd/monitor.py
+++ b/lib/spack/spack/cmd/monitor.py
@@ -29,6 +29,7 @@ def monitor(parser, args, **kwargs):
             host=args.monitor_host,
             prefix=args.monitor_prefix,
             disable_auth=args.monitor_disable_auth,
+            allow_fail=args.monitor_keep_going,
         )
 
         # Upload the directory


### PR DESCRIPTION
These are a few tweaks to spack monitor to better communicate to the user when something goes wrong, and expose more functionality. Specifically.

### Error messages
Currently when there is an error, you generally see something like 400 bad request. This update will retrieve the message from the server to tell the user exactly what is wrong.

### Keep Going

The keep going argument isn't properly passed to the client (so we can't keep going on failure) so I'm adding it here.

### Spec requirement for upload

If a user tries to upload a results folder without a spec, the error message will indicate that the spec isn't found, which is logical. Instead of trying to ping the server I'm catching it first.


Signed-off-by: vsoch <vsoch@users.noreply.github.com>