### PR TITLE
claw: new version 2.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/claw/package.py
+++ b/var/spack/repos/builtin/packages/claw/package.py
@@ -13,17 +13,17 @@ class Claw(CMakePackage):
 
     homepage = 'https://claw-project.github.io/'
     git      = 'https://github.com/claw-project/claw-compiler.git'
-    maintainers = ['clementval']
+    maintainers = ['clementval', 'skosukhin']
 
-    version('master', branch='master', submodules=True)
-    version('2.0.2', commit='8c012d58484d8caf79a4fe45597dc74b4367421c', submodules=True)
-    version('2.0.1', commit='f5acc929df74ce66a328aa4eda9cc9664f699b91', submodules=True)
-    version('2.0',   commit='53e705b8bfce40a5c5636e8194a7622e337cf4f5', submodules=True)
-    version('1.2.3', commit='eaf5e5fb39150090e51bec1763170ce5c5355198', submodules=True)
-    version('1.2.2', commit='fc27a267eef9f412dd6353dc0b358a05b3fb3e16', submodules=True)
-    version('1.2.1', commit='939989ab52edb5c292476e729608725654d0a59a', submodules=True)
-    version('1.2.0', commit='fc9c50fe02be97b910ff9c7015064f89be88a3a2', submodules=True)
-    version('1.1.0', commit='16b165a443b11b025a77cad830b1280b8c9bcf01', submodules=True)
+    version('2.0.3', tag='v2.0.3', submodules=True)
+    version('2.0.2', tag='v2.0.2', submodules=True)
+    version('2.0.1', tag='v2.0.1', submodules=True)
+    version('2.0',   tag='v2.0', submodules=True)
+    version('1.2.3', tag='v1.2.3', submodules=True)
+    version('1.2.2', tag='v1.2.2', submodules=True)
+    version('1.2.1', tag='v1.2.1', submodules=True)
+    version('1.2.0', tag='v1.2.0', submodules=True)
+    version('1.1.0', tag='v1.1.0', submodules=True)
 
     depends_on('cmake@3.0:', type='build')
     depends_on('ant@1.9:', type='build')
@@ -37,7 +37,7 @@ class Claw(CMakePackage):
     # Enable parsing of source files with calls to TRACEBACKQQ from the Intel
     # Fortran run-time library:
     patch('https://github.com/claw-project/claw-compiler/commit/e9fe6dbd291454ce34dd58f21d102f7f1bdff874.patch',
-          sha256='44a3e17bf6e972db9760fc50bc0948309ee441dab1cdb11816ba675de0138549',
+          sha256='82033a576966143f3b1fd66f4d5b5604704b615b3e08afa4901fc1c29caefbe2',
           when='@:2.0.2%intel')
 
     # Fix the dependency preprocessing for compilers that cannot use


### PR DESCRIPTION
1. Add version `2.0.3`.
2. Remove version `master` since the building procedure has changed (to be reintroduced later together with version `2.1.0`).
3. Replace commits with tags in the `version` directives.
4. Update hash sum of the intel-related patch. The difference is due to the change of the patch file that we get from GitHub:
    ```patch
    @@ -13 +13 @@
    -index ce33ffed..7ddbfcff 100644
    +index ce33ffed3..7ddbfcff7 100644
    @@ -61 +61 @@
    -index 00000000..7ac4c989
    +index 000000000..7ac4c989f
    @@ -98 +98 @@
    -index 7ac4c989..a59433f9 100644
    +index 7ac4c989f..a59433f94 100644
    ```
5. Add myself as a maintainer.