### PR TITLE
r-stringi: add 1.6.2

### DIFF
--- a/var/spack/repos/builtin/packages/r-stringi/package.py
+++ b/var/spack/repos/builtin/packages/r-stringi/package.py
@@ -18,10 +18,10 @@ class RStringi(RPackage):
     (International Components for Unicode) library - portable across all
     locales and platforms."""
 
-    homepage = "http://www.gagolewski.com/software/stringi/"
-    url      = "https://cloud.r-project.org/src/contrib/stringi_1.1.2.tar.gz"
-    list_url = "https://cloud.r-project.org/src/contrib/Archive/stringi"
+    homepage = "https://stringi.gagolewski.com/"
+    cran     = "stringi"
 
+    version('1.6.2', sha256='3a151dd9b982696370ac8df3920afe462f8abbd4e41b479ff8b66cfd7b602dae')
     version('1.5.3', sha256='224f1e8dedc962a676bc2e1f53016f6a129a0a38aa0f35daf6dece62ff714010')
     version('1.4.3', sha256='13cecb396b700f81af38746e97b550a1d9fda377ca70c78f6cdfc770d33379ed')
     version('1.3.1', sha256='32df663bb6e9527e1ac265eec2116d26f7b7e62ea5ae7cc5de217cbb8defc362')
@@ -30,6 +30,8 @@ class RStringi(RPackage):
     version('1.1.2', sha256='e50b7162ceb7ebae403475f6f8a76a39532a2abc82112db88661f48aa4b9218e')
     version('1.1.1', sha256='243178a138fe68c86384feb85ead8eb605e8230113d638da5650bca01e24e165')
 
-    depends_on('r@2.14:', type=('build', 'run'))
+    depends_on('r@2.14:', when='@:1.5.3', type=('build', 'run'))
+    depends_on('r@3.1:', when='@1.6.1:', type=('build', 'run'))
     depends_on('icu4c@52:')
     depends_on('icu4c@55:', when='@1.5.3:')
+    # since version 1.6.1 there is also a SystemRequirement on C++11


### PR DESCRIPTION
Since version 1.6.1 stringi has a SystemRequirement on C++11 (see [here](https://github.com/gagolews/stringi/blob/v1.6.1/DESCRIPTION#L17))

I did not find a way to specify that in spack so I added it as a comment.