### PR TITLE
gromacs-chain-coordinate: new package

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -28,6 +28,6 @@ class GromacsChainCoordinate(BuiltinGromacs):
             preferred=True)
 
     def __init__(self, spec):
-        super(BuiltinGromacs, self).__init__(spec)
+        super(GromacsChainCoordinate, self).__init__(spec)
 
         self.versions = filter_versions(self.versions, ['main', '2021.2-0.1'])

--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -8,7 +8,7 @@ from spack.pkg.builtin.gromacs import Gromacs as BuiltinGromacs
 
 
 def filter_versions(version_list, allowed_names):
-    return {key: value for key, value in version_list.items() if str(key) in allowed_names}
+    return dict((key, value) for key, value in version_list.items() if str(key) in allowed_names)
 
 
 class GromacsChainCoordinate(BuiltinGromacs):

--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -28,6 +28,6 @@ class GromacsChainCoordinate(BuiltinGromacs):
             preferred=True)
 
     def __init__(self, spec):
-        super().__init__(spec)
+        super(BuiltinGromacs, self).__init__(spec)
 
         self.versions = filter_versions(self.versions, ['main', '2021.2-0.1'])

--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack.pkg.builtin.gromacs import Gromacs as BuiltinGromacs
 
 

--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -1,0 +1,32 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+from spack.pkg.builtin.gromacs import Gromacs as BuiltinGromacs
+
+
+def filter_versions(version_list, allowed_names):
+    return {key: value for key, value in version_list.items() if str(key) in allowed_names}
+
+
+class GromacsChainCoordinate(BuiltinGromacs):
+    """
+    A modification of GROMACS that implements the "chain coordinate", a reaction
+    coordinate for pore formation in membranes and stalk formation between membranes.
+    """
+
+    homepage = 'https://gitlab.com/cbjh/gromacs-chain-coordinate/-/blob/main/README.md'
+    url = 'https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2'
+    git = 'https://gitlab.com/cbjh/gromacs-chain-coordinate.git'
+    maintainers = ['w8jcik']
+
+    version('main', branch='main')
+    version('2021.2-0.1', sha256="879fdd04662370a76408b72c9fbc4aff60a6387b459322ac2700d27359d0dd87",
+            url="https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2", preferred=True)
+
+    def __init__(self, spec):
+        super().__init__(spec)
+
+        self.versions = filter_versions(self.versions, ['main', '2021.2-0.1'])

--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -3,13 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.pkg.builtin.gromacs import Gromacs as BuiltinGromacs
 
 
 def filter_versions(version_list, allowed_names):
-    return dict((key, value) for key, value in version_list.items() if str(key) in allowed_names)
+    return dict((key, value) for key, value in version_list.items()
+                if str(key) in allowed_names)
 
 
 class GromacsChainCoordinate(BuiltinGromacs):

--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -25,7 +25,8 @@ class GromacsChainCoordinate(BuiltinGromacs):
 
     version('main', branch='main')
     version('2021.2-0.1', sha256="879fdd04662370a76408b72c9fbc4aff60a6387b459322ac2700d27359d0dd87",
-            url="https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2", preferred=True)
+            url="https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2",
+            preferred=True)
 
     def __init__(self, spec):
         super().__init__(spec)


### PR DESCRIPTION
# Short story

This pull request adds a package recipe for Gromacs Chain Coordinate (one of Gromacs forks)

- It is reusing part of Gromacs package to avoid duplication. 
- Re-using Gromacs package is not trivial, some problems are described below.
- Other than this, it is tested and recipe looks fine for me.

# Long story

## What is it?

There are at least four forks of Gromacs backed up by publications

- Gromacs FDA https://github.com/HITS-MBM/gromacs-fda
- Gromacs RAMD https://github.com/HITS-MCM/gromacs-ramd
- Gromacs SWAXS https://gitlab.com/cbjh/gromacs-swaxs
- Gromacs Chain Coordinate https://gitlab.com/cbjh/gromacs-chain-coordinate

This Pull request adds a package for Gromacs Chain Coordinate. 

My goal is to add all four of them, but let's start with Gromacs Chain Coordinate.

## Problem to solve

