### PR TITLE
paraview: patch for version 5.9.1 with gcc 11.1.0 

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -172,6 +172,9 @@ class Paraview(CMakePackage, CudaPackage):
     # Broken downstream FindMPI
     patch('vtkm-findmpi-downstream.patch', when='@5.9.0')
 
+    # Include limits header wherever needed to fix compilation with GCC 11
+    patch('paraview-gcc11-limits.patch', when='@5.9.1 %gcc@11.1.0:')
+   
     def url_for_version(self, version):
         _urlfmt  = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.{3}'
         """Handle ParaView version-based custom URLs."""

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -174,7 +174,7 @@ class Paraview(CMakePackage, CudaPackage):
 
     # Include limits header wherever needed to fix compilation with GCC 11
     patch('paraview-gcc11-limits.patch', when='@5.9.1 %gcc@11.1.0:')
-   
+
     def url_for_version(self, version):
         _urlfmt  = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.{3}'
         """Handle ParaView version-based custom URLs."""

--- a/var/spack/repos/builtin/packages/paraview/paraview-gcc11-limits.patch
+++ b/var/spack/repos/builtin/packages/paraview/paraview-gcc11-limits.patch
@@ -1,0 +1,49 @@
+Index: ParaView-v5.9.1/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h
+===================================================================
+--- ParaView-v5.9.1.orig/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h
++++ ParaView-v5.9.1/VTK/Common/Core/vtkGenericDataArrayLookupHelper.h
+@@ -25,6 +25,7 @@
+ #include "vtkIdList.h"
+ #include <algorithm>
+ #include <cmath>
++#include <limits>
+ #include <unordered_map>
+ #include <vector>
+ 
+Index: ParaView-v5.9.1/VTK/Rendering/Core/vtkColorTransferFunction.cxx
+===================================================================
+--- ParaView-v5.9.1.orig/VTK/Rendering/Core/vtkColorTransferFunction.cxx
++++ ParaView-v5.9.1/VTK/Rendering/Core/vtkColorTransferFunction.cxx
+@@ -21,6 +21,7 @@
+ #include <algorithm>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+Index: ParaView-v5.9.1/VTK/Common/DataModel/vtkPiecewiseFunction.cxx
+===================================================================
+--- ParaView-v5.9.1.orig/VTK/Common/DataModel/vtkPiecewiseFunction.cxx
++++ ParaView-v5.9.1/VTK/Common/DataModel/vtkPiecewiseFunction.cxx
+@@ -22,6 +22,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+Index: ParaView-v5.9.1/VTK/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+===================================================================
+--- ParaView-v5.9.1.orig/VTK/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
++++ ParaView-v5.9.1/VTK/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+@@ -27,6 +27,7 @@
+ #include "vtkHyperTreeGridNonOrientedCursor.h"
+ 
+ #include <cmath>
++#include <limits>
+ 
+ vtkStandardNewMacro(vtkHyperTreeGridThreshold);
+ 
+


### PR DESCRIPTION
Add paraview-gcc11-limits.patch: Include limits header wherever needed to fix compilation with GCC 11.
#25687
https://gitlab.kitware.com/vtk/vtk/-/issues/18194
