### PR TITLE
Reset the binary_index global in every test

### DIFF
--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -118,8 +118,7 @@ and then 'd', 'b', and 'a' to be put in the next three stages, respectively.
 
 
 def test_ci_generate_with_env(tmpdir, mutable_mock_env_path,
-                              install_mockery, mock_packages, project_dir_env,
-                              mock_binary_index):
+                              install_mockery, mock_packages, project_dir_env):
     """Make sure we can get a .gitlab-ci.yml from an environment file
        which has the gitlab-ci, cdash, and mirrors sections."""
     project_dir_env(tmpdir.strpath)
@@ -344,8 +343,7 @@ spack:
 
 def test_ci_generate_with_env_missing_section(tmpdir, mutable_mock_env_path,
                                               install_mockery,
-                                              mock_packages, project_dir_env,
-                                              mock_binary_index):
+                                              mock_packages, project_dir_env):
     """Make sure we get a reasonable message if we omit gitlab-ci section"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))
@@ -370,8 +368,7 @@ spack:
 
 def test_ci_generate_with_cdash_token(tmpdir, mutable_mock_env_path,
                                       install_mockery,
-                                      mock_packages, project_dir_env,
-                                      mock_binary_index):
+                                      mock_packages, project_dir_env):
     """Make sure we it doesn't break if we configure cdash"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))
@@ -427,7 +424,7 @@ spack:
 def test_ci_generate_with_custom_scripts(tmpdir, mutable_mock_env_path,
                                          install_mockery,
                                          mock_packages, monkeypatch,
-                                         project_dir_env, mock_binary_index):
+                                         project_dir_env):
     """Test use of user-provided scripts"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))
@@ -679,8 +676,7 @@ spack:
 
 def test_ci_rebuild(tmpdir, mutable_mock_env_path,
                     install_mockery, mock_packages, monkeypatch,
-                    mock_gnupghome, mock_fetch, project_dir_env,
-                    mock_binary_index):
+                    mock_gnupghome, mock_fetch, project_dir_env):
     project_dir_env(tmpdir.strpath)
     working_dir = tmpdir.join('working_dir')
 
@@ -838,7 +834,7 @@ spack:
 
 def test_ci_nothing_to_rebuild(tmpdir, mutable_mock_env_path,
                                install_mockery, mock_packages, monkeypatch,
-                               mock_fetch, project_dir_env, mock_binary_index):
+                               mock_fetch, project_dir_env):
     project_dir_env(tmpdir.strpath)
     working_dir = tmpdir.join('working_dir')
 
@@ -1465,8 +1461,7 @@ spack:
 
 def test_ci_subcommands_without_mirror(tmpdir, mutable_mock_env_path,
                                        mock_packages,
-                                       install_mockery, project_dir_env,
-                                       mock_binary_index):
+                                       install_mockery, project_dir_env):
     """Make sure we catch if there is not a mirror and report an error"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))
@@ -1545,7 +1540,7 @@ def test_ensure_only_one_temporary_storage():
 def test_ci_generate_temp_storage_url(tmpdir, mutable_mock_env_path,
                                       install_mockery,
                                       mock_packages, monkeypatch,
-                                      project_dir_env, mock_binary_index):
+                                      project_dir_env):
     """Verify correct behavior when using temporary-storage-url-prefix"""
     project_dir_env(tmpdir.strpath)
     filename = str(tmpdir.join('spack.yaml'))
@@ -1657,7 +1652,7 @@ spack:
 
 def test_ci_reproduce(tmpdir, mutable_mock_env_path,
                       install_mockery, mock_packages, monkeypatch,
-                      last_two_git_commits, project_dir_env, mock_binary_index):
+                      last_two_git_commits, project_dir_env):
     project_dir_env(tmpdir.strpath)
     working_dir = tmpdir.join('repro_dir')
     image_name = 'org/image:tag'


### PR DESCRIPTION
lazily like in the default definition
