### PR TITLE
py-mayavi: add 4.7.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-mayavi/package.py
+++ b/var/spack/repos/builtin/packages/py-mayavi/package.py
@@ -7,10 +7,12 @@
 class PyMayavi(PythonPackage):
     """Mayavi: 3D visualization of scientific data in Python."""
 
-    homepage = "https://docs.enthought.com/mayavi/mayavi/index.html"
-    pypi = "mayavi/mayavi-4.7.1.tar.bz2"
+    homepage = "https://github.com/enthought/mayavi"
+    pypi = "mayavi/mayavi-4.7.3.tar.gz"
 
-    version('4.7.1', sha256='be51fb6f886f304f7c593c907e6a2e88d7919f8f446cdccfcd184fa35b3db724')
+    version('4.7.3', sha256='670d0023b9cd2d2346c451db9ba2f61da23a5df5033b25aea89cb6d81b9464f0')
+    version('4.7.1', sha256='be51fb6f886f304f7c593c907e6a2e88d7919f8f446cdccfcd184fa35b3db724',
+            url='https://files.pythonhosted.org/packages/source/m/mayavi/mayavi-4.7.1.tar.bz2')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-apptools', type=('build', 'run'))
@@ -18,6 +20,9 @@ class PyMayavi(PythonPackage):
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-pyface@6.1.1:', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))
-    depends_on('py-traits@4.6.0:', type=('build', 'run'))
-    depends_on('py-traitsui@6.0.0:', type=('build', 'run'))
+    depends_on('py-traits@6:', when='@4.7.2:', type=('build', 'run'))
+    depends_on('py-traits@4.6:', type=('build', 'run'))
+    depends_on('py-traitsui@7:', when='@4.7.2:', type=('build', 'run'))
+    depends_on('py-traitsui@6:', type=('build', 'run'))
     depends_on('vtk+python', type=('build', 'run'))
+    depends_on('py-pyqt5', type=('build', 'run'))


### PR DESCRIPTION
version 4.7.1 seems to be broken (see #26561), but the newer patch release builds.

I got the dependencies from [mayavi/\_\_init\_\_.py](https://github.com/enthought/mayavi/blob/4.7.3/mayavi/__init__.py#L10) where `setup.py` reads them from and the `py-pytq5` dependency from [installation.rst](https://github.com/enthought/mayavi/blob/4.7.3/docs/source/mayavi/installation.rst#L28)