### PR TITLE
nginx: Bump version for OpenSSL@3 and restrict @:1.21.2 to openssl@:1

### DIFF
--- a/var/spack/repos/builtin/packages/nginx/package.py
+++ b/var/spack/repos/builtin/packages/nginx/package.py
@@ -14,11 +14,13 @@ class Nginx(AutotoolsPackage):
     homepage = "https://nginx.org/en/"
     url      = "https://nginx.org/download/nginx-1.12.0.tar.gz"
 
+    version('1.21.3', sha256='14774aae0d151da350417efc4afda5cce5035056e71894836797e1f6e2d1175a')
     version('1.15.6', sha256='a3d8c67c2035808c7c0d475fffe263db8c353b11521aa7ade468b780ed826cc6')
     version('1.13.8', sha256='8410b6c31ff59a763abf7e5a5316e7629f5a5033c95a3a0ebde727f9ec8464c5')
     version('1.12.0', sha256='b4222e26fdb620a8d3c3a3a8b955e08b713672e1bc5198d1e4f462308a795b30')
 
     depends_on('openssl')
+    depends_on('openssl@:1', when='@:1.21.2')
     depends_on('pcre')
     depends_on('zlib')
 


### PR DESCRIPTION
Bump the version of `nginx` to the current release which supports to build with OpenSSL-3.0.0.

Our current older versions of `nginx` use an API which OpenSSL-3.0.0 deprecated:

As nginx builds with deprecations as error, they are now restricted to OpenSSL:@1. 

Tested using the build of the two most recent versions in the OpenSSL-3.0.0 branch of @haampie 
