### PR TITLE
trilinos: disable optional packages by default

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -290,6 +290,7 @@ class Trilinos(CMakePackage, CudaPackage):
     depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('kokkos-nvcc-wrapper', when='+wrapper')
     depends_on('lapack')
+    # depends_on('perl', type=('build',)) # TriBITS finds but doesn't use...
     depends_on('libx11', when='+x11')
     depends_on('matio', when='+exodus')
     depends_on('metis', when='+zoltan')
@@ -426,20 +427,18 @@ class Trilinos(CMakePackage, CudaPackage):
         options.extend([
             define('Trilinos_VERBOSE_CONFIGURE', False),
             define_from_variant('BUILD_SHARED_LIBS', 'shared'),
-            define_from_variant("CMAKE_CXX_STANDARD", "cxxstd"),
-            define_trilinos_enable('TESTS', False),
-            define_trilinos_enable('EXAMPLES', False),
+            define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'),
+            define_trilinos_enable('ALL_OPTIONAL_PACKAGES', False),
+            define_trilinos_enable('ALL_PACKAGES', False),
             define_trilinos_enable('CXX11', True),
             define_trilinos_enable('DEBUG', 'debug'),
+            define_trilinos_enable('EXAMPLES', False),
+            define_trilinos_enable('SECONDARY_TESTED_CODE', True),
+            define_trilinos_enable('TESTS', False),
             define_trilinos_enable('Fortran'),
             define_trilinos_enable('OpenMP'),
             define_trilinos_enable('EXPLICIT_INSTANTIATION',
                                    'explicit_template_instantiation')
-            # The following can cause problems on systems that don't have
-            # static libraries available for things like dl and pthreads
-            # for example when trying to build static libs
-            # define_from_variant('TPL_FIND_SHARED_LIBS', 'shared')
-            # define('Trilinos_LINK_SEARCH_START_STATIC', '+shared' not in spec)
         ])
 
         # ################## Trilinos Packages #####################


### PR DESCRIPTION
TriBITS defaults "all optional packages" to on, so we now change it to off. For my typical configuration the only change ends up being to disable Xpetra, ShyLU_NodeHTS, and ShyLU_NodeTacho . Hopefully this will prevent unexpected packages being enabled.