### PR TITLE
Rename cray compiler to cce

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -235,7 +235,7 @@ class Cp2k(MakefilePackage, CudaPackage):
             'intel': ['-O2', '-pc64', '-unroll', ],
             'pgi': ['-fast'],
             'nvhpc': ['-fast'],
-            'cray': ['-O2'],
+            'cce': ['-O2'],
             'xl': ['-O3'],
             'aocc': ['-O1'],
         }
@@ -281,7 +281,7 @@ class Cp2k(MakefilePackage, CudaPackage):
             ]
         elif '%pgi' in spec or '%nvhpc' in spec:
             fcflags += ['-Mfreeform', '-Mextend']
-        elif '%cray' in spec:
+        elif '%cce' in spec:
             fcflags += ['-emf', '-ffree', '-hflex_mp=strict']
         elif '%xl' in spec:
             fcflags += ['-qpreprocess', '-qstrict', '-q64']
@@ -294,7 +294,7 @@ class Cp2k(MakefilePackage, CudaPackage):
             ldflags.append(self.compiler.openmp_flag)
             nvflags.append('-Xcompiler="{0}"'.format(
                 self.compiler.openmp_flag))
-        elif '%cray' in spec:  # Cray enables OpenMP by default
+        elif '%cce' in spec:  # Cray enables OpenMP by default
             cflags   += ['-hnoomp']
             cxxflags += ['-hnoomp']
             fcflags  += ['-hnoomp']

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import copy
 import os
 import os.path

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import copy
 import os
 import os.path
-import copy
 
 import spack.util.environment
 


### PR DESCRIPTION
Incorrect compiler name "cray", tested on Cray XC50 system.