### PR TITLE
concretizer: reuse existing packages

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -188,6 +188,34 @@ configuration a **spec**.  In the commands above, ``mpileaks`` and
 ``mpileaks@3.0.4`` are both valid *specs*.  We'll talk more about how
 you can use them to customize an installation in :ref:`sec-specs`.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Reusing installed dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. warning::
+
+   The ``--reuse`` option described here is experimental, and it will
+   likely be replaced with a different option and configuration settings
+   in the next Spack release.
+
+By default, when you run ``spack install``, Spack tries to build a new
+version of the package you asked for, along with updated versions of
+its dependencies.  This gets you the latest versions and configurations,
+but it can result in unwanted rebuilds if you update Spack frequently.
+
+If you want Spack to try hard to reuse existing installations as dependencies,
+you can add the ``--reuse`` option:
+
+.. code-block:: console
+
+   $ spack install --reuse mpich
+
+This will not do anything if ``mpich`` is already installed.  If ``mpich``
+is not installed, but dependencies like ``hwloc`` and ``libfabric`` are,
+the ``mpich`` will be build with the installed versions, if possible.
+You can use the :ref:`spack spec -I <cmd-spack-spec>` command to see what
+will be reused and what will be built before you install.
+
 .. _cmd-spack-uninstall:
 
 ^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -241,11 +241,16 @@ class BinaryCacheIndex(object):
                     ]
         """
         self.regenerate_spec_cache()
+        return self.find_by_hash(spec.dag_hash())
 
-        find_hash = spec.dag_hash()
+    def find_by_hash(self, find_hash):
+        """Same as find_built_spec but uses the hash of a spec.
+
+        Args:
+            find_hash (str): hash of the spec to search
+        """
         if find_hash not in self._mirrors_for_spec:
             return None
-
         return self._mirrors_for_spec[find_hash]
 
     def update_spec(self, spec, found_list):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -153,6 +153,7 @@ def parse_specs(args, **kwargs):
     concretize = kwargs.get('concretize', False)
     normalize = kwargs.get('normalize', False)
     tests = kwargs.get('tests', False)
+    reuse = kwargs.get('reuse', False)
 
     try:
         sargs = args
@@ -161,7 +162,7 @@ def parse_specs(args, **kwargs):
         specs = spack.spec.parse(sargs)
         for spec in specs:
             if concretize:
-                spec.concretize(tests=tests)  # implies normalize
+                spec.concretize(tests=tests, reuse=reuse)  # implies normalize
             elif normalize:
                 spec.normalize(tests=tests)
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -320,3 +320,11 @@ the build yourself.  Format: %%Y%%m%%d-%%H%%M-[cdash-track]"""
         default=None,
         help=cdash_help['buildstamp']
     )
+
+
+@arg
+def reuse():
+    return Args(
+        '--reuse', action='store_true', default=False,
+        help='reuse installed dependencies'
+    )

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import spack.cmd
+import spack.cmd.common.arguments
 import spack.environment as ev
 
 description = 'concretize an environment and write a lockfile'
@@ -12,6 +13,7 @@ level = "long"
 
 
 def setup_parser(subparser):
+    spack.cmd.common.arguments.add_common_arguments(subparser, ['reuse'])
     subparser.add_argument(
         '-f', '--force', action='store_true',
         help="Re-concretize even if already concretized.")
@@ -34,6 +36,8 @@ def concretize(parser, args):
         tests = False
 
     with env.write_transaction():
-        concretized_specs = env.concretize(force=args.force, tests=tests)
+        concretized_specs = env.concretize(
+            force=args.force, tests=tests, reuse=args.reuse
+        )
         ev.display_specs(concretized_specs)
         env.write()

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -68,8 +68,8 @@ def compare_specs(a, b, to_string=False, color=None):
     # Prepare a solver setup to parse differences
     setup = asp.SpackSolverSetup()
 
-    a_facts = set(t for t in setup.spec_clauses(a, body=True))
-    b_facts = set(t for t in setup.spec_clauses(b, body=True))
+    a_facts = set(t for t in setup.spec_clauses(a, body=True, expand_hashes=True))
+    b_facts = set(t for t in setup.spec_clauses(b, body=True, expand_hashes=True))
 
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -78,7 +78,7 @@ the dependencies"""
     subparser.add_argument(
         '-u', '--until', type=str, dest='until', default=None,
         help="phase to stop after when installing (default None)")
-    arguments.add_common_arguments(subparser, ['jobs'])
+    arguments.add_common_arguments(subparser, ['jobs', 'reuse'])
     subparser.add_argument(
         '--overwrite', action='store_true',
         help="reinstall an existing spec, even if it has dependents")
@@ -338,7 +338,7 @@ environment variables:
 
             if not args.only_concrete:
                 with env.write_transaction():
-                    concretized_specs = env.concretize(tests=tests)
+                    concretized_specs = env.concretize(tests=tests, reuse=args.reuse)
                     ev.display_specs(concretized_specs)
 
                     # save view regeneration for later, so that we only do it
@@ -392,7 +392,8 @@ environment variables:
 
     try:
         specs = spack.cmd.parse_specs(
-            args.spec, concretize=True, tests=tests)
+            args.spec, concretize=True, tests=tests, reuse=args.reuse
+        )
     except SpackError as e:
         tty.debug(e)
         reporter.concretization_report(e.message)

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -68,6 +68,9 @@ def setup_parser(subparser):
         '--stats', action='store_true', default=False,
         help='print out statistics from clingo')
     subparser.add_argument(
+        '--reuse', action='store_true', default=False,
+        help='reuse installed dependencies')
+    subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages")
 
 
@@ -103,7 +106,8 @@ def solve(parser, args):
 
     # dump generated ASP program
     result = asp.solve(
-        specs, dump=dump, models=models, timers=args.timers, stats=args.stats
+        specs, dump=dump, models=models, timers=args.timers, stats=args.stats,
+        reuse=args.reuse,
     )
     if 'solutions' not in dump:
         return

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -44,7 +44,8 @@ def setup_parser(subparser):
 
     # Below are arguments w.r.t. spec display (like spack spec)
     arguments.add_common_arguments(
-        subparser, ['long', 'very_long', 'install_status'])
+        subparser, ['long', 'very_long', 'install_status', 'reuse']
+    )
     subparser.add_argument(
         '-y', '--yaml', action='store_const', dest='format', default=None,
         const='yaml', help='print concrete spec as yaml')
@@ -67,9 +68,6 @@ def setup_parser(subparser):
     subparser.add_argument(
         '--stats', action='store_true', default=False,
         help='print out statistics from clingo')
-    subparser.add_argument(
-        '--reuse', action='store_true', default=False,
-        help='reuse installed dependencies')
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages")
 

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -122,13 +122,21 @@ def solve(parser, args):
             tty.msg("Best of %d considered solutions." % result.nmodels)
             tty.msg("Optimization Criteria:")
 
-            maxlen = max(len(s) for s in result.criteria)
+            maxlen = max(len(s[2]) for s in result.criteria)
             color.cprint(
-                "@*{  Priority  Criterion %sValue}" % ((maxlen - 10) * " ")
+                "@*{  Priority  Criterion %sInstalled  ToBuild}" % ((maxlen - 10) * " ")
             )
-            for i, (name, val) in enumerate(zip(result.criteria, opt)):
-                fmt = "  @K{%%-8d}  %%-%ds%%5d" % maxlen
-                color.cprint(fmt % (i + 1, name, val))
+
+            fmt = "  @K{%%-8d}  %%-%ds%%9s  %%7s" % maxlen
+            for i, (idx, build_idx, name) in enumerate(result.criteria, 1):
+                color.cprint(
+                    fmt % (
+                        i,
+                        name,
+                        "-" if build_idx is None else opt[idx],
+                        opt[idx] if build_idx is None else opt[build_idx],
+                    )
+                )
             print()
 
         for spec in result.specs:

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -732,7 +732,11 @@ def concretize_specs_together(*abstract_specs, **kwargs):
 
 def _concretize_specs_together_new(*abstract_specs, **kwargs):
     import spack.solver.asp
-    result = spack.solver.asp.solve(abstract_specs)
+    concretization_kwargs = {
+        'tests': kwargs.get('tests', False),
+        'reuse': kwargs.get('reuse', False)
+    }
+    result = spack.solver.asp.solve(abstract_specs, **concretization_kwargs)
     result.raise_if_unsat()
     return [s.copy() for s in result.specs]
 
@@ -768,10 +772,15 @@ def _concretize_specs_together_original(*abstract_specs, **kwargs):
     abstract_specs = [spack.spec.Spec(s) for s in abstract_specs]
     concretization_repository = make_concretization_repository(abstract_specs)
 
+    concretization_kwargs = {
+        'tests': kwargs.get('tests', False),
+        'reuse': kwargs.get('reuse', False)
+    }
+
     with spack.repo.additional_repository(concretization_repository):
         # Spec from a helper package that depends on all the abstract_specs
         concretization_root = spack.spec.Spec('concretizationroot')
-        concretization_root.concretize(tests=kwargs.get('tests', False))
+        concretization_root.concretize(**concretization_kwargs)
         # Retrieve the direct dependencies
         concrete_specs = [
             concretization_root[spec.name].copy() for spec in abstract_specs

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1035,7 +1035,7 @@ class Environment(object):
         """Returns true when the spec is built from local sources"""
         return spec.name in self.dev_specs
 
-    def concretize(self, force=False, tests=False):
+    def concretize(self, force=False, tests=False, reuse=False):
         """Concretize user_specs in this environment.
 
         Only concretizes specs that haven't been concretized yet unless
@@ -1049,6 +1049,8 @@ class Environment(object):
                already concretized
             tests (bool or list or set): False to run no tests, True to test
                 all packages, or a list of package names to run tests for some
+            reuse (bool): if True try to maximize reuse of already installed
+                specs, if False don't account for installation status.
 
         Returns:
             List of specs that have been concretized. Each entry is a tuple of
@@ -1062,14 +1064,15 @@ class Environment(object):
 
         # Pick the right concretization strategy
         if self.concretization == 'together':
-            return self._concretize_together(tests=tests)
+            return self._concretize_together(tests=tests, reuse=reuse)
+
         if self.concretization == 'separately':
-            return self._concretize_separately(tests=tests)
+            return self._concretize_separately(tests=tests, reuse=reuse)
 
         msg = 'concretization strategy not implemented [{0}]'
         raise SpackEnvironmentError(msg.format(self.concretization))
 
-    def _concretize_together(self, tests=False):
+    def _concretize_together(self, tests=False, reuse=False):
         """Concretization strategy that concretizes all the specs
         in the same DAG.
         """
@@ -1102,13 +1105,14 @@ class Environment(object):
         self.specs_by_hash = {}
 
         concrete_specs = spack.concretize.concretize_specs_together(
-            *self.user_specs, tests=tests)
+            *self.user_specs, tests=tests, reuse=reuse
+        )
         concretized_specs = [x for x in zip(self.user_specs, concrete_specs)]
         for abstract, concrete in concretized_specs:
             self._add_concrete_spec(abstract, concrete)
         return concretized_specs
 
-    def _concretize_separately(self, tests=False):
+    def _concretize_separately(self, tests=False, reuse=False):
         """Concretization strategy that concretizes separately one
         user spec after the other.
         """
@@ -1133,7 +1137,7 @@ class Environment(object):
         ):
             if uspec not in old_concretized_user_specs:
                 root_specs.append(uspec)
-                arguments.append((uspec_constraints, tests))
+                arguments.append((uspec_constraints, tests, reuse))
 
         # Ensure we don't try to bootstrap clingo in parallel
         if spack.config.get('config:concretizer') == 'clingo':
@@ -1988,7 +1992,7 @@ def display_specs(concretized_specs):
         print('')
 
 
-def _concretize_from_constraints(spec_constraints, tests=False):
+def _concretize_from_constraints(spec_constraints, tests=False, reuse=False):
     # Accept only valid constraints from list and concretize spec
     # Get the named spec even if out of order
     root_spec = [s for s in spec_constraints if s.name]
@@ -2007,7 +2011,7 @@ def _concretize_from_constraints(spec_constraints, tests=False):
             if c not in invalid_constraints:
                 s.constrain(c)
         try:
