### PR TITLE
umpire: patching not exported cmake targets from blt

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -50,6 +50,12 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
     patch('cmake_version_check.patch', when='@4.1')
     patch('missing_header_for_numeric_limits.patch', when='@4.1:5.0.1')
 
+    # https://llnl-blt.readthedocs.io/en/develop/tutorial/exporting_targets.html
+    # https://github.com/LLNL/Umpire/pull/541
+    patch('https://github.com/LLNL/Umpire/commit/5773ce9af88952c8d23f9bcdcb2e503ceda40763.patch',
+          sha256='f5c691752e4833a936bce224bbe0fe884d3afa84c5e5a4a481f59a12840159c9',
+          when='@:5.0.1 ^blt@0.4:')
+
     variant('fortran', default=False, description='Build C/Fortran API')
     variant('c', default=True, description='Build C API')
     variant('numa', default=False, description='Enable NUMA support')


### PR DESCRIPTION
I addressed this problem getting a `-lcuda_runtime not found` error when linking with umpire (using CMake).

After investigating the problem, I discovered that `cuda_runtime` is a CMake target of BLT acting as a sort of "placeholder" for the cuda libraries (it is not the only one). Going on in this investigation, I found out that starting from `blt@0.4.0` the management of these targets has changed.

https://github.com/spack/spack/blob/06c8fdafd4f139d8e92d1c9a06e3762b8329ed7e/var/spack/repos/builtin/packages/blt/package.py#L21-L24

And it has to be managed as reported in the [documentation](https://llnl-blt.readthedocs.io/en/develop/tutorial/exporting_targets.html) cited in the comment.

Then, I realized that on umpire `develop` branch it has been solved by the PR https://github.com/LLNL/Umpire/pull/541, but the current production release v5.0.1 does not have it.

For the above reasons I opted for applying the specific patch from the commit on the develop branch:
- for all versions of umpire up to (included) 5.0.1, because in the next release the fix should be in,
- but just for version of umpire depending on blt starting from version 0.4.0

I don't know have knowledge about the required mappings between the versions of blt and umpire, so I look forward for comments from the maintainers.