### PR TITLE
Python: use platform-specific site packages dir

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -129,7 +129,7 @@ class PythonPackage(PackageBase):
         modules = []
         root = os.path.join(
             self.prefix,
-            self.spec['python'].package.config_vars['python_lib']['false']['false'],
+            self.spec['python'].package.config_vars['python_lib']['true']['false'],
         )
 
         # Some Python libraries are packages: collections of modules

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -66,7 +66,7 @@ class SIPPackage(PackageBase):
         modules = []
         root = os.path.join(
             self.prefix,
-            self.spec['python'].package.config_vars['python_lib']['false']['false'],
+            self.spec['python'].package.config_vars['python_lib']['true']['false'],
         )
 
         # Some Python libraries are packages: collections of modules

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -892,7 +892,7 @@ for plat_specific in [True, False]:
             str: site-packages directory
         """
         try:
-            return self.config_vars['python_lib']['false']['false']
+            return self.config_vars['python_lib']['true']['false']
         except KeyError:
             return self.default_site_packages_dir
 


### PR DESCRIPTION
This is yet another follow-up to #24095.

On most systems that I've tested, the platform-dependent and platform-independent site packages directories are the same. However, in #25973, @robertu94 discovered that on his system, this is not the case. During installation, we pass both `--install-purelib` and `--install-platlib`, and Cython chooses to install to `platlib` instead of `purelib`. I see two possibilities:

1. Packages always install to `platlib` and we should always add `platlib` to the `PYTHONPATH` (done in this PR)
2. The installation directory changes from `platlib` to `purelib` depending on the package and we need to add both to the `PYTHONPATH`

@robertu94 can you test this and see if it introduces more bugs than it fixes? I'm also hoping GitLab will catch any potential issues as it builds a decently sized Python stack.