### PR TITLE
dropwatch: make check starts a daemon which does not stop: Skip it

### DIFF
--- a/var/spack/repos/builtin/packages/dropwatch/package.py
+++ b/var/spack/repos/builtin/packages/dropwatch/package.py
@@ -20,7 +20,7 @@ class Dropwatch(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('libnl')
     depends_on('libpcap')
     depends_on('binutils')
@@ -29,3 +29,7 @@ class Dropwatch(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         bash = which('bash')
         bash('./autogen.sh')
+
+    def check(self):
+        """`make check` starts a daemon which does not terminate, blocking the builds"""
+        pass


### PR DESCRIPTION
dropwatch is a network packet drop checker and it's make check (run by `spack install --test=root dropwatch`) starts
a daemon which does not terminate (tested in singularity containers).

- Skip this test to not block builds.
- Add depends_on('pkgconfig', type='build')
  It is needed in case the host does not have pkg-config installed.
- Remove the depends_on('m4', type='build'):
  The depends_on('autoconf', type='build') pulls m4 as it needs it.