### PR TITLE
Update Bedtools2 to 2.30.0

### DIFF
--- a/var/spack/repos/builtin/packages/bedtools2/package.py
+++ b/var/spack/repos/builtin/packages/bedtools2/package.py
@@ -13,8 +13,9 @@ class Bedtools2(Package):
        on the genome."""
 
     homepage = "https://github.com/arq5x/bedtools2"
-    url      = "https://github.com/arq5x/bedtools2/archive/v2.26.0.tar.gz"
+    url      = "https://github.com/arq5x/bedtools2/archive/v2.30.0.tar.gz"
 
+    version('2.30.0', sha256='c575861ec746322961cd15d8c0b532bb2a19333f1cf167bbff73230a7d67302f')
     version('2.29.2', sha256='bc2f36b5d4fc9890c69f607d54da873032628462e88c545dd633d2c787a544a5')
     version('2.27.1', sha256='edcac089d84e63a51f85c3c189469daa7d42180272130b046856faad3cf79112')
     version('2.27.0', sha256='e91390b567e577d337c15ca301e264b0355441f5ab90fa4f971622e3043e0ca0')


### PR DESCRIPTION
Update Bedtools2 to 2.30.0 which includes multiple performance speedups and bug fixes.

**Changelog:**
- Made substantial improvements in the speed associated with parsing input files and in printing results.
- Improved the stability and cleanliness of the code used for random number generation.
- Addressed numerical instability issues in the fisher tool.

The full changelog can be found [here](https://github.com/arq5x/bedtools2/releases/tag/v2.30.0).

**Test Plan:**
2.30.0 built successfully within the Autamus Build Workflow [here](https://github.com/autamus/registry/runs/2372926065).