### PR TITLE
Fix roctracer and rocprofiler directory paths

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -268,10 +268,10 @@ class Tau(Package):
             options.append("-rocm=%s" % spec['hsa-rocr-dev'].prefix)
 
         if '+rocprofiler' in spec:
-            options.append("-rocprofiler=%s" % spec['rocprofiler-dev'].prefix)
+            options.append("-rocprofiler=%s" % spec['rocprofiler-dev'].prefix+"/rocprofiler")
 
         if '+roctracer' in spec:
-            options.append("-roctracer=%s" % spec['roctracer-dev'].prefix)
+            options.append("-roctracer=%s" % spec['roctracer-dev'].prefix+"/roctracer")
 
         if '+adios2' in spec:
             options.append("-adios=%s" % spec['adios2'].prefix)

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -268,10 +268,12 @@ class Tau(Package):
             options.append("-rocm=%s" % spec['hsa-rocr-dev'].prefix)
 
         if '+rocprofiler' in spec:
-            options.append("-rocprofiler=%s" % spec['rocprofiler-dev'].prefix+"/rocprofiler")
+            options.append("-rocprofiler=%s" % spec['rocprofiler-dev']
+                           .prefix + "/rocprofiler")
 
         if '+roctracer' in spec:
-            options.append("-roctracer=%s" % spec['roctracer-dev'].prefix+"/roctracer")
+            options.append("-roctracer=%s" % spec['roctracer-dev']
+                           .prefix + "/roctracer")
 
         if '+adios2' in spec:
             options.append("-adios=%s" % spec['adios2'].prefix)


### PR DESCRIPTION
Roctracer and rocprofiler may not have the directory structure tau expects in their root directories. The /roctracer and /rocprofiler sub-directories should be safe so use them instead.