### PR TITLE
root: add determine_variants

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -328,23 +328,23 @@ class Root(CMakePackage):
 
     @classmethod
     def determine_variants(cls, exes, version_str):
-        variants = []
+        v = [] # list of determined variants 
         # there is a fairly direct mapping between build options ( which
-        # which root-config helpfully outputs) and variants
-        output = Executable('root-config')('--features', output=str, error=str)
-        features = set(output.strip().split(" "))
+        # root-config helpfully outputs) and variants
+        output = Executable(exes[0])('--features', output=str, error=str)
+        f = set(output.strip().split()) # features as reported by root-config
         # only multivalued variant: cxxstd
-        if "cxx11" in features:
-            variants.append("cxxstd=11")
-        elif "cxx14" in features:
-            variants.append("cxxstd=14")
-        elif "cxx17" in features:
-            variants.append("cxxstd=17")
+        if "cxx11" in f:
+            v.append("cxxstd=11")
+        elif "cxx14" in f:
+            v.append("cxxstd=14")
+        elif "cxx17" in f:
+            v.append("cxxstd=17")
 
         # helper function: check if featurename is in features, and if it is,
         # append variantname to variants. featurename may be a list/tuple, in
         # which case the variant is only added if all of them are present
-        def _add_variant_from_feature(variants, features, featurename, variantname):
+        def _add_variant(variants, features, featurename, variantname):
             if isinstance(featurename, str):
                 if featurename in features:
                     variants.append('%s' % variantname)
@@ -356,48 +356,48 @@ class Root(CMakePackage):
                 else:
                     variants.append('~%s' % variantname[1:])
 
