### PR TITLE
Speedup environment activation, part 2

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -257,7 +257,7 @@ class PythonPackage(PackageBase):
         pure_site_packages_dir = spec['python'].package.config_vars[
             'python_lib']['false']['false']
         plat_site_packages_dir = spec['python'].package.config_vars[
-            'python_lib']['false']['true']
+            'python_lib']['true']['false']
         inc_dir = spec['python'].package.config_vars['python_inc']
 
         args += ['--root=%s' % prefix,

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -128,7 +128,7 @@ class PythonPackage(PackageBase):
         """
         modules = []
         root = os.path.join(
-            self.prefix, self.spec['python'].package.config_vars[False][False]
+            self.prefix, self.spec['python'].package.config_vars['false']['false']
         )
 
         # Some Python libraries are packages: collections of modules
@@ -255,9 +255,9 @@ class PythonPackage(PackageBase):
         # We query the python with which these will be used for the lib and inc
         # directories. This ensures we use `lib`/`lib64` as expected by python.
         pure_site_packages_dir = spec['python'].package.config_vars[
-            'python_lib'][False][False]
+            'python_lib']['false']['false']
         plat_site_packages_dir = spec['python'].package.config_vars[
-            'python_lib'][False][True]
+            'python_lib']['false']['true']
         inc_dir = spec['python'].package.config_vars['python_inc']
 
         args += ['--root=%s' % prefix,

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -258,7 +258,7 @@ class PythonPackage(PackageBase):
             'python_lib']['false']['false']
         plat_site_packages_dir = spec['python'].package.config_vars[
             'python_lib']['true']['false']
-        inc_dir = spec['python'].package.config_vars['python_inc']
+        inc_dir = spec['python'].package.config_vars['python_inc']['true']
 
         args += ['--root=%s' % prefix,
                  '--install-purelib=%s' % pure_site_packages_dir,

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -128,7 +128,8 @@ class PythonPackage(PackageBase):
         """
         modules = []
         root = os.path.join(
-            self.prefix, self.spec['python'].package.config_vars['false']['false']
+            self.prefix,
+            self.spec['python'].package.config_vars['python_lib']['false']['false'],
         )
 
         # Some Python libraries are packages: collections of modules

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -127,7 +127,9 @@ class PythonPackage(PackageBase):
             list: list of strings of module names
         """
         modules = []
-        root = self.spec['python'].package.get_python_lib(prefix=self.prefix)
+        root = os.path.join(
+            self.prefix, self.spec['python'].package.config_vars[False][False]
+        )
 
         # Some Python libraries are packages: collections of modules
         # distributed in directories containing __init__.py files
@@ -252,12 +254,11 @@ class PythonPackage(PackageBase):
         # Get all relative paths since we set the root to `prefix`
         # We query the python with which these will be used for the lib and inc
         # directories. This ensures we use `lib`/`lib64` as expected by python.
-        pure_site_packages_dir = spec['python'].package.get_python_lib(
-            plat_specific=False, prefix='')
-        plat_site_packages_dir = spec['python'].package.get_python_lib(
-            plat_specific=True, prefix='')
-        inc_dir = spec['python'].package.get_python_inc(
-            plat_specific=True, prefix='')
+        pure_site_packages_dir = spec['python'].package.config_vars[
+            'python_lib'][False][False]
+        plat_site_packages_dir = spec['python'].package.config_vars[
+            'python_lib'][False][True]
+        inc_dir = spec['python'].package.config_vars['python_inc']
 
         args += ['--root=%s' % prefix,
                  '--install-purelib=%s' % pure_site_packages_dir,

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -65,7 +65,8 @@ class SIPPackage(PackageBase):
         """
         modules = []
         root = os.path.join(
-            self.prefix, self.spec['python'].package.config_vars['false']['false']
+            self.prefix,
+            self.spec['python'].package.config_vars['python_lib']['false']['false'],
         )
 
         # Some Python libraries are packages: collections of modules

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -65,7 +65,7 @@ class SIPPackage(PackageBase):
         """
         modules = []
         root = os.path.join(
-            self.prefix, self.spec['python'].package.config_vars[False][False]
+            self.prefix, self.spec['python'].package.config_vars['false']['false']
         )
 
         # Some Python libraries are packages: collections of modules

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -64,7 +64,9 @@ class SIPPackage(PackageBase):
             list: list of strings of module names
         """
         modules = []
-        root = self.spec['python'].package.get_python_lib(prefix=self.prefix)
+        root = os.path.join(
+            self.prefix, self.spec['python'].package.config_vars[False][False]
+        )
 
         # Some Python libraries are packages: collections of modules
         # distributed in directories containing __init__.py files

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -66,7 +66,8 @@ class Clingo(CMakePackage):
         current spec is the one found by CMake find_package(Python, ...)
         """
         python_spec = self.spec['python']
-        include_dir = python_spec.package.config_vars['python_inc']
+        include_dir = join_path(
+            python_spec.prefix, python_spec.package.config_vars['python_inc'])
         return [
             self.define('Python_EXECUTABLE', str(python_spec.command)),
             self.define('Python_INCLUDE_DIR', include_dir)

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -67,7 +67,7 @@ class Clingo(CMakePackage):
         """
         python_spec = self.spec['python']
         include_dir = join_path(
-            python_spec.prefix, python_spec.package.config_vars['python_inc'])
+            python_spec.prefix, python_spec.package.config_vars['python_inc']['false'])
         return [
             self.define('Python_EXECUTABLE', str(python_spec.command)),
             self.define('Python_INCLUDE_DIR', include_dir)

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -66,7 +66,7 @@ class Clingo(CMakePackage):
         current spec is the one found by CMake find_package(Python, ...)
         """
         python_spec = self.spec['python']
-        include_dir = python_spec.package.get_python_inc()
+        include_dir = python_spec.package.config_vars['python_inc']
         return [
             self.define('Python_EXECUTABLE', str(python_spec.command)),
             self.define('Python_INCLUDE_DIR', include_dir)

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -63,7 +63,7 @@ class Migraphx(CMakePackage):
         """
         python_spec = self.spec['python']
         include_dir = join_path(
-            python_spec.prefix, python_spec.package.config_vars['python_inc'])
+            python_spec.prefix, python_spec.package.config_vars['python_inc']['false'])
         return [
             self.define('Python_INCLUDE_DIR', include_dir)
         ]

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -62,7 +62,8 @@ class Migraphx(CMakePackage):
         CMake based on current spec
         """
         python_spec = self.spec['python']
-        include_dir = python_spec.package.config_vars['python_inc']
+        include_dir = join_path(
+            python_spec.prefix, python_spec.package.config_vars['python_inc'])
         return [
             self.define('Python_INCLUDE_DIR', include_dir)
         ]

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -62,7 +62,7 @@ class Migraphx(CMakePackage):
         CMake based on current spec
         """
         python_spec = self.spec['python']
