### PR TITLE
py-mypy: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -12,11 +12,16 @@ class PyMypy(PythonPackage):
     homepage = "http://www.mypy-lang.org/"
     pypi = "mypy/mypy-0.740.tar.gz"
 
+    version('0.910', sha256='704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150')
     version('0.800', sha256='e0202e37756ed09daf4b0ba64ad2c245d357659e014c3f51d8cd0681ba66940a')
     version('0.740', sha256='48c8bc99380575deb39f5d3400ebb6a8a1cb5cc669bbba4d3bb30f904e0a0e7d')
 
+    variant('python2', default=False, description='Enable checking of python 2 type annotations')
+
     depends_on('python@3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-typed-ast@1.4.0:1.4.999', type=('build', 'run'))
+    depends_on('py-typed-ast@1.4.0:1.4.999', when='@0.900:+python2', type=('build', 'run'))
+    depends_on('py-typed-ast@1.4.0:1.4.999', when='@:899', type=('build', 'run'))
     depends_on('py-typing-extensions@3.7.4:', type=('build', 'run'))
     depends_on('py-mypy-extensions@0.4.3:0.4.999', type=('build', 'run'))
+    depends_on('py-toml', when='@0.900:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.