### PR TITLE
Allow environment views to be sym/hard link and copy types

### DIFF
--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -42,7 +42,7 @@ import spack.environment as ev
 import spack.schema.projections
 import spack.store
 from spack.config import validate
-from spack.filesystem_view import YamlFilesystemView
+from spack.filesystem_view import YamlFilesystemView, view_func_parser
 from spack.util import spack_yaml as s_yaml
 
 description = "project packages to a compact naming scheme on the filesystem."

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -42,11 +42,7 @@ import spack.environment as ev
 import spack.schema.projections
 import spack.store
 from spack.config import validate
-from spack.filesystem_view import (
-    YamlFilesystemView,
-    view_func_parser,
-    view_symlink,
-)
+from spack.filesystem_view import YamlFilesystemView, view_func_parser, view_symlink
 from spack.util import spack_yaml as s_yaml
 
 description = "project packages to a compact naming scheme on the filesystem."

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -42,17 +42,12 @@ import spack.environment as ev
 import spack.schema.projections
 import spack.store
 from spack.config import validate
-<<<<<<< HEAD
 from spack.filesystem_view import (
     YamlFilesystemView,
     view_copy,
     view_hardlink,
     view_symlink,
 )
-=======
-from spack.filesystem_view import YamlFilesystemView
-from spack.filesystem_view import view_symlink, view_hardlink, view_copy, view_func_parser
->>>>>>> First commit for adding view type to env
 from spack.util import spack_yaml as s_yaml
 
 description = "project packages to a compact naming scheme on the filesystem."

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -42,12 +42,7 @@ import spack.environment as ev
 import spack.schema.projections
 import spack.store
 from spack.config import validate
-from spack.filesystem_view import (
-    YamlFilesystemView,
-    view_copy,
-    view_hardlink,
-    view_symlink,
-)
+from spack.filesystem_view import YamlFilesystemView
 from spack.util import spack_yaml as s_yaml
 
 description = "project packages to a compact naming scheme on the filesystem."

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -42,7 +42,7 @@ import spack.environment as ev
 import spack.schema.projections
 import spack.store
 from spack.config import validate
-from spack.filesystem_view import YamlFilesystemView, view_func_parser, view_symlink
+from spack.filesystem_view import YamlFilesystemView, view_func_parser
 from spack.util import spack_yaml as s_yaml
 
 description = "project packages to a compact naming scheme on the filesystem."
@@ -185,7 +185,7 @@ def view(parser, args):
     if args.action in actions_link:
         link_fn = view_func_parser(args.action)
     else:
