### PR TITLE
Make spack env activate x idempotent

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -103,6 +103,7 @@ def env_activate(args):
         tty.die("No such environment: '%s'" % env)
 
     if spack_env == os.environ.get('SPACK_ENV'):
+        tty.debug("Environment %s is already active" % args.activate_env)
         return
 
     active_env = ev.get_env(namedtuple('args', ['env'])(env),

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -103,7 +103,7 @@ def env_activate(args):
         tty.die("No such environment: '%s'" % env)
 
     if spack_env == os.environ.get('SPACK_ENV'):
-        tty.die("Environment %s is already active" % args.activate_env)
+        return
 
     active_env = ev.get_env(namedtuple('args', ['env'])(env),
                             'activate')


### PR DESCRIPTION
Currently we have this behavior:

```
$ spack env activate a
$ spack env activate a
==> Error: Environment a is already active
$ spack env activate a || echo wut
==> Error: Environment a is already active
```

It's not a real error, it's not colored output, it's not setting the correct return code (due to the shell wrapper?).

This PR removes the error and makes `spack activate a` idempotent for the same environment.

