### PR TITLE
MPICH: Add E4S testsuite stand alone test

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -481,13 +481,13 @@ spack package at this time.''',
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(join_path('test', 'mpi'))
+        self.cache_extra_test_sources(['examples', join_path('test', 'mpi')])
 
-    def run_mpi_test(self, mpi_dir, exe):
+    def run_mpich_test(self, example_dir, exe):
         """Run stand alone tests"""
 
         test_dir = join_path(self.test_suite.current_test_cache_dir,
-                             'test', 'mpi', mpi_dir)
+                             example_dir)
         exe_source = join_path(test_dir, '{0}.c'.format(exe))
 
         if not os.path.isfile(exe_source):
@@ -504,6 +504,7 @@ spack package at this time.''',
                       work_dir=test_dir)
 
     def test(self):
-        self.run_mpi_test('init', 'finalized')
-        self.run_mpi_test('basic', 'sendrecv')
-        self.run_mpi_test('ft', 'bcast')
+        self.run_mpich_test(join_path('test', 'mpi', 'init'), 'finalized')
+        self.run_mpich_test(join_path('test', 'mpi', 'basic'), 'sendrecv')
+        self.run_mpich_test('examples', 'cpi')
+        self.run_mpich_test('examples', 'ircpi')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -506,5 +506,5 @@ spack package at this time.''',
     def test(self):
         self.run_mpich_test(join_path('test', 'mpi', 'init'), 'finalized')
         self.run_mpich_test(join_path('test', 'mpi', 'basic'), 'sendrecv')
+        self.run_mpich_test(join_path('test', 'mpi', 'perf'), 'manyrma')
         self.run_mpich_test('examples', 'cpi')
-        self.run_mpich_test('examples', 'ircpi')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -481,43 +481,20 @@ spack package at this time.''',
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(['test'])
+        self.cache_extra_test_sources(join_path('test', 'mpi'))
 
-    def run_finalized_test(self, test_dir, exe):
-        """Run stand alone test: finalized"""
+    def run_test(self, test_dir, exe):
+        """Run stand alone tests"""
 
-        if not os.path.isfile(join_path(test_dir, exe)):
-            print('Skipping finalized test')
+        exe_source = join_path(test_dir, '{0}.c'.format(exe))
+
+        if not os.path.isfile(exe_source):
+            print('Skipping {0} test'.format(exe))
             return
 
         self.run_test(self.prefix.bin.mpicc,
-                      options=['-Wall', '-g',
-                               join_path(test_dir, '{0}.c'.format(exe)),
-                               '-o', exe],
+                      options=[exe_source, '-Wall', '-g', '-o', exe],
                       purpose='test: generate {0} file'.format(exe),
-                      work_dir=test_dir)
-
-        self.run_test(exe,
-                      purpose='test: run {0} example'.format(exe),
-                      work_dir=test_dir)
-
-    def run_sendrecv_test(self):
-        """Run stand alone test: sendrecv"""
-
-        test_dir = join_path(self.test_suite.current_test_cache_dir,
-                             'test', 'mpi')
-
-        if not os.path.exists(test_dir):
-            print('Skipping sendrecv test')
-            return
-
-        exe = 'sendrecv'
-
-        self.run_test(self.prefix.bin.mpicc,
-                      options=['-Wall', '-g',
-                               '{0}'.format(join_path(test_dir, 'basic', 'sendrecv.c')),
-                               '-o', exe],
-                      purpose='test: generate {0}.o file'.format(exe),
                       work_dir=test_dir)
 
         self.run_test(exe,
@@ -526,5 +503,6 @@ spack package at this time.''',
 
     def test(self):
         directory = join_path(self.test_suite.current_test_cache_dir,
-                             'test', 'mpi')
-        self.run_finalized_test(join_path(directory, 'init'), 'finalized')
+                              'test', 'mpi')
+        self.run_test(join_path(directory, 'init'), 'finalized')
+        self.run_test(join_path(directory, 'basic'), 'sendrecv')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -487,7 +487,7 @@ spack package at this time.''',
         """Run stand alone tests"""
 
         test_dir = join_path(self.test_suite.current_test_cache_dir,
-                             'test', 'mpi', mpi_dir )
+                             'test', 'mpi', mpi_dir)
         exe_source = join_path(test_dir, '{0}.c'.format(exe))
 
         if not os.path.isfile(exe_source):
