### PR TITLE
sfcgal: build fails with cgal@4.6, works with cgal@4.7:

### DIFF
--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -15,12 +15,14 @@ class Sfcgal(CMakePackage):
     """
 
     homepage = "http://www.sfcgal.org/"
-    url      = "https://github.com/Oslandia/SFCGAL/archive/v1.3.7.tar.gz"
+    url      = "https://github.com/Oslandia/SFCGAL/archive/v1.3.8.tar.gz"
 
+    version('1.3.8', sha256='5154bfc67a5e99d95cb653d70d2b9d9293d3deb3c8f18b938a33d68fec488a6d')
     version('1.3.7', sha256='30ea1af26cb2f572c628aae08dd1953d80a69d15e1cac225390904d91fce031b')
 
-    # Ref: https://oslandia.github.io/SFCGAL/installation.html
-    depends_on('cgal@4.3: +core')
+    depends_on('cmake@2.8.6:', type='build')
+    # Ref: https://oslandia.github.io/SFCGAL/installation.html, but starts to work @4.7:
+    depends_on('cgal@4.7: +core')
     depends_on('boost@1.54.0:')
     depends_on('mpfr@2.2.1:')
     depends_on('gmp@4.2:')


### PR DESCRIPTION
Use `depends_on('cgal@4.7: +core')` to fix the build