### PR TITLE
py-monty/pymatgen/spglib: bump versions and fix py-pymatgen dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-monty/package.py
+++ b/var/spack/repos/builtin/packages/py-monty/package.py
@@ -15,6 +15,6 @@ class PyMonty(PythonPackage):
     version('2021.8.17', sha256='d4d5b85566bda80360e275e6ffb72228d203de68c5155446a0e09f19c63e8540')
     version('0.9.6', sha256='bbf05646c4e86731c2398a57b1044add7487fc4ad03122578599ddd9a8892780')
 
-    depends_on('python@3.5:')
+    depends_on('python@3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-six',        type=('build', 'run'), when='@:1')

--- a/var/spack/repos/builtin/packages/py-monty/package.py
+++ b/var/spack/repos/builtin/packages/py-monty/package.py
@@ -12,7 +12,9 @@ class PyMonty(PythonPackage):
     homepage = "https://github.com/materialsvirtuallab/monty"
     pypi = "monty/monty-0.9.6.tar.gz"
 
+    version('2021.8.17', sha256='d4d5b85566bda80360e275e6ffb72228d203de68c5155446a0e09f19c63e8540')
     version('0.9.6', sha256='bbf05646c4e86731c2398a57b1044add7487fc4ad03122578599ddd9a8892780')
 
+    depends_on('python@3.5:')
     depends_on('py-setuptools', type='build')
-    depends_on('py-six',        type=('build', 'run'))
+    depends_on('py-six',        type=('build', 'run'), when='@:1')

--- a/var/spack/repos/builtin/packages/py-pymatgen/package.py
+++ b/var/spack/repos/builtin/packages/py-pymatgen/package.py
@@ -15,21 +15,41 @@ class PyPymatgen(PythonPackage):
     homepage = "http://www.pymatgen.org/"
     pypi = "pymatgen/pymatgen-4.7.2.tar.gz"
 
+    version('2021.3.9',  sha256='a6f22d69133a48b7801bfd5e6a2878b47b4b4b2ef1a377b87c6c573be14cbf16')
     version('4.7.2', sha256='e439b78cc3833a03963c3c3efe349d8a0e52a1550c8a05c56a89aa1b86657436')
     version('4.6.2', sha256='f34349090c6f604f7d402cb09cd486830b38523639d7160d7fd282d504036a0e')
 
-    extends('python', ignore='bin/tabulate')
+    # 2021.1.1, requires Python >=3.7, previous versions don't build with it
+    extends('python@:3.6',               ignore='bin/tabulate',  when='@:4.7.2')
+    extends('python@3.7:',               ignore='bin/tabulate',  when='@2021.1.1:')
 
     depends_on('py-setuptools@18.0:', type='build')
 
     depends_on('py-numpy@1.9:',          type=('build', 'run'))
-    depends_on('py-six',                 type=('build', 'run'))
+    depends_on('py-six',                 type=('build', 'run'),  when='@:4.7.2')
     depends_on('py-requests',            type=('build', 'run'))
-    depends_on('py-pyyaml@3.11:',        type=('build', 'run'))
+    depends_on('py-pyyaml@3.11:',        type=('build', 'run'),  when='@:4.7.2')
     depends_on('py-monty@0.9.6:',        type=('build', 'run'))
     depends_on('py-scipy@0.14:',         type=('build', 'run'))
-    depends_on('py-pydispatcher@2.0.5:', type=('build', 'run'))
+    depends_on('py-pydispatcher@2.0.5:', type=('build', 'run'),  when='@:4.7.2')
     depends_on('py-tabulate',            type=('build', 'run'))
     depends_on('py-spglib@1.9.8.7:',     type=('build', 'run'))
     depends_on('py-matplotlib@1.5:',     type=('build', 'run'))
     depends_on('py-palettable@2.1.1:',   type=('build', 'run'))
