### PR TITLE
perl: fix macOS build

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -15,6 +15,7 @@ import os
 import re
 from contextlib import contextmanager
 
+from llnl.util import tty
 from llnl.util.lang import match_predicate
 
 from spack import *
@@ -299,10 +300,21 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         # This is to avoid failures when using -mmacosx-version-min=11.1
         # since not all Apple Clang compilers support that version range
         # See https://eclecticlight.co/2020/07/21/big-sur-is-both-10-16-and-11-0-its-official/
-        # Setting this value *does* seem to break the install on newer xcode
-        # versions, however.
-        if spec.satisfies('os=bigsur %apple-clang@:12.0.0'):
-            env.set('SYSTEM_VERSION_COMPAT', 1)
+        # It seems that this is only necessary for older versions of the
+        # command line tools rather than the xcode/clang version.
+        if spec.satisfies('os=bigsur'):
+            pkgutil = Executable('pkgutil')
+            output = pkgutil('--pkg-info=com.apple.pkg.CLTools_Executables',
+                             output=str, error=str, fail_on_error=False)
+            match = re.search(r'version:\s*([0-9.]+)', output)
+            if not match:
+                tty.warn('Failed to detect macOS command line tools version: '
+                         + output)
+            else:
+                if Version(match.group(1)) < Version('12'):
+                    tty.warn("Setting SYSTEM_VERSION_COMPAT=1 due to older "
+                             "command line tools version")
+                    env.set('SYSTEM_VERSION_COMPAT', 1)
 
         # This is how we tell perl the locations of bzip and zlib.
         env.set('BUILD_BZIP2', 0)

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -299,7 +299,9 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         # This is to avoid failures when using -mmacosx-version-min=11.1
         # since not all Apple Clang compilers support that version range
         # See https://eclecticlight.co/2020/07/21/big-sur-is-both-10-16-and-11-0-its-official/
-        if spec.satisfies('os=bigsur'):
+        # Setting this value *does* seem to break the install on newer xcode
+        # versions, however.
+        if spec.satisfies('os=bigsur %apple-clang@:12.0.0'):
             env.set('SYSTEM_VERSION_COMPAT', 1)
 
         # This is how we tell perl the locations of bzip and zlib.


### PR DESCRIPTION
With both perl@5.34.0 and perl@5.32.1 the build fails on `macos-bigsur-skylake %apple-clang@12.0.5` and `%apple-clang@13.0.0`:
```
2 errors found in build log:
     579013    /private/var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/s3j/spack-stage/spack-stage-perl-5.34.0-tpha2u52qfwaraidpzzbf6u4dbqg7dk5/spack-src/cpan/
               Math-BigInt-FastCalc/../../miniperl "-I../../lib" -MExtUtils::Command::MM -e 'cp_nonempty' -- FastCalc.bs ../../lib/auto/Math/BigInt/FastCalc/Fas
               tCalc.bs 644
     579014
     579015    	Everything is up to date. Type '/Applications/Xcode.app/Contents/Developer/usr/bin/make test' to run test suite.
     579016    DYLD_LIBRARY_PATH=/private/var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/s3j/spack-stage/spack-stage-perl-5.34.0-tpha2u52qfwaraidpzzbf6u4dbqg7d
               k5/spack-src  ./perl -Ilib -I. installperl --destdir=
     579017    WARNING: You've never run 'make test' or some tests failed! (Installing anyway.)
     579018      /rnsdhpc/code/spack/opt/spack/apple-clang/perl/tpha2u5/bin/perl5.34.0
  >> 579019    install_name_tool: error: sh -c '/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -sdk /Applications/Xcode.app/Contents/Developer/Pl
               atforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -find install_name_tool 2> /dev/null' failed with exit code 256: (null) (errno=Invalid argument
               )
     579020    xcode-select: Failed to locate 'install_name_tool', requesting installation of command line developer tools.
     579021    Cannot update /rnsdhpc/code/spack/opt/spack/apple-clang/perl/tpha2u5/bin/perl5.34.0 dependency paths
  >> 579022    make: *** [install-all] Error 72
```

The system pops up a dialog box requesting an install of the command line tools -- installing them does nothing.

This is due to SYSTEM_VERSION_COMPAT being set when it should *not* be. I verified that the fix works on `perl@5.34.0`. I'm not sure in what circumstances the original failure took place that caused #21375 to be needed.