### PR TITLE
Revert #19736 because conflicts are avoided by clingo by default

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -5,7 +5,6 @@
 
 import spack.variant
 from spack.directives import conflicts, depends_on, variant
-from spack.multimethod import when
 from spack.package import PackageBase
 
 
@@ -88,101 +87,101 @@ class CudaPackage(PackageBase):
 
     # Linux x86_64 compiler conflicts from here:
     # https://gist.github.com/ax3l/9489132
-    with when('^cuda~allow-unsupported-compilers'):
-        # GCC
-        # According to
-        # https://github.com/spack/spack/pull/25054#issuecomment-886531664
-        # these conflicts are valid independently from the architecture
 
-        # minimum supported versions
-        conflicts('%gcc@:4', when='+cuda ^cuda@11.0:')
-        conflicts('%gcc@:5', when='+cuda ^cuda@11.4:')
+    # GCC
+    # According to
+    # https://github.com/spack/spack/pull/25054#issuecomment-886531664
+    # these conflicts are valid independently from the architecture
 
-        # maximum supported version
-        # NOTE:
-        # in order to not constrain future cuda version to old gcc versions,
-        # it has been decided to use an upper bound for the latest version.
-        # This implies that the last one in the list has to be updated at
-        # each release of a new cuda minor version.
-        conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
-        conflicts('%gcc@11:', when='+cuda ^cuda@:11.4')
+    # minimum supported versions
+    conflicts('%gcc@:4', when='+cuda ^cuda@11.0:')
+    conflicts('%gcc@:5', when='+cuda ^cuda@11.4:')
 
-        # https://gist.github.com/ax3l/9489132#gistcomment-3860114
-        conflicts('%gcc@10', when='+cuda ^cuda@:11.4.0')
-        conflicts('%gcc@5:', when='+cuda ^cuda@:7.5 target=x86_64:')
-        conflicts('%gcc@6:', when='+cuda ^cuda@:8 target=x86_64:')
-        conflicts('%gcc@7:', when='+cuda ^cuda@:9.1 target=x86_64:')
-        conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=x86_64:')
-        conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89 target=x86_64:')
-        conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27 target=x86_64:')
-        conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5 target=x86_64:')
-        conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8 target=x86_64:')
-        conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1 target=x86_64:')
-        conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10 target=x86_64:')
-        conflicts('%pgi@:17,20:', when='+cuda ^cuda@10.1.105:10.2.89 target=x86_64:')
-        conflicts('%pgi@:17,21:', when='+cuda ^cuda@11.0.2:11.1.0 target=x86_64:')
-        conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5 target=x86_64:')
-        conflicts('%clang@:3.7,4:', when='+cuda ^cuda@8.0:9.0 target=x86_64:')
-        conflicts('%clang@:3.7,4.1:', when='+cuda ^cuda@9.1 target=x86_64:')
-        conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2 target=x86_64:')
-        conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130 target=x86_64:')
-        conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105 target=x86_64:')
-        conflicts('%clang@:3.7,8.1:',
-                  when='+cuda ^cuda@10.1.105:10.1.243 target=x86_64:')
-        conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89 target=x86_64:')
-        conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=x86_64:')
-        conflicts('%clang@10:', when='+cuda ^cuda@:11.0.3 target=x86_64:')
-        conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
+    # maximum supported version
+    # NOTE:
+    # in order to not constrain future cuda version to old gcc versions,
+    # it has been decided to use an upper bound for the latest version.
+    # This implies that the last one in the list has to be updated at
+    # each release of a new cuda minor version.
+    conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
+    conflicts('%gcc@11:', when='+cuda ^cuda@:11.4')
 
