### PR TITLE
py-fsspec: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-fsspec/package.py
+++ b/var/spack/repos/builtin/packages/py-fsspec/package.py
@@ -12,6 +12,7 @@ class PyFsspec(PythonPackage):
     homepage = "https://github.com/intake/filesystem_spec"
     pypi = "fsspec/fsspec-0.4.4.tar.gz"
 
+    version('2021.7.0', sha256='792ebd3b54de0b30f1ce73f0ba0a8bcc864724f2d9f248cb8d0ece47db0cbde8')
     version('2021.4.0', sha256='8b1a69884855d1a8c038574292e8b861894c3373282d9a469697a2b41d5289a6')
     version('0.8.0', sha256='176f3fc405471af0f1f1e14cffa3d53ab8906577973d068b976114433c010d9d')
     version('0.7.3', sha256='1b540552c93b47e83c568e87507d6e02993e6d1b30bc7285f2336c81c5014103')


### PR DESCRIPTION
Successfully installs on Ubuntu 18.04 with Python 3.8.11 and GCC 7.5.0.