### PR TITLE
Stand-alone tests: distinguish NO-TESTS from PASSED

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2643,7 +2643,7 @@ def test_process(pkg, kwargs):
                     # Skip any test methods consisting solely of 'pass'
                     # since they do not contribute to package testing.
                     source = (inspect.getsource(test_fn)).split('\n')[1:]
-                    lines = [ln.strip() for ln in source]
+                    lines = (ln.strip() for ln in source)
                     statements = [ln for ln in lines if not ln.startswith('#')]
                     if len(statements) > 0 and statements[0] == 'pass':
                         continue

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2642,7 +2642,7 @@ def test_process(pkg, kwargs):
 
                     # Skip any test methods consisting solely of 'pass'
                     # since they do not contribute to package testing.
-                    source = (inspect.getsource(test_fn)).split('\n')[1:]
+                    source = (inspect.getsource(test_fn)).splitlines()[1:]
                     lines = (ln.strip() for ln in source)
                     statements = [ln for ln in lines if not ln.startswith('#')]
                     if len(statements) > 0 and statements[0] == 'pass':

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1785,12 +1785,14 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         # Clear test failures
         self.test_failures = []
         self.test_log_file = self.test_suite.log_file_for_spec(self.spec)
+        self.tested_file = self.test_suite.tested_file_for_spec(self.spec)
         fsys.touch(self.test_log_file)  # Otherwise log_parse complains
 
         kwargs = {'dirty': dirty, 'fake': False, 'context': 'test'}
         spack.build_environment.start_build_process(self, test_process, kwargs)
 
     def test(self):
+        # Defer tests to virtual and concrete packages
         pass
 
     def run_test(self, exe, options=[], expected=[], status=0,
@@ -2603,6 +2605,7 @@ def test_process(pkg, kwargs):
         test_specs = [pkg.spec] + [spack.spec.Spec(v_name)
                                    for v_name in sorted(v_names)]
 
+        ran_actual_test_function = False
         try:
             with fsys.working_dir(
                     pkg.test_suite.test_dir_for_spec(pkg.spec)):
@@ -2637,7 +2640,16 @@ def test_process(pkg, kwargs):
                     if not isinstance(test_fn, types.FunctionType):
                         test_fn = test_fn.__func__
 
+                    # Skip any test methods consisting solely of 'pass'
+                    # since they do not contribute to package testing.
+                    source = (inspect.getsource(test_fn)).split('\n')[1:]
+                    lines = [ln.strip() for ln in source]
+                    statements = [ln for ln in lines if not ln.startswith('#')]
+                    if len(statements) > 0 and statements[0] == 'pass':
+                        continue
+
                     # Run the tests
+                    ran_actual_test_function = True
                     test_fn(pkg)
 
             # If fail-fast was on, we error out above
@@ -2648,6 +2660,11 @@ def test_process(pkg, kwargs):
         finally:
             # reset debug level
             tty.set_debug(old_debug)
+
+            # flag the package as having been tested (i.e., ran one or more
+            # non-pass-only methods
+            if ran_actual_test_function:
+                fsys.touch(pkg.tested_file)
 
 
 inject_flags = PackageBase.inject_flags


### PR DESCRIPTION
This PR makes a distinction between packages that that do not have tests -- with test status reported as `NO-TESTS` -- from those that `PASSED`.

This is an initial distinction based on the lack or presence of *at least one* non-`pass`-only test method associated with the package.  In addition to implementing their own `test` method, packages can "inherit" them the virtual interfaces they provide (e.g., `mpi`).

 By checking for non-`pass`-only methods, packages that don't override the `test` method inherited from `PackageBase` and don't provide interfaces with `test` methods are reported as `NO-TESTS`.
 
This PR does not make any attempt to distinguish status based on the contents or actions of package-provided tests as there are a couple of approaches to be considered that could be taken to handle things like `skipped` tests , especially given that the tests are run from forked or spawned child processes.

Examples of test result output:

```
$ spack test results
==> Results for test suite 'cmppcmurnkm2qqddqosnolmhuji45a5b':
==>   umpire-1.1.0-i43hck4 PASSED
==>   umpire-2.0.0-2xjsztl PASSED
==>   umpire-2.0.0-svz25qg PASSED
==>   umpire-4.1.2-2b3i7cy PASSED
==>   umpire-5.0.1-6ohwphk PASSED
==>   umpire-develop-6wfdlow FAILED
==>   zlib-1.2.11-s4yfeca NO-TESTS
==>   zlib-1.2.11-c7zv5ft NO-TESTS
==>   zlib-1.2.11-kzsxhof NO-TESTS
```

and, for a class that currently only 'inherits' its tests:
```
$ spack test results
==> Results for test suite '62yrvhufhdktw2euwxmh7apqnxk6xkuj':
==>   mpich-3.4.2-2bnxajb PASSED
$ spack test results -l
==> Results for test suite '62yrvhufhdktw2euwxmh7apqnxk6xkuj':
==>   mpich-3.4.2-2bnxajb PASSED
==> Testing package mpich-3.4.2-2bnxajb
==> [2021-09-09-17:47:54.416046] test: mpicc: expect command status in [0]
==> [2021-09-09-17:47:54.416294] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-skylake_avx512/gcc-8.3.1/mpich-3.4.2-2bnxajb37bdwrmeju6j2ococuzwyk6va/bin/mpicc' '-o' 'mpi_hello_c' '/g/g21/dahlgren/.spack/test/62yrvhufhdktw2euwxmh7apqnxk6xkuj/mpich-3.4.2-2bnxajb/data/mpi/mpi_hello.c'
PASSED
==> [2021-09-09-17:47:54.539348] test: mpirun: expect command status in [0]
==> [2021-09-09-17:47:54.539692] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-skylake_avx512/gcc-8.3.1/mpich-3.4.2-2bnxajb37bdwrmeju6j2ococuzwyk6va/bin/mpirun' '-np' '1' 'mpi_hello_c'
Hello world! From rank 0 of 1
PASSED
==> [2021-09-09-17:47:54.789795] test: mpif90: expect command status in [0]
==> [2021-09-09-17:47:54.790151] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-skylake_avx512/gcc-8.3.1/mpich-3.4.2-2bnxajb37bdwrmeju6j2ococuzwyk6va/bin/mpif90' '-o' 'mpi_hello_f' '/g/g21/dahlgren/.spack/test/62yrvhufhdktw2euwxmh7apqnxk6xkuj/mpich-3.4.2-2bnxajb/data/mpi/mpi_hello.f'
PASSED
==> [2021-09-09-17:47:54.892304] test: mpirun: expect command status in [0]
==> [2021-09-09-17:47:54.892656] '/usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-skylake_avx512/gcc-8.3.1/mpich-3.4.2-2bnxajb37bdwrmeju6j2ococuzwyk6va/bin/mpirun' '-np' '1' 'mpi_hello_f'
 Hello world! From rank           0 of            1
PASSED
```