### PR TITLE
ctags uses custom autogen.sh script

### DIFF
--- a/var/spack/repos/builtin/packages/universal-ctags/package.py
+++ b/var/spack/repos/builtin/packages/universal-ctags/package.py
@@ -26,3 +26,6 @@ class UniversalCtags(AutotoolsPackage):
     depends_on('m4',       type='build')
     depends_on('libiconv', type='link')
     depends_on('pkgconfig', type='build')
+
+    def autoreconf(self, spec, prefix):
+        which('bash')('autogen.sh')


### PR DESCRIPTION
The universal-ctags docs (https://github.com/universal-ctags/ctags) give the following build instructions:

```shell
    $ git clone https://github.com/universal-ctags/ctags.git
    $ cd ctags
    $ ./autogen.sh
    $ ./configure --prefix=/where/you/want # defaults to /usr/local
    $ make
    $ make install # may require extra privileges depending on where to install
```

This adds the required `autoreconf` method to call the custom `autogen` script.  This fixes a failure I had when building with an older system provided autotools suite
