### PR TITLE
PROJ: add v8.x

### DIFF
--- a/var/spack/repos/builtin/packages/proj/package.py
+++ b/var/spack/repos/builtin/packages/proj/package.py
@@ -20,6 +20,9 @@ class Proj(AutotoolsPackage):
     # Version 6 removes projects.h, while version 7 removes proj_api.h.
     # Many packages that depend on proj do not yet support the newer API.
     # See https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status
+    version('8.1.0', sha256='22c5cdc5aa0832077b16c95ebeec748a0942811c1c3438c33d43c8d2ead59f48')
+    version('8.0.1', sha256='e0463a8068898785ca75dd49a261d3d28b07d0a88f3b657e8e0089e16a0375fa')
+    version('8.0.0', sha256='aa5d4b934450149a350aed7e5fbac880e2f7d3fa2f251c26cb64228f96a2109e')
     version('7.2.1', sha256='b384f42e5fb9c6d01fe5fa4d31da2e91329668863a684f97be5d4760dbbf0a14')
     version('7.2.0', sha256='2957798e5fe295ff96a2af1889d0428e486363d210889422f76dd744f7885763')
     version('7.1.0', sha256='876151e2279346f6bdbc63bd59790b48733496a957bccd5e51b640fdd26eaa8d')


### PR DESCRIPTION
Successfully builds and passes all tests on Ubuntu 20.04 with GCC 9.3.0.

WARNING: This PR will likely break a LOT of packages. I don't have the bandwidth to test every package that depends on PROJ, but I'm hoping CI will catch some of the more important packages.