### PR TITLE
cray-libsci package update: add an additional function to determine math libraries

### DIFF
--- a/var/spack/repos/builtin/packages/cray-libsci/package.py
+++ b/var/spack/repos/builtin/packages/cray-libsci/package.py
@@ -84,6 +84,10 @@ class CrayLibsci(Package):
     def scalapack_libs(self):
         return self.blas_libs
 
+    @property
+    def libs(self):
+        return self.blas_libs
+
     def install(self, spec, prefix):
         raise InstallError(
             self.spec.format('{name} is not installable, you need to specify '


### PR DESCRIPTION
cray-libsci package update: add an additional function to determine math libraries. The petsc packages dertmines library names with the libs function; e.g. from the petsc package: `value=spec[spacklibname].libs.joined()`