### PR TITLE
pgplot: fix with gcc<10

### DIFF
--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -38,7 +38,8 @@ class Pgplot(MakefilePackage):
             ('@CFLAGC@', ("-Wall -fPIC -DPG_PPU -O -std=c89 " +
                           "-Wno-error=implicit-function-declaration")),
             ('@FCOMPL@', self.compiler.f77),
-            ('@FFLAGC@', "-Wall -fPIC -O -ffixed-line-length-none -fallow-invalid-boz"),
+            ('@FFLAGC@', "-Wall -fPIC -O -ffixed-line-length-none" +
+                (" -fallow-invalid-boz" if spec.satisfies('%gcc@10:') else "")),
             ('@LIBS@', "-lgfortran"),
             ('@SHARED_LD@', self.compiler.cc + " -shared -o $SHARED_LIB -lgfortran"),
         ]


### PR DESCRIPTION
`-fallow-invalid-boz` is only valid on gcc 10.  Prior to that it's not necessary.  Fix build with earlier gcc versions.