### PR TITLE
url stats: add `--show-issues` option

### DIFF
--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 
 import six.moves.urllib.parse as urllib_parse
 
+import llnl.util.tty.color as color
 from llnl.util import tty
 
 import spack.fetch_strategy as fs
@@ -80,9 +81,13 @@ def setup_parser(subparser):
         help='print a summary of how well we are parsing package urls')
 
     # Stats
-    sp.add_parser(
+    stats_parser = sp.add_parser(
         'stats',
         help='print statistics on versions and checksums for all packages')
+    stats_parser.add_argument(
+        "--show-issues", action="store_true",
+        help="show packages with issues (md5 hashes, http urls)"
+    )
 
 
 def url(parser, args):
@@ -262,6 +267,9 @@ def url_summary(args):
 
 
 def url_stats(args):
+    # dictionary of issue type -> package -> descriptions
+    issues = defaultdict(lambda: defaultdict(lambda: []))
+
     class UrlStats(object):
         def __init__(self):
             self.total = 0
@@ -270,7 +278,7 @@ def url_stats(args):
             self.url_type = defaultdict(lambda: 0)
             self.git_type = defaultdict(lambda: 0)
 
-        def add(self, fetcher):
+        def add(self, pkg_name, fetcher):
             self.total += 1
 
             url_type = fetcher.url_attr
@@ -284,9 +292,17 @@ def url_stats(args):
                     algo = 'no checksum'
                 self.checksums[algo] += 1
 
+                if algo == "md5":
+                    md5_hashes = issues["md5 hashes"]
+                    md5_hashes[pkg_name].append(fetcher.url)
+
                 # parse out the URL scheme (https/http/ftp/etc.)
                 urlinfo = urllib_parse.urlparse(fetcher.url)
                 self.schemes[urlinfo.scheme] += 1
+
+                if urlinfo.scheme == "http":
+                    http_urls = issues["http urls"]
+                    http_urls[pkg_name].append(fetcher.url)
 
             elif url_type == 'git':
                 if getattr(fetcher, 'commit', None):
@@ -310,11 +326,11 @@ def url_stats(args):
                 fetcher = fs.for_package_version(pkg, v)
             except (fs.InvalidArgsError, fs.FetcherConflict):
                 continue
-            version_stats.add(pkg, fetcher)
+            version_stats.add(pkg.name, fetcher)
 
         for _, resources in pkg.resources.items():
             for resource in resources:
-                resource_stats.add(resource.fetcher)
+                resource_stats.add(pkg.name, resource.fetcher)
 
     # print a nice summary table
     tty.msg("URL stats for %d packages:" % npkgs)
@@ -363,6 +379,21 @@ def url_stats(args):
     for git_type in sorted(git_types):
         print_stat(4, git_type, "git_type")
     print_line()
+
+    if args.show_issues:
+        total_issues = sum(
+            len(issues)
+            for _, pkg_issues in issues.items()
+            for _, issues in pkg_issues.items()
+        )
+        print()
+        tty.msg("Found %d issues." % total_issues)
+        for issue_type, pkgs in issues.items():
+            tty.msg("Package URLs with %s" % issue_type)
+            for pkg, pkg_issues in pkgs.items():
+                color.cprint("    @*C{%s}" % pkg)
+                for issue in pkg_issues:
+                    print("      %s" % issue)
 
 
 def print_name_and_version(url):

--- a/lib/spack/spack/cmd/url.py
+++ b/lib/spack/spack/cmd/url.py
@@ -305,9 +305,12 @@ def url_stats(args):
     for pkg in spack.repo.path.all_packages():
         npkgs += 1
 
-        for v, args in pkg.versions.items():
-            fetcher = fs.for_package_version(pkg, v)
-            version_stats.add(fetcher)
+        for v in pkg.versions:
+            try:
+                fetcher = fs.for_package_version(pkg, v)
+            except (fs.InvalidArgsError, fs.FetcherConflict):
+                continue
+            version_stats.add(pkg, fetcher)
 
         for _, resources in pkg.resources.items():
             for resource in resources:

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -144,3 +144,20 @@ def test_url_stats(capfd, mock_packages):
         assert 'schemes' in output
         assert 'versions' in output
         assert 'resources' in output
+
+        output = url('stats', '--show-issues')
+        npkgs = '%d packages' % len(spack.repo.all_package_names())
+        assert npkgs in output
+        assert 'url' in output
+        assert 'git' in output
+        assert 'schemes' in output
+        assert 'versions' in output
+        assert 'resources' in output
+
+        assert 'Package URLs with md5 hashes' in output
+        assert 'needs-relocation' in output
+        assert 'https://cmake.org/files/v3.4/cmake-0.0.0.tar.gz' in output
+
+        assert 'Package URLs with http urls' in output
+        assert 'zmpi' in output
+        assert 'http://www.spack-fake-zmpi.org/downloads/zmpi-1.0.tar.gz' in output

--- a/lib/spack/spack/test/cmd/url.py
+++ b/lib/spack/spack/test/cmd/url.py
@@ -69,13 +69,15 @@ def test_url_with_no_version_fails():
         url('parse', 'http://www.netlib.org/voronoi/triangle.zip')
 
 
-@pytest.mark.maybeslow
-@pytest.mark.skipif(
+skip_python_26 = pytest.mark.skipif(
     sys.version_info < (2, 7),
     reason="Python 2.6 tests are run in a container, where "
            "networking is super slow"
 )
-def test_url_list():
+
+
+@skip_python_26
+def test_url_list(mock_packages):
     out = url('list')
     total_urls = len(out.split('\n'))
 
@@ -104,13 +106,8 @@ def test_url_list():
     assert 0 < correct_version_urls < total_urls
 
 
-@pytest.mark.maybeslow
-@pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason="Python 2.6 tests are run in a container, where "
-           "networking is super slow"
-)
-def test_url_summary():
+@skip_python_26
+def test_url_summary(mock_packages):
     """Test the URL summary command."""
     # test url_summary, the internal function that does the work
     (total_urls, correct_names, correct_versions,
@@ -136,12 +133,8 @@ def test_url_summary():
     assert out_correct_versions == correct_versions
 
 
-@pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason="Python 2.6 tests are run in a container, where "
-           "networking is super slow"
-)
-def test_url_stats(capfd):
+@skip_python_26
+def test_url_stats(capfd, mock_packages):
     with capfd.disabled():
         output = url('stats')
         npkgs = '%d packages' % len(spack.repo.all_package_names())

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -281,25 +281,28 @@ def test_git_url_top_level_url_versions(mock_packages, config):
 
     pkg = spack.repo.get('git-url-top-level')
 
+    # leading 62 zeros of sha256 hash
+    leading_zeros = '0' * 62
+
     fetcher = spack.fetch_strategy.for_package_version(pkg, '2.0')
     assert isinstance(fetcher, spack.fetch_strategy.URLFetchStrategy)
     assert fetcher.url == 'https://example.com/some/tarball-2.0.tar.gz'
-    assert fetcher.digest == 'abc20'
+    assert fetcher.digest == leading_zeros + '20'
 
     fetcher = spack.fetch_strategy.for_package_version(pkg, '2.1')
     assert isinstance(fetcher, spack.fetch_strategy.URLFetchStrategy)
     assert fetcher.url == 'https://example.com/some/tarball-2.1.tar.gz'
-    assert fetcher.digest == 'abc21'
+    assert fetcher.digest == leading_zeros + '21'
 
     fetcher = spack.fetch_strategy.for_package_version(pkg, '2.2')
     assert isinstance(fetcher, spack.fetch_strategy.URLFetchStrategy)
     assert fetcher.url == 'https://www.example.com/foo2.2.tar.gz'
-    assert fetcher.digest == 'abc22'
+    assert fetcher.digest == leading_zeros + '22'
 
     fetcher = spack.fetch_strategy.for_package_version(pkg, '2.3')
     assert isinstance(fetcher, spack.fetch_strategy.URLFetchStrategy)
     assert fetcher.url == 'https://www.example.com/foo2.3.tar.gz'
-    assert fetcher.digest == 'abc23'
+    assert fetcher.digest == leading_zeros + '23'
 
 
 def test_git_url_top_level_git_versions(mock_packages, config):
@@ -409,15 +412,15 @@ def test_fetch_options(mock_packages, config):
 
     fetcher = spack.fetch_strategy.for_package_version(pkg, '1.0')
     assert isinstance(fetcher, spack.fetch_strategy.URLFetchStrategy)
-    assert fetcher.digest == 'abc10'
+    assert fetcher.digest == '00000000000000000000000000000010'
     assert fetcher.extra_options == {'timeout': 42, 'cookie': 'foobar'}
 
     fetcher = spack.fetch_strategy.for_package_version(pkg, '1.1')
     assert isinstance(fetcher, spack.fetch_strategy.URLFetchStrategy)
-    assert fetcher.digest == 'abc11'
+    assert fetcher.digest == '00000000000000000000000000000011'
     assert fetcher.extra_options == {'timeout': 65}
 
     fetcher = spack.fetch_strategy.for_package_version(pkg, '1.2')
     assert isinstance(fetcher, spack.fetch_strategy.URLFetchStrategy)
-    assert fetcher.digest == 'abc12'
+    assert fetcher.digest == '00000000000000000000000000000012'
     assert fetcher.extra_options == {'cookie': 'baz'}

--- a/lib/spack/spack/test/url_fetch.py
+++ b/lib/spack/spack/test/url_fetch.py
@@ -160,13 +160,21 @@ def test_fetch(
 
 
 @pytest.mark.parametrize('spec,url,digest', [
-    ('url-list-test @0.0.0', 'foo-0.0.0.tar.gz', 'abc000'),
-    ('url-list-test @1.0.0', 'foo-1.0.0.tar.gz', 'abc100'),
-    ('url-list-test @3.0', 'foo-3.0.tar.gz', 'abc30'),
-    ('url-list-test @4.5', 'foo-4.5.tar.gz', 'abc45'),
-    ('url-list-test @2.0.0b2', 'foo-2.0.0b2.tar.gz', 'abc200b2'),
-    ('url-list-test @3.0a1', 'foo-3.0a1.tar.gz', 'abc30a1'),
-    ('url-list-test @4.5-rc5', 'foo-4.5-rc5.tar.gz', 'abc45rc5'),
+    ('url-list-test @0.0.0', 'foo-0.0.0.tar.gz', '00000000000000000000000000000000'),
+    ('url-list-test @1.0.0', 'foo-1.0.0.tar.gz', '00000000000000000000000000000100'),
+    ('url-list-test @3.0', 'foo-3.0.tar.gz', '00000000000000000000000000000030'),
+    ('url-list-test @4.5', 'foo-4.5.tar.gz', '00000000000000000000000000000450'),
+    (
+        'url-list-test @2.0.0b2',
+        'foo-2.0.0b2.tar.gz',
+        '000000000000000000000000000200b2'
+    ),
+    ('url-list-test @3.0a1', 'foo-3.0a1.tar.gz', '000000000000000000000000000030a1'),
+    (
+        'url-list-test @4.5-rc5',
+        'foo-4.5-rc5.tar.gz',
+        '000000000000000000000000000045c5'
+    ),
 ])
 @pytest.mark.parametrize('_fetch_method', ['curl', 'urllib'])
 def test_from_list_url(mock_packages, config, spec, url, digest, _fetch_method):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1798,7 +1798,7 @@ _spack_url_summary() {
 }
 
 _spack_url_stats() {
-    SPACK_COMPREPLY="-h --help"
+    SPACK_COMPREPLY="-h --help --show-issues"
 }
 
 _spack_verify() {

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -13,7 +13,7 @@ class A(AutotoolsPackage):
     url      = "http://www.example.com/a-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
-    version('2.0', '2.0_a_hash')
+    version('2.0', 'abcdef0123456789abcdef0123456789')
 
     variant(
         'foo', description='',

--- a/var/spack/repos/builtin.mock/packages/archive-files/package.py
+++ b/var/spack/repos/builtin.mock/packages/archive-files/package.py
@@ -13,7 +13,7 @@ class ArchiveFiles(AutotoolsPackage):
     url = "http://www.example.com/a-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
-    version('2.0', '2.0_a_hash')
+    version('2.0', 'abcdef0123456789abcdef0123456789')
 
     @property
     def archive_files(self):

--- a/var/spack/repos/builtin.mock/packages/build-error/package.py
+++ b/var/spack/repos/builtin.mock/packages/build-error/package.py
@@ -12,7 +12,7 @@ class BuildError(Package):
     homepage = "http://www.example.com/trivial_install"
     url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         with open('configure', 'w') as f:

--- a/var/spack/repos/builtin.mock/packages/build-warnings/package.py
+++ b/var/spack/repos/builtin.mock/packages/build-warnings/package.py
@@ -12,7 +12,7 @@ class BuildWarnings(Package):
     homepage = "http://www.example.com/trivial_install"
     url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         with open('configure', 'w') as f:

--- a/var/spack/repos/builtin.mock/packages/callpath/package.py
+++ b/var/spack/repos/builtin.mock/packages/callpath/package.py
@@ -10,9 +10,9 @@ class Callpath(Package):
     homepage = "https://github.com/tgamblin/callpath"
     url      = "http://github.com/tgamblin/callpath-1.0.tar.gz"
 
-    version(0.8, 'foobarbaz')
-    version(0.9, 'foobarbaz')
-    version(1.0, 'foobarbaz')
+    version(0.8, '0123456789abcdef0123456789abcdef')
+    version(0.9, '0123456789abcdef0123456789abcdef')
+    version(1.0, '0123456789abcdef0123456789abcdef')
 
     depends_on("dyninst")
     depends_on("mpi")

--- a/var/spack/repos/builtin.mock/packages/conflict-parent/package.py
+++ b/var/spack/repos/builtin.mock/packages/conflict-parent/package.py
@@ -10,9 +10,9 @@ class ConflictParent(Package):
     homepage = 'https://github.com/tgamblin/callpath'
     url = 'http://github.com/tgamblin/callpath-1.0.tar.gz'
 
-    version(0.8, 'foobarbaz')
-    version(0.9, 'foobarbaz')
-    version(1.0, 'foobarbaz')
+    version(0.8, '0123456789abcdef0123456789abcdef')
+    version(0.9, '0123456789abcdef0123456789abcdef')
+    version(1.0, '0123456789abcdef0123456789abcdef')
 
     depends_on('conflict')
 

--- a/var/spack/repos/builtin.mock/packages/conflict/package.py
+++ b/var/spack/repos/builtin.mock/packages/conflict/package.py
@@ -10,9 +10,9 @@ class Conflict(Package):
     homepage = 'https://github.com/tgamblin/callpath'
     url = 'http://github.com/tgamblin/callpath-1.0.tar.gz'
 
-    version(0.8, 'foobarbaz')
-    version(0.9, 'foobarbaz')
-    version(1.0, 'foobarbaz')
+    version(0.8, '0123456789abcdef0123456789abcdef')
+    version(0.9, '0123456789abcdef0123456789abcdef')
+    version(1.0, '0123456789abcdef0123456789abcdef')
 
     variant('foo', default=True, description='')
 

--- a/var/spack/repos/builtin.mock/packages/dependency-install/package.py
+++ b/var/spack/repos/builtin.mock/packages/dependency-install/package.py
@@ -12,8 +12,8 @@ class DependencyInstall(Package):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/a-1.0.tar.gz"
 
-    version('1.0', 'hash1.0')
-    version('2.0', 'hash2.0')
+    version('1.0', '0123456789abcdef0123456789abcdef')
+    version('2.0', 'abcdef0123456789abcdef0123456789')
 
     def install(self, spec, prefix):
         touch(join_path(prefix, 'an_installation_file'))

--- a/var/spack/repos/builtin.mock/packages/dependent-of-dev-build/package.py
+++ b/var/spack/repos/builtin.mock/packages/dependent-of-dev-build/package.py
@@ -8,7 +8,7 @@ class DependentOfDevBuild(Package):
     homepage = "example.com"
     url = "fake.com"
 
-    version('0.0.0', sha256='0123456789abcdefgh')
+    version('0.0.0', sha256='0123456789abcdef0123456789abcdef')
 
     depends_on('dev-build-test-install')
 

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-dependent/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-dependent/package.py
@@ -8,7 +8,7 @@ class DevBuildTestDependent(Package):
     homepage = "example.com"
     url = "fake.com"
 
-    version('0.0.0', sha256='0123456789abcdefgh')
+    version('0.0.0', sha256='0123456789abcdef0123456789abcdef')
 
     phases = ['edit', 'install']
 

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
@@ -10,7 +10,7 @@ class DevBuildTestInstallPhases(Package):
     homepage = "example.com"
     url = "fake.com"
 
-    version('0.0.0', sha256='0123456789abcdefgh')
+    version('0.0.0', sha256='0123456789abcdef0123456789abcdef')
 
     phases = ['one', 'two', 'three', 'install']
 

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-install/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-install/package.py
@@ -8,7 +8,7 @@ class DevBuildTestInstall(Package):
     homepage = "example.com"
     url = "fake.com"
 
-    version('0.0.0', sha256='0123456789abcdefgh')
+    version('0.0.0', sha256='0123456789abcdef0123456789abcdef')
 
     phases = ['edit', 'install']
 

--- a/var/spack/repos/builtin.mock/packages/direct-mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/direct-mpich/package.py
@@ -10,6 +10,6 @@ class DirectMpich(Package):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/direct_mpich-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     depends_on('mpich')

--- a/var/spack/repos/builtin.mock/packages/dyninst/package.py
+++ b/var/spack/repos/builtin.mock/packages/dyninst/package.py
@@ -10,11 +10,11 @@ class Dyninst(Package):
     homepage = "https://paradyn.org"
     url      = "http://www.paradyn.org/release8.1/DyninstAPI-8.1.1.tgz"
 
-    version('8.2',   'cxyzab',
+    version('8.2',   '0123456789abcdef0123456789abcdef',
             url='http://www.paradyn.org/release8.2/DyninstAPI-8.2.tgz')
-    version('8.1.2', 'bcxyza',
+    version('8.1.2', 'fedcba9876543210fedcba9876543210',
             url='http://www.paradyn.org/release8.1.2/DyninstAPI-8.1.2.tgz')
-    version('8.1.1', 'abcxyz',
+    version('8.1.1', '123456789abcdef0123456789abcdef0',
             url='http://www.paradyn.org/release8.1/DyninstAPI-8.1.1.tgz')
 
     depends_on("libelf")

--- a/var/spack/repos/builtin.mock/packages/extendee/package.py
+++ b/var/spack/repos/builtin.mock/packages/extendee/package.py
@@ -14,7 +14,7 @@ class Extendee(Package):
 
     extendable = True
 
-    version('1.0', 'hash-extendee-1.0')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/extension1/package.py
@@ -16,8 +16,8 @@ class Extension1(Package):
 
     extends('extendee')
 
-    version('1.0', 'hash-extension1-1.0')
-    version('2.0', 'hash-extension1-2.0')
+    version('1.0', '0123456789abcdef0123456789abcdef')
+    version('2.0', 'abcdef0123456789abcdef0123456789')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/extension2/package.py
@@ -18,7 +18,7 @@ class Extension2(Package):
     extends('extendee')
     depends_on('extension1', type=('build', 'run'))
 
-    version('1.0', 'hash-extension2-1.0')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/failing-build/package.py
+++ b/var/spack/repos/builtin.mock/packages/failing-build/package.py
@@ -12,7 +12,7 @@ class FailingBuild(Package):
     homepage = "http://www.example.com/trivial_install"
     url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         raise InstallError("Expected failure.")

--- a/var/spack/repos/builtin.mock/packages/fake/package.py
+++ b/var/spack/repos/builtin.mock/packages/fake/package.py
@@ -10,4 +10,4 @@ class Fake(Package):
     homepage = "http://www.fake-spack-example.org"
     url      = "http://www.fake-spack-example.org/downloads/fake-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')

--- a/var/spack/repos/builtin.mock/packages/fetch-options/package.py
+++ b/var/spack/repos/builtin.mock/packages/fetch-options/package.py
@@ -17,6 +17,6 @@ class FetchOptions(Package):
     timeout = {'timeout': 65}
     cookie = {'cookie': 'baz'}
 
-    version('1.2', 'abc12', fetch_options=cookie)
-    version('1.1', 'abc11', fetch_options=timeout)
-    version('1.0', 'abc10')
+    version('1.2', '00000000000000000000000000000012', fetch_options=cookie)
+    version('1.1', '00000000000000000000000000000011', fetch_options=timeout)
+    version('1.0', '00000000000000000000000000000010')

--- a/var/spack/repos/builtin.mock/packages/fftw/package.py
+++ b/var/spack/repos/builtin.mock/packages/fftw/package.py
@@ -10,8 +10,8 @@ class Fftw(Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/fftw-1.0.tar.gz"
 
-    version(2.0, 'foobar')
-    version(1.0, 'foobar')
+    version(2.0, 'abcdef1234567890abcdef1234567890')
+    version(1.0, '1234567890abcdef1234567890abcdef')
 
     variant('mpi', default=False, description='Enable MPI')
 

--- a/var/spack/repos/builtin.mock/packages/find-externals1/package.py
+++ b/var/spack/repos/builtin.mock/packages/find-externals1/package.py
@@ -13,7 +13,7 @@ class FindExternals1(AutotoolsPackage):
 
     url = "http://www.example.com/find-externals-1.0.tar.gz"
 
-    version('1.0', 'hash-1.0')
+    version('1.0', 'abcdef1234567890abcdef1234567890')
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):

--- a/var/spack/repos/builtin.mock/packages/gcc/package.py
+++ b/var/spack/repos/builtin.mock/packages/gcc/package.py
@@ -13,8 +13,8 @@ class Gcc(Package):
     url      = "http://www.example.com/gcc-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
-    version('2.0', '2.0_a_hash')
-    version('3.0', '3.0_a_hash')
+    version('2.0', 'abcdef0123456789abcdef0123456789')
+    version('3.0', 'def0123456789abcdef0123456789abc')
 
     depends_on('conflict', when='@3.0')
 

--- a/var/spack/repos/builtin.mock/packages/git-url-top-level/package.py
+++ b/var/spack/repos/builtin.mock/packages/git-url-top-level/package.py
@@ -28,13 +28,35 @@ class GitUrlTopLevel(Package):
     version('3.0', tag='v3.0')
 
     # These resolve to URL fetchers
-    version('2.3', 'abc23', url='https://www.example.com/foo2.3.tar.gz')
-    version('2.2', sha256='abc22', url='https://www.example.com/foo2.2.tar.gz')
-    version('2.1', sha256='abc21')
-    version('2.0', 'abc20')
+    version(
+        '2.3', '0000000000000000000000000000000000000000000000000000000000000023',
+        url='https://www.example.com/foo2.3.tar.gz',
+    )
+    version(
+        '2.2',
+        sha256='0000000000000000000000000000000000000000000000000000000000000022',
+        url='https://www.example.com/foo2.2.tar.gz',
+    )
+    version(
+        '2.1',
+        sha256='0000000000000000000000000000000000000000000000000000000000000021',
+    )
+    version(
+        '2.0',
+        '0000000000000000000000000000000000000000000000000000000000000020',
+    )
 
     # These result in a FetcherConflict b/c we can't tell what to use
-    version('1.3', sha256='abc13', commit='abc13')
-    version('1.2', sha512='abc12', branch='releases/v1.2')
-    version('1.1', md5='abc11', tag='v1.1')
-    version('1.0', 'abc11', tag='abc123')
+    version(
+        '1.3',
+        sha256='f66bbef3ccb8b06542c57d69804c5b0aba72051f693c17761ad8525786d259fa',
+        commit='abc13'
+    )
+    version(
+        '1.2',
+        sha512='f66bbef3ccb8b06542c57d69804c5b0aba72051f693c17761ad8525786d259fa'
+        '9ed8f2e950a4fb8a4b936f33e689187784699357bc16e49f33dfcda8ab8b00e4',
+        branch='releases/v1.2'
+    )
+    version('1.1', md5='00000000000000000000000000000011', tag='v1.1')
+    version('1.0', '00000000000000000000000000000011', tag='abc123')

--- a/var/spack/repos/builtin.mock/packages/gmt/package.py
+++ b/var/spack/repos/builtin.mock/packages/gmt/package.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 class Gmt(Package):
+    url = "http://www.example.com/"
+    url = "http://www.example.com/2.0.tar.gz"
 
-    version('2.0', 'abcdef')
-    version('1.0', 'abcdef')
+    version('2.0', 'abcdef1234567890abcdef1234567890')
+    version('1.0', 'abcdef1234567890abcdef1234567890')
 
     depends_on('mvdefaults', when='@1.0')

--- a/var/spack/repos/builtin.mock/packages/hdf5/package.py
+++ b/var/spack/repos/builtin.mock/packages/hdf5/package.py
@@ -8,7 +8,7 @@ class Hdf5(Package):
     homepage = "http://www.llnl.gov"
     url      = "http://www.llnl.gov/hdf5-1.0.tar.gz"
 
-    version(2.3, 'foobarbaz')
+    version(2.3, '0123456789abcdef0123456789abcdef')
 
     variant('mpi', default=True, description='Enable mpi')
 

--- a/var/spack/repos/builtin.mock/packages/impossible-concretization/package.py
+++ b/var/spack/repos/builtin.mock/packages/impossible-concretization/package.py
@@ -10,6 +10,6 @@ class ImpossibleConcretization(Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/example-1.0.tar.gz"
 
-    version(1.0, 'foobarbaz')
+    version(1.0, '0123456789abcdef0123456789abcdef')
 
     conflicts('target=x86_64:')

--- a/var/spack/repos/builtin.mock/packages/indirect-mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/indirect-mpich/package.py
@@ -14,7 +14,7 @@ class IndirectMpich(Package):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/indirect_mpich-1.0.tar.gz"
 
-    version(1.0, 'foobarbaz')
+    version(1.0, '0123456789abcdef0123456789abcdef')
 
     depends_on('mpi')
     depends_on('direct-mpich')

--- a/var/spack/repos/builtin.mock/packages/leaf-adds-virtual/package.py
+++ b/var/spack/repos/builtin.mock/packages/leaf-adds-virtual/package.py
@@ -3,7 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 class LeafAddsVirtual(Package):
-    version('2.0', sha256='abcde')
-    version('1.0', sha256='abcde')
+    url = "http://www.example.com/"
+    url = "http://www.example.com/2.0.tar.gz"
+
+    version('2.0', 'abcdef1234567890abcdef1234567890')
+    version('1.0', 'abcdef1234567890abcdef1234567890')
 
     depends_on('blas', when='@2.0')

--- a/var/spack/repos/builtin.mock/packages/libdwarf/package.py
+++ b/var/spack/repos/builtin.mock/packages/libdwarf/package.py
@@ -15,9 +15,9 @@ class Libdwarf(Package):
     list_url = homepage
 
     version(20130729, "64b42692e947d5180e162e46c689dfbf")
-    version(20130207, 'foobarbaz')
-    version(20111030, 'foobarbaz')
-    version(20070703, 'foobarbaz')
+    version(20130207, '0123456789abcdef0123456789abcdef')
+    version(20111030, '0123456789abcdef0123456789abcdef')
+    version(20070703, '0123456789abcdef0123456789abcdef')
 
     depends_on("libelf")
 

--- a/var/spack/repos/builtin.mock/packages/middle-adds-virtual/package.py
+++ b/var/spack/repos/builtin.mock/packages/middle-adds-virtual/package.py
@@ -3,5 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 class MiddleAddsVirtual(Package):
-    version('1.0', sha256='abcde')
+    url = "http://www.example.com/"
+    url = "http://www.example.com/2.0.tar.gz"
+
+    version('1.0', 'abcdef1234567890abcdef1234567890')
+
     depends_on('leaf-adds-virtual')

--- a/var/spack/repos/builtin.mock/packages/mixedversions/package.py
+++ b/var/spack/repos/builtin.mock/packages/mixedversions/package.py
@@ -9,6 +9,6 @@ from spack import *
 class Mixedversions(Package):
     url = "http://www.fake-mixedversions.org/downloads/mixedversions-1.0.tar.gz"
 
-    version('2.0.1', 'hashc')
-    version('2.0', 'hashb')
-    version('1.0.1', 'hasha')
+    version('2.0.1', '0000000000000000000000000000000c')
+    version('2.0', '0000000000000000000000000000000b')
+    version('1.0.1', '0000000000000000000000000000000a')

--- a/var/spack/repos/builtin.mock/packages/module-path-separator/package.py
+++ b/var/spack/repos/builtin.mock/packages/module-path-separator/package.py
@@ -10,7 +10,7 @@ class ModulePathSeparator(Package):
     homepage = "http://www.llnl.gov"
     url      = "http://www.llnl.gov/module-path-separator-1.0.tar.gz"
 
-    version(1.0, 'foobarbaz')
+    version(1.0, '0123456789abcdef0123456789abcdef')
 
     def setup_environment(self, senv, renv):
         renv.append_path("COLON", "foo")

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -18,11 +18,11 @@ class Mpich(Package):
             description="Compile MPICH with debug flags.")
 
     version('3.0.4', '9c5d5d4fe1e17dd12153f40bc5b6dbc0')
-    version('3.0.3', 'foobarbaz')
-    version('3.0.2', 'foobarbaz')
-    version('3.0.1', 'foobarbaz')
-    version('3.0', 'foobarbaz')
-    version('1.0', 'foobarbas')
+    version('3.0.3', '0123456789abcdef0123456789abcdef')
+    version('3.0.2', '0123456789abcdef0123456789abcdef')
+    version('3.0.1', '0123456789abcdef0123456789abcdef')
+    version('3.0', '0123456789abcdef0123456789abcdef')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     provides('mpi@:3', when='@3:')
     provides('mpi@:1', when='@:1')

--- a/var/spack/repos/builtin.mock/packages/mpich2/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich2/package.py
@@ -15,11 +15,11 @@ class Mpich2(Package):
     tags = ['tag1', 'tag3']
 
     version('1.5', '9c5d5d4fe1e17dd12153f40bc5b6dbc0')
-    version('1.4', 'foobarbaz')
-    version('1.3', 'foobarbaz')
-    version('1.2', 'foobarbaz')
-    version('1.1', 'foobarbaz')
-    version('1.0', 'foobarbaz')
+    version('1.4', '0123456789abcdef0123456789abcdef')
+    version('1.3', '0123456789abcdef0123456789abcdef')
+    version('1.2', '0123456789abcdef0123456789abcdef')
+    version('1.1', '0123456789abcdef0123456789abcdef')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     provides('mpi@:2.0')
     provides('mpi@:2.1', when='@1.1:')

--- a/var/spack/repos/builtin.mock/packages/mpileaks/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpileaks/package.py
@@ -10,10 +10,10 @@ class Mpileaks(Package):
     homepage = "http://www.llnl.gov"
     url      = "http://www.llnl.gov/mpileaks-1.0.tar.gz"
 
-    version(1.0, 'foobarbaz')
-    version(2.1, 'foobarbaz')
-    version(2.2, 'foobarbaz')
-    version(2.3, 'foobarbaz')
+    version(1.0, '0123456789abcdef0123456789abcdef')
+    version(2.1, '0123456789abcdef0123456789abcdef')
+    version(2.2, '0123456789abcdef0123456789abcdef')
+    version(2.3, '0123456789abcdef0123456789abcdef')
 
     variant('debug', default=False, description='Debug variant')
     variant('opt',   default=False, description='Optimized variant')

--- a/var/spack/repos/builtin.mock/packages/multi-provider-mpi/package.py
+++ b/var/spack/repos/builtin.mock/packages/multi-provider-mpi/package.py
@@ -12,13 +12,13 @@ class MultiProviderMpi(Package):
     homepage = "http://www.spack-fake-mpi.org"
     url      = "http://www.spack-fake-mpi.org/downloads/multi-mpi-1.0.tar.gz"
 
-    version('2.0.0', 'foobarbaz')
-    version('1.10.3', 'foobarbaz')
-    version('1.10.2', 'foobarbaz')
-    version('1.10.1', 'foobarbaz')
-    version('1.10.0', 'foobarbaz')
-    version('1.8.8', 'foobarbaz')
-    version('1.6.5', 'foobarbaz')
+    version('2.0.0', '0123456789abcdef0123456789abcdef')
+    version('1.10.3', '0123456789abcdef0123456789abcdef')
+    version('1.10.2', '0123456789abcdef0123456789abcdef')
+    version('1.10.1', '0123456789abcdef0123456789abcdef')
+    version('1.10.0', '0123456789abcdef0123456789abcdef')
+    version('1.8.8', '0123456789abcdef0123456789abcdef')
+    version('1.6.5', '0123456789abcdef0123456789abcdef')
 
     provides('mpi@3.1', when='@2.0.0')
     provides('mpi@3.0', when='@1.10.3')

--- a/var/spack/repos/builtin.mock/packages/multivalue-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/multivalue-variant/package.py
@@ -10,10 +10,10 @@ class MultivalueVariant(Package):
     homepage = "http://www.llnl.gov"
     url = "http://www.llnl.gov/mpileaks-1.0.tar.gz"
 
-    version(1.0, 'foobarbaz')
-    version(2.1, 'foobarbaz')
-    version(2.2, 'foobarbaz')
-    version(2.3, 'foobarbaz')
+    version(1.0, '0123456789abcdef0123456789abcdef')
+    version(2.1, '0123456789abcdef0123456789abcdef')
+    version(2.2, '0123456789abcdef0123456789abcdef')
+    version(2.3, '0123456789abcdef0123456789abcdef')
 
     variant('debug', default=False, description='Debug variant')
     variant(

--- a/var/spack/repos/builtin.mock/packages/mvdefaults/package.py
+++ b/var/spack/repos/builtin.mock/packages/mvdefaults/package.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 class Mvdefaults(Package):
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/mvdefaults-1.0.tar.gz"
 
-    version('1.0', 'abcdef')
+    version('1.0', 'abcdef1234567890abcdef1234567890')
 
     variant('foo', values=('a', 'b', 'c'), default=('a', 'b', 'c'),
             multi=True, description='')

--- a/var/spack/repos/builtin.mock/packages/override-context-templates/package.py
+++ b/var/spack/repos/builtin.mock/packages/override-context-templates/package.py
@@ -14,7 +14,7 @@ class OverrideContextTemplates(Package):
     homepage = "http://www.fake-spack-example.org"
     url      = "http://www.fake-spack-example.org/downloads/fake-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     tcl_template = 'extension.tcl'
     tcl_context = {'sentence': "sentence from package"}

--- a/var/spack/repos/builtin.mock/packages/override-module-templates/package.py
+++ b/var/spack/repos/builtin.mock/packages/override-module-templates/package.py
@@ -10,7 +10,7 @@ class OverrideModuleTemplates(Package):
     homepage = "http://www.fake-spack-example.org"
     url      = "http://www.fake-spack-example.org/downloads/fake-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     tcl_template = 'override.txt'
     lmod_template = 'override.txt'

--- a/var/spack/repos/builtin.mock/packages/perl-extension/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl-extension/package.py
@@ -13,8 +13,8 @@ class PerlExtension(PerlPackage):
     homepage = "http://www.example.com"
     url      = "http://www.example.com/extension1-1.0.tar.gz"
 
-    version('1.0', 'hash-extension-1.0')
-    version('2.0', 'hash-extension-2.0')
+    version('1.0', '00000000000000000000000000000010')
+    version('2.0', '00000000000000000000000000000020')
 
     extends("perl")
 

--- a/var/spack/repos/builtin.mock/packages/perl/package.py
+++ b/var/spack/repos/builtin.mock/packages/perl/package.py
@@ -12,4 +12,4 @@ class Perl(Package):
 
     extendable = True
 
-    version('0.0.0', 'hash')
+    version('0.0.0', 'abcdef1234567890abcdef1234567890')

--- a/var/spack/repos/builtin.mock/packages/printing-package/package.py
+++ b/var/spack/repos/builtin.mock/packages/printing-package/package.py
@@ -14,7 +14,7 @@ class PrintingPackage(Package):
     homepage = "http://www.example.com/printing_package"
     url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         print("BEFORE INSTALL")

--- a/var/spack/repos/builtin.mock/packages/py-extension1/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension1/package.py
@@ -16,8 +16,8 @@ class PyExtension1(PythonPackage):
     # Override settings in base class
     maintainers = []
 
-    version('1.0', 'hash-extension1-1.0')
-    version('2.0', 'hash-extension1-2.0')
+    version('1.0', '00000000000000000000000000000110')
+    version('2.0', '00000000000000000000000000000120')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/py-extension2/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension2/package.py
@@ -20,7 +20,7 @@ class PyExtension2(PythonPackage):
     extends("python")
     depends_on('py-extension1', type=('build', 'run'))
 
-    version('1.0', 'hash-extension2-1.0')
+    version('1.0', '00000000000000000000000000000210')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/py-extension3/package.py
+++ b/var/spack/repos/builtin.mock/packages/py-extension3/package.py
@@ -16,6 +16,6 @@ class PyExtension3(Package):
     depends_on('patchelf@0.9', when='@1.0:1.1 ^python@:2')
     depends_on('patchelf@0.10', when='@1.0:1.1 ^python@3:')
 
-    version('2.0', 'hash-extension3-1.0')
-    version('1.1', 'hash-extension3-1.0')
-    version('1.0', 'hash-extension3-1.0')
+    version('2.0', '00000000000000000000000000000320')
+    version('1.1', '00000000000000000000000000000311')
+    version('1.0', '00000000000000000000000000000310')

--- a/var/spack/repos/builtin.mock/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin.mock/packages/quantum-espresso/package.py
@@ -10,7 +10,7 @@ class QuantumEspresso(Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/qe-1.0.tar.gz"
 
-    version(1.0, 'foobar')
+    version(1.0, '1234567890abcdef1234567890abcdef')
 
     variant('invino', default=True, description='?')
     variant('veritas', default=True, description='?')

--- a/var/spack/repos/builtin.mock/packages/raiser/package.py
+++ b/var/spack/repos/builtin.mock/packages/raiser/package.py
@@ -17,7 +17,7 @@ class Raiser(Package):
     url = "http://www.example.com/a-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
-    version('2.0', '2.0_a_hash')
+    version('2.0', 'abcdef0123456789abcdef0123456789')
 
     variant(
         'exc_type',

--- a/var/spack/repos/builtin.mock/packages/requires-virtual/package.py
+++ b/var/spack/repos/builtin.mock/packages/requires-virtual/package.py
@@ -11,6 +11,6 @@ class RequiresVirtual(Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/a-1.0.tar.gz"
 
-    version('2.0', '2.0_a_hash')
+    version('2.0', 'abcdef0123456789abcdef0123456789')
 
     depends_on('stuff')

--- a/var/spack/repos/builtin.mock/packages/root-adds-virtual/package.py
+++ b/var/spack/repos/builtin.mock/packages/root-adds-virtual/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 class RootAddsVirtual(Package):
-    version('1.0', sha256='abcde')
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/root-adds-virtual-1.0.tar.gz"
+
+    version('1.0', sha256='abcdef0123456789abcdef0123456789')
 
     depends_on('middle-adds-virtual')

--- a/var/spack/repos/builtin.mock/packages/root/package.py
+++ b/var/spack/repos/builtin.mock/packages/root/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 class Root(Package):
-    version('1.0', 'abcdef')
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/root-1.0.tar.gz"
+
+    version('1.0', 'abcdef0123456789abcdef0123456789')
 
     depends_on('gmt')

--- a/var/spack/repos/builtin.mock/packages/singlevalue-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/singlevalue-variant/package.py
@@ -8,7 +8,7 @@ class SinglevalueVariant(Package):
     homepage = "http://www.llnl.gov"
     url = "http://www.llnl.gov/mpileaks-1.0.tar.gz"
 
-    version(1.0, 'foobarbaz')
+    version(1.0, '0123456789abcdef0123456789abcdef')
 
     variant(
         'fum',

--- a/var/spack/repos/builtin.mock/packages/test-error/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-error/package.py
@@ -12,7 +12,7 @@ class TestError(Package):
     homepage = "http://www.example.com/test-failure"
     url      = "http://www.test-failure.test/test-failure-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/test-fail/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-fail/package.py
@@ -12,7 +12,7 @@ class TestFail(Package):
     homepage = "http://www.example.com/test-failure"
     url      = "http://www.test-failure.test/test-failure-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin.mock/packages/trigger-external-non-default-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/trigger-external-non-default-variant/package.py
@@ -7,6 +7,6 @@ class TriggerExternalNonDefaultVariant(Package):
     homepage = "http://www.example.com"
     url = "http://www.someurl.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     depends_on('external-non-default-variant')

--- a/var/spack/repos/builtin.mock/packages/trivial-install-test-package/package.py
+++ b/var/spack/repos/builtin.mock/packages/trivial-install-test-package/package.py
@@ -12,7 +12,7 @@ class TrivialInstallTestPackage(Package):
     homepage = "http://www.example.com/trivial_install"
     url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     def install(self, spec, prefix):
         configure('--prefix=%s' % prefix)

--- a/var/spack/repos/builtin.mock/packages/trivial-smoke-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/trivial-smoke-test/package.py
@@ -11,7 +11,7 @@ class TrivialSmokeTest(Package):
     homepage = "http://www.example.com/trivial_test"
     url      = "http://www.unit-test-should-replace-this-url/trivial_test-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     test_source_filename = 'cached_file.in'
 

--- a/var/spack/repos/builtin.mock/packages/unsat-provider/package.py
+++ b/var/spack/repos/builtin.mock/packages/unsat-provider/package.py
@@ -7,7 +7,7 @@ class UnsatProvider(Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/v1.0.tgz"
 
-    version('1.0', sha256='foobarbaz')
+    version('1.0', sha256='0123456789abcdef0123456789abcdef')
 
     variant('foo', default=True, description='')
 

--- a/var/spack/repos/builtin.mock/packages/unsat-virtual-dependency/package.py
+++ b/var/spack/repos/builtin.mock/packages/unsat-virtual-dependency/package.py
@@ -7,6 +7,6 @@ class UnsatVirtualDependency(Package):
     homepage = "http://www.example.com"
     url = "http://www.example.com/v1.0.tgz"
 
-    version('1.0', sha256='foobarbaz')
+    version('1.0', sha256='0123456789abcdef0123456789abcdef')
 
     depends_on('unsatvdep')

--- a/var/spack/repos/builtin.mock/packages/url-list-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/url-list-test/package.py
@@ -16,10 +16,10 @@ class UrlListTest(Package):
     list_url = 'file://' + web_data_path + '/index.html'
     list_depth = 3
 
-    version('0.0.0',   'abc000')
-    version('1.0.0',   'abc100')
-    version('3.0',     'abc30')
-    version('4.5',     'abc45')
-    version('2.0.0b2', 'abc200b2')
-    version('3.0a1',   'abc30a1')
-    version('4.5-rc5', 'abc45rc5')
+    version('0.0.0',   '00000000000000000000000000000000')
+    version('1.0.0',   '00000000000000000000000000000100')
+    version('3.0',     '00000000000000000000000000000030')
+    version('4.5',     '00000000000000000000000000000450')
+    version('2.0.0b2', '000000000000000000000000000200b2')
+    version('3.0a1',   '000000000000000000000000000030a1')
+    version('4.5-rc5', '000000000000000000000000000045c5')

--- a/var/spack/repos/builtin.mock/packages/url-only-override-with-gaps/package.py
+++ b/var/spack/repos/builtin.mock/packages/url-only-override-with-gaps/package.py
@@ -9,10 +9,13 @@ from spack import *
 class UrlOnlyOverrideWithGaps(Package):
     homepage = 'http://www.example.com'
 
-    version('1.0.5', 'abcdef0')
-    version('1.0.0', 'bcdef0a', url='http://a.example.com/url_override-1.0.0.tar.gz')
-    version('0.9.5', 'cdef0ab')
-    version('0.9.0', 'def0abc', url='http://b.example.com/url_override-0.9.0.tar.gz')
-    version('0.8.5', 'ef0abcd')
-    version('0.8.1', 'f0abcde', url='http://c.example.com/url_override-0.8.1.tar.gz')
-    version('0.7.0', '0abcdef')
+    version('1.0.5', 'abcdef0123456789abcdef0123456789')
+    version('1.0.0', 'bcdef0123456789abcdef0123456789a',
+            url='http://a.example.com/url_override-1.0.0.tar.gz')
+    version('0.9.5', 'cdef0123456789abcdef0123456789ab')
+    version('0.9.0', 'def0123456789abcdef0123456789abc',
+            url='http://b.example.com/url_override-0.9.0.tar.gz')
+    version('0.8.5', 'ef0123456789abcdef0123456789abcd')
+    version('0.8.1', 'f0123456789abcdef0123456789abcde',
+            url='http://c.example.com/url_override-0.8.1.tar.gz')
+    version('0.7.0', '0123456789abcdef0123456789abcdef')

--- a/var/spack/repos/builtin.mock/packages/url-only-override/package.py
+++ b/var/spack/repos/builtin.mock/packages/url-only-override/package.py
@@ -9,6 +9,6 @@ from spack import *
 class UrlOnlyOverride(Package):
     homepage = 'http://www.example.com'
 
-    version('1.0.0', 'cxyzab', url='http://a.example.com/url_override-1.0.0.tar.gz')
-    version('0.9.0', 'bcxyza', url='http://b.example.com/url_override-0.9.0.tar.gz')
-    version('0.8.1', 'cxyzab', url='http://c.example.com/url_override-0.8.1.tar.gz')
+    version('1.0.0', '0123456789abcdef0123456789abcdef', url='http://a.example.com/url_override-1.0.0.tar.gz')
+    version('0.9.0', 'fedcba9876543210fedcba9876543210', url='http://b.example.com/url_override-0.9.0.tar.gz')
+    version('0.8.1', '0123456789abcdef0123456789abcdef', url='http://c.example.com/url_override-0.8.1.tar.gz')

--- a/var/spack/repos/builtin.mock/packages/url_override/package.py
+++ b/var/spack/repos/builtin.mock/packages/url_override/package.py
@@ -10,6 +10,6 @@ class UrlOverride(Package):
     homepage = 'http://www.doesnotexist.org'
     url      = 'http://www.doesnotexist.org/url_override-1.0.0.tar.gz'
 
-    version('1.0.0', 'cxyzab')
-    version('0.9.0', 'bcxyza', url='http://www.anothersite.org/uo-0.9.0.tgz')
-    version('0.8.1', 'cxyzab')
+    version('1.0.0', '0123456789abcdef0123456789abcdef')
+    version('0.9.0', 'fedcba9876543210fedcba9876543210', url='http://www.anothersite.org/uo-0.9.0.tgz')
+    version('0.8.1', '0123456789abcdef0123456789abcdef')

--- a/var/spack/repos/builtin.mock/packages/zmpi/package.py
+++ b/var/spack/repos/builtin.mock/packages/zmpi/package.py
@@ -12,7 +12,7 @@ class Zmpi(Package):
     homepage = "http://www.spack-fake-zmpi.org"
     url      = "http://www.spack-fake-zmpi.org/downloads/zmpi-1.0.tar.gz"
 
-    version('1.0', 'foobarbaz')
+    version('1.0', '0123456789abcdef0123456789abcdef')
 
     provides('mpi@:10.0')
     depends_on('fake')


### PR DESCRIPTION
Fixes #25512.

`spack url stats` tells us how many URLs are using what protocol, type of checksum, etc., but it previously did not tell us which packages and URLs had the issues. This adds a `--show-issues` option to show URLs with insecure (`http`) URLs or `md5` hashes (which are now deprecated by NIST).

Example:
```console
$ spack url stats --show-issues
==> URL stats for 5824 packages:
--------------------------------------------------------------
stat                    versions        %   resources        %
--------------------------------------------------------------
url                        17619    86.5%         790    88.0%
    schemes
                               1     0.0%           3     0.3%
        http                1996     9.8%          73     8.1%
        ftp                   84     0.4%           8     0.9%
        https              15437    75.8%         617    68.7%
        file                 101     0.5%          89     9.9%
    checksums
        sha256             17590    86.3%         787    87.6%
        no checksum            7     0.0%           3     0.3%
        md5                   22     0.1%           0     0.0%
--------------------------------------------------------------
cvs                            1     0.0%           0     0.0%
--------------------------------------------------------------
go                             1     0.0%           0     0.0%
--------------------------------------------------------------
hg                             6     0.0%           0     0.0%
--------------------------------------------------------------
no code                       63     0.3%           0     0.0%
--------------------------------------------------------------
svn                            6     0.0%          14     1.6%
--------------------------------------------------------------
git                         2675    13.1%          94    10.5%
    branch                   847     4.2%          28     3.1%
    commit                  1430     7.0%          24     2.7%
    no ref                    41     0.2%          13     1.4%
    tag                      357     1.8%          29     3.2%
--------------------------------------------------------------
==> Found 2091 issues.
==> Packages with http urls
    alps
      http://alps.comp-phys.org/static/software/releases/alps-2.3.0-src.tar.gz
    amber
      http://ambermd.org/downloads/AmberTools20.tar.bz2
      http://ambermd.org/downloads/AmberTools19.tar.bz2
      http://ambermd.org/downloads/AmberTools16.tar.bz2
...
==> Packages with md5 hashes
    gams
      file:///Users/gamblin2/linux_x64_64_sfx.exe
    gapfiller
      file:///Users/gamblin2/39GapFiller_v1-10_linux-x86_64.tar.gz
...      
```

- [x] initial implementation
- [x] tests