### PR TITLE
RADIUSS Cloud CI: Another pass at increasing the packages

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -31,15 +31,15 @@ spack:
       - axom
       - blt
       - caliper
-      #- care  ## ~benchmarks ~examples ~tests
-      #- chai  ## ~benchmarks ~examples ~tests
+      - care  ## ~benchmarks ~examples ~tests
+      - chai  ## ~benchmarks ~examples ~tests
       - conduit  # ^hdf5+shared
       - flux-core
       #- flux-sched
-      #- glvis   # ^mesa-glu@9.0.0 ^mesa18~llvm  # same issue w/chai
+      #- glvis   # ^mesa-glu@9.0.0 ^mesa18~llvm  # lib/sdl_x11.hpp errors
       - hypre
       - lbann
-      - lvarray ~tests  # per Spack issue #23192  # ~examples
+      - lvarray
       - mfem
       - py-hatchet
       - py-maestrowf
@@ -50,7 +50,7 @@ spack:
       - scr
       - sundials
       - umpire # ~openmp
-      #- visit   # ^mesa-glu@9.0.0
+      #- visit   # ^mesa-glu@9.0.0  # skipped due to qt build failures
       - xbraid
       - zfp
 


### PR DESCRIPTION
Note `lvarray` has an upstream fix now (in `develop`) and #25575 allows a couple of packages to get past a previous issue with `font-config`.

TODO
- [x] Remove version constraint (`develop`) from `lvarray` once a new release is made and available in the Spack package.