### PR TITLE
minc-toolkit: add perl-text-format as a dependency

### DIFF
--- a/var/spack/repos/builtin/packages/minc-toolkit/package.py
+++ b/var/spack/repos/builtin/packages/minc-toolkit/package.py
@@ -21,6 +21,7 @@ class MincToolkit(CMakePackage):
             description="Build visual tools (Display, register, etc.)")
 
     depends_on('perl')
+    depends_on('perl-text-format')  # vendored Text::Format not added to Perl @INC path
     depends_on('flex', type='build')
     depends_on('bison', type='build')
     depends_on('zlib', type='link')


### PR DESCRIPTION
- the toolkit vendors Text::Format but it doesn't get added to the Perl path