### PR TITLE
Add new package gnuconfig

### DIFF
--- a/var/spack/repos/builtin/packages/gnuconfig/package.py
+++ b/var/spack/repos/builtin/packages/gnuconfig/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Gnuconfig(Package):
+    """
+    The GNU config.guess and config.sub scripts versioned by timestamp.
+    This package can be used as a build dependency for autotools packages that
+    ship a tarball with outdated config.guess and config.sub files.
+    """
+
+    homepage = "https://www.gnu.org/software/config/"
+    url      = "https://github.com/haampie/config/archive/refs/tags/2021-08-14.tar.gz"
+
+    maintainers = ['haampie']
+
+    version('2021-08-14', sha256='1d1134f2f9d5f1342693793a536643c9aa11eaf672d1bf453ce2a415fdb8ebcc')
+
+    def install(self, spec, prefix):
+        with working_dir(self.stage.source_path):
+            install('config.sub', prefix)
+            install('config.guess', prefix)


### PR DESCRIPTION
There is no official tarball for config.guess and config.sub files, they are rather somewhat of a rolling release here:

https://git.savannah.gnu.org/cgit/config.git

However, they are versioned by a timestamp: https://git.savannah.gnu.org/cgit/config.git/tree/config.guess#n7.

So I've just mirrored the gnu repo to https://github.com/haampie/config and added the latest timestamp as a tag, so that we can simply download a tarball and install config files as `<prefix>/share/config.{sub,guess}`. Now the idea is to add this in the future as build dependency to autotools packages that ship a tarball with outdated config files, so that we can simply replace them with the files from this package. If for some reason one really needs the system versions of these config files, the package can simply be marked external. This allows us to drop the hard-coded system path `/usr/share` in

https://github.com/spack/spack/blob/f9314d38b0bec2df16e58312fad0cbb01fad7696/lib/spack/spack/build_systems/autotools.py#L154
