### PR TITLE
PICSAR: added support for GCC >10.0 and arm compiler

### DIFF
--- a/var/spack/repos/builtin/packages/picsar/package.py
+++ b/var/spack/repos/builtin/packages/picsar/package.py
@@ -70,7 +70,8 @@ class Picsar(MakefilePackage):
         targets.append('SYS = default')
 
         if '%gcc' in self.spec:
-            targets.append('FARGS=-g -fbounds-check -O3 -fopenmp -JModules -fallow-argument-mismatch')
+            targets.append('FARGS=-g -fbounds-check -O3 -fopenmp '
+                           '-JModules -fallow-argument-mismatch')
 
         return targets
 

--- a/var/spack/repos/builtin/packages/picsar/package.py
+++ b/var/spack/repos/builtin/packages/picsar/package.py
@@ -65,6 +65,9 @@ class Picsar(MakefilePackage):
 
         targets.append('SYS = default')
 
+        if '%gcc' in self.spec:
+            targets.append('FARGS=-g -fbounds-check -O3 -fopenmp -JModules -fallow-argument-mismatch')
+
         return targets
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/picsar/package.py
+++ b/var/spack/repos/builtin/packages/picsar/package.py
@@ -31,6 +31,10 @@ class Picsar(MakefilePackage):
 
     parallel = False
 
+    def patch(self):
+        if '%arm' in self.spec:
+            filter_file(r'!\$OMP SIMD SAFELEN\(LVEC2\)', '', 'src/diags/diags.F90')
+
     @property
     def build_targets(self):
         targets = []


### PR DESCRIPTION
We had the following error when compiling PICSAR with GCC 10.3.0:
```
     25    
     26      304 |               bztile, .FALSE., l_lower_order_in_v_in, LVEC_fieldgathe,                &
     27          |                      1
     28    ......
     29     1092 |                 bztile , l4symtry_in, l_lower_order_in_v_in, lvect,                   &
     30          |                         2
  >> 31    Error: Type mismatch between actual argument at (1) and actual argument at (2) (LOGICAL(4)/LOGICAL(8)).
     32    src/particle_pushers/particle_pusher_manager_3d.F90:318:23:
     33    
     34      318 |               bztile , .FALSE., l_lower_order_in_v_in, lvec_fieldgathe,               &
     35          |                       1
     36    ......
     37     1104 |                 bztile , l4symtry_in, l_lower_order_in_v_in, lvect,                   &
     38          |                         2
  >> 39    Error: Type mismatch between actual argument at (1) and actual argument at (2) (LOGICAL(4)/LOGICAL(8)).
  >> 40    make: *** [src/particle_pushers/particle_pusher_manager_3d.o] Error 1
```
It seems that it is caused due to some changes in GCC v10. To circumvent the error, one can compile with the flag "-fallow-argument-mismatch".

We also had some problems when compiling PICSAR with the arm compiler:

```
==> Error: ProcessError: Command exited with status 2:
    'make' 'FC=/scratch/opt/spack/linux-amzn2-aarch64/arm-21.0.0.879/openmpi-4.1.0-lmaoy5tql4ymankvskpqsplxlig5wzvy/bin/mpif90' 'CC=/scratch/opt/spack/linux-amzn2-aarch64/arm-21.0.0.879/openmpi-4.1.0-lmaoy5tql4ymankvskpqsplxlig5wzvy/bin/mpicc' 'COMP=user' 'FARGS=-g -O3 -fopenmp' 'MODE = prod' 'SYS = default'

1 error found in build log:
     222    
     223    6 warnings generated.
     224    /scratch/opt/spack/linux-amzn2-aarch64/arm-21.0.0.879/openmpi-4.1.0-lmaoy5tql4ymankvskpqsplxlig5wzvy/bin/mpif90 -g -O3 -fopenmp -c -o src/diags/diags.o 
            src/diags/diags.F90
     225    F90-W-0547-OpenMP feature, SAFELEN, not yet implemented in this version of the compiler. (src/diags/diags.F90: 900)
     226    F90-F-0155-DO loop expected after COLLAPSE (src/diags/diags.F90: 908)
     227    F90/aarch64 Linux FlangArm F90  - 1.5 2017-05-01: compilation aborted
  >> 228    make: *** [src/diags/diags.o] Error 1
```
The OpenMP directive SAFELEN is not implemented in the ARM compiler. The execution of the SAFELEN clause is not essential for the program, so we have eliminated the two troublesome lines of code using a spack-patch.