### PR TITLE
binutils: fix parallel make for version 2.36

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -48,6 +48,10 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     patch('cr16.patch', when='@:2.29.1')
     patch('update_symbol-2.26.patch', when='@2.26')
 
+    # 2.36 is missing some dependencies, this patch allows a parallel build.
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=27482
+    patch('parallel-build-2.36.patch', when='@2.36')
+
     depends_on('zlib')
     depends_on('diffutils', type='build')
     depends_on('gettext', when='+nls')
@@ -122,13 +126,6 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
             args.append('--program-prefix=g')
 
         return args
-
-    # 2.36 is missing some dependencies and requires serial make install.
-    # https://sourceware.org/bugzilla/show_bug.cgi?id=27482
-    @when('@2.36:')
-    def install(self, spec, prefix):
-        with working_dir(self.build_directory):
-            make('-j', '1', *self.install_targets)
 
     @run_after('install')
     def install_headers(self):

--- a/var/spack/repos/builtin/packages/binutils/parallel-build-2.36.patch
+++ b/var/spack/repos/builtin/packages/binutils/parallel-build-2.36.patch
@@ -1,0 +1,53 @@
+This patch fixes parallel make for versions 2.36.*.  This is taken
+from commit 755ba58ebef0 without the diff for ChangeLog.  The changes
+to ChangeLog are prepend only, so that diff only applies cleanly to
+the previous commit (git parent).
+
+
+diff --git a/Makefile.def b/Makefile.def
+index 0cdf044c5c3..364f7f3e011 100644
+--- a/Makefile.def
++++ b/Makefile.def
+@@ -448,7 +448,6 @@ dependencies = { module=all-binutils; on=all-intl; };
+ dependencies = { module=all-binutils; on=all-gas; };
+ dependencies = { module=all-binutils; on=all-libctf; };
+ dependencies = { module=all-ld; on=all-libctf; };
+-dependencies = { module=install-ld; on=install-libctf; };
+ 
+ // We put install-opcodes before install-binutils because the installed
+ // binutils might be on PATH, and they might need the shared opcodes
+@@ -456,6 +455,14 @@ dependencies = { module=install-ld; on=install-libctf; };
+ dependencies = { module=install-binutils; on=install-opcodes; };
+ dependencies = { module=install-strip-binutils; on=install-strip-opcodes; };
+ 
++// Likewise for ld, libctf, and bfd.
++dependencies = { module=install-libctf; on=install-bfd; };
++dependencies = { module=install-ld; on=install-bfd; };
++dependencies = { module=install-ld; on=install-libctf; };
++dependencies = { module=install-strip-libctf; on=install-strip-bfd; };
++dependencies = { module=install-strip-ld; on=install-strip-bfd; };
++dependencies = { module=install-strip-ld; on=install-strip-libctf; };
++
+ // libopcodes depends on libbfd
+ dependencies = { module=install-opcodes; on=install-bfd; };
+ dependencies = { module=install-strip-opcodes; on=install-strip-bfd; };
+diff --git a/Makefile.in b/Makefile.in
+index 4f82fd0a47f..57da7ec0790 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -52170,9 +52170,14 @@ all-stage3-ld: maybe-all-stage3-libctf
+ all-stage4-ld: maybe-all-stage4-libctf
+ all-stageprofile-ld: maybe-all-stageprofile-libctf
+ all-stagefeedback-ld: maybe-all-stagefeedback-libctf
+-install-ld: maybe-install-libctf
+ install-binutils: maybe-install-opcodes
+ install-strip-binutils: maybe-install-strip-opcodes
++install-libctf: maybe-install-bfd
++install-ld: maybe-install-bfd
++install-ld: maybe-install-libctf
++install-strip-libctf: maybe-install-strip-bfd
++install-strip-ld: maybe-install-strip-bfd
++install-strip-ld: maybe-install-strip-libctf
+ install-opcodes: maybe-install-bfd
+ install-strip-opcodes: maybe-install-strip-bfd
+ configure-gas: maybe-configure-intl


### PR DESCRIPTION
There was a bug in 2.36.* of missing Makefile dependencies.  The
previous workaround was to require 2.36 to be built serially.  This is
now fixed upstream in 2.37 and this PR adds the patch to restore
parallel make to 2.36.

ping @alalazo as maintainer

@michaelkuhn I didn't mean to step on your other PR #26521.  I noticed
this problem while looking at your PR.  But they're separate enough
that rebasing one should be straightforward.

(One of those things that either I have to do it now while I remember,
or else put it aside and I won't get back to it for 3 months. :-( 

----------

I tried to write a URL spec for the patch, but there are two problems
with that.

1. The binutils/gdb home repo is on sourceforge.  I clicked around
their website for a URL that would give me the raw patch (without
HTML), but I couldn't find anything.  You may notice, there aren't any
other URL patches for sourceforge in the spack packages.

2. The upstream patch that fixes this modifies three files: two
Makefiles plus ChangeLog.  ChangeLog is a prepend-only file and thus
any patch to it will only ever apply cleanly to its git parent, not
the 2.36.1 tarfile.  Blech.
