### PR TITLE
omegah: add version 9.34.1

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -18,6 +18,7 @@ class OmegaH(CMakePackage):
     maintainers = ['ibaned']
 
     version('main', branch='main')
+    version('9.34.1', sha256='3a812da3b8df3e0e5d78055e91ad23333761bcd9ed9b2c8c13ee1ba3d702e46c')
     version('9.32.5', sha256='963a203e9117024cd48d829d82b8543cd9133477fdc15386113b594fdc3246d8')
     version('9.29.0', sha256='b41964b018909ffe9cea91c23a0509b259bfbcf56874fcdf6bd9f6a179938014')
     version('9.27.0', sha256='aa51f83508cbd14a41ae953bda7da98a6ad2979465c76e5b3a3d9a7a651cb34a')


### PR DESCRIPTION
This PR adds omega_h version 9.34.1 . 

The following script successfully installed 9.34.1 on an Arch linux system with GCC 11.1.0:

```
#!/bin/bash
date=`date +%F-%H-%M`
spackDir=$PWD/testSpack_${date}
mkdir -p $spackDir
cd $spackDir
cp -r ~/develop/spack .
git clone -b cws/omegah9341 https://github.com/SCOREC/spack.git
cd spack
export SPACK_ROOT=$PWD
source $SPACK_ROOT/share/spack/setup-env.sh
which spack # sanity check

#load modules for compiler here
#yaml files
spack compiler find --scope site 

# setup scratch space for spack
spackScratch=$spackDir/spack_scratch
mkdir -p $spackScratch
(
cat <<APPEND_HEREDOC
config:
  build_stage:
   - $spackScratch
APPEND_HEREDOC
) >> $SPACK_ROOT/etc/spack/config.yaml

mkdir omegaEnv
cd $_
spack env create -d .
spack env activate $PWD
spack mirror add E4S https://cache.e4s.io
spack buildcache keys -it
spack install omega-h@9.34.1
```