### PR TITLE
seacas: new release and fixes for metis/parmetis

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -91,8 +91,9 @@ class Seacas(CMakePackage):
     depends_on('adios2@develop~mpi', when='+adios2 ~mpi')
     depends_on('adios2@develop+mpi', when='+adios2 +mpi')
     depends_on('matio', when='+matio')
-    depends_on('metis+int64+real64', when='+metis')
-    depends_on('parmetis+int64', when='+metis +mpi')
+    with when('+metis'):
+        depends_on('metis+int64+real64')
+        depends_on('parmetis+int64', when='+mpi')
 
     # MPI related dependencies
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -157,6 +157,7 @@ class Seacas(CMakePackage):
                     '-DSEACASProj_ENABLE_SEACASAprepro:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASAprepro_lib:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASConjoin:BOOL=ON',
+                    '-DSEACASProj_ENABLE_SEACASCpup:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASEjoin:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASEpu:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASExo2mat:BOOL=ON',
@@ -169,6 +170,7 @@ class Seacas(CMakePackage):
                     '-DSEACASProj_ENABLE_SEACASNemslice:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASNemspread:BOOL=ON',
                     '-DSEACASProj_ENABLE_SEACASSlice:BOOL=ON',
+                    '-DSEACASProj_ENABLE_SEACASZellij:BOOL=ON',
                 ])
 
             if '+legacy' in spec:

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -18,7 +18,7 @@ class Seacas(CMakePackage):
     """The SEACAS Project contains the Exodus and IOSS libraries and a
      collection of applications which create, query, modify, or
      translate exodus databases.  Default is to build the exodus and
-     IOSS libraries and the io_shell, io_info, struc_to_unstruc apps.
+     IOSS libraries and the io_shell, io_info, io_modify, struc_to_unstruc apps.
     """
     homepage = "https://gsjaardema.github.io/seacas/"
     git      = "https://github.com/gsjaardema/seacas.git"
@@ -27,6 +27,7 @@ class Seacas(CMakePackage):
 
     # ###################### Versions ##########################
     version('master', branch='master')
+    version('2021-09-28', sha256='3b17c6515beeb10ee0d559b2b570d3e480790fa32a56464ddc7c89d2f0c3a94c')
     version('2021-05-12', sha256='92663767f0317018d6f6e422e8c687e49f6f7eb2b92e49e837eb7dc0ca0ac33d')
     version('2021-04-05', sha256='76f66eec1fec7aba30092c94c7609495e6b90d9dcb6f35b3ee188304d02c6e04')
     version('2021-01-20', sha256='7814e81981d03009b6816be3eb4ed3845fd02cc69e006ee008a2cbc85d508246')
@@ -47,9 +48,9 @@ class Seacas(CMakePackage):
     variant('applications', default=True,
             description='Build all "current" SEACAS applications. This'
             ' includes a debatable list of essential applications: '
-            'aprepro, conjoin, ejoin, epu, exo2mat, mat2exo, '
-            'exo_format, exodiff, explore, grepos, '
-            'nemslice, nemspread')
+            'aprepro, conjoin, cpup, ejoin, epu, exo2mat, mat2exo, '
+            'exo_format, exodiff, explore, grepos, io_*, '
+            'nemslice, nemspread, zellij')
     variant('legacy', default=True,
             description='Build all "legacy" SEACAS applications. This includes'
             ' a debatable list of "legacy" applications: algebra, blot, '
@@ -90,8 +91,8 @@ class Seacas(CMakePackage):
     depends_on('adios2@develop~mpi', when='+adios2 ~mpi')
     depends_on('adios2@develop+mpi', when='+adios2 +mpi')
     depends_on('matio', when='+matio')
-    depends_on('metis+int64+real64', when='+metis ~mpi')
-    depends_on('parmetis+int64+real64', when='+metis +mpi')
+    depends_on('metis+int64+real64', when='+metis')
+    depends_on('parmetis+int64', when='+metis +mpi')
 
     # MPI related dependencies
     depends_on('mpi', when='+mpi')
@@ -198,7 +199,7 @@ class Seacas(CMakePackage):
             '-DNetCDF_ROOT:PATH=%s' % spec['netcdf-c'].prefix,
         ])
 
