### PR TITLE
[root] ROOT_INCLUDE_PATH: prepend dependent_spec.prefix.include

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -113,7 +113,6 @@ class Gaudi(CMakePackage):
         # environment as in Gaudi.xenv
         env.prepend_path('PATH', self.prefix.scripts)
         env.prepend_path('PYTHONPATH', self.prefix.python)
-        env.prepend_path('ROOT_INCLUDE_PATH', self.prefix.include)
 
     def url_for_version(self, version):
         major = str(version[0])

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -617,6 +617,7 @@ class Root(CMakePackage):
         env.prepend_path('PYTHONPATH', self.prefix.lib)
         env.prepend_path('PATH', self.prefix.bin)
         env.append_path('CMAKE_MODULE_PATH', self.prefix.cmake)
+        env.prepend_path('ROOT_INCLUDE_PATH', dependent_spec.prefix.include)
         if "+rpath" not in self.spec:
             env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -625,5 +625,6 @@ class Root(CMakePackage):
         env.set('ROOT_VERSION', 'v{0}'.format(self.version.up_to(1)))
         env.prepend_path('PYTHONPATH', self.prefix.lib)
         env.prepend_path('PATH', self.prefix.bin)
+        env.prepend_path('ROOT_INCLUDE_PATH', dependent_spec.prefix.include)
         if "+rpath" not in self.spec:
             env.prepend_path('LD_LIBRARY_PATH', self.prefix.lib)


### PR DESCRIPTION
closes #26361

For the past few releases, spack is [not populating CPATH anymore](https://github.com/spack/spack/commit/e3f97b37e64d4de70baf8e58fcd747b021d8f2f9). This means that cling is not picking up headers and we get warnings such as 
```
Error in cling::AutoLoadingVisitor::InsertIntoAutoLoadingState:
   Missing FileEntry for DDRec/ISurface.h
   requested to autoload type dd4hep::rec::ISurface
```

Downstream packages ([gaudi](https://github.com/spack/spack/blob/1aa7758dbb572aa0f92efe1e1f61b2df37aae2e5/var/spack/repos/builtin/packages/gaudi/package.py#L116)) have started to include changes to `ROOT_INCLUDE_DIR` in their `package.py` files. Instead of propagating this to all downstream packages, this PR tries to address the issue at the source.

Possible negative consequences:
- I could imagine that this introduces new symbol or include file name collisions in environments that include multiple ROOT-dependent packages that do not use proper include directories or guard symbols in namespaces (such as a generic `include/IO.h` in `genfit`). It's hard to guard for this, though...