-        _add_variant_from_feature(variants, features, 'cocoa', '+aqua')
-        _add_variant_from_feature(variants, features, 'davix', '+davix')
-        _add_variant_from_feature(variants, features, 'dcache', '+dcache')
-        _add_variant_from_feature(variants, features, 'fftw3', '+fftw')
-        _add_variant_from_feature(variants, features, 'fitsio', '+fits')
-        _add_variant_from_feature(variants, features, ('ftgl', 'opengl'), '+opengl')
-        _add_variant_from_feature(variants, features, 'gdml', '+gdml')
-        _add_variant_from_feature(variants, features, 'mathmore', '+math')
-        _add_variant_from_feature(variants, features, 'gviz', '+graphviz')
-        _add_variant_from_feature(variants, features, 'http', '+http')
-        _add_variant_from_feature(variants, features, ('imt', 'tbb'), '+tbb')
-        _add_variant_from_feature(variants, features, 'jemalloc', '+jemalloc')
-        _add_variant_from_feature(variants, features, 'memstat', '+memstat')
-        _add_variant_from_feature(variants, features, ('minuit', 'minuit2'), '+minuit')
-        _add_variant_from_feature(variants, features, 'mlp', '+mlp')
-        _add_variant_from_feature(variants, features, 'mysql', '+mysql')
-        _add_variant_from_feature(variants, features, 'oracle', '+oracle')
-        _add_variant_from_feature(variants, features, 'pgsql', '+postgres')
-        _add_variant_from_feature(variants, features, 'pythia6', '+pythia6')
-        _add_variant_from_feature(variants, features, 'pythia8', '+pythia8')
-        _add_variant_from_feature(variants, features, 'pyroot', '+python')
-        _add_variant_from_feature(variants, features, ('qt', 'qtgsi'), '+qt4')
-        _add_variant_from_feature(variants, features, 'r', '+r')
-        _add_variant_from_feature(variants, features, 'roofit', '+roofit')
-        _add_variant_from_feature(variants, features, ('root7', 'webui'), '+root7')
-        _add_variant_from_feature(variants, features, 'rpath', '+rpath')
-        _add_variant_from_feature(variants, features, 'shadowpw', '+shadow')
-        _add_variant_from_feature(variants, features, 'spectrum', '+spectrum')
-        _add_variant_from_feature(variants, features, 'sqlite', '+sqlite')
-        _add_variant_from_feature(variants, features, 'ssl', '+ssl')
-        _add_variant_from_feature(variants, features, 'table', '+table')
-        _add_variant_from_feature(variants, features, 'thread', '+threads')
-        _add_variant_from_feature(variants, features, 'tmva', '+tmva')
-        _add_variant_from_feature(variants, features, 'unuran', '+unuran')
-        _add_variant_from_feature(variants, features, 'vc', '+vc')
-        _add_variant_from_feature(variants, features, 'vdt', '+vdt')
-        _add_variant_from_feature(variants, features, 'veccore', '+veccore')
-        _add_variant_from_feature(variants, features, 'vmc', '+vmc')
-        _add_variant_from_feature(variants, features, ('x11', 'xft'), '+x')
-        _add_variant_from_feature(variants, features, 'xml', '+xml')
-        _add_variant_from_feature(variants, features, 'xrootd', '+xrootd')
-        return " ".join(variants)
+        _add_variant(v, f, 'cocoa', '+aqua')
+        _add_variant(v, f, 'davix', '+davix')
+        _add_variant(v, f, 'dcache', '+dcache')
+        _add_variant(v, f, 'fftw3', '+fftw')
+        _add_variant(v, f, 'fitsio', '+fits')
+        _add_variant(v, f, ('ftgl', 'opengl'), '+opengl')
+        _add_variant(v, f, 'gdml', '+gdml')
+        _add_variant(v, f, 'mathmore', '+math')
+        _add_variant(v, f, 'gviz', '+graphviz')
+        _add_variant(v, f, 'http', '+http')
+        _add_variant(v, f, ('imt', 'tbb'), '+tbb')
+        _add_variant(v, f, 'jemalloc', '+jemalloc')
+        _add_variant(v, f, 'memstat', '+memstat')
+        _add_variant(v, f, ('minuit', 'minuit2'), '+minuit')
+        _add_variant(v, f, 'mlp', '+mlp')
+        _add_variant(v, f, 'mysql', '+mysql')
+        _add_variant(v, f, 'oracle', '+oracle')
+        _add_variant(v, f, 'pgsql', '+postgres')
+        _add_variant(v, f, 'pythia6', '+pythia6')
+        _add_variant(v, f, 'pythia8', '+pythia8')
+        _add_variant(v, f, 'pyroot', '+python')
+        _add_variant(v, f, ('qt', 'qtgsi'), '+qt4')
+        _add_variant(v, f, 'r', '+r')
+        _add_variant(v, f, 'roofit', '+roofit')
+        _add_variant(v, f, ('root7', 'webui'), '+root7')
+        _add_variant(v, f, 'rpath', '+rpath')
+        _add_variant(v, f, 'shadowpw', '+shadow')
+        _add_variant(v, f, 'spectrum', '+spectrum')
+        _add_variant(v, f, 'sqlite', '+sqlite')
+        _add_variant(v, f, 'ssl', '+ssl')
+        _add_variant(v, f, 'table', '+table')
+        _add_variant(v, f, 'thread', '+threads')
+        _add_variant(v, f, 'tmva', '+tmva')
+        _add_variant(v, f, 'unuran', '+unuran')
+        _add_variant(v, f, 'vc', '+vc')
+        _add_variant(v, f, 'vdt', '+vdt')
+        _add_variant(v, f, 'veccore', '+veccore')
+        _add_variant(v, f, 'vmc', '+vmc')
+        _add_variant(v, f, ('x11', 'xft'), '+x')
+        _add_variant(v, f, 'xml', '+xml')
+        _add_variant(v, f, 'xrootd', '+xrootd')
+        return " ".join(v)
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -328,11 +328,11 @@ class Root(CMakePackage):
 
     @classmethod
     def determine_variants(cls, exes, version_str):
-        v = [] # list of determined variants 
+        v = []  # list of determined variants
         # there is a fairly direct mapping between build options ( which
         # root-config helpfully outputs) and variants
         output = Executable(exes[0])('--features', output=str, error=str)
