### PR TITLE
ArborX: Explicitly set path to Kokkos

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -92,10 +92,6 @@ class Arborx(CMakePackage):
     def build_tests(self):
         """Build the stand-alone/smoke test."""
 
-        # We don't need to append the path to Kokkos to CMAKE_PREFIX_PATH since
-        # a hint is already hardcoded inside the CMake ArborX configuration.
-        # Omitting it here allows us to avoid to distinguish between Kokkos
-        # being installed as a standalone or as part of Trilinos.
         arborx_dir = self.spec['arborx'].prefix
         cmake_prefix_path = "-DCMAKE_PREFIX_PATH={0}".format(arborx_dir)
         if '+mpi' in self.spec:
@@ -103,7 +99,9 @@ class Arborx(CMakePackage):
 
         cmake_args = [".",
                       cmake_prefix_path,
-                      "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx)]
+                      "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx),
+                      "-DKokkos_ROOT=%s" % (self.spec['kokkos'].prefix if '~trilinos' in self.spec
+                                            else self.spec['trilinos'].prefix)]
 
         self.run_test("cmake", cmake_args,
                       purpose="test: calling cmake",

--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -104,7 +104,6 @@ class Arborx(CMakePackage):
                                   if '~trilinos' in self.spec
                                   else self.spec['trilinos'].prefix)]
 
-
         self.run_test("cmake", cmake_args,
                       purpose="test: calling cmake",
                       work_dir=self.cached_tests_work_dir)

--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -100,9 +100,10 @@ class Arborx(CMakePackage):
         cmake_args = [".",
                       cmake_prefix_path,
                       "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx),
-                      "-DKokkos_ROOT=%s" % (self.spec['kokkos'].prefix
-                                            if '~trilinos' in self.spec
-                                            else self.spec['trilinos'].prefix)]
+                      self.define('Kokkos_ROOT', self.spec['kokkos'].prefix
+                                  if '~trilinos' in self.spec
+                                  else self.spec['trilinos'].prefix)]
+
 
         self.run_test("cmake", cmake_args,
                       purpose="test: calling cmake",

--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -100,7 +100,8 @@ class Arborx(CMakePackage):
         cmake_args = [".",
                       cmake_prefix_path,
                       "-DCMAKE_CXX_COMPILER={0}".format(self.compiler.cxx),
-                      "-DKokkos_ROOT=%s" % (self.spec['kokkos'].prefix if '~trilinos' in self.spec
+                      "-DKokkos_ROOT=%s" % (self.spec['kokkos'].prefix
+                                            if '~trilinos' in self.spec
                                             else self.spec['trilinos'].prefix)]
 
         self.run_test("cmake", cmake_args,


### PR DESCRIPTION
Searching for `Kokkos` when testing `ArborX` might find a different version from what was installed and that one might export incompatible flags because it was compiled with a different compiler and targeting a different backend.
Since the package testing considers the whole environment and not just the `spack` system, the tests might fail if other `Kokkos` versions not maintained by `spack` are installed.
In order to be able to test already released `ArborX`, it seems best to just set the `Kokkos` path explicitly to the one specified at installation.