### PR TITLE
cmd/arch: add --generic argument

### DIFF
--- a/lib/spack/spack/cmd/arch.py
+++ b/lib/spack/spack/cmd/arch.py
@@ -21,6 +21,10 @@ level = "short"
 
 def setup_parser(subparser):
     subparser.add_argument(
+        '-g', '--generic-target', action='store_true',
+        help='show the best generic target'
+    )
+    subparser.add_argument(
         '--known-targets', action='store_true',
         help='show a list of all known targets and exit'
     )
@@ -74,6 +78,10 @@ def display_targets(targets):
 
 
 def arch(parser, args):
+    if args.generic_target:
+        print(archspec.cpu.host().generic)
+        return
+
     if args.known_targets:
         display_targets(archspec.cpu.TARGETS)
         return

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -382,7 +382,7 @@ _spack_analyze_run() {
 }
 
 _spack_arch() {
-    SPACK_COMPREPLY="-h --help --known-targets -p --platform -o --operating-system -t --target -f --frontend -b --backend"
+    SPACK_COMPREPLY="-h --help -g --generic-target --known-targets -p --platform -o --operating-system -t --target -f --frontend -b --backend"
 }
 
 _spack_audit() {


### PR DESCRIPTION
The `--generic` argument allows printing the best generic target for the current machine. This can be quite handy when wanting to find the generic architecture to use when building a shared software stack for multiple machines.