### PR TITLE
netcdf-c: Update for 4.8.1 and new download site

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -13,39 +13,32 @@ class NetcdfC(AutotoolsPackage):
 
     homepage = "https://www.unidata.ucar.edu/software/netcdf"
     git      = "https://github.com/Unidata/netcdf-c.git"
-    url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-4.7.3.tar.gz"
-
-    def url_for_version(self, version):
-        if version >= Version('4.6.2'):
-            url = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-c-{0}.tar.gz"
-        else:
-            url = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-{0}.tar.gz"
-
-        return url.format(version.dotted)
+    url      = "https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz"
 
     maintainers = ['skosukhin', 'WardF']
 
     version('master', branch='master')
-    version('4.8.0',   sha256='679635119a58165c79bb9736f7603e2c19792dd848f19195bf6881492246d6d5')
-    version('4.7.4',   sha256='0e476f00aeed95af8771ff2727b7a15b2de353fb7bb3074a0d340b55c2bd4ea8')
-    version('4.7.3',   sha256='8e8c9f4ee15531debcf83788594744bd6553b8489c06a43485a15c93b4e0448b')
-    version('4.7.2',   sha256='b751cc1f314ac8357df2e0a1bacf35a624df26fe90981d3ad3fa85a5bbd8989a')
-    version('4.7.1',   sha256='5c537c585773e575a16b28c3973b9608a98fdc4cf7c42893aa5223024e0001fc')
-    version('4.7.0',   sha256='a512d2b4828c6177dd4b96791c4163e4e06e6bfc7123bebfbfe01762d777d1cb')
-    version('4.6.3',   sha256='335fdf16d7531f430ad75e732ed1a9a3fc83ad3ef91fb33a70119a555dd5415c')
-    version('4.6.2',   sha256='c37525981167b3cd82d32e1afa3022afb94e59287db5f116c57f5ed4d9c6a638')
-    version('4.6.1',   sha256='89c7957458740b763ae828c345240b8a1d29c2c1fed0f065f99b73181b0b2642')
-    version('4.6.0',   sha256='4bf05818c1d858224942ae39bfd9c4f1330abec57f04f58b9c3c152065ab3825')
-    version('4.5.0',   sha256='cbe70049cf1643c4ad7453f86510811436c9580cb7a1684ada2f32b95b00ca79')
+    version('4.8.1',   sha256='bc018cc30d5da402622bf76462480664c6668b55eb16ba205a0dfb8647161dd0')
+    version('4.8.0',   sha256='aff58f02b1c3e91dc68f989746f652fe51ff39e6270764e484920cb8db5ad092')
+    version('4.7.4',   sha256='99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b')
+    version('4.7.3',   sha256='05d064a2d55147b83feff3747bea13deb77bef390cb562df4f9f9f1ce147840d')
+    version('4.7.2',   sha256='7648db7bd75fdd198f7be64625af7b276067de48a49dcdfd160f1c2ddff8189c')
+    version('4.7.1',   sha256='583e6b89c57037293fc3878c9181bb89151da8c6015ecea404dd426fea219b2c')
+    version('4.7.0',   sha256='26d03164074363b3911ed79b7cddd045c22adf5ebaf978943db11a1d9f15e9d3')
+    version('4.6.3',   sha256='734a629cdaed907201084d003cfa091806d6080eeffbd4204e7c7f73ff9d3564')
+    version('4.6.2',   sha256='673936c76ae0c496f6dde7e077f5be480afc1e300adb2c200bf56fbe22e5a82a')
+    version('4.6.1',   sha256='a2fabf27c72a5ee746e3843e1debbaad37cd035767eaede2045371322211eebb')
+    version('4.6.0',   sha256='6d740356399aac12290650325a05aec2fe92c1905df10761b2b0100994197725')
+    version('4.5.0',   sha256='f7d1cb2a82100b9bf9a1130a50bc5c7baf0de5b5022860ac3e09a0a32f83cf4a')
     # Version 4.4.1.1 is having problems in tests
     #    https://github.com/Unidata/netcdf-c/issues/343
-    version('4.4.1.1', sha256='4d44c6f4d02a8faf10ea619bfe1ba8224cd993024f4da12988c7465f663c8cae')
+    version('4.4.1.1', sha256='7f040a0542ed3f6d27f3002b074e509614e18d6c515b2005d1537fec01b24909')
     # Version 4.4.1 can crash on you (in real life and in tests).  See:
     #    https://github.com/Unidata/netcdf-c/issues/282
-    version('4.4.1',   sha256='8915cc69817f7af6165fbe69a8d1dfe21d5929d7cca9d10b10f568669ec6b342')
-    version('4.4.0',   sha256='0d40cb7845abd03c363abcd5f57f16e3c0685a0faf8badb2c59867452f6bcf78')
-    version('4.3.3.1', sha256='bdde3d8b0e48eed2948ead65f82c5cfb7590313bc32c4cf6c6546e4cea47ba19')
-    version('4.3.3',   sha256='83223ed74423c685a10f6c3cfa15c2d6bf7dc84b46af1e95b9fa862016aaa27e')
+    version('4.4.1',   sha256='17599385fd76ccdced368f448f654de2ed000fece44dece9fb5d598798b4c9d6')
+    version('4.4.0',   sha256='09b78b152d3fd373bee4b5738dc05c7b2f5315fe34aa2d94ee9256661119112f')
+    version('4.3.3.1', sha256='f2ee78eb310637c007f001e7c18e2d773d23f3455242bde89647137b7344c2e2')
+    version('4.3.3',   sha256='3f16e21bc3dfeb3973252b9addf5defb48994f84fc9c9356081f871526a680e7')
 
     # configure fails if curl is not installed.
     # See https://github.com/Unidata/netcdf-c/issues/1390


### PR DESCRIPTION
    NetCDF-4.8.1 has been released.

    As discussed in https://github.com/Unidata/netcdf-c/issues/2110
    (netcdf-c-4.8.1.tar.gz not on ftp site... #2110), the canonical
    download site for netCDF releases has been changed and the previous
    ftp site is no longer available.

    This PR updates the `url` to point to the new recommended download
    site and updates the sha256 checksums for the new tar files.