### PR TITLE
Kokkos: allow c++17 starting with CUDA v11.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -197,7 +197,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     variant("pic", default=False, description="Build position independent code")
 
     # nvcc does not currently work with C++17 or C++20
-    conflicts("+cuda", when="std=17")
+    conflicts("+cuda", when="std=17 ^cuda@:10.99.99")
     conflicts("+cuda", when="std=20")
 
     variant('shared', default=True, description='Build shared libraries')


### PR DESCRIPTION
Kokkos already supports c++17 by itself, and CUDA supports c++17 starting with v11.0.0; the conflict for std=17 can be relaxed.