### PR TITLE
masurca: removing sys/sysctl.h include

### DIFF
--- a/var/spack/repos/builtin/packages/masurca/package.py
+++ b/var/spack/repos/builtin/packages/masurca/package.py
@@ -24,7 +24,8 @@ class Masurca(Package):
     patch('arm.patch', when='target=aarch64:')
 
     def patch(self):
-        filter_file('#include <sys/sysctl.h>', '', 'global-1/CA8/src/AS_BAT/memoryMappedFile.H')
+        filter_file('#include <sys/sysctl.h>', '',
+                    'global-1/CA8/src/AS_BAT/memoryMappedFile.H')
         if self.spec.target.family == 'aarch64':
             for makefile in 'Makefile.am', 'Makefile.in':
                 m = join_path('global-1', 'prepare', makefile)

--- a/var/spack/repos/builtin/packages/masurca/package.py
+++ b/var/spack/repos/builtin/packages/masurca/package.py
@@ -24,6 +24,7 @@ class Masurca(Package):
     patch('arm.patch', when='target=aarch64:')
 
     def patch(self):
+        filter_file('#include <sys/sysctl.h>', '', 'global-1/CA8/src/AS_BAT/memoryMappedFile.H')
         if self.spec.target.family == 'aarch64':
             for makefile in 'Makefile.am', 'Makefile.in':
                 m = join_path('global-1', 'prepare', makefile)


### PR DESCRIPTION
Per https://sourceware.org/pipermail/libc-announce/2020/000029.html sys/sysctl.h has been removed from glibc 2.32 and later. Furthermore, since kernel 5.5 the sysctl function has failed with ENOSYS. Removing this include allows the installation to complete on newer OSes. 

sysctl was only ever called in one function in one file, that function is as follows:
```
#ifdef HW_PHYSMEM

uint64
getMemorySize(void) {
  uint64  physMemory = 0;

  int     mib[2] = { CTL_HW, HW_PHYSMEM };
  size_t  len    = sizeof(uint64);

  errno = 0;

  if (sysctl(mib, 2, &physMemory, &len, NULL, 0) != 0)
    //  failed to get memory size, so what?
    fprintf(stderr, "sysctl() failed to return CTL_HW, HW_PHYSMEM: %s\n", strerror(errno)), exit(1);

  if (len != sizeof(uint64)) {
#ifdef HW_MEMSIZE
    mib[1] = HW_MEMSIZE;
    len = sizeof(uint64);
    if (sysctl(mib, 2, &physMemory, &len, NULL, 0) != 0 || len != sizeof(uint64))
#endif
       //  wasn't enough space, so what?
       fprintf(stderr, "sysctl() failed to return CTL_HW, HW_PHYSMEM: %s\n", strerror(errno)), exit(1);
  }

  return(physMemory);
}

#else

uint64
getMemorySize(void) {
  uint64  physPages  = sysconf(_SC_PHYS_PAGES);
  uint64  pageSize   = sysconf(_SC_PAGESIZE);
  uint64  physMemory = physPages * pageSize;

  fprintf(stderr, "PHYS_PAGES = " F_U64 "\n", physPages);
  fprintf(stderr, "PAGE_SIZE  = " F_U64 "\n", pageSize);
  fprintf(stderr, "MEMORY     = " F_U64 "\n", physMemory);

  return(physMemory);
}

#endif
```
The version of the function that calls sysctl is only included if HW_PHYSMEM is set, which I do not believe it is by default. So this PR shouldn't actually change anything functionally in the code, just fix build errors for newer OSes.