### PR TITLE
New versions: geant4@10.7.2, geant4-data@10.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -18,6 +18,7 @@ class Geant4Data(BundlePackage):
 
     tags = ['hep']
 
+    version('10.7.2')
     version('10.7.1')
     version('10.7.0')
     version('10.6.3')

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -19,6 +19,7 @@ class Geant4(CMakePackage):
 
     maintainers = ['drbenmorgan']
 
+    version('10.7.2', sha256='593fc85883a361487b17548ba00553501f66a811b0a79039276bb75ad59528cf')
     version('10.7.1', sha256='2aa7cb4b231081e0a35d84c707be8f35e4edc4e97aad2b233943515476955293')
     version('10.7.0', sha256='c991a139210c7f194720c900b149405090058c00beb5a0d2fac5c40c42a262d4')
     version('10.6.3', sha256='bf96d6d38e6a0deabb6fb6232eb00e46153134da645715d636b9b7b4490193d3')
@@ -48,6 +49,7 @@ class Geant4(CMakePackage):
     depends_on('cmake@3.5:', type='build')
     depends_on('cmake@3.8:', type='build', when='@10.6.0:')
 
+    depends_on('geant4-data@10.7.2', when='@10.7.2')
     depends_on('geant4-data@10.7.1', when='@10.7.1')
     depends_on('geant4-data@10.7.0', when='@10.7.0')
     depends_on('geant4-data@10.6.3', when='@10.6.3')


### PR DESCRIPTION
No major changes for this bugfix release, but nevertheless we would like to take advantage of them when 0.17 is tagged :-)

Release notes: https://geant4-data.web.cern.ch/ReleaseNotes/Patch4.10.7-2.txt

Maintainer: @drbenmorgan 