### PR TITLE
allow building silo+mpi ^hdf5~mpi

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -40,8 +40,7 @@ class Silo(AutotoolsPackage):
     depends_on('libtool', type='build', when='+shared')
     depends_on('mpi', when='+mpi')
     depends_on('hdf5@:1.10.999', when='@:4.10.2+hdf5')
-    depends_on('hdf5~mpi', when='~mpi+hdf5')
-    depends_on('hdf5+mpi', when='+mpi+hdf5')
+    depends_on('hdf5', when='+hdf5')
     depends_on('qt+gui~framework@4.8:4.9', when='+silex')
     depends_on('libx11', when='+silex')
     # Xmu dependency is required on Ubuntu 18-20


### PR DESCRIPTION
`silo+mpi` can build with `hdf5~mpi` if needed, so relax the `silo` constraints.