### PR TITLE
ASP-based solver: a package eligible to provide a virtual must provide it

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -164,7 +164,7 @@ virtual_node(Virtual)
 % If there's a virtual node, we must select one and only one provider.
 % The provider must be selected among the possible providers.
 1 { provider(Package, Virtual) : possible_provider(Package, Virtual) } 1
- :- virtual_node(Virtual).
+  :- virtual_node(Virtual).
 
 % virtual roots imply virtual nodes, and that one provider is a root
 virtual_node(Virtual) :- virtual_root(Virtual).
@@ -178,28 +178,17 @@ root(Package) :- virtual_root(Virtual), provider(Package, Virtual).
 % for environments that are concretized together (e.g. where we
 % asks to install "mpich" and "hdf5+mpi" and we want "mpich" to
 % be the mpi provider)
-provider(Package, Virtual) :- root(Package), provides_virtual(Package, Virtual).
+provider(Package, Virtual) :- node(Package), virtual_condition_holds(Package, Virtual).
 
 % The provider provides the virtual if some provider condition holds.
-provides_virtual(Provider, Virtual) :-
+virtual_condition_holds(Provider, Virtual) :-
    provider_condition(ID, Provider, Virtual),
    condition_holds(ID),
    virtual(Virtual).
 
 % A package cannot be the actual provider for a virtual if it does not
 % fulfill the conditions to provide that virtual
-:- provider(Package, Virtual), not provides_virtual(Package, Virtual).
-
-% If a package meets the condition to be a provider, it needs to be a provider
-:- not provider(Package, Virtual),
-   provides_virtual(Package, Virtual),
-   virtual_node(Virtual).
-
-% If a package is selected as a provider, it is provider of all
-% the virtuals it provides
-:- provides_virtual(Package, V1), provides_virtual(Package, V2), V1 != V2,
-   provider(Package, V1), not provider(Package, V2),
-   virtual_node(V1), virtual_node(V2).
+:- provider(Package, Virtual), not virtual_condition_holds(Package, Virtual).
 
 #defined possible_provider/2.
 
@@ -292,7 +281,7 @@ attr("node_compiler_version_satisfies", Package, Compiler, Version)
 #defined virtual/1.
 #defined virtual_node/1.
 #defined virtual_root/1.
-#defined provides_virtual/2.
+#defined virtual_condition_holds/2.
 #defined external/1.
 #defined external_spec/2.
 #defined external_version_declared/4.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -190,6 +190,11 @@ provides_virtual(Provider, Virtual) :-
 % fulfill the conditions to provide that virtual
 :- provider(Package, Virtual), not provides_virtual(Package, Virtual).
 
+% If a package meets the condition to be a provider, it needs to be a provider
+:- not provider(Package, Virtual),
+   provides_virtual(Package, Virtual),
+   virtual_node(Virtual).
+
 % If a package is selected as a provider, it is provider of all
 % the virtuals it provides
 :- provides_virtual(Package, V1), provides_virtual(Package, V2), V1 != V2,

--- a/lib/spack/spack/test/cmd/dependencies.py
+++ b/lib/spack/spack/test/cmd/dependencies.py
@@ -14,7 +14,9 @@ from spack.main import SpackCommand
 
 dependencies = SpackCommand('dependencies')
 
-mpis = ['mpich', 'mpich2', 'multi-provider-mpi', 'zmpi']
+mpis = [
+    'low-priority-provider', 'mpich', 'mpich2', 'multi-provider-mpi', 'zmpi'
+]
 mpi_deps = ['fake']
 
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1274,3 +1274,17 @@ class TestConcretize(object):
         # package doesn't end up using a later implementation
         s = spack.spec.Spec('hpcviewer@2019.02').concretized()
         assert s['java'].satisfies('virtual-with-versions@1.8.0')
+
+    @pytest.mark.regression('26866')
+    def test_non_default_provider_of_multiple_virtuals(self):
+        s = spack.spec.Spec(
+            'many-virtual-consumer ^low-priority-provider'
+        ).concretized()
+        assert s['mpi'].name == 'low-priority-provider'
+        assert s['lapack'].name == 'low-priority-provider'
+
+        for virtual_pkg in ('mpi', 'lapack'):
+            for pkg in spack.repo.path.providers_for(virtual_pkg):
+                if pkg.name == 'low-priority-provider':
+                    continue
+                assert pkg not in s

--- a/lib/spack/spack/test/data/config/packages.yaml
+++ b/lib/spack/spack/test/data/config/packages.yaml
@@ -1,7 +1,8 @@
 packages:
   all:
     providers:
-      mpi: [openmpi, mpich]
+      mpi: [openmpi, mpich, zmpi]
+      lapack: [openblas-with-lapack]
       blas: [openblas]
   externaltool:
     buildable: False

--- a/lib/spack/spack/test/package_class.py
+++ b/lib/spack/spack/test/package_class.py
@@ -30,6 +30,7 @@ def mpi_names(mock_repo_path):
 def mpileaks_possible_deps(mock_packages, mpi_names):
     possible = {
         'callpath': set(['dyninst'] + mpi_names),
+        'low-priority-provider': set(),
         'dyninst': set(['libdwarf', 'libelf']),
         'fake': set(),
         'libdwarf': set(['libelf']),

--- a/var/spack/repos/builtin.mock/packages/low-priority-provider/package.py
+++ b/var/spack/repos/builtin.mock/packages/low-priority-provider/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class LowPriorityProvider(Package):
+    """Provides multiple virtuals but is low in the priority of clingo"""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/a-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    provides('lapack')
+    provides('mpi')

--- a/var/spack/repos/builtin.mock/packages/many-virtual-consumer/package.py
+++ b/var/spack/repos/builtin.mock/packages/many-virtual-consumer/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class ManyVirtualConsumer(Package):
+    """PAckage that depends on many virtual packages"""
+    url = "http://www.example.com/"
+    url = "http://www.example.com/2.0.tar.gz"
+
+    version('1.0', 'abcdef1234567890abcdef1234567890')
+
+    depends_on('mpi')
+    depends_on('lapack')
+
+    # This directive is an example of imposing a constraint on a
+    # dependency is that dependency is in the DAG. This pattern
+    # is mainly used with virtual providers.
+    depends_on('low-priority-provider@1.0', when='^low-priority-provider')


### PR DESCRIPTION
fixes #26866

This semantics fits with the way Spack currently treats providers of virtual dependencies. It needs to be revisited when #15569 is reworked with a new syntax.

Modifications:
- [x] Ensure that if a package _can_ be a provider, then _it is_ a provider
- [x] Add a unit test to prevent regression