### PR TITLE
librsb: added v1.2.0.10

### DIFF
--- a/var/spack/repos/builtin/packages/librsb/package.py
+++ b/var/spack/repos/builtin/packages/librsb/package.py
@@ -11,9 +11,10 @@ class Librsb(AutotoolsPackage):
     library for the Recursive Sparse Blocks format"""
 
     homepage = "http://librsb.sourceforge.net/"
-    url      = "http://download.sourceforge.net/librsb/librsb-1.2.0.9.tar.gz"
+    url      = "http://download.sourceforge.net/librsb/librsb-1.2.0.10.tar.gz"
     list_url = "https://sourceforge.net/projects/librsb/files/"
 
+    version('1.2.0.10',  'ec49f3f78a7c43fc9e10976593d100aa49b1863309ed8fa3ccbb7aad52d2f7b8')
     version('1.2.0.9',   'f421f5d572461601120933e3c1cfee2ca69e6ecc92cbb11baa4e86bdedd3d9fa')
     version('1.2.0.8',   '8bebd19a1866d80ade13eabfdd0f07ae7e8a485c0b975b5d15f531ac204d80cb')
 


### PR DESCRIPTION
Fix #26043 by updating librsb-1.2.0.10 URL & checksum.