### PR TITLE
Cloverleaf: adding AOCC support

### DIFF
--- a/var/spack/repos/builtin/packages/cloverleaf/aocc_support.patch
+++ b/var/spack/repos/builtin/packages/cloverleaf/aocc_support.patch
@@ -1,0 +1,66 @@
+--- CloverLeaf_ref/Makefile	2021-09-22 04:02:11.724415652 -0500
++++ CloverLeaf_ref/Makefile_aocc	2021-09-22 04:08:10.620607168 -0500
+@@ -31,6 +31,7 @@
+ # To select a OpenMP compiler option, do this in the shell before typing make:-
+ #
+ #  export COMPILER=INTEL       # to select the Intel flags
++#  export COMPILER=AOCC        # to select the AOCC flags
+ #  export COMPILER=SUN         # to select the Sun flags
+ #  export COMPILER=GNU         # to select the Gnu flags
+ #  export COMPILER=CRAY        # to select the Cray flags
+@@ -41,6 +42,7 @@
+ # or this works as well:-
+ #
+ # make COMPILER=INTEL
++# make COMPILER=AOCC
+ # make COMPILER=SUN
+ # make COMPILER=GNU
+ # make COMPILER=CRAY
+@@ -63,6 +65,7 @@
+ endif
+ 
+ OMP_INTEL     = -openmp
++OMP_AOCC      = -fopenmp
+ OMP_SUN       = -xopenmp=parallel -vpara
+ OMP_GNU       = -fopenmp
+ OMP_CRAY      =
+@@ -73,6 +76,7 @@
+ OMP=$(OMP_$(COMPILER))
+ 
+ FLAGS_INTEL     = -O3 -no-prec-div
++FLAGS_AOCC      = -O3 -funroll-loops
+ FLAGS_SUN       = -fast -xipo=2 -Xlistv4
+ FLAGS_GNU       = -O3 -march=native -funroll-loops
+ FLAGS_CRAY      = -em -ra -h acc_model=fast_addr:no_deep_copy:auto_async_all
+@@ -82,6 +86,7 @@
+ FLAGS_ARM      = -O3 -ffp-contract=fast -march=armv8.1-a -mcpu=native
+ 
+ CFLAGS_INTEL     = -O3 -no-prec-div -restrict -fno-alias
++CFLAGS_AOCC      = -O3 -funroll-loops
+ CFLAGS_SUN       = -fast -xipo=2
+ CFLAGS_GNU       = -O3 -march=native -funroll-loops
+ CFLAGS_CRAY      = -em -h list=a
+@@ -93,6 +98,7 @@
+ 
+ ifdef DEBUG
+   FLAGS_INTEL     = -O0 -g -debug all -check all -traceback -check noarg_temp_created
++  FLAGS_AOCC      = -O0 -g -O -Wall -Wextra -fsanitize=address
+   FLAGS_SUN       = -g -xopenmp=noopt -stackvar -u -fpover=yes -C -ftrap=common
+   FLAGS_GNU       = -O0 -g -O -Wall -Wextra -fbounds-check
+   FLAGS_CRAY      = -O0 -g -em -eD
+@@ -103,6 +109,7 @@
+   FLAGS_          = -O0 -g
+ 
+   CFLAGS_INTEL    = -O0 -g -debug all -traceback
++  CFLAGS_AOCC     = -O0 -g -Wall -Wextra -fsanitize=address
+   CFLAGS_SUN      = -g -O0 -xopenmp=noopt -stackvar -u -fpover=yes -C -ftrap=common
+   CFLAGS_GNU       = -O0 -g -O -Wall -Wextra -fbounds-check
+   CFLAGS_CRAY     = -O0 -g -em -eD
+@@ -115,6 +122,7 @@
+ 
+ ifdef IEEE
+   I3E_INTEL     = -fp-model strict -fp-model source -prec-div -prec-sqrt
++  I3E_AOCC      = -ffast-math
+   I3E_SUN       = -fsimple=0 -fns=no
+   I3E_GNU       = -ffloat-store
+   I3E_CRAY      = -hflex_mp=intolerant

--- a/var/spack/repos/builtin/packages/cloverleaf/package.py
+++ b/var/spack/repos/builtin/packages/cloverleaf/package.py
@@ -39,7 +39,7 @@ class Cloverleaf(MakefilePackage):
     @run_before('build')
     def patch_for_reference_module(self):
         if self.spec.satisfies("@master %aocc"):
-            fp = self.package_dir + "/aocc_support.patch"
+            fp = join_path(self.package_dir, "aocc_support.patch")
             which('patch')('-s', '-p0', '-i', '{0}'.format(fp), '-d', '.')
 
     @property

--- a/var/spack/repos/builtin/packages/cloverleaf/package.py
+++ b/var/spack/repos/builtin/packages/cloverleaf/package.py
@@ -36,6 +36,12 @@ class Cloverleaf(MakefilePackage):
     conflicts('build=serial', when='%aocc', msg="Currently AOCC supports only ref variant")
     conflicts('@1.1', when='%aocc', msg="AOCC support is provided from version v.1.3 and above")
 
+    @run_before('build')
+    def patch_for_reference_module(self):
+        if self.spec.satisfies("@master %aocc"):
+            fp = self.package_dir + "/aocc_support.patch"
+            which('patch')('-s', '-p0', '-i', '{0}'.format(fp), '-d', '.')
+
     @property
     def type_of_build(self):
         build = 'ref'


### PR DESCRIPTION
History:
- Initial pull request is raised to add AOCC support for CloverLeaf (#25106), 

> from @adamjstewart: Instead of patching master, why not contribute the patch upstream so that everyone can benefit from it?  

As per the community comments, we up streamed the patch with `CloverLeaf_ref `source code (https://github.com/UK-MAC/CloverLeaf_ref/pull/7),  AOCC specific changes are now available in `Cloverleaf_ref@master` branch whereas in Spack recipe `Cloverleaf@master` refers `CloverLeaf_ref@b5e598d`, So, this branch will not have AOCC support as it was released 15 months back.

This pull request applies a patch onto the `Cloverleaf@master`  to extend AOCC support until new version of `Cloverleaf_ref `with AOCC support is released 

