### PR TITLE
rocsolver: Add spack test support

### DIFF
--- a/var/spack/repos/builtin/packages/rocsolver/link-clients-blas.patch
+++ b/var/spack/repos/builtin/packages/rocsolver/link-clients-blas.patch
@@ -1,0 +1,22 @@
+diff -r -u a/clients/benchmarks/CMakeLists.txt b/clients/benchmarks/CMakeLists.txt
+--- a/clients/benchmarks/CMakeLists.txt	2021-08-14 18:54:53.356456513 -0600
++++ b/clients/benchmarks/CMakeLists.txt	2021-08-14 18:55:25.125354419 -0600
+@@ -19,6 +19,7 @@
+ target_link_libraries( rocsolver-bench PRIVATE
+   cblas
+   lapack
++  blas
+   Threads::Threads
+   hip::device
+   rocsolver-common
+diff -r -u a/clients/gtest/CMakeLists.txt b/clients/gtest/CMakeLists.txt
+--- a/clients/gtest/CMakeLists.txt	2021-08-14 18:54:53.356456513 -0600
++++ b/clients/gtest/CMakeLists.txt	2021-08-14 18:55:16.581112850 -0600
+@@ -89,6 +89,7 @@
+ target_link_libraries( rocsolver-test PRIVATE
+   cblas
+   lapack
++  blas
+   GTest::GTest
+   hip::device
+   rocsolver-common

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -40,6 +40,15 @@ class Rocsolver(CMakePackage):
     depends_on('cmake@3.8:', type='build', when='@4.1.0:')
     depends_on('cmake@3.5:', type='build')
 
+    depends_on('googletest@1.10.0:', type='test')
+    depends_on('netlib-lapack@3.7.1:', type='test')
+
+    patch('link-clients-blas.patch', when='@4.3.0:')
+
+    def check(self):
+        exe = join_path(self.build_directory, 'clients', 'staging', 'rocsolver-test')
+        self.run_test(exe, options=['--gtest_filter=checkin*'])
+
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1']:
         depends_on('hip@' + ver, when='@' + ver)
@@ -50,7 +59,7 @@ class Rocsolver(CMakePackage):
         tgt = self.spec.variants['amdgpu_target'].value
         args = [
             self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
-            self.define('BUILD_CLIENTS_TESTS', 'OFF'),
+            self.define('BUILD_CLIENTS_TESTS', self.run_tests),
             self.define('BUILD_CLIENTS_BENCHMARKS', 'OFF')
         ]
         if self.spec.satisfies('@4.1.0'):


### PR DESCRIPTION
This change adds support for building the rocsolver-test client and teaches spack how to run the fast subset of tests. I don't know what the real minimum required versions of LAPACK and GoogleTest are. I just set the versions we used as the minimum and left the maximum unbounded.

To give it a spin, try:
```
spack install --verbose --test=root rocsolver@4.3.1~optimal
```

@haampie @srekolam @arjun-raj-kuppala