### PR TITLE
intel-oneapi-mkl: Add shared library option + static lib fix

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -65,9 +65,11 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         shared = True if '+shared' in self.spec else False
         mkl_libs = [self.xlp64_lib('libmkl_intel'), 'libmkl_sequential', 'libmkl_core']
         libs = find_libraries(mkl_libs,
-                              join_path(self.component_path, 'lib', 'intel64'), shared=shared)
+                              join_path(self.component_path, 'lib', 'intel64'),
+                                        shared=shared)
         if not shared:
-            libs = LibraryList(['-Wl,--start-group'] + libs.libraries + ['-Wl,--end-group'])
+            libs = LibraryList(['-Wl,--start-group'] + libs.libraries +
+                               ['-Wl,--end-group'])
 
         libs += find_system_libraries(['libpthread', 'libm', 'libdl'])
         return libs

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -34,6 +34,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                 sha256='818b6bd9a6c116f4578cda3151da0612ec9c3ce8b2c8a64730d625ce5b13cc0c',
                 expand=False)
 
+    variant('shared', default=True, description='Builds shared library')
     variant('ilp64', default=False,
             description='Build with ILP64 support')
 
@@ -61,8 +62,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     @property
     def libs(self):
+        shared = True if '+shared' in self.spec else False
         mkl_libs = [self.xlp64_lib('libmkl_intel'), 'libmkl_sequential', 'libmkl_core']
         libs = find_libraries(mkl_libs,
-                              join_path(self.component_path, 'lib', 'intel64'))
+                              join_path(self.component_path, 'lib', 'intel64'), shared=shared)
+        if not shared:
+            libs = LibraryList(['-Wl,--start-group'] + libs.libraries + ['-Wl,--end-group'])
+
         libs += find_system_libraries(['libpthread', 'libm', 'libdl'])
         return libs


### PR DESCRIPTION
Added option for shared libraries.

Also fixed circular dependency when only using static libraries.