### PR TITLE
minife: variant build: openmp_ref should be openmp

### DIFF
--- a/var/spack/repos/builtin/packages/minife/package.py
+++ b/var/spack/repos/builtin/packages/minife/package.py
@@ -19,7 +19,7 @@ class Minife(MakefilePackage):
     version('2.1.0', sha256='59f4c56d73d2a758cba86939db2d36e12705282cb4174ce78223d984527f5d15')
 
     variant('build', default='ref', description='Type of Parallelism',
-            values=('ref', 'openmp_ref', 'qthreads', 'kokkos'))
+            values=('ref', 'openmp', 'qthreads', 'kokkos'))
 
     depends_on('mpi')
     depends_on('qthreads', when='build=qthreads')


### PR DESCRIPTION
`minife`: for the `build` variant: `openmp_ref` should be `openmp` according to the layout of the source directory

@junghans @homerdin @coti