### PR TITLE
darshan runtime,darshan-util: convert to autotool packages

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -7,6 +7,7 @@ import os
 
 from spack import *
 
+
 class DarshanRuntime(AutotoolsPackage):
     """Darshan (runtime) is a scalable HPC I/O characterization tool
     designed to capture an accurate picture of application I/O behavior,

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -7,8 +7,7 @@ import os
 
 from spack import *
 
-
-class DarshanRuntime(Package):
+class DarshanRuntime(AutotoolsPackage):
     """Darshan (runtime) is a scalable HPC I/O characterization tool
     designed to capture an accurate picture of application I/O behavior,
     including properties such as patterns of access within files, with
@@ -38,6 +37,10 @@ class DarshanRuntime(Package):
     depends_on('zlib')
     depends_on('hdf5', when='+hdf5')
     depends_on('papi', when='+apxc')
+    depends_on('autoconf', type='build', when='@main')
+    depends_on('automake', type='build', when='@main')
+    depends_on('libtool',  type='build', when='@main')
+    depends_on('m4',       type='build', when='@main')
 
     variant('mpi', default=True, description='Compile with MPI support')
     variant('hdf5', default=False, description='Compile with HDF5 module')
@@ -61,7 +64,13 @@ class DarshanRuntime(Package):
     conflicts('+apxc', when='@:3.2.1',
               msg='+apxc variant only available starting from version 3.3.0')
 
-    def install(self, spec, prefix):
+    @property
+    def configure_directory(self):
+        return 'darshan-runtime'
+
+    def configure_args(self):
+        spec = self.spec
+        extra_args = []
 
         job_id = 'NONE'
         if '+slurm' in spec:
@@ -73,34 +82,31 @@ class DarshanRuntime(Package):
         if '+sge' in spec:
             job_id = 'JOB_ID'
 
-        # TODO: BG-Q and other platform configure options
-        options = []
-        if '+mpi' in spec:
-            options = ['CC=%s' % spec['mpi'].mpicc]
-        else:
-            options = ['--without-mpi']
-
         if '+hdf5' in spec:
-            options.extend(['--enable-hdf5-mod=%s' % spec['hdf5'].prefix])
-
+            if self.version < Version('3.3.2'):
+                extra_args.append('--enable-hdf5-mod=%s' % spec['hdf5'].prefix)
+            else:
+                extra_args.append('--enable-hdf5-mod')
         if '+apmpi' in spec:
-            options.extend(['--enable-apmpi-mod'])
+            extra_args.append('--enable-apmpi-mod')
         if '+apmpi_sync' in spec:
-            options.extend(['--enable-apmpi-mod',
-                            '--enable-apmpi-coll-sync'])
+            extra_args.append(['--enable-apmpi-mod',
+                               '--enable-apmpi-coll-sync'])
         if '+apxc' in spec:
-            options.extend(['--enable-apxc-mod'])
+            extra_args.append(['--enable-apxc-mod'])
 
-        options.extend(['--with-mem-align=8',
-                        '--with-log-path-by-env=DARSHAN_LOG_DIR_PATH',
-                        '--with-jobid-env=%s' % job_id,
-                        '--with-zlib=%s' % spec['zlib'].prefix])
+        extra_args.append('--with-mem-align=8')
+        extra_args.append('--with-log-path-by-env=DARSHAN_LOG_DIR_PATH')
+        extra_args.append('--with-jobid-env=%s' % job_id)
+        extra_args.append('--with-zlib=%s' % spec['zlib'].prefix)
 
-        with working_dir('spack-build', create=True):
-            configure = Executable('../darshan-runtime/configure')
-            configure('--prefix=%s' % prefix, *options)
-            make()
-            make('install')
+        if '+mpi' in spec:
+            extra_args.append('CC=%s' % self.spec['mpi'].mpicc)
+        else:
+            extra_args.append('CC=%s' % self.compiler.cc)
+            extra_args.append('--without-mpi')
+
+        return extra_args
 
     def setup_run_environment(self, env):
         # default path for log file, could be user or site specific setting

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class DarshanUtil(Package):
+class DarshanUtil(AutotoolsPackage):
     """Darshan (util) is collection of tools for parsing and summarizing log
     files produced by Darshan (runtime) instrumentation. This package is
     typically installed on systems (front-end) where you intend to analyze
@@ -32,12 +32,15 @@ class DarshanUtil(Package):
     version('3.0.0', sha256='95232710f5631bbf665964c0650df729c48104494e887442596128d189da43e0')
 
     variant('bzip2', default=False, description="Enable bzip2 compression")
-    variant('shared', default=True, description='Build shared libraries')
     variant('apmpi', default=False, description='Compile with AutoPerf MPI module support')
     variant('apxc', default=False, description='Compile with AutoPerf XC module support')
 
     depends_on('zlib')
     depends_on('bzip2', when="+bzip2", type=("build", "link", "run"))
+    depends_on('autoconf', type='build', when='@main')
+    depends_on('automake', type='build', when='@main')
+    depends_on('libtool',  type='build', when='@main')
+    depends_on('m4',       type='build', when='@main')
 
     patch('retvoid.patch', when='@3.2.0:3.2.1')
 
@@ -46,20 +49,25 @@ class DarshanUtil(Package):
     conflicts('+apxc', when='@:3.2.1',
               msg='+apxc variant only available starting from version 3.3.0')
 
-    def install(self, spec, prefix):
+    @property
+    def configure_directory(self):
+        return 'darshan-util'
 
-        options = ['CC=%s' % self.compiler.cc,
-                   '--with-zlib=%s' % spec['zlib'].prefix]
-        if '+shared' in spec:
-            options.extend(['--enable-shared'])
+    def configure_args(self):
+        spec = self.spec
+        extra_args = []
 
+        extra_args.append('CC=%s' % self.compiler.cc)
+        extra_args.append('--with-zlib=%s' % spec['zlib'].prefix)
         if '+apmpi' in spec:
-            options.extend(['--enable-autoperf-apmpi'])
+            if self.version < Version('3.3.2'):
+                extra_args.append('--enable-autoperf-apmpi')
+            else:
+                extra_args.append('--enable-apmpi-mod')
         if '+apxc' in spec:
-            options.extend(['--enable-autoperf-apxc'])
+            if self.version < Version('3.3.2'):
+                extra_args.append('--enable-autoperf-apxc')
+            else:
+                extra_args.append('--enable-apxc-mod')
 
-        with working_dir('spack-build', create=True):
-            configure = Executable('../darshan-util/configure')
-            configure('--prefix=%s' % prefix, *options)
-            make()
-            make('install')
+        return extra_args


### PR DESCRIPTION
Darshan's codebase has just been updated to utilize automake, and thus makes sense to convert Darshan's packages into `AutotoolsPackage`s. 

Most of the changes are obvious to convert to `AutotoolsPackage`, but also includes changes to some of Darshan's configure parameters that occurred as part of a general revamp of the Darshan build system.
- darshan-runtime HDF5 module is enabled slightly differently (`--enable-hdf5-mod` no longer takes an argument)
- `--enable-shared` no longer a supported option for darshan-util -- shared libraries will just be built if libtool determines it can do so
- darshan-util has new configure options for enabling APMPI and APXC modules