### PR TITLE
avoid PermissionError on Lustre when copying files (fixes #25354)

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -84,7 +84,7 @@ __all__ = [
     "visit_directory_tree",
 ]
 
-if sys.version_info < (3, 7, 4):    
+if sys.version_info < (3, 7, 4):
     # monkeypatch shutil.copystat to fix PermissionError when copying read-only
     # files on Lustre when using Python < 3.7.4
 
@@ -148,7 +148,7 @@ if sys.version_info < (3, 7, 4):
                         break
                 else:
                     raise
-    
+
     shutil.copystat = copystat
 
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -97,6 +97,7 @@ if sys.version_info < (3, 7, 4):
         If the optional flag `follow_symlinks` is not set, symlinks aren't
         followed if and only if both `src` and `dst` are symlinks.
         """
+
         def _nop(args, ns=None, follow_symlinks=None):
             pass
 
@@ -106,6 +107,7 @@ if sys.version_info < (3, 7, 4):
             # use the real function if it exists
             def lookup(name):
                 return getattr(os, name, _nop)
+
         else:
             # use the real function only if it exists
             # *and* it supports follow_symlinks
@@ -118,8 +120,7 @@ if sys.version_info < (3, 7, 4):
 
         st = lookup("stat")(src, follow_symlinks=follow)
         mode = stat.S_IMODE(st.st_mode)
-        lookup("utime")(dst, ns=(st.st_atime_ns, st.st_mtime_ns),
-                        follow_symlinks=follow)
+        lookup("utime")(dst, ns=(st.st_atime_ns, st.st_mtime_ns), follow_symlinks=follow)
 
         # We must copy extended attributes before the file is (potentially)
         # chmod()'ed read-only, otherwise setxattr() will error with -EACCES.
@@ -139,11 +140,11 @@ if sys.version_info < (3, 7, 4):
             # symlink.  give up, suppress the error.
             # (which is what shutil always did in this circumstance.)
             pass
-        if hasattr(st, 'st_flags'):
+        if hasattr(st, "st_flags"):
             try:
                 lookup("chflags")(dst, st.st_flags, follow_symlinks=follow)
             except OSError as why:
-                for err in 'EOPNOTSUPP', 'ENOTSUP':
+                for err in "EOPNOTSUPP", "ENOTSUP":
                     if hasattr(errno, err) and why.errno == getattr(errno, err):
                         break
                 else:

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -112,7 +112,7 @@ if sys.version_info < (3, 7, 4):
             def lookup(name):
                 fn = getattr(os, name, _nop)
                 if sys.version_info >= (3, 3):
-                    if fn in os.supports_follow_symlinks:
+                    if fn in os.supports_follow_symlinks:  # novermin
                         return fn
                 return _nop
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -84,6 +84,71 @@ __all__ = [
     "visit_directory_tree",
 ]
 
+if sys.version_info < (3, 7, 4):
+    def copystat(src, dst, *, follow_symlinks=True):
+        """Copy file metadata
+        Copy the permission bits, last access time, last modification time, and
+        flags from `src` to `dst`. On Linux, copystat() also copies the "extended
+        attributes" where possible. The file contents, owner, and group are
+        unaffected. `src` and `dst` are path names given as strings.
+        If the optional flag `follow_symlinks` is not set, symlinks aren't
+        followed if and only if both `src` and `dst` are symlinks.
+        """
+        def _nop(*args, ns=None, follow_symlinks=None):
+            pass
+
+        # follow symlinks (aka don't not follow symlinks)
+        follow = follow_symlinks or not (os.path.islink(src) and os.path.islink(dst))
+        if follow:
+            # use the real function if it exists
+            def lookup(name):
+                return getattr(os, name, _nop)
+        else:
+            # use the real function only if it exists
+            # *and* it supports follow_symlinks
+            def lookup(name):
+                fn = getattr(os, name, _nop)
+                if fn in os.supports_follow_symlinks:
+                    return fn
+                return _nop
+
+        st = lookup("stat")(src, follow_symlinks=follow)
+        mode = stat.S_IMODE(st.st_mode)
+        lookup("utime")(dst, ns=(st.st_atime_ns, st.st_mtime_ns),
+                        follow_symlinks=follow)
+
+        # We must copy extended attributes before the file is (potentially)
+        # chmod()'ed read-only, otherwise setxattr() will error with -EACCES.
+        shutil._copyxattr(src, dst, follow_symlinks=follow)
+
+        try:
+            lookup("chmod")(dst, mode, follow_symlinks=follow)
+        except NotImplementedError:
+            # if we got a NotImplementedError, it's because
+            #   * follow_symlinks=False,
+            #   * lchown() is unavailable, and
+            #   * either
+            #       * fchownat() is unavailable or
+            #       * fchownat() doesn't implement AT_SYMLINK_NOFOLLOW.
+            #         (it returned ENOSUP.)
+            # therefore we're out of options--we simply cannot chown the
+            # symlink.  give up, suppress the error.
+            # (which is what shutil always did in this circumstance.)
+            pass
+        if hasattr(st, 'st_flags'):
+            try:
+                lookup("chflags")(dst, st.st_flags, follow_symlinks=follow)
+            except OSError as why:
+                for err in 'EOPNOTSUPP', 'ENOTSUP':
+                    if hasattr(errno, err) and why.errno == getattr(errno, err):
+                        break
+                else:
+                    raise
+
+    ## monkeypatch shutil.copystat to fix error when
+    ## copying directory trees on Lustre for Python < 3.7.4
+    shutil.copystat = copystat
+
 
 def getuid():
     if is_windows:


### PR DESCRIPTION
There is a bug in Python versions < 3.7.4 that causes PermissionError to occur when using shutil.copy2 to copy read-only files that have extended attributes set by Lustre (which is used by lib/spack/llnl/util/filesystem.py:504 to copy directory trees). The upstream Python bug is [here](https://bugs.python.org/issue24538).

Setting SPACK_PYTHON to point to a python executable >= version 3.7.4 fixes the problem. However, for Python versions below this, we monkeypatch shutil.copystat to set extended attributes *before* setting permissions. This means that copying read-only files that have extended attributes set by Lustre can succeed, which is necessary to install openjdk (and fix #25354). I have confirmed on my cluster that this patch fixes openjdk installation when spack is installed on a Lustre FS when using Python 3.6.