### PR TITLE
Docs: manually adding external packages in modules

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -234,12 +234,12 @@ Each following paragraph will discuss one of the bullet points above.
 Module/Package Name Mismatches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For certain libraries there exist multiple implementations (e.g., MPI). If you
-modify the ``packages.yaml`` file, then you must make sure to select the
-correct package name. For example, the package ``mpich`` can be used only for
-the vanilla MPICH implementation but not for Cray MPICH; Cray MPICH has its own
-package called ``cray-mpich``. If the wrong module name is picked, this can
-cause errors later, e.g., Spack may compute a wrong prefix.
+For certain libraries there exist multiple implementations (e.g., MPI). When
+defining an external entry for a package, make sure the package name identifies
+the implementation that matches the module. For example, the package ``mpich``
+can be used only for the vanilla MPICH implementation but not for Cray MPICH;
+Cray MPICH has its own package called ``cray-mpich``. If the wrong module name
+is picked, this can cause errors later, e.g., Spack may compute a wrong prefix.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Missing Modules Dependencies
@@ -346,8 +346,9 @@ mpi`` output:
     [snip]
 
 Given this module output, ``spack external find`` will determine
-``/usr/lib64/openmpi`` as the prefix when it is actually ``/usr``. This
-incorrect prefix can cause the error message below when building packages::
+``/usr/lib64/openmpi`` as the prefix when only ``/usr`` allows Spack to
+determine all required paths. This incorrect prefix can cause the error message
+below when building packages::
 
     ==> Error: AttributeError: Query of package 'openmpi' for 'headers' failed
     	prefix : None
@@ -390,9 +391,10 @@ Consider the following ``module show`` output:
     -------------------------------------------------------------------
 
 The module ``intel-all`` is obviously a metamodule because it only loads other
-modules and its ``module show`` output cannot be used to derive the needed
-environment changes to use, e.g., Intel MPI. For this reason, metamodules
-*cannot* be used in ``packages.yaml`` files.
+modules; the module contents do not include direct manipulations of ``PATH``,
+which Spack depends on to determine the package prefix. For this reason,
+metamodules cannot generally be used in place of the direct package module when
+defining external packages.
 
 
 .. _concretization-preferences:

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -212,21 +212,27 @@ Specific limitations include:
 
 .. _manually-adding-external-packages:
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Manually Adding External Packages
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Manually Adding External Packages in Modules
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This section discusses how to add external packages to the ``packages.yaml``
-file when modules depend on other modules or when Spack is unable to compute
-the prefix. When using modules, Spack will attempt to parse the ``module show``
-output in order to determine all relevant settings and variables. Reasons why
-this may not work automatically are
+So far this section described external package detection and its limitations.
+The paragraphs below deal with challenges arising when external packages are
+found in loadable modules. When using modules, Spack will attempt to parse the
+``module show`` output in order to determine all relevant settings and
+variables. Reasons why this may not work automatically are
 
-* the wrong package name,
-* missing module dependencies,
-* nonstandard paths, and
+* a mismatch between module and package name,
+* missing module dependencies in the ``packages.yaml`` file,
+* modules whose directory structure does not match conventions, and
 * the use of metamodules, i.e., modules whose only purpose is to load other
   modules.
+
+Each following paragraph will discuss one of the bullet points above.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Module/Package Name Mismatches
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For certain libraries there exist multiple implementations (e.g., MPI). If you
 modify the ``packages.yaml`` file, then you must make sure to select the
@@ -234,6 +240,10 @@ correct package name. For example, the package ``mpich`` can be used only for
 the vanilla MPICH implementation but not for Cray MPICH; Cray MPICH has its own
 package called ``cray-mpich``. If the wrong module name is picked, this can
 cause errors later, e.g., Spack may compute a wrong prefix.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Missing Modules Dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The case of missing dependencies will be discussed based on the real-world
 example of loading OpenMPI 4.0.2 with CUDA support. Shown below is the ``module
@@ -264,10 +274,10 @@ show openmpi/4.0.2`` output.
     -------------------------------------------------------------------
 
 There are two things of importance to note. First, there are multiple possible
-module combinations to satisfy the compiler and CUDA dependency; for this
-example will use ``gcc/8.3.1`` and ``cuda/10.1.2``. Second, the output does not
-contain any information about environment variables or flags that are needed.
-The situation changes as soon as the dependencies are satisfied.
+module combinations to satisfy the compiler and CUDA dependency; this example
+will use ``gcc/8.3.1`` and ``cuda/10.1.2``. Second, the output does not contain
+any information about environment variables or flags that are needed. The
+situation changes as soon as the dependencies are satisfied.
 
 .. code-block:: console
 
@@ -306,13 +316,21 @@ following OpenMPI entry:
           prefix: /gpfslocalsup/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3
           modules: [gcc/8.3.1, cuda-10.1.2, openmpi/4.0.2-cuda]
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Nonstandard Directory Structure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Once all dependencies are satisfied or if there are no dependencies, then the
-prefix determined by Spack may not be correct in the presence of nonstandard
-paths. This is rarely the case because Spack contains package-specific code to
-deal with these quirks. Before manually setting the prefix in the
-``packages.yaml`` file in addition to a list of modules, it is strongly
-suggested to check the package name and the module list again. Consider the
-OpenMPI module on CentOS 7:
+prefix determined by Spack may not be correct in the presence of a nonstandard
+directory structure. This is rarely the case because Spack contains
+package-specific code to deal with these quirks. Before manually setting the
+prefix in the ``packages.yaml`` file in addition to a list of modules, it is
+strongly suggested to check the package name and the module list again. 
+
+The files of OpenMPI on CentOS 7 use a nonstandard directory structure. For
+example on x86-64, the libraries are in ``/usr/lib64/openmpi`` (on x86-64
+machines) instead of ``/usr/lib64`` or ``/usr/lib``. Consider the ``module show
+mpi`` output:
 
 .. code-block:: console
 
