### PR TITLE
Adding remainder of issues from repology problems

### DIFF
--- a/var/spack/repos/builtin/packages/ampliconnoise/package.py
+++ b/var/spack/repos/builtin/packages/ampliconnoise/package.py
@@ -10,7 +10,7 @@ class Ampliconnoise(MakefilePackage):
     """AmpliconNoise is a collection of programs for the removal of noise
        from 454 sequenced PCR amplicons."""
 
-    homepage = "https://code.google.com/archive/p/ampliconnoise/"
+    homepage = "https://directory.fsf.org/wiki/AmpliconNoise"
     url      = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ampliconnoise/AmpliconNoiseV1.29.tar.gz"
 
     version('1.29', sha256='0bf946806d77ecaf0994ad8ebf9a5e98ad33c809f6def5c9340a16c367918167')

--- a/var/spack/repos/builtin/packages/antlr/package.py
+++ b/var/spack/repos/builtin/packages/antlr/package.py
@@ -13,7 +13,7 @@ class Antlr(AutotoolsPackage):
     frameworks. From a grammar, ANTLR generates a parser that can build and
     walk parse trees."""
 
-    homepage = "http://www.antlr2.org/"
+    homepage = "https://www.antlr2.org/"
     url      = "http://www.antlr2.org/download/antlr-2.7.7.tar.gz"
 
     version('2.7.7', sha256='853aeb021aef7586bda29e74a6b03006bcb565a755c86b66032d8ec31b67dbb9')

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -11,7 +11,7 @@ class Arrayfire(CMakePackage, CudaPackage):
     with an easy-to-use API. Its array based function set makes parallel
     programming more accessible."""
 
-    homepage = "http://arrayfire.org/docs/index.htm"
+    homepage = "https://arrayfire.org/docs/index.htm"
     git      = "https://github.com/arrayfire/arrayfire.git"
 
     version('master', submodules=True)

--- a/var/spack/repos/builtin/packages/at-spi2-atk/package.py
+++ b/var/spack/repos/builtin/packages/at-spi2-atk/package.py
@@ -10,7 +10,7 @@ class AtSpi2Atk(MesonPackage):
     """The At-Spi2 Atk package contains a library that bridges ATK to
        At-Spi2 D-Bus service."""
 
-    homepage = "http://www.linuxfromscratch.org/blfs/view/cvs/x/at-spi2-atk.html"
+    homepage = "https://www.linuxfromscratch.org/blfs/view/cvs/x/at-spi2-atk.html"
     url      = "http://ftp.gnome.org/pub/gnome/sources/at-spi2-atk/2.26/at-spi2-atk-2.26.1.tar.xz"
     list_url = "http://ftp.gnome.org/pub/gnome/sources/at-spi2-atk"
     list_depth = 1

--- a/var/spack/repos/builtin/packages/at-spi2-core/package.py
+++ b/var/spack/repos/builtin/packages/at-spi2-core/package.py
@@ -11,7 +11,7 @@ class AtSpi2Core(MesonPackage):
        Assistive Technologies available on the GNOME platform and a library
        against which applications can be linked."""
 
-    homepage = "http://www.linuxfromscratch.org/blfs/view/cvs/x/at-spi2-core.html"
+    homepage = "https://www.linuxfromscratch.org/blfs/view/cvs/x/at-spi2-core.html"
     url      = "http://ftp.gnome.org/pub/gnome/sources/at-spi2-core/2.28/at-spi2-core-2.38.0.tar.xz"
     list_url = "http://ftp.gnome.org/pub/gnome/sources/at-spi2-core"
     list_depth = 1

--- a/var/spack/repos/builtin/packages/atop/package.py
+++ b/var/spack/repos/builtin/packages/atop/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class Atop(Package):
     """Atop is an ASCII full-screen performance monitor for Linux"""
-    homepage = "http://www.atoptool.nl/index.php"
+    homepage = "https://www.atoptool.nl/index.php"
     url      = "http://www.atoptool.nl/download/atop-2.2-3.tar.gz"
 
     version('2.5.0', sha256='4b911057ce50463b6e8b3016c5963d48535c0cddeebc6eda817e292b22f93f33')

--- a/var/spack/repos/builtin/packages/bbmap/package.py
+++ b/var/spack/repos/builtin/packages/bbmap/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Bbmap(Package, SourceforgePackage):
     """Short read aligner for DNA and RNA-seq data."""
 
-    homepage = "http://sourceforge.net/projects/bbmap/"
+    homepage = "https://sourceforge.net/projects/bbmap/"
     sourceforge_mirror_path = "bbmap/BBMap_38.63.tar.gz"
 
     version('38.63', sha256='089064104526c8d696164aefa067f935b888bc71ef95527c72a98c17ee90a01f')

--- a/var/spack/repos/builtin/packages/bigreqsproto/package.py
+++ b/var/spack/repos/builtin/packages/bigreqsproto/package.py
@@ -12,7 +12,7 @@ class Bigreqsproto(AutotoolsPackage, XorgPackage):
     This extension defines a protocol to enable the use of requests
     that exceed 262140 bytes in length."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/bigreqsproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/bigreqsproto"
     xorg_mirror_path = "proto/bigreqsproto-1.1.2.tar.gz"
 
     version('1.1.2', sha256='de68a1a9dd1a1219ad73531bff9f662bc62fcd777387549c43cd282399f4a6ea')

--- a/var/spack/repos/builtin/packages/blitz/package.py
+++ b/var/spack/repos/builtin/packages/blitz/package.py
@@ -8,7 +8,7 @@ from spack import *
 
 class Blitz(AutotoolsPackage):
     """N-dimensional arrays for C++"""
-    homepage = "http://github.com/blitzpp/blitz"
+    homepage = "https://github.com/blitzpp/blitz"
     url = "https://github.com/blitzpp/blitz/archive/1.0.2.tar.gz"
 
     version('1.0.2', sha256='500db9c3b2617e1f03d0e548977aec10d36811ba1c43bb5ef250c0e3853ae1c2')

--- a/var/spack/repos/builtin/packages/bml/package.py
+++ b/var/spack/repos/builtin/packages/bml/package.py
@@ -11,7 +11,7 @@ class Bml(CMakePackage):
     formats (in dense and sparse) and their associated algorithms for basic
     matrix operations."""
 
-    homepage = "http://lanl.github.io/bml/"
+    homepage = "https://lanl.github.io/bml/"
     url      = "https://github.com/lanl/bml/tarball/v1.2.2"
     git      = "https://github.com/lanl/bml.git"
 

--- a/var/spack/repos/builtin/packages/bolt/package.py
+++ b/var/spack/repos/builtin/packages/bolt/package.py
@@ -19,7 +19,7 @@ class Bolt(CMakePackage):
     runtime in LLVM, and thus it can be used with LLVM/Clang, Intel
     OpenMP compiler, and GCC."""
 
-    homepage = "http://www.bolt-omp.org/"
+    homepage = "https://www.bolt-omp.org/"
     url      = "https://github.com/pmodels/bolt/releases/download/v1.0b1/bolt-1.0b1.tar.gz"
     git      = "https://github.com/pmodels/bolt.git"
     maintainers = ['shintaro-iwasaki']

--- a/var/spack/repos/builtin/packages/busco/package.py
+++ b/var/spack/repos/builtin/packages/busco/package.py
@@ -10,7 +10,7 @@ class Busco(PythonPackage):
     """Assesses genome assembly and annotation completeness with Benchmarking
        Universal Single-Copy Orthologs"""
 
-    homepage = "http://busco.ezlab.org/"
+    homepage = "https://busco.ezlab.org/"
     url      = "https://gitlab.com/api/v4/projects/ezlab%2Fbusco/repository/archive.tar.gz?sha=2.0.1"
     git      = "https://gitlab.com/ezlab/busco.git"
 

--- a/var/spack/repos/builtin/packages/bwa/package.py
+++ b/var/spack/repos/builtin/packages/bwa/package.py
@@ -11,7 +11,7 @@ from spack import *
 class Bwa(Package):
     """Burrow-Wheeler Aligner for pairwise alignment between DNA sequences."""
 
-    homepage = "http://github.com/lh3/bwa"
+    homepage = "https://github.com/lh3/bwa"
     url      = "https://github.com/lh3/bwa/releases/download/v0.7.15/bwa-0.7.15.tar.bz2"
 
     version('0.7.17', sha256='de1b4d4e745c0b7fc3e107b5155a51ac063011d33a5d82696331ecf4bed8d0fd')

--- a/var/spack/repos/builtin/packages/cmark/package.py
+++ b/var/spack/repos/builtin/packages/cmark/package.py
@@ -10,7 +10,7 @@ class Cmark(CMakePackage):
     """cmark is the C reference implementation of CommonMark,
     a rationalized version of Markdown syntax with a spec."""
 
-    homepage = "http://commonmark.org/"
+    homepage = "https://commonmark.org/"
     url      = "https://github.com/commonmark/cmark/archive/0.29.0.tar.gz"
 
     version('0.29.0', sha256='2558ace3cbeff85610de3bda32858f722b359acdadf0c4691851865bb84924a6')

--- a/var/spack/repos/builtin/packages/compositeproto/package.py
+++ b/var/spack/repos/builtin/packages/compositeproto/package.py
@@ -12,7 +12,7 @@ class Compositeproto(AutotoolsPackage, XorgPackage):
     This package contains header files and documentation for the composite
     extension.  Library and server implementations are separate."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/compositeproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/compositeproto"
     xorg_mirror_path = "proto/compositeproto-0.4.2.tar.gz"
 
     version('0.4.2', sha256='22195b7e50036440b1c6b3b2d63eb03dfa6e71c8a1263ed1f07b0f31ae7dad50')

--- a/var/spack/repos/builtin/packages/connect-proxy/package.py
+++ b/var/spack/repos/builtin/packages/connect-proxy/package.py
@@ -8,9 +8,11 @@ from spack import *
 
 class ConnectProxy(MakefilePackage):
     """`connect.c` is a simple relaying command to make network connection
-    via SOCKS and https proxy"""
+    via SOCKS and https proxy. The original docs are https://bitbucket.org/gotoh/connect
+    are now 404, so the manpage is provided instead.
+    """
 
-    homepage = "https://bitbucket.org/gotoh/connect"
+    homepage = "https://manpages.debian.org/testing/connect-proxy/connect-proxy.1.en.html"
     url      = "https://bitbucket.org/gotoh/connect/get/1.105.tar.bz2"
 
     version('1.105', sha256='07366026b1f81044ecd8da9b5b5b51321327ecdf6ba23576271a311bbd69d403')

