### PR TITLE
Fix for - Installation issue: amdlibflame #25878

### DIFF
--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -44,7 +44,7 @@ class Amdlibflame(LibflameBase):
 
     provides('flame@5.2', when='@2:')
 
-    depends_on('python', type='build')
+    depends_on('python+pythoncmd', type='build')
 
     @property
     def lapack_libs(self):

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -44,6 +44,8 @@ class Amdlibflame(LibflameBase):
 
     provides('flame@5.2', when='@2:')
 
+    depends_on('python', type='build')
+
     @property
     def lapack_libs(self):
         """find lapack_libs function"""


### PR DESCRIPTION
Fixes #25878 

amdlibflame requires python for compiling some modules.
In spack, opensource libflame package.py already handled this with following line:
-	depends_on('python', type='build')

The above line of code is not inheritance in amdlibflame’s package.py, so adding the above line solves the issue.
Associated bug - https://github.com/spack/spack/issues/25878 
