### PR TITLE
mvapich2: add missing build dependency (flex)

### DIFF
--- a/var/spack/repos/builtin/packages/mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/mvapich2/package.py
@@ -112,6 +112,7 @@ class Mvapich2(AutotoolsPackage):
 
     depends_on('findutils', type='build')
     depends_on('bison', type='build')
+    depends_on('flex', type='build')
     depends_on('pkgconfig', type='build')
     depends_on('zlib')
     depends_on('libpciaccess', when=(sys.platform != 'darwin'))


### PR DESCRIPTION
The `flex` package is not listed as a build dependency for `mvapich2`. While this may not be a big problem as this package seems to be installed in most distributions, that is not the case in Ubuntu 20.04. This PR just adds the following line to `mvapich2/package.py`:

`depends_on('pkgconfig', type='build')`