### PR TITLE
spfft/spla/sirius: switch to CachedCMakePackage to fix wrong MPI implementation

### DIFF
--- a/var/spack/repos/builtin/packages/sirius/package.py
+++ b/var/spack/repos/builtin/packages/sirius/package.py
@@ -8,7 +8,7 @@ import os
 from spack import *
 
 
-class Sirius(CMakePackage, CudaPackage):
+class Sirius(CachedCMakePackage, CudaPackage):
     """Domain specific library for electronic structure calculations"""
 
     homepage = "https://github.com/electronic-structure/SIRIUS"
@@ -172,77 +172,73 @@ class Sirius(CMakePackage, CudaPackage):
                 shared='+shared' in self.spec, recursive=True
             )
 
-    def cmake_args(self):
+    def initconfig_package_entries(self):
         spec = self.spec
-
-        args = [
-            self.define_from_variant('USE_OPENMP', 'openmp'),
-            self.define_from_variant('USE_ELPA', 'elpa'),
-            self.define_from_variant('USE_MAGMA', 'magma'),
-            self.define_from_variant('USE_NLCGLIB', 'nlcglib'),
-            self.define_from_variant('USE_VDWXC', 'vdwxc'),
-            self.define_from_variant('USE_MEMORY_POOL', 'memory_pool'),
-            self.define_from_variant('USE_SCALAPACK', 'scalapack'),
-            self.define_from_variant('CREATE_FORTRAN_BINDINGS', 'fortran'),
-            self.define_from_variant('CREATE_PYTHON_MODULE', 'python'),
-            self.define_from_variant('USE_CUDA', 'cuda'),
-            self.define_from_variant('USE_ROCM', 'rocm'),
-            self.define_from_variant('BUILD_TESTING', 'tests'),
-            self.define_from_variant('BUILD_APPS', 'apps'),
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
-            self.define_from_variant('USE_FP32', 'single_precision'),
-            self.define_from_variant('USE_PROFILER', 'profiler')
-        ]
 
         lapack = spec['lapack']
         blas = spec['blas']
 
-        args.extend([
-            self.define('LAPACK_FOUND', 'true'),
-            self.define('LAPACK_LIBRARIES', lapack.libs.joined(';')),
-            self.define('BLAS_FOUND', 'true'),
-            self.define('BLAS_LIBRARIES', blas.libs.joined(';'))
-        ])
+        entries = [
+            cmake_cache_option('USE_OPENMP', '+openmp' in spec),
+            cmake_cache_option('USE_ELPA', '+elpa' in spec),
+            cmake_cache_option('USE_MAGMA', '+magma' in spec),
+            cmake_cache_option('USE_NLCGLIB', '+nlcglib' in spec),
+            cmake_cache_option('USE_VDWXC', '+vdwxc' in spec),
+            cmake_cache_option('USE_MEMORY_POOL', '+memory_pool' in spec),
+            cmake_cache_option('USE_SCALAPACK', '+scalapack' in spec),
+            cmake_cache_option('CREATE_FORTRAN_BINDINGS', '+fortran' in spec),
+            cmake_cache_option('CREATE_PYTHON_MODULE', '+python' in spec),
+            cmake_cache_option('USE_CUDA', '+cuda' in spec),
+            cmake_cache_option('USE_ROCM', '+rocm' in spec),
+            cmake_cache_option('USE_MKL', spec['blas'].name.startswith("intel")),
+            cmake_cache_option('BUILD_TESTING', '+tests' in spec),
+            cmake_cache_option('BUILD_APPS', '+apps' in spec),
+            cmake_cache_option('BUILD_SHARED_LIBS', '+shared' in spec),
+            cmake_cache_option('USE_FP32', '+single_precision' in spec),
+            cmake_cache_option('USE_PROFILER', '+profiler' in spec),
+            cmake_cache_string('LAPACK_FOUND', 'true'),
+            cmake_cache_string('LAPACK_LIBRARIES', lapack.libs.joined(';')),
+            cmake_cache_string('BLAS_FOUND', 'true'),
+            cmake_cache_string('BLAS_LIBRARIES', blas.libs.joined(';')),
+        ]
 
         if '+scalapack' in spec:
-            args.extend([
-                self.define('SCALAPACK_FOUND', 'true'),
-                self.define('SCALAPACK_INCLUDE_DIRS',
-                            spec['scalapack'].prefix.include),
-                self.define('SCALAPACK_LIBRARIES',
-                            spec['scalapack'].libs.joined(';'))
-            ])
-
-        if spec['blas'].name in ['intel-mkl', 'intel-parallel-studio']:
-            args.append(self.define('USE_MKL', 'ON'))
+            entries += [
+                cmake_cache_string('SCALAPACK_FOUND', 'true'),
+                cmake_cache_path('SCALAPACK_INCLUDE_DIRS',
+                                 spec['scalapack'].prefix.include),
+                cmake_cache_string('SCALAPACK_LIBRARIES',
+                                   spec['scalapack'].libs.joined(';'))
+            ]
 
         if '+elpa' in spec:
             elpa_incdir = os.path.join(
                 spec['elpa'].headers.directories[0],
                 'elpa'
             )
