### PR TITLE
Adding changes necessary to fix numpy compile on ppc with xlf and blas.

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -162,26 +162,21 @@ class PythonPackage(PackageBase):
 
     def setup_py(self, *args, **kwargs):
         setup = self.setup_file()
+        used_args = self.setup_args(self.spec, self.prefix) + args
 
         with working_dir(self.build_directory):
-            self.python('-s', setup, '--no-user-cfg', *args, **kwargs)
+            self.python('-s', setup, '--no-user-cfg', *used_args, **kwargs)
 
     # The following phases and their descriptions come from:
     #   $ python setup.py --help-commands
 
     # Standard commands
 
-    def setup_args(self, spec, prefix):
-        '''Arguments to pass to build before the target command'''
-        return []
-
     def build(self, spec, prefix):
         """Build everything needed to install."""
-        args = (self.setup_args(spec, prefix),
-                + ['build']
-                + self.build_args(spec, prefix))
+        args = self.build_args(spec, prefix)
 
-        self.setup_py(*args)
+        self.setup_py('build', *args)
 
     def build_args(self, spec, prefix):
         """Arguments to pass to build."""
@@ -189,11 +184,9 @@ class PythonPackage(PackageBase):
 
     def build_py(self, spec, prefix):
         '''"Build" pure Python modules (copy to build directory).'''
-        args = (self.setup_args(spec, prefix),
-                + ['build_py']
-                + self.build_py_args(spec, prefix))
+        args = self.build_py_args(spec, prefix)
 
-        self.setup_py(*args)
+        self.setup_py('build_py', *args)
 
     def build_py_args(self, spec, prefix):
         """Arguments to pass to build_py."""
@@ -201,11 +194,9 @@ class PythonPackage(PackageBase):
 
     def build_ext(self, spec, prefix):
         """Build C/C++ extensions (compile/link to build directory)."""
-        args = (self.setup_args(spec, prefix),
-                + ['build_ext']
-                + self.build_ext_args(spec, prefix))
+        args = self.build_ext_args(spec, prefix)
 
-        self.setup_py(*args)
+        self.setup_py('build_ext', *args)
 
     def build_ext_args(self, spec, prefix):
         """Arguments to pass to build_ext."""
@@ -213,11 +204,9 @@ class PythonPackage(PackageBase):
 
     def build_clib(self, spec, prefix):
         """Build C/C++ libraries used by Python extensions."""
-        args = (self.setup_args(spec, prefix),
-                + ['build_clib']
-                + self.build_clib_args(spec, prefix))
+        args = self.build_clib_args(spec, prefix)
 
-        self.setup_py(*args)
+        self.setup_py('build_clib', *args)
 
     def build_clib_args(self, spec, prefix):
         """Arguments to pass to build_clib."""
@@ -225,11 +214,9 @@ class PythonPackage(PackageBase):
 
     def build_scripts(self, spec, prefix):
         '''"Build" scripts (copy and fixup #! line).'''
-        args = (self.setup_args(spec, prefix),
-                + ['build_scripts']
-                + self.build_scripts_args(spec, prefix))
+        args = self.build_scripts_args(spec, prefix)
 
-        self.setup_py(*args)
+        self.setup_py('build_scripts', *args)
 
     def build_scripts_args(self, spec, prefix):
         """Arguments to pass to build_scripts."""
@@ -237,11 +224,9 @@ class PythonPackage(PackageBase):
 
     def install(self, spec, prefix):
         """Install everything from build directory."""
-        args = (self.setup_args(spec, prefix),
-                + ['install']
-                + self.install_args(spec, prefix))
+        args = self.install_args(spec, prefix)
 
-        self.setup_py(*args)
+        self.setup_py('install', *args)
 
     def install_args(self, spec, prefix):
         """Arguments to pass to install."""

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -171,11 +171,17 @@ class PythonPackage(PackageBase):
 
     # Standard commands
 
+    def setup_args(self, spec, prefix):
+        '''Arguments to pass to build before the target command'''
+        return []
+
     def build(self, spec, prefix):
         """Build everything needed to install."""
-        args = self.build_args(spec, prefix)
+        args = (self.setup_args(spec, prefix),
+                + ['build']
+                + self.build_args(spec, prefix))
 
