### PR TITLE
Enzo: building extra tools, optimization flag and gcc 10.2 fix

### DIFF
--- a/var/spack/repos/builtin/packages/enzo/package.py
+++ b/var/spack/repos/builtin/packages/enzo/package.py
@@ -60,9 +60,15 @@ class Enzo(MakefilePackage):
             make('opt-high')
             make('show-config')
             make()
+        with working_dir('src/inits'):
+            make()
+        with working_dir('src/ring'):
+            make()
 
     def install(self, spec, prefix):
         install_tree('bin', prefix.bin)
         install_tree('doc', prefix.doc)
         install_tree('input', prefix.input)
         install_tree('run', prefix.run)
+        install('src/ring/ring.exe', prefix.bin)
+

--- a/var/spack/repos/builtin/packages/enzo/package.py
+++ b/var/spack/repos/builtin/packages/enzo/package.py
@@ -62,13 +62,6 @@ class Enzo(MakefilePackage):
             filter_file('^LOCAL_HYPRE_INSTALL.*',
                         'LOCAL_HYPRE_INSTALL =',
                         'Make.mach.spack')
-            if spec.satisfies('%gcc@10.2.0:'):
-                filter_file(r'^MACH_FFLAGS\s*=\s*',
-                            'MACH_FFLAGS   = -fallow-argument-mismatch ',
-                            'Make.mach.spack')
-                filter_file(r'^MACH_F90FLAGS\s*=\s*',
-                            'MACH_F90FLAGS = -fallow-argument-mismatch ',
-                            'Make.mach.spack')
 
     def build(self, spec, prefix):
         with working_dir('src/enzo'):
@@ -86,5 +79,4 @@ class Enzo(MakefilePackage):
         install_tree('doc', prefix.doc)
         install_tree('input', prefix.input)
         install_tree('run', prefix.run)
-        with working_dir(join_path('src', 'ring')):
-            install('ring.exe', join_path(prefix.bin, 'ring'))
+        install(join_path('src', 'ring', 'ring.exe'), join_path(prefix.bin, 'ring'))

--- a/var/spack/repos/builtin/packages/enzo/package.py
+++ b/var/spack/repos/builtin/packages/enzo/package.py
@@ -22,9 +22,10 @@ class Enzo(MakefilePackage):
     depends_on('sse2neon', when='target=aarch64:')
 
     variant(
-        'opt', default='high', 
-        description='Optimization, some compilers do not produce stable code with high+ optimizations',
-        values=('warn', 'debug', 'cudadebug', 'high', 'aggressive'), 
+        'opt', default='high',
+        description='Optimization, some compilers do not ' +
+                    'produce stable code with high+ optimizations',
+        values=('warn', 'debug', 'cudadebug', 'high', 'aggressive'),
         multi=False
     )
 
@@ -87,4 +88,3 @@ class Enzo(MakefilePackage):
         install_tree('run', prefix.run)
         with working_dir(join_path('src', 'ring')):
             install('ring.exe', join_path(prefix.bin, 'ring'))
-

--- a/var/spack/repos/builtin/packages/enzo/package.py
+++ b/var/spack/repos/builtin/packages/enzo/package.py
@@ -70,5 +70,6 @@ class Enzo(MakefilePackage):
         install_tree('doc', prefix.doc)
         install_tree('input', prefix.input)
         install_tree('run', prefix.run)
-        install('src/ring/ring.exe', prefix.bin)
+        with working_dir(join_path('src', 'ring')):
+            install('ring.exe', join_path(prefix.bin, 'ring'))
 


### PR DESCRIPTION
This PR has three things

1. Built extra tools, namely inits and ring. Both needed for simulations.
2. Added optimization flag many new compilers do not produce stable code. I.e. with high and aggressive optimization some things diverges.
  *. In my test case gcc 9.3 and 10.2 failed to complete simulation if compiled with high or aggressive optimization
3. A fix for compiling with gcc 10.2 fix, original error message:
```
Error: Type mismatch in argument 'ispec' at (1); passed INTEGER(4) to INTEGER(8)
```

-Nikolay

PS: same as https://github.com/spack/spack/pull/25397 , was having some difficulties with PR system