### PR TITLE
Add cxxstd to abseil-cpp

### DIFF
--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -31,11 +31,10 @@ class AbseilCpp(CMakePackage):
             description="C++ standard used during compilation")
 
     def cmake_args(self):
+        shared = 'ON' if '+shared' in self.spec else 'OFF'
         cxxstd = self.spec.variants['cxxstd'].value
-        args = [
-            "-DBUILD_TESTING=OFF",
-            "-DCMAKE_CXX_STANDARD={}".format(cxxstd)
+        return [
+            self.define('BUILD_TESTING', 'OFF'),
+            self.define('BUILD_SHARED_LIBS:Bool', 'shared'),
+            self.define('CMAKE_CXX_STANDARD', cxxstd)
         ]
-        args.append('-DBUILD_SHARED_LIBS:Bool={0}'.format(
-            'ON' if '+shared' in self.spec else 'OFF'))
-        return args

--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -33,8 +33,8 @@ class AbseilCpp(CMakePackage):
     def cmake_args(self):
         cxxstd = self.spec.variants['cxxstd'].value
         args = [
-          "-DBUILD_TESTING=OFF",
-          "-DCMAKE_CXX_STANDARD={}".format(cxxstd)
+            "-DBUILD_TESTING=OFF",
+            "-DCMAKE_CXX_STANDARD={}".format(cxxstd)
         ]
         args.append('-DBUILD_SHARED_LIBS:Bool={0}'.format(
             'ON' if '+shared' in self.spec else 'OFF'))

--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -27,8 +27,15 @@ class AbseilCpp(CMakePackage):
 
     conflicts('+shared', when='@:20190808')
 
+    variant('cxxstd', values=('11', '14', '17', '20'), default='11',
+            description="C++ standard used during compilation")
+
     def cmake_args(self):
-        args = ["-DBUILD_TESTING=OFF",  "-DCMAKE_CXX_STANDARD=11"]
+        cxxstd = self.spec.variants['cxxstd'].value
+        args = [
+          "-DBUILD_TESTING=OFF",
+          "-DCMAKE_CXX_STANDARD={}".format(cxxstd)
+        ]
         args.append('-DBUILD_SHARED_LIBS:Bool={0}'.format(
             'ON' if '+shared' in self.spec else 'OFF'))
         return args

--- a/var/spack/repos/builtin/packages/abseil-cpp/package.py
+++ b/var/spack/repos/builtin/packages/abseil-cpp/package.py
@@ -35,6 +35,6 @@ class AbseilCpp(CMakePackage):
         cxxstd = self.spec.variants['cxxstd'].value
         return [
             self.define('BUILD_TESTING', 'OFF'),
-            self.define('BUILD_SHARED_LIBS:Bool', 'shared'),
+            self.define('BUILD_SHARED_LIBS:Bool', shared),
             self.define('CMAKE_CXX_STANDARD', cxxstd)
         ]


### PR DESCRIPTION
Abseil wasn't designed to be a shared library. They guarantee API compatibility but not ABI compatibility. Users compiling with -std=c++17 will need a version of abseil-cpp with the same ABI. This PR adds the 'cxxstd' variant to abseil-cpp