### PR TITLE
py-torch: add v1.8.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -24,6 +24,7 @@ class PyTorch(PythonPackage, CudaPackage):
 
     version('master', branch='master', submodules=True)
     version('1.9.0', tag='v1.9.0', submodules=True)
+    version('1.8.2', tag='v1.8.2', submodules=True)
     version('1.8.1', tag='v1.8.1', submodules=True)
     version('1.8.0', tag='v1.8.0', submodules=True)
     version('1.7.1', tag='v1.7.1', submodules=True)


### PR DESCRIPTION
Successfully builds on Ubuntu 18.04 with Python 3.8.11 and GCC 7.5.0.

https://github.com/pytorch/pytorch/releases/tag/v1.8.2