### PR TITLE
Camp: use external BLT

### DIFF
--- a/var/spack/repos/builtin/packages/camp/package.py
+++ b/var/spack/repos/builtin/packages/camp/package.py
@@ -29,10 +29,14 @@ class Camp(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('cub', when='+cuda')
 
+    depends_on('blt')
+
     def cmake_args(self):
         spec = self.spec
 
         options = []
+
+        options.append("-DBLT_SOURCE_DIR={0}".format(spec['blt'].prefix))
 
         if '+cuda' in spec:
             options.extend([


### PR DESCRIPTION
The new camp doesn't include BLT in its source tarball.  This allows camp to use the BLT's spack package.