### PR TITLE
py-anytree: Add dep py-six@1.9.0 as required by setup.py

### DIFF
--- a/var/spack/repos/builtin/packages/py-anytree/package.py
+++ b/var/spack/repos/builtin/packages/py-anytree/package.py
@@ -16,4 +16,5 @@ class PyAnytree(PythonPackage):
     version('2.8.0', sha256='3f0f93f355a91bc3e6245319bf4c1d50e3416cc7a35cc1133c1ff38306bbccab')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-six@1.9.0:', type='build')
+    depends_on('py-six@1.9.0:', type=('build', 'run'))
+    depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-anytree/package.py
+++ b/var/spack/repos/builtin/packages/py-anytree/package.py
@@ -16,3 +16,4 @@ class PyAnytree(PythonPackage):
     version('2.8.0', sha256='3f0f93f355a91bc3e6245319bf4c1d50e3416cc7a35cc1133c1ff38306bbccab')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-six@1.9.0:', type='build')


### PR DESCRIPTION
setup.py has: `config['install_requires'] = ['six>=1.9.0']` :+1: 