### PR TITLE
Fix symlinked directories in views

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -879,7 +879,7 @@ def traverse_tree(source_root, dest_root, rel_path='', **kwargs):
         follow_links (bool): Whether to descend into symlinks in ``src``
     """
     follow_nonexisting = kwargs.get('follow_nonexisting', True)
-    follow_links = kwargs.get('follow_link', False)
+    follow_links = kwargs.get('follow_links', False)
 
     # Yield in pre or post order?
     order = kwargs.get('order', 'pre')

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -91,7 +91,7 @@ class LinkTree(object):
                     link_dest = os.path.realpath(src)
                     link_rel = os.path.relpath(link_dest, start=src_parent)
 
-                    # Only create the link if it's inside the root root. 
+                    # Only create the link if it's inside the root root.
                     real_root = os.path.realpath(self._root)
                     if not os.path.relpath(link_dest, real_root).startswith('..'):
                         # Create link from dest to that relative location.
@@ -121,7 +121,7 @@ class LinkTree(object):
         # We have to find them all first, as they could link to each other.
         for link in rem_link_list:
             os.unlink(link)
-        
+ 
         for src, dest in traverse_tree(
                 self._root, dest_root, ignore=ignore, order='post'):
             if os.path.isdir(src):

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -91,7 +91,7 @@ class LinkTree(object):
                     link_dest = os.path.realpath(src)
                     link_rel = os.path.relpath(link_dest, start=src_parent)
 
-                    # Only create the link if it's inside the root root.
+                    # Only create the link if it's inside the root
                     real_root = os.path.realpath(self._root)
                     if not os.path.relpath(link_dest, real_root).startswith('..'):
                         # Create link from dest to that relative location.
@@ -191,8 +191,7 @@ class LinkTree(object):
             ignore = lambda x: False
 
         for src, dst in self.get_file_map(dest_root, ignore).items():
-            if not os.path.isdir(src):
-                remove_file(src, dst)
+            remove_file(src, dst)
         self.unmerge_directories(dest_root, ignore)
 
 

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -84,29 +84,44 @@ class LinkTree(object):
             if os.path.isdir(src):
                 if os.path.islink(src):
                     # Make a relative link in dest that mirrors the link in src.
-                    # Create a resolved src path except for the final component
-                    # This avoids unnecessary fs backtracking
+
                     src_parent = os.path.realpath(os.path.dirname(src))
-                    clean_src = os.path.join(src_parent, os.path.basename(src))
-                    link_dest = os.path.realpath(src)
+
                     # Find the relative path between src and it's target.
-                    link_rel = os.path.relpath(link_dest, clean_src)
-                    # Create link from dest to that relative location.
-                    os.symlink(link_rel, dest)
+                    link_dest = os.path.realpath(src)
+                    link_rel = os.path.relpath(link_dest, start=src_parent)
 
-                if not os.path.exists(dest):
-                    mkdirp(dest)
-                    continue
+                    # Only create the link if it's inside the root root. 
+                    real_root = os.path.realpath(self._root)
+                    if not os.path.relpath(link_dest, real_root).startswith('..'):
+                        # Create link from dest to that relative location.
+                        os.symlink(link_rel, dest)
 
-                if not os.path.isdir(dest):
-                    raise ValueError("File blocks directory: %s" % dest)
+                else:
+                    if not os.path.exists(dest):
+                        mkdirp(dest)
+                        continue
 
-                # mark empty directories so they aren't removed on unmerge.
-                if not os.listdir(dest):
-                    marker = os.path.join(dest, empty_file_name)
-                    touch(marker)
+                    if not os.path.isdir(dest):
+                        raise ValueError("File blocks directory: %s" % dest)
+
+                    # mark empty directories so they aren't removed on unmerge.
+                    if not os.listdir(dest):
+                        marker = os.path.join(dest, empty_file_name)
+                        touch(marker)
 
     def unmerge_directories(self, dest_root, ignore):
+        # Remove any symlinked directories first, while the directories still exist.
+        rem_link_list = []
+        for src, dest in traverse_tree(
+                self._root, dest_root, ignore=ignore, order='post'):
+            if os.path.isdir(src) and os.path.isdir(dest) and os.path.islink(dest):
+                rem_link_list.append(dest)
+
+        # We have to find them all first, as they could link to each other.
+        for link in rem_link_list:
+            os.unlink(link)
+        
         for src, dest in traverse_tree(
                 self._root, dest_root, ignore=ignore, order='post'):
             if os.path.isdir(src):
@@ -176,7 +191,8 @@ class LinkTree(object):
             ignore = lambda x: False
 
         for src, dst in self.get_file_map(dest_root, ignore).items():
-            remove_file(src, dst)
+            if not os.path.isdir(src):
+                remove_file(src, dst)
         self.unmerge_directories(dest_root, ignore)
 
 

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -82,6 +82,18 @@ class LinkTree(object):
     def merge_directories(self, dest_root, ignore):
         for src, dest in traverse_tree(self._root, dest_root, ignore=ignore):
             if os.path.isdir(src):
+                if os.path.islink(src):
+                    # Make a relative link in dest that mirrors the link in src.
+                    # Create a resolved src path except for the final component
+                    # This avoids unnecessary fs backtracking
+                    src_parent = os.path.realpath(os.path.dirname(src))
+                    clean_src = os.path.join(src_parent, os.path.basename(src))
+                    link_dest = os.path.realpath(src)
+                    # Find the relative path between src and it's target.
+                    link_rel = os.path.relpath(link_dest, clean_src)
+                    # Create link from dest to that relative location.
+                    os.symlink(link_rel, dest)
+
                 if not os.path.exists(dest):
                     mkdirp(dest)
                     continue

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -121,7 +121,7 @@ class LinkTree(object):
         # We have to find them all first, as they could link to each other.
         for link in rem_link_list:
             os.unlink(link)
- 
+
         for src, dest in traverse_tree(
                 self._root, dest_root, ignore=ignore, order='post'):
             if os.path.isdir(src):

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -174,4 +174,3 @@ def test_ignore(stage, link_tree):
 
         assert os.path.isfile('source/.spec')
         assert os.path.isfile('dest/.spec')
-

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -27,6 +27,8 @@ def stage():
         touchp('source/c/d/5')
         touchp('source/c/d/6')
         touchp('source/c/d/e/7')
+        os.symlink('c/d', 'source/d')
+        os.symlink('d', 'source/e')
 
     yield s
 
@@ -70,7 +72,7 @@ def test_merge_to_new_directory(stage, link_tree):
         assert os.path.isabs(os.readlink('dest/c/d/5'))
         assert os.path.isabs(os.readlink('dest/c/d/6'))
         assert os.path.isabs(os.readlink('dest/c/d/e/7'))
-
+ 
         link_tree.unmerge('dest')
 
         assert not os.path.exists('dest')

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -27,8 +27,12 @@ def stage():
         touchp('source/c/d/5')
         touchp('source/c/d/6')
         touchp('source/c/d/e/7')
+        # Symlinked directores will get a relative link within dest.
         os.symlink('c/d', 'source/d')
+        # Removing symlinks to symlinks has pitfalls to avoid.
         os.symlink('d', 'source/e')
+        # This symlink points outside of source, and should be ignored.
+        os.symlink('../../', 'source/f')
 
     yield s
 
@@ -170,3 +174,4 @@ def test_ignore(stage, link_tree):
 
         assert os.path.isfile('source/.spec')
         assert os.path.isfile('dest/.spec')
+

--- a/lib/spack/spack/test/llnl/util/link_tree.py
+++ b/lib/spack/spack/test/llnl/util/link_tree.py
@@ -72,7 +72,7 @@ def test_merge_to_new_directory(stage, link_tree):
         assert os.path.isabs(os.readlink('dest/c/d/5'))
         assert os.path.isabs(os.readlink('dest/c/d/6'))
         assert os.path.isabs(os.readlink('dest/c/d/e/7'))
- 
+
         link_tree.unmerge('dest')
 
         assert not os.path.exists('dest')


### PR DESCRIPTION
If a package install contains a symlink to another directory in the install, view creation currently creates an empty directory in the view instead of that link.

This change causes the link_tree to instead create a relative symlink to the original target as it exists in the link_tree.

For example, an install contains the following:
```
install_path/file1
install_path/dirA/file2
install_path/dirB -> dirA   (dirB is a symlink to dirA)
```
the following link tree is created:
```
view/file1 -> install_path/file1   (view/file1 is a symlink to file1 in the original install path)
view/dirA  # Just a directory
view/dirA/file2 -> install_path/dirA/file2
view/dirB -> dirA  (A relative symlink to dirA in the view)
```

