### PR TITLE
RAJA + Umpire: CUDA Arch fixes

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -40,14 +40,17 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('blt@0.4.0:', type='build', when='@0.13.1:')
     depends_on('blt@:0.3.6', type='build', when='@:0.13.0')
 
-    depends_on('camp')
-    depends_on('camp+cuda', when='+cuda')
-
     # variants +rocm and amdgpu_targets are not automatically passed to
     # dependencies, so do it manually.
     depends_on('camp+rocm', when='+rocm')
     for val in ROCmPackage.amdgpu_targets:
         depends_on('camp amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
+
+    depends_on('camp')
+    depends_on('camp+cuda', when='+cuda')
+    for sm_ in CudaPackage.cuda_arch_values:
+        depends_on('camp cuda_arch={0}'.format(sm_),
+                when='cuda_arch={0}'.format(sm_))
 
     conflicts('+openmp', when='+rocm')
 
@@ -68,6 +71,7 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
             if not spec.satisfies('cuda_arch=none'):
                 cuda_arch = spec.variants['cuda_arch'].value
                 options.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
+                options.append('-DCMAKE_CUDA_ARCHITECTURES={0}'.format(cuda_arch[0]))
         else:
             options.append('-DENABLE_CUDA=OFF')
 

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -50,7 +50,7 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('camp+cuda', when='+cuda')
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on('camp cuda_arch={0}'.format(sm_),
-                when='cuda_arch={0}'.format(sm_))
+                   when='cuda_arch={0}'.format(sm_))
 
     conflicts('+openmp', when='+rocm')
 

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -74,7 +74,7 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
         depends_on('camp amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
 
     depends_on('camp')
-    depends_on('camp+cuda', when'+cuda')
+    depends_on('camp+cuda', when='+cuda')
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on('camp cuda_arch={0}'.format(sm_),
                 when='cuda_arch={0}'.format(sm_))

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -74,6 +74,10 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
         depends_on('camp amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
 
     depends_on('camp')
+    depends_on('camp+cuda', when'+cuda')
+    for sm_ in CudaPackage.cuda_arch_values:
+        depends_on('camp cuda_arch={0}'.format(sm_),
+                when='cuda_arch={0}'.format(sm_))
 
     conflicts('+numa', when='@:0.3.2')
     conflicts('~c', when='+fortran', msg='Fortran API requires C API')
@@ -97,6 +101,7 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
             if not spec.satisfies('cuda_arch=none'):
                 cuda_arch = spec.variants['cuda_arch'].value
                 options.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
+                options.append('-DCMAKE_CUDA_ARCHITECTURES={0}'.format(cuda_arch[0]))
                 flag = '-arch sm_{0}'.format(cuda_arch[0])
                 options.append('-DCMAKE_CUDA_FLAGS:STRING={0}'.format(flag))
 

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -77,7 +77,7 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('camp+cuda', when='+cuda')
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on('camp cuda_arch={0}'.format(sm_),
-                when='cuda_arch={0}'.format(sm_))
+                   when='cuda_arch={0}'.format(sm_))
 
     conflicts('+numa', when='@:0.3.2')
     conflicts('~c', when='+fortran', msg='Fortran API requires C API')


### PR DESCRIPTION
This PR does two things:

* Quiets one warning per CMake target not having the target property CUDA_ARCHITECTURES set in CMake 3.18+ (CMAKE_CUDA_ARCHITECTURES is the global variable that the property defaults to)
* Passes the `cuda_arch` down to the camp dependency for RAJA and Umpire

@davidbeckingsale 