### PR TITLE
trilinos: Avoid Intel compiler segfaults in Trilinos with STK

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -357,7 +357,7 @@ class Trilinos(CMakePackage, CudaPackage):
         is_cce = self.spec.satisfies('%cce')
 
         # Workaround for Intel compiler segfaults with STK and IPO
-        if '+stk%intel' in self.spec:
+        if '+stk%intel' in self.spec and name == 'cxxflags':
             flags.append('-no-ipo')
 
         if name == 'cxxflags':

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -356,6 +356,10 @@ class Trilinos(CMakePackage, CudaPackage):
     def flag_handler(self, name, flags):
         is_cce = self.spec.satisfies('%cce')
 
+        # Workaround for Intel compiler segfaults with STK and IPO
+        if '+stk%intel' in self.spec and name != 'ldflags':
+            flags.append('-no-ipo')
+
         if name == 'cxxflags':
             spec = self.spec
             if '+mumps' in spec:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -356,10 +356,6 @@ class Trilinos(CMakePackage, CudaPackage):
     def flag_handler(self, name, flags):
         is_cce = self.spec.satisfies('%cce')
 
-        # Workaround for Intel compiler segfaults with STK and IPO
-        if '+stk%intel' in self.spec and name == 'cxxflags':
-            flags.append('-no-ipo')
-
         if name == 'cxxflags':
             spec = self.spec
             if '+mumps' in spec:
@@ -367,6 +363,9 @@ class Trilinos(CMakePackage, CudaPackage):
                 flags.append('-DMUMPS_5_0')
             if '+stk platform=darwin' in spec:
                 flags.append('-DSTK_NO_BOOST_STACKTRACE')
+            if '+stk%intel' in spec:
+                # Workaround for Intel compiler segfaults with STK and IPO
+                flags.append('-no-ipo')
             if '+wrapper' in spec:
                 flags.append('--expt-extended-lambda')
         elif name == 'ldflags' and is_cce:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -357,7 +357,7 @@ class Trilinos(CMakePackage, CudaPackage):
         is_cce = self.spec.satisfies('%cce')
 
         # Workaround for Intel compiler segfaults with STK and IPO
-        if '+stk%intel' in self.spec and name != 'ldflags':
+        if '+stk%intel' in self.spec:
             flags.append('-no-ipo')
 
         if name == 'cxxflags':


### PR DESCRIPTION
We have tested the version below of this. I need to test this updated version I tried to create for this PR. @alanw0 and @psakievich can verify that we have found `-no-ipo` to be necessary in this case or basically any version of the Intel compiler can segfault.
```
        if '%intel' in spec and '+stk' in spec:
            for cc in "CXX C F LD".split():
                env.append_flags(cc + "FLAGS", '-no-ipo')
```