### PR TITLE
autotools.py/autoreconf: Show the depends_on()s to add to the package

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -252,6 +252,18 @@ class AutotoolsPackage(PackageBase):
         if self.force_autoreconf:
             force_remove(self.configure_abs_path)
 
+    def _autoreconf_warning(self, spec, missing):
+        msg = ("Cannot generate configure: missing dependencies {0}.\n\nPlease add "
+               "the following lines to the package:\n\n".format(", ".join(missing)))
+
+        for dep in missing:
+            msg += ("    depends_on('{0}', type='build', when='@{1}')\n"
+                    .format(dep, spec.version))
+
+        msg += "\nUpdate the version (when='@{0}') as needed.".format(spec.version)
+
+        return msg
+
     def autoreconf(self, spec, prefix):
         """Not needed usually, configure should be already there"""
         # If configure exists nothing needs to be done
@@ -261,9 +273,10 @@ class AutotoolsPackage(PackageBase):
         needed_dependencies = ['autoconf', 'automake', 'libtool']
         build_deps = [d.name for d in spec.dependencies(deptype='build')]
         missing = [x for x in needed_dependencies if x not in build_deps]
+
         if missing:
-            msg = 'Cannot generate configure: missing dependencies {0}'
-            raise RuntimeError(msg.format(missing))
+            raise RuntimeError(self._autoreconf_warning(spec, missing))
+
         tty.msg('Configure script not found: trying to generate it')
         tty.warn('*********************************************************')
         tty.warn('* If the default procedure fails, consider implementing *')

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -258,8 +258,9 @@ class AutotoolsPackage(PackageBase):
         if os.path.exists(self.configure_abs_path):
             return
         # Else try to regenerate it
-        autotools = ['m4', 'autoconf', 'automake', 'libtool']
-        missing = [x for x in autotools if x not in spec]
+        needed_dependencies = ['autoconf', 'automake', 'libtool']
+        build_deps = [d.name for d in spec.dependencies(deptype='build')]
+        missing = [x for x in needed_dependencies if x not in build_deps]
         if missing:
             msg = 'Cannot generate configure: missing dependencies {0}'
             raise RuntimeError(msg.format(missing))


### PR DESCRIPTION
Based on the commit to fix missing autoreconf depends in #26101:
    
Generate a template for cut-and-paste into the package.py to fix it:
```py 
=> numactl: Executing phase: 'autoreconf'
==> [date-time] Warning: *********************************************************
*** Please add these lines to the depends of numactl/package.py:
    depends_on('autoconf', type='build', when='@2.0.14')
    depends_on('automake', type='build', when='@2.0.14')
    depends_on('libtool', type='build', when='@2.0.14')
*** and tweak the version in when='@...' as needed.
==> [date-time] Warning: *********************************************************
==> Error: RuntimeError: Cannot generate configure: missing dependencies ['autoconf', 'automake', 'libtool']
```