### PR TITLE
Use kcov from official Ubuntu 20.04 repository

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -131,10 +131,7 @@ jobs:
           # Needed for unit tests
           sudo apt-get -y install \
               coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build \
-              patchelf
-          # Needed for kcov
-          sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev
-          sudo apt-get -y install zlib1g-dev libdw-dev libiberty-dev
+              patchelf cmake bison libbison-dev kcov
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools codecov coverage[toml]
@@ -148,17 +145,6 @@ jobs:
           # Need this for the git tests to succeed.
           git --version
           . .github/workflows/setup_git.sh
-    - name: Install kcov for bash script coverage
-      if: ${{ needs.changes.outputs.with_coverage == 'true' }}
-      env:
-          KCOV_VERSION: 34
-      run: |
-          KCOV_ROOT=$(mktemp -d)
-          wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz
-          tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz
-          mkdir -p ${KCOV_ROOT}/build
-          cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd -
-          make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install
     - name: Bootstrap clingo
       if: ${{ matrix.concretizer == 'clingo' }}
       env:
@@ -300,21 +286,7 @@ jobs:
           # Needed for unit tests
           sudo apt-get -y install \
               coreutils cvs gfortran graphviz gnupg2 mercurial ninja-build \
-              patchelf
-          # Needed for kcov
-          sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev
-          sudo apt-get -y install zlib1g-dev libdw-dev libiberty-dev
-    - name: Install kcov for bash script coverage
-      if: ${{ needs.changes.outputs.with_coverage == 'true' }}
-      env:
-          KCOV_VERSION: 34
-      run: |
-          KCOV_ROOT=$(mktemp -d)
-          wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz
-          tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz
-          mkdir -p ${KCOV_ROOT}/build
-          cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd -
-          make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install
+              patchelf kcov
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools codecov coverage[toml] clingo

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -204,10 +204,7 @@ jobs:
       run: |
           sudo apt-get -y update
           # Needed for shell tests
-          sudo apt-get install -y coreutils csh zsh tcsh fish dash bash
-          # Needed for kcov
-          sudo apt-get -y install cmake binutils-dev libcurl4-openssl-dev
-          sudo apt-get -y install zlib1g-dev libdw-dev libiberty-dev
+          sudo apt-get install -y coreutils kcov csh zsh tcsh fish dash bash
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools codecov coverage[toml]
@@ -216,17 +213,6 @@ jobs:
           # Need this for the git tests to succeed.
           git --version
           . .github/workflows/setup_git.sh
-    - name: Install kcov for bash script coverage
-      if: ${{ needs.changes.outputs.with_coverage == 'true' }}
-      env:
-          KCOV_VERSION: 38
-      run: |
-          KCOV_ROOT=$(mktemp -d)
-          wget --output-document=${KCOV_ROOT}/${KCOV_VERSION}.tar.gz https://github.com/SimonKagstrom/kcov/archive/v${KCOV_VERSION}.tar.gz
-          tar -C ${KCOV_ROOT} -xzvf ${KCOV_ROOT}/${KCOV_VERSION}.tar.gz
-          mkdir -p ${KCOV_ROOT}/build
-          cd ${KCOV_ROOT}/build && cmake -Wno-dev ${KCOV_ROOT}/kcov-${KCOV_VERSION} && cd -
-          make -C ${KCOV_ROOT}/build && sudo  make -C ${KCOV_ROOT}/build install
     - name: Run shell tests (without coverage)
       if: ${{ needs.changes.outputs.with_coverage == 'false' }}
       run: |

--- a/share/spack/qa/bashcov
+++ b/share/spack/qa/bashcov
@@ -9,4 +9,7 @@ if [ -z "$SPACK_ROOT" ]; then
     exit 1
 fi
 
-kcov "$SPACK_ROOT/coverage" "$@"
+# Using a -- to separate the script to be tested from kcov is not documented
+# as of v38, but seems to work. The same is true for the "--debug-force-bash-stderr"
+# option, see https://github.com/SimonKagstrom/kcov/issues/61
+kcov --debug-force-bash-stderr "$SPACK_ROOT/coverage" -- "$@"

