### PR TITLE
py-pyqt5: Don't install files into qt install prefix

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -37,6 +37,8 @@ class PyPyqt5(SIPPackage):
         args = [
             '--pyuic5-interpreter', self.spec['python'].command.path,
             '--sipdir', self.prefix.share.sip.PyQt5,
+            '--designer-plugindir', self.prefix.plugins.designer,
+            '--qml-plugindir', self.prefix.plugins.PyQt5,
             '--stubsdir', join_path(
                 self.prefix,
                 self.spec['python'].package.site_packages_dir,
@@ -46,3 +48,6 @@ class PyPyqt5(SIPPackage):
             args.extend(['--qsci-api',
                          '--qsci-api-destdir', self.prefix.share.qsci])
         return args
+
+    def setup_run_environment(self, env):
+        env.prepend_path('QT_PLUGIN_PATH', self.prefix.plugins)


### PR DESCRIPTION
By default, `py-pyqt5` installs its qt designer and qml plugins into `qt`'s install prefix, and we don't want that.

I tested qt's `designer` with this fix and it correctly lists the pyqt5 plugin thanks to  `QT_PLUGIN_PATH`. But I wasn't able to simply test the qml plugin, but I found a couple reference saying `QT_PLUGIN_PATH` should work for qml plugins too.

EDIT: for the record:
```
$ spack verify .../qt-5.15.2-i46xrjybjytgf6fdnseiu37p37g44242/.spack/spec.yaml
==> In package qt/i46xrjy
.../qt-5.15.2-i46xrjybjytgf6fdnseiu37p37g44242/plugins/PyQt5 verification failed with error(s):
    added
.../qt-5.15.2-i46xrjybjytgf6fdnseiu37p37g44242/plugins/PyQt5/libpyqt5qmlplugin.so verification failed with error(s):
    added
.../qt-5.15.2-i46xrjybjytgf6fdnseiu37p37g44242/plugins/designer/libpyqt5.so verification failed with error(s):
    added
```
