### PR TITLE
VisIt: Update for building with 3.2.1.

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -193,13 +193,13 @@ class Visit(CMakePackage):
                patches=[patch('vtk_compiler_visibility.patch'),
                         patch('vtk_rendering_opengl2_x11.patch'),
                         patch('vtk_wrapping_python_x11.patch'),
-               ],
+                        ],
                when='~python @3.2:,develop')
     depends_on('vtk@8.1.0+opengl2+osmesa+python',
                patches=[patch('vtk_compiler_visibility.patch'),
                         patch('vtk_rendering_opengl2_x11.patch'),
                         patch('vtk_wrapping_python_x11.patch'),
-               ],
+                        ],
                when='+python @3.2:,develop')
     depends_on('glu', when='platform=linux')
     depends_on('vtk+python', when='+python @3.2:,develop')

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -216,7 +216,7 @@ class Visit(CMakePackage):
     depends_on('mesa+glx', when='^mesa')
     depends_on('mesa-glu', when='^mesa')
     # VisIt doesn't build with hdf5@1.12 and hdf5@1.10 produces files that
-    # are incompatible with hdf5@1.8
+    # are incompatible with hdf5@1.8.
     depends_on('hdf5@1.8', when='+hdf5')
     # VisIt uses Silo's 'ghost zone' data structures, which are only available
     # in v4.10+ releases: https://wci.llnl.gov/simulation/computer-codes/silo/releases/release-notes-4.10

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -175,13 +175,13 @@ class Visit(CMakePackage):
                patches=[patch('vtk_compiler_visibility.patch'),
                         patch('vtk_rendering_opengl2_x11.patch'),
                         patch('vtk_wrapping_python_x11.patch'),
-                       ],
+               ],
                when='~python @3.2:,develop')
     depends_on('vtk@8.1.0+opengl2+osmesa+python',
                patches=[patch('vtk_compiler_visibility.patch'),
                         patch('vtk_rendering_opengl2_x11.patch'),
                         patch('vtk_wrapping_python_x11.patch'),
-                       ],
+               ],
                when='+python @3.2:,develop')
     depends_on('glu', when='platform=linux')
     depends_on('vtk+python', when='+python @3.2:,develop')

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -54,9 +54,9 @@ class Visit(CMakePackage):
     # (dyld: Symbol not found: _GENERAL_NAME_free - which comes from OpenSSL)
     #
     ############################
-    homepage = "https://wci.llnl.gov/simulation/computer-codes/visit/"
+    homepage = "https://visit-dav.github.io/visit-website/"
     git      = "https://github.com/visit-dav/visit.git"
-    url = "https://github.com/visit-dav/visit/releases/download/v3.1.1/visit3.1.1.tar.gz"
+    url = "https://github.com/visit-dav/visit/releases/download/v3.2.1/visit3.2.1.tar.gz"
 
     tags = ['radiuss']
 
@@ -67,22 +67,14 @@ class Visit(CMakePackage):
     executables = ['^visit$']
 
     version('develop', branch='develop')
-    version('3.1.1', sha256='0b60ac52fd00aff3cf212a310e36e32e13ae3ca0ddd1ea3f54f75e4d9b6c6cf0')
-    version('3.0.1', sha256='a506d4d83b8973829e68787d8d721199523ce7ec73e7594e93333c214c2c12bd')
-    version('2.13.3', sha256='cf0b3d2e39e1cd102dd886d3ef6da892733445e362fc28f24d9682012cccf2e5')
-    version('2.13.0', sha256='716644b8e78a00ff82691619d4d1e7a914965b6535884890b667b97ba08d6a0f')
-    version('2.12.3', sha256='2dd351a291ee3e79926bc00391ca89b202cfa4751331b0fdee1b960c7922161f')
-    version('2.12.2', sha256='55897d656ac2ea4eb87a30118b2e3963d6c8a391dda0790268426a73e4b06943')
-    version('2.10.3', sha256='05018215c4727eb42d47bb5cc4ff937b2a2ccaca90d141bc7fa426a0843a5dbc')
-    version('2.10.2', sha256='89ecdfaf197ef431685e31b75628774deb6cd75d3e332ef26505774403e8beff')
-    version('2.10.1', sha256='6b53dea89a241fd03300a7a3a50c0f773e2fb8458cd3ad06816e9bd2f0337cd8')
+    version('3.2.1', sha256='779d59564c63f31fcbfeff24b14ddd6ac941b3bb7d671d31765a770d193f02e8')
 
     variant('gui',    default=True, description='Enable VisIt\'s GUI')
     variant('adios2', default=False, description='Enable ADIOS2 file format')
     variant('hdf5',   default=True, description='Enable HDF5 file format')
     variant('silo',   default=True, description='Enable Silo file format')
     variant('python', default=True, description='Enable Python support')
