### PR TITLE
Add Slepc v3.15.2

### DIFF
--- a/var/spack/repos/builtin/packages/slepc/package.py
+++ b/var/spack/repos/builtin/packages/slepc/package.py
@@ -13,7 +13,7 @@ class Slepc(Package, CudaPackage, ROCmPackage):
     """Scalable Library for Eigenvalue Problem Computations."""
 
     homepage = "https://slepc.upv.es"
-    url      = "https://slepc.upv.es/download/distrib/slepc-3.6.2.tar.gz"
+    url      = "https://slepc.upv.es/download/distrib/slepc-3.15.2.tar.gz"
     git      = "https://gitlab.com/slepc/slepc.git"
 
     maintainers = ['joseeroman', 'balay']
@@ -21,6 +21,7 @@ class Slepc(Package, CudaPackage, ROCmPackage):
     test_requires_compiler = True
 
     version('main', branch='main')
+    version('3.15.2', sha256='15fd317c4dd07bb41a994ad4c27271a6675af5f2abe40b82a64a27eaae2e632a')
     version('3.15.1', sha256='9c7c3a45f0d9df51decf357abe090ef05114c38a69b7836386a19a96fb203aea')
     version('3.15.0', sha256='e53783ae13acadce274ea65c67186b5ab12332cf17125a694e21d598aa6b5f00')
     version('3.14.2', sha256='3e54578dda1f4c54d35ac27d02f70a43f6837906cb7604dbcec0e033cfb264c8')


### PR DESCRIPTION
Add version 3.15.2 to Slepc which includes multiple new features. 

**Summarized Changelog:**
- SVD: New solver SVDRANDOMIZED.
- EPS: New interface to external package EVSL.
- Import SLEPc4py sources into SLEPc source tree.
- New function EPSKrylovSchurGetKSP() to extract the KSP object used in the case
of spectrum slicing runs. This allows setting MUMPS options even with partitions.

Full changelog can be found [here](https://gitlab.com/slepc/slepc/-/blob/main/CHANGELOG.md).

**Test Plan:**
Slepc 3.15.2 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/actions/runs/1253878519).