### PR TITLE
m4: (@1.4.19) Fix not running texinfo for m4.info

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import re
 
 
@@ -54,8 +55,8 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     @when('@1.4.19')
     def patch(self):
         """ skip texinfo of m4.info for patched m4.texi (patched only a test in it) """
-        touch('doc/m4.info')
-        touch('doc/stamp-vti')
+        timestamp = os.path.getmtime('doc/m4.info')
+        os.utime('doc/m4.texi', (timestamp, timestamp))
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
m4 had recently not been building for me on Summit due to:
```
     2619    /gpfs/alpine/yadda/yadda/stage/spack-stage-m4-1.4.19-65qjzp2gyiunr7mmf233e3giax6phee4/spack-src/build-aux/missing: line 81: makeinfo: command not found
  >> 2620    WARNING: 'makeinfo' is missing on your system.
     2621             You should only need it if you modified a '.texi' file, or
     2622             any other file indirectly affecting the aspect of the manual.
     2623             You might want to install the Texinfo package:
     2624             <https://www.gnu.org/software/texinfo/>
     2625             The spurious makeinfo call might also be the consequence of
     2626             using a buggy 'make' (AIX, DU, IRIX), in which case you might
```
This change solves it for me. Not sure if there is any better fix or if I'm missing something else.
@eugeneswalker 