### PR TITLE
Update Lmod to 8.5.6

### DIFF
--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -17,8 +17,9 @@ class Lmod(AutotoolsPackage):
     """
 
     homepage = 'https://www.tacc.utexas.edu/research-development/tacc-projects/lmod'
-    url      = 'https://github.com/TACC/Lmod/archive/7.4.11.tar.gz'
+    url      = "https://github.com/TACC/Lmod/archive/8.5.6.tar.gz"
 
+    version('8.5.6',  sha256='1d1058ffa33a661994c1b2af4bfee4aa1539720cd5c13d61e18adbfb231bbe88')
     version('8.3',    sha256='c2c2e9e6b387b011ee617cb009a2199caac8bf200330cb8a065ceedee09e664a')
     version('8.2.10', sha256='15676d82235faf5c755a747f0e318badb1a5c3ff1552fa8022c67ff083ee9e2f')
     version('8.1.5',  sha256='3e5846d3d8e593cbcdfa0aed1474569bf5b5cfd19fd288de22051823d449d344')


### PR DESCRIPTION
Update Lmod to 8.5.6

**Test Plan:**
8.5.6 built successfully within the Autamus Build Workflow [here](https://github.com/autamus/registry/runs/2885620065).