### PR TITLE
hipblas: Add spack test support

### DIFF
--- a/var/spack/repos/builtin/packages/hipblas/link-clients-blas.patch
+++ b/var/spack/repos/builtin/packages/hipblas/link-clients-blas.patch
@@ -1,0 +1,24 @@
+diff -r -u a/clients/benchmarks/CMakeLists.txt b/clients/benchmarks/CMakeLists.txt
+--- a/clients/benchmarks/CMakeLists.txt	2021-10-28 14:14:41.379987882 -0600
++++ b/clients/benchmarks/CMakeLists.txt	2021-10-28 13:37:50.409696036 -0600
+@@ -53,7 +53,7 @@
+     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
+ )
+ 
+-target_link_libraries( hipblas-bench PRIVATE hipblas_fortran_client roc::hipblas cblas lapack)
++target_link_libraries( hipblas-bench PRIVATE hipblas_fortran_client roc::hipblas cblas lapack blas)
+ 
+ # need mf16c flag for float->half convertion
+ target_compile_options( hipblas-bench PRIVATE -mf16c)
+diff -r -u a/clients/gtest/CMakeLists.txt b/clients/gtest/CMakeLists.txt
+--- a/clients/gtest/CMakeLists.txt	2021-10-28 14:14:41.379987882 -0600
++++ b/clients/gtest/CMakeLists.txt	2021-10-28 13:37:34.609274623 -0600
+@@ -146,7 +146,7 @@
+     ${ROCM_PATH}/hsa/include
+ )
+ 
+-target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack ${GTEST_LIBRARIES} ${Boost_LIBRARIES} hipblas_fortran_client )
++target_link_libraries( hipblas-test PRIVATE roc::hipblas cblas lapack blas ${GTEST_LIBRARIES} ${Boost_LIBRARIES} hipblas_fortran_client )
+ 
+ # need mf16c flag for float->half convertion
+ target_compile_options( hipblas-test PRIVATE -mf16c )

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -29,6 +29,16 @@ class Hipblas(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
+    depends_on('googletest@1.10.0:', type='test')
+    depends_on('netlib-lapack@3.7.1:', type='test')
+    depends_on('boost@1.64.0: cxxstd=14', type='test')
+
+    patch('link-clients-blas.patch', when='@4.3.0:')
+
+    def check(self):
+        exe = join_path(self.build_directory, 'clients', 'staging', 'hipblas-test')
+        self.run_test(exe)
+
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1']:
         depends_on('hip@' + ver, when='@' + ver)
@@ -42,7 +52,7 @@ class Hipblas(CMakePackage):
             # Make sure find_package(HIP) finds the module.
             self.define('CMAKE_MODULE_PATH', self.spec['hip'].prefix.cmake),
             self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
-            self.define('BUILD_CLIENTS_TESTS', 'OFF')
+            self.define('BUILD_CLIENTS_TESTS', self.run_tests)
         ]
 
         # hipblas actually prefers CUDA over AMD GPUs when you have it


### PR DESCRIPTION
This change adds support for building the hipblas-test client and teaches spack how to run the tests. The change is pretty similar to #26919. Though, these tests will run ~30 minutes.

To give it a spin, try:
```
spack install --verbose --test=root hipblas@4.3.1
```

@haampie @srekolam @arjun-raj-kuppala