### PR TITLE
llvm: Fix building llvm@4:9 using %clang@6: and %gcc@10:

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/llvm4-lld-ELF-Symbols.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm4-lld-ELF-Symbols.patch
@@ -1,0 +1,112 @@
+--- a/lldb/include/lldb/Utility/TaskPool.h
++++ b/lldb/include/lldb/Utility/TaskPool.h
+@@ -33,6 +33,7 @@
+ #include <queue>
+ #include <thread>
+ #include <vector>
++#include <functional>
+ 
+ // Global TaskPool class for running tasks in parallel on a set of worker thread
+ // created the first
+# Fix lld templates: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=230463
+--- a/lld/ELF/LTO.cpp
++++ b/lld/ELF/LTO.cpp
+@@ -158,7 +158,7 @@
+   return Ret;
+ }
+ 
+-template void BitcodeCompiler::template add<ELF32LE>(BitcodeFile &);
+-template void BitcodeCompiler::template add<ELF32BE>(BitcodeFile &);
+-template void BitcodeCompiler::template add<ELF64LE>(BitcodeFile &);
+-template void BitcodeCompiler::template add<ELF64BE>(BitcodeFile &);
++template void BitcodeCompiler::add<ELF32LE>(BitcodeFile &);
++template void BitcodeCompiler::add<ELF32BE>(BitcodeFile &);
++template void BitcodeCompiler::add<ELF64LE>(BitcodeFile &);
++template void BitcodeCompiler::add<ELF64BE>(BitcodeFile &);
+--- a/lld/ELF/Symbols.cpp
++++ b/lld/ELF/Symbols.cpp
+@@ -343,45 +343,45 @@
+ template bool SymbolBody::hasThunk<ELF64LE>() const;
+ template bool SymbolBody::hasThunk<ELF64BE>() const;
+ 
+-template uint32_t SymbolBody::template getVA<ELF32LE>(uint32_t) const;
+-template uint32_t SymbolBody::template getVA<ELF32BE>(uint32_t) const;
+-template uint64_t SymbolBody::template getVA<ELF64LE>(uint64_t) const;
+-template uint64_t SymbolBody::template getVA<ELF64BE>(uint64_t) const;
+-
+-template uint32_t SymbolBody::template getGotVA<ELF32LE>() const;
+-template uint32_t SymbolBody::template getGotVA<ELF32BE>() const;
+-template uint64_t SymbolBody::template getGotVA<ELF64LE>() const;
+-template uint64_t SymbolBody::template getGotVA<ELF64BE>() const;
+-
+-template uint32_t SymbolBody::template getGotOffset<ELF32LE>() const;
+-template uint32_t SymbolBody::template getGotOffset<ELF32BE>() const;
+-template uint64_t SymbolBody::template getGotOffset<ELF64LE>() const;
+-template uint64_t SymbolBody::template getGotOffset<ELF64BE>() const;
+-
+-template uint32_t SymbolBody::template getGotPltVA<ELF32LE>() const;
+-template uint32_t SymbolBody::template getGotPltVA<ELF32BE>() const;
+-template uint64_t SymbolBody::template getGotPltVA<ELF64LE>() const;
+-template uint64_t SymbolBody::template getGotPltVA<ELF64BE>() const;
+-
+-template uint32_t SymbolBody::template getThunkVA<ELF32LE>() const;
+-template uint32_t SymbolBody::template getThunkVA<ELF32BE>() const;
+-template uint64_t SymbolBody::template getThunkVA<ELF64LE>() const;
+-template uint64_t SymbolBody::template getThunkVA<ELF64BE>() const;
+-
+-template uint32_t SymbolBody::template getGotPltOffset<ELF32LE>() const;
+-template uint32_t SymbolBody::template getGotPltOffset<ELF32BE>() const;
+-template uint64_t SymbolBody::template getGotPltOffset<ELF64LE>() const;
+-template uint64_t SymbolBody::template getGotPltOffset<ELF64BE>() const;
+-
+-template uint32_t SymbolBody::template getPltVA<ELF32LE>() const;
+-template uint32_t SymbolBody::template getPltVA<ELF32BE>() const;
+-template uint64_t SymbolBody::template getPltVA<ELF64LE>() const;
+-template uint64_t SymbolBody::template getPltVA<ELF64BE>() const;
+-
+-template uint32_t SymbolBody::template getSize<ELF32LE>() const;
+-template uint32_t SymbolBody::template getSize<ELF32BE>() const;
+-template uint64_t SymbolBody::template getSize<ELF64LE>() const;
+-template uint64_t SymbolBody::template getSize<ELF64BE>() const;
++template uint32_t SymbolBody::getVA<ELF32LE>(uint32_t) const;
++template uint32_t SymbolBody::getVA<ELF32BE>(uint32_t) const;
++template uint64_t SymbolBody::getVA<ELF64LE>(uint64_t) const;
++template uint64_t SymbolBody::getVA<ELF64BE>(uint64_t) const;
++
++template uint32_t SymbolBody::getGotVA<ELF32LE>() const;
++template uint32_t SymbolBody::getGotVA<ELF32BE>() const;
++template uint64_t SymbolBody::getGotVA<ELF64LE>() const;
++template uint64_t SymbolBody::getGotVA<ELF64BE>() const;
++
++template uint32_t SymbolBody::getGotOffset<ELF32LE>() const;
++template uint32_t SymbolBody::getGotOffset<ELF32BE>() const;
++template uint64_t SymbolBody::getGotOffset<ELF64LE>() const;
++template uint64_t SymbolBody::getGotOffset<ELF64BE>() const;
++
++template uint32_t SymbolBody::getGotPltVA<ELF32LE>() const;
++template uint32_t SymbolBody::getGotPltVA<ELF32BE>() const;
++template uint64_t SymbolBody::getGotPltVA<ELF64LE>() const;
++template uint64_t SymbolBody::getGotPltVA<ELF64BE>() const;
++
++template uint32_t SymbolBody::getThunkVA<ELF32LE>() const;
++template uint32_t SymbolBody::getThunkVA<ELF32BE>() const;
++template uint64_t SymbolBody::getThunkVA<ELF64LE>() const;
++template uint64_t SymbolBody::getThunkVA<ELF64BE>() const;
++
++template uint32_t SymbolBody::getGotPltOffset<ELF32LE>() const;
++template uint32_t SymbolBody::getGotPltOffset<ELF32BE>() const;
++template uint64_t SymbolBody::getGotPltOffset<ELF64LE>() const;
++template uint64_t SymbolBody::getGotPltOffset<ELF64BE>() const;
++
++template uint32_t SymbolBody::getPltVA<ELF32LE>() const;
++template uint32_t SymbolBody::getPltVA<ELF32BE>() const;
++template uint64_t SymbolBody::getPltVA<ELF64LE>() const;
++template uint64_t SymbolBody::getPltVA<ELF64BE>() const;
++
++template uint32_t SymbolBody::getSize<ELF32LE>() const;
++template uint32_t SymbolBody::getSize<ELF32BE>() const;
++template uint64_t SymbolBody::getSize<ELF64LE>() const;
++template uint64_t SymbolBody::getSize<ELF64BE>() const;
+ 
+ template class elf::Undefined<ELF32LE>;
+ template class elf::Undefined<ELF32BE>;

