### PR TITLE
Relax constraints in e4s pipelines

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -19,7 +19,7 @@ spack:
       - r-rcpp  # RPackage
       - ruby-rake  # RubyPackage
     - arch:
-      - '%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64'
+      - '%gcc target=x86_64'
 
   specs:
     - matrix:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -303,7 +303,7 @@ spack:
     #- variorum
 
   - arch:
-    - '%gcc@9.3.0 arch=linux-ubuntu20.04-ppc64le'
+    - '%gcc target=ppc64le'
 
 
   specs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -313,7 +313,7 @@ spack:
     #- variorum # root fails
 
   - arch:
-    - '%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64'
+    - '%gcc target=x86_64'
 
 
   specs:


### PR DESCRIPTION
Currently e4s and the "build systems" pipelines are requiring specific versions of the OS and of the GCC compiler. Both of these are mandated by the runner image that is used in the pipeline so:
1. Specifying them also in the `spack.yaml` is redundant
2. Each update of the runner image requires a corresponding update of the `spack.yaml`

This PR relaxes these constraints by maintaining the targets and compiler type.