--- a/var/spack/repos/builtin/packages/delta/package.py
+++ b/var/spack/repos/builtin/packages/delta/package.py
@@ -10,7 +10,7 @@ class Delta(Package):
     """Delta Lake is a storage layer that brings scalable, ACID transactions
     to Apache Spark and other big-data engines."""
 
-    homepage = "http://delta.io/"
+    homepage = "https://delta.io/"
     url      = "https://github.com/delta-io/delta/archive/v0.7.0.tar.gz"
 
     version('0.7.0', sha256='1fb01e36c1cf670f201c615e5fd7df88f72c27157b7d2780d146e21b266bdb64')

--- a/var/spack/repos/builtin/packages/dsdp/package.py
+++ b/var/spack/repos/builtin/packages/dsdp/package.py
@@ -16,7 +16,7 @@ class Dsdp(MakefilePackage):
     allows feasible and infeasible starting points and provides approximate
     certificates of infeasibility when no feasible solution exists."""
 
-    homepage = "http://www.mcs.anl.gov/hs/software/DSDP/"
+    homepage = "https://www.mcs.anl.gov/hs/software/DSDP/"
     url      = "http://www.mcs.anl.gov/hs/software/DSDP/DSDP5.8.tar.gz"
 
     version('5.8', sha256='26aa624525a636de272c0b329e2dfd01a0d5b7827f1c1c76f393d71e37dead70')

--- a/var/spack/repos/builtin/packages/exonerate/package.py
+++ b/var/spack/repos/builtin/packages/exonerate/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Exonerate(AutotoolsPackage):
     """Pairwise sequence alignment of DNA and proteins"""
 
-    homepage = "http://www.ebi.ac.uk/about/vertebrate-genomics/software/exonerate"
+    homepage = "https://www.ebi.ac.uk/about/vertebrate-genomics/software/exonerate"
     url      = "http://ftp.ebi.ac.uk/pub/software/vertebrategenomics/exonerate/exonerate-2.4.0.tar.gz"
 
     version('2.4.0', sha256='f849261dc7c97ef1f15f222e955b0d3daf994ec13c9db7766f1ac7e77baa4042')

--- a/var/spack/repos/builtin/packages/fixesproto/package.py
+++ b/var/spack/repos/builtin/packages/fixesproto/package.py
@@ -13,7 +13,7 @@ class Fixesproto(AutotoolsPackage, XorgPackage):
     issues raised by application interaction with core protocol mechanisms
     that cannot be adequately worked around on the client side of the wire."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/fixesproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/fixesproto"
     xorg_mirror_path = "proto/fixesproto-5.0.tar.gz"
 
     version('5.0', sha256='67865a0e3cdc7dec1fd676f0927f7011ad4036c18eb320a2b41dbd56282f33b8')

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -9,7 +9,7 @@ from spack import *
 class FontUtil(AutotoolsPackage, XorgPackage):
     """X.Org font package creation/installation utilities and fonts."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/font/util"
+    homepage = "https://cgit.freedesktop.org/xorg/font/util"
     xorg_mirror_path = "font/font-util-1.3.1.tar.gz"
 
     version('1.3.2', sha256='f115a3735604de1e852a4bf669be0269d8ce8f21f8e0e74ec5934b31dadc1e76')

--- a/var/spack/repos/builtin/packages/fontsproto/package.py
+++ b/var/spack/repos/builtin/packages/fontsproto/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Fontsproto(AutotoolsPackage, XorgPackage):
     """X Fonts Extension."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/fontsproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/fontsproto"
     xorg_mirror_path = "proto/fontsproto-2.1.3.tar.gz"
 
     version('2.1.3', sha256='72c44e63044b2b66f6fa112921621ecc20c71193982de4f198d9a29cda385c5e')

--- a/var/spack/repos/builtin/packages/fonttosfnt/package.py
+++ b/var/spack/repos/builtin/packages/fonttosfnt/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Fonttosfnt(AutotoolsPackage, XorgPackage):
     """Wrap a bitmap font in a sfnt (TrueType) wrapper."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/fonttosfnt"
+    homepage = "https://cgit.freedesktop.org/xorg/app/fonttosfnt"
     xorg_mirror_path = "app/fonttosfnt-1.0.4.tar.gz"
 
     version('1.0.4', sha256='3873636be5b3b8e4160070e8f9a7a9221b5bd5efbf740d7abaa9092e10732673')

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4realsurface(Package):
     """Geant4 data for measured optical surface reflectance"""
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/RealSurface.1.0.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 class G4saiddata(Package):
     """Geant4 data from evaluated cross-sections in SAID data-base """
-    homepage = "http://geant4.web.cern.ch"
+    homepage = "https://geant4.web.cern.ch"
     url = "http://geant4-data.web.cern.ch/geant4-data/datasets/G4SAIDDATA.1.1.tar.gz"
 
     tags = ['hep']

--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -13,7 +13,7 @@ class GdkPixbuf(Package):
        GTK+ 2 but it was split off into a separate package in
        preparation for the change to GTK+ 3."""
 
-    homepage = "https://developer.gnome.org/gdk-pixbuf/"
+    homepage = "https://gitlab.gnome.org/GNOME/gdk-pixbuf"
     url      = "https://ftp.acc.umu.se/pub/gnome/sources/gdk-pixbuf/2.40/gdk-pixbuf-2.40.0.tar.xz"
     list_url = "https://ftp.acc.umu.se/pub/gnome/sources/gdk-pixbuf/"
     list_depth = 1

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -21,7 +21,7 @@ class Hwloc(AutotoolsPackage):
     efficiently.
     """
 
-    homepage = "http://www.open-mpi.org/projects/hwloc/"
+    homepage = "https://www.open-mpi.org/projects/hwloc/"
     url      = "https://download.open-mpi.org/release/hwloc/v2.0/hwloc-2.0.2.tar.gz"
     list_url = "http://www.open-mpi.org/software/hwloc/"
     list_depth = 2

--- a/var/spack/repos/builtin/packages/iceauth/package.py
+++ b/var/spack/repos/builtin/packages/iceauth/package.py
@@ -11,7 +11,7 @@ class Iceauth(AutotoolsPackage, XorgPackage):
     information used in connecting with ICE.   It operates very much
     like the xauth program for X11 connection authentication records."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/iceauth"
+    homepage = "https://cgit.freedesktop.org/xorg/app/iceauth"
     xorg_mirror_path = "app/iceauth-1.0.7.tar.gz"
 
     version('1.0.7', sha256='6c9706cce276609876e768759ed4ee3b447cd17af4a61f9b5a374c7dda9696d8')

--- a/var/spack/repos/builtin/packages/igraph/package.py
+++ b/var/spack/repos/builtin/packages/igraph/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Igraph(AutotoolsPackage):
     """igraph is a library for creating and manipulating graphs."""
 
-    homepage = "http://igraph.org/"
+    homepage = "https://igraph.org/"
     url      = "https://github.com/igraph/igraph/releases/download/0.7.1/igraph-0.7.1.tar.gz"
 
     version('0.7.1', sha256='d978030e27369bf698f3816ab70aa9141e9baf81c56cc4f55efbe5489b46b0df')

--- a/var/spack/repos/builtin/packages/ilmbase/package.py
+++ b/var/spack/repos/builtin/packages/ilmbase/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Ilmbase(AutotoolsPackage):
     """OpenEXR ILM Base libraries (high dynamic-range image file format)"""
 
-    homepage = "http://www.openexr.com/"
+    homepage = "https://www.openexr.com/"
     url      = "https://github.com/openexr/openexr/releases/download/v2.3.0/ilmbase-2.3.0.tar.gz"
 
     version('2.3.0', sha256='456978d1a978a5f823c7c675f3f36b0ae14dba36638aeaa3c4b0e784f12a3862')

--- a/var/spack/repos/builtin/packages/inputproto/package.py
+++ b/var/spack/repos/builtin/packages/inputproto/package.py
@@ -12,7 +12,7 @@ class Inputproto(AutotoolsPackage, XorgPackage):
     This extension defines a protocol to provide additional input devices
     management such as graphic tablets."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/inputproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/inputproto"
     xorg_mirror_path = "proto/inputproto-2.3.2.tar.gz"
 
     version('2.3.2', sha256='10eaadd531f38f7c92ab59ef0708ca195caf3164a75c4ed99f0c04f2913f6ef3')

--- a/var/spack/repos/builtin/packages/libcerf/package.py
+++ b/var/spack/repos/builtin/packages/libcerf/package.py
@@ -13,7 +13,7 @@ class Libcerf(AutotoolsPackage, SourceforgePackage):
        integral and Voigt's convolution of a Gaussian and a Lorentzian
 
     """
-    homepage = "http://sourceforge.net/projects/libcerf"
+    homepage = "https://sourceforge.net/projects/libcerf"
     sourceforge_mirror_path = "libcerf/libcerf-1.3.tgz"
 
     version('1.3', sha256='d7059e923d3f370c89fb4d19ed4f827d381bc3f0e36da5595a04aeaaf3e6a859')

--- a/var/spack/repos/builtin/packages/libdmx/package.py
+++ b/var/spack/repos/builtin/packages/libdmx/package.py
@@ -10,7 +10,7 @@ class Libdmx(AutotoolsPackage, XorgPackage):
     """libdmx - X Window System DMX (Distributed Multihead X) extension
     library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libdmx"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libdmx"
     xorg_mirror_path = "lib/libdmx-1.1.3.tar.gz"
 
     version('1.1.3', sha256='c4b24d7e13e5a67ead7a18f0b4cc9b7b5363c9d04cd01b83b5122ff92b3b4996')

