### PR TITLE
mpl: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/mpl/package.py
+++ b/var/spack/repos/builtin/packages/mpl/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Mpl(CMakePackage):
+    """A C++17 message passing library based on MPI."""
+
+    homepage    = "https://rabauke.github.io/mpl/html/"
+    git         = "https://github.com/rabauke/mpl.git"
+    url         = "https://github.com/rabauke/mpl/archive/refs/tags/v0.1.tar.gz"
+    maintainers = ['rabauke']
+
+    version('develop', branch='master')
+    version('0.1', tag='v0.1')
+
+    depends_on('mpi')


### PR DESCRIPTION
[MPL](https://github.com/rabauke/mpl) is a header-only message passing library written in C++17 based on MPI. 

This is my first contribution to Spack, thus feedback or suggestions for improvement will be welcome.