### PR TITLE
ccfits: version 2.5 doesn't find it's own .h: add version 2.6

### DIFF
--- a/var/spack/repos/builtin/packages/ccfits/package.py
+++ b/var/spack/repos/builtin/packages/ccfits/package.py
@@ -16,6 +16,7 @@ class Ccfits(AutotoolsPackage):
     homepage = "https://heasarc.gsfc.nasa.gov/fitsio/CCfits/"
     url      = "https://heasarc.gsfc.nasa.gov/fitsio/CCfits/CCfits-2.5.tar.gz"
 
+    version('2.6', sha256='2bb439db67e537d0671166ad4d522290859e8e56c2f495c76faa97bc91b28612')
     version('2.5', sha256='938ecd25239e65f519b8d2b50702416edc723de5f0a5387cceea8c4004a44740')
     version('2.4', sha256='ba6c5012b260adf7633f92581279ea582e331343d8c973981aa7de07242bd7f8')
 


### PR DESCRIPTION
ccfits@2.5 doesn't compile on Ubuntu 18.04: Update to version 2.6.