### PR TITLE
PAPI: add version 'master'

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -23,6 +23,9 @@ class Papi(AutotoolsPackage):
     maintainers = ['G-Ragghianti']
 
     url = "http://icl.cs.utk.edu/projects/papi/downloads/papi-5.4.1.tar.gz"
+    git = "https://bitbucket.org/icl/papi/src/master/"
+
+    version('master', branch='master')
     version('6.0.0.1', sha256='3cd7ed50c65b0d21d66e46d0ba34cd171178af4bbf9d94e693915c1aca1e287f')
     version('6.0.0', sha256='3442709dae3405c2845b304c06a8b15395ecf4f3899a89ceb4d715103cb4055f')
     version('5.7.0', sha256='d1a3bb848e292c805bc9f29e09c27870e2ff4cda6c2fba3b7da8b4bba6547589')


### PR DESCRIPTION
This is needed for testing with the ECP Dev Tools SDK.

@G-Ragghianti Is the Bitbucket link is the correct public repo?