### PR TITLE
Pipelines: build kokkos-kernels on bigger instance

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -348,6 +348,7 @@ spack:
         - cuda
         - dyninst
         - hpx
+        - kokkos-kernels
         - llvm
         - llvm-amdgpu
         - precice


### PR DESCRIPTION
This package recently failed with `g++: internal compiler error: Killed (program cc1plus)` on a `c5.2xlarge` (a runner that can get used when we supply the tags: [`spack`, `public`, `large`, `x86_64`]).  This PR causes `kokkos-kernels` to be built on a more capable runner by swapping the `xlarge` tag for the previous `large`.  This will result in getting built on `c5.4xlarge` instead, assuming a cloud runner is used.