### PR TITLE
babelflow, parallelmergetree: fix build with gcc11

### DIFF
--- a/var/spack/repos/builtin/packages/babelflow/package.py
+++ b/var/spack/repos/builtin/packages/babelflow/package.py
@@ -25,6 +25,11 @@ class Babelflow(CMakePackage):
 
     variant("shared", default=True, description="Build Babelflow as shared libs")
 
+    # The C++ headers of gcc-11 don't provide <limits> as side effect of others
+    @when('%gcc@11:')
+    def setup_build_environment(self, env):
+        env.append_flags('CXXFLAGS', '-include limits')
+
     def cmake_args(self):
         args = [self.define_from_variant('BUILD_SHARED_LIBS', 'shared')]
         return args

--- a/var/spack/repos/builtin/packages/parallelmergetree/package.py
+++ b/var/spack/repos/builtin/packages/parallelmergetree/package.py
@@ -37,6 +37,11 @@ class Parallelmergetree(CMakePackage):
 
     variant("shared", default=True, description="Build ParallelMergeTree as shared libs")
 
+    # The C++ headers of gcc-11 don't provide <algorithm> as side effect of others
+    @when('%gcc@11:')
+    def setup_build_environment(self, env):
+        env.append_flags('CXXFLAGS', '-include algorithm')
+
     def cmake_args(self):
         args = []
 


### PR DESCRIPTION
gcc-11 does not include the <limits> and <algorithm> as side effect
of including other header, at least not as often as earlier gcc did.