### PR TITLE
llvm: fix @11 for gcc@11

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -249,7 +249,7 @@ class Llvm(CMakePackage, CudaPackage):
     # https://github.com/spack/spack/issues/24270
     patch('https://src.fedoraproject.org/rpms/llvm10/raw/7ce7ebd066955ea95ba2b491c41fbc6e4ee0643a/f/llvm10-gcc11.patch',
           sha256='958c64838c9d469be514eef195eca0f8c3ab069bc4b64a48fad59991c626bab8',
-          when='@8:10 %gcc@11:')
+          when='@8:11 %gcc@11:')
 
     # Backport from llvm master + additional fix
     # see  https://bugs.llvm.org/show_bug.cgi?id=39696


### PR DESCRIPTION
llvm@11.1.0 does not build with gcc@11 (see [1]). 
The patch that fixes llvm@10 does also work for llvm@10 so that the build succeeds.

[1]:
```
==> Installing llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea
==> No binary for llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea found: installing from source
==> Using cached archive: $spack/var/spack/cache/_source-cache/archive/53/53a0719f3f4b0388013cfffd7b10c7d5682eece1929a9553c722348d1f866e79.tar.gz
==> No patches needed for llvm
==> llvm: Executing phase: 'cmake'
==> llvm: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j4'

5 errors found in build log:
     4131    [  7%] Building CXX object utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark.cc.o
     4132    cd $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/utils
             /benchmark/src && $spack/lib/spack/env/gcc/g++ -DHAVE_POSIX_REGEX -DHAVE_STD_REGEX -DHAVE_STE
             ADY_CLOCK -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/utils/benchmark/src -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src -I$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/libxml2-2.9.12-7jqzymjvos2b366hifprujd3egeil4ne/include/libxml2 -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/../include -std=c++11 -fPIC -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-redundant-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections  -std=c++11  -Wall  -Wextra  -Wshadow  -pedantic  -pedantic-errors  -Wfloat-equal  -fstrict-aliasing  -fno-exceptions  -Wstrict-aliasing -O3 -DNDEBUG -std=c++14 -MD -MT utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark.cc.o -MF CMakeFiles/benchmark.dir/benchmark.cc.o.d -o CMakeFiles/benchmark.dir/benchmark.cc.o -c $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/benchmark.cc
     4133    [  7%] Building CXX object utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o
     4134    cd $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/utils/benchmark/src && $spack/lib/spack/env/gcc/g++ -DHAVE_POSIX_REGEX -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/utils/benchmark/src -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src -I$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/libxml2-2.9.12-7jqzymjvos2b366hifprujd3egeil4ne/include/libxml2 -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/../include -std=c++11 -fPIC -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-redundant-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections  -std=c++11  -Wall  -Wextra  -Wshadow  -pedantic  -pedantic-errors  -Wfloat-equal  -fstrict-aliasing  -fno-exceptions  -Wstrict-aliasing -O3 -DNDEBUG-std=c++14 -MD -MT utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o -MF CMakeFiles/benchmark.dir/benchmark_register.cc.o.d -o CMakeFiles/benchmark.dir/benchmark_register.cc.o -c $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/benchmark_register.cc
     4135    In file included from $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/benchmark_register.cc:15:
     4136    $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/benchmark_register.h: In function 'void AddRange(std::vector<T>*, T, T, int)':
  >> 4137    $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:30: error: 'numeric_limits' is not a member of 'std'
     4138       17 |   static const T kmax = std::numeric_limits<T>::max();
     4139          |                              ^~~~~~~~~~~~~~
  >> 4140    $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:46: error: expected primary-expression before '>' token
     4141       17 |   static const T kmax = std::numeric_limits<T>::max();
     4142          |                                              ^
  >> 4143    $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:49: error: '::max' has not been declared; did you mean 'std::max'?
     4144       17 |   static const T kmax = std::numeric_limits<T>::max();
     4145          |                                                 ^~~
     4146          |                                                 std::max
     4147    In file included from $spack/opt/spack/linux-fedora32-haswell/gcc-10.3.1/gcc-11.2.0-3tjvptoh34f42eyyuunfdoohaaqk5ypz/include/c++/11.2.0/algorithm:62,
     4148                     from $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/include/benchmark/benchmark.h:175,
     4149                     from $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/utils/benchmark/src/internal_macros.h:4,

     ...

     4154     3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
     4155          |     ^~~
     4156    [  7%] Building CXX object tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangOpcodesEmitter.cpp.o
     4157    cd $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/utils/TableGen && $spack/lib/spack/env/gcc/g++ -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS-D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/utils/TableGen -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/utils/TableGen -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/include -I$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/libxml2-2.9.12-7jqzymjvos2b366hifprujd3egeil4ne/include/libxml2 -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/include -std=c++11 -fPIC -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-redundant-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -fno-strict-aliasing -O3 -DNDEBUG -std=c++14 -MD -MT tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangOpcodesEmitter.cpp.o -MF CMakeFiles/obj.clang-tblgen.dir/ClangOpcodesEmitter.cpp.o.d -o CMakeFiles/obj.clang-tblgen.dir/ClangOpcodesEmitter.cpp.o -c $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/utils/TableGen/ClangOpcodesEmitter.cpp
     4158    [  7%] Building CXX object tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangOpenCLBuiltinEmitter.cpp.o
     4159    cd $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/utils/TableGen && $spack/lib/spack/env/gcc/g++ -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/utils/TableGen -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/utils/TableGen -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/include -I$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/libxml2-2.9.12-7jqzymjvos2b366hifprujd3egeil4ne/include/libxml2 -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/include -std=c++11 -fPIC -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-redundant-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -fno-strict-aliasing -O3 -DNDEBUG -std=c++14 -MD -MT tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangOpenCLBuiltinEmitter.cpp.o -MF CMakeFiles/obj.clang-tblgen.dir/ClangOpenCLBuiltinEmitter.cpp.o.d -o CMakeFiles/obj.clang-tblgen.dir/ClangOpenCLBuiltinEmitter.cpp.o -c $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/utils/TableGen/ClangOpenCLBuiltinEmitter.cpp
  >> 4160    make[2]: *** [utils/benchmark/src/CMakeFiles/benchmark.dir/build.make:93: utils/benchmark/src/CMakeFiles/benchmark.dir/benchmark_register.cc.o] Error 1
     4161    make[2]: Leaving directory '$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut'
  >> 4162    make[1]: *** [CMakeFiles/Makefile2:220007: utils/benchmark/src/CMakeFiles/benchmark.dir/all] Error 2
     4163    make[1]: *** Waiting for unfinished jobs....
     4164    [  7%] Building CXX object tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangOptionDocEmitter.cpp.o
     4165    cd $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/utils/TableGen && $spack/lib/spack/env/gcc/g++ -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/utils/TableGen -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/utils/TableGen -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/include -I$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/libxml2-2.9.12-7jqzymjvos2b366hifprujd3egeil4ne/include/libxml2 -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/include -std=c++11 -fPIC -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-redundant-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -fno-strict-aliasing -O3 -DNDEBUG -std=c++14 -MD -MT tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangOptionDocEmitter.cpp.o -MF CMakeFiles/obj.clang-tblgen.dir/ClangOptionDocEmitter.cpp.o.d -o CMakeFiles/obj.clang-tblgen.dir/ClangOptionDocEmitter.cpp.o -c $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/utils/TableGen/ClangOptionDocEmitter.cpp
     4166    [  7%] Building CXX object tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangSACheckersEmitter.cpp.o
     4167    cd $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/utils/TableGen && $spack/lib/spack/env/gcc/g++ -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/utils/TableGen -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/utils/TableGen -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/tools/clang/include -I$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/libxml2-2.9.12-7jqzymjvos2b366hifprujd3egeil4ne/include/libxml2 -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-build-pe7cvut/include -I$stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/llvm/include -std=c++11 -fPIC -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-class-memaccess -Wno-redundant-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -fno-strict-aliasing -O3 -DNDEBUG -std=c++14 -MD -MT tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangSACheckersEmitter.cpp.o -MF CMakeFiles/obj.clang-tblgen.dir/ClangSACheckersEmitter.cpp.o.d -o CMakeFiles/obj.clang-tblgen.dir/ClangSACheckersEmitter.cpp.o -c $stage/spack-stage-llvm-11.1.0-pe7cvutgpdyy5xc5xjoclsp5fcgswbea/spack-src/clang/utils/TableGen/ClangSACheckersEmitter.cpp
     4168    [  7%] Building CXX object tools/clang/utils/TableGen/CMakeFiles/obj.clang-tblgen.dir/ClangTypeNodesEmitter.cpp.o
```