### PR TITLE
graphviz: add python dependency to fix installation

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -116,6 +116,8 @@ class Graphviz(AutotoolsPackage):
     depends_on('sed', type='build')
     depends_on('libtool', type='build')
     depends_on('pkgconfig', type='build')
+    # to process f-strings used in gen_version.py
+    depends_on('python@3.6:', when='@2.47:', type='build')
 
     conflicts('~doc',
               when='@:2.45',


### PR DESCRIPTION
On systems with python 3.5 or older graphviz does not build with the error message:
```
==> graphviz: Executing phase: 'autoreconf'
==> Error: ProcessError: Command exited with status 1:
    '/bin/bash' './autogen.sh' 'NOCONFIG'

1 error found in build log:
     1    ==> graphviz: Executing phase: 'autoreconf'
     2    ==> [2021-07-13-12:25:14.653339] '/bin/bash' './autogen.sh' 'NOCONFIG'
     3      File "gen_version.py", line 119
     4        print(f'#define BUILDDATE "{committer_date}"')
     5                                                    ^
     6    SyntaxError: invalid syntax
  >> 7    Error: Failed to set version
```
The bootstrap script in the autoreconf procedure calls the gen_version.py script which uses f-strings introduced in python 3.6. 