### PR TITLE
Un-unset TERM and DISPLAY

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -173,10 +173,6 @@ def clean_environment():
 
     # Affects GNU make, can e.g. indirectly inhibit enabling parallel build
     env.unset('MAKEFLAGS')
-    # Could make testsuites attempt to color their output
-    env.unset('TERM')
-    # Tests of GUI widget libraries might try to connect to an X server
-    env.unset('DISPLAY')
 
     # Avoid that libraries of build dependencies get hijacked.
     env.unset('LD_PRELOAD')


### PR DESCRIPTION
For interactive `spack build-env [spec] -- bash` debugging this is undesired behavior

fyi @albestro / @toxa81 / @bernhardkaindl 