### PR TITLE
cuda: set CUDA_HOME for dependent packages

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -164,6 +164,7 @@ class Cuda(Package):
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('CUDAHOSTCXX', dependent_spec.package.compiler.cxx)
+        env.set('CUDA_HOME', self.prefix)
 
     def setup_run_environment(self, env):
         env.set('CUDA_HOME', self.prefix)


### PR DESCRIPTION
As was mentioned in #10088 there are certain things that expect `CUDA_HOME` to be set. One can also search for `CUDA_HOME` in [var/spack/repos/builtin/packages](https://github.com/spack/spack/tree/develop/var/spack/repos/builtin/packages). I am actually quite surprised that we still don't have it. Do I miss something and that has already been discussed?