### PR TITLE
nsimd: Determine SIMD variant automatically by default

### DIFF
--- a/var/spack/repos/builtin/packages/nsimd/package.py
+++ b/var/spack/repos/builtin/packages/nsimd/package.py
@@ -103,15 +103,15 @@ class Nsimd(CMakePackage):
             elif 'sve' in self.spec.target:
                 # We require an explicit choice for particluar bit widths
                 simd = 'SVE'
-            elif self.spec.satisfies('target=aarch64'):
+            elif self.spec.satisfies('target=aarch64:'):
                 simd = 'AARCH64'
             elif 'neon' in self.spec.target:
                 simd = 'NEON128'
             # POWER
             elif 'vsx' in self.spec.target:
                 simd = 'VSX'
-            elif (self.spec.satisfies('target=ppc64') or
-                  self.spec.satisfies('target=ppc64le')):
+            elif (self.spec.satisfies('target=ppc64:') or
+                  self.spec.satisfies('target=ppc64le:')):
                 simd = 'VMX'
             # Unknown CPU architecture
             else:

--- a/var/spack/repos/builtin/packages/nsimd/package.py
+++ b/var/spack/repos/builtin/packages/nsimd/package.py
@@ -12,6 +12,7 @@ class Nsimd(CMakePackage):
 
     maintainers = ['eschnett']
 
+    version('3.0.1', sha256='6a90d7ce5f9da5cfac872463951f3374bb0e0824d92f714db0fd4901b32497fd')
     version('3.0', sha256='5cab09020ce3a6819ddb3b3b8cafa6bc1377821b596c0f2954f52c852d092d5c')
     version('2.2', sha256='7916bec6c8ea9ddc690a5bfc80fb1b9402f9e1b2a4b4bb6b6bb8eb5a07eb018e')
     version('2.1', sha256='3274f1061d1fac170130b8c75378a6b94580629b3dc1d53db244b51500ee4695')
