### PR TITLE
kokkos: make Spack accept CUDA compute capability 8.6

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -130,6 +130,7 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         "72": 'volta72',
         "75": 'turing75',
         "80": 'ampere80',
+        "86": 'ampere86',
     }
     cuda_arches = spack_cuda_arch_map.values()
     conflicts("+cuda", when="cuda_arch=none")


### PR DESCRIPTION
The Kokkos sources already know AMPERE86 since some time; make
Spack accept and pass it, too.