### PR TITLE
Add Metall v0.15

### DIFF
--- a/var/spack/repos/builtin/packages/metall/package.py
+++ b/var/spack/repos/builtin/packages/metall/package.py
@@ -9,13 +9,14 @@ class Metall(CMakePackage):
 
     homepage = "https://github.com/LLNL/metall"
     git      = "https://github.com/LLNL/metall.git"
-    url      = "https://github.com/LLNL/metall/archive/v0.2.tar.gz"
+    url      = "https://github.com/LLNL/metall/archive/v0.15.tar.gz"
 
     maintainers = ['KIwabuchi', 'rogerpearce', 'mayagokhale']
 
     version('master', branch='master')
     version('develop', branch='develop')
 
+    version('0.15', sha256='a1ea475ce1297b0c4cdf450544dc60ecf1b0a30c548b08ba77ccda5585df7248')
     version('0.13', sha256='959d37d0a7e7e5b4d5e6c0334aaaeef1b463e855fa8e807042f662c993ed60b1')
     version('0.12', sha256='b757b354b355e866bd6d42da53b0160442f3b7f663a19ba113da1ffc1a76176e')
     version('0.11', sha256='7cfa6a7eaaeb7fd11ecfbe43a172a36c8cde200601d6cd3b309d7a0acf752f3c')


### PR DESCRIPTION
Update Metall to v0.15 which includes new code organization.

**Changelog:**
- Major changes in the API and the code structure.

Full changelog can be found [here](https://github.com/LLNL/metall/releases/tag/v0.15).

**Test Plan:**
Metal v0.15 built successfully within the Autamus Pipeline [here](https://github.com/autamus/registry/runs/3069437548).