### PR TITLE
Removes unused ":-" in bash variable.

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -12,7 +12,7 @@
 """:"
 # prefer SPACK_PYTHON environment variable, python3, python, then python2
 SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
-for cmd in "${SPACK_PYTHON:-}" ${SPACK_PREFERRED_PYTHONS}; do
+for cmd in "${SPACK_PYTHON}" ${SPACK_PREFERRED_PYTHONS}; do
     if command -v > /dev/null "$cmd"; then
         export SPACK_PYTHON="$(command -v "$cmd")"
         exec "${SPACK_PYTHON}" "$0" "$@"


### PR DESCRIPTION
The bash expression ${SPACK_PYTHON:-} is equivalent to
${SPACK_PYTHON}.  Leaving it in is a bit of a speed bump for
those not quite as well-versed in shell parameter expansion.

For parameter expansion rule discussion, see:
https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html