### PR TITLE
evtgen: fix mac build and version 2.0.0 with pythia >= 8.304.

### DIFF
--- a/var/spack/repos/builtin/packages/evtgen/evtgen-2.0.0.patch
+++ b/var/spack/repos/builtin/packages/evtgen/evtgen-2.0.0.patch
@@ -1,0 +1,39 @@
+--- a/src/EvtGenExternal/EvtPythiaEngine.cpp.orig	2020-04-24 18:27:48.000000000 +0200
++++ b/src/EvtGenExternal/EvtPythiaEngine.cpp	2021-04-14 09:17:55.660743600 +0200
+@@ -36,7 +36,13 @@
+ 
+ #include <cmath>
+ #include <iostream>
+-#include <sstream>
++#include <sstream>  
++
++#if PYTHIA_VERSION_INTEGER < 8304
++typedef Pythia8::ParticleDataEntry* ParticleDataEntryPtr;
++#else
++typedef Pythia8::ParticleDataEntryPtr ParticleDataEntryPtr;
++#endif
+ 
+ using std::endl;
+ 
+@@ -430,9 +436,9 @@
+         // or assignment will give it a different memory address and it will no longer refer to
+         // the original particleData information from the generator pointer.
+ 
+-        Pythia8::ParticleDataEntry* entry_generic =
++        ParticleDataEntryPtr entry_generic =
+             _genericPythiaGen->particleData.particleDataEntryPtr( PDGCode );
+-        Pythia8::ParticleDataEntry* entry_alias =
++        ParticleDataEntryPtr entry_alias =
+             _aliasPythiaGen->particleData.particleDataEntryPtr( PDGCode );
+ 
+         // Check that the PDG code is not zero/null and exclude other
+--- a/EvtGenBase/EvtMatrix.hh.orig	2021-04-13 23:20:29.588804900 +0200
++++ b/EvtGenBase/EvtMatrix.hh	2021-04-13 23:20:36.663547400 +0200
+@@ -23,6 +23,7 @@
+ 
+ #include <sstream>
+ #include <vector>
++#include <cmath>
+ 
+ template <class T>
+ class EvtMatrix {

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -27,7 +27,7 @@ class Evtgen(CMakePackage):
     variant('hepmc3', default=False, description='Link with hepmc3 (instead of hepmc)')
 
     patch("g2c.patch", when='@01.07.00')
-    patch("evtgen-2.0.0.patch", when='@02.00.00')
+    patch("evtgen-2.0.0.patch", when='@02.00.00 ^pythia@8.304:')
 
     depends_on('hepmc', when='~hepmc3')
     depends_on('hepmc3', when='+hepmc3')

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -54,11 +54,11 @@ class Evtgen(CMakePackage):
         args.append(self.define_from_variant('EVTGEN_HEPMC3', 'hepmc3'))
 
         return args
-        
+
     def patch(self):
         if not self.spec.satisfies("platform=darwin"):
             return
-        
+
         filter_file('-shared', '-dynamiclib -undefined dynamic_lookup', 'make.inc')
 
     # Taken from AutotoolsPackage

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -27,6 +27,7 @@ class Evtgen(CMakePackage):
     variant('hepmc3', default=False, description='Link with hepmc3 (instead of hepmc)')
 
     patch("g2c.patch", when='@01.07.00')
+    patch("evtgen-2.0.0.patch", when='@02.00.00')
 
     depends_on('hepmc', when='~hepmc3')
     depends_on('hepmc3', when='+hepmc3')
@@ -53,6 +54,12 @@ class Evtgen(CMakePackage):
         args.append(self.define_from_variant('EVTGEN_HEPMC3', 'hepmc3'))
 
         return args
+        
+    def patch(self):
+        if not self.spec.satisfies("platform=darwin"):
+            return
+        
+        filter_file('-shared', '-dynamiclib -undefined dynamic_lookup', 'make.inc')
 
     # Taken from AutotoolsPackage
     def configure(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -56,7 +56,7 @@ class Evtgen(CMakePackage):
         return args
 
     def patch(self):
-        # gcc on MacOS doesn't recognize `-shared`, should use `-dynamiclib`; 
+        # gcc on MacOS doesn't recognize `-shared`, should use `-dynamiclib`;
         # the `-undefined dynamic_lookup` flag enables weak linking on Mac
         # Patch taken from CMS recipe:
         # https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_12_1_X/master/evtgen.spec#L48

--- a/var/spack/repos/builtin/packages/evtgen/package.py
+++ b/var/spack/repos/builtin/packages/evtgen/package.py
@@ -56,6 +56,10 @@ class Evtgen(CMakePackage):
         return args
 
     def patch(self):
+        # gcc on MacOS doesn't recognize `-shared`, should use `-dynamiclib`; 
+        # the `-undefined dynamic_lookup` flag enables weak linking on Mac
+        # Patch taken from CMS recipe:
+        # https://github.com/cms-sw/cmsdist/blob/IB/CMSSW_12_1_X/master/evtgen.spec#L48
         if not self.spec.satisfies("platform=darwin"):
             return
 


### PR DESCRIPTION
The patch is backwards-compatible. Also fix MacOS build.