### PR TITLE
sirius: add mpi datatypes patch for recent cray mpich

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/mpi_datatypes.patch
+++ b/var/spack/repos/builtin/packages/sirius/mpi_datatypes.patch
@@ -1,0 +1,22 @@
+diff --git a/src/mpi/communicator.hpp b/src/mpi/communicator.hpp
+index 709e56cfc..a05375bda 100644
+--- a/src/mpi/communicator.hpp
++++ b/src/mpi/communicator.hpp
+@@ -111,7 +111,7 @@ struct mpi_type_wrapper<std::complex<double>>
+ {
+     static MPI_Datatype kind()
+     {
+-        return MPI_CXX_DOUBLE_COMPLEX;
++        return MPI_C_DOUBLE_COMPLEX;
+     }
+ };
+ 
+@@ -174,7 +174,7 @@ struct mpi_type_wrapper<bool>
+ {
+     static MPI_Datatype kind()
+     {
+-        return MPI_CXX_BOOL;
++        return MPI_C_BOOL;
+     }
+ };
+ 

--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -147,6 +147,7 @@ class Sirius(CMakePackage, CudaPackage):
     patch("strip-spglib-include-subfolder.patch", when='@6.1.5')
     patch("link-libraries-fortran.patch", when='@6.1.5')
     patch("cmake-fix-shared-library-installation.patch", when='@6.1.5')
+    patch("mpi_datatypes.patch", when="@:7.2.6")
 
     @property
     def libs(self):


### PR DESCRIPTION
Recent versions of cray-mpich define `null` for `MPI_CXX_*` data types, add a patch to replace them by the corresponding `MPI_C_*` types.