-        self.setup_py('build', *args)
+        self.setup_py(*args)
 
     def build_args(self, spec, prefix):
         """Arguments to pass to build."""
@@ -183,9 +189,11 @@ class PythonPackage(PackageBase):
 
     def build_py(self, spec, prefix):
         '''"Build" pure Python modules (copy to build directory).'''
-        args = self.build_py_args(spec, prefix)
+        args = (self.setup_args(spec, prefix),
+                + ['build_py']
+                + self.build_py_args(spec, prefix))
 
-        self.setup_py('build_py', *args)
+        self.setup_py(*args)
 
     def build_py_args(self, spec, prefix):
         """Arguments to pass to build_py."""
@@ -193,9 +201,11 @@ class PythonPackage(PackageBase):
 
     def build_ext(self, spec, prefix):
         """Build C/C++ extensions (compile/link to build directory)."""
-        args = self.build_ext_args(spec, prefix)
+        args = (self.setup_args(spec, prefix),
+                + ['build_ext']
+                + self.build_ext_args(spec, prefix))
 
-        self.setup_py('build_ext', *args)
+        self.setup_py(*args)
 
     def build_ext_args(self, spec, prefix):
         """Arguments to pass to build_ext."""
@@ -203,9 +213,11 @@ class PythonPackage(PackageBase):
 
     def build_clib(self, spec, prefix):
         """Build C/C++ libraries used by Python extensions."""
-        args = self.build_clib_args(spec, prefix)
+        args = (self.setup_args(spec, prefix),
+                + ['build_clib']
+                + self.build_clib_args(spec, prefix))
 
-        self.setup_py('build_clib', *args)
+        self.setup_py(*args)
 
     def build_clib_args(self, spec, prefix):
         """Arguments to pass to build_clib."""
@@ -213,9 +225,11 @@ class PythonPackage(PackageBase):
 
     def build_scripts(self, spec, prefix):
         '''"Build" scripts (copy and fixup #! line).'''
-        args = self.build_scripts_args(spec, prefix)
+        args = (self.setup_args(spec, prefix),
+                + ['build_scripts']
+                + self.build_scripts_args(spec, prefix))
 
-        self.setup_py('build_scripts', *args)
+        self.setup_py(*args)
 
     def build_scripts_args(self, spec, prefix):
         """Arguments to pass to build_scripts."""
@@ -223,9 +237,11 @@ class PythonPackage(PackageBase):
 
     def install(self, spec, prefix):
         """Install everything from build directory."""
-        args = self.install_args(spec, prefix)
+        args = (self.setup_args(spec, prefix),
+                + ['install']
+                + self.install_args(spec, prefix))
 
-        self.setup_py('install', *args)
+        self.setup_py(*args)
 
     def install_args(self, spec, prefix):
         """Arguments to pass to install."""

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -160,6 +160,10 @@ class PythonPackage(PackageBase):
     def python(self, *args, **kwargs):
         inspect.getmodule(self).python(*args, **kwargs)
 
+    def setup_args(self, spec, prefix):
+        """Arguments to pass before invoking setup's subcommand"""
+        return []
+
     def setup_py(self, *args, **kwargs):
         setup = self.setup_file()
         used_args = self.setup_args(self.spec, self.prefix) + args

