### PR TITLE
py-monotonic: bump version to 1.6

### DIFF
--- a/var/spack/repos/builtin/packages/py-monotonic/package.py
+++ b/var/spack/repos/builtin/packages/py-monotonic/package.py
@@ -9,8 +9,9 @@ from spack import *
 class PyMonotonic(PythonPackage):
     """An implementation of time.monotonic() for Python 2 & < 3.3"""
 
-    pypi = "monotonic/monotonic-1.2.tar.gz"
+    pypi = "monotonic/monotonic-1.6.tar.gz"
 
+    version('1.6', sha256='3a55207bcfed53ddd5c5bae174524062935efed17792e9de2ad0205ce9ad63f7')
     version('1.2', sha256='c0e1ceca563ca6bb30b0fb047ee1002503ae6ad3585fc9c6af37a8f77ec274ba')
 
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Fixes `spack solve py-gsutil`: It depends on `'py-monotonic@1.4:'`