### PR TITLE
Updating htslib to 1.13

### DIFF
--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -10,8 +10,9 @@ class Htslib(AutotoolsPackage):
     """C library for high-throughput sequencing data formats."""
 
     homepage = "https://github.com/samtools/htslib"
-    url = "https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2"
+    url      = "https://github.com/samtools/htslib/releases/download/1.13/htslib-1.13.tar.bz2"
 
+    version('1.13', sha256='f2407df9f97f0bb6b07656579e41a1ca5100464067b6b21bf962a2ea4b0efd65')
     version('1.12', sha256='2280141b46e953ba4ae01b98335a84f8e6ccbdb6d5cdbab7f70ee4f7e3b6f4ca')
     version('1.10.2', sha256='e3b543de2f71723830a1e0472cf5489ec27d0fbeb46b1103e14a11b7177d1939')
     version('1.9', sha256='e04b877057e8b3b8425d957f057b42f0e8509173621d3eccaedd0da607d9929a')


### PR DESCRIPTION
This PR will update htslib to 1.13, you can see the successful build here: https://github.com/autamus/registry/pull/737

Signed-off-by: vsoch <vsoch@users.noreply.github.com>