### PR TITLE
[yoda] Only depend on root if explicitly desired

### DIFF
--- a/var/spack/repos/builtin/packages/yoda/package.py
+++ b/var/spack/repos/builtin/packages/yoda/package.py
@@ -88,9 +88,8 @@ class Yoda(AutotoolsPackage):
     def configure_args(self):
         args = []
         if self.spec.satisfies('@:1.6.0'):
-            args += '--with-boost=' + self.spec['boost'].prefix
+            args.append('--with-boost=' + self.spec['boost'].prefix)
 
-        if '+root' in self.spec:
-            args += '--enable-root'
+        args.extend(self.enable_or_disable('root'))
 
         return args


### PR DESCRIPTION
root has to be explicitly disabled if variant `root` is not activated, otherwise configuration will fail. Also fixing a small issue with defining the config args for boost.