### PR TITLE
MSVC with Intel Fortran compilers

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -213,7 +213,6 @@ def find_compilers(path_hints=None):
     for o in all_os_classes():
         search_paths = getattr(o, 'compiler_search_paths', default_paths)
         arguments.extend(arguments_to_detect_version_fn(o, search_paths))
-
     # Here we map the function arguments to the corresponding calls
     tp = multiprocessing.pool.ThreadPool()
     try:

--- a/lib/spack/spack/compilers/intel.py
+++ b/lib/spack/spack/compilers/intel.py
@@ -3,22 +3,23 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
 from spack.compiler import Compiler, UnsupportedCompilerFlag
 from spack.version import ver
 
 
 class Intel(Compiler):
     # Subclasses use possible names of C compiler
-    cc_names = ['icc']
+    cc_names = ['icc', 'icc.exe']
 
     # Subclasses use possible names of C++ compiler
-    cxx_names = ['icpc']
+    cxx_names = ['icpc', 'icpc.exe']
 
     # Subclasses use possible names of Fortran 77 compiler
-    f77_names = ['ifort']
+    f77_names = ['ifort', 'ifx.exe']
 
     # Subclasses use possible names of Fortran 90 compiler
-    fc_names = ['ifort']
+    fc_names = ['ifort', 'ifx.exe']
 
     # Named wrapper links within build_env_path
     link_paths = {'cc': 'intel/icc',
@@ -29,8 +30,15 @@ class Intel(Compiler):
     PrgEnv = 'PrgEnv-intel'
     PrgEnv_compiler = 'intel'
 
-    version_argument = '--version'
-    version_regex = r'\((?:IFORT|ICC)\) ([^ ]+)'
+    if sys.platform == 'win32':
+        version_argument = '/QV'
+    else:
+        version_argument = '--version'
+    
+    if sys.platform == 'win32':
+        version_regex = '([1-9][0-9]*\.[0-9]*\.[0-9]*)'
+    else:        
+        version_regex = r'\((?:IFORT|ICC)\) ([^ ]+)'
 
     @property
     def verbose_flag(self):

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -6,10 +6,14 @@
 import os
 import subprocess
 import sys
+import re
+
+import llnl.util.lang
 from typing import List  # novm
 
 from spack.compiler import Compiler
-
+import spack.util.executable
+import spack.operating_systems.windows_os
 
 class Msvc(Compiler):
     # Subclasses use possible names of C compiler
@@ -19,19 +23,23 @@ class Msvc(Compiler):
     cxx_names = ['cl.exe']
 
     # Subclasses use possible names of Fortran 77 compiler
-    f77_names = []  # type: List[str]
+    f77_names = ['ifx.exe']  # type: List[str]
 
     # Subclasses use possible names of Fortran 90 compiler
-    fc_names = []  # type: List[str]
+    fc_names = ['ifx.exe']  # type: List[str]
 
     # Named wrapper links within build_env_path
     link_paths = {'cc': 'msvc/cl.exe',
                   'cxx': 'msvc/cl.exe',
-                  'f77': '',
-                  'fc': ''}
+                  'f77': 'intel/ifx.exe',
+                  'fc': 'intel/ifx.exe'}
 
     #: Compiler argument that produces version information
     version_argument = ''
+
+    # For getting ifx's version, call it with version_argument
+    # and ignore the error code
+    ignore_version_errors = [1]
 
     #: Regex used to extract version from compiler's output
     version_regex = r'([1-9][0-9]*\.[0-9]*\.[0-9]*)'
@@ -41,11 +49,16 @@ class Msvc(Compiler):
 
     def __init__(self, *args, **kwargs):
         super(Msvc, self).__init__(*args, **kwargs)
-        self.vcvarsallfile = os.path.abspath(
-            os.path.join(self.cc, '../../../../../../..'))
-        self.vcvarsallfile = os.path.join(
-            self.vcvarsallfile, 'Auxiliary', 'Build', 'vcvarsall.bat')
-
+        if os.getenv("ONEAPI_ROOT"):
+            # If this found, it sets all the vars
+            self.setvarsfile = os.path.join(os.getenv("ONEAPI_ROOT"),
+                "setvars.bat")
+        else:
+            self.setvarsfile = os.path.abspath(
+                os.path.join(self.cc, '../../../../../../..'))
+            self.setvarsfile = os.path.join(self.setvarsfile,
+                'Auxiliary', 'Build', 'vcvars64.bat')
+        
     @property
     def verbose_flag(self):
         return ""
@@ -55,28 +68,41 @@ class Msvc(Compiler):
         return ""
 
     def setup_custom_environment(self, pkg, env):
