### PR TITLE
Use Leap instead of Tumbleweed for e2e bootstrapping test

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -78,7 +78,7 @@ jobs:
 
   opensuse-sources:
     runs-on: ubuntu-latest
-    container: "opensuse/tumbleweed:latest@sha256:aeb62bae53022901b5da5d78d8de6ca07f5b3992e147e4c9723e0378ac0463ca"
+    container: "opensuse/leap:latest"
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Tumbleweed has been broken for a couple of days. The attempt to fix it in #26170 didn't really work. Let's try to move to a more stable release series for openSUSE.