### PR TITLE
boost: Run `b2 headers` after a git clone

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -551,6 +551,10 @@ class Boost(Package):
 
         threading_opts = self.determine_b2_options(spec, b2_options)
 
+        # Create headers if building from a git checkout
+        if '@develop' in spec:
+            b2('headers', *b2_options)
+
         b2('--clean', *b2_options)
 
         # In theory it could be done on one call but it fails on


### PR DESCRIPTION
Closes https://github.com/spack/spack/issues/24888