### PR TITLE
dihydrogen: add missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -70,6 +70,7 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
     # Add Aluminum variants
     depends_on('aluminum +cuda +nccl +cuda_rma', when='+al +cuda')
     depends_on('aluminum +rocm +rccl', when='+al +rocm')
+    depends_on('aluminum +ht', when='+al +distconv')
 
     for arch in CudaPackage.cuda_arch_values:
         depends_on('aluminum cuda_arch=%s' % arch, when='+al +cuda cuda_arch=%s' % arch)


### PR DESCRIPTION
When DiHydrogen has distconv enabled, it needs Aluminum to have HostTransfer capability