### PR TITLE
Add module variables for NCEPLIBS 

### DIFF
--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -25,7 +25,7 @@ class Bufr(CMakePackage):
     def _setup_bufr_environment(self, env, suffix):
         libname = 'libufr_{0}'.format(suffix)
         lib = find_libraries(libname, root=self.prefix,
-                              shared=False, recursive=True)
+                             shared=False, recursive=True)
         lib_envname = 'BUFR_LIB{0}'.format(suffix)
         inc_envname = 'BUFR_INC{0}'.format(suffix)
         include_dir = 'include_{0}'.format(suffix)
@@ -36,7 +36,7 @@ class Bufr(CMakePackage):
         # Bufr has _DA (dynamic allocation) libs in versions <= 11.5.0
         if self.spec.satisfies('@:11.5.0'):
             da_lib = find_libraries(libname + "_DA", root=self.prefix,
-                              shared=False, recursive=True)
+                                    shared=False, recursive=True)
             env.set(lib_envname + '_DA', da_lib[0])
             env.set(inc_envname + '_DA', include_dir)
 

--- a/var/spack/repos/builtin/packages/bufr/package.py
+++ b/var/spack/repos/builtin/packages/bufr/package.py
@@ -21,3 +21,25 @@ class Bufr(CMakePackage):
                    'jbathegit']
 
     version('11.5.0', sha256='d154839e29ef1fe82e58cf20232e9f8a4f0610f0e8b6a394b7ca052e58f97f43')
+
+    def _setup_bufr_environment(self, env, suffix):
+        libname = 'libufr_{0}'.format(suffix)
+        lib = find_libraries(libname, root=self.prefix,
+                              shared=False, recursive=True)
+        lib_envname = 'BUFR_LIB{0}'.format(suffix)
+        inc_envname = 'BUFR_INC{0}'.format(suffix)
+        include_dir = 'include_{0}'.format(suffix)
+
+        env.set(lib_envname, lib[0])
+        env.set(inc_envname, include_dir)
+
+        # Bufr has _DA (dynamic allocation) libs in versions <= 11.5.0
+        if self.spec.satisfies('@:11.5.0'):
+            da_lib = find_libraries(libname + "_DA", root=self.prefix,
+                              shared=False, recursive=True)
+            env.set(lib_envname + '_DA', da_lib[0])
+            env.set(inc_envname + '_DA', include_dir)
+
+    def setup_run_environment(self, env):
+        for suffix in ('4', '8', 'd'):
+            self._setup_bufr_environment(env, suffix)

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -26,7 +26,7 @@ class G2(CMakePackage):
 
     def setup_run_environment(self, env):
         for suffix in ('4', 'd'):
