### PR TITLE
Make system config path overridable

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -84,6 +84,18 @@ all_schemas = copy.deepcopy(section_schemas)
 all_schemas.update(dict((key, spack.schema.env.schema)
                         for key in spack.schema.env.keys))
 
+
+def _get_system_config_path():
+    """
+    The user can override the system config path by setting SPACK_SYSTEM_CONFIG_PATH.
+    This is useful when:
+    a) multiple versions of a system-wide programming environment are installed
+    b) a shared system has spack config in /etc/spack, but the user wants to opt out
+    """
+    return (os.getenv('SPACK_SYSTEM_CONFIG_PATH') or
+            os.path.join(spack.paths.system_etc_path, 'spack'))
+
+
 #: Builtin paths to configuration files in Spack
 configuration_paths = (
     # Default configuration scope is the lowest-level scope. These are
@@ -92,7 +104,7 @@ configuration_paths = (
 
     # System configuration is per machine.
     # No system-level configs should be checked into spack by default
-    ('system', os.path.join(spack.paths.system_etc_path, 'spack')),
+    ('system', _get_system_config_path()),
 
     # Site configuration is per spack instance, for sites or projects
     # No site-level configs should be checked into spack by default.

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1167,3 +1167,15 @@ def test_internal_config_scope_cache_clearing():
     internal_scope.clear()
     # Check that this didn't affect the scope object
     assert internal_scope.sections['config'] == data
+
+
+def test_system_config_path_is_overridable(working_env):
+    p = "/some/path"
+    os.environ['SPACK_SYSTEM_CONFIG_PATH'] = p
+    assert spack.config._get_system_config_path() == p
+
+
+def test_system_config_path_is_default_when_env_var_is_empty(working_env):
+    os.environ['SPACK_SYSTEM_CONFIG_PATH'] = ''
+    default = os.path.join(spack.paths.system_etc_path, 'spack')
+    assert spack.config._get_system_config_path() == default


### PR DESCRIPTION
On shared systems with a system-wide versioned programming environment
where the user can switch between different versions (and test the
latest the greatest when they feel like it), it's convenient to provide
a config for compilers and packages depending on the programming
environment version. It'd also be nice if the user could use their own
version of Spack on their favorite commit, and pick up config without
having to back up their user config and replacing it with something
temporarily when switching programming environment versions.

With this change, people managing the system can provide compilers.yaml
and packages.yaml versioned with the programming environment:

```
/path/to/programming/environment/1.2.3/{compilers,packages}.yaml
```

and set `SPACK_SYSTEM_CONFIG_PATH` to point to this dir.

In particular, on Cray systems this variable could be set in a module
called `spack-system-config`, and the user could opt in to use it, and
doesn't have to know about whatever programming environment verison they
are in.

As a bonus, if somebody would ever put Spack config files in
`/etc/spack`, the user can now opt out of that by setting

```
SPACK_SYSTEM_CONFIG_PATH=/non-existing/dir
```
