### PR TITLE
py-antlr4-python3-runtime: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-antlr4-python3-runtime/package.py
@@ -15,7 +15,9 @@ class PyAntlr4Python3Runtime(PythonPackage):
     homepage = "https://www.antlr.org"
     pypi = "antlr4-python3-runtime/antlr4-python3-runtime-4.7.2.tar.gz"
 
+    version('4.8', sha256='15793f5d0512a372b4e7d2284058ad32ce7dd27126b105fb0b2245130445db33')
     version('4.7.2', sha256='168cdcec8fb9152e84a87ca6fd261b3d54c8f6358f42ab3b813b14a7193bb50b')
 
     depends_on('python@3:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-typing', when='^python@:3.4', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.

This exact version is needed for `py-omegaconf`.

@calebrob6 