-            return s.concretized(tests=tests)
+            return s.concretized(tests=tests, reuse=reuse)
         except spack.spec.InvalidDependencyError as e:
             invalid_deps_string = ['^' + d for d in e.invalid_deps]
             invalid_deps = [c for c in spec_constraints
@@ -2027,9 +2031,9 @@ def _concretize_from_constraints(spec_constraints, tests=False):
 
 
 def _concretize_task(packed_arguments):
-    spec_constraints, tests = packed_arguments
+    spec_constraints, tests, reuse = packed_arguments
     with tty.SuppressOutput(msg_enabled=False):
-        return _concretize_from_constraints(spec_constraints, tests)
+        return _concretize_from_constraints(spec_constraints, tests, reuse)
 
 
 def make_repo_path(root):

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -90,7 +90,7 @@ def _patchelf():
 
     # Check if patchelf spec is installed
     spec = spack.spec.Spec('patchelf')
-    spec._old_concretize()
+    spec._old_concretize(deprecation_warning=False)
     exe_path = os.path.join(spec.prefix.bin, "patchelf")
     if spec.package.installed and os.path.exists(exe_path):
         return exe_path

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1423,6 +1423,10 @@ class SpackSolverSetup(object):
         strict = spack.concretize.Concretizer().check_for_compiler_existence
         for spec in specs:
             for s in spec.traverse():
+                # we don't need to validate compilers for already-built specs
+                if s.concrete:
+                    continue
+
                 if not s.compiler or not s.compiler.concrete:
                     continue
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -808,7 +808,7 @@ class SpackSolverSetup(object):
         self.gen.fact(fn.condition(condition_id))
 
         # requirements trigger the condition
-        requirements = self.checked_spec_clauses(
+        requirements = self.spec_clauses(
             named_cond, body=True, required_from=name)
         for pred in requirements:
             self.gen.fact(
@@ -816,7 +816,7 @@ class SpackSolverSetup(object):
             )
 
         if imposed_spec:
-            imposed_constraints = self.checked_spec_clauses(
+            imposed_constraints = self.spec_clauses(
                 imposed_spec, body=False, required_from=name)
             for pred in imposed_constraints:
                 # imposed "node"-like conditions are no-ops
@@ -1006,13 +1006,13 @@ class SpackSolverSetup(object):
                     self.gen.fact(fn.compiler_version_flag(
                         compiler.name, compiler.version, name, flag))
 
-    def checked_spec_clauses(self, *args, **kwargs):
-        """Wrap a call to spec clauses into a try/except block that raise
-        a comprehensible error message in case of failure.
+    def spec_clauses(self, *args, **kwargs):
+        """Wrap a call to `_spec_clauses()` into a try/except block that
+        raises a comprehensible error message in case of failure.
         """
         requestor = kwargs.pop('required_from', None)
         try:
-            clauses = self.spec_clauses(*args, **kwargs)
+            clauses = self._spec_clauses(*args, **kwargs)
         except RuntimeError as exc:
             msg = str(exc)
             if requestor:
@@ -1020,7 +1020,7 @@ class SpackSolverSetup(object):
             raise RuntimeError(msg)
         return clauses
 
-    def spec_clauses(self, spec, body=False, transitive=True):
+    def _spec_clauses(self, spec, body=False, transitive=True):
         """Return a list of clauses for a spec mandates are true.
 
         Arguments:
@@ -1133,7 +1133,7 @@ class SpackSolverSetup(object):
         # add all clauses from dependencies
         if transitive:
             for dep in spec.traverse(root=False):
-                clauses.extend(self.spec_clauses(dep, body, transitive=False))
+                clauses.extend(self._spec_clauses(dep, body, transitive=False))
 
         return clauses
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -821,9 +821,9 @@ class SpackSolverSetup(object):
 
         return condition_id
 
-    def impose(self, condition_id, imposed_spec, node=True, name=None):
+    def impose(self, condition_id, imposed_spec, node=True, name=None, body=False):
         imposed_constraints = self.spec_clauses(
-            imposed_spec, body=False, required_from=name)
+            imposed_spec, body=body, required_from=name)
         for pred in imposed_constraints:
             # imposed "node"-like conditions are no-ops
             if not node and pred.name in ("node", "virtual_node"):
@@ -1505,7 +1505,7 @@ class SpackSolverSetup(object):
                     self.gen.fact(fn.installed_hash(spec.name, h))
 
                     # this describes what constraints it imposes on the solve
-                    self.impose(h, spec)
+                    self.impose(h, spec, body=True)
                     self.gen.newline()
 
     def setup(self, driver, specs, tests=False, reuse=False):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -43,6 +43,7 @@ import spack.package_prefs
 import spack.platforms
 import spack.repo
 import spack.spec
+import spack.store
 import spack.util.timer
 import spack.variant
 import spack.version
@@ -816,17 +817,20 @@ class SpackSolverSetup(object):
             )
 
         if imposed_spec:
-            imposed_constraints = self.spec_clauses(
-                imposed_spec, body=False, required_from=name)
-            for pred in imposed_constraints:
-                # imposed "node"-like conditions are no-ops
-                if pred.name in ("node", "virtual_node"):
-                    continue
-                self.gen.fact(
-                    fn.imposed_constraint(condition_id, pred.name, *pred.args)
-                )
+            self.impose(condition_id, imposed_spec, node=False, name=name)
 
         return condition_id
+
+    def impose(self, condition_id, imposed_spec, node=True, name=None):
+        imposed_constraints = self.spec_clauses(
+            imposed_spec, body=False, required_from=name)
+        for pred in imposed_constraints:
+            # imposed "node"-like conditions are no-ops
+            if not node and pred.name in ("node", "virtual_node"):
+                continue
+            self.gen.fact(
+                fn.imposed_constraint(condition_id, pred.name, *pred.args)
+            )
 
     def package_provider_rules(self, pkg):
         for provider_name in sorted(set(s.name for s in pkg.provided.keys())):
@@ -1127,13 +1131,22 @@ class SpackSolverSetup(object):
 
         # dependencies
         if spec.concrete:
-            clauses.append(fn.concrete(spec.name))
-            # TODO: add concrete depends_on() facts for concrete dependencies
+            clauses.append(fn.hash(spec.name, spec.dag_hash()))
 
         # add all clauses from dependencies
         if transitive:
+            if spec.concrete:
+                for dep_name, dep in spec.dependencies_dict().items():
+                    for dtype in dep.deptypes:
+                        clauses.append(fn.depends_on(spec.name, dep_name, dtype))
+
             for dep in spec.traverse(root=False):
-                clauses.extend(self._spec_clauses(dep, body, transitive=False))
+                if spec.concrete:
+                    clauses.append(fn.hash(dep.name, dep.dag_hash()))
+                else:
+                    clauses.extend(
+                        self._spec_clauses(dep, body, transitive=False)
+                    )
 
         return clauses
 
@@ -1475,6 +1488,26 @@ class SpackSolverSetup(object):
         for pkg, variant, value in sorted(self.variant_values_from_specs):
             self.gen.fact(fn.variant_possible_value(pkg, variant, value))
 
+    def define_installed_packages(self, possible):
+        """Add facts about all specs already in the database.
+
+        Arguments:
+            possible (dict): result of Package.possible_dependencies() for
+                specs in this solve.
+        """
+        with spack.store.db.read_transaction():
+            for spec in spack.store.db.query(installed=True):
+                # tell the solver about any installed packages that could
+                # be dependencies (don't tell it about the others)
+                if spec.name in possible:
+                    # this indicates that there is a spec like this installed
+                    h = spec.dag_hash()
+                    self.gen.fact(fn.installed_hash(spec.name, h))
+
+                    # this describes what constraints it imposes on the solve
+                    self.impose(h, spec)
+                    self.gen.newline()
+
     def setup(self, driver, specs, tests=False, reuse=False):
         """Generate an ASP program with relevant constraints for specs.
 
@@ -1577,6 +1610,10 @@ class SpackSolverSetup(object):
         self.gen.h1("Target Constraints")
         self.define_target_constraints()
 
+        if reuse:
+            self.gen.h1("Installed packages")
+            self.define_installed_packages(possible)
+
 
 class SpecBuilder(object):
     """Class with actions to rebuild a spec from ASP results."""
@@ -1585,6 +1622,14 @@ class SpecBuilder(object):
         self._command_line_specs = specs
         self._flag_sources = collections.defaultdict(lambda: set())
         self._flag_compiler_defaults = set()
+
+    def hash(self, pkg, h):
+        if pkg not in self._specs:
+            self._specs[pkg] = spack.store.db.get_by_hash(h)[0]
+        else:
+            # ensure that if it's already there, it's correct
+            spec = self._specs[pkg]
+            assert spec.dag_hash() == h
 
     def node(self, pkg):
         if pkg not in self._specs:
@@ -1727,6 +1772,7 @@ class SpecBuilder(object):
         # them here so that directives that build objects (like node and
         # node_compiler) are called in the right order.
         function_tuples.sort(key=lambda f: {
+            "hash": -3,
             "node": -2,
             "node_compiler": -1,
         }.get(f[0], 0))
@@ -1747,6 +1793,12 @@ class SpecBuilder(object):
             # solving but don't construct anything
             pkg = args[0]
             if spack.repo.path.is_virtual(pkg):
+                continue
+
+            # if we've already gotten a concrete spec for this pkg,
+            # do not bother calling actions on it.
+            spec = self._specs.get(pkg)
+            if spec and spec.concrete:
                 continue
 
             action(*args)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -440,7 +440,7 @@ class PyclingoDriver(object):
 
     def solve(
             self, solver_setup, specs, dump=None, nmodels=0,
-            timers=False, stats=False, tests=False
+            timers=False, stats=False, tests=False, reuse=False,
     ):
         timer = spack.util.timer.Timer()
 
@@ -457,7 +457,7 @@ class PyclingoDriver(object):
         self.assumptions = []
         with self.control.backend() as backend:
             self.backend = backend
-            solver_setup.setup(self, specs, tests=tests)
+            solver_setup.setup(self, specs, tests=tests, reuse=reuse)
         timer.phase("setup")
 
         # read in the main ASP program and display logic -- these are
@@ -1475,7 +1475,7 @@ class SpackSolverSetup(object):
         for pkg, variant, value in sorted(self.variant_values_from_specs):
             self.gen.fact(fn.variant_possible_value(pkg, variant, value))
 
-    def setup(self, driver, specs, tests=False):
+    def setup(self, driver, specs, tests=False, reuse=False):
         """Generate an ASP program with relevant constraints for specs.
 
         This calls methods on the solve driver to set up the problem with
@@ -1803,7 +1803,8 @@ def _develop_specs_from_env(spec, env):
 #
 # These are handwritten parts for the Spack ASP model.
 #
-def solve(specs, dump=(), models=0, timers=False, stats=False, tests=False):
+def solve(specs, dump=(), models=0, timers=False, stats=False, tests=False,
+          reuse=False):
     """Solve for a stable model of specs.
 
     Arguments:
@@ -1823,4 +1824,6 @@ def solve(specs, dump=(), models=0, timers=False, stats=False, tests=False):
             spack.spec.Spec.ensure_valid_variants(s)
 
     setup = SpackSolverSetup()
-    return driver.solve(setup, specs, dump, models, timers, stats, tests)
+    return driver.solve(
+        setup, specs, dump, models, timers, stats, tests, reuse
+    )

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1081,7 +1081,7 @@ class SpackSolverSetup(object):
             raise RuntimeError(msg)
         return clauses
 
-    def _spec_clauses(self, spec, body=False, transitive=True):
+    def _spec_clauses(self, spec, body=False, transitive=True, expand_hashes=False):
         """Return a list of clauses for a spec mandates are true.
 
         Arguments:
@@ -1089,7 +1089,15 @@ class SpackSolverSetup(object):
             body (bool): if True, generate clauses to be used in rule bodies
                 (final values) instead of rule heads (setters).
             transitive (bool): if False, don't generate clauses from
-                 dependencies (default True)
+                dependencies (default True)
+            expand_hashes (bool): if True, descend into hashes of concrete specs
+                (default False)
+
+        Normally, if called with ``transitive=True``, ``spec_clauses()`` just generates
+        hashes for the dependency requirements of concrete specs. If ``expand_hashes``
+        is ``True``, we'll *also* output all the facts implied by transitive hashes,
+        which are redundant during a solve but useful outside of one (e.g.,
+        for spec ``diff``).
         """
         clauses = []
 
@@ -1200,7 +1208,7 @@ class SpackSolverSetup(object):
             for dep in spec.traverse(root=False):
                 if spec.concrete:
                     clauses.append(fn.hash(dep.name, dep.dag_hash()))
-                else:
+                if not spec.concrete or expand_hashes:
                     clauses.extend(
                         self._spec_clauses(dep, body, transitive=False)
                     )

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1570,6 +1570,8 @@ class SpackSolverSetup(object):
 
         if reuse:
             self.gen.h1("Installed packages")
+            self.gen.fact(fn.optimize_for_reuse())
+            self.gen.newline()
             self.define_installed_packages(possible)
 
         self.gen.h1('General Constraints')

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -793,7 +793,12 @@ build(Package) :- not hash(Package, _), node(Package).
 % defaults and preferences.  This is implemented by bumping the priority of optimization
 % criteria for built specs -- so that they take precedence over the otherwise
 % topmost-priority criterion to reuse what is installed.
-build_priority(Package, 100) :- build(Package), node(Package).
+%
+% The priority ranges are:
+%   200+        Shifted priorities for build nodes; correspond to priorities 0 - 99.
+%   100 - 199   Unshifted priorities. Currently only includes minimizing #builds.
+%   0   -  99   Priorities for non-built nodes.
+build_priority(Package, 200) :- build(Package), node(Package).
 build_priority(Package, 0)   :- not build(Package), node(Package).
 
 #defined installed_hash/2.
@@ -807,18 +812,17 @@ build_priority(Package, 0)   :- not build(Package), node(Package).
 %      is displayed (clingo doesn't display sums over empty sets by default)
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
-opt_criterion(17, "number of packages to build (vs. reuse)").
-#minimize { 0@17: #true }.
-#minimize { 1@17,Package : build(Package), optimize_for_reuse() }.
+opt_criterion(100, "number of packages to build (vs. reuse)").
+#minimize { 0@100: #true }.
+#minimize { 1@100,Package : build(Package), optimize_for_reuse() }.
 #defined optimize_for_reuse/0.
 
 % Minimize the number of deprecated versions being used
-opt_criterion(116, "(build) deprecated versions used").
-opt_criterion(16, "deprecated versions used").
-#minimize{ 0@116: #true }.
-#minimize{ 0@16: #true }.
+opt_criterion(14, "deprecated versions used").
+#minimize{ 0@214: #true }.
+#minimize{ 0@14: #true }.
 #minimize{
-    1@16+Priority,Package
+    1@14+Priority,Package
     : deprecated(Package, _),
       build_priority(Package, Priority)
 }.
@@ -827,33 +831,30 @@ opt_criterion(16, "deprecated versions used").
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root(Package)
-opt_criterion(115, "(build) version weight").
-opt_criterion(15, "version weight").
-#minimize{ 0@115: #true }.
-#minimize{ 0@15: #true }.
+opt_criterion(13, "version weight").
+#minimize{ 0@213: #true }.
+#minimize{ 0@13: #true }.
 #minimize {
-    Weight@15+Priority
+    Weight@13+Priority
     : root(Package),version_weight(Package, Weight),
       build_priority(Package, Priority)
 }.
 
-opt_criterion(114, "(build) number of non-default variants (roots)").
-opt_criterion(14, "number of non-default variants (roots)").
-#minimize{ 0@114: #true }.
-#minimize{ 0@14: #true }.
+opt_criterion(12, "number of non-default variants (roots)").
+#minimize{ 0@212: #true }.
+#minimize{ 0@12: #true }.
 #minimize {
-    Weight@14+Priority,Package,Variant,Value
+    Weight@12+Priority,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight),
       root(Package),
       build_priority(Package, Priority)
 }.
 
-opt_criterion(112, "(build) preferred providers for roots").
-opt_criterion(12, "preferred providers for roots").
-#minimize{ 0@112 : #true }.
-#minimize{ 0@12: #true }.
+opt_criterion(11, "preferred providers for roots").
+#minimize{ 0@211 : #true }.
+#minimize{ 0@11: #true }.
 #minimize{
-    Weight@12+Priority,Provider,Virtual
+    Weight@11+Priority,Provider,Virtual
     : provider_weight(Provider, Virtual, Weight),
       root(Provider),
       build_priority(Provider, Priority)
@@ -862,12 +863,11 @@ opt_criterion(12, "preferred providers for roots").
 % If the value is a multivalued variant there could be multiple
 % values set as default. Since a default value has a weight of 0 we
 % need to maximize their number below to ensure they're all set
-opt_criterion(111, "(build) number of values in multi-valued variants (root)").
-opt_criterion(11, "number of values in multi-valued variants (root)").
-#minimize{ 0@111 : #true }.
-#minimize{ 0@11 : #true }.
+opt_criterion(10, "number of values in multi-valued variants (root)").
+#minimize{ 0@210 : #true }.
+#minimize{ 0@10 : #true }.
 #maximize {
-    1@11+Priority,Package,Variant,Value
+    1@10+Priority,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight),
       not variant_single_value(Package, Variant),
       root(Package),
@@ -875,11 +875,11 @@ opt_criterion(11, "number of values in multi-valued variants (root)").
 }.
 
 % Try to use default variants or variants that have been set
-opt_criterion(110, "(build) number of non-default variants (non-roots)").
-opt_criterion(10, "number of non-default variants (non-roots)").
-#minimize{ 0@10: #true }.
+opt_criterion(9, "number of non-default variants (non-roots)").
+#minimize{ 0@209: #true }.
+#minimize{ 0@9: #true }.
 #minimize {
-    Weight@10+Priority,Package,Variant,Value
+    Weight@9+Priority,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight),
       not root(Package),
       build_priority(Package, Priority)
@@ -887,62 +887,57 @@ opt_criterion(10, "number of non-default variants (non-roots)").
 
 % Minimize the weights of the providers, i.e. use as much as
 % possible the most preferred providers
-opt_criterion(109, "(build) preferred providers (non-roots)").
-opt_criterion(9, "preferred providers (non-roots)").
-#minimize{ 0@109: #true }.
-#minimize{ 0@9: #true }.
+opt_criterion(8, "preferred providers (non-roots)").
+#minimize{ 0@208: #true }.
+#minimize{ 0@8: #true }.
 #minimize{
-    Weight@9+Priority,Provider,Virtual
+    Weight@8+Priority,Provider,Virtual
     : provider_weight(Provider, Virtual, Weight), not root(Provider),
       build_priority(Provider, Priority)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.
-opt_criterion(108, "(build) compiler mismatches").
-opt_criterion(8, "compiler mismatches").
-#minimize{ 0@108: #true }.
-#minimize{ 0@8: #true }.
+opt_criterion(7, "compiler mismatches").
+#minimize{ 0@207: #true }.
+#minimize{ 0@7: #true }.
 #minimize{
-    1@8+Priority,Package,Dependency
+    1@7+Priority,Package,Dependency
     : compiler_mismatch(Package, Dependency),
       build_priority(Package, Priority)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.
-opt_criterion(107, "(build) OS mismatches").
-opt_criterion(7, "OS mismatches").
-#minimize{ 0@107: #true }.
-#minimize{ 0@7: #true }.
+opt_criterion(6, "OS mismatches").
+#minimize{ 0@206: #true }.
+#minimize{ 0@6: #true }.
 #minimize{
-    1@7+Priority,Package,Dependency
+    1@6+Priority,Package,Dependency
     : node_os_mismatch(Package, Dependency),
       build_priority(Package, Priority)
 }.
 
-opt_criterion(106, "(build) non-preferred OSes").
-#minimize{ 0@106: #true }.
-#minimize{ 0@6: #true }.
+opt_criterion(5, "non-preferred OS's").
+#minimize{ 0@205: #true }.
+#minimize{ 0@5: #true }.
 #minimize{
-    Weight@6+Priority,Package
+    Weight@5+Priority,Package
     : node_os_weight(Package, Weight),
       build_priority(Package, Priority)
 }.
 
 % Choose more recent versions for nodes
-opt_criterion(105, "(build) version badness").
 opt_criterion(5, "version badness").
-#minimize{ 0@105: #true }.
-#minimize{ 0@5: #true }.
+#minimize{ 0@204: #true }.
+#minimize{ 0@4: #true }.
 #minimize{
-    Weight@5+Priority,Package
+    Weight@4+Priority,Package
     : version_weight(Package, Weight),
       build_priority(Package, Priority)
 }.
 
 % Try to use preferred compilers
-opt_criterion(103, "(build) non-preferred compilers").
 opt_criterion(3, "non-preferred compilers").
-#minimize{ 0@103: #true }.
+#minimize{ 0@203: #true }.
 #minimize{ 0@3: #true }.
 #minimize{
     Weight@3+Priority,Package
@@ -952,9 +947,8 @@ opt_criterion(3, "non-preferred compilers").
 
 % Minimize the number of mismatches for targets in the DAG, try
 % to select the preferred target.
-opt_criterion(102, "(build) target mismatches").
 opt_criterion(2, "target mismatches").
-#minimize{ 0@102: #true }.
+#minimize{ 0@202: #true }.
 #minimize{ 0@2: #true }.
 #minimize{
     1@2+Priority,Package,Dependency
@@ -962,9 +956,8 @@ opt_criterion(2, "target mismatches").
       build_priority(Package, Priority)
 }.
 
-opt_criterion(101, "(build) non-preferred targets").
 opt_criterion(1, "non-preferred targets").
-#minimize{ 0@101: #true }.
+#minimize{ 0@201: #true }.
 #minimize{ 0@1: #true }.
 #minimize{
     Weight@1+Priority,Package

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -435,18 +435,23 @@ variant_value(Package, Variant, Value)
 % The rules below allow us to prefer default values for variants
 % whenever possible. If a variant is set in a spec, or if it is
 % specified in an external, we score it as if it was a default value.
-variant_not_default(Package, Variant, Actual, 1)
- :- variant_value(Package, Variant, Actual),
-    not variant_value(Package, Variant, Value),
-    variant_default_value(Package, Variant, Value),
-    Actual != Value,
+variant_not_default(Package, Variant, Value)
+ :- variant_value(Package, Variant, Value),
+    not variant_default_value(Package, Variant, Value),
     % variants set explicitly on the CLI don't count as non-default
-    not variant_set(Package, Variant, Actual),
+    not variant_set(Package, Variant, Value),
     % variants set on externals that we could use don't count as non-default
     % this makes spack prefer to use an external over rebuilding with the
     % default configuration
-    not external_with_variant_set(Package, Variant, Actual),
+    not external_with_variant_set(Package, Variant, Value),
     node(Package).
+
+
+% A default variant value that is not used
+variant_default_not_used(Package, Variant, Value)
+  :- variant_default_value(Package, Variant, Value),
+     not variant_value(Package, Variant, Value),
+     node(Package).
 
 % The variant is set in an external spec
 external_with_variant_set(Package, Variant, Value)
@@ -823,11 +828,11 @@ opt_criterion(100, "number of packages to build (vs. reuse)").
 #defined optimize_for_reuse/0.
 
 % Minimize the number of deprecated versions being used
-opt_criterion(14, "deprecated versions used").
-#minimize{ 0@214: #true }.
-#minimize{ 0@14: #true }.
+opt_criterion(15, "deprecated versions used").
+#minimize{ 0@215: #true }.
+#minimize{ 0@15: #true }.
 #minimize{
-    1@14+Priority,Package
+    1@15+Priority,Package
     : deprecated(Package, _),
       build_priority(Package, Priority)
 }.
@@ -836,93 +841,114 @@ opt_criterion(14, "deprecated versions used").
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root(Package)
-opt_criterion(13, "version weight").
-#minimize{ 0@213: #true }.
-#minimize{ 0@13: #true }.
+opt_criterion(14, "version weight").
+#minimize{ 0@214: #true }.
+#minimize{ 0@14: #true }.
 #minimize {
-    Weight@13+Priority
+    Weight@14+Priority
     : root(Package),version_weight(Package, Weight),
       build_priority(Package, Priority)
 }.
 
-opt_criterion(12, "number of non-default variants (roots)").
-#minimize{ 0@212: #true }.
-#minimize{ 0@12: #true }.
+opt_criterion(13, "number of non-default variants (roots)").
+#minimize{ 0@213: #true }.
+#minimize{ 0@13: #true }.
 #minimize {
-    Weight@12+Priority,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, Weight),
+    1@13+Priority,Package,Variant,Value
+    : variant_not_default(Package, Variant, Value),
       root(Package),
       build_priority(Package, Priority)
 }.
 
-opt_criterion(11, "preferred providers for roots").
-#minimize{ 0@211 : #true }.
-#minimize{ 0@11: #true }.
+opt_criterion(12, "preferred providers for roots").
+#minimize{ 0@212 : #true }.
+#minimize{ 0@12: #true }.
 #minimize{
-    Weight@11+Priority,Provider,Virtual
+    Weight@12+Priority,Provider,Virtual
     : provider_weight(Provider, Virtual, Weight),
       root(Provider),
       build_priority(Provider, Priority)
 }.
 
+opt_criterion(11, "default values of variants not being used (roots)").
+#minimize{ 0@211: #true }.
+#minimize{ 0@11: #true }.
+#minimize{
+    1@11+Priority,Package,Variant,Value
+    : variant_default_not_used(Package, Variant, Value),
+      root(Package),
+      build_priority(Package, Priority)
+}.
+
 % Try to use default variants or variants that have been set
-opt_criterion(9, "number of non-default variants (non-roots)").
-#minimize{ 0@209: #true }.
-#minimize{ 0@9: #true }.
+opt_criterion(10, "number of non-default variants (non-roots)").
+#minimize{ 0@210: #true }.
+#minimize{ 0@10: #true }.
 #minimize {
-    Weight@9+Priority,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, Weight),
+    1@10+Priority,Package,Variant,Value
+    : variant_not_default(Package, Variant, Value),
       not root(Package),
       build_priority(Package, Priority)
 }.
 
 % Minimize the weights of the providers, i.e. use as much as
 % possible the most preferred providers
-opt_criterion(8, "preferred providers (non-roots)").
-#minimize{ 0@208: #true }.
-#minimize{ 0@8: #true }.
+opt_criterion(9, "preferred providers (non-roots)").
+#minimize{ 0@209: #true }.
+#minimize{ 0@9: #true }.
 #minimize{
-    Weight@8+Priority,Provider,Virtual
+    Weight@9+Priority,Provider,Virtual
     : provider_weight(Provider, Virtual, Weight), not root(Provider),
       build_priority(Provider, Priority)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.
-opt_criterion(7, "compiler mismatches").
-#minimize{ 0@207: #true }.
-#minimize{ 0@7: #true }.
+opt_criterion(8, "compiler mismatches").
+#minimize{ 0@208: #true }.
+#minimize{ 0@8: #true }.
 #minimize{
-    1@7+Priority,Package,Dependency
+    1@8+Priority,Package,Dependency
     : compiler_mismatch(Package, Dependency),
       build_priority(Package, Priority)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.
-opt_criterion(6, "OS mismatches").
-#minimize{ 0@206: #true }.
-#minimize{ 0@6: #true }.
+opt_criterion(7, "OS mismatches").
+#minimize{ 0@207: #true }.
+#minimize{ 0@7: #true }.
 #minimize{
-    1@6+Priority,Package,Dependency
+    1@7+Priority,Package,Dependency
     : node_os_mismatch(Package, Dependency),
       build_priority(Package, Priority)
 }.
 
-opt_criterion(5, "non-preferred OS's").
-#minimize{ 0@205: #true }.
-#minimize{ 0@5: #true }.
+opt_criterion(6, "non-preferred OS's").
+#minimize{ 0@206: #true }.
+#minimize{ 0@6: #true }.
 #minimize{
-    Weight@5+Priority,Package
+    Weight@6+Priority,Package
     : node_os_weight(Package, Weight),
       build_priority(Package, Priority)
 }.
 
 % Choose more recent versions for nodes
 opt_criterion(5, "version badness").
+#minimize{ 0@205: #true }.
+#minimize{ 0@5: #true }.
+#minimize{
+    Weight@5+Priority,Package
+    : version_weight(Package, Weight),
+      build_priority(Package, Priority)
+}.
+
+% Try to use all the default values of variants
+opt_criterion(4, "default values of variants not being used (non-roots)").
 #minimize{ 0@204: #true }.
 #minimize{ 0@4: #true }.
 #minimize{
-    Weight@4+Priority,Package
-    : version_weight(Package, Weight),
+    1@4+Priority,Package,Variant,Value
+    : variant_default_not_used(Package, Variant, Value),
+      not root(Package),
       build_priority(Package, Priority)
 }.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -88,17 +88,27 @@ attr(Name, A1, A2, A3) :- impose(ID), imposed_constraint(ID, Name, A1, A2, A3).
 #defined imposed_constraint/5.
 
 %-----------------------------------------------------------------------------
+% Concrete specs
+%-----------------------------------------------------------------------------
+% if a package is assigned a hash, it's concrete.
+concrete(Package) :- hash(Package, _), node(Package).
+
+%-----------------------------------------------------------------------------
 % Dependency semantics
 %-----------------------------------------------------------------------------
 % Dependencies of any type imply that one package "depends on" another
 depends_on(Package, Dependency) :- depends_on(Package, Dependency, _).
 
-% a dependency holds if its condition holds
+% a dependency holds if its condition holds and if it is not external or
+% concrete. We chop off dependencies for externals, and dependencies of
+% concrete specs don't need to be resolved -- they arise from the concrete
+% specs themselves.
 dependency_holds(Package, Dependency, Type) :-
   dependency_condition(ID, Package, Dependency),
   dependency_type(ID, Type),
   condition_holds(ID),
-  not external(Package).
+  not external(Package),
+  not concrete(Package).
 
 % We cut off dependencies of externals (as we don't really know them).
 % Don't impose constraints on dependencies that don't exist.
@@ -251,6 +261,7 @@ possible_provider_weight(Dependency, Virtual, 100, "fallback") :- provider(Depen
 % These allow us to easily define conditional dependency and conflict rules
 % without enumerating all spec attributes every time.
 node(Package)                          :- attr("node", Package).
+hash(Package, Hash)                    :- attr("hash", Package, Hash).
 version(Package, Version)              :- attr("version", Package, Version).
 version_satisfies(Package, Constraint) :- attr("version_satisfies", Package, Constraint).
 node_platform(Package, Platform)       :- attr("node_platform", Package, Platform).
@@ -261,12 +272,14 @@ variant_value(Package, Variant, Value) :- attr("variant_value", Package, Variant
 variant_set(Package, Variant, Value)   :- attr("variant_set", Package, Variant, Value).
 node_flag(Package, FlagType, Flag)     :- attr("node_flag", Package, FlagType, Flag).
 node_compiler(Package, Compiler)       :- attr("node_compiler", Package, Compiler).
+depends_on(Package, Dependency, Type)  :- attr("depends_on", Package, Dependency, Type).
 node_compiler_version(Package, Compiler, Version)
   :- attr("node_compiler_version", Package, Compiler, Version).
 node_compiler_version_satisfies(Package, Compiler, Version)
   :- attr("node_compiler_version_satisfies", Package, Compiler, Version).
 
 attr("node", Package)                          :- node(Package).
+attr("hash", Package, Hash)                    :- hash(Package, Hash).
 attr("version", Package, Version)              :- version(Package, Version).
 attr("version_satisfies", Package, Constraint) :- version_satisfies(Package, Constraint).
 attr("node_platform", Package, Platform)       :- node_platform(Package, Platform).
@@ -277,6 +290,7 @@ attr("variant_value", Package, Variant, Value) :- variant_value(Package, Variant
 attr("variant_set", Package, Variant, Value)   :- variant_set(Package, Variant, Value).
 attr("node_flag", Package, FlagType, Flag)     :- node_flag(Package, FlagType, Flag).
 attr("node_compiler", Package, Compiler)       :- node_compiler(Package, Compiler).
+attr("depends_on", Package, Dependency, Type)  :- depends_on(Package, Dependency, Type).
 attr("node_compiler_version", Package, Compiler, Version)
   :- node_compiler_version(Package, Compiler, Version).
 attr("node_compiler_version_satisfies", Package, Compiler, Version)
@@ -732,6 +746,21 @@ no_flags(Package, FlagType)
 #defined node_flag/3.
 #defined node_flag_set/3.
 
+
+%-----------------------------------------------------------------------------
+% Installed packages
+%-----------------------------------------------------------------------------
+% the solver is free to choose at most one installed hash for each package
+{ hash(Package, Hash) : installed_hash(Package, Hash) } 1 :- node(Package).
+
+% if a hash is selected, we impose all the constraints that implies
+impose(Hash) :- hash(Package, Hash).
+
+% if we haven't selected a hash for a package, we'll be building it
+build(Package) :- not hash(Package, _), node(Package).
+
+#defined installed_hash/2.
+
 %-----------------------------------------------------------------------------
 % How to optimize the spec (high to low priority)
 %-----------------------------------------------------------------------------
@@ -740,12 +769,17 @@ no_flags(Package, FlagType)
 %   2. a `#minimize{ 0@2 : #true }.` statement that ensures the criterion
 %      is displayed (clingo doesn't display sums over empty sets by default)
 
+% Try hard to reuse installed packages (i.e., minimize the number built)
+opt_criterion(17, "number of packages to build (vs. reuse)").
+#minimize { 0@17 : #true }.
+#minimize { 1@17,Package : build(Package) }.
+
 % Minimize the number of deprecated versions being used
 opt_criterion(16, "deprecated versions used").
 #minimize{ 0@16 : #true }.
 #minimize{ 1@16,Package : deprecated(Package, _)}.
 
-% The highest priority is to minimize the:
+% Minimize the:
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root(Package)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -781,6 +781,19 @@ impose(Hash) :- hash(Package, Hash).
 % if we haven't selected a hash for a package, we'll be building it
 build(Package) :- not hash(Package, _), node(Package).
 
+% Minimizing builds is tricky. We want a minimizing criterion
+
+% because we want to reuse what is avaialble, but
+% we also want things that are built to stick to *default preferences* from
+% the package and from the user. We therefore treat built specs differently and apply
+% a different set of optimization criteria to them. Spack's *first* priority is to
+% reuse what it *can*, but if it builds something, the built specs will respect
+% defaults and preferences.  This is implemented by bumping the priority of optimization
+% criteria for built specs -- so that they take precedence over the otherwise
+% topmost-priority criterion to reuse what is installed.
+build_priority(Package, 100) :- build(Package), node(Package).
+build_priority(Package, 0)   :- not build(Package), node(Package).
+
 #defined installed_hash/2.
 
 %-----------------------------------------------------------------------------
@@ -792,111 +805,182 @@ build(Package) :- not hash(Package, _), node(Package).
 %      is displayed (clingo doesn't display sums over empty sets by default)
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
-opt_criterion(16, "number of packages to build (vs. reuse)").
-#minimize { 0@16: #true }.
-#minimize { 1@16,Package : build(Package), optimize_for_reuse() }.
+opt_criterion(17, "number of packages to build (vs. reuse)").
+#minimize { 0@17: #true }.
+#minimize { 1@17,Package : build(Package), optimize_for_reuse() }.
 #defined optimize_for_reuse/0.
 
 % Minimize the number of deprecated versions being used
-opt_criterion(15, "deprecated versions used").
-#minimize{ 0@15: #true }.
-#minimize{ 1@15,Package : deprecated(Package, _)}.
+opt_criterion(116, "(build) deprecated versions used").
+opt_criterion(16, "deprecated versions used").
+#minimize{ 0@116: #true }.
+#minimize{ 0@16: #true }.
+#minimize{
+    1@16+Priority,Package
+    : deprecated(Package, _),
+      build_priority(Package, Priority)
+}.
 
 % Minimize the:
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root(Package)
-opt_criterion(14, "version weight").
-#minimize{ 0@14: #true }.
-#minimize { Weight@14: root(Package),version_weight(Package, Weight) }.
-
-opt_criterion(13, "number of non-default variants (roots)").
-#minimize{ 0@13: #true }.
+opt_criterion(115, "(build) version weight").
+opt_criterion(15, "version weight").
+#minimize{ 0@115: #true }.
+#minimize{ 0@15: #true }.
 #minimize {
-    Weight@13,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, Weight), root(Package)
+    Weight@15+Priority
+    : root(Package),version_weight(Package, Weight),
+      build_priority(Package, Priority)
 }.
 
+opt_criterion(114, "(build) number of non-default variants (roots)").
+opt_criterion(14, "number of non-default variants (roots)").
+#minimize{ 0@114: #true }.
+#minimize{ 0@14: #true }.
+#minimize {
+    Weight@14+Priority,Package,Variant,Value
+    : variant_not_default(Package, Variant, Value, Weight),
+      root(Package),
+      build_priority(Package, Priority)
+}.
+
+opt_criterion(112, "(build) preferred providers for roots").
 opt_criterion(12, "preferred providers for roots").
+#minimize{ 0@112 : #true }.
 #minimize{ 0@12: #true }.
 #minimize{
-    Weight@12,Provider,Virtual
-    : provider_weight(Provider, Virtual, Weight), root(Provider)
+    Weight@12+Priority,Provider,Virtual
+    : provider_weight(Provider, Virtual, Weight),
+      root(Provider),
+      build_priority(Provider, Priority)
 }.
 
 % If the value is a multivalued variant there could be multiple
 % values set as default. Since a default value has a weight of 0 we
 % need to maximize their number below to ensure they're all set
+opt_criterion(111, "(build) number of values in multi-valued variants (root)").
 opt_criterion(11, "number of values in multi-valued variants (root)").
-#minimize{ 0@11: #true }.
+#minimize{ 0@111 : #true }.
+#minimize{ 0@11 : #true }.
 #maximize {
-    1@11,Package,Variant,Value
+    1@11+Priority,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight),
-    not variant_single_value(Package, Variant),
-    root(Package)
+      not variant_single_value(Package, Variant),
+      root(Package),
+      build_priority(Package, Priority)
 }.
 
 % Try to use default variants or variants that have been set
+opt_criterion(110, "(build) number of non-default variants (non-roots)").
 opt_criterion(10, "number of non-default variants (non-roots)").
 #minimize{ 0@10: #true }.
 #minimize {
-    Weight@10,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, Weight), not root(Package)
+    Weight@10+Priority,Package,Variant,Value
+    : variant_not_default(Package, Variant, Value, Weight),
+      not root(Package),
+      build_priority(Package, Priority)
 }.
 
 % Minimize the weights of the providers, i.e. use as much as
 % possible the most preferred providers
+opt_criterion(109, "(build) preferred providers (non-roots)").
 opt_criterion(9, "preferred providers (non-roots)").
+#minimize{ 0@109: #true }.
 #minimize{ 0@9: #true }.
 #minimize{
-    Weight@9,Provider,Virtual
-    : provider_weight(Provider, Virtual, Weight), not root(Provider)
+    Weight@9+Priority,Provider,Virtual
+    : provider_weight(Provider, Virtual, Weight), not root(Provider),
+      build_priority(Provider, Priority)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.
+opt_criterion(108, "(build) compiler mismatches").
 opt_criterion(8, "compiler mismatches").
+#minimize{ 0@108: #true }.
 #minimize{ 0@8: #true }.
-#minimize{ 1@8,Package,Dependency : compiler_mismatch(Package, Dependency) }.
+#minimize{
+    1@8+Priority,Package,Dependency
+    : compiler_mismatch(Package, Dependency),
+      build_priority(Package, Priority)
+}.
 
 % Try to minimize the number of compiler mismatches in the DAG.
+opt_criterion(107, "(build) OS mismatches").
 opt_criterion(7, "OS mismatches").
+#minimize{ 0@107: #true }.
 #minimize{ 0@7: #true }.
-#minimize{ 1@7,Package,Dependency : node_os_mismatch(Package, Dependency) }.
+#minimize{
+    1@7+Priority,Package,Dependency
+    : node_os_mismatch(Package, Dependency),
+      build_priority(Package, Priority)
+}.
 
-opt_criterion(6, "non-preferred OSes").
+opt_criterion(106, "(build) non-preferred OSes").
+#minimize{ 0@106: #true }.
 #minimize{ 0@6: #true }.
-#minimize{ Weight@6,Package : node_os_weight(Package, Weight) }.
+#minimize{
+    Weight@6+Priority,Package
+    : node_os_weight(Package, Weight),
+      build_priority(Package, Priority)
+}.
 
 % Choose more recent versions for nodes
+opt_criterion(105, "(build) version badness").
 opt_criterion(5, "version badness").
+#minimize{ 0@105: #true }.
 #minimize{ 0@5: #true }.
 #minimize{
-    Weight@5,Package : version_weight(Package, Weight)
+    Weight@5+Priority,Package
+    : version_weight(Package, Weight),
+      build_priority(Package, Priority)
 }.
 
 % If the value is a multivalued variant there could be multiple
 % values set as default. Since a default value has a weight of 0 we
 % need to maximize their number below to ensure they're all set
+opt_criterion(104, "(build) number of values in multi valued variants (non-root)").
 opt_criterion(4, "number of values in multi valued variants (non-root)").
-#minimize{ 0@4: #true }.
+#minimize{ 0@104 : #true }.
+#minimize{ 0@4 : #true }.
 #maximize {
-    1@4,Package,Variant,Value
+    1@4+Priority,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, _),
-    not variant_single_value(Package, Variant),
-    not root(Package)
+      not variant_single_value(Package, Variant),
+      not root(Package),
+      build_priority(Package, Priority)
 }.
 
 % Try to use preferred compilers
+opt_criterion(103, "(build) non-preferred compilers").
 opt_criterion(3, "non-preferred compilers").
+#minimize{ 0@103: #true }.
 #minimize{ 0@3: #true }.
-#minimize{ Weight@3,Package : compiler_weight(Package, Weight) }.
+#minimize{
+    Weight@3+Priority,Package
+    : compiler_weight(Package, Weight),
+      build_priority(Package, Priority)
+}.
 
 % Minimize the number of mismatches for targets in the DAG, try
 % to select the preferred target.
+opt_criterion(102, "(build) target mismatches").
 opt_criterion(2, "target mismatches").
+#minimize{ 0@102: #true }.
 #minimize{ 0@2: #true }.
-#minimize{ 1@2,Package,Dependency : node_target_mismatch(Package, Dependency) }.
+#minimize{
+    1@2+Priority,Package,Dependency
+    : node_target_mismatch(Package, Dependency),
+      build_priority(Package, Priority)
+}.
 
+opt_criterion(101, "(build) non-preferred targets").
 opt_criterion(1, "non-preferred targets").
+#minimize{ 0@101: #true }.
 #minimize{ 0@1: #true }.
-#minimize{ Weight@1,Package : node_target_weight(Package, Weight) }.
+#minimize{
+    Weight@1+Priority,Package
+    : node_target_weight(Package, Weight),
+      build_priority(Package, Priority)
+}.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -107,8 +107,7 @@ dependency_holds(Package, Dependency, Type) :-
   dependency_condition(ID, Package, Dependency),
   dependency_type(ID, Type),
   condition_holds(ID),
-  not external(Package),
-  not concrete(Package).
+  build(Package).
 
 % We cut off dependencies of externals (as we don't really know them).
 % Don't impose constraints on dependencies that don't exist.
@@ -153,10 +152,10 @@ path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
 % Conflicts
 %-----------------------------------------------------------------------------
 :- node(Package),
-   not external(Package),
    conflict(Package, TriggerID, ConstraintID),
    condition_holds(TriggerID),
    condition_holds(ConstraintID),
+   not external(Package),  % ignore conflicts for externals
    error("A conflict was triggered").
 
 #defined conflict/3.
@@ -402,7 +401,11 @@ variant(Package, Variant) :- variant_condition(ID, Package, Variant),
 variant_set(Package, Variant) :- variant_set(Package, Variant, _).
 
 % A variant cannot have a value that is not also a possible value
-:- variant_value(Package, Variant, Value), not variant_possible_value(Package, Variant, Value),
+% This only applies to packages we need to build -- concrete packages may
+% have been built w/different variants from older/different package versions.
+:- variant_value(Package, Variant, Value),
+   not variant_possible_value(Package, Variant, Value),
+   build(Package),
    error("Variant set to invalid value").
 
 % Some multi valued variants accept multiple values from disjoint sets.
@@ -477,8 +480,11 @@ variant_default_value(Package, Variant, Value) :- variant_default_value_from_cli
 
 % Treat 'none' in a special way - it cannot be combined with other
 % values even if the variant is multi-valued
-:- 2 {variant_value(Package, Variant, Value): variant_possible_value(Package, Variant, Value)},
+:- 2 {
+     variant_value(Package, Variant, Value) : variant_possible_value(Package, Variant, Value)
+   },
    variant_value(Package, Variant, "none"),
+   build(Package),
    error("Variant value 'none' cannot be combined with any other value").
 
 % patches and dev_path are special variants -- they don't have to be
@@ -603,6 +609,7 @@ target_weight(Target, Package, Weight)
    not compiler_supports_target(Compiler, Version, Target),
    node_compiler(Package, Compiler),
    node_compiler_version(Package, Compiler, Version),
+   build(Package),
    error("No satisfying compiler available is compatible with a satisfying target").
 
 % if a target is set explicitly, respect it
@@ -673,6 +680,7 @@ node_compiler_version(Package, Compiler, Version) :- node_compiler_version_set(P
 :- node_compiler_version(Package, Compiler, Version), node_os(Package, OS),
    not compiler_supports_os(Compiler, Version, OS),
    not allow_compiler(Compiler, Version),
+   build(Package),
    error("No satisfying compiler available is compatible with a satisfying os").
 
 % If a package and one of its dependencies don't have the
@@ -891,4 +899,3 @@ opt_criterion(2, "target mismatches").
 opt_criterion(1, "non-preferred targets").
 #minimize{ 0@1: #true }.
 #minimize{ Weight@1,Package : node_target_weight(Package, Weight) }.
-

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -107,7 +107,8 @@ dependency_holds(Package, Dependency, Type) :-
   dependency_condition(ID, Package, Dependency),
   dependency_type(ID, Type),
   condition_holds(ID),
-  build(Package).
+  build(Package),
+  not external(Package).
 
 % We cut off dependencies of externals (as we don't really know them).
 % Don't impose constraints on dependencies that don't exist.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -794,7 +794,8 @@ build(Package) :- not hash(Package, _), node(Package).
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(16, "number of packages to build (vs. reuse)").
 #minimize { 0@16: #true }.
-#minimize { 1@16,Package : build(Package) }.
+#minimize { 1@16,Package : build(Package), optimize_for_reuse() }.
+#defined optimize_for_reuse/0.
 
 % Minimize the number of deprecated versions being used
 opt_criterion(15, "deprecated versions used").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -790,7 +790,8 @@ no_flags(Package, FlagType)
 % Installed packages
 %-----------------------------------------------------------------------------
 % the solver is free to choose at most one installed hash for each package
-{ hash(Package, Hash) : installed_hash(Package, Hash) } 1 :- node(Package).
+{ hash(Package, Hash) : installed_hash(Package, Hash) } 1
+ :- node(Package), error("Internal error: package must resolve to at most one hash").
 
 % if a hash is selected, we impose all the constraints that implies
 impose(Hash) :- hash(Package, Hash).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -429,9 +429,11 @@ variant_value(Package, Variant, Value)
 % whenever possible. If a variant is set in a spec, or if it is
 % specified in an external, we score it as if it was a default value.
 variant_not_default(Package, Variant, Value, 1)
- :- variant_value(Package, Variant, Value),
-    not variant_default_value(Package, Variant, Value),
-    not variant_set(Package, Variant, Value),
+ :- variant_value(Package, Variant, Actual),
+    not variant_value(Package, Variant, Value),
+    variant_default_value(Package, Variant, Value),
+    Actual != Value,
+    not variant_set(Package, Variant, Actual),
     not external_with_variant_set(Package, Variant, Value),
     node(Package).
 
@@ -934,21 +936,6 @@ opt_criterion(5, "version badness").
 #minimize{
     Weight@5+Priority,Package
     : version_weight(Package, Weight),
-      build_priority(Package, Priority)
-}.
-
-% If the value is a multivalued variant there could be multiple
-% values set as default. Since a default value has a weight of 0 we
-% need to maximize their number below to ensure they're all set
-opt_criterion(104, "(build) number of values in multi valued variants (non-root)").
-opt_criterion(4, "number of values in multi valued variants (non-root)").
-#minimize{ 0@104 : #true }.
-#minimize{ 0@4 : #true }.
-#maximize {
-    1@4+Priority,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, _),
-      not variant_single_value(Package, Variant),
-      not root(Package),
       build_priority(Package, Priority)
 }.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -434,20 +434,12 @@ variant_not_default(Package, Variant, Actual, 1)
     not variant_value(Package, Variant, Value),
     variant_default_value(Package, Variant, Value),
     Actual != Value,
+    % variants set explicitly on the CLI don't count as non-default
     not variant_set(Package, Variant, Actual),
-    not external_with_variant_set(Package, Variant, Value),
-    node(Package).
-
-% We are using the default value for a variant
-variant_not_default(Package, Variant, Value, 0)
- :- variant_value(Package, Variant, Value),
-    variant_default_value(Package, Variant, Value),
-    node(Package).
-
-% The variant is set in the spec
-variant_not_default(Package, Variant, Value, 0)
- :- variant_value(Package, Variant, Value),
-    variant_set(Package, Variant, Value),
+    % variants set on externals that we could use don't count as non-default
+    % this makes spack prefer to use an external over rebuilding with the
+    % default configuration
+    not external_with_variant_set(Package, Variant, Actual),
     node(Package).
 
 % The variant is set in an external spec
@@ -456,11 +448,6 @@ external_with_variant_set(Package, Variant, Value)
     condition_requirement(ID, "variant_value", Package, Variant, Value),
     possible_external(ID, Package, _),
     external(Package),
-    node(Package).
-
-variant_not_default(Package, Variant, Value, 0)
- :- variant_value(Package, Variant, Value),
-    external_with_variant_set(Package, Variant, Value),
     node(Package).
 
 % The default value for a variant in a package is what is prescribed:
@@ -862,20 +849,6 @@ opt_criterion(11, "preferred providers for roots").
     : provider_weight(Provider, Virtual, Weight),
       root(Provider),
       build_priority(Provider, Priority)
-}.
-
-% If the value is a multivalued variant there could be multiple
-% values set as default. Since a default value has a weight of 0 we
-% need to maximize their number below to ensure they're all set
-opt_criterion(10, "number of values in multi-valued variants (root)").
-#minimize{ 0@210 : #true }.
-#minimize{ 0@10 : #true }.
-#maximize {
-    1@10+Priority,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value, Weight),
-      not variant_single_value(Package, Variant),
-      root(Package),
-      build_priority(Package, Priority)
 }.
 
 % Try to use default variants or variants that have been set

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -572,6 +572,9 @@ os_compatible(OS, OS) :- os(OS).
 % catalina binaries can be used on bigsur. Direction is package -> dependency.
 os_compatible("bigsur", "catalina").
 
+% If an OS is set explicitly respect the value
+node_os(Package, OS) :- node_os_set(Package, OS), node(Package).
+
 #defined node_os_set/2.
 #defined os_compatible/2.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -372,10 +372,13 @@ variant(Package, Variant) :- variant_condition(ID, Package, Variant),
 % a variant cannot be set if it is not a variant on the package
 :- variant_set(Package, Variant),
    not variant(Package, Variant),
+   build(Package),
    error("Unsatisfied conditional variants cannot be set").
 
 % a variant cannot take on a value if it is not a variant of the package
-:- variant_value(Package, Variant, _), not variant(Package, Variant),
+:- variant_value(Package, Variant, _),
+   not variant(Package, Variant),
+   build(Package),
    error("Unsatisfied conditional variants cannot take on a variant value").
 
 % one variant value for single-valued variants.
@@ -386,6 +389,7 @@ variant(Package, Variant) :- variant_condition(ID, Package, Variant),
  :- node(Package),
     variant(Package, Variant),
     variant_single_value(Package, Variant),
+    build(Package),
     error("Single valued variants must have a single value").
 
 % at least one variant value for multi-valued variants.
@@ -396,6 +400,7 @@ variant(Package, Variant) :- variant_condition(ID, Package, Variant),
  :- node(Package),
     variant(Package, Variant),
     not variant_single_value(Package, Variant),
+    build(Package),
     error("Internal error: All variants must have a value").
 
 % if a variant is set to anything, it is considered 'set'.
@@ -417,6 +422,7 @@ variant_set(Package, Variant) :- variant_set(Package, Variant, _).
    variant_value_from_disjoint_sets(Package, Variant, Value1, Set1),
    variant_value_from_disjoint_sets(Package, Variant, Value2, Set2),
    Set1 != Set2,
+   build(Package),
    error("Variant values selected from multiple disjoint sets").
 
 % variant_set is an explicitly set variant value. If it's not 'set',
@@ -640,10 +646,12 @@ node_target_mismatch(Parent, Dependency)
 %-----------------------------------------------------------------------------
 compiler(Compiler) :- compiler_version(Compiler, _).
 
-% There must be only one compiler set per node. The compiler
+% There must be only one compiler set per built node. The compiler
 % is chosen among available versions.
-1 { node_compiler_version(Package, Compiler, Version)
-    : compiler_version(Compiler, Version) } 1 :- node(Package), error("Each node must have exactly one compiler").
+1 { node_compiler_version(Package, Compiler, Version) : compiler_version(Compiler, Version) } 1 :-
+    node(Package),
+    build(Package),
+    error("Each node must have exactly one compiler").
 
 % Sometimes we just need to know the compiler and not the version
 node_compiler(Package, Compiler) :- node_compiler_version(Package, Compiler, _).
@@ -658,11 +666,14 @@ node_compiler(Package, Compiler) :- node_compiler_version(Package, Compiler, _).
 % version_satisfies implies that exactly one of the satisfying versions
 % is the package's version, and vice versa.
 1 { node_compiler_version(Package, Compiler, Version)
-    : node_compiler_version_satisfies(Package, Compiler, Constraint, Version) } 1
-  :- node_compiler_version_satisfies(Package, Compiler, Constraint), error("Internal error: node compiler version mismatch").
+    : node_compiler_version_satisfies(Package, Compiler, Constraint, Version) } 1 :-
+    node_compiler_version_satisfies(Package, Compiler, Constraint),
+    error("Internal error: node compiler version mismatch").
+
 node_compiler_version_satisfies(Package, Compiler, Constraint)
   :- node_compiler_version(Package, Compiler, Version),
-     node_compiler_version_satisfies(Package, Compiler, Constraint, Version).
+     node_compiler_version_satisfies(Package, Compiler, Constraint, Version),
+     build(Package).
 
 #defined node_compiler_version_satisfies/4.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -529,29 +529,43 @@ node_platform_set(Package) :- node_platform_set(Package, _).
 %-----------------------------------------------------------------------------
 % OS semantics
 %-----------------------------------------------------------------------------
+% convert weighted OS declarations to simple one
+os(OS) :- os(OS, _).
+
 % one os per node
 1 { node_os(Package, OS) : os(OS) } 1 :- node(Package), error("Each node must have exactly one OS").
 
-% node_os_set implies that the node must have that os
-node_os(Package, OS) :- node(Package), node_os_set(Package, OS).
-node_os_set(Package) :- node_os_set(Package, _).
+% can't have a non-buildable OS on a node we need to build
+:- build(Package), node_os(Package, OS), not buildable_os(OS).
 
-% inherit OS along dependencies
-node_os_inherit(Package, OS) :- node_os_set(Package, OS).
-node_os_inherit(Dependency, OS)
-  :- node_os_inherit(Package, OS), depends_on(Package, Dependency),
-     not node_os_set(Dependency).
-node_os_inherit(Package) :- node_os_inherit(Package, _).
+% can't have dependencies on incompatible OS's
+:- depends_on(Package, Dependency),
+   node_os(Package, PackageOS),
+   node_os(Dependency, DependencyOS),
+   not os_compatible(PackageOS, DependencyOS),
+   build(Package).
 
-node_os(Package, OS) :- node_os_inherit(Package, OS).
+% give OS choice weights according to os declarations
+node_os_weight(Package, Weight)
+ :- node(Package),
+    node_os(Package, OS),
+    os(OS, Weight).
 
-% fall back to default if not set or inherited
-node_os(Package, OS)
-  :- node(Package),
-     not node_os_set(Package), not node_os_inherit(Package),
-     node_os_default(OS).
+% match semantics for OS's
+node_os_match(Package, Dependency) :-
+   depends_on(Package, Dependency), node_os(Package, OS), node_os(Dependency, OS).
+node_os_mismatch(Package, Dependency) :-
+   depends_on(Package, Dependency), not node_os_match(Package, Dependency).
+
+% every OS is compatible with itself. We can use `os_compatible` to declare
+os_compatible(OS, OS) :- os(OS).
+
+% OS compatibility rules for reusing solves.
+% catalina binaries can be used on bigsur. Direction is package -> dependency.
+os_compatible("bigsur", "catalina").
 
 #defined node_os_set/2.
+#defined os_compatible/2.
 
 %-----------------------------------------------------------------------------
 % Target semantics
@@ -770,61 +784,61 @@ build(Package) :- not hash(Package, _), node(Package).
 %      is displayed (clingo doesn't display sums over empty sets by default)
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
-opt_criterion(17, "number of packages to build (vs. reuse)").
-#minimize { 0@17 : #true }.
-#minimize { 1@17,Package : build(Package) }.
+opt_criterion(16, "number of packages to build (vs. reuse)").
+#minimize { 0@16: #true }.
+#minimize { 1@16,Package : build(Package) }.
 
 % Minimize the number of deprecated versions being used
-opt_criterion(16, "deprecated versions used").
-#minimize{ 0@16 : #true }.
-#minimize{ 1@16,Package : deprecated(Package, _)}.
+opt_criterion(15, "deprecated versions used").
+#minimize{ 0@15: #true }.
+#minimize{ 1@15,Package : deprecated(Package, _)}.
 
 % Minimize the:
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
 % for the root(Package)
-opt_criterion(15, "version weight").
-#minimize{ 0@15 : #true }.
-#minimize { Weight@15 : root(Package),version_weight(Package, Weight) }.
+opt_criterion(14, "version weight").
+#minimize{ 0@14: #true }.
+#minimize { Weight@14: root(Package),version_weight(Package, Weight) }.
 
-opt_criterion(14, "number of non-default variants (roots)").
-#minimize{ 0@14 : #true }.
+opt_criterion(13, "number of non-default variants (roots)").
+#minimize{ 0@13: #true }.
 #minimize {
-    Weight@14,Package,Variant,Value
+    Weight@13,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight), root(Package)
 }.
 
-opt_criterion(13, "preferred providers for roots").
-#minimize{ 0@13 : #true }.
+opt_criterion(12, "preferred providers for roots").
+#minimize{ 0@12: #true }.
 #minimize{
-    Weight@13,Provider,Virtual
+    Weight@12,Provider,Virtual
     : provider_weight(Provider, Virtual, Weight), root(Provider)
 }.
 
 % If the value is a multivalued variant there could be multiple
 % values set as default. Since a default value has a weight of 0 we
 % need to maximize their number below to ensure they're all set
-opt_criterion(12, "number of values in multi valued variants (root)").
-#minimize{ 0@12 : #true }.
+opt_criterion(11, "number of values in multi-valued variants (root)").
+#minimize{ 0@11: #true }.
 #maximize {
-    1@12,Package,Variant,Value
+    1@11,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight),
     not variant_single_value(Package, Variant),
     root(Package)
 }.
 
 % Try to use default variants or variants that have been set
-opt_criterion(11, "number of non-default variants (non-roots)").
-#minimize{ 0@11 : #true }.
+opt_criterion(10, "number of non-default variants (non-roots)").
+#minimize{ 0@10: #true }.
 #minimize {
-    Weight@11,Package,Variant,Value
+    Weight@10,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, Weight), not root(Package)
 }.
 
 % Minimize the weights of the providers, i.e. use as much as
 % possible the most preferred providers
 opt_criterion(9, "preferred providers (non-roots)").
-#minimize{ 0@9 : #true }.
+#minimize{ 0@9: #true }.
 #minimize{
     Weight@9,Provider,Virtual
     : provider_weight(Provider, Virtual, Weight), not root(Provider)
@@ -832,39 +846,49 @@ opt_criterion(9, "preferred providers (non-roots)").
 
 % Try to minimize the number of compiler mismatches in the DAG.
 opt_criterion(8, "compiler mismatches").
-#minimize{ 0@8 : #true }.
+#minimize{ 0@8: #true }.
 #minimize{ 1@8,Package,Dependency : compiler_mismatch(Package, Dependency) }.
 
+% Try to minimize the number of compiler mismatches in the DAG.
+opt_criterion(7, "OS mismatches").
+#minimize{ 0@7: #true }.
+#minimize{ 1@7,Package,Dependency : node_os_mismatch(Package, Dependency) }.
+
+opt_criterion(6, "non-preferred OSes").
+#minimize{ 0@6: #true }.
+#minimize{ Weight@6,Package : node_os_weight(Package, Weight) }.
+
 % Choose more recent versions for nodes
-opt_criterion(7, "version badness").
-#minimize{ 0@7 : #true }.
+opt_criterion(5, "version badness").
+#minimize{ 0@5: #true }.
 #minimize{
-    Weight@7,Package : version_weight(Package, Weight)
+    Weight@5,Package : version_weight(Package, Weight)
 }.
 
 % If the value is a multivalued variant there could be multiple
 % values set as default. Since a default value has a weight of 0 we
 % need to maximize their number below to ensure they're all set
-opt_criterion(6, "number of values in multi valued variants (non-root)").
-#minimize{ 0@6 : #true }.
+opt_criterion(4, "number of values in multi valued variants (non-root)").
+#minimize{ 0@4: #true }.
 #maximize {
-    1@6,Package,Variant,Value
+    1@4,Package,Variant,Value
     : variant_not_default(Package, Variant, Value, _),
     not variant_single_value(Package, Variant),
     not root(Package)
 }.
 
 % Try to use preferred compilers
-opt_criterion(5, "non-preferred compilers").
-#minimize{ 0@5 : #true }.
-#minimize{ Weight@5,Package : compiler_weight(Package, Weight) }.
+opt_criterion(3, "non-preferred compilers").
+#minimize{ 0@3: #true }.
+#minimize{ Weight@3,Package : compiler_weight(Package, Weight) }.
 
 % Minimize the number of mismatches for targets in the DAG, try
 % to select the preferred target.
-opt_criterion(4, "target mismatches").
-#minimize{ 0@4 : #true }.
-#minimize{ 1@4,Package,Dependency : node_target_mismatch(Package, Dependency) }.
+opt_criterion(2, "target mismatches").
+#minimize{ 0@2: #true }.
+#minimize{ 1@2,Package,Dependency : node_target_mismatch(Package, Dependency) }.
 
-opt_criterion(3, "non-preferred targets").
-#minimize{ 0@3 : #true }.
-#minimize{ Weight@3,Package : node_target_weight(Package, Weight) }.
+opt_criterion(1, "non-preferred targets").
+#minimize{ 0@1: #true }.
+#minimize{ Weight@1,Package : node_target_weight(Package, Weight) }.
+

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -428,7 +428,7 @@ variant_value(Package, Variant, Value)
 % The rules below allow us to prefer default values for variants
 % whenever possible. If a variant is set in a spec, or if it is
 % specified in an external, we score it as if it was a default value.
-variant_not_default(Package, Variant, Value, 1)
+variant_not_default(Package, Variant, Actual, 1)
  :- variant_value(Package, Variant, Actual),
     not variant_value(Package, Variant, Value),
     variant_default_value(Package, Variant, Value),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -629,6 +629,8 @@ node_target_mismatch(Parent, Dependency)
   :- depends_on(Parent, Dependency),
      not node_target_match(Parent, Dependency).
 
+:- node(Package), node_target(Package, Target), not target(Target).
+
 #defined node_target_set/2.
 #defined package_target_weight/3.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -541,17 +541,20 @@ node_platform_set(Package) :- node_platform_set(Package, _).
 os(OS) :- os(OS, _).
 
 % one os per node
-1 { node_os(Package, OS) : os(OS) } 1 :- node(Package), error("Each node must have exactly one OS").
+1 { node_os(Package, OS) : os(OS) } 1 :-
+   node(Package), error("Each node must have exactly one OS").
 
 % can't have a non-buildable OS on a node we need to build
-:- build(Package), node_os(Package, OS), not buildable_os(OS).
+:- build(Package), node_os(Package, OS), not buildable_os(OS),
+   error("No available OS can be built for").
 
 % can't have dependencies on incompatible OS's
 :- depends_on(Package, Dependency),
    node_os(Package, PackageOS),
    node_os(Dependency, DependencyOS),
    not os_compatible(PackageOS, DependencyOS),
-   build(Package).
+   build(Package),
+   error("Dependencies must have compatible OS's with their dependents").
 
 % give OS choice weights according to os declarations
 node_os_weight(Package, Weight)
@@ -641,7 +644,9 @@ node_target_mismatch(Parent, Dependency)
   :- depends_on(Parent, Dependency),
      not node_target_match(Parent, Dependency).
 
-:- node(Package), node_target(Package, Target), not target(Target).
+% disallow reusing concrete specs that don't have a compatible target
+:- node(Package), node_target(Package, Target), not target(Target),
+   error("No satisfying package's target is compatible with this machine").
 
 #defined node_target_set/2.
 #defined package_target_weight/3.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -492,6 +492,7 @@ variant_single_value(Package, "dev_path")
 % warnings like 'info: atom does not occur in any rule head'.
 #defined variant/2.
 #defined variant_set/3.
+#defined variant_condition/3.
 #defined variant_single_value/2.
 #defined variant_default_value/3.
 #defined variant_possible_value/3.

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -12,6 +12,7 @@
 % Spec-related functions.
 % Used to build the result of the solve.
 #show node/1.
+#show hash/2.
 #show depends_on/3.
 #show version/2.
 #show variant_value/3.
@@ -25,6 +26,8 @@
 #show node_flag_source/2.
 #show no_flags/2.
 #show external_spec_selected/2.
+
+#show build/1.
 
 % names of optimization criteria
 #show opt_criterion/2.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -3052,6 +3052,10 @@ class Spec(object):
         Raises:
             spack.variant.UnknownVariantError: on the first unknown variant found
         """
+        # concrete variants are always valid
+        if spec.concrete:
+            return
+
         pkg_cls = spec.package_class
         pkg_variants = pkg_cls.variants
         # reserved names are variants that may be set on any package

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2666,7 +2666,7 @@ class Spec(object):
                 s.clear_cached_hashes()
             s._mark_root_concrete(value)
 
-    def concretized(self, tests=False):
+    def concretized(self, tests=False, reuse=False):
         """This is a non-destructive version of concretize().
 
         First clones, then returns a concrete version of this package
@@ -2676,9 +2676,11 @@ class Spec(object):
             tests (bool or list): if False disregard 'test' dependencies,
                 if a list of names activate them for the packages in the list,
                 if True activate 'test' dependencies for all packages.
+            reuse (bool): if True try to maximize reuse of already installed
+                specs, if False don't account for installation status.
         """
         clone = self.copy(caches=True)
-        clone.concretize(tests=tests)
+        clone.concretize(tests=tests, reuse=reuse)
         return clone
 
     def flat_dependencies(self, **kwargs):

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -29,10 +29,18 @@ def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):
 
     # Calculate the comparison (c)
     c = spack.cmd.diff.compare_specs(specA, specB, to_string=True)
