### PR TITLE
Remove requiring hiop+shared in ExaGO.

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -48,7 +48,6 @@ class Exago(CMakePackage, CudaPackage):
     depends_on('cmake@3.18:', type='build')
 
     # HiOp dependency logic
-    depends_on('hiop+shared', when='+hiop')
     depends_on('hiop+raja', when='+hiop+raja')
     depends_on('hiop@0.3.99:', when='@0.99:+hiop')
     depends_on('hiop+cuda', when='+hiop+cuda')

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -13,6 +13,7 @@ class Exago(CMakePackage, CudaPackage):
 
     homepage = 'https://gitlab.pnnl.gov/exasgd/frameworks/exago'
     git = 'https://gitlab.pnnl.gov/exasgd/frameworks/exago.git'
+    maintainers = ['ashermancinelli', 'CameronRutherford']
 
     version('1.0.0', tag='v1.0.0')
     version('0.99.2', tag='v0.99.2')


### PR DESCRIPTION
Small patch to enable building HiOp together with ExaGO after https://github.com/spack/spack/pull/26905 introduced a conflict requiring static when building with cuda+raja [here](https://github.com/spack/spack/pull/26905/files#diff-0fe716984421ac744a1904e2c83154f2d8c091291a7985ef15b89e3377a3e75bR78).

cc @ashermancinelli if you have any other suggestions for this PR