### PR TITLE
workaround a cmake/rocm bug in heffte

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -90,6 +90,10 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
             if 'none' not in rocm_arch:
                 args.append('-DCMAKE_CXX_FLAGS={0}'.format(self.hip_flags(rocm_arch)))
 
+            # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
+            if self.spec.satisfies('^cmake@3.21:'):
+                args.append(self.define('__skip_rocmclang', 'ON'))
+
         return args
 
     @run_after('install')


### PR DESCRIPTION
* CMake 3.21 and newer do not respect the `hipcc` compiler selection, see https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322 and https://gitlab.kitware.com/cmake/cmake/-/issues/22460