### PR TITLE
r-imager: add depends_on('r+X') and bump version

### DIFF
--- a/var/spack/repos/builtin/packages/r-imager/package.py
+++ b/var/spack/repos/builtin/packages/r-imager/package.py
@@ -24,7 +24,7 @@ class RImager(RPackage):
     version('0.42.3', sha256='6fc308153df8251cef48f1e13978abd5d29ec85046fbe0b27c428801d05ebbf3')
     version('0.41.2', sha256='9be8bc8b3190d469fcb2883045a404d3b496a0380f887ee3caea11f0a07cd8a5')
 
-    depends_on('libx11')
+    depends_on('r+X')
     depends_on('r@2.10.0:', type=('build', 'run'))
     depends_on('r-magrittr', type=('build', 'run'))
     depends_on('r-rcpp@0.11.5:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-imager/package.py
+++ b/var/spack/repos/builtin/packages/r-imager/package.py
@@ -20,9 +20,11 @@ class RImager(RPackage):
     url      = "https://cloud.r-project.org/src/contrib/imager_0.41.2.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/imager"
 
+    version('0.42.10', sha256='01939eb03ad2e1369a4240a128c3b246a4c56f572f1ea4967f1acdc555adaeee')
     version('0.42.3', sha256='6fc308153df8251cef48f1e13978abd5d29ec85046fbe0b27c428801d05ebbf3')
     version('0.41.2', sha256='9be8bc8b3190d469fcb2883045a404d3b496a0380f887ee3caea11f0a07cd8a5')
 
+    depends_on('libx11')
     depends_on('r@2.10.0:', type=('build', 'run'))
     depends_on('r-magrittr', type=('build', 'run'))
     depends_on('r-rcpp@0.11.5:', type=('build', 'run'))


### PR DESCRIPTION
Add depends_on('x11') to fix the build and bump the version