### PR TITLE
curl: explicitly disable unused dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import sys
+
+from spack import *
 
 
 class Curl(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -69,16 +69,27 @@ class Curl(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
 
-        args = ['--with-zlib={0}'.format(spec['zlib'].prefix)]
-        args.append('--with-libidn2={0}'.format(spec['libidn2'].prefix))
+        args = [
+            '--with-zlib=' + spec['zlib'].prefix,
+            '--with-libidn2=' + spec['libidn2'].prefix,
+            # Prevent unintentional linking against system libraries: we could
+            # add variants for these in the future
+            '--without-libbrotli',
+            '--without-libgsasl',
+            '--without-libmetalink',
+            '--without-libpsl',
+            '--without-zstd',
+        ]
 
         if spec.satisfies('+darwinssl'):
             args.append('--with-darwinssl')
         else:
-            args.append('--with-ssl={0}'.format(spec['openssl'].prefix))
+            args.append('--with-ssl=' + spec['openssl'].prefix)
 
         if spec.satisfies('+gssapi'):
-            args.append('--with-gssapi={0}'.format(spec['krb5'].prefix))
+            args.append('--with-gssapi=' + spec['krb5'].prefix)
+        else:
+            args.append('--without-gssapi')
 
         args += self.with_or_without('nghttp2')
         args += self.with_or_without('libssh2')


### PR DESCRIPTION
I installed curl on my mac and it picked up a homebrew (I think?) installation of gsasl. A later system update broke git because of the implicitly added dependency. Explicitly disabling libraries that *might* exist on the system is the safe approach here.

```
dyld: Library not loaded: /usr/local/opt/gsasl/lib/libgsasl.7.dylib
  Referenced from: /rnsdhpc/code/spack/opt/spack/apple-clang/curl/gag5v3c/lib/libcurl.4.dylib
  Reason: image not found
error: git-remote-https died of signal 6
```