--- a/var/spack/repos/builtin/packages/py-numpy/fix_blas_detection.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/fix_blas_detection.patch
@@ -1,0 +1,85 @@
+--- a/numpy/distutils/system_info.py	2016-06-25 17:59:40.000000000 -0700
++++ b/numpy/distutils/system_info.py	2021-03-23 15:36:25.610523000 -0700
+@@ -1682,17 +1682,40 @@
+             # treatment is not desirable, but windows is tricky.
+             info['language'] = 'f77'  # XXX: is it generally true?
+         else:
+-            lib = self.has_cblas(info)
++            lib = self.get_cblas_libs(info)
+             if lib is not None:
+                 info['language'] = 'c'
+-                info['libraries'] = [lib]
++                info['libraries'] = lib
+                 info['define_macros'] = [('HAVE_CBLAS', None)]
+         self.set_info(**info)
+ 
+-    def has_cblas(self, info):
++    def get_cblas_libs(self, info):
++        """ Check whether we can link with CBLAS interface
++
++        This method will search through several combinations of libraries
++        to check whether CBLAS is present:
++
++        1. Libraries in ``info['libraries']``, as is
++        2. As 1. but also explicitly adding ``'cblas'`` as a library
++        3. As 1. but also explicitly adding ``'blas'`` as a library
++        4. Check only library ``'cblas'``
++        5. Check only library ``'blas'``
++
++        Parameters
++        ----------
++        info : dict
++           system information dictionary for compilation and linking
++
++        Returns
++        -------
++        libraries : list of str or None
++            a list of libraries that enables the use of CBLAS interface.
++            Returns None if not found or a compilation error occurs.
++
++            Since 1.17 returns a list.
++        """
+         # primitive cblas check by looking for the header and trying to link
+         # cblas or blas
+-        res = False
+         c = distutils.ccompiler.new_compiler()
+         c.customize('')
+         tmpdir = tempfile.mkdtemp()
+@@ -1712,27 +1735,24 @@
+                 # check we can compile (find headers)
+                 obj = c.compile([src], output_dir=tmpdir,
+                                 include_dirs=self.get_include_dirs())
++            except (distutils.ccompiler.CompileError, distutils.ccompiler.LinkError):
++                return None
+ 
+-                # check we can link (find library)
+-                # some systems have separate cblas and blas libs. First
+-                # check for cblas lib, and if not present check for blas lib.
++            # check we can link (find library)
++            # some systems have separate cblas and blas libs.
++            for libs in [info['libraries'], ['cblas'] + info['libraries'],
++                         ['blas'] + info['libraries'], ['cblas'], ['blas']]:
+                 try:
+                     c.link_executable(obj, os.path.join(tmpdir, "a.out"),
+-                                      libraries=["cblas"],
++                                      libraries=libs,
+                                       library_dirs=info['library_dirs'],
+                                       extra_postargs=info.get('extra_link_args', []))
+-                    res = "cblas"
++                    return libs
+                 except distutils.ccompiler.LinkError:
+-                    c.link_executable(obj, os.path.join(tmpdir, "a.out"),
+-                                      libraries=["blas"],
+-                                      library_dirs=info['library_dirs'],
+-                                      extra_postargs=info.get('extra_link_args', []))
+-                    res = "blas"
+-            except distutils.ccompiler.CompileError:
+-                res = None
++                    pass
+         finally:
+             shutil.rmtree(tmpdir)
+-        return res
++        return None
+ 
+ 
+ class openblas_info(blas_info):

--- a/var/spack/repos/builtin/packages/py-numpy/ibm_fortran.patch
+++ b/var/spack/repos/builtin/packages/py-numpy/ibm_fortran.patch
@@ -1,0 +1,61 @@
+--- a/numpy/distutils/fcompiler/ibm.py    2016-06-18 10:15:36.000000000 -0700
++++ b/numpy/distutils/fcompiler/ibm.py    2021-03-24 15:31:35.615819000 -0700
+@@ -14,15 +14,15 @@
+ class IBMFCompiler(FCompiler):
+     compiler_type = 'ibm'
+     description = 'IBM XL Fortran Compiler'
+-    version_pattern =  r'(xlf\(1\)\s*|)IBM XL Fortran ((Advanced Edition |)Version |Enterprise Edition V|for AIX, V)(?P<version>[^\s*]*)'
++    version_pattern =  r'(xlf\(1\)\s*|)IBM XL Fortran ((Advanced Edition |)Version |Enterprise Edition V|for (AIX|Linux), V)(?P<version>[^\s*]*)'
+     #IBM XL Fortran Enterprise Edition V10.1 for AIX \nVersion: 10.01.0000.0004
+
+     executables = {
+         'version_cmd'  : ["<F77>", "-qversion"],
+-        'compiler_f77' : ["xlf"],
+-        'compiler_fix' : ["xlf90", "-qfixed"],
+-        'compiler_f90' : ["xlf90"],
+-        'linker_so'    : ["xlf95"],
++        'compiler_f77' : ["<F77>"],
++        'compiler_fix' : ["<F90>", "-qfixed"],
++        'compiler_f90' : ["<F90>"],
++        'linker_so'    : ["<F90>"],
+         'archiver'     : ["ar", "-cr"],
+         'ranlib'       : ["ranlib"]
+         }
+@@ -54,7 +54,7 @@
+         return version
+
+     def get_flags(self):
+-        return ['-qextname']
++        return []
+
+     def get_flags_debug(self):
+         return ['-g']
+@@ -64,13 +64,15 @@
+         if sys.platform=='darwin':
+             opt.append('-Wl,-bundle,-flat_namespace,-undefined,suppress')
+         else:
+-            opt.append('-bshared')
++            opt.append('-qmkshrobj')
+         version = self.get_version(ok_status=[0, 40])
+         if version is not None:
+-            if sys.platform.startswith('aix'):
+-                xlf_cfg = '/etc/xlf.cfg'
++            s, o = exec_command(["xlf_r", "-qversion", "-v"])
++            m = re.search('XL_CONFIG=(.*?):',o)
++            if m:
++                xlf_cfg = m.group(1)
+             else:
+-                xlf_cfg = '/etc/opt/ibmcmp/xlf/%s/xlf.cfg' % version
++                xlf_cfg = None
+             fo, new_cfg = make_temp_file(suffix='_xlf.cfg')
+             log.info('Creating '+new_cfg)
+             fi = open(xlf_cfg, 'r')
+@@ -86,6 +88,9 @@
+             opt.append('-F'+new_cfg)
+         return opt
+
++    def runtime_library_dir_option(self, dir):
++        return '-R%s' % dir
++
+     def get_flags_opt(self):
+         return ['-O3']

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -328,8 +328,26 @@ class PyNumpy(PythonPackage):
         spec = self.spec
 
         # https://numpy.org/devdocs/user/building.html#blas
