### PR TITLE
ParaView: add new release ParaView v5.10.0-RC1

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -22,6 +22,7 @@ class Paraview(CMakePackage, CudaPackage):
     maintainers = ['chuckatkins', 'danlipsa', 'vicentebolea']
 
     version('master', branch='master', submodules=True)
+    version('5.10.0-RC1', sha256='468d02962abfd5869c46f32fd9dee3095cb00264237edf2659f09a1c0990ec37')
     version('5.9.1', sha256='0d486cb6fbf55e428845c9650486f87466efcb3155e40489182a7ea85dfd4c8d', preferred=True)
     version('5.9.0', sha256='b03258b7cddb77f0ee142e3e77b377e5b1f503bcabc02bfa578298c99a06980d')
     version('5.8.1', sha256='7653950392a0d7c0287c26f1d3a25cdbaa11baa7524b0af0e6a1a0d7d487d034')


### PR DESCRIPTION
Finally! ParaView 5.10.0 first release candidate (RC) is out :tada: :tada: :tada:

This PR updates the ParaView Spack package to use this new release candidate, we expect to change the preferred version at the final release.

Let me know if we need to change anything else in the package.