### PR TITLE
Serf: add missing libuuid dependency

### DIFF
--- a/var/spack/repos/builtin/packages/apr-util/package.py
+++ b/var/spack/repos/builtin/packages/apr-util/package.py
@@ -32,6 +32,14 @@ class AprUtil(AutotoolsPackage):
     depends_on('sqlite', when='+sqlite')
     depends_on('unixodbc', when='+odbc')
 
+    @property
+    def libs(self):
+        return find_libraries(
+            ['libaprutil-{0}'.format(self.version.up_to(1))],
+            root=self.prefix,
+            recursive=True,
+        )
+
     def configure_args(self):
         spec = self.spec
 

--- a/var/spack/repos/builtin/packages/apr/package.py
+++ b/var/spack/repos/builtin/packages/apr/package.py
@@ -19,3 +19,11 @@ class Apr(AutotoolsPackage):
     patch('missing_includes.patch', when='@1.7.0')
 
     depends_on('uuid', type='link')
+
+    @property
+    def libs(self):
+        return find_libraries(
+            ['libapr-{0}'.format(self.version.up_to(1))],
+            root=self.prefix,
+            recursive=True,
+        )

--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -25,43 +25,42 @@ class Serf(SConsPackage):
     depends_on('apr-util')
     depends_on('openssl')
     depends_on('zlib')
+    depends_on('uuid')
 
     patch('py3syntax.patch')
 
     def build_args(self, spec, prefix):
-        args = [
-            'PREFIX={0}'.format(prefix),
-            'APR={0}'.format(spec['apr'].prefix),
-            'APU={0}'.format(spec['apr-util'].prefix),
-            'OPENSSL={0}'.format(spec['openssl'].prefix),
-            'ZLIB={0}'.format(spec['zlib'].prefix),
-        ]
-
-        # ZLIB variable is ignored on non-Windows platforms before and
-        # including the version 1.3.9:
-        # https://www.mail-archive.com/dev@serf.apache.org/msg01359.html
-        # The issue is fixed in the trunk. Hopefully, the next stable version
-        # will work properly.
-        if '@:1.3.9' in self.spec:
-            zlib_spec = self.spec['zlib']
-            link_flags = [zlib_spec.libs.search_flags]
-            link_flags.extend([self.compiler.cc_rpath_arg + d
-                               for d in zlib_spec.libs.directories])
-            args.append('LINKFLAGS=' + ' '.join(link_flags))
-            args.append('CPPFLAGS=' + zlib_spec.headers.cpp_flags)
-
-        if '+debug' in spec:
-            args.append('DEBUG=yes')
-        else:
-            args.append('DEBUG=no')
+        args = {
+            'PREFIX': prefix,
+            'APR': spec['apr'].prefix,
+            'APU': spec['apr-util'].prefix,
+            'OPENSSL': spec['openssl'].prefix,
+            'ZLIB': spec['zlib'].prefix,
+            'DEBUG': 'yes' if '+debug' in spec else 'no',
+        }
 
         # SCons doesn't pass Spack environment variables to the
         # execution environment. Therefore, we can't use Spack's compiler
         # wrappers. Use the actual compilers. SCons seems to RPATH things
         # on its own anyway.
-        args.append('CC={0}'.format(self.compiler.cc))
+        args['CC'] = self.compiler.cc
 
-        return args
+        # Old versions of serf ignore the ZLIB variable on non-Windows platforms.
+        # Also, there is no UUID variable to specify its installation location.
+        # Pass explicit link flags for both.
+        library_dirs = []
+        include_dirs = []
+        for dep in spec.dependencies(deptype='link'):
+            query = self.spec[dep.name]
+            library_dirs.extend(query.libs.directories)
+            include_dirs.extend(query.headers.directories)
+
+        rpath = self.compiler.cc_rpath_arg
+        args['LINKFLAGS'] = '-L' + ' -L'.join(library_dirs)
+        args['LINKFLAGS'] += ' ' + rpath + (' ' + rpath).join(library_dirs)
+        args['CPPFLAGS'] = '-I' + ' -I'.join(include_dirs)
+
+        return [key + '=' + value for key, value in args.items()]
 
     def build_test(self):
         # FIXME: Several test failures:


### PR DESCRIPTION
This PR adds a dependency on the `uuid` virtual package. It also refactors the dependency linking to specify all dependencies. This isn't really needed for any dependencies other than `zlib` and `uuid`, but I don't see any reason not to loop over all dependencies.

@alalazo is there a cleaner way to do this than what I did?

Fixes #21672  @LutzWeischerFujitsu @haampie @LDAmorim 
Fixes #22335 @vsoch 