### PR TITLE
Combine tags -- e4s and radiuss -- into one list

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -19,9 +19,7 @@ class Caliper(CMakePackage, CudaPackage):
     homepage = "https://github.com/LLNL/Caliper"
     git      = "https://github.com/LLNL/Caliper.git"
     url      = "https://github.com/LLNL/Caliper/archive/v2.6.0.tar.gz"
-    tags     = ['radiuss']
-
-    tags = ['e4s']
+    tags     = ['e4s', 'radiuss']
 
     maintainers = ["daboehme"]
 

--- a/var/spack/repos/builtin/packages/chai/package.py
+++ b/var/spack/repos/builtin/packages/chai/package.py
@@ -15,11 +15,9 @@ class Chai(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/LLNL/CHAI"
     git      = "https://github.com/LLNL/CHAI.git"
-    tags     = ['radiuss']
+    tags     = ['ecp', 'e4s', 'radiuss']
 
     maintainers = ['davidbeckingsale']
-
-    tags = ['ecp', 'e4s']
 
     version('develop', branch='develop', submodules=True)
     version('main', branch='main', submodules=True)

--- a/var/spack/repos/builtin/packages/hypre/package.py
+++ b/var/spack/repos/builtin/packages/hypre/package.py
@@ -17,11 +17,9 @@ class Hypre(AutotoolsPackage, CudaPackage):
     homepage = "https://computing.llnl.gov/project/linear_solvers/software.php"
     url      = "https://github.com/hypre-space/hypre/archive/v2.14.0.tar.gz"
     git      = "https://github.com/hypre-space/hypre.git"
-    tags     = ['radiuss']
+    tags     = ['e4s', 'radiuss']
 
     maintainers = ['ulrikeyang', 'osborn9', 'balay']
-
-    tags = ['e4s']
 
     test_requires_compiler = True
 

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -25,9 +25,7 @@ class Scr(CMakePackage):
     homepage = "https://computing.llnl.gov/projects/scalable-checkpoint-restart-for-mpi"
     url      = "https://github.com/LLNL/scr/archive/v1.2.0.tar.gz"
     git      = "https://github.com/llnl/scr.git"
-    tags     = ['radiuss']
-
-    tags = ['e4s']
+    tags     = ['e4s', 'radiuss']
 
     version('develop', branch='develop')
     version('legacy', branch='legacy', deprecated=True)


### PR DESCRIPTION
Somewhere along the line several packages appear to have not had conflicts resolved such that the tags lists merged.  This PR combines the lists so there is only one `tags` property for the associated packages.