### PR TITLE
py-sphinxcontrib-htmlhelp: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-htmlhelp/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-htmlhelp/package.py
@@ -18,7 +18,9 @@ class PySphinxcontribHtmlhelp(PythonPackage):
     # import any modules.
     import_modules = []
 
+    version('2.0.0', sha256='f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2')
     version('1.0.2', sha256='4670f99f8951bd78cd4ad2ab962f798f5618b17675c35c5ac3b2132a14ea8422')
 
+    depends_on('python@3.6:', when='@2:', type=('build', 'run'))
     depends_on('python@3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.