### PR TITLE
feature: 'spack find --info' with alias 'spack info --installed'

### DIFF
--- a/lib/spack/spack/cmd/common/display.py
+++ b/lib/spack/spack/cmd/common/display.py
@@ -31,7 +31,7 @@ def print_deps(spec, dependencies=True):
     Print dependency or dependent information for the spec.
 
     Arguments:
-        spec (Spec):  Spec whose information is being printed
+        spec (spack.spec.Spec): Spec whose information is being printed
         dependencies (bool): True if dependencies, False if dependents
     """
     deps = spec.dependencies_dict().items() if dependencies else \
@@ -54,7 +54,7 @@ def print_installed_info(spec):
     Print the installed spec's information
 
     Arguments:
-        spec (Spec): Installed spec whose information will be printed
+        spec (spack.spec.Spec): Installed spec whose information will be printed
     """
     dag = spec.dag_hash()
     _, record = spack.store.db.query_by_spec_hash(dag)

--- a/lib/spack/spack/cmd/common/display.py
+++ b/lib/spack/spack/cmd/common/display.py
@@ -1,0 +1,107 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from datetime import date
+
+import llnl.util.tty as tty
+import llnl.util.tty.color as color
+
+import spack.spec
+
+header_color = '@*b'
+plain_format = '@.'
+
+
+def section_title(s):
+    return header_color + s + plain_format
+
+
+def version(s):
+    return spack.spec.version_color + s + plain_format
+
+
+def variant(s):
+    return spack.spec.enabled_variant_color + s + plain_format
+
+
+def print_deps(spec, dependencies=True):
+    """
+    Print dependency or dependent information for the spec.
+
+    Arguments:
+        spec (Spec):  Spec whose information is being printed
+        dependencies (bool): True if dependencies, False if dependents
+    """
+    deps = spec.dependencies_dict().items() if dependencies else \
+        spec.dependents_dict().items()
+    if not deps:
+        return
+
+    color.cprint('')
+    title = 'Dependencies' if dependencies else 'Dependents'
+    color.cprint(section_title('Recorded {0}:'.format(title)))
+    for _, value in deps:
+        dep_str = str(value).replace(spec.name, '') if dependencies \
+            else str(value)
+        dep_str = dep_str.replace('-->', ' dependencies on')
+        color.cprint("    {0}".format(dep_str.strip()))
+
+
+def print_installed_info(spec):
+    """
+    Print the installed spec's information
+
+    Arguments:
+        spec (Spec): Installed spec whose information will be printed
+    """
+    dag = spec.dag_hash()
+    _, record = spack.store.db.query_by_spec_hash(dag)
+
+    if not record.installed:
+        tty.die("Spec is not installed.")
+
+    pkg_vers = version('{0}@@{1}'.format(spec.name, spec.versions[0]))
+    header = section_title(
+        '{0}:   '
+    ).format(spec.package.build_system_class) + pkg_vers
+    color.cprint(header)
+
+    color.cprint('')
+    color.cprint(section_title('Hashes:'))
+    color.cprint("    DAG  = {0}".format(dag))
+    color.cprint("    full = {0}".format(spec.full_hash()))
+
+    color.cprint('')
+    how = 'Explicitly' if record.explicit else 'as Dependency'
+    installation = 'Installed {0}:   '.format(how)
+    when = date.fromtimestamp(record.installation_time).strftime("%A %d %B %Y")
+    color.cprint(section_title(installation) + when)
+    color.cprint("    architecture = {0}".format(spec.architecture))
+    color.cprint("    prefix       = {0}".format(record.path))
+
+    if spec.external:
+        color.cprint('')
+        color.cprint(section_title('External:'))
+        color.cprint("    path             = {0}".format(spec.external_path))
+        color.cprint("    module           = {0}".format(spec.external_modules))
+        color.cprint("    extra_attributes = {0}".format(spec.extra_attributes))
+
+    color.cprint('')
+    compiler = '{0}@@{1}'.format(spec.compiler.name, spec.compiler.versions[0])
+    color.cprint(section_title('Compiler:   ') + version(compiler))
+    for flag, value in spec.compiler_flags.items():
+        color.cprint("    {0} = {1}".format(flag, value))
+
+    color.cprint('')
+    color.cprint(section_title('Variant Settings:'))
+    variants = spec.variants.items()
+    if len(variants) > 1:
+        for _, value in variants:
+            color.cprint("    {0}".format(value))
+    else:
+        color.cprint("    None")
+
+    print_deps(spec, dependencies=True)
+    print_deps(spec, dependencies=False)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -16,6 +16,7 @@ import llnl.util.tty.color as color
 import spack.bootstrap
 import spack.cmd as cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.common.display as display
 import spack.environment as ev
 import spack.repo
 import spack.user_environment as uenv