-        if '+metis' in spec:
+        if '+parmetis' in spec:
             options.extend([
                 '-DTPL_ENABLE_METIS:BOOL=ON',
                 '-DMETIS_LIBRARY_DIRS=%s' % spec['metis'].prefix.lib,
@@ -211,6 +212,14 @@ class Seacas(CMakePackage):
                 '-DTPL_ParMETIS_INCLUDE_DIRS=%s;%s' % (
                     spec['parmetis'].prefix.include,
                     spec['metis'].prefix.include)
+            ])
+        elif '+metis' in spec:
+            options.extend([
+                '-DTPL_ENABLE_METIS:BOOL=ON',
+                '-DMETIS_LIBRARY_DIRS=%s' % spec['metis'].prefix.lib,
+                '-DMETIS_LIBRARY_NAMES=metis',
+                '-DTPL_METIS_INCLUDE_DIRS=%s' % spec['metis'].prefix.include,
+                '-DTPL_ENABLE_ParMETIS:BOOL=OFF',
             ])
         else:
             options.extend([

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -27,7 +27,7 @@ class Seacas(CMakePackage):
 
     # ###################### Versions ##########################
     version('master', branch='master')
-    version('2021-09-28', sha256='3b17c6515beeb10ee0d559b2b570d3e480790fa32a56464ddc7c89d2f0c3a94c')
+    version('2021-09-29', sha256='48357b792f545ebe8add67ea3758bd67497ec868188abad0bee83ed3a0f9521e')
     version('2021-05-12', sha256='92663767f0317018d6f6e422e8c687e49f6f7eb2b92e49e837eb7dc0ca0ac33d')
     version('2021-04-05', sha256='76f66eec1fec7aba30092c94c7609495e6b90d9dcb6f35b3ee188304d02c6e04')
     version('2021-01-20', sha256='7814e81981d03009b6816be3eb4ed3845fd02cc69e006ee008a2cbc85d508246')

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -27,7 +27,7 @@ class Seacas(CMakePackage):
 
     # ###################### Versions ##########################
     version('master', branch='master')
-    version('2021-09-29a', sha256='28becc97b1ad81c315e44ccdd0a154d054473ad05c3f28e4904736c4122771cc')
+    version('2021-09-30', sha256='5d061e35e93eb81214da3b67ddda2829cf5efed38a566be6363a9866ba2f9ab3')
     version('2021-05-12', sha256='92663767f0317018d6f6e422e8c687e49f6f7eb2b92e49e837eb7dc0ca0ac33d')
     version('2021-04-05', sha256='76f66eec1fec7aba30092c94c7609495e6b90d9dcb6f35b3ee188304d02c6e04')
     version('2021-01-20', sha256='7814e81981d03009b6816be3eb4ed3845fd02cc69e006ee008a2cbc85d508246')

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -27,7 +27,7 @@ class Seacas(CMakePackage):
 
     # ###################### Versions ##########################
     version('master', branch='master')
-    version('2021-09-29', sha256='48357b792f545ebe8add67ea3758bd67497ec868188abad0bee83ed3a0f9521e')
+    version('2021-09-29a', sha256='28becc97b1ad81c315e44ccdd0a154d054473ad05c3f28e4904736c4122771cc')
     version('2021-05-12', sha256='92663767f0317018d6f6e422e8c687e49f6f7eb2b92e49e837eb7dc0ca0ac33d')
     version('2021-04-05', sha256='76f66eec1fec7aba30092c94c7609495e6b90d9dcb6f35b3ee188304d02c6e04')
     version('2021-01-20', sha256='7814e81981d03009b6816be3eb4ed3845fd02cc69e006ee008a2cbc85d508246')

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -49,8 +49,8 @@ class Seacas(CMakePackage):
             description='Build all "current" SEACAS applications. This'
             ' includes a debatable list of essential applications: '
             'aprepro, conjoin, cpup, ejoin, epu, exo2mat, mat2exo, '
-            'exo_format, exodiff, explore, grepos, io_*, '
-            'nemslice, nemspread, zellij')
+            'exo_format, exodiff, explore, grepos, io_shell, io_info, '
+            'io_modify, nemslice, nemspread, zellij')
     variant('legacy', default=True,
             description='Build all "legacy" SEACAS applications. This includes'
             ' a debatable list of "legacy" applications: algebra, blot, '


### PR DESCRIPTION
* Update to add sha256 checksum for latest seacas release

* Updated the documentation strings with new applications

* Fixed the metis/parmetis variants and logic depending on whether mpi
  is enabled/disabled. (There is still a zoltan issue I need to fix,
  but this will at least allow seacas to be built without
  metis/parmetis or with +mpi+parmetis.  The ~mpi+metis still needs
  work elsewhere.)