### PR TITLE
py-numba: add 0.54.0 and restrict old dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -12,15 +12,18 @@ class PyNumba(PythonPackage):
     homepage = "https://numba.pydata.org/"
     pypi = "numba/numba-0.35.0.tar.gz"
 
+    version('0.54.0', sha256='bad6bd98ab2e41c34aa9c80b8d9737e07d92a53df4f74d3ada1458b0b516ccff')
     version('0.51.1', sha256='1e765b1a41535684bf3b0465c1d0a24dcbbff6af325270c8f4dad924c0940160')
     version('0.50.1', sha256='89e81b51b880f9b18c82b7095beaccc6856fcf84ba29c4f0ced42e4e5748a3a7')
     version('0.48.0', sha256='9d21bc77e67006b5723052840c88cc59248e079a907cc68f1a1a264e1eaba017')
     version('0.40.1', sha256='52d046c13bcf0de79dbfb936874b7228f141b9b8e3447cc35855e9ad3e12aa33')
     version('0.35.0', sha256='11564937757605bee590c5758c73cfe9fd6d569726b56d970316a6228971ecc3')
 
+    depends_on('python@3.7:3.9.999', type=('build', 'run'), when='@0.54.0:')
     depends_on('python@3.6:', type=('build', 'run'), when='@0.48.0:')
     depends_on('python@3.3:3.7.9999', type=('build', 'run'), when='@0.40.1:0.47.999')
     depends_on('python@3.3:3.6.9999', type=('build', 'run'), when='@:0.35.0')
+    depends_on('py-numpy@1.17:1.20', type=('build', 'run'), when='@0.54.0:')
     depends_on('py-numpy@1.15:', type=('build', 'run'), when='@0.48.0:')
     depends_on('py-numpy@1.10:1.99', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
@@ -29,6 +32,7 @@ class PyNumba(PythonPackage):
     # That's why it was chosen as an upper bound in the following depends_on
     # calls.  If newer versions maintain backwards compatibility, the calls
     # can be updated accordingly.
+    depends_on('py-llvmlite@0.37.0rc1:0.37.9', type=('build', 'run'), when='@0.54.0')
     depends_on('py-llvmlite@0.34.0:0.34.999', type=('build', 'run'), when='@0.51.1')
     depends_on('py-llvmlite@0.33.0:0.33.999', type=('build', 'run'), when='@0.50.1')
     depends_on('py-llvmlite@0.31.0:0.31.999', type=('build', 'run'), when='@0.48.0')
@@ -36,8 +40,9 @@ class PyNumba(PythonPackage):
     depends_on('py-llvmlite@0.20:0.25',       type=('build', 'run'), when='@0.35.1')
 
     depends_on('py-argparse', type=('build', 'run'), when='^python@:2.6')
-    depends_on('py-funcsigs', type=('build', 'run'), when='^python@:3.3.99')
-    depends_on('py-singledispatch', type=('build', 'run'), when='^python@:3.3.99')
+    depends_on('py-funcsigs', type=('build', 'run'), when='@:0.47 ^python@:3.2.99')
+    depends_on('py-enum34', type=('build', 'run'), when='@:0.47 ^python@:3.3.99')
+    depends_on('py-singledispatch', type=('build', 'run'), when='@:0.47 ^python@:3.3.99')
 
     # Version 6.0.0 of llvm had a hidden symbol which breaks numba at runtime.
     # See https://reviews.llvm.org/D44140

--- a/var/spack/repos/builtin/packages/py-numba/package.py
+++ b/var/spack/repos/builtin/packages/py-numba/package.py
@@ -32,7 +32,7 @@ class PyNumba(PythonPackage):
     # That's why it was chosen as an upper bound in the following depends_on
     # calls.  If newer versions maintain backwards compatibility, the calls
     # can be updated accordingly.
-    depends_on('py-llvmlite@0.37.0rc1:0.37.9', type=('build', 'run'), when='@0.54.0')
+    depends_on('py-llvmlite@0.37.0:0.37.9', type=('build', 'run'), when='@0.54.0')
     depends_on('py-llvmlite@0.34.0:0.34.999', type=('build', 'run'), when='@0.51.1')
     depends_on('py-llvmlite@0.33.0:0.33.999', type=('build', 'run'), when='@0.50.1')
     depends_on('py-llvmlite@0.31.0:0.31.999', type=('build', 'run'), when='@0.48.0')


### PR DESCRIPTION
  The dependencies on `py-funcsigs`, `py-singledispatch` and `py-enum34` were only needed till version 0.47 according to the [`setup.py`](https://github.com/numba/numba/blob/0.47.0/setup.py#L312). From version 0.48 they are removed from the [`setup.py`](https://github.com/numba/numba/blob/0.48.0/setup.py#L311).