### PR TITLE
Fix NonVirtualInHierarchyError message format

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -139,7 +139,7 @@ class LmodConfiguration(BaseConfiguration):
         if not_virtual:
             msg = "Non-virtual specs in 'hierarchy' list for lmod: {0}\n"
             msg += "Please check the 'modules.yaml' configuration files"
-            msg.format(', '.join(not_virtual))
+            msg = msg.format(', '.join(not_virtual))
             raise NonVirtualInHierarchyError(msg)
 
         # Append 'compiler' which is always implied


### PR DESCRIPTION
Previously the message had `{0}` as the format result was lost.