### PR TITLE
py-omegaconf: add missing java dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-omegaconf/package.py
+++ b/var/spack/repos/builtin/packages/py-omegaconf/package.py
@@ -25,3 +25,4 @@ class PyOmegaconf(PythonPackage):
     depends_on('py-antlr4-python3-runtime@4.8', type=('build', 'run'))
     depends_on('py-pyyaml@5.1.0:', type=('build', 'run'))
     depends_on('py-dataclasses', when='^python@:3.6', type=('build', 'run'))
+    depends_on('java', type='build')


### PR DESCRIPTION
Java is used at build-time to generate parsers. The build fails if Java is not installed.

Successfully builds on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.