### PR TITLE
Rework rules for provider weights

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -767,7 +767,7 @@ class SpackSolverSetup(object):
 
             for i, provider in enumerate(providers):
                 provider_name = spack.spec.Spec(provider).name
-                func(vspec, provider_name, i + 10)
+                func(vspec, provider_name, i)
 
     def provider_defaults(self):
         self.gen.h2("Default virtual providers")

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -197,30 +197,33 @@ provides_virtual(Provider, Virtual) :-
 % A provider may have different possible weights depending on whether it's an external
 % or not, or on preferences expressed in packages.yaml etc. This rule ensures that
 % we select the weight, among the possible ones, that minimizes the overall objective function.
-1 { provider_weight(Dependency, Weight, Reason) : possible_provider_weight(Dependency, Weight, Reason) } 1
- :- provider(Dependency, _).
+1 { provider_weight(Dependency, Virtual, Weight, Reason) :
+    possible_provider_weight(Dependency, Virtual, Weight, Reason) } 1
+ :- provider(Dependency, Virtual).
 
 % Get rid or the reason for enabling the possible weight (useful for debugging)
-provider_weight(Dependency, Weight) :- provider_weight(Dependency, Weight, _).
+provider_weight(Dependency, Virtual, Weight) :- provider_weight(Dependency, Virtual, Weight, _).
 
 % A provider that is an external can use a weight of 0
-possible_provider_weight(Dependency, 0, "external") :- provider(Dependency, Virtual), external(Dependency).
+possible_provider_weight(Dependency, Virtual, 0, "external")
+  :- provider(Dependency, Virtual),
+     external(Dependency).
 
 % A provider mentioned in packages.yaml can use a weight
 % according to its priority in the list of providers
-possible_provider_weight(Dependency, Weight, "packages_yaml")
+possible_provider_weight(Dependency, Virtual, Weight, "packages_yaml")
   :- provider(Dependency, Virtual),
      depends_on(Package, Dependency),
      pkg_provider_preference(Package, Virtual, Dependency, Weight).
 
 % A provider mentioned in the default configuration can use a weight
 % according to its priority in the list of providers
-possible_provider_weight(Dependency, Weight, "default")
+possible_provider_weight(Dependency, Virtual, Weight, "default")
   :- provider(Dependency, Virtual),
      default_provider_preference(Virtual, Dependency, Weight).
 
 % Any provider can use 100 as a weight, which is very high and discourage its use
-possible_provider_weight(Dependency, 100, "fallback") :- provider(Dependency, Virtual).
+possible_provider_weight(Dependency, Virtual, 100, "fallback") :- provider(Dependency, Virtual).
 
 #defined possible_provider/2.
 #defined provider_condition/3.
@@ -736,8 +739,8 @@ opt_criterion(13, "multi-valued variants").
 opt_criterion(12, "preferred providers for roots").
 #minimize{ 0@12 : #true }.
 #minimize{
-    Weight@12,Provider
-    : provider_weight(Provider, Weight), root(Provider)
+    Weight@12,Provider,Virtual
+    : provider_weight(Provider, Virtual, Weight), root(Provider)
 }.
 
 % Try to use default variants or variants that have been set
@@ -753,8 +756,8 @@ opt_criterion(11, "number of non-default variants (non-roots)").
 opt_criterion(9, "preferred providers (non-roots)").
 #minimize{ 0@9 : #true }.
 #minimize{
-    Weight@9,Provider
-    : provider_weight(Provider, Weight), not root(Provider)
+    Weight@9,Provider,Virtual
+    : provider_weight(Provider, Virtual, Weight), not root(Provider)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -193,45 +193,34 @@ provides_virtual(Provider, Virtual) :-
 %-----------------------------------------------------------------------------
 % Virtual dependency weights
 %-----------------------------------------------------------------------------
-% give dependents the virtuals they want
-provider_weight(Dependency, 0)
- :- virtual(Virtual), depends_on(Package, Dependency),
-    provider(Dependency, Virtual),
-    external(Dependency).
 
-provider_weight(Dependency, Weight)
- :- virtual(Virtual), depends_on(Package, Dependency),
-    provider(Dependency, Virtual),
-    pkg_provider_preference(Package, Virtual, Dependency, Weight),
-    not external(Dependency).
+% A provider may have different possible weights depending on whether it's an external
+% or not, or on preferences expressed in packages.yaml etc. This rule ensures that
+% we select the weight, among the possible ones, that minimizes the overall objective function.
+1 { provider_weight(Dependency, Weight, Reason) : possible_provider_weight(Dependency, Weight, Reason) } 1
+ :- provider(Dependency, _).
 
