### PR TITLE
Limit Gdal Version for Grass and Add Version 7.8.5

### DIFF
--- a/var/spack/repos/builtin/packages/grass/package.py
+++ b/var/spack/repos/builtin/packages/grass/package.py
@@ -94,7 +94,7 @@ class Grass(AutotoolsPackage):
     depends_on('opencl', when='+opencl')
     depends_on('bzip2', when='+bzlib')
     depends_on('zstd', when='+zstd')
-    depends_on('gdal@:3.2.3', when='+gdal') 
+    depends_on('gdal@:3.2.999', when='+gdal') 
     depends_on('liblas', when='+liblas')
     depends_on('wxwidgets', when='+wxwidgets')
     depends_on('py-wxpython@2.8.10.1:', when='+wxwidgets', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/grass/package.py
+++ b/var/spack/repos/builtin/packages/grass/package.py
@@ -13,13 +13,14 @@ class Grass(AutotoolsPackage):
        graphics and maps production, spatial modeling, and visualization."""
 
     homepage = "https://grass.osgeo.org"
-    url      = "https://grass.osgeo.org/grass78/source/grass-7.8.2.tar.gz"
+    url      = "https://grass.osgeo.org/grass78/source/grass-7.8.5.tar.gz"
     list_url = "https://grass.osgeo.org/download/software/sources/"
     git      = "https://github.com/OSGeo/grass.git"
 
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('7.8.5', sha256='a359bb665524ecccb643335d70f5436b1c84ffb6a0e428b78dffebacd983ff37')
     version('7.8.2', sha256='33576f7078f805b39ca20c2fa416ac79c64260c0581072a6dc7d813f53aa9abb')
     version('7.8.1', sha256='6ae578fd67afcce7abec4ba4505dcc55b3d2dfe0ca46b99d966cb148c654abb3')
     version('7.8.0', sha256='4b1192294e959ffd962282344e4ff325c4472f73abe605e246a1da3beda7ccfa')
@@ -93,7 +94,7 @@ class Grass(AutotoolsPackage):
     depends_on('opencl', when='+opencl')
     depends_on('bzip2', when='+bzlib')
     depends_on('zstd', when='+zstd')
-    depends_on('gdal', when='+gdal')  # required?
+    depends_on('gdal@:3.2.3', when='+gdal') 
     depends_on('liblas', when='+liblas')
     depends_on('wxwidgets', when='+wxwidgets')
     depends_on('py-wxpython@2.8.10.1:', when='+wxwidgets', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/grass/package.py
+++ b/var/spack/repos/builtin/packages/grass/package.py
@@ -94,7 +94,7 @@ class Grass(AutotoolsPackage):
     depends_on('opencl', when='+opencl')
     depends_on('bzip2', when='+bzlib')
     depends_on('zstd', when='+zstd')
-    depends_on('gdal@:3.2.999', when='+gdal') 
+    depends_on('gdal@:3.2.999', when='+gdal')
     depends_on('liblas', when='+liblas')
     depends_on('wxwidgets', when='+wxwidgets')
     depends_on('py-wxpython@2.8.10.1:', when='+wxwidgets', type=('build', 'run'))


### PR DESCRIPTION
Limit the version of Gdal used to build Grass to fix build issues and add Grass version 7.8.5.

**Changelog:**
Full changelog for 7.8.5 can be found [here](https://trac.osgeo.org/grass/wiki/Grass7/NewFeatures78).

**Test Plan:**
Grass successfully built after making these changes in the Autamus Pipeline [here]( https://github.com/autamus/registry/runs/3002719375).