### PR TITLE
Move environment shell stuff into its own module

### DIFF
--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -1,0 +1,161 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
+import llnl.util.tty as tty
+from llnl.util.tty.color import colorize
+
+import spack.environment as ev
+import spack.repo
+import spack.store
+from spack.util.environment import EnvironmentModifications
+
+
+def activate_header(env, shell, prompt=None):
+    # Construct the commands to run
+    cmds = ''
+    if shell == 'csh':
+        # TODO: figure out how to make color work for csh
+        cmds += 'setenv SPACK_ENV %s;\n' % env.path
+        cmds += 'alias despacktivate "spack env deactivate";\n'
+        if prompt:
+            cmds += 'if (! $?SPACK_OLD_PROMPT ) '
+            cmds += 'setenv SPACK_OLD_PROMPT "${prompt}";\n'
+            cmds += 'set prompt="%s ${prompt}";\n' % prompt
+    elif shell == 'fish':
+        if 'color' in os.getenv('TERM', '') and prompt:
+            prompt = colorize('@G{%s} ' % prompt, color=True)
+
+        cmds += 'set -gx SPACK_ENV %s;\n' % env.path
+        cmds += 'function despacktivate;\n'
+        cmds += '   spack env deactivate;\n'
+        cmds += 'end;\n'
+        #
+        # NOTE: We're not changing the fish_prompt function (which is fish's
+        # solution to the PS1 variable) here. This is a bit fiddly, and easy to
+        # screw up => spend time reasearching a solution. Feedback welcome.
+        #
+    else:
+        if 'color' in os.getenv('TERM', '') and prompt:
+            prompt = colorize('@G{%s} ' % prompt, color=True)
+
+        cmds += 'export SPACK_ENV=%s;\n' % env.path
+        cmds += "alias despacktivate='spack env deactivate';\n"
+        if prompt:
+            cmds += 'if [ -z ${SPACK_OLD_PS1+x} ]; then\n'
+            cmds += '    if [ -z ${PS1+x} ]; then\n'
+            cmds += "        PS1='$$$$';\n"
+            cmds += '    fi;\n'
+            cmds += '    export SPACK_OLD_PS1="${PS1}";\n'
+            cmds += 'fi;\n'
+            cmds += 'export PS1="%s ${PS1}";\n' % prompt
+
+    return cmds
+
+
+def deactivate_header(shell):
+    cmds = ''
+    if shell == 'csh':
+        cmds += 'unsetenv SPACK_ENV;\n'
+        cmds += 'if ( $?SPACK_OLD_PROMPT ) '
+        cmds += 'set prompt="$SPACK_OLD_PROMPT" && '
+        cmds += 'unsetenv SPACK_OLD_PROMPT;\n'
+        cmds += 'unalias despacktivate;\n'
+    elif shell == 'fish':
+        cmds += 'set -e SPACK_ENV;\n'
+        cmds += 'functions -e despacktivate;\n'
+        #
+        # NOTE: Not changing fish_prompt (above) => no need to restore it here.
+        #
+    else:
+        cmds += 'if [ ! -z ${SPACK_ENV+x} ]; then\n'
+        cmds += 'unset SPACK_ENV; export SPACK_ENV;\n'
+        cmds += 'fi;\n'
+        cmds += 'unalias despacktivate;\n'
+        cmds += 'if [ ! -z ${SPACK_OLD_PS1+x} ]; then\n'
+        cmds += '    if [ "$SPACK_OLD_PS1" = \'$$$$\' ]; then\n'
+        cmds += '        unset PS1; export PS1;\n'
+        cmds += '    else\n'
+        cmds += '        export PS1="$SPACK_OLD_PS1";\n'
+        cmds += '    fi;\n'
+        cmds += '    unset SPACK_OLD_PS1; export SPACK_OLD_PS1;\n'
+        cmds += 'fi;\n'
+
+    return cmds
+
+
+def activate(env, use_env_repo=False, add_view=True):
+    """
+    Activate an environment and append environment modifications
+
+    To activate an environment, we add its configuration scope to the
+    existing Spack configuration, and we set active to the current
+    environment.
+
+    Arguments:
+        env (spack.environment.Environment): the environment to activate
+        use_env_repo (bool): use the packages exactly as they appear in the
+            environment's repository
+        add_view (bool): generate commands to add view to path variables
+
+    Returns:
+        spack.util.environment.EnvironmentModifications: Environment variables
+        modifications to activate environment.
+    """
+    ev.activate(env, use_env_repo=use_env_repo)
+
+    env_mods = EnvironmentModifications()
+
+    #
+    # NOTE in the fish-shell: Path variables are a special kind of variable
+    # used to support colon-delimited path lists including PATH, CDPATH,
+    # MANPATH, PYTHONPATH, etc. All variables that end in PATH (case-sensitive)
+    # become PATH variables.
+    #
+    try:
+        if add_view and ev.default_view_name in env.views:
+            with spack.store.db.read_transaction():
+                env.add_default_view_to_env(env_mods)
+    except (spack.repo.UnknownPackageError,
+            spack.repo.UnknownNamespaceError) as e:
+        tty.error(e)
+        tty.die(
+            'Environment view is broken due to a missing package or repo.\n',
+            '  To activate without views enabled, activate with:\n',
+            '    spack env activate -V {0}\n'.format(env.name),
+            '  To remove it and resolve the issue, '
+            'force concretize with the command:\n',
+            '    spack -e {0} concretize --force'.format(env.name))
+
+    return env_mods
+
+
+def deactivate():
+    """
+    Deactviate an environment and collect corresponding environment modifications
+
+    Returns:
+        spack.util.environment.EnvironmentModifications: Environment variables
+        modifications to activate environment.
+    """
+    env_mods = EnvironmentModifications()
+    active = ev.active_environment()
+
+    if active is None:
+        return env_mods
+
+    if ev.default_view_name in active.views:
+        try:
+            with spack.store.db.read_transaction():
+                active.rm_default_view_from_env(env_mods)
+        except (spack.repo.UnknownPackageError,
+                spack.repo.UnknownNamespaceError) as e:
+            tty.warn(e)
+            tty.warn('Could not fully deactivate view due to missing package '
+                     'or repo, shell environment may be corrupt.')
+
+    ev.deactivate()
+
+    return env_mods

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -745,7 +745,7 @@ def main(argv=None):
     if not args.no_env:
         env = spack.cmd.find_environment(args)
         if env:
