### PR TITLE
mesa: gallium fails with llvm@13: use 'llvm@6:12', add mesa@21.2.3

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -19,6 +19,7 @@ class Mesa(MesonPackage):
     url = "https://archive.mesa3d.org/mesa-20.2.1.tar.xz"
 
     version('master', tag='master')
+    version('21.2.3', sha256='7245284a159d2484770e1835a673e79e4322a9ddf43b17859668244946db7174')
     version('21.2.1', sha256='2c65e6710b419b67456a48beefd0be827b32db416772e0e363d5f7d54dc01787')
     version('21.0.3', sha256='565c6f4bd2d5747b919454fc1d439963024fc78ca56fd05158c3b2cde2f6912b')
     version('21.0.0', sha256='e6204e98e6a8d77cf9dc5d34f99dd8e3ef7144f3601c808ca0dd26ba522e0d84')
@@ -74,7 +75,7 @@ class Mesa(MesonPackage):
     provides('osmesa', when='+osmesa')
 
     # Variant dependencies
-    depends_on('llvm@6:', when='+llvm')
+    depends_on('llvm@6:12', when='+llvm')
     depends_on('libx11',  when='+glx')
     depends_on('libxcb',  when='+glx')
     depends_on('libxext', when='+glx')


### PR DESCRIPTION
This should fix issue #26595

The software rasterizer of Mesa's Gallium3D (even from `mesa@21.2.3` added by this PR) fails to build with the newly added `llvm@13.0.0`.

To fix the build, use: `depends_on('llvm@6:12', when='+llvm')`