### PR TITLE
[intel-oneapi-mkl] define MKLROOT

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -66,3 +66,6 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
                               join_path(self.component_path, 'lib', 'intel64'))
         libs += find_system_libraries(['libpthread', 'libm', 'libdl'])
         return libs
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('MKLROOT', self.component_path)


### PR DESCRIPTION
Suggestion from https://github.com/spack/spack/issues/27260

Define MKLROOT in dependent build environment.

Tested with 
```
spack install lammps +kspace ^intel-oneapi-mkl ^intel-oneapi-mpi
```