### PR TITLE
vapor: Fix the build and update: Use correct deps and find numpy incdir

### DIFF
--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -13,7 +13,7 @@ class Glew(CMakePackage):
     version('2.1.0',  sha256='04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95')
     version('2.0.0',  sha256='c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764')
 
-    depends_on("gl")
+    depends_on("glu")
     depends_on('libsm')
     depends_on('libice')
 

--- a/var/spack/repos/builtin/packages/vapor/package.py
+++ b/var/spack/repos/builtin/packages/vapor/package.py
@@ -18,21 +18,23 @@ class Vapor(CMakePackage):
 
     maintainers = ['RemiLacroix-IDRIS']
 
-    version('3.3.0', sha256='508f93db9f6d9307be260820b878d054553aeb1719087a14770889f9e50a18ac')
+    version('3.5.0', sha256='f055d488c6f5bda5174a63990b6b6600037f7ce73ac68d39ad0f371d67f2d685')
+    version('3.3.0', sha256='41c13d206cfcfa4146155d524106de2eb74e7b59af1e2f8c1c3056c15d508a93')
 
     depends_on('gl')  # GUI
-    depends_on('qt@5:+opengl+dbus')  # GUI
-    depends_on('netcdf-c')
-    depends_on('udunits')
-    depends_on('freetype')
-    depends_on('libgeotiff')
-    depends_on('jpeg')
-    depends_on('glew')  # GUI
-    depends_on('assimp')
-    depends_on('libtiff')
-    depends_on('proj')
+    depends_on('qt@5.13.2:+opengl+dbus')  # GUI
+    depends_on('netcdf-c@4.7.0:')
+    depends_on('udunits@2.2.26:')
+    depends_on('freetype@2.10.1:')
+    depends_on('libgeotiff@1.5.1:')
+    depends_on('hdf5@1.10.5:')
+    depends_on('jpeg@9c:')
+    depends_on('glew@2.1.0:')  # GUI
+    depends_on('assimp@4.1.0:')
+    depends_on('libtiff@4.0.10:')
+    depends_on('proj@6.1.1:7')
     depends_on('glm@0.9.9.1:')
-    depends_on('python@3.6.0:3.6')
+    depends_on('python@3.6.9:3.6')
     depends_on('py-numpy')
 
     def cmake_args(self):
@@ -41,6 +43,13 @@ class Vapor(CMakePackage):
             f.write('set (PYTHONVERSION {0})\n'.format(python.version.up_to(2)))
             f.write('set (PYTHONDIR {0})\n'.format(python.home))
             f.write('set (PYTHONPATH {0})\n'.format(python.package.site_packages_dir))
+            # install expects the share/images directory to install below this path
+            f.write('set (THIRD_PARTY_DIR {0})\n'.format(self.stage.source_path))
+            numpy_include = join_path(
+                self.spec['py-numpy'].prefix,
+                self.spec['python'].package.site_packages_dir,
+                'numpy', 'core', 'include')
+            f.write('set (THIRD_PARTY_INC_DIR "{0}")\n'.format(numpy_include))
 
         args = ['-DBUILD_OSP=OFF']
         return args


### PR DESCRIPTION
vapor needs `proj@:7` and gives a list of tested dependency versions.
Make it find the `numpy` include path and add version 3.5.0 as well