### PR TITLE
MAGMA: add v2.6.0, sm_37 support

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -19,6 +19,7 @@ class Magma(CMakePackage, CudaPackage):
 
     test_requires_compiler = True
 
+    version('2.6.0', sha256='82e34aff266253dac0ab9f795dc60dc891469f617c37856b04fc2f7679ba0d22')
     version('2.5.4', sha256='7734fb417ae0c367b418dea15096aef2e278a423e527c615aab47f0683683b67')
     version('2.5.3', sha256='c602d269a9f9a3df28f6a4f593be819abb12ed3fa413bba1ff8183de721c5ef6')
     version('2.5.2', sha256='065feb85558f9dd6f4cc4db36ac633a3f787827fc832d0b578a049a43a195620')
@@ -55,6 +56,7 @@ class Magma(CMakePackage, CudaPackage):
     patch('magma-2.5.0.patch', when='@2.5.0')
     patch('magma-2.5.0-cmake.patch', when='@2.5.0')
     patch('cmake-W.patch', when='@2.5.0:%nvhpc')
+    patch('sm_37.patch', when='@2.6.0 cuda_arch=37')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/magma/sm_37.patch
+++ b/var/spack/repos/builtin/packages/magma/sm_37.patch
@@ -1,0 +1,27 @@
+--- a/CMakeLists.txt	2021-06-17 05:48:48.000000000 +0000
++++ b/CMakeLists.txt	2021-06-17 15:50:13.683664538 +0000
+@@ -145,7 +145,7 @@
+     endif()
+ 
+     if (GPU_TARGET MATCHES Kepler)
+-        set( GPU_TARGET "${GPU_TARGET} sm_30 sm_35" )
++        set( GPU_TARGET "${GPU_TARGET} sm_30 sm_35 sm_37" )
+     endif()
+ 
+     if (GPU_TARGET MATCHES Maxwell)
+@@ -195,6 +195,15 @@
+         message( STATUS "    compile for CUDA arch 3.5 (Kepler)" )
+     endif()
+ 
++    if (GPU_TARGET MATCHES sm_37)
++        if (NOT MIN_ARCH)
++            set( MIN_ARCH 300 )
++        endif()
++        set( NV_SM ${NV_SM} -gencode arch=compute_37,code=sm_37 )
++        set( NV_COMP        -gencode arch=compute_37,code=compute_37 )
++        message( STATUS "    compile for CUDA arch 3.7 (Kepler)" )
++    endif()
++
+     if (GPU_TARGET MATCHES sm_50)
+         if (NOT MIN_ARCH)
+             set( MIN_ARCH 500 )


### PR DESCRIPTION
Successfully builds on Ubuntu 18.04 and Tesla K80 (sm_37) with CUDA 10.1.243 and GCC 7.5.0.

@luszczek @stomov can you review? It doesn't look like MAGMA has a GitHub repo so I'm not sure where to contribute the patch to.