### PR TITLE
Update Jasper to 2.0.32

### DIFF
--- a/var/spack/repos/builtin/packages/jasper/package.py
+++ b/var/spack/repos/builtin/packages/jasper/package.py
@@ -10,10 +10,12 @@ class Jasper(Package):
     """Library for manipulating JPEG-2000 images"""
 
     homepage = "https://www.ece.uvic.ca/~frodo/jasper/"
-    url      = "https://github.com/mdadams/jasper/archive/version-2.0.16.tar.gz"
+    url      = "https://github.com/mdadams/jasper/archive/version-2.0.32.tar.gz"
 
-    version('2.0.16',  sha256='f1d8b90f231184d99968f361884e2054a1714fdbbd9944ba1ae4ebdcc9bbfdb1')
-    version('2.0.14',  sha256='85266eea728f8b14365db9eaf1edc7be4c348704e562bb05095b9a077cf1a97b')
+    version('2.0.32', sha256='a3583a06698a6d6106f2fc413aa42d65d86bedf9a988d60e5cfa38bf72bc64b9')
+    version('2.0.31', sha256='d419baa2f8a6ffda18472487f6314f0f08b673204723bf11c3a1f5b3f1b8e768')
+    version('2.0.16', sha256='f1d8b90f231184d99968f361884e2054a1714fdbbd9944ba1ae4ebdcc9bbfdb1')
+    version('2.0.14', sha256='85266eea728f8b14365db9eaf1edc7be4c348704e562bb05095b9a077cf1a97b')
     version('1.900.1', sha256='c2b03f28166f9dc8ae434918839ae9aa9962b880fcfd24eebddd0a2daeb9192c')
 
     variant('jpeg',   default=True,  description='Enable the use of the JPEG library')


### PR DESCRIPTION
Update Jasper to 2.0.32 which includes multiple bug fixes.

**Changelog:**
- Loosen some overly tight restrictions on JP2 codestreams, which caused
  some valid codestreams to be rejected.
- Fix potential null pointer dereference in the JP2/JPC decoder.
- Fix ignoring of JAS_STREAM_FILEOBJ_NOCLOSE at stream close time.
- Fix integral type sizing problem in JP2 codec.

**Test Plan:**
2.0.32 build successfully within the Autamus Build Workflow [here](https://github.com/autamus/registry/runs/2383581863).