### PR TITLE
octave: override qtchooser, add bz2 variant

### DIFF
--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -75,6 +75,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
     depends_on('sed', when=sys.platform == 'darwin', type='build')
     depends_on('pcre')
     depends_on('pkgconfig', type='build')
+    depends_on('texinfo',   type='build')
 
     # Strongly recommended dependencies
     depends_on('readline',     when='+readline')

--- a/var/spack/repos/builtin/packages/octave/package.py
+++ b/var/spack/repos/builtin/packages/octave/package.py
@@ -46,6 +46,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
 
     # Variants
     variant('readline',   default=True)
+    variant('bz2',        default=True)
     variant('arpack',     default=False)
     variant('curl',       default=False)
     variant('fftw',       default=False)
@@ -77,6 +78,7 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
 
     # Strongly recommended dependencies
     depends_on('readline',     when='+readline')
+    depends_on('bzip2',        when='+bz2')
 
     # Optional dependencies
     depends_on('arpack-ng',    when='+arpack')
@@ -181,6 +183,14 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         else:
             config_args.append('--disable-readline')
 
+        if '+bz2' in spec:
+            config_args.extend([
+                "--with-bz2-includedir=%s" % spec['bzip2'].prefix.include,
+                "--with-bz2-libdir=%s"     % spec['bzip2'].prefix.lib
+            ])
+        else:
+            config_args.append("--without-bz2")
+
         # Optional dependencies
         if '+arpack' in spec:
             sa = spec['arpack-ng']
@@ -275,6 +285,8 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         else:
             config_args.append("--without-qrupdate")
 
+        config_args += self.with_or_without("qscintilla")
+
         if '+zlib' in spec:
             config_args.extend([
                 "--with-z-includedir=%s" % spec['zlib'].prefix.include,
@@ -292,6 +304,9 @@ class Octave(AutotoolsPackage, GNUMirrorPackage):
         # Use gfortran calling-convention %fj
         if spec.satisfies('%fj'):
             config_args.append('--enable-fortran-calling-convention=gfortran')
+
+        # Make sure we do not use qtchooser
+        config_args.append('ac_cv_prog_ac_ct_QTCHOOSER=')
 
         return config_args
 


### PR DESCRIPTION
Using qtchooser in configure may lead to the following unwished thing:
if qt is installed using spack, without qtchooser, and qt is installed by the distro with qtchooser : then octave configure may pick the wrong qt uic as reported in
https://savannah.gnu.org/bugs/?61339
This is why I believe it is safe to set "ac_cv_prog_ac_ct_QTCHOOSER=" to configure for spack.

Anecdotic is the bz2 variant.
