### PR TITLE
py-networkit/libnetworkit: Bump version 9.0

### DIFF
--- a/var/spack/repos/builtin/packages/libnetworkit/0001-Name-agnostic-import-of-tlx-library-90.patch
+++ b/var/spack/repos/builtin/packages/libnetworkit/0001-Name-agnostic-import-of-tlx-library-90.patch
@@ -1,0 +1,17 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -224,10 +224,11 @@ if(NOT NETWORKIT_EXT_TLX)
+ 				"Please run `git submodule update --init` to fetch the submodule.")
+ 	endif()
+ else()
++	file(GLOB tlx_path ${NETWORKIT_EXT_TLX}/lib/**.a)
+ 	add_library(tlx STATIC IMPORTED)
+ 	set_target_properties(tlx PROPERTIES
+-			IMPORTED_LOCATION "${NETWORKIT_EXT_TLX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}tlx${CMAKE_STATIC_LIBRARY_SUFFIX}"
+-			INTERFACE_INCLUDE_DIRECTORIES "${NETWORKIT_EXT_TLX}/include/")
++		IMPORTED_LOCATION "${tlx_path}"
++		INTERFACE_INCLUDE_DIRECTORIES "${NETWORKIT_EXT_TLX}/include/")
+ endif()
+ 
+ ################################################################################
+

--- a/var/spack/repos/builtin/packages/libnetworkit/package.py
+++ b/var/spack/repos/builtin/packages/libnetworkit/package.py
@@ -22,6 +22,7 @@ class Libnetworkit(CMakePackage):
 
     maintainers = ['fabratu']
 
+    version('9.0', sha256='c574473bc7d86934f0f4b3049c0eeb9c4444cfa873e5fecda194ee5b1930f82c')
     version('8.1', sha256='0a22eb839606b9fabfa68c7add12c4de5eee735c6f8bb34420e5916ce5d7f829')
     version('8.0', sha256='cdf9571043edbe76c447622ed33efe9cba2880f887ca231d98f6d3c22027e20e')
     version('7.1', sha256='60026c3be581ae9d5c919c861605082fcb9c8205758b3ddfcde2408153ae166e')
@@ -34,7 +35,8 @@ class Libnetworkit(CMakePackage):
     depends_on('libtlx')
     depends_on('py-sphinx', when='+doc', type='build')
 
-    patch('0001-Name-agnostic-import-of-tlx-library.patch', when='@6.1:')
+    patch('0001-Name-agnostic-import-of-tlx-library.patch', when='@6.1:8.1')
+    patch('0001-Name-agnostic-import-of-tlx-library-90.patch', when='@9.0:')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/py-networkit/package.py
+++ b/var/spack/repos/builtin/packages/py-networkit/package.py
@@ -22,6 +22,7 @@ class PyNetworkit(PythonPackage):
 
     maintainers = ['fabratu']
 
+    version('9.0', sha256='e27872d0d6a8a0a1ba862b0dab6adb4f0046fe6b20d3c47863075d1ee70226d3')
     version('8.1', sha256='5ff9e61496259280df4f913b1e37f51ca6f94974c4b9f623851f4d518f5ce0d5')
     version('8.0', sha256='36c30e894e835bf93f0aa0fb0b526758234e74318150820911e024ffe5ec1fd2')
     version('7.1', sha256='8609dc7a574a8a82d8880b8b1e3dfdd9c59ad67cd02135628e675c482fe98a96')
@@ -30,6 +31,7 @@ class PyNetworkit(PythonPackage):
 
     # Required dependencies
     depends_on('cmake', type='build')
+    depends_on('libnetworkit@9.0', type=('build', 'link'), when='@9.0')
     depends_on('libnetworkit@8.1', type=('build', 'link'), when='@8.1')
     depends_on('libnetworkit@8.0', type=('build', 'link'), when='@8.0')
     depends_on('libnetworkit@7.1', type=('build', 'link'), when='@7.1')


### PR DESCRIPTION
This PR raises version of libnetworkit/py-networkit to v9.0.