### PR TITLE
config add: use the provided value to validate the type

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -878,7 +878,7 @@ def add(fullpath, scope=None):
             # We've nested further than existing config, so we need the
             # type information for validation to know how to handle bare
             # values appended to lists.
-            existing = get_valid_type(path)
+            existing = get_valid_type(path, components[-1])
 
             # construct value from this point down
             value = syaml.load_config(components[-1])
@@ -1041,7 +1041,7 @@ def _mark_internal(data, name):
     return d
 
 
-def get_valid_type(path):
+def get_valid_type(path, value):
     """Returns an instance of a type that will pass validation for path.
 
     The instance is created by calling the constructor with no arguments.
@@ -1053,7 +1053,11 @@ def get_valid_type(path):
     section = components[0]
     for type in (list, syaml.syaml_dict, str, bool, int, float):
         try:
-            ret = type()
+            try:
+                ret = type(value)
+            except (ValueError):
+                ret = type()
+
             test_data = ret
             for component in reversed(components):
                 test_data = {component: test_data}

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -279,19 +279,29 @@ repos_high = {'repos': ["/some/other/path"]}
 # Test setting config values via path in filename
 
 
-def test_add_config_path():
-
+def test_add_config_path(mutable_config):
     # Try setting a new install tree root
     path = "config:install_tree:root:/path/to/config.yaml"
-    spack.config.add(path, scope="command_line")
+    spack.config.add(path)
     set_value = spack.config.get('config')['install_tree']['root']
     assert set_value == '/path/to/config.yaml'
 
     # Now a package:all setting
     path = "packages:all:compiler:[gcc]"
-    spack.config.add(path, scope="command_line")
+    spack.config.add(path)
     compilers = spack.config.get('packages')['all']['compiler']
     assert "gcc" in compilers
+
+
+def test_add_config_path_with_enumerated_type(mutable_config):
+    spack.config.add("config:concretizer:clingo")
+    assert spack.config.get('config')['concretizer'] == "clingo"
+
+    spack.config.add("config:concretizer:original")
+    assert spack.config.get('config')['concretizer'] == "original"
+
+    with pytest.raises(spack.config.ConfigError):
+        spack.config.add("config:concretizer:foo")
 
 
 def test_add_config_filename(mock_low_high_config, tmpdir):


### PR DESCRIPTION
Fixes #17543
Fixes #23259

When adding a config parameter via `spack config add 'foo:bar:baz'` an attempt is made to determine the appropriate type for the config entry by cycling through the default values for various types and attempting to validate against the schema.  This fails for enums since the default value is most likely not one of the valid enum values.  This change uses the user-provided value itself to construct the test value to validate with rather than the default value for a given type.

Before this change the following would fail and now succeeds:

```bash
$ spack config add 'config:concretizer:clingo'
==> Error: Cannot determine valid type for path 'config:concretizer'.
```