### PR TITLE
fontconfig: Add 2.13.94 and fix test with dash

### DIFF
--- a/var/spack/repos/builtin/packages/fontconfig/package.py
+++ b/var/spack/repos/builtin/packages/fontconfig/package.py
@@ -11,6 +11,7 @@ class Fontconfig(AutotoolsPackage):
     homepage = "https://www.freedesktop.org/wiki/Software/fontconfig/"
     url      = "https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.3.tar.gz"
 
+    version('2.13.94', sha256='246d1640a7e54fba697b28e4445f4d9eb63dda1b511d19986249368ee7191882')
     version('2.13.93', sha256='0f302a18ee52dde0793fe38b266bf269dfe6e0c0ae140e30d72c6cca5dc08db5')
     version('2.13.1', sha256='9f0d852b39d75fc655f9f53850eb32555394f36104a044bb2b2fc9e66dbbfa7f')
     version('2.12.3', sha256='ffc3cbf6dd9fcd516ee42f48306a715e66698b238933d6fa7cef02ea8b3b818e')
@@ -24,6 +25,10 @@ class Fontconfig(AutotoolsPackage):
     depends_on('font-util')
     depends_on('uuid', when='@2.13.1:')
     depends_on('python@3:', type='build', when='@2.13.93:')
+
+    def patch(self):
+        """Make test/run-test.sh compatible with dash"""
+        filter_file('SIGINT SIGTERM SIGABRT EXIT', '2 15 6 0', 'test/run-test.sh')
 
     # Resolve known issue with tarballs 2.12.3 - 2.13.0 plus
     # https://gitlab.freedesktop.org/fontconfig/fontconfig/-/issues/10


### PR DESCRIPTION
Fix install --test=root with /bin/sh -> dash: A test uses
SIGINT SIGTERM SIGABRT EXIT for trap -> use signal numbers