### PR TITLE
ants: fix build by setting BUILD_TESTING=OFF

### DIFF
--- a/var/spack/repos/builtin/packages/ants/package.py
+++ b/var/spack/repos/builtin/packages/ants/package.py
@@ -27,6 +27,7 @@ class Ants(CMakePackage):
 
     def cmake_args(self):
         return [
+            "-DBUILD_TESTING=OFF",  # needed for <= 2.3.5 due to ANTs/#1236
             self.define_from_variant('ITK_BUILD_MINC_SUPPORT', 'minc')
         ]
 


### PR DESCRIPTION
Due to Kitware API changes, default ANTs builds were failing, presumably for all versions (https://github.com/ANTsX/ANTs/issues/1236).
This commit defaults BUILD_TESTING to OFF, preventing calls against
these APIs and fixing all versions.
Note that the ANTs test suite was not clean anyway (e.g. ANTs/#842).