### PR TITLE
Add support for .tbz file extensions

### DIFF
--- a/lib/spack/spack/test/url_parse.py
+++ b/lib/spack/spack/test/url_parse.py
@@ -429,6 +429,8 @@ def test_url_parse_offset(name, noffset, ver, voffset, path):
     # .tgz
     ('ADOL-C', '2.6.1',
      'http://www.coin-or.org/download/source/ADOL-C/ADOL-C-2.6.1.tgz'),
+    # .tbz
+    ('mpfr', '4.0.1', 'https://ftpmirror.gnu.org/mpfr/mpfr-4.0.1.tbz'),
     # .tbz2
     ('mpfr', '4.0.1', 'https://ftpmirror.gnu.org/mpfr/mpfr-4.0.1.tbz2'),
     # .txz

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -11,7 +11,7 @@ from spack.util.executable import which
 # Supported archive extensions.
 PRE_EXTS   = ["tar", "TAR"]
 EXTS       = ["gz", "bz2", "xz", "Z"]
-NOTAR_EXTS = ["zip", "tgz", "tbz2", "txz"]
+NOTAR_EXTS = ["zip", "tgz", "tbz", "tbz2", "txz"]
 
 # Add PRE_EXTS and EXTS last so that .tar.gz is matched *before* .tar or .gz
 ALLOWED_ARCHIVE_TYPES = [".".join(ext) for ext in product(


### PR DESCRIPTION
Apparently `.tbz` file extensions are a thing. For example: https://gdo152.llnl.gov/cowc/download/cowc/datasets/patch_sets/detection/COWC_Detection_Selwyn_LINZ.tbz

I haven't yet found a software package that uses this suffix, but it isn't hard to add support for, so why not.