### PR TITLE
rsbench: Version bump and added compiler support

### DIFF
--- a/var/spack/repos/builtin/packages/rsbench/package.py
+++ b/var/spack/repos/builtin/packages/rsbench/package.py
@@ -14,26 +14,38 @@ class Rsbench(MakefilePackage):
     homepage = "https://github.com/ANL-CESAR/RSBench"
     url = "https://github.com/ANL-CESAR/RSBench/archive/v2.tar.gz"
 
+    version('12', sha256='2e437dbdaf7bf12bb9ade429d46a9e74fd519fc4686777a452770790d0546499')
     version('2', sha256='1e97a38a863836e98cedc5cc669f8fdcaed905fafdc921d2bce32319b3e157ff')
     version('0', sha256='95c06cf4cb6f396f9964d5e4b58a477bf9d7131cd39804480f1cb74e9310b271')
 
     tags = ['proxy-app']
 
-    build_directory = 'src'
+    # To-Do: Add build support for other parallelism versions in v12: 
+    # CUDA, Sycl, OpenCL, OpenMP Offload 
+
+    @property
+    def build_directory(self):
+        if self.spec.satisfies('@:2'):
+            return 'src'
+        else:
+            return 'openmp-threading'
+    
 
     @property
     def build_targets(self):
         targets = []
 
-        cflags = '-std=gnu99'
+        cflags = '-std=gnu99 -O3'
         ldflags = '-lm'
 
         if self.compiler.name == 'gcc':
             cflags += ' -ffast-math '
         elif self.compiler.name == 'intel':
             cflags += ' -xhost -ansi-alias -no-prec-div '
-        elif self.compiler.name == 'pgi':
+        elif self.compiler.name == 'nvhpc':
             cflags += ' -fastsse '
+        elif self.compiler.name == 'arm':
+            cflags += ' -ffast-math '
 
         cflags += self.compiler.openmp_flag
 
@@ -44,4 +56,4 @@ class Rsbench(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
-        install('src/rsbench', prefix.bin)
+        install('{0}/rsbench'.format(self.build_directory), prefix.bin)

--- a/var/spack/repos/builtin/packages/rsbench/package.py
+++ b/var/spack/repos/builtin/packages/rsbench/package.py
@@ -42,7 +42,7 @@ class Rsbench(MakefilePackage):
             cflags += ' -ffast-math '
         elif self.compiler.name == 'intel':
             cflags += ' -xhost -ansi-alias -no-prec-div '
-        elif self.compiler.name == 'nvhpc':
+        elif self.compiler.name == 'pgi' or self.compiler.name == 'nvhpc':
             cflags += ' -fastsse '
         elif self.compiler.name == 'arm':
             cflags += ' -ffast-math '
@@ -56,4 +56,4 @@ class Rsbench(MakefilePackage):
 
     def install(self, spec, prefix):
         mkdir(prefix.bin)
-        install('{0}/rsbench'.format(self.build_directory), prefix.bin)
+        install(join_path(self.build_directory, 'rsbench'), prefix.bin)

--- a/var/spack/repos/builtin/packages/rsbench/package.py
+++ b/var/spack/repos/builtin/packages/rsbench/package.py
@@ -27,8 +27,7 @@ class Rsbench(MakefilePackage):
     def build_directory(self):
         if self.spec.satisfies('@:2'):
             return 'src'
-        else:
-            return 'openmp-threading'
+        return 'openmp-threading'
 
     @property
     def build_targets(self):

--- a/var/spack/repos/builtin/packages/rsbench/package.py
+++ b/var/spack/repos/builtin/packages/rsbench/package.py
@@ -20,8 +20,8 @@ class Rsbench(MakefilePackage):
 
     tags = ['proxy-app']
 
-    # To-Do: Add build support for other parallelism versions in v12: 
-    # CUDA, Sycl, OpenCL, OpenMP Offload 
+    # To-Do: Add build support for other parallelism versions in v12:
+    # CUDA, Sycl, OpenCL, OpenMP Offload
 
     @property
     def build_directory(self):
@@ -29,7 +29,6 @@ class Rsbench(MakefilePackage):
             return 'src'
         else:
             return 'openmp-threading'
-    
 
     @property
     def build_targets(self):


### PR DESCRIPTION
Bumped to version12 (and handle the src vs threading-openmp like XSBench).

Added support for Arm compiler and NVHPC via the optimised flags.