-    variant('mpi',    default=True, description='Enable parallel engine')
+    variant('mpi',    default=False, description='Enable parallel engine')
 
     patch('spack-changes-3.1.patch', when="@3.1.0:,develop")
     patch('spack-changes-3.0.1.patch', when="@3.0.1")
@@ -177,19 +169,31 @@ class Visit(CMakePackage):
     #
     # =====================================
 
-    depends_on('cmake@3.0:', type='build')
+    depends_on('cmake@3.14.7', type='build')
     # https://github.com/visit-dav/visit/issues/3498
-    depends_on('vtk@8.1.0:8.1+opengl2~python', when='~python @3.0:3,develop')
-    depends_on('vtk@8.1.0:8.1+opengl2+python', when='+python @3.0:3,develop')
+    depends_on('vtk@8.1.0+opengl2+osmesa~python',
+               patches=[patch('vtk_compiler_visibility.patch'),
+                        patch('vtk_rendering_opengl2_x11.patch'),
+                        patch('vtk_wrapping_python_x11.patch'),
+                       ],
+               when='~python @3.2:,develop')
+    depends_on('vtk@8.1.0+opengl2+osmesa+python',
+               patches=[patch('vtk_compiler_visibility.patch'),
+                        patch('vtk_rendering_opengl2_x11.patch'),
+                        patch('vtk_wrapping_python_x11.patch'),
+                       ],
+               when='+python @3.2:,develop')
     depends_on('glu', when='platform=linux')
-    depends_on('vtk@6.1.0~opengl2', when='@:2')
-    depends_on('vtk+python', when='+python @3.0:,develop')
+    depends_on('vtk+python', when='+python @3.2:,develop')
     depends_on('vtk~mpi', when='~mpi')
     depends_on('vtk+qt', when='+gui')
-    depends_on('qt+gui@4.8.6:4', when='+gui @:2')
-    depends_on('qt+gui@5.10:', when='+gui @3.0:,develop')
-    depends_on('qwt', when='+gui')
-    depends_on('python@2.6:2.8', when='+python')
+    depends_on('qt+gui@5.14.2:', when='+gui @3.2:,develop')
+    depends_on('qwt@6.1.6', when='+gui')
+    depends_on('python@3.7.7', when='+python')
+    depends_on('llvm@6.0.1', when='^mesa')
+    depends_on('mesa+glx@20.2.1', when='^mesa')
+    depends_on('mesa-glu@9.0.1', when='^mesa')
+    depends_on('hdf5@1.8.14', when='+hdf5')
     # VisIt uses Silo's 'ghost zone' data structures, which are only available
     # in v4.10+ releases: https://wci.llnl.gov/simulation/computer-codes/silo/releases/release-notes-4.10
     depends_on('silo@4.10:+shared', when='+silo')
@@ -200,13 +204,9 @@ class Visit(CMakePackage):
     depends_on('mpi', when='+mpi')
     depends_on('adios2', when='+adios2')
 
-    conflicts('+adios2', when='@:2')
-    conflicts('+hdf5', when='~gui @:2')
-    conflicts('+silo', when='~gui @:2')
-
     root_cmakelists_dir = 'src'
 
-    @when('@3.0.0:3,develop')
+    @when('@3.0.0:,develop')
     def patch(self):
         # Some of VTK's targets don't create explicit libraries, so there is no
         # 'vtktiff'. Instead, replace with the library variable defined from
@@ -235,6 +235,7 @@ class Visit(CMakePackage):
             '-DVISIT_USE_GLEW=OFF',
             '-DCMAKE_CXX_FLAGS=' + ' '.join(cxx_flags),
             '-DCMAKE_C_FLAGS=' + ' '.join(cc_flags),
