### PR TITLE
update opium package recipe

### DIFF
--- a/var/spack/repos/builtin/packages/opium/package.py
+++ b/var/spack/repos/builtin/packages/opium/package.py
@@ -9,28 +9,33 @@ from spack import *
 class Opium(AutotoolsPackage):
     """DFT pseudopotential generation project"""
 
-    homepage = "https://opium.sourceforge.net/index.html"
+    homepage = "http://opium.sourceforge.net"
     url = "https://downloads.sourceforge.net/project/opium/opium/opium-v3.8/opium-v3.8-src.tgz"
 
+    version('4.1', sha256='e5a102b52601ad037d8a7b3e2dbd295baad23b8c1e4908b9014df2e432c23c60')
     version('3.8', sha256='edee6606519330aecaee436ee8cfb0a33788b5677861d59e38aba936e87d5ad3')
 
-    depends_on('blas')
-    depends_on('lapack')
+    variant('external-lapack', default=False,
+            description='Links to externally installed LAPACK')
+
+    depends_on('lapack', when='+external-lapack')
+
+    parallel = False
+
+    def patch(self):
+        if '+external-lapack' in self.spec:
+            with working_dir('src'):
+                filter_file(r'(^subdirs=.*) lapack', r'\1', 'Makefile')
 
     def configure_args(self):
-        spec = self.spec
         options = []
-        libs = spec['lapack'].libs + spec['blas'].libs
-        options.append('LDFLAGS=%s' % libs.ld_flags)
+        if '+external-lapack' in self.spec:
+            options.append('LDFLAGS={0}'.format(self.spec['lapack'].libs.ld_flags))
+
         return options
 
-    def build(self, spec, prefix):
-        with working_dir("src", create=False):
-            make("all-subdirs")
-            make("opium")
-
     def install(self, spec, prefix):
-        # opium not have a make install :-((
+        # opium does not have a make install target :-((
         mkdirp(self.prefix.bin)
         install(join_path(self.stage.source_path, 'opium'),
                 self.prefix.bin)


### PR DESCRIPTION
This PR updates the opium package.

- add version 4.1
- fix homepage link
- remove unneeded dependency on blas
- create external-lapack variant
- set parallel = False
- patch makefile to not build lapack if `+external-lapack`
- make references to `spec` consistent
- remove unneeded `build` method