### PR TITLE
fgfs: fix missing autotools depends_on

### DIFF
--- a/var/spack/repos/builtin/packages/fast-global-file-status/package.py
+++ b/var/spack/repos/builtin/packages/fast-global-file-status/package.py
@@ -25,9 +25,9 @@ class FastGlobalFileStatus(AutotoolsPackage):
     depends_on('mpi')
     depends_on('openssl')
     depends_on('elf')
-    depends_on('libtool', type='build')
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
+    depends_on('autoconf', type='build', when='@master')
+    depends_on('automake', type='build', when='@master')
+    depends_on('libtool', type='build', when='@master')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/fast-global-file-status/package.py
+++ b/var/spack/repos/builtin/packages/fast-global-file-status/package.py
@@ -26,6 +26,8 @@ class FastGlobalFileStatus(AutotoolsPackage):
     depends_on('openssl')
     depends_on('elf')
     depends_on('libtool', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/mount-point-attributes/package.py
+++ b/var/spack/repos/builtin/packages/mount-point-attributes/package.py
@@ -19,8 +19,8 @@ class MountPointAttributes(AutotoolsPackage):
     version('1.1.1', sha256='397de583a99e60aae8b4485d3decac6e23f50c658a6353fea149d6dd50d3ecee', url="https://github.com/LLNL/MountPointAttributes/releases/download/v1.1.1/mountpointattr-1.1.1.tar.gz")
     version('1.1', sha256='bff84c75c47b74ea09b6cff949dd699b185ddba0463cb1ff39ab138003c96e02')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool', type='build')
+    depends_on('autoconf', type='build', when='@master')
+    depends_on('automake', type='build', when='@master')
+    depends_on('libtool', type='build', when='@master')
 
     patch('mpa_type_conversion.patch', when='@1.1')


### PR DESCRIPTION
This fixes:

```
==> No patches needed for fast-global-file-status
==> fast-global-file-status: Executing phase: 'autoreconf'
==> Error: AttributeError: module 'spack.pkg.builtin.fast-global-file-status' has no attribute 'autoreconf'

/home/atosla/Tools/spack/lib/spack/spack/build_systems/autotools.py:277, in autoreconf:
        274            # --install, --verbose, --force
        275            autoreconf_args = ['-ivf']
        276            autoreconf_args += self.autoreconf_search_path_args
  >>    277            autoreconf_args += self.autoreconf_extra_args
        278            m.autoreconf(*autoreconf_args)
```