### PR TITLE
perl: add dependencies for bzip2 and zlib

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -11,12 +11,11 @@
 # Author: Justin Too <justin@doubleotoo.com>
 # Date: September 6, 2015
 #
-import re
 import os
+import re
 from contextlib import contextmanager
 
 from llnl.util.lang import match_predicate
-
 from spack import *
 
 
@@ -65,6 +64,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
 
     depends_on('gdbm')
     depends_on('berkeley-db')
+    depends_on('bzip2+shared')
+    depends_on('zlib+shared')
 
     # there has been a long fixed issue with 5.22.0 with regard to the ccflags
     # definition.  It is well documented here:
@@ -270,11 +271,21 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             mkdirp(module.perl_lib_dir)
 
     def setup_build_environment(self, env):
+        spec = self.spec
+
         # This is to avoid failures when using -mmacosx-version-min=11.1
         # since not all Apple Clang compilers support that version range
         # See https://eclecticlight.co/2020/07/21/big-sur-is-both-10-16-and-11-0-its-official/
-        if self.spec.satisfies('os=bigsur'):
+        if spec.satisfies('os=bigsur'):
             env.set('SYSTEM_VERSION_COMPAT', 1)
+
+        # This is how we tell perl the locations of bzip and zlib.
+        env.set('BUILD_BZIP2', 0)
+        env.set('BZIP2_INCLUDE', spec['bzip2'].prefix.include)
+        env.set('BZIP2_LIB',     spec['bzip2'].prefix.lib)
+        env.set('BUILD_ZLIB', 0)
+        env.set('ZLIB_INCLUDE', spec['zlib'].prefix.include)
+        env.set('ZLIB_LIB',     spec['zlib'].prefix.lib)
 
     @run_after('install')
     def filter_config_dot_pm(self):


### PR DESCRIPTION
Perl keeps copies of the bzip2 and zlib source code in its own source
tree and by default uses them in favor of outside libraries.  Instead,
put these dependencies under control of spack and tell perl to use the
spack-built versions.

----------

This all started when `spack install perl` failed on stria at Sandia
Natl Labs.

Turns out that perl keeps its own copies of the sources for bzip2 and zlib
(or parts thereof) and either uses its own copy or an external copy based on
some environ vars in `cpan/Compress-Raw-Bzip2/Makefile.PL`

```
my $BUILD_BZIP2 = defined($ENV{BUILD_BZIP2}) ? $ENV{BUILD_BZIP2} : 1;
my $BZIP2_LIB = defined($ENV{BZIP2_LIB}) ? $ENV{BZIP2_LIB} : 'bzip2-src';
my $BZIP2_INCLUDE = defined($ENV{BZIP2_INCLUDE}) ? $ENV{BZIP2_INCLUDE} : '.';
```

The problem on stria was that a bzip2 module set `BZIP2_LIB` and
`BZIP2_INC`, but not `BZIP2_INCLUDE`.  That is, half of the environment
was pointing to perl's internal bzip2 and half to the external
version.  This confused the Makefiles and broke the build.

Anyway, there are two solutions, either always use the internal copy
or always use the external version.

1. always use perl's internal copy.
pros: simpler, fewer dependencies, this is how spack has built perl
since forever.
cons: uses perl's vendor copies of bzip2, not the spack ones.

2. always use external (spack) version.
pros: puts dependencies under spack control.
cons: adds extra dependencies.

But spack really needs to make a decision, we can't leave it up to
local environment settings.  That would mean either option could
happen with the same hash.  Plus, it wouldn't fix the failure on stria.

Originally, I chose (1) and submitted PR #24605.  But the consensus in
#24605 was for (2), so I'm closing #24605 and opening this PR.

I'm still a bit uneasy about adding two new dependencies to perl, but we'll
see how it goes.

Ping @becker33 @michaelkuhn @mjwoods @hartzell @alalazo @gartung
@jrood-nrel @adamjstewart @scheibelp @tgamblin

in case anyone has strong feelings about (1) vs. (2).

And no, don't make me maintainer.
