### PR TITLE
WIP: buildcache re-sign: new cmd for re-signing local build cache, stripping spack-build-env.txt

### DIFF
--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -119,12 +119,14 @@ def gpg_create(args):
     """create a new key"""
     if args.export or args.secret:
         old_sec_keys = spack.util.gpg.signing_keys()
+        old_sec_keys = [k.fingerprint for k in old_sec_keys]
 
     # Create the new key
     spack.util.gpg.create(name=args.name, email=args.email,
                           comment=args.comment, expires=args.expires)
     if args.export or args.secret:
-        new_sec_keys = set(spack.util.gpg.signing_keys())
+        _keys = spack.util.gpg.signing_keys()
+        new_sec_keys = set([k.fingerprint for k in _keys])
         new_keys = new_sec_keys.difference(old_sec_keys)
 
     if args.export:
@@ -138,6 +140,7 @@ def gpg_export(args):
     keys = args.keys
     if not keys:
         keys = spack.util.gpg.signing_keys()
+        keys = [k.fingerprint for k in keys]
     spack.util.gpg.export_keys(args.location, keys, args.secret)
 
 
@@ -151,6 +154,7 @@ def gpg_sign(args):
     key = args.key
     if key is None:
         keys = spack.util.gpg.signing_keys()
+        keys = [k.fingerprint for k in keys]
         if len(keys) == 1:
             key = keys[0]
         elif not keys:

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -8,7 +8,6 @@ import os
 import pytest
 
 import llnl.util.filesystem as fs
-
 import spack.util.executable
 import spack.util.gpg
 from spack.main import SpackCommand
@@ -88,12 +87,14 @@ def test_gpg(tmpdir, mock_gnupghome):
 
     # Create a key for use in the tests.
     keypath = tmpdir.join('testing-1.key')
+
     gpg('create',
         '--comment', 'Spack testing key',
         '--export', str(keypath),
         'Spack testing 1',
         'spack@googlegroups.com')
-    keyfp = spack.util.gpg.signing_keys()[0]
+
+    keyfp = spack.util.gpg.signing_keys()[0].fingerprint
 
     # List the keys.
     # TODO: Test the output here.

--- a/lib/spack/spack/test/util/util_gpg.py
+++ b/lib/spack/spack/test/util/util_gpg.py
@@ -30,8 +30,8 @@ ssb::2048:1:AAAAAAAAAAAAAAAA:AAAAAAAAAA::::::::::
     keys = spack.util.gpg._parse_secret_keys_output(output)
 
     assert len(keys) == 2
-    assert keys[0] == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-    assert keys[1] == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
+    assert keys[0].fingerprint == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    assert keys[1].fingerprint == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
 
 
 def test_parse_gpg_output_case_two():
@@ -47,7 +47,7 @@ grp:::::::::AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA:
     keys = spack.util.gpg._parse_secret_keys_output(output)
 
     assert len(keys) == 1
-    assert keys[0] == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    assert keys[0].fingerprint == 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 
 
 def test_parse_gpg_output_case_three():
@@ -66,8 +66,8 @@ fpr:::::::::ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ:"""
     keys = spack.util.gpg._parse_secret_keys_output(output)
 
     assert len(keys) == 2
-    assert keys[0] == 'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW'
-    assert keys[1] == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
+    assert keys[0].fingerprint == 'WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW'
+    assert keys[1].fingerprint == 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'
 
 
 @pytest.mark.requires_executables('gpg2')


### PR DESCRIPTION
`spack buildcache re-sign` initial attempt adding a command for re-signing local build cache.

Optionally allows `spack-build-env.txt` to be stripped from existing `.spack` archives.