### PR TITLE
Don't warn about includes when persisting an environment

### DIFF
--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -8,8 +8,6 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/env.py
    :lines: 36-
 """
-import warnings
-
 from llnl.util.lang import union_dicts
 
 import spack.schema.merged
@@ -169,11 +167,6 @@ def update(data):
     Returns:
         True if data was changed, False otherwise
     """
-    if 'include' in data:
-        msg = ("included configuration files should be updated manually"
-               " [files={0}]")
-        warnings.warn(msg.format(', '.join(data['include'])))
-
     if 'packages' in data:
         return spack.schema.packages.update(data['packages'])
     return False


### PR DESCRIPTION
If you use spack environments with includes, you get warnings of this type:

```
Warning: included configuration files should be updated manually [files=${SPACK_SYSTEM_CONFIG_PATH}/packages.yaml]
```

*every* time the environment is persisted to disk.

This is quite annoying, cause it looks like something is wrong with how you're using environments.

The thing is that during `env.write()`, Spack checks if the environment file is of some outdated format, which imho should not bother about included config in the first place. It's really about the environment file itself, not about external config.

So, it'd be better not to warn.
