### PR TITLE
Add smoke test for darshan-util

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -72,12 +72,16 @@ class DarshanUtil(AutotoolsPackage):
 
         return extra_args
 
+    @property
+    def basepath(self):
+        return join_path('darshan-test', 'example-output')
+
     @run_after('install')
     def _copy_test_inputs(self):
         # add darshan-test/example-output/mpi-io-test-spack-expected.txt"
-        test_inputs = \
-            ["darshan-test/example-output/mpi-io-test-x86_64-{0}.darshan"
-                .format(self.spec.version)]
+        test_inputs = [
+            join_path(self.basepath,
+                      "mpi-io-test-x86_64-{0}.darshan".format(self.spec.version))]
         self.cache_extra_test_sources(test_inputs)
 
     def _test_parser(self):
@@ -85,14 +89,14 @@ class DarshanUtil(AutotoolsPackage):
                    from the current version and check some expected counter values"
         # Switch to loading the expected strings from the darshan source in future
         # filename = self.test_suite.current_test_cache_dir.
-        #            join("darshan-test/example-output/mpi-io-test-spack-expected.txt")
+        #            join(join_path(self.basepath, "mpi-io-test-spack-expected.txt"))
         # expected_output = self.get_escaped_text_output(filename)
         expected_output = [r"POSIX\s+-1\s+\w+\s+POSIX_OPENS\s+\d+",
                            r"MPI-IO\s+-1\s+\w+\s+MPIIO_INDEP_OPENS\s+\d+",
                            r"STDIO\s+0\s+\w+\s+STDIO_OPENS\s+\d+"]
-        logname = self.test_suite.current_test_cache_dir.\
-            join("darshan-test/example-output/mpi-io-test-x86_64-{0}.darshan".
-                 format(self.spec.version))
+        logname = self.test_suite.current_test_cache_dir.join(
+            join_path(self.basepath,
+                      "mpi-io-test-x86_64-{0}.darshan".format(self.spec.version)))
         exe = 'darshan-parser'
         options = [logname]
         status = [0]

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -74,26 +74,37 @@ class DarshanUtil(AutotoolsPackage):
 
     @run_after('install')
     def _copy_test_inputs(self):
-      # add darshan-test/example-output/mpi-io-test-spack-expected.txt" 
-      test_inputs = ["darshan-test/example-output/mpi-io-test-x86_64-{0}.darshan".format(self.spec.version)]
-      self.cache_extra_test_sources(test_inputs)
+        # add darshan-test/example-output/mpi-io-test-spack-expected.txt"
+        test_inputs = \
+            ["darshan-test/example-output/mpi-io-test-x86_64-{0}.darshan"
+                .format(self.spec.version)]
+        self.cache_extra_test_sources(test_inputs)
 
     def _test_parser(self):
-      purpose = "Verify darshan-parser can parse an example log from the current version and check some expected counter values"
-      # Switch to loading the expected strings from the darshan source in future
-      #filename = self.test_suite.current_test_cache_dir.join("darshan-test/example-output/mpi-io-test-spack-expected.txt")
-      #expected_output = self.get_escaped_text_output(filename)
-      expected_output = ["POSIX\s+-1\s+\w+\s+POSIX_OPENS\s+\d+",
-                         "MPI-IO\s+-1\s+\w+\s+MPIIO_INDEP_OPENS\s+\d+",
-                         "STDIO\s+0\s+\w+\s+STDIO_OPENS\s+\d+"
-                        ]
-      logname = self.test_suite.current_test_cache_dir.join("darshan-test/example-output/mpi-io-test-x86_64-{0}.darshan".format(self.spec.version))
-      exe = 'darshan-parser'
-      options = [logname]
-      status = [0] 
-      installed = True
-      self.run_test(exe, options, expected_output, status, installed, purpose, skip_missing=False, work_dir=None)
+        purpose = "Verify darshan-parser can parse an example log \
+                   from the current version and check some expected counter values"
+        # Switch to loading the expected strings from the darshan source in future
+        # filename = self.test_suite.current_test_cache_dir.
+        #            join("darshan-test/example-output/mpi-io-test-spack-expected.txt")
+        # expected_output = self.get_escaped_text_output(filename)
+        expected_output = [r"POSIX\s+-1\s+\w+\s+POSIX_OPENS\s+\d+",
+                           r"MPI-IO\s+-1\s+\w+\s+MPIIO_INDEP_OPENS\s+\d+",
+                           r"STDIO\s+0\s+\w+\s+STDIO_OPENS\s+\d+"]
+        logname = self.test_suite.current_test_cache_dir.\
+            join("darshan-test/example-output/mpi-io-test-x86_64-{0}.darshan".
+                 format(self.spec.version))
+        exe = 'darshan-parser'
+        options = [logname]
+        status = [0]
+        installed = True
+        self.run_test(exe,
+                      options,
+                      expected_output,
+                      status,
+                      installed,
+                      purpose,
+                      skip_missing=False,
+                      work_dir=None)
 
     def test(self):
