### PR TITLE
bugfix: `spack config edit` should work in a bad environment

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -170,12 +170,19 @@ def config_edit(args):
     With no arguments and an active environment, edit the spack.yaml for
     the active environment.
     """
-    scope, section = _get_scope_and_section(args)
-    if not scope and not section:
-        tty.die('`spack config edit` requires a section argument '
-                'or an active environment.')
+    spack_env = os.environ.get(ev.spack_env_var)
+    if spack_env and not args.scope:
+        # Don't use the scope object for envs, as `config edit` can be called
+        # for a malformed environment. Use SPACK_ENV to find spack.yaml.
+        config_file = ev.manifest_file(spack_env)
+    else:
+        # If we aren't editing a spack.yaml file, get config path from scope.
+        scope, section = _get_scope_and_section(args)
+        if not scope and not section:
+            tty.die('`spack config edit` requires a section argument '
+                    'or an active environment.')
+        config_file = spack.config.config.get_config_filename(scope, section)
 
-    config_file = spack.config.config.get_config_filename(scope, section)
     if args.print_file:
         print(config_file)
     else:

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -143,16 +143,16 @@ def config_get(args):
     """
     scope, section = _get_scope_and_section(args)
 
-    if scope and scope.startswith('env:'):
+    if section is not None:
+        spack.config.config.print_section(section)
+
+    elif scope and scope.startswith('env:'):
         config_file = spack.config.config.get_config_filename(scope, section)
         if os.path.exists(config_file):
             with open(config_file) as f:
                 print(f.read())
         else:
             tty.die('environment has no %s file' % ev.manifest_name)
