### PR TITLE
qhull deprecated libqhull.so in 2020.2

### DIFF
--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -34,3 +34,14 @@ class Qhull(CMakePackage):
         if name == 'cxxflags' and self.version == Version('2020.1'):
             flags.append(self.compiler.cxx11_flag)
         return (flags, None, None)
+
+    @property
+    def libs(self):
+        # in 2020.2 the libqhull.so library was deprecated in favor of
+        # libqhull_r.so
+        if self.spec.satifies('@2020.2:'):
+            return find_libraries('libqhull_r', self.prefix,
+                                  shared=True, recursive=True)
+        else:
+            return find_libraries('libqhull', self.prefix,
+

--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -39,10 +39,9 @@ class Qhull(CMakePackage):
     def libs(self):
         # in 2020.2 the libqhull.so library was deprecated in favor of
         # libqhull_r.so
-        if self.spec.satifies('@2020.2:'):
+        if self.spec.satisfies('@2020.2:'):
             return find_libraries('libqhull_r', self.prefix,
                                   shared=True, recursive=True)
         else:
             return find_libraries('libqhull', self.prefix,
                                   shared=True, recursive=True)
-

--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -44,4 +44,5 @@ class Qhull(CMakePackage):
                                   shared=True, recursive=True)
         else:
             return find_libraries('libqhull', self.prefix,
+                                  shared=True, recursive=True)
 


### PR DESCRIPTION
rather than remove qhull 2020.2 in #26302, this should fix the build such that the spec.libs property returns the appropriate library name.