### PR TITLE
start of work to add spack dag to generate workflow files

### DIFF
--- a/lib/spack/docs/dags.rst
+++ b/lib/spack/docs/dags.rst
@@ -1,0 +1,91 @@
+.. Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+   Spack Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. _dags:
+
+====
+Dags
+====
+
+You can use spack to generate DAGs, or directed acyclic graphs, for usage
+with other build systems and workflow managers. Currently, we just have
+support for Snakemake, which will produce a ``Snakefile``.
+
+---------
+Snakemake
+---------
+
+If you aren't familiar with Snakemake, you can learn more about it
+`here <https://about.gitlab.com/product/continuous-integration/>`_) 
+
+^^^^^^^^^^^^^^^^^^^^^
+Create an environment
+^^^^^^^^^^^^^^^^^^^^^
+
+Let's start with a really simple environment - one that has a few biology
+relevant stacks.
+
+.. code-block:: yaml
+
+    spack:
+        specs:
+          - bcftools
+          - samtools
+
+
+We would put this in some directory, let's say "bio" named ``spack.yaml``
+
+.. code-block:: console
+
+    $ ls
+    bio/
+       spack.yaml
+
+
+To activate the environment, we might then do:
+
+.. code-block:: console
+
+     $ spack env activate bio
+     $ cd bio/
+
+
+In a normal "let's get this environment working" scenario, we might then do:
+
+.. code-block:: console
+
+     $ spack install
+     
+But wait - maybe we can do it faster? Let's try using the workflow manager Snakemake
+to install the environment. Instead of doing the above command, let's ask spack
+to generate us a ``Snakefile``, which is the workflow instructions for Snakemake.
+They will be specific to the spack install here, as they have hard coded paths for
+the expected final install location.
+
+
+.. code-block:: console
+
+     $ spack dag generate-snakemake
+
+
+You'll notice a Snakefile appear in the present working directory, the "bio" folder.
+
+.. code-block:: console
+
+    $ ls
+    Snakefile  spack.lock  spack.yaml
+
+Next, we are assuming that you have `snakemake installed <https://snakemake.readthedocs.io/en/stable/getting_started/installation.html>`_
+You can run snakemake in the present working directory with some number of cores (N) as.
+
+.. code-block:: console
+    
+    $ snakemake --cores 4
+
+
+and this will install the packages in your environment. Snakemake will generate an internal
+DAG based on dependencies so nothing should attempt to be installed because it's requirement exists.
+This approach assumes a shared filesystem - if we want to be able to have isolated installs, we will
+need to add some shared build cache.

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -64,6 +64,7 @@ or refer to the full manual below.
 
    configuration
    config_yaml
+   dags
    build_settings
    environments
    containers

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -520,12 +520,18 @@ def format_job_needs(phase_name, strip_compilers, dep_jobs,
 def generate_gitlab_ci_yaml(env, print_summary, output_file,
                             prune_dag=False, check_index_only=False,
                             run_optimizer=False, use_dependencies=False,
-                            artifacts_root=None):
+                            artifacts_root=None, return_only=False):
+    """
+    Args:
+      return_only: Don't write or copy files, only return the json structure.
+    """
     with spack.concretize.disable_compiler_existence_check():
         with env.write_transaction():
             env.concretize()
             env.write()
 
+    import IPython
+    IPython.embed()
     yaml_root = ev.config_dict(env.yaml)
 
     if 'gitlab-ci' not in yaml_root:

