### PR TITLE
perl: Handle gdbm API change caused by gdbm@1.20:

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -63,7 +63,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
 
     extendable = True
 
-    depends_on('gdbm')
+    # Bind us below gdbm-1.20 due to API change: https://github.com/Perl/perl5/issues/18915
+    depends_on('gdbm@:1.19')
     # :5.28 needs gdbm@:1:14.1: https://rt-archive.perl.org/perl5/Ticket/Display.html?id=133295
     depends_on('gdbm@:1.14.1', when='@:5.28.0')
     depends_on('berkeley-db')


### PR DESCRIPTION
With version 1.20, gdbm's return values are enums, not C ```#defines``` anymore:

The absence of them causes a hack in perl for gdbm < 1.13 to `#define`
one a return value added later as another retval, breaking the backend:
```c
  #ifndef GDBM_ITEM_NOT_FOUND
  # define GDBM_ITEM_NOT_FOUND GDBM_NO_ERROR
  #endif
```
perl@5.34.0 can apply the patches from Fedora's RPM. The older releases
have to stay at the gdbm versions they used before the update of gdbm.

Upstream links:
Issue: https://github.com/Perl/perl5/issues/18915
Pull request https://github.com/Perl/perl5/pull/18924

@michaelkuhn The update of gdbm to 1.21 broke a hack in perl (shown by `spack install --test perl`), please review, thanks!