### PR TITLE
ispc: update development branch name and LLVM dependency

### DIFF
--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -39,7 +39,8 @@ class Ispc(CMakePackage):
     depends_on('ncurses', type='link')
     depends_on('zlib', type='link')
     depends_on('llvm+clang')
-    depends_on('llvm@11:', when='@1.16:')
+    depends_on('llvm@:12', when='@:1.16')
+    depends_on('llvm@11:', when='@1.16.0:')
     depends_on('llvm@10:11', when='@1.15.0:1.15')
     depends_on('llvm@10.0:10', when='@1.13:1.14')
 

--- a/var/spack/repos/builtin/packages/ispc/package.py
+++ b/var/spack/repos/builtin/packages/ispc/package.py
@@ -25,7 +25,7 @@ class Ispc(CMakePackage):
 
     executables = ['^ispc$']
 
-    version('master', branch='master')
+    version('main', branch='main')
     version('1.16.1', sha256='b32dbd374eea5f1b5f535bfd79c5cc35591c0df2e7bf1f86dec96b74e4ebf661')
     version('1.16.0', sha256='12db1a90046b51752a65f50426e1d99051c6d55e30796ddd079f7bc97d5f6faf')
     version('1.15.0', sha256='3b634aaa10c9bf0e82505d1af69cb307a3a00182d57eae019680ccfa62338af9')


### PR DESCRIPTION
released versions of ispc do not build against LLVM 13, and development seems to happen on main instead of master