- Gromacs Chain Coordinate builds in the same way as upstream Gromacs.
- Just the Git repository is different. I am trying to inherit and override versions/urls.
- There is no API for removing versions.

## Does it work?

```
$ spack versions gromacs-chain-coordinate
==> Safe versions (already checksummed):
  main  2021.2-0.1
```

```
$ spack install gromacs-chain-coordinate+cuda
...
==> Installing gromacs-chain-coordinate-2021.2-0.1-5pcghxnbfaxuqykgdkxfjlwry3phms6y
==> No binary for gromacs-chain-coordinate-2021.2-0.1-5pcghxnbfaxuqykgdkxfjlwry3phms6y found: installing from source
==> Using cached archive: /data/shared/spack/root/var/spack/cache/_source-cache/archive/87/879fdd04662370a76408b72c9fbc4aff60a6387b459322ac2700d27359d0dd87.tar.bz2
==> Ran patch() for gromacs-chain-coordinate
==> gromacs-chain-coordinate: Executing phase: 'cmake'
==> gromacs-chain-coordinate: Executing phase: 'build'
==> gromacs-chain-coordinate: Executing phase: 'install'
==> gromacs-chain-coordinate: Successfully installed gromacs-chain-coordinate-2021.2-0.1-5pcghxnbfaxuqykgdkxfjlwry3phms6y
  Fetch: 0.08s.  Build: 6m 47.03s.  Total: 6m 47.12s.
[+] /data/shared/spack/root/opt/spack/linux-archrolling-broadwell/gcc-8.4.0/gromacs-chain-coordinate-2021.2-0.1-5pcghxnbfaxuqykgdkxfjlwry3phms6y
$ module load gromacs-chain-coordinate@2021.2-0.1-mpi
$ which gmx_mpi
/data/shared/spack/root/opt/spack/linux-archrolling-broadwell/gcc-8.4.0/gromacs-chain-coordinate-2021.2-0.1-5pcghxnbfaxuqykgdkxfjlwry3phms6y/bin/gmx_mpi
```

So yes, normal Gromacs versions are not visible and the package installs correctly.

## Inheritance dillema

With current implementation, partial inheritance is used (calling some procedures of parent class, without real inheritance).

Is this a correct way to do it?

Three other options are
1) Copy entire Gromacs package – But we don't like duplication. More maintenance, bad by principle.
2) Add it to Gromacs package – I think it is not logical to do so, as these are forks, also Gromacs package is already complicated
3) Use full inheritance and reset versions

```python
# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
# Spack Project Developers. See the top-level COPYRIGHT file for details.
#
# SPDX-License-Identifier: (Apache-2.0 OR MIT)

from spack.pkg.builtin.gromacs import Gromacs as BuiltinGromacs


def filter_versions(version_list, allowed_names):
    return dict((key, value) for key, value in version_list.items()
                if str(key) in allowed_names)


class GromacsChainCoordinate(BuiltinGromacs):
    """
    A modification of GROMACS that implements the "chain coordinate", a reaction
    coordinate for pore formation in membranes and stalk formation between membranes.
    """

    homepage = 'https://gitlab.com/cbjh/gromacs-chain-coordinate/-/blob/main/README.md'
    url = 'https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2'
    git = 'https://gitlab.com/cbjh/gromacs-chain-coordinate.git'
    maintainers = ['w8jcik']

    version('main', branch='main')
    version('2021.2-0.1', sha256="879fdd04662370a76408b72c9fbc4aff60a6387b459322ac2700d27359d0dd87",
            url="https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2",
            preferred=True)

    def __init__(self, spec):
        super(GromacsChainCoordinate, self).__init__(spec)

        self.versions = filter_versions(self.versions, ['main', '2021.2-0.1'])
```

- This is less complicated.
- Unfortunately it is using private interface (overriding `versions` property).
- It is also less flexible if we want to have some alterations.
- Python 2.7 tests fail with something about pickling and I wasn't able to fix it

```python
TypeError: a class that defines __slots__ without defining __getstate__ cannot be pickled
```
https://github.com/spack/spack/pull/25426/checks?check_run_id=3329234588

Otherwise it works as well.

Is the current implementation fine?
