### PR TITLE
flux-core, -sched: update to latest versions, fix czmq build error

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/0001-build-fix-build-errors-with-side-installed-0MQ.patch
+++ b/var/spack/repos/builtin/packages/flux-core/0001-build-fix-build-errors-with-side-installed-0MQ.patch
@@ -1,0 +1,60 @@
+From bb0496137d5a15f67ccde15e4d1462d6abaee339 Mon Sep 17 00:00:00 2001
+From: Jim Garlick <garlick.jim@gmail.com>
+Date: Tue, 19 Oct 2021 14:27:47 -0700
+Subject: [PATCH 1/1] build: fix build errors with side-installed 0MQ
+
+Problem: when building against side-installed libzmq, libczmq,
+compilation fails with a missing zframe_t definition.
+
+If the side installed 0MQ packages were built with the "draft APIs"
+enabled (the default), libczmqcontainers/zhashx.h and zlistx.h define
+function prototypes using zframe_t.  Extend CZMQ_BUILD_EXTRA to
+include those prototypes so they are never defined in libczmqcontainers.
+---
+ src/common/libczmqcontainers/zhashx.h | 2 +-
+ src/common/libczmqcontainers/zlistx.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/common/libczmqcontainers/zhashx.h b/src/common/libczmqcontainers/zhashx.h
+index 01a69ae0a..d9cbe1712 100644
+--- a/src/common/libczmqcontainers/zhashx.h
++++ b/src/common/libczmqcontainers/zhashx.h
+@@ -267,7 +267,6 @@ CZMQ_EXPORT zhashx_t *
+ //  Self test of this class.
+ CZMQ_EXPORT void
+     zhashx_test (bool verbose);
+-#endif // CZMQ_BUILD_EXTRA
+ 
+ #ifdef CZMQ_BUILD_DRAFT_API
+ //  *** Draft method, for development use, may change without warning ***
+@@ -284,6 +283,7 @@ CZMQ_EXPORT zframe_t *
+     zhashx_pack_own (zhashx_t *self, zhashx_serializer_fn serializer);
+ 
+ #endif // CZMQ_BUILD_DRAFT_API
++#endif // CZMQ_BUILD_EXTRA
+ //  @end
+ 
+ #ifdef __cplusplus
+diff --git a/src/common/libczmqcontainers/zlistx.h b/src/common/libczmqcontainers/zlistx.h
+index c2ccd9877..1bb55eb6c 100644
+--- a/src/common/libczmqcontainers/zlistx.h
++++ b/src/common/libczmqcontainers/zlistx.h
+@@ -197,7 +197,6 @@ CZMQ_EXPORT void
+ //  Self test of this class.
+ CZMQ_EXPORT void
+     zlistx_test (bool verbose);
+-#endif // CZMQ_BUILD_EXTRA
+ 
+ #ifdef CZMQ_BUILD_DRAFT_API
+ //  *** Draft method, for development use, may change without warning ***
+@@ -225,6 +224,7 @@ CZMQ_EXPORT zframe_t *
+     zlistx_pack (zlistx_t *self);
+ 
+ #endif // CZMQ_BUILD_DRAFT_API
++#endif // CZMQ_BUILD_EXTRA
+ //  @end
+ 
+ 
+-- 
+2.27.0
+

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -19,6 +19,7 @@ class FluxCore(AutotoolsPackage):
     maintainers = ['grondo']
 
     version('master', branch='master')
+    version('0.30.0', sha256='e51fde4464140367ae4bc1b44f960675ea0a6f58eede3a561cacd8a11ca3e776')
     version('0.29.0', sha256='c13b40e82d66356e75208a689a495ca01f0a013e2e45ac8ea202ed8224987323')
     version('0.28.0', sha256='9a784def7186b0036091bd8d6d8fe5bc3425ab2927e1465e1c9ad266631c285d')
     version('0.27.0', sha256='abd46d38081ba6b501adb1c111374b39d6ae72ac1aec9fbbf31943a856541d3a')

--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -78,6 +78,10 @@ class FluxCore(AutotoolsPackage):
     depends_on("valgrind", type="test")
     depends_on("jq", type="test")
 
+    # Patch 0.27-0.30 for build errors when czmq built with "draft APIs":
+    patch('0001-build-fix-build-errors-with-side-installed-0MQ.patch',
+          when='@0.27.0:0.30.0')
+
     def url_for_version(self, version):
         '''
         Flux uses a fork of ZeroMQ's Collective Code Construction Contract

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -103,10 +103,18 @@ class FluxSched(AutotoolsPackage):
             bash = which('bash')
             bash('./autogen.sh')
 
+    @when('@:0.19')
+    def patch(self):
+        """Fix build with clang@13 and gcc@11"""
+        filter_file('NULL', 'nullptr', 'resource/schema/sched_data.hpp')
+        filter_file('size_t', 'std::size_t', 'resource/planner/planner.h')
+
     def configure_args(self):
         args = []
         if self.spec.satisfies('@0.9.0:'):
-            args.append('CXXFLAGS=-Wno-maybe-uninitialized')
+            args.append('CXXFLAGS=-Wno-uninitialized')
+        if self.spec.satisfies('%clang@12:'):
+            args.append('CXXFLAGS=-Wno-defaulted-function-deleted')
         # flux-sched's ax_boost is sometimes weird about non-system locations
         # explicitly setting the path guarantees success
         args.append('--with-boost={0}'.format(self.spec['boost'].prefix))

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -19,6 +19,7 @@ class FluxSched(AutotoolsPackage):
     maintainers = ['grondo']
 
     version('master', branch='master')
+    version('0.19.0', sha256='8dffa8eaec95a81286f621639ef851c52dc4c562d365971233bbd91100c31ed2')
     version('0.18.0', sha256='a4d8a6444fdb7b857b26f47fdea57992b486c9522f4ff92d5a6f547d95b586ae')
     version('0.17.0', sha256='5acfcb757e2294a92eaa91be58ba9b42736b88b42d2937de4a78f4642b1c4933')
     version('0.16.0', sha256='08313976161c141b9b34e2d44d5a08d1b11302e22d60aeaf878eef84d4bd2884')
@@ -52,6 +53,8 @@ class FluxSched(AutotoolsPackage):
     depends_on("flux-core@0.23.0:0.25", when='@0.15.0', type=('build', 'run', 'link'))
     depends_on("flux-core@0.26.0:", when='@0.16.0', type=('build', 'run', 'link'))
     depends_on("flux-core@0.28.0:", when='@0.17.0', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.29.0:", when='@0.18.0', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.30.0:", when='@0.19.0', type=('build', 'run', 'link'))
     depends_on("flux-core@master", when='@master', type=('build', 'run', 'link'))
 
     # Need autotools when building on master:


### PR DESCRIPTION
This PR simply adds versions flux-core@0.30.0 and flux-sched@0.19.0.

For flux-core `@0.27.0:0.30.0`, apply a patch that should fix libczmq_containers build as reported in #26690.