### PR TITLE
py-numpy: conflict with gcc11 and switch master to main

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import platform
 import subprocess
+
+from spack import *
 
 
 class PyNumpy(PythonPackage):
@@ -21,7 +22,8 @@ class PyNumpy(PythonPackage):
 
     maintainers = ['adamjstewart']
 
-    version('master', branch='master')
+    version('main', branch='main')
+    version('master', branch='main', deprecated=True)
     version('1.21.0', sha256='e80fe25cba41c124d04c662f33f6364909b985f2eb5998aaa5ae4b9587242cce')
     version('1.20.3', sha256='e55185e51b18d788e49fe8305fd73ef4470596b33fc2c1ceb304566b99c71a69')
     version('1.20.2', sha256='878922bf5ad7550aa044aa9301d417e2d3ae50f0f577de92051d739ac6096cee')
@@ -115,8 +117,9 @@ class PyNumpy(PythonPackage):
     patch('check_executables4.patch', when='@1.14.0:1.15.4')
     patch('check_executables5.patch', when='@:1.13.3')
 
-    # https://github.com/numpy/numpy/releases/tag/v1.21.0
-    conflicts('%gcc@11.1', when='@1.21.0')
+    # version 1.21.0 runs into an infinit loop during printing
+    # (e.g. print(numpy.ones(1000)) when compiled with gcc 11
+    conflicts('%gcc@11:', when='@1.21.0')
 
     # GCC 4.8 is the minimum version that works
     conflicts('%gcc@:4.7', msg='GCC 4.8+ required')
@@ -150,6 +153,7 @@ class PyNumpy(PythonPackage):
                                    '{0}'.format(gcc_version))
             if gcc_version <= Version('5.1'):
                 flags.append(self.compiler.c99_flag)
+
         return (flags, None, None)
 
     @run_before('build')


### PR DESCRIPTION
This fixes the syntax of the conflict between numpy 1.21.0 and gcc11 so that the clingo concretizer recognizes it (see below).
In addition the upstream master branch was renamed to main.


Concretization before:
```
$ spack spec py-numpy
Input spec
--------------------------------
py-numpy

Concretized
--------------------------------
py-numpy@1.21.0%gcc@11.1.0+blas+lapack patches=873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604 arch=linux-fedora32-haswell
    ^openblas@0.3.15%gcc@11.1.0~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none arch=linux-fedora32-haswell
        ^perl@5.34.0%gcc@11.1.0+cpanm+shared+threads arch=linux-fedora32-haswell
            ^berkeley-db@18.1.40%gcc@11.1.0+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=linux-fedora32-haswell
            ^gdbm@1.19%gcc@11.1.0 arch=linux-fedora32-haswell
                ^readline@8.1%gcc@11.1.0 arch=linux-fedora32-haswell
                    ^ncurses@6.2%gcc@11.1.0~symlinks+termlib abi=none arch=linux-fedora32-haswell
                        ^pkgconf@1.7.4%gcc@11.1.0 arch=linux-fedora32-haswell
    ^py-cython@0.29.22%gcc@11.1.0 arch=linux-fedora32-haswell
        ^py-setuptools@50.3.2%gcc@11.1.0 arch=linux-fedora32-haswell
            ^python@3.8.10%gcc@11.1.0+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87 arch=linux-fedora32-haswell
                ^bzip2@1.0.8%gcc@11.1.0~debug~pic+shared arch=linux-fedora32-haswell
                    ^diffutils@3.7%gcc@11.1.0 arch=linux-fedora32-haswell
                        ^libiconv@1.16%gcc@11.1.0 arch=linux-fedora32-haswell
                ^expat@2.3.0%gcc@11.1.0+libbsd arch=linux-fedora32-haswell
                    ^libbsd@0.11.3%gcc@11.1.0 arch=linux-fedora32-haswell
                        ^libmd@1.0.3%gcc@11.1.0 arch=linux-fedora32-haswell
                ^gettext@0.21%gcc@11.1.0+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-fedora32-haswell
                    ^libxml2@2.9.10%gcc@11.1.0~python arch=linux-fedora32-haswell
                        ^xz@5.2.5%gcc@11.1.0~pic libs=shared,static arch=linux-fedora32-haswell
                        ^zlib@1.2.11%gcc@11.1.0+optimize+pic+shared arch=linux-fedora32-haswell
                    ^tar@1.34%gcc@11.1.0 arch=linux-fedora32-haswell
                ^libffi@3.3%gcc@11.1.0 patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0 arch=linux-fedora32-haswell
                ^openssl@1.1.1k%gcc@11.1.0~docs+systemcerts arch=linux-fedora32-haswell
                ^sqlite@3.35.5%gcc@11.1.0+column_metadata+fts~functions~rtree arch=linux-fedora32-haswell
                ^util-linux-uuid@2.36.2%gcc@11.1.0 arch=linux-fedora32-haswell
```
-> still uses gcc together with numpy 1.21.0

