### PR TITLE
Add IFX to all MSVC

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -235,7 +235,7 @@ def find_compilers(path_hints=None):
     def remove_errors(item):
         value, _ = item
         return value
-    tty.warn(detected_versions)
+
     return make_compiler_list(
         map(remove_errors, filter(valid_version, detected_versions))
     )
@@ -605,7 +605,6 @@ def detect_version(detect_version_args):
         containing an explanation on why the version couldn't be computed.
     """
     def _default(fn_args):
-        tty.warn(fn_args)
         compiler_id = fn_args.id
         language = fn_args.language
         compiler_cls = class_for_compiler_name(compiler_id.compiler_name)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -235,7 +235,7 @@ def find_compilers(path_hints=None):
     def remove_errors(item):
         value, _ = item
         return value
-
+    tty.warn(detected_versions)
     return make_compiler_list(
         map(remove_errors, filter(valid_version, detected_versions))
     )
@@ -605,6 +605,7 @@ def detect_version(detect_version_args):
         containing an explanation on why the version couldn't be computed.
     """
     def _default(fn_args):
+        tty.warn(fn_args)
         compiler_id = fn_args.id
         language = fn_args.language
         compiler_cls = class_for_compiler_name(compiler_id.compiler_name)

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from typing import List  # novm
 
+from spack.error import SpackError
 import spack.operating_systems.windows_os
 import spack.util.executable
 from spack.compiler import Compiler
@@ -107,14 +108,9 @@ class Msvc(Compiler):
         if os.getenv("ONEAPI_ROOT"):
             try:
                 sps = spack.operating_systems.windows_os.WindowsOs.compiler_search_paths
-            except Exception:
-                print("sps not found.")
-                raise
-            try:
-                clp = spack.util.executable.which_string("cl", path=sps)
-            except Exception:
-                print("cl not found.")
-                raise
+            except AttributeError:
+                raise SpackError("Windows compiler search paths not established")
+            clp = spack.util.executable.which_string("cl", path=sps)
             ver = cls.default_version(clp)
             return ver
         else:

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -4,37 +4,37 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-from packaging import version
 import subprocess
 import sys
-from typing import List, OrderedDict  # novm
+from distutils.version import StrictVersion
+from typing import Dict, List, Set  # novm
 
-from spack.error import SpackError
 import spack.operating_systems.windows_os
 import spack.util.executable
 from spack.compiler import Compiler
+from spack.error import SpackError
 
-
-
-avail_fc_version = set()
-fc_path = {}
+avail_fc_version = set()  # type: Set[str]
+fc_path = dict()  # type: Dict[str, str]
 
 fortran_mapping = {
-                '2021.3.0' : '19.29.30133',
-                '2021.2.1' : '19.28.29913',
-                '2021.2.0' : '19.28.29334',
-                '2021.1.0' : '19.28.29333',
-            }
+    '2021.3.0': '19.29.30133',
+    '2021.2.1': '19.28.29913',
+    '2021.2.0': '19.28.29334',
+    '2021.1.0': '19.28.29333',
+}
+
 
 def get_valid_fortran_pth(comp_ver):
     cl_ver = str(comp_ver).split('@')[1]
-    sort_fn = lambda fc_ver: version.parse(fc_ver)
+    sort_fn = lambda fc_ver: StrictVersion(fc_ver)
     sort_fc_ver = sorted(list(avail_fc_version), key=sort_fn)
     for ver in sort_fc_ver:
         if ver in fortran_mapping:
-            if version.parse(cl_ver) <= version.parse(fortran_mapping[ver]):
+            if StrictVersion(cl_ver) <= StrictVersion(fortran_mapping[ver]):
                 return fc_path[ver]
     return None
+
 
 class Msvc(Compiler):
     # Subclasses use possible names of C compiler

--- a/lib/spack/spack/compilers/msvc.py
+++ b/lib/spack/spack/compilers/msvc.py
@@ -31,8 +31,9 @@ def get_valid_fortran_pth(comp_ver):
     sort_fn = lambda fc_ver: version.parse(fc_ver)
     sort_fc_ver = sorted(list(avail_fc_version), key=sort_fn)
     for ver in sort_fc_ver:
-        if version.parse(cl_ver) <= version.parse(fortran_mapping[ver]):
-            return fc_path[ver]
+        if ver in fortran_mapping:
+            if version.parse(cl_ver) <= version.parse(fortran_mapping[ver]):
+                return fc_path[ver]
     return None
 
 class Msvc(Compiler):


### PR DESCRIPTION
IFX compilers are compatible with multiple versions of MSVC compilers. This PR ensures that all MSVC versions that have a discoverable, compatible IFX compiler on the system are assigned that compiler. 

This fixes up a bug when building netlib-lapack where the selected MSVC compiler was missing it's FC entry, despite Spack being aware of a compatible version.