-    assert len(c['a_not_b']) == 1
-    assert len(c['b_not_a']) == 1
-    assert c['a_not_b'][0] == ['variant_value', 'mpileaks debug False']
-    assert c['b_not_a'][0] == ['variant_value', 'mpileaks debug True']
+
+    # these particular diffs should have the same length b/c thre aren't
+    # any node differences -- just value differences.
+    assert len(c['a_not_b']) == len(c['b_not_a'])
+
+    # ensure that variant diffs are in here the result
+    assert ['variant_value', 'mpileaks debug False'] in c['a_not_b']
+    assert ['variant_value', 'mpileaks debug True'] in c['b_not_a']
+
+    # ensure that hash diffs are in here the result
+    assert ['hash', 'mpileaks %s' % specA.dag_hash()] in c['a_not_b']
+    assert ['hash', 'mpileaks %s' % specB.dag_hash()] in c['b_not_a']
 
 
 def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -61,12 +61,30 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     output = diff_cmd('--json', 'mpileaks', 'mpileaks')
     result = sjson.load(output)
 
-    assert len(result['a_not_b']) == 0
-    assert len(result['b_not_a']) == 0
+    assert not result['a_not_b']
+    assert not result['b_not_a']
 
     assert 'mpileaks' in result['a_name']
     assert 'mpileaks' in result['b_name']
