### PR TITLE
Enzo: building extra tools, optimization flag and gcc 10.2 fix

### DIFF
--- a/var/spack/repos/builtin/packages/enzo/package.py
+++ b/var/spack/repos/builtin/packages/enzo/package.py
@@ -60,9 +60,15 @@ class Enzo(MakefilePackage):
             make('opt-high')
             make('show-config')
             make()
+        with working_dir('src/inits'):
+            make()
+        with working_dir('src/ring'):
+            make()
 
     def install(self, spec, prefix):
         install_tree('bin', prefix.bin)
         install_tree('doc', prefix.doc)
         install_tree('input', prefix.input)
         install_tree('run', prefix.run)
+        install('src/ring/ring.exe', prefix.bin)
+

--- a/var/spack/repos/builtin/packages/enzo/package.py
+++ b/var/spack/repos/builtin/packages/enzo/package.py
@@ -70,5 +70,6 @@ class Enzo(MakefilePackage):
         install_tree('doc', prefix.doc)
         install_tree('input', prefix.input)
         install_tree('run', prefix.run)
-        install('src/ring/ring.exe', prefix.bin)
+        with working_dir(join_path('src', 'ring')):
+            install('ring.exe', join_path(prefix.bin, 'ring'))
 

--- a/var/spack/repos/builtin/packages/enzo/package.py
+++ b/var/spack/repos/builtin/packages/enzo/package.py
@@ -23,7 +23,8 @@ class Enzo(MakefilePackage):
 
     variant(
         'opt', default='high', 
-        description='Optimization, some compilers do not produce stable code with high+ optimizations',
+        description='Optimization, ' + \
+                'some compilers do not produce stable code with high+ optimizations',
         values=('warn', 'debug', 'cudadebug', 'high', 'aggressive'), 
         multi=False
     )


### PR DESCRIPTION
This PR has three things

1. Built extra tools, namely inits and ring. Both needed for simulations.
2. Added optimization flag many new compilers do not produce stable code. I.e. with high and aggressive optimization some things diverges.
  *. In my test case gcc 9.3 and 10.2 failed to complete simulation if compiled with high or aggressive optimization
3. A fix for compiling with gcc 10.2 fix, original error message:
```
Error: Type mismatch in argument 'ispec' at (1); passed INTEGER(4) to INTEGER(8)
```

-Nikolay