### PR TITLE
bedops: Fix checksum for 2.4.40

### DIFF
--- a/var/spack/repos/builtin/packages/bedops/package.py
+++ b/var/spack/repos/builtin/packages/bedops/package.py
@@ -15,7 +15,7 @@ class Bedops(MakefilePackage):
     homepage = "https://bedops.readthedocs.io"
     url      = "https://github.com/bedops/bedops/archive/v2.4.39.tar.gz"
 
-    version('2.4.40', sha256='0670f9ce2da4b68ab13f82c023c84509c7fce5aeb5df980c385fac76eabed4fb')
+    version('2.4.40', sha256='8c01db76669dc58c595e2e1b9bdb6d462f3363fc569b15c460a63a63b8b6bf30')
     version('2.4.39', sha256='f8bae10c6e1ccfb873be13446c67fc3a54658515fb5071663883f788fc0e4912')
     version('2.4.35', sha256='da0265cf55ef5094834318f1ea4763d7a3ce52a6900e74f532dd7d3088c191fa')
     version('2.4.34', sha256='533a62a403130c048d3378e6a975b73ea88d156d4869556a6b6f58d90c52ed95')


### PR DESCRIPTION
Fixes #25951

```bash
$ spack checksum bedops
==> Found 10 versions of bedops:
  
  2.4.40  https://github.com/bedops/bedops/archive/refs/tags/v2.4.40.tar.gz
  2.4.39  https://github.com/bedops/bedops/archive/refs/tags/v2.4.39.tar.gz
  2.4.38  https://github.com/bedops/bedops/archive/refs/tags/v2.4.38.tar.gz
  2.4.37  https://github.com/bedops/bedops/archive/refs/tags/v2.4.37.tar.gz
  2.4.36  https://github.com/bedops/bedops/archive/refs/tags/v2.4.36.tar.gz
  2.4.35  https://github.com/bedops/bedops/archive/refs/tags/v2.4.35.tar.gz
  2.4.34  https://github.com/bedops/bedops/archive/refs/tags/v2.4.34.tar.gz
  2.4.33  https://github.com/bedops/bedops/archive/refs/tags/v2.4.33.tar.gz
  2.4.32  https://github.com/bedops/bedops/archive/refs/tags/v2.4.32.tar.gz
  2.4.31  https://github.com/bedops/bedops/archive/refs/tags/v2.4.31.tar.gz

==> How many would you like to checksum? (default is 1, q to abort) 1
==> Fetching https://github.com/bedops/bedops/archive/refs/tags/v2.4.40.tar.gz

    version('2.4.40', sha256='8c01db76669dc58c595e2e1b9bdb6d462f3363fc569b15c460a63a63b8b6bf30')
```