### PR TITLE
Add RelWithDebInfo to protobuf build_type list

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -60,7 +60,7 @@ class Protobuf(Package):
             description='Enables the build of shared libraries')
     variant('build_type', default='Release',
             description='The build type to build',
-            values=('Debug', 'Release'))
+            values=('Debug', 'Release', 'RelWithDebInfo'))
 
     depends_on('cmake', when='@3.0.2:', type='build')
     depends_on('zlib')


### PR DESCRIPTION
Without this change, I was not able to use:
```
all:
   variants: build_type=RelWithDebInfo
```

If we delete version 2.5.0, it looks like this could be made a `CMakePackage`.