+            '-DVISIT_CONFIG_SITE=NONE',
         ]
 
         # Provide the plugin compilation environment so as to extend VisIt
@@ -265,6 +266,12 @@ class Visit(CMakePackage):
         else:
             args.append('-DVISIT_SERVER_COMPONENTS_ONLY=ON')
             args.append('-DVISIT_ENGINE_ONLY=ON')
+
+        if '^mesa' in spec:
+            args.append(
+                '-DVISIT_LLVM_DIR:PATH={0}'.format(spec['llvm'].prefix))
+            args.append(
+                '-DVISIT_MESAGL_DIR:PATH={0}'.format(spec['mesa'].prefix))
 
         if '+hdf5' in spec:
             args.append(

--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -54,7 +54,7 @@ class Visit(CMakePackage):
     # (dyld: Symbol not found: _GENERAL_NAME_free - which comes from OpenSSL)
     #
     ############################
-    homepage = "https://visit-dav.github.io/visit-website/"
+    homepage = "https://wci.llnl.gov/simulation/computer-codes/visit/"
     git      = "https://github.com/visit-dav/visit.git"
     url = "https://github.com/visit-dav/visit/releases/download/v3.2.1/visit3.2.1.tar.gz"
 
@@ -68,6 +68,15 @@ class Visit(CMakePackage):
 
     version('develop', branch='develop')
     version('3.2.1', sha256='779d59564c63f31fcbfeff24b14ddd6ac941b3bb7d671d31765a770d193f02e8')
+    version('3.1.1', sha256='0b60ac52fd00aff3cf212a310e36e32e13ae3ca0ddd1ea3f54f75e4d9b6c6cf0')
+    version('3.0.1', sha256='a506d4d83b8973829e68787d8d721199523ce7ec73e7594e93333c214c2c12bd')
+    version('2.13.3', sha256='cf0b3d2e39e1cd102dd886d3ef6da892733445e362fc28f24d9682012cccf2e5')
+    version('2.13.0', sha256='716644b8e78a00ff82691619d4d1e7a914965b6535884890b667b97ba08d6a0f')
+    version('2.12.3', sha256='2dd351a291ee3e79926bc00391ca89b202cfa4751331b0fdee1b960c7922161f')
+    version('2.12.2', sha256='55897d656ac2ea4eb87a30118b2e3963d6c8a391dda0790268426a73e4b06943')
+    version('2.10.3', sha256='05018215c4727eb42d47bb5cc4ff937b2a2ccaca90d141bc7fa426a0843a5dbc')
+    version('2.10.2', sha256='89ecdfaf197ef431685e31b75628774deb6cd75d3e332ef26505774403e8beff')
+    version('2.10.1', sha256='6b53dea89a241fd03300a7a3a50c0f773e2fb8458cd3ad06816e9bd2f0337cd8')
 
     variant('gui',    default=True, description='Enable VisIt\'s GUI')
     variant('adios2', default=False, description='Enable ADIOS2 file format')
@@ -171,6 +180,15 @@ class Visit(CMakePackage):
 
     depends_on('cmake@3.14.7', type='build')
     # https://github.com/visit-dav/visit/issues/3498
+    # The vtk_compiler_visibility patch fixes a bug where
+    # VTKGenerateExportHeader.cmake fails to recognize gcc versions 10.0
+    # or greater.
+    # The vtk_rendering_opengl2_x11 patch adds include directories to
+    # Rendering/OpenGL2/CMakeLists.txt for systems that don't have the
+    # system X libraries and include files installed.
+    # The vtk_wrapping_python_x11 patch adds include directories to
+    # Wrapping/Python/CMakelists.txt for systems that don't have the
+    # system X libraries and include files installed.
     depends_on('vtk@8.1.0+opengl2+osmesa~python',
                patches=[patch('vtk_compiler_visibility.patch'),
                         patch('vtk_rendering_opengl2_x11.patch'),
@@ -187,13 +205,19 @@ class Visit(CMakePackage):
     depends_on('vtk+python', when='+python @3.2:,develop')
     depends_on('vtk~mpi', when='~mpi')
     depends_on('vtk+qt', when='+gui')
+    # VisIt doesn't work with later versions of qt.
     depends_on('qt+gui@5.14.2:', when='+gui @3.2:,develop')
-    depends_on('qwt@6.1.6', when='+gui')
-    depends_on('python@3.7.7', when='+python')
-    depends_on('llvm@6.0.1', when='^mesa')
-    depends_on('mesa+glx@20.2.1', when='^mesa')
-    depends_on('mesa-glu@9.0.1', when='^mesa')
-    depends_on('hdf5@1.8.14', when='+hdf5')
+    depends_on('qwt', when='+gui')
+    # python@3.8 doesn't work with VisIt.
+    depends_on('python@3.7', when='+python')
+    # llvm@12.0.1, @11.1.0, @10.0.1 fail in build phase with gcc 6.1.0.
+    # llvm@9.0.1 fails in cmake phase with gcc 6.1.0.
+    depends_on('llvm@6:8', when='^mesa')
+    depends_on('mesa+glx', when='^mesa')
+    depends_on('mesa-glu', when='^mesa')
+    # VisIt doesn't build with hdf5@1.12 and hdf5@1.10 produces files that
+    # are incompatible with hdf5@1.8
+    depends_on('hdf5@1.8', when='+hdf5')
     # VisIt uses Silo's 'ghost zone' data structures, which are only available
     # in v4.10+ releases: https://wci.llnl.gov/simulation/computer-codes/silo/releases/release-notes-4.10
     depends_on('silo@4.10:+shared', when='+silo')

--- a/var/spack/repos/builtin/packages/visit/vtk_compiler_visibility.patch
+++ b/var/spack/repos/builtin/packages/visit/vtk_compiler_visibility.patch
@@ -1,20 +1,12 @@
-diff -c ./CMake/VTKGenerateExportHeader.cmake.orig ./CMake/VTKGenerateExportHeader.cmake
-*** ./CMake/VTKGenerateExportHeader.cmake.orig	2021-10-07 12:11:56.447173341 -0400
---- ./CMake/VTKGenerateExportHeader.cmake	2021-10-07 12:11:39.367361524 -0400
-***************
-*** 174,180 ****
-      execute_process(COMMAND ${CMAKE_C_COMPILER} --version
-        OUTPUT_VARIABLE _gcc_version_info
-        ERROR_VARIABLE _gcc_version_info)
-!     string(REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
-        _gcc_version "${_gcc_version_info}")
-      # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
-      # patch level, handle this here:
---- 174,180 ----
-      execute_process(COMMAND ${CMAKE_C_COMPILER} --version
-        OUTPUT_VARIABLE _gcc_version_info
-        ERROR_VARIABLE _gcc_version_info)
-!     string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]*"
-        _gcc_version "${_gcc_version_info}")
-      # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
-      # patch level, handle this here:
+diff -u ./CMake/VTKGenerateExportHeader.cmake.orig ./CMake/VTKGenerateExportHeader.cmake
+--- ./CMake/VTKGenerateExportHeader.cmake.orig	2021-11-03 14:32:17.607243000 -0700
++++ ./CMake/VTKGenerateExportHeader.cmake	2021-11-03 14:35:54.896214000 -0700
+@@ -174,7 +174,7 @@
+     execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+       OUTPUT_VARIABLE _gcc_version_info
+       ERROR_VARIABLE _gcc_version_info)
+-    string(REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
++    string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]*"
+       _gcc_version "${_gcc_version_info}")
+     # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
+     # patch level, handle this here:

