### PR TITLE
umpire: conflict with gcc@10.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -101,6 +101,9 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     # currently only available for cuda.
     conflicts('+shared', when='+cuda')
 
+    # https://github.com/LLNL/Umpire/issues/653
+    conflicts('%gcc@10.3.0', when='+cuda')
+
     def _get_sys_type(self, spec):
         sys_type = spec.architecture
         if "SYS_TYPE" in env:


### PR DESCRIPTION
See https://github.com/LLNL/Umpire/issues/653

It looks like a GCC bug, so it is not expected a fix on umpire side, for this reason I would not constrain the conflict to specific versions of umpire.