-        include_dir = python_spec.package.get_python_inc()
+        include_dir = python_spec.package.config_vars['python_inc']
         return [
             self.define('Python_INCLUDE_DIR', include_dir)
         ]

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -698,6 +698,8 @@ class Python(AutotoolsPackage):
         """
         # TODO: distutils is deprecated in Python 3.10 and will be removed in
         # Python 3.12, find a different way to access this information.
+        # Also, calling the python executable disallows us from cross-compiling,
+        # so we want to try to avoid that if possible.
         cmd = """
 import json
 from distutils.sysconfig import (

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -720,7 +720,8 @@ for plat_specific in [True, False]:
         )
 
 {0}
-""".format(self.print_string("json.dumps(config)"))
+""".format(self.print_string("json.dumps(config)"))  # novm
+        # vermin false positive: https://github.com/netromdk/vermin/issues/75
 
         try:
             return json.loads(self.command('-c', cmd, output=str))
@@ -859,7 +860,7 @@ for plat_specific in [True, False]:
             str: standard library directory
         """
         if 'python_lib' in self.config_vars:
-            return self.config_vars['python_lib'][False][True]
+            return self.config_vars['python_lib']['false']['true']
         else:
             return os.path.join('lib', 'python{0}'.format(self.version.up_to(2)))
 
@@ -883,7 +884,7 @@ for plat_specific in [True, False]:
             str: site-packages directory
         """
         if 'python_lib' in self.config_vars:
