### PR TITLE
py-snappy: add patch to fix dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-snappy/package.py
+++ b/var/spack/repos/builtin/packages/py-snappy/package.py
@@ -14,5 +14,7 @@ class PySnappy(PythonPackage):
 
     version('0.1.0-alpha.1', sha256='f94c5bfc0b2bb42f7d442f0d84c9ffd9aa92876632d415612f25bafa61ddcfc4')
 
+    patch('req.patch')
+
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-snappy/req.patch
+++ b/var/spack/repos/builtin/packages/py-snappy/req.patch
@@ -7,7 +7,7 @@ index d6ec42a..53725c7 100644
      include_package_data=True,
      install_requires=[],
 -    setup_requires=['setuptools-markdown'],
-+    setup_requires=[''],
++    setup_requires=[],
      python_requires='>=3.6, <4',
      extras_require=extras_require,
      py_modules=['py_snappy'],

--- a/var/spack/repos/builtin/packages/py-snappy/req.patch
+++ b/var/spack/repos/builtin/packages/py-snappy/req.patch
@@ -1,0 +1,14 @@
+diff --git a/setup.py b/setup.py
+index d6ec42a..53725c7 100644
+--- a/setup.py
++++ b/setup.py
+@@ -49,7 +49,7 @@ setup(
+     url='https://github.com/ethereum/py-snappy',
+     include_package_data=True,
+     install_requires=[],
+-    setup_requires=['setuptools-markdown'],
++    setup_requires=[''],
+     python_requires='>=3.6, <4',
+     extras_require=extras_require,
+     py_modules=['py_snappy'],
+


### PR DESCRIPTION
So this package complained that it could not find a wheel for `setuptools-markdown`. I took a look at that package and found that it was deprecated due to the functionality now present in setuptools.

Attempt to push patch upstream: https://github.com/ethereum/py-snappy/pull/21