### PR TITLE
mpas-model: support Intel compiler

### DIFF
--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -55,6 +55,12 @@ class MpasModel(MakefilePackage):
                 '-Fwide',
                 '-CcdRR8',
             ])
+        elif satisfies('%intel'):
+            fflags.extend([
+                '-r8',
+                '-convert big_endian',
+                '-FR',
+            ])
             cppflags.append('-DUNDERSCORE')
         targets = [
             'FC_PARALLEL={0}'.format(spec['mpi'].mpifc),

--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -14,6 +14,7 @@ class MpasModel(MakefilePackage):
 
     homepage = "https://mpas-dev.github.io/"
     url = "https://github.com/MPAS-Dev/MPAS-Model/archive/v7.0.tar.gz"
+    maintainers = ['t-brown']
 
     version('7.0', sha256='f898ce257e66cff9e29320458870570e55721d16cb000de7f2cc27de7fdef14f')
     version('6.3', sha256='e7f1d9ebfeb6ada37d42a286aaedb2e69335cbc857049dc5c5544bb51e7a8db8')


### PR DESCRIPTION
Would it be possible to add support to compile the MPAS model with the Intel compiler?