### PR TITLE
Fix potentially broken shutil.rmtree in tests

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -971,7 +971,10 @@ def mock_gnupghome(monkeypatch):
         yield short_name_tmpdir
 
     # clean up, since we are doing this manually
-    shutil.rmtree(short_name_tmpdir)
+    # Ignore errors cause we seem to be hitting a bug similar to
+    # https://bugs.python.org/issue29699 in CI (FileNotFoundError: [Errno 2] No such
+    # file or directory: 'S.gpg-agent.extra').
+    shutil.rmtree(short_name_tmpdir, ignore_errors=True)
 
 ##########
 # Fake archives and repositories


### PR DESCRIPTION
fixes https://github.com/spack/spack/issues/17405

This silences the spurious but common CI failure:

```
FileNotFoundError: [Errno 2] No such file or directory: 'S.gpg-agent.extra'
```

The problem is:

> `shutil.rmtree` deleted the agents main socket, `gpg-agent`
> detected that, and deleted the other sockets as well, racing
> `shutil.rmtree` which did not cope will with that.

The fix is to ignore `shutil.rmtree` errors.

See 

- https://bugs.python.org/issue29699 
- https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;a=commitdiff;h=de8494b16bc50c60a8438f2cae1f8c88e8949f7a

for details. The issue is known to Python devs since March 2017, and
they don't seem keen on fixing it.