### PR TITLE
libtool-testsuite: Add test-dependencies and skip FC-tests if not present

### DIFF
--- a/var/spack/repos/builtin/packages/libtool/package.py
+++ b/var/spack/repos/builtin/packages/libtool/package.py
@@ -10,7 +10,7 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
     """libtool -- library building part of autotools."""
 
     homepage = 'https://www.gnu.org/software/libtool/'
-    gnu_mirror_path = "libtool/libtool-2.4.2.tar.gz"
+    gnu_mirror_path = "libtool/libtool-2.4.6.tar.gz"
 
     version('develop', git='https://git.savannah.gnu.org/git/libtool.git',
             branch='master', submodules=True)
@@ -24,6 +24,10 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
         depends_on('autoconf', type='build')
         depends_on('automake', type='build')
         depends_on('help2man', type='build')
+
+    with when('@2.4.6'):
+        depends_on('autoconf@2.62:', type='test')
+        depends_on('automake',       type='test')
 
     with when('@develop'):
         depends_on('autoconf', type='build')
@@ -92,3 +96,20 @@ class Libtool(AutotoolsPackage, GNUMirrorPackage):
                 join_path(self.prefix.bin, 'glibtool'))
         symlink(join_path(self.prefix.bin, 'libtoolize'),
                 join_path(self.prefix.bin, 'glibtoolize'))
+
+    def setup_build_environment(self, env):
+        """Wrapper until spack has a real implementation of setup_test_environment()"""
+        if self.run_tests:
+            self.setup_test_environment(env)
+
+    def setup_test_environment(self, env):
+        """When Fortran is not provided, a few tests need to be skipped"""
+        if (self.compiler.f77 is None):
+            env.set('F77', 'no')
+        if (self.compiler.fc is None):
+            env.set('FC', 'no')
+
+    @when('@2.4.6')
+    def check(self):
+        """installcheck of libtool-2.4.6 runs the full testsuite, skip 'make check'"""
+        pass


### PR DESCRIPTION
@adamjstewart - maybe you could approve this?
    
- The testsuite of 2.4.6 and newer needs autoconf >= 2.62
- The tests use automake, add it if building with --test
- If Fortran compilers are not present, skip the tests which use them.