### PR TITLE
[diffutils] Add v3.8, which fixes an incompatibility with newer glibc

### DIFF
--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -17,6 +17,7 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/diffutils/"
     gnu_mirror_path = "diffutils/diffutils-3.7.tar.xz"
 
+    version('3.8', sha256='a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec')
     version('3.7', sha256='b3a7a6221c3dc916085f0d205abf6b8e1ba443d4dd965118da364a1dc1cb3a26')
     version('3.6', sha256='d621e8bdd4b573918c8145f7ae61817d1be9deb4c8d2328a65cea8e11d783bd6')
 


### PR DESCRIPTION
Diffutils <3.8 would implicitly assumes that the SIGSTKSZ preprocessor define from glibc is an integer. Unfortunately, [this assumption is violated by glibc >= 2.24](https://sourceware.org/glibc/wiki/Release/2.34#Non-constant_MINSIGSTKSZ_and_SIGSTKSZ). So Linux distributions with a recent version of glibc won't build anything older than diffutils 3.8, which does away with this assumption.