### PR TITLE
w3m: Fix build by disabling RAND_egd and japanese messages

### DIFF
--- a/var/spack/repos/builtin/packages/w3m/package.py
+++ b/var/spack/repos/builtin/packages/w3m/package.py
@@ -14,9 +14,15 @@ class W3m(AutotoolsPackage):
     tool which typesets HTML into plain text.
     """
 
+    # The main w3m project is not active anymore, but distributions still keep
+    # and maintain it:
+    # https://sourceforge.net/p/w3m/support-requests/17/
+    # What source should distro packagers use for their w3m packages?
+    # Feel free to use Debian's branch as you need.
+    # Currently, Arch and Ubuntu (and Debian derivatives) use Debian's branch.
+    # Also, Gentoo, Fedora and openSUSE switched to Debian's branch.
     homepage = "http://w3m.sourceforge.net/index.en.html"
     url      = "https://downloads.sourceforge.net/project/w3m/w3m/w3m-0.5.3/w3m-0.5.3.tar.gz"
-
     maintainers = ['ronin_gw']
 
     version('0.5.3', sha256='e994d263f2fd2c22febfbe45103526e00145a7674a0fda79c822b97c2770a9e3')
@@ -48,6 +54,11 @@ class W3m(AutotoolsPackage):
     patch('fix_redef.patch')
     patch('fix_gc.patch')
 
+    def patch(self):
+        # w3m is not developed since 2012, everybody is doing this:
+        # https://www.google.com/search?q=USE_EGD+w3m
+        filter_file('#define USE_EGD', '#undef USE_EGD', 'config.h.in')
+
     def _add_arg_for_variant(self, args, variant, choices):
         for avail_lib in choices:
             if self.spec.variants[variant].value == avail_lib:
@@ -55,7 +66,7 @@ class W3m(AutotoolsPackage):
                 return
 
     def configure_args(self):
-        args = []
+        args = ['ac_cv_search_gettext=no', '--enable-unicode']
 
         self._add_arg_for_variant(args, 'termlib', ('termcap', 'ncurses'))
         if '+image' in self.spec:
@@ -72,5 +83,10 @@ class W3m(AutotoolsPackage):
             env.append_flags('LDFLAGS', '-lX11')
 
     # parallel build causes build failure
+    parallel = False
+
     def build(self, spec, prefix):
-        make(parallel=False)
+        make('NLSTARGET=scripts/w3mman')
+
+    def install(self, spec, prefix):
+        make('NLSTARGET=scripts/w3mman', 'install')


### PR DESCRIPTION
w3m's build fails with `undefined reference to `RAND_egd'` and from building a Japanese message catalog.

`RAND_egd` is an deprecated insecure feature, and disabling both makes the build of `w3m` work.