### PR TITLE
Make it possible to have more than one lexer mode at once!

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -35,8 +35,13 @@
 # - E203: white space around slice operators can be required, ignore : warn
 # - W503: see above, already ignored for line-breaks
 #
+# Import failure ignores: these are handled by isort.
+# - I100: Incorrect import order.
+# - I201: Missing newline between import groups.
+# - I202: Additional newline within an import group.
+#
 [flake8]
-ignore = E129,E221,E241,E272,E731,W503,W504,F999,N801,N813,N814,F403,F405
+ignore = E129,E221,E241,E272,E731,W503,W504,F999,N801,N813,N814,F403,F405,I100,I201,I202
 max-line-length = 88
 
 # F4: Import

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,10 @@
+[settings]
+profile=black
+known_first_party=spack
+known_archspec=archspec
+known_ruamel=ruamel
+known_compat=compat
+known_llnl=llnl
+known_third_party=six
+known_typing=typing,typing_extensions
+sections=FUTURE,STDLIB,TYPING,THIRDPARTY,COMPAT,ARCHSPEC,RUAMEL,LLNL,FIRSTPARTY,LOCALFOLDER

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -119,6 +119,9 @@ six
 * Homepage: https://pypi.python.org/pypi/six
 * Usage: Python 2 and 3 compatibility utilities.
 * Version: 1.11.0
+* Note: This package has been slightly extended:
+  * The `compat` module contains types from either `collections` or `collections.abc`,
+    according to the major Python version.
 
 macholib
 --------

--- a/lib/spack/external/_pytest/assertion/util.py
+++ b/lib/spack/external/_pytest/assertion/util.py
@@ -5,12 +5,9 @@ import pprint
 import _pytest._code
 import py
 try:
-    from collections.abc import Sequence
+    from compat import Sequence
 except ImportError:
-    try:
-        from collections import Sequence
-    except ImportError:
-        Sequence = list
+    Sequence = list
 
 
 u = py.builtin._totext

--- a/lib/spack/external/_pytest/main.py
+++ b/lib/spack/external/_pytest/main.py
@@ -10,12 +10,9 @@ from _pytest import nodes
 import _pytest._code
 import py
 try:
-    from collections.abc import MutableMapping as MappingMixin
+    from compat import MutableMapping as MappingMixin
 except ImportError:
-    try:
-        from collections import MutableMapping as MappingMixin
-    except ImportError:
-        from UserDict import DictMixin as MappingMixin
+    from UserDict import DictMixin as MappingMixin
 
 from _pytest.config import directory_arg, UsageError, hookimpl
 from _pytest.outcomes import exit

--- a/lib/spack/external/_pytest/pastebin.py
+++ b/lib/spack/external/_pytest/pastebin.py
@@ -60,11 +60,7 @@ def create_new_paste(contents):
     :returns: url to the pasted contents
     """
     import re
-    if sys.version_info < (3, 0):
-        from urllib import urlopen, urlencode
-    else:
-        from urllib.request import urlopen
-        from urllib.parse import urlencode
+    from compat import urlencode, urlopen
 
     params = {
         'code': contents,

--- a/lib/spack/external/_pytest/python_api.py
+++ b/lib/spack/external/_pytest/python_api.py
@@ -398,10 +398,7 @@ def approx(expected, rel=None, abs=None, nan_ok=False):
        __ https://docs.python.org/3/reference/datamodel.html#object.__ge__
     """
 
-    if sys.version_info >= (3, 3):
-        from collections.abc import Mapping, Sequence
-    else:
-        from collections import Mapping, Sequence
+    from compat import Mapping, Sequence
     from _pytest.compat import STRING_TYPES as String
 
     # Delegate the comparison to a class that knows how to deal with the type

--- a/lib/spack/external/archspec/cpu/schema.py
+++ b/lib/spack/external/archspec/cpu/schema.py
@@ -7,11 +7,7 @@ JSON file and its schema
 """
 import json
 import os.path
-
-try:
-    from collections.abc import MutableMapping  # novm
-except ImportError:
-    from collections import MutableMapping
+from compat import MutableMapping
 
 
 class LazyDictionary(MutableMapping):

--- a/lib/spack/external/compat.py
+++ b/lib/spack/external/compat.py
@@ -1,0 +1,56 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import multiprocessing
+import sys
+
+from ordereddict_backport import OrderedDict
+
+if sys.version_info < (3, 0):
+    from itertools import ifilter as filter
+    from itertools import imap as map
+    from itertools import izip as zip
+    from itertools import izip_longest as zip_longest
+    from urllib import urlopen as urlopen, urlencode as urlencode
+else:
+    filter = filter
+    map = map
+    zip = zip
+    from itertools import zip_longest as zip_longest   # novm
+    from urllib.request import urlopen as urlopen      # novm
+    from urllib.parse import urlencode as urlencode    # novm
+
+if sys.version_info >= (3, 3):
+    from collections.abc import Hashable as Hashable                # novm
+    from collections.abc import Iterable as Iterable                # novm
+    from collections.abc import Mapping as Mapping                  # novm
+    from collections.abc import MutableMapping as MutableMapping    # novm
+    from collections.abc import MutableSet as MutableSet            # novm
+    from collections.abc import MutableSequence as MutableSequence  # novm
+    from collections.abc import Sequence as Sequence                # novm
+else:
+    from collections import Hashable as Hashable
+    from collections import Iterable as Iterable
+    from collections import Mapping as Mapping
+    from collections import MutableMapping as MutableMapping
+    from collections import MutableSequence as MutableSequence
+    from collections import MutableSet as MutableSet
+    from collections import Sequence as Sequence
+
+# On macOS, Python 3.8 multiprocessing now defaults to the 'spawn' start
+# method. Spack cannot currently handle this, so force the process to start
+# using the 'fork' start method.
+#
+# TODO: This solution is not ideal, as the 'fork' start method can lead to
+# crashes of the subprocess. Figure out how to make 'spawn' work.
+#
+# See:
+# * https://github.com/spack/spack/pull/18124
+# * https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods  # noqa: E501
+# * https://bugs.python.org/issue33725
+if sys.version_info >= (3,):
+    fork_context = multiprocessing.get_context('fork')
+else:
+    fork_context = multiprocessing

--- a/lib/spack/external/jinja2/sandbox.py
+++ b/lib/spack/external/jinja2/sandbox.py
@@ -15,6 +15,7 @@
 import types
 import operator
 import sys
+from compat import Mapping, MutableMapping, MutableSequence, MutableSet
 from jinja2.environment import Environment
 from jinja2.exceptions import SecurityError
 from jinja2._compat import string_types, PY2
@@ -22,11 +23,6 @@ from jinja2.utils import Markup
 
 from markupsafe import EscapeFormatter
 from string import Formatter
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Mapping
-else:
-    from collections import Mapping
 
 
 #: maximum number of items a range may produce
@@ -84,10 +80,6 @@ except ImportError:
     pass
 
 #: register Python 2.6 abstract base classes
-if sys.version_info >= (3, 3):
-    from collections.abc import MutableSet, MutableMapping, MutableSequence
-else:
-    from collections import MutableSet, MutableMapping, MutableSequence
 _mutable_set_types += (MutableSet,)
 _mutable_mapping_types += (MutableMapping,)
 _mutable_sequence_types += (MutableSequence,)

--- a/lib/spack/external/jinja2/tests.py
+++ b/lib/spack/external/jinja2/tests.py
@@ -11,14 +11,10 @@
 import operator
 import re
 import sys
+from compat import Mapping
 from jinja2.runtime import Undefined
 from jinja2._compat import text_type, string_types, integer_types
 import decimal
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Mapping
-else:
-    from collections import Mapping
 
 number_re = re.compile(r'^-?\d+(\.\d+)?$')
 regex_type = type(number_re)

--- a/lib/spack/external/jsonschema/compat.py
+++ b/lib/spack/external/jsonschema/compat.py
@@ -1,11 +1,8 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import
 import sys
 import operator
 
-try:
-    from collections import MutableMapping, Sequence  # noqa
-except ImportError:
-    from collections.abc import MutableMapping, Sequence  # noqa
+from compat import MutableMapping, Sequence
 
 PY3 = sys.version_info[0] >= 3
 

--- a/lib/spack/external/markupsafe/__init__.py
+++ b/lib/spack/external/markupsafe/__init__.py
@@ -14,10 +14,7 @@ import sys
 from markupsafe._compat import text_type, string_types, int_types, \
      unichr, iteritems, PY2
 
-if sys.version_info >= (3, 3):
-    from collections.abc import Mapping
-else:
-    from collections import Mapping
+from compat import Mapping
 
 __version__ = "1.0"
 

--- a/lib/spack/external/py2/typing.py
+++ b/lib/spack/external/py2/typing.py
@@ -6,79 +6,77 @@
 This is a fake set of symbols to allow spack to import typing in python
 versions where we do not support type checking (<3)
 """
