### PR TITLE
font-util: fix the build when fontroot is not set

### DIFF
--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -102,6 +102,8 @@ class FontUtil(AutotoolsPackage, XorgPackage):
 
         for font in fonts:
             fontroot = find(font, '*', recursive=False)
+            if not fontroot:
+                continue
             with working_dir(fontroot[0]):
                 autoreconf(*autoconf_args)
                 configure = Executable("./configure")


### PR DESCRIPTION
On a server, some fonts could not be found. Pass the build despite it.