### PR TITLE
[libpmemobj-cpp] fixing package not building because of valgrind flag

### DIFF
--- a/var/spack/repos/builtin/packages/libpmemobj-cpp/package.py
+++ b/var/spack/repos/builtin/packages/libpmemobj-cpp/package.py
@@ -34,3 +34,7 @@ class LibpmemobjCpp(CMakePackage):
     depends_on('pmdk@1.8:', when='@1.9:')
     depends_on('pmdk@1.7:', when='@1.8:')
     depends_on('pmdk@1.4:', when='@1.5:')
+
+    def cmake_args(self):
+        args = ['-DTESTS_USE_VALGRIND=OFF']
+        return args


### PR DESCRIPTION
This PR simply add an argument to cmake, without which libpmemobj-cpp fails to build (at least the develop and 1.12 versions. The 1.8 version builds fine without. I haven't tried versions in between).