### PR TITLE
Fix ruby dependent extensions.

### DIFF
--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -18,6 +18,9 @@ class RubyPackage(PackageBase):
     #. :py:meth:`~.RubyPackage.build`
     #. :py:meth:`~.RubyPackage.install`
     """
+
+    maintainers = ['Kerilk']
+
     #: Phases of a Ruby package
     phases = ['build', 'install']
 

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -50,8 +50,12 @@ class RubyPackage(PackageBase):
 
         gems = glob.glob('*.gem')
         if gems:
+            # if --install-dir is not used, GEM_PATH is deleted from the
+            # environement, and Gems required to build native extensions will
+            # not be found. Those extensions are built during `gem install`.
             inspect.getmodule(self).gem(
-                'install', '--norc', '--ignore-dependencies', gems[0])
+                'install', '--norc', '--ignore-dependencies',
+                '--install-dir', prefix, gems[0])
 
     # Check that self.prefix is there after installation
     run_after('install')(PackageBase.sanity_check_prefix)

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -88,15 +88,17 @@ class Ruby(AutotoolsPackage):
     def setup_dependent_build_environment(self, env, dependent_spec):
         # TODO: do this only for actual extensions.
         # Set GEM_PATH to include dependent gem directories
-        ruby_paths = []
-        for d in dependent_spec.traverse():
+        for d in dependent_spec.traverse(deptype=('build', 'run', 'test'), root=True):
             if d.package.extends(self.spec):
-                ruby_paths.append(d.prefix)
-
-        env.set_path('GEM_PATH', ruby_paths)
+                env.prepend_path('GEM_PATH', d.prefix)
 
         # The actual installation path for this gem
         env.set('GEM_HOME', dependent_spec.prefix)
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        for d in dependent_spec.traverse(deptype=('run'), root=True):
+            if d.package.extends(self.spec):
+                env.prepend_path('GEM_PATH', d.prefix)
 
     def setup_dependent_package(self, module, dependent_spec):
         """Called before ruby modules' install() methods.  Sets GEM_HOME

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -10,6 +10,8 @@ class Ruby(AutotoolsPackage):
     """A dynamic, open source programming language with a focus on
     simplicity and productivity."""
 
+    maintainers = ['Kerilk']
+
     homepage = "https://www.ruby-lang.org/"
     url      = "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.0.tar.gz"
     list_url = "https://cache.ruby-lang.org/pub/ruby/"


### PR DESCRIPTION
Hello,

While trying to package ruby extensions for spack, I encountered several dependency issues between gems. They are related to how `GEM_PATH` is handled by spack and by Ruby `gem`.
 - Arguably `GEM_PATH` and `PYTHONPATH` should be treated similarly, so I mimicked how python is dealing with `PYTHONPATH`
 - Not using the `--install-dir` option of `gem` (relying on `GEM_HOME` to set it), causes `GEM_PATH` to be removed from the environment, so I added the `--install-dir` option to `gem install`. See below link for the problematic line of code.

https://github.com/rubygems/rubygems/blob/4ebde70687e5ec158537e852a34ac3cae1674647/lib/rubygems/commands/install_command.rb#L160

This fixes my issues and allows gems dependencies to be resolved at build time. I am very unfamiliar with spack, so I may have ended far the correct solution though.

Thanks,
Brice