### PR TITLE
glib: add 2.70.0

### DIFF
--- a/var/spack/repos/builtin/packages/glib/meson-gettext-2.70.patch
+++ b/var/spack/repos/builtin/packages/glib/meson-gettext-2.70.patch
@@ -1,0 +1,30 @@
+--- a/meson.build
++++ b/meson.build
+@@ -2047,9 +2047,10 @@ endif
+ # FIXME: glib-gettext.m4 has much more checks to detect broken/uncompatible
+ # implementations. This could be extended if issues are found in some platforms.
+ libintl_deps = []
+-if cc.has_function('ngettext', args : osx_ldflags)
++gettext_opt = get_option('gettext')
++if ['auto', 'libc'].contains(gettext_opt) and cc.has_function('ngettext', args : osx_ldflags)
+   have_bind_textdomain_codeset = cc.has_function('bind_textdomain_codeset')
+-else
++elif ['auto', 'external'].contains(gettext_opt)
+   # First just find the bare library.
+   libintl = cc.find_library('intl', required : false)
+   # The bare library probably won't link without help if it's static.
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -9,6 +9,12 @@ option('iconv',
+        value : 'auto',
+        description : 'iconv implementation to use (\'libc\' = \'Part of the C library\'; \'external\' = \'External libiconv\'; \'auto\' = \'Auto-detect which iconv is available\')')
+ 
++option('gettext',
++       type : 'combo',
++       choices : ['auto', 'libc', 'external'],
++       value : 'auto',
++       description : 'gettext implementation to use (\'libc\' = \'Part of the C library\'; \'external\' = \'External libintl\'; \'auto\' = \'Auto-detect which gettext is available\')')
++
+ option('charsetalias_dir',
+        type : 'string',
+        value : '',

--- a/var/spack/repos/builtin/packages/glib/package.py
+++ b/var/spack/repos/builtin/packages/glib/package.py
@@ -23,6 +23,7 @@ class Glib(Package):
 
     maintainers = ['michaelkuhn']
 
+    version('2.70.0', sha256='200d7df811c5ba634afbf109f14bb40ba7fde670e89389885da14e27c0840742')
     version('2.68.4', sha256='62fd061d08a75492617e625a73e2c05e259f831acbb8e1f8b9c81f23f7993a3b')
     version('2.68.3', sha256='e7e1a3c20c026109c45c9ec4a31d8dcebc22e86c69486993e565817d64be3138')
     version('2.68.2', sha256='ecc7798a9cc034eabdfd7f246e6dd461cdbf1175fcc2e9867cc7da7b7309e0fb')
@@ -85,7 +86,8 @@ class Glib(Package):
     # glib prefers the libc version of gettext, which breaks the build if the
     # external version is also found.
     patch('meson-gettext.patch', when='@2.58:2.64')
-    patch('meson-gettext-2.66.patch', when='@2.66:')
+    patch('meson-gettext-2.66.patch', when='@2.66:2.68')
+    patch('meson-gettext-2.70.patch', when='@2.70:')
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""


### PR DESCRIPTION
The GNOME GitLab is open for registrations again, so I will finally forward the patch upstream as soon as possible.