### PR TITLE
Integrate 2021.3 oneAPI release to Spack

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -29,7 +29,7 @@ class Oneapi(Compiler):
     PrgEnv_compiler = 'oneapi'
 
     version_argument = '--version'
-    version_regex = r'(?:(?:oneAPI DPC\+\+ Compiler)|(?:\(IFORT\))) (\S+)'
+    version_regex = r'(?:(?:oneAPI DPC\+\+(?:\/C\+\+)? Compiler)|(?:\(IFORT\))) (\S+)'
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -3,27 +3,26 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """Test detection of compiler version"""
-import pytest
 import os
 
-import llnl.util.filesystem as fs
+import pytest
 
+import llnl.util.filesystem as fs
+import spack.compilers.aocc
 import spack.compilers.arm
 import spack.compilers.cce
 import spack.compilers.clang
 import spack.compilers.fj
 import spack.compilers.gcc
 import spack.compilers.intel
-import spack.compilers.oneapi
 import spack.compilers.nag
 import spack.compilers.nvhpc
+import spack.compilers.oneapi
 import spack.compilers.pgi
 import spack.compilers.xl
 import spack.compilers.xl_r
-import spack.compilers.aocc
-
-from spack.operating_systems.cray_frontend import CrayFrontend
 import spack.util.module_cmd