-        #
-        # Also from https://github.com/numpy/numpy/blob/main/numpy/distutils/system_info.py:
+        if 'blas' not in spec:
+            blas = ''
+        elif spec['blas'].name == 'intel-mkl' or \
+                spec['blas'].name == 'intel-parallel-studio' or \
+                spec['blas'].name == 'intel-oneapi-mkl':
+            blas = 'mkl'
+        elif spec['blas'].name == 'blis':
+            blas = 'blis'
+        elif spec['blas'].name == 'openblas':
+            blas = 'openblas'
+        elif spec['blas'].name == 'atlas':
+            blas = 'atlas'
+        elif spec['blas'].name == 'veclibfort':
+            blas = 'accelerate'
+        else:
+            blas = 'blas'
+
+        env.set('NPY_BLAS_ORDER', blas)
+
+        # From https://github.com/numpy/numpy/blob/main/numpy/distutils/system_info.py:
         # Before 1.17 the order of finding the locations of resources was the following:
         #  1. environment variable
         #  2. section in site.cfg
@@ -345,35 +363,20 @@ class PyNumpy(PythonPackage):
         # this search and gives you the correct behavior for older versions.
         #
         # For 1.17 onwards, you can use NPY_BLAS_ORDER and this is a no-op.
-        blas = ''
-        if 'blas' in spec:
-            if spec['blas'].name == 'intel-mkl' or \
-                   spec['blas'].name == 'intel-parallel-studio' or \
-                   spec['blas'].name == 'intel-oneapi-mkl':
-                blas = 'mkl'
-            else:
-                env.set('MKLROOT', 'None')
-            if spec['blas'].name == 'blis':
-                blas = 'blis'
-            else:
-                env.set('BLIS', 'None')
-            if spec['blas'].name == 'openblas':
-                blas = 'openblas'
-            else:
-                env.set('OPENBLAS', 'None')
-            if spec['blas'].name == 'atlas':
-                blas = 'atlas'
-            else:
-                env.set('ATLAS', 'None')
-                env.set('PTATLAS', 'None')
-            if spec['blas'].name == 'veclibfort':
-                blas = 'accelerate'
-            else:
-                env.set('ACCELERATE', 'None')
-            if not blas:
-                blas = 'blas'
+        if spec['blas'].name != 'intel-mkl' and \
+                spec['blas'].name != 'intel-parallel-studio' and \
+                spec['blas'].name != 'intel-oneapi-mkl':
+            env.set('MKLROOT', 'None')
+        if spec['blas'].name != 'blis':
+            env.set('BLIS', 'None')
+        if spec['blas'].name != 'openblas':
+            env.set('OPENBLAS', 'None')
+        if spec['blas'].name != 'atlas':
+            env.set('ATLAS', 'None')
+            env.set('PTATLAS', 'None')
+        if spec['blas'].name != 'veclibfort':
+            env.set('ACCELERATE', 'None')
 
