### PR TITLE
comd: fix +openmp -mpi

### DIFF
--- a/var/spack/repos/builtin/packages/comd/package.py
+++ b/var/spack/repos/builtin/packages/comd/package.py
@@ -36,14 +36,17 @@ class Comd(MakefilePackage):
     conflicts('+openmp', when='+mpi')
 
     def edit(self, spec, prefix):
-        with working_dir('src-mpi') or working_dir('src-openmp'):
+        with working_dir('src-openmp'):
+            copy('Makefile.vanilla', 'Makefile')
+        with working_dir('src-mpi'):
             copy('Makefile.vanilla', 'Makefile')
 
     @property
     def build_targets(self):
         targets = []
         cflags = ' -std=c99 '
-        optflags = ' -g -O5 '
+        optflags = ' -g -O5 -Ofast'
+
         clib = ' -lm '
         comd_variant = 'CoMD'
         cc = spack_cc
@@ -56,7 +59,7 @@ class Comd(MakefilePackage):
                 comd_variant += '-mpi'
                 targets.append('CC = {0}'.format(self.spec['mpi'].mpicc))
             else:
-                targets.append('CC = {0}'.format('spack_cc'))
+                targets.append(f'CC = {spack_cc}')
 
         else:
             targets.append('--directory=src-mpi')


### PR DESCRIPTION
This fixes two issues in the `spack` package for CoMD (aka `comd`). Both appear to be typos.

* A copy of `Make.vanilla` would not happen in the `with ... or ...:` for the second thing, namely OpenMP
* `'spack_cc'` is incorrectly quoted, which prevents the variable from being evaluated to the correct compiler. Removing the quotes fixes this. 

`comd` will compile with its default `spack install comd`; however, this form isn't very helpful as it relies on MPI and `comd`'s implementation has limitations on scaling that. OpenMP in `comd` appears to be more helpful and requires compiling with `spack install comd +openmp -mpi` since MPI and OMP conflict in `comd`.

With this PR you can now compile on `arm`, `nvhpc` and `gcc` compilers and run CoMD-openmp` scaling tests that show OpenMP works.

```
[jayson@ip-10-0-0-176 spack]$ spack install comd@1.1%gcc@10.3.0 +openmp -mpi
==> Installing comd-1.1-luecpbxvvbzkc5eqkfkz3poc2nptxoeo
==> No binary for comd-1.1-luecpbxvvbzkc5eqkfkz3poc2nptxoeo found: installing from source
==> Using cached archive: /scratch/home/jayson/spack/var/spack/cache/_source-cache/archive/4e/4e85f86f043681a1ef72940fc24a4c71356a36afa45446f7cfe776abad6aa252.tar.gz
==> No patches needed for comd
==> comd: Executing phase: 'edit'
==> comd: Executing phase: 'build'
==> comd: Executing phase: 'install'
==> comd: Successfully installed comd-1.1-luecpbxvvbzkc5eqkfkz3poc2nptxoeo
  Fetch: 0.00s.  Build: 0.23s.  Total: 0.23s.
[+] /scratch/opt/spack/linux-amzn2-graviton2/gcc-10.3.0/comd-1.1-luecpbxvvbzkc5eqkfkz3poc2nptxoeo

[jayson@ip-10-0-0-176 spack]$ spack install comd@1.1%nvhpc@21.2 +openmp -mpi
==> Installing comd-1.1-ji2nrex5f44n7keyzwkt3okhdozygkzz
==> No binary for comd-1.1-ji2nrex5f44n7keyzwkt3okhdozygkzz found: installing from source
==> Using cached archive: /scratch/home/jayson/spack/var/spack/cache/_source-cache/archive/4e/4e85f86f043681a1ef72940fc24a4c71356a36afa45446f7cfe776abad6aa252.tar.gz
==> No patches needed for comd
==> comd: Executing phase: 'edit'
==> comd: Executing phase: 'build'
==> comd: Executing phase: 'install'
==> comd: Successfully installed comd-1.1-ji2nrex5f44n7keyzwkt3okhdozygkzz
  Fetch: 0.00s.  Build: 0.42s.  Total: 0.42s.

[+] /scratch/opt/spack/linux-amzn2-graviton2/nvhpc-21.2/comd-1.1-ji2nrex5f44n7keyzwkt3okhdozygkzz
[jayson@ip-10-0-0-176 spack]$ spack install comd@1.1%arm@21.0.0.879 +openmp -mpi
==> Warning: arm@21.0.0.879 cannot build optimized binaries for "graviton2". Using best target possible: "aarch64"
==> Installing comd-1.1-phpsqbdm2lucpiarf7j5rd2m22owszc5
==> No binary for comd-1.1-phpsqbdm2lucpiarf7j5rd2m22owszc5 found: installing from source
==> Using cached archive: /scratch/home/jayson/spack/var/spack/cache/_source-cache/archive/4e/4e85f86f043681a1ef72940fc24a4c71356a36afa45446f7cfe776abad6aa252.tar.gz
==> No patches needed for comd
==> comd: Executing phase: 'edit'
==> comd: Executing phase: 'build'
==> comd: Executing phase: 'install'
==> comd: Successfully installed comd-1.1-phpsqbdm2lucpiarf7j5rd2m22owszc5
  Fetch: 0.00s.  Build: 0.23s.  Total: 0.23s.
[+] /scratch/opt/spack/linux-amzn2-aarch64/arm-21.0.0.879/comd-1.1-phpsqbdm2lucpiarf7j5rd2m22owszc5
```