--- a/var/spack/repos/builtin/packages/libevdev/package.py
+++ b/var/spack/repos/builtin/packages/libevdev/package.py
@@ -11,7 +11,7 @@ class Libevdev(AutotoolsPackage):
     tasks when dealing with evdev devices into a library and provides a
     library interface to the callers, thus avoiding erroneous ioctls, etc."""
 
-    homepage = "http://cgit.freedesktop.org/libevdev"
+    homepage = "https://cgit.freedesktop.org/libevdev"
     url      = "https://github.com/whot/libevdev/archive/libevdev-1.5.4.tar.gz"
 
     version('1.5.4', sha256='11ef3510970c049b0e30985be3149d27b4b36b7cbe14ca678746aac1ca86744d')

--- a/var/spack/repos/builtin/packages/libfs/package.py
+++ b/var/spack/repos/builtin/packages/libfs/package.py
@@ -12,7 +12,7 @@ class Libfs(AutotoolsPackage, XorgPackage):
     This library is used by clients of X Font Servers (xfs), such as
     xfsinfo, fslsfonts, and the X servers themselves."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libFS"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libFS"
     xorg_mirror_path = "lib/libFS-1.0.7.tar.gz"
 
     version('1.0.7', sha256='91bf1c5ce4115b7dbf4e314fdbee54052708e8f7b6a2ec6e82c309bcbe40ef3d')

--- a/var/spack/repos/builtin/packages/libice/package.py
+++ b/var/spack/repos/builtin/packages/libice/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libice(AutotoolsPackage, XorgPackage):
     """libICE - Inter-Client Exchange Library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libICE"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libICE"
     xorg_mirror_path = "lib/libICE-1.0.9.tar.gz"
 
     version('1.0.9', sha256='7812a824a66dd654c830d21982749b3b563d9c2dfe0b88b203cefc14a891edc0')

--- a/var/spack/repos/builtin/packages/libmng/package.py
+++ b/var/spack/repos/builtin/packages/libmng/package.py
@@ -10,7 +10,7 @@ class Libmng(CMakePackage):
     """THE reference library for reading, displaying, writing
        and examining Multiple-Image Network Graphics.  MNG is the animation
        extension to the popular PNG image format."""
-    homepage = "http://sourceforge.net/projects/libmng/"
+    homepage = "https://sourceforge.net/projects/libmng/"
     url      = "http://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz"
 
     version('2.0.3', sha256='cf112a1fb02f5b1c0fce5cab11ea8243852c139e669c44014125874b14b7dfaa')

--- a/var/spack/repos/builtin/packages/libsm/package.py
+++ b/var/spack/repos/builtin/packages/libsm/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libsm(AutotoolsPackage, XorgPackage):
     """libSM - X Session Management Library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libSM"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libSM"
     xorg_mirror_path = "lib/libSM-1.2.2.tar.gz"
 
     version('1.2.3', sha256='1e92408417cb6c6c477a8a6104291001a40b3bb56a4a60608fdd9cd2c5a0f320')

--- a/var/spack/repos/builtin/packages/libxaw/package.py
+++ b/var/spack/repos/builtin/packages/libxaw/package.py
@@ -10,7 +10,7 @@ class Libxaw(AutotoolsPackage, XorgPackage):
     """Xaw is the X Athena Widget Set.
     Xaw is a widget set based on the X Toolkit Intrinsics (Xt) Library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXaw"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXaw"
     xorg_mirror_path = "lib/libXaw-1.0.13.tar.gz"
 
     version('1.0.13', sha256='7e74ac3e5f67def549722ff0333d6e6276b8becd9d89615cda011e71238ab694')

--- a/var/spack/repos/builtin/packages/libxcomposite/package.py
+++ b/var/spack/repos/builtin/packages/libxcomposite/package.py
@@ -10,7 +10,7 @@ class Libxcomposite(AutotoolsPackage, XorgPackage):
     """libXcomposite - client library for the Composite extension to the
     X11 protocol."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXcomposite"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXcomposite"
     xorg_mirror_path = "lib/libXcomposite-0.4.4.tar.gz"
 
     version('0.4.4', sha256='83c04649819c6f52cda1b0ce8bcdcc48ad8618428ad803fb07f20b802f1bdad1')

--- a/var/spack/repos/builtin/packages/libxcursor/package.py
+++ b/var/spack/repos/builtin/packages/libxcursor/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxcursor(AutotoolsPackage, XorgPackage):
     """libXcursor - X Window System Cursor management library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXcursor"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXcursor"
     xorg_mirror_path = "lib/libXcursor-1.1.14.tar.gz"
 
     version('1.1.14', sha256='be0954faf274969ffa6d95b9606b9c0cfee28c13b6fc014f15606a0c8b05c17b')

--- a/var/spack/repos/builtin/packages/libxdamage/package.py
+++ b/var/spack/repos/builtin/packages/libxdamage/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxdamage(AutotoolsPackage, XorgPackage):
     """This package contains the library for the X Damage extension."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXdamage"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXdamage"
     xorg_mirror_path = "lib/libXdamage-1.1.4.tar.gz"
 
     version('1.1.4', sha256='4bb3e9d917f5f593df2277d452926ee6ad96de7b7cd1017cbcf4579fe5d3442b')

--- a/var/spack/repos/builtin/packages/libxdmcp/package.py
+++ b/var/spack/repos/builtin/packages/libxdmcp/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxdmcp(AutotoolsPackage, XorgPackage):
     """libXdmcp - X Display Manager Control Protocol library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXdmcp"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXdmcp"
     xorg_mirror_path = "lib/libXdmcp-1.1.2.tar.gz"
 
     version('1.1.2', sha256='6f7c7e491a23035a26284d247779174dedc67e34e93cc3548b648ffdb6fc57c0')

--- a/var/spack/repos/builtin/packages/libxext/package.py
+++ b/var/spack/repos/builtin/packages/libxext/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxext(AutotoolsPackage, XorgPackage):
     """libXext - library for common extensions to the X11 protocol."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXext"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXext"
     xorg_mirror_path = "lib/libXext-1.3.3.tar.gz"
 
     version('1.3.3', sha256='eb0b88050491fef4716da4b06a4d92b4fc9e76f880d6310b2157df604342cfe5')

--- a/var/spack/repos/builtin/packages/libxfixes/package.py
+++ b/var/spack/repos/builtin/packages/libxfixes/package.py
@@ -10,7 +10,7 @@ class Libxfixes(AutotoolsPackage, XorgPackage):
     """This package contains header files and documentation for the XFIXES
     extension.  Library and server implementations are separate."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXfixes"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXfixes"
     xorg_mirror_path = "lib/libXfixes-5.0.2.tar.gz"
 
     version('5.0.2', sha256='ad8df1ecf3324512b80ed12a9ca07556e561b14256d94216e67a68345b23c981')

--- a/var/spack/repos/builtin/packages/libxfont/package.py
+++ b/var/spack/repos/builtin/packages/libxfont/package.py
@@ -14,7 +14,7 @@ class Libxfont(AutotoolsPackage, XorgPackage):
     but should not be used by normal X11 clients.  X11 clients access fonts
     via either the new API's in libXft, or the legacy API's in libX11."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXfont"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXfont"
     xorg_mirror_path = "lib/libXfont-1.5.2.tar.gz"
 
     version('1.5.2', sha256='a7350c75171d03d06ae0d623e42240356d6d3e1ac7dfe606639bf20f0d653c93')

--- a/var/spack/repos/builtin/packages/libxfont2/package.py
+++ b/var/spack/repos/builtin/packages/libxfont2/package.py
@@ -14,7 +14,7 @@ class Libxfont2(AutotoolsPackage, XorgPackage):
     but should not be used by normal X11 clients.  X11 clients access fonts
     via either the new API's in libXft, or the legacy API's in libX11."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXfont"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXfont"
     xorg_mirror_path = "lib/libXfont2-2.0.1.tar.gz"
 
     version('2.0.1', sha256='381b6b385a69343df48a082523c856aed9042fbbc8ee0a6342fb502e4321230a')

--- a/var/spack/repos/builtin/packages/libxfontcache/package.py
+++ b/var/spack/repos/builtin/packages/libxfontcache/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxfontcache(AutotoolsPackage, XorgPackage):
     """Xfontcache - X-TrueType font cache extension client library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXfontcache"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXfontcache"
     xorg_mirror_path = "lib/libXfontcache-1.0.5.tar.gz"
 
     version('1.0.5', sha256='fdba75307a0983d2566554e0e9effa7079551f1b7b46e8de642d067998619659')

--- a/var/spack/repos/builtin/packages/libxft/package.py
+++ b/var/spack/repos/builtin/packages/libxft/package.py
@@ -13,7 +13,7 @@ class Libxft(AutotoolsPackage, XorgPackage):
     connects X applications with the FreeType font rasterization library. Xft
     uses fontconfig to locate fonts so it has no configuration files."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXft"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXft"
     xorg_mirror_path = "lib/libXft-2.3.2.tar.gz"
 
     version('2.3.2', sha256='26cdddcc70b187833cbe9dc54df1864ba4c03a7175b2ca9276de9f05dce74507')

--- a/var/spack/repos/builtin/packages/libxi/package.py
+++ b/var/spack/repos/builtin/packages/libxi/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxi(AutotoolsPackage, XorgPackage):
     """libXi - library for the X Input Extension."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXi"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXi"
     xorg_mirror_path = "lib/libXi-1.7.6.tar.gz"
 
     version('1.7.6', sha256='4e88fa7decd287e58140ea72238f8d54e4791de302938c83695fc0c9ac102b7e')

--- a/var/spack/repos/builtin/packages/libxinerama/package.py
+++ b/var/spack/repos/builtin/packages/libxinerama/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxinerama(AutotoolsPackage, XorgPackage):
     """libXinerama - API for Xinerama extension to X11 Protocol."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXinerama"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXinerama"
     xorg_mirror_path = "lib/libXinerama-1.1.3.tar.gz"
 
     version('1.1.3', sha256='0ba243222ae5aba4c6a3d7a394c32c8b69220a6872dbb00b7abae8753aca9a44')

--- a/var/spack/repos/builtin/packages/libxmu/package.py
+++ b/var/spack/repos/builtin/packages/libxmu/package.py
@@ -12,7 +12,7 @@ class Libxmu(AutotoolsPackage, XorgPackage):
     that it may be layered on top of any proprietary implementation of Xlib
     or Xt."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXmu"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXmu"
     xorg_mirror_path = "lib/libXmu-1.1.2.tar.gz"
 
     version('1.1.2', sha256='e5fd4bacef068f9509b8226017205040e38d3fba8d2de55037200e7176c13dba')

--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxpm(AutotoolsPackage, XorgPackage):
     """libXpm - X Pixmap (XPM) image file format library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXpm"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXpm"
     xorg_mirror_path = "lib/libXpm-3.5.12.tar.gz"
 
     version('3.5.12', sha256='2523acc780eac01db5163267b36f5b94374bfb0de26fc0b5a7bee76649fd8501')

