### PR TITLE
Fix style checks (and command return codes)

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -873,7 +873,7 @@ def main(argv=None):
 
     """
     try:
-        _main(argv)
+        return _main(argv)
 
     except SpackError as e:
         tty.debug(e)


### PR DESCRIPTION
Bug introduced in https://github.com/spack/spack/pull/24689 (in particular see https://github.com/spack/spack/pull/24689#issuecomment-954976350)

For Spack commands that fail but don't throw exceptions, we were discarding the return code. This restores that.