### PR TITLE
installer: fix double printing of exception

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1618,6 +1618,7 @@ class PackageInstaller(object):
                 # package as a failure.
                 if (not isinstance(exc, spack.error.SpackError) or
                     not exc.printed):
+                    exc.printed = True
                     # SpackErrors can be printed by the build process or at
                     # lower levels -- skip printing if already printed.
                     # TODO: sort out this and SpackError.print_context()


### PR DESCRIPTION
Don't double print exceptions raised during install.

**Without PR**
```
# No GPG keys trusted
$> spack install --cache-only zlib
==> Installing zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6
==> Fetching file:///Users/walker/go/src/github.com/eugeneswalker/cache-manager/cache-resigner/build_cache/darwin-catalina-cannonlake/apple-clang-11.0.3/zlib-1.2.3/darwin-catalina-cannonlake-apple-clang-11.0.3-zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6.spack
==> Extracting zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6 from binary cache
gpg: WARNING: unsafe permissions on homedir '/Users/walker/.gnupg'
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
==> Error: Failed to install zlib due to ProcessError: Command exited with status 2:
    '/usr/local/bin/gpg' '--verify' '/var/folders/9v/y92nf36513l__z5rtnm_g4q00000gn/T/tmpsuvv11uy/darwin-catalina-cannonlake-apple-clang-11.0.3-zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6.spec.yaml.asc' '/var/folders/9v/y92nf36513l__z5rtnm_g4q00000gn/T/tmpsuvv11uy/darwin-catalina-cannonlake-apple-clang-11.0.3-zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6.spec.yaml'
gpg: keybox '/Users/walker/spack/opt/spack/gpg/pubring.kbx' created
gpg: Signature made Sun Jul  4 14:20:38 2021 PDT
gpg:                using RSA key 7D344E2992071B0AAAE1EDB0E68DE2A80314303D
gpg: Can't check signature: No public key

==> Error: Command exited with status 2:
'/usr/local/bin/gpg' '--verify' '/var/folders/9v/y92nf36513l__z5rtnm_g4q00000gn/T/tmpsuvv11uy/darwin-catalina-cannonlake-apple-clang-11.0.3-zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6.spec.yaml.asc' '/var/folders/9v/y92nf36513l__z5rtnm_g4q00000gn/T/tmpsuvv11uy/darwin-catalina-cannonlake-apple-clang-11.0.3-zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6.spec.yaml'
gpg: keybox '/Users/walker/spack/opt/spack/gpg/pubring.kbx' created
gpg: Signature made Sun Jul  4 14:20:38 2021 PDT
gpg:                using RSA key 7D344E2992071B0AAAE1EDB0E68DE2A80314303D
gpg: Can't check signature: No public key
```

**With PR**
```
# No GPG keys trusted
$> spack install --cache-only zlib
==> Installing zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6
==> Extracting zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6 from binary cache
gpg: WARNING: unsafe permissions on homedir '/Users/walker/.gnupg'
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
==> Error: Failed to install zlib due to ProcessError: Command exited with status 2:
    '/usr/local/bin/gpg' '--verify' '/var/folders/9v/y92nf36513l__z5rtnm_g4q00000gn/T/tmp_e3d9m3x/darwin-catalina-cannonlake-apple-clang-11.0.3-zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6.spec.yaml.asc' '/var/folders/9v/y92nf36513l__z5rtnm_g4q00000gn/T/tmp_e3d9m3x/darwin-catalina-cannonlake-apple-clang-11.0.3-zlib-1.2.3-ry6cgr4nxbtapbqdhorsy2vl4yvt4sw6.spec.yaml'
gpg: Signature made Sun Jul  4 14:20:38 2021 PDT
gpg:                using RSA key 7D344E2992071B0AAAE1EDB0E68DE2A80314303D
gpg: Can't check signature: No public key
```

@tldahlgren 