### PR TITLE
mfem: Update stand-alone test to use test stage directory

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -810,20 +810,35 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             self.test_suite.current_test_cache_dir,
             self.examples_src_dir
         )
-        with working_dir(test_dir, create=False):
-            # MFEM has many examples to serve as a suitable smoke check. ex10
-            # was chosen arbitrarily among the examples that work both with
-            # MPI and without it
-            test_exe = 'ex10p' if ('+mpi' in self.spec) else 'ex10'
-            make('CONFIG_MK={0}/share/mfem/config.mk'.format(self.prefix),
-                 test_exe, parallel=False)
-            self.run_test('./{0}'.format(test_exe),
-                          ['--mesh', '../{0}/beam-quad.mesh'.format(
-                              self.examples_data_dir)],
-                          [], installed=False,
-                          purpose='test: running {0}'.format(test_exe),
-                          skip_missing=False, work_dir='.')
-            make('clean')
+
+        # MFEM has many examples to serve as a suitable smoke check. ex10
+        # was chosen arbitrarily among the examples that work both with
+        # MPI and without it
+        test_exe = 'ex10p' if ('+mpi' in self.spec) else 'ex10'
+        self.run_test(
+            'make',
+            [
+                'CONFIG_MK={0}/share/mfem/config.mk'.format(self.prefix),
+                test_exe,
+                'parallel=False'
+            ],
+            purpose='test: building {0}'.format(test_exe),
+            skip_missing=False,
+            work_dir=test_dir,
+        )
+
+        self.run_test(
+            './{0}'.format(test_exe),
+            [
+                '--mesh',
+                '../{0}/beam-quad.mesh'.format(self.examples_data_dir)
+            ],
+            [],
+            installed=False,
+            purpose='test: running {0}'.format(test_exe),
+            skip_missing=False,
+            work_dir=test_dir,
+        )
 
     # this patch is only needed for mfem 4.1, where a few
     # released files include byte order marks

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -809,7 +809,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         test_dir = join_path(
             self.test_suite.current_test_cache_dir,
             self.examples_src_dir
-       )
+        )
         with working_dir(test_dir, create=False):
             # MFEM has many examples to serve as a suitable smoke check. ex10
             # was chosen arbitrarily among the examples that work both with

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -806,7 +806,10 @@ class Mfem(Package, CudaPackage, ROCmPackage):
                                        self.examples_data_dir])
 
     def test(self):
-        test_dir = join_path(self.install_test_root, self.examples_src_dir)
+        test_dir = join_path(
+            self.test_suite.current_test_cache_dir,
+            self.examples_src_dir
+       )
         with working_dir(test_dir, create=False):
             # MFEM has many examples to serve as a suitable smoke check. ex10
             # was chosen arbitrarily among the examples that work both with
@@ -817,7 +820,8 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             self.run_test('./{0}'.format(test_exe),
                           ['--mesh', '../{0}/beam-quad.mesh'.format(
                               self.examples_data_dir)],
-                          [], installed=True, purpose='Smoke test for mfem',
+                          [], installed=False,
+                          purpose='test: running {0}'.format(test_exe),
                           skip_missing=False, work_dir='.')
             make('clean')
 


### PR DESCRIPTION
Change the stand-alone/smoke tests to use the (new) test stage directory automatically created for cached test sources (versus referencing and or using the files under the package's install prefix).  

This means the test program will not be built in the prefix so don't want running the test to make that check.  Also tweaked the test description.