-    assert "intersect" in result and len(result['intersect']) > 50
+
+    # spot check attributes in the intersection to ensure they describe the spec
+    assert "intersect" in result
+    assert all(["node", dep] in result["intersect"] for dep in (
+        "mpileaks", "callpath", "dyninst", "libelf", "libdwarf", "mpich"
+    ))
+    assert all(
+        len([diff for diff in result["intersect"] if diff[0] == attr]) == 6
+        for attr in (
+            "version",
+            "node_target",
+            "node_platform",
+            "node_os",
+            "node_compiler",
+            "node_compiler_version",
+            "node",
+            "hash",
+        )
+    )
 
     # After we install another version, it should ask us to disambiguate
     install_cmd('mpileaks+debug')
@@ -87,7 +105,8 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
                       "mpileaks/{0}".format(no_debug_hash))
     result = sjson.load(output)
 
-    assert len(result['a_not_b']) == 1
-    assert len(result['b_not_a']) == 1
-    assert result['a_not_b'][0] == ['variant_value', 'mpileaks debug True']
-    assert result['b_not_a'][0] == ['variant_value', 'mpileaks debug False']
+    assert ['hash', 'mpileaks %s' % debug_hash] in result['a_not_b']
+    assert ['variant_value', 'mpileaks debug True'] in result['a_not_b']
+
+    assert ['hash', 'mpileaks %s' % no_debug_hash] in result['b_not_a']
+    assert ['variant_value', 'mpileaks debug False'] in result['b_not_a']

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -299,7 +299,7 @@ class TestConcretize(object):
 
         with spack.repo.use_repositories(mock_repo):
             spec = Spec('foopkg %gcc@4.5.0 os=CNL target=nocona' +
-                        ' ^barpkg os=SuSE11 ^bazpkg os=be')
+                        ' ^barpkg os=CNL ^bazpkg os=CNL')
             spec.concretize()
 
             for s in spec.traverse(root=False):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1635,7 +1635,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --models -l --long -L --very-long -I --install-status -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats --reuse"
