### PR TITLE
Papyrus: Add E4S testsuite stand alone test

### DIFF
--- a/var/spack/repos/builtin/packages/papyrus/package.py
+++ b/var/spack/repos/builtin/packages/papyrus/package.py
@@ -22,6 +22,8 @@ class Papyrus(CMakePackage):
 
     depends_on('mpi')
 
+    test_requires_compiler = True
+
     def setup_run_environment(self, env):
         if os.path.isdir(self.prefix.lib64):
             lib_dir = self.prefix.lib64
@@ -37,3 +39,35 @@ class Papyrus(CMakePackage):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources([join_path('kv', 'tests', '01_open_close')])
+
+    def run_01_open_close_test(self):
+        """Run stand alone test: 01_open_close"""
+
+        test_dir = join_path(self.test_suite.current_test_cache_dir,
+                            'kv', 'tests', '01_open_close')
+
+        if not os.path.exists(test_dir):
+            print('Skipping 01_open_close test')
+            return
+
+        if os.path.isdir(self.prefix.lib64):
+            lib_dir = self.prefix.lib64
+        else:
+            lib_dir = self.prefix.lib
+
+        exe = 'test01_open_close'
+
+        options = ['-I{0}'.format(join_path(self.prefix, 'include')),
+                   '-L{0}'.format(lib_dir), '-lpapyruskv', '-g', '-o',
+                   exe, 'test01_open_close.c', '-lpthread', '-lm']
+
+        self.run_test(self.spec['mpi'].mpicxx, options,
+                      purpose  ='test: compile {0} example'.format(exe),
+                      work_dir =test_dir)
+
+        self.run_test(exe,
+                      purpose='test: run {0} example'.format(exe),
+                      work_dir=test_dir)
+
+    def test(self):
+        self.run_01_open_close_test()

--- a/var/spack/repos/builtin/packages/papyrus/package.py
+++ b/var/spack/repos/builtin/packages/papyrus/package.py
@@ -31,3 +31,9 @@ class Papyrus(CMakePackage):
         env.prepend_path('CPATH', self.prefix.include)
         env.prepend_path('LIBRARY_PATH', lib_dir)
         env.prepend_path('LD_LIBRARY_PATH', lib_dir)
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources([join_path('kv', 'tests', '01_open_close')])

--- a/var/spack/repos/builtin/packages/papyrus/package.py
+++ b/var/spack/repos/builtin/packages/papyrus/package.py
@@ -49,31 +49,30 @@ class Papyrus(CMakePackage):
             lib_dir = self.prefix.lib
 
         example_list = ['01_open_close', '02_put_get', '03_barrier',
-                        '04_delete', '05_fence', #'06_signal'],
+                        '04_delete', '05_fence', '06_signal',
                         '07_consistency', '08_protect', '09_cache',
                         '10_checkpoint', '11_restart', '12_free']
 
         for example in example_list:
 
             test_dir = join_path(self.test_suite.current_test_cache_dir,
-                             'kv', 'tests', example)
+                                 'kv', 'tests', example)
+            test_example = 'test{0}.c'.format(example)
 
             if not os.path.exists(test_dir):
-                print('Skipping {} test'.format(example))
+                print('Skipping {0} test'.format(example))
                 continue
-
-            test_example = 'test{}.c'.format(example)
 
             self.run_test(self.spec['mpi'].mpicxx,
                           options=['{0}'.format(join_path(test_dir, test_example)),
                                    '-I{0}'.format(join_path(self.prefix, 'include')),
                                    '-L{0}'.format(lib_dir), '-lpapyruskv', '-g', '-o',
-                                   example, '-lpthread',
-                                   '-lm'],
+                                   example, '-lpthread', '-lm'],
                           purpose='test: compile {0} example'.format(example),
                           work_dir=test_dir)
 
-            self.run_test(example,
+            self.run_test(self.spec['mpi'].prefix.bin.mpirun,
+                          options=['-np', '4', example],
                           purpose='test: run {0} example'.format(example),
                           work_dir=test_dir)
 

--- a/var/spack/repos/builtin/packages/papyrus/package.py
+++ b/var/spack/repos/builtin/packages/papyrus/package.py
@@ -38,36 +38,44 @@ class Papyrus(CMakePackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([join_path('kv', 'tests', '01_open_close')])
+        self.cache_extra_test_sources([join_path('kv', 'tests')])
 
-    def run_01_open_close_test(self):
+    def run_example_tests(self):
         """Run stand alone test: 01_open_close"""
-
-        test_dir = join_path(self.test_suite.current_test_cache_dir,
-                            'kv', 'tests', '01_open_close')
-
-        if not os.path.exists(test_dir):
-            print('Skipping 01_open_close test')
-            return
 
         if os.path.isdir(self.prefix.lib64):
             lib_dir = self.prefix.lib64
         else:
             lib_dir = self.prefix.lib
 
-        exe = 'test01_open_close'
+        example_list = ['01_open_close', '02_put_get', '03_barrier',
+                        '04_delete', '05_fence', #'06_signal'],
+                        '07_consistency', '08_protect', '09_cache',
+                        '10_checkpoint', '11_restart', '12_free']
 
-        options = ['-I{0}'.format(join_path(self.prefix, 'include')),
-                   '-L{0}'.format(lib_dir), '-lpapyruskv', '-g', '-o',
-                   exe, 'test01_open_close.c', '-lpthread', '-lm']
+        for example in example_list:
 
-        self.run_test(self.spec['mpi'].mpicxx, options,
-                      purpose  ='test: compile {0} example'.format(exe),
-                      work_dir =test_dir)
+            test_dir = join_path(self.test_suite.current_test_cache_dir,
+                             'kv', 'tests', example)
 
-        self.run_test(exe,
-                      purpose='test: run {0} example'.format(exe),
-                      work_dir=test_dir)
+            if not os.path.exists(test_dir):
+                print('Skipping {} test'.format(example))
+                continue
+
+            test_example = 'test{}.c'.format(example)
+
+            self.run_test(self.spec['mpi'].mpicxx,
+                          options=['{0}'.format(join_path(test_dir, test_example)),
+                                   '-I{0}'.format(join_path(self.prefix, 'include')),
+                                   '-L{0}'.format(lib_dir), '-lpapyruskv', '-g', '-o',
+                                   example, '-lpthread',
+                                   '-lm'],
+                          purpose='test: compile {0} example'.format(example),
+                          work_dir=test_dir)
+
+            self.run_test(example,
+                          purpose='test: run {0} example'.format(example),
+                          work_dir=test_dir)
 
     def test(self):
-        self.run_01_open_close_test()
+        self.run_example_tests()

--- a/var/spack/repos/builtin/packages/papyrus/package.py
+++ b/var/spack/repos/builtin/packages/papyrus/package.py
@@ -41,7 +41,13 @@ class Papyrus(CMakePackage):
         self.cache_extra_test_sources([join_path('kv', 'tests')])
 
     def run_example_tests(self):
-        """Run stand alone test: 01_open_close"""
+        """Run all c & c++ stand alone test"""
+
+        example_dir = join_path(self.test_suite.current_test_cache_dir, 'kv', 'tests')
+
+        if not os.path.exists(example_dir):
+            print('Skipping all test')
+            return
 
         if os.path.isdir(self.prefix.lib64):
             lib_dir = self.prefix.lib64


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `papyrus` package and is intended to serve the following purposes:

Leverage the current E4S test suite for the software
Demonstrate to package maintainers how to start a Spack stand alone test.

