### PR TITLE
trilinos: simplify variants

### DIFF
--- a/var/spack/repos/builtin/packages/albany/package.py
+++ b/var/spack/repos/builtin/packages/albany/package.py
@@ -54,7 +54,7 @@ class Albany(CMakePackage):
 
     # Add dependencies
     depends_on('mpi')
-    depends_on('trilinos~superlu-dist+isorropia+tempus+rythmos+teko+intrepid+intrepid2+minitensor+phalanx+pnetcdf+nox+piro+rol+shards+stk+superlu@master,develop')
+    depends_on('trilinos~superlu-dist+isorropia+tempus+rythmos+teko+intrepid+intrepid2+minitensor+phalanx+nox+piro+rol+shards+stk+superlu@master')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/camellia/package.py
+++ b/var/spack/repos/builtin/packages/camellia/package.py
@@ -20,7 +20,7 @@ class Camellia(CMakePackage):
 
     variant('moab', default=True, description='Compile with MOAB to include support for reading standard mesh formats')
 
-    depends_on('trilinos+amesos+amesos2+belos+epetra+epetraext+exodus+ifpack+ifpack2+intrepid+intrepid2+kokkos+ml+muelu+sacado+shards+tpetra+zoltan+mumps+superlu-dist+hdf5+zlib+mpi+netcdf+pnetcdf@master,12.12.1:')
+    depends_on('trilinos+amesos+amesos2+belos+epetra+epetraext+exodus+ifpack+ifpack2+intrepid+intrepid2+kokkos+ml+muelu+sacado+shards+tpetra+zoltan+mumps+superlu-dist+hdf5+zlib+mpi@master,12.12.1:')
     depends_on('moab@:4', when='+moab')
 
     # Cameilla needs hdf5 but the description "hdf5@:1.8" is

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -197,7 +197,7 @@ class Dealii(CMakePackage, CudaPackage):
     # depends_on('taskflow',         when='@9.3:+taskflow')
     depends_on('trilinos gotype=int', when='+trilinos@12.18.1:')
     # TODO: next line fixes concretization with trilinos and adol-c
-    depends_on('trilinos~exodus~netcdf',    when='@9.0:+adol-c+trilinos')
+    depends_on('trilinos~exodus',    when='@9.0:+adol-c+trilinos')
     # Both Trilinos and SymEngine bundle the Teuchos RCP library.
     # This leads to conflicts between macros defined in the included
     # headers when they are not compiled in the same mode.
@@ -296,12 +296,9 @@ class Dealii(CMakePackage, CudaPackage):
     conflicts('+adol-c', when='^trilinos+chaco',
               msg='Symbol clash between the ADOL-C library and '
                   'Trilinos SEACAS Chaco.')
