### PR TITLE
pgplot: Add intel compiler support and add more driver

### DIFF
--- a/var/spack/repos/builtin/packages/pgplot/g77_gcc.conf.patch
+++ b/var/spack/repos/builtin/packages/pgplot/g77_gcc.conf.patch
@@ -1,7 +1,24 @@
-diff -ruN a/sys_linux/g77_gcc.conf b/sys_linux/g77_gcc.conf
---- a/sys_linux/g77_gcc.conf	1969-12-31 19:00:00.000000000 -0500
-+++ b/sys_linux/g77_gcc.conf	2021-04-22 16:48:45.000000000 -0400
-@@ -34,13 +34,13 @@
+--- a/sys_linux/g77_gcc.conf	2021-10-14 16:24:57.912819100 +0900
++++ b/sys_linux/g77_gcc.conf	2021-10-14 16:25:00.840831262 +0900
+@@ -5,7 +5,7 @@
+ #           X2DRIV (/xdisp and /figdisp).
+ # The arguments needed by the C compiler to locate X-window include files.
+  
+-   XINCL="-I/usr/X11R6/include"
++   XINCL="@XINCL@"
+ 
+ # Optional: Needed by XMDRIV (/xmotif).
+ # The arguments needed by the C compiler to locate Motif, Xt and
+@@ -23,7 +23,7 @@
+ # The arguments needed by the C compiler to locate Tcl, Tk and
+ # X-window include files.
+  
+-   TK_INCL="-I/usr/include $XINCL"
++   TK_INCL="@TK_INCL@"
+ 
+ # Optional: Needed by RVDRIV (/xrv).
+ # The arguments needed by the C compiler to locate Rivet, Tcl, Tk and
+@@ -34,35 +34,35 @@
  # Mandatory.
  # The FORTRAN compiler to use.
   
@@ -17,7 +34,12 @@ diff -ruN a/sys_linux/g77_gcc.conf b/sys_linux/g77_gcc.conf
  
  # Mandatory.
  # The FORTRAN compiler flags to use when compiling fortran demo programs.
-@@ -52,12 +52,12 @@
+ # This may need to include a flag to tell the compiler not to treat
+ # backslash characters as C-style escape sequences
+  
+-   FFLAGD="-fno-backslash"
++   FFLAGD="@FFLAGD@"
+ 
  # Mandatory.
  # The C compiler to use.
   
@@ -32,8 +54,13 @@ diff -ruN a/sys_linux/g77_gcc.conf b/sys_linux/g77_gcc.conf
  
  # Mandatory.
  # The C compiler flags to use when compiling C demo programs.
-@@ -73,9 +73,9 @@
- # Mandatory.
+  
+-   CFLAGD="-Wall -O"
++   CFLAGD="@CFLAGD@"
+ 
+ # Optional: Only needed if the cpgplot library is to be compiled.
+ # The flags to use when running pgbind to create the C pgplot wrapper
+@@ -74,7 +74,7 @@
  # The library-specification flags to use when linking normal pgplot
  # demo programs.
   
@@ -42,8 +69,16 @@ diff -ruN a/sys_linux/g77_gcc.conf b/sys_linux/g77_gcc.conf
  
  # Optional: Needed by XMDRIV (/xmotif).
  # The library-specification flags to use when linking motif
- # demo programs.
-@@ -108,8 +108,8 @@
+@@ -92,7 +92,7 @@
+ # The library-specification flags to use when linking Tk demo programs.
+ # Note that you may need to append version numbers to -ltk and -ltcl.
+  
+-   TK_LIBS="-L/usr/lib -ltk -ltcl $LIBS -ldl"
++   TK_LIBS="@TK_LIBS@"
+ 
+ # Mandatory.
+ # On systems that have a ranlib utility, put "ranlib" here. On other
+@@ -108,7 +108,7 @@
  # Optional: Needed if SHARED_LIB is set.
  # How to create a shared library from a trailing list of object files.
   
@@ -52,4 +87,3 @@ diff -ruN a/sys_linux/g77_gcc.conf b/sys_linux/g77_gcc.conf
  
  # Optional:
  # On systems such as Solaris 2.x, that allow specification of the
- # libraries that a shared library needs to be linked with when a

