### PR TITLE
docs: link projections docs to spec format

### DIFF
--- a/lib/spack/docs/workflows.rst
+++ b/lib/spack/docs/workflows.rst
@@ -543,7 +543,8 @@ specified from the command line using the ``--projection-file`` option
 to the ``spack view`` command.
 
 The projections configuration file is a mapping of partial specs to
-spec format strings, as shown in the example below.
+spec format strings, defined by the :meth:`~spack.spec.Spec.format`
+function, as shown in the example below.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Add a link to the spec format string documentation from the projection docs that mention them (which is where I'm always looking for it from).