### PR TITLE
Docs: add link to source code

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -107,6 +107,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
     'sphinxcontrib.programoutput',
 ]
 


### PR DESCRIPTION
By using [sphinx.ext.viewcode](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html), we can add links in the API Docs to view the source code for each method.