### PR TITLE
qt: Extend build conflicts for %gcc@11 and fix build of v5.6.3

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -143,7 +143,8 @@ class Qt(Package):
           working_dir='qtwebsockets',
           when='@5.14: %gcc@11:')
     conflicts('%gcc@10:', when='@5.9:5.12.6 +opengl')
-    conflicts('%gcc@11:', when='@5.9:5.13')
+    # Error: 'numeric_limits' is not a class template
+    conflicts('%gcc@11:', when='@5.8:5.14')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')
@@ -523,10 +524,10 @@ class Qt(Package):
             use_spack_dep('jpeg', 'libjpeg')
             use_spack_dep('zlib')
 
-        if '@:5.7.0' in spec:
+        if '@:5.5' in spec:
             config_args.extend([
                 # NIS is deprecated in more recent glibc,
-                # but qt-5.7.1 does not recognize this option
+                # but qt-5.6.3 does not recognize this option
                 '-no-nis',
             ])
 
@@ -635,7 +636,7 @@ class Qt(Package):
         if '~webkit' in spec:
             config_args.extend([
                 '-skip',
-                'webengine' if version >= Version('5.7') else 'qtwebkit',
+                'webengine' if version >= Version('5.6') else 'qtwebkit',
             ])
 
         if spec.satisfies('@5.7'):


### PR DESCRIPTION
### Extend build conflicts for %gcc@11 ###

* 5.14.2 fails with %gcc@11 with Error: 'numeric_limits' is not a class template
* 5.8.0 has multiple compile failures as well: Extend the conflict to those too.

### Fix the build of 5.6.3 ###

- The qtwebkit module was removed from qt as of version 5.6, not 5.7 (as also written here):
https://github.com/spack/spack/blob/15e5508fcfd60e6f014eabdd440ab05fe7f3d497/var/spack/repos/builtin/packages/qgis/package.py#L142

- Two options were passed to configure of @5.6.3 which cause it to fail independent of the compiler (tested with %gcc@11, build works with it)

ping @sethrj 