### PR TITLE
scr/veloc: component releases

### DIFF
--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -22,34 +22,44 @@ class Axl(CMakePackage):
     homepage = "https://github.com/ecp-veloc/AXL"
     url      = "https://github.com/ecp-veloc/AXL/archive/v0.4.0.tar.gz"
     git      = "https://github.com/ecp-veloc/axl.git"
-
     tags = ['ecp']
 
+    maintainers = ['CamStan', 'gonsie']
+
     version('main',  branch='main')
+    version('0.5.0', sha256='9f3bbb4de563896551bdb68e889ba93ea1984586961ad8c627ed766bff020acf')
     version('0.4.0', sha256='0530142629d77406a00643be32492760c2cf12d1b56c6b6416791c8ff5298db2')
     version('0.3.0', sha256='737d616b669109805f7aed1858baac36c97bf0016e1115b5c56ded05d792613e')
     version('0.2.0', sha256='d04a445f102b438fe96a1ff3429790b0c035f0d23c2797bb5601a00b582a71fc', deprecated=True)
     version('0.1.1', sha256='36edac007938fe47d979679414c5c27938944d32536e2e149f642916c5c08eaa', deprecated=True)
 
+    depends_on('kvtree')
+    depends_on('zlib', type='link')
+
     variant('async_api', default='daemon',
-            description="Set of async transfer APIs to enable",
+            description='Set of async transfer APIs to enable',
             values=['cray_dw', 'intel_cppr', 'daemon', 'none'], multi=True,
             validator=async_api_validator)
 
