### PR TITLE
magma: fix bugs in cuda_arch variant

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -39,7 +39,7 @@ class Magma(CMakePackage, CudaPackage):
     depends_on('cuda@8:', when='@2.5.1:')  # See PR #14471
 
     conflicts('~cuda', msg='Magma requires cuda')
-    conflicts('cuda_arch=none', when='+cuda',
+    conflicts('cuda_arch=none',
               msg='Please indicate a CUDA arch value or values')
 
     # currently not compatible with CUDA-11

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -33,15 +33,13 @@ class Magma(CMakePackage, CudaPackage):
     variant('shared', default=True,
             description='Enable shared library')
     variant('cuda', default=True, description='Build with CUDA')
-    variant('cuda_arch', default='none', multi=True,
-            description='Specify CUDA architecture(s)')
 
     depends_on('blas')
     depends_on('lapack')
     depends_on('cuda@8:', when='@2.5.1:')  # See PR #14471
 
     conflicts('~cuda', msg='Magma requires cuda')
-    conflicts('cuda_arch=none',
+    conflicts('cuda_arch=none', when='+cuda',
               msg='Please indicate a CUDA arch value or values')
 
     # currently not compatible with CUDA-11


### PR DESCRIPTION
The `cuda_arch` defined in `CudaPackage` was being overridden. This prevented valid value parsing, and prevented valid options from being displayed in `spack info magma`.