### PR TITLE
updating spack monitor to support new spec

### DIFF
--- a/lib/spack/spack/monitor.py
+++ b/lib/spack/spack/monitor.py
@@ -385,7 +385,9 @@ class SpackMonitorClient:
             # Not sure if this is needed here, but I see it elsewhere
             if spec.name in spack.repo.path or spec.virtual:
                 spec.concretize()
-            as_dict = {"spec": spec.to_dict(hash=ht.full_hash),
+
+            # Remove extra level of nesting
+            as_dict = {"spec": spec.to_dict(hash=ht.full_hash)['spec'],
                        "spack_version": self.spack_version}
 
             if self.save_local:


### PR DESCRIPTION
This PR coincides with tiny changes to spack to support spack monitor using the new spec. The corresponding spack monitor PR is at https://github.com/spack/spack-monitor/pull/31. Since there are no changes to the database we can actually update the current server fairly easily, so either someone can test locally or we can just update and then test from that (and update as needed).

Signed-off-by: vsoch <vsoch@users.noreply.github.com>