### PR TITLE
Simplify "best-effort" expansion of matrix in environments

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -44,7 +44,6 @@ from spack.installer import PackageInstaller
 from spack.spec import Spec
 from spack.spec_list import InvalidSpecConstraintError, SpecList
 from spack.util.path import substitute_path_variables
-from spack.variant import UnknownVariantError
 
 #: environment variable used to indicate the active environment
 spack_env_var = 'SPACK_ENV'


### PR DESCRIPTION
fixes #20340

Spec matrices are expanded as cross-products in a best-effort fashion i.e. if some dimension would prevent a spec in the cross-product space to concretize, that dimension is discarded.

The current algorithm relies on the iterative nature of the original concretizer and searches which constraints in the cross-product to discard based on the exceptions raised during the build of a concrete spec. This approach cannot work with the new ASP-based solver, which solves the constraint problem "at once". 

Thus, the algorithm has been modified in a way that fits both the original and ASP-based solver: if a spec cannot be concretized the last dimension from the cartesian product is popped, until we reach a concretizeable spec or raise.

Modfications:
- [x] Simplify the algorithm for best effort expansion of matrices
- [ ] Don't print core dumps in intermediate stages when using clingo
- [ ] Add unit tests