### PR TITLE
libfuse: Fix build when meson doesn't get host's udev pkg

### DIFF
--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -15,6 +15,7 @@ class Libfuse(MesonPackage):
     homepage = "https://github.com/libfuse/libfuse"
     url      = "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz"
 
+    version('3.10.5', sha256='e73f75e58da59a0e333d337c105093c496c0fd7356ef3a5a540f560697c9c4e6')
     version('3.10.4', sha256='bfcb2520fd83db29e9fefd57d3abd5285f38ad484739aeee8e03fbec9b2d984a')
     version('3.10.3', sha256='c32527782cef620df58b162aa29901d1fb13253b029375d5860a2253a810344e')
     version('3.10.2', sha256='a16f93cc083264afd0d2958a0dc88f24c6c5d40a9f3842c645b1909e13edb75f')
@@ -59,6 +60,13 @@ class Libfuse(MesonPackage):
             args.append('-Duseroot=true')
         else:
             args.append('-Duseroot=false')
+
+        if '~system_install' in self.spec:
+            # Fix meson's setup if meson does not have the host system's udev package:
+            args.append('-Dudevrulesdir={0}'.format(self.prefix.etc.rules.d))
+        else:
+            # Likewise, but with +system_install, it may install to /lib/udev/rules.d:
+            args.append('-Dudevrulesdir={0}'.format('/lib/udev/rules.d'))
 
         return args
 


### PR DESCRIPTION
Despite the patch disabling installation of rules, meson's setup stage looks up the udev package to get `/lib/udev/rules.d`, but as spack has no `systemd/udev` package, it would fail to build.

Fix such builds by passing `-Dudevrulesdir` and bump version to 3.10.5