### PR TITLE
py-matplotlib: fix qhull dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -92,7 +92,10 @@ class PyMatplotlib(PythonPackage):
     depends_on('python@3.6:', when='@3.1:', type=('build', 'link', 'run'))
     depends_on('python@3.7:', when='@3.4:', type=('build', 'link', 'run'))
     depends_on('freetype@2.3:')  # freetype 2.6.1 needed for tests to pass
-    depends_on('qhull@2015.2:', when='@3.3:')
+    depends_on('qhull@2020.2:', when='@3.4:')
+    # starting from qhull 2020 libqhull.so on which py-matplotlib@3.3 versions
+    # rely on does not exist anymore, only libqhull_r.so
+    depends_on('qhull@2015.2:2020.1', when='@3.3.0:3')
     depends_on('libpng@1.2:')
     depends_on('py-setuptools', type=('build', 'run'))  # See #3813
     depends_on('py-certifi@2020.6.20:', when='@3.3.1:', type='build')


### PR DESCRIPTION
`py-matplotlib@3.3.4` installation was failing [1] because `libqhull.so` does not exist anymore in `qhull@ 2020.2` [2] whereas in `qhull@2020.1` it still is present [3]. 
In additional `py-matplotlib@3.4.3` requests an newer qhull minimal version now (see [here](https://matplotlib.org/stable/devel/dependencies.html))

[1]:
```
  >> 641    /usr/bin/ld: cannot find -lqhull
  >> 642    collect2: error: ld returned 1 exit status
  >> 643    error: command '$spack/lib/spack/env/gcc/gcc' failed with exit status 1
```
[2]:
```
lib
├── cmake
│   └── Qhull
│       ├── QhullConfig.cmake
│       ├── QhullConfigVersion.cmake
│       ├── QhullTargets.cmake
│       └── QhullTargets-relwithdebinfo.cmake
├── libqhullcpp.a
├── libqhull_r.so -> libqhull_r.so.8.0
├── libqhull_r.so.8.0 -> libqhull_r.so.8.0.2
├── libqhull_r.so.8.0.2
├── libqhullstatic.a
├── libqhullstatic_r.a
└── pkgconfig
    ├── qhullcpp.pc
    ├── qhull_r.pc
    ├── qhullstatic.pc
    └── qhullstatic_r.pc
```
[3]:
```
lib
├── cmake
│   └── Qhull
│       ├── QhullConfig.cmake
│       ├── QhullConfigVersion.cmake
│       ├── QhullTargets.cmake
│       └── QhullTargets-relwithdebinfo.cmake
├── libqhullcpp.a
├── libqhull_p.so -> libqhull_p.so.8.0
├── libqhull_p.so.8.0 -> libqhull_p.so.8.0.0
├── libqhull_p.so.8.0.0
├── libqhull_r.so -> libqhull_r.so.8.0
├── libqhull_r.so.8.0 -> libqhull_r.so.8.0.0
├── libqhull_r.so.8.0.0
├── libqhull.so -> libqhull.so.8.0
├── libqhull.so.8.0 -> libqhull.so.8.0.0
├── libqhull.so.8.0.0
├── libqhullstatic.a
├── libqhullstatic_r.a
└── pkgconfig
    ├── qhullcpp.pc
    ├── qhull.pc
    ├── qhull_r.pc
    ├── qhullstatic.pc
    └── qhullstatic_r.pc
```