### PR TITLE
bootstrap: fix printing for python 2

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from __future__ import print_function
+
 import contextlib
 import json
 import os

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from __future__ import print_function
+
 import os.path
 import shutil
 


### PR DESCRIPTION
The bootstrap classes don't properly `from __future__ import print_function`, so we get output like this:

```console
(spackle):~> spack bootstrap list
Name: github-actions TRUSTED
()
  Type: buildcache
()
...
```

- [x] add the imports to get rid of parens.