### PR TITLE
Fix deps of gtk packages: pkgconfig, m4, libtool, libintl

### DIFF
--- a/var/spack/repos/builtin/packages/cairomm/package.py
+++ b/var/spack/repos/builtin/packages/cairomm/package.py
@@ -17,3 +17,4 @@ class Cairomm(AutotoolsPackage):
 
     depends_on('cairo')
     depends_on('libsigcpp')
+    depends_on('pkgconfig', type='build')

--- a/var/spack/repos/builtin/packages/cups/package.py
+++ b/var/spack/repos/builtin/packages/cups/package.py
@@ -19,6 +19,7 @@ class Cups(AutotoolsPackage):
     version('2.2.3', sha256='66701fe15838f2c892052c913bde1ba106bbee2e0a953c955a62ecacce76885f')
 
     depends_on('gnutls')
+    depends_on('pkgconfig', type='build')
 
     def configure_args(self):
         args = ['--enable-gnutls', '--with-components=core']

--- a/var/spack/repos/builtin/packages/gconf/package.py
+++ b/var/spack/repos/builtin/packages/gconf/package.py
@@ -19,6 +19,8 @@ class Gconf(AutotoolsPackage):
     version('3.2.6', sha256='1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c', deprecated=True)
 
     depends_on('pkgconfig', type='build')
+    depends_on('gettext',  type='build')
+    depends_on('intltool',  type='build')
     depends_on('glib@2.14.0:')
     depends_on('libxml2')
     depends_on('dbus')

--- a/var/spack/repos/builtin/packages/glibmm/package.py
+++ b/var/spack/repos/builtin/packages/glibmm/package.py
@@ -16,8 +16,9 @@ class Glibmm(AutotoolsPackage):
     version('2.16.0', sha256='99795b9c6e58e490df740a113408092bf47a928427cbf178d77c35adcb6a57a3')
     version('2.4.8', sha256='78b97bfa1d001cc7b398f76bf09005ba55b45ae20780b297947a1a71c4f07e1f')
 
-    depends_on('libsigcpp')
+    depends_on('libsigcpp@:2.9')
     depends_on('glib')
+    depends_on('pkgconfig', type='build')
 
     patch('guint16_cast.patch', when='@2.19.3')
 

--- a/var/spack/repos/builtin/packages/glibmm/package.py
+++ b/var/spack/repos/builtin/packages/glibmm/package.py
@@ -9,14 +9,20 @@ from spack import *
 class Glibmm(AutotoolsPackage):
     """Glibmm is a C++ wrapper for the glib library."""
 
-    homepage = "https://developer.gnome.org/glib/"
-    url      = "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.19/glibmm-2.19.3.tar.gz"
+    homepage = 'https://gitlab.gnome.org/GNOME/glibmm'
+    url      = 'https://download-fallback.gnome.org/sources/glibmm/2.70/glibmm-2.70.0.tar.xz'
 
+    # version('2.70.0', sha256='8008fd8aeddcc867a3f97f113de625f6e96ef98cf7860379813a9c0feffdb520')
     version('2.19.3', sha256='23958368535c19188b1241c4615dcf1f35e80e0922a04236bb9247dcd8fe0a2b')
     version('2.16.0', sha256='99795b9c6e58e490df740a113408092bf47a928427cbf178d77c35adcb6a57a3')
     version('2.4.8', sha256='78b97bfa1d001cc7b398f76bf09005ba55b45ae20780b297947a1a71c4f07e1f')
 
-    depends_on('libsigcpp@:2.9')
+    depends_on('libsigcpp')
+    # https://libsigcplusplus.github.io/libsigcplusplus/index.html
+    # sigc++-2.0 and sigc++-3.0 are different parallel-installable ABIs:
+    # libsigcpp@:2.99: are pre-releases of 3.0 & glibmm@:2.19 is not updated for @2.99:
+    # The newer glibmm releases have dependencies which are not yet in spack:
+    depends_on('libsigcpp@:2.9', when='@:2.19')
     depends_on('glib')
     depends_on('pkgconfig', type='build')
 

--- a/var/spack/repos/builtin/packages/gtkmm/package.py
+++ b/var/spack/repos/builtin/packages/gtkmm/package.py
@@ -26,6 +26,7 @@ class Gtkmm(AutotoolsPackage):
     depends_on('gtkplus')
     depends_on('pangomm')
     depends_on('cairomm')
+    depends_on('pkgconfig', type='build')
 
     def url_for_version(self, version):
         """Handle glib's version-based custom URLs."""

--- a/var/spack/repos/builtin/packages/libcanberra/package.py
+++ b/var/spack/repos/builtin/packages/libcanberra/package.py
@@ -35,7 +35,7 @@ class Libcanberra(AutotoolsPackage):
     depends_on('gtkplus',       when='+gtk')
 
     depends_on('libvorbis')
-    depends_on('libtool')
+    depends_on('libtool', type='build')
 
     depends_on('pkgconfig', type='build')
 

--- a/var/spack/repos/builtin/packages/libcanberra/package.py
+++ b/var/spack/repos/builtin/packages/libcanberra/package.py
@@ -35,6 +35,7 @@ class Libcanberra(AutotoolsPackage):
     depends_on('gtkplus',       when='+gtk')
 
     depends_on('libvorbis')
+    depends_on('libtool')
 
     depends_on('pkgconfig', type='build')
 

--- a/var/spack/repos/builtin/packages/libsigcpp/package.py
+++ b/var/spack/repos/builtin/packages/libsigcpp/package.py
@@ -19,6 +19,8 @@ class Libsigcpp(AutotoolsPackage):
     version('2.1.1', sha256='7a2bd0b521544b31051c476205a0e74ace53771ec1a939bfec3c297b50c9fd78')
     version('2.0.3', sha256='6ee6d5f164d8a34da33d2251cdb348b4f5769bf993ed8a6d4055bd47562f94a2')
 
+    depends_on('m4', when='@:2.9', type='build')
+
     def url_for_version(self, version):
         """Handle version-based custom URLs."""
         url = "https://ftp.acc.umu.se/pub/GNOME/sources/libsigc++"


### PR DESCRIPTION
gconf depends on gettext and libintl (dep: intltool)
glibmm, gtkmm, libcanberra and cups need pkgconfig
glibmm needs libsigc++ < 2.9x(which are 3.x pre-releases)
libsigc++@:2.9 depends on m4 for the build