### PR TITLE
SQLite: make variants discoverable

### DIFF
--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -91,11 +91,9 @@ class Sqlite(AutotoolsPackage):
     def determine_variants(cls, exes, version_str):
         all_variants = []
 
-        def call(exe, feature, query):
-            prefix = 'spack-sqlite-{:s}-'.format(feature)
-            with NamedTemporaryFile(mode='w', prefix=prefix) as sqlite_stdin:
+        def call(exe, query):
+            with NamedTemporaryFile(mode='w', buffering=1) as sqlite_stdin:
                 sqlite_stdin.write(query + '\n')
-                sqlite_stdin.flush()
                 e = Executable(exe)
                 e(fail_on_error=False,
                   input=sqlite_stdin.name,
@@ -115,19 +113,19 @@ class Sqlite(AutotoolsPackage):
                 return 'CREATE VIRTUAL TABLE name ' \
                        'USING fts{:d}(sender, title, body);'.format(version)
 
-            rc_fts4 = call(exe, 'fts4', query_fts(4))
-            rc_fts5 = call(exe, 'fts5', query_fts(5))
+            rc_fts4 = call(exe, query_fts(4))
+            rc_fts5 = call(exe, query_fts(5))
             variants.append(get_variant('fts', rc_fts4 == 0 and rc_fts5 == 0))
 
             # check for functions
             # SQL query taken from extension-functions.c usage instructions
             query_functions = "SELECT load_extension('libsqlitefunctions');"
-            rc_functions = call(exe, 'functions', query_functions)
+            rc_functions = call(exe, query_functions)
             variants.append(get_variant('functions', rc_functions == 0))
 
             # check for rtree
             query_rtree = 'CREATE VIRTUAL TABLE name USING rtree(id, x, y);'
-            rc_rtree = call(exe, 'rtree', query_rtree)
+            rc_rtree = call(exe, query_rtree)
             variants.append(get_variant('rtree', rc_rtree == 0))
 
             # TODO: column_metadata

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import re
 from tempfile import NamedTemporaryFile
 
@@ -98,8 +99,8 @@ class Sqlite(AutotoolsPackage):
                 e = Executable(exe)
                 e(fail_on_error=False,
                   input=sqlite_stdin.name,
-                  output='/dev/null',
-                  error='/dev/null')
+                  output=os.devnull,
+                  error=os.devnull)
             return e.returncode
 
         def get_variant(name, has_variant):

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -130,22 +130,7 @@ class Sqlite(AutotoolsPackage):
             rc_rtree = call(exe, 'rtree', query_rtree)
             variants.append(get_variant('rtree', rc_rtree == 0))
 
-            # The column metadata feature enables six additional functions in
-            # the C API, see SQLITE_ENABLE_COLUMN_METADATA at
-            # https://www.sqlite.org/compile.html. Usually one would have to
-            # check the SQLite library to determine if this feature is enabled.
-            # Spack only examines executables but due to a quirk of the SQLite
-            # setup, it can still be possible to extract this information:
-            # By default, the `sqlite` executable is linked _statically_
-            # against the SQLite library and by default, the GNU linker does
-            # not remove unused symbols from binaries. Thus, one could check
-            # for this feature by looking at the list of external defined
-            # symbols in the `sqlite` executable (e.g., with `nm`).
-            # The original author of the `determine_variants` function decided
-            # not to implement this because on CentOS 7, Centos 8, Devuan
-            # Beowulf, and Ubuntu 20.04, the `sqlite` executable has been
-            # stripped so the implementation will probably be useless most of
-            # the time.
+            # TODO: column_metadata
 
             all_variants.append(''.join(variants))
 


### PR DESCRIPTION
The setup can detect all variants except for `column_metadata`.