### PR TITLE
Add special commit_sha variant to allow fetching specific commits

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -57,7 +57,7 @@ else:
 __all__ = ['DirectiveError', 'DirectiveMeta']
 
 #: These are variant names used by Spack internally; packages can't use them
-reserved_names = ['patches', 'dev_path']
+reserved_names = ['patches', 'dev_path', 'commit_sha']
 
 _patch_order_index = 0
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -815,7 +815,7 @@ class GitFetchStrategy(VCSFetchStrategy):
     Repositories are cloned into the standard stage source path directory.
     """
     url_attr = 'git'
-    optional_attrs = ['tag', 'branch', 'commit', 'submodules',
+    optional_attrs = ['tag', 'branch', 'commit', 'submodules', 'commit_sha',
                       'get_full_repo', 'submodules_delete']
 
     git_version_re = r'git version (\S+)'
@@ -898,7 +898,9 @@ class GitFetchStrategy(VCSFetchStrategy):
         tty.debug('Cloning git repository: {0}'.format(self._repo_info()))
 
         git = self.git
-        if self.commit:
+        if self.commit or self.commit_sha:
+            if self.commit_sha:
+              self.commit = self.commit_sha
             # Need to do a regular clone and check out everything if
             # they asked for a particular commit.
             debug = spack.config.get('config:debug')
@@ -969,6 +971,8 @@ class GitFetchStrategy(VCSFetchStrategy):
 
                     git(*pull_args, ignore_errors=1)
                     git(*co_args)
+
+        self.commit_sha = git('rev-parse', 'HEAD')
 
         if self.submodules_delete:
             with working_dir(self.stage.source_path):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -993,9 +993,12 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         # Construct a composite stage on top of the composite FetchStrategy
         composite_fetcher = self.fetcher
+        commit_sha_var = self.spec.variants.get('commit_sha', None)
         composite_stage = StageComposite()
         resources = self._get_needed_resources()
         for ii, fetcher in enumerate(composite_fetcher):
+            if commit_sha_var:
+                fetcher.commit_sha = commit_sha_var.value[0]
             if ii == 0:
                 # Construct root stage first
                 stage = self._make_root_stage(fetcher)
@@ -1004,6 +1007,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 resource = resources[ii - 1]  # ii == 0 is root!
                 stage = self._make_resource_stage(composite_stage[0], fetcher,
                                                   resource)
+
+
             # Append the item to the composite
             composite_stage.append(stage)
 


### PR DESCRIPTION
A major shortcoming of building `package@main` is that there is no way of knowing what commit has been used for the build, and it has to be uninstalled in order to get an updated build if the branch has been changed. It's possible to add `version("foo", commit="12345bar")` to the recipe, but that is not really practical in most applications. 
This is an alternative attempt to attempt to improve spack for nightly builds and similar applications.

Here the idea is to add a general `commit_sha` variant, modeled after `dev_path`. `commit_sha` should do two things:

1. It should be settable on the command line, in order to build any commit of the spackage according to the recipe for any version, e.g.

```
spack install package@develop commit_sha=abc123
```

2. If a package is installed from a branch, it should record the acutal commit hash that is used:
```
spack install package@develop
...
spack find -v package

package@develop commit_hash=abc123
```

This PR is a very quick implementation of 1. There are quite a few implications like changing the concretization, none of which I have thought through yet. A complication is the current possibility of doing:

```
version('someversion', commit='abc123')
```

and if `spack install package@someversion commit_sha=def567` should then override `commit`.

For a very simple, but maybe even better, alternative solution to the same problem see: https://github.com/spack/spack/pull/20065