### PR TITLE
py-kornia: add v0.6.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-kornia/package.py
+++ b/var/spack/repos/builtin/packages/py-kornia/package.py
@@ -12,9 +12,12 @@ class PyKornia(PythonPackage):
     homepage = "https://www.kornia.org/"
     pypi     = "kornia/kornia-0.5.10.tar.gz"
 
+    version('0.6.1', sha256='f638fb3309f88666545866c162f510b6d485fd8f7131d5570d4e6c0d295fdcd6')
     version('0.5.10', sha256='428b4b934a2ba7360cc6cba051ed8fd96c2d0f66611fdca0834e82845f14f65d')
 
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-pytest-runner', type='build')
     depends_on('py-torch@1.6.0:', type=('build', 'run'))
+    depends_on('py-torch@1.8.1:', when='@0.6:', type=('build', 'run'))
+    depends_on('py-packaging', when='@0.6:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds and passes all tests on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.