### PR TITLE
ocl-icd, opencl-c-headers and opencl-clhpp: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -43,6 +43,16 @@ OpenCL ICD loaders."""
     provides('opencl@:2.1', when='@2.2.8:2.2.11+headers')
     provides('opencl@:2.0', when='@2.2.3:2.2.7+headers')
 
+    def configure_args(self):
+        # use Khronos OpenCL headers provided in the sources instead of OpenCL
+        # headers installed on the system or via spack package opencl-headers
+        # to avoid build problems with incompatible OpenCL headers, ie if they
+        # to not match the exact version as the configure script only checks if
+        # the headers support >= 3.0
+        args = ['--enable-official-khronos-headers']
+
+        return args
+
     def flag_handler(self, name, flags):
         if name == 'cflags' and self.spec.satisfies('@:2.2.12'):
             # https://github.com/OCL-dev/ocl-icd/issues/8

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -13,6 +13,7 @@ OpenCL ICD loaders."""
     homepage = "https://github.com/OCL-dev/ocl-icd"
     url      = "https://github.com/OCL-dev/ocl-icd/archive/v2.2.12.tar.gz"
 
+    version('2.3.0', sha256='469f592ccd9b0547fb7212b17e1553b203d178634c20d3416640c0209e3ddd50')
     version('2.2.14', sha256='46df23608605ad548e80b11f4ba0e590cef6397a079d2f19adf707a7c2fbfe1b')
     version('2.2.13', sha256='f85d59f3e8327f15637b91e4ae8df0829e94daeff68c647b2927b8376b1f8d92')
     version('2.2.12', sha256='17500e5788304eef5b52dbe784cec197bdae64e05eecf38317840d2d05484272')

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -43,6 +43,8 @@ OpenCL ICD loaders."""
     provides('opencl@:2.1', when='@2.2.8:2.2.11+headers')
     provides('opencl@:2.0', when='@2.2.3:2.2.7+headers')
 
+    # upstream patch to fix compatibility with the latest version of the
+    # official khronos OpenCL C headers release, ie opencl-c-headers@2021.04.29
     patch('https://github.com/OCL-dev/ocl-icd/commit/aed1832c81c0971ea001e12d41e04df834257f94.patch',
           sha256='c6bb2813e2a59ac9b79b86d7f421c3e6446c0f9d8a4c850e5641fb7273ab3b43', when='@2.3.0')
 

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -43,15 +43,8 @@ OpenCL ICD loaders."""
     provides('opencl@:2.1', when='@2.2.8:2.2.11+headers')
     provides('opencl@:2.0', when='@2.2.3:2.2.7+headers')
 
-    def configure_args(self):
-        # use Khronos OpenCL headers provided in the sources instead of OpenCL
-        # headers installed on the system or via spack package opencl-headers
-        # to avoid build problems with incompatible OpenCL headers, ie if they
-        # to not match the exact version as the configure script only checks if
-        # the headers support >= 3.0
-        args = ['--enable-official-khronos-headers']
-
-        return args
+    patch('https://github.com/OCL-dev/ocl-icd/commit/aed1832c81c0971ea001e12d41e04df834257f94.patch',
+          sha256='c6bb2813e2a59ac9b79b86d7f421c3e6446c0f9d8a4c850e5641fb7273ab3b43', when='@2.3.0')
 
     def flag_handler(self, name, flags):
         if name == 'cflags' and self.spec.satisfies('@:2.2.12'):

--- a/var/spack/repos/builtin/packages/opencl-c-headers/package.py
+++ b/var/spack/repos/builtin/packages/opencl-c-headers/package.py
@@ -14,6 +14,7 @@ class OpenclCHeaders(Package):
     homepage = "https://www.khronos.org/registry/OpenCL/"
     url      = "https://github.com/KhronosGroup/OpenCL-Headers/archive/v2020.06.16.tar.gz"
 
+    version('2021.04.29', sha256='477e2b26125d99a9b2f20c68262f27ca3f3ca7899593a8af2b7fe077bdce18d1')
     version('2020.12.18', sha256='5dad6d436c0d7646ef62a39ef6cd1f3eba0a98fc9157808dfc1d808f3705ebc2')
     version('2020.06.16', sha256='2f5a60e5ac4b127650618c58a7e3b35a84dbf23c1a0ac72eb5e7baf221600e06')
     version('2020.03.13', sha256='664bbe587e5a0a00aac267f645b7c413586e7bc56dca9ff3b00037050d06f476')

--- a/var/spack/repos/builtin/packages/opencl-clhpp/package.py
+++ b/var/spack/repos/builtin/packages/opencl-clhpp/package.py
@@ -14,6 +14,7 @@ class OpenclClhpp(CMakePackage):
     homepage = "https://www.khronos.org/registry/OpenCL/"
     url      = "https://github.com/KhronosGroup/OpenCL-CLHPP/archive/v2.0.12.tar.gz"
 
+    version('2.0.14', sha256='c8821a7638e57a2c4052631c941af720b581edda634db6ab0b59924c958d69b6')
     version('2.0.13', sha256='8ff0d0cd94d728edd30c876db546bf13e370ee7863629b4b9b5e2ef8e130d23c')
     version('2.0.12', sha256='20b28709ce74d3602f1a946d78a2024c1f6b0ef51358b9686612669897a58719')
     version('2.0.11', sha256='ffc2ca08cf4ae90ee55f14ea3735ccc388f454f4422b69498b2e9b93a1d45181')


### PR DESCRIPTION
This PR adds the new version from `ocl-icd` and also for  `opencl-c-headers` and `opencl-clhpp`. I had problems building `ocl-icd` with the  `opencl-c-headers`, because this `ocl-icd` version uses an untagged copy of these headers somewhere between `opencl-c-headers@2020.12.18` and `opencl-c-header@2021.04.29`, so I decided to use an upstream patch, that's also the way, [archlinux](https://github.com/archlinux/svntogit-packages/blob/96a94c57472947d89d468fb81529acdd0844d85d/trunk/PKGBUILD#L27) and [opensuse](https://build.opensuse.org/request/show/900646) builds this packages. Another option would be to use the copy of these headers, which is shipped with `ocl-icd` and can be enabled via the configure script, but I find it cleaner to use the installed headers.