### PR TITLE
subread: updating subread to 2.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/subread/package.py
+++ b/var/spack/repos/builtin/packages/subread/package.py
@@ -14,6 +14,7 @@ class Subread(MakefilePackage):
     homepage = "http://subread.sourceforge.net/"
     url      = "https://iweb.dl.sourceforge.net/project/subread/subread-1.5.2/subread-1.5.2-source.tar.gz"
 
+    version('2.0.2', sha256='0b64bd51f39f8d322c4594697fa5f0f64fbe60283113eadadff9f4268f897079')
     version('2.0.0', sha256='bd7b45f7d8872b0f5db5d23a385059f21d18b49e432bcb6e3e4a879fe51b41a8')
     version('1.6.4', sha256='b7bd0ee3b0942d791aecce6454d2f3271c95a010beeeff2daf1ff71162e43969')
     version('1.6.2', sha256='77b4896c1c242967c5883a06c0a5576a5ff220008a12aa60af9669d2f9a87d7a')


### PR DESCRIPTION
This also resolves compilation issues with gcc 10+ that the older versions had.