### PR TITLE
depend on libevent when +pmix

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -314,6 +314,7 @@ class Openmpi(AutotoolsPackage):
     depends_on('pbs', when='schedulers=tm')
     depends_on('slurm', when='schedulers=slurm')
     depends_on('pmix', when='+pmix')
+    depends_on('libevent', when='+pmix')
 
     depends_on('openssh', type='run')
 
@@ -707,7 +708,7 @@ class Openmpi(AutotoolsPackage):
             lustre_opt = '--with-lustre={0}'.format(spec['lustre'].prefix)
             config_args.append(lustre_opt)
         # external libevent
-        if spec.satisfies('@4.0.0:'):
+        if spec.satisfies('@4.0.0:') or spec.satisfies('+pmix'):
             config_args.append('--with-libevent={0}'.format(spec['libevent'].prefix))
         # Hwloc support
         if '~internal-hwloc' in spec and spec.satisfies('@1.5.2:'):


### PR DESCRIPTION
`PMIx` support (via variant) was added to this OpenMPI spackage in commit 98466f9b120, 2021-10-01; looks like `PMIx` has been present within the project since `openmpi@2`.  A dependency on `libevent` was listed in that commit, however it is only effectively applied to `openmpi@4:`  This MR fixes up the OpenMPI versions in between.  If this MR is _not_ applied, the build fails like this, e.g., when I attempt to build `openmpi@3.1.6`:

> 1 error found in build log:
>      1765    --- MCA component pmix:ext2x (m4 configuration macro)
>      1766    checking for MCA component pmix:ext2x compile mode... static
>      1767    checking if external component is version 2.x... yes
>      1768    configure: WARNING: EXTERNAL PMIX SUPPORT REQUIRES USE OF EXTERNAL LIBEVENT
>      1769    configure: WARNING: LIBRARY. THIS LIBRARY MUST POINT TO THE SAME ONE USED
>      1770    configure: WARNING: TO BUILD PMIX OR ELSE UNPREDICTABLE BEHAVIOR MAY RESULT
>      1771    configure: error: PLEASE CORRECT THE CONFIGURE COMMAND LINE AND REBUILD

This occurs because `libevent` is a direct spack dependency of `pmix` whereas this version _hole_ in the OpenMPI spackage permits its configuration to pick up the system `libevent`, thereby crashing the configure due to version skew.