--- a/var/spack/repos/builtin/packages/llvm/llvm5-lld-ELF-Symbols.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm5-lld-ELF-Symbols.patch
@@ -1,0 +1,33 @@
+# Fix lld templates: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=230463
+--- a/lld/ELF/Symbols.cpp
++++ b/lld/ELF/Symbols.cpp
+@@ -383,17 +383,17 @@
+   return B.getName();
+ }
+ 
+-template uint32_t SymbolBody::template getSize<ELF32LE>() const;
+-template uint32_t SymbolBody::template getSize<ELF32BE>() const;
+-template uint64_t SymbolBody::template getSize<ELF64LE>() const;
+-template uint64_t SymbolBody::template getSize<ELF64BE>() const;
++template uint32_t SymbolBody::getSize<ELF32LE>() const;
++template uint32_t SymbolBody::getSize<ELF32BE>() const;
++template uint64_t SymbolBody::getSize<ELF64LE>() const;
++template uint64_t SymbolBody::getSize<ELF64BE>() const;
+ 
+-template bool DefinedRegular::template isMipsPIC<ELF32LE>() const;
+-template bool DefinedRegular::template isMipsPIC<ELF32BE>() const;
+-template bool DefinedRegular::template isMipsPIC<ELF64LE>() const;
+-template bool DefinedRegular::template isMipsPIC<ELF64BE>() const;
++template bool DefinedRegular::isMipsPIC<ELF32LE>() const;
++template bool DefinedRegular::isMipsPIC<ELF32BE>() const;
++template bool DefinedRegular::isMipsPIC<ELF64LE>() const;
++template bool DefinedRegular::isMipsPIC<ELF64BE>() const;
+ 
+-template uint32_t SharedSymbol::template getAlignment<ELF32LE>() const;
+-template uint32_t SharedSymbol::template getAlignment<ELF32BE>() const;
+-template uint32_t SharedSymbol::template getAlignment<ELF64LE>() const;
+-template uint32_t SharedSymbol::template getAlignment<ELF64BE>() const;
++template uint32_t SharedSymbol::getAlignment<ELF32LE>() const;
++template uint32_t SharedSymbol::getAlignment<ELF32BE>() const;
++template uint32_t SharedSymbol::getAlignment<ELF64LE>() const;
++template uint32_t SharedSymbol::getAlignment<ELF64BE>() const;

