### PR TITLE
axel(download manager): bump version and fix build

### DIFF
--- a/var/spack/repos/builtin/packages/axel/package.py
+++ b/var/spack/repos/builtin/packages/axel/package.py
@@ -10,18 +10,15 @@ class Axel(AutotoolsPackage):
     """Axel is a light command line download accelerator for Linux and Unix"""
 
     homepage = "https://github.com/axel-download-accelerator/axel"
-    url      = "https://github.com/axel-download-accelerator/axel/archive/v2.16.1.tar.gz"
+    url      = 'https://github.com/axel-download-accelerator/axel/releases/download/v2.17.10/axel-2.17.10.tar.bz2'
 
-    version('2.16.1', sha256='64529add74df3db828f704b42d4ec3fcdacb8142c84f051f9213637c337e706c')
+    version('2.17.10', sha256='c0d26eba6b94945cd98c5b69ca6df2744639d17bfd49047ef51a8a48f067de10')
+    version('2.16.1',  sha256='763066efc61e4f7be2eb59afa049bdbc520837e01c95a78f403e542ad82f2719')
 
-    depends_on('m4', type='build')
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool', type='build')
     depends_on('pkgconfig', type='build')
+    # For systems not providing libintl APU in the system libc (glibc integrated it)
     depends_on('gettext')
     depends_on('openssl')
 
-    def autoreconf(self, spec, prefix):
-        bash = which('bash')
-        bash('./autogen.sh')
+    def installcheck(self):
+        Executable(self.prefix.bin.axel)('--version')


### PR DESCRIPTION
Use the release tarballs which fix the build and does not need all the autotools and pkg-config as dependencies. :+1: 