### PR TITLE
commands: `spack load --list` alias for `spack find --loaded`

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -924,6 +924,9 @@ use ``spack find --loaded``.
     -- linux-debian7 / intel@15.0.0 ---------------------------------
     libelf@0.8.13
 
+You can also use ``spack load --list`` to get the same output, but it
+does not have the full set of query options that ``spack find`` offers.
+
 We'll learn more about Spack's spec syntax in the next section.
 
 

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -27,6 +27,7 @@ import spack.extensions
 import spack.paths
 import spack.spec
 import spack.store
+import spack.user_environment as uenv
 import spack.util.spack_json as sjson
 import spack.util.string
 
@@ -439,6 +440,27 @@ def display_specs(specs, args=None, **kwargs):
 
     output.write(out)
     output.flush()
+
+
+def filter_loaded_specs(specs):
+    """Filter a list of specs returning only those that are
+    currently loaded."""
+    hashes = os.environ.get(uenv.spack_loaded_hashes_var, '').split(':')
+    return [x for x in specs if x.dag_hash() in hashes]
+
+
+def print_how_many_pkgs(specs, pkg_type=""):
+    """Given a list of specs, this will print a message about how many
+    specs are in that list.
+
+    Args:
+        specs (list): depending on how many items are in this list, choose
+            the plural or singular form of the word "package"
+        pkg_type (str): the output string will mention this provided
+            category, e.g. if pkg_type is "installed" then the message
+            would be "3 installed packages"
+    """
+    tty.msg("%s" % plural(len(specs), pkg_type + " package"))
 
 
 def spack_is_git_repo():

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -460,7 +460,8 @@ def print_how_many_pkgs(specs, pkg_type=""):
             category, e.g. if pkg_type is "installed" then the message
             would be "3 installed packages"
     """
-    tty.msg("%s" % plural(len(specs), pkg_type + " package"))
+    tty.msg("%s" % spack.util.string.plural(
+            len(specs), pkg_type + " package"))
 
 
 def spack_is_git_repo():

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -204,6 +204,16 @@ def display_env(env, args, decorator):
         print()
 
 
+def filter_loaded_specs(specs):
+    """Filter a list of specs returning only those that are currently loaded."""
+    hashes = os.environ.get(uenv.spack_loaded_hashes_var, '').split(':')
+    return [x for x in specs if x.dag_hash() in hashes]
+
+
+def print_how_many_pkgs(specs, pkg_type=""):
+    tty.msg("%s" % plural(len(specs), pkg_type + " package"))
+
+
 def find(parser, args):
     if args.bootstrap:
         bootstrap_store_path = spack.bootstrap.store_path()
@@ -241,8 +251,7 @@ def _find(parser, args):
         results = [x for x in results if x.name in packages_with_tags]
 
     if args.loaded:
-        hashes = os.environ.get(uenv.spack_loaded_hashes_var, '').split(':')
-        results = [x for x in results if x.dag_hash() in hashes]
+        results = filter_loaded_specs(results)
 
     # Display the result
     if args.json:
@@ -251,7 +260,10 @@ def _find(parser, args):
         if not args.format:
             if env:
                 display_env(env, args, decorator)
+
         if sys.stdout.isatty() and args.groups:
-            tty.msg("%s" % plural(len(results), 'installed package'))
+            pkg_type = "loaded" if args.loaded else "installed"
+            print_how_many_pkgs(results, pkg_type)
+
         cmd.display_specs(
             results, args, decorator=decorator, all_headers=True)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -204,16 +204,6 @@ def display_env(env, args, decorator):
         print()
 
 
-def filter_loaded_specs(specs):
-    """Filter a list of specs returning only those that are currently loaded."""
-    hashes = os.environ.get(uenv.spack_loaded_hashes_var, '').split(':')
-    return [x for x in specs if x.dag_hash() in hashes]
-
-
-def print_how_many_pkgs(specs, pkg_type=""):
-    tty.msg("%s" % plural(len(specs), pkg_type + " package"))
-
-
 def find(parser, args):
     if args.bootstrap:
         bootstrap_store_path = spack.bootstrap.store_path()
@@ -251,7 +241,7 @@ def _find(parser, args):
         results = [x for x in results if x.name in packages_with_tags]
 
     if args.loaded:
-        results = filter_loaded_specs(results)
+        results = spack.cmd.filter_loaded_specs(results)
 
     # Display the result
     if args.json:
@@ -263,7 +253,7 @@ def _find(parser, args):
 
         if sys.stdout.isatty() and args.groups:
             pkg_type = "loaded" if args.loaded else "installed"
-            print_how_many_pkgs(results, pkg_type)
+            spack.cmd.print_how_many_pkgs(results, pkg_type)
 
         cmd.display_specs(
             results, args, decorator=decorator, all_headers=True)

--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -6,7 +6,6 @@
 from __future__ import print_function
 
 import copy
-import os
 import sys
 
 import llnl.util.lang
@@ -18,9 +17,7 @@ import spack.cmd as cmd
 import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.repo
-import spack.user_environment as uenv
 from spack.database import InstallStatuses
-from spack.util.string import plural
 
 description = "list and search installed packages"
 section = "basic"

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -7,6 +7,7 @@ import sys
 
 import spack.cmd
 import spack.cmd.common.arguments as arguments
+import spack.cmd.find
 import spack.environment as ev
 import spack.store
 import spack.user_environment as uenv
@@ -20,8 +21,7 @@ level = "short"
 def setup_parser(subparser):
     """Parser is only constructed so that this prints a nice help
        message with -h. """
-    arguments.add_common_arguments(
-        subparser, ['installed_specs'])
+    arguments.add_common_arguments(subparser, ['constraint'])
 
     shells = subparser.add_mutually_exclusive_group()
     shells.add_argument(
@@ -53,14 +53,29 @@ alternatively one can decide to load only the package or only
 the dependencies"""
     )
 
