### PR TITLE
icet: add variants to enable 'opengl' and shared libraries.

### DIFF
--- a/var/spack/repos/builtin/packages/icet/package.py
+++ b/var/spack/repos/builtin/packages/icet/package.py
@@ -18,7 +18,7 @@ class Icet(CMakePackage):
     version('2.1.1', sha256='04cc5b7aa5b3ec95b255febdcfc2312e553ce3db5ca305526803d5737561ec32')
 
     variant('opengl', default=False, description="Use opengl")
-    variant('shared', default=False, description='Enable shared library')
+    variant('shared', default=True, description='Enable shared library')
 
     depends_on('mpi')
     depends_on('gl', when="+opengl")

--- a/var/spack/repos/builtin/packages/icet/package.py
+++ b/var/spack/repos/builtin/packages/icet/package.py
@@ -17,10 +17,15 @@ class Icet(CMakePackage):
     version('develop', branch='master')
     version('2.1.1', sha256='04cc5b7aa5b3ec95b255febdcfc2312e553ce3db5ca305526803d5737561ec32')
 
+    variant('opengl', default=False, description="Use opengl")
+    variant('shared', default=False, description='Enable shared library')
+
     depends_on('mpi')
+    depends_on('gl', when="+opengl")
 
     def cmake_args(self):
-        return ['-DICET_USE_OPENGL:BOOL=OFF']
+        return [ self.define_from_variant("ICET_USE_OPENGL", "opengl"),
+                 self.define_from_variant("BUILD_SHARED_LIBS", "shared") ]
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Work-around for ill-placed CMake modules"""

--- a/var/spack/repos/builtin/packages/icet/package.py
+++ b/var/spack/repos/builtin/packages/icet/package.py
@@ -24,8 +24,8 @@ class Icet(CMakePackage):
     depends_on('gl', when="+opengl")
 
     def cmake_args(self):
-        return [ self.define_from_variant("ICET_USE_OPENGL", "opengl"),
-                 self.define_from_variant("BUILD_SHARED_LIBS", "shared") ]
+        return [self.define_from_variant("ICET_USE_OPENGL", "opengl"),
+                self.define_from_variant("BUILD_SHARED_LIBS", "shared")]
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Work-around for ill-placed CMake modules"""


### PR DESCRIPTION
Add two variants to icet:
- `opengl` to compile with OpenGL support (`False` by default)
- `shared` to build shared libraries instead of static libraries (`False` by default)