### PR TITLE
Expat: add version 2.4.0, 2.4.1; fix CVE-2013-0340

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -61,7 +61,7 @@ spack:
       variants: +bzip2 ~nls +xz
     expat:
       version:
-      - 2.3.0
+      - 2.4.1
     findutils:
       version:
       - 4.8.0

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -58,7 +58,7 @@ spack:
       variants: +bzip2 ~nls +xz
     expat:
       version:
-        - 2.3.0
+        - 2.4.1
     findutils:
       version:
         - 4.8.0

--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -14,9 +14,13 @@ class Expat(AutotoolsPackage):
     homepage = "https://libexpat.github.io/"
     url      = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
-    version('2.3.0', sha256='f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586')
-    version('2.2.10', sha256='b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5')
-    version('2.2.9', sha256='f1063084dc4302a427dabcca499c8312b3a32a29b7d2506653ecc8f950a9a237')
+    version('2.4.1', sha256='2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40')
+    version('2.4.0', sha256='8c59142ef88913bc0a8b6e4c58970c034210ca552e6271f52f6cd6cce3708424')
+    # deprecate all releases before 2.4.0 because of CVE-2013-0340
+    # ("billion laughs attack")
+    version('2.3.0', sha256='f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586', deprecated=True)
+    version('2.2.10', sha256='b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5', deprecated=True)
+    version('2.2.9', sha256='f1063084dc4302a427dabcca499c8312b3a32a29b7d2506653ecc8f950a9a237', deprecated=True)
     version('2.2.6', sha256='17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2', deprecated=True)
     version('2.2.5', sha256='d9dc32efba7e74f788fcc4f212a43216fc37cf5f23f4c2339664d473353aedf6', deprecated=True)
     version('2.2.2', sha256='4376911fcf81a23ebd821bbabc26fd933f3ac74833f74924342c29aad2c86046', deprecated=True)


### PR DESCRIPTION
Per the Packaging Guide, this pull requests deprecates Expat releases before version 2.4.0 because they contain the security vulnerability [CVE-2013-0340](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-0340).

This pull request was _not_ checked with `py-flake8-import-order` because the latest Spack `develop` branch refuses to run this tool:
```console
~/spack$ spack load py-flake8-import-order
~/spack$ spack style
==> style: running code checks on spack.
==> style: tools selected: flake8, mypy
==> Modified files:
  var/spack/repos/builtin/packages/expat/package.py
==> style: running flake8 checks on spack.
==> Flake8 style checks were clean
==> style: running mypy checks on spack.
^CTraceback (most recent call last):
```

fixes #24628