### PR TITLE
Add a __reduce__ method to Environment

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -581,6 +581,10 @@ class ViewDescriptor(object):
                     tty.warn(msg)
 
 
+def _create_environment(*args, **kwargs):
+    return Environment(*args, **kwargs)
+
+
 class Environment(object):
     def __init__(self, path, init_file=None, with_view=None, keep_relative=False):
         """Create a new environment.
@@ -601,6 +605,9 @@ class Environment(object):
                 directory.
         """
         self.path = os.path.abspath(path)
+        self.init_file = init_file
+        self.with_view = with_view
+        self.keep_relative = keep_relative
 
         self.txlock = lk.Lock(self._transaction_lock_path)
 
@@ -642,6 +649,11 @@ class Environment(object):
                                                             with_view)}
         # If with_view is None, then defer to the view settings determined by
         # the manifest file
+
+    def __reduce__(self):
+        return _create_environment, (
+            self.path, self.init_file, self.with_view, self.keep_relative
+        )
 
     def _rewrite_relative_paths_on_relocation(self, init_file_dir):
         """When initializing the environment from a manifest file and we plan

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -9,7 +9,7 @@ from spack.environment import Environment
 
 
 def test_environment_pickle(tmpdir):
-    env1 = Environment(tmpdir)
+    env1 = Environment(str(tmpdir))
     obj = pickle.dumps(env1)
     env2 = pickle.loads(obj)
     assert isinstance(env2, Environment)

--- a/lib/spack/spack/test/environment.py
+++ b/lib/spack/spack/test/environment.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import pickle
+
+from spack.environment import Environment
+
+
+def test_environment_pickle(tmpdir):
+    env1 = Environment(tmpdir)
+    obj = pickle.dumps(env1)
+    env2 = pickle.loads(obj)
+    assert isinstance(env2, Environment)


### PR DESCRIPTION
This PR adds a `__reduce__` method to `spack.environment.Environment`. Without this, we hit the maximum recursion limit when trying to pickle `Environment` objects.

Fixes #20025. This PR is very similar in spirit to #25658, which fixed #23892.

This PR was just the bare minimum needed to fix the issue. I have no idea if I implemented `__reduce__` correctly or not...

Also, I would really like to avoid catching `BaseException` in `spack.install_test.TestSuite.__call__` so that this kind of issue would be easier to diagnose in the future. On develop, `spack test run` doesn't raise any exception and silently doesn't do anything.