### PR TITLE
Paraview: Allow +shared +cuda

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -64,7 +64,6 @@ class Paraview(CMakePackage, CudaPackage):
     # Python 2 support dropped with 5.9.0
     conflicts('+python', when='@5.9:')
     conflicts('+python3', when='@:5.5')
-    conflicts('+shared', when='+cuda')
     # Legacy rendering dropped in 5.5
     # See commit: https://gitlab.kitware.com/paraview/paraview/-/commit/798d328c
     conflicts('~opengl2', when='@5.5:')


### PR DESCRIPTION
It seems this was added for vtk-m once, but is no longer a requirement of vtk-m and therefore can be removed from paraview.