### PR TITLE
build_environment: clean *_ROOT variables

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -184,6 +184,12 @@ def clean_environment():
     env.unset('LD_PRELOAD')
     env.unset('DYLD_INSERT_LIBRARIES')
 
+    # Avoid <packagename>_ROOT user variables overriding spack dependencies
+    # https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html
+    for varname in os.environ.keys():
+        if '_ROOT' in varname:
+            env.unset(varname)
+
     # On Cray "cluster" systems, unset CRAY_LD_LIBRARY_PATH to avoid
     # interference with Spack dependencies.
     # CNL requires these variables to be set (or at least some of them,

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -186,8 +186,9 @@ def clean_environment():
 
     # Avoid <packagename>_ROOT user variables overriding spack dependencies
     # https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html
+    # Spack needs SPACK_ROOT though, so we need to exclude that
     for varname in os.environ.keys():
-        if varname.endswith('_ROOT'):
+        if varname.endswith('_ROOT') and varname != 'SPACK_ROOT':
             env.unset(varname)
 
     # On Cray "cluster" systems, unset CRAY_LD_LIBRARY_PATH to avoid

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -187,7 +187,7 @@ def clean_environment():
     # Avoid <packagename>_ROOT user variables overriding spack dependencies
     # https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html
     for varname in os.environ.keys():
-        if '_ROOT' in varname:
+        if varname.endswith('_ROOT'):
             env.unset(varname)
 
     # On Cray "cluster" systems, unset CRAY_LD_LIBRARY_PATH to avoid


### PR DESCRIPTION
This will otherwise lead to user variables overriding the dependencies set up by spack - which should not happen. See https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html