### PR TITLE
Fixing "problems in spack" as identified by repology

### DIFF
--- a/var/spack/repos/builtin/packages/abinit/package.py
+++ b/var/spack/repos/builtin/packages/abinit/package.py
@@ -27,7 +27,7 @@ class Abinit(AutotoolsPackage):
     programs are provided.
     """
 
-    homepage = 'http://www.abinit.org'
+    homepage = 'https://www.abinit.org/'
     url      = 'https://www.abinit.org/sites/default/files/packages/abinit-8.6.3.tar.gz'
 
     version('9.4.2', sha256='d40886f5c8b138bb4aa1ca05da23388eb70a682790cfe5020ecce4db1b1a76bc')

--- a/var/spack/repos/builtin/packages/ack/package.py
+++ b/var/spack/repos/builtin/packages/ack/package.py
@@ -13,8 +13,8 @@ class Ack(Package):
        source code, ack is written purely in portable Perl 5 and takes
        advantage of the power of Perl's regular expressions."""
 
-    homepage = "http://beyondgrep.com/"
-    url      = "http://beyondgrep.com/ack-2.14-single-file"
+    homepage = "https://beyondgrep.com/"
+    url      = "https://beyondgrep.com/ack-2.14-single-file"
 
     version('2.22', sha256='fd0617585b88517a3d41d3d206c1dc38058c57b90dfd88c278049a41aeb5be38', expand=False)
     version('2.18', sha256='6e41057c8f50f661d800099471f769209480efa53b8a886969d7ec6db60a2208', expand=False)

--- a/var/spack/repos/builtin/packages/alglib/package.py
+++ b/var/spack/repos/builtin/packages/alglib/package.py
@@ -11,8 +11,8 @@ class Alglib(MakefilePackage):
     """ALGLIB is a cross-platform numerical analysis and data processing
     library."""
 
-    homepage = "http://www.alglib.net"
-    url      = "http://www.alglib.net/translator/re/alglib-3.11.0.cpp.gpl.tgz"
+    homepage = "https://www.alglib.net/"
+    url      = "https://www.alglib.net/translator/re/alglib-3.11.0.cpp.gpl.tgz"
 
     version('3.11.0', sha256='34e391594aac89fb354bdaf58c42849489cd1199197398ba98bb69961f42bdb0')
 

--- a/var/spack/repos/builtin/packages/applewmproto/package.py
+++ b/var/spack/repos/builtin/packages/applewmproto/package.py
@@ -13,7 +13,7 @@ class Applewmproto(AutotoolsPackage, XorgPackage):
     to better interact with the Mac OS X Aqua user interface when
     running X11 in a rootless mode."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/applewmproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/applewmproto"
     xorg_mirror_path = "proto/applewmproto-1.4.2.tar.gz"
 
     version('1.4.2', sha256='ff8ac07d263a23357af2d6ff0cca3c1d56b043ddf7797a5a92ec624f4704df2e')

--- a/var/spack/repos/builtin/packages/asciidoc/package.py
+++ b/var/spack/repos/builtin/packages/asciidoc/package.py
@@ -10,7 +10,7 @@ class Asciidoc(AutotoolsPackage):
     """A presentable text document format for writing articles, UNIX man
     pages and other small to medium sized documents."""
 
-    homepage = "http://asciidoc.org"
+    homepage = "https://asciidoc.org/"
     # Always working URL but strangely with another checksum
     url      = "https://github.com/asciidoc-py/asciidoc-py/archive/8.6.10.tar.gz"
     git      = "https://github.com/asciidoc-py/asciidoc-py.git"

--- a/var/spack/repos/builtin/packages/bcache/package.py
+++ b/var/spack/repos/builtin/packages/bcache/package.py
@@ -10,7 +10,7 @@ class Bcache(MakefilePackage):
     """Bcache is a patch for the Linux kernel to use SSDs to cache other block
     devices."""
 
-    homepage = "http://bcache.evilpiepirate.org"
+    homepage = "https://bcache.evilpiepirate.org/"
     url      = "https://github.com/g2p/bcache-tools/archive/v1.0.8.tar.gz"
 
     version('1.0.8', sha256='d56923936f37287efc57a46315679102ef2c86cd0be5874590320acd48c1201c')

--- a/var/spack/repos/builtin/packages/bib2xhtml/package.py
+++ b/var/spack/repos/builtin/packages/bib2xhtml/package.py
@@ -6,7 +6,7 @@
 
 class Bib2xhtml(Package):
     """bib2xhtml is a program that converts BibTeX files into HTML."""
-    homepage = "http://www.spinellis.gr/sw/textproc/bib2xhtml/"
+    homepage = "https://www.spinellis.gr/sw/textproc/bib2xhtml/"
     url = 'https://www.spinellis.gr/sw/textproc/bib2xhtml/bib2xhtml-v3.0-79-ge935.tar.gz'
 
     version('3.0-79-ge935', sha256='4a2d2d89dd2f3fed1c735055b806809b5cc1cde32dee1aa5987097ec5bf2181f')

--- a/var/spack/repos/builtin/packages/blast-plus/package.py
+++ b/var/spack/repos/builtin/packages/blast-plus/package.py
@@ -20,7 +20,7 @@ from spack import *
 class BlastPlus(AutotoolsPackage):
     """Basic Local Alignment Search Tool."""
 
-    homepage = "http://blast.ncbi.nlm.nih.gov/"
+    homepage = "https://blast.ncbi.nlm.nih.gov/"
     url      = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.12.0/ncbi-blast-2.12.0+-src.tar.gz"
 
     maintainers = ['weijianwen']

--- a/var/spack/repos/builtin/packages/bohrium/package.py
+++ b/var/spack/repos/builtin/packages/bohrium/package.py
@@ -15,7 +15,7 @@ from spack.util.executable import Executable
 class Bohrium(CMakePackage, CudaPackage):
     """Library for automatic acceleration of array operations"""
 
-    homepage = "http://bh107.org"
+    homepage = "https://github.com/bh107/bohrium"
     url      = "https://github.com/bh107/bohrium/archive/v0.9.0.tar.gz"
     git      = "https://github.com/bh107/bohrium.git"
 

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -18,7 +18,7 @@ class Boost(Package):
        across a broad spectrum of applications. The Boost license
        encourages both commercial and non-commercial use.
     """
-    homepage = "http://www.boost.org"
+    homepage = "https://www.boost.org"
     url      = "http://downloads.sourceforge.net/project/boost/boost/1.55.0/boost_1_55_0.tar.bz2"
     git      = "https://github.com/boostorg/boost.git"
     list_url = "http://sourceforge.net/projects/boost/files/boost/"

--- a/var/spack/repos/builtin/packages/byobu/package.py
+++ b/var/spack/repos/builtin/packages/byobu/package.py
@@ -10,7 +10,7 @@ from spack import *
 class Byobu(AutotoolsPackage):
     """Byobu: Text-based window manager and terminal multiplexer."""
 
-    homepage = "http://www.byobu.co"
+    homepage = "https://www.byobu.co/"
     url      = "https://launchpad.net/byobu/trunk/5.123/+download/byobu_5.123.orig.tar.gz"
 
     maintainers = ['matthiasdiener']

--- a/var/spack/repos/builtin/packages/byte-unixbench/package.py
+++ b/var/spack/repos/builtin/packages/byte-unixbench/package.py
@@ -9,7 +9,7 @@ from spack import *
 class ByteUnixbench(MakefilePackage):
     """UnixBench is the original BYTE UNIX benchmark suite."""
 
-    homepage = "https://code.google.com/archive/p/byte-unixbench"
+    homepage = "https://github.com/kdlucas/byte-unixbench"
     url      = "https://github.com/kdlucas/byte-unixbench/archive/v5.1.3.tar.gz"
 
     version('5.1.3', sha256='3a6bb00f270a5329682dff20fd2c1ab5332ef046eb54a96a0d7bd371005d31a3')

--- a/var/spack/repos/builtin/packages/c-blosc/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc/package.py
@@ -11,7 +11,7 @@ from spack import *
 
 class CBlosc(CMakePackage):
     """Blosc, an extremely fast, multi-threaded, meta-compressor library"""
-    homepage = "http://www.blosc.org"
+    homepage = "https://www.blosc.org"
     url      = "https://github.com/Blosc/c-blosc/archive/v1.11.1.tar.gz"
 
     version('1.21.0', sha256='b0ef4fda82a1d9cbd11e0f4b9685abf14372db51703c595ecd4d76001a8b342d')

--- a/var/spack/repos/builtin/packages/c-blosc2/package.py
+++ b/var/spack/repos/builtin/packages/c-blosc2/package.py
@@ -10,7 +10,7 @@ class CBlosc2(CMakePackage):
     """Next generation c-blosc with a new API, a new container and
        other bells and whistles"""
 
-    homepage = "http://www.blosc.org"
+    homepage = "https://www.blosc.org/"
     url      = "https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.0.1.tar.gz"
     git      = "https://github.com/Blosc/c-blosc2.git"
 

--- a/var/spack/repos/builtin/packages/cfitsio/package.py
+++ b/var/spack/repos/builtin/packages/cfitsio/package.py
@@ -11,8 +11,8 @@ class Cfitsio(AutotoolsPackage):
     data files in FITS (Flexible Image Transport System) data format.
     """
 
-    homepage = 'http://heasarc.gsfc.nasa.gov/fitsio/'
-    url      = 'http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-3.49.tar.gz'
+    homepage = 'https://heasarc.gsfc.nasa.gov/fitsio/'
+    url      = 'https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-3.49.tar.gz'
 
     version('3.49', sha256='5b65a20d5c53494ec8f638267fca4a629836b7ac8dd0ef0266834eab270ed4b3')
     version('3.48', sha256='91b48ffef544eb8ea3908543052331072c99bf09ceb139cb3c6977fc3e47aac1')

--- a/var/spack/repos/builtin/packages/codec2/package.py
+++ b/var/spack/repos/builtin/packages/codec2/package.py
@@ -11,7 +11,7 @@ class Codec2(CMakePackage):
     between 450 and 3200 bit/s. The main application is low bandwidth
     HF/VHF digital radio."""
 
-    homepage = "http://www.rowetel.com/codec2.html"
+    homepage = "https://www.rowetel.com/?page_id=452"
     url      = "https://github.com/drowe67/codec2/archive/v0.9.2.tar.gz"
 
     version('0.9.2', sha256='19181a446f4df3e6d616b50cabdac4485abb9cd3242cf312a0785f892ed4c76c')

--- a/var/spack/repos/builtin/packages/dbus/package.py
+++ b/var/spack/repos/builtin/packages/dbus/package.py
@@ -16,8 +16,8 @@ class Dbus(Package):
        by any two applications to communicate directly (without going
        through the message bus daemon)."""
 
-    homepage = "http://dbus.freedesktop.org/"
-    url      = "http://dbus.freedesktop.org/releases/dbus/dbus-1.8.8.tar.gz"
+    homepage = "https://dbus.freedesktop.org/"
+    url      = "https://dbus.freedesktop.org/releases/dbus/dbus-1.8.8.tar.gz"
 
     version('1.12.8', sha256='e2dc99e7338303393b6663a98320aba6a63421bcdaaf571c8022f815e5896eb3')
     version('1.11.2', sha256='5abc4c57686fa82669ad0039830788f9b03fdc4fff487f0ccf6c9d56ba2645c9')

--- a/var/spack/repos/builtin/packages/editline/package.py
+++ b/var/spack/repos/builtin/packages/editline/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Editline(AutotoolsPackage):
     """A readline() replacement for UNIX without termcap (ncurses)"""
 
-    homepage = "http://troglobit.com/editline.html"
+    homepage = "https://troglobit.com/editline.html"
     url      = "https://github.com/troglobit/editline/archive/1.16.0.tar.gz"
 
     version('1.16.0', sha256='33421a1569d025f332a87054bfea28e2c757bdb573f1437bc22c34b798b6383c')

--- a/var/spack/repos/builtin/packages/elemental/package.py
+++ b/var/spack/repos/builtin/packages/elemental/package.py
@@ -13,7 +13,7 @@ class Elemental(CMakePackage):
     """Elemental: Distributed-memory dense and sparse-direct linear algebra
        and optimization library."""
 
-    homepage = "http://libelemental.org"
+    homepage = "https://libelemental.org"
     url      = "https://github.com/elemental/Elemental/archive/v0.87.7.tar.gz"
     git      = "https://github.com/elemental/Elemental.git"
 

--- a/var/spack/repos/builtin/packages/etsf-io/package.py
+++ b/var/spack/repos/builtin/packages/etsf-io/package.py
@@ -15,7 +15,7 @@ class EtsfIo(Package):
     quantum-chemical applications relying upon Density Functional Theory (DFT).
     """
 
-    homepage = "http://www.etsf.eu/resources/software/libraries_and_tools"
+    homepage = "https://github.com/ElectronicStructureLibrary/libetsf_io"
     url = "https://launchpad.net/etsf-io/1.0/1.0.4/+download/etsf_io-1.0.4.tar.gz"
 
     version('1.0.4', sha256='3140c2cde17f578a0e6b63acb27a5f6e9352257a1371a17b9c15c3d0ef078fa4')

--- a/var/spack/repos/builtin/packages/exciting/package.py
+++ b/var/spack/repos/builtin/packages/exciting/package.py
@@ -15,8 +15,8 @@ class Exciting(MakefilePackage):
     particular focus are excited states within many-body perturbation theory.
     """
 
-    homepage = "http://exciting-code.org/"
-    url      = "http://exciting.wdfiles.com/local--files/nitrogen-14/exciting.nitrogen-14.tar.gz"
+    homepage = "https://exciting-code.org/"
+    url      = "https://exciting.wdfiles.com/local--files/nitrogen-14/exciting.nitrogen-14.tar.gz"
 
     version('14', sha256='a7feaffdc23881d6c0737d2f79f94d9bf073e85ea358a57196d7f7618a0a3eff')
 

--- a/var/spack/repos/builtin/packages/exempi/package.py
+++ b/var/spack/repos/builtin/packages/exempi/package.py
@@ -14,7 +14,7 @@ class Exempi(AutotoolsPackage):
     a command line tool.
     """
 
-    homepage = "http://libopenraw.freedesktop.org/wiki/Exempi"
+    homepage = "https://libopenraw.freedesktop.org/wiki/Exempi"
     url      = "https://libopenraw.freedesktop.org/download/exempi-2.5.2.tar.bz2"
 
     version('2.5.2', sha256='52f54314aefd45945d47a6ecf4bd21f362e6467fa5d0538b0d45a06bc6eaaed5')

--- a/var/spack/repos/builtin/packages/f2c/package.py
+++ b/var/spack/repos/builtin/packages/f2c/package.py
@@ -9,8 +9,8 @@ from spack import *
 class F2c(MakefilePackage):
     """F2c converts Fortran 77 source code to C or C++ source files."""
 
-    homepage = "http://www.netlib.org/f2c/"
-    url      = "http://www.netlib.org/f2c/src.tgz"
+    homepage = "https://www.netlib.org/f2c/"
+    url      = "https://www.netlib.org/f2c/src.tgz"
 
     version('master', sha256='d4847456aa91c74e5e61e2097780ca6ac3b20869fae8864bfa8dcc66f6721d35')
 

--- a/var/spack/repos/builtin/packages/fastqc/package.py
+++ b/var/spack/repos/builtin/packages/fastqc/package.py
@@ -9,8 +9,8 @@ from spack import *
 class Fastqc(Package):
     """A quality control tool for high throughput sequence data."""
 
-    homepage = "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
-    url = "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip"
+    homepage = "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+    url = "https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5.zip"
 
     version('0.11.9', sha256='15510a176ef798e40325b717cac556509fb218268cfdb9a35ea6776498321369')
     version('0.11.7', sha256='59cf50876bbe5f363442eb989e43ae3eaab8d932c49e8cff2c1a1898dd721112')

--- a/var/spack/repos/builtin/packages/faust/package.py
+++ b/var/spack/repos/builtin/packages/faust/package.py
@@ -11,7 +11,7 @@ class Faust(MakefilePackage):
     specifically designed for real-time signal processing and synthesis.
     A distinctive characteristic of Faust is to be fully compiled."""
 
-    homepage = "http://faust.grame.fr/"
+    homepage = "https://faust.grame.fr/"
     url      = "https://github.com/grame-cncm/faust/archive/2.27.2.tar.gz"
 
     version('2.27.2', sha256='3367a868a93b63582bae29ab8783f1df7a10f4084a2bc1d2258ebf3d6a8c31d7')

--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -14,7 +14,7 @@ class Fenics(CMakePackage):
     the code generation interface UFC, the form language UFL and a range of
     additional components."""
 
-    homepage = "http://fenicsproject.org/"
+    homepage = "https://fenicsproject.org/"
     git      = "https://bitbucket.org/fenics-project/dolfin.git"
     url      = "https://bitbucket.org/fenics-project/dolfin/downloads/dolfin-2019.1.0.post0.tar.gz"
 

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -18,7 +18,7 @@ class Flann(CMakePackage):
     C, MATLAB and Python.
     """
 
-    homepage = "http://www.cs.ubc.ca/research/flann/"
+    homepage = "https://github.com/mariusmuja/flann"
     url      = "https://github.com/mariusmuja/flann/archive/1.9.1.tar.gz"
 
     version('1.9.1', sha256='b23b5f4e71139faa3bcb39e6bbcc76967fbaf308c4ee9d4f5bfbeceaa76cc5d3')

--- a/var/spack/repos/builtin/packages/fltk/package.py
+++ b/var/spack/repos/builtin/packages/fltk/package.py
@@ -18,8 +18,8 @@ class Fltk(Package):
        applications in minutes.
 
     """
-    homepage = 'http://www.fltk.org/'
-    url = 'http://fltk.org/pub/fltk/1.3.3/fltk-1.3.3-source.tar.gz'
+    homepage = 'https://www.fltk.org/'
+    url = 'https://fltk.org/pub/fltk/1.3.3/fltk-1.3.3-source.tar.gz'
 
     version('1.3.3', sha256='f8398d98d7221d40e77bc7b19e761adaf2f1ef8bb0c30eceb7beb4f2273d0d97')
 

--- a/var/spack/repos/builtin/packages/fseq/package.py
+++ b/var/spack/repos/builtin/packages/fseq/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Fseq(Package):
     """F-Seq: A Feature Density Estimator for High-Throughput Sequence Tags"""
 
-    homepage = "http://fureylab.web.unc.edu/software/fseq/"
+    homepage = "https://fureylab.web.unc.edu/software/fseq/"
     url      = "http://html-large-files-dept-fureylab.cloudapps.unc.edu/fureylabfiles/fseq/fseq_1.84.tgz"
 
     version('1.84', sha256='22d603a51f127cb86cdecde9aeae14d273bb98bcd2b47724763ab3b3241a6e68')

--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4abla(Package):
     """Geant4 data for nuclear shell effects in INCL/ABLA hadronic mode"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ABLA.3.0.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4emlow(Package):
     """Geant4 data files for low energy electromagnetic processes."""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.6.50.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4ensdfstate(Package):
     """Geant4 data for nuclides properties"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ENSDFSTATE.2.1.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -10,7 +10,7 @@ from spack import *
 class G4incl(Package):
     """Geant4 data for evaluated particle cross-sections on natural
     composition of elements"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4INCL.1.0.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4ndl(Package):
     """Geant4 Neutron data files with thermal cross sections """
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NDL.4.5.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4neutronxs/package.py
+++ b/var/spack/repos/builtin/packages/g4neutronxs/package.py
@@ -10,7 +10,7 @@ from spack import *
 class G4neutronxs(Package):
     """Geant4 data for evaluated neutron cross-sections on natural composition
        of elements"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NEUTRONXS.1.4.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -10,7 +10,7 @@ from spack import *
 class G4particlexs(Package):
     """Geant4 data for evaluated particle cross-sections on
     natural composition of elements"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLEXS.2.1.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4photonevaporation(Package):
     """Geant4 data for photon evaporation"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PhotonEvaporation.4.3.2.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4pii(Package):
     """Geant4 data for shell ionisation cross-sections"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4PII.1.3.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4radioactivedecay(Package):
     """Geant4 data files for radio-active decay hadronic processes"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4RadioactiveDecay.5.1.1.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4tendl(Package):
     """Geant4 data for incident particles [optional]"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4TENDL.1.3.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/gatk/package.py
+++ b/var/spack/repos/builtin/packages/gatk/package.py
@@ -12,7 +12,7 @@ class Gatk(Package):
     Variant Discovery in High-Throughput Sequencing Data
     """
 
-    homepage = "https://software.broadinstitute.org/gatk/"
+    homepage = "https://gatk.broadinstitute.org/hc/en-us"
     url = "https://github.com/broadinstitute/gatk/releases/download/4.1.0.0/gatk-4.1.0.0.zip"
     list_url = "https://github.com/broadinstitute/gatk/releases"
 

--- a/var/spack/repos/builtin/packages/gconf/package.py
+++ b/var/spack/repos/builtin/packages/gconf/package.py
@@ -7,12 +7,16 @@ from spack import *
 
 
 class Gconf(AutotoolsPackage):
-    """GConf is a system for storing application preferences."""
+    """GConf is a system for storing application preferences.
 
-    homepage = "https://projects.gnome.org/gconf/"
+    Note that this software is now deprecated in favor of moving to GSettings
+    and dconf with the GNOME 3 transition.
+    """
+
+    homepage = "https://en.wikipedia.org/wiki/GConf"
     url      = "http://ftp.gnome.org/pub/gnome/sources/GConf/3.2/GConf-3.2.6.tar.xz"
 
-    version('3.2.6', sha256='1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c')
+    version('3.2.6', sha256='1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c', deprecated=True)
 
     depends_on('pkgconfig', type='build')
     depends_on('glib@2.14.0:')

--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -13,7 +13,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     These routines are provided to a programmer needing to create and
     manipulate a hashed database."""
 
-    homepage = "http://www.gnu.org.ua/software/gdbm/gdbm.html"
+    homepage = "https://www.gnu.org.ua/software/gdbm/gdbm.html"
     gnu_mirror_path = "gdbm/gdbm-1.13.tar.gz"
 
     version('1.19',   sha256='37ed12214122b972e18a0d94995039e57748191939ef74115b1d41d8811364bc')

--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -13,7 +13,7 @@ class Geos(CMakePackage):
        Simple Features for SQL spatial predicate functions and spatial
        operators, as well as specific JTS enhanced topology functions."""
 
-    homepage = "http://trac.osgeo.org/geos/"
+    homepage = "https://trac.osgeo.org/geos/"
     url      = "https://download.osgeo.org/geos/geos-3.8.1.tar.bz2"
 
     maintainers = ['adamjstewart']

--- a/var/spack/repos/builtin/packages/ghostscript-fonts/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript-fonts/package.py
@@ -11,7 +11,7 @@ from spack import *
 class GhostscriptFonts(Package):
     """Ghostscript Fonts"""
 
-    homepage = "http://ghostscript.com/"
+    homepage = "https://ghostscript.com/"
     url = "https://www.imagemagick.org/download/delegates/ghostscript-fonts-std-8.11.tar.gz"
 
     version('8.11', sha256='0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401')

--- a/var/spack/repos/builtin/packages/ghostscript/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript/package.py
@@ -12,7 +12,7 @@ from spack import *
 class Ghostscript(AutotoolsPackage):
     """An interpreter for the PostScript language and for PDF."""
 
-    homepage = "http://ghostscript.com/"
+    homepage = "https://ghostscript.com/"
     url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.gz"
 
     executables = [r'^gs$']

--- a/var/spack/repos/builtin/packages/gource/package.py
+++ b/var/spack/repos/builtin/packages/gource/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Gource(AutotoolsPackage):
     """Software version control visualization."""
 
-    homepage = "http://gource.io"
+    homepage = "https://gource.io"
     url = "https://github.com/acaudwell/Gource/releases/download/gource-0.44/gource-0.44.tar.gz"
 
     version('0.44', sha256='2604ca4442305ffdc5bb1a7bac07e223d59c846f93567be067e8dfe2f42f097c')

--- a/var/spack/repos/builtin/packages/grib-api/package.py
+++ b/var/spack/repos/builtin/packages/grib-api/package.py
@@ -9,18 +9,20 @@ from spack import *
 class GribApi(CMakePackage):
     """The ECMWF GRIB API is an application program interface accessible from
        C, FORTRAN and Python programs developed for encoding and decoding WMO
-       FM-92 GRIB edition 1 and edition 2 messages."""
+       FM-92 GRIB edition 1 and edition 2 messages. The API was deprecated
+       https://www.ecmwf.int/en/newsletter/152/news/end-road-grib-api in favor
+       of ecCodes."""
 
-    homepage = 'https://software.ecmwf.int/wiki/display/GRIB/Home'
+    homepage = 'https://www.ecmwf.int/en/newsletter/152/news/end-road-grib-api'
     url = 'https://software.ecmwf.int/wiki/download/attachments/3473437/grib_api-1.17.0-Source.tar.gz?api=v2'
     list_url = 'https://software.ecmwf.int/wiki/display/GRIB/Releases'
 
     maintainers = ['skosukhin']
 
-    version('1.24.0', sha256='6b0d443cb0802c5de652e5816c5b88734cb3ead454eb932c5ec12ef8d4f77bcd')
-    version('1.21.0', sha256='50c2b58303ab578c55735e6c21c72ffc24f82a5bf52565550f54d49cb60e8a90')
-    version('1.17.0', sha256='55cbb4fdcb4ee1be6a27cece9ae7e26070beb8ab6cb7e77773db3fb0d4272462')
-    version('1.16.0', sha256='0068ca4149a9f991d4c86a813ac73b4e2299c6a3fd53aba9e6ab276ef6f0ff9a')
+    version('1.24.0', sha256='6b0d443cb0802c5de652e5816c5b88734cb3ead454eb932c5ec12ef8d4f77bcd', deprecated=True)
+    version('1.21.0', sha256='50c2b58303ab578c55735e6c21c72ffc24f82a5bf52565550f54d49cb60e8a90', deprecated=True)
+    version('1.17.0', sha256='55cbb4fdcb4ee1be6a27cece9ae7e26070beb8ab6cb7e77773db3fb0d4272462', deprecated=True)
+    version('1.16.0', sha256='0068ca4149a9f991d4c86a813ac73b4e2299c6a3fd53aba9e6ab276ef6f0ff9a', deprecated=True)
 
     variant('netcdf', default=False,
             description='Enable netcdf encoding/decoding using netcdf library')

--- a/var/spack/repos/builtin/packages/h5part/package.py
+++ b/var/spack/repos/builtin/packages/h5part/package.py
@@ -10,7 +10,7 @@ from spack import *
 class H5part(AutotoolsPackage):
     """Portable High Performance Parallel Data Interface to HDF5"""
 
-    homepage = "http://vis.lbl.gov/Research/H5Part/"
+    homepage = "https://dav.lbl.gov/archive/Research/AcceleratorSAPP/"
     url      = "https://codeforge.lbl.gov/frs/download.php/latestfile/18/H5Part-1.6.6.tar.gz"
 
     version('1.6.6', sha256='10347e7535d1afbb08d51be5feb0ae008f73caf889df08e3f7dde717a99c7571')

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -12,7 +12,7 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     """Hydrogen: Distributed-memory dense and sparse-direct linear algebra
        and optimization library. Based on the Elemental library."""
 
-    homepage = "http://libelemental.org"
+    homepage = "https://libelemental.org"
     url      = "https://github.com/LLNL/Elemental/archive/v1.0.1.tar.gz"
     git      = "https://github.com/LLNL/Elemental.git"
 

--- a/var/spack/repos/builtin/packages/icedtea/package.py
+++ b/var/spack/repos/builtin/packages/icedtea/package.py
@@ -14,7 +14,7 @@ class Icedtea(AutotoolsPackage):
     of key features to the upstream OpenJDK codebase. IcedTea requires an
     existing IcedTea or OpenJDK install to build."""
 
-    homepage = "http://icedtea.classpath.org/wiki/Main_Page"
+    homepage = "https://openjdk.java.net/projects/icedtea/"
     url      = "http://icedtea.wildebeest.org/download/source/icedtea-3.4.0.tar.gz"
 
     version('3.9.0', sha256='84a63bc59f4e101ce8fa183060a59c7e8cbe270945310e90c92b8609a9b8bc88')

--- a/var/spack/repos/builtin/packages/imlib2/package.py
+++ b/var/spack/repos/builtin/packages/imlib2/package.py
@@ -11,7 +11,7 @@ class Imlib2(AutotoolsPackage, SourceforgePackage):
     manipulation, arbitrary polygon support
     """
 
