### PR TITLE
Fix: --overwrite backs up old install dir, but it gets destroyed anyways

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -701,10 +701,7 @@ def replace_directory_transaction(directory_name, tmp_root=None):
             dst=os.path.dirname(directory_name)
         )
         tty.debug('DIRECTORY RECOVERED [{0}]'.format(directory_name))
-
-        msg = 'the transactional move of "{0}" failed.'
-        msg += '\n    ' + str(e)
-        raise RuntimeError(msg.format(directory_name))
+        raise e
     else:
         # Otherwise delete the temporary directory
         shutil.rmtree(tmp_dir)

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -692,7 +692,7 @@ def replace_directory_transaction(directory_name, tmp_root=None):
 
     try:
         yield tmp_dir
-    except (Exception, KeyboardInterrupt, SystemExit) as e:
+    except (Exception, KeyboardInterrupt, SystemExit):
         # Delete what was there, before copying back the original content
         if os.path.exists(directory_name):
             shutil.rmtree(directory_name)
@@ -701,7 +701,7 @@ def replace_directory_transaction(directory_name, tmp_root=None):
             dst=os.path.dirname(directory_name)
         )
         tty.debug('DIRECTORY RECOVERED [{0}]'.format(directory_name))
-        raise e
+        raise
     else:
         # Otherwise delete the temporary directory
         shutil.rmtree(tmp_dir)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1564,6 +1564,9 @@ class PackageInstaller(object):
                             if os.path.exists(rec.path):
                                 with fs.replace_directory_transaction(
                                         rec.path):
+                                    # fs transaction will put the old prefix
+                                    # back on failure, so make sure to keep it.
+                                    keep_prefix = True
                                     self._install_task(task)
                             else:
                                 tty.debug("Missing installation to overwrite")

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -132,7 +132,7 @@ def test_failing_overwrite_install_should_keep_previous_installation(
 ):
     """
     Make sure that whenever `spack install --overwrite` fails, spack restores
-    the original build directory instead of cleaning it.
+    the original install prefix instead of cleaning it.
     """
     # Do a successful install
     spec = Spec('canfail').concretized()

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -126,6 +126,31 @@ def test_partial_install_delete_prefix_and_stage(install_mockery, mock_fetch):
         pkg.remove_prefix = instance_rm_prefix
 
 
+@pytest.mark.disable_clean_stage_check
+def test_failing_overwrite_install_should_keep_previous_installation(
+    mock_fetch, install_mockery
+):
+    """
+    Make sure that whenever `spack install --overwrite` fails, spack restores
+    the original build directory instead of cleaning it.
+    """
+    # Do a successful install
+    spec = Spec('canfail').concretized()
+    pkg = spack.repo.get(spec)
+    pkg.succeed = True
+
+    # Do a failing overwrite install
+    pkg.do_install()
+    pkg.succeed = False
+    kwargs = {'overwrite': [spec.dag_hash()]}
+
+    with pytest.raises(Exception):
+        pkg.do_install(**kwargs)
+
+    assert pkg.installed
+    assert os.path.exists(spec.prefix)
+
+
 def test_dont_add_patches_to_installed_package(install_mockery, mock_fetch):
     dependency = Spec('dependency-install')
     dependency.concretize()


### PR DESCRIPTION
Closes #25582 

- Make sure PackageInstaller does not remove the install directory that was just recovered after failed `spack install --overwrite`
- Remove cryptic error message and rethrow actual error

Before:

