### PR TITLE
perl-extutils-installpaths: depend on perl-extutils-config

### DIFF
--- a/var/spack/repos/builtin/packages/perl-extutils-installpaths/package.py
+++ b/var/spack/repos/builtin/packages/perl-extutils-installpaths/package.py
@@ -13,3 +13,5 @@ class PerlExtutilsInstallpaths(PerlPackage):
     url      = "https://cpan.metacpan.org/authors/id/L/LE/LEONT/ExtUtils-InstallPaths-0.012.tar.gz"
 
     version('0.012', sha256='84735e3037bab1fdffa3c2508567ad412a785c91599db3c12593a50a1dd434ed')
+
+    depends_on('perl-extutils-config', type=('build', 'run'))


### PR DESCRIPTION
depend on perl-extutils-config like perl-module-build-tiny does.