### PR TITLE
Make 'spack location -e' print the current env, and 'spack cd -e' go to the current env

### DIFF
--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -56,8 +56,8 @@ def setup_parser(subparser):
         help="build directory for a spec "
              "(requires it to be staged first)")
     directories.add_argument(
-        '-e', '--env', action='store', dest='location_env', nargs='*',
-        help="location of the named or current environment")
+        '-e', '--env', action='store', dest='location_env', nargs='?', metavar="name",
+        default=False, help="location of the named or current environment")
 
     arguments.add_common_arguments(subparser, ['spec'])
 
@@ -71,19 +71,17 @@ def location(parser, args):
         print(spack.paths.prefix)
         return
 
-    if isinstance(args.location_env, list):
-        if len(args.location_env) == 0:
+    # no -e corresponds to False, -e without arg to None, -e name to the string name.
+    if args.location_env is not False:
+        if args.location_env is None:
             # Get current environment path
             spack.cmd.require_active_env('location -e')
             path = ev.active_environment().path
-        elif len(args.location_env) == 1:
-            # Get named environment path
-            name = args.location_env[0]
-            if not ev.exists(name):
-                tty.die("no such environment: '%s'" % name)
-            path = ev.root(args.location_env[0])
         else:
-            tty.die("provide a single environment name")
+            # Get named environment path
+            if not ev.exists(args.location_env):
+                tty.die("no such environment: '%s'" % args.location_env)
+            path = ev.root(args.location_env)
         print(path)
         return
 

--- a/lib/spack/spack/cmd/location.py
+++ b/lib/spack/spack/cmd/location.py
@@ -56,8 +56,8 @@ def setup_parser(subparser):
         help="build directory for a spec "
              "(requires it to be staged first)")
     directories.add_argument(
-        '-e', '--env', action='store', dest='location_env',
-        help="location of an environment managed by spack")
+        '-e', '--env', action='store', dest='location_env', nargs='*',
+        help="location of the named or current environment")
 
     arguments.add_common_arguments(subparser, ['spec'])
 
@@ -71,10 +71,19 @@ def location(parser, args):
         print(spack.paths.prefix)
         return
 
-    if args.location_env:
-        path = ev.root(args.location_env)
-        if not os.path.isdir(path):
-            tty.die("no such environment: '%s'" % args.location_env)
+    if isinstance(args.location_env, list):
+        if len(args.location_env) == 0:
+            # Get current environment path
+            spack.cmd.require_active_env('location -e')
+            path = ev.active_environment().path
+        elif len(args.location_env) == 1:
+            # Get named environment path
+            name = args.location_env[0]
+            if not ev.exists(name):
+                tty.die("no such environment: '%s'" % name)
+            path = ev.root(args.location_env[0])
+        else:
+            tty.die("provide a single environment name")
         print(path)
         return
 

--- a/lib/spack/spack/test/cmd/location.py
+++ b/lib/spack/spack/test/cmd/location.py
@@ -78,7 +78,7 @@ def test_location_env_exists(mutable_mock_env_path):
     assert location('--env', "example").strip() == e.path
 
 
-def test_location_with_active_env():
+def test_location_with_active_env(mutable_mock_env_path):
     """Tests spack location --env with active env"""
     e = ev.create("example")
     e.write()
@@ -113,12 +113,6 @@ def test_location_env_missing():
     error = "==> Error: no such environment: '%s'" % missing_env_name
     out = location('--env', missing_env_name, fail_on_error=False).strip()
     assert out == error
-
-
-def test_location_multiple_envs_fails():
-    """Don't allow location --env a b"""
-    out = location('--env', 'a', 'b', fail_on_error=False).strip()
-    assert "provide a single environment name" in out
 
 
 @pytest.mark.db


### PR DESCRIPTION
This allows the workflow

```
spack env activate --temp
spack cd -e
```

The helptext now reads:

```
usage: spack location [-h] [-m | -r | -i | -p | -P | -s | -S | --source-dir | -b | -e [name]] ...

print out locations of packages and spack directories

positional arguments:
  spec                  package spec

optional arguments:
  -h, --help            show this help message and exit
  -m, --module-dir      spack python module directory
  -r, --spack-root      spack installation root
  -i, --install-dir     install prefix for spec (spec need not be installed)
  -p, --package-dir     directory enclosing a spec's package.py file
  -P, --packages        top-level packages directory for Spack
  -s, --stage-dir       stage directory for a spec
  -S, --stages          top level stage directory
  --source-dir          source directory for a spec (requires it to be staged first)
  -b, --build-dir       build directory for a spec (requires it to be staged first)
  -e [name], --env [name]
                        location of the named or current environment
```