### PR TITLE
[openloops][vbfnlo] Fix recipes and updated dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/openloops/package.py
+++ b/var/spack/repos/builtin/packages/openloops/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
+
+from spack import *
 
 
 class Openloops(Package):

--- a/var/spack/repos/builtin/packages/openloops/package.py
+++ b/var/spack/repos/builtin/packages/openloops/package.py
@@ -74,7 +74,6 @@ class Openloops(Package):
                                     'Set to 1 if compiling a large number' +
                                     'of processes (e.g. lcg.coll)', default=0)
     depends_on('python', type=("build", "run"))
-    depends_on('scons', type=('build', 'run'))
 
     phases = ['configure', 'build', 'build_processes', 'install']
 
@@ -113,6 +112,16 @@ class Openloops(Package):
             copy(join_path(os.path.dirname(__file__), 'sft2.coll'), 'lcg.coll')
         elif self.spec.satisfies('@2.1.2:2.99.99 processes=lcg.coll'):
             copy(join_path(os.path.dirname(__file__), 'sft3.coll'), 'lcg.coll')
+
+    def setup_build_environment(self, env):
+        # Make sure that calling openloops picks up the scons that is shipped
+        # instead of falling back to a potentially unsuitable system version
+        env.set('OLPYTHON', self.spec['python'].prefix.bin.python)
+
+    def setup_run_environment(self, env):
+        # Make sure that calling openloops picks up the scons that is shipped
+        # instead of falling back to a potentially unsuitable system version
+        env.set('OLPYTHON', self.spec['python'].prefix.bin.python)
 
     def build(self, spec, prefix):
         scons = Executable('./scons')

--- a/var/spack/repos/builtin/packages/openloops/package.py
+++ b/var/spack/repos/builtin/packages/openloops/package.py
@@ -74,6 +74,7 @@ class Openloops(Package):
                                     'Set to 1 if compiling a large number' +
                                     'of processes (e.g. lcg.coll)', default=0)
     depends_on('python', type=("build", "run"))
+    depends_on('scons', type=('build', 'run'))
 
     phases = ['configure', 'build', 'build_processes', 'install']
 

--- a/var/spack/repos/builtin/packages/vbfnlo/package.py
+++ b/var/spack/repos/builtin/packages/vbfnlo/package.py
@@ -26,6 +26,12 @@ class Vbfnlo(AutotoolsPackage):
     version('2.7.1',      sha256='13e33d73d8a8ef64094621f87e6f94e01712e76cc19a86298d0b52cfcb9decca', preferred=True)
     # version('2.7.0',      sha256='0e96c0912599e3000fffec5305700b947b604a7b06c7975851503f445311e4ef')
 
+    # Documentation is broken on some systems:
+    # See https://github.com/vbfnlo/vbfnlo/issues/2
+    variant('doc', default=False,
+            description='Build documentation')
+    patch('vbfnlo_no_docs.patch', when='~doc')
+
     depends_on('hepmc')
     depends_on('gsl')
     depends_on('lhapdf')

--- a/var/spack/repos/builtin/packages/vbfnlo/vbfnlo_no_docs.patch
+++ b/var/spack/repos/builtin/packages/vbfnlo/vbfnlo_no_docs.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index e3cfec3..ebf48f4 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -5,7 +5,7 @@ SUBDIRS = include \
+           loops \
+           amplitudes \
+           phasespace \
+-          lib src doc \
++          lib src \
+           regress
+ 
+ ACLOCAL_AMFLAGS = -I m4


### PR DESCRIPTION
These are two fixes that are necessary to build these packages on systems with an unsuitable `scons` and/or `pdflatex` installed.

For `openloops` I added `scons` as a dependency to make sure that the `openloops` call in `build_processes` finds a suitable one in its environment.
For `vbfnlo` I added a variant to toggle the building of the documentation and default it to `False`. This seems to be a long(er) standing issue in vbfnlo: vbfnlo/vbfnlo#2

Pinging @vvolkl and @iarspider (seem to be most active according to git blame)