### PR TITLE
gettext: fix aarch64 build with AutotoolsPackage (fixes multiple aarch64 builds)

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -30,6 +30,7 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     variant('libunistring', default=False, description='Use libunistring')
 
     depends_on('iconv')
+    depends_on('automake', type='build', when='target=aarch64:')
     # Recommended dependencies
     depends_on('ncurses',  when='+curses')
     depends_on('libxml2',  when='+libxml2')


### PR DESCRIPTION
Adds `automake` to build `spec`. This fixes the `config.guess` find in:

https://github.com/spack/spack/blob/29d344e4c72aadb1672a2c8f36f9ff773b636ac4/lib/spack/spack/build_systems/autotools.py#L155-L156

As automake is not a dependency of `gettext` the `automake` path is not added which leads to this error:
```bash
==> gettext: Executing phase: 'autoreconf'
==> Error: RuntimeError: Failed to find suitable substitutes for config.sub, config.guess

/(redacted)/autotools.py:174, in _do_patch_config_files:
        171
        172        # Check that we found everything we needed
        173        if to_be_found:
  >>    174            msg = 'Failed to find suitable substitutes for {0}'
        175            raise RuntimeError(msg.format(', '.join(to_be_found)))
        176
        177        # Copy the good files over the bad ones
```


Fixes: #23534 