-
-    elif section is not None:
-        spack.config.config.print_section(section)
 
     else:
         tty.die('`spack config get` requires a section argument '

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -741,6 +741,14 @@ def _main(argv=None):
             the executable name. If None, parses from sys.argv.
 
     """
+    # ------------------------------------------------------------------------
+    # main() is tricky to get right, so be careful where you put things.
+    #
+    # Things in this first part of `main()` should *not* require any
+    # configuration. This doesn't include much -- setting up th parser,
+    # restoring some key environment variables, very simple CLI options, etc.
+    # ------------------------------------------------------------------------
+
     # Create a parser with a simple positional argument first.  We'll
     # lazily load the subcommand(s) we need later. This allows us to
     # avoid loading all the modules from spack.cmd when we don't need
@@ -763,20 +771,6 @@ def _main(argv=None):
         if stored_var_name in os.environ:
             os.environ[var] = os.environ[stored_var_name]
 
-    # make spack.config aware of any command line configuration scopes
-    if args.config_scopes:
-        spack.config.command_line_scopes = args.config_scopes
-
-    # activate an environment if one was specified on the command line
-    if not args.no_env:
-        env = spack.cmd.find_environment(args)
-        if env:
-            ev.activate(env, args.use_env_repo)
-
-    if args.print_shell_vars:
-        print_setup_info(*args.print_shell_vars.split(','))
-        return 0
-
     # Just print help and exit if run with no arguments at all
     no_args = (len(sys.argv) == 1) if argv is None else (len(argv) == 0)
     if no_args:
@@ -791,12 +785,39 @@ def _main(argv=None):
     elif args.help:
         sys.stdout.write(parser.format_help(level=args.help))
         return 0
-    elif not args.command:
-        parser.print_help()
-        return 1
+
+    # ------------------------------------------------------------------------
+    # This part of the `main()` sets up Spack's configuration.
+    #
+    # We set command line options (like --debug), then command line config
+    # scopes, then environment configuration here.
+    # ------------------------------------------------------------------------
 
     # ensure options on spack command come before everything
     setup_main_options(args)
+
+    # make spack.config aware of any command line configuration scopes
+    if args.config_scopes:
+        spack.config.command_line_scopes = args.config_scopes
+
+    # activate an environment if one was specified on the command line
+    if not args.no_env:
+        env = spack.cmd.find_environment(args)
+        if env:
+            ev.activate(env, args.use_env_repo)
+
+    # ------------------------------------------------------------------------
+    # Things that require configuration should go below here
+    # ------------------------------------------------------------------------
+    if args.print_shell_vars:
+        print_setup_info(*args.print_shell_vars.split(','))
+        return 0
+
+    # At this point we've considered all the options to spack itself, so we
+    # need a command or we're done.
+    if not args.command:
+        parser.print_help()
+        return 1
 
     # Try to load the particular command the caller asked for.
     cmd_name = args.command[0]

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -738,7 +738,7 @@ def _main(argv=None):
 
     Args:
         argv (list or None): command line arguments, NOT including
-            the executable name. If None, parses from sys.argv.
+            the executable name. If None, parses from ``sys.argv``.
 
     """
     # ------------------------------------------------------------------------
@@ -801,10 +801,17 @@ def _main(argv=None):
         spack.config.command_line_scopes = args.config_scopes
 
     # activate an environment if one was specified on the command line
+    env_format_error = None
     if not args.no_env:
-        env = spack.cmd.find_environment(args)
-        if env:
-            ev.activate(env, args.use_env_repo)
+        try:
+            env = spack.cmd.find_environment(args)
+            if env:
+                ev.activate(env, args.use_env_repo)
+        except spack.config.ConfigFormatError as e:
+            # print the context but delay this exception so that commands like
+            # `spack config edit` can still work with a bad environment.
+            e.print_context()
+            env_format_error = e
 
     # ------------------------------------------------------------------------
     # Things that require configuration should go below here
@@ -827,6 +834,13 @@ def _main(argv=None):
 
     # Re-parse with the proper sub-parser added.
     args, unknown = parser.parse_known_args()
+
+    # Now that we know what command this is and what its args are, determine
+    # whether we can continue with a bad environment and raise if not.
+    if env_format_error:
+        subcommand = getattr(args, "config_command", None)
+        if (cmd_name, subcommand) != ("config", "edit"):
+            raise env_format_error
 
     # many operations will fail without a working directory.
     set_working_dir()
@@ -852,7 +866,7 @@ def main(argv=None):
     The logic is all in ``_main()``.
 
     Args:
-        argv (list of str or None): command line arguments, NOT including
+        argv (list or None): command line arguments, NOT including
             the executable name. If None, parses from sys.argv.
 
     """

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -725,12 +725,21 @@ def print_setup_info(*info):
             shell_set('_sp_module_prefix', 'not_installed')
 
 
-def main(argv=None):
-    """This is the entry point for the Spack command.
+def _main(argv=None):
+    """Logic for the main entry point for the Spack command.
+
+    ``main()`` calls ``_main()`` and catches any errors that emerge.
+
+    ``_main()`` handles:
+
+    1. Parsing arguments;
+    2. Setting up configuration; and
+    3. Finding and executing a Spack command.
 
     Args:
         argv (list or None): command line arguments, NOT including
             the executable name. If None, parses from sys.argv.
+
     """
     # Create a parser with a simple positional argument first.  We'll
     # lazily load the subcommand(s) we need later. This allows us to
@@ -786,32 +795,48 @@ def main(argv=None):
         parser.print_help()
         return 1
 
+    # ensure options on spack command come before everything
+    setup_main_options(args)
+
+    # Try to load the particular command the caller asked for.
+    cmd_name = args.command[0]
+    cmd_name = aliases.get(cmd_name, cmd_name)
+
+    command = parser.add_command(cmd_name)
+
+    # Re-parse with the proper sub-parser added.
+    args, unknown = parser.parse_known_args()
+
+    # many operations will fail without a working directory.
+    set_working_dir()
+
+    # now we can actually execute the command.
+    if args.spack_profile or args.sorted_profile:
+        _profile_wrapper(command, parser, args, unknown)
+    elif args.pdb:
+        import pdb
+        pdb.runctx('_invoke_command(command, parser, args, unknown)',
+                   globals(), locals())
+        return 0
+    else:
+        return _invoke_command(command, parser, args, unknown)
+
+
+def main(argv=None):
+    """This is the entry point for the Spack command.
+
+    ``main()`` itself is just an error handler -- it handles errors for
+    everything in Spack that makes it to the top level.
+
+    The logic is all in ``_main()``.
+
+    Args:
+        argv (list of str or None): command line arguments, NOT including
+            the executable name. If None, parses from sys.argv.
+
+    """
     try:
-        # ensure options on spack command come before everything
-        setup_main_options(args)
-
-        # Try to load the particular command the caller asked for.
-        cmd_name = args.command[0]
-        cmd_name = aliases.get(cmd_name, cmd_name)
-
-        command = parser.add_command(cmd_name)
-
-        # Re-parse with the proper sub-parser added.
-        args, unknown = parser.parse_known_args()
-
-        # many operations will fail without a working directory.
-        set_working_dir()
-
-        # now we can actually execute the command.
-        if args.spack_profile or args.sorted_profile:
-            _profile_wrapper(command, parser, args, unknown)
-        elif args.pdb:
-            import pdb
-            pdb.runctx('_invoke_command(command, parser, args, unknown)',
-                       globals(), locals())
-            return 0
-        else:
-            return _invoke_command(command, parser, args, unknown)
+        _main(argv)
 
     except SpackError as e:
         tty.debug(e)

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -49,6 +49,8 @@ fi
 
 $coverage_run $(which spack) unit-test -x --verbose
 
+bash "$QA_DIR/test-env-cfg.sh"
+
 # Delete the symlink going from ./lib/spack/docs/_spack_root back to
 # the initial directory, since it causes ELOOP errors with codecov/actions@2
 if [[ "$COVERAGE" == "true" ]]; then

--- a/share/spack/qa/test-env-cfg.sh
+++ b/share/spack/qa/test-env-cfg.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#
+# This script ensures that Spack can help users edit an environment's
+# manifest file even when it has invalid configuration.
+#
+
+export QA_DIR=$(dirname "$0")
+export SHARE_DIR=$(cd "$QA_DIR/.." && pwd)
+
+# Include convenience functions
+. "$QA_DIR/test-framework.sh"
+. "$QA_DIR/setup.sh"
+
+# Source setup-env.sh before tests
+. "$SHARE_DIR/setup-env.sh"
+
+env_cfg=""
+
+function cleanup {
+  # Regardless of whether the test fails or succeeds, we can't remove the
+  # environment without restoring spack.yaml to match the schema
+  if [ ! -z "env_cfg" ]; then
+    echo "\
+spack:
+  specs: []
+  view: False
+" > "$env_cfg"
+  fi
+
+  spack env deactivate
+  spack env rm -y broken-cfg-env
+}
+
+trap cleanup EXIT
+
+spack env create broken-cfg-env
+echo "Activating test environment"
+spack env activate broken-cfg-env
+env_cfg=`spack config --scope=env:broken-cfg-env edit --print-file`
+# Save this, so we can make sure it is reported correctly when the environment
+# contains broken configuration
+orig_manifest_path="$env_cfg"
+
+echo "Environment config file: $env_cfg"
+# Make sure we got a manifest file path
+contains "spack.yaml" echo "$env_cfg"
+
+# Create an invalid packages.yaml configuration for the environment
+echo "\
+spack:
+  specs: []
+  view: False
+  packages:
+    what:
+" > "$env_cfg"
+
+echo "Try 'spack config edit' with broken environment"
+manifest_path=`spack config edit --print-file`
+# Re-run command for coverage purposes
+$coverage_run $(which spack) config edit --print-file
+
+if [ $orig_manifest_path = $manifest_path ]; then
+  pass
+else
+  fail
+fi
+


### PR DESCRIPTION
Fixes #2468. (this may have been fixed already but it's related)

This PR fixes a number of bugs (one per commit -- this should be rebased not squashed) to get to the main one:

1. `spack --debug` wasn't in the right place and wouldn't take effect for things at the beginning of `main()`.
2. Config errors had gotten really verbose -- they print a full stack trace and don't just show the user where the error is like they used to.
3. `spack config get <section>` and `spack config --scope <scope> edit <section>` weren't working in environments. `spack config get <section>`  should return the combined configuration for that section (including anything from `spack.yaml`), even in an environment, and `spack config edit` should respect the scope argument.
4. If you don't format `spack.yaml` correctly, `spack config edit` still fails and you have to edit your `spack.yaml` manually. Spack should be smarter than this.

- [x] Rework `_main()` and add some notes for maintainers on where things need to go for configuration to work properly.
- [x] Move config setup to *after* command-line parsing is done.
- [x] Add some code to `_main()` to defer `ConfigFormatError` when loading the environment, until we know what command is being run.  
- [x] Make `spack config edit` use `SPACK_ENV` instead of the config scope object to find `spack.yaml`, so it can work even if the environment is bad.
- [x] Reorder conditions in `cmd/config.py` to fix environment issues.
- [x] Tests