### PR TITLE
cmake and now trilinos don't conflict

### DIFF
--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -28,14 +28,15 @@ class Nalu(CMakePackage):
             description='Compile with Tioga support')
 
     # Required dependencies
+    depends_on('cmake@3.20.0')
     depends_on('mpi')
     depends_on('yaml-cpp@0.5.3:', when='+shared')
     depends_on('yaml-cpp~shared@0.5.3:', when='~shared')
     # Cannot build Trilinos as a shared library with STK on Darwin
     # which is why we have a 'shared' variant for Nalu
     # https://github.com/trilinos/Trilinos/issues/2994
-    depends_on('trilinos+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop', when='+shared')
-    depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop', when='~shared')
+    depends_on('trilinos@master,develop ~cuda~wrapper+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+pnetcdf+shards~hypre cxxstd=14', when='+shared')
+    depends_on('trilinos@master,develop ~cuda~wrapper+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+pnetcdf+shards~hypre cxxstd=14', when='~shared')
     # Optional dependencies
     depends_on('tioga', when='+tioga+shared')
     depends_on('tioga~shared', when='+tioga~shared')


### PR DESCRIPTION
This patch ups the dependent version of cmake and fixes the correct way to describe trilinos dependence.  Tested on AWS skylake C5n using spack’s gcc@11.1.0 and system openmpi (w/ efa).