-            lib = find_libraries('libg2_' + suffix, root=self.prefix, 
+            lib = find_libraries('libg2_' + suffix, root=self.prefix,
                                  shared=False, recursive=True)
             env.set('G2_LIB' + suffix, lib[0])
             env.set('G2_INC' + suffix, join_path(self.prefix, 'include_' + suffix))

--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -23,3 +23,10 @@ class G2(CMakePackage):
 
     depends_on('jasper')
     depends_on('libpng')
+
+    def setup_run_environment(self, env):
+        for suffix in ('4', 'd'):
+            lib = find_libraries('libg2_' + suffix, root=self.prefix, 
+                                 shared=False, recursive=True)
+            env.set('G2_LIB' + suffix, lib[0])
+            env.set('G2_INC' + suffix, join_path(self.prefix, 'include_' + suffix))

--- a/var/spack/repos/builtin/packages/g2c/package.py
+++ b/var/spack/repos/builtin/packages/g2c/package.py
@@ -26,3 +26,8 @@ class G2c(CMakePackage):
     depends_on('libpng', when='+png')
     depends_on('jasper', when='+jasper')
     depends_on('openjpeg', when='+openjpeg')
+
+    def setup_run_environment(self, env):
+        lib = find_libraries('libg2c', root=self.prefix, shared=False, recursive=True)
+        env.set('G2C_LIB', lib[0])
+        env.set('G2C_INC', join_path(self.prefix, 'include'))

--- a/var/spack/repos/builtin/packages/gfsio/package.py
+++ b/var/spack/repos/builtin/packages/gfsio/package.py
@@ -18,3 +18,10 @@ class Gfsio(CMakePackage):
     maintainers = ['t-brown', 'kgerheiser', 'Hang-Lei-NOAA', 'edwardhartnett']
 
     version('1.4.1', sha256='eab106302f520600decc4f9665d7c6a55e7b4901fab6d9ef40f29702b89b69b1')
+
+    def setup_run_environment(self, env):
+        lib = find_libraries('libgfsio', root=self.prefix, shared=False, recursive=True)
+        # Only one library version, but still need to set _4 to make NCO happy
+        for suffix in ('4', ''):
+            env.set('GFSIO_LIB' + suffix, lib[0])
+            env.set('GFSIO_INC' + suffix, join_path(self.prefix, 'include'))

--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -19,3 +19,10 @@ class Ip(CMakePackage):
     version('3.3.3', sha256='d5a569ca7c8225a3ade64ef5cd68f3319bcd11f6f86eb3dba901d93842eb3633')
 
     depends_on('sp')
+
+    def setup_run_environment(self, env):
+        for suffix in ('4', '8', 'd'):
+            lib = find_libraries('libip_4', root=self.prefix,
+                                 shared=False, recursive=True)
+            env.set('IP_LIB' + suffix, lib[0])
+            env.set('IP_INC' + suffix, join_path(self.prefix, 'include_' + suffix))

--- a/var/spack/repos/builtin/packages/ip2/package.py
+++ b/var/spack/repos/builtin/packages/ip2/package.py
@@ -22,3 +22,10 @@ class Ip2(CMakePackage):
     version('1.1.2', sha256='73c6beec8fd463ec7ccba3633d8c5d53d385c43d507367efde918c2db0af42ab')
 
     depends_on('sp')
+
+    def setup_run_environment(self, env):
+        for suffix in ('4', '8', 'd'):
+            lib = find_libraries('libip2_' + suffix, root=self.prefix,
+                                 shared=False, recursive=True)
+            env.set('IP2_LIB' + suffix, lib[0])
+            env.set('IP2_INC' + suffix, join_path(self.prefix, 'include_' + suffix))

--- a/var/spack/repos/builtin/packages/landsfcutil/package.py
+++ b/var/spack/repos/builtin/packages/landsfcutil/package.py
@@ -23,7 +23,7 @@ class Landsfcutil(CMakePackage):
         for suffix in ('4', 'd'):
             lib = find_libraries('liblandsfcutil_' + suffix, root=self.prefix,
                                  shared=False, recursive=True)
-        
+
             env.set('LANDSFCUTIL_LIB' + suffix, lib[0])
             env.set('LANDSFCUTIL_INC' + suffix,
                     join_path(self.prefix, 'include_' + suffix))

--- a/var/spack/repos/builtin/packages/landsfcutil/package.py
+++ b/var/spack/repos/builtin/packages/landsfcutil/package.py
@@ -18,3 +18,12 @@ class Landsfcutil(CMakePackage):
     maintainers = ['edwardhartnett', 'kgerheiser', 'Hang-Lei-NOAA']
 
     version('2.4.1', sha256='831c5005a480eabe9a8542b4deec838c2650f6966863ea2711cc0cc5db51ca14')
+
+    def setup_run_environment(self, env):
+        for suffix in ('4', 'd'):
+            lib = find_libraries('liblandsfcutil_' + suffix, root=self.prefix,
+                                 shared=False, recursive=True)
+        
+            env.set('LANDSFCUTIL_LIB' + suffix, lib[0])
+            env.set('LANDSFCUTIL_INC' + suffix,
+                    join_path(self.prefix, 'include_' + suffix))

--- a/var/spack/repos/builtin/packages/ncio/package.py
+++ b/var/spack/repos/builtin/packages/ncio/package.py
@@ -21,3 +21,9 @@ class Ncio(CMakePackage):
 
     depends_on('mpi')
     depends_on('netcdf-fortran')
+
+    def setup_run_environment(self, env):
+        lib = find_libraries('libncio', root=self.prefix, shared=False, recursive=True)
+        env.set('NCIO_LIB', lib[0])
+        env.set('NCIO_INC', join_path(self.prefix, 'include'))
+        env.set('NCIO_LIBDIR', lib[0])

--- a/var/spack/repos/builtin/packages/sfcio/package.py
+++ b/var/spack/repos/builtin/packages/sfcio/package.py
@@ -18,3 +18,10 @@ class Sfcio(CMakePackage):
     maintainers = ['t-brown', 'kgerheiser', 'Hang-Lei-NOAA', 'edwardhartnett']
 
     version('1.4.1', sha256='d9f900cf18ec1a839b4128c069b1336317ffc682086283443354896746b89c59')
+
+    def setup_run_environment(self, env):
+        lib = find_libraries('libsfcio', root=self.prefix, shared=False, recursive=True)
+        # Only one library version, but still need to set _4 to make NCO happy
+        for suffix in ('4', ''):
+            env.set('SFCIO_LIB' + suffix, lib[0])
+            env.set('SFCIO_INC' + suffix, join_path(self.prefix, 'include'))

--- a/var/spack/repos/builtin/packages/sigio/package.py
+++ b/var/spack/repos/builtin/packages/sigio/package.py
@@ -18,3 +18,10 @@ class Sigio(CMakePackage):
     maintainers = ['t-brown', 'kgerheiser', 'Hang-Lei-NOAA', 'edwardhartnett']
 
     version('2.3.2', sha256='333f3cf3a97f97103cbafcafc2ad89b24faa55b1332a98adc1637855e8a5b613')
+
+    def setup_run_environment(self, env):
+        lib = find_libraries('libsigio', root=self.prefix, shared=False, recursive=True)
+        # Only one library version, but still need to set _4 to make NCO happy
+        for suffix in ('4', ''):
+            env.set('SIGIO_LIB' + suffix, lib[0])
+            env.set('SIGIO_INC' + suffix, join_path(self.prefix, 'include'))

--- a/var/spack/repos/builtin/packages/sp/package.py
+++ b/var/spack/repos/builtin/packages/sp/package.py
@@ -17,3 +17,10 @@ class Sp(CMakePackage):
     maintainers = ['t-brown', 'kgerheiser', 'edwardhartnett', 'Hang-Lei-NOAA']
 
     version('2.3.3', sha256='c0d465209e599de3c0193e65671e290e9f422f659f1da928505489a3edeab99f')
+
+    def setup_run_environment(self, env):
+        for suffix in ('4', '8', 'd'):
+            lib = find_libraries('libsp_' + suffix, root=self.prefix,
+                                 shared=False, recursive=True)
+            env.set('SP_LIB' + suffix, lib[0])
+            env.set('SP_INC' + suffix, 'include_' + suffix)

--- a/var/spack/repos/builtin/packages/w3emc/package.py
+++ b/var/spack/repos/builtin/packages/w3emc/package.py
@@ -28,3 +28,10 @@ class W3emc(CMakePackage):
     depends_on('nemsio', when='@2.7.3')
     depends_on('sigio', when='@2.7.3')
     depends_on('netcdf-fortran', when='@2.7.3')
+
+    def setup_run_environment(self, env):
+        for suffix in ('4', '8', 'd'):
+            lib = find_libraries('libw3emc_' + suffix, root=self.prefix,
+                                 shared=False, recursive=True)
+            env.set('W3EMC_LIB' + suffix, lib[0])
+            env.set('W3EMC_INC' + suffix, join_path(self.prefix, 'include_' + suffix))


### PR DESCRIPTION
Use setup_run_environment to search for libraries and set env variables for module generation. 

Other non-spack builds rely on these variables.

Libraries are installed with CMAKE_INSTALL_LIBDIR, which can be lib or lib64 depending on the machine, which makes it impossible to hardcode through modules.yaml.

I know this is a little hacky,  but the documentation says to use setup_run_environment to add module variables, and I don't know of any other way to query the lib directory.