### PR TITLE
ParaView: Add cli11 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -142,6 +142,10 @@ class Paraview(CMakePackage, CudaPackage):
     # Can't contretize with python2 and py-pillow@7.0.0:
     depends_on('pil@:6', when='+python')
 
+    # ParaView depends on cli11 due to changes in MR
+    # https://gitlab.kitware.com/paraview/paraview/-/merge_requests/4951
+    depends_on('cli11@1.9.1', when='@5.10:')
+
     patch('stl-reader-pv440.patch', when='@4.4.0')
 
     # Broken gcc-detection - improved in 5.1.0, redundant later


### PR DESCRIPTION
@chuckatkins @danlipsa @vicentebolea 

This adds `cli11` as a paraview dependency. Targetting `5.10`  and up which does work with `paraview@master`. Solves issue on ParaView gitlab [here](https://gitlab.kitware.com/paraview/paraview/-/issues/20827) . Tested on centos7 with paraview@master.