### PR TITLE
py-pydeprecate: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-pydeprecate/package.py
+++ b/var/spack/repos/builtin/packages/py-pydeprecate/package.py
@@ -13,6 +13,7 @@ class PyPydeprecate(PythonPackage):
     homepage = "https://borda.github.io/pyDeprecate/"
     pypi     = "pyDeprecate/pyDeprecate-0.3.0.tar.gz"
 
+    version('0.3.1', sha256='fa26870924d3475621c344045c2c01a16ba034113a902600c78e75b3fac5f72c')
     version('0.3.0', sha256='335742ec53b9d22a0a9ff4f3470300c94935f6e169c74b08aee14d871ca40e00')
 
     depends_on('python@3.6:',       type=('build', 'run'))


### PR DESCRIPTION
Successfully installs and passes all import tests on Ubuntu 18.04 with Python 3.8.11 and GCC 7.5.0.