### PR TITLE
database.py: handle ~ in upstreams' install_tree-s

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -333,7 +333,7 @@ class Database(object):
         ``enable_transaction_locking=False``, and specify a list of needed
         fields in ``record_fields``.
         """
-        self.root = root
+        self.root = os.path.expanduser(root)
 
         # If the db_dir is not provided, default to within the db root.
         self._db_dir = db_dir or os.path.join(self.root, _db_dirname)


### PR DESCRIPTION
When an upstream uses `~` in its `install_tree`, e.g. like so:

```
  1 upstreams:
  2   spack-instance-one:
  3     install_tree: ~/.spack/opt/spack-one
```

Spack fails to find the files it needs, `index.json` being one of those files. As a result, (most) Spack commands fail with:

```
==> Error: No database index file is present, and upstream databases cannot generate an index file
```

This behavior is due to `os.path.isfile` and `open()` not being able to correctly interpret the `~`.
Here, I apply `os.path.expanduser` to `_db_dir`, so that `_db_dir` refers to the absolute path of the `install_tree`.

**Update:** I now apply `os.path.expanduser` to `root`.