### PR TITLE
Proposal: standardize variant names a bit more

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -5325,6 +5325,7 @@ variant names are:
   shared   True     Build shared libraries
   mpi      True     Use MPI
   python   False    Build Python extension
+  x        False    Use X11 visualization
   ======= ======== ========================
 
 If specified in this table, the corresponding default should be used
@@ -5335,6 +5336,11 @@ built `~shared`, the package guarantees that no shared libraries are
 built. When a package is built `+shared`, the package guarantees that
 shared libraries are built, but it makes no guarantee about whether
 static libraries are built.
+
+Variant names must be lowercase alphanumerics and, if necessary, an
+underscore ``_``. (Dashes must not be used because they are equivalent to ``~``
+in a spec.) Like variable names in python, variant names should be short but
+understandable.
 
 ^^^^^^^^^^^^^
 Version Lists


### PR DESCRIPTION
- Standardize `x11`/`X`/`x` -> `x`
- Remove uppercase names from variants
- Remove dashes from variants (ambiguous with `~`)
- Discourage numbers in variants (?)
- Discourage underscore use
- static/shared/pic (see https://github.com/spack/spack/issues/5269)

## Variants with capital letters

```console
$ grep -Hn " variant(['\"][^'\"]*[A-Z]" */package.py
cairo/package.py:23:    variant('X', default=False, description="Build with X11 support")
eem/package.py:18:    variant('K', default=False, description='Build for K computer')
emacs/package.py:29:    variant('X', default=False, description="Enable an X toolkit")
environment-modules/package.py:47:    variant('X', default=True, description='Build with X functionality')
ffmpeg/package.py:41:    variant('X', default=False, description='X11 support')
gnuplot/package.py:46:    variant('X',       default=False,
icedtea/package.py:28:    variant('X', default=False, description="Build with GUI support.")
netpbm/package.py:33:    variant('X', default=True,
ngspice/package.py:37:    variant('X', default=False, description='Use the X Window System')
oce/package.py:32:    variant('X11', default=False,
pango/package.py:31:    variant('X', default=False, description="Enable an X toolkit")
petsc/package.py:127:    variant('X', default=False,
planck-likelihood/package.py:21:    variant('plik-DS', default=False,
planck-likelihood/package.py:23:    variant('plik-HM-ext', default=False,
r/package.py:60:    variant('X', default=False,
yorick/package.py:27:    variant('X', default=False, description='Enable X11 support')
```

And SUNDIALS (and possibly other packages that programmatically generate variant names):
```python
    sun_solvers = ['CVODE', 'CVODES', 'ARKODE', 'IDA', 'IDAS', 'KINSOL']

    for pkg in sun_solvers:
        variant(pkg, default=True,
                description='Enable %s solver' % pkg)
```

## Variants called x11

```console
$ grep -Hn " variant(['\"]x11" */package.py
amber/package.py:120:    variant('x11', description='Build programs that require X11',
gdk-pixbuf/package.py:27:    variant('x11', default=False, description="Enable X11 support")
gdl/package.py:34:    variant('x11', default=False, description='Enable X11')
geant4/package.py:43:    variant('x11', default=False, description='Optional X11 support')
povray/package.py:56:    # variant('x11', default=True, description='Build with X11 support')
pulseaudio/package.py:30:    variant('x11', default=False, description='x11 support')
seacas/package.py:78:    variant('x11',          default=True,
```

## Variants with dashes

```console
$ grep -Hn " variant(['\"][^'\"]*-" */package.py
abinit/package.py:54:    variant('optimization-flavor', default='standard', multi=False,
amr-wind/package.py:55:    variant('internal-amrex', default=True,
aocc/package.py:57:    variant('license-agreed', default=False,
bcftools/package.py:31:    variant('perl-filters',
bdw-gc/package.py:20:    variant('libatomic-ops', default=True,
cdo/package.py:40:    variant('external-grib1', default=False,
clapack/package.py:23:    variant('external-blas', default=True,
cuda/package.py:125:    variant('allow-unsupported-compilers', default=False,
dataspaces/package.py:31:    variant('cray-drc',
dataspaces/package.py:34:    variant('gni-cookie',
datatransferkit/package.py:22:    variant('external-arborx', default=False,
dealii/package.py:70:    variant('adol-c',   default=True,
esmf/package.py:27:    variant('external-lapack', default=False, description='Build with external LAPACK support')
fastjet/package.py:54:    variant('auto-ptr', default=False, description='Use auto_ptr')
fenics/package.py:45:    variant('suite-sparse', default=True,
fides/package.py:23:    variant('vtk-m', default=True, description="build VTK-m support")
gdb/package.py:43:    variant('source-highlight', default=False, description='Compile with source-highlight support')
geopm/package.py:45:    variant('gnu-ld', default=False, description='Assume C compiler uses gnu-ld.')
gsl/package.py:30:    variant('external-cblas', default=False, description='Build against external blas')
hdf/package.py:27:    variant('external-xdr', default=sys.platform != 'darwin',
henson/package.py:21:    variant('mpi-wrappers', default=False, description='Build MPI wrappers (PMPI)')
hpctoolkit/package.py:53:    variant('all-static', default=False,
hypre/package.py:52:    variant('internal-superlu', default=False,
hypre/package.py:54:    variant('superlu-dist', default=False,
hypre/package.py:65:    variant('unified-memory', default=False, description='Use unified memory')
libsndfile/package.py:21:    variant('external-libs',
libxsmm/package.py:60:    variant('header-only', default=False,
llvm-amdgpu/package.py:35:    variant('rocm-device-libs', default=True, description='Build ROCm device libs as external LLVM project instead of a standalone spack package.')
meme/package.py:25:    variant('image-magick', default=False, description='Enable image-magick for png output')
mfem/package.py:120:    variant('superlu-dist', default=False,
mfem/package.py:124:    variant('suite-sparse', default=False,
mofem-cephas/package.py:35:    variant('adol-c', default=True, description='Compile with ADOL-C')
mono/package.py:22:    variant('patch-folder-path', default=False,
nalu-wind/package.py:50:    variant('wind-utils', default=False,
ncep-post/package.py:20:    variant('wrf-io', default=True, description='Enable WRF I/O.')
netcdf-c/package.py:62:    variant('parallel-netcdf', default=False,
netlib-lapack/package.py:37:    variant('external-blas', default=False,
neuron/package.py:29:    variant("cross-compile", default=False, description="Build for cross-compile environment")
neuron/package.py:31:    variant("legacy-unit",   default=False, description="Enable legacy units")
opencv/package.py:85:    variant('fast-math', default=False,
openfast/package.py:30:    variant('double-precision', default=True,
openfast/package.py:32:    variant('dll-interface', default=True,
openmpi/package.py:232:    variant('wrapper-rpath', default=True,
openmpi/package.py:259:    variant('internal-hwloc', default=False, description='Use internal hwloc')
opium/package.py:18:    variant('external-lapack', default=False,
petsc/package.py:106:    variant('superlu-dist', default=True,
petsc/package.py:114:    variant('mkl-pardiso', default=False,
petsc/package.py:123:    variant('suite-sparse', default=False,
pism/package.py:34:    variant('parallel-netcdf4', default=False,
pism/package.py:36:    variant('parallel-netcdf3', default=False,
pism/package.py:38:    variant('parallel-hdf5', default=False,
planck-likelihood/package.py:19:    variant('lensing-ext', default=False,
planck-likelihood/package.py:21:    variant('plik-DS', default=False,
planck-likelihood/package.py:23:    variant('plik-HM-ext', default=False,
planck-likelihood/package.py:25:    variant('plik-unbinned', default=False,
povray/package.py:37:    variant('io-restrictions', default=True,
powerapi/package.py:20:    variant('gnu-ld', default=False, description='Assume GNU compiled uses gnu-ld')
py-datalad/package.py:25:    variant('downloaders-extra', default=False, description="Enable extra downloaders support")
py-datalad/package.py:28:    variant('metadata-extra', default=False, description="Enable extra metadata support")
py-xgboost/package.py:25:    variant('scikit-learn', default=False, description='Enable scikit-learn extensions for training.')
r/package.py:58:    variant('external-lapack', default=False,
relion/package.py:35:    variant('double-gpu', default=False, description="double precision gpu")
rpm/package.py:33:    variant('berkeley-db', values=('full', 'readonly', 'none'), default='none',
sollve/package.py:35:    variant('compiler-rt', default=True,
sos/package.py:23:    variant('shr-atomics', default=False, description='Enable shared memory atomic operations')
specfem3d-globe/package.py:23:    variant('double-precision', default=False,
sundials/package.py:89:    variant('superlu-mt',   default=False,
sundials/package.py:91:    variant('superlu-dist', default=False,
sundials/package.py:111:    variant('examples-install', default=True,
sundials/package.py:115:    variant('generic-math', default=True,
tfel/package.py:97:    variant('diana-fea', default=True,
trilinos/package.py:103:    variant('suite-sparse', default=False,
trilinos/package.py:105:    variant('superlu-dist', default=False,
ucx/package.py:73:    variant('mlx5-dv', default=False,
ucx/package.py:75:    variant('ib-hw-tm', default=False,
unifyfs/package.py:26:    variant('auto-mount', default='True', description='Enable automatic mount/unmount in MPI_Init/Finalize')
virtuoso/package.py:20:    variant('dbpedia-vad', default=False, description='DBpedia vad package')
virtuoso/package.py:21:    variant('demo-vad', default=False, description='Demo vad package')
virtuoso/package.py:22:    variant('fct-vad', default=True, description='Facet Browser vad package')
virtuoso/package.py:23:    variant('ods-vad', default=True, description='ODS vad package')
virtuoso/package.py:24:    variant('sparqldemo-vad', default=False, description='Sparql Demo vad package')
virtuoso/package.py:25:    variant('tutorial-vad', default=False, description='Tutorial vad package')
virtuoso/package.py:26:    variant('isparql-vad', default=True, description='iSPARQL vad package')
virtuoso/package.py:27:    variant('rdfmappers-vad', default=True, description='RDF Mappers vad package')
xpmem/package.py:36:    variant('kernel-module', default=True,
xsdk/package.py:32:    variant('omega-h', default=True, description='Enable omega-h package build')
zsh/package.py:28:    variant('skip-tcsetpgrp-test', default=True,
```