### PR TITLE
updating sparsehash to 2.0.4

### DIFF
--- a/var/spack/repos/builtin/packages/sparsehash/package.py
+++ b/var/spack/repos/builtin/packages/sparsehash/package.py
@@ -9,6 +9,7 @@ from spack import *
 class Sparsehash(AutotoolsPackage):
     """Sparse and dense hash-tables for C++ by Google"""
     homepage = "https://github.com/sparsehash/sparsehash"
-    url      = "https://github.com/sparsehash/sparsehash/archive/sparsehash-2.0.3.tar.gz"
+    url      = "https://github.com/sparsehash/sparsehash/archive/sparsehash-2.0.4.tar.gz"
 
+    version('2.0.4', sha256='8cd1a95827dfd8270927894eb77f62b4087735cbede953884647f16c521c7e58')
     version('2.0.3', sha256='05e986a5c7327796dad742182b2d10805a8d4f511ad090da0490f146c1ff7a8c')


### PR DESCRIPTION
You can see the successful build here: https://github.com/autamus/registry/pull/757

Signed-off-by: vsoch <vsoch@users.noreply.github.com>