### PR TITLE
qgis: fix build of LTS release with proj>7

### DIFF
--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -161,7 +161,10 @@ class Qgis(CMakePackage):
                     self.spec['geos'].prefix.bin,
                     '-DGSL_CONFIG_PREFER_PATH=' + self.spec['gsl'].prefix.bin,
                     '-DPOSTGRES_CONFIG_PREFER_PATH=' +
-                    self.spec['postgresql'].prefix.bin
+                    self.spec['postgresql'].prefix.bin,
+                    '-DPROJ_INCLUDE_DIR=' + self.spec['proj'].prefix.include,
+                    '-DSQLITE3_LIBRARY='
+                    + join_path(self.spec['sqlite'].prefix.lib, 'libsqlite3.so')
                     ])
 
         args.extend([
@@ -232,3 +235,7 @@ class Qgis(CMakePackage):
         else:
             args.append('-DWITH_GRASS7=OFF')
         return args
+
+    def check(self):
+        """The tests of fail without access to an X server, cant run on build servers"""
+        pass

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -162,7 +162,7 @@ class Qgis(CMakePackage):
                     '-DGSL_CONFIG_PREFER_PATH=' + self.spec['gsl'].prefix.bin,
                     '-DPOSTGRES_CONFIG_PREFER_PATH=' +
                     self.spec['postgresql'].prefix.bin,
-                    '-DPROJ_INCLUDE_DIR=' + self.spec['proj'].headers.directories[0]
+                    '-DPROJ_INCLUDE_DIR=' + self.spec['proj'].headers.directories[0],
                     '-DSQLITE3_LIBRARY='
                     + self.spec['sqlite'].libs[0]
                     ])

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -162,7 +162,7 @@ class Qgis(CMakePackage):
                     '-DGSL_CONFIG_PREFER_PATH=' + self.spec['gsl'].prefix.bin,
                     '-DPOSTGRES_CONFIG_PREFER_PATH=' +
                     self.spec['postgresql'].prefix.bin,
-                    '-DPROJ_INCLUDE_DIR=' + self.spec['proj'].prefix.include,
+                    '-DPROJ_INCLUDE_DIR=' + self.spec['proj'].headers.directories[0]
                     '-DSQLITE3_LIBRARY='
                     + self.spec['sqlite'].libs[0]
                     ])

--- a/var/spack/repos/builtin/packages/qgis/package.py
+++ b/var/spack/repos/builtin/packages/qgis/package.py
@@ -164,7 +164,7 @@ class Qgis(CMakePackage):
                     self.spec['postgresql'].prefix.bin,
                     '-DPROJ_INCLUDE_DIR=' + self.spec['proj'].prefix.include,
                     '-DSQLITE3_LIBRARY='
-                    + join_path(self.spec['sqlite'].prefix.lib, 'libsqlite3.so')
+                    + self.spec['sqlite'].libs[0]
                     ])
 
         args.extend([


### PR DESCRIPTION
Apply upstream patch to qgis@3.16:3.19 to fix build with proj@8