### PR TITLE
Allow matching specs with wildcards

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -77,6 +77,7 @@ specs to avoid ambiguity.  Both are provided because ~ can cause shell
 expansion when it is the first character in an id typed on the command line.
 """
 import collections
+import fnmatch
 import itertools
 import operator
 import os
@@ -3198,7 +3199,8 @@ class Spec(object):
             return self.concrete and self.dag_hash() == other.dag_hash()
 
         # If the names are different, we need to consider virtuals
-        if self.name != other.name and self.name and other.name:
+        if (self.name != other.name and self.name and other.name and
+                not fnmatch.fnmatchcase(self.name, other.name)):
             # A concrete provider can satisfy a virtual dependency.
             if not self.virtual and other.virtual:
                 try:
@@ -4394,7 +4396,7 @@ class LazySpecCache(collections.defaultdict):
 HASH, DEP, AT, COLON, COMMA, ON, OFF, PCT, EQ, ID, VAL, FILE = range(12)
 
 #: Regex for fully qualified spec names. (e.g., builtin.hdf5)
-spec_id_re = r'\w[\w.-]*'
+spec_id_re = r'[\w*][\w*.-]*'
 
 
 class SpecLexer(spack.parse.Lexer):


### PR DESCRIPTION
It would be useful to be able to match specs by glob/wildcard in some contexts.  For example, you could easily create a view with all python packages (`select: py-*`), or change the projection for R packages (`r-*: R/{name}/{version}`), or uninstall `intel-oneapi-*`.

This is less a PR and more a feature request with a proof-of-concept implementation. This simple change works fine for the basic case, but doesn't cover namespaces properly and allows `*` some places it probably shouldn't be. It might also be nice to allow full globs (`?[]`).

If this seems useful, I'm happy to work this into a full implementation with some guidance, including proper checks, tests, and documenation.