### PR TITLE
py-sphinxcontrib-serializinghtml: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinxcontrib-serializinghtml/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinxcontrib-serializinghtml/package.py
@@ -18,6 +18,7 @@ class PySphinxcontribSerializinghtml(PythonPackage):
     # to import any modules.
     import_modules = []
 
+    version('1.1.5', sha256='aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952')
     version('1.1.3', sha256='c0efb33f8052c04fd7a26c0a07f1678e8512e0faec19f4aa8f2473a8b81d5227')
 
     depends_on('python@3.5:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.