-      self._test_parser()
-
+        self._test_parser()

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -71,3 +71,29 @@ class DarshanUtil(AutotoolsPackage):
                 extra_args.append('--enable-apxc-mod')
 
         return extra_args
+
+    @run_after('install')
+    def _copy_test_inputs(self):
+      # add darshan-test/example-output/mpi-io-test-spack-expected.txt" 
+      test_inputs = ["darshan-test/example-output/mpi-io-test-x86_64-{0}.darshan".format(self.spec.version)]
+      self.cache_extra_test_sources(test_inputs)
+
+    def _test_parser(self):
+      purpose = "Verify darshan-parser can parse an example log from the current version and check some expected counter values"
+      # Switch to loading the expected strings from the darshan source in future
+      #filename = self.test_suite.current_test_cache_dir.join("darshan-test/example-output/mpi-io-test-spack-expected.txt")
+      #expected_output = self.get_escaped_text_output(filename)
+      expected_output = ["POSIX\s+-1\s+\w+\s+POSIX_OPENS\s+\d+",
+                         "MPI-IO\s+-1\s+\w+\s+MPIIO_INDEP_OPENS\s+\d+",
+                         "STDIO\s+0\s+\w+\s+STDIO_OPENS\s+\d+"
+                        ]
+      logname = self.test_suite.current_test_cache_dir.join("darshan-test/example-output/mpi-io-test-x86_64-{0}.darshan".format(self.spec.version))
+      exe = 'darshan-parser'
+      options = [logname]
+      status = [0] 
+      installed = True
+      self.run_test(exe, options, expected_output, status, installed, purpose, skip_missing=False, work_dir=None)
+
+    def test(self):
+      self._test_parser()
+


### PR DESCRIPTION
Add a smoke test for the darshan-util package. 

This adds a test to run darshan-parser against an example logfile which is included in the darshan release. The test verifies that 3 counters are present in the output, one for each of the POSIX, MPI-IO, and STDIO modules. The test assumes that darshan-parser must be in the user's path.

Example output:
kharms@shuttleworth:~/working/darshan/spack$ spack install darshan-util
[+] /home/kharms/working/darshan/spack/opt/spack/linux-ubuntu20.04-sandybridge/gcc-9.3.0/zlib-1.2.11-bjaye35neuvuamo32i2cbv4c22m367c2
==> Installing darshan-util-3.3.1-vtcpygtbyefth637pue7cyyi35mg4fnk
==> No binary for darshan-util-3.3.1-vtcpygtbyefth637pue7cyyi35mg4fnk found: installing from source
==> Using cached archive: /home/kharms/working/darshan/spack/var/spack/cache/_source-cache/archive/28/281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7.tar.gz
==> No patches needed for darshan-util
==> darshan-util: Executing phase: 'autoreconf'
==> darshan-util: Executing phase: 'configure'
==> darshan-util: Executing phase: 'build'
==> darshan-util: Executing phase: 'install'
==> darshan-util: Successfully installed darshan-util-3.3.1-vtcpygtbyefth637pue7cyyi35mg4fnk
  Fetch: 0.03s.  Build: 9.87s.  Total: 9.90s.
[+] /home/kharms/working/darshan/spack/opt/spack/linux-ubuntu20.04-sandybridge/gcc-9.3.0/darshan-util-3.3.1-vtcpygtbyefth637pue7cyyi35mg4fnk
kharms@shuttleworth:~/working/darshan/spack$ spack test run darshan-util
==> Spack test qjfbz5waqzhol6xxuy4k3svxehz4d6cx
==> Testing package darshan-util-3.3.1-vtcpygt
==> Error: TestFailure: 1 tests failed.


Failed to find executable 'darshan-parser'

/home/kharms/working/darshan/spack/lib/spack/spack/package.py:1871, in run_test:
       1868                    # stack instead of from traceback.
       1869                    # The traceback is truncated here, so we can't use it to
       1870                    # traverse the stack.
  >>   1871                    m = '\n'.join(
       1872                        spack.build_environment.get_package_context(tb)
       1873                    )
       1874


/home/kharms/working/darshan/spack/lib/spack/spack/build_environment.py:1029, in _setup_pkg_and_run:
       1026        tb_string = traceback.format_exc()
       1027
       1028        # build up some context from the offending package so we can
  >>   1029        # show that, too.
       1030        package_context = get_package_context(tb)
       1031
       1032        logfile = None

See test log for details:
  /home/kharms/.spack/test/qjfbz5waqzhol6xxuy4k3svxehz4d6cx/darshan-util-3.3.1-vtcpygt-test-out.txt

kharms@shuttleworth:~/working/darshan/spack$ spack load darshan-util
kharms@shuttleworth:~/working/darshan/spack$ spack test run darshan-util
==> Spack test qjfbz5waqzhol6xxuy4k3svxehz4d6cx
==> Testing package darshan-util-3.3.1-vtcpygt
