### PR TITLE
Add Julia v1.6.2

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -13,12 +13,13 @@ class Julia(Package):
     """The Julia Language: A fresh approach to technical computing"""
 
     homepage = "http://julialang.org"
-    url      = "https://github.com/JuliaLang/julia/releases/download/v0.4.3/julia-0.4.3-full.tar.gz"
+    url      = "https://github.com/JuliaLang/julia/releases/download/v1.6.2/julia-1.6.2-full.tar.gz"
     git      = "https://github.com/JuliaLang/julia.git"
 
     maintainers = ['glennpj']
 
     version('master', branch='master')
+    version('1.6.2', sha256='01241120515cb9435b96179cf301fbd2c24d4405f252588108d13ceac0f41c0a')
     version('1.6.1', sha256='71d8e40611361370654e8934c407b2dec04944cf3917c5ecb6482d6b85ed767f')
     version('1.6.0', sha256='1b05f42c9368bc2349c47363b7ddc175a2da3cd162d52b6e24c4f5d4d6e1232c')
     version('1.5.4', sha256='dbfb8cd544b223eff70f538da7bb9d5b6f76fd0b00dd2385e6254e74ad4e892f')

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -13,6 +13,7 @@ class Julia(Package):
     """The Julia Language: A fresh approach to technical computing"""
 
     homepage = "http://julialang.org"
+    url      = "https://github.com/JuliaLang/julia/releases/download/v0.4.3/julia-0.4.3-full.tar.gz"
     git      = "https://github.com/JuliaLang/julia.git"
 
     maintainers = ['glennpj']

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -13,7 +13,6 @@ class Julia(Package):
     """The Julia Language: A fresh approach to technical computing"""
 
     homepage = "http://julialang.org"
-    url      = "https://github.com/JuliaLang/julia/releases/download/v1.6.2/julia-1.6.2-full.tar.gz"
     git      = "https://github.com/JuliaLang/julia.git"
 
     maintainers = ['glennpj']


### PR DESCRIPTION
Update Julia to 1.6.2 which is the second patch release of the 1.6 series.

**Changelog:**
- Fix Rational{T} constructor for abstract T.
- fix threadcall for new ccall lookup strategy.

Full changelog can be found [here](https://github.com/JuliaLang/julia/compare/v1.6.1...v1.6.2).

**Test Plan:**
Julia 1.6.2 built successfully within the Autamus pipeline [here](https://github.com/autamus/registry/runs/3070414423).