### PR TITLE
Bump boost version to 1.55.0 to enable use with recent glibc versions

### DIFF
--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -27,7 +27,7 @@ class Bcl2fastq2(Package):
     conflicts('platform=darwin',
               msg='malloc.h/etc requirements break build on macs')
 
-    depends_on('boost@1.55.0')
+    depends_on('boost@1.54.0:1.55')
     depends_on('cmake@2.8.9:', type='build')
     depends_on('libxml2@2.7.8')
     depends_on('libxslt@1.1.26~crypto')

--- a/var/spack/repos/builtin/packages/bcl2fastq2/package.py
+++ b/var/spack/repos/builtin/packages/bcl2fastq2/package.py
@@ -27,7 +27,7 @@ class Bcl2fastq2(Package):
     conflicts('platform=darwin',
               msg='malloc.h/etc requirements break build on macs')
 
-    depends_on('boost@1.54.0')
+    depends_on('boost@1.55.0')
     depends_on('cmake@2.8.9:', type='build')
     depends_on('libxml2@2.7.8')
     depends_on('libxslt@1.1.26~crypto')


### PR DESCRIPTION
The current package fails to install on 64-bit Linux systems with recent versions of glibc due to failure of the boost dependency to compile. This is due to changes in the assuptions regarding uint64_t that cause the current boost version 1.54.0 to fail to build.

A better solution would be for the authors to update all dependencies, but for now it seems to be enough to bump the boost version to 1.55.0, which allows the package to build and install.