### PR TITLE
Fix uninstall after change of projections

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -101,7 +101,7 @@ class DirectoryLayout(object):
         """Removes a prefix and any empty parent directories from the root.
            Raised RemoveFailedError if something goes wrong.
         """
-        path = self.path_for_spec(spec)
+        path = spec.prefix
         assert(path.startswith(self.root))
 
         if deprecated:

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -3,21 +3,20 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import errno
+import glob
 import os
 import shutil
-import glob
 import tempfile
-import errno
 from contextlib import contextmanager
 
 import ruamel.yaml as yaml
-
-from llnl.util.filesystem import mkdirp
 
 import spack.config
 import spack.hash_types as ht
 import spack.spec
 import spack.util.spack_json as sjson
+from llnl.util.filesystem import mkdirp
 from spack.error import SpackError
 
 


### PR DESCRIPTION
When uninstalling a spec, we should not recompute the prefix path since it may have changed since the installation of that spec.

For instance:

```
$ spack install zlib~shared
[+] /spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.2.0/zlib-1.2.11-k5l7ccyobzhdyxt3wpzzxgyy5va636sq

$ spack -c 'config:install_tree:projections:all:${HASH}' find -p zlib~shared
zlib@1.2.11  /spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.2.0/zlib-1.2.11-k5l7ccyobzhdyxt3wpzzxgyy5va636sq

$ spack -c 'config:install_tree:projections:all:${HASH}' uninstall zlib~shared
==> Successfully uninstalled zlib@1.2.11%gcc@10.2.0+optimize+pic~shared arch=linux-ubuntu20.04-zen2/k5l7ccy

$ ls /spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.2.0/zlib-1.2.11-k5l7ccyobzhdyxt3wpzzxgyy5va636sq
include  lib  share
```

When working with concrete specs from the database, we should not recompute these properties I suppose.

Marking this as draft since likely there are more instances where the prefix path gets recomputed incorrectly.
