### PR TITLE
Reduce verbosity of error messages when concretizing environments

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1161,7 +1161,8 @@ class Environment(object):
         tty.msg(msg)
 
         concretized_root_specs = spack.util.parallel.parallel_map(
-            _concretize_task, arguments, max_processes=max_processes
+            _concretize_task, arguments, max_processes=max_processes,
+            debug=tty.is_debug()
         )
 
         finish = time.time()

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -58,7 +58,7 @@ class Task(object):
         return value
 
 
-def raise_if_errors(*results, debug=False):
+def raise_if_errors(*results, **kwargs):
     """Analyze results from worker Processes to search for ErrorFromWorker
     objects. If found print all of them and raise an exception.
 
@@ -69,6 +69,7 @@ def raise_if_errors(*results, debug=False):
     Raise:
         RuntimeError: if ErrorFromWorker objects are in the results
     """
+    debug = kwargs.get('debug', False)  # This can be a keyword only arg in Python 3
     err_stream = six.StringIO()
     errors = [x for x in results if isinstance(x, ErrorFromWorker)]
     if not errors:

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -75,17 +75,15 @@ def raise_if_errors(*results, **kwargs):
     if not errors:
         return
 
-    # Report the errors and then raise
-    if debug:
-        for error in errors:
-            print(error.stacktrace, file=err_stream)
+    for error in errors:
+        print(
+            error.stacktrace if debug else error,
+            file=err_stream
+        )
 
-        print('[PARENT PROCESS]:', file=err_stream)
-        traceback.print_stack(file=err_stream)
-    else:
-        for error in errors:
-            print(error, file=err_stream)
-    error_msg = 'errors occurred during concretization of the environment:\n{0}'
+    error_msg = '{0}'
+    if len(errors) > 1 and not debug:
+        error_msg = 'errors occurred during concretization of the environment:\n{0}'
 
     raise RuntimeError(error_msg.format(err_stream.getvalue()))
 
@@ -127,8 +125,8 @@ def parallel_map(func, arguments, max_processes=None, debug=False):
         func (Task): user defined task object
         arguments (list): list of arguments for the task
         max_processes (int or None): maximum number of processes allowed
-        debug (bool): if False, just show error messages. If True show complete
-            stacktraces
+        debug (bool): if False, raise an exception containing just the error messages
+            from workers, if True an exception with complete stacktraces
 
     Raises:
         RuntimeError: if any error occurred in the worker processes

--- a/lib/spack/spack/util/parallel.py
+++ b/lib/spack/spack/util/parallel.py
@@ -10,8 +10,6 @@ import os
 import sys
 import traceback
 
-import six
-
 from .cpus import cpus_available
 
 
@@ -70,22 +68,19 @@ def raise_if_errors(*results, **kwargs):
         RuntimeError: if ErrorFromWorker objects are in the results
     """
     debug = kwargs.get('debug', False)  # This can be a keyword only arg in Python 3
-    err_stream = six.StringIO()
     errors = [x for x in results if isinstance(x, ErrorFromWorker)]
     if not errors:
         return
 
-    for error in errors:
-        print(
-            error.stacktrace if debug else error,
-            file=err_stream
-        )
+    msg = '\n'.join([
+        error.stacktrace if debug else str(error) for error in errors
+    ])
 
-    error_msg = '{0}'
+    error_fmt = '{0}'
     if len(errors) > 1 and not debug:
-        error_msg = 'errors occurred during concretization of the environment:\n{0}'
+        error_fmt = 'errors occurred during concretization of the environment:\n{0}'
 
-    raise RuntimeError(error_msg.format(err_stream.getvalue()))
+    raise RuntimeError(error_fmt.format(msg))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Modifications:
- [x] Stacktraces are shown only if debug mode is active


With this environment:
```yaml
spack:
  specs:
  - zlib
  - hdf5+bar
```
and an artificially introduced conflict:
```diff
--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -29,7 +29,8 @@ class Zlib(Package):
             description='Enable -O2 for a more optimized lib')
 
     patch('w_patch.patch', when="@1.2.11%cce")
-
+    conflicts('%gcc')
+
     @property
     def libs(self):
         shared = '+shared' in self.spec

```
we get the following output:

<details>

<summary>After the PR</summary>

```console
$ spack -e . concretize -f
==> Starting concretization pool with 2 processes
==> Error: errors occurred during concretization of the environment:
zlib does not satisfy unknown
trying to set variant "bar" in package "hdf5", but the package has no such variant [happened during concretization of hdf5+bar]
```

</details>

<details>

<summary>Before the PR</summary>

```console
$ spack -e . concretize -f
==> Starting concretization pool with 2 processes
==> Error: errors occurred in worker processes:
[PID=30631] Traceback (most recent call last):
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/util/parallel.py", line 50, in __call__
    value = self.func(*args, **kwargs)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/environment/environment.py", line 2021, in _concretize_task
    return _concretize_from_constraints(spec_constraints, tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/environment/environment.py", line 1999, in _concretize_from_constraints
    return s.concretized(tests=tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2678, in concretized
    clone.concretize(tests=tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2640, in concretize
    self._new_concretize(tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2613, in _new_concretize
    raise spack.error.UnsatisfiableSpecError(
spack.error.UnsatisfiableSpecError: zlib does not satisfy unknown

[PID=30632] Traceback (most recent call last):
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/util/parallel.py", line 50, in __call__
    value = self.func(*args, **kwargs)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/environment/environment.py", line 2021, in _concretize_task
    return _concretize_from_constraints(spec_constraints, tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/environment/environment.py", line 2014, in _concretize_from_constraints
    raise e
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/environment/environment.py", line 1999, in _concretize_from_constraints
    return s.concretized(tests=tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2678, in concretized
    clone.concretize(tests=tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2640, in concretize
    self._new_concretize(tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 2610, in _new_concretize
    result = spack.solver.asp.solve([self], tests=tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/solver/asp.py", line 1688, in solve
    spack.spec.Spec.ensure_valid_variants(s)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/spec.py", line 3066, in ensure_valid_variants
    raise vt.UnknownVariantError(spec, not_existing)
spack.variant.UnknownVariantError: trying to set variant "bar" in package "hdf5", but the package has no such variant [happened during concretization of hdf5+bar]

[PARENT PROCESS]:
  File "/home/culpo/PycharmProjects/spack/bin/spack", line 100, in <module>
    sys.exit(spack.main.main())
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/main.py", line 816, in main
    return _invoke_command(command, parser, args, unknown)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/main.py", line 529, in _invoke_command
    return_val = command(parser, args)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/cmd/concretize.py", line 37, in concretize
    concretized_specs = env.concretize(force=args.force, tests=tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/environment/environment.py", line 1057, in concretize
    return self._concretize_separately(tests=tests)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/environment/environment.py", line 1163, in _concretize_separately
    concretized_root_specs = spack.util.parallel.parallel_map(
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/util/parallel.py", line 128, in parallel_map
    raise_if_errors(*results)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/util/parallel.py", line 76, in raise_if_errors
    traceback.print_stack(file=err_stream)
```

</details>

The error message for specs which are unsat will be improved further with #26719 