### PR TITLE
Generalize env var PYTHON to avoid version conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/py-pythonsollya/package.py
+++ b/var/spack/repos/builtin/packages/py-pythonsollya/package.py
@@ -27,6 +27,6 @@ class PyPythonsollya(PythonPackage):
     @run_before('build')
     def patch(self):
         filter_file('PYTHON ?= python2',
-                    'PYTHON ?= python',
+                    'PYTHON ?= ' + self.spec['python'].command.path,
                     'GNUmakefile',
                     string=True)

--- a/var/spack/repos/builtin/packages/py-pythonsollya/package.py
+++ b/var/spack/repos/builtin/packages/py-pythonsollya/package.py
@@ -23,3 +23,10 @@ class PyPythonsollya(PythonPackage):
     depends_on('sollya', type=('build', 'link'))
     depends_on('py-bigfloat', type=('build', 'run'))
     depends_on('mpfi', type=('build', 'link'))
+
+    @run_before('build')
+    def patch(self):
+        filter_file('PYTHON ?= python2',
+                    'PYTHON ?= python',
+                    'GNUmakefile',
+                    string=True)


### PR DESCRIPTION
If PYTHON environment variable is not defined, it will be set to python2, which can cause this problem:
```
==> py-pythonsollya: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 1:
    '/mnt/build/hahansen/Spack/spack/opt/spack/linux-centos7-haswell/gcc-4.8.5/python-3.8.12-jbmgbgrgk4xvq3uzxxo5gcveaydqcbam/bin/python3.8' '-s' 'setup.py' '--no-user-cfg' 'build'

1 error found in build log:
     3    ==> [2021-11-10-17:53:45.964987] '/mnt/build/hahansen/Spack/spack/opt
          /spack/linux-centos7-haswell/gcc-4.8.5/python-3.8.12-jbmgbgrgk4xvq3uz
          xxo5gcveaydqcbam/bin/python3.8' '-s' 'setup.py' '--no-user-cfg' 'buil
          d'
     4    running build
     5    running build_ext
     6    PATH="/usr/local:/mnt/build/hahansen/Spack/spack/opt/spack/linux-cent
          os7-haswell/gcc-4.8.5/sollya-7.0-e2if323wtc7qm6pc6ksw6myu5xspfkom/bin
          :/mnt/build/hahansen/Spack/spack/opt/spack/linux-centos7-haswell/gcc-
          4.8.5/py-cython-0.29.24-ajh5rsu37c74ovpxy2fgdxzzu5gy3to3/bin:/mnt/bui
          ld/hahansen/Spack/spack/opt/spack/linux-centos7-haswell/gcc-4.8.5/pyt
          hon-3.8.12-jbmgbgrgk4xvq3uzxxo5gcveaydqcbam/bin:/mnt/build/hahansen/S
          pack/spack/opt/spack/linux-centos7-haswell/gcc-4.8.5/python-3.8.12-jb
          mgbgrgk4xvq3uzxxo5gcveaydqcbam/bin:/mnt/build/hahansen/Spack/spack/li
          b/spack/env/gcc:/mnt/build/hahansen/Spack/spack/lib/spack/env/case-in
          sensitive:/mnt/build/hahansen/Spack/spack/lib/spack/env:/cvmfs/sw.hsf
          .org/spackages/linux-centos7-x86_64/gcc-8.3.0/python-3.7.8-frt23dg2wx
          sliomspjt5yyg6attakzgk/bin:/build/hahansen/Spack/spack/bin:/usr/sue/b
          in:/cvmfs/sft.cern.ch/lcg/contrib/git/latest/x86_64-centos7/bin:/usr/
          lib64/ccache:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/p
          uppetlabs/bin:/afs/cern.ch/user/h/hahansen/.local/bin:/afs/cern.ch/us
          er/h/hahansen/bin" python2 gen_func.py > sollya_func.pxi
     7    ImportError: No module named site
     8    ImportError: No module named site
  >> 9    make: *** [sollya_func.pxi] Error 1
     10   Traceback (most recent call last):
     11     File "setup.py", line 50, in <module>
     12       setuptools.setup(
     13     File "/mnt/build/hahansen/Spack/spack/opt/spack/linux-centos7-haswe
          ll/gcc-4.8.5/py-setuptools-58.2.0-j6lcpgqcecgtuxxebz5uchdnjros2a7p/li
          b/python3.8/site-packages/setuptools/__init__.py", line 153, in setup
     14       return distutils.core.setup(**attrs)
     15     File "/mnt/build/hahansen/Spack/spack/opt/spack/linux-centos7-haswe
          ll/gcc-4.8.5/python-3.8.12-jbmgbgrgk4xvq3uzxxo5gcveaydqcbam/lib/pytho
          n3.8/distutils/core.py", line 148, in setup
```
