### PR TITLE
Disable __skip_rocmclang again

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -91,7 +91,7 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
                 args.append('-DCMAKE_CXX_FLAGS={0}'.format(self.hip_flags(rocm_arch)))
 
             # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
-            if self.spec.satisfies('^cmake@3.21:'):
+            if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
                 args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -71,7 +71,7 @@ class Hip(CMakePackage):
     patch('0004-Drop-clang-rt-builtins-linking-on-hip-host.3.10.0.patch', when='@3.10.0:4.1.0')
 
     # Tests are broken when using cmake 3.21
-    with when('^cmake@3.21:'):
+    with when('^cmake@3.21.0:3.21.2'):
         patch('0005-Disable-tests-3.5.0.patch', when='@3.5.0')
         patch('0005-Disable-tests-3.6.0.patch', when='@3.6.0:3.8.0')
         patch('0005-Disable-tests-3.9.0.patch', when='@3.9.0:4.0.0')

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -50,7 +50,7 @@ class Hipblas(CMakePackage):
         else:
             args.append(self.define('USE_CUDA', 'OFF'))
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -45,7 +45,7 @@ class Hipcub(CMakePackage):
             self.define('CMAKE_MODULE_PATH', self.spec['hip'].prefix.cmake)
         ]
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -44,7 +44,7 @@ class Hipfft(CMakePackage):
             self.define('BUILD_CLIENTS_SAMPLES', 'OFF')
         ]
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/hipfort/package.py
+++ b/var/spack/repos/builtin/packages/hipfort/package.py
@@ -39,7 +39,7 @@ class Hipfort(CMakePackage):
     def cmake_args(self):
         args = []
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -52,7 +52,7 @@ class Hipsparse(CMakePackage):
             self.define('BUILD_CLIENTS_TESTS', 'OFF'),
         ]
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -208,7 +208,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
         # HIP support requires compiling with hipcc
         if '+rocm' in self.spec:
             args += [self.define('CMAKE_CXX_COMPILER', self.spec['hip'].hipcc)]
-            if self.spec.satisfies('^cmake@3.21:'):
+            if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
                 args += [self.define('__skip_rocmclang', True)]
 
         # Instrumentation

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -129,7 +129,7 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
             options.extend(['-DMAGMA_ENABLE_HIP=ON'])
             options.extend(['-DCMAKE_CXX_COMPILER=hipcc'])
             # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
-            if spec.satisfies('^cmake@3.21:'):
+            if spec.satisfies('^cmake@3.21.0:3.21.2'):
                 options.extend(['-D__skip_rocmclang=ON'])
         else:
             options.extend(['-DMAGMA_ENABLE_CUDA=ON'])

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -54,7 +54,7 @@ class Rccl(CMakePackage):
                 self.spec['numactl'].prefix
             ))
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -67,7 +67,7 @@ class Rocalution(CMakePackage):
             self.define('BUILD_CLIENTS_SAMPLES', 'OFF')
         ]
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -114,7 +114,7 @@ class Rocblas(CMakePackage):
             args.append(self.define('AMDGPU_TARGETS', arch))
 
         # See https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1196
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -66,7 +66,7 @@ class Rocfft(CMakePackage):
             args.append(self.define('AMDGPU_TARGETS_SRAM_ECC', ";".join(tgt_sram)))
 
         # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -84,7 +84,7 @@ class RocmTensile(CMakePackage):
                 arch = arch + ':xnack-'
         args.append(self.define('Tensile_ARCHITECTURE', arch))
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -51,7 +51,7 @@ class Rocprim(CMakePackage):
             self.define('BUILD_EXAMPLE', 'OFF')
         ]
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -73,7 +73,7 @@ class Rocrand(CMakePackage):
             self.define('BUILD_TEST', 'OFF')
         ]
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -75,7 +75,7 @@ class Rocsolver(CMakePackage):
             else:
                 args.append(self.define('AMDGPU_TARGETS', ";".join(tgt)))
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -47,7 +47,7 @@ class Rocsparse(CMakePackage):
             self.define('BUILD_CLIENTS_TESTS', 'OFF'),
             self.define('BUILD_CLIENTS_BENCHMARKS', 'OFF')
         ]
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -52,7 +52,7 @@ class Rocthrust(CMakePackage):
             )
         ]
 
-        if self.spec.satisfies('^cmake@3.21:'):
+        if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
         return args


### PR DESCRIPTION
CMake 3.21.3 disables the broken hipcc-as-rocmclang detection again.

From the release notes:

> The AMD ROCm Platform hipcc compiler was identifed by CMake 3.21.0
> through 3.21.2 as a distinct compiler with id ROCMClang. This has been
> removed because it caused regressions. Instead:
> * hipcc may no longer be used as a HIP compiler because it interferes
>   with flags CMake needs to pass to Clang. Use Clang directly.
> * hipcc may once again be used as a CXX compiler, and is treated as
>   whatever compiler it selects underneath, as CMake 3.20 and below
>   did.

I don't believe "use Clang directly" solves a lot of issues, but we can
dream
