### PR TITLE
virtest: Prevent out-of-order build/test

### DIFF
--- a/var/spack/repos/builtin/packages/virtest/package.py
+++ b/var/spack/repos/builtin/packages/virtest/package.py
@@ -17,6 +17,11 @@ class Virtest(CMakePackage):
 
     version('master', branch='master')
 
+    def patch(self):
+        script = FileFilter('tests/CMakeLists.txt')
+        script.filter(r' *\${CMAKE_CTEST_COMMAND} -V -R \${target}',
+                      '${CMAKE_CTEST_COMMAND} -V -R "^${target}$"')
+
     def setup_run_environment(self, env):
         env.prepend_path('CPATH', self.prefix.include.vir)
 


### PR DESCRIPTION
Discovered whilst trying to install the dependent `vc` package. 

Virtest uses the `-R` flag to CTest to run tests as part of the build, but this can cause a bad match - specifically, an error is encountered with the `empty` test, which tries to run the `empty-14` test instead of the correct `empty` executable. The build then fails as the `empty-14` target hasn't (may not have) been built yet.

The PR adds an inplace patch to make the CTest command match the required test/executable name exactly.