### PR TITLE
support patching on win via git

### DIFF
--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -36,7 +36,7 @@ def apply_patch(stage, patch_path, level=1, working_dir='.'):
     if os.name == 'nt':
         git = which_string('git', required=True)
         git_root = os.path.dirname(git).split('/')[:-1]
-        git_root.extend(['usr','bin'])
+        git_root.extend(['usr', 'bin'])
         git_utils_path = os.sep.join(git_root)
 
     patch = which("patch", required=True, path=git_utils_path)

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -19,7 +19,7 @@ import spack.stage
 import spack.util.spack_json as sjson
 from spack.util.compression import allowed_archive
 from spack.util.crypto import Checker, checksum
-from spack.util.executable import which
+from spack.util.executable import which, which_string
 
 
 def apply_patch(stage, patch_path, level=1, working_dir='.'):
@@ -32,7 +32,14 @@ def apply_patch(stage, patch_path, level=1, working_dir='.'):
         working_dir (str): relative path *within* the stage to change to
             (default '.')
     """
-    patch = which("patch", required=True)
+    git_utils_path = os.environ.get('PATH', '')
+    if os.name == 'nt':
+        git = which_string('git', required=True)
+        git_root = os.path.dirname(git).split('/')[:-1]
+        git_root.extend(['usr','bin'])
+        git_utils_path = os.sep.join(git_root)
+
+    patch = which("patch", required=True, path=git_utils_path)
     with llnl.util.filesystem.working_dir(stage.source_path):
         patch('-s',
               '-p', str(level),


### PR DESCRIPTION
This PR operates under the impression that Git is available on the Windows system. GNU32 Patch was considered but requires elevated permissions to run.