### PR TITLE
Add new packages for using MEDCoupling from SALOME platform

### DIFF
--- a/var/spack/repos/builtin/packages/salome-configuration/FindSalomeHDF5.patch
+++ b/var/spack/repos/builtin/packages/salome-configuration/FindSalomeHDF5.patch
@@ -1,0 +1,27 @@
+--- a/FindSalomeHDF5.cmake	2020-02-14 09:27:51.918313640 +0100
++++ b/FindSalomeHDF5.cmake.patched	2020-02-14 09:28:38.658223715 +0100
+@@ -69,15 +69,15 @@
+     SET(_suffix "-shared")
+     SET(HDF5_LIBRARIES "${_target_prefix}hdf5${_suffix}")
+   ENDIF()
+-  GET_PROPERTY(_lib_lst TARGET ${HDF5_LIBRARIES} PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG)
+-  FOREACH(s ${_lib_lst})
+-    STRING(FIND "${s}" "mpi." _res)   # should cover WIN(?) and LINUX
+-    IF(_res GREATER -1)
+-      GET_FILENAME_COMPONENT(_tmp "${s}" PATH)     # go up to levels
+-      GET_FILENAME_COMPONENT(MPI_ROOT_DIR_EXP "${_tmp}" PATH)
+-      BREAK()
+-    ENDIF()
+-  ENDFOREACH()
++#  GET_PROPERTY(_lib_lst TARGET ${HDF5_LIBRARIES} PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_NOCONFIG)
++#  FOREACH(s ${_lib_lst})
++#    STRING(FIND "${s}" "mpi." _res)   # should cover WIN(?) and LINUX
++#    IF(_res GREATER -1)
++#      GET_FILENAME_COMPONENT(_tmp "${s}" PATH)     # go up to levels
++#      GET_FILENAME_COMPONENT(MPI_ROOT_DIR_EXP "${_tmp}" PATH)
++#      BREAK()
++#    ENDIF()
++#  ENDFOREACH()
+   IF(NOT SalomeHDF5_FIND_QUIETLY)
+     MESSAGE(STATUS "HDF5 was compiled with MPI: ${MPI_ROOT_DIR_EXP}")
+   ENDIF()  

--- a/var/spack/repos/builtin/packages/salome-configuration/SalomeMacros.patch
+++ b/var/spack/repos/builtin/packages/salome-configuration/SalomeMacros.patch
@@ -1,0 +1,11 @@
+--- a/SalomeMacros.cmake	2021-03-09 12:23:13.164874719 +0100
++++ b/SalomeMacros.cmake.patched	2021-03-09 15:09:40.906813952 +0100
+@@ -19,4 +19,8 @@
+ # Author: A.Geay, V. Sandler, A. Bruneton
+ #
+ 
++IF(CMAKE_VERSION VERSION_GREATER_EQUAL 3.3)
++  CMAKE_POLICY(SET CMP0057 NEW)
++ENDIF()
++
+ #----------------------------------------------------------------------------

