### PR TITLE
pigz: new version 2.6

### DIFF
--- a/var/spack/repos/builtin/packages/pigz/package.py
+++ b/var/spack/repos/builtin/packages/pigz/package.py
@@ -13,6 +13,7 @@ class Pigz(MakefilePackage):
     homepage = "https://zlib.net/pigz/"
     url      = "https://github.com/madler/pigz/archive/v2.3.4.tar.gz"
 
+    version('2.6', sha256='577673676cd5c7219f94b236075451220bae3e1ca451cf849947a2998fbf5820')
     version('2.4', sha256='e228e7d18b34c4ece8d596eb6eee97bde533c6beedbb728d07d3abe90b4b1b52')
     version('2.3.4', sha256='763f2fdb203aa0b7b640e63385e38e5dd4e5aaa041bc8e42aa96f2ef156b06e8')
 


### PR DESCRIPTION
History in https://github.com/madler/pigz/blob/master/pigz.c
```
   2.5    23 Jan 2021  Add --alias/-A option to set .zip name for stdin input
                       Add --comment/-C option to add comment in .gz or .zip
                       Fix a bug that misidentified a multi-entry .zip
                       Fix a bug that did not emit double syncs for -i -p 1
                       Fix a bug in yarn that could try to access freed data
                       Do not delete multi-entry .zip files when extracting
                       Do not reject .zip entries with bit 11 set
                       Avoid a possible threads lock-order inversion
                       Ignore trailing junk after a gzip stream by default
   2.6     6 Feb 2021  Add --huffman/-H and --rle/U strategy options
                       Fix issue when compiling for no threads
                       Fail silently on a broken pipe
```