### PR TITLE
Fix assumption v.concrete => isinstance(v, Version)

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4712,8 +4712,12 @@ class SpecParser(spack.parse.Parser):
         # Generate lookups for git-commit-based versions
         for spec in specs:
             # Cannot do lookups for versions in anonymous specs
-            # Only allow concrete versions using git for now
-            if spec.name and spec.versions.concrete and spec.version.is_commit:
+            # Only allow Version objects to use git for now
+            # Note: VersionRange(x, x) is currently concrete, hence isinstance(...).
+            if (
+                spec.name and spec.versions.concrete and
+                isinstance(spec.version, vn.Version) and spec.version.is_commit
+            ):
                 pkg = spec.package
                 if hasattr(pkg, 'git'):
                     spec.version.generate_commit_lookup(pkg)

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -628,3 +628,17 @@ def test_version_wrong_idx_type():
     v = Version('1.1')
     with pytest.raises(TypeError):
         v['0:']
+
+
+@pytest.mark.regression('26482')
+def test_version_list_with_range_included_in_concrete_version_interpreted_as_range():
+    # Note: this test only tests whether we can construct a version list of a range
+    # and a version, where the range is contained in the version when it is interpreted
+    # as a range. That is: Version('3.1') interpreted as VersionRange('3.1', '3.1').
+    # Cleary it *shouldn't* be interpreted that way, but that is how Spack currently
+    # behaves, and this test only ensures that creating a VersionList of this type
+    # does not throw like reported in the linked Github issue.
+    v = VersionList([Version('3.1'), VersionRange('3.1.1', '3.1.2')])
+
+    # This currently does not hold, but should hold.
+    # assert not v.concrete

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -638,7 +638,10 @@ def test_version_list_with_range_included_in_concrete_version_interpreted_as_ran
     # Cleary it *shouldn't* be interpreted that way, but that is how Spack currently
     # behaves, and this test only ensures that creating a VersionList of this type
     # does not throw like reported in the linked Github issue.
-    v = VersionList([Version('3.1'), VersionRange('3.1.1', '3.1.2')])
+    VersionList([Version('3.1'), VersionRange('3.1.1', '3.1.2')])
 
-    # This currently does not hold, but should hold.
-    # assert not v.concrete
+
+@pytest.mark.xfail
+def test_version_list_with_range_and_concrete_version_is_not_concrete():
+    v = VersionList([Version('3.1'), VersionRange('3.1.1', '3.1.2')])
+    assert v.concrete


### PR DESCRIPTION
Adds a test to ensure that versions like `3.1,3.1.1:3.1.2` do not throw when constructed.

Currently Spack interprets the Version `3.1` as the VersionRange `3.1:3.1` and then simplifies the VersionList to `3.1:3.1` as `3.1.1:3.1.2` is included in the range already.

That is a bug, but at least the buggy behavior is better than Spack raising an error when trying to construct `3.1,3.1.1:3.1.2`.


