### PR TITLE
Trilinos: improve behavior of `gotype`

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -100,7 +100,7 @@ class Trilinos(CMakePackage, CudaPackage):
             description='Enable ADIOS2')
     variant('glm',          default=True,
             description='Compile with GLM')
-    variant('gtest',        default=True,
+    variant('gtest',        default=False,
             description='Compile with Gtest')
     variant('hdf5',         default=True,
             description='Compile with HDF5')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -306,6 +306,7 @@ class Trilinos(CMakePackage, CudaPackage):
     conflicts('+teko', when='~ml')
     conflicts('+teko', when='~teuchos')
     conflicts('+teko', when='~tpetra')
+    conflicts('+teko', when='gotype=long')
     conflicts('+tempus', when='~nox')
     conflicts('+tempus', when='~teuchos')
     conflicts('+tpetra', when='~kokkos')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+
 from spack import *
 from spack.operating_systems.mac_os import macos_version
 from spack.pkg.builtin.kokkos import Kokkos

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -29,7 +29,7 @@ class Trilinos(CMakePackage, CudaPackage):
     url      = "https://github.com/trilinos/Trilinos/archive/trilinos-release-12-12-1.tar.gz"
     git      = "https://github.com/trilinos/Trilinos.git"
 
-    maintainers = ['keitat']
+    maintainers = ['keitat', 'sethrj']
 
     # ###################### Versions ##########################
 


### PR DESCRIPTION
- Mark `+teko gotype=long` conflict (fixes #24455 )
- Remove `gotype=none` variant (which is binary identical to `gotype=long` on trilinos >12.15 but has very different behavior on other versions) in favor of `gotype=all` which has a very particular behavior and conflicts with newer versions.