### PR TITLE
OpenJDK: new version 16

### DIFF
--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -17,6 +17,10 @@ from spack.util.prefix import Prefix
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    '16.0.1': {
+        'Linux-aarch64': ('602b005074777df2a0b4306e20152a6446803edd87ccbab95b2f313c4d9be6ba', 'https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-aarch64_bin.tar.gz')},
+    '16.0.1': {
+        'Linux-x86_64': ('b1198ffffb7d26a3fdedc0fa599f60a0d12aa60da1714b56c1defbce95d8b235', 'https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz')},
     '11.0.9.1_1': {
         'Linux-ppc64le': ('d94b6b46a14ab0974b1c1b89661741126d8cf8a0068b471b8f5fa286a71636b1', 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.9.1_1.tar.gz')},
     '11.0.8_10': {
@@ -55,6 +59,7 @@ class Openjdk(Package):
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
 
+    provides('java@16', when='@16.0:16.99')
     provides('java@11', when='@11.0:11.99')
     provides('java@10', when='@10.0:10.99')
     provides('java@9', when='@9.0:9.99')

--- a/var/spack/repos/builtin/packages/openjdk/package.py
+++ b/var/spack/repos/builtin/packages/openjdk/package.py
@@ -18,8 +18,7 @@ from spack.util.prefix import Prefix
 
 _versions = {
     '16.0.1': {
-        'Linux-aarch64': ('602b005074777df2a0b4306e20152a6446803edd87ccbab95b2f313c4d9be6ba', 'https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-aarch64_bin.tar.gz')},
-    '16.0.1': {
+        'Linux-aarch64': ('602b005074777df2a0b4306e20152a6446803edd87ccbab95b2f313c4d9be6ba', 'https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-aarch64_bin.tar.gz'),
         'Linux-x86_64': ('b1198ffffb7d26a3fdedc0fa599f60a0d12aa60da1714b56c1defbce95d8b235', 'https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz')},
     '11.0.9.1_1': {
         'Linux-ppc64le': ('d94b6b46a14ab0974b1c1b89661741126d8cf8a0068b471b8f5fa286a71636b1', 'https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.9.1_1.tar.gz')},


### PR DESCRIPTION
The current version of OpenJDK is 16 and the `spack` config only has up to OpenJDK 11 (several years old!). As part of the a-hug hackathon, I've been making sure that a [Java-based application (GATK) is working](https://github.com/arm-hpc-user-group/Cloud-HPC-Hackathon-2021/pull/19). It seemed helpful to test performance against the latest OpenJDK version.

This PR adds in x86 and arm config for OpenJDK 16. I also added the provides mapping for `openjdk@16`. Same style as the previous versions of the config. These JDK downloads can be found at https://jdk.java.net/16/

You can see the new versions with `spack info openjdk`

```
[jayson@ip-10-0-0-37 spack]$ spack info openjdk
Package:   openjdk

Description:
    The free and opensource java implementation

Homepage: https://jdk.java.net

Externally Detectable:
    True (version, variants)

Tags:
    None

Preferred version:
    16.0.1           https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz

Safe versions:
    16.0.1           https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-x64_bin.tar.gz
    11.0.8_10        https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.8_10.tar.gz
    11.0.2           https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz
    11.0.1           https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz
    1.8.0_265-b01    https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u265b01.tar.gz
    1.8.0_222-b10    https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u222-b10_openj9-0.15.1/OpenJDK8U-jdk_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz
    1.8.0_202-b08    https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u202-b08/OpenJDK8U-jdk_x64_linux_openj9_8u202b08_openj9-0.12.0.tar.gz
    1.8.0_40-b25     https://download.java.net/openjdk/jdk8u40/ri/jdk_ri-8u40-b25-linux-x64-10_feb_2015.tar.gz

Variants:
    None

Installation Phases:
    install

Build Dependencies:
    None

Link Dependencies:
    None

Run Dependencies:
    None

Virtual Packages:
    openjdk@16.0:16.99 provides java@16
    openjdk@11.0:11.99 provides java@11
    openjdk@10.0:10.99 provides java@10
    openjdk@9.0:9.99 provides java@9
    openjdk@1.8.0:1.8.999 provides java@8
```

You can install and use OpenJDK 16 as follows.

```
# for x86 HPCs
spack install openjdk@16.0.1%gcc@10.3.0

# for ARM HPCs
spack install openjdk@16.0.1%arm@21.0.0.879
```

And then use it with `spack load openjdk@16.0.01`

```
[jayson@ip-10-0-0-37 spack]$ spack load openjdk@16.0.1

[jayson@ip-10-0-0-37 spack]$ java --version
openjdk 16.0.1 2021-04-20
OpenJDK Runtime Environment (build 16.0.1+9-24)
OpenJDK 64-Bit Server VM (build 16.0.1+9-24, mixed mode, sharing)

# go back to system default
[jayson@ip-10-0-0-37 spack]$ spack unload openjdk

[jayson@ip-10-0-0-37 spack]$ java -version
openjdk version "1.8.0_282"
OpenJDK Runtime Environment (build 1.8.0_282-b08)
OpenJDK 64-Bit Server VM (build 25.282-b08, mixed mode)
```