### PR TITLE
Add GCS Bucket Mirrors

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1422,6 +1422,7 @@ class GCSFetchStrategy(URLFetchStrategy):
 
     @_needs_stage
     def fetch(self):
+        import spack.util.web as web_util
         if self.archive_file:
             tty.debug('Already downloaded {0}'.format(self.archive_file))
             return

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -318,6 +318,12 @@ class URLFetchStrategy(FetchStrategy):
         url = None
         errors = []
         for url in self.candidate_urls:
+            if url[0:1] == 'gs':
+                import spack.util.gcs as gcs_util
+                parsed_url = urllib_parse.urlparse(url)
+                gcs = gcs_util.GCSBlob(parsed_url)
+                url = gcsblob.gcs_url()
+
             if not self._existing_url(url):
                 continue
 
@@ -1590,6 +1596,7 @@ def from_url_scheme(url, *args, **kwargs):
             'https': 'url',
             'ftp': 'url',
             'ftps': 'url',
+            'gs':'url',
         })
 
     scheme = parsed_url.scheme

--- a/lib/spack/spack/gcs_handler.py
+++ b/lib/spack/spack/gcs_handler.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import six.moves.urllib.response as urllib_response
+
+import spack.util.url as url_util
+import spack.util.web as web_util
+
+
+def gcs_open(req, *args, **kwargs):
+    import spack.util.gcs as gcs_util
+
+    url = url_util.parse(req.get_full_url())
+    gcsblob = gcs_util.GCSBlob(url)
+
+    if not gcsblob.exists():
+        raise web_util.SpackWebError('GCS blob {0} does not exist'.format(
+                                     gcsblob.blob_path))
+    stream = gcsblob.get_blob_byte_stream()
+    headers = gcsblob.get_blob_headers()
+
+    return urllib_response.addinfourl(stream, headers, url)

--- a/lib/spack/spack/gcs_handler.py
+++ b/lib/spack/spack/gcs_handler.py
@@ -10,6 +10,8 @@ import spack.util.web as web_util
 
 
 def gcs_open(req, *args, **kwargs):
+    """Open a reader stream to a blob object on GCS
+    """
     import spack.util.gcs as gcs_util
 
     url = url_util.parse(req.get_full_url())

--- a/lib/spack/spack/test/gcs_fetch.py
+++ b/lib/spack/spack/test/gcs_fetch.py
@@ -1,0 +1,54 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import pytest
+
+import spack.config as spack_config
+import spack.fetch_strategy as spack_fs
+import spack.stage as spack_stage
+
+
+@pytest.mark.parametrize('_fetch_method', ['curl', 'urllib'])
+def test_gcsfetchstrategy_sans_url(_fetch_method):
+    """Ensure constructor with no URL fails."""
+    with spack_config.override('config:url_fetch_method', _fetch_method):
+        with pytest.raises(ValueError):
+            spack_fs.GCSFetchStrategy(None)
+
+
+@pytest.mark.parametrize('_fetch_method', ['curl', 'urllib'])
+def test_gcsfetchstrategy_bad_url(tmpdir, _fetch_method):
+    """Ensure fetch with bad URL fails as expected."""
+    testpath = str(tmpdir)
+
+    with spack_config.override('config:url_fetch_method', _fetch_method):
+        fetcher = spack_fs.GCSFetchStrategy(url='file:///does-not-exist')
+        assert fetcher is not None
+
+        with spack_stage.Stage(fetcher, path=testpath) as stage:
+            assert stage is not None
+            assert fetcher.archive_file is None
+            with pytest.raises(spack_fs.FetchError):
+                fetcher.fetch()
+
+
+@pytest.mark.parametrize('_fetch_method', ['curl', 'urllib'])
+def test_gcsfetchstrategy_downloaded(tmpdir, _fetch_method):
+    """Ensure fetch with archive file already downloaded is a noop."""
+    testpath = str(tmpdir)
+    archive = os.path.join(testpath, 'gcs.tar.gz')
+
+    with spack_config.override('config:url_fetch_method', _fetch_method):
+        class Archived_GCSFS(spack_fs.GCSFetchStrategy):
+            @property
+            def archive_file(self):
+                return archive
+
+        url = 'gcs:///{0}'.format(archive)
+        fetcher = Archived_GCSFS(url=url)
+        with spack_stage.Stage(fetcher, path=testpath):
+            fetcher.fetch()

