### PR TITLE
autoconf: Fix config.guess on ppc

### DIFF
--- a/var/spack/repos/builtin/packages/autoconf/autoconf_ppc_build.patch
+++ b/var/spack/repos/builtin/packages/autoconf/autoconf_ppc_build.patch
@@ -1,0 +1,15 @@
+--- a/build-aux/config.guess
++++ b/build-aux/config.guess
+@@ -975,6 +975,12 @@
+     ppc:Linux:*:*)
+ 	echo powerpc-unknown-linux-gnu
+ 	exit ;;
++    ppc64le:Linux:*:*)
++	echo powerpc64le-unknown-linux-gnu
++	exit ;;
++    ppcle:Linux:*:*)
++	echo powerpcle-unknown-linux-gnu
++	exit ;;
+     s390:Linux:*:* | s390x:Linux:*:*)
+ 	echo ${UNAME_MACHINE}-ibm-linux
+ 	exit ;;

--- a/var/spack/repos/builtin/packages/autoconf/package.py
+++ b/var/spack/repos/builtin/packages/autoconf/package.py
@@ -36,6 +36,8 @@ class Autoconf(AutotoolsPackage, GNUMirrorPackage):
     patch('http://mirrors.mit.edu/gentoo-portage/sys-devel/autoconf/files/autoconf-2.69-perl-5.26-2.patch',
           sha256='a49dd5bac3b62daa0ff688ab4d508d71dbd2f4f8d7e2a02321926346161bf3ee',
           when='@2.62:2.69 ^perl@5.17:')
+    # Fix config.guess on ppc
+    patch('autoconf_ppc_build.patch', when='@2.61:2.69')
 
     # Note: m4 is not a pure build-time dependency of autoconf. m4 is
     # needed when autoconf runs, not only when autoconf is built.


### PR DESCRIPTION
Fix #24248
The original error: 
```
==> Installing autoconf-2.69-wrg6ktvtw2tgao5psjguouzptf5obfaf
==> No binary for autoconf-2.69-wrg6ktvtw2tgao5psjguouzptf5obfaf found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/95/954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969.tar.gz
==> Fetching https://mirror.spack.io/_source-cache/archive/77/7793209b33013dc0f81208718c68440c5aae80e7a1c4b8d336e382525af791a7
==> Fetching https://mirror.spack.io/_source-cache/archive/35/35c449281546376449766f92d49fc121ca50e330e60fefcfc9be2af3253082c2
==> Fetching https://mirror.spack.io/_source-cache/archive/a4/a49dd5bac3b62daa0ff688ab4d508d71dbd2f4f8d7e2a02321926346161bf3ee
==> Applied patch http://mirrors.mit.edu/gentoo-portage/sys-devel/autoconf/files/autoconf-2.69-fix-libtool-test.patch
==> Applied patch http://mirrors.mit.edu/gentoo-portage/sys-devel/autoconf/files/autoconf-2.69-perl-5.26.patch
==> Applied patch http://mirrors.mit.edu/gentoo-portage/sys-devel/autoconf/files/autoconf-2.69-perl-5.26-2.patch
==> Ran patch() for autoconf
==> autoconf: Executing phase: 'autoreconf'
==> Error: RuntimeError: Failed to find suitable substitutes for config.guess

/home/ubuntu/spack/lib/spack/spack/build_systems/autotools.py:172, in _do_patch_config_files:
        169
        170        # Check that we found everything we needed
        171        if to_be_found:
  >>    172            msg = 'Failed to find suitable substitutes for {0}'
        173            raise RuntimeError(msg.format(', '.join(to_be_found)))
        174
        175        # Copy the good files over the bad ones

See build log for details:
  /tmp/ubuntu/spack-stage/spack-stage-autoconf-2.69-wrg6ktvtw2tgao5psjguouzptf5obfaf/spack-build-out.txt
```

Created a patch that adds `ppcle` and `ppc64le` to `config.guess` and fixes the versions 2.64, 2.65, 2.66, 2.67, 2.68 and 2.69 of autoconf package.

/cc @hyviquel