### PR TITLE
Additional Flecsi Spackage Updates

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -64,17 +64,19 @@ class Flecsi(CMakePackage, CudaPackage):
     variant('openmp', default=False,
             description='Enable OpenMP Support')
 
-    # All Current FLecsi Releases
+    # All Current FleCSI Releases
     for level in ('low', 'medium', 'high'):
-        depends_on('caliper', when='caliper_detail=%s' % level)
-        depends_on('caliper@2.0.1~adiak', when='@:1.9 caliper_detail=%s' % level)
+        depends_on('caliper@2.0.1~adiak~libdw', when='@:1.9 caliper_detail=%s' % level)
+        depends_on('caliper@2.4.0~libdw', when='@2.0: caliper_detail=%s' % level)
     depends_on('graphviz', when='+graphviz')
-    depends_on('hdf5+mpi', when='+hdf5')
+    depends_on('hdf5+hl+mpi', when='+hdf5')
     depends_on('metis@5.1.0:')
     depends_on('parmetis@4.0.3:')
     depends_on('boost@1.70.0: cxxstd=17 +program_options')
+    depends_on('openmpi+legacylaunchers', when='+unit_tests ^openmpi')
+    depends_on('legion network=gasnet', when='backend=legion')
 
-    # Flecsi@1.x
+    # FleCSI@1.x
     depends_on('cmake@3.12:', when='@:1.9')
     # Requires cinch > 1.0 due to cinchlog installation issue
     depends_on('cinch@1.01:', type='build', when='+external_cinch @:1.9')
@@ -84,55 +86,58 @@ class Flecsi(CMakePackage, CudaPackage):
     depends_on('legion+shared', when='backend=legion @:1.9')
     depends_on('legion+hdf5', when='backend=legion +hdf5 @:1.9')
     depends_on('legion build_type=Debug', when='backend=legion +debug_backend @:1.9')
+    depends_on('legion@ctrl-rep-7', when='backend=legion @:1.9')
     depends_on('hpx@1.4.1 cxxstd=17 malloc=system max_cpu_count=128', when='backend=hpx @:1.9')
     depends_on('hpx build_type=Debug', when='backend=hpx +debug_backend @:1.9')
     depends_on('googletest@1.8.1+gmock', when='@:1.9')
-    depends_on('hdf5+hl', when='+hdf5 @:1.9')
     depends_on('python@3.0:', when='+tutorial @:1.9')
     depends_on('doxygen', when='+doxygen @:1.9')
     depends_on('llvm', when='+flecstan @:1.9')
     depends_on('pfunit@3.0:3.99', when='@:1.9')
     depends_on('py-gcovr', when='+coverage @:1.9')
 
-    # Flecsi@2.x
+    # FleCSI@2.x
     depends_on('cmake@3.15:', when='@2.0:')
-    depends_on('boost@1.70.0 +atomic +filesystem +regex +system', when='@2.0:')
+    depends_on('boost +atomic +filesystem +regex +system', when='@2.0:')
     depends_on('kokkos@3.2.00:', when='+kokkos @2.0:')
     depends_on('legion@ctrl-rep-9:ctrl-rep-99', when='backend=legion @2.0:')
     depends_on('legion+hdf5', when='backend=legion +hdf5 @2.0:')
     depends_on('hdf5@1.10.7:', when='backend=legion +hdf5 @2.0:')
     depends_on('hpx@1.3.0 cxxstd=17 malloc=system', when='backend=hpx @2.0:')
     depends_on('kokkos@3.2.00:', when='+kokkos @2.0:')
-    depends_on('mpich@3.4.1', when='@2.0: ^mpich')
-    depends_on('openmpi@4.1.0', when='@2.0: ^openmpi')
+    depends_on('mpich@3.4.1:', when='@2.0: ^mpich')
+    depends_on('openmpi@4.1.0:', when='@2.0: ^openmpi')
 
     conflicts('+tutorial', when='backend=hpx')
-    # Flecsi@2: no longer supports serial or charmpp backends
+    # FleCSI@2: no longer supports serial or charmpp backends
     conflicts('backend=serial', when='@2.0:')
     conflicts('backend=charmpp', when='@2.0:')
-    # FLecsi@2: no longer expects to control how backend is built
+    # FleCSI@2: no longer expects to control how backend is built
     conflicts('+debug_backend', when='@2.0:')
-    # Flecsi@2: No longer supports previous TPL related flags
+    # FleCSI@2: No longer supports previous TPL related flags
     conflicts('+disable_metis', when='@2.0:')
-    # Flecsi@2: no longer provides documentation variants
+    # FleCSI@2: no longer provides documentation variants
     conflicts('+doxygen', when='@2.0:')
     conflicts('+doc', when='@2.0:')
-    # Flecsi@2: no longer provides coverage variants
+    # FleCSI@2: no longer provides coverage variants
     conflicts('+coverage', when='@2.0:')
-    # Flecsi@2: no longer provides tutorial variants
+    # FleCSI@2: no longer provides tutorial variants
     conflicts('+tutorial', when='@2.0:')
-    # Flecsi@2: no longer supports flecstan
+    # FleCSI@2: no longer supports flecstan
     conflicts('+flecstan', when='@2.0:')
-    # Flecsi@2: integrates cinch and no longer depends on external installs
+    # FleCSI@2: integrates cinch and no longer depends on external installs
     conflicts('+external_cinch', when='@2.0:')
-    # Current Flecsi@:1.9 releases do not support kokkos, omp, or cuda
+    # Current FleCSI@:1.9 releases do not support kokkos, omp, or cuda
     conflicts('+kokkos', when='@:1.9')
     conflicts('+openmp', when='@:1.9')
     conflicts('+cuda', when='@:1.9')
     # Unit tests require flog support
     conflicts('+unit_tests', when='~flog')
-    # Disallow network=none when using legion as a backend
-    conflicts('legion network=none', when='backend=legion @:1.9')
+    # Disallow conduit=none when using legion as a backend
+    conflicts('legion conduit=none', when='backend=legion')
+    # Due to overhauls of Legion and Gasnet spackages
+    #   flecsi@:1.9 can no longer be built with a usable legion
+    conflicts('backend=legion', when='@:1.9')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
Worked with flecsi developers to tighten, relax, and clarify
constraints and better understand how the flecsi project uses
legion. In the process, discovered that flecsi@1.4 cannot be
built with legion without heavy changes/reverts to the legion
and gasnet spackages.

Also, most importantly, fixed branding as to how flecsi is spelled