### PR TITLE
Rename the temporary scope for bootstrap buildcache

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -311,7 +311,7 @@ class _BuildcacheBootstrapper(object):
     @property
     def mirror_scope(self):
         return spack.config.InternalConfigScope(
-            'bootstrap', {'mirrors:': {self.name: self.url}}
+            'bootstrap_buildcache', {'mirrors:': {self.name: self.url}}
         )
 
     def try_import(self, module, abstract_spec_str):


### PR DESCRIPTION
If we don't rename Spack will fail with:
```console
ImportError: cannot bootstrap the "clingo" Python module from spec "clingo-bootstrap@spack+python %gcc target=x86_64" due to the following failures:
    'spack-install' raised ValueError: Invalid config scope: 'bootstrap'.  Must be one of odict_keys(['_builtin', 'defaults', 'defaults/cray', 'bootstrap/cray', 'disable_modules', 'overrides-0'])
    Please run `spack -d spec zlib` for more verbose error messages
```
in case bootstrapping from binaries fails and we are falling back to bootstrapping from sources.