### PR TITLE
environment-modules: add version 4.8.0

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -10,10 +10,11 @@ class EnvironmentModules(Package):
     """
 
     homepage = 'https://cea-hpc.github.io/modules/'
-    url = 'https://github.com/cea-hpc/modules/releases/download/v4.7.1/modules-4.7.1.tar.gz'
+    url = 'https://github.com/cea-hpc/modules/releases/download/v4.8.0/modules-4.8.0.tar.gz'
 
     maintainers = ['xdelaruelle']
 
+    version('4.8.0', sha256='d6b45cadc2146ed5e0b25a96d44643ad516054eb7745acb14a1dc7bf30744f6e')
     version('4.7.1', sha256='ee7ecd62bbbde6d51e30788a97800c39e72515b6a910839fb84041b35ba42b4d')
     version('4.7.0', sha256='3ab0a649e23b4dd00963e4cae60e573b449194ecb4035c5ce487330b272b4d06')
     version('4.6.1', sha256='3445df39abe5838b94552b53e7dbff56ada8347b9fdc6c04a72297d5b04af76f')


### PR DESCRIPTION
New feature release in the v4 series.

Major new features included: https://modules.readthedocs.io/en/stable/MIGRATING.html#from-v4-7-to-v4-8