### PR TITLE
xdriinfo: uses glXGetProcAddressARB, add: depends_on('gl')

### DIFF
--- a/var/spack/repos/builtin/packages/xdriinfo/package.py
+++ b/var/spack/repos/builtin/packages/xdriinfo/package.py
@@ -22,6 +22,8 @@ class Xdriinfo(AutotoolsPackage, XorgPackage):
     depends_on('libxfixes')
     depends_on('pcre')
 
+    # Uses glXGetProcAddressARB, add OpenGL:
+    depends_on('gl')
     depends_on('glproto')
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')


### PR DESCRIPTION
xdriinfo uses `glXGetProcAddressARB`.

Add a `depends_on('gl')` to compile and link with the preferred OpenGL package.