### PR TITLE
Revert "Pin opensuse image in bootstrap tests (#26170)"

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -78,7 +78,7 @@ jobs:
 
   opensuse-sources:
     runs-on: ubuntu-latest
-    container: "opensuse/tumbleweed:latest@sha256:aeb62bae53022901b5da5d78d8de6ca07f5b3992e147e4c9723e0378ac0463ca"
+    container: "opensuse/tumbleweed:latest"
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Hopefully the opensuse image will be fixed at some point in the future, so preparing this pull request to go back to an unpinned version.