-    homepage = "http://sourceforge.net/projects/enlightenment/"
+    homepage = "https://sourceforge.net/projects/enlightenment/"
     sourceforge_mirror_path = "enlightenment/imlib2-1.5.1.tar.bz2"
 
     maintainers = ['TheQueasle']

--- a/var/spack/repos/builtin/packages/jemalloc/package.py
+++ b/var/spack/repos/builtin/packages/jemalloc/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Jemalloc(AutotoolsPackage):
     """jemalloc is a general purpose malloc(3) implementation that emphasizes
        fragmentation avoidance and scalable concurrency support."""
-    homepage = "http://www.canonware.com/jemalloc/"
+    homepage = "http://jemalloc.net/"
     url      = "https://github.com/jemalloc/jemalloc/releases/download/4.0.4/jemalloc-4.0.4.tar.bz2"
 
     version('5.2.1', sha256='34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6')

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -12,7 +12,7 @@ from spack import *
 class Julia(Package):
     """The Julia Language: A fresh approach to technical computing"""
 
-    homepage = "http://julialang.org"
+    homepage = "https://julialang.org"
     url      = "https://github.com/JuliaLang/julia/releases/download/v0.4.3/julia-0.4.3-full.tar.gz"
     git      = "https://github.com/JuliaLang/julia.git"
 

--- a/var/spack/repos/builtin/packages/keepalived/package.py
+++ b/var/spack/repos/builtin/packages/keepalived/package.py
@@ -12,7 +12,7 @@ class Keepalived(AutotoolsPackage):
     maintain and manage loadbalanced server pool according their health
     """
 
-    homepage = "http://www.keepalived.org"
+    homepage = "https://www.keepalived.org"
     url      = "http://www.keepalived.org/software/keepalived-1.2.0.tar.gz"
 
     version('2.0.19', sha256='0e2f8454765bc6a5fa26758bd9cec18aae42882843cdd24848aff0ae65ce4ca7')

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -22,7 +22,7 @@ class Legion(CMakePackage):
        that is orthogonal to correctness, thereby enabling easy porting and
        tuning of Legion applications to new architectures."""
 
-    homepage = "http://legion.stanford.edu/"
+    homepage = "https://legion.stanford.edu/"
     git = "https://github.com/StanfordLegion/legion.git"
 
     maintainers = ['pmccormick', 'streichler']

--- a/var/spack/repos/builtin/packages/libapplewm/package.py
+++ b/var/spack/repos/builtin/packages/libapplewm/package.py
@@ -11,7 +11,7 @@ class Libapplewm(AutotoolsPackage, XorgPackage):
     extension. This extension allows X window managers to better interact with
     the Mac OS X Aqua user interface when running X11 in a rootless mode."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libAppleWM"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libAppleWM"
     xorg_mirror_path = "lib/libAppleWM-1.4.1.tar.gz"
 
     version('1.4.1', sha256='d7fb098d65ad4d840f60e5c92de7f58f1725bd70d0d132755ea453462fd50049')

--- a/var/spack/repos/builtin/packages/libatasmart/package.py
+++ b/var/spack/repos/builtin/packages/libatasmart/package.py
@@ -10,7 +10,7 @@ class Libatasmart(AutotoolsPackage):
     """A small and lightweight parser library for ATA S.M.A.R.T. hard disk
     health monitoring."""
 
-    homepage = "http://git.0pointer.de/?p=libatasmart.git"
+    homepage = "https://github.com/ebe-forks/libatasmart"
     url      = "https://github.com/ebe-forks/libatasmart/archive/v0.19.tar.gz"
 
     version('0.19', sha256='10bb5321a254e28bd60fd297f284bfc81cce4fde92e150187640e62ec667e5fb')

--- a/var/spack/repos/builtin/packages/libdatrie/package.py
+++ b/var/spack/repos/builtin/packages/libdatrie/package.py
@@ -10,7 +10,7 @@ class Libdatrie(AutotoolsPackage):
     """datrie is an implementation of double-array structure for representing
     trie."""
 
-    homepage = "http://linux.thai.net/projects/datrie"
+    homepage = "https://linux.thai.net/projects/datrie"
     url      = "https://github.com/tlwg/libdatrie/releases/download/v0.2.12/libdatrie-0.2.12.tar.xz"
 
     version('0.2.12', sha256='452dcc4d3a96c01f80f7c291b42be11863cd1554ff78b93e110becce6e00b149')

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -10,7 +10,7 @@ class Libdrm(AutotoolsPackage):
     """A userspace library for accessing the DRM, direct rendering manager,
     on Linux, BSD and other systems supporting the ioctl interface."""
 
-    homepage = "http://dri.freedesktop.org/libdrm/"
+    homepage = "https://dri.freedesktop.org/libdrm/"
     url      = "https://dri.freedesktop.org/libdrm/libdrm-2.4.59.tar.gz"
 
     version('2.4.100', sha256='6a5337c054c0c47bc16607a21efa2b622e08030be4101ef4a241c5eb05b6619b')

--- a/var/spack/repos/builtin/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin/packages/libdwarf/package.py
@@ -24,7 +24,7 @@ class Libdwarf(Package):
        respectively, not source) with every release of the SGI
        MIPS/IRIX C compiler."""
 
-    homepage = "http://www.prevanders.net/dwarf.html"
+    homepage = "https://www.prevanders.net/dwarf.html"
     url      = "http://www.prevanders.net/libdwarf-20160507.tar.gz"
     list_url = homepage
 

--- a/var/spack/repos/builtin/packages/libevent/package.py
+++ b/var/spack/repos/builtin/packages/libevent/package.py
@@ -14,7 +14,7 @@ class Libevent(AutotoolsPackage):
 
     """
 
-    homepage = "http://libevent.org"
+    homepage = "https://libevent.org"
     url      = "https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz"
     list_url = "http://libevent.org/old-releases.html"
 

--- a/var/spack/repos/builtin/packages/libfontenc/package.py
+++ b/var/spack/repos/builtin/packages/libfontenc/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libfontenc(AutotoolsPackage, XorgPackage):
     """libfontenc - font encoding library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libfontenc"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libfontenc"
     xorg_mirror_path = "lib/libfontenc-1.1.3.tar.gz"
 
     version('1.1.3', sha256='6fba26760ca8d5045f2b52ddf641c12cedc19ee30939c6478162b7db8b6220fb')

--- a/var/spack/repos/builtin/packages/libgpuarray/package.py
+++ b/var/spack/repos/builtin/packages/libgpuarray/package.py
@@ -11,7 +11,7 @@ class Libgpuarray(CMakePackage):
     projects that is as future proof as possible, while keeping it easy to use
     for simple need/quick test."""
 
-    homepage = "http://deeplearning.net/software/libgpuarray/"
+    homepage = "https://github.com/Theano/libgpuarray"
     url      = "https://github.com/Theano/libgpuarray/archive/v0.6.1.tar.gz"
 
     version('0.7.6', sha256='ad1c00dd47c3d36ee1708e5167377edbfcdb7226e837ef9c68b841afbb4a4f6a')

--- a/var/spack/repos/builtin/packages/liblbxutil/package.py
+++ b/var/spack/repos/builtin/packages/liblbxutil/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Liblbxutil(AutotoolsPackage, XorgPackage):
     """liblbxutil - Low Bandwith X extension (LBX) utility routines."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/liblbxutil"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/liblbxutil"
     xorg_mirror_path = "lib/liblbxutil-1.1.0.tar.gz"
 
     version('1.1.0', sha256='285c1bc688cc71ec089e9284f2566d1780cc5d90816e9997890af8689f386951')

--- a/var/spack/repos/builtin/packages/libnetfilter-conntrack/package.py
+++ b/var/spack/repos/builtin/packages/libnetfilter-conntrack/package.py
@@ -10,7 +10,7 @@ class LibnetfilterConntrack(AutotoolsPackage):
     """libnetfilter_conntrack is a userspace library providing a programming
     interface (API) to the in-kernel connection tracking state table."""
 
-    homepage = "http://netfilter.org"
+    homepage = "https://netfilter.org"
     url      = "https://github.com/Distrotech/libnetfilter_conntrack/archive/libnetfilter_conntrack-1.0.4.tar.gz"
 
     version('1.0.4', sha256='68168697b9d6430b7797ddd579e13a2cef06ea15c154dfd14e18be64e035ea6e')

--- a/var/spack/repos/builtin/packages/libnfnetlink/package.py
+++ b/var/spack/repos/builtin/packages/libnfnetlink/package.py
@@ -12,7 +12,7 @@ class Libnfnetlink(AutotoolsPackage):
     netfilter subsystem specific libraries such as libnfnetlink_conntrack,
     libnfnetlink_log and libnfnetlink_queue."""
 
-    homepage = "http://netfilter.org"
+    homepage = "https://netfilter.org"
     url      = "https://github.com/Distrotech/libnfnetlink/archive/libnfnetlink-1.0.1.tar.gz"
 
     version('1.0.1',  sha256='11dd8a1045b03d47c878535eeb6b9eb34db295d21903a4dfd2c2cc63f45e675b')

--- a/var/spack/repos/builtin/packages/libpciaccess/package.py
+++ b/var/spack/repos/builtin/packages/libpciaccess/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libpciaccess(AutotoolsPackage, XorgPackage):
     """Generic PCI access library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libpciaccess/"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libpciaccess/"
     xorg_mirror_path = "lib/libpciaccess-0.13.5.tar.gz"
 
     version('0.16', sha256='84413553994aef0070cf420050aa5c0a51b1956b404920e21b81e96db6a61a27')

--- a/var/spack/repos/builtin/packages/libthai/package.py
+++ b/var/spack/repos/builtin/packages/libthai/package.py
@@ -13,7 +13,7 @@ class Libthai(AutotoolsPackage):
     word breaking, input and output methods as well as basic character
     and string supports."""
 
-    homepage = "http://linux.thai.net"
+    homepage = "https://linux.thai.net"
     url      = "https://github.com/tlwg/libthai/releases/download/v0.1.28/libthai-0.1.28.tar.xz"
 
     version('0.1.28', sha256='ffe0a17b4b5aa11b153c15986800eca19f6c93a4025ffa5cf2cab2dcdf1ae911')

--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libtheora(AutotoolsPackage):
     """Theora Video Compression."""
 
-    homepage = "http://www.theora.org"
+    homepage = "https://www.theora.org"
     url      = "http://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.xz"
 
     version('1.1.1',       sha256='f36da409947aa2b3dcc6af0a8c2e3144bc19db2ed547d64e9171c59c66561c61')

--- a/var/spack/repos/builtin/packages/libtommath/package.py
+++ b/var/spack/repos/builtin/packages/libtommath/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libtommath(MakefilePackage):
     """A portable number theoretic multiple-precision integer library."""
 
-    homepage = "http://www.libtom.net/"
+    homepage = "https://www.libtom.net/"
     url      = "https://github.com/libtom/libtommath/archive/v1.2.0.tar.gz"
 
     version('1.2.0', sha256='f3c20ab5df600d8d89e054d096c116417197827d12732e678525667aa724e30f')

--- a/var/spack/repos/builtin/packages/libwindowswm/package.py
+++ b/var/spack/repos/builtin/packages/libwindowswm/package.py
@@ -14,7 +14,7 @@ class Libwindowswm(AutotoolsPackage, XorgPackage):
     better interact with the Cygwin XWin server when running X11 in a
     rootless mode."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libWindowsWM"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libWindowsWM"
     xorg_mirror_path = "lib/libWindowsWM-1.0.1.tar.gz"
 
     version('1.0.1', sha256='94f9c0add3bad38ebd84bc43d854207c4deaaa74fb15339276e022546124b98a')

--- a/var/spack/repos/builtin/packages/libxaw3d/package.py
+++ b/var/spack/repos/builtin/packages/libxaw3d/package.py
@@ -10,7 +10,7 @@ class Libxaw3d(AutotoolsPackage, XorgPackage):
     """Xaw3d is the X 3D Athena Widget Set.
     Xaw3d is a widget set based on the X Toolkit Intrinsics (Xt) Library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXaw3d"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXaw3d"
     xorg_mirror_path = "lib/libXaw3d-1.6.2.tar.gz"
 
     version('1.6.2', sha256='847dab01aeac1448916e3b4edb4425594b3ac2896562d9c7141aa4ac6c898ba9')

--- a/var/spack/repos/builtin/packages/libxevie/package.py
+++ b/var/spack/repos/builtin/packages/libxevie/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxevie(AutotoolsPackage, XorgPackage):
     """Xevie - X Event Interception Extension (XEvIE)."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXevie"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXevie"
     xorg_mirror_path = "lib/libXevie-1.0.3.tar.gz"
 
     version('1.0.3', sha256='3759bb1f7fdade13ed99bfc05c0717bc42ce3f187e7da4eef80beddf5e461258')

--- a/var/spack/repos/builtin/packages/libxp/package.py
+++ b/var/spack/repos/builtin/packages/libxp/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxp(AutotoolsPackage, XorgPackage):
     """libXp - X Print Client Library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXp"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXp"
     xorg_mirror_path = "lib/libXp-1.0.3.tar.gz"
 
     version('1.0.3', sha256='f6b8cc4ef05d3eafc9ef5fc72819dd412024b4ed60197c0d5914758125817e9c')

--- a/var/spack/repos/builtin/packages/libxxf86misc/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86misc/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxxf86misc(AutotoolsPackage, XorgPackage):
     """libXxf86misc - Extension library for the XFree86-Misc X extension."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXxf86misc"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXxf86misc"
     xorg_mirror_path = "lib/libXxf86misc-1.0.3.tar.gz"
 
     version('1.0.3', sha256='358f692f793af00f6ef4c7a8566c1bcaeeea37e417337db3f519522cc1df3946')

--- a/var/spack/repos/builtin/packages/lzma/package.py
+++ b/var/spack/repos/builtin/packages/lzma/package.py
@@ -16,7 +16,7 @@ class Lzma(AutotoolsPackage):
     tools of LZMA Utils. This should make transition from LZMA Utils to XZ
     Utils relatively easy."""
 
-    homepage = "http://tukaani.org/lzma/"
+    homepage = "https://tukaani.org/lzma/"
     url      = "http://tukaani.org/lzma/lzma-4.32.7.tar.gz"
 
     version('4.32.7', sha256='9f337a8c51e5ded198d1032f5087ba3fe438f2a54e9df419e513a151775b032c')

--- a/var/spack/repos/builtin/packages/mapserver/package.py
+++ b/var/spack/repos/builtin/packages/mapserver/package.py
@@ -14,7 +14,7 @@ class Mapserver(CMakePackage):
        "geographic image maps", that is, maps that can direct users
        to content"""
 
-    homepage = "http://www.mapserver.org/"
+    homepage = "https://www.mapserver.org/"
     url      = "https://download.osgeo.org/mapserver/mapserver-7.2.1.tar.gz"
 
     version('7.2.1', sha256='9459a7057d5a85be66a41096a5d804f74665381186c37077c94b56e784db6102')

--- a/var/spack/repos/builtin/packages/mawk/package.py
+++ b/var/spack/repos/builtin/packages/mawk/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Mawk(AutotoolsPackage):
     """mawk is an interpreter for the AWK Programming Language."""
 
-    homepage = "http://invisible-island.net/mawk/mawk.html"
+    homepage = "https://invisible-island.net/mawk/mawk.html"
     url      = "http://invisible-mirror.net/archives/mawk/mawk-1.3.4.tgz"
 
     version('1.3.4-20171017', sha256='db17115d1ed18ed1607c8b93291db9ccd4fe5e0f30d2928c3c5d127b23ec9e5b')

--- a/var/spack/repos/builtin/packages/med/package.py
+++ b/var/spack/repos/builtin/packages/med/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Med(CMakePackage):
     """The MED file format is a specialization of the HDF5 standard."""
 
-    homepage = "http://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html"
+    homepage = "https://docs.salome-platform.org/latest/dev/MEDCoupling/med-file.html"
     url = "https://files.salome-platform.org/Salome/other/med-3.2.0.tar.gz"
 
     maintainers = ['likask']

--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -11,7 +11,7 @@ class Meson(PythonPackage):
     """Meson is a portable open source build system meant to be both
        extremely fast, and as user friendly as possible."""
 
-    homepage = "http://mesonbuild.com/"
+    homepage = "https://mesonbuild.com/"
     url      = "https://github.com/mesonbuild/meson/archive/0.49.0.tar.gz"
 
     maintainers = ['michaelkuhn']

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -13,7 +13,7 @@ class Mono(AutotoolsPackage):
        standards for C# and the Common Language Runtime.
     """
 
-    homepage = "http://www.mono-project.com/"
+    homepage = "https://www.mono-project.com/"
     url      = "https://download.mono-project.com/sources/mono/mono-5.0.1.1.tar.bz2"
 
     # /usr/share/.mono/keypairs needs to exist or be able to be

--- a/var/spack/repos/builtin/packages/motif/package.py
+++ b/var/spack/repos/builtin/packages/motif/package.py
@@ -13,7 +13,7 @@ class Motif(AutotoolsPackage):
     """
     force_autoreconf = True
 
-    homepage = "http://motif.ics.com/"
+    homepage = "https://motif.ics.com/"
     url = "http://cfhcable.dl.sourceforge.net/project/motif/Motif%202.3.8%20Source%20Code/motif-2.3.8.tar.gz"
 
     version('2.3.8', sha256='859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7')

--- a/var/spack/repos/builtin/packages/mozjs/package.py
+++ b/var/spack/repos/builtin/packages/mozjs/package.py
@@ -11,7 +11,7 @@ class Mozjs(AutotoolsPackage):
     It is used in various Mozilla products, including Firefox, and is
     available under the MPL2."""
 
-    homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey"
+    homepage = "https://firefox-source-docs.mozilla.org/js/index.html"
 
     version('24.2.0', sha256='e62f3f331ddd90df1e238c09d61a505c516fe9fd8c5c95336611d191d18437d8',
             url="http://ftp.mozilla.org/pub/js/mozjs-24.2.0.tar.bz2")

--- a/var/spack/repos/builtin/packages/mrtrix3/package.py
+++ b/var/spack/repos/builtin/packages/mrtrix3/package.py
@@ -12,7 +12,7 @@ class Mrtrix3(Package):
        probabilistic tractography, track-density imaging, and apparent fibre
        density."""
 
-    homepage = "http://www.mrtrix.org/"
+    homepage = "https://www.mrtrix.org/"
     git      = "https://github.com/MRtrix3/mrtrix3.git"
 
     version('2017-09-25', commit='72aca89e3d38c9d9e0c47104d0fb5bd2cbdb536d')

--- a/var/spack/repos/builtin/packages/muparser/package.py
+++ b/var/spack/repos/builtin/packages/muparser/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class Muparser(Package):
     """C++ math expression parser library."""
-    homepage = "http://muparser.beltoforion.de/"
+    homepage = "https://beltoforion.de/en/muparser/"
     url      = "https://github.com/beltoforion/muparser/archive/v2.2.5.tar.gz"
 
     version('2.2.6.1', sha256='d2562853d972b6ddb07af47ce8a1cdeeb8bb3fa9e8da308746de391db67897b3')

--- a/var/spack/repos/builtin/packages/nano/package.py
+++ b/var/spack/repos/builtin/packages/nano/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Nano(AutotoolsPackage):
     """Tiny little text editor"""
 
-    homepage = "http://www.nano-editor.org"
+    homepage = "https://www.nano-editor.org"
     url      = "https://www.nano-editor.org/dist/v4/nano-4.9.tar.xz"
     list_url = "https://www.nano-editor.org/dist/"
     list_depth = 1

--- a/var/spack/repos/builtin/packages/ncdu/package.py
+++ b/var/spack/repos/builtin/packages/ncdu/package.py
@@ -14,7 +14,7 @@ class Ncdu(Package):
     to run in any minimal POSIX-like environment with ncurses installed.
     """
 
-    homepage = "http://dev.yorhel.nl/ncdu"
+    homepage = "https://dev.yorhel.nl/ncdu"
     url      = "http://dev.yorhel.nl/download/ncdu-1.11.tar.gz"
 
     version('1.15.1', sha256='b02ddc4dbf1db139cc6fbbe2f54a282770380f0ca5c17089855eab52a9ea3fb0')

--- a/var/spack/repos/builtin/packages/ncftp/package.py
+++ b/var/spack/repos/builtin/packages/ncftp/package.py
@@ -10,7 +10,7 @@ class Ncftp(AutotoolsPackage):
     """NcFTP Client is a set of application programs implementing the
        File Transfer Protocol."""
 
-    homepage = "http://www.ncftp.com/"
+    homepage = "https://www.ncftp.com/"
     url      = "ftp://ftp.ncftp.com/ncftp/ncftp-3.2.6-src.tar.gz"
 
     version('3.2.6', sha256='129e5954850290da98af012559e6743de193de0012e972ff939df9b604f81c23')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -16,7 +16,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
     characters and function-key mapping, and has all the other
     SYSV-curses enhancements over BSD curses."""
 
-    homepage = "http://invisible-island.net/ncurses/ncurses.html"
+    homepage = "https://invisible-island.net/ncurses/ncurses.html"
     # URL must remain http:// so Spack can bootstrap curl
     gnu_mirror_path = "ncurses/ncurses-6.1.tar.gz"
 

--- a/var/spack/repos/builtin/packages/ncview/package.py
+++ b/var/spack/repos/builtin/packages/ncview/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class Ncview(AutotoolsPackage):
     """Simple viewer for NetCDF files."""
-    homepage = "http://meteora.ucsd.edu/~pierce/ncview_home_page.html"
+    homepage = "https://cirrus.ucsd.edu/ncview/"
     url      = "ftp://cirrus.ucsd.edu/pub/ncview/ncview-2.1.7.tar.gz"
 
     version('2.1.8', sha256='e8badc507b9b774801288d1c2d59eb79ab31b004df4858d0674ed0d87dfc91be')

--- a/var/spack/repos/builtin/packages/neo4j/package.py
+++ b/var/spack/repos/builtin/packages/neo4j/package.py
@@ -13,7 +13,7 @@ class Neo4j(MavenPackage):
     enterprise-quality database. For many applications, Neo4j offers orders
     of magnitude performance benefits compared to relational DBs."""
 
-    homepage = "http://neo4j.com/"
+    homepage = "https://neo4j.com/"
     url      = "https://github.com/neo4j/neo4j/archive/4.0.3.tar.gz"
 
     version('4.0.3',  sha256='19d79052657665dd661bbe906b3552b88108bf379d39fa007b883fff718cabee')

--- a/var/spack/repos/builtin/packages/nest/package.py
+++ b/var/spack/repos/builtin/packages/nest/package.py
@@ -12,7 +12,7 @@ class Nest(CMakePackage):
     It focuses on the dynamics, size and structure of neural systems rather
     than on the exact morphology of individual neurons."""
 
-    homepage = "http://www.nest-simulator.org"
+    homepage = "https://www.nest-simulator.org"
     url      = "https://github.com/nest/nest-simulator/archive/refs/tags/v3.0.tar.gz"
     git      = "https://github.com/nest/nest-simulator.git"
 

--- a/var/spack/repos/builtin/packages/nspr/package.py
+++ b/var/spack/repos/builtin/packages/nspr/package.py
@@ -10,7 +10,7 @@ class Nspr(AutotoolsPackage):
     """Netscape Portable Runtime (NSPR) provides a platform-neutral API
     for system level and libc-like functions."""
 
-    homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR"
+    homepage = "https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Reference/NSPR_functions"
     url      = "https://ftp.mozilla.org/pub/nspr/releases/v4.13.1/src/nspr-4.13.1.tar.gz"
 
     version('4.31',   sha256='5729da87d5fbf1584b72840751e0c6f329b5d541850cacd1b61652c95015abc8')

--- a/var/spack/repos/builtin/packages/numactl/package.py
+++ b/var/spack/repos/builtin/packages/numactl/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Numactl(AutotoolsPackage):
     """NUMA support for Linux"""
 
-    homepage = "http://oss.sgi.com/projects/libnuma/"
+    homepage = "https://github.com/numactl/numactl"
     url      = "https://github.com/numactl/numactl/archive/v2.0.11.tar.gz"
 
     force_autoreconf = True

--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -10,7 +10,7 @@ class Ocaml(Package):
     """OCaml is an industrial strength programming language supporting
        functional, imperative and object-oriented styles"""
 
-    homepage = "http://ocaml.org/"
+    homepage = "https://ocaml.org/"
     url      = "https://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz"
 
     maintainers = ['scemama']

--- a/var/spack/repos/builtin/packages/oclint/package.py
+++ b/var/spack/repos/builtin/packages/oclint/package.py
@@ -13,7 +13,7 @@ class Oclint(Package):
        reducing defects by inspecting C, C++ and Objective-C code and
        looking for potential problems"""
 
-    homepage = "http://oclint.org/"
+    homepage = "https://oclint.org/"
     url      = "https://github.com/oclint/oclint/archive/v0.13.tar.gz"
 
     version('0.13', sha256='a0fd188673863e6357d6585b9bb9c3affe737df134b9383a1a5ed021d09ed848')

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Openexr(AutotoolsPackage):
     """OpenEXR Graphics Tools (high dynamic-range image file format)"""
 
-    homepage = "http://www.openexr.com/"
+    homepage = "https://www.openexr.com/"
     url = "https://github.com/openexr/openexr/releases/download/v2.3.0/openexr-2.3.0.tar.gz"
 
     # New versions should come from github now

--- a/var/spack/repos/builtin/packages/openmm/package.py
+++ b/var/spack/repos/builtin/packages/openmm/package.py
@@ -14,7 +14,7 @@ class Openmm(CMakePackage, CudaPackage):
     LGPL. Part of the Omnia suite of tools for predictive biomolecular
     simulation. """
 
-    homepage = "http://openmm.org/"
+    homepage = "https://openmm.org/"
     url      = "https://github.com/openmm/openmm/archive/7.4.1.tar.gz"
 
     version('7.5.0', sha256='516748b4f1ae936c4d70cc6401174fc9384244c65cd3aef27bc2c53eac6d6de5')

--- a/var/spack/repos/builtin/packages/openpa/package.py
+++ b/var/spack/repos/builtin/packages/openpa/package.py
@@ -9,7 +9,7 @@ class Openpa(AutotoolsPackage):
     """An open source, highly-portable library that provides atomic primitives
     (and related constructs) for high performance, concurrent software"""
 
-    homepage = 'https://trac.mpich.org/projects/openpa'
+    homepage = 'https://github.com/pmodels/openpa'
     url      = 'https://github.com/pmodels/openpa/releases/download/v1.0.4/openpa-1.0.4.tar.gz'
 
     version('1.0.4', sha256='9e5904b3bbdcb24e8429c12d613422e716a3479f3e0aeefbd9ce546852899e3a')

--- a/var/spack/repos/builtin/packages/openslide/package.py
+++ b/var/spack/repos/builtin/packages/openslide/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Openslide(AutotoolsPackage):
     """OpenSlide reads whole slide image files."""
 
-    homepage = "http://openslide.org/"
+    homepage = "https://openslide.org/"
     url      = "https://github.com/openslide/openslide/releases/download/v3.4.1/openslide-3.4.1.tar.xz"
 
     version('3.4.1', sha256='9938034dba7f48fadc90a2cdf8cfe94c5613b04098d1348a5ff19da95b990564')

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -16,7 +16,7 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
        commercial-grade, and full-featured toolkit for the Transport
        Layer Security (TLS) and Secure Sockets Layer (SSL) protocols.
        It is also a general-purpose cryptography library."""
-    homepage = "http://www.openssl.org"
+    homepage = "https://www.openssl.org"
 
     # URL must remain http:// so Spack can bootstrap curl
     url = "http://www.openssl.org/source/openssl-1.1.1d.tar.gz"

--- a/var/spack/repos/builtin/packages/opensubdiv/package.py
+++ b/var/spack/repos/builtin/packages/opensubdiv/package.py
@@ -14,7 +14,7 @@ class Opensubdiv(CMakePackage, CudaPackage):
     This code path is optimized for drawing deforming surfaces
     with static topology at interactive framerates."""
 
