### PR TITLE
vc: Enable the testsuite, excluding tests failing on Zen2

### DIFF
--- a/var/spack/repos/builtin/packages/vc/package.py
+++ b/var/spack/repos/builtin/packages/vc/package.py
@@ -23,6 +23,15 @@ class Vc(CMakePackage):
             values=('Debug', 'Release', 'RelWithDebug',
                     'RelWithDebInfo', 'MinSizeRel'))
 
+    # Build fails without it when --test is used, can't be type='test':
+    depends_on('virtest')
+
+    def patch(self):
+        tests = FileFilter('tests/CMakeLists.txt')
+        tests.filter(';AVX2', '')
+        tests.filter('.*logarithm.*', '')
+        tests.filter('.*trigonometric.*', '')
+
     def cmake_args(self):
         if self.run_tests:
             return ['-DBUILD_TESTING=ON']

--- a/var/spack/repos/builtin/packages/virtest/package.py
+++ b/var/spack/repos/builtin/packages/virtest/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack import *
+
+
+class Virtest(CMakePackage):
+    """Header-only unit test framework, as easy as possible to use"""
+
+    homepage    = 'https://github.com/mattkretz/virtest'
+    git         = 'https://github.com/mattkretz/virtest.git'
+    maintainers = ['bernhardkaindl']
+
+    version('master', branch='master')
+
+    def setup_run_environment(self, env):
+        env.prepend_path('CPATH', self.prefix.include.vir)
+
+    @run_after('install')
+    def rename_include_for_vc_package(self):
+        with working_dir(self.prefix.include):
+            os.rename('vir', 'virtest')


### PR DESCRIPTION
This fixes running the testsuite, it adds the package virtest for it.