### PR TITLE
update E4S CI environments in preparation for 21.11 release

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -3,6 +3,7 @@ spack:
   concretization: separately
 
   config:
+    concretizer: clingo
     install_tree:
       root: /home/software/spack
       padded_length: 512

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -21,160 +21,37 @@ spack:
       target:
         - ppc64le
       variants: +mpi
-    autoconf:
-      version:
-      - '2.69'
-    automake:
-      version:
-      - 1.16.3
-    berkeley-db:
-      version:
-      - 18.1.40
     binutils:
       variants: +ld +gold +headers +libiberty ~nls +plugins
       version:
       - 2.36.1
-    boost:
-      version:
-      - 1.76.0
-    bzip2:
-      version:
-      - 1.0.8
-    c-blosc:
-      version:
-      - 1.21.0
-    cmake:
-      version:
-      - 3.20.3
-    curl:
-      version:
-      - 7.76.1
-    diffutils:
-      version:
-      - 3.7
     doxygen:
       version:
       - 1.8.20
     elfutils:
-      version:
-      - 0.185
       variants: +bzip2 ~nls +xz
-    expat:
-      version:
-      - 2.4.1
-    findutils:
-      version:
-      - 4.8.0
-    gdbm:
-      version:
-      - 1.19
-    gettext:
-      version:
-      - 0.21
-    git:
-      version:
-      - 2.31.1
-    glib:
-      version:
-      - 2.68.2
     hdf5:
       variants: +fortran +hl +shared api=v18
       version:
       - 1.12.0
-    help2man:
-      version:
-      - 1.47.16
-    hwloc:
-      version:
-      - 2.4.1
-    json-c:
-      version:
-      - 0.15
-    libbsd:
-      version:
-      - 0.11.3
     libfabric:
-      version:
-      - 1.12.1
       variants: fabrics=sockets,tcp,udp,rxm
-    libiconv:
-      version:
-      - 1.16
-    libsigsegv:
-      version:
-      - 2.13
-    libpciaccess:
-      version:
-      - 0.16
-    libtool:
-      version:
-      - 2.4.6
     libunwind:
-      version:
-      - 1.5.0
       variants: +pic +xz
-    libxml2:
-      version:
-      - 2.9.10
-    lz4:
-      version:
-      - 1.9.3
-    m4:
-      version:
-      - 1.4.19
     mesa:
       variants: ~llvm
     mesa18:
       variants: ~llvm
     mpich:
       variants: ~wrapperrpath
-      version:
-      - 3.4.2
     ncurses:
-      version:
-      - 6.2
       variants: +termlib
-    numactl:
-      version:
-      - 2.0.14
     openblas:
-      version:
-      - 0.3.15
       variants: threads=openmp
-    openssl:
-      version:
-        - 1.1.1l
-    perl:
-      version:
-      - 5.34.0 # 5.34.0
-    pkgconf:
-      version:
-      - 1.7.4
-    python:
-      version:
-      - 3.8.10
-    readline:
-      version:
-      - 8.1
-    sqlite:
-      version:
-      - 3.35.5
-    tar:
-      version:
-      - 1.34
-    texinfo:
-      version:
-      - 6.5
+    trilinos:
+      variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     xz:
-      version:
-      - 5.2.5
       variants: +pic
-    zlib:
-      version:
-      - 1.2.11
-    zstd:
-      version:
-      - 1.5.0
 
   definitions:
 
@@ -209,11 +86,11 @@ spack:
     - archer
     - argobots
     - ascent
-    - axom ^umpire@5.0.1 ^raja@0.13.0
+    - axom ^umpire@4.1.2
     - bolt
     - cabana
     - caliper
-    - chai ~benchmarks ~tests
+    - chai ~benchmarks ~tests ^umpire@4.1.2
     - charliecloud
     - conduit
     - darshan-runtime
@@ -223,7 +100,8 @@ spack:
     - faodel ~tcmalloc
     - flecsi
     - flit
-    - fortrilinos ^trilinos +nox +superlu-dist +stratimikos
+    - flux-core
+    - fortrilinos
     - gasnet
     - ginkgo
     - globalarrays
