### PR TITLE
Remove --shallow option from git clone with https url as well.

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1000,6 +1000,7 @@ class GitFetchStrategy(VCSFetchStrategy):
         HTTP protocol or by no-protocol file specifications.
         Use (e.g.) https:// or file:// instead."""
         return not (self.url.startswith('http://') or
+                    self.url.startswith('https://') or
                     self.url.startswith('/'))
 
     def __str__(self):


### PR DESCRIPTION
With git repo url starting with https:// getting this error 
```
fatal: dumb http transport does not support shallow capabilities
==> Error: FetchError: All fetchers failed

spack/v0.16.1.fermi/NULL/lib/spack/spack/package.py:1360, in do_fetch:
       1357
       1358        self.stage.create()
       1359        err_msg = None if not self.manual_download else self.download_instr
  >>   1360        start_time = time.time()
       1361        self.stage.fetch(mirror_only, err_msg=err_msg)
       1362        self._fetch_time = time.time() - start_time
       1363
```