### PR TITLE
py-itk: fix dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-itk/package.py
+++ b/var/spack/repos/builtin/packages/py-itk/package.py
@@ -95,12 +95,11 @@ class PyItk(Package):
     depends_on('python@3.8.0:3.8', when='@5.1.1-cp38,5.1.2-cp38', type=('build', 'run'))
     depends_on('python@3.9.0:3.9', when='@5.1.2-cp39', type=('build', 'run'))
 
-    depends_on('itk@5.1.1', when='@5.1.1-cp35:5.1.1-cp39', type='run')
-    depends_on('itk@5.1.2', when='@5.1.2-cp35:5.1.2-cp39', type='run')
+    depends_on('py-setuptools', type='run')
 
     for t in set([str(x.family) for x in archspec.cpu.TARGETS.values()
                  if str(x.family) != 'x86_64']):
-        conflicts('target={0}:'.format(t), msg='py-itk is available x86_64 only')
+        conflicts('target={0}:'.format(t), msg='py-itk is available for x86_64 only')
 
     def install(self, spec, prefix):
         pip = which('pip')


### PR DESCRIPTION
`py-itk` didn't use its existing `itk` dependency but does rely on setuptools at runtime.