### PR TITLE
ASP-based solver: fix facts for default providers

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -786,7 +786,8 @@ class SpackSolverSetup(object):
                 continue
 
             for i, provider in enumerate(providers):
-                func(vspec, provider, i + 10)
+                provider_name = spack.spec.Spec(provider).name
+                func(vspec, provider_name, i + 10)
 
     def provider_defaults(self):
         self.gen.h2("Default virtual providers")


### PR DESCRIPTION
refers #24205

Facts used to compute weights for providers only need the package name, since the other attributes are computed as part of the solve.