### PR TITLE
Return early in do_fetch when there is no code or a package is external

### DIFF
--- a/lib/spack/spack/cmd/fetch.py
+++ b/lib/spack/spack/cmd/fetch.py
@@ -76,10 +76,6 @@ def fetch(parser, args):
                 if args.missing and package.installed:
                     continue
 
-                # Do not attempt to fetch externals (they're local)
-                if package.spec.external:
-                    continue
-
                 package.do_fetch()
 
         package = spack.repo.get(spec)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1333,9 +1333,9 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         Creates a stage directory and downloads the tarball for this package.
         Working directory will be set to the stage directory.
         """
-        if not self.has_code:
-            tty.debug('No fetch required for {0}: package has no code.'
-                      .format(self.name))
+        if not self.has_code or self.spec.external:
+            tty.debug('No fetch required for {0}'.format(self.name))
+            return
 
         checksum = spack.config.get('config:checksum')
         fetch = self.stage.managed_by_spack


### PR DESCRIPTION
Supersedes #26177, both external packages and packages without code should not fetch anything, and we should be OK to just run do_fetch even if it's a noop in cmd/fetch.py.