### PR TITLE
Install command scope

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -79,9 +79,9 @@ the dependencies"""
     scopes = spack.config.scopes()
     scopes_metavar = spack.config.scopes_metavar
     subparser.add_argument(
-        '--min-scope', choices=scopes, metavar=scopes_metavar,
-        default=spack.config.default_modify_scope('compilers'),
-        help="min configuration scope to use for installing packages")
+        '--scope', choices=scopes, metavar=scopes_metavar,
+        default=spack.config.default_modify_scope('packages'),
+        help="configuration scope to use for installing packages")
     subparser.add_argument(
         '-u', '--until', type=str, dest='until', default=None,
         help="phase to stop after when installing (default None)")
@@ -422,6 +422,11 @@ environment variables:
 
     if len(specs) == 0:
         tty.die('The `spack install` command requires a spec to install.')
+
+    if args.scope:
+        # TODO: Get necessary install variables from config module
+        # TODO: Set configuration within scope
+        pass
 
     if not args.log_file and not reporter.filename:
         reporter.filename = default_log_file(specs[0])

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -424,9 +424,20 @@ environment variables:
         tty.die('The `spack install` command requires a spec to install.')
 
     if args.scope:
-        # TODO: Get necessary install variables from config module
-        # TODO: Set configuration within scope
-        pass
+        kept_scope = None
+        all_scopes = []
+        while True:
+            scope = spack.config.config.pop_scope()
+            if not scope:
+                break
+            all_scopes.append(scope)
+            if scope.name == args.scope:
+                kept_scope = scope
+                break
+        if kept_scope:
+            spack.config.config.push_scope(kept_scope)
+        else:
+            raise Exception("Scope not found")
 
     if not args.log_file and not reporter.filename:
         reporter.filename = default_log_file(specs[0])

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -20,6 +20,7 @@ import spack.fetch_strategy
 import spack.monitor
 import spack.paths
 import spack.report
+import spack.config
 from spack.error import SpackError
 from spack.installer import PackageInstaller
 
@@ -75,6 +76,12 @@ the default is to install the package along with all its dependencies.
 alternatively one can decide to install only the package or only
 the dependencies"""
     )
+    scopes = spack.config.scopes()
+    scopes_metavar = spack.config.scopes_metavar
+    subparser.add_argument(
+        '--min-scope', choices=scopes, metavar=scopes_metavar,
+        default=spack.config.default_modify_scope('compilers'),
+        help="min configuration scope to use for installing packages")
     subparser.add_argument(
         '-u', '--until', type=str, dest='until', default=None,
         help="phase to stop after when installing (default None)")


### PR DESCRIPTION
This change adds a `--scope` flag to the `spack install` command. I am new to Spack and am not fully aware of the inner workings of the `config` module, so I think my current changes may cause nasty side effects. However, in summary, my current changes should simply remove all scopes except the specified one from the configuration so that the specified scope is the only one used, or else an error occurs.

Closes #25547