### PR TITLE
ci: tolerate 'InvalidAccessKeyId'

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1395,7 +1395,7 @@ def push_mirror_contents(env, spec, yaml_path, mirror_url, sign_binaries):
         #     BaseException
         #     object
         err_msg = 'Error msg: {0}'.format(inst)
-        if 'Access Denied' in err_msg:
+        if any(x in err_msg for x in ['Access Denied', 'InvalidAccessKeyId']):
             tty.msg('Permission problem writing to {0}'.format(
                 mirror_url))
             tty.msg(err_msg)


### PR DESCRIPTION
Add 'InvalidAccessKeyId' to the list of error messages we expect and tolerate in `push_mirror_contents()`