### PR TITLE
bootstrap: use `sys.exec_prefix` to set up external python correctly

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -265,7 +265,7 @@ def spack_python_interpreter():
     which Spack is currently running as the only Python external spec
     available.
     """
-    python_prefix = os.path.dirname(os.path.dirname(sys.executable))
+    python_prefix = sys.exec_prefix
     external_python = spec_for_current_python()
 
     entry = {


### PR DESCRIPTION
Bootstrapping clingo on macOS on `develop` gives errors like this:

```
==> Error: RuntimeError: Unable to locate python command in /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/bin

/Users/gamblin2/Workspace/spack/var/spack/repos/builtin/packages/python/package.py:662, in command:
        659                return Executable(path)
        660        else:
        661            msg = 'Unable to locate {0} command in {1}'
  >>    662            raise RuntimeError(msg.format(self.name, self.prefix.bin))
```

On macOS, `python` is laid out differently. In particular, `sys.executable` is here:

```console
Python 2.7.16 (default, May  8 2021, 11:48:02)
[GCC Apple LLVM 12.0.5 (clang-1205.0.19.59.6) [+internal-os, ptrauth-isa=deploy on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.executable
'/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python'
```

Based on that, you'd think that
`/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents` would be
where you'd look for a `bin` directory, but you (and Spack) would be wrong:

```console
$ ls /System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/
Info.plist      MacOS/          PkgInfo         Resources/      _CodeSignature/ version.plist
```

You need to look in `sys.exec_prefix`

```
>>> sys.exec_prefix
'/System/Library/Frameworks/Python.framework/Versions/2.7'
```

Which looks much more like a standard prefix, with understandable `bin`, `lib`, and `include`
directories:

```console
$ ls /System/Library/Frameworks/Python.framework/Versions/2.7
Extras/         Mac/            Resources/      bin/            lib/
Headers@        Python*         _CodeSignature/ include/
$ ls -l /System/Library/Frameworks/Python.framework/Versions/2.7/bin/python
lrwxr-xr-x  1 root  wheel     7B Jan  1  2020 /System/Library/Frameworks/Python.framework/Versions/2.7/bin/python@ -> python2
```

- [x] change `bootstrap.py` to use the `sys.exec_prefix` as the external prefix, instead of just
      getting the parent directory of the executable.