### PR TITLE
Make macOS installed libraries more relocatable

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -645,3 +645,6 @@ To resolve this problem, please try the following:
             fs.mkdirp(os.path.dirname(self._removed_la_files_log))
             with open(self._removed_la_files_log, mode='w') as f:
                 f.write('\n'.join(libtool_files))
+
+    # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
+    run_after('install')(PackageBase.apply_macos_rpath_fixups)

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -110,3 +110,6 @@ class MakefilePackage(PackageBase):
 
     # Check that self.prefix is there after installation
     run_after('install')(PackageBase.sanity_check_prefix)
+
+    # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
+    run_after('install')(PackageBase.apply_macos_rpath_fixups)

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -19,7 +19,6 @@ from llnl.util.tty.color import colorize
 
 import spack.config
 import spack.projections
-import spack.relocate
 import spack.schema.projections
 import spack.spec
 import spack.store
@@ -73,6 +72,9 @@ def view_copy(src, dst, view, spec=None):
         # will have the old sbang location in their shebangs.
         # TODO: Not sure which one to use...
         import spack.hooks.sbang as sbang
+
+        # Break a package include cycle
+        import spack.relocate
 
         orig_sbang = '#!/bin/bash {0}/bin/sbang'.format(spack.paths.spack_root)
         new_sbang = sbang.sbang_shebang_line()

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -283,34 +283,27 @@ class PackageMeta(
 
         def _flush_callbacks(check_name):
             # Name of the attribute I am going to check it exists
-            attr_name = PackageMeta.phase_fmt.format(check_name)
-            checks = getattr(cls, attr_name)
+            check_attr = PackageMeta.phase_fmt.format(check_name)
+            checks = getattr(cls, check_attr)
             if checks:
                 for phase_name, funcs in checks.items():
+                    phase_attr = PackageMeta.phase_fmt.format(phase_name)
                     try:
                         # Search for the phase in the attribute dictionary
-                        phase = attr_dict[
-                            PackageMeta.phase_fmt.format(phase_name)]
+                        phase = attr_dict[phase_attr]
                     except KeyError:
                         # If it is not there it's in the bases
                         # and we added a check. We need to copy
                         # and extend
                         for base in bases:
-                            phase = getattr(
-                                base,
-                                PackageMeta.phase_fmt.format(phase_name),
-                                None
-                            )
+                            phase = getattr(base, phase_attr, None)
                             if phase is not None:
                                 break
 
-                        attr_dict[PackageMeta.phase_fmt.format(
-                            phase_name)] = phase.copy()
-                        phase = attr_dict[
-                            PackageMeta.phase_fmt.format(phase_name)]
+                        phase = attr_dict[phase_attr] = phase.copy()
                     getattr(phase, check_name).extend(funcs)
                 # Clear the attribute for the next class
-                setattr(cls, attr_name, {})
+                setattr(cls, check_attr, {})
 
         _flush_callbacks('run_before')
         _flush_callbacks('run_after')

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -1041,12 +1041,15 @@ def fixup_macos_rpath(root, filename):
 
     # Check for relocatable ID
     if id_dylib is None:
-        tty.info("No dylib ID is set for {0}".format(abspath))
+        tty.debug("No dylib ID is set for {0}".format(abspath))
     elif not id_dylib.startswith('@'):
         tty.debug("Non-relocatable dylib ID for {0}: {1}"
                   .format(abspath, id_dylib))
-        args += ['-id', '@rpath/' + filename]
-        add_rpaths.add(root)
+        if root in rpaths or root in add_rpaths:
+            args += ['-id', '@rpath/' + filename]
+        else:
+            tty.debug("Allowing hardcoded dylib ID because its rpath "
+                      "is *not* in the library already")
 
     for (rpath, count) in rpaths.items():
         if count > 1:

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -487,6 +487,11 @@ def test_fixup_macos_rpaths(make_dylib, make_object_file):
     (root, filename) = make_dylib("abs", no_rpath)
     assert not fixup_rpath(root, filename)
 
+    # Relocatable with executable paths and loader paths
+    (root, filename) = make_dylib("rpath", ['@executable_path/../lib',
+                                            '@loader_path'])
+    assert not fixup_rpath(root, filename)
+
     # Non-relocatable library id but nonexistent rpath
     (root, filename) = make_dylib("abs", bad_rpath)
     assert fixup_rpath(root, filename)

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import collections
 import os.path
-import platform
 import re
 import shutil
 
@@ -14,11 +13,19 @@ import llnl.util.filesystem
 
 import spack.concretize
 import spack.paths
+import spack.platforms
 import spack.relocate
 import spack.spec
 import spack.store
 import spack.tengine
 import spack.util.executable
+
+
+def skip_unless_linux(f):
+    return pytest.mark.skipif(
+        str(spack.platforms.real_host()) != 'linux',
+        reason='implementation currently requires linux'
+    )(f)
 
 
 def rpaths_for(new_binary):
@@ -179,10 +186,7 @@ def test_patchelf_is_relocatable():
     assert spack.relocate.file_is_relocatable(patchelf)
 
 
-@pytest.mark.skipif(
-    platform.system().lower() != 'linux',
-    reason='implementation for MacOS still missing'
-)
+@skip_unless_linux
 def test_file_is_relocatable_errors(tmpdir):
     # The file passed in as argument must exist...
     with pytest.raises(ValueError) as exc_info:
@@ -199,10 +203,7 @@ def test_file_is_relocatable_errors(tmpdir):
         assert 'is not an absolute path' in str(exc_info.value)
 
 
-@pytest.mark.skipif(
-    platform.system().lower() != 'linux',
-    reason='implementation for MacOS still missing'
-)
+@skip_unless_linux
 def test_search_patchelf(expected_patchelf_path):
     current = spack.relocate._patchelf()
     assert current == expected_patchelf_path
@@ -272,10 +273,7 @@ def test_set_elf_rpaths_warning(mock_patchelf):
 
 
 @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
-@pytest.mark.skipif(
-    platform.system().lower() != 'linux',
-    reason='implementation for MacOS still missing'
-)
+@skip_unless_linux
 def test_replace_prefix_bin(hello_world):
     # Compile an "Hello world!" executable and set RPATHs
     executable = hello_world(rpaths=['/usr/lib', '/usr/lib64'])
@@ -288,10 +286,7 @@ def test_replace_prefix_bin(hello_world):
 
 
 @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
-@pytest.mark.skipif(
-    platform.system().lower() != 'linux',
-    reason='implementation for MacOS still missing'
-)
+@skip_unless_linux
 def test_relocate_elf_binaries_absolute_paths(
         hello_world, copy_binary, tmpdir
 ):
@@ -316,10 +311,7 @@ def test_relocate_elf_binaries_absolute_paths(
 
 
 @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
-@pytest.mark.skipif(
-    platform.system().lower() != 'linux',
-    reason='implementation for MacOS still missing'
-)
+@skip_unless_linux
 def test_relocate_elf_binaries_relative_paths(hello_world, copy_binary):
     # Create an executable, set some RPATHs, copy it to another location
     orig_binary = hello_world(rpaths=['lib', 'lib64', '/opt/local/lib'])
@@ -340,10 +332,7 @@ def test_relocate_elf_binaries_relative_paths(hello_world, copy_binary):
 
 
 @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
-@pytest.mark.skipif(
-    platform.system().lower() != 'linux',
-    reason='implementation for MacOS still missing'
-)
+@skip_unless_linux
 def test_make_elf_binaries_relative(hello_world, copy_binary, tmpdir):
     orig_binary = hello_world(rpaths=[
         str(tmpdir.mkdir('lib')), str(tmpdir.mkdir('lib64')), '/opt/local/lib'
@@ -367,10 +356,7 @@ def test_raise_if_not_relocatable(monkeypatch):
 
 
 @pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
-@pytest.mark.skipif(
-    platform.system().lower() != 'linux',
-    reason='implementation for MacOS still missing'
-)
+@skip_unless_linux
 def test_relocate_text_bin(hello_world, copy_binary, tmpdir):
     orig_binary = hello_world(rpaths=[
         str(tmpdir.mkdir('lib')), str(tmpdir.mkdir('lib64')), '/opt/local/lib'

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from llnl.util import tty
 
 
 class Zstd(MakefilePackage):
@@ -37,10 +38,10 @@ class Zstd(MakefilePackage):
     depends_on('lzma', when='+programs')
     depends_on('lz4', when='+programs')
 
-    def _make(self, *args):
+    def _make(self, *args, **kwargs):
         # PREFIX must be defined on macOS even when building the library, since
         # it gets hardcoded into the library's install_path
-        make('VERBOSE=1', 'PREFIX=' + self.prefix, '-C', *args)
+        make('VERBOSE=1', 'PREFIX=' + self.prefix, '-C', *args, **kwargs)
 
     def build(self, spec, prefix):
         self._make('lib')
@@ -48,6 +49,6 @@ class Zstd(MakefilePackage):
             self._make('programs')
 
     def install(self, spec, prefix):
-        self._make('lib', 'install')
+        self._make('lib', 'install', parallel=False)
         if spec.variants['programs'].value:
             self._make('programs', 'install')

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from llnl.util import tty
 
 
 class Zstd(MakefilePackage):


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/26544 and https://github.com/spack/spack/issues/26552 by adding a post-install step on macOS for autotools-based and package-based packages. The fixup will:
- Replace hard-coded `$prefix/foo.dylib` paths with `@rpath/foo.dylib` if and only if `$prefix` is in the library's list of rpaths
- Replace `$spack_root/$other/bar.dylib` with `@rpath/bar.dylib` and add `$spack_root/$other` to the rpath list
- Remove duplicate rpath entries due to duplication between libtool and spack's compiler wrapper

I used the following script to successfully fix up a number of affected (already installed) libraries:
```python
#!/usr/bin/env spack-python

import spack.store
from spack.relocate import fixup_macos_rpaths

def needs_fixup(spec):
    if spec.external or spec.virtual:
        return False
    return True

def fixup(specs):
    for spec in specs:
        fixup_macos_rpaths(spec)
        break

def main():
    specs = [s for s in spack.store.db.query() if needs_fixup(s)]
    fixup(specs)

if __name__ == '__main__':
    main()
```

Of course, libraries that link *against* the previously broken ones are unaffected since they may still contain hard-coded library IDs. But newly installed binaries from here out will *not*.