### PR TITLE
sleef: disable optional dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/sleef/package.py
+++ b/var/spack/repos/builtin/packages/sleef/package.py
@@ -36,3 +36,10 @@ class Sleef(CMakePackage):
     depends_on('ninja', type='build')
 
     generator = 'Ninja'
+
+    def cmake_args(self):
+        return [
+            self.define('DISABLE_FFTW', True),
+            self.define('DISABLE_MPFR', True),
+            self.define('DISABLE_SSL', True),
+        ]


### PR DESCRIPTION
Allows me to work around the problem reported in https://github.com/shibatch/sleef/issues/427

Successfully builds on Cray CNL5 with GCC 5.3.0.