### PR TITLE
exempi: fix expat dependency

### DIFF
--- a/var/spack/repos/builtin/packages/exempi/package.py
+++ b/var/spack/repos/builtin/packages/exempi/package.py
@@ -27,6 +27,13 @@ class Exempi(AutotoolsPackage):
 
     conflicts('%gcc@:4.5')
 
+    def patch(self):
+        # fix make check: Fix undefined reference to `boost::unit_test::unit_test_main`:
+        # BOOST_TEST_DYN_LINK only works with shlib and when boost is linked after src:
+        # https://bugs.launchpad.net/widelands/+bug/662908
+        # https://github.com/bincrafters/community/issues/127
+        filter_file('#define BOOST_TEST_DYN_LINK', '', 'exempi/tests/test-adobesdk.cpp')
+
     def configure_args(self):
         args = ['--with-boost={0}'.format(self.spec['boost'].prefix)]
 

--- a/var/spack/repos/builtin/packages/exempi/package.py
+++ b/var/spack/repos/builtin/packages/exempi/package.py
@@ -23,6 +23,7 @@ class Exempi(AutotoolsPackage):
     depends_on('iconv')
     depends_on('boost@1.48.0:')
     depends_on('pkgconfig')
+    depends_on('expat')
 
     conflicts('%gcc@:4.5')
 


### PR DESCRIPTION
The exempi package is missing the expat dependency and I get the following error when installing it:
```
==> exempi: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    $spack-stage/spack-stage-exempi-2.5.2-7vts3x4ll7gbxwfux76crd6evpqqp4qt/spack-src/configure' '--prefix=$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/exempi-2.5.2-7vts3x4ll7gbxwfux76crd6evpqqp4qt' '--with-boost=$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/boost-1.77.0-w4nu7zcsa4gm3oykb6fadjhox7bjajfv'

1 error found in build log:
     95     checking how to hardcode library paths into programs... immediate
     96     checking whether $spack/lib/spack/env/gcc/g++ supports C++11 features by default... yes
     97     checking whether byte ordering is bigendian... no
     98     checking expat.h usability... no
     99     checking expat.h presence... no
     100    checking for expat.h... no
  >> 101    configure: error: expat headers missing
```
Adding the missing dependency fixes that.