### PR TITLE
git-annex: add 8.20210804 for amd64

### DIFF
--- a/var/spack/repos/builtin/packages/git-annex/package.py
+++ b/var/spack/repos/builtin/packages/git-annex/package.py
@@ -30,8 +30,10 @@ class GitAnnex(Package):
     #
     # Steps to find the static link e.g. for amd64:
     # - $ git clone https://downloads.kitenet.net/.git/
-    # - $ ls -la git-annex/linux/current/
-    #       gives for example for amd64
+    # - $ cd git-annex
+    # - $ ls -l git-annex/linux/current/
+    #   gives for example for amd64
+    #   git-annex-standalone-amd64.tar.gz ->
     #       ../../../.git/annex/objects/KM/Ff/SHA256E-s51276461--a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e.tar.gz/SHA256E-s51276461--a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e.tar.gz
     # - exchange "../../../" with "https://downloads.kitenet.net" and you have the link
     # the version to the link can be found in
@@ -41,10 +43,17 @@ class GitAnnex(Package):
     # broken and always behind
 
     if platform.system() == "Linux" and platform.machine() == "aarch64":
+        # git-annex-standalone-arm64.tar.gz
+
+        # release 8.20210804 was not properly updated for arm64 upstream
+        # the sha256sums of 8.20210622 and 8.20210804 were the same
         version('8.20210622', sha256='869f875e280db0cc3243d9d0d33492f1c3bc182053544c1d5eb0ec463125fe76',
                 url="https://downloads.kitenet.net/.git/annex/objects/MJ/p3/SHA256E-s55109776--869f875e280db0cc3243d9d0d33492f1c3bc182053544c1d5eb0ec463125fe76.tar.gz/SHA256E-s55109776--869f875e280db0cc3243d9d0d33492f1c3bc182053544c1d5eb0ec463125fe76.tar.gz")
 
     elif platform.system() == "Linux":
+        # git-annex-standalone-amd64.tar.gz
+        version('8.20210804', sha256='f9d4bec06dddaeced25eec5f46360223797363e608fe37cfa93b2481f0166e1f',
+                url="https://downloads.kitenet.net/.git/annex/objects/4M/J4/SHA256E-s51465538--f9d4bec06dddaeced25eec5f46360223797363e608fe37cfa93b2481f0166e1f.tar.gz/SHA256E-s51465538--f9d4bec06dddaeced25eec5f46360223797363e608fe37cfa93b2481f0166e1f.tar.gz")
         version('8.20210622', sha256='a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e',
                 url="https://downloads.kitenet.net/.git/annex/objects/KM/Ff/SHA256E-s51276461--a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e.tar.gz/SHA256E-s51276461--a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e.tar.gz")
 


### PR DESCRIPTION
The standalone tar ball for arm64 was not updated upstream and thus I could add the new release only for amd64.