### PR TITLE
Legion: Add E4S testsuite stand alone test

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -332,3 +332,23 @@ class Legion(CMakePackage):
             options.append('-DBUILD_MARCH:STRING=native')
 
         return options
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources([join_path('examples', 'local_function_tasks')])
+
+    def run_local_function_tasks_test(self):
+        """Run stand alone test: local_function_tasks"""
+
+        test_dir = join_path(self.test_suite.current_test_cache_dir, 'examples', 'local_function_tasks')
+
+        if not os.path.exists(test_dir):
+            print('Skipping local_function_tasks test')
+            return
+
+        exe = 'local_function_tasks'
+
+    def test(self):
+        self.run_local_function_tasks_test()

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -360,7 +360,7 @@ class Legion(CMakePackage):
 
         self.run_test('cmake',
                       options=cmake_args,
-                      purpose='test: compile {0} example'.format(exe),
+                      purpose='test: generate makefile for {0} example'.format(exe),
                       work_dir=test_dir)
 
         self.run_test('make',

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -350,5 +350,22 @@ class Legion(CMakePackage):
 
         exe = 'local_function_tasks'
 
+        cmake_args = ['-DCMAKE_C_COMPILER={0}'.format(self.compiler.cc),
+                      '-DCMAKE_CXX_COMPILER={0}'.format(self.compiler.cxx),
+                      '-DLegion_DIR={0}'.format(join_path(self.prefix, 'share', 'Legion', 'cmake'))]
+
+        self.run_test('cmake',
+                      options=cmake_args,
+                      purpose='test: compile {0} example'.format(exe),
+                      work_dir=test_dir)
+
+        self.run_test('make',
+                      purpose='test: build {0} example'.format(exe),
+                      work_dir=test_dir)
+
+        self.run_test(exe,
+                      purpose='test: run {0} example'.format(exe),
+                      work_dir=test_dir)
+
     def test(self):
         self.run_local_function_tasks_test()

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -342,7 +342,8 @@ class Legion(CMakePackage):
     def run_local_function_tasks_test(self):
         """Run stand alone test: local_function_tasks"""
 
-        test_dir = join_path(self.test_suite.current_test_cache_dir, 'examples', 'local_function_tasks')
+        test_dir = join_path(self.test_suite.current_test_cache_dir,
+                             'examples', 'local_function_tasks')
 
         if not os.path.exists(test_dir):
             print('Skipping local_function_tasks test')
@@ -352,7 +353,10 @@ class Legion(CMakePackage):
 
         cmake_args = ['-DCMAKE_C_COMPILER={0}'.format(self.compiler.cc),
                       '-DCMAKE_CXX_COMPILER={0}'.format(self.compiler.cxx),
-                      '-DLegion_DIR={0}'.format(join_path(self.prefix, 'share', 'Legion', 'cmake'))]
+                      '-DLegion_DIR={0}'.format(join_path(self.prefix,
+                                                          'share',
+                                                          'Legion',
+                                                          'cmake'))]
 
         self.run_test('cmake',
                       options=cmake_args,


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `legion` package and is intended to serve the following purposes:

Leverage the current E4S test suite for the software
Demonstrate to package maintainers how to start a Spack stand alone test.