### PR TITLE
mountpointattr: Fix checksum of 1.1.1 and fix build of 1.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/mount-point-attributes/package.py
+++ b/var/spack/repos/builtin/packages/mount-point-attributes/package.py
@@ -16,11 +16,11 @@ class MountPointAttributes(AutotoolsPackage):
     maintainers = ['lee218llnl']
 
     version('master', branch='master')
-    version('1.1.1', sha256='397de583a99e60aae8b4485d3decac6e23f50c658a6353fea149d6dd50d3ecee', url="https://github.com/LLNL/MountPointAttributes/releases/download/v1.1.1/mountpointattr-1.1.1.tar.gz")
+    version('1.1.1', sha256='c58967fde59974407b4fee3e490b2e7d922d947e726faf2291c6c886b95abf78', url="https://github.com/LLNL/MountPointAttributes/releases/download/v1.1.1/mountpointattr-1.1.1.tar.gz")
     version('1.1', sha256='bff84c75c47b74ea09b6cff949dd699b185ddba0463cb1ff39ab138003c96e02')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
 
-    patch('mpa_type_conversion.patch', when='@1.1')
+    patch('mpa_type_conversion.patch', when='@1.1:1.1.0')


### PR DESCRIPTION
Fixes the checksum of 1.1.1 and fix build(the patch is only for version 1.1)