### PR TITLE
Bump nlohman-json and fix cmake args

### DIFF
--- a/var/spack/repos/builtin/packages/nlohmann-json/package.py
+++ b/var/spack/repos/builtin/packages/nlohmann-json/package.py
@@ -13,17 +13,19 @@ class NlohmannJson(CMakePackage):
     url      = "https://github.com/nlohmann/json/archive/v3.1.2.tar.gz"
     maintainers = ['ax3l']
 
-    version('3.9.1', sha256='4cf0df69731494668bdd6460ed8cb269b68de9c19ad8c27abc24cd72605b2d5b')
-    version('3.8.0', sha256='7d0edf65f2ac7390af5e5a0b323b31202a6c11d744a74b588dc30f5a8c9865ba')
-    version('3.7.2', sha256='914c4af3f14bb98ff084172685fba5d32e8ce4390ec8ba5da45c63daa305df4d')
-    version('3.7.0', sha256='d51a3a8d3efbb1139d7608e28782ea9efea7e7933157e8ff8184901efd8ee760')
-    version('3.6.1', sha256='80c45b090e40bf3d7a7f2a6e9f36206d3ff710acfa8d8cc1f8c763bb3075e22e')
-    version('3.5.0', sha256='e0b1fc6cc6ca05706cce99118a87aca5248bd9db3113e703023d23f044995c1d')
-    version('3.4.0', sha256='c377963a95989270c943d522bfefe7b889ef5ed0e1e15d535fd6f6f16ed70732')
-    version('3.3.0', sha256='2fd1d207b4669a7843296c41d3b6ac5b23d00dec48dba507ba051d14564aa801')
-    version('3.2.0', sha256='2de558ff3b3b32eebfb51cf2ceb835a0fa5170e6b8712b02be9c2c07fcfe52a1')
-    version('3.1.2', sha256='e8fffa6cbdb3c15ecdff32eebf958b6c686bc188da8ad5c6489462d16f83ae54')
-    version('3.1.1', sha256='9f3549824af3ca7e9707a2503959886362801fb4926b869789d6929098a79e47')
+    version('3.10.0', sha256='eb8b07806efa5f95b349766ccc7a8ec2348f3b2ee9975ad879259a371aea8084')
+    version('3.9.1',  sha256='4cf0df69731494668bdd6460ed8cb269b68de9c19ad8c27abc24cd72605b2d5b')
+    version('3.9.0',  sha256='9943db11eeaa5b23e58a88fbc26c453faccef7b546e55063ad00e7caaaf76d0b')
+    version('3.8.0',  sha256='7d0edf65f2ac7390af5e5a0b323b31202a6c11d744a74b588dc30f5a8c9865ba')
+    version('3.7.2',  sha256='914c4af3f14bb98ff084172685fba5d32e8ce4390ec8ba5da45c63daa305df4d')
+    version('3.7.0',  sha256='d51a3a8d3efbb1139d7608e28782ea9efea7e7933157e8ff8184901efd8ee760')
+    version('3.6.1',  sha256='80c45b090e40bf3d7a7f2a6e9f36206d3ff710acfa8d8cc1f8c763bb3075e22e')
+    version('3.5.0',  sha256='e0b1fc6cc6ca05706cce99118a87aca5248bd9db3113e703023d23f044995c1d')
+    version('3.4.0',  sha256='c377963a95989270c943d522bfefe7b889ef5ed0e1e15d535fd6f6f16ed70732')
+    version('3.3.0',  sha256='2fd1d207b4669a7843296c41d3b6ac5b23d00dec48dba507ba051d14564aa801')
+    version('3.2.0',  sha256='2de558ff3b3b32eebfb51cf2ceb835a0fa5170e6b8712b02be9c2c07fcfe52a1')
+    version('3.1.2',  sha256='e8fffa6cbdb3c15ecdff32eebf958b6c686bc188da8ad5c6489462d16f83ae54')
+    version('3.1.1',  sha256='9f3549824af3ca7e9707a2503959886362801fb4926b869789d6929098a79e47')
 
     variant('single_header', default=True,
             description='Use amalgamated single-header')
@@ -39,12 +41,7 @@ class NlohmannJson(CMakePackage):
     conflicts('%pgi@:14')
 
     def cmake_args(self):
-        spec = self.spec
-        define = CMakePackage.define
-
-        args = [
-            define('JSON_MultipleHeaders', '~single_header' in spec),
-            define('BUILD_TESTING', self.run_tests),
+        return [
+            self.define_from_variant('JSON_MultipleHeaders', 'single_header'),
+            self.define('JSON_BuildTests', self.run_tests),
         ]
-
-        return args

--- a/var/spack/repos/builtin/packages/nlohmann-json/package.py
+++ b/var/spack/repos/builtin/packages/nlohmann-json/package.py
@@ -27,7 +27,7 @@ class NlohmannJson(CMakePackage):
     version('3.1.2',  sha256='e8fffa6cbdb3c15ecdff32eebf958b6c686bc188da8ad5c6489462d16f83ae54')
     version('3.1.1',  sha256='9f3549824af3ca7e9707a2503959886362801fb4926b869789d6929098a79e47')
 
-    variant('single_header', default=True,
+    variant('multiple_headers', default=False,
             description='Use amalgamated single-header')
 
     depends_on('cmake@3.8:', type='build')
@@ -42,6 +42,6 @@ class NlohmannJson(CMakePackage):
 
     def cmake_args(self):
         return [
-            self.define_from_variant('JSON_MultipleHeaders', 'single_header'),
+            self.define_from_variant('JSON_MultipleHeaders', 'multiple_headers'),
             self.define('JSON_BuildTests', self.run_tests),
         ]


### PR DESCRIPTION
See https://github.com/nlohmann/json/commit/d1cda6888e6d57107a459d7a5bb4b77bdc371b96, we need to set JSON_BuildTests since the oldest supported version.
