### PR TITLE
[superlu-dist][fix]: Make superlu-dist@7.1.0 request CMake 3.18.1 or newer

### DIFF
--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -45,6 +45,7 @@ class SuperluDist(CMakePackage, CudaPackage):
     depends_on('lapack')
     depends_on('parmetis')
     depends_on('metis@5:')
+    depends_on('cmake@3.18.1:', type='build', when='@7.1.0:')
 
     conflicts('+cuda', when='@:6.3')
 


### PR DESCRIPTION
`superlu-dist@7.1.0:` requires `cmake@3.18.1:` for building (https://github.com/xiaoyeli/superlu_dist/blob/e3eba614889674975dca9f9a697129f9f9cfecf6/CMakeLists.txt#L8). I ran into this issue on Ubuntu 20.04 where the system's preinstalled `cmake@3.16.3` was preferred. 

This patch explicitly adds the `cmake@3.18.1:` dependency during build time of `superlu-dist@7.1.0:`.

## Related information

### Concretization example without patch

The concretization requests `superlu-dist@7.1.0`, but `cmake@3.16.3` which will fail to build.

```
==> Concretized py-pyprecice@develop arch=linux-None-x86_64                                                                                                                                                                                                                               
 -   zlpduyj  py-pyprecice@develop%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                                
 -   gyjgf3f      ^precice@develop%gcc@9.3.0~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo arch=linux-ubuntu20.04-x86_64                                                                                                                                                          
 -   rwif7ud          ^boost@1.71.0%gcc@9.3.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethre
aded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden arch=linux-ubuntu20.04-x86_64                                                                                                                                                                 
 -   am4f5we          ^cmake@3.16.3%gcc@9.3.0~doc+ncurses+openssl+ownlibs~qt build_type=Release patches=1c540040c7e203dd8e27aa20345ecb07fe06570d56410a24a266ae570b1c4c39,bf695e3febb222da2ed94b3beea600650e4318975da90e4a71d6f31a6d5d8c3d arch=linux-ubuntu20.04-x86_64                   
 -   qfebobf          ^eigen@3.3.7%gcc@9.3.0~ipo build_type=RelWithDebInfo patches=55daee880b7669807efc0dcbeda2ae3b659e6dd4df3932f3573c8778bf5f8a42 arch=linux-ubuntu20.04-x86_64                                                                                                         
 -   dlo3m6p          ^libxml2@2.9.12%gcc@9.3.0~python arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                      
 -   zth4ohv              ^libiconv@1.16%gcc@9.3.0 libs=shared,static arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                       
 -   osgk6q3              ^pkgconf@1.8.0%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                          
 -   2vumtpy              ^xz@5.2.4%gcc@9.3.0~pic libs=shared,static arch=linux-ubuntu20.04-x86_64                                           
 -   5zdqiyc              ^zlib@1.2.11%gcc@9.3.0+optimize+pic+shared arch=linux-ubuntu20.04-x86_64                                           
 -   blmtnb5          ^openmpi@4.0.3%gcc@9.3.0~atomics~cuda+cxx~cxx_exceptions+gpfs~internal-hwloc+java~legacylaunchers~lustre~memchecker+pmi~pmix~singularity~sqlite3~static~thread_multiple+vt~wrapper-rpath fabrics=ofi,psm,psm2 patches=60ce20bc14d98c572ef7883b9fcd254c3f232c2f3a1337
7480f96466169ac4c8 schedulers=slurm arch=linux-ubuntu20.04-x86_64                                                                            
 -   5cixgih          ^petsc@3.16.0%gcc@9.3.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5~hpddm~hwloc+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpa
ck~suite-sparse+superlu-dist~tetgen~trilinos~valgrind amdgpu_target=none clanguage=C cuda_arch=none arch=linux-ubuntu20.04-x86_64                                                                                                                                                         
 -   yalen5s              ^amdblis@3.0%gcc@9.3.0+blas+cblas+shared+static threads=none arch=linux-ubuntu20.04-x86_64                                                                                                                                                                      
 -   44caf3m                  ^python@3.8.10%gcc@9.3.0+bz2+ctypes+dbm~debug+libxml2+lzma+nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl+tix+tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,f2fd060afc4b4618fe8104c4c
5d771f36dc55b1db5a4623785a4ea707ec72fb4 arch=linux-ubuntu20.04-x86_64                                                                        
 -   ssqouid              ^amdlibflame@3.0%gcc@9.3.0~debug+lapack2flame+shared+static patches=b3066e8ea70f9a59d1ce00330d72764482dd0faa57d185a45f73ce0effa2bc14 threads=none arch=linux-ubuntu20.04-x86_64
 -   zutmm6t              ^diffutils@3.7%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                             
 -   lkkonr2              ^hdf5@1.10.7%gcc@9.3.0~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-ubuntu20.04-x86_64
 -   vtmwyej              ^hypre@2.23.0%gcc@9.3.0~complex~cuda~debug+fortran~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none arch=linux-ubuntu20.04-x86_64
 -   vds2a7e              ^metis@5.1.0%gcc@9.3.0~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2 arch=linux-ubuntu20.04-x86_64
 -   lnzeqk4              ^parmetis@4.0.3%gcc@9.3.0~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4e
e3cf50f369bce972a9d arch=linux-ubuntu20.04-x86_64                     
 -   uzhexbu              ^superlu-dist@7.1.0%gcc@9.3.0~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none arch=linux-ubuntu20.04-x86_64
 -   e7yhimg      ^py-cython@0.29.24%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                 
 -   4doxxxn          ^py-setuptools@58.2.0%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                          
 -   7uxr4dy      ^py-mpi4py@3.0.3%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                   
 -   jprkdzl      ^py-numpy@1.21.2%gcc@9.3.0+blas+lapack patches=873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604 arch=linux-ubuntu20.04-x86_64

```

### Error message without patch
```
[+] /data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/hypre-2.23.0-vtmwyejkctfwnwxxtjlinindoeozb5ww
==> Installing superlu-dist-7.1.0-uzhexbuz5wdeah6lpu5pyhdywjrojv5o
==> No binary for superlu-dist-7.1.0-uzhexbuz5wdeah6lpu5pyhdywjrojv5o found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/ed/edbea877562be95fb22c7de1ff484f18685bec4baa8e4f703c414d3c035d4a66.tar.gz
==> No patches needed for superlu-dist
==> superlu-dist: Executing phase: 'cmake'
==> Error: ProcessError: Command exited with status 1:
    'cmake' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:STRING=/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/superlu-dist-7.1.0-uzhexbuz5wdeah6lpu5pyhdywjrojv5o' '-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo' '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF' '-DCMAKE_INSTALL_RPATH:STRING=/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/superlu-dist-7.1.0-uzhexbuz5wdeah6lpu5pyhdywjrojv5o/lib;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/superlu-dist-7.1.0-uzhexbuz5wdeah6lpu5pyhdywjrojv5o/lib64;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/amdblis-3.0-yalen5szfz6w2uthtrvminsl43hjdphc/lib;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/amdlibflame-3.0-ssqouidn4skq7hrqdignk36gq3t64pwk/lib;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/metis-5.1.0-vds2a7ehbmqig5t4e5albl6ivgtl4mvm/lib;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/parmetis-4.0.3-lnzeqk4ez3536pqauvxbatz3dawgfnty/lib' '-DCMAKE_PREFIX_PATH:STRING=/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/parmetis-4.0.3-lnzeqk4ez3536pqauvxbatz3dawgfnty;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/metis-5.1.0-vds2a7ehbmqig5t4e5albl6ivgtl4mvm;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/amdlibflame-3.0-ssqouidn4skq7hrqdignk36gq3t64pwk;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/amdblis-3.0-yalen5szfz6w2uthtrvminsl43hjdphc' '-DCMAKE_C_FLAGS=-std=c99' '-DCMAKE_CXX_FLAGS=-std=c++11' '-DCMAKE_C_COMPILER=/usr/bin/mpicc' '-DCMAKE_CXX_COMPILER=/usr/bin/mpic++' '-DCMAKE_INSTALL_LIBDIR:STRING=/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/superlu-dist-7.1.0-uzhexbuz5wdeah6lpu5pyhdywjrojv5o/lib' '-DTPL_BLAS_LIBRARIES=/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/amdblis-3.0-yalen5szfz6w2uthtrvminsl43hjdphc/lib/libblis.so' '-DTPL_LAPACK_LIBRARIES=/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/amdlibflame-3.0-ssqouidn4skq7hrqdignk36gq3t64pwk/lib/libflame.so' '-DUSE_XSDK_DEFAULTS=YES' '-DTPL_PARMETIS_LIBRARIES=-L/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/parmetis-4.0.3-lnzeqk4ez3536pqauvxbatz3dawgfnty/lib -lparmetis;-L/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/metis-5.1.0-vds2a7ehbmqig5t4e5albl6ivgtl4mvm/lib -lmetis' '-DTPL_PARMETIS_INCLUDE_DIRS=/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/parmetis-4.0.3-lnzeqk4ez3536pqauvxbatz3dawgfnty/include;/data/scratch/sgs/jaustar/spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-9.3.0/metis-5.1.0-vds2a7ehbmqig5t4e5albl6ivgtl4mvm/include' '-DXSDK_INDEX_SIZE=32' '-Denable_openmp=OFF' '-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=ON' '-DBUILD_SHARED_LIBS:BOOL=ON' '/data/scratch/sgs/jaustar/spack-tmp/spack-stage-superlu-dist-7.1.0-uzhexbuz5wdeah6lpu5pyhdywjrojv5o/spack-src'

1 error found in build log:
  >> 3    CMake Error at CMakeLists.txt:8 (cmake_minimum_required):
     4      CMake 3.18.1 or higher is required.  You are running version 3.16.3
     5    
     6    
     7    -- Configuring incomplete, errors occurred!

See build log for details:
  /data/scratch/sgs/jaustar/spack-tmp/spack-stage-superlu-dist-7.1.0-uzhexbuz5wdeah6lpu5pyhdywjrojv5o/spack-build-out.txt
```

### Concretization example with patch

In my case, after applying the patch `superlu-dist@6.4.0` is requested as it is compatible with `cmake@3.16.3`.

```
==> Concretized py-pyprecice@develop arch=linux-None-x86_64                                                                                                                                                                                                                               
 -   ha5nkup  py-pyprecice@develop%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                                
 -   hpmdawe      ^precice@develop%gcc@9.3.0~ipo+mpi+petsc~python+shared build_type=RelWithDebInfo arch=linux-ubuntu20.04-x86_64                                                                                                                                                          
 -   rwif7ud          ^boost@1.71.0%gcc@9.3.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden arch=linux-ubuntu20.04-x86_64                                                                                                                                                                 
 -   am4f5we          ^cmake@3.16.3%gcc@9.3.0~doc+ncurses+openssl+ownlibs~qt build_type=Release patches=1c540040c7e203dd8e27aa20345ecb07fe06570d56410a24a266ae570b1c4c39,bf695e3febb222da2ed94b3beea600650e4318975da90e4a71d6f31a6d5d8c3d arch=linux-ubuntu20.04-x86_64                   
 -   qfebobf          ^eigen@3.3.7%gcc@9.3.0~ipo build_type=RelWithDebInfo patches=55daee880b7669807efc0dcbeda2ae3b659e6dd4df3932f3573c8778bf5f8a42 arch=linux-ubuntu20.04-x86_64                                                                                                         
[+]  dlo3m6p          ^libxml2@2.9.12%gcc@9.3.0~python arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                      
[+]  zth4ohv              ^libiconv@1.16%gcc@9.3.0 libs=shared,static arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                       
[+]  osgk6q3              ^pkgconf@1.8.0%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                          
[+]  2vumtpy              ^xz@5.2.4%gcc@9.3.0~pic libs=shared,static arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                        
[+]  5zdqiyc              ^zlib@1.2.11%gcc@9.3.0+optimize+pic+shared arch=linux-ubuntu20.04-x86_64                                           
[+]  blmtnb5          ^openmpi@4.0.3%gcc@9.3.0~atomics~cuda+cxx~cxx_exceptions+gpfs~internal-hwloc+java~legacylaunchers~lustre~memchecker+pmi~pmix~singularity~sqlite3~static~thread_multiple+vt~wrapper-rpath fabrics=ofi,psm,psm2 patches=60ce20bc14d98c572ef7883b9fcd254c3f232c2f3a1337
7480f96466169ac4c8 schedulers=slurm arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                                         
 -   w2hteso          ^petsc@3.16.0%gcc@9.3.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw~giflib+hdf5~hpddm~hwloc+hypre~int64~jpeg~knl~libpng~libyaml~memkind+metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpa
ck~suite-sparse+superlu-dist~tetgen~trilinos~valgrind amdgpu_target=none clanguage=C cuda_arch=none arch=linux-ubuntu20.04-x86_64                                                                                                                                                         
[+]  yalen5s              ^amdblis@3.0%gcc@9.3.0+blas+cblas+shared+static threads=none arch=linux-ubuntu20.04-x86_64                                                                                                                                                                      
[+]  44caf3m                  ^python@3.8.10%gcc@9.3.0+bz2+ctypes+dbm~debug+libxml2+lzma+nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl+tix+tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,f2fd060afc4b4618fe8104c4c
5d771f36dc55b1db5a4623785a4ea707ec72fb4 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                                     
[+]  ssqouid              ^amdlibflame@3.0%gcc@9.3.0~debug+lapack2flame+shared+static patches=b3066e8ea70f9a59d1ce00330d72764482dd0faa57d185a45f73ce0effa2bc14 threads=none arch=linux-ubuntu20.04-x86_64                                                                                 
 -   zutmm6t              ^diffutils@3.7%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                          
[+]  lkkonr2              ^hdf5@1.10.7%gcc@9.3.0~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-ubuntu20.04-x86_64                                                                                                             
[+]  vtmwyej              ^hypre@2.23.0%gcc@9.3.0~complex~cuda~debug+fortran~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist~unified-memory cuda_arch=none arch=linux-ubuntu20.04-x86_64                                                                                   
[+]  vds2a7e              ^metis@5.1.0%gcc@9.3.0~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2 arch=linux-ubuntu20.04-x86_64                       
[+]  lnzeqk4              ^parmetis@4.0.3%gcc@9.3.0~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4e
e3cf50f369bce972a9d arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                                                         
 -   t6mwrni              ^superlu-dist@6.4.0%gcc@9.3.0~cuda~int64~ipo~openmp+shared build_type=RelWithDebInfo cuda_arch=none arch=linux-ubuntu20.04-x86_64                                                                                                                               
[+]  e7yhimg      ^py-cython@0.29.24%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                              
[+]  4doxxxn          ^py-setuptools@58.2.0%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                       
[+]  7uxr4dy      ^py-mpi4py@3.0.3%gcc@9.3.0 arch=linux-ubuntu20.04-x86_64                                                                                                                                                                                                                
 -   jprkdzl      ^py-numpy@1.21.2%gcc@9.3.0+blas+lapack patches=873745d7b547857fcfec9cae90b09c133b42a4f0c23b6c2d84cf37e2dd816604 arch=linux-ubuntu20.04-x86_64  
```