### PR TITLE
med: work around "could not find TARGET hdf5" error

### DIFF
--- a/var/spack/repos/builtin/packages/med/med-4.1.0-hdf5-target.patch
+++ b/var/spack/repos/builtin/packages/med/med-4.1.0-hdf5-target.patch
@@ -1,0 +1,13 @@
+diff --git a/config/cmake_files/FindMedfileHDF5.cmake b/config/cmake_files/FindMedfileHDF5.cmake
+index fbadbf4..5ed78f5 100644
+--- a/config/cmake_files/FindMedfileHDF5.cmake
++++ b/config/cmake_files/FindMedfileHDF5.cmake
+@@ -115,7 +115,7 @@ IF (HDF5_FOUND)
+       # HDF5 was compiled with MPI support
+       # Unfortunately HDF5 doesn't expose its MPI configuration easily ...
+       # We sniff the properties of the HDF5 target which should also be there:
+-      GET_PROPERTY(_lib_lst TARGET hdf5 PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG)
++      GET_PROPERTY(_lib_lst TARGET hdf5-shared PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG)
+       FOREACH(s ${_lib_lst})
+         STRING(FIND "${s}" "mpi." _res)   # should cover WIN(?) and LINUX
+         IF(_res GREATER -1)

--- a/var/spack/repos/builtin/packages/med/package.py
+++ b/var/spack/repos/builtin/packages/med/package.py
@@ -30,11 +30,15 @@ class Med(CMakePackage):
     depends_on('hdf5@1.10.2:1.10.7+mpi', when='@4.0.0:+mpi')
     depends_on('hdf5@:1.8.22~mpi', when='@3.2.0~mpi')
     depends_on('hdf5@1.10.2:1.10.7~mpi', when='@4.0.0:~mpi')
+    # the "TARGET hdf5" patch below only works with HDF5 shared library builds
+    depends_on('hdf5+shared', when='@4.0.0:4.1.99')
 
     conflicts("@4.1.0", when="~shared", msg="Link error when static")
 
     # C++11 requires a space between literal and identifier
     patch('add_space.patch', when='@3.2.0')
+    # fix problem where CMake "could not find TARGET hdf5"
+    patch('med-4.1.0-hdf5-target.patch', when='@4.0.0:4.1.99')
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
This pull request works around Spack issue #24671. With this work-around med 4.0.0 and newer do not work with static HDF5 builds anymore (i.e., `med@4.0.0:` depends on `hdf+shared`).

The changes were tested on Devuan Ascii with HDF5 built by Spack and Devuan Beowulf with HDF5 1.10.4 installed by Devuan's package manager apt.