### PR TITLE
Pipelines: cleanup and speedup

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1047,11 +1047,6 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
             ]
             final_job['when'] = 'always'
 
-            if artifacts_root:
-                final_job['variables'] = {
-                    'SPACK_CONCRETE_ENV_DIR': concrete_env_dir
-                }
-
             output_object['rebuild-index'] = final_job
 
         output_object['stages'] = stage_names

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -35,6 +35,11 @@ default:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags: ["spack", "public", "medium", "x86_64"]
   interruptible: true
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
 
 .pr-generate:
   extends: [ ".pr", ".generate" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -194,13 +194,9 @@ build_systems-develop-build:
   variables:
     SPACK_CI_STACK_NAME: radiuss
 
-.radiuss-generate:
-  extends: [ ".radiuss"]
-  image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
-
 # ---------  PRs ---------
 radiuss-pr-generate:
-  extends: [ ".radiuss-generate", ".pr-generate" ]
+  extends: [ ".radiuss", ".pr-generate" ]
 
 radiuss-pr-build:
   extends: [ ".radiuss", ".pr-build" ]
@@ -212,7 +208,7 @@ radiuss-pr-build:
 
 # ---------  Develop ---------
 radiuss-develop-generate:
-  extends: [ ".radiuss-generate", ".develop-generate" ]
+  extends: [ ".radiuss", ".develop-generate" ]
 
 radiuss-develop-build:
   extends: [ ".radiuss", ".develop-build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -116,6 +116,9 @@ e4s-pr-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: e4s-pr-generate
     strategy: depend
+  needs:
+    - artifacts: True
+      job: e4s-pr-generate
 
 e4s-develop-build:
   extends: [ ".e4s", ".develop-build" ]
@@ -124,6 +127,9 @@ e4s-develop-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: e4s-develop-generate
     strategy: depend
+  needs:
+    - artifacts: True
+      job: e4s-develop-generate
 
 ########################################
 # E4S on Power
@@ -149,6 +155,9 @@ e4s-develop-build:
 #       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
 #         job: e4s-on-power-pr-generate
 #     strategy: depend
+#   needs:
+#     - artifacts: True
+#       job: e4s-on-power-pr-generate
 
 # e4s-on-power-develop-build:
 #   extends: [ ".e4s-on-power", ".develop-build" ]
@@ -157,6 +166,9 @@ e4s-develop-build:
 #       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
 #         job: e4s-on-power-develop-generate
 #     strategy: depend
+#   needs:
+#     - artifacts: True
+#       job: e4s-on-power-develop-generate
 
 #########################################
 # Build tests for different build-systems
@@ -178,6 +190,9 @@ build_systems-pr-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: build_systems-pr-generate
     strategy: depend
+  needs:
+    - artifacts: True
+      job: build_systems-pr-generate
 
 build_systems-develop-build:
   extends: [ ".build_systems", ".develop-build" ]
@@ -186,6 +201,9 @@ build_systems-develop-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: build_systems-develop-generate
     strategy: depend
+  needs:
+    - artifacts: True
+      job: build_systems-develop-generate
 
 #########################################
 # RADIUSS
@@ -205,6 +223,9 @@ radiuss-pr-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: radiuss-pr-generate
     strategy: depend
+  needs:
+    - artifacts: True
+      job: radiuss-pr-generate
 
 # ---------  Develop ---------
 radiuss-develop-generate:
@@ -217,6 +238,9 @@ radiuss-develop-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: radiuss-develop-generate
     strategy: depend
+  needs:
+    - artifacts: True
+      job: radiuss-develop-generate
 
 ########################################
 # ECP Data & Vis SDK
@@ -238,6 +262,9 @@ data-vis-sdk-pr-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: data-vis-sdk-pr-generate
     strategy: depend
+  needs:
+    - artifacts: True
+      job: data-vis-sdk-pr-generate
 
 data-vis-sdk-develop-build:
   extends: [ ".data-vis-sdk", ".develop-build" ]
@@ -246,3 +273,6 @@ data-vis-sdk-develop-build:
       - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
         job: data-vis-sdk-develop-generate
     strategy: depend
+  needs:
+    - artifacts: True
+      job: data-vis-sdk-develop-generate

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -49,8 +49,6 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd ${SPACK_CONCRETE_ENV_DIR}
-        - spack env activate --without-view .
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "x86_64"]
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -49,7 +49,7 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd share/spack/gitlab/cloud_pipelines/stacks/build_systems
+        - cd ${SPACK_CONCRETE_ENV_DIR}
         - spack env activate --without-view .
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "x86_64"]

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -52,8 +52,6 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd ${SPACK_CONCRETE_ENV_DIR}
-        - spack env activate --without-view .
       tags: ["spack", "public", "medium", "x86_64"]
 
   cdash:

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -46,12 +46,13 @@ spack:
         runner-attributes:
           tags: ["spack", "public", "large", "x86_64"]
     temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
