### PR TITLE
CMake - Windows Bootstrap

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -511,7 +511,8 @@ def _set_variables_for_single_module(pkg, module):
     # m.cmake = Executable('cmake')
     m.cmake = Executable('cmake')
     m.ctest = MakeExecutable('ctest', jobs)
-
+    if os.name == 'nt':
+        m.nmake = Executable('nmake')
     # Standard CMake arguments
     m.std_cmake_args = spack.build_systems.cmake.CMakePackage._std_args(pkg)
     m.std_meson_args = spack.build_systems.meson.MesonPackage._std_args(pkg)

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -117,6 +117,9 @@ class Msvc(Compiler):
                 env.set_path('PATH', int_env['path'].split(';'))
             env.set_path('INCLUDE', int_env.get('include', '').split(';'))
             env.set_path('LIB', int_env.get('lib', '').split(';'))
+
+            env.set('CC', self.cc)
+            env.set('CXX', self.cxx)
         else:
             # Should not this be an exception?
             print("Cannot pull msvc compiler information in Python 2.6 or below")

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -248,7 +248,7 @@ class Cmake(Package):
 
     def setup_build_environment(self, env):
         spec = self.spec
-        if '+openssl+ownlibs' in spec:
+        if '+openssl' in spec:
             print(spec['openssl'].prefix)
             env.set('OPENSSL_ROOT_DIR', spec['openssl'].prefix)
 

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -3,9 +3,13 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import re
+import shutil
+import sys
 
 import spack.build_environment
+from spack import *
 
 
 class Cmake(Package):
@@ -135,6 +139,12 @@ class Cmake(Package):
     # https://gitlab.kitware.com/cmake/cmake/merge_requests/4075
     patch('fix-xlf-ninja-mr-4075.patch', sha256="42d8b2163a2f37a745800ec13a96c08a3a20d5e67af51031e51f63313d0dedd1", when="@3.15.5")
 
+    variant('generator',
+            default='Unix Makefiles' if sys.platform != 'win32' else 'Ninja',
+            description='Build system to generate',
+            values=('Unix Makefiles', 'Ninja'))
+    depends_on('ninja', when='generator=Ninja')
+
     # We default ownlibs to true because it greatly speeds up the CMake
     # build, and CMake is built frequently. Also, CMake is almost always
     # a build dependency, and its libs will not interfere with others in
@@ -238,34 +248,40 @@ class Cmake(Package):
 
     def bootstrap_args(self):
         spec = self.spec
-        args = [
-            '--prefix={0}'.format(self.prefix),
-            '--parallel={0}'.format(make_jobs)
-        ]
+        args = []
+        if not os.name == 'nt':
+            args.extend(
+                ['--prefix={0}'.format(self.prefix),
+                 '--parallel={0}'.format(make_jobs)]
+            )
 
-        if '+ownlibs' in spec:
-            # Build and link to the CMake-provided third-party libraries
-            args.append('--no-system-libs')
+            if '+ownlibs' in spec:
+                # Build and link to the CMake-provided third-party libraries
+                args.append('--no-system-libs')
+            else:
+                # Build and link to the Spack-installed third-party libraries
+                args.append('--system-libs')
+
+                if spec.satisfies('@3.2:'):
+                    # jsoncpp requires CMake to build
+                    # use CMake-provided library to avoid circular dependency
+                    args.append('--no-system-jsoncpp')
+
+            if '+qt' in spec:
+                args.append('--qt-gui')
+            else:
+                args.append('--no-qt-gui')
+
+            if '+doc' in spec:
+                args.append('--sphinx-html')
+                args.append('--sphinx-man')
+
+            # Now for CMake arguments to pass after the initial bootstrap
+            args.append('--')
         else:
-            # Build and link to the Spack-installed third-party libraries
-            args.append('--system-libs')
-
-            if spec.satisfies('@3.2:'):
-                # jsoncpp requires CMake to build
-                # use CMake-provided library to avoid circular dependency
-                args.append('--no-system-jsoncpp')
-
-        if '+qt' in spec:
-            args.append('--qt-gui')
-        else:
-            args.append('--no-qt-gui')
-
-        if '+doc' in spec:
-            args.append('--sphinx-html')
-            args.append('--sphinx-man')
-
-        # Now for CMake arguments to pass after the initial bootstrap
-        args.append('--')
+            args.append('-DCMAKE_INSTALL_PREFIX=%s' % self.prefix)
+        if self.spec.satisfies('generator=Ninja'):
+            args.append('-GNinja')
 
         args.append('-DCMAKE_BUILD_TYPE={0}'.format(
             self.spec.variants['build_type'].value))
