### PR TITLE
boost: conflict with GCC on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -198,6 +198,14 @@ class Boost(Package):
     # Container's Extended Allocators were not added until 1.56.0
     conflicts('+container', when='@:1.55.99')
 
+    # Boost.System till 1.76 (included) was relying on mutex, which was not
+    # detected correctly on Darwin platform when using GCC
+    #
+    # More details here:
+    # https://github.com/STEllAR-GROUP/hpx/issues/5442#issuecomment-878889166
+    # https://github.com/STEllAR-GROUP/hpx/issues/5442#issuecomment-878913339
+    conflicts('%gcc', when='@:1.76 platform=darwin')
+
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11856
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -204,7 +204,7 @@ class Boost(Package):
     # More details here:
     # https://github.com/STEllAR-GROUP/hpx/issues/5442#issuecomment-878889166
     # https://github.com/STEllAR-GROUP/hpx/issues/5442#issuecomment-878913339
-    conflicts('%gcc', when='@:1.76 platform=darwin')
+    conflicts('%gcc', when='@:1.76 +system platform=darwin')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11856
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')


### PR DESCRIPTION
See the comments for a more detailed explanation of the conflict.

https://github.com/STEllAR-GROUP/hpx/issues/5442#issuecomment-878889166
https://github.com/STEllAR-GROUP/hpx/issues/5442#issuecomment-878913339

@msimberg is it what you found out, right?