### PR TITLE
RAJA: update blt constraints

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -186,7 +186,7 @@ spack:
     - amrex +cuda cuda_arch=70
     # - axom +cuda cuda_arch=70 ^umpire@4.1.2 ~shared
     - caliper +cuda cuda_arch=70
-    - chai +cuda ~benchmarks ~tests cuda_arch=70 ^umpire@4.1.2 ~shared
+    - chai +cuda ~benchmarks ~tests cuda_arch=70 ^umpire@4.1.2 ~shared ^blt@0.3.6
     - ginkgo +cuda cuda_arch=70
     - hpx +cuda cuda_arch=70
     - kokkos +cuda +wrapper cuda_arch=70
@@ -229,7 +229,7 @@ spack:
     - bolt
     - cabana
     - caliper
-    - chai ~benchmarks ~tests ^umpire@4.1.2
+    - chai ~benchmarks ~tests ^umpire@4.1.2 ^blt@0.3.6
     - conduit
     - darshan-runtime
     - darshan-util

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -37,8 +37,8 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
     # and remove the +tests conflict below.
     variant('tests', default=False, description='Build tests')
 
-    depends_on('blt@0.4.0:', type='build', when='@0.13.1:')
-    depends_on('blt@:0.3.6', type='build', when='@:0.13.0')
+    depends_on('blt@0.4.0:', type='build', when='@0.13.0:')
+    depends_on('blt@:0.3.6', type='build', when='@:0.12.0')
 
     # variants +rocm and amdgpu_targets are not automatically passed to
     # dependencies, so do it manually.

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -37,6 +37,7 @@ class Raja(CMakePackage, CudaPackage, ROCmPackage):
     # and remove the +tests conflict below.
     variant('tests', default=False, description='Build tests')
 
+    depends_on('blt', type='build')
     depends_on('blt@0.4.0:', type='build', when='@0.13.0:')
     depends_on('blt@:0.3.6', type='build', when='@:0.12.0')
 


### PR DESCRIPTION
@white238 

All `0.13.x` versions of RAJA need `blt@0.4.0:`; allow versions `@0.12.1:` to build with `blt@0.4.0`