### PR TITLE
Remove unused --dependencies flag

### DIFF
--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -21,7 +21,7 @@ def setup_parser(subparser):
     """Parser is only constructed so that this prints a nice help
        message with -h. """
     arguments.add_common_arguments(
-        subparser, ['recurse_dependencies', 'installed_specs'])
+        subparser, ['installed_specs'])
 
     shells = subparser.add_mutually_exclusive_group()
     shells.add_argument(

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1202,7 +1202,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -r --dependencies --sh --csh --fish --first --only"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --first --only"
     else
         _installed_packages
     fi


### PR DESCRIPTION
spack load has

```
  -r, --dependencies    recursively traverse spec dependencies
  --only {package,dependencies}
```

the former is not used.