@@ -506,3 +506,4 @@ spack package at this time.''',
     def test(self):
         self.run_mpi_test('init', 'finalized')
         self.run_mpi_test('basic', 'sendrecv')
+        self.run_mpi_test('ft', 'bcast')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -476,3 +476,9 @@ spack package at this time.''',
             config_args.append('--with-argobots=' + spec['argobots'].prefix)
 
         return config_args
+
+    @run_after('install')
+    def cache_test_sources(self):
+        """Copy the example source files after the package is installed to an
+        install test subdirectory for use during `spack test run`."""
+        self.cache_extra_test_sources(['test'])

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -483,9 +483,11 @@ spack package at this time.''',
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(join_path('test', 'mpi'))
 
-    def run_test(self, test_dir, exe):
+    def run_mpi_test(self, mpi_dir, exe):
         """Run stand alone tests"""
 
+        test_dir = join_path(self.test_suite.current_test_cache_dir,
+                             'test', 'mpi', mpi_dir )
         exe_source = join_path(test_dir, '{0}.c'.format(exe))
 
         if not os.path.isfile(exe_source):
@@ -502,7 +504,5 @@ spack package at this time.''',
                       work_dir=test_dir)
 
     def test(self):
-        directory = join_path(self.test_suite.current_test_cache_dir,
-                              'test', 'mpi')
-        self.run_test(join_path(directory, 'init'), 'finalized')
-        self.run_test(join_path(directory, 'basic'), 'sendrecv')
+        self.run_mpi_test('init', 'finalized')
+        self.run_mpi_test('basic', 'sendrecv')

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -482,3 +482,49 @@ spack package at this time.''',
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
         self.cache_extra_test_sources(['test'])
+
+    def run_finalized_test(self, test_dir, exe):
+        """Run stand alone test: finalized"""
+
+        if not os.path.isfile(join_path(test_dir, exe)):
+            print('Skipping finalized test')
+            return
+
+        self.run_test(self.prefix.bin.mpicc,
+                      options=['-Wall', '-g',
+                               join_path(test_dir, '{0}.c'.format(exe)),
+                               '-o', exe],
+                      purpose='test: generate {0} file'.format(exe),
+                      work_dir=test_dir)
+
+        self.run_test(exe,
+                      purpose='test: run {0} example'.format(exe),
+                      work_dir=test_dir)
+
+    def run_sendrecv_test(self):
+        """Run stand alone test: sendrecv"""
+
+        test_dir = join_path(self.test_suite.current_test_cache_dir,
+                             'test', 'mpi')
+
+        if not os.path.exists(test_dir):
+            print('Skipping sendrecv test')
+            return
+
+        exe = 'sendrecv'
+
+        self.run_test(self.prefix.bin.mpicc,
+                      options=['-Wall', '-g',
+                               '{0}'.format(join_path(test_dir, 'basic', 'sendrecv.c')),
+                               '-o', exe],
+                      purpose='test: generate {0}.o file'.format(exe),
+                      work_dir=test_dir)
+
+        self.run_test(exe,
+                      purpose='test: run {0} example'.format(exe),
+                      work_dir=test_dir)
+
+    def test(self):
+        directory = join_path(self.test_suite.current_test_cache_dir,
+                             'test', 'mpi')
+        self.run_finalized_test(join_path(directory, 'init'), 'finalized')


### PR DESCRIPTION
This PR represents a preliminary smoke test for the `mpich` package and is intended to serve the following purposes:

Leverage the current E4S test suite for the software
Demonstrate to package maintainers how to start a Spack stand alone test.

