### PR TITLE
nut: reflect conflict with nvhpc.

### DIFF
--- a/var/spack/repos/builtin/packages/nut/package.py
+++ b/var/spack/repos/builtin/packages/nut/package.py
@@ -24,11 +24,12 @@ class Nut(CMakePackage):
     depends_on('cmake@3.0:', type='build')
     depends_on('random123')
 
+    conflicts('%nvhpc)
     conflicts('%intel', when='@serial')
     conflicts('%pgi', when='@serial')
     conflicts('%xl', when='@serial')
     conflicts('%nag', when='@serial')
-
+    
     build_targets = ['VERBOSE=on']
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/nut/package.py
+++ b/var/spack/repos/builtin/packages/nut/package.py
@@ -24,6 +24,8 @@ class Nut(CMakePackage):
     depends_on('cmake@3.0:', type='build')
     depends_on('random123')
 
+    # The conflict with %nvhpc is inherited from random123,
+    # which is a C++ template library
     conflicts('%nvhpc)
     conflicts('%intel', when='@serial')
     conflicts('%pgi', when='@serial')

--- a/var/spack/repos/builtin/packages/nut/package.py
+++ b/var/spack/repos/builtin/packages/nut/package.py
@@ -26,7 +26,7 @@ class Nut(CMakePackage):
 
     # The conflict with %nvhpc is inherited from random123,
     # which is a C++ template library
-    conflicts('%nvhpc)
+    conflicts('%nvhpc')
     conflicts('%intel', when='@serial')
     conflicts('%pgi', when='@serial')
     conflicts('%xl', when='@serial')

--- a/var/spack/repos/builtin/packages/nut/package.py
+++ b/var/spack/repos/builtin/packages/nut/package.py
@@ -31,7 +31,6 @@ class Nut(CMakePackage):
     conflicts('%pgi', when='@serial')
     conflicts('%xl', when='@serial')
     conflicts('%nag', when='@serial')
-    
     build_targets = ['VERBOSE=on']
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
discussion here: https://github.com/spack/spack/pull/24921
and here: https://github.com/arm-hpc-user-group/Cloud-HPC-Hackathon-2021/tree/main/Applications/Applications/nut#compiler-3-nvhpc
TLDR; this package uses 'random123' which is a header library, specifically it includes "philox.h" from random123, which uses 'uint128_t' that NVHPC does not support and as of now leads to long stack traces of compilation error messages, this way instead of that people would get an informative msg that nvhpc can't compile this.
If someone _really_ wishes to add nvhpc support there is a blueprint for a patch here: https://github.com/spack/spack/pull/24921