-provider_weight(Dependency, Weight)
- :- virtual(Virtual), depends_on(Package, Dependency),
-    provider(Dependency, Virtual),
-    not pkg_provider_preference(Package, Virtual, Dependency, _),
-    not external(Dependency),
-    default_provider_preference(Virtual, Dependency, Weight).
+% Get rid or the reason for enabling the possible weight (useful for debugging)
+provider_weight(Dependency, Weight) :- provider_weight(Dependency, Weight, _).
 
-% if there's no preference for something, it costs 100 to discourage its
-% use with minimization
-provider_weight(Dependency, 100)
- :- virtual(Virtual),
-    provider(Dependency, Virtual),
-    depends_on(Package, Dependency),
-    not external(Dependency),
-    not pkg_provider_preference(Package, Virtual, Dependency, _),
-    not default_provider_preference(Virtual, Dependency, _).
+% A provider that is an external can use a weight of 0
+possible_provider_weight(Dependency, 0, "external") :- provider(Dependency, Virtual), external(Dependency).
 
-% Do the same for virtual roots
-provider_weight(Package, Weight)
- :- virtual_root(Virtual),
-    provider(Package, Virtual),
-    default_provider_preference(Virtual, Package, Weight).
+% A provider mentioned in packages.yaml can use a weight
+% according to its priority in the list of providers
+possible_provider_weight(Dependency, Weight, "packages_yaml")
+  :- provider(Dependency, Virtual),
+     depends_on(Package, Dependency),
+     pkg_provider_preference(Package, Virtual, Dependency, Weight).
 
-provider_weight(Package, 100)
- :- virtual_root(Virtual),
-    provider(Package, Virtual),
-    not default_provider_preference(Virtual, Package, _).
+% A provider mentioned in the default configuration can use a weight
+% according to its priority in the list of providers
+possible_provider_weight(Dependency, Weight, "default")
+  :- provider(Dependency, Virtual),
+     default_provider_preference(Virtual, Dependency, Weight).
+
+% Any provider can use 100 as a weight, which is very high and discourage its use
+possible_provider_weight(Dependency, 100, "fallback") :- provider(Dependency, Virtual).
 
 #defined possible_provider/2.
 #defined provider_condition/3.

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -2,6 +2,7 @@ packages:
   all:
     providers:
       mpi: [openmpi, mpich]
+      blas: [openblas]
   externaltool:
     buildable: False
     externals:

--- a/var/spack/repos/builtin.mock/packages/leaf-adds-virtual/package.py
+++ b/var/spack/repos/builtin.mock/packages/leaf-adds-virtual/package.py
@@ -1,0 +1,9 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class LeafAddsVirtual(Package):
+    version('2.0', sha256='abcde')
+    version('1.0', sha256='abcde')
+
+    depends_on('blas', when='@2.0')

--- a/var/spack/repos/builtin.mock/packages/middle-adds-virtual/package.py
+++ b/var/spack/repos/builtin.mock/packages/middle-adds-virtual/package.py
@@ -1,0 +1,7 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class MiddleAddsVirtual(Package):
+    version('1.0', sha256='abcde')
+    depends_on('leaf-adds-virtual')

--- a/var/spack/repos/builtin.mock/packages/root-adds-virtual/package.py
+++ b/var/spack/repos/builtin.mock/packages/root-adds-virtual/package.py
@@ -1,0 +1,8 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class RootAddsVirtual(Package):
+    version('1.0', sha256='abcde')
+
+    depends_on('middle-adds-virtual')


### PR DESCRIPTION
fixes #23951 

Preferred providers had a non-zero weight because in an earlier formulation of the logic program that was needed to prefer external providers over default providers. With the current formulation for externals this is not needed anymore, so we can give a weight of zero to both default choices and providers that are externals. _Using zero ensures that we don't introduce any drift towards having less providers, which was happening when minimizing positive weights_.

Modifications:

- [x] Default weight for providers starts at 0 (instead of 10, needed before to prefer externals)
- [x] Rules to compute the `provider_weight` have been refactored. There are multiple possible weights for a given `Virtual`. Only one gets selected by the solver (the one that minimizes the objective function).
- [x] `provider_weight` are now accounting for each different `Virtual`. Before there was a single weight per provider, even if the package was providing multiple virtuals.