### PR TITLE
poppler: drop splash patch for 21.07.0

### DIFF
--- a/var/spack/repos/builtin/packages/poppler/package.py
+++ b/var/spack/repos/builtin/packages/poppler/package.py
@@ -66,7 +66,7 @@ class Poppler(CMakePackage):
     # a small section of code in the QT5 wrappers that expects it
     # to be present.
     patch('poppler_page_splash.patch', when='@0.64.0:0.90.0 ^qt@5.0:')
-    patch('poppler_page_splash.0.90.1.patch', when='@0.90.1: ^qt@5.0:')
+    patch('poppler_page_splash.0.90.1.patch', when='@0.90.1:21.06 ^qt@5.0:')
 
     # Only needed to run `make test`
     resource(


### PR DESCRIPTION
`ENABLE_SPLASH` configuration has been removed entirely so patch is no longer necessary after #24931 (I think -- I'm not entirely sure why this was disabled to begin with).  Theoretically the `-DENABLE_SPLASH=OFF` could be conditionalized out as well, but it doesn't seem to be hurting anything.