### PR TITLE
qt: add gcc@11 coflicts for older versions

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -143,6 +143,7 @@ class Qt(Package):
           working_dir='qtwebsockets',
           when='@5.14: %gcc@11:')
     conflicts('%gcc@10:', when='@5.9:5.12.6 +opengl')
+    conflicts('%gcc@11:', when='@5.9:5.13')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')


### PR DESCRIPTION
Numerous incidents of missing `numeric_limits` in qt@5.9.9. Given the abundance of patches for `@5.14: %gcc@11` I'm assuming the earlier versions are unpatched and thus adding conflicts.

```
/tmp/s3j/spack-stage/spack-stage-qt-5.9.9-5oa5kpuizuf6dosw3flhyvxr53jewo3o/spack-src/qtbase/src/corelib/tools/qbytearraymatcher.h:103:38: error: 'numeric_limits' is not a member of 'std'
  103 |         const auto uchar_max = (std::numeric_limits<uchar>::max)();
      |                                      ^~~~~~~~~~~~~~
```