+    broken-specs-url: "s3://spack-binaries-develop/broken-specs"
     service-job-attributes:
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk
+        - cd ${SPACK_CONCRETE_ENV_DIR}
         - spack env activate --without-view .
       tags: ["spack", "public", "medium", "x86_64"]
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -30,7 +30,7 @@ spack:
   mirrors: { "mirror": "s3://spack-binaries-develop/data-vis-sdk" }
 
   gitlab-ci:
-    image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
+    image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
     script:
       - . "./share/spack/setup-env.sh"
       - spack --version
@@ -47,7 +47,7 @@ spack:
           tags: ["spack", "public", "large", "x86_64"]
     temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     service-job-attributes:
-      image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
+      image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -357,7 +357,7 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power
+        - cd ${SPACK_CONCRETE_ENV_DIR}
         - spack env activate --without-view .
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-ppc64le:2021-07-01", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "ppc64le"]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -357,8 +357,6 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd ${SPACK_CONCRETE_ENV_DIR}
-        - spack env activate --without-view .
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu20.04-runner-ppc64le:2021-07-01", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "ppc64le"]
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -361,11 +361,11 @@ spack:
         - vtk-m
         - warpx
         runner-attributes:
-          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
+          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
           tags: ["spack", "public", "xlarge", "x86_64"]
       - match: ['os=ubuntu18.04']
         runner-attributes:
-          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
+          image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
           tags: ["spack", "public", "large", "x86_64"]
     temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
@@ -375,7 +375,7 @@ spack:
         - spack --version
         - cd share/spack/gitlab/cloud_pipelines/stacks/e4s
         - spack env activate --without-view .
-      image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2020-09-01", "entrypoint": [""] }
+      image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "x86_64"]
 
   cdash:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -373,7 +373,7 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd share/spack/gitlab/cloud_pipelines/stacks/e4s
+        - cd ${SPACK_CONCRETE_ENV_DIR}
         - spack env activate --without-view .
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "x86_64"]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -373,8 +373,6 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd ${SPACK_CONCRETE_ENV_DIR}
-        - spack env activate --without-view .
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "x86_64"]
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -79,8 +79,6 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd ${SPACK_CONCRETE_ENV_DIR}
-        - spack env activate --without-view .
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
       tags: ["spack", "public", "medium", "x86_64"]
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -79,14 +79,9 @@ spack:
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version
-        - cd share/spack/gitlab/cloud_pipelines/stacks/radiuss
+        - cd ${SPACK_CONCRETE_ENV_DIR}
         - spack env activate --without-view .
       image: { "name": "ghcr.io/scottwittenburg/ecpe4s-ubuntu18.04-runner-x86_64:2021-05-15", "entrypoint": [""] }
-      #before_script:
-      #  - . "./share/spack/setup-env.sh"
-      #  - spack --version
-      #  - cd share/spack/gitlab/cloud_pipelines/stacks/radiuss
-      #  - spack env activate --without-view .
       tags: ["spack", "public", "medium", "x86_64"]
 
   cdash:


### PR DESCRIPTION
Addresses the short list of the easiest improvements mentioned in #26241 

The two biggest performance improvements here include:

1. DAG scheduling of build pipelines, so we don't have to wait for all the pipeline generation jobs finish before the first rebuild jobs can begin
2. Removal of environment activation for service jobs like rebuild-index, cleanup, and no-op
