### PR TITLE
`spack load x` should load `x + runtime deps` by default

### DIFF
--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -44,13 +44,12 @@ def setup_parser(subparser):
 
     subparser.add_argument(
         '--only',
-        default='package,dependencies',
+        default='package',
         dest='things_to_load',
         choices=['package', 'dependencies'],
-        help="""select whether to load the package and its dependencies
-the default is to load the package and all dependencies
-alternatively one can decide to load only the package or only
-the dependencies"""
+        help="""load either the package, its dependencies, or both
+note that required runtime dependencies are always loaded
+the default is to load the specified package only"""
     )
 
 


### PR DESCRIPTION
This PR requires https://github.com/spack/spack/pull/25755 (we need `setup_run_environment` to be called on dependencies)

The current default of `spack load x` is to load *all* dependencies, including build deps of build deps of build deps, which does not make any sense.

The PR changes this into loading `x` with its runtime deps. That way `spack load x` behaves equivalent to `spack env activate e` for an environment `e` which has `x` as a root spec.

Also it solves a performance issue: #25669.

Question remains what to do with the --only flag. Should `--only=dependencies` only load runtime deps? Or should it have the original behavior of loading build deps of build deps of build deps too?

Note that the discussion below about performance is largely irrelevant for this PR; performance is definitely improved, the example given by @tylerjereddy seems to be of a package that has a bunch of run-time deps that should reallly be build/link deps.