-    homepage = "http://graphics.pixar.com/opensubdiv/docs/intro.html"
+    homepage = "https://graphics.pixar.com/opensubdiv/docs/intro.html"
     url      = "https://github.com/PixarAnimationStudios/OpenSubdiv/archive/v3_4_0.tar.gz"
     git      = "https://github.com/PixarAnimationStudios/OpenSubdiv"
 

--- a/var/spack/repos/builtin/packages/opus/package.py
+++ b/var/spack/repos/builtin/packages/opus/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Opus(AutotoolsPackage):
     """Opus is a totally open, royalty-free, highly versatile audio codec."""
 
-    homepage = "http://opus-codec.org/"
+    homepage = "https://opus-codec.org/"
     url      = "http://downloads.xiph.org/releases/opus/opus-1.1.4.tar.gz"
 
     version('1.3.1',      sha256='65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d')

--- a/var/spack/repos/builtin/packages/orientdb/package.py
+++ b/var/spack/repos/builtin/packages/orientdb/package.py
@@ -11,7 +11,7 @@ class Orientdb(MavenPackage):
     of Native Graphs, Documents Full-Text, Reactivity, Geo-Spatial and Object
     Oriented concepts. It's written in Java and it's amazingly fast."""
 
-    homepage = "https://orientdb.com/"
+    homepage = "https://orientdb.org"
     url      = "https://github.com/orientechnologies/orientdb/archive/3.1.2.tar.gz"
 
     version('3.1.2', sha256='3c8e1f55de9e1a6c3cd714832deb7369f50096e85f1e048f0c0328e611970850')

--- a/var/spack/repos/builtin/packages/packmol/package.py
+++ b/var/spack/repos/builtin/packages/packmol/package.py
@@ -10,7 +10,7 @@ class Packmol(CMakePackage):
     """Packmol creates an initial point for molecular dynamics simulations
     by packing molecules in defined regions of space."""
 
-    homepage = "http://m3g.iqm.unicamp.br/packmol/home.shtml"
+    homepage = "https://m3g.iqm.unicamp.br/packmol/home.shtml"
     url      = "https://github.com/mcubeg/packmol/archive/18.169.tar.gz"
 
     version('18.169', sha256='8acf2cbc742a609e763eb00cae55aecd09af2edb4cc4e931706e2f06ac380de9')

--- a/var/spack/repos/builtin/packages/parmgridgen/package.py
+++ b/var/spack/repos/builtin/packages/parmgridgen/package.py
@@ -15,7 +15,7 @@ class Parmgridgen(Package):
     ParMGridGen is the parallel version of MGridGen.
     """
 
-    homepage = "http://www-users.cs.umn.edu/~moulitsa/software.html"
+    homepage = "https://github.com/mrklein/ParMGridGen"
     url = "http://www.stasyan.com/devel/distfiles/ParMGridGen-1.0.tar.gz"
 
     version('1.0', sha256='62cdb6e48cfc59124e5d5d360c2841e0fc2feecafe65bda110b74e942740b395')

--- a/var/spack/repos/builtin/packages/perl-algorithm-diff/package.py
+++ b/var/spack/repos/builtin/packages/perl-algorithm-diff/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlAlgorithmDiff(PerlPackage):
     """Compute 'intelligent' differences between two files / lists"""
 
-    homepage = "http://search.cpan.org/~tyemq/Algorithm-Diff-1.1903/lib/Algorithm/Diff.pm"
+    homepage = "https://metacpan.org/pod/Algorithm::Diff"
     url      = "http://search.cpan.org/CPAN/authors/id/T/TY/TYEMQ/Algorithm-Diff-1.1903.tar.gz"
 
     version('1.1903', sha256='30e84ac4b31d40b66293f7b1221331c5a50561a39d580d85004d9c1fff991751')

--- a/var/spack/repos/builtin/packages/perl-app-cmd/package.py
+++ b/var/spack/repos/builtin/packages/perl-app-cmd/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlAppCmd(PerlPackage):
     """Write command line apps with less suffering"""
 
-    homepage = "http://search.cpan.org/~rjbs/App-Cmd/lib/App/Cmd.pm"
+    homepage = "https://metacpan.org/pod/App::Cmd"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/App-Cmd-0.331.tar.gz"
 
     version('0.331', sha256='4a5d3df0006bd278880d01f4957aaa652a8f91fe8f66e93adf70fba0c3ecb680')

--- a/var/spack/repos/builtin/packages/perl-array-utils/package.py
+++ b/var/spack/repos/builtin/packages/perl-array-utils/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlArrayUtils(PerlPackage):
     """Small utils for array manipulation"""
 
-    homepage = "http://search.cpan.org/~zmij/Array-Utils/Utils.pm"
+    homepage = "https://metacpan.org/pod/Array::Utils"
     url      = "http://search.cpan.org/CPAN/authors/id/Z/ZM/ZMIJ/Array/Array-Utils-0.5.tar.gz"
 
     version('0.5', sha256='89dd1b7fcd9b4379492a3a77496e39fe6cd379b773fd03a6b160dd26ede63770')

--- a/var/spack/repos/builtin/packages/perl-b-hooks-endofscope/package.py
+++ b/var/spack/repos/builtin/packages/perl-b-hooks-endofscope/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlBHooksEndofscope(PerlPackage):
     """Execute code after a scope finished compilation."""
 
-    homepage = "http://search.cpan.org/~ether/B-Hooks-EndOfScope-0.21/lib/B/Hooks/EndOfScope.pm"
+    homepage = "https://metacpan.org/pod/B::Hooks::EndOfScope"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/B-Hooks-EndOfScope-0.21.tar.gz"
 
     version('0.21', sha256='90f3580880f1d68b843c142cc86f58bead1f3e03634c63868ac9eba5eedae02c')

--- a/var/spack/repos/builtin/packages/perl-bit-vector/package.py
+++ b/var/spack/repos/builtin/packages/perl-bit-vector/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlBitVector(PerlPackage):
     """Efficient bit vector, set of integers and "big int" math library"""
 
-    homepage = "http://search.cpan.org/~stbey/Bit-Vector-7.4/Vector.pod"
+    homepage = "https://metacpan.org/dist/Bit-Vector/view/Vector.pod"
     url      = "http://search.cpan.org/CPAN/authors/id/S/ST/STBEY/Bit-Vector-7.4.tar.gz"
 
     version('7.4', sha256='3c6daa671fecfbc35f92a9385b563d65f50dfc6bdc8b4805f9ef46c0d035a926')

--- a/var/spack/repos/builtin/packages/perl-cairo/package.py
+++ b/var/spack/repos/builtin/packages/perl-cairo/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlCairo(PerlPackage):
     """Perl interface to the cairo 2d vector graphics library"""
 
-    homepage = "http://search.cpan.org/~xaoc/Cairo/lib/Cairo.pm"
+    homepage = "https://metacpan.org/pod/Cairo"
     url      = "http://search.cpan.org/CPAN/authors/id/X/XA/XAOC/Cairo-1.106.tar.gz"
 
     version('1.106', sha256='e64803018bc7cba49e73e258547f5378cc4249797beafec524852140f49c45c4')

--- a/var/spack/repos/builtin/packages/perl-capture-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-capture-tiny/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlCaptureTiny(PerlPackage):
     """Capture STDOUT and STDERR from Perl, XS or external programs"""
 
-    homepage = "http://search.cpan.org/~dagolden/Capture-Tiny-0.46/lib/Capture/Tiny.pm"
+    homepage = "https://metacpan.org/pod/Capture::Tiny"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.46.tar.gz"
 
     version('0.46', sha256='5d7a6a830cf7f2b2960bf8b8afaac16a537ede64f3023827acea5bd24ca77015')

--- a/var/spack/repos/builtin/packages/perl-carp-clan/package.py
+++ b/var/spack/repos/builtin/packages/perl-carp-clan/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlCarpClan(PerlPackage):
     """Report errors from perspective of caller of a "clan" of modules"""
 
-    homepage = "http://search.cpan.org/~kentnl/Carp-Clan-6.06/lib/Carp/Clan.pod"
+    homepage = "https://metacpan.org/pod/Carp::Clan"
     url      = "http://search.cpan.org/CPAN/authors/id/K/KE/KENTNL/Carp-Clan-6.06.tar.gz"
 
     version('6.06', sha256='ea4ac8f611354756d43cb369880032901e9cc4cc7e0bebb7b647186dac00c9d4')

--- a/var/spack/repos/builtin/packages/perl-class-data-inheritable/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-data-inheritable/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlClassDataInheritable(PerlPackage):
     """For creating accessor/mutators to class data."""
 
-    homepage = "http://search.cpan.org/~tmtm/Class-Data-Inheritable-0.08/lib/Class/Data/Inheritable.pm"
+    homepage = "https://metacpan.org/pod/Class::Data::Inheritable"
     url      = "http://search.cpan.org/CPAN/authors/id/T/TM/TMTM/Class-Data-Inheritable-0.08.tar.gz"
 
     version('0.08', sha256='9967feceea15227e442ec818723163eb6d73b8947e31f16ab806f6e2391af14a')

--- a/var/spack/repos/builtin/packages/perl-class-inspector/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-inspector/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlClassInspector(PerlPackage):
     """Get information about a class and its structure"""
 
-    homepage = "http://search.cpan.org/~plicease/Class-Inspector-1.32/lib/Class/Inspector.pm"
+    homepage = "https://metacpan.org/pod/Class::Inspector"
     url      = "http://search.cpan.org/CPAN/authors/id/P/PL/PLICEASE/Class-Inspector-1.32.tar.gz"
 
     version('1.32', sha256='cefadc8b5338e43e570bc43f583e7c98d535c17b196bcf9084bb41d561cc0535')

--- a/var/spack/repos/builtin/packages/perl-class-load-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-load-xs/package.py
@@ -10,7 +10,7 @@ class PerlClassLoadXs(PerlPackage):
     """This module provides an XS implementation for portions of
        Class::Load."""
 
-    homepage = "http://search.cpan.org/~ether/Class-Load-XS-0.10/lib/Class/Load/XS.pm"
+    homepage = "https://metacpan.org/pod/Class::Load::XS"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Class-Load-XS-0.10.tar.gz"
 
     version('0.10', sha256='5bc22cf536ebfd2564c5bdaf42f0d8a4cee3d1930fc8b44b7d4a42038622add1')

--- a/var/spack/repos/builtin/packages/perl-class-load/package.py
+++ b/var/spack/repos/builtin/packages/perl-class-load/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlClassLoad(PerlPackage):
     """A working (require "Class::Name") and more"""
 
-    homepage = "http://search.cpan.org/~ether/Class-Load-0.24/lib/Class/Load.pm"
+    homepage = "https://metacpan.org/pod/Class::Load"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Class-Load-0.24.tar.gz"
 
     version('0.24', sha256='0bb983da46c146534fc77a556d6e40d925142f2eb43103534025ee545265ca36')

--- a/var/spack/repos/builtin/packages/perl-compress-raw-bzip2/package.py
+++ b/var/spack/repos/builtin/packages/perl-compress-raw-bzip2/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlCompressRawBzip2(PerlPackage):
     """A low-Level Interface to bzip2 compression library."""
 
-    homepage = "http://search.cpan.org/~pmqs/Compress-Raw-Bzip2-2.081/lib/Compress/Raw/Bzip2.pm"
+    homepage = "https://metacpan.org/pod/Compress::Raw::Bzip2"
     url      = "http://search.cpan.org/CPAN/authors/id/P/PM/PMQS/Compress-Raw-Bzip2-2.081.tar.gz"
 
     version('2.081', sha256='8692b5c9db91954408e24e805fbfda222879da80d89d9410791421e3e5bc3520')

--- a/var/spack/repos/builtin/packages/perl-compress-raw-zlib/package.py
+++ b/var/spack/repos/builtin/packages/perl-compress-raw-zlib/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlCompressRawZlib(PerlPackage):
     """A low-Level Interface to zlib compression library."""
 
-    homepage = "http://search.cpan.org/~pmqs/Compress-Raw-Zlib-2.081/lib/Compress/Raw/Zlib.pm"
+    homepage = "https://metacpan.org/pod/Compress::Raw::Zlib"
     url      = "https://cpan.metacpan.org/authors/id/P/PM/PMQS/Compress-Raw-Zlib-2.081.tar.gz"
 
     version('2.081', sha256='e156de345bd224bbdabfcab0eeb3f678a3099a4e86c9d1b6771d880b55aa3a1b')

--- a/var/spack/repos/builtin/packages/perl-contextual-return/package.py
+++ b/var/spack/repos/builtin/packages/perl-contextual-return/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlContextualReturn(PerlPackage):
     """Create context-sensitive return values"""
 
-    homepage = "http://search.cpan.org/~dconway/Contextual-Return/lib/Contextual/Return.pm"
+    homepage = "https://metacpan.org/pod/Contextual::Return"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DC/DCONWAY/Contextual-Return-0.004014.tar.gz"
 
     version('0.004014', sha256='09fe1415e16e49a69e13c0ef6e6a4a3fd8b856f389d3f3e624d7ab3b71719f78')

--- a/var/spack/repos/builtin/packages/perl-cpan-meta-check/package.py
+++ b/var/spack/repos/builtin/packages/perl-cpan-meta-check/package.py
@@ -10,7 +10,7 @@ class PerlCpanMetaCheck(PerlPackage):
     """This module verifies if requirements described in a CPAN::Meta object
        are present.."""
 
-    homepage = "http://search.cpan.org/~leont/CPAN-Meta-Check-0.014/lib/CPAN/Meta/Check.pm"
+    homepage = "https://metacpan.org/pod/CPAN::Meta::Check"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/CPAN-Meta-Check-0.014.tar.gz"
 
     version('0.014', sha256='28a0572bfc1c0678d9ce7da48cf521097ada230f96eb3d063fcbae1cfe6a351f')

--- a/var/spack/repos/builtin/packages/perl-data-dumper/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-dumper/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDataDumper(PerlPackage):
     """Stringified perl data structures, suitable for both printing and eval"""
 
-    homepage = "http://search.cpan.org/dist/Data-Dumper/Dumper.pm"
+    homepage = "https://metacpan.org/pod/Data::Dumper"
     url      = "https://cpan.metacpan.org/authors/id/X/XS/XSAWYERX/Data-Dumper-2.173.tar.gz"
 
     version('2.173', sha256='697608b39330988e519131be667ff47168aaaaf99f06bd2095d5b46ad05d76fa')

--- a/var/spack/repos/builtin/packages/perl-data-optlist/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-optlist/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDataOptlist(PerlPackage):
     """Parse and validate simple name/value option pairs"""
 
-    homepage = "http://search.cpan.org/~rjbs/Data-OptList-0.110/lib/Data/OptList.pm"
+    homepage = "https://metacpan.org/pod/Data::OptList"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Data-OptList-0.110.tar.gz"
 
     version('0.110', sha256='366117cb2966473f2559f2f4575ff6ae69e84c69a0f30a0773e1b51a457ef5c3')

--- a/var/spack/repos/builtin/packages/perl-data-stag/package.py
+++ b/var/spack/repos/builtin/packages/perl-data-stag/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDataStag(PerlPackage):
     """Structured Tags datastructures"""
 
-    homepage = "http://search.cpan.org/~cmungall/Data-Stag-0.14/Data/Stag.pm"
+    homepage = "https://metacpan.org/pod/Data::Stag"
     url      = "http://search.cpan.org/CPAN/authors/id/C/CM/CMUNGALL/Data-Stag-0.14.tar.gz"
 
     version('0.14', sha256='4ab122508d2fb86d171a15f4006e5cf896d5facfa65219c0b243a89906258e59')

--- a/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
+++ b/var/spack/repos/builtin/packages/perl-dbd-mysql/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDbdMysql(PerlPackage):
     """MySQL driver for the Perl5 Database Interface (DBI)"""
 
-    homepage = "http://search.cpan.org/~michielb/DBD-mysql-4.043/lib/DBD/mysql.pm"
+    homepage = "https://metacpan.org/pod/DBD::mysql"
     url      = "http://search.cpan.org/CPAN/authors/id/M/MI/MICHIELB/DBD-mysql-4.043.tar.gz"
 
     version('4.043', sha256='629f865e8317f52602b2f2efd2b688002903d2e4bbcba5427cb6188b043d6f99')

--- a/var/spack/repos/builtin/packages/perl-devel-cycle/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-cycle/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDevelCycle(PerlPackage):
     """Find memory cycles in objects"""
 
-    homepage = "http://search.cpan.org/~lds/Devel-Cycle-1.12/lib/Devel/Cycle.pm"
+    homepage = "https://metacpan.org/pod/Devel::Cycle"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LD/LDS/Devel-Cycle-1.12.tar.gz"
 
     version('1.12', sha256='fd3365c4d898b2b2bddbb78a46d507a18cca8490a290199547dab7f1e7390bc2')

--- a/var/spack/repos/builtin/packages/perl-devel-globaldestruction/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-globaldestruction/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDevelGlobaldestruction(PerlPackage):
     """Makes Perl's global destruction less tricky to deal with"""
 
-    homepage = "http://search.cpan.org/~haarg/Devel-GlobalDestruction-0.14/lib/Devel/GlobalDestruction.pm"
+    homepage = "https://metacpan.org/pod/Devel::GlobalDestruction"
     url      = "http://search.cpan.org/CPAN/authors/id/H/HA/HAARG/Devel-GlobalDestruction-0.14.tar.gz"
 
     version('0.14', sha256='34b8a5f29991311468fe6913cadaba75fd5d2b0b3ee3bb41fe5b53efab9154ab')

--- a/var/spack/repos/builtin/packages/perl-devel-overloadinfo/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-overloadinfo/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDevelOverloadinfo(PerlPackage):
     """Returns information about overloaded operators for a given class"""
 
-    homepage = "http://search.cpan.org/~ilmari/Devel-OverloadInfo-0.004/lib/Devel/OverloadInfo.pm"
+    homepage = "https://metacpan.org/pod/Devel::OverloadInfo"
     url      = "http://search.cpan.org/CPAN/authors/id/I/IL/ILMARI/Devel-OverloadInfo-0.004.tar.gz"
 
     version('0.005', sha256='8bfde2ffa47c9946f8adc8cfc445c2f97b8d1cdd678111bee9f444e82f7aa6e7')

--- a/var/spack/repos/builtin/packages/perl-devel-stacktrace/package.py
+++ b/var/spack/repos/builtin/packages/perl-devel-stacktrace/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDevelStacktrace(PerlPackage):
     """An object representing a stack trace."""
 
-    homepage = "http://search.cpan.org/~drolsky/Devel-StackTrace-2.02/lib/Devel/StackTrace.pm"
+    homepage = "https://metacpan.org/pod/Devel::StackTrace"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Devel-StackTrace-2.02.tar.gz"
 
     version('2.02', sha256='cbbd96db0ecf194ed140198090eaea0e327d9a378a4aa15f9a34b3138a91931f')

--- a/var/spack/repos/builtin/packages/perl-digest-md5/package.py
+++ b/var/spack/repos/builtin/packages/perl-digest-md5/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDigestMd5(PerlPackage):
     """Perl interface to the MD5 Algorithm"""
 
-    homepage = "http://search.cpan.org/dist/Digest-MD5/MD5.pm"
+    homepage = "https://metacpan.org/pod/Digest::MD5"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/Digest-MD5-2.55.tar.gz"
 
     version('2.55', sha256='03b198a2d14425d951e5e50a885d3818c3162c8fe4c21e18d7798a9a179d0e3c')

--- a/var/spack/repos/builtin/packages/perl-dist-checkconflicts/package.py
+++ b/var/spack/repos/builtin/packages/perl-dist-checkconflicts/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlDistCheckconflicts(PerlPackage):
     """Declare version conflicts for your dist"""
 
-    homepage = "http://search.cpan.org/~doy/Dist-CheckConflicts-0.11/lib/Dist/CheckConflicts.pm"
+    homepage = "https://metacpan.org/pod/Dist::CheckConflicts"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Dist-CheckConflicts-0.11.tar.gz"
 
     version('0.11', sha256='ea844b9686c94d666d9d444321d764490b2cde2f985c4165b4c2c77665caedc4')

--- a/var/spack/repos/builtin/packages/perl-encode-locale/package.py
+++ b/var/spack/repos/builtin/packages/perl-encode-locale/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlEncodeLocale(PerlPackage):
     """Determine the locale encoding"""
 
-    homepage = "http://search.cpan.org/~gaas/Encode-Locale-1.05/lib/Encode/Locale.pm"
+    homepage = "https://metacpan.org/pod/Encode::Locale"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/Encode-Locale-1.05.tar.gz"
 
     version('1.05', sha256='176fa02771f542a4efb1dbc2a4c928e8f4391bf4078473bd6040d8f11adb0ec1')

--- a/var/spack/repos/builtin/packages/perl-eval-closure/package.py
+++ b/var/spack/repos/builtin/packages/perl-eval-closure/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlEvalClosure(PerlPackage):
     """Safely and cleanly create closures via string eval"""
 
-    homepage = "http://search.cpan.org/~doy/Eval-Closure-0.14/lib/Eval/Closure.pm"
+    homepage = "https://metacpan.org/pod/Eval::Closure"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Eval-Closure-0.14.tar.gz"
 
     version('0.14', sha256='ea0944f2f5ec98d895bef6d503e6e4a376fea6383a6bc64c7670d46ff2218cad')

--- a/var/spack/repos/builtin/packages/perl-exception-class/package.py
+++ b/var/spack/repos/builtin/packages/perl-exception-class/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlExceptionClass(PerlPackage):
     """A module that allows you to declare real exception classes in Perl"""
 
-    homepage = "http://search.cpan.org/~drolsky/Exception-Class-1.43/lib/Exception/Class.pm"
+    homepage = "https://metacpan.org/pod/Exception::Class"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Exception-Class-1.43.tar.gz"
 
     version('1.43', sha256='ff3b4b3f706e84aaa87ab0dee5cec6bd7a8fc9f72cf76d115212541fa0a13760')

--- a/var/spack/repos/builtin/packages/perl-exporter-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-exporter-tiny/package.py
@@ -10,7 +10,7 @@ class PerlExporterTiny(PerlPackage):
     """An exporter with the features of Sub::Exporter but only core
     dependencies"""
 
-    homepage = "http://search.cpan.org/~tobyink/Exporter-Tiny/lib/Exporter/Tiny.pm"
+    homepage = "https://metacpan.org/pod/Exporter::Tiny"
     url      = "http://search.cpan.org/CPAN/authors/id/T/TO/TOBYINK/Exporter-Tiny-1.000000.tar.gz"
 
     version('1.000000', sha256='ffdd77d57de099e8f64dd942ef12a00a3f4313c2531f342339eeed2d366ad078')

--- a/var/spack/repos/builtin/packages/perl-extutils-depends/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-depends/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlExtutilsDepends(PerlPackage):
     """Easily build XS extensions that depend on XS extensions"""
 
-    homepage = "http://search.cpan.org/~xaoc/ExtUtils-Depends/lib/ExtUtils/Depends.pm"
+    homepage = "https://metacpan.org/pod/ExtUtils::Depends"
     url      = "http://search.cpan.org/CPAN/authors/id/X/XA/XAOC/ExtUtils-Depends-0.405.tar.gz"
 
     version('0.405', sha256='8ad6401ad7559b03ceda1fe4b191c95f417bdec7c542a984761a4656715a8a2c')

--- a/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-pkgconfig/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlExtutilsPkgconfig(PerlPackage):
     """simplistic interface to pkg-config"""
 
-    homepage = "http://search.cpan.org/~xaoc/ExtUtils-PkgConfig-1.16/lib/ExtUtils/PkgConfig.pm"
+    homepage = "https://metacpan.org/pod/ExtUtils::PkgConfig"
     url      = "http://search.cpan.org/CPAN/authors/id/X/XA/XAOC/ExtUtils-PkgConfig-1.16.tar.gz"
 
     version('1.16', sha256='bbeaced995d7d8d10cfc51a3a5a66da41ceb2bc04fedcab50e10e6300e801c6e')

--- a/var/spack/repos/builtin/packages/perl-file-copy-recursive/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-copy-recursive/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlFileCopyRecursive(PerlPackage):
     """Perl extension for recursively copying files and directories"""
 
-    homepage = "http://search.cpan.org/~dmuey/File-Copy-Recursive-0.38/Recursive.pm"
+    homepage = "https://metacpan.org/pod/File::Copy::Recursive"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DM/DMUEY/File-Copy-Recursive-0.38.tar.gz"
 
     version('0.40', sha256='e8b8923b930ef7bcb59d4a97456d0e149b8487597cd1550f836451d936ce55a1')

--- a/var/spack/repos/builtin/packages/perl-file-listing/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-listing/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlFileListing(PerlPackage):
     """Parse directory listing"""
 
-    homepage = "http://search.cpan.org/~gaas/File-Listing-6.04/lib/File/Listing.pm"
+    homepage = "https://metacpan.org/pod/File::Listing"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/File-Listing-6.04.tar.gz"
 
     version('6.04', sha256='1e0050fcd6789a2179ec0db282bf1e90fb92be35d1171588bd9c47d52d959cf5')

--- a/var/spack/repos/builtin/packages/perl-file-pushd/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-pushd/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlFilePushd(PerlPackage):
     """Change directory temporarily for a limited scope"""
 
-    homepage = "http://search.cpan.org/~dagolden/File-pushd-1.014/lib/File/pushd.pm"
+    homepage = "https://metacpan.org/pod/File::pushd"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/File-pushd-1.014.tar.gz"
 
     version('1.014', sha256='b5ab37ffe3acbec53efb7c77b4423a2c79afa30a48298e751b9ebee3fdc6340b')

--- a/var/spack/repos/builtin/packages/perl-file-sharedir-install/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-sharedir-install/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlFileSharedirInstall(PerlPackage):
     """Install shared files"""
 
-    homepage = "http://search.cpan.org/~ether/File-ShareDir-Install-0.11/lib/File/ShareDir/Install.pm"
+    homepage = "https://metacpan.org/pod/File::ShareDir::Install"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/File-ShareDir-Install-0.11.tar.gz"
 
     version('0.11', sha256='32bf8772e9fea60866074b27ff31ab5bc3f88972d61915e84cbbb98455e00cc8')

--- a/var/spack/repos/builtin/packages/perl-file-slurp-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-slurp-tiny/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlFileSlurpTiny(PerlPackage):
     """A simple, sane and efficient file slurper"""
 
-    homepage = "http://search.cpan.org/~leont/File-Slurp-Tiny-0.004/lib/File/Slurp/Tiny.pm"
+    homepage = "https://metacpan.org/pod/File::Slurp::Tiny"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/File-Slurp-Tiny-0.004.tar.gz"
 
     version('0.004', sha256='452995beeabf0e923e65fdc627a725dbb12c9e10c00d8018c16d10ba62757f1e')

--- a/var/spack/repos/builtin/packages/perl-file-slurper/package.py
+++ b/var/spack/repos/builtin/packages/perl-file-slurper/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlFileSlurper(PerlPackage):
     """A simple, sane and efficient module to slurp a file"""
 
-    homepage = "http://search.cpan.org/~leont/File-Slurper/lib/File/Slurper.pm"
+    homepage = "https://metacpan.org/pod/File::Slurper"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/File-Slurper-0.011.tar.gz"
 
     version('0.011', sha256='f6494844b9759b3d1dd8fc4ffa790f8e6e493c4eb58e88831a51e085f2e76010')

--- a/var/spack/repos/builtin/packages/perl-font-ttf/package.py
+++ b/var/spack/repos/builtin/packages/perl-font-ttf/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlFontTtf(PerlPackage):
     """Perl module for TrueType Font hacking"""
 
-    homepage = "http://search.cpan.org/~bhallissy/Font-TTF-1.06/lib/Font/TTF.pm"
+    homepage = "https://metacpan.org/pod/Font::TTF"
     url      = "http://search.cpan.org/CPAN/authors/id/B/BH/BHALLISSY/Font-TTF-1.06.tar.gz"
 
     version('1.06', sha256='4b697d444259759ea02d2c442c9bffe5ffe14c9214084a01f743693a944cc293')

