### PR TITLE
[WIP] Search binary indices for spec hashes parsed from command line

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -257,6 +257,7 @@ class BinaryCacheIndex(object):
         return self._mirrors_for_spec[find_hash]
 
     def find_hash_prefix(self, hash_prefix):
+        self.regenerate_spec_cache()
         results = []
         for dag_hash, info in self._mirrors_for_spec.items():
             if dag_hash.startswith(hash_prefix):

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -171,10 +171,18 @@ class BinaryCacheIndex(object):
 
             self._index_file_cache.init_entry(cache_key)
             cache_path = self._index_file_cache.cache_path(cache_key)
+
+            import time
+            t0 = time.time()
+
             with self._index_file_cache.read_transaction(cache_key):
                 db._read_from_file(cache_path)
+            t1 = time.time()
+            tty.msg("Read DB: " + str(t1 - t0))
 
             spec_list = db.query_local(installed=False, in_buildcache=True)
+            t2 = time.time()
+            tty.msg("Query DB: " + str(t2 - t1))
 
             for indexed_spec in spec_list:
                 dag_hash = indexed_spec.dag_hash()
@@ -247,6 +255,13 @@ class BinaryCacheIndex(object):
             return None
 
         return self._mirrors_for_spec[find_hash]
+
+    def find_hash_prefix(self, hash_prefix):
+        results = []
+        for dag_hash, info in self._mirrors_for_spec.items():
+            if dag_hash.startswith(hash_prefix):
+                results.append(info[0]['spec'])
+        return results
 
     def update_spec(self, spec, found_list):
         """

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1518,7 +1518,7 @@ class Database(object):
     def query_local(self, *args, **kwargs):
         """Query only the local Spack database."""
         with self.read_transaction():
-            return sorted(self._query(*args, **kwargs))
+            return self._query(*args, **kwargs)
 
     if query_local.__doc__ is None:
         query_local.__doc__ = ""

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4803,8 +4803,8 @@ class SpecParser(spack.parse.Parser):
             # time, but if a hash prefix matches local installations and
             # remote installations, this will not inform the user that there
             # are possibly other matches.
-            matches = (spack.binary_distribution
-                       .binary_index.find_hash_prefix(dag_hash))
+            matches = set(spack.binary_distribution
+                          .binary_index.find_hash_prefix(dag_hash))
         else:
             tty.debug("Local matches found for hash ({0}) skip checking "
                       "binary indices.".format(dag_hash))
@@ -4817,7 +4817,7 @@ class SpecParser(spack.parse.Parser):
                 "Multiple packages specify hash beginning '%s'."
                 % dag_hash, *matches)
 
-        return matches[0]
+        return next(iter(matches))
 
     def spec(self, name):
         """Parse a spec out of the input. If a spec is supplied, initialize

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4797,7 +4797,9 @@ class SpecParser(spack.parse.Parser):
         self.expect(ID)
 
         dag_hash = self.token.value
-        matches = spack.store.db.get_by_hash(dag_hash)
+        matches = spack.store.db.get_by_hash(dag_hash) or list()
+        matches.extend(
+            spack.binary_distribution.binary_index.find_hash_prefix(dag_hash))
         if not matches:
             raise NoSuchHashError(dag_hash)
 


### PR DESCRIPTION
This is a combination of https://github.com/spack/spack/pull/22503 and https://github.com/spack/spack/pull/25302. 

This is slow without ~(likely breaking)~(EDIT: all the tests pass with this change) change in #25302 to not sort `Database.query_local`. I can add an option for this if needed (the sorting isn't required when resolving hashes while parsing command-line specs).

For example timing this with the E4S cache (times are in seconds):

```
$ spack mirror add E4S https://cache.e4s.io
$ spack -d buildcache list --allarch gcc
==> [2021-10-20-14:06:28.974284] Read DB: 11.0089852809906
==> [2021-10-20-14:06:56.917867] Query DB: 27.943589210510254

If I omit the sorting, it is much faster

==> [2021-10-20-14:17:00.120463] Read DB: 11.312503099441528
==> [2021-10-20-14:17:00.259022] Query DB: 0.13856101036071777
```

The 11-second read time is difficult to avoid, but this will only be incurred when the user (a) refers to a hash that is not installed in the DB or (b) mistypes a hash ((b) is an instance of (a) but IMO it's worth noting that "incorrect" hashes will incur the full lookup cost).
