### PR TITLE
Speed up install of environments with dev packages

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -15,6 +15,7 @@ import ruamel.yaml as yaml
 import six
 
 import llnl.util.filesystem as fs
+import llnl.util.lang as lang
 import llnl.util.tty as tty
 
 import spack.bootstrap
@@ -1392,6 +1393,7 @@ class Environment(object):
         self.concretized_order.append(h)
         self.specs_by_hash[h] = concrete
 
+    @lang.memoized
     def _spec_needs_overwrite(self, spec):
         # Overwrite the install if it's a dev build (non-transitive)
         # and the code has been changed since the last install
@@ -1431,6 +1433,8 @@ class Environment(object):
         return mtime > record.installation_time
 
     def _get_overwrite_specs(self):
+        # TODO: Can the cache even be populated at this point?
+        self._spec_needs_overwrite.cache.clear()
         ret = []
         for dag_hash in self.concretized_order:
             spec = self.specs_by_hash[dag_hash]


### PR DESCRIPTION
I am currently experimenting with using environments as development environments, and I have an environment with roughly 50 root specs, with about 20 of them being local dev packages, i.e.

```yaml
spack:
  specs: 
    - lcio
  # about 50 other packages here
  develop:
    lcio:
      path: /path/to/local/git/repo
      spec: lcio@master
    # another 20 of these
```
This seems to work as expected, i.e. changing a dev package will result in a rebuild of the package itself and all its dependents via `spack install`. The problem I ran into was that it takes quite long (order of 15 - 20 minutes) for spack to figure out which packages need to be built again. This is also the case when there were no changes at all.

I have tracked this down to the fact that `Environment._spec_needs_overwrite` is called over and over again with the same specs, because when figuring out which packages to rebuild, spack walks the complete DAGs of all root packages (and then recursively the DAGs of dependencies as far as I can tell). This becomes quite expensive, because for dev packages it will actually start to compare timestamps of the source files with the installation time stamp. Simply memoizing the results for a given spec avoids having to check specs multiple times in different dependency graphs.

For me the observable behavior is unchanged. I have timed a `spack install` with and without these changes, where all packages were up to date, i.e. only the "overhead" (figuring out which packages to build, recreating the view, etc..) but no actual build is measured. Times before:
```console
real	19m21,477s
user	17m20,906s
sys	1m58,962s
```
with memoizing:
```console
real	1m49,284s
user	1m46,653s
sys	0m2,568s
```