### PR TITLE
Spack version: 0.16.1 -> 0.16.2

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 #: major, minor, patch version for Spack, in a tuple
-spack_version_info = (0, 16, 1)
+spack_version_info = (0, 16, 2)
 
 #: String containing Spack version joined with .'s
 spack_version = '.'.join(str(v) for v in spack_version_info)


### PR DESCRIPTION
Do we have a document somewhere that describes the process of how to release a new version of Spack? Something like https://github.com/adamjstewart/fiscalyear/wiki/Releasing-Instructions? If we do, we should add bumping the Spack version to that document.