### PR TITLE
py-efficientnet-pytorch: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-efficientnet-pytorch/package.py
+++ b/var/spack/repos/builtin/packages/py-efficientnet-pytorch/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyEfficientnetPytorch(PythonPackage):
+    """EfficientNet implemented in PyTorch."""
+
+    homepage = "https://github.com/lukemelas/efficientnet_pytorch"
+    pypi     = "efficientnet_pytorch/efficientnet_pytorch-0.6.3.tar.gz"
+
+    version('0.6.3', sha256='6667459336893e9bf6367de3788ba449fed97f65da3b6782bf2204b6273a319f')
+
+    depends_on('python@3.5.0:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-torch', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds and passes all import tests on Ubuntu 18.04 with Python 3.8.11 and GCC 7.5.0.

@calebrob6