### PR TITLE
Add build-env --tty flag to make interactive drop-in-the-build-env shells behave nicely

### DIFF
--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -480,7 +480,7 @@ _spack_bootstrap_untrust() {
 _spack_build_env() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --clean --dirty --dump --pickle"
+        SPACK_COMPREPLY="-h --help --clean --dirty --dump --pickle --tty"
     else
         _all_packages
     fi
@@ -1725,7 +1725,7 @@ _spack_test_remove() {
 _spack_test_env() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --clean --dirty --dump --pickle"
+        SPACK_COMPREPLY="-h --help --clean --dirty --dump --pickle --tty"
     else
         _all_packages
     fi


### PR DESCRIPTION
Some variables like TERM and DISPLAY are convenient when dropping a shell in the build env, but are unset in the build environment.

Now we can preserve them with `spack build-env --tty zlib -- bash`

I was thinking whether `spack build-env --tty zlib` without a command should just open a shell, but if `build-env` mimicks `env` that's feature creep.

One issue though is that `spack build-env --tty zlib -- bash` may find a bash built by spack. `.. -- /bin/bash` or `.. -- $SHELL` would solve that.
