### PR TITLE
RAJA: Change camp version for develop

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -47,6 +47,7 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
         depends_on('camp amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
 
     depends_on('camp')
+    depends_on('camp@master', when='@develop')
     depends_on('camp+cuda', when='+cuda')
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on('camp cuda_arch={0}'.format(sm_),


### PR DESCRIPTION
Fixes #25326 

Codifies the recommended action by making `raja@develop` depend on `camp@master`.  

This is the preferred/recommended approach to dealing with dependencies.