+
+    # dependencies of never versions
+    depends_on('py-matplotlib@1.5:',      when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-monty@3.0.2:',         when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-numpy@1.20.1:',        when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-palettable@3.1.1:',    when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-pandas',               when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-plotly@4.5.0:',        when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-ruamel-yaml@0.15.6:',  when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-scipy@1.5.0:',         when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-spglib@1.9.9.44:',     when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-sympy',                when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-tabulate',             when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-uncertainties@3.1.4:', when='@2021.1.1:', type=('build', 'run'))
+    # while optional, for imports of spack install --test=root, these are required
+    depends_on('py-networkx@2.2:',        when='@2021.1.1:', type=('build', 'run'))
+    depends_on('py-netcdf4@1.5.3:',       when='@2021.1.1:', type=('test', 'run'))

--- a/var/spack/repos/builtin/packages/py-pymatgen/package.py
+++ b/var/spack/repos/builtin/packages/py-pymatgen/package.py
@@ -49,8 +49,7 @@ class PyPymatgen(PythonPackage):
     depends_on('py-scipy@1.5.0:',         when='@2021.1.1:', type=('build', 'run'))
     depends_on('py-spglib@1.9.9.44:',     when='@2021.1.1:', type=('build', 'run'))
     depends_on('py-sympy',                when='@2021.1.1:', type=('build', 'run'))
-    depends_on('py-tabulate',             when='@2021.1.1:', type=('build', 'run'))
     depends_on('py-uncertainties@3.1.4:', when='@2021.1.1:', type=('build', 'run'))
     # while optional, for imports of spack install --test=root, these are required
     depends_on('py-networkx@2.2:',        when='@2021.1.1:', type=('build', 'run'))
-    depends_on('py-netcdf4@1.5.3:',       when='@2021.1.1:', type=('test', 'run'))
+    depends_on('py-netcdf4@1.5.3:',       when='@2021.1.1:', type=('test'))

--- a/var/spack/repos/builtin/packages/py-pymatgen/package.py
+++ b/var/spack/repos/builtin/packages/py-pymatgen/package.py
@@ -19,7 +19,8 @@ class PyPymatgen(PythonPackage):
     version('4.7.2', sha256='e439b78cc3833a03963c3c3efe349d8a0e52a1550c8a05c56a89aa1b86657436')
     version('4.6.2', sha256='f34349090c6f604f7d402cb09cd486830b38523639d7160d7fd282d504036a0e')
 
-    # 2021.1.1, requires Python >=3.7, previous versions don't build with it
+    # Old versions come pre-cythonized and so don't support newer python versions
+    # and 2021.1.1 and newer require Python >= 3.7
     extends('python@:3.6',               ignore='bin/tabulate',  when='@:4.7.2')
     extends('python@3.7:',               ignore='bin/tabulate',  when='@2021.1.1:')
 

--- a/var/spack/repos/builtin/packages/py-pymatgen/package.py
+++ b/var/spack/repos/builtin/packages/py-pymatgen/package.py
@@ -50,6 +50,6 @@ class PyPymatgen(PythonPackage):
     depends_on('py-spglib@1.9.9.44:',     when='@2021.1.1:', type=('build', 'run'))
     depends_on('py-sympy',                when='@2021.1.1:', type=('build', 'run'))
     depends_on('py-uncertainties@3.1.4:', when='@2021.1.1:', type=('build', 'run'))
-    # while optional, for imports of spack install --test=root, these are required
     depends_on('py-networkx@2.2:',        when='@2021.1.1:', type=('build', 'run'))
+    # while optional, for imports of spack install --test=root, these are required
     depends_on('py-netcdf4@1.5.3:',       when='@2021.1.1:', type=('test'))

--- a/var/spack/repos/builtin/packages/py-ruamel-yaml/package.py
+++ b/var/spack/repos/builtin/packages/py-ruamel-yaml/package.py
@@ -15,12 +15,15 @@ class PyRuamelYaml(PythonPackage):
     homepage = "https://sourceforge.net/p/ruamel-yaml/code/ci/default/tree"
     pypi = "ruamel.yaml/ruamel.yaml-0.16.10.tar.gz"
 
+    version('0.17.16', sha256='1a771fc92d3823682b7f0893ad56cb5a5c87c48e62b5399d6f42c8759a583b33')
     version('0.16.10', sha256='099c644a778bf72ffa00524f78dd0b6476bca94a1da344130f4bf3381ce5b954')
     version('0.16.5',  sha256='412a6f5cfdc0525dee6a27c08f5415c7fd832a7afcb7a0ed7319628aed23d408')
     version('0.11.7',  sha256='c89363e16c9eafb9354e55d757723efeff8682d05e56b0881450002ffb00a344')
 
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('python@3.5:',                when='@0.17:',             type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools@28.7:',        when='@0.17:',             type=('build'))
     depends_on('py-ruamel-ordereddict', when='@0.15:^python@:2', type=('build', 'run'))
     depends_on('py-ruamel-yaml-clib@0.1.2:', when='@0.16:^python@:3.8', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-spglib/package.py
+++ b/var/spack/repos/builtin/packages/py-spglib/package.py
@@ -13,6 +13,7 @@ class PySpglib(PythonPackage):
     homepage = "https://atztogo.github.io/spglib/"
     pypi = "spglib/spglib-1.9.9.18.tar.gz"
 
+    version('1.16.1', sha256='9fd2fefbd83993b135877a69c498d8ddcf20a9980562b65b800cfb4cdadad003')
     version('1.9.9.18', sha256='cbbb8383320b500dc6100b83d5e914a26a97ef8fc97c82d8921b10220e4126cd')
 
     # Most Python packages only require setuptools as a build dependency.

--- a/var/spack/repos/builtin/packages/py-uncertainties/package.py
+++ b/var/spack/repos/builtin/packages/py-uncertainties/package.py
@@ -14,6 +14,7 @@ class PyUncertainties(PythonPackage):
     homepage = "https://uncertainties-python-package.readthedocs.io/en/latest/"
     pypi = "uncertainties/uncertainties-3.1.4.tar.gz"
 
+    version('3.1.6', sha256='7c4db5aaafd227e95485b61fba5d235dc8133aeecd98f8fc1224c038ce063e2d')
     version('3.1.4', sha256='63548a94899f2a51eeb89b640f6ac311f481a8016b37dce157186e44619bc968')
 
     variant('optional', default=False, description='Enable extra features involving numpy')


### PR DESCRIPTION
Fix build of old versions to use pytong 3.6 or older: They are pre-cythonized so can't build with python@3.7:
Add version 2021.3.5  is the last version using the old/revious API,
