### PR TITLE
gxsview: new package, an MCNP viewer

### DIFF
--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -31,7 +31,6 @@ class Gxsview(QMakePackage):
 
     def qmake_args(self):
         vtk_suffix = self.spec['vtk'].version.up_to(2)
-        # vtk_lib_dir = self.spec['vtk'].prefix.lib64
         vtk_lib_dir = self.spec['vtk'].prefix.lib
         vtk_include_dir = join_path(self.spec['vtk'].prefix.include,
                                     'vtk-{0}'.format(vtk_suffix))

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -25,7 +25,7 @@ class Gxsview(QMakePackage):
     # centos7: spack install --keep-stage gxsview ^vtk@9.0.3+mpi ^hdf5+mpi ^mpich
     depends_on('fontconfig')
     depends_on('qt@5.14.0:+opengl+gui')
-    depends_on('vtk@8.0:+qt+opengl2') # +mpi+python are optional
+    depends_on('vtk@8.0:+qt+opengl2')  # +mpi+python are optional
     conflicts('%gcc@:7.2.0', msg='Requires C++17 compiler support')  # need C++17 standard
 
     # parallel = False
@@ -46,5 +46,4 @@ class Gxsview(QMakePackage):
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        install(join_path('gui','gxsview'), prefix.bin)
-
+        install(join_path('gui', 'gxsview'), prefix.bin)

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Gxsview(QMakePackage):
+    """Gxsview is a stand-alone multi-platform integrated tool to visualize input
+    data of Monte Carlo radiation transport calculation code, MCNP5, and PHITS3.
+
+    It consists of 3D, 2D, cross-section, and input file viewers.
+    Also, this software is capable of exporting in 2D(png, jpg, and xpm)
+    or 3D(stl, vtk, vtp and ply) formats."""
+
+    homepage = "https://www.nmri.go.jp/study/research_organization/risk/gxsview/en/index.html"
+    url      = "https://www.nmri.go.jp/study/research_organization/risk/gxsview/download/gxsview-2021.07.01-src.zip"
+
+    # Support email for questions ohnishi@m.mpat.go.jp
+    maintainers = ['cessenat']
+
+    version('2021.07.01', '000f9b4721d4ee03b02730dbbfe83947f96a60a183342b127f0b6b63b03e8f9a')
+
+    # centos7: spack install --keep-stage gxsview ^vtk@9.0.3+mpi ^hdf5+mpi ^mpich
+    depends_on('fontconfig')
+    depends_on('qt@5.14.0:+opengl+gui')
+    depends_on('vtk@8.0:+qt+opengl2') # +mpi+python are optional
+    conflicts('%gcc@:7.2.0', msg='Requires C++17 compiler support')  # need C++17 standard
+
+    # parallel = False
+    build_directory = 'gui'
+
+    def qmake_args(self):
+        vtk_suffix = self.spec['vtk'].version.up_to(2)
+        # vtk_lib_dir = self.spec['vtk'].prefix.lib64
+        vtk_lib_dir = self.spec['vtk'].prefix.lib
+        vtk_include_dir = join_path(self.spec['vtk'].prefix.include,
+                                    'vtk-{0}'.format(vtk_suffix))
+        args = [
+            'VTK_LIB_DIR={0}'.format(vtk_lib_dir),
+            'VTK_INC_DIR={0}'.format(vtk_include_dir),
+            'VTK_MAJOR_VER={0}'.format(str(vtk_suffix)),
+        ]
+        return args
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install(join_path('gui','gxsview'), prefix.bin)
+

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -27,7 +27,6 @@ class Gxsview(QMakePackage):
     depends_on('vtk@8.0:+qt+opengl2')  # +mpi+python are optional
     conflicts('%gcc@:7.2.0', msg='Requires C++17 compiler support')  # need C++17 standard
 
-    # parallel = False
     build_directory = 'gui'
 
     def qmake_args(self):

--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -22,7 +22,6 @@ class Gxsview(QMakePackage):
 
     version('2021.07.01', '000f9b4721d4ee03b02730dbbfe83947f96a60a183342b127f0b6b63b03e8f9a')
 
-    # centos7: spack install --keep-stage gxsview ^vtk@9.0.3+mpi ^hdf5+mpi ^mpich
     depends_on('fontconfig')
     depends_on('qt@5.14.0:+opengl+gui')
     depends_on('vtk@8.0:+qt+opengl2')  # +mpi+python are optional


### PR DESCRIPTION
Gxsview is a stand-alone multi-platform integrated tool to visualize input
data of Monte Carlo radiation transport calculation code, MCNP5, and PHITS3.

It consists of 3D, 2D, cross-section, and input file viewers.
Also, this software is capable of exporting in 2D(png, jpg, and xpm)
or 3D(stl, vtk, vtp and ply) formats.

It seems to be a free software under GPL v3 but collaboration is to be done emailing the author at least for now.
More details below.
https://www.nmri.go.jp/study/research_organization/risk/gxsview/en/index.html