### PR TITLE
fltk: new version 1.3.7, new variant xft

### DIFF
--- a/var/spack/repos/builtin/packages/fltk/package.py
+++ b/var/spack/repos/builtin/packages/fltk/package.py
@@ -20,7 +20,10 @@ class Fltk(Package):
     """
     homepage = 'https://www.fltk.org/'
     url = 'https://fltk.org/pub/fltk/1.3.3/fltk-1.3.3-source.tar.gz'
+    git = 'https://github.com/fltk/fltk.git'
 
+    version('master', branch='master')
+    version('1.3.7', sha256='5d2ccb7ad94e595d3d97509c7a931554e059dd970b7b29e6fd84cb70fd5491c6')
     version('1.3.3', sha256='f8398d98d7221d40e77bc7b19e761adaf2f1ef8bb0c30eceb7beb4f2273d0d97')
 
     depends_on('libx11')
@@ -41,8 +44,13 @@ class Fltk(Package):
     variant('gl', default=True,
             description='Enables opengl support')
 
+    variant('xft', default=False,
+            description='Enables Anti-Aliased Fonts')
+
     # variant dependencies
     depends_on('gl', when='+gl')
+
+    depends_on('libxft', when='+xft')
 
     def install(self, spec, prefix):
         options = ['--prefix=%s' % prefix,
@@ -52,6 +60,12 @@ class Fltk(Package):
 
         if '+shared' in spec:
             options.append('--enable-shared')
+
+        if '+xft' in spec:
+            # https://www.fltk.org/articles.php?L374+I0+TFAQ+P1+Q
+            options.append('--enable-xft')
+        else:
+            options.append('--disable-xft')
 
         if '~gl' in spec:
             options.append('--disable-gl')


### PR DESCRIPTION
There has been reports of `gmsh` not finding symbol `XGetUtf8FontAndGlyph` in fltk.
Using latest fltk release, 1.3.7 seems to solve the issue at least on Ubuntu 21,
 $ spack debug report
* **Spack:** 0.16.2-4553-b96d836a72
* **Python:** 3.9.5
* **Platform:** linux-ubuntu21.04-x86_64_v2
* **Concretizer:** original

Also, it seems that explicitly setting `--enable-xft` for Anti-Aliased Fonts is better than relying on `fltk` defaults.
See https://www.fltk.org/articles.php?L374+I0+TFAQ+P1+Q
What do you think @amaji, as a recent contributor to fltk ?
This PR may interest @antiskid56 with issue #22095 (where libxft dependency was missing)
and @maruthinh with issue #26051.
It also solved issue #26408 that I reported.
Note that it may be interesting to switch from 'Package' to 'AutotoolsPackage', maybe the reviewer could tell what he thinks.
I would be glad if @sethrj could review that (once more !) since he reviewed one of my PRs on gmsh which is a dependency. As you can see, the default is ~xft despite +xft solves the "gmsh not finding symbol issue" even with fltk release 1.3.3. This is because ~xft is what is perfomed by fltk 1.3.3 as a default (despite 'configure' indicates the contrary). Last, I checked `octave` was OK with 1.3.7.
