### PR TITLE
py-netcdf4: adds parallel IO support

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -18,23 +18,20 @@ class PyNetcdf4(PythonPackage):
     version('1.4.2',   sha256='b934af350459cf9041bcdf5472e2aa56ed7321c018d918e9f325ec9a1f9d1a30')
     version('1.2.7',   sha256='0c449b60183ee06238a8f9a75de7b0eed3acaa7a374952ff9f1ff06beb8f94ba')
     version('1.2.3.1', sha256='55edd74ef9aabb1f7d1ea3ffbab9c555da2a95632a97f91c0242281dc5eb919f')
-    variant(
-        "parallel",
-        default=True,
-        description="Parallel IO support"
-    )
+    variant("mpi", default=True, description="Parallel IO support")
+
     depends_on('py-setuptools',   type='build')
     depends_on('py-cython@0.19:', type='build')
 
     depends_on('py-numpy@1.7:', type=('build', 'run'))
     depends_on('py-cftime', type=('build', 'run'))
-    depends_on('py-mpi4py', when='+parallel')
+    depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
 
-    depends_on('netcdf-c', when='-parallel')
-    depends_on('netcdf-c+mpi', when='+parallel')
+    depends_on('netcdf-c', when='-mpi')
+    depends_on('netcdf-c+mpi', when='+mpi')
 
-    depends_on('hdf5@1.8.0:+hl', when='-parallel')
-    depends_on('hdf5@1.8.0:+hl+mpi', when='+parallel')
+    depends_on('hdf5@1.8.0:+hl', when='-mpi')
+    depends_on('hdf5@1.8.0:+hl+mpi', when='+mpi')
 
     # The installation script tries to find hdf5 using pkg-config. However, the
     # version of hdf5 installed with Spack does not have pkg-config files.

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -29,10 +29,10 @@ class PyNetcdf4(PythonPackage):
     depends_on('py-numpy@1.7:', type=('build', 'run'))
     depends_on('py-cftime', type=('build', 'run'))
     depends_on('py-mpi4py', when='+parallel')
-    
+
     depends_on('netcdf-c', when='-parallel')
     depends_on('netcdf-c+mpi', when='+parallel')
-    
+
     depends_on('hdf5@1.8.0:+hl', when='-parallel')
     depends_on('hdf5@1.8.0:+hl+mpi', when='+parallel')
 

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -36,10 +36,6 @@ class PyNetcdf4(PythonPackage):
     depends_on('hdf5@1.8.0:+hl', when='-parallel')
     depends_on('hdf5@1.8.0:+hl+mpi', when='+parallel')
 
-
-    
-    
-
     # The installation script tries to find hdf5 using pkg-config. However, the
     # version of hdf5 installed with Spack does not have pkg-config files.
     # Therefore, if pkg-config finds hdf5.pc at all (e.g. provided by

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -18,15 +18,27 @@ class PyNetcdf4(PythonPackage):
     version('1.4.2',   sha256='b934af350459cf9041bcdf5472e2aa56ed7321c018d918e9f325ec9a1f9d1a30')
     version('1.2.7',   sha256='0c449b60183ee06238a8f9a75de7b0eed3acaa7a374952ff9f1ff06beb8f94ba')
     version('1.2.3.1', sha256='55edd74ef9aabb1f7d1ea3ffbab9c555da2a95632a97f91c0242281dc5eb919f')
-
+    variant(
+        "parallel",
+        default=True,
+        description="Parallel IO support"
+    )
     depends_on('py-setuptools',   type='build')
     depends_on('py-cython@0.19:', type='build')
 
     depends_on('py-numpy@1.7:', type=('build', 'run'))
     depends_on('py-cftime', type=('build', 'run'))
+    depends_on('py-mpi4py', when='+parallel')
+    
+    depends_on('netcdf-c', when='-parallel')
+    depends_on('netcdf-c+mpi', when='+parallel')
+    
+    depends_on('hdf5@1.8.0:+hl', when='-parallel')
+    depends_on('hdf5@1.8.0:+hl+mpi', when='+parallel')
 
-    depends_on('netcdf-c')
-    depends_on('hdf5@1.8.0:+hl')
+
+    
+    
 
     # The installation script tries to find hdf5 using pkg-config. However, the
     # version of hdf5 installed with Spack does not have pkg-config files.


### PR DESCRIPTION
@skosukhin

This adds support for parallel IO when using py-netcdf4. Closes #20349.
Previously a runtime error would claiming that netcdf-c was not compiled with MPI support (even if it was specifically requested) 

`ValueError: parallel mode requires MPI enabled netcdf-c
`
The setup.py checks for parallel support by trying to import mpi4py, so it is added as a dependency.