-        env.set('NPY_BLAS_ORDER', blas)
 
         # https://numpy.org/devdocs/user/building.html#lapack
         if 'lapack' not in spec:

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -21,7 +21,7 @@ class PyNumpy(PythonPackage):
     pypi = "numpy/numpy-1.19.4.zip"
     git      = "https://github.com/numpy/numpy.git"
 
-    maintainers = ['adamjstewart']
+    maintainers = ['adamjstewart', 'rblake-llnl']
 
     version('main', branch='main')
     version('master', branch='main', deprecated=True)

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -328,20 +328,23 @@ class PyNumpy(PythonPackage):
         spec = self.spec
 
         # https://numpy.org/devdocs/user/building.html#blas
+        #
         # Also from https://github.com/numpy/numpy/blob/main/numpy/distutils/system_info.py:
-        # The order of finding the locations of resources is the following:
+        # Before 1.17 the order of finding the locations of resources was the following:
         #  1. environment variable
         #  2. section in site.cfg
         #  3. DEFAULT section in site.cfg
         #  4. System default search paths (see ``default_*`` variables below).
         # Only the first complete match is returned.
         #
-        # The way the detection works, it performs the above scan FOR
-        # EACH different type of lapack. That means that if ATLAS is
-        # installed in a default location, py-numpy will always prefer
-        # it since atlas appears higher in distutils search
+        # The way the detection worked, it performed the above scan FOR
+        # EACH different type of lapack. That meant that if ATLAS was
+        # installed in a default location, py-numpy always prefered
+        # it since atlas appeared higher in distutils search
         # order. Adding these environment variables short circuits
-        # this search and gives you the correct behavior.
+        # this search and gives you the correct behavior for older versions.
+        #
+        # For 1.17 onwards, you can use NPY_BLAS_ORDER and this is a no-op.
         blas = ''
         if 'blas' in spec:
             if spec['blas'].name == 'intel-mkl' or \

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -395,7 +395,7 @@ class PyNumpy(PythonPackage):
         # https://github.com/scipy/scipy/issues/9080
         env.set('F90', spack_fc)
 
-    def fortran_args(self, spec, prefix):
+    def setup_args(self, spec, prefix):
         args = []
         if spec.satisfies('%fj'):
             args.extend(['config_fc', '--fcompiler=fj'])
@@ -404,22 +404,6 @@ class PyNumpy(PythonPackage):
               "xlf" in env['SPACK_F77']):
             args.extend(['config_fc', '--fcompiler=ibm'])
         return args
-
-    def build(self, spec, prefix):
-        """Install everything from build directory."""
-        args = (self.fortran_args(spec, prefix)
-                + ['build']
-                + self.build_args(spec, prefix))
-
-        self.setup_py(*args)
-
-    def install(self, spec, prefix):
-        """Install everything from build directory."""
-        args = (self.fortran_args(spec, prefix)
-                + ['install']
-                + self.install_args(spec, prefix))
-
-        self.setup_py(*args)
 
     def build_args(self, spec, prefix):
         args = []

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -263,9 +263,8 @@ class PyNumpy(PythonPackage):
                 extra_link_args = ''
                 rpath = ''
                 if '^netlib-lapack~shared' in spec:
