### PR TITLE
New version: py-html5lib 1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -15,8 +15,7 @@ class PyHtml5lib(PythonPackage):
     version('1.1', sha256='b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f',
            preferred=True)
     version('1.0.1', sha256='66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736')
-    version('0.99', sha256='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-            url='https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-0.99.tar.gz')
+    version('0.99', sha256='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
     version('099', sha256='2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868',
            deprecated=True)
 

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -12,12 +12,19 @@ class PyHtml5lib(PythonPackage):
     homepage = "https://github.com/html5lib/html5lib-python"
     pypi = "html5lib/html5lib-099.tar.gz"
 
+    version('1.1', sha256='b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f')
     version('1.0.1', sha256='66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736')
-    version('099', sha256='2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868')
+    version('0.99', sha256='2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868',
+            url='https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-099.tar.gz')
 
     depends_on('python@2.6:2.8,3.2:', when='@099', type=('build', 'run'))
     depends_on('python@2.6:2.8,3.3:', when='@1.0.1:', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.5:', when='@1.1:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-six@1.9:', type=('build', 'run'), when='@1.0.1:')
     depends_on('py-setuptools', type='build', when='@1.0.1:')
     depends_on('py-webencodings', type=('build', 'run'), when='@1.0.1:')
+
+    def url_for_version(self, version):
+        root = 'https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-'
+        return root + str(version) + '.tar.gz'

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -17,7 +17,7 @@ class PyHtml5lib(PythonPackage):
     version('1.0.1', sha256='66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736')
     version('0.99', sha256='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
     version('099', sha256='2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868',
-           deprecated=True)
+            deprecated=True)
 
     depends_on('python@2.6:2.8,3.2:', when='@099', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.3:', when='@1.0.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -10,7 +10,7 @@ class PyHtml5lib(PythonPackage):
     """HTML parser based on the WHATWG HTML specification."""
 
     homepage = "https://github.com/html5lib/html5lib-python"
-    pypi = "html5lib/html5lib-099.tar.gz"
+    pypi = "html5lib/html5lib-1.1.tar.gz"
 
     version('1.1', sha256='b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f')
     version('1.0.1', sha256='66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736')

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -12,11 +12,13 @@ class PyHtml5lib(PythonPackage):
     homepage = "https://github.com/html5lib/html5lib-python"
     pypi = "html5lib/html5lib-1.1.tar.gz"
 
-    version('1.1', sha256='b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f')
+    version('1.1', sha256='b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f',
+           preferred=True)
     version('1.0.1', sha256='66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736')
     version('0.99', sha256='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-            url='https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-0.99.tar.gz',
-            deprecated=True)
+            url='https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-0.99.tar.gz')
+    version('099', sha256='2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868',
+           deprecated=True)
 
     depends_on('python@2.6:2.8,3.2:', when='@099', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.3:', when='@1.0.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -19,7 +19,7 @@ class PyHtml5lib(PythonPackage):
     version('099', sha256='2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868',
             deprecated=True)
 
-    depends_on('python@2.6:2.8,3.2:', when='@099', type=('build', 'run'))
+    depends_on('python@2.6:2.8,3.2:', when='@0.99', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.3:', when='@1.0.1:', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.5:', when='@1.1:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -13,7 +13,7 @@ class PyHtml5lib(PythonPackage):
     pypi = "html5lib/html5lib-1.1.tar.gz"
 
     version('1.1', sha256='b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f',
-           preferred=True)
+            preferred=True)
     version('1.0.1', sha256='66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736')
     version('0.99', sha256='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
     version('099', sha256='2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868',

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -18,8 +18,8 @@ class PyHtml5lib(PythonPackage):
             url='https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-099.tar.gz')
 
     depends_on('python@2.6:2.8,3.2:', when='@099', type=('build', 'run'))
-    depends_on('python@2.6:2.8,3.3:', when='@1.0.1:', type=('build', 'run'))
-    depends_on('python@2.6:2.8,3.5:', when='@1.1:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.3:', when='@1.0.1:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.5:', when='@1.1:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-six@1.9:', type=('build', 'run'), when='@1.0.1:')
     depends_on('py-setuptools', type='build', when='@1.0.1:')

--- a/var/spack/repos/builtin/packages/py-html5lib/package.py
+++ b/var/spack/repos/builtin/packages/py-html5lib/package.py
@@ -14,8 +14,9 @@ class PyHtml5lib(PythonPackage):
 
     version('1.1', sha256='b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f')
     version('1.0.1', sha256='66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736')
-    version('0.99', sha256='2612a191a8d5842bfa057e41ba50bbb9dcb722419d2408c78cff4758d0754868',
-            url='https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-099.tar.gz')
+    version('0.99', sha256='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+            url='https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-0.99.tar.gz',
+            deprecated=True)
 
     depends_on('python@2.6:2.8,3.2:', when='@099', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.3:', when='@1.0.1:', type=('build', 'run'))
@@ -24,7 +25,3 @@ class PyHtml5lib(PythonPackage):
     depends_on('py-six@1.9:', type=('build', 'run'), when='@1.0.1:')
     depends_on('py-setuptools', type='build', when='@1.0.1:')
     depends_on('py-webencodings', type=('build', 'run'), when='@1.0.1:')
-
-    def url_for_version(self, version):
-        root = 'https://files.pythonhosted.org/packages/source/h/html5lib/html5lib-'
-        return root + str(version) + '.tar.gz'


### PR DESCRIPTION
* Fix URL construction (the default URL generator treats '5lib' as part of the version)
* Fix version comparision