### PR TITLE
py-tensorflow: relax version requirements on py-gast

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -148,7 +148,7 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-backports-weakref@1.0rc1', type=('build', 'run'), when='@1.2.0:1.2.1')
     depends_on('py-enum34@1.1.6:', type=('build', 'run'), when='@1.5: ^python@:3.3')
     depends_on('py-enum34@1.1.6:', type=('build', 'run'), when='@1.4.0:1.4.1')
-    depends_on('py-gast@0.3.3', type=('build', 'run'), when='@2.2:')
+    depends_on('py-gast@0.3.3:', type=('build', 'run'), when='@2.2:')
     depends_on('py-gast@0.2.2', type=('build', 'run'), when='@1.15:2.1')
     depends_on('py-gast@0.2.0:', type=('build', 'run'), when='@1.6:1.14')
     depends_on('py-google-pasta@0.2:0.999', type=('build', 'run'), when='@2.4.0:')


### PR DESCRIPTION
Can we relax the version requirements on py-gast? At the moment this stop `py-pythran` from installing (which requires `py-gast` >=0.4)