### PR TITLE
only apply nvhpc.patch for version 1.4.18 for #24726

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -18,7 +18,7 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
 
     patch('gnulib-pgi.patch', when='@1.4.18')
     patch('pgi.patch', when='@1.4.17')
-    patch('nvhpc.patch', when='%nvhpc')
+    patch('nvhpc.patch', when='@1.4.18 %nvhpc')
     patch('oneapi.patch', when='@1.4.18 %oneapi')
     # from: https://github.com/Homebrew/homebrew-core/blob/master/Formula/m4.rb
     # Patch credit to Jeremy Huddleston Sequoia <jeremyhu@apple.com>


### PR DESCRIPTION
addresses patch failure for nvhpc in #24726