### PR TITLE
SOS: add xpmem variant

### DIFF
--- a/var/spack/repos/builtin/packages/sos/package.py
+++ b/var/spack/repos/builtin/packages/sos/package.py
@@ -52,8 +52,7 @@ class Sos(AutotoolsPackage):
     def configure_args(self):
         args = []
         args.extend(self.with_or_without('xpmem'))
-        if '+ofi'  in self.spec:
-            args.append('--with-ofi')
+        args.extend(self.with_or_without('ofi'))
         # This option is not compatiable with remote atomics
         if '+shr-atomics' in self.spec:
             args.append('--enable-shr-atomics')

--- a/var/spack/repos/builtin/packages/sos/package.py
+++ b/var/spack/repos/builtin/packages/sos/package.py
@@ -54,7 +54,6 @@ class Sos(AutotoolsPackage):
         args.extend(self.with_or_without('xpmem'))
         args.extend(self.with_or_without('ofi'))
         # This option is not compatiable with remote atomics
-        if '+shr-atomics' in self.spec:
-            args.append('--enable-shr-atomics')
+        args.extend(self.with_or_without('shr-atomics'))
         args.append('--enable-pmi-simple')
         return args

--- a/var/spack/repos/builtin/packages/sos/package.py
+++ b/var/spack/repos/builtin/packages/sos/package.py
@@ -18,12 +18,17 @@ class Sos(AutotoolsPackage):
     version('1.5.0', sha256='02679da6085cca2919f900022c46bad48479690586cb4e7f971ec3a735bab4d4')
     version('1.4.5', sha256='42778ba3cedb632ac3fbbf8917f415a804f8ca3b67fb3da6d636e6c50c501906')
 
+    variant('xpmem', default=False, description='Enable xpmem for transport')
+    variant('ofi', default=True, description='Enable ofi for transport')
+    variant('shr-atomics', default=False, description='Enable shared memory atomic operations')
+
     depends_on('autoconf',  type='build')
     depends_on('automake',  type='build')
     depends_on('libtool',   type='build')
     depends_on('m4',        type='build')
 
-    depends_on('libfabric', type='link')
+    depends_on('libfabric', type='link', when='+ofi')
+    depends_on('xpmem',     type='link', when='+xpmem')
 
     # Enable use of the OSH wrappers outside of Spack by preventing
     # them from using the spack wrappers
@@ -46,6 +51,12 @@ class Sos(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        args.append('--with-ofi')
+        if '+xpmem' in self.spec:
+            args.append('--with-xpmem')
+        if '+ofi'  in self.spec:
+            args.append('--with-ofi')
+        # This option is not compatiable with remote atomics
+        if '+shr-atomics' in self.spec:
+            args.append('--enable-shr-atomics')
         args.append('--enable-pmi-simple')
         return args

--- a/var/spack/repos/builtin/packages/sos/package.py
+++ b/var/spack/repos/builtin/packages/sos/package.py
@@ -51,8 +51,7 @@ class Sos(AutotoolsPackage):
 
     def configure_args(self):
         args = []
-        if '+xpmem' in self.spec:
-            args.append('--with-xpmem')
+        args.extend(self.with_or_without('xpmem'))
         if '+ofi'  in self.spec:
             args.append('--with-ofi')
         # This option is not compatiable with remote atomics


### PR DESCRIPTION
Add xpmem variant. Using xpmem disables ofi because it interferes with single node optimizations.

@davidozog: please review