### PR TITLE
CachedCMakePackage: Remove unnecessary compiler id override for XL

### DIFF
--- a/lib/spack/spack/build_systems/cached_cmake.py
+++ b/lib/spack/spack/build_systems/cached_cmake.py
@@ -108,21 +108,6 @@ class CachedCMakePackage(CMakePackage):
         if fflags:
             entries.append(cmake_cache_string("CMAKE_Fortran_FLAGS", fflags))
 
-        # Override XL compiler family
-        familymsg = ("Override to proper compiler family for XL")
-        if "xlf" in (self.compiler.fc or ''):  # noqa: F821
-            entries.append(cmake_cache_string(
-                "CMAKE_Fortran_COMPILER_ID", "XL",
-                familymsg))
-        if "xlc" in self.compiler.cc:  # noqa: F821
-            entries.append(cmake_cache_string(
-                "CMAKE_C_COMPILER_ID", "XL",
-                familymsg))
-        if "xlC" in self.compiler.cxx:  # noqa: F821
-            entries.append(cmake_cache_string(
-                "CMAKE_CXX_COMPILER_ID", "XL",
-                familymsg))
-
         return entries
 
     def initconfig_mpi_entries(self):


### PR DESCRIPTION
This overriding was necessary a long time ago due to compilers lying about their compiler family on BlueOS.  This also possibly was also put in defensively against possibly wrong compiler flags that could result from everything returning clang.

Either way this is now causing problems for some packages (Umpire) and I did a full battery of tests through Axom (where this originated).  I could not reproduce any failures from removing these lines.

@davidbeckingsale  @kennyweiss 