--- a/var/spack/repos/builtin/packages/libxrandr/package.py
+++ b/var/spack/repos/builtin/packages/libxrandr/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxrandr(AutotoolsPackage, XorgPackage):
     """libXrandr - X Resize, Rotate and Reflection extension library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXrandr"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXrandr"
     xorg_mirror_path = "lib/libXrandr-1.5.0.tar.gz"
 
     version('1.5.0', sha256='1b594a149e6b124aab7149446f2fd886461e2935eca8dca43fe83a70cf8ec451')

--- a/var/spack/repos/builtin/packages/libxrender/package.py
+++ b/var/spack/repos/builtin/packages/libxrender/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxrender(AutotoolsPackage, XorgPackage):
     """libXrender - library for the Render Extension to the X11 protocol."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXrender"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXrender"
     xorg_mirror_path = "lib/libXrender-0.9.10.tar.gz"
 
     version('0.9.10', sha256='770527cce42500790433df84ec3521e8bf095dfe5079454a92236494ab296adf')

--- a/var/spack/repos/builtin/packages/libxres/package.py
+++ b/var/spack/repos/builtin/packages/libxres/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxres(AutotoolsPackage, XorgPackage):
     """libXRes - X-Resource extension client library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXRes"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXRes"
     xorg_mirror_path = "lib/libXres-1.0.7.tar.gz"
 
     version('1.0.7', sha256='488c9fa14b38f794d1f019fe62e6b06514a39f1a7538e55ece8faf22482fefcd')

--- a/var/spack/repos/builtin/packages/libxscrnsaver/package.py
+++ b/var/spack/repos/builtin/packages/libxscrnsaver/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxscrnsaver(AutotoolsPackage, XorgPackage):
     """XScreenSaver - X11 Screen Saver extension client library"""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXScrnSaver"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXScrnSaver"
     xorg_mirror_path = "lib/libXScrnSaver-1.2.2.tar.gz"
 
     version('1.2.2', sha256='e12ba814d44f7b58534c0d8521e2d4574f7bf2787da405de4341c3b9f4cc8d96')

--- a/var/spack/repos/builtin/packages/libxt/package.py
+++ b/var/spack/repos/builtin/packages/libxt/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxt(AutotoolsPackage, XorgPackage):
     """libXt - X Toolkit Intrinsics library."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXt"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXt"
     xorg_mirror_path = "lib/libXt-1.1.5.tar.gz"
 
     version('1.1.5', sha256='b59bee38a9935565fa49dc1bfe84cb30173e2e07e1dcdf801430d4b54eb0caa3')

--- a/var/spack/repos/builtin/packages/libxtst/package.py
+++ b/var/spack/repos/builtin/packages/libxtst/package.py
@@ -18,7 +18,7 @@ class Libxtst(AutotoolsPackage, XorgPackage):
     The RECORD extension supports the recording and reporting of all
     core X protocol and arbitrary X extension protocol."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXtst"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXtst"
     xorg_mirror_path = "lib/libXtst-1.2.2.tar.gz"
 
     version('1.2.2', sha256='221838960c7b9058cd6795c1c3ee8e25bae1c68106be314bc3036a4f26be0e6c')

--- a/var/spack/repos/builtin/packages/libxv/package.py
+++ b/var/spack/repos/builtin/packages/libxv/package.py
@@ -10,7 +10,7 @@ class Libxv(AutotoolsPackage, XorgPackage):
     """libXv - library for the X Video (Xv) extension to the
     X Window System."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXv"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXv"
     xorg_mirror_path = "lib/libXv-1.0.10.tar.gz"
 
     version('1.0.10', sha256='89a664928b625558268de81c633e300948b3752b0593453d7815f8775bab5293')

--- a/var/spack/repos/builtin/packages/libxxf86dga/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86dga/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxxf86dga(AutotoolsPackage, XorgPackage):
     """libXxf86dga - Client library for the XFree86-DGA extension."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXxf86dga"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXxf86dga"
     xorg_mirror_path = "lib/libXxf86dga-1.1.4.tar.gz"
 
     version('1.1.4', sha256='e6361620a15ceba666901ca8423e8be0c6ed0271a7088742009160349173766b')

--- a/var/spack/repos/builtin/packages/libxxf86vm/package.py
+++ b/var/spack/repos/builtin/packages/libxxf86vm/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libxxf86vm(AutotoolsPackage, XorgPackage):
     """libXxf86vm - Extension library for the XFree86-VidMode X extension."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libXxf86vm"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libXxf86vm"
     xorg_mirror_path = "lib/libXxf86vm-1.1.4.tar.gz"
 
     version('1.1.4', sha256='5108553c378a25688dcb57dca383664c36e293d60b1505815f67980ba9318a99')

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Libzmq(AutotoolsPackage):
     """The ZMQ networking/concurrency library and core API"""
 
-    homepage = "http://zguide.zeromq.org/"
+    homepage = "https://zguide.zeromq.org/"
     url      = "https://github.com/zeromq/libzmq/releases/download/v4.3.2/zeromq-4.3.2.tar.gz"
     git      = "https://github.com/zeromq/libzmq.git"
 

--- a/var/spack/repos/builtin/packages/luit/package.py
+++ b/var/spack/repos/builtin/packages/luit/package.py
@@ -12,7 +12,7 @@ class Luit(AutotoolsPackage, XorgPackage):
     output from the locale's encoding into UTF-8, and convert terminal
     input from UTF-8 into the locale's encoding."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/luit"
+    homepage = "https://cgit.freedesktop.org/xorg/app/luit"
     xorg_mirror_path = "app/luit-1.1.1.tar.gz"
 
     version('1.1.1', sha256='87b0be0bd01f3b857a53e6625bdd31cef18418c95394b7f4387f8ecef78e45da')

--- a/var/spack/repos/builtin/packages/mafft/package.py
+++ b/var/spack/repos/builtin/packages/mafft/package.py
@@ -12,7 +12,7 @@ class Mafft(Package):
        methods, L-INS-i (accurate; for alignment of <~200 sequences),
        FFT-NS-2 (fast; for alignment of <~30,000 sequences), etc."""
 
-    homepage = "http://mafft.cbrc.jp/alignment/software/index.html"
+    homepage = "https://mafft.cbrc.jp/alignment/software/index.html"
     url      = "http://mafft.cbrc.jp/alignment/software/mafft-7.221-with-extensions-src.tgz"
 
     version('7.481', sha256='7397f1193048587a3d887e46a353418e67849f71729764e8195b218e3453dfa2')

--- a/var/spack/repos/builtin/packages/mira/package.py
+++ b/var/spack/repos/builtin/packages/mira/package.py
@@ -10,7 +10,7 @@ class Mira(AutotoolsPackage):
     """MIRA is a multi-pass DNA sequence data assembler/mapper for whole genome
        and EST/RNASeq projects."""
 
-    homepage = "http://sourceforge.net/projects/mira-assembler/"
+    homepage = "https://sourceforge.net/projects/mira-assembler/"
     url      = "https://downloads.sourceforge.net/project/mira-assembler/MIRA/stable/mira-4.0.2.tar.bz2"
 
     version('4.0.2', sha256='a32cb2b21e0968a5536446287c895fe9e03d11d78957554e355c1080b7b92a80')

--- a/var/spack/repos/builtin/packages/mkfontscale/package.py
+++ b/var/spack/repos/builtin/packages/mkfontscale/package.py
@@ -10,7 +10,7 @@ class Mkfontscale(AutotoolsPackage, XorgPackage):
     """mkfontscale creates the fonts.scale and fonts.dir index files used by the
     legacy X11 font system."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/mkfontscale"
+    homepage = "https://cgit.freedesktop.org/xorg/app/mkfontscale"
     xorg_mirror_path = "app/mkfontscale-1.1.2.tar.gz"
 
     version('1.1.2', sha256='8bba59e60fbc4cb082092cf6b67e810b47b4fe64fbc77dbea1d7e7d55312b2e4')

--- a/var/spack/repos/builtin/packages/nauty/package.py
+++ b/var/spack/repos/builtin/packages/nauty/package.py
@@ -12,7 +12,7 @@ from spack import *
 class Nauty(AutotoolsPackage):
     """nauty and Traces are programs for computing automorphism groups of
     graphsq and digraphs"""
-    homepage = "http://pallini.di.uniroma1.it/index.html"
+    homepage = "https://pallini.di.uniroma1.it/index.html"
     url      = "http://pallini.di.uniroma1.it/nauty26r7.tar.gz"
 
     version('2.6r7', sha256='97b5648de17645895cbd56a9a0b3e23cf01f5332c476d013ea459f1a0363cdc6')

--- a/var/spack/repos/builtin/packages/of-precice/package.py
+++ b/var/spack/repos/builtin/packages/of-precice/package.py
@@ -14,7 +14,7 @@ from spack.pkg.builtin.openfoam import add_extra_files
 class OfPrecice(Package):
     """preCICE adapter for OpenFOAM"""
 
-    homepage = 'https://www.precice.org'
+    homepage = 'https://precice.org/'
     git      = 'https://github.com/precice/openfoam-adapter.git'
 
     # Currently develop only

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -9,7 +9,7 @@ from spack import *
 class OpenpmdApi(CMakePackage):
     """C++ & Python API for Scientific I/O"""
 
-    homepage = "http://www.openPMD.org"
+    homepage = "https://www.openPMD.org"
     url      = "https://github.com/openPMD/openPMD-api/archive/0.13.3.tar.gz"
     git      = "https://github.com/openPMD/openPMD-api.git"
 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -11,7 +11,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     differential equations.
     """
 
-    homepage = "http://www.mcs.anl.gov/petsc/index.html"
+    homepage = "https://www.mcs.anl.gov/petsc/index.html"
     url = "http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-3.15.0.tar.gz"
     git = "https://gitlab.com/petsc/petsc.git"
     maintainers = ['balay', 'barrysmith', 'jedbrown']

--- a/var/spack/repos/builtin/packages/pplacer/package.py
+++ b/var/spack/repos/builtin/packages/pplacer/package.py
@@ -14,7 +14,7 @@ class Pplacer(Package):
        visualization and downstream analysis.
     """
 
-    homepage = "http://matsen.fhcrc.org/pplacer/"
+    homepage = "https://matsen.fhcrc.org/pplacer/"
     url      = "https://github.com/matsen/pplacer/releases/download/v1.1.alpha19/pplacer-linux-v1.1.alpha19.zip"
 
     version('1.1.alpha19', sha256='9131b45c35ddb927f866385f149cf64af5dffe724234cd4548c22303a992347d')

--- a/var/spack/repos/builtin/packages/pvm/package.py
+++ b/var/spack/repos/builtin/packages/pvm/package.py
@@ -13,7 +13,7 @@ class Pvm(MakefilePackage):
     heterogeneous collection of Unix and/or Windows computers hooked together
     by a network to be used as a single large parallel computer."""
 