--- a/var/spack/repos/builtin/packages/visit/vtk_compiler_visibility.patch
+++ b/var/spack/repos/builtin/packages/visit/vtk_compiler_visibility.patch
@@ -1,0 +1,20 @@
+diff -c ./CMake/VTKGenerateExportHeader.cmake.orig ./CMake/VTKGenerateExportHeader.cmake
+*** ./CMake/VTKGenerateExportHeader.cmake.orig	2021-10-07 12:11:56.447173341 -0400
+--- ./CMake/VTKGenerateExportHeader.cmake	2021-10-07 12:11:39.367361524 -0400
+***************
+*** 174,180 ****
+      execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+        OUTPUT_VARIABLE _gcc_version_info
+        ERROR_VARIABLE _gcc_version_info)
+!     string(REGEX MATCH "[3-9]\\.[0-9]\\.[0-9]*"
+        _gcc_version "${_gcc_version_info}")
+      # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
+      # patch level, handle this here:
+--- 174,180 ----
+      execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+        OUTPUT_VARIABLE _gcc_version_info
+        ERROR_VARIABLE _gcc_version_info)
+!     string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]*"
+        _gcc_version "${_gcc_version_info}")
+      # gcc on mac just reports: "gcc (GCC) 3.3 20030304 ..." without the
+      # patch level, handle this here:

