### PR TITLE
Allow spack develop to recover from dev spec not installed

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1490,8 +1490,8 @@ class Environment(object):
         # or one of the dependencies has been reinstalled since
         # the last install
 
-        # if it's not installed, we don't need to overwrite it
-        if not spec.package.installed:
+        # if it's not installed, and it's not a dev spec we don't need to overwrite it
+        if not spec.package.installed and spec.variants.get('dev_path', None) is None:
             return False
 
         # if spec and all deps aren't dev builds, we don't need to overwrite it


### PR DESCRIPTION
Some corner cases pop up during installs with `spack develop` specs where the develop spec's are no longer registered as installed in the database.  From conversations on slack there seems to be triggered through some incremental builds.

I have not been able to trace down what causes the spec to be listed as `uninstalled`, adding another conditional to the check for installed specs allows spack to recover and reinstall the develop specs properly.