### PR TITLE
vtk-m: Add conflict with gcc version < 4.9

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -72,6 +72,9 @@ class VtkM(CMakePackage, CudaPackage):
     depends_on("cmake@3.12:", type="build")               # CMake >= 3.12
     depends_on("cmake@3.18:", when="+hip", type="build")  # CMake >= 3.18
 
+    conflicts('%gcc@:4.10',
+              msg='vtk-m requires gcc >= 5. Please install a newer version')
+
     depends_on('cuda@10.1.0:', when='+cuda')
     depends_on("tbb", when="+tbb")
     depends_on("mpi", when="+mpi")


### PR DESCRIPTION
vtk-m uses OpenMP 4.0 which gcc < 4.9 [does not support](https://gcc.gnu.org/wiki/openmp).

This is well documented over:
- https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/CMake/VTKmDeviceAdapters.cmake#L54
- https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/1.3/release-notes.md#openmp-device-adapter

This PR just adds this requirement to spack whenever openmp is used