### PR TITLE
Upgrade STRUMPACK to 6.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -316,7 +316,7 @@ class Dealii(CMakePackage, CudaPackage):
         cxx_flags_release = []
         # Debug and release flags
         cxx_flags = []
-
+        options.append(self.define('DEAL_II_FORCE_BUNDLED_TBB',True))
         # Set directory structure:
         if spec.satisfies('@:8.2.1'):
             options.append(

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -25,6 +25,7 @@ class Dealii(CMakePackage, CudaPackage):
     generator = 'Ninja'
 
     version('master', branch='master')
+    version('9.3.2', branch='dealii-9.3')
     version('9.3.1', sha256='a62f4676ab2dc029892251d141427fb75cbb83cddd606019f615d0dde9c61ab8')
     version('9.3.0', sha256='aef8c7a87510ce827dfae3bdd4ed7bff82004dc09f96fa7a65b2554f2839b931')
     version('9.2.0', sha256='d05a82fb40f1f1e24407451814b5a6004e39366a44c81208b1ae9d65f3efa43a')

--- a/var/spack/repos/builtin/packages/sundials/package.py
+++ b/var/spack/repos/builtin/packages/sundials/package.py
@@ -290,6 +290,7 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
 
         if '+rocm' in spec:
             args.extend([
+                '-DCMAKE_C_COMPILER=%s' % (spec['llvm-amdgpu'].prefix+'/bin/clang'),
                 '-DCMAKE_CXX_COMPILER=%s' % spec['hip'].hipcc,
                 '-DENABLE_HIP=ON',
                 '-DHIP_PATH=%s' % spec['hip'].prefix,

--- a/var/spack/repos/builtin/packages/superlu-dist/package.py
+++ b/var/spack/repos/builtin/packages/superlu-dist/package.py
@@ -53,6 +53,7 @@ class SuperluDist(CMakePackage, CudaPackage):
 
     patch('xl-611.patch', when='@:6.1.1 %xl')
     patch('xl-611.patch', when='@:6.1.1 %xl_r')
+    patch('superlu-cray-ftn-case.patch', when='%cce')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/superlu-dist/superlu-cray-ftn-case.patch
+++ b/var/spack/repos/builtin/packages/superlu-dist/superlu-cray-ftn-case.patch
@@ -1,0 +1,15 @@
+diff --git a/FORTRAN/CMakeLists.txt b/FORTRAN/CMakeLists.txt
+index bf402a9..6a039e1 100644
+--- a/FORTRAN/CMakeLists.txt
++++ b/FORTRAN/CMakeLists.txt
+@@ -3,8 +3,8 @@ include_directories(${SuperLU_DIST_SOURCE_DIR}/SRC)
+ include_directories(${SuperLU_DIST_BINARY_DIR}/FORTRAN)
+ 
+ set(headers
+-    ${CMAKE_BINARY_DIR}/FORTRAN/superlu_mod.mod
+-    ${CMAKE_BINARY_DIR}/FORTRAN/superlupara_mod.mod
++  ${CMAKE_BINARY_DIR}/FORTRAN/SUPERLU_MOD.mod
++    ${CMAKE_BINARY_DIR}/FORTRAN/SUPERLUPARA_MOD.mod
+     ${CMAKE_BINARY_DIR}/FORTRAN/superlu_dist_config.fh
+     )
+ 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -39,6 +39,7 @@ class Trilinos(CMakePackage, CudaPackage):
 
     version('master', branch='master')
     version('develop', branch='develop')
+    version('13.2.0', commit='efad248a0ec610250682edf12cb0555fcff668c2')  # develop Oct 22
     version('13.0.1', commit='4796b92fb0644ba8c531dd9953e7a4878b05c62d')  # tag trilinos-release-13-0-1
     version('13.0.0', commit='9fec35276d846a667bc668ff4cbdfd8be0dfea08')  # tag trilinos-release-13-0-0
     version('12.18.1', commit='55a75997332636a28afc9db1aee4ae46fe8d93e7')  # tag trilinos-release-12-8-1

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -105,8 +105,8 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     variant('slate', default=True, description='Enable slate package build')
     variant('arborx', default=True, description='Enable ArborX build')
 
-    xsdk_depends_on('hypre@develop+superlu-dist+shared', when='@develop')
-    xsdk_depends_on('hypre@2.23.0+superlu-dist+shared', when='@0.7.0')
+    xsdk_depends_on('hypre@develop+superlu-dist+shared', when='@develop', cuda_var='cuda')
+    xsdk_depends_on('hypre@2.23.0+superlu-dist+shared', when='@0.7.0', cuda_var='cuda')
     xsdk_depends_on('hypre@2.20.0+superlu-dist+shared', when='@0.6.0')
     xsdk_depends_on('hypre@2.18.2+superlu-dist+shared', when='@0.5.0')
     xsdk_depends_on('hypre@2.15.1~internal-superlu', when='@0.4.0')

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -20,6 +20,7 @@ class Xsdk(BundlePackage):
     maintainers = ['balay', 'luszczek']
 
     version('develop')
+    version('0.7.0')
     version('0.6.0')
     version('0.5.0')
     version('0.4.0', deprecated=True)
@@ -44,18 +45,21 @@ class Xsdk(BundlePackage):
     variant('arborx', default=True, description='Enable ArborX build')
 
     depends_on('hypre@develop+superlu-dist+shared', when='@develop')
+    depends_on('hypre@2.23.0+superlu-dist+shared', when='@0.7.0')
     depends_on('hypre@2.20.0+superlu-dist+shared', when='@0.6.0')
     depends_on('hypre@2.18.2+superlu-dist+shared', when='@0.5.0')
     depends_on('hypre@2.15.1~internal-superlu', when='@0.4.0')
     depends_on('hypre@2.12.1~internal-superlu', when='@0.3.0')
 
     depends_on('mfem@develop+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@develop')
+    depends_on('mfem@4.3.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.7.0')
     depends_on('mfem@4.2.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.6.0')
     depends_on('mfem@4.0.1-xsdk+mpi~superlu-dist+petsc+sundials+examples+miniapps', when='@0.5.0')
     depends_on('mfem@3.4.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.4.0')
     depends_on('mfem@3.3.2+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.3.0')
 
     depends_on('superlu-dist@develop', when='@develop')
+    depends_on('superlu-dist@7.1.1', when='@0.7.0')
     depends_on('superlu-dist@6.4.0', when='@0.6.0')
     depends_on('superlu-dist@6.1.1', when='@0.5.0')
     depends_on('superlu-dist@6.1.0', when='@0.4.0')
@@ -63,6 +67,8 @@ class Xsdk(BundlePackage):
 
     depends_on('trilinos@develop+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards+stratimikos gotype=int cxxstd=14',
                when='@develop +trilinos')
+    depends_on('trilinos@13.2.0+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards+stratimikos gotype=int cxxstd=14',
+               when='@0.7.0 +trilinos')
     depends_on('trilinos@13.0.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards gotype=int',
                when='@0.6.0 +trilinos')
     depends_on('trilinos@12.18.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
@@ -73,13 +79,17 @@ class Xsdk(BundlePackage):
                when='@0.3.0 +trilinos')
 
     depends_on('datatransferkit@master', when='@develop +trilinos +datatransferkit')
+    dtk7ver = '3.1-rc2' if sys.platform == 'darwin' else '3.1-rc3'
+    depends_on('datatransferkit@'+dtk7ver, when='@0.7.0 +trilinos +datatransferkit')
     depends_on('datatransferkit@3.1-rc2', when='@0.6.0 +trilinos +datatransferkit')
 
-    depends_on('petsc +trilinos', when='+trilinos')
+    depends_on('petsc +trilinos', when='+trilinos @:0.6.0')
     depends_on('petsc +cuda', when='+cuda @0.6.0:')
     depends_on('petsc +batch', when='platform=cray @0.5.0:')
     depends_on('petsc@main+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
                when='@develop')
+    depends_on('petsc@3.16.0+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+               when='@0.7.0')
     depends_on('petsc@3.14.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
                when='@0.6.0')
     depends_on('petsc@3.12.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
@@ -91,18 +101,21 @@ class Xsdk(BundlePackage):
 
     depends_on('dealii +trilinos~adol-c', when='+trilinos +dealii')
     depends_on('dealii ~trilinos', when='~trilinos +dealii')
-    depends_on('dealii@master~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~nanoflann', when='@develop +dealii')
+    depends_on('dealii@master~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~nanoflann~simplex~arborx', when='@develop +dealii')
+    depends_on('dealii@9.3.2~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~simplex~arborx', when='@0.7.0 +dealii')
     depends_on('dealii@9.2.0~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~simplex~arborx', when='@0.6.0 +dealii')
     depends_on('dealii@9.1.1~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine', when='@0.5.0 +dealii')
     depends_on('dealii@9.0.1~assimp~python~doc~gmsh+petsc~slepc+mpi~int64+hdf5~netcdf+metis~ginkgo~symengine', when='@0.4.0 +dealii')
 
     depends_on('pflotran@develop', when='@develop')
+    depends_on('pflotran@3.0.2', when='@0.7.0')
     depends_on('pflotran@xsdk-0.6.0', when='@0.6.0')
     depends_on('pflotran@xsdk-0.5.0', when='@0.5.0')
     depends_on('pflotran@xsdk-0.4.0', when='@0.4.0')
     depends_on('pflotran@xsdk-0.3.0', when='@0.3.0')
 
     depends_on('alquimia@develop', when='@develop +alquimia')
+    depends_on('alquimia@1.0.9', when='@0.7.0 +alquimia')
     depends_on('alquimia@xsdk-0.6.0', when='@0.6.0 +alquimia')
     depends_on('alquimia@xsdk-0.5.0', when='@0.5.0 +alquimia ')
     depends_on('alquimia@xsdk-0.4.0', when='@0.4.0 +alquimia')
@@ -111,17 +124,20 @@ class Xsdk(BundlePackage):
     depends_on('sundials +cuda', when='+cuda @0.6.0:')
     depends_on('sundials +trilinos', when='+trilinos @0.6.0:')
     depends_on('sundials@develop~int64+hypre+petsc+superlu-dist', when='@develop')
+    depends_on('sundials@5.8.0~int64+hypre+petsc+superlu-dist', when='@0.7.0')
     depends_on('sundials@5.5.0~int64+hypre+petsc+superlu-dist', when='@0.6.0')
     depends_on('sundials@5.0.0~int64+hypre+petsc+superlu-dist', when='@0.5.0')
     depends_on('sundials@3.2.1~int64+hypre', when='@0.4.0')
     depends_on('sundials@3.1.0~int64+hypre', when='@0.3.0')
 
-    depends_on('plasma@20.9.20:', when='@develop %gcc@6.0:')
+    depends_on('plasma@develop:', when='@develop %gcc@6.0:')
+    depends_on('plasma@21.8.29:', when='@0.7.0 %gcc@6.0:')
     depends_on('plasma@20.9.20:', when='@0.6.0 %gcc@6.0:')
     depends_on('plasma@19.8.1:', when='@0.5.0 %gcc@6.0:')
     depends_on('plasma@18.11.1:', when='@0.4.0 %gcc@6.0:')
 
-    depends_on('magma@2.5.4', when='@develop +cuda')
+    depends_on('magma@master', when='@develop +cuda')
+    depends_on('magma@2.6.1', when='@0.7.0 +cuda')
     depends_on('magma@2.5.4', when='@0.6.0 +cuda')
     depends_on('magma@2.5.1', when='@0.5.0 +cuda')
     depends_on('magma@2.4.0', when='@0.4.0 +cuda')
@@ -129,6 +145,8 @@ class Xsdk(BundlePackage):
 
     depends_on('amrex@develop', when='@develop %intel')
     depends_on('amrex@develop', when='@develop %gcc')
+    depends_on('amrex@21.10', when='@0.7.0 %intel')
+    depends_on('amrex@21.10', when='@0.7.0 %gcc')
     depends_on('amrex@20.10', when='@0.6.0 %intel')
     depends_on('amrex@20.10', when='@0.6.0 %gcc')
     depends_on('amrex@19.08', when='@0.5.0 %intel')
@@ -137,6 +155,7 @@ class Xsdk(BundlePackage):
     depends_on('amrex@18.10.1', when='@0.4.0 %gcc')
 
     depends_on('slepc@main', when='@develop')
+    depends_on('slepc@3.16.0', when='@0.7.0')
     depends_on('slepc@3.14.0', when='@0.6.0')
     depends_on('slepc@3.12.0', when='@0.5.0')
     depends_on('slepc@3.10.1', when='@0.4.0')
@@ -144,17 +163,20 @@ class Xsdk(BundlePackage):
     depends_on('omega-h +trilinos', when='+trilinos +omega-h')
     depends_on('omega-h ~trilinos', when='~trilinos +omega-h')
     depends_on('omega-h@main', when='@develop +omega-h')
+    depends_on('omega-h@9.34.1', when='@0.7.0 +omega-h')
     depends_on('omega-h@9.32.5', when='@0.6.0 +omega-h')
     depends_on('omega-h@9.29.0', when='@0.5.0 +omega-h')
     depends_on('omega-h@9.19.1', when='@0.4.0 +omega-h')
 
     depends_on('strumpack ~cuda', when='~cuda @0.6.0: +strumpack')
     depends_on('strumpack@master~slate~openmp', when='@develop +strumpack')
+    depends_on('strumpack@6.0.0~slate~openmp', when='@0.7.0 +strumpack')
     depends_on('strumpack@5.0.0~slate~openmp', when='@0.6.0 +strumpack')
     depends_on('strumpack@3.3.0~slate~openmp', when='@0.5.0 +strumpack')
     depends_on('strumpack@3.1.1~slate~openmp', when='@0.4.0 +strumpack')
 
     depends_on('pumi@master', when='@develop')
+    depends_on('pumi@2.2.6', when='@0.7.0')
     depends_on('pumi@2.2.5', when='@0.6.0')
     depends_on('pumi@2.2.1', when='@0.5.0')
     depends_on('pumi@2.2.0', when='@0.4.0')
@@ -162,6 +184,8 @@ class Xsdk(BundlePackage):
     tasmanian_openmp = '~openmp' if sys.platform == 'darwin' else '+openmp'
     depends_on('tasmanian@develop+xsdkflags+blas' + tasmanian_openmp, when='@develop')
     depends_on('tasmanian@develop+xsdkflags+blas+cuda+magma' + tasmanian_openmp, when='@develop +cuda')
+    depends_on('tasmanian@7.7+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.7.0')
+    depends_on('tasmanian@7.7+xsdkflags+mpi+blas+cuda+magma' + tasmanian_openmp, when='@0.7.0 +cuda')
     depends_on('tasmanian@7.3+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.6.0')
     depends_on('tasmanian@7.3+xsdkflags+mpi+blas+cuda+magma' + tasmanian_openmp, when='@0.6.0 +cuda')
     depends_on('tasmanian@7.0+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.5.0')
@@ -169,7 +193,8 @@ class Xsdk(BundlePackage):
     depends_on('tasmanian@6.0+xsdkflags+blas~openmp', when='@0.4.0')
     depends_on('tasmanian@6.0+xsdkflags+blas+cuda+magma~openmp', when='@0.4.0 +cuda')
 
-    depends_on('arborx@1.0', when='@develop +arborx')
+    depends_on('arborx@master', when='@develop +arborx')
+    depends_on('arborx@1.1', when='@0.7.0 +arborx')
 
     # the Fortran 2003 bindings of phist require python@3:, but this
     # creates a conflict with other packages like petsc@main. Actually
@@ -180,12 +205,15 @@ class Xsdk(BundlePackage):
     depends_on('phist kernel_lib=tpetra', when='+trilinos +phist')
     depends_on('phist kernel_lib=petsc', when='~trilinos +phist')
     depends_on('phist@develop ~fortran ~scamac ~openmp ~host ~int64', when='@develop +phist')
+    depends_on('phist@1.9.5 ~fortran ~scamac ~openmp ~host ~int64', when='@0.7.0 +phist')
     depends_on('phist@1.9.3 ~fortran ~scamac ~openmp ~host ~int64', when='@0.6.0 +phist')
     depends_on('phist@1.8.0 ~fortran ~scamac ~openmp ~host ~int64', when='@0.5.0 +phist')
     depends_on('phist@1.7.5 ~fortran ~scamac ~openmp ~host ~int64', when='@0.4.0 +phist')
 
     depends_on('ginkgo@develop ~openmp', when='@develop +ginkgo')
     depends_on('ginkgo@develop ~openmp+cuda', when='@develop +ginkgo +cuda')
+    depends_on('ginkgo@1.4.0 ~openmp', when='@0.7.0 +ginkgo')
+    depends_on('ginkgo@1.4.0 ~openmp+cuda', when='@0.7.0 +cuda +ginkgo')
     depends_on('ginkgo@1.3.0 ~openmp', when='@0.6.0 +ginkgo')
     depends_on('ginkgo@1.3.0 ~openmp+cuda', when='@0.6.0 +cuda +ginkgo')
     depends_on('ginkgo@1.1.0 ~openmp', when='@0.5.0 +ginkgo')
@@ -193,6 +221,8 @@ class Xsdk(BundlePackage):
 
     depends_on('py-libensemble@develop+petsc4py', type='run', when='@develop +libensemble')
     depends_on('py-petsc4py@main', type='run', when='@develop +libensemble')
+    depends_on('py-libensemble@0.8.0+petsc4py', type='run', when='@0.7.0 +libensemble')
+    depends_on('py-petsc4py@3.16.0', type='run', when='@0.7.0 +libensemble')
     depends_on('py-libensemble@0.7.1+petsc4py', type='run', when='@0.6.0 +libensemble')
     depends_on('py-petsc4py@3.14.0', type='run', when='@0.6.0 +libensemble')
     depends_on('py-libensemble@0.5.2+petsc4py', type='run', when='@0.5.0 +libensemble')
@@ -200,20 +230,24 @@ class Xsdk(BundlePackage):
 
     depends_on('precice ~petsc', when='platform=cray +precice')
     depends_on('precice@develop', when='@develop +precice')
+    depends_on('precice@2.3.0', when='@0.7.0 +precice')
     depends_on('precice@2.1.1', when='@0.6.0 +precice')
     depends_on('precice@1.6.1', when='@0.5.0 +precice')
 
     depends_on('butterflypack@master', when='@develop +butterflypack')
+    depends_on('butterflypack@2.0.0', when='@0.7.0 +butterflypack')
     depends_on('butterflypack@1.2.1', when='@0.6.0 +butterflypack')
     depends_on('butterflypack@1.1.0', when='@0.5.0 +butterflypack')
 
     depends_on('heffte +fftw+cuda+magma', when='+cuda +heffte')
     depends_on('openmpi +cuda', when='+cuda +heffte')
     depends_on('heffte@develop+fftw', when='@develop +heffte')
+    depends_on('heffte@2.2.0+fftw', when='@0.7.0 +heffte')
     depends_on('heffte@2.0.0+fftw', when='@0.6.0 +heffte')
 
     depends_on('slate@master ~cuda', when='@develop ~cuda +slate %gcc@6.0:')
     depends_on('slate@master +cuda', when='@develop +cuda +slate %gcc@6.0:')
+    depends_on('slate@2021.05.02 ~cuda', when='@0.7.0 ~cuda +slate %gcc@6.0:')
     depends_on('slate@2020.10.00 ~cuda', when='@0.6.0 ~cuda +slate %gcc@6.0:')
     depends_on('slate@2020.10.00 +cuda', when='@0.6.0 +cuda +slate %gcc@6.0:')
 

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -7,17 +7,101 @@
 import sys
 
 from spack import *
+from copy import deepcopy
 
 
-class Xsdk(BundlePackage):
+def depends_on_cuda(cuda_var, *args, **kwargs):
+    # require ~cuda when xsdk~cuda
+    if not isinstance(cuda_var, list):
+        cuda_var = [cuda_var]
+    args_new = list(deepcopy(args))
+    for idx, var in enumerate(cuda_var):
+        # skip variants starting with '?' so that
+        # that that they are left unspecified by xsdk
+        if not var.startswith('?'):
+            args_new[0] += ' ~%s' % var
+        else:
+            cuda_var[idx] = var.replace('?', '')
+    kwargs_new = deepcopy(kwargs)
+    if 'when' in kwargs_new:
+        kwargs_new['when'] += ' ~cuda'
+    else:
+        kwargs_new['when'] = '~cuda'
+    depends_on(*args_new, **kwargs_new)
+
+    # require +cuda when xsdk+cuda, and match the arch
+    for arch in CudaPackage.cuda_arch_values:
+        args_new = list(deepcopy(args))
+        kwargs_new = deepcopy(kwargs)
+        args_new[0] += '+%s cuda_arch=%s' % ('+'.join(cuda_var), arch)
+        if 'when' in kwargs_new:
+            kwargs_new['when'] += ' +cuda cuda_arch=%s' % arch
+        else:
+            kwargs_new['when'] = '+cuda cuda_arch=%s' % arch
+        depends_on(*args_new, **kwargs_new)
+
+
+def depends_on_rocm(rocm_var, *args, **kwargs):
+    # require ~rocm when xsdk~rocm
+    args_new = list(deepcopy(args))
+    if not isinstance(rocm_var, list):
+        rocm_var = [rocm_var]
+    for idx, var in enumerate(rocm_var):
+        # skip variants starting with '?' so that
+        # that that they are left unspecified by xsdk
+        if not var.startswith('?'):
+            args_new[0] += ' ~%s' % var
+        else:
+            rocm_var[idx] = var.replace('?', '')
+    kwargs_new = deepcopy(kwargs)
+    if 'when' in kwargs_new:
+        kwargs_new['when'] += ' ~rocm'
+    else:
+        kwargs_new['when'] = '~rocm'
+    depends_on(*args_new, **kwargs_new)
+
+    # require +rocm when xsdk+rocm, and match the target
+    for tgt in ROCmPackage.amdgpu_targets:
+        args_new = list(deepcopy(args))
+        kwargs_new = deepcopy(kwargs)
+        args_new[0] += ' +%s amdgpu_target=%s' % ('+'.join(rocm_var), tgt)
+        if 'when' in kwargs_new:
+            kwargs_new['when'] += ' +rocm amdgpu_target=%s' % tgt
+        else:
+            kwargs_new['when'] = '+rocm amdgpu_target=%s' % tgt
+        depends_on(*args_new, **kwargs_new)
+
+
+class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
     """Xsdk is a suite of Department of Energy (DOE) packages for numerical
        simulation. This is a Spack bundle package that installs the xSDK
        packages
     """
 
     homepage = "https://xsdk.info"
+    maintainers = ['balay', 'luszczek', 'balos1']
 
-    maintainers = ['balay', 'luszczek']
+    def xsdk_depends_on(*args, cuda_var='', rocm_var='', **kwargs):
+        """
+        Wrapper for depends_on which can handle propagating cuda and rocm
+        variants.
+
+        Currently, it propagates +cuda_var when xsdk+cuda and rocm_var
+        when xsdk+rocm. When xsdk~[cuda|rocm], then ~[cuda|rocm]_var is
+        selected unless the variant string is prefixed with a '?'
+        (see the tasmanian use below). When '?' prefix is used, then
+        the variant is left unspecified.
+
+        [cuda|rocm]_var can be an array of variant strings or just a single
+        variant string. The spack '+' and '~' symbols should not appear
+        in the strings.
+        """
+        if bool(cuda_var):
+            depends_on_cuda(cuda_var, *args, **kwargs)
+        if bool(rocm_var):
+            depends_on_rocm(rocm_var, *args, **kwargs)
+        else:
+            depends_on(*args, **kwargs)
 
     version('develop')
     version('0.7.0')
@@ -27,7 +111,6 @@ class Xsdk(BundlePackage):
     version('0.3.0', deprecated=True)
 
     variant('debug', default=False, description='Compile in debug mode')
-    variant('cuda', default=False, description='Enable CUDA dependent packages')
     variant('trilinos', default=True, description='Enable trilinos package build')
     variant('datatransferkit', default=True, description='Enable datatransferkit package build')
     variant('omega-h', default=True, description='Enable omega-h package build')
@@ -44,157 +127,153 @@ class Xsdk(BundlePackage):
     variant('slate', default=True, description='Enable slate package build')
     variant('arborx', default=True, description='Enable ArborX build')
 
-    depends_on('hypre@develop+superlu-dist+shared', when='@develop')
-    depends_on('hypre@2.23.0+superlu-dist+shared', when='@0.7.0')
-    depends_on('hypre@2.20.0+superlu-dist+shared', when='@0.6.0')
-    depends_on('hypre@2.18.2+superlu-dist+shared', when='@0.5.0')
-    depends_on('hypre@2.15.1~internal-superlu', when='@0.4.0')
-    depends_on('hypre@2.12.1~internal-superlu', when='@0.3.0')
+    xsdk_depends_on('hypre@develop+superlu-dist+shared', when='@develop')
+    xsdk_depends_on('hypre@2.23.0+superlu-dist+shared', when='@0.7.0')
+    xsdk_depends_on('hypre@2.20.0+superlu-dist+shared', when='@0.6.0')
+    xsdk_depends_on('hypre@2.18.2+superlu-dist+shared', when='@0.5.0')
+    xsdk_depends_on('hypre@2.15.1~internal-superlu', when='@0.4.0')
+    xsdk_depends_on('hypre@2.12.1~internal-superlu', when='@0.3.0')
 
-    depends_on('mfem@develop+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@develop')
-    depends_on('mfem@4.3.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.7.0')
-    depends_on('mfem@4.2.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.6.0')
-    depends_on('mfem@4.0.1-xsdk+mpi~superlu-dist+petsc+sundials+examples+miniapps', when='@0.5.0')
-    depends_on('mfem@3.4.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.4.0')
-    depends_on('mfem@3.3.2+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.3.0')
+    xsdk_depends_on('mfem@develop+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@develop', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('mfem@4.3.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.7.0', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('mfem@4.2.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.6.0', cuda_var='cuda')
+    xsdk_depends_on('mfem@4.0.1-xsdk+mpi~superlu-dist+petsc+sundials+examples+miniapps', when='@0.5.0')
+    xsdk_depends_on('mfem@3.4.0+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.4.0')
+    xsdk_depends_on('mfem@3.3.2+mpi+superlu-dist+petsc+sundials+examples+miniapps', when='@0.3.0')
 
-    depends_on('superlu-dist@develop', when='@develop')
-    depends_on('superlu-dist@7.1.1', when='@0.7.0')
-    depends_on('superlu-dist@6.4.0', when='@0.6.0')
-    depends_on('superlu-dist@6.1.1', when='@0.5.0')
-    depends_on('superlu-dist@6.1.0', when='@0.4.0')
-    depends_on('superlu-dist@5.2.2', when='@0.3.0')
+    xsdk_depends_on('superlu-dist@develop', when='@develop')
+    xsdk_depends_on('superlu-dist@7.1.1', when='@0.7.0')
+    xsdk_depends_on('superlu-dist@6.4.0', when='@0.6.0')
+    xsdk_depends_on('superlu-dist@6.1.1', when='@0.5.0')
+    xsdk_depends_on('superlu-dist@6.1.0', when='@0.4.0')
+    xsdk_depends_on('superlu-dist@5.2.2', when='@0.3.0')
 
-    depends_on('trilinos@develop+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards+stratimikos gotype=int cxxstd=14',
-               when='@develop +trilinos')
-    depends_on('trilinos@13.2.0+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards+stratimikos gotype=int cxxstd=14',
-               when='@0.7.0 +trilinos')
-    depends_on('trilinos@13.0.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards gotype=int',
-               when='@0.6.0 +trilinos')
-    depends_on('trilinos@12.18.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
-               when='@0.5.0 +trilinos')
-    depends_on('trilinos@12.14.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
-               when='@0.4.0 +trilinos')
-    depends_on('trilinos@12.12.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan~zoltan2~amesos2~exodus',
-               when='@0.3.0 +trilinos')
+    xsdk_depends_on('trilinos@develop+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards+stratimikos gotype=int cxxstd=14',
+                    when='@develop +trilinos')
+    xsdk_depends_on('trilinos@13.2.0+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards+stratimikos gotype=int cxxstd=14',
+                    when='@0.7.0 +trilinos')
+    xsdk_depends_on('trilinos@13.0.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus~dtk+intrepid2+shards gotype=int',
+                    when='@0.6.0 +trilinos')
+    xsdk_depends_on('trilinos@12.18.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
+                    when='@0.5.0 +trilinos')
+    xsdk_depends_on('trilinos@12.14.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse+tpetra+nox+ifpack2+zoltan+zoltan2+amesos2~exodus+dtk+intrepid2+shards',
+                    when='@0.4.0 +trilinos')
+    xsdk_depends_on('trilinos@12.12.1+hypre+superlu-dist+hdf5~mumps+boost~suite-sparse~tpetra~ifpack2~zoltan~zoltan2~amesos2~exodus',
+                    when='@0.3.0 +trilinos')
 
-    depends_on('datatransferkit@master', when='@develop +trilinos +datatransferkit')
+    xsdk_depends_on('datatransferkit@master', when='@develop +trilinos +datatransferkit')
     dtk7ver = '3.1-rc2' if sys.platform == 'darwin' else '3.1-rc3'
-    depends_on('datatransferkit@'+dtk7ver, when='@0.7.0 +trilinos +datatransferkit')
-    depends_on('datatransferkit@3.1-rc2', when='@0.6.0 +trilinos +datatransferkit')
+    xsdk_depends_on('datatransferkit@'+dtk7ver, when='@0.7.0 +trilinos +datatransferkit')
+    xsdk_depends_on('datatransferkit@3.1-rc2', when='@0.6.0 +trilinos +datatransferkit')
 
-    depends_on('petsc +trilinos', when='+trilinos @:0.6.0')
-    depends_on('petsc +cuda', when='+cuda @0.6.0:')
-    depends_on('petsc +batch', when='platform=cray @0.5.0:')
-    depends_on('petsc@main+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
-               when='@develop')
-    depends_on('petsc@3.16.0+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
-               when='@0.7.0')
-    depends_on('petsc@3.14.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
-               when='@0.6.0')
-    depends_on('petsc@3.12.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
-               when='@0.5.0')
-    depends_on('petsc@3.10.3+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
-               when='@0.4.0')
-    depends_on('petsc@3.8.2+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
-               when='@0.3.0')
+    xsdk_depends_on('petsc +trilinos', when='+trilinos @:0.6.0')
+    xsdk_depends_on('petsc +batch', when='platform=cray @0.5.0:')
+    xsdk_depends_on('petsc@main+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+                    when='@develop', cuda_var='cuda')
+    xsdk_depends_on('petsc@3.16.0+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+                    when='@0.7.0', cuda_var='cuda')
+    xsdk_depends_on('petsc@3.14.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+                    when='@0.6.0', cuda_var='cuda')
+    xsdk_depends_on('petsc@3.12.1+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+                    when='@0.5.0')
+    xsdk_depends_on('petsc@3.10.3+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+                    when='@0.4.0')
+    xsdk_depends_on('petsc@3.8.2+mpi+hypre+superlu-dist+metis+hdf5~mumps+double~int64',
+                    when='@0.3.0')
 
-    depends_on('dealii +trilinos~adol-c', when='+trilinos +dealii')
-    depends_on('dealii ~trilinos', when='~trilinos +dealii')
-    depends_on('dealii@master~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~nanoflann~simplex~arborx', when='@develop +dealii')
-    depends_on('dealii@9.3.2~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~simplex~arborx', when='@0.7.0 +dealii')
-    depends_on('dealii@9.2.0~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~simplex~arborx', when='@0.6.0 +dealii')
-    depends_on('dealii@9.1.1~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine', when='@0.5.0 +dealii')
-    depends_on('dealii@9.0.1~assimp~python~doc~gmsh+petsc~slepc+mpi~int64+hdf5~netcdf+metis~ginkgo~symengine', when='@0.4.0 +dealii')
+    xsdk_depends_on('dealii +trilinos~adol-c', when='+trilinos +dealii')
+    xsdk_depends_on('dealii ~trilinos', when='~trilinos +dealii')
+    xsdk_depends_on('dealii@master~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~nanoflann~simplex~arborx', when='@develop +dealii')
+    xsdk_depends_on('dealii@9.3.2~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~simplex~arborx', when='@0.7.0 +dealii')
+    xsdk_depends_on('dealii@9.2.0~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine~simplex~arborx', when='@0.6.0 +dealii')
+    xsdk_depends_on('dealii@9.1.1~assimp~python~doc~gmsh+petsc+slepc+mpi~int64+hdf5~netcdf+metis~sundials~ginkgo~symengine', when='@0.5.0 +dealii')
+    xsdk_depends_on('dealii@9.0.1~assimp~python~doc~gmsh+petsc~slepc+mpi~int64+hdf5~netcdf+metis~ginkgo~symengine', when='@0.4.0 +dealii')
 
-    depends_on('pflotran@develop', when='@develop')
-    depends_on('pflotran@3.0.2', when='@0.7.0')
-    depends_on('pflotran@xsdk-0.6.0', when='@0.6.0')
-    depends_on('pflotran@xsdk-0.5.0', when='@0.5.0')
-    depends_on('pflotran@xsdk-0.4.0', when='@0.4.0')
-    depends_on('pflotran@xsdk-0.3.0', when='@0.3.0')
+    xsdk_depends_on('pflotran@develop', when='@develop')
+    xsdk_depends_on('pflotran@3.0.2', when='@0.7.0')
+    xsdk_depends_on('pflotran@xsdk-0.6.0', when='@0.6.0')
+    xsdk_depends_on('pflotran@xsdk-0.5.0', when='@0.5.0')
+    xsdk_depends_on('pflotran@xsdk-0.4.0', when='@0.4.0')
+    xsdk_depends_on('pflotran@xsdk-0.3.0', when='@0.3.0')
 
-    depends_on('alquimia@develop', when='@develop +alquimia')
-    depends_on('alquimia@1.0.9', when='@0.7.0 +alquimia')
-    depends_on('alquimia@xsdk-0.6.0', when='@0.6.0 +alquimia')
-    depends_on('alquimia@xsdk-0.5.0', when='@0.5.0 +alquimia ')
-    depends_on('alquimia@xsdk-0.4.0', when='@0.4.0 +alquimia')
-    depends_on('alquimia@xsdk-0.3.0', when='@0.3.0 +alquimia')
+    xsdk_depends_on('alquimia@develop', when='@develop +alquimia')
+    xsdk_depends_on('alquimia@1.0.9', when='@0.7.0 +alquimia')
+    xsdk_depends_on('alquimia@xsdk-0.6.0', when='@0.6.0 +alquimia')
+    xsdk_depends_on('alquimia@xsdk-0.5.0', when='@0.5.0 +alquimia ')
+    xsdk_depends_on('alquimia@xsdk-0.4.0', when='@0.4.0 +alquimia')
+    xsdk_depends_on('alquimia@xsdk-0.3.0', when='@0.3.0 +alquimia')
 
-    depends_on('sundials +cuda', when='+cuda @0.6.0:')
-    depends_on('sundials +trilinos', when='+trilinos @0.6.0:')
-    depends_on('sundials@develop~int64+hypre+petsc+superlu-dist', when='@develop')
-    depends_on('sundials@5.8.0~int64+hypre+petsc+superlu-dist', when='@0.7.0')
-    depends_on('sundials@5.5.0~int64+hypre+petsc+superlu-dist', when='@0.6.0')
-    depends_on('sundials@5.0.0~int64+hypre+petsc+superlu-dist', when='@0.5.0')
-    depends_on('sundials@3.2.1~int64+hypre', when='@0.4.0')
-    depends_on('sundials@3.1.0~int64+hypre', when='@0.3.0')
+    xsdk_depends_on('sundials +trilinos', when='+trilinos @0.6.0:')
+    xsdk_depends_on('sundials@develop~int64+hypre+petsc+superlu-dist', when='@develop', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('sundials@5.8.0~int64+hypre+petsc+superlu-dist', when='@0.7.0', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('sundials@5.5.0~int64+hypre+petsc+superlu-dist', when='@0.6.0', cuda_var='cuda')
+    xsdk_depends_on('sundials@5.0.0~int64+hypre+petsc+superlu-dist', when='@0.5.0')
+    xsdk_depends_on('sundials@3.2.1~int64+hypre', when='@0.4.0')
+    xsdk_depends_on('sundials@3.1.0~int64+hypre', when='@0.3.0')
 
-    depends_on('plasma@develop:', when='@develop %gcc@6.0:')
-    depends_on('plasma@21.8.29:', when='@0.7.0 %gcc@6.0:')
-    depends_on('plasma@20.9.20:', when='@0.6.0 %gcc@6.0:')
-    depends_on('plasma@19.8.1:', when='@0.5.0 %gcc@6.0:')
-    depends_on('plasma@18.11.1:', when='@0.4.0 %gcc@6.0:')
+    xsdk_depends_on('plasma@develop:', when='@develop %gcc@6.0:')
+    xsdk_depends_on('plasma@21.8.29:', when='@0.7.0 %gcc@6.0:')
+    xsdk_depends_on('plasma@20.9.20:', when='@0.6.0 %gcc@6.0:')
+    xsdk_depends_on('plasma@19.8.1:', when='@0.5.0 %gcc@6.0:')
+    xsdk_depends_on('plasma@18.11.1:', when='@0.4.0 %gcc@6.0:')
 
-    depends_on('magma@master', when='@develop +cuda')
-    depends_on('magma@2.6.1', when='@0.7.0 +cuda')
-    depends_on('magma@2.5.4', when='@0.6.0 +cuda')
-    depends_on('magma@2.5.1', when='@0.5.0 +cuda')
-    depends_on('magma@2.4.0', when='@0.4.0 +cuda')
-    depends_on('magma@2.2.0', when='@0.3.0 +cuda')
+    xsdk_depends_on('magma@master', when='@develop', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('magma@2.6.1', when='@0.7.0', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('magma@2.5.4', when='@0.6.0', cuda_var='cuda')
+    xsdk_depends_on('magma@2.5.1', when='@0.5.0', cuda_var='cuda')
+    xsdk_depends_on('magma@2.4.0', when='@0.4.0', cuda_var='cuda')
+    xsdk_depends_on('magma@2.2.0', when='@0.3.0', cuda_var='cuda')
 
-    depends_on('amrex@develop', when='@develop %intel')
-    depends_on('amrex@develop', when='@develop %gcc')
-    depends_on('amrex@21.10', when='@0.7.0 %intel')
-    depends_on('amrex@21.10', when='@0.7.0 %gcc')
-    depends_on('amrex@20.10', when='@0.6.0 %intel')
-    depends_on('amrex@20.10', when='@0.6.0 %gcc')
-    depends_on('amrex@19.08', when='@0.5.0 %intel')
-    depends_on('amrex@19.08', when='@0.5.0 %gcc')
-    depends_on('amrex@18.10.1', when='@0.4.0 %intel')
-    depends_on('amrex@18.10.1', when='@0.4.0 %gcc')
+    xsdk_depends_on('amrex@develop+sundials', when='@develop %intel', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('amrex@develop+sundials', when='@develop %gcc', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('amrex@develop+sundials', when='@develop %cce', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('amrex@21.10+sundials', when='@0.7.0 %intel', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('amrex@21.10+sundials', when='@0.7.0 %gcc', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('amrex@21.10+sundials', when='@0.7.0 %cce', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('amrex@20.10', when='@0.6.0 %intel')
+    xsdk_depends_on('amrex@20.10', when='@0.6.0 %gcc')
+    xsdk_depends_on('amrex@19.08', when='@0.5.0 %intel')
+    xsdk_depends_on('amrex@19.08', when='@0.5.0 %gcc')
+    xsdk_depends_on('amrex@18.10.1', when='@0.4.0 %intel')
+    xsdk_depends_on('amrex@18.10.1', when='@0.4.0 %gcc')
 
-    depends_on('slepc@main', when='@develop')
-    depends_on('slepc@3.16.0', when='@0.7.0')
-    depends_on('slepc@3.14.0', when='@0.6.0')
-    depends_on('slepc@3.12.0', when='@0.5.0')
-    depends_on('slepc@3.10.1', when='@0.4.0')
+    xsdk_depends_on('slepc@main', when='@develop')
+    xsdk_depends_on('slepc@3.16.0', when='@0.7.0')
+    xsdk_depends_on('slepc@3.14.0', when='@0.6.0')
+    xsdk_depends_on('slepc@3.12.0', when='@0.5.0')
+    xsdk_depends_on('slepc@3.10.1', when='@0.4.0')
 
-    depends_on('omega-h +trilinos', when='+trilinos +omega-h')
-    depends_on('omega-h ~trilinos', when='~trilinos +omega-h')
-    depends_on('omega-h@main', when='@develop +omega-h')
-    depends_on('omega-h@9.34.1', when='@0.7.0 +omega-h')
-    depends_on('omega-h@9.32.5', when='@0.6.0 +omega-h')
-    depends_on('omega-h@9.29.0', when='@0.5.0 +omega-h')
-    depends_on('omega-h@9.19.1', when='@0.4.0 +omega-h')
+    xsdk_depends_on('omega-h +trilinos', when='+trilinos +omega-h')
+    xsdk_depends_on('omega-h ~trilinos', when='~trilinos +omega-h')
+    xsdk_depends_on('omega-h@main', when='@develop +omega-h')
+    xsdk_depends_on('omega-h@9.34.1', when='@0.7.0 +omega-h')
+    xsdk_depends_on('omega-h@9.32.5', when='@0.6.0 +omega-h')
+    xsdk_depends_on('omega-h@9.29.0', when='@0.5.0 +omega-h')
+    xsdk_depends_on('omega-h@9.19.1', when='@0.4.0 +omega-h')
 
-    depends_on('strumpack ~cuda', when='~cuda @0.6.0: +strumpack')
-    depends_on('strumpack@master~slate~openmp', when='@develop +strumpack')
-    depends_on('strumpack@6.0.0~slate~openmp', when='@0.7.0 +strumpack')
-    depends_on('strumpack@5.0.0~slate~openmp', when='@0.6.0 +strumpack')
-    depends_on('strumpack@3.3.0~slate~openmp', when='@0.5.0 +strumpack')
-    depends_on('strumpack@3.1.1~slate~openmp', when='@0.4.0 +strumpack')
+    xsdk_depends_on('strumpack ~cuda', when='~cuda @0.6.0: +strumpack')
+    xsdk_depends_on('strumpack@master~slate~openmp', when='@develop +strumpack')
+    xsdk_depends_on('strumpack@6.0.0~slate~openmp', when='@0.7.0 +strumpack')
+    xsdk_depends_on('strumpack@5.0.0~slate~openmp', when='@0.6.0 +strumpack')
+    xsdk_depends_on('strumpack@3.3.0~slate~openmp', when='@0.5.0 +strumpack')
+    xsdk_depends_on('strumpack@3.1.1~slate~openmp', when='@0.4.0 +strumpack')
 
-    depends_on('pumi@master', when='@develop')
-    depends_on('pumi@2.2.6', when='@0.7.0')
-    depends_on('pumi@2.2.5', when='@0.6.0')
-    depends_on('pumi@2.2.1', when='@0.5.0')
-    depends_on('pumi@2.2.0', when='@0.4.0')
+    xsdk_depends_on('pumi@master', when='@develop')
+    xsdk_depends_on('pumi@2.2.6', when='@0.7.0')
+    xsdk_depends_on('pumi@2.2.5', when='@0.6.0')
+    xsdk_depends_on('pumi@2.2.1', when='@0.5.0')
+    xsdk_depends_on('pumi@2.2.0', when='@0.4.0')
 
     tasmanian_openmp = '~openmp' if sys.platform == 'darwin' else '+openmp'
-    depends_on('tasmanian@develop+xsdkflags+blas' + tasmanian_openmp, when='@develop')
-    depends_on('tasmanian@develop+xsdkflags+blas+cuda+magma' + tasmanian_openmp, when='@develop +cuda')
-    depends_on('tasmanian@7.7+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.7.0')
-    depends_on('tasmanian@7.7+xsdkflags+mpi+blas+cuda+magma' + tasmanian_openmp, when='@0.7.0 +cuda')
-    depends_on('tasmanian@7.3+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.6.0')
-    depends_on('tasmanian@7.3+xsdkflags+mpi+blas+cuda+magma' + tasmanian_openmp, when='@0.6.0 +cuda')
-    depends_on('tasmanian@7.0+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.5.0')
-    depends_on('tasmanian@7.0+xsdkflags+mpi+blas+cuda+magma' + tasmanian_openmp, when='@0.5.0 +cuda')
-    depends_on('tasmanian@6.0+xsdkflags+blas~openmp', when='@0.4.0')
-    depends_on('tasmanian@6.0+xsdkflags+blas+cuda+magma~openmp', when='@0.4.0 +cuda')
+    xsdk_depends_on('tasmanian@develop+xsdkflags+blas' + tasmanian_openmp, when='@develop', cuda_var=['cuda', '?magma'], rocm_var=['rocm', '?magma'])
+    xsdk_depends_on('tasmanian@7.7+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.7.0', cuda_var=['cuda', '?magma'])
+    #xsdk_depends_on('tasmanian@7.7+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.7.0', cuda_var=['cuda', '?magma'], rocm_var=['rocm', '?magma']) # TODO: not sure why this causes a conflict
+    xsdk_depends_on('tasmanian@7.3+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.6.0', cuda_var=['cuda', '?magma'])
+    xsdk_depends_on('tasmanian@7.0+xsdkflags+mpi+blas' + tasmanian_openmp, when='@0.5.0', cuda_var=['cuda', '?magma'])
+    xsdk_depends_on('tasmanian@6.0+xsdkflags+blas~openmp', when='@0.4.0', cuda_var=['cuda', '?magma'])
 
-    depends_on('arborx@master', when='@develop +arborx')
-    depends_on('arborx@1.1', when='@0.7.0 +arborx')
+    xsdk_depends_on('arborx@master', when='@develop +arborx')
+    xsdk_depends_on('arborx@1.1', when='@0.7.0 +arborx')
 
     # the Fortran 2003 bindings of phist require python@3:, but this
     # creates a conflict with other packages like petsc@main. Actually
@@ -202,54 +281,47 @@ class Xsdk(BundlePackage):
     # This will be fixed once the new concretizer becomes available
     # (says @adamjstewart)
 
-    depends_on('phist kernel_lib=tpetra', when='+trilinos +phist')
-    depends_on('phist kernel_lib=petsc', when='~trilinos +phist')
-    depends_on('phist@develop ~fortran ~scamac ~openmp ~host ~int64', when='@develop +phist')
-    depends_on('phist@1.9.5 ~fortran ~scamac ~openmp ~host ~int64', when='@0.7.0 +phist')
-    depends_on('phist@1.9.3 ~fortran ~scamac ~openmp ~host ~int64', when='@0.6.0 +phist')
-    depends_on('phist@1.8.0 ~fortran ~scamac ~openmp ~host ~int64', when='@0.5.0 +phist')
-    depends_on('phist@1.7.5 ~fortran ~scamac ~openmp ~host ~int64', when='@0.4.0 +phist')
+    xsdk_depends_on('phist kernel_lib=tpetra', when='+trilinos +phist')
+    xsdk_depends_on('phist kernel_lib=petsc', when='~trilinos +phist')
+    xsdk_depends_on('phist@develop ~fortran ~scamac ~openmp ~host ~int64', when='@develop +phist')
+    xsdk_depends_on('phist@1.9.5 ~fortran ~scamac ~openmp ~host ~int64', when='@0.7.0 +phist')
+    xsdk_depends_on('phist@1.9.3 ~fortran ~scamac ~openmp ~host ~int64', when='@0.6.0 +phist')
+    xsdk_depends_on('phist@1.8.0 ~fortran ~scamac ~openmp ~host ~int64', when='@0.5.0 +phist')
+    xsdk_depends_on('phist@1.7.5 ~fortran ~scamac ~openmp ~host ~int64', when='@0.4.0 +phist')
 
-    depends_on('ginkgo@develop ~openmp', when='@develop +ginkgo')
-    depends_on('ginkgo@develop ~openmp+cuda', when='@develop +ginkgo +cuda')
-    depends_on('ginkgo@1.4.0 ~openmp', when='@0.7.0 +ginkgo')
-    depends_on('ginkgo@1.4.0 ~openmp+cuda', when='@0.7.0 +cuda +ginkgo')
-    depends_on('ginkgo@1.3.0 ~openmp', when='@0.6.0 +ginkgo')
-    depends_on('ginkgo@1.3.0 ~openmp+cuda', when='@0.6.0 +cuda +ginkgo')
-    depends_on('ginkgo@1.1.0 ~openmp', when='@0.5.0 +ginkgo')
-    depends_on('ginkgo@1.1.0 ~openmp+cuda', when='@0.5.0 +cuda +ginkgo')
+    xsdk_depends_on('ginkgo@develop ~openmp', when='@develop +ginkgo', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('ginkgo@1.4.0 ~openmp', when='@0.7.0 +ginkgo', cuda_var='cuda', rocm_var='rocm')
+    xsdk_depends_on('ginkgo@1.3.0 ~openmp', when='@0.6.0 +ginkgo', cuda_var='cuda')
+    xsdk_depends_on('ginkgo@1.1.0 ~openmp', when='@0.5.0 +ginkgo')
 
-    depends_on('py-libensemble@develop+petsc4py', type='run', when='@develop +libensemble')
-    depends_on('py-petsc4py@main', type='run', when='@develop +libensemble')
-    depends_on('py-libensemble@0.8.0+petsc4py', type='run', when='@0.7.0 +libensemble')
-    depends_on('py-petsc4py@3.16.0', type='run', when='@0.7.0 +libensemble')
-    depends_on('py-libensemble@0.7.1+petsc4py', type='run', when='@0.6.0 +libensemble')
-    depends_on('py-petsc4py@3.14.0', type='run', when='@0.6.0 +libensemble')
-    depends_on('py-libensemble@0.5.2+petsc4py', type='run', when='@0.5.0 +libensemble')
-    depends_on('py-petsc4py@3.12.0', type='run', when='@0.5.0 +libensemble')
+    xsdk_depends_on('py-libensemble@develop+petsc4py', type='run', when='@develop +libensemble')
+    xsdk_depends_on('py-petsc4py@main', type='run', when='@develop +libensemble')
+    xsdk_depends_on('py-libensemble@0.8.0+petsc4py', type='run', when='@0.7.0 +libensemble')
+    xsdk_depends_on('py-petsc4py@3.16.0', type='run', when='@0.7.0 +libensemble')
+    xsdk_depends_on('py-libensemble@0.7.1+petsc4py', type='run', when='@0.6.0 +libensemble')
+    xsdk_depends_on('py-petsc4py@3.14.0', type='run', when='@0.6.0 +libensemble')
+    xsdk_depends_on('py-libensemble@0.5.2+petsc4py', type='run', when='@0.5.0 +libensemble')
+    xsdk_depends_on('py-petsc4py@3.12.0', type='run', when='@0.5.0 +libensemble')
 
-    depends_on('precice ~petsc', when='platform=cray +precice')
-    depends_on('precice@develop', when='@develop +precice')
-    depends_on('precice@2.3.0', when='@0.7.0 +precice')
-    depends_on('precice@2.1.1', when='@0.6.0 +precice')
-    depends_on('precice@1.6.1', when='@0.5.0 +precice')
+    xsdk_depends_on('precice ~petsc', when='platform=cray +precice')
+    xsdk_depends_on('precice@develop', when='@develop +precice')
+    xsdk_depends_on('precice@2.3.0', when='@0.7.0 +precice')
+    xsdk_depends_on('precice@2.1.1', when='@0.6.0 +precice')
+    xsdk_depends_on('precice@1.6.1', when='@0.5.0 +precice')
 
-    depends_on('butterflypack@master', when='@develop +butterflypack')
-    depends_on('butterflypack@2.0.0', when='@0.7.0 +butterflypack')
-    depends_on('butterflypack@1.2.1', when='@0.6.0 +butterflypack')
-    depends_on('butterflypack@1.1.0', when='@0.5.0 +butterflypack')
+    xsdk_depends_on('butterflypack@master', when='@develop +butterflypack')
+    xsdk_depends_on('butterflypack@2.0.0', when='@0.7.0 +butterflypack')
+    xsdk_depends_on('butterflypack@1.2.1', when='@0.6.0 +butterflypack')
+    xsdk_depends_on('butterflypack@1.1.0', when='@0.5.0 +butterflypack')
 
-    depends_on('heffte +fftw+cuda+magma', when='+cuda +heffte')
-    depends_on('openmpi +cuda', when='+cuda +heffte')
-    depends_on('heffte@develop+fftw', when='@develop +heffte')
-    depends_on('heffte@2.2.0+fftw', when='@0.7.0 +heffte')
-    depends_on('heffte@2.0.0+fftw', when='@0.6.0 +heffte')
+    xsdk_depends_on('heffte@develop+fftw', when='@develop +heffte', cuda_var=['cuda', '?magma'], rocm_var=['rocm', '?magma'])
+    xsdk_depends_on('heffte@2.2.0+fftw', when='@0.7.0 +heffte', cuda_var=['cuda', '?magma'], rocm_var=['rocm', '?magma'])
+    xsdk_depends_on('heffte@2.0.0+fftw', when='@0.6.0 +heffte', cuda_var=['cuda', '?magma'])
+    xsdk_depends_on('openmpi+cuda', when='+cuda +heffte') # openmpi does not use CudaPackage and has no cuda_arch variant
 
-    depends_on('slate@master ~cuda', when='@develop ~cuda +slate %gcc@6.0:')
-    depends_on('slate@master +cuda', when='@develop +cuda +slate %gcc@6.0:')
-    depends_on('slate@2021.05.02 ~cuda', when='@0.7.0 ~cuda +slate %gcc@6.0:')
-    depends_on('slate@2020.10.00 ~cuda', when='@0.6.0 ~cuda +slate %gcc@6.0:')
-    depends_on('slate@2020.10.00 +cuda', when='@0.6.0 +cuda +slate %gcc@6.0:')
+    xsdk_depends_on('slate@master', when='@develop +slate %gcc@6.0:', cuda_var='cuda')
+    xsdk_depends_on('slate@2021.05.02 ~cuda', when='@0.7.0 ~cuda +slate %gcc@6.0:') # TODO: should this version have +cuda?
+    xsdk_depends_on('slate@2020.10.00', when='@0.6.0 +slate %gcc@6.0:', cuda_var='cuda')
 
     # How do we propagate debug flag to all depends on packages ?
     # If I just do spack install xsdk+debug will that propogate it down?

--- a/var/spack/repos/builtin/packages/xsdk/package.py
+++ b/var/spack/repos/builtin/packages/xsdk/package.py
@@ -231,7 +231,7 @@ class Xsdk(BundlePackage, CudaPackage, ROCmPackage):
 
     xsdk_depends_on('strumpack ~cuda', when='~cuda @0.6.0: +strumpack')
     xsdk_depends_on('strumpack@master~slate~openmp', when='@develop +strumpack')
-    xsdk_depends_on('strumpack@6.0.0~slate~openmp', when='@0.7.0 +strumpack')
+    xsdk_depends_on('strumpack@6.1.0~slate~openmp', when='@0.7.0 +strumpack')
     xsdk_depends_on('strumpack@5.0.0~slate~openmp', when='@0.6.0 +strumpack')
     xsdk_depends_on('strumpack@3.3.0~slate~openmp', when='@0.5.0 +strumpack')
     xsdk_depends_on('strumpack@3.1.1~slate~openmp', when='@0.4.0 +strumpack')


### PR DESCRIPTION
6.1.0 changes compared to 6.0.0:
-  Change default BLR blocksize, and in the BLR preconditioner use right-looking algorithm as the default. This has higher peak memory usage, but is much faster and more robust.
- Fixes in printing of compression statistics.
- Always build the test when doing 'make', you no longer have to run 'make tests'.
- Setup CI at github and gitlab, remove Travis testing.
