### PR TITLE
aocc: New version 3.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -32,6 +32,8 @@ class Aocc(Package):
 
     maintainers = ['amd-toolchain-support']
 
+    version(ver="3.1.0", sha256='1948104a430506fe5e445c0c796d6956109e7cc9fc0a1e32c9f1285cfd566d0c',
+            url='http://developer.amd.com/wordpress/media/files/aocc-compiler-3.1.0.tar')
     version(ver="3.0.0", sha256='4ff269b1693856b9920f57e3c85ce488c8b81123ddc88682a3ff283979362227',
             url='http://developer.amd.com/wordpress/media/files/aocc-compiler-3.0.0.tar')
     version(ver="2.3.0", sha256='9f8a1544a5268a7fb8cd21ac4bdb3f8d1571949d1de5ca48e2d3309928fc3d15',


### PR DESCRIPTION
Adding the latest AMD AOCC.
https://developer.amd.com/amd-aocc/