### PR TITLE
Make 3:3 a non-concrete range and add tests for VersionRange

### DIFF
--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1348,31 +1348,31 @@ def test_ci_generate_bootstrap_prune_dag(
     mirror_url = 'file://{0}'.format(mirror_dir.strpath)
 
     # Install a compiler, because we want to put it in a buildcache
-    install_cmd('gcc@10.1.0%gcc@4.5.0')
+    install_cmd('gcc@2.0%gcc@4.5.0')
 
     # Put installed compiler in the buildcache
     buildcache_cmd('create', '-u', '-a', '-f', '-d', mirror_dir.strpath,
-                   'gcc@10.1.0%gcc@4.5.0')
+                   'gcc@2.0%gcc@4.5.0')
 
     # Now uninstall the compiler
-    uninstall_cmd('-y', 'gcc@10.1.0%gcc@4.5.0')
+    uninstall_cmd('-y', 'gcc@2.0%gcc@4.5.0')
 
     monkeypatch.setattr(spack.concretize.Concretizer,
                         'check_for_compiler_existence', False)
     spack.config.set('config:install_missing_compilers', True)
-    assert CompilerSpec('gcc@10.1.0') not in compilers.all_compiler_specs()
+    assert CompilerSpec('gcc@2.0') not in compilers.all_compiler_specs()
 
     # Configure the mirror where we put that buildcache w/ the compiler
     mirror_cmd('add', 'test-mirror', mirror_url)
 
-    install_cmd('--no-check-signature', 'a%gcc@10.1.0')
+    install_cmd('--no-check-signature', 'a%gcc@2.0')
 
     # Put spec built with installed compiler in the buildcache
     buildcache_cmd('create', '-u', '-a', '-f', '-d', mirror_dir.strpath,
-                   'a%gcc@10.1.0')
+                   'a%gcc@2.0')
 
     # Now uninstall the spec
-    uninstall_cmd('-y', 'a%gcc@10.1.0')
+    uninstall_cmd('-y', 'a%gcc@2.0')
 
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:
@@ -1380,9 +1380,9 @@ def test_ci_generate_bootstrap_prune_dag(
 spack:
   definitions:
     - bootstrap:
-      - gcc@10.1.0%gcc@4.5.0
+      - gcc@2.0%gcc@4.5.0
   specs:
-    - a%gcc@10.1.0
+    - a%gcc@2.0
   mirrors:
     atestm: {0}
   gitlab-ci:

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -16,7 +16,7 @@ from llnl.util.filesystem import working_dir
 import spack.package
 import spack.spec
 from spack.util.executable import which
-from spack.version import Version, VersionList, ver
+from spack.version import Version, VersionList, VersionRange, ver
 
 
 def assert_ver_lt(a, b):
@@ -602,3 +602,19 @@ def test_versions_from_git(mock_git_version_info, monkeypatch, mock_packages):
             expected = f.read()
 
         assert str(comparator) == expected
+
+
+def test_range_is_not_concrete_when_start_is_end():
+    r = VersionRange('3', '3')
+    assert Version('3.2.1').satisfies(r)
+    assert ver('3:3') == r
+    assert not r.concrete
+
+
+def test_range_is_generally_not_concrete():
+    assert not VersionRange('3', '4').concrete
+
+
+def test_range_throws_when_start_is_after_end():
+    with pytest.raises(ValueError):
+        VersionRange('3', '2')

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -550,7 +550,7 @@ class VersionRange(object):
 
     @property
     def concrete(self):
-        return self.start if self.start == self.end else None
+        return None
 
     @coerced
     def __contains__(self, other):


### PR DESCRIPTION
Currently Spack simplifies the range `3:3` incorrectly to the concrete version `3`: `Spec('python@3:3')` becomes `python@3` during version list simplification.

The reason is that `VersionRange::concrete()` incorrectly returns a concrete version when start == end.

`3:3` means the closed-open range `[3, 4)` just like `3:4` means `[3, 5)` and `3:3.0` means `[3, 3.1)`.

This PR ensures that a VersionRange is never considered concrete, and adds tests for 3:3, 3:4, 3:2 type of ranges.

After this PR, `spack spec something ^python@3:3` can be used to require the optimal Python 3 and avoid Python 2.
