### PR TITLE
update bacio for 2.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/bacio/package.py
+++ b/var/spack/repos/builtin/packages/bacio/package.py
@@ -16,4 +16,10 @@ class Bacio(CMakePackage):
 
     maintainers = ['t-brown', 'edwardhartnett', 'kgerheiser', 'Hang-Lei-NOAA']
 
-    version('2.4.1', sha256='7b9b6ba0a288f438bfba6a08b6e47f8133f7dba472a74ac56a5454e2260a7200')
+    version('2.5.0', sha256='540a0ed73941d70dbf5d7b21d5d0a441e76fad2bfe37dfdfea0db3e98fc0fbfb')
+
+    # Prefer version 2.4.1 because the library and include directory
+    # names changed in verion 2.5.0 (dropping the "_4" they used to
+    # contain.) We need some time to let all the using packages adjust
+    # to the new names.
+    version('2.4.1', sha256='7b9b6ba0a288f438bfba6a08b6e47f8133f7dba472a74ac56a5454e2260a7200', preferred=True)


### PR DESCRIPTION
update bacio for 2.5.0

The previous version (2.4.1) remains the preferred version for now, due to a library name change.