### PR TITLE
trilinos: Add missing mumps TPL commands

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -555,6 +555,7 @@ class Trilinos(CMakePackage, CudaPackage):
             ('LAPACK', 'lapack'),
             ('Matio', 'matio'),
             ('METIS', 'metis'),
+            ('MUMPS', 'mumps'),
             ('Netcdf', 'netcdf-c'),
             ('SCALAPACK', 'scalapack'),
             ('SuperLU', 'superlu'),


### PR DESCRIPTION
Seems MUMPS got forgotten in the updated configure