### PR TITLE
perl: force perl to build its own versions of bzip2 and zlib

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -14,6 +14,7 @@
 import os
 import re
 from contextlib import contextmanager
+
 from llnl.util.lang import match_predicate
 from spack import *
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -11,12 +11,10 @@
 # Author: Justin Too <justin@doubleotoo.com>
 # Date: September 6, 2015
 #
-import re
 import os
+import re
 from contextlib import contextmanager
-
 from llnl.util.lang import match_predicate
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -276,6 +276,15 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if self.spec.satisfies('os=bigsur'):
             env.set('SYSTEM_VERSION_COMPAT', 1)
 
+        # Force perl to build its own, internal copies of bzip2 and zlib.
+        # Otherwise, some modules can confuse config and break the build.
+        env.set('BUILD_BZIP2', 1)
+        env.unset('BZIP2_LIB')
+        env.unset('BZIP2_INCLUDE')
+        env.set('BUILD_ZLIB', 1)
+        env.unset('ZLIB_LIB')
+        env.unset('ZLIB_INCLUDE')
+
     @run_after('install')
     def filter_config_dot_pm(self):
         """Run after install so that Config.pm records the compiler that Spack


### PR DESCRIPTION
Disable perl's detection of system bzip2 and zlib and force it to
build its own, internal copies.  Otherwise, modules on some systems
confuse perl's detection and break the build.

----------

Normally, perl builds its own, internal copies of bzip2 and zlib.
However, it will try to use a system version of these libraries if
some environ variables are set.

For example, in cpan/Compress-Raw-Bzip2/Makefile.PL, perl searches for
an external bzip2 with:

```
my $BUILD_BZIP2 = defined($ENV{BUILD_BZIP2}) ? $ENV{BUILD_BZIP2} : 1;
my $BZIP2_LIB = defined($ENV{BZIP2_LIB}) ? $ENV{BZIP2_LIB} : 'bzip2-src';
my $BZIP2_INCLUDE = defined($ENV{BZIP2_INCLUDE}) ? $ENV{BZIP2_INCLUDE} : '.';
```

However, on some systems (eg, stria at Sandia Natl Labs), the bzip2
module sets a bunch of environ variables that confuse perl's detection
and end up breaking the build.  The module sets: INCLUDE, LIBRARY_PATH,
BZIP2_DIR, BZIP2_BIN, BZIP2_INC, BZIP2_LIB, all pointing to the
module's version.

The build fails with:

```
     1537    cc  -shared -O2 -L/home/mwkrent/hpc_home/perl/install/linux-rhel7-aarch64/gcc-7.2.0/gdbm-1.19-o6o4vyy
             6u5zcl7x2wg4gbm5mzttnfifl/lib -fstack-protector-strong  Bzip2.o blocksort.o bzlib.o compress.o crctab
             le.o decompress.o huffman.o randtable.o   -o ../../lib/auto/Compress/Raw/Bzip2/Bzip2.so  \
     1538          \
     1539    
  >> 1540    gcc: error: blocksort.o: No such file or directory
  >> 1541    gcc: error: bzlib.o: No such file or directory
  >> 1542    gcc: error: compress.o: No such file or directory
  >> 1543    gcc: error: crctable.o: No such file or directory
  >> 1544    gcc: error: decompress.o: No such file or directory
  >> 1545    gcc: error: huffman.o: No such file or directory
  >> 1546    gcc: error: randtable.o: No such file or directory
  >> 1547    make[1]: *** [../../lib/auto/Compress/Raw/Bzip2/Bzip2.so] Error 1
```

The way it fails is that configure determines that there is a system
bzip2 available, so it does NOT build its own, but then the Makefile
dies because nothing was built.  So, there may be something broken in
perl's build system because it seems like the left hand doesn't know
what the right hand is doing.

Anyway, the simple solution is to set the BUILD_BZIP2, BUILD_ZLIB, etc
environ vars to tell perl to always build its own copies.

Note: bzip2 and zlib are not under active development, and perl
already has the latest versions.  So, there is no point in building
them with spack.  That would just add unnecessary dependencies.

----------

Here's how you can see the failure on any linux system.

Use spack to build a module for bzip2.  Set or add to these environ
variables to point to the include or lib dirs for bzip2.

```
INCLUDE, LIBRARY_PATH, BZIP2_INC, BZIP2_LIB
```

Then, you should see the same failure as above.

