### PR TITLE
Add v1.6.0 to Benchmark

### DIFF
--- a/var/spack/repos/builtin/packages/benchmark/package.py
+++ b/var/spack/repos/builtin/packages/benchmark/package.py
@@ -10,12 +10,13 @@ class Benchmark(CMakePackage):
     """A microbenchmark support library"""
 
     homepage = "https://github.com/google/benchmark"
-    url      = "https://github.com/google/benchmark/archive/v1.5.5.tar.gz"
+    url      = "https://github.com/google/benchmark/archive/v1.6.0.tar.gz"
     git      = "https://github.com/google/benchmark.git"
 
     # first properly installed CMake config packages in
     # 1.2.0 release: https://github.com/google/benchmark/issues/363
     version('develop', branch='master')
+    version('1.6.0', sha256='1f71c72ce08d2c1310011ea6436b31e39ccab8c2db94186d26657d41747c85d6')
     version('1.5.5', sha256='3bff5f237c317ddfd8d5a9b96b3eede7c0802e799db520d38ce756a2a46a18a0')
     version('1.5.4', sha256='e3adf8c98bb38a198822725c0fc6c0ae4711f16fbbf6aeb311d5ad11e5a081b5')
     version('1.5.0', sha256='3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a')


### PR DESCRIPTION
Add v1.6.0 to Benchmark which includes multiple bug fixes and new features.

**Changelog:**
- features
  - [breaking change] introduce accessorrs for public data members (google/benchmark#1208)
  - add support for percentage units in statistics (google/benchmark#1219)
  - introduce coefficient of variation aggregate (google/benchmark#1220)
  - format percentages in console reporter (google/benchmark#1221)

- bugfixes
  - fix unreachable code warning (google/benchmark#1214)
  - replace #warning with #pragma message (google/benchmark#1216)
  - report PFM as found when it is
  - update u-test value expectations due to scipy upgrade

- other stuff
  - refactored documentation to minimise README.md (google/benchmark#1211)
  - install docs when installing library (google/benchmark#1212)

**Test Plan:**
Benchmark v1.6.0 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/pull/732/checks?check_run_id=3622166455).