### PR TITLE
Only load root specs in env (de)activate

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -956,6 +956,8 @@ def modifications_from_dependencies(spec, context, custom_mods_only=True):
                 dpkg.setup_dependent_build_environment(env, spec)
             else:
                 dpkg.setup_dependent_run_environment(env, spec)
+            if dep in exe_deps:
+                dpkg.setup_run_environment(env)
 
     # Note that we want to perform environment modifications in a fixed order.
     # The Spec.traverse method provides this: i.e. in addition to

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1305,31 +1305,30 @@ class Environment(object):
         errors = []
         for _, root_spec in self.concretized_specs():
             if root_spec in self.default_view and root_spec.package.installed:
-                for spec in root_spec.traverse(deptype='run', root=True):
-                    if spec.name in visited:
-                        # It is expected that only one instance of the package
-                        # can be added to the environment - do not attempt to
-                        # add multiple.
-                        tty.debug(
-                            "Not adding {0} to shell modifications: "
-                            "this package has already been added".format(
-                                spec.format("{name}/{hash:7}")
-                            )
+                if root_spec.name in visited:
+                    # It is expected that only one instance of the package
+                    # can be added to the environment - do not attempt to
+                    # add multiple.
+                    tty.debug(
+                        "Not adding {0} to shell modifications: "
+                        "this package has already been added".format(
+                            root_spec.format("{name}/{hash:7}")
                         )
-                        continue
-                    else:
-                        visited.add(spec.name)
+                    )
+                    continue
+                else:
+                    visited.add(root_spec.name)
 
-                    try:
-                        mods = uenv.environment_modifications_for_spec(
-                            spec, self.default_view)
-                    except Exception as e:
-                        msg = ("couldn't get environment settings for %s"
-                               % spec.format("{name}@{version} /{hash:7}"))
-                        errors.append((msg, str(e)))
-                        continue
+                try:
+                    mods = uenv.environment_modifications_for_spec(
+                        root_spec, self.default_view)
+                except Exception as e:
+                    msg = ("couldn't get environment settings for %s"
+                           % root_spec.format("{name}@{version} /{hash:7}"))
+                    errors.append((msg, str(e)))
+                    continue
 
-                    all_mods.extend(mods.reversed() if reverse else mods)
+                all_mods.extend(mods.reversed() if reverse else mods)
 
         return all_mods, errors
 


### PR DESCRIPTION
This PR partially reverts #23485 as it introduced a performance regression
in `spack env activate`. The test from that PR is still there and passing.

The current logic of `spack env activate` is as follows:

1. collect root specs
2. add root specs + transitive run type deps of root specs to a list
3. call `environment_modifications_for_spec` for every spec of this list

However, `environment_modifications_for_spec` also processes run type
dependencies of the spec, so we're doing a lot of redundant work,
resulting in O(n^2) processed specs given `n` of them in
a chain like `a` <- `b` <- ... <- `z`

This PR drops step 2, so that we call
`environment_modifications_for_spec` only on the root specs, and this
function will process the run type deps for us anyways.

Given an environment like this:

```yaml
spack:
  specs:
  - py-flake8
  - py-matplotlib
  - py-isort
  - py-sphinx
  - py-six
  - py-ipython
```

This is the time spent on `activate` before and after:

**Before**:

```
In [1]: from spack.main import SpackCommand
In [2]: env = SpackCommand('env')
In [3]: %timeit env('activate', '--sh', '.')
2.56 s ± 11.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

**After**:

```
In [1]: from spack.main import SpackCommand
In [2]: env = SpackCommand('env')
In [3]: %timeit env('activate', '--sh', '.')
820 ms ± 6.22 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

which is 68% less.

The diff of `spack env activate --sh .` is the same except for the order of paths in `PYTHONPATH`, but note that the logic introduced in #23485 didn't walk over the deps in post order: `root_spec.traverse(deptype='run', root=True)` which seems to be a mistake? (@scheibelp). Anyways, that's gone with this pr.
