### PR TITLE
llvm-openmp: 12.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-openmp/package.py
+++ b/var/spack/repos/builtin/packages/llvm-openmp/package.py
@@ -13,6 +13,7 @@ class LlvmOpenmp(CMakePackage):
     homepage = "https://openmp.llvm.org/"
     url      = "https://releases.llvm.org/9.0.0/openmp-9.0.0.src.tar.xz"
 
+    version('12.0.1', sha256='60fe79440eaa9ebf583a6ea7f81501310388c02754dbe7dc210776014d06b091')
     version('9.0.0', sha256='9979eb1133066376cc0be29d1682bc0b0e7fb541075b391061679111ae4d3b5b')
     version('8.0.0', sha256='f7b1705d2f16c4fc23d6531f67d2dd6fb78a077dd346b02fed64f4b8df65c9d5')
 
@@ -20,6 +21,14 @@ class LlvmOpenmp(CMakePackage):
 
     variant('multicompat', default=False,
             description="Support gomp and the Intel openMP runtime library.")
+
+    def url_for_version(self, version):
+        if version >= Version('9.0.1'):
+            url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-{0}/openmp-{0}.src.tar.xz"
+        else:
+            url = "https://releases.llvm.org/{0}/openmp-{0}.src.tar.xz"
+
+        return url.format(version.dotted)
 
     def cmake_args(self):
 


### PR DESCRIPTION
Add the latest LLVM OpenMP release.
This one compiles for aarch64/M1 on mac.

Close #26319