### PR TITLE
OPENMPI: fixes to enable building of ompi master

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -33,7 +33,7 @@ class Openmpi(AutotoolsPackage):
 
     executables = ['^ompi_info$']
 
-    version('master', branch='master')
+    version('master', branch='master', submodules=True)
 
     # Current
     version('4.1.1', sha256='e24f7a778bd11a71ad0c14587a7f5b00e68a71aa5623e2157bafee3d44c07cda')  # libmpi.so.40.30.1
@@ -597,7 +597,7 @@ class Openmpi(AutotoolsPackage):
                 'OpenMPI requires both C and Fortran compilers!'
             )
 
-    @when('@develop')
+    @when('@master')
     def autoreconf(self, spec, prefix):
         perl = which('perl')
         perl('autogen.pl')


### PR DESCRIPTION
yes I know this name isn't popular but that's the way it is right now.

master and the upcoming v5.0.x release branch use git submodules.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>