--- a/var/spack/repos/builtin/packages/perl-gd/package.py
+++ b/var/spack/repos/builtin/packages/perl-gd/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlGd(PerlPackage):
     """Interface to Gd Graphics Library"""
 
-    homepage = "http://search.cpan.org/~lds/GD-2.53/GD.pm"
+    homepage = "https://metacpan.org/pod/GD"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LD/LDS/GD-2.53.tar.gz"
 
     version('2.53', sha256='d05d01fe95e581adb3468cf05ab5d405db7497c0fb3ec7ecf23d023705fab7aa')

--- a/var/spack/repos/builtin/packages/perl-gdgraph/package.py
+++ b/var/spack/repos/builtin/packages/perl-gdgraph/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlGdgraph(PerlPackage):
     """Graph Plotting Module for Perl 5"""
 
-    homepage = "http://search.cpan.org/~bwarfield/GDGraph/Graph.pm"
+    homepage = "https://metacpan.org/pod/GD::Graph"
     url      = "http://search.cpan.org/CPAN/authors/id/B/BW/BWARFIELD/GDGraph-1.4308.tar.gz"
 
     version('1.4308', sha256='75b3c7e280431404ed096c6e120d552cc39052a8610787149515e94b9ba237cb')

--- a/var/spack/repos/builtin/packages/perl-gdtextutil/package.py
+++ b/var/spack/repos/builtin/packages/perl-gdtextutil/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlGdtextutil(PerlPackage):
     """Text utilities for use with GD"""
 
-    homepage = "http://search.cpan.org/~mverb/GDTextUtil-0.86/Text.pm"
+    homepage = "https://metacpan.org/pod/GD::Text"
     url      = "http://search.cpan.org/CPAN/authors/id/M/MV/MVERB/GDTextUtil-0.86.tar.gz"
 
     version('0.86', sha256='886ecbf85cfe94f4135ee5689c4847a9ae783ecb99e6759e12c734f2dd6116bc')

--- a/var/spack/repos/builtin/packages/perl-graph-readwrite/package.py
+++ b/var/spack/repos/builtin/packages/perl-graph-readwrite/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlGraphReadwrite(PerlPackage):
     """Write out directed graph in Dot format"""
 
-    homepage = "http://search.cpan.org/~neilb/Graph-ReadWrite/lib/Graph/Writer/Dot.pm"
+    homepage = "https://metacpan.org/pod/Graph::ReadWrite"
     url      = "http://search.cpan.org/CPAN/authors/id/N/NE/NEILB/Graph-ReadWrite-2.09.tar.gz"
 
     version('2.09', sha256='b01ef06ce922eea12d5ce614d63ddc5f3ee7ad0d05f9577051d3f87a89799a4a')

--- a/var/spack/repos/builtin/packages/perl-graph/package.py
+++ b/var/spack/repos/builtin/packages/perl-graph/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlGraph(PerlPackage):
     """Graph data structures and algorithms"""
 
-    homepage = "http://search.cpan.org/~jhi/Graph/lib/Graph.pod"
+    homepage = "https://metacpan.org/pod/Graph"
     url      = "http://search.cpan.org/CPAN/authors/id/J/JH/JHI/Graph-0.9704.tar.gz"
 
     version('0.9704', sha256='325e8eb07be2d09a909e450c13d3a42dcb2a2e96cc3ac780fe4572a0d80b2a25')

--- a/var/spack/repos/builtin/packages/perl-html-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-html-parser/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlHtmlParser(PerlPackage):
     """HTML parser class"""
 
-    homepage = "http://search.cpan.org/~gaas/HTML-Parser-3.72/Parser.pm"
+    homepage = "https://metacpan.org/pod/HTML::Parser"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/HTML-Parser-3.72.tar.gz"
 
     version('3.72', sha256='ec28c7e1d9e67c45eca197077f7cdc41ead1bb4c538c7f02a3296a4bb92f608b')

--- a/var/spack/repos/builtin/packages/perl-html-tagset/package.py
+++ b/var/spack/repos/builtin/packages/perl-html-tagset/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlHtmlTagset(PerlPackage):
     """Data tables useful in parsing HTML"""
 
-    homepage = "http://search.cpan.org/~petdance/HTML-Tagset-3.20/Tagset.pm"
+    homepage = "https://metacpan.org/pod/HTML::Tagset"
     url      = "http://search.cpan.org/CPAN/authors/id/P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz"
 
     version('3.20', sha256='adb17dac9e36cd011f5243881c9739417fd102fce760f8de4e9be4c7131108e2')

--- a/var/spack/repos/builtin/packages/perl-http-cookies/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-cookies/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlHttpCookies(PerlPackage):
     """HTTP cookie jars"""
 
-    homepage = "http://search.cpan.org/~oalders/HTTP-Cookies-6.04/lib/HTTP/Cookies.pm"
+    homepage = "https://metacpan.org/pod/HTTP::Cookies"
     url      = "http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/HTTP-Cookies-6.04.tar.gz"
 
     version('6.04', sha256='0cc7f079079dcad8293fea36875ef58dd1bfd75ce1a6c244cd73ed9523eb13d4')

--- a/var/spack/repos/builtin/packages/perl-http-daemon/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-daemon/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlHttpDaemon(PerlPackage):
     """A simple http server class"""
 
-    homepage = "http://search.cpan.org/~gaas/HTTP-Daemon-6.01/lib/HTTP/Daemon.pm"
+    homepage = "https://metacpan.org/pod/HTTP::Daemon"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/HTTP-Daemon-6.01.tar.gz"
 
     version('6.01', sha256='43fd867742701a3f9fcc7bd59838ab72c6490c0ebaf66901068ec6997514adc2')

--- a/var/spack/repos/builtin/packages/perl-http-date/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-date/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlHttpDate(PerlPackage):
     """Date conversion routines"""
 
-    homepage = "http://search.cpan.org/~gaas/HTTP-Date-6.02/lib/HTTP/Date.pm"
+    homepage = "https://metacpan.org/pod/HTTP::Date"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/HTTP-Date-6.02.tar.gz"
 
     version('6.02', sha256='e8b9941da0f9f0c9c01068401a5e81341f0e3707d1c754f8e11f42a7e629e333')

--- a/var/spack/repos/builtin/packages/perl-http-message/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-message/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlHttpMessage(PerlPackage):
     """HTTP style message (base class)"""
 
-    homepage = "http://search.cpan.org/~oalders/HTTP-Message-6.13/lib/HTTP/Status.pm"
+    homepage = "https://metacpan.org/pod/HTTP::Message"
     url      = "http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/HTTP-Message-6.13.tar.gz"
 
     version('6.13', sha256='f25f38428de851e5661e72f124476494852eb30812358b07f1c3a289f6f5eded')

--- a/var/spack/repos/builtin/packages/perl-http-negotiate/package.py
+++ b/var/spack/repos/builtin/packages/perl-http-negotiate/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlHttpNegotiate(PerlPackage):
     """Choose a variant to serve"""
 
-    homepage = "http://search.cpan.org/~gaas/HTTP-Negotiate-6.01/lib/HTTP/Negotiate.pm"
+    homepage = "https://metacpan.org/pod/HTTP::Negotiate"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/HTTP-Negotiate-6.01.tar.gz"
 
     version('6.01', sha256='1c729c1ea63100e878405cda7d66f9adfd3ed4f1d6cacaca0ee9152df728e016')

--- a/var/spack/repos/builtin/packages/perl-inline-c/package.py
+++ b/var/spack/repos/builtin/packages/perl-inline-c/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlInlineC(PerlPackage):
     """C Language Support for Inline"""
 
-    homepage = "http://search.cpan.org/~tinita/Inline-C-0.78/lib/Inline/C.pod"
+    homepage = "https://metacpan.org/pod/Inline::C"
     url      = "http://search.cpan.org/CPAN/authors/id/T/TI/TINITA/Inline-C-0.78.tar.gz"
 
     version('0.78', sha256='9a7804d85c01a386073d2176582b0262b6374c5c0341049da3ef84c6f53efbc7')

--- a/var/spack/repos/builtin/packages/perl-inline/package.py
+++ b/var/spack/repos/builtin/packages/perl-inline/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlInline(PerlPackage):
     """Write Perl Subroutines in Other Programming Languages"""
 
-    homepage = "http://search.cpan.org/~ingy/Inline-0.80/lib/Inline.pod"
+    homepage = "https://metacpan.org/pod/Inline"
     url      = "http://search.cpan.org/CPAN/authors/id/I/IN/INGY/Inline-0.80.tar.gz"
 
     version('0.80', sha256='7e2bd984b1ebd43e336b937896463f2c6cb682c956cbd2c311a464363d2ccef6')

--- a/var/spack/repos/builtin/packages/perl-io-compress/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-compress/package.py
@@ -10,7 +10,7 @@ class PerlIoCompress(PerlPackage):
     """A perl library for uncompressing gzip, zip, bzip2
     or lzop file/buffer."""
 
-    homepage = "http://search.cpan.org/~pmqs/IO-Compress-2.070/lib/IO/Uncompress/AnyUncompress.pm"
+    homepage = "https://metacpan.org/pod/IO::Uncompress::AnyUncompress"
     url      = "http://search.cpan.org/CPAN/authors/id/P/PM/PMQS/IO-Compress-2.081.tar.gz"
 
     version('2.081', sha256='5211c775544dc8c511af08edfb1c0c22734daa2789149c2a88d68e17b43546d9')

--- a/var/spack/repos/builtin/packages/perl-io-html/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-html/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlIoHtml(PerlPackage):
     """Open an HTML file with automatic charset detection."""
 
-    homepage = "http://search.cpan.org/~cjm/IO-HTML-1.001/lib/IO/HTML.pm"
+    homepage = "https://metacpan.org/pod/IO::HTML"
     url      = "http://search.cpan.org/CPAN/authors/id/C/CJ/CJM/IO-HTML-1.001.tar.gz"
 
     version('1.001', sha256='ea78d2d743794adc028bc9589538eb867174b4e165d7d8b5f63486e6b828e7e0')

--- a/var/spack/repos/builtin/packages/perl-io-sessiondata/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-sessiondata/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlIoSessiondata(PerlPackage):
     """A wrapper around a single IO::Socket object"""
 
-    homepage = "http://search.cpan.org/~phred/IO-SessionData-1.03/"
+    homepage = "https://metacpan.org/release/PHRED/IO-SessionData-1.03/source/lib/IO/SessionData.pm#PIO::SessionData"
     url      = "http://search.cpan.org/CPAN/authors/id/P/PH/PHRED/IO-SessionData-1.03.tar.gz"
 
     version('1.03', sha256='64a4712a3edbb3fd10230db296c29c8c66f066adfbc0c3df6a48258fef392ddd')

--- a/var/spack/repos/builtin/packages/perl-io-socket-ssl/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-socket-ssl/package.py
@@ -11,7 +11,7 @@ from spack import *
 class PerlIoSocketSsl(PerlPackage):
     """SSL sockets with IO::Socket interface"""
 
-    homepage = "http://search.cpan.org/~sullr/IO-Socket-SSL-2.052/lib/IO/Socket/SSL.pod"
+    homepage = "https://metacpan.org/dist/IO-Socket-SSL/view/lib/IO/Socket/SSL.pod"
     url      = "http://search.cpan.org/CPAN/authors/id/S/SU/SULLR/IO-Socket-SSL-2.052.tar.gz"
 
     version('2.052', sha256='e4897a9b17cb18a3c44aa683980d52cef534cdfcb8063d6877c879bfa2f26673')

--- a/var/spack/repos/builtin/packages/perl-io-string/package.py
+++ b/var/spack/repos/builtin/packages/perl-io-string/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlIoString(PerlPackage):
     """Emulate file interface for in-core strings"""
 
-    homepage = "http://search.cpan.org/~gaas/IO-String-1.08/String.pm"
+    homepage = "https://metacpan.org/pod/IO::String"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/IO-String-1.08.tar.gz"
 
     version('1.08', sha256='2a3f4ad8442d9070780e58ef43722d19d1ee21a803bf7c8206877a10482de5a0')

--- a/var/spack/repos/builtin/packages/perl-json/package.py
+++ b/var/spack/repos/builtin/packages/perl-json/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlJson(PerlPackage):
     """JSON (JavaScript Object Notation) encoder/decoder"""
 
-    homepage = "http://search.cpan.org/~ishigaki/JSON/lib/JSON.pm"
+    homepage = "https://metacpan.org/pod/JSON"
     url      = "http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/JSON-2.97001.tar.gz"
 
     version('2.97001', sha256='e277d9385633574923f48c297e1b8acad3170c69fa590e31fa466040fc6f8f5a')

--- a/var/spack/repos/builtin/packages/perl-list-moreutils/package.py
+++ b/var/spack/repos/builtin/packages/perl-list-moreutils/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlListMoreutils(PerlPackage):
     """Provide the stuff missing in List::Util"""
 
-    homepage = "http://search.cpan.org/~rehsack/List-MoreUtils/lib/List/MoreUtils.pm"
+    homepage = "https://metacpan.org/pod/List::MoreUtils"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RE/REHSACK/List-MoreUtils-0.428.tar.gz"
 
     version('0.428', sha256='713e0945d5f16e62d81d5f3da2b6a7b14a4ce439f6d3a7de74df1fd166476cc2')

--- a/var/spack/repos/builtin/packages/perl-log-log4perl/package.py
+++ b/var/spack/repos/builtin/packages/perl-log-log4perl/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlLogLog4perl(PerlPackage):
     """Log4j implementation for Perl"""
 
-    homepage = "http://search.cpan.org/~mschilli/Log-Log4perl-1.44/lib/Log/Log4perl.pm"
+    homepage = "https://metacpan.org/pod/Log::Log4perl"
     url      = "https://cpan.metacpan.org/authors/id/M/MS/MSCHILLI/Log-Log4perl-1.46.tar.gz"
 
     version('1.46', sha256='31011a17c04e78016e73eaa4865d0481d2ffc3dc22813c61065d90ad73c64e6f')

--- a/var/spack/repos/builtin/packages/perl-lwp-mediatypes/package.py
+++ b/var/spack/repos/builtin/packages/perl-lwp-mediatypes/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlLwpMediatypes(PerlPackage):
     """Guess media type for a file or a URL"""
 
-    homepage = "http://search.cpan.org/~gaas/LWP-MediaTypes-6.02/lib/LWP/MediaTypes.pm"
+    homepage = "https://metacpan.org/pod/LWP::MediaTypes"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/LWP-MediaTypes-6.02.tar.gz"
 
     version('6.02', sha256='18790b0cc5f0a51468495c3847b16738f785a2d460403595001e0b932e5db676')

--- a/var/spack/repos/builtin/packages/perl-lwp-protocol-https/package.py
+++ b/var/spack/repos/builtin/packages/perl-lwp-protocol-https/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlLwpProtocolHttps(PerlPackage):
     """ Provide https support for LWP::UserAgent"""
 
-    homepage = "http://search.cpan.org/~gaas/LWP-Protocol-https-6.04/lib/LWP/Protocol/https.pm"
+    homepage = "https://metacpan.org/pod/LWP::Protocol::https"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GA/GAAS/LWP-Protocol-https-6.04.tar.gz"
 
     version('6.04', sha256='1ef67750ee363525cf729b59afde805ac4dc80eaf8d36ca01082a4d78a7af629')

--- a/var/spack/repos/builtin/packages/perl-math-cdf/package.py
+++ b/var/spack/repos/builtin/packages/perl-math-cdf/package.py
@@ -10,7 +10,7 @@ class PerlMathCdf(PerlPackage):
     """Generate probabilities and quantiles from several statistical
        probability functions"""
 
-    homepage = "http://search.cpan.org/~callahan/Math-CDF-0.1/CDF.pm"
+    homepage = "https://metacpan.org/pod/Math::CDF"
     url      = "http://search.cpan.org/CPAN/authors/id/C/CA/CALLAHAN/Math-CDF-0.1.tar.gz"
 
     version('0.1', sha256='7896bf250835ce47dcc813cb8cf9dc576c5455de42e822dcd7d8d3fef2125565')

--- a/var/spack/repos/builtin/packages/perl-math-cephes/package.py
+++ b/var/spack/repos/builtin/packages/perl-math-cephes/package.py
@@ -10,7 +10,7 @@ class PerlMathCephes(PerlPackage):
     """This module provides an interface to over 150 functions of the
        cephes math library of Stephen Moshier."""
 
-    homepage = "http://search.cpan.org/~shlomif/Math-Cephes/lib/Math/Cephes.pod"
+    homepage = "https://metacpan.org/pod/Math::Cephes"
     url      = "http://search.cpan.org/CPAN/authors/id/S/SH/SHLOMIF/Math-Cephes-0.5305.tar.gz"
 
     version('0.5305', sha256='561a800a4822e748d2befc366baa4b21e879a40cc00c22293c7b8736caeb83a1')

--- a/var/spack/repos/builtin/packages/perl-math-matrixreal/package.py
+++ b/var/spack/repos/builtin/packages/perl-math-matrixreal/package.py
@@ -10,7 +10,7 @@ class PerlMathMatrixreal(PerlPackage):
     """Implements the data type "matrix of real numbers" (and consequently
     also "vector of real numbers")."""
 
-    homepage = "http://search.cpan.org/~leto/Math-MatrixReal/lib/Math/MatrixReal.pm"
+    homepage = "https://metacpan.org/pod/Math::MatrixReal"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LE/LETO/Math-MatrixReal-2.13.tar.gz"
 
     version('2.13', sha256='4f9fa1a46dd34d2225de461d9a4ed86932cdd821c121fa501a15a6d4302fb4b2')

--- a/var/spack/repos/builtin/packages/perl-module-build/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-build/package.py
@@ -16,7 +16,7 @@ class PerlModuleBuild(PerlPackage):
     pure-perl and written in a very cross-platform way.
     """
 
-    homepage = "http://search.cpan.org/perldoc/Module::Build"
+    homepage = "https://metacpan.org/pod/Module::Build"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/Module-Build-0.4224.tar.gz"
 
     version('0.4224', sha256='a6ca15d78244a7b50fdbf27f85c85f4035aa799ce7dd018a0d98b358ef7bc782')

--- a/var/spack/repos/builtin/packages/perl-module-implementation/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-implementation/package.py
@@ -10,7 +10,7 @@ class PerlModuleImplementation(PerlPackage):
     """Loads one of several alternate underlying implementations for a
     module"""
 
-    homepage = "http://search.cpan.org/~drolsky/Module-Implementation/lib/Module/Implementation.pm"
+    homepage = "https://metacpan.org/pod/Module::Implementation"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Module-Implementation-0.09.tar.gz"
 
     version('0.09', sha256='c15f1a12f0c2130c9efff3c2e1afe5887b08ccd033bd132186d1e7d5087fd66d')

--- a/var/spack/repos/builtin/packages/perl-module-runtime-conflicts/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-runtime-conflicts/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlModuleRuntimeConflicts(PerlPackage):
     """Provide information on conflicts for Module::Runtime"""
 
-    homepage = "http://search.cpan.org/~ether/Module-Runtime-Conflicts-0.003/lib/Module/Runtime/Conflicts.pm"
+    homepage = "https://metacpan.org/pod/Module::Runtime::Conflicts"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Module-Runtime-Conflicts-0.003.tar.gz"
 
     version('0.003', sha256='707cdc75038c70fe91779b888ac050f128565d3967ba96680e1b1c7cc9733875')

--- a/var/spack/repos/builtin/packages/perl-module-runtime/package.py
+++ b/var/spack/repos/builtin/packages/perl-module-runtime/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlModuleRuntime(PerlPackage):
     """Runtime module handling"""
 
-    homepage = "http://search.cpan.org/~zefram/Module-Runtime/lib/Module/Runtime.pm"
+    homepage = "https://metacpan.org/pod/Module::Runtime"
     url      = "http://search.cpan.org/CPAN/authors/id/Z/ZE/ZEFRAM/Module-Runtime-0.016.tar.gz"
 
     version('0.016', sha256='68302ec646833547d410be28e09676db75006f4aa58a11f3bdb44ffe99f0f024')

--- a/var/spack/repos/builtin/packages/perl-moose/package.py
+++ b/var/spack/repos/builtin/packages/perl-moose/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlMoose(PerlPackage):
     """A postmodern object system for Perl 5"""
 
-    homepage = "http://search.cpan.org/~ether/Moose-2.2006/lib/Moose.pm"
+    homepage = "https://metacpan.org/pod/Moose"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Moose-2.2006.tar.gz"
 
     version('2.2010', sha256='af0905b69f18c27de1177c9bc7778ee495d4ec91be1f223e8ca8333af4de08c5')

--- a/var/spack/repos/builtin/packages/perl-mozilla-ca/package.py
+++ b/var/spack/repos/builtin/packages/perl-mozilla-ca/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlMozillaCa(PerlPackage):
     """Mozilla's CA cert bundle in PEM format"""
 
-    homepage = "http://search.cpan.org/~abh/Mozilla-CA-20160104/lib/Mozilla/CA.pm"
+    homepage = "https://metacpan.org/pod/Mozilla::CA"
     url      = "http://search.cpan.org/CPAN/authors/id/A/AB/ABH/Mozilla-CA-20160104.tar.gz"
 
     version('20160104', sha256='27a7069a243162b65ada4194ff9d21b6ebc304af723eb5d3972fb74c11b03f2a')

--- a/var/spack/repos/builtin/packages/perl-mro-compat/package.py
+++ b/var/spack/repos/builtin/packages/perl-mro-compat/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlMroCompat(PerlPackage):
     """Provides several utilities for dealing with method resolution order."""
 
-    homepage = "http://search.cpan.org/~haarg/MRO-Compat-0.13/lib/MRO/Compat.pm"
+    homepage = "https://metacpan.org/pod/MRO::Compat"
     url      = "http://search.cpan.org/CPAN/authors/id/H/HA/HAARG/MRO-Compat-0.13.tar.gz"
 
     version('0.13', sha256='8a2c3b6ccc19328d5579d02a7d91285e2afd85d801f49d423a8eb16f323da4f8')

--- a/var/spack/repos/builtin/packages/perl-namespace-clean/package.py
+++ b/var/spack/repos/builtin/packages/perl-namespace-clean/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlNamespaceClean(PerlPackage):
     """Keep imports and functions out of your namespace."""
 
-    homepage = "http://search.cpan.org/~ribasushi/namespace-clean-0.27/lib/namespace/clean.pm"
+    homepage = "https://metacpan.org/pod/namespace::clean"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RI/RIBASUSHI/namespace-clean-0.27.tar.gz"
 
     version('0.27', sha256='8a10a83c3e183dc78f9e7b7aa4d09b47c11fb4e7d3a33b9a12912fd22e31af9d')

--- a/var/spack/repos/builtin/packages/perl-net-http/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-http/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlNetHttp(PerlPackage):
     """Low-level HTTP connection (client)"""
 
-    homepage = "http://search.cpan.org/~oalders/Net-HTTP-6.17/lib/Net/HTTP.pm"
+    homepage = "https://metacpan.org/pod/Net::HTTP"
     url      = "http://search.cpan.org/CPAN/authors/id/O/OA/OALDERS/Net-HTTP-6.17.tar.gz"
 
     version('6.17', sha256='1e8624b1618dc6f7f605f5545643ebb9b833930f4d7485d4124aa2f2f26d1611')

--- a/var/spack/repos/builtin/packages/perl-net-scp-expect/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-scp-expect/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlNetScpExpect(PerlPackage):
     """Wrapper for scp that allows passwords via Expect."""
 
-    homepage = "http://search.cpan.org/~rybskej/Net-SCP-Expect/Expect.pm"
+    homepage = "https://metacpan.org/pod/Net::SCP::Expect"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RY/RYBSKEJ/Net-SCP-Expect-0.16.tar.gz"
 
     version('0.16', sha256='97586e0ee0d61c987a7efaaffbfa551b95c426b3ef3625e046dc456fe9170591')

--- a/var/spack/repos/builtin/packages/perl-net-ssleay/package.py
+++ b/var/spack/repos/builtin/packages/perl-net-ssleay/package.py
@@ -11,7 +11,7 @@ from spack import *
 class PerlNetSsleay(PerlPackage):
     """Perl extension for using OpenSSL"""
 
-    homepage = "http://search.cpan.org/~mikem/Net-SSLeay-1.82/lib/Net/SSLeay.pod"
+    homepage = "https://metacpan.org/pod/Net::SSLeay"
     url      = "http://search.cpan.org/CPAN/authors/id/M/MI/MIKEM/Net-SSLeay-1.82.tar.gz"
 
     version('1.85', sha256='9d8188b9fb1cae3bd791979c20554925d5e94a138d00414f1a6814549927b0c8')

--- a/var/spack/repos/builtin/packages/perl-package-deprecationmanager/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-deprecationmanager/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPackageDeprecationmanager(PerlPackage):
     """Manage deprecation warnings for your distribution"""
 
-    homepage = "http://search.cpan.org/~drolsky/Package-DeprecationManager-0.17/lib/Package/DeprecationManager.pm"
+    homepage = "https://metacpan.org/pod/Package::DeprecationManager"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DR/DROLSKY/Package-DeprecationManager-0.17.tar.gz"
 
     version('0.17', sha256='1d743ada482b5c9871d894966e87d4c20edc96931bb949fb2638b000ddd6684b')

--- a/var/spack/repos/builtin/packages/perl-package-stash-xs/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-stash-xs/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPackageStashXs(PerlPackage):
     """Faster and more correct implementation of the Package::Stash API"""
 
-    homepage = "http://search.cpan.org/~doy/Package-Stash-XS-0.28/lib/Package/Stash/XS.pm"
+    homepage = "https://metacpan.org/pod/Package::Stash::XS"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Package-Stash-XS-0.28.tar.gz"
 
     version('0.28', sha256='23d8c5c25768ef1dc0ce53b975796762df0d6e244445d06e48d794886c32d486')

--- a/var/spack/repos/builtin/packages/perl-package-stash/package.py
+++ b/var/spack/repos/builtin/packages/perl-package-stash/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPackageStash(PerlPackage):
     """Routines for manipulating stashes"""
 
-    homepage = "http://search.cpan.org/~doy/Package-Stash-0.37/lib/Package/Stash.pm"
+    homepage = "https://metacpan.org/pod/Package::Stash"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DO/DOY/Package-Stash-0.37.tar.gz"
 
     version('0.37', sha256='06ab05388f9130cd377c0e1d3e3bafeed6ef6a1e22104571a9e1d7bfac787b2c')

--- a/var/spack/repos/builtin/packages/perl-padwalker/package.py
+++ b/var/spack/repos/builtin/packages/perl-padwalker/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPadwalker(PerlPackage):
     """play with other peoples' lexical variables"""
 
-    homepage = "http://search.cpan.org/~robin/PadWalker-2.2/PadWalker.pm"
+    homepage = "https://metacpan.org/pod/PadWalker"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RO/ROBIN/PadWalker-2.2.tar.gz"
 
     version('2.2', sha256='fc1df2084522e29e892da393f3719d2c1be0da022fdd89cff4b814167aecfea3')

--- a/var/spack/repos/builtin/packages/perl-parallel-forkmanager/package.py
+++ b/var/spack/repos/builtin/packages/perl-parallel-forkmanager/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlParallelForkmanager(PerlPackage):
     """A simple parallel processing fork manager"""
 
-    homepage = "http://search.cpan.org/~yanick/Parallel-ForkManager/lib/Parallel/ForkManager.pm"
+    homepage = "https://metacpan.org/pod/Parallel::ForkManager"
     url      = "http://search.cpan.org/CPAN/authors/id/Y/YA/YANICK/Parallel-ForkManager-1.19.tar.gz"
 
     version('1.19', sha256='f1de2e9875eeb77d65f80338905dedd522f3913822502982f805aa71cde5a472')

--- a/var/spack/repos/builtin/packages/perl-params-util/package.py
+++ b/var/spack/repos/builtin/packages/perl-params-util/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlParamsUtil(PerlPackage):
     """Simple, compact and correct param-checking functions"""
 
