### PR TITLE
Archer: Add E4S testsuite stand alone test

### DIFF
--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -5,6 +5,7 @@
 
 
 import os
+
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -35,3 +35,9 @@ class Archer(CMakePackage):
             '-DCMAKE_CXX_COMPILER=clang++',
             '-DOMP_PREFIX:PATH=%s' % self.spec['llvm-openmp-ompt'].prefix,
         ]
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources('test')

--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -47,7 +47,7 @@ class Archer(CMakePackage):
     def run_parallel_example_test(self):
         """Run stand alone test: parallel-simple"""
 
-        test_dir = join_path(self.install_test_root, 'test', 'parallel')
+        test_dir = join_path(self.test_suite.current_test_cache_dir, 'test', 'parallel')
 
         if not os.path.exists(test_dir):
             print('Skipping archer test')

--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -15,6 +15,8 @@ class Archer(CMakePackage):
     homepage = "https://github.com/PRUNERS/ARCHER"
     url      = "https://github.com/PRUNERS/archer/archive/v1.0.0.tar.gz"
 
+    test_requires_compiler = True
+
     version('2.0.0', sha256='3241cadb0078403368b69166b27f815e12c350486d4ceb3fb33147895b9ebde8')
     version('1.0.0', sha256='df814a475606b83c659932caa30a68bed1c62e713386b375c1b78eb8d60e0d15')
 

--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -47,7 +47,7 @@ class Archer(CMakePackage):
     def run_parallel_example_test(self):
         """Run stand alone test: parallel-simple"""
 
-        test_dir = join_path(self.prefix, '.spack', 'test', 'test', 'parallel')
+        test_dir = join_path(self.install_test_root, 'test', 'parallel')
 
         if not os.path.exists(test_dir):
             print('Skipping archer test')

--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -35,3 +35,9 @@ class Archer(CMakePackage):
             '-DCMAKE_CXX_COMPILER=clang++',
             '-DOMP_PREFIX:PATH=%s' % self.spec['llvm-openmp-ompt'].prefix,
         ]
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources(['test'])

--- a/var/spack/repos/builtin/packages/archer/package.py
+++ b/var/spack/repos/builtin/packages/archer/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import os
 from spack import *
 
 
@@ -41,3 +42,27 @@ class Archer(CMakePackage):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(['test'])
+
+    def run_parallel_example_test(self):
+        """Run stand alone test: parallel-simple"""
+
+        test_dir = join_path(self.prefix, '.spack', 'test', 'test', 'parallel')
+
+        if not os.path.exists(test_dir):
+            print('Skipping archer test')
+            return
+
+        exe = 'parallel-simple'
+
+        self.run_test('clang-archer',
+                      options=['-o', exe,
+                               '{0}'.format(join_path(test_dir, 'parallel-simple.c'))],
+                      purpose='test: compile {0} example'.format(exe),
+                      work_dir=test_dir)
+
+        self.run_test(exe,
+                      purpose='test: run {0} example'.format(exe),
+                      work_dir=test_dir)
+
+    def test(self):
+        self.run_parallel_example_test()


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `archer` package and is intended to serve the following purposes:

1. Leverage the current E4S test suite for the software
2. Demonstrate to package maintainers how to start a Spack stand alone test.