### PR TITLE
Update HPX package

### DIFF
--- a/var/spack/repos/builtin/packages/asio/package.py
+++ b/var/spack/repos/builtin/packages/asio/package.py
@@ -26,7 +26,7 @@ class Asio(AutotoolsPackage):
     depends_on("m4", type="build")
     depends_on("libtool", type="build")
 
-    stds = ("11", "14", "17")
+    stds = ("11", "14", "17", "2a")
     variant(
         "cxxstd",
         default="11",

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -174,6 +174,10 @@ class Hpx(CMakePackage, CudaPackage):
             self.define('HPX_DATASTRUCTURES_WITH_ADAPT_STD_TUPLE', False),
         ]
 
+        # Enable unity builds when available
+        if spec.satisfies("@1.7:"):
+            args += [self.define('HPX_WITH_UNITY_BUILD', True)]
+
         # Instrumentation
         args += self.instrumentation_args()
 


### PR DESCRIPTION
Rebased on #25535.

- Adds support for ROCm to HPX package
- Enables unity builds when it's supported by HPX
- Updates conflicts etc. for 1.7.X
- Reorganizes the constraints and dependencies a bit (to hopefully be a bit more organized, let me know if someone thinks this looks worse)