### PR TITLE
Improved error messages from clingo

### DIFF
--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -111,8 +111,8 @@ def solve(parser, args):
     # die if no solution was found
     # TODO: we need to be able to provide better error messages than this
     if not result.satisfiable:
-        result.minimize_and_print_cores()
-        tty.die("Unsatisfiable spec.")
+        conflicts = result.format_minimal_cores()
+        tty.die("Unsatisfiable spec generated the following core(s):", *conflicts)
 
     # dump the solutions as concretized specs
     if 'solutions' in dump:

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -109,10 +109,7 @@ def solve(parser, args):
         return
 
     # die if no solution was found
-    # TODO: we need to be able to provide better error messages than this
-    if not result.satisfiable:
-        conflicts = result.format_minimal_cores()
-        tty.die("Unsatisfiable spec generated the following core(s):", *conflicts)
+    result.raise_if_unsat()
 
     # dump the solutions as concretized specs
     if 'solutions' in dump:

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -111,7 +111,7 @@ def solve(parser, args):
     # die if no solution was found
     # TODO: we need to be able to provide better error messages than this
     if not result.satisfiable:
-        result.print_cores()
+        result.minimize_and_print_cores()
         tty.die("Unsatisfiable spec.")
 
     # dump the solutions as concretized specs

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -728,11 +728,7 @@ def concretize_specs_together(*abstract_specs, **kwargs):
 def _concretize_specs_together_new(*abstract_specs, **kwargs):
     import spack.solver.asp
     result = spack.solver.asp.solve(abstract_specs)
-
-    if not result.satisfiable:
-        conflicts = result.format_minimal_cores()
-        tty.die("Unsatisfiable spec generated the following core(s):", *conflicts)
-
+    result.raise_if_unsat()
     return [s.copy() for s in result.specs]
 
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -730,8 +730,8 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
     result = spack.solver.asp.solve(abstract_specs)
 
     if not result.satisfiable:
-        result.minimize_and_print_cores()
-        tty.die("Unsatisfiable spec.")
+        conflicts = result.format_minimal_cores()
+        tty.die("Unsatisfiable spec generated the following core(s):", *conflicts)
 
     return [s.copy() for s in result.specs]
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -730,7 +730,7 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
     result = spack.solver.asp.solve(abstract_specs)
 
     if not result.satisfiable:
-        result.print_cores()
+        result.minimize_and_print_cores()
         tty.die("Unsatisfiable spec.")
 
     return [s.copy() for s in result.specs]

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -117,11 +117,21 @@ class SpecError(SpackError):
 
 
 class UnsatisfiableSpecError(SpecError):