--- a/lib/spack/spack/cmd/dag.py
+++ b/lib/spack/spack/cmd/dag.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import spack.dag as spack_dag
+import spack.mirror
+
+description = "generate DAGs for workflows using spack"
+section = "build"
+level = "long"
+
+
+def get_env_var(variable_name):
+    if variable_name in os.environ:
+        return os.environ.get(variable_name)
+    return None
+
+
+def setup_parser(subparser):
+    setup_parser.parser = subparser
+    subparsers = subparser.add_subparsers(help='CI sub-commands')
+
+    # Dynamic generation of the jobs yaml from a spack environment
+    generate = subparsers.add_parser('generate-snakemake',
+                                     help=generate_snakemake.__doc__)
+    generate.add_argument(
+        '--output-file', default=None,
+        help="Path to file where generated DAG file should be " +
+             "written.  The default will depend on your workflow chosen.")
+    generate.set_defaults(func=generate_snakemake)
+
+
+def generate_snakemake(args):
+    """Generate a Snakefile with a DAG to install things with Spack."""
+    env = spack.cmd.require_active_env(cmd_name='dag generate-snakemake')
+
+    output_file = os.path.abspath(args.output_file or "Snakefile")
+
+    # Generate the dag
+    spack_dag.generate_snakefile(env, True, output_file)
+
+
+def dag(parser, args):
+    if args.func:
+        return args.func(args)

