### PR TITLE
Ensure no autotools on Windows

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -14,6 +14,7 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 from llnl.util.filesystem import force_remove, working_dir
 
+from spack.directives import conflicts
 from spack.package import PackageBase, run_after, run_before
 from spack.util.executable import Executable
 
@@ -82,6 +83,8 @@ class AutotoolsPackage(PackageBase):
     #: If False deletes all the .la files in the prefix folder
     #: after the installation. If True instead it installs them.
     install_libtool_archives = False
+
+    conflicts('platform=windows')
 
     @property
     def _removed_la_files_log(self):


### PR DESCRIPTION
Throws a spec conflict when use of Autotools build system is used on Windows.

Requested on this [Slack thread](https://spackpm.slack.com/archives/C01E7RJ9G49/p1629121305034300?thread_ts=1629008874.032900&cid=C01E7RJ9G49)