### PR TITLE
[acts] eigen is not only a build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -139,7 +139,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on('cmake @3.14:', type='build')
     depends_on('dd4hep @1.11:', when='+dd4hep')
     depends_on('dd4hep @1.11: +geant4', when='+dd4hep +geant4')
-    depends_on('eigen @3.3.7:', type='build')
+    depends_on('eigen @3.3.7:')
     depends_on('geant4', when='+fatras_geant4')
     depends_on('geant4', when='+geant4')
     depends_on('hepmc3 @3.2.1:', when='+hepmc3')


### PR DESCRIPTION
The [ActsConfig.cmake](https://github.com/acts-project/acts/blob/v13.0.0/cmake/ActsConfig.cmake.in#L59) includes a `find_dependency(Eigen3)` line. Requiring depends_on type='build' does not expose eigen to dependents during their build.

This has been the case since v0.28.0, https://github.com/acts-project/acts/commit/370e4a98f10837c68750f865f584277283d80fac, but I think even before then there was an eigen dependency, just not included in ActsConfig.cmake (as deduced from the commit message).