-            return self.config_vars['python_lib'][False][False]
+            return self.config_vars['python_lib']['false']['false']
         else:
             return self.default_site_packages_dir
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -710,18 +710,17 @@ config = get_config_vars()
 config['config_h_filename'] = get_config_h_filename()
 config['makefile_filename'] = get_makefile_filename()
 config['python_inc'] = get_python_inc(prefix='')
-config['python_lib'] = {{}}
+config['python_lib'] = {}
 
 for plat_specific in [True, False]:
-    config['python_lib'][plat_specific] = {{}}
+    config['python_lib'][plat_specific] = {}
     for standard_lib in [True, False]:
         config['python_lib'][plat_specific][standard_lib] = get_python_lib(
             plat_specific, standard_lib, prefix=''
         )
 
-{0}
-""".format(self.print_string("json.dumps(config)"))  # novm
-        # vermin false positive: https://github.com/netromdk/vermin/issues/75
+%s
+""" % self.print_string("json.dumps(config)")
 
         try:
             return json.loads(self.command('-c', cmd, output=str))

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -713,7 +713,7 @@ from distutils.sysconfig import (
 config = get_config_vars()
 config['config_h_filename'] = get_config_h_filename()
 config['makefile_filename'] = get_makefile_filename()
-config['python_inc'] = get_python_inc(prefix='')
+config['python_inc'] = get_python_inc(True, prefix='')
 config['python_lib'] = {}
 
 for plat_specific in [True, False]:

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -713,10 +713,11 @@ from distutils.sysconfig import (
 config = get_config_vars()
 config['config_h_filename'] = get_config_h_filename()
 config['makefile_filename'] = get_makefile_filename()
-config['python_inc'] = get_python_inc(True, prefix='')
+config['python_inc'] = {}
 config['python_lib'] = {}
 
 for plat_specific in [True, False]:
+    config['python_inc'][plat_specific] = get_python_inc(plat_specific, prefix='')
     config['python_lib'][plat_specific] = {}
     for standard_lib in [True, False]:
         config['python_lib'][plat_specific][standard_lib] = get_python_lib(
@@ -841,7 +842,7 @@ for plat_specific in [True, False]:
             str: include files directory
         """
         if 'python_inc' in self.config_vars:
-            return self.config_vars['python_inc']
+            return self.config_vars['python_inc']['false']
         else:
             return os.path.join('include', 'python{0}'.format(self.version.up_to(2)))
 


### PR DESCRIPTION
This is a direct followup to #13557 which caches additional attributes that were added in #24095 that are expensive to compute. I had to reopen #25556 in another PR to invalidate the GitLab CI cache, but see #25556 for prior discussion.

### Before

```console
$ time spack env activate .

real	2m13.037s
user	1m25.584s
sys	0m43.654s
$ time spack env view regenerate
==> Updating view at /Users/Adam/.spack/.spack-env/view

real	16m3.541s
user	10m28.892s
sys	4m57.816s
$ time spack env deactivate

real	2m30.974s
user	1m38.090s
sys	0m49.781s
```

### After
```console
$ time spack env activate .

real	0m8.937s
user	0m7.323s
sys	0m1.074s
$ time spack env view regenerate
==> Updating view at /Users/Adam/.spack/.spack-env/view

real	2m22.024s
user	1m44.739s
sys	0m30.717s
$ time spack env deactivate

real	0m10.398s
user	0m8.414s
sys	0m1.630s
```

Fixes #25555
Fixes #25541