### PR TITLE
g2: add maintainers and version 3.4.5

### DIFF
--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -9,7 +9,9 @@ from spack import *
 class G2(CMakePackage):
     """Utilities for coding/decoding GRIB2 messages. This library contains
     Fortran 90 decoder/encoder routines for GRIB edition 2, as well as
-    indexing/searching utility routines."""
+    indexing/searching utility routines.
+    
+    This is part of the NCEPLIBS project."""
 
     homepage = "https://noaa-emc.github.io/NCEPLIBS-g2"
     url      = "https://github.com/NOAA-EMC/NCEPLIBS-g2/archive/refs/tags/v3.4.3.tar.gz"

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -10,7 +10,7 @@ class G2(CMakePackage):
     """Utilities for coding/decoding GRIB2 messages. This library contains
     Fortran 90 decoder/encoder routines for GRIB edition 2, as well as
     indexing/searching utility routines.
-    
+
     This is part of the NCEPLIBS project."""
 
     homepage = "https://noaa-emc.github.io/NCEPLIBS-g2"

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -14,8 +14,9 @@ class G2(CMakePackage):
     homepage = "https://noaa-emc.github.io/NCEPLIBS-g2"
     url      = "https://github.com/NOAA-EMC/NCEPLIBS-g2/archive/refs/tags/v3.4.3.tar.gz"
 
-    maintainers = ['t-brown']
+    maintainers = ['t-brown', 'kgerheiser', 'Hang-Lei-NOAA', 'edwardhartnett']
 
+    version('3.4.5', sha256='c18e991c56964953d778632e2d74da13c4e78da35e8d04cb742a2ca4f52737b6')
     version('3.4.3', sha256='679ea99b225f08b168cbf10f4b29f529b5b011232f298a5442ce037ea84de17c')
 
     depends_on('jasper')


### PR DESCRIPTION
added new release, added noaa software maintainers to maintainer list for NCEPLIBS-g2