--- a/lib/spack/spack/test/gcs_fetch.py
+++ b/lib/spack/spack/test/gcs_fetch.py
@@ -7,17 +7,17 @@ import os
 
 import pytest
 
-import spack.config as spack_config
-import spack.fetch_strategy as spack_fs
-import spack.stage as spack_stage
+import spack.config
+import spack.fetch_strategy
+import spack.stage
 
 
 @pytest.mark.parametrize('_fetch_method', ['curl', 'urllib'])
-def test_gcsfetchstrategy_sans_url(_fetch_method):
+def test_gcsfetchstrategy_without_url(_fetch_method):
     """Ensure constructor with no URL fails."""
-    with spack_config.override('config:url_fetch_method', _fetch_method):
+    with spack.config.override('config:url_fetch_method', _fetch_method):
         with pytest.raises(ValueError):
-            spack_fs.GCSFetchStrategy(None)
+            spack.fetch_strategy.GCSFetchStrategy(None)
 
 
 @pytest.mark.parametrize('_fetch_method', ['curl', 'urllib'])
@@ -25,14 +25,14 @@ def test_gcsfetchstrategy_bad_url(tmpdir, _fetch_method):
     """Ensure fetch with bad URL fails as expected."""
     testpath = str(tmpdir)
 
-    with spack_config.override('config:url_fetch_method', _fetch_method):
-        fetcher = spack_fs.GCSFetchStrategy(url='file:///does-not-exist')
+    with spack.config.override('config:url_fetch_method', _fetch_method):
+        fetcher = spack.fetch_strategy.GCSFetchStrategy(url='file:///does-not-exist')
         assert fetcher is not None
 
-        with spack_stage.Stage(fetcher, path=testpath) as stage:
+        with spack.stage.Stage(fetcher, path=testpath) as stage:
             assert stage is not None
             assert fetcher.archive_file is None
-            with pytest.raises(spack_fs.FetchError):
+            with pytest.raises(spack.fetch_strategy.FetchError):
                 fetcher.fetch()
 
 
@@ -42,13 +42,13 @@ def test_gcsfetchstrategy_downloaded(tmpdir, _fetch_method):
     testpath = str(tmpdir)
     archive = os.path.join(testpath, 'gcs.tar.gz')
 
-    with spack_config.override('config:url_fetch_method', _fetch_method):
-        class Archived_GCSFS(spack_fs.GCSFetchStrategy):
+    with spack.config.override('config:url_fetch_method', _fetch_method):
+        class Archived_GCSFS(spack.fetch_strategy.GCSFetchStrategy):
             @property
             def archive_file(self):
                 return archive
 
         url = 'gcs:///{0}'.format(archive)
         fetcher = Archived_GCSFS(url=url)
