### PR TITLE
Tell gtk-doc where the XML catalog is

### DIFF
--- a/var/spack/repos/builtin/packages/gtk-doc/package.py
+++ b/var/spack/repos/builtin/packages/gtk-doc/package.py
@@ -45,6 +45,6 @@ class GtkDoc(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            '--with-xml-catalog={0}'.format(self.spec['docbook-xml'].prefix.catalog)
+            '--with-xml-catalog={0}'.format(self.spec['docbook-xml'].package.catalog)
         ]
         return args

--- a/var/spack/repos/builtin/packages/gtk-doc/package.py
+++ b/var/spack/repos/builtin/packages/gtk-doc/package.py
@@ -42,3 +42,9 @@ class GtkDoc(AutotoolsPackage):
         """Handle gnome's version-based custom URLs."""
         url = 'https://gitlab.gnome.org/GNOME/gtk-doc/-/archive/GTK_DOC_{0}/gtk-doc-GTK_DOC_{0}.tar.gz'
         return url.format(version.underscored)
+
+    def configure_args(self):
+        args = [
+            '--with-xml-catalog={0}'.format(self.spec['docbook-xml'].prefix.catalog)
+        ]
+        return args


### PR DESCRIPTION
Potentially fixes #25420 

The gtk-doc configure script has an option for specifying the path to
the XML catalog. If this is not set the configure script will search
a defined set of directories for a catalog file and will set
`with_xml_catalog` based on that. Only if no system catalog is found will
the XML_CATALOG_FILES be looked at. In order to make sure that the spack
provided catalog is used, pass the `--with-xml-catalog` option.