### PR TITLE
limit the amd_target_sram_ecc inside rocfft package to rocm-3.9.0-4.0.0 releases

### DIFF
--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -62,7 +62,7 @@ class Rocfft(CMakePackage):
         # From version 3.9 and above we have AMDGPU_TARGETS_SRAM_ECC
         tgt_sram = self.spec.variants['amdgpu_target_sram_ecc'].value
 
-        if tgt_sram[0] != 'none' and '@3.9.0:' in self.spec:
+        if tgt_sram[0] != 'none' and self.spec.satisfies('@3.9.0:4.0.0'):
             args.append(self.define('AMDGPU_TARGETS_SRAM_ECC', ";".join(tgt_sram)))
 
         # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322


### PR DESCRIPTION
amd_target_sram_ecc is being only used inside the cmakelists.txt for rocfft@3.9.0 and until rocfft@4.0.0 . This change will fix #25773 