### PR TITLE
cp2k: update elpa and sirius dependencies, fix build with mpich and gcc@10

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -120,7 +120,8 @@ class Cp2k(MakefilePackage, CudaPackage):
         depends_on('elpa~openmp', when='~openmp')
         depends_on('elpa@2011.12:2016.13', when='@:5.999')
         depends_on('elpa@2011.12:2017.11', when='@6.0:6.999')
-        depends_on('elpa@2018.05:', when='@7.0:')
+        depends_on('elpa@2018.05:2020.11.001', when='@7.0:8.2')
+        depends_on('elpa@2021.05:', when='@8.3:')
 
     with when('+plumed'):
         depends_on('plumed+shared')
@@ -138,11 +139,12 @@ class Cp2k(MakefilePackage, CudaPackage):
     # like ELPA, SCALAPACK are independent and Spack will ensure that
     # a consistent/compatible combination is pulled into the dependency graph.
     with when('+sirius'):
-        depends_on('sirius+fortran+vdwxc+shared')
+        depends_on('sirius+fortran+shared')
         depends_on('sirius+openmp', when='+openmp')
         depends_on('sirius~openmp', when='~openmp')
         depends_on('sirius@:6.999', when='@:7.999')
-        depends_on('sirius@7:', when='@8:')
+        depends_on('sirius@7:7.0.999', when='@8:8.2')
+        depends_on('sirius@7.2:', when='@8.3:')
         conflicts('~mpi')
         # sirius support was introduced in 7+
         conflicts('@:6.999')

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -299,6 +299,9 @@ class Cp2k(MakefilePackage, CudaPackage):
             fcflags += ['-qpreprocess', '-qstrict', '-q64']
             ldflags += ['-Wl,--allow-multiple-definition']
 
+        if '%gcc@10: +mpi' in spec and spec['mpi'].name in ['mpich', 'cray-mpich']:
+            fcflags += ['-fallow-argument-mismatch']  # https://github.com/pmodels/mpich/issues/4300
+
         if '+openmp' in spec:
             cflags.append(self.compiler.openmp_flag)
             cxxflags.append(self.compiler.openmp_flag)

--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -8,12 +8,13 @@ import os
 from spack import *
 
 
-class Elpa(AutotoolsPackage, CudaPackage):
+class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     """Eigenvalue solvers for Petaflop-Applications (ELPA)"""
 
     homepage = 'https://elpa.mpcdf.mpg.de/'
-    url = 'https://elpa.mpcdf.mpg.de/elpa-2015.11.001.tar.gz'
+    url = 'https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/2015.11.001/elpa-2015.11.001.tar.gz'
 
+    version('2021.05.001', sha256='a4f1a4e3964f2473a5f8177f2091a9da5c6b5ef9280b8272dfefcbc3aad44d41')
     version('2020.05.001', sha256='66ff1cf332ce1c82075dc7b5587ae72511d2bcb3a45322c94af6b01996439ce5')
     version('2019.11.001', sha256='10374a8f042e23c7e1094230f7e2993b6f3580908a213dbdf089792d05aff357')
     version('2019.05.002', sha256='d2eab5e5d74f53601220b00d18185670da8c00c13e1c1559ecfb0cd7cb2c4e8d')
@@ -28,23 +29,31 @@ class Elpa(AutotoolsPackage, CudaPackage):
     version('2016.05.003', sha256='c8da50c987351514e61491e14390cdea4bdbf5b09045261991876ed5b433fca4')
     version('2015.11.001', sha256='c0761a92a31c08a4009c9688c85fc3fc8fde9b6ce05e514c3e1587cf045e9eba')
 
-    variant('openmp', default=False, description='Activates OpenMP support')
+    variant('openmp', default=True, description='Activates OpenMP support')
+    variant('mpi', default=True, description='Activates MPI support')
 
-    depends_on('mpi')
     depends_on('blas')
     depends_on('lapack')
-    depends_on('scalapack')
+    depends_on('mpi', when='+mpi')
+    depends_on('scalapack', when='+mpi')
+    depends_on('rocblas', when='+rocm')
     depends_on('libtool', type='build')
     depends_on('python@:2', type='build', when='@:2020.05.001')
     depends_on('python@3:', type='build', when='@2020.11.001:')
 
     patch('python_shebang.patch', when='@:2020.05.001')
 
