### PR TITLE
Make env (de)activate error with -e, -E, -D flags

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -88,6 +88,11 @@ def env_activate(args):
         )
         return 1
 
+    # Error out when -e, -E, -D flags are given, cause they are ambiguous.
+    if args.env or args.no_env or args.env_dir:
+        tty.die('Calling spack env activate with --env, --env-dir and --no-env '
+                'is ambiguous')
+
     if ev.exists(env) and not args.dir:
         spack_env = ev.root(env)
         short_name = env
@@ -136,6 +141,11 @@ def env_deactivate(args):
             "    eval `spack env deactivate {sh_arg}`",
         )
         return 1
+
+    # Error out when -e, -E, -D flags are given, cause they are ambiguous.
+    if args.env or args.no_env or args.env_dir:
+        tty.die('Calling spack env deactivate with --env, --env-dir and --no-env '
+                'is ambiguous')
 
     if 'SPACK_ENV' not in os.environ:
         tty.die('No environment is currently active.')


### PR DESCRIPTION
Bit of a trivial issue, but came up here:

https://github.com/spack/spack/pull/25409#discussion_r695850783
