### PR TITLE
Windows lock timeout

### DIFF
--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -83,7 +83,7 @@ class Lock(object):
     maintain multiple locks on the same file.
     """
 
-    file_map = {}
+    # file_map = {}
 
     def __init__(self, path, start=0, length=0, default_timeout=None,
                  debug=False, desc=''):
@@ -109,12 +109,12 @@ class Lock(object):
                 helpful for distinguishing between different Spack locks.
         """
         self.path = path
-        self.__file = None
+        self._file = None
         self._file_mode = ""
         self._reads = 0
         self._writes = 0
-        if self.path not in Lock.file_map:
-            Lock.file_map[self.path] = self
+        # if self.path not in Lock.file_map:
+        #     Lock.file_map[self.path] = (self.__file, 0)
         # byte range parameters
         self._start = start
         self._length = length
@@ -150,20 +150,22 @@ class Lock(object):
         self.lock_type = {self.LOCK_SH: 'read', self.LOCK_EX: 'write'}
         self.current_lock = None
 
-    @property
-    def _file(self):
-        if self == Lock.file_map[self.path]:
-            return self.__file
-        else:
-            return Lock.file_map[self.path]._file
+    # @property
+    # def _file(self):
+    #     if self == Lock.file_map[self.path][0]:
+    #         return self.__file
+    #     else:
+    #         return Lock.file_map[self.path][0]._file
 
-    @_file.setter
-    def _file(self, val):
-        if not self is Lock.file_map[self.path]:
-            Lock.file_map[self.path]._file = val
-        else:
-            print(Lock.file_map.keys())
-            self.__file is val
+    # @_file.setter
+    # def _file(self, val):
+    #     if not self is Lock.file_map[self.path]:
+    #         if val is None:
+    #             Lock.file_map[self.path][1] -= 1
+    #         else:
+    #             Lock.file_map[self.path]._file = val
+    #     else:
+    #         self.__file is val
 
     def __lock_fail_condition(self,e):
         if _platform == "win32":

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -53,18 +53,19 @@ def _attempts_str(wait_time, nattempts):
 
 def lock_checking(func):
     from functools import wraps
+
     @wraps(func)
     def win_lock(self, *args, **kwargs):
         if _platform == "win32" and self._reads > 0:
             self._partial_unlock()
             try:
-                suc = func(self,*args,**kwargs)
+                suc = func(self, *args, **kwargs)
             except Exception as e:
                 if self.current_lock:
                     self._lock(self.current_lock, timeout=kwargs['timeout'])
                 raise e
         else:
-            suc = func(self,*args, **kwargs)
+            suc = func(self, *args, **kwargs)
         return suc
     return win_lock
 
@@ -113,8 +114,7 @@ class Lock(object):
         self._file_mode = ""
         self._reads = 0
         self._writes = 0
-        # if self.path not in Lock.file_map:
-        #     Lock.file_map[self.path] = (self.__file, 0)
+
         # byte range parameters
         self._start = start
         self._length = length
@@ -150,24 +150,7 @@ class Lock(object):
         self.lock_type = {self.LOCK_SH: 'read', self.LOCK_EX: 'write'}
         self.current_lock = None
 
-    # @property
-    # def _file(self):
-    #     if self == Lock.file_map[self.path][0]:
-    #         return self.__file
-    #     else:
-    #         return Lock.file_map[self.path][0]._file
-
-    # @_file.setter
-    # def _file(self, val):
-    #     if not self is Lock.file_map[self.path]:
-    #         if val is None:
-    #             Lock.file_map[self.path][1] -= 1
-    #         else:
-    #             Lock.file_map[self.path]._file = val
-    #     else:
-    #         self.__file is val
-
-    def __lock_fail_condition(self,e):
+    def __lock_fail_condition(self, e):
         if _platform == "win32":
             # 33 "The process cannot access the file because another
             #     process has locked a portion of the file."
@@ -386,7 +369,6 @@ class Lock(object):
         else:
             fcntl.lockf(self._file, self.LOCK_UN,
                         self._length, self._start, os.SEEK_SET)
