### PR TITLE
Don't print error output in the test whether gpgconf works

### DIFF
--- a/lib/spack/spack/util/gpg.py
+++ b/lib/spack/spack/util/gpg.py
@@ -344,7 +344,7 @@ def _gpgconf():
 
     # ensure that the gpgconf we found can run "gpgconf --create-socketdir"
     try:
-        exe('--dry-run', '--create-socketdir')
+        exe('--dry-run', '--create-socketdir', output=os.devnull, error=os.devnull)
     except spack.util.executable.ProcessError:
         # no dice
         exe = None


### PR DESCRIPTION
In the test failure of centos 6 here: https://github.com/spack/spack/runs/3870440581

The stderr output is a red herring :( gpgcong --create-socketdir errors, but it errors during the test that detects whether it works.

So instead silence the stderr/stdout and just look at the return code.
