### PR TITLE
Make it easier to switch out the hook runner

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -761,7 +761,7 @@ In this example, we use it outside of a logger that is already defined:
     import spack.hooks
 
     # We do something here to generate a logger and message
-    spack.hooks.post_log_write(message, logger.level)
+    spack.hooks.runner('post_log_write', message, logger.level)
 
 
 This is not to say that this would be the best way to implement an integration

--- a/lib/spack/spack/analyzers/analyzer_base.py
+++ b/lib/spack/spack/analyzers/analyzer_base.py
@@ -113,4 +113,4 @@ class AnalyzerBase(object):
                 spack.monitor.write_json(result[self.name], outfile)
 
         # This hook runs after a save result
-        spack.hooks.on_analyzer_save(self.spec.package, result)
+        spack.hooks.runner('on_analyzer_save', self.spec.package, result)

--- a/lib/spack/spack/analyzers/libabigail.py
+++ b/lib/spack/spack/analyzers/libabigail.py
@@ -113,4 +113,5 @@ class Libabigail(AnalyzerBase):
             # A result needs an analyzer, value or binary_value, and name
             data = {"value": content, "install_file": rel_path, "name": "abidw-xml"}
             tty.info("Sending result for %s %s to monitor." % (name, rel_path))
-            spack.hooks.on_analyzer_save(self.spec.package, {"libabigail": [data]})
+            spack.hooks.runner('on_analyzer_save', self.spec.package, {
+                "libabigail": [data]})

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -544,7 +544,7 @@ def install_tarball(spec, args):
             tty.msg('Installing buildcache for spec %s' % spec.format())
             bindist.extract_tarball(spec, tarball, args.allow_root,
                                     args.unsigned, args.force)
-            spack.hooks.post_install(spec)
+            spack.hooks.runner('post_install', spec)
             spack.store.db.add(spec, spack.store.layout)
         else:
             tty.die('Download of binary cache file for spec %s failed.' %

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1817,7 +1817,7 @@ class Environment(object):
             self.regenerate_views()
 
             # Run post_env_hooks
-            spack.hooks.post_env_write(self)
+            spack.hooks.runner('post_env_write', self)
 
         # new specs and new installs reset at write time
         self.new_specs = []

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -36,7 +36,7 @@ class HookRunner(object):
     #: all HookRunner objects
     _hooks = None
 
-    def __init__(self, hooks):
+    def __init__(self, hooks=None):
         self.hooks_names = hooks or []
 
     def _init_hooks(cls):

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -36,8 +36,8 @@ class HookRunner(object):
     #: all HookRunner objects
     _hooks = None
 
-    def __init__(self, hooks=[]):
-        self.hooks_names = hooks
+    def __init__(self, hooks):
+        self.hooks_names = hooks or []
 
     def _init_hooks(cls):
         # Lazily populate the list of hooks
@@ -82,7 +82,8 @@ runner = _default_runner
 @contextlib.contextmanager
 def use_hook_runner(new_runner):
     global runner
-    old_runner = runner
-    runner = new_runner
-    yield
-    runner = old_runner
+    old_runner, runner = runner, new_runner
+    try:
+        yield
+    finally:
+        runner = old_runner

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2190,7 +2190,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
             if pkg is not None:
                 try:
-                    spack.hooks.pre_uninstall(spec)
+                    spack.hooks.runner('pre_uninstall', spec)
                 except Exception as error:
                     if force:
                         error_msg = (
@@ -2227,7 +2227,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         if pkg is not None:
             try:
-                spack.hooks.post_uninstall(spec)
+                spack.hooks.runner('post_uninstall', spec)
             except Exception:
                 # If there is a failure here, this is our only chance to do
                 # something about it: at this point the Spec has been removed

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -15,6 +15,7 @@ import llnl.util.tty as tty
 import spack.binary_distribution
 import spack.compilers
 import spack.directory_layout as dl
+import spack.hooks
 import spack.installer as inst
 import spack.package_prefs as prefs
 import spack.repo
@@ -176,9 +177,10 @@ def test_install_from_cache_ok(install_mockery, monkeypatch):
     spec = spack.spec.Spec('trivial-install-test-package')
     spec.concretize()
     monkeypatch.setattr(inst, '_try_install_from_binary_cache', _true)
-    monkeypatch.setattr(spack.hooks, 'post_install', _noop)
 
-    assert inst._install_from_cache(spec.package, True, True, False)
+    # Disable hooks.
+    with spack.hooks.use_hook_runner(spack.hooks.HookRunner()):
+        assert inst._install_from_cache(spec.package, True, True, False)
 
 
 def test_process_external_package_module(install_mockery, monkeypatch, capfd):


### PR DESCRIPTION
This PR introduces a single hook runner handling all hooks, instead of one hook runner per hook. That way it's much easier to turn them off or replace them with a no-op runner.

Allows one to disable hooks in tests more easily:

```python
with spack.hooks.use_hook_runner(spack.hooks.HookRunner()):
   install_something()
```

Or implement a new hook "runner" that merely logs events, so that you
can test hooks being triggered / events being emitted without having to execute those:

```python
class NoopHookRunner(object):
    events = []
    def __call__(self, hook_name, *args, **kwargs):
        events.append(hook_name)

noop_hook_runner = NoopHookRunner()

with spack.hooks.use_hook_runner(noop_hook_runner):
  do_something_complicated()

assert 'on_install_failure' in noop_hook_runner.events
```

Edit: note that our automatic hook searching/enabling stuff doesn't make sense when we also require a particular order of execution; at that point we can better just list the names in order. It's not like hooks get added every other day...

---

I think it's beyond the scope of this PR to do more than refactoring the hooks themselves, but as follow-up action items, I can think of:
- enabling a dummy hook runner by default in tests
- move the environment view updating & log symlinking to hooks