### PR TITLE
universal-ctags: add latest tag

### DIFF
--- a/var/spack/repos/builtin/packages/universal-ctags/package.py
+++ b/var/spack/repos/builtin/packages/universal-ctags/package.py
@@ -13,9 +13,11 @@ class UniversalCtags(AutotoolsPackage):
     the indexed items."""
 
     homepage = "https://ctags.io/"
+    url      = "https://github.com/universal-ctags/ctags/archive/refs/tags/p5.9.20210808.0.tar.gz"
     git      = "https://github.com/universal-ctags/ctags.git"
 
     version('master', branch='master')
+    version('5.9.20210808.0', sha256='7f5f88d20750dfa2437ca9d163972b8684e3cf16de022a5177f322be92f528cc')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')


### PR DESCRIPTION
This change to universal-ctags adds the latest tagged version.