### PR TITLE
whizard: add libtirpc for rpc/types.h

### DIFF
--- a/var/spack/repos/builtin/packages/whizard/package.py
+++ b/var/spack/repos/builtin/packages/whizard/package.py
@@ -58,6 +58,7 @@ class Whizard(AutotoolsPackage):
     variant('latex', default=False,
             description="data visualization with latex")
 
+    depends_on('libtirpc')
     depends_on('ocaml@4.02.3:', type='build', when="@3:")
     depends_on('ocaml@4.02.3:~force-safe-string', type='build', when="@:2")
     depends_on('hepmc', when="hepmc=2")


### PR DESCRIPTION
rpc/types.h has been removed in recent glibc