-    homepage = "http://www.csm.ornl.gov/pvm/pvm_home.html"
+    homepage = "https://www.csm.ornl.gov/pvm/pvm_home.html"
     url      = "http://www.netlib.org/pvm3/pvm3.4.6.tgz"
 
     version('3.4.6', sha256='482665e9bc975d826bcdacf1df1d42e43deda9585a2c430fd3b7b7ed08eada44')

--- a/var/spack/repos/builtin/packages/py-biopython/package.py
+++ b/var/spack/repos/builtin/packages/py-biopython/package.py
@@ -12,7 +12,7 @@ class PyBiopython(PythonPackage):
        bioinformatics.
 
     """
-    homepage = "http://biopython.org/wiki/Main_Page"
+    homepage = "https://biopython.org/wiki/Main_Page"
     url      = "http://biopython.org/DIST/biopython-1.65.tar.gz"
 
     version('1.78', sha256='1ee0a0b6c2376680fea6642d5080baa419fd73df104a62d58a8baf7a8bbe4564')

--- a/var/spack/repos/builtin/packages/py-pyrsistent/package.py
+++ b/var/spack/repos/builtin/packages/py-pyrsistent/package.py
@@ -11,7 +11,7 @@ class PyPyrsistent(PythonPackage):
        (by some referred to as functional data structures).
        Persistent in the sense that they are immutable."""
 
-    homepage = "http://github.com/tobgu/pyrsistent/"
+    homepage = "https://github.com/tobgu/pyrsistent/"
     pypi = "pyrsistent/pyrsistent-0.15.7.tar.gz"
 
     version('0.15.7', sha256='cdc7b5e3ed77bed61270a47d35434a30617b9becdf2478af76ad2c6ade307280')

--- a/var/spack/repos/builtin/packages/py-python-igraph/package.py
+++ b/var/spack/repos/builtin/packages/py-python-igraph/package.py
@@ -10,7 +10,7 @@ class PyPythonIgraph(PythonPackage):
     """igraph is a collection of network analysis tools with the emphasis on
        efficiency, portability and ease of use."""
 
-    homepage = "http://igraph.org/"
+    homepage = "https://igraph.org/"
     url      = "http://igraph.org/nightly/get/python/python-igraph-0.7.0.tar.gz"
 
     version('0.7.0', sha256='64ac270e80a92066d489407be1900a329df8e26844430f941ecc88771188c471')

--- a/var/spack/repos/builtin/packages/py-zope-event/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-event/package.py
@@ -9,7 +9,7 @@ from spack import *
 class PyZopeEvent(PythonPackage):
     """Very basic event publishing system."""
 
-    homepage = "http://github.com/zopefoundation/zope.event"
+    homepage = "https://github.com/zopefoundation/zope.event"
     pypi = "zope.event/zope.event-4.3.0.tar.gz"
 
     version('4.3.0', sha256='e0ecea24247a837c71c106b0341a7a997e3653da820d21ef6c08b32548f733e7')

--- a/var/spack/repos/builtin/packages/r-amelia/package.py
+++ b/var/spack/repos/builtin/packages/r-amelia/package.py
@@ -15,7 +15,7 @@ class RAmelia(RPackage):
     time-series-cross-sectional data set (such as collected by
     years for each of several countries)."""
 
-    homepage = "http://gking.harvard.edu/amelia"
+    homepage = "https://gking.harvard.edu/amelia"
     url      = "https://cloud.r-project.org/src/contrib/Amelia_1.7.6.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/Amelia"
 

--- a/var/spack/repos/builtin/packages/r-biasedurn/package.py
+++ b/var/spack/repos/builtin/packages/r-biasedurn/package.py
@@ -14,7 +14,7 @@ class RBiasedurn(RPackage):
        hypergeometric distribution). See vignette("UrnTheory") for
        explanation of these distributions."""
 
-    homepage = "http://www.agner.org/random/"
+    homepage = "https://www.agner.org/random/"
     url      = "https://cloud.r-project.org/src/contrib/BiasedUrn_1.07.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/BiasedUrn/"
 

--- a/var/spack/repos/builtin/packages/r-europepmc/package.py
+++ b/var/spack/repos/builtin/packages/r-europepmc/package.py
@@ -21,7 +21,7 @@ class REuropepmc(RPackage):
     registration or API key is required. See the vignettes for usage
     examples."""
 
-    homepage = "http://github.com/ropensci/europepmc/"
+    homepage = "https://github.com/ropensci/europepmc/"
     url      = "https://cloud.r-project.org/src/contrib/europepmc_0.3.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/europepmc"
 

--- a/var/spack/repos/builtin/packages/r-expm/package.py
+++ b/var/spack/repos/builtin/packages/r-expm/package.py
@@ -12,7 +12,7 @@ class RExpm(RPackage):
     Computation of the matrix exponential, logarithm, sqrt, and related
     quantities."""
 
-    homepage = "http://r-forge.r-project.org/projects/expm"
+    homepage = "https://r-forge.r-project.org/projects/expm"
     url      = "https://cloud.r-project.org/src/contrib/expm_0.999-2.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/expm"
 

--- a/var/spack/repos/builtin/packages/r-forcats/package.py
+++ b/var/spack/repos/builtin/packages/r-forcats/package.py
@@ -14,7 +14,7 @@ class RForcats(RPackage):
     and tools for modifying factor levels (including collapsing rare levels
     into other, 'anonymising', and manually 'recoding')."""
 
-    homepage = "http://forcats.tidyverse.org/"
+    homepage = "https://forcats.tidyverse.org/"
     url      = "https://cloud.r-project.org/src/contrib/forcats_0.2.0.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/forcats"
 

--- a/var/spack/repos/builtin/packages/r-ggplot2/package.py
+++ b/var/spack/repos/builtin/packages/r-ggplot2/package.py
@@ -14,7 +14,7 @@ class RGgplot2(RPackage):
     aesthetics, what graphical primitives to use, and it takes care of the
     details."""
 
-    homepage = "http://ggplot2.org/"
+    homepage = "https://ggplot2.tidyverse.org/"
     url      = "https://cloud.r-project.org/src/contrib/ggplot2_2.2.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/ggplot2"
 

--- a/var/spack/repos/builtin/packages/r-ggrepel/package.py
+++ b/var/spack/repos/builtin/packages/r-ggrepel/package.py
@@ -13,7 +13,7 @@ class RGgrepel(RPackage):
     text labels. Labels repel away from each other and away from the data
     points."""
 
-    homepage = "http://github.com/slowkow/ggrepel"
+    homepage = "https://github.com/slowkow/ggrepel"
     url      = "https://cloud.r-project.org/src/contrib/ggrepel_0.6.5.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/ggrepel"
 

--- a/var/spack/repos/builtin/packages/r-ggvis/package.py
+++ b/var/spack/repos/builtin/packages/r-ggvis/package.py
@@ -13,7 +13,7 @@ class RGgvis(RPackage):
     parts of 'ggplot2', combining them with the reactive framework from 'shiny'
     and web graphics from 'vega'."""
 
-    homepage = "http://ggvis.rstudio.com/"
+    homepage = "https://ggvis.rstudio.com/"
     url      = "https://cloud.r-project.org/src/contrib/ggvis_0.4.3.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/ggvis"
 

--- a/var/spack/repos/builtin/packages/r-haven/package.py
+++ b/var/spack/repos/builtin/packages/r-haven/package.py
@@ -12,7 +12,7 @@ class RHaven(RPackage):
     Import foreign statistical formats into R via the embedded 'ReadStat' C
     library, <https://github.com/WizardMac/ReadStat>."""
 
-    homepage = "http://haven.tidyverse.org/"
+    homepage = "https://haven.tidyverse.org/"
     url      = "https://cloud.r-project.org/src/contrib/haven_1.1.0.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/haven"
 

--- a/var/spack/repos/builtin/packages/r-hexbin/package.py
+++ b/var/spack/repos/builtin/packages/r-hexbin/package.py
@@ -13,7 +13,7 @@ class RHexbin(RPackage):
     Binning and plotting functions for hexagonal bins. Now uses and relies
     on grid graphics and formal (S4) classes and methods."""
 
-    homepage = "http://github.com/edzer/hexbin"
+    homepage = "https://github.com/edzer/hexbin"
     url      = "https://cloud.r-project.org/src/contrib/hexbin_1.27.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/hexbin"
 

--- a/var/spack/repos/builtin/packages/r-igraph/package.py
+++ b/var/spack/repos/builtin/packages/r-igraph/package.py
@@ -13,7 +13,7 @@ class RIgraph(RPackage):
     graphs very well and provides functions for generating random and regular
     graphs, graph visualization, centrality methods and much more."""
 
-    homepage = "http://igraph.org/"
+    homepage = "https://igraph.org/"
     url      = "https://cloud.r-project.org/src/contrib/igraph_1.0.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/igraph"
 

--- a/var/spack/repos/builtin/packages/r-intervals/package.py
+++ b/var/spack/repos/builtin/packages/r-intervals/package.py
@@ -11,7 +11,7 @@ class RIntervals(RPackage):
 
     Tools for working with and comparing sets of points and intervals."""
 
-    homepage = "http://github.com/edzer/intervals"
+    homepage = "https://github.com/edzer/intervals"
     url      = "https://cloud.r-project.org/src/contrib/intervals_0.15.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/intervals"
 

--- a/var/spack/repos/builtin/packages/r-maptools/package.py
+++ b/var/spack/repos/builtin/packages/r-maptools/package.py
@@ -15,7 +15,7 @@ class RMaptools(RPackage):
     exchanging spatial objects with packages such as PBSmapping, spatstat,
     maps, RArcInfo, Stata tmap, WinBUGS, Mondrian, and others."""
 
-    homepage = "http://r-forge.r-project.org/projects/maptools/"
+    homepage = "https://r-forge.r-project.org/projects/maptools/"
     url      = "https://cloud.r-project.org/src/contrib/maptools_0.8-39.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/maptools"
 