-        f = set(output.strip().split()) # features as reported by root-config
+        f = set(output.strip().split())  # features as reported by root-config
         # only multivalued variant: cxxstd
         if "cxx11" in f:
             v.append("cxxstd=11")

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -326,6 +326,79 @@ class Root(CMakePackage):
         # into the format used in this recipe (6.22.06)
         return output.strip().replace('/', '.')
 
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        variants = []
+        # there is a fairly direct mapping between build options ( which
+        # which root-config helpfully outputs) and variants
+        output = Executable('root-config')('--features', output=str, error=str)
+        features = set(output.strip().split(" "))
+        # only multivalued variant: cxxstd
+        if "cxx11" in features:
+            variants.append("cxxstd=11")
+        elif "cxx14" in features:
+            variants.append("cxxstd=14")
+        elif "cxx17" in features:
+            variants.append("cxxstd=17")
+
+        # helper function: check if featurename is in features, and if it is,
+        # append variantname to variants. featurename may be a list/tuple, in
+        # which case the variant is only added if all of them are present
+        def _add_variant_from_feature(variants, features, featurename, variantname):
+            if isinstance(featurename, str):
+                if featurename in features:
+                    variants.append('%s' % variantname)
+                else:
+                    variants.append('~%s' % variantname[1:])
+            else:
+                if set(featurename).issubset(features):
+                    variants.append('%s' % variantname)
+                else:
+                    variants.append('~%s' % variantname[1:])
+
+        _add_variant_from_feature(variants, features, 'cocoa', '+aqua')
+        _add_variant_from_feature(variants, features, 'davix', '+davix')
+        _add_variant_from_feature(variants, features, 'dcache', '+dcache')
+        _add_variant_from_feature(variants, features, 'fftw3', '+fftw')
+        _add_variant_from_feature(variants, features, 'fitsio', '+fits')
+        _add_variant_from_feature(variants, features, ('ftgl', 'opengl'), '+opengl')
+        _add_variant_from_feature(variants, features, 'gdml', '+gdml')
+        _add_variant_from_feature(variants, features, 'mathmore', '+math')
+        _add_variant_from_feature(variants, features, 'gviz', '+graphviz')
+        _add_variant_from_feature(variants, features, 'http', '+http')
+        _add_variant_from_feature(variants, features, ('imt', 'tbb'), '+tbb')
+        _add_variant_from_feature(variants, features, 'jemalloc', '+jemalloc')
+        _add_variant_from_feature(variants, features, 'memstat', '+memstat')
+        _add_variant_from_feature(variants, features, ('minuit', 'minuit2'), '+minuit')
+        _add_variant_from_feature(variants, features, 'mlp', '+mlp')
+        _add_variant_from_feature(variants, features, 'mysql', '+mysql')
+        _add_variant_from_feature(variants, features, 'oracle', '+oracle')
+        _add_variant_from_feature(variants, features, 'pgsql', '+postgres')
+        _add_variant_from_feature(variants, features, 'pythia6', '+pythia6')
+        _add_variant_from_feature(variants, features, 'pythia8', '+pythia8')
+        _add_variant_from_feature(variants, features, 'pyroot', '+python')
+        _add_variant_from_feature(variants, features, ('qt', 'qtgsi'), '+qt4')
+        _add_variant_from_feature(variants, features, 'r', '+r')
+        _add_variant_from_feature(variants, features, 'roofit', '+roofit')
+        _add_variant_from_feature(variants, features, ('root7', 'webui'), '+root7')
+        _add_variant_from_feature(variants, features, 'rpath', '+rpath')
+        _add_variant_from_feature(variants, features, 'shadowpw', '+shadow')
+        _add_variant_from_feature(variants, features, 'spectrum', '+spectrum')
+        _add_variant_from_feature(variants, features, 'sqlite', '+sqlite')
+        _add_variant_from_feature(variants, features, 'ssl', '+ssl')
+        _add_variant_from_feature(variants, features, 'table', '+table')
+        _add_variant_from_feature(variants, features, 'thread', '+threads')
+        _add_variant_from_feature(variants, features, 'tmva', '+tmva')
+        _add_variant_from_feature(variants, features, 'unuran', '+unuran')
+        _add_variant_from_feature(variants, features, 'vc', '+vc')
+        _add_variant_from_feature(variants, features, 'vdt', '+vdt')
+        _add_variant_from_feature(variants, features, 'veccore', '+veccore')
+        _add_variant_from_feature(variants, features, 'vmc', '+vmc')
+        _add_variant_from_feature(variants, features, ('x11', 'xft'), '+x')
+        _add_variant_from_feature(variants, features, 'xml', '+xml')
+        _add_variant_from_feature(variants, features, 'xrootd', '+xrootd')
+        return " ".join(variants)
+
     def cmake_args(self):
         spec = self.spec
         define = self.define


### PR DESCRIPTION
mostly serves to increase the size of this  too-short recipe `</joke>`. 

The variants were obviously not written with achieving a one-to-one mapping to roots build options and that's probably a good thing, because mainly they should be for installing root with spack. Even if it is not 100% for this reason, being a bit more accurate when running `spack external find root`  may still prove useful in some scenarios. 
