### PR TITLE
Add a deprecation warning when using the old concretizer

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -82,6 +82,7 @@ import operator
 import os
 import re
 import sys
+import warnings
 
 import ruamel.yaml as yaml
 import six
@@ -2398,6 +2399,13 @@ class Spec(object):
         normalize() for more details on this.
         """
         import spack.concretize
+
+        # Add a warning message to inform users that the original concretizer
+        # will be removed in v0.18.0
+        msg = ('the original concretizer is currently being used.\n\tUpgrade to '
+               '"clingo" at your earliest convenience. The original concretizer '
+               'will be removed from Spack starting at v0.18.0')
+        warnings.warn(msg)
 
         if not self.name:
             raise spack.error.SpecError(


### PR DESCRIPTION
This PR just adds a deprecation warning telling users that the original concretizer will be removed from Spack v0.18.0.

The output is the following:
```console
$ spack spec zlib
Input spec
--------------------------------
zlib

Concretized
--------------------------------
==> Warning: the original concretizer is currently being used.
	Upgrade to "clingo" at your earliest convenience. The original concretizer will be removed from Spack starting at v0.18.0
zlib@1.2.11%gcc@11.2.0+optimize+pic+shared arch=linux-ubuntu20.04-icelake

$ spack install zlib
==> Warning: the original concretizer is currently being used.
	Upgrade to "clingo" at your earliest convenience. The original concretizer will be removed from Spack starting at v0.18.0
==> Installing zlib-1.2.11-h7tvzacqculnkfs44qyfaizurnqsfvdr
==> No binary for zlib-1.2.11-h7tvzacqculnkfs44qyfaizurnqsfvdr found: installing from source
==> Using cached archive: /home/culpo/PycharmProjects/spack/var/spack/cache/_source-cache/archive/c3/c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1.tar.gz
==> No patches needed for zlib
==> zlib: Executing phase: 'install'
==> zlib: Successfully installed zlib-1.2.11-h7tvzacqculnkfs44qyfaizurnqsfvdr
  Fetch: 0.00s.  Build: 1.88s.  Total: 1.88s.
[+] /home/culpo/PycharmProjects/spack/opt/spack/linux-ubuntu20.04-icelake/gcc-11.2.0/zlib-1.2.11-h7tvzacqculnkfs44qyfaizurnqsfvdr
```