### PR TITLE
py-black: add new version, missing dep

### DIFF
--- a/var/spack/repos/builtin/packages/py-black/package.py
+++ b/var/spack/repos/builtin/packages/py-black/package.py
@@ -15,6 +15,7 @@ class PyBlack(PythonPackage):
     homepage = "https://github.com/psf/black"
     pypi = "black/black-20.8b1.tar.gz"
 
+    version('21.7b0', sha256='c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219')
     version('21.6b0', sha256='dc132348a88d103016726fe360cb9ede02cecf99b76e3660ce6c596be132ce04')
     version('21.4b0', sha256='915d916c48646dbe8040d5265cff7111421a60a3dfe7f7e07273176a57c24a34')
     version('20.8b1', sha256='1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea')
@@ -30,14 +31,16 @@ class PyBlack(PythonPackage):
     # Needs setuptools at runtime so that `import pkg_resources` succeeds
     # See #8843 and #8689 for examples of setuptools added as a runtime dep
     depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-setuptools-scm', when='@19.10:', type='build')
     # Translated from black's setup.py:
     # https://github.com/ambv/black/blob/master/setup.py
     depends_on('py-click@6.5:', type=('build', 'run'))
     depends_on('py-click@7.1.2:', when='@20.8b1:', type=('build', 'run'))
     depends_on('py-attrs@18.1.0:', when='@:20.8b0', type=('build', 'run'))
     depends_on('py-appdirs', type=('build', 'run'))
-    depends_on('py-toml@0.9.4:', type=('build', 'run'))
-    depends_on('py-toml@0.10.1:', when='@20.8b1:', type=('build', 'run'))
+    depends_on('py-toml@0.9.4:', when='@:19', type=('build', 'run'))
+    depends_on('py-toml@0.10.1:', when='@20:21.6', type=('build', 'run'))
+    depends_on('py-tomli@0.2.6:1.999', when='@21.7:', type=('build', 'run'))
     depends_on('py-typed-ast@1.4.0:', when='@19.10b0:20', type=('build', 'run'))
     depends_on('py-typed-ast@1.4.2:', when='@21: ^python@:3.7.999', type=('build', 'run'))
     depends_on('py-regex@2020.1.8:', when='@20.8b0:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-tomli/package.py
+++ b/var/spack/repos/builtin/packages/py-tomli/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyTomli(Package):
+    """Tomli is a Python library for parsing TOML.
+
+    Tomli is fully compatible with TOML v1.0.0."""
+
+    homepage = "https://github.com/hukkin/tomli"
+    url = "https://pypi.io/packages/py3/t/tomli/tomli-1.2.1-py3-none-any.whl"
+
+    version('1.2.1', sha256='8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f', expand=False)
+
+    extends('python')
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-pip', type='build')
+
+    def install(self, spec, prefix):
+        # TODO: figure out how to build with flit
+        pip = which('pip')
+        pip('install', self.stage.archive_file, '--prefix={0}'.format(prefix))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.

Also adds a new `py-tomli` package. This package can be built from source using `flit`, but `flit` doesn't seem to have an option to control the installation prefix. For now, I'm just installing the wheel.