--- a/share/spack/qa/run-shell-tests
+++ b/share/spack/qa/run-shell-tests
@@ -38,8 +38,8 @@ cd "$SPACK_ROOT"
 # Run bash tests with coverage enabled, but pipe output to /dev/null
 # because it seems that kcov seems to undo the script's redirection
 if [ "$COVERAGE" = true ]; then
-    "$QA_DIR/bashcov" "$QA_DIR/setup-env-test.sh" &> /dev/null
-    "$QA_DIR/bashcov" "$QA_DIR/completion-test.sh" &> /dev/null
+    kcov "$SPACK_ROOT/coverage" "$QA_DIR/setup-env-test.sh" &> /dev/null
+    kcov "$SPACK_ROOT/coverage" "$QA_DIR/completion-test.sh" &> /dev/null
 else
     bash "$QA_DIR/setup-env-test.sh"
     bash "$QA_DIR/completion-test.sh"

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -31,10 +31,10 @@ if [[ "$COVERAGE" == "true" ]]; then
     bashcov=$(realpath ${QA_DIR}/bashcov)
 
     # instrument scripts requiring shell coverage
-    sed -i~ "s@#\!/bin/bash@#\!${bashcov}@" "$SPACK_ROOT/lib/spack/env/cc"
+    sed -i "s@#\!/bin/bash@#\!${bashcov}@" "$SPACK_ROOT/lib/spack/env/cc"
     if [ "$(uname -o)" != "Darwin" ]; then
         # On darwin, #! interpreters must be binaries, so no sbang for bashcov
-        sed -i~ "s@#\!/bin/sh@#\!${bashcov}@"   "$SPACK_ROOT/bin/sbang"
+        sed -i "s@#\!/bin/sh@#\!${bashcov}@"   "$SPACK_ROOT/bin/sbang"
     fi
 fi
 

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -31,10 +31,10 @@ if [[ "$COVERAGE" == "true" ]]; then
     bashcov=$(realpath ${QA_DIR}/bashcov)
 
     # instrument scripts requiring shell coverage
-    sed -i "s@#\!/bin/bash@#\!${bashcov}@" "$SPACK_ROOT/lib/spack/env/cc"
+    sed -i '' "s@#\!/bin/bash@#\!${bashcov}@" "$SPACK_ROOT/lib/spack/env/cc"
     if [ "$(uname -o)" != "Darwin" ]; then
         # On darwin, #! interpreters must be binaries, so no sbang for bashcov
-        sed -i "s@#\!/bin/sh@#\!${bashcov}@"   "$SPACK_ROOT/bin/sbang"
+        sed -i '' "s@#\!/bin/sh@#\!${bashcov}@"   "$SPACK_ROOT/bin/sbang"
     fi
 fi
 

--- a/share/spack/qa/setup.sh
+++ b/share/spack/qa/setup.sh
@@ -31,10 +31,10 @@ if [[ "$COVERAGE" == "true" ]]; then
     bashcov=$(realpath ${QA_DIR}/bashcov)
 
     # instrument scripts requiring shell coverage
-    sed -i '' "s@#\!/bin/bash@#\!${bashcov}@" "$SPACK_ROOT/lib/spack/env/cc"
+    sed -i "s@#\!/bin/bash@#\!${bashcov}@" "$SPACK_ROOT/lib/spack/env/cc"
     if [ "$(uname -o)" != "Darwin" ]; then
         # On darwin, #! interpreters must be binaries, so no sbang for bashcov
-        sed -i '' "s@#\!/bin/sh@#\!${bashcov}@"   "$SPACK_ROOT/bin/sbang"
+        sed -i "s@#\!/bin/sh@#\!${bashcov}@"   "$SPACK_ROOT/bin/sbang"
     fi
 fi
 


### PR DESCRIPTION
fixes https://github.com/spack/spack/issues/23164

Modifications:
- [x] Use kcov from Ubuntu 20.04 repository for shell tests
- [x] Use kcov from Ubuntu 20.04 repository for unit tests
- [x] Fix using kcov v3.8 with unit tests