### PR TITLE
Retain 'build' and 'test' dependencies in the database

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -596,7 +596,7 @@ class ViewDescriptor(object):
             if spec.concrete:  # Do not link unconcretized roots
                 # We preserve _hash _normal to avoid recomputing DAG
                 # hashes (DAG hashes don't consider build deps)
-                spec_copy = spec.copy(deps=('link', 'run'))
+                spec_copy = spec.copy(deps=ht.dag_deptypes)
                 spec_copy._hash = spec._hash
                 spec_copy._normal = spec._normal
                 specs_for_view.append(spec_copy)

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -34,6 +34,7 @@ import spack.util.lock as lk
 import spack.util.path
 import spack.util.spack_json as sjson
 import spack.util.spack_yaml as syaml
+from spack.database import tracked_deptypes as db_tracked_deptypes
 from spack.filesystem_view import YamlFilesystemView
 from spack.spec import Spec
 from spack.spec_list import InvalidSpecConstraintError, SpecList
@@ -1754,7 +1755,7 @@ class Environment(object):
         for spec_hash in self.concretized_order:
             spec = self.specs_by_hash[spec_hash]
 
-            specs = (spec.traverse(deptype=('link', 'run'))
+            specs = (spec.traverse(deptype=db_tracked_deptypes)
                      if recurse_dependencies else (spec,))
 
             spec_list.extend(specs)

--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -2,10 +2,15 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 """Definitions that control how Spack creates Spec hashes."""
 
 import spack.dependency as dp
+
+#: Spec build hash dependency types
+build_deptypes = ('build', 'link', 'run')
+
+#: Spec DAG hash dependency types, which don't consider build dependencies
+dag_deptypes = ('link', 'run')
 
 
 class SpecHashDescriptor(object):
@@ -21,7 +26,7 @@ class SpecHashDescriptor(object):
 
     hash_types = ('_dag_hash', '_build_hash', '_full_hash', '_package_hash')
 
-    def __init__(self, deptype=('link', 'run'), package_hash=False, attr=None,
+    def __init__(self, deptype=dag_deptypes, package_hash=False, attr=None,
                  override=None):
         self.deptype = dp.canonical_deptype(deptype)
         self.package_hash = package_hash
@@ -31,18 +36,18 @@ class SpecHashDescriptor(object):
 
 
 #: Default Hash descriptor, used by Spec.dag_hash() and stored in the DB.
-dag_hash = SpecHashDescriptor(deptype=('link', 'run'), package_hash=False,
+dag_hash = SpecHashDescriptor(deptype=dag_deptypes, package_hash=False,
                               attr='_hash')
 
 
 #: Hash descriptor that includes build dependencies.
 build_hash = SpecHashDescriptor(
-    deptype=('build', 'link', 'run'), package_hash=False, attr='_build_hash')
+    deptype=build_deptypes, package_hash=False, attr='_build_hash')
 
 
 #: Full hash used in build pipelines to determine when to rebuild packages.
 full_hash = SpecHashDescriptor(
-    deptype=('build', 'link', 'run'), package_hash=True, attr='_full_hash')
+    deptype=build_deptypes, package_hash=True, attr='_full_hash')
 
 
 #: Package hash used as part of full hash

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -65,7 +65,7 @@ def test_installed_upstream(upstream_and_downstream_db):
     upstream_write_db, upstream_db, upstream_layout,\
         downstream_db, downstream_layout = (upstream_and_downstream_db)
 
-    default = ('build', 'link')
+    default = spack.database.tracked_deptypes
     mock_repo = MockPackageMultiRepo()
     x = mock_repo.add_package('x', [], [])
     z = mock_repo.add_package('z', [], [])
@@ -108,7 +108,7 @@ def test_removed_upstream_dep(upstream_and_downstream_db):
     upstream_write_db, upstream_db, upstream_layout,\
         downstream_db, downstream_layout = (upstream_and_downstream_db)
 
-    default = ('build', 'link')
+    default = spack.database.tracked_deptypes
     mock_repo = MockPackageMultiRepo()
     z = mock_repo.add_package('z', [], [])
     mock_repo.add_package('y', [z], [default])
@@ -201,7 +201,7 @@ def test_recursive_upstream_dbs(tmpdir_factory, gen_mock_layout):
     roots = [str(tmpdir_factory.mktemp(x)) for x in ['a', 'b', 'c']]
     layouts = [gen_mock_layout(x) for x in ['/ra/', '/rb/', '/rc/']]
 
-    default = ('build', 'link')
+    default = spack.database.tracked_deptypes
     mock_repo = MockPackageMultiRepo()
     z = mock_repo.add_package('z', [], [])
     y = mock_repo.add_package('y', [z], [default])


### PR DESCRIPTION
With the introduction of `spack test` (i.e., stand-alone tests), packages can re-use software (e.g., examples, tests) from their repository.  With some tweaks, they could also re-use their build-time tests.  The problem is, Spack is currently only retaining entries in the database for dependency types `link` and `run`.  In some cases, key build dependencies (e.g., a critical version of `CMake` that was used to build the software) is not available to build these cached tests.

Additionally, there is a proliferation of hard-coded dependency types related to different aspects or phases of Spack processing that include hash calculations that somewhat obscure the necessary changes.

This PR addresses the database dependency retention problem by ensuring the database retains `build` and `test` dependencies.  Unfortunately, it is not sufficient to just tell the database to track the additional types.