### PR TITLE
paraview: require cli11 for 5.10+

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -110,6 +110,7 @@ class Paraview(CMakePackage, CudaPackage):
     conflicts('+qt', when='+osmesa')
 
     depends_on('bzip2')
+    depends_on('cli11', when='@5.9.1:')
     depends_on('double-conversion')
     depends_on('expat')
     depends_on('eigen@3:')


### PR DESCRIPTION
5.9.1 is used since `master` is also marked as 5.9.1.

---
Added upstream here: https://gitlab.kitware.com/paraview/paraview/-/merge_requests/4951

Cc: @utkarshayachit 