### PR TITLE
trilinos: enable +teko gotype=long

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -303,11 +303,13 @@ class Trilinos(CMakePackage, CudaPackage):
     conflicts('+teko', when='~amesos')
     conflicts('+teko', when='~anasazi')
     conflicts('+teko', when='~aztec')
+    conflicts('+teko', when='~epetraext')
     conflicts('+teko', when='~ifpack')
     conflicts('+teko', when='~ml')
+    conflicts('+teko', when='~stratimikos')
     conflicts('+teko', when='~teuchos')
     conflicts('+teko', when='~tpetra')
-    conflicts('+teko', when='gotype=long')
+    conflicts('+teko', when='@:12 gotype=long')
     conflicts('+tempus', when='~nox')
     conflicts('+tempus', when='~teuchos')
     conflicts('+tpetra', when='~kokkos')
@@ -458,6 +460,10 @@ class Trilinos(CMakePackage, CudaPackage):
     # workaround an NVCC bug with c++14 (https://github.com/trilinos/Trilinos/issues/6954)
     # avoid calling deprecated functions with CUDA-11
     patch('fix_cxx14_cuda11.patch', when='@13.0.0:13.0.1 cxxstd=14 ^cuda@11:')
+
+    patch('https://github.com/trilinos/Trilinos/commit/b17f20a0b91e0b9fc5b1b0af3c8a34e2a4874f3f.patch',
+          sha256='dee6c55fe38eb7f6367e1896d6bc7483f6f9ab8fa252503050cc0c68c6340610',
+          when='@13.0.0:13.0.1 +teko gotype=long')
 
     def url_for_version(self, version):
         url = "https://github.com/trilinos/Trilinos/archive/trilinos-release-{0}.tar.gz"


### PR DESCRIPTION
This applies the patch that @keitat kindly linked to on #24565 so that https://github.com/E4S-Project/e4s/pull/10 will build correctly with `gotype=long`.

It also adds necessary `conflicts` to get a minimal `trilinos+teko` to build.

I successfully compiled:
```
trilinos@13.0.1%gcc@10.2.0~adios2~alloptpkgs+amesos~amesos2~amesos2basker+anasazi+aztec~belos~boost~cgns~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings~exodus~explicit_template_instantiation~float~fortran~glm~gtest~hdf5~hwloc~hypre+ifpack~ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos~matio~mesquite~metis~minitensor+ml~mpi~muelu~mumps~netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos~sacado~scorec~shards+shared~shylu~stk~stokhos+stratimikos~strumpack~suite-sparse~superlu~superlu-dist+teko~tempus+teuchos+tpetra~trilinoscouplings~wrapper~x11~xsdkflags~zlib~zoltan~zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long patches=dee6c55fe38eb7f6367e1896d6bc7483f6f9ab8fa252503050cc0c68c6340610 arch=linux-rhel7-haswell/6fxyb6h
```