### PR TITLE
Support older py-pygments

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -757,7 +757,7 @@ The output is colored, and written in the style of a git diff. This means that y
 can copy and paste it into a GitHub markdown as a code block with language "diff"
 and it will render nicely! Here is an example:
 
-.. code-block:: markdown
+.. code-block:: md
 
     ```diff
     --- zlib@1.2.11/efzjziyc3dmb5h5u5azsthgbgog5mj7g


### PR DESCRIPTION
`markdown` is only supported since py-pygments@2.8.0:, see
https://github.com/pygments/pygments/commit/9647d2ae506b8e05ebabe9243df707bac901a6a3

Before #25455 building the docs with spack's py-sphinx would simply error about a non-existing markdown lexer.

Let's allow old versions too

(Ping @vsoch)