-        with spack_stage.Stage(fetcher, path=testpath):
+        with spack.stage.Stage(fetcher, path=testpath):
             fetcher.fetch()

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -1,0 +1,126 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""
+This file contains the definition of the GCS Blob storage Class used to
+integrate GCS Blob storage with spack buildcache.
+"""
+
+import os
+import sys
+
+import llnl.util.tty as tty
+
+
+class GCSBlob:
+    def __init__(self, url):
+        from google.cloud import storage
+        import google.auth
+
+        self.url = url
+        (self.bucket_name, self.blob_path) = self.get_bucket_blob_path()
+        if url.scheme != 'gs':
+            raise ValueError('Can not create GCS blob connection with scheme: {SCHEME}'
+                             .format(SCHEME=url.scheme))
+
+        self.storage_credentials, self.storage_project = google.auth.default()
+        self.storage_client = storage.Client(self.storage_project,
+                                             self.storage_credentials)
+        if not self.gcs_bucket_exists():
+            tty.warn("The bucket {} does not exist, it will be created"
+                     .format(self.bucket_name))
+            self.storage_client.create_bucket(self.bucket_name)
+
+    def get_bucket_blob_path(self):
+        blob_path = self.url.path
+        bucket_name = self.url.netloc
+        tty.debug("bucket_name = {}, blob_path = {}".format(bucket_name, blob_path))
+        return (bucket_name, blob_path)
+
+    def is_https(self):
+        return False
+
+    def gcs_bucket_exists(self):
+        try:
+            bucket = self.storage_client.bucket(self.bucket_name)
+        except Exception as ex:
+            tty.error("{}, Failed check for bucket existence".format(ex))
+            sys.exit(1)
+        return (bucket is not None)
+
+    def gcs_blob_exists(self):
+        from google.cloud import storage
+        try:
+            bucket = self.storage_client.bucket(self.bucket_name)
+            blob_exists = storage.Blob(bucket=bucket,
+                                       blob=self.blob_path).exists(
+                self.storage_client)
+        except Exception:
+            return False
+
+        return blob_exists
+
+    def gcs_delete_blob(self):
+        try:
+            bucket = self.storage_client.bucket(self.bucket_name)
+            blob = bucket.blob(self.blob_path)
+            blob.delete()
+        except Exception as ex:
+            tty.error("{}, Could not delete gcs blob {}".format(ex, self.blob_path))
+
+    def gcs_upload_to_blob(self, local_file_path):
+        try:
+            bucket = self.storage_client.bucket(self.bucket_name)
+            blob = bucket.blob(self.blob_path.lstrip("/"))
+            blob.upload_from_filename(local_file_path)
+        except Exception as ex:
+            tty.error("{}, Could not upload {} to gcs blob storage"
+                      .format(ex, local_file_path))
+            sys.exit(1)
+
+    def gcs_list_blobs(self):
+        try:
+            blobs = self.storage_client.list_blobs(self.bucket_name,
+                                                   prefix=self.blob_path)
+            blob_list = []
+            for blob in blobs:
+                p = blob.name.split('/')
+                build_cache_index = p.index('build_cache')
+                blob_list.append(os.path.join(*p[build_cache_index + 1:]))
+            return blob_list
+
+        except Exception as ex:
+            tty.error("{}, Could not get a list of gcs blobs".format(ex))
+            sys.exit(1)
+
+    def gcs_url(self):
+        import os
+        from google.auth.transport import requests
+        from google.auth import compute_engine
+        from datetime import datetime, timedelta
+
+        try:
+            auth_request = requests.Request()
+            data_bucket = self.storage_client.lookup_bucket(self.bucket_name)
+            signed_blob_path = data_bucket.blob(self.blob_path)
+
+            expires_at_ms = datetime.now() + timedelta(minutes=5)
+
+            if os.getenv('GCE_COMPUTE_ENGINE') == 'False':
+                signed_url = signed_blob_path.generate_signed_url(expires_at_ms,
+                                                                  version='v4')
+            else:
+                # Generate Compute Engine credentials
+                signing_credentials = compute_engine.IDTokenCredentials(auth_request,
+                                                                        "")
+                signed_url = signed_blob_path.generate_signed_url(
+                    expires_at_ms, credentials=signing_credentials, version="v4")
+
+        except Exception as ex:
+            tty.error("{}, Could not generate a signed URL for GCS blob storage"
+                      .format(ex))
+            sys.exit(1)
+
+        return signed_url

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -14,113 +14,202 @@ import sys
 import llnl.util.tty as tty
 
 
-class GCSBlob:
-    def __init__(self, url):
-        from google.cloud import storage
+def gcs_client():
+    """Create a GCS client
+    Creates an authenticated GCS client to access GCS buckets and blobs
+    """
+
+    try:
         import google.auth
+        from google.cloud import storage
+    except ImportError as ex:
+        tty.error('{0}, google-cloud-storage python module is missing.'.format(ex) +
+                  ' Please install to use the gs:// backend.')
+        sys.exit(1)
+
+    storage_credentials, storage_project = google.auth.default()
+    storage_client = storage.Client(storage_project,
+                                    storage_credentials)
+    return storage_client
+
+
+class GCSBucket(object):
+    """GCS Bucket Object
+    Create a wrapper object for a GCS Bucket. Provides methods to wrap spack
+    related tasks, such as destroy.
+    """
+    def __init__(self, url, client=None):
+        """Constructor for GCSBucket objects
+        """
+        self. url = url
+        self.name = self.url.netloc
+        tty.debug("bucket_name = {0}".format(self.name))
+
+        if not client:
+            self.client = gcs_client()
+        else:
+            self.client = client
+
+        self.bucket = None
+
+    def exists(self):
+        if not self.bucket:
+            try:
+                self.bucket = self.client.bucket(self.name)
+            except Exception as ex:
+                tty.error("{0}, Failed check for bucket existence".format(ex))
+                sys.exit(1)
+        return (self.bucket is not None)
+
+    def create(self):
+        if not self.bucket:
+            self.bucket = self.client.create_bucket(self.name)
+
+    def get_blob(self, blob_path):
+        if self.exists():
+            return self.bucket.get_blob(blob_path)
+        return None
+
+    def blob(self, blob_path):
+        if self.exists():
+            return self.bucket.blob(blob_path)
+        return None
+
+    def get_all_blobs(self, relative=True):
+        """Get a list of all blobs
+        Returns a list of all blobs within this bucket.
+
+        Args:
+            relative: If true (default), print relative blob paths to
+                         'build_cache' directory.
+                      If false, print absolute blob paths (useful for
+                         destruction of bucket)
+        """
+        if self.exists():
+            try:
+                all_blobs = self.bucket.list_blobs()
+                blob_list = []
+
+                if not relative:
+                    # If we do not want relative paths, just return the list
+                    for blob in all_blobs:
+                        blob_list.append(blob.name)
+                else:
+                    # To create relative paths, strip everything before 'build_cache'
+                    for blob in all_blobs:
+                        p = blob.name.split('/')
+                        try:
+                            build_cache_index = p.index('build_cache')
+                            blob_list.append(os.path.join(*p[build_cache_index + 1:]))
+                        except ValueError:
+                            blob_list.append(os.path.join(*p[:]))
+
+                        tty.debug("Blob name = {0}, converted blob name = {1}".format(
+                                  blob.name, blob_list[-1]))
+
+                return blob_list
+            except Exception as ex:
+                tty.error("{0}, Could not get a list of all GCS blobs.".format(ex))
+                sys.exit(1)
+
+    def destroy(self):
+        """Bucket destruction method
+
+        Deletes all blobs within the bucket, and then deletes the bucket itself.
+
+        Uses GCS Batch operations to bundle several delete operations together.
+        """
+        try:
+            bucket_blobs = self.get_all_blobs(relative=False)
+            batch_size = 1000
+
+            num_blobs = len(bucket_blobs)
+            for i in range(0, num_blobs, batch_size):
+                with self.client.batch():
+                    for j in range(i, min(i + batch_size, num_blobs)):
+                        blob = self.blob(bucket_blobs[j])
+                        blob.delete()
+        except Exception as ex:
+            tty.error("{0}, Could not delete a blob in bucket {1}.".format(
+                      ex, self.name))
+            sys.exit(1)
+
+        try:
+            self.bucket.delete()
+        except Exception as ex:
+            tty.error("{0}, Could not destroy bucket {1}.".format(ex, self.name))
+            sys.exit(1)
+
+
+class GCSBlob(object):
+    """GCS Blob object
+
+    Wraps some blob methods for spack functionality
+    """
+    def __init__(self, url, client=None):
 
         self.url = url
-        (self.bucket_name, self.blob_path) = self.get_bucket_blob_path()
         if url.scheme != 'gs':
             raise ValueError('Can not create GCS blob connection with scheme: {SCHEME}'
                              .format(SCHEME=url.scheme))
 
-        self.storage_credentials, self.storage_project = google.auth.default()
-        self.storage_client = storage.Client(self.storage_project,
-                                             self.storage_credentials)
-        if not self.gcs_bucket_exists():
-            tty.warn("The bucket {} does not exist, it will be created"
-                     .format(self.bucket_name))
-            self.storage_client.create_bucket(self.bucket_name)
+        if not client:
+            self.client = gcs_client()
+        else:
+            self.client = client
 
-    def get_bucket_blob_path(self):
-        blob_path = self.url.path
-        bucket_name = self.url.netloc
-        tty.debug("bucket_name = {}, blob_path = {}".format(bucket_name, blob_path))
-        return (bucket_name, blob_path)
+        self.bucket = GCSBucket(url)
 
-    def is_https(self):
-        return False
+        if self.url.path[0] == '/':
+            self.blob_path = self.url.path[1:]
+        else:
+            self.blob_path = self.url.path
 
-    def gcs_bucket_exists(self):
+        tty.debug("blob_path = {0}".format(self.blob_path))
+
+        if not self.bucket.exists():
+            tty.warn("The bucket {0} does not exist, it will be created"
+                     .format(self.bucket.name))
+            self.bucket.create()
+
+    def get(self):
+        return self.bucket.get_blob(self.blob_path)
+
+    def exists(self):
         try:
-            bucket = self.storage_client.bucket(self.bucket_name)
-        except Exception as ex:
-            tty.error("{}, Failed check for bucket existence".format(ex))
-            sys.exit(1)
-        return (bucket is not None)
-
-    def gcs_blob_exists(self):
-        from google.cloud import storage
-        try:
-            bucket = self.storage_client.bucket(self.bucket_name)
-            blob_exists = storage.Blob(bucket=bucket,
-                                       blob=self.blob_path).exists(
-                self.storage_client)
+            blob = self.bucket.blob(self.blob_path)
+            exists = blob.exists()
         except Exception:
             return False
 
-        return blob_exists
+        return exists
 
-    def gcs_delete_blob(self):
+    def delete_blob(self):
         try:
-            bucket = self.storage_client.bucket(self.bucket_name)
-            blob = bucket.blob(self.blob_path)
+            blob = self.bucket.blob(self.blob_path)
             blob.delete()
         except Exception as ex:
-            tty.error("{}, Could not delete gcs blob {}".format(ex, self.blob_path))
+            tty.error("{0}, Could not delete gcs blob {1}".format(ex, self.blob_path))
 
-    def gcs_upload_to_blob(self, local_file_path):
+    def upload_to_blob(self, local_file_path):
         try:
-            bucket = self.storage_client.bucket(self.bucket_name)
-            blob = bucket.blob(self.blob_path.lstrip("/"))
+            blob = self.bucket.blob(self.blob_path.lstrip("/"))
             blob.upload_from_filename(local_file_path)
         except Exception as ex:
-            tty.error("{}, Could not upload {} to gcs blob storage"
+            tty.error("{0}, Could not upload {1} to gcs blob storage"
                       .format(ex, local_file_path))
             sys.exit(1)
 
-    def gcs_list_blobs(self):
-        try:
-            blobs = self.storage_client.list_blobs(self.bucket_name,
-                                                   prefix=self.blob_path)
-            blob_list = []
-            for blob in blobs:
-                p = blob.name.split('/')
-                build_cache_index = p.index('build_cache')
-                blob_list.append(os.path.join(*p[build_cache_index + 1:]))
-            return blob_list
+    def get_blob_byte_stream(self):
+        return self.bucket.get_blob(self.blob_path).open(mode='rb')
 
-        except Exception as ex:
-            tty.error("{}, Could not get a list of gcs blobs".format(ex))
-            sys.exit(1)
+    def get_blob_headers(self):
+        blob = self.bucket.get_blob(self.blob_path)
 
-    def gcs_url(self):
-        import os
-        from google.auth.transport import requests
-        from google.auth import compute_engine
-        from datetime import datetime, timedelta
+        headers = {}
+        headers['Content-type'] = blob.content_type
+        headers['Content-encoding'] = blob.content_encoding
+        headers['Content-language'] = blob.content_language
+        headers['MD5Hash'] = blob.md5_hash
 
-        try:
-            auth_request = requests.Request()
-            data_bucket = self.storage_client.lookup_bucket(self.bucket_name)
-            signed_blob_path = data_bucket.blob(self.blob_path)
-
-            expires_at_ms = datetime.now() + timedelta(minutes=5)
-
-            if os.getenv('GCE_COMPUTE_ENGINE') == 'False':
-                signed_url = signed_blob_path.generate_signed_url(expires_at_ms,
-                                                                  version='v4')
-            else:
-                # Generate Compute Engine credentials
-                signing_credentials = compute_engine.IDTokenCredentials(auth_request,
-                                                                        "")
-                signed_url = signed_blob_path.generate_signed_url(
-                    expires_at_ms, credentials=signing_credentials, version="v4")
-
-        except Exception as ex:
-            tty.error("{}, Could not generate a signed URL for GCS blob storage"
-                      .format(ex))
-            sys.exit(1)
-
-        return signed_url
+        return headers

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -56,10 +56,7 @@ class GCSBucket(object):
         else:
             self.prefix = self.url.path
 
-        if not client:
-            self.client = gcs_client()
-        else:
-            self.client = client
+        self.client = client or gcs_client()
 
         self.bucket = None
         tty.debug('New GCS bucket:')

--- a/lib/spack/spack/util/gcs.py
+++ b/lib/spack/spack/util/gcs.py
@@ -41,9 +41,15 @@ class GCSBucket(object):
     def __init__(self, url, client=None):
         """Constructor for GCSBucket objects
         """
+        if url.scheme != 'gs':
+            raise ValueError('Can not create GCS bucket connection with scheme {SCHEME}'
+                             .format(SCHEME=url.scheme))
         self. url = url
         self.name = self.url.netloc
-        tty.debug("bucket_name = {0}".format(self.name))
+        if self.url.path[0] == '/':
+            self.prefix = self.url.path[1:]
+        else:
+            self.prefix = self.url.path
 
         if not client:
             self.client = gcs_client()
@@ -51,12 +57,16 @@ class GCSBucket(object):
             self.client = client
 
         self.bucket = None
+        tty.debug('New GCS bucket:')
+        tty.debug("    name: {0}".format(self.name))
+        tty.debug("    prefix: {0}".format(self.prefix))
 
     def exists(self):
+        from google.cloud.exceptions import NotFound
         if not self.bucket:
             try:
                 self.bucket = self.client.bucket(self.name)
-            except Exception as ex:
+            except NotFound as ex:
                 tty.error("{0}, Failed check for bucket existence".format(ex))
                 sys.exit(1)
         return (self.bucket is not None)
@@ -75,52 +85,54 @@ class GCSBucket(object):
             return self.bucket.blob(blob_path)
         return None
 
-    def get_all_blobs(self, relative=True):
+    def get_all_blobs(self, recursive=True, relative=True):
         """Get a list of all blobs
         Returns a list of all blobs within this bucket.
 
         Args:
