### PR TITLE
py-fenics-ffcx: dependency updates

### DIFF
--- a/var/spack/repos/builtin/packages/py-fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-basix/package.py
@@ -30,7 +30,7 @@ class PyFenicsBasix(PythonPackage):
     depends_on("cmake@3.18:", type="build")
     depends_on("xtl@0.7.2:", type="build")
     depends_on("xtensor@0.23.10:", type="build")
-    depends_on("py-pybind11@2.6.2:2.7", type="build")
+    depends_on("py-pybind11@2.6.2:", type="build")
 
     phases = ['build_ext', 'build', 'install']
 

--- a/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
@@ -12,7 +12,7 @@ class PyFenicsFfcx(PythonPackage):
     homepage = "https://github.com/FEniCS/ffcx"
     url = "https://github.com/FEniCS/ffcx/archive/v0.1.0.tar.gz"
     git = "https://github.com/FEniCS/ffcx.git"
-    maintainers = ["js947", "chrisrichardson", "garth-wells"]
+    maintainers = ["chrisrichardson", "garth-wells"]
 
     version('main', branch='main')
     version('0.3.0', sha256='33fa1a0cc5762f360033c25a99ec9462be933f8ba413279e35cd2c3b5c3e6096')
@@ -20,7 +20,10 @@ class PyFenicsFfcx(PythonPackage):
     version('0.1.0', sha256='98a47906146ac892fb4a358e04cbfd04066f12d0a4cdb505a6b08ff0b1a17e89')
 
     depends_on('python@3.7:', type=('build', 'run'))
-    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-setuptools@58:', type='build', when="@0.1.0")
+    depends_on('py-setuptools', type='build')
+    depends_on('py-wheel:', type='build', when="@main")
+
     depends_on('py-cffi', type='run')
 
     depends_on('py-fenics-ufl@main', type='run', when='@main')

--- a/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
@@ -22,7 +22,7 @@ class PyFenicsFfcx(PythonPackage):
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-setuptools@58:', type='build', when="@0.4:")
     depends_on('py-setuptools', type='build')
-    depends_on('py-wheel:', type='build', when="@0.4:")
+    depends_on('py-wheel', type='build', when="@0.4:")
 
     depends_on('py-cffi', type='run')
 

--- a/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
+++ b/var/spack/repos/builtin/packages/py-fenics-ffcx/package.py
@@ -20,9 +20,9 @@ class PyFenicsFfcx(PythonPackage):
     version('0.1.0', sha256='98a47906146ac892fb4a358e04cbfd04066f12d0a4cdb505a6b08ff0b1a17e89')
 
     depends_on('python@3.7:', type=('build', 'run'))
-    depends_on('py-setuptools@58:', type='build', when="@0.1.0")
+    depends_on('py-setuptools@58:', type='build', when="@0.4:")
     depends_on('py-setuptools', type='build')
-    depends_on('py-wheel:', type='build', when="@main")
+    depends_on('py-wheel:', type='build', when="@0.4:")
 
     depends_on('py-cffi', type='run')
 


### PR DESCRIPTION
FFCx install has been updated to conform to PEP517. Requires `setuptools>=0.58` and `wheel`. This PR provides updates for these dependencies.

Also updates FFCx maintainers and relaxes `py-fenics-basix` dependency on `pybind11`. 