### PR TITLE
py-matplotlib: fix 3.4.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -93,7 +93,7 @@ class PyMatplotlib(PythonPackage):
     depends_on('python@3.7:', when='@3.4:', type=('build', 'link', 'run'))
     depends_on('freetype@2.3:')  # freetype 2.6.1 needed for tests to pass
     depends_on('qhull@2020.2:', when='@3.4:')
-    # starting from qhull 2020 libqhull.so on which py-matplotlib@3.3 versions
+    # starting from qhull 2020.2 libqhull.so on which py-matplotlib@3.3 versions
     # rely on does not exist anymore, only libqhull_r.so
     depends_on('qhull@2015.2:2020.1', when='@3.3.0:3.3')
     depends_on('libpng@1.2:')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -95,7 +95,7 @@ class PyMatplotlib(PythonPackage):
     depends_on('qhull@2020.2:', when='@3.4:')
     # starting from qhull 2020 libqhull.so on which py-matplotlib@3.3 versions
     # rely on does not exist anymore, only libqhull_r.so
-    depends_on('qhull@2015.2:2020.1', when='@3.3.0:3')
+    depends_on('qhull@2015.2:2020.1', when='@3.3.0:3.3')
     depends_on('libpng@1.2:')
     depends_on('py-setuptools', type=('build', 'run'))  # See #3813
     depends_on('py-certifi@2020.6.20:', when='@3.3.1:', type='build')


### PR DESCRIPTION
Sorry, it seems that I had a typo in #26553 for the version restriction. For `py-matplotlib@3.4.3` the qhull restrictions were contradicting:  'qhull@2020.2:' and 'qhull@2015.2:2020.1 where both true so that concretization failed when pinning it to that specific version. I only tested if `spack install --test=true py-matplolib` still worked and overlooked that it actually concretized to an older version, which ran through.
Fixed that now.