### PR TITLE
database: don't sort query results by default

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1519,7 +1519,7 @@ class Database(object):
     def query_local(self, *args, **kwargs):
         """Query only the local Spack database."""
         with self.read_transaction():
-            return sorted(self._query(*args, **kwargs))
+            return self._query(*args, **kwargs)
 
     if query_local.__doc__ is None:
         query_local.__doc__ = ""
@@ -1539,7 +1539,7 @@ class Database(object):
         results = list(local_results) + list(
             x for x in upstream_results if x not in local_results)
 
-        return sorted(results)
+        return results
 
     if query.__doc__ is None:
         query.__doc__ = ""


### PR DESCRIPTION
Sorting very large sets of specs (e.g., from a buildcache) can be very slow, so do not sort database results by default. Commands and other consumers of search results should sort their own results instead.

This speeds up `spack buildcache list` for https://cache.e4s.io by 2-3x -- from 40s to around 15s for tens of thousands of specs.

Draft for now because I want to see if this breaks anything, and I need to look at places where we sort specs.