### PR TITLE
tests: speed up `spack list` tests

### DIFF
--- a/lib/spack/spack/cmd/list.py
+++ b/lib/spack/spack/cmd/list.py
@@ -221,9 +221,13 @@ def html(pkg_names, out):
 
         out.write('<dt>Homepage:</dt>\n')
         out.write('<dd><ul class="first last simple">\n')
-        out.write(('<li>'
-                   '<a class="reference external" href="%s">%s</a>'
-                   '</li>\n') % (pkg.homepage, escape(pkg.homepage, True)))
+
+        if pkg.homepage:
+            out.write(('<li>'
+                       '<a class="reference external" href="%s">%s</a>'
+                       '</li>\n') % (pkg.homepage, escape(pkg.homepage, True)))
+        else:
+            out.write('No homepage\n')
         out.write('</ul></dd>\n')
 
         out.write('<dt>Spack package:</dt>\n')

--- a/lib/spack/spack/test/cmd/list.py
+++ b/lib/spack/spack/test/cmd/list.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import pytest
-
 from spack.main import SpackCommand
 
 list = SpackCommand('list')
@@ -16,62 +14,65 @@ def test_list():
     assert 'hdf5' in output
 
 
-def test_list_filter():
+def test_list_filter(mock_packages):
     output = list('py-*')
-    assert 'py-numpy' in output
-    assert 'perl-file-copy-recursive' not in output
+    assert 'py-extension1' in output
+    assert 'py-extension2' in output
+    assert 'py-extension3' in output
+    assert 'python' not in output
+    assert 'mpich' not in output
 
-    output = list('py-')
-    assert 'py-numpy' in output
-    assert 'perl-file-copy-recursive' in output
-
-
-@pytest.mark.maybeslow
-def test_list_search_description():
-    output = list('--search-description', 'xml')
-    assert 'expat' in output
-
-
-def test_list_tags():
-    output = list('--tag', 'proxy-app')
-    assert 'cloverleaf3d' in output
-    assert 'hdf5' not in output
-
-    output = list('--tag', 'hpc')
-    assert 'nek5000' in output
-    assert 'mfem' in output
-
-    output = list('--tag', 'HPC')
-    assert 'nek5000' in output
-    assert 'mfem' in output
+    output = list('py')
+    assert 'py-extension1' in output
+    assert 'py-extension2' in output
+    assert 'py-extension3' in output
+    assert 'python' in output
+    assert 'mpich' not in output
 
 
-def test_list_format_name_only():
+def test_list_search_description(mock_packages):
+    output = list('--search-description', 'one build dependency')
+    assert 'depb' in output
+
+
+def test_list_tags(mock_packages):
+    output = list('--tag', 'tag1')
+    assert 'mpich' in output
+    assert 'mpich2' in output
+
+    output = list('--tag', 'tag2')
+    assert 'mpich\n' in output
+    assert 'mpich2' not in output
+
+    output = list('--tag', 'tag3')
+    assert 'mpich\n' not in output
+    assert 'mpich2' in output
+
+
+def test_list_format_name_only(mock_packages):
     output = list('--format', 'name_only')
-    assert 'cloverleaf3d' in output
+    assert 'zmpi' in output
     assert 'hdf5' in output
 
 
-@pytest.mark.maybeslow
-def test_list_format_version_json():
+def test_list_format_version_json(mock_packages):
     output = list('--format', 'version_json')
-    assert '  {"name": "cloverleaf3d",' in output
-    assert '  {"name": "hdf5",' in output
+    assert '{"name": "zmpi",' in output
+    assert '{"name": "dyninst",' in output
     import json
     json.loads(output)
 
 
-@pytest.mark.maybeslow
-def test_list_format_html():
+def test_list_format_html(mock_packages):
     output = list('--format', 'html')
-    assert '<div class="section" id="cloverleaf3d">' in output
-    assert '<h1>cloverleaf3d' in output
+    assert '<div class="section" id="zmpi">' in output
+    assert '<h1>zmpi' in output
 
     assert '<div class="section" id="hdf5">' in output
     assert '<h1>hdf5' in output
 
 
-def test_list_update(tmpdir):
+def test_list_update(tmpdir, mock_packages):
     update_file = tmpdir.join('output')
 
     # not yet created when list is run


### PR DESCRIPTION
`spack list` tests are not using mock packages for some reason, and many are marked as potentially slow. This isn't really necessary; we don't need 6,000 packages to test the command.

- [x] update tests to use `mock_packages` fixture
- [x] remove `maybeslow` annotations


Not sure why we weren't using mock packages to begin with, but this should speed up the tests for `spack list`. The hope is to avoid the error that @haampie reported in https://github.com/spack/spack/pull/26735#issuecomment-952393879.  I suspect it is because the output is large and there are issues getting it all in a string in `SpackCommand`, so this will hopefully help.

before:

```
8 passed, 3174 deselected in 28.29 seconds
```

after:

```
8 passed, 3174 deselected in 6.04 seconds
```
