### PR TITLE
Allow setting variant name  in AutotoolsPackage._activate_or_not

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -521,7 +521,7 @@ class AutotoolsPackage(PackageBase):
         Returns:
             list of arguments to configure
         """
-        return self._activate_or_not(name, 'with', 'without', activation_value, 
+        return self._activate_or_not(name, 'with', 'without', activation_value,
                                      variant_name)
 
     def enable_or_disable(self, name, activation_value=None, variant_name=None):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -394,7 +394,7 @@ class AutotoolsPackage(PackageBase):
                 The special value 'prefix' can also be assigned and will return
                 ``spec[name].prefix`` as activation parameter.
             variant_name (str): name of the variant that is being processed (if differs from option name)
-            
+
         Examples:
 
             Given a package with:
@@ -435,7 +435,7 @@ class AutotoolsPackage(PackageBase):
 
         if activation_value == 'prefix':
             activation_value = lambda x: spec[x].prefix
-            
+
         if variant_name is None:
             variant_name = name
 

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -373,14 +373,15 @@ class AutotoolsPackage(PackageBase):
             name,
             activation_word,
             deactivation_word,
-            activation_value=None
+            activation_value=None,
+            variant_name=None
     ):
         """This function contains the current implementation details of
         :meth:`~spack.build_systems.autotools.AutotoolsPackage.with_or_without` and
         :meth:`~spack.build_systems.autotools.AutotoolsPackage.enable_or_disable`.
 
         Args:
-            name (str): name of the variant that is being processed
+            name (str): name of the option that is being activated or not
             activation_word (str): the default activation word ('with' in the
                 case of ``with_or_without``)
             deactivation_word (str): the default deactivation word ('without'
@@ -392,7 +393,8 @@ class AutotoolsPackage(PackageBase):
 
                 The special value 'prefix' can also be assigned and will return
                 ``spec[name].prefix`` as activation parameter.
-
+            variant_name (str): name of the variant that is being processed (if differs from option name)
+            
         Examples:
 
             Given a package with:
@@ -401,6 +403,7 @@ class AutotoolsPackage(PackageBase):
 
                 variant('foo', values=('x', 'y'), description='')
                 variant('bar', default=True, description='')
+                variant('ba_z', default=True, description='')
 
             calling this function like:
 
@@ -410,12 +413,13 @@ class AutotoolsPackage(PackageBase):
                     'foo', 'with', 'without', activation_value='prefix'
                 )
                 _activate_or_not('bar', 'with', 'without')
+                _activate_or_not('ba-z', 'with', 'without', variant_name='ba_z')
 
             will generate the following configuration options:
 
             .. code-block:: console
 
-                --with-x=<prefix-to-x> --without-y --with-bar
+                --with-x=<prefix-to-x> --without-y --with-bar --with-ba-z
 
             for ``<spec-name> foo=x +bar``
 
@@ -431,33 +435,36 @@ class AutotoolsPackage(PackageBase):
 
         if activation_value == 'prefix':
             activation_value = lambda x: spec[x].prefix
+            
+        if variant_name is None:
+            variant_name = name
 
         # Defensively look that the name passed as argument is among
         # variants
-        if name not in self.variants:
+        if variant_name not in self.variants:
             msg = '"{0}" is not a variant of "{1}"'
-            raise KeyError(msg.format(name, self.name))
+            raise KeyError(msg.format(variant_name, self.name))
 
         # Create a list of pairs. Each pair includes a configuration
         # option and whether or not that option is activated
-        if set(self.variants[name].values) == set((True, False)):
+        if set(self.variants[variant_name].values) == set((True, False)):
             # BoolValuedVariant carry information about a single option.
             # Nonetheless, for uniformity of treatment we'll package them
             # in an iterable of one element.
-            condition = '+{name}'.format(name=name)
+            condition = '+{name}'.format(name=variant_name)
             options = [(name, condition in spec)]
         else:
