### PR TITLE
OpenSSL 3.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -25,6 +25,8 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
 
     executables = ['openssl']
 
+    version('3.0.0', sha256='59eedfcb46c25214c9bd37ed6078297b4df01d012267fe9e9eee31f61bc70536')
+
     # The latest stable version is the 1.1.1 series. This is also our Long Term
     # Support (LTS) version, supported until 11th September 2023.
     version('1.1.1l', sha256='0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1')


### PR DESCRIPTION
Likely we should prefer 1.1.1l until we've got all the conflicts figured out, but not doing that now, to see if the Gitlab pipelines catch any build failures.

The most interesting feature about OpenSSL is actually the change of license :tada: unfortunately the build system is still based on Perl
