### PR TITLE
Constrain abstract specs rather than concatenating strings in the "when" context manager

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2810,7 +2810,7 @@ The snippet above is equivalent to the more verbose:
        conflicts('languages=brig', when='+nvptx')
        conflicts('languages=go', when='+nvptx')
 
-Constraints stemming from the context are added to what is explicitly present in the
+Constraints stemming from the context are by default appended to what is explicitly present in the
 ``when=`` argument of a directive, so:
 
 .. code-block:: python
@@ -2824,7 +2824,20 @@ is equivalent to:
 
    depends_on('elpa+openmp', when='+openmp+elpa')
 
-Constraints from nested context managers are also added together, but they are rarely
+Sometimes the constraint that is grouped together in the context manager needs to be
+prepended for the ``when=`` argument to make sense. In those cases users need to specify
+that behavior with a keyword argument:
+
+.. code-block:: python
+
+   with when('@14:', prepend=True):
+       depends_on('py-distro', when='^python@3.8:')
+
+In the example above ``prepend=True`` is needed to constrain the dependency
+on ``@0.14: ^python@3.8:``. Not doing so would result in a syntax error since
+``^python@3.8: @0.14:`` is an invalid spec.
+
+Constraints from nested context managers are also combined together, but they are rarely
 needed or recommended.
 
 .. _install-method:

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2810,7 +2810,7 @@ The snippet above is equivalent to the more verbose:
        conflicts('languages=brig', when='+nvptx')
        conflicts('languages=go', when='+nvptx')
 
-Constraints stemming from the context are by default appended to what is explicitly present in the
+Constraints stemming from the context are added to what is explicitly present in the
 ``when=`` argument of a directive, so:
 
 .. code-block:: python
@@ -2823,19 +2823,6 @@ is equivalent to:
 .. code-block:: python
 
    depends_on('elpa+openmp', when='+openmp+elpa')
-
-Sometimes the constraint that is grouped together in the context manager needs to be
-prepended for the ``when=`` argument to make sense. In those cases users need to specify
-that behavior with a keyword argument:
-
-.. code-block:: python
-
-   with when('@14:', prepend=True):
-       depends_on('py-distro', when='^python@3.8:')
-
-In the example above ``prepend=True`` is needed to constrain the dependency
-on ``@0.14: ^python@3.8:``. Not doing so would result in a syntax error since
-``^python@3.8: @0.14:`` is an invalid spec.
 
 Constraints from nested context managers are also combined together, but they are rarely
 needed or recommended.

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -88,7 +88,7 @@ class CudaPackage(PackageBase):
 
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132
-    with when('~allow-unsupported-compilers'):
+    with when('^cuda~allow-unsupported-compilers'):
         # GCC
         # According to
         # https://github.com/spack/spack/pull/25054#issuecomment-886531664

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -112,7 +112,8 @@ class DirectiveMeta(type):
     # Set of all known directives
     _directive_names = set()  # type: Set[str]
     _directives_to_be_executed = []  # type: List[str]
-    _when_constraints_from_context = []  # type: List[str]
+    _when_constraints_appended_from_context = []  # type: List[str]
+    _when_constraints_prepended_from_context = []  # type: List[str]
 
     def __new__(cls, name, bases, attr_dict):
         # Initialize the attribute containing the list of directives
@@ -167,14 +168,28 @@ class DirectiveMeta(type):
         super(DirectiveMeta, cls).__init__(name, bases, attr_dict)
 
     @staticmethod
-    def push_to_context(when_spec):
-        """Add a spec to the context constraints."""
-        DirectiveMeta._when_constraints_from_context.append(when_spec)
+    def _when_context_list(prepend):
+        context_attribute = DirectiveMeta._when_constraints_appended_from_context
+        if prepend is True:
+            context_attribute = DirectiveMeta._when_constraints_prepended_from_context
+        return context_attribute
 
     @staticmethod
-    def pop_from_context():
+    def push_to_context(when_spec, prepend):
+        """Add a spec to the context constraints."""
+        context_attribute = DirectiveMeta._when_context_list(prepend)
+        context_attribute.append(when_spec)
+
+    @staticmethod
+    def pop_from_context(prepend):
         """Pop the last constraint from the context"""
-        return DirectiveMeta._when_constraints_from_context.pop()
+        context_attribute = DirectiveMeta._when_context_list(prepend)
+        return context_attribute.pop()
+
+    @staticmethod
+    def has_when_constraints_from_context():
+        return (DirectiveMeta._when_constraints_appended_from_context or
+                DirectiveMeta._when_constraints_prepended_from_context)
 
     @staticmethod
     def directive(dicts=None):
@@ -238,7 +253,7 @@ class DirectiveMeta(type):
             @functools.wraps(decorated_function)
             def _wrapper(*args, **kwargs):
                 # Inject when arguments from the context
