### PR TITLE
tauola: Fix build: The current build wants lhapdf headers by default

### DIFF
--- a/var/spack/repos/builtin/packages/tauola/package.py
+++ b/var/spack/repos/builtin/packages/tauola/package.py
@@ -18,7 +18,7 @@ class Tauola(AutotoolsPackage):
 
     variant('hepmc', default=True, description="Enable hepmc 2.x support")
     variant('hepmc3', default=False, description="Enable hepmc3 support")
-    variant('lhapdf', default=False, description="Enable lhapdf support")
+    variant('lhapdf', default=True, description="Enable lhapdf support")
     variant('cxxstd',
             default='11',
             values=('11', '14', '17', '20'),


### PR DESCRIPTION
Enable the variant `lhapdf` by default.

The hand-written `configure` script of this package does not handle `--without-FEATURE` at all and the build fails with it disabled, because:

The source wants to use `lhapdf` headers even if support of `lhapdf` is not indicated using `--with-lhapdf`.

Thiis commit fixes the build of the current package and provides the TauSpinner feature as well.