### PR TITLE
py-particle: add version 0.15.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-particle/package.py
+++ b/var/spack/repos/builtin/packages/py-particle/package.py
@@ -20,6 +20,7 @@ class PyParticle(PythonPackage):
     tags = ['hep']
 
     version('master', branch='master')
+    version('0.15.1', sha256='6b05cdc4b76c70f785e89258a470504ad87ca119057c65da30a7d4412cca824f')
     version('0.14.1', sha256='05b345f8fbfdb12a0aa744c788b6e1b22326b5a6ad95230596e0fc9ebad56621')
     version('0.11.0', sha256='e90dc36c8b7d7431bd14ee5a28486d28b6c0708555845d1d7bdf59a165405f12')
 


### PR DESCRIPTION
Seems like there were no changes to the requirements and tests still pass.