### PR TITLE
flecsi: fix typo in specification of hpx backend variant

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -84,7 +84,7 @@ class Flecsi(CMakePackage, CudaPackage):
     depends_on('legion+shared+mpi', when='backend=legion @:1.9')
     depends_on('legion+hdf5', when='backend=legion +hdf5 @:1.9')
     depends_on('legion build_type=Debug', when='backend=legion +debug_backend @:1.9')
-    depends_on('hpx@1.4.1 cxxstd=17 malloc=system max_cpu_count=128', when='backend=hpx@:1.9')
+    depends_on('hpx@1.4.1 cxxstd=17 malloc=system max_cpu_count=128', when='backend=hpx @:1.9')
     depends_on('hpx build_type=Debug', when='backend=hpx +debug_backend @:1.9')
     depends_on('googletest@1.8.1+gmock', when='@:1.9')
     depends_on('hdf5+hl', when='+hdf5 @:1.9')


### PR DESCRIPTION
`flecsi`: fix typo in specification of hpx backend; needs space between `backend=hpx` and the version specifier. New clingo concretizer catches this and doesn't like it.

@rspavel @ktsai7 