### PR TITLE
Update pinned OpenSSL version to 1.1.1l

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -143,7 +143,7 @@ spack:
       variants: threads=openmp
     openssl:
       version:
-        - 1.1.1k
+        - 1.1.1l
     perl:
       version:
       - 5.34.0 # 5.34.0

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -143,7 +143,7 @@ spack:
       variants: threads=openmp
     openssl:
       version:
-        - 1.1.1k
+        - 1.1.1l
     perl:
       version:
         - 5.34.0


### PR DESCRIPTION
Update to the latest version of openssl, as the previous one (1.1.1k) is now deprecated, so spack can no longer rebuild it from source.