### PR TITLE
pthreadpool: enable shared libraries

### DIFF
--- a/var/spack/repos/builtin/packages/pthreadpool/package.py
+++ b/var/spack/repos/builtin/packages/pthreadpool/package.py
@@ -50,7 +50,7 @@ class Pthreadpool(CMakePackage):
 
     def cmake_args(self):
         return [
-            '-DBUILD_SHARED_LIBS=ON',
+            self.define('BUILD_SHARED_LIBS', True),
             self.define('FXDIV_SOURCE_DIR',
                         join_path(self.stage.source_path, 'deps', 'fxdiv')),
             self.define('GOOGLETEST_SOURCE_DIR',

--- a/var/spack/repos/builtin/packages/pthreadpool/package.py
+++ b/var/spack/repos/builtin/packages/pthreadpool/package.py
@@ -50,6 +50,7 @@ class Pthreadpool(CMakePackage):
 
     def cmake_args(self):
         return [
+            '-DBUILD_SHARED_LIBS=ON',
             self.define('FXDIV_SOURCE_DIR',
                         join_path(self.stage.source_path, 'deps', 'fxdiv')),
             self.define('GOOGLETEST_SOURCE_DIR',


### PR DESCRIPTION
Since #24294, py-torch fails to build with the error:
```
/bin/ld: .../linux-centos7-broadwell/gcc-10.2.0/pthreadpool-2021-04-13-y6ixkfza7p7nn5dtsqol6xhvmdfnxopq/lib64/libpthreadpool.a(legacy-api.c.o): relocation R_X86_64_32 against `.text' can not be used when making a shared object; recompile with -fPIC
```
My pthreadpool build only has static libraries. This switches pthreadpool to shared libraries so it can be linked into other shared libraries. With this, py-torch builds for me.