### PR TITLE
Use both fetch/push url for build_tarball

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -949,9 +949,7 @@ def build_tarball(spec, mirror, force=False, rel=False, unsigned=False,
             raise NoOverwriteException(url_util.format(push_spackfile_path))
 
     if web_util.url_exists(fetch_spackfile_path):
-        if force:
-            web_util.remove_url(fetch_spackfile_path)
-        else:
+        if not force:
             raise NoOverwriteException(url_util.format(fetch_spackfile_path))
 
     # need to copy the spec file so the build cache can be downloaded

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -949,7 +949,8 @@ def build_tarball(spec, mirror, force=False, rel=False, unsigned=False,
         else:
             raise NoOverwriteException(url_util.format(push_spackfile_path))
 
-    if web_util.url_exists(fetch_spackfile_path) and not force:
+    if (push_spackfile_path != fetch_spackfile_path and
+            web_util.url_exists(fetch_spackfile_path) and not force):
         raise NoOverwriteException(url_util.format(fetch_spackfile_path))
 
     # need to copy the spec file so the build cache can be downloaded
@@ -971,7 +972,8 @@ def build_tarball(spec, mirror, force=False, rel=False, unsigned=False,
         else:
             raise NoOverwriteException(url_util.format(push_specfile_path))
 
-    if web_util.url_exists(fetch_specfile_path) and not force:
+    if (push_specfile_path != fetch_specfile_path and
+            web_util.url_exists(fetch_specfile_path) and not force):
         raise NoOverwriteException(url_util.format(fetch_specfile_path))
 
     # make a copy of the install directory to work with

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -916,7 +916,7 @@ def generate_key_index(key_prefix, tmpdir=None):
                 shutil.rmtree(tmpdir)
 
 
-def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
+def build_tarball(spec, mirror, force=False, rel=False, unsigned=False,
                   allow_root=False, key=None, regenerate_index=False):
     """
     Build a tarball from given spec and put it into the directory structure
@@ -935,10 +935,19 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
     spackfile_path = os.path.join(
         cache_prefix, tarball_path_name(spec, '.spack'))
 
+    outdir = mirror.push_url
     remote_spackfile_path = url_util.join(
+        mirror.fetch_url, os.path.relpath(spackfile_path, tmpdir))
+    local_spackfile_path = url_util.join(
         outdir, os.path.relpath(spackfile_path, tmpdir))
 
     mkdirp(tarfile_dir)
+    if web_util.url_exists(local_spackfile_path):
+        if force:
+            web_util.remove_url(local_spackfile_path)
+        else:
+            raise NoOverwriteException(url_util.format(local_spackfile_path))
+
     if web_util.url_exists(remote_spackfile_path):
         if force:
             web_util.remove_url(remote_spackfile_path)

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -936,23 +936,23 @@ def build_tarball(spec, mirror, force=False, rel=False, unsigned=False,
         cache_prefix, tarball_path_name(spec, '.spack'))
 
     outdir = mirror.push_url
-    remote_spackfile_path = url_util.join(
+    fetch_spackfile_path = url_util.join(
         mirror.fetch_url, os.path.relpath(spackfile_path, tmpdir))
-    local_spackfile_path = url_util.join(
+    push_spackfile_path = url_util.join(
         outdir, os.path.relpath(spackfile_path, tmpdir))
 
     mkdirp(tarfile_dir)
-    if web_util.url_exists(local_spackfile_path):
+    if web_util.url_exists(push_spackfile_path):
         if force:
-            web_util.remove_url(local_spackfile_path)
+            web_util.remove_url(push_spackfile_path)
         else:
-            raise NoOverwriteException(url_util.format(local_spackfile_path))
+            raise NoOverwriteException(url_util.format(push_spackfile_path))
 
-    if web_util.url_exists(remote_spackfile_path):
+    if web_util.url_exists(fetch_spackfile_path):
         if force:
-            web_util.remove_url(remote_spackfile_path)
+            web_util.remove_url(fetch_spackfile_path)
         else:
-            raise NoOverwriteException(url_util.format(remote_spackfile_path))
+            raise NoOverwriteException(url_util.format(fetch_spackfile_path))
 
     # need to copy the spec file so the build cache can be downloaded
     # without concretizing with the current spack packages
@@ -1055,12 +1055,12 @@ def build_tarball(spec, mirror, force=False, rel=False, unsigned=False,
         os.remove('%s.asc' % specfile_path)
 
     web_util.push_to_url(
-        spackfile_path, remote_spackfile_path, keep_original=False)
+        spackfile_path, fetch_spackfile_path, keep_original=False)
     web_util.push_to_url(
         specfile_path, remote_specfile_path, keep_original=False)
 
     tty.debug('Buildcache for "{0}" written to \n {1}'
-              .format(spec, remote_spackfile_path))
+              .format(spec, fetch_spackfile_path))
 
     try:
         # push the key to the build cache's _pgp directory so it can be

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -409,7 +409,7 @@ def _createtarball(env, spec_yaml=None, packages=None, add_spec=True,
     for spec in specs:
         tty.debug('creating binary cache file for package %s ' % spec.format())
         try:
-            bindist.build_tarball(spec, outdir, force, make_relative,
+            bindist.build_tarball(spec, mirror, force, make_relative,
                                   unsigned, allow_root, signing_key,
                                   rebuild_index)
         except bindist.NoOverwriteException as e:

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -5,9 +5,9 @@
 
 import os
 import os.path
+import shutil
 
 import pytest
-
 import spack.binary_distribution
 import spack.mirror
 import spack.spec
@@ -41,3 +41,46 @@ def test_build_tarball_overwrite(
 
         with pytest.raises(spack.binary_distribution.NoOverwriteException):
             spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)
+
+
+def test_build_tarball_split_mirror(install_mockery,
+                                    mock_fetch, monkeypatch, tmpdir):
+
+    with tmpdir.as_cwd():
+        spec = spack.spec.Spec('trivial-install-test-package').concretized()
+        install(str(spec))
+
+        # Runs fine the first time, throws the second time
+        mirror = spack.mirror.MirrorCollection().lookup('.')
+        base_url = mirror.push_url
+        mirror.push_url = base_url + '/push'
+        mirror.fetch_url = base_url + '/fetch'
+        spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)
+        # It exists in the push dir
+        with pytest.raises(spack.binary_distribution.NoOverwriteException):
+            spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)
+        # But now we force building anyway
+        spack.binary_distribution.build_tarball(spec, mirror, force=True, unsigned=True)
+        os.rename('push', 'fetch')
+        # It now exists in the fetch dir, but not push
+        with pytest.raises(spack.binary_distribution.NoOverwriteException):
+            spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)
+        # But now we force the build anyway
+        spack.binary_distribution.build_tarball(spec, mirror, force=True, unsigned=True)
+
+        shutil.rmtree('push')
+        # Delete all packages from the fetch directory
+        # Remove the tarball and try again.
+        # This must *also* throw, because of the existing .spec.yaml file
+        os.remove(os.path.join(
+            spack.binary_distribution.build_cache_prefix('fetch'),
+            spack.binary_distribution.tarball_directory_name(spec),
+            spack.binary_distribution.tarball_name(spec, '.spack')))
+        with pytest.raises(spack.binary_distribution.NoOverwriteException):
+            spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)
+        spack.binary_distribution.build_tarball(spec, mirror, force=True, unsigned=True)
+        shutil.rmtree('push')
+        os.rename('fetch', 'push')
+        with pytest.raises(spack.binary_distribution.NoOverwriteException):
+            spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)
+        spack.binary_distribution.build_tarball(spec, mirror, force=True, unsigned=True)

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -9,8 +9,8 @@ import os.path
 import pytest
 
 import spack.binary_distribution
-import spack.spec
 import spack.mirror
+import spack.spec
 
 install = spack.main.SpackCommand('install')
 

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -10,6 +10,7 @@ import pytest
 
 import spack.binary_distribution
 import spack.spec
+import spack.mirror
 
 install = spack.main.SpackCommand('install')
 
@@ -22,13 +23,14 @@ def test_build_tarball_overwrite(
         install(str(spec))
 
         # Runs fine the first time, throws the second time
-        spack.binary_distribution.build_tarball(spec, '.', unsigned=True)
+        mirror = spack.mirror.MirrorCollection().lookup('.')
+        spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)
         with pytest.raises(spack.binary_distribution.NoOverwriteException):
-            spack.binary_distribution.build_tarball(spec, '.', unsigned=True)
+            spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)
 
         # Should work fine with force=True
         spack.binary_distribution.build_tarball(
-            spec, '.', force=True, unsigned=True)
+            spec, mirror, force=True, unsigned=True)
 
         # Remove the tarball and try again.
         # This must *also* throw, because of the existing .spec.yaml file
@@ -38,4 +40,4 @@ def test_build_tarball_overwrite(
             spack.binary_distribution.tarball_name(spec, '.spack')))
 
         with pytest.raises(spack.binary_distribution.NoOverwriteException):
-            spack.binary_distribution.build_tarball(spec, '.', unsigned=True)
+            spack.binary_distribution.build_tarball(spec, mirror, unsigned=True)

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -8,6 +8,7 @@ import os.path
 import shutil
 
 import pytest
+
 import spack.binary_distribution
 import spack.mirror
 import spack.spec


### PR DESCRIPTION
Currently build_tarball only checks for the existence of a binary dist
at the push url. We need it to check both the push and fetch url's,
so that we only rebuild parts of the binary cache that don't exist in
our remote cache.