### PR TITLE
Filter UserWarning out of test output

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@
 addopts = --durations=30 -ra
 testpaths = lib/spack/spack/test
 python_files = *.py
+filterwarnings =
+  ignore::UserWarning
 markers =
   db: tests that require creating a DB
   maybeslow: tests that may be slow (e.g. access a lot the filesystem, etc.)


### PR DESCRIPTION
Follows #25966 to remove noisy output like [this](https://github.com/spack/spack/pull/25895/checks?check_run_id=3624241913)