### PR TITLE
p7zip: resolve gcc 10 conflict thanks to Eric Brugger

### DIFF
--- a/var/spack/repos/builtin/packages/p7zip/gcc10.patch
+++ b/var/spack/repos/builtin/packages/p7zip/gcc10.patch
@@ -1,0 +1,13 @@
+diff --git a/CPP/Windows/ErrorMsg.cpp.orig b/CPP/Windows/ErrorMsg.cpp
+index 99684ae..68416d6 100644
+--- a/CPP/Windows/ErrorMsg.cpp.orig
++++ b/CPP/Windows/ErrorMsg.cpp
+@@ -13,7 +13,7 @@ UString MyFormatMessage(DWORD errorCode)
+   const char * txt = 0;
+   AString msg;
+ 
+-  switch(errorCode) {
++  switch((Int32)errorCode) {
+     case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
+     case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
+     case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;

--- a/var/spack/repos/builtin/packages/p7zip/package.py
+++ b/var/spack/repos/builtin/packages/p7zip/package.py
@@ -13,7 +13,7 @@ class P7zip(MakefilePackage):
 
     version('16.02', sha256='5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f')
 
-    conflicts('%gcc@10:')
+    patch('gcc10.patch', when='%gcc@10:', sha256='96914025b9f431fdd75ae69768162d57751413634622f9df1a4bc4960e7e8fe1')
     # all3 includes 7z, 7za, and 7zr
     build_targets = ['all3']
 


### PR DESCRIPTION
The VisIt team with Eric Brugger made a patch to build p7zip against gcc 10:
https://github.com/visit-dav/visit/pull/13232/files
This merely imports it for spack.
Might interest @cyrush.
I found no way to upgrade p7zip to 20.02 or even 19.00.
