### PR TITLE
Remove `-Wmissing-format-attribute` from `libxslt` if compiling with `nvhpc`

### DIFF
--- a/var/spack/repos/builtin/packages/libxslt/package.py
+++ b/var/spack/repos/builtin/packages/libxslt/package.py
@@ -57,3 +57,8 @@ class Libxslt(AutotoolsPackage):
         if '+python' in self.spec:
             with working_dir('spack-test', create=True):
                 python('-c', 'import libxslt')
+
+    def patch(self):
+        # Remove flags not recognized by the NVIDIA compiler
+        if self.spec.satisfies('%nvhpc'):
+            filter_file('-Wmissing-format-attribute', '', 'configure')


### PR DESCRIPTION
The Nvidia compiler does not recognise `-Wmissing-format-attribute`, which makes the build fail. I think it's safe to remove it when compiling with NVHPC.