### PR TITLE
[package][new version] Provide draco-7_11_0

### DIFF
--- a/var/spack/repos/builtin/packages/draco/package.py
+++ b/var/spack/repos/builtin/packages/draco/package.py
@@ -18,6 +18,7 @@ class Draco(CMakePackage):
     maintainers = ['KineticTheory']
 
     version('develop', branch='develop')
+    version('7.11.0',  sha256='a829984778fefd98c3c609ac10403df3eb06f02d57bdbc013634d0dc1ed5af29')
     version('7.10.0',  sha256='3530263a23a648fc7ae65748568f0a725a8b2c9bac9a41cc3cb1250c4af579de')
     version('7.9.1',  sha256='c8fd029d5b74afc68670f7d449d60c24f2d284c9d6a944a2d3dce6efeb6ad097')
     version('7.9.0',  sha256='17b54301897da0d4f9b91fef15cc2ec5e6c65a8e8c1c09e6e7b516c0fb82b50f')
@@ -53,12 +54,14 @@ class Draco(CMakePackage):
     depends_on('cmake@3.14:', when='@7.2.0:7.6.99', type='build')
     depends_on('cmake@3.17:', when='@7.7:',         type='build')
     depends_on('cmake@3.18:', when='@7.9:',         type='build')
-    depends_on('gsl')
+    depends_on('gsl@:2.5.99', when='@:7.10.99')
+    depends_on('gsl@2.6:',    when='@7.11.0:')
     depends_on('mpi@3:',         type=('build', 'link', 'run'))
     depends_on('numdiff',        type='build')
-    depends_on('random123@1.09', type='build')
-    depends_on('python@2.7:', when='@7.7.0:',       type=('build', 'run'))
-    depends_on('python@3.5:', when='@:7.6.99',      type=('build', 'run', 'test'))
+    depends_on('random123@1.09', when='@:7.6.99')
+    depends_on('random123',      when='@7.7.0:')
+    depends_on('python@2.7:',    when='@:7.6.99',   type=('build', 'run', 'test'))
+    depends_on('python@3.5:',    when='@7.7.0:',    type=('build', 'run', 'test'))
 
     # Optional dependencies
     depends_on('caliper',     when='+caliper')


### PR DESCRIPTION
+ Clarify version requirements for Random123.  Newer versions of Draco can use newer versions of Random123.
+ Fix a python version requirement that had inverted (and confusing) requirements for Draco-7_7_0. Newer versions of Draco require `python@3.5:`.
+ Revert the variant name `+superlu-dist` to a hyphen instead of an underscore to match trilinos/package.py.
