### PR TITLE
Windows Support Python sysconfig

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -924,12 +924,16 @@ for plat_specific in [True, False]:
         # installs them into lib64. If the user is using an externally
         # installed package, it may be in either lib or lib64, so we need
         # to ask Python where its LIBDIR is.
-        libdir = self.config_vars['LIBDIR']
+        # Some values set by sysconfig may not always exist on Windows, so
+        # check for Windows alternative and KeyError if that is also not found
+        libdir = self.config_vars.get("LIBDIR", self.config_vars["LIBDEST"])
 
         # In Ubuntu 16.04.6 and python 2.7.12 from the system, lib could be
         # in LBPL
         # https://mail.python.org/pipermail/python-dev/2013-April/125733.html
-        libpl = self.config_vars['LIBPL']
+        # LIBPL does not exist in Windows, avoid uneccesary KeyError while allowing
+        # later failures. Return empty string rather than none so os.path doesn't complain
+        libpl = self.config_vars.get("LIBPL", "")
 
         # The system Python installation on macOS and Homebrew installations
         # install libraries into a Frameworks directory

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -846,8 +846,18 @@ class Python(Package):
         # Some values set by sysconfig may not always exist on Windows, so
         # compute Windows alternatives
         def repair_win_sysconf(conf):
-            if not conf["LIBDIR"]:
+            if not is_windows:
+                pass
+            else:
                 conf["LIBDIR"] = os.path.join(conf["LIBDEST"], "..", "libs")
+                conf["LIBPL"] = conf["LIBDIR"]
+                conf["PYTHONFRAMEWORKPREFIX"] = ""
+                conf["LDLIBRARY"] = "python"+conf["VERSION"]+".dll"
+                conf["LIBRARY"] = "python"+conf["VERSION"]+".lib"
+                conf["CC"] = ""
+                conf["CXX"] = ""
+                conf["LDSHARED"] = ""
+                conf["LDCXXSHARED"] = ""
             return conf
 
         # TODO: distutils is deprecated in Python 3.10 and will be removed in
@@ -1147,7 +1157,7 @@ for plat_specific in [True, False]:
             # fact that LDSHARED is set in the environment, therefore we export
             # the variable only if the new value is different from what we got
             # from the sysconfigdata file:
-            if config_link != new_link:
+            if config_link != new_link and not is_windows:
                 env.set(link_var, new_link)
 
     def setup_dependent_run_environment(self, env, dependent_spec):


### PR DESCRIPTION
This PR makes an effort to bridge the gap in the Windows function of python's `get_config_vars` method in `sysconfig` from the Unix function. Unix implementation exposes dramatically more information.

This PR fills in install config info as best as is able, or simply fills in an empty string to allow other packages to query Python's configuration without KeyErrors while still indicating an issue.

This PR is necessary to install/bootstrap Ninja and Clingo on Windows