@@ -35,6 +36,9 @@ def setup_parser(subparser):
     format_group.add_argument(
         "--json", action="store_true", default=False,
         help="output specs as machine-readable json records")
+    format_group.add_argument(
+        "--info", action="store_true", default=False,
+        help="output single spec in human-readable form")
 
     subparser.add_argument('-d', '--deps', action='store_true',
                            help='output dependencies along with found specs')
@@ -247,6 +251,11 @@ def _find(parser, args):
     # Display the result
     if args.json:
         cmd.display_specs_as_json(results, deps=args.deps)
+    elif args.info:
+        if len(results) != 1:
+            tty.die("Information is provided for a single package only")
+
+        display.print_installed_info(results[0])
     else:
         if not args.format:
             if env:

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import argparse
 import textwrap
-from datetime import date
 
 from six.moves import zip_longest
 

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -333,3 +333,25 @@ def test_find_loaded(database, working_env):
     output = find('--loaded')
     expected = find()
     assert output == expected
+
+
+def test_find_info_multiple(database):
+    out = find('--info', 'mpileaks', fail_on_error=False)
+    assert 'Error:' in out
+    assert 'single package' in out
+
+
+def test_find_info_fields(database):
+    expected_fields = (
+        'Hashes:',
+        'Installed',
+        'Compiler:',
+        'Variant Settings:',
+        'Dependents:',
+    )
+
+    out = find('--info', 'mpich', fail_on_error=False)
+
+    for text in expected_fields:
+        match = [x for x in out.splitlines() if text in x]
+        assert match

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -105,3 +105,34 @@ def test_info_fields(pkg_query, parser, info_lines):
     for text in expected_fields:
         match = [x for x in info_lines if text in x]
         assert match
