### PR TITLE
Umpire: change camp version for develop

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -74,6 +74,7 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
         depends_on('camp amdgpu_target=%s' % val, when='amdgpu_target=%s' % val)
 
     depends_on('camp')
+    depends_on('camp@master', when='@develop')
     depends_on('camp+cuda', when='+cuda')
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on('camp cuda_arch={0}'.format(sm_),


### PR DESCRIPTION
Fixes #25327 

Codifies the recommended action by making `umpire@develop` depend on `camp@master`.

This is the preferred/recommended approach to dealing with dependencies.