Concretization after:
```
$ spack spec py-numpy
Input spec
--------------------------------
py-numpy

Concretized
--------------------------------
py-numpy@1.21.0%gcc@10.2.1+blas+lapack patches=873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604 arch=linux-fedora32-haswell
    ^openblas@0.3.15%gcc@10.2.1~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none arch=linux-fedora32-haswell
        ^perl@5.34.0%gcc@10.2.1+cpanm+shared+threads arch=linux-fedora32-haswell
            ^berkeley-db@18.1.40%gcc@10.2.1+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=linux-fedora32-haswell
            ^gdbm@1.19%gcc@10.2.1 arch=linux-fedora32-haswell
                ^readline@8.1%gcc@10.2.1 arch=linux-fedora32-haswell
                    ^ncurses@6.2%gcc@10.2.1~symlinks+termlib abi=none arch=linux-fedora32-haswell
                        ^pkgconf@1.7.4%gcc@10.2.1 arch=linux-fedora32-haswell
    ^py-cython@0.29.22%gcc@10.2.1 arch=linux-fedora32-haswell
        ^py-setuptools@50.3.2%gcc@10.2.1 arch=linux-fedora32-haswell
            ^python@3.8.10%gcc@10.2.1+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87 arch=linux-fedora32-haswell
                ^bzip2@1.0.8%gcc@10.2.1~debug~pic+shared arch=linux-fedora32-haswell
                    ^diffutils@3.7%gcc@10.2.1 arch=linux-fedora32-haswell
                        ^libiconv@1.16%gcc@10.2.1 arch=linux-fedora32-haswell
                ^expat@2.3.0%gcc@10.2.1+libbsd arch=linux-fedora32-haswell
                    ^libbsd@0.11.3%gcc@10.2.1 arch=linux-fedora32-haswell
                        ^libmd@1.0.3%gcc@10.2.1 arch=linux-fedora32-haswell
                ^gettext@0.21%gcc@10.2.1+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-fedora32-haswell
                    ^libxml2@2.9.10%gcc@10.2.1~python arch=linux-fedora32-haswell
                        ^xz@5.2.5%gcc@10.2.1~pic libs=shared,static arch=linux-fedora32-haswell
                        ^zlib@1.2.11%gcc@10.2.1+optimize+pic+shared arch=linux-fedora32-haswell
                    ^tar@1.34%gcc@10.2.1 arch=linux-fedora32-haswell
                ^libffi@3.3%gcc@10.2.1 patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0 arch=linux-fedora32-haswell
                ^openssl@1.1.1k%gcc@10.2.1~docs+systemcerts arch=linux-fedora32-haswell
                ^sqlite@3.35.5%gcc@10.2.1+column_metadata+fts~functions~rtree arch=linux-fedora32-haswell
                ^util-linux-uuid@2.36.2%gcc@10.2.1 arch=linux-fedora32-haswell
```
-> downgrades gcc
resp.:
```
$ spack spec py-numpy %gcc@11.1.0
Input spec
--------------------------------
py-numpy%gcc@11.1.0

Concretized
--------------------------------
py-numpy@1.20.3%gcc@11.1.0+blas+lapack patches=873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604 arch=linux-fedora32-haswell
    ^openblas@0.3.15%gcc@11.1.0~bignuma~consistent_fpcsr~ilp64+locking+pic+shared threads=none arch=linux-fedora32-haswell
        ^perl@5.34.0%gcc@11.1.0+cpanm+shared+threads arch=linux-fedora32-haswell
            ^berkeley-db@18.1.40%gcc@11.1.0+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=linux-fedora32-haswell
            ^gdbm@1.19%gcc@11.1.0 arch=linux-fedora32-haswell
                ^readline@8.1%gcc@11.1.0 arch=linux-fedora32-haswell
                    ^ncurses@6.2%gcc@11.1.0~symlinks+termlib abi=none arch=linux-fedora32-haswell
                        ^pkgconf@1.7.4%gcc@11.1.0 arch=linux-fedora32-haswell
    ^py-cython@0.29.22%gcc@11.1.0 arch=linux-fedora32-haswell
        ^py-setuptools@50.3.2%gcc@11.1.0 arch=linux-fedora32-haswell
            ^python@3.8.10%gcc@11.1.0+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87 arch=linux-fedora32-haswell
                ^bzip2@1.0.8%gcc@11.1.0~debug~pic+shared arch=linux-fedora32-haswell
                    ^diffutils@3.7%gcc@11.1.0 arch=linux-fedora32-haswell
                        ^libiconv@1.16%gcc@11.1.0 arch=linux-fedora32-haswell
                ^expat@2.3.0%gcc@11.1.0+libbsd arch=linux-fedora32-haswell
                    ^libbsd@0.11.3%gcc@11.1.0 arch=linux-fedora32-haswell
                        ^libmd@1.0.3%gcc@11.1.0 arch=linux-fedora32-haswell
                ^gettext@0.21%gcc@11.1.0+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-fedora32-haswell
                    ^libxml2@2.9.10%gcc@11.1.0~python arch=linux-fedora32-haswell
                        ^xz@5.2.5%gcc@11.1.0~pic libs=shared,static arch=linux-fedora32-haswell
                        ^zlib@1.2.11%gcc@11.1.0+optimize+pic+shared arch=linux-fedora32-haswell
                    ^tar@1.34%gcc@11.1.0 arch=linux-fedora32-haswell
                ^libffi@3.3%gcc@11.1.0 patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0 arch=linux-fedora32-haswell
                ^openssl@1.1.1k%gcc@11.1.0~docs+systemcerts arch=linux-fedora32-haswell
                ^sqlite@3.35.5%gcc@11.1.0+column_metadata+fts~functions~rtree arch=linux-fedora32-haswell
                ^util-linux-uuid@2.36.2%gcc@11.1.0 arch=linux-fedora32-haswell
```
-> downgrades numpy