### PR TITLE
Smoke test for darshan-runtime, builds a test code, runs it and check…

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -163,6 +163,7 @@ class DarshanRuntime(AutotoolsPackage):
                 env.pop('LD_PRELOAD')
 
                 import llnl.util.tty as tty
+
                 # verify existence of log and size is > 0
                 tty.msg("Test for existince of log:")
                 if os.path.exists(logname):

--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -21,6 +21,8 @@ class DarshanRuntime(AutotoolsPackage):
 
     maintainers = ['shanedsnyder', 'carns']
 
+    test_requires_compiler = True
+
     version('main', branch='main', submodules=True)
     version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7')
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
@@ -113,3 +115,76 @@ class DarshanRuntime(AutotoolsPackage):
         # default path for log file, could be user or site specific setting
         darshan_log_dir = os.environ['HOME']
         env.set('DARSHAN_LOG_DIR_PATH', darshan_log_dir)
+
+    @property
+    def basepath(self):
+        return join_path('darshan-test',
+                         join_path('regression',
+                                   join_path('test-cases', 'src')))
+
+    @run_after('install')
+    def _copy_test_inputs(self):
+        test_inputs = [
+            join_path(self.basepath, 'mpi-io-test.c')]
+        self.cache_extra_test_sources(test_inputs)
+
+    def _test_intercept(self):
+        testdir = "intercept-test"
+        with working_dir(testdir, create=True):
+            if '+mpi' in self.spec:
+                # compile a test program
+                logname = join_path(os.getcwd(), "test.darshan")
+                fname = join_path(self.test_suite.current_test_cache_dir,
+                                  join_path(self.basepath, 'mpi-io-test.c'))
+                cc = Executable(self.spec['mpi'].mpicc)
+                compile_opt = ['-c', fname]
+                link_opt = ['-o', "mpi-io-test", 'mpi-io-test.o']
+                cc(*(compile_opt))
+                cc(*(link_opt))
+
+                # run test program and intercept
+                purpose = "Test running code built against darshan"
+                exe = "./mpi-io-test"
+                options = ['-f', 'tmp.dat']
+                status = [0]
+                installed = False
+                expected_output = [r"Write bandwidth = \d+.\d+ Mbytes/sec",
+                                   r"Read bandwidth = \d+.\d+ Mbytes/sec"]
+                env['LD_PRELOAD'] = 'libdarshan.so'
+                env['DARSHAN_LOGFILE'] = logname
+                self.run_test(exe,
+                              options,
+                              expected_output,
+                              status,
+                              installed,
+                              purpose,
+                              skip_missing=False,
+                              work_dir=None)
+                env.pop('LD_PRELOAD')
+
+                import llnl.util.tty as tty
+                # verify existence of log and size is > 0
+                tty.msg("Test for existince of log:")
+                if os.path.exists(logname):
+                    sr = os.stat(logname)
+                    print("PASSED")
+                    tty.msg("Test for size of log:")
+                    if not sr.st_size > 0:
+                        exc = BaseException('log size is 0')
+                        m = None
+                        if spack.config.get('config:fail_fast', False):
+                            raise TestFailure([(exc, m)])
+                        else:
+                            self.test_failures.append((exc, m))
+                    else:
+                        print("PASSED")
+                else:
+                    exc = BaseException('log does not exist')
+                    m = None
+                    if spack.config.get('config:fail_fast', False):
+                        raise TestFailure([(exc, m)])
+                    else:
+                        self.test_failures.append((exc, m))
+
+    def test(self):
+        self._test_intercept()


### PR DESCRIPTION
This provide a smoke test for the darshan-runtime package. The test compiles a binary and runs it with interception enabled. The tests will confirm the darshan log was created and that the file is non-zero in size. Current test supports on MPI builds (which is the darshan default)

kharms@shuttleworth:~/working/darshan/spack$ spack install darshan-runtime
[+] /home/kharms/working/darshan/spack/opt/spack/linux-ubuntu20.04-sandybridge/gcc-9.3.0/libsigsegv-2.13-o2wgkh4f5rm7pykjjc55vznzzsjx6ayt
... CLIP ...
[+] /home/kharms/working/darshan/spack/opt/spack/linux-ubuntu20.04-sandybridge/gcc-9.3.0/openmpi-4.1.1-qobxdreouwkvtleu6aldh6sww7tqxd4d
==> Installing darshan-runtime-3.3.1-3fqhtuhinxmp27wuw2mce6olo5bff23p
==> No binary for darshan-runtime-3.3.1-3fqhtuhinxmp27wuw2mce6olo5bff23p found: installing from source
==> Using cached archive: /home/kharms/working/darshan/spack/var/spack/cache/_source-cache/archive/28/281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7.tar.gz
==> No patches needed for darshan-runtime
==> darshan-runtime: Executing phase: 'autoreconf'
==> darshan-runtime: Executing phase: 'configure'
==> darshan-runtime: Executing phase: 'build'
==> darshan-runtime: Executing phase: 'install'
==> darshan-runtime: Successfully installed darshan-runtime-3.3.1-3fqhtuhinxmp27wuw2mce6olo5bff23p
  Fetch: 0.02s.  Build: 22.77s.  Total: 22.79s.
[+] /home/kharms/working/darshan/spack/opt/spack/linux-ubuntu20.04-sandybridge/gcc-9.3.0/darshan-runtime-3.3.1-3fqhtuhinxmp27wuw2mce6olo5bff23p

kharms@shuttleworth:~/working/darshan/spack$ spack test run --keep-stage darshan-runtime
==> Spack test 6zz3l2lunffg7sspv3befs3n2wdkgo3n
==> Testing package darshan-runtime-3.3.1-3fqhtuh

