### PR TITLE
Update CAMP, Umpire, RAJA, and CHAI packages with newly available versions

### DIFF
--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -17,6 +17,10 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
     url      = "https://github.com/LLNL/camp/archive/v0.1.0.tar.gz"
 
     version('master', branch='master', submodules='True')
+    version('0.2.3', tag='v0.2.3', submodules='True')
+    version('0.2.2', tag='v0.2.2', submodules='True')
+    version('0.2.1', tag='v0.2.1', submodules='True')
+    version('0.2.0', tag='v0.2.0', submodules='True')
     version('0.1.0', sha256='fd4f0f2a60b82a12a1d9f943f8893dc6fe770db493f8fae5ef6f7d0c439bebcc')
 
     # TODO: figure out gtest dependency and then set this default True.

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -16,6 +16,7 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
 
     version('develop', branch='develop', submodules=True)
     version('master', branch='main', submodules=True)
+    version('2.4.0', tag='v2.4.0', submodules=True)
     version('2.3.0', tag='v2.3.0', submodules=True)
     version('2.2.2', tag='v2.2.2', submodules=True)
     version('2.2.1', tag='v2.2.1', submodules=True)
@@ -39,11 +40,15 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', type='build', when="+cuda")
 
+    depends_on('blt@0.4.1:', type='build', when='@2.4.0:')
     depends_on('blt@0.4.0:', type='build', when='@2.3.1:')
     depends_on('blt@:0.3.6', type='build', when='@:2.3.0')
 
-    depends_on('umpire')
-    depends_on('raja', when="+raja")
+    depends_on('umpire@0.6.0:', when='@2.4.0:')
+    depends_on('umpire@:0.6.0', when='@:2.4.0')
+
+    depends_on('raja@0.14.0:', when='@2.4.0:+raja')
+    depends_on('raja@:0.14.0', when=":@2.4.0+raja")
 
     depends_on('umpire+cuda', when="+cuda")
     depends_on('raja+cuda', when="+raja+cuda")

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -12,6 +12,7 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
 
     version('develop', branch='develop', submodules='True')
     version('main',  branch='main',  submodules='True')
+    version('0.14.0', tag='v0.14.0', submodules='True')
     version('0.13.0', tag='v0.13.0', submodules='True')
     version('0.12.1', tag='v0.12.1', submodules="True")
     version('0.12.0', tag='v0.12.0', submodules="True")
@@ -37,7 +38,8 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
     # and remove the +tests conflict below.
     variant('tests', default=False, description='Build tests')
 
-    depends_on('blt@0.4.0:', type='build', when='@0.13.1:')
+    depends_on('blt@0.4.1:', type='build', when='@0.14.0:')
+    depends_on('blt@0.4.0:', type='build', when='@0.13.0:')
     depends_on('blt@:0.3.6', type='build', when='@:0.13.0')
 
     # variants +rocm and amdgpu_targets are not automatically passed to

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -19,6 +19,7 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
 
     version('develop', branch='develop', submodules=True)
     version('main', branch='main', submodules=True)
+    version('6.0.0', tag='v6.0.0', submodules=True)
     version('5.0.1', tag='v5.0.1', submodules=True)
     version('5.0.0', tag='v5.0.0', submodules=True)
     version('4.1.2', tag='v4.1.2', submodules=True)
@@ -64,6 +65,7 @@ class Umpire(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', when='+cuda', type='build')
 
+    depends_on('blt@0.4.1:', type='build', when='@6.0.0:')
     depends_on('blt@0.4.0:', type='build', when='@4.1.3:')
     depends_on('blt@:0.3.6', type='build', when='@:4.1.2')
 


### PR DESCRIPTION
CAMP: Adds tags up to v0.2.3
Umpire: Adds tags up to v6.0.0
RAJA: Adds tags up to v0.14.0
CHAI: Adds tags up to v2.4.0