### PR TITLE
Use gnuconfig package for config file replacement

### DIFF
--- a/var/spack/repos/builtin.mock/packages/gnuconfig/package.py
+++ b/var/spack/repos/builtin.mock/packages/gnuconfig/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Gnuconfig(Package):
+    """
+    The GNU config.guess and config.sub scripts versioned by timestamp.
+    This package can be used as a build dependency for autotools packages that
+    ship a tarball with outdated config.guess and config.sub files.
+    """
+
+    has_code = False
+
+    version('2021-08-14')
+
+    def install(self, spec, prefix):
+        touch(join_path(prefix, 'config.sub'))
+        touch(join_path(prefix, 'config.guess'))


### PR DESCRIPTION
Closes #25784 

Currently the autotools build system tries to pick up config.sub and
config.guess files from the system (in /usr/share) on arm and power.
This is introduces an implicit system dependency which we can avoid by
distributing config.guess and config.sub files in a separate package,
such as the new `gnuconfig` package which is very lightweight/text only
(unlike automake where we previously pulled these files from as a
backup). This PR adds `gnuconfig` as an unconditional build dependency
for arm and power archs.

In case the user needs a system version of config.sub and config.guess,
they are free to mark `gnuconfig` as an external package with the prefix
pointing to the directory containing the config files:

```yaml
    gnuconfig:
      externals:
      - spec: gnuconfig@master
        prefix: /usr/somewhere/config/files
      buildable: false
```

Apart from that, this PR gives some better instructions for users when
replacing config files goes wrong.
