### PR TITLE
HiPACE: Update openPMD dep, add v21.09

### DIFF
--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -38,7 +38,7 @@ class Hipace(CMakePackage):
     depends_on('cuda@9.2.88:', when='compute=cuda')
     depends_on('mpi', when='+mpi')
     with when('+openpmd'):
-        depends_on('openpmd-api@hipace')
+        depends_on('openpmd-api@0.14.2:')
         depends_on('openpmd-api ~mpi', when='~mpi')
         depends_on('openpmd-api +mpi', when='+mpi')
     with when('compute=omp'):

--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -12,12 +12,13 @@ class Hipace(CMakePackage):
     """
 
     homepage = "https://hipace.readthedocs.io"
-    # url      = "https://github.com/Hi-PACE/hipace/archive/refs/tags/21.06.tar.gz"
+    url      = "https://github.com/Hi-PACE/hipace/archive/refs/tags/v21.09.tar.gz"
     git      = "https://github.com/Hi-PACE/hipace.git"
 
     maintainers = ['ax3l', 'MaxThevenet', 'SeverinDiederichs']
 
     version('develop', branch='development')
+    version('21.09', sha256='5d27824fe6aac47ce26ca69759140ab4d7844f9042e436c343c03ea4852825f1')
 
     variant('compute',
             default='noacc',

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -10,7 +10,7 @@ class OpenpmdApi(CMakePackage):
     """C++ & Python API for Scientific I/O"""
 
     homepage = "https://www.openPMD.org"
-    url      = "https://github.com/openPMD/openPMD-api/archive/0.13.3.tar.gz"
+    url      = "https://github.com/openPMD/openPMD-api/archive/0.14.2.tar.gz"
     git      = "https://github.com/openPMD/openPMD-api.git"
 
     maintainers = ['ax3l']
@@ -20,8 +20,6 @@ class OpenpmdApi(CMakePackage):
     version('0.14.2', sha256='25c6b4bcd0ae1ba668b633b8514e66c402da54901c26861fc754fca55717c836')
     version('0.14.1', sha256='172fd1d785627d01c77f1170adc5a18bd8a6302e804d0f271dc0d616a5156791')
     version('0.14.0', sha256='7bb561c1a6f54e9a6a1b56aaf1d4d098bbe290d204f84ebe5a6f11b3cab2be6e')
-    #   temporary, pre 0.14.0 version for HiPACE++
-    version('hipace', commit='ac083025ee662469b8cad1adf93eef48cde35f58')
     version('0.13.4', sha256='46c013be5cda670f21969675ce839315d4f5ada0406a6546a91ec3441402cf5e')
     version('0.13.3', sha256='4b8f84bd89cd540c73ffe8c21085970453cb7f0e4f125f11a4e288433f64b58c')
     version('0.13.2', sha256='2e5170d41bb7b2c0608ec833eee7f9adf8175b46734743f6e46dcce6f6685fb0')


### PR DESCRIPTION
HiPACE++ depends on a regular openPMD-api release now.

X-ref: https://github.com/Hi-PACE/hipace/pull/585

Also tag the first release version.