### PR TITLE
Load package environment prior to stand-alone/smoke test execution

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -61,6 +61,7 @@ import spack.repo
 import spack.schema.environment
 import spack.store
 import spack.subprocess_context
+import spack.user_environment
 import spack.util.path
 from spack.error import NoHeadersError, NoLibrariesError
 from spack.util.cpus import cpus_available
@@ -69,6 +70,7 @@ from spack.util.environment import (
     env_flag,
     filter_system_paths,
     get_path,
+    inspect_path,
     is_system_path,
     preserve_environment,
     system_dirs,
@@ -781,8 +783,14 @@ def setup_package(pkg, dirty, context='build'):
                       "config to assume that the package is part of the system"
                       " includes and omit it when invoked with '--cflags'.")
     elif context == 'test':
+        env.extend(
+            inspect_path(
+                pkg.spec.prefix,
+                spack.user_environment.prefix_inspections(pkg.spec.platform),
+                exclude=is_system_path
+            )
+        )
         pkg.setup_run_environment(env)
-        pkg.setup_package_environment()
         env.prepend_path('PATH', '.')
 
     # Loading modules, in particular if they are meant to be used outside

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -782,6 +782,7 @@ def setup_package(pkg, dirty, context='build'):
                       " includes and omit it when invoked with '--cflags'.")
     elif context == 'test':
         pkg.setup_run_environment(env)
+        pkg.setup_package_environment()
         env.prepend_path('PATH', '.')
 
     # Loading modules, in particular if they are meant to be used outside

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -52,6 +52,7 @@ import spack.paths
 import spack.repo
 import spack.store
 import spack.url
+import spack.user_environment
 import spack.util.environment
 import spack.util.web
 from spack.filesystem_view import YamlFilesystemView
@@ -2021,6 +2022,23 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         if legacy_fn:
             _ = spack.util.environment.EnvironmentModifications()
             legacy_fn(env, _)
+
+    def setup_package_environment(self):
+        """Sets up the package environment for a package.
+
+        This method "loads" the package's environment, making it useful
+        for operations like stand-alone/smoke testing.
+        """
+        env_mod = spack.util.environment.EnvironmentModifications()
+        spec = self.spec
+        env_mod.extend(
+            spack.user_environment.environment_modifications_for_spec(spec)
+        )
+        env_mod.prepend_path(
+            spack.user_environment.spack_loaded_hashes_var,
+            spec.dag_hash()
+        )
+        env_mod.apply_modifications()
 
     def setup_run_environment(self, env):
         """Sets up the run environment for a package.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -52,7 +52,6 @@ import spack.paths
 import spack.repo
 import spack.store
 import spack.url
-import spack.user_environment
 import spack.util.environment
 import spack.util.web
 from spack.filesystem_view import YamlFilesystemView
@@ -2022,23 +2021,6 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         if legacy_fn:
             _ = spack.util.environment.EnvironmentModifications()
             legacy_fn(env, _)
-
-    def setup_package_environment(self):
-        """Sets up the package environment for a package.
-
-        This method "loads" the package's environment, making it useful
-        for operations like stand-alone/smoke testing.
-        """
-        env_mod = spack.util.environment.EnvironmentModifications()
-        spec = self.spec
-        env_mod.extend(
-            spack.user_environment.environment_modifications_for_spec(spec)
-        )
-        env_mod.prepend_path(
-            spack.user_environment.spack_loaded_hashes_var,
-            spec.dag_hash()
-        )
-        env_mod.apply_modifications()
 
     def setup_run_environment(self, env):
         """Sets up the run environment for a package.


### PR DESCRIPTION
Fixes #25618 
Fixes #25093 

This PR has been tested on MacOS with Python 3.8.2 and 2.7.16.

~The initial commit only does the equivalent of a `spack load` on the package itself, not any dependencies.~

~It also loads the settings for each package before testing.  It does not load the settings for all packages being tested before testing any.  Why you may ask?  Because you may want to test multiple versions of a package with a single `spack test run` and some stand-alone tests confirm that they are running an executable associated with the installation being tested.  Such tests will fail if the paths for all specs are each prepended in advance.~