### PR TITLE
garfieldpp: update dependencies, add variants

### DIFF
--- a/var/spack/repos/builtin/packages/garfieldpp/package.py
+++ b/var/spack/repos/builtin/packages/garfieldpp/package.py
@@ -17,9 +17,19 @@ class Garfieldpp(CMakePackage):
     tags = ['hep']
 
     maintainers = ['mirguest']
+    
+    variants('examples', default=False, description="Build garfield examples")
 
     version('master', branch='master')
     version('4.0', sha256='82bc1f0395213bd30a7cd854426e6757d0b4155e99ffd4405355c9648fa5ada3')
     version('3.0', sha256='c1282427a784658bc38b71c8e8cfc8c9f5202b185f0854d85f7c9c5a747c5406')
 
     depends_on('root')
+    depends_on('gsl')
+    depends_on('geant4', when='+examples')
+    
+    def cmake_args(self):
+        args = [
+            self.define_from_variant('WITH_EXAMPLES', 'examples')
+        ]
+        return args

--- a/var/spack/repos/builtin/packages/garfieldpp/package.py
+++ b/var/spack/repos/builtin/packages/garfieldpp/package.py
@@ -17,7 +17,7 @@ class Garfieldpp(CMakePackage):
     tags = ['hep']
 
     maintainers = ['mirguest']
-    
+
     variant('examples', default=False, description="Build garfield examples")
 
     version('master', branch='master')
@@ -27,7 +27,7 @@ class Garfieldpp(CMakePackage):
     depends_on('root')
     depends_on('gsl')
     depends_on('geant4', when='+examples')
-    
+
     def cmake_args(self):
         args = [
             self.define_from_variant('WITH_EXAMPLES', 'examples')

--- a/var/spack/repos/builtin/packages/garfieldpp/package.py
+++ b/var/spack/repos/builtin/packages/garfieldpp/package.py
@@ -18,7 +18,7 @@ class Garfieldpp(CMakePackage):
 
     maintainers = ['mirguest']
     
-    variants('examples', default=False, description="Build garfield examples")
+    variant('examples', default=False, description="Build garfield examples")
 
     version('master', branch='master')
     version('4.0', sha256='82bc1f0395213bd30a7cd854426e6757d0b4155e99ffd4405355c9648fa5ada3')


### PR DESCRIPTION
GSL is required by garfield, and only an optional dependency of root, so safer to add it directly.
Also add a variant to make the examples optional. 