### PR TITLE
py-peachpy: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-peachpy/package.py
+++ b/var/spack/repos/builtin/packages/py-peachpy/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPeachpy(PythonPackage):
+    """Portable Efficient Assembly Codegen in Higher-level Python."""
+
+    homepage = "https://github.com/Maratyszcza/PeachPy"
+    git      = "https://github.com/Maratyszcza/PeachPy.git"
+
+    version('master', branch='master')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-opcodes@0.3.13:', type='build')
+    depends_on('py-six', type=('build', 'run'))
+    depends_on('py-enum34', when='^python@:3.3.999', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.10 and Apple Clang 12.0.0.

Depends on #24372