### PR TITLE
Add Poppler 21.07.0

### DIFF
--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -13,7 +13,7 @@ class Poppler(CMakePackage):
     url      = "https://poppler.freedesktop.org/poppler-21.07.0.tar.xz"
     list_url = "https://poppler.freedesktop.org/releases.html"
     git      = "https://gitlab.freedesktop.org/poppler/poppler.git"
-    
+
     version('master', branch='master')
     version('21.07.0', sha256='e26ab29f68065de4d6562f0a3e2b5435a83ca92be573b99a1c81998fa286a4d4')
     version('0.90.1', sha256='984d82e72e91418d280885298c8bdc855a2fd92665fd52a1345b27235e0c71c4')
@@ -93,7 +93,7 @@ class Poppler(CMakePackage):
             args.append('-DENABLE_BOOST=ON')
         else:
             args.append('-DENABLE_BOOST=OFF')
-            
+
         if '+cms' in spec:
             args.append('-DENABLE_CMS=lcms2')
         else:

--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -10,11 +10,12 @@ class Poppler(CMakePackage):
     """Poppler is a PDF rendering library based on the xpdf-3.0 code base."""
 
     homepage = "https://poppler.freedesktop.org"
-    url      = "https://poppler.freedesktop.org/poppler-0.77.0.tar.xz"
+    url      = "https://poppler.freedesktop.org/poppler-21.07.0.tar.xz"
     list_url = "https://poppler.freedesktop.org/releases.html"
     git      = "https://gitlab.freedesktop.org/poppler/poppler.git"
-
+    
     version('master', branch='master')
+    version('21.07.0', sha256='e26ab29f68065de4d6562f0a3e2b5435a83ca92be573b99a1c81998fa286a4d4')
     version('0.90.1', sha256='984d82e72e91418d280885298c8bdc855a2fd92665fd52a1345b27235e0c71c4')
     version('0.87.0', sha256='6f602b9c24c2d05780be93e7306201012e41459f289b8279a27a79431ad4150e')
     version('0.79.0', sha256='f985a4608fe592d2546d9d37d4182e502ff6b4c42f8db4be0a021a1c369528c8')
@@ -24,6 +25,7 @@ class Poppler(CMakePackage):
     version('0.64.0', sha256='b21df92ca99f78067785cf2dc8e06deb04726b62389c0ee1f5d8b103c77f64b1')
     version('0.61.1', sha256='1266096343f5163c1a585124e9a6d44474e1345de5cdfe55dc7b47357bcfcda9')
 
+    variant('boost',    default=False, description='Enable Boost for Splash')
     variant('cms',      default=False, description='Use color management system')
     variant('cpp',      default=False, description='Compile poppler cpp wrapper')
     variant('glib',     default=False, description='Compile poppler glib wrapper')
@@ -43,6 +45,7 @@ class Poppler(CMakePackage):
     depends_on('fontconfig')
     depends_on('freetype')
 
+    depends_on('boost@1.58.0:', when='+boost')
     depends_on('lcms', when='+cms')
     depends_on('glib@2.41:', when='+glib')
     depends_on('gobject-introspection', when='+gobject')
@@ -86,6 +89,11 @@ class Poppler(CMakePackage):
         # Install header files
         args.append('-DENABLE_UNSTABLE_API_ABI_HEADERS=ON')
 
+        if '+boost' in spec:
+            args.append('-DENABLE_BOOST=ON')
+        else:
+            args.append('-DENABLE_BOOST=OFF')
+            
         if '+cms' in spec:
             args.append('-DENABLE_CMS=lcms2')
         else:


### PR DESCRIPTION
Add version 21.07.0 to Poppler.

**Changelog:**
- JBIG2Stream: Do not consider a size-0 to be an error.
- PSOutputDev: fix off-by-one error for image masking in L1/L2 output.
 - CairoOutputDev: Fix memory leak on broken files
- Minor code improvements
- set C standard to 11 without extensions

Full changelog can be found [here](https://poppler.freedesktop.org/releases.html).

**Test Plan:**
Poppler 21.07.0 built sucessfully within the Autamus Pipeline [here](https://github.com/autamus/registry/actions/runs/1038255802).