### PR TITLE
Do not try to compute hashes of concrete specs from yaml

### DIFF
--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -282,8 +282,8 @@ def ci_rebuild(args):
         env, root_spec, job_spec_pkg_name, related_builds, compiler_action)
     job_spec = spec_map[job_spec_pkg_name]
 
-    job_spec_yaml_file = '{0}.yaml'.format(job_spec_pkg_name)
-    job_spec_yaml_path = os.path.join(repro_dir, job_spec_yaml_file)
+    job_spec_json_file = '{0}.json'.format(job_spec_pkg_name)
+    job_spec_json_path = os.path.join(repro_dir, job_spec_json_file)
 
     # To provide logs, cdash reports, etc for developer download/perusal,
     # these things have to be put into artifacts.  This means downstream
@@ -337,23 +337,23 @@ def ci_rebuild(args):
     # using a compiler already installed on the target system).
     spack_ci.configure_compilers(compiler_action)
 
-    # Write this job's spec yaml into the reproduction directory, and it will
+    # Write this job's spec json into the reproduction directory, and it will
     # also be used in the generated "spack install" command to install the spec
-    tty.debug('job concrete spec path: {0}'.format(job_spec_yaml_path))
-    with open(job_spec_yaml_path, 'w') as fd:
-        fd.write(job_spec.to_yaml(hash=ht.build_hash))
+    tty.debug('job concrete spec path: {0}'.format(job_spec_json_path))
+    with open(job_spec_json_path, 'w') as fd:
+        fd.write(job_spec.to_json(hash=ht.full_hash))
 
-    # Write the concrete root spec yaml into the reproduction directory
-    root_spec_yaml_path = os.path.join(repro_dir, 'root.yaml')
-    with open(root_spec_yaml_path, 'w') as fd:
-        fd.write(spec_map['root'].to_yaml(hash=ht.build_hash))
+    # Write the concrete root spec json into the reproduction directory
+    root_spec_json_path = os.path.join(repro_dir, 'root.json')
+    with open(root_spec_json_path, 'w') as fd:
+        fd.write(spec_map['root'].to_json(hash=ht.full_hash))
 
     # Write some other details to aid in reproduction into an artifact
     repro_file = os.path.join(repro_dir, 'repro.json')
     repro_details = {
         'job_name': ci_job_name,
-        'job_spec_yaml': job_spec_yaml_file,
-        'root_spec_yaml': 'root.yaml',
+        'job_spec_json': job_spec_json_file,
+        'root_spec_json': 'root.json',
         'ci_project_dir': ci_project_dir
     }
     with open(repro_file, 'w') as fd:
@@ -457,8 +457,8 @@ def ci_rebuild(args):
 
     # TODO: once we have the concrete spec registry, use the DAG hash
     # to identify the spec to install, rather than the concrete spec