-        link_fn = view_symlink
+        link_fn = view_func_parser('symlink')
 
     view = YamlFilesystemView(
         path, spack.store.layout,

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -42,12 +42,17 @@ import spack.environment as ev
 import spack.schema.projections
 import spack.store
 from spack.config import validate
+<<<<<<< HEAD
 from spack.filesystem_view import (
     YamlFilesystemView,
     view_copy,
     view_hardlink,
     view_symlink,
 )
+=======
+from spack.filesystem_view import YamlFilesystemView
+from spack.filesystem_view import view_symlink, view_hardlink, view_copy, view_func_parser
+>>>>>>> First commit for adding view type to env
 from spack.util import spack_yaml as s_yaml
 
 description = "project packages to a compact naming scheme on the filesystem."
@@ -187,12 +192,7 @@ def view(parser, args):
         ordered_projections = {}
 
     # What method are we using for this view
-    if args.action in ("hardlink", "hard"):
-        link_fn = view_hardlink
-    elif args.action in ("copy", "relocate"):
-        link_fn = view_copy
-    else:
-        link_fn = view_symlink
+    link_fn = view_func_parser(args.action)
 
     view = YamlFilesystemView(
         path, spack.store.layout,

--- a/lib/spack/spack/cmd/view.py
+++ b/lib/spack/spack/cmd/view.py
@@ -42,7 +42,11 @@ import spack.environment as ev
 import spack.schema.projections
 import spack.store
 from spack.config import validate
-from spack.filesystem_view import YamlFilesystemView, view_func_parser
+from spack.filesystem_view import (
+    YamlFilesystemView,
+    view_func_parser,
+    view_symlink,
+)
 from spack.util import spack_yaml as s_yaml
 
 description = "project packages to a compact naming scheme on the filesystem."
@@ -182,7 +186,10 @@ def view(parser, args):
         ordered_projections = {}
 
     # What method are we using for this view
-    link_fn = view_func_parser(args.action)
+    if args.action in actions_link:
+        link_fn = view_func_parser(args.action)
+    else:
+        link_fn = view_symlink
 
     view = YamlFilesystemView(
         path, spack.store.layout,

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -28,18 +28,18 @@ import spack.spec
 import spack.stage
 import spack.store
 import spack.user_environment as uenv
-from spack.filesystem_view import (
-    YamlFilesystemView,
-    view_func_parser,
-    inverse_view_func_parser,
-    view_symlink
-)
 import spack.util.environment
 import spack.util.hash
 import spack.util.lock as lk
 import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
+from spack.filesystem_view import (
+    YamlFilesystemView,
+    inverse_view_func_parser,
+    view_func_parser,
+    view_symlink,
+)
 from spack.spec import Spec
 from spack.spec_list import InvalidSpecConstraintError, SpecList
 from spack.util.path import substitute_path_variables

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -32,7 +32,8 @@ from spack.filesystem_view import (
     YamlFilesystemView,
     view_func_parser,
     inverse_view_func_parser,
-    view_symlink)
+    view_symlink
+)
 import spack.util.environment
 import spack.util.hash
 import spack.util.lock as lk

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -479,7 +479,8 @@ class ViewDescriptor(object):
                     self.projections == other.projections,
                     self.select == other.select,
                     self.exclude == other.exclude,
-                    self.link == other.link])
+                    self.link == other.link,
+                    self.link_type == other.link_type])
 
     def to_dict(self):
         ret = syaml.syaml_dict([('root', self.root)])

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -38,7 +38,6 @@ from spack.filesystem_view import (
     YamlFilesystemView,
     inverse_view_func_parser,
     view_func_parser,
-    view_symlink,
 )
 from spack.spec import Spec
 from spack.spec_list import InvalidSpecConstraintError, SpecList
@@ -509,7 +508,7 @@ class ViewDescriptor(object):
                               d.get('select', []),
                               d.get('exclude', []),
                               d.get('link', default_view_link),
-                              d.get('link_type', view_symlink))
+                              d.get('link_type', 'symlink'))
 
     @property
     def _current_root(self):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -28,14 +28,17 @@ import spack.spec
 import spack.stage
 import spack.store
 import spack.user_environment as uenv
-from spack.filesystem_view import YamlFilesystemView, view_func_parser, inverse_view_func_parser, view_symlink
+from spack.filesystem_view import (
+    YamlFilesystemView,
+    view_func_parser,
+    inverse_view_func_parser,
+    view_symlink)
 import spack.util.environment
 import spack.util.hash
 import spack.util.lock as lk
 import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
-from spack.filesystem_view import YamlFilesystemView
 from spack.spec import Spec
 from spack.spec_list import InvalidSpecConstraintError, SpecList
 from spack.util.path import substitute_path_variables

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -28,6 +28,10 @@ import spack.spec
 import spack.stage
 import spack.store
 import spack.user_environment as uenv
+<<<<<<< HEAD
+=======
+from spack.filesystem_view import YamlFilesystemView, view_func_parser, inverse_view_func_parser, view_symlink
+>>>>>>> First commit for adding view type to env
 import spack.util.environment
 import spack.util.hash
 import spack.util.lock as lk
@@ -456,13 +460,14 @@ def _eval_conditional(string):
 
 class ViewDescriptor(object):
     def __init__(self, base_path, root, projections={}, select=[], exclude=[],
-                 include_implicits=default_include_implicits):
+                 include_implicits=default_include_implicits, link_type=view_symlink):
         self.base = base_path
         self.root = spack.util.path.canonicalize_path(root)
         self.projections = projections
         self.select = select
         self.exclude = exclude
         self.include_implicits = include_implicits
+        self.link_type = link_type
 
     def select_fn(self, spec):
         return any(spec.satisfies(s) for s in self.select)
