### PR TITLE
environments: add support for mods to shell environment in Spack environments

### DIFF
--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -12,6 +12,7 @@ import warnings
 
 from llnl.util.lang import union_dicts
 
+import spack.schema.environment
 import spack.schema.merged
 import spack.schema.packages
 import spack.schema.projections
@@ -152,7 +153,8 @@ schema = {
                         'type': 'string',
                         'enum': ['together', 'separately'],
                         'default': 'separately'
-                    }
+                    },
+                    'environment': spack.schema.environment.definition
                 }
             )
         }

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -760,6 +760,8 @@ class EnvironmentModifications(object):
                 remaining_list = [
                     ii for ii in before_list if ii in after_list]
                 try:
+                    # TODO: this should throw only when len(remaining_list) ==
+                    # 0, why not just check that condition?
                     start = after_list.index(remaining_list[0])
                     end = after_list.index(remaining_list[-1])
                     search = sep.join(after_list[start:end + 1])
@@ -769,7 +771,7 @@ class EnvironmentModifications(object):
 
                 if search not in value_before:
                     # We just need to set the variable to the new value
-                    env.prepend_path(x, value_after)
+                    env.set(x, value_after)
                 else:
                     try:
                         prepend_list = after_list[:start]

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -593,20 +593,22 @@ class EnvironmentModifications(object):
             for x in actions:
                 x.execute(env)
 
-    def shell_modifications(self, shell='sh'):
-        """Return shell code to apply the modifications and clears the list."""
-        modifications = self.group_by_name()
-        new_env = os.environ.copy()
+    def shell_modifications(self, shell='sh', env=None):
+        """Return shell code to apply the modifications in environment env and
+        clears the list.
+        """
+        # Use os.environ if not specified
+        if env is None:
+            env = os.environ
+        new_env = env.copy()
 
-        for name, actions in sorted(modifications.items()):
-            for x in actions:
-                x.execute(new_env)
+        self.apply_modifications(new_env)
 
         cmds = ''
 
-        for name in set(new_env) | set(os.environ):
+        for name in set(new_env) | set(env):
             new = new_env.get(name, None)
-            old = os.environ.get(name, None)
+            old = env.get(name, None)
             if new != old:
                 if new is None:
                     cmds += _shell_unset_strings[shell].format(name)

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -351,6 +351,7 @@ is_set SPACK_ENV
 echo "Testing 'spack env deactivate'"
 spack env deactivate
 is_not_set SPACK_ENV
+is_not_set SPACK_ENV_RESTORE
 
 echo "Testing 'spack env activate spack_test_env'"
 spack env activate spack_test_env
@@ -359,6 +360,7 @@ is_set SPACK_ENV
 echo "Testing 'despacktivate'"
 despacktivate
 is_not_set SPACK_ENV
+is_not_set SPACK_ENV_RESTORE
 
 #
 # NOTE: `--prompt` on fish does nothing => currently not implemented.

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -155,6 +155,7 @@ is_set SPACK_ENV
 echo "Testing 'spack env deactivate'"
 spack env deactivate
 is_not_set SPACK_ENV
+is_not_set SPACK_ENV_RESTORE
 
 echo "Testing 'spack env activate spack_test_env'"
 spack env activate spack_test_env
@@ -163,6 +164,7 @@ is_set SPACK_ENV
 echo "Testing 'despacktivate'"
 despacktivate
 is_not_set SPACK_ENV
+is_not_set SPACK_ENV_RESTORE
 
 echo "Testing 'spack env activate --prompt spack_test_env'"
 spack env activate --prompt spack_test_env


### PR DESCRIPTION
These changes add support for an `environment` section in the `spack.yaml` file of a Spack environment definition.

This is my first PR for core Spack. My implementation makes sense to me, but it's clearly possible that it's not optimal or violates some design I'm unaware of, and I'm completely open to suggestions both major and minor.

The implementation uses the `EnvironmentModifications` class to compute the shell commands for both activating and deactivating an environment.
- Some changes to `EnvironmentModifications.shell_modifications()` were needed to allow computing the shell commands in environments other than the one defined by `os.environ`, but this was done in a way similar to existing functionality in `EnvironmentModifications.apply_modifications()`.
- A change in `EnvironmentModifications.from_environment_diff()` https://github.com/spack/spack/compare/develop...mpokorny:env2var?expand=1#diff-0cc2226e3e202ef9144cd62eaf79b43f4fb5cf95adb00ee92f2e572e94adc393R774 was made to simplify the reversal of the removal of a path from a path list from somewhere in the middle of the list. This change prevents the growth of the path list when such a list modification is reversed.
- I added a comment https://github.com/spack/spack/compare/develop...mpokorny:env2var?expand=1#diff-0cc2226e3e202ef9144cd62eaf79b43f4fb5cf95adb00ee92f2e572e94adc393R763 to code in `EnvironmentModifications.from_environment_diff()` that suggests a possible further simplification to code, but isn't strictly required.
- I didn't find any unit tests for `EnvironmentModifications.shell_modifications()`, but I added one called `test_shell_modifications_round_trip()` to `test/environment_modifications.py`.
- Saving the shell environment that exists prior to activating a Spack environment is implemented by computing the shell modifications that will later be needed to restore the shell environment, and saving those modifications in the shell environment variable `SPACK_ENV_RESTORE`. The value of that variable is simply `eval`ed to restore the shell environment on Spack environment deactivation.