### PR TITLE
dyninst: use spack libiberty path

### DIFF
--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -104,6 +104,7 @@ class Dyninst(CMakePackage):
             '-DElfUtils_ROOT_DIR=%s'  % spec['elf'].prefix,
             '-DLibIberty_ROOT_DIR=%s' % spec['libiberty'].prefix,
             '-DTBB_ROOT_DIR=%s'       % spec['tbb'].prefix,
+            self.define('LibIberty_LIBRARIES', spec['libiberty'].libs)
         ]
 
         if '+openmp' in spec:


### PR DESCRIPTION
This branch adds the LibIberty path for users which use a gcc (or other compiler) without a libiberty ship with it and forces dyninst to use the on provided by spack.