@@ -492,6 +497,8 @@ class ViewDescriptor(object):
             ret['exclude'] = self.exclude
         if self.include_implicits != default_include_implicits:
             ret['include_implicits'] = self.include_implicits
+        if self.link_type:
+            ret['link_type'] = inverse_view_func_parser(self.link_type)
         return ret
 
     @staticmethod
@@ -501,7 +508,8 @@ class ViewDescriptor(object):
                               d.get('projections', {}),
                               d.get('select', []),
                               d.get('exclude', []),
-                              d.get('include_implicits', default_include_implicits))
+                              d.get('include_implicits', default_include_implicits),
+                              d.get('link_type', view_symlink))
 
     @property
     def _current_root(self):
@@ -565,7 +573,8 @@ class ViewDescriptor(object):
             raise SpackEnvironmentViewError(msg)
         return YamlFilesystemView(root, spack.store.layout,
                                   ignore_conflicts=True,
-                                  projections=self.projections)
+                                  projections=self.projections,
+                                  link=self.link_type)
 
     def __contains__(self, spec):
         """Is the spec described by the view descriptor

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -28,10 +28,7 @@ import spack.spec
 import spack.stage
 import spack.store
 import spack.user_environment as uenv
-<<<<<<< HEAD
-=======
 from spack.filesystem_view import YamlFilesystemView, view_func_parser, inverse_view_func_parser, view_symlink
->>>>>>> First commit for adding view type to env
 import spack.util.environment
 import spack.util.hash
 import spack.util.lock as lk
@@ -574,7 +571,7 @@ class ViewDescriptor(object):
         return YamlFilesystemView(root, spack.store.layout,
                                   ignore_conflicts=True,
                                   projections=self.projections,
-                                  link=view_func_parser(self.link_type))
+                                  link=self.link_type)
 
     def __contains__(self, spec):
         """Is the spec described by the view descriptor

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -574,7 +574,7 @@ class ViewDescriptor(object):
         return YamlFilesystemView(root, spack.store.layout,
                                   ignore_conflicts=True,
                                   projections=self.projections,
-                                  link=self.link_type)
+                                  link=view_func_parser(self.link_type))
 
     def __contains__(self, spec):
         """Is the spec described by the view descriptor

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -87,7 +87,8 @@ user_speclist_name = 'specs'
 # The name of the default view (the view loaded on env.activate)
 default_view_name = 'default'
 # Default behavior to link all packages into views (vs. only root packages)
-default_view_link = 'all'
+# This was previously "all" and False would be "root"
+default_include_implicits = True
 
 
 def valid_env_name(name):
@@ -455,13 +456,13 @@ def _eval_conditional(string):
 
 class ViewDescriptor(object):
     def __init__(self, base_path, root, projections={}, select=[], exclude=[],
-                 link=default_view_link):
+                 include_implicits=default_include_implicits):
         self.base = base_path
         self.root = spack.util.path.canonicalize_path(root)
         self.projections = projections
         self.select = select
         self.exclude = exclude
-        self.link = link
+        self.include_implicits = include_implicits
 
     def select_fn(self, spec):
         return any(spec.satisfies(s) for s in self.select)
@@ -474,7 +475,7 @@ class ViewDescriptor(object):
                     self.projections == other.projections,
                     self.select == other.select,
                     self.exclude == other.exclude,
-                    self.link == other.link])
+                    self.include_implicits == other.include_implicits])
 
     def to_dict(self):
         ret = syaml.syaml_dict([('root', self.root)])
@@ -489,8 +490,8 @@ class ViewDescriptor(object):
             ret['select'] = self.select
         if self.exclude:
             ret['exclude'] = self.exclude
-        if self.link != default_view_link:
-            ret['link'] = self.link
+        if self.include_implicits != default_include_implicits:
+            ret['include_implicits'] = self.include_implicits
         return ret
 
     @staticmethod
@@ -500,7 +501,7 @@ class ViewDescriptor(object):
                               d.get('projections', {}),
                               d.get('select', []),
                               d.get('exclude', []),
-                              d.get('link', default_view_link))
+                              d.get('include_implicits', default_include_implicits))
 
     @property
     def _current_root(self):
@@ -585,7 +586,7 @@ class ViewDescriptor(object):
 
     def specs_for_view(self, all_specs, roots):
         specs_for_view = []
-        specs = all_specs if self.link == 'all' else roots
+        specs = all_specs if self.include_implicits else roots
 
         for spec in specs:
             # The view does not store build deps, so if we want it to

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -457,14 +457,14 @@ def _eval_conditional(string):
 
 class ViewDescriptor(object):
     def __init__(self, base_path, root, projections={}, select=[], exclude=[],
-                 include_implicits=default_include_implicits, link_type=view_symlink):
+                 include_implicits=default_include_implicits, link_type='symlink'):
         self.base = base_path
         self.root = spack.util.path.canonicalize_path(root)
         self.projections = projections
         self.select = select
         self.exclude = exclude
         self.include_implicits = include_implicits
-        self.link_type = link_type
+        self.link_type = view_func_parser(link_type)
 
     def select_fn(self, spec):
         return any(spec.satisfies(s) for s in self.select)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -104,7 +104,7 @@ def view_func_parser(parsed_name):
         return view_hardlink
     elif parsed_name in ("copy", "relocate"):
         return view_copy
-    elif parsed_name == "symlink":
+    elif parsed_name in ("add", "symlink", "soft"):
         return view_symlink
     else:
         raise ValueError("invalid link type for view: '%s'" % parsed_name)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -98,6 +98,26 @@ def view_copy(src, dst, view, spec=None):
             )
 
 
+def view_func_parser(parsed_name):
+    # What method are we using for this view
+    if parsed_name in ("hardlink", "hard"):
+        link_fn = view_hardlink
+    elif parsed_name in ("copy", "relocate"):
+        link_fn = view_copy
+    else:
+        link_fn = view_symlink
+    return link_fn
+
+
+def inverse_view_func_parser(view_type):
+    # get string based on view type
+    if view_type is view_hardlink:
+        link_name = 'hardlink'
+    elif view_type is view_copy:
+        link_name = 'copy'
+    else:
+        link_name = 'symlink'
+    return link_name
 class FilesystemView(object):
     """
         Governs a filesystem view that is located at certain root-directory.

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -101,12 +101,13 @@ def view_copy(src, dst, view, spec=None):
 def view_func_parser(parsed_name):
     # What method are we using for this view
     if parsed_name in ("hardlink", "hard"):
