### PR TITLE
gmsh: add dependency on gl and glu providers when +fltk

### DIFF
--- a/var/spack/repos/builtin/packages/gmsh/package.py
+++ b/var/spack/repos/builtin/packages/gmsh/package.py
@@ -71,8 +71,9 @@ class Gmsh(CMakePackage):
     depends_on('cmake@2.8:', type='build')
     depends_on('gmp',     when='+gmp')
     depends_on('mpi',     when='+mpi')
-    # Assumes OpenGL with GLU is already provided by the system:
     depends_on('fltk+gl', when='+fltk')
+    depends_on('gl',      when='+fltk')
+    depends_on('glu',     when='+fltk')
     depends_on('cairo',   when='+cairo')
     depends_on('hdf5',    when='+hdf5')
     depends_on('hdf5',    when='+med')


### PR DESCRIPTION
`gmsh +fltk` currently assumes that OpenGL and GLU are present and fails to build otherwise.

This PR adds dependencies on the `gl` and `glu` providers.

@cessenat does this break anything?