### PR TITLE
py-mock: fix depends of `@:2.0.0` and bump version

### DIFF
--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -19,10 +19,8 @@ class PyMock(PythonPackage):
     version('2.0.0', sha256='b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba')
     version('1.3.0', sha256='1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6')
 
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:2.0.0')
     depends_on('py-setuptools@17.1:', type='build')
-    depends_on('py-wheel',      type='build', when='@:2.0.0')
-    depends_on('py-pbr@1.3:',        type='build', when='@:2.0.0')
-    depends_on('py-six@1.7:', type=('build', 'run'))
-    depends_on('py-six@1.9:', type=('build', 'run'), when='@2.0.0:')
+    depends_on('py-pbr@1.3:',         type=('build'),        when='@:2.0.0')
+    depends_on('py-six@1.9:',         type=('build', 'run'), when='@:2.0.0')
     depends_on('py-funcsigs@1:', type=('build', 'run'), when='^python@:3.2')

--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -20,7 +20,7 @@ class PyMock(PythonPackage):
     version('1.3.0', sha256='1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6')
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools@17.1:', type='build')
     depends_on('py-wheel',      type='build', when='@:2.0.0')
     depends_on('py-pbr',        type='build', when='@:2.0.0')
     depends_on('py-six@1.7:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -22,7 +22,7 @@ class PyMock(PythonPackage):
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools@17.1:', type='build')
     depends_on('py-wheel',      type='build', when='@:2.0.0')
-    depends_on('py-pbr',        type='build', when='@:2.0.0')
+    depends_on('py-pbr@1.3:',        type='build', when='@:2.0.0')
     depends_on('py-six@1.7:', type=('build', 'run'))
     depends_on('py-six@1.9:', type=('build', 'run'), when='@2.0.0:')
     depends_on('py-funcsigs@1:', type=('build', 'run'), when='^python@:3.2')

--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -12,14 +12,17 @@ class PyMock(PythonPackage):
     they have been used."""
 
     homepage = "https://github.com/testing-cabal/mock"
-    pypi = "mock/mock-3.0.5.tar.gz"
+    pypi = "mock/mock-4.0.3.tar.gz"
 
+    version('4.0.3', sha256='7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc')
     version('3.0.5', sha256='83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3')
     version('2.0.0', sha256='b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba')
     version('1.3.0', sha256='1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6')
 
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-wheel',      type='build', when='@:2.0.0')
+    depends_on('py-pbr',        type='build', when='@:2.0.0')
     depends_on('py-six@1.7:', type=('build', 'run'))
     depends_on('py-six@1.9:', type=('build', 'run'), when='@2.0.0:')
     depends_on('py-funcsigs@1:', type=('build', 'run'), when='^python@:3.2')

--- a/var/spack/repos/builtin/packages/py-mock/package.py
+++ b/var/spack/repos/builtin/packages/py-mock/package.py
@@ -19,8 +19,9 @@ class PyMock(PythonPackage):
     version('2.0.0', sha256='b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba')
     version('1.3.0', sha256='1e247dbecc6ce057299eb7ee019ad68314bb93152e81d9a6110d35f4d5eca0f6')
 
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:2.0.0')
+    depends_on('python@3.6:',         type=('build', 'run'), when='@3')
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:2')
     depends_on('py-setuptools@17.1:', type='build')
-    depends_on('py-pbr@1.3:',         type=('build'),        when='@:2.0.0')
-    depends_on('py-six@1.9:',         type=('build', 'run'), when='@:2.0.0')
+    depends_on('py-pbr@1.3:',         type=('build'),        when='@:2')
+    depends_on('py-six@1.9:',         type=('build', 'run'), when='@:2')
     depends_on('py-funcsigs@1:', type=('build', 'run'), when='^python@:3.2')


### PR DESCRIPTION
fixes the build of `py-gsutil`, it depends on `'py-mock@:2.0.0'`.