### PR TITLE
DiHydrogen: Specify required NVSHMEM variants

### DIFF
--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -122,7 +122,8 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('llvm-openmp', when='%apple-clang +openmp')
 
-    depends_on('nvshmem', when='+nvshmem')
+    # TODO: Debug linker errors when NVSHMEM is built with UCX
+    depends_on('nvshmem +nccl~ucx', when='+nvshmem')
 
     # Idenfity versions of cuda_arch that are too old
     # from lib/spack/spack/build_systems/cuda.py


### PR DESCRIPTION
https://github.com/LLNL/DiHydrogen/pull/61 assumes that NVSHMEM has NCCL support.

I've also encountered linker errors when building with NVSHMEM with UCX support. The quickest fix is to just disable UCX, but it would be worthwhile debugging this in the future.