### PR TITLE
Bugfix: Correct source of PID for -ddd installation outputs

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1163,7 +1163,7 @@ class PackageInstaller(object):
         except spack.build_environment.StopPhase as e:
             # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
-            pid = '{0}: '.format(pkg.pid) if tty.show_pid() else ''
+            pid = '{0}: '.format(self.pid) if tty.show_pid() else ''
             tty.debug('{0}{1}'.format(pid, str(e)))
             tty.debug('Package stage directory: {0}' .format(pkg.stage.source_path))
 
@@ -1715,7 +1715,7 @@ class BuildProcessInstaller(object):
         self.filter_fn = spack.util.path.padding_filter if filter_padding else None
 
         # info/debug information
-        pid = '{0}: '.format(pkg.pid) if tty.show_pid() else ''
+        pid = '{0}: '.format(os.getpid()) if tty.show_pid() else ''
         self.pre = '{0}{1}:'.format(pid, pkg.name)
         self.pkg_id = package_id(pkg)
 


### PR DESCRIPTION
Fixes #25595 

The `PackageInstaller`, not `Package`, has a `pid` attribute.  This PR switches to using the proper attribute from within the `PackageInstaller` and lets the newer `BuildProcessInstaller` grab the current PID for its debug output.