### PR TITLE
Bootstrap should search for compilers after switching config scopes

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -18,7 +18,6 @@ from llnl.util.tty.color import colorize
 import spack.compilers
 import spack.config
 import spack.spec
-from spack.spec import ArchSpec, CompilerSpec
 
 description = "manage compilers"
 section = "system"
@@ -78,24 +77,13 @@ def compiler_find(args):
     # None signals spack.compiler.find_compilers to use its default logic
     paths = args.add_paths or None
 
-    # Don't initialize compilers config via compilers.get_compiler_config.
-    # Just let compiler_find do the
-    # entire process and return an empty config from all_compilers
-    # Default for any other process is init_config=True
-    compilers = [c for c in spack.compilers.find_compilers(paths)]
-    new_compilers = []
-    for c in compilers:
-        arch_spec = ArchSpec((None, c.operating_system, c.target))
-        same_specs = spack.compilers.compilers_for_spec(
-            c.spec, arch_spec, init_config=False)
-
-        if not same_specs:
-            new_compilers.append(c)
-
+    # Below scope=None because we want new compilers that don't appear
+    # in any other configuration.
+    new_compilers = spack.compilers.find_new_compilers(paths, scope=None)
     if new_compilers:
-        spack.compilers.add_compilers_to_config(new_compilers,
-                                                scope=args.scope,
-                                                init_config=False)
+        spack.compilers.add_compilers_to_config(
+            new_compilers, scope=args.scope, init_config=False
+        )
         n = len(new_compilers)
         s = 's' if n > 1 else ''
 
@@ -110,7 +98,7 @@ def compiler_find(args):
 
 
 def compiler_remove(args):
-    cspec = CompilerSpec(args.compiler_spec)
+    cspec = spack.spec.CompilerSpec(args.compiler_spec)
     compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope)
     if not compilers:
         tty.die("No compilers match spec %s" % cspec)
@@ -128,7 +116,7 @@ def compiler_remove(args):
 
 def compiler_info(args):
     """Print info about all compilers matching a spec."""
-    cspec = CompilerSpec(args.compiler_spec)
+    cspec = spack.spec.CompilerSpec(args.compiler_spec)
     compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope)
 
     if not compilers:

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -5,6 +5,7 @@
 import pytest
 
 import spack.bootstrap
+import spack.compilers
 import spack.environment
 import spack.store
 import spack.util.path
@@ -78,3 +79,23 @@ def test_bootstrap_disables_modulefile_generation(mutable_config):
         assert 'lmod' not in spack.config.get('modules:enable')
     assert 'tcl' in spack.config.get('modules:enable')
     assert 'lmod' in spack.config.get('modules:enable')
+
+
+@pytest.mark.regression('25992')
+@pytest.mark.requires_executables('gcc')
+def test_bootstrap_search_for_compilers_with_no_environment(no_compilers_yaml):
+    assert not spack.compilers.all_compiler_specs(init_config=False)
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        assert spack.compilers.all_compiler_specs(init_config=False)
+    assert not spack.compilers.all_compiler_specs(init_config=False)
+
+
+@pytest.mark.regression('25992')
+@pytest.mark.requires_executables('gcc')
+def test_bootstrap_search_for_compilers_with_environment_active(
+        no_compilers_yaml, active_mock_environment
+):
+    assert not spack.compilers.all_compiler_specs(init_config=False)
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        assert spack.compilers.all_compiler_specs(init_config=False)
+    assert not spack.compilers.all_compiler_specs(init_config=False)

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -17,18 +17,6 @@ compiler = spack.main.SpackCommand('compiler')
 
 
 @pytest.fixture
-def no_compilers_yaml(mutable_config):
-    """Creates a temporary configuration without compilers.yaml"""
-
-    for scope, local_config in mutable_config.scopes.items():
-        compilers_yaml = os.path.join(
-            local_config.path, scope, 'compilers.yaml'
-        )
-        if os.path.exists(compilers_yaml):
-            os.remove(compilers_yaml)
-
-
-@pytest.fixture
 def mock_compiler_version():
     return '4.5.3'
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -652,6 +652,15 @@ def mutable_empty_config(tmpdir_factory, configuration_dir):
         yield cfg
 
 
+@pytest.fixture
+def no_compilers_yaml(mutable_config):
+    """Creates a temporary configuration without compilers.yaml"""
+    for scope, local_config in mutable_config.scopes.items():
+        compilers_yaml = os.path.join(local_config.path, 'compilers.yaml')
+        if os.path.exists(compilers_yaml):
+            os.remove(compilers_yaml)
+
+
 @pytest.fixture()
 def mock_low_high_config(tmpdir):
     """Mocks two configuration scopes: 'low' and 'high'."""


### PR DESCRIPTION
fixes #25992

Currently the bootstrapping process may need a compiler.

When bootstrapping from sources the need is obvious, while when bootstrapping from binaries it's currently needed in case `patchelf` is not on the system (since it will be then bootstrapped from sources).

Before this PR we were searching for compilers as the first operation, in case they were not declared in the configuration. This fails in case we start bootstrapping from within an environment.

The fix is to defer the search until we have swapped configuration.

Modifications:
- [x] Search for compilers during bootstrapping _after_ configuration has been swapped
- [x] Add unit tests to avoid regressions