### PR TITLE
ddd,debuild,flux-sched: Fix the build - add missing libraries

### DIFF
--- a/var/spack/repos/builtin/packages/ddd/package.py
+++ b/var/spack/repos/builtin/packages/ddd/package.py
@@ -23,6 +23,9 @@ class Ddd(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on('gdb@4.16:')
     depends_on('lesstif@0.89:')
+    depends_on('libelf')
+    depends_on('readline')
+    depends_on('termcap')
 
     # Patch to fix hangs due to injection of bogus GDB init settings:
     #     https://savannah.gnu.org/bugs/index.php?58191

--- a/var/spack/repos/builtin/packages/debbuild/package.py
+++ b/var/spack/repos/builtin/packages/debbuild/package.py
@@ -13,3 +13,5 @@ class Debbuild(AutotoolsPackage):
     url      = "https://github.com/debbuild/debbuild/archive/20.04.0.tar.gz"
 
     version('20.04.0', sha256='e17c4f5b37e8c16592ebd99281884cabc053fb890af26531e9825417047d1430')
+
+    depends_on('gettext')

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -36,6 +36,7 @@ class FluxSched(AutotoolsPackage):
 
     depends_on("boost+graph@1.53.0,1.59.0:")
     depends_on("py-pyyaml")
+    depends_on("libedit")
     depends_on("libxml2@2.9.1:")
     depends_on("yaml-cpp")
     depends_on("uuid")


### PR DESCRIPTION
While building lots of autoconf packages to test a PR, these failed on Ubuntu 18.04 due to missing libs