-        link_fn = view_hardlink
+        return view_hardlink
     elif parsed_name in ("copy", "relocate"):
-        link_fn = view_copy
+        return view_copy
+    elif parsed_name == "symlink":
+        return view_symlink
     else:
-        link_fn = view_symlink
-    return link_fn
+        raise ValueError("invalid link type for view: '%s'" % parsed_name)
 
 
 def inverse_view_func_parser(view_type):

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -118,6 +118,8 @@ def inverse_view_func_parser(view_type):
     else:
         link_name = 'symlink'
     return link_name
+
+
 class FilesystemView(object):
     """
         Governs a filesystem view that is located at certain root-directory.

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -125,6 +125,9 @@ schema = {
                                             'include_implicits': {
                                                 'type': 'boolean'
                                             },
+                                            'link_type': {
+                                                'type': 'string'
+                                            },
                                             'select': {
                                                 'type': 'array',
                                                 'items': {

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -122,9 +122,8 @@ schema = {
                                             'root': {
                                                 'type': 'string'
                                             },
-                                            'link': {
-                                                'type': 'string',
-                                                'pattern': '(roots|all)',
+                                            'include_implicits': {
+                                                'type': 'boolean'
                                             },
                                             'select': {
                                                 'type': 'array',

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -122,8 +122,9 @@ schema = {
                                             'root': {
                                                 'type': 'string'
                                             },
-                                            'include_implicits': {
-                                                'type': 'boolean'
+                                            'link': {
+                                                'type': 'string',
+                                                'pattern': '(roots|all)',
                                             },
                                             'link_type': {
                                                 'type': 'string'

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1949,7 +1949,7 @@ env:
 
 
 def test_view_link_type_copy(tmpdir, mock_fetch, mock_packages, mock_archive,
-                        install_mockery):
+                             install_mockery):
     filename = str(tmpdir.join('spack.yaml'))
     viewdir = str(tmpdir.join('view'))
     with open(filename, 'w') as f:
@@ -1988,6 +1988,7 @@ env:
                 assert not os.path.exists(
                     os.path.join(viewdir, spec.name, '%s-%s' %
                                  (spec.version, spec.compiler.name)))
+
 
 def test_view_link_all(tmpdir, mock_fetch, mock_packages, mock_archive,
                        install_mockery):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1948,16 +1948,6 @@ env:
                                  (spec.version, spec.compiler.name)))
 
 
-def print_dir(path):
-    for dirpath, dirnames, filenames in os.walk(path):
-        directory_level = dirpath.replace(path, "")
-        directory_level = directory_level.count(os.sep)
-        indent = " " * 4
-        print("%s%s/" % (indent * directory_level, os.path.basename(dirpath)))
-        for f in filenames:
-            print("%s%s" % (indent * (directory_level + 1), f))
-
-
 @pytest.mark.parametrize('link_type', ['hardlink', 'copy', 'symlink'])
 def test_view_link_type(link_type, tmpdir, mock_fetch, mock_packages, mock_archive,
                         install_mockery):
@@ -1979,15 +1969,12 @@ env:
 
         test = ev.read('test')
 
-        for spec in test._get_environment_specs():
-            try:
-                file_to_test = os.path.join(
-                    test.default_view.view()._root, spec.name)
-                assert os.path.islink(file_to_test)  == (link_type == 'symlink')
-            except AssertionError as ae:
-                print("The failing spec is: ", spec.name)
-                print_dir(test.default_view.view()._root)
-                raise ae
+        for spec in test.roots():
+            file_path = test.default_view.view()._root
+            file_to_test = os.path.join(
+                file_path, spec.name)
+            assert os.path.isfile(file_to_test)
+            assert os.path.islink(file_to_test)  == (link_type == 'symlink')
 
 
 def test_view_link_all(tmpdir, mock_fetch, mock_packages, mock_archive,

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1927,7 +1927,7 @@ env:
       root: %s
       select: ['%%gcc']
       exclude: [callpath]
-      include_implicits: false
+      link: 'roots'
       projections:
         'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():
@@ -1968,7 +1968,6 @@ env:
       root: %s
       select: ['%%gcc']
       exclude: [callpath]
-      include_implicits: false
       link_type: copy
       projections:
         'all': '{name}/{version}-{compiler.name}'""" % viewdir)