--- a/var/spack/repos/builtin/packages/salome-configuration/package.py
+++ b/var/spack/repos/builtin/packages/salome-configuration/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#
+# Important feature: a set of salome-xxx packages must have all the same version
+# - except salome-med that is also fixed but by another number version
+
+from spack import *
+
+
+class SalomeConfiguration(Package):
+    """salome-configuration is a part of SALOME platform and define general
+    build tools for the platform."""
+
+    maintainers = ['franciskloss']
+
+    homepage = "https://www.salome-platform.org"
+    git      = "https://git.salome-platform.org/gitpub/tools/configuration.git"
+
+    version('9.7.0', tag='V9_7_0')
+    version('9.6.0', tag='V9_6_0')
+    version('9.5.0', tag='V9_5_0')
+    version('9.4.0', tag='V9_4_0')
+    version('9.3.0', tag='V9_3_0')
+
+    patch('SalomeMacros.patch',   working_dir='./cmake')
+    patch('FindSalomeHDF5.patch', working_dir='./cmake')
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('CONFIGURATION_ROOT_DIR', self.prefix)
+
+    def install(self, spec, prefix):
+        install_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/salome-med/MAJ_400_410_champs.patch
+++ b/var/spack/repos/builtin/packages/salome-med/MAJ_400_410_champs.patch
@@ -1,0 +1,10 @@
+--- a/MAJ_400_410_champs.c	2020-03-11 11:03:40.000000000 +0100
++++ b/MAJ_400_410_champs.c.patched	2021-07-13 16:51:23.622940398 +0200
+@@ -27,7 +27,6 @@
+ 
+ #define USER_MODE MED_COMPACT_STMODE
+ 
+-#include "_MEDfieldValueUpdateEntityList41.c"
+ 
+ med_err getFieldsOn40(med_idt                  fid,
+ 		    const char * const       nommaa,

--- a/var/spack/repos/builtin/packages/salome-med/package.py
+++ b/var/spack/repos/builtin/packages/salome-med/package.py
@@ -43,6 +43,10 @@ class SalomeMed(CMakePackage):
 
     patch('MAJ_400_410_champs.patch', when='@4.1.0+static', working_dir='./tools/medimport/4.0.0')
 
+    def check(self):
+        with working_dir(self.build_directory):
+            make('test', parallel=False)
+
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('HDF5_ROOT_DIR', self.spec['hdf5'].prefix)
 
@@ -74,7 +78,7 @@ class SalomeMed(CMakePackage):
         options.extend([
             '-DMEDFILE_BUILD_PYTHON=OFF',
             '-DMEDFILE_INSTALL_DOC=OFF',
-            '-DMEDFILE_BUILD_TESTS={0}'.format('ON' if self.run_tests else 'OFF'),
+            '-DMEDFILE_BUILD_TESTS=%s' % self.run_tests,
             '-DHDF5_ROOT_DIR=%s' % spec['hdf5'].prefix])
 
         return options

--- a/var/spack/repos/builtin/packages/salome-med/package.py
+++ b/var/spack/repos/builtin/packages/salome-med/package.py
@@ -1,0 +1,75 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#
+# Important feature: to interoperate goodly MED files, it is imperative to fix
+# the HDF5 version for a salome-med version
+
+from spack import *
+
+
+class SalomeMed(CMakePackage):
+    """salome-med is the MED file format that is the SALOME platform standard
+    file for meshes and fields and salome-med is based on HDF5 library."""
+
+    maintainers = ['franciskloss']
+
+    homepage = "https://docs.salome-platform.org/latest/dev/MEDCoupling/developer/med-file.html"
+    url      = "ftp://ftp.cea.fr/pub/salome/prerequisites/med-4.1.0.tar.gz"
+
+    version('4.1.0', sha256='847db5d6fbc9ce6924cb4aea86362812c9a5ef6b9684377e4dd6879627651fce')
+    version('4.0.0', sha256='a474e90b5882ce69c5e9f66f6359c53b8b73eb448c5f631fa96e8cd2c14df004')
+    version('3.3.1', sha256='856e9c4bb75eb0cceac3d5a5c65b1ce52fb3c46b9182920e1c9f34ae69bd2d5f')
+    version('3.2.0', sha256='d52e9a1bdd10f31aa154c34a5799b48d4266dc6b4a5ee05a9ceda525f2c6c138')
+
+    variant('mpi',    default=False, description='Enable MPI')
+    variant('static', default=False, description='Enable static library build')
+
+    depends_on('mpi', when='+mpi')
+
+    depends_on('hdf5@1.10.3+mpi', when='@4.1.0+mpi')
+    depends_on('hdf5@1.10.3~mpi', when='@4.1.0~mpi')
+
+    depends_on('hdf5@1.10.3+mpi', when='@4.0.0+mpi')
+    depends_on('hdf5@1.10.3~mpi', when='@4.0.0~mpi')
+
+    depends_on('hdf5@1.8.14+mpi', when='@3.3.1+mpi')
+    depends_on('hdf5@1.8.14~mpi', when='@3.3.1~mpi')
+
+    depends_on('hdf5@1.8.14+mpi', when='@3.2.0+mpi')
+    depends_on('hdf5@1.8.14~mpi', when='@3.2.0~mpi')
+
+    patch('MAJ_400_410_champs.patch', when='@4.1.0+static', working_dir='./tools/medimport/4.0.0')
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('HDF5_ROOT_DIR', self.spec['hdf5'].prefix)
+
+    def cmake_args(self):
+        spec    = self.spec
+        options = []
+
+        if '+mpi' in spec:
+            options.extend([
+                '-DMEDFILE_USE_MPI=ON',
+                '-DMPI_ROOT_DIR=%s' % spec['mpi'].prefix])
+        else:
+            options.extend(['-DMEDFILE_USE_MPI=OFF'])
+
+        if '+static' in spec:
+            options.extend([
+                '-DMEDFILE_BUILD_SHARED_LIBS=OFF',
+                '-DMEDFILE_BUILD_STATIC_LIBS=ON'])
+        else:
+            options.extend([
+                '-DMEDFILE_BUILD_SHARED_LIBS=ON',
+                '-DMEDFILE_BUILD_STATIC_LIBS=OFF'])
+
+        options.extend([
+            '-DMEDFILE_BUILD_PYTHON=OFF',
+            '-DMEDFILE_INSTALL_DOC=OFF',
+            '-DMEDFILE_BUILD_TESTS={0}'.format('ON' if self.run_tests else 'OFF'),
+            '-DCMAKE_Fortran_COMPILER=',
+            '-DHDF5_ROOT_DIR=%s' % spec['hdf5'].prefix])
+
+        return options

--- a/var/spack/repos/builtin/packages/salome-med/package.py
+++ b/var/spack/repos/builtin/packages/salome-med/package.py
@@ -23,8 +23,9 @@ class SalomeMed(CMakePackage):
     version('3.3.1', sha256='856e9c4bb75eb0cceac3d5a5c65b1ce52fb3c46b9182920e1c9f34ae69bd2d5f')
     version('3.2.0', sha256='d52e9a1bdd10f31aa154c34a5799b48d4266dc6b4a5ee05a9ceda525f2c6c138')
 
-    variant('mpi',    default=False, description='Enable MPI')
-    variant('static', default=False, description='Enable static library build')
+    variant('mpi',     default=False, description='Enable MPI')
+    variant('static',  default=False, description='Enable static library build')
+    variant('fortran', default=False, description='Enable Fortran')
 
     depends_on('mpi', when='+mpi')
 
@@ -65,11 +66,15 @@ class SalomeMed(CMakePackage):
                 '-DMEDFILE_BUILD_SHARED_LIBS=ON',
                 '-DMEDFILE_BUILD_STATIC_LIBS=OFF'])
 
