### PR TITLE
gloo: add +cuda variant

### DIFF
--- a/var/spack/repos/builtin/packages/gloo/package.py
+++ b/var/spack/repos/builtin/packages/gloo/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Gloo(CMakePackage):
+class Gloo(CMakePackage, CudaPackage):
     """Gloo is a collective communications library."""
 
     homepage = "https://github.com/facebookincubator/gloo"

--- a/var/spack/repos/builtin/packages/gloo/package.py
+++ b/var/spack/repos/builtin/packages/gloo/package.py
@@ -28,3 +28,6 @@ class Gloo(CMakePackage, CudaPackage):
     depends_on('ninja', type='build')
 
     generator = 'Ninja'
+
+    def cmake_args(self):
+        return [self.define_from_variant('USE_CUDA', 'cuda')]


### PR DESCRIPTION
`py-torch+gloo+cuda` requires `^gloo+cuda`.

Successfully builds on Ubuntu 18.04 with GCC 7.5.0.