### PR TITLE
Disable z3 python binding by default

### DIFF
--- a/var/spack/repos/builtin/packages/z3/package.py
+++ b/var/spack/repos/builtin/packages/z3/package.py
@@ -19,7 +19,7 @@ class Z3(CMakePackage):
     version('4.8.7', sha256='8c1c49a1eccf5d8b952dadadba3552b0eac67482b8a29eaad62aa7343a0732c3')
     version('4.5.0', sha256='aeae1d239c5e06ac183be7dd853775b84698db1265cb2258e5918a28372d4a0c')
 
-    variant('python', default=True, description='Enable python binding')
+    variant('python', default=False, description='Enable python binding')
     depends_on('python', type='build', when='~python')
     depends_on('python', type=('build', 'run'), when='+python')
     depends_on('py-setuptools', type=('run'), when='+python')


### PR DESCRIPTION
z3 is a dependency of llvm and llvm-amdgpu, and when z3 python bindings
are enabled it depends on py-setuptools as a run dependency. That's
fine, except that py-setuptools now influences the hash of
llvm/llvm-amdgpu, which can be very annoying when another package
restricts the py-setuptools version -- you'll end up recompiling llvm
for no good reason :(.
