### PR TITLE
Python tests: skip importing weirdly-named modules

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -136,16 +136,14 @@ class PythonPackage(PackageBase):
         # Some Python libraries are packages: collections of modules
         # distributed in directories containing __init__.py files
         for path in find(root, '__init__.py', recursive=True):
-            mod = path.replace(root + os.sep, '', 1).replace(
-                os.sep + '__init__.py', '').replace('/', '.')
-            modules.append(mod)
+            modules.append(path.replace(root + os.sep, '', 1).replace(
+                os.sep + '__init__.py', '').replace('/', '.'))
 
         # Some Python libraries are modules: individual *.py files
         # found in the site-packages directory
         for path in find(root, '*.py', recursive=False):
-            mod = path.replace(root + os.sep, '', 1).replace(
-                '.py', '').replace('/', '.')
-            modules.append(mod)
+            modules.append(path.replace(root + os.sep, '', 1).replace(
+                '.py', '').replace('/', '.'))
 
         modules = [mod for mod in modules if re.match('[a-zA-Z0-9._]+$', mod)]
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -136,14 +136,20 @@ class PythonPackage(PackageBase):
         # Some Python libraries are packages: collections of modules
         # distributed in directories containing __init__.py files
         for path in find(root, '__init__.py', recursive=True):
-            modules.append(path.replace(root + os.sep, '', 1).replace(
-                os.sep + '__init__.py', '').replace('/', '.'))
+            mod = path.replace(root + os.sep, '', 1).replace(
+                os.sep + '__init__.py', '').replace('/', '.')
+            if not re.match('[a-zA-Z0-9._]+$', mod):
+                continue
+            modules.append(mod)
 
         # Some Python libraries are modules: individual *.py files
         # found in the site-packages directory
         for path in find(root, '*.py', recursive=False):
-            modules.append(path.replace(root + os.sep, '', 1).replace(
-                '.py', '').replace('/', '.'))
+            mod = path.replace(root + os.sep, '', 1).replace(
+                '.py', '').replace('/', '.')
+            if not re.match('[a-zA-Z0-9._]+$', mod):
+                continue
+            modules.append(mod)
 
         tty.debug('Detected the following modules: {0}'.format(modules))
 
@@ -320,9 +326,6 @@ class PythonPackage(PackageBase):
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
         for module in self.import_modules:
