### PR TITLE
mpibind: Adding Python bindings

### DIFF
--- a/var/spack/repos/builtin/packages/mpibind/package.py
+++ b/var/spack/repos/builtin/packages/mpibind/package.py
@@ -23,10 +23,10 @@ class Mpibind(AutotoolsPackage):
     # Furthermore, the package can't be cached because
     # AC_INIT would be missing the version argument,
     # which is derived with git.
-    version('master', branch='master', get_full_repo=True)
-    version('0.8.0',  tag='v0.8.0',    no_cache=True)
-    version('0.7.0',  tag='v0.7.0',    no_cache=True)
-    version('0.5.0',  tag='v0.5.0',    no_cache=True)
+    version('master', branch='master',  get_full_repo=True)
+    version('0.8.0',  commit='ff38b9d', no_cache=True)
+    version('0.7.0',  commit='3c437a9', no_cache=True)
+    version('0.5.0',  commit='8698f07', no_cache=True)
 
     variant('cuda',   default=False,
             description='Build w/support for NVIDIA GPUs.')

--- a/var/spack/repos/builtin/packages/mpibind/package.py
+++ b/var/spack/repos/builtin/packages/mpibind/package.py
@@ -13,39 +13,48 @@ class Mpibind(AutotoolsPackage):
     to heterogeneous architectures"""
 
     homepage    = "https://github.com/LLNL/mpibind"
-    url         = "https://github.com/LLNL/mpibind/archive/refs/tags/v0.5.0.tar.gz"
     git         = "https://github.com/LLNL/mpibind.git"
 
     maintainers = ['eleon']
 
-    # The build process uses 'git describe --tags' to get the
-    # package version, thus we need 'get_full_repo'
+    # This package uses 'git describe --tags' to get the
+    # package version in Autotools' AC_INIT, thus
+    # 'get_full_repo' is needed.
+    # Furthermore, the package can't be cached because
+    # AC_INIT would be missing the version argument,
+    # which is derived with git.
     version('master', branch='master', get_full_repo=True)
-    version('0.7.0', sha256='33077e7eb50322d2bcfe87bb3ea9159c2e49f6f045cbbcd2e69e763c3bec4330')
-    version('0.5.0', sha256='51bb27341109aeef121a8630bd56f5551c70ebfd337a459fb70ef9015d97d2b7')
+    version('0.8.0',  tag='v0.8.0',    no_cache=True)
+    version('0.7.0',  tag='v0.7.0',    no_cache=True)
+    version('0.5.0',  tag='v0.5.0',    no_cache=True)
 
-    variant('cuda', default=False,
+    variant('cuda',   default=False,
             description='Build w/support for NVIDIA GPUs.')
-    variant('rocm', default=False,
+    variant('rocm',   default=False,
             description='Build w/support for AMD GPUs.')
-    variant('flux', default=False,
+    variant('flux',   default=False,
             description='Build the Flux plugin.')
+    variant('python', default=False,
+            description='Build the Python bindings.')
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool',  type='build')
-    depends_on('m4',       type='build')
+    depends_on('autoconf',  type='build')
+    depends_on('automake',  type='build')
+    depends_on('libtool',   type='build')
+    depends_on('m4',        type='build')
     depends_on('pkgconfig', type='build')
 
-    depends_on('hwloc@2:+libxml2', type='link')
-    depends_on('hwloc@2:+pci', when=(sys.platform != 'darwin'), type='link')
-    depends_on('hwloc@2:+cuda+nvml', when='+cuda', type='link')
-    depends_on('hwloc@2.4:+rocm+opencl', when='+rocm', type='link')
+    depends_on('hwloc@2:+libxml2',       type='link')
+    depends_on('hwloc@2:+cuda+nvml',     type='link', when='+cuda')
+    depends_on('hwloc@2.4:+rocm+opencl', type='link', when='+rocm')
+    depends_on('hwloc@2:+pci',           type='link',
+               when=(sys.platform != 'darwin'))
 
-    # Requiring @master temporarily while Flux adds
-    # FLUX_SHELL_RC_PATH to a stable version (>0.29.0).
-    # mpibind will require at least such version.
-    depends_on('flux-core@master', when='+flux', type='link')
+    # flux-core >= 0.30.0 supports FLUX_SHELL_RC_PATH,
+    # which is needed to load the plugin into Flux
+    depends_on('flux-core@0.30:', when='+flux', type='link')
+
+    depends_on('python@3:', when='+python', type=('build', 'run'))
+    depends_on('py-cffi',   when='+python', type=('build', 'run'))
 
     def autoreconf(self, spec, prefix):
         autoreconf('--install', '--verbose', '--force')
@@ -56,6 +65,8 @@ class Mpibind(AutotoolsPackage):
         env.prepend_path('FLUX_SHELL_RC_PATH',
                          join_path(self.prefix, 'share', 'mpibind'))
 
-    # To build and run the tests, make sure 'libtap' is installed
-    # on the target system and is recognized by pkg-config.
-    # Unfortunately, libtap is not in Spack.
+    # To build and run the C unit tests, make sure 'libtap'
+    # is installed and recognized by pkgconfig.
+    # To build and run the Python unit tests, make sure 'pycotap'
+    # is installed in your Python environment.
+    # Unfortunately, 'tap' and 'pycotap' are not in Spack.


### PR DESCRIPTION
In addition to the Python interface, the `mpibind` recipe now uses `git` for all versions since git is used to get the package version in `Autotools`.