### PR TITLE
Ascent: removed redundant cuda variant

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -76,7 +76,6 @@ class Ascent(Package, CudaPackage):
 
     variant("openmp", default=(sys.platform != 'darwin'),
             description="build openmp support")
-    variant("cuda", default=False, description="Build cuda support")
     variant("mfem", default=False, description="Build MFEM filter support")
     variant("adios", default=False, description="Build Adios filter support")
     variant("dray", default=False, description="Build with Devil Ray support")


### PR DESCRIPTION
By inheriting from `CudaPackage`, Ascent automatically gets both the `cuda` and `cuda_arch` variants so there is no reason to explicitly include (override?) the `cuda` variant in the package.

This PR simply removed the redundant variant.