### PR TITLE
Fix broken develop as CI didn't run on latest merge commit

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -876,7 +876,7 @@ def buildcache_sync(args):
     dest_mirror_url = url_util.format(dest_mirror.fetch_url)
 
     # Get the active environment
-    env = ev.get_env(args, 'buildcache sync', required=True)
+    env = spack.cmd.require_active_env('buildcache sync')
 
     tty.msg('Syncing environment buildcache files from {0} to {1}'.format(
         src_mirror_url, dest_mirror_url))

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -876,7 +876,7 @@ def buildcache_sync(args):
     dest_mirror_url = url_util.format(dest_mirror.fetch_url)
 
     # Get the active environment
-    env = spack.cmd.require_active_env('buildcache sync')
+    env = spack.cmd.require_active_env(cmd_name='buildcache sync')
 
     tty.msg('Syncing environment buildcache files from {0} to {1}'.format(
         src_mirror_url, dest_mirror_url))


### PR DESCRIPTION
CI for #25439 was not run on the latest merge commit, and should've failed after #25470 was merged.

https://github.com/spack/spack/runs/3378122243