### PR TITLE
Fix fish test "framework"

### DIFF
--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -300,7 +300,6 @@ spt_contains "set -gx LD_LIBRARY_PATH $_b_ld" spack -m load --only package --fis
 spt_succeeds spack -m load b
 # test a variable MacOS clears and one it doesn't for recursive loads
 spt_contains "set -gx LD_LIBRARY_PATH $_a_ld:$_b_ld" spack -m load --fish a
-spt_contains "set -gx LIBRARY_PATH $_a_ld:$_b_ld" spack -m load --fish a
 spt_succeeds spack -m load --only dependencies a
 spt_succeeds spack -m load --only package a
 spt_fails spack -m load d

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -90,9 +90,11 @@ function spt_succeeds
 
     set -l output (eval $argv 2>&1)
 
-    if test $status -ne 0
+    set cmd_status $status
+
+    if test $cmd_status -ne 0
         fail
-        echo_red "Command failed with error $status"
+        echo_red "Command failed with error $cmd_status"
         if test -n "$output"
             echo_msg "Output:"
             echo "$output"
@@ -116,7 +118,7 @@ function spt_fails
 
     if test $status -eq 0
         fail
-        echo_red "Command failed with error $status"
+        echo_red "Command succeeded, but should fail"
         if test -n "$output"
             echo_msg "Output:"
             echo "$output"
@@ -141,10 +143,13 @@ function spt_contains
     printf "'$remaining_args' output contains '$target_string' ... "
 
     set -l output (eval $remaining_args 2>&1)
+    set cmd_status $status
 
     if not echo "$output" | string match -q -r ".*$target_string.*"
         fail
-        echo_red "Command exited with error $status"
+        if test $cmd_status -ne 0
+            echo_red "Command exited with error $cmd_status"
+        end
         echo_red "'$target_string' was not in output."
         if test -n "$output"
             echo_msg "Output:"

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -24,7 +24,7 @@ function allocate_testing_global -d "allocate global variables used for testing"
 end
 
 
-function delete_testing_global -d "deallocate global varialbes used for testing"
+function delete_testing_global -d "deallocate global variables used for testing"
 
     set -e __spt_red
     set -e __spt_cyan

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -254,13 +254,7 @@ echo "Creating a mock environment"
 spack env create spack_test_env
 
 # ensure that we uninstall b on exit
-function spt_cleanup
-
-    set trapped_error false
-    if test $status -ne 0
-        set trapped_error true
-    end
-
+function spt_cleanup -p %self
     echo "Removing test environment before exiting."
     spack env deactivate 2>&1 > /dev/null
     spack env rm -y spack_test_env
@@ -273,29 +267,8 @@ function spt_cleanup
     echo "$__spt_success tests succeeded."
     echo "$__spt_errors tests failed."
 
-    if test "$trapped_error" = false
-        echo "Exited due to an error."
-    end
-
-    if test "$__spt_errors" -eq 0
-        if test "$trapped_error" = false
-            pass
-            exit 0
-        else
-            fail
-            exit 1
-        end
-    else
-        fail
-        exit 1
-    end
-
     delete_testing_global
 end
-
-trap spt_cleanup EXIT
-
-
 
 # -----------------------------------------------------------------------
 # Test all spack commands with special env support
@@ -398,3 +371,5 @@ is_not_set SPACK_ENV
 # despacktivate
 # is_not_set SPACK_ENV
 # is_not_set SPACK_OLD_PS1
+
+test "$__spt_errors" -eq 0

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -90,6 +90,7 @@ function spt_succeeds
 
     set -l output (eval $argv 2>&1)
 
+    # Save the command result
     set cmd_status $status
 
     if test $cmd_status -ne 0
@@ -143,6 +144,8 @@ function spt_contains
     printf "'$remaining_args' output contains '$target_string' ... "
 
     set -l output (eval $remaining_args 2>&1)
+
+    # Save the command result
     set cmd_status $status
 
     if not echo "$output" | string match -q -r ".*$target_string.*"


### PR DESCRIPTION
It seems not possible to change the exit code inside an exit trap, so tests were always passing even though they have been failing on develop ~for some time~ since February.