@@ -240,20 +118,25 @@ spack:
     - libnrm
     - libquo
     - libunwind
+    - llvm +all_targets +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
     - loki
     - mercury
     - metall
     - mfem
     - mpark-variant
     - mpifileutils ~xattr
+    - netlib-scalapack
     - ninja
     - nrm
+    - nvhpc
     - omega-h
     - openmpi
     - openpmd-api ^hdf5@1.12.0 +fortran +shared +hl api=default
     - papi
     - papyrus@1.0.1
     - parallel-netcdf
+    - paraview
+    - parsec ~cuda
     - pdt
     - petsc
     - plasma
@@ -273,28 +156,24 @@ spack:
     - slepc
     - stc
     - strumpack ~slate
-    # holding off on the specs until infrastructure is ready
-    # - sundials
-    # - superlu
-    # - superlu-dist
-    # - swig
-    # - swig@4.0.2-fortran
-    # - sz
-    # - tasmanian
-    # - tau
-    #- trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +boost +superlu-dist gotype=long
-    # - turbine
-    # - umap
-    # - unifyfs@0.9.1
-    # - upcxx
-    # - veloc
-    # - zfp
-
-    # build issues
+    - sundials
+    - superlu
+    - superlu-dist
+    - swig
+    - swig@4.0.2-fortran
+    - sz
+    - tasmanian
+    - tau
+    - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+    - turbine
+    - umap
+    - unifyfs@0.9.1
+    - upcxx
+    - veloc
+    - vtk-m
+    - zfp
     #- dealii
     #- geopm
-    #- llvm-doe@doe +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang
-    #- parsec
     #- phist
     #- qt
     #- qwt

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -21,170 +21,42 @@ spack:
       target:
         - x86_64
       variants: +mpi
-    autoconf:
-      version:
-        - '2.69'
-    automake:
-      version:
-        - 1.16.3
-    berkeley-db:
-      version:
-        - 18.1.40
     binutils:
       variants: +ld +gold +headers +libiberty ~nls
       version:
         - 2.36.1
-    boost:
-      version:
-        - 1.76.0
-    bzip2:
-      version:
-        - 1.0.8
-    c-blosc:
-      version:
-        - 1.21.0
-    cmake:
-      version:
-        - 3.20.5
-    curl:
-      version:
-        - 7.76.1
-    diffutils:
-      version:
-        - 3.7
     doxygen:
       version:
         - 1.8.20
     elfutils:
-      version:
-        - 0.185
       variants: +bzip2 ~nls +xz
-    expat:
-      version:
-        - 2.4.1
-    findutils:
-      version:
-        - 4.8.0
-    gdbm:
-      version:
-        - 1.19
-    gettext:
-      version:
-        - 0.21
-    git:
-      version:
-        - 2.31.1
-    glib:
-      version:
-        - 2.68.2
     hdf5:
       variants: +fortran +hl +shared
       version:
         - 1.10.7
-    help2man:
-      version:
-        - 1.47.16
-    hwloc:
-      version:
-        - 2.4.1
-    json-c:
-      version:
-        - 0.15
-    libbsd:
-      version:
-        - 0.11.3
     libfabric:
-      version:
-        - 1.12.1
       variants: fabrics=sockets,tcp,udp,rxm
-    libiconv:
-      version:
-        - 1.16
-    libsigsegv:
-      version:
-        - 2.13
-    libpciaccess:
-      version:
-        - 0.16
-    libtool:
-      version:
-        - 2.4.6
     libunwind:
-      version:
-        - 1.5.0
       variants: +pic +xz
-    libxml2:
-      version:
-        - 2.9.10
-    lz4:
-      version:
-        - 1.9.3
-    m4:
-      version:
-        - 1.4.19
     mesa:
       variants: ~llvm
     mesa18:
       variants: ~llvm
     mpich:
       variants: ~wrapperrpath
-      version:
-        - 3.4.2
     ncurses:
-      version:
-        - 6.2
       variants: +termlib
-    numactl:
-      version:
-        - 2.0.14
     openblas:
