### PR TITLE
openPMD-api: rename develop

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -16,7 +16,7 @@ class OpenpmdApi(CMakePackage):
     maintainers = ['ax3l']
 
     # C++14 up until here
-    version('dev', branch='dev')
+    version('develop', branch='dev')
     #   temporary, pre 0.14.0 version for HiPACE++
     version('hipace', commit='ac083025ee662469b8cad1adf93eef48cde35f58')
     version('0.13.4', sha256='46c013be5cda670f21969675ce839315d4f5ada0406a6546a91ec3441402cf5e')

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -84,7 +84,7 @@ class Warpx(CMakePackage):
     depends_on('fftw +mpi', when='+psatd +mpi compute=omp')
     depends_on('lapackpp', when='+psatd dims=rz')
     depends_on('mpi', when='+mpi')
-    depends_on('openpmd-api@0.13.1:,dev', when='+openpmd')
+    depends_on('openpmd-api@0.13.1:,develop', when='+openpmd')
     depends_on('openpmd-api ~mpi', when='+openpmd ~mpi')
     depends_on('openpmd-api +mpi', when='+openpmd +mpi')
     depends_on('pkgconfig', type='build', when='+psatd compute=omp')

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -84,7 +84,7 @@ class Warpx(CMakePackage):
     depends_on('fftw +mpi', when='+psatd +mpi compute=omp')
     depends_on('lapackpp', when='+psatd dims=rz')
     depends_on('mpi', when='+mpi')
-    depends_on('openpmd-api@0.13.1:,develop', when='+openpmd')
+    depends_on('openpmd-api@0.13.1:', when='+openpmd')
     depends_on('openpmd-api ~mpi', when='+openpmd ~mpi')
     depends_on('openpmd-api +mpi', when='+openpmd +mpi')
     depends_on('pkgconfig', type='build', when='+psatd compute=omp')


### PR DESCRIPTION
Rename to match known Spack version comparison schemes:
```
develop>main>master>head>trunk>9999>0>z>a
```

Currently, the hdf5 patch that is pre-0.14.0 is also applied to `dev`, which naturally fails (already applied).