-                if DirectiveMeta._when_constraints_from_context:
+                if DirectiveMeta.has_when_constraints_from_context():
                     # Check that directives not yet supporting the when= argument
                     # are not used inside the context manager
                     if decorated_function.__name__ in ('version', 'variant'):
@@ -248,10 +263,15 @@ class DirectiveMeta(type):
                         msg = msg.format(decorated_function.__name__)
                         raise DirectiveError(msg)
 
-                    when_spec_from_context = ' '.join(
-                        DirectiveMeta._when_constraints_from_context
+                    when_spec_appended_from_context = ' '.join(
+                        DirectiveMeta._when_constraints_appended_from_context
                     )
-                    when_spec = kwargs.get('when', '') + ' ' + when_spec_from_context
+                    when_spec_prepended_from_context = ' '.join(
+                        DirectiveMeta._when_constraints_prepended_from_context
+                    )
+                    when_spec = (when_spec_prepended_from_context +
+                                 ' ' + kwargs.get('when', '') + ' ' +
+                                 when_spec_appended_from_context)
                     kwargs['when'] = when_spec
 
                 # If any of the arguments are executors returned by a

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -155,7 +155,7 @@ class SpecMultiMethod(object):
 
 
 class when(object):
-    def __init__(self, condition):
+    def __init__(self, condition, prepend=False):
         """Can be used both as a decorator, for multimethods, or as a context
         manager to group ``when=`` arguments together.
 
@@ -163,11 +163,15 @@ class when(object):
 
         Args:
             condition (str): condition to be met
+            prepend (bool): if the object is used as a context manager determine if
+                the constrain needs to be prepended or appended to the ones already
+                expressed in each directive
         """
         if isinstance(condition, bool):
             self.spec = Spec() if condition else None
         else:
             self.spec = Spec(condition)
+        self.prepend = prepend
 
     def __call__(self, method):
         """This annotation lets packages declare multiple versions of
@@ -266,10 +270,10 @@ class when(object):
         and add their constraint to whatever may be already present in the directive
         `when=` argument.
         """
-        spack.directives.DirectiveMeta.push_to_context(str(self.spec))
+        spack.directives.DirectiveMeta.push_to_context(str(self.spec), self.prepend)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        spack.directives.DirectiveMeta.pop_from_context()
+        spack.directives.DirectiveMeta.pop_from_context(self.prepend)
 
 
 class MultiMethodError(spack.error.SpackError):

--- a/lib/spack/spack/multimethod.py
+++ b/lib/spack/spack/multimethod.py
@@ -155,7 +155,7 @@ class SpecMultiMethod(object):
 
 
 class when(object):
-    def __init__(self, condition, prepend=False):
+    def __init__(self, condition):
         """Can be used both as a decorator, for multimethods, or as a context
         manager to group ``when=`` arguments together.
 
@@ -163,15 +163,11 @@ class when(object):
 
         Args:
             condition (str): condition to be met
-            prepend (bool): if the object is used as a context manager determine if
-                the constrain needs to be prepended or appended to the ones already
-                expressed in each directive
         """
         if isinstance(condition, bool):
             self.spec = Spec() if condition else None
         else:
             self.spec = Spec(condition)
-        self.prepend = prepend
 
     def __call__(self, method):
         """This annotation lets packages declare multiple versions of
@@ -270,10 +266,10 @@ class when(object):
         and add their constraint to whatever may be already present in the directive
         `when=` argument.
         """
-        spack.directives.DirectiveMeta.push_to_context(str(self.spec), self.prepend)
+        spack.directives.DirectiveMeta.push_to_context(str(self.spec))
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        spack.directives.DirectiveMeta.pop_from_context(self.prepend)
+        spack.directives.DirectiveMeta.pop_from_context()
 
 
 class MultiMethodError(spack.error.SpackError):

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -34,11 +34,18 @@ def test_true_directives_exist(mock_packages):
     assert Spec() in cls.patches
 
 
-def test_constraints_from_context(mock_packages):
+def test_constraints_appended_from_context(mock_packages):
     pkg_cls = spack.repo.path.get_pkg_class('with-constraint-met')
 
     assert pkg_cls.dependencies
     assert Spec('@1.0') in pkg_cls.dependencies['b']
 
     assert pkg_cls.conflicts
-    assert (Spec('@1.0'), None) in pkg_cls.conflicts['%gcc']
+    assert (Spec('+foo@1.0'), None) in pkg_cls.conflicts['%gcc']
+
+
+def test_constraints_prepended_from_context(mock_packages):
+    pkg_cls = spack.repo.path.get_pkg_class('with-constraint-met')
+
+    assert pkg_cls.dependencies
+    assert Spec('@0.14: ^b@3.8:') in pkg_cls.dependencies['c']

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -2,9 +2,10 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
 
 import spack.repo
-from spack.spec import Spec
+import spack.spec
 
 
 def test_false_directives_do_not_exist(mock_packages):
@@ -24,28 +25,29 @@ def test_true_directives_exist(mock_packages):
     cls = spack.repo.path.get_pkg_class('when-directives-true')
 
     assert cls.dependencies
-    assert Spec() in cls.dependencies['extendee']
-    assert Spec() in cls.dependencies['b']
+    assert spack.spec.Spec() in cls.dependencies['extendee']
+    assert spack.spec.Spec() in cls.dependencies['b']
 
     assert cls.resources
-    assert Spec() in cls.resources
+    assert spack.spec.Spec() in cls.resources
 
     assert cls.patches
-    assert Spec() in cls.patches
+    assert spack.spec.Spec() in cls.patches
 
 
-def test_constraints_appended_from_context(mock_packages):
+def test_constraints_from_context(mock_packages):
     pkg_cls = spack.repo.path.get_pkg_class('with-constraint-met')
 
     assert pkg_cls.dependencies
-    assert Spec('@1.0') in pkg_cls.dependencies['b']
+    assert spack.spec.Spec('@1.0') in pkg_cls.dependencies['b']
 
     assert pkg_cls.conflicts
-    assert (Spec('+foo@1.0'), None) in pkg_cls.conflicts['%gcc']
+    assert (spack.spec.Spec('+foo@1.0'), None) in pkg_cls.conflicts['%gcc']
 
 
-def test_constraints_prepended_from_context(mock_packages):
+@pytest.mark.regression('26656')
+def test_constraints_from_context_are_merged(mock_packages):
     pkg_cls = spack.repo.path.get_pkg_class('with-constraint-met')
 
     assert pkg_cls.dependencies
-    assert Spec('@0.14: ^b@3.8:') in pkg_cls.dependencies['c']
+    assert spack.spec.Spec('@0.14:15 ^b@3.8:4.0') in pkg_cls.dependencies['c']

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1212,3 +1212,19 @@ def test_spec_dict_hashless_dep():
                 }
             }
         )