--- a/var/spack/repos/builtin/packages/r-marray/package.py
+++ b/var/spack/repos/builtin/packages/r-marray/package.py
@@ -12,7 +12,7 @@ class RMarray(RPackage):
     Class definitions for two-color spotted microarray data. Fuctions for data
     input, diagnostic plots, normalization and quality checking."""
 
-    homepage = "http://www.maths.usyd.edu.au/u/jeany/"
+    homepage = "https://www.maths.usyd.edu.au/u/jeany/"
     bioc     = "marray"
 
     version('1.68.0', commit='67b3080486abdba7dd19fccd7fb731b0e8b5b3f9')

--- a/var/spack/repos/builtin/packages/r-phytools/package.py
+++ b/var/spack/repos/builtin/packages/r-phytools/package.py
@@ -28,7 +28,7 @@ class RPhytools(RPackage):
     range of models, and for a wide variety of other manipulations and analyses
     that phylogenetic biologists might find useful in their research."""
 
-    homepage = "http://github.com/liamrevell/phytools"
+    homepage = "https://github.com/liamrevell/phytools"
     url      = "https://cloud.r-project.org/src/contrib/phytools_0.6-60.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/phytools/"
 

--- a/var/spack/repos/builtin/packages/r-purrr/package.py
+++ b/var/spack/repos/builtin/packages/r-purrr/package.py
@@ -9,7 +9,7 @@ from spack import *
 class RPurrr(RPackage):
     """A complete and consistent functional programming toolkit for R."""
 
-    homepage = "http://purrr.tidyverse.org/"
+    homepage = "https://purrr.tidyverse.org/"
     url      = "https://cloud.r-project.org/src/contrib/purrr_0.2.4.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/purrr"
 

--- a/var/spack/repos/builtin/packages/r-qtl/package.py
+++ b/var/spack/repos/builtin/packages/r-qtl/package.py
@@ -13,7 +13,7 @@ class RQtl(RPackage):
     trait loci, QTLs) contributing to variation in quantitative traits. Broman
     et al. (2003) <doi:10.1093/bioinformatics/btg112>."""
 
-    homepage = "http://rqtl.org"
+    homepage = "https://rqtl.org"
     url      = "https://cloud.r-project.org/src/contrib/qtl_1.44-9.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/qtl"
 

--- a/var/spack/repos/builtin/packages/r-readxl/package.py
+++ b/var/spack/repos/builtin/packages/r-readxl/package.py
@@ -13,7 +13,7 @@ class RReadxl(RPackage):
     <https://rapidxml.sourceforge.net>. Works on Windows, Mac and Linux
     without external dependencies."""
 
-    homepage = "http://readxl.tidyverse.org/"
+    homepage = "https://readxl.tidyverse.org/"
     url      = "https://cloud.r-project.org/src/contrib/readxl_1.1.0.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/readxl"
 

--- a/var/spack/repos/builtin/packages/r-rgexf/package.py
+++ b/var/spack/repos/builtin/packages/r-rgexf/package.py
@@ -18,7 +18,7 @@ class RRgexf(RPackage):
     through "sigmajs" (a javascript library) and interact with the igraph
     package."""
 
-    homepage = "http://bitbucket.org/gvegayon/rgexf"
+    homepage = "https://bitbucket.org/gvegayon/rgexf"
     url      = "https://cloud.r-project.org/src/contrib/rgexf_0.15.3.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/rgexf"
 

--- a/var/spack/repos/builtin/packages/r-rmarkdown/package.py
+++ b/var/spack/repos/builtin/packages/r-rmarkdown/package.py
@@ -12,7 +12,7 @@ class RRmarkdown(RPackage):
 
     Convert R Markdown documents into a variety of formats."""
 
-    homepage = "http://rmarkdown.rstudio.com/"
+    homepage = "https://rmarkdown.rstudio.com/"
     cran     = "rmarkdown"
 
     version('2.9', sha256='6ce5af8b9a7c282619f74d3999d27ec4de12d3f93cde8fd12cc4c19f02ea8668')

--- a/var/spack/repos/builtin/packages/r-rstantools/package.py
+++ b/var/spack/repos/builtin/packages/r-rstantools/package.py
@@ -15,7 +15,7 @@ class RRstantools(RPackage):
     'Stan'-based R packages, and vignettes with recommendations for
     developers."""
 
-    homepage = "http://discourse.mc-stan.org/"
+    homepage = "https://discourse.mc-stan.org/"
     url      = "https://cloud.r-project.org/src/contrib/rstantools_1.5.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/rstantools"
 

--- a/var/spack/repos/builtin/packages/r-seurat/package.py
+++ b/var/spack/repos/builtin/packages/r-seurat/package.py
@@ -17,7 +17,7 @@ class RSeurat(RPackage):
     R, et al (2015) <doi:10.1016/j.cell.2015.05.002>, and Stuart T, Butler A,
     et al (2019) <doi:10.1016/j.cell.2019.05.031> for more details."""
 
-    homepage = "http://satijalab.org/seurat/"
+    homepage = "https://satijalab.org/seurat/"
     url      = "https://cloud.r-project.org/src/contrib/Seurat_2.1.0.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/Seurat"
 

--- a/var/spack/repos/builtin/packages/r-shiny/package.py
+++ b/var/spack/repos/builtin/packages/r-shiny/package.py
@@ -14,7 +14,7 @@ class RShiny(RPackage):
     pre-built widgets make it possible to build beautiful, responsive, and
     powerful applications with minimal effort."""
 
-    homepage = "http://shiny.rstudio.com/"
+    homepage = "https://shiny.rstudio.com/"
     url      = "https://cloud.r-project.org/src/contrib/shiny_1.0.5.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/shiny"
 

--- a/var/spack/repos/builtin/packages/r-spacetime/package.py
+++ b/var/spack/repos/builtin/packages/r-spacetime/package.py
@@ -16,7 +16,7 @@ class RSpacetime(RPackage):
     subsetting, as well as for spatial/temporal/spatio-temporal matching or
     aggregation, retrieving coordinates, print, summary, etc."""
 
-    homepage = "http://github.com/edzer/spacetime"
+    homepage = "https://github.com/edzer/spacetime"
     url      = "https://cloud.r-project.org/src/contrib/spacetime_1.2-2.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/spacetime"
 

--- a/var/spack/repos/builtin/packages/r-splitstackshape/package.py
+++ b/var/spack/repos/builtin/packages/r-splitstackshape/package.py
@@ -18,7 +18,7 @@ class RSplitstackshape(RPackage):
     and which melt and dcast from reshape2 do not easily handle.
     """
 
-    homepage = "http://github.com/mrdwab/splitstackshape"
+    homepage = "https://github.com/mrdwab/splitstackshape"
     url      = "https://cloud.r-project.org/src/contrib/splitstackshape_1.4.4.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/splitstackshape"
 

--- a/var/spack/repos/builtin/packages/r-tidyverse/package.py
+++ b/var/spack/repos/builtin/packages/r-tidyverse/package.py
@@ -15,7 +15,7 @@ class RTidyverse(RPackage):
     in a single step. Learn more about the 'tidyverse' at
     <https://tidyverse.org>."""
 
-    homepage = "http://tidyverse.tidyverse.org/"
+    homepage = "https://tidyverse.tidyverse.org/"
     url      = "https://cloud.r-project.org/src/contrib/tidyverse_1.2.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/tidyverse"
 

--- a/var/spack/repos/builtin/packages/r-upsetr/package.py
+++ b/var/spack/repos/builtin/packages/r-upsetr/package.py
@@ -10,7 +10,7 @@ class RUpsetr(RPackage):
     """UpSetR: A More Scalable Alternative to Venn and Euler Diagrams
        forVisualizing Intersecting Sets"""
 
-    homepage = "http://github.com/hms-dbmi/UpSetR"
+    homepage = "https://github.com/hms-dbmi/UpSetR"
     url      = "https://cloud.r-project.org/src/contrib/UpSetR_1.4.0.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/UpSetR"
 

--- a/var/spack/repos/builtin/packages/r-xts/package.py
+++ b/var/spack/repos/builtin/packages/r-xts/package.py
@@ -14,7 +14,7 @@ class RXts(RPackage):
     allowing for user level customization and extension, while simplifying
     cross-class interoperability."""
 
-    homepage = "http://r-forge.r-project.org/projects/xts/"
+    homepage = "https://r-forge.r-project.org/projects/xts/"
     url      = "https://cloud.r-project.org/src/contrib/xts_0.11-2.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/xts"
 

--- a/var/spack/repos/builtin/packages/randrproto/package.py
+++ b/var/spack/repos/builtin/packages/randrproto/package.py
@@ -13,7 +13,7 @@ class Randrproto(AutotoolsPackage, XorgPackage):
     screens, so as to resize, rotate and reflect the root window of a screen.
     """
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/randrproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/randrproto"
     xorg_mirror_path = "proto/randrproto-1.5.0.tar.gz"
 
     version('1.5.0', sha256='8f8a716d6daa6ba05df97d513960d35a39e040600bf04b313633f11679006fab')

