### PR TITLE
backport version tuple change

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -136,7 +136,8 @@ copyright = u'2013-2019, Lawrence Livermore National Laboratory.'
 #
 # The short X.Y version.
 import spack
-version = '.'.join(str(s) for s in spack.spack_version_info[:2])
+
+version = '.'.join(spack.spack_version_info[:2])
 # The full version, including alpha/beta/rc tags.
 release = spack.spack_version
 

--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -3,11 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+#: (major, minor, patch, pre-release) semantic version for Spack
+spack_version_info = ('0', '16', '2')
 
-#: major, minor, patch version for Spack, in a tuple
-spack_version_info = (0, 16, 2)
-
-#: String containing Spack version joined with .'s
-spack_version = '.'.join(str(v) for v in spack_version_info)
+#: Semantic version string <major>.<minor>.<path>-<pre-release>
+spack_version = '.'.join(spack_version_info[:3])
+if len(spack_version_info) >= 4:
+    spack_version += '-' + spack_version_info[3]
 
 __all__ = ['spack_version_info', 'spack_version']


### PR DESCRIPTION
Backports #25267

I checked that after #25267 is merged to develop, and this is merged into `releases/v0.16`, that when I create a new commit bumping the version in `releases/v0.16` and then tag it `v0.16.3`, and then do `git checkout develop && git merge --no-ff -s ours v0.16.3` -- it works fine; develop's `__init__.py`'s version remains at `spack_version_info = ('0', '17', '0', 'dev')`.