### PR TITLE
spack tutorial: fix output to screen

### DIFF
--- a/lib/spack/spack/cmd/tutorial.py
+++ b/lib/spack/spack/cmd/tutorial.py
@@ -77,7 +77,9 @@ def tutorial(parser, args):
     # Note that checkout MUST be last. It changes Spack under our feet.
     # If you don't put this last, you'll get import errors for the code
     # that follows (exacerbated by the various lazy singletons we use)
-    tty.msg("Ensuring we're on the releases/v0.16 branch")
+    tty.msg("Ensuring we're on the releases/v{0}.{1} branch".format(
+        *spack.spack_version_info[:2]
+    ))
     git = which("git", required=True)
     with working_dir(spack.paths.prefix):
         git("checkout", tutorial_branch)


### PR DESCRIPTION
Spack was checking out v0.17, the output reported v0.16