@@ -2010,7 +2009,7 @@ env:
       root: %s
       select: ['%%gcc']
       exclude: [callpath]
-      include_implicits: true
+      link: 'all'
       projections:
         'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1948,7 +1948,7 @@ env:
                                  (spec.version, spec.compiler.name)))
 
 
-def test_view_type_copy(tmpdir, mock_fetch, mock_packages, mock_archive,
+def test_view_link_type_copy(tmpdir, mock_fetch, mock_packages, mock_archive,
                         install_mockery):
     filename = str(tmpdir.join('spack.yaml'))
     viewdir = str(tmpdir.join('view'))

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1927,7 +1927,7 @@ env:
       root: %s
       select: ['%%gcc']
       exclude: [callpath]
-      link: 'roots'
+      include_implicits: false
       projections:
         'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():
@@ -1968,7 +1968,7 @@ env:
       root: %s
       select: ['%%gcc']
       exclude: [callpath]
-      link: 'all'
+      include_implicits: true
       projections:
         'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1969,6 +1969,7 @@ env:
       select: ['%%gcc']
       exclude: [callpath]
       link_type: copy
+      link: 'roots'
       projections:
         'all': '{name}/{version}-{compiler.name}'""" % viewdir)
     with tmpdir.as_cwd():

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1973,7 +1973,7 @@ env:
             view_path = os.path.join(viewdir, spec.name)
             assert os.path.exists(view_path)
 
-            file_to_test = os.path.join(view_path, spec.name)
+            file_to_test = os.path.join(test.default_view.view()._root, spec.name)
 
             assert os.path.isfile(file_to_test)
             assert os.path.islink(file_to_test) == (link_type == 'symlink')


### PR DESCRIPTION
Add a syntax to specify view type as copy/symlink/hardlink.
This can stand with or without the commit by @vsoch which is in #24087. 