### PR TITLE
cc: Use parameter expansion instead of basename

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -128,7 +128,7 @@ fi
 #    ld      link
 #    ccld    compile & link
 
-command=$(basename "$0")
+command="${0##*/}"
 comp="CC"
 case "$command" in
     cpp)


### PR DESCRIPTION
While debugging #24508, I noticed that we call `basename` in `cc`. The same can be achieved by using Bash's parameter expansion, saving one external process per call.