### PR TITLE
Add Bedops v2.4.40

### DIFF
--- a/var/spack/repos/builtin/packages/bedops/package.py
+++ b/var/spack/repos/builtin/packages/bedops/package.py
@@ -15,6 +15,7 @@ class Bedops(MakefilePackage):
     homepage = "https://bedops.readthedocs.io"
     url      = "https://github.com/bedops/bedops/archive/v2.4.39.tar.gz"
 
+    version('2.4.40', sha256='0670f9ce2da4b68ab13f82c023c84509c7fce5aeb5df980c385fac76eabed4fb')
     version('2.4.39', sha256='f8bae10c6e1ccfb873be13446c67fc3a54658515fb5071663883f788fc0e4912')
     version('2.4.35', sha256='da0265cf55ef5094834318f1ea4763d7a3ce52a6900e74f532dd7d3088c191fa')
     version('2.4.34', sha256='533a62a403130c048d3378e6a975b73ea88d156d4869556a6b6f58d90c52ed95')


### PR DESCRIPTION
Update Bedops to 2.4.40 which includes multiple bug fixes.

**Summarized Changelog:**
- Modified wig2bed start and end shift arithmetic to ensure conversion from 1-based, fully-closed indexing to 0-based, half-open indexing.
- Added wig2bed integration tests. See tests/conversion/Makefile and wig2bed_* targets for more detail.
- Sample input updated for gtf2bed and gff2bed online documentation.
- Conversion of GTF to BED would fail with an error where one of either the gene_id or transcript_id attribute is missing, such as in Ensembl-sourced GTF. This behavior has been changed to a warning.

Full changelog can be found [here](https://bedops.readthedocs.io/en/latest/content/revision-history.html#v2-4-40).

**Test Plan:**
Bedops v2.4.40 built successfully in the Autamus Workflow [here](https://github.com/autamus/registry/runs/3134767644).