### PR TITLE
Add FTObjectLibrary package

### DIFF
--- a/var/spack/repos/builtin/packages/ftobjectlibrary/package.py
+++ b/var/spack/repos/builtin/packages/ftobjectlibrary/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Ftobjectlibrary(CMakePackage):
+    """FTObjectLibrary provides a collection of reference counted Fortran 2003
+    classes to facilitate writing generic object oriented Fortran programs. """
+
+    homepage = "https://github.com/trixi-framework/FTObjectLibrary"
+    url      = "https://github.com/trixi-framework/FTObjectLibrary"
+    git      = "https://github.com/trixi-framework/FTObjectLibrary.git"
+
+    maintainers = ['schoonovernumerics']
+
+    version('main', branch='main')
+
+    def cmake_args(self):
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/ftobjectlibrary/package.py
+++ b/var/spack/repos/builtin/packages/ftobjectlibrary/package.py
@@ -17,7 +17,3 @@ class Ftobjectlibrary(CMakePackage):
     maintainers = ['schoonovernumerics']
 
     version('main', branch='main')
-
-    def cmake_args(self):
-        args = []
-        return args


### PR DESCRIPTION
Add the new FTObjectLibrary package from trixi-framework to support spectral element methods mesh generators and other tools.