### PR TITLE
Recommend Git's manyFiles feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for examples and highlights.
 To install spack and your first package, make sure you have Python.
 Then:
 
-    $ git clone https://github.com/spack/spack.git
+    $ git clone -c feature.manyFiles=true https://github.com/spack/spack.git
     $ cd spack/bin
     $ ./spack install zlib
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -35,7 +35,7 @@ Getting Spack is easy.  You can clone it from the `github repository
 
 .. code-block:: console
 
-   $ git clone https://github.com/spack/spack.git
+   $ git clone -c feature.manyFiles=true https://github.com/spack/spack.git
 
 This will create a directory called ``spack``.
 

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -39,7 +39,7 @@ package:
 
 .. code-block:: console
 
-   $ git clone https://github.com/spack/spack.git
+   $ git clone -c feature.manyFiles=true https://github.com/spack/spack.git
    $ cd spack/bin
    $ ./spack install libelf
 


### PR DESCRIPTION
Git 2.24 introduced a feature flag for repositories with many files, see:
https://github.blog/2019-11-03-highlights-from-git-2-24/#feature-macros

Since Spack's Git repository contains roughly 8,500 files, it can be
worthwhile to enable this, especially on slow file systems such as NFS:
```
$ hyperfine --warmup 3 'cd spack-default; git status' 'cd spack-manyfiles; git status'
Benchmark #1: cd spack-default; git status
  Time (mean ± σ):      3.388 s ±  0.095 s    [User: 256.2 ms, System: 625.8 ms]
  Range (min … max):    3.168 s …  3.535 s    10 runs

Benchmark #2: cd spack-manyfiles; git status
  Time (mean ± σ):     168.7 ms ±  10.9 ms    [User: 98.6 ms, System: 126.1 ms]
  Range (min … max):   144.8 ms … 188.0 ms    19 runs

Summary
  'cd spack-manyfiles; git status' ran
   20.09 ± 1.42 times faster than 'cd spack-default; git status'
```