### PR TITLE
Use Python's zipfile, if available

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -18,7 +18,6 @@ import sys
 import ctypes
 import traceback
 import signal
-import tempfile
 import threading
 from threading import Thread
 from contextlib import contextmanager

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1788,8 +1788,6 @@ def build_process(pkg, kwargs):
                 else:
                     with winlog(pkg.log_path, True, True,
                                 env=unmodified_env) as logger:
-
-
                         for phase_name, phase_attr in zip(
                                 pkg.phases, pkg._InstallPhase_phases):
 

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -47,7 +47,7 @@ class WindowsOs(OperatingSystem):
                 paths = paths.decode()
             vs_install_paths = paths.split('\n')
             msvc_paths = [os.path.join(path, "VC", "Tools", "MSVC")
-                         for path in vs_install_paths]
+                          for path in vs_install_paths]
             for p in msvc_paths:
                 comp_search_paths.extend(
                     glob.glob(os.path.join(p, '*', 'bin', 'Hostx64', 'x64')))

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -38,13 +38,31 @@ def _gunzip(archive_file):
             f_out.write(f_in.read())
 
 
+def _unzip(archive_file):
+    """Try to use Python's zipfile, but extract in the current working
+    directory instead of in-place.
+
+    If unavailable, try unzip
+
+    Args:
+        archive_file (str): absolute path of the file to be decompressed
+    """
+    try:
+        from zipfile import ZipFile
+        destination_abspath = os.getcwd()
+        with ZipFile(archive_file, 'r') as zf:
+            zf.extractall(destination_abspath)
+    except ImportError:
+        unzip = which('unzip', required=True)
+        unzip.add_default_arg('-q')
+        return unzip
+
+
 def decompressor_for(path, extension=None):
     """Get the appropriate decompressor for a path."""
     if ((extension and re.match(r'\.?zip$', extension)) or
             path.endswith('.zip')):
-        unzip = which('unzip', required=True)
-        unzip.add_default_arg('-q')
-        return unzip
+        return _unzip
     if extension and re.match(r'gz', extension):
         return _gunzip
     if extension and re.match(r'bz2', extension):

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -52,8 +52,8 @@ class Zlib(CMakePackage):
         if '+pic' in self.spec:
             env.append_flags('CFLAGS', self.compiler.cc_pic_flag)
         if '+optimize' in self.spec:
-            env.append_flags('CFLAGS', '-O2')            
- 
+            env.append_flags('CFLAGS', '-O2')
+
     # Build, install, and check both static and shared versions of the
     # libraries when +shared
     @when('+shared platform=windows')
@@ -65,7 +65,7 @@ class Zlib(CMakePackage):
     def build(self, spec, prefix):
         for self._building_shared in (False, True):
             super(Zlib, self).build(spec, prefix)
-       
+
     @when('+shared platform=windows')
     def check(self):
         for self._building_shared in (False, True):
@@ -80,11 +80,8 @@ class Zlib(CMakePackage):
             if '~shared' in spec:
                 config_args.append('--static')
             configure('--prefix={0}'.format(prefix), *config_args)
- 
+
             make()
             if self.run_tests:
                 make('check')
             make('install')
-
-
-    


### PR DESCRIPTION
cpuinfo now requires unzip. To support the feature in Windows, use Python's zipfile module. For all platforms, prefer Pythons implementation and fall back on unzip when not available.


To test

`spack install cpuinfo`