### PR TITLE
damask-{grid,mesh}: Use hdf5+hl as py-h5py uses it, cleanup LDFLAGS

### DIFF
--- a/var/spack/repos/builtin/packages/damask-mesh/package.py
+++ b/var/spack/repos/builtin/packages/damask-mesh/package.py
@@ -17,9 +17,12 @@ class DamaskMesh(CMakePackage):
 
     depends_on('pkgconfig', type='build')
     depends_on('cmake@3.10:', type='build')
+    depends_on('petsc+hdf5+mpi')
     depends_on('petsc@3.14.0:3.14,3.15.1:3.15', when='@3.0.0-alpha4')
     depends_on('petsc@3.14.0:3.14,3.15.1:3.16', when='@3.0.0-alpha5')
-    depends_on('hdf5+fortran')
+
+    # See damask-grid for a full explanation of what this does exactly.
+    depends_on('hdf5+fortran+hl')
 
     patch('CMakeDebugRelease.patch', when='@3.0.0-alpha4')
 
@@ -27,12 +30,8 @@ class DamaskMesh(CMakePackage):
             description='The build type to build',
             values=('Debug', 'Release', 'DebugRelease'))
 
-    def patch(self):
-        filter_file(' -lhdf5 ', ' -lhdf5_fortran -lhdf5 ', 'CMakeLists.txt')
-
     def cmake_args(self):
-        args = ['-DDAMASK_SOLVER:STRING=mesh']
-        return args
+        return [self.define('DAMASK_SOLVER', 'mesh')]
 
     @run_after('install')
     @on_package_attributes(run_tests=True)

--- a/var/spack/repos/builtin/packages/py-damask/package.py
+++ b/var/spack/repos/builtin/packages/py-damask/package.py
@@ -22,5 +22,8 @@ class PyDamask(PythonPackage):
     depends_on('py-h5py')
     depends_on('py-matplotlib')
     depends_on('py-pyyaml')
+    # Force the hdf5+hl variant added by py-h5py to also have +fortan.
+    # This makes that hdf5 to use the same variants as damask-grid and damask-mesh:
+    depends_on('hdf5+fortran')
 
     build_directory = 'python'


### PR DESCRIPTION
@sethrj This PR is ready for **merge** or ***final merge-review***

# Latest Status: 
spack-maintainer and upstream approval by @MarDiehl:

@MarDiehl did a final rebuild from scratch no a new computer as well and reported (emphasis mine):
> installing from scratch works like a charm, ***green lights from my side.***

---
---
# Description

For reproduibility, this build-only update cleans up the build of the individual packages to use the same concretization of hdf5 for all packages, even when built independenty.

As a minor improvement, it cleans up the how the build flags are passed, pending further improvements in upstream `CMakeLists.txt` to enable passing which FFTW Libs to use flags as CMake variables without patching `CMakeLists.txt`

# Original message

@MarDiehl - I've built alpha4 and alpha5 with this. I it should explain and fix remaining issues:

> The package damask depends on py-damask which depends on py-h5py,
which depends hdf5@1.8.4:+hl. As spack can only use one concretisation
a build, 'spack install damask', spack is forced to use hdf5@1.8.4:+hl.
>
> When damask-grid is built without that concretisation in the picture,
e.g using 'spack install damask-grid', spack would use the hdf5~hl instead.
>
> To avoid producing two different builds of hdf5 (and damask-grid as result),
add +hl to the list of requested variants of damask-grid and -mesh.

Further explanation: the hdf5 libs are now added by CMake itself thru pkg-config, you should install pkg-config on your host as well if you build without spack. But some build machines might not have it, therefore keep is also as a depends_on in the recipes.

But it means you would not have to add -lhdf5_fortran to the CMakeLists, cmake and pkgconfig would take care of this as long as hdf5 provide the pkg-config file that enable it.

This cleanup therefore removes it. I hope it works for you too, at least in spack!

Using LDFLAGS to pass the FFTW libs didn't work, but to enable passing them without patching in the future, this cleanup uses a CMake variable which can be set as a CMake argument to add FFTW libs.

Ideally, the next improvement would be that the Alpha release should add `${FFTW_LIBS}` to the patched line. Then the damask recipes in `spack` don't have to filter the `CMakeLists.txt` to add it, and you can use it `-DFFTW_LIBS="..."` for other builds as well.

I hope this helps. If it works for you and you'd approve it, please add a comment that you approve this PR, we can then try to find a spack maintainer for merging it to develop.