@@ -276,7 +292,7 @@ class Cmake(Package):
 
         # When building our own private copy of curl then we need to properly
         # enable / disable oepnssl
-        if '+ownlibs' in spec:
+        if '+openssl' in spec and '+ownlibs' not in spec:
             args.append('-DCMAKE_USE_OPENSSL=%s' % str('+openssl' in spec))
 
         args.append('-DBUILD_CursesDialog=%s' % str('+ncurses' in spec))
@@ -292,21 +308,59 @@ class Cmake(Package):
 
         return args
 
+    def winbootcmake(self, spec):
+        from spack import fetch_strategy, stage
+        urls = {
+            '3': 'https://cmake.org/files/v3.21/cmake-3.21.2-windows-x86_64.zip',
+            '2': 'https://cmake.org/files/v2.8/cmake-2.8.4-win32-x86.zip'
+        }
+        if spec.satisfies('@3.0.2:'):
+            bootstrap_url = urls['3']
+        else:
+            bootstrap_url = urls['2']
+        remote = fetch_strategy.URLFetchStrategy(url=bootstrap_url)
+        bootstrap_stage_path = os.path.join(self.stage.path, "cmake-bootstraper")
+        with stage.Stage(remote, path=bootstrap_stage_path) as bootstrap_stage:
+            remote.stage = bootstrap_stage
+            remote.fetch()
+            remote.expand()
+            shutil.move(bootstrap_stage.source_path, self.stage.source_path)
+
+    def cmake_bootstrap(self):
+        exe_prefix = self.stage.source_path
+        relative_cmake_exe = os.path.join('spack-src', 'bin', 'cmake.exe')
+        return Executable(os.path.join(exe_prefix, relative_cmake_exe))
+
     def bootstrap(self, spec, prefix):
-        bootstrap = Executable('./bootstrap')
-        bootstrap(*self.bootstrap_args())
+        bootstrap_args = self.bootstrap_args()
+        if os.name == 'nt':
+            self.winbootcmake(spec)
+            bootstrap = self.cmake_bootstrap()
+            bootstrap_args.extend(['.'])
+        else:
+            bootstrap = Executable('./bootstrap')
+        bootstrap(*bootstrap_args)
 
     def build(self, spec, prefix):
-        make()
+        if self.spec.satisfies("generator=Ninja"):
+            ninja()
+        else:
+            make()
 
     @run_after('build')
     @on_package_attributes(run_tests=True)
     def build_test(self):
         # Some tests fail, takes forever
-        make('test')
+        if self.spec.satisfies('generator=Ninja'):
+            ninja('test')
+        else:
+            make('test')
 
     def install(self, spec, prefix):
-        make('install')
+        if self.spec.satisfies("generator=Ninja"):
+            ninja('install')
+        else:
+            make('install')
 
         if spec.satisfies('%fj'):
             for f in find(self.prefix, 'FindMPI.cmake', recursive=True):

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -249,7 +249,6 @@ class Cmake(Package):
     def setup_build_environment(self, env):
         spec = self.spec
         if '+openssl' in spec:
-            print(spec['openssl'].prefix)
             env.set('OPENSSL_ROOT_DIR', spec['openssl'].prefix)
 
     def bootstrap_args(self):


### PR DESCRIPTION
CMake can now bootstrap itself as it would on *nix systems. 
This is accomplished by using Spack's fetch system to fetch and 'install' a cmake binary into the cmake stage source directory. That binary is then used to build CMake from source as usual.

In order to prevent CMake from requiring ZLib, openssl has to be manually disabled via `~openssl` which can then be reenabled after Zlib is built. This situation is not ideal, but currently, AFAIK, no other way exists to have a 'bootstrapped' dependency in Spack. 

MSVC compiler class was previously leaving `CC` and `CXX` env variables unset, causing problems in CMake and Meson build systems. The variables are now set to their respective compiler locations on the system, which are configured by the WindowsOs Class.