-        # x86_64 vs. ppc64le differ according to NVidia docs
-        # Linux ppc64le compiler conflicts from Table from the docs below:
-        # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
-        # https://docs.nvidia.com/cuda/archive/9.2/cuda-installation-guide-linux/index.html
-        # https://docs.nvidia.com/cuda/archive/9.1/cuda-installation-guide-linux/index.html
-        # https://docs.nvidia.com/cuda/archive/9.0/cuda-installation-guide-linux/index.html
-        # https://docs.nvidia.com/cuda/archive/8.0/cuda-installation-guide-linux/index.html
+    # https://gist.github.com/ax3l/9489132#gistcomment-3860114
+    conflicts('%gcc@10', when='+cuda ^cuda@:11.4.0')
+    conflicts('%gcc@5:', when='+cuda ^cuda@:7.5 target=x86_64:')
+    conflicts('%gcc@6:', when='+cuda ^cuda@:8 target=x86_64:')
+    conflicts('%gcc@7:', when='+cuda ^cuda@:9.1 target=x86_64:')
+    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=x86_64:')
+    conflicts('%gcc@9:', when='+cuda ^cuda@:10.2.89 target=x86_64:')
+    conflicts('%pgi@:14.8', when='+cuda ^cuda@:7.0.27 target=x86_64:')
+    conflicts('%pgi@:15.3,15.5:', when='+cuda ^cuda@7.5 target=x86_64:')
+    conflicts('%pgi@:16.2,16.0:16.3', when='+cuda ^cuda@8 target=x86_64:')
+    conflicts('%pgi@:15,18:', when='+cuda ^cuda@9.0:9.1 target=x86_64:')
+    conflicts('%pgi@:16,19:', when='+cuda ^cuda@9.2.88:10 target=x86_64:')
+    conflicts('%pgi@:17,20:', when='+cuda ^cuda@10.1.105:10.2.89 target=x86_64:')
+    conflicts('%pgi@:17,21:', when='+cuda ^cuda@11.0.2:11.1.0 target=x86_64:')
+    conflicts('%clang@:3.4', when='+cuda ^cuda@:7.5 target=x86_64:')
+    conflicts('%clang@:3.7,4:', when='+cuda ^cuda@8.0:9.0 target=x86_64:')
+    conflicts('%clang@:3.7,4.1:', when='+cuda ^cuda@9.1 target=x86_64:')
+    conflicts('%clang@:3.7,5.1:', when='+cuda ^cuda@9.2 target=x86_64:')
+    conflicts('%clang@:3.7,6.1:', when='+cuda ^cuda@10.0.130 target=x86_64:')
+    conflicts('%clang@:3.7,7.1:', when='+cuda ^cuda@10.1.105 target=x86_64:')
+    conflicts('%clang@:3.7,8.1:',
+              when='+cuda ^cuda@10.1.105:10.1.243 target=x86_64:')
+    conflicts('%clang@:3.2,9:', when='+cuda ^cuda@10.2.89 target=x86_64:')
+    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=x86_64:')
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.3 target=x86_64:')
+    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=x86_64:')
 
-        # information prior to CUDA 9 difficult to find
-        conflicts('%gcc@6:', when='+cuda ^cuda@:9 target=ppc64le:')
-        conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=ppc64le:')
-        conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243 target=ppc64le:')
-        # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
-        conflicts('%pgi', when='+cuda ^cuda@:8 target=ppc64le:')
-        conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185 target=ppc64le:')
-        conflicts('%pgi@:17', when='+cuda ^cuda@:10 target=ppc64le:')
-        conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176 target=ppc64le:')
-        conflicts('%clang@5:', when='+cuda ^cuda@:9.1 target=ppc64le:')
-        conflicts('%clang@6:', when='+cuda ^cuda@:9.2 target=ppc64le:')
-        conflicts('%clang@7:', when='+cuda ^cuda@10.0.130 target=ppc64le:')
-        conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105 target=ppc64le:')
-        conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89 target=ppc64le:')
-        conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=ppc64le:')
-        conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
-        conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
+    # x86_64 vs. ppc64le differ according to NVidia docs
+    # Linux ppc64le compiler conflicts from Table from the docs below:
+    # https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
+    # https://docs.nvidia.com/cuda/archive/9.2/cuda-installation-guide-linux/index.html
+    # https://docs.nvidia.com/cuda/archive/9.1/cuda-installation-guide-linux/index.html
+    # https://docs.nvidia.com/cuda/archive/9.0/cuda-installation-guide-linux/index.html
+    # https://docs.nvidia.com/cuda/archive/8.0/cuda-installation-guide-linux/index.html
 
