### PR TITLE
genfit: Add googletest dependency

### DIFF
--- a/var/spack/repos/builtin/packages/genfit/package.py
+++ b/var/spack/repos/builtin/packages/genfit/package.py
@@ -26,6 +26,7 @@ class Genfit(CMakePackage):
     depends_on('root')
     depends_on('root@:6.16.00', when='@b496504a')
     depends_on('eigen')
+    depends_on('googletest')
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
Not strictly necessary, but building the tests implicitly depends on the presence of `gtest`. To avoid that a potentially incompatible version provided by the system interferes, make sure that a version that is compiled with the same compiler as `genfit` is available.