### PR TITLE
shtools: Disable libtool

### DIFF
--- a/var/spack/repos/builtin/packages/shtools/nolibtool.patch
+++ b/var/spack/repos/builtin/packages/shtools/nolibtool.patch
@@ -1,0 +1,16 @@
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -80,10 +80,10 @@
+ 	@echo "--> Compilation of source files successful"
+ 	@echo
+ 	@rm -f $(PROG)
+-	$(LIBTOOL) $(LIBTOOLFLAGS) -o $(PROG) $(OBJS)
++#	$(LIBTOOL) $(LIBTOOLFLAGS) -o $(PROG) $(OBJS)
+ #	If you prefer to use libtool, uncomment the above line, and comment the two lines below (AR and RLIB)
+-#	$(AR) $(ARFLAGS) $(PROG) $(OBJS)
+-#	$(RLIB) $(RLIBFLAGS) $(PROG)
++	$(AR) $(ARFLAGS) $(PROG) $(OBJS)
++	$(RLIB) $(RLIBFLAGS) $(PROG)
+ 	@echo
+ 	@echo "--> Creation of static library successful"
+ #	@rm -f $(OBJS)

--- a/var/spack/repos/builtin/packages/shtools/package.py
+++ b/var/spack/repos/builtin/packages/shtools/package.py
@@ -31,6 +31,11 @@ class Shtools(MakefilePackage):
     depends_on('blas')
     depends_on('fftw')
     depends_on('lapack')
+    depends_on('py-flake8', type='test')
+
+    def patch(self):
+        """make check fix: Silence "do not use bare 'except'" in number of files"""
+        filter_file('ignore=', 'ignore=E722,', 'Makefile')
 
     # Options for the Makefile
     def makeopts(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/shtools/package.py
+++ b/var/spack/repos/builtin/packages/shtools/package.py
@@ -14,12 +14,17 @@ class Shtools(MakefilePackage):
 
     maintainers = ['eschnett']
 
+    version('4.9.1', sha256='5c22064f9daf6e9aa08cace182146993aa6b25a6ea593d92572c59f4013d53c2')
     version('4.8', sha256='c36fc86810017e544abbfb12f8ddf6f101a1ac8b89856a76d7d9801ffc8dac44')
     version('4.5', sha256='1975a2a2bcef8c527d321be08c13c2bc479e0d6b81c468a3203f95df59be4f89')
 
     # Note: This package also provides Python wrappers. We do not
     # install these properly yet, only the Fortran library is
     # installed.
+
+    # The Makefile expects the "other" libtool, not the GNU libtool we have in
+    # Spack
+    patch('nolibtool.patch')
 
     variant('openmp', default=True, description="Enable OpenMP support")
 


### PR DESCRIPTION
The Makefile expects the "other" libtool, not the GNU libtool we have in Spack.

Also add new version 4.9.1.

Closes https://github.com/spack/spack/issues/26993