### PR TITLE
vtkm: add v1.7.0-rc1

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -28,6 +28,7 @@ class VtkM(CMakePackage, CudaPackage):
 
     version('master', branch='master')
     version('release', branch='release')
+    version('1.7.0-rc1', sha256="e9cedc21f0ad326317acc7689ee0c7719a6cb8af41e87fd232aee5ab8d0620e4")
     version('1.6.0', sha256="14e62d306dd33f82eb9ddb1d5cee987b7a0b91bf08a7a02ca3bce3968c95fd76", preferred=True)
     version('1.5.5', commit="d2d1c854adc8c0518802f153b48afd17646b6252")
     version('1.5.4', commit="bbba2a1967b271cc393abd043716d957bca97972")


### PR DESCRIPTION
Finally! After a quite summer, VTK-m v1.7.0-rc1 is finally out :tada: :tada: :tada:

This bring exiting new features, and bugfixes, find the tentative release notes at https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/1.7/release-notes.md

Let me know if we need to change anything else in the package

ViB