### PR TITLE
Fix issues where tests assume a develop branch to exist

### DIFF
--- a/.github/workflows/setup_git.sh
+++ b/.github/workflows/setup_git.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env sh
 git config --global user.email "spack@example.com"
 git config --global user.name "Test User"
-# With fetch-depth: 0 we have a remote develop
-# but not a local branch. Don't do this on develop
-if [ "$(git branch --show-current)" != "develop" ]
-then
-  git branch develop origin/develop
+
+# create a local pr base branch
+if [[ -n $GITHUB_BASE_REF ]]; then
+    git branch "${GITHUB_BASE_REF}" "origin/${GITHUB_BASE_REF}"
 fi

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -199,6 +199,11 @@ jobs:
     runs-on: ubuntu-latest
     container: spack/github-actions:centos6
     steps:
+    - name: Setup git configuration
+      run: |
+        # Need this for the git tests to succeed.
+        git --version
+        . .github/workflows/setup_git.sh
     - name: Run unit tests (full test-suite)
       # The CentOS 6 container doesn't run with coverage, but
       # under the same conditions it runs the full test suite

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -198,12 +198,6 @@ jobs:
     needs: [ validate, style, changes ]
     runs-on: ubuntu-latest
     container: spack/github-actions:centos6
-    steps:
-    - name: Setup git configuration
-      run: |
-        # Need this for the git tests to succeed.
-        git --version
-        . .github/workflows/setup_git.sh
     - name: Run unit tests (full test-suite)
       # The CentOS 6 container doesn't run with coverage, but
       # under the same conditions it runs the full test suite
@@ -214,6 +208,7 @@ jobs:
       run: |
           whoami && echo $HOME && cd $HOME
           git clone "${{ github.server_url }}/${{ github.repository }}.git" && cd spack
+          . .github/workflows/setup_git.sh
           git fetch origin "${{ github.ref }}:test-branch"
           git checkout test-branch
           bin/spack unit-test -x
@@ -226,6 +221,7 @@ jobs:
       run: |
           whoami && echo $HOME && cd $HOME
           git clone "${{ github.server_url }}/${{ github.repository }}.git" && cd spack
+          . .github/workflows/setup_git.sh
           git fetch origin "${{ github.ref }}:test-branch"
           git checkout test-branch
           bin/spack unit-test -x -m "not maybeslow" -k "package_sanity"

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -24,8 +24,19 @@ style_data = os.path.join(spack.paths.test_path, 'data', 'style')
 
 style = spack.main.SpackCommand("style")
 
+
+def has_develop_branch():
+    git = which('git')
+    if not git:
+        return False
+    git("show-ref", "--verify", "--quiet",
+        "refs/heads/develop", fail_on_error=False)
+    return git.returncode == 0
+
+
 # spack style requires git to run -- skip the tests if it's not there
-pytestmark = pytest.mark.skipif(not which('git'), reason='requires git')
+pytestmark = pytest.mark.skipif(not has_develop_branch(),
+                                reason='requires git with develop branch')
 
 # The style tools have requirements to use newer Python versions.  We simplify by
 # requiring Python 3.6 or higher to run spack style.

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -206,8 +206,12 @@ def test_prs_update_old_api():
     """Ensures that every package modified in a PR doesn't contain
     deprecated calls to any method.
     """
+    ref = os.getenv("GITHUB_BASE_REF")
+    if not ref:
+        pytest.skip("No base ref found")
+
     changed_package_files = [
-        x for x in style.changed_files() if style.is_package(x)
+        x for x in style.changed_files(base=ref) if style.is_package(x)
     ]
     failing = []
     for file in changed_package_files:

--- a/share/spack/qa/run-style-tests
+++ b/share/spack/qa/run-style-tests
@@ -14,15 +14,15 @@
 # Usage:
 #     run-flake8-tests
 #
-. "$(dirname $0)/setup.sh"
+. "$(dirname "$0")/setup.sh"
 
-BASE=""
-if [ -n "$GITHUB_BASE_REF" ]; then
-    BASE="--base ${GITHUB_BASE_REF}"
+args=()
+if [[ -n $GITHUB_BASE_REF ]]; then
+    args+=("--base" "${GITHUB_BASE_REF}")
 fi
 
 # verify that the code style is correct
-spack style --root-relative $BASE
+spack style --root-relative "${args[@]}"
 
 # verify that the license headers are present
 spack license verify


### PR DESCRIPTION
- Make style tests work when targeting a release branch
- Skip some tests when there is no develop branch

... and this should be backported in #27261

Edit: this was more involved than I thought. Seems like some tests want there to be a develop branch, makes little sense to me but well. I've marked some tests as skipped if there is no develop branch.