### PR TITLE
ca-certificates-mozilla for openssl & curl

### DIFF
--- a/var/spack/repos/builtin/packages/ca-certificates-mozilla/package.py
+++ b/var/spack/repos/builtin/packages/ca-certificates-mozilla/package.py
@@ -31,9 +31,13 @@ class CaCertificatesMozilla(Package):
     def url_for_version(self, version):
         return "https://curl.se/ca/cacert-{0}.pem".format(version)
 
+    def setup_dependent_package(self, module, dep_spec):
+        """Returns the absolute path to the bundled certificates"""
+        self.spec.pem_path = join_path(self.prefix.share, 'cacert.pem')
+
     # Install the the pem file as share/cacert.pem
     def install(self, spec, prefix):
-        share = join_path(self.prefix, 'share')
+        share = join_path(prefix, 'share')
         mkdir(share)
         install("cacert-{0}.pem".format(spec.version),
                 join_path(share, "cacert.pem"))

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -97,6 +97,9 @@ class Curl(AutotoolsPackage):
     depends_on('libssh', when='+libssh')
     depends_on('krb5', when='+gssapi')
 
+    # curl queries pkgconfig for openssl compilation flags
+    depends_on('pkgconfig', type='build')
+
     def configure_args(self):
         spec = self.spec
 
@@ -108,6 +111,9 @@ class Curl(AutotoolsPackage):
             '--without-libgsasl',
             '--without-libpsl',
             '--without-zstd',
+            '--without-ca-bundle',
+            '--without-ca-path',
+            '--with-ca-fallback',
         ]
 
         # https://daniel.haxx.se/blog/2021/06/07/bye-bye-metalink-in-curl/

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -76,12 +76,15 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
     version('1.0.1h', sha256='9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093', deprecated=True)
     version('1.0.1e', sha256='f74f15e8c8ff11aa3d5bb5f276d202ec18d7246e95f961db76054199c69c1ae3', deprecated=True)
 
-    variant('systemcerts', default=True, description='Use system certificates')
+    variant('certs', default='mozilla',
+            values=('mozilla', 'system', 'none'), multi=False,
+            description=('Use certificates from the ca-certificates-mozilla '
+                         'package, symlink system certificates, or none'))
     variant('docs', default=False, description='Install docs and manpages')
 
     depends_on('zlib')
-
     depends_on('perl@5.14.0:', type=('build', 'test'))
+    depends_on('ca-certificates-mozilla', type=('build', 'run'), when='certs=mozilla')
 
     @classmethod
     def determine_version(cls, exe):
@@ -146,7 +149,7 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
 
     @run_after('install')
     def link_system_certs(self):
-        if '+systemcerts' not in self.spec:
+        if self.spec.variants['certs'].value != 'system':
             return
 
         system_dirs = [
@@ -185,6 +188,20 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
                 if os.path.isdir(pkg_certs):
                     os.rmdir(pkg_certs)
                 os.symlink(sys_certs, pkg_certs)
+
+    @run_after('install')
+    def link_mozilla_certs(self):
+        if self.spec.variants['certs'].value != 'mozilla':
+            return
+
+        pkg_dir = join_path(self.prefix, 'etc', 'openssl')
+        mkdirp(pkg_dir)
+
+        mozilla_pem = self.spec['ca-certificates-mozilla'].pem_path
+        pkg_cert = join_path(pkg_dir, 'cert.pem')
+
+        if not os.path.exists(pkg_cert):
+            os.symlink(mozilla_pem, pkg_cert)
 
     def patch(self):
         if self.spec.satisfies('%nvhpc'):

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -76,7 +76,7 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
     version('1.0.1h', sha256='9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093', deprecated=True)
     version('1.0.1e', sha256='f74f15e8c8ff11aa3d5bb5f276d202ec18d7246e95f961db76054199c69c1ae3', deprecated=True)
 
-    variant('certs', default='mozilla',
+    variant('certs', default='system',
             values=('mozilla', 'system', 'none'), multi=False,
             description=('Use certificates from the ca-certificates-mozilla '
                          'package, symlink system certificates, or none'))


### PR DESCRIPTION
Currently openssl defaults to using system provided certificates, which
kinda make sense, until you happen to work on a Cray system which does
not allow symlinking to /etc/openssl/certs anymore, because of what
likely is a bug on their side.

IMHO the better default for Spack is not to rely on the system, and we
can already do so, because we have `ca-certificates-mozilla` as a
package for quite a while now.

This PR:
1. Replaces the `systemcerts` variant of openssl with 
   `certs=mozilla/system/none` so that users can pick whether they want
   Spack or system certs, or if they don't want certs at all.
2. Changes the default behavior of openssl to use certs=mozilla, meaning
   that by default we do not rely on the system.
3. Changes the curl configuration to not guess the ca path during
   config, but rather fall back to whatever the tls provider is
   configured with. If we don't do this, curl will still pick up system
   certs if it finds them.

As a minor fix, it also adds the build dep `pkgconfig` to curl, since
that's being used during the configure phase to get openssl compilation
flags.

As a follow-up we should look at `curl tls=mbedtls` and make `mbedtls`
also use ca-certificates by default. Since `mbedtls` support was only
added recently, I don't think it's important to fix that in this PR.

I didn't find any mention of `systemcerts` in other Spack packages, so
should be safe to rename.

Thanks to @bernhardkaindl for figuring out some curl issues