+        SPACK_COMPREPLY="-h --help --show --models -l --long -L --very-long -I --install-status --reuse -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats"
     else
         _all_packages
     fi
@@ -1644,7 +1644,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -I --install-status -y --yaml -j --json -c --cover -N --namespaces --hash-type -t --types"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -I --install-status --reuse -y --yaml -j --json -c --cover -N --namespaces --hash-type -t --types"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -705,7 +705,7 @@ _spack_compilers() {
 }
 
 _spack_concretize() {
-    SPACK_COMPREPLY="-h --help -f --force --test"
+    SPACK_COMPREPLY="-h --help --reuse -f --force --test"
 }
 
 _spack_config() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1176,7 +1176,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-save-local --monitor-no-auth --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --reuse --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-save-local --monitor-no-auth --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
     else
         _all_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1635,7 +1635,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --models -l --long -L --very-long -I --install-status -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats"
+        SPACK_COMPREPLY="-h --help --show --models -l --long -L --very-long -I --install-status -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats --reuse"
     else
         _all_packages
     fi


### PR DESCRIPTION
Draft PR because it still needs some work, but it's in a state that @adamjstewart could start playing with.

Fixes #311.
Fixes #22613.
Fixes #20429.

This PR makes the concretizer aware of already-installed packages, and it tries to optimize the solve by reusing them instead of building when it can.

