### PR TITLE
exaworks doesn't need mpix-launch-swift

### DIFF
--- a/var/spack/repos/builtin/packages/exaworks/package.py
+++ b/var/spack/repos/builtin/packages/exaworks/package.py
@@ -18,7 +18,6 @@ class Exaworks(BundlePackage):
 
     depends_on('adlbx',                   type=('build', 'run'))
     depends_on('turbine',                 type=('build', 'run'))
-    depends_on('mpix-launch-swift',       type=('build', 'run'))
 
     depends_on('flux-core',               type=('build', 'run'))
     depends_on('flux-sched',              type=('build', 'run'))


### PR DESCRIPTION
ExaWorks doesn't need `mpix-launch-swift` per offline communications with ExaWorks team.

We need to merge this PR to include ExaWorks in E4S 21.11

@andre-merzky @j-woz @kshitij-v-mehta 