### PR TITLE
updating cloc to 1.90

### DIFF
--- a/var/spack/repos/builtin/packages/cloc/package.py
+++ b/var/spack/repos/builtin/packages/cloc/package.py
@@ -11,8 +11,9 @@ class Cloc(Package):
     given files (may be archives such as compressed tarballs or zip files)
     and/or recursively below the given directories."""
     homepage = "https://github.com/AlDanial/cloc/"
-    url      = "https://github.com/AlDanial/cloc/releases/download/1.74/cloc-1.74.tar.gz"
+    url      = "https://github.com/AlDanial/cloc/archive/v1.90.tar.gz"
 
+    version('1.90', sha256='60b429dd2aa5cd65707b359dcbcbeb710c8e4db880886528ced0962c67e52548')
     version('1.84', sha256='c3f0a6bd2319110418ccb3e55a7a1b6d0edfd7528bfd2ae5d530938abe90f254')
     version('1.80', sha256='082f53530eee3f9ee84ec449eca59a77ff114250cd7daf9519679537b5b21d67')
     version('1.74', sha256='55ac423d5766c74236700a47838ed66bea47ba42e1d594fdd894074ba3eb0567')


### PR DESCRIPTION
This will update cloc to version 1.9.0, you can see the successful build at https://github.com/autamus/registry/pull/734.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>