### PR TITLE
python: correctly disable ~tkinter when @3.8

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -197,6 +197,7 @@ class Python(AutotoolsPackage):
     patch('python-3.7.4+-distutils-C++.patch', when='@3.7.4:')
 
     patch('tkinter.patch', when='@:2.8,3.3:3.7 platform=darwin')
+    patch('tkinter-3.8.patch', when='@3.8: ~tkinter')
 
     # Ensure that distutils chooses correct compiler option for RPATH on cray:
     patch('cray-rpath-2.3.patch', when='@2.3:3.0.1 platform=cray')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -197,6 +197,8 @@ class Python(AutotoolsPackage):
     patch('python-3.7.4+-distutils-C++.patch', when='@3.7.4:')
 
     patch('tkinter.patch', when='@:2.8,3.3:3.7 platform=darwin')
+    # Patch the setup script to deny that tcl/x11 exists rather than allowing
+    # autodetection of (possibly broken) system components
     patch('tkinter-3.8.patch', when='@3.8: ~tkinter')
 
     # Ensure that distutils chooses correct compiler option for RPATH on cray:

--- a/var/spack/repos/builtin/packages/python/tkinter-3.8.patch
+++ b/var/spack/repos/builtin/packages/python/tkinter-3.8.patch
@@ -1,0 +1,12 @@
+diff -Naur a/setup.py b/setup.py
+--- a/setup.py.orig	2021-09-29 21:28:23.000000000 -0400
++++ a/setup.py	2021-09-29 21:28:44.000000000 -0400
+@@ -1826,6 +1826,8 @@
+     def detect_tkinter(self):
+         # The _tkinter module.
+
++        return False
++
+         # Check whether --with-tcltk-includes and --with-tcltk-libs were
+         # configured or passed into the make target.  If so, use these values
+         # to build tkinter and bypass the searches for Tcl and TK in standard


### PR DESCRIPTION
The older patch does not apply so the build ends up failing:
```
     1539    In file included from /private/var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/s3j/spack-stage/spack-stage-python-3.8.11
             -6jyb6sxztfs6fw26xdbc3ktmbtut3ypr/spack-src/Modules/_tkinter.c:48:
  >> 1540    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/tk.h:86:11: f
             atal error: 'X11/Xlib.h' file not found
     1541    #       include <X11/Xlib.h>
     1542                    ^~~~~~~~~~~~
     1543    1 error generated.
```

The patch should be applicable to other systems besides darwin. I assume those were just relying on the lack of system `tk`/`tcl` when the default `~tkinter` is set.