### PR TITLE
Added Version 1.30. Fixed Build Issues

### DIFF
--- a/var/spack/repos/builtin/packages/fraggenescan/package.py
+++ b/var/spack/repos/builtin/packages/fraggenescan/package.py
@@ -15,11 +15,14 @@ class Fraggenescan(MakefilePackage):
     url      = "https://downloads.sourceforge.net/project/fraggenescan/FragGeneScan1.31.tar.gz"
 
     version('1.31', sha256='cd3212d0f148218eb3b17d24fcd1fc897fb9fee9b2c902682edde29f895f426c')
-
-    build_targets = ['clean', 'hmm.obj']
+    version('1.30', sha256='f2d7f0dfa4a5f4bbea295ed865dcbfedf16c954ea1534c2a879ebdcfb8650d95')
 
     def edit(self, spec, prefix):
         filter_file('gcc', spack_cc, 'Makefile', string=True)
+
+    def build(self, spec, prefic):
+        make('clean')
+        make('fgs')
 
     def install(self, spec, prefix):
         install_tree('.', prefix.bin)


### PR DESCRIPTION
According to the README fgs is a required build_target and was not included in the original package. Also modified the build process to deal with potential race condition that arises from running `'make' '-j8' 'clean' 'hmm.obj' 'fgs'` which is the default make command that arises when specifying `build_targets = ['clean', 'hmm.obj']`