```
$ spack install zlib
$ spack edit zlib # change make('install') to make('aergaergaerg')
$ spack install --overwrite zlib
==> The following package specs will be reinstalled:

-- linux-ubuntu20.04-zen2 / gcc@10.3.0 --------------------------
jcfc4hl zlib@1.2.11%gcc +optimize+pic~shared
==> Do you want to proceed? [y/N] y
==> Installing zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl
==> No binary for zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl found: installing from source
==> Using cached archive: /home/user/.spack/source_cache/_source-cache/archive/c3/c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1.tar.gz
==> No patches needed for zlib
==> zlib: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'agjaeoigjaerogiaeorgaejoaejoaejigaeorgi'

1 error found in build log:
     34    ar rc libz.a adler32.o crc32.o deflate.o infback.o inffast.o inflate.o inftrees.o trees.o zutil.o compress.o uncompr.o gzclose.o gzlib.o gzread.o gzwrite.o
     35    /home/user/spack/lib/spack/env/gcc/gcc -fPIC -O2 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o example example.o -L. libz.a
     36    /home/user/spack/lib/spack/env/gcc/gcc -fPIC -O2 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o minigzip minigzip.o -L. libz.a
     37    /home/user/spack/lib/spack/env/gcc/gcc -fPIC -O2 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o example64 example64.o -L. libz.a
     38    /home/user/spack/lib/spack/env/gcc/gcc -fPIC -O2 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o minigzip64 minigzip64.o -L. libz.a
     39    ==> [2021-08-24-15:13:46.190571] 'make' '-j16' 'agjaeoigjaerogiaeorgaejoaejoaejigaeorgi'
  >> 40    make: *** No rule to make target 'agjaeoigjaerogiaeorgaejoaejoaejigaeorgi'.  Stop.

See build log for details:
  /tmp/user/spack-stage/spack-stage-zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl/spack-build-out.txt

==> Error: Failed to install zlib due to RuntimeError: the transactional move of "/home/user/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl" failed.
    ProcessError: Command exited with status 2:
    'make' '-j16' 'agjaeoigjaerogiaeorgaejoaejoaejigaeorgi'
==> Error: the transactional move of "/home/user/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl" failed.
    ProcessError: Command exited with status 2:
    'make' '-j16' 'agjaeoigjaerogiaeorgaejoaejoaejigaeorgi'

$ stat /home/user/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl
stat: cannot stat '/home/user/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl': No such file or directory
```

After:

```
$ spack install zlib
$ spack edit zlib # change make('install') to make('aergaergaerg')
$ spack install --overwrite zlib
==> The following package specs will be reinstalled:

-- linux-ubuntu20.04-zen2 / gcc@10.3.0 --------------------------
jcfc4hl zlib@1.2.11%gcc +optimize+pic~shared
==> Do you want to proceed? [y/N] y
==> Installing zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl
==> No binary for zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl found: installing from source
==> Using cached archive: /home/user/.spack/source_cache/_source-cache/archive/c3/c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1.tar.gz
==> No patches needed for zlib
==> zlib: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'agjaeoigjaerogiaeorgaejoaejoaejigaeorgi'

1 error found in build log:
     34    ar rc libz.a adler32.o crc32.o deflate.o infback.o inffast.o inflate.o inftrees.o trees.o zutil.o compress.o uncompr.o gzclose.o gzlib.o gzread.o gzwrite.o
     35    /home/user/spack/lib/spack/env/gcc/gcc -fPIC -O2 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o example example.o -L. libz.a
     36    /home/user/spack/lib/spack/env/gcc/gcc -fPIC -O2 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o minigzip minigzip.o -L. libz.a
     37    /home/user/spack/lib/spack/env/gcc/gcc -fPIC -O2 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o example64 example64.o -L. libz.a
     38    /home/user/spack/lib/spack/env/gcc/gcc -fPIC -O2 -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o minigzip64 minigzip64.o -L. libz.a
     39    ==> [2021-08-24-15:16:59.715395] 'make' '-j16' 'agjaeoigjaerogiaeorgaejoaejoaejigaeorgi'
  >> 40    make: *** No rule to make target 'agjaeoigjaerogiaeorgaejoaejoaejigaeorgi'.  Stop.

See build log for details:
  /tmp/user/spack-stage/spack-stage-zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl/spack-build-out.txt

$ stat /home/user/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl
  File: /home/user/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.11-jcfc4hlhnbwlpbz2jzjcgvwkacxyppbl
  Size: 4096      	Blocks: 8          IO Block: 4096   directory

```