-    conflicts('+adol-c', when='^trilinos+netcdf',
+    conflicts('+adol-c', when='^trilinos+exodus',
               msg='Symbol clash between the ADOL-C library and '
                   'Trilinos Netcdf.')
-    conflicts('+adol-c', when='^trilinos+pnetcdf',
-              msg='Symbol clash between the ADOL-C library and '
-                  'Trilinos parallel Netcdf.')
 
     conflicts('+slepc', when='~petsc',
               msg='It is not possible to enable slepc interfaces '

--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -56,7 +56,7 @@ class NaluWind(CMakePackage, CudaPackage):
     depends_on('tioga@master,develop', when='+tioga')
     depends_on('hypre@develop,2.18.2: +int64+mpi~superlu-dist', when='+hypre')
     depends_on('kokkos-nvcc-wrapper', type='build', when='+cuda')
-    depends_on('trilinos@master,develop +exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+pnetcdf+shards~hypre cxxstd=14')
+    depends_on('trilinos@master +exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+zlib+shards~hypre cxxstd=14')
     # Cannot build Trilinos as a shared library with STK on Darwin
     # https://github.com/trilinos/Trilinos/issues/2994
     depends_on('trilinos~shared', when=(sys.platform == 'darwin'))

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -35,8 +35,8 @@ class Nalu(CMakePackage):
     # Cannot build Trilinos as a shared library with STK on Darwin
     # which is why we have a 'shared' variant for Nalu
     # https://github.com/trilinos/Trilinos/issues/2994
-    depends_on('trilinos+mpi+netcdf+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop', when='+shared')
-    depends_on('trilinos~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+shards~hypre@master,develop', when='~shared')
+    depends_on('trilinos+mpi+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+shards~hypre@master')
+    depends_on('trilinos~shared', when='~shared')
     # Optional dependencies
     depends_on('tioga', when='+tioga+shared')
     depends_on('tioga~shared', when='+tioga~shared')

--- a/var/spack/repos/builtin/packages/percept/package.py
+++ b/var/spack/repos/builtin/packages/percept/package.py
@@ -25,7 +25,7 @@ class Percept(CMakePackage):
     depends_on('opennurbs@percept')
     depends_on('boost+graph+mpi')
     depends_on('yaml-cpp+pic~shared@0.5.3:')
-    depends_on('trilinos~shared+exodus+netcdf+mpi+tpetra+epetra+epetraext+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+pnetcdf+aztec+sacado~openmp+shards+intrepid+cgns@master,12.14.1:')
+    depends_on('trilinos~shared+exodus+mpi+tpetra+epetra+epetraext+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+aztec+sacado~openmp+shards+intrepid@master,12.14.1:')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/quinoa/package.py
+++ b/var/spack/repos/builtin/packages/quinoa/package.py
@@ -21,7 +21,7 @@ class Quinoa(CMakePackage):
 
     depends_on('hdf5+mpi')
     depends_on("charmpp backend=mpi")
-    depends_on("trilinos+exodus+mpi+netcdf")
+    depends_on("trilinos+exodus+mpi")
     depends_on("boost")
     depends_on("hypre~internal-superlu")
     depends_on("random123")

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -290,7 +290,7 @@ class Trilinos(CMakePackage, CudaPackage):
     # Only allow DTK with Trilinos 12
     conflicts('+dtk', when='~boost')
     conflicts('+dtk', when='~intrepid2')
-    conflicts('+dtk', when='@:12.12.99,develop,master')
+    conflicts('+dtk', when='@:12.12.99,master')
 
     # Only allow Mesquite with Trilinos 12.12 and up, and master
     conflicts('+mesquite', when='@:12.10.99,master')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -610,7 +610,6 @@ class Trilinos(CMakePackage, CudaPackage):
             ('Matio', 'matio'),
             ('METIS', 'metis'),
             ('Netcdf', 'netcdf-c'),
-            ('STRUMPACK', 'strumpack'),
             ('SuperLU', 'superlu'),
             ('SuperLUDist', 'superlu-dist'),
             ('X11', 'libx11'),
@@ -619,7 +618,10 @@ class Trilinos(CMakePackage, CudaPackage):
         if spec.satisfies('@12.12.1:'):
             tpl_dep_map.append(('Pnetcdf', 'parallel-netcdf'))
         if spec.satisfies('@13:'):
-            tpl_dep_map.append(('HWLOC', 'hwloc'))
+            tpl_dep_map.extend([
+                ('HWLOC', 'hwloc'),
+                ('STRUMPACK', 'strumpack'),
+            ])
 
         for tpl_name, dep_name in tpl_dep_map:
             have_dep = (dep_name in spec)

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -89,8 +89,6 @@ class Trilinos(CMakePackage, CudaPackage):
     # TPLs (alphabet order)
     variant('boost',        default=False,
             description='Compile with Boost')
-    variant('cgns',         default=False,
-            description='Enable CGNS')
     variant('adios2',       default=False,
             description='Enable ADIOS2')
     variant('hdf5',         default=False,
@@ -351,7 +349,7 @@ class Trilinos(CMakePackage, CudaPackage):
     depends_on('adios2', when='+adios2')
     depends_on('blas')
     depends_on('boost', when='+boost')
-    depends_on('cgns', when='+cgns')
+    depends_on('cgns', when='+exodus')
     depends_on('hdf5+hl', when='+hdf5')
     depends_on('hdf5~mpi', when='+hdf5~mpi')
     depends_on('hdf5+mpi', when="+hdf5+mpi")
@@ -403,12 +401,9 @@ class Trilinos(CMakePackage, CudaPackage):
     # ###################### Patches ##########################
 
     patch('umfpack_from_suitesparse.patch', when='@11.14.1:12.8.1')
-    patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl')
-    patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %xl_r')
-    patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %clang')
-    patch('xlf_tpetra.patch', when='@12.12.1%xl')
-    patch('xlf_tpetra.patch', when='@12.12.1%xl_r')
-    patch('xlf_tpetra.patch', when='@12.12.1%clang')
+    for _compiler in ['xl', 'xl_r', 'clang']:
+        patch('xlf_seacas.patch', when='@12.10.1:12.12.1 %' + _compiler)
+        patch('xlf_tpetra.patch', when='@12.12.1 %' + _compiler)
     patch('fix_clang_errors_12_18_1.patch', when='@12.18.1%clang')
     patch('cray_secas_12_12_1.patch', when='@12.12.1%cce')
     patch('cray_secas.patch', when='@12.14.1:%cce')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -308,8 +308,6 @@ class Trilinos(CMakePackage, CudaPackage):
     # https://trilinos.org/pipermail/trilinos-users/2015-March/004802.html
     conflicts('+superlu-dist', when='+complex+amesos2')
     conflicts('+strumpack', when='@:13.0.99')
-    # PnetCDF was only added after v12.10.1
-    conflicts('+pnetcdf', when='@0:12.10.1')
     # https://github.com/trilinos/Trilinos/issues/2994
     conflicts(
         '+shared', when='+stk platform=darwin',
@@ -394,7 +392,7 @@ class Trilinos(CMakePackage, CudaPackage):
     depends_on('matio', when='+exodus')
     depends_on('netcdf-c', when="+exodus")
     depends_on('netcdf-c+mpi+parallel-netcdf', when="+exodus+mpi@12.12.1:")
-    depends_on('pnetcdf', when='+exodus+mpi')
+    depends_on('parallel-netcdf', when='+exodus+mpi')
     depends_on('parmetis', when='+mpi +zoltan')
     depends_on('parmetis', when='+scorec')
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -97,8 +97,6 @@ class Trilinos(CMakePackage, CudaPackage):
             description='Compile with HDF5')
     variant('hypre',        default=False,
             description='Compile with Hypre preconditioner')
-    variant('matio',        default=False,
-            description='Compile with Matio')
     variant('mpi',          default=True,
             description='Compile with MPI parallelism')
     variant('mumps',        default=False,
@@ -358,7 +356,6 @@ class Trilinos(CMakePackage, CudaPackage):
     depends_on('hdf5~mpi', when='+hdf5~mpi')
     depends_on('hdf5+mpi', when="+hdf5+mpi")
     depends_on('lapack')
-    depends_on('matio', when='+matio')
     depends_on('mpi', when='+mpi')
     depends_on('suite-sparse', when='+suite-sparse')
     depends_on('zlib', when="+zlib")
@@ -396,6 +393,7 @@ class Trilinos(CMakePackage, CudaPackage):
     # Variant requirements from packages
     depends_on('metis', when='+zoltan')
     depends_on('libx11', when='+exodus')
+    depends_on('matio', when='+exodus')
     depends_on('netcdf-c', when="+exodus")
     depends_on('netcdf-c+mpi+parallel-netcdf', when="+exodus+mpi@12.12.1:")
     depends_on('pnetcdf', when='+exodus+mpi')


### PR DESCRIPTION
A couple of the variants only apply when using `+exodus`, and dependents with `+exodus` currently enable those variants, so simplify the recipe by enabling them.