### PR TITLE
cli11: disable building the examples

### DIFF
--- a/var/spack/repos/builtin/packages/cli11/package.py
+++ b/var/spack/repos/builtin/packages/cli11/package.py
@@ -20,6 +20,7 @@ class Cli11(CMakePackage):
 
     def cmake_args(self):
         args = [
+            '-DCLI11_BUILD_EXAMPLES=OFF',
             '-DCLI11_BUILD_DOCS=OFF',
             '-DCLI11_BUILD_TESTS=OFF',
         ]


### PR DESCRIPTION
Disables building the examples for CLI11. Matches the behavior for CLI11 packages in other package managers.

This could be changed to use a variant -- I don't know how common it is for spack packages to provide variants to enable/disable things like examples and tests?