### PR TITLE
CUDA official GCC conflicts

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -91,7 +91,7 @@ class CudaPackage(PackageBase):
     # https://github.com/spack/spack/pull/25054#issuecomment-886531664
     # these conflicts are valid independently from the architecture
 
-    # minimum versions
+    # minimum supported versions
     conflicts('%gcc@:4', when='+cuda ^cuda@11.0:')
     conflicts('%gcc@:5', when='+cuda ^cuda@11.4:')
 
@@ -99,8 +99,8 @@ class CudaPackage(PackageBase):
     # NOTE:
     # in order to not constrain future cuda version to old gcc versions,
     # it has been decided to use an upper bound for the latest version.
-    # This implies that the latter one has to be updated at each release
-    # of a new cuda minor version.
+    # This implies that the last one in the list has to be updated at
+    # each release of a new cuda minor version.
     conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
     conflicts('%gcc@11:', when='+cuda ^cuda@:11.4')
 

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -86,6 +86,24 @@ class CudaPackage(PackageBase):
     # apply to platform=darwin. We currently do not provide conflicts for
     # platform=darwin with %apple-clang.
 
+    # GCC
+    # According to
+    # https://github.com/spack/spack/pull/25054#issuecomment-886531664
+    # these conflicts are valid independently from the architecture
+
+    # minimum versions
+    conflicts('%gcc@:4', when='+cuda ^cuda@11.0:')
+    conflicts('%gcc@:5', when='+cuda ^cuda@11.4:')
+
+    # maximum supported version
+    # NOTE:
+    # in order to not constrain future cuda version to old gcc versions,
+    # it has been decided to use an upper bound for the latest version.
+    # This implies that the latter one has to be updated at each release
+    # of a new cuda minor version.
+    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
+    conflicts('%gcc@11:', when='+cuda ^cuda@:11.4')
+
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132
     with when('~allow-unsupported-compilers'):
@@ -94,9 +112,6 @@ class CudaPackage(PackageBase):
         conflicts('%gcc@7:', when='+cuda ^cuda@:9.1 target=x86_64:')
         conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=x86_64:')
         conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89 target=x86_64:')
-        conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2: target=x86_64:')
-        conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.3 target=x86_64:')
-        conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
         conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27 target=x86_64:')
         conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5 target=x86_64:')
         conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8 target=x86_64:')
@@ -130,9 +145,6 @@ class CudaPackage(PackageBase):
         conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=ppc64le:')
         conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243 target=ppc64le:')
         # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
-        conflicts('%gcc@:4', when='+cuda ^cuda@11.0.2: target=ppc64le:')
-        conflicts('%gcc@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
-        conflicts('%gcc@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
         conflicts('%pgi', when='+cuda ^cuda@:8 target=ppc64le:')
         conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185 target=ppc64le:')
         conflicts('%pgi@:17', when='+cuda ^cuda@:10 target=ppc64le:')

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -104,6 +104,9 @@ class CudaPackage(PackageBase):
     conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
     conflicts('%gcc@11:', when='+cuda ^cuda@:11.4')
 
+    # https://gist.github.com/ax3l/9489132#gistcomment-3860114
+    conflicts('%gcc@10', when='+cuda ^cuda@:11.4.0')
+
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132
     with when('~allow-unsupported-compilers'):


### PR DESCRIPTION
Looking at the CUDA conflicts declaration I realized that there is a mismatch between CUDA versions and officially supported GCC.

In particular, targeting CUDA 11 on generic x86_64, looking at the official DOC for various minor versions ([11.0](https://docs.nvidia.com/cuda/archive/11.0/cuda-installation-guide-linux/index.html#system-requirements), [11.1.0](https://docs.nvidia.com/cuda/archive/11.1.0/cuda-installation-guide-linux/index.html#system-requirements), [11.2.0](https://docs.nvidia.com/cuda/archive/11.2.0/cuda-installation-guide-linux/index.html#system-requirements), [11.3.0](https://docs.nvidia.com/cuda/archive/11.3.0/cuda-installation-guide-linux/index.html#system-requirements), [11.4.0](https://docs.nvidia.com/cuda/archive/11.4.0/cuda-installation-guide-linux/index.html#system-requirements)), they all report GCC 9.x as supported version. 

From this, together with the following notes extents from the official doc
> (2) Note that starting with CUDA 11.0, the minimum recommended GCC compiler is at least GCC 5 [ed GCC 6 for Cuda 11.4.0] due to C++11 requirements in CUDA libraries e.g. cuFFT and CUB

> (3) Minor versions of the following compilers listed: of GCC, ICC, PGI and XLC, as host compilers for nvcc are supported.

I would say that:
- CUDA 11 (at the time of writing) works with GCC up to version 9 (all minor versions included);
- CUDA [11.0, 11.4) requires GCC 5 as minimum version
- CUDA 11.4 requires GCC 6 as minimum version

As an additional information, I quickly checked `crt/host_config.h` in the CUDA version I have right now (11.0) which contains the following snippet

```cpp
#if __GNUC__ > 9

#error -- unsupported GNU version! gcc versions later than 9 are not supported!

#endif /* __GNUC__ > 9 */
```

which looks quite strict in not supporting newer versions.

As a last note, I looked at https://gist.github.com/ax3l/9489132 that is reported just above the declaration of cuda conflicts in spack, and it says

> [...] Sometimes it is possible to hack the requirements there to get some newer versions working, too :)

which may be (at least partially) in contrast with the previous `crt/host_config.h`. Moreover, there is also a [section](https://gist.github.com/ax3l/9489132#nvcc) that tries to report in a table the compatibility list of CUDA with the different compilers, but it looks incomplete and not fully correct (e.g. it reports `11.1.0 NVCC:11.1.74 compatible with GCC (5-)6-10.0`, but AFAIK is incorrect).

The content of the gist may be useful and it may be worth to put it somewhere where it can be easily updated/fixed (thanks @haampie for the suggestion).