## `--reuse` option

Currently, this adds a `--reuse` option to `spack solve`.  You can try it out with `spack solve -Il --reuse <spec>`.  I think the interface is TBD; we probably want to think about what to call this vs. the old solve, and about which one should be default.

## Minimizing builds

The way this works is:

1. Figure out which installed packages are possible dependencies of the things to be installed.
2. Add information about installed hashes that are possible dependencies to the ASP program.  
    It looks kind of like this `openssl` example, but for everything that is installed:
    ```prolog
    installed_hash("openssl","lwatuuysmwkhuahrncywvn77icdhs6mn").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","node","openssl").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","version","openssl","1.1.1g").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","node_platform","openssl","darwin").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","node_os","openssl","catalina").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","node_target","openssl","x86_64").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","node_compiler","openssl","apple-clang").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","node_compiler_version","openssl","apple-clang","12.0.0").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","hash","openssl","lwatuuysmwkhuahrncywvn77icdhs6mn").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","depends_on","openssl","zlib","build").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","depends_on","openssl","zlib","link").
    imposed_constraint("lwatuuysmwkhuahrncywvn77icdhs6mn","hash","zlib","x2anksgssxsxa7pcnhzg5k3dhgacglze").
    ```
    You can see from the example that if we use this hash for `openssl`, it also forces a bunch of constraints and a dependency on its particular `zlib` installation on the solve.  i.e., it's concrete -- we *have* to use it the way it was built and we cannot twiddle things like variant values on things we already installed.
