### PR TITLE
assimp: depends_on zlib

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -21,6 +21,7 @@ class Assimp(CMakePackage):
     variant('shared',  default=True,
             description='Enables the build of shared libraries')
 
+    depends_on('zlib')
     depends_on('boost')
 
     def cmake_args(self):


### PR DESCRIPTION
Assimp searches for zlib (or builds its own version). When it searches, it can find a system install that is not provided by spack. Ref: https://github.com/assimp/assimp/blob/d286aadbdf82c0860ce6c5dbdcab80cba4828606/CMakeLists.txt#L451

Maintainer not listed, but @sethrj and @vvolkl made recent edits to this package.