### PR TITLE
dos2unix: new version 7.4.2 and enforced link with gettext

### DIFF
--- a/var/spack/repos/builtin/packages/dos2unix/package.py
+++ b/var/spack/repos/builtin/packages/dos2unix/package.py
@@ -12,9 +12,20 @@ class Dos2unix(MakefilePackage):
     homepage = "https://waterlan.home.xs4all.nl/dos2unix.html"
     url      = "https://waterlan.home.xs4all.nl/dos2unix/dos2unix-7.3.4.tar.gz"
 
+    maintainers = ['cessenat']
+
+    version('7.4.2', sha256='6035c58df6ea2832e868b599dfa0d60ad41ca3ecc8aa27822c4b7a9789d3ae01')
     version('7.3.4', sha256='8ccda7bbc5a2f903dafd95900abb5bf5e77a769b572ef25150fde4056c5f30c5')
 
     depends_on('gettext')
+
+    @property
+    def build_targets(self):
+        targets = [
+            'LDFLAGS_USER=-L{0} {1}'.format(
+                self.spec['gettext'].prefix.lib, self.spec['gettext'].libs.link_flags),
+        ]
+        return targets
 
     def install(self, spec, prefix):
         make('prefix={0}'.format(prefix), 'install')


### PR DESCRIPTION
From installation issue #26369 it appears that dos2unix does not set the proper link flags.
Following dos2unix Makefile from Erwin Waterlander, the variable LDFLAGS_USER is set to ensure that
`gettext` adequate link flags are set.
This solves the isssue for all tested platforms (Ubuntu 18, 20, 21, CentOS 7.8 and 7.9, Rasp Pi Ubuntu 20).
I would be pleased to have a review from @adamjstewart who has been the regular contributor to this package.
I added myseld as a maintainer, as the spack bot suggests.
I also added a new release, both releases were concerned by the link issue.