### PR TITLE
[imlib2] depends_on pkg-config, type = build; and new versions

### DIFF
--- a/var/spack/repos/builtin/packages/imlib2/package.py
+++ b/var/spack/repos/builtin/packages/imlib2/package.py
@@ -28,3 +28,4 @@ class Imlib2(AutotoolsPackage, SourceforgePackage):
     depends_on('libpng')
     depends_on('libid3tag')
     depends_on('libjpeg-turbo')
+    depends_on('pkg-config', type='build')

--- a/var/spack/repos/builtin/packages/imlib2/package.py
+++ b/var/spack/repos/builtin/packages/imlib2/package.py
@@ -16,6 +16,8 @@ class Imlib2(AutotoolsPackage, SourceforgePackage):
 
     maintainers = ['TheQueasle']
 
+    version('1.7.1', sha256='033a6a639dcbc8e03f65ff05e57068e7346d50ee2f2fff304bb9095a1b2bc407')
+    version('1.7.0', sha256='1976ca3db48cbae79cd0fc737dabe39cc81494fc2560e1d22821e7dc9c22b37d')
     version('1.6.1', sha256='4d393a77e13da883c8ee2da3b029da3570210fe37d000c9ac33d9fce751b166d')
     version('1.6.0', sha256='cfc440ddfaed5fc85ba2572ad8d87a87cd77a5bffb33ebca882c42cefcd8691d')
     version('1.5.1', sha256='fa4e57452b8843f4a70f70fd435c746ae2ace813250f8c65f977db5d7914baae')

--- a/var/spack/repos/builtin/packages/imlib2/package.py
+++ b/var/spack/repos/builtin/packages/imlib2/package.py
@@ -30,4 +30,4 @@ class Imlib2(AutotoolsPackage, SourceforgePackage):
     depends_on('libpng')
     depends_on('libid3tag')
     depends_on('libjpeg-turbo')
-    depends_on('pkg-config', type='build')
+    depends_on('pkgconfig', type='build')


