### PR TITLE
Add the spack tutorial environment as a cloud pipeline stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -281,3 +281,38 @@ data-vis-sdk-develop-build:
   needs:
     - artifacts: True
       job: data-vis-sdk-develop-generate
+
+########################################
+# Spack Tutorial
+########################################
+.tutorial:
+  variables:
+    SPACK_CI_STACK_NAME: tutorial
+
+tutorial-pr-generate:
+  extends: [ ".tutorial", ".pr-generate"]
+
+tutorial-develop-generate:
+  extends: [ ".tutorial", ".develop-generate"]
+
+tutorial-pr-build:
+  extends: [ ".tutorial", ".pr-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: tutorial-pr-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: tutorial-pr-generate
+
+tutorial-develop-build:
+  extends: [ ".tutorial", ".develop-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: tutorial-develop-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: tutorial-develop-generate

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -59,6 +59,7 @@ spack:
     script:
       - . "./share/spack/setup-env.sh"
       - spack --version
+      - spack compiler find
       - cd ${SPACK_CONCRETE_ENV_DIR}
       - spack env activate --without-view .
       - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -62,16 +62,19 @@ spack:
       - cd ${SPACK_CONCRETE_ENV_DIR}
       - spack env activate --without-view .
       - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
-      - spack ${SPACK_DEBUG} ci rebuild
+      - spack -d ci rebuild
     mappings:
       - match: [llvm]
         runner-attributes:
+          image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
           tags: ["spack", "public", "huge", "x86_64"]
       - match: [trilinos, gcc]
         runner-attributes:
+          image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
           tags: ["spack", "public", "xlarge", "x86_64"]
       - match: ['@:']
         runner-attributes:
+          image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
           tags: ["spack", "public", "large", "x86_64"]
     temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -57,7 +57,7 @@ spack:
 
   gitlab-ci:
     script:
-      - . "./spack/share/spack/setup-env.sh"
+      - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}
       - spack env activate --without-view .

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -66,20 +66,20 @@ spack:
     mappings:
       - match: [llvm]
         runner-attributes:
-          image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+          image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
           tags: ["spack", "public", "huge", "x86_64"]
       - match: [trilinos, gcc]
         runner-attributes:
-          image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+          image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
           tags: ["spack", "public", "xlarge", "x86_64"]
       - match: ['@:']
         runner-attributes:
-          image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+          image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
           tags: ["spack", "public", "large", "x86_64"]
     temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
     service-job-attributes:
-      image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+      image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
       before_script:
         - . "./share/spack/setup-env.sh"
         - spack --version

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -1,0 +1,89 @@
+spack:
+  view: false
+  concretization: separately
+
+  config:
+    install_tree:
+      root: /home/software/spack
+      padded_length: 512
+      projections:
+        all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
+
+  packages:
+    all:
+      target: [x86_64]
+
+  definitions:
+  - gcc_system_packages:
+    - matrix:
+      - - zlib
+        - zlib@1.2.8
+        - zlib@1.2.8 cppflags=-O3
+        - tcl
+        - tcl ^zlib@1.2.8 cppflags=-O3
+        - hdf5
+        - hdf5~mpi
+        - hdf5+hl+mpi ^mpich
+        - trilinos
+        - trilinos +hdf5 ^hdf5+hl+mpi ^mpich
+        - gcc@8.3.0
+        - mpileaks
+        - lmod
+        - macsio@1.1+scr^scr@2.0.0~fortran^silo~fortran^hdf5~fortran
+      - ['%gcc@7.5.0']
+  - gcc_old_packages:
+    - zlib%gcc@6.5.0
+  - clang_packages:
+    - matrix:
+      - [zlib, tcl ^zlib@1.2.8]
+      - ['%clang@6.0.0']
+  - gcc_spack_built_packages:
+    - matrix:
+      - [netlib-scalapack]
+      - [^mpich, ^openmpi]
+      - [^openblas, ^netlib-lapack]
+      - ['%gcc@8.3.0']
+    - matrix:
+      - [py-scipy^openblas, armadillo^openblas, netlib-lapack, openmpi, mpich, elpa^mpich]
+      - ['%gcc@8.3.0']
+  specs:
+  - $gcc_system_packages
+  - $gcc_old_packages
+  - $clang_packages
+  - $gcc_spack_built_packages
+
+  mirrors:
+    mirror: 's3://spack-binaries-develop/tutorial'
+
+  gitlab-ci:
+    script:
+      - . "./spack/share/spack/setup-env.sh"
+      - spack --version
+      - cd ${SPACK_CONCRETE_ENV_DIR}
+      - spack env activate --without-view .
+      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+      - spack ${SPACK_DEBUG} ci rebuild
+    mappings:
+      - match: [llvm]
+        runner-attributes:
+          tags: ["spack", "public", "huge", "x86_64"]
+      - match: [trilinos, gcc]
+        runner-attributes:
+          tags: ["spack", "public", "xlarge", "x86_64"]
+      - match: ['@:']
+        runner-attributes:
+          tags: ["spack", "public", "large", "x86_64"]
+    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
+    broken-specs-url: "s3://spack-binaries-develop/broken-specs"
+    service-job-attributes:
+      image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }
+      before_script:
+        - . "./share/spack/setup-env.sh"
+        - spack --version
+      tags: ["spack", "public", "medium", "x86_64"]
+
+  cdash:
+    build-group: Spack Tutorial
+    url: https://cdash.spack.io
+    project: Spack Testing
+    site: Cloud Gitlab Infrastructure

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -26,7 +26,7 @@ spack:
         - hdf5+hl+mpi ^mpich
         - trilinos
         - trilinos +hdf5 ^hdf5+hl+mpi ^mpich
-        - gcc@8.3.0
+        - gcc@8.4.0
         - mpileaks
         - lmod
         - macsio@1.1+scr^scr@2.0.0~fortran^silo~fortran^hdf5~fortran
@@ -36,16 +36,16 @@ spack:
   - clang_packages:
     - matrix:
       - [zlib, tcl ^zlib@1.2.8]
-      - ['%clang@6.0.0']
+      - ['%clang@7.0.0']
   - gcc_spack_built_packages:
     - matrix:
       - [netlib-scalapack]
       - [^mpich, ^openmpi]
       - [^openblas, ^netlib-lapack]
-      - ['%gcc@8.3.0']
+      - ['%gcc@8.4.0']
     - matrix:
       - [py-scipy^openblas, armadillo^openblas, netlib-lapack, openmpi, mpich, elpa^mpich]
-      - ['%gcc@8.3.0']
+      - ['%gcc@8.4.0']
   specs:
   - $gcc_system_packages
   - $gcc_old_packages


### PR DESCRIPTION
This PR adds the Spack tutorial (environment) as a cloud pipeline stack.  

The goal is to ensure Spack is building a cache of binaries for the tutorial to simplify the tutorial preparation process.