### PR TITLE
unifyfs: Remove the hdf5 variant

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -92,7 +92,7 @@ class EcpDataVisSdk(BundlePackage):
 
     dav_sdk_depends_on('parallel-netcdf+shared+fortran', when='+pnetcdf')
 
-    dav_sdk_depends_on('unifyfs', when='+unifyfs ', propagate=['hdf5'])
+    dav_sdk_depends_on('unifyfs', when='+unifyfs ')
 
     dav_sdk_depends_on('veloc', when='+veloc')
 

--- a/var/spack/repos/builtin/packages/unifyfs/package.py
+++ b/var/spack/repos/builtin/packages/unifyfs/package.py
@@ -26,7 +26,6 @@ class Unifyfs(AutotoolsPackage):
     version('0.9.1', sha256='2498a859cfa4961356fdf5c4c17e3afc3de7e034ad013b8c7145a622ef6199a0')
 
     variant('auto-mount', default='True', description='Enable automatic mount/unmount in MPI_Init/Finalize')
-    variant('hdf5', default='False', description='Build with parallel HDF5 (install with `^hdf5~mpi` for serial)')
     variant('fortran', default='False', description='Build with gfortran support')
     variant('pmi', default='False', description='Enable PMI2 build options')
     variant('pmix', default='False', description='Enable PMIx build options')
@@ -48,7 +47,6 @@ class Unifyfs(AutotoolsPackage):
     depends_on('openssl@:1')
 
     # Optional dependencies
-    depends_on('hdf5', when='+hdf5')
     depends_on('libfabric fabrics=rxm,sockets,tcp', when="^mercury@2:+ofi")
     depends_on('spath~mpi', when='+spath')
 
@@ -80,15 +78,6 @@ class Unifyfs(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         args = []
-
-        # UnifyFS's configure requires the exact path for HDF5
-        def hdf5_compiler_path(name):
-            if '~mpi' in spec[name]:  # serial HDF5
-                return spec[name].prefix.bin.h5cc
-            else:  # parallel HDF5
-                return spec[name].prefix.bin.h5pcc
-
-        args.extend(self.with_or_without('hdf5', hdf5_compiler_path))
 
         if '+auto-mount' in spec:
             args.append('--enable-mpi-mount')


### PR DESCRIPTION
UnifyFS doesn't actually use HDF5 for anything.  Enabling it only enables
a few examples to be built so it's not actually a dependency of the
package.