--- a/var/spack/repos/builtin/packages/llvm/llvm5-sanitizer-ustat.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm5-sanitizer-ustat.patch
@@ -1,0 +1,25 @@
+# <sys/ustat.h> has been removed from glibc 2.28,
+# backport fix from llvm-6.0.1:
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -159,1 +159,0 @@
+-#include <sys/ustat.h>
+@@ -252,5 +252,17 @@
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned struct_ustat_sz = sizeof(struct ustat);
++  // Use pre-computed size of struct ustat to avoid <sys/ustat.h> which
++  // has been removed from glibc 2.28.
++#if defined(__aarch64__) || defined(__s390x__) || defined (__mips64) \
++  || defined(__powerpc64__) || defined(__arch64__) || defined(__sparcv9) \
++  || defined(__x86_64__)
++#define SIZEOF_STRUCT_USTAT 32
++#elif defined(__arm__) || defined(__i386__) || defined(__mips__) \
++  || defined(__powerpc__) || defined(__s390__)
++#define SIZEOF_STRUCT_USTAT 20
++#else
++#error Unknown size of struct ustat
++#endif
++  unsigned struct_ustat_sz = SIZEOF_STRUCT_USTAT;
+   unsigned struct_rlimit64_sz = sizeof(struct rlimit64);
+   unsigned struct_statvfs64_sz = sizeof(struct statvfs64);

--- a/var/spack/repos/builtin/packages/llvm/missing-includes.patch
+++ b/var/spack/repos/builtin/packages/llvm/missing-includes.patch
@@ -1,0 +1,23 @@
+# https://github.com/spack/spack/issues/24270 (This hunk is upstream since llvm-10)
+--- a/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
++++ b/llvm/include/llvm/Demangle/MicrosoftDemangleNodes.h
+@@ -4,6 +4,8 @@
+ #include "llvm/Demangle/Compiler.h"
+ #include "llvm/Demangle/StringView.h"
+ #include <array>
++#include <cstdint>
++#include <string>
+ 
+ class OutputStream;
+ 
+# https://github.com/spack/spack/pull/27233
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -2,6 +2,7 @@
+ #define BENCHMARK_REGISTER_H
+ 
+ #include <vector>
++#include <limits>
+ 
+ #include "check.h"
+ 

