### PR TITLE
py-setuptools-scm-git-archive: Fix deps: Add py-wheel, py-tomli, py-packaging

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools-scm-git-archive/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm-git-archive/package.py
@@ -22,3 +22,6 @@ class PySetuptoolsScmGitArchive(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-setuptools-scm', type='build')
+    depends_on('py-wheel',          type='build')
+    depends_on('py-tomli')
+    depends_on('py-packaging')


### PR DESCRIPTION
Fix the build: `py-setuptools-scm-git-archive` needs `py-wheel`, `py-tomli` and `py-packaging`.

Tested by packaging new versions of `py-tomopy` (the current version fails build)