### PR TITLE
ASP-based solver: add a rule for version uniqueness in virtual packages

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -28,6 +28,9 @@ version_declared(Package, Version) :- version_declared(Package, Version, _).
 1 { version(Package, Version) : version_declared(Package, Version) } 1
  :- node(Package).
 
+% A virtual package may have or not a version, but never has more than one
+:- virtual_node(Package), 2 { version(Package, _) }.
+
 % If we select a deprecated version, mark the package as deprecated
 deprecated(Package, Version) :- version(Package, Version), deprecated_version(Package, Version).
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1267,3 +1267,10 @@ class TestConcretize(object):
         s = spack.spec.Spec('root-adds-virtual').concretized()
         assert s['leaf-adds-virtual'].satisfies('@2.0')
         assert 'blas' in s
+
+    @pytest.mark.regression('26718')
+    def test_versions_in_virtual_dependencies(self):
+        # Ensure that a package that needs a given version of a virtual
+        # package doesn't end up using a later implementation
+        s = spack.spec.Spec('hpcviewer@2019.02').concretized()
+        assert s['java'].satisfies('virtual-with-versions@1.8.0')

--- a/var/spack/repos/builtin.mock/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin.mock/packages/hpcviewer/package.py
@@ -7,7 +7,7 @@ class Hpcviewer(AutotoolsPackage):
     homepage = "http://www.spack.org"
     url = "http://www.spack.org/downloads/aml-1.0.tar.gz"
 
-    version('2019.02', sha256='abcde')
+    version('2019.02', '0123456789abcdef0123456789abcdef')
 
     depends_on('java@11:', type=('build', 'run'), when='@2021.0:')
     depends_on('java@8', type=('build', 'run'), when='@:2020')

--- a/var/spack/repos/builtin.mock/packages/hpcviewer/package.py
+++ b/var/spack/repos/builtin.mock/packages/hpcviewer/package.py
@@ -1,0 +1,13 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class Hpcviewer(AutotoolsPackage):
+    """Uses version-test-pkg, as a build dependency"""
+    homepage = "http://www.spack.org"
+    url = "http://www.spack.org/downloads/aml-1.0.tar.gz"
+
+    version('2019.02', sha256='abcde')
+
+    depends_on('java@11:', type=('build', 'run'), when='@2021.0:')
+    depends_on('java@8', type=('build', 'run'), when='@:2020')

--- a/var/spack/repos/builtin.mock/packages/virtual-with-versions/package.py
+++ b/var/spack/repos/builtin.mock/packages/virtual-with-versions/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class VirtualWithVersions(AutotoolsPackage):
+    """Uses version-test-pkg, as a build dependency"""
+    homepage = "http://www.spack.org"
+    url = "http://www.spack.org/downloads/aml-1.0.tar.gz"
+
+    version('17.0.1', sha256='abcde')
+    version('16.0.1', sha256='abcde')
+    version('11.0.1', sha256='abcde')
+    version('1.8.0', sha256='abcde')
+
+    provides('java@17', when='@17.0:17.9')
+    provides('java@16', when='@16.0:16.9')
+    provides('java@11', when='@11.0:11.9')
+    provides('java@10', when='@10.0:10.9')
+    provides('java@9', when='@9.0:9.9')
+    provides('java@8', when='@1.8.0:1.8.9')

--- a/var/spack/repos/builtin.mock/packages/virtual-with-versions/package.py
+++ b/var/spack/repos/builtin.mock/packages/virtual-with-versions/package.py
@@ -7,10 +7,10 @@ class VirtualWithVersions(AutotoolsPackage):
     homepage = "http://www.spack.org"
     url = "http://www.spack.org/downloads/aml-1.0.tar.gz"
 
-    version('17.0.1', sha256='abcde')
-    version('16.0.1', sha256='abcde')
-    version('11.0.1', sha256='abcde')
-    version('1.8.0', sha256='abcde')
+    version('17.0.1', '0123456789abcdef0123456789abcdef')
+    version('16.0.1', '0123456789abcdef0123456789abcdef')
+    version('11.0.1', '0123456789abcdef0123456789abcdef')
+    version('1.8.0', '0123456789abcdef0123456789abcdef')
 
     provides('java@17', when='@17.0:17.9')
     provides('java@16', when='@16.0:16.9')


### PR DESCRIPTION
fixes #26718

A virtual package may or may not have a version, but it never has more than one. Previously we were missing a rule for that.