### PR TITLE
[docs] document official gfortran macOS precompiled binaries

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -643,7 +643,16 @@ Fortran.
 
 #. There are different ways to get ``gfortran`` on macOS. For example, you can
    install GCC with Spack (``spack install gcc``) or with Homebrew
-   (``brew install gcc``).
+   (``brew install gcc``). To avoid compiling all of ``gcc``, users may obtain
+   a precompiled binary `prepared by the developers
+   <https://gcc.gnu.org/wiki/GFortranBinaries#MacOS>`_. For a given `release
+   installer <https://github.com/fxcoudert/gfortran-for-macOS/releases>`_,
+   download the ``.dmg`` binary, double click it, and once the dmg is mounted
+   right-click the ``gfortran.pkg`` file and select "open" (to bypass
+   codesigning requirements by Apple). It will install to the directory
+   ``/usr/local/gfortran/``, and produce a symbolic link of
+   ``/usr/local/bin/gfortran`` (but ``gcc`` and ``g++`` will **not** be linked
+   to ``/usr/local/bin``).
 
 #. The only thing left to do is to edit ``~/.spack/darwin/compilers.yaml`` to provide
    the path to ``gfortran``:

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -642,17 +642,9 @@ Fortran.
 #. Run ``spack compiler find`` to locate Clang.
 
 #. There are different ways to get ``gfortran`` on macOS. For example, you can
-   install GCC with Spack (``spack install gcc``) or with Homebrew
-   (``brew install gcc``). To avoid compiling all of ``gcc``, users may obtain
-   a precompiled binary `prepared by the developers
-   <https://gcc.gnu.org/wiki/GFortranBinaries#MacOS>`_. For a given `release
-   installer <https://github.com/fxcoudert/gfortran-for-macOS/releases>`_,
-   download the ``.dmg`` binary, double click it, and once the dmg is mounted
-   right-click the ``gfortran.pkg`` file and select "open" (to bypass
-   codesigning requirements by Apple). It will install to the directory
-   ``/usr/local/gfortran/``, and produce a symbolic link of
-   ``/usr/local/bin/gfortran`` (but ``gcc`` and ``g++`` will **not** be linked
-   to ``/usr/local/bin``).
+   install GCC with Spack (``spack install gcc``), with Homebrew (``brew install
+   gcc``), or from a `DMG installer
+   <https://github.com/fxcoudert/gfortran-for-macOS/releases>`_.
 
 #. The only thing left to do is to edit ``~/.spack/darwin/compilers.yaml`` to provide
    the path to ``gfortran``:
@@ -673,7 +665,8 @@ Fortran.
    If you used Spack to install GCC, you can get the installation prefix by
    ``spack location -i gcc`` (this will only work if you have a single version
    of GCC installed). Whereas for Homebrew, GCC is installed in
-   ``/usr/local/Cellar/gcc/x.y.z``.
+   ``/usr/local/Cellar/gcc/x.y.z``. With the DMG installer, the correct path
+   will be ``/usr/local/gfortran``.
 
 ^^^^^^^^^^^^^^^^^^^^^
 Compiler Verification


### PR DESCRIPTION
Since I don't want to `spack install gcc`, and I also don't want to use `brew`, I found they had some precompiled binaries ready for me.  Nice to know about, it definitely worked for `openblas` // `numpy` :slightly_smiling_face:

Bikeshedding on verbiage welcome, perhaps this is too explicit, but personally I think letting people know they can get these with relatively minimal effort is a good idea.  Just don't break those rst links :scream: