### PR TITLE
Fix Cray target setting on Perlmutter where 'target-' in not included in module name

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -170,7 +170,10 @@ class Cray(Platform):
             targets = []
             for mod in modules:
                 if 'craype-' in mod:
-                    name = mod[7:]
+                    if 'target' in mod:
+                        name = mod[7:]
+                    else:
+                        name = mod
                     name = name.split()[0]
                     _n = name.replace('-', '_')  # test for mic-knl/mic_knl
                     is_target_name = (name in archspec.cpu.TARGETS or


### PR DESCRIPTION
Fixes this error when running spack on Cori or Perlmutter at NERSC

```
 =gartung@perlmutter:login37:~> source spack/share/spack/setup-env.sh 
Traceback (most recent call last):
  File "/global/homes/g/gartung/spack/bin/spack", line 100, in <module>
    sys.exit(spack.main.main())
  File "/global/u1/g/gartung/spack/lib/spack/spack/main.py", line 751, in main
    print_setup_info(*args.print_shell_vars.split(','))
  File "/global/u1/g/gartung/spack/lib/spack/spack/main.py", line 669, in print_setup_info
    shell_set('_sp_sys_type', str(spack.architecture.default_arch()))
  File "/global/u1/g/gartung/spack/lib/spack/llnl/util/lang.py", line 190, in _memoized_function
    func.cache[args] = func(*args)
  File "/global/u1/g/gartung/spack/lib/spack/spack/architecture.py", line 191, in default_arch
    return Arch(platform(), 'default_os', 'default_target')
  File "/global/u1/g/gartung/spack/lib/spack/llnl/util/lang.py", line 190, in _memoized_function
    func.cache[args] = func(*args)
  File "/global/u1/g/gartung/spack/lib/spack/spack/architecture.py", line 176, in _platform
    return spack.platforms.host()
  File "/global/u1/g/gartung/spack/lib/spack/spack/platforms/__init__.py", line 29, in host
    return platform_cls()
  File "/global/u1/g/gartung/spack/lib/spack/spack/platforms/cray.py", line 63, in __init__
    raise NoPlatformError()
spack.platforms._platform.NoPlatformError: Could not determine a platform for this machine
```

Fixes #25914 (partially)