### PR TITLE
py-flit: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-flit-core/package.py
+++ b/var/spack/repos/builtin/packages/py-flit-core/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyFlitCore(Package):
+    """Distribution-building parts of Flit."""
+
+    homepage = "https://github.com/takluyver/flit"
+    url = "https://pypi.io/packages/py3/f/flit-core/flit_core-3.3.0-py3-none-any.whl"
+
+    version('3.3.0', sha256='9b247b3095cb3c43933a59a7433f92ddfdd7fc843e08ef0f4550d53a9cfbbef6', expand=False)
+
+    extends('python')
+    depends_on('python@3.4:', type=('build', 'run'))
+    depends_on('py-pip', type='build')
+    depends_on('py-toml', type=('build', 'run'))
+
+    def install(self, spec, prefix):
+        # Install wheel instead of installing from source
+        # to prevent circular dependency on flit
+        pip = which('pip')
+        pip('install', self.stage.archive_file, '--prefix={0}'.format(prefix))

--- a/var/spack/repos/builtin/packages/py-flit/package.py
+++ b/var/spack/repos/builtin/packages/py-flit/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyFlit(PythonPackage):
+    """Flit is a simple way to put Python packages and modules on PyPI."""
+
+    pypi = "flit/flit-3.3.0.tar.gz"
+
+    version('3.3.0', sha256='65fbe22aaa7f880b776b20814bd80b0afbf91d1f95b17235b608aa256325ce57')
+
+    depends_on('py-flit-core@3.3.0:', type=('build', 'run'))
+    depends_on('py-requests', type=('build', 'run'))
+    depends_on('py-docutils', type=('build', 'run'))
+    depends_on('py-toml', type=('build', 'run'))
+
+    def setup_dependent_package(self, module, dependent_spec):
+        module.flit = Executable(self.prefix.bin.flit)


### PR DESCRIPTION
Adds a package for the flit build system.

Successfully installs on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.