### PR TITLE
Avoid double loop in subprocess_context.store_patches

### DIFF
--- a/lib/spack/spack/subprocess_context.py
+++ b/lib/spack/spack/subprocess_context.py
@@ -139,16 +139,15 @@ def store_patches():
     class_patches = list()
     if not patches:
         return TestPatches(list(), list())
-    for patch in patches:
-        for target, name, _ in patches:
-            if isinstance(target, ModuleType):
-                new_val = getattr(target, name)
-                module_name = target.__name__
-                module_patches.append((module_name, name, new_val))
-            elif isinstance(target, type):
-                new_val = getattr(target, name)
-                class_fqn = '.'.join([target.__module__, target.__name__])
-                class_patches.append((class_fqn, name, new_val))
+    for target, name, _ in patches:
+        if isinstance(target, ModuleType):
+            new_val = getattr(target, name)
+            module_name = target.__name__
+            module_patches.append((module_name, name, new_val))
+        elif isinstance(target, type):
+            new_val = getattr(target, name)
+            class_fqn = '.'.join([target.__module__, target.__name__])
+            class_patches.append((class_fqn, name, new_val))
 
     return TestPatches(module_patches, class_patches)
 


### PR DESCRIPTION
fixes #21643

As far as I can see the double loop is not needed, since "patch" is never used and the items in the list are tuples of three values.

This code is exercised only during unit-tests, the portion that constructs the list is:

https://github.com/spack/spack/blob/4ddc0ff218d5ed0968f6efb0fac855b1b7127375/lib/spack/spack/test/conftest.py#L69-L82