### PR TITLE
add last mesa version in recipe

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -19,6 +19,7 @@ class Mesa(MesonPackage):
     url = "https://archive.mesa3d.org/mesa-20.2.1.tar.xz"
 
     version('master', tag='master')
+    version('21.2.1', sha256='2c65e6710b419b67456a48beefd0be827b32db416772e0e363d5f7d54dc01787')
     version('21.0.3', sha256='565c6f4bd2d5747b919454fc1d439963024fc78ca56fd05158c3b2cde2f6912b')
     version('21.0.0', sha256='e6204e98e6a8d77cf9dc5d34f99dd8e3ef7144f3601c808ca0dd26ba522e0d84')
     version('20.3.4', sha256='dc21a987ec1ff45b278fe4b1419b1719f1968debbb80221480e44180849b4084')


### PR DESCRIPTION
Hello,

I need a more recent version of mesa than the preferred, because of this merge (https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/9750) and updating this recipe seems to me a good idea anyway =).

I only put the last version (21.2.1), but i don't know which one you want to highlight, neither if you want to change the preferred version.

Please, tell me if I add other version or change the preferred version =)
@chuckatkins  @v-dobrev 
