### PR TITLE
PyTorch/torchvision: add latest versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -23,6 +23,7 @@ class PyTorch(PythonPackage, CudaPackage):
     import_modules = ['torch', 'torch.autograd', 'torch.nn', 'torch.utils']
 
     version('master', branch='master', submodules=True)
+    version('1.10.0', tag='v1.10.0', submodules=True)
     version('1.9.1', tag='v1.9.1', submodules=True)
     version('1.9.0', tag='v1.9.0', submodules=True)
     version('1.8.2', tag='v1.8.2', submodules=True)
@@ -118,8 +119,7 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-typing', when='@0.4: ^python@:3.4', type=('build', 'run'))
     depends_on('py-typing-extensions', when='@1.7:', type=('build', 'run'))
-    depends_on('py-pybind11@master', when='@master', type=('build', 'link', 'run'))
-    depends_on('py-pybind11@2.6.2', when='@1.8.0:1.9', type=('build', 'link', 'run'))
+    depends_on('py-pybind11@2.6.2', when='@1.8.0:', type=('build', 'link', 'run'))
     depends_on('py-pybind11@2.3.0', when='@1.1.0:1.7', type=('build', 'link', 'run'))
     depends_on('py-pybind11@2.2.4', when='@1.0.0:1.0', type=('build', 'link', 'run'))
     depends_on('py-pybind11@2.2.2', when='@0.4.0:0.4', type=('build', 'link', 'run'))
@@ -131,25 +131,19 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('lapack')
     depends_on('eigen', when='@0.4:')
     # https://github.com/pytorch/pytorch/issues/60329
-    # depends_on('cpuinfo@master', when='@master')
-    # depends_on('cpuinfo@2020-12-17', when='@1.8.0:1.9')
+    # depends_on('cpuinfo@2020-12-17', when='@1.8.0:')
     # depends_on('cpuinfo@2020-06-11', when='@1.6.0:1.7')
     # https://github.com/shibatch/sleef/issues/427
-    # depends_on('sleef@master', when='@master')
-    # depends_on('sleef@3.5.1_2020-12-22', when='@1.8.0:1.9')
+    # depends_on('sleef@3.5.1_2020-12-22', when='@1.8.0:')
     # https://github.com/pytorch/pytorch/issues/60334
     # depends_on('sleef@3.4.0_2019-07-30', when='@1.6.0:1.7')
     # https://github.com/Maratyszcza/FP16/issues/18
-    # depends_on('fp16@master', when='@master')
-    # depends_on('fp16@2020-05-14', when='@1.6.0:1.9')
-    depends_on('pthreadpool@master', when='@master')
-    depends_on('pthreadpool@2021-04-13', when='@1.9.0:1.9')
+    # depends_on('fp16@2020-05-14', when='@1.6.0:')
+    depends_on('pthreadpool@2021-04-13', when='@1.9.0:')
     depends_on('pthreadpool@2020-10-05', when='@1.8.0:1.8')
     depends_on('pthreadpool@2020-06-15', when='@1.6.0:1.7')
-    depends_on('psimd@master', when='@master')
-    depends_on('psimd@2020-05-17', when='@1.6.0:1.9')
-    depends_on('fxdiv@master', when='@master')
-    depends_on('fxdiv@2020-04-17', when='@1.6.0:1.9')
+    depends_on('psimd@2020-05-17', when='@1.6.0:')
+    depends_on('fxdiv@2020-04-17', when='@1.6.0:')
     depends_on('benchmark', when='@1.6:+test')
 
     # Optional dependencies
@@ -166,18 +160,15 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('llvm-openmp', when='%apple-clang +openmp')
     depends_on('valgrind', when='+valgrind')
     # https://github.com/pytorch/pytorch/issues/60332
