### PR TITLE
intel-oneapi: fix parallel installer errors

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -69,6 +69,9 @@ class IntelOneApiPackage(Package):
 
             # Installer writes files in ~/intel set HOME so it goes to prefix
             bash.add_default_env('HOME', prefix)
+            # Installer checks $XDG_RUNTIME_DIR/.bootstrapper_lock_file as well
+            bash.add_default_env('XDG_RUNTIME_DIR',
+                                 join_path(self.stage.path, 'runtime'))
 
             bash(installer_path,
                  '-s', '-a', '-s', '--action', 'install',


### PR DESCRIPTION
When installing intel-oneapi components in parallel, we often get errors about "Another program is being installed". From the intel installer log:
```
07/15/2021 13:22:33:153 : 2111733 : MESSAGE : PreRequisite for no other Intel install begin [PreRequisiteRequireNoOtherIntelInstall]
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <SingleInstance> lockFile: '/tmp/runtime-spack/.bootstrapper_lock_file'
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <SingleInstance> tryLock status: '1'
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <MetaVariablesManager> Resolving all names, Input text is 'Another program is being installed.'
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <MetaVariablesManager> Resolving all names, Output text is 'Another program is being installed.'                                                             07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <MetaVariablesManager> Resolving all names, Input text is 'Wait until that installation is complete, and then try installing this software again.'           07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <MetaVariablesManager> Resolving all names, Output text is 'Wait until that installation is complete, and then try installing this software again.'          07/15/2021 13:22:33:178 : 2111733 : WARNING : No other Intel installs required
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : Error [Another program is being installed.]
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : Description [Wait until that installation is complete, and then try installing this software again.]                                                         07/15/2021 13:22:33:178 : 2111733 : MESSAGE : PreRequisite for no other Intel install end [PreRequisiteRequireNoOtherIntelInstall]                                                                         07/15/2021 13:22:33:178 : 2111733 : WARNING : <Bootstrapper> Prerequisite 'Require no other Intel install' has an error!
07/15/2021 13:22:33:178 : 2111733 : WARNING : <Bootstrapper> The error descriptions of the 'require-no-other-intel-install' prerequisite:Wait until that installation is complete, and then try installing
this software again.
07/15/2021 13:22:33:178 : 2111733 : WARNING : <Bootstrapper> * 'Wait until that installation is complete, and then try installing this software again.'
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : PreRequisite for permissions begin [PreRequisitePermission]
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : Check path [/cm/shared/sw/spack/20210715/linux-centos7-broadwell/gcc-7.5.0/intel-oneapi-mpi-2021.3.0-w2dgtifuy6abqu2pgey2yxphykjap42b/intel/oneapi/installer]
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : Path exists
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : Check path [/cm/shared/sw/spack/20210715/linux-centos7-broadwell/gcc-7.5.0/intel-oneapi-mpi-2021.3.0-w2dgtifuy6abqu2pgey2yxphykjap42b/intel/packagemanager/1.0]
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : PreRequisite for permissions passed
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : PreRequisite for permissions end [PreRequisitePermission]
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <Bootstrapper> Prerequisite 'Permission' is correct!
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : PreRequisite for admin rights begin [PreRequisiteRequireAdminRights]
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : PreRequisite for admin rights successfully checked
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : PreRequisite for admin rights end [PreRequisiteRequireAdminRights]
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <Bootstrapper> Prerequisite 'Required Admin Rights' is correct!
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <Bootstrapper> Prerequisite 'Supported OS' is correct!
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <Bootstrapper> CHECKING PREREQUISITES IS FINISHED
07/15/2021 13:22:33:178 : 2111733 : ERROR : CommandLineController - Requirements check failed, exiting.
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : Error:
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : System requirements are not met.
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : Another program is being installed.:
Wait until that installation is complete, and then try installing this software again.
07/15/2021 13:22:33:178 : 2111733 : MESSAGE : <Bootstrapper> >>> THE BOOTSTRAPPER FINISHED WITH CODE 1 <<<
```
The spack logs also note:
```
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-spack'
```
which is apparently where the `/tmp/runtime-spack/.bootstrapper_lock_file` path above comes from.  Setting XDG_RUNTIME_DIR to somewhere specific to the install (in this case the staging directory) seems to fix it.