### PR TITLE
add MIOPEN_AMDGCN_ASSEMBLER to cmake args

### DIFF
--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -67,6 +67,10 @@ class MiopenHip(CMakePackage):
                 'CMAKE_CXX_COMPILER',
                 '{0}/bin/clang++'.format(spec['llvm-amdgpu'].prefix)
             ),
+            self.define(
+                'MIOPEN_AMDGCN_ASSEMBLER',
+                '{0}/bin/clang'.format(spec['llvm-amdgpu'].prefix)
+            ),
             self.define('Boost_USE_STATIC_LIBS', 'Off'),
             self.define('HIP_PREFIX_PATH', spec['hip'].prefix),
             self.define('DEVICELIBS_PREFIX_PATH', self.get_bitcode_dir())

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -59,6 +59,10 @@ class MiopenOpencl(CMakePackage):
                 'HIP_CXX_COMPILER',
                 '{0}/bin/clang++'.format(self.spec['llvm-amdgpu'].prefix)
             ),
+            self.define(
+                'MIOPEN_AMDGCN_ASSEMBLER',
+                '{0}/bin/clang'.format(self.spec['llvm-amdgpu'].prefix)
+            ),
             self.define('Boost_USE_STATIC_LIBS', 'Off')
         ]
         return args

--- a/var/spack/repos/builtin/packages/mivisionx/package.py
+++ b/var/spack/repos/builtin/packages/mivisionx/package.py
@@ -41,6 +41,10 @@ class Mivisionx(CMakePackage):
                         self.spec['rocm-opencl'].prefix,
                         'amd_openvx/cmake/FindOpenCL.cmake',
                         string=True)
+            filter_file('/opt/rocm/mivisionx/include',
+                        self.spec['mivisionx'].prefix.include,
+                        'utilities/mv_deploy/CMakeLists.txt',
+                        string=True)
 
     def flag_handler(self, name, flags):
         spec = self.spec


### PR DESCRIPTION
when there is /opt/rocm/rocm-ver installed , while testing the spack packages for miopen-hip and miopen-opencl i found from the cmakecache.txt ,that it is picking the below 
AMDGCN assembler: /opt/rocm/llvm/bin/clang   MIOPEN_AMDGCN_ASSEMBLER:FILEPATH=/opt/rocm/llvm/bin/clang
i modified the spack packages so that it can look at the clang from the llvm-amdgpu prefix path and use that instead.