### PR TITLE
pbs: new virtual package

### DIFF
--- a/etc/spack/defaults/packages.yaml
+++ b/etc/spack/defaults/packages.yaml
@@ -43,6 +43,7 @@ packages:
       opencl: [pocl]
       onedal: [intel-oneapi-dal]
       osmesa: [mesa+osmesa, mesa18+osmesa]
+      pbs: [openpbs, torque]
       pil: [py-pillow]
       pkgconfig: [pkgconf, pkg-config]
       rpc: [libtirpc]

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -589,7 +589,7 @@ class Openmpi(AutotoolsPackage):
     def with_or_without_tm(self, activated):
         if not activated:
             return '--without-tm'
-        return '--with-tm={0}'.format(self.spec['openpbs'].prefix)
+        return '--with-tm={0}'.format(self.spec['pbs'].prefix)
 
     @run_before('autoreconf')
     def die_without_fortran(self):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -308,7 +308,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('knem', when='fabrics=knem')
 
     depends_on('lsf', when='schedulers=lsf')
-    depends_on('openpbs', when='schedulers=tm')
+    depends_on('pbs', when='schedulers=tm')
     depends_on('slurm', when='schedulers=slurm')
 
     depends_on('openssh', type='run')

--- a/var/spack/repos/builtin/packages/torque/package.py
+++ b/var/spack/repos/builtin/packages/torque/package.py
@@ -6,12 +6,30 @@
 from spack import *
 
 
-class Torque(BundlePackage):
-    """Placeholder package for external TORUQE/PBS installation."""
+class Torque(Package):
+    """TORQUE (Terascale Open-source Resource and QUEue Manager) is an open
+    source project based on the original PBS resource manager developed by NASA,
+    LLNL, and MRJ."""
 
     homepage = "https://github.com/abarbu/torque"
+    has_code = False
 
     version('3.0.4')
     version('3.0.2')
 
     provides('pbs')
+
+    # TORQUE needs to be added as an external package to SPACK. For this, the
+    # config file packages.yaml needs to be adjusted:
+    #
+    # packages:
+    #   torque:
+    #     buildable: False
+    #     externals:
+    #     - spec: torque@3.0.2
+    #       prefix: /opt/torque (path to your TORQUE installation)
+
+    def install(self, spec, prefix):
+        raise InstallError(
+            self.spec.format('{name} is not installable, you need to specify '
+                             'it as an external package in packages.yaml'))

--- a/var/spack/repos/builtin/packages/torque/package.py
+++ b/var/spack/repos/builtin/packages/torque/package.py
@@ -14,6 +14,8 @@ class Torque(Package):
     homepage = "https://github.com/abarbu/torque"
     has_code = False
 
+    maintainers = ['sethrj']
+
     version('3.0.4')
     version('3.0.2')
 

--- a/var/spack/repos/builtin/packages/torque/package.py
+++ b/var/spack/repos/builtin/packages/torque/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Torque(BundlePackage):
+    """Placeholder package for external TORUQE/PBS installation."""
+
+    homepage = "https://github.com/abarbu/torque"
+
+    version('3.0.4')
+    version('3.0.2')
+
+    provides('pbs')


### PR DESCRIPTION
Some of our clusters have an older installation of libtorque and tm.h that are *not* from OpenPBS. (It's apparently TORQUE 3.0.2, possibly from 2008ish.) Using the current openpbs dependency for openmpi causes concretization errors due to restrictions on older python and hwloc requirements that don't apply, even with an external non-buildable installation. The new 'torque' bundle package allows users to point to that external installation without problems.

@skosukhin It looks like you added the OpenPBS package and the explicit dependency in `openmpi schedulers=tm`, so please let me know if I'm missing something. Thanks!