### PR TITLE
Mark spec uninstalled if spack install --overwrite fails and backup can't be restored

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -708,7 +708,6 @@ def replace_directory_transaction(directory_name, tmp_root=None):
                 src=os.path.join(tmp_dir, directory_basename),
                 dst=os.path.dirname(directory_name)
             )
-            raise OSError("whoopsie!")
         except OSError as e:
             raise CouldNotRestoreDirectoryBackup(e)
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -704,7 +704,7 @@ def replace_directory_transaction(directory_name, tmp_root=None):
         raise
     else:
         # Otherwise delete the temporary directory
-        shutil.rmtree(tmp_dir)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
         tty.debug('TEMPORARY DIRECTORY DELETED [{0}]'.format(tmp_dir))
 
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -1189,7 +1189,7 @@ def test_overwrite_install_backup_success(temporary_store, config, mock_packages
     # Where to store the backups
     backup = str(tmpdir.mkdir("backup"))
 
-    # Get a build task (TODO: can this be done without calling internal methods?)
+    # Get a build task. TODO: refactor this to avoid calling internal methods
     const_arg = installer_args(["b"])
     installer = create_installer(const_arg)
     installer._init_queue()
@@ -1249,7 +1249,7 @@ def test_overwrite_install_backup_failure(temporary_store, config, mock_packages
         def remove(self, spec):
             self.called = True
 
-    # Get a build task (TODO: can this be done without calling internal methods?)
+    # Get a build task. TODO: refactor this to avoid calling internal methods
     const_arg = installer_args(["b"])
     installer = create_installer(const_arg)
     installer._init_queue()

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import shutil
 
 import py
 import pytest
@@ -1177,3 +1178,97 @@ def test_install_skip_patch(install_mockery, mock_fetch):
 
     spec, install_args = const_arg[0]
     assert inst.package_id(spec.package) in installer.installed
+
+
+def test_overwrite_install_backup_success(temporary_store, config, mock_packages,
+                                          tmpdir):
+    """
+    When doing an overwrite install that fails, Spack should restore the backup
+    of the original prefix, and leave the original spec marked installed.
+    """
+    # Where to store the backups
+    backup = str(tmpdir.mkdir("backup"))
+
+    # Get a build task (TODO: can this be done without calling internal methods?)
+    const_arg = installer_args(["b"])
+    installer = create_installer(const_arg)
+    installer._init_queue()
+    task = installer._pop_task()
+
+    # Make sure the install prefix exists with some trivial file
+    installed_file = os.path.join(task.pkg.prefix, 'some_file')
+    fs.touchp(installed_file)
+
+    class InstallerThatWipesThePrefixDir:
+        def _install_task(self, task):
+            shutil.rmtree(task.pkg.prefix, ignore_errors=True)
+            fs.mkdirp(task.pkg.prefix)
+            raise Exception("Some fatal install error")
+
+    class FakeDatabase:
+        called = False
+
+        def remove(self, spec):
+            self.called = True
+
+    fake_installer = InstallerThatWipesThePrefixDir()
+    fake_db = FakeDatabase()
+    overwrite_install = inst.OverwriteInstall(
+        fake_installer, fake_db, task, tmp_root=backup)
+
+    # Installation should throw the installation exception, not the backup
+    # failure.
+    with pytest.raises(Exception, match='Some fatal install error'):
+        overwrite_install.install()
+
+    # Make sure the package is not marked uninstalled and the original dir
+    # is back.
+    assert not fake_db.called
+    assert os.path.exists(installed_file)
+
+
+def test_overwrite_install_backup_failure(temporary_store, config, mock_packages,
+                                          tmpdir):
+    """
+    When doing an overwrite install that fails, Spack should try to recover the
+    original prefix. If that fails, the spec is lost, and it should be removed
+    from the database.
+    """
+    # Where to store the backups
+    backup = str(tmpdir.mkdir("backup"))
+
+    class InstallerThatAccidentallyDeletesTheBackupDir:
+        def _install_task(self, task):
+            # Remove the backup directory so that restoring goes terribly wrong
+            shutil.rmtree(backup)
+            raise Exception("Some fatal install error")
+
+    class FakeDatabase:
+        called = False
+
+        def remove(self, spec):
+            self.called = True
+
+    # Get a build task (TODO: can this be done without calling internal methods?)
+    const_arg = installer_args(["b"])
+    installer = create_installer(const_arg)
+    installer._init_queue()
+    task = installer._pop_task()
+
+    # Make sure the install prefix exists
+    installed_file = os.path.join(task.pkg.prefix, 'some_file')
+    fs.touchp(installed_file)
+
+    fake_installer = InstallerThatAccidentallyDeletesTheBackupDir()
+    fake_db = FakeDatabase()
+    overwrite_install = inst.OverwriteInstall(
+        fake_installer, fake_db, task, tmp_root=backup)
+
+    # Installation should throw the installation exception, not the backup
+    # failure.
+    with pytest.raises(Exception, match='Some fatal install error'):
+        overwrite_install.install()
+
+    # Make sure that `remove` was called on the database after an unsuccessful
+    # attempt to restore the backup.
+    assert fake_db.called


### PR DESCRIPTION
This fixes the last bug (noted by @scheibelp and me) in `overwrite: True` installs. In the unlikely case where both `spack install --overwrite` (or `spack install` with develop specs) fails and Spack can't restore the backup of the original prefix, we should reflect in the database that the original spec is uninstalled.

It's hard to add a test for this since it's not very modular code... The last 3 commits are the ones that matter.