### PR TITLE
p4est: use autoreconf only for @:2.2

### DIFF
--- a/var/spack/repos/builtin/packages/p4est/package.py
+++ b/var/spack/repos/builtin/packages/p4est/package.py
@@ -48,8 +48,9 @@ class P4est(AutotoolsPackage):
           when='@2.0')
 
     def autoreconf(self, spec, prefix):
-        bootstrap = Executable('./bootstrap')
-        bootstrap()
+        if self.spec.satisfies('@:2.2'):
+            bootstrap = Executable('./bootstrap')
+            bootstrap()
 
     def configure_args(self):
         args = [


### PR DESCRIPTION
This fixes @2.3.2 build breakage with #23824 changes

```
==> p4est: Executing phase: 'autoreconf'
==> Error: ProcessError: Command exited with status 1:
    './bootstrap'

2 errors found in build log:
     5     It is NOT required to run bootstrap to build from a tar.gz archive
     6     Development requires a libtool recent enough to contain LT_INIT
     7     Current directory is /data/balay/spack.x/spack-stage/spack-stage-p4est-2.3.2-hqihqwmmaz273f7qkwkofmoyd67kvhlb/spack-src/sc
     8     glibtoolize:   error: 'build-aux/config.guess' is newer: use '--force' to overwrite
     9     glibtoolize:   error: 'build-aux/config.sub' is newer: use '--force' to overwrite
     10    glibtoolize:   error: 'build-aux/install-sh' is newer: use '--force' to overwrite
  >> 11    Makefile.am:26: error: 'pkgconfig_DATA' is used but 'pkgconfigdir' is undefined
     12    --- This is the bootstrap script for p4est ---
     13    It is NOT required to run bootstrap to build from a tar.gz archive
     14    Development requires a libtool recent enough to contain LT_INIT
     15    Current directory is /data/balay/spack.x/spack-stage/spack-stage-p4est-2.3.2-hqihqwmmaz273f7qkwkofmoyd67kvhlb/spack-src
     16    glibtoolize:   error: 'build-aux/config.guess' is newer: use '--force' to overwrite
     17    glibtoolize:   error: 'build-aux/config.sub' is newer: use '--force' to overwrite
     18    glibtoolize:   error: 'build-aux/install-sh' is newer: use '--force' to overwrite
  >> 19    Makefile.am:30: error: 'pkgconfig_DATA' is used but 'pkgconfigdir' is undefined

See build log for details:
  /data/balay/spack.x/spack-stage/spack-stage-p4est-2.3.2-hqihqwmmaz273f7qkwkofmoyd67kvhlb/spack-build-out.txt

==> Error: Terminating after first install failure: ProcessError: Command exited with status 1:
    './bootstrap'
```
cc: @davydden @rmsds @marcfehling