+
+
+@pytest.mark.parametrize('specs,expected', [
+    # Anonymous specs without dependencies
+    (['+baz', '+bar'], '+baz+bar'),
+    (['@2.0:', '@:5.1', '+bar'], '@2.0:5.1 +bar'),
+    # Anonymous specs with dependencies
+    (['^mpich@3.2', '^mpich@:4.0+foo'], '^mpich@3.2 +foo'),
+    # Mix a real package with a virtual one. This test
+    # should fail if we start using the repository
+    (['^mpich@3.2', '^mpi+foo'], '^mpich@3.2 ^mpi+foo'),
+])
+def test_merge_abstract_anonymous_specs(specs, expected):
+    specs = [Spec(x) for x in specs]
+    result = spack.spec.merge_abstract_anonymous_specs(*specs)
+    assert result == Spec(expected)

--- a/var/spack/repos/builtin.mock/packages/with-constraint-met/package.py
+++ b/var/spack/repos/builtin.mock/packages/with-constraint-met/package.py
@@ -15,18 +15,9 @@ class WithConstraintMet(Package):
     version('2.0', '0123456789abcdef0123456789abcdef')
     version('1.0', '0123456789abcdef0123456789abcdef')
 
-    # By default constraints from the context manager are appended
-    # to each when= argument in the directive, so the following are
-    # equivalent to:
-    # depends_on('b', when='@1.0')
-    # conflicts('%gcc', when='+foo @1.0')
     with when('@1.0'):
         depends_on('b')
         conflicts('%gcc', when='+foo')
 
-    # In certain contexts it is necessary to prepend the constraint
-    # that is grouped together among different directives. The following
-    # is equivalent to:
-    # depends_on('c', when='@0.14: ^b@3.8:')
-    with when('@0.14:', prepend=True):
-        depends_on('c', when='^b@3.8:')
+    with when('@0.14: ^b@:4.0'):
+        depends_on('c', when='@:15 ^b@3.8:')

--- a/var/spack/repos/builtin.mock/packages/with-constraint-met/package.py
+++ b/var/spack/repos/builtin.mock/packages/with-constraint-met/package.py
@@ -15,6 +15,18 @@ class WithConstraintMet(Package):
     version('2.0', '0123456789abcdef0123456789abcdef')
     version('1.0', '0123456789abcdef0123456789abcdef')
 
+    # By default constraints from the context manager are appended
+    # to each when= argument in the directive, so the following are
+    # equivalent to:
+    # depends_on('b', when='@1.0')
+    # conflicts('%gcc', when='+foo @1.0')
     with when('@1.0'):
         depends_on('b')
-        conflicts('%gcc')
+        conflicts('%gcc', when='+foo')
+
+    # In certain contexts it is necessary to prepend the constraint
+    # that is grouped together among different directives. The following
+    # is equivalent to:
+    # depends_on('c', when='@0.14: ^b@3.8:')
+    with when('@0.14:', prepend=True):
+        depends_on('c', when='^b@3.8:')


### PR DESCRIPTION
fixes #26656

Modifications:
- [x] Add a function to merge abstract anonymous specs without resorting to any repository lookup
- [x] Implemented the when context manager based on that function