### PR TITLE
Fix spack develop reinstall after failure / make definition of 'installed' uniform in different code paths

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1252,18 +1252,14 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         Returns:
             True if the package has been installed, False otherwise.
         """
-        has_prefix = os.path.isdir(self.prefix)
         try:
             # If the spec is in the DB, check the installed
             # attribute of the record
-            rec = spack.store.db.get_record(self.spec)
-            db_says_installed = rec.installed
+            return spack.store.db.get_record(self.spec).installed
         except KeyError:
             # If the spec is not in the DB, the method
             #  above raises a Key error
-            db_says_installed = False
-
-        return has_prefix and db_says_installed
+            return False
 
     @property
     def prefix(self):


### PR DESCRIPTION
(This is a bugfix for an issue incidentally uncovered due to another bug in spack develop fixed here https://github.com/spack/spack/pull/25583)

PackageInstaller and pkg.installed disagree over what it means for a package to be installed.

PackageInstaller believes it should be enough for a database entry to exist, whereas pkg.installed requires a database entry & a prefix directory.

This leads to the following niche issue:
- a develop spec in an environment is successfully installed
- then *somehow* its install prefix is removed (e.g. through a bug fixed in 25583)
- you modify the sources and reinstall the environment
   1. spack checks pkg.installed and realizes the develop spec is NOT installed, therefore it doesn't need to have 'overwrite: true'
   2. the installer gets the build task and checks the database and realizes the spec IS installed, hence it doesn't have to install it.
   3. the develop spec is not rebuilt.

The solution is to make `PackageInstaller` and `pkg.installed` agree over what it means to be installed, and this PR does that by dropping the prefix directory check from `pkg.installed`, so that it only checks the database.

As a result, spack will create a build task with `overwrite: true` for the develop spec, and the installer in fact handles overwrite requests fine even if the install prefix doesn't exist (it just does a normal install).

The arguments for making pkg.installed behave like this are:
1. `pkg.installed` should be cheap to evaluate
2. An installed spec can be corrupt, but it remains an installed spec
3. There are many ways in which an installed spec can be corrupt, and a missing install prefix is just one way. E.g. a spec that fails the `spack verify spec` test is still an installed spec.