### PR TITLE
xload: fix build by disabling gettext and add new version

### DIFF
--- a/var/spack/repos/builtin/packages/xload/package.py
+++ b/var/spack/repos/builtin/packages/xload/package.py
@@ -11,8 +11,9 @@ class Xload(AutotoolsPackage, XorgPackage):
     system load average."""
 
     homepage = "https://cgit.freedesktop.org/xorg/app/xload"
-    xorg_mirror_path = "app/xload-1.1.2.tar.gz"
+    xorg_mirror_path = "app/xload-1.1.3.tar.gz"
 
+    version('1.1.3', sha256='9952e841d25ab2fd0ce5e27ba91858331c3f97575d726481772d4deb89432483')
     version('1.1.2', sha256='4863ad339d22c41a0ca030dc5886404f5ae8b8c47cd5e09f0e36407edbdbe769')
 
     depends_on('libxaw')
@@ -23,3 +24,6 @@ class Xload(AutotoolsPackage, XorgPackage):
     depends_on('xproto@7.0.17:')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
+
+    def configure_args(self):
+        return ['ac_cv_search_gettext=no']


### PR DESCRIPTION
xload failed with unresolved referenced to `libint`l functions:

Disabled it's use of `gettext` calls and added the last "new" version.