### PR TITLE
config: fix `SPACK_DISABLE_LOCAL_CONFIG`, remove `$user_config_path`

### DIFF
--- a/etc/spack/defaults/bootstrap.yaml
+++ b/etc/spack/defaults/bootstrap.yaml
@@ -4,7 +4,7 @@ bootstrap:
   enable: true
   # Root directory for bootstrapping work. The software bootstrapped
   # by Spack is installed in a "store" subfolder of this root directory
-  root: $user_config_path/bootstrap
+  root: $user_cache_path/bootstrap
   # Methods that can be used to bootstrap software. Each method may or
   # may not be able to bootstrap all of the software that Spack needs,
   # depending on its type.

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -409,8 +409,6 @@ Spack understands several special variables. These are:
   <https://docs.python.org/2/library/tempfile.html#tempfile.tempdir>`_
   variable.
 * ``$user``: name of the current user
-* ``$user_config_path``: user configuration directory (``~/.spack`` unless
-  :ref:`overridden <local-config-overrides>`)
 * ``$user_cache_path``: user cache directory (``~/.spack`` unless
   :ref:`overridden <local-config-overrides>`)
 
@@ -587,9 +585,9 @@ Spack provides three environment variables that allow you to override or opt out
 configuration locations:
 
 * ``SPACK_USER_CONFIG_PATH``: Override the path to use for the
-  ``user`` (``~/.spack``) scope.
-* ``SPACK_SYSTEM_CONFIG_PATH``: Override the path to use for the ``system``
-  (``/etc/spack``) scope.
+  ``user`` scope (``~/.spack`` by default).
+* ``SPACK_SYSTEM_CONFIG_PATH``: Override the path to use for the
+  ``system`` scope (``/etc/spack`` by default).
 * ``SPACK_DISABLE_LOCAL_CONFIG``: set this environment variable to completely disable
   **both** the system and user configuration directories. Spack will only consider its
   own defaults and ``site`` configuration locations.

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -13,6 +13,7 @@ import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 
 import spack.error
+import spack.paths
 import spack.util.prefix
 import spack.util.spack_json as sjson
 from spack.spec import Spec
@@ -41,7 +42,8 @@ def get_escaped_text_output(filename):
 
 def get_test_stage_dir():
     return spack.util.path.canonicalize_path(
-        spack.config.get('config:test_stage', '~/.spack/test'))
+        spack.config.get('config:test_stage', spack.paths.default_test_path)
+    )
 
 
 def get_all_test_suites():

--- a/lib/spack/spack/monitor.py
+++ b/lib/spack/spack/monitor.py
@@ -28,6 +28,7 @@ import spack
 import spack.config
 import spack.hash_types as ht
 import spack.main
+import spack.paths
 import spack.store
 import spack.util.path
 import spack.util.spack_json as sjson
@@ -143,7 +144,8 @@ class SpackMonitorClient:
             return
 
         save_dir = spack.util.path.canonicalize_path(
-            spack.config.get('config:monitor_dir', '~/.spack/reports/monitor'))
+            spack.config.get('config:monitor_dir', spack.paths.default_monitor_path)
+        )
 
         # Name based on timestamp
         now = datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%s')

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -89,8 +89,11 @@ user_cache_path = _get_user_cache_path()
 #: junit, cdash, etc. reports about builds
 reports_path = os.path.join(user_cache_path, "reports")
 
+#: installation test (spack test) output
+default_test_path = os.path.join(user_cache_path, "test")
+
 #: spack monitor analysis directories
-monitor_path = os.path.join(reports_path, "monitor")
+default_monitor_path = os.path.join(reports_path, "monitor")
 
 #: git repositories fetched to compare commits to versions
 user_repos_cache_path = os.path.join(user_cache_path, 'git_repos')

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -432,13 +432,6 @@ def test_substitute_user(mock_low_high_config):
     )
 
 
-def test_substitute_user_config(mock_low_high_config):
-    user_config_path = spack.paths.user_config_path
-    assert user_config_path + '/baz' == spack_path.canonicalize_path(
-        '$user_cache_path/baz'
-    )
-
-
 def test_substitute_user_cache(mock_low_high_config):
     user_cache_path = spack.paths.user_cache_path
     assert user_cache_path + '/baz' == spack_path.canonicalize_path(

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -30,7 +30,6 @@ replacements = {
     'spack': spack.paths.prefix,
     'user': getpass.getuser(),
     'tempdir': tempfile.gettempdir(),
-    'user_config_path': spack.paths.user_config_path,
     'user_cache_path': spack.paths.user_cache_path,
 }
 
@@ -80,7 +79,6 @@ def substitute_config_variables(path):
     - $spack             The Spack instance's prefix
     - $tempdir           Default temporary directory returned by tempfile.gettempdir()
     - $user              The current user's username
-    - $user_config_path  The user configuration directory (~/.spack, unless overridden)
     - $user_cache_path   The user cache directory (~/.spack, unless overridden)
 
     These are substituted case-insensitively into the path, and users can


### PR DESCRIPTION
Closes #27010.

There were some loose ends left in ##26735 that cause errors when using `SPACK_DISABLE_LOCAL_CONFIG`.

- [x] Fix hard-coded `~/.spack` references in `install_test.py` and `monitor.py`

Also, if `SPACK_DISABLE_LOCAL_CONFIG` is used, there is the issue that `$user_config_path`, when used in configuration files, makes no sense, because there is no user config scope.

Since we already have `$user_cache_path` in configuration files, and since there really shouldn't be *any* data stored in a configuration scope (which is what you'd configure in `config.yaml`/`bootstrap.yaml`/etc., this just removes `$user_config_path`.

There will *always* be a `$user_cache_path`, as Spack needs to write files, but we shouldn't rely on the existence of a particular configuration scope in the Spack code, as scopes are configurable, both in number and location.

- [x] Remove `$user_config_path` substitution.
- [x] Fix reference to `$user_config_path` in `etc/spack/deaults/bootstrap.yaml` to refer to `$user_cache_path`, which is where it was intended to be.