@@ -20,10 +21,10 @@ class Nsimd(CMakePackage):
     version('1.0', sha256='523dae83f1d93eab30114321f1c9a67e2006a52595da4c51f121ca139abe0857')
 
     variant('simd',
-            default='none',
+            default='auto',
             description='SIMD instruction set',
             values=(
-                'none',
+                'auto',
                 'CPU',
                 'SSE2', 'SSE42', 'AVX', 'AVX2', 'AVX512_KNL', 'AVX512_SKYLAKE',
                 'NEON128', 'AARCH64',
@@ -35,7 +36,6 @@ class Nsimd(CMakePackage):
     variant('optionals', values=any_combination_of('FMA', 'FP16'),
             description='Optional SIMD features',)
 
-    conflicts('simd=none', msg="SIMD instruction set not defined")
     conflicts('simd=SVE128', when=('@:1'),
               msg="SIMD extension not available in version @:1")
     conflicts('simd=SVE256', when=('@:1'),
@@ -85,6 +85,40 @@ class Nsimd(CMakePackage):
     def cmake_args(self):
         # Required SIMD argument
         simd = self.spec.variants['simd'].value
+        if simd == 'auto':
+            # x86
+            if 'avx512' in self.spec.target:
+                simd = 'AVX512_SKYLAKE'
+            elif ('avx512f' in self.spec.target and
+                 'avx512pf' in self.spec.target and
+                 'avx512er' in self.spec.target and
+                 'avx512cd' in self.spec.target and
+                 'avx512vl' in self.spec.target):
+                simd = 'AVX512_KNL'
+            elif 'avx2' in self.spec.target:
+                simd = 'AVX2'
+            elif 'avx' in self.spec.target:
+                simd = 'AVX'
+            elif 'sse4_2' in self.spec.target:
+                simd = 'SSE42'
+            elif 'sse2' in self.spec.target:
+                simd = 'SSE2'
+            # ARM
+            elif 'sve' in self.spec.target:
+                simd = 'SVE' # need explicit choice for particluar bit widths
+            elif self.spec.target.microarchitecture == 'aarch64':
+                simd = 'AARCH64'
+            elif 'neon' in self.spec.target:
+                simd = 'NEON128'
+            # POWER
+            elif 'vsx' in self.spec.target:
+                simd = 'VSX'
+            elif self.spec.target.microarchitecture in ['ppc64', 'ppc64le']:
+                simd = 'VMX'
+            # Unknown CPU architecture
+            else:
+                simd = 'CPU'
+
         if self.spec.satisfies("@:1"):
             cmake_args = ["-DSIMD={0}".format(simd)]
         else:

--- a/var/spack/repos/builtin/packages/nsimd/package.py
+++ b/var/spack/repos/builtin/packages/nsimd/package.py
@@ -89,11 +89,7 @@ class Nsimd(CMakePackage):
             # x86
             if 'avx512' in self.spec.target:
                 simd = 'AVX512_SKYLAKE'
-            elif ('avx512f' in self.spec.target and
-                  'avx512pf' in self.spec.target and
-                  'avx512er' in self.spec.target and
-                  'avx512cd' in self.spec.target and
-                  'avx512vl' in self.spec.target):
+            elif self.spec.satisfies('target=mic_knl'):
                 simd = 'AVX512_KNL'
             elif 'avx2' in self.spec.target:
                 simd = 'AVX2'
@@ -107,14 +103,14 @@ class Nsimd(CMakePackage):
             elif 'sve' in self.spec.target:
                 # We require an explicit choice for particluar bit widths
                 simd = 'SVE'
-            elif self.spec.target.microarchitecture == 'aarch64':
+            elif self.spec.satisfies('target=aarch64'):
                 simd = 'AARCH64'
             elif 'neon' in self.spec.target:
                 simd = 'NEON128'
             # POWER
             elif 'vsx' in self.spec.target:
                 simd = 'VSX'
-            elif self.spec.target.microarchitecture in ['ppc64', 'ppc64le']:
+            elif self.spec.satisfies('target=ppc64') or self.spec.satisfies('target=ppc64le'):
                 simd = 'VMX'
             # Unknown CPU architecture
             else:

--- a/var/spack/repos/builtin/packages/nsimd/package.py
+++ b/var/spack/repos/builtin/packages/nsimd/package.py
@@ -110,7 +110,8 @@ class Nsimd(CMakePackage):
             # POWER
             elif 'vsx' in self.spec.target:
                 simd = 'VSX'
-            elif self.spec.satisfies('target=ppc64') or self.spec.satisfies('target=ppc64le'):
+            elif (self.spec.satisfies('target=ppc64') or
+                  self.spec.satisfies('target=ppc64le')):
                 simd = 'VMX'
             # Unknown CPU architecture
             else:

--- a/var/spack/repos/builtin/packages/nsimd/package.py
+++ b/var/spack/repos/builtin/packages/nsimd/package.py
@@ -90,10 +90,10 @@ class Nsimd(CMakePackage):
             if 'avx512' in self.spec.target:
                 simd = 'AVX512_SKYLAKE'
             elif ('avx512f' in self.spec.target and
-                 'avx512pf' in self.spec.target and
-                 'avx512er' in self.spec.target and
-                 'avx512cd' in self.spec.target and
-                 'avx512vl' in self.spec.target):
+                  'avx512pf' in self.spec.target and
+                  'avx512er' in self.spec.target and
+                  'avx512cd' in self.spec.target and
+                  'avx512vl' in self.spec.target):
                 simd = 'AVX512_KNL'
             elif 'avx2' in self.spec.target:
                 simd = 'AVX2'
@@ -105,7 +105,8 @@ class Nsimd(CMakePackage):
                 simd = 'SSE2'
             # ARM
             elif 'sve' in self.spec.target:
-                simd = 'SVE' # need explicit choice for particluar bit widths
+                # We require an explicit choice for particluar bit widths
+                simd = 'SVE'
             elif self.spec.target.microarchitecture == 'aarch64':
                 simd = 'AARCH64'
             elif 'neon' in self.spec.target:


### PR DESCRIPTION
Manually setting the SIMD variant is still possible.
Also remove default setting `simd=none` which doesn't work with the clingo concretizer.
Also add new version 3.0.1.