-            ev.activate(env, args.use_env_repo, add_view=False)
+            ev.activate(env, args.use_env_repo)
 
     if args.print_shell_vars:
         print_setup_info(*args.print_shell_vars.split(','))

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -12,8 +12,10 @@ import llnl.util.filesystem as fs
 import llnl.util.link_tree
 
 import spack.environment as ev
+import spack.environment.shell
 import spack.hash_types as ht
 import spack.modules
+import spack.repo
 import spack.util.spack_json as sjson
 from spack.cmd.env import _env_create
 from spack.main import SpackCommand, SpackCommandError
@@ -211,8 +213,8 @@ def test_env_modifications_error_on_activate(
 
     pkg = spack.repo.path.get_pkg_class("cmake-client")
     monkeypatch.setattr(pkg, "setup_run_environment", setup_error)
-    with e:
-        pass
+
+    spack.environment.shell.activate(e)
 
     _, err = capfd.readouterr()
     assert "cmake-client had issues!" in err
@@ -228,8 +230,7 @@ def test_activate_adds_transitive_run_deps_to_path(
     with e:
         install('depends-on-run-env')
 
-    _, mods = ev.activate(e)
-    env_variables = mods.apply_modifications({})
+    env_variables = spack.environment.shell.activate(e).apply_modifications({})
     assert env_variables['DEPENDENCY_ENV_VAR'] == '1'
 
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -228,8 +228,9 @@ def test_activate_adds_transitive_run_deps_to_path(
     with e:
         install('depends-on-run-env')
 
-    cmds = ev.activate(e)
-    assert 'DEPENDENCY_ENV_VAR=1' in cmds
+    _, mods = ev.activate(e)
+    env_variables = mods.apply_modifications({})
+    assert env_variables['DEPENDENCY_ENV_VAR'] == '1'
 
 
 def test_env_install_same_spec_twice(install_mockery, mock_fetch):
@@ -553,15 +554,10 @@ packages:
         e.install_all()
         e.write()
 
-        env_modifications = e.add_default_view_to_shell('sh')
-        individual_modifications = env_modifications.split('\n')
-
-        def path_includes_fake_prefix(cmd):
-            return 'export PATH' in cmd and str(fake_bin) in cmd
-
-        assert any(
-            path_includes_fake_prefix(cmd) for cmd in individual_modifications
-        )
+        env_mod = spack.util.environment.EnvironmentModifications()
+        e.add_default_view_to_env(env_mod)
+        env_variables = env_mod.apply_modifications({})
+        assert str(fake_bin) in env_variables['PATH']
 
 
 def test_init_with_file_and_remove(tmpdir):

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -593,6 +593,8 @@ class EnvironmentModifications(object):
             for x in actions:
                 x.execute(env)
 
+        return env
+
     def shell_modifications(self, shell='sh'):
         """Return shell code to apply the modifications and clears the list."""
         modifications = self.group_by_name()

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -88,7 +88,7 @@ end
 function spt_succeeds
     printf "'$argv' succeeds ... "
 
-    set -l output (eval $argv 2>&1)
+    set -l output ($argv 2>&1)
 
     if test $status -ne 0
         fail
@@ -112,7 +112,7 @@ end
 function spt_fails
     printf "'$argv' fails ... "
 
-    set -l output (eval $argv 2>&1)
+    set -l output ($argv 2>&1)
 
     if test $status -eq 0
         fail
@@ -140,7 +140,7 @@ function spt_contains
 
     printf "'$remaining_args' output contains '$target_string' ... "
 
-    set -l output (eval $remaining_args 2>&1)
+    set -l output ($remaining_args 2>&1)
 
     if not echo "$output" | string match -q -r ".*$target_string.*"
         fail

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -159,6 +159,34 @@ end
 
 
 #
+# Ensure that a string is not in the output of a command.
+# Suppresses output on success.
+# On failure, echo the exit code and output.
+#
+function spt_does_not_contain
+    set -l target_string $argv[1]
+    set -l remaining_args $argv[2..-1]
+
+    printf "'$remaining_args' does not contain '$target_string' ... "
+
+    set -l output ($remaining_args 2>&1)
+
+    if not echo "$output" | string match -q -r ".*$target_string.*"
+        pass
+    else
+        fail
+        echo_red "'$target_string' was in the output."
+        if test -n "$output"
+            echo_msg "Output:"
+            echo "$output"
+        else
+            echo_msg "No output."
+        end
+    end
+end
+
+
+#
 # Ensure that a variable is set.
 #
 function is_set
@@ -247,6 +275,7 @@ spack -m install --fake a
 # create a test environment for testing environment commands
 echo "Creating a mock environment"
 spack env create spack_test_env
+spack env create spack_test_2_env
 
 # ensure that we uninstall b on exit
 function spt_cleanup
@@ -258,7 +287,7 @@ function spt_cleanup
 
     echo "Removing test environment before exiting."
     spack env deactivate 2>&1 > /dev/null
-    spack env rm -y spack_test_env
+    spack env rm -y spack_test_env spack_test_2_env
 
     title "Cleanup"
     echo "Removing test packages before exiting."
@@ -379,6 +408,12 @@ is_set SPACK_ENV
 echo "Testing 'despacktivate'"
 despacktivate
 is_not_set SPACK_ENV
+
+echo "Testing spack env activate repeatedly"
+spack env activate spack_test_env
+spack env activate spack_test_2_env
+spt_contains 'spack_test_2_env' 'fish' '-c' 'echo $PATH'
+spt_does_not_contain 'spack_test_env' 'fish' '-c' 'echo $PATH'
 
 #
 # NOTE: `--prompt` on fish does nothing => currently not implemented.

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -70,13 +70,13 @@ b_module=$(spack -m module tcl find b)
 # Create a test environment for testing environment commands
 echo "Creating a mock environment"
 spack env create spack_test_env
-test_env_location=$(spack location -e spack_test_env)
+spack env create spack_test_2_env
 
 # Ensure that we uninstall b on exit
 cleanup() {
     echo "Removing test environment before exiting."
     spack env deactivate 2>&1 > /dev/null
-    spack env rm -y spack_test_env
+    spack env rm -y spack_test_env spack_test_2_env
 
     title "Cleanup"
     echo "Removing test packages before exiting."
@@ -173,3 +173,9 @@ echo "Testing 'despacktivate'"
 despacktivate
 is_not_set SPACK_ENV
 is_not_set SPACK_OLD_PS1
+
+echo "Testing spack env activate repeatedly"
+spack env activate spack_test_env
+spack env activate spack_test_2_env
+contains "spack_test_2_env" sh -c 'echo $PATH'
+does_not_contain "spack_test_env" sh -c 'echo $PATH'

--- a/share/spack/qa/test-framework.sh
+++ b/share/spack/qa/test-framework.sh
@@ -133,6 +133,33 @@ contains() {
 }
 
 #
+# Ensure that a string is not in the output of a command.
+# Suppresses output on success.
+# On failure, echo the exit code and output.
+#
+does_not_contain() {
+    string="$1"
+    shift
+
+    printf "'%s' output does not contain '$string' ... " "$*"
+    output=$("$@" 2>&1)
+    err="$?"
+
+    if [ "${output#*$string}" = "${output}" ]; then
+        pass
+    else
+        fail
+        echo_red "'$string' was in the output."
+        if [ -n "$output" ]; then
+            echo_msg "Output:"
+            echo "$output"
+        else
+            echo_msg "No output."
+        fi
+    fi
+}
+
+#
 # Ensure that a variable is set.
 #
 is_set() {


### PR DESCRIPTION
This is an additional commit on top of https://github.com/spack/spack/pull/25409

With this PR we can activate an environment in Spack itself, without computing changes to environment variables only necessary for "shell aware" env activation.

1. Activating an environment:
    
    ```python
    spack.environment.activate(Environment(xyz)) -> None
    ```
    this basically just sets `_active_environment` and modifies some config scopes.

2. Activating an environment **and** getting environment variable modifications for the shell:

    ```python
    spack.environment.shell.activate(Environment(xyz)) -> EnvironmentModifications
    ```

This should make it easier/faster to do unit tests and scripting with spack, without the cli interface.

