### PR TITLE
zstd: fix install name on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -37,12 +37,17 @@ class Zstd(MakefilePackage):
     depends_on('lzma', when='+programs')
     depends_on('lz4', when='+programs')
 
+    def _make(self, *args):
+        # PREFIX must be defined on macOS even when building the library, since
+        # it gets hardcoded into the library's install_path
+        make('VERBOSE=1', 'PREFIX=' + self.prefix, '-C', *args)
+
     def build(self, spec, prefix):
-        make('-C', 'lib')
+        self._make('lib')
         if spec.variants['programs'].value:
-            make('-C', 'programs')
+            self._make('programs')
 
     def install(self, spec, prefix):
-        make('-C', 'lib', 'install', 'PREFIX={0}'.format(prefix))
+        self._make('lib', 'install')
         if spec.variants['programs'].value:
-            make('-C', 'programs', 'install', 'PREFIX={0}'.format(prefix))
+            self._make('programs', 'install')


### PR DESCRIPTION
Reverting from CMake to Make install caused `-install_path=/usr/local/lib/libzstd.1.dylib` to be hardcoded into the installed library. Now we explicitly pass the PREFIX into the build command so that the correct spack install path is saved. (I also added the verbose flag so it's easier to do a postmortem on the installed library.)

Fixes #26438 and also the ROOT install issue I had :)