### PR TITLE
setup-env: allow users to skip slow parts

### DIFF
--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -699,71 +699,73 @@ set -xg _sp_shell "fish"
 
 
 
-#
-# Check whether we need environment-variables (module) <= `use` is not available
-#
-set -l need_module "no"
-if test -z "$SPACK_SKIP_MODULES"; and not functions -q use; and not functions -q module
-    set need_module "yes"
-end
-
-
-
-#
-# Make environment-modules available to shell
-#
-function sp_apply_shell_vars -d "applies expressions of the type `a='b'` as `set a b`"
-
-    # convert `a='b' to array variable `a b`
-    set -l expr_token (string trim -c "'" (string split "=" $argv))
-
-    # run set command to takes, converting lists of type `a:b:c` to array
-    # variables `a b c` by splitting around the `:` character
-    set -xg $expr_token[1] (string split ":" $expr_token[2])
-end
-
-
-if test "$need_module" = "yes"
-    set -l sp_shell_vars (command spack --print-shell-vars sh,modules)
-
-    for sp_var_expr in $sp_shell_vars
-        sp_apply_shell_vars $sp_var_expr
+if test -z "$SPACK_SKIP_MODULES"
+    #
+    # Check whether we need environment-variables (module) <= `use` is not available
+    #
+    set -l need_module "no"
+    if not functions -q use; and not functions -q module
+        set need_module "yes"
     end
 
-    # _sp_module_prefix is set by spack --print-sh-vars
-    if test "$_sp_module_prefix" != "not_installed"
-        set -xg MODULE_PREFIX $_sp_module_prefix
-        spack_pathadd PATH "$MODULE_PREFIX/bin"
+
+
+    #
+    # Make environment-modules available to shell
+    #
+    function sp_apply_shell_vars -d "applies expressions of the type `a='b'` as `set a b`"
+
+        # convert `a='b' to array variable `a b`
+        set -l expr_token (string trim -c "'" (string split "=" $argv))
+
+        # run set command to takes, converting lists of type `a:b:c` to array
+        # variables `a b c` by splitting around the `:` character
+        set -xg $expr_token[1] (string split ":" $expr_token[2])
     end
 
-else
 
-    set -l sp_shell_vars (command spack --print-shell-vars sh)
+    if test "$need_module" = "yes"
+        set -l sp_shell_vars (command spack --print-shell-vars sh,modules)
 
-    for sp_var_expr in $sp_shell_vars
-        sp_apply_shell_vars $sp_var_expr
+        for sp_var_expr in $sp_shell_vars
+            sp_apply_shell_vars $sp_var_expr
+        end
+
+        # _sp_module_prefix is set by spack --print-sh-vars
+        if test "$_sp_module_prefix" != "not_installed"
+            set -xg MODULE_PREFIX $_sp_module_prefix
+            spack_pathadd PATH "$MODULE_PREFIX/bin"
+        end
+
+    else
+
+        set -l sp_shell_vars (command spack --print-shell-vars sh)
+
+        for sp_var_expr in $sp_shell_vars
+            sp_apply_shell_vars $sp_var_expr
+        end
+
     end
 
-end
-
-if test "$need_module" = "yes"
-    function module -d "wrapper for the `module` command to point at Spack's modules instance" --inherit-variable MODULE_PREFIX
-        eval $MODULE_PREFIX/bin/modulecmd $SPACK_SHELL $argv
+    if test "$need_module" = "yes"
+        function module -d "wrapper for the `module` command to point at Spack's modules instance" --inherit-variable MODULE_PREFIX
+            eval $MODULE_PREFIX/bin/modulecmd $SPACK_SHELL $argv
+        end
     end
+
+
+
+    #
+    # set module system roots
+    #
+
+    # Search of MODULESPATHS by trying all possible compatible system types as
+    # module roots.
+    if test -z "$MODULEPATH"
+        set -gx MODULEPATH
+    end
+    sp_multi_pathadd MODULEPATH $_sp_tcl_roots
 end
-
-
-
-#
-# set module system roots
-#
-
-# Search of MODULESPATHS by trying all possible compatible system types as
-# module roots.
-if test -z "$MODULEPATH"
-    set -gx MODULEPATH
-end
-sp_multi_pathadd MODULEPATH $_sp_tcl_roots
 
 
 

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -306,11 +306,6 @@ _spack_fn_exists() {
     LANG= type $1 2>&1 | grep -q 'function'
 }
 
