### PR TITLE
gromacs-chain-coordinate: Fix calling the test suite

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -77,3 +77,11 @@ class GromacsChainCoordinate(CMakePackage):
 
     def cmake_args(self):
         return super(GromacsChainCoordinate, self).cmake_args()
+
+    def check(self):
+        """The default 'test' targets does not compile the test programs"""
+        with working_dir(self.build_directory):
+            if self.generator == 'Unix Makefiles':
+                self._if_make_target_execute('check')
+            elif self.generator == 'Ninja':
+                self._if_ninja_target_execute('check')


### PR DESCRIPTION
The default 'test' target does not compile the test programs.

This is a follow-up commit for my review of gromacs-chain-coordinate which I couldn't push due to missing write permission.