### PR TITLE
Add Gromacs 2020.6 and Plumed 2.7.2

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -29,6 +29,7 @@ class Gromacs(CMakePackage):
     version('2021.2', sha256='d940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb')
     version('2021.1', sha256='bc1d0a75c134e1fb003202262fe10d3d32c59bbb40d714bc3e5015c71effe1e5')
     version('2021', sha256='efa78ab8409b0f5bf0fbca174fb8fbcf012815326b5c71a9d7c385cde9a8f87b')
+    version('2020.6', sha256='d8bbe57ed3c9925a8cb99ecfe39e217f930bed47d5268a9e42b33da544bdb2ee')
     version('2020.5', sha256='7b6aff647f7c8ee1bf12204d02cef7c55f44402a73195bd5f42cf11850616478')
     version('2020.4', sha256='5519690321b5500c7951aaf53ff624042c3edd1a5f5d6dd1f2d802a3ecdbf4e6')
     version('2020.3', sha256='903183691132db14e55b011305db4b6f4901cc4912d2c56c131edfef18cc92a9')
@@ -96,6 +97,7 @@ class Gromacs(CMakePackage):
 
     depends_on('mpi', when='+mpi')
 
+    # Plumed 2.7.2 needs Gromacs 2021, 2020.6, 2019.6
     # Plumed 2.7.1 needs Gromacs 2021, 2020.5, 2019.6
     # Plumed 2.7.0 needs Gromacs       2020.4, 2019.6
     # Plumed 2.6.3 needs Gromacs       2020.4, 2019.6, 2018.8
@@ -117,8 +119,10 @@ class Gromacs(CMakePackage):
 
     depends_on('plumed+mpi', when='+plumed+mpi')
     depends_on('plumed~mpi', when='+plumed~mpi')
-    depends_on('plumed@2.7.1+mpi', when='@2021+plumed+mpi')
-    depends_on('plumed@2.7.1~mpi', when='@2021+plumed~mpi')
+    depends_on('plumed@2.7.1:2.7.2+mpi', when='@2021+plumed+mpi')
+    depends_on('plumed@2.7.1:2.7.2~mpi', when='@2021+plumed~mpi')
+    depends_on('plumed@2.7.2+mpi', when='@2020.6+plumed+mpi')
+    depends_on('plumed@2.7.2~mpi', when='@2020.6+plumed~mpi')
     depends_on('plumed@2.7.1+mpi', when='@2020.5+plumed+mpi')
     depends_on('plumed@2.7.1~mpi', when='@2020.5+plumed~mpi')
     depends_on('plumed@2.6.2:2.7.0+mpi', when='@2020.4+plumed+mpi')

--- a/var/spack/repos/builtin/packages/plumed/package.py
+++ b/var/spack/repos/builtin/packages/plumed/package.py
@@ -25,6 +25,7 @@ class Plumed(AutotoolsPackage):
     git = 'https://github.com/plumed/plumed2.git'
 
     version('master', branch='master')
+    version('2.7.2', sha256='c9a31e68d6440828cf186ca43c9e11a5e5c7ad1c96b2b66ed5a5a141fc954373')
     version('2.7.1', sha256='cb8b5735d8dd61980fa6441f3dde3f33544240ae4177da0f529fb5abb355cd4a')
     version('2.7.0', sha256='14450ea566c25ac9bf71fd77bb9c0c95e9038462b5739c73a515be82e2011cd6')
     version('2.6.3', preferred=True, sha256='d05b9e4a4c1329fc932d5bdd04f20419be230f98159bdc012a91716461ab4a2f')


### PR DESCRIPTION
- [x] Adds two hashes for Gromacs and Plumed
- [x] Adds Plumed 2.7.2 to Gromacs version constraints 

# Tests

- `spack spec gromacs@2020.6+plumed` pulls Plumed 2.7.2
- `spack spec gromacs@2021+plumed` pulls Plumed 2.7.2
- `spack spec gromacs@2020.5+plumed` pulls Plumed 2.7.1
- `spack install gromacs@2020.6~mpi+plumed` installs successfully
- `spack load gromacs@2020.6~mpi+plumed` `gmx` runs successfully