### PR TITLE
Fix nghttp2

### DIFF
--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack import *
 
 
@@ -15,23 +13,25 @@ class Nghttp2(AutotoolsPackage):
     homepage = "https://nghttp2.org/"
     url      = "https://github.com/nghttp2/nghttp2/releases/download/v1.26.0/nghttp2-1.26.0.tar.gz"
 
+    version('1.44.0', sha256='3e4824d02ae27eca931e0bb9788df00a26e5fd8eb672cf52cbb89c1463ba16e9')
     version('1.26.0', sha256='daf7c0ca363efa25b2cbb1e4bd925ac4287b664c3d1465f6a390359daa3f0cf1')
 
-    depends_on('python@2.7:', type=('build', 'run'))
-    depends_on('py-cython@0.19:', type=('build', 'run'))
-    depends_on('py-setuptools', type=('build'))
+    depends_on('pkgconfig', type='build')
 
-    def setup_build_environment(self, env):
-        site_packages_dir = os.path.join(
-            self.spec.prefix.lib,
-            'python' + str(self.spec['python'].version.up_to(2)),
-            'site-packages')
-        env.prepend_path('PYTHONPATH', site_packages_dir)
-
-    @run_before('install')
-    def ensure_install_dir_exists(self):
-        site_packages_dir = os.path.join(
-            self.spec.prefix.lib,
-            'python' + str(self.spec['python'].version.up_to(2)),
-            'site-packages')
-        mkdirp(site_packages_dir)
+    def configure_args(self):
+        return [
+            '--enable-lib-only',
+            '--with-libxml2=no',
+            '--with-jansson=no',
+            '--with-zlib=no',
+            '--with-libevent-openssl=no',
+            '--with-libcares=no',
+            '--with-openssl=no',
+            '--with-libev=no',
+            '--with-cunit=no',
+            '--with-jemalloc=no',
+            '--with-systemd=no',
+            '--with-mruby=no',
+            '--with-neverbleed=no',
+            '--with-boost=no'
+        ]


### PR DESCRIPTION
This package was previously broken, cause there are many missing dependencies.

Adding `--enable-lib-only` is enough to disable all the other deps, but the configure script redundantly searches for deps, so disabled them explicitly.

Note that nghttp2 is a dependency of cmake.
