### PR TITLE
py-flit: add maintainer

### DIFF
--- a/var/spack/repos/builtin/packages/py-flit-core/package.py
+++ b/var/spack/repos/builtin/packages/py-flit-core/package.py
@@ -11,6 +11,7 @@ class PyFlitCore(Package):
 
     homepage = "https://github.com/takluyver/flit"
     url = "https://pypi.io/packages/py3/f/flit-core/flit_core-3.3.0-py3-none-any.whl"
+    maintainers = ['takluyver']
 
     version('3.3.0', sha256='9b247b3095cb3c43933a59a7433f92ddfdd7fc843e08ef0f4550d53a9cfbbef6', expand=False)
 

--- a/var/spack/repos/builtin/packages/py-flit/package.py
+++ b/var/spack/repos/builtin/packages/py-flit/package.py
@@ -10,6 +10,7 @@ class PyFlit(PythonPackage):
     """Flit is a simple way to put Python packages and modules on PyPI."""
 
     pypi = "flit/flit-3.3.0.tar.gz"
+    maintainers = ['takluyver']
 
     version('3.3.0', sha256='65fbe22aaa7f880b776b20814bd80b0afbf91d1f95b17235b608aa256325ce57')
 
@@ -17,6 +18,3 @@ class PyFlit(PythonPackage):
     depends_on('py-requests', type=('build', 'run'))
     depends_on('py-docutils', type=('build', 'run'))
     depends_on('py-toml', type=('build', 'run'))
-
-    def setup_dependent_package(self, module, dependent_spec):
-        module.flit = Executable(self.prefix.bin.flit)


### PR DESCRIPTION
@takluyver volunteered to maintain these packages in https://github.com/takluyver/flit/issues/439

First question for you: my `py-flit` installation doesn't have a `flit` executable. Should it? In the build log I see warnings like:
```console
/Users/Adam/spack/opt/spack/darwin-catalina-x86_64/apple-clang-12.0.0/python-3.8.11-mboaywuagomyhvr2ajgug3lctyy7sahc/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'extras_require'
  warnings.warn(msg)
```
because the `setup.py` uses `distutils` instead of `setuptools`. Should it use `setuptools` so that a `flit` executable gets installed?