### PR TITLE
fmt: add "shared" variant

### DIFF
--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -35,7 +35,7 @@ class Fmt(CMakePackage):
             values=('98', '11', '14', '17'),
             multi=False,
             description='Use the specified C++ standard when building')
-    variant('pic', default=True, description='Enable generation of position-independent code')
+    variant('shared', default=False, description='Build shared library')
 
     depends_on('cmake@3.1.0:', type='build')
 
@@ -63,11 +63,8 @@ class Fmt(CMakePackage):
         spec = self.spec
         args = []
 
-        if '+pic' in spec:
-            args.extend([
-                '-DCMAKE_C_FLAGS={0}'.format(self.compiler.cc_pic_flag),
-                '-DCMAKE_CXX_FLAGS={0}'.format(self.compiler.cxx_pic_flag)
-            ])
+        if self.spec.satisfies('+shared'):
+            args.append('BUILD_SHARED_LIBS=ON")
 
         args.append('-DCMAKE_CXX_STANDARD={0}'.format(
                     spec.variants['cxxstd'].value))

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -36,6 +36,7 @@ class Fmt(CMakePackage):
             multi=False,
             description='Use the specified C++ standard when building')
     variant('shared', default=False, description='Build shared library')
+    variant('pic', default=True, description='Build position-independent code')
 
     depends_on('cmake@3.1.0:', type='build')
 
@@ -64,7 +65,13 @@ class Fmt(CMakePackage):
         args = []
 
         if self.spec.satisfies('+shared'):
-            args.append('BUILD_SHARED_LIBS=ON')
+            args.append('-DBUILD_SHARED_LIBS=ON')
+
+        if '+pic' in spec:
+            args.extend([
+                '-DCMAKE_C_FLAGS={0}'.format(self.compiler.cc_pic_flag),
+                '-DCMAKE_CXX_FLAGS={0}'.format(self.compiler.cxx_pic_flag)
+            ])
 
         args.append('-DCMAKE_CXX_STANDARD={0}'.format(
                     spec.variants['cxxstd'].value))

--- a/var/spack/repos/builtin/packages/fmt/package.py
+++ b/var/spack/repos/builtin/packages/fmt/package.py
@@ -64,7 +64,7 @@ class Fmt(CMakePackage):
         args = []
 
         if self.spec.satisfies('+shared'):
-            args.append('BUILD_SHARED_LIBS=ON")
+            args.append('BUILD_SHARED_LIBS=ON')
 
         args.append('-DCMAKE_CXX_STANDARD={0}'.format(
                     spec.variants['cxxstd'].value))


### PR DESCRIPTION
I can keep the old variant name (`pic`) or make it an alias of sorts.