### PR TITLE
cgdcbxd(net_prio cgroup daemon): Add variant '+system_install'

### DIFF
--- a/var/spack/repos/builtin/packages/cgdcbxd/package.py
+++ b/var/spack/repos/builtin/packages/cgdcbxd/package.py
@@ -20,10 +20,17 @@ class Cgdcbxd(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('libcgroup@0.32:')
     depends_on('libmnl')
 
     def autoreconf(self, spec, prefix):
         bash = which('bash')
         bash('./bootstrap.sh')
+
+    @property
+    def install_targets(self):
+        # Without DESTDIR=self.prefix, an attempt would be made to install
+        # configuration files to /etc, which would faild the build and even
+        # when privileges for this exist, spack could not remove it on uninstall:
+        return ['install', 'DESTDIR={0}'.format(self.prefix)]


### PR DESCRIPTION
Fix the build for normal non-root/non-system-user builds:

Add variant `'system_install'` (like `libfuse`) to not attempt install
int the system by default. On `~system_install`, use `DESTDIR=prefix`

Also add `pkgconfig` and remove not explicitly needed `depends_on('m4')`