### PR TITLE
ci: add e4s-on-power pipeline

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -124,3 +124,37 @@ e4s-develop-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: e4s-develop-generate
     strategy: depend
+
+
+########################################
+# E4S on Power
+########################################
+.power-e4s-generate-tags-and-image:
+  image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-ppc64le:2021-07-01", "entrypoint": [""] }
+  tags: ["spack", "public", "medium", "ppc64le"]
+
+.e4s-on-power:
+  variables:
+    SPACK_CI_STACK_NAME: e4s-on-power
+
+e4s-on-power-pr-generate:
+  extends: [ ".e4s-on-power", ".pr-generate", ".power-e4s-generate-tags-and-image"]
+
+e4s-on-power-develop-generate:
+  extends: [ ".e4s-on-power", ".develop-generate", ".power-e4s-generate-tags-and-image"]
+
+e4s-on-power-pr-build:
+  extends: [ ".e4s-on-power", ".pr-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: e4s-on-power-pr-generate
+    strategy: depend
+
+e4s-on-power-develop-build:
+  extends: [ ".e4s-on-power", ".develop-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: e4s-on-power-develop-generate
+    strategy: depend

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -1,0 +1,372 @@
+spack:
+  view: false
+  concretization: separately
+
+  config:
+    install_tree:
+      root: /home/software/spack
+      padded_length: 512
+      projections:
+        all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
+
+  packages:
+    all:
+      compiler:
+        - gcc@9.3.0
+      providers:
+        blas:
+          - openblas
+        mpi:
+          - mpich
+      target:
+        - ppc64le
+      variants: +mpi
+    autoconf:
+      version:
+      - '2.69'
+    automake:
+      version:
+      - 1.16.3
+    berkeley-db:
+      version:
+      - 18.1.40
+    binutils:
+      variants: +ld +gold +headers +libiberty ~nls +plugins
+      version:
+      - 2.36.1
+    boost:
+      version:
+      - 1.76.0
+    bzip2:
+      version:
+      - 1.0.8
+    c-blosc:
+      version:
+      - 1.21.0
+    cmake:
+      version:
+      - 3.20.3
+    curl:
+      version:
+      - 7.76.1
+    diffutils:
+      version:
+      - 3.7
+    doxygen:
+      version:
+      - 1.8.20
+    elfutils:
+      version:
+      - 0.185
+      variants: +bzip2 ~nls +xz
+    expat:
+      version:
+      - 2.3.0
+    findutils:
+      version:
+      - 4.8.0
+    gdbm:
+      version:
+      - 1.19
+    gettext:
+      version:
+      - 0.21
+    git:
+      version:
+      - 2.31.1
+    glib:
+      version:
+      - 2.68.2
+    hdf5:
+      variants: +fortran +hl +shared api=v18
+      version:
+      - 1.12.0
+    help2man:
+      version:
+      - 1.47.16
+    hwloc:
+      version:
+      - 2.4.1
+    json-c:
+      version:
+      - 0.15
+    libbsd:
+      version:
+      - 0.11.3
+    libfabric:
+      version:
+      - 1.12.1
+      variants: fabrics=sockets,tcp,udp,rxm
+    libiconv:
+      version:
+      - 1.16
+    libsigsegv:
+      version:
+      - 2.13
+    libpciaccess:
+      version:
+      - 0.16
+    libtool:
+      version:
+      - 2.4.6
+    libunwind:
+      version:
+      - 1.5.0
+      variants: +pic +xz
+    libxml2:
+      version:
+      - 2.9.10
+    lz4:
+      version:
+      - 1.9.3
+    m4:
+      version:
+      - 1.4.19
+    mesa:
+      variants: ~llvm
+    mesa18:
+      variants: ~llvm
+    mpich:
+      variants: ~wrapperrpath
+      version:
+      - 3.4.2
+    ncurses:
+      version:
+      - 6.2
+      variants: +termlib
+    numactl:
+      version:
+      - 2.0.14
+    openblas:
+      version:
+      - 0.3.15
+      variants: threads=openmp
+    openssl:
+      version:
+        - 1.1.1k
+    perl:
+      version:
+      - 5.34.0 # 5.34.0
+    pkgconf:
+      version:
+      - 1.7.4
+    python:
+      version:
+      - 3.8.10
+    readline:
+      version:
+      - 8.1
+    sqlite:
+      version:
+      - 3.35.5
+    tar:
+      version:
+      - 1.34
+    texinfo:
+      version:
+      - 6.5
+    xz:
+      version:
+      - 5.2.5
+      variants: +pic
+    zlib:
+      version:
+      - 1.2.11
+    zstd:
+      version:
+      - 1.5.0
+
+  definitions:
+
+  - cuda_specs:
+    - amrex +cuda cuda_arch=70
+    - caliper +cuda cuda_arch=70
+    - chai +cuda ~benchmarks ~tests cuda_arch=70 ^umpire@4.1.2 ~shared
+    - ginkgo +cuda cuda_arch=70
+    - hpx +cuda cuda_arch=70
+    - kokkos +cuda +wrapper cuda_arch=70
+    - kokkos-kernels +cuda cuda_arch=70 ^kokkos +cuda +wrapper cuda_arch=70
+    - magma cuda_arch=70
+    - raja +cuda cuda_arch=70
+    - slate +cuda cuda_arch=70
+    - strumpack +cuda ~slate cuda_arch=70
+    - sundials +cuda cuda_arch=70
+    - superlu-dist +cuda cuda_arch=70
+    - tasmanian +cuda cuda_arch=70
+    - umpire +cuda ~shared cuda_arch=70
+    - zfp +cuda cuda_arch=70
+    #- ascent +cuda ~shared cuda_arch=70
+    #- axom +cuda cuda_arch=70 ^umpire~shared
+    #- hypre +cuda cuda_arch=70
+    #- mfem +cuda cuda_arch=70
+
+  - default_specs:
+    - adios
+    - adios2
+    - aml
+    - amrex
+    - arborx
+    - archer
+    - argobots
+    - ascent
+    - axom ^umpire@4.1.2
+    - bolt
+    - cabana
+    - caliper
+    - chai ~benchmarks ~tests ^umpire@4.1.2
+    - charliecloud
+    - conduit
+    - darshan-runtime
+    - darshan-util
+    - datatransferkit
+    - dyninst
+    - faodel ~tcmalloc
+    - flecsi
+    - flit
+    - fortrilinos ^trilinos +nox +superlu-dist +stratimikos
+    - gasnet
+    - ginkgo
+    - globalarrays
+    - gmp
+    - gotcha
+    - hdf5
+    - heffte +fftw
+    - hpctoolkit
+    - hpx
+    - hypre
+    - kokkos +openmp
+    - kokkos-kernels +openmp
+    - legion
+    - libnrm
+    - libquo
+    - libunwind
+    - loki
+    - mercury
+    - metall
+    - mfem
+    - mpark-variant
+    - mpifileutils ~xattr
+    - ninja
+    - nrm
+    - omega-h
+    - openmpi
+    - openpmd-api ^hdf5@1.12.0 +fortran +shared +hl api=default
+
+    # holding off on the specs until infrastructure is ready
+    # - papi
+    # - papyrus@1.0.1
+    # - parallel-netcdf
+    # - pdt
+    # - petsc
+    # - plasma
+    # - precice
+    # - pumi
+    # - py-jupyterhub
+    # - py-libensemble
+    # - py-petsc4py
+    # - py-warpx ^warpx dims=2 ^hdf5@1.12.0 +fortran +shared +hl api=default
+    # - py-warpx ^warpx dims=3 ^hdf5@1.12.0 +fortran +shared +hl api=default
+    # - py-warpx ^warpx dims=rz ^hdf5@1.12.0 +fortran +shared +hl api=default
+    # - qthreads scheduler=distrib
+    # - raja
+    # - rempi
+    # - scr
+    # - slate ~cuda
+    # - slepc
+    # - stc
+    # - strumpack ~slate
+    # - sundials
+    # - superlu
+    # - superlu-dist
+    # - swig
+    # - swig@4.0.2-fortran
+    # - sz
+    # - tasmanian
+    # - tau
+    # - trilinos
+    # - turbine
+    # - umap
+    # - unifyfs@0.9.1
+    # - upcxx
+    # - veloc
+    # - zfp
+
+    # build issues
+    #- dealii
+    #- geopm
+    #- llvm-doe@doe +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang
+    #- parsec
+    #- phist
+    #- qt
+    #- qwt
+    #- stat
+    #- umpire
+    #- variorum
+
+  - arch:
+    - '%gcc@9.3.0 arch=linux-ubuntu20.04-ppc64le'
+
+
+  specs:
+
+  - matrix:
+    - - $default_specs
+    - - $arch
+
+  - matrix:
+    - - $cuda_specs
+    - - $arch
+
+  mirrors: { "mirror": "s3://spack-binaries-develop/e4s" }
+
+  gitlab-ci:
+
+    script:
+      - . "./share/spack/setup-env.sh"
+      - spack --version
+      - cd ${SPACK_CONCRETE_ENV_DIR}
+      - spack env activate --without-view .
+      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+      - spack -d ci rebuild
+
+    mappings:
+      - match:
+        - cuda
+        - dyninst
+        - hpx
+        - llvm
+        - llvm-amdgpu
+        - precice
+        - rocblas
+        - rocsolver
+        - strumpack
+        - sundials
+        - trilinos
+        - vtk-h
+        - vtk-m
+        - warpx
+        runner-attributes:
+          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-ppc64le:2021-07-01", "entrypoint": [""] }
+          tags: ["spack", "public", "xlarge", "ppc64le"]
+      - match: ['os=ubuntu20.04']
+        runner-attributes:
+          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-ppc64le:2021-07-01", "entrypoint": [""] }
+          tags: ["spack", "public", "large", "ppc64le"]
+    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
+    broken-specs-url: "s3://spack-binaries-develop/broken-specs"
+    service-job-attributes:
+      before_script:
+        - . "./share/spack/setup-env.sh"
+        - spack --version
+        - cd share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power
+        - spack env activate --without-view .
+      image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-ppc64le:2021-07-01", "entrypoint": [""] }
+      tags: ["spack", "public", "medium", "ppc64le"]
+
+  cdash:
+    build-group: New PR testing workflow
+    url: https://cdash.spack.io
+    project: Spack Testing
+    site: Cloud Gitlab Infrastructure
+
+


### PR DESCRIPTION
Enable ~1/2 of the E4S stack for Power, using `Ubuntu 20.04 - GCC 9.3.0`

Plan is to evaluate how the 2 Power8 and 3 Power9 runners at University of Oregon handle this load. If performance is satisfactory, the full E4S stack for power will be enabled.

@scottwittenburg