### PR TITLE
Add new package libdc1394

### DIFF
--- a/var/spack/repos/builtin/packages/libdc1394/package.py
+++ b/var/spack/repos/builtin/packages/libdc1394/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libdc1394(AutotoolsPackage):
+    """Library providing an API for IEEE 1394 cameras."""
+
+    homepage = "https://damien.douxchamps.net/ieee1394/libdc1394/"
+    url      = "https://downloads.sourceforge.net/project/libdc1394/libdc1394-2/2.2.6/libdc1394-2.2.6.tar.gz"
+
+    maintainers = ['traversaro']
+
+    version('2.2.6', sha256='2b905fc9aa4eec6bdcf6a2ae5f5ba021232739f5be047dec8fe8dd6049c10fed')
+
+    depends_on('libusb')
+
+    def configure_args(self):
+        args = ['--disable-dependency-tracking', '--disable-examples', '--disable-sdltest']
+        return args

--- a/var/spack/repos/builtin/packages/libdc1394/package.py
+++ b/var/spack/repos/builtin/packages/libdc1394/package.py
@@ -19,5 +19,8 @@ class Libdc1394(AutotoolsPackage):
     depends_on('libusb')
 
     def configure_args(self):
-        args = ['--disable-dependency-tracking', '--disable-examples', '--disable-sdltest']
+        args = []
+        args.append('--disable-dependency-tracking')
+        args.append('--disable-examples')
+        args.append('--disable-sdltest')
         return args


### PR DESCRIPTION
The `libdc1394` is a library to access [IEEE 1394](https://en.wikipedia.org/wiki/IEEE_1394) cameras.
I used the name `libdc1394` as it seems the more widespread among other package managers (https://repology.org/project/libdc1394/versions).
The option have been taken from the conda-forge package for the same library: https://github.com/conda-forge/libdc1394-feedstock/blob/cfec2770a53b3f49e49dbab0ac22a201ad41e3dd/recipe/build.sh#L2 .
