### PR TITLE
llvm: add conflict for newer apple-clang versions

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -192,10 +192,11 @@ class Llvm(CMakePackage, CudaPackage):
     # Introduced in version 11 as a part of LLVM and not a separate package.
     conflicts("+flang", when="@:10")
 
-    # Older LLVM do not build with newer GCC
+    # Older LLVM do not build with newer compilers, and vice versa
     conflicts("%gcc@11:", when="@:7")
     conflicts("%gcc@8:", when="@:5")
     conflicts("%gcc@:5.0", when="@8:")
+    conflicts("%apple-clang@13:", when="@:9")
 
     # libc++ of LLVM13, see https://libcxx.llvm.org/#platform-and-compiler-support
     # @13 does not support %gcc@:10 https://bugs.llvm.org/show_bug.cgi?id=51359#c1


### PR DESCRIPTION
llvm@9.0.1 fails to build with apple-clang@13.0.0:

```
[  8%] Building C object projects/compiler-rt/lib/builtins/CMakeFiles/clang_rt.builtins_arm64_osx.dir/comparetf2.c.o
cd /private/var/folders/gy/mrg1ffts2h945qj9k29s1l1dvvmbqb/T/s3j/spack-stage/spack-stage-llvm-9.0.1-5bva5qxq6qgoeupd3nhoqgjyxbptktmx/spack-build-5bva5qx/projects/compiler-rt/lib/builtins && /rnsdhpc/code/spack/lib/spack/env/clang/clang -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/private/var/folders/gy/mrg1ffts2h945qj9k29s1l1dvvmbqb/T/s3j/spack-stage/spack-stage-llvm-9.0.1-5bva5qxq6qgoeupd3nhoqgjyxbptktmx/spack-build-5bva5qx/projects/compiler-rt/lib/builtins -I/private/var/folders/gy/mrg1ffts2h945qj9k29s1l1dvvmbqb/T/s3j/spack-stage/spack-stage-llvm-9.0.1-5bva5qxq6qgoeupd3nhoqgjyxbptktmx/spack-src/compiler-rt/lib/builtins -I/rnsdhpc/code/spack/opt/spack/apple-clang/libxml2/3dwrkpb/include/libxml2 -I/private/var/folders/gy/mrg1ffts2h945qj9k29s1l1dvvmbqb/T/s3j/spack-stage/spack-stage-llvm-9.0.1-5bva5qxq6qgoeupd3nhoqgjyxbptktmx/spack-build-5bva5qx/include -I/private/var/folders/gy/mrg1ffts2h945qj9k29s1l1dvvmbqb/T/s3j/spack-stage/spack-stage-llvm-9.0.1-5bva5qxq6qgoeupd3nhoqgjyxbptktmx/spack-src/llvm/include -O3 -DNDEBUG -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk  -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -mmacosx-version-min=10.5 -fPIC -O3 -fvisibility=hidden -DVISIBILITY_HIDDEN -Wall -fomit-frame-pointer -arch arm64 -MD -MT projects/compiler-rt/lib/builtins/CMakeFiles/clang_rt.builtins_arm64_osx.dir/comparetf2.c.o -MF CMakeFiles/clang_rt.builtins_arm64_osx.dir/comparetf2.c.o.d -o CMakeFiles/clang_rt.builtins_arm64_osx.dir/comparetf2.c.o -c /private/var/folders/gy/mrg1ffts2h945qj9k29s1l1dvvmbqb/T/s3j/spack-stage/spack-stage-llvm-9.0.1-5bva5qxq6qgoeupd3nhoqgjyxbptktmx/spack-src/compiler-rt/lib/builtins/comparetf2.c
clang: error: the clang compiler does not support '-march=x86-64'
make[2]: *** [projects/compiler-rt/lib/builtins/CMakeFiles/clang_rt.builtins_arm64_osx.dir/comparetf2.c.o] Error 1
```