### PR TITLE
installation: filter padding from command arguments

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -54,6 +54,7 @@ import spack.package
 import spack.package_prefs as prefs
 import spack.repo
 import spack.store
+import spack.util.executable
 from spack.util.environment import dump_environment
 from spack.util.executable import which
 from spack.util.timer import Timer
@@ -1883,7 +1884,10 @@ def build_process(pkg, install_args):
 
     """
     installer = BuildProcessInstaller(pkg, install_args)
-    return installer.run()
+
+    # don't print long padded paths in executable debug output.
+    with spack.util.executable.filter_padding():
+        return installer.run()
 
 
 class BuildTask(object):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import contextlib
 import os
 import re
 import shlex
@@ -15,6 +16,27 @@ import llnl.util.tty as tty
 import spack.error
 
 __all__ = ['Executable', 'which', 'ProcessError']
+
+#: optionally filter padding on debug output in spack.util.executable
+_filter_padding = False
+
+
+@contextlib.contextmanager
+def filter_padding():
+    """Context manager to safely disable path padding in debug output.
+
+    This is needed because Spack's debug output gets extremely long when we use a
+    long padded installation path.
+    """
+    global _filter_padding
+    try:
+        # don't bother filtering if padding isn't actually enabled
+        padding = spack.config.get("config:install_tree:padded_length", None)
+        if padding:
+            _filter_padding = True
+        yield
+    finally:
+        _filter_padding = False
 
 
 class Executable(object):
@@ -187,7 +209,10 @@ class Executable(object):
         cmd_line = "'%s'" % "' '".join(
             map(lambda arg: arg.replace("'", "'\"'\"'"), cmd))
 
-        tty.debug(cmd_line)
+        debug_cmd_line = cmd_line
+        if _filter_padding:
+            debug_cmd_line = [spack.util.path.padding_filter(elt) for elt in cmd_line]
+        tty.debug(debug_cmd_line)
 
         try:
             proc = subprocess.Popen(


### PR DESCRIPTION
Requires #25167.

Long, padded install paths can get to be very long in the verbose install output and prevent people from seeing the real errors in pipeline builds on gitlab.spack.io (see https://github.com/spack/spack/pull/25137#issuecomment-889583746).

We filtered padding out of the build login #24514, but it still shows up in all the commands that are run by the build. This has to be filtered out by the `spack.util.executable.Executable` class, as it generates these debug messages.

- [x] add ability to filter paths from Executable output.
- [x] add a context manager that can enable path filtering
- [x] make `build_process` in `installer.py`

This should hopefully allow us to see most of the build output in Gitlab pipeline builds again.

Note that to do this modification we need #25167, so that we do not just keep indenting all the code in `build_process` as we add context managers.