### PR TITLE
py-beniget: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-beniget/package.py
+++ b/var/spack/repos/builtin/packages/py-beniget/package.py
@@ -12,8 +12,12 @@ class PyBeniget(PythonPackage):
     homepage = "https://github.com/serge-sans-paille/beniget/"
     pypi     = "beniget/beniget-0.3.0.tar.gz"
 
+    version('0.4.0', sha256='72bbd47b1ae93690f5fb2ad3902ce1ae61dcd868ce6cfbf33e9bad71f9ed8749')
     version('0.3.0', sha256='062c893be9cdf87c3144fb15041cce4d81c67107c1591952cd45fdce789a0ff1')
+    version('0.2.3', sha256='350422b0598c92fcc5f8bcaf77f2a62f6744fb8f2fb495b10a50176c1283639f')
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-gast@0.4.0:0.4.999', type=('build', 'run'))
+    depends_on('py-gast@0.5.0:0.5.999', when='@0.4.0:', type=('build', 'run'))
+    depends_on('py-gast@0.4.0:0.4.999', when='@0.3.0:0.3.999', type=('build', 'run'))
+    depends_on('py-gast@0.3.3:0.3.999', when='@:0.2.999', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.