### PR TITLE
openssh: Fix parallel install issue, add test suite

### DIFF
--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -65,9 +65,16 @@ class Openssh(AutotoolsPackage):
         return args
 
     def install(self, spec, prefix):
+        """Install generates etc/sshd_config, but it fails in parallel mode"""
         make('install', parallel=False)
 
     def setup_build_environment(self, env):
+        """Until spack supports a real implementation of setup_test_environment()"""
+        if self.run_tests:
+            self.setup_test_environment(env)
+
+    def setup_test_environment(self, env):
+        """Configure the regression test suite like Debian's openssh-tests package"""
         p = self.prefix
         j = join_path
         env.set('TEST_SSH_SSH', p.bin.ssh)
@@ -89,7 +96,7 @@ class Openssh(AutotoolsPackage):
         tcp.close()
         env.set('TEST_SSH_PORT', port)
         env.set('SKIP_LTESTS', 'key-options forward-control forwarding '
-                'multiplex addrmatch cfgmatch cfgmatchlisten')
+                'multiplex addrmatch cfgmatch cfgmatchlisten percent')
 
     def installcheck(self):
         make('-e', 'tests', parallel=False)

--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
+import socket
 
 from spack import *
 
@@ -44,10 +45,11 @@ class Openssh(AutotoolsPackage):
     depends_on('libedit')
     depends_on('ncurses')
     depends_on('zlib')
+    depends_on('py-twisted', type='test')
 
-    # Note: some server apps have "ssh" in the name, so require the exact
-    # command 'ssh'
-    executables = ['^ssh$', '^rsh$']
+    maintainers = ['bernhardkaindl']
+    executables = ['^ssh$', '^scp$', '^sftp$', '^ssh-add$', '^ssh-agent$',
+                   '^ssh-keygen$', '^ssh-keyscan$']
 
     @classmethod
     def determine_version(cls, exe):
@@ -61,3 +63,33 @@ class Openssh(AutotoolsPackage):
         # install step and fail if they cannot do so.
         args = ['--with-privsep-path={0}'.format(self.prefix.var.empty)]
         return args
+
+    def install(self, spec, prefix):
+        make('install', parallel=False)
+
+    def setup_build_environment(self, env):
+        p = self.prefix
+        j = join_path
+        env.set('TEST_SSH_SSH', p.bin.ssh)
+        env.set('TEST_SSH_SCP', p.bin.scp)
+        env.set('TEST_SSH_SFTP', p.bin.sftp)
+        env.set('TEST_SSH_SK_HELPER', j(p.libexec, 'ssh-sk-helper'))
+        env.set('TEST_SSH_SFTPSERVER', j(p.libexec, 'sftp-server'))
+        env.set('TEST_SSH_PKCS11_HELPER', j(p.libexec, 'ssh-pkcs11-helper'))
+        env.set('TEST_SSH_SSHD', p.sbin.sshd)
+        env.set('TEST_SSH_SSHADD', j(p.bin, 'ssh-add'))
+        env.set('TEST_SSH_SSHAGENT', j(p.bin, 'ssh-agent'))
+        env.set('TEST_SSH_SSHKEYGEN', j(p.bin, 'ssh-keygen'))
+        env.set('TEST_SSH_SSHKEYSCAN', j(p.bin, 'ssh-keyscan'))
+        env.set('TEST_SSH_UNSAFE_PERMISSIONS', '1')
+        # Get a free port for the simple tests and skip the complex tests:
+        tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        tcp.bind(('', 0))
+        host, port = tcp.getsockname()
+        tcp.close()
+        env.set('TEST_SSH_PORT', port)
+        env.set('SKIP_LTESTS', 'key-options forward-control forwarding '
+                'multiplex addrmatch cfgmatch cfgmatchlisten')
+
+    def installcheck(self):
+        make('-e', 'tests', parallel=False)


### PR DESCRIPTION
@alalazo You reviewed my openssh update today, so maybe you like to review this too, cheers, Bernhard

### Summary
- Parallel install was failing to generate a config file.
- OpenSSH has an extensive test suite, run it if requested.
- 'executables' wrongly had 'rsh', replaced the openssh tools.
- Added myself to be available for questions (add maintainer)

### Details

#### Parallel install was failing to generate a config file:

```sh
$dest/sbin/sshd -t -f $inst/etc/sshd_config
make: $dest/sbin/sshd: Command not found
...
/usr/bin/install -c -m 0755 -s sshd $dest/sbin/sshd
```
```py
+    def install(self, spec, prefix):
+        make('install', parallel=False)
```
#### OpenSSH has an extensive test suite, run it if requested:

This was several dimensions more involved than I thought to get it run reliably, but with only a couple
regression tests (which need more than one TCP port) disabled, it passes reliably now even if the test suite is running 4 times in parallel on the same machine.

Since it tries to use also the moduli file installed by the openssh package, I decided to go all the way and make it an installcheck. This means more code, but tests the actually installed programs and files:
```py
+    def setup_build_environment(self, env):
+        p = self.prefix
+        j = join_path
+        env.set('TEST_SSH_SSH', p.bin.ssh)
+        env.set('TEST_SSH_SCP', p.bin.scp)
+        env.set('TEST_SSH_SFTP', p.bin.sftp)
+        env.set('TEST_SSH_SK_HELPER', j(p.libexec, 'ssh-sk-helper'))
+        env.set('TEST_SSH_SFTPSERVER', j(p.libexec, 'sftp-server'))
+        env.set('TEST_SSH_PKCS11_HELPER', j(p.libexec, 'ssh-pkcs11-helper'))
+        env.set('TEST_SSH_SSHD', p.sbin.sshd)
+        env.set('TEST_SSH_SSHADD', j(p.bin, 'ssh-add'))
+        env.set('TEST_SSH_SSHAGENT', j(p.bin, 'ssh-agent'))
+        env.set('TEST_SSH_SSHKEYGEN', j(p.bin, 'ssh-keygen'))
+        env.set('TEST_SSH_SSHKEYSCAN', j(p.bin, 'ssh-keyscan'))
+        env.set('TEST_SSH_UNSAFE_PERMISSIONS', '1')
+        # Get a free port for the simple tests and skip the complex tests:
+        tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        tcp.bind(('', 0))
+        host, port = tcp.getsockname()
+        tcp.close()
+        env.set('TEST_SSH_PORT', port)
+        env.set('SKIP_LTESTS', 'key-options forward-control forwarding multiplex')
+
+    def installcheck(self):
+        make('-e', 'tests', parallel=False)
```
#### 'executables' wrongly had 'rsh', replaced the openssh tools and add maintainer line:
```py
-    # Note: some server apps have "ssh" in the name, so require the exact
-    # command 'ssh'
-    executables = ['^ssh$', '^rsh$']
+    maintainers = ['bernhardkaindl']
+    executables = ['^ssh$', '^scp$', '^sftp$', '^ssh-add$', '^ssh-agent$',
+                   '^ssh-keygen$', '^ssh-keyscan$']
```
PS: I removed the comment because it distracts and the reason why it has to be written `^ssh$` is well-documented. We can't just add `ssh*` as there are tools like ssh-askpass which are separate packages.