### PR TITLE
Fix LBANN and related packages CMake CUDA arch flag

### DIFF
--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -69,7 +69,7 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
             args.append('-DCMAKE_CUDA_STANDARD=14')
             archs = spec.variants['cuda_arch'].value
             if archs != 'none':
-                arch_str = ",".join(archs)
+                arch_str = ";".join(archs)
             args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
         if spec.satisfies('@0.5:'):

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -70,7 +70,7 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
             archs = spec.variants['cuda_arch'].value
             if archs != 'none':
                 arch_str = ";".join(archs)
-            args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
+                args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
         if spec.satisfies('@0.5:'):
             args.extend([

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -160,7 +160,7 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
             archs = spec.variants['cuda_arch'].value
             if archs != 'none':
                 arch_str = ";".join(archs)
-            args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
+                args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
         if '+cuda' in spec or '+distconv' in spec:
             args.append('-DcuDNN_DIR={0}'.format(

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -159,7 +159,7 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
                 args.append('-DCMAKE_CUDA_STANDARD=14')
             archs = spec.variants['cuda_arch'].value
             if archs != 'none':
-                arch_str = ",".join(archs)
+                arch_str = ";".join(archs)
             args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
         if '+cuda' in spec or '+distconv' in spec:

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -165,7 +165,7 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
             archs = spec.variants['cuda_arch'].value
             if archs != 'none':
                 arch_str = ";".join(archs)
-            args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
+                args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
         if '+rocm' in spec:
             args.extend([

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -164,7 +164,7 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
             args.append('-DCMAKE_CUDA_STANDARD=14')
             archs = spec.variants['cuda_arch'].value
             if archs != 'none':
-                arch_str = ",".join(archs)
+                arch_str = ";".join(archs)
             args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
         if '+rocm' in spec:

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -323,7 +323,7 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
                 args.append('-DCMAKE_CUDA_STANDARD=14')
             archs = spec.variants['cuda_arch'].value
             if archs != 'none':
-                arch_str = ",".join(archs)
+                arch_str = ";".join(archs)
             args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
         if spec.satisfies('@:0.90') or spec.satisfies('@0.95:'):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -324,7 +324,7 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
             archs = spec.variants['cuda_arch'].value
             if archs != 'none':
                 arch_str = ";".join(archs)
-            args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
+                args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
         if spec.satisfies('@:0.90') or spec.satisfies('@0.95:'):
             args.append(


### PR DESCRIPTION
Some fixes after #24074.

1. When specifying multiple compute capabilities, `CMAKE_CUDA_ARCHITECTURES` expects a list delimited by `;` not `,`.
2. Current packages will set `CMAKE_CUDA_ARCHITECTURES=none` when no `cuda_arch` is specified. This is not a valid argument and results in CMake trying to use nvcc arch compilation flags like: `-gencode=arch=compute_,code=sm_`. Modified the packages to not set `CMAKE_CUDA_ARCHITECTURES` at all if no `cuda_arch` is specified.

cc: @bvanessen 