### PR TITLE
xfwp: Fix build using: env.append_flags('CPPFLAGS', '-D_GNU_SOURCE')

### DIFF
--- a/var/spack/repos/builtin/packages/xfwp/package.py
+++ b/var/spack/repos/builtin/packages/xfwp/package.py
@@ -21,5 +21,7 @@ class Xfwp(AutotoolsPackage, XorgPackage):
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
-    # FIXME: fails with the error message:
+    # Fixes this and a long list of other compilation errors:
     # io.c:1039:7: error: implicit declaration of function 'swab'
+    def setup_build_environment(self, env):
+        env.append_flags('CPPFLAGS', '-D_GNU_SOURCE')


### PR DESCRIPTION
Without `-D_GNU_SOURCE`, the build of `xfwp` has many compilation errors.
Example: `io.c:1039:7: error: implicit declaration of function 'swab'`