### PR TITLE
py-cartopy: mark incompatibility with PROJ 8

### DIFF
--- a/var/spack/repos/builtin/packages/py-cartopy/package.py
+++ b/var/spack/repos/builtin/packages/py-cartopy/package.py
@@ -38,8 +38,8 @@ class PyCartopy(PythonPackage):
     depends_on('py-six@1.3.0:',     type=('build', 'run'))
     depends_on('py-futures', when='^python@:2', type=('build', 'run'))
     depends_on('geos@3.3.3:')
-    depends_on('proj@4.9.0:5', when='@:0.16.0')
-    depends_on('proj@4.9:',    when='@0.17.0:')
+    depends_on('proj@4.9:5', when='@:0.16.0')
+    depends_on('proj@4.9:7', when='@0.17.0:')
 
     # Optional dependecies
     depends_on('py-pyepsg@0.4.0:',     type=('build', 'run'), when='+epsg')


### PR DESCRIPTION
PROJ 8 will soon be released, and `py-cartopy` will not yet support it, see https://github.com/SciTools/cartopy/issues/1140