### PR TITLE
Correct typo in r-assertive-data-uk

### DIFF
--- a/var/spack/repos/builtin/packages/r-assertive-data-uk/package.py
+++ b/var/spack/repos/builtin/packages/r-assertive-data-uk/package.py
@@ -22,5 +22,5 @@ class RAssertiveDataUk(RPackage):
     version('0.0-2', sha256='ab48dab6977e8f43d6fffb33228d158865f68dde7026d123c693d77339dcf2bb')
 
     depends_on('r@3.0.0:', type=('build', 'run'))
-    depends_on('r-assertive-base@0.0.2:', type=('build', 'run'))
+    depends_on('r-assertive-base@0.0-2:', type=('build', 'run'))
     depends_on('r-assertive-strings', type=('build', 'run'))


### PR DESCRIPTION
`r-assertive-base` version contains a dot instead of a hyphen.