### PR TITLE
Fix spack in environments w/o username resolution

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -6,7 +6,6 @@
 from __future__ import print_function
 
 import errno
-import getpass
 import glob
 import hashlib
 import os
@@ -55,7 +54,7 @@ def create_stage_root(path):
 
     # Obtain lists of ancestor and descendant paths of the $user node, if any.
     group_paths, user_node, user_paths = partition_path(path,
-                                                        getpass.getuser())
+                                                        sup._getuser_fallback_to_uid())
 
     for p in group_paths:
         if not os.path.exists(p):
@@ -138,7 +137,7 @@ def _resolve_paths(candidates):
     $user and appending $user if it is not present in the path.
     """
     temp_path = sup.canonicalize_path('$tempdir')
-    user = getpass.getuser()
+    user = sup._getuser_fallback_to_uid()
     tmp_has_usr = user in temp_path.split(os.path.sep)
 
     paths = []

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -24,10 +24,18 @@ __all__ = [
     'substitute_path_variables',
     'canonicalize_path']
 
+
+def _getuser_fallback_to_uid():
+    try:
+        return getpass.getuser()
+    except KeyError:
+        return str(os.getuid())
+
+
 # Substitutions to perform
 replacements = {
     'spack': spack.paths.prefix,
-    'user': getpass.getuser(),
+    'user': _getuser_fallback_to_uid(),
     'tempdir': tempfile.gettempdir(),
 }
 


### PR DESCRIPTION
Hey *,

I'm trying to use spack in a gitlab-based CI flow which relies on CentOS 7 containers.
These containers do not resolve usernames correctly, i.e. when calling `getpass.getuser()` I get (at several places):
```
  File "/opt/rh/rh-python36/root/usr/lib64/python3.6/getpass.py", line 169, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 1000'
```
After applying this (maybe too hacky :)) change `spack` is working again (spack temp folders etc.).

I guess this might occur in other places (mostly containerized environments?) as well.
⇒ Would this (in general) be a valid change or does spack want to enforce a working username resolution? Should I have a look at the other places where this code path might be called?

Cheers,
Eric