### PR TITLE
damask-3.0.0-alpha5

### DIFF
--- a/var/spack/repos/builtin/packages/damask-grid/package.py
+++ b/var/spack/repos/builtin/packages/damask-grid/package.py
@@ -13,16 +13,24 @@ class DamaskGrid(CMakePackage):
     maintainers = ['MarDieh']
 
     version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
+    version('3.0.0-alpha5', sha256='2d2b10901959c26a5bb5c52327cdafc7943bc1b36b77b515b0371221703249ae')
 
+    depends_on('pkgconfig', type='build')
     depends_on('cmake@3.10:', type='build')
-    depends_on('petsc+fftw@3.14.0:3.14,3.15.1:3.15')
+    depends_on('petsc@3.14.0:3.14,3.15.1:3.15', when='@3.0.0-alpha4')
+    depends_on('petsc@3.14.0:3.14,3.15.1:3.16', when='@3.0.0-alpha5')
     depends_on('hdf5+fortran')
+    depends_on('fftw+mpi')
 
     patch('CMakeDebugRelease.patch', when='@3.0.0-alpha4')
 
     variant('build_type', default='DebugRelease',
             description='The build type to build',
             values=('Debug', 'Release', 'DebugRelease'))
+
+    def patch(self):
+        filter_file(' -lhdf5 ', ' -lhdf5_fortran -lhdf5 ', 'CMakeLists.txt')
+        filter_file(' -lz ', ' -lz -lfftw3 -lfftw3_mpi ', 'CMakeLists.txt')
 
     def cmake_args(self):
         args = ['-DDAMASK_SOLVER:STRING=grid']

--- a/var/spack/repos/builtin/packages/damask-mesh/package.py
+++ b/var/spack/repos/builtin/packages/damask-mesh/package.py
@@ -13,9 +13,12 @@ class DamaskMesh(CMakePackage):
     maintainers = ['MarDieh']
 
     version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
+    version('3.0.0-alpha5', sha256='2d2b10901959c26a5bb5c52327cdafc7943bc1b36b77b515b0371221703249ae')
 
+    depends_on('pkgconfig', type='build')
     depends_on('cmake@3.10:', type='build')
-    depends_on('petsc@3.14.0:3.14,3.15.1:3.15')
+    depends_on('petsc@3.14.0:3.14,3.15.1:3.15', when='@3.0.0-alpha4')
+    depends_on('petsc@3.14.0:3.14,3.15.1:3.16', when='@3.0.0-alpha5')
     depends_on('hdf5+fortran')
 
     patch('CMakeDebugRelease.patch', when='@3.0.0-alpha4')
@@ -23,6 +26,9 @@ class DamaskMesh(CMakePackage):
     variant('build_type', default='DebugRelease',
             description='The build type to build',
             values=('Debug', 'Release', 'DebugRelease'))
+
+    def patch(self):
+        filter_file(' -lhdf5 ', ' -lhdf5_fortran -lhdf5 ', 'CMakeLists.txt')
 
     def cmake_args(self):
         args = ['-DDAMASK_SOLVER:STRING=mesh']

--- a/var/spack/repos/builtin/packages/damask/package.py
+++ b/var/spack/repos/builtin/packages/damask/package.py
@@ -26,7 +26,12 @@ class Damask(BundlePackage):
     maintainers = ['MarDieh']
 
     version('3.0.0-alpha4')
+    version('3.0.0-alpha5')
 
     depends_on('damask-grid@3.0.0-alpha4', when='@3.0.0-alpha4', type='run')
     depends_on('damask-mesh@3.0.0-alpha4', when='@3.0.0-alpha4', type='run')
     depends_on('py-damask@3.0.0-alpha4',   when='@3.0.0-alpha4', type='run')
+
+    depends_on('damask-grid@3.0.0-alpha5', when='@3.0.0-alpha5', type='run')
+    depends_on('damask-mesh@3.0.0-alpha5', when='@3.0.0-alpha5', type='run')
+    depends_on('py-damask@3.0.0-alpha5',   when='@3.0.0-alpha5', type='run')

--- a/var/spack/repos/builtin/packages/py-damask/package.py
+++ b/var/spack/repos/builtin/packages/py-damask/package.py
@@ -13,6 +13,7 @@ class PyDamask(PythonPackage):
     maintainers = ['MarDieh']
 
     version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
+    version('3.0.0-alpha5', sha256='2d2b10901959c26a5bb5c52327cdafc7943bc1b36b77b515b0371221703249ae')
 
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('vtk+python')


### PR DESCRIPTION
update from 3.0.0-alpha4 to damask-3.0.0-alpha5.
supports PETSc 3.16.x