### PR TITLE
Update Diamond to 2.0.9

### DIFF
--- a/var/spack/repos/builtin/packages/diamond/package.py
+++ b/var/spack/repos/builtin/packages/diamond/package.py
@@ -11,8 +11,10 @@ class Diamond(CMakePackage):
     designed for high performance analysis of big sequence data."""
 
     homepage = "https://ab.inf.uni-tuebingen.de/software/diamond"
-    url      = "https://github.com/bbuchfink/diamond/archive/v0.9.14.tar.gz"
+    url      = "https://github.com/bbuchfink/diamond/archive/v2.0.9.tar.gz"
 
+    version('2.0.9', sha256='3019f1adb6411c6669a3a17351d0338ae02f6b3cab3c8a3bac91cf334dcda620')
+    version('2.0.8', sha256='04eed7c83828f50c7d9a1d48fe7c50a4c753e008501dc639c6521cf8a756c43b')
     version('2.0.4', sha256='94e8fe72bdc28b83fd0f2d90c439b58b63b38263aa1a3905582ef68f614ae95d')
     version('0.9.25', sha256='65298f60cf9421dcc7669ce61642611cd9eeffc32f66fd39ebfa25dd64416808')
     version('0.9.23', sha256='0da5cdd5e5b77550ec0eaba2c6c431801cdd10d31606ca12f952b57d3d31db92')


### PR DESCRIPTION
Update Diamond to 2.0.9 which includes multiple bug fixes and new features.

**Changelog:**
- Reduced the memory use of database building with taxonomy mapping.
- Removed the limitation of sequence accession length.
- Fixed a bug that could cause using a BLAST database not to function correctly.
- Added support for using BLAST alias databases (created by blastdb_aliastool).
- Reduced the memory use of the seed hit sorting stage.
- Improved the consistency of results when running in query-indexed mode (--algo 1).
- Added the option --skip-missing-seqids to ignore cases of missing sequences in the database when using the --seqidlist option.
- The --min-orf parameter now defaults to 1 in frameshift alignment mode.
- Added support for using BLAST databases to the Docker container.

The full changelog can be found [here](https://github.com/bbuchfink/diamond/releases/tag/v2.0.9).

**Test Plan:**
2.0.9 built successfully within the Autamus Build Workflow [here](https://github.com/autamus/registry/runs/2324563169).