### PR TITLE
precice: Add version 2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -21,6 +21,7 @@ class Precice(CMakePackage):
     tags = ['e4s']
 
     version('develop', branch='develop')
+    version('2.3.0', sha256='57bab08e8b986f5faa364689d470940dbd9c138e5cfa7b861793e7db56b89da3')
     version('2.2.1', sha256='bca8cedfb5c86656e4fdfaca5cb982b861f9aba926538fa4411bc0d015e09c1f')
     version('2.2.0', sha256='f8c4e0810dcaeb6a40a0fcab64b95c899f0121c968e0730416d4d2a97d39d0c4')
     version('2.1.1', sha256='729b7c24a7a61b3953bb70d96a954ad3a85729a29a35a288b59ba25661117064')


### PR DESCRIPTION
This PR adds version 2.3.0 of the xSDK member preCICE.