### PR TITLE
ci: only write to broken-specs list on SpackError

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -14,11 +14,10 @@ import tempfile
 from six.moves.urllib.parse import urlencode
 
 import llnl.util.tty as tty
-
 import spack.binary_distribution as bindist
 import spack.ci as spack_ci
-import spack.config as cfg
 import spack.cmd.buildcache as buildcache
+import spack.config as cfg
 import spack.environment as ev
 import spack.hash_types as ht
 import spack.mirror

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -496,7 +496,7 @@ def ci_rebuild(args):
     # If a spec fails to build in a spack develop pipeline, we add it to a
     # list of known broken full hashes.  This allows spack PR pipelines to
     # avoid wasting compute cycles attempting to build those hashes.
-    if install_exit_code != 0 and spack_is_develop_pipeline:
+    if install_exit_code == 1 and spack_is_develop_pipeline:
         tty.debug('Install failed on develop')
         if 'broken-specs-url' in gitlab_ci:
             broken_specs_url = gitlab_ci['broken-specs-url']

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -775,12 +775,6 @@ def main(argv=None):
         tty.debug(e)
         e.die()  # gracefully die on any SpackErrors
 
-    except Exception as e:
-        if spack.config.get('config:debug'):
-            raise
-        tty.error(e)
-        return 3
-
     except KeyboardInterrupt:
         if spack.config.get('config:debug'):
             raise
@@ -792,6 +786,12 @@ def main(argv=None):
         if spack.config.get('config:debug'):
             traceback.print_exc()
         return e.code
+
+    except Exception as e:
+        if spack.config.get('config:debug'):
+            raise
+        tty.error(e)
+        return 3
 
 
 class SpackCommandError(Exception):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -17,6 +17,7 @@ import os.path
 import inspect
 import pstats
 import argparse
+import signal
 import traceback
 import warnings
 from six import StringIO
@@ -777,13 +778,15 @@ def main(argv=None):
     except Exception as e:
         if spack.config.get('config:debug'):
             raise
-        tty.die(e)
+        tty.error(e)
+        return 3
 
     except KeyboardInterrupt:
         if spack.config.get('config:debug'):
             raise
         sys.stderr.write('\n')
-        tty.die("Keyboard interrupt.")
+        tty.error("Keyboard interrupt.")
+        return signal.SIGINT.value
 
     except SystemExit as e:
         if spack.config.get('config:debug'):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -10,36 +10,36 @@ after the system path is set up.
 """
 from __future__ import print_function
 
-import sys
-import re
+import argparse
+import inspect
 import os
 import os.path
-import inspect
 import pstats
-import argparse
+import re
 import signal
+import sys
 import traceback
 import warnings
-from six import StringIO
 
 import archspec.cpu
+from six import StringIO
+
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 import llnl.util.tty.color as color
-from llnl.util.tty.log import log_output
-
 import spack
 import spack.architecture
-import spack.config
 import spack.cmd
+import spack.config
 import spack.environment as ev
 import spack.modules
 import spack.paths
 import spack.repo
 import spack.store
 import spack.util.debug
-import spack.util.path
 import spack.util.executable as exe
+import spack.util.path
+from llnl.util.tty.log import log_output
 from spack.error import SpackError
 
 #: names of profile statistics


### PR DESCRIPTION
Only write to the broken-specs list when `spack install` raises a SpackError.

Before this commit we were writing to this list unnecessarily when
infrastructure-related problems prevented a develop job from completing
successfully.