### PR TITLE
py-omegaconf: add missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-omegaconf/package.py
+++ b/var/spack/repos/builtin/packages/py-omegaconf/package.py
@@ -22,6 +22,7 @@ class PyOmegaconf(PythonPackage):
 
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-pytest-runner', type='build')
     depends_on('py-antlr4-python3-runtime@4.8', type=('build', 'run'))
     depends_on('py-pyyaml@5.1.0:', type=('build', 'run'))
     depends_on('py-dataclasses', when='^python@:3.6', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.

Without this, setuptools tries to pip install the dependency, which doesn't work if `pip` isn't installed or you're on an air-gapped network.