3. Try to minimize the number of packages that are built.  That looks like of like:
    ```prolog
    % the solver is free to choose at most one installed hash for each package in the solution
    { hash(Package, Hash) : installed_hash(Package, Hash) } 1 :- node(Package).

    % if a hash is selected, we impose all of its constraints
    impose(Hash) :- hash(Package, Hash).

    % if we haven't selected a hash for a package, and if it is not external, we build it
    build(Package) :- not hash(Package, _), not external(Package), node(Package).
    #minimize { 1@18,Package : build(Package) }.
    ```

## OS handling

The solver was still handling OS defaults through hard constraints (this is how we did it before we knew how to do it the right way -- with optimization), so this reworks OS handling in the solver.  I believe this is the last part of the spec that needed converting -- targets and compilers were already changed in past PRs.

We now optimize for OS matches in the Spec, but we allow you to depend on a package for an older OS, with some limits.  Specifically, I noticed when testing this that I wanted to reuse still-working Catalina installations on Big Sur.  This adds the ability to specify, e.g.: `os_compatible("catalina", "bigsur")` so that the solver knows that it can safely reuse certain packages. I think we can also leverage this for, e.g., reusing CentOS binaries on RHEL.

## Relaxing existing constraints

Many of the existing constraints in the solver are meant for *things we plan to build*.  When reusing concrete specs, We have to take the installed specs as they are.  We can't do things like disallow unknown variant names (the variants may not exist) or compiler version OS support (we only know about the compilers on the current system, not the ones the concrete specs were built with).  So, these types of constraints have been restricted to *only* apply to specs we intend to build.  If we reuse something concrete, we still have to consider things like dependency version constraints (e.g. if you want to reuse `openssl` you should still check if the version that's installed satisfies your `depends_on("openssl@:1.0")` constraint).

