### PR TITLE
py-pyinstrument: add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyinstrument/package.py
+++ b/var/spack/repos/builtin/packages/py-pyinstrument/package.py
@@ -10,12 +10,15 @@ class PyPyinstrument(PythonPackage):
     """Call stack profiler for Python. Shows you why your code is slow!"""
 
     homepage = "https://github.com/joerick/pyinstrument"
-    url      = "https://github.com/joerick/pyinstrument/archive/v3.1.3.tar.gz"
+    pypi = "pyinstrument/pyinstrument-4.0.3.tar.gz"
 
-    version('3.1.3', sha256='ca4571775caa06444cd7e832056afc21175130271fe3f3481e3ab1bf67f96c8b')
-    version('3.1.0', sha256='02319607daf65110e246085f5e2ee111f565f213eed1991229f2d58e9a7657a5')
+    version('4.0.3', sha256='08caf41d21ae8f24afe79c664a34af1ed1e17aa5d4441cd9b1dc15f87bbbac95')
+    version('3.1.3', sha256='353c7000a6563b16c0be0c6a04104d42b3154c5cd7c1979ab66efa5fdc5f5571')
+    version('3.1.0', sha256='10c1fed4996a72c3e1e2bac1940334756894dbd116df3cc3b2d9743f2ae43016')
 
+    depends_on('python@3.7:', when='@4:', type=('build', 'run'))
+    depends_on('python@3.6:', when='@3.3:3.4', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
-    depends_on('py-pytest-runner', type='build')
-    depends_on('npm', type='build')
-    depends_on('py-pyinstrument-cext@0.2.2:', type=('build', 'run'))
+    depends_on('py-pytest-runner', when='@:3.1.3', type='build')
+    depends_on('npm', when='@:3', type='build')
+    depends_on('py-pyinstrument-cext@0.2.2:', when='@:3', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.

This new version no longer requires npm/node-js, which takes a long time to build.