### PR TITLE
Regenerate views + log links as hooks

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -761,7 +761,7 @@ In this example, we use it outside of a logger that is already defined:
     import spack.hooks
 
     # We do something here to generate a logger and message
-    spack.hooks.post_log_write(message, logger.level)
+    spack.hooks.runner('post_log_write', message, logger.level)
 
 
 This is not to say that this would be the best way to implement an integration

--- a/lib/spack/spack/analyzers/analyzer_base.py
+++ b/lib/spack/spack/analyzers/analyzer_base.py
@@ -113,4 +113,4 @@ class AnalyzerBase(object):
                 spack.monitor.write_json(result[self.name], outfile)
 
         # This hook runs after a save result
-        spack.hooks.on_analyzer_save(self.spec.package, result)
+        spack.hooks.runner('on_analyzer_save', self.spec.package, result)

--- a/lib/spack/spack/analyzers/libabigail.py
+++ b/lib/spack/spack/analyzers/libabigail.py
@@ -113,4 +113,5 @@ class Libabigail(AnalyzerBase):
             # A result needs an analyzer, value or binary_value, and name
             data = {"value": content, "install_file": rel_path, "name": "abidw-xml"}
             tty.info("Sending result for %s %s to monitor." % (name, rel_path))
-            spack.hooks.on_analyzer_save(self.spec.package, {"libabigail": [data]})
+            spack.hooks.runner('on_analyzer_save', self.spec.package, {
+                "libabigail": [data]})

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -544,7 +544,7 @@ def install_tarball(spec, args):
             tty.msg('Installing buildcache for spec %s' % spec.format())
             bindist.extract_tarball(spec, tarball, args.allow_root,
                                     args.unsigned, args.force)
