### PR TITLE
py-tomopy: version bump and master, add new deps, make runtest pass

### DIFF
--- a/var/spack/repos/builtin/packages/py-tomopy/package.py
+++ b/var/spack/repos/builtin/packages/py-tomopy/package.py
@@ -13,15 +13,43 @@ class PyTomopy(PythonPackage):
 
     homepage = "https://tomopy.readthedocs.io/en/latest/index.html"
     url      = "https://github.com/tomopy/tomopy/archive/1.0.0.tar.gz"
+    git      = 'https://github.com/tomopy/tomopy.git'
 
+    version('master', branch='master')
+    version('1.10.4', sha256='2f15edda11b4337a1a5560684fcf8f28a35c5035932b22b842ce728bd13fba01')
     version('1.0.0', sha256='ee45f7a062e5a66d6f18a904d2e204e48d85a1ce1464156f9e2f6353057dfe4c')
 
+    # GPU accel needs PTL which is a git submodule. Thus, we can only build it on master
+    depends_on('cuda',                          when='@master')
+    # The shared opencv is not found by during runtest. Not using GOT/PLT is faster too
+    depends_on('opencv+imgproc~shared@3.4:',    when='@master')
+    # During the runtest, the shared MKL libs aren't found yet:
+    # depends_on('intel-mkl~shared')
+    depends_on('cmake@3.17:',                   type=('build'))
+    depends_on('ninja',                         type=('build'))
+    depends_on('py-setuptools-scm',             type=('build'))
+    depends_on('py-setuptools-scm-git-archive', type=('build'))
+    # Note: The module name of py-scikit-build is skbuild:
+    depends_on('py-scikit-build',               type=('build'))
+    depends_on('py-scikit-image@0.17:',         type=('build', 'run'))
+    depends_on('py-numpy+blas',                 type=('build', 'run'))
+    depends_on('py-pyfftw',                     type=('build', 'run'), when='@1.0:1.9')
+    depends_on('py-numexpr',                    type=('test'))
+    depends_on('py-scipy',                      type=('build', 'test', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-h5py', type=('build', 'run'))
-    depends_on('py-scipy', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
-    depends_on('py-scikit-image', type=('build', 'run'))
     depends_on('py-pywavelets', type=('build', 'run'))
-    depends_on('py-pyfftw', type=('build', 'run'))
     depends_on('py-dxchange', type=('build', 'run'))
+
+    @when('@1.10:')
+    def build_args(self, spec, prefix):
+        args = ['--enable-arch']
+        if 'avx512' in self.spec.target:
+            args.append('--enable-avx512')
+
+        # PTL is a git submodule, we only fetch it's source by git-submodule on master:
+        if self.version != Version('master'):
+            args.append('--disable-tasking')
+
+        return args


### PR DESCRIPTION
Current `py-tomopy` has many new features and dependencies, add them.