### PR TITLE
Use hooks for timers

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -761,7 +761,7 @@ In this example, we use it outside of a logger that is already defined:
     import spack.hooks
 
     # We do something here to generate a logger and message
-    spack.hooks.post_log_write(message, logger.level)
+    spack.hooks.runner('post_log_write', message, logger.level)
 
 
 This is not to say that this would be the best way to implement an integration

--- a/lib/spack/spack/analyzers/analyzer_base.py
+++ b/lib/spack/spack/analyzers/analyzer_base.py
@@ -113,4 +113,4 @@ class AnalyzerBase(object):
                 spack.monitor.write_json(result[self.name], outfile)
 
         # This hook runs after a save result
-        spack.hooks.on_analyzer_save(self.spec.package, result)
+        spack.hooks.runner('on_analyzer_save', self.spec.package, result)

--- a/lib/spack/spack/analyzers/libabigail.py
+++ b/lib/spack/spack/analyzers/libabigail.py
@@ -113,4 +113,5 @@ class Libabigail(AnalyzerBase):
             # A result needs an analyzer, value or binary_value, and name
             data = {"value": content, "install_file": rel_path, "name": "abidw-xml"}
             tty.info("Sending result for %s %s to monitor." % (name, rel_path))
-            spack.hooks.on_analyzer_save(self.spec.package, {"libabigail": [data]})
+            spack.hooks.runner('on_analyzer_save', self.spec.package, {
+                "libabigail": [data]})

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -544,7 +544,7 @@ def install_tarball(spec, args):
             tty.msg('Installing buildcache for spec %s' % spec.format())
             bindist.extract_tarball(spec, tarball, args.allow_root,
                                     args.unsigned, args.force)
