### PR TITLE
kokkos: fail gracefully on missing microarch

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -656,7 +656,7 @@ class Trilinos(CMakePackage, CudaPackage):
         # ################# Kokkos ######################
 
         if '+kokkos' in spec:
-            arch = Kokkos.spack_micro_arch_map.get(spec.target.name, None)
+            arch = Kokkos.get_microarch(spec.target)
             if arch:
                 options.append(define("Kokkos_ARCH_" + arch.upper(), True))
 


### PR DESCRIPTION
Fall back on known parent microarches (as determined by spack's built-in archspec knowledge). Closes spack/spack#25907 .