### PR TITLE
py-nipype: add 1.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-nipype/package.py
+++ b/var/spack/repos/builtin/packages/py-nipype/package.py
@@ -9,9 +9,10 @@ from spack import *
 class PyNipype(PythonPackage):
     """Neuroimaging in Python: Pipelines and Interfaces."""
 
-    homepage = "https://nipy.org/nipype"
+    homepage = "https://github.com/nipy/nipype"
     pypi     = "nipype/nipype-1.6.0.tar.gz"
 
+    version('1.7.0', sha256='e689fe2e5049598c9cd3708e8df1cac732fa1a88696f283e3bc0a70fecb8ab51')
     version('1.6.1', sha256='8428cfc633d8e3b8c5650e241e9eedcf637b7969bcd40f3423334d4c6b0992b5')
     version('1.6.0', sha256='bc56ce63f74c9a9a23c6edeaf77631377e8ad2bea928c898cc89527a47f101cf')
     version('1.4.2', sha256='069dcbb0217f13af6ee5a7f1e58424b9061290a3e10d7027d73bf44e26f820db')


### PR DESCRIPTION
dependencies can be found in [info.py](https://github.com/nipy/nipype/blob/1.7.0/nipype/info.py)