### PR TITLE
py-torch: fix bug in libs/headers attributes

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -223,12 +223,14 @@ class PyTorch(PythonPackage, CudaPackage):
 
     @property
     def libs(self):
-        root = join_path(site_packages_dir, 'torch', 'lib')
+        root = join_path(self.prefix, self.spec['python'].package.site_packages_dir,
+                         'torch', 'lib')
         return find_libraries('libtorch', root)
 
     @property
     def headers(self):
-        root = join_path(site_packages_dir, 'torch', 'include')
+        root = join_path(self.prefix, self.spec['python'].package.site_packages_dir,
+                         'torch', 'include')
         headers = find_all_headers(root)
         headers.directories = [root]
         return headers


### PR DESCRIPTION
Fixes a bug introduced in #24294 

I have no idea why this doesn't work because we use the same syntax in dozens of other packages.

This was causing the `py-torchvision` build to fail.

With this PR, `py-torchvision` now successfully builds and passes all import tests on Ubuntu 18.04 with Python 3.8.10 and GCC 7.5.0.