-                    if "xlf" in env['SPACK_F77']:
-                        bin_index = env['SPACK_F77'].find("/bin")
-                        compiler_home = env['SPACK_F77'][:bin_index]
+                    if "xlf" in self.compiler.f77:
+                        compiler_home = os.path.dirname(os.path.dirname(self.compiler.f77))
                         extra_link_args += (
                             '{0}/alllibs/libxlf90_r.a {0}/alllibs/libxl.a '
                             + '{0}/alllibs/libxlopt.a -lrt '

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -260,24 +260,24 @@ class PyNumpy(PythonPackage):
             if '^netlib-lapack' in spec:
                 # netlib requires blas and lapack listed
                 # separately so that scipy can find them
-                extraLinkItems = ''
+                extra_link_args = ''
                 rpath = ''
                 if '^netlib-lapack~shared' in spec:
                     if "xlf" in env['SPACK_F77']:
                         bin_index = env['SPACK_F77'].find("/bin")
-                        compilerHome = env['SPACK_F77'][:bin_index]
-                        extraLinkItems += (
+                        compiler_home = env['SPACK_F77'][:bin_index]
+                        extra_link_args += (
                             '{0}/alllibs/libxlf90_r.a {0}/alllibs/libxl.a '
                             + '{0}/alllibs/libxlopt.a -lrt '
-                        ).format(compilerHome)
+                        ).format(compiler_home)
                     if "gfortran" in env['SPACK_F77']:
                         bin_index = env['SPACK_F77'].find("/bin")
-                        compilerHome = env['SPACK_F77'][:bin_index]
+                        compiler_home = env['SPACK_F77'][:bin_index]
                         found_gfortran = False
-                        for mydir, _, filenames in os.walk(compilerHome):
+                        for mydir, _, filenames in os.walk(compiler_home):
                             for filename in filenames:
                                 if filename == 'libgfortran.so':
-                                    extraLinkItems += os.path.join(mydir,
+                                    extra_link_args += os.path.join(mydir,
                                                                    filename)
                                     found_gfortran = True
                                     break
@@ -288,15 +288,15 @@ class PyNumpy(PythonPackage):
                     f.write('libraries = {0}\n'.format(blas_lib_names))
                     write_library_dirs(f, blas_lib_dirs)
                     f.write('include_dirs = {0}\n'.format(blas_header_dirs))
-                    if extraLinkItems:
-                        f.write("extra_link_args = {0}\n".format(extraLinkItems))
+                    if extra_link_args:
+                        f.write("extra_link_args = {0}\n".format(extra_link_args))
                 if spec.satisfies('+lapack'):
                     f.write('[lapack]\n')
                     f.write('libraries = {0}\n'.format(lapack_lib_names))
                     write_library_dirs(f, lapack_lib_dirs)
                     f.write('include_dirs = {0}\n'.format(lapack_header_dirs))
-                    if extraLinkItems:
-                        f.write("extra_link_args = {0}\n".format(extraLinkItems))
+                    if extra_link_args:
+                        f.write("extra_link_args = {0}\n".format(extra_link_args))
 
             if '^fujitsu-ssl2' in spec:
                 if spec.satisfies('+blas'):

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -269,9 +269,8 @@ class PyNumpy(PythonPackage):
                             '{0}/alllibs/libxlf90_r.a {0}/alllibs/libxl.a '
                             + '{0}/alllibs/libxlopt.a -lrt '
                         ).format(compiler_home)
-                    if "gfortran" in env['SPACK_F77']:
-                        bin_index = env['SPACK_F77'].find("/bin")
-                        compiler_home = env['SPACK_F77'][:bin_index]
+                    if "gfortran" in self.compiler.f77:
+                        compiler_home = os.path.dirname(os.path.dirname(self.compiler.f77))
                         found_gfortran = False
                         for mydir, _, filenames in os.walk(compiler_home):
                             for filename in filenames:
@@ -399,9 +398,7 @@ class PyNumpy(PythonPackage):
         args = []
         if spec.satisfies('%fj'):
             args.extend(['config_fc', '--fcompiler=fj'])
-        elif (spec.satisfies('platform=linux') and
-              spec.target.family == 'ppc64le' and
-              "xlf" in env['SPACK_F77']):
+        elif "xlf" in self.compiler.f77:
             args.extend(['config_fc', '--fcompiler=ibm'])
         return args
 

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -82,7 +82,7 @@ class PyScikitLearn(PythonPackage):
                 'LDFLAGS', self.spec['llvm-openmp'].libs.ld_flags)
 
     def install_args(self, spec, prefix):
