### PR TITLE
`spack style`: automatically bootstrap dependencies

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -39,7 +39,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-        pip install --upgrade pip six setuptools flake8 isort>=4.3.5 mypy>=0.900 black types-six
+        pip install --upgrade pip six setuptools types-six
     - name: Setup git configuration
       run: |
         # Need this for the git tests to succeed.
@@ -370,7 +370,6 @@ jobs:
       run: |
           pip install --upgrade pip six setuptools
           pip install --upgrade codecov coverage[toml]
-          pip install --upgrade flake8 isort>=4.3.5 mypy>=0.900
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg2 kcov

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -818,6 +818,29 @@ Developer commands
 ``spack doc``
 ^^^^^^^^^^^^^
 
+.. _cmd-spack-style:
+
+^^^^^^^^^^^^^^^
+``spack style``
+^^^^^^^^^^^^^^^
+
+spack style exists to help the developer user to check imports and style with
+mypy, flake8, isort, and (soon) black. To run all style checks, simply do:
+
+.. code-block:: console
+
+    $ spack style
+
+To run automatic fixes for isort you can do:
+
+.. code-block:: console
+
+    $ spack style --fix
+
+You do not need any of these Python packages installed on your system for
+the checks to work! Spack will bootstrap install them from packages for
+your use.
+
 ^^^^^^^^^^^^^^^^^^^
 ``spack unit-test``
 ^^^^^^^^^^^^^^^^^^^

--- a/share/spack/qa/run-style-tests
+++ b/share/spack/qa/run-style-tests
@@ -15,7 +15,6 @@
 #     run-flake8-tests
 #
 . "$(dirname $0)/setup.sh"
-check_dependencies flake8 mypy
 
 # verify that the code style is correct
 spack style --root-relative

--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -13,15 +13,15 @@ class PyMypy(PythonPackage):
     pypi = "mypy/mypy-0.740.tar.gz"
 
     version('0.910', sha256='704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150')
+    version('0.900', sha256='65c78570329c54fb40f956f7645e2359af5da9d8c54baa44f461cdc7f4984108')
     version('0.800', sha256='e0202e37756ed09daf4b0ba64ad2c245d357659e014c3f51d8cd0681ba66940a')
     version('0.740', sha256='48c8bc99380575deb39f5d3400ebb6a8a1cb5cc669bbba4d3bb30f904e0a0e7d')
 
     variant('python2', default=False, description='Enable checking of python 2 type annotations')
 
-    depends_on('python@3.5:', type=('build', 'run'))
+    depends_on("python@3.5:", type=("build", "run"))
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-typed-ast@1.4.0:1.4.999', when='@0.900:+python2', type=('build', 'run'))
-    depends_on('py-typed-ast@1.4.0:1.4.999', when='@:899', type=('build', 'run'))
+    depends_on('py-typed-ast@1.4.0:1.4.999', type=('build', 'run'))
     depends_on('py-typing-extensions@3.7.4:', type=('build', 'run'))
     depends_on('py-mypy-extensions@0.4.3:0.4.999', type=('build', 'run'))
     depends_on('py-toml', when='@0.900:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-typed-ast/package.py
+++ b/var/spack/repos/builtin/packages/py-typed-ast/package.py
@@ -12,7 +12,11 @@ class PyTypedAst(PythonPackage):
     homepage = "https://github.com/python/typed_ast"
     pypi = "typed-ast/typed_ast-1.4.0.tar.gz"
 
+    version('1.4.3', sha256='fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65')
+    version('1.4.2', sha256='9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a')
+    version('1.4.1', sha256='8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b')
     version('1.4.0', sha256='66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34')
 
-    depends_on('python@3.3:', type=('build', 'run'))
+    depends_on('python@3.3:', type=('build', 'link', 'run'))
+    depends_on('python@:3.8', when="@:1.4.0")  # build errors with 3.9 until 1.4.1
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
The developer user shouldn't need to install all the linting/formatting tools to run `spack style`. This PR installs these tools via bootstrap so they don't have to.

I also added a documentation section on spack style because there wasn't one!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>