### PR TITLE
python, cmake: remove nvhpc conflict

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -153,7 +153,6 @@ class Cmake(Package):
               msg='CMake <3.18 does not compile with GCC on macOS, '
                   'please use %apple-clang or a newer CMake release. '
                   'See: https://gitlab.kitware.com/cmake/cmake/-/issues/21135')
-    conflicts('%nvhpc')
 
     # Really this should conflict since it's enabling or disabling openssl for
     # CMake's internal copy of curl.  Ideally we'd want a way to have the

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -239,8 +239,6 @@ class Python(AutotoolsPackage):
     conflicts('+tix', when='~tkinter',
               msg='python+tix requires python+tix+tkinter')
 
-    conflicts('%nvhpc')
-
     # Used to cache various attributes that are expensive to compute
     _config_vars = {}
 


### PR DESCRIPTION
`python` and `cmake` are confirmed to build successfully with `nvhpc`.  The conflicts as initially implemented were done so without specifying the nature of the conflict or pointing to known issues.  So this removes the conlfict since it's confirmed to build and if the a new conflict arises it can be added in a more narrowed and scoped restriction.