### PR TITLE
Disable module generation during bootstrapping

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -25,6 +25,7 @@ import spack.binary_distribution
 import spack.config
 import spack.environment
 import spack.main
+import spack.modules
 import spack.paths
 import spack.repo
 import spack.spec
@@ -430,8 +431,9 @@ def ensure_bootstrap_configuration():
                     # and builtin but accounting for platform specific scopes
                     config_scopes = _bootstrap_config_scopes()
                     with spack.config.use_configuration(*config_scopes):
-                        with spack_python_interpreter():
-                            yield
+                        with spack.modules.disable_modules():
+                            with spack_python_interpreter():
+                                yield
 
 
 def store_path():

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -750,10 +750,11 @@ def override(path_or_scope, value=None):
         config.push_scope(overrides)
         config.set(path_or_scope, value, scope=scope_name)
 
-    yield config
-
-    scope = config.remove_scope(overrides.name)
-    assert scope is overrides
+    try:
+        yield config
+    finally:
+        scope = config.remove_scope(overrides.name)
+        assert scope is overrides
 
 
 #: configuration scopes added on the command line

--- a/lib/spack/spack/modules/__init__.py
+++ b/lib/spack/spack/modules/__init__.py
@@ -9,12 +9,14 @@ include TCL non-hierarchical modules, LUA hierarchical modules, and others.
 
 from __future__ import absolute_import
 
+from .common import disable_modules
 from .lmod import LmodModulefileWriter
 from .tcl import TclModulefileWriter
 
 __all__ = [
     'TclModulefileWriter',
-    'LmodModulefileWriter'
+    'LmodModulefileWriter',
+    'disable_modules'
 ]
 
 module_types = {

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -29,6 +29,7 @@ Each of the four classes needs to be sub-classed when implementing a new
 module type.
 """
 import collections
+import contextlib
 import copy
 import datetime
 import inspect
@@ -41,6 +42,7 @@ import llnl.util.tty as tty
 from llnl.util.lang import dedupe
 
 import spack.build_environment as build_environment
+import spack.config
 import spack.environment as ev
 import spack.error
 import spack.paths
@@ -903,6 +905,19 @@ class BaseModuleFileWriter(object):
             except OSError:
                 # removedirs throws OSError on first non-empty directory found
                 pass
+
+
+@contextlib.contextmanager
+def disable_modules():
+    """Disable the generation of modulefiles within the context manager."""
+    data = {
+        'modules:': {
+            'enable': []
+        }
+    }
+    disable_scope = spack.config.InternalConfigScope('disable_modules', data=data)
+    with spack.config.override(disable_scope):
+        yield
 
 
 class ModulesError(spack.error.SpackError):

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -64,3 +64,17 @@ def test_bootstrap_deactivates_environments(active_mock_environment):
     with spack.bootstrap.ensure_bootstrap_configuration():
         assert spack.environment.active_environment() is None
     assert spack.environment.active_environment() == active_mock_environment
+
+
+@pytest.mark.regression('25805')
+def test_bootstrap_disables_modulefile_generation(mutable_config):
+    # Be sure to enable both lmod and tcl in modules.yaml
+    spack.config.set('modules:enable', ['tcl', 'lmod'])
+
+    assert 'tcl' in spack.config.get('modules:enable')
+    assert 'lmod' in spack.config.get('modules:enable')
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        assert 'tcl' not in spack.config.get('modules:enable')
+        assert 'lmod' not in spack.config.get('modules:enable')
+    assert 'tcl' in spack.config.get('modules:enable')
+    assert 'lmod' in spack.config.get('modules:enable')


### PR DESCRIPTION
fixes #25805

This PR adds a context manager to disable modulefile generation. The context manager is currently used during bootstrapping.

Modifications:
- [x] Add a context manager to disable modulefile generation
- [x] Use it during bootstrapping
- [x] Add unit tests to ensure modulefiles are disabled when bootstrapping software