### PR TITLE
boost: @1.77.0: need updated python_jam.patch for +python

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -211,8 +211,9 @@ class Boost(Package):
     patch('boost_11856.patch', when='@1.60.0%gcc@4.4.7')
 
     # Patch fix from https://svn.boost.org/trac/boost/ticket/11120
-    patch('python_jam.patch', when='@1.56.0: ^python@3:')
-    patch('python_jam_pre156.patch', when='@:1.55.0 ^python@3:')
+    patch('python_jam-1_77.patch',   when='@1.77:     ^python@3:')
+    patch('python_jam.patch',        when='@1.56:1.76 ^python@3:')
+    patch('python_jam_pre156.patch', when='@:1.55.0   ^python@3:')
 
     # Patch fix for IBM XL compiler
     patch('xl_1_62_0_le.patch', when='@1.62.0%xl_r')

--- a/var/spack/repos/builtin/packages/boost/python_jam-1_77.patch
+++ b/var/spack/repos/builtin/packages/boost/python_jam-1_77.patch
@@ -1,0 +1,42 @@
+Index: spack-src/tools/build/src/tools/python.jam
+===================================================================
+--- spack-src/tools/build/src/tools/python.jam
++++ spack-src/tools/build/src/tools/python.jam
+@@ -501,6 +501,10 @@ local rule probe ( python-cmd )
+                 sys.$(s) = [ SUBST $(output) "\\<$(s)=([^$(nl)]+)" $1 ] ;
+             }
+         }
++         # Try to get python abiflags
++        full-cmd = $(python-cmd)" -c \"from sys import abiflags; print(abiflags, end='')\"" ;
++
++        sys.abiflags = [ SHELL $(full-cmd) ] ;
+         return $(output) ;
+     }
+ }
+@@ -510,7 +514,7 @@ local rule probe ( python-cmd )
+ # have a value based on the information given.
+ #
+ local rule compute-default-paths ( target-os : version ? : prefix ? :
+-    exec-prefix ? )
++    exec-prefix ? : abiflags ? )
+ {
+     exec-prefix ?= $(prefix) ;
+ 
+@@ -547,7 +551,7 @@ local rule compute-default-paths ( targe
+     }
+     else
+     {
+-        local default-include-path = $(prefix)/include/python$(version) ;
++        local default-include-path = $(prefix)/include/python$(version)$(abiflags) ;
+         if ! [ path.exists $(default-include-path) ] && [ path.exists $(default-include-path)m ]
+         {
+             default-include-path = $(default-include-path)m ;
+@@ -798,7 +802,7 @@ local rule configure ( version ? : cmd-o
+                     exec-prefix = $(sys.exec_prefix) ;
+ 
+                     compute-default-paths $(target-os) : $(sys.version) :
+-                        $(sys.prefix) : $(sys.exec_prefix) ;
++                        $(sys.prefix) : $(sys.exec_prefix) : $(sys.abiflags) ;
+ 
+                     version = $(sys.version) ;
+                     interpreter-cmd ?= $(cmd) ;


### PR DESCRIPTION
One hunk changed and the new patch is refreshed using quilt.

Details in issue #26172, which this PR fixes.
