### PR TITLE
getting_started.rst: fix the order of Git's command line arguments

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -35,7 +35,7 @@ Getting Spack is easy.  You can clone it from the `github repository
 
 .. code-block:: console
 
-   $ git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+   $ git -c feature.manyFiles=true clone https://github.com/spack/spack.git
 
 This will create a directory called ``spack``.
 


### PR DESCRIPTION
To pass configuration parameters on the command line using `-c name=value`, it has to be passed to the `git` command itself, not to its subcommand. That is, the order or arguments should be: `git -c name=value clone ...` instead of `git clone -c name=value`