### PR TITLE
py-traceback2: Fix depends_on: pbr -> six, add py-linecache2

### DIFF
--- a/var/spack/repos/builtin/packages/py-traceback2/package.py
+++ b/var/spack/repos/builtin/packages/py-traceback2/package.py
@@ -16,3 +16,5 @@ class PyTraceback2(PythonPackage):
 
     depends_on('py-setuptools', type='build')
     depends_on('py-pbr', type='build')
+    depends_on('py-six',        type=('build', 'run'))
+    depends_on('py-linecache2', type=('build', 'run'))


### PR DESCRIPTION
linecache2 is needed, pbr isn't used by this version, but six is.