### PR TITLE
cairo: pass tests: devs wrote that other people shouldn't attempt them

### DIFF
--- a/var/spack/repos/builtin/packages/cairo/package.py
+++ b/var/spack/repos/builtin/packages/cairo/package.py
@@ -13,6 +13,8 @@ class Cairo(AutotoolsPackage):
     homepage = "https://www.cairographics.org/"
     url      = "https://www.cairographics.org/releases/cairo-1.16.0.tar.xz"
 
+    version('1.17.4', sha256='74b24c1ed436bbe87499179a3b27c43f4143b8676d8ad237a6fa787401959705',
+            url='https://cairographics.org/snapshots/cairo-1.17.4.tar.xz')  # Snapshot
     version('1.17.2', sha256='6b70d4655e2a47a22b101c666f4b29ba746eda4aa8a0f7255b32b2e9408801df',
             url='https://cairographics.org/snapshots/cairo-1.17.2.tar.xz')  # Snapshot
     version('1.16.0', sha256='5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331', preferred=True)
@@ -76,3 +78,7 @@ class Cairo(AutotoolsPackage):
         args.extend(self.enable_or_disable('fc'))
 
         return args
+
+    def check(self):
+        """The checks are only for the cairo devs: They write others shouldn't bother"""
+        pass


### PR DESCRIPTION
The cairo test suite is huge, has many backends and the README states
that running and attempting to pass it is not a goal for normal users,
it has so many dependencies into the system, including fonts, that
passing it is not a goal realistically in reach soon:
Skip it, it takes far too long to be practical.