### PR TITLE
fix bug when there is version id in the path of compiler in `wrf` package

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -197,8 +197,8 @@ class Wrf(Package):
         if "Please select from among the following" in outputbuf:
             options = collect_platform_options(outputbuf)
             comp_pair = "%s/%s" % (
-                basename(self.compiler.fc),
-                basename(self.compiler.cc),
+                basename(self.compiler.fc).split("-")[0],
+                basename(self.compiler.cc).split("-")[0],
             )
             compiler_matches = dict(
                 (x, y) for x, y in options.items() if comp_pair in x.lower()


### PR DESCRIPTION
When there is version id in the path of  compiler ( for example, `/usr/bin/gcc-8` instead of `/usr/bin/gcc`) , the `wrf` package cannot correctly recognize the compiler and raise `InstallError` when trying to answer configure question. 

This PR fixed it.