### PR TITLE
Update the cray-mpich package to use the new cray-mpich MPI wrappers

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -59,17 +59,17 @@ class CrayMpich(Package):
                 return os.path.dirname(os.path.normpath(libdir))
 
     def setup_run_environment(self, env):
-        if(self.spec.satisfies('@:8.1.6')):        
+        if(self.spec.satisfies('@:8.1.6')):
             env.set('MPICC', spack_cc)
             env.set('MPICXX', spack_cxx)
             env.set('MPIF77', spack_fc)
             env.set('MPIF90', spack_fc)
         else:
-            #cray-mpich 8.1.7: features MPI compiler wrappers
-            env.set('MPICC', join_path(self.prefix.bin, 'mpicc') )
-            env.set('MPICXX', join_path(self.prefix.bin, 'mpicxx') )
-            env.set('MPIF77', join_path(self.prefix.bin, 'mpif77') )
-            env.set('MPIF90', join_path(self.prefix.bin, 'mpif90') )
+            # cray-mpich 8.1.7: features MPI compiler wrappers
+            env.set('MPICC', join_path(self.prefix.bin, 'mpicc'))
+            env.set('MPICXX', join_path(self.prefix.bin, 'mpicxx'))
+            env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
+            env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)
@@ -87,7 +87,7 @@ class CrayMpich(Package):
             spec.mpifc = spack_fc
             spec.mpif77 = spack_f77
         else:
-            #cray-mpich 8.1.7: features MPI compiler wrappers
+            # cray-mpich 8.1.7: features MPI compiler wrappers
             spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
             spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
             spec.mpifc  = join_path(self.prefix.bin, 'mpif90')

--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -18,6 +18,7 @@ class CrayMpich(Package):
 
     maintainers = ['haampie']
 
+    version('8.1.7')
     version('8.1.0')
     version('8.0.16')
     version('8.0.14')
@@ -58,14 +59,20 @@ class CrayMpich(Package):
                 return os.path.dirname(os.path.normpath(libdir))
 
     def setup_run_environment(self, env):
-        env.set('MPICC', spack_cc)
-        env.set('MPICXX', spack_cxx)
-        env.set('MPIF77', spack_fc)
-        env.set('MPIF90', spack_fc)
+        if(self.spec.satisfies('@:8.1.6')):        
+            env.set('MPICC', spack_cc)
+            env.set('MPICXX', spack_cxx)
+            env.set('MPIF77', spack_fc)
+            env.set('MPIF90', spack_fc)
+        else:
+            #cray-mpich 8.1.7: features MPI compiler wrappers
+            env.set('MPICC', join_path(self.prefix.bin, 'mpicc') )
+            env.set('MPICXX', join_path(self.prefix.bin, 'mpicxx') )
+            env.set('MPIF77', join_path(self.prefix.bin, 'mpif77') )
+            env.set('MPIF90', join_path(self.prefix.bin, 'mpif90') )
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)
-
         env.set('MPICH_CC', spack_cc)
         env.set('MPICH_CXX', spack_cxx)
         env.set('MPICH_F77', spack_f77)
@@ -74,10 +81,17 @@ class CrayMpich(Package):
 
     def setup_dependent_package(self, module, dependent_spec):
         spec = self.spec
-        spec.mpicc = spack_cc
-        spec.mpicxx = spack_cxx
-        spec.mpifc = spack_fc
-        spec.mpif77 = spack_f77
+        if(spec.satisfies('@:8.1.6')):
+            spec.mpicc = spack_cc
+            spec.mpicxx = spack_cxx
+            spec.mpifc = spack_fc
+            spec.mpif77 = spack_f77
+        else:
+            #cray-mpich 8.1.7: features MPI compiler wrappers
+            spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
+            spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
+            spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
+            spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
     def install(self, spec, prefix):
         raise InstallError(


### PR DESCRIPTION
As of cray-mpich version 8.1.7, conventional MPI compiler wrappers are included with cray-mpich.