### PR TITLE
ParaView: disable VTK_MODULE_USE_EXTERNAL_ParaView_vtkcatalyst

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -273,6 +273,9 @@ class Paraview(CMakePackage, CudaPackage):
             '-DBUILD_TESTING:BOOL=OFF',
             '-DOpenGL_GL_PREFERENCE:STRING=LEGACY']
 
+        if spec.satisfies('@5.10:'):
+            cmake_args.append('-DVTK_MODULE_USE_EXTERNAL_ParaView_vtkcatalyst:BOOL=OFF')
+
         if spec.satisfies('@:5.7') and spec['cmake'].satisfies('@3.17:'):
             cmake_args.append('-DFPHSA_NAME_MISMATCHED:BOOL=ON')
 


### PR DESCRIPTION
Fixes #25057

@mathstuf Not sure if this is the correct fix for spack, but the build succeeded for me after adding this change. Tested on:
```console
* **Spack:** 0.16.2-3651-25c09e7a56
* **Python:** 3.6.3
* **Platform:** linux-rhel7-broadwell
* **Concretizer:** original
```