-    """Raised when a spec conflicts with package constraints.
-       Provide the requirement that was violated when raising."""
-    def __init__(self, provided, required, constraint_type):
-        super(UnsatisfiableSpecError, self).__init__(
-            "%s does not satisfy %s" % (provided, required))
+    """
+    Raised when a spec conflicts with package constraints.
+
+    For original concretizer, provide the requirement that was violated when
+    raising.
+    """
+    def __init__(self, provided, required=None, constraint_type=None):
+        # required is only set by the original concretizer.
+        # clingo concretizer handles error messages differently.
+        if required:
+            super(UnsatisfiableSpecError, self).__init__(
+                "%s does not satisfy %s" % (provided, required))
+        else:
+            super(UnsatisfiableSpecError, self).__init__(
+                "%s is unsatisfiable." % provided)
         self.provided = provided
         self.required = required
         self.constraint_type = constraint_type

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -123,15 +123,18 @@ class UnsatisfiableSpecError(SpecError):
     For original concretizer, provide the requirement that was violated when
     raising.
     """
-    def __init__(self, provided, required=None, constraint_type=None):
+    def __init__(self, provided, required=None, constraint_type=None, conflicts=None):
         # required is only set by the original concretizer.
         # clingo concretizer handles error messages differently.
         if required:
+            assert not conflicts  # can't mix formats
             super(UnsatisfiableSpecError, self).__init__(
                 "%s does not satisfy %s" % (provided, required))
         else:
-            super(UnsatisfiableSpecError, self).__init__(
-                "%s is unsatisfiable." % provided)
+            indented = ['  %s\n' % conflict for conflict in conflicts]
+            conflict_msg = ''.join(indented)
+            msg = '%s is unsatisfiable, conflicts are:\n%s' % (provided, conflict_msg)
+            super(UnsatisfiableSpecError, self).__init__(msg)
         self.provided = provided
         self.required = required
         self.constraint_type = constraint_type

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -126,7 +126,7 @@ class UnsatisfiableSpecError(SpecError):
     def __init__(self, provided, required=None, constraint_type=None, conflicts=None):
         # required is only set by the original concretizer.
         # clingo concretizer handles error messages differently.
-        if required:
+        if required is not None:
             assert not conflicts  # can't mix formats
             super(UnsatisfiableSpecError, self).__init__(
                 "%s does not satisfy %s" % (provided, required))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1441,7 +1441,8 @@ class SpackSolverSetup(object):
 
         # Fail if we already know an unreachable node is requested
         for spec in specs:
-            missing_deps = [d for d in spec.traverse() if d.name not in possible]
+            missing_deps = [d for d in spec.traverse()
+                            if d.name not in possible and not d.virtual]
             if missing_deps:
                 raise spack.spec.InvalidDependencyError(spec.name, missing_deps)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -245,7 +245,8 @@ class Result(object):
         core_symbols = []
         for atom in core:
             sym = symbols[atom]
-            if sym.name == "rule":
+            if sym.name in ("rule", "error"):
+                # these are special symbols we use to get messages in the core
                 sym = sym.arguments[0].string
             core_symbols.append(sym)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -238,7 +238,7 @@ class Result(object):
         if debug:
             tty.debug("The following core was generated:", *out_list, level=debug)
         else:
-            tty.msg("The following constraints are unsatisfiable:", *out_list)
+            tty.msg("The input spec(s) break the following rules:", *out_list)
 
     def minimize_and_print_cores(self):
         assert self.control

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -391,7 +391,13 @@ class PyclingoDriver(object):
         self.out.write('\n')
 
     def fact(self, head, assumption=False):
-        """ASP fact (a rule without a body)."""
+        """ASP fact (a rule without a body).
+
+        Arguments:
+            head (AspFunction): ASP function to generate as fact
+            assumption (bool): If True and using cores, use this fact as a
+                choice point in ASP and include it in unsatisfiable cores
+        """
         symbol = head.symbol() if hasattr(head, 'symbol') else head
 
         self.out.write("%s.\n" % str(symbol))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -508,11 +508,11 @@ class SpackSolverSetup(object):
             "A node must have exactly one platform",
             "Each node must have exactly one OS",
             "Each node must have exactly one target",
-            "No satisfying compiler is compatible with a satisfying target",
+            "No satisfying compiler available is compatible with a satisfying target",
             "Each node must have exactly one compiler",
             "Internal error: mismatch between selected compiler and compiler version",
             "Internal error: node compiler version mismatch",
-            "No satisfying compiler is compatible with a satisfying os",
+            "No satisfying compiler available is compatible with a satisfying os",
         ]
         for message in error_messages:
             self.gen.fact(fn.error(message), assumption=True)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -298,9 +298,6 @@ class Result(object):
         if self.satisfiable:
             return
 
-        tty.error("Unsatisfiable spec.",
-                  "Analyzing conflicts. This may take some time...")
-
         constraints = self.abstract_specs
         if len(constraints) == 1:
             constraints = constraints[0]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -221,7 +221,9 @@ class Result(object):
         # Concrete specs
         self._concrete_specs = None
 
-    def print_core(self, core, debug=False):
+    def format_core(self, core):
+        assert self.control
+
         symbols = dict(
             (a.literal, a.symbol)
             for a in self.control.symbolic_atoms
@@ -234,19 +236,7 @@ class Result(object):
                 sym = sym.arguments[0].string
             core_symbols.append(sym)
 
-        out_list = sorted(str(symbol) for symbol in core_symbols)
-        if debug:
-            tty.debug("The following core was generated:", *out_list, level=debug)
-        else:
-            tty.msg("The input spec(s) break the following rules:", *out_list)
-
-    def minimize_and_print_cores(self):
-        assert self.control
-
-        for core in self.cores:
-            self.print_core(core, debug=3)
-            min_core = self.minimize_core(core)
-            self.print_core(min_core)
+        return sorted(str(symbol) for symbol in core_symbols)
 
     def minimize_core(self, core):
         assert self.control
@@ -259,6 +249,21 @@ class Result(object):
             if not ret.unsatisfiable:
                 min_core.append(fact)
         return min_core
+
+    def minimal_cores(self):
+        return [self.minimize_core(core) for core in self.cores]
+
+    def format_minimal_cores(self):
+        """List of facts for each core
+
+        Separate cores are separated by an empty line
+        """
+        string_list = []
+        for core in self.minimal_cores():
+            if string_list:
+                string_list.append('\n')
+            string_list.extend(self.format_core(core))
+        return string_list
 
     @property
     def specs(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -435,7 +435,7 @@ class PyclingoDriver(object):
         parent_dir = os.path.dirname(__file__)
 
         # read in the error messages from the file
-        from clingo.ast import ASTType, parse_string
+        from clingo.ast import ASTType, parse_files
         with self.backend:
             def visit(node):
                 if node.ast_type == ASTType.Rule:
@@ -446,7 +446,7 @@ class PyclingoDriver(object):
                                     string = term.atom.symbol.arguments[0].symbol.string
                                     self.fact(fn.error(string), assumption=True)
             path = os.path.join(parent_dir, 'concretize.lp')
-            parse_string(open(path).read(), visit)
+            parse_files([path], visit)
 
         # Load the file itself
         self.control.load(os.path.join(parent_dir, 'concretize.lp'))

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -572,7 +572,7 @@ target_weight(Target, Package, Weight)
    not compiler_supports_target(Compiler, Version, Target),
    node_compiler(Package, Compiler),
    node_compiler_version(Package, Compiler, Version),
-   error("No satisfying compiler is compatible with a satisfying target").
+   error("No satisfying compiler available is compatible with a satisfying target").
 
 % if a target is set explicitly, respect it
 node_target(Package, Target)
@@ -642,7 +642,7 @@ node_compiler_version(Package, Compiler, Version) :- node_compiler_version_set(P
 :- node_compiler_version(Package, Compiler, Version), node_os(Package, OS),
    not compiler_supports_os(Compiler, Version, OS),
    not allow_compiler(Compiler, Version),
-   error("No satisfying compiler is compatible with a satisfying os").
+   error("No satisfying compiler available is compatible with a satisfying os").
 
 % If a package and one of its dependencies don't have the
 % same compiler there's a mismatch.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -133,7 +133,6 @@ path(Parent, Child) :- depends_on(Parent, Child).
 path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
 :- path(A, B), path(B, A).
 
-:- error("This should be the only error").
 #defined error/1.
 
 #defined dependency_type/2.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -171,6 +171,10 @@ virtual_node(Virtual)
 1 { provider(Package, Virtual) : possible_provider(Package, Virtual) } 1
   :- virtual_node(Virtual), error("Virtual packages must be satisfied by a unique provider").
 
+% If a virtual is specified on the command line, we have to use it
+% This ensures appropriate error messages
+provider(Package, Virtual) :- virtual_node(Virtual), possible_provider(Package, Virtual), node(Package).
+
 % virtual roots imply virtual nodes, and that one provider is a root
 virtual_node(Virtual) :- virtual_root(Virtual).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -44,7 +44,8 @@ possible_version_weight(Package, Weight)
 % version_satisfies implies that exactly one of the satisfying versions
 % is the package's version, and vice versa.
 1 { version(Package, Version) : version_satisfies(Package, Constraint, Version) } 1
-  :- version_satisfies(Package, Constraint), error("Internal error: package version weight mismatch").
+  :- version_satisfies(Package, Constraint),
+     error("no version satisfies the given constraints").
 version_satisfies(Package, Constraint)
   :- version(Package, Version), version_satisfies(Package, Constraint, Version).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -19,6 +19,7 @@ version_declared(Package, Version, Weight) :- version_declared(Package, Version,
 :- version_declared(Package, Version, Weight, Origin1),
    version_declared(Package, Version, Weight, Origin2),
    Origin1 != Origin2.
+%   error("Internal error: two versions with identical weights").
 
 % versions are declared w/priority -- declared with priority implies declared
 version_declared(Package, Version) :- version_declared(Package, Version, _).
@@ -123,6 +124,7 @@ node(Dependency) :- node(Package), depends_on(Package, Dependency).
 needed(Package) :- root(Package).
 needed(Dependency) :- needed(Package), depends_on(Package, Dependency).
 :- node(Package), not needed(Package).
+%   error("All dependencies must be reachable from root").
 
 % Avoid cycles in the DAG
 % some combinations of conditional dependencies can result in cycles;
@@ -130,6 +132,9 @@ needed(Dependency) :- needed(Package), depends_on(Package, Dependency).
 path(Parent, Child) :- depends_on(Parent, Child).
 path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
 :- path(A, B), path(B, A).
+
+:- error("This should be the only error").
+#defined error/1.
 
 #defined dependency_type/2.
 #defined dependency_condition/3.
@@ -516,6 +521,7 @@ node_os(Package, OS)
 %-----------------------------------------------------------------------------
 % one target per node -- optimization will pick the "best" one
 1 { node_target(Package, Target) : target(Target) } 1 :- node(Package).
+%     error("Each node must have exactly one target").
 
 % node_target_satisfies semantics
 1 { node_target(Package, Target) : node_target_satisfies(Package, Constraint, Target) } 1
@@ -547,6 +553,7 @@ target_weight(Target, Package, Weight)
    not compiler_supports_target(Compiler, Version, Target),
    node_compiler(Package, Compiler),
    node_compiler_version(Package, Compiler, Version).
+%   error("No satisfying compiler is compatible with a satisfying target").
 
 % if a target is set explicitly, respect it
 node_target(Package, Target)
@@ -615,6 +622,7 @@ node_compiler_version(Package, Compiler, Version) :- node_compiler_version_set(P
 :- node_compiler_version(Package, Compiler, Version), node_os(Package, OS),
    not compiler_supports_os(Compiler, Version, OS),
    not allow_compiler(Compiler, Version).
+%   error("No satisfying compiler is compatible with a satisfying os").
 
 % If a package and one of its dependencies don't have the
 % same compiler there's a mismatch.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -18,8 +18,8 @@ version_declared(Package, Version, Weight) :- version_declared(Package, Version,
 % We can't emit the same version **with the same weight** from two different sources
 :- version_declared(Package, Version, Weight, Origin1),
    version_declared(Package, Version, Weight, Origin2),
-   Origin1 != Origin2.
-%   error("Internal error: two versions with identical weights").
+   Origin1 != Origin2,
+   error("Internal error: two versions with identical weights").
 
 % versions are declared w/priority -- declared with priority implies declared
 version_declared(Package, Version) :- version_declared(Package, Version, _).
@@ -27,7 +27,7 @@ version_declared(Package, Version) :- version_declared(Package, Version, _).
 % If something is a package, it has only one version and that must be a
 % declared version.
 1 { version(Package, Version) : version_declared(Package, Version) } 1
- :- node(Package).
+ :- node(Package), error("Each node must have exactly one version").
 
 % A virtual package may have or not a version, but never has more than one
 :- virtual_node(Package), 2 { version(Package, _) }.
@@ -39,12 +39,12 @@ possible_version_weight(Package, Weight)
  :- version(Package, Version),
     version_declared(Package, Version, Weight).
 
-1 { version_weight(Package, Weight) : possible_version_weight(Package, Weight) } 1 :- node(Package).
+1 { version_weight(Package, Weight) : possible_version_weight(Package, Weight) } 1 :- node(Package), error("Internal error: Package version must have a unique weight").
 
 % version_satisfies implies that exactly one of the satisfying versions
 % is the package's version, and vice versa.
 1 { version(Package, Version) : version_satisfies(Package, Constraint, Version) } 1
-  :- version_satisfies(Package, Constraint).
+  :- version_satisfies(Package, Constraint), error("Internal error: package version weight mismatch").
 version_satisfies(Package, Constraint)
   :- version(Package, Version), version_satisfies(Package, Constraint, Version).
 
@@ -123,15 +123,15 @@ node(Dependency) :- node(Package), depends_on(Package, Dependency).
 % dependencies) and get a two-node unconnected graph
 needed(Package) :- root(Package).
 needed(Dependency) :- needed(Package), depends_on(Package, Dependency).
-:- node(Package), not needed(Package).
-%   error("All dependencies must be reachable from root").
+:- node(Package), not needed(Package),
+   error("All dependencies must be reachable from root").
 
 % Avoid cycles in the DAG
 % some combinations of conditional dependencies can result in cycles;
 % this ensures that we solve around them
 path(Parent, Child) :- depends_on(Parent, Child).
 path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
-:- path(A, B), path(B, A).
+:- path(A, B), path(B, A), error("Cyclic dependencies are not allowed").
 
 #defined error/1.
 
@@ -145,7 +145,8 @@ path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
    not external(Package),
    conflict(Package, TriggerID, ConstraintID),
    condition_holds(TriggerID),
-   condition_holds(ConstraintID).
+   condition_holds(ConstraintID),
+   error("A conflict was triggered").
 
 #defined conflict/3.
 
@@ -168,7 +169,7 @@ virtual_node(Virtual)
 % If there's a virtual node, we must select one and only one provider.
 % The provider must be selected among the possible providers.
 1 { provider(Package, Virtual) : possible_provider(Package, Virtual) } 1
-  :- virtual_node(Virtual).
+  :- virtual_node(Virtual), error("Virtual packages must be satisfied by a unique provider").
 
 % virtual roots imply virtual nodes, and that one provider is a root
 virtual_node(Virtual) :- virtual_root(Virtual).
@@ -192,7 +193,16 @@ virtual_condition_holds(Provider, Virtual) :-
 
 % A package cannot be the actual provider for a virtual if it does not
 % fulfill the conditions to provide that virtual
-:- provider(Package, Virtual), not virtual_condition_holds(Package, Virtual).
+:- provider(Package, Virtual), not virtual_condition_holds(Package, Virtual),
+   error("Internal error: virtual when provides not respected").
+
+% If a package is selected as a provider, it is provider of all
+% the virtuals it provides
+% TODO: May be obsolete now
+:- provides_virtual(Package, V1), provides_virtual(Package, V2), V1 != V2,
+   provider(Package, V1), not provider(Package, V2),
+   virtual_node(V1), virtual_node(V2),
+   error("Virtual packages must provide all of their virtuals").
 
 #defined possible_provider/2.
 
@@ -205,7 +215,7 @@ virtual_condition_holds(Provider, Virtual) :-
 % we select the weight, among the possible ones, that minimizes the overall objective function.
 1 { provider_weight(Dependency, Virtual, Weight, Reason) :
     possible_provider_weight(Dependency, Virtual, Weight, Reason) } 1
- :- provider(Dependency, Virtual).
+ :- provider(Dependency, Virtual), error("Internal error: package provider weights must be unique").
 
 % Get rid or the reason for enabling the possible weight (useful for debugging)
 provider_weight(Dependency, Virtual, Weight) :- provider_weight(Dependency, Virtual, Weight, _).
@@ -303,7 +313,7 @@ attr("node_compiler_version_satisfies", Package, Compiler, Version)
 % if a package is external its version must be one of the external versions
 1 { external_version(Package, Version, Weight):
     version_declared(Package, Version, Weight, "external") } 1
-    :- external(Package).
+    :- external(Package), error("External package version does not satisfy external spec").
 
 version_weight(Package, Weight) :- external_version(Package, Version, Weight).
 version(Package, Version) :- external_version(Package, Version, Weight).
@@ -322,7 +332,8 @@ external(Package) :- external_spec_selected(Package, _).
 :- version(Package, Version),
    version_weight(Package, Weight),
    version_declared(Package, Version, Weight, "external"),
-   not external(Package).
+   not external(Package),
+   error("Internal error: external weight used for internal spec").
 
 % determine if an external spec has been selected
 external_spec_selected(Package, LocalIndex) :-
@@ -334,7 +345,8 @@ external_conditions_hold(Package, LocalIndex) :-
 
 % it cannot happen that a spec is external, but none of the external specs
 % conditions hold.
-:- external(Package), not external_conditions_hold(Package, _).
+:- external(Package), not external_conditions_hold(Package, _),
+   error("External package does not satisfy external spec").
 
 #defined possible_external/3.
 #defined external_spec_index/3.
@@ -352,7 +364,8 @@ external_conditions_hold(Package, LocalIndex) :-
 } 1
  :- node(Package),
     variant(Package, Variant),
-    variant_single_value(Package, Variant).
+    variant_single_value(Package, Variant),
+    error("Single valued variants must have a single value").
 
 % at least one variant value for multi-valued variants.
 1 {
@@ -361,13 +374,15 @@ external_conditions_hold(Package, LocalIndex) :-
 }
  :- node(Package),
     variant(Package, Variant),
-    not variant_single_value(Package, Variant).
+    not variant_single_value(Package, Variant),
+    error("Internal error: All variants must have a value").
 
 % if a variant is set to anything, it is considered 'set'.
 variant_set(Package, Variant) :- variant_set(Package, Variant, _).
 
 % A variant cannot have a value that is not also a possible value
-:- variant_value(Package, Variant, Value), not variant_possible_value(Package, Variant, Value).
+:- variant_value(Package, Variant, Value), not variant_possible_value(Package, Variant, Value),
+   error("Variant set to invalid value").
 
 % Some multi valued variants accept multiple values from disjoint sets.
 % Ensure that we respect that constraint and we don't pick values from more
@@ -376,7 +391,8 @@ variant_set(Package, Variant) :- variant_set(Package, Variant, _).
    variant_value(Package, Variant, Value2),
    variant_value_from_disjoint_sets(Package, Variant, Value1, Set1),
    variant_value_from_disjoint_sets(Package, Variant, Value2, Set2),
-   Set1 != Set2.
+   Set1 != Set2,
+   error("Variant values selected from multiple disjoint sets").
 
 % variant_set is an explicitly set variant value. If it's not 'set',
 % we revert to the default value. If it is set, we force the set value
@@ -441,7 +457,8 @@ variant_default_value(Package, Variant, Value) :- variant_default_value_from_cli
 % Treat 'none' in a special way - it cannot be combined with other
 % values even if the variant is multi-valued
 :- 2 {variant_value(Package, Variant, Value): variant_possible_value(Package, Variant, Value)},
-   variant_value(Package, Variant, "none").
+   variant_value(Package, Variant, "none"),
+   error("Variant value 'none' cannot be combined with any other value").
 
 % patches and dev_path are special variants -- they don't have to be
 % declared in the package, so we just allow them to spring into existence
@@ -471,7 +488,7 @@ variant_single_value(Package, "dev_path")
 %-----------------------------------------------------------------------------
 
 % one platform per node
-:- M = #count { Platform : node_platform(Package, Platform) }, M !=1, node(Package).
+:- M = #count { Platform : node_platform(Package, Platform) }, M !=1, node(Package), error("A node must have exactly one platform").
 
 % if no platform is set, fall back to the default
 node_platform(Package, Platform)
@@ -492,7 +509,7 @@ node_platform_set(Package) :- node_platform_set(Package, _).
 % OS semantics
 %-----------------------------------------------------------------------------
 % one os per node
-1 { node_os(Package, OS) : os(OS) } 1 :- node(Package).
+1 { node_os(Package, OS) : os(OS) } 1 :- node(Package), error("Each node must have exactly one OS").
 
 % node_os_set implies that the node must have that os
 node_os(Package, OS) :- node(Package), node_os_set(Package, OS).
@@ -519,12 +536,11 @@ node_os(Package, OS)
 % Target semantics
 %-----------------------------------------------------------------------------
 % one target per node -- optimization will pick the "best" one
-1 { node_target(Package, Target) : target(Target) } 1 :- node(Package).
-%     error("Each node must have exactly one target").
+1 { node_target(Package, Target) : target(Target) } 1 :- node(Package), error("Each node must have exactly one target").
 
 % node_target_satisfies semantics
 1 { node_target(Package, Target) : node_target_satisfies(Package, Constraint, Target) } 1
-  :- node_target_satisfies(Package, Constraint).
+  :- node_target_satisfies(Package, Constraint), error("Each node must have exactly one target").
 node_target_satisfies(Package, Constraint)
   :- node_target(Package, Target), node_target_satisfies(Package, Constraint, Target).
 #defined node_target_satisfies/3.
@@ -551,8 +567,8 @@ target_weight(Target, Package, Weight)
 :- node_target(Package, Target),
    not compiler_supports_target(Compiler, Version, Target),
    node_compiler(Package, Compiler),
-   node_compiler_version(Package, Compiler, Version).
-%   error("No satisfying compiler is compatible with a satisfying target").
+   node_compiler_version(Package, Compiler, Version),
+   error("No satisfying compiler is compatible with a satisfying target").
 
 % if a target is set explicitly, respect it
 node_target(Package, Target)
@@ -589,7 +605,7 @@ compiler(Compiler) :- compiler_version(Compiler, _).
 % There must be only one compiler set per node. The compiler
 % is chosen among available versions.
 1 { node_compiler_version(Package, Compiler, Version)
-    : compiler_version(Compiler, Version) } 1 :- node(Package).
+    : compiler_version(Compiler, Version) } 1 :- node(Package), error("Each node must have exactly one compiler").
 
 % Sometimes we just need to know the compiler and not the version
 node_compiler(Package, Compiler) :- node_compiler_version(Package, Compiler, _).
@@ -597,14 +613,15 @@ node_compiler(Package, Compiler) :- node_compiler_version(Package, Compiler, _).
 % We can't have a compiler be enforced and select the version from another compiler
 :- node_compiler(Package, Compiler1),
    node_compiler_version(Package, Compiler2, _),
-   Compiler1 != Compiler2.
+   Compiler1 != Compiler2,
+   error("Internal error: mismatch between selected compiler and compiler version").
 
 % define node_compiler_version_satisfies/3 from node_compiler_version_satisfies/4
 % version_satisfies implies that exactly one of the satisfying versions
 % is the package's version, and vice versa.
 1 { node_compiler_version(Package, Compiler, Version)
     : node_compiler_version_satisfies(Package, Compiler, Constraint, Version) } 1
-  :- node_compiler_version_satisfies(Package, Compiler, Constraint).
+  :- node_compiler_version_satisfies(Package, Compiler, Constraint), error("Internal error: node compiler version mismatch").
 node_compiler_version_satisfies(Package, Compiler, Constraint)
   :- node_compiler_version(Package, Compiler, Version),
      node_compiler_version_satisfies(Package, Compiler, Constraint, Version).
@@ -620,8 +637,8 @@ node_compiler_version(Package, Compiler, Version) :- node_compiler_version_set(P
 % are excluded from this check
 :- node_compiler_version(Package, Compiler, Version), node_os(Package, OS),
    not compiler_supports_os(Compiler, Version, OS),
-   not allow_compiler(Compiler, Version).
-%   error("No satisfying compiler is compatible with a satisfying os").
+   not allow_compiler(Compiler, Version),
+   error("No satisfying compiler is compatible with a satisfying os").
 
 % If a package and one of its dependencies don't have the
 % same compiler there's a mismatch.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -171,10 +171,6 @@ virtual_node(Virtual)
 1 { provider(Package, Virtual) : possible_provider(Package, Virtual) } 1
   :- virtual_node(Virtual), error("Virtual packages must be satisfied by a unique provider").
 
-% If a virtual is specified on the command line, we have to use it
-% This ensures appropriate error messages
-provider(Package, Virtual) :- virtual_node(Virtual), provides_virtual(Package, Virtual), node(Package).
-
 % virtual roots imply virtual nodes, and that one provider is a root
 virtual_node(Virtual) :- virtual_root(Virtual).
 
@@ -199,14 +195,6 @@ virtual_condition_holds(Provider, Virtual) :-
 % fulfill the conditions to provide that virtual
 :- provider(Package, Virtual), not virtual_condition_holds(Package, Virtual),
    error("Internal error: virtual when provides not respected").
-
-% If a package is selected as a provider, it is provider of all
-% the virtuals it provides
-% TODO: May be obsolete now
-:- provides_virtual(Package, V1), provides_virtual(Package, V2), V1 != V2,
-   provider(Package, V1), not provider(Package, V2),
-   virtual_node(V1), virtual_node(V2),
-   error("Virtual packages must provide all of their virtuals").
 
 #defined possible_provider/2.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -173,7 +173,7 @@ virtual_node(Virtual)
 
 % If a virtual is specified on the command line, we have to use it
 % This ensures appropriate error messages
-provider(Package, Virtual) :- virtual_node(Virtual), possible_provider(Package, Virtual), node(Package).
+provider(Package, Virtual) :- virtual_node(Virtual), provides_virtual(Package, Virtual), node(Package).
 
 % virtual roots imply virtual nodes, and that one provider is a root
 virtual_node(Virtual) :- virtual_root(Virtual).

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2608,9 +2608,7 @@ class Spec(object):
             return
 
         result = spack.solver.asp.solve([self], tests=tests)
-        if not result.satisfiable:
-            conflicts = result.format_minimal_cores()
-            raise spack.error.UnsatisfiableSpecError(self, conflicts=conflicts)
+        result.raise_if_unsat()
 
         # take the best answer
         opt, i, answer = min(result.answers)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2609,7 +2609,7 @@ class Spec(object):
 
         result = spack.solver.asp.solve([self], tests=tests)
         if not result.satisfiable:
-            result.print_cores()
+            result.minimize_and_print_cores()
             raise spack.error.UnsatisfiableSpecError(
                 self, "unknown", "Unsatisfiable!")
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2609,8 +2609,8 @@ class Spec(object):
 
         result = spack.solver.asp.solve([self], tests=tests)
         if not result.satisfiable:
-            result.minimize_and_print_cores()
-            raise spack.error.UnsatisfiableSpecError(self)
+            conflicts = result.format_minimal_cores()
+            raise spack.error.UnsatisfiableSpecError(self, conflicts=conflicts)
 
         # take the best answer
         opt, i, answer = min(result.answers)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2610,8 +2610,7 @@ class Spec(object):
         result = spack.solver.asp.solve([self], tests=tests)
         if not result.satisfiable:
             result.minimize_and_print_cores()
-            raise spack.error.UnsatisfiableSpecError(
-                self, "unknown", "Unsatisfiable!")
+            raise spack.error.UnsatisfiableSpecError(self)
 
         # take the best answer
         opt, i, answer = min(result.answers)

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -515,7 +515,7 @@ def test_cdash_report_concretization_error(tmpdir, mock_fetch, install_mockery,
             # new or the old concretizer
             expected_messages = (
                 'Conflicts in concretized spec',
-                'does not satisfy'
+                'break the following rules'
             )
             assert any(x in content for x in expected_messages)
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -515,7 +515,7 @@ def test_cdash_report_concretization_error(tmpdir, mock_fetch, install_mockery,
             # new or the old concretizer
             expected_messages = (
                 'Conflicts in concretized spec',
-                'break the following rules'
+                'A conflict was triggered',
             )
             assert any(x in content for x in expected_messages)
 


### PR DESCRIPTION
Generating legible error messages from the new clingo concretizer has proven challenging, in part because the unsatisfiable cores returned from clingo solves are not minimal and cannot be minimized with reasonable performance so far.

This PR adds error message sentinels to the solve, attached to the rules that could fail a solve. The unsat core is then restricted to these messages, which makes the minimization problem tractable. Errors that can only be generated by a bug in the logic program or generating code are prefaced with `Internal error` to make clear to users that something has gone wrong on the Spack side of things.

Examples:
```
$ spack spec hdf5 ^mpich ^openmpi
Input spec
--------------------------------
hdf5
    ^mpich
    ^openmpi

Concretized
--------------------------------
==> Error: hdf5 ^mpich ^openmpi is unsatisfiable, conflicts are:
  error("All dependencies must be reachable from root")
  error("Virtual packages must be satisfied by a unique provider")
```

On an x86_64 system
```
$ spack spec zlib target=power9
Input spec
--------------------------------
zlib arch=darwin-None-power9

Concretized
--------------------------------
==> Error: zlib arch=darwin-None-power9 is unsatisfiable, conflicts are:
  error("Each node must have exactly one compiler")
  error("No satisfying compiler available is compatible with a satisfying target")
```