### PR TITLE
figlet: Fix figlet font dir

### DIFF
--- a/var/spack/repos/builtin/packages/figlet/package.py
+++ b/var/spack/repos/builtin/packages/figlet/package.py
@@ -29,3 +29,7 @@ class Figlet(MakefilePackage):
             install(f, prefix.man6)
 
         install_tree('./fonts', prefix.share.figlet)
+
+    @property
+    def build_targets(self):
+        return ['DEFAULTFONTDIR=' + self.prefix.share.figlet]


### PR DESCRIPTION
By default, figlet looks for figlet fonts in `/usr/local/share/figlet`, and if it doesn't exist you get `figlet: standard: Unable to open font file`.

This fix changes the default font dir to the ones installed in the install prefix (L31).

(@darmac originally contributed the recipe.)
