### PR TITLE
Update Coreset to 1.09

### DIFF
--- a/var/spack/repos/builtin/packages/corset/package.py
+++ b/var/spack/repos/builtin/packages/corset/package.py
@@ -11,8 +11,9 @@ class Corset(Package):
        transcriptome assembly to gene-level counts."""
 
     homepage = "https://github.com/Oshlack/Corset/wiki"
-    url      = "https://github.com/Oshlack/Corset/releases/download/version-1.06/corset-1.06-linux64.tar.gz"
+    url      = "https://github.com/Oshlack/Corset/releases/download/version-1.09/corset-1.09-linux64.tar.gz"
 
+    version('1.09', sha256='9c349afc5a66c43e6b73c62f5d3166dac2fd06696aa40cff648226a5d0427a59')
     version('1.06', sha256='4aff83844461cea1edfce3d89776236c300650fc02b497cc9f11eba42d161b60')
 
     def url_for_version(self, version):


### PR DESCRIPTION
Update Coreset to 1.09 which includes a fix for improved performance on large datasets.

**Changelog:**
This version of corset redistributes reads when the -l flag is used rather than throwing them away. This option can help on large assemblies / datasets when computational resources are an issue.

**Test Plan:**
1.09 built successfully within the Autamus Build Workflow [here](https://github.com/autamus/registry/runs/2353573854).