### PR TITLE
gromacs-swaxs: new package

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs-swaxs/gmxDetectCpu-cmake-3.14.patch
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/gmxDetectCpu-cmake-3.14.patch
@@ -1,0 +1,11 @@
+--- a/cmake/gmxDetectCpu.cmake
++++ b/cmake/gmxDetectCpu.cmake
+@@ -83,7 +83,7 @@ function(gmx_run_cpu_detection TYPE)
+                 set(GCC_INLINE_ASM_DEFINE "-DGMX_X86_GCC_INLINE_ASM=0")
+             endif()
+ 
+-            set(_compile_definitions "${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE}")
++            set(_compile_definitions ${GCC_INLINE_ASM_DEFINE} -I${PROJECT_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE})
+             set(LINK_LIBRARIES "${GMX_STDLIB_LIBRARIES}")
+             try_compile(CPU_DETECTION_COMPILED
+                 "${PROJECT_BINARY_DIR}"

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/gmxDetectSimd-cmake-3.14.patch
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/gmxDetectSimd-cmake-3.14.patch
@@ -1,0 +1,11 @@
+--- a/cmake/gmxDetectSimd.cmake
++++ b/cmake/gmxDetectSimd.cmake
+@@ -77,7 +77,7 @@ function(gmx_suggest_simd _suggested_simd)
+     else()
+         set(GMX_TARGET_X86_VALUE 0)
+     endif()
+-    set(_compile_definitions "${GCC_INLINE_ASM_DEFINE} -I${CMAKE_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE}")
++    set(_compile_definitions ${GCC_INLINE_ASM_DEFINE} -I${CMAKE_SOURCE_DIR}/src -DGMX_CPUINFO_STANDALONE ${GMX_STDLIB_CXX_FLAGS} -DGMX_TARGET_X86=${GMX_TARGET_X86_VALUE})
+ 
+     # Prepare a default suggestion
+     set(OUTPUT_SIMD "None")

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -45,12 +45,9 @@ class GromacsSwaxs(Gromacs):
         They are not valid, so we are removing them.
         """
 
-        gromacs_package = Gromacs
-
         for version_key in Gromacs.versions.keys():
             if version_key in self.versions:
                 del self.versions[version_key]
-
 
     def __init__(self, spec):
         super(GromacsSwaxs, self).__init__(spec)

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack.pkg.builtin.gromacs import Gromacs
 
 
@@ -31,25 +29,25 @@ class GromacsSwaxs(Gromacs):
     maintainers = ['w8jcik']
 
     version('2019.6-0.1', sha256='91da09eed80646d6a1c500be78891bef22623a19795a9bc89adf9f2ec4f85635',
-        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2019.swaxs-0.1/gromacs-swaxs-release-2019.swaxs-0.1.tar.bz2')
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2019.swaxs-0.1/gromacs-swaxs-release-2019.swaxs-0.1.tar.bz2')
 
     version('2018.8-0.2', sha256='f8bf0d363334a9117a2a8deb690dadaa826b73b57a761949c7846a13b84b5af5',
-        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2018.swaxs-0.2/gromacs-swaxs-release-2018.swaxs-0.2.tar.bz2')
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2018.swaxs-0.2/gromacs-swaxs-release-2018.swaxs-0.2.tar.bz2')
 
     version('2018.8-0.1', sha256='478f45286dfedb8f01c2d5bf0773a391c2de2baf85283ef683e911bc43e24675',
-        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2018.swaxs-0.1/gromacs-swaxs-release-2018.swaxs-0.1.tar.bz2')
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2018.swaxs-0.1/gromacs-swaxs-release-2018.swaxs-0.1.tar.bz2')
 
     version('2016.6-0.1', sha256='11e8ae6b3141f356bae72b595737a1f253b878d313169703ba33a69ded01a04e',
-        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2016.swaxs-0.1/gromacs-swaxs-release-2016.swaxs-0.1.tar.bz2')
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2016.swaxs-0.1/gromacs-swaxs-release-2016.swaxs-0.1.tar.bz2')
 
     version('5.1.5-0.3', sha256='a9e8382eec3cc0d943e1869f13945ea4a971a95a70eb314c1f26a17fa7d03792',
-        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-5-1.swaxs-0.3/gromacs-swaxs-release-5-1.swaxs-0.3.tar.bz2')
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-5-1.swaxs-0.3/gromacs-swaxs-release-5-1.swaxs-0.3.tar.bz2')
 
     version('5.0.7-0.5', sha256='7f7f69726472a641a5443f1993a6e1fb8cfa9c74aeaf46e8c5d1db37005ece79',
-        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-5-0.swaxs-0.5/gromacs-swaxs-release-5-0.swaxs-0.5.tar.bz2')
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-5-0.swaxs-0.5/gromacs-swaxs-release-5-0.swaxs-0.5.tar.bz2')
 
     version('4.6.7-0.8', sha256='1cfa34fe9ff543b665cd556f3395a9aa67f916110ba70255c97389eafe8315a2',
-        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-4-6.swaxs-0.8/gromacs-swaxs-release-4-6.swaxs-0.8.tar.bz2')
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-4-6.swaxs-0.8/gromacs-swaxs-release-4-6.swaxs-0.8.tar.bz2')
 
     conflicts('+plumed')
     conflicts('+opencl')

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -1,0 +1,55 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack.pkg.builtin.gromacs import Gromacs
+
+
+def is_swaxs_version(version):
+    return "url" in version and "swaxs" in version["url"]
+
+
+def filter_versions(versions):
+    return { key: version for key, version in versions.items() if is_swaxs_version(version) }
+
+
+class GromacsSwaxs(Gromacs):
+    """Modified Gromacs for small-angle scattering calculations (SAXS/WAXS/SANS)"""
+
+    homepage = 'https://biophys.uni-saarland.de/swaxs.html'
+    url = 'https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2019.swaxs-0.1/gromacs-swaxs-release-2019.swaxs-0.1.tar.bz2'
+    git = 'https://gitlab.com/cbjh/gromacs-swaxs.git'
+    maintainers = ['w8jcik']
+
+    version('2019.6-0.1', sha256='91da09eed80646d6a1c500be78891bef22623a19795a9bc89adf9f2ec4f85635',
+        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2019.swaxs-0.1/gromacs-swaxs-release-2019.swaxs-0.1.tar.bz2')
+
+    version('2018.8-0.2', sha256='f8bf0d363334a9117a2a8deb690dadaa826b73b57a761949c7846a13b84b5af5',
+        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2018.swaxs-0.2/gromacs-swaxs-release-2018.swaxs-0.2.tar.bz2')
+
+    version('2018.8-0.1', sha256='478f45286dfedb8f01c2d5bf0773a391c2de2baf85283ef683e911bc43e24675',
+        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2018.swaxs-0.1/gromacs-swaxs-release-2018.swaxs-0.1.tar.bz2')
+
+    version('2016.6-0.1', sha256='11e8ae6b3141f356bae72b595737a1f253b878d313169703ba33a69ded01a04e',
+        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2016.swaxs-0.1/gromacs-swaxs-release-2016.swaxs-0.1.tar.bz2')
+
+    version('5.1.5-0.3', sha256='a9e8382eec3cc0d943e1869f13945ea4a971a95a70eb314c1f26a17fa7d03792',
+        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-5-1.swaxs-0.3/gromacs-swaxs-release-5-1.swaxs-0.3.tar.bz2')
+
+    version('5.0.7-0.5', sha256='7f7f69726472a641a5443f1993a6e1fb8cfa9c74aeaf46e8c5d1db37005ece79',
+        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-5-0.swaxs-0.5/gromacs-swaxs-release-5-0.swaxs-0.5.tar.bz2')
+
+    version('4.6.7-0.8', sha256='1cfa34fe9ff543b665cd556f3395a9aa67f916110ba70255c97389eafe8315a2',
+        url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-4-6.swaxs-0.8/gromacs-swaxs-release-4-6.swaxs-0.8.tar.bz2')
+
+    conflicts('+plumed')
+    conflicts('+opencl')
+    conflicts('+sycl')
+
+    def __init__(self, spec):
+        super(Gromacs, self).__init__(spec)
+
+        self.versions = filter_versions(self.versions)

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -13,7 +13,13 @@ def is_swaxs_version(version):
 
 
 def filter_versions(versions):
-    return { key: version for key, version in versions.items() if is_swaxs_version(version) }
+    filtered = {}
+
+    for key, version in versions.items():
+        if is_swaxs_version(version):
+            filtered[key] = version
+
+    return filtered
 
 
 class GromacsSwaxs(Gromacs):

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -6,20 +6,6 @@
 from spack.pkg.builtin.gromacs import Gromacs
 
 
-def is_swaxs_version(version):
-    return "url" in version and "swaxs" in version["url"]
-
-
-def filter_versions(versions):
-    filtered = {}
-
-    for key, version in versions.items():
-        if is_swaxs_version(version):
-            filtered[key] = version
-
-    return filtered
-
-
 class GromacsSwaxs(Gromacs):
     """Modified Gromacs for small-angle scattering calculations (SAXS/WAXS/SANS)"""
 
@@ -53,7 +39,20 @@ class GromacsSwaxs(Gromacs):
     conflicts('+opencl')
     conflicts('+sycl')
 
-    def __init__(self, spec):
-        super(Gromacs, self).__init__(spec)
+    def remove_parent_versions(self):
+        """
+        By inheriting GROMACS package we also inherit versions.
+        They are not valid, so we are removing them.
+        """
 
-        self.versions = filter_versions(self.versions)
+        gromacs_package = Gromacs
+
+        for version_key in Gromacs.versions.keys():
+            if version_key in self.versions:
+                del self.versions[version_key]
+
+
+    def __init__(self, spec):
+        super(GromacsSwaxs, self).__init__(spec)
+
+        self.remove_parent_versions()


### PR DESCRIPTION
There are at least four forks of GROMACS backed up by publications

- GROMACS-FDA https://github.com/HITS-MBM/gromacs-fda
- GROMACS-RAMD https://github.com/HITS-MCM/gromacs-ramd
- GROMACS-SWAXS https://gitlab.com/cbjh/gromacs-swaxs
- GROMACS Chain Coordinate https://gitlab.com/cbjh/gromacs-chain-coordinate
  (added with https://github.com/spack/spack/pull/25426)

This Pull request adds a package for GROMACS-SWAXS

It is reusing GROMACS package by inheriting from it.

Two small complications are:
- patches of GROMACS package had to be copied over
- inherited versions/archive sources are not valid and this packages actively removes them from the list