### PR TITLE
Fix error message when test throws AttributeError

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2551,11 +2551,12 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         for name in self.build_time_test_callbacks:
             try:
                 fn = getattr(self, name)
-                tty.msg('RUN-TESTS: build-time tests [{0}]'.format(name))
-                fn()
             except AttributeError:
                 msg = 'RUN-TESTS: method not implemented [{0}]'
                 tty.warn(msg.format(name))
+            else:
+                tty.msg('RUN-TESTS: build-time tests [{0}]'.format(name))
+                fn()
 
     @on_package_attributes(run_tests=True)
     def _run_default_install_time_test_callbacks(self):
@@ -2570,11 +2571,12 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         for name in self.install_time_test_callbacks:
             try:
                 fn = getattr(self, name)
-                tty.msg('RUN-TESTS: install-time tests [{0}]'.format(name))
-                fn()
             except AttributeError:
                 msg = 'RUN-TESTS: method not implemented [{0}]'
                 tty.warn(msg.format(name))
+            else:
+                tty.msg('RUN-TESTS: install-time tests [{0}]'.format(name))
+                fn()
 
 
 def test_process(pkg, kwargs):


### PR DESCRIPTION
This change narrows the scope of the try/except block used for checking if a package implements build- or install-time tests, to avoid a misleading error message if the test function throws an AttributeError.

The original error message told me that the check method wasn't implemented, but the problem was actually that I had an error within my check method. As someone new to spack (and thus who makes lots of mistakes) this was confusing, as it was the same error message that I had been seeing before I found the correct name for the test method.

I hope this change is useful. There were a few failures in the style and unit tests, but those appear to have also existed on the develop branch.