### PR TITLE
Try to make `ascent+conduit+python` compile properly

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -185,7 +185,11 @@ class Ascent(Package, CudaPackage):
         with working_dir('spack-build', create=True):
             py_site_pkgs_dir = None
             if "+python" in spec:
-                py_site_pkgs_dir = site_packages_dir
+                try:
+                    py_site_pkgs_dir = site_packages_dir
+                except NameError:
+                    # spack's  won't exist in a subclass
+                    pass
 
             host_cfg_fname = self.create_host_config(spec,
                                                      prefix,
@@ -356,6 +360,7 @@ class Ascent(Package, CudaPackage):
         if cppflags:
             # avoid always ending up with ' ' with no flags defined
             cppflags += ' '
+        cppflags += '-lz '
         cflags = cppflags + ' '.join(spec.compiler_flags['cflags'])
         if cflags:
             cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -196,6 +196,14 @@ class Conduit(CMakePackage):
     # Note: cmake, build, and install stages are handled by CMakePackage
     ####################################################################
 
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        if name == 'ldflags':
+            if '+hdf5' in spec:
+                if spec['hdf5'].satisfies('~shared'):
+                    flags.extend(['-ldl', '-lz'])
+        return super(Conduit, self).flag_handler(name, flags)
+
     # provide cmake args (pass host config as cmake cache file)
     def cmake_args(self):
         host_config = self._get_host_config_path(self.spec)


### PR DESCRIPTION
I have been trying to compile `ascent+python` with CUDA on SUMMIT, and have encountered a whole bunch of issues. This fixes some but still does not compile properly.... It's a part-PR, part-bug report issue.

### Command used

`spack install ascent~test+python+cuda~shared ^conduit~hdf5_compat`

The `hdf5_compat` is explained below.

### Issue breakdown

- HDF5 version: doing `spack install ascent+python` uses conduit, which by default has `hdf5_compat` enabled. I get this error:

```
     1630    /sw/summit/gcc/7.4.0/bin/g++ -O2 -g -DNDEBUG -rdynamic -pthread CM
             akeFiles/conduit_blueprint_verify.dir/conduit_blueprint_verify_exe
             .cpp.o -o conduit_blueprint_verify  -Wl,-rpath,/tmp/potterg/spack-
             stage/spack-stage-conduit-0.7.2-cqfd7knohz2u3dymmfskceclnenqocdx/s
             pack-build-cqfd7kn/lib:/autofs/nccs-svm1_home1/potterg/spack/opt/s
             pack/linux-rhel7-power9le/gcc-7.4.0/hdf5-1.8.22-w3vpzki7mkj224lsga
             6lhn43pexori77/lib:::::::::::::::::::::: ../../lib/libconduit_rela
             y.so ../../lib/libconduit_blueprint.so ../../lib/libconduit.so -lr
             t -lpthread /autofs/nccs-svm1_home1/potterg/spack/opt/spack/linux-
             rhel7-power9le/gcc-7.4.0/hdf5-1.8.22-w3vpzki7mkj224lsga6lhn43pexor
             i77/lib/libhdf5.so.10.4.0 -ldl -lmpiprofilesupport -lmpi_ibm
  >> 1631    ../../lib/libconduit_relay.so: undefined reference to `H5Oget_info
             1'
  >> 1632    ../../lib/libconduit_relay.so: undefined reference to `H5Oget_info
             _by_name1'
```

where conduit tries to use a function that isn't available below hdf5 1.10.2 but spack installs hdf5 1.8. I am not sure why this option is here, but I'm now using `^conduit~hdf5_compat` in all further commands. This is not fixed here

- Moving on, I now get the following

```
     650    /sw/summit/gcc/7.4.0/bin/g++ -O2 -g -DNDEBUG -rdynamic CMakeFiles/t
            _rapidjson_smoke.dir/t_rapidjson_smoke.cpp.o -o t_rapidjson_smoke
            ../../lib/libgtest_main.a ../../lib/libgtest.a -lpthread -lpthread
     651    make[2]: Leaving directory `/tmp/potterg/spack-stage/spack-stage-co
            nduit-0.7.2-vv222qykcw3fxlrkndwfyspbtqgdmaew/spack-build-vv222qy'
     652    make[2]: Leaving directory `/tmp/potterg/spack-stage/spack-stage-co
            nduit-0.7.2-vv222qykcw3fxlrkndwfyspbtqgdmaew/spack-build-vv222qy'
     653    [ 21%] Built target t_civetweb_smoke
     654    [ 21%] Built target blt_gtest_smoke
  >> 655    /usr/bin/ld: /autofs/nccs-svm1_home1/potterg/spack/opt/spack/linux-
            rhel7-power9le/gcc-7.4.0/hdf5-1.10.7-dtx3nzujzgg5pavhkslezvjekmppxx
            5v/lib/libhdf5.a(H5PLint.c.o): undefined reference to symbol 'dlsym
            @@@@GLIBC_2.17'
  >> 656    //usr/lib64/libdl.so.2: error adding symbols: DSO missing from comm
            and line
  >> 657    collect2: error: ld returned 1 exit status
  >> 658    make[2]: *** [tests/thirdparty/t_hdf5_smoke] Error 1
```

This is exactly https://github.com/spack/spack/pull/7385 so I used mostly the same fix.

- Moving on, I get the following

```
     656    [ 21%] Built target t_libb64_smoke
     657    /autofs/nccs-svm1_home1/potterg/spack/opt/spack/linux-rhel7-power9l
            e/gcc-7.4.0/hdf5-1.10.7-dtx3nzujzgg5pavhkslezvjekmppxx5v/lib/libhdf
            5.a(H5Zdeflate.c.o): In function `H5Z__filter_deflate':
  >> 658    /tmp/potterg/spack-stage/spack-stage-hdf5-1.10.7-dtx3nzujzgg5pavhks
            lezvjekmppxx5v/spack-src/src/H5Zdeflate.c:106: undefined reference
            to `inflateInit_'
```

So let's add a `-lz` in there. At this point, `conduit` compiles

- Moving on, I get the following

```
==> Error: NameError: global name 'site_packages_dir' is not defined

/autofs/nccs-svm1_home1/potterg/spack/var/spack/repos/builtin/packages/ascent/package.py:217, in install:
        214            print("Installing Ascent...")
        215            make("install")
        216            # install copy of host config for provenance
  >>    217            install(host_cfg_fname, prefix)
```
I re-used https://github.com/spack/spack/pull/23156 but it's probably not the right fix...?

- I'm currently stuck with a `uses too much data for compiler-generated constants; please recompile with -Xptxas --disable-optimizer-constants` error.

<details>

<summary>Full error</summary>

```
  >> 595    make[2]: *** [lib/libascent_mpi.a] Error 255
     596    make[2]: Leaving directory `/tmp/potterg/spack-stage/spack-stage-as
            cent-0.7.1-lsiqyvxlznnoza2gncv2humxr4c77lts/spack-src/spack-build'
  >> 597    make[1]: *** [ascent/CMakeFiles/ascent_mpi.dir/all] Error 2
     598    make[1]: *** Waiting for unfinished jobs....
     599    [ 56%] Linking CXX static library ../lib/libascent.a
     600    cd /tmp/potterg/spack-stage/spack-stage-ascent-0.7.1-lsiqyvxlznnoza
            2gncv2humxr4c77lts/spack-src/spack-build/ascent && /autofs/nccs-svm
            1_home1/potterg/spack/opt/spack/linux-rhel7-power9le/gcc-7.4.0/cmak
            e-3.20.5-fpqhvbibm5p25btq7jvz5h3f2wcsvqeq/bin/cmake -P CMakeFiles/a
            scent.dir/cmake_clean_target.cmake
     601    manual device link step for Ascent
     602    cd /tmp/potterg/spack-stage/spack-stage-ascent-0.7.1-lsiqyvxlznnoza
            2gncv2humxr4c77lts/spack-src/spack-build/ascent && /sw/summit/cuda/
            11.4.0/bin/nvcc --device-link -Xnvlink=--suppress-stack-size-warnin
            g --generate-code=arch=compute_70,code=sm_70 /tmp/potterg/spack-sta
            ge/spack-stage-ascent-0.7.1-lsiqyvxlznnoza2gncv2humxr4c77lts/spack-
            src/spack-build/ascent/CMakeFiles/ascent.dir/runtimes/ascent_data_o
            bject.cpp.o /tmp/potterg/spack-stage/spack-stage-ascent-0.7.1-lsiqy
            vxlznnoza2gncv2humxr4c77lts/spack-src/spack-build/ascent/CMakeFiles
            /ascent.dir/runtimes/ascent_vtkh_data_adapter.cpp.o /tmp/potterg/sp
            ack-stage/spack-stage-ascent-0.7.1-lsiqyvxlznnoza2gncv2humxr4c77lts
            /spack-src/spack-build/ascent/CMakeFiles/ascent.dir/runtimes/ascent
            _vtkh_collection.cpp.o /tmp/potterg/spack-stage/spack-stage-ascent-
            0.7.1-lsiqyvxlznnoza2gncv2humxr4c77lts/spack-src/spack-build/ascent
            /CMakeFiles/ascent.dir/runtimes/flow_filters/ascent_runtime_vtkh_fi
            lters.cpp.o /tmp/potterg/spack-stage/spack-stage-ascent-0.7.1-lsiqy
            vxlznnoza2gncv2humxr4c77lts/spack-src/spack-build/ascent/CMakeFiles
            /ascent.dir/runtimes/flow_filters/ascent_runtime_vtkh_utils.cpp.o /
            tmp/potterg/spack-stage/spack-stage-ascent-0.7.1-lsiqyvxlznnoza2gnc
            v2humxr4c77lts/spack-src/spack-build/ascent/CMakeFiles/ascent.dir/r
            untimes/flow_filters/ascent_runtime_rendering_filters.cpp.o /tmp/po
            tterg/spack-stage/spack-stage-ascent-0.7.1-lsiqyvxlznnoza2gncv2humx
            r4c77lts/spack-src/spack-build/ascent/CMakeFiles/ascent.dir/runtime
            s/flow_filters/ascent_runtime_rover_filters.cpp.o /tmp/potterg/spac
            k-stage/spack-stage-ascent-0.7.1-lsiqyvxlznnoza2gncv2humxr4c77lts/s
            pack-src/spack-build/ascent/CMakeFiles/ascent.dir/runtimes/flow_fil
            ters/ascent_runtime_conduit_to_vtkm_parsing.cpp.o /tmp/potterg/spac
            k-stage/spack-stage-ascent-0.7.1-lsiqyvxlznnoza2gncv2humxr4c77lts/s
            pack-src/spack-build/ascent/CMakeFiles/ascent.dir/runtimes/ascent_m
            ain_runtime.cpp.o /tmp/potterg/spack-stage/spack-stage-ascent-0.7.1
            -lsiqyvxlznnoza2gncv2humxr4c77lts/spack-src/spack-build/ascent/CMak
            eFiles/ascent.dir/runtimes/flow_filters/ascent_runtime_blueprint_fi
            lters.cpp.o /tmp/potterg/spack-stage/spack-stage-ascent-0.7.1-lsiqy
            vxlznnoza2gncv2humxr4c77lts/spack-src/spack-build/lib/librover.a /a
            utofs/nccs-svm1_home1/potterg/spack/opt/spack/linux-rhel7-power9le/
            gcc-7.4.0/vtk-h-0.7.1-5vxkfcn7ukur47iyv27bpombjbbkhzsl/lib/libvtkh_
            rendering.a /autofs/nccs-svm1_home1/potterg/spack/opt/spack/linux-r
            hel7-power9le/gcc-7.4.0/vtk-h-0.7.1-5vxkfcn7ukur47iyv27bpombjbbkhzs
            l/lib/libvtkh_compositing.a /autofs/nccs-svm1_home1/potterg/spack/o
            pt/spack/linux-rhel7-power9le/gcc-7.4.0/vtk-h-0.7.1-5vxkfcn7ukur47i
            yv27bpombjbbkhzsl/lib/libvtkh_filters.a /autofs/nccs-svm1_home1/pot
            terg/spack/opt/spack/linux-rhel7-power9le/gcc-7.4.0/vtk-h-0.7.1-5vx
            kfcn7ukur47iyv27bpombjbbkhzsl/lib/libvtkh_core.a /autofs/nccs-svm1_
            home1/potterg/spack/opt/spack/linux-rhel7-power9le/gcc-7.4.0/vtk-h-
            0.7.1-5vxkfcn7ukur47iyv27bpombjbbkhzsl/lib/libvtkh_lodepng.a /autof
            s/nccs-svm1_home1/potterg/spack/opt/spack/linux-rhel7-power9le/gcc-
            7.4.0/vtk-h-0.7.1-5vxkfcn7ukur47iyv27bpombjbbkhzsl/lib/libvtkh_util
            s.a /autofs/nccs-svm1_home1/potterg/spack/opt/spack/linux-rhel7-pow
            er9le/gcc-7.4.0/vtk-m-1.6.0-nnolfl66fv3znuummzweoiiattimnee2/lib/li
            bvtkm_io-1.6.a /autofs/nccs-svm1_home1/potterg/spack/opt/spack/linu
            x-rhel7-power9le/gcc-7.4.0/vtk-m-1.6.0-nnolfl66fv3znuummzweoiiattim
            nee2/lib/libvtkm_rendering-1.6.a /autofs/nccs-svm1_home1/potterg/sp
            ack/opt/spack/linux-rhel7-power9le/gcc-7.4.0/vtk-m-1.6.0-nnolfl66fv
            3znuummzweoiiattimnee2/lib/libvtkm_filter_common-1.6.a /autofs/nccs
            -svm1_home1/potterg/spack/opt/spack/linux-rhel7-power9le/gcc-7.4.0/
            vtk-m-1.6.0-nnolfl66fv3znuummzweoiiattimnee2/lib/libvtkm_filter_con
            tour-1.6.a /autofs/nccs-svm1_home1/potterg/spack/opt/spack/linux-rh
            el7-power9le/gcc-7.4.0/vtk-m-1.6.0-nnolfl66fv3znuummzweoiiattimnee2
            /lib/libvtkm_filter_gradient-1.6.a /autofs/nccs-svm1_home1/potterg/
            spack/opt/spack/linux-rhel7-power9le/gcc-7.4.0/vtk-m-1.6.0-nnolfl66
            fv3znuummzweoiiattimnee2/lib/libvtkm_filter_extra-1.6.a /autofs/ncc
            s-svm1_home1/potterg/spack/opt/spack/linux-rhel7-power9le/gcc-7.4.0
            /vtk-m-1.6.0-nnolfl66fv3znuummzweoiiattimnee2/lib/libvtkm_worklet-1
            .6.a /autofs/nccs-svm1_home1/potterg/spack/opt/spack/linux-rhel7-po
            wer9le/gcc-7.4.0/vtk-m-1.6.0-nnolfl66fv3znuummzweoiiattimnee2/lib/l
            ibvtkm_source-1.6.a /autofs/nccs-svm1_home1/potterg/spack/opt/spack
            /linux-rhel7-power9le/gcc-7.4.0/vtk-m-1.6.0-nnolfl66fv3znuummzweoii
            attimnee2/lib/libvtkm_cont-1.6.a /autofs/nccs-svm1_home1/potterg/sp
            ack/opt/spack/linux-rhel7-power9le/gcc-7.4.0/vtk-m-1.6.0-nnolfl66fv
            3znuummzweoiiattimnee2/lib/libvtkmdiympi_nompi.a -lcudadevrt -lcuda
            rt_static --output-file bcal_vtkm.o
     603    nvlink error   : Entry function '_ZN4vtkm4cont4cuda8internal19TaskS
            trided1DLaunchINS_4exec4cuda8internal13TaskStrided1DIKNS_7worklet17
            particleadvection21ParticleAdvectWorkletEKNS_8internal10InvocationI
            NSC_17FunctionInterfaceIFvNSC_19ArrayPortalImplicitINSC_12IndexFunc
            torEEEPKNS9_14IntegratorBase10ExecObjectENS9_23ParticleExecutionObj
            ectINS_8ParticleEEENSF_INS0_8internal15ConstantFunctorIiEEEEEEENSE_
            IFvNS8_15WorkletMapField7FieldInENS8_8internal11WorkletBase10ExecOb
            jectESZ_SW_EEENSE_IFvNS_12placeholders3ArgILi1EEENS13_ILi2EEENS13_I
            Li3EEENS13_ILi4EEEEEELi1ESH_SS_SH_NS0_20DeviceAdapterTagCudaEEEEEEE
            vT_i' uses too much data for compiler-generated constants; please r
            ecompile with -Xptxas --disable-optimizer-constants
  >> 604    make[2]: *** [lib/libascent.a] Error 255
     605    make[2]: Leaving directory `/tmp/potterg/spack-stage/spack-stage-as
            cent-0.7.1-lsiqyvxlznnoza2gncv2humxr4c77lts/spack-src/spack-build'
  >> 606    make[1]: *** [ascent/CMakeFiles/ascent.dir/all] Error 2
     607    make[1]: Leaving directory `/tmp/potterg/spack-stage/spack-stage-as
            cent-0.7.1-lsiqyvxlznnoza2gncv2humxr4c77lts/spack-src/spack-build'
  >> 608    make: *** [all] Error 2
```

</details>

The only similar issue I could find was https://github.com/ECP-WarpX/WarpX/issues/2004 but because it said not to follow the recommanded compiler I don't know how to go further.

### Additional infos

* **Spack:** 0.16.2-3697-258f757
* **Python:** 2.7.5
* **Platform:** linux-rhel7-power9le
* **Concretizer:** original
* I'm using `CUDA 11.4.0`

Thanks a lot for some feedback or help