### PR TITLE
Petsc with hpddm and parmmg

### DIFF
--- a/var/spack/repos/builtin/packages/hpddm/package.py
+++ b/var/spack/repos/builtin/packages/hpddm/package.py
@@ -1,0 +1,92 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install hpddm
+#
+# You can edit this file again by typing:
+#
+#     spack edit hpddm
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class Hpddm(Package):
+    """HPDDM — high-performance unified framework for domain decomposition methods"""
+
+    homepage = "https://github.com/hpddm/hpddm"
+    url      = "https://github.com/hpddm/hpddm"
+    git      = "https://github.com/hpddm/hpddm.git"
+
+    maintainers = ['corentin-dev']
+
+    version('main', branch='main')
+    version('2.1.2', commit='e58205623814f59bf2aec2e2bab8eafcfbd22466')
+
+    depends_on('mpi')
+    depends_on('blas')
+    depends_on('lapack')
+    depends_on('mumps')
+    depends_on('hypre')
+    depends_on('scalapack')
+    depends_on('arpack-ng')
+    depends_on('python')
+
+    def configure(self):
+        makefile_inc = []
+        # cflags = [
+        makefile_inc.append('SOLVER ?= MUMPS')
+        makefile_inc.append('SUBSOLVER ?= MUMPS')
+        makefile_inc.append('EIGENSOLVER ?= ARPACK')
+        makefile_inc.append('MPICXX ?= mpic++')
+        makefile_inc.append('MPICC ?= mpicc')
+        makefile_inc.append('MPIF90 ?= mpif90')
+        makefile_inc.append('MPIRUN ?= mpirun -np')
+
+        makefile_inc.append('override CXXFLAGS += -std=c++11 -O3 -fPIC')
+        makefile_inc.append('override CFLAGS += -std=c99 -O3')
+        makefile_inc.append('INCS =')
+        makefile_inc.append('LIBS =')
+
+        makefile_inc.append("HPDDMFLAGS ?= -DHPDM_NUMBERING=\'C\'")
+
+        makefile_inc.append('MUMPS_INCS = ')
+        makefile_inc.append('PYTHON_INCS = ')
+        makefile_inc.append('BLAS_LIBS = -lopenblas')
+        makefile_inc.append('ARPACK_LIBS = -larpack')
+        makefile_inc.append('SCALAPACK_LIBS = -lscalapack')
+        makefile_inc.append(' '.join([
+            'MUMPS_LIBS', '=',
+            '-lcmumps',
+            '-ldmumps',
+            '-lsmumps',
+            '-lzmumps',
+            '-lmumps_common',
+            '-lpord',
+            '-fopenmp']))
+        makefile_inc.append('HYPRE_LIBS = -lHYPRE')
+        makefile_inc.append('PYTHON_LIBS = -lpython3')
+
+        with working_dir('.'):
+            with open('Makefile.inc', 'w') as fh:
+                fh.write('\n'.join(makefile_inc))
+
+    def patch(self):
+        self.configure()
+
+    def install(self, spec, prefix):
+        make()
+        install_tree('include', prefix.include)
+        # make('install')

--- a/var/spack/repos/builtin/packages/mmg/package.py
+++ b/var/spack/repos/builtin/packages/mmg/package.py
@@ -26,6 +26,7 @@ class Mmg(CMakePackage):
     homepage = "http://www.mmgtools.org/"
     url      = "https://github.com/MmgTools/mmg/archive/v5.3.13.tar.gz"
 
+    version('5.5.2',  sha256='58e3b866101e6f0686758e16bcf9fb5fb06c85184533fc5054ef1c8adfd4be73')
     version('5.4.0',  sha256='2b5cc505018859856766be901797ff5d4789f89377038a0211176a5571039750')
     version('5.3.13', sha256='d9a5925b69b0433f942ab2c8e55659d9ccea758743354b43d54fdf88a6c3c191')
 

