### PR TITLE
graph500: added option -fcommon for gcc@10.2

### DIFF
--- a/var/spack/repos/builtin/packages/graph500/package.py
+++ b/var/spack/repos/builtin/packages/graph500/package.py
@@ -18,11 +18,18 @@ class Graph500(MakefilePackage):
 
     build_directory = 'src'
 
+    def flag_handler(self, name, flags):
+        wrapper_flags = None
+
+        if name == 'cflags':
+            if self.spec.satisfies('%gcc@10:'):
+                wrapper_flags = ['-fcommon']
+
+        return (wrapper_flags, None, flags)
+
     def edit(self, spec, prefix):
         makefile = FileFilter(join_path(self.build_directory, 'Makefile'))
         makefile.filter(r'^MPICC\s*=.*', 'MPICC={0}'.format(spec['mpi'].mpicc))
-        if spec.satisfies('%gcc@10.2.0:'):
-            makefile.filter(r'^CFLAGS\s*=\s*', 'CFLAGS = -fcommon ')
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):

--- a/var/spack/repos/builtin/packages/graph500/package.py
+++ b/var/spack/repos/builtin/packages/graph500/package.py
@@ -21,6 +21,8 @@ class Graph500(MakefilePackage):
     def edit(self, spec, prefix):
         makefile = FileFilter(join_path(self.build_directory, 'Makefile'))
         makefile.filter(r'^MPICC\s*=.*', 'MPICC={0}'.format(spec['mpi'].mpicc))
+        if spec.satisfies('%gcc@10.2.0:'):
+            makefile.filter(r'^CFLAGS\s*=\s*', 'CFLAGS = -fcommon ')
 
     def install(self, spec, prefix):
         with working_dir(self.build_directory):


### PR DESCRIPTION
Hello,

graph500 failed to compile when gcc compiler of version 10.2 is used. Adding -fcommon option fixes a problem. Tested on Bridges-2 system at PSC.

-Nick