### PR TITLE
e4s ci: expand +cuda specs

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -59,24 +59,33 @@ spack:
   - cuda_specs:
     - amrex +cuda cuda_arch=70
     - caliper +cuda cuda_arch=70
-    - chai +cuda ~benchmarks ~tests cuda_arch=70 ^umpire~shared+cuda
+    - chai ~benchmarks ~tests +cuda cuda_arch=70 ^umpire ~shared
     - ginkgo +cuda cuda_arch=70
+    - heffte +cuda cuda_arch=70
     - hpx +cuda cuda_arch=70
-    - kokkos +cuda +wrapper cuda_arch=70
-    - kokkos-kernels +cuda cuda_arch=70 ^kokkos +cuda +wrapper cuda_arch=70
-    - magma cuda_arch=70
+    - hypre +cuda cuda_arch=70
+    - kokkos +wrapper +cuda cuda_arch=70
+    - kokkos-kernels +cuda cuda_arch=70 ^kokkos +wrapper +cuda cuda_arch=70
+    - magma +cuda cuda_arch=70
+    - mfem +cuda cuda_arch=70
+    - parsec +cuda cuda_arch=70
+    - petsc +cuda cuda_arch=70
     - raja +cuda cuda_arch=70
     - slate +cuda cuda_arch=70
-    - strumpack +cuda ~slate cuda_arch=70
+    - slepc +cuda cuda_arch=70
+    - strumpack ~slate +cuda cuda_arch=70
     - sundials +cuda cuda_arch=70
     - superlu-dist +cuda cuda_arch=70
     - tasmanian +cuda cuda_arch=70
-    - umpire +cuda ~shared cuda_arch=70
+    - trilinos@13.2.0 +cuda cuda_arch=70
+    - umpire ~shared +cuda cuda_arch=70
+    - vtk-m +cuda cuda_arch=70
     - zfp +cuda cuda_arch=70
-    #- ascent +cuda ~shared cuda_arch=70
-    #- axom +cuda cuda_arch=70 ^umpire~shared
-    #- hypre +cuda cuda_arch=70
-    #- mfem +cuda cuda_arch=70
+   #- ascent ~shared +cuda cuda_arch=70
+   #- axom +cuda cuda_arch=70 ^umpire ~shared
+   #- dealii +cuda cuda_arch=70 # gmsh
+   #- flecsi +cuda cuda_arch=70
+   #- paraview +cuda cuda_arch=70
 
   - default_specs:
     - adios

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -59,24 +59,33 @@ spack:
   - cuda_specs:
     - amrex +cuda cuda_arch=70
     - caliper +cuda cuda_arch=70
-    - chai +cuda ~benchmarks ~tests cuda_arch=70 ^umpire~shared+cuda
+    - chai ~benchmarks ~tests +cuda cuda_arch=70 ^umpire ~shared
     - ginkgo +cuda cuda_arch=70
+    - heffte +cuda cuda_arch=70
     - hpx +cuda cuda_arch=70
-    - kokkos +cuda +wrapper cuda_arch=70
-    - kokkos-kernels +cuda cuda_arch=70 ^kokkos +cuda +wrapper cuda_arch=70
-    - magma cuda_arch=70
+    - hypre +cuda cuda_arch=70
+    - kokkos +wrapper +cuda cuda_arch=70
+    - kokkos-kernels +cuda cuda_arch=70 ^kokkos +wrapper +cuda cuda_arch=70
+    - magma +cuda cuda_arch=70
+    - mfem +cuda cuda_arch=70
+    - parsec +cuda cuda_arch=70
+    - petsc +cuda cuda_arch=70
     - raja +cuda cuda_arch=70
     - slate +cuda cuda_arch=70
-    - strumpack +cuda ~slate cuda_arch=70
+    - slepc +cuda cuda_arch=70
+    - strumpack ~slate +cuda cuda_arch=70
     - sundials +cuda cuda_arch=70
     - superlu-dist +cuda cuda_arch=70
     - tasmanian +cuda cuda_arch=70
+    - trilinos@13.2.0 +cuda cuda_arch=70
+    - umpire ~shared +cuda cuda_arch=70
+    - vtk-m +cuda cuda_arch=70
     - zfp +cuda cuda_arch=70
-    #- ascent +cuda ~shared cuda_arch=70
-    #- axom +cuda cuda_arch=70 ^umpire@4.1.2 ~shared
-    #- hypre +cuda cuda_arch=70
-    #- mfem +cuda cuda_arch=70
-    #- umpire +cuda ~shared cuda_arch=70 # unsatisfiable concretization conflict w/ blt
+   #- ascent ~shared +cuda cuda_arch=70
+   #- axom +cuda cuda_arch=70 ^umpire ~shared
+   #- dealii +cuda cuda_arch=70 # gmsh
+   #- flecsi +cuda cuda_arch=70
+   #- paraview +cuda cuda_arch=70
 
   - rocm_specs:
     - kokkos +rocm amdgpu_target=gfx906


### PR DESCRIPTION
Expand the list of `+cuda` specs built as part of E4S CI