### PR TITLE
Avoid replacing symlinked spack.yaml when concretizing an environment

### DIFF
--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1944,10 +1944,7 @@ class Environment(object):
         written = os.path.exists(self.manifest_path)
         if changed or not written:
             self.raw_yaml = copy.deepcopy(self.yaml)
-            real_manifest_path = self.manifest_path
-            if os.path.islink(self.manifest_path):
-                real_manifest_path = os.readlink(self.manifest_path)
-            with fs.write_tmp_and_move(real_manifest_path) as f:
+            with fs.write_tmp_and_move(os.path.realpath(self.manifest_path)) as f:
                 _write_yaml(self.yaml, f)
 
     def __enter__(self):

--- a/lib/spack/spack/environment.py
+++ b/lib/spack/spack/environment.py
@@ -1944,7 +1944,10 @@ class Environment(object):
         written = os.path.exists(self.manifest_path)
         if changed or not written:
             self.raw_yaml = copy.deepcopy(self.yaml)
-            with fs.write_tmp_and_move(self.manifest_path) as f:
+            real_manifest_path = self.manifest_path
+            if os.path.islink(self.manifest_path):
+                real_manifest_path = os.readlink(self.manifest_path)
+            with fs.write_tmp_and_move(real_manifest_path) as f:
                 _write_yaml(self.yaml, f)
 
     def __enter__(self):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -249,20 +249,22 @@ def test_env_install_same_spec_twice(install_mockery, mock_fetch):
 
 
 def test_env_definition_symlink(install_mockery, mock_fetch, tmpdir):
-    filename = 'spack.yaml'
-    filepath = str(tmpdir.join(filename))
+    filepath = str(tmpdir.join('spack.yaml'))
+    filepath_mid = str(tmpdir.join('spack_mid.yaml'))
 
     env('create', 'test')
     e = ev.read('test')
     e.add('mpileaks')
 
     os.rename(e.manifest_path, filepath)
-    os.symlink(filepath, e.manifest_path)
+    os.symlink(filepath, filepath_mid)
+    os.symlink(filepath_mid, e.manifest_path)
 
     e.concretize()
     e.write()
 
     assert os.path.islink(e.manifest_path)
+    assert os.path.islink(filepath_mid)
 
 
 def test_env_install_two_specs_same_dep(

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -248,6 +248,23 @@ def test_env_install_same_spec_twice(install_mockery, mock_fetch):
         assert 'already installed' in out
 
 
+def test_env_definition_symlink(install_mockery, mock_fetch, tmpdir):
+    filename = 'spack.yaml'
+    filepath = str(tmpdir.join(filename))
+
+    env('create', 'test')
+    e = ev.read('test')
+    e.add('mpileaks')
+
+    os.replace(e.manifest_path, filepath)
+    os.symlink(filepath, e.manifest_path)
+
+    e.concretize()
+    e.write()
+
+    assert os.path.islink(e.manifest_path)
+
+
 def test_env_install_two_specs_same_dep(
         install_mockery, mock_fetch, tmpdir, capsys):
     """Test installation of two packages that share a dependency with no

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -256,7 +256,7 @@ def test_env_definition_symlink(install_mockery, mock_fetch, tmpdir):
     e = ev.read('test')
     e.add('mpileaks')
 
-    os.replace(e.manifest_path, filepath)
+    os.rename(e.manifest_path, filepath)
     os.symlink(filepath, e.manifest_path)
 
     e.concretize()


### PR DESCRIPTION
fixes #26231 - Status: 1 unittest FAIL, codecov FAIL