### PR TITLE
amrex: support sundials variant in newer amrex versions

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -84,7 +84,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('sundials@4.0.0:4.1.0 +ARKODE +CVODE', when='@19.08:20.11 +sundials')
     depends_on('sundials@5.7.0: +ARKODE +CVODE', when='@21.07: +sundials')
     for arch in CudaPackage.cuda_arch_values:
-        depends_on(f'sundials@5.7.0: +ARKODE +CVODE +cuda cuda_arch={arch}', when=f'@21.07: +sundials +cuda cuda_arch={arch}')
+        depends_on('sundials@5.7.0: +ARKODE +CVODE +cuda cuda_arch=%s' % arch, when='@21.07: +sundials +cuda cuda_arch=%s' % arch)
     depends_on('cuda@9.0.0:', when='+cuda')
     depends_on('python@2.7:', type='build', when='@:20.04')
     depends_on('cmake@3.5:',  type='build', when='@:18.10.99')

--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -68,20 +68,22 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
             description='Build particle classes')
     variant('plotfile_tools', default=False,
             description='Build plotfile_tools like fcompare')
-    variant('sundials', default=False,
-            description='Build AMReX with SUNDIALS support')
     variant('hdf5',  default=False,
             description='Enable HDF5-based I/O')
     variant('hypre', default=False,
             description='Enable Hypre interfaces')
     variant('petsc', default=False,
             description='Enable PETSc interfaces')
+    variant('sundials', default=False,
+            description='Enable SUNDIALS interfaces')
     variant('pic', default=False,
             description='Enable PIC')
 
     # Build dependencies
     depends_on('mpi', when='+mpi')
-    depends_on('sundials@4.0.0:4.1.0 +ARKODE +CVODE', when='@19.08: +sundials')
+    depends_on('sundials@4.0.0:4.1.0 +ARKODE +CVODE', when='@19.08:20.11 +sundials')
+    depends_on('sundials@5.7.0: +ARKODE +CVODE', when='@21.07: +sundials')
+    depends_on('sundials@5.7.0: +ARKODE +CVODE +cuda', when='@21.07: +sundials +cuda')
     depends_on('cuda@9.0.0:', when='+cuda')
     depends_on('python@2.7:', type='build', when='@:20.04')
     depends_on('cmake@3.5:',  type='build', when='@:18.10.99')
@@ -103,10 +105,10 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('%gcc@8.1.0:8.2.0', when='@21.01:21.02')
 
     # Check options compatibility
-    conflicts('+sundials', when='~fortran',
+    conflicts('+sundials', when='@19.08:20.11 ~fortran',
               msg='AMReX SUNDIALS support needs AMReX Fortran API (+fortran)')
-    conflicts('+sundials', when='@20.12:',
-              msg='AMReX >= 20.12 no longer supports SUNDIALS interfaces')
+    conflicts('+sundials', when='@20.12:21.06',
+              msg='AMReX 20.12 -- 21.06 does not support SUNDIALS interfaces')
     conflicts('+hdf5', when='@:20.06',
               msg='AMReX HDF5 support needs AMReX newer than version 20.06')
     conflicts('+hypre', when='@:20.06',
@@ -175,6 +177,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant('AMReX_HDF5', 'hdf5'),
             self.define_from_variant('AMReX_HYPRE', 'hypre'),
             self.define_from_variant('AMReX_PETSC', 'petsc'),
+            self.define_from_variant('AMReX_SUNDIALS', 'sundials'),
             self.define_from_variant('AMReX_PIC', 'pic'),
         ]
 

--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -83,7 +83,8 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('mpi', when='+mpi')
     depends_on('sundials@4.0.0:4.1.0 +ARKODE +CVODE', when='@19.08:20.11 +sundials')
     depends_on('sundials@5.7.0: +ARKODE +CVODE', when='@21.07: +sundials')
-    depends_on('sundials@5.7.0: +ARKODE +CVODE +cuda', when='@21.07: +sundials +cuda')
+    for arch in CudaPackage.cuda_arch_values:
+        depends_on(f'sundials@5.7.0: +ARKODE +CVODE +cuda cuda_arch={arch}', when=f'@21.07: +sundials +cuda cuda_arch={arch}')
     depends_on('cuda@9.0.0:', when='+cuda')
     depends_on('python@2.7:', type='build', when='@:20.04')
     depends_on('cmake@3.5:',  type='build', when='@:18.10.99')

--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -85,6 +85,8 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('sundials@5.7.0: +ARKODE +CVODE', when='@21.07: +sundials')
     for arch in CudaPackage.cuda_arch_values:
         depends_on('sundials@5.7.0: +ARKODE +CVODE +cuda cuda_arch=%s' % arch, when='@21.07: +sundials +cuda cuda_arch=%s' % arch)
+    for tgt in ROCmPackage.amdgpu_targets:
+        depends_on('sundials@5.7.0: +ARKODE +CVODE +rocm amdgpu_target=%s' % tgt, when='@21.07: +sundials +rocm amdgpu_target=%s' % tgt)
     depends_on('cuda@9.0.0:', when='+cuda')
     depends_on('python@2.7:', type='build', when='@:20.04')
     depends_on('cmake@3.5:',  type='build', when='@:18.10.99')


### PR DESCRIPTION
AMReX 21.07 reintroduces sundials interfaces, albeit entirely different ones. 

CC: @balay 