### PR TITLE
add 'develop' branch to cmake package

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -19,7 +19,7 @@ class Cmake(Package):
 
     executables = ['^cmake$']
 
-    version('develop',  branch='master')
+    version('master',  branch='master')
     version('3.21.2',   sha256='94275e0b61c84bb42710f5320a23c6dcb2c6ee032ae7d2a616f53f68b3d21659')
     version('3.21.1',   sha256='fac3915171d4dff25913975d712f76e69aef44bf738ba7b976793a458b4cfed4')
     version('3.21.0',   sha256='4a42d56449a51f4d3809ab4d3b61fd4a96a469e56266e896ce1009b5768bd2ab')

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -12,12 +12,15 @@ class Cmake(Package):
     """
     homepage = 'https://www.cmake.org'
     url = 'https://github.com/Kitware/CMake/releases/download/v3.19.0/cmake-3.19.0.tar.gz'
+    git = 'https://gitlab.kitware.com/cmake/cmake.git'
     maintainers = ['chuckatkins']
 
     tags = ['build-tools']
 
     executables = ['^cmake$']
 
+    version('develop',  branch='master')
+    version('3.21.2',   sha256='94275e0b61c84bb42710f5320a23c6dcb2c6ee032ae7d2a616f53f68b3d21659')
     version('3.21.1',   sha256='fac3915171d4dff25913975d712f76e69aef44bf738ba7b976793a458b4cfed4')
     version('3.21.0',   sha256='4a42d56449a51f4d3809ab4d3b61fd4a96a469e56266e896ce1009b5768bd2ab')
     version('3.20.5',   sha256='12c8040ef5c6f1bc5b8868cede16bb7926c18980f59779e299ab52cbc6f15bb0')


### PR DESCRIPTION
And also add the latest release 3.21.2, while I was at it.

Obviously, the `develop` branch is a moving target, but it's still useful if one wants to try out the latest and greatest -- and the latest release remains the preferred version, so it doesn't interfere unless one explicitly asks for `@develop`.

@chuckatkins 