### PR TITLE
Make `SpecBuildInterface` pickleable

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -321,7 +321,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.6, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -337,11 +337,15 @@ jobs:
       run: |
         brew install dash fish gcc gnupg2 kcov
     - name: Run unit tests
+      env:
+        SPACK_TEST_SOLVER: clingo
       run: |
         git --version
         . .github/workflows/setup_git.sh
         . share/spack/setup-env.sh
-        if [ "${{ needs.changes.outputs.with_coverage }}" == "true" ]
+        $(which spack) bootstrap untrust spack-install
+        $(which spack) solve zlib
+        if [ "${{ needs.changes.outputs.with_coverage }}" == "true" && "${{ matrix.python-version }}" == "3.8" ]
         then
           coverage run $(which spack) unit-test -x
           coverage combine

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -345,7 +345,7 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap untrust spack-install
         $(which spack) solve zlib
-        if [ "${{ needs.changes.outputs.with_coverage }}" == "true" && "${{ matrix.python-version }}" == "3.8" ]
+        if [ "${{ needs.changes.outputs.with_coverage }}" == "true" ] && [ "${{ matrix.python-version }}" == "3.8" ]
         then
           coverage run $(which spack) unit-test -x
           coverage combine

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -321,7 +321,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.9]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -345,7 +345,7 @@ jobs:
         . share/spack/setup-env.sh
         $(which spack) bootstrap untrust spack-install
         $(which spack) solve zlib
-        if [ "${{ needs.changes.outputs.with_coverage }}" == "true" ] && [ "${{ matrix.python-version }}" == "3.8" ]
+        if [ "${{ needs.changes.outputs.with_coverage }}" == "true" ]
         then
           coverage run $(which spack) unit-test -x
           coverage combine

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1019,13 +1019,18 @@ class SpecBuildInterface(lang.ObjectWrapper):
 
     def __init__(self, spec, name, query_parameters):
         super(SpecBuildInterface, self).__init__(spec)
-
+        # Adding new attributes goes after super() call since the ObjectWrapper
+        # resets __dict__ to behave like the passed object
+        self.token = spec, name, query_parameters
         is_virtual = spack.repo.path.is_virtual(name)
         self.last_query = QueryState(
             name=name,
             extra_parameters=query_parameters,
             isvirtual=is_virtual
         )
+
+    def __reduce__(self):
+        return SpecBuildInterface, self.token
 
 
 @lang.lazy_lexicographic_ordering(set_hash=False)


### PR DESCRIPTION
fixes #21215 

This PR makes two unit tests that were failing on macOS, with Python 3.8 and `clingo` PASS. The fix for that was adding an explicit `__reduce__` method to the `SpecBuildInterface`, which is an object wrapper around a spec. Without it `pickle` _sometimes_ would try to search for the wrapped class in the module containing the base class of `SpecBuildInterface`. 

Modifications:

- [x] Add a `__reduce__` method to `SpecBuildInterface`
- [x] Switch the macOS unit tests to `clingo` to check that #21215 is effectively solved

There are still questions I don't know how to answer:
- Why only those two tests were failing, given the abundance of use of the subscript notation with specs?
- Are there other classes that may need to be serialized explicitly?