### PR TITLE
Slurm: Added new versions and deprecated vulnerable versions

### DIFF
--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -22,18 +22,24 @@ class Slurm(AutotoolsPackage):
     """
 
     homepage = 'https://slurm.schedmd.com'
-    url = 'https://github.com/SchedMD/slurm/archive/slurm-19-05-6-1.tar.gz'
+    url = 'https://github.com/SchedMD/slurm/archive/slurm-20-02-7-1.tar.gz'
 
-    version('20-11-5-1', sha256='d0634c6c6cc79bde38d19f0ef0de0de3b07907830f5e45be6f4a9ca4259f8f67')
-    version('20-11-4-1', sha256='06c5333e85f531730bf1c6eb48a8d48a551d9090540ce37b78181024273fb6bd')
-    version('20-11-0-1', sha256='404f72c287c5aad887a5b141304e4962548c12f79b04fc9c88550bc024604228')
-    version('20-02-4-1', sha256='d32a39df20a99430973de6692870269f38443d8b963c32b4d6475c9d5e92cd73')
-    version('19-05-6-1', sha256='1b83bce4260af06d644253b1f2ec2979b80b4418c631e9c9f48c2729ae2c95ba')
-    version('19-05-5-1', sha256='e53e67bd0bb4c37a9c481998764a746467a96bc41d6527569080514f36452c07')
-    version('18-08-9-1', sha256='32eb0b612ca18ade1e35c3c9d3b4d71aba2b857446841606a9e54d0a417c3b03')
-    version('18-08-0-1', sha256='62129d0f2949bc8a68ef86fe6f12e0715cbbf42f05b8da6ef7c3e7e7240b50d9')
-    version('17-11-9-2', sha256='6e34328ed68262e776f524f59cca79ac75bcd18030951d45ea545a7ba4c45906')
-    version('17-02-6-1', sha256='97b3a3639106bd6d44988ed018e2657f3d640a3d5c105413d05b4721bc8ee25e')
+    version('21-08-1-1', sha256='23321719101762b055a6b1da6ff4261f5e6c469bce038c6c23549840453862e7')
+    version('21-08-0-1', sha256='c8caf9b5f715c02b6f9e55e9737ee7b99f93c5efc8dcc34c2ce40bed0aea5402')
+    version('20-11-8-1', sha256='1cafed56ae9d90387a5dc6092090c174e144a6e5a31330f748d1fd3a616ae92f')
+    version('20-11-7-1', sha256='7d92babd97d0b8750b8c25eced4507323aff32a9d85af3a644c1acedbddb9d2f')
+    version('20-02-7-1', sha256='060acf966af53e75c7eaae83c4f42abdcc60702838c2dcd35cb01468b45a68a1')
+    # Due to CVE-2021-31215, all versions prior to 20.11.7 or 20.02.7 are deprecated.
+    version('20-11-5-1', sha256='d0634c6c6cc79bde38d19f0ef0de0de3b07907830f5e45be6f4a9ca4259f8f67', deprecated=True)
+    version('20-11-4-1', sha256='06c5333e85f531730bf1c6eb48a8d48a551d9090540ce37b78181024273fb6bd', deprecated=True)
+    version('20-11-0-1', sha256='404f72c287c5aad887a5b141304e4962548c12f79b04fc9c88550bc024604228', deprecated=True)
+    version('20-02-4-1', sha256='d32a39df20a99430973de6692870269f38443d8b963c32b4d6475c9d5e92cd73', deprecated=True)
+    version('19-05-6-1', sha256='1b83bce4260af06d644253b1f2ec2979b80b4418c631e9c9f48c2729ae2c95ba', deprecated=True)
+    version('19-05-5-1', sha256='e53e67bd0bb4c37a9c481998764a746467a96bc41d6527569080514f36452c07', deprecated=True)
+    version('18-08-9-1', sha256='32eb0b612ca18ade1e35c3c9d3b4d71aba2b857446841606a9e54d0a417c3b03', deprecated=True)
+    version('18-08-0-1', sha256='62129d0f2949bc8a68ef86fe6f12e0715cbbf42f05b8da6ef7c3e7e7240b50d9', deprecated=True)
+    version('17-11-9-2', sha256='6e34328ed68262e776f524f59cca79ac75bcd18030951d45ea545a7ba4c45906', deprecated=True)
+    version('17-02-6-1', sha256='97b3a3639106bd6d44988ed018e2657f3d640a3d5c105413d05b4721bc8ee25e', deprecated=True)
 
     variant('gtk', default=False, description='Enable GTK+ support')
     variant('mariadb', default=False, description='Use MariaDB instead of MySQL')


### PR DESCRIPTION
Due to a security vulnerability (CVE-2021-31215), all versions of Slurm prior to 20.11.7 or 20.02.7 are no longer available for download.

(via https://www.schedmd.com/archives.php)

As a result, these versions should be deprecated and new versions added.