### PR TITLE
fix icelake detection on AWS

### DIFF
--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -1044,7 +1044,6 @@
         "avx512vbmi",
         "avx512ifma",
         "sha_ni",
-        "umip",
         "clwb",
         "rdpid",
         "gfni",


### PR DESCRIPTION
`umip` not available in m6i (icelake) instances.