### PR TITLE
py-pybind11: use PythonPackage install method

### DIFF
--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -8,7 +8,7 @@ import os
 from spack import *
 
 
-class PyPybind11(CMakePackage):
+class PyPybind11(CMakePackage, PythonPackage):
     """pybind11 -- Seamless operability between C++11 and Python.
 
     pybind11 is a lightweight header-only library that exposes C++ types in
@@ -43,12 +43,12 @@ class PyPybind11(CMakePackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-pytest', type='test')
 
-    extends('python')
-
     # compiler support
     conflicts('%gcc@:4.7')
     conflicts('%clang@:3.2')
     conflicts('%intel@:16')
+
+    build_directory = '.'
 
     def cmake_args(self):
         args = []
@@ -72,9 +72,8 @@ class PyPybind11(CMakePackage):
                     string=True)
 
     def install(self, spec, prefix):
-        super(PyPybind11, self).install(spec, prefix)
-        setup_py('install', '--single-version-externally-managed', '--root=/',
-                 '--prefix={0}'.format(prefix))
+        CMakePackage.install(self, spec, prefix)
+        PythonPackage.install(self, spec, prefix)
 
     @run_after('install')
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
Fixes #25580 

@mdorier @ax3l can you test this? I'm able to successfully install on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0, and all tests pass.

I had to override the `build_directory` because that's where `PythonPackage` looks for a `setup.py` file. Hopefully there aren't any negative consequences of building in the source directory.

We could move the URL to `pypi` if we want to. There are a lot of benefits from directly subclassing from `PythonPackage`. When subclassing two classes like this, all attributes come from the first package if available, then the second package if not.