### PR TITLE
Add Go v1.17.1 (and v1.17)

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -43,6 +43,8 @@ class Go(Package):
 
     maintainers = ['alecbcs']
 
+    version('1.17.1',  sha256='49dc08339770acd5613312db8c141eaf61779995577b89d93b541ef83067e5b1')
+    version('1.17',    sha256='3a70e5055509f347c0fb831ca07a2bf3b531068f349b14a3c652e9b5b67beb5d')
     version('1.16.6',  sha256='a3a5d4bc401b51db065e4f93b523347a4d343ae0c0b08a65c3423b05a138037d')
     version('1.16.5',  sha256='7bfa7e5908c7cc9e75da5ddf3066d7cbcf3fd9fa51945851325eebc17f50ba80')
     version('1.16.4',  sha256='ae4f6b6e2a1677d31817984655a762074b5356da50fb58722b99104870d43503')


### PR DESCRIPTION
Add version 1.17.1 to Go which includes multiple bug fixes and changes to the language. 

**Changelog:**
The full changelog for the 1.17 series of releases can be found [here](https://golang.org/doc/go1.17).

**Test Plan:**
Go v1.17.1 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/runs/3667349619).