### PR TITLE
cray architecture detection for zen3/milan

### DIFF
--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -153,11 +153,12 @@ class Cray(Platform):
                 front_end = archspec.cpu.host()
                 # Look for the frontend architecture or closest ancestor
                 # available in cray target modules
+                avail = [
+                    _target_name_from_craype_target_name(x)
+                    for x in self._avail_targets()
+                ]
                 for front_end_possibility in [front_end] + front_end.ancestors:
-                    if front_end_possibility.name in list(
-                            map(lambda x: _target_name_from_craype_target_name(x),
-                                self._avail_targets())
-                    ):
+                    if front_end_possibility.name in avail:
                         tty.debug("using front-end architecture or available ancestor")
                         return front_end_possibility.name
                 else:

--- a/lib/spack/spack/platforms/cray.py
+++ b/lib/spack/spack/platforms/cray.py
@@ -24,6 +24,7 @@ _craype_name_to_target_name = {
     'x86-cascadelake': 'cascadelake',
     'x86-naples': 'zen',
     'x86-rome': 'zen2',
+    'x86-milan': 'zen3',
     'x86-skylake': 'skylake_avx512',
     'mic-knl': 'mic_knl',
     'interlagos': 'bulldozer',
@@ -143,19 +144,24 @@ class Cray(Platform):
                 env={'TERM': os.environ.get('TERM', '')},
                 output=str, error=os.devnull
             )
+
             default_from_module = ''.join(output.split())  # rm all whitespace
             if default_from_module:
                 tty.debug("Found default module:%s" % default_from_module)
                 return default_from_module
             else:
-                front_end = archspec.cpu.host().name
-                if front_end in list(
-                        map(lambda x: _target_name_from_craype_target_name(x),
-                            self._avail_targets())
-                ):
-                    tty.debug("default to front-end architecture")
-                    return archspec.cpu.host().name
+                front_end = archspec.cpu.host()
+                # Look for the frontend architecture or closest ancestor
+                # available in cray target modules
+                for front_end_possibility in [front_end] + front_end.ancestors:
+                    if front_end_possibility.name in list(
+                            map(lambda x: _target_name_from_craype_target_name(x),
+                                self._avail_targets())
+                    ):
+                        tty.debug("using front-end architecture or available ancestor")
+                        return front_end_possibility.name
                 else:
+                    tty.debug("using platform.machine as default")
                     return platform.machine()
 
     def _avail_targets(self):


### PR DESCRIPTION
This PR does two things:
Update the cray architecture module table with x86-milan -> zen3

Make cray architecture more robust to future cray systems. In the future, if Spack cannot find the frontend architecture among the cray modules, it will back off and try ancestors of the current architecture. In this case, instead of an error users would have built for `cray-sles15-zen2` instead of `cray-sles15-zen3` between the creation of the system and adding the translation of x86-milan -> zen3 to the cray architecture module table.

Fixes #25914 