### PR TITLE
py-slurm-pipeline: Add 4.0.4, Fix base.py: import six for @:3

### DIFF
--- a/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
+++ b/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
@@ -12,11 +12,12 @@ class PySlurmPipeline(PythonPackage):
     homepage = "https://github.com/acorg/slurm-pipeline"
     pypi = "slurm-pipeline/slurm-pipeline-1.1.13.tar.gz"
 
+    version('4.0.4',  sha256='5496e46edb890ef745231b4d05b8dfd194374b3fe2c6b33da43cda9685f145c8')
     version('3.0.2',  sha256='28e07eb93e846b395a16e6778fd3fc8344a82d115a6a8420276ec68f67f7131c')
     version('2.0.9',  sha256='2360e43965ecfa3701f287b7d597c99b4accd4dc8faf9d55cfdcc2228c4054cc')
     version('1.1.13', sha256='6d6ca2e96a16780fd9520957166afd06272c57abd962e76bfe74c4d394b38da1')
 
     depends_on('py-setuptools', type='build')
-    # using open range although requirements*.txt give explicit versions
-    # test dependencies are omitted, see #7681
-    depends_on('py-six@1.10.0:', type=('build', 'run'), when='^python@:2.8')
+    # test dependencies are omitted as we don't run unit tests, see #7681
+    # Before 4.0.0, slurm_pipeline/base.py has: from six import string_types
+    depends_on('py-six@1.10.0:', type=('build', 'run'), when='@:3')

--- a/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
+++ b/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
@@ -18,6 +18,8 @@ class PySlurmPipeline(PythonPackage):
     version('1.1.13', sha256='6d6ca2e96a16780fd9520957166afd06272c57abd962e76bfe74c4d394b38da1')
 
     depends_on('py-setuptools', type='build')
+    # listed in install_requires:
+    depends_on('py-pytest@6.2.2:', type='build')
     # test dependencies are omitted as we don't run unit tests, see #7681
     # Before 4.0.0, slurm_pipeline/base.py has: from six import string_types
     depends_on('py-six@1.10.0:', type=('build', 'run'), when='@:3')

--- a/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
+++ b/var/spack/repos/builtin/packages/py-slurm-pipeline/package.py
@@ -20,6 +20,5 @@ class PySlurmPipeline(PythonPackage):
     depends_on('py-setuptools', type='build')
     # listed in install_requires:
     depends_on('py-pytest@6.2.2:', type='build')
-    # test dependencies are omitted as we don't run unit tests, see #7681
     # Before 4.0.0, slurm_pipeline/base.py has: from six import string_types
     depends_on('py-six@1.10.0:', type=('build', 'run'), when='@:3')


### PR DESCRIPTION
Before 4.0.0, slurm_pipeline/base.py has: `from six import string_types`

In case you want to see it yourself: https://github.com/acorg/slurm-pipeline/commit/f4ea680cc3b9bcacceb14c154d51b5d4003f9598