### PR TITLE
pango: Fix build: restore autotools-based versions

### DIFF
--- a/var/spack/repos/builtin/packages/pango/package.py
+++ b/var/spack/repos/builtin/packages/pango/package.py
@@ -16,12 +16,8 @@ class Pango(AutotoolsPackage):
     list_url = "http://ftp.gnome.org/pub/gnome/sources/pango/"
     list_depth = 1
 
-    version('1.48.0', sha256='391f26f3341c2d7053e0fb26a956bd42360dadd825efe7088b1e9340a65e74e6')
-    version('1.47.0', sha256='730db8652fc43188e03218c3374db9d152351f51fc7011b9acae6d0a6c92c367')
-    version('1.46.0', sha256='9a81572ebb946187fbdd69d5ffc57e2f7a1f768cd8d2fd89dbb03fb9002a99b5')
-    version('1.45.0', sha256='381347c6f7696e64d5a7e29c93867c804ae556092b45778310b368066e089015')
-    version('1.44.0', sha256='004fffebb2ab4f89b375f4720c54b285d569526969ba791dfa20757a7f2f1d1b')
-    version('1.43.0', sha256='d2c0c253a5328a0eccb00cdd66ce2c8713fabd2c9836000b6e22a8b06ba3ddd2')
+    # These are the last pango versions which can be built using autotools,
+    # Using Meson instead has some hurdles ahead, see PR #25472
     version('1.42.0', sha256='9924d88a3dcedff753f0763814a1605307c5c9c931413b8b47ea7267d1b19446')
     version('1.41.0', sha256='1f76ef95953dc58ee5d6a53e5f1cb6db913f3e0eb489713ee9266695cae580ba')
     version('1.40.3', sha256='abba8b5ce728520c3a0f1535eab19eac3c14aeef7faa5aded90017ceac2711d3')


### PR DESCRIPTION
# This fixes the build of up to 21 packages/specs (pango and it's 20 dependents) provided in spack's builtin repo.

## Summary
Fix the pango build by restoring it to build the autoconf-enabled versions only.
The conversion to MesonPackage in #25472has not progressed so far to be usable soon.

## Details

The build of pango is broken since Aug 11 when new sha256sums were added to the package which only build with Meson.

The PR #25472 was created to convert pango to MesonPackage, but the submitted didn't even start properly and since then, there is no apparent activitly to get the build breakage introduced on Aug 11 fixed.

Issue #25651 reported the build failure, but maybe due to the bug misleading error
```
==> Error: AttributeError: module 'spack.pkg.builtin.pango' has no attribute 'autoreconf'
```
because of a wrong check which we are fixing in #26101 and #26115, the issue #25651 might have not been tackled yet.

This PR fixes issue #25651 (build `'pango@1.43:'` broken) in the only way currently feasible, by removing the meson-only sha256sums which were added in error on Aug 11.