### PR TITLE
hdf5: fix compiler detection in flag_handler 

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -185,7 +185,7 @@ class Hdf5(AutotoolsPackage):
 
         # Quiet warnings/errors about implicit declaration of functions in C99
         if name == "cflags":
-            if "clang" in self.compiler.cc or "gcc" in self.compiler.cc:
+            if "%clang" in self.spec or "%gcc" in self.spec:
                 flags.append("-Wno-implicit-function-declaration")
 
         return (None, None, flags)


### PR DESCRIPTION
The original implementation of `flag_handler` searched the
`self.compiler.cc` string for `clang` or `gcc` in order to add a flag
for those compilers.  This approach fails when using a spack-installed
compiler that was itself built with gcc or clang, as those strings will
appear in the fully-qualified compiler executable paths.  This commit
switches to searching for `%gcc` or `%clang` in `self.spec`.

This address build-error #23830