### PR TITLE
Docs: attempt to fix doc tests for sphinx 4.1.2

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,7 +1,7 @@
 # These dependencies should be installed using pip in order
 # to build the documentation.
 
-sphinx>=3.4
+sphinx>=3.4,!=4.1.2
 sphinxcontrib-programoutput
 sphinx-rtd-theme
 python-levenshtein

--- a/lib/spack/docs/spack.yaml
+++ b/lib/spack/docs/spack.yaml
@@ -8,12 +8,20 @@
 # these commands in this directory to install Sphinx and its plugins,
 # then build the docs:
 #
-#     spack install
 #     spack env activate .
+#     spack install
 #     make
 #
 spack:
   specs:
-  - "py-sphinx@3.4:"
+  # Sphinx
+  - "py-sphinx@3.4:4.1.1,4.1.3:"
   - py-sphinxcontrib-programoutput
   - py-sphinx-rtd-theme
+  # VCS
+  - git
+  - mercurial
+  - subversion
+  # Plotting
+  - graphviz
+  concretization: together

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2657,7 +2657,7 @@ build_system_flags = PackageBase.build_system_flags
 
 
 class BundlePackage(PackageBase):
-    #"""General purpose bundle, or no-code, package class."""
+    """General purpose bundle, or no-code, package class."""
     #: There are no phases by default but the property is required to support
     #: post-install hooks (e.g., for module generation).
     phases = []  # type: List[str]

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2657,15 +2657,15 @@ build_system_flags = PackageBase.build_system_flags
 
 
 class BundlePackage(PackageBase):
-    """General purpose bundle, or no-code, package class."""
-    # There are no phases by default but the property is required to support
-    # post-install hooks (e.g., for module generation).
+    #"""General purpose bundle, or no-code, package class."""
+    #: There are no phases by default but the property is required to support
+    #: post-install hooks (e.g., for module generation).
     phases = []  # type: List[str]
-    # This attribute is used in UI queries that require to know which
-    # build-system class we are using
+    #: This attribute is used in UI queries that require to know which
+    #: build-system class we are using
     build_system_class = 'BundlePackage'
 
-    # Bundle packages do not have associated source or binary code.
+    #: Bundle packages do not have associated source or binary code.
     has_code = False
 
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2658,14 +2658,14 @@ build_system_flags = PackageBase.build_system_flags
 
 class BundlePackage(PackageBase):
     """General purpose bundle, or no-code, package class."""
-    #: There are no phases by default but the property is required to support
-    #: post-install hooks (e.g., for module generation).
+    # There are no phases by default but the property is required to support
+    # post-install hooks (e.g., for module generation).
     phases = []  # type: List[str]
-    #: This attribute is used in UI queries that require to know which
-    #: build-system class we are using
+    # This attribute is used in UI queries that require to know which
+    # build-system class we are using
     build_system_class = 'BundlePackage'
 
-    #: Bundle packages do not have associated source or binary code.
+    # Bundle packages do not have associated source or binary code.
     has_code = False
 
 


### PR DESCRIPTION
Sphinx 4.1.2 was released a couple of hours ago and is causing our documentation CI to fail with the following error:
```
Warning, treated as error:
/home/runner/work/spack/spack/lib/spack/spack/package.py:docstring of spack.package.BundlePackage:1:py:obj reference target not found: spack.package.None
```
This PR is an attempt to fix that.