### PR TITLE
AOCC 3.1 support for WRF 3.9.1.1 and 4.2

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -108,6 +108,7 @@ class Wrf(Package):
     patch("patches/3.9/add_aarch64.patch", when="@3.9.1.1")
     patch("patches/3.9/configure_aocc_2.3.patch", when="@3.9.1.1 %aocc@:2.4.0")
     patch("patches/3.9/configure_aocc_3.0.patch", when="@3.9.1.1 %aocc@3.0.0")
+    patch("patches/3.9/configure_aocc_3.1.patch", when="@3.9.1.1 %aocc@3.1.0")
 
     # These patches deal with netcdf & netcdf-fortran being two diff things
     # Patches are based on:
@@ -133,7 +134,8 @@ class Wrf(Package):
     patch("patches/4.2/tirpc_detect.patch", when="@4.2")
     patch("patches/4.2/add_aarch64.patch", when="@4.2")
     patch("patches/4.2/configure_aocc_2.3.patch", when="@4.2 %aocc@:2.4.0")
-    patch("patches/4.2/configure_aocc_3.0.patch", when="@4.2 %aocc@3.0.0")
+    patch("patches/4.2/configure_aocc_3.0.patch", when="@4.2 %aocc@3.0.0:3.2.0")
+    patch("patches/4.2/hdf5_fix.patch", when="@4.2 %aocc")
     patch("patches/4.2/derf_fix.patch", when="@4.2 %aocc")
 
     depends_on("pkgconfig", type=("build"))
@@ -339,7 +341,7 @@ class Wrf(Package):
 
     @run_after("configure")
     def patch_for_libmvec(self):
-        if self.spec.satisfies("@3.9.1.1 %aocc@:3.0"):
+        if self.spec.satisfies("@3.9.1.1 %aocc"):
             fp = self.package_dir + "/patches/3.9/aocc_lmvec.patch"
             which('patch')('-s', '-p1', '-i', '{0}'.format(fp), '-d', '.')
 

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_3.1.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_3.1.patch
@@ -1,0 +1,53 @@
+--- WRF-3.9.1.1/arch/configure_new.defaults	2021-03-10 10:08:07.885236847 +0530
++++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-08-12 08:58:35.442165745 +0530
+@@ -1917,6 +1917,50 @@
+ CC_TOOLS        =      $(SCC) 
+ 
+ #insert new stanza here
++##############################################################
++#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
++#
++DESCRIPTION     =       AMD AOCC ($SFC/$SCC): EPYC
++DMPARALLEL      =       1
++OMPCPP          =       -D_OPENMP
++OMP             =       -fopenmp
++OMPCC           =       -fopenmp -Mpreprocess
++SFC             =       flang
++SCC             =       clang
++CCOMP           =       clang
++DM_FC           =       mpif90 -DMPI2_SUPPORT
++DM_CC           =       mpicc -DMPI2_SUPPORT
++FC              =       $(DM_FC)
++CC              =       $(DM_CC) -DFSEEKO64_OK
++LD              =       $(FC)
++RWORDSIZE       =       $(NATIVE_RWORDSIZE)
++PROMOTION       =
++ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
++LIBMVEC         =       -mllvm -vector-library=LIBMVEC-X86 -mllvm -enable-loop-vectorization-with-conditions -Mstack_arrays
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math
++CFLAGS_LOCAL    =       -w $(AOCCOPT)
++LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
++CPLUSPLUSLIB    =
++ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
++FCOPTIM         =       $(AOCCOPT) -fopenmp
++FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
++FCNOOPT         =       -O0 -DFCNOOPT -fopenmp
++FCDEBUG         =       #-g
++FORMAT_FIXED    =       -Mfixed
++FORMAT_FREE     =       -Mfreeform
++FCSUFFIX        =
++BYTESWAPIO      =       -Mbyteswapio
++FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) -fopenmp
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS -fopenmp
++MODULE_SRCH_FLAG =
++TRADFLAG        =       -traditional
++CPP             =       /lib/cpp -P
++AR              =       llvm-ar
++ARFLAGS         =       ru
++M4              =       m4
++RANLIB          =       llvm-ranlib
++RLFLAGS         =
++CC_TOOLS        =       $(SCC)
+ 
+ ###########################################################
+ #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/hdf5_fix.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/hdf5_fix.patch
@@ -1,0 +1,20 @@
+--- WRF-4.2/arch/Config.pl	2021-08-12 16:39:02.339226280 +0530
++++ WRF-4.2/arch/Config_hdf5.pl	2021-08-12 18:17:17.362452577 +0530
+@@ -514,7 +514,7 @@
+ 	 }
+ 
+     if ( $sw_hdf5_path ) 
+-      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
++      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib -lhdf5_hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
+         $_ =~ s:CONFIGURE_HDF5_FLAG:-DHDF5: ;
+          }
+     else
+@@ -836,7 +836,7 @@
+ 	 }
+ 
+     if ( $sw_hdf5_path )
+-      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib -lhdf5hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
++      { $_ =~ s:CONFIGURE_HDF5_LIB_PATH:-L$sw_hdf5_path/lib -lhdf5_hl_fortran -lhdf5_hl -lhdf5_fortran -lhdf5 -lm -lz: ;
+         $_ =~ s:CONFIGURE_HDF5_FLAG:-DHDF5: ;
+          }
+     else


### PR DESCRIPTION
- Added AOCC 3.1 support for WRF 3.9.1.1 and 4.2
- Fixed HDF5 issue `ld.lld: error: unable to find library -lhdf5hl_fortran` in WRF 4.2