### PR TITLE
bugfix: be careful about GITHUB_BASE_REF in `spack style`

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -79,16 +79,19 @@ class tool(object):
         return fun
 
 
-def changed_files(base=None, untracked=True, all_files=False, root=None):
-    """Get list of changed files in the Spack repository."""
+def changed_files(base="develop", untracked=True, all_files=False, root=None):
+    """Get list of changed files in the Spack repository.
+
+    Arguments:
+        base (str): name of base branch to evaluate differences with.
+        untracked (bool): include untracked files in the list.
+        all_files (bool): list all files in the repository.
+        root (str): use this directory instead of the Spack prefix.
+    """
     if root is None:
         root = spack.paths.prefix
 
     git = which("git", required=True)
-
-    # GITHUB_BASE_REF is set to the base branch for pull request actions
-    if base is None:
-        base = os.environ.get("GITHUB_BASE_REF", "develop")
 
     # ensure base is in the repo
     git("show-ref", "--verify", "--quiet", "refs/heads/%s" % base,
@@ -147,8 +150,8 @@ def setup_parser(subparser):
         "-b",
         "--base",
         action="store",
-        default=None,
-        help="select base branch for collecting list of modified files",
+        default="develop",
+        help="branch to compare against to determine changed files (default: develop)",
     )
     subparser.add_argument(
         "-a",

--- a/share/spack/qa/run-style-tests
+++ b/share/spack/qa/run-style-tests
@@ -16,8 +16,13 @@
 #
 . "$(dirname $0)/setup.sh"
 
+BASE=""
+if [ -n "$GITHUB_BASE_REF" ]; then
+    BASE="--base ${GITHUB_BASE_REF}"
+fi
+
 # verify that the code style is correct
-spack style --root-relative
+spack style --root-relative $BASE
 
 # verify that the license headers are present
 spack license verify


### PR DESCRIPTION
`spack style` previously used a Travis CI variable to figure out what the base branch of a PR was, and this was apparently also set on `develop`.  We switched to `GITHUB_BASE_REF` to support GitHub Actions, but it looks like this is set to `""` in pushes to develop, so `spack style` breaks there.

This PR does two things:

- [x] Remove `GITHUB_BASE_REF` knowledge from `spack style` entirely
- [x] Handle `GITHUB_BASE_REF` in style scripts instead, and explicitly
      pass the base ref if it is present, but don't otherwise.

This makes `spack style` *not* dependent on the environment and fixes handling of the base branch in the right place.