### PR TITLE
Pipelines: (Re)enable E4S on Power stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -136,27 +136,27 @@ e4s-develop-build:
   variables:
     SPACK_CI_STACK_NAME: e4s-on-power
 
-# e4s-on-power-pr-generate:
-#   extends: [ ".e4s-on-power", ".pr-generate", ".power-e4s-generate-tags-and-image"]
+e4s-on-power-pr-generate:
+  extends: [ ".e4s-on-power", ".pr-generate", ".power-e4s-generate-tags-and-image"]
 
-# e4s-on-power-develop-generate:
-#   extends: [ ".e4s-on-power", ".develop-generate", ".power-e4s-generate-tags-and-image"]
+e4s-on-power-develop-generate:
+  extends: [ ".e4s-on-power", ".develop-generate", ".power-e4s-generate-tags-and-image"]
 
-# e4s-on-power-pr-build:
-#   extends: [ ".e4s-on-power", ".pr-build" ]
-#   trigger:
-#     include:
-#       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-#         job: e4s-on-power-pr-generate
-#     strategy: depend
+e4s-on-power-pr-build:
+  extends: [ ".e4s-on-power", ".pr-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: e4s-on-power-pr-generate
+    strategy: depend
 
-# e4s-on-power-develop-build:
-#   extends: [ ".e4s-on-power", ".develop-build" ]
-#   trigger:
-#     include:
-#       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
-#         job: e4s-on-power-develop-generate
-#     strategy: depend
+e4s-on-power-develop-build:
+  extends: [ ".e4s-on-power", ".develop-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: e4s-on-power-develop-generate
+    strategy: depend
 
 #########################################
 # Build tests for different build-systems

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -181,7 +181,7 @@ spack:
   - cuda_specs:
     - amrex +cuda cuda_arch=70
     - caliper +cuda cuda_arch=70
-    - chai +cuda ~benchmarks ~tests cuda_arch=70 ^umpire@4.1.2 ~shared
+    - chai +cuda ~benchmarks ~tests cuda_arch=70 ^umpire~shared+cuda
     - ginkgo +cuda cuda_arch=70
     - hpx +cuda cuda_arch=70
     - kokkos +cuda +wrapper cuda_arch=70
@@ -209,11 +209,11 @@ spack:
     - archer
     - argobots
     - ascent
-    - axom ^umpire@4.1.2
+    - axom ^umpire@5.0.1 ^raja@0.13.0
     - bolt
     - cabana
     - caliper
-    - chai ~benchmarks ~tests ^umpire@4.1.2
+    - chai ~benchmarks ~tests
     - charliecloud
     - conduit
     - darshan-runtime


### PR DESCRIPTION
Now that the power runners are back online, we can re-enable these builds.

Since this stack was commented out, some changes (#25528) happened to the E4S `x86_64` stack.  This PR makes the same changes to the power stack.