-            condition = '{name}={value}'
+            condition = '{variant_name}={value}'
             # "feature_values" is used to track values which correspond to
             # features which can be enabled or disabled as understood by the
             # package's build system. It excludes values which have special
             # meanings and do not correspond to features (e.g. "none")
             feature_values = getattr(
-                self.variants[name].values, 'feature_values', None
-            ) or self.variants[name].values
+                self.variants[variant_name].values, 'feature_values', None
+            ) or self.variants[variant_name].values
 
             options = [
-                (value, condition.format(name=name, value=value) in spec)
+                (value, condition.format(variant_name=variant_name, value=value) in spec)
                 for value in feature_values
             ]
 
@@ -485,7 +492,7 @@ class AutotoolsPackage(PackageBase):
             args.append(line_generator(activated))
         return args
 
-    def with_or_without(self, name, activation_value=None):
+    def with_or_without(self, name, activation_value=None, variant_name=None):
         """Inspects a variant and returns the arguments that activate
         or deactivate the selected feature(s) for the configure options.
 
@@ -513,7 +520,7 @@ class AutotoolsPackage(PackageBase):
         """
         return self._activate_or_not(name, 'with', 'without', activation_value)
 
-    def enable_or_disable(self, name, activation_value=None):
+    def enable_or_disable(self, name, activation_value=None, variant_name=None):
         """Same as
         :meth:`~spack.build_systems.autotools.AutotoolsPackage.with_or_without`
         but substitute ``with`` with ``enable`` and ``without`` with ``disable``.
@@ -531,7 +538,7 @@ class AutotoolsPackage(PackageBase):
             list of arguments to configure
         """
         return self._activate_or_not(
-            name, 'enable', 'disable', activation_value
+            name, 'enable', 'disable', activation_value, variant_name
         )
 
     run_after('install')(PackageBase._run_default_install_time_test_callbacks)

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -521,7 +521,8 @@ class AutotoolsPackage(PackageBase):
         Returns:
             list of arguments to configure
         """
-        return self._activate_or_not(name, 'with', 'without', activation_value)
+        return self._activate_or_not(name, 'with', 'without', activation_value, 
+                                     variant_name)
 
     def enable_or_disable(self, name, activation_value=None, variant_name=None):
         """Same as

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -393,7 +393,8 @@ class AutotoolsPackage(PackageBase):
 
                 The special value 'prefix' can also be assigned and will return
                 ``spec[name].prefix`` as activation parameter.
-            variant_name (str): name of the variant that is being processed (if differs from option name)
+            variant_name (str): name of the variant that is being processed
+                                (if different from option name)
 
         Examples:
 
@@ -464,7 +465,9 @@ class AutotoolsPackage(PackageBase):
             ) or self.variants[variant_name].values
 
             options = [
-                (value, condition.format(variant_name=variant_name, value=value) in spec)
+                (value,
+                 condition.format(variant_name=variant_name,
+                                  value=value) in spec)
                 for value in feature_values
             ]
 

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -169,6 +169,9 @@ class TestAutotoolsPackage(object):
         options = pkg.with_or_without('bvv')
         assert '--with-bvv' in options
 
+        options = pkg.with_or_without('lorem_ipsum', variant_name='lorem-ipsum')
+        assert '--without-lorem-ipsum' in options
+
     def test_none_is_allowed(self):
         s = Spec('a foo=none')
         s.concretize()

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -169,7 +169,7 @@ class TestAutotoolsPackage(object):
         options = pkg.with_or_without('bvv')
         assert '--with-bvv' in options
 
-        options = pkg.with_or_without('lorem_ipsum', variant_name='lorem-ipsum')
+        options = pkg.with_or_without('lorem-ipsum', variant_name='lorem_ipsum')
         assert '--without-lorem-ipsum' in options
 
     def test_none_is_allowed(self):

--- a/var/spack/repos/builtin.mock/packages/a/package.py
+++ b/var/spack/repos/builtin.mock/packages/a/package.py
@@ -28,6 +28,8 @@ class A(AutotoolsPackage):
         multi=False
     )
 
+    variant('lorem_ipsum', description='', default=False)
+
     variant('bvv', default=True, description='The good old BV variant')
 
     depends_on('b', when='foobar=bar')


### PR DESCRIPTION
Based on a discussion with @haampie here: https://github.com/spack/spack/pull/26032#discussion_r711731513

I will also try to update tests with this new feature, if I can figure them out...