### PR TITLE
otf: Explicitly disable MPI and ZOIDFS

### DIFF
--- a/var/spack/repos/builtin/packages/otf/package.py
+++ b/var/spack/repos/builtin/packages/otf/package.py
@@ -21,7 +21,9 @@ class Otf(AutotoolsPackage):
     def configure_args(self):
         args = []
 
+        args.append('--without-mpi')
         args.append('--without-vtf3')
         args.append('--with-zlib')
         args.append('--with-zlibsymbols')
+        args.append('--without-zoidfs')
         return args


### PR DESCRIPTION
Otherwise, global installations of MPI could be picked up by OTF.