--- a/var/spack/repos/builtin/packages/visit/vtk_rendering_opengl2_x11.patch
+++ b/var/spack/repos/builtin/packages/visit/vtk_rendering_opengl2_x11.patch
@@ -1,20 +1,12 @@
-diff -c a/Rendering/OpenGL2/CMakeLists.txt b/Rendering/OpenGL2/CMakeLists.txt
-*** a/Rendering/OpenGL2/CMakeLists.txt
---- b/Rendering/OpenGL2/CMakeLists.txt
-***************
-*** 194,200 ****
-    if(NOT X11_Xt_FOUND)
-      message(FATAL_ERROR "X11_Xt_LIB could not be found. Required for VTK X lib.")
-    endif()
-!   include_directories(${X11_INCLUDE_DIR} ${X11_Xt_INCLUDE_PATH})
-  endif()
-  
-  # setup factory overrides
---- 194,200 ----
-    if(NOT X11_Xt_FOUND)
-      message(FATAL_ERROR "X11_Xt_LIB could not be found. Required for VTK X lib.")
-    endif()
-!   include_directories(${X11_INCLUDE_DIR} ${X11_SM_INCLUDE_PATH} ${X11_ICE_INCLUDE_PATH} ${X11_Xt_INCLUDE_PATH})
-  endif()
-  
-  # setup factory overrides
+diff -u ./Rendering/OpenGL2/CMakeLists.txt.orig ./Rendering/OpenGL2/CMakeLists.txt
+--- ./Rendering/OpenGL2/CMakeLists.txt.orig	2021-11-03 14:33:11.582334000 -0700
++++ ./Rendering/OpenGL2/CMakeLists.txt	2021-11-03 14:36:50.263234000 -0700
+@@ -194,7 +194,7 @@
+   if(NOT X11_Xt_FOUND)
+     message(FATAL_ERROR "X11_Xt_LIB could not be found. Required for VTK X lib.")
+   endif()
+-  include_directories(${X11_INCLUDE_DIR} ${X11_Xt_INCLUDE_PATH})
++  include_directories(${X11_INCLUDE_DIR} ${X11_SM_INCLUDE_PATH} ${X11_ICE_INCLUDE_PATH} ${X11_Xt_INCLUDE_PATH})
+ endif()
+ 
+ # setup factory overrides

--- a/var/spack/repos/builtin/packages/visit/vtk_rendering_opengl2_x11.patch
+++ b/var/spack/repos/builtin/packages/visit/vtk_rendering_opengl2_x11.patch
@@ -1,0 +1,20 @@
+diff -c a/Rendering/OpenGL2/CMakeLists.txt b/Rendering/OpenGL2/CMakeLists.txt
+*** a/Rendering/OpenGL2/CMakeLists.txt
+--- b/Rendering/OpenGL2/CMakeLists.txt
+***************
+*** 194,200 ****
+    if(NOT X11_Xt_FOUND)
+      message(FATAL_ERROR "X11_Xt_LIB could not be found. Required for VTK X lib.")
+    endif()
+!   include_directories(${X11_INCLUDE_DIR} ${X11_Xt_INCLUDE_PATH})
+  endif()
+  
+  # setup factory overrides
+--- 194,200 ----
+    if(NOT X11_Xt_FOUND)
+      message(FATAL_ERROR "X11_Xt_LIB could not be found. Required for VTK X lib.")
+    endif()
+!   include_directories(${X11_INCLUDE_DIR} ${X11_SM_INCLUDE_PATH} ${X11_ICE_INCLUDE_PATH} ${X11_Xt_INCLUDE_PATH})
+  endif()
+  
+  # setup factory overrides

