### PR TITLE
HPCG Fix for the Cray complier (CCE)

### DIFF
--- a/var/spack/repos/builtin/packages/hpcg/package.py
+++ b/var/spack/repos/builtin/packages/hpcg/package.py
@@ -36,7 +36,9 @@ class Hpcg(AutotoolsPackage):
         if not spec.satisfies('%aocc') and not spec.satisfies('%cce'):
             CXXFLAGS += ' -ftree-vectorizer-verbose=0 '
         if spec.satisfies('%cce'):
-            CXXFLAGS += ' -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize '
+            CXXFLAGS += ' -Rpass=loop-vectorize'
+            CXXFLAGS += ' -Rpass-missed=loop-vectorize'
+            CXXFLAGS += ' -Rpass-analysis=loop-vectorize '
         if '+openmp' in self.spec:
             CXXFLAGS += self.compiler.openmp_flag
         config = [

--- a/var/spack/repos/builtin/packages/hpcg/package.py
+++ b/var/spack/repos/builtin/packages/hpcg/package.py
@@ -33,8 +33,10 @@ class Hpcg(AutotoolsPackage):
 
     def configure(self, spec, prefix):
         CXXFLAGS = '-O3 -ffast-math -ftree-vectorize '
-        if '%aocc' not in self.spec:
+        if not spec.satisfies('%aocc') and not spec.satisfies('%cce'):
             CXXFLAGS += ' -ftree-vectorizer-verbose=0 '
+        if spec.satisfies('%cce'):
+            CXXFLAGS += ' -Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize '
         if '+openmp' in self.spec:
             CXXFLAGS += self.compiler.openmp_flag
         config = [


### PR DESCRIPTION
CCE's C++ compiler (Clang based) does not accept the '-ftree-vectorizer-verbose=0'
flag. That flag is removed and a suitable substitution is made.