### PR TITLE
py-pytorch-lightning: add v1.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -12,6 +12,7 @@ class PyPytorchLightning(PythonPackage):
     homepage = "https://github.com/PyTorchLightning/pytorch-lightning"
     pypi     = "pytorch-lightning/pytorch-lightning-1.2.10.tar.gz"
 
+    version('1.5.0', sha256='5bc28022f749d6a7644027ca0428bc162c9ab401cdea78b264d14f5018430f3b')
     version('1.4.1', sha256='1d1128aeb5d0e523d2204c4d9399d65c4e5f41ff0370e96d694a823af5e8e6f3')
     version('1.4.0', sha256='6529cf064f9dc323c94f3ce84b56ee1a05db1b0ab17db77c4d15aa36e34da81f')
     version('1.3.8', sha256='60b0a3e464d394864dae4c8d251afa7aa453644a19bb7672f5ee400343cdf7b0')
@@ -30,7 +31,9 @@ class PyPytorchLightning(PythonPackage):
     depends_on('py-pyyaml@5.1:5.3,5.5:', when='@:1.2', type=('build', 'run'))
     depends_on('py-fsspec@2021.05.0:2021.05,2021.06.1:+http', when='@1.3:', type=('build', 'run'))
     depends_on('py-fsspec@0.8.1:+http', when='@:1.2', type=('build', 'run'))
-    depends_on('py-tensorboard@2.2.0:2.4,2.5.1:', type=('build', 'run'))
+    depends_on('py-tensorboard@2.2.0:', when='@1.5:', type=('build', 'run'))
+    depends_on('py-tensorboard@2.2.0:2.4,2.5.1:', when='@:1.4', type=('build', 'run'))
+    depends_on('py-torchmetrics@0.4.1:', when='@1.5:', type=('build', 'run'))
     depends_on('py-torchmetrics@0.4.0:', when='@1.4:', type=('build', 'run'))
     depends_on('py-torchmetrics@0.2.0:', when='@1.3', type=('build', 'run'))
     depends_on('py-torchmetrics@0.2.0', when='@:1.2', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
+++ b/var/spack/repos/builtin/packages/py-pytorch-lightning/package.py
@@ -22,6 +22,9 @@ class PyPytorchLightning(PythonPackage):
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy@1.17.2:', when='@1.3:', type=('build', 'run'))
     depends_on('py-numpy@1.16.6:', when='@:1.2', type=('build', 'run'))
+    # TODO: add patch and remove +distributed once the following issue is resolved:
+    # https://github.com/PyTorchLightning/pytorch-lightning/issues/10348
+    depends_on('py-torch@1.6:+distributed', when='@1.5.0', type=('build', 'run'))
     depends_on('py-torch@1.6:', when='@1.4:', type=('build', 'run'))
     depends_on('py-torch@1.4:', when='@:1.3', type=('build', 'run'))
     depends_on('py-future@0.17.1:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.