### PR TITLE
openslide: Fix missing dependencies: gdk-pixbuf and perl-alien-libxml2

### DIFF
--- a/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
+++ b/var/spack/repos/builtin/packages/gdk-pixbuf/package.py
@@ -32,8 +32,8 @@ class GdkPixbuf(Package):
     depends_on('meson@0.46.0:', type='build', when='@2.37.92:')
     depends_on('meson@0.45.0:', type='build', when='@2.37.0:')
     depends_on('ninja', type='build', when='@2.37.0:')
-    depends_on('shared-mime-info', type='build', when='@2.36.8: platform=linux')
-    depends_on('shared-mime-info', type='build', when='@2.36.8: platform=cray')
+    depends_on('shared-mime-info', when='@2.36.8: platform=linux')
+    depends_on('shared-mime-info', when='@2.36.8: platform=cray')
     depends_on('pkgconfig', type='build')
     # Building the man pages requires libxslt and the Docbook stylesheets
     depends_on('libxslt', type='build', when='+man')

--- a/var/spack/repos/builtin/packages/openslide/package.py
+++ b/var/spack/repos/builtin/packages/openslide/package.py
@@ -14,6 +14,7 @@ class Openslide(AutotoolsPackage):
 
     version('3.4.1', sha256='9938034dba7f48fadc90a2cdf8cfe94c5613b04098d1348a5ff19da95b990564')
 
+    depends_on('pkgconfig', type='build')
     depends_on('openjpeg')
     depends_on('jpeg')
     depends_on('libtiff')

--- a/var/spack/repos/builtin/packages/perl-alien-libxml2/package.py
+++ b/var/spack/repos/builtin/packages/perl-alien-libxml2/package.py
@@ -16,3 +16,4 @@ class PerlAlienLibxml2(PerlPackage):
 
     depends_on('libxml2')
     depends_on('perl-alien-build', type=('build', 'run'))
+    depends_on('pkgconfig',        type=('build'))


### PR DESCRIPTION
Add missing pkgconfig to openslide and its dep perl-alien-libxml2.

Fix shared-mime-info to be a runtime dependency of gdk-pixbuf,
Otherwise, configure cannot detect use gdk-pixbuf without error.