### PR TITLE
makes cuda a direct dependency, so it still shows up when using exter…

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -185,7 +185,8 @@ class Hdf5(AutotoolsPackage):
 
         # Quiet warnings/errors about implicit declaration of functions in C99
         if name == "cflags":
-            if "clang" in self.compiler.cc or "gcc" in self.compiler.cc:
+            if ("clang" in self.compiler.cc or "gcc" in self.compiler.cc)\
+                and not "nvc" in self.compiler.cc:
                 flags.append("-Wno-implicit-function-declaration")
 
         return (None, None, flags)

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -282,6 +282,8 @@ class Openmpi(AutotoolsPackage):
     depends_on('hwloc@:1.999', when='@:3.999.999 ~internal-hwloc')
 
     depends_on('hwloc +cuda', when='+cuda ~internal-hwloc')
+    # Still need cuda as dependent when using external hwloc
+    depends_on('cuda', when='+cuda ~internal-hwloc')
     depends_on('java', when='+java')
     depends_on('sqlite', when='+sqlite3@:1.11')
     depends_on('zlib', when='@3.0.0:')


### PR DESCRIPTION
The compiler in use is currently detected from: 

``` 
self.compiler.cc =  /gpfs/mira-home/willmore/spack/opt/spack/linux-ubun
tu18.04-x86_64/gcc-7.5.0/nvhpc-21.5-c4a4ab5yemaxeibnhtqzqfmvepmm2gv5/Linux_x86_6
4/21.5/compilers/bin/nvc
```

This is a hacky patch that correct for the use case where the compiler being used (e.g. nvhpc in my case) is falsely detected as gcc or clang because it was built with gcc or clang. I'm asking around to see if there's a better way to detect, will update if I learn more. 