--- a/var/spack/repos/builtin/packages/pgplot/g77_gcc.conf.patch
+++ b/var/spack/repos/builtin/packages/pgplot/g77_gcc.conf.patch
@@ -5,7 +5,7 @@
  # The arguments needed by the C compiler to locate X-window include files.
   
 -   XINCL="-I/usr/X11R6/include"
-+   XINCL="@XINCL@"
++   XINCL=""
  
  # Optional: Needed by XMDRIV (/xmotif).
  # The arguments needed by the C compiler to locate Motif, Xt and

--- a/var/spack/repos/builtin/packages/pgplot/grsy00.f.patch
+++ b/var/spack/repos/builtin/packages/pgplot/grsy00.f.patch
@@ -1,0 +1,11 @@
+--- a/sys/grsy00.f	1995-06-14 11:01:04.000000000 +0900
++++ b/sys/grsy00.f	2021-10-15 13:39:33.715071295 +0900
+@@ -58,7 +58,7 @@
+       INTEGER    FNTFIL, IER, INDEX(3000), NC1, NC2, NC3
+       INTEGER    L, GRTRIM
+       COMMON     /GRSYMB/ NC1, NC2, INDEX, BUFFER
+-      CHARACTER*128 FF
++      CHARACTER*256 FF
+ C
+ C Read the font file. If an I/O error occurs, it is ignored; the
+ C effect will be that all symbols will be undefined (treated as 

--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -47,7 +47,7 @@ class Pgplot(MakefilePackage):
             description='Enable driver for PostScript files.')
 
     depends_on('libx11', when='+X')
-    depends_on('libpng', when='+png', type=('build', 'run'))
+    depends_on('libpng', when='+png')
     depends_on('zlib', when='+png')
 
     def edit(self, spec, prefix):
@@ -99,6 +99,7 @@ class Pgplot(MakefilePackage):
             enable_driver('! PNDRIV 1 /PNG')
             sub['@CCOMPL@'] += ' -I{0}'.format(self.spec['libpng'].prefix.include)
             sub['@FFLAGD@'] += ' -L{0} -lpng'.format(self.spec['libpng'].prefix.lib)
