### PR TITLE
patch serf and scons to use #!/usr/bin/env python3

### DIFF
--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -26,6 +26,7 @@ class Scons(PythonPackage):
     depends_on('py-setuptools', when='@3.0.2:', type=('build', 'run'))
 
     patch('fjcompiler.patch', when='%fj')
+    patch('py3-hashbang.patch', when='^python@3:')
 
     # Prevent passing --single-version-externally-managed to
     # setup.py, which it does not support.

--- a/var/spack/repos/builtin/packages/scons/py3-hashbang.patch
+++ b/var/spack/repos/builtin/packages/scons/py3-hashbang.patch
@@ -1,0 +1,40 @@
+diff --git a/script/scons b/script/scons
+index d889e74..f1b5105 100755
+--- a/script/scons
++++ b/script/scons
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python
++#! /usr/bin/env python3
+ #
+ # SCons - a Software Constructor
+ #
+diff --git a/script/scons-configure-cache b/script/scons-configure-cache
+index ee11943..898dbef 100644
+--- a/script/scons-configure-cache
++++ b/script/scons-configure-cache
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python
++#! /usr/bin/env python3
+ #
+ # SCons - a Software Constructor
+ #
+diff --git a/script/sconsign b/script/sconsign
+index b1f7cd0..cc5c018 100644
+--- a/script/sconsign
++++ b/script/sconsign
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python
++#! /usr/bin/env python3
+ #
+ # SCons - a Software Constructor
+ #
+diff --git a/script/scons-time b/script/scons-time
+index c371d59..8d17718 100644
+--- a/script/scons-time
++++ b/script/scons-time
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ # scons-time - run SCons timings and collect statistics
+ #

--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -13,6 +13,8 @@ class Serf(SConsPackage):
     homepage  = 'https://serf.apache.org/'
     url       = 'https://archive.apache.org/dist/serf/serf-1.3.9.tar.bz2'
 
+    maintainers = ['cosmicexplorer']
+
     version('1.3.9', sha256='549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc')
     version('1.3.8', sha256='e0500be065dbbce490449837bb2ab624e46d64fc0b090474d9acaa87c82b2590')
 

--- a/var/spack/repos/builtin/packages/serf/package.py
+++ b/var/spack/repos/builtin/packages/serf/package.py
@@ -28,6 +28,7 @@ class Serf(SConsPackage):
     depends_on('zlib')
 
     patch('py3syntax.patch')
+    patch('py3-hashbang.patch')
 
     def build_args(self, spec, prefix):
         args = {

--- a/var/spack/repos/builtin/packages/serf/py3-hashbang.patch
+++ b/var/spack/repos/builtin/packages/serf/py3-hashbang.patch
@@ -1,0 +1,20 @@
+diff --git a/build/gen_def.py b/build/gen_def.py
+index a2222d0..926b813 100755
+--- a/build/gen_def.py
++++ b/build/gen_def.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ # gen_def.py :  Generate the .DEF file for Windows builds
+ #
+diff --git a/build/check.py b/build/check.py
+index 2dacb4c..c44eb5a 100755
+--- a/build/check.py
++++ b/build/check.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ # check.py :  Run all the test cases.
+ #


### PR DESCRIPTION
### Problem
`scons` uses `#!/usr/bin/env python` in its script. This causes e.g. `serf` and other `SconsPackage`s to fail to build on my ubuntu machine which has no `python` symlink.

### Solution
Patch `scons` to explicitly refer to `#!/usr/bin/env python3`.