### PR TITLE
Updating libabigail to 2.0

### DIFF
--- a/var/spack/repos/builtin/packages/libabigail/0001-plt.patch
+++ b/var/spack/repos/builtin/packages/libabigail/0001-plt.patch
@@ -1,0 +1,27 @@
+From ba5e2b5dc9de106635c12ebe9260e2fc0212ff91 Mon Sep 17 00:00:00 2001
+From: @vsoch <vsoch@noreply.users.github.com>
+Date: Fri, 15 Oct 2021 05:17:47 +0000
+Subject: [PATCH] fixing incorrect symbol
+
+Signed-off-by: @vsoch <vsoch@noreply.users.github.com>
+---
+ src/abg-dwarf-reader.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/abg-dwarf-reader.cc b/src/abg-dwarf-reader.cc
+index 1d6ad24c..8dd86c5a 100644
+--- a/src/abg-dwarf-reader.cc
++++ b/src/abg-dwarf-reader.cc
+@@ -11053,7 +11053,7 @@ dwarf_language_to_tu_language(size_t l)
+       return translation_unit::LANG_Ada95;
+     case DW_LANG_Fortran95:
+       return translation_unit::LANG_Fortran95;
+-    case DW_LANG_PL1:
++    case DW_LANG_PLI:
+       return translation_unit::LANG_PL1;
+     case DW_LANG_ObjC:
+       return translation_unit::LANG_ObjC;
+-- 
+2.17.1
+
+

--- a/var/spack/repos/builtin/packages/libabigail/package.py
+++ b/var/spack/repos/builtin/packages/libabigail/package.py
@@ -10,13 +10,19 @@ class Libabigail(AutotoolsPackage):
     """The ABI Generic Analysis and Instrumentation Library"""
 
     homepage = "https://sourceware.org/libabigail"
-    url      = "https://mirrors.kernel.org/sourceware/libabigail/libabigail-1.8.tar.gz"
+    url      = "https://mirrors.kernel.org/sourceware/libabigail/libabigail-2.0.tar.gz"
+    git      = "https://sourceware.org/git/libabigail.git"
 
+    version('master')
+    version('2.0', sha256='3704ae97a56bf076ca08fb5dea6b21db998fbbf14c4f9de12824b78db53b6fda')
     version('1.8', sha256='1cbf260b894ccafc61b2673ba30c020c3f67dbba9dfa88dca3935dff661d665c')
 
     variant('docs', default=False, description='build documentation')
 
+    # version 2.0 will error because of using an old symbol, this error
+    # libdw: dwarf.h corrected the DW_LANG_PLI constant name (was DW_LANG_PL1).
     depends_on('elfutils', type=('build', 'link'))
+
     depends_on('libdwarf')
     depends_on('libxml2')
 
@@ -26,3 +32,11 @@ class Libabigail(AutotoolsPackage):
     # Documentation dependencies
     depends_on('doxygen', type="build", when="+docs")
     depends_on('py-sphinx', type='build', when="+docs")
+
+    # The symbol PL1 needs to be renamed to PLI
+    patch("0001-plt.patch")
+
+    def autoreconf(self, spec, prefix):
+        autoreconf = which('autoreconf')
+        with working_dir(self.configure_directory):
+            autoreconf('-ivf')


### PR DESCRIPTION
Libabigail is updated to 2.0, and this fix is important because the previously working libabigail analyzer doesn't appear to work. I can't figure out what changed between it and it's dependencies, but without the fix (it's a bit of hack) here, a missing symbol is used that I was not able to compile with any set of dependencies. The missing symbol is documented on line 7 here:

https://chromium.googlesource.com/external/elfutils/+/515dd0acc77673c953380bcf5ccfb05b83c5a3ab/NEWS and my error again:

And the error without the fix is:

```bash
 error: 'DW_LANG_PL1' was not declared in this scope; did you mean 'DW_LANG_PLI'
```

So this line https://sourceware.org/git/?p=libabigail.git;a=blob;f=src/abg-dwarf-reader.cc;h=1d6ad24cbfcc2d94c07311bb04112f14f4f0e71c;hb=HEAD#l11056 needs to be DW_LANG_PLI.  needs to be updated. from PL1 to PLI. I'll make sure to ping the libabigail folks about it, and update the hack here as soon as it's fixed in a new release.

But this should be important to merge because as far as I've tested, the current recipe no longer works, period.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>