### PR TITLE
py-pretrainedmodels: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pretrainedmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-pretrainedmodels/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPretrainedmodels(PythonPackage):
+    """Pretrained models for Pytorch."""
+
+    homepage = "https://github.com/cadene/pretrained-models.pytorch"
+    pypi     = "pretrainedmodels/pretrainedmodels-0.7.4.tar.gz"
+
+    version('0.7.4', sha256='7e77ead4619a3e11ab3c41982c8ad5b86edffe37c87fd2a37ec3c2cc6470b98a')
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-torch', type=('build', 'run'))
+    depends_on('py-torchvision', type=('build', 'run'))
+    depends_on('py-munch', type=('build', 'run'))
+    depends_on('py-tqdm', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds and passes all import tests on Ubuntu 18.04 with Python 3.8.11 and GCC 7.5.0.

@calebrob6