### PR TITLE
Don't run lsb_release on linux

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -38,6 +38,7 @@ distro
 * Homepage: https://pypi.python.org/pypi/distro
 * Usage: Provides a more stable linux distribution detection.
 * Version: 1.0.4 (last version supporting Python 2.6)
+* Note: Patched to disable lsb_release by default to improve Spack's startup time.
 
 functools
 ---------

--- a/lib/spack/external/distro.py
+++ b/lib/spack/external/distro.py
@@ -1072,7 +1072,7 @@ class LinuxDistribution(object):
         return distro_info
 
 
-_distro = LinuxDistribution()
+_distro = LinuxDistribution(include_lsb=False)
 
 
 def main():

--- a/lib/spack/external/distro.py
+++ b/lib/spack/external/distro.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Spack managed modifications: use include_lsb=False by default.
+
 """
 The ``distro`` package (``distro`` stands for Linux Distribution) provides
 information about the Linux distribution it runs on, such as a reliable


### PR DESCRIPTION
Running `lsb_release` on Linux takes about 50ms because it is written in
this language called "Python".

It's entirely useless to gather `lsb_release` info and therefore a waste
of time during startup.

This cuts down env activate times about 10% for me.
