### PR TITLE
py-fuzzywuzzy: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-fuzzywuzzy/package.py
+++ b/var/spack/repos/builtin/packages/py-fuzzywuzzy/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyFuzzywuzzy(PythonPackage):
+    """Fuzzy string matching in python."""
+
+    homepage = "https://github.com/seatgeek/fuzzywuzzy"
+    pypi     = "fuzzywuzzy/fuzzywuzzy-0.18.0.tar.gz"
+
+    version('0.18.0', sha256='45016e92264780e58972dca1b3d939ac864b78437422beecebb3095f8efd00e8')
+
+    variant('speedup', default=False, description='Provide a 4-10x speedup')
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-python-levenshtein@0.12:', when='+speedup', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.