### PR TITLE
Feature: Add tag filters to `spack test list`

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -89,6 +89,12 @@ def setup_parser(subparser):
         "-a", "--all", action="store_true", dest="list_all",
         help="list all packages with tests (not just installed)")
 
+    list_parser.add_argument(
+        'tag',
+        nargs='*',
+        help="limit packages to those with all listed tags"
+    )
+
     # Find
     find_parser = sp.add_parser('find', description=test_find.__doc__,
                                 help=first_line(test_find.__doc__))
@@ -214,15 +220,25 @@ def has_test_method(pkg):
 
 def test_list(args):
     """List installed packages with available tests."""
+    tagged = set(spack.repo.path.packages_with_tags(*args.tag)) if args.tag \
+        else set()
+
+    def has_test_and_tags(pkg_class):
+        return has_test_method(pkg_class) and \
+            (not args.tag or pkg_class.name in tagged)
+
     if args.list_all:
-        all_packages_with_tests = [
+        report_packages = [
             pkg_class.name
             for pkg_class in spack.repo.path.all_package_classes()
-            if has_test_method(pkg_class)
+            if has_test_and_tags(pkg_class)
         ]
+
         if sys.stdout.isatty():
-            tty.msg("%d packages with tests." % len(all_packages_with_tests))
-        colify.colify(all_packages_with_tests)
+            filtered = ' tagged' if args.tag else ''
+            tty.msg("{0}{1} packages with tests.".
+                    format(len(report_packages), filtered))
+        colify.colify(report_packages)
         return
 
     # TODO: This can be extended to have all of the output formatting options
@@ -231,7 +247,7 @@ def test_list(args):
     hashes = env.all_hashes() if env else None
 
     specs = spack.store.db.query(hashes=hashes)
-    specs = list(filter(lambda s: has_test_method(s.package_class), specs))
+    specs = list(filter(lambda s: has_test_and_tags(s.package_class), specs))
 
     spack.cmd.display_specs(specs, long=True)
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1683,7 +1683,12 @@ _spack_test_run() {
 }
 
 _spack_test_list() {
-    SPACK_COMPREPLY="-h --help -a --all"
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help -a --all"
+    else
+        SPACK_COMPREPLY=""
+    fi
 }
 
 _spack_test_find() {


### PR DESCRIPTION
@wspear @shahzebsiddiqui 

This PR adds support for one or more tags to be provided on the command line to filter `spack test list` results.

```
$ spack test list --help
usage: spack test list [-ha] [tag [tag ...]]

List installed packages with available tests.

positional arguments:
  tag         limit packages to those with all listed tags

optional arguments:
  -h, --help  show this help message and exit
  -a, --all   list all packages with tests (not just installed)

$ spack test list -a e4s ecp
==> 2 tagged packages with tests.
arborx  heffte

$ spack test list e4s
-- linux-rhel7-broadwell / gcc@8.3.1 ----------------------------
qax6x57 aml@master      32owbus swig@fortran  6ohwphk umpire@5.0.1
eudzg7h hypre@2.20.0    vsgppwe swig@4.0.2    6wfdlow umpire@develop
ploc3n2 kokkos@develop  i43hck4 umpire@1.1.0  tnscabn upcxx@2019.3.2
ddngphs openmpi@4.1.1   2xjsztl umpire@2.0.0  ehjj2qb upcxx@2021.3.0
vngwd6m openmpi@4.1.1   svz25qg umpire@2.0.0  ejt5z4d upcxx@2021.3.0
4ibfg3c raja@develop    2b3i7cy umpire@4.1.2

-- linux-rhel7-skylake_avx512 / gcc@8.3.1 -----------------------
piknyyb mpich@3.4.2  mrheofe raja@0.14.0  ewsohjo strumpack@5.1.1
2bnxajb mpich@3.4.2  eyih3vk raja@0.14.0  duhzjng strumpack@5.1.1
```