+    # fails to build due to broken type-bound procedures in OMP parallel regions
+    conflicts('+openmp', when='@2021.05.001: %gcc@:7.999',
+              msg='ELPA-2021.05.001+ requires GCC-8+ for OpenMP support')
+    conflicts('+rocm', when='@:2020.99',
+              msg='ROCm support was introduced in ELPA 2021.05.001')
+    conflicts('+mpi', when='+rocm',
+              msg='ROCm support and MPI are not yet compatible')
+
     def url_for_version(self, version):
-        t = 'https://elpa.mpcdf.mpg.de/html/Releases/{0}/elpa-{0}.tar.gz'
-        if version < Version('2016.05.003'):
-            t = 'https://elpa.mpcdf.mpg.de/elpa-{0}.tar.gz'
-        return t.format(str(version))
+        return ('https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/{0}/elpa-{0}.tar.gz'
+                .format(str(version)))
 
     # override default implementation which returns static lib
     @property
@@ -73,8 +82,11 @@ class Elpa(AutotoolsPackage, CudaPackage):
         spec = self.spec
         options = []
 
+        options += self.with_or_without('mpi')
+
         # TODO: --disable-sse-assembly, --enable-sparc64, --enable-neon-arch64
-        simd_features = ['vsx', 'sse', 'avx', 'avx2', 'avx512']
+        simd_features = ['vsx', 'sse', 'avx', 'avx2', 'avx512',
+                         'sve128', 'sve256', 'sve512']
 
         for feature in simd_features:
             msg = '--enable-{0}' if feature in spec.target else '--disable-{0}'
@@ -111,34 +123,41 @@ class Elpa(AutotoolsPackage, CudaPackage):
                 'CFLAGS=-O3'
             ])
 
+        cuda_flag = 'nvidia-gpu' if '@2021.05.001:' in self.spec else 'gpu'
         if '+cuda' in spec:
             prefix = spec['cuda'].prefix
-            options.append('--enable-gpu')
+            options.append('--enable-{0}'.format(cuda_flag))
             options.append('--with-cuda-path={0}'.format(prefix))
             options.append('--with-cuda-sdk-path={0}'.format(prefix))
 
             cuda_arch = spec.variants['cuda_arch'].value[0]
 
             if cuda_arch != 'none':
-                options.append('--with-GPU-compute-capability=sm_{0}'.
-                               format(cuda_arch))
+                options.append('--with-{0}-compute-capability=sm_{1}'.
+                               format(cuda_flag.upper(), cuda_arch))
         else:
-            options.append('--disable-gpu')
+            options.append('--disable-{0}'.format(cuda_flag))
 
-        if '+openmp' in spec:
-            options.append('--enable-openmp')
-        else:
-            options.append('--disable-openmp')
+        if '+rocm' in spec:
+            options.append('--enable-amd-gpu')
+            options.append('CXX={0}'.format(self.spec['hip'].hipcc))
+        elif '@2021.05.001:' in self.spec:
+            options.append('--disable-amd-gpu')
 
-        options.extend([
-            'CC={0}'.format(spec['mpi'].mpicc),
-            'FC={0}'.format(spec['mpi'].mpifc),
-            'CXX={0}'.format(spec['mpi'].mpicxx),
+        options += self.enable_or_disable('openmp')
+
+        options += [
             'LDFLAGS={0}'.format(spec['lapack'].libs.search_flags),
             'LIBS={0} {1}'.format(
-                spec['lapack'].libs.link_flags, spec['blas'].libs.link_flags),
-            'SCALAPACK_LDFLAGS={0}'.format(spec['scalapack'].libs.joined())
-        ])
+                spec['lapack'].libs.link_flags, spec['blas'].libs.link_flags)]
+
+        if '+mpi' in self.spec:
+            options += [
+                'CC={0}'.format(spec['mpi'].mpicc),
+                'CXX={0}'.format(spec['mpi'].mpicxx),
+                'FC={0}'.format(spec['mpi'].mpifc),
+                'SCALAPACK_LDFLAGS={0}'.format(spec['scalapack'].libs.joined())
+            ]
 
         options.append('--disable-silent-rules')
 


### PR DESCRIPTION
- cp2k: fix build with GCC-10+ and MPICH
- cp2k: fix build for CP2K-8+ and SIRIUS-7.2+
