### PR TITLE
Added package for the Python Globus SDK (globus.org)

### DIFF
--- a/var/spack/repos/builtin/packages/py-globus-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-sdk/package.py
@@ -20,4 +20,3 @@ class PyGlobusSdk(PythonPackage):
     depends_on('py-requests@2.19.1:2.999.999', type=('run', 'test'))
     depends_on('py-cryptography@2.0:3.3.999,3.4.1:3.6.999', type=('run', 'test'))
     depends_on('py-pyjwt@2.0.0:2.999.999+crypto', type=('run', 'test'))
-

--- a/var/spack/repos/builtin/packages/py-globus-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-sdk/package.py
@@ -12,6 +12,7 @@ class PyGlobusSdk(PythonPackage):
     homepage = "https://github.com/globus/globus-sdk-python"
     pypi     = "globus-sdk/globus-sdk-3.0.2.tar.gz"
 
+    maintainers = ['hategan']
 
     version('3.0.2', sha256='765b577b37edac70c513179607f1c09de7b287baa855165c9dd68de076d67f16')
 

--- a/var/spack/repos/builtin/packages/py-globus-sdk/package.py
+++ b/var/spack/repos/builtin/packages/py-globus-sdk/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class PyGlobusSdk(PythonPackage):
+    """
+    Globus SDK for Python
+    """
+
+    homepage = "https://github.com/globus/globus-sdk-python"
+    pypi     = "globus-sdk/globus-sdk-3.0.2.tar.gz"
+
+
+    version('3.0.2', sha256='765b577b37edac70c513179607f1c09de7b287baa855165c9dd68de076d67f16')
+
+    depends_on('python@3.4:', type=('build', 'run'))
+    depends_on('py-requests@2.19.1:2.999.999', type=('run', 'test'))
+    depends_on('py-cryptography@2.0:3.3.999,3.4.1:3.6.999', type=('run', 'test'))
+    depends_on('py-pyjwt@2.0.0:2.999.999+crypto', type=('run', 'test'))
+


### PR DESCRIPTION
This is ultimately needed by Parsl (#26360).

It takes a while to install since it depends on py-cryptography, which needs rust-lang to compile.