### PR TITLE
gurobi: new version and extend python

### DIFF
--- a/var/spack/repos/builtin/packages/gurobi/package.py
+++ b/var/spack/repos/builtin/packages/gurobi/package.py
@@ -58,4 +58,3 @@ class Gurobi(Package):
         with working_dir('linux64'):
             python = which('python')
             python('setup.py', 'install', '--prefix={0}'.format(self.prefix))
-

--- a/var/spack/repos/builtin/packages/gurobi/package.py
+++ b/var/spack/repos/builtin/packages/gurobi/package.py
@@ -11,33 +11,51 @@ from spack import *
 class Gurobi(Package):
     """The Gurobi Optimizer was designed from the ground up to be the fastest,
     most powerful solver available for your LP, QP, QCP, and MIP (MILP, MIQP,
-    and MIQCP) problems.
+    and MIQCP) problems."""
 
-    Note: Gurobi is licensed software. You will need to create an account on
-    the Gurobi homepage and download Gurobi Optimizer yourself. Spack will
-    search your current directory for the download file. Alternatively, add
-    this file to a mirror so that Spack can find it. For instructions on how to
-    set up a mirror, see http://spack.readthedocs.io/en/latest/mirrors.html
-
-    Please set the path to licence file with the following command (for bash)
-    export GRB_LICENSE_FILE=/path/to/gurobi/license/. See section 4 in
-    $GUROBI_HOME/docs/quickstart_linux.pdf for more details."""
+    # Note: Gurobi is licensed software. You will need to create an account on
+    # the Gurobi homepage and download Gurobi Optimizer yourself. Spack will
+    # search your current directory for the download file. Alternatively, add
+    # this file to a mirror so that Spack can find it. For instructions on how
+    # to set up a mirror, see
+    # http://spack.readthedocs.io/en/latest/mirrors.html
 
     homepage = "http://www.gurobi.com/index"
     manual_download = True
 
+    maintainers = ['glennpj']
+
+    version('9.1.2', sha256='7f60bd675f79476bb2b32cd632aa1d470f8246f2b033b7652d8de86f6e7e429b')
     version('7.5.2', '01f6dbb8d165838cca1664a1a14e4a85')
 
     # Licensing
     license_required = True
+    license_files    = ['gurobi.lic']
     license_vars     = ['GRB_LICENSE_FILE']
     license_url      = 'http://www.gurobi.com/downloads/download-center'
+
+    extends('python')
+    depends_on('python@2.7,3.6:')
 
     def url_for_version(self, version):
         return "file://{0}/gurobi{1}_linux64.tar.gz".format(os.getcwd(), version)
 
+    def patch(self):
+        # Strip out existing PYTHONPATH as the presence of that will generally
+        # break given that Spack has likely set that for a different Python.
+        gurobi_shell = join_path('linux64', 'bin', 'gurobi.sh')
+        filter_file(r':\$PYTHONPATH', '', gurobi_shell)
+
     def setup_run_environment(self, env):
         env.set('GUROBI_HOME', self.prefix)
+        env.set('GRB_LICENSE_FILE', join_path(self.prefix, 'gurobi.lic'))
 
     def install(self, spec, prefix):
         install_tree('linux64', prefix)
+
+    @run_after('install')
+    def gurobipy(self):
+        with working_dir('linux64'):
+            python = which('python')
+            python('setup.py', 'install', '--prefix={0}'.format(self.prefix))
+


### PR DESCRIPTION
- add version 9.1.2
- set a license file
- set the license environment variable
- remove the download and license information out of the description so
  it does not show up in environment modules
- extend python and set python version constraints
- build gurobipy to be used in any compatible python, used for more
  extensive computations than the gurobi shell
- remove preexisting PYTHONPATH from gurobi.sh as the shell uses a
  built-in python, which will likely be different from "system" python
- add myself as maintainer