### PR TITLE
buildcache create: respect user-specified signing key

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -678,20 +678,22 @@ def checksum_tarball(file):
 
 
 def select_signing_key(key=None):
-    if key is None:
-        keys = spack.util.gpg.signing_keys()
-        if len(keys) == 1:
-            key = keys[0]
+    keys = spack.util.gpg.signing_keys()
 
-        if len(keys) > 1:
-            raise PickKeyException(str(keys))
+    if len(keys) <= 0:
+        raise NoKeyException(
+            "No default key available for signing.\n"
+            "Use spack gpg init and spack gpg create"
+            " to create a default key.")
 
-        if len(keys) == 0:
-            raise NoKeyException(
-                "No default key available for signing.\n"
-                "Use spack gpg init and spack gpg create"
-                " to create a default key.")
-    return key
+    if key:
+        if key not in keys:
+            raise NoKeyException("Key not found: {0}".format(key))
+        return key
+    elif len(keys) == 1:
+        return keys[0]
+
+    raise PickKeyException(str(keys))
 
 
 def sign_tarball(key, force, specfile_path):


### PR DESCRIPTION
`spack buildcache create --key <KEY> ...` will currently use a key *other than the user-specified signing key* if the user-specified key does not exist and there is a single signing key in the keyring. 

This PR makes `spack buildcache create` fail if a user specifically instructs Spack to use a key that does not exist.

Here is the current behavior (i.e. without changes in this PR):
```
$> spack gpg list --signing
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
/Users/walker/spack/opt/spack/gpg/pubring.kbx
---------------------------------------------
pub   rsa3072 2019-08-09 [SC] [expires: 2021-08-08]
      7D344E2992071B0AAAE1EDB0E68DE2A80314303D
uid           [ unknown] prl
sub   rsa3072 2019-08-09 [E]

pub   ed25519 2021-07-01 [SC] [expires: 2023-07-01]
      EED1B255BD10B849FCC9AAF0F6066B76BC28E44D
uid           [ unknown] University of Oregon - E4S
sub   cv25519 2021-07-01 [E] [expires: 2023-07-01]

/Users/walker/spack/opt/spack/gpg/pubring.kbx
---------------------------------------------
sec   rsa3072 2019-08-09 [SC] [expires: 2021-08-08]
      7D344E2992071B0AAAE1EDB0E68DE2A80314303D
uid           [ unknown] prl
ssb   rsa3072 2019-08-09 [E]
```

```
$> spack buildcache create ... --key "University of Oregon - E4S" ...
==> Buildcache files will be output to ...
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
gpg: Warning: not using 'University of Oregon - E4S' as default key: No secret key
gpg: all values passed to '--default-key' ignored

$> echo $?
0
```

Here is the behavior with this PR:
```
$> spack buildcache create ... --key "University of Oregon - E4S" ...
==> Buildcache files will be output to file:///Users/walker/go/src/github.com/eugeneswalker/cache-manager/cache-resigner/build_cache
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
==> Error: Key not found: University of Oregon - E4S

$> echo $?
1
```

@becker33 @vsoch @alalazo @opadron @scottwittenburg 