### PR TITLE
Speed up pipeline generation

### DIFF
--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -1617,6 +1617,8 @@ def test_ci_generate_read_broken_specs_url(tmpdir, mutable_mock_env_path,
     with open(broken_spec_a_path, 'w') as bsf:
         bsf.write('')
 
+    broken_specs_url = 'file://{0}'.format(tmpdir.strpath)
+
     # Test that `spack ci generate` notices this broken spec and fails.
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:
@@ -1639,7 +1641,7 @@ spack:
           tags:
             - donotcare
           image: donotcare
-""".format(tmpdir.strpath))
+""".format(broken_specs_url))
 
     with tmpdir.as_cwd():
         env_cmd('create', 'test', './spack.yaml')


### PR DESCRIPTION
Find some things to speed up pipeline generation, apart from the parallelization of separate concretization done in #26264.

- [x] Stage already concretized specs instead of abstract ones
- [x] Reduce number of network calls
- [x] Resolve compiler bootstrapping issues caused by removal of "redundant" concretization 

Without this PR (or #26264) the time to generate the E4S stack on a machine with 16 cores and 128GB RAM: 

```
         2791561432 function calls (2640954370 primitive calls) in 3768.751 seconds

   Ordered by: internal time
   List reduced from 5804 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      204 1136.368    5.570 1139.205    5.584 {method 'solve' of 'clingo.Control' objects}
     1094  657.732    0.601  657.732    0.601 {method 'connect' of '_socket.socket' objects}
      204  316.340    1.551  316.340    1.551 {method 'ground' of 'clingo.Control' objects}
      204   78.431    0.384 2926.023   14.343 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/spec.py:2586(_new_concretize)
102037509/30236460   74.983    0.000  575.468    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:99(coercing_method)
      366   58.462    0.160   58.462    0.160 {method 'do_handshake' of '_ssl._SSLSocket' objects}
 14283931   52.750    0.000  169.638    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:336(__getitem__)
141907172   45.957    0.000   74.038    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:208(is_commit)
 14401892   44.065    0.000   90.838    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:172(__init__)
  9145110   43.108    0.000  147.485    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/solver/asp.py:314(fact)
160589001   41.149    0.000   41.149    0.000 {method 'match' of 're.Pattern' objects}
3236948/3236942   36.132    0.000   78.594    0.000 {built-in method builtins.__build_class__}
     1105   35.954    0.033   35.954    0.033 {method 'read' of '_ssl._SSLSocket' objects}
281940552/281922412   35.696    0.000   44.353    0.000 {built-in method builtins.isinstance}
 14351403   28.026    0.000  331.781    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:67(coerce_versions)
 28424087   27.347    0.000  103.055    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:373(__lt__)
 85054216   25.348    0.000   68.962    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:192(_cmp)
161804638/111592283   24.136    0.000   35.727    0.000 {built-in method builtins.len}
4557944/3222059   23.377    0.000   43.056    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/spec.py:1356(traverse_edges)
  9425890   21.790    0.000  249.868    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:498(__init__)
```

With this PR on the same machine:

```
         1493151814 function calls (1411155039 primitive calls) in 3006.827 seconds

   Ordered by: internal time
   List reduced from 16155 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1094  648.836    0.593  648.836    0.593 {method 'connect' of '_socket.socket' objects}
      102  639.888    6.273  640.250    6.277 {method 'solve' of 'clingo.Control' objects}
      102  235.054    2.304  235.054    2.304 {method 'ground' of 'clingo.Control' objects}
51294040/15288593   66.863    0.000  514.913    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:99(coercing_method)
      366   56.795    0.155   56.795    0.155 {method 'do_handshake' of '_ssl._SSLSocket' objects}
 71255182   49.230    0.000   78.362    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:208(is_commit)
  7165293   46.909    0.000  150.008    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:336(__getitem__)
      102   40.387    0.396 2136.177   20.943 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/spec.py:2586(_new_concretize)
  7295389   38.481    0.000   81.537    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:172(__init__)
 80863592   37.962    0.000   37.962    0.000 {method 'match' of 're.Pattern' objects}
     1094   36.112    0.033   36.112    0.033 {method 'read' of '_ssl._SSLSocket' objects}
  4572555   34.259    0.000  115.351    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/solver/asp.py:314(fact)
150773974/150755834   33.646    0.000   40.963    0.000 {built-in method builtins.isinstance}
1625206/1625200   26.473    0.000  105.364    0.000 {built-in method builtins.__build_class__}
 14264122   25.757    0.000  105.578    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:373(__lt__)
 42719382   24.636    0.000   71.369    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:192(_cmp)
84444956/58691964   22.380    0.000   33.521    0.000 {built-in method builtins.len}
  7182053   22.346    0.000  286.052    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/version.py:67(coerce_versions)
     1102   18.557    0.017   18.565    0.017 /usr/lib/python3.8/json/decoder.py:343(raw_decode)
2590831/1709814   17.795    0.000   35.024    0.000 /data/scott/Documents/spack/speedup_pipeline_generation/spack/lib/spack/spack/spec.py:1356(traverse_edges)
```

We can see that we reduced the number of calls to `ground` and `solve` in half, and got some speedup, from ~62 min down to ~50 min.

According to the profile log, another place we're spending a lot of time is in making network connections, and one thing we do for every spec in the environment (both roots and dependencies), is to check the presence of the spec hash in the "naughty list".  Perhaps by retrieving everything from the naughty list up front, just once, we can get the number of network connect calls down.