### PR TITLE
Ensure consistency of buildcache spec.yaml files and buildcache index

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import traceback
 from contextlib import closing
 
 import ruamel.yaml as yaml
@@ -27,6 +28,7 @@ import spack.cmd
 import spack.config as config
 import spack.database as spack_db
 import spack.fetch_strategy as fs
+import spack.hash_types as ht
 import spack.mirror
 import spack.relocate as relocate
 import spack.util.file_cache as file_cache
@@ -709,12 +711,6 @@ def generate_package_index(cache_prefix):
     cache_prefix.  This page contains a link for each binary package (.yaml)
     under cache_prefix.
     """
-    tmpdir = tempfile.mkdtemp()
-    db_root_dir = os.path.join(tmpdir, 'db_root')
-    db = spack_db.Database(None, db_dir=db_root_dir,
-                           enable_transaction_locking=False,
-                           record_fields=['spec', 'ref_count', 'in_buildcache'])
-
     try:
         file_list = (
             entry
@@ -735,22 +731,90 @@ def generate_package_index(cache_prefix):
 
     tty.debug('Retrieving spec.yaml files from {0} to build index'.format(
         cache_prefix))
+
+    all_mirror_specs = {}
+
     for file_path in file_list:
         try:
             yaml_url = url_util.join(cache_prefix, file_path)
             tty.debug('fetching {0}'.format(yaml_url))
             _, _, yaml_file = web_util.read_from_url(yaml_url)
             yaml_contents = codecs.getreader('utf-8')(yaml_file).read()
-            # yaml_obj = syaml.load(yaml_contents)
-            # s = Spec.from_yaml(yaml_obj)
+            spec_dict = syaml.load(yaml_contents)
             s = Spec.from_yaml(yaml_contents)
-            db.add(s, None)
-            db.mark(s, 'in_buildcache', True)
+            all_mirror_specs[s.dag_hash()] = {
+                'yaml_url': yaml_url,
+                'spec': s,
+                'num_deps': len(list(s.traverse(root=False))),
+                'binary_cache_checksum': spec_dict['binary_cache_checksum'],
+                'buildinfo': spec_dict['buildinfo'],
+            }
         except (URLError, web_util.SpackWebError) as url_err:
             tty.error('Error reading spec.yaml: {0}'.format(file_path))
             tty.error(url_err)
 
+    sorted_specs = sorted(all_mirror_specs.keys(),
+                          key=lambda k: all_mirror_specs[k]['num_deps'])
+
+    tmpdir = tempfile.mkdtemp()
+    db_root_dir = os.path.join(tmpdir, 'db_root')
+    db = spack_db.Database(None, db_dir=db_root_dir,
+                           enable_transaction_locking=False,
+                           record_fields=['spec', 'ref_count', 'in_buildcache'])
+
     try:
+        tty.debug('Specs sorted by number of dependencies:')
+        for dag_hash in sorted_specs:
+            spec_record = all_mirror_specs[dag_hash]
+            s = spec_record['spec']
+            num_deps = spec_record['num_deps']
+            tty.debug('  {0}/{1} -> {2}'.format(
+                s.name, dag_hash[:7], num_deps))
+            if num_deps > 0:
+                # Check each of this spec's dependencies (which we have already
+                # processed), as they are the source of truth for their own
+                # full hash.  If the full hash we have for any deps does not
+                # match what those deps have themselves, then we need to splice
+                # this spec with those deps, and push this spliced spec
+                # (spec.yaml file) back to the mirror, as well as update the
+                # all_mirror_specs dictionary with this spliced spec.
+                to_splice = []
+                for dep in s.dependencies():
+                    dep_dag_hash = dep.dag_hash()
+                    if dep_dag_hash in all_mirror_specs:
+                        true_dep = all_mirror_specs[dep_dag_hash]['spec']
+                        if true_dep.full_hash() != dep.full_hash():
+                            to_splice.append(true_dep)
+
+                if to_splice:
+                    tty.debug('    needs the following deps spliced:')
+                    for true_dep in to_splice:
+                        tty.debug('      {0}/{1}'.format(
+                            true_dep.name, true_dep.dag_hash()[:7]))
+                        s = s.splice(true_dep, True)
+
+                    # Push this spliced spec back to the mirror
+                    spliced_yaml = s.to_dict(hash=ht.full_hash)
+                    for key in ['binary_cache_checksum', 'buildinfo']:
+                        spliced_yaml[key] = spec_record[key]
+
+                    temp_yaml_path = os.path.join(tmpdir, 'spliced.spec.yaml')
+                    with open(temp_yaml_path, 'w') as fd:
+                        fd.write(syaml.dump(spliced_yaml))
+
+                    spliced_yaml_url = spec_record['yaml_url']
+                    web_util.push_to_url(
+                        temp_yaml_path, spliced_yaml_url, keep_original=False)
+                    tty.debug('    spliced and wrote {0}'.format(
+                        spliced_yaml_url))
+                    spec_record['spec'] = s
+
+            db.add(s, None)
+            db.mark(s, 'in_buildcache', True)
+
+        # Now that we have fixed any old spec yamls that might have had the wrong
+        # full hash for their dependencies, we can generate the index, compute
+        # the hash, and push those files to the mirror.
         index_json_path = os.path.join(db_root_dir, 'index.json')
         with open(index_json_path, 'w') as f:
             db._write_to_file(f)
@@ -782,6 +846,7 @@ def generate_package_index(cache_prefix):
         msg = 'Encountered problem pushing package index to {0}: {1}'.format(
             cache_prefix, err)
         tty.warn(msg)
+        tty.debug('\n' + traceback.format_exc())
     finally:
         shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
The process of updating the index of a binary mirror involves iterating over the spec.yaml files in the mirror and adding each one to a temporary database, then writing out the database using db._write_to_file(). There has been an issue observed when updating the index of binary mirrors which was only reproducible with a large mirror with a lot of versions of the various specs in the environment. The issue resulted in the regenerated index having full hash values on specs not matching the full hashes in the individual spec.yaml files from which the index was built.

Debugging the problem indicated that a spec could be added to the db as a dependency of something else (possibly an old or out of date spec.yaml), and then when it's again encountered directly (not as a dependency, but because we read its spec.yaml and added it explicitly), the database code would find the dag hash already present and not overwrite it.

This PR changes how `spack buildcache update-index` works by checking each spec.yaml to see if it's dependencies' full hashes were changed (the spec.yaml for the dependency is considered to be the source of truth regarding the full hash of the dependency).  If we find any mismatches between the full hash of  a dependency in a parent spec.yaml and the full hash in the dependency spec.yaml, we fix up the parent by splicing in the correct dependency specs, and then push the spliced parent spec.yaml to the mirror.  Once we have fixed up all the spec yamls on the mirror, we then update the buildcache index.  The end result is that the full hash of the root spec in each spec.yaml matches the full hash of the corresponding dag hash in the index.

This depends on #24795