### PR TITLE
py-wurlitzer: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-wurlitzer/package.py
+++ b/var/spack/repos/builtin/packages/py-wurlitzer/package.py
@@ -10,10 +10,10 @@ class PyWurlitzer(PythonPackage):
     """Capture C-level stdout/stderr pipes in Python via os.dup2."""
 
     homepage = "https://github.com/minrk/wurlitzer"
-    url      = "https://github.com/minrk/wurlitzer/archive/refs/tags/3.0.2.tar.gz"
+    url      = "https://files.pythonhosted.org/packages/e8/2c/3e57755689fcf75aa25f6afba064d3891e9864ef43a24745575c86b12ad4/wurlitzer-3.0.2.tar.gz"
     maintainers = ['sethrj']
 
-    version('3.0.2', sha256='c09508dbf8e1e53f8fcc703790887f446d8c08c705a8f14957ccfdb0dc17e8a0')
+    version('3.0.2', sha256='36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf')
 
     depends_on('python+ctypes@3.5:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-wurlitzer/package.py
+++ b/var/spack/repos/builtin/packages/py-wurlitzer/package.py
@@ -9,8 +9,8 @@ from spack import *
 class PyWurlitzer(PythonPackage):
     """Capture C-level stdout/stderr pipes in Python via os.dup2."""
 
-    homepage = "https://github.com/minrk/wurlitzer"
-    url      = "https://files.pythonhosted.org/packages/e8/2c/3e57755689fcf75aa25f6afba064d3891e9864ef43a24745575c86b12ad4/wurlitzer-3.0.2.tar.gz"
+    pypi = 'wurlitzer/wurlitzer-3.0.2.tar.gz'
+
     maintainers = ['sethrj']
 
     version('3.0.2', sha256='36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf')

--- a/var/spack/repos/builtin/packages/py-wurlitzer/package.py
+++ b/var/spack/repos/builtin/packages/py-wurlitzer/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyWurlitzer(PythonPackage):
+    """Capture C-level stdout/stderr pipes in Python via os.dup2."""
+
+    homepage = "https://github.com/minrk/wurlitzer"
+    url      = "https://github.com/minrk/wurlitzer/archive/refs/tags/3.0.2.tar.gz"
+    maintainers = ['sethrj']
+
+    version('3.0.2', sha256='c09508dbf8e1e53f8fcc703790887f446d8c08c705a8f14957ccfdb0dc17e8a0')
+
+    depends_on('python+ctypes@3.5:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    # In some circumstances (unclear exactly what) Wurlitzer is unable to get
+    # stdout/stderr pointers from ctypes, so it falls back to trying to use
+    # cffi. If you encounter this, please add the dependency below.
+    # depends_on('py-cffi', type='run', when='...????')


### PR DESCRIPTION
This is a new python package that's very useful for jupyter-lab/notebook when running wrapped C++ code. It redirects the C/C++ streams into the python application so that they can be rendered on-screen rather than in the background terminal that launched the app.