### PR TITLE
sundials: alter hypre dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -175,6 +175,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('lapack',              when='+lapack')
     depends_on('suite-sparse',        when='+klu')
     depends_on('petsc+mpi',           when='+petsc')
+    depends_on('hypre+mpi',           when='@5.7.1: +hypre')
     depends_on('hypre@:2.22.0+mpi',   when='@:5.7.0 +hypre')
     depends_on('superlu-dist@6.1.1:', when='@:5.4.0 +superlu-dist')
     depends_on('superlu-dist@6.3.0:', when='@5.5.0: +superlu-dist')
@@ -185,6 +186,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('petsc+double~complex', when='+petsc precision=double')
 
     # Require that external libraries built with the same index type
+    depends_on('hypre~int64', when='@5.7.1: +hypre ~int64')
+    depends_on('hypre+int64', when='@5.7.1: +hypre +int64')
     depends_on('hypre@:2.22.0~int64', when='@:5.7.0 +hypre ~int64')
     depends_on('hypre@:2.22.0+int64', when='@:5.7.0 +hypre +int64')
     depends_on('petsc~int64', when='+petsc ~int64')

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -175,7 +175,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('lapack',              when='+lapack')
     depends_on('suite-sparse',        when='+klu')
     depends_on('petsc+mpi',           when='+petsc')
-    depends_on('hypre+mpi',           when='+hypre')
+    depends_on('hypre@:2.22.0+mpi',   when='@:5.7.0 +hypre')
     depends_on('superlu-dist@6.1.1:', when='@:5.4.0 +superlu-dist')
     depends_on('superlu-dist@6.3.0:', when='@5.5.0: +superlu-dist')
     depends_on('trilinos+tpetra',     when='+trilinos')
@@ -185,8 +185,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('petsc+double~complex', when='+petsc precision=double')
 
     # Require that external libraries built with the same index type
-    depends_on('hypre~int64', when='+hypre ~int64')
-    depends_on('hypre+int64', when='+hypre +int64')
+    depends_on('hypre@:2.22.0~int64', when='@:5.7.0 +hypre ~int64')
+    depends_on('hypre@:2.22.0+int64', when='@:5.7.0 +hypre +int64')
     depends_on('petsc~int64', when='+petsc ~int64')
     depends_on('petsc+int64', when='+petsc +int64')
     depends_on('superlu-dist+int64', when='+superlu-dist +int64')

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -172,24 +172,22 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('raja+rocm', when='+raja +rocm')
 
     # External libraries
-    depends_on('lapack',              when='+lapack')
-    depends_on('suite-sparse',        when='+klu')
-    depends_on('petsc+mpi',           when='+petsc')
-    depends_on('hypre+mpi',           when='@5.7.1: +hypre')
-    depends_on('hypre@:2.22.0+mpi',   when='@:5.7.0 +hypre')
-    depends_on('superlu-dist@6.1.1:', when='@:5.4.0 +superlu-dist')
-    depends_on('superlu-dist@6.3.0:', when='@5.5.0: +superlu-dist')
-    depends_on('trilinos+tpetra',     when='+trilinos')
+    depends_on('lapack',                  when='+lapack')
+    depends_on('suite-sparse',            when='+klu')
+    depends_on('petsc+mpi',               when='+petsc')
+    depends_on('hypre+mpi~int64',         when='@5.7.1: +hypre ~int64')
+    depends_on('hypre+mpi+int64',         when='@5.7.1: +hypre +int64')
+    depends_on('hypre@:2.22.0+mpi~int64', when='@:5.7.0 +hypre ~int64')
+    depends_on('hypre@:2.22.0+mpi+int64', when='@:5.7.0 +hypre +int64')
+    depends_on('superlu-dist@6.1.1:',     when='@:5.4.0 +superlu-dist')
+    depends_on('superlu-dist@6.3.0:',     when='@5.5.0: +superlu-dist')
+    depends_on('trilinos+tpetra',         when='+trilinos')
 
     # Require that external libraries built with the same precision
     depends_on('petsc~double~complex', when='+petsc precision=single')
     depends_on('petsc+double~complex', when='+petsc precision=double')
 
     # Require that external libraries built with the same index type
-    depends_on('hypre~int64', when='@5.7.1: +hypre ~int64')
-    depends_on('hypre+int64', when='@5.7.1: +hypre +int64')
-    depends_on('hypre@:2.22.0~int64', when='@:5.7.0 +hypre ~int64')
-    depends_on('hypre@:2.22.0+int64', when='@:5.7.0 +hypre +int64')
     depends_on('petsc~int64', when='+petsc ~int64')
     depends_on('petsc+int64', when='+petsc +int64')
     depends_on('superlu-dist+int64', when='+superlu-dist +int64')


### PR DESCRIPTION
Like for MFEM and PETSc as found out by @balay, package sundials breaks with Hypre 2.22.1.
This PR is to correct that for sundials. It is the sister PR to https://github.com/spack/spack/pull/25902.
It may interest @scheibelp as well.