### PR TITLE
kokkos-nvcc-wrapper: Add HPE MPT to MPI environment variables

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-nvcc-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-nvcc-wrapper/package.py
@@ -42,6 +42,7 @@ class KokkosNvccWrapper(Package):
         env.set('KOKKOS_CXX', self.compiler.cxx)
         env.set('MPICH_CXX', wrapper)
         env.set('OMPI_CXX', wrapper)
+        env.set('MPICXX_CXX', wrapper) # HPE MPT
 
     def setup_dependent_package(self, module, dependent_spec):
         wrapper = join_path(self.prefix.bin, "nvcc_wrapper")


### PR DESCRIPTION
When using HPE's MPT MPI implementation with Kokkos, we need to use `MPICXX_CXX`.