### PR TITLE
gtkplus: fix build of GTK2 versions with gcc-11, skip X tests

### DIFF
--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -61,7 +61,7 @@ class Gtkplus(MesonPackage):
                     '', 'configure', string=True)
 
         # https://gitlab.gnome.org/GNOME/gtk/-/issues/3776
-        if self.spec.satisfies('%gcc@11:'):
+        if self.spec.satisfies('@3:%gcc@11:'):
             filter_file("    '-Werror=array-bounds',",
                         '', 'meson.build', string=True)
 
@@ -123,3 +123,7 @@ class Gtkplus(MesonPackage):
     @when('@:3.20.10')
     def install(self, spec, prefix):
         make('install')
+
+    def check(self):
+        """All build time checks open windows in the X server, don't do that"""
+        pass


### PR DESCRIPTION
@michaelkuhn - You touched this in the past, could you approve it?
- Fix to not attempt to patch a nonexisting file for building old versions when building with gcc-11.
- Skip the build-time tests as all access the X DISPLAY and open many windows on the screen.