### PR TITLE
py-pbr: fix import tests

### DIFF
--- a/var/spack/repos/builtin/packages/py-pbr/package.py
+++ b/var/spack/repos/builtin/packages/py-pbr/package.py
@@ -12,6 +12,9 @@ class PyPbr(PythonPackage):
 
     pypi = "pbr/pbr-5.4.3.tar.gz"
 
+    # Skip 'pbr.tests' imports
+    import_modules = ['pbr', 'pbr.cmd', 'pbr.hooks']
+
     version('5.4.3',  sha256='2c8e420cd4ed4cec4e7999ee47409e876af575d4c35a45840d59e8b5f3155ab8')
     version('5.2.1',  sha256='93d2dc6ee0c9af4dbc70bc1251d0e545a9910ca8863774761f92716dece400b6')
     version('3.1.1',  sha256='05f61c71aaefc02d8e37c0a3eeb9815ff526ea28b3b76324769e6158d7f95be1')


### PR DESCRIPTION
Successfully tested on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.