### PR TITLE
SQLite: fix rtree, add version, make discoverable

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -118,8 +118,7 @@ class Sqlite(AutotoolsPackage):
             args.extend(['--disable-fts4', '--disable-fts5'])
 
         # Ref: https://sqlite.org/rtree.html
-        if '+rtree' in self.spec:
-            args.append('CPPFLAGS=-DSQLITE_ENABLE_RTREE=1')
+        args.extend(self.enable_or_disable('rtree'))
 
         # Ref: https://sqlite.org/compile.html
         if '+column_metadata' in self.spec:

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -13,6 +13,7 @@ class Sqlite(AutotoolsPackage):
     """
     homepage = "https://www.sqlite.org"
 
+    version('3.36.0', sha256='bd90c3eb96bee996206b83be7065c9ce19aef38c3f4fb53073ada0d0b69bbce3')
     version('3.35.5', sha256='f52b72a5c319c3e516ed7a92e123139a6e87af08a2dc43d7757724f6132e6db0')
     version('3.35.4', sha256='7771525dff0185bfe9638ccce23faa0e1451757ddbda5a6c853bb80b923a512d')
     version('3.35.3', sha256='ecbccdd440bdf32c0e1bb3611d635239e3b5af268248d130d0445a32daf0274b')


### PR DESCRIPTION
* fix rtree variant
* add version 3.36.0
* make package and most variants discoverable

The SQLite build always enabled the rtree variant due to a confusion between the Autotools build and the amalgamation (SQLite in a single C file) build. This has been fixed. Example:
```console
ubuntu@u20:~$ git clone --depth=1 --branch=v0.16.2 -- 'https://github.com/spack/spack.git'
Cloning into 'spack'...
[...]
ubuntu@u20:~$ . ~/spack/share/spack/setup-env.sh 
ubuntu@u20:~$ spack external find
[...]
ubuntu@u20:~$ spack install sqlite~rtree
[...]
[+] /home/ubuntu/spack/opt/spack/linux-ubuntu20.04-skylake/gcc-9.3.0/sqlite-3.33.0-5gu52nmcpfl4x6rzhfugv64tf5gd2bjp
ubuntu@u20:~$ spack load sqlite
ubuntu@u20:~$ which sqlite3
/home/ubuntu/spack/opt/spack/linux-ubuntu20.04-skylake/gcc-9.3.0/sqlite-3.33.0-5gu52nmcpfl4x6rzhfugv64tf5gd2bjp/bin/sqlite3
ubuntu@u20:~$ spack find --long --variants sqlite
==> 1 installed package
-- linux-ubuntu20.04-skylake / gcc@9.3.0 ------------------------
5gu52nm sqlite@3.33.0+column_metadata+fts~functions~rtree
ubuntu@u20:~$ sqlite3 <<<'CREATE VIRTUAL TABLE t USING rtree(id, x, y);'
ubuntu@u20:~$ sqlite3 <<<'CREATE VIRTUAL TABLE t USING rtree(id, x);'
Error: near line 1: Too few columns for an rtree table
```