--- a/var/spack/repos/builtin/packages/visit/vtk_wrapping_python_x11.patch
+++ b/var/spack/repos/builtin/packages/visit/vtk_wrapping_python_x11.patch
@@ -1,16 +1,14 @@
-diff -c a/Wrapping/Python/CMakeLists.txt b/Wrapping/Python/CMakeLists.txt
-*** a/Wrapping/Python/CMakeLists.txt
---- b/Wrapping/Python/CMakeLists.txt
-***************
-*** 23,28 ****
---- 23,32 ----
-  
-  get_property(VTK_PYTHON_MODULES GLOBAL PROPERTY VTK_PYTHON_WRAPPED)
-  
-+ include_directories(${X11_Xlib_INCLUDE_PATH})
-+ include_directories(${X11_X11_INCLUDE_PATH})
-+ include_directories(${X11_Xt_INCLUDE_PATH})
-+ 
-  # Get the include directories for the module and all its dependencies.
-  macro(vtk_include_recurse module)
-    _vtk_module_config_recurse("${module}_PYTHON" ${module})
+diff -u ./Wrapping/Python/CMakeLists.txt.orig ./Wrapping/Python/CMakeLists.txt
+--- ./Wrapping/Python/CMakeLists.txt.orig	2021-11-03 14:33:41.413950000 -0700
++++ ./Wrapping/Python/CMakeLists.txt	2021-11-03 14:37:03.634738000 -0700
+@@ -23,6 +23,10 @@
+ 
+ get_property(VTK_PYTHON_MODULES GLOBAL PROPERTY VTK_PYTHON_WRAPPED)
+ 
++include_directories(${X11_Xlib_INCLUDE_PATH})
++include_directories(${X11_X11_INCLUDE_PATH})
++include_directories(${X11_Xt_INCLUDE_PATH})
++
+ # Get the include directories for the module and all its dependencies.
+ macro(vtk_include_recurse module)
+   _vtk_module_config_recurse("${module}_PYTHON" ${module})

--- a/var/spack/repos/builtin/packages/visit/vtk_wrapping_python_x11.patch
+++ b/var/spack/repos/builtin/packages/visit/vtk_wrapping_python_x11.patch
@@ -1,0 +1,16 @@
+diff -c a/Wrapping/Python/CMakeLists.txt b/Wrapping/Python/CMakeLists.txt
+*** a/Wrapping/Python/CMakeLists.txt
+--- b/Wrapping/Python/CMakeLists.txt
+***************
+*** 23,28 ****
+--- 23,32 ----
+  
+  get_property(VTK_PYTHON_MODULES GLOBAL PROPERTY VTK_PYTHON_WRAPPED)
+  
++ include_directories(${X11_Xlib_INCLUDE_PATH})
++ include_directories(${X11_X11_INCLUDE_PATH})
++ include_directories(${X11_Xt_INCLUDE_PATH})
++ 
+  # Get the include directories for the module and all its dependencies.
+  macro(vtk_include_recurse module)
+    _vtk_module_config_recurse("${module}_PYTHON" ${module})


### PR DESCRIPTION
I updated the VisIt package to build with 3.2.1.

It includes several several patches to vtk 8.1 for building on a system with no system install X11 libraries or include files.

It specifies specific versions of dependent packages that are known to work with 3.2.1.

It was tested on spock.olcf.ornl.gov. The GUI came up and rendered images and an image was successfully saved using off screen rendering from data from curv2d.silo.

I had to make some changes to my environment on spock to get the spack package to work properly.

For pcre to build, I had to do:

LD_LIBRARY_PATH=/opt/cray/pe/gcc/10.3.0/snos/lib64:/opt/cray/libfabric/1.11.0.4.75/lib64

I also had to change:

extra_rpaths: []

to

extra_rpaths: [/opt/cray/libfabric/1.11.0.4.75/lib64]

for the gcc@10.3.0 compiler in .spack/cray/compilers.yaml

Finally for cairo to install I had to do:

export LC_ALL=en_US.utf8

I'm not sure how to fix these for a user in general, but I am documenting them here.