### PR TITLE
Fix macOS github action name

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,4 +1,4 @@
-name: linux tests
+name: Unit tests
 
 on:
   push:
@@ -319,7 +319,7 @@ jobs:
       with:
         flags: unittests,linux,clingo
   # Run unit tests on MacOS
-  build:
+  macOS:
     needs: [ validate, style, documentation, changes ]
     runs-on: macos-latest
     strategy:


### PR DESCRIPTION
macOS is listed under linux tests with a very generic name 'build',
which is somewhat confusing when the builds fail only on macOS
like in #26035 