### PR TITLE
openmpi: does not support "--without-pmix"

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -652,7 +652,8 @@ class Openmpi(AutotoolsPackage):
                     spec['slurm'].prefix))
             else:
                 config_args.extend(self.with_or_without('pmi'))
-            config_args += self.with_or_without('pmix', activation_value='prefix')
+            if spec.satisfies('+pmix'):
+                config_args.append('--with-pmix={0}'.format(spec['pmix'].prefix))
             if spec.satisfies('@3.1.3:') or spec.satisfies('@3.0.3'):
                 if '+static' in spec:
                     config_args.append('--enable-static')


### PR DESCRIPTION
Open MPI currently fails to build with scheduler=slurm if +pmix is
not given with a fatal error due to ``config_args +=
self.with_or_without('pmix', ...)`` resulting in --without-pmix.
However, Open MPI's configure points out "Note that Open MPI does
not support --without-pmix."

The PR only adds "--with-pmix=PATH" only if +pmix is part of the spec.
Otherwise, nothing is added and Open MPI can fall back to its
internal PMIX sources.

(The other alternativ would be to depend on +pmix in for
scheduler=slurm as is done for +pmi.)