### PR TITLE
libidl builds using flex and bison: Add them with depends_on()

### DIFF
--- a/var/spack/repos/builtin/packages/libidl/package.py
+++ b/var/spack/repos/builtin/packages/libidl/package.py
@@ -15,5 +15,7 @@ class Libidl(AutotoolsPackage):
 
     version('0.8.14', sha256='c5d24d8c096546353fbc7cedf208392d5a02afe9d56ebcc1cccb258d7c4d2220')
 
+    depends_on('flex',      type='build')
+    depends_on('bison',     type='build')
     depends_on('pkgconfig', type='build')
     depends_on('glib')


### PR DESCRIPTION
When flex and bison aren't installed on the build host, build would fail.
Add them with depends_on() to ensure that libidl can build independent of that.