### PR TITLE
Package magma: Fix for problem with cmake@3.21

### DIFF
--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -128,6 +128,9 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
         if '+rocm' in spec:
             options.extend(['-DMAGMA_ENABLE_HIP=ON'])
             options.extend(['-DCMAKE_CXX_COMPILER=hipcc'])
+            # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
+            if spec.satisfies('^cmake@3.21:'):
+                options.extend(['-D__skip_rocmclang=ON'])
         else:
             options.extend(['-DMAGMA_ENABLE_CUDA=ON'])
 


### PR DESCRIPTION
Workaround for https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322 which causes failure in using hipcc for magma+rocm.