### PR TITLE
py-torch: CUDA 9.2+ required

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -150,6 +150,7 @@ class PyTorch(PythonPackage, CudaPackage):
     # Optional dependencies
     depends_on('cuda@7.5:', when='+cuda', type=('build', 'link', 'run'))
     depends_on('cuda@9:', when='@1.1:+cuda', type=('build', 'link', 'run'))
+    depends_on('cuda@9.2:', when='@1.6:+cuda', type=('build', 'link', 'run'))
     depends_on('cudnn@6.0:7.999', when='@:1.0.999+cudnn')
     depends_on('cudnn@7.0:7.999', when='@1.1.0:1.5.999+cudnn')
     depends_on('cudnn@7.0:', when='@1.6.0:+cudnn')


### PR DESCRIPTION
PyTorch 1.6+ requires CUDA 9.2+. Support for CUDA 9.1 and older was dropped in https://github.com/pytorch/pytorch/pull/36848 and documented in the README in https://github.com/pytorch/pytorch/pull/38977, but not properly checked for until https://github.com/pytorch/pytorch/pull/61462 which is why I didn't catch it until now.