### PR TITLE
py-scipy: fix missing py-cython dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -65,6 +65,7 @@ class PyScipy(PythonPackage):
     depends_on('py-numpy@1.14.5:+blas+lapack', when='@1.5:1.5.999', type=('build', 'link', 'run'))
     depends_on('py-numpy@1.16.5:+blas+lapack', when='@1.6:1.6.1', type=('build', 'link', 'run'))
     depends_on('py-numpy@1.16.5:1.22.999+blas+lapack', when='@1.6.2:', type=('build', 'link', 'run'))
+    depends_on('py-cython@0.29.18:2.9', when='@1.7:', type='build')
     depends_on('py-pythran@0.9.11:', when='@1.7:', type=('build', 'link'))
     depends_on('py-pytest', type='test')
 


### PR DESCRIPTION
After the upgrade to 1.7.0 `py-scipy` did not build for me anymore with the following error

```
==> Installing py-scipy-1.7.0-vx7z4ppiptwbudmwem2wnakyzj7r4spe
==> No binary for py-scipy-1.7.0-vx7z4ppiptwbudmwem2wnakyzj7r4spe found: installing from source
==> Using cached archive: $spack/var/spack/cache/_source-cache/archive/99/998c5e6ea649489302de2c0bc026ed34284f531df89d2bdc8df3a0d44d165739.tar.gz
==> No patches needed for py-scipy
==> py-scipy: Executing phase: 'build'
==> [2021-06-26-01:22:13.400149] '$spack/opt/spack/linux-debian9-piledriver/gcc-11.1.0/python-3.8.10-qlxpnsh6n5qxwtyvf56biltled4k22d7/bin/python3.8' '-s' 'setup.py' '--no-user-cfg' 'build'
Running scipy/special/_generate_pyx.py
Running scipy/stats/_generate_pyx.py
Running scipy/linalg/_generate_pyx.py
Processing scipy/interpolate/_bspl.pyx
Processing scipy/interpolate/interpnd.pyx
Processing scipy/interpolate/_ppoly.pyx
Processing scipy/special/_ellip_harm_2.pyx
Processing scipy/special/_test_round.pyx
Processing scipy/special/cython_special.pyx
Processing scipy/special/_ufuncs.pyx
Processing scipy/special/_ufuncs_cxx.pyx
Processing scipy/special/_comb.pyx
Processing scipy/cluster/_optimal_leaf_ordering.pyx
Processing scipy/cluster/_vq.pyx
Processing scipy/cluster/_hierarchy.pyx
Processing scipy/optimize/_group_columns.pyx
Processing scipy/optimize/_bglu_dense.pyx
Processing scipy/optimize/_highs/cython/src/_highs_wrapper.pyx
Processing scipy/optimize/_highs/cython/src/_highs_constants.pyx
Processing scipy/optimize/_lsq/givens_elimination.pyx
Processing scipy/optimize/_trlib/_trlib.pyx
ImportError: No module named site
ImportError: No module named site
ImportError: No module named site
ImportError: No module named site
ImportError: No module named site
ImportError: No module named site
ImportError: No module named site
Processing scipy/optimize/cython_optimize/_zeros.pyx.in
ImportError: No module named site
ImportError: No module named site
ImportError: No module named site
ImportError: No module named site
Processing scipy/spatial/qhull.pyx
Traceback (most recent call last):
  File "$spage/spack-stage-py-scipy-1.7.0-vx7z4ppiptwbudmwem2wnakyzj7r4spe/spack-src/tools/cythonize.py", line 324, in <module>
    main()
  File "$stage/spack-stage-py-scipy-1.7.0-vx7z4ppiptwbudmwem2wnakyzj7r4spe/spack-src/tools/cythonize.py", line 320, in main
    find_process_files(root_dir)
  File "$stage/spack-stage-py-scipy-1.7.0-vx7z4ppiptwbudmwem2wnakyzj7r4spe/spack-src/tools/cythonize.py", line 309, in find_process_files
    for result in pool.imap_unordered(lambda args: process(*args), jobs):
  File "$spack/opt/spack/linux-debian9-piledriver/gcc-11.1.0/python-3.8.10-qlxpnsh6n5qxwtyvf56biltled4k22d7/lib/python3.8/multiprocessing/pool.py", line 868, in next
    raise value
  File "$spack/opt/spack/linux-debian9-piledriver/gcc-11.1.0/python-3.8.10-qlxpnsh6n5qxwtyvf56biltled4k22d7/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "$stage/spack-stage-py-scipy-1.7.0-vx7z4ppiptwbudmwem2wnakyzj7r4spe/spack-src/tools/cythonize.py", line 309, in <lambda>
    for result in pool.imap_unordered(lambda args: process(*args), jobs):
  File "$stage/spack-stage-py-scipy-1.7.0-vx7z4ppiptwbudmwem2wnakyzj7r4spe/spack-src/tools/cythonize.py", line 243, in process
    processor_function(fromfile, tofile, cwd=path)
  File "$stage/spack-stage-py-scipy-1.7.0-vx7z4ppiptwbudmwem2wnakyzj7r4spe/spack-src/tools/cythonize.py", line 108, in process_pyx
    raise Exception('Cython failed')
Exception: Cython failed
ImportError: No module named site
ImportError: No module named site
Running from SciPy source directory.
Cythonizing sources
Traceback (most recent call last):
  File "setup.py", line 356, in generate_cython
    import pip
ModuleNotFoundError: No module named 'pip'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "setup.py", line 629, in <module>
    setup_package()
  File "setup.py", line 613, in setup_package
    generate_cython()
  File "setup.py", line 365, in generate_cython
    raise RuntimeError("Running cythonize failed!")
RuntimeError: Running cythonize failed!
==> Error: ProcessError: Command exited with status 1:
    '$spack/opt/spack/linux-debian9-piledriver/gcc-11.1.0/python-3.8.10-qlxpnsh6n5qxwtyvf56biltled4k22d7/bin/python3.8' '-s' 'setup.py' '--no-user-cfg' 'build'
```

According to its [project.toml](https://github.com/scipy/scipy/blob/v1.7.0/pyproject.toml) scipy has an additional dependency on cython which was not present in the package. Adding `py-cython` fixed it for me and `py-scipy` is building again.