-    # depends_on('xnnpack@master', when='@master+xnnpack')
-    # depends_on('xnnpack@2021-02-22', when='@1.8.0:1.9+xnnpack')
+    # depends_on('xnnpack@2021-02-22', when='@1.8.0:+xnnpack')
     # depends_on('xnnpack@2020-03-23', when='@1.6.0:1.7+xnnpack')
     depends_on('mpi', when='+mpi')
     # https://github.com/pytorch/pytorch/issues/60270
-    # depends_on('gloo@master', when='@master+gloo')
-    # depends_on('gloo@2021-05-04', when='@1.9.0:1.9+gloo')
+    # depends_on('gloo@2021-05-04', when='@1.9.0:+gloo')
     # depends_on('gloo@2020-09-18', when='@1.7.0:1.8+gloo')
     # depends_on('gloo@2020-03-17', when='@1.6.0:1.6+gloo')
     # https://github.com/pytorch/pytorch/issues/60331
-    # depends_on('onnx@master', when='@master+onnx_ml')
-    # depends_on('onnx@1.8.0_2020-11-03', when='@1.8.0:1.9+onnx_ml')
+    # depends_on('onnx@1.8.0_2020-11-03', when='@1.8.0:+onnx_ml')
     # depends_on('onnx@1.7.0_2020-05-31', when='@1.6.0:1.7+onnx_ml')
     depends_on('mkl', when='+mkldnn')
 

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -16,6 +16,8 @@ class PyTorchvision(PythonPackage):
 
     version('main', branch='main')
     version('master', branch='main', deprecated=True)
+    version('0.11.1', sha256='32a06ccf755e4d75006ce03701f207652747a63dbfdf65f0f20a1b6f93a2e834')
+    version('0.11.0', sha256='8e85acf8f5d39f27e92e610ccb506dac0bf4412bb366a318d2aa5f384cbd4d2c')
     version('0.10.1', sha256='4d595cf0214c8adc817f8e3cd0043a027b52b481e05d67b04f4947fcb43d4277')
     version('0.10.0', sha256='82bb2c2b03d8a65f4ea74bb0ee5566b0876a1992aceefb1e11475c7b5d2e857b')
     version('0.9.1', sha256='79964773729880e0eee0e6af13f336041121d4cc8491a3e2c0e5f184cac8a718')
@@ -49,6 +51,7 @@ class PyTorchvision(PythonPackage):
 
     # https://github.com/pytorch/vision#installation
     depends_on('py-torch@master', when='@master', type=('build', 'link', 'run'))
+    depends_on('py-torch@1.10.0', when='@0.11.0:0.11.1', type=('build', 'link', 'run'))
     depends_on('py-torch@1.9.1', when='@0.10.1', type=('build', 'link', 'run'))
     depends_on('py-torch@1.9.0', when='@0.10.0', type=('build', 'link', 'run'))
     depends_on('py-torch@1.8.1', when='@0.9.1', type=('build', 'link', 'run'))
@@ -69,7 +72,8 @@ class PyTorchvision(PythonPackage):
     # https://github.com/pytorch/vision/issues/1712
     depends_on('pil@4.1.1:6', when='@:0.4 backend=pil', type=('build', 'run'))
     depends_on('pil@4.1.1:',  when='@0.5: backend=pil', type=('build', 'run'))
-    depends_on('pil@5.3.0:', when='@0.10: backend=pil', type=('build', 'run'))
+    # https://github.com/pytorch/vision/issues/4146
+    depends_on('pil@5.3:8.2,8.3.1:', when='@0.10: backend=pil', type=('build', 'run'))
     depends_on('py-accimage', when='backend=accimage', type=('build', 'run'))
     depends_on('libpng@1.6.0:', when='backend=png')
     depends_on('jpeg', when='backend=jpeg')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.11 and Apple Clang 12.0.0.

https://github.com/pytorch/pytorch/releases/tag/v1.10.0
https://github.com/pytorch/vision/releases/tag/v0.11.0
https://github.com/pytorch/vision/releases/tag/v0.11.1