### PR TITLE
dataspaces: replace autotools package with cmake package for dspaces2

### DIFF
--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -86,7 +86,7 @@ class Adios(AutotoolsPackage):
     depends_on('hdf5@1.8:+hl+mpi', when='+hdf5')
     depends_on('netcdf-c', when='+netcdf')
     depends_on('libevpath', when='staging=flexpath')
-    depends_on('dataspaces+mpi', when='staging=dataspaces')
+    depends_on('dataspaces', when='staging=dataspaces')
 
     for p in ['+hdf5', '+netcdf', 'staging=flexpath', 'staging=dataspaces']:
         conflicts(p, when='~mpi')

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -91,7 +91,7 @@ class Adios2(CMakePackage):
 
     depends_on('mpi', when='+mpi')
     depends_on('libzmq', when='+dataman')
-    depends_on('dataspaces@1.8.0:', when='+dataspaces')
+    depends_on('dataspaces', when='+dataspaces')
 
     depends_on('hdf5', when='+hdf5')
     depends_on('hdf5+mpi', when='+hdf5+mpi')

--- a/var/spack/repos/builtin/packages/dataspaces/package.py
+++ b/var/spack/repos/builtin/packages/dataspaces/package.py
@@ -1,7 +1,7 @@
 # Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
 

--- a/var/spack/repos/builtin/packages/dataspaces/package.py
+++ b/var/spack/repos/builtin/packages/dataspaces/package.py
@@ -1,77 +1,30 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
-# Spack Project Developers. See the top-level COPYRIGHT file for details.
-#
-# SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-import six
-
 from spack import *
 
-
-def is_string(x):
-    """validate a string"""
-    try:
-        return isinstance(x, six.string_types)
-    except ValueError:
-        return False
+class Dataspaces(CMakePackage):
+    """DataSpaces v2 based on margo, also called dspaces"""
 
 
-class Dataspaces(AutotoolsPackage):
-    """an extreme scale data management framework."""
+    homepage = "wwww.dataspaces.org"
+    url = ""
+    git = "https://github.com/rdi2dspaces/dspaces.git"
 
-    homepage = "http://www.dataspaces.org"
-    url      = "https://dataspaces.rdi2.rutgers.edu/downloads/dataspaces-1.6.2.tar.gz"
+    maintainers = ['pradsubedi', 'pdavis']
 
-    version('1.8.0', sha256='7f204bb3c03c2990f5a2d76a29185466b584793c63ada03e5e694627e6060605')
-    version('1.6.2', sha256='3c43d551c1e8198a4ab269c83928e1dc6f8054e6d41ceaee45155d91a48cf9bf')
+    version('master', branch='master', submodules=True)
+    
+    variant('pybind', default=True, description='build Python bindings')
 
-    variant('dimes',
-            default=False,
-            description='enabled DIMES transport mode')
-    variant('cray-drc',
-            default=False,
-            description='using Cray Dynamic Credentials library')
-    variant('gni-cookie',
-            default='0x5420000',
-            description='Cray UGNI communication token',
-            values=is_string)
-    variant('ptag',
-            default='250',
-            description='Cray UGNI protection tag',
-            values=is_string)
-    variant('mpi',
-            default=True,
-            description='Use MPI for collective communication')
+    depends_on('mpi')
+    depends_on('py-numpy', when='+pybind')
+    depends_on('swig', when='+pybind')
+    depends_on('cmake', type="build")
+    depends_on('mochi-margo')
+    depends_on('pkgconfig', type="build")
+    depends_on('libtool', type="build")
 
-    depends_on('m4', type='build')
-    depends_on('automake', type='build')
-    depends_on('autoconf', type='build')
-    depends_on('libtool', type='build')
-    depends_on('mpi', when='+mpi')
-
-    def autoreconf(self, spec, prefix):
-        bash = which('bash')
-        bash('./autogen.sh')
-
-    def setup_build_environment(self, env):
-        if self.spec.satisfies('+mpi'):
-            env.set('CC', self.spec['mpi'].mpicc)
-            env.set('FC', self.spec['mpi'].mpifc)
-
-        env.set('CFLAGS', self.compiler.cc_pic_flag)
-
-        if '%gcc@10:' in self.spec:
-            env.set('FCFLAGS', '-fallow-argument-mismatch')
-
-    def configure_args(self):
-        args = []
-        cookie = self.spec.variants['gni-cookie'].value
-        ptag = self.spec.variants['ptag'].value
-        if self.spec.satisfies('+dimes'):
-            args.append('--enable-dimes')
-        if self.spec.satisfies('+cray-drc'):
-            args.append('--enable-drc')
-        else:
-            args.append('--with-gni-cookie=%s' % cookie)
-            args.append('--with-gni-ptag=%s' % ptag)
-        return args
+    def cmake_args(self):
+        """Populate cmake arguments for Dspaces."""
+        extra_args = ['-DCMAKE_C_COMPILER=%s' % self.spec['mpi'].mpicc]
+        extra_args.extend(['-DCMAKE_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx])
+        extra_args.extend(['-DENABLE_TESTS=ON'])
+        return extra_args

--- a/var/spack/repos/builtin/packages/dataspaces/package.py
+++ b/var/spack/repos/builtin/packages/dataspaces/package.py
@@ -1,8 +1,13 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: MIT
+
 from spack import *
+
 
 class Dataspaces(CMakePackage):
     """DataSpaces v2 based on margo, also called dspaces"""
-
 
     homepage = "wwww.dataspaces.org"
     url = ""
@@ -11,7 +16,7 @@ class Dataspaces(CMakePackage):
     maintainers = ['pradsubedi', 'pdavis']
 
     version('master', branch='master', submodules=True)
-    
+
     variant('pybind', default=True, description='build Python bindings')
 
     depends_on('mpi')


### PR DESCRIPTION
DataSpaces2 (dspaces) uses the CMake build system instead of autotools, so an overhaul of the package was required.

The ADIOS dependency has been updated to be non-version specific, as any DataSpaces version built by the new package will work with ADIOS.