### PR TITLE
Style: Use earlier/common isort settings option

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -312,7 +312,7 @@ def run_mypy(mypy_cmd, file_list, args):
 @tool("isort")
 def run_isort(isort_cmd, file_list, args):
     # always run with config from running spack prefix
-    isort_args = ("--settings-file", os.path.join(spack.paths.prefix, "pyproject.toml"))
+    isort_args = ("--settings-path", os.path.join(spack.paths.prefix, "pyproject.toml"))
     if not args.fix:
         isort_args += ("--check", "--diff")
 


### PR DESCRIPTION
Fixes #25341 

Switching from `--settings-file` to `--settings-path` option since the former fails with `py-isort@4.2.15`, which is the oldest safe version listed in the package, while the latter works *and* is listed as a valid option in the latest version.