### PR TITLE
Fix fetching for Python 3.9.6, 3.8.11

### DIFF
--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -154,7 +154,7 @@ def join(base_url, path, *extra, **kwargs):
     scheme = None
     for i in range(n - 1, -1, -1):
         obj = urllib_parse.urlparse(
-            paths[i], scheme=None, allow_fragments=False)
+            paths[i], scheme='', allow_fragments=False)
 
         scheme = obj.scheme
 

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -151,7 +151,7 @@ def join(base_url, path, *extra, **kwargs):
         for x in itertools.chain((base_url, path), extra)]
     n = len(paths)
     last_abs_component = None
-    scheme = None
+    scheme = ''
     for i in range(n - 1, -1, -1):
         obj = urllib_parse.urlparse(
             paths[i], scheme='', allow_fragments=False)
@@ -159,13 +159,13 @@ def join(base_url, path, *extra, **kwargs):
         scheme = obj.scheme
 
         # in either case the component is absolute
-        if scheme is not None or obj.path.startswith('/'):
-            if scheme is None:
+        if scheme or obj.path.startswith('/'):
+            if not scheme:
                 # Without a scheme, we have to go back looking for the
                 # next-last component that specifies a scheme.
                 for j in range(i - 1, -1, -1):
                     obj = urllib_parse.urlparse(
-                        paths[j], scheme=None, allow_fragments=False)
+                        paths[j], scheme='', allow_fragments=False)
 
                     if obj.scheme:
                         paths[i] = '{SM}://{NL}{PATH}'.format(

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -11,8 +11,8 @@ import itertools
 import os.path
 import re
 
-from six import string_types
 import six.moves.urllib.parse as urllib_parse
+from six import string_types
 
 import spack.util.path
 


### PR DESCRIPTION
When using Python 3.9.6, Spack is no longer able to fetch anything. Commands like `spack fetch` and `spack install` all break.

Python 3.9.6 includes a [new change](https://github.com/python/cpython/pull/25853/files#diff-b3712475a413ec972134c0260c8f1eb1deefb66184f740ef00c37b4487ef873eR462) that means that `scheme` must be a string, it cannot be None. The solution is to use an empty string like the method default.

Fixes #24644. Also see https://github.com/Homebrew/homebrew-core/pull/80175 where this issue was discovered by CI. Thanks @branchvincent for reporting such a serious issue before any actual users encountered it!