### PR TITLE
Add Picard v2.26.2

### DIFF
--- a/var/spack/repos/builtin/packages/picard/package.py
+++ b/var/spack/repos/builtin/packages/picard/package.py
@@ -16,12 +16,13 @@ class Picard(Package):
     """
 
     homepage = "https://broadinstitute.github.io/picard/"
-    url      = "https://github.com/broadinstitute/picard/releases/download/2.9.2/picard.jar"
+    url      = "https://github.com/broadinstitute/picard/releases/download/2.26.2/picard.jar"
     _urlfmt  = "https://github.com/broadinstitute/picard/releases/download/{0}/picard.jar"
     _oldurlfmt = 'https://github.com/broadinstitute/picard/releases/download/{0}/picard-tools-{0}.zip'
 
     # They started distributing a single jar file at v2.6.0, prior to
     # that it was a .zip file with multiple .jar and .so files
+    version('2.26.2', sha256='99fab1699a735fd048a05975a243774f1cc99e87a9b28311d4aa872d06390474', expand=False)
     version('2.25.7', sha256='dc0e830d3e838dee2b4f4aa1c9631fb3a4c3ec982de8dfe5145fc748104c7146', expand=False)
     version('2.25.6', sha256='768709826514625381e6fa3920945360167f4e830bf72f79eb070da059676f02', expand=False)
     version('2.25.5', sha256='f7fa9784b84d384abfcbd77076f5ceab7b2797dc863ac35fd41470daa3efe3a5', expand=False)


### PR DESCRIPTION
Add version 2.26.2 to Picard which includes multiple bug fixes.

**Changelog:**
- Changed calculation of call rate to account for zeroed out SNPs. (broadinstitute/picard#1711)
- Updated documentation for MarkDuplicates.java (broadinstitute/picard#1704)
- Fixed a tiny typo in CollectWgsMetrics (broadinstitute/picard#1705)
- Added adapter and quality trimming to IlluminaBasecallsToFastq. (broadinstitute/picard#1646)

Full changelog can be found [here](https://github.com/broadinstitute/picard/releases).

**Test Plan:**
Picard v2.26.2 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/actions/runs/1246177193).