### PR TITLE
add hash field to spec on find --json and assert in test its there

### DIFF
--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -262,20 +262,16 @@ def display_specs_as_json(specs, deps=False):
         dag_hash = spec.dag_hash()
         if dag_hash in seen:
             continue
+        records.append(spec.node_dict_with_hashes())
         seen.add(dag_hash)
-        record = spec.to_node_dict()
-        record["hash"] = dag_hash
-        records.append(record)
 
         if deps:
             for dep in spec.traverse():
                 dep_dag_hash = dep.dag_hash()
                 if dep_dag_hash in seen:
                     continue
+                records.append(dep.node_dict_with_hashes())
                 seen.add(dep_dag_hash)
-                record = dep.to_node_dict()
-                record["hash"] = dep_dag_hash
-                records.append(record)
 
     sjson.dump(records, sys.stdout)
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -259,17 +259,23 @@ def display_specs_as_json(specs, deps=False):
     seen = set()
     records = []
     for spec in specs:
-        if spec.dag_hash() in seen:
+        dag_hash = spec.dag_hash()
+        if dag_hash in seen:
             continue
-        seen.add(spec.dag_hash())
-        records.append(spec.to_node_dict())
+        seen.add(dag_hash)
+        record = spec.to_node_dict()
+        record["hash"] = dag_hash
+        records.append(record)
 
         if deps:
             for dep in spec.traverse():
-                if dep.dag_hash() in seen:
+                dep_dag_hash = dep.dag_hash()
+                if dep_dag_hash in seen:
                     continue
-                seen.add(dep.dag_hash())
-                records.append(dep.to_node_dict())
+                seen.add(dep_dag_hash)
+                record = dep.to_node_dict()
+                record["hash"] = dep_dag_hash
+                records.append(record)
 
     sjson.dump(records, sys.stdout)
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -128,6 +128,7 @@ def test_namespaces_shown_correctly(database):
 def _check_json_output(spec_list):
     assert len(spec_list) == 3
     assert all(spec["name"] == "mpileaks" for spec in spec_list)
+    assert all(spec["hash"] for spec in spec_list)
 
     deps = [spec["dependencies"] for spec in spec_list]
     assert sum(["zmpi" in [node["name"] for d in deps for node in d]]) == 1


### PR DESCRIPTION
Closes https://github.com/spack/spack/issues/26348

Added a new "hash" field to json dict spec only on `display_specs_as_json`. 

Shouldn't` break compatibility as this command is only used by the `find --json` output.

I'm deliberately being verbose on the implementation to allow people to further change (if needed) this behaviour. I have considered adding another argument to output hashed json but discarded it due to the minimal changes this implementation had.