### PR TITLE
Update Abyss to 2.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)  
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import numbers
 from spack import *

--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)  
 
 import numbers
 from spack import *
@@ -22,8 +22,11 @@ class Abyss(AutotoolsPackage):
        is useful for assembling genomes up to 100 Mbases in size."""
 
     homepage = "http://www.bcgsc.ca/platform/bioinfo/software/abyss"
-    url      = "https://github.com/bcgsc/abyss/releases/download/1.5.2/abyss-1.5.2.tar.gz"
+    url      = "https://github.com/bcgsc/abyss/releases/download/2.3.1/abyss-2.3.1.tar.gz"
 
+    version('2.3.1', sha256='664045e7903e9732411effc38edb9ebb1a0c1b7636c64b3a14a681f465f43677')
+    version('2.3.0', sha256='3df923b0699187fb27948cae43293eeb5745161d5dc484b9befbe2ca8efb6ad7')
+    version('2.2.5', sha256='38e886f455074c76b32dd549e94cc345f46cb1d33ab11ad3e8e1f5214fc65521')
     version('2.1.4', sha256='2145a1727556104d6a14db06a9c06f47b96c31cc5ac595ae9c92224349bdbcfc')
     version('2.0.2', sha256='d87b76edeac3a6fb48f24a1d63f243d8278a324c9a5eb29027b640f7089422df')
     version('1.5.2', sha256='8a52387f963afb7b63db4c9b81c053ed83956ea0a3981edcad554a895adf84b1')


### PR DESCRIPTION
Update Abyss to 2.3.1 which includes resolver bug fixes.

**Changelog:**

- Fixed a bug that crashed ABySS if Bloom filter size is not specified.
- Fixed a compilation error for clang-10.

The full changlog can be found [here](https://github.com/bcgsc/abyss/releases/tag/2.3.1).

**Test Plan:**
Abyss 2.3.1 [Build Log](https://github.com/autamus/registry/runs/2415173286) within Autamus.