-Annotated = None
-Any = None
-Callable = None
-ForwardRef = None
-Generic = None
-Literal = None
-Optional = None
-Tuple = None
-TypeVar = None
-Union = None
-AbstractSet = None
-ByteString = None
-Container = None
-Hashable = None
-ItemsView = None
-Iterable = None
-Iterator = None
-KeysView = None
-Mapping = None
-MappingView = None
-MutableMapping = None
-MutableSequence = None
-MutableSet = None
-Sequence = None
-Sized = None
-ValuesView = None
-Awaitable = None
-AsyncIterator = None
-AsyncIterable = None
-Coroutine = None
-Collection = None
-AsyncGenerator = None
-AsyncContextManager = None
-Reversible = None
-SupportsAbs = None
-SupportsBytes = None
-SupportsComplex = None
-SupportsFloat = None
-SupportsInt = None
-SupportsRound = None
-ChainMap = None
-Dict = None
-List = None
-OrderedDict = None
-Set = None
-FrozenSet = None
-NamedTuple = None
-Generator = None
-AnyStr = None
-cast = None
+from collections import defaultdict
+
+# (1) Unparameterized types.
+Annotated = object
+Any = object
+AnyStr = object
+ByteString = object
+Counter = object
+Final = object
+Hashable = object
+NoReturn = object
+Sized = object
+SupportsAbs = object
+SupportsBytes = object
+SupportsComplex = object
+SupportsFloat = object
+SupportsIndex = object
+SupportsInt = object
+SupportsRound = object
+
+# (2) Parameterized types.
+AbstractSet = defaultdict(lambda: object)
+AsyncContextManager = defaultdict(lambda: object)
+AsyncGenerator = defaultdict(lambda: object)
+AsyncIterable = defaultdict(lambda: object)
+AsyncIterator = defaultdict(lambda: object)
+Awaitable = defaultdict(lambda: object)
+Callable = defaultdict(lambda: object)
+ChainMap = defaultdict(lambda: object)
+ClassVar = defaultdict(lambda: object)
+Collection = defaultdict(lambda: object)
+Container = defaultdict(lambda: object)
+ContextManager = defaultdict(lambda: object)
+Coroutine = defaultdict(lambda: object)
+DefaultDict = defaultdict(lambda: object)
+Deque = defaultdict(lambda: object)
+Dict = defaultdict(lambda: object)
+ForwardRef = defaultdict(lambda: object)
+FrozenSet = defaultdict(lambda: object)
+Generator = defaultdict(lambda: object)
+Generic = defaultdict(lambda: object)
+ItemsView = defaultdict(lambda: object)
+Iterable = defaultdict(lambda: object)
+Iterator = defaultdict(lambda: object)
+KeysView = defaultdict(lambda: object)
+List = defaultdict(lambda: object)
+Literal = defaultdict(lambda: object)
+Mapping = defaultdict(lambda: object)
+MappingView = defaultdict(lambda: object)
+MutableMapping = defaultdict(lambda: object)
+MutableSequence = defaultdict(lambda: object)
+MutableSet = defaultdict(lambda: object)
+NamedTuple = defaultdict(lambda: object)
+Optional = defaultdict(lambda: object)
+OrderedDict = defaultdict(lambda: object)
+Reversible = defaultdict(lambda: object)
+Sequence = defaultdict(lambda: object)
+Set = defaultdict(lambda: object)
+Tuple = defaultdict(lambda: object)
+Type = defaultdict(lambda: object)
+TypedDict = defaultdict(lambda: object)
+Union = defaultdict(lambda: object)
+ValuesView = defaultdict(lambda: object)
+
+# (3) Type variable declarations.
+TypeVar = lambda *args, **kwargs: None
+
+# (4) Functions.
+cast = lambda _type, x: x
 get_args = None
 get_origin = None
 get_type_hints = None
 no_type_check = None
 no_type_check_decorator = None
-NoReturn = None
-
-# these are the typing extension symbols
-ClassVar = None
-Final = None
-Protocol = None
-Type = None
-TypedDict = None
-ContextManager = None
-Counter = None
-Deque = None
-DefaultDict = None
-SupportsIndex = None
-final = None
-IntVar = None
-Literal = None
-NewType = None
-overload = None
-runtime_checkable = None
-Text = None
-TYPE_CHECKING = None

--- a/lib/spack/external/py2/typing_extensions.py
+++ b/lib/spack/external/py2/typing_extensions.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+"""
+This is a fake set of symbols to allow spack to import typing in python
+versions where we do not support type checking (<3)
+"""
+from collections import defaultdict
+
+# (1) Unparameterized types.
+IntVar = object
+Literal = object
+NewType = object
+Text = object
+
+# (2) Parameterized types.
+Protocol = defaultdict(lambda: object)
+
+# (3) Macro for avoiding evaluation except during type checking.
+TYPE_CHECKING = False
+
+# (4) Decorators.
+final = lambda x: x
+overload = lambda x: x
+runtime_checkable = lambda x: x

