### PR TITLE
libtirpc: Fix for #24806 (remove -pipe flag when using %nvhpc)

### DIFF
--- a/var/spack/repos/builtin/packages/libtirpc/libtirpc-remove-pipe-flag-for-nvhpc.patch
+++ b/var/spack/repos/builtin/packages/libtirpc/libtirpc-remove-pipe-flag-for-nvhpc.patch
@@ -1,0 +1,24 @@
+diff -Naur spack-src/src/Makefile.am spack-src.patch/src/Makefile.am
+--- spack-src/src/Makefile.am	2020-04-07 09:24:34.000000000 -0400
++++ spack-src.patch/src/Makefile.am	2021-07-09 10:52:47.702886134 -0400
+@@ -8,7 +8,7 @@
+ noinst_HEADERS = rpc_com.h debug.h
+ 
+ AM_CPPFLAGS = -I$(top_srcdir)/tirpc -include config.h -DPORTMAP -DINET6 \
+-		-D_GNU_SOURCE -Wall -pipe
++		-D_GNU_SOURCE -Wall
+ 
+ lib_LTLIBRARIES = libtirpc.la
+ 
+diff -Naur spack-src/src/Makefile.in spack-src.patch/src/Makefile.in
+--- spack-src/src/Makefile.in	2020-04-07 09:26:28.000000000 -0400
++++ spack-src.patch/src/Makefile.in	2021-07-09 10:52:55.102361747 -0400
+@@ -455,7 +455,7 @@
+ top_srcdir = @top_srcdir@
+ noinst_HEADERS = rpc_com.h debug.h
+ AM_CPPFLAGS = -I$(top_srcdir)/tirpc -include config.h -DPORTMAP -DINET6 \
+-		-D_GNU_SOURCE -Wall -pipe
++		-D_GNU_SOURCE -Wall
+ 
+ lib_LTLIBRARIES = libtirpc.la
+ libtirpc_la_LDFLAGS = @LDFLAG_NOUNDEFINED@ -no-undefined -lpthread \

--- a/var/spack/repos/builtin/packages/libtirpc/package.py
+++ b/var/spack/repos/builtin/packages/libtirpc/package.py
@@ -20,6 +20,9 @@ class Libtirpc(AutotoolsPackage):
 
     provides('rpc')
 
+    # Remove -pipe flag to compiler in Makefiles when using nvhpc
+    patch('libtirpc-remove-pipe-flag-for-nvhpc.patch', when='%nvhpc')
+
     # FIXME: build error on macOS
     # auth_none.c:81:9: error: unknown type name 'mutex_t'
     conflicts('platform=darwin', msg='Does not build on macOS')


### PR DESCRIPTION
Fixes #24806

Makefiles for libtirpc have hardcoded the -pipe flag to the compiler
nvhpc compilers do not recognize that flag.
This PR provides a patch to remove the -pipe flag from the Makefile.
Patch should work with libtirpc@1.2.6 and @1.1.4