### PR TITLE
Make `spack graph -i` environment-aware

### DIFF
--- a/lib/spack/spack/cmd/graph.py
+++ b/lib/spack/spack/cmd/graph.py
@@ -10,6 +10,7 @@ import llnl.util.tty as tty
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.config
+import spack.environment as ev
 import spack.store
 from spack.graph import graph_ascii, graph_dot
 
@@ -35,7 +36,7 @@ def setup_parser(subparser):
 
     subparser.add_argument(
         '-i', '--installed', action='store_true',
-        help="graph all installed specs in dot format (implies --dot)")
+        help="graph installed specs, or specs in the active env (implies --dot)")
 
     arguments.add_common_arguments(subparser, ['deptype', 'specs'])
 
@@ -45,7 +46,12 @@ def graph(parser, args):
         if args.specs:
             tty.die("Can't specify specs with --installed")
         args.dot = True
-        specs = spack.store.db.query()
+
+        env = ev.active_environment()
+        if env:
+            specs = env.all_specs()
+        else:
+            specs = spack.store.db.query()
 
     else:
         specs = spack.cmd.parse_specs(args.specs, concretize=not args.static)

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -550,11 +550,21 @@ def graph_dot(specs, deptype='all', static=False, out=None):
     out.write('     style="rounded,filled"')
     out.write('  ]\n')
 
+    # write nodes
     out.write('\n')
     for key, label in nodes:
         out.write('  "%s" [label="%s"]\n' % (key, label))
 
+    # write edges
     out.write('\n')
     for src, dest in edges:
         out.write('  "%s" -> "%s"\n' % (src, dest))
+
+    # ensure that roots are all at the top of the plot
+    dests = set([d for _, d in edges])
+    roots = ['"%s"' % k for k, _ in nodes if k not in dests]
+    out.write('\n')
+    out.write('  { rank=min; %s; }' % "; ".join(roots))
+
+    out.write('\n')
     out.write('}\n')


### PR DESCRIPTION
This allows you to run `spack graph --installed` from within an environment and get a dot graph of
its concrete specs.

- [x] make `spack graph -i` environment-aware
- [x] add code to the generated dot graph to ensure roots have min rank (i.e., they're all at the
      top or left of the DAG)

Example graph:

![default](https://user-images.githubusercontent.com/299842/130727510-a79c745f-2049-495b-8b51-38980c11458b.png)
