### PR TITLE
Make s3 multipart upload threshold configurable

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -191,3 +191,8 @@ config:
   # Set to 'false' to allow installation on filesystems that doesn't allow setgid bit
   # manipulation by unprivileged user (e.g. AFS)
   allow_sgid: true
+
+
+  # The transfer size threshold in bytes for which multipart uploads will be
+  # triggered when uploading to an s3 bucket (defaults to 100MB)
+  multipart_threshold: 104857600

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -103,6 +103,7 @@ properties = {
                 'type': 'string',
                 'enum': ['urllib', 'curl']
             },
+            'multipart_threshold': {'type': 'integer', 'minimum': 1}
         },
     },
 }

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -190,8 +190,11 @@ def push_to_url(
             remote_path = remote_path[1:]
 
         s3 = s3_util.create_s3_session(remote_url)
+        from boto3.s3.transfer import TransferConfig
+        transfer_cfg = TransferConfig(multipart_threshold=1024 ** 4)
         s3.upload_file(local_file_path, remote_url.netloc,
-                       remote_path, ExtraArgs=extra_args)
+                       remote_path, ExtraArgs=extra_args,
+                       Config=transfer_cfg)
 
         if not keep_original:
             os.remove(local_file_path)


### PR DESCRIPTION
Multipart uploads are not assembled to a single file on openstack
object storage, instead they are stored as Static Large Object. This is rather
inconvenient, because it means there is not a single URL for the file;
instead the user has to download all parts and assemble the file
themselves. This makes spack install using a binary cache over https://
instead of s3:// fail.

To work around this, this commit ensures that we use a high multipart
threshold of 1TB, which basically means we never use multipart uploads.
