### PR TITLE
nix: bump version, add new depends and make installcheck pass

### DIFF
--- a/var/spack/repos/builtin/packages/nix/package.py
+++ b/var/spack/repos/builtin/packages/nix/package.py
@@ -3,6 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+import stat
+import tempfile
+
 from spack import *
 
 
@@ -10,8 +14,9 @@ class Nix(AutotoolsPackage):
     """Nix, the purely functional package manager"""
 
     homepage = "https://nixos.org/nix"
-    url      = "https://github.com/NixOS/nix/archive/2.2.1.zip"
+    url      = "https://github.com/NixOS/nix/archive/2.3.15.zip"
 
+    version('2.3.15', sha256='7bf04e47960e7895655ad40461f2cf8038b97e98165672db7a7ac1990fc77a22')
     version('2.2.1', sha256='b591664dd1b04a8f197407d445799ece41140a3117bcbdf8e3c5e94cd3f59854')
     version('2.1.3', sha256='80d0834f3e34b3e91bd20969733d8010b3e253517ea64bf12258c5f450f86425')
     version('2.0.4', sha256='49c78122b20e3ad894f546dd2a2f01c32ec528de790314820b1f1335276e3c22')
@@ -22,27 +27,30 @@ class Nix(AutotoolsPackage):
             description='path of the Nix store (defaults to /nix)')
     variant('statedir', values=str, default='none',
             description='path to the locale state (defaults to /nix/var)')
-    variant('doc', default=True,
-            description='Build and install documentation')
+    variant('doc', default=False,
+            description='Build documentation, tries to fetch docbook.xsl from sf.net')
     variant('sandboxing', default=True,
             description='Enable build isolation')
 
+    depends_on('autoconf-archive', type='build')
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
+    depends_on('pkgconfig', type='build')
     depends_on('bison@2.6.0:', type='build')
     depends_on('flex@2.5.35:', type='build')
     depends_on('libtool', type='build')
+    depends_on('libxml2', when='+doc', type='build')
     depends_on('libxslt', when='+doc', type='build')
 
     depends_on('boost@1.66.0:+coroutine+context cxxstd=14', when='@2.2.0:')
     depends_on('boost@1.61.0:+coroutine+context cxxstd=14', when='@2.0.0:')
     depends_on('brotli')
     depends_on('editline')
-    depends_on('m4', type='build')
 
     depends_on('bzip2')
     depends_on('curl')
     depends_on('libseccomp', when='+sandboxing')
+    depends_on("libsodium")
     depends_on('openssl')
     depends_on('sqlite@3.6.19:')
     depends_on('xz')
@@ -63,3 +71,29 @@ class Nix(AutotoolsPackage):
         if statedir != 'none':
             args.append('--localstatedir=' + statedir)
         return args
+
+    def patch(self):
+        """A few files of the testsuite need to be patched for all tests to pass"""
+        filter_file('wc', '/usr/bin/wc', 'tests/gc-auto.sh')
+        # For nix shebang with full path to work, spack's self.prefix has to shorten:
+        filter_file('@ENV_PROG@', '/usr/bin/env', 'tests/shell.shebang.sh')
+        filter_file('@SHELL_PROG@', '/usr/bin/env nix-shell', 'tests/shell.shebang.rb')
+
+    def installcheck(self):
+        # We have to clean this tmpdir ourself later as it contains readonly directories
+        self.test_path = tempfile.mkdtemp(dir='/tmp',
+                                          prefix='tmp-spack-check-nix-{0}-'.
+                                                 format(self.spec.version))
+        mkdir(self.test_path + '/nix-test')
+        mkdir(self.test_path + '/tests')
+        os.environ['TMPDIR'] = self.test_path
+        os.environ['TEST_ROOT'] = self.test_path + '/tests'
+        with working_dir(self.build_directory):
+            make('installcheck')
+
+    @run_after('install')
+    def installcheck_clean(self):
+        if self.test_path:
+            for (root, dirs, files) in os.walk(self.test_path, topdown=True):
+                os.chmod(root, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+            remove_linked_tree(self.test_path)


### PR DESCRIPTION
The current version of `nix` has some more features and has more
dependencies. The installcheck is quite involved but passes now.