### PR TITLE
silo: new release 4.11

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -14,6 +14,10 @@ class Silo(AutotoolsPackage):
     homepage = "https://wci.llnl.gov/simulation/computer-codes/silo"
     url      = "https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2.tgz"
 
+    version('4.11', sha256='ab936c1f4fc158d9fdc4415965f7d9def7f4abeca596fe5a25bd8485654898ac',
+            url="https://github.com/LLNL/Silo/releases/download/v4.11/silo-4.11.tar.gz")
+    version('4.11-bsd', sha256='6d0a85a079d48fcdcc0084ecb5fc4cfdcc64852edee780c60cb244d16f4bc4ec',
+            url="https://github.com/LLNL/Silo/releases/download/v4.11/silo-4.11-bsd.tar.gz")
     version('4.10.2', sha256='3af87e5f0608a69849c00eb7c73b11f8422fa36903dd14610584506e7f68e638', preferred=True)
     version('4.10.2-bsd', sha256='4b901dfc1eb4656e83419a6fde15a2f6c6a31df84edfad7f1dc296e01b20140e',
             url="https://wci.llnl.gov/sites/wci/files/2021-01/silo-4.10.2-bsd.tgz")
@@ -50,7 +54,12 @@ class Silo(AutotoolsPackage):
     depends_on('zlib')
 
     patch('remove-mpiposix.patch', when='@4.8:4.10.2')
-    patch('H5FD_class_t-terminate.patch', when='^hdf5@1.10.0:')
+    patch('H5FD_class_t-terminate.patch', when='@:4.10.2 ^hdf5@1.10.0:')
+
+    conflicts('+hzip', when="@4.11-bsd")
+    conflicts('+fpzip', when="@4.11-bsd")
+    conflicts('+hzip', when="@4.10.2-bsd")
+    conflicts('+fpzip', when="@4.10.2-bsd")
 
     def flag_handler(self, name, flags):
         spec = self.spec
@@ -67,6 +76,9 @@ class Silo(AutotoolsPackage):
                 flags.append(self.compiler.cxx_pic_flag)
             elif name == 'fcflags':
                 flags.append(self.compiler.fc_pic_flag)
+        if name == 'cflags':
+            if spec.compiler.name in ['clang', 'apple-clang']:
+                flags.append('-Wno-implicit-function-declaration')
         return (flags, None, None)
 
     @when('%clang@9:')
@@ -110,7 +122,10 @@ class Silo(AutotoolsPackage):
     def force_autoreconf(self):
         # Update autoconf's tests whether libtool supports shared libraries.
         # (Otherwise, shared libraries are always disabled on Darwin.)
-        return self.spec.satisfies('+shared')
+        if self.spec.satisfies('@4.11-bsd') or self.spec.satisfies('@4.10.2-bsd'):
+            return False
+        else:
+            return self.spec.satisfies('+shared')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
This is another PR that may replace #26748 that got into a mess despite cheerful help from @sethrj.
There bsd versions do not autoreconf, 4.11 compiles on apple. 
Silo author is @markcmiller86 