+
+
+def test_info_multiple():
+    out = info('openmpi', 'xsdk', fail_on_error=False)
+    assert 'Only one' in out
+
+
+def test_info_installed_none():
+    out = info('--installed', 'mpileaks', fail_on_error=False)
+    assert 'no installed' in out
+
+
+def test_info_installed_multiple(database):
+    out = info('--installed', 'mpileaks', fail_on_error=False)
+    assert 'matches multiple' in out
+
+
+def test_info_installed_fields(database):
+    expected_fields = (
+        'Hashes:',
+        'Installed',
+        'Compiler:',
+        'Variant Settings:',
+        'Dependents:',
+    )
+
+    out = info('--installed', 'mpich', fail_on_error=False)
+
+    for text in expected_fields:
+        match = [x for x in out.splitlines() if text in x]
+        assert match

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1047,7 +1047,7 @@ _spack_fetch() {
 _spack_find() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --format --json -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date -b --bootstrap"
+        SPACK_COMPREPLY="-h --help --format --json --info -d --deps -p --paths --groups --no-groups -l --long -L --very-long -t --tag -c --show-concretized -f --show-flags --show-full-compiler -x --explicit -X --implicit -u --unknown -m --missing -v --variants --loaded -M --only-missing --deprecated --only-deprecated -N --namespace --start-date --end-date -b --bootstrap"
     else
         _installed_packages
     fi
@@ -1167,9 +1167,9 @@ _spack_help() {
 _spack_info() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help"
+        SPACK_COMPREPLY="-h --help -i --installed"
     else
-        _all_packages
+        SPACK_COMPREPLY=""
     fi
 }
 


### PR DESCRIPTION
People have requested a command to get details on how a package is actually built to include, more recently, compiler flags.  Unless I'm mistaken, that level of detail is not available in any Spack commands so this PR leverages `spack info` to provide it.

(Update: `spack find --json` *does* provide all of the information here and a bit more in machine-readable form.  `spack find` also has options to get dependencies (`-d`), variants (`-v`), compiler flags (`-f`), install path (`-p`).  I still think the  output from this PR is more user friendly and complete -- except when `--json` is used with `spack find`.)

Help output:
```
$ spack info --help
usage: spack info [-hi] ...

get detailed information on a particular package

positional arguments:
  pkg_spec         Package name or, with --installed, spec

optional arguments:
  -h, --help       show this help message and exit
  -i, --installed  Show installation details: same as `spack find --info`
```

Output from a Spack instance with one version of _hypre_ 2.23.0 installed:
```
$ spack find --info hypre@2.23.0      # OR  $ spack info --installed hypre@2.23.0
AutotoolsPackage:   hypre@2.23.0

Hashes:
    DAG  = odn3zibu5sjt2xumsin6b4quduykiklt
    full = jtv3ffez3sjcrwgrvrtdcxjndrczdhz6

Installed Explicitly:   Thursday 21 October 2021
    architecture = linux-rhel7-skylake_avx512
    prefix       = /usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-skylake_avx512/gcc-8.3.1/hypre-2.23.0-odn3zibu5sjt2xumsin6b4quduykiklt

Compiler:   gcc@8.3.1
    cflags = []
    cppflags = []
    cxxflags = []
    fflags = []
    ldflags = []
    ldlibs = []

Variant Settings:
    ~complex
    ~cuda
    cuda_arch=none
    ~debug
    +fortran
    ~int64
    ~internal-superlu
    ~mixedint
    +mpi
    ~openmp
    +shared
    ~superlu-dist
    ~unified-memory

Recorded Dependencies:
    ('build', 'link') dependencies on openblas
    ('build', 'link') dependencies on openmpi
```

Output when multiple versions of a package are installed in the instance:
```
$ spack find --info zlib
==> Error: Information is provided for a single package only

$ spack info -i zlib
==> Error: zlib matches multiple packages.
  Matching packages:
    s4yfeca zlib@1.2.11%clang@11.0.1 arch=linux-rhel7-cascadelake
    c7zv5ft zlib@1.2.11%gcc@8.3.1 arch=linux-rhel7-broadwell
    ash26ww zlib@1.2.11%gcc@8.3.1 arch=linux-rhel7-skylake_avx512
    kzsxhof zlib@1.2.11%gcc@8.3.1 arch=linux-rhel7-skylake_avx512
  Use a more specific spec.

$ spack find --info /s4yfeca     # OR  $ spack info -i /s4yfeca
Package:   zlib@1.2.11

Hashes:
    DAG  = s4yfecahwfhlopnflf3unufea6hh2efg
    full = n2uzqshm22zbhvho3lw36zrtziglracf

Installed as Dependency:   Wednesday 01 September 2021
    architecture = linux-rhel7-cascadelake
    prefix       = /usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-cascadelake/clang-11.0.1/zlib-1.2.11-s4yfecahwfhlopnflf3unufea6hh2efg

Compiler:   clang@11.0.1
    cflags = []
    cppflags = []
    cxxflags = []
    fflags = []
    ldflags = []
    ldlibs = []

Variant Settings:
    +optimize
    +pic
    +shared

Recorded Dependents:
    libxml2 ('build', 'link') dependencies on zlib
```

Output for an externally installed package:
```
$ spack find --info /er475uw    # OR $ spack info -i /er475uw
AutotoolsPackage:   xz@5.2.2

Hashes:
    DAG  = er475uwcmw5la52ymtpaskn43zua5x37
    full = ydmq7okvsa4c3z6hffqxnki42pnymwkt

Installed as Dependency:   Friday 30 July 2021
    architecture = linux-rhel7-broadwell
    prefix       = /usr

External:
    path             = /usr
    module           = None
    extra_attributes = {}

Compiler:   gcc@8.3.1
    cflags = []
    cppflags = []
    cxxflags = []
    fflags = []
    ldflags = []
    ldlibs = []

Variant Settings:
    libs=shared,static
    ~pic

Recorded Dependents:
    libxml2 ('build', 'link') dependencies on xz
    gettext ('build', 'link', 'run') dependencies on xz
```


TODO:
- [x] Is it better to use the ASP solver or database to get to the information?  (A: database is faster and more complete)
- [x] Format the output, whether ASP or database, in a human-readable form