### PR TITLE
rust: add spack external find support

### DIFF
--- a/var/spack/repos/builtin/packages/rust/package.py
+++ b/var/spack/repos/builtin/packages/rust/package.py
@@ -2,6 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import re
+
 from six import iteritems
 
 
@@ -458,6 +461,14 @@ class Rust(Package):
                         target=rust_arch['target']
                     )
                 )
+
+    executables = ['^rustc$']
+
+    @classmethod
+    def determine_version(csl, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.match(r'rustc (\S+)', output)
+        return match.group(1) if match else None
 
     # This routine returns the target architecture we intend to build for.
     def get_rust_target(self):


### PR DESCRIPTION
Rust takes forever to install, and I only need it as a dependency of `py-setuptools-rust`, so I installed a binary. This PR makes it easy to automatically detect a rust installation in your PATH via `spack external find rust`.

@AndrewGaspar if you want to add any additional features like variant detection feel free to push to my branch.