### PR TITLE
openmpi: fix cuda dependency

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -284,8 +284,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('hwloc@:1.999', when='@:3.999.999 ~internal-hwloc')
 
     depends_on('hwloc +cuda', when='+cuda ~internal-hwloc')
-    # Still need cuda as dependent when using external hwloc
-    depends_on('cuda', when='+cuda ~internal-hwloc')
+    depends_on('cuda', when='+cuda')
     depends_on('java', when='+java')
     depends_on('sqlite', when='+sqlite3@:1.11')
     depends_on('zlib', when='@3.0.0:')


### PR DESCRIPTION
Fixes:
```
[balay@p1 spack]$ spack install openmpi+cuda+internal-hwloc

<snip>

==> Error: KeyError: 'No spec with name cuda in openmpi@4.1.1%gcc@9.3.1~atomics+cuda~cxx~cxx_exceptions+gpfs+internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-fedora31-skylake ^libedit@3.1-20210216%gcc@9.3.1 arch=linux-fedora31-skylake ^libevent@2.1.12%gcc@9.3.1+openssl arch=linux-fedora31-skylake ^ncurses@6.1.12%gcc@9.3.1~symlinks+termlib abi=none arch=linux-fedora31-skylake ^numactl@2.0.12%gcc@9.3.1 patches=62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006 arch=linux-fedora31-skylake ^openssh@8.5p1%gcc@9.3.1 arch=linux-fedora31-skylake ^openssl@1.1.1d%gcc@9.3.1~docs+systemcerts arch=linux-fedora31-skylake ^perl@5.30.0%gcc@9.3.1+cpanm+shared+threads arch=linux-fedora31-skylake ^pkg-config@1.6.3%gcc@9.3.1+internal_glib arch=linux-fedora31-skylake ^zlib@1.2.11%gcc@9.3.1+optimize+pic+shared arch=linux-fedora31-skylake'

/home/balay/spack-temp/spack/var/spack/repos/builtin/packages/openmpi/package.py:745, in configure_args:
        742                config_args.append('--enable-dlopen')
        743                # Searches for header files in DIR/include
        744                config_args.append('--with-cuda={0}'.format(
  >>    745                    spec['cuda'].prefix))
        746                if spec.satisfies('@1.7:1.7.2'):
        747                    # This option was removed from later versions
        748                    config_args.append('--with-cuda-libdir={0}'.format(
```