### PR TITLE
Add SYCL build option to ArborX

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -26,7 +26,8 @@ class Arborx(CMakePackage):
         'serial': (True,  "enable Serial backend (default)"),
         'cuda': (False,  "enable Cuda backend"),
         'openmp': (False,  "enable OpenMP backend"),
-        'rocm': (False,  "enable HIP backend")
+        'rocm': (False,  "enable HIP backend"),
+        'sycl': (False, "enable SYCL backend")
     }
 
     variant('mpi', default=True, description='enable MPI')


### PR DESCRIPTION
This largely just depends on `Kokkos` supporting the backend.