### PR TITLE
add `spack help --spec` to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Documentation
 [**Full documentation**](https://spack.readthedocs.io/) is available, or
 run `spack help` or `spack help --all`.
 
+For a cheat sheet on Spack syntax, run `spack help --spec`.
+
 Tutorial
 ----------------
 


### PR DESCRIPTION
We don't really advertise `spack help --spec` enough. I think the README is a good place to start doing that.