### PR TITLE
Add version 8.1 for openCARP packages

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -15,7 +15,8 @@ class Meshtool(MakefilePackage):
     maintainers = ['MarieHouillon']
 
     version('master', branch='master')
-    # Version to use with opencarp@7.0
+    # Version to use with openCARP releases
+    version('oc8.1', commit="6c5cfbd067120901f15a04bf63beec409bda6dc9")
     version('oc7.0', commit="6c5cfbd067120901f15a04bf63beec409bda6dc9")
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -18,7 +18,8 @@ class Opencarp(CMakePackage):
 
     maintainers = ['MarieHouillon']
 
-    version('7.0', commit='78da9195', submodules=False, no_cache=True, preferred=True)
+    version('8.1', commit='28eb2e97', submodules=False, no_cache=True, preferred=True)
+    version('7.0', commit='78da9195', submodules=False, no_cache=True)
     version('master', branch='master', submodules=False, no_cache=True)
 
     variant('carputils', default=False, description='Installs the carputils framework')
@@ -39,7 +40,7 @@ class Opencarp(CMakePackage):
     depends_on('py-carputils')
     depends_on('meshtool')
     # Use specific versions of carputils and meshtool for releases
-    for ver in ['7.0']:
+    for ver in ['7.0', '8.1']:
         depends_on('py-carputils@oc' + ver, when='@' + ver + ' +carputils')
         depends_on('meshtool@oc' + ver, when='@' + ver + ' +meshtool')
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -13,7 +13,8 @@ class PyCarputils(PythonPackage):
     maintainers = ['MarieHouillon']
 
     version('master', branch='master')
-    # Version to use with openCARP 7.0
+    # Version to use with openCARP releases
+    version('oc8.1', commit='a4210fcb0fe17226a1744ee9629f85b629decba3')
     version('oc7.0', commit='4c04db61744f2fb7665594d7c810699c5c55c77c')
 
     depends_on('git')


### PR DESCRIPTION
Modify the following packages of the openCARP ecosystem for adding version 8.1 of openCARP:
- py-carputils (add version associated to openCARP 8.1)
- meshtool (add version associated to openCARP 8.1)
- opencarp (add version 8.1)