### PR TITLE
Apply backported fixes to GCC@4.9.3

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -262,7 +262,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         patch('darwin/gcc-4.9.patch2', when='@4.9.0:4.9.3')
 
     patch('piclibs.patch', when='+piclibs')
-    patch('gcc-backport.patch', when='@4.7:4.9.2,5:5.3')
+    patch('gcc-backport.patch', when='@4.7:4.9.3,5:5.3')
 
     # Backport libsanitizer patch for glibc >= 2.31 and 5.3.0 <= gcc <= 9.2.0
     # https://bugs.gentoo.org/708346


### PR DESCRIPTION
This was erroneously changed in #2259 

Looking at one of the files that should be patched, you can see the fix in the patch is missing from GCC 4.9.3, but is applied to GCC 4.9.4

- https://github.com/gcc-mirror/gcc/blob/releases/gcc-4.9.3/gcc/cp/cfns.h
- https://github.com/gcc-mirror/gcc/blob/releases/gcc-4.9.4/gcc/cp/cfns.h