-
 
     def _unlock(self):
         """Releases a lock using POSIX locks (``fcntl.lockf``)

--- a/lib/spack/llnl/util/lock.py
+++ b/lib/spack/llnl/util/lock.py
@@ -84,8 +84,6 @@ class Lock(object):
     maintain multiple locks on the same file.
     """
 
-    # file_map = {}
-
     def __init__(self, path, start=0, length=0, default_timeout=None,
                  debug=False, desc=''):
         """Construct a new lock on the file at ``path``.
@@ -429,7 +427,7 @@ class Lock(object):
             # can raise LockError.
             wait_time, nattempts = self._lock(self.LOCK_EX, timeout=timeout)
             self._writes += 1
-            self.LOCK_EX
+            self.current_lock = self.LOCK_EX
             # Log if acquired, which includes counts when verbose
             self._log_acquired('WRITE LOCK', wait_time, nattempts)
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1017,7 +1017,7 @@ class Database(object):
                 os.remove(temp_file)
             raise
 
-    def _read(self):
+    def _read(self):######################################################################################################################
         """Re-read Database from the data in the set location.
 
         This does no locking, with one exception: it will automatically

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1017,7 +1017,7 @@ class Database(object):
                 os.remove(temp_file)
             raise
 
-    def _read(self):######################################################################################################################
+    def _read(self):
         """Re-read Database from the data in the set location.
 
         This does no locking, with one exception: it will automatically

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -695,7 +695,7 @@ class Environment(object):
         """
         self.path = os.path.abspath(path)
 
-        self.txlock = lk.Lock(self._transaction_lock_path)
+        self.txlock = lk.LockFactory.lock(self._transaction_lock_path)
 
         # This attribute will be set properly from configuration
         # during concretization

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -352,7 +352,7 @@ class Stage(object):
                 stage_lock_path = os.path.join(get_stage_root(), '.lock')
 
                 tty.debug("Creating stage lock {0}".format(self.name))
-                Stage.stage_locks[self.name] = spack.util.lock.Lock(
+                Stage.stage_locks[self.name] = spack.util.lock.LockFactory.lock(
                     stage_lock_path, lock_id, 1, desc=self.name)
 
             self._lock = Stage.stage_locks[self.name]

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -383,7 +383,7 @@ def test_ensure_locked_have(install_mockery, tmpdir, capsys):
 
     with tmpdir.as_cwd():
         # Test "downgrade" of a read lock (to a read lock)
-        lock = lk.Lock('./test', default_timeout=1e-9, desc='test')
+        lock = lk.LockFactory.lock('./test', default_timeout=1e-9, desc='test')
         lock_type = 'read'
         tpl = (lock_type, lock)
         installer.locks[pkg_id] = tpl
@@ -577,7 +577,7 @@ def test_clear_failures_success(install_mockery):
     """Test the clear_failures happy path."""
 
     # Set up a test prefix failure lock
-    lock = lk.Lock(spack.store.db.prefix_fail_path, start=1, length=1,
+    lock = lk.LockFactory.lock(spack.store.db.prefix_fail_path, start=1, length=1,
                    default_timeout=1e-9, desc='test')
     try:
         lock.acquire_write()
@@ -808,7 +808,7 @@ def test_release_lock_write_n_exception(install_mockery, tmpdir, capsys):
 
     pkg_id = 'test'
     with tmpdir.as_cwd():
-        lock = lk.Lock('./test', default_timeout=1e-9, desc='test')
+        lock = lk.LockFactory.lock('./test', default_timeout=1e-9, desc='test')
         installer.locks[pkg_id] = ('write', lock)
         assert lock._writes == 0
 
@@ -938,7 +938,7 @@ def test_cleanup_failed_err(install_mockery, tmpdir, monkeypatch, capsys):
     monkeypatch.setattr(lk.Lock, 'release_write', _raise_except)
     pkg_id = 'test'
     with tmpdir.as_cwd():
-        lock = lk.Lock('./test', default_timeout=1e-9, desc='test')
+        lock = lk.LockFactory.lock('./test', default_timeout=1e-9, desc='test')
         installer.failed[pkg_id] = lock
 
         installer._cleanup_failed(pkg_id)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -578,7 +578,7 @@ def test_clear_failures_success(install_mockery):
 
     # Set up a test prefix failure lock
     lock = lk.LockFactory.lock(spack.store.db.prefix_fail_path, start=1, length=1,
-                   default_timeout=1e-9, desc='test')
+                               default_timeout=1e-9, desc='test')
     try:
         lock.acquire_write()
     except lk.LockTimeoutError:

--- a/lib/spack/spack/test/util/spack_lock_wrapper.py
+++ b/lib/spack/spack/test/util/spack_lock_wrapper.py
@@ -32,7 +32,7 @@ def test_disable_locking(tmpdir):
     old_value = spack.config.get('config:locks')
 
     with spack.config.override('config:locks', False):
-        lock = lk.Lock(lock_path)
+        lock = lk.LockFactory.lock(lock_path)
 
         lock.acquire_read()
         assert not os.path.exists(lock_path)

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -67,7 +67,7 @@ class FileCache(object):
         """Create a lock for a key, if necessary, and return a lock object."""
         if key not in self._locks:
             self._locks[key] = LockFactory.lock(self._lock_path(key),
-                                    default_timeout=self.lock_timeout)
+                                                default_timeout=self.lock_timeout)
         return self._locks[key]
 
     def init_entry(self, key):

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -10,7 +10,7 @@ from sys import platform as _platform
 from llnl.util.filesystem import mkdirp
 
 from spack.error import SpackError
