### PR TITLE
spack recipe for AOCC 3.1.0 release

### DIFF
--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -106,7 +106,15 @@ class Aocc(Compiler):
         )
         if match:
             loc_ver = output.split('AOCC_')[1].split('-')[0]
-        return loc_ver
+            #Maintaining compatibility with previous release
+            #versioning format where dots are used instead
+            #of underscores.
+            #Only 3.1.0 is an expection, next release by default
+            #will have dots instead of underscores
+            if loc_ver == '3_1_0':
+                return '3.1.0'
+            else:
+                return loc_ver
 
     @classmethod
     def fc_version(cls, fortran_compiler):

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -99,7 +99,7 @@ class Aocc(Compiler):
     @llnl.util.lang.memoized
     def extract_version_from_output(cls, output):
         match = re.search(
-            r'AOCC_(\d)[._](\d)[._](\d)',
+            r'AOCC_(\d+)[._](\d+)[._](\d+)',
             output
         )
         if match:

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -101,20 +101,11 @@ class Aocc(Compiler):
         loc_ver = 'unknown'
 
         match = re.search(
-            r'AMD clang version ([^ )]+)',
+            r'AOCC_(\d)[._](\d)[._](\d)',
             output
         )
         if match:
-            loc_ver = output.split('AOCC_')[1].split('-')[0]
-            # Maintaining compatibility with previous release
-            # versioning format where dots are used instead
-            # of underscores.
-            # Only 3.1.0 is an expection, next release by default
-            # will have dots instead of underscores
-            if loc_ver == '3_1_0':
-                return '3.1.0'
-            else:
-                return loc_ver
+            return '.'.join(match.groups())
 
     @classmethod
     def fc_version(cls, fortran_compiler):

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -106,11 +106,11 @@ class Aocc(Compiler):
         )
         if match:
             loc_ver = output.split('AOCC_')[1].split('-')[0]
-            #Maintaining compatibility with previous release
-            #versioning format where dots are used instead
-            #of underscores.
-            #Only 3.1.0 is an expection, next release by default
-            #will have dots instead of underscores
+            # Maintaining compatibility with previous release
+            # versioning format where dots are used instead
+            # of underscores.
+            # Only 3.1.0 is an expection, next release by default
+            # will have dots instead of underscores
             if loc_ver == '3_1_0':
                 return '3.1.0'
             else:

--- a/lib/spack/spack/compilers/aocc.py
+++ b/lib/spack/spack/compilers/aocc.py
@@ -98,8 +98,6 @@ class Aocc(Compiler):
     @classmethod
     @llnl.util.lang.memoized
     def extract_version_from_output(cls, output):
-        loc_ver = 'unknown'
-
         match = re.search(
             r'AOCC_(\d)[._](\d)[._](\d)',
             output

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -345,6 +345,11 @@ def test_cray_frontend_compiler_detection(
 
 @pytest.mark.parametrize('version_str,expected_version', [
     # This applies to C,C++ and FORTRAN compiler
+    ('AMD clang version 12.0.0 (CLANG: AOCC_3_1_0-Build#126 2021_06_07)'
+     '(based on LLVM Mirror.Version.12.0.0)\n'
+     'Target: x86_64-unknown-linux-gnu\n'
+     'Thread model: posix\n', '3.1.0'
+     ),
     ('AMD clang version 12.0.0 (CLANG: AOCC_3.0.0-Build#78 2020_12_10)'
      '(based on LLVM Mirror.Version.12.0.0)\n'
      'Target: x86_64-unknown-linux-gnu\n'

--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -32,6 +32,8 @@ class Aocc(Package):
 
     maintainers = ['amd-toolchain-support']
 
+    version(ver="3.1.0", sha256='1948104a430506fe5e445c0c796d6956109e7cc9fc0a1e32c9f1285cfd566d0c',
+            url='http://developer.amd.com/wordpress/media/files/aocc-compiler-3.1.0.tar')
     version(ver="3.0.0", sha256='4ff269b1693856b9920f57e3c85ce488c8b81123ddc88682a3ff283979362227',
             url='http://developer.amd.com/wordpress/media/files/aocc-compiler-3.0.0.tar')
     version(ver="2.3.0", sha256='9f8a1544a5268a7fb8cd21ac4bdb3f8d1571949d1de5ca48e2d3309928fc3d15',


### PR DESCRIPTION
What's new in AOCC 3.1?
	1. Based on LLVM 12.0 Release (llvm.org, 14th April 2021)
	2. Added vector, inline, and unroll related pragma directives in Flang. Refer AOCC_Flang_Fortran_Compiler document for more details
	3. OMP 4.5 increased coverage for if clauses, parallel clauses and mapping structure to target in FORTRAN
	
Details: https://developer.amd.com/amd-aocc/