### PR TITLE
Make the concretizer consider package versions as ranges consistently

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1230,12 +1230,6 @@ class SpackSolverSetup(object):
                 if v.satisfies(versions)
             ]
 
-            # This is needed to account for a variable number of
-            # numbers e.g. if both 1.0 and 1.0.2 are possible versions
-            exact_match = [v for v in allowed_versions if v == versions]
-            if exact_match:
-                allowed_versions = exact_match
-
             # generate facts for each package constraint and the version
             # that satisfies it
             for v in allowed_versions:

--- a/var/spack/repos/builtin.mock/packages/depends-and-conflicts-with-exact-versions/package.py
+++ b/var/spack/repos/builtin.mock/packages/depends-and-conflicts-with-exact-versions/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class DependsAndConflictsWithExactVersions(Package):
+    """
+    This package is used to test whether the concretizer interprets the version
+    3.0 in conflicts('mpich@3.0') and depends_on('mpich@3.0') as the closed-open
+    range [3.0, 3.1). This is relevant for packages like mpich which have a
+    versioning scheme that goes 3.0, 3.0.1, 3.0.2, ..., and 3.0 can be
+    ambiguous, as mpich@3.0.1 satisfies mpich@3.0 as spec.
+    """
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/a-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    variant('type', values=(
+        'depends_on_3.0',
+        'conflicts_with_3.0',
+        'depends_on_3.0:3.0.0',
+        'conflicts_with_3.0:3.0.0',
+    ), multi=False, default='depends_on_3.0')
+
+    depends_on('mpich')
+
+    depends_on('mpich@3.0', when='type=depends_on_3.0')
+    conflicts('^mpich@3.0', when='type=conflicts_with_3.0')
+    depends_on('mpich@3.0:3.0.0', when='type=depends_on_3.0:3.0.0')
+    conflicts('^mpich@3.0:3.0.0', when='type=conflicts_with_3.0:3.0.0')


### PR DESCRIPTION
Partly resolves #8957

If you have an external package, and you want to add some identifier as a 
version suffix, say `pkg@x.y.z-identifier`, then Spack considers this to 
satisfy `pkg@x.y.z`:

```python
spack.spec.Spec('pkg@x.y.z-identifier').satisfies(spack.spec.Spec('pkg@x.y.z'))  # True
```

So whenever a package specifies

```python
conflicts('^pkg@x.y.z')
```

you would expect this to conflict with the external package.

Surprisingly this is not the case, because the concretizer believes it should
interpret `x.y.z` as an exact version, not as the closed-open range `[x.y.z,
x.y.z+1)`.

The rational for this is to support packages with versions `1.0`, `1.0.1`,
`1.0.2`, et cetera. However, the fact that some packages have poor choices for
versioning doesn't mean that all other packages have to be treated badly.
Instead, our ranges support differentiating between `1.0` and `1.0.1`:

```python
depends_on('poorly_versioned_package@1.0:1.0.0')  # depends on 1.0, not 1.0.1
conflicts('^poorly_versioned_package@:1.0.0')  # conflicts with 1.0, not with 1.0.1
```

so the only thing that has to be done is to be careful when specifying conflicts and
dependencies on these type of packages.

Right now the situation is the opposite: packages that do proper semver versioning
and want to specify a conflict on `x.y.z` may need to write

```python
conflicts('^properly_versioned_package@1.2.3:1.2.3.0')   # so that it also conflicts with 1.2.3-external-system-version
```

which is not great. No longer so after this PR.

---

A similar issue for compilers could also be fixed, but is more challenging, because of compiler bootstrapping