### PR TITLE
Log4cxx 0.12.0 only as CMake package

### DIFF
--- a/var/spack/repos/builtin/packages/log4cxx/package.py
+++ b/var/spack/repos/builtin/packages/log4cxx/package.py
@@ -12,6 +12,8 @@ class Log4cxx(CMakePackage):
     homepage = "https://logging.apache.org/log4cxx/latest_stable/"
     url      = "https://dlcdn.apache.org/logging/log4cxx/0.12.0/apache-log4cxx-0.12.0.tar.gz"
 
+    maintainers = ['nicmcd']
+
     version('0.12.0', sha256='bd5b5009ca914c8fa7944b92ea6b4ca6fb7d146f65d526f21bf8b3c6a0520e44')
 
     depends_on('cmake@3.13:', type='build')

--- a/var/spack/repos/builtin/packages/log4cxx/package.py
+++ b/var/spack/repos/builtin/packages/log4cxx/package.py
@@ -6,25 +6,20 @@
 from spack import *
 
 
-class Log4cxx(AutotoolsPackage):
+class Log4cxx(CMakePackage):
     """A C++ port of Log4j"""
 
     homepage = "https://logging.apache.org/log4cxx/latest_stable/"
-    url      = "http://mirror.netcologne.de/apache.org/logging/log4cxx/0.10.0/apache-log4cxx-0.10.0.tar.gz"
+    url      = "https://dlcdn.apache.org/logging/log4cxx/0.12.0/apache-log4cxx-0.12.0.tar.gz"
 
-    version('0.10.0', sha256='0de0396220a9566a580166e66b39674cb40efd2176f52ad2c65486c99c920c8c')
+    version('0.12.0', sha256='bd5b5009ca914c8fa7944b92ea6b4ca6fb7d146f65d526f21bf8b3c6a0520e44')
+
+    depends_on('cmake@3.13:', type='build')
 
     depends_on('apr-util')
     depends_on('apr')
+    depends_on('zlib')
     depends_on('zip')
 
-    build_directory = 'spack-build'
-
-    # patches from https://aur.archlinux.org/packages/log4cxx/
-    patch('log4cxx-0.10.0-missing_includes.patch')
-    patch('log4cxx-0.10.0-narrowing-fixes-from-upstream.patch')
-
-    def configure_args(self):
-        args = ['--disable-static']
-
-        return args
+    def cmake_args(self):
+        return [self.define('BUILD_TESTING', 'off')]


### PR DESCRIPTION
This commit removes all prior versions of log4cxx since log4cxx has moved to now using CMake instead of autotools as of 0.12.0. If prior versions of log4cxx are still desired, I suggest a Log4cxxLegacy package be defined. Please let me know if you want it added to this PR.

There is only a single known spack package that depends on log4cxx and it is libsakura and it does NOT specify a version.