### PR TITLE
mesa: Use the llvm-config of spec['llvm'] for '+llvm'

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -169,6 +169,16 @@ class Mesa(MesonPackage):
         args.append(opt_enable(num_frontends > 1, 'shared-glapi'))
 
         if '+llvm' in spec:
+            # Fix builds on hosts where /usr/bin/llvm-config-* is found and provides an
+            # incompatible version. Ensure that the llvm-config of spec['llvm'] is used.
+            args.append('--native-file')
+            args.append('meson-native-config.ini')
+            mkdirp(self.build_directory)
+            with working_dir(self.build_directory):
+                with open('meson-native-config.ini', 'w') as native_config:
+                    llvm_config = spec['llvm'].prefix.bin + '/llvm-config'
+                    native_config.write('[binaries]\n')
+                    native_config.write("llvm-config = '{0}'\n".format(llvm_config))
             args.append('-Dllvm=enabled')
             args.append(opt_enable(
                 '+link_dylib' in spec['llvm'], 'shared-llvm'))


### PR DESCRIPTION
When running `spack install mesa@@21.2.3 %clang@8.0.1` on a host which has `/usr/bin/llvm-config-13`, meson picked /usr/bin/llvm-config-13, which in turn caused it to fail to build since it is not yet updated for llvm-13.

Therefore:

Fix builds on hosts where /usr/bin/llvm-config-* is found and provides an incompatible version:

Ensure that the `llvm-config` of `spec['llvm'].prefix` is used.