### PR TITLE
Add ccache 4.4.

### DIFF
--- a/var/spack/repos/builtin/packages/ccache/package.py
+++ b/var/spack/repos/builtin/packages/ccache/package.py
@@ -18,6 +18,7 @@ class Ccache(CMakePackage):
 
     executables = ['^ccache$']
 
+    version('4.4',   sha256='61a993d62216aff35722a8d0e8ffef9b677fc3f6accd8944ffc2a6db98fb3142')
     version('4.3',   sha256='b9789c42e52c73e99428f311a34def9ffec3462736439afd12dbacc7987c1533')
     version('4.2.1', sha256='320d2b17d2f76393e5d4bb28c8dee5ca783248e9cd23dff0654694d60f8a4b62')
     version('4.2',   sha256='dbf139ff32031b54cb47f2d7983269f328df14b5a427882f89f7721e5c411b7e')
@@ -36,6 +37,7 @@ class Ccache(CMakePackage):
     depends_on('zstd', when='@4.0:')
 
     depends_on('gperf', when='@:3.99')
+    depends_on('hiredis@0.13.3:', when='@4.4:')
     depends_on('libxslt', when='@:3.99')
     depends_on('zlib', when='@:3.99')
 


### PR DESCRIPTION
This was released yesterday: https://github.com/ccache/ccache/releases/tag/v4.4

Add `hiredis` dependency, see: https://github.com/ccache/ccache/wiki/Redis-storage