### PR TITLE
patches: make re-applied patches idempotent

### DIFF
--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -7,6 +7,7 @@ import hashlib
 import inspect
 import os
 import os.path
+import sys
 
 import llnl.util.filesystem
 import llnl.util.lang
@@ -25,6 +26,12 @@ from spack.util.executable import which
 def apply_patch(stage, patch_path, level=1, working_dir='.'):
     """Apply the patch at patch_path to code in the stage.
 
+    Spack runs ``patch`` with ``-N`` so that it does not reject already-applied
+    patches.  This is useful for develop specs, so that the build does not fail
+    due to repeated application of patches, and for easing requirements on patch
+    specifications in packages -- packages won't stop working when patches we
+    previously had to apply land in upstream.
+
     Args:
         stage (spack.stage.Stage): stage with code that will be patched
         patch_path (str): filesystem location for the patch to apply
@@ -34,10 +41,31 @@ def apply_patch(stage, patch_path, level=1, working_dir='.'):
     """
     patch = which("patch", required=True)
     with llnl.util.filesystem.working_dir(stage.source_path):
-        patch('-s',
-              '-p', str(level),
-              '-i', patch_path,
-              '-d', working_dir)
+        output = patch(
+            '-N',               # don't reject already-applied patches
+            '-p', str(level),   # patch level (directory depth)
+            '-i', patch_path,   # input source is the patch file
+            '-d', working_dir,  # patch chdir's to here before patching
+            output=str,
+            fail_on_error=False,
+        )
+
+        if patch.returncode != 0:
+            # `patch` returns 1 both:
+            #   a) when an error applying a patch, and
+            #   b) when -N is supplied and the patch has already been applied
+            #
+            # It returns > 1 if there's something more serious wrong.
+            #
+            # So, the best we can do is to look for return code 1, look for output
+            # indicating that the patch was already applied, and ignore the error
+            # if we see it. Most implementations (BSD and GNU) seem to have the
+            # same messages, so we expect these checks to be reliable.
+            if patch.returncode > 1 or not any(
+                    s in output for s in ("Skipping patch", "ignored")
+            ):
+                sys.stderr.write(output)
+                raise patch.error
 
 
 class Patch(object):

--- a/lib/spack/spack/util/crypto.py
+++ b/lib/spack/spack/util/crypto.py
@@ -92,6 +92,11 @@ def checksum(hashlib_algo, filename, **kwargs):
     """Returns a hex digest of the filename generated using an
        algorithm from hashlib.
     """
+    if isinstance(hashlib_algo, str):
+        if hashlib_algo not in hashes:
+            raise ValueError("Invalid hash algorithm: ", hashlib_algo)
+        hashlib_algo = hash_fun_for_algo(hashlib_algo)
+
     block_size = kwargs.get('block_size', 2**20)
     hasher = hashlib_algo()
     with open(filename, 'rb') as file:


### PR DESCRIPTION
We use POSIX `patch` to apply patches to files when building, but `patch` by default prompts the user when it looks like a patch has already been applied. This means that:

1. If a patch lands in upstream and we don't disable it in a package, the build will start failing.
2. `spack develop` builds (which keep the stage around) will fail the second time you try to use them.

To avoid that, we can run `patch` with `-N` (also called `--forward`, but the long option is not in POSIX). `-N` causes `patch` to just ignore patches that have already been applied. This *almost* makes `patch` idempotent, except that it returns 1 when it detects already applied patches with `-N`, so we have to look at the output of the command to see if it's safe to ignore the error.

- [x] Remove non-POSIX `-s` option from `patch` call
- [x] Add `-N` option to `patch`
- [x] Ignore error status when `patch` returns 1 due to `-N`
- [x] Add tests for applying a patch twice and applying a bad patch
- [x] Tweak `spack.util.executable` so that it saves the error that *would have been* raised with `fail_on_error=True`. This lets us easily re-raise it.