-need_module="no"
-if [ -z "${SPACK_SKIP_MODULES+x}" ] && ! _spack_fn_exists use && ! _spack_fn_exists module; then
-    need_module="yes"
-fi;
-
 # Define the spack shell function with some informative no-ops, so when users
 # run `which spack`, they see the path to spack and where the function is from.
 eval "spack() {
@@ -334,48 +329,55 @@ for cmd in "${SPACK_PYTHON:-}" python3 python python2; do
     fi
 done
 
-#
-# make available environment-modules
-#
-if [ "${need_module}" = "yes" ]; then
-    eval `spack --print-shell-vars sh,modules`
-
-    # _sp_module_prefix is set by spack --print-sh-vars
-    if [ "${_sp_module_prefix}" != "not_installed" ]; then
-        # activate it!
-        # environment-modules@4: has a bin directory inside its prefix
-        _sp_module_bin="${_sp_module_prefix}/bin"
-        if [ ! -d "${_sp_module_bin}" ]; then
-            # environment-modules@3 has a nested bin directory
-            _sp_module_bin="${_sp_module_prefix}/Modules/bin"
-        fi
-
-        # _sp_module_bin and _sp_shell are evaluated here; the quoted
-        # eval statement and $* are deferred.
-        _sp_cmd="module() { eval \`${_sp_module_bin}/modulecmd ${_sp_shell} \$*\`; }"
-        eval "$_sp_cmd"
-        _spack_pathadd PATH "${_sp_module_bin}"
+if [ -z "${SPACK_SKIP_MODULES+x}" ]; then
+    need_module="no"
+    if ! _spack_fn_exists use && ! _spack_fn_exists module; then
+        need_module="yes"
     fi;
-else
-    eval `spack --print-shell-vars sh`
-fi;
+
+    #
+    # make available environment-modules
+    #
+    if [ "${need_module}" = "yes" ]; then
+        eval `spack --print-shell-vars sh,modules`
+
+        # _sp_module_prefix is set by spack --print-sh-vars
+        if [ "${_sp_module_prefix}" != "not_installed" ]; then
+            # activate it!
+            # environment-modules@4: has a bin directory inside its prefix
+            _sp_module_bin="${_sp_module_prefix}/bin"
+            if [ ! -d "${_sp_module_bin}" ]; then
+                # environment-modules@3 has a nested bin directory
+                _sp_module_bin="${_sp_module_prefix}/Modules/bin"
+            fi
+
+            # _sp_module_bin and _sp_shell are evaluated here; the quoted
+            # eval statement and $* are deferred.
+            _sp_cmd="module() { eval \`${_sp_module_bin}/modulecmd ${_sp_shell} \$*\`; }"
+            eval "$_sp_cmd"
+            _spack_pathadd PATH "${_sp_module_bin}"
+        fi;
+    else
+        eval `spack --print-shell-vars sh`
+    fi;
 
 
-#
-# set module system roots
-#
-_sp_multi_pathadd() {
-    local IFS=':'
-    if [ "$_sp_shell" = zsh ]; then
-        emulate -L sh
-    fi
-    for pth in $2; do
-        for systype in ${_sp_compatible_sys_types}; do
-            _spack_pathadd "$1" "${pth}/${systype}"
+    #
+    # set module system roots
+    #
+    _sp_multi_pathadd() {
+        local IFS=':'
+        if [ "$_sp_shell" = zsh ]; then
+            emulate -L sh
+        fi
+        for pth in $2; do
+            for systype in ${_sp_compatible_sys_types}; do
+                _spack_pathadd "$1" "${pth}/${systype}"
+            done
         done
-    done
-}
-_sp_multi_pathadd MODULEPATH "$_sp_tcl_roots"
+    }
+    _sp_multi_pathadd MODULEPATH "$_sp_tcl_roots"
+fi
 
 # Add programmable tab completion for Bash
 #


### PR DESCRIPTION
This is a follow-up to #24236 

Originally, I thought `spack --print-shell-vars sh,modules` was slowing down my shell initialization times. I didn't realize that in the else-clause we also call `spack --print-shell-vars sh`. Both options only set variables related to modules, and I don't use modules, so these are entirely useless to me. With this PR, users who set `SPACK_SKIP_MODULES` will have significantly faster startup times, especially on clusters where Spack is slow to run.

@michaelkuhn @eugeneswalker @alalazo @JBlaschke 