### PR TITLE
axom/conduit: allow use of hdf5+cxx+fortran

### DIFF
--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -94,7 +94,7 @@ class Axom(CachedCMakePackage, CudaPackage):
     depends_on("conduit~hdf5", when="~hdf5")
 
     # HDF5 needs to be the same as Conduit's
-    depends_on("hdf5@1.8.19:1.8.999~cxx~fortran", when="+hdf5")
+    depends_on("hdf5@1.8.19:1.8.999", when="+hdf5")
 
     depends_on("lua", when="+lua")
 

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -110,16 +110,12 @@ class Conduit(CMakePackage):
     ###############
     # HDF5
     ###############
-    # Note: cxx variant is disabled due to build issue Cyrus
-    # experienced on BGQ. When on, the static build tries
-    # to link against shared libs.
-    #
     # Use HDF5 1.8, for wider output compatibly
     # variants reflect we are not using hdf5's mpi or fortran features.
-    depends_on("hdf5@1.8.19:1.8.999~cxx", when="+hdf5+hdf5_compat+shared")
-    depends_on("hdf5@1.8.19:1.8.999~shared~cxx", when="+hdf5+hdf5_compat~shared")
-    depends_on("hdf5~cxx", when="+hdf5~hdf5_compat+shared")
-    depends_on("hdf5~shared~cxx", when="+hdf5~hdf5_compat~shared")
+    depends_on("hdf5@1.8.19:1.8.999", when="+hdf5+hdf5_compat+shared")
+    depends_on("hdf5@1.8.19:1.8.999~shared", when="+hdf5+hdf5_compat~shared")
+    depends_on("hdf5", when="+hdf5~hdf5_compat+shared")
+    depends_on("hdf5~shared", when="+hdf5~hdf5_compat~shared")
 
     ###############
     # Silo


### PR DESCRIPTION
Conduit used to require `hdf5~cxx` for reasons that no longer apply

Axom (which depends on Conduit) required `hdf5~cxx` to avoid conflicts. Axom also required `hdf5~fortran`, and this PR removes this constraint as it wasn't needed by Conduit.