### PR TITLE
Parsec: add missing build deps on flex/bison

### DIFF
--- a/var/spack/repos/builtin/packages/parsec/package.py
+++ b/var/spack/repos/builtin/packages/parsec/package.py
@@ -39,6 +39,8 @@ class Parsec(CMakePackage, CudaPackage):
 
     depends_on('cmake@3.16:', type='build')
     depends_on('python', type='build')
+    depends_on('flex', type='build')
+    depends_on('bison', type='build')
     depends_on('hwloc')
     depends_on('mpi')
     depends_on('papi', when='+profile')


### PR DESCRIPTION
fixes #25339
Signed-off-by: Aurelien Bouteiller <bouteill@icl.utk.edu>