### PR TITLE
Update Accumulo to 2.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/accumulo/package.py
+++ b/var/spack/repos/builtin/packages/accumulo/package.py
@@ -9,8 +9,9 @@ class Accumulo(MavenPackage):
     provides robust, scalable data storage and retrieval."""
 
     homepage = "https://accumulo.apache.org/"
-    url      = "https://github.com/apache/accumulo/archive/rel/2.0.0.tar.gz"
+    url      = "https://github.com/apache/accumulo/archive/rel/2.0.1.tar.gz"
 
+    version('2.0.1', sha256='2756ac14e850b30ad9bd1043418d621b93307d083f84904cd8fac5c8beec751b')
     version('2.0.0', sha256='2564056dc24398aa464763c21bae10ef09356fe3261600d27744071cf965c265')
     version('1.9.3', sha256='d9548d5b9cf9f494f027f0fe59d5d6d45d09064359d7761cade62991ce2a5d0c')
     version('1.9.2', sha256='11ab028143ad6313cd5fc701b36b4c35e46a4a3fa2ce663869860b9f6bf5ee4d')


### PR DESCRIPTION
Update Accumulo to 2.0.1 which includes critical security bug fixes.

**Changelog:**
- This release includes critical bug fixes to fix security bugs identified as [CVE-2020-17533](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-17533).
- Throw exceptions when permission checks fail, and improve test coverage for permissions checks.
- Fix AccumuloClient’s builder to prevent it from modifying a provided Properties object when building a client from Properties.

The full changelog can be found [here](https://accumulo.apache.org/release/accumulo-2.0.1/).

**Test Plan:**
Accumulo 2.0.1 built successfully within Autamus [here](https://github.com/autamus/registry/runs/2353571885).