### PR TITLE
Fix namespace in exception constructor

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -662,7 +662,7 @@ class RepoPath(object):
         if namespace:
             fullspace = get_full_namespace(namespace)
             if fullspace not in self.by_namespace:
-                raise UnknownNamespaceError(spec.namespace)
+                raise UnknownNamespaceError(namespace)
             return self.by_namespace[fullspace]
 
         # If there's no namespace, search in the RepoPath.


### PR DESCRIPTION
`repo_for_pkg` accepts a `spec` argument that may be a spec or a string. The name and namespace are computed from that string or spec, and used throughout the method.

The exception raised when the repo is not found includes the namespace in its constructor. This PR fixes it to use `namespace` instead of `spec.namespace`, since the latter may not be a valid attribute if `spec` is a string.