--- a/lib/spack/spack/dag.py
+++ b/lib/spack/spack/dag.py
@@ -1,0 +1,100 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import spack
+import spack.binary_distribution as bindist
+import spack.ci
+import spack.cmd
+import spack.main
+import spack.mirror
+import spack.paths
+import spack.repo
+
+
+def generate_snakefile(env, print_summary, output_file):
+
+    with spack.concretize.disable_compiler_existence_check():
+        with env.write_transaction():
+            env.concretize()
+            env.write()
+
+    phases = []
+    phases.append({
+        'name': 'specs',
+        'strip-compilers': False,
+    })
+
+    # Speed up staging by first fetching binary indices from all mirrors
+    # (including the per-PR mirror we may have just added above).
+    bindist.binary_index.update()
+
+    staged_phases = {}
+    for phase in phases:
+        phase_name = phase['name']
+        with spack.concretize.disable_compiler_existence_check():
+            staged_phases[phase_name] = spack.ci.stage_spec_jobs(
+                env.spec_lists[phase_name],
+                check_index_only=True)
+
+    # There should only be one phase for now, so one snakefile
+    for phase in phases:
+        phase_name = phase['name']
+
+        # We care about dependencies
+        spec_labels, dependencies, stages = staged_phases[phase_name]
+
+        # This will be the spec for the very last spec to be installed
+        last_spec = [spec_labels[x] for x in stages[-1]][-1]
+        last_spec['spec'].concretize()
+
+        # The "final" output file is the last log of the last install
+        snakefile = '''rule all:
+    input:
+        "%s"\n''' % last_spec['spec'].package.times_log_path
+
+        seen_rules = set()
+
+        # First generate rules for specs that don't have any deps
+        for key, value in spec_labels.items():
+            rule_name = key.replace("/", "_").replace('-', "_")
+            if len(value['spec'].dependencies()) != 0:
+                continue
+            spec_labels[key]['spec'].concretize()
+            output = spec_labels[key]['spec'].package.times_log_path
+            snakefile += '''\nrule %s:
+    output:
+        "%s"
+    shell:
+        "spack install %s"\n''' % (rule_name, output, spec_labels[key]['spec'])
+            seen_rules.add(rule_name)
+
+        # Now for each set of package and dependencies, create a step
+        for pkg, deps in dependencies.items():
+            rule_name = pkg.replace("/", "_").replace('-', "_")
+            if rule_name in seen_rules:
+                continue
+            seen_rules.add(rule_name)
+
+            # Inputs are the dependency log files, which must exist
+            inputs = []
+            for dep in deps:
+                spec_labels[dep]['spec'].concretize()
+                inputs.append(spec_labels[dep]['spec'].package.times_log_path)
+            inputs = "\n".join(['        "%s",' % ip for ip in inputs]).strip(",")
+
+            # Outputs are the build log of the package
+            spec_labels[pkg]['spec'].concretize()
+            output = spec_labels[pkg]['spec'].package.times_log_path
+            snakefile += '''\nrule %s:
+    input:
+%s
+    output:
+        "%s"
+    shell:
+        "spack install %s"\n''' % (rule_name, inputs, output, spec_labels[pkg]['spec'])
+
+    # snakemake --cores <N>
+    with open(output_file, 'w') as outf:
+        outf.write(snakefile)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -333,7 +333,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="activate add analyze arch audit blame bootstrap build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mark mirror module monitor patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="activate add analyze arch audit blame bootstrap build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create dag deactivate debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find flake8 gc gpg graph help info install license list load location log-parse maintainers mark mirror module monitor patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -795,6 +795,19 @@ _spack_create() {
     else
         SPACK_COMPREPLY=""
     fi
+}
+
+_spack_dag() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY="generate-snakemake"
+    fi
+}
+
+_spack_dag_generate_snakemake() {
+    SPACK_COMPREPLY="-h --help --output-file"
 }
 
 _spack_deactivate() {


### PR DESCRIPTION
This is the start of work to be able to use spack to generate workflow files that can be used to install software in a view. This technically works, but there is some limit in spack where (given too many cores are given to snakemake) some of the jobs appear to not be allowed to run (there is some lock) that then times out toward the end:

```bash
==> Error: Failed to install py-lazy-object-proxy due to LockTimeoutError: Timed out waiting for a write lock.
```
So I think perhaps there is a lock somewhere (on the database? or cache?) If we can get a workaround for this, using Snakemake would actually work! It was pretty speedy when I only gave it `--cores 6`.  My suspicion is that it has to do with that, because when I tried it with just `--cores 2` again this morning, it picked up where it left off, and finished the installs without issue.

For some background - the way it works is that we provide workflow steps, each clearly defining input and outputs. The inputs, in this case, are the time log files for packages that are dependencies (or empty if there aren't any) and the outputs are the same log files, which are reliably produced (environment and build logs are not). For the "final" output I chose the last package as determined by the stages derived from the gitlab CI pipeline. It could be that we actually want to include more than one package output here to ensure all steps run, but we can figure that out with further testing.

cc @tgamblin for ideas, and @johanneskoester if you are interested! We chat about this yesterday in https://github.com/snakemake/snakemake/pull/998 and it seemed like a cool idea so I wanted to try it last night. I've added complete docs to the PR in dag.rst for how to reproduce if anyone is interested to try - the Snakefile genereated will be specific for a view. I think once we figure out this lock issue, it would be cool to do the same install, once with and once without snakemake, and see if there is an improvement in overall time.

For provenance, here is the Snakefile that I produced, the start of the run, and the log when there was an error (n=6) and when it finished (n=2)

[Snakefile (specific to my environment)](https://github.com/spack/spack/files/7048399/Snakefile.txt)
[First log (error, N=6) : 2021-08-24T213029.150385.snakemake.log.txt](https://github.com/spack/spack/files/7048400/2021-08-24T213029.150385.snakemake.log.txt)
[Second log (success, N=2) : 2021-08-25T095937.957766.snakemake.log,txt](https://github.com/spack/spack/files/7048404/2021-08-25T095937.957766.snakemake.log.txt)

And a shot of when the run started

![image (2)](https://user-images.githubusercontent.com/814322/130826709-66ed38aa-7ee7-4f42-a7f1-bac178a272e1.png)

**Updated with @scottwittenburg feedback!**

What we can do next:

- [ ] @scottwittenburg is going to refactor the function that returns the specs/dependencies/stages
- [ ] then @vsoch (me!) will refactor the PR here to work with that change
  - [ ] inputs should also include all final time log files for packages in the last stage (or some other subset from the function output)
  - [ ]  we also don't need to concretize - the returned object has another key that should include the already-concretized spec
- [ ] we will need to discuss the lock issue - it should be possible to lock only parts of the database

Signed-off-by: vsoch <vsoch@users.noreply.github.com>