### PR TITLE
Revert "Updated flecsph to use up to date dependencies"

### DIFF
--- a/var/spack/repos/builtin/packages/flecsph/package.py
+++ b/var/spack/repos/builtin/packages/flecsph/package.py
@@ -22,10 +22,10 @@ class Flecsph(CMakePackage):
     variant('test', default=True, description='Adding tests')
 
     depends_on('cmake@3.15:', type='build')
-    depends_on('boost@1.70.0: cxxstd=17 +program_options')
+    depends_on('boost@1.70.0: cxxstd=14 +program_options')
     depends_on('mpi')
     depends_on('hdf5+hl@1.8:')
-    depends_on('flecsi@1.4.2 +external_cinch backend=mpi')
+    depends_on('flecsi@1 +cinch backend=mpi')
     depends_on('gsl')
     depends_on('googletest', when='+test')
     depends_on("pkgconfig", type='build')


### PR DESCRIPTION
Reverts spack/spack#24856

Another attempt to fix GitLab CI E4S pipelines