### PR TITLE
Add new versions of py-autopep8 and py-pycodestyle

### DIFF
--- a/var/spack/repos/builtin/packages/py-autopep8/package.py
+++ b/var/spack/repos/builtin/packages/py-autopep8/package.py
@@ -13,6 +13,8 @@ class PyAutopep8(PythonPackage):
     homepage = "https://github.com/hhatto/autopep8"
     pypi = "autopep8/autopep8-1.2.4.tar.gz"
 
+    version('1.6.0', sha256='44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979')
+    version('1.5.7', sha256='276ced7e9e3cb22e5d7c14748384a5cf5d9002257c0ed50c0e075b68011bb6d0')
     version('1.4.4', sha256='4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee')
     version('1.3.3', sha256='ff787bffb812818c3071784b5ce9a35f8c481a0de7ea0ce4f8b68b8788a12f30')
     version('1.2.4', sha256='38e31e266e29808e8a65a307778ed8e402e1f0d87472009420d6d18146cdeaa2')
@@ -24,5 +26,9 @@ class PyAutopep8(PythonPackage):
     depends_on('py-pycodestyle@1.5.7:1.7.0', type=('build', 'run'), when='@:1.2.4')
     depends_on('py-pycodestyle@2.3.0:', type=('build', 'run'), when='@1.3:')
     depends_on('py-pycodestyle@2.4.0:', type=('build', 'run'), when='@1.4:')
+    depends_on('py-pycodestyle@2.7.0:', type=('build', 'run'), when='@1.5.6:')
+    depends_on('py-pycodestyle@2.8.0:', type=('build', 'run'), when='@1.6.0:')
+
+    depends_on('py-toml', type=('build', 'run'), when='@1.5.3:')
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pycodestyle/package.py
+++ b/var/spack/repos/builtin/packages/py-pycodestyle/package.py
@@ -23,6 +23,22 @@ class PyPycodestyle(PythonPackage):
     version('2.1.0', sha256='5b540e4f19b4938c082cfd13f5d778d1ad2308b337abbc687ab9335233f5f3e2')
     version('2.0.0', sha256='37f0420b14630b0eaaf452978f3a6ea4816d787c3e6dcbba6fb255030adae2e7')
     # Versions below 2.0.0 are not on pypi
+    version('1.7.0', sha256='3f62d19b5cbcbdcb7810f967dcc2fbdd090256e090c32b457e2580a841d118ef',
+            url='https://github.com/PyCQA/pycodestyle/archive/1.7.0.tar.gz', deprecated=True)
+    version('1.6.2', sha256='508bfd7d457046891bf4b8fbfc95ccac7995c37cdfdb3daf97bfeb7a13fa4c9c',
+            url='https://github.com/PyCQA/pycodestyle/archive/1.6.2.tar.gz', deprecated=True)
+    version('1.6.1', sha256='3a910a0d0d998d4c3c2b8152a4816b98938b27cc73a4433c61202449706a73c8',
+            url='https://github.com/PyCQA/pycodestyle/archive/1.6.1.tar.gz', deprecated=True)
+    version('1.6',   sha256='5e7bb5156af311079345b5e81f8154c3e1420d723150a6cba5a70245eb0d515a',
+            url='https://github.com/PyCQA/pycodestyle/archive/1.6.tar.gz',   deprecated=True)
+    version('1.5.7', sha256='9bf020638986f2e254823aee62cfd97e55ba08ad51503cd5ae26172c47f48401',
+            url='https://github.com/PyCQA/pycodestyle/archive/1.5.7.tar.gz', deprecated=True)
+    version('1.5.6', sha256='9f164c1211854678b2cb269954bc8aac2dcfa142d40c99f7bab08f9344cf3241',
+            url='https://github.com/PyCQA/pycodestyle/archive/1.5.6.tar.gz', deprecated=True)
+    version('1.5.5', sha256='e55204c5477a29eb094835ad6e83be292aa3e06be12e51f5b4cc67f38d0d61ba',
+            url='https://github.com/PyCQA/pycodestyle/archive/1.5.5.tar.gz', deprecated=True)
+    version('1.5.4', sha256='bc234f7935a350c79c953421b01163db01010f39caeddfa8602ff54f76a6fd9e',
+            url='https://github.com/PyCQA/pycodestyle/archive/1.5.4.tar.gz', deprecated=True)
 
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-pycodestyle requires py-setuptools during runtime as well.

