### PR TITLE
Fix KeyboardInterrupt signal for Python 2

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -782,7 +782,10 @@ def main(argv=None):
             raise
         sys.stderr.write('\n')
         tty.error("Keyboard interrupt.")
-        return signal.SIGINT.value
+        if sys.version_info >= (3, 5):
+            return signal.SIGINT.value
+        else:
+            return signal.SIGINT
 
     except SystemExit as e:
         if spack.config.get('config:debug'):


### PR DESCRIPTION
When using Python 2, if you kill Spack with a <kbd>Ctrl</kbd>+<kbd>C</kbd>, you encounter the following error:
```
==> Error: Keyboard interrupt.
Traceback (most recent call last):
  File "/u/sciteam/stewart1/spack/bin/spack", line 77, in <module>
    sys.exit(spack.main.main())
  File "/mnt/a/u/sciteam/stewart1/spack/lib/spack/spack/main.py", line 785, in main
    return signal.SIGINT.value
AttributeError: 'int' object has no attribute 'value'
```
From https://docs.python.org/3/library/signal.html#module-contents:

> _Changed in version 3.5:_ signal (SIG*), handler (SIG_DFL, SIG_IGN) and sigmask (SIG_BLOCK, SIG_UNBLOCK, SIG_SETMASK) related constants listed below were turned into enums.

The solution is to only use `.value` for Python 3.5+ only.