### PR TITLE
acl: Switch to https

### DIFF
--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -10,7 +10,7 @@ class Acl(AutotoolsPackage):
     """Commands for Manipulating POSIX Access Control Lists."""
 
     homepage = "https://savannah.nongnu.org/projects/acl"
-    url      = "http://git.savannah.nongnu.org/cgit/acl.git/snapshot/acl-2.2.53.tar.gz"
+    url      = "https://git.savannah.nongnu.org/cgit/acl.git/snapshot/acl-2.2.53.tar.gz"
 
     version('2.2.53', sha256='9e905397ac10d06768c63edd0579c34b8431555f2ea8e8f2cee337b31f856805')
     version('2.2.52', sha256='f3f31d2229c903184ff877aa0ee658b87ec20fec8aebb51e65eaa68d7b24e629')


### PR DESCRIPTION
Switching to https will allow the package to be installed where http is blocked.