### PR TITLE
intel-oneapi-mpi, intel-oneapi-mkl add ilp64 support

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -35,7 +35,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     variant('ilp64', default=False,
             description='Build with ILP64 support')
 
-    provides('mpi@:3')
+    provides('mpi@:3.1')
 
     depends_on('patchelf', type='build')
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import glob
 import platform
 import subprocess
 
@@ -30,6 +31,9 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17397/l_mpi_oneapi_p_2021.1.1.76_offline.sh',
                 sha256='8b7693a156c6fc6269637bef586a8fd3ea6610cac2aae4e7f48c1fbb601625fe',
                 expand=False)
+
+    variant('ilp64', default=False,
+            description='Build with ILP64 support')
 
     provides('mpi@:3')
 
@@ -62,25 +66,35 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         env.set('MPIFC', join_path(dir, 'mpifc'))
 
     @property
+    def headers(self):
+        include_path = join_path(self.component_path, 'include')
+        headers = find_headers('*', include_path)
+        if '+ilp64' in self.spec:
+            headers += find_headers('*', join_path(include_path, 'ilp64'))
+        return headers
+
+    @property
     def libs(self):
+        lib_dir = join_path(self.component_path, 'lib')
+        release_lib_dir = join_path(lib_dir, 'release')
         libs = []
-        for dir in [join_path('lib', 'release_mt'),
-                    'lib',
-                    join_path('libfabric', 'lib')]:
-            lib_path = join_path(self.component_path, dir)
-            ldir = find_libraries('*', root=lib_path, shared=True, recursive=False)
-            libs += ldir
+        if '+ilp64' in self.spec:
+            libs += find_libraries('libmpi_ilp64', release_lib_dir)
+        libs += find_libraries(['libmpicxx', 'libmpifort'], lib_dir)
+        libs += find_libraries('libmpi', release_lib_dir)
+        libs += find_system_libraries(['libdl', 'librt', 'libpthread'])
         return libs
 
     def install(self, spec, prefix):
         super(IntelOneapiMpi, self).install(spec, prefix)
 
-        # need to patch libmpi.so so it can always find libfabric
+        # Patch libmpi.so rpath so it can find libfabric
         libfabric_rpath = join_path(self.component_path, 'libfabric', 'lib')
-        for lib_version in ['debug', 'release', 'release_mt', 'debug_mt']:
-            file = join_path(self.component_path, 'lib', lib_version, 'libmpi.so')
-            subprocess.call(['patchelf', '--set-rpath', libfabric_rpath, file])
+        for libmpi in glob.glob(join_path(self.component_path,
+                                          'lib', '**', 'libmpi*.so')):
+            subprocess.call(['patchelf', '--set-rpath', libfabric_rpath, libmpi])
 
+        # When spack builds from source
         # fix I_MPI_SUBSTITUTE_INSTALLDIR and
         #   __EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__
         scripts = ["mpif77", "mpif90", "mpigcc", "mpigxx", "mpiicc", "mpiicpc",


### PR DESCRIPTION
Add ILP64 support to oneapi MKL and MPI packages.
Addresses issue from https://github.com/spack/spack/issues/22621#issuecomment
Tests are here: https://github.com/rscohn2/oneapi-spack-tests/actions/runs/1248579024

@jasukhar: Can someone familiar with mkl compile/link line check the mkl changes? Spack provides  ```-I```, ```-L```, and ```-l``` options, and the user is responsible for the rest.  ```-I``` comes from the ```headers``` function. The link options come from the ```libs``` function. You specify the libraries and it generates corresponding ```-L -l```

@VadimKutovoi: same for MPI

