### PR TITLE
gcc: support alternate mechanism for providing GCC rpaths

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -689,9 +689,15 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                     out.write('%(link_libgcc_rpath) ')
 
             # Add easily-overridable rpath string at the end
-            rpath = ':'.join([self.prefix.lib, self.prefix.lib64])
-            out.write('*link_libgcc_rpath:\n'
-                      '-rpath {0}\n'.format(rpath))
+            libdirs = [self.prefix.lib, self.prefix.lib64]
+            out.write('*link_libgcc_rpath:\n')
+            if 'platform=darwin' in spec:
+                # macOS linker requires separate rpath commands
+                out.write(' '.join('-rpath ' + lib for lib in libdirs))
+            else:
+                # linux linker uses colon-separated rpath
+                out.write('-rpath ' + ':'.join(libdirs))
+            out.write('\n')
         set_install_permissions(specs_file)
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
Spack's GCC install hardwires (through the specs file) the linker to adding an rpath entry to GCC's library dir, so that compiled binaries get the right libstdc++ etc. Unfortunately this leaves build tools like CMake unable to automatically remove those hardcoded paths when creating a relocatable installation.

My solution is to slightly refactor the way spack modifies the GCC `specs` file so that a simple robust spec file:
```
*link_libgcc_rpath:


```
and the linker option `--specs=norpath.spec` will skip the addition of the spack rpaths. (You can instead use CMake's `CMAKE_BUILD_RPATH` to provide the paths to the GCC libraries as needed). I've tested that the updated spec file works exactly like the original with single-line builds of an executable, as well as using GCC to generate shared libraries, and that the spec option above can disable the extra rpaths in both cases.

Fixes #26582 .

This *also* fixes the rpath construction on macOS, which has always been incorrect: rpaths must be given as separate rpath commands to the linker, rather than combined with a colon as is the case for linux.