### PR TITLE
xtensor and xsimd: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/xsimd/package.py
+++ b/var/spack/repos/builtin/packages/xsimd/package.py
@@ -16,6 +16,7 @@ class Xsimd(CMakePackage):
     maintainers = ['ax3l']
 
     version('develop', branch='master')
+    version('7.5.0', sha256='45337317c7f238fe0d64bb5d5418d264a427efc53400ddf8e6a964b6bcb31ce9')
     version('7.4.10', sha256='df00f476dea0c52ffebad60924e3f0db2a016b80d508f8d5a2399a74c0d134cd')
     version('7.4.9', sha256='f6601ffb002864ec0dc6013efd9f7a72d756418857c2d893be0644a2f041874e')
     version('7.2.3', sha256='bbc673ad3e9d4523503a4222da05886e086b0e0bd6bd93d03ea3b663c74297b9')

--- a/var/spack/repos/builtin/packages/xtensor/package.py
+++ b/var/spack/repos/builtin/packages/xtensor/package.py
@@ -16,6 +16,7 @@ class Xtensor(CMakePackage):
     maintainers = ['ax3l']
 
     version('develop', branch='master')
+    version('0.23.10', sha256='2e770a6d636962eedc868fef4930b919e26efe783cd5d8732c11e14cf72d871c')
     version('0.23.4', sha256='c8377f8ec995762c89dea2fdf4ac06b53ba491a6f0df3421c4719355e42425d2')
     version('0.23.2', sha256='fde26dcf93f5d95996b8cc7e556b84930af41ff699492b7b20b2e3335e12f862')
     version('0.20.7', sha256='b45290d1bb0d6cef44771e7482f1553b2aa54dbf99ef9406fec3eb1e4d01d52b')
@@ -28,12 +29,12 @@ class Xtensor(CMakePackage):
             description='Enable TBB parallelization')
 
     depends_on('xtl', when='@develop')
-    depends_on('xtl@0.7.2:0.7.99', when='@0.23.2:0.23.4')
+    depends_on('xtl@0.7.2:0.7.99', when='@0.23.2:')
     depends_on('xtl@0.6.4:0.6.99', when='@0.20.7')
     depends_on('xtl@0.4.0:0.4.99', when='@0.15.1')
     depends_on('xtl@0.3.3:0.3.99', when='@0.13.1')
     depends_on('xsimd', when='@develop')
-    depends_on('xsimd@7.4.10:7.99', when='@0.23.4 +xsimd')
+    depends_on('xsimd@7.4.10:7.99', when='@0.23.4: +xsimd')
     depends_on('xsimd@7.4.9:7.99', when='@0.23.2 +xsimd')
     depends_on('xsimd@7.2.3:7.99', when='@0.20.7 +xsimd')
     depends_on('xsimd@4.0.0:4.99', when='@0.15.1 +xsimd')


### PR DESCRIPTION
Add xtensor 0.23.10 and xsimd 07.5.0 version. xtensor 0.23.10 is required by fenics-dolfinx@main.

@ax3l 