--- a/var/spack/repos/builtin/packages/llvm/no_cyclades9.patch
+++ b/var/spack/repos/builtin/packages/llvm/no_cyclades9.patch
@@ -1,0 +1,42 @@
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -370,9 +370,0 @@
+-  _(CYGETDEFTHRESH, WRITE, sizeof(int));
+-  _(CYGETDEFTIMEOUT, WRITE, sizeof(int));
+-  _(CYGETMON, WRITE, struct_cyclades_monitor_sz);
+-  _(CYGETTHRESH, WRITE, sizeof(int));
+-  _(CYGETTIMEOUT, WRITE, sizeof(int));
+-  _(CYSETDEFTHRESH, NONE, 0);
+-  _(CYSETDEFTIMEOUT, NONE, 0);
+-  _(CYSETTHRESH, NONE, 0);
+-  _(CYSETTIMEOUT, NONE, 0);
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -986,1 +986,0 @@
+-  extern unsigned struct_cyclades_monitor_sz;
+@@ -1331,9 +1327,0 @@
+-  extern unsigned IOCTL_CYGETDEFTHRESH;
+-  extern unsigned IOCTL_CYGETDEFTIMEOUT;
+-  extern unsigned IOCTL_CYGETMON;
+-  extern unsigned IOCTL_CYGETTHRESH;
+-  extern unsigned IOCTL_CYGETTIMEOUT;
+-  extern unsigned IOCTL_CYSETDEFTHRESH;
+-  extern unsigned IOCTL_CYSETDEFTIMEOUT;
+-  extern unsigned IOCTL_CYSETTHRESH;
+-  extern unsigned IOCTL_CYSETTIMEOUT;
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -143,1 +143,0 @@
+-#include <linux/cyclades.h>
+@@ -460,1 +459,0 @@
+-  unsigned struct_cyclades_monitor_sz = sizeof(struct cyclades_monitor);
+@@ -824,9 +822,0 @@
+-  unsigned IOCTL_CYGETDEFTHRESH = CYGETDEFTHRESH;
+-  unsigned IOCTL_CYGETDEFTIMEOUT = CYGETDEFTIMEOUT;
+-  unsigned IOCTL_CYGETMON = CYGETMON;
+-  unsigned IOCTL_CYGETTHRESH = CYGETTHRESH;
+-  unsigned IOCTL_CYGETTIMEOUT = CYGETTIMEOUT;
+-  unsigned IOCTL_CYSETDEFTHRESH = CYSETDEFTHRESH;
+-  unsigned IOCTL_CYSETDEFTIMEOUT = CYSETDEFTIMEOUT;
+-  unsigned IOCTL_CYSETTHRESH = CYSETTHRESH;
+-  unsigned IOCTL_CYSETTIMEOUT = CYSETTIMEOUT;

--- a/var/spack/repos/builtin/packages/llvm/sanitizer-ipc_perm_mode.patch
+++ b/var/spack/repos/builtin/packages/llvm/sanitizer-ipc_perm_mode.patch
@@ -1,0 +1,9 @@
+# ipc_perm.mode is not used and has changed from short to int over architecures
+# and versions. The last change was in glibc-2.31.
+# LLVM upstream decided to not check ipc_perm.mode below glibc-2.31,
+# because it is not actually used in the sanitizer:
+# github.com/llvm/llvm-project/commit/947f9692440836dcb8d88b74b69dd379d85974ce
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -1143,1 +1143,0 @@
+-CHECK_SIZE_AND_OFFSET(ipc_perm, mode);

--- a/var/spack/repos/builtin/packages/llvm/xray_buffer_queue-cstddef.patch
+++ b/var/spack/repos/builtin/packages/llvm/xray_buffer_queue-cstddef.patch
@@ -1,0 +1,5 @@
+# Fix missing std:size_t in 'llvm@4:5' for build with '%clang@7:'
+--- a/compiler-rt/lib/xray/xray_buffer_queue.h
++++ b/compiler-rt/lib/xray/xray_buffer_queue.h
+@@ -18,0 +18,1 @@
++#include <cstddef>


### PR DESCRIPTION
@trws wrote here below
"... getting older LLVM (even 9) to build on newer Linux systems has proven to be a major problem in some cases because of things like this."

# This fixes building these older LLVM versions with more recent compilers:
## LLVM @8:11
Fix build of MicrosoftDemangle code (add missing include)
## LLVM@5:7
- Fix building sanitizers: https://github.com/llvm/llvm-project/commit/947f9692440836dcb8d88b74b69dd379d85974ce
## LLVM@4:5
 - `sys/ustat.h` has been removed in favour of statfs from glibc-2.28. Use fixed sizes (applied fix from llvm-6.0.1)
 -  Fix `lld` templates: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=230463
 -  Add missing `include <cstddef>` for `std:size_t` in `llvm@4:5`,
    when built with '%clang@7:'

(and more fixes)