### PR TITLE
py-jinja2: add 3.0.1 and +i18n variant

### DIFF
--- a/var/spack/repos/builtin/packages/py-jinja2/package.py
+++ b/var/spack/repos/builtin/packages/py-jinja2/package.py
@@ -14,6 +14,7 @@ class PyJinja2(PythonPackage):
     homepage = "https://palletsprojects.com/p/jinja/"
     pypi = "Jinja2/Jinja2-2.10.3.tar.gz"
 
+    version('3.0.1', sha256='703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4')
     version('2.11.3', sha256='a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6')
     version('2.10.3', sha256='9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de')
     version('2.10.1', sha256='065c4f02ebe7f7cf559e49ee5a95fb800a9e4528727aec6f24402a5374c65013')
@@ -25,7 +26,12 @@ class PyJinja2(PythonPackage):
     version('2.7.1',  sha256='5cc0a087a81dca1c08368482fb7a92fe2bdd8cfbb22bc0fccfe6c85affb04c8b')
     version('2.7',    sha256='474f1518d189ae7e318b139fecc1d30b943f124448cfa0f09582ca23e069fa4d')
 
+    variant('i18n', default=False, description="Enables I18N support with Babel")
+
+    depends_on('python@3.6:', when='@3:', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-markupsafe@2.0:', when='@3:', type=('build', 'run'))
     depends_on('py-markupsafe@0.23:', type=('build', 'run'))
-    depends_on('py-babel@0.8:', type=('build', 'run'))  # optional, required for i18n
+    depends_on('py-babel@2.7:', when='@3:+i18n', type=('build', 'run'))
+    depends_on('py-babel@0.8:', when='+i18n', type=('build', 'run'))


### PR DESCRIPTION
Move the py-babel dependency into an i18n variant. 
This depends on #24766