### PR TITLE
ginkgo: update smoke test location

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -132,7 +132,7 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
             return
         with working_dir(self.build_directory):
             make("test_install")
-        smoke_test_path = join_path(self.build_directory, 'test_install')
+        smoke_test_path = join_path(self.build_directory, 'test', 'test_install')
         with working_dir(smoke_test_path):
             make("install")
 


### PR DESCRIPTION
The `test_install` folder was moved to `test/test_install` with https://github.com/ginkgo-project/ginkgo/pull/733. This caused the smoke tests to fail in https://github.com/xsdk-project/xsdk-issues/issues/151.