### PR TITLE
Update Beast2 to 2.6.4

### DIFF
--- a/var/spack/repos/builtin/packages/beast2/package.py
+++ b/var/spack/repos/builtin/packages/beast2/package.py
@@ -15,8 +15,10 @@ class Beast2(Package):
        conditioning on a single tree topology."""
 
     homepage = "http://beast2.org/"
-    url      = "https://github.com/CompEvol/beast2/releases/download/v2.4.6/BEAST.v2.4.6.Linux.tgz"
+    url      = "https://github.com/CompEvol/beast2/releases/download/v2.6.4/BEAST.v2.6.4.Linux.tgz"
 
+    version('2.6.4', sha256='4f80e2920eb9d87f3e9f64433119774dc67aca390fbd13dd480f852e3f8701a4')
+    version('2.6.3', sha256='8899277b0d7124ab04dc512444d45f0f1a13505f3ce641e1f117098be3e2e20d')
     version('2.5.2', sha256='2feb2281b4f7cf8f7de1a62de50f52a8678ed0767fc72f2322e77dde9b8cd45f')
     version('2.4.6', sha256='84029c5680cc22f95bef644824130090f5f12d3d7f48d45cb4efc8e1d6b75e93')
 


### PR DESCRIPTION
Update Beast2 to 2.6.4 which includes multiple bug fixes and general improvements.

**Changelog:**

- Less clutter on screen output.
- Bayesian skyline plot has a proper prior alternative for the first element of the popSizes parameter.
- LogCombiner can now write to stdout.
- FilteredAlignment can deal with missing and ambiguous values.
- Node now recognises age trait.
- Add differentRandomIndex to UpDownOperator.
- Checksum support for developers chasing incorrectly calculated likelihoods.

The full changelog can be found [here](https://github.com/CompEvol/beast2/releases/tag/v2.6.4).

**Test Plan:**
2.6.4 built successfully as part of the Autamus Build Workflow [here](https://github.com/autamus/registry/runs/2546296621).