### PR TITLE
Fix Amber patch target specification

### DIFF
--- a/var/spack/repos/builtin/packages/amber/package.py
+++ b/var/spack/repos/builtin/packages/amber/package.py
@@ -101,10 +101,10 @@ class Amber(Package, CudaPackage):
               sha256=checksum, level=0, when='@{0}'.format(ver))
 
     # Patch to add ppc64le in config.guess
-    patch('ppc64le.patch', when='@18: target=ppc64le')
+    patch('ppc64le.patch', when='@18: target=ppc64le:')
 
     # Patch to add aarch64 in config.guess
-    patch('aarch64.patch', when='@18: target=aarch64')
+    patch('aarch64.patch', when='@18: target=aarch64:')
 
     # Workaround to modify the AmberTools script when using the NVIDIA
     # compilers


### PR DESCRIPTION
The patches to add ppc64le and aarch64 in config.guess were not being applied.  Fix this by specifying an open range to select all architectures in the family (https://github.com/spack/spack/blob/develop/lib/spack/docs/packaging_guide.rst#querying-the-target-microarchitecture).