### PR TITLE
WarpX & HiPACE++: Constrain FFTW for No-MPI

### DIFF
--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -44,6 +44,7 @@ class Hipace(CMakePackage):
         depends_on('openpmd-api +mpi', when='+mpi')
     with when('compute=omp'):
         depends_on('fftw@3: +openmp')
+        depends_on('fftw ~mpi', when='~mpi')
         depends_on('fftw +mpi', when='+mpi')
         depends_on('pkgconfig', type='build')
         depends_on('llvm-openmp', when='%apple-clang')

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -90,6 +90,7 @@ class Warpx(CMakePackage):
         depends_on('blaspp +cuda', when='compute=cuda')
     with when('+psatd compute=omp'):
         depends_on('fftw@3: +openmp')
+        depends_on('fftw ~mpi', when='~mpi')
         depends_on('fftw +mpi', when='+mpi')
         depends_on('pkgconfig', type='build')
     with when('+openpmd'):


### PR DESCRIPTION
Contrain FFTW for no-MPI to simplify builds and logic to handle.