### PR TITLE
motif: fix linking the simple_app demo program

### DIFF
--- a/var/spack/repos/builtin/packages/motif/package.py
+++ b/var/spack/repos/builtin/packages/motif/package.py
@@ -37,6 +37,13 @@ class Motif(AutotoolsPackage):
 
     patch('add_xbitmaps_dependency.patch')
 
+    def patch(self):
+        # fix linking the simple_app demo program
+        # https://bugs.launchpad.net/ubuntu/+source/openmotif/+bug/705294
+        filter_file('../../../lib/Exm/libExm.a',
+                    '../../../lib/Exm/libExm.a -lX11',
+                    'demos/programs/Exm/simple_app/Makefile.am')
+
     def autoreconf(self, spec, prefix):
         autoreconf = which('autoreconf')
         with working_dir(self.configure_directory):


### PR DESCRIPTION
Fixes the build of the package by adding the missing `-lX11` to the link command of the `simple_app` demo program

The matching report and fix is mentioned in the patch() function fixing the build.
https://bugs.launchpad.net/ubuntu/+source/openmotif/+bug/705294
