### PR TITLE
autotools.py: add automatic depends on autotools when='@master,develop'

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -258,8 +258,9 @@ class AutotoolsPackage(PackageBase):
         if os.path.exists(self.configure_abs_path):
             return
         # Else try to regenerate it
-        autotools = ['m4', 'autoconf', 'automake', 'libtool']
-        missing = [x for x in autotools if x not in spec]
+        needed_dependencies = ['autoconf', 'automake', 'libtool']
+        build_deps = [d.name for d in spec.dependencies(deptype='build')]
+        missing = [x for x in needed_dependencies if x not in build_deps]
         if missing:
             msg = 'Cannot generate configure: missing dependencies {0}'
             raise RuntimeError(msg.format(missing))

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -275,6 +275,15 @@ class AutotoolsPackage(PackageBase):
         build_deps = [d.name for d in spec.dependencies(deptype='build')]
         missing = [x for x in needed_dependencies if x not in build_deps]
         if missing:
+            tty.warn('*********************************************************')
+            package_file = spec.name + '/package.py:'
+            vers         = spec.version
+            print('*** Please add these lines to the depends of ' + package_file)
+            print("    depends_on('autoconf', type='build', when='@{0}')".format(vers))
+            print("    depends_on('automake', type='build', when='@{0}')".format(vers))
+            print("    depends_on('libtool',  type='build', when='@{0}')".format(vers))
+            print("*** and tweak the version in when='@...' as needed.")
+            tty.warn('*********************************************************')
             msg = 'Cannot generate configure: missing dependencies {0}'
             raise RuntimeError(msg.format(missing))
         tty.msg('Configure script not found: trying to generate it')

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -14,6 +14,7 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 from llnl.util.filesystem import force_remove, working_dir
 
+from spack.directives import depends_on
 from spack.package import PackageBase, run_after, run_before
 from spack.util.executable import Executable
 
@@ -82,6 +83,18 @@ class AutotoolsPackage(PackageBase):
     #: If False deletes all the .la files in the prefix folder
     #: after the installation. If True instead it installs them.
     install_libtool_archives = False
+
+    #: autoreconf depends on autoconf, automake and libtool:
+    autoreconf_depends = ['autoconf', 'automake', 'libtool']
+
+    #: Is it possible to override this from a subclass? Even moving this into a
+    #: function didn't change it as on class scope, we don't have 'self' to call
+    #: the overridden method of a subclass.
+    #: It is not a big problem though because unless the master,develop branches
+    #: also provide the configure script itself, autoreconf will check that the
+    #: autotools packages are installed before calling autoreconf automatically
+    depends_on(autoreconf_depends, type='build', when='@master,develop',
+               skip=autoreconf_depends)
 
     @property
     def _removed_la_files_log(self):


### PR DESCRIPTION
Practically every `AutotoolsPackage`, when built from git, will have to
run `autoreconf` to generate the `configure` script and other files.

Before calling `autoreconf`, `AutotoolsPackage.autoreconf()` checks
that `autoconf, automake` and `libtool` are installed,
as these are needed for `autoreconf` to succeed.

In the past, many `package.py` files were written without this check
present or working. As result many just have 'depends_on('libtool'),
bit miss it for `autoconf` and `automake`.

Also at the moment, that check is not working, as can be seen in #26005

1st:

Fix this check which didn't stop the code in #26005 by checking if the `autotools` packages are in `specs._dependencies`, not just in `specs`.

2nd:

With this fix, each package with version master or develop need to have these depends present to build for `@master` or `@develop`
```
    depends_on('autoconf', when='@master,develop')
    depends_on('automake', when='@master,develop')
    depends_on('libtool',  when='@master,develop')
```
In order to not have to update each relevant package.py, this commit
also makes adding these depends automatic for all AutotoolsPackages.

Of course it should excempt m4, autoconf, automake and libtool from
this to not add dependencies which they don't need to their graph,
a dependency on the package itself is also impossible.

To allow for this, the depends_on() gets an optional skip-argument for
which `AutotoolsPackage` passes `['autoconf','automake','libtool']`

For convenience, it's spec argument is also extended to take a list of
specs, which allows many packages which always require `autoreconf` to
add this to their `package.py` instead:

    `depends_on(AutotoolsPackage.autoreconf_depends, type='build')`