### PR TITLE
environments: fail gracefully on missing keys

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1552,7 +1552,14 @@ class Environment(object):
         """Return all specs, even those a user spec would shadow."""
         all_specs = set()
         for h in self.concretized_order:
-            all_specs.update(self.specs_by_hash[h].traverse())
+            try:
+                spec = self.specs_by_hash[h]
+            except KeyError:
+                tty.warn(
+                    'Environment %s appears to be corrupt: missing spec '
+                    '"%s"' % (self.name, h))
+                continue
+            all_specs.update(spec.traverse())
 
         return sorted(all_specs)
 


### PR DESCRIPTION
Sometimes while trying a spack command (on a development machine where my spack version gets fairly frequently) I'll see an error like this:
```console
$ spack uninstall /sw4mxks
==> Error: '4b7gjvyzvujh7ifzc5hzr3oqohlkiieu'
```
which is not helpful at all, and the full traceback is:
```console
$ spack -vd uninstall /sw4mxks
==> [2021-09-30-10:33:48.761610] Imported uninstall from built-in commands
==> [2021-09-30-10:33:48.762667] Imported uninstall from built-in commands
==> [2021-09-30-10:33:48.764193] Reading config file /rnsdhpc/code/spack/etc/spack/defaults/config.yaml
==> [2021-09-30-10:33:48.781559] Reading config file /rnsdhpc/code/spack/etc/spack/config.yaml
==> [2021-09-30-10:33:48.784150] Reading config file /rnsdhpc/code/spack/etc/spack/defaults/bootstrap.yaml
==> [2021-09-30-10:33:48.790486] Reading config file /Users/s3j/.spack/darwin/bootstrap.yaml
==> [2021-09-30-10:33:48.793134] DATABASE LOCK TIMEOUT: 3s
==> [2021-09-30-10:33:48.793218] PACKAGE LOCK TIMEOUT: No timeout
Traceback (most recent call last):
  File "/rnsdhpc/code/spack/bin/spack", line 100, in <module>
    sys.exit(spack.main.main())
  File "/rnsdhpc/code/spack/lib/spack/spack/main.py", line 797, in main
    return _invoke_command(command, parser, args, unknown)
  File "/rnsdhpc/code/spack/lib/spack/spack/main.py", line 525, in _invoke_command
    return_val = command(parser, args)
  File "/rnsdhpc/code/spack/lib/spack/spack/cmd/uninstall.py", line 360, in uninstall
    uninstall_specs(args, specs)
  File "/rnsdhpc/code/spack/lib/spack/spack/cmd/uninstall.py", line 316, in uninstall_specs
    uninstall_list, remove_list = get_uninstall_list(args, specs, env)
  File "/rnsdhpc/code/spack/lib/spack/spack/cmd/uninstall.py", line 252, in get_uninstall_list
    spec_envs = dependent_environments(uninstall_list)
  File "/rnsdhpc/code/spack/lib/spack/spack/cmd/uninstall.py", line 163, in dependent_environments
    hashes = set(env.all_hashes())
  File "/rnsdhpc/code/spack/lib/spack/spack/environment.py", line 1550, in all_hashes
    return list(set(s.dag_hash() for s in self.all_specs()))
  File "/rnsdhpc/code/spack/lib/spack/spack/environment.py", line 1542, in all_specs
    all_specs.update(self.specs_by_hash[h].traverse())
KeyError: '4b7gjvyzvujh7ifzc5hzr3oqohlkiieu'
```

