### PR TITLE
Add pmix variant to openmpi package

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -646,12 +646,12 @@ class Openmpi(AutotoolsPackage):
         if spec.satisfies('schedulers=slurm'):
             if spec.satisfies('+pmi'):
                 config_args.append('--with-pmi={0}'.format(
-                   spec['slurm'].prefix))
+                    spec['slurm'].prefix))
             else:
                 config_args.extend(self.with_or_without('pmi'))
             if spec.satisfies('+pmix'):
                 config_args.append('--with-pmix={0}'.format(
-                   spec['pmix'].prefix))
+                    spec['pmix'].prefix))
             else:
                 config_args.extend(self.with_or_without('pmix'))
             if spec.satisfies('@3.1.3:') or spec.satisfies('@3.0.3'):

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -320,7 +320,7 @@ class Openmpi(AutotoolsPackage):
     # PMI support was added in 1.5.5
     conflicts('+pmi', when='@:1.5.4')
     # PMIx support was added in 2.0.0
-    conflicts('+pmix', when='@:1.999.999')
+    conflicts('+pmix', when='@:1')
     # RPATH support in the wrappers was added in 1.7.4
     conflicts('+wrapper-rpath', when='@:1.7.3')
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -649,11 +649,7 @@ class Openmpi(AutotoolsPackage):
                     spec['slurm'].prefix))
             else:
                 config_args.extend(self.with_or_without('pmi'))
-            if spec.satisfies('+pmix'):
-                config_args.append('--with-pmix={0}'.format(
-                    spec['pmix'].prefix))
-            else:
-                config_args.extend(self.with_or_without('pmix'))
+            config_args += self.with_or_without('pmix', activation_value='prefix')
             if spec.satisfies('@3.1.3:') or spec.satisfies('@3.0.3'):
                 if '+static' in spec:
                     config_args.append('--enable-static')


### PR DESCRIPTION
Allows to compile openmpi against pmix, relates to '--with-pmix=' configure option.

See #19925