### PR TITLE
Add buildcache find subcommand, update tests

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -25,7 +25,7 @@ import spack.store
 import spack.util.crypto
 import spack.util.url as url_util
 import spack.util.web as web_util
-from spack.cmd import display_specs
+from spack.cmd import display_specs, display_specs_as_json
 from spack.error import SpecError
 from spack.spec import Spec, save_dependency_specfiles
 from spack.stage import Stage

--- a/lib/spack/spack/test/cmd/buildcache.py
+++ b/lib/spack/spack/test/cmd/buildcache.py
@@ -59,23 +59,23 @@ def test_buildcache_preview_just_runs(database):
 
 @pytest.mark.db
 @pytest.mark.regression('13757')
-def test_buildcache_list_duplicates(mock_get_specs, capsys):
+def test_buildcache_find_duplicates(mock_get_specs, capsys):
     with capsys.disabled():
-        output = buildcache('list', 'mpileaks', '@2.3')
+        output = buildcache('find', 'mpileaks', '@2.3')
 
     assert output.count('mpileaks') == 3
 
 
 @pytest.mark.db
 @pytest.mark.regression('17827')
-def test_buildcache_list_allarch(database, mock_get_specs_multiarch, capsys):
+def test_buildcache_find_allarch(database, mock_get_specs_multiarch, capsys):
     with capsys.disabled():
-        output = buildcache('list', '--allarch')
+        output = buildcache('find', '--allarch')
 
     assert output.count('mpileaks') == 3
 
     with capsys.disabled():
-        output = buildcache('list')
+        output = buildcache('find')
 
     assert output.count('mpileaks') == 2
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -491,7 +491,7 @@ _spack_buildcache() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="create install list keys preview check download get-buildcache-name save-specfile copy sync update-index"
+        SPACK_COMPREPLY="create install find list keys preview check download get-buildcache-name save-specfile copy sync update-index"
     fi
 }
 
@@ -513,10 +513,19 @@ _spack_buildcache_install() {
     fi
 }
 
+_spack_buildcache_find() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -v --variants -a --allarch --json"
+    else
+        _all_packages
+    fi
+}
+
 _spack_buildcache_list() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -v --variants -a --allarch"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -v --variants -a --allarch --json"
     else
         _all_packages
     fi


### PR DESCRIPTION
Update bash completion for buildcache command.

The buildcache list subcommand behaves more like the find spack command,
so the command was renamed to `find`, and `list` was kept. This should
be marked as deprecated somehow.

This was discussed in the spack sync call.