### PR TITLE
wireshark: Fix install race and skip network capture tests

### DIFF
--- a/var/spack/repos/builtin/packages/wireshark/package.py
+++ b/var/spack/repos/builtin/packages/wireshark/package.py
@@ -39,6 +39,11 @@ class Wireshark(CMakePackage):
     depends_on('nghttp2',   when='+nghttp2')
     depends_on('qt@4.8:',   when='+qt')
 
+    def patch(self):
+        # These try to capture from the network and run not compiled programs
+        filter_file('suite_capture',   '', 'CMakeLists.txt')
+        filter_file('suite_unittests', '', 'CMakeLists.txt')
+
     def cmake_args(self):
         args = [
             '-DENEABLE_CARES=ON',
@@ -96,5 +101,6 @@ class Wireshark(CMakePackage):
             folders = ['.', 'epan/crypt', 'epan/dfilter', 'epan/dissectors',
                        'epan/ftypes', 'epan/wmem', 'wiretap', 'wsutil']
             for folder in folders:
+                mkdirp(join_path(prefix.include.wireshark, folder))
                 install(join_path(folder, '*.h'),
                         join_path(prefix.include.wireshark, folder))


### PR DESCRIPTION
The network capture tests can't pass when built as normal user.