-            args.append(self.define('ELPA_INCLUDE_DIR', elpa_incdir))
+            entries.append(cmake_cache_path('ELPA_INCLUDE_DIR', elpa_incdir))
 
         if '+cuda' in spec:
             cuda_arch = spec.variants['cuda_arch'].value
             if cuda_arch[0] != 'none':
                 # Specify a single arch directly
                 if '@:6' in spec:
-                    args.append(self.define(
+                    entries.append(cmake_cache_string(
                         'CMAKE_CUDA_FLAGS',
                         '-arch=sm_{0}'.format(cuda_arch[0]))
                     )
 
                 # Make SIRIUS handle it
                 else:
-                    args.append(self.define('CUDA_ARCH', ';'.join(cuda_arch)))
+                    entries.append(cmake_cache_string('CUDA_ARCH', ';'.join(cuda_arch)))
 
-        if '+rocm' in spec:
+        if '+rocm' in self.spec:
             archs = ",".join(self.spec.variants['amdgpu_target'].value)
-            args.extend([
-                self.define('HIP_ROOT_DIR', spec['hip'].prefix),
-                self.define('HIP_HCC_FLAGS', '--amdgpu-target={0}'.format(archs)),
-                self.define('HIP_CXX_COMPILER', self.spec['hip'].hipcc)
-            ])
+            entries += [
+                cmake_cache_path('HIP_ROOT_DIR', self.spec['hip'].prefix),
+                cmake_cache_string('HIP_HCC_FLAGS',
+                                   '--amdgpu-target={0}'.format(archs)),
+                cmake_cache_string('HIP_CXX_COMPILER', self.spec['hip'].hipcc),
+            ]
 
-        return args
+        return entries

--- a/var/spack/repos/builtin/packages/spfft/package.py
+++ b/var/spack/repos/builtin/packages/spfft/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class Spfft(CMakePackage, CudaPackage):
+class Spfft(CachedCMakePackage, CudaPackage):
     """Sparse 3D FFT library with MPI, OpenMP, CUDA and ROCm support."""
 
     homepage = "https://github.com/eth-cscs/SpFFT"
@@ -66,32 +66,36 @@ class Spfft(CMakePackage, CudaPackage):
     # before version 1.0.3
     patch('0001-fix-missing-limits-include.patch', when='@:1.0.2')
 
-    def cmake_args(self):
-        spec = self.spec
-        args = [
-            self.define_from_variant('SPFFT_OMP', 'openmp'),
-            self.define_from_variant('SPFFT_MPI', 'mpi'),
-            self.define_from_variant('SPFFT_SINGLE_PRECISION', 'single_precision'),
-            self.define_from_variant('SPFFT_GPU_DIRECT', 'gpu_direct'),
-            self.define_from_variant('SPFFT_FORTRAN', 'fortran'),
-            self.define_from_variant('SPFFT_STATIC', 'static')
+    def initconfig_package_entries(self):
+        gpu_backend = 'OFF'
+        if '+cuda' in self.spec:
+            gpu_backend = 'CUDA'
+        elif '+rocm' in self.spec:
+            gpu_backend = 'ROCM'
+
+        entries = [
+            cmake_cache_option('SPFFT_OMP', '+openmp' in self.spec),
+            cmake_cache_option('SPFFT_MPI', '+mpi' in self.spec),
+            cmake_cache_option('SPFFT_SINGLE_PRECISION',
+                               '+single_precision' in self.spec),
+            cmake_cache_option('SPFFT_GPU_DIRECT', '+gpu_direct' in self.spec),
+            cmake_cache_option('SPFFT_FORTRAN', '+fortran' in self.spec),
+            cmake_cache_option('SPFFT_STATIC', '+static' in self.spec),
+            cmake_cache_string('SPFFT_GPU_BACKEND', gpu_backend),
         ]
 
-        if spec.satisfies('+cuda'):
-            args += ["-DSPFFT_GPU_BACKEND=CUDA"]
-
-        if spec.satisfies('+rocm'):
+        if '+rocm' in self.spec:
             archs = ",".join(self.spec.variants['amdgpu_target'].value)
-            args += [
-                '-DSPFFT_GPU_BACKEND=ROCM',
-                '-DHIP_ROOT_DIR={0}'.format(spec['hip'].prefix),
-                '-DHIP_HCC_FLAGS=--amdgpu-target={0}'.format(archs),
-                '-DHIP_CXX_COMPILER={0}'.format(self.spec['hip'].hipcc)
+            entries += [
+                cmake_cache_path('HIP_ROOT_DIR', self.spec['hip'].prefix),
+                cmake_cache_string('HIP_HCC_FLAGS',
+                                   '--amdgpu-target={0}'.format(archs)),
+                cmake_cache_string('HIP_CXX_COMPILER', self.spec['hip'].hipcc),
             ]
 
-        if 'fftw' in spec:
-            args += ["-DSPFFT_FFTW_LIB=FFTW"]
-        elif 'intel-mkl' in spec:
-            args += ["-DSPFFT_FFTW_LIB=MKL"]
+        if self.spec['fftw-api'].name == 'fftw':
+            entries.append(cmake_cache_string('SPFFT_FFTW_LIB', 'FFTW'))
+        elif self.spec['fftw-api'].name.startswith('intel'):
+            entries.append(cmake_cache_string('SPFFT_FFTW_LIB', 'MKL'))
 
-        return args
+        return entries

--- a/var/spack/repos/builtin/packages/spla/package.py
+++ b/var/spack/repos/builtin/packages/spla/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Spla(CMakePackage):
+class Spla(CachedCMakePackage):
     """Specialized Parallel Linear Algebra, providing distributed GEMM
     functionality for specific matrix distributions with optional GPU
     acceleration."""
@@ -47,40 +47,39 @@ class Spla(CMakePackage):
     depends_on('hip', when='+rocm')
 
     # Propagate openmp to blas
-    depends_on('openblas threads=openmp', when='+openmp ^openblas')
-    depends_on('amdblis threads=openmp', when='+openmp ^amdblis')
-    depends_on('blis threads=openmp', when='+openmp ^blis')
-    depends_on('intel-mkl threads=openmp', when='+openmp ^intel-mkl')
+    with when('+openmp'):
+        depends_on('openblas threads=openmp', when='^openblas')
+        depends_on('amdblis threads=openmp', when='^amdblis')
+        depends_on('blis threads=openmp', when='^blis')
+        depends_on('intel-mkl threads=openmp', when='^intel-mkl')
 
     # Fix CMake find module for AMD BLIS,
     # which uses a different library name for the multi-threaded version
     patch('0001-amd_blis.patch', when='@1.3.0:1.4.0 ^amdblis')
 
-    def cmake_args(self):
-        args = [
-            self.define_from_variant('SPLA_OMP', 'openmp'),
-            self.define_from_variant('SPLA_FORTRAN', 'fortran'),
-            self.define_from_variant('SPLA_STATIC', 'static')
-        ]
+    def initconfig_package_entries(self):
+        def _blas2cmake(bname):
+            if bname == 'netlib-lapack':
+                return 'GENERIC'
+            if bname.startswith('intel'):
+                return 'MKL'
+            if bname == 'amdblis':
+                return 'BLIS'
+            if bname in ('openblas', 'atlas', 'blis', 'cray-libsci'):
+                return bname.replace('-', '_').upper()
+            return 'AUTO'
 
+        gpu_backend = 'OFF'
         if '+cuda' in self.spec:
-            args += ["-DSPLA_GPU_BACKEND=CUDA"]
+            gpu_backend = 'CUDA'
         elif '+rocm' in self.spec:
-            args += ["-DSPLA_GPU_BACKEND=ROCM"]
-        else:
-            args += ["-DSPLA_GPU_BACKEND=OFF"]
+            gpu_backend = 'ROCM'
 
-        if self.spec['blas'].name == 'openblas':
-            args += ["-DSPLA_HOST_BLAS=OPENBLAS"]
-        elif self.spec['blas'].name in ['amdblis', 'blis']:
-            args += ["-DSPLA_HOST_BLAS=BLIS"]
-        elif self.spec['blas'].name == 'atlas':
-            args += ["-DSPLA_HOST_BLAS=ATLAS"]
-        elif self.spec['blas'].name == 'intel-mkl':
-            args += ["-DSPLA_HOST_BLAS=MKL"]
-        elif self.spec['blas'].name == 'netlib-lapack':
-            args += ["-DSPLA_HOST_BLAS=GENERIC"]
-        elif self.spec['blas'].name == 'cray-libsci':
-            args += ["-DSPLA_HOST_BLAS=CRAY_LIBSCI"]
-
-        return args
+        return [
+            cmake_cache_option('SPLA_OMP', '+openmp' in self.spec),
+            cmake_cache_option('SPLA_FORTRAN', '+fortran' in self.spec),
+            cmake_cache_option('SPLA_STATIC', '+static' in self.spec),
+            cmake_cache_string('SPLA_GPU_BACKEND', gpu_backend),
+            cmake_cache_string('SPLA_HOST_BLAS',
+                               _blas2cmake(self.spec['blas'].name)),
+        ]


### PR DESCRIPTION
As described in #13944 there are cases where CMake is unable to detect the MPI implementation or picks the wrong one (system-provided one), leading to inconsistencies. One way would be to manually set MPI_*_COMPILER args for CMake, but the CachedCMakePackage already does that (plus some CUDA-related things).

To discuss: the HIP-related CMake things could be moved to CachedCMakePackage as well. Has it converged enough to do it?
