### PR TITLE
More strict ReadTheDocs tests

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,7 @@ version: 2
 
 sphinx:
   configuration: lib/spack/docs/conf.py
+  fail_on_warning: true
 
 python:
   version: 3.7


### PR DESCRIPTION
In #26450 we proposed to replace our GitHub Action for documentation testing with testing directly in ReadTheDocs. This PR ensures that warnings get translated to errors and our docs remain strictly tested.

We'll probably wait until the next time we add or rename tests to make the new RTD test required and remove the old GitHub Action test.