### PR TITLE
Add v7.0.2 to Admixtools

### DIFF
--- a/var/spack/repos/builtin/packages/admixtools/package.py
+++ b/var/spack/repos/builtin/packages/admixtools/package.py
@@ -12,15 +12,16 @@ class Admixtools(MakefilePackage):
     of the methods and algorithm can be found in this paper.."""
 
     homepage = "https://github.com/DReichLab/AdmixTools"
-    url      = "https://github.com/DReichLab/AdmixTools/archive/v7.0.1.tar.gz"
+    url      = "https://github.com/DReichLab/AdmixTools/archive/v7.0.2.tar.gz"
 
+    version('7.0.2', sha256='d1dc1963e01017f40e05e28009008e14388a14a3facc75cff46653da585bd91e')
     version('7.0.1', sha256='182dd6f55109e9a1569b47843b0d1aa89fe4cf4a05f9292519b9811faea67a20')
-    version('7.0',   sha256='c00faab626f02bbf9c25c6d2dcf661db225776e9ed61251f164e5edeb5a448e5')
-    version('6.0',   sha256='8fcd6c6834c7b33afdd7188516856d9c66b53c33dc82e133b72b56714fb67ad5')
-    version('5.1',   sha256='42b584cc785abfdfa9f39a341bdf81f800639737feaf3d07702de4a2e373557e')
-    version('5.0',   sha256='9f00637eac84c1ca152b65313d803616ee62c4156c7c737a33f5b31aeeac1367')
+    version('7.0', sha256='c00faab626f02bbf9c25c6d2dcf661db225776e9ed61251f164e5edeb5a448e5')
+    version('6.0', sha256='8fcd6c6834c7b33afdd7188516856d9c66b53c33dc82e133b72b56714fb67ad5')
+    version('5.1', sha256='42b584cc785abfdfa9f39a341bdf81f800639737feaf3d07702de4a2e373557e')
+    version('5.0', sha256='9f00637eac84c1ca152b65313d803616ee62c4156c7c737a33f5b31aeeac1367')
     version('1.0.1', sha256='ef3afff161e6a24c0857678373138edb1251c24d7b5308a07f10bdb0dedd44d0')
-    version('1.0',   sha256='cf0d6950285e801e8a99c2a0b3dbbbc941a78e867af1767b1d002ec3f5803c4b')
+    version('1.0', sha256='cf0d6950285e801e8a99c2a0b3dbbbc941a78e867af1767b1d002ec3f5803c4b')
 
     depends_on('lapack')
     depends_on('gsl')


### PR DESCRIPTION
Add v7.0.2 to Admixtools which includes important bugfixes to qpfstats.

```
*** there was a bad bug in release 7.0 when qpfstats was run with                 
1) allsnps: YES 
2) inbreed: NO 
3) Samples with pseudo-diploid data.    

In the new release if you do this, f-statistics involving psuedo-populations twice (such aas an f_3 with target pseudo-diploid are  
(correctly) flagged as having very large standard error.  
```

Checkout the full explanation [here](https://github.com/DReichLab/AdmixTools/blob/master/README.qpfstats).

**Test Plan:**
Admixtools v7.0.2 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/pull/760/checks?check_run_id=3622720789).