### PR TITLE
Fix leaky spack.binary_distribution.binary_index in tests

### DIFF
--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -118,7 +118,8 @@ and then 'd', 'b', and 'a' to be put in the next three stages, respectively.
 
 
 def test_ci_generate_with_env(tmpdir, mutable_mock_env_path,
-                              install_mockery, mock_packages, project_dir_env):
+                              install_mockery, mock_packages, project_dir_env,
+                              mock_binary_index):
     """Make sure we can get a .gitlab-ci.yml from an environment file
        which has the gitlab-ci, cdash, and mirrors sections."""
     project_dir_env(tmpdir.strpath)
@@ -343,7 +344,8 @@ spack:
 
 def test_ci_generate_with_env_missing_section(tmpdir, mutable_mock_env_path,
                                               install_mockery,
-                                              mock_packages, project_dir_env):
+                                              mock_packages, project_dir_env,
+                                              mock_binary_index):
     """Make sure we get a reasonable message if we omit gitlab-ci section"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))
@@ -368,7 +370,8 @@ spack:
 
 def test_ci_generate_with_cdash_token(tmpdir, mutable_mock_env_path,
                                       install_mockery,
-                                      mock_packages, project_dir_env):
+                                      mock_packages, project_dir_env,
+                                      mock_binary_index):
     """Make sure we it doesn't break if we configure cdash"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))
@@ -424,7 +427,7 @@ spack:
 def test_ci_generate_with_custom_scripts(tmpdir, mutable_mock_env_path,
                                          install_mockery,
                                          mock_packages, monkeypatch,
-                                         project_dir_env):
+                                         project_dir_env, mock_binary_index):
     """Test use of user-provided scripts"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))
@@ -676,7 +679,8 @@ spack:
 
 def test_ci_rebuild(tmpdir, mutable_mock_env_path,
                     install_mockery, mock_packages, monkeypatch,
-                    mock_gnupghome, mock_fetch, project_dir_env):
+                    mock_gnupghome, mock_fetch, project_dir_env,
+                    mock_binary_index):
     project_dir_env(tmpdir.strpath)
     working_dir = tmpdir.join('working_dir')
 
@@ -834,7 +838,7 @@ spack:
 
 def test_ci_nothing_to_rebuild(tmpdir, mutable_mock_env_path,
                                install_mockery, mock_packages, monkeypatch,
-                               mock_fetch, project_dir_env):
+                               mock_fetch, project_dir_env, mock_binary_index):
     project_dir_env(tmpdir.strpath)
     working_dir = tmpdir.join('working_dir')
 
@@ -1461,7 +1465,8 @@ spack:
 
 def test_ci_subcommands_without_mirror(tmpdir, mutable_mock_env_path,
                                        mock_packages,
-                                       install_mockery, project_dir_env):
+                                       install_mockery, project_dir_env,
+                                       mock_binary_index):
     """Make sure we catch if there is not a mirror and report an error"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -22,6 +22,7 @@ import pytest
 import archspec.cpu.microarchitecture
 import archspec.cpu.schema
 
+import llnl.util.lang
 from llnl.util.filesystem import mkdirp, remove_linked_tree, working_dir
 
 import spack.binary_distribution
@@ -1524,3 +1525,10 @@ def mock_test_stage(mutable_config, tmpdir):
     mutable_config.set('config:test_stage', tmp_stage)
 
     yield tmp_stage
+
+
+@pytest.fixture(autouse=True)
+def brand_new_binary_cache():
+    yield
+    spack.binary_distribution.binary_index = llnl.util.lang.Singleton(
+        spack.binary_distribution._binary_index)


### PR DESCRIPTION
This is a blocker for #26599 where tests suddenly started failing because

```
spack.binary_distribution.binary_index
```

has state leaking between tests.

In particular, `archive-files` which was pushed to a local mirror in one test, was later pulled during a spack install in an entirely unrelated test, which then failed, because there was no gpg signature for it. :(.

After fixing individual tests, other failures creeped in, namely 

```
test_patchelf_is_relocatable
```

referencing a patchelf binary from a buildcache, which did not exist anymore at the time the test was executed. I have no clue and don't want to figure out why.

What's important is that tests shouldn't leak state, and hence the second commit of this PR resets

```
spack.binary_distribution.binary_index
```

at the end of every test, hopefully solving the issue.

This would hopefully be a temporary measure until someone takes on the project of getting rid of those great globals sprinkled around in Spack.
