### PR TITLE
Fixes and improvements to py-pyprecice

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -36,7 +36,8 @@ class PyPyprecice(PythonPackage):
     # removes the pip dependency.
     # See also https://github.com/spack/spack/pull/19558
     patch("deactivate-version-check-via-pip.patch", when="@:2.1.1.2")
-    # From v2.2.0.1 versioneer is used in a way that breaks the installation procedure for Spack
+    # From v2.2.0.1 versioneer is used in a way that breaks the installation
+    # procedure for Spack
     patch("setup-v2-versioneer.patch", when="@2.2.0.1:")
 
     depends_on("precice@develop", when="@develop")

--- a/var/spack/repos/builtin/packages/py-pyprecice/setup-v2-versioneer.patch
+++ b/var/spack/repos/builtin/packages/py-pyprecice/setup-v2-versioneer.patch
@@ -1,0 +1,27 @@
+diff --git a/setup.py b/setup.py
+index b6efc9f..da4f6b8 100644
+--- a/setup.py
++++ b/setup.py
+@@ -127,16 +127,17 @@ this_directory = os.path.abspath(os.path.dirname(__file__))
+ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+     long_description = f.read()
+ 
+-my_cmdclass = {
+-    'test': my_test,
+-    'build_ext': my_build_ext,
+-    'install': my_install}
++
++cmdclass = versioneer.get_cmdclass()
++cmdclass.update(build_ext=my_build_ext)
++cmdclass.update(install=my_install)
++cmdclass.update(test=my_test)
+ 
+ # build precice.so python extension to be added to "PYTHONPATH" later
+ setup(
+     name=APPNAME,
+     version=versioneer.get_version(),
+-    cmdclass=versioneer.get_cmdclass(my_cmdclass),
++    cmdclass=cmdclass,
+     description='Python language bindings for the preCICE coupling library',
+     long_description=long_description,
+     long_description_content_type='text/markdown',

--- a/var/spack/repos/builtin/packages/py-pyprecice/setup-v2.0.0.1.patch
+++ b/var/spack/repos/builtin/packages/py-pyprecice/setup-v2.0.0.1.patch
@@ -1,0 +1,55 @@
+diff --git a/setup.py b/setup.py
+index 8c554a1..ef7c221 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,7 +1,17 @@
+ import os
+ import subprocess
+-from enum import Enum
++import warnings
++from packaging import version
++import pip
++
++if version.parse(pip.__version__) < version.parse("19.0"):
++    # version 19.0 is required, since we are using pyproject.toml for definition of build-time depdendencies. See https://pip.pypa.io/en/stable/news/#id209
++    warnings.warn("You are using pip version {}. However, pip version > 19.0 is recommended. You can continue with the installation, but installation problems can occour. Please refer to https://github.com/precice/python-bindings#build-time-dependencies-cython-numpy-defined-in-pyprojecttoml-are-not-installed-automatically for help.".format(pip.__version__))
++
++if version.parse(pip.__version__) < version.parse("10.0.1"):        
++    warnings.warn("You are using pip version {}. However, pip version > 10.0.1 is required. If you continue with installation it is likely that you will face an error. See https://github.com/precice/python-bindings#version-of-pip3-is-too-old".format(pip.__version__))
+ 
++from enum import Enum
+ from setuptools import setup
+ from setuptools.command.test import test
+ from Cython.Distutils.extension import Extension
+@@ -9,11 +19,8 @@ from Cython.Distutils.build_ext import new_build_ext as build_ext
+ from Cython.Build import cythonize
+ from distutils.command.install import install
+ from distutils.command.build import build
+-from packaging import version
+-import pip
+ import numpy
+ 
+-assert(version.parse(pip.__version__) >= version.parse("10.0.1"))  # minimum version 10.0.1 is required. See https://github.com/precice/precice/wiki/Non%E2%80%93standard-APIs#python-bindings-version-of-pip3-is-too-old
+ 
+ # name of Interfacing API
+ APPNAME = "pyprecice"
+@@ -104,11 +111,19 @@ class my_test(test, object):
+         self.distribution.is_test = True       
+         super().initialize_options()
+ 
++        
++this_directory = os.path.abspath(os.path.dirname(__file__))
++with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
++    long_description = f.read()
++    
++    
+ # build precice.so python extension to be added to "PYTHONPATH" later
+ setup(
+     name=APPNAME,
+     version=str(APPVERSION),
+     description='Python language bindings for the preCICE coupling library',
++    long_description=long_description,
++    long_description_content_type='text/markdown',
+     url='https://github.com/precice/python-bindings',
+     author='the preCICE developers',
+     author_email='info@precice.org',


### PR DESCRIPTION
This PR contains several fixes and improvements of the Spack package for `py-pyprecice`. I would need some *feedback* on how to handle the installation when one uses Spack with a pre-installed Python version available on a system.

The initial reason for my work was to make `py-pyprecice` usable when Spack uses Python provided by the system (see also https://github.com/precice/python-bindings/issues/86 and https://github.com/precice/python-bindings/issues/87). With the current changes it is possible to install `py-pyprecice@.2.2.0.1:` using the current `develop` of Spack while using the system's preinstalled Python 3 environment.  

For older versions, i.e. `py-pyprecice@:2.1.1.2`, it still results in an unusable package when a preinstalled Python is used with Spack. `py-pyprecice` is compiled and installed, but the resulting files seem to be put into a wrong directory. The files end up in `<prefix>/lib/python3.8/site-packages/` while Spack seems to expect it at `<prefix>/lib/python3/dist-packages/`. I am not sure if this is due to the unusual installation procedure of `py-precice@:2.1.1.2` which makes it necessary to overwrite Spack's installation and building flags for the package. Feedback on this would be appreciated.

I tested this on Ubuntu 20.04 with Python@3.8.10 which was detected by `spack external find`.

**Changes:**
- Fixing the installation process for the bindings v2.0.0.1. The `setup.py` differed from other versions up to v2.1.1.2. Thus, application of the patch `deactivate-version-check-via-pip.patch` failed. I added an additional patch `setup-v2.0.0.1.patch` that updates the `setup.py` such that `deactivate-version-check-via-pip.patch` can be applied to v2.0.0.1.
- The patch `deactivate-version-check-via-pip.patch` was not applied to v2.1.1.2 in the previous Spack package such that the installation would fail.
- v2.2.0.1 introduced a new installation routine that is much closer to standard Python packages. However, this made the Spack package a bit more complicated. I added a new patch `setup-v2-versioneer.patch`which adapts the `setup.py` which allows to simplify the Spack package again. This change is also reported upstream https://github.com/precice/python-bindings/pull/113
