### PR TITLE
Add a conflict for patchelf to catch errors earlier in bootstrapping

### DIFF
--- a/var/spack/repos/builtin/packages/patchelf/package.py
+++ b/var/spack/repos/builtin/packages/patchelf/package.py
@@ -27,6 +27,8 @@ class Patchelf(AutotoolsPackage):
     # of SHT_NOTE and PT_NOTE'
     patch('https://github.com/NixOS/patchelf/pull/230.patch', sha256='a155f233b228f02d7886e304cb13898d93801b52f351e098c2cc0719697ec9d0', when='@0.12')
 
+    conflicts('%gcc@:4.6', when='@0.10:', msg="Requires C++11 support")
+
     def url_for_version(self, version):
         if version < Version('0.12'):
             return "https://nixos.org/releases/patchelf/patchelf-{0}/patchelf-{1}.tar.gz".format(version, version)


### PR DESCRIPTION
Bootstrapping from binaries doesn't work on centos with default system compilers because patchelf@0.10: requires c++11.

Bad news is that this conflicts isn't picked up by the old concretizer, so it will simply issue a concretization error instead of using and old version of patchelf.
