### PR TITLE
use rync spack package instead of refering rsync pkg install

### DIFF
--- a/var/spack/repos/builtin/packages/atmi/0002-Remove-usr-bin-rsync-reference.patch
+++ b/var/spack/repos/builtin/packages/atmi/0002-Remove-usr-bin-rsync-reference.patch
@@ -1,0 +1,68 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ab4533a..9249de2 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -64,7 +64,7 @@ add_subdirectory(device_runtime)
+ # make examples available in local build
+ add_custom_command(
+   OUTPUT examples
+-  COMMAND /usr/bin/rsync -rl ${CMAKE_CURRENT_SOURCE_DIR}/../examples .
++  COMMAND rsync -rl ${CMAKE_CURRENT_SOURCE_DIR}/../examples .
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../examples/*
+   )
+ add_custom_target(example ALL DEPENDS examples)
+@@ -72,7 +72,7 @@ add_custom_target(example ALL DEPENDS examples)
+ # make bin available in local build
+ add_custom_command(
+   OUTPUT bin
+-  COMMAND /usr/bin/rsync -rl ${CMAKE_CURRENT_SOURCE_DIR}/../bin .
++  COMMAND rsync -rl ${CMAKE_CURRENT_SOURCE_DIR}/../bin .
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../bin/*
+   )
+ add_custom_target(script ALL DEPENDS bin)
+diff --git a/src/device_runtime/CMakeLists.txt b/src/device_runtime/CMakeLists.txt
+index 20e15a8..333cb47 100644
+--- a/src/device_runtime/CMakeLists.txt
++++ b/src/device_runtime/CMakeLists.txt
+@@ -108,7 +108,7 @@ set (OUTPUT_INC_DIRECTORY ${ATMI_RUNTIME_PATH}/include)
+ execute_process(COMMAND "/bin/mkdir" "-p" "${OUTPUT_INC_DIRECTORY}")
+ add_custom_command(
+   OUTPUT ${OUTPUT_INC_DIRECTORY}/atmi_kl.h
+-  COMMAND /usr/bin/rsync ${CMAKE_CURRENT_SOURCE_DIR}/../../include/atmi_kl.h ${OUTPUT_INC_DIRECTORY}/atmi_kl.h
++  COMMAND rsync ${CMAKE_CURRENT_SOURCE_DIR}/../../include/atmi_kl.h ${OUTPUT_INC_DIRECTORY}/atmi_kl.h
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../include/*.h
+   )
+ add_custom_target(device_header ALL DEPENDS ${OUTPUT_INC_DIRECTORY}/atmi_kl.h)
+diff --git a/src/runtime/core/CMakeLists.txt b/src/runtime/core/CMakeLists.txt
+index 132a2f6..034a728 100644
+--- a/src/runtime/core/CMakeLists.txt
++++ b/src/runtime/core/CMakeLists.txt
+@@ -128,13 +128,13 @@ execute_process(COMMAND "/bin/mkdir" "-p" "${OUTPUT_INC_DIRECTORY}")
+ 
+ add_custom_command(
+   OUTPUT ${OUTPUT_INC_DIRECTORY}/atmi.h
+-  COMMAND /usr/bin/rsync ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi.h ${OUTPUT_INC_DIRECTORY}/atmi.h
++  COMMAND rsync ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi.h ${OUTPUT_INC_DIRECTORY}/atmi.h
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/*.h
+   )
+ 
+ add_custom_command(
+   OUTPUT ${OUTPUT_INC_DIRECTORY}/atmi_runtime.h
+-  COMMAND /usr/bin/rsync ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi_runtime.h ${OUTPUT_INC_DIRECTORY}/atmi_runtime.h
++  COMMAND rsync ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi_runtime.h ${OUTPUT_INC_DIRECTORY}/atmi_runtime.h
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/*.h
+   )
+ 
+diff --git a/src/runtime/interop/hsa/CMakeLists.txt b/src/runtime/interop/hsa/CMakeLists.txt
+index f868972..97d8ae8 100644
+--- a/src/runtime/interop/hsa/CMakeLists.txt
++++ b/src/runtime/interop/hsa/CMakeLists.txt
+@@ -22,7 +22,7 @@ execute_process(COMMAND "/bin/mkdir" "-p" "${OUTPUT_INC_DIRECTORY}")
+ 
+ add_custom_command(
+   OUTPUT ${OUTPUT_INC_DIRECTORY}/atmi_interop_hsa.h
+-  COMMAND /usr/bin/rsync ${CMAKE_CURRENT_SOURCE_DIR}/../../../../include/atmi_interop_hsa.h ${OUTPUT_INC_DIRECTORY}/atmi_interop_hsa.h
++  COMMAND rsync ${CMAKE_CURRENT_SOURCE_DIR}/../../../../include/atmi_interop_hsa.h ${OUTPUT_INC_DIRECTORY}/atmi_interop_hsa.h
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../../../include/*.h
+   )
+ 

--- a/var/spack/repos/builtin/packages/atmi/package.py
+++ b/var/spack/repos/builtin/packages/atmi/package.py
@@ -32,6 +32,8 @@ class Atmi(CMakePackage):
     variant('build_type', default='Release', values=("Release", "Debug"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
+    depends_on('rsync')
+
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1']:
         depends_on('comgr@' + ver, type='link', when='@' + ver)
@@ -41,6 +43,7 @@ class Atmi(CMakePackage):
     root_cmakelists_dir = 'src'
 
     patch('0001-Remove-relative-link-paths-to-external-libraries.patch', when='@3.5.0')
+    patch('0002-Remove-usr-bin-rsync-reference.patch', when='@4.0.0:')
 
     def cmake_args(self):
         return [


### PR DESCRIPTION
currently it requires the rsync pkg to be installed . i found that the cmakelists.txt uses hardcoded paths for rsync pkg ( /usr/bin/rsync) . i have replaced it with the rsync spack package instead and removed the references in the cmakelists.txt
I have verified for the latest rocm-4.3.1 release but the changes should be valid for older releases too. hence made it applicable from 4.0.0 onwards