### PR TITLE
trilinos: default gotype=long_long

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -65,7 +65,7 @@ class Trilinos(CMakePackage, CudaPackage):
     variant('explicit_template_instantiation', default=True, description='Enable explicit template instantiation (ETI)')
     variant('float', default=False, description='Enable single precision (float) numbers in Trilinos')
     variant('fortran', default=True, description='Compile with Fortran support')
-    variant('gotype', default='long',
+    variant('gotype', default='long_long',
             values=('int', 'long', 'long_long', 'all'),
             multi=False,
             description='global ordinal type for Tpetra')


### PR DESCRIPTION
"Long long" is the default type when building trilinos on its own, and
many downstream packages (both in and out of spack) rely on it. E4S
already sets this explicitly to long_long.