### PR TITLE
m4-1.4.19: Fix testsuite glitch

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -33,6 +33,12 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     patch('secure_snprintf.patch', when='@:1.4.18 os=bigsur')
     # https://bugzilla.redhat.com/show_bug.cgi?id=1573342
     patch('https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch', sha256='fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8', when='@1.4.18')
+    # from: https://www.mail-archive.com/m4-patches@gnu.org/msg01208.html
+    # tests: Fix failing test checks/198.sysval with upstream patch for doc/m4.texi
+    patch('http://git.savannah.gnu.org/cgit/m4.git/patch/?id=a1354086',
+          sha256='bfdffa7c2eb01021d5849b36972c069693654ad826c1a20b53534009a4ec7a89', when='@1.4.19')
+    patch('http://git.savannah.gnu.org/cgit/m4.git/patch/?id=cd7f4d15',
+          sha256='9dc5fbd0d5cb1037ab1e6d0ecc74a30df218d0a94bdd5a02759a97f62daca573', when='@1.4.19')
 
     variant('sigsegv', default=True,
             description="Build the libsigsegv dependency")
@@ -44,6 +50,12 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     tags = ['build-tools']
 
     executables = ['^g?m4$']
+
+    @when('@1.4.19')
+    def patch(self):
+        """ skip texinfo of m4.info for patched m4.texi (patched only a test in it) """
+        touch('doc/m4.info')
+        touch('doc/stamp-vti')
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
In an attempt to avoid test failures on Haiku, the upstream maintainer
broke the test suite on all other platforms which use a shell like bash
as /bin/sh (emitting "Killed" when a subprocess is killed)...