### PR TITLE
darshan-runtime,darshan-util: new version released + move to github

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
+from spack import *
 
 
 class DarshanRuntime(Package):

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -15,13 +15,13 @@ class DarshanRuntime(Package):
     systems where you intend to instrument MPI applications."""
 
     homepage = "http://www.mcs.anl.gov/research/projects/darshan/"
-    url = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
     git      = "https://xgitlab.cels.anl.gov/darshan/darshan.git"
 
     maintainers = ['shanedsnyder', 'carns']
 
     version('master', branch='master', submodules=True)
-    version('3.3.0',      sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a', preferred=True)
+    version('3.3.1', sha256='284224404cb8d0bd4cedd1819587164b5d4f0bfe2f7115ead8364d185e3ab1be')
+    version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')
     version('3.2.1', sha256='d63048b7a3d1c4de939875943e3e7a2468a9034fcb68585edbc87f57f622e7f7')
@@ -104,3 +104,10 @@ class DarshanRuntime(Package):
         # default path for log file, could be user or site specific setting
         darshan_log_dir = os.environ['HOME']
         env.set('DARSHAN_LOG_DIR_PATH', darshan_log_dir)
+
+    def url_for_version(self, version):
+        if version >= Version('3.3.1'):
+            url = "https://github.com/darshan-hpc/darshan/archive/refs/tags/v{0}.tar.gz"
+        else:
+            url = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-{0}.tar.gz"
+        return url.format(version)

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -15,11 +15,11 @@ class DarshanRuntime(Package):
     systems where you intend to instrument MPI applications."""
 
     homepage = "http://www.mcs.anl.gov/research/projects/darshan/"
-    git      = "https://xgitlab.cels.anl.gov/darshan/darshan.git"
+    git      = "https://github.com/darshan-hpc/darshan.git"
 
     maintainers = ['shanedsnyder', 'carns']
 
-    version('master', branch='master', submodules=True)
+    version('main', branch='main', submodules=True)
     version('3.3.1', sha256='284224404cb8d0bd4cedd1819587164b5d4f0bfe2f7115ead8364d185e3ab1be')
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -16,12 +16,13 @@ class DarshanRuntime(Package):
     systems where you intend to instrument MPI applications."""
 
     homepage = "http://www.mcs.anl.gov/research/projects/darshan/"
+    url      = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
     git      = "https://github.com/darshan-hpc/darshan.git"
 
     maintainers = ['shanedsnyder', 'carns']
 
     version('main', branch='main', submodules=True)
-    version('3.3.1', sha256='284224404cb8d0bd4cedd1819587164b5d4f0bfe2f7115ead8364d185e3ab1be')
+    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7')
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')
@@ -105,10 +106,3 @@ class DarshanRuntime(Package):
         # default path for log file, could be user or site specific setting
         darshan_log_dir = os.environ['HOME']
         env.set('DARSHAN_LOG_DIR_PATH', darshan_log_dir)
-
-    def url_for_version(self, version):
-        if version >= Version('3.3.1'):
-            url = "https://github.com/darshan-hpc/darshan/archive/refs/tags/v{0}.tar.gz"
-        else:
-            url = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-{0}.tar.gz"
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -13,11 +13,11 @@ class DarshanUtil(Package):
     log files produced by Darshan (runtime)."""
 
     homepage = "http://www.mcs.anl.gov/research/projects/darshan/"
-    git      = "https://xgitlab.cels.anl.gov/darshan/darshan.git"
+    git      = "https://github.com/darshan-hpc/darshan.git"
 
     maintainers = ['shanedsnyder', 'carns']
 
-    version('master', branch='master', submodules='True')
+    version('main', branch='main', submodules='True')
     version('3.3.1', sha256='284224404cb8d0bd4cedd1819587164b5d4f0bfe2f7115ead8364d185e3ab1be')
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -13,12 +13,13 @@ class DarshanUtil(Package):
     log files produced by Darshan (runtime)."""
 
     homepage = "http://www.mcs.anl.gov/research/projects/darshan/"
+    url      = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
     git      = "https://github.com/darshan-hpc/darshan.git"
 
     maintainers = ['shanedsnyder', 'carns']
 
     version('main', branch='main', submodules='True')
-    version('3.3.1', sha256='284224404cb8d0bd4cedd1819587164b5d4f0bfe2f7115ead8364d185e3ab1be')
+    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7')
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')
@@ -62,10 +63,3 @@ class DarshanUtil(Package):
             configure('--prefix=%s' % prefix, *options)
             make()
             make('install')
-
-    def url_for_version(self, version):
-        if version >= Version('3.3.1'):
-            url = "https://github.com/darshan-hpc/darshan/archive/refs/tags/v{0}.tar.gz"
-        else:
-            url = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-{0}.tar.gz"
-        return url.format(version)

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -13,13 +13,13 @@ class DarshanUtil(Package):
     log files produced by Darshan (runtime)."""
 
     homepage = "http://www.mcs.anl.gov/research/projects/darshan/"
-    url = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-3.1.0.tar.gz"
     git      = "https://xgitlab.cels.anl.gov/darshan/darshan.git"
 
     maintainers = ['shanedsnyder', 'carns']
 
     version('master', branch='master', submodules='True')
-    version('3.3.0',      sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a', preferred=True)
+    version('3.3.1', sha256='284224404cb8d0bd4cedd1819587164b5d4f0bfe2f7115ead8364d185e3ab1be')
+    version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')
     version('3.2.1', sha256='d63048b7a3d1c4de939875943e3e7a2468a9034fcb68585edbc87f57f622e7f7')
@@ -62,3 +62,10 @@ class DarshanUtil(Package):
             configure('--prefix=%s' % prefix, *options)
             make()
             make('install')
+
+    def url_for_version(self, version):
+        if version >= Version('3.3.1'):
+            url = "https://github.com/darshan-hpc/darshan/archive/refs/tags/v{0}.tar.gz"
+        else:
+            url = "http://ftp.mcs.anl.gov/pub/darshan/releases/darshan-{0}.tar.gz"
+        return url.format(version)


### PR DESCRIPTION
- add 3.3.1 tag for runtime/util components
- remove preferred tag to make sure we use our most recent release
- add url_for_version() for each package to pick right URL based on version number (pre 3.3.1 versions not available on GitHub)