### PR TITLE
py-pytorch-sphinx-theme: add master version

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytorch-sphinx-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-sphinx-theme/package.py
@@ -10,9 +10,9 @@ class PyPytorchSphinxTheme(PythonPackage):
     """PyTorch Sphinx Theme."""
 
     homepage = "https://github.com/pytorch/pytorch_sphinx_theme"
-    pypi     = "pytorch_sphinx_theme/pytorch_sphinx_theme-0.0.19.tar.gz"
+    git      = "https://github.com/pytorch/pytorch_sphinx_theme.git"
 
-    version('0.0.19', sha256='9c0472a82fc72e5b4c4c5202fc9cdd6de8f1de6050a98f4ace75707ebb184bfd')
+    version('master', branch='master')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-sphinx', type=('build', 'run'))


### PR DESCRIPTION
The PyPI release is broken and doesn't actually contain any of the theme files.