### PR TITLE
Build container images on Github Actions and push to multiple registries

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -3,6 +3,12 @@ on:
   # Build new Spack develop containers nightly.
   schedule:
     - cron: '34 0 * * *'
+  # Run on pull requests that modify this file
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/build-containers.yml'
   # Let's also build & tag Spack containers on releases.
   release:
     types: [published]
@@ -29,7 +35,7 @@ jobs:
 
       - name: Set Container Tag Normal (Nightly)
         run: |
-          container="ghcr.io/spack/${{ matrix.dockerfile[0]}}:latest"
+          container="${{ matrix.dockerfile[0] }}:latest"
           echo "container=${container}" >> $GITHUB_ENV
           echo "versioned=${container}" >> $GITHUB_ENV
 
@@ -37,7 +43,7 @@ jobs:
       - name: Set Container Tag on Release
         if: github.event_name == 'release'
         run: |
-          versioned="ghcr.io/spack/${{matrix.dockerfile[0]}}:${GITHUB_REF##*/}"
+          versioned="${{matrix.dockerfile[0]}}:${GITHUB_REF##*/}"
           echo "versioned=${versioned}" >> $GITHUB_ENV
 
       - name: Check ${{ matrix.dockerfile[1] }} Exists
@@ -66,7 +72,7 @@ jobs:
         with:
           file: share/spack/docker/${{matrix.dockerfile[1]}}
           platforms: ${{ matrix.dockerfile[2] }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ${{ env.container }}
-            ${{ env.versioned }}
+            ghcr.io/spack/${{ env.container }}
+            ghcr.io/spack/${{ env.versioned }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -54,6 +54,12 @@ jobs:
               exit 1;
           fi
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -61,11 +67,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Log in to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build & Deploy ${{ matrix.dockerfile[1] }}
         uses: docker/build-push-action@v2
@@ -74,5 +80,7 @@ jobs:
           platforms: ${{ matrix.dockerfile[2] }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
+            spack/${{ env.container }}
+            spack/${{ env.versioned }}
             ghcr.io/spack/${{ env.container }}
             ghcr.io/spack/${{ env.versioned }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Bootstrapping](https://github.com/spack/spack/actions/workflows/bootstrap.yml/badge.svg)](https://github.com/spack/spack/actions/workflows/bootstrap.yml)
 [![macOS Builds (nightly)](https://github.com/spack/spack/workflows/macOS%20builds%20nightly/badge.svg?branch=develop)](https://github.com/spack/spack/actions?query=workflow%3A%22macOS+builds+nightly%22)
 [![codecov](https://codecov.io/gh/spack/spack/branch/develop/graph/badge.svg)](https://codecov.io/gh/spack/spack)
+[![Build & Deploy Docker Containers](https://github.com/spack/spack/actions/workflows/build-containers.yml/badge.svg)](https://github.com/spack/spack/actions/workflows/build-containers.yml)
 [![Read the Docs](https://readthedocs.org/projects/spack/badge/?version=latest)](https://spack.readthedocs.io)
 [![Slack](https://slack.spack.io/badge.svg)](https://slack.spack.io)
 

--- a/share/spack/docker/amazonlinux-2.dockerfile
+++ b/share/spack/docker/amazonlinux-2.dockerfile
@@ -24,6 +24,7 @@ RUN yum update -y \
         Lmod \
         make \
         patch \
+        patchelf \
         python \
         python-pip \
         python-setuptools \
@@ -64,6 +65,7 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # TODO: add a command to Spack that (re)creates the package cache
+RUN spack bootstrap untrust spack-install
 RUN spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]

--- a/share/spack/docker/amazonlinux-2.dockerfile
+++ b/share/spack/docker/amazonlinux-2.dockerfile
@@ -24,14 +24,13 @@ RUN yum update -y \
         Lmod \
         make \
         patch \
-        patchelf \
-        python \
-        python-pip \
-        python-setuptools \
+        python3 \
+        python3-pip \
+        python3-setuptools \
         tcl \
         unzip \
         which \
- && pip install boto3 \
+ && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all
 

--- a/share/spack/docker/centos-7.dockerfile
+++ b/share/spack/docker/centos-7.dockerfile
@@ -27,13 +27,13 @@ RUN yum update -y \
         make \
         patch \
         patchelf \
-        python \
-        python-pip \
-        python-setuptools \
+        python3 \
+        python3-pip \
+        python3-setuptools \
         tcl \
         unzip \
         which \
- && pip install boto3 \
+ && pip3 install boto3 \
  && rm -rf /var/cache/yum \
  && yum clean all
 

--- a/share/spack/docker/centos-7.dockerfile
+++ b/share/spack/docker/centos-7.dockerfile
@@ -26,6 +26,7 @@ RUN yum update -y \
         Lmod \
         make \
         patch \
+        patchelf \
         python \
         python-pip \
         python-setuptools \
@@ -66,6 +67,7 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # TODO: add a command to Spack that (re)creates the package cache
+RUN spack bootstrap untrust spack-install
 RUN spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]

--- a/share/spack/docker/leap-15.dockerfile
+++ b/share/spack/docker/leap-15.dockerfile
@@ -1,20 +1,20 @@
-FROM opensuse/leap:15.2
+FROM opensuse/leap:15.3
 MAINTAINER Christian Goll <cgoll@suse.com>
 
 ENV DOCKERFILE_BASE=opensuse          \
     DOCKERFILE_DISTRO=opensuse_leap   \
-    DOCKERFILE_DISTRO_VERSION=15.2    \
+    DOCKERFILE_DISTRO_VERSION=15.3    \
     SPACK_ROOT=/opt/spack      \
     DEBIAN_FRONTEND=noninteractive    \
     CURRENTLY_BUILDING_DOCKER_IMAGE=1 \
     container=docker
 
-RUN 	zypper ref && \
-	zypper up -y && \
-	zypper in -y python3-base python3-boto3\
-	xz gzip tar bzip2 curl patch \
-	gcc-c++ gcc-fortran make cmake automake &&\
-  zypper clean
+RUN zypper ref && \
+    zypper up -y && \
+    zypper in -y python3-base python3-boto3 \
+    xz gzip tar bzip2 curl patch patchelf file \
+    gcc-c++ gcc-fortran make cmake automake && \
+    zypper clean
 
 # clean up manpages
 RUN	rm -rf /var/cache/zypp/*  \
@@ -51,8 +51,8 @@ RUN [ -f ~/.profile ]                                               \
 WORKDIR /root
 SHELL ["docker-shell"]
 
-# Find tools which are in distro
-RUN ${SPACK_ROOT}/bin/spack external find  --scope system
+# Disable bootstrapping from sources
+RUN ${SPACK_ROOT}/bin/spack bootstrap untrust spack-install
 
 # TODO: add a command to Spack that (re)creates the package cache
 RUN ${SPACK_ROOT}/bin/spack spec hdf5+mpi

--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -69,6 +69,7 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # TODO: add a command to Spack that (re)creates the package cache
+RUN spack bootstrap untrust spack-install
 RUN spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -73,6 +73,7 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # TODO: add a command to Spack that (re)creates the package cache
+RUN spack bootstrap untrust spack-install
 RUN spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]


### PR DESCRIPTION
Modifications:
- [x] Modify the workflow to build container images without pushing when the workflow file itself is modified
- [x] Strip the leading `ghcr.io/spack/` from `env.container` `env.versioned` to prepare pushing to multiple registries
- [x] Fixed CentOS 7 and Amazon Linux builds
- [ ] Login and push to Docker Hub as well as Github Action
- [x] Add a badge to README.md with the status of docker images