### PR TITLE
py-setuptools-rust: remove checksum url workaround (issue 24668)

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools-rust/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-rust/package.py
@@ -13,11 +13,10 @@ class PySetuptoolsRust(PythonPackage):
     pypi = "setuptools-rust/setuptools-rust-0.12.1.tar.gz"
 
     version('0.12.1', sha256='647009e924f0ae439c7f3e0141a184a69ad247ecb9044c511dabde232d3d570e')
+
     # Version 0.10.6 is not available on pypi and can only be found on github
     version('0.10.6', sha256='1446d3985e4aaf4cc679fda8a48a73ac1390b627c8ae1bebe7d9e08bb3b33769',
-            # version specific url is not used here because spack checksum would
-            # use it instead of pypi (see #24668)
-            # url="https://github.com/PyO3/setuptools-rust/archive/v0.10.6.tar.gz",
+            url="https://github.com/PyO3/setuptools-rust/archive/v0.10.6.tar.gz",
             deprecated=True)
 
     depends_on('python@3.6:', when='@0.12:', type=('build', 'run'))
@@ -27,11 +26,3 @@ class PySetuptoolsRust(PythonPackage):
     depends_on('py-semantic-version@2.6.0:', type=('build', 'run'))
     depends_on('py-toml@0.9.0:', type=('build', 'run'))
     depends_on('rust', type='run')
-
-    # when #24668 is fixed remove url_for_version and use url= (see above) for
-    # version 0.10.6
-    def url_for_version(self, version):
-        if version >= Version('0.12.0'):
-            return 'https://files.pythonhosted.org/packages/source/s/setuptools-rust/setuptools-rust-{0}.tar.gz'.format(version)
-        else:
-            return 'https://github.com/PyO3/setuptools-rust/archive/v{0}.tar.gz'.format(version)


### PR DESCRIPTION
Depends on #25831 

This PR removes the url-related workaround reported in https://github.com/spack/spack/issues/24668.  

@manuelakuhn 

With #25831 and this change, `spack checksum` has the following output, which produces the correct `sha256` for 0.10.6:

