### PR TITLE
phist: patch to  not use MPI_IN_PLACE in FORTRAN

### DIFF
--- a/var/spack/repos/builtin/packages/phist/avoid-MPI_IN_PLACE.patch
+++ b/var/spack/repos/builtin/packages/phist/avoid-MPI_IN_PLACE.patch
@@ -1,0 +1,41 @@
+From 5a9893cfa86930ef948d89c96520fc3260a2bbd0 Mon Sep 17 00:00:00 2001
+From: Jonas Thies
+Date: Fri, 17 Sep 2021 09:30:50 +0200
+Subject: [PATCH] avoid MPI_IN_PLACE in Allreduce because it gives some
+ compiler/MPI combinations a headache
+
+---
+ src/kernels/builtin/map_module.F90 | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/kernels/builtin/map_module.F90 b/src/kernels/builtin/map_module.F90
+index 5f461456..556acd9d 100644
+--- a/src/kernels/builtin/map_module.F90
++++ b/src/kernels/builtin/map_module.F90
+@@ -328,7 +328,7 @@ end if
+     type(Map_t), pointer :: map1,map2
+     !------------------------------------------------------------
+     
+-    integer :: i, mpi_ierr
++    integer :: i, mpi_ierr, my_ierr, global_ierr
+     logical :: map1_permuted, map2_permuted
+ 
+     ! check if the two pointers refer to the same memory location
+@@ -386,11 +386,13 @@ end if
+           exit
+         end if
+       end do
+-      call MPI_Allreduce(MPI_IN_PLACE,ierr,1,MPI_INTEGER,MPI_MAX,map1%comm,mpi_ierr)
++      my_ierr=ierr
++      call MPI_Allreduce(my_ierr,global_ierr,1,MPI_INTEGER,MPI_MAX,map1%comm,mpi_ierr)
+       if (mpi_ierr/=MPI_SUCCESS) then
+         ierr=PHIST_MPI_ERROR
+         return
+       end if
++      ierr=global_ierr
+       if (ierr/=0) then
+         ! we don't support this type of construction (both maps permuted with different orderings)
+         ierr=-1
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -101,7 +101,7 @@ class Phist(CMakePackage):
 
     # ###################### Patches ##########################
 
-    patch('avoid-MPI_IN_PLACE.patch', when='@:1.9.5')
+    patch('avoid-MPI_IN_PLACE.patch', when='@:1.9.4')
     patch('update_tpetra_gotypes.patch', when='@:1.8.99')
     patch('sbang.patch', when='+fortran')
 

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -101,6 +101,7 @@ class Phist(CMakePackage):
 
     # ###################### Patches ##########################
 
+    patch('ppc64_sse.patch', when='@1.7.4:1.9.4')
     patch('avoid-MPI_IN_PLACE.patch', when='@:1.9.4')
     patch('update_tpetra_gotypes.patch', when='@:1.8.99')
     patch('sbang.patch', when='+fortran')

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -101,7 +101,7 @@ class Phist(CMakePackage):
 
     # ###################### Patches ##########################
 
-    patch('void-MPI_IN_PLACE.patch', when='@:1.9.5')
+    patch('avoid-MPI_IN_PLACE.patch', when='@:1.9.5')
     patch('update_tpetra_gotypes.patch', when='@:1.8.99')
     patch('sbang.patch', when='+fortran')
 

--- a/var/spack/repos/builtin/packages/phist/package.py
+++ b/var/spack/repos/builtin/packages/phist/package.py
@@ -101,8 +101,8 @@ class Phist(CMakePackage):
 
     # ###################### Patches ##########################
 
+    patch('void-MPI_IN_PLACE.patch', when='@:1.9.5')
     patch('update_tpetra_gotypes.patch', when='@:1.8.99')
-
     patch('sbang.patch', when='+fortran')
 
     # ###################### Dependencies ##########################

--- a/var/spack/repos/builtin/packages/phist/ppc64_sse.patch
+++ b/var/spack/repos/builtin/packages/phist/ppc64_sse.patch
@@ -1,0 +1,12 @@
+--- a/cmake/SetHostCompileFlag.cmake
++++ b/cmake/SetHostCompileFlag.cmake
+@@ -45,3 +45,9 @@ cmake_pop_check_state() # Recover variables
+ foreach (LANG C CXX Fortran)
+   set(CMAKE_${LANG}_FLAGS "${CMAKE_${LANG}_FLAGS} ${${LANG}_ARCH_FLAG}")
+ endforeach()
++
++if(PHIST_HOST_OPTIMIZE)
++  if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ppc64le")
++    add_definitions(-DNO_WARN_X86_INTRINSICS)
++  endif()
++endif()


### PR DESCRIPTION
Fixes #26002 

Patch to make package not use MPI_IN_PLACE in fortran code

(seems to be hard to implement for MPI vendors if the compiler is strict about data types)