### PR TITLE
Backport to 0.16: Fix use of quotes in Python build system (#22279)

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -252,7 +252,7 @@ class PythonPackage(PackageBase):
                  '--install-purelib=%s' % pure_site_packages_dir,
                  '--install-platlib=%s' % plat_site_packages_dir,
                  '--install-scripts=bin',
-                 '--install-data=""',
+                 '--install-data=',
                  '--install-headers=%s' % inc_dir
                  ]
 


### PR DESCRIPTION
Seems to me that this should be in the latest stable release branch, too.