### PR DESCRIPTION
imlib2 (https://sourceforge.net/projects/enlightenment/files/imlib2-src/1.7.1/) uses pkg-config. Without pkg-config it tries to use the system pkg-config at /usr/bin/pkg-config. This leads to errors such as 
```
#14 1923.9   >> 95    configure: error: in `/tmp/root/spack-stage/spack-stage-imlib2-1.6.1
#14 1923.9            -7c5wakn4gyfz6q34uwlt5n4zjucw2w7e/spack-src':
#14 1923.9   >> 96    configure: error: The pkg-config script could not be found or is too
#14 1923.9             old.  Make sure it
#14 1923.9      97    is in your PATH or set the PKG_CONFIG environment variable to the fu
#14 1923.9            ll
#14 1923.9      98    path to pkg-config.
```
when pkg-config cannot be found. This test system, based on amd64/debian:testing-20210408-slim, had a pkg-config installed by spack but not system-wide available and was therefore not made available to the imlib2 build withou the explicit build dependency.

While here, I also updated to include imlib2@1.7.0 and imlib2@1.7.1.

Imlib2 has direct dependents feh, giblib, scrot, w3m. I tested building each of these against both imlib2@1.7.0 and imlib2@1.7.1 on a current spack develop 37ad6a862 with %gcc@10.3.0 on linux-ubuntu21.04-skylake with the following results:
- feh ^imlib2@1.7.0: builds fine
- feh ^imlib2@1.7.1: builds fine
- giblib ^imlib2@1.7.0: builds fine
- giblib ^imlib2@1.7.1: builds fine
- w3m ^imlib2@1.7.0: builds fine
- w3m ^imlib2@1.7.1: builds fine
- scrot ^imlib2@1.7.0 as well as scrot ^imlib2@1.7.1
```
==> Installing scrot-1.5-3w66dp7mmv3cjpuywwbe652iduve2ayl
==> No binary for scrot-1.5-3w66dp7mmv3cjpuywwbe652iduve2ayl found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/87/87afba3998aac097f13231f3b0452c21188bf4b5cc6ac0747693a1da1a0ae40f.tar.gz
==> No patches needed for scrot
==> scrot: Executing phase: 'autoreconf'
==> Error: AttributeError: module 'spack.pkg.builtin.scrot' has no attribute 'autoreconf'

/home/wdconinc/git/spack/lib/spack/spack/build_systems/autotools.py:277, in autoreconf:
        274            # --install, --verbose, --force
        275            autoreconf_args = ['-ivf']
        276            autoreconf_args += self.autoreconf_search_path_args
  >>    277            autoreconf_args += self.autoreconf_extra_args
        278            m.autoreconf(*autoreconf_args)

See build log for details:
  /home/wdconinc/.spack/stage/spack-stage-scrot-1.5-3w66dp7mmv3cjpuywwbe652iduve2ayl/spack-build-out.txt
```
which seems to be a bug in autotools that is not relevant her.

Changelogs for imlib2 @1.7.0 and 1.7.1 for the benefit of maintainer @TheQueasle
```
***
*** Version 1.7.1 ***
***

Daniel Kolesa (1):
      Fix big endian build

Kim Woelders (6):
      rend.c: Fix __imlib_generic_render() when jump != 0
      grab.c: Support 30bpp display in __imlib_GrabXImageToRGBA()
      WEBP loader: Add initial signature check
      XPM loader: Get transparency right when doing header-only loading
      Silence a couple of sign-compare warnings
      1.7.1


***
*** Version 1.7.0 ***
***

Alexander Volkov (3):
      GIF loader: Don't close file descriptor twice
      Introduce imlib_load_image_from_fd()
      Don't rescan loaders

Kim Woelders (49):
      XPM loader: Major speedup for cpp > 2
      imlib2_load: Properly check non-full loads (load data too)
      imlib2_load: Use getopt()
      imlib2_load: Add repeated load option
      Simplify __imlib_FileExtension()
      Refactor many __imlib_File...() functions to use common __imlib_FileStat()
      Drop the __imlib_IsRealFile() file check in __imlib_File...() functions
      image.c: Add some space for readability
      image.c: Remove some unnecessary clearing of calloc'ed structs
      image.c: Rework some obscure file name stuff in __imlib_SaveImage()
      image.c: Don't strdup() real_name when not necessary in __imlib_LoadImage()
      image.c: Use real_file to get file time
      image.c: Introduce __imlib_ErrorFromErrno()
      image.c: Use loader return value, not im->w to determine load success
      Loader cleanups
      Saver cleanups
      image.c/h: Cleanups
      image.c: Move image tag functions to separate file
      image.c: Move loader functions to separate file
      image.c: Enable non-dirty pixmap cache cleaning
      image.c: Minor refactoring of pixmap cache cleaners
      image.c: Move data_memory_func assignment to better place
      imlib2_view: Various tweaks
      Fix loader cleanup breakage (gif)
      image.c: Remove redundant pixmap unref
      image.c: Add infrastructure to simplify progress handling
      Loaders: Simplify/fix progress handling
      Savers: Simplify progress handling
      Introduce __imlib_LoadEmbedded()
      Introduce __imlib_LoaderSetFormats()
      Make ImlibLoader struct opaque
      autogen.sh: Add -n as alternative to NOCONFIGURE
      Fix enum conversion warnings (gcc10)
      JPG, PNG loaders: Avoid clobber warnings
      Add a couple of consts
      TIFF loader: Minor speedup
      ID3 loader: Some mostly cosmetic rearrangements
      GZ, BZ2 loaders: Accept more file names
      __imlib_FileExtension: Use basename if there are no dots
      Revert "JPG, PNG loaders: Avoid clobber warnings"
      JPG, PNG loaders: Avoid clobber warnings - Take N+1
      Add infrastructure for new loader entry - load2()
      Move loaders to load2()
      Reduce number of stat() calls during load
      configure.ac: Drop initial config.cache removal
      imlib2_load: Optionally use imlib_load_image_fd()
      Fix build without X11
      Remove a couple of unused includes
      1.7.0

Tobias Stoeckmann (2):
      ICO loader: Do not crash on invalid files
      ICO loader: Handle malloc failures
```