## Example

Here's a comparison of reusing vs. not reusing with `llvm`:

With reuse:

<details>
<summary>`spack solve -Il --reuse llvm` output</summary>

```console
(spackle):spack> spack solve -Il --reuse llvm
==> Best of 7 considered solutions.
==> Optimization Criteria:
  Priority  Criterion                                 Value
  1         number of packages to build (vs. reuse)       5
  2         deprecated versions used                      2
  3         version weight                                0
  4         number of non-default variants (roots)        1
  5         multi-valued variants                        -1
  6         preferred providers for roots                 0
  7         number of non-default variants (non-roots)    5
  8         preferred providers (non-roots)              10
  9         compiler mismatches                           0
  10        os mismatches                                 8
  11        version badness                              51
  12        count of non-root multi-valued variants      -5
  13        non-preferred compilers                       0
  14        target mismatches                             0
  15        non-preferred targets                       253

 -   ikfi254  llvm@12.0.1%apple-clang@12.0.0~all_targets+clang~code_signing+compiler-rt~cuda~flang~gold+internal_unwind~ipo+libcxx+lld~lldb~llvm_dylib~mlir~omp_debug~omp_tsan+polly~python~shared_libs~split_dwarf build_type=Release cuda_arch=none arch=darwin-bigsur-x86_64
 -   xtkcrrd      ^cmake@3.20.5%apple-clang@12.0.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=darwin-bigsur-x86_64
[+]  eli4aax          ^ncurses@6.2%apple-clang@12.0.0~symlinks+termlib arch=darwin-catalina-x86_64
[+]  lwatuuy          ^openssl@1.1.1g%apple-clang@12.0.0+systemcerts arch=darwin-catalina-x86_64
[+]  x2anksg              ^zlib@1.2.11%apple-clang@12.0.0+optimize+pic+shared arch=darwin-catalina-x86_64
 -   oc2m54j      ^hwloc@2.5.0%apple-clang@12.0.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml~pci+shared arch=darwin-bigsur-x86_64
[+]  dqzlvh6          ^libxml2@2.9.10%apple-clang@12.0.0~python arch=darwin-catalina-x86_64
[+]  xrjlxcv              ^libiconv@1.16%apple-clang@12.0.0 arch=darwin-catalina-x86_64
[+]  gfa5h76              ^xz@5.2.5%apple-clang@12.0.0~pic arch=darwin-catalina-x86_64
 -   ozoef2w          ^pkgconf@1.7.4%apple-clang@12.0.0 arch=darwin-bigsur-x86_64
 -   tzk3evu      ^perl-data-dumper@2.173%apple-clang@12.0.0 arch=darwin-bigsur-x86_64
[+]  jjgcc6o          ^perl@5.30.3%apple-clang@12.0.0+cpanm+shared+threads arch=darwin-catalina-x86_64
[+]  df3hxmr              ^gdbm@1.18.1%apple-clang@12.0.0 arch=darwin-catalina-x86_64
[+]  4d3hjqd                  ^readline@8.0%apple-clang@12.0.0 arch=darwin-catalina-x86_64
[+]  24lf5pr      ^python@3.7.8%apple-clang@12.0.0+bz2+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4~uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,210df3f28cde02a8135b58cc4168e70ab91dbf9097359d05938f1e2843875e57 arch=darwin-catalina-x86_64
[+]  6ntaixw          ^bzip2@1.0.8%apple-clang@12.0.0+shared arch=darwin-catalina-x86_64
[+]  2jdnmfp          ^expat@2.2.9%apple-clang@12.0.0~libbsd arch=darwin-catalina-x86_64
[+]  g5lf2co          ^gettext@0.20.2%apple-clang@12.0.0+bzip2+curses+git~libunistring+libxml2+tar+xz arch=darwin-catalina-x86_64
[+]  dc675hk              ^tar@1.32%apple-clang@12.0.0 arch=darwin-catalina-x86_64
[+]  5ye4c7r          ^libffi@3.3%apple-clang@12.0.0 patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0 arch=darwin-catalina-x86_64
[+]  nwrcpot          ^sqlite@3.31.1%apple-clang@12.0.0+column_metadata+fts~functions~rtree arch=darwin-catalina-x86_64
[+]  de6nj46      ^z3@4.8.7%apple-clang@12.0.0+python arch=darwin-catalina-x86_64
[+]  mjlsl7o          ^py-setuptools@49.2.0%apple-clang@12.0.0 arch=darwin-catalina-x86_64
```

</details>

Without reuse:

<details>
<summary>`spack solve -Il llvm` output</summary>

```console
(spackle):spack> spack solve -Il llvm
==> Best of 7 considered solutions.
==> Optimization Criteria:
  Priority  Criterion                                 Value
  1         number of packages to build (vs. reuse)      16
  2         deprecated versions used                      0
  3         version weight                                9
  4         number of non-default variants (roots)        1
  5         multi-valued variants                        -1
  6         preferred providers for roots                 0
  7         number of non-default variants (non-roots)   10
  8         preferred providers (non-roots)              20
  9         compiler mismatches                           0
  10        os mismatches                                 0
  11        version badness                               9
  12        count of non-root multi-valued variants       0
  13        non-preferred compilers                       0
  14        target mismatches                             0
  15        non-preferred targets                         0

 -   2p6rpiv  llvm@8.0.1%apple-clang@12.0.0~all_targets+clang~code_signing+compiler-rt~cuda~flang~gold+internal_unwind~ipo+libcxx+lld~lldb~llvm_dylib~mlir~omp_debug~omp_tsan+polly~python~shared_libs~split_dwarf build_type=Release cuda_arch=none patches=3fa900e31763cc7ff604430b86faa4eb650048c1796ebd39db2dcf84f6168a8b arch=darwin-bigsur-skylake
 -   rs5nwwn      ^cmake@3.20.5%apple-clang@12.0.0~doc+ncurses~openssl+ownlibs~qt build_type=Release arch=darwin-bigsur-skylake
 -   xrklbl5          ^ncurses@6.2%apple-clang@12.0.0~symlinks+termlib abi=none arch=darwin-bigsur-skylake
 -   ztt3pgs              ^pkgconf@1.7.4%apple-clang@12.0.0 arch=darwin-bigsur-skylake
 -   hjw2gx7      ^hwloc@2.5.0%apple-clang@12.0.0~cairo~cuda~gl~libudev~libxml2~netloc~nvml~pci+shared arch=darwin-bigsur-skylake
 -   zipu7bi      ^perl-data-dumper@2.173%apple-clang@12.0.0 arch=darwin-bigsur-skylake
 -   raet62c          ^perl@5.34.0%apple-clang@12.0.0+cpanm+shared+threads arch=darwin-bigsur-skylake
 -   akjl2di              ^berkeley-db@18.1.40%apple-clang@12.0.0+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=darwin-bigsur-skylake
 -   l7gigul              ^bzip2@1.0.8%apple-clang@12.0.0~debug~pic+shared arch=darwin-bigsur-skylake
 -   vazus7p                  ^diffutils@3.7%apple-clang@12.0.0 arch=darwin-bigsur-skylake
 -   vtlbzpn                      ^libiconv@1.16%apple-clang@12.0.0 arch=darwin-bigsur-skylake
 -   xkdly6s              ^gdbm@1.19%apple-clang@12.0.0 arch=darwin-bigsur-skylake
 -   gmhw2jt                  ^readline@8.1%apple-clang@12.0.0 arch=darwin-bigsur-skylake
[+]  xflsoui              ^zlib@1.2.11%apple-clang@12.0.0+optimize+pic+shared arch=darwin-bigsur-skylake
 -   inxzdsq      ^python@3.9.6%apple-clang@12.0.0+bz2~ctypes+dbm~debug~libxml2~lzma~nis~optimizations+pic~pyexpat+pythoncmd+readline+shared~sqlite3~ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87 arch=darwin-bigsur-skylake
 -   m6ef5no          ^apple-libuuid@1353.100.2%apple-clang@12.0.0 arch=darwin-bigsur-skylake
 -   otyemkg          ^gettext@0.21%apple-clang@12.0.0+bzip2+curses+git~libunistring~libxml2~tar~xz arch=darwin-bigsur-skylake
```

</details>

You can see we reuse a lot more with the reuse option on -- whereas without it Spack wants to build clean versions of everything but `zlib`.  You can see this in the optimization criteria as well -- the difference between using `--reuse` and not is 16 built packages.  In the case without `--reuse`, we're just not telling the solver about the installed packages so it has no hashes to swap in for different builds.

## Optimization criteria

There are still some tricky things in here -- specifically around the priority of these optimizations.  You can see in the solve calls above that we're optimizing by *minimizing* the number of packages built.  That has some weird consequences for things that aren't installed yet, like:

```console
(spackle):spack> spack solve -Il --reuse cmake
[...]
 -   fw3sb6l  cmake@3.20.5%apple-clang@12.0.0~doc+ncurses~openssl+ownlibs~qt build_type=Release arch=darwin-bigsur-skylake
[+]  ywtu57g      ^ncurses@6.2%apple-clang@12.0.0~symlinks+termlib abi=none arch=darwin-catalina-skylake
```

Here, the concretizer decided to disable `openssl` on a new cmake install, to avoid installing more things.  So it did exactly what we told it to, but not what we likely want. We probably need to add some nuance to the optimization criterion.  In particular, sometimes you care more about default variants, and sometimes you'd rather it reuse what's already installed.

Currently, I am thinking we want to only minimize builds *if* something that is installed could be reused. If there's some package we already have to build, we should just respect its defaults and build dependencies as we normally would.  I haven't worked out how best to model that yet or if it'll end up fitting peoples' intuition, so please provide suggestions.

On a similar note, you can see that we also used a couple of deprecated versions of things *because they were already installed*.  Seems like maybe we should put the reuse optimization below the "don't use deprecated versions" optimization so that this won't happen.  That would mean that you'd need to be explicit on the command line about using deprecated versions to get them into the solve.  I suspect that might surprise some people so I'm not sure whether we shouldn't just warn instead.

## Tasks

- [x] Add information about installed dependencies to the solve
- [x] Rework OS semantics in the solver to allow for certain OS's to be compatible
- [x] Make certain integrity constraints only apply to specs we intend to build and not to reused specs
- [x] Resolve issues with semantics and ordering of optimization criteria (i.e. do the right thing when we're not reusing)
- [x] Figure out whether this should be the default and what the option should be called (e.g., this is `--reuse` -- should the old way be `--deterministic`?  `--upgrade`? `--latest`?)
- [x] add options to `spack install`
- [x] enable reuse from binary caches and upstreams too (so that if you register them, you automatically reuse prebuilt things)
- [x] add `--reuse` to docs

That last task will make build caches and upstreams significantly easier to use the way we intended them, and it'll mean that you can both pull from `develop` *and* easily reuse binaries from older versions of Spack.  This will reduce the perception of "hashes changing" that people have with the old, more deterministic concretizer.