### PR TITLE
gdbm: fix build issue on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/macOS.patch
+++ b/var/spack/repos/builtin/packages/gdbm/macOS.patch
@@ -1,0 +1,14 @@
+--- a/src/gdbmshell.c	2021-09-02 07:39:55.000000000 -0500
++++ b/src/gdbmshell.c	2021-09-06 20:30:20.000000000 -0500
+@@ -1010,7 +1010,11 @@
+       fprintf (fp, "%s: ", snapname);
+       fprintf (fp, "%03o %s ", st.st_mode & 0777,
+ 	       decode_mode (st.st_mode, buf));
++#if defined(__APPLE__)
++      fprintf (fp, "%ld.%09ld", st.st_mtimespec.tv_sec, st.st_mtimespec.tv_nsec);
++#else
+       fprintf (fp, "%ld.%09ld", st.st_mtim.tv_sec, st.st_mtim.tv_nsec);
++#endif
+       if (S_ISREG (st.st_mode))
+ 	{
+ 	  GDBM_FILE dbf;

--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -17,6 +17,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     gnu_mirror_path = "gdbm/gdbm-1.13.tar.gz"
 
     version('1.21',   sha256='b0b7dbdefd798de7ddccdd8edf6693a30494f7789777838042991ef107339cc2')
+    version('1.20',   sha256='3aeac05648b3482a10a2da986b9f3a380a29ad650be80b9817a435fb8114a292')
     version('1.19',   sha256='37ed12214122b972e18a0d94995039e57748191939ef74115b1d41d8811364bc')
     version('1.18.1', sha256='86e613527e5dba544e73208f42b78b7c022d4fa5a6d5498bf18c8d6f745b91dc')
     version('1.14.1', sha256='cdceff00ffe014495bed3aed71c7910aa88bf29379f795abc0f46d4ee5f8bc5f')
@@ -28,6 +29,8 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
     version('1.9',    sha256='f85324d7de3777db167581fd5d3493d2daa3e85e195a8ae9afc05b34551b6e57')
 
     depends_on("readline")
+
+    patch('macOS.patch', when='@1.21: platform=darwin')
     patch('gdbm.patch', when='@:1.18 %gcc@10:')
     patch('gdbm.patch', when='@:1.18 %clang@11:')
     patch('gdbm.patch', when='@:1.18 %cce@11:')


### PR DESCRIPTION
On macOS 10.15.7 with Apple Clang 12.0.0, I see the following build issue with gdbm 1.21:
```
gdbmshell.c:1013:36: error: no member named 'st_mtim' in 'struct stat'
      fprintf (fp, "%ld.%09ld", st.st_mtim.tv_sec, st.st_mtim.tv_nsec);
                                ~~ ^
gdbmshell.c:1013:55: error: no member named 'st_mtim' in 'struct stat'
      fprintf (fp, "%ld.%09ld", st.st_mtim.tv_sec, st.st_mtim.tv_nsec);
                                                   ~~ ^
2 errors generated.
make[3]: *** [gdbmshell.o] Error 1
make[3]: *** Waiting for unfinished jobs....
mv -f .deps/gram.Tpo .deps/gram.Po
mv -f .deps/var.Tpo .deps/var.Po
mv -f .deps/lex.Tpo .deps/lex.Po
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```
The attached patch seems to solve this issue. Both the bug and potential solution have been reported to the gdbm developers.