+from spack.operating_systems.cray_frontend import CrayFrontend
 
 
 @pytest.mark.parametrize('version_str,expected_version', [
@@ -157,17 +156,41 @@ def test_intel_version_detection(version_str, expected_version):
 
 @pytest.mark.parametrize('version_str,expected_version', [
     (  # ICX/ICPX
-        'Intel(R) oneAPI DPC++ Compiler 2021.1 (2020.10.0.1113)\n'
+        'Intel(R) oneAPI DPC++ Compiler 2021.1.2 (2020.10.0.1214)\n'
         'Target: x86_64-unknown-linux-gnu\n'
         'Thread model: posix\n'
         'InstalledDir: /made/up/path',
-        '2021.1'
+        '2021.1.2'
+    ),
+    (  # ICX/ICPX
+        'Intel(R) oneAPI DPC++ Compiler 2021.2.0 (2021.2.0.20210317)\n'
+        'Target: x86_64-unknown-linux-gnu\n'
+        'Thread model: posix\n'
+        'InstalledDir: /made/up/path',
+        '2021.2.0'
+    ),
+    (  # ICX/ICPX
+        'Intel(R) oneAPI DPC++/C++ Compiler 2021.3.0 (2021.3.0.20210619)\n'
+        'Target: x86_64-unknown-linux-gnu\n'
+        'Thread model: posix\n'
+        'InstalledDir: /made/up/path',
+        '2021.3.0'
     ),
     (  # IFX
-        'ifx (IFORT) 2021.1 Beta 20201113\n'
+        'ifx (IFORT) 2021.1.2 Beta 20201214\n'
         'Copyright (C) 1985-2020 Intel Corporation. All rights reserved.',
-        '2021.1'
-    )
+        '2021.1.2'
+    ),
+    (  # IFX
+        'ifx (IFORT) 2021.2.0 Beta 20210317\n'
+        'Copyright (C) 1985-2020 Intel Corporation. All rights reserved.',
+        '2021.2.0'
+    ),
+    (  # IFX
+        'ifx (IFORT) 2021.3.0 Beta 20210619\n'
+        'Copyright (C) 1985-2020 Intel Corporation. All rights reserved.',
+        '2021.3.0'
+    ),
 ])
 def test_oneapi_version_detection(version_str, expected_version):
     version = spack.compilers.oneapi.Oneapi.extract_version_from_output(

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -18,6 +18,10 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on('intel-oneapi-mpi')
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17920/l_oneapi_ccl_p_2021.3.0.343_offline.sh',
+                sha256='0bb63e2077215cc161973b2e5029919c55e84aea7620ee9a848f6c2cc1245e3f',
+                expand=False)
         version('2021.2.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17731/l_oneapi_ccl_p_2021.2.0.269_offline.sh',
                 sha256='18b7875030243295b75471e235e91e5f7b4fc15caf18c07d941a6d47fba378d7',

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import glob
-from os import path
-import subprocess
 import platform
+import subprocess
+from os import path
 
 from spack import *
 
@@ -22,9 +22,19 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     depends_on('patchelf', type='build')
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh',
+                sha256='f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1',
+                expand=False)
+        resource(name='fortran-installer',
+                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh',
+                 sha256='c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c',
+                 expand=False,
+                 placement='fortran-installer',
+                 when='@2021.3.0')
         version('2021.2.0',
-                sha256='5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh',
+                sha256='5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59',
                 expand=False)
         resource(name='fortran-installer',
                  url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onedal.html'
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17905/l_daal_oneapi_p_2021.3.0.557_offline.sh',
+                sha256='4c2e77a3a2fa5f8a09b7d68760dfca6c07f3949010836cd6da34075463467995',
+                expand=False)
         version('2021.2.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17747/l_daal_oneapi_p_2021.2.0.358_offline.sh',
                 sha256='cbf4e64dbd21c10179f2d1d7e8b8b0f12eeffe6921602df33276cd0ebd1f8e34',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onednn.html'
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17923/l_onednn_p_2021.3.0.344_offline.sh',
+                sha256='1521f6cbffcf9ce0c7b5dfcf1a2546a4a0c8d8abc99f3011709039aaa9e0859a',
+                expand=False)
         version('2021.2.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17751/l_onednn_p_2021.2.0.228_offline.sh',
                 sha256='62121a3355298211a124ff4e71c42fc172bf1061019be6c6120830a1a502aa88',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -16,6 +16,10 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17958/l_ipp_oneapi_p_2021.3.0.333_offline.sh',
+                sha256='67e75c80813ec9a30d5fda5860f76122ae66fa2128a48c8461f5e6b100b38bbb',
+                expand=False)
         version('2021.2.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17758/l_ipp_oneapi_p_2021.2.0.233_offline.sh',
                 sha256='ccdfc81f77203822d80151b40ce9e8fd82bb2de85a9b132ceed12d24d3f3ff52',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -17,6 +17,10 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17886/l_ippcp_oneapi_p_2021.3.0.315_offline.sh',
+                sha256='0214d132d8e64b02e9cc63182e2099fb9caebf8c240fb1629ae898c2e1f72fb9',
+                expand=False)
         version('2021.2.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17684/l_ippcp_oneapi_p_2021.2.0.231_offline.sh',
                 sha256='64cd5924b42f924b6a8128a8bf8e686f5dc52b98f586ffac6c2e2f1585e3aba9',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -17,6 +17,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html'
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17901/l_onemkl_p_2021.3.0.520_offline.sh',
+                sha256='a06e1cdbfd8becc63440b473b153659885f25a6e3c4dcb2907ad9cd0c3ad59ce',
+                expand=False)
         version('2021.2.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17757/l_onemkl_p_2021.2.0.296_offline.sh',
                 sha256='816e9df26ff331d6c0751b86ed5f7d243f9f172e76f14e83b32bf4d1d619dbae',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import subprocess
 import platform
+import subprocess
 
 
 from spack import *
@@ -19,6 +19,10 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html'
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17947/l_mpi_oneapi_p_2021.3.0.294_offline.sh',
+                sha256='04c48f864ee4c723b1b4ca62f2bea8c04d5d7e3de19171fd62b17868bc79bc36',
+                expand=False)
         version('2021.2.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17729/l_mpi_oneapi_p_2021.2.0.215_offline.sh',
                 sha256='d0d4cdd11edaff2e7285e38f537defccff38e37a3067c02f4af43a3629ad4aa3',

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -17,6 +17,10 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onetbb.html'
 
     if platform.system() == 'Linux':
+        version('2021.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17952/l_tbb_oneapi_p_2021.3.0.511_offline.sh',
+                sha256='b83f5e018e3d262e42e9c96881845bbc09c3f036c265e65023422ca8e8637633',
+                expand=False)
         version('2021.2.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17759/l_tbb_oneapi_p_2021.2.0.357_offline.sh',
                 sha256='c1c3623c5bef547b30eac009e7a444611bf714c758d7472c114e9be9d5700eba',


### PR DESCRIPTION
Add oneAPI packages from the 2021.3 release

I did manual checks of style checking and oneapi-tests on the local machine.
oneapi-test CI results: https://github.com/DanVev/oneapi-spack-tests/actions

Included a quick fix for correct ICX compiler version parsing. 
FYI: @rscohn2