--- a/lib/spack/external/ruamel/yaml/comments.py
+++ b/lib/spack/external/ruamel/yaml/comments.py
@@ -10,11 +10,7 @@ a separate base
 """
 
 import sys
-
-if sys.version_info >= (3, 3):
-    from collections.abc import MutableSet
-else:
-    from collections import MutableSet
+from compat import MutableSet
 
 __all__ = ["CommentedSeq", "CommentedMap", "CommentedOrderedMap",
            "CommentedSet", 'comment_attrib', 'merge_attrib']

--- a/lib/spack/external/ruamel/yaml/compat.py
+++ b/lib/spack/external/ruamel/yaml/compat.py
@@ -18,8 +18,8 @@ except:
             from collections import OrderedDict
         except ImportError:
             from ordereddict import OrderedDict
-    # to get the right name import ... as ordereddict doesn't do that
 
+    # Monkey-patch `ordereddict.insert()` for very old Python versions.
     class ordereddict(OrderedDict):
         if not hasattr(OrderedDict, 'insert'):
             def insert(self, pos, key, value):

--- a/lib/spack/external/ruamel/yaml/constructor.py
+++ b/lib/spack/external/ruamel/yaml/constructor.py
@@ -9,6 +9,7 @@ import binascii
 import re
 import sys
 import types
+from compat import Hashable
 
 try:
     from .error import *                               # NOQA
@@ -23,12 +24,6 @@ except (ImportError, ValueError):  # for Jython
                                     ordereddict, text_type)
     from ruamel.yaml.comments import *                               # NOQA
     from ruamel.yaml.scalarstring import *                           # NOQA
-
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Hashable
-else:
-    from collections import Hashable
 
 
 __all__ = ['BaseConstructor', 'SafeConstructor', 'Constructor',

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -20,15 +20,12 @@ from contextlib import contextmanager
 
 import six
 
+from compat import Sequence
+
 from llnl.util import tty
 from llnl.util.lang import dedupe, memoized
 
 from spack.util.executable import Executable
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Sequence  # novm
-else:
-    from collections import Sequence
 
 __all__ = [
     'FileFilter',

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -625,7 +625,7 @@ def mkdirp(*paths, **kwargs):
 
             except OSError as e:
                 if e.errno != errno.EEXIST or not os.path.isdir(path):
-                    raise e
+                    raise
         elif not os.path.isdir(path):
             raise OSError(errno.EEXIST, "File already exists", path)
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -17,7 +17,6 @@ from six import string_types
 
 from compat import Hashable, MutableMapping, zip_longest
 
-
 # Ignore emacs backups when listing modules
 ignore_modules = [r'^\.#', '~$']
 

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -15,16 +15,7 @@ from datetime import datetime, timedelta
 
 from six import string_types
 
-if sys.version_info < (3, 0):
-    from itertools import izip_longest  # novm
-    zip_longest = izip_longest
-else:
-    from itertools import zip_longest  # novm
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Hashable, MutableMapping  # novm
-else:
-    from collections import Hashable, MutableMapping
+from compat import Hashable, MutableMapping, zip_longest
 
 
 # Ignore emacs backups when listing modules

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -16,9 +16,11 @@ import tempfile
 import traceback
 from contextlib import closing
 
-import ruamel.yaml as yaml
-from ordereddict_backport import OrderedDict
 from six.moves.urllib.error import HTTPError, URLError
+
+from compat import OrderedDict
+
+import ruamel.yaml as yaml
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1321,9 +1321,9 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
                 suppress = config.get('config:suppress_gpg_warnings', False)
                 spack.util.gpg.verify(
                     '%s.asc' % specfile_path, specfile_path, suppress)
-            except Exception as e:
+            except Exception:
                 shutil.rmtree(tmpdir)
-                raise e
+                raise
         else:
             shutil.rmtree(tmpdir)
             raise NoVerifyException(
@@ -1394,9 +1394,9 @@ def extract_tarball(spec, filename, allow_root=False, unsigned=False,
 
     try:
         relocate_package(spec, allow_root)
-    except Exception as e:
+    except Exception:
         shutil.rmtree(spec.prefix)
-        raise e
+        raise
     else:
         manifest_file = os.path.join(spec.prefix,
                                      spack.store.layout.metadata_dir,

--- a/lib/spack/spack/ci_needs_workaround.py
+++ b/lib/spack/spack/ci_needs_workaround.py
@@ -3,18 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import collections
-
-try:
-    # dynamically import to keep vermin from complaining
-    collections_abc = __import__('collections.abc')
-except ImportError:
-    collections_abc = collections
+from compat import Mapping
 
 
 get_job_name = lambda needs_entry: (
     needs_entry.get('job') if (
-        isinstance(needs_entry, collections_abc.Mapping) and
+        isinstance(needs_entry, Mapping) and
         needs_entry.get('artifacts', True))
 
     else
@@ -25,7 +19,7 @@ get_job_name = lambda needs_entry: (
 
 
 def convert_job(job_entry):
-    if not isinstance(job_entry, collections_abc.Mapping):
+    if not isinstance(job_entry, Mapping):
         return job_entry
 
     needs = job_entry.get('needs')

--- a/lib/spack/spack/ci_needs_workaround.py
+++ b/lib/spack/spack/ci_needs_workaround.py
@@ -5,7 +5,6 @@
 
 from compat import Mapping
 
-
 get_job_name = lambda needs_entry: (
     needs_entry.get('job') if (
         isinstance(needs_entry, Mapping) and

--- a/lib/spack/spack/ci_optimization.py
+++ b/lib/spack/spack/ci_optimization.py
@@ -3,28 +3,22 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import collections
-
-try:
-    # dynamically import to keep vermin from complaining
-    collections_abc = __import__('collections.abc')
-except ImportError:
-    collections_abc = collections
-
 import copy
 import hashlib
+from collections import defaultdict
+from compat import Mapping, Sequence
 
 import spack.util.spack_yaml as syaml
 
 
 def sort_yaml_obj(obj):
-    if isinstance(obj, collections_abc.Mapping):
+    if isinstance(obj, Mapping):
         return syaml.syaml_dict(
             (k, sort_yaml_obj(v))
             for k, v in
             sorted(obj.items(), key=(lambda item: str(item[0]))))
 
-    if isinstance(obj, collections_abc.Sequence) and not isinstance(obj, str):
+    if isinstance(obj, Sequence) and not isinstance(obj, str):
         return syaml.syaml_list(sort_yaml_obj(x) for x in obj)
 
     return obj
@@ -44,8 +38,8 @@ def matches(obj, proto):
 
     Precondition: proto must not have any reference cycles
     """
-    if isinstance(obj, collections_abc.Mapping):
-        if not isinstance(proto, collections_abc.Mapping):
+    if isinstance(obj, Mapping):
+        if not isinstance(proto, Mapping):
             return False
 
         return all(
@@ -53,10 +47,10 @@ def matches(obj, proto):
             for key, val in proto.items()
         )
 
