### PR TITLE
Made Legion Dependency on Gasnet Tarball Explicit

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -74,6 +74,14 @@ class Legion(CMakePackage):
             description="The network communications/transport layer to use.",
             multi=False)
 
+    # Add Gasnet tarball dependency in spack managed manner
+    # TODO: Provide less mutable tag instead of branch
+    resource(name='stanfordgasnet',
+             git='https://github.com/StanfordLegion/gasnet.git',
+             destination='stanfordgasnet',
+             branch='master',
+             when='network=gasnet')
+
     # We default to automatically embedding a gasnet build. To override this
     # point the package a pre-installed version of GASNet-Ex via the gasnet_root
     # variant.
@@ -204,7 +212,9 @@ class Legion(CMakePackage):
                 gasnet_dir = spec.variants['gasnet_root'].value
                 options.append('-DGASNet_ROOT_DIR=%s' % gasnet_dir)
             else:
+                gasnet_dir = join_path(self.stage.source_path, "stanfordgasnet", "gasnet")
                 options.append('-DLegion_EMBED_GASNet=ON')
+                options.append('-DLegion_EMBED_GASNet_LOCALSRC=%s' % gasnet_dir)
 
             gasnet_conduit = spec.variants['conduit'].value
             options.append('-DGASNet_CONDUIT=%s' % gasnet_conduit)

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -212,7 +212,9 @@ class Legion(CMakePackage):
                 gasnet_dir = spec.variants['gasnet_root'].value
                 options.append('-DGASNet_ROOT_DIR=%s' % gasnet_dir)
             else:
-                gasnet_dir = join_path(self.stage.source_path, "stanfordgasnet", "gasnet")
+                gasnet_dir = join_path(self.stage.source_path,
+                                       "stanfordgasnet",
+                                       "gasnet")
                 options.append('-DLegion_EMBED_GASNet=ON')
                 options.append('-DLegion_EMBED_GASNet_LOCALSRC=%s' % gasnet_dir)
 


### PR DESCRIPTION
Currently the legion build system fetches a known compatible version of gasnet, builds it itself, and uses it as a dependency. To do this, it fetches the file as part of the cmake command

This PR makes that dependency explicit in the form of a `resource()` so that it will be captured in spack mirrors for the purposes of building and deploying on machines with restrictive firewalls that may block direct access to github