### PR TITLE
gromacs: @2020: add #include <limits> for newer %gcc builds

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -172,6 +172,20 @@ class Gromacs(CMakePackage):
         relative_root=os.path.join('share', 'cmake', 'gromacs'))
 
     def patch(self):
+        # Otherwise build fails with GCC 11 (11.2)
+        if self.spec.satisfies('@2018:2020.6'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/awh/biasparams.h')
+        if self.spec.satisfies('@2018:2018.8'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/mdlib/minimize.cpp')
+        if self.spec.satisfies('@2019:2019.6,2020:2020.6'):
+            filter_file('#include <vector>', '#include <vector>\n#include <limits>',
+                        'src/gromacs/mdrun/minimize.cpp')
+        if self.spec.satisfies('@2020:2020.6'):
+            filter_file('#include <queue>', '#include <queue>\n#include <limits>',
+                        'src/gromacs/modularsimulator/modularsimulator.h')
+
         if '+plumed' in self.spec:
             self.spec['plumed'].package.apply_patch(self)
 


### PR DESCRIPTION

We noticed this during review of #26663:

`gromacs@2020:2020.6` is fixed to build at least with `gcc@11.2.0`
by adding #include <limits> to two header files.

Thanks to Maciej Wójcik <w8jcik@gmail.com> for testing versions.