### PR TITLE
curl: fix mbedtls dependencies and config

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -88,7 +88,7 @@ class Curl(AutotoolsPackage):
 
     depends_on('gnutls', when='tls=gnutls')
     depends_on('mbedtls@3:', when='@7.79: tls=mbedtls')
-    depends_on('mbedtls@:2.999', when='@:7.78 tls=mbedtls')
+    depends_on('mbedtls@:2', when='@:7.78 tls=mbedtls')
     depends_on('nss', when='tls=nss')
     depends_on('openssl', when='tls=openssl')
     depends_on('libidn2', when='+libidn2')

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -112,10 +112,16 @@ class Curl(AutotoolsPackage):
             '--without-libgsasl',
             '--without-libpsl',
             '--without-zstd',
-            '--without-ca-bundle',
-            '--without-ca-path',
-            '--with-ca-fallback',
         ]
+
+        # Make gnutls / openssl decide what certs are trusted.
+        # TODO: certs for other tls options.
+        if spec.satisfies('tls=gnutls') or spec.satisfies('tls=openssl'):
+            args.extend([
+                '--without-ca-bundle',
+                '--without-ca-path',
+                '--with-ca-fallback',
+            ])
 
         # https://daniel.haxx.se/blog/2021/06/07/bye-bye-metalink-in-curl/
         # We always disable it explicitly, but the flag is gone in newer
@@ -135,9 +141,6 @@ class Curl(AutotoolsPackage):
         args += self.with_or_without('libssh2')
         args += self.with_or_without('libssh')
         args += self.enable_or_disable('ldap')
-
-        if '--without-openssl' in args or '--without-ssl' in args:
-            args.remove('--with-ca-fallback')
 
         return args
 

--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -87,7 +87,8 @@ class Curl(AutotoolsPackage):
     conflicts('tls=mbedtls', when='@:7.45')
 
     depends_on('gnutls', when='tls=gnutls')
-    depends_on('mbedtls', when='tls=mbedtls')
+    depends_on('mbedtls@3:', when='@7.79: tls=mbedtls')
+    depends_on('mbedtls@:2.999', when='@:7.78 tls=mbedtls')
     depends_on('nss', when='tls=nss')
     depends_on('openssl', when='tls=openssl')
     depends_on('libidn2', when='+libidn2')
@@ -134,6 +135,10 @@ class Curl(AutotoolsPackage):
         args += self.with_or_without('libssh2')
         args += self.with_or_without('libssh')
         args += self.enable_or_disable('ldap')
+
+        if '--without-openssl' in args or '--without-ssl' in args:
+            args.remove('--with-ca-fallback')
+
         return args
 
     def with_or_without_gnutls(self, activated):


### PR DESCRIPTION
This pull request fixes two issues I observed while trying to install `curl`. (See below). I have introduced a version dependency on `mbedtls` because different versions of curl need different version of that. I am not sure if there is a nicer way to do that. If that is the case, please let me know.


---------
In essence curl doesn't build for me if configured with `tls=mbedtls`. In the dependency tree I am currently trying to build it gets concretized to the following:
```console
[...]
 -   di6n2om          ^curl@7.72.0%gcc@9.3.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2~nghttp2 tls=mbedtls arch=linux-ubuntu20.04-x86_64
[+]  woxox4m              ^mbedtls@3.0.0%gcc@9.3.0~pic build_type=Release libs=static arch=linux-ubuntu20.04-x86_64
[...]
```

Trying to install all of this leads to a configuration error:
```console
==> curl: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 1:
    '/tmp/tmadlener/spack-stage/spack-stage-curl-7.72.0-di6n2ompu35yvf77y57zyc3g5alfsm27/spack-src/configure' '--prefix=/home/tmadlener/work/spackages/curl/7.72.0/x86_64-ubuntu20.04-gcc9.3.0-opt/di6n2ompu35yvf77y57zyc3g5alfsm27' '--with-zlib=/home/tmadlener/work/spackages/zlib/1.2.11/x86_64-ubuntu20.04-gcc9.3.0-opt/ufqpqnpj5gjkfx5sd2o3twwveuowcz2b' '--without-brotli' '--without-libgsasl' '--without-libpsl' '--without-zstd' '--without-ca-bundle' '--without-ca-path' '--with-ca-fallback' '--without-libmetalink' '--without-gssapi' '--without-gnutls' '--with-mbedtls=/home/tmadlener/work/spackages/mbedtls/3.0.0/x86_64-ubuntu20.04-gcc9.3.0-opt/woxox4mizrsazzraztvh7q4hqyrnw2tf' '--without-nss' '--without-ssl' '--without-secure-transport' '--without-libidn2' '--without-librtmp' '--without-nghttp2' '--without-libssh2' '--without-libssh' '--disable-ldap'

1 error found in build log:
     194    checking for mbedtls_ssl_init in -lmbedtls... yes
     195    configure: detected mbedTLS
     196    configure: Added /home/tmadlener/work/spackages/mbedtls/3.0.0/x86_64-ubuntu20.04-gcc9.3.0-opt/woxox4mizrsazzraztvh7q4hqyrnw2tf/lib to CURL_LIBRARY_PATH
     197    configure: built with one SSL backend
     198    checking default CA cert bundle/path... no
     199    checking whether to use builtin CA store of SSL library... yes
  >> 200    configure: error: --with-ca-fallback only works with OpenSSL or GnuTLS
```

Fixing the config flags, and trying again then leads to a build error, complaining about a missing header:
```console
            .c  -fPIC -DPIC -o .libs/libcurl_la-curl_addrinfo.o
     768    libtool: compile:  /home/tmadlener/work/spack/lib/spack/env/gcc/gcc -DHAVE_CONFIG_H -I../include -I../lib -I../lib -DBUILDING_LIBCURL -DCURL_HIDDEN_SYMBOLS -isystem /home/tmadlener/work/spackages/zl
            ib/1.2.11/x86_64-ubuntu20.04-gcc9.3.0-opt/ufqpqnpj5gjkfx5sd2o3twwveuowcz2b/include -isystem /home/tmadlener/work/spackages/mbedtls/3.0.0/x86_64-ubuntu20.04-gcc9.3.0-opt/woxox4mizrsazzraztvh7q4hqyrnw
            2tf/include -fvisibility=hidden -Werror-implicit-function-declaration -O2 -Wno-system-headers -pthread -MT libcurl_la-conncache.lo -MD -MP -MF .deps/libcurl_la-conncache.Tpo -c conncache.c  -fPIC -D
            PIC -o .libs/libcurl_la-conncache.o
     769    In file included from asyn-thread.c:23:
  >> 770    curl_setup.h:650:12: fatal error: mbedtls/md4.h: No such file or directory
     771      650 | #  include <mbedtls/md4.h>
     772          |            ^~~~~~~~~~~~~~~
     773    compilation terminated.
```

That is because compatibility with `mbedtls@3:` was only introduced in `curl@7.79` (curl/curl#7428)