### PR TITLE
Update Z-checker and SZ

### DIFF
--- a/var/spack/repos/builtin/packages/sz/package.py
+++ b/var/spack/repos/builtin/packages/sz/package.py
@@ -10,15 +10,9 @@ class Sz(CMakePackage):
     """Error-bounded Lossy Compressor for HPC Data"""
 
     homepage = "https://szcompressor.org"
-    url      = "https://github.com/szcompressor/SZ/archive/v2.1.10.tar.gz"
+    url      = "https://github.com/szcompressor/SZ/releases/download/v2.1.11/SZ-2.1.11.tar.gz"
     git      = "https://github.com/szcompressor/sz"
     maintainers = ['disheng222', 'robertu94']
-
-    def url_for_version(self, version):
-        """provide url to ensure that download counting via github releases
-        works accurately"""
-        url = "https://github.com/szcompressor/SZ/releases/download/v{0}/SZ-{0}.tar.gz"
-        return url.format(version)
 
     version('master', branch='master')
     version('2.1.11.1', sha256='e6fa5c969b012782b1e5e9fbd1cd7d1c0ace908d9ec982e78b2910ec5c2161ac')

--- a/var/spack/repos/builtin/packages/z-checker/package.py
+++ b/var/spack/repos/builtin/packages/z-checker/package.py
@@ -16,6 +16,7 @@ class ZChecker(AutotoolsPackage):
 
     maintainers = ['disheng222']
 
+    version('0.6.0', sha256='b01c2c78157234a734c2f4c10a7ab82c329d3cd1a8389d597e09386fa33a3117')
     version('0.5.0', sha256='ad5e68472c511b393ee1ae67d2e3072a22004001cf19a14bd99a2e322a6ce7f9')
 
     variant('mpi', default=False,


### PR DESCRIPTION
Release a new version for Z-checker and fix a typo in SZ

@alalazo  This PR updates SZ and Z-checker fixing the unneeded url_for_version  that @adamjstewart noticed in #20343.  I'm creating a separate PR since I didn't create the other one and can't easily make change to it.

closes: #20343
CC: @disheng222 