### PR TITLE
[Draft] WarpX & HiPACE++: fftw-api Provider

### DIFF
--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -43,9 +43,14 @@ class Hipace(CMakePackage):
         depends_on('openpmd-api ~mpi', when='~mpi')
         depends_on('openpmd-api +mpi', when='+mpi')
     with when('compute=omp'):
-        depends_on('fftw@3: +openmp')
-        depends_on('fftw ~mpi', when='~mpi')
-        depends_on('fftw +mpi', when='+mpi')
+        # FFTW: general API, implemented by various packages
+        depends_on('fftw-api@3 +openmp')
+        depends_on('fftw-api ~mpi', when='~mpi')
+        depends_on('fftw-api +mpi', when='+mpi')
+        # FFTW: specific variants for implementations
+        depends_on('fftw@3: +openmp', when='^fftw')
+        depends_on('fftw ~mpi', when='~mpi ^fftw')
+        depends_on('fftw +mpi', when='+mpi ^fftw')
         depends_on('pkgconfig', type='build')
         depends_on('llvm-openmp', when='%apple-clang')
     with when('compute=hip'):

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -90,9 +90,14 @@ class Warpx(CMakePackage):
         depends_on('blaspp')
         depends_on('blaspp +cuda', when='compute=cuda')
     with when('+psatd compute=omp'):
-        depends_on('fftw@3: +openmp')
-        depends_on('fftw ~mpi', when='~mpi')
-        depends_on('fftw +mpi', when='+mpi')
+        # FFTW: general API, implemented by various packages
+        depends_on('fftw-api@3 +openmp')
+        depends_on('fftw-api ~mpi', when='~mpi')
+        depends_on('fftw-api +mpi', when='+mpi')
+        # FFTW: specific variants for implementations
+        depends_on('fftw@3: +openmp', when='^fftw')
+        depends_on('fftw ~mpi', when='~mpi ^fftw')
+        depends_on('fftw +mpi', when='+mpi ^fftw')
         depends_on('pkgconfig', type='build')
     with when('+openpmd'):
         depends_on('openpmd-api@0.13.1:')


### PR DESCRIPTION
Generalize the `fftw` dependency on the `fftw-api` virtual package (aka Spack Provider). That way, we can use the FFTW API from Cray's `libsci`, MKL and others.

I don't like that I cannot control the `+mpi`/`~mpi` requirement as well as `+openmp`/`~openmp` anymore for those from our `depends_on()` calls, but what shall I do.

Currently Spack concretizes `depends_on('fftw-api ~mpi +openmp')` to `^fftw@3.3.10+mpi~openmp`.

Update: using `when='^fftw'` dependencies now for `fftw` variants.


- [x] rebase after #27043
- [ ] depends on a solution/work-around/workflow for https://github.com/spack/spack/issues/1712