### PR TITLE
gtk-doc: fix testsuite (hung if gtkdocize was not installed)

### DIFF
--- a/var/spack/repos/builtin/packages/gtk-doc/package.py
+++ b/var/spack/repos/builtin/packages/gtk-doc/package.py
@@ -30,6 +30,10 @@ class GtkDoc(AutotoolsPackage):
 
     depends_on('python@3.2:', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))
+    depends_on('py-anytree',       type=('test'))
+    depends_on('py-lxml',          type=('test'))
+    depends_on('py-parameterized', type=('test'))
+    depends_on('py-six',           type=('test'))
     depends_on('libxslt')
     depends_on('libxml2')
     depends_on('docbook-xsl@1.78.1')
@@ -37,6 +41,19 @@ class GtkDoc(AutotoolsPackage):
     # depends_on('dblatex', when='+pdf')
 
     patch('build.patch')
+
+    def setup_build_environment(self, env):
+        """ If test/tools.sh does not find gtkdocize it starts a sh which blocks"""
+        env.prepend_path('PATH',
+                         join_path(self.stage.source_path, 'buildsystems', 'autotools'))
+
+    def install(self, spec, prefix):
+        make('install', 'V=1')
+        install(join_path('buildsystems', 'autotools', 'gtkdocize'), prefix.bin)
+
+    def installcheck(self):
+        """gtk-doc does not support installcheck properly, skip it"""
+        pass
 
     def url_for_version(self, version):
         """Handle gnome's version-based custom URLs."""


### PR DESCRIPTION
Ensure that testsuite has `py-six`, `py-lxml`, `py-anytree` and `py-parameterized`, and finds `gtk-doc`'s `gitdocize` tool.

(open TODO for the future: For the full unit-tests, the package would need to be switched to to `MesonPackage`)