### PR TITLE
boost @1.76: set toolset for intel b2 invocation

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -446,7 +446,11 @@ class Boost(Package):
             '--layout=%s' % layout
         ])
 
-        if (not spec.satisfies('%intel')) or spec.satisfies('@1.76:'):
+        if not spec.satisfies('@:1.75 %intel'):
+            # When building any version >= 1.76, the toolset must be specified.
+            # Some earlier versions could not specify Intel as the toolset
+            # (although it is not currently know if 1.76 is the earliest
+            # version that requires specifying the toolset for Intel)
             options.extend([
                 'toolset=%s' % self.determine_toolset(spec)
             ])

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -448,8 +448,10 @@ class Boost(Package):
 
         if not spec.satisfies('@:1.75 %intel'):
             # When building any version >= 1.76, the toolset must be specified.
-            # Some earlier versions could not specify Intel as the toolset
-            # (although it is not currently know if 1.76 is the earliest
+            # Earlier versions could not specify Intel as the toolset
+            # as that was considered to be redundant/conflicting with
+            # --with-toolset in bootstrap.
+            # (although it is not currently known if 1.76 is the earliest
             # version that requires specifying the toolset for Intel)
             options.extend([
                 'toolset=%s' % self.determine_toolset(spec)

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -446,7 +446,7 @@ class Boost(Package):
             '--layout=%s' % layout
         ])
 
-        if not spec.satisfies('%intel'):
+        if (not spec.satisfies('%intel')) or spec.satisfies('@1.76:'):
             options.extend([
                 'toolset=%s' % self.determine_toolset(spec)
             ])


### PR DESCRIPTION
When building boost 1.76 with `%intel`, I had to set `toolset=` for the `b2` invocation or boost would choose the toolset itself (in my case gcc).