### PR TITLE
fix compile error with the correct python path for migraphx recipe

### DIFF
--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -43,6 +43,7 @@ class Migraphx(CMakePackage):
     depends_on('nlohmann-json', type='link')
     depends_on('msgpack-c', type='link')
     depends_on('half@1.12.0', type='link')
+    depends_on('python@3:', type='build')
     depends_on('py-pybind11', type='build', when='@:4.0.0')
     depends_on('py-pybind11@2.6:', type='build', when='@4.1.0:')
 
@@ -54,6 +55,17 @@ class Migraphx(CMakePackage):
         depends_on('rocblas@' + ver,                  when='@' + ver)
         depends_on('miopen-hip@' + ver,               when='@' + ver)
 
+    @property
+    def cmake_python_hints(self):
+        """Include the python include path to the
+        CMake based on current spec
+        """
+        python_spec = self.spec['python']
+        include_dir = python_spec.package.get_python_inc()
+        return [
+            self.define('Python_INCLUDE_DIR', include_dir)
+        ]
+
     def cmake_args(self):
         args = [
             '-DCMAKE_CXX_COMPILER={0}/bin/clang++'
@@ -63,4 +75,6 @@ class Migraphx(CMakePackage):
             args.append('-DNLOHMANN_JSON_INCLUDE={0}'.format(
                 self.spec['nlohmann-json'].prefix.include))
 
+        if self.spec['cmake'].satisfies('@3.16.0:'):
+            args += self.cmake_python_hints
         return args


### PR DESCRIPTION
A issue was found and logged as #24429 while building migraphx.  The added lines will ensure we pass the include path for python as per the spec . 
Let me know any comments 