### PR TITLE
opempi: add cuda as explicit dependency

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -282,6 +282,8 @@ class Openmpi(AutotoolsPackage):
     depends_on('hwloc@:1.999', when='@:3.999.999 ~internal-hwloc')
 
     depends_on('hwloc +cuda', when='+cuda ~internal-hwloc')
+    # Still need cuda as dependent when using external hwloc
+    depends_on('cuda', when='+cuda ~internal-hwloc')
     depends_on('java', when='+java')
     depends_on('sqlite', when='+sqlite3@:1.11')
     depends_on('zlib', when='@3.0.0:')


### PR DESCRIPTION
When concretizing against an external hwloc, cuda disappears from the spec, causing openmpi configure to fail when looking for it. This adds cuda as an explicit dependency when +cuda~internal-hwloc is specified. 