--- a/var/spack/repos/builtin/packages/rasqal/package.py
+++ b/var/spack/repos/builtin/packages/rasqal/package.py
@@ -12,7 +12,7 @@ class Rasqal(AutotoolsPackage):
     syntaxes, query construction and execution of queries returning
     results as bindings, boolean, RDF graphs/triples or syntaxes."""
 
-    homepage = "http://librdf.org/"
+    homepage = "https://librdf.org/"
     url      = "http://download.librdf.org/source/rasqal-0.9.33.tar.gz"
 
     version('0.9.33', sha256='6924c9ac6570bd241a9669f83b467c728a322470bf34f4b2da4f69492ccfd97c')

--- a/var/spack/repos/builtin/packages/recordproto/package.py
+++ b/var/spack/repos/builtin/packages/recordproto/package.py
@@ -12,7 +12,7 @@ class Recordproto(AutotoolsPackage, XorgPackage):
     This extension defines a protocol for the recording and playback of user
     actions in the X Window System."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/recordproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/recordproto"
     xorg_mirror_path = "proto/recordproto-1.14.2.tar.gz"
 
     version('1.14.2', sha256='485f792570dd7afe49144227f325bf2827bc7d87aae6a8ab6c1de2b06b1c68c5')

--- a/var/spack/repos/builtin/packages/renderproto/package.py
+++ b/var/spack/repos/builtin/packages/renderproto/package.py
@@ -12,7 +12,7 @@ class Renderproto(AutotoolsPackage, XorgPackage):
     This extension defines the protcol for a digital image composition as
     the foundation of a new rendering model within the X Window System."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/renderproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/renderproto"
     xorg_mirror_path = "proto/renderproto-0.11.1.tar.gz"
 
     version('0.11.1', sha256='a0a4be3cad9381ae28279ba5582e679491fc2bec9aab8a65993108bf8dbce5fe')

--- a/var/spack/repos/builtin/packages/resourceproto/package.py
+++ b/var/spack/repos/builtin/packages/resourceproto/package.py
@@ -12,7 +12,7 @@ class Resourceproto(AutotoolsPackage, XorgPackage):
     This extension defines a protocol that allows a client to query the
     X server about its usage of various resources."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/resourceproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/resourceproto"
     xorg_mirror_path = "proto/resourceproto-1.2.0.tar.gz"
 
     version('1.2.0', sha256='469029d14fdeeaa7eed1be585998ff4cb92cf664f872d1d69c04140815b78734')

--- a/var/spack/repos/builtin/packages/scrnsaverproto/package.py
+++ b/var/spack/repos/builtin/packages/scrnsaverproto/package.py
@@ -12,7 +12,7 @@ class Scrnsaverproto(AutotoolsPackage, XorgPackage):
     This extension defines a protocol to control screensaver features
     and also to query screensaver info on specific windows."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/scrnsaverproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/scrnsaverproto"
     xorg_mirror_path = "proto/scrnsaverproto-1.2.2.tar.gz"
 
     version('1.2.2', sha256='d8dee19c52977f65af08fad6aa237bacee11bc5a33e1b9b064e8ac1fd99d6e79')

--- a/var/spack/repos/builtin/packages/setxkbmap/package.py
+++ b/var/spack/repos/builtin/packages/setxkbmap/package.py
@@ -11,7 +11,7 @@ class Setxkbmap(AutotoolsPackage, XorgPackage):
     specified keyboard to use the layout determined by the options listed
     on the command line."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/setxkbmap"
+    homepage = "https://cgit.freedesktop.org/xorg/app/setxkbmap"
     xorg_mirror_path = "app/setxkbmap-1.3.1.tar.gz"
 
     version('1.3.1', sha256='e24a73669007fa3b280eba4bdc7f75715aeb2e394bf2d63f5cc872502ddde264')

--- a/var/spack/repos/builtin/packages/smartmontools/package.py
+++ b/var/spack/repos/builtin/packages/smartmontools/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Smartmontools(AutotoolsPackage):
     """S.M.A.R.T. utility toolset."""
 
-    homepage = "http://smartmontools.sourceforge.net"
+    homepage = "https://smartmontools.sourceforge.net"
     url      = "https://nchc.dl.sourceforge.net/project/smartmontools/smartmontools/6.6/smartmontools-6.6.tar.gz"
 
     version('6.6', sha256='51f43d0fb064fccaf823bbe68cf0d317d0895ff895aa353b3339a3b316a53054')

--- a/var/spack/repos/builtin/packages/twm/package.py
+++ b/var/spack/repos/builtin/packages/twm/package.py
@@ -12,7 +12,7 @@ class Twm(AutotoolsPackage, XorgPackage):
     user-defined macro functions, click-to-type and pointer-driven
     keyboard focus, and user-specified key and pointer button bindings."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/twm"
+    homepage = "https://cgit.freedesktop.org/xorg/app/twm"
     xorg_mirror_path = "app/twm-1.0.9.tar.gz"
 
     version('1.0.9', sha256='1c325e8456a200693c816baa27ceca9c5e5e0f36af63d98f70a335853a0039e8')

--- a/var/spack/repos/builtin/packages/util-macros/package.py
+++ b/var/spack/repos/builtin/packages/util-macros/package.py
@@ -11,7 +11,7 @@ class UtilMacros(AutotoolsPackage, XorgPackage):
     other Xorg modular packages, and is needed to generate new versions
     of their configure scripts with autoconf."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/util/macros/"
+    homepage = "https://cgit.freedesktop.org/xorg/util/macros/"
     xorg_mirror_path = "util/util-macros-1.19.1.tar.bz2"
 
     maintainers = ['robert-mijakovic']

--- a/var/spack/repos/builtin/packages/videoproto/package.py
+++ b/var/spack/repos/builtin/packages/videoproto/package.py
@@ -12,7 +12,7 @@ class Videoproto(AutotoolsPackage, XorgPackage):
     This extension provides a protocol for a video output mechanism,
     mainly to rescale video playback in the video controller hardware."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/videoproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/videoproto"
     xorg_mirror_path = "proto/videoproto-2.3.3.tar.gz"
 
     version('2.3.3', sha256='df8dfeb158767f843054248d020e291a2c40f7f5e0ac6d8706966686fee7c5c0')

--- a/var/spack/repos/builtin/packages/xauth/package.py
+++ b/var/spack/repos/builtin/packages/xauth/package.py
@@ -10,7 +10,7 @@ class Xauth(AutotoolsPackage, XorgPackage):
     """The xauth program is used to edit and display the authorization
     information used in connecting to the X server."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xauth"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xauth"
     xorg_mirror_path = "app/xauth-1.0.9.tar.gz"
 
     version('1.0.9', sha256='0709070caf23ba2fb99536907b75be1fe31853999c62d3e87a6a8d26ba8a8cdb')

--- a/var/spack/repos/builtin/packages/xbacklight/package.py
+++ b/var/spack/repos/builtin/packages/xbacklight/package.py
@@ -12,7 +12,7 @@ class Xbacklight(AutotoolsPackage, XorgPackage):
     supporting backlight brightness control and changes them all in the
     same way."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xbacklight"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xbacklight"
     xorg_mirror_path = "app/xbacklight-1.2.1.tar.gz"
 
     version('1.2.1', sha256='82c80cd851e3eb6d7a216d92465fcf6d5e456c2d5ac12c63cd2757b39fb65b10')

--- a/var/spack/repos/builtin/packages/xcalc/package.py
+++ b/var/spack/repos/builtin/packages/xcalc/package.py
@@ -10,7 +10,7 @@ class Xcalc(AutotoolsPackage, XorgPackage):
     """xcalc is a scientific calculator X11 client that can emulate a TI-30
     or an HP-10C."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xcalc"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xcalc"
     xorg_mirror_path = "app/xcalc-1.0.6.tar.gz"
 
     version('1.0.6', sha256='7fd5cd9a35160925c41cbadfb1ea23599fa20fd26cd873dab20a650b24efe8d1')

--- a/var/spack/repos/builtin/packages/xclock/package.py
+++ b/var/spack/repos/builtin/packages/xclock/package.py
@@ -11,7 +11,7 @@ class Xclock(AutotoolsPackage, XorgPackage):
     the time in analog or digital form, continuously updated at a
     frequency which may be specified by the user."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xclock"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xclock"
     xorg_mirror_path = "app/xclock-1.0.7.tar.gz"
 
     version('1.0.7', sha256='e730bd575938d5628ef47003a9d4d41b882621798227f5d0c12f4a26365ed1b5')

--- a/var/spack/repos/builtin/packages/xcmiscproto/package.py
+++ b/var/spack/repos/builtin/packages/xcmiscproto/package.py
@@ -12,7 +12,7 @@ class Xcmiscproto(AutotoolsPackage, XorgPackage):
     This extension defines a protocol that provides Xlib two ways to query
     the server for available resource IDs."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/xcmiscproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xcmiscproto"
     xorg_mirror_path = "proto/xcmiscproto-1.2.2.tar.gz"
 
     version('1.2.2', sha256='48013cfbe4bd5580925a854a43e2bccbb4c7a5a31128070644617b6dc7f8ef85')

--- a/var/spack/repos/builtin/packages/xcompmgr/package.py
+++ b/var/spack/repos/builtin/packages/xcompmgr/package.py
@@ -11,7 +11,7 @@ class Xcompmgr(AutotoolsPackage, XorgPackage):
     XFIXES, DAMAGE, RENDER, and COMPOSITE extensions.  It enables basic
     eye-candy effects."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xcompmgr"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xcompmgr"
     xorg_mirror_path = "app/xcompmgr-1.1.7.tar.gz"
 
     version('1.1.7', sha256='ef4b23c370f99403bbd9b6227f8aa4edc3bc83fc6d57ee71f6f442397cef505a')

--- a/var/spack/repos/builtin/packages/xcursor-themes/package.py
+++ b/var/spack/repos/builtin/packages/xcursor-themes/package.py
@@ -11,7 +11,7 @@ class XcursorThemes(Package, XorgPackage):
     originally created for the XFree86 Project, and now shipped as part
     of the X.Org software distribution."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/data/cursors"
+    homepage = "https://cgit.freedesktop.org/xorg/data/cursors"
     xorg_mirror_path = "data/xcursor-themes-1.0.4.tar.gz"
 
     version('1.0.4', sha256='8ed23bab13a4010fe4e95b37eefb634e31ac7cb8240b8b3b7d919c3a2db09503')

--- a/var/spack/repos/builtin/packages/xdm/package.py
+++ b/var/spack/repos/builtin/packages/xdm/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xdm(AutotoolsPackage, XorgPackage):
     """X Display Manager / XDMCP server."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xdm"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xdm"
     xorg_mirror_path = "app/xdm-1.1.11.tar.gz"
 
     version('1.1.11', sha256='38c544a986143b1f24566c1a0111486b339b92224b927be78714eeeedca12a14')

--- a/var/spack/repos/builtin/packages/xdpyinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdpyinfo/package.py
@@ -14,7 +14,7 @@ class Xdpyinfo(AutotoolsPackage, XorgPackage):
     and the server, and the different types of screens, visuals, and X11
     protocol extensions that are available."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xdpyinfo"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xdpyinfo"
     xorg_mirror_path = "app/xdpyinfo-1.3.2.tar.gz"
 
     version('1.3.2', sha256='ef39935e8e9b328e54a85d6218d410d6939482da6058db1ee1b39749d98cbcf2')

--- a/var/spack/repos/builtin/packages/xdriinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdriinfo/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xdriinfo(AutotoolsPackage, XorgPackage):
     """xdriinfo - query configuration information of X11 DRI drivers."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xdriinfo"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xdriinfo"
     xorg_mirror_path = "app/xdriinfo-1.0.5.tar.gz"
 
     version('1.0.5', sha256='e4e6abaa4591c540ab63133927a6cebf0a5f4d27dcd978878ab4a422d62a838e')

--- a/var/spack/repos/builtin/packages/xev/package.py
+++ b/var/spack/repos/builtin/packages/xev/package.py
@@ -15,7 +15,7 @@ class Xev(AutotoolsPackage, XorgPackage):
     debugging and development tool, and should not be needed in normal
     usage."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xev"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xev"
     xorg_mirror_path = "app/xev-1.2.2.tar.gz"
 
     version('1.2.2', sha256='e4c0c7b6f411e8b9731f2bb10d729d167bd00480d172c28b62607a6ea9e45c57')

--- a/var/spack/repos/builtin/packages/xextproto/package.py
+++ b/var/spack/repos/builtin/packages/xextproto/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xextproto(AutotoolsPackage, XorgPackage):
     """X Protocol Extensions."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/proto/xextproto"
