### PR TITLE
py-pyrsistent: need link dep on python

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyrsistent/package.py
+++ b/var/spack/repos/builtin/packages/py-pyrsistent/package.py
@@ -16,6 +16,6 @@ class PyPyrsistent(PythonPackage):
 
     version('0.15.7', sha256='cdc7b5e3ed77bed61270a47d35434a30617b9becdf2478af76ad2c6ade307280')
 
-    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'link', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-six', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.