### PR TITLE
Add rocm and rocm-smi variant for papi package

### DIFF
--- a/var/spack/repos/builtin/packages/papi/package.py
+++ b/var/spack/repos/builtin/packages/papi/package.py
@@ -43,6 +43,8 @@ class Papi(AutotoolsPackage):
     variant('lmsensors', default=False, description='Enable lm_sensors support')
     variant('sde', default=False, description='Enable software defined events')
     variant('cuda', default=False, description='Enable CUDA support')
+    variant('rocm', default=False, description='Enable ROCM support')
+    variant('rocm-smi', default=False, description='Enable ROCM SMI support')
     variant('nvml', default=False, description='Enable NVML support')
 
     variant('shared', default=True, description='Build shared libraries')
@@ -54,6 +56,7 @@ class Papi(AutotoolsPackage):
     depends_on('lm-sensors', when='+lmsensors')
     depends_on('cuda', when='+cuda')
     depends_on('cuda', when='+nvml')
+    depends_on('rocm-smi-lib', when='+rocm+rocm-smi')
 
     conflicts('%gcc@8:', when='@5.3.0', msg='Requires GCC version less than 8.0')
     conflicts('+sde', when='@:5', msg='Software defined events (SDE) added in 6.0.0')
@@ -88,7 +91,7 @@ class Papi(AutotoolsPackage):
         components = filter(
             lambda x: spec.variants[x].value,
             ['example', 'infiniband', 'powercap', 'rapl', 'lmsensors', 'sde',
-             'cuda', 'nvml'])
+             'cuda', 'nvml', 'rocm'])
         if components:
             options.append('--with-components=' + ' '.join(components))
 
@@ -97,6 +100,8 @@ class Papi(AutotoolsPackage):
 
         if '+static_tools' in spec:
             options.append('--with-static-tools')
+        if '+rocm-smi' in spec:
+            options.append('--with-components=rocm rocm_smi')
 
         return options
 


### PR DESCRIPTION
This PR enables the rocm and rocm-smi variants for papi package.
This papi code refers to rocm rpm packages using PAPI_ROCM_ROOT which needs to be set.
eg - export PAPI_ROCM_ROOT=/opt/rocm
I have tested with spack install papi+rocm+rocm_smi and tested a few binaries like papi_native_avail, papi_mem_info etc

As per the README provided inside papi, it is also required to set the below - AQLPROFILE_READ_API ROCP_METRICS ROCPROFILER_LOG and HSA_VEN_AMD_AQLPROFILE_LOG 
as like below 
export PAPI_ROCM_ROOT=/opt/rocm
export ROCP_METRICS=$PAPI_ROCM_ROOT/rocprofiler/lib/metrics.xml
export ROCPROFILER_LOG=1
export HSA_VEN_AMD_AQLPROFILE_LOG=1
export AQLPROFILE_READ_API=1

I am trying to use the spack rocm packages like hip, hsa-rocr-dev, rocprofiler-dev so that we can build and link to *.so but due to hardcoded paths to /opt/rocm in the rules.rocm ,rules.rocm_smi, the build fails. this i plan to resolve sooner .
CFLAGS += -I$(PAPI_ROCM_ROOT)/hsa/include/hsa
CFLAGS += -I$(PAPI_ROCM_ROOT)/rocprofiler/include
 