### PR TITLE
py-templateflow: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-templateflow/package.py
+++ b/var/spack/repos/builtin/packages/py-templateflow/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyTemplateflow(PythonPackage):
+    """A python client to query TemplateFlow via pyBIDS."""
+
+    homepage = "https://github.com/templateflow/python-client"
+    pypi     = "templateflow/templateflow-0.7.1.tar.gz"
+
+    version('0.7.1', sha256='c6e8282d1ffbb5dca7bd704a12e02bd00021860b71a043c35716861910c7187f')
+
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools@40.9:', type='build')
+    depends_on('py-setuptools-scm+toml@3.4:', type='build')
+    depends_on('py-wheel', type='build')
+    depends_on('py-pybids@0.12.1:', type=('build', 'run'))
+    depends_on('py-requests', type=('build', 'run'))
+    depends_on('py-tqdm', type=('build', 'run'))


### PR DESCRIPTION
The build dependency on `py-wheel` was needed because otherwise built failed with the error
```
==> py-templateflow: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 1:
    '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/python-3.8.11-qb6vxvfx4xxepklct22lumb542nhqznm/bin/python3.8' '-s' 'setup.py' '--no-user-cfg' 'build'

1 warning found in build log:
  >> 3    WARNING: The wheel package is not available.
     4    $spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/python-3.8.11-qb6vxvfx4xxepklct22lu
          mb542nhqznm/bin/python3.8: No module named pip
     5    Traceback (most recent call last):
     6      File "$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-setuptools-57.4.0-3uj3pw
          t5mbrkpnlqkbsbuzojxswwqpp6/lib/python3.8/site-packages/setuptools/installer.py", line 75, in fetch_build_egg
     7        subprocess.check_call(cmd)
     8      File "$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/python-3.8.11-qb6vxvfx4xxep
          klct22lumb542nhqznm/lib/python3.8/subprocess.py", line 364, in check_call
     9        raise CalledProcessError(retcode, cmd)
```