### PR TITLE
Deactivate previous env before activating new one

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -23,6 +23,7 @@ import spack.environment as ev
 import spack.environment.shell
 import spack.schema.env
 import spack.util.string as string
+from spack.util.environment import EnvironmentModifications
 
 description = "manage virtual environments"
 section = "environments"
@@ -115,42 +116,46 @@ def env_activate(args):
     # Temporary environment
     if args.temp:
         env = create_temp_env_directory()
-        spack_env = os.path.abspath(env)
-        short_name = os.path.basename(spack_env)
+        env_path = os.path.abspath(env)
+        short_name = os.path.basename(env_path)
         ev.Environment(env).write(regenerate=False)
 
     # Named environment
     elif ev.exists(env_name_or_dir) and not args.dir:
-        spack_env = ev.root(env_name_or_dir)
+        env_path = ev.root(env_name_or_dir)
         short_name = env_name_or_dir
 
     # Environment directory
     elif ev.is_env_dir(env_name_or_dir):
-        spack_env = os.path.abspath(env_name_or_dir)
-        short_name = os.path.basename(spack_env)
+        env_path = os.path.abspath(env_name_or_dir)
+        short_name = os.path.basename(env_path)
 
     else:
         tty.die("No such environment: '%s'" % env_name_or_dir)
 
     env_prompt = '[%s]' % short_name
 
-    if spack_env == os.environ.get('SPACK_ENV'):
-        tty.debug("Environment is already active")
-        return
+    # Deactivate the current environment first.  We don't properly support
+    # stacked environments at the moment.
+    if ev.active_environment() is None:
+        cmds = ''
+        env_mods = EnvironmentModifications()
+    else:
+        cmds = spack.environment.shell.deactivate_header(shell=args.shell)
+        env_mods = spack.environment.shell.deactivate()
 
     # Activate new environment
