### PR TITLE
docs: fix reference to count of system packages

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -777,7 +777,7 @@ an OpenMPI installed in /opt/local, one would use:
             buildable: False
 
 In general, Spack is easier to use and more reliable if it builds all of
-its own dependencies.  However, there are two packages for which one
+its own dependencies.  However, there are several packages for which one
 commonly needs to use system versions:
 
 ^^^


### PR DESCRIPTION
015e29efe105ddd039e8b395e12cf78a3787ebb3 that introduced this section to the
documentation said “two” here instead of the actual count, three.
9f54cea5c500bb19d2301149460c741e96be1f8b then added a fourth, BLAS/LAPACK.
Rather than trying to keep this leading count in sync, this change just replaces
the wording with something more generic/stable.