### PR TITLE
asdf-cxx: Require a particular version of yaml-cpp

### DIFF
--- a/var/spack/repos/builtin/packages/asdf-cxx/package.py
+++ b/var/spack/repos/builtin/packages/asdf-cxx/package.py
@@ -45,5 +45,5 @@ class AsdfCxx(CMakePackage):
     # An error in the cmake script requires swig all the time, not only when
     # Python bindings are used
     depends_on('swig @3.0.0:3.999.999', type='build')
-    depends_on('yaml-cpp')
+    depends_on('yaml-cpp @0.6.3')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/asdf-cxx/package.py
+++ b/var/spack/repos/builtin/packages/asdf-cxx/package.py
@@ -45,5 +45,6 @@ class AsdfCxx(CMakePackage):
     # An error in the cmake script requires swig all the time, not only when
     # Python bindings are used
     depends_on('swig @3.0.0:3.999.999', type='build')
+    # Neither earlier nor later versions of yaml-cpp work
     depends_on('yaml-cpp @0.6.3')
     depends_on('zlib')


### PR DESCRIPTION
Neither older nor versions of yaml-cpp will work.