-    homepage = "http://search.cpan.org/~adamk/Params-Util-1.07/lib/Params/Util.pm"
+    homepage = "https://metacpan.org/pod/Params::Util"
     url      = "http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Params-Util-1.07.tar.gz"
 
     version('1.07', sha256='30f1ec3f2cf9ff66ae96f973333f23c5f558915bb6266881eac7423f52d7c76c')

--- a/var/spack/repos/builtin/packages/perl-parse-recdescent/package.py
+++ b/var/spack/repos/builtin/packages/perl-parse-recdescent/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlParseRecdescent(PerlPackage):
     """Generate Recursive-Descent Parsers"""
 
-    homepage = "http://search.cpan.org/~jtbraun/Parse-RecDescent-1.967015/lib/Parse/RecDescent.pm"
+    homepage = "https://metacpan.org/pod/Parse::RecDescent"
     url      = "http://search.cpan.org/CPAN/authors/id/J/JT/JTBRAUN/Parse-RecDescent-1.967015.tar.gz"
 
     version('1.967015', sha256='1943336a4cb54f1788a733f0827c0c55db4310d5eae15e542639c9dd85656e37')

--- a/var/spack/repos/builtin/packages/perl-pdf-api2/package.py
+++ b/var/spack/repos/builtin/packages/perl-pdf-api2/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPdfApi2(PerlPackage):
     """Facilitates the creation and modification of PDF files"""
 
-    homepage = "http://search.cpan.org/~ssimms/PDF-API2-2.033/lib/PDF/API2.pm"
+    homepage = "https://metacpan.org/pod/PDF::API2"
     url      = "http://search.cpan.org/CPAN/authors/id/S/SS/SSIMMS/PDF-API2-2.033.tar.gz"
 
     version('2.033', sha256='9c0866ec1a3053f73afaca5f5cdbe6925903b4ce606f4bf4ac317731a69d27a0')

--- a/var/spack/repos/builtin/packages/perl-pegex/package.py
+++ b/var/spack/repos/builtin/packages/perl-pegex/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPegex(PerlPackage):
     """Acmeist PEG Parser Framework"""
 
-    homepage = "http://search.cpan.org/~ingy/Pegex-0.64/lib/Pegex.pod"
+    homepage = "https://metacpan.org/pod/Pegex"
     url      = "http://search.cpan.org/CPAN/authors/id/I/IN/INGY/Pegex-0.64.tar.gz"
 
     version('0.64', sha256='27e00264bdafb9c2109212b9654542032617fecf7b7814915d2bdac198f067cd')

--- a/var/spack/repos/builtin/packages/perl-perl-version/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl-version/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPerlVersion(PerlPackage):
     """Parse and manipulate Perl version strings"""
 
-    homepage = "http://search.cpan.org/~bdfoy/Perl-Version-1.013/lib/Perl/Version.pm"
+    homepage = "https://metacpan.org/pod/Perl::Version"
     url      = "http://search.cpan.org/CPAN/authors/id/B/BD/BDFOY/Perl-Version-1.013_03.tar.gz"
 
     version('1.013_03', sha256='6b5978f598dcdf8a304500c1b7bcdce967ca05e7b38673cebfdb4237531c2ff9')

--- a/var/spack/repos/builtin/packages/perl-perl6-slurp/package.py
+++ b/var/spack/repos/builtin/packages/perl-perl6-slurp/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPerl6Slurp(PerlPackage):
     """Perl6::Slurp - Implements the Perl 6 'slurp' built-in"""
 
-    homepage = "http://search.cpan.org/~dconway/Perl6-Slurp-0.051005/lib/Perl6/Slurp.pm"
+    homepage = "https://metacpan.org/pod/Perl6::Slurp"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DC/DCONWAY/Perl6-Slurp-0.051005.tar.gz"
 
     version('0.051005', sha256='0e0ceb30495ecf64dc6cacd12113d604871104c0cfe153487b8d68bc9393d78f')

--- a/var/spack/repos/builtin/packages/perl-perlio-gzip/package.py
+++ b/var/spack/repos/builtin/packages/perl-perlio-gzip/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPerlioGzip(PerlPackage):
     """Perl extension to provide a PerlIO layer to gzip/gunzip"""
 
-    homepage = "http://search.cpan.org/~nwclark/PerlIO-gzip/gzip.pm"
+    homepage = "https://metacpan.org/pod/PerlIO::gzip"
     url      = "http://search.cpan.org/CPAN/authors/id/N/NW/NWCLARK/PerlIO-gzip-0.19.tar.gz"
 
     version('0.20', sha256='4848679a3f201e3f3b0c5f6f9526e602af52923ffa471a2a3657db786bd3bdc5')

--- a/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
+++ b/var/spack/repos/builtin/packages/perl-perlio-utf8-strict/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlPerlioUtf8Strict(PerlPackage):
     """This module provides a fast and correct UTF-8 PerlIO layer."""
 
-    homepage = "http://search.cpan.org/~leont/PerlIO-utf8_strict/lib/PerlIO/utf8_strict.pm"
+    homepage = "https://metacpan.org/pod/PerlIO::utf8_strict"
     url      = "http://search.cpan.org/CPAN/authors/id/L/LE/LEONT/PerlIO-utf8_strict-0.002.tar.gz"
 
     version('0.002', sha256='6e3163f8a2f1d276c975f21789d7a07843586d69e3e6156ffb67ef6680ceb75f')

--- a/var/spack/repos/builtin/packages/perl-soap-lite/package.py
+++ b/var/spack/repos/builtin/packages/perl-soap-lite/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlSoapLite(PerlPackage):
     """Perl's Web Services Toolkit"""
 
-    homepage = "http://search.cpan.org/~phred/SOAP-Lite-1.20/lib/SOAP/Lite.pm"
+    homepage = "https://metacpan.org/pod/SOAP::Lite"
     url      = "http://search.cpan.org/CPAN/authors/id/P/PH/PHRED/SOAP-Lite-1.22.tar.gz"
 
     version('1.22', sha256='92f492f8722cb3002cd1dce11238cee5599bb5bd451a062966df45223d33693a')

--- a/var/spack/repos/builtin/packages/perl-statistics-descriptive/package.py
+++ b/var/spack/repos/builtin/packages/perl-statistics-descriptive/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlStatisticsDescriptive(PerlPackage):
     """Module of basic descriptive statistical functions."""
 
-    homepage = "http://search.cpan.org/~shlomif/Statistics-Descriptive-3.0612/lib/Statistics/Descriptive.pm"
+    homepage = "https://metacpan.org/pod/Statistics::Descriptive"
     url      = "http://search.cpan.org/CPAN/authors/id/S/SH/SHLOMIF/Statistics-Descriptive-3.0612.tar.gz"
 
     version('3.0612', sha256='772413148e5e00efb32f277c4254aa78b9112490a896208dcd0025813afdbf7a')

--- a/var/spack/repos/builtin/packages/perl-statistics-pca/package.py
+++ b/var/spack/repos/builtin/packages/perl-statistics-pca/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlStatisticsPca(PerlPackage):
     """A simple Perl implementation of Principal Component Analysis."""
 
-    homepage = "http://search.cpan.org/~dsth/Statistics-PCA/lib/Statistics/PCA.pm"
+    homepage = "https://metacpan.org/pod/Statistics::PCA"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DS/DSTH/Statistics-PCA-0.0.1.tar.gz"
 
     version('0.0.1', sha256='f8adb10b00232123d103a5b49161ad46370f47fe0f752e5462a4dc15f9d46bc4')

--- a/var/spack/repos/builtin/packages/perl-sub-exporter-progressive/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-exporter-progressive/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlSubExporterProgressive(PerlPackage):
     """Progressive Sub::Exporter"""
 
-    homepage = "http://search.cpan.org/~frew/Sub-Exporter-Progressive-0.001013/lib/Sub/Exporter/Progressive.pm"
+    homepage = "https://metacpan.org/pod/Sub::Exporter::Progressive"
     url      = "http://search.cpan.org/CPAN/authors/id/F/FR/FREW/Sub-Exporter-Progressive-0.001013.tar.gz"
 
     version('0.001013', sha256='d535b7954d64da1ac1305b1fadf98202769e3599376854b2ced90c382beac056')

--- a/var/spack/repos/builtin/packages/perl-sub-exporter/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-exporter/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlSubExporter(PerlPackage):
     """A sophisticated exporter for custom-built routines"""
 
-    homepage = "http://search.cpan.org/~rjbs/Sub-Exporter-0.987/lib/Sub/Exporter.pm"
+    homepage = "https://metacpan.org/pod/Sub::Exporter"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Sub-Exporter-0.987.tar.gz"
 
     version('0.987', sha256='543cb2e803ab913d44272c7da6a70bb62c19e467f3b12aaac4c9523259b083d6')

--- a/var/spack/repos/builtin/packages/perl-sub-identify/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-identify/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlSubIdentify(PerlPackage):
     """Retrieve names of code references"""
 
-    homepage = "http://search.cpan.org/~rgarcia/Sub-Identify-0.14/lib/Sub/Identify.pm"
+    homepage = "https://metacpan.org/pod/Sub::Identify"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RG/RGARCIA/Sub-Identify-0.14.tar.gz"
 
     version('0.14', sha256='068d272086514dd1e842b6a40b1bedbafee63900e5b08890ef6700039defad6f')

--- a/var/spack/repos/builtin/packages/perl-sub-install/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-install/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlSubInstall(PerlPackage):
     """Install subroutines into packages easily"""
 
-    homepage = "http://search.cpan.org/~rjbs/Sub-Install-0.928/lib/Sub/Install.pm"
+    homepage = "https://metacpan.org/pod/Sub::Install"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Sub-Install-0.928.tar.gz"
 
     version('0.928', sha256='61e567a7679588887b7b86d427bc476ea6d77fffe7e0d17d640f89007d98ef0f')

--- a/var/spack/repos/builtin/packages/perl-sub-name/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-name/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlSubName(PerlPackage):
     """Name or rename a sub"""
 
-    homepage = "http://search.cpan.org/~ether/Sub-Name-0.21/lib/Sub/Name.pm"
+    homepage = "https://metacpan.org/pod/Sub::Name"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Sub-Name-0.21.tar.gz"
 
     version('0.21', sha256='bd32e9dee07047c10ae474c9f17d458b6e9885a6db69474c7a494ccc34c27117')

--- a/var/spack/repos/builtin/packages/perl-sub-uplevel/package.py
+++ b/var/spack/repos/builtin/packages/perl-sub-uplevel/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlSubUplevel(PerlPackage):
     """apparently run a function in a higher stack frame"""
 
-    homepage = "http://search.cpan.org/~dagolden/Sub-Uplevel-0.2800/lib/Sub/Uplevel.pm"
+    homepage = "https://metacpan.org/pod/Sub::Uplevel"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DA/DAGOLDEN/Sub-Uplevel-0.2800.tar.gz"
 
     version('0.2800', sha256='b4f3f63b80f680a421332d8851ddbe5a8e72fcaa74d5d1d98f3c8cc4a3ece293')

--- a/var/spack/repos/builtin/packages/perl-svg/package.py
+++ b/var/spack/repos/builtin/packages/perl-svg/package.py
@@ -10,7 +10,7 @@ class PerlSvg(PerlPackage):
     """Perl extension for generating Scalable Vector Graphics (SVG) documents.
     """
 
-    homepage = "http://search.cpan.org/~manwar/SVG-2.78/lib/SVG.pm"
+    homepage = "https://metacpan.org/pod/SVG"
     url      = "http://search.cpan.org/CPAN/authors/id/M/MA/MANWAR/SVG-2.78.tar.gz"
 
     version('2.78', sha256='a665c1f18c0529f3da0f4b631976eb47e0f71f6d6784ef3f44d32fd76643d6bb')

--- a/var/spack/repos/builtin/packages/perl-task-weaken/package.py
+++ b/var/spack/repos/builtin/packages/perl-task-weaken/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTaskWeaken(PerlPackage):
     """Ensure that a platform has weaken support"""
 
-    homepage = "http://search.cpan.org/~adamk/Task-Weaken-1.04/lib/Task/Weaken.pm"
+    homepage = "https://metacpan.org/pod/Task::Weaken"
     url      = "http://search.cpan.org/CPAN/authors/id/A/AD/ADAMK/Task-Weaken-1.04.tar.gz"
 
     version('1.04', sha256='67e271c55900fe7889584f911daa946e177bb60c8af44c32f4584b87766af3c4')

--- a/var/spack/repos/builtin/packages/perl-termreadkey/package.py
+++ b/var/spack/repos/builtin/packages/perl-termreadkey/package.py
@@ -15,7 +15,7 @@ class PerlTermreadkey(PerlPackage):
     "use Term::ReadKey" on any architecture and have a good likelihood of it
     working."""
 
-    homepage = "http://search.cpan.org/perldoc/Term::ReadKey"
+    homepage = "https://metacpan.org/pod/Term::ReadKey"
     url = "http://www.cpan.org/authors/id/J/JS/JSTOWE/TermReadKey-2.37.tar.gz"
 
     version('2.38', sha256='5a645878dc570ac33661581fbb090ff24ebce17d43ea53fd22e105a856a47290')

--- a/var/spack/repos/builtin/packages/perl-test-cleannamespaces/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-cleannamespaces/package.py
@@ -10,7 +10,7 @@ class PerlTestCleannamespaces(PerlPackage):
     """This module lets you check your module's namespaces for imported
        functions you might have forgotten to remove"""
 
-    homepage = "http://search.cpan.org/~ether/Test-CleanNamespaces-0.22/lib/Test/CleanNamespaces.pm"
+    homepage = "https://metacpan.org/pod/Test::CleanNamespaces"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Test-CleanNamespaces-0.22.tar.gz"
 
     version('0.22', sha256='862a221994dd413b2f350450f22c96f57cac78784b1aca1a8fc763fc5449aaca')

--- a/var/spack/repos/builtin/packages/perl-test-deep/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-deep/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestDeep(PerlPackage):
     """Extremely flexible deep comparison"""
 
-    homepage = "http://search.cpan.org/~rjbs/Test-Deep-1.127/lib/Test/Deep.pm"
+    homepage = "https://metacpan.org/pod/Test::Deep"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Test-Deep-1.127.tar.gz"
 
     version('1.127', sha256='b78cfc59c41ba91f47281e2c1d2bfc4b3b1b42bfb76b4378bc88cc37b7af7268')

--- a/var/spack/repos/builtin/packages/perl-test-differences/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-differences/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestDifferences(PerlPackage):
     """Test strings and data structures and show differences if not ok"""
 
-    homepage = "http://search.cpan.org/~dcantrell/Test-Differences-0.64/lib/Test/Differences.pm"
+    homepage = "https://metacpan.org/pod/Test::Differences"
     url      = "http://search.cpan.org/CPAN/authors/id/D/DC/DCANTRELL/Test-Differences-0.64.tar.gz"
 
     version('0.64', sha256='9f459dd9c2302a0a73e2f5528a0ce7d09d6766f073187ae2c69e603adf2eb276')

--- a/var/spack/repos/builtin/packages/perl-test-exception/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-exception/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestException(PerlPackage):
     """Test exception-based code"""
 
-    homepage = "http://search.cpan.org/~exodist/Test-Exception-0.43/lib/Test/Exception.pm"
+    homepage = "https://metacpan.org/pod/Test::Exception"
     url      = "http://search.cpan.org/CPAN/authors/id/E/EX/EXODIST/Test-Exception-0.43.tar.gz"
 
     version('0.43', sha256='156b13f07764f766d8b45a43728f2439af81a3512625438deab783b7883eb533')

--- a/var/spack/repos/builtin/packages/perl-test-fatal/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-fatal/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestFatal(PerlPackage):
     """Incredibly simple helpers for testing code with exceptions"""
 
-    homepage = "http://search.cpan.org/~rjbs/Test-Fatal-0.014/lib/Test/Fatal.pm"
+    homepage = "https://metacpan.org/pod/Test::Fatal"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Test-Fatal-0.014.tar.gz"
 
     version('0.014', sha256='bcdcef5c7b2790a187ebca810b0a08221a63256062cfab3c3b98685d91d1cbb0')

--- a/var/spack/repos/builtin/packages/perl-test-memory-cycle/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-memory-cycle/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestMemoryCycle(PerlPackage):
     """Check for memory leaks and circular memory references"""
 
-    homepage = "http://search.cpan.org/~petdance/Test-Memory-Cycle-1.06/Cycle.pm"
+    homepage = "https://metacpan.org/pod/Test::Memory::Cycle"
     url      = "http://search.cpan.org/CPAN/authors/id/P/PE/PETDANCE/Test-Memory-Cycle-1.06.tar.gz"
 
     version('1.06', sha256='9d53ddfdc964cd8454cb0da4c695b6a3ae47b45839291c34cb9d8d1cfaab3202')

--- a/var/spack/repos/builtin/packages/perl-test-most/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-most/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestMost(PerlPackage):
     """Most commonly needed test functions and features."""
 
-    homepage = "http://search.cpan.org/~ovid/Test-Most-0.35/lib/Test/Most.pm"
+    homepage = "https://metacpan.org/pod/Test::Most"
     url      = "http://search.cpan.org/CPAN/authors/id/O/OV/OVID/Test-Most-0.35.tar.gz"
 
     version('0.35', sha256='9897a6f4d751598d2ed1047e01c1554b01d0f8c96c45e7e845229782bf6f657f')

--- a/var/spack/repos/builtin/packages/perl-test-needs/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-needs/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestNeeds(PerlPackage):
     """Skip tests when modules not available."""
 
-    homepage = "http://search.cpan.org/~haarg/Test-Needs-0.002005/lib/Test/Needs.pm"
+    homepage = "https://metacpan.org/pod/Test::Needs"
     url      = "http://search.cpan.org/CPAN/authors/id/H/HA/HAARG/Test-Needs-0.002005.tar.gz"
 
     version('0.002005', sha256='5a4f33983586edacdbe00a3b429a9834190140190dab28d0f873c394eb7df399')

--- a/var/spack/repos/builtin/packages/perl-test-requires/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-requires/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestRequires(PerlPackage):
     """Checks to see if the module can be loaded."""
 
-    homepage = "http://search.cpan.org/~tokuhirom/Test-Requires-0.10/lib/Test/Requires.pm"
+    homepage = "https://metacpan.org/pod/Test::Requires"
     url      = "http://search.cpan.org/CPAN/authors/id/T/TO/TOKUHIROM/Test-Requires-0.10.tar.gz"
 
     version('0.10', sha256='2768a391d50ab94b95cefe540b9232d7046c13ee86d01859e04c044903222eb5')

--- a/var/spack/repos/builtin/packages/perl-test-requiresinternet/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-requiresinternet/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestRequiresinternet(PerlPackage):
     """Easily test network connectivity"""
 
-    homepage = "http://search.cpan.org/~mallen/Test-RequiresInternet-0.05/lib/Test/RequiresInternet.pm"
+    homepage = "https://metacpan.org/pod/Test::RequiresInternet"
     url      = "http://search.cpan.org/CPAN/authors/id/M/MA/MALLEN/Test-RequiresInternet-0.05.tar.gz"
 
     version('0.05', sha256='bba7b32a1cc0d58ce2ec20b200a7347c69631641e8cae8ff4567ad24ef1e833e')

--- a/var/spack/repos/builtin/packages/perl-test-warn/package.py
+++ b/var/spack/repos/builtin/packages/perl-test-warn/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTestWarn(PerlPackage):
     """Perl extension to test methods for warnings"""
 
-    homepage = "http://search.cpan.org/~chorny/Test-Warn-0.30/Warn.pm"
+    homepage = "https://metacpan.org/pod/Test::Warn"
     url      = "http://search.cpan.org/CPAN/authors/id/C/CH/CHORNY/Test-Warn-0.30.tar.gz"
 
     version('0.30', sha256='8197555b94189d919349a03f7058f83861f145af9bee59f505bfe47562144e41')

--- a/var/spack/repos/builtin/packages/perl-text-csv/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-csv/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTextCsv(PerlPackage):
     """Comma-separated values manipulator (using XS or PurePerl)"""
 
-    homepage = "http://search.cpan.org/~ishigaki/Text-CSV/lib/Text/CSV.pm"
+    homepage = "https://metacpan.org/pod/Text::CSV"
     url      = "http://search.cpan.org/CPAN/authors/id/I/IS/ISHIGAKI/Text-CSV-1.95.tar.gz"
 
     version('1.95', sha256='7e0a11d9c1129a55b68a26aa4b37c894279df255aa63ec8341d514ab848dbf61')

--- a/var/spack/repos/builtin/packages/perl-text-diff/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-diff/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTextDiff(PerlPackage):
     """Provides a basic set of services akin to the GNU diff utility."""
 
-    homepage = "http://search.cpan.org/~neilb/Text-Diff-1.45/lib/Text/Diff.pm"
+    homepage = "https://metacpan.org/pod/Text::Diff"
     url      = "http://search.cpan.org/CPAN/authors/id/N/NE/NEILB/Text-Diff-1.45.tar.gz"
 
     version('1.45', sha256='e8baa07b1b3f53e00af3636898bbf73aec9a0ff38f94536ede1dbe96ef086f04')

--- a/var/spack/repos/builtin/packages/perl-text-simpletable/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-simpletable/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTextSimpletable(PerlPackage):
     """Simple Eyecandy ASCII Tables"""
 
-    homepage = "http://search.cpan.org/~mramberg/Text-SimpleTable/lib/Text/SimpleTable.pm"
+    homepage = "https://metacpan.org/pod/Text::SimpleTable"
     url      = "http://search.cpan.org/CPAN/authors/id/M/MR/MRAMBERG/Text-SimpleTable-2.04.tar.gz"
 
     version('2.04', sha256='8d82f3140b1453b962956b7855ba288d435e7f656c3c40ced4e3e8e359ab5293')

--- a/var/spack/repos/builtin/packages/perl-text-soundex/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-soundex/package.py
@@ -12,7 +12,7 @@ class PerlTextSoundex(PerlPackage):
        pronunciation to be encoded to the same representation so
        that they can be matched despite minor differences in spelling"""
 
-    homepage = "http://search.cpan.org/~rjbs/Text-Soundex-3.05/Soundex.pm"
+    homepage = "https://metacpan.org/pod/Text::Soundex"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RJ/RJBS/Text-Soundex-3.05.tar.gz"
 
     version('3.05', sha256='f6dd55b4280b25dea978221839864382560074e1d6933395faee2510c2db60ed')

--- a/var/spack/repos/builtin/packages/perl-text-unidecode/package.py
+++ b/var/spack/repos/builtin/packages/perl-text-unidecode/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTextUnidecode(PerlPackage):
     """plain ASCII transliterations of Unicode text"""
 
-    homepage = "http://search.cpan.org/~sburke/Text-Unidecode/lib/Text/Unidecode.pm"
+    homepage = "https://metacpan.org/pod/Text::Unidecode"
     url      = "http://search.cpan.org/CPAN/authors/id/S/SB/SBURKE/Text-Unidecode-1.30.tar.gz"
 
     version('1.30', sha256='6c24f14ddc1d20e26161c207b73ca184eed2ef57f08b5fb2ee196e6e2e88b1c6')

--- a/var/spack/repos/builtin/packages/perl-time-hires/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-hires/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTimeHires(PerlPackage):
     """High resolution alarm, sleep, gettimeofday, interval timers"""
 
-    homepage = "http://search.cpan.org/~jhi/Time-HiRes-1.9746/HiRes.pm"
+    homepage = "https://metacpan.org/pod/Time::HiRes"
     url      = "http://search.cpan.org/CPAN/authors/id/J/JH/JHI/Time-HiRes-1.9746.tar.gz"
 
     version('1.9746', sha256='89408c81bb827bc908c98eec50071e6e1158f38fa462865ecc3dc03aebf5f596')

--- a/var/spack/repos/builtin/packages/perl-time-piece/package.py
+++ b/var/spack/repos/builtin/packages/perl-time-piece/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTimePiece(PerlPackage):
     """Object Oriented time objects"""
 
-    homepage = "http://search.cpan.org/~esaym/Time-Piece/Piece.pm"
+    homepage = "https://metacpan.org/pod/Time::Piece"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ES/ESAYM/Time-Piece-1.3203.tar.gz"
 
     version('1.3203', sha256='6971faf6476e4f715a5b5336f0a97317f36e7880fcca6c4db7c3e38e764a6f41')

--- a/var/spack/repos/builtin/packages/perl-try-tiny/package.py
+++ b/var/spack/repos/builtin/packages/perl-try-tiny/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlTryTiny(PerlPackage):
     """Minimal try/catch with proper preservation of $@"""
 
-    homepage = "http://search.cpan.org/~ether/Try-Tiny-0.28/lib/Try/Tiny.pm"
+    homepage = "https://metacpan.org/pod/Try::Tiny"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/Try-Tiny-0.28.tar.gz"
 
     version('0.28', sha256='f1d166be8aa19942c4504c9111dade7aacb981bc5b3a2a5c5f6019646db8c146')

--- a/var/spack/repos/builtin/packages/perl-uri/package.py
+++ b/var/spack/repos/builtin/packages/perl-uri/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlUri(PerlPackage):
     """Uniform Resource Identifiers (absolute and relative)"""
 
-    homepage = "http://search.cpan.org/~ether/URI-1.72/lib/URI.pm"
+    homepage = "https://metacpan.org/pod/URI"
     url      = "http://search.cpan.org/CPAN/authors/id/E/ET/ETHER/URI-1.72.tar.gz"
 
     version('1.72', sha256='35f14431d4b300de4be1163b0b5332de2d7fbda4f05ff1ed198a8e9330d40a32')

--- a/var/spack/repos/builtin/packages/perl-want/package.py
+++ b/var/spack/repos/builtin/packages/perl-want/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlWant(PerlPackage):
     """A generalisation of wantarray."""
 
-    homepage = "http://search.cpan.org/~robin/Want/Want.pm"
+    homepage = "https://metacpan.org/pod/Want"
     url      = "http://search.cpan.org/CPAN/authors/id/R/RO/ROBIN/Want-0.29.tar.gz"
 
     version('0.29', sha256='b4e4740b8d4cb783591273c636bd68304892e28d89e88abf9273b1de17f552f7')

--- a/var/spack/repos/builtin/packages/perl-xml-parser-lite/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-parser-lite/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlXmlParserLite(PerlPackage):
     """Lightweight pure-perl XML Parser (based on regexps)"""
 
-    homepage = "http://search.cpan.org/~phred/XML-Parser-Lite-0.721/lib/XML/Parser/Lite.pm"
+    homepage = "https://metacpan.org/pod/XML::Parser::Lite"
     url      = "http://search.cpan.org/CPAN/authors/id/P/PH/PHRED/XML-Parser-Lite-0.721.tar.gz"
 
     version('0.721', sha256='5862a36ecab9db9aad021839c847e8d2f4ab5a7796c61d0fb069bb69cf7908ba')

--- a/var/spack/repos/builtin/packages/perl-xml-parser/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-parser/package.py
@@ -10,7 +10,7 @@ from spack import *
 class PerlXmlParser(PerlPackage):
     """XML::Parser - A perl module for parsing XML documents"""
 
-    homepage = "http://search.cpan.org/perldoc/XML::Parser"
+    homepage = "https://metacpan.org/pod/XML::Parser"
     url      = "http://search.cpan.org/CPAN/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz"
 
     version('2.44', sha256='1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216')

--- a/var/spack/repos/builtin/packages/perl-xml-simple/package.py
+++ b/var/spack/repos/builtin/packages/perl-xml-simple/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlXmlSimple(PerlPackage):
     """An API for simple XML files"""
 
-    homepage = "http://search.cpan.org/~grantm/XML-Simple/lib/XML/Simple.pm"
+    homepage = "https://metacpan.org/pod/XML::Simple"
     url      = "http://search.cpan.org/CPAN/authors/id/G/GR/GRANTM/XML-Simple-2.24.tar.gz"
 
     version('2.24', sha256='9a14819fd17c75fbb90adcec0446ceab356cab0ccaff870f2e1659205dc2424f')

--- a/var/spack/repos/builtin/packages/perl-yaml-libyaml/package.py
+++ b/var/spack/repos/builtin/packages/perl-yaml-libyaml/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PerlYamlLibyaml(PerlPackage):
     """Perl YAML Serialization using XS and libyaml  """
 
