### PR TITLE
relocate: do not change library id to use rpaths on package install

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1975,11 +1975,9 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         """On Darwin, make installed libraries more easily relocatable.
 
         Some build systems (handrolled, autotools, makefiles) can set their own
-        rpaths that are duplicated by spack's compiler wrapper. Additionally,
-        many simpler build systems do not link using ``-install_name
-        @rpath/foo.dylib``, which propagates the library's hardcoded
-        absolute path into downstream dependencies. This fixup interrogates,
-        and postprocesses if necessary, all libraries installed by the code.
+        rpaths that are duplicated by spack's compiler wrapper. This fixup
+        interrogates, and postprocesses if necessary, all libraries installed
+        by the code.
 
         It should be added as a @run_after to packaging systems (or individual
         packages) that do not install relocatable libraries by default.

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -469,9 +469,8 @@ def test_fixup_macos_rpaths(make_dylib, make_object_file):
     assert fixup_rpath(root, filename)
     assert not fixup_rpath(root, filename)
 
-    # Bad but relocatable library id
+    # Hardcoded but relocatable library id (but we do NOT relocate)
     (root, filename) = make_dylib("abs_with_rpath", no_rpath)
-    assert fixup_rpath(root, filename)
     assert not fixup_rpath(root, filename)
 
     # Library id uses rpath but there are extra duplicate rpaths


### PR DESCRIPTION
After #26608 I got a report about missing rpaths when building a downstream package independently using a spack-installed toolchain (@tmdelellis). This occurred because the spack-installed libraries were being linked into the downstream app, but the rpaths were not being manually added. Prior to #26608 autotools-installed libs would retain their hard-coded path and would thus propagate their link information into the downstream library on mac.

We could solve this problem *if* the mac linker (ld) respected `LD_RUN_PATH` like it does on GNU systems, i.e. adding `rpath` entries to each item in the environment variable. However on mac we would have to manually add rpaths either using spack's compiler wrapper scripts or manually (e.g. using `CMAKE_BUILD_RPATH` and pointing to the libraries of all the autotools-installed spack libraries).

The easier and safer thing to do for now is to simply stop changing the dylib IDs.
