### PR TITLE
cray-mvapich2: add a package to support

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mvapich2/package.py
+++ b/var/spack/repos/builtin/packages/cray-mvapich2/package.py
@@ -1,0 +1,59 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class CrayMvapich2(Package):
+    """Cray/HPE packaging of MVAPICH2 for HPE Apollo systems"""
+
+    homepage = "https://docs.nersc.gov/development/compilers/wrappers/"
+    has_code = False    # Skip attempts to fetch source that is not available
+
+    maintainers = ['hppritcha']
+
+    version('8.1.0')
+    version('8.0.16')
+    version('8.0.14')
+    version('8.0.11')
+    version('8.0.9')
+    version('7.7.16')
+    version('7.7.15')
+    version('7.7.14')
+    version('7.7.13')
+
+    provides('mpi@3')
+
+    def setup_run_environment(self, env):
+        env.set('MPICC', spack_cc)
+        env.set('MPICXX', spack_cxx)
+        env.set('MPIF77', spack_fc)
+        env.set('MPIF90', spack_fc)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_run_environment(env)
+
+        env.set('MPICH_CC', spack_cc)
+        env.set('MPICH_CXX', spack_cxx)
+        env.set('MPICH_F77', spack_f77)
+        env.set('MPICH_F90', spack_fc)
+        env.set('MPICH_FC', spack_fc)
+
+    def setup_dependent_package(self, module, dependent_spec):
+        spec = self.spec
+        spec.mpicc = spack_cc
+        spec.mpicxx = spack_cxx
+        spec.mpifc = spack_fc
+        spec.mpif77 = spack_f77
+
+        spec.mpicxx_shared_libs = [
+            join_path(self.prefix.lib, 'libmpicxx.{0}'.format(dso_suffix)),
+            join_path(self.prefix.lib, 'libmpi.{0}'.format(dso_suffix))
+        ]
+
+    def install(self, spec, prefix):
+        raise InstallError(
+            self.spec.format('{name} is not installable, you need to specify '
+                             'it as an external package in packages.yaml'))


### PR DESCRIPTION
The format of the HPE/Cray supplied module for cray-mvapich2 on HPE apollo systems is
very different from the cray-mpich module supplied on Cray EX and XE
systems.

Recent changes to the cray-mpich package -

https://github.com/spack/spack/pull/23470

broke support for cray-mvapich2 and relies now on the structure of the
cray-mpich module to work properly.

Rather than try to support two very different vendor mpich modules
using the same spack package, just add another one specialized for
the cray-mvapich2 module.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>