### PR TITLE
DD4hep: fixes to run tests

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -71,6 +71,7 @@ class Dd4hep(CMakePackage):
     depends_on('hepmc3', when="+hepmc3")
     depends_on('lcio', when="+lcio")
     depends_on('edm4hep', when="+edm4hep")
+    depends_on('py-pytest', type="test")
 
     # See https://github.com/AIDASoft/DD4hep/pull/771
     conflicts('^cmake@3.16:3.17.0', when='@1.15',
@@ -130,3 +131,15 @@ class Dd4hep(CMakePackage):
             version_str = 'v%02d-%02d-%02d.tar.gz' % (major, minor, patch)
 
         return base_url + '/' + version_str
+
+    # dd4hep tests need to run after install step:
+    # disable the usual check
+    def check(self):
+        pass
+
+    # instead add custom check step that runs after installation
+    @run_after('install')
+    def install_check(self):
+        with working_dir(self.build_directory):
+            if self.run_tests:
+                ninja('test')


### PR DESCRIPTION
DD4hep tests use install paths, so I disable the usual `check` step,  and  instead add a custom one that runs after all files have been installed.