### PR TITLE
py-pathlib: prevent conflicts with standard library

### DIFF
--- a/var/spack/repos/builtin/packages/py-geeup/package.py
+++ b/var/spack/repos/builtin/packages/py-geeup/package.py
@@ -29,6 +29,6 @@ class PyGeeup(PythonPackage):
     depends_on('py-pysmartdl', type=('build', 'run'))
     depends_on('py-pysmartdl@1.2.5', type=('build', 'run'), when='^python@:3.3')
     depends_on('py-pysmartdl@1.3.1:', type=('build', 'run'), when='^python@3.4:')
-    depends_on('py-pathlib@1.0.1:', type=('build', 'run'))
+    depends_on('py-pathlib@1.0.1:', when='^python@:3.3', type=('build', 'run'))
     depends_on('py-lxml@4.1.1:', type=('build', 'run'))
     depends_on('py-oauth2client@4.1.3:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-nbmake/package.py
+++ b/var/spack/repos/builtin/packages/py-nbmake/package.py
@@ -20,6 +20,6 @@ class PyNbmake(PythonPackage):
     depends_on('py-ipykernel@5.4.0:5.999', type=('build', 'run'))
     depends_on('py-nbclient@0.3:0.999', type=('build', 'run'))
     depends_on('py-nbformat@5.0.8:5.999', type=('build', 'run'))
-    depends_on('py-pathlib@1.0.1:1.999', type=('build', 'run'))
+    depends_on('py-pathlib@1.0.1:1.999', when='^python@:3.3', type=('build', 'run'))
     depends_on('py-pydantic@1.7.2:1.999', type=('build', 'run'))
     depends_on('py-pytest@6.1.2:6.999', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pathlib/package.py
+++ b/var/spack/repos/builtin/packages/py-pathlib/package.py
@@ -17,3 +17,11 @@ class PyPathlib(PythonPackage):
     pypi = "pathlib/pathlib-1.0.1.tar.gz"
 
     version('1.0.1', sha256='6940718dfc3eff4258203ad5021090933e5c04707d5ca8cc9e73c94a7894ea9f')
+
+    # This is a backport of the pathlib module from Python 3.4. Since pathlib is now
+    # part of the standard library, this module isn't needed in Python 3.4+. Although it
+    # can be installed, differences between this implementation and the standard library
+    # implementation can cause other packages to fail. If it is installed, it ends up
+    # masking the standard library and doesn't have the same features that the standard
+    # library has in newer versions of Python.
+    conflicts('^python@3.4:')


### PR DESCRIPTION
Confirmed that even though these packages explicitly list `pathlib` in `install_requires`, `setuptools` doesn't try to `pip install pathlib` if the Python standard library already contains `pathlib`.