### PR TITLE
py-datalad: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-datalad/package.py
+++ b/var/spack/repos/builtin/packages/py-datalad/package.py
@@ -1,0 +1,108 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyDatalad(PythonPackage):
+    """data distribution geared toward scientific datasets.
+
+    DataLad makes data management and data distribution more accessible. To do
+    that, it stands on the shoulders of Git and Git-annex to deliver a
+    decentralized system for data exchange. This includes automated ingestion
+    of data from online portals and exposing it in readily usable form as
+    Git(-annex) repositories, so-called datasets. The actual data storage and
+    permission management, however, remains with the original data providers.
+    """
+
+    homepage = "http://datalad.org/"
+    pypi     = "datalad/datalad-0.14.6.tar.gz"
+
+    version('0.14.6', sha256='149b25a00da133a81be3cbdc041a1985418f0918fa5961ba979e23b5b3c08c63')
+
+    variant('downloaders-extra', default=False, description="Enable extra downloaders support")
+    variant('misc', default=False, description="Enable misc")
+    variant('tests', default=False, description="Enable tests")
+    variant('metadata-extra', default=False, description="Enable extra metadata support")
+    variant('duecredit', default=False, description="Enable duecredit support")
+    variant('full', default=False, description="Enable support for all available variants")
+
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools@40.8.0:', type='build')
+    depends_on('git', type=('build', 'run'))
+    depends_on('git-annex', type=('build', 'run'))
+
+    # core
+    depends_on('py-appdirs', type=('build', 'run'))
+    depends_on('py-chardet@3.0.4:', type=('build', 'run'))
+    depends_on('py-distro', type=('build', 'run'), when='^python@3.8:')
+    depends_on('py-importlib-metadata', type=('build', 'run'), when='^python@:3.7')
+    depends_on('py-iso8601', type=('build', 'run'))
+    depends_on('py-humanize', type=('build', 'run'))
+    depends_on('py-fasteners@0.14:', type=('build', 'run'))
+    depends_on('py-patool@1.7:', type=('build', 'run'))
+    depends_on('py-tqdm', type=('build', 'run'))
+    depends_on('py-wrapt', type=('build', 'run'))
+    depends_on('py-annexremote', type=('build', 'run'))
+    # additional dependency on 'colorama' if platform_system=="Windows"'
+
+    # downloaders
+    depends_on('py-boto', type=('build', 'run'))
+    depends_on('py-keyring@8.0:', type=('build', 'run'))
+    depends_on('py-keyrings-alt', type=('build', 'run'))
+    depends_on('py-msgpack', type=('build', 'run'))
+    depends_on('py-requests@1.2:', type=('build', 'run'))
+
+    # puplish
+    depends_on('py-jsmin', type=('build', 'run'))
+    depends_on('py-pygithub', type=('build', 'run'))
+
+    # metadata
+    depends_on('py-simplejson', type=('build', 'run'))
+    depends_on('py-whoosh', type=('build', 'run'))
+
+    with when('+downloaders-extra'):
+        depends_on('py-requests-ftp', type=('build', 'run'))
+
+    with when('+misc'):
+        depends_on('py-pyperclip', type=('build', 'run'))
+        depends_on('py-python-dateutil', type=('build', 'run'))
+
+    with when('+tests'):
+        depends_on('py-beautifulsoup4', type=('build', 'run'))
+        depends_on('py-httpretty@0.9.4:', type=('build', 'run'))
+        depends_on('py-nose@1.3.4:', type=('build', 'run'))
+        depends_on('py-vcrpy', type=('build', 'run'))
+
+    with when('+metadata-extra'):
+        depends_on('py-pyyaml', type=('build', 'run'))
+        depends_on('py-mutagen@1.36:', type=('build', 'run'))
+        depends_on('py-exifread', type=('build', 'run'))
+        depends_on('py-python-xmp-toolkit', type=('build', 'run'))
+        depends_on('py-pillow', type=('build', 'run'))
+
+    with when('+duecredit'):
+        depends_on('py-duecredit', type=('build', 'run'))
+
+    with when('+full'):
+        # all the above
+        # downloader-extra
+        depends_on('py-requests-ftp', type=('build', 'run'))
+        # misc
+        depends_on('py-pyperclip', type=('build', 'run'))
+        depends_on('py-python-dateutil', type=('build', 'run'))
+        # tests
+        depends_on('py-beautifulsoup4', type=('build', 'run'))
+        depends_on('py-httpretty@0.9.4:', type=('build', 'run'))
+        depends_on('py-nose@1.3.4:', type=('build', 'run'))
+        depends_on('py-vcrpy', type=('build', 'run'))
+        # metadata-extra
+        depends_on('py-pyyaml', type=('build', 'run'))
+        depends_on('py-mutagen@1.36:', type=('build', 'run'))
+        depends_on('py-exifread', type=('build', 'run'))
+        depends_on('py-python-xmp-toolkit', type=('build', 'run'))
+        depends_on('py-pillow', type=('build', 'run'))
+        # duecredit
+        depends_on('py-duecredit', type=('build', 'run'))


### PR DESCRIPTION
The `full` variant requires all dependencies from all other variants according to the [`setup.py`](https://github.com/datalad/datalad/blob/0.14.6/setup.py#L89). 
I duplicated the dependencies for it because I did not know of a better solution. Suggestions on how to do it better are highly appreciated.