### PR TITLE
Fix GitHub Action's container build

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,4 +1,5 @@
 name: Containers
+
 on:
   # This Workflow can be triggered manually
   workflow_dispatch:
@@ -59,7 +60,7 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action27d0a4f181a40b142cce983c5393082c365d1480 # @v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # @v1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # @v1


### PR DESCRIPTION
#26538 introduce a bug that causes the Docker image build to fail. This PR fixes the typo introduced there.