### PR TITLE
bugfix: make python package `headers()` method work w/o `config.h`

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -823,9 +823,12 @@ for plat_specific in [True, False]:
         else:
             headers = find_headers(
                 'pyconfig', self.prefix.include, recursive=True)
-            config_h = headers[0]
+            config_h = headers[0] if headers else None
 
-        headers.directories = [os.path.dirname(config_h)]
+        if config_h:
+            headers.directories = [os.path.dirname(config_h)]
+        else:
+            return self.prefix.include
         return headers
 
     @property


### PR DESCRIPTION
@adamjstewart: what's the right thing to do here?  Had to fix the b/c Python envs were not activating properly.

`headers()` was assuming that `config.h` is always there, but it is not. Spack built pythons on macOS do not seem to have it.

- [x] don't assume headers list has any elements