### PR TITLE
don't spin writer daemon when < /dev/null

### DIFF
--- a/lib/spack/llnl/util/tty/log.py
+++ b/lib/spack/llnl/util/tty/log.py
@@ -533,13 +533,15 @@ class log_output(object):
         # Sets a daemon that writes to file what it reads from a pipe
         try:
             # need to pass this b/c multiprocessing closes stdin in child.
+            input_multiprocess_fd = None
             try:
-                input_multiprocess_fd = MultiProcessFd(
-                    os.dup(sys.stdin.fileno())
-                )
+                if sys.stdin.isatty():
+                    input_multiprocess_fd = MultiProcessFd(
+                        os.dup(sys.stdin.fileno())
+                    )
             except BaseException:
                 # just don't forward input if this fails
-                input_multiprocess_fd = None
+                pass
 
             with replace_environment(self.env):
                 self.process = multiprocessing.Process(


### PR DESCRIPTION
When running `spack install < /dev/null`, during a build the `_writer_daemon` process uses 100% cpu.  It's continually polling for input and checking tty state, but since /dev/null is always readable (essentially at EOF), it ends up spinning. (The same would happen with stdin redirected from any file really.)

This looks like this:
```
00:01:31.717831 select(49, [42 48], [], [], {tv_sec=0, tv_usec=100000}) = 1 (in [48], left {tv_sec=0, tv_usec=99999})
00:01:31.717860 ioctl(48, TCGETS, 0x7fffffff7ab0) = -1 ENOTTY (Inappropriate ioctl for device)
00:01:31.717885 rt_sigaction(SIGTTIN, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x15555472c630}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x15555472c630}, 8) = 0
00:01:31.717913 read(48, "", 8192)      = 0
00:01:31.717937 rt_sigaction(SIGTTIN, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x15555472c630}, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x15555472c630}, 8) = 0
00:01:31.717964 select(49, [42 48], [], [], {tv_sec=0, tv_usec=100000}) = 1 (in [48], left {tv_sec=0, tv_usec=99999})
00:01:31.717992 ioctl(48, TCGETS, 0x7fffffff7ab0) = -1 ENOTTY (Inappropriate ioctl for device)
00:01:31.718016 rt_sigaction(SIGTTIN, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x15555472c630}, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x15555472c630}, 8) = 0
00:01:31.718042 read(48, "", 8192)      = 0
00:01:31.718066 rt_sigaction(SIGTTIN, {sa_handler=SIG_DFL, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x15555472c630}, {sa_handler=SIG_IGN, sa_mask=[], sa_flags=SA_RESTORER, sa_restorer=0x15555472c630}, 8) = 0
```
48 here is the dup'd stdin /dev/null.

This patch just disables all stdin processing if stdin is not a tty.  Since the only reason it's using stdin at all is to check for the user pressing `v` (to toggle verbose), and this really only makes sense to do on a terminal, this seems reasonable.  (And, of course, builds end up going somewhat faster, too.)