### PR TITLE
[libdrm] new versions up to 2.4.110, build system meson

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -62,7 +62,9 @@ class Libdrm(Package):
             # Needed to fix build for spack/spack#1740, but breaks newer
             # builds/compilers
             args.append('LIBS=-lrt')
-        if self.spec.satisfies('%gcc@10.0.0:') or self.spec.satisfies('%clang@11.0.0:') or self.spec.satisfies('%aocc@2.3.0:'):
+        if (self.spec.satisfies('%gcc@10.0.0:') or
+            self.spec.satisfies('%clang@11.0.0:') or
+            self.spec.satisfies('%aocc@2.3.0:')):
             args.append('CFLAGS=-fcommon')
         return args
 

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -12,6 +12,7 @@ class Libdrm(Package):
 
     homepage = "https://dri.freedesktop.org/libdrm/"
     url      = "https://dri.freedesktop.org/libdrm/libdrm-2.4.101.tar.xz"
+    list_url = "https://dri.freedesktop.org/libdrm/"
 
     maintainers = ['wdconinc']
 

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -13,6 +13,10 @@ class Libdrm(Package):
     homepage = "https://dri.freedesktop.org/libdrm/"
     list_url = "https://dri.freedesktop.org/libdrm/"
 
+    maintainers = ['wdconinc']
+
+    version('2.4.109', sha256='629352e08c1fe84862ca046598d8a08ce14d26ab25ee1f4704f993d074cb7f26')
+    version('2.4.108', sha256='a1d7948cbc536763fde14b4beb5e4da7867607966d4cf46301087e8b8fe3d6a0')
     version('2.4.107', sha256='c554cef03b033636a975543eab363cc19081cb464595d3da1ec129f87370f888')
     version('2.4.100', sha256='6a5337c054c0c47bc16607a21efa2b622e08030be4101ef4a241c5eb05b6619b')
     version('2.4.81',  sha256='64036c5e0668fdc2b820dcc0ebab712f44fd2c2147d23dc5a6e003b19f0d3e9f')

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -29,9 +29,9 @@ class Libdrm(Package):
 
     def url_for_version(self, version):
         if version <= Version('2.4.100'):
-            return self.list_url + 'libdrm-{}.tar.gz'.format(version)
+            return self.list_url + 'libdrm-%s.tar.gz' % version
         else:
-            return self.list_url + 'libdrm-{}.tar.xz'.format(version)
+            return self.list_url + 'libdrm-%s.tar.xz' % version
 
     def meson_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -11,7 +11,7 @@ class Libdrm(Package):
     on Linux, BSD and other systems supporting the ioctl interface."""
 
     homepage = "https://dri.freedesktop.org/libdrm/"
-    list_url = "https://dri.freedesktop.org/libdrm/"
+    url      = "https://dri.freedesktop.org/libdrm/libdrm-2.4.101.tar.xz"
 
     maintainers = ['wdconinc']
 

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -16,6 +16,7 @@ class Libdrm(Package):
 
     maintainers = ['wdconinc']
 
+    version('2.4.110', sha256='eecee4c4b47ed6d6ce1a9be3d6d92102548ea35e442282216d47d05293cf9737')
     version('2.4.109', sha256='629352e08c1fe84862ca046598d8a08ce14d26ab25ee1f4704f993d074cb7f26')
     version('2.4.108', sha256='a1d7948cbc536763fde14b4beb5e4da7867607966d4cf46301087e8b8fe3d6a0')
     version('2.4.107', sha256='c554cef03b033636a975543eab363cc19081cb464595d3da1ec129f87370f888')


### PR DESCRIPTION
This introduces the newest version for libdrm, 2.4.107. The version 2.4.100 was having trouble building with clang-14.

The previously most recent version was the last one based on autotools. This PR therefore also adds support for the newer meson build system while maintaining support for the older versions. The inspiration for the approach came from the glib package.

There are no meson arguments needed, but because the package does not inherit from MesonPackage we still have to define it.

The previous autotools arguments do not seem necessary. I hope the additional compilation tests on the CI nodes may point out issues on platforms I have no access to for testing.