### PR TITLE
WarpX: Check & Smoke Tests

### DIFF
--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -173,6 +173,7 @@ class Warpx(CMakePackage):
     def test(self):
         """Perform smoke tests on the installed package."""
         if '+app' not in self.spec:
+            print("Smoke tests skipped: requires variant +app")
             pass
 
         # our executable names are a variant-dependent and naming evolves

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -175,10 +175,6 @@ class Warpx(CMakePackage):
         if '+app' not in self.spec:
             pass
 
-        # TODO @reviewer: "where" am I, directory-wise?
-        # Do I need to create and cd into a working_dir or is one set up?
-        # Do I need to clean up?
-
         # our executable names are a variant-dependent and naming evolves
         exe = find(self.prefix.bin, 'warpx.*', recursive=False)[0]
 

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -135,3 +135,55 @@ class Warpx(CMakePackage):
             ['libwarpx.' + libsuffix[dims]], root=self.prefix, recursive=True,
             shared=True
         )
+
+    # WarpX has many examples to serve as a suitable smoke check. One
+    # that is typical was chosen here
+    examples_src_dir = 'Examples/Physics_applications/laser_acceleration/'
+
+    def _get_input_options(self, post_install):
+        examples_dir = join_path(
+            self.install_test_root if post_install else self.stage.source_path,
+            self.examples_src_dir)
+        dims = self.spec.variants['dims'].value
+        inputs_nD = {'2': 'inputs_2d', '3': 'inputs_3d', 'rz': 'inputs_2d_rz'}
+        inputs = join_path(examples_dir, inputs_nD[dims])
+
+        cli_args = [inputs, "max_step=50", "diag1.intervals=10"]
+        # test openPMD output if compiled in
+        if '+openpmd' in self.spec:
+            cli_args.append('diag1.format=openpmd')
+        return cli_args
+
+    def check(self):
+        """Checks after the build phase"""
+        if '+app' not in self.spec:
+            pass
+
+        with working_dir("spack-check", create=True):
+            cli_args = self._get_input_options(False)
+            warpx = Executable(join_path(self.build_directory, 'bin/warpx'))
+            warpx(*cli_args)
+
+    @run_after('install')
+    def copy_test_sources(self):
+        """Copy the example input files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources([self.examples_src_dir])
+
+    def test(self):
+        """Perform smoke tests on the installed package."""
+        if '+app' not in self.spec:
+            pass
+
+        # TODO @reviewer: "where" am I, directory-wise?
+        # Do I need to create and cd into a working_dir or is one set up?
+        # Do I need to clean up?
+
+        # our executable names are a variant-dependent and naming evolves
+        exe = find(self.prefix.bin, 'warpx.*', recursive=False)[0]
+
+        cli_args = self._get_input_options(True)
+        self.run_test(exe,
+                      cli_args,
+                      [], installed=True, purpose='Smoke test for WarpX',
+                      skip_missing=False)

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -157,6 +157,7 @@ class Warpx(CMakePackage):
     def check(self):
         """Checks after the build phase"""
         if '+app' not in self.spec:
+            print("WarpX check skipped: requires variant +app")
             pass
 
         with working_dir("spack-check", create=True):
@@ -173,7 +174,7 @@ class Warpx(CMakePackage):
     def test(self):
         """Perform smoke tests on the installed package."""
         if '+app' not in self.spec:
-            print("Smoke tests skipped: requires variant +app")
+            print("WarpX smoke tests skipped: requires variant +app")
             pass
 
         # our executable names are a variant-dependent and naming evolves


### PR DESCRIPTION
Run an example at build time with:
```
spack install --test=root warpx@<version>
```
Ref.: https://spack.readthedocs.io/en/latest/packaging_guide.html#stand-alone-or-smoke-tests

Run smoke-tests after install and loading of the package via
```
spack load -r /<spec>
spack test run /<spec>
```

These tests are added so that facilities (NERSC/OLCF/ALCF/...) that install E4S packages can do tests with a built WarpX to ensure it truly works :)

x-ref: https://github.com/buildtesters/buildtest-cori/issues/56
x-ref: #25300 (comments)