### PR TITLE
FEniCS: Loosen restriction on Boost version for FEniCS@2019.1.0 and newer

### DIFF
--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -96,11 +96,8 @@ class Fenics(CMakePackage):
     depends_on('pkgconfig', type='build')
     depends_on('zlib', when='+zlib')
 
-    for ver in dolfin_versions:
-        if Version(ver) == Version('2019.1.0'):
-            depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono')
-        else:
-            depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono@1.68.0')
+    depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono')
+    depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono@1.68.0', when='@:2018.99')
 
     depends_on('mpi', when='+mpi')
     depends_on('hdf5+hl+fortran', when='+hdf5+petsc')


### PR DESCRIPTION
The FEniCS package for `fenics@2019.1.0.post0` is currently too restrictive on the version of Boost to be used. It should restrict Boost to `boost@1.68.0` for all FEniCS versions before `2019.1.0.post` but allow for newer versions of Boost starting from version `2019.1.0` and later. However, the current FEniCS package will also request `boost@1.68.0` if `fenics@2019.1.0.post0` is installed. I guess that is due to the strict comparison for the Boost dependency defined in the package. This PR loosens the dependency check for version `2019.1.0` of FEniCS and later.

**Without changes from PR**

Concretization without PR requests `boost@1.68.0`:
```
spack add fenics@2019.1.0.post0
==> Adding fenics@2019.1.0.post0 to environment fenics-2019
> spack concretize -f
==> Concretized fenics@2019.1.0.post0
 -   pqtqzzj  fenics@2019.1.0.post0%gcc@9.3.0~doc+hdf5~ipo+mpi+openmp+parmetis+petsc+petsc4py+python~qt+scotch+shared+slepc+slepc4py+suite-sparse~trilinos~vtk~zlib build_type=RelWithDebInfo patches=bdfccb7573b646f7d523d02bca60cc91b08ad0a3ce3cf0a42c1a840518f819ae arch=linux-ubuntu20.04-skylake
 -   5a47cse      ^boost@1.68.0%gcc@9.3.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden arch=linux-ubuntu20.04-skylake
[...]
```
Spack should prefer the newest available Boost here (`boost@1.76.0` at the time of writing).

**After changes from PR**
Concretization with PR requests newest boost accepted by environment (here `boost@1.76.0`):
```
spack concretize -f
==> Concretized fenics@2019.1.0.post0
 -   wjnfelh  fenics@2019.1.0.post0%gcc@9.3.0~doc+hdf5~ipo+mpi+openmp+parmetis+petsc+petsc4py+python~qt+scotch+shared+slepc+slepc4py+suite-sparse~trilinos~vtk~zlib build_type=RelWithDebInfo patches=bdfccb7573b646f7d523d02bca60cc91b08ad0a3ce3cf0a42c1a840518f819ae arch=linux-ubuntu20.04-skylake
 -   nhquzjn      ^boost@1.76.0%gcc@9.3.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden arch=linux-ubuntu20.04-skylake
[...]
```
The concretization with PR still requests `boost@1.68.0` for older versions of FEniCS:
```
> spack concretize -f
==> Concretized fenics@2018.1.0.post0
 -   elzpmlf  fenics@2018.1.0.post0%gcc@9.3.0~doc+hdf5~ipo+mpi+openmp+parmetis+petsc+petsc4py+python~qt+scotch+shared+slepc+slepc4py+suite-sparse~trilinos~vtk~zlib build_type=RelWithDebInfo arch=linux-ubuntu20.04-skylake
 -   5a47cse      ^boost@1.68.0%gcc@9.3.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden arch=linux-ubuntu20.04-skylake
[...]
```