### PR TITLE
Fix build-deps of diffmark, faiss, fgsl, fipcheck, nbdkit, ncbi-magicblast, xcb-util-cursor

### DIFF
--- a/var/spack/repos/builtin/packages/diffmark/package.py
+++ b/var/spack/repos/builtin/packages/diffmark/package.py
@@ -18,4 +18,5 @@ class Diffmark(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('pkg-config', type='build')
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/faiss/package.py
+++ b/var/spack/repos/builtin/packages/faiss/package.py
@@ -37,6 +37,7 @@ class Faiss(AutotoolsPackage, CudaPackage):
     depends_on('py-scipy',      when='+tests',  type=('build', 'run'))
 
     depends_on('blas')
+    depends_on('python',                        type='build')
     depends_on('py-setuptools', when='+python', type='build')
     depends_on('swig',          when='+python', type='build')
 

--- a/var/spack/repos/builtin/packages/fgsl/package.py
+++ b/var/spack/repos/builtin/packages/fgsl/package.py
@@ -24,6 +24,7 @@ class Fgsl(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
+    depends_on('pkg-config', type='build')
     depends_on('gsl@2.4', when='@1.3.0')
     depends_on('gsl@2.3', when='@1.2.0')
     depends_on('gsl@2.2.1', when='@1.1.0')

--- a/var/spack/repos/builtin/packages/fipscheck/package.py
+++ b/var/spack/repos/builtin/packages/fipscheck/package.py
@@ -21,6 +21,7 @@ class Fipscheck(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('pkg-config', type='build')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')

--- a/var/spack/repos/builtin/packages/nbdkit/package.py
+++ b/var/spack/repos/builtin/packages/nbdkit/package.py
@@ -24,6 +24,7 @@ class Nbdkit(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('pkg-config', type='build')
 
     def configure_args(self):
         args = ['bashcompdir={0}'.format(prefix)]

--- a/var/spack/repos/builtin/packages/ncbi-magicblast/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-magicblast/package.py
@@ -16,7 +16,9 @@ class NcbiMagicblast(AutotoolsPackage):
     version('1.5.0', sha256='b261914d9f7ffc0e655079ceba3e348ba11df1a1f73c4e47a4b1ca154754985c')
     version('1.3.0', sha256='47b9b65d595b5cb0c4fef22bc7f7c038fb8d4a0accdbe560d7232820575aff67')
 
+    depends_on('cpio', type='build')
     depends_on('lmdb')
+
     configure_directory = 'c++'
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
+++ b/var/spack/repos/builtin/packages/xcb-util-cursor/package.py
@@ -23,4 +23,5 @@ class XcbUtilCursor(AutotoolsPackage):
     depends_on('xcb-util-renderutil')
     depends_on('xcb-util-image')
 
+    depends_on('m4',        type='build')
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
Fix missing type='build' deps for cpio, m4, pkg-config and python in
diffmark, faiss, fgsl, fipcheck, nbdkit, ncbi-magicblast and xcb-util-cursor