### PR TITLE
[WIP] Very early (and so far failed) attempt to convert pango to MesonPackage

### DIFF
--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Pango(AutotoolsPackage):
+class Pango(MesonPackage):
     """Pango is a library for laying out and rendering of text, with
        an emphasis on internationalization. It can be used anywhere
        that text layout is needed, though most of the work on Pango so
@@ -30,6 +30,7 @@ class Pango(AutotoolsPackage):
 
     variant('X', default=False, description="Enable an X toolkit")
 
+    depends_on("meson@0.54:", type="build")
     depends_on("pkgconfig@0.9.0:", type="build")
     depends_on("harfbuzz")
     depends_on("cairo+ft+fc")
@@ -68,9 +69,6 @@ class Pango(AutotoolsPackage):
         args.append('GTKDOC_REBASE={0}'.format(true))
 
         return args
-
-    def install(self, spec, prefix):
-        make("install", parallel=False)
 
     def setup_run_environment(self, env):
         env.prepend_path("GI_TYPELIB_PATH",


### PR DESCRIPTION
Work on this wasn't properly started in this branch so far. The current useful edit is adding the minimum meson version:
```
depends_on("meson@0.54:", type="build")
```
To work, the build has to be fixed (currently the build tries to interpret system headers as some script!), and all the variants would have to be converted, and checked which versions can be supported with the Meson build.
If older versions of pango are used by users, a dual buildsystem with Meson and Autotools would be needed if the older versions don't work as `MesonPackage`.