### PR TITLE
LAMMPS: update recipe for AOCC

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -220,11 +220,11 @@ class Lammps(CMakePackage, CudaPackage):
             if '^amdfftw' in spec:
                 # If FFTW3 is selected, then CMake will try to detect, if threaded
                 # FFTW libraries are available and enable them by default.
-                args.append('-DFFT=FFTW3')
+                args.append(self.define('FFT', 'FFTW3'))
                 # Using the -DFFT_SINGLE setting trades off a little accuracy
                 # for reduced memory use and parallel communication costs
                 # for transposing 3d FFT data.
-                args.append('-DFFT_SINGLE=ON')
+                args.append(self.define('FFT_SINGLE', True))
 
         if '+kokkos' in spec:
             args.append('-DEXTERNAL_KOKKOS=ON')

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -196,6 +196,10 @@ class Lammps(CMakePackage, CudaPackage):
         if spec.satisfies('@20180629:+lib'):
             args.append('-DBUILD_LIB=ON')
 
+        if spec.satisfies('%aocc'):
+            cxx_flags = '-Ofast -mfma -fvectorize -funroll-loops'
+            args.append('-DCMAKE_CXX_FLAGS_RELEASE={0}'.format(cxx_flags))
+
         args.append(self.define_from_variant('WITH_JPEG', 'jpeg'))
         args.append(self.define_from_variant('WITH_PNG', 'png'))
         args.append(self.define_from_variant('WITH_FFMPEG', 'ffmpeg'))
@@ -214,11 +218,14 @@ class Lammps(CMakePackage, CudaPackage):
             if '^mkl' in spec:
                 args.append('-DFFT=MKL')
             if '^amdfftw' in spec:
-                fftw_prefix = spec['amdfftw'].prefix
-                args.append('-DFFTW_HOME={0}'.format(fftw_prefix))
-                args.append('-DFFTW_INCLUDE_DIRS={0}'
-                            .format(fftw_prefix.include))
-                args.append('-DFFTW_LIBRARY_DIRS={0}'.format(fftw_prefix.lib))
+                # If FFTW3 is selected, then CMake will try to detect, if threaded
+                # FFTW libraries are available and enable them by default.
+                args.append('-DFFT=FFTW3')
+                # Using the -DFFT_SINGLE setting trades off a little accuracy
+                # for reduced memory use and parallel communication costs
+                # for transposing 3d FFT data.
+                args.append('-DFFT_SINGLE=ON')
+
         if '+kokkos' in spec:
             args.append('-DEXTERNAL_KOKKOS=ON')
         if '+user-adios' in spec:

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -198,7 +198,7 @@ class Lammps(CMakePackage, CudaPackage):
 
         if spec.satisfies('%aocc'):
             cxx_flags = '-Ofast -mfma -fvectorize -funroll-loops'
-            args.append('-DCMAKE_CXX_FLAGS_RELEASE={0}'.format(cxx_flags))
+            args.append(self.define('CMAKE_CXX_FLAGS_RELEASE', cxx_flags))
 
         args.append(self.define_from_variant('WITH_JPEG', 'jpeg'))
         args.append(self.define_from_variant('WITH_PNG', 'png'))


### PR DESCRIPTION
- As CMake build system doesn't allow to pass flags from the command line in Spack, we have accommodated required flags in the `package.py`
- Removed unused FFTW related variables as CMake will automatically detects them