### PR TITLE
Allowing spack monitor to handle redirect

### DIFF
--- a/lib/spack/spack/monitor.py
+++ b/lib/spack/spack/monitor.py
@@ -278,6 +278,22 @@ class SpackMonitorClient:
                     )
                     return self.issue_request(request, False)
 
+            # Handle permanent re-directs!
+            elif hasattr(e, "code") and e.code == 308:
+                location = e.headers.get('Location')
+
+                request_data = None
+                if request.data:
+                    request_data = sjson.load(request.data.decode('utf-8'))[0]
+
+                if location:
+                    request = self.prepare_request(
+                        location,
+                        request_data,
+                        self.headers
+                    )
+                    return self.issue_request(request, True)
+
             # Otherwise, relay the message and exit on error
             msg = ""
             if hasattr(e, 'reason'):


### PR DESCRIPTION
when deployed on kubernetes, the server sends back permanent redirect responses. This is elegantly handled by the requests library, but not urllib that we have to use here, so I have to manually handle it by parsing the exception to get the Location header, and then retrying the request there. The new monitor server on Kubernetes won't work with spack without this update.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>