### PR TITLE
meme: fix compilation with `arm` and `nvhpc` compilers

### DIFF
--- a/var/spack/repos/builtin/packages/meme/arm.patch
+++ b/var/spack/repos/builtin/packages/meme/arm.patch
@@ -1,0 +1,36 @@
+--- a/src/mtwist.h	2021-07-14 12:18:25.848290454 +0000
++++ b/src/mtwist.h	2021-07-14 12:37:35.581368981 +0000
+@@ -285,6 +285,7 @@
+   prototypes using the ifdef.
+ */
+ #ifndef __APPLE__
++#ifndef __ARM_LINUX_COMPILER__
+ extern uint32_t		mts_lrand(mt_state* state);
+ 					/* Generate 32-bit value, any gen. */
+ #ifdef UINT64_MAX
+@@ -310,6 +311,7 @@
+ 					/* Generate floating value */
+ 					/* Slower, with 64-bit precision */
+ #endif
++#endif
+ 
+ /*
+  * Tempering parameters.  These are perhaps the most magic of all the magic
+@@ -381,10 +383,14 @@
+ #ifdef __cplusplus
+ #define MT_EXTERN			/* C++ doesn't need static */
+ #else /* __cplusplus */
+-#ifndef __APPLE__
+-#define MT_EXTERN	extern		/* C (at least gcc) needs extern */
+-#else
++#ifdef __APPLE__
+ #define MT_EXTERN	static 		/* The apple compiler freaks out if the definitions are not static */
++#else /* __APPLE__ */
++#ifdef __ARM_LINUX_COMPILER__
++#define MT_EXTERN	static 		/* The Arm compiler complains if the definitions are not static */
++#else /* __ARM_LINUX_COMPILER__ */
++#define MT_EXTERN	extern		/* C (at least gcc) needs extern */
++#endif /* __ARM_LINUX_COMPILER__ */
+ #endif /* __APPLE__ */
+ #endif /* __cplusplus */
+ #endif /* MT_EXTERN */

--- a/var/spack/repos/builtin/packages/meme/package.py
+++ b/var/spack/repos/builtin/packages/meme/package.py
@@ -43,8 +43,6 @@ class Meme(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        # have meme build its own versions of libxml2/libxslt, see #6736
-        #args = ['--enable-build-libxml2', '--enable-build-libxslt']
         args = []
         if '~mpi' in spec:
             args += ['--enable-serial']

--- a/var/spack/repos/builtin/packages/meme/package.py
+++ b/var/spack/repos/builtin/packages/meme/package.py
@@ -31,6 +31,10 @@ class Meme(AutotoolsPackage):
     depends_on('mpi', when='+mpi')
     depends_on('imagemagick', type=('build', 'run'), when='+image-magick')
     depends_on('perl-xml-parser', type=('build', 'run'))
+    depends_on('libxml2', type=('build', 'run'))
+    depends_on('libxslt', type=('build', 'run'))
+
+    patch('arm.patch', when='%arm')
 
     def url_for_version(self, version):
         url = 'http://meme-suite.org/meme-software/{0}/meme{1}{2}.tar.gz'
@@ -40,7 +44,14 @@ class Meme(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         # have meme build its own versions of libxml2/libxslt, see #6736
-        args = ['--enable-build-libxml2', '--enable-build-libxslt']
+        #args = ['--enable-build-libxml2', '--enable-build-libxslt']
+        args = []
         if '~mpi' in spec:
             args += ['--enable-serial']
         return args
+
+    def patch(self):
+        # Remove flags not recognized by the NVIDIA compiler
+        if self.spec.satisfies('%nvhpc'):
+            filter_file('-fno-common', '', 'configure')
+            filter_file('-Wno-unused', '', 'configure')


### PR DESCRIPTION
This commit (i) patches `meme` so that it compiles with `armclang` and (ii) modifies the `spack` `meme` package so that it uses the `spack` versions of `libxml2` and `libxslt`. Using the built-in versions of these packages was resulting in several linkage errors, at least when compiling with `nvhpc@21.2`.

I've successfully built this package with `arm@21.0.0.879`, `gcc@10.3.0`, and `nvhpc@21.2` (provided `libxslt` is patched as per #24873).