### PR TITLE
dnstop: Fix build: needs ncurses and it forgot to add -ltinfo

### DIFF
--- a/var/spack/repos/builtin/packages/dnstop/package.py
+++ b/var/spack/repos/builtin/packages/dnstop/package.py
@@ -15,6 +15,10 @@ class Dnstop(AutotoolsPackage):
     version('master', branch='master')
 
     depends_on('libpcap')
+    depends_on('ncurses')
+
+    def configure_args(self):
+        return ['LIBS=-ltinfo']
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
`dnstop` misses a `depends('ncurses')` and it needs to link with `libtinfo` from `ncurses` as well.