### PR TITLE
When creating filesystem views, skip hidden spack folder literally, not as a regex

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -6,6 +6,7 @@
 import errno
 import glob
 import os
+import re
 import shutil
 import tempfile
 from contextlib import contextmanager
@@ -88,8 +89,8 @@ class DirectoryLayout(object):
         self.manifest_file_name  = 'install_manifest.json'
 
     @property
-    def hidden_file_paths(self):
-        return (self.metadata_dir,)
+    def hidden_file_regexes(self):
+        return (re.escape(self.metadata_dir),)
 
     def relative_path_for_spec(self, spec):
         _check_concrete(spec)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -406,7 +406,7 @@ class YamlFilesystemView(FilesystemView):
 
         ignore = ignore or (lambda f: False)
         ignore_file = match_predicate(
-            self.layout.hidden_file_paths, ignore)
+            self.layout.hidden_file_regexes, ignore)
 
         # check for dir conflicts
         conflicts = tree.find_dir_conflicts(view_dst, ignore_file)
@@ -432,7 +432,7 @@ class YamlFilesystemView(FilesystemView):
 
         ignore = ignore or (lambda f: False)
         ignore_file = match_predicate(
-            self.layout.hidden_file_paths, ignore)
+            self.layout.hidden_file_regexes, ignore)
 
         merge_map = tree.get_file_map(view_dst, ignore_file)
         pkg.remove_files_from_view(self, merge_map)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1952,7 +1952,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         installed = set(os.listdir(self.prefix))
         installed.difference_update(
-            spack.store.layout.hidden_file_paths)
+            spack.store.layout.hidden_file_regexes)
         if not installed:
             raise InstallError(
                 "Install failed for %s.  Nothing was installed!" % self.name)


### PR DESCRIPTION
Not sure how to add a test for this, but basically we currently skip files matching `.spack` as a regex, which includes `bin/spack` when there is a spack package in spack. This PR makes sure we match '.spack' literally.
