### PR TITLE
Do not issue a warning for a missing source id when installing from local sources

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1180,6 +1180,10 @@ class Environment(object):
             return True
         return False
 
+    def is_develop(self, spec):
+        """Returns true when the spec is built from local sources"""
+        return spec.name in self.dev_specs
+
     def concretize(self, force=False, tests=False):
         """Concretize user_specs in this environment.
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1537,7 +1537,9 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             # should this attempt to download the source and set one? This
             # probably only happens for source repositories which are
             # referenced by branch name rather than tag or commit ID.
-            if not self.spec.external:
+            env = spack.environment.get_env(None, None)
+            from_local_sources = env and env.is_develop(self.spec)
+            if not self.spec.external and not from_local_sources:
                 message = 'Missing a source id for {s.name}@{s.version}'
                 tty.warn(message.format(s=self))
             hash_content.append(''.encode('utf-8'))

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2591,3 +2591,15 @@ def test_virtual_spec_concretize_together(tmpdir):
     e.concretize()
 
     assert any(s.package.provides('mpi') for _, s in e.concretized_specs())
+
+
+def test_query_develop_specs():
+    """Test whether a spec is develop'ed or not"""
+    env('create', 'test')
+    with ev.read('test') as e:
+        e.add('mpich')
+        e.add('mpileaks')
+        e.develop(Spec('mpich@1'), 'here', clone=False)
+
+        assert e.is_develop(Spec('mpich'))
+        assert not e.is_develop(Spec('mpileaks'))


### PR DESCRIPTION
When running `spack -e . concretize -f` on

```
$ cat spack.yaml
spack:
  specs: [zlib@1.3.0]
  develop:
    zlib:
      spec: zlib@1.3.0
```

it issues a missing source id warning after concretization, which doesn't really make sense for a development package.

Before:
```
$ spack -e . concretize -f
==> Concretized zlib@1.3.0
[+]  4qrd4ug  zlib@1.3.0%gcc@10.2.0+optimize+pic+shared dev_path=/tmp/tmp.Ua8r8vqDUt/zlib arch=linux-ubuntu20.04-zen2

==> Warning: Missing a source id for zlib@1.3.0
```

After:

```
$ spack -e . concretize -f
==> Concretized zlib@1.3.0
[+]  4qrd4ug  zlib@1.3.0%gcc@10.2.0+optimize+pic+shared dev_path=/tmp/tmp.Ua8r8vqDUt/zlib arch=linux-ubuntu20.04-zen2
```
