### PR TITLE
pumi: support build/install time and stand-alone testing

### DIFF
--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -105,3 +105,11 @@ class Pumi(CMakePackage):
         expected = 'mesh pipe_unif.smb written'
         description = 'testing pumi uniform mesh refinement'
         self.run_test(exe,options,expected,purpose=description,work_dir=self.prefix.bin)
+
+        mpiexec = Executable(join_path(self.spec['mpi'].prefix.bin,'mpiexec')).command
+        mpiopt = ['-n', '2']
+        exe = ['split']
+        options = ['../testdata/pipe.dmg', '../testdata/pipe.smb', 'pipe_2_.smb', '2']
+        expected = 'mesh pipe_2_.smb written'
+        description = 'testing pumi mesh partitioning'
+        self.run_test(mpiexec,mpiopt+exe+options,expected,purpose=description,work_dir=self.prefix.bin)

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -98,6 +98,8 @@ class Pumi(CMakePackage):
         return args
 
     def test(self):
+        if self.spec.version <= Version('2.2.6'):
+            return
         exe = 'uniform'
         options = ['../testdata/pipe.dmg', '../testdata/pipe.smb', 'pipe_unif.smb']
         expected = 'mesh pipe_unif.smb written'

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -41,7 +41,7 @@ class Pumi(CMakePackage):
     variant('shared', default=False, description='Build shared libraries')
     variant('zoltan', default=False, description='Enable Zoltan Features')
     variant('fortran', default=False, description='Enable FORTRAN interface')
-    variant('testing', default=False, description='Enable tests')
+    variant('testing', default=False, description='Enable all tests')
     variant('simmodsuite', default='none',
             values=('none', 'base', 'kernels', 'full'),
             description="Enable Simmetrix SimModSuite Support: 'base' enables "
@@ -96,11 +96,3 @@ class Pumi(CMakePackage):
             mpi_id = spec['mpi'].name + spec['mpi'].version.string
             args.append('-DSIM_MPI=' + mpi_id)
         return args
-
-    @run_after('build')
-    @on_package_attributes(run_tests=True)
-    def check(self):
-        """Run ctest after building project."""
-
-        with working_dir(self.build_directory):
-            ctest(parallel=False)

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -104,12 +104,14 @@ class Pumi(CMakePackage):
         options = ['../testdata/pipe.dmg', '../testdata/pipe.smb', 'pipe_unif.smb']
         expected = 'mesh pipe_unif.smb written'
         description = 'testing pumi uniform mesh refinement'
-        self.run_test(exe,options,expected,purpose=description,work_dir=self.prefix.bin)
+        self.run_test(exe, options, expected, purpose=description,
+                      work_dir=self.prefix.bin)
 
-        mpiexec = Executable(join_path(self.spec['mpi'].prefix.bin,'mpiexec')).command
+        mpiexec = Executable(join_path(self.spec['mpi'].prefix.bin, 'mpiexec')).command
         mpiopt = ['-n', '2']
         exe = ['split']
         options = ['../testdata/pipe.dmg', '../testdata/pipe.smb', 'pipe_2_.smb', '2']
         expected = 'mesh pipe_2_.smb written'
         description = 'testing pumi mesh partitioning'
-        self.run_test(mpiexec,mpiopt+exe+options,expected,purpose=description,work_dir=self.prefix.bin)
+        self.run_test(mpiexec, mpiopt + exe + options, expected,
+                      purpose=description, work_dir=self.prefix.bin)

--- a/var/spack/repos/builtin/packages/pumi/package.py
+++ b/var/spack/repos/builtin/packages/pumi/package.py
@@ -96,3 +96,10 @@ class Pumi(CMakePackage):
             mpi_id = spec['mpi'].name + spec['mpi'].version.string
             args.append('-DSIM_MPI=' + mpi_id)
         return args
+
+    def test(self):
+        exe = 'uniform'
+        options = ['../testdata/pipe.dmg', '../testdata/pipe.smb', 'pipe_unif.smb']
+        expected = 'mesh pipe_unif.smb written'
+        description = 'testing pumi uniform mesh refinement'
+        self.run_test(exe,options,expected,purpose=description,work_dir=self.prefix.bin)


### PR DESCRIPTION
This PR adds support for build/install time testing and stand-alone (aka 'smoke tests').

- https://github.com/spack/spack/pull/26832/commits/171ea1a3a9ba2dfe8d97176764085c3c7eb05ae3 removes the custom method that calls `ctest` and instead relies on the built-in CMakePackage support for calling `make check`.  Note, the supporting changes in pumi `master` are [here](https://github.com/SCOREC/core/commit/2bc66985ec2bff3cd2ca9d0e0f157cd5b19b50e8).

- https://github.com/spack/spack/pull/26832/commits/95db7666564ad8039d077b0bd03e33637dda5a59 .. https://github.com/spack/spack/pull/26832/commits/4d5a90090b732b5626ac0a1198bd5fece307a9a6 define the `test` method to support stand-alone tests.  The corresponding change in the pumi repo is [here](https://github.com/SCOREC/core/commit/fd6ccc83e17ad8df04dac8a11931061a0d155f95).
