### PR TITLE
kmod: Add the missing depends on m4 and pkgconfig

### DIFF
--- a/var/spack/repos/builtin/packages/kmod/package.py
+++ b/var/spack/repos/builtin/packages/kmod/package.py
@@ -23,14 +23,16 @@ class Kmod(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
+    depends_on('pkgconfig', type='build')
+    depends_on('lzma')
 
     def autoreconf(self, spec, prefix):
         bash = which("bash")
         bash('autogen.sh')
 
     def configure_args(self):
-        args = ["--with-bashcompletiondir=" +
+        args = ['--disable-manpages',
+                '--with-bashcompletiondir=' +
                 join_path(self.spec['kmod'].prefix, 'share',
                           'bash-completion', 'completions')]
         return args


### PR DESCRIPTION
The build needs `pkgconfig` and `lzma`, `m4` is already added by `autoconf`.

Disable generation of kmod manpages as spack does not have xsltproc yet.