### PR TITLE
gatk: require BWA and samtools

### DIFF
--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -100,6 +100,8 @@ class Gatk(Package):
     # output.
     variant('r', default=False, description='Use R for plotting')
 
+    depends_on("samtools", type="run")
+    depends_on("bwa", type="run")
     depends_on("java@8", type="run")
     depends_on("python@2.6:2.8,3.6:", type="run", when="@4.0:")
     depends_on("r@3.2:", type="run", when="@4.0: +r")


### PR DESCRIPTION
GATK requires `bwa` and `samtools` in its [best practices guide](https://gatk.broadinstitute.org/hc/en-us/articles/360041320571--How-to-Install-all-software-packages-required-to-follow-the-GATK-Best-Practices); however, the current spack package doesn't have them as dependencies. This PR adds them.

`gatk` still installs same as before
```
spack install gatk %gcc@10.3.0
```

Dependencies now have `bwa` and `samtools`
```
[jayson@ip-10-0-0-37 spack]$ spack spec -Il gatk@4.1.8.1 %gcc@10.3.0
Input spec
--------------------------------
 -   gatk@4.1.8.1%gcc@10.3.0

Concretized
--------------------------------
[+]  v6xcxol  gatk@4.1.8.1%gcc@10.3.0~r arch=linux-amzn2-skylake_avx512
[+]  ztpzyhm      ^bwa@0.7.17%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  q2x25kt          ^zlib@1.2.11%gcc@10.3.0+optimize+pic+shared arch=linux-amzn2-skylake_avx512
[+]  z77sgxs      ^openjdk@1.8.0_265-b01%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  p7mkxd4      ^python@3.8.11%gcc@10.3.0+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87 arch=linux-amzn2-skylake_avx512
[+]  s36txvt          ^bzip2@1.0.8%gcc@10.3.0~debug~pic+shared arch=linux-amzn2-skylake_avx512
[+]  kjoplsl              ^diffutils@3.7%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  qmzfn6j                  ^libiconv@1.16%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  256y6qy          ^expat@2.4.1%gcc@10.3.0+libbsd arch=linux-amzn2-skylake_avx512
[+]  mxgrkle              ^libbsd@0.11.3%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  aehweer                  ^libmd@1.0.3%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  fgwgsih          ^gdbm@1.19%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  i35suwy              ^readline@8.1%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  xbybdoz                  ^ncurses@6.2%gcc@10.3.0~symlinks+termlib abi=none arch=linux-amzn2-skylake_avx512
[+]  i665ooz                      ^pkgconf@1.7.4%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  vfg4fms          ^gettext@0.21%gcc@10.3.0+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-amzn2-skylake_avx512
[+]  mztzlil              ^libxml2@2.9.10%gcc@10.3.0~python arch=linux-amzn2-skylake_avx512
[+]  p7yqdpr                  ^xz@5.2.5%gcc@10.3.0~pic libs=shared,static arch=linux-amzn2-skylake_avx512
[+]  fajl3kg              ^tar@1.34%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  vv3r7pc          ^libffi@3.3%gcc@10.3.0 patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0 arch=linux-amzn2-skylake_avx512
[+]  larjnul          ^openssl@1.1.1k%gcc@10.3.0~docs+systemcerts arch=linux-amzn2-skylake_avx512
[+]  fb3kjch              ^perl@5.32.1%gcc@10.3.0+cpanm+shared+threads arch=linux-amzn2-skylake_avx512
[+]  i5lbkjo                  ^berkeley-db@18.1.40%gcc@10.3.0+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=linux-amzn2-skylake_avx512
[+]  6ox5zyb          ^sqlite@3.35.5%gcc@10.3.0+column_metadata+fts~functions~rtree arch=linux-amzn2-skylake_avx512
[+]  uzq2g5d          ^util-linux-uuid@2.36.2%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  wy7qefd      ^samtools@1.12%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  pbccjac          ^htslib@1.12%gcc@10.3.0+libcurl arch=linux-amzn2-skylake_avx512
[+]  zf3o4dn              ^curl@7.76.1%gcc@10.3.0~darwinssl~gssapi~libssh~libssh2~nghttp2 arch=linux-amzn2-skylake_avx512
[+]  rkhja6k                  ^libidn2@2.3.0%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
[+]  wnpqqe5                      ^libunistring@0.9.10%gcc@10.3.0 arch=linux-amzn2-skylake_avx512
```