### PR TITLE
Update docs how to display loaded modules

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -879,7 +879,7 @@ your path:
    ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/mpich@3.0.4/bin/mpicc
    $ spack find --loaded
    ==> 9 installed packages
-   -- linux-rhel7-broadwell / gcc@4.4.7 ----------------------------
+   -- linux-debian7-x86_64 / gcc@4.4.7 ----------------------------
    libiconv@1.16  libpciaccess@0.16  libxml2@2.9.12  mpich@3.0.4  xz@5.2.5
    zlib@1.2.11
 

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -864,11 +864,6 @@ your path:
    $ spack load mpich %gcc@4.4.7
    $ which mpicc
    ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/mpich@3.0.4/bin/mpicc
-   $ spack find --loaded
-   ==> 9 installed packages
-   -- linux-debian7-x86_64 / gcc@4.4.7 ----------------------------
-   libiconv@1.16  libpciaccess@0.16  libxml2@2.9.12  mpich@3.0.4  xz@5.2.5
-   zlib@1.2.11
 
 These commands will add appropriate directories to your ``PATH``,
 ``MANPATH``, ``CPATH``, and ``LD_LIBRARY_PATH`` according to the
@@ -916,8 +911,8 @@ first ``libelf`` above, you would run:
 
    $ spack load /qmm4kso
 
-To see which packages that you have installed and loaded to your enviornment
-you would use ``spack find --loaded``.
+To see which packages that you have loaded to your enviornment you would
+use ``spack find --loaded``.
 
 .. code-block:: console
 
@@ -1668,6 +1663,7 @@ and it will be added to the ``PYTHONPATH`` in your current shell:
 
 Now ``import numpy`` will succeed for as long as you keep your current
 session open.
+The loaded packages can be checked using ``spack find --loaded``
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Loading Extensions via Modules

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -591,6 +591,19 @@ with the 'debug' compile-time option enabled.
 
 The full spec syntax is discussed in detail in :ref:`sec-specs`.
 
+""""""""""""""""""""""""""""""""
+Seeing loaded packages
+""""""""""""""""""""""""""""""""
+To see the packages that you have installed and loaded to your enviornment
+you would use ``spack find --loaded``.
+
+.. code-block:: console
+
+    $ spack load libelf@0.8.12
+    $ spack find --loaded
+    ==> 1 installed package
+    -- linux-debian7-x86_64 / gcc@4.4.7 ----------------------------
+    libelf@0.8.12
 
 """"""""""""""""""""""""""""""""
 Machine-readable output
@@ -864,6 +877,11 @@ your path:
    $ spack load mpich %gcc@4.4.7
    $ which mpicc
    ~/spack/opt/linux-debian7-x86_64/gcc@4.4.7/mpich@3.0.4/bin/mpicc
+   $ spack find --loaded
+   ==> 9 installed packages
+   -- linux-rhel7-broadwell / gcc@4.4.7 ----------------------------
+   hwloc@2.5.0       libiconv@1.16      libxml2@2.9.12  ncurses@6.2  zlib@1.2.11
+   libfabric@1.13.1  libpciaccess@0.16  mpich@3.0.4     xz@5.2.5
 
 These commands will add appropriate directories to your ``PATH``,
 ``MANPATH``, ``CPATH``, and ``LD_LIBRARY_PATH`` according to the

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -591,19 +591,6 @@ with the 'debug' compile-time option enabled.
 
 The full spec syntax is discussed in detail in :ref:`sec-specs`.
 
-""""""""""""""""""""""""""""""""
-Seeing loaded packages
-""""""""""""""""""""""""""""""""
-To see the packages that you have installed and loaded to your enviornment
-you would use ``spack find --loaded``.
-
-.. code-block:: console
-
-    $ spack load libelf@0.8.12
-    $ spack find --loaded
-    ==> 1 installed package
-    -- linux-debian7-x86_64 / gcc@4.4.7 ----------------------------
-    libelf@0.8.12
 
 """"""""""""""""""""""""""""""""
 Machine-readable output
@@ -886,8 +873,9 @@ your path:
 These commands will add appropriate directories to your ``PATH``,
 ``MANPATH``, ``CPATH``, and ``LD_LIBRARY_PATH`` according to the
 :ref:`prefix inspections <customize-env-modifications>` defined in your
-modules configuration.  When you no longer want to use a package, you
-can type unload or unuse similarly:
+modules configuration.
+When you no longer want to use a package, you can type unload or
+unuse similarly:
 
 .. code-block:: console
 
@@ -927,6 +915,19 @@ first ``libelf`` above, you would run:
 .. code-block:: console
 
    $ spack load /qmm4kso
+
+To see which packages that you have installed and loaded to your enviornment
+you would use ``spack find --loaded``.
+
+.. code-block:: console
+
+    $ spack find --loaded
+    ==> 2 installed packages
+    -- linux-debian7 / gcc@4.4.7 ------------------------------------
+    libelf@0.8.13
+
+    -- linux-debian7 / intel@15.0.0 ---------------------------------
+    libelf@0.8.13
 
 We'll learn more about Spack's spec syntax in the next section.
 

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -880,8 +880,8 @@ your path:
    $ spack find --loaded
    ==> 9 installed packages
    -- linux-rhel7-broadwell / gcc@4.4.7 ----------------------------
-   hwloc@2.5.0       libiconv@1.16      libxml2@2.9.12  ncurses@6.2  zlib@1.2.11
-   libfabric@1.13.1  libpciaccess@0.16  mpich@3.0.4     xz@5.2.5
+   libiconv@1.16  libpciaccess@0.16  libxml2@2.9.12  mpich@3.0.4  xz@5.2.5
+   zlib@1.2.11
 
 These commands will add appropriate directories to your ``PATH``,
 ``MANPATH``, ``CPATH``, and ``LD_LIBRARY_PATH`` according to the


### PR DESCRIPTION
Closes #25249

Update the documentation on how to display a list of all modules loaded by `spack find --loaded`