### PR TITLE
perl: Fix test case bug Perl/perl5#15544: Don't fail with PATH >1000 chars

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -129,6 +129,11 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
 
     phases = ['configure', 'build', 'install']
 
+    def patch(self):
+        # https://github.com/Perl/perl5/issues/15544 long PATH(>1000 chars) fails a test
+        os.chmod('lib/perlbug.t', 0o644)
+        filter_file('!/$B/', '! (/(?:$B|PATH)/)', 'lib/perlbug.t')
+
     @classmethod
     def determine_version(cls, exe):
         perl = spack.util.executable.Executable(exe)


### PR DESCRIPTION
Fix the perl test case bug https://github.com/Perl/perl5/issues/15544:

Variable `PATH` longer than 1000 characters (as is usual with spack) fails a perl test case:

The fix is: Don't test PATH in testcase `perlbug.t`

Fixes `spack install --test=all` for specs triggering a build and test of perl! :100: %