### PR TITLE
trilinos: variant for libx11

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -9,6 +9,7 @@ import sys
 from spack import *
 from spack.operating_systems.mac_os import macos_version
 from spack.pkg.builtin.kokkos import Kokkos
+from spack.build_environment import dso_suffix
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:
@@ -687,13 +688,12 @@ class Trilinos(CMakePackage, CudaPackage):
                 and spec.compiler.name in ['gcc', 'clang', 'apple-clang']):
             fc = Executable(spec['mpi'].mpifc) if (
                 '+mpi' in spec) else Executable(spack_fc)
-            sharedlibext = 'dylib' if sys.platform == 'darwin' else 'so'
             libgfortran = fc('--print-file-name',
-                             'libgfortran.%s' % sharedlibext,
+                             'libgfortran.' + dso_suffix,
                              output=str).strip()
-            # if libgfortran is equal to "libgfortran.<libext>" then
+            # if libgfortran is equal to "libgfortran.<dso_suffix>" then
             # print-file-name failed, use static library instead
-            if (libgfortran == ('libgfortran.%s' % sharedlibext)):
+            if libgfortran == 'libgfortran.' + dso_suffix:
                 libgfortran = fc('--print-file-name',
                                  'libgfortran.a',
                                  output=str).strip()

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import sys
 
 from spack import *
@@ -696,7 +697,11 @@ class Trilinos(CMakePackage, CudaPackage):
                 libgfortran = fc('--print-file-name',
                                  'libgfortran.a',
                                  output=str).strip()
-            options.append(define('Trilinos_EXTRA_LINK_FLAGS', libgfortran))
+            # -L<libdir> -lgfortran required for OSX
+            # https://github.com/spack/spack/pull/25823#issuecomment-917231118
+            options.append(
+                define('Trilinos_EXTRA_LINK_FLAGS',
+                       '-L%s/ -lgfortran' % os.path.dirname(libgfortran)))
 
         if sys.platform == 'darwin' and macos_version() >= Version('10.12'):
             # use @rpath on Sierra due to limit of dynamic loader

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -11,7 +11,6 @@ from spack.build_environment import dso_suffix
 from spack.operating_systems.mac_os import macos_version
 from spack.pkg.builtin.kokkos import Kokkos
 
-
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:
 # https://github.com/hpcugent/easybuild-easyblocks/blob/master/easybuild/easyblocks/t/trilinos.py#L111

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -682,15 +682,20 @@ class Trilinos(CMakePackage, CudaPackage):
         # ################# System-specific ######################
 
         # Fortran lib (assumes clang is built with gfortran!)
-        if ('+fortran' in spec and spec.compiler.name in ['gcc', 'clang', 'apple-clang']):
-            fc = Executable(spec['mpi'].mpifc) if ('+mpi' in spec) else Executable(spack_fc)
+        if ('+fortran' in spec
+                and spec.compiler.name in ['gcc', 'clang', 'apple-clang']):
+            fc = Executable(spec['mpi'].mpifc) if (
+                '+mpi' in spec) else Executable(spack_fc)
             sharedlibext = 'dylib' if sys.platform == 'darwin' else 'so'
             libgfortran = fc('--print-file-name',
-                'libgfortran.%s' % sharedlibext, output=str).strip()
+                             'libgfortran.%s' % sharedlibext,
+                             output=str).strip()
             # if libgfortran is equal to "libgfortran.<libext>" then
             # print-file-name failed, use static library instead
-            if (libgfortran == ('libgfortran.%s' %  sharedlibext)):
-                libgfortran = fc('--print-file-name', 'libgfortran.a', output=str).strip()
+            if (libgfortran == ('libgfortran.%s' % sharedlibext)):
+                libgfortran = fc('--print-file-name',
+                                 'libgfortran.a',
+                                 output=str).strip()
             options.append(define('Trilinos_EXTRA_LINK_FLAGS', libgfortran))
 
         if sys.platform == 'darwin' and macos_version() >= Version('10.12'):

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -7,9 +7,10 @@ import os
 import sys
 
 from spack import *
+from spack.build_environment import dso_suffix
 from spack.operating_systems.mac_os import macos_version
 from spack.pkg.builtin.kokkos import Kokkos
-from spack.build_environment import dso_suffix
+
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:


### PR DESCRIPTION
SEACAS only uses X11 for blot/fastq as far as I'm aware.

blot/fastq are pretty niche/legacy programs, this re-adds a variant to avoid bringing in X11 by default

@sethrj 