### PR TITLE
SpecBuilder: ensure external path for external specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1522,6 +1522,7 @@ class SpecBuilder(object):
         self._specs[pkg].external_modules = (
             spack.spec.Spec._format_module_list(spec_info.get('modules', None))
         )
+        spack.spec.Spec.ensure_external_path_if_external(self._specs[pkg])
         self._specs[pkg].extra_attributes = spec_info.get(
             'extra_attributes', {}
         )


### PR DESCRIPTION
Fixes #24506 

Ensures that external specs rebuilt from clingo concretization set the external_path property, even if the external is specified by module.

@Paul-Ferrell can you confirm that this fixes your bug?