### PR TITLE
intel-gpu-tools: Fix build: libunwind, kmod, find glib, bump version

### DIFF
--- a/var/spack/repos/builtin/packages/intel-gpu-tools/package.py
+++ b/var/spack/repos/builtin/packages/intel-gpu-tools/package.py
@@ -21,10 +21,13 @@ class IntelGpuTools(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/app/intel-gpu-tools/"
     xorg_mirror_path = "app/intel-gpu-tools-1.16.tar.gz"
 
+    version('1.20', sha256='c6ee992301e43ec14ef810ef532e2601ecf7399315f942207ae0dd568fd9c2b7')
     version('1.16', sha256='4874e6e7704c8d315deaf5b44cc9467ea5e502c7f816470a4a28827fcb34643f')
 
     depends_on('libdrm@2.4.64:')
     depends_on('libpciaccess@0.10:', when=(sys.platform != 'darwin'))
+    depends_on('libunwind')
+    depends_on('kmod')
     depends_on('cairo@1.12.0:')
     depends_on('glib')
 
@@ -34,10 +37,13 @@ class IntelGpuTools(AutotoolsPackage, XorgPackage):
     depends_on('pkgconfig', type='build')
     depends_on('util-macros', type='build')
 
+    def configure_args(self):
+        glib_include = join_path(self.spec['glib'].prefix.include, 'glib-2.0')
+        return ['CPPFLAGS=-I{0}'.format(glib_include)]
+
     # xrandr ?
 
     # gtk-doc-tools
-    # libunwind-dev
     # python-docutils
     # x11proto-dri2-dev
     # xutils-dev


### PR DESCRIPTION
Add version 1.20, fix including the glib-2.0 header files
and add missing dependencies: libunwind and kmod.