-      version:
-        - 0.3.17
       variants: threads=openmp
-    openssl:
-      version:
-        - 1.1.1l
-    perl:
-      version:
-        - 5.34.0
-    pkgconf:
-      version:
-        - 1.7.4
-    python:
-      version:
-        - 3.8.10
-    readline:
-      version:
-        - 8.1
-    sqlite:
-      version:
-        - 3.35.5
-    tar:
-      version:
-        - 1.34
-    texinfo:
-      version:
-        - 6.5
     trilinos:
-      version:
-        - 13.0.1
       variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     xz:
-      version:
-        - 5.2.5
       variants: +pic
-    zlib:
-      version:
-        - 1.2.11
-    zstd:
-      version:
-        - 1.5.0
 
   definitions:
 
   - cuda_specs:
     - amrex +cuda cuda_arch=70
-    # - axom +cuda cuda_arch=70 ^umpire@4.1.2 ~shared
     - caliper +cuda cuda_arch=70
     - chai +cuda ~benchmarks ~tests cuda_arch=70 ^umpire~shared+cuda
     - ginkgo +cuda cuda_arch=70
@@ -200,18 +72,19 @@ spack:
     - tasmanian +cuda cuda_arch=70
     - zfp +cuda cuda_arch=70
     #- ascent +cuda ~shared cuda_arch=70
+    #- axom +cuda cuda_arch=70 ^umpire@4.1.2 ~shared
     #- hypre +cuda cuda_arch=70
     #- mfem +cuda cuda_arch=70
     #- umpire +cuda ~shared cuda_arch=70 # unsatisfiable concretization conflict w/ blt
 
   - rocm_specs:
     - kokkos +rocm amdgpu_target=gfx906
-    - strumpack +rocm ~slate amdgpu_target=gfx906
     #- amrex +rocm amdgpu_target=gfx906
     #- chai +rocm ~benchmarks amdgpu_target=gfx906
     #- ginkgo +rocm amdgpu_target=gfx906 # needs hip<4.1
     #- raja +rocm ~openmp amdgpu_target=gfx906 # blt 0.3.6 issue with rocm
     #- slate +rocm amdgpu_target=gfx906
+    #- strumpack +rocm ~slate amdgpu_target=gfx906
     #- sundials +rocm amdgpu_target=gfx906
     #- tasmanian +rocm amdgpu_target=gfx906
     #- umpire+rocm amdgpu_target=gfx906 # blt 0.3.6 issue with rocm
@@ -238,6 +111,7 @@ spack:
     - faodel
     - flecsi@1.4.2 +external_cinch
     - flit
+    - flux-core
     - fortrilinos
     - gasnet
     - ginkgo
@@ -255,6 +129,7 @@ spack:
     - libnrm
     - libquo
     - libunwind
+    - llvm +all_targets +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
     - loki
     - mercury
     - metall
@@ -297,7 +172,7 @@ spack:
     - sz
     - tasmanian
     - tau
-    - trilinos@13.0.1 +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
+    - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     - turbine
     - umap
     - unifyfs@0.9.1
@@ -306,7 +181,6 @@ spack:
     - zfp
     #- dealii
     #- geopm
-    #- llvm-doe@doe +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang
     #- qt
     #- qwt
     #- umpire # unsatisfiable concretization conflict w/ blt
@@ -325,10 +199,6 @@ spack:
   - matrix:
     - - $cuda_specs
     - - $arch
-
-  # - matrix:
-  #   - - $rocm_specs
-  #   - - $arch
 
   mirrors: { "mirror": "s3://spack-binaries-develop/e4s" }
 

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -3,6 +3,7 @@ spack:
   concretization: separately
 
   config:
+    concretizer: clingo
     install_tree:
       root: /home/software/spack
       padded_length: 512


### PR DESCRIPTION
Updating E4S CI environments in preparation for E4S 21.11:
* Using clingo
* Removing package preferences not strictly required
* Expanding set of specs to build on power
* Adding LLVM
* ... possibly some more not changes not noted here in order to sync with local UO CI