### PR TITLE
py-metpy: fix import tests

### DIFF
--- a/var/spack/repos/builtin/packages/py-metpy/package.py
+++ b/var/spack/repos/builtin/packages/py-metpy/package.py
@@ -14,6 +14,10 @@ class PyMetpy(PythonPackage):
     pypi     = "MetPy/MetPy-1.0.1.tar.gz"
     maintainers = ['dopplershift']
 
+    # Importing 'metpy.io' results in downloads, so skip it.
+    # https://github.com/Unidata/MetPy/issues/1888
+    import_modules = ['metpy', 'metpy._vendor', 'metpy.calc', 'metpy.interpolate']
+
     version('1.0.1', sha256='16fa9806facc24f31f454b898741ec5639a72ba9d4ff8a19ad0e94629d93cb95')
     version('1.0', sha256='11b043aaa4e3d35db319e96bb9967eb9f73da653e155bca2d62f838108b100dc',
             deprecated=True)


### PR DESCRIPTION
We don't want any of our tests to download files over the internet. This removes `metpy.io` imports that trigger downloads. I'm also seeing some weird errors when importing `metpy.io` and `metpy.plots` that @dopplershift may want to know about:

* [py-metpy-1.0.1-frrg7v7-test-out.txt](https://github.com/spack/spack/files/7071579/py-metpy-1.0.1-frrg7v7-test-out.txt)

Successfully tested on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.