### PR TITLE
py-build: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-build/package.py
+++ b/var/spack/repos/builtin/packages/py-build/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyBuild(PythonPackage):
+    """A simple, correct PEP517 package builder."""
+
+    homepage = "https://github.com/pypa/build"
+    pypi     = "build/build-0.7.0.tar.gz"
+
+    version('0.7.0', sha256='1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f')
+
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-packaging@19:', type=('build', 'run'))
+    depends_on('py-pep517@0.9.1:', type=('build', 'run'))
+    depends_on('py-tomli@1:', type=('build', 'run'))
+    depends_on('py-colorama', when='platform=windows', type=('build', 'run'))
+    depends_on('py-importlib-metadata@0.22:', when='^python@:3.7', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pep517/package.py
+++ b/var/spack/repos/builtin/packages/py-pep517/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPep517(PythonPackage):
+    """Wrappers to build Python packages using PEP 517 hooks."""
+
+    homepage = "https://github.com/pypa/pep517"
+    pypi     = "pep517/pep517-0.12.0.tar.gz"
+
+    version('0.12.0', sha256='931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0')
+
+    depends_on('py-toml', when='^python@:3.5', type=('build', 'run'))
+    depends_on('py-importlib-metadata', when='^python@:3.7', type=('build', 'run'))
+    depends_on('py-zipp', when='^python@:3.7', type=('build', 'run'))
+    depends_on('py-tomli@1.1:', when='^python@3.6:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.