-    variant('bbapi_fallback', default='False',
+    variant('bbapi', default=True, description='Enable IBM BBAPI support')
+
+    variant('bbapi_fallback', default=False,
             description='Using BBAPI, if source or destination don\'t support \
             file extents then fallback to pthreads')
 
-    depends_on('kvtree')
+    variant('dw', default=False, description='Enable Cray DataWarp support')
+
+    variant('shared', default=True, description='Build with shared libraries')
+    depends_on('kvtree+shared', when='@0.5: +shared')
+    depends_on('kvtree~shared', when='@0.5: ~shared')
 
     def cmake_args(self):
+        spec = self.spec
         args = []
-        if self.spec.satisfies('platform=cray'):
-            args.append("-DAXL_LINK_STATIC=ON")
-        args.append("-DWITH_KVTREE_PREFIX=%s" % self.spec['kvtree'].prefix)
+        args.append(self.define('WITH_KVTREE_PREFIX', spec['kvtree'].prefix))
 
-        if self.spec.satisfies('@:0.3.0'):
-            apis = list(self.spec.variants['async_api'].value)
+        if spec.satisfies('@:0.3.0'):
+            apis = list(spec.variants['async_api'].value)
             if 'daemon' in apis:
                 args.append('-DAXL_ASYNC_DAEMON=ON')
                 apis.remove('daemon')
@@ -57,10 +67,17 @@ class Axl(CMakePackage):
             for api in apis:
                 args.append('-DAXL_ASYNC_API={0}'.format(api.upper()))
 
-        if self.spec.satisfies('@0.4.0:'):
-            if '+bbapi_fallback' in self.spec:
-                args.append('-DENABLE_BBAPI_FALLBACK=ON')
-            else:
-                args.append('-DENABLE_BBAPI_FALLBACK=OFF')
+        if spec.satisfies('@0.4.0:'):
+            args.append(self.define_from_variant(
+                'ENABLE_BBAPI_FALLBACK', 'bbapi_fallback'
+            ))
+
+        if spec.satisfies('@0.5.0:'):
+            args.append(self.define_from_variant('ENABLE_IBM_BBAPI', 'bbapi'))
+            args.append(self.define_from_variant('ENABLE_CRAY_DW', 'dw'))
+            args.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
+        else:
+            if spec.satisfies('platform=cray'):
+                args.append(self.define('AXL_LINK_STATIC', True))
 
         return args

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -29,14 +29,10 @@ class Er(CMakePackage):
     depends_on('zlib', type='link')
 
     variant('shared', default=True, description='Build with shared libraries')
-    depends_on('kvtree+shared',   when='@0.1: +shared')
-    depends_on('kvtree~shared',   when='@0.1: ~shared')
-    depends_on('rankstr+shared',  when='@0.1: +shared')
-    depends_on('rankstr~shared',  when='@0.1: ~shared')
-    depends_on('redset+shared',   when='@0.1: +shared')
-    depends_on('redset~shared',   when='@0.1: ~shared')
-    depends_on('shuffile+shared', when='@0.1: +shared')
-    depends_on('shuffile~shared', when='@0.1: ~shared')
+    deps = ['kvtree', 'rankstr', 'redset', 'shuffile']
+    for dep in deps:
+        depends_on(dep + '+shared', when='@0.1: +shared')
+        depends_on(dep + '~shared', when='@0.1: ~shared')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -12,10 +12,12 @@ class Er(CMakePackage):
     homepage = "https://github.com/ecp-veloc/er"
     url      = "https://github.com/ecp-veloc/er/archive/v0.0.3.tar.gz"
     git      = "https://github.com/ecp-veloc/er.git"
-
     tags = ['ecp']
 
+    maintainers = ['CamStan', 'gonsie']
+
     version('main',  branch='main')
+    version('0.1.0', sha256='543afc1c48bb2c67f48c32f6c9efcbf7bb27f2e622ff76f2c2ce5618c77aacfc')
     version('0.0.4', sha256='c456d34719bb57774adf6d7bc2fa9917ecb4a9de442091023c931a2cb83dfd37')
     version('0.0.3', sha256='243b2b46ea274e17417ef5873c3ed7ba16dacdfdaf7053d1de5434e300de796b')
 
@@ -24,16 +26,37 @@ class Er(CMakePackage):
     depends_on('rankstr', when='@0.0.4:')
     depends_on('redset')
     depends_on('shuffile')
+    depends_on('zlib', type='link')
+
+    variant('shared', default=True, description='Build with shared libraries')
+    depends_on('kvtree+shared',   when='@0.1: +shared')
+    depends_on('kvtree~shared',   when='@0.1: ~shared')
+    depends_on('rankstr+shared',  when='@0.1: +shared')
+    depends_on('rankstr~shared',  when='@0.1: ~shared')
+    depends_on('redset+shared',   when='@0.1: +shared')
+    depends_on('redset~shared',   when='@0.1: ~shared')
+    depends_on('shuffile+shared', when='@0.1: +shared')
+    depends_on('shuffile~shared', when='@0.1: ~shared')
 
     def cmake_args(self):
         spec = self.spec
         args = []
-        args.append("-DMPI_C_COMPILER=%s" % spec['mpi'].mpicc)
-        if spec.satisfies('platform=cray'):
-            args.append("-DER_LINK_STATIC=ON")
-        args.append("-DWITH_KVTREE_PREFIX=%s" % spec['kvtree'].prefix)
-        args.append("-DWITH_REDSET_PREFIX=%s" % spec['redset'].prefix)
-        args.append("-DWITH_SHUFFILE_PREFIX=%s" % spec['shuffile'].prefix)
+        args.append(self.define('MPI_C_COMPILER', spec['mpi'].mpicc))
+        args.append(self.define('WITH_KVTREE_PREFIX', spec['kvtree'].prefix))
+        args.append(self.define('WITH_REDSET_PREFIX', spec['redset'].prefix))
+        args.append(
+            self.define('WITH_SHUFFILE_PREFIX', spec['shuffile'].prefix)
+        )
+
         if spec.satisfies('@0.0.4:'):
-            args.append("-DWITH_RANKSTR_PREFIX=%s" % spec['rankstr'].prefix)
+            args.append(
+                self.define('WITH_RANKSTR_PREFIX', spec['rankstr'].prefix)
+            )
+
+        if spec.satisfies('@0.1.0:'):
+            args.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
+        else:
+            if spec.satisfies('platform=cray'):
+                args.append(self.define('ER_LINK_STATIC', True))
+
         return args

--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -13,22 +13,28 @@ class Kvtree(CMakePackage):
     homepage = "https://github.com/ecp-veloc/KVTree"
     url      = "https://github.com/ecp-veloc/KVTree/archive/v1.1.1.tar.gz"
     git      = "https://github.com/ecp-veloc/kvtree.git"
-
     tags = ['ecp']
 
+    maintainers = ['CamStan', 'gonsie']
+
     version('main',  branch='main')
+    version('1.2.0', sha256='ecd4b8bc479c33ab4f23fc764445a3bb353a1d15c208d011f5577a32c182477f')
     version('1.1.1', sha256='4776bd55a559b7f9bb594454ae6b14ebff0087c93c3d59ac7d1ab27df4aa4d74')
     version('1.1.0', sha256='3e6c003e7b8094d7c2d1529a973d68a68f953ffa63dcde5f4c7c7e81ddf06564')
     version('1.0.3', sha256='c742cdb1241ef4cb13767019204d5350a3c4383384bed9fb66680b93ff44b0d4')
     version('1.0.2', sha256='56fb5b747758c24a907a8380e8748d296900d94de9547bc15f6b427ac4ae2ec4')
 
-    variant('mpi', default=True, description="Build with MPI message packing")
+    depends_on('zlib', type='link')
+
+    variant('mpi', default=True, description='Build with MPI message packing')
     depends_on('mpi', when='+mpi')
 
     variant('file_lock', default='FLOCK',
             values=('FLOCK', 'FNCTL', 'NONE'),
             multi=False,
             description='File locking style for KVTree.')
+
+    variant('shared', default=True, description='Build with shared libraries')
 
     def flag_handler(self, name, flags):
         if self.spec.satisfies('%cce'):
@@ -37,16 +43,18 @@ class Kvtree(CMakePackage):
         return (flags, None, None)
 
     def cmake_args(self):
+        spec = self.spec
         args = []
-        if self.spec.satisfies('+mpi'):
-            args.append("-DMPI=ON")
-            args.append("-DMPI_C_COMPILER=%s" % self.spec['mpi'].mpicc)
+        args.append(self.define_from_variant('MPI'))
+        if '+mpi' in spec:
+            args.append(self.define('MPI_C_COMPILER', spec['mpi'].mpicc))
+
+        args.append(self.define_from_variant('KVTREE_FILE_LOCK', 'file_lock'))
+
+        if spec.satisfies('@1.2.0:'):
+            args.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
         else:
-            args.append("-DMPI=OFF")
+            if spec.satisfies('platform=cray'):
+                args.append(self.define('KVTREE_LINK_STATIC', True))
 
-        args.append('-DKVTREE_FILE_LOCK={0}'.format(
-            self.spec.variants['file_lock'].value.upper()))
-
-        if self.spec.satisfies('platform=cray'):
-            args.append("-DKVTREE_LINK_STATIC=ON")
         return args

--- a/var/spack/repos/builtin/packages/rankstr/package.py
+++ b/var/spack/repos/builtin/packages/rankstr/package.py
@@ -12,18 +12,28 @@ class Rankstr(CMakePackage):
     homepage = "https://github.com/ecp-veloc/rankstr"
     url      = "https://github.com/ecp-veloc/rankstr/archive/v0.0.3.tar.gz"
     git      = "https://github.com/ecp-veloc/rankstr.git"
-
     tags = ['ecp']
 
+    maintainers = ['CamStan', 'gonsie']
+
     version('main',  branch='main')
+    version('0.1.0', sha256='b68239d67b2359ecc067cc354f86ccfbc8f02071e60d28ae0a2449f2e7f88001')
     version('0.0.3', sha256='d32052fbecd44299e13e69bf2dd7e5737c346404ccd784b8c2100ceed99d8cd3')
-    version('0.0.2', sha256='c16d53aa9bb79934cbe2dcd8612e2db7d59de80be500c104e39e8623d4eacd8e')
+    version('0.0.2', sha256='b88357bf88cdda9565472543225d6b0fa50f0726f6e2d464c92d31a98b493abb')
 
     depends_on('mpi')
 
+    variant('shared', default=True, description='Build with shared libraries')
+
     def cmake_args(self):
+        spec = self.spec
         args = []
-        args.append("-DMPI_C_COMPILER=%s" % self.spec['mpi'].mpicc)
-        if self.spec.satisfies('platform=cray'):
-            args.append("-DRANKSTR_LINK_STATIC=ON")
+        args.append(self.define('MPI_C_COMPILER', spec['mpi'].mpicc))
+
+        if spec.satisfies('@0.1.0:'):
+            args.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
+        else:
+            if spec.satisfies('platform=cray'):
+                args.append(self.define('RANKSTR_LINK_STATIC', True))
+
         return args

--- a/var/spack/repos/builtin/packages/redset/package.py
+++ b/var/spack/repos/builtin/packages/redset/package.py
@@ -12,23 +12,38 @@ class Redset(CMakePackage):
     homepage = "https://github.com/ecp-veloc/redset"
     url      = "https://github.com/ecp-veloc/redset/archive/v0.0.5.tar.gz"
     git      = "https://github.com/ecp-veloc/redset.git"
-
     tags = ['ecp']
 
+    maintainers = ['CamStan', 'gonsie']
+
     version('main',  branch='main')
+    version('0.1.0', sha256='baa75de0d0d6de64ade50cff3d38ee89fd136ce69869182bdaefccf5be5d286d')
     version('0.0.5', sha256='4db4ae59ab9d333a6d1d80678dedf917d23ad461c88b6d39466fc4bf6467d1ee')
     version('0.0.4', sha256='c33fce458d5582f01ad632c6fae8eb0a03eaef00e3c240c713b03bb95e2787ad')
     version('0.0.3', sha256='30ac1a960f842ae23a960a88b312af3fddc4795f2053eeeec3433a61e4666a76')
 
     depends_on('mpi')
-    depends_on('rankstr')
     depends_on('kvtree+mpi')
+    depends_on('rankstr')
+    depends_on('zlib', type='link')
+
+    variant('shared', default=True, description='Build with shared libraries')
+    depends_on('kvtree+shared',  when='@0.1: +shared')
+    depends_on('kvtree~shared',  when='@0.1: ~shared')
+    depends_on('rankstr+shared', when='@0.1: +shared')
+    depends_on('rankstr~shared', when='@0.1: ~shared')
 
     def cmake_args(self):
+        spec = self.spec
         args = []
-        args.append("-DMPI_C_COMPILER=%s" % self.spec['mpi'].mpicc)
-        if self.spec.satisfies('platform=cray'):
-            args.append("-DREDSET_LINK_STATIC=ON")
-        args.append("-DWITH_KVTREE_PREFIX=%s" % self.spec['kvtree'].prefix)
-        args.append("-DWITH_RANKSTR_PREFIX=%s" % self.spec['rankstr'].prefix)
+        args.append(self.define('MPI_C_COMPILER', spec['mpi'].mpicc))
+        args.append(self.define('WITH_KVTREE_PREFIX', spec['kvtree'].prefix))
+        args.append(self.define('WITH_RANKSTR_PREFIX', spec['rankstr'].prefix))
+
+        if spec.satisfies('@0.1.0:'):
+            args.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
+        else:
+            if spec.satisfies('platform=cray'):
+                args.append(self.define('REDSET_LINK_STATIC', True))
+
         return args

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -53,13 +53,13 @@ class Scr(CMakePackage):
 
     # SCR legacy is anything 2.x.x or earlier
     # SCR components is anything 3.x.x or later
-    depends_on('axl@0.4.0:',      when="@3:")
-    depends_on('er@0.0.4:',       when="@3:")
-    depends_on('kvtree@1.1.1:',   when="@3:")
-    depends_on('rankstr@0.0.3:',  when="@3:")
-    depends_on('redset@0.0.5:',   when="@3:")
-    depends_on('shuffile@0.0.4:', when="@3:")
-    depends_on('spath@0.0.2:',    when="@3:")
+    depends_on('axl@0.4.0',      when="@3.0rc1")
+    depends_on('er@0.0.4',       when="@3.0rc1")
+    depends_on('kvtree@1.1.1',   when="@3.0rc1")
+    depends_on('rankstr@0.0.3',  when="@3.0rc1")
+    depends_on('redset@0.0.5',   when="@3.0rc1")
+    depends_on('shuffile@0.0.4', when="@3.0rc1")
+    depends_on('spath@0.0.2',    when="@3.0rc1")
 
     # DTCMP is an optional dependency up until 3.x
     variant('dtcmp', default=True,

--- a/var/spack/repos/builtin/packages/shuffile/package.py
+++ b/var/spack/repos/builtin/packages/shuffile/package.py
@@ -12,20 +12,33 @@ class Shuffile(CMakePackage):
     homepage = "https://github.com/ecp-veloc/shuffile"
     url      = "https://github.com/ecp-veloc/shuffile/archive/v0.0.4.tar.gz"
     git      = "https://github.com/ecp-veloc/shuffile.git"
-
     tags = ['ecp']
 
+    maintainers = ['CamStan', 'gonsie']
+
     version('main',  branch='main')
+    version('0.1.0', sha256='9e730cc8b7937517a9cffb08c031d9f5772306341c49d17b87b7f349d55a6d5e')
     version('0.0.4', sha256='f0249ab31fc6123103ad67b1eaf799277c72adcf0dfcddf8c3a18bad2d45031d')
     version('0.0.3', sha256='a3f685526a1146a5ad8dbacdc5f9c2e1152d9761a1a179c1db34f55afc8372f6')
 
     depends_on('mpi')
     depends_on('kvtree+mpi')
+    depends_on('zlib', type='link')
+
+    variant('shared', default=True, description='Build with shared libraries')
+    depends_on('kvtree+shared', when='@0.1: +shared')
+    depends_on('kvtree~shared', when='@0.1: ~shared')
 
     def cmake_args(self):
+        spec = self.spec
         args = []
-        args.append("-DMPI_C_COMPILER=%s" % self.spec['mpi'].mpicc)
-        if self.spec.satisfies('platform=cray'):
-            args.append("-DSHUFFILE_LINK_STATIC=ON")
-        args.append("-DWITH_KVTREE_PREFIX=%s" % self.spec['kvtree'].prefix)
+        args.append(self.define('MPI_C_COMPILER', spec['mpi'].mpicc))
+        args.append(self.define('WITH_KVTREE_PREFIX', spec['kvtree'].prefix))
+
+        if spec.satisfies('@0.1.0:'):
+            args.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
+        else:
+            if spec.satisfies('platform=cray'):
+                args.append(self.define('SHUFFILE_LINK_STATIC', True))
+
         return args

--- a/var/spack/repos/builtin/packages/spath/package.py
+++ b/var/spack/repos/builtin/packages/spath/package.py
@@ -12,27 +12,33 @@ class Spath(CMakePackage):
     homepage = "https://github.com/ecp-veloc/spath"
     url      = "https://github.com/ECP-VeloC/spath/archive/v0.0.2.tar.gz"
     git      = "https://github.com/ecp-veloc/spath.git"
-
     tags = ['ecp']
 
+    maintainers = ['CamStan', 'gonsie']
+
     version('main',  branch='main')
+    version('0.1.0', sha256='2cfc635b2384d3f92973c7aea173dabe47da112d308f5098e6636e4b2f4a704c')
     version('0.0.2', sha256='7a65be59c3d27e92ed4718fba1a97a4a1c68e0a552b54de13d58afe3d8199cf7')
     version('0.0.1', sha256='f41c0ac74e6fb8acfd0c072d756db0fc9c00441f22be492cc4ad25f7fb596a24')
 
-    variant('mpi', default=True, description="Build with MPI support.")
+    depends_on('zlib', type='link', when='@:0.0.2')
+
+    variant('mpi', default=True, description='Build with MPI support')
     depends_on('mpi', when='+mpi')
-    depends_on('zlib', type='link')
+
+    variant('shared', default=True, description='Build with shared libraries')
 
     def cmake_args(self):
+        spec = self.spec
         args = []
+        args.append(self.define_from_variant('MPI'))
+        if '+mpi' in spec:
+            args.append(self.define('MPI_C_COMPILER', spec['mpi'].mpicc))
 
-        if self.spec.satisfies('platform=cray'):
-            args.append("-DSPATH_LINK_STATIC=ON")
-
-        if "+mpi" in self.spec:
-            args.append('-DMPI=ON')
-            args.append("-DMPI_C_COMPILER=%s" % self.spec['mpi'].mpicc)
+        if spec.satisfies('@0.1.0:'):
+            args.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
         else:
-            args.append('-DMPI=OFF')
+            if spec.satisfies('platform=cray'):
+                args.append(self.define('SPATH_LINK_STATIC', True))
 
         return args


### PR DESCRIPTION
Update the ECP-VeloC component packages in preparation for an
upcoming scr@3.0rc2 release.

All
- Add new release versions
- Add new `shared` variant for all components
- Add zlib link dependency to packages that were missing it

axl
- Add independent vendor async support variants

rankstr
- Update older version sha that fails checksum on install

#### Update
All
- Add maintainers
- Use `self.define` and `self.define_from_variant` to clean up `cmake_args`