-            relative: If true (default), print relative blob paths to
-                         'build_cache' directory.
+            relative: If true (default), print blob paths
+                         relative to 'build_cache' directory.
                       If false, print absolute blob paths (useful for
                          destruction of bucket)
         """
+        tty.debug('Getting GCS blobs... Recurse {0} -- Rel: {1}'.format(
+            recursive, relative))
+
+        if relative:
+            converter = self._relative_blob_name
+        else:
+            converter = str
+
         if self.exists():
-            try:
-                all_blobs = self.bucket.list_blobs()
-                blob_list = []
+            all_blobs = self.bucket.list_blobs(prefix=self.prefix)
+            blob_list = []
 
-                if not relative:
-                    # If we do not want relative paths, just return the list
-                    for blob in all_blobs:
-                        blob_list.append(blob.name)
+            base_dirs = len(self.prefix.split('/')) + 1
+
+            for blob in all_blobs:
+                if not recursive:
+                    num_dirs = len(blob.name.split('/'))
+                    if num_dirs <= base_dirs:
+                        blob_list.append(converter(blob.name))
                 else:
-                    # To create relative paths, strip everything before 'build_cache'
-                    for blob in all_blobs:
-                        p = blob.name.split('/')
-                        try:
-                            build_cache_index = p.index('build_cache')
-                            blob_list.append(os.path.join(*p[build_cache_index + 1:]))
-                        except ValueError:
-                            blob_list.append(os.path.join(*p[:]))
+                    blob_list.append(converter(blob.name))
 
-                        tty.debug("Blob name = {0}, converted blob name = {1}".format(
-                                  blob.name, blob_list[-1]))
+            return blob_list
 
-                return blob_list
-            except Exception as ex:
-                tty.error("{0}, Could not get a list of all GCS blobs.".format(ex))
-                sys.exit(1)
+    def _relative_blob_name(self, blob_name):
+        return os.path.relpath(blob_name, self.prefix)
 
-    def destroy(self):
+    def destroy(self, recursive=False, **kwargs):
         """Bucket destruction method
 
         Deletes all blobs within the bucket, and then deletes the bucket itself.
 
         Uses GCS Batch operations to bundle several delete operations together.
         """
+        from google.cloud.exceptions import NotFound
+        tty.debug("Bucket.destroy(recursive={0})".format(recursive))
         try:
-            bucket_blobs = self.get_all_blobs(relative=False)
+            bucket_blobs = self.get_all_blobs(recursive=recursive, relative=False)
             batch_size = 1000
 
             num_blobs = len(bucket_blobs)
@@ -129,15 +141,9 @@ class GCSBucket(object):
                     for j in range(i, min(i + batch_size, num_blobs)):
                         blob = self.blob(bucket_blobs[j])
                         blob.delete()
-        except Exception as ex:
+        except NotFound as ex:
             tty.error("{0}, Could not delete a blob in bucket {1}.".format(
                       ex, self.name))
-            sys.exit(1)
-
-        try:
-            self.bucket.delete()
-        except Exception as ex:
-            tty.error("{0}, Could not destroy bucket {1}.".format(ex, self.name))
             sys.exit(1)
 
 
@@ -160,12 +166,10 @@ class GCSBlob(object):
 
         self.bucket = GCSBucket(url)
 
-        if self.url.path[0] == '/':
-            self.blob_path = self.url.path[1:]
-        else:
-            self.blob_path = self.url.path
+        self.blob_path = self.url.path.lstrip('/')
 
-        tty.debug("blob_path = {0}".format(self.blob_path))
+        tty.debug("New GCSBlob")
+        tty.debug("  blob_path = {0}".format(self.blob_path))
 
         if not self.bucket.exists():
             tty.warn("The bucket {0} does not exist, it will be created"
@@ -176,29 +180,26 @@ class GCSBlob(object):
         return self.bucket.get_blob(self.blob_path)
 
     def exists(self):
+        from google.cloud.exceptions import NotFound
         try:
             blob = self.bucket.blob(self.blob_path)
             exists = blob.exists()
-        except Exception:
+        except NotFound:
             return False
 
         return exists
 
     def delete_blob(self):
+        from google.cloud.exceptions import NotFound
         try:
             blob = self.bucket.blob(self.blob_path)
             blob.delete()
-        except Exception as ex:
+        except NotFound as ex:
             tty.error("{0}, Could not delete gcs blob {1}".format(ex, self.blob_path))
 
     def upload_to_blob(self, local_file_path):
-        try:
-            blob = self.bucket.blob(self.blob_path.lstrip("/"))
-            blob.upload_from_filename(local_file_path)
-        except Exception as ex:
-            tty.error("{0}, Could not upload {1} to gcs blob storage"
-                      .format(ex, local_file_path))
-            sys.exit(1)
+        blob = self.bucket.blob(self.blob_path)
+        blob.upload_from_filename(local_file_path)
 
     def get_blob_byte_stream(self):
         return self.bucket.get_blob(self.blob_path).open(mode='rb')

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -297,10 +297,10 @@ def remove_url(url, recursive=False):
     elif url.scheme == 'gs':
         if recursive:
             bucket = gcs_util.GCSBucket(url)
-            bucket.destroy()
+            bucket.destroy(recursive=recursive)
         else:
             blob = gcs_util.GCSBlob(url)
-            blob._delete_blob()
+            blob.delete_blob()
         return
 
     # Don't even try for other URL schemes.
@@ -384,7 +384,7 @@ def list_url(url, recursive=False):
 
     elif url.scheme == 'gs':
         gcs = gcs_util.GCSBucket(url)
-        return gcs.get_all_blobs()
+        return gcs.get_all_blobs(recursive=recursive)
 
 
 def spider(root_urls, depth=0, concurrency=32):
@@ -546,7 +546,7 @@ def _urlopen(req, *args, **kwargs):
         opener = spack.s3_handler.open
     elif url_util.parse(url).scheme == 'gs':
         import spack.gcs_handler
-        return spack.gcs_handler.gcs_open(req)
+        opener = spack.gcs_handler.gcs_open
 
     try:
         return opener(req, *args, **kwargs)

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -28,8 +28,8 @@ import spack.config
 import spack.error
 import spack.url
 import spack.util.crypto
-import spack.util.s3 as s3_util
 import spack.util.gcs as gcs_util
+import spack.util.s3 as s3_util
 import spack.util.url as url_util
 from spack.util.compression import ALLOWED_ARCHIVE_TYPES
 
@@ -76,10 +76,8 @@ def uses_ssl(parsed_url):
             return True
 
     elif parsed_url.scheme == 'gs':
-        gcs = gcs_util.GCSBlob(parsed_url)
-        if gcs.is_https():
-            tty.debug("(uses_ssl) GCS Blob is https")
-            return True
+        tty.debug("(uses_ssl) GCS Blob is https")
+        return True
 
     return False
 
@@ -113,14 +111,7 @@ def read_from_url(url, accept_content_type=None):
             if not __UNABLE_TO_VERIFY_SSL:
                 context = ssl._create_unverified_context()
 
-    if url.scheme == 'gs':
-        gcs = gcs_util.GCSBlob(url)
-        gcs_url = gcs.gcs_url()
-        tty.debug("(read_from_url) gcs_url = {}".format(gcs_url))
-        req = Request(gcs.gcs_url())
-    else:
-        req = Request(url_util.format(url))
-
+    req = Request(url_util.format(url))
     content_type = None
     is_web_url = url.scheme in ('http', 'https')
     if accept_content_type and is_web_url:
@@ -211,7 +202,7 @@ def push_to_url(
 
     elif remote_url.scheme == 'gs':
         gcs = gcs_util.GCSBlob(remote_url)
-        gcs.gcs_upload_to_blob(local_file_path)
+        gcs.upload_to_blob(local_file_path)
         if not keep_original:
             os.remove(local_file_path)
 
@@ -239,7 +230,7 @@ def url_exists(url):
 
     elif url.scheme == 'gs':
         gcs = gcs_util.GCSBlob(url)
-        return gcs.gcs_blob_exists()
+        return gcs.exists()
 
     # otherwise, just try to "read" from the URL, and assume that *any*
     # non-throwing response contains the resource represented by the URL
@@ -304,8 +295,12 @@ def remove_url(url, recursive=False):
         return
 
     elif url.scheme == 'gs':
-        gcs = gcs_util.GCSBlob(url)
-        gcs.gcs_delete_blob()
+        if recursive:
+            bucket = gcs_util.GCSBucket(url)
+            bucket.destroy()
+        else:
+            blob = gcs_util.GCSBlob(url)
+            blob._delete_blob()
         return
 
     # Don't even try for other URL schemes.
@@ -388,8 +383,8 @@ def list_url(url, recursive=False):
             for key in _iter_s3_prefix(s3, url)))
 
     elif url.scheme == 'gs':
-        gcs = gcs_util.GCSBlob(url)
-        return gcs.gcs_list_blobs()
+        gcs = gcs_util.GCSBucket(url)
+        return gcs.get_all_blobs()
 
 
 def spider(root_urls, depth=0, concurrency=32):
@@ -549,6 +544,9 @@ def _urlopen(req, *args, **kwargs):
     if url_util.parse(url).scheme == 's3':
         import spack.s3_handler
         opener = spack.s3_handler.open
+    elif url_util.parse(url).scheme == 'gs':
+        import spack.gcs_handler
+        return spack.gcs_handler.gcs_open(req)
 
     try:
         return opener(req, *args, **kwargs)


### PR DESCRIPTION
This pull request contains changes to support Google Cloud Storage buckets as mirrors, meant for hosting Spack build-caches. This feature is beneficial for folks that are running infrastructure on Google Cloud Platform. On public cloud systems, resources are ephemeral and in many cases, installing compilers, MPI flavors, and user packages from scratch takes up considerable time.

Giving users the ability to host a Spack mirror that can store build caches in GCS buckets offers a clean solution for reducing application rebuilds for Google Cloud infrastructure.