### PR TITLE
py-tensorflow: fixing vector conversion error on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -148,7 +148,7 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-backports-weakref@1.0rc1', type=('build', 'run'), when='@1.2.0:1.2.1')
     depends_on('py-enum34@1.1.6:', type=('build', 'run'), when='@1.5: ^python@:3.3')
     depends_on('py-enum34@1.1.6:', type=('build', 'run'), when='@1.4.0:1.4.1')
-    depends_on('py-gast@0.3.3:', type=('build', 'run'), when='@2.2:')
+    depends_on('py-gast@0.3.3', type=('build', 'run'), when='@2.2:')
     depends_on('py-gast@0.2.2', type=('build', 'run'), when='@1.15:2.1')
     depends_on('py-gast@0.2.0:', type=('build', 'run'), when='@1.6:1.14')
     depends_on('py-google-pasta@0.2:0.999', type=('build', 'run'), when='@2.4.0:')

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -148,7 +148,7 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-backports-weakref@1.0rc1', type=('build', 'run'), when='@1.2.0:1.2.1')
     depends_on('py-enum34@1.1.6:', type=('build', 'run'), when='@1.5: ^python@:3.3')
     depends_on('py-enum34@1.1.6:', type=('build', 'run'), when='@1.4.0:1.4.1')
-    depends_on('py-gast@0.3.3', type=('build', 'run'), when='@2.2:')
+    depends_on('py-gast@0.3.3:', type=('build', 'run'), when='@2.2:')
     depends_on('py-gast@0.2.2', type=('build', 'run'), when='@1.15:2.1')
     depends_on('py-gast@0.2.0:', type=('build', 'run'), when='@1.6:1.14')
     depends_on('py-google-pasta@0.2:0.999', type=('build', 'run'), when='@2.4.0:')

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -558,10 +558,11 @@ class PyTensorflow(Package, CudaPackage):
         # see third_party/systemlibs/jsoncpp.BUILD
         env.set('INCLUDEDIR', spec['protobuf'].prefix.include)
 
-        # fixing https://stackoverflow.com/questions/56055359/tensorflow-lite-arm64-error-cannot-convert-const-int8x8-t
-        if spec.satisfies('target=aarch64'):
-            env.set("CXXFLAGS", "-flax-vector-conversions -fomit-frame-pointer")
-            env.set("CFLAGS", "-flax-vector-conversions -fomit-frame-pointer")
+    # fixing https://stackoverflow.com/questions/56055359/tensorflow-lite-arm64-error-cannot-convert-const-int8x8-t
+    def inject_flags(self, name, flags):
+        if self.spec.satisfies('target=aarch64') and (name in ["cxxflags", "cflags"]):
+            return ([*flags, "-flax-vector-conversions", "-fomit-frame-pointer"], None, None)
+        return (flags, None, None)
 
     def patch(self):
         if self.spec.satisfies('@2.3.0:'):

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -558,6 +558,11 @@ class PyTensorflow(Package, CudaPackage):
         # see third_party/systemlibs/jsoncpp.BUILD
         env.set('INCLUDEDIR', spec['protobuf'].prefix.include)
 
+        # fixing https://stackoverflow.com/questions/56055359/tensorflow-lite-arm64-error-cannot-convert-const-int8x8-t
+        if spec.satisfies('target=aarch64'):
+            env.set("CXXFLAGS", "-flax-vector-conversions -fomit-frame-pointer")
+            env.set("CFLAGS", "-flax-vector-conversions -fomit-frame-pointer")
+
     def patch(self):
         if self.spec.satisfies('@2.3.0:'):
             filter_file('deps = protodeps + well_known_proto_libs(),',


### PR DESCRIPTION
I recently encountered this error while building py-tensorflow https://stackoverflow.com/questions/56055359/tensorflow-lite-arm64-error-cannot-convert-const-int8x8-t , hope this pull request can fix it. 