### PR TITLE
e4s ci: trilinos: build trilinos with all variants on

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -283,7 +283,7 @@ spack:
     # - sz
     # - tasmanian
     # - tau
-    # - trilinos
+    #- trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +teuchos +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long
     # - turbine
     # - umap
     # - unifyfs@0.9.1

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -284,8 +284,7 @@ spack:
     - sz
     - tasmanian
     - tau
-    - trilinos
-    - trilinos +nox +superlu-dist
+    - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +teuchos +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long
     - turbine
     - umap
     - unifyfs@0.9.1


### PR DESCRIPTION
Build `trilinos` with all variants turned on

@sethrj this PR is needed to actually change what is built as part of the PR- and merge-to-develop E4S pipelines on github.com/spack/spack

@zackgalbreath @alalazo 