### PR TITLE
Add new versions for HOHQMesh and switch to tar-ball releases

### DIFF
--- a/var/spack/repos/builtin/packages/hohqmesh/package.py
+++ b/var/spack/repos/builtin/packages/hohqmesh/package.py
@@ -10,13 +10,15 @@ class Hohqmesh(CMakePackage):
     """High Order mesh generator for Hexahedral and Quadrilateral meshes."""
 
     homepage = "https://github.com/trixi-framework/HOHQMesh"
-    url      = "https://github.com/trixi-framework/HOHQMesh"
     git      = "https://github.com/trixi-framework/HOHQMesh.git"
+    url      = "https://github.com/trixi-framework/HOHQMesh/archive/v1.0.0.tar.gz"
 
-    maintainers = ['schoonovernumerics']
+    maintainers = ['fluidnumerics-joe']
 
-    version('main', branch='main')
-    version('v1.0.1', tag='v1.0.1')
+    version('1.1.0', sha256='977109d57dbb6b74c2d2c52b9bc3ac5ad4ecbfaa0dbe3ef2291f68eea05f1b78')
+    version('1.0.1', sha256='83c2c48aec9cd6b1ade0d9b04a0d68782ea7e0a5d9fb28ac7510d4ad401e64ee')
+    version('1.0.0', sha256='b5e983fa4a34311042e29792bf0e233fafc63b8f98873c041b8f7e4f1e26a19f')
+
 
     depends_on('ftobjectlibrary')
 

--- a/var/spack/repos/builtin/packages/hohqmesh/package.py
+++ b/var/spack/repos/builtin/packages/hohqmesh/package.py
@@ -15,9 +15,9 @@ class Hohqmesh(CMakePackage):
 
     maintainers = ['fluidnumerics-joe']
 
-    version('1.1.0', sha256='977109d57dbb6b74c2d2c52b9bc3ac5ad4ecbfaa0dbe3ef2291f68eea05f1b78')
-    version('1.0.1', sha256='83c2c48aec9cd6b1ade0d9b04a0d68782ea7e0a5d9fb28ac7510d4ad401e64ee')
-    version('1.0.0', sha256='b5e983fa4a34311042e29792bf0e233fafc63b8f98873c041b8f7e4f1e26a19f')
+    version('1.1.0', sha256='5fdb75157d9dc29bba55e6ae9dc2be71294754204f4f0912795532ae66aada10')
+    version('1.0.1', sha256='8435f13c96d714a287f3c24392330047e2131d53fafe251a77eba365bd2b3141')
+    version('1.0.0', sha256='3800e63975d0a61945508f13fb76d5e2145c0260440484252b6b81aa0bfe076d')
 
     depends_on('ftobjectlibrary')
 

--- a/var/spack/repos/builtin/packages/hohqmesh/package.py
+++ b/var/spack/repos/builtin/packages/hohqmesh/package.py
@@ -19,7 +19,6 @@ class Hohqmesh(CMakePackage):
     version('1.0.1', sha256='83c2c48aec9cd6b1ade0d9b04a0d68782ea7e0a5d9fb28ac7510d4ad401e64ee')
     version('1.0.0', sha256='b5e983fa4a34311042e29792bf0e233fafc63b8f98873c041b8f7e4f1e26a19f')
 
-
     depends_on('ftobjectlibrary')
 
     parallel = False


### PR DESCRIPTION
New release of HOHQMesh is available, which includes ABAQUS IO from the mesh generator.
I've switched to tar-ball releases for HOHQMesh, rather than git branches and tags.