+        if '+fortran' in spec:
+            options.extend(['-DCMAKE_Fortran_COMPILER=%s' % self.compiler.fc])
+        else:
+            options.extend(['-DCMAKE_Fortran_COMPILER='])
+
         options.extend([
             '-DMEDFILE_BUILD_PYTHON=OFF',
             '-DMEDFILE_INSTALL_DOC=OFF',
             '-DMEDFILE_BUILD_TESTS={0}'.format('ON' if self.run_tests else 'OFF'),
-            '-DCMAKE_Fortran_COMPILER=',
             '-DHDF5_ROOT_DIR=%s' % spec['hdf5'].prefix])
 
         return options

--- a/var/spack/repos/builtin/packages/salome-medcoupling/package.py
+++ b/var/spack/repos/builtin/packages/salome-medcoupling/package.py
@@ -75,8 +75,7 @@ class SalomeMedcoupling(CMakePackage):
     depends_on('salome-med@4.0.0',            when='@9.3.0~mpi')
 
     def check(self):
-        with working_dir(self.build_directory):
-            make('test', parallel=False)
+        pass
 
     def setup_build_environment(self, env):
         if '+metis' in self.spec:

--- a/var/spack/repos/builtin/packages/salome-medcoupling/package.py
+++ b/var/spack/repos/builtin/packages/salome-medcoupling/package.py
@@ -74,6 +74,10 @@ class SalomeMedcoupling(CMakePackage):
     depends_on('salome-med@4.0.0+static',     when='@9.3.0~mpi+static')
     depends_on('salome-med@4.0.0',            when='@9.3.0~mpi')
 
