### PR TITLE
vtk: Limit freetype versions

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -90,7 +90,7 @@ class Vtk(CMakePackage):
 
     depends_on('expat')
     # See <https://gitlab.kitware.com/vtk/vtk/-/issues/18033> for why vtk doesn't
-    # work yet with freetype 2.10.3 doesn't work yet (including possible patches)
+    # work yet with freetype 2.10.3 (including possible patches)
     depends_on('freetype @:2.10.2')
     depends_on('freetype')
     depends_on('glew')

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -89,6 +89,9 @@ class Vtk(CMakePackage):
     depends_on('mpi', when='+mpi')
 
     depends_on('expat')
+    # See <https://gitlab.kitware.com/vtk/vtk/-/issues/18033> for why vtk doesn't
+    # work yet with freetype 2.10.3 doesn't work yet (including possible patches)
+    depends_on('freetype @:2.10.2')
     depends_on('freetype')
     depends_on('glew')
     # set hl variant explicitly, similar to issue #7145


### PR DESCRIPTION
freetype 2.0.3 introduces an incompatible change