### PR TITLE
Add 'radiuss' tags to RADIUSS packages

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -36,6 +36,7 @@ class Ascent(CMakePackage, CudaPackage):
     homepage = "https://github.com/Alpine-DAV/ascent"
     git      = "https://github.com/Alpine-DAV/ascent.git"
     url      = "https://github.com/Alpine-DAV/ascent/releases/download/v0.5.1/ascent-v0.5.1-src-with-blt.tar.gz"
+    tags     = ['radiuss']
 
     maintainers = ['cyrush']
 

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -36,6 +36,7 @@ class Axom(CachedCMakePackage, CudaPackage):
 
     homepage = "https://github.com/LLNL/axom"
     git      = "https://github.com/LLNL/axom.git"
+    tags     = ['radiuss']
 
     version('main', branch='main', submodules=True)
     version('develop', branch='develop', submodules=True)

--- a/var/spack/repos/builtin/packages/blt/package.py
+++ b/var/spack/repos/builtin/packages/blt/package.py
@@ -13,6 +13,7 @@ class Blt(Package):
     homepage = "https://github.com/LLNL/blt"
     url      = "https://github.com/LLNL/blt/archive/v0.4.0.tar.gz"
     git      = "https://github.com/LLNL/blt.git"
+    tags     = ['radiuss']
 
     maintainers = ['white238', 'davidbeckingsale']
 

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -19,6 +19,7 @@ class Caliper(CMakePackage, CudaPackage):
     homepage = "https://github.com/LLNL/Caliper"
     git      = "https://github.com/LLNL/Caliper.git"
     url      = "https://github.com/LLNL/Caliper/archive/v2.6.0.tar.gz"
+    tags     = ['radiuss']
 
     maintainers = ["daboehme"]
 