+            sub['@FFLAGD@'] += ' -L{0} -lz'.format(self.spec['zlib'].prefix.lib)
 
             filter_file('pndriv.o : ./png.h ./pngconf.h ./zlib.h ./zconf.h',
                         'pndriv.o : {0}/png.h {0}/pngconf.h {1}/zlib.h {1}/zconf.h'.

--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -41,6 +41,8 @@ class Pgplot(MakefilePackage):
     # enable drivers
     variant('X', default=True,
             description='Build with X-windows support.')
+    variant('png', default=True,
+            description='Enable driver for Portable Network Graphics file.')
     variant('ps', default=True,
             description='Enable driver for PostScript files.')
 
@@ -93,6 +95,18 @@ class Pgplot(MakefilePackage):
             substitutions['@FFLAGD@'] += ' -L{} -lX11'.format(self.spec['libx11'].prefix.lib)
             substitutions['@LIBS@'] += ' -L{} -lX11'.format(self.spec['libx11'].prefix.lib)
 
+        if '+png' in spec:
+            enable_driver('! PNDRIV 1 /PNG')
+            substitutions['@CCOMPL@'] += ' -I{0}'.format(self.spec['libpng'].prefix.include)
+            substitutions['@FFLAGD@'] += ' -L{0} -lpng -L{1} -lz'.format(
+                    self.spec['libpng'].prefix.lib,
+                    self.spec['zlib'].prefix.lib)
+
+            filter_file('pndriv.o : ./png.h ./pngconf.h ./zlib.h ./zconf.h', 
+                    'pndriv.o : {0}/png.h {0}/pngconf.h {1}/zlib.h {1}/zconf.h'.format(
+                        self.spec['libpng'].prefix.include,
+                        self.spec['zlib'].prefix.include), 'makemake')
+            self.rpath.append(self.spec['libpng'].prefix)
 
 
         # Alwasy enable PS and LATEX since they are not depending on other libraries.

--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -40,18 +40,18 @@ class Pgplot(MakefilePackage):
     def edit(self, spec, prefix):
 
         if spec.satisfies('%gcc'):
-            substitutions = [
-                ('@CCOMPL@', self.compiler.cc),
-                ('@CFLAGC@', ("-Wall -fPIC -DPG_PPU -O -std=c89 " +
-                              "-Wno-error=implicit-function-declaration")),
-                ('@FCOMPL@', self.compiler.f77),
-                ('@FFLAGC@', "-Wall -fPIC -O -ffixed-line-length-none" +
-                    (" -fallow-invalid-boz" if spec.satisfies('%gcc@10:') else "")),
-                ('@FFLAGD@', "-Wall -fPIC -O -ffixed-line-length-none" +
-                    (" -fallow-invalid-boz" if spec.satisfies('%gcc@10:') else "")),
-                ('@LIBS@', "-lgfortran"),
-                ('@SHARED_LD@', self.compiler.cc + " -shared -o $SHARED_LIB -lgfortran"),
-            ]
+            substitutions = {
+                '@CCOMPL@': self.compiler.cc,
+                '@CFLAGC@': "-Wall -fPIC -DPG_PPU -O -std=c89 " +
+                              "-Wno-error=implicit-function-declaration",
+                '@CFLAGD@': "-O2",
+                '@FCOMPL@': self.compiler.f77,
+                '@FFLAGC@': "-Wall -fPIC -O -ffixed-line-length-none" +
+                    (" -fallow-invalid-boz" if spec.satisfies('%gcc@10:') else ""),
+                '@FFLAGD@': "-fno-backslash",
+                '@LIBS@': "-lgfortran",
+                '@SHARED_LD@': self.compiler.cc + " -shared -o $SHARED_LIB -lgfortran"
+            }
         elif spec.satisfies('%intel'):
             substitutions = {
                 '@CCOMPL@': self.compiler.cc,

--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -40,7 +40,7 @@ class Pgplot(MakefilePackage):
 
     # enable drivers
     variant('X', default=True,
-            description='Build with X-windows support.')
+            description='Build with X11 support.')
     variant('png', default=True,
             description='Enable driver for Portable Network Graphics file.')
     variant('ps', default=True,

--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -39,7 +39,7 @@ class Pgplot(MakefilePackage):
     parallel = False
 
     # enable drivers
-    variant('X', default=True,
+    variant('X', default=False,
             description='Build with X11 support.')
     variant('png', default=True,
             description='Enable driver for Portable Network Graphics file.')
@@ -49,7 +49,6 @@ class Pgplot(MakefilePackage):
     depends_on('libx11', when='+X')
     depends_on('libpng', when='+png', type=('build', 'run'))
     depends_on('zlib', when='+png')
-    depends_on('libx11', when='+png')
 
     def edit(self, spec, prefix):
 

--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -87,7 +87,6 @@ class Pgplot(MakefilePackage):
         enable_driver = lambda s: filter_file(s, s[2:] , drivers_list)
 
         if '+X' in spec:
-            substitutions['@XINCL@'] = '-I{0}'.format(self.spec['libx11'].prefix.include)
             enable_driver('! XWDRIV 1 /XWINDOW')
             enable_driver('! XWDRIV 2 /XSERVE')
 

--- a/var/spack/repos/builtin/packages/pgplot/pndriv.c.patch
+++ b/var/spack/repos/builtin/packages/pgplot/pndriv.c.patch
@@ -1,0 +1,11 @@
+--- a/drivers/pndriv.c	1999-03-27 11:06:23.000000000 +0900
++++ b/drivers/pndriv.c	2021-10-15 13:02:16.531645384 +0900
+@@ -222,7 +222,7 @@
+ 	return;
+   }
+ 
+-  if (setjmp(png_ptr->jmpbuf)) { /* not really sure what I'm doing here... */
++  if (setjmp(png_jmpbuf(png_ptr))) {
+ 	fprintf(stderr,"%s: error in libpng while writing file %s, plotting disabled\n", png_ident, filename);
+ 	png_destroy_write_struct(&png_ptr,&info_ptr);
+ 	dev->error = true;


### PR DESCRIPTION
1. It can be compiled with intel compiler. 
2. Enable drivers for X Window, PS, PNG and Latex. 

Tested with intel compiler 2021.2.0, gcc@4.8.5 and gcc@11.2.0