### PR TITLE
Simplify setup_package in build environment

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -799,9 +799,6 @@ def setup_package(pkg, dirty, context='build'):
     # own environment modifications. This ensures Spack controls CC/CXX/... variables.
     if need_compiler:
         for mod in pkg.compiler.modules:
-            # Fixes issue https://github.com/spack/spack/issues/3153
-            if os.environ.get("CRAY_CPU_TARGET") == "mic-knl":
-                load_module("cce")
             load_module(mod)
 
     # kludge to handle cray libsci being automatically loaded by PrgEnv


### PR DESCRIPTION
1. Remove preserve environment logic, it's redundant because we apply changes to these variables after module loading
2. Remove a workaround for a broken module file on a particular cray pe (https://github.com/spack/spack/issues/3153#issuecomment-280460041)