### PR TITLE
flecsi: legion has no +mpi variant, but does have network=mpi

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -81,7 +81,7 @@ class Flecsi(CMakePackage, CudaPackage):
     depends_on('mpi', when='backend=mpi @:1.9')
     depends_on('mpi', when='backend=legion @:1.9')
     depends_on('mpi', when='backend=hpx @:1.9')
-    depends_on('legion+shared+mpi', when='backend=legion @:1.9')
+    depends_on('legion+shared network=mpi', when='backend=legion @:1.9')
     depends_on('legion+hdf5', when='backend=legion +hdf5 @:1.9')
     depends_on('legion build_type=Debug', when='backend=legion +debug_backend @:1.9')
     depends_on('hpx@1.4.1 cxxstd=17 malloc=system max_cpu_count=128', when='backend=hpx@:1.9')


### PR DESCRIPTION
`flecsi`: there is no `legion +mpi` but there is `legion network=mpi`

Can someone verify this is OK? I don't know enough about flecsi to know if `legion network=mpi` is what is actually meant by `legion +mpi` 

@rspavel @ktsai7 @tldahlgren 