### PR TITLE
[py-meshio] Added py-meshio package

### DIFF
--- a/var/spack/repos/builtin/packages/py-meshio/package.py
+++ b/var/spack/repos/builtin/packages/py-meshio/package.py
@@ -18,6 +18,6 @@ class PyMeshio(PythonPackage):
     # This patch adds a small setup.py file that spack can call.
     patch('setup.patch')
 
-    depends_on('python@3.7:')
+    depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-setuptools')
     depends_on('py-numpy')

--- a/var/spack/repos/builtin/packages/py-meshio/package.py
+++ b/var/spack/repos/builtin/packages/py-meshio/package.py
@@ -19,4 +19,5 @@ class PyMeshio(PythonPackage):
     patch('setup.patch')
 
     depends_on('python@3.7:')
+    depends_on('py-setuptools')
     depends_on('py-numpy')

--- a/var/spack/repos/builtin/packages/py-meshio/package.py
+++ b/var/spack/repos/builtin/packages/py-meshio/package.py
@@ -12,7 +12,7 @@ class PyMeshio(PythonPackage):
     homepage = "https://github.com/nschloe/meshio"
     pypi = "meshio/meshio-5.0.0.tar.gz"
 
-    version('5.0.0', sha256='68c221872226d504296f94294b61f278cc838dd42dfcb08708398cf30790c38b')
+    version('5.0.0', sha256='f6327c06d6171d30e0991d3dcb048751035f9cfac1f19e2444971275fd971188')
 
     # MeshIO uses a setup.cfg/pyproject.toml structure, which spack doesn't yet handle.
     # This patch adds a small setup.py file that spack can call.

--- a/var/spack/repos/builtin/packages/py-meshio/package.py
+++ b/var/spack/repos/builtin/packages/py-meshio/package.py
@@ -19,5 +19,5 @@ class PyMeshio(PythonPackage):
     patch('setup.patch')
 
     depends_on('python@3.7:', type=('build', 'run'))
-    depends_on('py-setuptools')
+    depends_on('py-setuptools', type='build')
     depends_on('py-numpy')

--- a/var/spack/repos/builtin/packages/py-meshio/package.py
+++ b/var/spack/repos/builtin/packages/py-meshio/package.py
@@ -20,4 +20,4 @@ class PyMeshio(PythonPackage):
 
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-numpy')
+    depends_on('py-numpy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-meshio/package.py
+++ b/var/spack/repos/builtin/packages/py-meshio/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyMeshio(PythonPackage):
+    """MeshIO is a Python library to read and write many mesh formats."""
+
+    homepage = "https://github.com/nschloe/meshio"
+    url      = "https://github.com/nschloe/meshio/archive/refs/tags/5.0.0.tar.gz"
+
+    version('5.0.0', sha256='68c221872226d504296f94294b61f278cc838dd42dfcb08708398cf30790c38b')
+
+    # MeshIO uses a setup.cfg/pyproject.toml structure, which spack doesn't yet handle.
+    # This patch adds a small setup.py file that spack can call.
+    patch('setup.patch')
+
+    depends_on('python@3.7:')
+    depends_on('py-numpy')

--- a/var/spack/repos/builtin/packages/py-meshio/package.py
+++ b/var/spack/repos/builtin/packages/py-meshio/package.py
@@ -21,3 +21,4 @@ class PyMeshio(PythonPackage):
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-importlib-metadata', when='^python@:3.7', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-meshio/package.py
+++ b/var/spack/repos/builtin/packages/py-meshio/package.py
@@ -10,7 +10,7 @@ class PyMeshio(PythonPackage):
     """MeshIO is a Python library to read and write many mesh formats."""
 
     homepage = "https://github.com/nschloe/meshio"
-    url      = "https://github.com/nschloe/meshio/archive/refs/tags/5.0.0.tar.gz"
+    pypi = "meshio/meshio-5.0.0.tar.gz"
 
     version('5.0.0', sha256='68c221872226d504296f94294b61f278cc838dd42dfcb08708398cf30790c38b')
 

--- a/var/spack/repos/builtin/packages/py-meshio/setup.patch
+++ b/var/spack/repos/builtin/packages/py-meshio/setup.patch
@@ -1,0 +1,10 @@
+diff --git a/setup.py b/setup.py
+new file mode 100644
+index 0000000..7f1a176
+--- /dev/null
++++ b/setup.py
+@@ -0,0 +1,4 @@
++from setuptools import setup
++
++if __name__ == "__main__":
++    setup()


### PR DESCRIPTION
This PR adds the py-meshio package, a python package for reading and writing various mesh file formats.

I only added the latest release (5.0.0) since this is the one I'm using. meshio uses a `setup.cfg` and a `pyproject.toml` file for setup, instead of a `setup.py`, but spack is currently not able to handle this type of configuration-based setup. Hence, I added a patch that adds a 3-line `setup.py` file for setuptools to use.