### PR TITLE
Change sbang install error into a warning by using /usr/bin/env sbang when sbang itself is nested too deeply

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -969,6 +969,12 @@ def build_tarball(spec, outdir, force=False, rel=False, unsigned=False,
     if not spec.concrete:
         raise ValueError('spec must be concrete to build tarball')
 
+    # Avoid creating a tarball that may include `#!/usr/bin/env sbang` shebang lines
+    # for sbang. TODO: be less strict, we can allow this shebang and change it upon
+    # install to an absolute path if the target system has a short path to sbang.
+    if spack.hooks.sbang.sbang_shebang_itself_too_long():
+        raise spack.hooks.sbang.SbangPathError()
+
     # set up some paths
     tmpdir = tempfile.mkdtemp()
     cache_prefix = build_cache_prefix(tmpdir)
@@ -1229,6 +1235,12 @@ def relocate_package(spec, allow_root):
     """
     Relocate the given package
     """
+    # Error early if we cannot use the new sbang.
+    # TODO: use #!/usr/bin/env sbang and inform the user sbang works, but needs to be
+    # put in PATH.
+    if spack.hooks.sbang.sbang_shebang_itself_too_long():
+        raise spack.hooks.sbang.SbangPathError()
+
     workdir = str(spec.prefix)
     buildinfo = read_buildinfo_file(workdir)
     new_layout_root = str(spack.store.layout.root)

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -11,6 +11,7 @@ import sys
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+from llnl.util.lang import elide_list
 
 import spack.paths
 import spack.store
@@ -27,17 +28,10 @@ else:
 def sbang_install_path():
     """Location sbang should be installed within Spack's ``install_tree``."""
     sbang_root = str(spack.store.unpadded_root)
-    install_path = os.path.join(sbang_root, "bin", "sbang")
-    path_length = len(install_path)
-    if path_length > shebang_limit:
-        msg = ('Install tree root is too long. Spack cannot patch shebang lines'
-               ' when script path length ({0}) exceeds limit ({1}).\n  {2}')
-        msg = msg.format(path_length, shebang_limit, install_path)
-        raise SbangPathError(msg)
-    return install_path
+    return os.path.join(sbang_root, "bin", "sbang")
 
 
-def sbang_shebang_line():
+def sbang_shebang_line(use_sbang_in_PATH=False):
     """Full shebang line that should be prepended to files to use sbang.
 
     The line returned does not have a final newline (caller should add it
@@ -46,7 +40,16 @@ def sbang_shebang_line():
     This should be the only place in Spack that knows about what
     interpreter we use for ``sbang``.
     """
-    return '#!/bin/sh %s' % sbang_install_path()
+    if use_sbang_in_PATH:
+        return '#!/usr/bin/env sbang'
+    else:
+        return '#!/bin/sh %s' % sbang_install_path()
+
+
+def sbang_shebang_itself_too_long():
+    """When sbang itself is installed in a very long path, we can't use its absolute
+    path to shorten shebang lines. This function tests if that is the case."""
+    return len(sbang_shebang_line()) > shebang_limit
 
 
 def shebang_too_long(path):
@@ -63,7 +66,7 @@ def shebang_too_long(path):
         return len(line) > shebang_limit
 
 
-def filter_shebang(path):
+def filter_shebang(path, use_sbang_in_PATH):
     """Adds a second shebang line, using sbang, at the beginning of a file."""
     with open(path, 'rb') as original_file:
         original = original_file.read()
@@ -73,7 +76,7 @@ def filter_shebang(path):
             original = original.decode('UTF-8')
 
     # This line will be prepended to file
-    new_sbang_line = '%s\n' % sbang_shebang_line()
+    new_sbang_line = '%s\n' % sbang_shebang_line(use_sbang_in_PATH)
 
     # Skip files that are already using sbang.
     if original.startswith(new_sbang_line):
@@ -116,25 +119,32 @@ def filter_shebang(path):
     tty.debug("Patched overlong shebang in %s" % path)
 
 
-def filter_shebangs_in_directory(directory, filenames=None):
-    if filenames is None:
-        filenames = os.listdir(directory)
-    for file in filenames:
-        path = os.path.join(directory, file)
+def filter_shebangs_in_directory(directory):
+    patched_files = []
 
-        # only handle files
-        if not os.path.isfile(path):
-            continue
+    # Switch to /usr/bin/env sbang when sbang is installed in a long path itself.
+    use_sbang_in_PATH = sbang_shebang_itself_too_long()
 
-        # only handle links that resolve within THIS package's prefix.
-        if os.path.islink(path):
-            real_path = os.path.realpath(path)
-            if not real_path.startswith(directory + os.sep):
+    for (root, _, filenames) in os.walk(directory):
+        for file in filenames:
+            path = os.path.join(root, file)
+
+            # only handle files
+            if not os.path.isfile(path):
                 continue
 
-        # test the file for a long shebang, and filter
-        if shebang_too_long(path):
-            filter_shebang(path)
+            # only handle links that resolve within THIS package's prefix.
+            if os.path.islink(path):
+                real_path = os.path.realpath(path)
+                if not real_path.startswith(root + os.sep):
+                    continue
+
+            # test the file for a long shebang, and filter
+            if shebang_too_long(path):
+                filter_shebang(path, use_sbang_in_PATH)
+                patched_files.append(file)
+
+    return patched_files
 
 
 def install_sbang():
@@ -157,6 +167,21 @@ def install_sbang():
     fs.set_install_permissions(sbang_bin_dir)
 
 
+def filter_shebangs_in_directory_and_warn(directory):
+    paths = filter_shebangs_in_directory(directory)
+
+    if not (paths and sbang_shebang_itself_too_long()):
+        return
+
+    short_list = elide_list(paths, 4)
+    sbang_bin = os.path.dirname(sbang_install_path())
+    tty.warn("Failed to shorten shebang lines of {0} files {1}, because sbang's "
+             "install path ({2}) is too long. For the installation to work, it is "
+             "required to have sbang in your PATH. Alternatively, you can shorten the "
+             "install root (config:install_tree:root).".format(
+                 len(paths), short_list, sbang_bin))
+
+
 def post_install(spec):
     """This hook edits scripts so that they call /bin/bash
     $spack_prefix/bin/sbang instead of something longer than the
@@ -167,10 +192,4 @@ def post_install(spec):
         return
 
     install_sbang()
-
-    for directory, _, filenames in os.walk(spec.prefix):
-        filter_shebangs_in_directory(directory, filenames)
-
-
-class SbangPathError(spack.error.SpackError):
-    """Raised when the install tree root is too long for sbang to work."""
+    filter_shebangs_in_directory_and_warn(spec.prefix)

--- a/lib/spack/spack/hooks/sbang.py
+++ b/lib/spack/spack/hooks/sbang.py
@@ -184,3 +184,14 @@ def post_install(spec):
 
     install_sbang()
     filter_shebangs_in_directory_and_warn(spec.prefix)
+
+
+class SbangPathError(spack.error.SpackError):
+    """Raised when the install tree root is too long for sbang to work."""
+
+    def __init__(self):
+        shebang_len = len(sbang_shebang_line())
+        fmt = ('Install tree root is too long. Spack cannot patch shebang lines'
+               ' when script path length ({0}) exceeds limit ({1}).')
+        msg = fmt.format(shebang_len, shebang_limit)
+        super(SbangPathError, self).__init__(msg)

--- a/lib/spack/spack/test/util/executable.py
+++ b/lib/spack/spack/test/util/executable.py
@@ -33,7 +33,7 @@ print(u'\\xc3')
 
         # make it executable
         fs.set_executable(script_name)
-        filter_shebangs_in_directory('.', [script_name])
+        filter_shebangs_in_directory('.')
 
         # read the unicode back in and see whether things work
         script = ex.Executable('./%s' % script_name)


### PR DESCRIPTION
When using spack install tree's with long paths, as is rather common in conintuous integration setups, spack often fails with an sbang-error where it can't shorten shebang lines because the path to sbang itself is too long.

This PR makes Spack use `#!/usr/bin/env sbang` as the shebang in those cases, and changes the error into a warning:

```
==> Warning: Failed to shorten shebang lines of 6 files ['autoheader', 'autoscan', 'autom4te', '...', 'autoreconf'], because sbang's install path (/tmp/tmp.xyLJCF9DeK/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/aaaaaaaaaaaa/here/bin) is too long. For the installation to work, it is required to have sbang in your PATH. Alternatively, you can shorten the install root (config:install_tree:root).
```

As a small improvement it skips over symlinks as it always recurses over the install prefix now, so whatever the symlinks point to will be visited anyways.

Todo:

- [x] Some relocation code relies on `sbang_install_path` raising an error when it's too long (I think?). With this PR it does not anymore.
- [ ] Maybe add `<install root>/bin` to PATH on spack load / env activate / module load by default iff sbang path too long? Or unconditionally? Note that `sbang` is by default in the PATH when `spack` is.
