### PR TITLE
gromacs-chain-coordinate: inherit from gromacs package

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -3,18 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# This is a partial copy of Spack Gromacs package
-# - modified URL and versions
-# - removed Plumed patches
-# - calling original patch and cmake-related procedures to not duplicate them
-# - simplified variants/dependencies because this fork starts at Gromacs 2021
-
-import os
-
-from spack.pkg.builtin.gromacs import Gromacs as BuiltinGromacs
+from spack.pkg.builtin.gromacs import Gromacs
 
 
-class GromacsChainCoordinate(CMakePackage):
+class GromacsChainCoordinate(Gromacs):
     """
     A modification of GROMACS that implements the "chain coordinate", a reaction
     coordinate for pore formation in membranes and stalk formation between membranes.
@@ -26,57 +18,27 @@ class GromacsChainCoordinate(CMakePackage):
     maintainers = ['w8jcik']
 
     version('main', branch='main')
+
     version('2021.2-0.1', sha256="879fdd04662370a76408b72c9fbc4aff60a6387b459322ac2700d27359d0dd87",
             url="https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2",
             preferred=True)
 
-    variant('mpi', default=True,
-            description='Activate MPI support (disable for Thread-MPI support)')
-    variant('shared', default=True,
-            description='Enables the build of shared libraries')
-    variant(
-        'double', default=False,
-        description='Produces a double precision version of the executables')
-    variant('cuda', default=False, description='Enable CUDA support')
-    variant('opencl', default=False, description='Enable OpenCL support')
-    variant('sycl', default=False, description='Enable SYCL support')
-    variant('nosuffix', default=False, description='Disable default suffixes')
-    variant('build_type', default='RelWithDebInfo',
-            description='The build type to build',
-            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel',
-                    'Reference', 'RelWithAssert', 'Profile'))
-    variant('openmp', default=True,
-            description='Enables OpenMP at configure time')
-    variant('hwloc', default=True,
-            description='Use the hwloc portable hardware locality library')
-    variant('lapack', default=False,
-            description='Enables an external LAPACK library')
-    variant('blas', default=False,
-            description='Enables an external BLAS library')
-    variant('cycle_subcounters', default=False,
-            description='Enables cycle subcounters')
+    conflicts('+plumed')
 
-    depends_on('mpi', when='+mpi')
-    depends_on('fftw-api@3')
-    depends_on('cmake@3.16.0:3', type='build')
-    depends_on('cuda', when='+cuda')
-    depends_on('sycl', when='+sycl')
-    depends_on('lapack', when='+lapack')
-    depends_on('blas', when='+blas')
-    depends_on('hwloc', when='+hwloc')
+    def remove_parent_versions(self):
+        """
+        By inheriting GROMACS package we also inherit versions.
+        They are not valid, so we are removing them.
+        """
 
-    filter_compiler_wrappers(
-        '*.cmake',
-        relative_root=os.path.join('share', 'cmake', 'gromacs_mpi'))
-    filter_compiler_wrappers(
-        '*.cmake',
-        relative_root=os.path.join('share', 'cmake', 'gromacs'))
+        for version_key in Gromacs.versions.keys():
+            if version_key in self.versions:
+                del self.versions[version_key]
 
-    def patch(self):
-        BuiltinGromacs.patch(self)
+    def __init__(self, spec):
+        super(GromacsChainCoordinate, self).__init__(spec)
 
-    def cmake_args(self):
-        return super(GromacsChainCoordinate, self).cmake_args()
+        self.remove_parent_versions()
 
     def check(self):
         """The default 'test' targets does not compile the test programs"""


### PR DESCRIPTION
Previous implementation was copying GROMACS package with some modifications.

New implementation inherits from GROMACS package making it more readable. What is more important, there is no need to keep synchronizing it with normal GROMACS package.

In case the list of changes is not readable, it is the same approach as here https://github.com/spack/spack/pull/26902/files#diff-f72fa5c72c640d4c85323f4e1288398c35bfd9af835385e7236c04729919c1da