+    subparser.add_argument(
+        '--list',
+        action='store_true',
+        default=False,
+        help="show loaded packages: same as `spack find --loaded`"
+    )
+
 
 def load(parser, args):
     env = ev.active_environment()
+
+    if args.list:
+        results = spack.cmd.find.filter_loaded_specs(args.specs())
+        if sys.stdout.isatty():
+            spack.cmd.find.print_how_many_pkgs(results, "loaded")
+        spack.cmd.display_specs(results)
+        return
+
     specs = [spack.cmd.disambiguate_spec(spec, env, first=args.load_first)
-             for spec in spack.cmd.parse_specs(args.specs)]
+             for spec in spack.cmd.parse_specs(args.constraint)]
 
     if not args.shell:
-        specs_str = ' '.join(args.specs) or "SPECS"
+        specs_str = ' '.join(args.constraint) or "SPECS"
         spack.cmd.common.shell_init_instructions(
             "spack load",
             "    eval `spack load {sh_arg} %s`" % specs_str,

--- a/lib/spack/spack/cmd/load.py
+++ b/lib/spack/spack/cmd/load.py
@@ -65,9 +65,9 @@ def load(parser, args):
     env = ev.active_environment()
 
     if args.list:
-        results = spack.cmd.find.filter_loaded_specs(args.specs())
+        results = spack.cmd.filter_loaded_specs(args.specs())
         if sys.stdout.isatty():
-            spack.cmd.find.print_how_many_pkgs(results, "loaded")
+            spack.cmd.print_how_many_pkgs(results, "loaded")
         spack.cmd.display_specs(results)
         return
 

--- a/share/spack/csh/spack.csh
+++ b/share/spack/csh/spack.csh
@@ -148,6 +148,7 @@ case unload:
     # argument and specs with "-h" in the name.
     if ( " $_sp_spec" =~ "* --sh*" || \
          " $_sp_spec" =~ "* --csh*" || \
+         " $_sp_spec" =~ "* --list*" || \
          " $_sp_spec" =~ "* -h*" || \
          " $_sp_spec" =~ "* --help*") then
         # Args contain --sh, --csh, or -h/--help: just execute.

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -339,6 +339,7 @@ spt_contains "set -gx LD_LIBRARY_PATH $_b_ld" spack -m load --only package --fis
 spt_succeeds spack -m load b
 set LIST_CONTENT (spack -m load b; spack load --list)
 spt_contains "b@" echo $LIST_CONTENT
+spt_does_not_contain "a@" echo $LIST_CONTENT
 # test a variable MacOS clears and one it doesn't for recursive loads
 spt_contains "set -gx LD_LIBRARY_PATH $_a_ld:$_b_ld" spack -m load --fish a
 spt_succeeds spack -m load --only dependencies a

--- a/share/spack/qa/setup-env-test.fish
+++ b/share/spack/qa/setup-env-test.fish
@@ -337,6 +337,8 @@ set _a_ld $_a_loc"/lib"
 
 spt_contains "set -gx LD_LIBRARY_PATH $_b_ld" spack -m load --only package --fish b
 spt_succeeds spack -m load b
+set LIST_CONTENT (spack -m load b; spack load --list)
+spt_contains "b@" echo $LIST_CONTENT
 # test a variable MacOS clears and one it doesn't for recursive loads
 spt_contains "set -gx LD_LIBRARY_PATH $_a_ld:$_b_ld" spack -m load --fish a
 spt_succeeds spack -m load --only dependencies a

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -108,6 +108,7 @@ contains "export PATH=$(spack -m location -i b)/bin" spack -m load --only packag
 succeeds spack -m load b
 LIST_CONTENT=`spack -m load b; spack load --list`
 contains "b@" echo $LIST_CONTENT
+does_not_contain "a@" echo $LIST_CONTENT
 fails spack -m load -l
 # test a variable MacOS clears and one it doesn't for recursive loads
 contains "export PATH=$(spack -m location -i a)/bin:$(spack -m location -i b)/bin" spack -m load --sh a

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -106,6 +106,7 @@ contains "usage: spack module " spack -m module
 title 'Testing `spack load`'
 contains "export PATH=$(spack -m location -i b)/bin" spack -m load --only package --sh b
 succeeds spack -m load b
+contains "b@" spack load --list
 fails spack -m load -l
 # test a variable MacOS clears and one it doesn't for recursive loads
 contains "export PATH=$(spack -m location -i a)/bin:$(spack -m location -i b)/bin" spack -m load --sh a

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -106,7 +106,8 @@ contains "usage: spack module " spack -m module
 title 'Testing `spack load`'
 contains "export PATH=$(spack -m location -i b)/bin" spack -m load --only package --sh b
 succeeds spack -m load b
-contains "b@" spack load --list
+LIST_CONTENT=`spack -m load b; spack load --list`
+contains "b@" echo $LIST_CONTENT
 fails spack -m load -l
 # test a variable MacOS clears and one it doesn't for recursive loads
 contains "export PATH=$(spack -m location -i a)/bin:$(spack -m location -i b)/bin" spack -m load --sh a

--- a/share/spack/setup-env.fish
+++ b/share/spack/setup-env.fish
@@ -320,6 +320,11 @@ function check_env_activate_flags -d "check spack env subcommand flags for -h, -
             return 0
         end
 
+        # looks for a single `--list`
+        if match_flag $_a "--list"
+            return 0
+        end
+
     end
 
     return 1

--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -180,6 +180,7 @@ _spack_shell_wrapper() {
             if [ "${_a#* --sh}" != "$_a" ] || \
                 [ "${_a#* --csh}" != "$_a" ] || \
                 [ "${_a#* -h}" != "$_a" ] || \
+                [ "${_a#* --list}" != "$_a" ] || \
                 [ "${_a#* --help}" != "$_a" ];
             then
                 # Args contain --sh, --csh, or -h/--help: just execute.

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1215,7 +1215,7 @@ _spack_list() {
 _spack_load() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --sh --csh --fish --first --only"
+        SPACK_COMPREPLY="-h --help --sh --csh --fish --first --only --list"
     else
         _installed_packages
     fi


### PR DESCRIPTION
See #25249 and https://github.com/spack/spack/pull/27159#issuecomment-958163679.
This adds `spack load --list` as an alias for `spack find --loaded`.  The new command is
not as powerful as `spack find --loaded`, as you can't combine it with all the queries or
formats that `spack find` provides.  However, it is more intuitively located in the command
structure in that it appears in the output of `spack load --help`.

The idea here is that people can use `spack load --list`  for simple stuff but fall back to
`spack find --loaded` if they need more.

- [x] add help to `spack load --list` that references `spack find`
- [x] factor some parts of `spack find` out to be called from `spack load`
- [x] add shell integration
- [x] add shell test
- [x] update completion
- [x] update docs