### PR TITLE
edm4hep: Add latest version and Catch2 test depenency

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -16,6 +16,7 @@ class Edm4hep(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version('master', branch='master')
+    version('0.3.2', sha256='b6a28649a4ba9ec1c4423bd1397b0a810ca97374305c4856186b506e4c00f769')
     version('0.3.1', sha256='eeec38fe7d72d2a72f07a63dca0a34ca7203727f67869c0abf6bef014b8b319b')
     version('0.3', sha256='d0ad8a486c3ed1659ea97d47b268fe56718fdb389b5935f23ba93804e4d5fbc5')
 
@@ -33,6 +34,7 @@ class Edm4hep(CMakePackage):
 
     depends_on('hepmc@:2', type='test')
     depends_on('heppdt', type='test')
+    depends_on('catch2@3.0.1:', type='test')
 
     def cmake_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -20,6 +20,8 @@ class Edm4hep(CMakePackage):
     version('0.3.1', sha256='eeec38fe7d72d2a72f07a63dca0a34ca7203727f67869c0abf6bef014b8b319b')
     version('0.3', sha256='d0ad8a486c3ed1659ea97d47b268fe56718fdb389b5935f23ba93804e4d5fbc5')
 
+    patch('test-deps.patch', when='@:0.3.2')
+
     variant('cxxstd',
             default='17',
             values=('17',),

--- a/var/spack/repos/builtin/packages/edm4hep/test-deps.patch
+++ b/var/spack/repos/builtin/packages/edm4hep/test-deps.patch
@@ -1,0 +1,12 @@
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 6413c03..11325a4 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -54,6 +54,7 @@ IF(TARGET ROOT::ROOTDataFrame)
+   add_test(NAME test_rdf COMMAND test_rdf)
+   set_tests_properties(test_rdf PROPERTIES
+     ENVIRONMENT LD_LIBRARY_PATH=$<TARGET_FILE_DIR:edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$ENV{LD_LIBRARY_PATH}
++    DEPENDS write_events
+     )
+ endif()
+ 


### PR DESCRIPTION
Add latest version and the dependency on Catch2 v3 for tests.