-            if not re.match('[a-zA-Z0-9._]+$', module):
-                continue
-
             self.run_test(inspect.getmodule(self).python.path,
                           ['-c', 'import {0}'.format(module)],
                           purpose='checking import of {0}'.format(module),

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -138,8 +138,6 @@ class PythonPackage(PackageBase):
         for path in find(root, '__init__.py', recursive=True):
             mod = path.replace(root + os.sep, '', 1).replace(
                 os.sep + '__init__.py', '').replace('/', '.')
-            if not re.match('[a-zA-Z0-9._]+$', mod):
-                continue
             modules.append(mod)
 
         # Some Python libraries are modules: individual *.py files
@@ -147,9 +145,9 @@ class PythonPackage(PackageBase):
         for path in find(root, '*.py', recursive=False):
             mod = path.replace(root + os.sep, '', 1).replace(
                 '.py', '').replace('/', '.')
-            if not re.match('[a-zA-Z0-9._]+$', mod):
-                continue
             modules.append(mod)
+
+        modules = [mod for mod in modules if re.match('[a-zA-Z0-9._]+$', mod)]
 
         tty.debug('Detected the following modules: {0}'.format(modules))
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -320,7 +320,7 @@ class PythonPackage(PackageBase):
         # not the ones in the source directory
         for module in self.import_modules:
             self.run_test(inspect.getmodule(self).python.path,
-                          ['-c', 'import {0}'.format(module)],
+                          ['-c', '__import__("{0}")'.format(module)],
                           purpose='checking import of {0}'.format(module),
                           work_dir='spack-test')
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import inspect
 import os
+import re
 import shutil
 
 import llnl.util.tty as tty
@@ -319,8 +320,11 @@ class PythonPackage(PackageBase):
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
         for module in self.import_modules:
+            if not re.match('[a-zA-Z0-9._]+$', module):
+                continue
+
             self.run_test(inspect.getmodule(self).python.path,
-                          ['-c', '__import__("{0}")'.format(module)],
+                          ['-c', 'import {0}'.format(module)],
                           purpose='checking import of {0}'.format(module),
                           work_dir='spack-test')
 

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -149,9 +149,6 @@ class SIPPackage(PackageBase):
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
         for module in self.import_modules:
-            if not re.match('[a-zA-Z0-9._]+$', module):
-                continue
-
             self.run_test(inspect.getmodule(self).python.path,
                           ['-c', 'import {0}'.format(module)],
                           purpose='checking import of {0}'.format(module),

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -5,6 +5,7 @@
 
 import inspect
 import os
+import re
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import find, join_path, working_dir
@@ -146,8 +147,11 @@ class SIPPackage(PackageBase):
         # Make sure we are importing the installed modules,
         # not the ones in the source directory
         for module in self.import_modules:
+            if not re.match('[a-zA-Z0-9._]+$', module):
+                continue
+
             self.run_test(inspect.getmodule(self).python.path,
-                          ['-c', '__import__("{0}")'.format(module)],
+                          ['-c', 'import {0}'.format(module)],
                           purpose='checking import of {0}'.format(module),
                           work_dir='spack-test')
 

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -147,7 +147,7 @@ class SIPPackage(PackageBase):
         # not the ones in the source directory
         for module in self.import_modules:
             self.run_test(inspect.getmodule(self).python.path,
-                          ['-c', 'import {0}'.format(module)],
+                          ['-c', '__import__("{0}")'.format(module)],
                           purpose='checking import of {0}'.format(module),
                           work_dir='spack-test')
 

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -73,16 +73,14 @@ class SIPPackage(PackageBase):
         # Some Python libraries are packages: collections of modules
         # distributed in directories containing __init__.py files
         for path in find(root, '__init__.py', recursive=True):
-            mod = path.replace(root + os.sep, '', 1).replace(
-                os.sep + '__init__.py', '').replace('/', '.')
-            modules.append(mod)
+            modules.append(path.replace(root + os.sep, '', 1).replace(
+                os.sep + '__init__.py', '').replace('/', '.'))
 
         # Some Python libraries are modules: individual *.py files
         # found in the site-packages directory
         for path in find(root, '*.py', recursive=False):
-            mod = path.replace(root + os.sep, '', 1).replace(
-                '.py', '').replace('/', '.')
-            modules.append(mod)
+            modules.append(path.replace(root + os.sep, '', 1).replace(
+                '.py', '').replace('/', '.'))
 
         modules = [mod for mod in modules if re.match('[a-zA-Z0-9._]+$', mod)]
 

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -73,14 +73,20 @@ class SIPPackage(PackageBase):
         # Some Python libraries are packages: collections of modules
         # distributed in directories containing __init__.py files
         for path in find(root, '__init__.py', recursive=True):
-            modules.append(path.replace(root + os.sep, '', 1).replace(
-                os.sep + '__init__.py', '').replace('/', '.'))
+            mod = path.replace(root + os.sep, '', 1).replace(
+                os.sep + '__init__.py', '').replace('/', '.')
+            if not re.match('[a-zA-Z0-9._]+$', mod):
+                continue
+            modules.append(mod)
 
         # Some Python libraries are modules: individual *.py files
         # found in the site-packages directory
         for path in find(root, '*.py', recursive=False):
-            modules.append(path.replace(root + os.sep, '', 1).replace(
-                '.py', '').replace('/', '.'))
+            mod = path.replace(root + os.sep, '', 1).replace(
+                '.py', '').replace('/', '.')
+            if not re.match('[a-zA-Z0-9._]+$', mod):
+                continue
+            modules.append(mod)
 
         tty.debug('Detected the following modules: {0}'.format(modules))
 

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -75,8 +75,6 @@ class SIPPackage(PackageBase):
         for path in find(root, '__init__.py', recursive=True):
             mod = path.replace(root + os.sep, '', 1).replace(
                 os.sep + '__init__.py', '').replace('/', '.')
-            if not re.match('[a-zA-Z0-9._]+$', mod):
-                continue
             modules.append(mod)
 
         # Some Python libraries are modules: individual *.py files
@@ -84,9 +82,9 @@ class SIPPackage(PackageBase):
         for path in find(root, '*.py', recursive=False):
             mod = path.replace(root + os.sep, '', 1).replace(
                 '.py', '').replace('/', '.')
-            if not re.match('[a-zA-Z0-9._]+$', mod):
-                continue
             modules.append(mod)
+
+        modules = [mod for mod in modules if re.match('[a-zA-Z0-9._]+$', mod)]
 
         tty.debug('Detected the following modules: {0}'.format(modules))
 


### PR DESCRIPTION
e.g. with dashes in name