### PR TITLE
log4cxx: new version and fix for c++11

### DIFF
--- a/var/spack/repos/builtin/packages/log4cxx/package.py
+++ b/var/spack/repos/builtin/packages/log4cxx/package.py
@@ -14,6 +14,7 @@ class Log4cxx(CMakePackage):
 
     maintainers = ['nicmcd']
 
+    version('0.12.1', sha256='7bea5cb477f0e31c838f0e1f4f498cc3b30c2eae74703ddda923e7e8c2268d22')
     version('0.12.0', sha256='bd5b5009ca914c8fa7944b92ea6b4ca6fb7d146f65d526f21bf8b3c6a0520e44')
 
     depends_on('cmake@3.13:', type='build')

--- a/var/spack/repos/builtin/packages/log4cxx/package.py
+++ b/var/spack/repos/builtin/packages/log4cxx/package.py
@@ -17,12 +17,18 @@ class Log4cxx(CMakePackage):
     version('0.12.1', sha256='7bea5cb477f0e31c838f0e1f4f498cc3b30c2eae74703ddda923e7e8c2268d22')
     version('0.12.0', sha256='bd5b5009ca914c8fa7944b92ea6b4ca6fb7d146f65d526f21bf8b3c6a0520e44')
 
+    variant('cxxstd', default='17', description='C++ standard',
+            values=('11', '17'), multi=False)
+
     depends_on('cmake@3.13:', type='build')
 
     depends_on('apr-util')
     depends_on('apr')
+    depends_on('boost+thread+system', when='cxxstd=11')
     depends_on('zlib')
     depends_on('zip')
 
     def cmake_args(self):
-        return [self.define('BUILD_TESTING', 'off')]
+        return [
+            self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'),
+            self.define('BUILD_TESTING', 'off')]


### PR DESCRIPTION
The removal of older versions of log4cxx from Spack, together with the failure of version 0.12.0 to build correctly for use by C++11 codes, broke dependent packages that do not use C++17. This PR restores the usability of log4cxx by C++11 codes.