### PR TITLE
Explicitly enable ccmake in cmake, and make bootstrapping use CMAKE_PREFIX_PATH to detect dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -141,7 +141,7 @@ class Cmake(Package):
     variant('qt',      default=False, description='Enables the build of cmake-gui')
     variant('doc',     default=False, description='Enables the generation of html and man page documentation')
     variant('openssl', default=True,  description="Enables CMake's OpenSSL features")
-    variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
+    variant('ccmake',  default=False, description='Enables the build of the ncurses gui')
 
     # Does not compile and is not covered in upstream CI (yet).
     conflicts('%gcc platform=darwin',
@@ -174,7 +174,7 @@ class Cmake(Package):
     depends_on('py-sphinx',      when='+doc', type='build')
     depends_on('openssl', when='+openssl')
     depends_on('openssl@:1.0.99', when='@:3.6.9+openssl')
-    depends_on('ncurses',        when='+ncurses')
+    depends_on('ncurses',        when='+ccmake')
 
     # Cannot build with Intel, should be fixed in 3.6.2
     # https://gitlab.kitware.com/cmake/cmake/issues/16226
@@ -276,6 +276,8 @@ class Cmake(Package):
         # enable / disable oepnssl
         if '+ownlibs' in spec:
             args.append('-DCMAKE_USE_OPENSSL=%s' % str('+openssl' in spec))
+
+        args.append('-DBUILD_CursesDialog=%s' % str('+ccmake' in spec))
 
         return args
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -143,7 +143,7 @@ class Cmake(Package):
     variant('qt',      default=False, description='Enables the build of cmake-gui')
     variant('doc',     default=False, description='Enables the generation of html and man page documentation')
     variant('openssl', default=True,  description="Enables CMake's OpenSSL features")
-    variant('ccmake',  default=False, description='Enables the build of the ncurses gui')
+    variant('ncurses', default=True, description='Enables the build of the ncurses gui')
 
     # Does not compile and is not covered in upstream CI (yet).
     conflicts('%gcc platform=darwin',
@@ -176,7 +176,7 @@ class Cmake(Package):
     depends_on('py-sphinx',      when='+doc', type='build')
     depends_on('openssl', when='+openssl')
     depends_on('openssl@:1.0.99', when='@:3.6.9+openssl')
-    depends_on('ncurses',        when='+ccmake')
+    depends_on('ncurses',        when='+ncurses')
 
     # Cannot build with Intel, should be fixed in 3.6.2
     # https://gitlab.kitware.com/cmake/cmake/issues/16226
@@ -279,7 +279,7 @@ class Cmake(Package):
         if '+ownlibs' in spec:
             args.append('-DCMAKE_USE_OPENSSL=%s' % str('+openssl' in spec))
 
-        args.append('-DBUILD_CursesDialog=%s' % str('+ccmake' in spec))
+        args.append('-DBUILD_CursesDialog=%s' % str('+ncurses' in spec))
 
         # Make CMake find its own dependencies.
         rpaths = spack.build_environment.get_rpaths(self)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -143,7 +143,7 @@ class Cmake(Package):
     variant('qt',      default=False, description='Enables the build of cmake-gui')
     variant('doc',     default=False, description='Enables the generation of html and man page documentation')
     variant('openssl', default=True,  description="Enables CMake's OpenSSL features")
-    variant('ncurses', default=True, description='Enables the build of the ncurses gui')
+    variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
 
     # Does not compile and is not covered in upstream CI (yet).
     conflicts('%gcc platform=darwin',

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -5,6 +5,8 @@
 
 import re
 
+import spack.build_environment
+
 
 class Cmake(Package):
     """A cross-platform, open-source build system. CMake is a family of
@@ -278,6 +280,15 @@ class Cmake(Package):
             args.append('-DCMAKE_USE_OPENSSL=%s' % str('+openssl' in spec))
 
         args.append('-DBUILD_CursesDialog=%s' % str('+ccmake' in spec))
+
+        # Make CMake find its own dependencies.
+        rpaths = spack.build_environment.get_rpaths(self)
+        prefixes = spack.build_environment.get_cmake_prefix_path(self)
+        args.extend([
+            '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF',
+            '-DCMAKE_INSTALL_RPATH={0}'.format(";".join(str(v) for v in rpaths)),
+            '-DCMAKE_PREFIX_PATH={0}'.format(";".join(str(v) for v in prefixes))
+        ])
 
         return args
 


### PR DESCRIPTION
Explicitly enable/disable `BUILD_CursesDialog`, use `CMAKE_PREFIX_PATH` to make cmake detect its own deps, and also set RPATH related variables like we do in all cmake packages.