### PR TITLE
scallop: Fix build by bumping the version to 0.10.5

### DIFF
--- a/var/spack/repos/builtin/packages/scallop/package.py
+++ b/var/spack/repos/builtin/packages/scallop/package.py
@@ -10,8 +10,9 @@ class Scallop(AutotoolsPackage):
     """Scallop is a reference-based transcriptome assembler for RNA-seq"""
 
     homepage = "https://github.com/Kingsford-Group/scallop"
-    url      = "https://github.com/Kingsford-Group/scallop/releases/download/v0.10.3/scallop-0.10.3.tar.gz"
+    url      = "https://github.com/Kingsford-Group/scallop/releases/download/v0.10.5/scallop-0.10.5.tar.gz"
 
+    version('0.10.5', sha256='b09e3c61f1b3b1da2a96d9d8429d80326a3bb14f5fe6af9b5e87570d4b86937a')
     version('0.10.3', sha256='04eb3ab27ed8c7ae38e1780d6b2af16b6a2c01807ffafd59e819d33bfeff58a0')
 
     depends_on('clp')


### PR DESCRIPTION
build of 0.10.3 fails with: `CoinPragma.hpp: No such file or directory`