### PR TITLE
Add variant for the --enable-two-level-namespace option in MPICH

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -82,7 +82,7 @@ spack package at this time.''',
     variant('fortran', default=True, description='Enable Fortran support')
 
     variant(
-        'two-level-namespace',
+        'two_level_namespace',
         default=False,
         description='''Build shared libraries and programs
 built with the mpicc/mpifort/etc. compiler wrappers
@@ -484,7 +484,7 @@ with '-Wl,-commons,use_dylibs' and without
             config_args.append('--with-thread-package=argobots')
             config_args.append('--with-argobots=' + spec['argobots'].prefix)
 
-        if '+two-level-namespace' in spec:
+        if '+two_level_namespace' in spec:
             config_args.append('--enable-two-level-namespace')
 
         return config_args

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -81,6 +81,15 @@ spack package at this time.''',
             description='Enable Argobots support')
     variant('fortran', default=True, description='Enable Fortran support')
 
+    variant(
+        'two-level-namespace',
+        default=False,
+        description='''Build shared libraries and programs
+built with the mpicc/mpifort/etc. compiler wrappers
+with '-Wl,-commons,use_dylibs' and without
+'-Wl,-flat_namespace'.'''
+    )
+
     provides('mpi@:3.1')
     provides('mpi@:3.0', when='@:3.1')
     provides('mpi@:2.2', when='@:1.2')
@@ -474,6 +483,9 @@ spack package at this time.''',
         if '+argobots' in spec:
             config_args.append('--with-thread-package=argobots')
             config_args.append('--with-argobots=' + spec['argobots'].prefix)
+
+        if '+two-level-namespace' in spec:
+            config_args.append('--enable-two-level-namespace')
 
         return config_args
 


### PR DESCRIPTION
We have mixed C/C++ and Fortran in several libraries, and -flat_namespace leads to aborts when exceptions are thrown on macOS.

