### PR TITLE
Revert "Don't run lsb_release on linux"

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -38,7 +38,6 @@ distro
 * Homepage: https://pypi.python.org/pypi/distro
 * Usage: Provides a more stable linux distribution detection.
 * Version: 1.0.4 (last version supporting Python 2.6)
-* Note: Patched to disable lsb_release by default to improve Spack's startup time.
 
 functools
 ---------

--- a/lib/spack/external/distro.py
+++ b/lib/spack/external/distro.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Spack managed modifications: use include_lsb=False by default.
-
 """
 The ``distro`` package (``distro`` stands for Linux Distribution) provides
 information about the Linux distribution it runs on, such as a reliable
@@ -1074,7 +1072,7 @@ class LinuxDistribution(object):
         return distro_info
 
 
-_distro = LinuxDistribution(include_lsb=False)
+_distro = LinuxDistribution()
 
 
 def main():


### PR DESCRIPTION
Reverts spack/spack#26707
fixes #26755 

Apparently on arch linux the os name was taken from lsb_release where it is archrolling. Without lsb_release it is arch. Even if arch is a better name, it's an inconvenient hash-changing spack breaking change :(.