### PR TITLE
Fix broken opensuse docker image

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -78,7 +78,7 @@ jobs:
 
   opensuse-sources:
     runs-on: ubuntu-latest
-    container: "opensuse/tumbleweed:latest"
+    container: "opensuse/tumbleweed:latest@sha256:aeb62bae53022901b5da5d78d8de6ca07f5b3992e147e4c9723e0378ac0463ca"
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Currently zypper in opensuse containers throws 'not permitted'

Temporarily fix the digest until they fixed their upstream package manager issues