-        return (super(PyScikitLearn,self).install_args(spec,prefix)
+        return (super(PyScikitLearn,self).install_args(spec, prefix)
                 + ['--skip-build'])
 
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -85,21 +85,8 @@ class PyScikitLearn(PythonPackage):
         return (super(PyScikitLearn,self).install_args(spec, prefix)
                 + ['--skip-build'])
 
-    def build(self, spec, prefix):
-        """Install everything from build directory."""
-        args = (spec['py-numpy'].package.fortran_args(spec, prefix)
-                + ['build']
-                + self.build_args(spec, prefix))
-
-        self.setup_py(*args)
-
-    def install(self, spec, prefix):
-        """Install everything from build directory."""
-        args = (spec['py-numpy'].package.fortran_args(spec, prefix)
-                + ['install']
-                + self.install_args(spec, prefix))
-
-        self.setup_py(*args)
+    def setup_args(self, spec, prefix):
+        return spec['py-numpy'].package.setup_args(spec, prefix)
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -81,6 +81,26 @@ class PyScikitLearn(PythonPackage):
             env.append_flags(
                 'LDFLAGS', self.spec['llvm-openmp'].libs.ld_flags)
 
+    def install_args(self, spec, prefix):
+        return (super(PyScikitLearn,self).install_args(spec,prefix)
+                + ['--skip-build'])
+
+    def build(self, spec, prefix):
+        """Install everything from build directory."""
+        args = (spec['py-numpy'].package.fortran_args(spec, prefix)
+                + ['build']
+                + self.build_args(spec, prefix))
+
+        self.setup_py(*args)
+
+    def install(self, spec, prefix):
+        """Install everything from build directory."""
+        args = (spec['py-numpy'].package.fortran_args(spec, prefix)
+                + ['install']
+                + self.install_args(spec, prefix))
+
+        self.setup_py(*args)
+
     @run_after('install')
     @on_package_attributes(run_tests=True)
     def install_test(self):

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -99,6 +99,9 @@ class PyScipy(PythonPackage):
     def flag_handler(self, name, flags):
         return self.spec['py-numpy'].package.flag_handler(name, flags)
 
+    def setup_args(self, spec, prefix):
+        return spec['py-numpy'].package.setup_args(spec, prefix)
+
     def build_args(self, spec, prefix):
         args = []
 
@@ -110,22 +113,6 @@ class PyScipy(PythonPackage):
             args.extend(['-j', str(make_jobs)])
 
         return args
-
-    def build(self, spec, prefix):
-        """Install everything from build directory."""
-        args = (spec['py-numpy'].package.fortran_args(spec, prefix)
-                + ['build']
-                + self.build_args(spec, prefix))
-
-        self.setup_py(*args)
-
-    def install(self, spec, prefix):
-        """Install everything from build directory."""
-        args = (spec['py-numpy'].package.fortran_args(spec, prefix)
-                + ['install']
-                + self.install_args(spec, prefix))
-
-        self.setup_py(*args)
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -96,10 +96,11 @@ class PyScipy(PythonPackage):
         if platform.mac_ver()[0][0:2] == '11':
             env.set('MACOSX_DEPLOYMENT_TARGET', '10.15')
 
+    def flag_handler(self, name, flags):
+        return self.spec['py-numpy'].package.flag_handler(name, flags)
+
     def build_args(self, spec, prefix):
         args = []
-        if spec.satisfies('%fj'):
-            args.extend(['config_fc', '--fcompiler=fujitsu'])
 
         # Build in parallel
         # Known problems with Python 3.5+
@@ -109,6 +110,22 @@ class PyScipy(PythonPackage):
             args.extend(['-j', str(make_jobs)])
 
         return args
+
+    def build(self, spec, prefix):
+        """Install everything from build directory."""
+        args = (spec['py-numpy'].package.fortran_args(spec, prefix)
+                + ['build']
+                + self.build_args(spec, prefix))
+
+        self.setup_py(*args)
+
+    def install(self, spec, prefix):
+        """Install everything from build directory."""
+        args = (spec['py-numpy'].package.fortran_args(spec, prefix)
+                + ['install']
+                + self.install_args(spec, prefix))
+
+        self.setup_py(*args)
 
     @run_after('install')
     @on_package_attributes(run_tests=True)


### PR DESCRIPTION
These are a series of changes that allow py-numpy to work with netlib-lapack on power PC systems.  In the process, I've dug deep into the py-numpy build system and reverse engineered the undocumented environment variables that need to be set in order to get things to link correctly.  Specifically, we need the following:

1.) py-numpy needs to define setup_dependent_build_environment in case anyone else tries to use py-numpy's distutil to configure fortran
2.) for those codes that DO use fortran, they need to call "config_fc" before they call "build" and "install"
3.) Extra environment variables need to be set when using py-numpy to disable it from detecting the system blas and using it by default.
4.) Depending on the blas, you might need to link in additional libraries.  netlib-lapack is specifically vulnerable to this.

 