### PR TITLE
Add Externally Findable section to info command

### DIFF
--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -156,6 +156,32 @@ def print_text_info(pkg):
         color.cprint(section_title('Maintainers: ') + mnt)
 
     color.cprint('')
+    color.cprint(section_title('Externally Findable: '))
+    find_method = ''
+    is_findable = False
+    if hasattr(pkg, 'executables'):
+        is_findable = True
+        find_method += 'executables'
+
+    if hasattr(pkg, 'determine_version'):
+        is_findable = True
+        find_method += ', ' if len(find_method) > 0 else ''
+        find_method += 'version'
+
+    if hasattr(pkg, 'determine_variants'):
+        is_findable = True
+        find_method += ', ' if len(find_method) > 0 else ''
+        find_method += 'variants'
+
+    # What to do with this?
+    # if hasattr(pkg, 'determine_spec_details'):
+    #     is_findable = True
+    #     find_method += ', ' if len(find_method) > 0 else ''
+    #     find_method += 'custom'
+
+    color.cprint('    {0}'.format(find_method if len(find_method) > 0 else 'False'))
+
+    color.cprint('')
     color.cprint(section_title("Tags: "))
     if hasattr(pkg, 'tags'):
         tags = sorted(pkg.tags)

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -10,7 +10,6 @@ from six.moves import zip_longest
 
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
-from spack.util.string import comma_and
 from llnl.util.tty.colify import colify
 
 import spack.cmd.common.arguments as arguments

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -171,10 +171,8 @@ def print_text_info(pkg):
         # If the package does not define 'determine_version' nor
         # 'determine_variants', then it must use some custom detection
         # mechanism. In this case, just inform the user it's detectable somehow.
-        if len(find_attributes) == 0:
-            color.cprint('    True')
-        else:
-            color.cprint('    {0}'.format(', '.join(find_attributes)))
+        color.cprint('    True{0}'.format(
+            ' (' + ', '.join(find_attributes) + ')' if find_attributes else ''))
     else:
         color.cprint('    False')
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -158,24 +158,19 @@ def print_text_info(pkg):
     color.cprint('')
     color.cprint(section_title('Externally Findable: '))
     find_method = ''
-    is_findable = False
     if hasattr(pkg, 'executables'):
-        is_findable = True
         find_method += 'executables'
 
     if hasattr(pkg, 'determine_version'):
-        is_findable = True
         find_method += ', ' if len(find_method) > 0 else ''
         find_method += 'version'
 
     if hasattr(pkg, 'determine_variants'):
-        is_findable = True
         find_method += ', ' if len(find_method) > 0 else ''
         find_method += 'variants'
 
     # What to do with this?
     # if hasattr(pkg, 'determine_spec_details'):
-    #     is_findable = True
     #     find_method += ', ' if len(find_method) > 0 else ''
     #     find_method += 'custom'
 

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -10,6 +10,7 @@ from six.moves import zip_longest
 
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
+from spack.util.string import comma_and
 from llnl.util.tty.colify import colify
 
 import spack.cmd.common.arguments as arguments
@@ -156,25 +157,21 @@ def print_text_info(pkg):
         color.cprint(section_title('Maintainers: ') + mnt)
 
     color.cprint('')
-    color.cprint(section_title('Externally Findable: '))
-    find_method = ''
+    color.cprint(section_title('Externally Detectable: '))
     if hasattr(pkg, 'executables'):
-        find_method += 'executables'
+        find_attributes = []
+        if hasattr(pkg, 'determine_version'):
+            find_attributes.append('version')
 
-    if hasattr(pkg, 'determine_version'):
-        find_method += ', ' if len(find_method) > 0 else ''
-        find_method += 'version'
+        if hasattr(pkg, 'determine_variants'):
+            find_attributes.append('variants')
 
-    if hasattr(pkg, 'determine_variants'):
-        find_method += ', ' if len(find_method) > 0 else ''
-        find_method += 'variants'
+        if hasattr(pkg, 'determine_spec_details'):
+            find_attributes.append('custom')
 
-    # What to do with this?
-    # if hasattr(pkg, 'determine_spec_details'):
-    #     find_method += ', ' if len(find_method) > 0 else ''
-    #     find_method += 'custom'
-
-    color.cprint('    {0}'.format(find_method if len(find_method) > 0 else 'False'))
+        color.cprint('    {0}'.format(comma_and(find_attributes)))
+    else:
+        color.cprint('    False')
 
     color.cprint('')
     color.cprint(section_title("Tags: "))

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -158,6 +158,8 @@ def print_text_info(pkg):
 
     color.cprint('')
     color.cprint(section_title('Externally Detectable: '))
+
+    # If the package has an 'executables' field, it can detect an installation
     if hasattr(pkg, 'executables'):
         find_attributes = []
         if hasattr(pkg, 'determine_version'):
@@ -166,10 +168,13 @@ def print_text_info(pkg):
         if hasattr(pkg, 'determine_variants'):
             find_attributes.append('variants')
 
-        if hasattr(pkg, 'determine_spec_details'):
-            find_attributes.append('custom')
-
-        color.cprint('    {0}'.format(comma_and(find_attributes)))
+        # If the package does not define 'determine_version' nor
+        # 'determine_variants', then it must use some custom detection
+        # mechanism. In this case, just inform the user it's detectable somehow.
+        if len(find_attributes) == 0:
+            color.cprint('    True')
+        else:
+            color.cprint('    {0}'.format(', '.join(find_attributes)))
     else:
         color.cprint('    False')
 

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -48,6 +48,22 @@ def test_it_just_runs(pkg):
     info(pkg)
 
 
+@pytest.mark.parametrize('pkg_query,expected', [
+    ('zlib', 'False'),
+    ('gcc', 'True (version, variants)'),
+])
+@pytest.mark.usefixtures('mock_print')
+def test_is_externally_detectable(pkg_query, expected, parser, info_lines):
+    args = parser.parse_args([pkg_query])
+    spack.cmd.info.info(parser, args)
+
+    line_iter = info_lines.__iter__()
+    for line in line_iter:
+        if 'Externally Detectable' in line:
+            is_externally_detectable = next(line_iter).strip()
+            assert is_externally_detectable == expected
+
+
 @pytest.mark.parametrize('pkg_query', [
     'hdf5',
     'cloverleaf3d',
@@ -59,6 +75,7 @@ def test_info_fields(pkg_query, parser, info_lines):
     expected_fields = (
         'Description:',
         'Homepage:',
+        'Externally Detectable:',
         'Safe versions:',
         'Variants:',
         'Installation Phases:',


### PR DESCRIPTION
Include if/how given package is findable via `spack external find` in `spack info` command.

CC @becker33