### PR TITLE
Mention bash in prerequisites

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -17,7 +17,8 @@ Spack has the following minimum requirements, which must be installed
 before Spack is run:
 
 #. Python 2 (2.6 or 2.7) or 3 (3.5 - 3.9) to run Spack
-#. A C/C++ compiler for building
+#. A C/C++ compiler for building and the ``bash`` shell for Spack's compiler
+   wrapper
 #. The ``make`` executable for building
 #. The ``tar``, ``gzip``, ``unzip``, ``bzip2``, ``xz`` and optionally ``zstd``
    executables for extracting source code


### PR DESCRIPTION
Isn't installed on Alpine.
