### PR TITLE
Fix broken CI for package only PRs, make dateutil not strictly required

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -156,6 +156,8 @@ jobs:
           make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install
     - name: Bootstrap clingo from sources
       if: ${{ matrix.concretizer == 'clingo' }}
+      env:
+          SPACK_PYTHON: python
       run: |
           . share/spack/setup-env.sh
           spack external find --not-buildable cmake bison
@@ -163,6 +165,7 @@ jobs:
     - name: Run unit tests (full suite with coverage)
       if: ${{ needs.changes.outputs.with_coverage == 'true' }}
       env:
+          SPACK_PYTHON: python
           COVERAGE: true
           SPACK_TEST_SOLVER: ${{ matrix.concretizer }}
       run: |
@@ -172,6 +175,7 @@ jobs:
     - name: Run unit tests (reduced suite without coverage)
       if: ${{ needs.changes.outputs.with_coverage == 'false' }}
       env:
+          SPACK_PYTHON: python
           ONLY_PACKAGES: true
           SPACK_TEST_SOLVER: ${{ matrix.concretizer }}
       run: |

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -12,20 +12,19 @@ import os
 import os.path
 import re
 import shutil
-import sys
 import tempfile
 import xml.etree.ElementTree
 
-if sys.version_info >= (2, 7):
+try:
     # CVS outputs dates in different formats on different systems. We are using
     # the dateutil package to parse these dates. This package does not exist
     # for Python <2.7. That means that we cannot test checkouts "by date" for
     # CVS respositories. (We can still use CVS repos with all features, only
     # our tests break.)
     from dateutil.parser import parse as parse_date
-else:
+except ImportError:
     def parse_date(string):
-        pytest.skip("dateutil package not available for Python 2.6")
+        pytest.skip("dateutil package not available")
 
 import py
 import pytest

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -16,10 +16,10 @@ import sys
 import tempfile
 import xml.etree.ElementTree
 
-if sys.version_info >= (3,):
+if sys.version_info >= (2, 7):
     # CVS outputs dates in different formats on different systems. We are using
     # the dateutil package to parse these dates. This package does not exist
-    # for Python 2.x. That means that we cannot test checkouts "by date" for
+    # for Python <2.7. That means that we cannot test checkouts "by date" for
     # CVS respositories. (We can still use CVS repos with all features, only
     # our tests break.)
     from dateutil.parser import parse as parse_date

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -23,7 +23,7 @@ try:
     # our tests break.)
     from dateutil.parser import parse as parse_date
 except ImportError:
-    def parse_date(string):
+    def parse_date(string):  # type: ignore
         pytest.skip("dateutil package not available")
 
 import py


### PR DESCRIPTION
Modifications:
- [x] Enforce the Python interpreter being used by setting `SPACK_PYTHON`
- [x] Revert modification on `python-dateutil` not being present in Python 2.7
- [x] Make `python-dateutil` not a hard requirement for unit tests   