After this patch, those missing keys are warned about but ignored, allowing the `uninstall` command to see that no active environment uses the spec I'm asking to uninstall:
```console
$ spack uninstall /sw4mxks
==> Warning: Environment celeritas appears to be corrupt: missing spec "4b7gjvyzvujh7ifzc5hzr3oqohlkiieu"
==> Warning: Environment celeritas appears to be corrupt: missing spec "i2eicxrlx7khg4zi33lly6n7x45nrkpe"
==> Warning: Environment celeritas appears to be corrupt: missing spec "p6cqprf6nysumovcbnlavwngqt5mqkpw"
==> Warning: Environment celeritas appears to be corrupt: missing spec "gfsb3hfwcg4awh6a5djp55445yreqfup"
==> Warning: Environment celeritas appears to be corrupt: missing spec "ubltzbwf6wnkzhpnn5kwz7w74cmkpiza"
==> Warning: Environment celeritas appears to be corrupt: missing spec "26dem4hiyne4lrdl5d272iz3525cr5yv"
==> Warning: Environment celeritas appears to be corrupt: missing spec "jslgtdvxofv4573b53wvaj25ru7xw6lb"
==> Warning: Environment celeritas appears to be corrupt: missing spec "3iior6dcwrb7xbknvie7dt52dv3dythe"
==> Warning: Environment celeritas appears to be corrupt: missing spec "23f6lrxka33pum7ys6u5eox5vl3uetog"
==> Warning: Environment celeritas appears to be corrupt: missing spec "ozvbugmvucb57yq6jimjnoqboa5o7g55"
==> Warning: Environment celeritas appears to be corrupt: missing spec "fxfzfals2hqwz7u3wh52lzge3jpvswxq"
==> Warning: Environment celeritas appears to be corrupt: missing spec "3et5hgtukfpm7vlldlqfe2zymbx63dhv"
==> Warning: Environment core appears to be corrupt: missing spec "z5p62pph7x76cn5fdtceurzdompjgkxs"
==> Warning: Environment core appears to be corrupt: missing spec "vksvku7qbycab4zxjq3gl5qcaenlsvgy"
==> Warning: Environment core appears to be corrupt: missing spec "u3oxl7vahrihzej77ylrp6iofcq6g2bw"
==> Warning: Environment core appears to be corrupt: missing spec "vypslx2qze7kl4g3spmv2cpc4qzoc2vx"
==> Warning: Environment core appears to be corrupt: missing spec "rjdn6nrt7w4fuc2sqlpsnw3i4t4pxvjz"
==> Warning: Environment core appears to be corrupt: missing spec "b7cok36alm6osta55aiuiq4mhx4gfljf"
==> Warning: Environment detribits appears to be corrupt: missing spec "c3wo34lk4j43zy32lg2isf4cko55o7mo"
==> Warning: Environment detribits appears to be corrupt: missing spec "sfyiwdawwnngglx63u44vigcunhe3gfo"
==> Warning: Environment detribits appears to be corrupt: missing spec "6ph4lvyhjj5alqhvnnswfv4dboj4i3bc"
==> Warning: Environment detribits appears to be corrupt: missing spec "j6clnpco24u6rr7voeypla5rp6pbwgew"
==> Warning: Environment detribits appears to be corrupt: missing spec "5lzxbkp34ltyexxtbagtaiv7mmyj5qrt"
==> Warning: Environment detribits appears to be corrupt: missing spec "kedeoqtc4jjwewjt5aryxl274vc3lzoo"
==> Warning: Environment detribits appears to be corrupt: missing spec "rjdn6nrt7w4fuc2sqlpsnw3i4t4pxvjz"
==> Warning: Environment detribits appears to be corrupt: missing spec "apdu2quoktdwdpxbkzkne3jmrg4brbjg"
==> Warning: Environment detribits appears to be corrupt: missing spec "f6pccott4enug4gmou3ckbcjmuag2vq4"
==> Warning: Environment detribits appears to be corrupt: missing spec "izvikl6smawc7zherzl7xp2xsstwqio4"
==> Warning: Environment detribits appears to be corrupt: missing spec "b7cok36alm6osta55aiuiq4mhx4gfljf"
==> Warning: Environment detribits appears to be corrupt: missing spec "edwudtxev242ook43loighrmpe26eyny"
==> Warning: Environment detribits appears to be corrupt: missing spec "tu7p6wjiblouhb75amlfraokqkgw5szx"
==> Warning: Environment detribits appears to be corrupt: missing spec "5pfux4gnk33bj76ucuiqyzs6voj7r3y5"
==> Warning: Environment detribits appears to be corrupt: missing spec "veioyihwnjs3gkgyprdlrkjm7oxlajsd"
==> Warning: Environment detribits appears to be corrupt: missing spec "xltoo7pm3a5j3psqk7qrt2snc4yjenft"
==> Warning: Environment detribits appears to be corrupt: missing spec "nitirotbtwsazygq3mmqqtg6377c7tyf"
==> Warning: Environment detribits appears to be corrupt: missing spec "wk3wg5owo5lr5ukt36q4hvn7cx6e5euk"
==> Warning: Environment detribits appears to be corrupt: missing spec "uvadx5hwemtsfs6gq5lvbc2w6osacxjr"
==> Warning: Environment detribits appears to be corrupt: missing spec "ivx3iiivp7owtmlnnyaub4yqa2zdbocs"
==> Warning: Environment detribits appears to be corrupt: missing spec "bco7d4kjbl6fa2w3avy7y3e6aouj5wsk"
==> Warning: Environment detribits appears to be corrupt: missing spec "kqf73fcn2gbacpwjca3rwgvytvwakmcz"
==> Warning: Environment detribits appears to be corrupt: missing spec "saatgposjwvpoxww5eyxs6vxfzm5ahxj"
==> Warning: Environment detribits appears to be corrupt: missing spec "jo5sqm4fjft5gbdeesvbnem7zighgqmu"
==> The following packages will be uninstalled:

    -- darwin-bigsur-x86_64 / apple-clang@13.0.0 --------------------
    sw4mxks trilinos@13.0.1

==> Do you want to proceed? [y/N] y
==> Successfully uninstalled trilinos@13.0.1%apple-clang@13.0.0~adios2+amesos+amesos2+anasazi+aztec~basker+belos~boost~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings~exodus+explicit_template_instantiation~float+fortran+hdf5~hypre+ifpack+ifpack2+intrepid~intrepid2~ipo~isorropia+kokkos~mesquite~minitensor+ml~mpi~muelu~mumps~nox~openmp~phalanx~piro~python~rol~rythmos+sacado~scorec+shards+shared~shylu~stk~stokhos+stratimikos~strumpack~suite-sparse~superlu~superlu-dist~teko~tempus+tpetra~trilinoscouplings~wrapper~zlib~zoltan~zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long_long arch=darwin-bigsur-x86_64/sw4mxks
```

There's clearly an underlying problem that `self.concretized_order` is out of sync with `self.specs_by_hash`, but this PR at least will work around the error rather than failing catastrophically.