-    active_env = ev.Environment(spack_env)
-    cmds = spack.environment.shell.activate_header(
+    active_env = ev.Environment(env_path)
+    cmds += spack.environment.shell.activate_header(
         env=active_env,
         shell=args.shell,
         prompt=env_prompt if args.prompt else None
     )
-    env_mods = spack.environment.shell.activate(
+    env_mods.extend(spack.environment.shell.activate(
         env=active_env,
         add_view=args.with_view
-    )
+    ))
     cmds += env_mods.shell_modifications(args.shell)
-
     sys.stdout.write(cmds)
 
 
@@ -181,10 +186,10 @@ def env_deactivate(args):
 
     # Error out when -e, -E, -D flags are given, cause they are ambiguous.
     if args.env or args.no_env or args.env_dir:
-        tty.die('Calling spack env deactivate with --env, --env-dir and --no-env '
+        tty.die('Calling spack env activate with --env, --env-dir and --no-env '
                 'is ambiguous')
 
-    if 'SPACK_ENV' not in os.environ:
+    if ev.active_environment() is None:
         tty.die('No environment is currently active.')
 
     cmds = spack.environment.shell.deactivate_header(args.shell)

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -135,8 +135,7 @@ def env_activate(args):
 
     env_prompt = '[%s]' % short_name
 
-    # Deactivate the current environment first.  We don't properly support
-    # stacked environments at the moment.
+    # We only support one active environment at a time, so deactivate the current one.
     if ev.active_environment() is None:
         cmds = ''
         env_mods = EnvironmentModifications()

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -185,7 +185,7 @@ def env_deactivate(args):
 
     # Error out when -e, -E, -D flags are given, cause they are ambiguous.
     if args.env or args.no_env or args.env_dir:
-        tty.die('Calling spack env activate with --env, --env-dir and --no-env '
+        tty.die('Calling spack env deactivate with --env, --env-dir and --no-env '
                 'is ambiguous')
 
     if ev.active_environment() is None:

--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -134,7 +134,11 @@ def activate(env, use_env_repo=False, add_view=True):
 
 def deactivate():
     """
-    Deactivate an environment and collect corresponding environment modifications
+    Deactivate an environment and collect corresponding environment modifications.
+
+    Note: unloads the environment in its current state, not in the state it was
+        loaded in, meaning that specs that were removed from the spack environment
+        after activation are not unloaded.
 
     Returns:
         spack.util.environment.EnvironmentModifications: Environment variables

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -167,8 +167,8 @@ end
 
 
 #
-# Ensure that a string is not in the output of a command.
-# Suppresses output on success.
+# Ensure that a string is not in the output of a command. The command must have a 0 exit
+# status to guard against false positives. Suppresses output on success.
 # On failure, echo the exit code and output.
 #
 function spt_does_not_contain
@@ -179,17 +179,24 @@ function spt_does_not_contain
 
     set -l output ($remaining_args 2>&1)
 
-    if not echo "$output" | string match -q -r ".*$target_string.*"
+    # Save the command result
+    set cmd_status $status
+
+    if test $cmd_status -ne 0
+        fail
+        echo_red "Command exited with error $cmd_status."
+    else if not echo "$output" | string match -q -r ".*$target_string.*"
         pass
+        return
     else
         fail
         echo_red "'$target_string' was in the output."
-        if test -n "$output"
-            echo_msg "Output:"
-            echo "$output"
-        else
-            echo_msg "No output."
-        end
+    end
+    if test -n "$output"
+        echo_msg "Output:"
+        echo "$output"
+    else
+        echo_msg "No output."
     end
 end
 

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -70,13 +70,13 @@ b_module=$(spack -m module tcl find b)
 # Create a test environment for testing environment commands
 echo "Creating a mock environment"
 spack env create spack_test_env
-test_env_location=$(spack location -e spack_test_env)
+spack env create spack_test_2_env
 
 # Ensure that we uninstall b on exit
 cleanup() {
     echo "Removing test environment before exiting."
     spack env deactivate 2>&1 > /dev/null
-    spack env rm -y spack_test_env
+    spack env rm -y spack_test_env spack_test_2_env
 
     title "Cleanup"
     echo "Removing test packages before exiting."
@@ -179,3 +179,9 @@ spack env activate --temp
 is_set SPACK_ENV
 spack env deactivate
 is_not_set SPACK_ENV
+
+echo "Testing spack env activate repeatedly"
+spack env activate spack_test_env
+spack env activate spack_test_2_env
+contains "spack_test_2_env" sh -c 'echo $PATH'
+does_not_contain "spack_test_env" sh -c 'echo $PATH'

--- a/share/spack/qa/test-framework.sh
+++ b/share/spack/qa/test-framework.sh
@@ -133,8 +133,8 @@ contains() {
 }
 
 #
-# Ensure that a string is not in the output of a command.
-# Suppresses output on success.
+# Ensure that a string is not in the output of a command. The command must have a 0 exit
+# status to guard against false positives. Suppresses output on success.
 # On failure, echo the exit code and output.
 #
 does_not_contain() {
@@ -145,17 +145,20 @@ does_not_contain() {
     output=$("$@" 2>&1)
     err="$?"
 
-    if [ "${output#*$string}" = "${output}" ]; then
+    if [ "$err" != 0 ]; then
+        fail
+    elif [ "${output#*$string}" = "${output}" ]; then
         pass
+        return
     else
         fail
         echo_red "'$string' was in the output."
-        if [ -n "$output" ]; then
-            echo_msg "Output:"
-            echo "$output"
-        else
-            echo_msg "No output."
-        fi
+    fi
+    if [ -n "$output" ]; then
+        echo_msg "Output:"
+        echo "$output"
+    else
+        echo_msg "No output."
     fi
 }
 

--- a/share/spack/qa/test-framework.sh
+++ b/share/spack/qa/test-framework.sh
@@ -133,6 +133,33 @@ contains() {
 }
 
 #
+# Ensure that a string is not in the output of a command.
+# Suppresses output on success.
+# On failure, echo the exit code and output.
+#
+does_not_contain() {
+    string="$1"
+    shift
+
+    printf "'%s' output does not contain '$string' ... " "$*"
+    output=$("$@" 2>&1)
+    err="$?"
+
+    if [ "${output#*$string}" = "${output}" ]; then
+        pass
+    else
+        fail
+        echo_red "'$string' was in the output."
+        if [ -n "$output" ]; then
+            echo_msg "Output:"
+            echo "$output"
+        else
+            echo_msg "No output."
+        fi
+    fi
+}
+
+#
 # Ensure that a variable is set.
 #
 is_set() {


### PR DESCRIPTION
Currently on develop you can run `spack env activate` multiple times to switch
between environments, but they leave traces, even though Spack only supports
one active environment at a time.

Currently:

```
$ spack env create a
$ spack env create b
$ spack env activate -p a
[a] $ spack env activate -p b
[b] [a] $ spack env activate -p a
[a] [b] [a] $ echo $MANPATH | tr ":" "\n"
/path/to/environments/a/.spack-env/view/share/man
/path/to/environments/a/.spack-env/view/man
/path/to/environments/b/.spack-env/view/share/man
/path/to/environments/b/.spack-env/view/man
```

This PR fixes that by deactivating the previous environment before activating a new one (basically merging env modifications for deactiviate + activate and applying them after the shell "headers" for activation / deactivation)

```
$ spack env activate -p a
[a] $ spack env activate -p b
[b] $ spack env activate -p a
[a] $ echo $MANPATH | tr ":" "\n"
/path/to/environments/a/.spack-env/view/share/man
/path/to/environments/a/.spack-env/view/man
```

With this PR shell modifications work like this:

1. Activating a new environment with no prior environment activated:

```console
$ spack env activate --sh -p a
export SPACK_ENV=/environments/a;
alias despacktivate='spack env deactivate';
if [ -z ${SPACK_OLD_PS1+x} ]; then
    if [ -z ${PS1+x} ]; then
        PS1='$$$$';
    fi;
    export SPACK_OLD_PS1="${PS1}";
fi;
export PS1="[a]  ${PS1}";
export CMAKE_PREFIX_PATH=/environments/a/.spack-env/view;
export MANPATH=/environments/a/.spack-env/view/share/man:/environments/a/.spack-env/view/man;
export PATH='/environments/a/.spack-env/view/bin:/usr/local/go/bin:~/.cargo/bin:/home/harmen/bin:/home/harmen/spack/bin:/home/harmen/clingo/.spack-env/view/bin:/home/harmen/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin';
export ACLOCAL_PATH=/environments/a/.spack-env/view/share/aclocal;
export PKG_CONFIG_PATH=/environments/a/.spack-env/view/share/pkgconfig:/environments/a/.spack-env/view/lib64/pkgconfig:/environments/a/.spack-env/view/lib/pkgconfig;
```

2. "Reactivating" the environment (usually a no-op, but it will also modify the environment variables in case you somehow unset them):

```console
$ spack env activate -p a
[a] $ spack env activate --sh a
if [ ! -z ${SPACK_ENV+x} ]; then
unset SPACK_ENV; export SPACK_ENV;
fi;
unalias despacktivate;
if [ ! -z ${SPACK_OLD_PS1+x} ]; then
    if [ "$SPACK_OLD_PS1" = '$$$$' ]; then
        unset PS1; export PS1;
    else
        export PS1="$SPACK_OLD_PS1";
    fi;
    unset SPACK_OLD_PS1; export SPACK_OLD_PS1;
fi;
export SPACK_ENV=/environments/a;
alias despacktivate='spack env deactivate';
if [ -z ${SPACK_OLD_PS1+x} ]; then
    if [ -z ${PS1+x} ]; then
        PS1='$$$$';
    fi;
    export SPACK_OLD_PS1="${PS1}";
fi;
export PS1="[a]  ${PS1}";
```

3. Switching environments from `a` to `b` (undoes env a, applies b):

```console
if [ ! -z ${SPACK_ENV+x} ]; then
unset SPACK_ENV; export SPACK_ENV;
fi;
unalias despacktivate;
if [ ! -z ${SPACK_OLD_PS1+x} ]; then
    if [ "$SPACK_OLD_PS1" = '$$$$' ]; then
        unset PS1; export PS1;
    else
        export PS1="$SPACK_OLD_PS1";
    fi;
    unset SPACK_OLD_PS1; export SPACK_OLD_PS1;
fi;
export SPACK_ENV=/environments/b;
alias despacktivate='spack env deactivate';
if [ -z ${SPACK_OLD_PS1+x} ]; then
    if [ -z ${PS1+x} ]; then
        PS1='$$$$';
    fi;
    export SPACK_OLD_PS1="${PS1}";
fi;
export PS1="[b]  ${PS1}";
export PKG_CONFIG_PATH=/environments/b/.spack-env/view/share/pkgconfig:/environments/b/.spack-env/view/lib64/pkgconfig:/environments/b/.spack-env/view/lib/pkgconfig;
export LD_LIBRARY_PATH=/environments/b/.spack-env/view/lib64:/environments/b/.spack-env/view/lib;
export PATH='/environments/b/.spack-env/view/bin:/usr/local/go/bin:~/.cargo/bin:/home/harmen/bin:/home/harmen/spack/bin:/home/harmen/clingo/.spack-env/view/bin:/home/harmen/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin';
export ACLOCAL_PATH=/environments/b/.spack-env/view/share/aclocal;
export MANPATH=/environments/b/.spack-env/view/share/man:/environments/b/.spack-env/view/man;
export CMAKE_PREFIX_PATH=/environments/b/.spack-env/view;
```
