### PR TITLE
RMBlast depends on cpio during build

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -34,6 +34,7 @@ class NcbiRmblastn(AutotoolsPackage):
         archive_sha256='e746ee480ade608052306fd21f015c8a323f27029f65399275216f9a4c882d59',
         when='@2.9.0'
     )
+    depends_on('cpio', type='build')
 
     configure_directory = 'c++'
 


### PR DESCRIPTION
Although `cpio` is present in many environments, it may not be always available.

The failure to build this package can be reproduced in a fresh Docker image `debian:10`. Explicitly depending on cpio during build lets the build succeed.