### PR TITLE
Turn mbedtls into a MakefilePackage

### DIFF
--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -19,9 +19,11 @@ class Mbedtls(MakefilePackage):
 
     version('3.0.0', sha256='377d376919be19f07c7e7adeeded088a525be40353f6d938a78e4f986bce2ae0')
     version('2.27.0', sha256='4f6a43f06ded62aa20ef582436a39b65902e1126cbbe2fb17f394e9e9a552767')
+    version('2.16.11', sha256='51bb9685c4f4ff9255da5659ff346b89dcaf129e3ba0f3b2b0c48a1a7495e701')
     version('2.16.9', sha256='b7ca99ee10551b5b13242b7effebefd2a5cc38c287e5f5be1267d51ee45effe3', deprecated=True)
     version('2.16.7', sha256='4786b7d1676f5e4d248f3a7f2d28446876d64962634f060ff21b92c690cfbe86', deprecated=True)
     version('2.16.1', sha256='daf0d40f3016c34eb42d1e4b3b52be047e976d566aba8668977723c829af72f3', deprecated=True)
+    version('2.7.19',  sha256='3da12b1cebe1a25da8365d5349f67db514aefcaa75e26082d7cb2fa3ce9608aa')
     version('2.7.10', sha256='42b19b30b86a798bdb69c5da2f8bbd7d72ffede9a35b888ab986a29480f9dc3e', deprecated=True)
     version('2.3.0', sha256='1614ee70be99a18ca8298148308fb725aad4ad31c569438bb51655a4999b14f9', deprecated=True)
     version('2.2.1', sha256='32819c62c20e8740a11b49daa5d09ac6f179edf120a87ac559cd63120b66b699', deprecated=True)
@@ -30,7 +32,7 @@ class Mbedtls(MakefilePackage):
     version('2.1.3', sha256='94da4618d5a518b99f7914a5e348be436e3571113d9a9978d130725a1fc7bfac', deprecated=True)
     version('1.3.16', sha256='0c2666222b66cf09c4630fa60a715aafd7decb1a09933b75c0c540b0625ac5df', deprecated=True)
 
-    variant('pic', default=True, description='Compile with position independent code.')
+    variant('pic', default=False, description='Compile with position independent code.')
     variant('build_type', default='Release', description='Build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
     variant('libs', default='static', values=('shared', 'static'),

--- a/var/spack/repos/builtin/packages/mbedtls/package.py
+++ b/var/spack/repos/builtin/packages/mbedtls/package.py
@@ -18,16 +18,17 @@ class Mbedtls(MakefilePackage):
     maintainers = ['mwkrentel']
 
     version('3.0.0', sha256='377d376919be19f07c7e7adeeded088a525be40353f6d938a78e4f986bce2ae0')
-    version('2.16.9', sha256='b7ca99ee10551b5b13242b7effebefd2a5cc38c287e5f5be1267d51ee45effe3')
-    version('2.16.7', sha256='4786b7d1676f5e4d248f3a7f2d28446876d64962634f060ff21b92c690cfbe86')
-    version('2.16.1', sha256='daf0d40f3016c34eb42d1e4b3b52be047e976d566aba8668977723c829af72f3')
-    version('2.7.10', sha256='42b19b30b86a798bdb69c5da2f8bbd7d72ffede9a35b888ab986a29480f9dc3e')
-    version('2.3.0', sha256='1614ee70be99a18ca8298148308fb725aad4ad31c569438bb51655a4999b14f9')
-    version('2.2.1', sha256='32819c62c20e8740a11b49daa5d09ac6f179edf120a87ac559cd63120b66b699')
-    version('2.2.0', sha256='75494361e412444b38ebb9c908b7e17a5fb582eb9c3fadb2fe9b21e96f1bf8cb')
-    version('2.1.4', sha256='a0ee4d3dd135baf67a3cf5ad9e70d67575561704325d6c93d8f087181f4db338')
-    version('2.1.3', sha256='94da4618d5a518b99f7914a5e348be436e3571113d9a9978d130725a1fc7bfac')
-    version('1.3.16', sha256='0c2666222b66cf09c4630fa60a715aafd7decb1a09933b75c0c540b0625ac5df')
+    version('2.27.0', sha256='4f6a43f06ded62aa20ef582436a39b65902e1126cbbe2fb17f394e9e9a552767')
+    version('2.16.9', sha256='b7ca99ee10551b5b13242b7effebefd2a5cc38c287e5f5be1267d51ee45effe3', deprecated=True)
+    version('2.16.7', sha256='4786b7d1676f5e4d248f3a7f2d28446876d64962634f060ff21b92c690cfbe86', deprecated=True)
+    version('2.16.1', sha256='daf0d40f3016c34eb42d1e4b3b52be047e976d566aba8668977723c829af72f3', deprecated=True)
+    version('2.7.10', sha256='42b19b30b86a798bdb69c5da2f8bbd7d72ffede9a35b888ab986a29480f9dc3e', deprecated=True)
+    version('2.3.0', sha256='1614ee70be99a18ca8298148308fb725aad4ad31c569438bb51655a4999b14f9', deprecated=True)
+    version('2.2.1', sha256='32819c62c20e8740a11b49daa5d09ac6f179edf120a87ac559cd63120b66b699', deprecated=True)
+    version('2.2.0', sha256='75494361e412444b38ebb9c908b7e17a5fb582eb9c3fadb2fe9b21e96f1bf8cb', deprecated=True)
+    version('2.1.4', sha256='a0ee4d3dd135baf67a3cf5ad9e70d67575561704325d6c93d8f087181f4db338', deprecated=True)
+    version('2.1.3', sha256='94da4618d5a518b99f7914a5e348be436e3571113d9a9978d130725a1fc7bfac', deprecated=True)
+    version('1.3.16', sha256='0c2666222b66cf09c4630fa60a715aafd7decb1a09933b75c0c540b0625ac5df', deprecated=True)
 
     variant('pic', default=True, description='Compile with position independent code.')
     variant('build_type', default='Release', description='Build type',


### PR DESCRIPTION
This is a step towards building cmake with curl using mbedtls instead of
openssl; building mbedtls shouldn't require cmake then.
