### PR TITLE
Allow non-empty ranges 1.1.0:1.1

### DIFF
--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -16,7 +16,7 @@ from llnl.util.filesystem import working_dir
 import spack.package
 import spack.spec
 from spack.util.executable import which
-from spack.version import Version, VersionList, ver
+from spack.version import Version, VersionList, VersionRange, ver
 
 
 def assert_ver_lt(a, b):
@@ -602,3 +602,15 @@ def test_versions_from_git(mock_git_version_info, monkeypatch, mock_packages):
             expected = f.read()
 
         assert str(comparator) == expected
+
+
+def test_version_range_nonempty():
+    assert Version('1.2.9') in VersionRange('1.2.0', '1.2')
+    assert Version('1.1.1') in ver('1.0:1')
+
+
+def test_empty_version_range_raises():
+    with pytest.raises(ValueError):
+        assert VersionRange('2', '1.0')
+    with pytest.raises(ValueError):
+        assert ver('2:1.0')

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -500,7 +500,16 @@ class VersionRange(object):
 
         self.start = start
         self.end = end
-        if start and end and end < start:
+
+        # Unbounded ranges are not empty
+        if not start or not end:
+            return
+
+        # Do not allow empty ranges. We have to be careful about lexicographical
+        # ordering of versions here: 1.2 < 1.2.3 lexicographically, but 1.2.3:1.2
+        # means the range [1.2.3, 1.3), which is non-empty.
+        min_len = min(len(start), len(end))
+        if end.up_to(min_len) < start.up_to(min_len):
             raise ValueError("Invalid Version range: %s" % self)
 
     def lowest(self):


### PR DESCRIPTION
Spack thinks that `1.1.0:1.1` is an empty range because it uses `end < start` as a criterion for being empty, but `<` uses lexicographical ordering where `1.1 < 1.1.0` holds.

This criterion is incorrect, because `1.1.0:1.1` means the closed open range `[1.1.0, 1.2)` which contains an infinite number of versions. Just like `1.1:1.2` means `[1.1, 1.3)`.

This PR fixes the logic by doing a `<` comparison on the truncated version to common length, so `1.1.0:1.1` is non-empty because `1.1 < 1.1` is not true.

After this PR, we can simplify a bunch of packages that put upper bounds on major versions, like this:

```diff
-    depends_on('py-botocore@1.21.12:1.21.999',  when='@1.18.12:', type=('build', 'run'))
-    depends_on('py-botocore@1.20.27:1.20.999',  when='@1.17.27', type=('build', 'run'))
-    depends_on('py-botocore@1.13.44:1.13.999',  when='@1.10.44', type=('build', 'run'))
-    depends_on('py-botocore@1.13.38:1.13.999',  when='@1.10.38', type=('build', 'run'))
-    depends_on('py-botocore@1.12.169:1.12.999', when='@1.9.169', type=('build', 'run'))
+    depends_on('py-botocore@1.21.12:1.21',  when='@1.18.12:', type=('build', 'run'))
+    depends_on('py-botocore@1.20.27:1.20',  when='@1.17.27', type=('build', 'run'))
+    depends_on('py-botocore@1.13.44:1.13',  when='@1.10.44', type=('build', 'run'))
+    depends_on('py-botocore@1.13.38:1.13',  when='@1.10.38', type=('build', 'run'))
+    depends_on('py-botocore@1.12.169:1.12', when='@1.9.169', type=('build', 'run'))
```

In fact all packages respecting semver benefit from `0.y.0:0.y` (where `0.[y+1].0` is breaking) or `x.y:x` (where `[x+1].0` is breaking) type of bounds
