### PR TITLE
buildcache create: gpg: require user-specified keys to be unambiguous, fail otherwise

### DIFF
--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -119,12 +119,14 @@ def gpg_create(args):
     """create a new key"""
     if args.export or args.secret:
         old_sec_keys = spack.util.gpg.signing_keys()
+        old_sec_keys = [k.fingerprint for k in old_sec_keys]
 
     # Create the new key
     spack.util.gpg.create(name=args.name, email=args.email,
                           comment=args.comment, expires=args.expires)
     if args.export or args.secret:
-        new_sec_keys = set(spack.util.gpg.signing_keys())
+        _keys = spack.util.gpg.signing_keys()
+        new_sec_keys = set([k.fingerprint for k in _keys])
         new_keys = new_sec_keys.difference(old_sec_keys)
 
     if args.export:
@@ -138,6 +140,7 @@ def gpg_export(args):
     keys = args.keys
     if not keys:
         keys = spack.util.gpg.signing_keys()
+        keys = [k.fingerprint for k in keys]
     spack.util.gpg.export_keys(args.location, keys, args.secret)
 
 
@@ -151,6 +154,7 @@ def gpg_sign(args):
     key = args.key
     if key is None:
         keys = spack.util.gpg.signing_keys()
+        keys = [k.fingerprint for k in keys]
         if len(keys) == 1:
             key = keys[0]
         elif not keys:

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -8,7 +8,6 @@ import os
 import pytest
 
 import llnl.util.filesystem as fs
-
 import spack.util.executable
 import spack.util.gpg
 from spack.main import SpackCommand
@@ -88,12 +87,14 @@ def test_gpg(tmpdir, mock_gnupghome):
 
     # Create a key for use in the tests.
     keypath = tmpdir.join('testing-1.key')
+
     gpg('create',
         '--comment', 'Spack testing key',
         '--export', str(keypath),
         'Spack testing 1',
         'spack@googlegroups.com')
-    keyfp = spack.util.gpg.signing_keys()[0]
+
+    keyfp = spack.util.gpg.signing_keys()[0].fingerprint
 
     # List the keys.
     # TODO: Test the output here.

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -30,8 +30,8 @@ ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
     keys = spack.util.gpg._parse_secret_keys_output(output)
 
     assert len(keys) == 2
-    assert keys[0] == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-    assert keys[1] == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
+    assert keys[0].fingerprint == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    assert keys[1].fingerprint == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
 
 
 def test_parse_gpg_output_case_two():
@@ -47,7 +47,7 @@ grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
     keys = spack.util.gpg._parse_secret_keys_output(output)
 
     assert len(keys) == 1
-    assert keys[0] == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    assert keys[0].fingerprint == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 
 
 def test_parse_gpg_output_case_three():
@@ -66,8 +66,8 @@ fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
     keys = spack.util.gpg._parse_secret_keys_output(output)
 
     assert len(keys) == 2
-    assert keys[0] == 'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW'
-    assert keys[1] == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
+    assert keys[0].fingerprint == 'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW'
+    assert keys[1].fingerprint == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
 
 
 @pytest.mark.requires_executables('gpg2')


### PR DESCRIPTION
Spack will currently proceed with `spack buildcache create --key <ID> ...` even when `<ID>` is ambiguous. It will select one of the two matching keys and go foward.

This PR makes requires a user-specified key to be unambiguous and will fail if that isn't the case.

**Pre-PR behavior**
```
$> spack gpg list --signing
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
/Users/walker/spack/opt/spack/gpg/pubring.kbx
---------------------------------------------
pub   ed25519 2021-07-02 [SC] [expires: 2023-07-02]
      E71A44702F3735330EEA83A29281F0C65F2225C8
uid           [ unknown] prl
sub   cv25519 2021-07-02 [E]

pub   ed25519 2021-07-02 [SC] [expires: 2023-07-02]
      0AF82F37CFF43EDA39E134EB1ED1F82618DA13C6
uid           [ unknown] prl
sub   cv25519 2021-07-02 [E]

/Users/walker/spack/opt/spack/gpg/pubring.kbx
---------------------------------------------
sec   ed25519 2021-07-02 [SC] [expires: 2023-07-02]
      E71A44702F3735330EEA83A29281F0C65F2225C8
uid           [ unknown] prl
ssb   cv25519 2021-07-02 [E]

sec   ed25519 2021-07-02 [SC] [expires: 2023-07-02]
      0AF82F37CFF43EDA39E134EB1ED1F82618DA13C6
uid           [ unknown] prl
ssb   cv25519 2021-07-02 [E]


$> spack buildcache create -af -d . --key prl zlib
==> Buildcache files will be output to ...
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
gpg: using "prl" as default secret key for signing
```

**Post-PR behavior**
```
$> spack gpg list --signing
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
/Users/walker/spack/opt/spack/gpg/pubring.kbx
---------------------------------------------
pub   ed25519 2021-07-02 [SC] [expires: 2023-07-02]
      E71A44702F3735330EEA83A29281F0C65F2225C8
uid           [ unknown] prl
sub   cv25519 2021-07-02 [E]

pub   ed25519 2021-07-02 [SC] [expires: 2023-07-02]
      0AF82F37CFF43EDA39E134EB1ED1F82618DA13C6
uid           [ unknown] prl
sub   cv25519 2021-07-02 [E]

/Users/walker/spack/opt/spack/gpg/pubring.kbx
---------------------------------------------
sec   ed25519 2021-07-02 [SC] [expires: 2023-07-02]
      E71A44702F3735330EEA83A29281F0C65F2225C8
uid           [ unknown] prl
ssb   cv25519 2021-07-02 [E]

sec   ed25519 2021-07-02 [SC] [expires: 2023-07-02]
      0AF82F37CFF43EDA39E134EB1ED1F82618DA13C6
uid           [ unknown] prl
ssb   cv25519 2021-07-02 [E]


$> spack buildcache create -af -d . --key prl zlib
==> Buildcache files will be output to ...
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
==> Error: Multiple keys available for signing
---
1.  User ID: prl
    Fingerprint: 701B8145CE0B3F10E8607AB08B6375B19D94B27F

2.  User ID: prl
    Fingerprint: 6DC00513AE82C7E152F976170E2DD6534CE14084
---
Specify your key choice unambiguously using `--key <ID>`. <ID> can be the fingerprint or user-id.

$> spack buildcache create -af -d . --key 6DC00513AE82C7E152F976170E2DD6534CE14084 zlib
==> Buildcache files will be output to ...
gpgconf: socketdir is '/Users/walker/.gnupg'
gpgconf: 	no /run/user dir
gpgconf: 	using homedir as fallback
gpg: using "6DC00513AE82C7E152F976170E2DD6534CE14084" as default secret key for signing
```

@alalazo 