### PR TITLE
py-rdflib: Add py-requests as build+run dep, fixes test

### DIFF
--- a/var/spack/repos/builtin/packages/py-rdflib/package.py
+++ b/var/spack/repos/builtin/packages/py-rdflib/package.py
@@ -24,3 +24,5 @@ class PyRdflib(PythonPackage):
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-pyparsing', type=('build', 'run'))
     depends_on('py-isodate', type=('build', 'run'))
+    # An optional dependency of the sparql feature, but it fixes import the tests:
+    depends_on('py-requests', type=('build', 'run'))


### PR DESCRIPTION
Adding py-requests as build and run dependency fixes import tests.
It is an optional dependency for the sparql plugin, but it is light.