-    # yaml file.
-    install_args.extend(['-f', job_spec_yaml_path])
+    # json file.
+    install_args.extend(['-f', job_spec_json_path])
 
     tty.debug('Installing {0} from source'.format(job_spec.name))
     tty.debug('spack install arguments: {0}'.format(
@@ -508,7 +508,7 @@ def ci_rebuild(args):
                 'broken-spec': {
                     'job-url': get_env_var('CI_JOB_URL'),
                     'pipeline-url': get_env_var('CI_PIPELINE_URL'),
-                    'concrete-spec-yaml': job_spec.to_dict(hash=ht.full_hash)
+                    'concrete-spec-dict': job_spec.to_dict(hash=ht.full_hash)
                 }
             }
 
@@ -553,7 +553,7 @@ def ci_rebuild(args):
         # per-PR mirror, if this is a PR pipeline
         if buildcache_mirror_url:
             spack_ci.push_mirror_contents(
-                env, job_spec, job_spec_yaml_path, buildcache_mirror_url,
+                env, job_spec, job_spec_json_path, buildcache_mirror_url,
                 sign_binaries)
 
             if cdash_build_id:
@@ -568,7 +568,7 @@ def ci_rebuild(args):
         # prefix is set)
         if pipeline_mirror_url:
             spack_ci.push_mirror_contents(
-                env, job_spec, job_spec_yaml_path, pipeline_mirror_url,
+                env, job_spec, job_spec_json_path, pipeline_mirror_url,
                 sign_binaries)
 
             if cdash_build_id:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1623,9 +1623,8 @@ class Environment(object):
             for s in spec.traverse():
                 build_hash = s.build_hash()
                 if build_hash not in concrete_specs:
-                    spec_dict = s.to_node_dict(hash=ht.build_hash)
-                    # Assumes no legacy formats, since this was just created.
-                    spec_dict[ht.dag_hash.name] = s.dag_hash()
+                    spec_dict = s.node_dict_with_hashes(
+                        hash=ht.full_hash, dep_hash=ht.build_hash)
                     concrete_specs[build_hash] = spec_dict
 
         hash_spec_list = zip(

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -793,8 +793,8 @@ spack:
 
         expected_repro_files = [
             'install.sh',
-            'root.yaml',
-            'archive-files.yaml',
+            'root.json',
+            'archive-files.json',
             'spack.yaml',
             'spack.lock'
         ]
@@ -821,7 +821,7 @@ spack:
         assert('--no-add' in install_parts)
         assert('-f' in install_parts)
         flag_index = install_parts.index('-f')
-        assert('archive-files.yaml' in install_parts[flag_index + 1])
+        assert('archive-files.json' in install_parts[flag_index + 1])
 
         broken_spec_file = os.path.join(broken_specs_path, job_spec_full_hash)
         with open(broken_spec_file) as fd:
@@ -957,7 +957,7 @@ spack:
             spec_map = ci.get_concrete_specs(
                 env, 'patchelf', 'patchelf', '', 'FIND_ANY')
             concrete_spec = spec_map['patchelf']
-            spec_json = concrete_spec.to_json(hash=ht.build_hash)
+            spec_json = concrete_spec.to_json(hash=ht.full_hash)
             json_path = str(tmpdir.join('spec.json'))
             with open(json_path, 'w') as ypfd:
                 ypfd.write(spec_json)
@@ -1308,7 +1308,7 @@ spack:
             spec_map = ci.get_concrete_specs(
                 env, 'callpath', 'callpath', '', 'FIND_ANY')
             concrete_spec = spec_map['callpath']
-            spec_yaml = concrete_spec.to_yaml(hash=ht.build_hash)
+            spec_yaml = concrete_spec.to_yaml(hash=ht.full_hash)
             yaml_path = str(tmpdir.join('spec.yaml'))
             with open(yaml_path, 'w') as ypfd:
                 ypfd.write(spec_yaml)
@@ -1703,12 +1703,12 @@ spack:
                     job_spec = s
 
             job_spec_yaml_path = os.path.join(
-                working_dir.strpath, 'archivefiles.yaml')
+                working_dir.strpath, 'archivefiles.json')
             with open(job_spec_yaml_path, 'w') as fd:
                 fd.write(job_spec.to_yaml(hash=ht.full_hash))
 
             root_spec_yaml_path = os.path.join(
-                working_dir.strpath, 'root.yaml')
+                working_dir.strpath, 'root.json')
             with open(root_spec_yaml_path, 'w') as fd:
                 fd.write(root_spec.to_yaml(hash=ht.full_hash))
 
@@ -1724,8 +1724,8 @@ spack:
             repro_file = os.path.join(working_dir.strpath, 'repro.json')
             repro_details = {
                 'job_name': job_name,
-                'job_spec_yaml': 'archivefiles.yaml',
-                'root_spec_yaml': 'root.yaml',
+                'job_spec_json': 'archivefiles.json',
+                'root_spec_json': 'root.json',
                 'ci_project_dir': working_dir.strpath
             }
             with open(repro_file, 'w') as fd:

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -454,7 +454,7 @@ def test_user_removed_spec():
 env:
   specs:
   - mpileaks
-  - hypre
+  - hypre ^openblas-with-lapack
   - libelf
 """)
 
@@ -488,7 +488,7 @@ def test_init_from_lockfile(tmpdir):
 env:
   specs:
   - mpileaks
-  - hypre
+  - hypre ^openblas-with-lapack
   - libelf
 """)
     e1 = ev.create('test', initial_yaml)
@@ -514,7 +514,7 @@ def test_init_from_yaml(tmpdir):
 env:
   specs:
   - mpileaks
-  - hypre
+  - hypre ^openblas-with-lapack
   - libelf
 """)
     e1 = ev.create('test', initial_yaml)


### PR DESCRIPTION
Some old concrete `spec.yaml` files in binary mirrors may appear without `full_hash` or `package_hash`, and when spack encounters these (for example, when running `spack buildcache update-index` on a mirror with old binaries), it tries to compute those hashes, even though it already decided it should not when it set `_hashes_final = True`.  When this happens, spack can easily discover that a patch present at the time the `spec.yaml` was written is no longer present in the repository, at which point it crashes with an error similar to the following:

```
spack.patch.NoSuchPatchError: Couldn't find patch for package builtin.mpfr with sha256: 66a5d58364113a21405fc53f4a48f4e8
```

This PR solves the problem by making sure spack does not attempt to re-compute hashes when the `_hashes_final` property is set to `True`.  Instead, spack will just take the `dag_hash` and use it for any of the unknown hashes.

This PR also make sure that going forward, the `spack.lock` files will contain all the hashes for each spec, as otherwise if we were to reconstitute specs from the `spack.lock` after this change, those hashes would be lost forever.  However, the lockfile is still keyed on build hash.

TODO:

- [ ] remove build provenance (build_spec = None) after splicing, be sure DAG hash doesn't change
- [ ] update jobs to read/write `json` specs instead of `yaml` 
- [ ] remove old yaml from mirror whenever you update `yaml` -> `json`