### PR TITLE
py-imageio-ffmpeg: add 0.4.5, fix installation and import

### DIFF
--- a/var/spack/repos/builtin/packages/py-imageio-ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/py-imageio-ffmpeg/package.py
@@ -18,8 +18,14 @@ class PyImageioFfmpeg(PythonPackage):
     homepage = "https://github.com/imageio/imageio-ffmpeg"
     pypi = "imageio-ffmpeg/imageio-ffmpeg-0.4.3.tar.gz"
 
+    version('0.4.5', sha256='f2ea4245a2adad25dedf98d343159579167e549ac8c4691cef5eff980e20c139')
     version('0.4.3', sha256='f826260a3207b872f1a4ba87ec0c8e02c00afba4fd03348a59049bdd8215841e')
 
     depends_on('python@3.4:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    # Needs setuptools at runtime so that `import pkg_resources` succeeds
+    depends_on('py-setuptools', type=('build', 'run'))
     depends_on('ffmpeg', type='run')
+
+    def patch(self):
+        filter_file('setup_requires=["pip>19"]', 'setup_requires=[]',
+                    'setup.py', string=True)


### PR DESCRIPTION
This also fixed (version 0.4.3 was also affected by this):
-  the failing installation by removing pip from setup_require. Error was:
  ```
  ==> Error: ProcessError: Command exited with status 1:
      '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/python-3.8.11-nc77n35dwwio5n4g6lk5uqbnnoeh732n/bin/python3.8' '-s' 'setup.py' '--no-user-cfg' 'build'
  
  1 warning found in build log:
    >> 3    WARNING: The wheel package is not available.
       4    $spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/python-3.8.11-nc77n35dwwio5n4g6lk5uq
            bnnoeh732n/bin/python3.8: No module named pip
       5    Traceback (most recent call last):
       6      File "$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-setuptools-57.4.0-askbgzt
            o2n7t5wcwj3qdltcypucis5f3/lib/python3.8/site-packages/setuptools/installer.py", line 75, in fetch_build_egg
       7        subprocess.check_call(cmd)
       8      File "$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/python-3.8.11-nc77n35dwwio5n
            4g6lk5uqbnnoeh732n/lib/python3.8/subprocess.py", line 364, in check_call
       9        raise CalledProcessError(retcode, cmd)
  ```
- `ModuleNotFoundError: No module named 'pkg_resources'`-Error during import by adding `py-setuptools` to runtime.