### PR TITLE
py-rtree: add new version, fix runtime env

### DIFF
--- a/var/spack/repos/builtin/packages/libspatialindex/package.py
+++ b/var/spack/repos/builtin/packages/libspatialindex/package.py
@@ -13,3 +13,9 @@ class Libspatialindex(CMakePackage):
     url      = "https://github.com/libspatialindex/libspatialindex/tarball/1.8.5"
 
     version('1.8.5', sha256='271f0d1425c527fd7d8b4be45b27e9383b244047b5918225877105616e7c0ad2')
+
+    @property
+    def libs(self):
+        return find_libraries(
+            ['libspatialindex_c'], root=self.prefix, recursive=True, shared=True
+        )

--- a/var/spack/repos/builtin/packages/libspatialindex/package.py
+++ b/var/spack/repos/builtin/packages/libspatialindex/package.py
@@ -10,9 +10,12 @@ class Libspatialindex(CMakePackage):
     """C++ implementation of R*-tree, an MVR-tree and a TPR-tree with C API."""
 
     homepage = "https://libspatialindex.org/"
-    url      = "https://github.com/libspatialindex/libspatialindex/tarball/1.8.5"
+    url = "https://github.com/libspatialindex/libspatialindex/archive/refs/tags/1.8.5.tar.gz"
 
-    version('1.8.5', sha256='271f0d1425c527fd7d8b4be45b27e9383b244047b5918225877105616e7c0ad2')
+    version('1.9.3', sha256='7b44340a3edc55c11abfc453bb60f148b29f569cef9e1148583e76132e9c7379')
+    version('1.8.5', sha256='93cce77269612f45287b521d5afdfb245be2b93b8b6438d92f8b9e0bdb37059d')
+
+    depends_on('cmake@3.5.0:', type='build')
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -7,18 +7,21 @@ from spack import *
 
 
 class PyRtree(PythonPackage):
-    """Python interface to the RTREE.4 Library."""
-    homepage = "http://toblerity.org/rtree/"
+    """R-Tree spatial index for Python GIS."""
+
+    homepage = "https://github.com/Toblerity/rtree"
     pypi = "Rtree/Rtree-0.8.3.tar.gz"
 
+    version('0.9.7', sha256='be8772ca34699a9ad3fb4cfe2cfb6629854e453c10b3328039301bbfc128ca3e')
     version('0.8.3', sha256='6cb9cf3000963ea6a3db777a597baee2bc55c4fc891e4f1967f262cc96148649')
 
+    depends_on('python@3:', when='@0.9.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('libspatialindex')
+    depends_on('py-wheel', when='@0.9.4:', type='build')
+    depends_on('libspatialindex@1.8.5:')
 
     def setup_build_environment(self, env):
-        lib = self.spec['libspatialindex'].prefix.lib
-        env.set('SPATIALINDEX_LIBRARY',
-                join_path(lib, 'libspatialindex.%s'   % dso_suffix))
-        env.set('SPATIALINDEX_C_LIBRARY',
-                join_path(lib, 'libspatialindex_c.%s' % dso_suffix))
+        env.set('SPATIALINDEX_C_LIBRARY', self.spec['libspatialindex'].libs[0])
+
+    def setup_run_environment(self, env):
+        self.setup_build_environment(env)


### PR DESCRIPTION
Successfully builds and passes all import tests on Ubuntu 20.04 (WSL) with Python 3.8.11 and GCC 9.3.0.