### PR TITLE
Update package to reflect conflict with nvhpc

### DIFF
--- a/var/spack/repos/builtin/packages/random123/package.py
+++ b/var/spack/repos/builtin/packages/random123/package.py
@@ -22,6 +22,7 @@ class Random123(Package):
     patch('ibmxl.patch', when='@1.09')
     patch('arm-gcc.patch', when='@1.09')
     patch('v1132-xl161.patch', when='@1.13.2')
+    conflicts('%nvhpc')
 
     def install(self, spec, prefix):
         # Random123 doesn't have a build system.


### PR DESCRIPTION
nvhpc does not support ACLE (Arm C Language Extensiosn) for Neon intrinsic which this app uses so it won't compile with nvhpc.
This would make the error clear (it would've saved me some time trying to debug long unhelpful cmake errors).