### PR TITLE
Update abi-dumper to version 1.2

### DIFF
--- a/var/spack/repos/builtin/packages/abi-dumper/package.py
+++ b/var/spack/repos/builtin/packages/abi-dumper/package.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)  
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
 
@@ -13,7 +13,7 @@ class AbiDumper(MakefilePackage):
     homepage = "https://github.com/lvc/abi-dumper"
     url      = "https://github.com/lvc/abi-dumper/archive/1.2.tar.gz"
 
-    version('1.2', sha256='8a9858c91b4e9222c89b676d59422053ad560fa005a39443053568049bd4d27e', url='https://github.com/lvc/abi-dumper/archive/1.2.tar.gz')
+    version('1.2', sha256='8a9858c91b4e9222c89b676d59422053ad560fa005a39443053568049bd4d27e')
     version('1.1', sha256='ef63201368e0d76a29d2f7aed98c488f6fb71898126762d65baed1e762988083')
     version('1.0', sha256='bfa0189a172fa788afc603b1ae675808a57556a77a008e4af8f643d396c34bbb')
     version('0.99.19', sha256='6bbc35795839a04523d9e7bdb07806b9a661e17d8be0e755c99e4235805d4528')

--- a/var/spack/repos/builtin/packages/abi-dumper/package.py
+++ b/var/spack/repos/builtin/packages/abi-dumper/package.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)  
 
 from spack import *
 
@@ -11,10 +11,11 @@ class AbiDumper(MakefilePackage):
     DWARF debug info."""
 
     homepage = "https://github.com/lvc/abi-dumper"
-    url      = "https://github.com/lvc/abi-dumper/archive/1.1.tar.gz"
+    url      = "https://github.com/lvc/abi-dumper/archive/1.2.tar.gz"
 
-    version('1.1',     sha256='ef63201368e0d76a29d2f7aed98c488f6fb71898126762d65baed1e762988083')
-    version('1.0',     sha256='bfa0189a172fa788afc603b1ae675808a57556a77a008e4af8f643d396c34bbb')
+    version('1.2', sha256='8a9858c91b4e9222c89b676d59422053ad560fa005a39443053568049bd4d27e', url='https://github.com/lvc/abi-dumper/archive/1.2.tar.gz')
+    version('1.1', sha256='ef63201368e0d76a29d2f7aed98c488f6fb71898126762d65baed1e762988083')
+    version('1.0', sha256='bfa0189a172fa788afc603b1ae675808a57556a77a008e4af8f643d396c34bbb')
     version('0.99.19', sha256='6bbc35795839a04523d9e7bdb07806b9a661e17d8be0e755c99e4235805d4528')
 
     depends_on('perl@5:')


### PR DESCRIPTION
Update abi-dumper to version 1.2 which includes support for Fedora 30 and misc bug fixes. 

### Changelog
- Support for Fedora 30
- Misc Bug Fixes

The full changelog can be found [here](https://github.com/lvc/abi-dumper/releases/tag/1.2). 

### Test Plan
A Spack build log for this version can be found [here](https://github.com/autamus/registry/runs/2353571383) as proof of the update compiling successfully.