### PR TITLE
py-nbsphinx: add new version, missing dep

### DIFF
--- a/var/spack/repos/builtin/packages/py-nbsphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-nbsphinx/package.py
@@ -18,9 +18,11 @@ class PyNbsphinx(PythonPackage):
     homepage = "https://nbsphinx.readthedocs.io"
     pypi     = "nbsphinx/nbsphinx-0.8.0.tar.gz"
 
+    version('0.8.7', sha256='ff91b5b14ceb1a9d44193b5fc3dd3617e7b8ab59c788f7710049ce5faff2750c')
     version('0.8.1', sha256='24d59aa3a1077ba58d9769c64c38fb05b761a1af21c1ac15f6393500cd008ea6')
     version('0.8.0', sha256='369c16fe93af14c878d61fb3e81d838196fb35b27deade2cd7b95efe1fe56ea0')
 
+    # https://nbsphinx.readthedocs.io/en/latest/installation.html
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-docutils', type=('build', 'run'))
@@ -29,3 +31,4 @@ class PyNbsphinx(PythonPackage):
     depends_on('py-traitlets', type=('build', 'run'))
     depends_on('py-nbformat', type=('build', 'run'))
     depends_on('py-sphinx@1.8:', type=('build', 'run'))
+    depends_on('pandoc', type='run')


### PR DESCRIPTION
pandoc seems to be required to convert markdown to rst.

Successfully builds on Ubuntu 20.04 with Python 3.8.11 and GCC 9.3.0.