-from spack.util.lock import Lock, ReadTransaction, WriteTransaction
+from spack.util.lock import LockFactory, ReadTransaction, WriteTransaction
 
 
 class FileCache(object):
@@ -66,7 +66,7 @@ class FileCache(object):
     def _get_lock(self, key):
         """Create a lock for a key, if necessary, and return a lock object."""
         if key not in self._locks:
-            self._locks[key] = Lock(self._lock_path(key),
+            self._locks[key] = LockFactory.lock(self._lock_path(key),
                                     default_timeout=self.lock_timeout)
         return self._locks[key]
 

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -7,7 +7,7 @@
 import os
 import stat
 import sys
-from typing import Dict
+from typing import Dict  # novm
 
 import llnl.util.lock
 

--- a/lib/spack/spack/util/lock.py
+++ b/lib/spack/spack/util/lock.py
@@ -6,6 +6,7 @@
 """Wrapper for ``llnl.util.lock`` allows locking to be enabled/disabled."""
 import os
 import stat
+import sys
 
 import llnl.util.lock
 
@@ -73,3 +74,19 @@ def check_lock_safety(path):
                 "Running a shared spack without locks is unsafe. You must "
                 "restrict permissions on {0} or enable locks.").format(path)
             raise spack.error.SpackError(msg, long_msg)
+
+class LockFactory(object):
+
+    __lock_map = {}
+
+    def __init__(self):
+        raise RuntimeWarning("Call static lock method. LockFactory.lock(*args,**kwargs)")
+
+    @staticmethod
+    def lock(*args, **kwargs):
+        if sys.platform == "win32":
+            if args[0] not in LockFactory.__lock_map:
+                LockFactory.__lock_map[args[0]] = Lock(*args,**kwargs)
+            return LockFactory.__lock_map[args[0]]
+        else:
+            return Lock(*args, **kwargs)


### PR DESCRIPTION
Fixes #59 on the Windows Issue Board. 

Solves two issues:

Posix locks can be arbitrarily promoted/demoted by any handle from the same process. This is not true in Windows. Solves the issue by first unlocking the file lock (if necessary) before taking the promotion.

Multiple instances of the `spack.Lock` type take the same lock one after the other are acceptable in Posix locks, but not Windows. Implement a flyweight pattern to serve one lock instance per lock path per process on Windows. This allows all calls to share the same fd handle. The Lock interface should only differ by virtue of calling the factory instead of Lock directly.