### PR TITLE
py-jupyterlab, py-jupyter-server: fix version range

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -19,7 +19,7 @@ class PyJupyterServer(PythonPackage):
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-jinja2', type=('build', 'run'))
-    depends_on('py-tornado@6.1.0:', type=('build', 'run'))
+    depends_on('py-tornado@6.1:', type=('build', 'run'))
     depends_on('py-pyzmq@17:', type=('build', 'run'))
     depends_on('py-argon2-cffi', type=('build', 'run'))
     depends_on('py-ipython-genutils', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jupyterlab/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyterlab/package.py
@@ -27,7 +27,7 @@ class PyJupyterlab(PythonPackage):
     # @3:
     depends_on('py-ipython', when='@3:', type=('build', 'run'))
     depends_on('py-packaging', when='@3:', type=('build', 'run'))
-    depends_on('py-tornado@6.1.0:', when='@3:', type=('build', 'run'))
+    depends_on('py-tornado@6.1:', when='@3:', type=('build', 'run'))
     depends_on('py-jupyter-core', when='@3:', type=('build', 'run'))
     depends_on('py-jupyterlab-server@2.3:2.999', when='@3.0.9:', type=('build', 'run'))
     depends_on('py-jupyterlab-server@2.0:2.999', when='@3.0.0:3.0.8', type=('build', 'run'))


### PR DESCRIPTION
Using the original concretizer, trying to concretize py-jupyterlab fails with
```
==> Error: Invalid Version range: 6.1.0:6.1
```
because py-tornado does not have a 6.1.0 version but only a 6.1 one.