### PR TITLE
Update Bismark to 0.23.0

### DIFF
--- a/var/spack/repos/builtin/packages/bismark/package.py
+++ b/var/spack/repos/builtin/packages/bismark/package.py
@@ -11,8 +11,9 @@ class Bismark(Package):
     methylation states"""
 
     homepage = "https://www.bioinformatics.babraham.ac.uk/projects/bismark"
-    url      = "https://github.com/FelixKrueger/Bismark/archive/0.19.0.tar.gz"
+    url      = "https://github.com/FelixKrueger/Bismark/archive/0.23.0.tar.gz"
 
+    version('0.23.0', sha256='ea1625808487c1442dbf825d9cbe5c0cbc37ea5bd1460f59e1e0ccc80cc01c9e')
     version('0.19.0', sha256='91707737f96a0574956a282b635abad7560e7d90bee188a67a7807b2470deae2')
     version('0.18.2', sha256='83391c5b5af33047178e7774ac25f5a69ce9315c13ae02f016baf7c50b73e702')
 


### PR DESCRIPTION
Update Bismark to 0.23.0 which includes many bug fixes and few features.

**Changelog:**
Check out the extensive changelog [here](https://github.com/FelixKrueger/Bismark/releases/tag/0.23.0).

**Test Plan**
0.23.0 built successfully within the Autamus Build Workflow [here](https://github.com/autamus/registry/runs/2362974547).