### PR TITLE
[cppgsl] branch 'master' is now 'main'

### DIFF
--- a/var/spack/repos/builtin/packages/cppgsl/package.py
+++ b/var/spack/repos/builtin/packages/cppgsl/package.py
@@ -13,8 +13,8 @@ class Cppgsl(CMakePackage):
     url      = "https://github.com/Microsoft/GSL/archive/v2.0.0.tar.gz"
     git      = "https://github.com/Microsoft/GSL.git"
 
+    version('main', branch='main')
     version('3.1.0', sha256='d3234d7f94cea4389e3ca70619b82e8fb4c2f33bb3a070799f1e18eef500a083')
-    version('master', branch='master')
     version('2.1.0', sha256='ef73814657b073e1be86c8f7353718771bf4149b482b6cb54f99e79b23ff899d')
     version('2.0.0', sha256='6cce6fb16b651e62711a4f58e484931013c33979b795d1b1f7646f640cfa9c8e')
     version('1.0.0', sha256='9694b04cd78e5b1a769868f19fdd9eea2002de3d4c3a81a1b769209364543c36')


### PR DESCRIPTION
This avoid fetch failures like this:
```
==> Installing cppgsl-master-odppuo7avhge4mtsgk4wj7x3l5hpe55m
==> No binary for cppgsl-master-odppuo7avhge4mtsgk4wj7x3l5hpe55m found: installing from source
==> Warning: There is no checksum on file to fetch cppgsl@master safely.
==>   Fetch anyway? [y/N] y
==> Error: FetchError: All fetchers failed for spack-stage-cppgsl-master-odppuo7avhge4mtsgk4wj7x3l5hpe55m

/home/wdconinc/git/spack/lib/spack/spack/package.py:1379, in do_fetch:
       1376
       1377        self.stage.create()
       1378        err_msg = None if not self.manual_download else self.download_instr
  >>   1379        start_time = time.time()
       1380        self.stage.fetch(mirror_only, err_msg=err_msg)
       1381        self._fetch_time = time.time() - start_time
       1382


```

Maintainer tag: no one, but @joequant as most recent committer.