### PR TITLE
double-conversion: New versions 3.1.5, 2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/double-conversion/package.py
+++ b/var/spack/repos/builtin/packages/double-conversion/package.py
@@ -21,6 +21,8 @@ class DoubleConversion(CMakePackage):
     homepage = "https://github.com/google/double-conversion"
     url      = "https://github.com/google/double-conversion/archive/v2.0.1.zip"
 
+    version('3.1.5', sha256='72c0e3925a1214095afc6f1c214faecbec20e8526cf6b8a541cf72195a11887f')
+    version('2.0.2', sha256='7a0ae55ec9f75c22607808d091bae050a38d4a7728c52273c89d25dd5b78fcdd')
     version('2.0.1', sha256='476aefbdc2051bbcca0d5919ebc293c90a7ad2c0cb6c4ad877d6e665f469146b')
     version('2.0.0', sha256='437df89059bfa6c1c0f8703693c2584a57f75289ed7020d801c9befb23f46a26')
     version('1.1.5', sha256='496fd3354fa0ff17562907632f5560c1d444ea98b6069f1436fa573949b94fb0')


### PR DESCRIPTION
A version 2.0.3 is also advertised, but doesn't download.