-    if (isinstance(obj, collections_abc.Sequence) and
+    if (isinstance(obj, Sequence) and
             not isinstance(obj, str)):
 
-        if not (isinstance(proto, collections_abc.Sequence) and
+        if not (isinstance(proto, Sequence) and
                 not isinstance(proto, str)):
             return False
 
@@ -90,8 +84,8 @@ def subkeys(obj, proto):
 
     Otherwise, obj is returned.
     """
-    if not (isinstance(obj, collections_abc.Mapping) and
-            isinstance(proto, collections_abc.Mapping)):
+    if not (isinstance(obj, Mapping) and
+            isinstance(proto, Mapping)):
         return obj
 
     new_obj = {}
@@ -104,7 +98,7 @@ def subkeys(obj, proto):
             matches(proto[key], value)):
             continue
 
-        if isinstance(value, collections_abc.Mapping):
+        if isinstance(value, Mapping):
             new_obj[key] = subkeys(value, proto[key])
             continue
 
@@ -132,7 +126,7 @@ def add_extends(yaml, key):
     has_key = ('extends' in yaml)
     extends = yaml.get('extends')
 
-    if has_key and not isinstance(extends, (str, collections_abc.Sequence)):
+    if has_key and not isinstance(extends, (str, Sequence)):
         return
 
     if extends is None:
@@ -283,7 +277,7 @@ def build_histogram(iterator, key):
     The list is sorted in descending order by count, yielding the most
     frequently occuring hashes first.
     """
-    buckets = collections.defaultdict(int)
+    buckets = defaultdict(int)
     values = {}
 
     num_objects = 0

--- a/lib/spack/spack/ci_optimization.py
+++ b/lib/spack/spack/ci_optimization.py
@@ -6,6 +6,7 @@
 import copy
 import hashlib
 from collections import defaultdict
+
 from compat import Mapping, Sequence
 
 import spack.util.spack_yaml as syaml

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -73,7 +73,7 @@ def ipython_interpreter(args):
     support running a script or arguments
     """
     try:
-        import IPython
+        import IPython  # type: ignore[import]
     except ImportError:
         tty.die("ipython is not installed, install and try again.")
 

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -295,12 +295,19 @@ def run_mypy(mypy_cmd, file_list, args):
         "--package", "spack",
         "--package", "llnl",
         "--show-error-codes",
+        "--follow-imports=silent",
+        "--ignore-missing-imports",
     ]
     # not yet, need other updates to enable this
     # if any([is_package(f) for f in file_list]):
     #     mypy_args.extend(["--package", "packages"])
 
-    output = mypy_cmd(*mypy_args, fail_on_error=False, output=str)
+    output = mypy_cmd(
+        *mypy_args, fail_on_error=False, output=str,
+        extra_env={
+            'MYPYPATH': 'bin:lib/spack:lib/spack/external:var/spack/repos/builtin',
+        }
+    )
     returncode = mypy_cmd.returncode
 
     rewrite_and_print_output(output, args)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -36,14 +36,16 @@ import os
 import re
 import sys
 from contextlib import contextmanager
+
 from typing import List  # novm
 
 import six
+from six import iteritems
+
+from compat import OrderedDict
 
 import ruamel.yaml as yaml
-from ordereddict_backport import OrderedDict
 from ruamel.yaml.error import MarkedYAMLError
-from six import iteritems
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -38,6 +38,8 @@ import sys
 from contextlib import contextmanager
 from typing import List  # novm
 
+import six
+
 import ruamel.yaml as yaml
 from ordereddict_backport import OrderedDict
 from ruamel.yaml.error import MarkedYAMLError
@@ -958,7 +960,7 @@ def validate(data, schema, filename=None):
             line_number = e.instance.lc.line + 1
         else:
             line_number = None
-        raise ConfigFormatError(e, data, filename, line_number)
+        raise six.raise_from(ConfigFormatError(e, data, filename, line_number), e)
     # return the validated data so that we can access the raw data
     # mostly relevant for environments
     return test_data

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -26,6 +26,7 @@ import os
 import socket
 import sys
 import time
+
 from typing import Dict  # novm
 
 import six

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -724,7 +724,9 @@ class Database(object):
             with open(filename, 'r') as f:
                 fdata = sjson.load(f)
         except Exception as e:
-            raise CorruptDatabaseError("error parsing database:", str(e))
+            raise six.raise_from(
+                CorruptDatabaseError("error parsing database:", str(e)),
+                e)
 
         if fdata is None:
             return

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -30,6 +30,7 @@ The available directives are:
 import functools
 import os.path
 import re
+
 from typing import List, Set  # novm
 
 import six

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -30,10 +30,11 @@ The available directives are:
 import functools
 import os.path
 import re
-import sys
 from typing import List, Set  # novm
 
 import six
+
+from compat import Sequence
 
 import llnl.util.lang
 import llnl.util.tty.color
@@ -47,12 +48,6 @@ from spack.dependency import Dependency, canonical_deptype, default_deptype
 from spack.fetch_strategy import from_kwargs
 from spack.resource import Resource
 from spack.version import Version, VersionChecksumError
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Sequence  # novm
-else:
-    from collections import Sequence
-
 
 __all__ = ['DirectiveError', 'DirectiveMeta']
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -11,6 +11,7 @@ import tempfile
 from contextlib import contextmanager
 
 import ruamel.yaml as yaml
+import six
 
 from llnl.util.filesystem import mkdirp
 
@@ -110,13 +111,13 @@ class DirectoryLayout(object):
                     os.unlink(path)
                     os.remove(metapath)
                 except OSError as e:
-                    raise RemoveFailedError(spec, path, e)
+                    raise six.raise_from(RemoveFailedError(spec, path, e), e)
 
         elif os.path.exists(path):
             try:
                 shutil.rmtree(path)
             except OSError as e:
-                raise RemoveFailedError(spec, path, e)
+                raise six.raise_from(RemoveFailedError(spec, path, e), e)
 
         path = os.path.dirname(path)
         while path != self.root:
@@ -131,7 +132,7 @@ class DirectoryLayout(object):
                         # directory wasn't empty, done
                         return
                     else:
-                        raise e
+                        raise
             path = os.path.dirname(path)
 
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -10,8 +10,9 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 
-import ruamel.yaml as yaml
 import six
+
+import ruamel.yaml as yaml
 
 from llnl.util.filesystem import mkdirp
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -2088,7 +2088,7 @@ def _concretize_from_constraints(spec_constraints, tests=False):
                             if any(c.satisfies(invd, strict=True)
                                    for invd in invalid_deps_string)]
             if len(invalid_deps) != len(invalid_deps_string):
-                raise e
+                raise
             invalid_constraints.extend(invalid_deps)
         except UnknownVariantError as e:
             invalid_variants = e.unknown_variants
@@ -2096,7 +2096,7 @@ def _concretize_from_constraints(spec_constraints, tests=False):
                                        if any(name in c.variants
                                               for name in invalid_variants)]
             if len(inv_variant_constraints) != len(invalid_variants):
-                raise e
+                raise
             invalid_constraints.extend(inv_variant_constraints)
 
 

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -9,9 +9,11 @@ import re
 import shutil
 import sys
 
-import ruamel.yaml as yaml
 import six
-from ordereddict_backport import OrderedDict
+
+from compat import OrderedDict
+
+import ruamel.yaml as yaml
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -9,9 +9,7 @@ import re
 import shutil
 import sys
 
-from ordereddict_backport import OrderedDict
-
-from compat import filter, map, zip
+from compat import OrderedDict, filter, map, zip
 
 from llnl.util import tty
 from llnl.util.filesystem import mkdirp, remove_dead_links, remove_empty_directories

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -11,6 +11,8 @@ import sys
 
 from ordereddict_backport import OrderedDict
 
+from compat import filter, map, zip
+
 from llnl.util import tty
 from llnl.util.filesystem import mkdirp, remove_dead_links, remove_empty_directories
 from llnl.util.lang import index_by, match_predicate
@@ -30,12 +32,6 @@ from spack.directory_layout import (
     YamlViewExtensionsLayout,
 )
 from spack.error import SpackError
-
-# compatability
-if sys.version_info < (3, 0):
-    from itertools import ifilter as filter
-    from itertools import imap as map
-    from itertools import izip as zip
 
 __all__ = ["FilesystemView", "YamlFilesystemView"]
 

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -10,6 +10,8 @@ import shutil
 import sys
 import tty
 
+import six
+
 import llnl.util.filesystem as fs
 
 import spack.error
@@ -245,7 +247,9 @@ class TestSuite(object):
                 return TestSuite.from_dict(data)
         except Exception as e:
             tty.debug(e)
-            raise sjson.SpackJSONError("error parsing JSON TestSuite:", str(e))
+            raise six.raise_from(
+                sjson.SpackJSONError("error parsing JSON TestSuite:", str(e)),
+                e)
 
 
 def _add_msg_to_file(filename, msg):

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -14,17 +14,14 @@ to download packages directly from a mirror (e.g., on an intranet).
 import operator
 import os
 import os.path
-import sys
 import traceback
+import operator
+
+import six
 
 import ruamel.yaml.error as yaml_error
-import six
-from ordereddict_backport import OrderedDict
 
-if sys.version_info >= (3, 5):
-    from collections.abc import Mapping  # novm
-else:
-    from collections import Mapping
+from compat import Mapping, OrderedDict
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -14,14 +14,14 @@ to download packages directly from a mirror (e.g., on an intranet).
 import operator
 import os
 import os.path
+import sys
 import traceback
-import operator
 
 import six
 
-import ruamel.yaml.error as yaml_error
-
 from compat import Mapping, OrderedDict
+
+import ruamel.yaml.error as yaml_error
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -73,7 +73,9 @@ class Mirror(object):
             data = syaml.load(stream)
             return Mirror.from_dict(data, name)
         except yaml_error.MarkedYAMLError as e:
-            raise syaml.SpackYAMLError("error parsing YAML spec:", str(e))
+            raise six.raise_from(
+                syaml.SpackYAMLError("error parsing YAML spec:", str(e)),
+                e)
 
     @staticmethod
     def from_json(stream, name=None):
@@ -182,7 +184,9 @@ class MirrorCollection(Mapping):
             data = syaml.load(stream)
             return MirrorCollection(data)
         except yaml_error.MarkedYAMLError as e:
-            raise syaml.SpackYAMLError("error parsing YAML spec:", str(e))
+            raise six.raise_from(
+                syaml.SpackYAMLError("error parsing YAML spec:", str(e)),
+                e)
 
     @staticmethod
     def from_json(stream, name=None):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -26,10 +26,12 @@ import textwrap
 import time
 import traceback
 import types
+
 from typing import Any, Callable, Dict, List, Optional  # novm
 
 import six
-from ordereddict_backport import OrderedDict
+
+from compat import OrderedDict
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1279,7 +1279,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             raise ValueError("Can only get the arch for concrete package.")
         return spack.architecture.arch_for_spec(self.spec.architecture)
 
-    @property  # type: ignore
+    @property  # type: ignore[misc]
     @memoized
     def compiler(self):
         """Get the spack.compiler.Compiler object used to build this package"""

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -10,7 +10,8 @@ import shutil
 
 import macholib.mach_o
 import macholib.MachO
-from ordereddict_backport import OrderedDict
+
+from compat import OrderedDict
 
 import llnl.util.lang
 import llnl.util.tty as tty

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -189,7 +189,7 @@ class FastPackageChecker(Mapping):
                 elif e.errno == errno.EACCES:
                     tty.warn("Can't read package file %s." % pkg_file)
                     continue
-                raise e
+                raise
 
             # If it's not a file, skip it.
             if stat.S_ISDIR(sinfo.st_mode):

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -19,14 +19,10 @@ import traceback
 import types
 from typing import Dict  # novm
 
+import ruamel.yaml as yaml
 import six
 
-if sys.version_info >= (3, 5):
-    from collections.abc import Mapping  # novm
-else:
-    from collections import Mapping
-
-import ruamel.yaml as yaml
+from compat import Mapping
 
 import llnl.util.filesystem as fs
 import llnl.util.lang

--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -17,12 +17,14 @@ import stat
 import sys
 import traceback
 import types
+
 from typing import Dict  # novm
 
-import ruamel.yaml as yaml
 import six
 
 from compat import Mapping
+
+import ruamel.yaml as yaml
 
 import llnl.util.filesystem as fs
 import llnl.util.lang

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -13,10 +13,11 @@ import socket
 import time
 import xml.sax.saxutils
 
-from ordereddict_backport import OrderedDict
 from six import iteritems, text_type
 from six.moves.urllib.parse import urlencode
 from six.moves.urllib.request import HTTPHandler, Request, build_opener
+
+from compat import OrderedDict
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import working_dir

--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -62,7 +62,7 @@ def _s3_open(url):
 class UrllibS3Handler(urllib_request.HTTPSHandler):
     def s3_open(self, req):
         orig_url = req.get_full_url()
-        from botocore.exceptions import ClientError
+        from botocore.exceptions import ClientError  # type: ignore[import]
         try:
             url, headers, stream = _s3_open(orig_url)
             return urllib_response.addinfourl(stream, headers, url)

--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -5,6 +5,7 @@
 
 from io import BufferedReader
 
+import six
 import six.moves.urllib.error as urllib_error
 import six.moves.urllib.request as urllib_request
 import six.moves.urllib.response as urllib_response
@@ -78,11 +79,11 @@ class UrllibS3Handler(urllib_request.HTTPSHandler):
                 except ClientError as err2:
                     if err.response['Error']['Code'] == 'NoSuchKey':
                         # raise original error
-                        raise urllib_error.URLError(err)
+                        raise six.raise_from(urllib_error.URLError(err), err)
 
-                    raise urllib_error.URLError(err2)
+                    raise six.raise_from(urllib_error.URLError(err2), err2)
 
-            raise urllib_error.URLError(err)
+            raise six.raise_from(urllib_error.URLError(err), err)
 
 
 S3OpenerDirector = urllib_request.build_opener(UrllibS3Handler())

--- a/lib/spack/spack/schema/environment.py
+++ b/lib/spack/spack/schema/environment.py
@@ -38,13 +38,8 @@ def parse(config_obj):
         config_obj: a configuration dictionary conforming to the
             schema definition for environment modifications
     """
-    import sys
-
     import spack.util.environment as ev
-    if sys.version_info >= (3, 5):
-        from collections.abc import Sequence  # novm
-    else:
-        from collections import Sequence  # novm
+    from compat import Sequence
 
     env = ev.EnvironmentModifications()
     for command, variable in config_obj.items():

--- a/lib/spack/spack/schema/environment.py
+++ b/lib/spack/spack/schema/environment.py
@@ -38,8 +38,9 @@ def parse(config_obj):
         config_obj: a configuration dictionary conforming to the
             schema definition for environment modifications
     """
-    import spack.util.environment as ev
     from compat import Sequence
+
+    import spack.util.environment as ev
 
     env = ev.EnvironmentModifications()
     for command, variable in config_obj.items():

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -13,6 +13,8 @@ import sys
 import types
 import warnings
 
+from compat import Sequence
+
 from six import string_types
 
 import archspec.cpu
@@ -46,10 +48,6 @@ import spack.util.timer
 import spack.variant
 import spack.version
 
-if sys.version_info >= (3, 3):
-    from collections.abc import Sequence  # novm
-else:
-    from collections import Sequence
 
 
 def issequence(obj):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -13,9 +13,9 @@ import sys
 import types
 import warnings
 
-from compat import Sequence
-
 from six import string_types
+
+from compat import Sequence
 
 import archspec.cpu
 
@@ -47,7 +47,6 @@ import spack.spec
 import spack.util.timer
 import spack.variant
 import spack.version
-
 
 
 def issequence(obj):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -20,12 +20,12 @@ from compat import Sequence
 import archspec.cpu
 
 try:
-    import clingo
+    import clingo  # type: ignore[import]
 
     # There may be a better way to detect this
     clingo_cffi = hasattr(clingo.Symbol, '_rep')
 except ImportError:
-    clingo = None  # type: ignore
+    clingo = None
     clingo_cffi = False
 
 import llnl.util.lang

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2119,7 +2119,9 @@ class Spec(object):
             data = yaml.load(stream)
             return Spec.from_dict(data)
         except yaml.error.MarkedYAMLError as e:
-            raise syaml.SpackYAMLError("error parsing YAML spec:", str(e))
+            raise six.raise_from(
+                syaml.SpackYAMLError("error parsing YAML spec:", str(e)),
+                e)
 
     @staticmethod
     def from_json(stream):
@@ -2133,7 +2135,9 @@ class Spec(object):
             return Spec.from_dict(data)
         except Exception as e:
             tty.debug(e)
-            raise sjson.SpackJSONError("error parsing JSON spec:", str(e))
+            raise six.raise_from(
+                sjson.SpackJSONError("error parsing JSON spec:", str(e)),
+                e)
 
     @staticmethod
     def from_detection(spec_str, extra_attributes=None):
@@ -2655,7 +2659,9 @@ class Spec(object):
             # with inconsistent constraints.  Users cannot produce
             # inconsistent specs like this on the command line: the
             # parser doesn't allow it. Spack must be broken!
-            raise InconsistentSpecError("Invalid Spec DAG: %s" % e.message)
+            raise six.raise_from(
+                InconsistentSpecError("Invalid Spec DAG: %s" % e.message),
+                e)
 
     def index(self, deptype='all'):
         """Return DependencyMap that points to all the dependencies in this
@@ -4558,7 +4564,7 @@ class SpecParser(spack.parse.Parser):
                         self.unexpected_token()
 
         except spack.parse.ParseError as e:
-            raise SpecParseError(e)
+            raise six.raise_from(SpecParseError(e), e)
 
         return specs
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -86,6 +86,8 @@ import sys
 import ruamel.yaml as yaml
 import six
 
+from compat import Mapping
+
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
 import llnl.util.tty as tty
@@ -114,11 +116,6 @@ import spack.util.spack_yaml as syaml
 import spack.util.string
 import spack.variant as vt
 import spack.version as vn
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Mapping  # novm
-else:
-    from collections import Mapping
 
 
 __all__ = [

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4407,35 +4407,49 @@ class SpecLexer(spack.parse.Lexer):
 
     """Parses tokens that make up spack specs."""
 
+    # TODO: Determine whether using >2 lexer modes would allow us to create
+    # a separate entry (likely defined the same as `spec_id_re` at first) to
+    # specifically match version strings, variant names, compiler dependency
+    # names (with '%').
     def __init__(self):
         super(SpecLexer, self).__init__([
-            (r'\^', lambda scanner, val: self.token(DEP,   val)),
-            (r'\@', lambda scanner, val: self.token(AT,    val)),
-            (r'\:', lambda scanner, val: self.token(COLON, val)),
-            (r'\,', lambda scanner, val: self.token(COMMA, val)),
-            (r'\+', lambda scanner, val: self.token(ON,    val)),
-            (r'\-', lambda scanner, val: self.token(OFF,   val)),
-            (r'\~', lambda scanner, val: self.token(OFF,   val)),
-            (r'\%', lambda scanner, val: self.token(PCT,   val)),
-            (r'\=', lambda scanner, val: self.token(EQ,    val)),
+            ([
+                # '^': dependency, or "AND":
+                (r'\^', lambda scanner, val: self.token(DEP,   val)),
+                # '@': begin a Version, VersionRange, or VersionList:
+                (r'\@', lambda scanner, val: self.token(AT,    val)),
+                # VersionRange syntax:
+                (r'\:', lambda scanner, val: self.token(COLON, val)),
+                # VersionList syntax:
+                (r'\,', lambda scanner, val: self.token(COMMA, val)),
+                # variant syntax:
+                (r'\+', lambda scanner, val: self.token(ON,    val)),
+                (r'\-', lambda scanner, val: self.token(OFF,   val)),
+                (r'\~', lambda scanner, val: self.token(OFF,   val)),
+                # Compiler dependency syntax:
+                (r'\%', lambda scanner, val: self.token(PCT,   val)),
 
-            # Filenames match before identifiers, so no initial filename
-            # component is parsed as a spec (e.g., in subdir/spec.yaml)
-            (r'[/\w.-]*/[/\w/-]+\.yaml[^\b]*',
-             lambda scanner, v: self.token(FILE, v)),
+                # This is *not* used in version string parsing.
+                (r'\=', lambda scanner, val: self.token(EQ,    val)),
 
-            # Hash match after filename. No valid filename can be a hash
-            # (files end w/.yaml), but a hash can match a filename prefix.
-            (r'/', lambda scanner, val: self.token(HASH, val)),
+                # Filenames match before identifiers, so no initial filename
+                # component is parsed as a spec (e.g., in subdir/spec.yaml)
+                (r'[/\w.-]*/[/\w/-]+\.yaml[^\b]*',
+                 lambda scanner, v: self.token(FILE, v)),
 
-            # Identifiers match after filenames and hashes.
-            (spec_id_re, lambda scanner, val: self.token(ID, val)),
+                # Hash match after filename. No valid filename can be a hash
+                # (files end w/.yaml), but a hash can match a filename prefix.
+                (r'/', lambda scanner, val: self.token(HASH, val)),
 
-            (r'\s+', lambda scanner, val: None)],
-            [EQ],
-            [(r'[\S].*', lambda scanner, val: self.token(VAL,    val)),
-             (r'\s+', lambda scanner, val: None)],
-            [VAL])
+                # Identifiers match after filenames and hashes.
+                (spec_id_re, lambda scanner, val: self.token(ID, val)),
+
+                # Gobble up all remaining whitespace between tokens.
+                (r'\s+', lambda scanner, val: None),
+            ], {1: [EQ]}),
+            ([(r'[\S].*', lambda scanner, val: self.token(VAL,    val)),
+              (r'\s+', lambda scanner, val: None)],
+             {0: [VAL]})])
 
 
 # Lexer is always the same for every parser.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -81,12 +81,12 @@ import itertools
 import operator
 import os
 import re
-import sys
 
-import ruamel.yaml as yaml
 import six
 
 from compat import Mapping
+
+import ruamel.yaml as yaml
 
 import llnl.util.filesystem as fs
 import llnl.util.lang as lang
@@ -116,7 +116,6 @@ import spack.util.spack_yaml as syaml
 import spack.util.string
 import spack.variant as vt
 import spack.version as vn
-
 
 __all__ = [
     'CompilerSpec',

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -24,12 +24,6 @@ import spack.spec as spec
 import spack.util.gpg
 import spack.util.spack_yaml as syaml
 
-try:
-    # dynamically import to keep vermin from complaining
-    collections_abc = __import__('collections.abc')
-except ImportError:
-    collections_abc = collections
-
 
 @pytest.fixture
 def tmp_scope():

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import collections
 import itertools as it
 import json
 import os

--- a/lib/spack/spack/test/cmd/versions.py
+++ b/lib/spack/spack/test/cmd/versions.py
@@ -41,7 +41,7 @@ def test_remote_versions_only():
 @pytest.mark.usefixtures('mock_packages')
 def test_new_versions_only(monkeypatch):
     """Test a package for which new versions should be available."""
-    from spack.pkg.builtin.mock.brillig import Brillig
+    from spack.pkg.builtin.mock.brillig import Brillig  # type: ignore[import]
 
     def mock_fetch_remote_versions(*args, **kwargs):
         mock_remote_versions = {

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -16,6 +16,8 @@ import shutil
 import tempfile
 import xml.etree.ElementTree
 
+from typing import Dict  # novm
+
 import py
 import pytest
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1363,7 +1363,7 @@ repo:
 class MockBundle(object):
     has_code = False
     name = 'mock-bundle'
-    versions = {}  # type: ignore
+    versions = {}  # type: Dict
 
 
 @pytest.fixture

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -51,8 +51,8 @@ from spack.util.pattern import Bunch
 #
 # Return list of shas for latest two git commits in local spack repo
 #
-@pytest.fixture
-def last_two_git_commits(scope='session'):
+@pytest.fixture(scope='session')
+def last_two_git_commits():
     git = spack.util.executable.which('git', required=True)
     spack_git_path = spack.paths.prefix
     with working_dir(spack_git_path):

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -106,13 +106,13 @@ class TestPackage(object):
     # Below tests target direct imports of spack packages from the
     # spack.pkg namespace
     def test_import_package(self):
-        import spack.pkg.builtin.mock.mpich             # noqa
+        import spack.pkg.builtin.mock.mpich  # type: ignore[import] # noqa
 
     def test_import_package_as(self):
-        import spack.pkg.builtin.mock.mpich as mp       # noqa
-        import spack.pkg.builtin.mock                   # noqa
-        import spack.pkg.builtin.mock as m              # noqa
-        from spack.pkg.builtin import mock              # noqa
+        import spack.pkg.builtin.mock  # noqa
+        import spack.pkg.builtin.mock as m  # noqa
+        import spack.pkg.builtin.mock.mpich as mp  # noqa
+        from spack.pkg.builtin import mock  # noqa
 
     def test_inheritance_of_diretives(self):
         p = spack.repo.get('simple-inheritance')
@@ -155,18 +155,18 @@ class TestPackage(object):
         from spack.pkg.builtin.mock.mpich import Mpich  # noqa
 
     def test_import_module_from_package(self):
-        from spack.pkg.builtin.mock import mpich        # noqa
+        from spack.pkg.builtin.mock import mpich  # noqa
 
     def test_import_namespace_container_modules(self):
-        import spack.pkg                                # noqa
-        import spack.pkg as p                           # noqa
-        from spack import pkg                           # noqa
-        import spack.pkg.builtin                        # noqa
-        import spack.pkg.builtin as b                   # noqa
-        from spack.pkg import builtin                   # noqa
-        import spack.pkg.builtin.mock                   # noqa
-        import spack.pkg.builtin.mock as m              # noqa
-        from spack.pkg.builtin import mock              # noqa
+        import spack.pkg  # noqa
+        import spack.pkg as p  # noqa
+        import spack.pkg.builtin  # noqa
+        import spack.pkg.builtin as b  # noqa
+        import spack.pkg.builtin.mock  # noqa
+        import spack.pkg.builtin.mock as m  # noqa
+        from spack import pkg  # noqa
+        from spack.pkg import builtin  # noqa
+        from spack.pkg.builtin import mock  # noqa
 
 
 @pytest.mark.regression('2737')

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -11,9 +11,10 @@ YAML format preserves DAG information in the spec.
 import ast
 import inspect
 import os
-from compat import Iterable, Mapping
 
 import pytest
+
+from compat import Iterable, Mapping
 
 import spack.architecture
 import spack.hash_types as ht
@@ -25,6 +26,7 @@ from spack import repo
 from spack.spec import Spec, save_dependency_spec_yamls
 from spack.util.mock_package import MockPackageMultiRepo
 from spack.util.spack_yaml import syaml_dict
+
 
 def check_yaml_round_trip(spec):
     yaml_text = spec.to_yaml()

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -11,7 +11,7 @@ YAML format preserves DAG information in the spec.
 import ast
 import inspect
 import os
-import sys
+from compat import Iterable, Mapping
 
 import pytest
 
@@ -25,12 +25,6 @@ from spack import repo
 from spack.spec import Spec, save_dependency_spec_yamls
 from spack.util.mock_package import MockPackageMultiRepo
 from spack.util.spack_yaml import syaml_dict
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Iterable, Mapping  # novm
-else:
-    from collections import Iterable, Mapping
-
 
 def check_yaml_round_trip(spec):
     yaml_text = spec.to_yaml()

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -23,6 +23,7 @@ import llnl.util.tty as tty
 from llnl.util.lang import dedupe
 
 import spack.util.executable as executable
+import spack.util.spack_json as sjson
 
 system_paths = ['/', '/usr', '/usr/local']
 suffixes = ['bin', 'bin64', 'include', 'lib', 'lib64']
@@ -1003,13 +1004,7 @@ def environment_after_sourcing_files(*files, **kwargs):
 
         # If we're in python2, convert to str objects instead of unicode
         # like json gives us.  We can't put unicode in os.environ anyway.
-        if sys.version_info[0] < 3:
-            environment = dict(
-                (k.encode('utf-8'), v.encode('utf-8'))
-                for k, v in environment.items()
-            )
-
-        return environment
+        return sjson.encode_json_dict(environment)
 
     current_environment = kwargs.get('env', dict(os.environ))
     for f in files:
@@ -1050,7 +1045,7 @@ def sanitize(environment, blacklist, whitelist):
         return subset
 
     # Don't modify input, make a copy instead
-    environment = dict(environment)
+    environment = sjson.decode_json_dict(dict(environment))
 
     # Retain (whitelist) has priority over prune (blacklist)
     prune = set_intersection(set(environment), *blacklist)

--- a/lib/spack/spack/util/pattern.py
+++ b/lib/spack/spack/util/pattern.py
@@ -5,12 +5,8 @@
 
 import functools
 import inspect
-import sys
 
-if sys.version_info >= (3, 3):
-    from collections.abc import MutableSequence  # novm
-else:
-    from collections import MutableSequence
+from compat import MutableSequence
 
 
 class Delegate(object):

--- a/lib/spack/spack/util/py2.py
+++ b/lib/spack/spack/util/py2.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import base64
+
+from six import binary_type, text_type, PY3
+
+
+def b32encode(digest):
+    # type: (binary_type) -> text_type
+    b32 = base64.b32encode(digest)
+    if PY3:
+        return b32.decode()
+    return b32

--- a/lib/spack/spack/util/py2.py
+++ b/lib/spack/spack/util/py2.py
@@ -5,7 +5,7 @@
 
 import base64
 
-from six import binary_type, text_type, PY3
+from six import PY3, binary_type, text_type
 
 
 def b32encode(digest):

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -28,8 +28,8 @@ def create_s3_session(url):
     # NOTE(opadron): import boto and friends as late as possible.  We don't
     # want to require boto as a dependency unless the user actually wants to
     # access S3 mirrors.
-    from boto3 import Session
-    from botocore.exceptions import ClientError
+    from boto3 import Session  # type: ignore[import]
+    from botocore.exceptions import ClientError  # type: ignore[import]
 
     session = Session()
 
@@ -41,8 +41,8 @@ def create_s3_session(url):
 
     # if no access credentials provided above, then access anonymously
     if not session.get_credentials():
-        from botocore import UNSIGNED
-        from botocore.client import Config
+        from botocore import UNSIGNED  # type: ignore[import]
+        from botocore.client import Config  # type: ignore[import]
 
         s3_client_args["config"] = Config(signature_version=UNSIGNED)
 

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -40,7 +40,7 @@ def encode_json_dict(data):
 def dump(data, stream=None):
     # type: (Dict, Optional[Any]) -> Optional[str]
     """Dump JSON with a reasonable amount of indentation and separation."""
-    data = _strify(data, encode_strings=False)
+    data = _strify(data)
     if stream is None:
         return json.dumps(data, **_json_dump_args)     # type: ignore[arg-type]
     json.dump(data, stream, **_json_dump_args)         # type: ignore[arg-type]
@@ -50,11 +50,11 @@ def dump(data, stream=None):
 def decode_json_dict(data):
     # type: (Dict) -> Dict
     """Converts str to python 2 unicodes in JSON data."""
-    return _strify(data, encode_strings=False)
+    return _strify(data)
 
 
-def _strify(data, ignore_dicts=False, encode_strings=True):
-    # type: (Dict, bool, bool) -> Dict
+def _strify(data, ignore_dicts=False):
+    # type: (Dict, bool) -> Dict
     """Helper method for ``encode_json_dict()`` and ``decode_json_dict()``.
 
     Converts python 2 unicodes to str in JSON data, or the other way around."""
@@ -63,12 +63,10 @@ def _strify(data, ignore_dicts=False, encode_strings=True):
         return data
 
     # if this is a unicode string in python 2, return its string representation
-    if encode_strings:
-        if isinstance(data, string_types):
-            return data.encode('utf-8')
-    else:
-        if isinstance(data, binary_type):
-            return data.decode()
+    if isinstance(data, string_types):
+        return data.encode('utf-8')
+    elif isinstance(data, binary_type):
+        return data.decode()
 
     # if this is a list of values, return list of byteified values
     if isinstance(data, list):

--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -5,9 +5,10 @@
 
 """Simple wrapper around JSON to guarantee consistent use of load/dump. """
 import json
+
 from typing import Any, Dict, Optional  # novm
 
-from six import binary_type, iteritems, string_types, PY3
+from six import PY3, binary_type, iteritems, string_types
 
 import spack.error
 

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -14,22 +14,17 @@
 """
 import ctypes
 import re
-import sys
 from typing import List  # novm
 
 import ruamel.yaml as yaml
-from ordereddict_backport import OrderedDict
 from ruamel.yaml import RoundTripDumper, RoundTripLoader
 from six import StringIO, string_types
+
+from compat import Mapping, OrderedDict
 
 from llnl.util.tty.color import cextra, clen, colorize
 
 import spack.error
-
-if sys.version_info >= (3, 3):
-    from collections.abc import Mapping  # novm
-else:
-    from collections import Mapping
 
 
 # Only export load and dump

--- a/lib/spack/spack/util/spack_yaml.py
+++ b/lib/spack/spack/util/spack_yaml.py
@@ -14,18 +14,19 @@
 """
 import ctypes
 import re
+
 from typing import List  # novm
 
-import ruamel.yaml as yaml
-from ruamel.yaml import RoundTripDumper, RoundTripLoader
 from six import StringIO, string_types
 
 from compat import Mapping, OrderedDict
 
+import ruamel.yaml as yaml
+from ruamel.yaml import RoundTripDumper, RoundTripLoader
+
 from llnl.util.tty.color import cextra, clen, colorize
 
 import spack.error
-
 
 # Only export load and dump
 __all__ = ['load', 'dump', 'SpackYAMLError']

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -216,7 +216,7 @@ def url_exists(url):
         except s3.ClientError as err:
             if err.response['Error']['Code'] == 'NoSuchKey':
                 return False
-            raise err
+            raise
 
     # otherwise, just try to "read" from the URL, and assume that *any*
     # non-throwing response contains the resource represented by the URL

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -11,14 +11,10 @@ import functools
 import inspect
 import itertools
 import re
-import sys
 
 from six import StringIO
 
-if sys.version_info >= (3, 5):
-    from collections.abc import Sequence  # novm
-else:
-    from collections import Sequence
+from compat import Sequence
 
 import llnl.util.lang as lang
 import llnl.util.tty.color

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -2,13 +2,15 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import base64
 import hashlib
 import os
-import sys
 
 import llnl.util.tty as tty
 
+import spack.util.py2 as compat
+import spack.util.spack_json as sjson
+import spack.util.file_permissions as fp
+import spack.store
 import spack.filesystem_view
 import spack.store
 import spack.util.file_permissions as fp
@@ -18,12 +20,7 @@ import spack.util.spack_json as sjson
 def compute_hash(path):
     with open(path, 'rb') as f:
         sha1 = hashlib.sha1(f.read()).digest()
-        b32 = base64.b32encode(sha1)
-
-        if sys.version_info[0] >= 3:
-            b32 = b32.decode()
-
-        return b32
+        return compat.b32encode(sha1)
 
 
 def create_manifest_entry(path):

--- a/lib/spack/spack/verify.py
+++ b/lib/spack/spack/verify.py
@@ -7,13 +7,10 @@ import os
 
 import llnl.util.tty as tty
 
-import spack.util.py2 as compat
-import spack.util.spack_json as sjson
-import spack.util.file_permissions as fp
-import spack.store
 import spack.filesystem_view
 import spack.store
 import spack.util.file_permissions as fp
+import spack.util.py2 as compat
 import spack.util.spack_json as sjson
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+show_error_codes=True
+show_absolute_path=True
+show_error_context=True
+show_column_numbers=True
+mypy_path=lib/spack:lib/spack/external
+follow_imports=silent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,21 @@
 [tool.isort]
 profile = "black"
 sections = [
-  "FUTURE",
-  "STDLIB",
-  "THIRDPARTY",
-  "ARCHSPEC", "LLNL", "FIRSTPARTY",
-  "LOCALFOLDER",
-]
+    "FUTURE",
+    "STDLIB",
+    "TYPING",
+    "THIRDPARTY",
+    "COMPAT",
+    "ARCHSPEC", "RUAMEL", "LLNL", "FIRSTPARTY",
+    "LOCALFOLDER",
+  ]
 known_first_party = "spack"
 known_archspec = "archspec"
+known_ruamel = "ruamel"
+known_compat = "compat"
 known_llnl = "llnl"
+known_third_party = "six"
+known_typing = ["typing", "typing_extensions"]
 src_paths = "lib"
 honor_noqa = true
 
@@ -67,7 +73,7 @@ omit = [
     'lib/spack/docs/*',
     'lib/spack/external/*',
     'share/spack/qa/*',
-]
+  ]
 
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration
@@ -87,7 +93,7 @@ exclude_lines = [
     'if 0:',
     'if False:',
     'if __name__ == .__main__.:',
-]
+  ]
 ignore_errors = true
 
 [tool.coverage.html]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,10 @@ known_typing = ["typing", "typing_extensions"]
 src_paths = "lib"
 honor_noqa = true
 
+[mypy]
+
 [tool.mypy]
 python_version = 3.7
-files = ['lib/spack/llnl/**/*.py', 'lib/spack/spack/**/*.py']
 mypy_path = ['bin', 'lib/spack', 'lib/spack/external', 'var/spack/repos/builtin']
 
 # This and a generated import file allows supporting packages


### PR DESCRIPTION
*This PR is on top of #21720--see the diff vs that one at https://github.com/cosmicexplorer/spack/compare/compat-collections...arbitrary-lexer-modes?expand=1.*

### Problem

*This PR is a component of #24025.*

The current `Lexer` class only allows specifically two modes. While this is fine for spack's purposes, there is reason to believe we might want more than two at some point (see #20256).

### Solution

- Allow the `Lexer` to accept a dictionary of values.