### PR TITLE
qt: replace conflicts('%gcc@11:', when='@5.9:5.14') with -include limits

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -143,8 +143,7 @@ class Qt(Package):
           working_dir='qtwebsockets',
           when='@5.14: %gcc@11:')
     conflicts('%gcc@10:', when='@5.9:5.12.6 +opengl')
-    # Error: 'numeric_limits' is not a class template
-    conflicts('%gcc@11:', when='@5.8:5.14')
+    conflicts('%gcc@11:', when='@5.8')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')
@@ -417,6 +416,11 @@ class Qt(Package):
         # Don't error out on undefined symbols
         filter_file('^QMAKE_LFLAGS_NOUNDEF .*', 'QMAKE_LFLAGS_NOUNDEF = ',
                     conf('g++-unix'))
+
+        # https://gcc.gnu.org/gcc-11/porting_to.html: add -include limits
+        if self.spec.satisfies('@5.9:5.14%gcc@11:'):
+            with open(conf('gcc-base'), 'a') as f:
+                f.write("QMAKE_CXXFLAGS += -include limits\n")
 
         if self.spec.satisfies('@4'):
             # The gnu98 flag is necessary to build with GCC 6 and other modern


### PR DESCRIPTION
I noted that the missing definition of `numeric_limits` was the cause of the compile issues with `gcc-11`.
(which extend to qt-5.14.2 - the current preferred version -  which I to in the `conflicts` for `gcc-11`),

Obligatory reference https://bugreports.qt.io/browse/QTBUG-93452  

As these are fixable by including `limits`, and documented in https://gcc.gnu.org/gcc-11/porting_to.html ,
I tested adding `-include limits` fixing @5.9:5.14%gcc@11 - which fixed all releases from `5.9` to `5.14.2`! Huray!

Therefore, we can replace the conflicts('%gcc@11:', when='@5.9:5.14'), with including `limits`, making gcc-11 behave gcc-11 for like `gcc@:10` for these builds.

Inside the when %gcc patch function, add:
```py
        # https://gcc.gnu.org/gcc-11/porting_to.html: add -include limits
        if self.spec.satisfies('@5.9:5.14%gcc@11:'):
            with open(conf('gcc-base'), 'a') as f:
                f.write("QMAKE_CXXFLAGS += -include limits\n")
```

The alternative would have been to patch every affected file like this:
```py
filter_file('string.h>', 'string.h>\n#include <limits>',                                                                                                       
            'qtbase/src/corelib/global/qendian.h')                                 
filter_file('string.h>', 'string.h>\n#include <limits>',                           
            'qtbase/src/corelib/global/qfloat16.h')                                
if self.spec.satisfies('@:5.13'):                                                  
     filter_file('y.h>', 'y.h>\n#include <limits>',                                
                 'qtbase/src/corelib/tools/qbytearraymatcher.h')                   
     filter_file('p.h>', 'p.h>\n#include <limits>',                                
                 'qtdeclarative/src/qml/jsruntime/qv4propertykey_p.h')             
     filter_file('limits.h>', 'limits>',                                           
                 'qtdeclarative/src/3rdparty/masm/yarr/Yarr.h')                    
     ... qqmlprofilerevent_p.h:314:90 ...                                          
     (I have no idea how many would have to be patched)
```
As the former is far nicer and it is what these older qt versions get when built with `gcc@:10`, it is far better this way.