### PR TITLE
use conflicts() instead of referring to SpecError in mesa

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -40,10 +40,10 @@ class Mesa(MesonPackage):
     # Internal options
     variant('llvm', default=True, description="Enable LLVM.")
     _SWR_AUTO_VALUE = 'auto'
-    _SWR_ENABLED_VALUES = [_SWR_AUTO_VALUE, 'avx', 'avx2', 'knl', 'skx']
-    _SWR_DISABLED_VALUE = 'none'
+    _SWR_ENABLED_VALUES = (_SWR_AUTO_VALUE, 'avx', 'avx2', 'knl', 'skx')
+    _SWR_DISABLED_VALUES = ('none',)
     variant('swr', default=_SWR_AUTO_VALUE,
-            values=(_SWR_DISABLED_VALUE,) + tuple(_SWR_ENABLED_VALUES),
+            values=_SWR_DISABLED_VALUES + _SWR_ENABLED_VALUES,
             multi=True,
             description="Enable the SWR driver.")
     for swr_enabled_value in _SWR_ENABLED_VALUES:

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -39,11 +39,15 @@ class Mesa(MesonPackage):
 
     # Internal options
     variant('llvm', default=True, description="Enable LLVM.")
-    variant('swr', default='auto',
-            values=('auto', 'none', 'avx', 'avx2', 'knl', 'skx'),
+    _SWR_AUTO_VALUE = 'auto'
+    _SWR_ENABLED_VALUES = [_SWR_AUTO_VALUE, 'avx', 'avx2', 'knl', 'skx']
+    _SWR_DISABLED_VALUE = 'none'
+    variant('swr', default=_SWR_AUTO_VALUE,
+            values=(_SWR_DISABLED_VALUE,) + tuple(_SWR_ENABLED_VALUES),
             multi=True,
             description="Enable the SWR driver.")
-    # conflicts('~llvm', when='~swr=none')
+    for swr_enabled_value in _SWR_ENABLED_VALUES:
+        conflicts('~llvm', when='swr={0}'.format(swr_enabled_value))
 
     # Front ends
     variant('osmesa', default=True, description="Enable the OSMesa frontend.")
@@ -192,8 +196,6 @@ class Mesa(MesonPackage):
                 args_swr_arches.append('skx')
 
         if args_swr_arches:
-            if '+llvm' not in spec:
-                raise SpecError('Variant swr requires +llvm')
             args_gallium_drivers.append('swr')
             args.append('-Dswr-arches=' + ','.join(args_swr_arches))
 


### PR DESCRIPTION
### Problem

`mesa` will try to raise a `SpecError` dynamically if it's told to enable the multi-valued `swr` variant when `+llvm` isn't also enabled. Two problems with this:
- The concretizer doesn't understand this and it will cause annoying failures for users who don't want to build all of llvm.
- `SpecError` isn't exported in the top-level `from spack import *` module that `.../mesa/package.py` imports at the top, causing a very confusing error while building the package.

### Solution
1. List the values of the `swr` variant that count as being "enabled", i.e. ones that will need llvm in order to build, as a private class-level variable `_SWR_ENABLED_VALUES`.
2. Make the commented-out `# conflicts('~llvm', when='~swr=none')` line work as intended, by adding a `conflicts(`~llvm`, ...)` for each "enabled" value of the `swr` variant.

### Result
`mesa`'s relationship between the `llvm` and `swr` variants is now visible to the concretizer!