### PR TITLE
Make CUDA and ROCm architecture conditional 

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -35,7 +35,8 @@ class CudaPackage(PackageBase):
 
     variant('cuda_arch',
             description='CUDA architecture',
-            values=spack.variant.any_combination_of(*cuda_arch_values))
+            values=spack.variant.any_combination_of(*cuda_arch_values),
+            when='+cuda')
 
     # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-examples
     # https://llvm.org/docs/CompileCudaWithLLVM.html#compiling-cuda-code

--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -100,7 +100,8 @@ class ROCmPackage(PackageBase):
     # possible amd gpu targets for rocm builds
     variant('amdgpu_target',
             description='AMD GPU architecture',
-            values=spack.variant.any_combination_of(*amdgpu_targets))
+            values=spack.variant.any_combination_of(*amdgpu_targets),
+            when='+rocm')
 
     depends_on('llvm-amdgpu', when='+rocm')
     depends_on('hsa-rocr-dev', when='+rocm')

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -53,14 +53,15 @@ class Cp2k(MakefilePackage, CudaPackage):
                          ' and BQB compression'))
     variant('spglib', default=False, description='Enable support for spglib')
 
-    variant('cuda_arch_35_k20x', default=False,
-            description=('CP2K (resp. DBCSR) has specific parameter sets for'
-                         ' different GPU models. Enable this when building'
-                         ' with cuda_arch=35 for a K20x instead of a K40'))
-    variant('cuda_fft', default=False,
-            description=('Use CUDA also for FFTs in the PW part of CP2K'))
-    variant('cuda_blas', default=False,
-            description=('Use CUBLAS for general matrix operations in DBCSR'))
+    with when('+cuda'):
+        variant('cuda_arch_35_k20x', default=False,
+                description=('CP2K (resp. DBCSR) has specific parameter sets for'
+                             ' different GPU models. Enable this when building'
+                             ' with cuda_arch=35 for a K20x instead of a K40'))
+        variant('cuda_fft', default=False,
+                description=('Use CUDA also for FFTs in the PW part of CP2K'))
+        variant('cuda_blas', default=False,
+                description=('Use CUBLAS for general matrix operations in DBCSR'))
 
     HFX_LMAX_RANGE = range(4, 8)
 
@@ -167,8 +168,6 @@ class Cp2k(MakefilePackage, CudaPackage):
     depends_on('python@3.6:', when='@7:+cuda', type='build')
 
     depends_on('spglib', when='+spglib')
-    conflicts('~cuda', '+cuda_fft')
-    conflicts('~cuda', '+cuda_blas')
 
     # Apparently cp2k@4.1 needs an "experimental" version of libwannier.a
     # which is only available contacting the developer directly. See INSTALL


### PR DESCRIPTION
fixes #14337
fixes #27213 

Modifications:
- [x] The variant to specify which architecture to use for CUDA and ROCm are now conditional on `+cuda` and
`+rocm` respectively.
- [x] Modify `cp2k` to make all CUDA related variants conditional on `+cuda`