### PR TITLE
GDB: resolve warnings about imp being deprecated

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/importlib.patch
+++ b/var/spack/repos/builtin/packages/gdb/importlib.patch
@@ -1,0 +1,18 @@
+diff --git a/gdb/python/lib/gdb/__init__.py b/gdb/python/lib/gdb/__init__.py
+index 84ec728ea21..9a0e9891cc5 100644
+--- a/gdb/python/lib/gdb/__init__.py
++++ b/gdb/python/lib/gdb/__init__.py
+@@ -18,8 +18,10 @@ import os
+ import sys
+ import _gdb
+ 
+-if sys.version_info[0] > 2:
+-    # Python 3 moved "reload"
++# Python 3 moved "reload"
++if sys.version_info >= (3, 4):
++    from importlib import reload
++elif sys.version_info[0] > 2:
+     from imp import reload
+ 
+ from _gdb import *
+-- 

--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -50,6 +50,10 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     # https://www.gnu.org/software/gettext/FAQ.html#integrating_undefined
     patch('gdb-libintl.patch', level=0, when='@10.1:')
 
+    # Silence warnings about imp being deprecated on new python versions
+    # https://sourceware.org/pipermail/gdb-patches/2021-February/176622.html
+    patch('importlib.patch', when="@8.3.1:10.2 ^python@3.4:")
+
     # Required dependency
     depends_on('texinfo', type='build')
 


### PR DESCRIPTION
This patch has already been accepted into gdb's trunk, we just adopting
it earlier here since it is small and gives a better user experience.