### PR TITLE
cp2k: use variant propagation trick for virtuals

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -77,6 +77,12 @@ class Cp2k(MakefilePackage, CudaPackage):
     depends_on('lapack')
     depends_on('fftw-api@3')
 
+    # Force openmp propagation on some providers of blas / fftw-api
+    with when('+openmp'):
+        depends_on('fftw+openmp', when='^fftw')
+        depends_on('amdfftw+openmp', when='^amdfftw')
+        depends_on('openblas threads=openmp', when='^openblas')
+
     with when('smm=libxsmm'):
         # require libxsmm-1.11+ since 1.10 can leak file descriptors in Fortran
         depends_on('libxsmm@1.11:~header-only')
@@ -173,11 +179,6 @@ class Cp2k(MakefilePackage, CudaPackage):
     conflicts('%apple-clang')
     conflicts('%clang')
     conflicts('%nag')
-
-    conflicts('^fftw~openmp', when='+openmp')
-    conflicts('^amdfftw~openmp', when='+openmp')
-    conflicts('^openblas threads=none', when='+openmp')
-    conflicts('^openblas threads=pthreads', when='+openmp')
 
     conflicts('~openmp', when='@8:', msg='Building without OpenMP is not supported in CP2K 8+')
 


### PR DESCRIPTION
Conflicts on default variant values of providers of blas/lapack/fftw-api makes clingo rather choose a different provider.

Instead we can formulate the double negative with a single conditional depends_on, which is a nice trick to stick to preferred providers.

With this change cp2k picks up openblas threads=openmp for me instead of amdblis, and indeed openblas is my preferred blas/lapack provider.
