### PR TITLE
acct: skip installcheck: fails checking if all progs have --help

### DIFF
--- a/var/spack/repos/builtin/packages/acct/package.py
+++ b/var/spack/repos/builtin/packages/acct/package.py
@@ -18,3 +18,7 @@ class Acct(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         env.prepend_path('PATH', self.prefix.sbin)
+
+    def installcheck(self):
+        """"Runs standard check if all programs support --help but not all do"""
+        pass


### PR DESCRIPTION
Checks if all programs support --help and --version but not all do.