### PR TITLE
Bugfix: Don't pop an empty version string_arg

### DIFF
--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -614,3 +614,16 @@ def test_empty_version_range_raises():
         assert VersionRange('2', '1.0')
     with pytest.raises(ValueError):
         assert ver('2:1.0')
+
+
+def test_version_empty_slice():
+    """Check an empty slice to confirm not getting IndexError (#25953)."""
+    with pytest.raises(ValueError):
+        Version('1.')[1:]
+
+
+def test_version_wrong_idx_type():
+    """Ensure exception raised if attempt to use non-integer index."""
+    v = Version('1.1')
+    with pytest.raises(TypeError):
+        v['0:']

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -617,9 +617,10 @@ def test_empty_version_range_raises():
 
 
 def test_version_empty_slice():
-    """Check an empty slice to confirm not getting IndexError (#25953)."""
-    with pytest.raises(ValueError):
-        Version('1.')[1:]
+    """Check an empty slice to confirm get "empty" version instead of
+       an IndexError (#25953).
+    """
+    assert Version('1.')[1:] == Version('')
 
 
 def test_version_wrong_idx_type():

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -177,7 +177,7 @@ class Version(object):
         string = string.strip()
         self.string = string
 
-        if not VALID_VERSION.match(string):
+        if string and not VALID_VERSION.match(string):
             raise ValueError("Bad characters in version string: %s" % string)
 
         # An object that can lookup git commits to compare them to versions
@@ -352,7 +352,7 @@ class Version(object):
                 string_arg = ''.join(string_arg)
                 return cls(string_arg)
             else:
-                return None
+                return Version('')
 
         message = '{cls.__name__} indices must be integers'
         raise TypeError(message.format(cls=cls))

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -347,9 +347,12 @@ class Version(object):
                 string_arg.append(str(token))
                 string_arg.append(str(sep))
 
-            string_arg.pop()  # We don't need the last separator
-            string_arg = ''.join(string_arg)
-            return cls(string_arg)
+            if string_arg:
+                string_arg.pop()  # We don't need the last separator
+                string_arg = ''.join(string_arg)
+                return cls(string_arg)
+            else:
+                return None
 
         message = '{cls.__name__} indices must be integers'
         raise TypeError(message.format(cls=cls))


### PR DESCRIPTION
This PR prevents an `IndexError: pop from empty list` in `version.py`, thereby allowing processing to proceed. (Note that this PR does NOT address the fetch issue in the  `cudnn` package that occurs after version processing.)

Motivation:
There was an issue reported in the packaging slack channel that I could reproduce with the following:

```
$ spack -d install cudnn@7.1
...
  File "/usr/WS1/dahlgren/releases/spack/var/spack/repos/builtin/packages/cudnn/package.py", line 222, in url_for_version
    elif version >= Version('7.0'):
  File "/usr/WS1/dahlgren/releases/spack/lib/spack/spack/version.py", line 304, in __getitem__
    string_arg.pop()  # We don't need the last separator
IndexError: pop from empty list
```

The install process proceeds with the fix BUT does not complete successfully but as follows:

```
$ spack install cudnn@7.1
==> Warning: gcc@8.3.1 cannot build optimized binaries for "cascadelake". Using best target possible: "skylake_avx512"
==> Warning: Missing a source id for cudnn@7.1
==> Installing cudnn-7.1-mcpbvxsum7p2g3nk2fudvov3pywpzmo6
==> No binary for cudnn-7.1-mcpbvxsum7p2g3nk2fudvov3pywpzmo6 found: installing from source
==> Warning: There is no checksum on file to fetch cudnn@7.1 safely.
==>   Fetch anyway? [y/N] y
==> Error: FetchError: All fetchers failed

/usr/WS1/dahlgren/releases/spack/lib/spack/spack/package.py:1376, in do_fetch:
       1373
       1374        self.stage.create()
       1375        err_msg = None if not self.manual_download else self.download_instr
  >>   1376        start_time = time.time()
       1377        self.stage.fetch(mirror_only, err_msg=err_msg)
       1378        self._fetch_time = time.time() - start_time
       1379
```