### PR TITLE
source-highlight: allow to build the git master branch

### DIFF
--- a/var/spack/repos/builtin/packages/source-highlight/package.py
+++ b/var/spack/repos/builtin/packages/source-highlight/package.py
@@ -14,7 +14,7 @@ class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = "https://www.gnu.org/software/src-highlite/"
     gnu_mirror_path = "src-highlite/source-highlight-3.1.8.tar.gz"
-    git = "https://git.savannah.gnu.org/git/src-highlite.git"
+    git = "https://git.savannah.gnu.org/cgit/src-highlite.git"
 
     version('master',  branch='master')
     version('3.1.9', sha256='3a7fd28378cb5416f8de2c9e77196ec915145d44e30ff4e0ee8beb3fe6211c91')

--- a/var/spack/repos/builtin/packages/source-highlight/package.py
+++ b/var/spack/repos/builtin/packages/source-highlight/package.py
@@ -14,11 +14,20 @@ class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = "https://www.gnu.org/software/src-highlite/"
     gnu_mirror_path = "src-highlite/source-highlight-3.1.8.tar.gz"
+    git = "https://git.savannah.gnu.org/git/src-highlite.git"
 
+    version('master',  branch='master')
     version('3.1.9', sha256='3a7fd28378cb5416f8de2c9e77196ec915145d44e30ff4e0ee8beb3fe6211c91')
     version('3.1.8', sha256='01336a7ea1d1ccc374201f7b81ffa94d0aecb33afc7d6903ebf9fbf33a55ada3')
 
     depends_on('boost')
+
+    # git version needs autotools
+    depends_on('m4', when='@master')
+    depends_on('autoconf', when='@master')
+    depends_on('automake', when='@master')
+    depends_on('libtool', when='@master')
+    depends_on('texinfo', when='@master')
 
     def configure_args(self):
         args = ["--with-boost={0}".format(self.spec['boost'].prefix)]


### PR DESCRIPTION
Allow to build the source-highlight from git.
The git master branch contains a patch to make it compile with GCC 11.