### PR TITLE
Better bootstrap errors

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -291,7 +291,7 @@ class _SourceBootstrapper(object):
 
             if module == 'clingo':
                 # TODO: remove when the old concretizer is deprecated
-                concrete_spec._old_concretize()
+                concrete_spec._old_concretize(deprecation_warning=False)
             else:
                 concrete_spec.concretize()
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -277,6 +277,8 @@ class _SourceBootstrapper(object):
         if _try_import_from_store(module, abstract_spec_str):
             return True
 
+        tty.info("Bootstrapping {0} from sources".format(module))
+
         # Try to build and install from sources
         with spack_python_interpreter():
             # Add hint to use frontend operating system on Cray
@@ -295,7 +297,6 @@ class _SourceBootstrapper(object):
 
         msg = "[BOOTSTRAP MODULE {0}] Try installing '{1}' from sources"
         tty.debug(msg.format(module, abstract_spec_str))
-        tty.info("Bootstrapping {0} from sources".format(module))
 
         # Install the spec that should make the module importable
         concrete_spec.package.do_install(fail_fast=True)

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -402,7 +402,7 @@ def ensure_module_importable_or_raise(module, abstract_spec=None):
             errors[current_config['name']] = e
 
     # We couldn't import in any way, so raise an import error
-    msg = 'Cannot bootstrap the "{0}" Python module'.format(module)
+    msg = 'cannot bootstrap the "{0}" Python module'.format(module)
     if abstract_spec:
         msg += ' from spec "{0}"'.format(abstract_spec)
     msg += ' due to the following failures:\n'

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -216,6 +216,10 @@ class _BuildcacheBootstrapper(object):
             # specs that wwe know by dag hash.
             spack.binary_distribution.binary_index.regenerate_spec_cache()
             index = spack.binary_distribution.update_cache_and_get_specs()
+
+            if not index:
+                raise RuntimeError("Could not populate the binary index")
+
             for item in data['verified']:
                 candidate_spec = item['spec']
                 python_spec = item['python']

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -298,7 +298,7 @@ class _SourceBootstrapper(object):
         tty.info("Bootstrapping {0} from sources".format(module))
 
         # Install the spec that should make the module importable
-        concrete_spec.package.do_install()
+        concrete_spec.package.do_install(fail_fast=True)
 
         return _try_import_from_store(module, abstract_spec_str=abstract_spec_str)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2381,8 +2381,8 @@ class Spec(object):
         # will be removed in v0.18.0
         if deprecation_warning:
             msg = ('the original concretizer is currently being used.\n\tUpgrade to '
-                '"clingo" at your earliest convenience. The original concretizer '
-                'will be removed from Spack starting at v0.18.0')
+                   '"clingo" at your earliest convenience. The original concretizer '
+                   'will be removed from Spack starting at v0.18.0')
             warnings.warn(msg)
 
         if not self.name:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2357,13 +2357,15 @@ class Spec(object):
 
         return changed
 
-    def _old_concretize(self, tests=False):
+    def _old_concretize(self, tests=False, deprecation_warning=True):
         """A spec is concrete if it describes one build of a package uniquely.
         This will ensure that this spec is concrete.
 
         Args:
             tests (list or bool): list of packages that will need test
                 dependencies, or True/False for test all/none
+            deprecation_warning (bool): enable or disable the deprecation
+                warning for the old concretizer
 
         If this spec could describe more than one version, variant, or build
         of a package, this will add constraints to make it concrete.
@@ -2377,10 +2379,11 @@ class Spec(object):
 
         # Add a warning message to inform users that the original concretizer
         # will be removed in v0.18.0
-        msg = ('the original concretizer is currently being used.\n\tUpgrade to '
-               '"clingo" at your earliest convenience. The original concretizer '
-               'will be removed from Spack starting at v0.18.0')
-        warnings.warn(msg)
+        if deprecation_warning:
+            msg = ('the original concretizer is currently being used.\n\tUpgrade to '
+                '"clingo" at your earliest convenience. The original concretizer '
+                'will be removed from Spack starting at v0.18.0')
+            warnings.warn(msg)
 
         if not self.name:
             raise spack.error.SpecError(


### PR DESCRIPTION
With this PR you get the following output when both bootstrapping methods fail (I didn't install ca-certificates and make in an ubuntu container):

```
$ ./spack/bin/spack spec zlib
Input spec
--------------------------------
zlib

Concretized
--------------------------------
==> Bootstrapping clingo from pre-built binaries
==> Bootstrapping clingo from sources
==> Installing libiconv-1.16-zth4ohvj7y3p532iqjw7fptg3kkn3ixv
==> No binary for libiconv-1.16-zth4ohvj7y3p532iqjw7fptg3kkn3ixv found: installing from source
==> Using cached archive: /home/harmen/spack/var/spack/cache/_source-cache/archive/e6/e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04.tar.gz
==> No patches needed for libiconv
==> libiconv: Executing phase: 'autoreconf'
==> libiconv: Executing phase: 'configure'
==> libiconv: Executing phase: 'build'
==> Error: ProcessError: make: No such file or directory
    Command: 'make' '-j16' 'V=1'
See build log for details:
  /tmp/root/spack-stage/spack-stage-libiconv-1.16-zth4ohvj7y3p532iqjw7fptg3kkn3ixv/spack-build-out.txt

==> Warning: Skipping build of diffutils-3.8-4rwlz7r3qbaxxw5pkfxm67rakinywxli since libiconv-1.16-zth4ohvj7y3p532iqjw7fptg3kkn3ixv failed
==> Warning: Skipping build of bison-3.7.6-omerd6jkiab7src3hkrc5q36gqyxsnbv since diffutils-3.8-4rwlz7r3qbaxxw5pkfxm67rakinywxli failed
==> Warning: Skipping build of clingo-bootstrap-spack-3noqr57b5x2yabkr3oplw6nodw42zx2k since bison-3.7.6-omerd6jkiab7src3hkrc5q36gqyxsnbv failed
==> Warning: Skipping build of bzip2-1.0.8-acrm735zgsyk4wgjgz3o4jlq5vq5h4jd since diffutils-3.8-4rwlz7r3qbaxxw5pkfxm67rakinywxli failed
==> Warning: Skipping build of perl-5.34.0-mdh4pnqbunno4o2mkaa7q7gexnwjd6kg since bzip2-1.0.8-acrm735zgsyk4wgjgz3o4jlq5vq5h4jd failed
==> Warning: Skipping build of openssl-1.1.1l-7kailyhg3esql5mlv34myo7wwyfyloth since perl-5.34.0-mdh4pnqbunno4o2mkaa7q7gexnwjd6kg failed
==> Warning: Skipping build of cmake-3.21.3-mh6eyehef6pqisd7frult6jignowcftp since openssl-1.1.1l-7kailyhg3esql5mlv34myo7wwyfyloth failed
==> Error: Cannot bootstrap the "clingo" Python module from spec "clingo-bootstrap@spack+python %gcc target=x86_64" due to the following failures:
    'github-actions' raised RuntimeError: Could not populate the binary index
    'spack-install' raised InstallError: Terminating after first install failure: ProcessError: make: No such file or directory
    Command: 'make' '-j16' 'V=1'
    Please run `spack -d spec zlib` for more verbose error messages
```

Also note that bootstrapping from sources fails fast now, which has the additional benefit of actually getting the original install error from the specific package, so you immediately see you have a missing dependency.

