### PR TITLE
scr: rename default branches to main

### DIFF
--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -25,7 +25,7 @@ class Axl(CMakePackage):
 
     tags = ['ecp']
 
-    version('master', branch='master')
+    version('main',  branch='main')
     version('0.4.0', sha256='0530142629d77406a00643be32492760c2cf12d1b56c6b6416791c8ff5298db2')
     version('0.3.0', sha256='737d616b669109805f7aed1858baac36c97bf0016e1115b5c56ded05d792613e')
     version('0.2.0', sha256='d04a445f102b438fe96a1ff3429790b0c035f0d23c2797bb5601a00b582a71fc', deprecated=True)

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -15,7 +15,7 @@ class Er(CMakePackage):
 
     tags = ['ecp']
 
-    version('master', branch='master')
+    version('main',  branch='main')
     version('0.0.4', sha256='c456d34719bb57774adf6d7bc2fa9917ecb4a9de442091023c931a2cb83dfd37')
     version('0.0.3', sha256='243b2b46ea274e17417ef5873c3ed7ba16dacdfdaf7053d1de5434e300de796b')
 

--- a/var/spack/repos/builtin/packages/filo/package.py
+++ b/var/spack/repos/builtin/packages/filo/package.py
@@ -14,7 +14,7 @@ class Filo(CMakePackage):
 
     tags = ['ecp']
 
-    version('master', branch='master')
+    version('main', branch='main')
 
     depends_on('mpi')
     depends_on('axl')

--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -16,7 +16,7 @@ class Kvtree(CMakePackage):
 
     tags = ['ecp']
 
-    version('master', branch='master')
+    version('main',  branch='main')
     version('1.1.1', sha256='4776bd55a559b7f9bb594454ae6b14ebff0087c93c3d59ac7d1ab27df4aa4d74')
     version('1.1.0', sha256='3e6c003e7b8094d7c2d1529a973d68a68f953ffa63dcde5f4c7c7e81ddf06564')
     version('1.0.3', sha256='c742cdb1241ef4cb13767019204d5350a3c4383384bed9fb66680b93ff44b0d4')

--- a/var/spack/repos/builtin/packages/rankstr/package.py
+++ b/var/spack/repos/builtin/packages/rankstr/package.py
@@ -15,7 +15,7 @@ class Rankstr(CMakePackage):
 
     tags = ['ecp']
 
-    version('master', branch='master')
+    version('main',  branch='main')
     version('0.0.3', sha256='d32052fbecd44299e13e69bf2dd7e5737c346404ccd784b8c2100ceed99d8cd3')
     version('0.0.2', sha256='c16d53aa9bb79934cbe2dcd8612e2db7d59de80be500c104e39e8623d4eacd8e')
 

--- a/var/spack/repos/builtin/packages/redset/package.py
+++ b/var/spack/repos/builtin/packages/redset/package.py
@@ -15,7 +15,7 @@ class Redset(CMakePackage):
 
     tags = ['ecp']
 
-    version('master', branch='master')
+    version('main',  branch='main')
     version('0.0.5', sha256='4db4ae59ab9d333a6d1d80678dedf917d23ad461c88b6d39466fc4bf6467d1ee')
     version('0.0.4', sha256='c33fce458d5582f01ad632c6fae8eb0a03eaef00e3c240c713b03bb95e2787ad')
     version('0.0.3', sha256='30ac1a960f842ae23a960a88b312af3fddc4795f2053eeeec3433a61e4666a76')

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -3,12 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 import os
-
-# to get system platform type
 import sys
+
+from spack import *
 
 
 def detect_scheduler():
@@ -42,13 +40,13 @@ class Scr(CMakePackage):
     depends_on('mpi')
 
     # Use the latest iteration of the components when installing scr@develop
-    depends_on('axl@master',      when="@develop")
-    depends_on('er@master',       when="@develop")
-    depends_on('kvtree@master',   when="@develop")
-    depends_on('rankstr@master',  when="@develop")
-    depends_on('redset@master',   when="@develop")
-    depends_on('shuffile@master', when="@develop")
-    depends_on('spath@master',    when="@develop")
+    depends_on('axl@main',      when="@develop")
+    depends_on('er@main',       when="@develop")
+    depends_on('kvtree@main',   when="@develop")
+    depends_on('rankstr@main',  when="@develop")
+    depends_on('redset@main',   when="@develop")
+    depends_on('shuffile@main', when="@develop")
+    depends_on('spath@main',    when="@develop")
 
     # SCR legacy is anything 2.x.x or earlier
     # SCR components is anything 3.x.x or later

--- a/var/spack/repos/builtin/packages/shuffile/package.py
+++ b/var/spack/repos/builtin/packages/shuffile/package.py
@@ -15,7 +15,7 @@ class Shuffile(CMakePackage):
 
     tags = ['ecp']
 
-    version('master', branch='master')
+    version('main',  branch='main')
     version('0.0.4', sha256='f0249ab31fc6123103ad67b1eaf799277c72adcf0dfcddf8c3a18bad2d45031d')
     version('0.0.3', sha256='a3f685526a1146a5ad8dbacdc5f9c2e1152d9761a1a179c1db34f55afc8372f6')
 

--- a/var/spack/repos/builtin/packages/spath/package.py
+++ b/var/spack/repos/builtin/packages/spath/package.py
@@ -15,7 +15,7 @@ class Spath(CMakePackage):
 
     tags = ['ecp']
 
-    version('master', branch='master')
+    version('main',  branch='main')
     version('0.0.2', sha256='7a65be59c3d27e92ed4718fba1a97a4a1c68e0a552b54de13d58afe3d8199cf7')
     version('0.0.1', sha256='f41c0ac74e6fb8acfd0c072d756db0fc9c00441f22be492cc4ad25f7fb596a24')
 


### PR DESCRIPTION
This is work in progress.

A number of repos on which SCR depends have renamed their default branch from "master" to "main".

I can squash these commits into one if desired.  I left them separate to start with since it's easier to squash than to split them back apart.