### PR TITLE
vermin: show line numbers of violations

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,9 +24,9 @@ jobs:
         pip install --upgrade pip
         pip install --upgrade vermin
     - name: vermin (Spack's Core)
-      run: vermin --backport argparse --backport typing -t=2.6- -t=3.5- -v lib/spack/spack/ lib/spack/llnl/ bin/
+      run: vermin --backport argparse --violations --backport typing -t=2.6- -t=3.5- -vvv lib/spack/spack/ lib/spack/llnl/ bin/
     - name: vermin (Repositories)
-      run: vermin --backport argparse --backport typing -t=2.6- -t=3.5- -v var/spack/repos
+      run: vermin --backport argparse --violations --backport typing -t=2.6- -t=3.5- -vvv var/spack/repos
   # Run style checks on the files that have been changed
   style:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fixes #24550

This commit runs vermin with the `--violations` option that shows details of the violations to target requirements. When / if https://github.com/netromdk/vermin/issues/74 is implemented the CI output will be terser and only show details of failing files.