### PR TITLE
Disable magma in the E4S pipeline

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -178,7 +178,7 @@ spack:
     - hpx +cuda cuda_arch=70
     - kokkos +cuda +wrapper cuda_arch=70
     - kokkos-kernels +cuda cuda_arch=70 ^kokkos +cuda +wrapper cuda_arch=70
-    - magma cuda_arch=70
+    #- magma cuda_arch=70
     - raja +cuda cuda_arch=70
     - slate +cuda cuda_arch=70
     - strumpack +cuda ~slate cuda_arch=70


### PR DESCRIPTION
Building magma has been failing consistently and is currently blocking PRs from being merged. Disable that spec while we investigate the failure and work on a fix.