### PR TITLE
Revert "py-setuptools-scm: make py-tomli dependency an open range (#2…

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -30,4 +30,4 @@ class PySetuptoolsScm(PythonPackage):
     depends_on('py-setuptools@45:', type=('build', 'run'), when='@6:')
 
     depends_on('py-toml', when='+toml @:6.1.0', type=('build', 'run'))
-    depends_on('py-tomli@1.0.0:', when='+toml @6.1.0:', type=('build', 'run'))
+    depends_on('py-tomli@1.0.0', when='+toml @6.1.0:', type=('build', 'run'))


### PR DESCRIPTION
…6820)"

This reverts commit a678a666838212bb054a5dd28a731820dae57668, as it broke
several python packages.