@@ -349,7 +367,11 @@ The solution in this case is to manually edit the prefix in the
           prefix: /usr
           modules: [mpi]
 
-At last, we consider the case of metamodules.
+~~~~~~~~~~~
+Metamodules
+~~~~~~~~~~~
+
+Consider the following ``module show`` output:
 
 .. code-block:: console
 

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -222,10 +222,18 @@ the prefix. When using modules, Spack will attempt to parse the ``module show``
 output in order to determine all relevant settings and variables. Reasons why
 this may not work automatically are
 
+* the wrong package name,
 * missing module dependencies,
 * nonstandard paths, and
 * the use of metamodules, i.e., modules whose only purpose is to load other
   modules.
+
+For certain libraries there exist multiple implementations (e.g., MPI). If you
+modify the ``packages.yaml`` file, then you must make sure to select the
+correct package name. For example, the package ``mpich`` can be used only for
+the vanilla MPICH implementation but not for Cray MPICH; Cray MPICH has its own
+package called ``cray-mpich``. If the wrong module name is picked, this can
+cause errors later, e.g., Spack may compute a wrong prefix.
 
 The case of missing dependencies will be discussed based on the real-world
 example of loading OpenMPI 4.0.2 with CUDA support. Shown below is the ``module
@@ -300,7 +308,11 @@ following OpenMPI entry:
 
 Once all dependencies are satisfied or if there are no dependencies, then the
 prefix determined by Spack may not be correct in the presence of nonstandard
-paths. Consider the OpenMPI module on CentOS 7:
+paths. This is rarely the case because Spack contains package-specific code to
+deal with these quirks. Before manually setting the prefix in the
+``packages.yaml`` file in addition to a list of modules, it is strongly
+suggested to check the package name and the module list again. Consider the
+OpenMPI module on CentOS 7:
 
 .. code-block:: console
 

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -253,7 +253,7 @@ show openmpi/4.0.2`` output.
 
     $ module show openmpi/4.0.2-cuda
     -------------------------------------------------------------------
-    /gpfslocalsup/pub/modules-idris-env4/modulefiles/linux-rhel8-skylake_avx512/openmpi/4.0.2-cuda:
+    /usr/local/modulefiles/openmpi/4.0.2-cuda:
 
     module-whatis   {An open source Message Passing Interface implementation.}
     prereq          intel-compilers/19.0.4 pgi/20.1 pgi/19.10 gcc/10.1.0 gcc/8.3.1
@@ -286,17 +286,17 @@ situation changes as soon as the dependencies are satisfied.
     $ module load cuda/10.1.2
     $ module show openmpi/4.0.2-cuda
     -------------------------------------------------------------------
-    /gpfslocalsup/pub/modules-idris-env4/modulefiles/linux-rhel8-skylake_avx512/openmpi/4.0.2-cuda:
+    /usr/local/modulefiles/openmpi/4.0.2-cuda:
 
     module-whatis   {An open source Message Passing Interface implementation.}
     prereq          intel-compilers/19.0.4 pgi/20.1 pgi/19.10 gcc/10.1.0 gcc/8.3.1
     prereq          cuda/10.2 cuda/10.1.2 cuda/10.1.1
     conflict        openmpi
     conflict        intel-mpi
-    prepend-path    CPATH /gpfslocalsup/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3/include
-    prepend-path    LD_LIBRARY_PATH /gpfslocalsup/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3/lib
-    prepend-path    LIBRARY_PATH /gpfslocalsup/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3/lib
-    prepend-path    PATH /gpfslocalsup/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3/bin
+    prepend-path    CPATH /usr/local/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3/include
+    prepend-path    LD_LIBRARY_PATH /usr/local/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3/lib
+    prepend-path    LIBRARY_PATH /usr/local/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3/lib
+    prepend-path    PATH /usr/local/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3/bin
     [snip]
 
 This output can be parsed by Spack when building software. To obtain an entry
@@ -313,7 +313,7 @@ following OpenMPI entry:
         externals:
         - spec: openmpi@4.0.2+cuda+cxx+cxx_exceptions~java~memchecker+pmi~sqlite3+static~thread_multiple~wrapper-rpath
             fabrics=psm2 schedulers=slurm
-          prefix: /gpfslocalsup/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3
+          prefix: /usr/local/spack_soft/openmpi/4.0.2/gcc-8.3.1-n6vcsair26tkpepojy3c2gqxtqccijq3
           modules: [gcc/8.3.1, cuda-10.1.2, openmpi/4.0.2-cuda]
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
~~fixes #25612~~

After having trouble to use MPI on two supercomputers with Spack (see #12520), I decided to look at the Spack source  code. The `module show` output is critically important to the use of external packages in modules. This pull request adds a subsection explaining how to handle
* modules with dependencies on other modules,
* modules where the prefix computation does not work, and
* metamodules (i.e., modules that only load other modules).

I want to thank the Spack team for the clean code base and spelling out function names. Within hours I had a rough grasp of how the prefix is computed inside the Spack code. (It could have been faster if I had read the [Developer Guide](https://spack.readthedocs.io/en/latest/developer_guide.html) but adding `print()` statements was more engaging.)