### PR TITLE
Fix caching of spack.repo.all_package_names

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -473,7 +473,6 @@ class RepoPath(object):
         self.repos = []
         self.by_namespace = nm.NamespaceTrie()
 
-        self._all_package_names = None
         self._provider_index = None
         self._patch_index = None
 
@@ -544,15 +543,17 @@ class RepoPath(object):
         """Get the first repo in precedence order."""
         return self.repos[0] if self.repos else None
 
-    def all_package_names(self, include_virtuals=False):
+    @llnl.util.lang.memoized
+    def _all_package_names(self, include_virtuals):
         """Return all unique package names in all repositories."""
-        if self._all_package_names is None:
-            all_pkgs = set()
-            for repo in self.repos:
-                for name in repo.all_package_names(include_virtuals):
-                    all_pkgs.add(name)
-            self._all_package_names = sorted(all_pkgs, key=lambda n: n.lower())
-        return self._all_package_names
+        all_pkgs = set()
+        for repo in self.repos:
+            for name in repo.all_package_names(include_virtuals):
+                all_pkgs.add(name)
+        return sorted(all_pkgs, key=lambda n: n.lower())
+
+    def all_package_names(self, include_virtuals=False):
+        return self._all_package_names(include_virtuals)
 
     def packages_with_tags(self, *tags):
         r = set()

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -80,3 +80,9 @@ def test_namespace_hasattr(attr_name, exists, mutable_mock_repo):
     # of a custom __getattr__ implementation
     nms = spack.repo.SpackNamespace('spack.pkg.builtin.mock')
     assert hasattr(nms, attr_name) == exists
+
+
+@pytest.mark.regression('24552')
+def test_all_package_names_is_cached_correctly():
+    assert 'mpi' in spack.repo.all_package_names(include_virtuals=True)
+    assert 'mpi' not in spack.repo.all_package_names(include_virtuals=False)


### PR DESCRIPTION
fixes #24552

Modifications:
- [x] Use `llnl.util.lang.memoized` instead of an explicit attribute