### PR TITLE
Pipelines: Set a pipeline type variable

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -549,9 +549,8 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
     generate_job_name = os.environ.get('CI_JOB_NAME', None)
     parent_pipeline_id = os.environ.get('CI_PIPELINE_ID', None)
 
-    is_pr_pipeline = (
-        os.environ.get('SPACK_IS_PR_PIPELINE', '').lower() == 'true'
-    )
+    spack_pipeline_type = os.environ.get('SPACK_PIPELINE_TYPE', None)
+    is_pr_pipeline = spack_pipeline_type == 'spack_pull_request'
 
     spack_pr_branch = os.environ.get('SPACK_PR_BRANCH', None)
     pr_mirror_url = None
@@ -1073,7 +1072,7 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
             'SPACK_JOB_LOG_DIR': rel_job_log_dir,
             'SPACK_JOB_REPRO_DIR': rel_job_repro_dir,
             'SPACK_LOCAL_MIRROR_DIR': rel_local_mirror_dir,
-            'SPACK_IS_PR_PIPELINE': str(is_pr_pipeline)
+            'SPACK_PIPELINE_TYPE': str(spack_pipeline_type)
         }
 
         if pr_mirror_url:

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -612,14 +612,14 @@ spack:
         outputfile = str(tmpdir.join('.gitlab-ci.yml'))
 
         with ev.read('test'):
-            os.environ['SPACK_IS_PR_PIPELINE'] = 'True'
+            os.environ['SPACK_PIPELINE_TYPE'] = 'spack_pull_request'
             os.environ['SPACK_PR_BRANCH'] = 'fake-test-branch'
             monkeypatch.setattr(
                 ci, 'SPACK_PR_MIRRORS_ROOT_URL', r"file:///fake/mirror")
             try:
                 ci_cmd('generate', '--output-file', outputfile)
             finally:
-                del os.environ['SPACK_IS_PR_PIPELINE']
+                del os.environ['SPACK_PIPELINE_TYPE']
                 del os.environ['SPACK_PR_BRANCH']
 
         with open(outputfile) as f:
@@ -630,8 +630,8 @@ spack:
 
             assert('variables' in yaml_contents)
             pipeline_vars = yaml_contents['variables']
-            assert('SPACK_IS_PR_PIPELINE' in pipeline_vars)
-            assert(pipeline_vars['SPACK_IS_PR_PIPELINE'] == 'True')
+            assert('SPACK_PIPELINE_TYPE' in pipeline_vars)
+            assert(pipeline_vars['SPACK_PIPELINE_TYPE'] == 'spack_pull_request')
 
 
 def test_ci_generate_with_external_pkg(tmpdir, mutable_mock_env_path,
@@ -779,7 +779,7 @@ spack:
         set_env_var('SPACK_CDASH_BUILD_NAME', '(specs) archive-files')
         set_env_var('SPACK_RELATED_BUILDS_CDASH', '')
         set_env_var('SPACK_REMOTE_MIRROR_URL', mirror_url)
-        set_env_var('SPACK_IS_DEVELOP_PIPELINE', 'True')
+        set_env_var('SPACK_PIPELINE_TYPE', 'spack_protected_branch')
 
         ci_cmd('rebuild', fail_on_error=False)
 

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -12,13 +12,13 @@ default:
   - /^github\/pr[\d]+_.*$/
   variables:
     SPACK_PR_BRANCH: ${CI_COMMIT_REF_NAME}
-    SPACK_IS_PR_PIPELINE: "True"
+    SPACK_PIPELINE_TYPE: "spack_pull_request"
 
 .develop:
   only:
   - /^github\/develop$/
   variables:
-    SPACK_IS_PR_PIPELINE: "False"
+    SPACK_PIPELINE_TYPE: "spack_protected_branch"
 
 .generate:
   stage: generate


### PR DESCRIPTION
Spack pipelines need to take specific actions internally that depend
on whether the pipeline is being run on a PR to spack or a merge to
the develop branch.  Pipelines can also run in other repositories,
which represents other possible use cases than just the two mentioned
above.  This PR creates a "SPACK_PIPELINE_TYPE" gitlab variable which
is propagated to rebuild jobs, and is also used internally to determine
which pipeline-specific tasks to run.

One goal of the PR is fix an issue where rebuild jobs which failed on
develop pipelines did not properly report the broken full hash to the
"broken-specs-url".