### PR TITLE
added workaround for rocm/cmake bug in tasmanian

### DIFF
--- a/var/spack/repos/builtin/packages/tasmanian/package.py
+++ b/var/spack/repos/builtin/packages/tasmanian/package.py
@@ -140,6 +140,10 @@ class Tasmanian(CMakePackage, CudaPackage, ROCmPackage):
             args.append('-DPYTHON_EXECUTABLE:FILEPATH={0}'.format(
                 self.spec['python'].command.path))
 
+        # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
+        if self.spec.satisfies('+rocm') and self.spec.satisfies('^cmake@3.21:'):
+            args.append(self.define('__skip_rocmclang', 'ON'))
+
         # _CUBLAS and _CUDA were separate options prior to 6.0
         # skipping _CUBLAS leads to peformance regression
         if spec.satisfies('@:5.1'):


### PR DESCRIPTION
* CMake 3.21 and newer do not respect the `hipcc` compiler selection, see https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322 and https://gitlab.kitware.com/cmake/cmake/-/issues/22460