### PR TITLE
Sensei repo update

### DIFF
--- a/var/spack/repos/builtin/packages/sensei/package.py
+++ b/var/spack/repos/builtin/packages/sensei/package.py
@@ -15,8 +15,8 @@ class Sensei(CMakePackage):
 
     homepage = "https://sensei-insitu.org"
     url      = "https://gitlab.kitware.com/sensei/sensei/-/archive/v3.1.0/sensei-v3.1.0.tar.gz"
-    git      = "https://gitlab.kitware.com/sensei/sensei.git"
-    maintainers = ['sshudler']
+    git      = "https://github.com/SENSEI-insitu/SENSEI.git"
+    maintainers = ['sshudler','rkrattiger']
 
     version('develop', branch='develop')
     version('3.2.1', sha256='8cde9ac5313e6c03fd793d24a6f285b60cca14cacfc83931f11d878163ee9d5b')

--- a/var/spack/repos/builtin/packages/sensei/package.py
+++ b/var/spack/repos/builtin/packages/sensei/package.py
@@ -14,20 +14,20 @@ class Sensei(CMakePackage):
     Visit/Libsim, ADIOS, Python scripts, and so on."""
 
     homepage = "https://sensei-insitu.org"
-    url      = "https://gitlab.kitware.com/sensei/sensei/-/archive/v3.1.0/sensei-v3.1.0.tar.gz"
+    url      = "https://github.com/SENSEI-insitu/SENSEI/releases/download/v3.2.1/SENSEI-3.2.1.tar.gz"
     git      = "https://github.com/SENSEI-insitu/SENSEI.git"
-    maintainers = ['sshudler','rkrattiger']
+    maintainers = ['sshudler', 'kwryankrattiger']
 
     version('develop', branch='develop')
-    version('3.2.1', sha256='8cde9ac5313e6c03fd793d24a6f285b60cca14cacfc83931f11d878163ee9d5b')
-    version('3.2.0', sha256='fe4fe294c17e469bfd1824130648a7d25b1fa771904b5c5edc37b820d090e224')
-    version('3.1.0', sha256='9a3e6d0d5bb6170ee666586435434da1708b3876fd448b9d41142571ed9da939')
-    version('3.0.0', sha256='0aabbea03ade9947c88fc0aa6d3cbaf3c8267e8504e384a041445678a95e58eb')
-    version('2.1.1', sha256='8a27ebf133fef00a59e4b29433762e6560bf20214072de7808836eb668bb5687')
-    version('2.1.0', sha256='b7af21a25523cf6cd8934d797471b75ca32881166625d71f24b5c8b6d727ca99')
-    version('2.0.0', sha256='df48eab035e1acdd8edf5159955c05306f9ca48117effacc4a6b77c3fb24f62b')
-    version('1.1.0', sha256='e5a4ba691573ff6c7b0d4793665e218ee5868ebcc0198915d1f16a4b7b92a368')
-    version('1.0.0', sha256='bdcb03c56b51f2795ec5a7e85a5abb01d473d192fac50f2a8bf2608cc3564ff8')
+    version('3.2.1', sha256='7438fb4b148e4d1eb888c619366d0d8639122ecbbf1767e19549d6ca0c8698ca')
+    version('3.2.0', sha256='fd1a69134d9f8151d85a7f84a67d6a648aef5580585b39f74a56367cff433c82')
+    version('3.1.0', sha256='813075e033904835afa74231a841ab46424d4567157ee7366f3b785357ffc0ea')
+    version('3.0.0', sha256='e9b4d7531bbe8848a7fb182f1d2706b397d18e1a580a51f79b4bf6793be195e5')
+    version('2.1.1', sha256='7e211b3d9ce8576d33dbb39ea367c971bb8863e1cf53b9c0e13f00b53bd16526')
+    version('2.1.0', sha256='3de667523d5a8e5576e29ff9528f7f341fcc799b55c9cd824dc61c7ca1a2a910')
+    version('2.0.0', sha256='e985778ebbf0b9a103d11e069e58f8975f98a63dc2861b7cde34ea12a23fee20')
+    version('1.1.0', sha256='769e0b5db50be25666c0d13176a7e4f89cbffe19cdc12349437d0efff615b200')
+    version('1.0.0', sha256='5b8609352048e048e065a7b99f615a602f84b3329085e40274341488ef1b9522')
 
     variant('shared', default=True, description='Enables shared libraries')
     variant('sencore', default=True, description='Enables the SENSEI core library')


### PR DESCRIPTION
Update `url` and `git` attributes in Sensei package to point to new locations on [Github](https://github.com/SENSEI-insitu/SENSEI/)