### PR TITLE
VTK: VTK fixes for a Cray AMD system.

### DIFF
--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -50,9 +50,8 @@ class Vtk(CMakePackage):
     patch('https://gitlab.kitware.com/vtk/vtk/-/commit/e066c3f4fbbfe7470c6207db0fc3f3952db633c.diff',
           when="@9:", sha256='0546696bd02f3a99fccb9b7c49533377bf8179df16d901cefe5abf251173716d')
 
-    # At the moment, we cannot build with both osmesa and qt, but as of
-    # VTK 8.1, that should change
-    conflicts('+osmesa', when='+qt')
+    # We cannot build with both osmesa and qt prior to VTK 8.1
+    conflicts('+osmesa', when='@:8.0 +qt')
 
     extends('python', when='+python')
 
@@ -224,6 +223,7 @@ class Vtk(CMakePackage):
                 '-DVTK_QT_VERSION:STRING={0}'.format(qt_ver),
                 '-DQT_QMAKE_EXECUTABLE:PATH={0}'.format(qmake_exe),
                 '-DVTK_Group_Qt:BOOL=ON',
+                '-DXCB_INCLUDE_DIR:PATH={0}'.format(spec['libxcb'].prefix),
             ])
             # https://github.com/martijnkoopman/Qt-VTK-viewer/blob/master/doc/Build-VTK.md
             if spec.satisfies('@9.0.0:'):
@@ -270,7 +270,7 @@ class Vtk(CMakePackage):
 
         cmake_args.append('-DVTK_RENDERING_BACKEND:STRING=' + opengl_ver)
 
-        if spec.satisfies('@:8.1.0'):
+        if spec.satisfies('@:8.1.0') and '~osmesa' in spec:
             cmake_args.append('-DVTK_USE_SYSTEM_GLEW:BOOL=ON')
 
         if '+osmesa' in spec:


### PR DESCRIPTION
The first change is to make the conflicts between `osmesa` and `qt` dependent on versions of VTK prior to 8.1. The comment implied that they should no longer conflict starting with 8.1. I tested this on `spock.olcf.ornl.gov` and it worked fine.

The second change is to set the include path for xcb, since the system has no X11 libraries or includes in it and the only way that the xcb include files were found was if it found it in a system location. I also tested this on `spock.olcf.ornl.gov`.

The last change makes the use of system `GLEW` dependent on `osmesa` being disabled. When it used system `GLEW` with `osmesa`, all the rendering the involved textures resulted in black boxes when doing off screen rendering. I also tested this on `spock.olcf.ornl.gov`.