### PR TITLE
python: Update testsuite to pass with distutils-C++ patch

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -192,9 +192,11 @@ class Python(AutotoolsPackage):
     # https://github.com/spack/spack/pull/16856
     patch('python-2.7.8-distutils-C++.patch', when='@2.7.8:2.7.16')
     patch('python-2.7.17+-distutils-C++.patch', when='@2.7.17:2.7.18')
+    patch('python-2.7.17+-distutils-C++-fixup.patch', when='@2.7.17:2.7.18')
     patch('python-3.6.8-distutils-C++.patch', when='@3.6.8,3.7.2')
     patch('python-3.7.3-distutils-C++.patch', when='@3.7.3')
     patch('python-3.7.4+-distutils-C++.patch', when='@3.7.4:')
+    patch('python-3.7.4+-distutils-C++-testsuite.patch', when='@3.7.4:')
 
     patch('tkinter.patch', when='@:2.8,3.3:3.7 platform=darwin')
 

--- a/var/spack/repos/builtin/packages/python/python-2.7.17+-distutils-C++-fixup.patch
+++ b/var/spack/repos/builtin/packages/python/python-2.7.17+-distutils-C++-fixup.patch
@@ -1,0 +1,120 @@
+This patch fixes a regression intoduced by python-2.7.17+-distutils-C++.patch
+and updates the distutils testsuite to pass with 2.7.16:2.7.18:
+
+This how the test suite would have to change when the bug is not fixed:
+
+         self.assertEqual(comp.exes['compiler'],
+-                         'env_cc --sc-cflags --env-cflags --env-cppflags')
++                         'env_cc  --env-cflags --env-cppflags')
+         self.assertEqual(comp.exes['compiler_so'],
+-                         ('env_cc --sc-cflags '
++                         ('env_cc  '
+                           '--env-cflags ''--env-cppflags --sc-ccshared'))
+         self.assertEqual(comp.exes['compiler'],
+-                         'sc_cc --sc-cflags')
++                         'sc_cc ')
+         self.assertEqual(comp.exes['compiler_so'],
+-                         'sc_cc --sc-cflags --sc-ccshared')
++                         'sc_cc  --sc-ccshared')
+         self.assertEqual(comp.exes['compiler_cxx'],
+-                         'sc_cxx')
++                         'sc_cxx ')
+
+As shown, it removes the default, builtin cflags when calling the pure
+C compiler CC, which is wrong, introducing a regression.
+
+The cause is that the patch removes reading the python distutils cflags
+value and sets both empty.
+
+-        (cc, cxx, cflags, ccshared, ldshared, so_ext, ar, ar_flags) = \
+-            get_config_vars('CC', 'CXX', 'CFLAGS',
+-                            'CCSHARED', 'LDSHARED', 'SO', 'AR',
+-                            'ARFLAGS')
++        (cc, cxx, ccshared, ldshared, ldcxxshared, so_ext, ar, ar_flags) = \
++            get_config_vars('CC', 'CXX', 'CCSHARED', 'LDSHARED', 'LDCXXSHARED',
++                            'SO', 'AR', 'ARFLAGS')
++        cflags = ''
++        cxxflags = ''
+
+The fix is obvious when comparing it with python-3.7.4+-distutils-C++.patch
+
+-        (cc, cxx, cflags, ccshared, ldshared, shlib_suffix, ar, ar_flags) = \
+-            get_config_vars('CC', 'CXX', 'CFLAGS',
+-                            'CCSHARED', 'LDSHARED', 'SHLIB_SUFFIX', 'AR', 'ARFLAGS')
++        (cc, cxx, cflags, ccshared, ldshared, ldcxxshared, shlib_suffix, ar, ar_flags) = \
++            get_config_vars('CC', 'CXX', 'CFLAGS', 'CCSHARED', 'LDSHARED', 'LDCXXSHARED',
++                            'SHLIB_SUFFIX', 'AR', 'ARFLAGS')
++
++        cxxflags = cflags
+
+When handling CFLAGS the same as in python-3.7.4+-distutils-C++.patch,
+the issue is fixed.
+
+--- a/Lib/distutils/sysconfig.py
++++ b/Lib/distutils/sysconfig.py
+@@ -181,12 +181,11 @@
+                 _osx_support.customize_compiler(_config_vars)
+                 _config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
+ 
+-        (cc, cxx, ccshared, ldshared, ldcxxshared, so_ext, ar, ar_flags) = \
+-            get_config_vars('CC', 'CXX', 'CCSHARED', 'LDSHARED', 'LDCXXSHARED',
++        (cc, cxx, cflags, ccshared, ldshared, ldcxxshared, so_ext, ar, ar_flags) = \
++            get_config_vars('CC', 'CXX', 'CFLAGS', 'CCSHARED', 'LDSHARED', 'LDCXXSHARED',
+                             'SO', 'AR', 'ARFLAGS')
+ 
+-        cflags = ''
+-        cxxflags = ''
++        cxxflags = cflags
+ 
+         if 'CC' in os.environ:
+             newcc = os.environ['CC']
+--- a/Lib/distutils/tests/test_sysconfig.py
++++ b/Lib/distutils/tests/test_sysconfig.py
+@@ -65,6 +65,7 @@
+             'CXX': 'sc_cxx',
+             'ARFLAGS': '--sc-arflags',
+             'CFLAGS': '--sc-cflags',
++            'CPPFLAGS': '--sc-cppflags',
+             'CCSHARED': '--sc-ccshared',
+             'LDSHARED': 'sc_ldshared',
+             'SO': 'sc_shutil_suffix',
+@@ -94,11 +95,12 @@
+         os.environ['AR'] = 'env_ar'
+         os.environ['CC'] = 'env_cc'
+         os.environ['CPP'] = 'env_cpp'
+-        os.environ['CXX'] = 'env_cxx --env-cxx-flags'
++        os.environ['CXX'] = 'env_cxx'
+         os.environ['LDSHARED'] = 'env_ldshared'
+         os.environ['LDFLAGS'] = '--env-ldflags'
+         os.environ['ARFLAGS'] = '--env-arflags'
+         os.environ['CFLAGS'] = '--env-cflags'
++        os.environ['CXXFLAGS'] = '--env-cxxflags'
+         os.environ['CPPFLAGS'] = '--env-cppflags'
+ 
+         comp = self.customize_compiler()
+@@ -112,7 +114,7 @@
+                          ('env_cc --sc-cflags '
+                           '--env-cflags ''--env-cppflags --sc-ccshared'))
+         self.assertEqual(comp.exes['compiler_cxx'],
+-                         'env_cxx --env-cxx-flags')
++                         'env_cxx --sc-cflags --env-cxxflags --env-cppflags')
+         self.assertEqual(comp.exes['linker_exe'],
+                          'env_cc')
+         self.assertEqual(comp.exes['linker_so'],
+@@ -128,6 +130,7 @@
+         del os.environ['LDFLAGS']
+         del os.environ['ARFLAGS']
+         del os.environ['CFLAGS']
++        del os.environ['CXXFLAGS']
+         del os.environ['CPPFLAGS']
+ 
+         comp = self.customize_compiler()
+@@ -140,7 +143,7 @@
+         self.assertEqual(comp.exes['compiler_so'],
+                          'sc_cc --sc-cflags --sc-ccshared')
+         self.assertEqual(comp.exes['compiler_cxx'],
+-                         'sc_cxx')
++                         'sc_cxx --sc-cflags')
+         self.assertEqual(comp.exes['linker_exe'],
+                          'sc_cc')
+         self.assertEqual(comp.exes['linker_so'],

--- a/var/spack/repos/builtin/packages/python/python-3.7.4+-distutils-C++-testsuite.patch
+++ b/var/spack/repos/builtin/packages/python/python-3.7.4+-distutils-C++-testsuite.patch
@@ -1,0 +1,138 @@
+This patch updates the distutils test suite for:
+var/spack/repos/builtin/packages/python/python-3.7.4+-distutils-C++.patch
+
+That patch fixes several shortcomings in the distutils C++ support,
+most prominently missing support for passing CXXFLAGS from the environment.
+
+Since it does not update the distutils testsuite, it causes the testsuite
+to fail, which this patch updates to pass.
+
+-----------------------------------------------------------------------------
+Spack changelog
+- Added patch header to aid understanding the patch and maintainance
+- Updated the distutils testsuite in Lib/distutils/tests/test_sysconfig.py
+
+-----------------------------------------------------------------------------
+Upstream status
+
+Upstream bug: https://bugs.python.org/issue1222585
+
+Status: Closed, wont fix, comment by Eric Araujo, Python Core Dev:
+"setuptools and other active build tools are the better target for this feature."
+https://bugs.python.org/issue1222585#msg379348
+
+But according to the last-but-oncomment, setuptools seems to be lacking there too.
+https://bugs.python.org/issue1222585#msg371840
+
+-----------------------------------------------------------------------------
+Description
+
+distutils has no support for CXXFLAGS, this patch adds it.
+
+Upstream distutils requires to pass all CXXFLAGS (C++-specific CFLAGS)
+as part of the CXX enviromnent variable instead.
+
+This patch:
+- adds CXXFLAGS support
+- adds LDCXXSHARED like LDSHARED
+- passes cflags to CXX like it passes them to CC.
+
+The distutils testsuite is updated accordingly to pass the tests.
+Since it passes, it is the authoritative info of the current effects of this patch.
+
+See the update of the distutils testsuite in Lib/distutils/tests/test_sysconfig.py
+below for details on the effect of this patch.
+
+diff --git a/Lib/distutils/tests/test_sysconfig.py b/Lib/distutils/tests/test_sysconfig.py
+index db6674e..ccbe09a 100644
+--- a/Lib/distutils/tests/test_sysconfig.py
++++ b/Lib/distutils/tests/test_sysconfig.py
+@@ -89,8 +89,10 @@
+             'CXX': 'sc_cxx',
+             'ARFLAGS': '--sc-arflags',
+             'CFLAGS': '--sc-cflags',
++            'CXXFLAGS': '--sc-cxxflags',
+             'CCSHARED': '--sc-ccshared',
+             'LDSHARED': 'sc_ldshared',
++            'LDCXXSHARED': 'sc_ldshared_cxx',
+             'SHLIB_SUFFIX': 'sc_shutil_suffix',
+ 
+             # On macOS, disable _osx_support.customize_compiler()
+@@ -114,11 +116,13 @@
+         os.environ['AR'] = 'env_ar'
+         os.environ['CC'] = 'env_cc'
+         os.environ['CPP'] = 'env_cpp'
+-        os.environ['CXX'] = 'env_cxx --env-cxx-flags'
++        os.environ['CXX'] = 'env_cxx'
+         os.environ['LDSHARED'] = 'env_ldshared'
++        os.environ['LDCXXSHARED'] = 'env_ldshared_cxx'
+         os.environ['LDFLAGS'] = '--env-ldflags'
+         os.environ['ARFLAGS'] = '--env-arflags'
+         os.environ['CFLAGS'] = '--env-cflags'
++        os.environ['CXXFLAGS'] = '--env-cxxflags'
+         os.environ['CPPFLAGS'] = '--env-cppflags'
+ 
+         comp = self.customize_compiler()
+@@ -128,16 +132,24 @@
+                          'env_cpp --env-cppflags')
+         self.assertEqual(comp.exes['compiler'],
+                          'env_cc --sc-cflags --env-cflags --env-cppflags')
++        self.assertEqual(comp.exes['compiler_cxx'],
++                         'env_cxx --sc-cflags --env-cxxflags --env-cppflags')
+         self.assertEqual(comp.exes['compiler_so'],
+                          ('env_cc --sc-cflags '
+                           '--env-cflags ''--env-cppflags --sc-ccshared'))
+-        self.assertEqual(comp.exes['compiler_cxx'],
+-                         'env_cxx --env-cxx-flags')
++        self.assertEqual(comp.exes['compiler_so_cxx'],
++                         ('env_cxx --sc-cflags '
++                          '--env-cxxflags ''--env-cppflags --sc-ccshared'))
+         self.assertEqual(comp.exes['linker_exe'],
+                          'env_cc')
++        self.assertEqual(comp.exes['linker_exe_cxx'],
++                         'env_cxx')
+         self.assertEqual(comp.exes['linker_so'],
+                          ('env_ldshared --env-ldflags --env-cflags'
+                           ' --env-cppflags'))
++        self.assertEqual(comp.exes['linker_so_cxx'],
++                         ('env_ldshared_cxx --env-ldflags --env-cxxflags'
++                          ' --env-cppflags'))
+         self.assertEqual(comp.shared_lib_extension, 'sc_shutil_suffix')
+ 
+         del os.environ['AR']
+@@ -145,9 +157,11 @@
+         del os.environ['CPP']
+         del os.environ['CXX']
+         del os.environ['LDSHARED']
++        del os.environ['LDCXXSHARED']
+         del os.environ['LDFLAGS']
+         del os.environ['ARFLAGS']
+         del os.environ['CFLAGS']
++        del os.environ['CXXFLAGS']
+         del os.environ['CPPFLAGS']
+ 
+         comp = self.customize_compiler()
+@@ -157,14 +171,21 @@
+                          'sc_cc -E')
+         self.assertEqual(comp.exes['compiler'],
+                          'sc_cc --sc-cflags')
++        # TODO: Likely this sould get --sc-cxxflags instead:
++        self.assertEqual(comp.exes['compiler_cxx'],
++                         'sc_cxx --sc-cflags')
+         self.assertEqual(comp.exes['compiler_so'],
+                          'sc_cc --sc-cflags --sc-ccshared')
+-        self.assertEqual(comp.exes['compiler_cxx'],
+-                         'sc_cxx')
++        self.assertEqual(comp.exes['compiler_so_cxx'],
++                         'sc_cxx --sc-cflags --sc-ccshared')
+         self.assertEqual(comp.exes['linker_exe'],
+                          'sc_cc')
++        self.assertEqual(comp.exes['linker_exe_cxx'],
++                         'sc_cxx')
+         self.assertEqual(comp.exes['linker_so'],
+                          'sc_ldshared')
++        self.assertEqual(comp.exes['linker_so_cxx'],
++                         'sc_ldshared_cxx')
+         self.assertEqual(comp.shared_lib_extension, 'sc_shutil_suffix')
+ 
+     def test_parse_makefile_base(self):


### PR DESCRIPTION
Fix passing the python testsuite with spack install --test:

The distutils-C++ patch fixes missing support for CXXFLAGS and CPPFLAGS
for C++ compiles. This patch updates the distutils testsuite to expect
these additional flags to be passed to the C++ compiler and also covers
the other additions of the patch.