### PR TITLE
metis: Suppress warnings causing issues for %nvhpc builds

### DIFF
--- a/var/spack/repos/builtin/packages/metis/package.py
+++ b/var/spack/repos/builtin/packages/metis/package.py
@@ -53,6 +53,17 @@ class Metis(Package):
         # Ignore warnings/errors re unrecognized omp pragmas on %intel
         if '%intel@14:' in self.spec:
             env.append_flags('CFLAGS', '-diag-disable 3180')
+        # Ignore some warnings to get it to compile with %nvhpc
+        #   111: statement is unreachable
+        #   177: variable "foo" was declared but never referenced
+        #   188: enumerated type mixed with another type
+        #   550: variable "foo" was set but never used
+        if '%nvhpc' in self.spec:
+            env.append_flags('CFLAGS', '--display_error_number')
+            env.append_flags('CFLAGS', '--diag_suppress 111')
+            env.append_flags('CFLAGS', '--diag_suppress 177')
+            env.append_flags('CFLAGS', '--diag_suppress 188')
+            env.append_flags('CFLAGS', '--diag_suppress 550')
 
     @when('@5:')
     def patch(self):


### PR DESCRIPTION
fixes #25013

We add compilation flags when using %nvhpc to suppress warnings
(which due to global -Werror flag in the build get promoted to
errors) for the following:
Diagnostic 111: statement is unreachable
Diagnostic 177: variable "foo" was declared but never referenced
Diagnostic 188: enumerated type mixed with another type
Diagnostic 550: variable "foo" was set but never used