### PR TITLE
[podio] add supported build_type values

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -28,7 +28,7 @@ class Podio(CMakePackage):
 
     variant('build_type', default='Release',
             description='The build type to build',
-            values=('Debug', 'RelWithDebInfo', 'MinSizeRel', 'Release')
+            values=('Debug', 'RelWithDebInfo', 'MinSizeRel', 'Release'))
 
     variant('sio', default=False,
             description='Build the SIO I/O backend')

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -28,7 +28,7 @@ class Podio(CMakePackage):
 
     variant('build_type', default='Release',
             description='The build type to build',
-            values=('Debug', 'Release'))
+            values=('Debug', 'RelWithDebInfo', 'MinSizeRel', 'Release')
 
     variant('sio', default=False,
             description='Build the SIO I/O backend')


### PR DESCRIPTION
"Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo"
Ref: https://github.com/AIDASoft/podio/blob/master/CMakeLists.txt#L24

This is partly for completeness, but also because we typically build environments with RelWithDebInfo during development.