### PR TITLE
Bugfix: spack test debug requires Spack tty

### DIFF
--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -8,9 +8,9 @@ import os
 import re
 import shutil
 import sys
-import tty
 
 import llnl.util.filesystem as fs
+import llnl.util.tty as tty
 
 import spack.error
 import spack.util.prefix


### PR DESCRIPTION
The incorrect `tty` module was being used by `spack test results` will trigger the following error:

```
==> Error: module 'tty' has no attribute 'debug'
```

without this fix possibly as a result of the merge of #22845 .