### PR TITLE
Caliper: Add E4S testsuite stand alone test

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -147,9 +147,6 @@ class Caliper(CMakePackage, CudaPackage):
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([join_path('examples', 'apps')])
 
-    def setup_run_environment(self, env):
-        env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix, 'lib64'))
-
     def run_cxx_example_test(self):
         """Run stand alone test: cxx_example"""
 
@@ -174,5 +171,4 @@ class Caliper(CMakePackage, CudaPackage):
                       work_dir=test_dir)
 
     def test(self):
-        print("Running caliper example test")
         self.run_cxx_example_test()

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -138,7 +138,7 @@ class Caliper(CMakePackage, CudaPackage):
 
         return args
 
-    run_after('install')
+    @run_after('install')
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -137,3 +137,9 @@ class Caliper(CMakePackage, CudaPackage):
             args.append('-DWITH_CUPTI=Off')
 
         return args
+
+    run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources([join_path('examples', 'apps')])

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -162,18 +162,17 @@ class Caliper(CMakePackage, CudaPackage):
         exe = 'cxx-example'
 
         self.run_test(exe='gcc',
-                      options=['{0}'.format(join_path(self.prefix, '.spack', 'test', 'examples', 'apps', 'cxx-example.cpp')),
+                      options=['{0}'.format(join_path(test_dir, 'cxx-example.cpp')),
                                '-L{0}'.format(join_path(self.prefix, 'lib64')),
                                '-I{0}'.format(join_path(self.prefix, 'include')),
-                               '-std=c++11', '-o', '-lcaliper', '-lstdc++', exe],
+                               '-std=c++11', '-lcaliper', '-lstdc++', '-o', exe],
                       purpose='test: compile {0} example'.format(exe),
                       work_dir=test_dir)
 
-        """self.run_test(exe,
+        self.run_test(exe,
                       purpose='test: run {0} example'.format(exe),
-                      work_dir=test_dir)"""
+                      work_dir=test_dir)
 
     def test(self):
-        print('{0}'.format(self.test_suite.current_test_cache_dir))
         print("Running caliper example test")
         self.run_cxx_example_test()


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `caliper` package and is intended to serve the following purposes:

1. Leverage the current E4S test suite for the software
2. Demonstrate to package maintainers how to start a Spack smoke test.