### PR TITLE
Fix the FORM package

### DIFF
--- a/var/spack/repos/builtin/packages/form/package.py
+++ b/var/spack/repos/builtin/packages/form/package.py
@@ -17,8 +17,8 @@ class Form(AutotoolsPackage):
     version('4.1-20131025', sha256='fb3470937d66ed5cb1af896b15058836d2c805d767adac1b9073ed2df731cbe9',
             url='https://github.com/vermaseren/form/releases/download/v4.1-20131025/form-4.1.tar.gz')
 
-    depends_on('gmp',      type='link', when='+zlib')
-    depends_on('zlib',     type='link', when='+gmp')
+    depends_on('gmp',      type='link', when='+gmp')
+    depends_on('zlib',     type='link', when='+zlib')
     depends_on('mpi',      type='link', when='+parform')
 
     variant('gmp', default=False, description='Use GMP for long integer arithmetic')

--- a/var/spack/repos/builtin/packages/form/package.py
+++ b/var/spack/repos/builtin/packages/form/package.py
@@ -21,8 +21,8 @@ class Form(AutotoolsPackage):
     depends_on('zlib',     type='link', when='+zlib')
     depends_on('mpi',      type='link', when='+parform')
 
-    variant('gmp', default=False, description='Use GMP for long integer arithmetic')
-    variant('zlib', default=False, description='Use zlib for compression')
+    variant('gmp', default=True, description='Use GMP for long integer arithmetic')
+    variant('zlib', default=True, description='Use zlib for compression')
     variant('scalar', default=True, description='Build scalar version (form)')
     variant('threaded', default=True, description='Build threaded version (tform)')
     variant('parform', default=False, description='Build parallel version using MPI (parform)')

--- a/var/spack/repos/builtin/packages/form/package.py
+++ b/var/spack/repos/builtin/packages/form/package.py
@@ -10,16 +10,13 @@ class Form(AutotoolsPackage):
     """FORM is a Symbolic Manipulation System."""
 
     homepage = "https://www.nikhef.nl/~form/"
-    url      = "https://github.com/vermaseren/form/archive/v4.2.1.tar.gz"
+    url      = "https://github.com/vermaseren/form/releases/download/v4.2.1/form-4.2.1.tar.gz"
     maintainers = ['iarspider']
 
-    version('4.2.1', sha256='6f32c7470d00e8ab6934dc352f5a78e29290146a00e5775f8cd5fef7810bbbb8')
-    version('4.1-20131025', sha256='caece2c6e605ccf32eb3612c4ed5c9257a7a62824ad219c5e46b6d00066f1ba6')
+    version('4.2.1', sha256='f2722d6d4ccb034e01cf786d55342e1c21ff55b182a4825adf05d50702ab1a28')
+    version('4.1-20131025', sha256='fb3470937d66ed5cb1af896b15058836d2c805d767adac1b9073ed2df731cbe9',
+            url='https://github.com/vermaseren/form/releases/download/v4.1-20131025/form-4.1.tar.gz')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
     depends_on('gmp',      type='link', when='+zlib')
     depends_on('zlib',     type='link', when='+gmp')
     depends_on('mpi',      type='link', when='+parform')

--- a/var/spack/repos/builtin/packages/form/package.py
+++ b/var/spack/repos/builtin/packages/form/package.py
@@ -11,7 +11,7 @@ class Form(AutotoolsPackage):
 
     homepage = "https://www.nikhef.nl/~form/"
     url      = "https://github.com/vermaseren/form/releases/download/v4.2.1/form-4.2.1.tar.gz"
-    maintainers = ['iarspider']
+    maintainers = ['iarspider', 'tueda']
 
     version('4.2.1', sha256='f2722d6d4ccb034e01cf786d55342e1c21ff55b182a4825adf05d50702ab1a28')
     version('4.1-20131025', sha256='fb3470937d66ed5cb1af896b15058836d2c805d767adac1b9073ed2df731cbe9',


### PR DESCRIPTION
- The first commit aims to fetch the correct tarballs.
- The second one fixes the dependency.

---

The first one may need some explanation. Currently, `form` executables installed via Spack do not know revision information correctly. Indeed, the build dates are printed:
```
# form@4.2.1
$ form -v
FORM 4.2 (Oct  2 2021) 64-bits
  0.00 sec out of 0.00 sec
```
```
# form@4.1-20131025
$ form -v
FORM 4.1 (Oct  2 2021) 64-bits
  0.00 sec out of 0.00 sec
```
This is because the fetched tarballs are not intended to be used for build and do not contain detailed revision information. You see some warnings about the revision information on running `spack install -v form@4.2.1`:
```
========================================================================
Failed to determine the revision of the source code.

The reason may be
  - this is neither a source distribution (containing the configure
    script) nor a cloned Git repository,
  - this is a shallow clone and no version tags are reachable,
  - some required utilities (e.g., git) are missing.

Source distributions and some binaries can be found in:

  http://www.nikhef.nl/~form/maindir/binaries/binaries.html
  https://github.com/vermaseren/form/releases

The latest source code can be cloned by:

  git clone https://github.com/vermaseren/form.git

You can continue the build, but binaries will not contain the revision
information.
========================================================================
```
After applying the first commit, `form` prints the revision information correctly:
```
# form@4.2.1
$ form -v
FORM 4.2.1 (Nov 21 2018, v4.2.1) 64-bits
  0.00 sec out of 0.00 sec
```
```
# form@4.1-20131025
$ form -v
FORM 4.1 (Oct 25 2013) 64-bits
  0.00 sec out of 0.00 sec
```