-            spack.hooks.post_install(spec)
+            spack.hooks.runner('post_install', spec)
             spack.store.db.add(spec, spack.store.layout)
         else:
             tty.die('Download of binary cache file for spec %s failed.' %

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1817,7 +1817,7 @@ class Environment(object):
             self.regenerate_views()
 
             # Run post_env_hooks
-            spack.hooks.post_env_write(self)
+            spack.hooks.runner('post_env_write', self)
 
         # new specs and new installs reset at write time
         self.new_specs = []

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -36,7 +36,7 @@ class HookRunner(object):
     #: all HookRunner objects
     _hooks = None
 
-    def __init__(self, hooks):
+    def __init__(self, hooks=None):
         self.hooks_names = hooks or []
 
     def _init_hooks(cls):

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -36,8 +36,8 @@ class HookRunner(object):
     #: all HookRunner objects
     _hooks = None
 
-    def __init__(self, hooks=[]):
-        self.hooks_names = hooks
+    def __init__(self, hooks):
+        self.hooks_names = hooks or []
 
     def _init_hooks(cls):
         # Lazily populate the list of hooks
@@ -82,7 +82,8 @@ runner = _default_runner
 @contextlib.contextmanager
 def use_hook_runner(new_runner):
     global runner
-    old_runner = runner
-    runner = new_runner
-    yield
-    runner = old_runner
+    old_runner, runner = runner, new_runner
+    try:
+        yield
+    finally:
+        runner = old_runner

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -22,6 +22,7 @@ Currently the following hooks are supported:
     * on_phase_error(pkg, phase_name, log_file)
     * on_phase_error(pkg, phase_name, log_file)
     * on_analyzer_save(pkg, result)
+    * post_env_install(env, new_installs)
     * post_env_write(env)
 
 This can be used to implement support for things like module
@@ -72,7 +73,9 @@ _default_runner = HookRunner([
     'permissions_setters',
     'monitor',
     'sbang',
-    'write_install_manifest'
+    'env_install_log_links',
+    'env_regenerate_view',
+    'write_install_manifest',
 ])
 
 

--- a/lib/spack/spack/hooks/env_install_log_links.py
+++ b/lib/spack/spack/hooks/env_install_log_links.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from llnl.util import tty
+
+
+def post_env_install(env, new_installs):
+    """
+    Install log links for all newly installed specs in an environment
+
+    Parameters:
+        env (spack.environment.Environment): the environment
+        new_installs (list): list of newly installed specs
+    """
+    for spec in new_installs:
+        try:
+            env._install_log_links(spec)
+        except OSError as e:
+            tty.warn('Could not install log links for {0}: {1}'
+                     .format(spec.name, str(e)))

--- a/lib/spack/spack/hooks/env_regenerate_view.py
+++ b/lib/spack/spack/hooks/env_regenerate_view.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+def post_env_install(env, new_installs):
+    """
+    Update the view of an environment after installation.
+
+    Parameters:
+        env (spack.environment.Environment): the environment
+        new_installs (list): list of newly installed specs
+    """
+    with env.write_transaction():
+        env.regenerate_views()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2190,7 +2190,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
             if pkg is not None:
                 try:
-                    spack.hooks.pre_uninstall(spec)
+                    spack.hooks.runner('pre_uninstall', spec)
                 except Exception as error:
                     if force:
                         error_msg = (
@@ -2227,7 +2227,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         if pkg is not None:
             try:
-                spack.hooks.post_uninstall(spec)
+                spack.hooks.runner('post_uninstall', spec)
             except Exception:
                 # If there is a failure here, this is our only chance to do
                 # something about it: at this point the Spec has been removed

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -15,6 +15,7 @@ import llnl.util.tty as tty
 import spack.binary_distribution
 import spack.compilers
 import spack.directory_layout as dl
+import spack.hooks
 import spack.installer as inst
 import spack.package_prefs as prefs
 import spack.repo
@@ -176,9 +177,10 @@ def test_install_from_cache_ok(install_mockery, monkeypatch):
     spec = spack.spec.Spec('trivial-install-test-package')
     spec.concretize()
     monkeypatch.setattr(inst, '_try_install_from_binary_cache', _true)
-    monkeypatch.setattr(spack.hooks, 'post_install', _noop)
 
-    assert inst._install_from_cache(spec.package, True, True, False)
+    # Disable hooks.
+    with spack.hooks.use_hook_runner(spack.hooks.HookRunner()):
+        assert inst._install_from_cache(spec.package, True, True, False)
 
 
 def test_process_external_package_module(install_mockery, monkeypatch, capfd):


### PR DESCRIPTION
This builds on top of https://github.com/spack/spack/pull/25573 and should make it easier to disable view regeneration & log links stuff in tests. Potentially it could speed up tests, see https://github.com/spack/spack/issues/25541.

Finally it's a step towards solving https://github.com/spack/spack/issues/25532, where this does not work:

```python
from spack.environment import Environment
with open("spack.yaml", 'w') as f:
    f.write("""\
spack:
  config:
    install_tree:
      root: ./store
  specs:
    - zlib
""")

with Environment(".") as e:
  e.concretize()
  print(e.all_specs()) # [zlib@1.2.11%gcc@10.3.0+optimize+pic+shared arch=linux-ubuntu20.04-zen2]
  e.install_all()
  print(e.all_specs()) # [] empty array?!
```

and now the problematic `regenerate_views` inside a write transaction can at least be disabled:

```python
# only need to disable 'env_regenerate_view' really, but disabling all now:
with spack.hooks.use_hook_runner(spack.hooks.HookRunner()):
  with Environment(".") as e:
    e.concretize()
    print(e.all_specs()) # [zlib@1.2.11%gcc@10.3.0+optimize+pic+shared arch=linux-ubuntu20.04-zen2]
    e.install_all()
    print(e.all_specs()) # [zlib@1.2.11%gcc@10.3.0+optimize+pic+shared arch=linux-ubuntu20.04-zen2] yay.
```

TODO:
- [ ] think a bit more about `self.new_installs` and `self.new_specs`
- [ ] see if we can avoid _re_read altogether, cause there's an assumption the env is persisted to disk before calling install_all