### PR TITLE
Update Benchmark to 1.5.5

### DIFF
--- a/var/spack/repos/builtin/packages/benchmark/package.py
+++ b/var/spack/repos/builtin/packages/benchmark/package.py
@@ -10,13 +10,14 @@ class Benchmark(CMakePackage):
     """A microbenchmark support library"""
 
     homepage = "https://github.com/google/benchmark"
-    url      = "https://github.com/google/benchmark/archive/v1.1.0.tar.gz"
+    url      = "https://github.com/google/benchmark/archive/v1.5.5.tar.gz"
     git      = "https://github.com/google/benchmark.git"
 
     # first properly installed CMake config packages in
     # 1.2.0 release: https://github.com/google/benchmark/issues/363
-
     version('develop', branch='master')
+    version('1.5.5', sha256='3bff5f237c317ddfd8d5a9b96b3eede7c0802e799db520d38ce756a2a46a18a0')
+    version('1.5.4', sha256='e3adf8c98bb38a198822725c0fc6c0ae4711f16fbbf6aeb311d5ad11e5a081b5')
     version('1.5.0', sha256='3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a')
     version('1.4.1', sha256='f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d')
     version('1.4.0', sha256='616f252f37d61b15037e3c2ef956905baf9c9eecfeab400cb3ad25bae714e214')


### PR DESCRIPTION
Update Benchmark to 1.5.5 which includes multiple new features, bug fixes, and some internal cleanup of the codebase.

**Changelog:**
- Add support for new architecture loongarch.
- Fixed version of random interleaving of benchmark repetitions.
- Easier comparison of results across families.
- Fix perf counter argument parsing.
- Drop warning to satisfy clang's -Wunused-but-set-variable diag.
- Enable some sanitizer builds in github actions.
- Fix memory leak in test.

The full changelog can be found [here](https://github.com/google/benchmark/releases/tag/v1.5.5).

**Test Plan:**
1.5.5 built successfully within the Autamus Build Workflow [here](https://github.com/autamus/registry/runs/2803608222).