--- a/var/spack/repos/builtin/packages/parmmg/package.py
+++ b/var/spack/repos/builtin/packages/parmmg/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install parmmg
+#
+# You can edit this file again by typing:
+#
+#     spack edit parmmg
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class Parmmg(CMakePackage):
+    """ParMMG is a parallel remesher based on MMG"""
+
+    homepage = "https://www.mmgtools.org"
+    url      = "https://github.com/MmgTools/ParMmg/archive/refs/tags/v1.3.0.tar.gz"
+
+    maintainers = ['corentin-dev']
+
+    version('1.3.0', sha256='d43b73a73b62545b5a31bbe25562f69c9e63ad8a6d416bd459781203e37427cf')
+    version('1.2.0', sha256='99729cc292dcb59c87e3f25d4cabf5a64841e83b624d383e1fd3fb7f960df672')
+    version('1.1.0', sha256='a5904f1f56b7809ab9ec2f6118b03a082ec2b5564355a73c74fc55426cc69600')
+    version('1.0.0', sha256='614feb815ff6cdfc9bced30e8105994f0bf3a812243619d3349203ec1851cf6d')
+
+    depends_on('mmg')
+    depends_on('metis')
+    depends_on('vtk')
+    depends_on('mpi')
+
+    def cmake_args(self):
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -237,7 +237,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     depends_on('valgrind', when='+valgrind')
     depends_on('mmg', when='+mmg')
     depends_on('parmmg', when='+parmmg')
-    depends_on('tetgen', when='+tetgen')
+    depends_on('tetgen+pic', when='+tetgen')
     # Hypre does not support complex numbers.
     # Also PETSc prefer to build it without internal superlu, likely due to
     # conflict in headers see

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -90,6 +90,14 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             description='Activates support for HDF5 (only parallel)')
     variant('hypre',   default=True,
             description='Activates support for Hypre (only parallel)')