-    homepage = "http://search.cpan.org/~tinita/YAML-LibYAML/"
+    homepage = "https://metacpan.org/pod/YAML::LibYAML"
     url      = "http://search.cpan.org/CPAN/authors/id/T/TI/TINITA/YAML-LibYAML-0.67.tar.gz"
 
     version('0.67', sha256='e65a22abc912a46a10abddf3b88d806757f44f164ab3167c8f0ff6aa30648187')

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -24,7 +24,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     """Perl 5 is a highly capable, feature-rich programming language with over
        27 years of development."""
 
-    homepage = "http://www.perl.org"
+    homepage = "https://www.perl.org"
     # URL must remain http:// so Spack can bootstrap curl
     url = "http://www.cpan.org/src/5.0/perl-5.24.1.tar.gz"
 

--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -20,7 +20,7 @@ class Plumed(AutotoolsPackage):
     The software, written in C++, can be easily interfaced with both fortran
     and C/C++ codes.
     """
-    homepage = 'http://www.plumed.org/'
+    homepage = 'https://www.plumed.org/'
     url = 'https://github.com/plumed/plumed2/archive/v2.6.3.tar.gz'
     git = 'https://github.com/plumed/plumed2.git'
 

--- a/var/spack/repos/builtin/packages/pmdk/package.py
+++ b/var/spack/repos/builtin/packages/pmdk/package.py
@@ -12,7 +12,7 @@ class Pmdk(Package):
     for persistent memory
     """
 
-    homepage = "http://pmem.io/pmdk/"
+    homepage = "https://pmem.io/pmdk/"
     url      = "https://github.com/pmem/pmdk/archive/1.5.tar.gz"
     git      = "https://github.com/pmem/pmdk.git"
 

--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -14,7 +14,7 @@ class Postgresql(AutotoolsPackage):
     that has earned it a strong reputation for reliability, data integrity, and
     correctness."""
 
-    homepage = "http://www.postgresql.org/"
+    homepage = "https://www.postgresql.org/"
     url      = "http://ftp.postgresql.org/pub/source/v9.3.4/postgresql-9.3.4.tar.bz2"
     list_url = "http://ftp.postgresql.org/pub/source"
     list_depth = 1

--- a/var/spack/repos/builtin/packages/powertop/package.py
+++ b/var/spack/repos/builtin/packages/powertop/package.py
@@ -10,7 +10,7 @@ class Powertop(AutotoolsPackage):
     """Powertop is a Linux tool to diagnose issues with power consumption
     and power management"""
 
-    homepage = "http://01.org/powertop/"
+    homepage = "https://01.org/powertop/"
     url      = "http://01.org/sites/default/files/downloads/powertop/powertop-v2.9.tar.gz"
 
     version('2.9', sha256='aa7fb7d8e9a00f05e7d8a7a2866d85929741e0d03a5bf40cab22d2021c959250')

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -13,7 +13,7 @@ class Precice(CMakePackage):
     capable of simulating a subpart of the complete physics involved in
     a simulation."""
 
-    homepage = 'https://www.precice.org'
+    homepage = 'https://precice.org/'
     git      = 'https://github.com/precice/precice.git'
     url      = 'https://github.com/precice/precice/archive/v1.2.0.tar.gz'
     maintainers = ['fsimonis', 'MakisH']

