### PR TITLE
adlbx: switch url to https

### DIFF
--- a/var/spack/repos/builtin/packages/adlbx/package.py
+++ b/var/spack/repos/builtin/packages/adlbx/package.py
@@ -11,7 +11,7 @@ class Adlbx(AutotoolsPackage):
     """ADLB/X: Master-worker library + work stealing and data dependencies"""
 
     homepage = 'http://swift-lang.org/Swift-T'
-    url      = 'http://swift-lang.github.io/swift-t-downloads/spack/adlbx-1.0.0.tar.gz'
+    url      = 'https://swift-lang.github.io/swift-t-downloads/spack/adlbx-1.0.0.tar.gz'
     git      = "https://github.com/swift-lang/swift-t.git"
 
     version('master', branch='master')


### PR DESCRIPTION
Switching url to https will allow the package to be installed where http is blocked (whenever the URL is used).