+    homepage = "https://cgit.freedesktop.org/xorg/proto/xextproto"
     xorg_mirror_path = "proto/xextproto-7.3.0.tar.gz"
 
     version('7.3.0', sha256='1b1bcdf91221e78c6c33738667a57bd9aaa63d5953174ad8ed9929296741c9f5')

--- a/var/spack/repos/builtin/packages/xeyes/package.py
+++ b/var/spack/repos/builtin/packages/xeyes/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xeyes(AutotoolsPackage, XorgPackage):
     """xeyes - a follow the mouse X demo, using the X SHAPE extension"""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xeyes"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xeyes"
     xorg_mirror_path = "app/xeyes-1.1.1.tar.gz"
 
     version('1.1.1', sha256='3a1871a560ab87c72a2e2ecb7fd582474448faec3e254c9bd8bead428ab1bca3')

--- a/var/spack/repos/builtin/packages/xhost/package.py
+++ b/var/spack/repos/builtin/packages/xhost/package.py
@@ -10,7 +10,7 @@ class Xhost(AutotoolsPackage, XorgPackage):
     """xhost is used to manage the list of host names or user names
     allowed to make connections to the X server."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xhost"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xhost"
     xorg_mirror_path = "app/xhost-1.0.7.tar.gz"
 
     version('1.0.7', sha256='8dd1b6245dfbdef45a64a18ea618f233f77432c2f30881b1db9dc40d510d9490')

--- a/var/spack/repos/builtin/packages/xinput/package.py
+++ b/var/spack/repos/builtin/packages/xinput/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xinput(AutotoolsPackage, XorgPackage):
     """xinput is a utility to configure and test XInput devices."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xinput"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xinput"
     xorg_mirror_path = "app/xinput-1.6.2.tar.gz"
 
     version('1.6.2', sha256='2c8ca5ff2a8703cb7d898629a4311db720dbd30d0c162bfe37f18849a727bd42')

--- a/var/spack/repos/builtin/packages/xmessage/package.py
+++ b/var/spack/repos/builtin/packages/xmessage/package.py
@@ -11,7 +11,7 @@ class Xmessage(AutotoolsPackage, XorgPackage):
     on an "okay" button to dismiss it or can select one of several buttons
     to answer a question.  xmessage can also exit after a specified time."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xmessage"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xmessage"
     xorg_mirror_path = "app/xmessage-1.0.4.tar.gz"
 
     version('1.0.4', sha256='883099c3952c8cace5bd11d3df2e9ca143fc07375997435d5ff4f2d50353acca')

--- a/var/spack/repos/builtin/packages/xmore/package.py
+++ b/var/spack/repos/builtin/packages/xmore/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xmore(AutotoolsPackage, XorgPackage):
     """xmore - plain text display program for the X Window System."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xmore"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xmore"
     xorg_mirror_path = "app/xmore-1.0.2.tar.gz"
 
     version('1.0.2', sha256='7371631d05986f1111f2026a77e43e048519738cfcc493c6222b66e7b0f309c0')

--- a/var/spack/repos/builtin/packages/xorg-cf-files/package.py
+++ b/var/spack/repos/builtin/packages/xorg-cf-files/package.py
@@ -12,7 +12,7 @@ class XorgCfFiles(AutotoolsPackage, XorgPackage):
     have not been verified or tested in over a decade), and for many of the
     libraries formerly delivered in the X.Org monolithic releases."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/util/cf"
+    homepage = "https://cgit.freedesktop.org/xorg/util/cf"
     xorg_mirror_path = "util/xorg-cf-files-1.0.6.tar.gz"
 
     version('1.0.6', sha256='6d56094e5d1a6c7d7a9576ac3a0fc2c042344509ea900d59f4b23df668b96c7a')

--- a/var/spack/repos/builtin/packages/xorg-docs/package.py
+++ b/var/spack/repos/builtin/packages/xorg-docs/package.py
@@ -12,7 +12,7 @@ class XorgDocs(AutotoolsPackage, XorgPackage):
 
     The preferred documentation format for these documents is DocBook XML."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/doc/xorg-docs"
+    homepage = "https://cgit.freedesktop.org/xorg/doc/xorg-docs"
     xorg_mirror_path = "doc/xorg-docs-1.7.1.tar.gz"
 
     version('1.7.1', sha256='360707db2ba48f6deeb53d570deca9fa98218af48ead4a726a67f63e3ef63816')

--- a/var/spack/repos/builtin/packages/xorg-server/package.py
+++ b/var/spack/repos/builtin/packages/xorg-server/package.py
@@ -10,7 +10,7 @@ class XorgServer(AutotoolsPackage, XorgPackage):
     """X.Org Server is the free and open source implementation of the display
     server for the X Window System stewarded by the X.Org Foundation."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/xserver"
+    homepage = "https://cgit.freedesktop.org/xorg/xserver"
     xorg_mirror_path = "xserver/xorg-server-1.18.99.901.tar.gz"
 
     version('1.18.99.901', sha256='c8425163b588de2ee7e5c8e65b0749f2710f55a7e02a8d1dc83b3630868ceb21')

--- a/var/spack/repos/builtin/packages/xrandr/package.py
+++ b/var/spack/repos/builtin/packages/xrandr/package.py
@@ -10,7 +10,7 @@ class Xrandr(AutotoolsPackage, XorgPackage):
     """xrandr - primitive command line interface to X11 Resize, Rotate, and
     Reflect (RandR) extension."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xrandr"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xrandr"
     xorg_mirror_path = "app/xrandr-1.5.0.tar.gz"
 
     version('1.5.0', sha256='ddfe8e7866149c24ccce8e6aaa0623218ae19130c2859cadcaa4228d8bb4a46d')

--- a/var/spack/repos/builtin/packages/xrdb/package.py
+++ b/var/spack/repos/builtin/packages/xrdb/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xrdb(AutotoolsPackage, XorgPackage):
     """xrdb - X server resource database utility."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xrdb"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xrdb"
     xorg_mirror_path = "app/xrdb-1.1.0.tar.gz"
 
     version('1.1.0', sha256='44b0b6b7b7eb80b83486dfea67c880f6b0059052386c7ddec4d58fd2ad9ae8e9')

--- a/var/spack/repos/builtin/packages/xset/package.py
+++ b/var/spack/repos/builtin/packages/xset/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xset(AutotoolsPackage, XorgPackage):
     """User preference utility for X."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xset"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xset"
     xorg_mirror_path = "app/xset-1.2.3.tar.gz"
 
     version('1.2.3', sha256='5ecb2bb2cbf3c9349b735080b155a08c97b314dacedfc558c7f5a611ee1297f7')

--- a/var/spack/repos/builtin/packages/xsetroot/package.py
+++ b/var/spack/repos/builtin/packages/xsetroot/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xsetroot(AutotoolsPackage, XorgPackage):
     """xsetroot - root window parameter setting utility for X."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/app/xsetroot"
+    homepage = "https://cgit.freedesktop.org/xorg/app/xsetroot"
     xorg_mirror_path = "app/xsetroot-1.1.1.tar.gz"
 
     version('1.1.1', sha256='6cdd48757d18835251124138b4a8e4008c3bbc51cf92533aa39c6ed03277168b')

--- a/var/spack/repos/builtin/packages/xsimd/package.py
+++ b/var/spack/repos/builtin/packages/xsimd/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xsimd(CMakePackage):
     """C++ wrappers for SIMD intrinsics"""
 
-    homepage = "http://quantstack.net/xsimd"
+    homepage = "https://quantstack.net/xsimd"
     url      = "https://github.com/QuantStack/xsimd/archive/3.1.0.tar.gz"
     git      = "https://github.com/QuantStack/xsimd.git"
 

--- a/var/spack/repos/builtin/packages/xtensor/package.py
+++ b/var/spack/repos/builtin/packages/xtensor/package.py
@@ -9,7 +9,7 @@ from spack import *
 class Xtensor(CMakePackage):
     """Multi-dimensional arrays with broadcasting and lazy computing"""
 
-    homepage = "http://quantstack.net/xtensor"
+    homepage = "https://github.com/xtensor-stack/xtensor-io"
     url      = "https://github.com/QuantStack/xtensor/archive/0.13.1.tar.gz"
     git      = "https://github.com/QuantStack/xtensor.git"
 

--- a/var/spack/repos/builtin/packages/xtrans/package.py
+++ b/var/spack/repos/builtin/packages/xtrans/package.py
@@ -12,7 +12,7 @@ class Xtrans(AutotoolsPackage, XorgPackage):
     single place to add new transport types.  It is used by the X server,
     libX11, libICE, the X font server, and related components."""
 
-    homepage = "http://cgit.freedesktop.org/xorg/lib/libxtrans"
+    homepage = "https://cgit.freedesktop.org/xorg/lib/libxtrans"
     xorg_mirror_path = "lib/xtrans-1.3.5.tar.gz"
 
     version('1.3.5', sha256='b7a577c1b6c75030145e53b4793db9c88f9359ac49e7d771d4385d21b3e5945d')

--- a/var/spack/repos/builtin/packages/yorick/package.py
+++ b/var/spack/repos/builtin/packages/yorick/package.py
@@ -16,7 +16,7 @@ class Yorick(Package):
        most operating systems (*nix systems, MacOS X, Windows).
     """
 
-    homepage = "http://dhmunro.github.io/yorick-doc/"
+    homepage = "https://dhmunro.github.io/yorick-doc/"
     url      = "https://github.com/dhmunro/yorick/archive/y_2_2_04.tar.gz"
     git      = "https://github.com/dhmunro/yorick.git"
 


### PR DESCRIPTION
This issue addresses "MOAR SPECK PROBLEMS" (more spack problems) as reported by https://repology.org/repository/spack/problems. After this is reviewed and merged I'll follow up with adding a check to audit so we won't let in packages/package updates that have a working https URL.

Not all of them on that page are fixable - some of these are not resolvable in that there is only an http page available, or a page reported as broken is actually ok, or a page has an SSL error that does not prevent one from visiting (and no good replacement). Anyway, tiny steps! I suppose this is like untangling hair where we get our the big knots first and then zoom in on the smaller ones.


Signed-off-by: vsoch <vsoch@users.noreply.github.com>