### PR TITLE
Fix JSONDecodeError when using compiler modules

### DIFF
--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -989,7 +989,7 @@ def environment_after_sourcing_files(*files, **kwargs):
         python_cmd = python_cmd.name if python_cmd else sys.executable
 
         dump_cmd = 'import os, json; print(json.dumps(dict(os.environ)))'
-        dump_environment = python_cmd + ' -c "{0}"'.format(dump_cmd)
+        dump_environment = python_cmd + ' -E -c "{0}"'.format(dump_cmd)
 
         # Try to source the file
         source_file_arguments = ' '.join([

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -47,7 +47,7 @@ def module(*args):
         module_cmd += 'LD_LIBRARY_PATH="$SPACK_LD_LIBRARY_PATH" '
 
         # Execute the python command
-        module_cmd += '%s -c "%s";' % (sys.executable, py_cmd)
+        module_cmd += '%s -E -c "%s";' % (sys.executable, py_cmd)
 
         # If LD_LIBRARY_PATH was set after `module`, dump the old value because
         # we have since corrupted it to ensure python would run.


### PR DESCRIPTION
When using modules for compiler (and/or external package), if a package's `setup_[dependent_]build_environment` set `PYTHONHOME`, it can influence the python [subprocess executed to gather module information](https://github.com/spack/spack/blob/4ddc0ff218d5ed0968f6efb0fac855b1b7127375/lib/spack/spack/util/module_cmd.py#L50):

Spack failed with this error:

```
  File "spack/var/spack/repos/builtin/packages/harfbuzz/package.py", line 50, in configure_args
    args.append('CXXFLAGS={0}'.format(self.compiler.cxx11_flag))
  File "spack/lib/spack/spack/compilers/gcc.py", line 66, in cxx11_flag
    if self.real_version < ver('4.3'):
  File "spack/lib/spack/spack/compiler.py", line 348, in real_version
    self.get_real_version())
  File "spack/lib/spack/spack/compiler.py", line 524, in get_real_version
    with self._compiler_environment():
  File "/usr/lib64/python3.6/contextlib.py", line 81, in __enter__
    return next(self.gen)
  File "spack/lib/spack/spack/compiler.py", line 609, in _compiler_environment
    spack.util.module_cmd.load_module(module)
  File "spack/lib/spack/spack/util/module_cmd.py", line 106, in load_module
    module('unload', text[i + 1])
  File "spack/lib/spack/spack/util/module_cmd.py", line 73, in module
    env_dict = json.loads(env_json)
  File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

But the actual hidden error happened in the `python -c 'import json...'` subprocess, which made it output nothing on stdout, and on stderr:

```
ModuleNotFoundError: No module named 'encodings'
```

This fix uses `python -E` to ignore `PYTHONHOME` and `PYTHONPATH`. Should be safe here because the python subprocess code only use packages built-in to python.

The python subprocess in `environment.py` was also patched to be safe and consistent.