--- a/var/spack/repos/builtin/packages/printproto/package.py
+++ b/var/spack/repos/builtin/packages/printproto/package.py
@@ -10,7 +10,7 @@ class Printproto(AutotoolsPackage, XorgPackage):
     """Xprint extension to the X11 protocol - a portable, network-transparent
     printing system."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/printproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/printproto"
     xorg_mirror_path = "proto/printproto-1.0.5.tar.gz"
 
     version('1.0.5', sha256='e8b6f405fd865f0ea7a3a2908dfbf06622f57f2f91359ec65d13b955e49843fc')

--- a/var/spack/repos/builtin/packages/pugixml/package.py
+++ b/var/spack/repos/builtin/packages/pugixml/package.py
@@ -10,7 +10,7 @@ from spack import *
 class Pugixml(CMakePackage):
     """Light-weight, simple, and fast XML parser for C++ with XPath support"""
 
-    homepage = "http://pugixml.org/"
+    homepage = "https://pugixml.org/"
     url      = "https://github.com/zeux/pugixml/releases/download/v1.10/pugixml-1.10.tar.gz"
 
     version('1.11.4', sha256='8ddf57b65fb860416979a3f0640c2ad45ddddbbafa82508ef0a0af3ce7061716')

--- a/var/spack/repos/builtin/packages/py-adios/package.py
+++ b/var/spack/repos/builtin/packages/py-adios/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyAdios(PythonPackage):
     """NumPy bindings of ADIOS1"""
 
-    homepage = "https://www.olcf.ornl.gov/center-projects/adios/"
+    homepage = "https://csmd.ornl.gov/adios"
     url      = "https://github.com/ornladios/ADIOS/archive/v1.12.0.tar.gz"
     git      = "https://github.com/ornladios/ADIOS.git"
 

--- a/var/spack/repos/builtin/packages/py-aenum/package.py
+++ b/var/spack/repos/builtin/packages/py-aenum/package.py
@@ -10,7 +10,7 @@ class PyAenum(PythonPackage):
     """Advanced Enumerations (compatible with Python's stdlib Enum),
     NamedTuples, and NamedConstants."""
 
-    homepage = "https://bitbucket.org/stoneleaf/aenum"
+    homepage = "https://github.com/ethanfurman/aenum"
     pypi = "aenum/aenum-2.1.2.tar.gz"
 
     version('2.1.2', sha256='a3208e4b28db3a7b232ff69b934aef2ea1bf27286d9978e1e597d46f490e4687')

--- a/var/spack/repos/builtin/packages/py-arviz/package.py
+++ b/var/spack/repos/builtin/packages/py-arviz/package.py
@@ -11,7 +11,7 @@ class PyArviz(PythonPackage):
     analysis of Bayesian models. Includes functions for posterior analysis,
     model checking, comparison and diagnostics."""
 
-    homepage = "http://github.com/arviz-devs/arviz"
+    homepage = "https://github.com/arviz-devs/arviz"
     pypi = "arviz/arviz-0.6.1.tar.gz"
 
     version('0.6.1', sha256='435edf8db49c41a8fa198f959e7581063006c49a4efdef4755bb778db6fd4f72')

--- a/var/spack/repos/builtin/packages/py-asteval/package.py
+++ b/var/spack/repos/builtin/packages/py-asteval/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyAsteval(PythonPackage):
     """Safe, minimalistic evaluator of python expression using ast module"""
 
-    homepage = "http://github.com/newville/asteval"
+    homepage = "https://github.com/newville/asteval"
     pypi = "asteval/asteval-0.9.18.tar.gz"
 
     version('0.9.25', sha256='bea22b7d8fa16bcba95ebc72052ae5d8ca97114c9959bb47f8b8eebf30e4342f')

--- a/var/spack/repos/builtin/packages/py-azureml-dataprep-native/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-dataprep-native/package.py
@@ -9,7 +9,7 @@ import sys
 class PyAzuremlDataprepNative(Package):
     """Python Package for AzureML DataPrep specific native extensions."""
 
-    homepage = "http://aka.ms/data-prep-sdk"
+    homepage = "https://docs.microsoft.com/en-us/python/api/overview/azure/ml/?view=azure-ml-py"
 
     if sys.platform == 'darwin':
         version('30.0.0-py3.9', sha256='eaf3fcd9f965e87b03fe89d7c6fe6abce53483a79afc963e4981061f4c250e85', expand=False,

--- a/var/spack/repos/builtin/packages/py-azureml-dataprep-rslex/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-dataprep-rslex/package.py
@@ -14,7 +14,7 @@ class PyAzuremlDataprepRslex(Package):
     """Azure Machine Learning Data Prep RsLex is a Rust implementation of Data Prep's
     capabilities to load, transform, and write data for machine learning workflows."""
 
-    homepage = "http://aka.ms/data-prep-sdk"
+    homepage = "https://docs.microsoft.com/en-us/python/api/overview/azure/ml/?view=azure-ml-py"
 
     if sys.platform == 'darwin':
         version('1.9.0-py3.9', sha256='9bdaa31d129dac19ee20d5a3aad1726397e90d8d741b4f6de4554040800fefe8', expand=False,

--- a/var/spack/repos/builtin/packages/py-azureml-dataprep/package.py
+++ b/var/spack/repos/builtin/packages/py-azureml-dataprep/package.py
@@ -7,7 +7,7 @@
 class PyAzuremlDataprep(Package):
     """Azure ML Data Preparation SDK."""
 
-    homepage = "http://aka.ms/data-prep-sdk"
+    homepage = "https://docs.microsoft.com/en-us/python/api/overview/azure/ml/?view=azure-ml-py"
     url      = "https://pypi.io/packages/py3/a/azureml_dataprep/azureml_dataprep-2.0.2-py3-none-any.whl"
 
     version('2.11.0', sha256='755c0d7cfe228705aee7adc97813fb6d7d6ecb048b66f47c1fd5897f2709c3a2', expand=False)

--- a/var/spack/repos/builtin/packages/py-basemap/package.py
+++ b/var/spack/repos/builtin/packages/py-basemap/package.py
@@ -13,7 +13,7 @@ class PyBasemap(PythonPackage):
     2D data on maps in Python."""
 
     url = 'https://github.com/matplotlib/basemap/archive/v1.2.0rel.tar.gz'
-    homepage = "http://matplotlib.org/basemap/"
+    homepage = "https://matplotlib.org/basemap/"
 
     version('1.2.1', sha256='3fb30424f18cd4ffd505e30fd9c810ae81b999bb92f950c76553e1abc081faa7')
     version('1.2.0', sha256='bd5bf305918a2eb675939873b735238f9e3dfe6b5c290e37c41e5b082ff3639a')

--- a/var/spack/repos/builtin/packages/py-bigfloat/package.py
+++ b/var/spack/repos/builtin/packages/py-bigfloat/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyBigfloat(PythonPackage):
     """Arbitrary-precision correctly-rounded floating-point arithmetic, via MPFR."""
 
-    homepage = "http://github.com/mdickinson/bigfloat"
+    homepage = "https://github.com/mdickinson/bigfloat"
     pypi     = "bigfloat/bigfloat-0.4.0.tar.gz"
 
     version('0.4.0', sha256='58b96bde872aca5989d13d82eba3acf2aa1b94e22117dd72a16ba5911b0c0cb8')

--- a/var/spack/repos/builtin/packages/py-bleach/package.py
+++ b/var/spack/repos/builtin/packages/py-bleach/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyBleach(PythonPackage):
     """An easy whitelist-based HTML-sanitizing tool."""
 
-    homepage = "http://github.com/mozilla/bleach"
+    homepage = "https://github.com/mozilla/bleach"
     pypi = "bleach/bleach-3.1.0.tar.gz"
 
     version('3.1.0', sha256='3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa')

--- a/var/spack/repos/builtin/packages/py-bokeh/package.py
+++ b/var/spack/repos/builtin/packages/py-bokeh/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyBokeh(PythonPackage):
     """Statistical and novel interactive HTML plots for Python"""
 
-    homepage = "http://github.com/bokeh/bokeh"
+    homepage = "https://github.com/bokeh/bokeh"
     pypi = "bokeh/bokeh-0.12.2.tar.gz"
 
     version('1.3.4', sha256='e2d97bed5b199a10686486001fed5c854e4c04ebe28859923f27c52b93904754')

--- a/var/spack/repos/builtin/packages/py-certifi/package.py
+++ b/var/spack/repos/builtin/packages/py-certifi/package.py
@@ -11,7 +11,7 @@ class PyCertifi(PythonPackage):
     the trustworthiness of SSL certificates while verifying the identity of TLS
     hosts."""
 
-    homepage = "http://certifi.io/"
+    homepage = "https://github.com/certifi/python-certifi"
     pypi = "certifi/certifi-2020.6.20.tar.gz"
 
     version('2020.6.20', sha256='5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3')

--- a/var/spack/repos/builtin/packages/py-cheroot/package.py
+++ b/var/spack/repos/builtin/packages/py-cheroot/package.py
@@ -10,7 +10,7 @@ from spack import *
 class PyCheroot(PythonPackage):
     """ Highly-optimized, pure-python HTTP server """
 
-    homepage = "https://cheroot.cherrypy.org/"
+    homepage = "https://cheroot.readthedocs.io/en/latest/"
     pypi = "cheroot/cheroot-6.5.5.tar.gz"
 
     version('8.3.0', sha256='a0577e1f28661727d472671a7cc4e0c12ea0cbc5220265e70f00a8b8cb628931')

--- a/var/spack/repos/builtin/packages/py-cherrypy/package.py
+++ b/var/spack/repos/builtin/packages/py-cherrypy/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyCherrypy(PythonPackage):
     """CherryPy is a pythonic, object-oriented HTTP framework."""
 
-    homepage = "https://cherrypy.org/"
+    homepage = "https://cherrypy.readthedocs.io/en/latest/"
     pypi = "CherryPy/CherryPy-18.1.1.tar.gz"
 
     version('18.1.1', sha256='6585c19b5e4faffa3613b5bf02c6a27dcc4c69a30d302aba819639a2af6fa48b')

--- a/var/spack/repos/builtin/packages/py-cogent/package.py
+++ b/var/spack/repos/builtin/packages/py-cogent/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyCogent(PythonPackage):
     """A toolkit for statistical analysis of biological sequences."""
 
-    homepage = "http://pycogent.org"
+    homepage = "https://github.com/Magdoll/Cogent/wiki/Installing-Cogent"
     pypi = "cogent/cogent-1.9.tar.gz"
 
     version('1.9', sha256='57d8c58e0273ffe4f2b907874f9b49dadfd0600f5507b7666369f4e44d56ce14')

--- a/var/spack/repos/builtin/packages/py-cycler/package.py
+++ b/var/spack/repos/builtin/packages/py-cycler/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyCycler(PythonPackage):
     """Composable style cycles."""
 
-    homepage = "http://matplotlib.org/cycler/"
+    homepage = "https://matplotlib.org/cycler/"
     url      = "https://github.com/matplotlib/cycler/archive/v0.10.0.tar.gz"
 
     version('0.10.0', sha256='b6d217635e03024196225367b1a438996dbbf0271bec488f00584f0e7dc15cfa')

--- a/var/spack/repos/builtin/packages/py-et-xmlfile/package.py
+++ b/var/spack/repos/builtin/packages/py-et-xmlfile/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyEtXmlfile(PythonPackage):
     """An implementation of lxml.xmlfile for the standard library."""
 
-    homepage = "https://bitbucket.org/openpyxl/et_xmlfile"
+    homepage = "https://et-xmlfile.readthedocs.io/en/latest/"
     pypi = "et_xmlfile/et_xmlfile-1.0.1.tar.gz"
 
     version('1.0.1', sha256='614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b')

--- a/var/spack/repos/builtin/packages/py-google/package.py
+++ b/var/spack/repos/builtin/packages/py-google/package.py
@@ -7,7 +7,7 @@
 class PyGoogle(PythonPackage):
     """Python bindings to the Google search engine."""
 
-    homepage = "http://breakingcode.wordpress.com/"
+    homepage = "https://breakingcode.wordpress.com/"
     pypi = "google/google-3.0.0.tar.gz"
 
     version('3.0.0', sha256='143530122ee5130509ad5e989f0512f7cb218b2d4eddbafbad40fd10e8d8ccbe')

--- a/var/spack/repos/builtin/packages/py-gpy/package.py
+++ b/var/spack/repos/builtin/packages/py-gpy/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyGpy(PythonPackage):
     """The Gaussian Process Toolbox."""
 
-    homepage = "http://sheffieldml.github.com/GPy/"
+    homepage = "https://sheffieldml.github.io/GPy/"
     pypi = "gpy/GPy-1.9.9.tar.gz"
 
     version('1.9.9', sha256='04faf0c24eacc4dea60727c50a48a07ddf9b5751a3b73c382105e2a31657c7ed')

--- a/var/spack/repos/builtin/packages/py-holland-backup/package.py
+++ b/var/spack/repos/builtin/packages/py-holland-backup/package.py
@@ -14,7 +14,7 @@ class PyHollandBackup(PythonPackage):
     Because of its plugin structure, Holland can be used to backup anything
     you want by whatever means you want."""
 
-    homepage = "http://hollandbackup.org/"
+    homepage = "https://hollandbackup.org/"
     url      = "https://github.com/holland-backup/holland/archive/1.2.2.tar.gz"
 
     version('1.2.2', sha256='836337c243b2dff5ff6a3ce0b647f123ab24697a5de8ac8ae8b7839aa23dff68')

--- a/var/spack/repos/builtin/packages/py-jdcal/package.py
+++ b/var/spack/repos/builtin/packages/py-jdcal/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyJdcal(PythonPackage):
     """Julian dates from proleptic Gregorian and Julian calendars"""
 
-    homepage = "http://github.com/phn/jdcal"
+    homepage = "https://github.com/phn/jdcal"
     pypi = "jdcal/jdcal-1.3.tar.gz"
 
     version('1.3', sha256='b760160f8dc8cc51d17875c6b663fafe64be699e10ce34b6a95184b5aa0fdc9e')

--- a/var/spack/repos/builtin/packages/py-jsonschema/package.py
+++ b/var/spack/repos/builtin/packages/py-jsonschema/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyJsonschema(PythonPackage):
     """Jsonschema: An(other) implementation of JSON Schema for Python."""
 
-    homepage = "http://github.com/Julian/jsonschema"
+    homepage = "https://github.com/Julian/jsonschema"
     pypi = "jsonschema/jsonschema-3.2.0.tar.gz"
 
     version('3.2.0', sha256='c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a')

--- a/var/spack/repos/builtin/packages/py-keras-applications/package.py
+++ b/var/spack/repos/builtin/packages/py-keras-applications/package.py
@@ -10,7 +10,7 @@ class PyKerasApplications(PythonPackage):
     """Sample Deep Learning application in Keras.
     Keras depends on this package to run properly."""
 
-    homepage = "http://keras.io"
+    homepage = "https://keras.io"
     url      = "https://github.com/keras-team/keras-applications/archive/1.0.4.tar.gz"
 
     version('1.0.8', sha256='7c37f9e9ef93efac9b4956301cb21ce46c474ce9da41fac9a46753bab6823dfc')

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -10,7 +10,7 @@ class PyKeras(PythonPackage):
     """Deep Learning library for Python. Convnets, recurrent neural networks,
     and more. Runs on Theano or TensorFlow."""
 
-    homepage = "http://keras.io"
+    homepage = "https://keras.io"
     pypi = "Keras/Keras-1.2.2.tar.gz"
 
     version('2.4.3', sha256='fedd729b52572fb108a98e3d97e1bac10a81d3917d2103cc20ab2a5f03beb973')

--- a/var/spack/repos/builtin/packages/py-lazyarray/package.py
+++ b/var/spack/repos/builtin/packages/py-lazyarray/package.py
@@ -10,7 +10,7 @@ class PyLazyarray(PythonPackage):
     """a Python package that provides a lazily-evaluated numerical array class,
     larray, based on and compatible with NumPy arrays."""
 
-    homepage = "http://bitbucket.org/apdavison/lazyarray/"
+    homepage = "https://lazyarray.readthedocs.io/en/latest/"
     pypi = "lazyarray/lazyarray-0.2.8.tar.gz"
 
     version('0.3.2',  sha256='be980534c5950a976709085570f69be9534bdf0f3e5c21a9113de3ee2052683e')

--- a/var/spack/repos/builtin/packages/py-lmfit/package.py
+++ b/var/spack/repos/builtin/packages/py-lmfit/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyLmfit(PythonPackage):
     """Least-Squares Minimization with Bounds and Constraints"""
 
-    homepage = "http://lmfit.github.io/lmfit-py/"
+    homepage = "https://lmfit.github.io/lmfit-py/"
     pypi = "lmfit/lmfit-0.9.5.tar.gz"
 
     version('1.0.2',  sha256='67090ce56685cf7f92bd7358a1e7d4ad862b3758988109ec440e9825e5184b45')

--- a/var/spack/repos/builtin/packages/py-locket/package.py
+++ b/var/spack/repos/builtin/packages/py-locket/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyLocket(PythonPackage):
     """File-based locks for Python for Linux and Windows."""
 
-    homepage = "http://github.com/mwilliamson/locket.py"
+    homepage = "https://github.com/mwilliamson/locket.py"
     pypi = "locket/locket-0.2.0.tar.gz"
 
     version('0.2.0', sha256='1fee63c1153db602b50154684f5725564e63a0f6d09366a1cb13dffcec179fb4')

--- a/var/spack/repos/builtin/packages/py-markdown/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown/package.py
@@ -14,7 +14,7 @@ class PyMarkdown(PythonPackage):
     Documentation for the syntax rules.
     """
 
-    homepage = "https://pythonhosted.org/Markdown/"
+    homepage = "https://python-markdown.github.io/"
     pypi = "markdown/Markdown-2.6.11.tar.gz"
 
     version('3.1.1', sha256='2e50876bcdd74517e7b71f3e7a76102050edec255b3983403f1a63e7c8a41e7a')

--- a/var/spack/repos/builtin/packages/py-mdanalysis/package.py
+++ b/var/spack/repos/builtin/packages/py-mdanalysis/package.py
@@ -13,7 +13,7 @@ class PyMdanalysis(PythonPackage):
     Gromacs. (See the lists of supported trajectory formats and
     topology formats.)"""
 
-    homepage = "http://www.mdanalysis.org"
+    homepage = "https://www.mdanalysis.org"
     pypi = "MDAnalysis/MDAnalysis-0.19.2.tar.gz"
 
     version('1.0.0',  sha256='f45a024aca45e390ff1c45ca90beb2180b78881be377e2a1aa9cd6c109bcfa81')

--- a/var/spack/repos/builtin/packages/py-mpld3/package.py
+++ b/var/spack/repos/builtin/packages/py-mpld3/package.py
@@ -10,7 +10,7 @@ class PyMpld3(PythonPackage):
     """An interactive D3js-based viewer which brings matplotlib graphics
     to the browser."""
 
-    homepage = "http://mpld3.github.com/"
+    homepage = "https://mpld3.github.io/"
     pypi = "mpld3/mpld3-0.3.tar.gz"
 
     version('0.3', sha256='4d455884a211bf99b37ecc760759435c7bb6a5955de47d8daf4967e301878ab7')

--- a/var/spack/repos/builtin/packages/py-mpmath/package.py
+++ b/var/spack/repos/builtin/packages/py-mpmath/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class PyMpmath(PythonPackage):
     """A Python library for arbitrary-precision floating-point arithmetic."""
-    homepage = "http://mpmath.org"
+    homepage = "https://mpmath.org"
     pypi = "mpmath/mpmath-1.0.0.tar.gz"
 
     version('1.1.0', sha256='fc17abe05fbab3382b61a123c398508183406fa132e0223874578e20946499f6')

--- a/var/spack/repos/builtin/packages/py-mx/package.py
+++ b/var/spack/repos/builtin/packages/py-mx/package.py
@@ -13,7 +13,7 @@ class PyMx(PythonPackage):
        date/time processing and high speed data types.
 
     """
-    homepage = "http://www.egenix.com/products/python/mxBase/"
+    homepage = "https://www.egenix.com/products/python/mxBase/"
     url      = "https://downloads.egenix.com/python/egenix-mx-base-3.2.8.tar.gz"
 
     version('3.2.8', sha256='0da55233e45bc3f88870e62e60a79c2c86bad4098b8128343fd7be877f44a3c0')

--- a/var/spack/repos/builtin/packages/py-neotime/package.py
+++ b/var/spack/repos/builtin/packages/py-neotime/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyNeotime(PythonPackage):
     """Nanosecond resolution temporal types"""
 
-    homepage = "https://neotime.readthedocs.io/"
+    homepage = "https://github.com/neo4j-drivers/neotime"
     pypi = "neotime/neotime-1.7.4.tar.gz"
 
     version('1.7.4', sha256='4e0477ba0f24e004de2fa79a3236de2bd941f20de0b5db8d976c52a86d7363eb')

--- a/var/spack/repos/builtin/packages/py-netifaces/package.py
+++ b/var/spack/repos/builtin/packages/py-netifaces/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyNetifaces(PythonPackage):
     """Portable network interface information"""
 
-    homepage = "https://bitbucket.org/al45tair/netifaces"
+    homepage = "https://0xbharath.github.io/python-network-programming/libraries/netifaces/index.html"
     pypi = "netifaces/netifaces-0.10.5.tar.gz"
 
     version('0.10.5', sha256='59d8ad52dd3116fcb6635e175751b250dc783fb011adba539558bd764e5d628b')

--- a/var/spack/repos/builtin/packages/py-nose-cov/package.py
+++ b/var/spack/repos/builtin/packages/py-nose-cov/package.py
@@ -9,7 +9,6 @@ from spack import *
 class PyNoseCov(PythonPackage):
     """This plugin produces coverage reports."""
 
-    homepage = "http://bitbucket.org/memedough/nose-cov/overview"
     pypi = "nose-cov/nose-cov-1.6.tar.gz"
 
     version('1.6', sha256='8bec0335598f1cc69e3262cc50d7678c1a6010fa44625ce343c4ec1500774412')

--- a/var/spack/repos/builtin/packages/py-pager/package.py
+++ b/var/spack/repos/builtin/packages/py-pager/package.py
@@ -10,7 +10,6 @@ class PyPager(PythonPackage):
     """Python module that pages output to the screen,
        reads keys and console dimensions without executing external utils."""
 
-    homepage = "http://bitbucket.org/techtonik/python-pager"
     pypi     = "pager/pager-3.3.tar.gz"
 
     version('3.3', sha256='18aa45ec877dca732e599531c7b3b0b22ed6a4445febdf1bdf7da2761cca340d')

--- a/var/spack/repos/builtin/packages/py-partd/package.py
+++ b/var/spack/repos/builtin/packages/py-partd/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyPartd(PythonPackage):
     """Key-value byte store with appendable values."""
 
-    homepage = "http://github.com/dask/partd/"
+    homepage = "https://github.com/dask/partd/"
     pypi = "partd/partd-0.3.8.tar.gz"
 
     version('1.1.0', sha256='6e258bf0810701407ad1410d63d1a15cfd7b773fd9efe555dac6bb82cc8832b0')

--- a/var/spack/repos/builtin/packages/py-pil/package.py
+++ b/var/spack/repos/builtin/packages/py-pil/package.py
@@ -9,7 +9,7 @@ class PyPil(PythonPackage):
     to your Python interpreter. This library supports many file formats,
     and provides powerful image processing and graphics capabilities."""
 
-    homepage = "http://www.pythonware.com/products/pil/"
+    homepage = "https://pillow.readthedocs.io/en/stable/"
     url      = "http://effbot.org/media/downloads/Imaging-1.1.7.tar.gz"
 
     version('1.1.7', sha256='895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211')

--- a/var/spack/repos/builtin/packages/py-pkgconfig/package.py
+++ b/var/spack/repos/builtin/packages/py-pkgconfig/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyPkgconfig(PythonPackage):
     """Interface Python with pkg-config."""
 
-    homepage = "http://github.com/matze/pkgconfig"
+    homepage = "https://github.com/matze/pkgconfig"
     pypi = "pkgconfig/pkgconfig-1.2.2.tar.gz"
 
     version('1.5.1', sha256='97bfe3d981bab675d5ea3ef259045d7919c93897db7d3b59d4e8593cba8d354f')

--- a/var/spack/repos/builtin/packages/py-pudb/package.py
+++ b/var/spack/repos/builtin/packages/py-pudb/package.py
@@ -10,7 +10,7 @@ from spack import *
 class PyPudb(PythonPackage):
     """Full-screen console debugger for Python"""
 
-    homepage = "http://mathema.tician.de/software/pudb"
+    homepage = "https://mathema.tician.de/software/pudb"
     pypi = "pudb/pudb-2017.1.1.tar.gz"
 
     version('2017.1.1', sha256='87117640902c5f602c8517d0167eb5c953a5bdede97975ba29ff17e3d570442c')

--- a/var/spack/repos/builtin/packages/py-pure-sasl/package.py
+++ b/var/spack/repos/builtin/packages/py-pure-sasl/package.py
@@ -10,7 +10,7 @@ class PyPureSasl(PythonPackage):
     but by default, support for PLAIN, ANONYMOUS, EXTERNAL, CRAM-MD5,
     DIGEST-MD5, and GSSAPI are provided."""
 
-    homepage = "http://github.com/thobbs/pure-sasl"
+    homepage = "https://github.com/thobbs/pure-sasl"
     pypi = "pure-sasl/pure-sasl-0.6.2.tar.gz"
 
     version('0.6.2', sha256='53c1355f5da95e2b85b2cc9a6af435518edc20c81193faa0eea65fdc835138f4')

--- a/var/spack/repos/builtin/packages/py-py2neo/package.py
+++ b/var/spack/repos/builtin/packages/py-py2neo/package.py
@@ -10,7 +10,7 @@ class PyPy2neo(PythonPackage):
     """Py2neo is a client library and toolkit for working with Neo4j from
     within Python applications and from the command line."""
 
-    homepage = "http://py2neo.org/"
+    homepage = "https://py2neo.org/"
     pypi = "py2neo/py2neo-2.0.8.tar.gz"
 
     version('4.3.0', sha256='a218ccb4b636e3850faa6b74ebad80f00600217172a57f745cf223d38a219222')

--- a/var/spack/repos/builtin/packages/py-pybids/package.py
+++ b/var/spack/repos/builtin/packages/py-pybids/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyPybids(PythonPackage):
     """bids: interface with datasets conforming to BIDS"""
 
-    homepage = "http://github.com/bids-standard/pybids"
+    homepage = "https://github.com/bids-standard/pybids"
     pypi     = "pybids/pybids-0.13.1.tar.gz"
 
     version('0.13.1', sha256='c920e1557e1dae8b671625d70cafbdc28437ba2822b2db9da4c2587a7625e3ba')

--- a/var/spack/repos/builtin/packages/py-pygit2/package.py
+++ b/var/spack/repos/builtin/packages/py-pygit2/package.py
@@ -11,7 +11,7 @@ class PyPygit2(PythonPackage):
     libgit2 implements the core of Git.
     """
 
-    homepage = "http://www.pygit2.org/"
+    homepage = "https://www.pygit2.org/"
     pypi = "pygit2/pygit2-0.24.1.tar.gz"
 
     version('1.6.0', sha256='7aacea4e57011777f4774421228e5d0ddb9a6ddb87ac4b542346d17ab12a4d62')

--- a/var/spack/repos/builtin/packages/py-pygments/package.py
+++ b/var/spack/repos/builtin/packages/py-pygments/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyPygments(PythonPackage):
     """Pygments is a syntax highlighting package written in Python."""
 
-    homepage = "http://pygments.org/"
+    homepage = "https://pygments.org/"
     pypi = "Pygments/Pygments-2.4.2.tar.gz"
 
     version('2.10.0', sha256='f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6')

--- a/var/spack/repos/builtin/packages/py-pygpu/package.py
+++ b/var/spack/repos/builtin/packages/py-pygpu/package.py
@@ -11,7 +11,7 @@ from spack import *
 class PyPygpu(PythonPackage):
     """Python packge for the libgpuarray C library."""
 
-    homepage = "http://deeplearning.net/software/libgpuarray/"
+    homepage = "https://github.com/Theano/libgpuarray"
     url      = "https://github.com/Theano/libgpuarray/archive/v0.6.1.tar.gz"
 
     version('0.7.6', sha256='ad1c00dd47c3d36ee1708e5167377edbfcdb7226e837ef9c68b841afbb4a4f6a')

--- a/var/spack/repos/builtin/packages/py-pyke/package.py
+++ b/var/spack/repos/builtin/packages/py-pyke/package.py
@@ -12,7 +12,7 @@ class PyPyke(PythonPackage):
     engine (expert system) written in 100% Python.
     """
 
-    homepage = "http://sourceforge.net/projects/pyke"
+    homepage = "https://sourceforge.net/projects/pyke"
     url      = "https://sourceforge.net/projects/pyke/files/pyke/1.1.1/pyke-1.1.1.zip"
 
     version('1.1.1', sha256='b0b294f435c6e6d2d4a80badf57d92cb66814dfe21e644a521901209e6a3f8ae')

--- a/var/spack/repos/builtin/packages/py-pymc3/package.py
+++ b/var/spack/repos/builtin/packages/py-pymc3/package.py
@@ -12,7 +12,7 @@ class PyPymc3(PythonPackage):
     Carlo (MCMC) and variational inference (VI) algorithms. Its flexibility and
     extensibility make it applicable to a large suite of problems."""
 
-    homepage = "http://github.com/pymc-devs/pymc3"
+    homepage = "https://github.com/pymc-devs/pymc3"
     pypi = "pymc3/pymc3-3.8.tar.gz"
 
     version('3.8', sha256='1bb2915e4a29877c681ead13932b0b7d276f7f496e9c3f09ba96b977c99caf00')

--- a/var/spack/repos/builtin/packages/py-pypar/package.py
+++ b/var/spack/repos/builtin/packages/py-pypar/package.py
@@ -10,7 +10,7 @@ class PyPypar(PythonPackage):
     """Pypar is an efficient but easy-to-use module that allows programs
        written in Python to run in parallel on multiple processors and
        communicate using MPI."""
-    homepage = "http://code.google.com/p/pypar/"
+    homepage = "https://github.com/daleroberts/pypar"
     url      = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/pypar/pypar-2.1.5_108.tgz"
 
     version('2.1.5_108', sha256='6076c47d32d48424a07c7b7b29ac16e12cc4b2d28b681b895f94fa76cd82fa12')

--- a/var/spack/repos/builtin/packages/py-pyparsing/package.py
+++ b/var/spack/repos/builtin/packages/py-pyparsing/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class PyPyparsing(PythonPackage):
     """A Python Parsing Module."""
-    homepage = "http://pyparsing.wikispaces.com/"
+    homepage = "https://pyparsing-docs.readthedocs.io/en/latest/"
     pypi = "pyparsing/pyparsing-2.4.2.tar.gz"
 
     version('2.4.7',  sha256='c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1')

--- a/var/spack/repos/builtin/packages/py-pyprecice/package.py
+++ b/var/spack/repos/builtin/packages/py-pyprecice/package.py
@@ -12,7 +12,7 @@ class PyPyprecice(PythonPackage):
     C++ library preCICE.
     """
 
-    homepage = "https://www.precice.org"
+    homepage = "https://precice.org"
     git = "https://github.com/precice/python-bindings.git"
     url = "https://github.com/precice/python-bindings/archive/v2.0.0.1.tar.gz"
     maintainers = ["ajaust", "BenjaminRodenberg", "IshaanDesai"]

--- a/var/spack/repos/builtin/packages/py-pytest-pep8/package.py
+++ b/var/spack/repos/builtin/packages/py-pytest-pep8/package.py
@@ -9,7 +9,6 @@ from spack import *
 class PyPytestPep8(PythonPackage):
     """pytest plugin for efficiently checking PEP8 compliance"""
 
-    homepage = "https://bitbucket.org/pytest-dev/pytest-pep8"
     pypi = "pytest-pep8/pytest-pep8-1.0.6.tar.gz"
 
     version('1.0.6', sha256='032ef7e5fa3ac30f4458c73e05bb67b0f036a8a5cb418a534b3170f89f120318')

--- a/var/spack/repos/builtin/packages/py-python-fmask/package.py
+++ b/var/spack/repos/builtin/packages/py-python-fmask/package.py
@@ -10,7 +10,7 @@ class PyPythonFmask(PythonPackage):
     """A set of command line utilities and Python modules that implement
        the FMASK algorithm for Landsat and Sentinel-2"""
 
-    homepage = "http://pythonfmask.org"
+    homepage = "http://www.pythonfmask.org/en/latest/"
     url      = "https://github.com/ubarsc/python-fmask/archive/pythonfmask-0.5.4.tar.gz"
 
     version('0.5.4', sha256='a216aa3108de837fec182602b2b4708442746be31fc1585906802437784a63fe')

--- a/var/spack/repos/builtin/packages/py-rios/package.py
+++ b/var/spack/repos/builtin/packages/py-rios/package.py
@@ -14,7 +14,7 @@ class PyRios(PythonPackage):
        etc., allowing the programmer to concentrate on the processing involved.
     """
 
-    homepage = "http://rioshome.org"
+    homepage = "http://www.rioshome.org/en/latest/"
     url      = "https://github.com/ubarsc/rios/archive/rios-1.4.10.tar.gz"
 
     version('1.4.10', sha256='7f11b54eb1f2ec551d7fc01c039b60bf2c67f0c2fc5b2946f8d986d6a9bc7063')

--- a/var/spack/repos/builtin/packages/py-ruamel-ordereddict/package.py
+++ b/var/spack/repos/builtin/packages/py-ruamel-ordereddict/package.py
@@ -11,7 +11,7 @@ class PyRuamelOrdereddict(PythonPackage):
     at the back). The standard library module OrderedDict, implemented later,
     implements a subset of ordereddict functionality."""
 
-    homepage = "https://bitbucket.org/ruamel/ordereddict"
+    homepage = "https://sourceforge.net/projects/ruamel-ordereddict/"
     pypi = "ruamel.ordereddict/ruamel.ordereddict-0.4.14.tar.gz"
 
     version('0.4.14', sha256='281051d26eb2b18ef3d920e1e260716a52bd058a6b1a2f324102fc6a15cb8d4a')

--- a/var/spack/repos/builtin/packages/py-ruamel-yaml-clib/package.py
+++ b/var/spack/repos/builtin/packages/py-ruamel-yaml-clib/package.py
@@ -8,7 +8,7 @@ class PyRuamelYamlClib(PythonPackage):
     """C version of reader, parser and emitter for ruamel.yaml derived from
     libyaml."""
 
-    homepage = "https://bitbucket.org/ruamel/yaml.clib"
+    homepage = "https://sourceforge.net/p/ruamel-yaml-clib/code/ci/default/tree/"
     pypi = "ruamel.yaml.clib/ruamel.yaml.clib-0.2.0.tar.gz"
 
     version('0.2.0', sha256='b66832ea8077d9b3f6e311c4a53d06273db5dc2db6e8a908550f3c14d67e718c')

--- a/var/spack/repos/builtin/packages/py-scikit-image/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-image/package.py
@@ -10,7 +10,7 @@ class PyScikitImage(PythonPackage):
     """Image processing algorithms for SciPy, including IO, morphology,
     filtering, warping, color manipulation, object detection, etc."""
 
-    homepage = "http://scikit-image.org/"
+    homepage = "https://scikit-image.org/"
     pypi = "scikit-image/scikit-image-0.17.2.tar.gz"
 
     version('0.18.1', sha256='fbb618ca911867bce45574c1639618cdfb5d94e207432b19bc19563d80d2f171')

--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PySphinx(PythonPackage):
     """Sphinx Documentation Generator."""
 
-    homepage = "https://sphinx-doc.org/"
+    homepage = "https://www.sphinx-doc.org/en/master/"
     pypi = "Sphinx/Sphinx-3.2.0.tar.gz"
 
     version('4.1.2', sha256='3092d929cd807926d846018f2ace47ba2f3b671b309c7a89cd3306e80c826b13')

--- a/var/spack/repos/builtin/packages/py-statsmodels/package.py
+++ b/var/spack/repos/builtin/packages/py-statsmodels/package.py
@@ -11,7 +11,7 @@ from spack import *
 class PyStatsmodels(PythonPackage):
     """Statistical computations and models for use with SciPy"""
 
-    homepage = "http://www.statsmodels.org"
+    homepage = "https://www.statsmodels.org"
     pypi = "statsmodels/statsmodels-0.8.0.tar.gz"
 
     version('0.12.2', sha256='8ad7a7ae7cdd929095684118e3b05836c0ccb08b6a01fe984159475d174a1b10')

--- a/var/spack/repos/builtin/packages/py-theano/package.py
+++ b/var/spack/repos/builtin/packages/py-theano/package.py
@@ -10,7 +10,7 @@ class PyTheano(PythonPackage, CudaPackage):
     """Optimizing compiler for evaluating mathematical expressions on CPUs
     and GPUs."""
 
-    homepage = "http://deeplearning.net/software/theano/"
+    homepage = "https://theano-pymc.readthedocs.io/en/latest/"
     pypi = "Theano/Theano-0.8.2.tar.gz"
     git      = "https://github.com/Theano/Theano.git"
 

--- a/var/spack/repos/builtin/packages/py-thirdorder/package.py
+++ b/var/spack/repos/builtin/packages/py-thirdorder/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyThirdorder(PythonPackage):
     """It helps ShengBTE users create FORCE_CONSTANTS_3RD files efficiently"""
 
-    homepage = "http://www.shengbte.org"
+    homepage = "https://www.shengbte.org"
     url      = "http://www.shengbte.org/downloads/thirdorder-v1.1.1-8526f47.tar.bz2"
 
     version('1.1.1-8526f47', '5e1cc8d6ffa7efdb7325c397ca236863ea8a9c5bed1c558acca68b140f89167e')

--- a/var/spack/repos/builtin/packages/py-toolz/package.py
+++ b/var/spack/repos/builtin/packages/py-toolz/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyToolz(PythonPackage):
     """A set of utility functions for iterators, functions, and dictionaries"""
 
-    homepage = "http://github.com/pytoolz/toolz/"
+    homepage = "https://github.com/pytoolz/toolz/"
     pypi = "toolz/toolz-0.9.0.tar.gz"
 
     version('0.9.0', sha256='929f0a7ea7f61c178bd951bdae93920515d3fbdbafc8e6caf82d752b9b3b31c9')

--- a/var/spack/repos/builtin/packages/py-uvloop/package.py
+++ b/var/spack/repos/builtin/packages/py-uvloop/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyUvloop(PythonPackage):
     """uvloop is a fast, drop-in replacement of the built-in asyncio event"""
 
-    homepage = "http://github.com/MagicStack/uvloop"
+    homepage = "https://github.com/MagicStack/uvloop"
     pypi = "uvloop/uvloop-0.14.0.tar.gz"
 
     version('0.14.0', sha256='123ac9c0c7dd71464f58f1b4ee0bbd81285d96cdda8bc3519281b8973e3a461e')

--- a/var/spack/repos/builtin/packages/py-wget/package.py
+++ b/var/spack/repos/builtin/packages/py-wget/package.py
@@ -12,7 +12,6 @@ class PyWget(PythonPackage):
     Download the file for your platform. If you're not sure which to choose,
     learn more about installing packages."""
 
-    homepage = "http://bitbucket.org/techtonik/python-wget/"
     pypi     = "wget/wget-3.2.zip"
 
     version('3.2', sha256='35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061')

--- a/var/spack/repos/builtin/packages/py-wincertstore/package.py
+++ b/var/spack/repos/builtin/packages/py-wincertstore/package.py
@@ -10,7 +10,7 @@ class PyWincertstore(PythonPackage):
     """wincertstore provides an interface to access Windows' CA and CRL certificates.
     It uses ctypes and Windows's sytem cert store API through crypt32.dll."""
 
-    homepage = "https://bitbucket.org/tiran/wincertstore"
+    homepage = "https://github.com/tiran/wincertstore"
     pypi     = "wincertstore/wincertstore-0.2.zip"
 
     version('0.2', sha256='780bd1557c9185c15d9f4221ea7f905cb20b93f7151ca8ccaed9714dce4b327a')

--- a/var/spack/repos/builtin/packages/py-xattr/package.py
+++ b/var/spack/repos/builtin/packages/py-xattr/package.py
@@ -9,7 +9,7 @@ class PyXattr(PythonPackage):
     sans libattr dependency.
     """
 
-    homepage = "http://pyxattr.k1024.org/"
+    homepage = "https://pyxattr.k1024.org/"
     pypi = "xattr/xattr-0.9.6.tar.gz"
     git = "https://github.com/iustin/pyxattr.git"
 

--- a/var/spack/repos/builtin/packages/py-yamlreader/package.py
+++ b/var/spack/repos/builtin/packages/py-yamlreader/package.py
@@ -10,7 +10,7 @@ class PyYamlreader(PythonPackage):
     """Yamlreader merges YAML data from a directory, a list of files or a
     file glob."""
 
-    homepage = "http://pyyaml.org/wiki/PyYAML"
+    homepage = "https://pyyaml.org/wiki/PyYAML"
     pypi = "yamlreader/yamlreader-3.0.4.tar.gz"
 
     version('3.0.4', sha256='765688036d57104ac26e4500ab088d42f4f2d06687ce3daa26543d7ae38c2470')

--- a/var/spack/repos/builtin/packages/py-yt/package.py
+++ b/var/spack/repos/builtin/packages/py-yt/package.py
@@ -15,7 +15,7 @@ class PyYt(PythonPackage):
        simulations, radio telescopes, and a burgeoning
        interdisciplinary community.
     """
-    homepage = "http://yt-project.org"
+    homepage = "https://yt-project.org"
     url      = "https://github.com/yt-project/yt/archive/yt-3.5.0.tar.gz"
     git      = "https://github.com/yt-project/yt.git"
 

--- a/var/spack/repos/builtin/packages/py-zc-buildout/package.py
+++ b/var/spack/repos/builtin/packages/py-zc-buildout/package.py
@@ -9,7 +9,6 @@ from spack import *
 class PyZcBuildout(PythonPackage):
     """System for managing development buildouts"""
 
-    homepage = "http://buildout.org/"
     pypi = "zc.buildout/zc.buildout-2.13.1.tar.gz"
 
     version('2.13.1', sha256='3d14d07226963a517295dfad5879d2799e2e3b65b2c61c71b53cb80f5ab11484')

--- a/var/spack/repos/builtin/packages/qrupdate/package.py
+++ b/var/spack/repos/builtin/packages/qrupdate/package.py
@@ -13,7 +13,7 @@ class Qrupdate(MakefilePackage, SourceforgePackage):
     """qrupdate is a Fortran library for fast updates of QR and
     Cholesky decompositions."""
 
-    homepage = "http://sourceforge.net/projects/qrupdate/"
+    homepage = "https://sourceforge.net/projects/qrupdate/"
     sourceforge_mirror_path = "qrupdate/qrupdate-1.1.2.tar.gz"
 
     version('1.1.2', sha256='e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08')

--- a/var/spack/repos/builtin/packages/quota/package.py
+++ b/var/spack/repos/builtin/packages/quota/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Quota(AutotoolsPackage):
     """Linux Diskquota system as part of the Linux kernel."""
 
-    homepage = "http://sourceforge.net/projects/linuxquota"
+    homepage = "https://sourceforge.net/projects/linuxquota"
     url      = "https://udomain.dl.sourceforge.net/project/linuxquota/quota-tools/4.05/quota-4.05.tar.gz"
 
     version('4.05', sha256='ef3b5b5d1014ed1344b46c1826145e20cbef8db967b522403c9a060761cf7ab9')

--- a/var/spack/repos/builtin/packages/r-amap/package.py
+++ b/var/spack/repos/builtin/packages/r-amap/package.py
@@ -12,7 +12,7 @@ class RAmap(RPackage):
     Tools for Clustering and Principal Component Analysis (With robust methods,
     and parallelized functions)."""
 
-    homepage = "http://mulcyber.toulouse.inra.fr/projects/amap/"
+    homepage = "https://cran.r-project.org/web/packages/amap/index.html"
     url      = "https://cloud.r-project.org/src/contrib/amap_0.8-16.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/amap/"
 

--- a/var/spack/repos/builtin/packages/r-fs/package.py
+++ b/var/spack/repos/builtin/packages/r-fs/package.py
@@ -12,7 +12,7 @@ class RFs(RPackage):
     A cross-platform interface to file system operations, built on top of
     the 'libuv' C library."""
 
-    homepage = "http://fs.r-lib.org/"
+    homepage = "https://ggplot2.tidyverse.org/"
     url      = "https://cloud.r-project.org/src/contrib/fs_1.3.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/fs"
 

--- a/var/spack/repos/builtin/packages/r-hmisc/package.py
+++ b/var/spack/repos/builtin/packages/r-hmisc/package.py
@@ -16,7 +16,7 @@ class RHmisc(RPackage):
     string manipulation, conversion of R objects to LaTeX and html
     code, and recoding variables."""
 
-    homepage = "http://biostat.mc.vanderbilt.edu/Hmisc"
+    homepage = "https://cran.r-project.org/web/packages/Hmisc/index.html"
     url      = "https://cloud.r-project.org/src/contrib/Hmisc_4.1-1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/Hmisc"
 

--- a/var/spack/repos/builtin/packages/r-pbkrtest/package.py
+++ b/var/spack/repos/builtin/packages/r-pbkrtest/package.py
@@ -20,7 +20,7 @@ class RPbkrtest(RPackage):
     paper by Halehoh and Hojsgaard, (2012, <doi:10.18637/jss.v059.i09>).
     Please see 'citation("pbkrtest")' for citation details."""
 
-    homepage = "http://people.math.aau.dk/~sorenh/software/pbkrtest/"
+    homepage = "https://cran.r-project.org/web/packages/pbkrtest/index.html"
     url      = "https://cloud.r-project.org/src/contrib/pbkrtest_0.4-6.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/pbkrtest"
 

--- a/var/spack/repos/builtin/packages/r-proto/package.py
+++ b/var/spack/repos/builtin/packages/r-proto/package.py
@@ -10,7 +10,7 @@ class RProto(RPackage):
     """An object oriented system using object-based, also called
     prototype-based, rather than class-based object oriented ideas."""
 
-    homepage = "http://r-proto.googlecode.com/"
+    homepage = "https://cran.r-project.org/web/packages/proto/index.html"
     url      = "https://cloud.r-project.org/src/contrib/proto_0.3-10.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/proto"
 

--- a/var/spack/repos/builtin/packages/r-rmpi/package.py
+++ b/var/spack/repos/builtin/packages/r-rmpi/package.py
@@ -10,7 +10,7 @@ class RRmpi(RPackage):
     """An interface (wrapper) to MPI APIs. It also provides interactive R
        manager and worker environment."""
 
-    homepage = "http://www.stats.uwo.ca/faculty/yu/Rmpi"
+    homepage = "https://cran.r-project.org/web/packages/Rmpi/index.html"
     url      = "https://cloud.r-project.org/src/contrib/Rmpi_0.6-6.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/Rmpi"
 

--- a/var/spack/repos/builtin/packages/r-rpostgresql/package.py
+++ b/var/spack/repos/builtin/packages/r-rpostgresql/package.py
@@ -17,7 +17,7 @@ class RRpostgresql(RPackage):
     issue tracking system for the package are available at Google Code at
     https://code.google.com/p/rpostgresql/."""
 
-    homepage = "https://code.google.com/p/rpostgresql/"
+    homepage = "https://cran.r-project.org/web/packages/RPostgreSQL/index.html"
     url      = "https://cloud.r-project.org/src/contrib/RPostgreSQL_0.4-1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/RPostgreSQL"
 

--- a/var/spack/repos/builtin/packages/r-rstan/package.py
+++ b/var/spack/repos/builtin/packages/r-rstan/package.py
@@ -19,7 +19,7 @@ class RRstan(RPackage):
     quickly and accurately evaluate gradients without burdening the user with
     the need to derive the partial derivatives."""
 
-    homepage = "http://mc-stan.org/"
+    homepage = "https://mc-stan.org/users/interfaces/rstan"
     url      = "https://cloud.r-project.org/src/contrib/rstan_2.10.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/rstan"
 

--- a/var/spack/repos/builtin/packages/r-shinystan/package.py
+++ b/var/spack/repos/builtin/packages/r-shinystan/package.py
@@ -17,7 +17,7 @@ class RShinystan(RPackage):
     programming language (and has extended functionality for 'Stan' models fit
     using the 'rstan' and 'rstanarm' packages)."""
 
-    homepage = "http://mc-stan.org/"
+    homepage = "https://mc-stan.org/"
     cran     = "shinystan"
 
     version('2.5.0', sha256='45f9c552a31035c5de8658bb9e5d72da7ec1f88fbddb520d15fe701c677154a1')

--- a/var/spack/repos/builtin/packages/r-stabledist/package.py
+++ b/var/spack/repos/builtin/packages/r-stabledist/package.py
@@ -11,7 +11,7 @@ class RStabledist(RPackage):
     generation for (skew) stable distributions, using the parametrizations of
     Nolan."""
 
-    homepage = "http://www.rmetrics.org/"
+    homepage = "https://www.rmetrics.org/"
     url      = "https://cloud.r-project.org/src/contrib/stabledist_0.7-1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/stabledist"
 

--- a/var/spack/repos/builtin/packages/r-stanheaders/package.py
+++ b/var/spack/repos/builtin/packages/r-stanheaders/package.py
@@ -25,7 +25,7 @@ class RStanheaders(RPackage):
     'rstan' package provides user-facing R functions to parse, compile, test,
     estimate, and analyze Stan models."""
 
-    homepage = "http://mc-stan.org/"
+    homepage = "https://mc-stan.org/"
     url      = "https://cloud.r-project.org/src/contrib/StanHeaders_2.10.0-2.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/StanHeaders"
 

--- a/var/spack/repos/builtin/packages/r-whisker/package.py
+++ b/var/spack/repos/builtin/packages/r-whisker/package.py
@@ -11,7 +11,7 @@ class RWhisker(RPackage):
 
     Implements 'Mustache' logicless templating."""
 
-    homepage = "http://github.com/edwindj/whisker"
+    homepage = "https://github.com/edwindj/whisker"
     url      = "https://cloud.r-project.org/src/contrib/whisker_0.3-2.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/whisker"
 

--- a/var/spack/repos/builtin/packages/r-xlsx/package.py
+++ b/var/spack/repos/builtin/packages/r-xlsx/package.py
@@ -12,7 +12,7 @@ class RXlsx(RPackage):
     Provide R functions to read/write/format Excel 2007 and Excel
     97/2000/XP/2003 file formats."""
 
-    homepage = "http://code.google.com/p/rexcel/"
+    homepage = "https://github.com/colearendt/xlsx"
     url      = "https://cloud.r-project.org/src/contrib/xlsx_0.6.1.tar.gz"
     listurl  = "https://cloud.r-project.org/src/contrib/Archive/xlsx"
 

--- a/var/spack/repos/builtin/packages/rabbitmq/package.py
+++ b/var/spack/repos/builtin/packages/rabbitmq/package.py
@@ -14,7 +14,7 @@ class Rabbitmq(Package):
     high-availability requirements.
     """
 
-    homepage = "http://www.rabbitmq.com/"
+    homepage = "https://www.rabbitmq.com/"
     url      = "http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.15/rabbitmq-server-generic-unix-3.6.15.tar.xz"
 
     version('3.6.15', sha256='04e6a291642f80e87fc892d5e8ea309fb3fab85ebb64a79a70dfe6c6cfde36fb')

--- a/var/spack/repos/builtin/packages/random123/package.py
+++ b/var/spack/repos/builtin/packages/random123/package.py
@@ -12,7 +12,7 @@ class Random123(Package):
     by applying a stateless mixing function to N instead of the
     conventional approach of using N iterations of a stateful
     transformation."""
-    homepage = "http://www.deshawresearch.com/resources_random123.html"
+    homepage = "https://www.deshawresearch.com/resources_random123.html"
     url      = "http://www.deshawresearch.com/downloads/download_random123.cgi/Random123-1.09.tar.gz"
 
     version('1.13.2', sha256='74a1c6bb66b2684f03d3b1008642a2e9141909103cd09f428d2c60bcaa51cb40')

--- a/var/spack/repos/builtin/packages/raptor2/package.py
+++ b/var/spack/repos/builtin/packages/raptor2/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Raptor2(AutotoolsPackage):
     """libraptor2 for parsing and serializing RDF syntaxes"""
 
-    homepage = "http://librdf.org/"
+    homepage = "https://librdf.org/"
     url      = "http://download.librdf.org/source/raptor2-2.0.15.tar.gz"
 
     version('2.0.15', sha256='ada7f0ba54787b33485d090d3d2680533520cd4426d2f7fb4782dd4a6a1480ed')

--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -10,7 +10,7 @@ class Rclone(Package):
     """Rclone is a command line program to sync files and directories
        to and from various cloud storage providers"""
 
-    homepage = "http://rclone.org"
+    homepage = "https://rclone.org"
     url      = "https://github.com/ncw/rclone/releases/download/v1.43/rclone-v1.43.tar.gz"
 
     maintainers = ['alecbcs']

--- a/var/spack/repos/builtin/packages/redland-bindings/package.py
+++ b/var/spack/repos/builtin/packages/redland-bindings/package.py
@@ -11,7 +11,7 @@ from spack import *
 class RedlandBindings(AutotoolsPackage):
     """Redland Language Bindings for language APIs to Redland"""
 
-    homepage = "http://librdf.org/"
+    homepage = "https://librdf.org/"
     url      = "http://download.librdf.org/source/redland-bindings-1.0.17.1.tar.gz"
 
     version('1.0.17.1', sha256='ff72b587ab55f09daf81799cb3f9d263708fad5df7a5458f0c28566a2563b7f5')

--- a/var/spack/repos/builtin/packages/redland/package.py
+++ b/var/spack/repos/builtin/packages/redland/package.py
@@ -10,7 +10,7 @@ from spack import *
 class Redland(AutotoolsPackage):
     """Redland RDF Library - librdf providing the RDF API and triple stores"""
 
-    homepage = "http://librdf.org/"
+    homepage = "https://librdf.org/"
     url      = "http://download.librdf.org/source/redland-1.0.17.tar.gz"
 
     version('1.0.17', sha256='de1847f7b59021c16bdc72abb4d8e2d9187cd6124d69156f3326dd34ee043681')

--- a/var/spack/repos/builtin/packages/rr/package.py
+++ b/var/spack/repos/builtin/packages/rr/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class Rr(CMakePackage):
     """Application execution recorder, player and debugger"""
-    homepage = "http://rr-project.org/"
+    homepage = "https://rr-project.org/"
     url      = "https://github.com/mozilla/rr/archive/4.5.0.tar.gz"
 
     version('4.5.0', sha256='19f28259c0aa562c9518ae51207377fa93071a7dc270a0738d8d39e45ae2b1c0')

--- a/var/spack/repos/builtin/packages/rust-bindgen/package.py
+++ b/var/spack/repos/builtin/packages/rust-bindgen/package.py
@@ -10,7 +10,7 @@ from spack import *
 
 class RustBindgen(Package):
     """The rust programming language toolchain"""
-    homepage = "http://www.rust-lang.org"
+    homepage = "https://www.rust-lang.org"
     url = "https://github.com/servo/rust-bindgen/archive/v0.20.5.tar.gz"
 
     version('0.20.5', sha256='4f5236e7979d262c43267afba365612b1008b91b8f81d1efc6a8a2199d52bb37')

--- a/var/spack/repos/builtin/packages/sblim-sfcc/package.py
+++ b/var/spack/repos/builtin/packages/sblim-sfcc/package.py
@@ -9,7 +9,7 @@ from spack import *
 class SblimSfcc(AutotoolsPackage):
     """Small Footprint CIM Client Library"""
 
-    homepage = "http://sourceforge.net/projects/sblim"
+    homepage = "https://sourceforge.net/projects/sblim"
     url      = "https://github.com/kkaempf/sblim-sfcc/archive/SFCC_2_2_1.tar.gz"
 
     version('2_2_8', sha256='d8d0bf06a487483df507f512ddf0c7b2c1b878a1c9b039bf5c2357c4ba13b882')

--- a/var/spack/repos/builtin/packages/sbt/package.py
+++ b/var/spack/repos/builtin/packages/sbt/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Sbt(Package):
     """Scala Build Tool"""
 
-    homepage = 'http://www.scala-sbt.org'
+    homepage = 'https://www.scala-sbt.org'
     url      = "https://github.com/sbt/sbt/releases/download/v1.1.4/sbt-1.1.4.tgz"
 
     version('1.1.6', sha256='f545b530884e3abbca026df08df33d5a15892e6d98da5b8c2297413d1c7b68c1')

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Scons(PythonPackage):
     """SCons is a software construction tool"""
 
-    homepage = "http://scons.org"
+    homepage = "https://scons.org"
     pypi = "scons/scons-3.1.1.tar.gz"
 
     version('3.1.2', sha256='8aaa483c303efeb678e6f7c776c8444a482f8ddc3ad891f8b6cdd35264da9a1f')

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -22,7 +22,7 @@ class Scr(CMakePackage):
        Linux cluster to provide a fast, scalable checkpoint/restart
        capability for MPI codes"""
 
-    homepage = "http://computing.llnl.gov/projects/scalable-checkpoint-restart-for-mpi"
+    homepage = "https://computing.llnl.gov/projects/scalable-checkpoint-restart-for-mpi"
     url      = "https://github.com/LLNL/scr/archive/v1.2.0.tar.gz"
     git      = "https://github.com/llnl/scr.git"
 

--- a/var/spack/repos/builtin/packages/setserial/package.py
+++ b/var/spack/repos/builtin/packages/setserial/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Setserial(AutotoolsPackage):
     """A utility for configuring serial ports."""
 
-    homepage = "https://setserial.sourceforge.net"
+    homepage = "http://setserial.sourceforge.net"
     url      = "https://udomain.dl.sourceforge.net/project/setserial/setserial/2.17/setserial-2.17.tar.gz"
 
     version('2.17', sha256='7e4487d320ac31558563424189435d396ddf77953bb23111a17a3d1487b5794a')

--- a/var/spack/repos/builtin/packages/smalt/package.py
+++ b/var/spack/repos/builtin/packages/smalt/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Smalt(AutotoolsPackage, SourceforgePackage):
     """SMALT aligns DNA sequencing reads with a reference genome."""
 
-    homepage = "http://www.sanger.ac.uk/science/tools/smalt-0"
+    homepage = "https://www.sanger.ac.uk/science/tools/smalt-0"
     sourceforge_mirror_path = "smalt/smalt-0.7.6.tar.gz"
 
     version('0.7.6', sha256='89ccdfe471edba3577b43de9ebfdaedb5cd6e26b02bf4000c554253433796b31')

--- a/var/spack/repos/builtin/packages/soapdenovo-trans/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo-trans/package.py
@@ -11,7 +11,7 @@ class SoapdenovoTrans(MakefilePackage):
        SOAPdenovo framework, adapt to alternative splicing and different
        expression level among transcripts."""
 
-    homepage = "http://soap.genomics.org.cn/SOAPdenovo-Trans.html"
+    homepage = "https://github.com/aquaskyline/SOAPdenovo-Trans"
     url      = "https://github.com/aquaskyline/SOAPdenovo-Trans/archive/1.0.4.tar.gz"
 
     version('1.0.4', sha256='378a54cde0ebe240fb515ba67197c053cf95393645c1ae1399b3a611be2a9795')

--- a/var/spack/repos/builtin/packages/sparskit/package.py
+++ b/var/spack/repos/builtin/packages/sparskit/package.py
@@ -14,7 +14,7 @@ class Sparskit(MakefilePackage):
     Made by Yousef Saad, University of Minnesota.
     """
 
-    homepage = "https://www-users.cs.umn.edu/~saad/software/SPARSKIT/"
+    homepage = "https://www-users.cse.umn.edu/~saad/software/SPARSKIT/"
 
     version('develop', sha256='ecdd0a9968d6b45153a328710a42fe87600f0bba0e3c53896090b8ae1c113b7a',
             url='http://www-users.cs.umn.edu/~saad/software/SPARSKIT/SPARSKIT2.tar.gz')

--- a/var/spack/repos/builtin/packages/tcsh/package.py
+++ b/var/spack/repos/builtin/packages/tcsh/package.py
@@ -14,7 +14,7 @@ class Tcsh(AutotoolsPackage):
     correction, a history mechanism, job control and a C language like
     syntax."""
 
-    homepage = "http://www.tcsh.org/"
+    homepage = "https://www.tcsh.org/"
     url      = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/tcsh-6.20.00.tar.gz"
     list_url = "http://ftp.funet.fi/pub/mirrors/ftp.astron.com/pub/tcsh/old/"
 

--- a/var/spack/repos/builtin/packages/texstudio/package.py
+++ b/var/spack/repos/builtin/packages/texstudio/package.py
@@ -10,7 +10,7 @@ class Texstudio(QMakePackage):
     """TeXstudio is a fully featured LaTeX editor, whose goal is to make
     writing LaTeX documents as easy and comfortable as possible."""
 
-    homepage = "http://www.texstudio.org"
+    homepage = "https://www.texstudio.org"
     url      = "https://github.com/texstudio-org/texstudio/archive/2.12.16.tar.gz"
     git      = "https://github.com/texstudio-org/texstudio.git"
 

--- a/var/spack/repos/builtin/packages/the-silver-searcher/package.py
+++ b/var/spack/repos/builtin/packages/the-silver-searcher/package.py
@@ -9,7 +9,7 @@ from spack import *
 class TheSilverSearcher(AutotoolsPackage):
     """Fast recursive grep alternative"""
 
-    homepage = "http://geoff.greer.fm/ag/"
+    homepage = "https://geoff.greer.fm/ag/"
     url      = "http://geoff.greer.fm/ag/releases/the_silver_searcher-0.32.0.tar.gz"
 
     version('2.2.0', sha256='d9621a878542f3733b5c6e71c849b9d1a830ed77cb1a1f6c2ea441d4b0643170')

--- a/var/spack/repos/builtin/packages/velvet/package.py
+++ b/var/spack/repos/builtin/packages/velvet/package.py
@@ -10,7 +10,7 @@ class Velvet(MakefilePackage):
     """Velvet is a de novo genomic assembler specially designed for short read
        sequencing technologies."""
 
-    homepage = "http://www.ebi.ac.uk/~zerbino/velvet/"
+    homepage = "https://www.ebi.ac.uk/~zerbino/velvet/"
     url      = "http://www.ebi.ac.uk/~zerbino/velvet/velvet_1.2.10.tgz"
 
     version('1.2.10', sha256='884dd488c2d12f1f89cdc530a266af5d3106965f21ab9149e8cb5c633c977640')

--- a/var/spack/repos/builtin/packages/votca-csg-tutorials/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg-tutorials/package.py
@@ -15,7 +15,7 @@ class VotcaCsgTutorials(CMakePackage):
 
        This package contains the VOTCA coarse-graining tutorials.
     """
-    homepage = "http://www.votca.org"
+    homepage = "https://www.votca.org"
     url      = "https://github.com/votca/csg-tutorials/tarball/v1.4"
     git      = "https://github.com/votca/csg-tutorials.git"
     maintainers = ['junghans']

--- a/var/spack/repos/builtin/packages/votca-csg/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg/package.py
@@ -15,7 +15,7 @@ class VotcaCsg(CMakePackage):
 
        This package contains the VOTCA coarse-graining engine.
     """
-    homepage = "http://www.votca.org"
+    homepage = "https://www.votca.org"
     url      = "https://github.com/votca/csg/tarball/v1.4"
     git      = "https://github.com/votca/csg.git"
     maintainers = ['junghans']

--- a/var/spack/repos/builtin/packages/votca-csgapps/package.py
+++ b/var/spack/repos/builtin/packages/votca-csgapps/package.py
@@ -15,7 +15,7 @@ class VotcaCsgapps(CMakePackage):
 
        This package contains the VOTCA coarse-graining extra apps.
     """
-    homepage = "http://www.votca.org"
+    homepage = "https://www.votca.org"
     url      = "https://github.com/votca/csgapps/tarball/v1.4"
     git      = "https://github.com/votca/csgapps.git"
     maintainers = ['junghans']

--- a/var/spack/repos/builtin/packages/votca-ctp/package.py
+++ b/var/spack/repos/builtin/packages/votca-ctp/package.py
@@ -15,7 +15,7 @@ class VotcaCtp(CMakePackage):
 
        This package contains the VOTCA charge transport engine.
     """
-    homepage = "http://www.votca.org"
+    homepage = "https://www.votca.org"
     url      = "https://github.com/votca/ctp/tarball/v1.5"
     git      = "https://github.com/votca/ctp.git"
 

--- a/var/spack/repos/builtin/packages/votca-tools/package.py
+++ b/var/spack/repos/builtin/packages/votca-tools/package.py
@@ -15,7 +15,7 @@ class VotcaTools(CMakePackage):
 
        This package contains the basic tools library of VOTCA.
     """
-    homepage = "http://www.votca.org"
+    homepage = "https://www.votca.org"
     url      = "https://github.com/votca/tools/tarball/v1.4"
     git      = "https://github.com/votca/tools.git"
     maintainers = ['junghans']

--- a/var/spack/repos/builtin/packages/votca-xtp/package.py
+++ b/var/spack/repos/builtin/packages/votca-xtp/package.py
@@ -15,7 +15,7 @@ class VotcaXtp(CMakePackage):
 
        This package contains the VOTCA exciton transport engine.
     """
-    homepage = "http://www.votca.org"
+    homepage = "https://www.votca.org"
     url      = "https://github.com/votca/xtp/tarball/v1.4.1"
     git      = "https://github.com/votca/xtp.git"
     maintainers = ['junghans']

--- a/var/spack/repos/builtin/packages/wcslib/package.py
+++ b/var/spack/repos/builtin/packages/wcslib/package.py
@@ -10,7 +10,7 @@ class Wcslib(AutotoolsPackage):
     """WCSLIB a C implementation of the coordinate transformations
     defined in the FITS WCS papers."""
 
-    homepage = "http://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/"
+    homepage = "https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib/"
     url      = "ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-7.3.tar.bz2"
 
     version('7.3', sha256='4b01cf425382a26ca4f955ed6841a5f50c55952a2994367f8e067e4183992961')

--- a/var/spack/repos/builtin/packages/windowswmproto/package.py
+++ b/var/spack/repos/builtin/packages/windowswmproto/package.py
@@ -14,7 +14,7 @@ class Windowswmproto(AutotoolsPackage, XorgPackage):
     WindowsWM is only intended to be used on Cygwin when running a
     rootless XWin server."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/windowswmproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/windowswmproto"
     xorg_mirror_path = "proto/windowswmproto-1.0.4.tar.gz"
 
     version('1.0.4', sha256='2dccf510cf18a1b5cfd3a277c678d88303efc85478b479fec46228a861956eb7')

--- a/var/spack/repos/builtin/packages/wt/package.py
+++ b/var/spack/repos/builtin/packages/wt/package.py
@@ -11,7 +11,7 @@ class Wt(CMakePackage):
 
     Wt is a C++ library for developing web applications."""
 
-    homepage = "http://www.webtoolkit.eu/wt"
+    homepage = "https://www.webtoolkit.eu/wt"
     url      = "https://github.com/emweb/wt/archive/3.3.7.tar.gz"
     git      = "https://github.com/emweb/wt.git"
 

--- a/var/spack/repos/builtin/packages/xcb-proto/package.py
+++ b/var/spack/repos/builtin/packages/xcb-proto/package.py
@@ -10,7 +10,7 @@ class XcbProto(AutotoolsPackage):
     """xcb-proto provides the XML-XCB protocol descriptions that libxcb uses to
     generate the majority of its code and API."""
 
-    homepage = "http://xcb.freedesktop.org/"
+    homepage = "https://xcb.freedesktop.org/"
     url      = "https://xorg.freedesktop.org/archive/individual/proto/xcb-proto-1.14.1.tar.xz"
 
     version('1.14.1', sha256='f04add9a972ac334ea11d9d7eb4fc7f8883835da3e4859c9afa971efdf57fcc3')

--- a/var/spack/repos/builtin/packages/xf86driproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86driproto/package.py
@@ -13,7 +13,7 @@ class Xf86driproto(AutotoolsPackage, XorgPackage):
     the video hardware without requiring data to be passed through the X
     server."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/xf86driproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xf86driproto"
     xorg_mirror_path = "proto/xf86driproto-2.1.1.tar.gz"
 
     version('2.1.1', sha256='18ff8de129b89fa24a412a1ec1799f8687f96c186c655b44b1a714a3a5d15d6c')

--- a/var/spack/repos/builtin/packages/xf86miscproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86miscproto/package.py
@@ -12,7 +12,7 @@ class Xf86miscproto(AutotoolsPackage, XorgPackage):
     supported by the XFree86 X server and versions of the Xorg X server
     prior to Xorg 1.6."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/xf86miscproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xf86miscproto"
     xorg_mirror_path = "proto/xf86miscproto-0.9.3.tar.gz"
 
     version('0.9.3', sha256='1b05cb76ac165c703b82bdd270b86ebbc4d42a7d04d299050b07ba2099c31352')

--- a/var/spack/repos/builtin/packages/xf86vidmodeproto/package.py
+++ b/var/spack/repos/builtin/packages/xf86vidmodeproto/package.py
@@ -12,7 +12,7 @@ class Xf86vidmodeproto(AutotoolsPackage, XorgPackage):
     This extension defines a protocol for dynamically configuring modelines
     and gamma."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/xf86vidmodeproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xf86vidmodeproto"
     xorg_mirror_path = "proto/xf86vidmodeproto-2.3.1.tar.gz"
 
     version('2.3.1', sha256='c3512b11cefa7558576551f8582c6e7071c8a24d78176059d94b84b48b262979')

--- a/var/spack/repos/builtin/packages/xfsdump/package.py
+++ b/var/spack/repos/builtin/packages/xfsdump/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xfsdump(MakefilePackage):
     """XFS Dump Tools."""
 
-    homepage = "http://oss.sgi.com/projects/xfs/"
+    homepage = "https://github.com/pcacjr/xfsdump"
     url      = "https://github.com/pcacjr/xfsdump/archive/v3.1.6.tar.gz"
 
     version('3.1.6', sha256='bbf659758107cad9b41cf3001df121e6428485b341109a1f1a952fd477a7010b')

--- a/var/spack/repos/builtin/packages/xfsinfo/package.py
+++ b/var/spack/repos/builtin/packages/xfsinfo/package.py
@@ -13,7 +13,7 @@ class Xfsinfo(AutotoolsPackage, XorgPackage):
     clients and the server, and the font catalogues and alternate servers
     that are available."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xfsinfo"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xfsinfo"
     xorg_mirror_path = "app/xfsinfo-1.0.5.tar.gz"
 
     version('1.0.5', sha256='56a0492ed2cde272dc8f4cff4ba0970ccb900e51c10bb8ec62747483d095fd69')

--- a/var/spack/repos/builtin/packages/xfsprogs/package.py
+++ b/var/spack/repos/builtin/packages/xfsprogs/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xfsprogs(AutotoolsPackage):
     """XFS User Tools."""
 
-    homepage = "http://oss.sgi.com/projects/xfs/"
+    homepage = "https://github.com/mtanski/xfsprogs"
     url      = "http://kernel.org/pub/linux/utils/fs/xfs/xfsprogs/xfsprogs-4.17.0.tar.xz"
 
     version('5.11.0', sha256='0e9c390fcdbb8a79e1b8f5e6e25fd529fc9f9c2ef8f2d5e647b3556b82d1b353')

--- a/var/spack/repos/builtin/packages/xineramaproto/package.py
+++ b/var/spack/repos/builtin/packages/xineramaproto/package.py
@@ -12,7 +12,7 @@ class Xineramaproto(AutotoolsPackage, XorgPackage):
     This is an X extension that allows multiple physical screens controlled
     by a single X server to appear as a single screen."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/xineramaproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xineramaproto"
     xorg_mirror_path = "proto/xineramaproto-1.2.1.tar.gz"
 
     version('1.2.1', sha256='d99e121edf7b310008d7371ac5dbe3aa2810996d476b754dc78477cc26e5e7c1')

--- a/var/spack/repos/builtin/packages/xinit/package.py
+++ b/var/spack/repos/builtin/packages/xinit/package.py
@@ -11,7 +11,7 @@ class Xinit(AutotoolsPackage, XorgPackage):
     first client program on systems that are not using a display manager
     such as xdm."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xinit"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xinit"
     xorg_mirror_path = "app/xinit-1.3.4.tar.gz"
 
     version('1.3.4', sha256='754c284875defa588951c1d3d2b20897d3b84918d0a97cb5a4724b00c0da0746')

--- a/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
+++ b/var/spack/repos/builtin/packages/xorg-sgml-doctools/package.py
@@ -11,7 +11,7 @@ class XorgSgmlDoctools(AutotoolsPackage, XorgPackage):
     sheets used in building/formatting the documentation provided in other
     X.Org packages."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/doc/xorg-sgml-doctools"
+    homepage = "https://cgit.freedesktop.org/xorg/doc/xorg-sgml-doctools"
     xorg_mirror_path = "doc/xorg-sgml-doctools-1.11.tar.gz"
 
     version('1.11', sha256='986326d7b4dd2ad298f61d8d41fe3929ac6191c6000d6d7e47a8ffc0c34e7426')

--- a/var/spack/repos/builtin/packages/xphelloworld/package.py
+++ b/var/spack/repos/builtin/packages/xphelloworld/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xphelloworld(AutotoolsPackage, XorgPackage):
     """Xprint sample applications."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xphelloworld"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xphelloworld"
     xorg_mirror_path = "app/xphelloworld-1.0.1.tar.gz"
 
     version('1.0.1', sha256='ead6437c4dc9540698a41e174c9d1ac792de07baeead81935d72cb123196f866')

--- a/var/spack/repos/builtin/packages/xprehashprinterlist/package.py
+++ b/var/spack/repos/builtin/packages/xprehashprinterlist/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xprehashprinterlist(AutotoolsPackage, XorgPackage):
     """Rehash list of Xprint printers."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xprehashprinterlist"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xprehashprinterlist"
     xorg_mirror_path = "app/xprehashprinterlist-1.0.1.tar.gz"
 
     version('1.0.1', sha256='396986da064b584138cfcff79a8aed12590a9dab24f1cd2d80b08bc1cb896a43')

--- a/var/spack/repos/builtin/packages/xprop/package.py
+++ b/var/spack/repos/builtin/packages/xprop/package.py
@@ -10,7 +10,7 @@ class Xprop(AutotoolsPackage, XorgPackage):
     """xprop is a command line tool to display and/or set window and font
     properties of an X server."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xprop"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xprop"
     xorg_mirror_path = "app/xprop-1.2.2.tar.gz"
 
     version('1.2.2', sha256='3db78771ce8fb8954fb242ed9d4030372523649c5e9c1a9420340020dd0afbc2')

--- a/var/spack/repos/builtin/packages/xrx/package.py
+++ b/var/spack/repos/builtin/packages/xrx/package.py
@@ -14,7 +14,7 @@ class Xrx(AutotoolsPackage, XorgPackage):
     browser must identify specific instances of the services in the request
     to invoke the application."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xrx"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xrx"
     xorg_mirror_path = "app/xrx-1.0.4.tar.gz"
 
     version('1.0.4', sha256='1ffa1c2af28587c6ed7ded3af2e62e93bad8f9900423d09c45b1d59449d15134')

--- a/var/spack/repos/builtin/packages/xscope/package.py
+++ b/var/spack/repos/builtin/packages/xscope/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xscope(AutotoolsPackage, XorgPackage):
     """XSCOPE -- a program to monitor X11/Client conversations."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xscope"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xscope"
     xorg_mirror_path = "app/xscope-1.4.1.tar.gz"
 
     version('1.4.1', sha256='f99558a64e828cd2c352091ed362ad2ef42b1c55ef5c01cbf782be9735bb6de3')

--- a/var/spack/repos/builtin/packages/xsetmode/package.py
+++ b/var/spack/repos/builtin/packages/xsetmode/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xsetmode(AutotoolsPackage, XorgPackage):
     """Set the mode for an X Input device."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xsetmode"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xsetmode"
     xorg_mirror_path = "app/xsetmode-1.0.0.tar.gz"
 
     version('1.0.0', sha256='9ee0d6cf72dfaacb997f9570779dcbc42f5395ae102180cb19382860b4b02ef3')

--- a/var/spack/repos/builtin/packages/xsetpointer/package.py
+++ b/var/spack/repos/builtin/packages/xsetpointer/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xsetpointer(AutotoolsPackage, XorgPackage):
     """Set an X Input device as the main pointer."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xsetpointer"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xsetpointer"
     xorg_mirror_path = "app/xsetpointer-1.0.1.tar.gz"
 
     version('1.0.1', sha256='54be93b20fd6f1deac67246d6e214a60b02dcfbf05295e43751f7a04edb986ac')

--- a/var/spack/repos/builtin/packages/xterm/package.py
+++ b/var/spack/repos/builtin/packages/xterm/package.py
@@ -11,7 +11,7 @@ class Xterm(AutotoolsPackage):
     provides DEC VT102 and Tektronix 4014 compatible terminals for programs
     that can't use the window system directly."""
 
-    homepage = "http://invisible-island.net/xterm/"
+    homepage = "https://invisible-island.net/xterm/"
     url      = "ftp://ftp.invisible-island.net/xterm/xterm-327.tgz"
 
     version('353', sha256='e521d3ee9def61f5d5c911afc74dd5c3a56ce147c7071c74023ea24cac9bb768')

--- a/var/spack/repos/builtin/packages/xtrap/package.py
+++ b/var/spack/repos/builtin/packages/xtrap/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xtrap(AutotoolsPackage, XorgPackage):
     """XTrap sample clients."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xtrap"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xtrap"
     xorg_mirror_path = "app/xtrap-1.0.2.tar.gz"
 
     version('1.0.2', sha256='e8916e05bfb0d72a088aaaac0feaf4ad7671d0f509d1037fb3c0c9ea131b93d2')

--- a/var/spack/repos/builtin/packages/xwd/package.py
+++ b/var/spack/repos/builtin/packages/xwd/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xwd(AutotoolsPackage, XorgPackage):
     """xwd - dump an image of an X window."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xwd"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xwd"
     xorg_mirror_path = "app/xwd-1.0.6.tar.gz"
 
     version('1.0.6', sha256='ff01f0a4b736f955aaf7c8c3942211bc52f9fb75d96f2b19777f33fff5dc5b83')

--- a/var/spack/repos/builtin/packages/xz/package.py
+++ b/var/spack/repos/builtin/packages/xz/package.py
@@ -14,7 +14,7 @@ class Xz(AutotoolsPackage, SourceforgePackage):
     but also work on some not-so-POSIX systems. XZ Utils are the successor
     to LZMA Utils."""
 
-    homepage = "http://tukaani.org/xz/"
+    homepage = "https://tukaani.org/xz/"
     sourceforge_mirror_path = "lzmautils/files/xz-5.2.5.tar.bz2"
     list_url = "http://tukaani.org/xz/old.html"
 

--- a/var/spack/repos/builtin/packages/zabbix/package.py
+++ b/var/spack/repos/builtin/packages/zabbix/package.py
@@ -10,7 +10,7 @@ class Zabbix(AutotoolsPackage):
     """Real-time monitoring of IT components and services,
     such as networks, servers, VMs, applications and the cloud."""
 
-    homepage = "http://www.zabbix.com"
+    homepage = "https://www.zabbix.com"
     url      = "https://github.com/zabbix/zabbix/archive/5.0.3.tar.gz"
 
     version('5.0.3',       sha256='d579c5fa4e9065e8041396ace24d7132521ef5054ce30dfd9d151cbb7f0694ec')

--- a/var/spack/repos/builtin/packages/zsh/package.py
+++ b/var/spack/repos/builtin/packages/zsh/package.py
@@ -12,7 +12,7 @@ class Zsh(AutotoolsPackage):
     tcsh were incorporated into zsh; many original features were added.
     """
 
-    homepage = "http://www.zsh.org"
+    homepage = "https://www.zsh.org"
     url = "http://downloads.sourceforge.net/project/zsh/zsh/5.4.2/zsh-5.4.2.tar.xz"
 
     version('5.8', sha256='dcc4b54cc5565670a65581760261c163d720991f0d06486da61f8d839b52de27')


### PR DESCRIPTION
I've added spack to repology (went live in the middle of today) and as part of that, I stumbled on this entire three page of "spack problems"

https://repology.org/repository/spack/problems

And of course could not simply leave them there, so I went through each one and fixed the package. There were a few that should be further discussed in #25490 but for the most part these are small changes to update urls to use https, or update the perl package manager, or replace urls that are now 404. For a few sites that triggered errors (that didn't have https) the certificate setup might be strange but it's not broken, so I didn't change those. It looks like from the file count I was able to fix 379/397, which is pretty good!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>