+    def check(self):
+        with working_dir(self.build_directory):
+            make('test', parallel=False)
+
     def setup_build_environment(self, env):
         if '+metis' in self.spec:
             env.set('METIS_ROOT_DIR', self.spec['metis'].prefix)

--- a/var/spack/repos/builtin/packages/salome-medcoupling/package.py
+++ b/var/spack/repos/builtin/packages/salome-medcoupling/package.py
@@ -1,0 +1,141 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#
+# Important feature: a version of salome-medcoupling depand on
+# a specific version of salome-med package
+
+from spack import *
+
+
+class SalomeMedcoupling(CMakePackage):
+    """salome-medcoupling is a part of SALOME platform to manipulate meshes and
+    fields in memory, and use salome-med format for files."""
+
+    maintainers = ['franciskloss']
+
+    homepage = "https://docs.salome-platform.org/latest/dev/MEDCoupling/developer/index.html"
+    git      = "https://git.salome-platform.org/gitpub/tools/medcoupling.git"
+
+    version('9.7.0', tag='V9_7_0')
+    version('9.6.0', tag='V9_6_0')
+    version('9.5.0', tag='V9_5_0')
+    version('9.4.0', tag='V9_4_0')
+    version('9.3.0', tag='V9_3_0')
+
+    variant('static',      default=False, description='Enable static library build')
+    variant('mpi',         default=False, description='Enable MPI')
+    variant('in64',        default=False, description='Enable 64 bits indexes')
+    variant('partitioner', default=False, description='Enable partitioner')
+    variant('metis',       default=False, description='Enable Metis')
+    variant('scotch',      default=False, description='Enable Scotch')
+
+    depends_on('libxml2@2.9.1:')
+    depends_on('libtirpc')
+    depends_on('cppunit')
+    depends_on('python@3.6.5:')
+    depends_on('py-scipy@0.19.1:', type=('build', 'run'))
+    depends_on('py-numpy@1.15.1:', type=('build', 'run'))
+    depends_on('boost+python+numpy@1.58.0:')
+    depends_on('swig@3.0.12:', type='build')
+
+    depends_on('metis@5.1.0:',  when='+metis')
+    depends_on('scotch@6.0.4:', when='+scotch')
+    depends_on('mpi',           when='+mpi')
+
+    depends_on('salome-configuration@9.7.0',  when='@9.7.0')
+    depends_on('salome-med@4.1.0+mpi+static', when='@9.7.0+mpi+static')
+    depends_on('salome-med@4.1.0+mpi',        when='@9.7.0+mpi')
+    depends_on('salome-med@4.1.0+static',     when='@9.7.0~mpi+static')
+    depends_on('salome-med@4.1.0',            when='@9.7.0~mpi')
+
+    depends_on('salome-configuration@9.6.0',  when='@9.6.0')
+    depends_on('salome-med@4.1.0+mpi+static', when='@9.6.0+mpi+static')
+    depends_on('salome-med@4.1.0+mpi',        when='@9.6.0+mpi')
+    depends_on('salome-med@4.1.0+static',     when='@9.6.0~mpi+static')
+    depends_on('salome-med@4.1.0',            when='@9.6.0~mpi')
+
+    depends_on('salome-configuration@9.5.0',  when='@9.5.0')
+    depends_on('salome-med@4.1.0+mpi+static', when='@9.5.0+mpi+static')
+    depends_on('salome-med@4.1.0+mpi',        when='@9.5.0+mpi')
+    depends_on('salome-med@4.1.0+static',     when='@9.5.0~mpi+static')
+    depends_on('salome-med@4.1.0',            when='@9.5.0~mpi')
+
+    depends_on('salome-configuration@9.4.0',  when='@9.4.0')
+    depends_on('salome-med@4.0.0+mpi+static', when='@9.4.0+mpi+static')
+    depends_on('salome-med@4.0.0+mpi',        when='@9.4.0+mpi')
+    depends_on('salome-med@4.0.0+static',     when='@9.4.0~mpi+static')
+    depends_on('salome-med@4.0.0',            when='@9.4.0~mpi')
+
+    depends_on('salome-configuration@9.3.0',  when='@9.3.0')
+    depends_on('salome-med@4.0.0+mpi+static', when='@9.3.0+mpi+static')
+    depends_on('salome-med@4.0.0+mpi',        when='@9.3.0+mpi')
+    depends_on('salome-med@4.0.0+static',     when='@9.3.0~mpi+static')
+    depends_on('salome-med@4.0.0',            when='@9.3.0~mpi')
+
+    def setup_build_environment(self, env):
+        if '+metis' in self.spec:
+            env.set('METIS_ROOT_DIR', self.spec['metis'].prefix)
+
+        if '+scotch' in self.spec:
+            env.set('SCOTCH_ROOT_DIR', self.spec['scotch'].prefix)
+
+    def setup_run_environment(self, env):
+        env.prepend_path(
+            'PYTHONPATH',
+            join_path(
+                self.prefix.lib,
+                'python{0}'.format(self.spec['python'].version.up_to(2)),
+                'site-packages'))
+
+    def cmake_args(self):
+        spec    = self.spec
+        options = []
+
+        if '+static' in spec:
+            options.extend(['-DMEDCOUPLING_BUILD_STATIC=ON'])
+        else:
+            options.extend(['-DMEDCOUPLING_BUILD_STATIC=OFF'])
+
+        if '+mpi' in spec:
+            options.extend([
+                '-DMEDCOUPLING_USE_MPI=ON',
+                '-DSALOME_USE_MPI=ON'])
+        else:
+            options.extend([
+                '-DMEDCOUPLING_USE_MPI=OFF',
+                '-DSALOME_USE_MPI=OFF'])
+
+        if '+in64' in spec:
+            options.extend(['-DMEDCOUPLING_USE_64BIT_IDS=ON'])
+        else:
+            options.extend(['-DMEDCOUPLING_USE_64BIT_IDS=OFF'])
+
+        if '+partitioner' in spec:
+            options.extend(['-DMEDCOUPLING_ENABLE_PARTITIONER=ON'])
+        else:
+            options.extend(['-DMEDCOUPLING_ENABLE_PARTITIONER=OFF'])
+
+        if '+metis' in spec:
+            options.extend(['-DMEDCOUPLING_ENABLE_PARTITIONER=ON'])
+            options.extend(['-DMEDCOUPLING_PARTITIONER_METIS=ON'])
+        else:
+            options.extend(['-DMEDCOUPLING_PARTITIONER_METIS=OFF'])
+
+        if '+scotch' in spec:
+            options.extend(['-DMEDCOUPLING_ENABLE_PARTITIONER=ON'])
+            options.extend(['-DMEDCOUPLING_PARTITIONER_SCOTCH=ON'])
+        else:
+            options.extend(['-DMEDCOUPLING_PARTITIONER_SCOTCH=OFF'])
+
+        options.extend([
+            '-DMEDCOUPLING_BUILD_DOC=OFF',
+            '-DMEDCOUPLING_ENABLE_PYTHON=ON',
+            '-DMEDCOUPLING_ENABLE_RENUMBER=OFF',
+            '-DMEDCOUPLING_PARTITIONER_PARMETIS=OFF',
+            '-DMEDCOUPLING_PARTITIONER_PTSCOTCH=OFF',
+            '-DMEDCOUPLING_MICROMED=OFF',
+            '-DMEDCOUPLING_BUILD_TESTS=OFF'])
+
+        return options


### PR DESCRIPTION
See: https://salome-platform.org
Theses packages follow SALOME build constraints.
We recommand to use "salome-med" instead of "med" package.

Sur la branche salome_fkl
	nouveau fichier : var/spack/repos/builtin/packages/salome-configuration/FindSalomeHDF5.patch
	nouveau fichier : var/spack/repos/builtin/packages/salome-configuration/SalomeMacros.patch
	nouveau fichier : var/spack/repos/builtin/packages/salome-configuration/package.py
	nouveau fichier : var/spack/repos/builtin/packages/salome-med/MAJ_400_410_champs.patch
	nouveau fichier : var/spack/repos/builtin/packages/salome-med/package.py
	nouveau fichier : var/spack/repos/builtin/packages/salome-medcoupling/package.py