### PR TITLE
gsl: new release 2.7

### DIFF
--- a/var/spack/repos/builtin/packages/gsl/package.py
+++ b/var/spack/repos/builtin/packages/gsl/package.py
@@ -17,6 +17,7 @@ class Gsl(AutotoolsPackage, GNUMirrorPackage):
     homepage = "http://www.gnu.org/software/gsl"
     gnu_mirror_path = "gsl/gsl-2.3.tar.gz"
 
+    version('2.7', sha256='efbbf3785da0e53038be7907500628b466152dbc3c173a87de1b5eba2e23602b')
     version('2.6', sha256='b782339fc7a38fe17689cb39966c4d821236c28018b6593ddb6fd59ee40786a8')
     version('2.5', sha256='0460ad7c2542caaddc6729762952d345374784100223995eb14d614861f2258d')
     version('2.4',   sha256='4d46d07b946e7b31c19bbf33dda6204d7bedc2f5462a1bae1d4013426cd1ce9b')


### PR DESCRIPTION
Only a new release ; +external-cblas patch works as for release 2.6 and as @glennpj did in PR #22968.
Sorry @glennpj I did not update the 2.3 patch for 2.6 since when not using +external-cblas for gsl but when using blas for a package that depends on gsl, the package "automagically" depends on the "external" blas, not the libgslcblas.so shipped with gsl ; this might interest @sethrj and he may give hints on the subject.
You made it explicit @glennpj , I assume you have a need for that, but I prefer not since I may compile my code without blas for all my code but with a complete gsl. Maybe gsl developpers would have some advise about it, they say "Users who have access to other conforming CBLAS implementations can use these in place of the version provided by the library" but it is a bit short for me, I fail to understand that. Reference : 
https://www.gnu.org/software/gsl/doc/html/blas.html#blas-support