### PR TITLE
[dd4hep] prepend_path ROOT_INCLUDE_PATH

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -109,6 +109,7 @@ class Dd4hep(CMakePackage):
         env.set("DD4HEP", self.prefix.examples)
         env.set("DD4hep_DIR", self.prefix)
         env.set("DD4hep_ROOT", self.prefix)
+        env.prepend_path('ROOT_INCLUDE_PATH', self.prefix.include)
 
     def url_for_version(self, version):
         # dd4hep releases are dashes and padded with a leading zero


### PR DESCRIPTION
Including the headers in ROOT_INCLUDE_PATH ensures that they are found by the cling autoloader. This avoids warnings such as:
```
Error in cling::AutoLoadingVisitor::InsertIntoAutoLoadingState:
   Missing FileEntry for DDRec/ISurface.h
   requested to autoload type dd4hep::rec::ISurface
```
A similar approach is applied in [gaudi](https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/gaudi/package.py#L116).