### PR TITLE
Speed up tests a bit

### DIFF
--- a/lib/spack/spack/test/cmd/activate.py
+++ b/lib/spack/spack/test/cmd/activate.py
@@ -14,7 +14,7 @@ extensions = SpackCommand('extensions')
 def test_activate(
         mock_packages, mock_archive, mock_fetch, config,
         install_mockery):
-    install('extension1')
+    install('--fake', 'extension1')
     activate('extension1')
     output = extensions('--show', 'activated', 'extendee')
     assert 'extension1' in output
@@ -23,7 +23,7 @@ def test_activate(
 def test_deactivate(
         mock_packages, mock_archive, mock_fetch, config,
         install_mockery):
-    install('extension1')
+    install('--fake', 'extension1')
     activate('extension1')
     deactivate('extension1')
     output = extensions('--show', 'activated', 'extendee')
@@ -33,8 +33,8 @@ def test_deactivate(
 def test_deactivate_all(
         mock_packages, mock_archive, mock_fetch, config,
         install_mockery):
-    install('extension1')
-    install('extension2')
+    install('--fake', 'extension1')
+    install('--fake', 'extension2')
     activate('extension1')
     activate('extension2')
     deactivate('--all', 'extendee')

--- a/lib/spack/spack/test/cmd/analyze.py
+++ b/lib/spack/spack/test/cmd/analyze.py
@@ -63,8 +63,8 @@ def test_analyze_output(tmpdir, mock_fetch, install_mockery_mutable_config):
     """
     Test that an analyzer errors if requested name does not exist.
     """
-    install('libdwarf')
-    install('python@3.8')
+    install('--fake', 'libdwarf')
+    install('--fake', 'python@3.8')
     analyzer_dir = tmpdir.join('analyzers')
 
     # An analyzer that doesn't exist should not work
@@ -108,7 +108,7 @@ def test_installfiles_analyzer(tmpdir, mock_fetch, install_mockery_mutable_confi
     """
     test the install files analyzer
     """
-    install('libdwarf')
+    install('--fake', 'libdwarf')
     output_file = _run_analyzer("install_files", "libdwarf", tmpdir)
 
     # Ensure it's the correct content
@@ -170,7 +170,7 @@ def test_configargs_analyzer(tmpdir, mock_fetch, install_mockery_mutable_config)
 
     Since we don't have any, this should return an empty result.
     """
-    install('libdwarf')
+    install('--fake', 'libdwarf')
     analyzer_dir = tmpdir.join('analyzers')
     out = analyze('run', '-a', 'config_args', '-p', str(analyzer_dir), 'libdwarf')
     assert out == ''

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -84,7 +84,7 @@ def tests_buildcache_create(
         install_mockery, mock_fetch, monkeypatch, tmpdir):
     """"Ensure that buildcache create creates output files"""
     pkg = 'trivial-install-test-package'
-    install(pkg)
+    install('--fake', pkg)
 
     buildcache('create', '-d', str(tmpdir), '--unsigned', pkg)
 
@@ -129,7 +129,7 @@ def test_buildcache_create_fails_on_noargs(tmpdir):
 def test_buildcache_create_fail_on_perm_denied(
         install_mockery, mock_fetch, monkeypatch, tmpdir):
     """Ensure that buildcache create fails on permission denied error."""
-    install('trivial-install-test-package')
+    install('--fake', 'trivial-install-test-package')
 
     tmpdir.chmod(0)
     with pytest.raises(OSError) as error:
@@ -155,7 +155,7 @@ def test_update_key_index(tmpdir, mutable_mock_env_path,
     s = Spec('libdwarf').concretized()
 
     # Install a package
-    install(s.name)
+    install('--fake', s.name)
 
     # Put installed package in the buildcache, which, because we're signing
     # it, should result in the public key getting pushed to the buildcache
@@ -210,7 +210,7 @@ def test_buildcache_sync(mutable_mock_env_path, install_mockery_mutable_config,
 
     # Install a package and put it in the buildcache
     s = Spec(out_env_pkg).concretized()
-    install(s.name)
+    install('--fake', s.name)
     buildcache(
         'create', '-u', '-f', '-a', '--mirror-url', src_mirror_url, s.name)
 

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -106,7 +106,7 @@ def tests_buildcache_create_env(
     env('create', 'test')
     with ev.read('test'):
         add(pkg)
-        install()
+        install('--fake')
 
         buildcache('create', '-d', str(tmpdir), '--unsigned')
 
@@ -217,7 +217,7 @@ def test_buildcache_sync(mutable_mock_env_path, install_mockery_mutable_config,
     env('create', 'test')
     with ev.read('test'):
         add(in_env_pkg)
-        install()
+        install('--fake')
         buildcache(
             'create', '-u', '-f', '-a', '--mirror-url', src_mirror_url, in_env_pkg)
 

--- a/lib/spack/spack/test/cmd/deprecate.py
+++ b/lib/spack/spack/test/cmd/deprecate.py
@@ -16,8 +16,8 @@ activate = SpackCommand('activate')
 
 
 def test_deprecate(mock_packages, mock_archive, mock_fetch, install_mockery):
-    install('libelf@0.8.13')
-    install('libelf@0.8.10')
+    install('--fake', 'libelf@0.8.13')
+    install('--fake', 'libelf@0.8.10')
 
     all_installed = spack.store.db.query()
     assert len(all_installed) == 2
@@ -40,7 +40,7 @@ def test_deprecate_fails_no_such_package(mock_packages, mock_archive,
                        fail_on_error=False)
     assert "Spec 'libelf@0.8.10' matches no installed packages" in output
 
-    install('libelf@0.8.10')
+    install('--fake', 'libelf@0.8.10')
 
     output = deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13',
                        fail_on_error=False)
@@ -51,7 +51,7 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch,
                            install_mockery):
     """Tests that the ```-i`` option allows us to deprecate in favor of a spec
     that is not yet installed."""
-    install('libelf@0.8.10')
+    install('--fake', 'libelf@0.8.10')
 
     to_deprecate = spack.store.db.query()
     assert len(to_deprecate) == 1
@@ -68,8 +68,8 @@ def test_deprecate_install(mock_packages, mock_archive, mock_fetch,
 def test_deprecate_deps(mock_packages, mock_archive, mock_fetch,
                         install_mockery):
     """Test that the deprecate command deprecates all dependencies properly."""
-    install('libdwarf@20130729 ^libelf@0.8.13')
-    install('libdwarf@20130207 ^libelf@0.8.10')
+    install('--fake', 'libdwarf@20130729 ^libelf@0.8.13')
+    install('--fake', 'libdwarf@20130207 ^libelf@0.8.10')
 
     new_spec = spack.spec.Spec('libdwarf@20130729^libelf@0.8.13').concretized()
     old_spec = spack.spec.Spec('libdwarf@20130207^libelf@0.8.10').concretized()
@@ -93,8 +93,8 @@ def test_deprecate_fails_active_extensions(mock_packages, mock_archive,
                                            mock_fetch, install_mockery):
     """Tests that active extensions and their extendees cannot be
     deprecated."""
-    install('extendee')
-    install('extension1')
+    install('--fake', 'extendee')
+    install('--fake', 'extension1')
     activate('extension1')
 
     output = deprecate('-yi', 'extendee', 'extendee@nonexistent',
@@ -111,8 +111,8 @@ def test_deprecate_fails_active_extensions(mock_packages, mock_archive,
 def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch,
                               install_mockery):
     """Tests that we can still uninstall deprecated packages."""
-    install('libelf@0.8.13')
-    install('libelf@0.8.10')
+    install('--fake', 'libelf@0.8.13')
+    install('--fake', 'libelf@0.8.10')
 
     deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13')
 
@@ -127,9 +127,9 @@ def test_uninstall_deprecated(mock_packages, mock_archive, mock_fetch,
 def test_deprecate_already_deprecated(mock_packages, mock_archive, mock_fetch,
                                       install_mockery):
     """Tests that we can re-deprecate a spec to change its deprecator."""
-    install('libelf@0.8.13')
-    install('libelf@0.8.12')
-    install('libelf@0.8.10')
+    install('--fake', 'libelf@0.8.13')
+    install('--fake', 'libelf@0.8.12')
+    install('--fake', 'libelf@0.8.10')
 
     deprecated_spec = spack.spec.Spec('libelf@0.8.10').concretized()
 
@@ -153,9 +153,9 @@ def test_deprecate_deprecator(mock_packages, mock_archive, mock_fetch,
                               install_mockery):
     """Tests that when a deprecator spec is deprecated, its deprecatee specs
     are updated to point to the new deprecator."""
-    install('libelf@0.8.13')
-    install('libelf@0.8.12')
-    install('libelf@0.8.10')
+    install('--fake', 'libelf@0.8.13')
+    install('--fake', 'libelf@0.8.12')
+    install('--fake', 'libelf@0.8.10')
 
     first_deprecated_spec = spack.spec.Spec('libelf@0.8.10').concretized()
     second_deprecated_spec = spack.spec.Spec('libelf@0.8.12').concretized()
@@ -183,8 +183,8 @@ def test_concretize_deprecated(mock_packages, mock_archive, mock_fetch,
                                install_mockery):
     """Tests that the concretizer throws an error if we concretize to a
     deprecated spec"""
-    install('libelf@0.8.13')
-    install('libelf@0.8.10')
+    install('--fake', 'libelf@0.8.13')
+    install('--fake', 'libelf@0.8.10')
 
     deprecate('-y', 'libelf@0.8.10', 'libelf@0.8.13')
 

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -246,7 +246,7 @@ env:
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
             with pytest.raises(spack.spec.UnsatisfiableVersionSpecError):
-                install()
+                install('--fake')
 
 
 def test_dev_build_multiple(tmpdir, mock_packages, install_mockery,
@@ -392,11 +392,11 @@ env:
 
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
             reset_string()  # so the package will accept rebuilds
 
             fs.touch(os.path.join(str(build_dir), 'test'))
-            output = install()
+            output = install('--fake')
 
     assert 'Installing %s' % test_spec in output

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -36,7 +36,7 @@ def test_diff(install_mockery, mock_fetch, mock_archive, mock_packages):
 
 def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test with and without the --first option"""
-    install('mpileaks')
+    install('--fake', 'mpileaks')
 
     # Only one version of mpileaks will work
     diff('mpileaks', 'mpileaks')
@@ -60,7 +60,7 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     assert "intersect" in result and len(result['intersect']) > 50
 
     # After we install another version, it should ask us to disambiguate
-    install('mpileaks+debug')
+    install('--fake', 'mpileaks+debug')
 
     # There are two versions of mpileaks
     with pytest.raises(spack.main.SpackCommandError):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -168,7 +168,7 @@ def test_env_install_single_spec(install_mockery, mock_fetch):
 
     e = ev.read('test')
     with e:
-        install('cmake-client')
+        install('--fake', 'cmake-client')
 
     e = ev.read('test')
     assert e.user_specs[0].name == 'cmake-client'
@@ -178,7 +178,7 @@ def test_env_install_single_spec(install_mockery, mock_fetch):
 
 def test_env_roots_marked_explicit(install_mockery, mock_fetch):
     install = SpackCommand('install')
-    install('dependent-install')
+    install('--fake', 'dependent-install')
 
     # Check one explicit, one implicit install
     dependent = spack.store.db.query(explicit=True)
@@ -204,7 +204,7 @@ def test_env_modifications_error_on_activate(
 
     e = ev.read('test')
     with e:
-        install('cmake-client')
+        install('--fake', 'cmake-client')
 
     def setup_error(pkg, env):
         raise RuntimeError("cmake-client had issues!")
@@ -226,7 +226,7 @@ def test_activate_adds_transitive_run_deps_to_path(
 
     e = ev.read('test')
     with e:
-        install('depends-on-run-env')
+        install('--fake', 'depends-on-run-env')
 
     cmds = ev.activate(e)
     assert 'DEPENDENCY_ENV_VAR=1' in cmds
@@ -238,11 +238,11 @@ def test_env_install_same_spec_twice(install_mockery, mock_fetch):
     e = ev.read('test')
     with e:
         # The first installation outputs the package prefix, updates the view
-        out = install('cmake-client')
+        out = install('--fake', 'cmake-client')
         assert 'Updating view at' in out
 
         # The second installation reports all packages already installed
-        out = install('cmake-client')
+        out = install('--fake', 'cmake-client')
         assert 'already installed' in out
 
 
@@ -372,7 +372,7 @@ def test_env_status_broken_view(
     install_mockery
 ):
     with ev.create('test'):
-        install('trivial-install-test-package')
+        install('--fake', 'trivial-install-test-package')
 
         # switch to a new repo that doesn't include the installed package
         # test that Spack detects the missing package and warns the user
@@ -393,7 +393,7 @@ def test_env_activate_broken_view(
     install_mockery
 ):
     with ev.create('test'):
-        install('trivial-install-test-package')
+        install('--fake', 'trivial-install-test-package')
 
     # switch to a new repo that doesn't include the installed package
     # test that Spack detects the missing package and fails gracefully
@@ -1783,7 +1783,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         test = ev.read('test')
         for spec in test._get_environment_specs():
@@ -1816,7 +1816,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         test = ev.read('test')
         for spec in test._get_environment_specs():
@@ -1854,7 +1854,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         test = ev.read('test')
         for spec in test._get_environment_specs():
@@ -1893,7 +1893,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         test = ev.read('test')
         for spec in test._get_environment_specs():
@@ -1933,7 +1933,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         test = ev.read('test')
         for spec in test._get_environment_specs():
@@ -2003,7 +2003,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         test = ev.read('test')
         for spec in test._get_environment_specs():
@@ -2040,7 +2040,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         shell = env('activate', '--sh', 'test')
 
@@ -2073,7 +2073,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         shell = env('activate', '--sh', 'test')
         assert 'PATH' not in shell
@@ -2110,7 +2110,7 @@ env:
     with tmpdir.as_cwd():
         env('create', 'test', './spack.yaml')
         with ev.read('test'):
-            install()
+            install('--fake')
 
         shell = env('activate', '--sh', 'test')
         assert 'PATH' in shell
@@ -2548,7 +2548,7 @@ spack:
     _env_create('test', StringIO(spack_yaml))
 
     with ev.read('test') as e:
-        install()
+        install('--fake')
 
         spec = e.specs_by_hash[e.concretized_order[0]]
         view_prefix = e.default_view.get_projection_for_spec(spec)
@@ -2583,7 +2583,7 @@ spack:
     _env_create('test', StringIO(spack_yaml))
 
     with ev.read('test') as e:
-        install()
+        install('--fake')
 
         spec = e.specs_by_hash[e.concretized_order[0]]
         view_prefix = e.default_view.get_projection_for_spec(spec)

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -316,7 +316,7 @@ def test_find_prefix_in_env(mutable_mock_env_path, install_mockery, mock_fetch,
     """Test `find` formats requiring concrete specs work in environments."""
     env('create', 'test')
     with ev.read('test'):
-        install('mpileaks')
+        install('--fake', 'mpileaks')
         find('-p')
         find('-l')
         find('-L')

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -311,7 +311,7 @@ def test_install_invalid_spec(invalid_spec):
         install(invalid_spec)
 
 
-@pytest.mark.usefixtures('noop_install', 'config')
+@pytest.mark.usefixtures('noop_install', 'mock_packages', 'config')
 @pytest.mark.parametrize('spec,concretize,error_code', [
     (Spec('mpi'), False, 1),
     (Spec('mpi'), True, 0),

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -415,7 +415,7 @@ def test_junit_output_with_errors(
     assert 'error message="{0}"'.format(msg) in content
 
 
-@pytest.mark.usefixtures('noop_install', 'config')
+@pytest.mark.usefixtures('noop_install', 'mock_packages', 'config')
 @pytest.mark.parametrize('clispecs,filespecs', [
     [[],                  ['mpi']],
     [[],                  ['mpi', 'boost']],

--- a/lib/spack/spack/test/cmd/load.py
+++ b/lib/spack/spack/test/cmd/load.py
@@ -50,7 +50,7 @@ def test_load_recursive(install_mockery, mock_fetch, mock_archive,
                         mock_packages):
     """Test that the '-r' option to the load command prepends dependency prefix
     inspections in post-order"""
-    install('mpileaks')
+    install('--fake', 'mpileaks')
     mpileaks_spec = spack.spec.Spec('mpileaks').concretized()
 
     sh_out = load('--sh', 'mpileaks')
@@ -79,7 +79,7 @@ def test_load_includes_run_env(install_mockery, mock_fetch, mock_archive,
     """Tests that environment changes from the package's
     `setup_run_environment` method are added to the user environment in
     addition to the prefix inspections"""
-    install('mpileaks')
+    install('--fake', 'mpileaks')
 
     sh_out = load('--sh', 'mpileaks')
     csh_out = load('--csh', 'mpileaks')
@@ -90,8 +90,8 @@ def test_load_includes_run_env(install_mockery, mock_fetch, mock_archive,
 
 def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
     """Test with and without the --first option"""
-    install('libelf@0.8.12')
-    install('libelf@0.8.13')
+    install('--fake', 'libelf@0.8.12')
+    install('--fake', 'libelf@0.8.13')
     # Now there are two versions of libelf
     with pytest.raises(SpackCommandError):
         # This should cause an error due to multiple versions
@@ -103,7 +103,7 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
 def test_load_fails_no_shell(install_mockery, mock_fetch, mock_archive,
                              mock_packages):
     """Test that spack load prints an error message without a shell."""
-    install('mpileaks')
+    install('--fake', 'mpileaks')
 
     out = load('mpileaks', fail_on_error=False)
     assert "To set up shell support" in out
@@ -113,7 +113,7 @@ def test_unload(install_mockery, mock_fetch, mock_archive, mock_packages,
                 working_env):
     """Tests that any variables set in the user environment are undone by the
     unload command"""
-    install('mpileaks')
+    install('--fake', 'mpileaks')
     mpileaks_spec = spack.spec.Spec('mpileaks').concretized()
 
     # Set so unload has something to do
@@ -134,7 +134,7 @@ def test_unload(install_mockery, mock_fetch, mock_archive, mock_packages,
 def test_unload_fails_no_shell(install_mockery, mock_fetch, mock_archive,
                                mock_packages, working_env):
     """Test that spack unload prints an error message without a shell."""
-    install('mpileaks')
+    install('--fake', 'mpileaks')
     mpileaks_spec = spack.spec.Spec('mpileaks').concretized()
     os.environ[uenv.spack_loaded_hashes_var] = mpileaks_spec.dag_hash()
 

--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -200,7 +200,7 @@ def test_mirror_destroy(install_mockery_mutable_config,
     spec_name = 'libdwarf'
 
     # Put a binary package in a buildcache
-    install('--no-cache', spec_name)
+    install('--fake', '--no-cache', spec_name)
     buildcache('create', '-u', '-a', '-f', '-d', mirror_dir.strpath, spec_name)
 
     contents = os.listdir(mirror_dir.strpath)

--- a/lib/spack/spack/test/cmd/reindex.py
+++ b/lib/spack/spack/test/cmd/reindex.py
@@ -14,8 +14,8 @@ reindex = SpackCommand('reindex')
 
 def test_reindex_basic(mock_packages, mock_archive, mock_fetch,
                        install_mockery):
-    install('libelf@0.8.13')
-    install('libelf@0.8.12')
+    install('--fake', 'libelf@0.8.13')
+    install('--fake', 'libelf@0.8.12')
 
     all_installed = spack.store.db.query()
 
@@ -26,8 +26,8 @@ def test_reindex_basic(mock_packages, mock_archive, mock_fetch,
 
 def test_reindex_db_deleted(mock_packages, mock_archive, mock_fetch,
                             install_mockery):
-    install('libelf@0.8.13')
-    install('libelf@0.8.12')
+    install('--fake', 'libelf@0.8.13')
+    install('--fake', 'libelf@0.8.12')
 
     all_installed = spack.store.db.query()
 
@@ -39,8 +39,8 @@ def test_reindex_db_deleted(mock_packages, mock_archive, mock_fetch,
 
 def test_reindex_with_deprecated_packages(mock_packages, mock_archive,
                                           mock_fetch, install_mockery):
-    install('libelf@0.8.13')
-    install('libelf@0.8.12')
+    install('--fake', 'libelf@0.8.13')
+    install('--fake', 'libelf@0.8.12')
 
     deprecate('-y', 'libelf@0.8.12', 'libelf@0.8.13')
 

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -342,7 +342,7 @@ class TestLmod(object):
             self, tmpdir, modulefile_content, module_configuration, install_mockery):
         with ev.Environment(str(tmpdir), with_view=True) as e:
             module_configuration('with_view')
-            install('cmake')
+            install('--fake', 'cmake')
 
             spec = spack.spec.Spec('cmake').concretized()
 

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -351,15 +351,7 @@ class PruneDuplicatePaths(NameModifier):
 
 
 class EnvironmentModifications(object):
-    """Keeps track of requests to modify the current environment.
-
-    Each call to a method to modify the environment stores the extra
-    information on the caller in the request:
-
-        * 'filename' : filename of the module where the caller is defined
-        * 'lineno': line number where the request occurred
-        * 'context' : line of code that issued the request that failed
-    """
+    """Keeps track of requests to modify the current environment."""
 
     def __init__(self, other=None):
         """Initializes a new instance, copying commands from 'other'
@@ -389,18 +381,6 @@ class EnvironmentModifications(object):
             raise TypeError(
                 'other must be an instance of EnvironmentModifications')
 
-    def _get_outside_caller_attributes(self):
-        stack = inspect.stack()
-        try:
-            _, filename, lineno, _, context, index = stack[2]
-            context = context[index].strip()
-        except Exception:
-            filename = 'unknown file'
-            lineno = 'unknown line'
-            context = 'unknown context'
-        args = {'filename': filename, 'lineno': lineno, 'context': context}
-        return args
-
     def set(self, name, value, **kwargs):
         """Stores a request to set an environment variable.
 
@@ -408,7 +388,6 @@ class EnvironmentModifications(object):
             name: name of the environment variable to be set
             value: value of the environment variable
         """
-        kwargs.update(self._get_outside_caller_attributes())
         item = SetEnv(name, value, **kwargs)
         self.env_modifications.append(item)
 
@@ -421,7 +400,6 @@ class EnvironmentModifications(object):
             value: value to append to the environment variable
         Appends with spaces separating different additions to the variable
         """
-        kwargs.update(self._get_outside_caller_attributes())
         kwargs.update({'separator': sep})
         item = AppendFlagsEnv(name, value, **kwargs)
         self.env_modifications.append(item)
@@ -432,7 +410,6 @@ class EnvironmentModifications(object):
         Args:
             name: name of the environment variable to be unset
         """
-        kwargs.update(self._get_outside_caller_attributes())
         item = UnsetEnv(name, **kwargs)
         self.env_modifications.append(item)
 
@@ -446,7 +423,6 @@ class EnvironmentModifications(object):
             value: value to remove to the environment variable
             sep: separator to assume for environment variable
         """
-        kwargs.update(self._get_outside_caller_attributes())
         kwargs.update({'separator': sep})
         item = RemoveFlagsEnv(name, value, **kwargs)
         self.env_modifications.append(item)
@@ -458,7 +434,6 @@ class EnvironmentModifications(object):
             name: name o the environment variable to be set.
             elements: elements of the path to set.
         """
-        kwargs.update(self._get_outside_caller_attributes())
         item = SetPath(name, elements, **kwargs)
         self.env_modifications.append(item)
 
@@ -469,7 +444,6 @@ class EnvironmentModifications(object):
             name: name of the path list in the environment
             path: path to be appended
         """
-        kwargs.update(self._get_outside_caller_attributes())
         item = AppendPath(name, path, **kwargs)
         self.env_modifications.append(item)
 
@@ -480,7 +454,6 @@ class EnvironmentModifications(object):
             name: name of the path list in the environment
             path: path to be pre-pended
         """
-        kwargs.update(self._get_outside_caller_attributes())
         item = PrependPath(name, path, **kwargs)
         self.env_modifications.append(item)
 
@@ -491,7 +464,6 @@ class EnvironmentModifications(object):
             name: name of the path list in the environment
             path: path to be removed
         """
-        kwargs.update(self._get_outside_caller_attributes())
         item = RemovePath(name, path, **kwargs)
         self.env_modifications.append(item)
 
@@ -502,7 +474,6 @@ class EnvironmentModifications(object):
         Args:
             name: name of the path list in the environment.
         """
-        kwargs.update(self._get_outside_caller_attributes())
         item = DeprioritizeSystemPaths(name, **kwargs)
         self.env_modifications.append(item)
 
@@ -513,7 +484,6 @@ class EnvironmentModifications(object):
         Args:
             name: name of the path list in the environment.
         """
-        kwargs.update(self._get_outside_caller_attributes())
         item = PruneDuplicatePaths(name, **kwargs)
         self.env_modifications.append(item)
 
@@ -815,8 +785,8 @@ def set_or_unset_not_first(variable, changes, errstream):
                not item.args.get('force', False) and
                type(item) in [SetEnv, UnsetEnv]]
     if indexes:
-        good = '\t    \t{context} at {filename}:{lineno}'
-        nogood = '\t--->\t{context} at {filename}:{lineno}'
+        good = '\t    \t{context}'
+        nogood = '\t--->\t{context}'
         message = "Suspicious requests to set or unset '{var}' found"
         errstream(message.format(var=variable))
         for ii, item in enumerate(changes):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -6,7 +6,6 @@
 """Utilities for setting and modifying environment variables."""
 import collections
 import contextlib
-import inspect
 import json
 import os
 import os.path


### PR DESCRIPTION
- Lots of time is spent on env modifications: some_mock_env.install() is 50% faster without on inspect.xxx
- install('--fake') is significantly faster even with mock_everything pytest fixtures
- 2 tests do not have the correct fixtures and use the builtin repo

For me locally: 

- `spack unit-test`: 608.93s -> 532.28s (-13%)
- `spack unit-test -k 'install and not bindist'`: 81.75s -> 65.24s (-20%)