### PR TITLE
Add Rclone v1.56.1

### DIFF
--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -11,10 +11,11 @@ class Rclone(Package):
        to and from various cloud storage providers"""
 
     homepage = "https://rclone.org"
-    url      = "https://github.com/ncw/rclone/releases/download/v1.43/rclone-v1.43.tar.gz"
+    url      = "https://github.com/ncw/rclone/releases/download/v1.56.1/rclone-v1.56.1.tar.gz"
 
     maintainers = ['alecbcs']
 
+    version('1.56.1', sha256='090b4b082caa554812f341ae26ea6758b40338836122595d6283c60c39eb5a97')
     version('1.56.0', sha256='81d2eda23ebaad0a355aab6ff030712470a42505b94c01c9bb5a9ead9168cedb')
     version('1.55.1', sha256='25da7fc5c9269b3897f27b0d946919df595c6dda1b127085fda0fe32aa59d29d')
     version('1.55.0', sha256='75accdaedad3b82edc185dc8824a19a59c30dc6392de7074b6cd98d1dc2c9040')


### PR DESCRIPTION
Add version 1.56.1 to Rclone which includes multiple bug fixes and performance improvements.

**Summarized Changelog:**
- accounting: Fix maximum bwlimit by scaling scale max token bucket size.
- rc: Fix speed does not update in core/stats.
- selfupdate: Fix --quiet option, not quite quiet.
- serve http: Fix serve http exiting directly after starting.
- Fix crash when truncating a just uploaded object.

Full changelog can be found [here](https://rclone.org/changelog/#v1-56-1-2021-09-19).

**Test Plan:**
Rclone v1.56.1 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/actions/runs/1250869807).