### PR TITLE
flecsi 2.1.0: conflicts with gcc<9

### DIFF
--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -110,7 +110,7 @@ class Flecsi(CMakePackage, CudaPackage):
     depends_on('mpich@3.4.1:', when='@2.0: ^mpich')
     depends_on('openmpi@4.1.0:', when='@2.0: ^openmpi')
 
-    conflicts('%gcc@:8.9999', when='@2.1:')
+    conflicts('%gcc@:8', when='@2.1:')
 
     conflicts('+tutorial', when='backend=hpx')
     # FleCSI@2: no longer supports serial or charmpp backends

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -110,6 +110,8 @@ class Flecsi(CMakePackage, CudaPackage):
     depends_on('mpich@3.4.1:', when='@2.0: ^mpich')
     depends_on('openmpi@4.1.0:', when='@2.0: ^openmpi')
 
+    conflicts('%gcc@:8.9999', when='@2.1:')
+
     conflicts('+tutorial', when='backend=hpx')
     # FleCSI@2: no longer supports serial or charmpp backends
     conflicts('backend=serial', when='@2.0:')


### PR DESCRIPTION
@ktsai7 @rspavel 

@haampie - is this the proper way to express a conflict with GCC < 9?

This is what happens if you try to build `flecsi@2.1.0 %gcc@7.5.0` for instance:
```
$> spack install flecsi@2.1.0 %gcc@7.5.0
...
1 error found in build log:
     9     -- Detecting CXX compile features - done
     10    -- Detecting C compiler ABI info
     11    -- Detecting C compiler ABI info - done
     12    -- Check for working C compiler: /opt/spack/lib/spack/env/gcc/gcc - 
           skipped
     13    -- Detecting C compile features
     14    -- Detecting C compile features - done
  >> 15    CMake Error at CMakeLists.txt:38 (message):
     16      Version 9.0 of gnu compilers required!
     17    
     18    
     19    -- Configuring incomplete, errors occurred!
     20    See also "/tmp/root/spack-stage/spack-stage-flecsi-2.1.0-szm7uxngfdd
           l27cv7hqt42adufz67mbt/spack-build-szm7uxn/CMakeFiles/CMakeOutput.log
           ".
```