### PR TITLE
py-pyside: @1.2.2 => fix sphinx doc build

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyside/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside/package.py
@@ -29,7 +29,8 @@ class PyPyside(PythonPackage):
     depends_on('cmake', type='build')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-sphinx', type=('build', 'run'))
+    depends_on('py-sphinx',        type=('build', 'run'))
+    depends_on('py-sphinx@:3.5.0', type=('build', 'run'), when='@:1.2.2')
     depends_on('qt@4.5:4.9')
     depends_on('libxml2@2.6.32:')
     depends_on('libxslt@1.1.19:')


### PR DESCRIPTION
Restrict py-pyside@:1.2.2 to older sphinx versions to not fail the build
