### PR TITLE
atk,at-spi2-atk,-core: add 2.42, fix deps and tests w/o DBUSd

### DIFF
--- a/var/spack/repos/builtin/packages/at-spi2-atk/package.py
+++ b/var/spack/repos/builtin/packages/at-spi2-atk/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack import *
 
 
@@ -28,3 +30,7 @@ class AtSpi2Atk(MesonPackage):
         """Handle gnome's version-based custom URLs."""
         url = 'http://ftp.gnome.org/pub/gnome/sources/at-spi2-atk'
         return url + '/%s/at-spi2-atk-%s.tar.xz' % (version.up_to(2), version)
+
+    def check(self):
+        if os.environ.get('DBUS_SESSION_BUS_ADDRESS'):
+            make('check')

--- a/var/spack/repos/builtin/packages/atk/package.py
+++ b/var/spack/repos/builtin/packages/atk/package.py
@@ -29,7 +29,6 @@ class Atk(Package):
     depends_on('gettext')
     depends_on('pkgconfig', type='build')
     depends_on('gobject-introspection')
-    depends_on('libffi')
 
     def url_for_version(self, version):
         """Handle gnome's version-based custom URLs."""


### PR DESCRIPTION
at-spi2-atk: Tests need DBUS, skip them if none is provided.

at-spi2-core: Likewise, and the build does not use python, so
remove it and the not used input/record/fixesproto depends.
(adding these was part of a huge commit where many packages
were updated and these changes were made to the wrong file)

atk: Remove depends_on('libffi'): It was added claiming:
"atk build requires libffi to detect glib", but neither
Homebrew nor Debian have it as dependency, this must have
been a bug in spack not providing the libffi link dep of
glib or a broken external glib package.