### PR TITLE
py-requests-unixsocket: add missing py-pbr dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-requests-unixsocket/package.py
+++ b/var/spack/repos/builtin/packages/py-requests-unixsocket/package.py
@@ -15,5 +15,6 @@ class PyRequestsUnixsocket(PythonPackage):
     version('0.2.0', sha256='9e5c1a20afc3cf786197ae59c79bcdb0e7565f218f27df5f891307ee8817c1ea')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-pbr', type='build')
     depends_on('py-requests@1.1:', type=('build', 'run'))
     depends_on('py-urllib3@1.8:', type=('build', 'run'))


### PR DESCRIPTION
Without this, the build either:

1. fails because if can't find pip, or
2. runs pip to install pbr, which won't work on air-gapped networks

Successfully builds on Ubuntu 18.04 with GCC 7.5.0.