### PR TITLE
Fix incorrect full hashes in binary index

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1096,7 +1096,8 @@ class Database(object):
                 }
                 self._add(dep, directory_layout, **extra_args)
 
-        if key not in self._data:
+        if (key not in self._data or
+                self._data[key].spec._full_hash != spec._full_hash):
             installed = bool(spec.external)
             path = None
             if not spec.external and directory_layout:


### PR DESCRIPTION
The process of updating the index of a binary mirror involves iterating over the spec.yaml files in the mirror and adding each one to a temporary database, then writing out the database using db._write_to_file().  There has been an issue observed when updating the index of binary mirrors which was only reproducible with a large mirror with a lot of versions of the various specs in the environment.  The issue resulted in the regenerated index having full hash values on specs not matching the full hashes in the individual spec.yaml files from which the index was built.

Debugging the problem indicated that a spec could be added to the db as a dependency of something else (possibly an old or out of date spec.yaml), and then when it's again encountered directly (not as a dependency, but because we read its spec.yaml and added it explicitly), the database code would find the dag hash already present and not overwrite it.

This change relaxes the guard against re-adding specs to the db so that if the dag hash is already in the db, but the full hash in the install record doesn't match that of the spec we're adding, then we still add the spec to the db, overwriting the existing record.  The previous less-relaxed guard is still used before calling _add() recursively, so we should only ever overwrite an install record when `db._add()`-ing a spec directly, never when `db._add()`-ing it as a dependency of something else.