### PR TITLE
spack: Allow smooth transition period between v5 and v6 db

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -26,6 +26,12 @@ def misc_cache_location():
     path = spack.config.get('config:misc_cache')
     if not path:
         path = os.path.join(spack.paths.user_config_path, 'cache')
+    # The current format of the misc_cache isn't forwards-compatbile with
+    # the misc_cache of spack versions before the Version 6 database format.
+    # For a smooth transition period, don't replace the previous caches to
+    # avoid errors like this from the solver/provided_index when switching
+    # to pre-v6 commits: AttributeError: 'str' object has no attribute 'get'
+    path = os.path.join(path, 'v6')
     path = spack.util.path.canonicalize_path(path)
     return path
 


### PR DESCRIPTION
*Update - see below for a full quite - Massimiliano wrote*:
> What puzzles me is that up to this PR there was a 1:1 mapping from the store to the DB. Here the store is a superset of the DB.

My answer:
Cool, thanks! This made it clear to me that there seems to be (in my understanding) another feature which might currently not work as I expected:

At least from reading the pull request messages around #22845, it's commit message and the comments in it, I understood that an intent of it was to have a "read-only" compatibility with the old `spec.yaml` files.

So I guess, the implementation should have been that the new code should read `spec.yaml` as well as `spec.json` formats from the .spack subdirectory of installed packages in `{install_tree:root(default: $spack/opt/spack)}/projections:all (default: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}")/.spack/`

But it seems a reindex without the presence of the old specs.json apparently misses to properly add the old installed specs which only have `spec.yaml` files to the new database (independent of how the db file is named).

----

#### The Story wihch is implemented so far:

Sometimes, it might be needed to (temporarily) checkout older spack revisions. It would be nice to allow switching between of v5 and v6 database code (including misc_cache):

#### Database handling

In case a developer checks out an old branch or commit, this error is shown by spack:
```py
==> Error: Expected database version 5 but found version 6.
`spack reindex` may fix this, or you may need a newer Spack version.
```
As @haampie reported in  #25872, `spack reindex` itself also throws the same error:
```py
$ spack reindex 
==> Error: Expected database version 5 but found version 6.
`spack reindex` may fix this, or you may need a newer Spack version.
```

The only way to reindex the db in this case is to remove the database file and let spack recreate it:
```sh
rm opt/spack/.spack-db/index.json
```
This fast without noticeable delay (at least with a local SSD as storage).

#### This PR takes advantage of this by:
* Using `opt/spack/.spack-db/iindex-v6.json` for the version 6 database.
* When **writing** a *v6* db(when packages are removed/installed), it removes old v5 `index.json file`, so in case a v5 spack is used gain, it will automatically reindex.

##### Coexistence of misc_cache versions

What's also needed to make this work is to not overwrite the v5 misc_cache files, otherwise `"'str' object has no attribute 'get'"` is triggered in the provider_index. Put the v6 misc_cache into it's own subdirectory.
#### Summary
These changes allow to switch back and forth between git revisions using v5 databasse and misc_cache and those after the intro of v6. The only caveat is:

The v5 reindex code will not find packages built by new spack, but it is possible to work on the older spack versions and build packages:

The apparent cause for this might be that currently, spack reindex without the presence of the old `index.json` apparently misses to include the old installed specs which only have `spec.yaml` files into the new database (independent of how the db file is named).