### PR TITLE
Package silo depends on m4 as well as autoconf/automake/libtool

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -35,6 +35,7 @@ class Silo(AutotoolsPackage):
     variant('fpzip', default=True,
             description='Enable fpzip support')
 
+    depends_on('m4', type='build', when='+shared')
     depends_on('autoconf', type='build', when='+shared')
     depends_on('automake', type='build', when='+shared')
     depends_on('libtool', type='build', when='+shared')


### PR DESCRIPTION
Without m4 one may have a complaint:

```
==> silo: Executing phase: 'autoreconf'
==> Error: RuntimeError: Cannot generate configure: missing dependencies ['m4']

/path_to/spack/lib/spack/spack/build_systems/autotools.py:264, in autoreconf:
        261        autotools = ['m4', 'autoconf', 'automake', 'libtool']
        262        missing = [x for x in autotools if x not in spec]
        263        if missing:
  >>    264            msg = 'Cannot generate configure: missing dependencies {0}'
        265            raise RuntimeError(msg.format(missing))
        266        tty.msg('Configure script not found: trying to generate it')
        267        tty.warn('*********************************************************')


```