### PR TITLE
cuda: add 11.4.1, 11.4.2, 11.5.0.

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -105,8 +105,8 @@ class CudaPackage(PackageBase):
     # each release of a new cuda minor version.
     conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
     conflicts('%gcc@11:', when='+cuda ^cuda@:11.4.0')
-    conflicts('%clang@12:', when='+cuda ^cuda@:11.4.2')
     conflicts('%gcc@12:', when='+cuda ^cuda@:11.5.0')
+    conflicts('%clang@12:', when='+cuda ^cuda@:11.4.0')
     conflicts('%clang@13:', when='+cuda ^cuda@:11.5.0')
 
     # https://gist.github.com/ax3l/9489132#gistcomment-3860114

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -104,7 +104,10 @@ class CudaPackage(PackageBase):
     # This implies that the last one in the list has to be updated at
     # each release of a new cuda minor version.
     conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
-    conflicts('%gcc@11:', when='+cuda ^cuda@:11.4')
+    conflicts('%gcc@11:', when='+cuda ^cuda@:11.4.0')
+    conflicts('%clang@12:', when='+cuda ^cuda@:11.4.2')
+    conflicts('%gcc@12:', when='+cuda ^cuda@:11.5.0')
+    conflicts('%clang@13:', when='+cuda ^cuda@:11.5.0')
 
     # https://gist.github.com/ax3l/9489132#gistcomment-3860114
     conflicts('%gcc@10', when='+cuda ^cuda@:11.4.0')

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -25,6 +25,18 @@ from spack import *
 #    format returned by platform.system() and 'arch' by platform.machine()
 
 _versions = {
+    '11.5.0': {
+        'Linux-aarch64': ('6ea9d520cc956cc751a5ac54f4acc39109627f4e614dd0b1a82cc86f2aa7d8c4', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_sbsa.run'),
+        'Linux-x86_64': ('ae0a1693d9497cf3d81e6948943e3794636900db71c98d58eefdacaf7f1a1e4c', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run'),
+        'Linux-ppc64le': ('95baefdc5adf165189407b119861ffb2e9800fd94d7fc81d10fb81ed36dc12db', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_ppc64le.run')},
+    '11.4.2': {
+        'Linux-aarch64': ('f2c4a52e06329606c8dfb7c5ea3f4cb4c0b28f9d3fdffeeb734fcc98daf580d8', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux_sbsa.run'),
+        'Linux-x86_64': ('bbd87ca0e913f837454a796367473513cddef555082e4d86ed9a38659cc81f0a', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run'),
+        'Linux-ppc64le': ('a917c2e53dc13fdda7def71fd40920bf3809d5a2caa3e9acfe377fb9fb22f12d', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux_ppc64le.run')},
+    '11.4.1': {
+        'Linux-aarch64': ('8efa725a41dfd3c0c0f453c2dd535d149154102bf2b791718859417b4f84f922', 'https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux_sbsa.run'),
+        'Linux-x86_64': ('dd6c339a719989d2518f5d54eeac1ed707d0673f8664ba0c4d4b2af7c3ba0005', 'https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux.run'),
+        'Linux-ppc64le': ('dd92ca04f76ad938da3480e2901c0e52dbff6028ada63c09071ed9e3055dc361', 'https://developer.download.nvidia.com/compute/cuda/11.4.1/local_installers/cuda_11.4.1_470.57.02_linux_ppc64le.run')},
     '11.4.0': {
         'Linux-aarch64': ('f0c8e80d98a601ddca031b6764459984366008c7d3847e7c7f99b36bd4438e3c', 'https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux_sbsa.run'),
         'Linux-x86_64': ('d219db30f7415a115a4ea22bdbb5984b0a18f7f891cad6074c5da45d223aaa4b', 'https://developer.download.nvidia.com/compute/cuda/11.4.0/local_installers/cuda_11.4.0_470.42.01_linux.run'),
@@ -124,9 +136,10 @@ class Cuda(Package):
     variant('dev', default=False, description='Enable development dependencies, i.e to use cuda-gdb')
 
     depends_on('libxml2', when='@10.1.243:')
-    # cuda-gdb needs libncurses.so.5
-    # see https://docs.nvidia.com/cuda/cuda-gdb/index.html#common-issues-oss
-    depends_on('ncurses abi=5', type='run', when='+dev')
+    # cuda-gdb needed libncurses.so.5 before 11.4.0
+    # see https://docs.nvidia.com/cuda/archive/11.3.1/cuda-gdb/index.html#common-issues-oss
+    # see https://docs.nvidia.com/cuda/archive/11.4.0/cuda-gdb/index.html#release-notes
+    depends_on('ncurses abi=5', type='run', when='@:11.3.99+dev')
 
     provides('opencl@:1.2', when='@7:')
     provides('opencl@:1.1', when='@:6')

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -48,6 +48,7 @@ class SuperluDist(CMakePackage, CudaPackage):
     depends_on('cmake@3.18.1:', type='build', when='@7.1.0:')
 
     conflicts('+cuda', when='@:6.3')
+    conflicts('cuda@11.5.0:', when='@7.1.0:')
 
     patch('xl-611.patch', when='@:6.1.1 %xl')
     patch('xl-611.patch', when='@:6.1.1 %xl_r')

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -48,7 +48,7 @@ class SuperluDist(CMakePackage, CudaPackage):
     depends_on('cmake@3.18.1:', type='build', when='@7.1.0:')
 
     conflicts('+cuda', when='@:6.3')
-    conflicts('cuda@11.5.0:', when='@7.1.0:')
+    conflicts('^cuda@11.5.0:', when='@7.1.0:')
 
     patch('xl-611.patch', when='@:6.1.1 %xl')
     patch('xl-611.patch', when='@:6.1.1 %xl_r')


### PR DESCRIPTION
Note that the `ncurses` dependency from `cuda-gdb` was dropped in 11.4.0.

I added all URLs/hashes for consistency, and have no reason to think there is a problem, but I have only actually tested 11.4.2 / x86_64.