### PR TITLE
Fix for license symlinking issue.

### DIFF
--- a/lib/spack/spack/hooks/licensing.py
+++ b/lib/spack/spack/hooks/licensing.py
@@ -175,7 +175,7 @@ def symlink_license(pkg):
             mkdirp(license_dir)
 
         # If example file already exists, overwrite it with a symlink
-        if os.path.exists(link_name):
+        if os.path.lexists(link_name):
             os.remove(link_name)
 
         if os.path.exists(target):


### PR DESCRIPTION
When a symlink to a license file exists but is broken, the license symlink post-install hook fails
because os.path.exists() checks the existence of the target not the symlink itself.
os.path.lexists() is the proper function to use.