### PR TITLE
py-torchmetrics: add v0.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchmetrics/package.py
+++ b/var/spack/repos/builtin/packages/py-torchmetrics/package.py
@@ -12,6 +12,7 @@ class PyTorchmetrics(PythonPackage):
     homepage = "https://github.com/PyTorchLightning/metrics"
     pypi     = "torchmetrics/torchmetrics-0.3.1.tar.gz"
 
+    version('0.5.1', sha256='22fbcb6fc05348ca3f2bd06e0763e88411a6b68c2b9fc26084b39d40cc4021b0')
     version('0.4.1', sha256='2fc50f812210c33b8c2649dbb1482e3c47e93cae33e4b3d0427fb830384effbd')
     version('0.3.1', sha256='78f4057db53f7c219fdf9ec9eed151adad18dd43488a44e5c780806d218e3f1d')
     version('0.2.0', sha256='481a28759acd2d77cc088acba6bc7dc4a356c7cb767da2e1495e91e612e2d548')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.