### PR TITLE
cmake: allow gcc on macOS for newer versions

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -146,7 +146,10 @@ class Cmake(Package):
     variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
-    conflicts('%gcc platform=darwin', when='@:3.17')
+    conflicts('%gcc platform=darwin', when='@:3.17',
+              msg='CMake <3.18 does not compile with GCC on macOS, '
+                  'please use %apple-clang or a newer CMake release. '
+                  'See: https://gitlab.kitware.com/cmake/cmake/-/issues/21135')
     conflicts('%nvhpc')
 
     # Really this should conflict since it's enabling or disabling openssl for

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -145,12 +145,8 @@ class Cmake(Package):
     variant('openssl', default=True,  description="Enable openssl for curl bootstrapped by CMake when using +ownlibs")
     variant('ncurses', default=True,  description='Enables the build of the ncurses gui')
 
-    # Does not compile and is not covered in upstream CI (yet).
-    conflicts('%gcc platform=darwin',
-              msg='CMake does not compile with GCC on macOS yet, '
-                  'please use %apple-clang. '
-                  'See: https://gitlab.kitware.com/cmake/cmake/-/issues/21135')
-
+    # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
+    conflicts('%gcc platform=darwin', when='@:3.17')
     conflicts('%nvhpc')
 
     # Really this should conflict since it's enabling or disabling openssl for


### PR DESCRIPTION
Newer versions of CMake should work on macOS as of July 2020, see https://gitlab.kitware.com/cmake/cmake/-/issues/20620 . Closes #25983.