### PR TITLE
libfabric: add 1.13.2

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -17,6 +17,7 @@ class Libfabric(AutotoolsPackage):
     maintainers = ['rajachan']
 
     version('master', branch='master')
+    version('1.13.2', sha256='25d783b0722a8df8fe61c1de75fafca684c5fe520303180f26f0ad6409cfc0b9')
     version('1.13.1', sha256='8e6eed38c4a39aa4cbf7d5d3734f0eecbfc030182f1f9b3be470702f2586d30e')
     version('1.12.1', sha256='db3c8e0a495e6e9da6a7436adab905468aedfbd4579ee3da5232a5c111ba642c')
     version('1.12.0', sha256='ca98785fe25e68a26c61e272be64a1efeea37e61b0dcebd34ccfd381bda7d9cc')


### PR DESCRIPTION
1.13.0 and 1.13.1 have critical issues in tcp/rxm providers that are addressed in 1.13.2