### PR TITLE
py-sip: fix python_include_dir

### DIFF
--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -99,7 +99,9 @@ class SIPPackage(PackageBase):
 
         args = self.configure_args()
 
-        python_include_dir = 'python' + str(spec['python'].version.up_to(2))
+        python_include_dir = os.path.basename(
+            inspect.getmodule(self).python_include_dir
+        )
 
         args.extend([
             '--verbose',


### PR DESCRIPTION
While installing `py-pyqt5` as a dependency of `py-mne+full` inside an environment which was concretized together, I ran into the issue that the `py-sip`-`python_include_dir` could not be found. The error was
```
==> Installing py-pyqt5-5.13.1-m3js6fcjkfpkce6c347yc2ounxno3wgb
==> No binary for py-pyqt5-5.13.1-m3js6fcjkfpkce6c347yc2ounxno3wgb found: installing from source
==> Using cached archive: $spack/var/spack/cache/_source-cache/archive/54/54b7f456341b89eeb3930e786837762ea67f235e886512496c4152ebe106d4af.tar.gz
==> No patches needed for py-pyqt5
==> py-pyqt5: Executing phase: 'configure'
==> Error: ProcessError: Command exited with status 2:
    '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/python-3.8.11-4hnravhbnyay4hbfrsztzoh56pslz5rm/bin/python3.8' 'configure.py' '--pyuic5-interpreter' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/python-3.8.11-4hnravhbnyay4hbfrsztzoh56pslz5rm/bin/python3.8' '--sipdir' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-pyqt5-5.13.1-m3js6fcjkfpkce6c347yc2ounxno3wgb/share/sip/PyQt5' '--designer-plugindir' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-pyqt5-5.13.1-m3js6fcjkfpkce6c347yc2ounxno3wgb/plugins/designer' '--qml-plugindir' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-pyqt5-5.13.1-m3js6fcjkfpkce6c347yc2ounxno3wgb/plugins/PyQt5' '--stubsdir' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-pyqt5-5.13.1-m3js6fcjkfpkce6c347yc2ounxno3wgb/lib/python3.8/site-packages/PyQt5' '--verbose' '--confirm-license' '--qmake' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/qt-5.15.2-gij2o2lm6ufl7leq632ht22wjdxsjmev/bin/qmake' '--sip' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-sip-4.19.21-td6ml3zjgsp7b47nr6uc7duuiy5hqcvv/bin/sip' '--sip-incdir' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-sip-4.19.21-td6ml3zjgsp7b47nr6uc7duuiy5hqcvv/include/python3.8' '--bindir' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-pyqt5-5.13.1-m3js6fcjkfpkce6c347yc2ounxno3wgb/bin' '--destdir' '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-pyqt5-5.13.1-m3js6fcjkfpkce6c347yc2ounxno3wgb/lib/python3.8/site-packages'

1 error found in build log:
     4
  >> 5    configure.py: error: '$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-sip-4.19.
          21-td6ml3zjgsp7b47nr6uc7duuiy5hqcvv/include/python3.8' is not a directory
```
The correct path is `$spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/py-sip-4.19.21-td6ml3zjgsp7b47nr6uc7duuiy5hqcvv/include/python3.8d/`

The problem comes from [ this line in lib/spack/spack/build_systems/sip.py](https://github.com/spack/spack/blob/develop/lib/spack/spack/build_systems/sip.py#L102).

Picking up the suggestion from [this thread](https://github.com/spack/spack/pull/15297#discussion_r390438696) and extracting the path instead of rebuilding it, fixes the installation for me.
