### PR TITLE
omega-h: add support for stand-alone testing

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -101,7 +101,7 @@ class OmegaH(CMakePackage):
         return (None, None, flags)
 
     def test(self):
-        if self.spec.version <= Version('9.34.1'):
+        if self.spec.version < Version('9.34.1'):
             print('Skipping tests since only relevant for versions > 9.34.1')
             return
 

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -112,7 +112,7 @@ class OmegaH(CMakePackage):
 
         exe = 'osh_scale'
         options = ['box.osh', '100', 'box_100.osh']
-        expected='adapting took'
+        expected = 'adapting took'
         description = 'testing mesh adaptation'
         self.run_test(exe, options, expected, purpose=description,
                       work_dir=self.prefix.bin)

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -15,7 +15,7 @@ class OmegaH(CMakePackage):
     url      = "https://github.com/sandialabs/omega_h/archive/v9.34.1.tar.gz"
     git      = "https://github.com/sandialabs/omega_h.git"
 
-    maintainers = ['ibaned']
+    maintainers = ['cwsmith']
     tags = ['e4s']
     version('main', branch='main')
     version('9.34.1', sha256='3a812da3b8df3e0e5d78055e91ad23333761bcd9ed9b2c8c13ee1ba3d702e46c')

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -102,6 +102,7 @@ class OmegaH(CMakePackage):
 
     def test(self):
         if self.spec.version <= Version('9.34.1'):
+            print('Skipping tests since only relevant for versions > 9.34.1')
             return
 
         exe = 'osh_box'

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -105,21 +105,18 @@ class OmegaH(CMakePackage):
             print('Skipping tests since only relevant for versions > 9.34.1')
             return
 
-        exe = 'osh_box'
+        exe = join_path(self.prefix.bin, 'osh_box')
         options = ['1', '1', '1', '2', '2', '2', 'box.osh']
         description = 'testing mesh construction'
-        self.run_test(exe, options, purpose=description,
-                      work_dir=self.prefix.bin)
+        self.run_test(exe, options, purpose=description)
 
-        exe = 'osh_scale'
+        exe = join_path(self.prefix.bin, 'osh_scale')
         options = ['box.osh', '100', 'box_100.osh']
         expected = 'adapting took'
         description = 'testing mesh adaptation'
-        self.run_test(exe, options, expected, purpose=description,
-                      work_dir=self.prefix.bin)
+        self.run_test(exe, options, expected, purpose=description)
 
-        exe = 'osh2vtk'
+        exe = join_path(self.prefix.bin, 'osh2vtk')
         options = ['box_100.osh', 'box_100_vtk']
         description = 'testing mesh to vtu conversion'
-        self.run_test(exe, options, purpose=description,
-                      work_dir=self.prefix.bin)
+        self.run_test(exe, options, purpose=description)

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -11,9 +11,9 @@ class OmegaH(CMakePackage):
     hardware including GPUs.
     """
 
-    homepage = "https://github.com/SNLComputation/omega_h"
-    url      = "https://github.com/SNLComputation/omega_h/archive/v9.34.1.tar.gz"
-    git      = "https://github.com/SNLComputation/omega_h.git"
+    homepage = "https://github.com/sandialabs/omega_h"
+    url      = "https://github.com/sandialabs/omega_h/archive/v9.34.1.tar.gz"
+    git      = "https://github.com/sandialabs/omega_h.git"
 
     maintainers = ['ibaned']
     tags = ['e4s']

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -99,3 +99,26 @@ class OmegaH(CMakePackage):
                 flags.append("-Wno-final-dtor-non-final-class")
 
         return (None, None, flags)
+
+    def test(self):
+        if self.spec.version <= Version('9.34.1'):
+            return
+
+        exe = 'osh_box'
+        options = ['1', '1', '1', '2', '2', '2', 'box.osh']
+        description = 'testing mesh construction'
+        self.run_test(exe, options, purpose=description,
+                      work_dir=self.prefix.bin)
+
+        exe = 'osh_scale'
+        options = ['box.osh', '100', 'box_100.osh']
+        expected='adapting took'
+        description = 'testing mesh adaptation'
+        self.run_test(exe, options, expected, purpose=description,
+                      work_dir=self.prefix.bin)
+
+        exe = 'osh2vtk'
+        options = ['box_100.osh', 'box_100_vtk']
+        description = 'testing mesh to vtu conversion'
+        self.run_test(exe, options, purpose=description,
+                      work_dir=self.prefix.bin)


### PR DESCRIPTION
This PR adds support for `spack test` stand-alone testing.

It also updates the repo url and sets me as the package maintainer.