### PR TITLE
ParaView: paraview should build its own IOSS

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -274,7 +274,10 @@ class Paraview(CMakePackage, CudaPackage):
             '-DOpenGL_GL_PREFERENCE:STRING=LEGACY']
 
         if spec.satisfies('@5.10:'):
-            cmake_args.append('-DVTK_MODULE_USE_EXTERNAL_ParaView_vtkcatalyst:BOOL=OFF')
+            cmake_args.extend([
+                '-DVTK_MODULE_USE_EXTERNAL_ParaView_vtkcatalyst:BOOL=OFF',
+                '-DVTK_MODULE_USE_EXTERNAL_VTK_ioss:BOOL=OFF'
+            ])
 
         if spec.satisfies('@:5.7') and spec['cmake'].satisfies('@3.17:'):
             cmake_args.append('-DFPHSA_NAME_MISMATCHED:BOOL=ON')


### PR DESCRIPTION
Changes to make ParaView build its own IOSS library. Resolves issue in paraview gitlab repository [here](https://gitlab.kitware.com/paraview/paraview/-/issues/20868)

Tested on:
```console
* **Spack:** 0.16.2-3799-929eb311c7
* **Python:** 3.6.3
* **Platform:** linux-rhel7-broadwell
* **Concretizer:** original
```