### PR TITLE
flux-core, -sched, mpibind: integrate fux-clore@0.30.0 

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -19,6 +19,7 @@ class FluxCore(AutotoolsPackage):
     maintainers = ['SteVwonder']
 
     version('master', branch='master')
+    version('0.30.0', sha256='e51fde4464140367ae4bc1b44f960675ea0a6f58eede3a561cacd8a11ca3e776')
     version('0.29.0', sha256='c13b40e82d66356e75208a689a495ca01f0a013e2e45ac8ea202ed8224987323')
     version('0.28.0', sha256='9a784def7186b0036091bd8d6d8fe5bc3425ab2927e1465e1c9ad266631c285d')
     version('0.27.0', sha256='abd46d38081ba6b501adb1c111374b39d6ae72ac1aec9fbbf31943a856541d3a')
@@ -77,6 +78,8 @@ class FluxCore(AutotoolsPackage):
     depends_on("valgrind", type="test")
     depends_on("jq", type="test")
 
+    conflicts('%gcc@11:', when='@:0.29')
+
     def url_for_version(self, version):
         '''
         Flux uses a fork of ZeroMQ's Collective Code Construction Contract
@@ -94,6 +97,11 @@ class FluxCore(AutotoolsPackage):
         else:
             url = "https://github.com/flux-framework/flux-core-v{1}/releases/download/v{0}/flux-core-{0}.tar.gz"
         return url.format(version.up_to(3), version.up_to(2))
+
+    def patch(self):
+        filter_file('#include "czmq_rename.h"',
+                    '#include "czmq_rename.h"\ntypedef struct _zframe_t zframe_t;',
+                    'src/common/libczmqcontainers/czmq_containers.h')
 
     def setup(self):
         pass

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -54,6 +54,9 @@ class FluxSched(AutotoolsPackage):
     depends_on("flux-core@0.28.0:", when='@0.17.0', type=('build', 'run', 'link'))
     depends_on("flux-core@master", when='@master', type=('build', 'run', 'link'))
 
+    # https://github.com/flux-framework/flux-core/pull/3879
+    conflicts("flux-core@0.30", when='@:0.18.0', msg='@0.30.0 needs master or new rel')
+
     # Need autotools when building on master:
     depends_on("autoconf", type='build', when='@master')
     depends_on("automake", type='build', when='@master')

--- a/var/spack/repos/builtin/packages/mpibind/package.py
+++ b/var/spack/repos/builtin/packages/mpibind/package.py
@@ -31,6 +31,9 @@ class Mpibind(AutotoolsPackage):
     variant('flux', default=False,
             description='Build the Flux plugin.')
 
+    conflicts('+flux', when='@:0.6',
+              msg='flux variant is not available until mpibind 0.7.0')
+
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
@@ -42,10 +45,12 @@ class Mpibind(AutotoolsPackage):
     depends_on('hwloc@2:+cuda+nvml', when='+cuda', type='link')
     depends_on('hwloc@2.4:+rocm+opencl', when='+rocm', type='link')
 
-    # Requiring @master temporarily while Flux adds
-    # FLUX_SHELL_RC_PATH to a stable version (>0.29.0).
-    # mpibind will require at least such version.
-    depends_on('flux-core@master', when='+flux', type='link')
+    # Need FLUX_SHELL_RC_PATH from (>=0.30.0) for flux variant:
+    depends_on('flux-core@0.30.0:', when='+flux', type='link')
+
+    # https://github.com/flux-framework/flux-core/pull/3879
+    conflicts("flux-core@0.30:", when='@:0.6+flux',
+              msg='flux-core >= 0.30.0 is not supported with mpibind < 0.7.0')
 
     def autoreconf(self, spec, prefix):
         autoreconf('--install', '--verbose', '--force')


### PR DESCRIPTION
Addresses my build issue with flux-core:

flux-core: Add 0.30.0 to fix %gcc@11.2.0, add zframe_t to czmq_containers.h  
* To build with `%gcc@11.2.0`, `@0.30.0` (added) is needed, conflict older versions.
* Add typedef struct _zframe_t zframe_t to src/common/libczmqcontainers/czmq_containers.h to fix 'unknown type zframe_t' in files using this include file.
* mpibind, flux-sched: Update to cope with new flux-core@0.30.0 due to the included API change: https://github.com/flux-framework/flux-core/pull/3879 (this 2nd commit make them use master until a newer release is added the them when building with flux-core@0.30.0)
