### PR TITLE
updating universal ctags to 5.2.0.xxxx

### DIFF
--- a/var/spack/repos/builtin/packages/universal-ctags/package.py
+++ b/var/spack/repos/builtin/packages/universal-ctags/package.py
@@ -13,10 +13,11 @@ class UniversalCtags(AutotoolsPackage):
     the indexed items."""
 
     homepage = "https://ctags.io/"
-    url      = "https://github.com/universal-ctags/ctags/archive/refs/tags/p5.9.20210808.0.tar.gz"
+    url      = "https://github.com/universal-ctags/ctags/archive/p5.9.20210912.0.tar.gz"
     git      = "https://github.com/universal-ctags/ctags.git"
 
     version('master', branch='master')
+    version('5.9.20210912.0', sha256='5082d4f7e5695be3d697c46e2232d76c6d8adff51d22ba7a4b869362f444ee21')
     version('5.9.20210808.0', sha256='7f5f88d20750dfa2437ca9d163972b8684e3cf16de022a5177f322be92f528cc')
 
     depends_on('autoconf', type='build')


### PR DESCRIPTION
You can see the successful build here: https://github.com/autamus/registry/pull/758

Signed-off-by: vsoch <vsoch@users.noreply.github.com>