### PR TITLE
binary_distribution: relocate x-pie-executable files

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -583,7 +583,7 @@ def get_buildfile_manifest(spec):
                     added = True
 
             if relocate.needs_binary_relocation(m_type, m_subtype):
-                if ((m_subtype in ('x-executable', 'x-sharedlib')
+                if ((m_subtype in ('x-executable', 'x-sharedlib', 'x-pie-executable')
                     and sys.platform != 'darwin') or
                    (m_subtype in ('x-mach-binary')
                     and sys.platform == 'darwin') or


### PR DESCRIPTION
Add `x-pie-executable` to the list of files requiring relocation when installing from cache.

Ubuntu 21.04 ships with `file@5.39` and returns `application/x-pie-executable` as the MIME type for some files which were identified as `application/x-sharedlib` in earlier versions of `file`.

```
$> file --version
file-5.39

$> file -b -h --mime-type $(spack location -i pkgconf)/bin/pkgconf
application/x-pie-executable
```

```
$> spack load file@5.38
file-5.38

$> file -b -h --mime-type $(spack location -i pkgconf)/bin/pkgconf
application/x-sharedlib
```

@scottwittenburg @becker33 @gartung 