### PR TITLE
ParaView: disable externals for fmt and exprtk

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -285,7 +285,9 @@ class Paraview(CMakePackage, CudaPackage):
         if spec.satisfies('@5.10:'):
             cmake_args.extend([
                 '-DVTK_MODULE_USE_EXTERNAL_ParaView_vtkcatalyst:BOOL=OFF',
-                '-DVTK_MODULE_USE_EXTERNAL_VTK_ioss:BOOL=OFF'
+                '-DVTK_MODULE_USE_EXTERNAL_VTK_ioss:BOOL=OFF',
+                '-DVTK_MODULE_USE_EXTERNAL_VTK_exprtk:BOOL=OFF',
+                '-DVTK_MODULE_USE_EXTERNAL_VTK_fmt:BOOL=OFF'
             ])
 
         if spec.satisfies('@:5.7') and spec['cmake'].satisfies('@3.17:'):


### PR DESCRIPTION
Fixes #25387 

Let ParaView build `fmt` and `exprtk` third-party libraries for VTK. There is no spack package for `exprtk` and I could not get the `fmt` spack package to build with `intel@19.0.4` which is an important compiler for LANL.

Tested on:
```console
* **Spack:** 0.16.2-3947-f444303ce5
* **Python:** 3.6.3
* **Platform:** linux-rhel7-broadwell
* **Concretizer:** original
``` 