### PR TITLE
Fix spack.platforms.host() slowness

### DIFF
--- a/lib/spack/spack/platforms/_functions.py
+++ b/lib/spack/spack/platforms/_functions.py
@@ -13,6 +13,7 @@ from .test import Test
 platforms = [Cray, Darwin, Linux, Test]
 
 
+@llnl.util.lang.memoized
 def _host():
     """Detect and return the platform for this machine or None if detection fails."""
     for platform_cls in sorted(platforms, key=lambda plt: plt.priority):


### PR DESCRIPTION
Current develop:

```
time spack python -c 'spack.store.db.query("environment-modules target=x86_64")'
real	0m5.402s
```

With this PR:
```
time spack python -c 'spack.store.db.query("environment-modules target=x86_64")'
real	0m1.582s
```

Before #25986 

```
$ time spack python -c 'spack.store.db.query("environment-modules target=x86_64")'
real    0m1.576s
```