### PR TITLE
pinentry: add gui multi-valued variant

### DIFF
--- a/var/spack/repos/builtin/packages/pinentry/package.py
+++ b/var/spack/repos/builtin/packages/pinentry/package.py
@@ -20,27 +20,35 @@ class Pinentry(AutotoolsPackage):
     version('1.1.1', sha256='cd12a064013ed18e2ee8475e669b9f58db1b225a0144debdb85a68cecddba57f')
     version('1.1.0', sha256='68076686fa724a290ea49cdf0d1c0c1500907d1b759a3bcbfbec0293e8f56570')
 
+    supported_guis = [
+        'curses', 'tty', 'emacs', 'efl', 'gtk2', 'gnome3', 'qt', 'qt5', 'tqt', 'fltk'
+    ]
+
+    # Default to 'tty' as it has no additional dependencies
+    variant('gui', default='tty', description='GUI to use for passphrase entry',
+            values=supported_guis, multi=True)
+
     depends_on('libgpg-error@1.16:')
     depends_on('libassuan@2.1.0:')
 
+    # Optional GUI dependencies
+    depends_on('ncurses', when='gui=curses')
+    depends_on('emacs', when='gui=emacs')
+    # depends_on('efl@1.18:', when='gui=efl')  # Enlightenment
+    depends_on('gtkplus@2:', when='gui=gtk2')
+    # depends_on('gnome@3:', when='gui=gnome3')  # GNOME
+    depends_on('qt@4.4.0:', when='gui=qt')
+    depends_on('qt@5.0:5.999', when='gui=qt5')
+    # depends_on('tqt', when='gui=tqt')  # Trinity QT
+    depends_on('fltk@1.3:', when='gui=fltk')
+
+    # TODO: add packages for these optional GUIs
+    conflicts('gui=efl')
+    conflicts('gui=gnome3')
+    conflicts('gui=tqt')
+
     def configure_args(self):
-        return [
-            '--enable-static',
-            '--enable-shared',
-            # Autotools automatically enables these if dependencies found
-            # TODO: add variants for these
-            '--disable-pinentry-curses',
-            '--disable-pinentry-emacs',
-            '--disable-pinentry-gtk2',
-            '--disable-pinentry-gnome3',
-            '--disable-pinentry-qt',
-            '--disable-pinentry-qt5',
-            '--disable-pinentry-tqt',
-            '--disable-pinentry-fltk',
-
-            # No dependencies, simplest installation
-            '--enable-pinentry-tty',
-
+        args = [
             # Disable extra features
             '--disable-fallback-curses',
             '--disable-inside-emacs',
@@ -50,3 +58,27 @@ class Pinentry(AutotoolsPackage):
             '--with-gpg-error-prefix=' + self.spec['libgpg-error'].prefix,
             '--with-libassuan-prefix=' + self.spec['libassuan'].prefix,
         ]
+
+        if 'gui=curses' in self.spec:
+            args.append('--with-ncurses-include-dir=' +
+                        self.spec['ncurses'].headers.directories[0])
+
+        for gui in self.supported_guis:
+            if 'gui=' + gui in self.spec:
+                args.append('--enable-pinentry-' + gui)
+            else:
+                args.append('--disable-pinentry-' + gui)
+
+        return args
+
+    def test(self):
+        kwargs = {
+            'exe': self.prefix.bin.pinentry,
+            'options': ['--version'],
+            'expected': [str(self.version)],
+        }
+        self.run_test(**kwargs)
+        for gui in self.supported_guis:
+            if 'gui=' + gui in self.spec:
+                kwargs['exe'] = self.prefix.bin.pinentry + '-' + gui
+                self.run_test(**kwargs)


### PR DESCRIPTION
This PR includes the following changes:

- [x] Add a `gui` multi-valued variant to select passphrase entry backends to build
- [x] Remove `--enable-shared` and `--enable-static` (non-existing options)
- [x] Add smoke tests

When I build `gui=tty,curses`, it decides to make `curses` the default backend. I'm not sure if there is any way to control this or not. On the `gpg` side of things, I can set my own default in `~/.gnupg/gpg-agent.conf`, but I don't know how you would do that in the `gnupg` package. I guess we could make the variant not-multi-valued and set the path explicitly, or add another variant for `default_gui`, but that seems complicated.