### PR TITLE
openssl: link system openssl.conf after installation

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -163,6 +163,12 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
         mkdirp(pkg_dir)
 
         for directory in system_dirs:
+            # Link configuration file
+            sys_conf = join_path(directory, 'openssl.cnf')
+            pkg_conf = join_path(pkg_dir, 'openssl.cnf')
+            if os.path.exists(sys_conf) and not os.path.exists(pkg_conf):
+                os.symlink(sys_conf, pkg_conf)
+
             sys_cert = join_path(directory, 'cert.pem')
             pkg_cert = join_path(pkg_dir, 'cert.pem')
             # If a bundle exists, use it. This is the preferred way on Fedora,


### PR DESCRIPTION
In the compilation of a package which needs `openssl.conf` there is a
crash due this file is missing in the paths specified by Spack, e.g.,:
`+Can't open
/opt/spack/opt/spack/linux-fedora34-skylake/gcc-7.5.0/openssl-1.1.1l-bnwhtmqzbgx5cke7cc4nvkrpqt6wyr6k/etc/openssl/openssl.cnf
for reading, No such file or directory`. The added lines fix this
issue by a symlink to the system `openssl` configuration file.