### PR TITLE
Add v1.56.2 to Rclone

### DIFF
--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -11,10 +11,11 @@ class Rclone(Package):
        to and from various cloud storage providers"""
 
     homepage = "https://rclone.org"
-    url      = "https://github.com/ncw/rclone/releases/download/v1.56.1/rclone-v1.56.1.tar.gz"
+    url      = "https://github.com/ncw/rclone/releases/download/v1.56.2/rclone-v1.56.2.tar.gz"
 
     maintainers = ['alecbcs']
 
+    version('1.56.2', sha256='a8813d25c4640e52495fee83e525e76283c63f01d1cce8fbb58d8486b0c20c8a')
     version('1.56.1', sha256='090b4b082caa554812f341ae26ea6758b40338836122595d6283c60c39eb5a97')
     version('1.56.0', sha256='81d2eda23ebaad0a355aab6ff030712470a42505b94c01c9bb5a9ead9168cedb')
     version('1.55.1', sha256='25da7fc5c9269b3897f27b0d946919df595c6dda1b127085fda0fe32aa59d29d')


### PR DESCRIPTION
Add v1.56.2 to Rclone which includes multiple bug fixes. 

**Changelog:**

- serve http: Re-add missing auth to http service (Nolan Woods)
- build: Update golang.org/x/sys to fix crash on macOS when compiled with go1.17 (Herby Gillot)
- Fix deadlock after failed update when concurrency=1 (Ivan Andreev)

**Test Plan:**
Rclone v1.56.2 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/actions/runs/1298402762).
