### PR TITLE
Add maintainers for gperftools

### DIFF
--- a/var/spack/repos/builtin/packages/gperftools/package.py
+++ b/var/spack/repos/builtin/packages/gperftools/package.py
@@ -14,6 +14,7 @@ class Gperftools(AutotoolsPackage):
     """
     homepage = "https://github.com/gperftools/gperftools"
     url      = "https://github.com/gperftools/gperftools/releases/download/gperftools-2.7/gperftools-2.7.tar.gz"
+    maintainers = ['albestro', 'eschnett', 'msimberg', 'teonnik']
 
     version('2.9.1', sha256='ea566e528605befb830671e359118c2da718f721c27225cbbc93858c7520fee3')
     version('2.8.1', sha256='12f07a8ba447f12a3ae15e6e3a6ad74de35163b787c0c7b76288d7395f2f74e0')


### PR DESCRIPTION
This adds @albestro, @eschnett, @teonnik and myself as maintainers for gperftools. We are not affiliated with gperftools otherwise, but agree to try to add new versions when they're available. I've subscribed to the releases for gperftools on GitHub, so I hope I'll be able to add new versions relatively quickly. @teonnik I did not actually check with you if you're ok with this. Are you? If not I don't mind removing you.