### PR TITLE
flux: update maintainer of flux-core, flux-sched

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -16,7 +16,7 @@ class FluxCore(AutotoolsPackage):
     git      = "https://github.com/flux-framework/flux-core.git"
     tags     = ['radiuss', 'e4s']
 
-    maintainers = ['SteVwonder']
+    maintainers = ['grondo']
 
     version('master', branch='master')
     version('0.29.0', sha256='c13b40e82d66356e75208a689a495ca01f0a013e2e45ac8ea202ed8224987323')

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -16,7 +16,7 @@ class FluxSched(AutotoolsPackage):
     git      = "https://github.com/flux-framework/flux-sched.git"
     tags     = ['radiuss', 'e4s']
 
-    maintainers = ['SteVwonder']
+    maintainers = ['grondo']
 
     version('master', branch='master')
     version('0.18.0', sha256='a4d8a6444fdb7b857b26f47fdea57992b486c9522f4ff92d5a6f547d95b586ae')


### PR DESCRIPTION
@SteVwonder no longer works on the Flux project, update maintainer
of flux-sched and flux-core packages to @grondo.

Hopefully since this PR only updates maintainer, it will be easier to get approval and merge.