### PR TITLE
qhull: use secure github URLS instead of www.qhull.org downloads

### DIFF
--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -17,15 +17,13 @@ class Qhull(CMakePackage):
        approximations to the convex hull."""
 
     homepage = "http://www.qhull.org"
+    url = "https://github.com/qhull/qhull/archive/refs/tags/2020.2.tar.gz"
 
-    version('2020.1', sha256='1ac92a5538f61e297c72aebe4d4ffd731ceb3e6045d6d15faf1c212713798df4',
-            url="http://www.qhull.org/download/qhull-2020-src-8.0.0.tgz")
-    version('2019.1', sha256='2b7990558c363076261564f61b74db4d0d73b71869755108a469038c07dc43fb',
-            url="http://www.qhull.org/download/qhull-2019-src-7.3.2.tgz")
-    version('2015.2', sha256='78b010925c3b577adc3d58278787d7df08f7c8fb02c3490e375eab91bb58a436',
-            url="http://www.qhull.org/download/qhull-2015-src-7.2.0.tgz")
-    version('2012.1', sha256='a35ecaa610550b7f05c3ce373d89c30cf74b059a69880f03080c556daebcff88',
-            url="http://www.qhull.org/download/qhull-2012.1-src.tgz")
+    version('2020.2', sha256='59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5')
+    version('2020.1', sha256='0258bbf5de447e3d6b3968c5a7b51c08ca5d98f11f94f86621ed3e7c98365b8d')
+    version('2019.1', sha256='cf7235b76244595a86b9407b906e3259502b744528318f2178155e5899d6cf9f')
+    version('2015.2', sha256='8b6dd67ff77ce1ee814da84f4134ef4bdce1f1031e570b8d83019ccef58b1c00')
+    version('2012.1', sha256='cb1296fbb9ec8b7d6e8f4c239ad165590616f242c7c46f790c27d8dcebe96c6a')
 
     patch('qhull-unused-intel-17.02.patch', when='@2015.2')
 

--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -19,7 +19,6 @@ class Qhull(CMakePackage):
     homepage = "http://www.qhull.org"
     url = "https://github.com/qhull/qhull/archive/refs/tags/2020.2.tar.gz"
 
-    version('2020.2', sha256='59356b229b768e6e2b09a701448bfa222c37b797a84f87f864f97462d8dbc7c5')
     version('2020.1', sha256='0258bbf5de447e3d6b3968c5a7b51c08ca5d98f11f94f86621ed3e7c98365b8d')
     version('2019.1', sha256='cf7235b76244595a86b9407b906e3259502b744528318f2178155e5899d6cf9f')
     version('2015.2', sha256='8b6dd67ff77ce1ee814da84f4134ef4bdce1f1031e570b8d83019ccef58b1c00')


### PR DESCRIPTION
Fixes #26210 

As reported in the error, attempts to stage or install the package fail with `Connection reset by peer` errors.  This has been happening *at least* today for builds on different efforts (including CI/CD jobs).

This PR switches from the `http://www.qhull.org` URL for downloads to the GitHub repository, which appears to have all of the necessary versions PLUS an update.

I am now able to successfully install the package for all of the explicitly listed versions.