### PR TITLE
sw4lite: fixed to include build targets

### DIFF
--- a/var/spack/repos/builtin/packages/sw4lite/package.py
+++ b/var/spack/repos/builtin/packages/sw4lite/package.py
@@ -81,9 +81,9 @@ class Sw4lite(MakefilePackage, CudaPackage):
 
     def build(self, spec, prefix):
         if '+cuda' in spec:
-            make('-f', 'Makefile.cuda')
+            make('-f', 'Makefile.cuda', *self.build_targets)
         else:
-            make('-f', 'Makefile')
+            make('-f', 'Makefile', *self.build_targets)
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)


### PR DESCRIPTION
Please correct me if I am wrong with this.
sw4lite was always failing for me, by not being able to pick up the blas / lapack dependencies. 
These are established in 'build_targets'
Looks like build_targets is only called by build, which is locally overloaded in sw4lite, without an explicit call.
This was actually causing sw4lite to pick up `/usr/lib64/libblas.so` thus bypassing the spack dependencies altogether. 

Added the call, and it looks like the correct args are now generated and passed through.