### PR TITLE
xyce: clean and fix trilinos dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -43,7 +43,7 @@ class Xyce(CMakePackage):
 
     # Xyce is built against an older version of Trilinos unlikely to be
     # used for any other purpose.
-    depends_on('trilinos@12.12.1 +amesos+amesos2+anasazi+aztec+belos+complex+epetra+epetraext+explicit_template_instantiation+fortran+hdf5+ifpack+isorropia+kokkos+nox+sacado+suite-sparse-dist+teuchos+trilinoscouplings+zoltan+stokhos+amesos2basker+epetraextbtf+epetraextexperimental+epetraextgraphreordering gotype=all')
+    depends_on('trilinos@12.12.1 +amesos+amesos2+anasazi+aztec+belos+complex+epetra+epetraext+explicit_template_instantiation+fortran+hdf5+ifpack+isorropia+kokkos+nox+sacado+suite-sparse+teuchos+trilinoscouplings+zoltan+stokhos+amesos2basker+epetraextbtf+epetraextexperimental+epetraextgraphreorderings gotype=all')
 
     # MPI options must be consistent with Trilinos
     depends_on('trilinos~mpi', when='~mpi')
@@ -55,7 +55,7 @@ class Xyce(CMakePackage):
     # applications, namely xSDK, deal.ii, and DTK. Future changes to the
     # Trilinos recipe will disable all packages by default. At that
     # point, these ~variants can be removed from the following recipes.
-    depends_on('trilinos~adios2~alloptpkgs~boost~cgns~chaco~cuda~cuda_rdc~debug~dtk~exodus~float~glm~gtest~hwloc~hypre~ifpack2~intrepid~intrepid2~ipo~matio~mesquite~metis~minitensor~ml~muelu~mumps~netcdf~openmp~phalanx~piro~pnetcdf~python~rol~rythmos~shards~shared~shylu~stk~stratimikos~strumpack-sparse~superlu~superlu-dist~teko~tempus~wrapper~x11~xsdkflags~zlib~zoltan2')
+    depends_on('trilinos~adios2~alloptpkgs~boost~cgns~chaco~cuda~cuda_rdc~debug~dtk~exodus~float~glm~gtest~hwloc~hypre~ifpack2~intrepid~intrepid2~ipo~matio~mesquite~metis~minitensor~ml~muelu~mumps~netcdf~openmp~phalanx~piro~pnetcdf~python~rol~rythmos~shards~shared~shylu~stk~stratimikos~strumpack~superlu~superlu-dist~teko~tempus~wrapper~x11~xsdkflags~zlib~zoltan2')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -42,17 +42,20 @@ class Xyce(CMakePackage):
     depends_on('py-pybind11@2.6.1:', when='+pymi')
 
     # Xyce is built against an older version of Trilinos unlikely to be
-    # used for any other purpose. The default settings for various
-    # Trilinos variants would require the installation of many more
-    # packages than are needed for Xyce, hence the ~variant for many
-    # packages.
+    # used for any other purpose.
+    depends_on('trilinos@12.12.1 +amesos+amesos2+anasazi+aztec+belos+complex+epetra+epetraext+explicit_template_instantiation+fortran+hdf5+ifpack+isorropia+kokkos+nox+sacado+suite-sparse-dist+teuchos+trilinoscouplings+zoltan+stokhos+amesos2basker+epetraextbtf+epetraextexperimental+epetraextgraphreordering gotype=all')
+
+    # MPI options must be consistent with Trilinos
+    depends_on('trilinos~mpi', when='~mpi')
+    depends_on('trilinos+mpi', when='+mpi')
+
+    # The default settings for various Trilinos variants would require the
+    # installation of many more packages than are needed for Xyce.
     # The default variants in Trilinos have been set for several
     # applications, namely xSDK, deal.ii, and DTK. Future changes to the
     # Trilinos recipe will disable all packages by default. At that
     # point, these ~variants can be removed from the following recipes.
-
-    depends_on('trilinos@12.12.1~adios2~alloptpkgs+amesos+amesos2+anasazi+aztec+belos~boost~cgns~chaco+complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~exodus+explicit_template_instantiation~float+fortran~glm~gtest+hdf5~hwloc~hypre+ifpack~ifpack2~intrepid~intrepid2~ipo+isorropia+kokkos~matio~mesquite~metis~minitensor~ml+mpi~muelu~mumps~netcdf+nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~shards~shared~shylu~stk~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra+trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan~zoltan2+stokhos+amesos2basker+epetraextbtf+epetraextexperimental+epetraextgraphreorderings gotype=\'none\'', when="+mpi")
-    depends_on('trilinos@12.12.1~adios2~alloptpkgs+amesos+amesos2+anasazi+aztec+belos~boost~cgns~chaco+complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~exodus+explicit_template_instantiation~float+fortran~glm~gtest+hdf5~hwloc~hypre+ifpack~ifpack2~intrepid~intrepid2~ipo+isorropia+kokkos~matio~mesquite~metis~minitensor~ml~mpi~muelu~mumps~netcdf+nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~shards~shared~shylu~stk~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra+trilinoscouplings~wrapper~x11~xsdkflags~zlib+zoltan~zoltan2+stokhos+amesos2basker+epetraextbtf+epetraextexperimental+epetraextgraphreorderings gotype=\'none\'', when="~mpi")
+    depends_on('trilinos~adios2~alloptpkgs~boost~cgns~chaco~cuda~cuda_rdc~debug~dtk~exodus~float~glm~gtest~hwloc~hypre~ifpack2~intrepid~intrepid2~ipo~matio~mesquite~metis~minitensor~ml~muelu~mumps~netcdf~openmp~phalanx~piro~pnetcdf~python~rol~rythmos~shards~shared~shylu~stk~stratimikos~strumpack-sparse~superlu~superlu-dist~teko~tempus~wrapper~x11~xsdkflags~zlib~zoltan2')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
@kuberry This should fix the problem with the missing 'none' variant in https://github.com/spack/spack/pull/24565 .