### PR TITLE
Parallel-netcdf: Update Spack test dir

### DIFF
--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -177,14 +177,16 @@ class ParallelNetcdf(AutotoolsPackage):
 
         return args
 
+    examples_src_dir = join_path('examples', 'CXX')
+
     @run_after('install')
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(join_path('examples', 'CXX'))
+        self.cache_extra_test_sources(examples_src_dir)
 
     def test(self):
-        test_dir = join_path(self.test_suite.current_test_cache_dir, 'examples', 'CXX')
+        test_dir = join_path(self.test_suite.current_test_cache_dir, examples_src_dir)
         # pnetcdf has many examples to serve as a suitable smoke check.
         # column_wise was chosen based on the E4S test suite. Other
         # examples should work as well.

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -193,8 +193,8 @@ class ParallelNetcdf(AutotoolsPackage):
         # examples should work as well.
         test_exe = 'column_wise'
         options = ['{0}.cpp'.format(test_exe), '-o', test_exe, '-lpnetcdf',
-                   '-L{0}'.format(join_path(self.prefix, 'lib')),
-                   '-I{0}'.format(join_path(self.prefix, 'include'))]
+                   '-L{0}'.format(self.prefix.lib),
+                   '-I{0}'.format(self.prefix.include)]
         reason = 'test: compiling and linking pnetcdf example'
         self.run_test(self.spec['mpi'].mpicxx, options, [],
                       installed=False, purpose=reason, work_dir=test_dir)

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -183,7 +183,7 @@ class ParallelNetcdf(AutotoolsPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(self.examples_src_dir)
+        self.cache_extra_test_sources([self.examples_src_dir])
 
     def test(self):
         test_dir = join_path(self.test_suite.current_test_cache_dir,

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -183,10 +183,11 @@ class ParallelNetcdf(AutotoolsPackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(examples_src_dir)
+        self.cache_extra_test_sources(self.examples_src_dir)
 
     def test(self):
-        test_dir = join_path(self.test_suite.current_test_cache_dir, examples_src_dir)
+        test_dir = join_path(self.test_suite.current_test_cache_dir,
+                             self.examples_src_dir)
         # pnetcdf has many examples to serve as a suitable smoke check.
         # column_wise was chosen based on the E4S test suite. Other
         # examples should work as well.

--- a/var/spack/repos/builtin/packages/parallel-netcdf/package.py
+++ b/var/spack/repos/builtin/packages/parallel-netcdf/package.py
@@ -177,28 +177,30 @@ class ParallelNetcdf(AutotoolsPackage):
 
         return args
 
-    examples_src_dir = 'examples/CXX'
-
     @run_after('install')
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([self.examples_src_dir])
+        self.cache_extra_test_sources(join_path('examples', 'CXX'))
 
     def test(self):
-        test_dir = join_path(self.install_test_root, self.examples_src_dir)
+        test_dir = join_path(self.test_suite.current_test_cache_dir, 'examples', 'CXX')
         # pnetcdf has many examples to serve as a suitable smoke check.
         # column_wise was chosen based on the E4S test suite. Other
         # examples should work as well.
         test_exe = 'column_wise'
-        options = ['{0}.cpp'.format(test_exe), '-o', test_exe, '-lpnetcdf']
+        options = ['{0}.cpp'.format(test_exe), '-o', test_exe, '-lpnetcdf',
+                   '-L{0}'.format(join_path(self.prefix, 'lib')),
+                   '-I{0}'.format(join_path(self.prefix, 'include'))]
         reason = 'test: compiling and linking pnetcdf example'
         self.run_test(self.spec['mpi'].mpicxx, options, [],
                       installed=False, purpose=reason, work_dir=test_dir)
-        mpiexe_list = ['mpirun', 'mpiexec', 'srun']
+        mpiexe_list = [self.spec['mpi'].prefix.bin.srun,
+                       self.spec['mpi'].prefix.bin.mpirun,
+                       self.spec['mpi'].prefix.bin.mpiexec]
         for mpiexe in mpiexe_list:
             if os.path.isfile(mpiexe):
-                self.run_test(mpiexe, ['-n', '4', test_exe], [],
+                self.run_test(mpiexe, ['-n', '1', test_exe], [],
                               installed=False,
                               purpose='test: pnetcdf smoke test',
                               skip_missing=True,


### PR DESCRIPTION
Re-work `parallel-netcdf` from building in the install test root to using the test suite cache directory.