### PR TITLE
libssh2: Skip the testsuite when docker is not installed

### DIFF
--- a/var/spack/repos/builtin/packages/libssh2/package.py
+++ b/var/spack/repos/builtin/packages/libssh2/package.py
@@ -32,3 +32,8 @@ class Libssh2(CMakePackage):
         # The shared library is not installed correctly on Darwin; fix this
         if self.spec.satisfies('platform=darwin'):
             fix_darwin_install_name(self.prefix.lib)
+
+    def check(self):
+        docker = which('docker')
+        if docker:
+            make('test')

--- a/var/spack/repos/builtin/packages/libssh2/package.py
+++ b/var/spack/repos/builtin/packages/libssh2/package.py
@@ -34,6 +34,6 @@ class Libssh2(CMakePackage):
             fix_darwin_install_name(self.prefix.lib)
 
     def check(self):
-        docker = which('docker')
-        if docker:
+        # Docker is required to run tests
+        if which('docker'):
             make('test')


### PR DESCRIPTION
The build-time testsuite which would be run when building
with tests needs docker. Check that it exists before
attempting to execute the tests.