### PR TITLE
lib/spack/env/cc: Fix finding ld.lld (e.g. for installing llvm)

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -271,6 +271,10 @@ case "$command" in
         ;;
     ld|ld.gold|ld.lld)
         mode=ld
+        # ld.lld may not be in PATH, but it should be provided by llvm/clang:
+        if [ "$command" = ld.lld ] && [ "${SPACK_CC##*/}" = clang ]; then
+	    [ -x "${SPACK_CC%/*}/ld.lld" ] && command="${SPACK_CC%/*}/ld.lld"
+        fi
         ;;
     *)
         die "Unknown compiler: $command"


### PR DESCRIPTION
*Sorry for any bad or confusing grammar, it's been a long day with many other fixes*

Background: This sequence can be used to install clang@12 for spack:
```py
spack install  llvm@12.0.1
spack load     llvm@12.0.1
spack compiler find
```
This is just an example, it can be any clang compiler build.

Then it can be used (among other builds) to build another version of LLVM, (but  llvm@13.0.0 triggers it for me):
```py
spack install llvm@13.0.0
```
When the build of `llvm@13.0.0` is run in a different shell-environment where the `PATH` (set by the `spack load llvm@...` before) is not set to include the bindir of `llvm@12.0.1`, the build may fail.

The reason for that is that because the `ld.lld` wrapper does not find the `ld.lld`, when it should find the ld.lld of `clang@12.0.1`.

In my case (with no `ld.lld` in the `PATH` otherwise), the build of llvm@13.0.0 aborted with:
```py
ld.lld: File not found
```

Fix this by checking if `$SPACK_CC` is `clang` and checking if `ld.lld` exists in `clang`'s directory.

I thought this should have worked with the previous cc wrapper, but the PR adding supprt for wrapping ld.gold and ld.lld is new, and it does not set the PATH of ld.lld from SPACK_CC: #25626 - Thanks to @Jordan474 