--- a/var/spack/repos/builtin/packages/py-pycodestyle/package.py
+++ b/var/spack/repos/builtin/packages/py-pycodestyle/package.py
@@ -11,8 +11,10 @@ class PyPycodestyle(PythonPackage):
     style conventions in PEP 8. Note: formerly called pep8."""
 
     homepage = "https://github.com/PyCQA/pycodestyle"
-    url      = "https://github.com/PyCQA/pycodestyle/archive/2.0.0.tar.gz"
+    pypi     = "pycodestyle/pycodestyle-2.8.0.tar.gz"
 
+    version('2.8.0', sha256='eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f')
+    version('2.7.0', sha256='c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef')
     version('2.6.0', sha256='08347fbc48cc92afd33117c1e8af9b99b292a4e5889f6b776f402e062fc39c97')
     version('2.5.0', sha256='a603453c07e8d8e15a43cf062aa7174741b74b4a27b110f9ad03d74d519173b5')
     version('2.3.1', sha256='e9fc1ca3fd85648f45c0d2e33591b608a17d8b9b78e22c5f898e831351bacb03')
@@ -32,3 +34,6 @@ class PyPycodestyle(PythonPackage):
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-pycodestyle requires py-setuptools during runtime as well.
     depends_on('py-setuptools', type=('build', 'run'))
+
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@2.7.0:')
+    depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@2.8.0:')

--- a/var/spack/repos/builtin/packages/py-pycodestyle/package.py
+++ b/var/spack/repos/builtin/packages/py-pycodestyle/package.py
@@ -15,21 +15,14 @@ class PyPycodestyle(PythonPackage):
 
     version('2.8.0', sha256='eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f')
     version('2.7.0', sha256='c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef')
-    version('2.6.0', sha256='08347fbc48cc92afd33117c1e8af9b99b292a4e5889f6b776f402e062fc39c97')
+    version('2.6.0', sha256='c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e')
     version('2.5.0', sha256='a603453c07e8d8e15a43cf062aa7174741b74b4a27b110f9ad03d74d519173b5')
-    version('2.3.1', sha256='e9fc1ca3fd85648f45c0d2e33591b608a17d8b9b78e22c5f898e831351bacb03')
-    version('2.3.0', sha256='ac2a849987316521a56814b5618668d36cd5f3b04843803832a15b93b8383a50')
-    version('2.2.0', sha256='aa663451c9de97d00eff396eeffe1095fd1597491341ca3c0be54983b25b1a7d')
-    version('2.1.0', sha256='2190466d2b421da0d915b506eb690a6784feaef3ba33043665bf86581b02ccd9')
-    version('2.0.0', sha256='7e65a888def0abc467fa2cf614b3f84a74a8991045a2adcf11e1c225d8798796')
-    version('1.7.0', sha256='3f62d19b5cbcbdcb7810f967dcc2fbdd090256e090c32b457e2580a841d118ef')
-    version('1.6.2', sha256='508bfd7d457046891bf4b8fbfc95ccac7995c37cdfdb3daf97bfeb7a13fa4c9c')
-    version('1.6.1', sha256='3a910a0d0d998d4c3c2b8152a4816b98938b27cc73a4433c61202449706a73c8')
-    version('1.6',   sha256='5e7bb5156af311079345b5e81f8154c3e1420d723150a6cba5a70245eb0d515a')
-    version('1.5.7', sha256='9bf020638986f2e254823aee62cfd97e55ba08ad51503cd5ae26172c47f48401')
-    version('1.5.6', sha256='9f164c1211854678b2cb269954bc8aac2dcfa142d40c99f7bab08f9344cf3241')
-    version('1.5.5', sha256='e55204c5477a29eb094835ad6e83be292aa3e06be12e51f5b4cc67f38d0d61ba')
-    version('1.5.4', sha256='bc234f7935a350c79c953421b01163db01010f39caeddfa8602ff54f76a6fd9e')
+    version('2.3.1', sha256='682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766')
+    version('2.3.0', sha256='a5910db118cf7e66ff92fb281a203c19ca2b5134620dd2538a794e636253863b')
+    version('2.2.0', sha256='df81dc3293e0123e2e8d1f2aaf819600e4ae287d8b3af8b72181af50257e5d9a')
+    version('2.1.0', sha256='5b540e4f19b4938c082cfd13f5d778d1ad2308b337abbc687ab9335233f5f3e2')
+    version('2.0.0', sha256='37f0420b14630b0eaaf452978f3a6ea4816d787c3e6dcbba6fb255030adae2e7')
+    # Versions below 2.0.0 are not on pypi
 
     # Most Python packages only require py-setuptools as a build dependency.
     # However, py-pycodestyle requires py-setuptools during runtime as well.


### PR DESCRIPTION
py-autopep8: 1.5.7, 1.6.0
py-pycodestyle: 2.7.0, 2.8.0