### PR TITLE
mfem, hpx: fix recipes after conditional variants

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -163,13 +163,16 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     patch('git_external.patch', when='@1.3.0 instrumentation=apex')
 
     def instrumentation_args(self):
-        for value in self.variants['instrumentation'].values:
+        args = []
+        for value in self.variants['instrumentation'][0].values:
             if value == 'none':
                 continue
 
             condition = 'instrumentation={0}'.format(value)
-            yield self.define(
-                'HPX_WITH_{0}'.format(value.upper()), condition in self.spec)
+            args.append(self.define(
+                'HPX_WITH_{0}'.format(value.upper()), condition in self.spec
+            ))
+        return args
 
     def cmake_args(self):
         spec, args = self.spec, []

--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -343,7 +343,7 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         if '+cuda' in spec:
             xcompiler = '-Xcompiler='
             xlinker = '-Xlinker='
-        cuda_arch = spec.variants['cuda_arch'].value
+        cuda_arch = None if '~cuda' in spec else spec.variants['cuda_arch'].value
 
         # We need to add rpaths explicitly to allow proper export of link flags
         # from within MFEM.


### PR DESCRIPTION
fixes #27213

The `variants` attribute of package objects was changed to allow for conditional variants. While a better API can be thought of (as correctly noted in https://github.com/spack/spack/pull/27185#discussion_r742385665), the recipes reading it directly are just a handful so here I'm fixing them without introducing core changes. 