### PR TITLE
py-datalad: move datalad wtf test over from py-datalad-metalad

### DIFF
--- a/var/spack/repos/builtin/packages/py-datalad-metalad/package.py
+++ b/var/spack/repos/builtin/packages/py-datalad-metalad/package.py
@@ -17,9 +17,3 @@ class PyDataladMetalad(PythonPackage):
     depends_on('py-setuptools',      type=('build'))
     depends_on('py-datalad@0.12.3:', type=('build', 'run'))
     depends_on('git-annex',          type=('run'))
-    depends_on('py-nose',            type=('run', 'test'))
-
-    install_time_test_callbacks = ['test', 'installtest']
-
-    def installtest(self):
-        which('datalad')('wtf')

--- a/var/spack/repos/builtin/packages/py-datalad/package.py
+++ b/var/spack/repos/builtin/packages/py-datalad/package.py
@@ -115,5 +115,5 @@ class PyDatalad(PythonPackage):
     install_time_test_callbacks = ['test', 'installtest']
 
     def installtest(self):
-        datalad = Executable('{0}/datalad'.format(self.prefix.bin))
+        datalad = Executable(self.prefix.bin.datalad)
         datalad('wtf')

--- a/var/spack/repos/builtin/packages/py-datalad/package.py
+++ b/var/spack/repos/builtin/packages/py-datalad/package.py
@@ -110,3 +110,10 @@ class PyDatalad(PythonPackage):
         depends_on('py-pillow', type=('build', 'run'))
         # duecredit
         depends_on('py-duecredit', type=('build', 'run'))
+
+    depends_on('py-nose', type=('test'))
+    install_time_test_callbacks = ['test', 'installtest']
+
+    def installtest(self):
+        datalad = Executable('{0}/datalad'.format(self.prefix.bin))
+        datalad('wtf')


### PR DESCRIPTION
As discussed in #26225.
Calling `datalad` by using `which` did not work after moving the tests over from `py-datalad-metadata` because `datalad` was not in the path anymore.

ping @bernhardkaindl