### PR TITLE
Remove handling for deprecated module commands

### DIFF
--- a/lib/spack/spack/cmd/module.py
+++ b/lib/spack/spack/cmd/module.py
@@ -3,10 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import argparse
 from typing import Callable, Dict  # novm
-
-import llnl.util.tty as tty
 
 import spack.cmd.modules.lmod
 import spack.cmd.modules.tcl
@@ -18,49 +15,12 @@ level = "short"
 
 _subcommands = {}  # type: Dict[str, Callable]
 
-_deprecated_commands = ('refresh', 'find', 'rm', 'loads')
-
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='module_command')
     spack.cmd.modules.lmod.add_command(sp, _subcommands)
     spack.cmd.modules.tcl.add_command(sp, _subcommands)
 
-    for name in _deprecated_commands:
-        add_deprecated_command(sp, name)
 
-
-def add_deprecated_command(subparser, name):
-    parser = subparser.add_parser(name)
-    parser.add_argument(
-        '-m', '--module-type', help=argparse.SUPPRESS,
-        choices=spack.modules.module_types.keys(), action='append'
-    )
-
-
-def handle_deprecated_command(args, unknown_args):
-    command = args.module_command
-    unknown = ' '.join(unknown_args)
-
-    module_types = args.module_type or ['tcl']
-
-    msg = '`spack module {0} {1}` has moved. Use these commands instead:\n'
-    msg = msg.format(command, ' '.join('-m ' + x for x in module_types))
-    for x in module_types:
-        msg += '\n\t$ spack module {0} {1} {2}'.format(x, command, unknown)
-    msg += '\n'
-    tty.die(msg)
-
-
-def module(parser, args, unknown_args):
-
-    # Here we permit unknown arguments to intercept deprecated calls
-    if args.module_command in _deprecated_commands:
-        handle_deprecated_command(args, unknown_args)
-
-    # Fail if unknown arguments are present, once we excluded a deprecated
-    # command
-    if unknown_args:
-        tty.die('unrecognized arguments: {0}'.format(' '.join(unknown_args)))
-
+def module(parser, args):
     _subcommands[args.module_command](parser, args)

--- a/lib/spack/spack/test/cmd/module.py
+++ b/lib/spack/spack/test/cmd/module.py
@@ -66,17 +66,6 @@ def test_exit_with_failure(database, module_type, failure_args):
 
 
 @pytest.mark.db
-@pytest.mark.parametrize('deprecated_command', [
-    ('refresh', '-m', 'tcl', 'mpileaks'),
-    ('rm', '-m', 'tcl', '-m', 'lmod', 'mpileaks'),
-    ('find', 'mpileaks'),
-])
-def test_deprecated_command(database, deprecated_command):
-    with pytest.raises(spack.main.SpackCommandError):
-        module(*deprecated_command)
-
-
-@pytest.mark.db
 def test_remove_and_add(database, module_type):
     """Tests adding and removing a tcl module file."""
 


### PR DESCRIPTION
The commands have been deprecated in #7098, and have been failing with an error message since then. Cleaning the code since it is unlikely that somebody is still using them.