### PR TITLE
environment-modules: fix build

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -57,6 +57,8 @@ class EnvironmentModules(Package):
 
         config_args = [
             "--prefix=" + prefix,
+            # It looks for tclConfig.sh
+            "--with-tcl=" + tcl.libs.directories[0],
             '--datarootdir=' + prefix.share
         ]
 
@@ -117,8 +119,6 @@ class EnvironmentModules(Package):
             config_args.extend([
                 "--without-tclx",
                 "--with-tclx-ver=0.0",
-                # It looks for tclConfig.sh
-                "--with-tcl=" + tcl.libs.directories[0],
                 "--with-tcl-ver={0}".format(tcl.version.up_to(2)),
                 '--disable-versioning'
             ])


### PR DESCRIPTION
PR #25904 moved the `--with-tcl` option to only older versions. However, without this option, the build breaks:
```
checking for Tcl configuration... configure: error: Can't find Tcl configuration definitions. Use --with-tcl to specify a directory containing tclConfig.sh
```