-            spack.hooks.post_install(spec)
+            spack.hooks.runner('post_install', spec)
             spack.store.db.add(spec, spack.store.layout)
         else:
             tty.die('Download of binary cache file for spec %s failed.' %

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1833,7 +1833,7 @@ class Environment(object):
             self.regenerate_views()
 
             # Run post_env_hooks
-            spack.hooks.post_env_write(self)
+            spack.hooks.runner('post_env_write', self)
 
         # new specs and new installs reset at write time
         self.new_specs = []

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -36,7 +36,7 @@ class HookRunner(object):
     #: all HookRunner objects
     _hooks = None
 
-    def __init__(self, hooks):
+    def __init__(self, hooks=None):
         self.hooks_names = hooks or []
 
     def _init_hooks(cls):

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -12,7 +12,7 @@ Hooks are not executed in any particular order.
 Currently the following hooks are supported:
 
     * pre_install(spec)
-    * post_install(spec)
+    * post_install(spec, timer=None)
     * pre_uninstall(spec)
     * post_uninstall(spec)
     * on_install_start(spec)
@@ -72,6 +72,7 @@ _default_runner = HookRunner([
     'permissions_setters',
     'monitor',
     'sbang',
+    'build_timers',
     'write_install_manifest'
 ])
 

--- a/lib/spack/spack/hooks/__init__.py
+++ b/lib/spack/spack/hooks/__init__.py
@@ -36,8 +36,8 @@ class HookRunner(object):
     #: all HookRunner objects
     _hooks = None
 
-    def __init__(self, hooks=[]):
-        self.hooks_names = hooks
+    def __init__(self, hooks):
+        self.hooks_names = hooks or []
 
     def _init_hooks(cls):
         # Lazily populate the list of hooks
@@ -82,7 +82,8 @@ runner = _default_runner
 @contextlib.contextmanager
 def use_hook_runner(new_runner):
     global runner
-    old_runner = runner
-    runner = new_runner
-    yield
-    runner = old_runner
+    old_runner, runner = runner, new_runner
+    try:
+        yield
+    finally:
+        runner = old_runner

--- a/lib/spack/spack/hooks/build_timers.py
+++ b/lib/spack/spack/hooks/build_timers.py
@@ -3,9 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import spack.verify
-
-
 def post_install(spec, timer=None):
-    if not spec.external:
-        spack.verify.write_manifest(spec)
+    if not timer:
+        return
+    with open(spec.package.times_log_path, 'w') as timelog:
+        timer.write_json(timelog)

--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -155,7 +155,7 @@ def write_license_file(pkg, license_path):
         f.close()
 
 
-def post_install(spec):
+def post_install(spec, timer=None):
     """This hook symlinks local licenses to the global license for
     licensed software.
     """

--- a/lib/spack/spack/hooks/module_file_generation.py
+++ b/lib/spack/spack/hooks/module_file_generation.py
@@ -36,7 +36,7 @@ def _for_each_enabled(spec, method_name):
                 tty.warn(msg.format(method_name, str(e)))
 
 
-def post_install(spec):
+def post_install(spec, timer=None):
     import spack.environment as ev  # break import cycle
     if ev.active_environment():
         # If the installed through an environment, we skip post_install

--- a/lib/spack/spack/hooks/permissions_setters.py
+++ b/lib/spack/spack/hooks/permissions_setters.py
@@ -8,7 +8,7 @@ import os
 import spack.util.file_permissions as fp
 
 
-def post_install(spec):
+def post_install(spec, timer=None):
     if not spec.external:
         fp.set_permissions_by_spec(spec.prefix, spec)
 

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -154,7 +154,7 @@ def install_sbang():
     fs.set_install_permissions(sbang_bin_dir)
 
 
-def post_install(spec):
+def post_install(spec, timer=None):
     """This hook edits scripts so that they call /bin/bash
     $spack_prefix/bin/sbang instead of something longer than the
     shebang limit.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -279,7 +279,7 @@ def _install_from_cache(pkg, cache_only, explicit, unsigned=False,
 
     tty.debug('Successfully extracted {0} from binary cache'.format(pkg_id))
     _print_installed_pkg(pkg.spec.prefix)
-    spack.hooks.post_install(pkg.spec)
+    spack.hooks.runner('post_install', pkg.spec)
     return True
 
 
@@ -332,7 +332,7 @@ def _process_external_package(pkg, explicit):
         # For external packages we just need to run
         # post-install hooks to generate module files.
         tty.debug('{0} generating module file'.format(pre))
-        spack.hooks.post_install(spec)
+        spack.hooks.runner('post_install', spec)
 
         # Add to the DB
         tty.debug('{0} registering into DB'.format(pre))
@@ -1436,7 +1436,7 @@ class PackageInstaller(object):
             if task is None:
                 continue
 
-            spack.hooks.on_install_start(task.request.pkg.spec)
+            spack.hooks.runner('on_install_start', task.request.pkg.spec)
             install_args = task.request.install_args
             keep_prefix = install_args.get('keep_prefix')
 
@@ -1461,7 +1461,7 @@ class PackageInstaller(object):
                 dep_str = 'dependencies' if task.priority > 1 else 'dependency'
 
                 # Hook to indicate task failure, but without an exception
-                spack.hooks.on_install_failure(task.request.pkg.spec)
+                spack.hooks.runner('on_install_failure', task.request.pkg.spec)
 
                 raise InstallError(
                     'Cannot proceed with {0}: {1} uninstalled {2}: {3}'
@@ -1485,7 +1485,7 @@ class PackageInstaller(object):
                 # Mark that the package failed
                 # TODO: this should also be for the task.pkg, but we don't
                 # model transitive yet.
-                spack.hooks.on_install_failure(task.request.pkg.spec)
+                spack.hooks.runner('on_install_failure', task.request.pkg.spec)
 
                 if self.fail_fast:
                     raise InstallError(fail_fast_err)
@@ -1596,7 +1596,7 @@ class PackageInstaller(object):
                 # Only terminate at this point if a single build request was
                 # made.
                 if task.explicit and single_explicit_spec:
-                    spack.hooks.on_install_failure(task.request.pkg.spec)
+                    spack.hooks.runner('on_install_failure', task.request.pkg.spec)
                     raise
 
                 if task.explicit:
@@ -1608,12 +1608,12 @@ class PackageInstaller(object):
                 err = 'Failed to install {0} due to {1}: {2}'
                 tty.error(err.format(pkg.name, exc.__class__.__name__,
                           str(exc)))
-                spack.hooks.on_install_failure(task.request.pkg.spec)
+                spack.hooks.runner('on_install_failure', task.request.pkg.spec)
                 raise
 
             except (Exception, SystemExit) as exc:
                 self._update_failed(task, True, exc)
-                spack.hooks.on_install_failure(task.request.pkg.spec)
+                spack.hooks.runner('on_install_failure', task.request.pkg.spec)
 
                 # Best effort installs suppress the exception and mark the
                 # package as a failure.
@@ -1751,7 +1751,7 @@ class BuildProcessInstaller(object):
         with self.pkg.stage:
             # Run the pre-install hook in the child process after
             # the directory is created.
-            spack.hooks.pre_install(self.pkg.spec)
+            spack.hooks.runner('pre_install', self.pkg.spec)
             if self.fake:
                 _do_fake_install(self.pkg)
             else:
@@ -1766,7 +1766,7 @@ class BuildProcessInstaller(object):
                 self.timer.write_json(timelog)
 
             # Run post install hooks before build stage is removed.
-            spack.hooks.post_install(self.pkg.spec)
+            spack.hooks.runner('post_install', self.pkg.spec)
 
         build_time = self.timer.total - self.pkg._fetch_time
         tty.msg('{0} Successfully installed {1}'.format(self.pre, self.pkg_id),
@@ -1776,7 +1776,7 @@ class BuildProcessInstaller(object):
         _print_installed_pkg(self.pkg.prefix)
 
         # Send final status that install is successful
-        spack.hooks.on_install_success(self.pkg.spec)
+        spack.hooks.runner('on_install_success', self.pkg.spec)
 
         # preserve verbosity across runs
         return self.echo
@@ -1857,11 +1857,12 @@ class BuildProcessInstaller(object):
 
                         # Catch any errors to report to logging
                         phase(pkg.spec, pkg.prefix)
-                        spack.hooks.on_phase_success(pkg, phase_name, log_file)
+                        spack.hooks.runner('on_phase_success', pkg, phase_name,
+                                           log_file)
 
                 except BaseException:
                     combine_phase_logs(pkg.phase_log_files, pkg.log_path)
-                    spack.hooks.on_phase_error(pkg, phase_name, log_file)
+                    spack.hooks.runner('on_phase_error', pkg, phase_name, log_file)
                     raise
 
                 # We assume loggers share echo True/False

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2186,7 +2186,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
             if pkg is not None:
                 try:
-                    spack.hooks.pre_uninstall(spec)
+                    spack.hooks.runner('pre_uninstall', spec)
                 except Exception as error:
                     if force:
                         error_msg = (
@@ -2223,7 +2223,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         if pkg is not None:
             try:
-                spack.hooks.post_uninstall(spec)
+                spack.hooks.runner('post_uninstall', spec)
             except Exception:
                 # If there is a failure here, this is our only chance to do
                 # something about it: at this point the Spec has been removed

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -14,7 +14,6 @@ import spack.error
 import spack.patch
 import spack.repo
 import spack.store
-import spack.util.spack_json as sjson
 from spack.package import (
     InstallError,
     PackageBase,
@@ -166,32 +165,6 @@ def test_install_dependency_symlinks_pkg(
     # Ensure dependency directory exists after the installation.
     dependency_dir = os.path.join(pkg.prefix, 'dependency-install')
     assert os.path.isdir(dependency_dir)
-
-
-def test_install_times(
-        install_mockery, mock_fetch, mutable_mock_repo):
-    """Test install times added."""
-    spec = Spec('dev-build-test-install-phases')
-    spec.concretize()
-    pkg = spec.package
-    pkg.do_install()
-
-    # Ensure dependency directory exists after the installation.
-    install_times = os.path.join(pkg.prefix, ".spack", 'install_times.json')
-    assert os.path.isfile(install_times)
-
-    # Ensure the phases are included
-    with open(install_times, 'r') as timefile:
-        times = sjson.load(timefile.read())
-
-    # The order should be maintained
-    phases = [x['name'] for x in times['phases']]
-    total = sum([x['seconds'] for x in times['phases']])
-    for name in ['one', 'two', 'three', 'install']:
-        assert name in phases
-
-    # Give a generous difference threshold
-    assert abs(total - times['total']['seconds']) < 5
 
 
 def test_flatten_deps(

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -15,6 +15,7 @@ import llnl.util.tty as tty
 import spack.binary_distribution
 import spack.compilers
 import spack.directory_layout as dl
+import spack.hooks
 import spack.installer as inst
 import spack.package_prefs as prefs
 import spack.repo
@@ -176,9 +177,10 @@ def test_install_from_cache_ok(install_mockery, monkeypatch):
     spec = spack.spec.Spec('trivial-install-test-package')
     spec.concretize()
     monkeypatch.setattr(inst, '_try_install_from_binary_cache', _true)
-    monkeypatch.setattr(spack.hooks, 'post_install', _noop)
 
-    assert inst._install_from_cache(spec.package, True, True, False)
+    # Disable hooks.
+    with spack.hooks.use_hook_runner(spack.hooks.HookRunner()):
+        assert inst._install_from_cache(spec.package, True, True, False)
 
 
 def test_process_external_package_module(install_mockery, monkeypatch, capfd):

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from time import sleep
-
 
 class DevBuildTestInstallPhases(Package):
     homepage = "example.com"
@@ -15,15 +13,12 @@ class DevBuildTestInstallPhases(Package):
     phases = ['one', 'two', 'three', 'install']
 
     def one(self, spec, prefix):
-        sleep(1)
         print("One locomoco")
 
     def two(self, spec, prefix):
-        sleep(2)
         print("Two locomoco")
 
     def three(self, spec, prefix):
-        sleep(3)
         print("Three locomoco")
 
     def install(self, spec, prefix):


### PR DESCRIPTION
This is again on top of #25573, only the last commit is relevant for this pr.

Use hooks for timers and get rid of the 6 second install test, instead use dependency injection to get a mock timer.
