### PR TITLE
Bugfix: Correct checksum's sha256 when retrieve from remote

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -65,10 +65,10 @@ def checksum(parser, args):
 
         # And ensure the specified version URLs take precedence, if available
         try:
-            explicit_dict = {
-                (v, pkg.url_for_version(v)) for v in pkg.versions
-                if not v.isdevelop()
-            }
+            explicit_dict = {}
+            for v in pkg.versions:
+                if not v.isdevelop():
+                    explicit_dict[v] = pkg.url_for_version(v)
             url_dict.update(explicit_dict)
         except spack.package.NoURLError:
             pass

--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -63,6 +63,16 @@ def checksum(parser, args):
         if not url_dict:
             tty.die("Could not find any versions for {0}".format(pkg.name))
 
+        # And ensure the specified version URLs take precedence, if available
+        try:
+            explicit_dict = {
+                (v, pkg.url_for_version(v)) for v in pkg.versions
+                if not v.isdevelop()
+            }
+            url_dict.update(explicit_dict)
+        except spack.package.NoURLError:
+            pass
+
     version_lines = spack.stage.get_checksums_for_versions(
         url_dict, pkg.name, keep_stage=args.keep_stage,
         batch=(args.batch or len(args.versions) > 0 or len(url_dict) == 1),


### PR DESCRIPTION
Fixes #24971 
Fixes #24668

This PR ensures the proper URL when not given versions on the command line by using the URL associated/derived for versions listed in the package.

For example, the output without this fix is:
```
$ spack checksum pmdk
==> Found 11 versions of pmdk:
  
  1.11.0-rc2  https://github.com/pmem/pmdk/releases/download/1.11.0-rc2/pmdk-1.11.0-rc2.tar.gz
  1.11.0-rc1  https://github.com/pmem/pmdk/releases/download/1.11.0-rc1/pmdk-1.11.0-rc1.tar.gz
  1.11.0      https://github.com/pmem/pmdk/releases/download/1.11.0/pmdk-1.11.0.tar.gz
  1.10-rc1    https://github.com/pmem/pmdk/releases/download/1.10-rc1/pmdk-1.10-rc1.tar.gz
  1.10        https://github.com/pmem/pmdk/releases/download/1.10/pmdk-1.10.tar.gz
  1.9.2       https://github.com/pmem/pmdk/releases/download/1.9.2/pmdk-1.9.2.tar.gz
  1.9.1       https://github.com/pmem/pmdk/releases/download/1.9.1/pmdk-1.9.1.tar.gz
  1.9         https://github.com/pmem/pmdk/releases/download/1.9/pmdk-1.9.tar.gz
  1.8.1       https://github.com/pmem/pmdk/releases/download/1.8.1/pmdk-1.8.1.tar.gz
  ...
  1.5         https://github.com/pmem/pmdk/archive/1.5.tar.gz

==> How many would you like to checksum? (default is 1, q to abort) 10
==> Fetching https://github.com/pmem/pmdk/releases/download/1.11.0-rc2/pmdk-1.11.0-rc2.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.11.0-rc1/pmdk-1.11.0-rc1.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.11.0/pmdk-1.11.0.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.10-rc1/pmdk-1.10-rc1.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.10/pmdk-1.10.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.9.2/pmdk-1.9.2.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.9.1/pmdk-1.9.1.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.9/pmdk-1.9.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.8.1/pmdk-1.8.1.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.7.1/pmdk-1.7.1.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.5.tar.gz

    version('1.11.0-rc2', sha256='25885ea35d2bb25fc5193135045efacf97f64b26df12585e885a849972cd850d')
    version('1.11.0-rc1', sha256='0d0947ab079be50ff752c184d04f6001d2bc95f2083c59c488ff4304c45deaec')
    version('1.11.0',     sha256='2116f30b1fbb3ee11b208f21f6eb81e594649608d85f6741d597a7fbea36143b')
    version('1.10-rc1',   sha256='8dd6fdad1a870f7f861e760c40aa3cc4fb248b9eec5f98a869c05cbd96971b5f')
    version('1.10',       sha256='08dafcf94db5ac13fac9139c92225d9aa5f3724ea74beee4e6ca19a01a2eb20c')
    version('1.9.2',      sha256='38c0dc5cec1145b1a42d7c3de8fa726f246346c29256c6658ccb264a00db54f3')
    version('1.9.1',      sha256='3f31b75b07ec484028b8c00918b2dcb410fed5e3683e471f04bdf1e957f39b75')
    version('1.9',        sha256='956186faa3feb0156f58da5578143cce22501b9b4a00133a490f997594cb466f')
    version('1.8.1',      sha256='0ae98ace247e2417718e64e3ea2cf7959cf7dce0e686f95ebfe3853a4c22c00e')
    version('1.7.1',      sha256='cc48cc623fd36f9fb7898dde7406802f4e1a4ad7c84c091979ce20cd5a0e14b0')
```

Using the change in this PR:
```
$ spack checksum pmdk
==> Found 14 versions of pmdk:
  
  1.11.0-rc2  https://github.com/pmem/pmdk/releases/download/1.11.0-rc2/pmdk-1.11.0-rc2.tar.gz
  1.11.0-rc1  https://github.com/pmem/pmdk/releases/download/1.11.0-rc1/pmdk-1.11.0-rc1.tar.gz
  1.11.0      https://github.com/pmem/pmdk/archive/1.11.0.tar.gz
  1.10-rc1    https://github.com/pmem/pmdk/releases/download/1.10-rc1/pmdk-1.10-rc1.tar.gz
  1.10        https://github.com/pmem/pmdk/archive/1.10.tar.gz
  1.9.2       https://github.com/pmem/pmdk/archive/1.9.2.tar.gz
  1.9.1       https://github.com/pmem/pmdk/archive/1.9.1.tar.gz
  1.9         https://github.com/pmem/pmdk/archive/1.9.tar.gz
  1.8.1       https://github.com/pmem/pmdk/archive/1.8.1.tar.gz
  ...
  1.5         https://github.com/pmem/pmdk/archive/1.5.tar.gz

==> How many would you like to checksum? (default is 1, q to abort) 11
==> Fetching https://github.com/pmem/pmdk/releases/download/1.11.0-rc2/pmdk-1.11.0-rc2.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.11.0-rc1/pmdk-1.11.0-rc1.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.11.0.tar.gz
==> Fetching https://github.com/pmem/pmdk/releases/download/1.10-rc1/pmdk-1.10-rc1.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.10.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.9.2.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.9.1.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.9.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.8.1.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.8.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.7.1.tar.gz

    version('1.11.0-rc2', sha256='25885ea35d2bb25fc5193135045efacf97f64b26df12585e885a849972cd850d')
    version('1.11.0-rc1', sha256='0d0947ab079be50ff752c184d04f6001d2bc95f2083c59c488ff4304c45deaec')
    version('1.11.0',     sha256='bfbc82e6bfd788c8bcb380da76172b83732d12775a719c9c423eb2fadc78bb3a')
    version('1.10-rc1',   sha256='8dd6fdad1a870f7f861e760c40aa3cc4fb248b9eec5f98a869c05cbd96971b5f')
    version('1.10',       sha256='06edcd43ef267c4cc70754d5d1a5d88aeb9f2086bc014bf2594df4c5efd8cc4e')
    version('1.9.2',      sha256='6bca98ecf9e036603951024b7436d688cd1907b2d8c428373697fafff4096a4f')
    version('1.9.1',      sha256='3d0ea15099d6dc7b454a67ecd0ed04d7426ff05ee0331a221cb384e293d841f0')
    version('1.9',        sha256='2c8a148070f4bbf9f82e2ca63d2f84cb5101fc6e72c1ba93cc673ca3b7b95467')
    version('1.8.1',      sha256='ee4e93bbf29976eac2444e4eb04a862f38b8446f7400f8f7cdcf58febf6f6ba2')
    version('1.8',        sha256='a241ea76ef76d233cb92826b6823ed48091a2fb6963282a4fea848dbce68aa21')
    version('1.7.1',      sha256='7e98c0522a3e96b64822902c66024e24455f4742246c679cc0f46036ef4685bc')
```

The differences for the overlapping versions (PR vs. without PR):
```
    version('1.11.0-rc2', sha256='25885ea35d2bb25fc5193135045	    version('1.11.0-rc2', sha256='25885ea35d2bb25fc5193135045
    version('1.11.0-rc1', sha256='0d0947ab079be50ff752c184d04	    version('1.11.0-rc1', sha256='0d0947ab079be50ff752c184d04
    version('1.11.0',     sha256='bfbc82e6bfd788c8bcb380da761 |	    version('1.11.0',     sha256='2116f30b1fbb3ee11b208f21f6e
    version('1.10-rc1',   sha256='8dd6fdad1a870f7f861e760c40a	    version('1.10-rc1',   sha256='8dd6fdad1a870f7f861e760c40a
    version('1.10',       sha256='06edcd43ef267c4cc70754d5d1a |	    version('1.10',       sha256='08dafcf94db5ac13fac9139c922
    version('1.9.2',      sha256='6bca98ecf9e036603951024b743 |	    version('1.9.2',      sha256='38c0dc5cec1145b1a42d7c3de8f
    version('1.9.1',      sha256='3d0ea15099d6dc7b454a67ecd0e |	    version('1.9.1',      sha256='3f31b75b07ec484028b8c00918b
    version('1.9',        sha256='2c8a148070f4bbf9f82e2ca63d2 |	    version('1.9',        sha256='956186faa3feb0156f58da55781
    version('1.8.1',      sha256='ee4e93bbf29976eac2444e4eb04 |	    version('1.8.1',      sha256='0ae98ace247e2417718e64e3ea2
    version('1.7.1',      sha256='7e98c0522a3e96b64822902c660 |	    version('1.7.1',      sha256='cc48cc623fd36f9fb7898dde740
```

And the checksums listed in the package correspond to the versions with difference above, with or without this PR:

```
$ spack checksum pmdk 1.11.0 1.10 1.9.2 1.9.1 1.9 1.8.1 1.7.1
==> Found 7 versions of pmdk:
  
  1.11.0  https://github.com/pmem/pmdk/archive/1.11.0.tar.gz
  1.10    https://github.com/pmem/pmdk/archive/1.10.tar.gz
  1.9.2   https://github.com/pmem/pmdk/archive/1.9.2.tar.gz
  1.9.1   https://github.com/pmem/pmdk/archive/1.9.1.tar.gz
  1.9     https://github.com/pmem/pmdk/archive/1.9.tar.gz
  1.8.1   https://github.com/pmem/pmdk/archive/1.8.1.tar.gz
  1.7.1   https://github.com/pmem/pmdk/archive/1.7.1.tar.gz

==> Fetching https://github.com/pmem/pmdk/archive/1.11.0.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.10.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.9.2.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.9.1.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.9.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.8.1.tar.gz
==> Fetching https://github.com/pmem/pmdk/archive/1.7.1.tar.gz

    version('1.11.0', sha256='bfbc82e6bfd788c8bcb380da76172b83732d12775a719c9c423eb2fadc78bb3a')
    version('1.10',   sha256='06edcd43ef267c4cc70754d5d1a5d88aeb9f2086bc014bf2594df4c5efd8cc4e')
    version('1.9.2',  sha256='6bca98ecf9e036603951024b7436d688cd1907b2d8c428373697fafff4096a4f')
    version('1.9.1',  sha256='3d0ea15099d6dc7b454a67ecd0ed04d7426ff05ee0331a221cb384e293d841f0')
    version('1.9',    sha256='2c8a148070f4bbf9f82e2ca63d2f84cb5101fc6e72c1ba93cc673ca3b7b95467')
    version('1.8.1',  sha256='ee4e93bbf29976eac2444e4eb04a862f38b8446f7400f8f7cdcf58febf6f6ba2')
    version('1.7.1',  sha256='7e98c0522a3e96b64822902c66024e24455f4742246c679cc0f46036ef4685bc')
```

match the changes from this PR.
