### PR TITLE
gosam: new version 2.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-gosam/package.py
+++ b/var/spack/repos/builtin/packages/py-gosam/package.py
@@ -11,17 +11,20 @@ class PyGosam(PythonPackage):
        one-loop amplitudes for multi-particle processes in renormalizable
        quantum field theories."""
 
-    homepage = "https://gosam.hepforge.org"
-    url      = "https://gosam.hepforge.org/downloads/?f=gosam-2.0.4-6d9f1cba.tar.gz"
+    homepage = "https://github.com/gudrunhe/gosam"
+    url      = "https://github.com/gudrunhe/gosam/archive/refs/tags/2.1.1.tar.gz"
 
     tags = ['hep']
 
-    version('2.0.4', sha256='faf621c70f66d9dffc16ac5cce66258067f39f686d722a4867eeb759fcde4f44')
+    version('2.1.1', sha256='dd562675085123bef0c145fd5532c23eecd59f0176afc56fb5c832ca1b4233a6')
+    version('2.0.4', sha256='faf621c70f66d9dffc16ac5cce66258067f39f686d722a4867eeb759fcde4f44',
+            url='https://gosam.hepforge.org/downloads/?f=gosam-2.0.4-6d9f1cba.tar.gz')
 
     depends_on('form', type='run')
     depends_on('qgraf', type='run')
     depends_on('gosam-contrib', type='link')
-    depends_on('python@2.7:2.7.99', type=('build', 'run'))
+    depends_on('python@2.7:2.7.99', type=('build', 'run'), when='@2.0.4')
+    depends_on('python@3:', type=('build', 'run'), when='@2.1.1:')
 
     def setup_run_environment(self, env):
         gosam_contrib_lib_dir = self.spec['gosam-contrib'].prefix.lib

--- a/var/spack/repos/builtin/packages/py-gosam/package.py
+++ b/var/spack/repos/builtin/packages/py-gosam/package.py
@@ -16,10 +16,10 @@ class PyGosam(PythonPackage):
 
     tags = ['hep']
 
-    version('2.1.1', tag='2.1.1', commit='4b98559')
+    version('2.1.1', tag='2.1.1', commit='4b98559212dfcb71f9d983a3a605e4693ac7f83f')
     version('2.0.4', sha256='faf621c70f66d9dffc16ac5cce66258067f39f686d722a4867eeb759fcde4f44',
             url='https://gosam.hepforge.org/downloads/?f=gosam-2.0.4-6d9f1cba.tar.gz')
-    version('2.0.3', tag='v2.0.3', commit='4146ab2')
+    version('2.0.3', tag='v2.0.3', commit='4146ab23a06b7c57c10fb36df60758d34aa58387')
 
     depends_on('form', type='run')
     depends_on('qgraf', type='run')

--- a/var/spack/repos/builtin/packages/py-gosam/package.py
+++ b/var/spack/repos/builtin/packages/py-gosam/package.py
@@ -16,14 +16,15 @@ class PyGosam(PythonPackage):
 
     tags = ['hep']
 
-    version('2.1.1', tag='2.1.1')
+    version('2.1.1', tag='2.1.1', commit='4b98559')
     version('2.0.4', sha256='faf621c70f66d9dffc16ac5cce66258067f39f686d722a4867eeb759fcde4f44',
             url='https://gosam.hepforge.org/downloads/?f=gosam-2.0.4-6d9f1cba.tar.gz')
+    version('2.0.3', tag='v2.0.3', commit='4146ab2')
 
     depends_on('form', type='run')
     depends_on('qgraf', type='run')
     depends_on('gosam-contrib', type='link')
-    depends_on('python@2.7:2.7.99', type=('build', 'run'), when='@2.0.4')
+    depends_on('python@2.7:2.7.99', type=('build', 'run'), when='@:2.0.4')
     depends_on('python@3:', type=('build', 'run'), when='@2.1.1:')
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-gosam/package.py
+++ b/var/spack/repos/builtin/packages/py-gosam/package.py
@@ -12,11 +12,11 @@ class PyGosam(PythonPackage):
        quantum field theories."""
 
     homepage = "https://github.com/gudrunhe/gosam"
-    url      = "https://github.com/gudrunhe/gosam/archive/refs/tags/2.1.1.tar.gz"
+    git      = "https://github.com/gudrunhe/gosam.git"
 
     tags = ['hep']
 
-    version('2.1.1', sha256='dd562675085123bef0c145fd5532c23eecd59f0176afc56fb5c832ca1b4233a6')
+    version('2.1.1', tag='2.1.1')
     version('2.0.4', sha256='faf621c70f66d9dffc16ac5cce66258067f39f686d722a4867eeb759fcde4f44',
             url='https://gosam.hepforge.org/downloads/?f=gosam-2.0.4-6d9f1cba.tar.gz')
 


### PR DESCRIPTION
Gosam is now python3 compatible; development moved to github (however 2.0.4 is not available on github)