### PR TITLE
CUDA: 11.0.3 (11.0 "Update 1")

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -94,7 +94,7 @@ class CudaPackage(PackageBase):
     conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=x86_64:')
     conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89 target=x86_64:')
     conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2: target=x86_64:')
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2 target=x86_64:')
+    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.3 target=x86_64:')
     conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
     conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27 target=x86_64:')
     conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5 target=x86_64:')
@@ -117,7 +117,7 @@ class CudaPackage(PackageBase):
               when='+cuda ^cuda@10.1.105:10.1.243 target=x86_64:')
     conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89 target=x86_64:')
     conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=x86_64:')
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=x86_64:')
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.3 target=x86_64:')
     conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
 
     # x86_64 vs. ppc64le differ according to NVidia docs
@@ -134,7 +134,7 @@ class CudaPackage(PackageBase):
     conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243 target=ppc64le:')
     # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
     conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2: target=ppc64le:')
-    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
+    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.3 target=ppc64le:')
     conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
     conflicts('%pgi', when='+cuda ^cuda@:8 target=ppc64le:')
     conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185 target=ppc64le:')
@@ -146,7 +146,7 @@ class CudaPackage(PackageBase):
     conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105 target=ppc64le:')
     conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89 target=ppc64le:')
     conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=ppc64le:')
-    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.3 target=ppc64le:')
     conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
 
     # Intel is mostly relevant for x86_64 Linux, even though it also

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -51,6 +51,10 @@ _versions = {
         'Linux-aarch64': ('878cbd36c5897468ef28f02da50b2f546af0434a8a89d1c724a4d2013d6aa993', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux_sbsa.run'),
         'Linux-x86_64': ('858cbab091fde94556a249b9580fadff55a46eafbcb4d4a741d2dcd358ab94a5', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux.run'),
         'Linux-ppc64le': ('a561e6f7f659bc4100e4713523b0b8aad6b36aa77fac847f6423e7780c750064', 'https://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/cuda_11.1.0_455.23.05_linux_ppc64le.run')},
+    '11.0.3': {
+        'Linux-aarch64': ('1e24f61f79c1043aa3d1d126ff6158daa03a62a51b5195a2ed5fbe75c3b718f3', 'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux_sbsa.run'),
+        'Linux-x86_64': ('b079c4e408adf88c3f1ffb8418a97dc4227c37935676b4bf4ca0beec6c328cc0', 'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run'),
+        'Linux-ppc64le': ('4775b21df004b1433bafff9b48a324075c008509f4c0fe28cd060d042d2e0794', 'https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux_ppc64le.run')},
     '11.0.2': {
         'Linux-aarch64': ('23851e30f7c47a1baad92891abde0adbc783de5962c7480b9725198ceacda4a0', 'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux_sbsa.run'),
         'Linux-x86_64': ('48247ada0e3f106051029ae8f70fbd0c238040f58b0880e55026374a959a69c1', 'https://developer.download.nvidia.com/compute/cuda/11.0.2/local_installers/cuda_11.0.2_450.51.05_linux.run'),


### PR DESCRIPTION
Add CUDA 11.0.3 aka "11.0 Update 1": https://developer.nvidia.com/cuda-11.0-update1-download-archive

This release adds new features such as NVCC flags
`--forward-unknown-to-host-compiler` and
`--forward-unknown-to-host-linker`