-        """Set environment variables for MSVC using the Microsoft-provided
-        script."""
+        """Set environment variables for MSVC using the
+        Microsoft-provided script."""
         if sys.version_info[:2] > (2, 6):
-            # Capture output from batch script and DOS environment dump
-            out = subprocess.check_output(  # novermin
-                'cmd /u /c "{0}" {1} && set'.format(self.vcvarsallfile, 'amd64'),
-                stderr=subprocess.STDOUT)
-            if sys.version_info[0] >= 3:
-                out = out.decode('utf-16le', errors='replace')
+        # If you have setvars.bat, just call it and get the includes,
+        # libs variables correct.
+            subprocess.call([self.setvarsfile])
         else:
+        # Should not this be an exception?
             print("Cannot pull msvc compiler information in Python 2.6 or below")
 
-        # Process in to nice Python dictionary
-        vc_env = {  # novermin
-            key.lower(): value
-            for key, _, value in
-            (line.partition('=') for line in out.splitlines())
-            if key and value
-        }
 
-        # Request setting environment variables
-        if 'path' in vc_env:
-            env.set_path('PATH', vc_env['path'].split(';'))
-        env.set_path('INCLUDE', vc_env.get('include', '').split(';'))
-        env.set_path('LIB', vc_env.get('lib', '').split(';'))
+    # fc_version only loads the ifx compiler into the first MSVC stanza; 
+    # if there are other versions of Microsoft VS installed and detected, they 
+    # will only have cl.exe as the C/C++ compiler
+
+    @classmethod
+    def fc_version(cls, fc):
+        # We're using intel for the Fortran compilers, which exist if
+        # ONEAPI_ROOT is a meaningful variable
+        if os.getenv("ONEAPI_ROOT"):
+            try:
+                sps = spack.operating_systems.windows_os.WindowsOs.compiler_search_paths
+            except:
+                print("sps not found.")
+                raise
+            try:
+                clp = spack.util.executable.which_string("cl", path = sps)
+            except:
+                print("cl not found.")
+                raise
+            ver = cls.default_version(clp)
+            return ver
+        else:
+            return cls.default_version(fc)
+
+    @classmethod
+    def f77_version(cls, f77):
+        return cls.fc_version(f77)

--- a/lib/spack/spack/operating_systems/windows_os.py
+++ b/lib/spack/spack/operating_systems/windows_os.py
@@ -23,8 +23,9 @@ def windows_version():
 class WindowsOs(OperatingSystem):
     """This class represents the Windows operating system.  This will be
     auto detected using the python platform.win32_ver() once we have a
-    python setup that runs natively.  The Windows platform will be represented
-    using the major version operating system number, e.g. 10.
+    python setup that runs natively.  The Windows platform will be
+    represented using the major version operating system number, e.g.
+    10.
     """
 
     # Find MSVC directories using vswhere
@@ -36,9 +37,10 @@ class WindowsOs(OperatingSystem):
             extra_args = {}
             if sys.version_info[:3] >= (3, 6, 0):
                 extra_args = {'encoding': 'mbcs', 'errors': 'strict'}
-            paths = subprocess.check_output([  # novermin
-                os.path.join(root, "Microsoft Visual Studio", "Installer",
-                             "vswhere.exe"),
+
+            paths = subprocess.check_output([
+                os.path.join(root, "Microsoft Visual Studio",
+                "Installer", "vswhere.exe"),
                 "-prerelease",
                 "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
                 "-property", "installationPath",
@@ -52,6 +54,12 @@ class WindowsOs(OperatingSystem):
             for p in msvc_paths:
                 comp_search_paths.extend(
                     glob.glob(os.path.join(p, '*', 'bin', 'Hostx64', 'x64')))
+            if os.getenv("ONEAPI_ROOT"):
+                intelsetvars = os.path.join(os.getenv("ONEAPI_ROOT"),
+                    "setvars.bat")
+                subprocess.call([intelsetvars])
+                comp_search_paths.extend(glob.glob(os.path.join(os.getenv("ONEAPI_ROOT"), 
+                'compiler', '*', 'windows', 'bin')))
         except (subprocess.CalledProcessError, OSError, UnicodeDecodeError):
             pass
     if comp_search_paths:


### PR DESCRIPTION
This PR allows for automatic detection and integration of Intel's IFX Fortran compiler into the MSVC compiler blocks written by spack compiler find. If there is more than one version of MSVC installed on a machine and detected by spack, only the first version in compilers.yaml will be written with the IFX executable as fc and f77. We also include support for detecting the IFX compiler on Windows and writing a separate Intel compiler block in compilers.yaml with it