+    variant('hpddm',   default=False,
+            description='Activates support for HPDDM (only parallel)')
+    variant('mmg',   default=False,
+            description='Activates support for MMG')
+    variant('parmmg',   default=False,
+            description='Activates support for ParMMG (only parallel)')
+    variant('tetgen',   default=False,
+            description='Activates support for Tetgen')
     # Mumps is disabled by default, because it depends on Scalapack
     # which is not portable to all HPC systems
     variant('mumps',   default=False,
@@ -156,6 +164,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     conflicts('+fftw', when='~mpi', msg=mpi_msg)
     conflicts('+hdf5', when='~mpi', msg=mpi_msg)
     conflicts('+hypre', when='~mpi', msg=mpi_msg)
+    conflicts('+hpddm', when='~mpi', msg=mpi_msg)
+    conflicts('+parmmg', when='~mpi', msg=mpi_msg)
     conflicts('+moab', when='~mpi', msg=mpi_msg)
     conflicts('+mumps', when='~mpi', msg=mpi_msg)
     conflicts('+p4est', when='~mpi', msg=mpi_msg)
@@ -179,6 +189,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     patch('xlf_fix-dup-petscfecreate.patch', when='@3.11.0')
     patch('disable-DEPRECATED_ENUM.diff', when='@3.14.1 +cuda')
 
+    depends_on('gmake')
     depends_on('diffutils', type='build')
 
     # Virtual dependencies
@@ -224,6 +235,9 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     depends_on('parmetis+int64', when='+metis+mpi+int64')
     depends_on('parmetis~int64', when='+metis+mpi~int64')
     depends_on('valgrind', when='+valgrind')
+    depends_on('mmg', when='+mmg')
+    depends_on('parmmg', when='+parmmg')
+    depends_on('tetgen', when='+tetgen')
     # Hypre does not support complex numbers.
     # Also PETSc prefer to build it without internal superlu, likely due to
     # conflict in headers see
@@ -377,6 +391,44 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             options.extend([
                 '--with-scalapack=0'
             ])
+
+        # For the moment, HPDDM does not work as a dependency
+        # using download instead
+        if '+hpddm' in spec:
+            options.extend(['--download-hpddm'])
+
+        if '+mmg' in spec:
+            options.extend([
+                '--with-mmg-dir=%s' %
+                spec['mmg'].prefix,
+                '--with-mmg=1'
+            ])
+        else:
+            options.append(
+                '--with-mmg=0'
+            )
+
+        if '+parmmg' in spec:
+            options.extend([
+                '--with-parmmg-dir=%s' %
+                spec['parmmg'].prefix,
+                '--with-parmmg=1'
+            ])
+        else:
+            options.append(
+                '--with-parmmg=0'
+            )
+
+        if '+tetgen' in spec:
+            options.extend([
+                '--with-tetgen-dir=%s' %
+                spec['tetgen'].prefix,
+                '--with-tetgen=1'
+            ])
+        else:
+            options.append(
+                '--with-tetgen=0'
+            )
 
         # Activates library support if needed (i.e. direct dependency)
         if '^libjpeg-turbo' in spec:

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -15,6 +15,8 @@ class Scotch(Package):
     url      = "http://gforge.inria.fr/frs/download.php/latestfile/298/scotch_6.0.4.tar.gz"
     list_url = "http://gforge.inria.fr/frs/?group_id=248"
 
+    version('6.1.1', sha256='39052f59ff474a4a69cefc25cf3caf8429400889deba010ee6403ca188f8b311')
+    version('6.1.0', sha256='a3bc3fa3b243fcb52f8d68de4272562a0328afb18a96f535724d284e36730485')
     version('6.0.10', sha256='fd8b707b8200823312a1571d97d3776ff3dfd3280cfa4b6e38987153cea5dbda')
     version('6.0.9', sha256='622b4143cf01c480bb15708b3651b29c25e4aeb00c8c6447ff196aca2eca5c93')
     version('6.0.8', sha256='0ba3f145026174304f910c8770a3cbb034f213c91d939573751cfbb4fd46d45e')

--- a/var/spack/repos/builtin/packages/tetgen/package.py
+++ b/var/spack/repos/builtin/packages/tetgen/package.py
@@ -20,6 +20,7 @@ class Tetgen(Package):
     version('1.5.0', sha256='4d114861d5ef2063afd06ef38885ec46822e90e7b4ea38c864f76493451f9cf3', url='http://www.tetgen.org/1.5/src/tetgen1.5.0.tar.gz')
     version('1.4.3', sha256='952711bb06b7f64fd855eb24c33f08e3faf40bdd54764de10bbe5ed5b0dce034', url='http://www.tetgen.org/files/tetgen1.4.3.tar.gz')
 
+    variant('pic', default=True, description='Builds the library in pic mode.')
     variant('debug', default=False, description='Builds the library in debug mode.')
     variant('except', default=False, description='Replaces asserts with exceptions for better C++ compatibility.')
 
@@ -27,9 +28,12 @@ class Tetgen(Package):
 
     def patch(self):
         cflags = '-g -O0' if '+debug' in self.spec else '-g0 -O3'
+        cflags = cflags + ' -fPIC' if '+pic' in self.spec else cflags
+        predcflags = '-fPIC' if '+pic' in self.spec else ''
 
         mff = FileFilter('makefile')
         mff.filter(r'^(C(XX)?FLAGS\s*=)(.*)$', r'\1 {0}'.format(cflags))
+        mff.filter(r'^(PREDC(XX)?FLAGS\s*=.*)$', r'\1 {0}'.format(predcflags))
 
         if '+except' in self.spec:
             hff = FileFilter('tetgen.h')


### PR DESCRIPTION
Adding new variants to PETSc package : 
- HPDDM for domain decomposition methods : https://github.com/hpddm/hpddm
- MMG and ParMMG for remeshing : https://github.com/MmgTools/ParMmg