### PR TITLE
goshimmer: new package

### DIFF
--- a/var/spack/repos/builtin/packages/goshimmer/package.py
+++ b/var/spack/repos/builtin/packages/goshimmer/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Goshimmer(Package):
+    """GoShimmer is a prototype node for exploring the implementation of IOTA 2.0"""
+    homepage = 'https://github.com/iotaledger/goshimmer'
+    url      = 'https://github.com/iotaledger/goshimmer/archive/refs/tags/v0.8.0.tar.gz'
+
+    maintainers = ['bernhardkaindl']
+
+    version('0.8.0', 'ec515deebf0dd35ff76cd98addae9cfcbf4758ab9eb72eb0f6ff4654f2658980')
+
+    depends_on('go@1.16:', type='build')
+    depends_on('snappy')
+    depends_on('rocksdb')
+    depends_on('zstd')
+    depends_on('zlib')
+    depends_on('lz4')
+
+    @property
+    def snapbin(self):
+        return join_path(self.prefix.bin, 'snapshot.bin')
+
+    def patch(self):
+        for file in ['tools/genesis-snapshot/main', 'plugins/messagelayer/parameters']:
+            filter_file('./snapshot.bin', self.snapbin, file + '.go')
+
+    def install(self, spec, prefix):
+        which('go')('build', '-modcacherw', '-tags', 'rocksdb,netgo')
+        mkdir(prefix.bin)
+        install('config.default.json', prefix.bin)
+        install('goshimmer',           prefix.bin)
+        which('wget')('-O', self.snapbin,
+                      'https://dbfiles-goshimmer.s3.eu-central-1.amazonaws.com/snapshots/nectar/snapshot-latest.bin')
+        remove_linked_tree(prefix.pkg)


### PR DESCRIPTION
GoShimmer is first and foremost a research prototype node for exploring the implementation of IOTA 2.0.

Status: Builds and starts up but not tested yet - to be followed up with future improvements determined by time and interest.

Further information on the software:
https://github.com/iotaledger/meta-iota/wiki/honeycombOS-Notes

Repo:
https://github.com/iotaledger/goshimmer