### PR TITLE
[vtk] depends_on freetype @:2.10.2 through @:9.0.1 only

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -124,7 +124,7 @@ class Vtk(CMakePackage):
     # See https://gitlab.kitware.com/vtk/vtk/-/issues/18033
     patch('https://gitlab.kitware.com/vtk/vtk/uploads/c6fa799a1a028b8f8a728a40d26d3fec/vtk-freetype-2.10.3-replace-FT_CALLBACK_DEF.patch',
           sha256='eefda851f844e8a1dfb4ebd8a9ff92d2b78efc57f205774052c5f4c049cc886a',
-          when='^freetype@2.10.3:')
+          when='@:9.0.1 ^freetype@2.10.3:')
 
     def url_for_version(self, version):
         url = "http://www.vtk.org/files/release/{0}/VTK-{1}.tar.gz"

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -98,7 +98,7 @@ class Vtk(CMakePackage):
     depends_on('expat')
     # See <https://gitlab.kitware.com/vtk/vtk/-/issues/18033> for why vtk doesn't
     # work yet with freetype 2.10.3 (including possible patches)
-    depends_on('freetype @:2.10.2', when='@:9.0.1)
+    depends_on('freetype @:2.10.2', when='@:9.0.1')
     depends_on('freetype')
     depends_on('glew')
     # set hl variant explicitly, similar to issue #7145

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -98,7 +98,7 @@ class Vtk(CMakePackage):
     depends_on('expat')
     # See <https://gitlab.kitware.com/vtk/vtk/-/issues/18033> for why vtk doesn't
     # work yet with freetype 2.10.3 (including possible patches)
-    depends_on('freetype @:2.10.2')
+    depends_on('freetype @:2.10.2', when='@:9.0.1)
     depends_on('freetype')
     depends_on('glew')
     # set hl variant explicitly, similar to issue #7145


### PR DESCRIPTION
The issues in https://gitlab.kitware.com/vtk/vtk/-/issues/18033 which required freetype @:2.10.2 (FT_CALLBACK_DEF) were fixed by @mathstuf in
- https://github.com/Kitware/VTK/commit/dae1718d50bec1b40b860280acafbdd94fc4cd5d
- https://github.com/Kitware/VTK/commit/31e8e4ebeb3152f7cfdb3f14f24f7e5d31a4f8b5

These fixes are in vtk@9.0.2 https://github.com/Kitware/VTK/releases/tag/v9.0.2 and beyond.

Maintainer tags: @chuckatkins  @danlipsa