### PR TITLE
Ignore Modules v5 environment variables in `from_sourcing_file`

### DIFF
--- a/lib/spack/spack/test/environment_modifications.py
+++ b/lib/spack/spack/test/environment_modifications.py
@@ -397,6 +397,12 @@ def test_sanitize_literals(env, blacklist, whitelist):
     ({'A_modquar': '1', 'b_modquar': '2', 'C_modshare': '3'},
      [r'(\w*)_mod(quar|share)'], [], [],
      ['A_modquar', 'b_modquar', 'C_modshare']),
+    # Check regex to blacklist Modules v5 related vars
+    ({'__MODULES_LMALTNAME': '1', '__MODULES_LMCONFLICT': '2'},
+     ['__MODULES_(.*)'], [], [], ['__MODULES_LMALTNAME', '__MODULES_LMCONFLICT']),
+    ({'__MODULES_QUAR_A': '1', '__MODULES_QUAR_b': '2', '__MODULES_SHARE_C': '3'},
+     [r'__MODULES_(QUAR|SHARE)_(\w*)'], [], [],
+     ['__MODULES_QUAR_A', '__MODULES_QUAR_b', '__MODULES_SHARE_C']),
 ])
 def test_sanitize_regex(env, blacklist, whitelist, expected, deleted):
 


### PR DESCRIPTION
Update list of excluded variables with Modules-specific environment
variables that have been renamed from v4 to v5:

* `MODULES_LM*` > `__MODULES_LM*`
* `*_modquar` > `__MODULES_QUAR_*`
* `*_modshare` > `__MODULES_SHARE_*`

Maybe the change proposed here could be done differently. Do not hesitate to improve it. My goal here is mainly to indicate that the Modules-specific variables described in this `environment_modifications.py` file have been renamed on Modules v5.