### PR TITLE
Add v0.935 to Angsd

### DIFF
--- a/var/spack/repos/builtin/packages/angsd/package.py
+++ b/var/spack/repos/builtin/packages/angsd/package.py
@@ -15,8 +15,9 @@ class Angsd(MakefilePackage):
     """
 
     homepage = "https://github.com/ANGSD/angsd"
-    url = "https://github.com/ANGSD/angsd/archive/0.919.tar.gz"
+    url      = "https://github.com/ANGSD/angsd/archive/0.935.tar.gz"
 
+    version('0.935', sha256='15000281330fa59ddf745cb84eeaa653acf6da34a4ac6c3df7c5835d1d01ba16')
     version('0.933', sha256='2f992325dc08fa25ac525d9300ef6bd61808e74c521b4cc72a2ce00d98f402bb')
     version('0.921', sha256='8892d279ce1804f9e17fe2fc65a47e5498e78fc1c1cb84d2ca2527fd5c198772')
     version('0.919', sha256='c2ea718ca5a5427109f4c3415e963dcb4da9afa1b856034e25c59c003d21822a')


### PR DESCRIPTION
Add v0.935 to Angsd which includes multiple bugs fixes. 

**Changelog:**
- Refactor of argument parsing system.
- Add support for VCF
- Fixed memory leak in vcf-gp reader if vcf-pl or vcf-gl was chosen.

Full changelog can be found [here](https://github.com/ANGSD/angsd/compare/0.933...0.935).

**Test Plan:**
Angsd v0.925 built successfully within the Autamus workflow [here](https://github.com/autamus/registry/pull/731/checks?check_run_id=3622152736).