### PR TITLE
Fixing bugs with new package updates for samtools and abi-dumper

### DIFF
--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -33,7 +33,9 @@ class Samtools(Package):
     depends_on('python', type='run')
 
     # htslib became standalone @1.3.1, must use corresponding version
+    depends_on('htslib@1.13', when='@1.13')
     depends_on('htslib@1.12', when='@1.12')
+    depends_on('htslib@1.11', when='@1.11')
     depends_on('htslib@1.10.2', when='@1.10')
     depends_on('htslib@1.9', when='@1.9')
     depends_on('htslib@1.8', when='@1.8')

--- a/var/spack/repos/builtin/packages/universal-ctags/package.py
+++ b/var/spack/repos/builtin/packages/universal-ctags/package.py
@@ -22,3 +22,4 @@ class UniversalCtags(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('libiconv', type='link')
+    depends_on('pkg-config', type='build')


### PR DESCRIPTION
samtools needed more constraints for htslib, and abi-dumper was missing pkg-config on the dependency universal ctags

You can see successful builds here:
 - https://github.com/autamus/registry/actions/runs/1167444242
 - https://github.com/autamus/registry/actions/runs/1167274397

Signed-off-by: vsoch <vsoch@users.noreply.github.com>