-        # Intel is mostly relevant for x86_64 Linux, even though it also
-        # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1
-        conflicts('%intel@:11.0', when='+cuda ^cuda@:3.1')
-        conflicts('%intel@:12.0', when='+cuda ^cuda@5.5:')
-        conflicts('%intel@:13.0', when='+cuda ^cuda@6.0:')
-        conflicts('%intel@:13.2', when='+cuda ^cuda@6.5:')
-        conflicts('%intel@:14.9', when='+cuda ^cuda@7:')
-        # Intel 15.x is compatible with CUDA 7 thru current CUDA
-        conflicts('%intel@16.0:', when='+cuda ^cuda@:8.0.43')
-        conflicts('%intel@17.0:', when='+cuda ^cuda@:8.0.60')
-        conflicts('%intel@18.0:', when='+cuda ^cuda@:9.9')
-        conflicts('%intel@19.0:', when='+cuda ^cuda@:10.0')
-        conflicts('%intel@19.1:', when='+cuda ^cuda@:10.1')
-        conflicts('%intel@19.2:', when='+cuda ^cuda@:11.1.0')
+    # information prior to CUDA 9 difficult to find
+    conflicts('%gcc@6:', when='+cuda ^cuda@:9 target=ppc64le:')
+    conflicts('%gcc@8:', when='+cuda ^cuda@:10.0.130 target=ppc64le:')
+    conflicts('%gcc@9:', when='+cuda ^cuda@:10.1.243 target=ppc64le:')
+    # officially, CUDA 11.0.2 only supports the system GCC 8.3 on ppc64le
+    conflicts('%pgi', when='+cuda ^cuda@:8 target=ppc64le:')
+    conflicts('%pgi@:16', when='+cuda ^cuda@:9.1.185 target=ppc64le:')
+    conflicts('%pgi@:17', when='+cuda ^cuda@:10 target=ppc64le:')
+    conflicts('%clang@4:', when='+cuda ^cuda@:9.0.176 target=ppc64le:')
+    conflicts('%clang@5:', when='+cuda ^cuda@:9.1 target=ppc64le:')
+    conflicts('%clang@6:', when='+cuda ^cuda@:9.2 target=ppc64le:')
+    conflicts('%clang@7:', when='+cuda ^cuda@10.0.130 target=ppc64le:')
+    conflicts('%clang@7.1:', when='+cuda ^cuda@:10.1.105 target=ppc64le:')
+    conflicts('%clang@8.1:', when='+cuda ^cuda@:10.2.89 target=ppc64le:')
+    conflicts('%clang@:5', when='+cuda ^cuda@11.0.2: target=ppc64le:')
+    conflicts('%clang@10:', when='+cuda ^cuda@:11.0.2 target=ppc64le:')
+    conflicts('%clang@11:', when='+cuda ^cuda@:11.1.0 target=ppc64le:')
 
-        # XL is mostly relevant for ppc64le Linux
-        conflicts('%xl@:12,14:', when='+cuda ^cuda@:9.1')
-        conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
-        conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.1.0')
+    # Intel is mostly relevant for x86_64 Linux, even though it also
+    # exists for Mac OS X. No information prior to CUDA 3.2 or Intel 11.1
+    conflicts('%intel@:11.0', when='+cuda ^cuda@:3.1')
+    conflicts('%intel@:12.0', when='+cuda ^cuda@5.5:')
+    conflicts('%intel@:13.0', when='+cuda ^cuda@6.0:')
+    conflicts('%intel@:13.2', when='+cuda ^cuda@6.5:')
+    conflicts('%intel@:14.9', when='+cuda ^cuda@7:')
+    # Intel 15.x is compatible with CUDA 7 thru current CUDA
+    conflicts('%intel@16.0:', when='+cuda ^cuda@:8.0.43')
+    conflicts('%intel@17.0:', when='+cuda ^cuda@:8.0.60')
+    conflicts('%intel@18.0:', when='+cuda ^cuda@:9.9')
+    conflicts('%intel@19.0:', when='+cuda ^cuda@:10.0')
+    conflicts('%intel@19.1:', when='+cuda ^cuda@:10.1')
+    conflicts('%intel@19.2:', when='+cuda ^cuda@:11.1.0')
 
-        # Darwin.
-        # TODO: add missing conflicts for %apple-clang cuda@:10
-        conflicts('platform=darwin', when='+cuda ^cuda@11.0.2: ')
+    # XL is mostly relevant for ppc64le Linux
+    conflicts('%xl@:12,14:', when='+cuda ^cuda@:9.1')
+    conflicts('%xl@:12,14:15,17:', when='+cuda ^cuda@9.2')
+    conflicts('%xl@:12,17:', when='+cuda ^cuda@:11.1.0')
+
+    # Darwin.
+    # TODO: add missing conflicts for %apple-clang cuda@:10
+    conflicts('platform=darwin', when='+cuda ^cuda@11.0.2: ')
 
     # Make sure cuda_arch can not be used without +cuda
     for value in cuda_arch_values:

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -122,8 +122,6 @@ class Cuda(Package):
     conflicts('arch=darwin-mojave-x86_64')
 
     variant('dev', default=False, description='Enable development dependencies, i.e to use cuda-gdb')
-    variant('allow-unsupported-compilers', default=False,
-            description='Allow unsupported host compiler and CUDA version combinations')
 
     depends_on('libxml2', when='@10.1.243:')
     # cuda-gdb needs libncurses.so.5


### PR DESCRIPTION
Clingo toggles to +allow-unsupported-compilers to avoid any conflicts.