### PR TITLE
pipelines: Change x86_64 E4S stack to use clingo concretizer

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -103,11 +103,15 @@ default:
   variables:
     SPACK_CI_STACK_NAME: e4s
 
+.e4s-clingo-generate:
+  extends: [".e4s"]
+  image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-x86_64:2021-07-01", "entrypoint": [""] }
+
 e4s-pr-generate:
-  extends: [ ".e4s", ".pr-generate"]
+  extends: [ ".e4s-clingo-generate", ".pr-generate"]
 
 e4s-develop-generate:
-  extends: [ ".e4s", ".develop-generate"]
+  extends: [ ".e4s-clingo-generate", ".develop-generate"]
 
 e4s-pr-build:
   extends: [ ".e4s", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -340,6 +340,7 @@ spack:
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}
       - spack env activate --without-view .
+      - spack config add "config:concretizer:original"
       - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
       - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
       - spack -d ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -13,7 +13,7 @@ spack:
   packages:
     all:
       compiler:
-        - gcc@7.5.0
+        - gcc@9.3.0
       providers:
         blas:
           - openblas
@@ -314,7 +314,7 @@ spack:
     #- variorum # root fails
 
   - arch:
-    - '%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64'
+    - '%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64'
 
 
   specs:
@@ -364,7 +364,7 @@ spack:
         runner-attributes:
           image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-x86_64:2021-07-01", "entrypoint": [""] }
           tags: ["spack", "public", "xlarge", "x86_64"]
-      - match: ['os=ubuntu18.04']
+      - match: ['os=ubuntu20.04']
         runner-attributes:
           image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-x86_64:2021-07-01", "entrypoint": [""] }
           tags: ["spack", "public", "large", "x86_64"]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -3,6 +3,7 @@ spack:
   concretization: separately
 
   config:
+    concretizer: clingo
     install_tree:
       root: /home/software/spack
       padded_length: 512
@@ -360,11 +361,11 @@ spack:
         - vtk-m
         - warpx
         runner-attributes:
-          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
+          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-x86_64:2021-07-01", "entrypoint": [""] }
           tags: ["spack", "public", "xlarge", "x86_64"]
       - match: ['os=ubuntu18.04']
         runner-attributes:
-          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
+          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-x86_64:2021-07-01", "entrypoint": [""] }
           tags: ["spack", "public", "large", "x86_64"]
     temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
@@ -374,7 +375,7 @@ spack:
         - spack --version
         - cd share/spack/gitlab/cloud_pipelines/stacks/e4s
         - spack env activate --without-view .
-      image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
+      image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-x86_64:2021-07-01", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "x86_64"]
 
   cdash:


### PR DESCRIPTION
Use the new concretizer for gitlab PR/develop pipelines building the E4S stack, initially just on `x86_64`.