### PR TITLE
Remove PR Logic from Container Builder

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -49,8 +49,6 @@ jobs:
           fi
 
       - name: Log in to GitHub Container Registry
-        # Don't log into registry on pull request.
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -63,17 +61,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Build ${{ matrix.dockerfile[1] }}
+      - name: Build & Deploy ${{ matrix.dockerfile[1] }}
         uses: docker/build-push-action@v2
         with:
           file: share/spack/docker/${{matrix.dockerfile[1]}}
           platforms: ${{ matrix.dockerfile[2] }}
-          push: false
+          push: true
           tags: |
             ${{ env.container }}
             ${{ env.versioned }}
-
-      - name: Deploy ${{ matrix.dockerfile[1] }}
-        # And don't push the container on a pull request.
-        if: github.event_name != 'pull_request'
-        run: docker push ghcr.io/spack/${{ matrix.dockerfile[0]}} --all-tags


### PR DESCRIPTION
Hi all,

This is another quick fix to clean up the container builder since we no longer need to check the status of the run to see if we're running as a PR. Because well this isn't going to be triggered on a PR. This allowed us to remove a section to better simplify the workflow.