### PR TITLE
Pipelines: pin importlib-metadata and setuptools-scm versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
+++ b/var/spack/repos/builtin/packages/py-importlib-metadata/package.py
@@ -13,7 +13,7 @@ class PyImportlibMetadata(PythonPackage):
     pypi = "importlib_metadata/importlib_metadata-1.2.0.tar.gz"
 
     version('4.8.1', sha256='f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1')
-    version('4.6.1', sha256='079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac')
+    version('4.6.1', sha256='079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac', preferred=True)
     version('3.10.1', sha256='c9356b657de65c53744046fa8f7358afe0714a1af7d570c00c3835c2d724a7c1')
     version('3.10.0', sha256='c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a')
     version('2.0.0', sha256='77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da')

--- a/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools-scm/package.py
@@ -13,7 +13,7 @@ class PySetuptoolsScm(PythonPackage):
     pypi = "setuptools_scm/setuptools_scm-4.1.2.tar.gz"
 
     version('6.3.2',  sha256='a49aa8081eeb3514eb9728fa5040f2eaa962d6c6f4ec9c32f6c1fba88f88a0f2')
-    version('6.0.1',  sha256='d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92')
+    version('6.0.1',  sha256='d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92', preferred=True)
     version('4.1.2',  sha256='a8994582e716ec690f33fec70cca0f85bd23ec974e3f783233e4879090a7faa8')
     version('3.5.0',  sha256='5bdf21a05792903cafe7ae0c9501182ab52497614fa6b1750d9dbae7b60c1a87')
     version('3.3.3',  sha256='bd25e1fb5e4d603dcf490f1fde40fb4c595b357795674c3e5cb7f6217ab39ea5')


### PR DESCRIPTION
This will hopefully be a hotfix for the issue with pipelines in #26813 and #26820