### PR TITLE
iproute2: Add sha256 for 5.10.0 and 5.11.0, add missing deps

### DIFF
--- a/var/spack/repos/builtin/packages/iproute2/package.py
+++ b/var/spack/repos/builtin/packages/iproute2/package.py
@@ -12,6 +12,12 @@ class Iproute2(AutotoolsPackage):
     homepage = "https://github.com/shemminger/iproute2"
     url      = "https://github.com/shemminger/iproute2/archive/v5.9.0.tar.gz"
 
+    depends_on('bison', type='build')
+    depends_on('flex',  type='build')
+    depends_on('libmnl')
+
+    version('5.11.0', sha256='16b79e6ce65d4d5fd425cef2fd92a58c403a93faeeed0e0a3202b36a8e857d1f')
+    version('5.10.0', sha256='164f1de457eefbdadb98d82c309a0977542b34e7a2dfe81e497a0b93675cb3d2')
     version('5.9.0', sha256='1afde56d416f136b1236ac2f8276e4edbe114ca3c2ab12f11af11b84cf0992e4')
     version('5.8.0', sha256='78c73ed49c35fae59ab4e9d88220dcc70da924de3838e13a3cdc7c09496e5a45')
     version('5.7.0', sha256='12a3861f463c6bbd1bb3b213ac734f75c89172b74104140dd0bbfcb1e13ee798')


### PR DESCRIPTION
`iproute2` needs `libmnl` and builds using `flex` and `bison`: Add them.