### PR TITLE
py-pandas: fix installation and tests for versions @:0.25

### DIFF
--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -13,21 +13,6 @@ class PyPandas(PythonPackage):
     pypi = "pandas/pandas-1.2.0.tar.gz"
 
     maintainers = ['adamjstewart']
-    import_modules = [
-        'pandas', 'pandas.compat', 'pandas.compat.numpy', 'pandas.core',
-        'pandas.core.reshape', 'pandas.core.tools', 'pandas.core.util',
-        'pandas.core.array_algos', 'pandas.core.dtypes', 'pandas.core.groupby',
-        'pandas.core.internals', 'pandas.core.computation',
-        'pandas.core.window', 'pandas.core.arrays',
-        'pandas.core.arrays.sparse', 'pandas.core.ops', 'pandas.core.sparse',
-        'pandas.core.indexes', 'pandas.util', 'pandas.io', 'pandas.io.formats',
-        'pandas.io.excel', 'pandas.io.json', 'pandas.io.sas',
-        'pandas.io.clipboard', 'pandas.tseries', 'pandas._libs',
-        'pandas._libs.window', 'pandas._libs.tslibs', 'pandas.plotting',
-        'pandas.arrays', 'pandas.api', 'pandas.api.indexers',
-        'pandas.api.types', 'pandas.api.extensions', 'pandas.errors',
-        'pandas._config'
-    ]
 
     version('1.3.3',  sha256='272c8cb14aa9793eada6b1ebe81994616e647b5892a370c7135efb2924b701df')
     version('1.3.2',  sha256='cbcb84d63867af3411fa063af3de64902665bb5b3d40b25b2059e40603594e87')
@@ -78,6 +63,8 @@ class PyPandas(PythonPackage):
     depends_on('py-setuptools@24.2.0:', type='build')
     depends_on('py-setuptools@38.6.0:', type='build', when='@1.3:')
     depends_on('py-numpy', type=('build', 'run'))
+    # 'NUMPY_IMPORT_ARRAY_RETVAL' was removed in numpy@0.19
+    depends_on('py-numpy@:1.18', type=('build', 'run'), when='@:0.25')
     depends_on('py-numpy@1.13.3:', type=('build', 'run'), when='@0.25:')
     depends_on('py-numpy@1.15.4:', type=('build', 'run'), when='@1.1:')
     depends_on('py-numpy@1.16.5:', type=('build', 'run'), when='@1.2:')
@@ -99,3 +86,12 @@ class PyPandas(PythonPackage):
 
     # Optional dependencies
     # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#optional-dependencies
+
+    @property
+    def import_modules(self):
+        modules = super().import_modules
+
+        ignored_imports = ["pandas.tests", "pandas.plotting._matplotlib"]
+
+        return [i for i in modules
+                if not any(map(i.startswith, ignored_imports))]


### PR DESCRIPTION
Fixes installation of older `py-pandas` versions which did not build with newer `py-numpy` versions.

Tests for these older versions also did not run through because `import_modules` where different. Instead of tracing back which modules changed for which `py-pandas` version, I decided to go the opposite way and use the automatic retrieved ones and remove those we do not want to test. This should also be way easier to maintain in the future. I have checked if the tests now work for versions 1.3.3, 0.24.2 and 1.1.5, which they do.