### PR TITLE
docs: mention unit-test dependency on file

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -24,6 +24,7 @@ before Spack is run:
 #. The ``patch`` command to apply patches
 #. The ``git`` and ``curl`` commands for fetching
 #. If using the ``gpg`` subcommand, ``gnupg2`` is required
+#. If using the ``unit-test`` subcommand, ``file`` is required
 
 These requirements can be easily installed on most modern Linux systems;
 on macOS, XCode is required.  Spack is designed to run on HPC


### PR DESCRIPTION
Mention the Spack dependency on the program `file` when running the subcommand `unit-test`.

Without `file`, `spack unit-test` may generate errors like the one below:
```
E           spack.util.executable.ProcessError: file: No such file or directory: 'file'
E               Command: 'file' '-b' '-h' '--mime-type' '/tmp/pytest-of-john/pytest-0/mock_store0/test-debian6-core2/gcc-4.5.0/mpileaks-2.3-a3frzecng4q6lqvw76zfdq7fuirlwcuh/include/mpileaks.h'
```