### PR TITLE
Remove SPACK_DISABLE_LOCAL_CONFIG

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -583,23 +583,21 @@ settings when running in a continuous integration environment.
 Spack also, by default, keeps various caches and user data in ``~/.spack``, but
 users may want to override these locations.
 
-Spack provides three environment variables that allow you to override or opt out of
-configuration locations:
+Spack provides two environment variables that allow you to override configuration
+locations:
 
 * ``SPACK_USER_CONFIG_PATH``: Override the path to use for the
   ``user`` (``~/.spack``) scope.
 * ``SPACK_SYSTEM_CONFIG_PATH``: Override the path to use for the ``system``
   (``/etc/spack``) scope.
-* ``SPACK_DISABLE_LOCAL_CONFIG``: set this environment variable to completely disable
-  **both** the system and user configuration directories. Spack will only consider its
-  own defaults and ``site`` configuration locations.
 
 And one that allows you to move the default cache location:
 
 * ``SPACK_USER_CACHE_PATH``: Override the default path to use for user data
   (misc_cache, tests, reports, etc.)
 
-With these settings, if you want to isolate Spack in a CI environment, you can do this::
+With these settings, if you want to isolate Spack in a CI environment, you can do this:
 
-  export SPACK_DISABLE_LOCAL_CONFIG=true
-  export SPACK_USER_CACHE_PATH=/tmp/spack
+  export SPACK_USER_CONFIG_PATH="$WORKSPACE/.spack"
+  export SPACK_USER_CACHE_PATH="$WORKSPACE/.spack"
+  export SPACK_SYSTEM_CONFIG_PATH=/dev/null

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -800,14 +800,10 @@ def _config():
         configuration_defaults_path,
     ]
 
-    disable_local_config = "SPACK_DISABLE_LOCAL_CONFIG" in os.environ
-
     # System configuration is per machine.
-    # This is disabled if user asks for no local configuration.
-    if not disable_local_config:
-        configuration_paths.append(
-            ('system', spack.paths.system_config_path),
-        )
+    configuration_paths.append(
+        ('system', spack.paths.system_config_path),
+    )
 
     # Site configuration is per spack instance, for sites or projects
     # No site-level configs should be checked into spack by default.
@@ -816,11 +812,9 @@ def _config():
     )
 
     # User configuration can override both spack defaults and site config
-    # This is disabled if user asks for no local configuration.
-    if not disable_local_config:
-        configuration_paths.append(
-            ('user', spack.paths.user_config_path)
-        )
+    configuration_paths.append(
+        ('user', spack.paths.user_config_path)
+    )
 
     # add each scope and its platform-specific directory
     for name, path in configuration_paths:

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -108,7 +108,6 @@ default_misc_cache_path = os.path.join(user_cache_path, 'cache')
 # the host environment:
 # - `SPACK_USER_CONFIG_PATH`: override `~/.spack` location (for config and caches)
 # - `SPACK_SYSTEM_CONFIG_PATH`: override `/etc/spack` configuration scope.
-# - `SPACK_DISABLE_LOCAL_CONFIG`: disable both of these locations.
 
 
 # User configuration and caches in $HOME/.spack

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -1205,29 +1205,6 @@ def test_user_config_path_is_default_when_env_var_is_empty(working_env):
     assert os.path.expanduser("~/.spack") == spack.paths._get_user_config_path()
 
 
-def test_local_config_can_be_disabled(working_env):
-    os.environ['SPACK_DISABLE_LOCAL_CONFIG'] = 'true'
-    cfg = spack.config._config()
-    assert "defaults" in cfg.scopes
-    assert "system" not in cfg.scopes
-    assert "site" in cfg.scopes
-    assert "user" not in cfg.scopes
-
-    os.environ['SPACK_DISABLE_LOCAL_CONFIG'] = ''
-    cfg = spack.config._config()
-    assert "defaults" in cfg.scopes
-    assert "system" not in cfg.scopes
-    assert "site" in cfg.scopes
-    assert "user" not in cfg.scopes
-
-    del os.environ['SPACK_DISABLE_LOCAL_CONFIG']
-    cfg = spack.config._config()
-    assert "defaults" in cfg.scopes
-    assert "system" in cfg.scopes
-    assert "site" in cfg.scopes
-    assert "user" in cfg.scopes
-
-
 def test_user_cache_path_is_overridable(working_env):
     p = "/some/path"
     os.environ['SPACK_USER_CACHE_PATH'] = p


### PR DESCRIPTION
1. It's only confusing since we allow `$user_config_path` as a variable, which is used in `bootstrap.yaml`, meaning that, although config from `~/.spack` is not read, it still is potentially referred and written to in places.
2. With `SPACK_DISABLE_LOCAL_CONFIG`, the first writable config scope for spack is `$spack/etc/spack`, it's only a matter of time until people start opening issues about that.

Another one-liner solution is to use `$user_cache_path` in bootstrap.yaml's defaults, but this goes counter to the original goal of being able to reuse the same bootstrap store across multiple spack versions (or rather: package repos) using a different misc cache folder. So we should probably not pursue that.

After this PR, ci scripts would have to use:

```
SPACK_SYSTEM_CONFIG_PATH="$(mktemp -d)"
SPACK_USER_CONFIG_PATH="$workspace/.spack"
SPACK_USER_CACHE_PATH="$workspace/.spack"
```

Before this PR, they would have to do:

```
SPACK_DISABLE_LOCAL_CONFIG=yes_please
SPACK_USER_CONFIG_PATH="$workspace/.spack"
SPACK_USER_CACHE_PATH="$workspace/.spack"
```

so it's not an inconvenience.

In the end it's important we don't solve this problem through even more ad-hoc solutions, but rather we should reduce the complexity introduced in #26735, of which I wasn't a fan from the start... Any new feature that's introduced is something we'd have to live with in 0.17, and that was exactly the reason my original version of #26735 was *very* minimal.