### PR TITLE
Another pass at increasing RADIUSS cloud CI packages

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -27,25 +27,25 @@ spack:
       - axom
       - blt
       - caliper
-      #- care
-      #- chai
+      #- care  ## ~benchmarks ~examples ~tests
+      #- chai  ## ~benchmarks ~examples ~tests
       - conduit  # ^hdf5+shared
       - flux-core
       #- flux-sched
-      #- glvis   # ^mesa-glu@9.0.0 ^mesa18~llvm
+      #- glvis   # ^mesa-glu@9.0.0 ^mesa18~llvm  # same issue w/chai
       - hypre
       - lbann
-      #- lvarray # ^raja~openmp  # per Ben Corbett Issue #23192
+      - lvarray ~tests  # per Spack issue #23192  # ~examples
       - mfem
       - py-hatchet
       - py-maestrowf
       - py-merlin
       - py-shroud
-      #- raja
+      - raja # ~examples  # ~tests
       - samrai
       - scr
       - sundials
-      #- umpire #~openmp
+      - umpire # ~openmp
       #- visit   # ^mesa-glu@9.0.0
       - xbraid
       - zfp
@@ -71,7 +71,7 @@ spack:
       - match: [ascent, axom, sundials, umpire, vtk-h, vtk-m]
         runner-attributes:
           tags: ["spack", "public", "xlarge", "x86_64"]
-      - match: ['@:']
+      - match: ['os=ubuntu18.04']
         runner-attributes:
           tags: ["spack", "public", "large", "x86_64"]
     temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"


### PR DESCRIPTION
The current configuration has eighteen (18) of the twenty six (26) packages.  This PR is another cut at increasing the RADIUSS packages since the goal is to eventually have all twenty six packages included.

This PR enables building three more RADIUSS packages.  One (`lvarray`) by by-passing the fact the tests fail to build and two (`raja` and `umpire`) after dependency changes were made to their packages (see #25346 , #25347 ).