### PR TITLE
py-torchmetrics: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchmetrics/package.py
+++ b/var/spack/repos/builtin/packages/py-torchmetrics/package.py
@@ -12,11 +12,13 @@ class PyTorchmetrics(PythonPackage):
     homepage = "https://github.com/PyTorchLightning/metrics"
     pypi     = "torchmetrics/torchmetrics-0.3.1.tar.gz"
 
+    version('0.4.1', sha256='2fc50f812210c33b8c2649dbb1482e3c47e93cae33e4b3d0427fb830384effbd')
     version('0.3.1', sha256='78f4057db53f7c219fdf9ec9eed151adad18dd43488a44e5c780806d218e3f1d')
     version('0.2.0', sha256='481a28759acd2d77cc088acba6bc7dc4a356c7cb767da2e1495e91e612e2d548')
 
-    depends_on('python@3.6:',     type=('build', 'run'))
-    depends_on('py-setuptools',   type='build')
-    depends_on('py-numpy',        type=('build', 'run'), when='@0.3.0:')
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-numpy@1.17.2:', when='@0.4:', type=('build', 'run'))
+    depends_on('py-numpy', when='@0.3:', type=('build', 'run'))
     depends_on('py-torch@1.3.1:', type=('build', 'run'))
-    depends_on('py-packaging',    type=('build', 'run'), when='@0.3.0:')
+    depends_on('py-packaging', when='@0.3:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds and passes all import tests on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.