### PR TITLE
docutils > 0.17 issue with rendering list items in sphinx

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -5,5 +5,6 @@ sphinx>=3.4,!=4.1.2
 sphinxcontrib-programoutput
 sphinx-rtd-theme
 python-levenshtein
-# issue rendering list in sphinx docutils 0.17 or higher see https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
+# Restrict to docutils <0.17 to workaround a list rendering issue in sphinx.
+# https://stackoverflow.com/questions/67542699
 docutils <0.17

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -6,4 +6,4 @@ sphinxcontrib-programoutput
 sphinx-rtd-theme
 python-levenshtein
 # issue rendering list in sphinx docutils 0.17 or higher see https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
-docutils==0.16
+docutils <0.17

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -5,3 +5,5 @@ sphinx>=3.4,!=4.1.2
 sphinxcontrib-programoutput
 sphinx-rtd-theme
 python-levenshtein
+# issue rendering list in sphinx docutils 0.17 or higher see https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
+docutils==0.16.1

--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -6,4 +6,4 @@ sphinxcontrib-programoutput
 sphinx-rtd-theme
 python-levenshtein
 # issue rendering list in sphinx docutils 0.17 or higher see https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
-docutils==0.16.1
+docutils==0.16

--- a/lib/spack/docs/spack.yaml
+++ b/lib/spack/docs/spack.yaml
@@ -17,7 +17,7 @@ spack:
   # Sphinx
   - "py-sphinx@3.4:4.1.1,4.1.3:"
   - py-sphinxcontrib-programoutput
-  - py-docutils@0.16:
+  - py-docutils@:0.16
   - py-sphinx-rtd-theme
   # VCS
   - git

--- a/lib/spack/docs/spack.yaml
+++ b/lib/spack/docs/spack.yaml
@@ -17,7 +17,7 @@ spack:
   # Sphinx
   - "py-sphinx@3.4:4.1.1,4.1.3:"
   - py-sphinxcontrib-programoutput
-  - py-docutils@0.17:
+  - py-docutils@0.16:
   - py-sphinx-rtd-theme
   # VCS
   - git

--- a/lib/spack/docs/spack.yaml
+++ b/lib/spack/docs/spack.yaml
@@ -17,6 +17,7 @@ spack:
   # Sphinx
   - "py-sphinx@3.4:4.1.1,4.1.3:"
   - py-sphinxcontrib-programoutput
+  - py-docutils@0.17:
   - py-sphinx-rtd-theme
   # VCS
   - git


### PR DESCRIPTION
This PR will address issue with rendered list items in sphinx we must use 0.16.x in order for this to work for time being until this is fixed in docutils.

This is an issue where list dont show up correctly. I can confirm this change fix the issue.


![Screen Shot 2021-09-29 at 4 53 25 PM](https://user-images.githubusercontent.com/12942230/135346887-02011ff3-0eaf-4dfd-94a0-b02a94f91d0b.png)