--- a/var/spack/repos/builtin/packages/care/package.py
+++ b/var/spack/repos/builtin/packages/care/package.py
@@ -13,6 +13,7 @@ class Care(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/LLNL/CARE"
     git      = "https://github.com/LLNL/CARE.git"
+    tags     = ['radiuss']
 
     version('develop', branch='develop', submodules='True')
     version('master', branch='main', submodules='True')

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -15,6 +15,7 @@ class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/LLNL/CHAI"
     git      = "https://github.com/LLNL/CHAI.git"
+    tags     = ['radiuss']
 
     maintainers = ['davidbeckingsale']
 

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -36,6 +36,7 @@ class Conduit(CMakePackage):
     homepage = "https://software.llnl.gov/conduit"
     url      = "https://github.com/LLNL/conduit/releases/download/v0.3.0/conduit-v0.3.0-src-with-blt.tar.gz"
     git      = "https://github.com/LLNL/conduit.git"
+    tags     = ['radiuss']
 
     version('develop', branch='develop', submodules=True)
     # note: the main branch in conduit was renamed to develop, this next entry

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -14,6 +14,8 @@ class FluxCore(AutotoolsPackage):
     homepage = "https://github.com/flux-framework/flux-core"
     url      = "https://github.com/flux-framework/flux-core/releases/download/v0.8.0/flux-core-0.8.0.tar.gz"
     git      = "https://github.com/flux-framework/flux-core.git"
+    tags     = ['radiuss']
+
     maintainers = ['SteVwonder']
 
     version('master', branch='master')

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -14,6 +14,8 @@ class FluxSched(AutotoolsPackage):
     homepage = "https://github.com/flux-framework/flux-sched"
     url      = "https://github.com/flux-framework/flux-sched/releases/download/v0.5.0/flux-sched-0.5.0.tar.gz"
     git      = "https://github.com/flux-framework/flux-sched.git"
+    tags     = ['radiuss']
+
     maintainers = ['SteVwonder']
 
     version('master', branch='master')

--- a/var/spack/repos/builtin/packages/glvis/package.py
+++ b/var/spack/repos/builtin/packages/glvis/package.py
@@ -11,6 +11,7 @@ class Glvis(MakefilePackage):
 
     homepage = "https://glvis.org"
     git      = "https://github.com/glvis/glvis.git"
+    tags     = ['radiuss']
 
     maintainers = ['goxberry', 'v-dobrev', 'tzanio', 'tomstitt']
 

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -17,6 +17,7 @@ class Hypre(Package, CudaPackage):
     homepage = "https://computing.llnl.gov/project/linear_solvers/software.php"
     url      = "https://github.com/hypre-space/hypre/archive/v2.14.0.tar.gz"
     git      = "https://github.com/hypre-space/hypre.git"
+    tags     = ['radiuss']
 
     maintainers = ['ulrikeyang', 'osborn9', 'balay']
 

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -18,6 +18,7 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     homepage = "https://software.llnl.gov/lbann/"
     url      = "https://github.com/LLNL/lbann/archive/v0.91.tar.gz"
     git      = "https://github.com/LLNL/lbann.git"
+    tags     = ['radiuss']
 
     maintainers = ['bvanessen']
 

--- a/var/spack/repos/builtin/packages/lvarray/package.py
+++ b/var/spack/repos/builtin/packages/lvarray/package.py
@@ -36,6 +36,7 @@ class Lvarray(CMakePackage, CudaPackage):
 
     homepage = "https://github.com/GEOSX/lvarray"
     git      = "https://github.com/GEOSX/LvArray.git"
+    tags     = ['radiuss']
 
     maintainers = ['corbett5']
 

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -13,7 +13,7 @@ from spack import *
 class Mfem(Package, CudaPackage, ROCmPackage):
     """Free, lightweight, scalable C++ library for finite element methods."""
 
-    tags = ['FEM', 'finite elements', 'high-order', 'AMR', 'HPC']
+    tags = ['fem', 'finite-elements', 'high-order', 'amr', 'hpc', 'radiuss']
 
     homepage = 'http://www.mfem.org'
     git      = 'https://github.com/mfem/mfem.git'

--- a/var/spack/repos/builtin/packages/py-hatchet/package.py
+++ b/var/spack/repos/builtin/packages/py-hatchet/package.py
@@ -12,6 +12,7 @@ class PyHatchet(PythonPackage):
 
     homepage = "https://github.com/hatchet/hatchet"
     url      = "https://github.com/hatchet/hatchet/archive/v1.0.0.tar.gz"
+    tags     = ['radiuss']
 
     maintainers = ["slabasan", "bhatele", "tgamblin"]
 

--- a/var/spack/repos/builtin/packages/py-maestrowf/package.py
+++ b/var/spack/repos/builtin/packages/py-maestrowf/package.py
@@ -13,6 +13,7 @@ class PyMaestrowf(PythonPackage):
     homepage = "https://github.com/LLNL/maestrowf/"
     pypi = "maestrowf/maestrowf-1.1.8.tar.gz"
     git      = "https://github.com/LLNL/maestrowf/"
+    tags     = ['radiuss']
 
     maintainers = ['FrankD412']
 

--- a/var/spack/repos/builtin/packages/py-merlin/package.py
+++ b/var/spack/repos/builtin/packages/py-merlin/package.py
@@ -12,6 +12,7 @@ class PyMerlin(PythonPackage):
     homepage = "https://github.com/LLNL/merlin"
     pypi = "merlin/merlin-1.4.1.tar.gz"
     git      = "https://github.com/LLNL/merlin.git"
+    tags     = ['radiuss']
 
     version('1.7.5', sha256='1994c1770ec7fc9da216f9d0ca8214684dcc0daa5fd55337b96e308b2e68daaa')
     version('1.7.4', sha256='9a6f8a84a1b52d0bfb0dc7bdbd7e15677e4a1041bd25a49a2d965efe503a6c20')

--- a/var/spack/repos/builtin/packages/py-shroud/package.py
+++ b/var/spack/repos/builtin/packages/py-shroud/package.py
@@ -11,6 +11,7 @@ class PyShroud(PythonPackage):
 
     homepage = "https://github.com/LLNL/shroud"
     git      = "https://github.com/LLNL/shroud.git"
+    tags     = ['radiuss']
 
     version('develop', branch='develop')
     version('master',  branch='master')

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -13,6 +13,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://software.llnl.gov/RAJA/"
     git      = "https://github.com/LLNL/RAJA.git"
+    tags     = ['radiuss']
 
     maintainers = ['davidbeckingsale']
 

--- a/var/spack/repos/builtin/packages/samrai/package.py
+++ b/var/spack/repos/builtin/packages/samrai/package.py
@@ -17,6 +17,7 @@ class Samrai(AutotoolsPackage):
     homepage = "https://computing.llnl.gov/projects/samrai"
     url      = "https://computing.llnl.gov/projects/samrai/download/SAMRAI-v3.11.2.tar.gz"
     list_url = homepage
+    tags     = ['radiuss']
 
     version('3.12.0',     sha256='b8334aa22330a7c858e09e000dfc62abbfa3c449212b4993ec3c4035bed6b832')
     version('3.11.5',     sha256='6ec1f4cf2735284fe41f74073c4f1be87d92184d79401011411be3c0671bd84c')

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -25,6 +25,7 @@ class Scr(CMakePackage):
     homepage = "https://computing.llnl.gov/projects/scalable-checkpoint-restart-for-mpi"
     url      = "https://github.com/LLNL/scr/archive/v1.2.0.tar.gz"
     git      = "https://github.com/llnl/scr.git"
+    tags     = ['radiuss']
 
     version('develop', branch='develop')
     version('legacy', branch='legacy', deprecated=True)

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -17,6 +17,8 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     urls = ["https://computing.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz",
             "https://github.com/LLNL/sundials/releases/download/v2.7.0/sundials-2.7.0.tar.gz"]
     git = "https://github.com/llnl/sundials.git"
+    tags = ['radiuss']
+
     maintainers = ['cswoodward', 'gardner48', 'balos1']
 
     # ==========================================================================

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -17,6 +17,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     homepage = 'https://github.com/LLNL/Umpire'
     git      = 'https://github.com/LLNL/Umpire.git'
+    tags     = ['radiuss']
 
     maintainers = ['davidbeckingsale']
 

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -58,6 +58,8 @@ class Visit(CMakePackage):
     git      = "https://github.com/visit-dav/visit.git"
     url = "https://github.com/visit-dav/visit/releases/download/v3.1.1/visit3.1.1.tar.gz"
 
+    tags = ['radiuss']
+
     maintainers = ['cyrush']
 
     extendable = True

--- a/var/spack/repos/builtin/packages/xbraid/package.py
+++ b/var/spack/repos/builtin/packages/xbraid/package.py
@@ -11,6 +11,7 @@ class Xbraid(MakefilePackage):
 
     homepage = "https://computing.llnl.gov/projects/parallel-time-integration-multigrid/software"
     url      = "https://github.com/XBraid/xbraid/archive/v2.2.0.tar.gz"
+    tags     = ['radiuss']
 
     version('3.0.0', sha256='06988c0599cd100d3b3f3ebb183c9ad34a4021922e0896815cbedc659aaadce6')
     version('2.3.0', sha256='706f0acde201c7c336ade3604679759752a74e2cd6c2a29a8bf5676b6e54b704')

--- a/var/spack/repos/builtin/packages/zfp/package.py
+++ b/var/spack/repos/builtin/packages/zfp/package.py
@@ -21,6 +21,7 @@ class Zfp(CMakePackage, CudaPackage):
     url         = 'https://github.com/LLNL/zfp/releases/download/0.5.5/zfp-0.5.5.tar.gz'
     git         = 'https://github.com/LLNL/zfp.git'
     maintainers = ['lindstro', 'GarrettDMorrison']
+    tags        = ['radiuss']
 
     # Versions
     version('develop', branch='develop')


### PR DESCRIPTION
This PR tags all of the RADIUSS packages, allowing for them to be searched using and reported using commands such as:

```
$ spack list -t radiuss
==> 26 packages.
ascent   care       flux-sched  lvarray       py-merlin  scr       xbraid
axom     chai       glvis       mfem          py-shroud  sundials  zfp
blt      conduit    hypre       py-hatchet    raja       umpire
caliper  flux-core  lbann       py-maestrowf  samrai     visit

$ spack find -t radius
==> 2 installed packages
-- linux-rhel7-broadwell / gcc@8.3.1 ----------------------------
zfp@0.5.5

-- linux-rhel7-skylake_avx512 / gcc@8.3.1 -----------------------
hypre@2.22.0
```

Note: You will likely have to run the following to get these to show up:

```
$ spack clean -m           # the cache needs to be re-generated to pick up the new tags
$ spack providers mpi   # this will regenerate providers *and* tags; takes a while
```