### PR TITLE
Fix typos in fixture use. Mention fixtures in pytest.ini

### DIFF
--- a/lib/spack/spack/test/config_values.py
+++ b/lib/spack/spack/test/config_values.py
@@ -9,7 +9,7 @@ import spack.store
 
 
 @pytest.mark.parametrize('hash_length', [1, 2, 3, 4, 5, 9])
-@pytest.mark.use_fixtures('mock_packages')
+@pytest.mark.usefixtures('mock_packages')
 def test_set_install_hash_length(hash_length, mutable_config, tmpdir):
     mutable_config.set('config:install_hash_length', hash_length)
     mutable_config.set('config:install_tree', {'root': str(tmpdir)})
@@ -24,7 +24,7 @@ def test_set_install_hash_length(hash_length, mutable_config, tmpdir):
         assert len(hash_str) == hash_length
 
 
-@pytest.mark.use_fixtures('mock_packages')
+@pytest.mark.usefixtures('mock_packages')
 def test_set_install_hash_length_upper_case(mutable_config, tmpdir):
     mutable_config.set('config:install_hash_length', 5)
     mutable_config.set(

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,8 @@ markers =
   db: tests that require creating a DB
   maybeslow: tests that may be slow (e.g. access a lot the filesystem, etc.)
   regression: tests that fix a reported bug
+  requires_executables: tests that requires certain executables in PATH to run
+  nomockstage: use a stage area specifically created for this test, instead of relying on a common mock stage
+  enable_compiler_verification: enable compiler verification within unit tests
+  enable_compiler_link_paths: verifies compiler link paths within unit tests
+  disable_clean_stage_check: avoid failing tests if there are leftover files in the stage area


### PR DESCRIPTION
Modifications:
- [x] List in pytest.ini all the fixtures that are used in unit tests
- [x] Fix a few errors reported by later versions of pytest