### PR TITLE
hdf5: Fix compiler test

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -187,7 +187,7 @@ class Hdf5(CMakePackage):
         cmake_flags = []
 
         if name == "cflags":
-            if "clang" in self.compiler.cc or "gcc" in self.compiler.cc:
+            if self.spec.satisfies('%clang') or self.spec.satisfies('%gcc'):
                 # Quiet warnings/errors about implicit declaration of functions
                 # in C99:
                 cmake_flags.append("-Wno-implicit-function-declaration")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import pathlib
 import shutil
 import sys
 
@@ -188,7 +187,7 @@ class Hdf5(CMakePackage):
         cmake_flags = []
 
         if name == "cflags":
-            cc_name = pathlib.PurePosixPath(self.compiler.cc).name
+            cc_name = os.path.basename(self.compiler.cc)
             if "clang" in cc_name or "gcc" in cc_name:
                 # Quiet warnings/errors about implicit declaration of functions
                 # in C99:

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import pathlib
 import shutil
 import sys
 
@@ -187,7 +188,8 @@ class Hdf5(CMakePackage):
         cmake_flags = []
 
         if name == "cflags":
-            if self.spec.satisfies('%clang') or self.spec.satisfies('%gcc'):
+            cc_name = pathlib.PurePosixPath(self.compiler.cc).name
+            if "clang" in cc_name or "gcc" in cc_name:
                 # Quiet warnings/errors about implicit declaration of functions
                 # in C99:
                 cmake_flags.append("-Wno-implicit-function-declaration")


### PR DESCRIPTION
Use `self.spec.satisfies` on compiler to determine if a flag should be
applied or not.  This approach avoids issues with the strings `gcc`
or `clang` appearing in the full path to the compiler executables, as
happens with spack-installed compilers (e.g. `nvhpc%gcc`).  Effectively,
this restores PR #24451, although uses a slightly different test. @skosukhin 