```
$ spack checksum py-setuptools-rust 
==> Found 40 versions of py-setuptools-rust:
  
  0.12.1    https://files.pythonhosted.org/packages/source/s/setuptools-rust/setuptools-rust-0.12.1.tar.gz
  0.12.0    https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.12.0.tar.gz
  0.11.6    https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.6.tar.gz
  0.11.5    https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.5.tar.gz
  0.11.4    https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.4.tar.gz
  0.11.3    https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.3.tar.gz
  0.11.2b0  https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.2b0.tar.gz
  0.11.2    https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.2.tar.gz
  0.11.1    https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.1.tar.gz
  ...
  0.1       https://files.pythonhosted.org/packages/33/97/1af5de73a08cc7f384e2a5a63b70633df8d5b9066e1bcdd7c015da63a979/setuptools-rust-0.1.tar.gz#sha256=58dc0ac6bd78513a9441b1a8af59515690e71b3bd6f33683f2cf4e8490fa831b

==> How many would you like to checksum? (default is 1, q to abort) 20
==> Fetching https://files.pythonhosted.org/packages/source/s/setuptools-rust/setuptools-rust-0.12.1.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.12.0.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.6.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.5.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.4.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.3.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.2b0.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.2.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.1.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/refs/tags/v0.11.0.tar.gz
==> Fetching https://github.com/PyO3/setuptools-rust/archive/v0.10.6.tar.gz
==> Fetching https://files.pythonhosted.org/packages/3a/f3/30a9422214aeec4ca6cf4fea7d0099cd2cb3d57e4e69928cd8a5844335a5/setuptools-rust-0.10.3.tar.gz#sha256=ef596edebe2d075cd76e40e8c1f18ac54f14b93dbccef48cbf91d584372b4907
==> Fetching https://files.pythonhosted.org/packages/cd/1c/d5823f99fe35801be1683d4266ae4ffb5656eb66fcf0ef56c733b3575ec4/setuptools-rust-0.10.2.tar.gz#sha256=2effd86c48b6ea5a559ab92d45ce6cea38fabb3780e2acd7dd0e39b034f220e2
==> Fetching https://files.pythonhosted.org/packages/5f/f2/4d8bbf1d4ceb77868457c7dcaed3db5aab4a16ea337266c2ddfdbedd5164/setuptools-rust-0.10.1.tar.gz#sha256=a42dd46780e921d960cb71d992668111c2859a352a10619e4a56c979f83050bb
==> Fetching https://files.pythonhosted.org/packages/08/f2/121f76114140169ca353055b42f69055ea33a258712de7e8f4ebe95a42a0/setuptools-rust-0.10.0.tar.gz#sha256=f165e32b3737c53ad313a266e49e01b7ae57a97a9b203aeee067f1908f8e421a
==> Fetching https://files.pythonhosted.org/packages/2f/76/ae238a9c9dd46a200ce59d28ad8112845fb66a1ae52432c198f5fa755763/setuptools-rust-0.9.2.tar.gz#sha256=3a7de7653bcc73a8dd6ee3d6abcf43fc8a44f50a05e5187cdefe49d3e07f22ad
==> Fetching https://files.pythonhosted.org/packages/20/69/506ec1da0d7bbed74ea49865bdd460f7df97dff062fab8e7a68291ea7935/setuptools-rust-0.9.1.tar.gz#sha256=edb2adc4afe3a6737bdb5db7a4837b794de3ad90a119d059fe3a0e81c0244021
==> Fetching https://files.pythonhosted.org/packages/f7/7b/6ee009926e7d7c5ad570ac13884f6fd0dce70ed6d99efcef14b986e097e2/setuptools-rust-0.9.0.tar.gz#sha256=897ad8db7988e4850156546e1e6d792cf0ffffa08ff354b61940da7519f119f6
==> Fetching https://files.pythonhosted.org/packages/35/35/ca9137afe3a02b43011cd35adc95edde4b8c3fc910a9cc3eff7b82285c4f/setuptools-rust-0.8.4.tar.gz#sha256=79775699da34fdb4cc003457f757d6bd0655230bbce16cd85ad104b630eb0d65
==> Fetching https://files.pythonhosted.org/packages/e6/fd/deb8e33096d79b617b0973c537bfacccd4182115a441fee231e67eed84e3/setuptools-rust-0.8.3.tar.gz#sha256=877e56be751508eb8f696d9f3dc4c75de5185e9405558d57a6c4c4f826523119

    version('0.12.1',   sha256='647009e924f0ae439c7f3e0141a184a69ad247ecb9044c511dabde232d3d570e')
    version('0.12.0',   sha256='84a8e7a56093a68a40fd37e9061c28696e59261107bf86790a01273a6af981a6')
    version('0.11.6',   sha256='0c22494070035f43b8b1578dc28d247e3efaeea401fd67b7d062ebc5ce800786')
    version('0.11.5',   sha256='fb1207dc9bc29cc950888121d3eccd44fab6f580dd129ddeaaf0a6845b0e96b2')
    version('0.11.4',   sha256='6eb525a109966593e0846532014fbd82f6bcfc46124b8eb42f9dde4e1f6a3e3b')
    version('0.11.3',   sha256='fb5d751115ef906de7e3296ef5c0cba3775342adf83af69bcbf223eb0cc12e0e')
    version('0.11.2b0', sha256='42ab713fa127e9649344e4d6450610f264cecfce6260be1941dbaceaaef1a756')
    version('0.11.2',   sha256='e03d70c48860ea8e384e582bb66f15c53e8d56a842d6e8bb30b5a249911de5ad')
    version('0.11.1',   sha256='dabeb412baaa06d9f94d2f89fea8140676ca26030c036ad256edd26f2a5b87ba')
    version('0.11.0',   sha256='f3eb4af4cdacc5c019e893e2a4e6e43d4e3b146df8c08010735de97dc5e2dacf')
    version('0.10.6',   sha256='1446d3985e4aaf4cc679fda8a48a73ac1390b627c8ae1bebe7d9e08bb3b33769')
    version('0.10.3',   sha256='ef596edebe2d075cd76e40e8c1f18ac54f14b93dbccef48cbf91d584372b4907')
    version('0.10.2',   sha256='2effd86c48b6ea5a559ab92d45ce6cea38fabb3780e2acd7dd0e39b034f220e2')
    version('0.10.1',   sha256='a42dd46780e921d960cb71d992668111c2859a352a10619e4a56c979f83050bb')
    version('0.10.0',   sha256='f165e32b3737c53ad313a266e49e01b7ae57a97a9b203aeee067f1908f8e421a')
    version('0.9.2',    sha256='3a7de7653bcc73a8dd6ee3d6abcf43fc8a44f50a05e5187cdefe49d3e07f22ad')
    version('0.9.1',    sha256='edb2adc4afe3a6737bdb5db7a4837b794de3ad90a119d059fe3a0e81c0244021')
    version('0.9.0',    sha256='897ad8db7988e4850156546e1e6d792cf0ffffa08ff354b61940da7519f119f6')
    version('0.8.4',    sha256='79775699da34fdb4cc003457f757d6bd0655230bbce16cd85ad104b630eb0d65')
    version('0.8.3',    sha256='877e56be751508eb8f696d9f3dc4c75de5185e9405558d57a6c4c4f826523119')
```