### PR TITLE
Support databases keyed by any hash type

### DIFF
--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -225,7 +225,8 @@ def do_uninstall(env, specs, force):
         is_ready = lambda x: True
 
     while packages:
-        ready = [x for x in packages if is_ready(x.spec.dag_hash())]
+        ready = [x for x in packages if is_ready(
+            x.spec._cached_hash(hash=spack.store.db.key_hash_type))]
         if not ready:
             msg = 'unexpected error [cannot proceed uninstalling specs with' \
                   ' remaining dependents {0}]'

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -320,7 +320,7 @@ class DirectoryLayout(object):
             return spec.external_path
         if self.check_upstream:
             upstream, record = spack.store.db.query_by_spec_hash(
-                spec.dag_hash())
+                spec._cached_hash(hash=spack.store.db.key_hash_type))
             if upstream:
                 raise SpackError(
                     "Internal error: attempted to call path_for_spec on"

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -381,7 +381,8 @@ def get_module(
     try:
         upstream = spec.package.installed_upstream
     except spack.repo.UnknownPackageError:
-        upstream, record = spack.store.db.query_by_spec_hash(spec.dag_hash())
+        upstream, record = spack.store.db.query_by_spec_hash(
+            spec._cached_hash(hash=spack.store.db.key_hash_type))
     if upstream:
         module = (spack.modules.common.upstream_module_index
                   .upstream_module(spec, module_type))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -724,7 +724,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     def installed_upstream(self):
         if not hasattr(self, '_installed_upstream'):
             upstream, record = spack.store.db.query_by_spec_hash(
-                self.spec.dag_hash())
+                self.spec._cached_hash(hash=spack.store.db.key_hash_type))
             self._installed_upstream = upstream
 
         return self._installed_upstream

--- a/lib/spack/spack/schema/database_index.py
+++ b/lib/spack/spack/schema/database_index.py
@@ -52,6 +52,7 @@ schema = {
                     },
                 },
                 'version': {'type': 'string'},
+                'key_hash_type': {'type': 'string'}
             }
         },
     },

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1497,7 +1497,7 @@ class Spec(object):
 
         if self._prefix is None:
             upstream, record = spack.store.db.query_by_spec_hash(
-                self.dag_hash())
+                self._cached_hash(hash=spack.store.db.key_hash_type))
             if record and record.path:
                 self.prefix = record.path
             else:
@@ -1585,7 +1585,11 @@ class Spec(object):
 
     def dag_hash_bit_prefix(self, bits):
         """Get the first <bits> bits of the DAG hash as an integer type."""
-        return spack.util.hash.base32_prefix_bits(self.dag_hash(), bits)
+        return self.hash_bit_prefix(bits, hash=ht.dag_hash)
+
+    def hash_bit_prefix(self, bits, hash=ht.dag_hash):
+        return spack.util.hash.base32_prefix_bits(
+            self._cached_hash(hash=hash), bits)
 
     def to_node_dict(self, hash=ht.dag_hash):
         """Create a dictionary representing the state of this Spec.
@@ -2585,7 +2589,8 @@ class Spec(object):
         deprecated = []
         with spack.store.db.read_transaction():
             for x in root.traverse():
-                _, rec = spack.store.db.query_by_spec_hash(x.dag_hash())
+                _, rec = spack.store.db.query_by_spec_hash(
+                    x._cached_hash(hash=spack.store.db.key_hash_type))
                 if rec and rec.deprecated_for:
                     deprecated.append(rec)
         if deprecated:

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -32,6 +32,7 @@ import spack.config
 import spack.database
 import spack.directory_layout
 import spack.environment as ev
+import spack.hash_types as ht
 import spack.package
 import spack.package_prefs
 import spack.paths
@@ -842,10 +843,15 @@ def install_mockery(temporary_store, config, mock_packages):
 
 
 @pytest.fixture(scope='function')
-def temporary_store(tmpdir):
+def temporary_store(tmpdir, request):
     """Hooks a temporary empty store for the test function."""
+    hash_type = ht.dag_hash
+    if request and hasattr(request, 'param'):
+        hash_type = request.param
+
     temporary_store_path = tmpdir.join('opt')
-    with spack.store.use_store(str(temporary_store_path)) as s:
+    store = spack.store.Store(str(temporary_store_path), db_key_hash_type=hash_type)
+    with spack.store.use_store(store) as s:
         yield s
     temporary_store_path.remove()
 


### PR DESCRIPTION
This change supports using full hash to name buildcache entries by allowing database instances to be keyed by full hash.

TODO:

- [ ] Expose `_cached_hash()` method on the spec class publicly (rename or add new method)
- [ ] Decide whether we need to make explicit a constraint that a db and its upstream dbs must all use same hash type for their key
- [x] Figure out what to do about failing test (changing db hash key appears to change DAG hash of specs inserted)
- [x] Update database version information (or describe key type used in a top-level field) 
  * [ ] Now we have some version information stored, how do we want to use it?