### PR TITLE
updating siesta to 4.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/siesta/package.py
+++ b/var/spack/repos/builtin/packages/siesta/package.py
@@ -15,8 +15,11 @@ class Siesta(Package):
 
     homepage = "https://departments.icmab.es/leem/siesta/"
 
-    version('4.0.1', sha256='bfb9e4335ae1d1639a749ce7e679e739fdead5ee5766b5356ea1d259a6b1e6d1', url='https://launchpad.net/siesta/4.0/4.0.1/+download/siesta-4.0.1.tar.gz')
-    version('3.2-pl-5', sha256='e438bb007608e54c650e14de7fa0b5c72562abb09cbd92dcfb5275becd929a23', url='http://departments.icmab.es/leem/siesta/CodeAccess/Code/siesta-3.2-pl-5.tgz')
+    version('4.0.2', sha256='bafbda19358f0c1dd39bb1253c92ee548791a1c0f648977051d2657216874f7e')
+    version('4.0.1', sha256='bfb9e4335ae1d1639a749ce7e679e739fdead5ee5766b5356ea1d259a6b1e6d1',
+            url='https://launchpad.net/siesta/4.0/4.0.1/+download/siesta-4.0.1.tar.gz')
+    version('3.2-pl-5', sha256='e438bb007608e54c650e14de7fa0b5c72562abb09cbd92dcfb5275becd929a23',
+            url='http://departments.icmab.es/leem/siesta/CodeAccess/Code/siesta-3.2-pl-5.tgz')
 
     patch('configure.patch', when='@:4.0')
 


### PR DESCRIPTION
You can see the successful autamus build here: https://github.com/autamus/registry/pull/755

I'm also undecided if the url on the next line or same line is better - if someone wants to convince me one way or the other I can be more consistent in future updates :Lp 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>