### PR TITLE
geant4: depends_on vecgeom@1.1.8:1.1 range

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -82,7 +82,7 @@ class Geant4(CMakePackage):
         depends_on('xerces-c netaccessor=curl cxxstd=' + std, when='cxxstd=' + std)
 
         # Vecgeom specific versions for each Geant4 version
-        depends_on('vecgeom@1.1.8: cxxstd=' + std,
+        depends_on('vecgeom@1.1.8:1.1 cxxstd=' + std,
                    when='@10.7.0: +vecgeom cxxstd=' + std)
         depends_on('vecgeom@1.1.5 cxxstd=' + std,
                    when='@10.6.0:10.6 +vecgeom cxxstd=' + std)

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -82,7 +82,7 @@ class Geant4(CMakePackage):
         depends_on('xerces-c netaccessor=curl cxxstd=' + std, when='cxxstd=' + std)
 
         # Vecgeom specific versions for each Geant4 version
-        depends_on('vecgeom@1.1.8 cxxstd=' + std,
+        depends_on('vecgeom@1.1.8: cxxstd=' + std,
                    when='@10.7.0: +vecgeom cxxstd=' + std)
         depends_on('vecgeom@1.1.5 cxxstd=' + std,
                    when='@10.6.0:10.6 +vecgeom cxxstd=' + std)

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -20,6 +20,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     maintainers = ['drbenmorgan', 'sethrj']
 
     version('master', branch='master')
+    version('1.1.17', sha256='2e95429b795311a6986320d785bedcd9dace9f8e7b7f6bd778d23a4ff23e0424')
     version('1.1.16', sha256='2fa636993156d9d06750586e8a1ac1701ae2be62dea07964e2369698ae521d02')
     version('1.1.15', sha256='0ee9897eb12d8d560dc0c9e56e8fdb78d0111f651a984df24e983da035bd1c70')
     version('1.1.13', sha256='6bb364cc74bdab2e64e2fe132debd7f1e192da0a103f5149df7ab25b7c19a205')


### PR DESCRIPTION
While previous geant4 versions were unclear on the matter, the [geant4.10.7 release notes](https://geant4-data.web.cern.ch/ReleaseNotes/ReleaseNotes4.10.7.html) indicate that vecgeom@1.1.8 is a minimum required version, not an exact required version ("Set VecGeom-1.1.8 as minimum required version for optional build with VecGeom."). This will allow some more freedom on the concretizer solutions while allowing geant4 to take advantage of bugfixes and improvements in vecgeom.

The allowed range is still limited to the 1.1 versions only so as to not introduce any unexpected future breaking changes in the last version of the geant4.10 sequence when a vecgeom@1.2 or vecgeom@2 is ever released.

This allows geant4 (the only dependent package of vecgeom) to use the most recent vecgeom@1.1.17, which is also added as a new version here, for expediency.

Maintainers: @drbenmorgan @sethrj 