### PR TITLE
visit: add an external find function (determine_version)

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -62,7 +62,7 @@ class Visit(CMakePackage):
 
     extendable = True
 
-    executables = ['^xml2cmake$']
+    executables = ['^visit$']
 
     version('develop', branch='develop')
     version('3.1.1', sha256='0b60ac52fd00aff3cf212a310e36e32e13ae3ca0ddd1ea3f54f75e4d9b6c6cf0')

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -62,6 +62,8 @@ class Visit(CMakePackage):
 
     extendable = True
 
+    executables = ['^xml2cmake$']
+
     version('develop', branch='develop')
     version('3.1.1', sha256='0b60ac52fd00aff3cf212a310e36e32e13ae3ca0ddd1ea3f54f75e4d9b6c6cf0')
     version('3.0.1', sha256='a506d4d83b8973829e68787d8d721199523ce7ec73e7594e93333c214c2c12bd')

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -280,3 +280,11 @@ class Visit(CMakePackage):
             args.append('-DVISIT_MPI_COMPILER={0}'.format(spec['mpi'].mpicxx))
 
         return args
+
+    # https://spack.readthedocs.io/en/latest/packaging_guide.html?highlight=executables#making-a-package-discoverable-with-spack-external-find
+    # Here we are only able to determine the latest version despite VisIt may have multiple versions
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'xml2cmake\s*([\d\.]+)', output)
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -282,7 +282,8 @@ class Visit(CMakePackage):
         return args
 
     # https://spack.readthedocs.io/en/latest/packaging_guide.html?highlight=executables#making-a-package-discoverable-with-spack-external-find
-    # Here we are only able to determine the latest version despite VisIt may have multiple versions
+    # Here we are only able to determine the latest version
+    # despite VisIt may have multiple versions
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('--version', output=str, error=str)

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -288,6 +288,6 @@ class Visit(CMakePackage):
     # despite VisIt may have multiple versions
     @classmethod
     def determine_version(cls, exe):
-        output = Executable(exe)('--version', output=str, error=str)
-        match = re.search(r'xml2cmake\s*([\d\.]+)', output)
+        output = Executable(exe)('-version', output=str, error=str)
+        match = re.search(r'\s*(\d[\d\.]+)\.', output)
         return match.group(1) if match else None


### PR DESCRIPTION
It is a cool use case to have VisIt installed using build_visit by sys admins and then to extend it compiling some plugins (such as visit-ffp, visit-unv, visit-cgns and more). In that case it is cool if VisIt in spack has a rule to make

>  spack external find visit

 find the VisIt installation.

This PR adds a "determine_version' to VisIt package.