### PR TITLE
Provide more info in `SbangPathError` to aid CI debugging

### DIFF
--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -28,9 +28,12 @@ def sbang_install_path():
     """Location sbang should be installed within Spack's ``install_tree``."""
     sbang_root = str(spack.store.unpadded_root)
     install_path = os.path.join(sbang_root, "bin", "sbang")
-    if len(install_path) > shebang_limit:
-        raise SbangPathError(
-            'Install tree root is too long. Spack cannot patch shebang lines.')
+    path_length = len(install_path)
+    if path_length > shebang_limit:
+        msg = ('Install tree root is too long. Spack cannot patch shebang lines'
+               ' when script path length ({0}) exceeds limit ({1}).\n  {2}')
+        msg = msg.format(path_length, shebang_limit, install_path)
+        raise SbangPathError(msg)
     return install_path
 
 

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -227,9 +227,11 @@ def test_install_sbang(install_mockery):
     sbang.install_sbang()
     check_sbang_installation()
 
+
 def test_install_sbang_too_long(tmpdir):
     root = str(tmpdir)
-    long_path = os.path.join(tmpdir, 'e' * (sbang.shebang_limit - len(root)))
+    num_extend = sbang.shebang_limit - len(root) - len('/bin/sbang')
+    long_path = os.path.join(root, 'e' * num_extend)
     with spack.store.use_store(spack.store.Store(long_path)):
         with pytest.raises(sbang.SbangPathError) as exc_info:
             sbang.sbang_install_path()

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -231,7 +231,11 @@ def test_install_sbang(install_mockery):
 def test_install_sbang_too_long(tmpdir):
     root = str(tmpdir)
     num_extend = sbang.shebang_limit - len(root) - len('/bin/sbang')
-    long_path = os.path.join(root, 'e' * num_extend)
+    long_path = root
+    while num_extend > 1:
+        add = min(num_extend, 255)
+        long_path = os.path.join(root, 'e' * add)
+        num_extend -= add
     with spack.store.use_store(spack.store.Store(long_path)):
         with pytest.raises(sbang.SbangPathError) as exc_info:
             sbang.sbang_install_path()

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -16,7 +16,6 @@ import pytest
 
 import llnl.util.filesystem as fs
 
-import spack.config
 import spack.hooks.sbang as sbang
 import spack.paths
 import spack.store

--- a/lib/spack/spack/test/sbang.py
+++ b/lib/spack/spack/test/sbang.py
@@ -233,7 +233,7 @@ def test_install_sbang_too_long(tmpdir):
     long_path = root
     while num_extend > 1:
         add = min(num_extend, 255)
-        long_path = os.path.join(root, 'e' * add)
+        long_path = os.path.join(long_path, 'e' * add)
         num_extend -= add
     with spack.store.use_store(spack.store.Store(long_path)):
         with pytest.raises(sbang.SbangPathError) as exc_info:


### PR DESCRIPTION
GitLab instances have different rules for creating their build paths, which can create a lot of confusion when people encounter the `SbangPathError`.  It's easy for people to confuse or conflate the platform-specific `shebang_limit` with`config:install_tree:padded_length`.

This PR simply adds the length (and path) to the exception message to provide a quick way for people performing CI to debug their issue.  It includes a new unit test as well.

The fully qualified path for the `sbang` script is included since it can help people determine how paths are constructed for a given CI instance, for example.  Having this information has proven useful on at least one ECP CI instance.

For example, the error in the unit test is:

```
Install tree root is too long. Spack cannot patch shebang lines when script path length (138) exceeds limit (127).
   /tmp/dahlgren/pytest-of-dahlgren/pytest-0/test_install_sbang_too_long0/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/bin/sbang
```

@shahzebsiddiqui 