### PR TITLE
swiftsim: Fix build with version bump and depends_on('gsl')

### DIFF
--- a/var/spack/repos/builtin/packages/swiftsim/package.py
+++ b/var/spack/repos/builtin/packages/swiftsim/package.py
@@ -15,8 +15,9 @@ class Swiftsim(AutotoolsPackage):
     """
 
     homepage = 'http://icc.dur.ac.uk/swift/'
-    url = 'https://gitlab.cosma.dur.ac.uk/api/v4/projects/swift%2Fswiftsim/repository/archive.tar.gz?sha=v0.3.0'
+    url = 'https://gitlab.cosma.dur.ac.uk/api/v4/projects/swift%2Fswiftsim/repository/archive.tar.gz?sha=v0.9.0'
 
+    version('0.9.0', sha256='5b4477289c165838c3823ef47a2a94eff7129927babbf5eb8785f8e4bf686117')
     version('0.7.0', sha256='d570e83e1038eb31bc7ae95d1903a2371fffbca90d08f60b6b32bb0fd8a6f516')
     version('0.3.0', sha256='dd26075315cb2754dc1292e8d838bbb83739cff7f068a98319b80b9c2b0f84bc')
 
@@ -27,8 +28,9 @@ class Swiftsim(AutotoolsPackage):
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool', type='build')
-    depends_on('m4', type='build')
     # link-time / run-time dependencies
+    # gsl is optional, but strong compiler settings choke on function without retval:
+    depends_on('gsl')
     depends_on('mpi', when='+mpi')
     depends_on('metis')
     depends_on('hdf5~mpi', when='~mpi')
@@ -44,5 +46,6 @@ class Swiftsim(AutotoolsPackage):
         return [
             '--enable-mpi' if '+mpi' in self.spec else '--disable-mpi',
             '--with-metis={0}'.format(self.spec['metis'].prefix),
+            '--disable-dependency-tracking',
             '--enable-optimization'
         ]


### PR DESCRIPTION
swiftsim 0.7.0 didn't build because of a configure script issue and more issues after that.

Fix the build by a version bump and adding `depends_on('gsl')`.