### PR TITLE
Minigmg

### DIFF
--- a/var/spack/repos/builtin/packages/minigmg/package.py
+++ b/var/spack/repos/builtin/packages/minigmg/package.py
@@ -24,16 +24,49 @@ class Minigmg(Package):
 
     version('master', sha256='1c2d27496a881f655f5e849d6a7a132625e535739f82575991c511cc2cf899ac')
 
+    version('local', branch='minigmg', git='https://github.com/FindHao/minigmg')
+
+    variant('debug', default=False, description='Enable debug flag')
+    variant('simde', default=False, description='enable simde')
+    variant('opt', default=False,
+            description='enable -Ofast -D__PREFETCH_NEXT_PLANE_FROM_DRAM -D__FUSION_RESIDUAL_RESTRICTION')
+
     depends_on('mpi')
+    depends_on('simde', when="+simde")
 
     phases = ['build', 'install']
 
     def build(self, spec, prefix):
         cc = Executable(spec['mpi'].mpicc)
-        cc('-O3', self.compiler.openmp_flag, 'miniGMG.c',
-            'mg.c', 'box.c', 'solver.c', 'operators.ompif.c', 'timer.x86.c',
-            '-D__MPI', '-D__COLLABORATIVE_THREADING=6',
-            '-D__TEST_MG_CONVERGENCE', '-D__PRINT_NORM', '-D__USE_BICGSTAB',
+        if spec.satisfies('target=aarch64:'):
+            arm_archflag = '-Daarch64'
+        else:
+            arm_archflag = ''
+        if spec.satisfies('+debug'):
+            self.debug_flags = '-g'
+        else:
+            self.debug_flags = ''
+
+        if spec.satisfies('+simde'):
+            operators_source_file = 'operators.avx.c'
+        else:
+            operators_source_file = 'operators.ompif.c'
+
+        if spec.satisfies('+opt'):
+            opt_flag = '-D__PREFETCH_NEXT_PLANE_FROM_DRAM -D__FUSION_RESIDUAL_RESTRICTION'
+            fast_flag = '-Ofast'
+            COLLABORATIVE_THREADING_flag = ''
+            arch_flag = '-march=armv8.2-a'
+        else:
+            opt_flag = ''
+            fast_flag = ''
+            arch_flag = ''
+            COLLABORATIVE_THREADING_flag = '-D__COLLABORATIVE_THREADING=6'
+
+        cc('-O3', fast_flag, arch_flag, self.compiler.openmp_flag, self.debug_flags, 'miniGMG.c',
+            'mg.c', 'box.c', 'solver.c', operators_source_file, 'timer.x86.c',
+            '-D__MPI', COLLABORATIVE_THREADING_flag, opt_flag,
+            '-D__TEST_MG_CONVERGENCE', '-D__PRINT_NORM', '-D__USE_BICGSTAB', arm_archflag,
             '-o', 'run.miniGMG', '-lm')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/minigmg/package.py
+++ b/var/spack/repos/builtin/packages/minigmg/package.py
@@ -56,14 +56,12 @@ class Minigmg(Package):
             opt_flag = '-D__PREFETCH_NEXT_PLANE_FROM_DRAM -D__FUSION_RESIDUAL_RESTRICTION'
             fast_flag = '-Ofast'
             COLLABORATIVE_THREADING_flag = ''
-            arch_flag = '-march=armv8.2-a'
         else:
             opt_flag = ''
             fast_flag = ''
-            arch_flag = ''
             COLLABORATIVE_THREADING_flag = '-D__COLLABORATIVE_THREADING=6'
 
-        cc('-O3', fast_flag, arch_flag, self.compiler.openmp_flag, self.debug_flags, 'miniGMG.c',
+        cc('-O3', fast_flag, self.compiler.openmp_flag, self.debug_flags, 'miniGMG.c',
             'mg.c', 'box.c', 'solver.c', operators_source_file, 'timer.x86.c',
             '-D__MPI', COLLABORATIVE_THREADING_flag, opt_flag,
             '-D__TEST_MG_CONVERGENCE', '-D__PRINT_NORM', '-D__USE_BICGSTAB', arm_archflag,


### PR DESCRIPTION
update package.py to include variants with optimizations. Because we have changed the source code and the original code is a tar file, we have to add a new version in my repo. It does not violate their BSD license.
By applying new compiler flags, there is up to 14X speedup on gcc@10.3.0 with arm platform.
By applying our modification with simde and compiler flags, there is up to 23X speedup on  gcc@10.3.0 with arm platform.