### PR TITLE
gpg: silence binary package signature verification warnings for explicitly trusted keys

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -90,11 +90,17 @@ config:
 
 
   # Suppress gpg warnings from binary package verification
-  # Only suppresses warnings, gpg failure will still fail the install
-  # Potential rationale to set True: users have already explicitly trusted the
-  # gpg key they are using, and may not want to see repeated warnings that it
-  # is self-signed or something of the sort.
-  suppress_gpg_warnings: false
+  # Warnings are suppressed by default. It is assumed that
+  # if a user explicitly trusts a GPG key, then they do in fact
+  # mean to trust the key for verification purposes. This spares
+  # users from a barrage of GPG warnings during binary package
+  # verification that arise because the trust model used by Spack
+  # is NOT a web of trust model as GPG assumes.
+  # Binary package verification will STILL FAIL, regardless of the
+  # value of this config option, if a user is trying to install
+  # a package that has been signed with a key that has not been
+  # explicitly trusted by the user.
+  suppress_gpg_warnings: true
 
 
   # If set to true, Spack will attempt to build any compiler on the spec

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -4,39 +4,36 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import codecs
+import glob
+import hashlib
+import json
 import os
 import re
+import shutil
 import sys
 import tarfile
-import shutil
 import tempfile
-import hashlib
-import glob
-from ordereddict_backport import OrderedDict
-
 from contextlib import closing
+
 import ruamel.yaml as yaml
-
-import json
-
-from six.moves.urllib.error import URLError, HTTPError
+from ordereddict_backport import OrderedDict
+from six.moves.urllib.error import HTTPError, URLError
 
 import llnl.util.lang
 import llnl.util.tty as tty
-from llnl.util.filesystem import mkdirp
-
 import spack.cmd
 import spack.config as config
 import spack.database as spack_db
 import spack.fetch_strategy as fs
-import spack.util.file_cache as file_cache
+import spack.mirror
 import spack.relocate as relocate
+import spack.util.file_cache as file_cache
 import spack.util.gpg
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-import spack.mirror
 import spack.util.url as url_util
 import spack.util.web as web_util
+from llnl.util.filesystem import mkdirp
 from spack.caches import misc_cache_location
 from spack.spec import Spec
 from spack.stage import Stage
@@ -1256,9 +1253,9 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
     if not unsigned:
         if os.path.exists('%s.asc' % specfile_path):
             try:
-                suppress = config.get('config:suppress_gpg_warnings', False)
+                suppress = config.get('config:suppress_gpg_warnings', True)
                 spack.util.gpg.verify(
-                    '%s.asc' % specfile_path, specfile_path, suppress)
+                    '%s.asc' % specfile_path, specfile_path, suppress_warnings=suppress)
             except Exception as e:
                 shutil.rmtree(tmpdir)
                 raise e

--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -250,7 +250,7 @@ def sign(key, file, output, clearsign=False):
 
 
 @_autoinit
-def verify(signature, file, suppress_warnings=False):
+def verify(signature, file, suppress_warnings=True):
     """Verify the signature on a file.
 
     Args:


### PR DESCRIPTION
Binary package signature verification is currently implemented such that warnings are displayed which say, in effect, that a "signature is not trusted", even when signature verification succeeds using a key that a user has, in fact, *explicitly trusted*. These warnings come from GPG's assumption of a web of trust model, which is NOT the model of trust used by Spack. For this reason, Spack's default behavior should be to silence these warnings. The warnings are confusing to those not familiar with GPG's trust model. Even to those who are familiar with GPG's trust model, they are still confusing because why should Spack be warning me about a key that I have explicitly trusted via `spack gpg trust` or `spack buildcache keys -it` ?

Users who like seeing these messages can restore what is currently the default behavior by setting `config:suppress_gpg_warnings: true`.

Importantly, binary package signature verification should, and does, fail if a user has not *explicitly trusted* the public key associated with the private key used to sign a binary, _regardless of the value of this configuration option._

**New Behavior**
```
$> spack gpg trust <prl-key>
OK

$> spack install --cache-only zlib
==> Installing zlib-1.2.11-hmubt3qr3rxmeglrozk6niu22dbj35um
==> Fetching ...
==> Extracting zlib-1.2.11-hmubt3qr3rxmeglrozk6niu22dbj35um from binary cache
gpgconf: socketdir is '/run/user/0/gnupg'
[+] /spack/opt/spack/linux-ubuntu20.04-cascadelake/gcc-9.3.0/zlib-1.2.11-hmubt3qr3rxmeglrozk6niu22dbj35um
```

**Old Behavior**
```
$> spack gpg trust <prl-key>
OK

$> spack install --cache-only zlib
==> Installing zlib-1.2.11-hmubt3qr3rxmeglrozk6niu22dbj35um
==> Fetching ...
==> Extracting zlib-1.2.11-hmubt3qr3rxmeglrozk6niu22dbj35um from binary cache
gpgconf: socketdir is '/run/user/0/gnupg'
gpg: Signature made Wed 07 Jul 2021 09:07:12 AM PDT
gpg:                using RSA key 7D344E2992071B0AAAE1EDB0E68DE2A80314303D
gpg: Good signature from "prl" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 7D34 4E29 9207 1B0A AAE1  EDB0 E68D E2A8 0314 303D
[+] /spack/opt/spack/linux-ubuntu20.04-cascadelake/gcc-9.3.0/zlib-1.2.11-hmubt3qr3rxmeglrozk6niu22dbj35um
```

@sameershende 