### PR TITLE
pipelines: llvm kills the xlarge, use huge

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -39,7 +39,10 @@ spack:
       - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
       - spack -d ci rebuild
     mappings:
-      - match: [vtk-h, vtk-m, paraview, llvm, vtk]
+      - match: [llvm]
+        runner-attributes:
+          tags: ["spack", "public", "huge", "x86_64"]
+      - match: [vtk-h, vtk-m, paraview, vtk]
         runner-attributes:
           tags: ["spack", "public", "xlarge", "x86_64"]
       - match: ['@:']

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -217,12 +217,16 @@ spack:
 
     mappings:
       - match:
+        - llvm
+        - llvm-amdgpu
+        runner-attributes:
+          image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+          tags: ["spack", "public", "huge", "x86_64"]
+      - match:
         - cuda
         - dyninst
         - hpx
         - kokkos-kernels
-        - llvm
-        - llvm-amdgpu
         - precice
         - rocblas
         - rocsolver


### PR DESCRIPTION
Map jobs building `llvm` to larger cloud instances as it is exceeding the resource limits of the current instances we build it with.