### PR TITLE
spindle: Fix build: Version bump & add depends_on('mpi')

### DIFF
--- a/var/spack/repos/builtin/packages/spindle/package.py
+++ b/var/spack/repos/builtin/packages/spindle/package.py
@@ -13,8 +13,21 @@ class Spindle(AutotoolsPackage):
        linked libraries, causing site-wide performance problems.
     """
     homepage = "https://computing.llnl.gov/project/spindle/"
-    url      = "https://github.com/hpc/Spindle/archive/v0.8.1.tar.gz"
+    url      = "https://github.com/hpc/Spindle/archive/v0.12.tar.gz"
 
+    version('0.12',  sha256='3fd9d0afefa9072fffdf2cfd80a0b5e557e201a0b0eb02e7379eae65e64eb1f2')
     version('0.8.1', sha256='c1e099e913faa8199be5811dc7b8be0266f0d1fd65f0a3a25bb46fbc70954ed6')
 
     depends_on("launchmon")
+    # All versions provide the runtime option --no-mpi to not use MPI, but mpi
+    # is needed for the build:
+    # 0.8.1 wants to compile tests with mpi.h, newer versions need mpicc
+    depends_on("mpi")
+
+    # Workaround for:
+    # spindle_logd.cc:65:76: error: narrowing conversion of '255' from 'int' to 'char'
+    # spindle_logd.cc:65:76: error: narrowing conversion of '223' from 'int' to 'char'
+    # spindle_logd.cc:65:76: error: narrowing conversion of '191' from 'int' to 'char'
+    @when('@0.8.1 %gcc')
+    def setup_build_environment(self, env):
+        env.append_flags('CPPFLAGS', '-Wno-narrowing')


### PR DESCRIPTION
spindle 0.8.1 compiles tests in the build stage using mpi.h.
Newer versions compile files with mpicc -> adding depends on mpi.

Spindle supports the --no-mpi to disable MPI.

Aslo workaround this (on at least Ubuntu fatal) compile error for gcc of 0.8.1 by adding -Wno-narrowing for it:
```yaml
spindle_logd.cc:65:76: error: narrowing conversion of '255' from 'int' to 'char'
spindle_logd.cc:65:76: error: narrowing conversion of '223' from 'int' to 'char'
spindle_logd.cc:65:76: error: narrowing conversion of '191' from 'int' to 'char'
```
