### PR TITLE
FEniCSx: fix CMake root directory and dependency versions

### DIFF
--- a/var/spack/repos/builtin/packages/fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/fenics-basix/package.py
@@ -29,4 +29,4 @@ class FenicsBasix(CMakePackage):
     def root_cmakelists_dir(self):
         if self.spec.satisfies("@main"):
             return "cpp"
-        return None
+        return self.stage.source_path

--- a/var/spack/repos/builtin/packages/fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/fenics-basix/package.py
@@ -23,9 +23,10 @@ class FenicsBasix(CMakePackage):
     depends_on("xtl@0.7.2:")
     depends_on("xtensor@0.23.10:")
     depends_on("blas", type=("build", "run"))
+    depends_on("lapack", type=("build", "run"))
 
     @property
-    def root_cmake_lists_dir(self):
+    def root_cmakelists_dir(self):
         if self.spec.satisfies("@main"):
             return "cpp"
         return None

--- a/var/spack/repos/builtin/packages/fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/fenics-basix/package.py
@@ -22,8 +22,8 @@ class FenicsBasix(CMakePackage):
     depends_on("cmake@3.18:", type="build")
     depends_on("xtl@0.7.2:")
     depends_on("xtensor@0.23.10:")
-    depends_on("blas", type=("build", "run"))
-    depends_on("lapack", type=("build", "run"))
+    depends_on("blas")
+    depends_on("lapack")
 
     @property
     def root_cmakelists_dir(self):

--- a/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/fenics-dolfinx/package.py
@@ -12,7 +12,7 @@ class FenicsDolfinx(CMakePackage):
     homepage = "https://github.com/FEniCS/dolfinx"
     git = "https://github.com/FEniCS/dolfinx.git"
     url = "https://github.com/FEniCS/dolfinx/archive/v0.1.0.tar.gz"
-    maintainers = ["js947", "chrisrichardson", "garth-wells"]
+    maintainers = ["chrisrichardson", "garth-wells", "nate-sime"]
 
     version("main", branch="main")
     version("0.3.0", sha256="4857d0fcb44a4e9bf9eb298ba5377abdee17a7ad0327448bdd06cce73d109bed")

--- a/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
@@ -44,7 +44,7 @@ class PyFenicsDolfinx(PythonPackage):
     depends_on("py-fenics-ffcx@0.2.0", type="run", when="@0.2.0")
     depends_on("py-fenics-ffcx@0.1.0", type="run", when="@0.1.0")
     depends_on("py-fenics-ufl@main", type="run", when="@main")
-    depends_on("py-fenics-ufl@2021.1.0", type="run", when="@0.1:")
+    depends_on("py-fenics-ufl@2021.1.0", type="run", when="@0.1:0.3.99")
 
     depends_on("py-cffi", type="run")
     depends_on("py-numpy", type="run")

--- a/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-dolfinx/package.py
@@ -13,7 +13,7 @@ class PyFenicsDolfinx(PythonPackage):
     homepage = "https://github.com/FEniCS/dolfinx"
     url = "https://github.com/FEniCS/dolfinx/archive/v0.1.0.tar.gz"
     git = "https://github.com/FEniCS/dolfinx.git"
-    maintainers = ["js947", "chrisrichardson", "garth-wells"]
+    maintainers = ["chrisrichardson", "garth-wells", "nate-sime"]
 
     version("main", branch="main")
     version("0.3.0", sha256="4857d0fcb44a4e9bf9eb298ba5377abdee17a7ad0327448bdd06cce73d109bed")


### PR DESCRIPTION
- Fixes a typo in `root_cmakelists_dir` for `fenics-basix`
- Fixes a dependency range in `py-fenics-dolfinx`
- Updates maintainers for  `fenics-dolfinx` and  `py-fenics-dolfinx`

Changes have been tested. 