### PR TITLE
Deactivate environments after tests

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -442,7 +442,8 @@ class Configuration(object):
 
     @_config_mutator
     def remove_scope(self, scope_name):
-        return self.scopes.pop(scope_name)
+        """Remove scope by name; has no effect when ``scope_name`` does not exist"""
+        return self.scopes.pop(scope_name, None)
 
     @property
     def file_scopes(self):

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -92,24 +92,24 @@ def no_path_access(monkeypatch):
 
 
 #
-# Disable any activate Spack environment BEFORE all tests
+# Disable any active Spack environment BEFORE all tests
 #
 @pytest.fixture(scope='session', autouse=True)
 def clean_user_environment():
-    env_var = ev.spack_env_var in os.environ
-    active = ev._active_environment
-
-    if env_var:
-        spack_env_value = os.environ.pop(ev.spack_env_var)
-    if active:
-        ev.deactivate()
-
-    yield
-
-    if env_var:
+    spack_env_value = os.environ.pop(ev.spack_env_var, None)
+    with ev.deactivate_environment():
+        yield
+    if spack_env_value:
         os.environ[ev.spack_env_var] = spack_env_value
-    if active:
-        ev.activate(active)
+
+
+#
+# Make sure global state of active env does not leak between tests.
+#
+@pytest.fixture(scope='function', autouse=True)
+def clean_test_environment():
+    yield
+    ev.deactivate()
 
 
 def _verify_executables_noop(*args):


### PR DESCRIPTION
Closes #25728. Fixes test failures encountered in #25388.

- Always disable leftover active environment after tests

Multiple tests enable an environment without deactivating, which may influence a consecutive test if
it runs environment aware commands.

- Don't error when removing scope that does not exist

The problem here is that a config fixture may replace the configuration
instance, the test calls `spack.environment.activate(...)` which adds a config
scope, then the config fixture removes the config scope, and lastly the
environment fixture deactivates the environment, which removes the environment
config scope, but at that point it doesn't exist anymore.

So, it's easiest simply not to error when calling `remove_scope` for a
non-existing config scope.

---

Once more, the proper solution is in #25608, since this PR uses @alalazo's context manager which mutates globals directly instead of using spack.environment.activate(...) and spack.environment.deactivate().