### PR TITLE
Trilinos: fix DEP_INCLUDE_DIRS definition

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -562,7 +562,7 @@ class Trilinos(CMakePackage, CudaPackage):
             depspec = spec[spack_name]
             libs = depspec.libs
             options.extend([
-                define(trilinos_name + '_INCLUDE_DIRS', depspec.headers.directories[0]),
+                define(trilinos_name + '_INCLUDE_DIRS', depspec.headers.directories),
                 define(trilinos_name + '_ROOT', depspec.prefix),
                 define(trilinos_name + '_LIBRARY_NAMES', libs.names),
                 define(trilinos_name + '_LIBRARY_DIRS', libs.directories),

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -631,9 +631,8 @@ class Trilinos(CMakePackage, CudaPackage):
                 ]),
                 define('ParMETIS_LIBRARY_NAMES', ['parmetis', 'metis']),
                 define('TPL_ParMETIS_INCLUDE_DIRS',
-                    spec['parmetis'].headers.directories +
-                    spec['metis'].headers.directories
-                ),
+                       spec['parmetis'].headers.directories +
+                       spec['metis'].headers.directories),
             ])
 
         if spec.satisfies('^superlu-dist@4.0:'):

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -562,7 +562,7 @@ class Trilinos(CMakePackage, CudaPackage):
             depspec = spec[spack_name]
             libs = depspec.libs
             options.extend([
-                define(trilinos_name + '_INCLUDE_DIRS', depspec.headers.directories),
+                define(trilinos_name + '_INCLUDE_DIRS', depspec.headers.directories[0]),
                 define(trilinos_name + '_ROOT', depspec.prefix),
                 define(trilinos_name + '_LIBRARY_NAMES', libs.names),
                 define(trilinos_name + '_LIBRARY_DIRS', libs.directories),
@@ -631,8 +631,8 @@ class Trilinos(CMakePackage, CudaPackage):
                 ]),
                 define('ParMETIS_LIBRARY_NAMES', ['parmetis', 'metis']),
                 define('TPL_ParMETIS_INCLUDE_DIRS', [
-                    spec['parmetis'].headers.directories,
-                    spec['metis'].headers.directories
+                    spec['parmetis'].headers.directories[0],
+                    spec['metis'].headers.directories[0]
                 ]),
             ])
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -562,7 +562,7 @@ class Trilinos(CMakePackage, CudaPackage):
             depspec = spec[spack_name]
             libs = depspec.libs
             options.extend([
-                define(trilinos_name + '_INCLUDE_DIRS', depspec.prefix.include),
+                define(trilinos_name + '_INCLUDE_DIRS', depspec.headers.directories),
                 define(trilinos_name + '_ROOT', depspec.prefix),
                 define(trilinos_name + '_LIBRARY_NAMES', libs.names),
                 define(trilinos_name + '_LIBRARY_DIRS', libs.directories),
@@ -631,8 +631,8 @@ class Trilinos(CMakePackage, CudaPackage):
                 ]),
                 define('ParMETIS_LIBRARY_NAMES', ['parmetis', 'metis']),
                 define('TPL_ParMETIS_INCLUDE_DIRS', [
-                    spec['parmetis'].prefix.include,
-                    spec['metis'].prefix.include
+                    spec['parmetis'].headers.directories,
+                    spec['metis'].headers.directories
                 ]),
             ])
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -630,10 +630,10 @@ class Trilinos(CMakePackage, CudaPackage):
                     spec['parmetis'].prefix.lib, spec['metis'].prefix.lib
                 ]),
                 define('ParMETIS_LIBRARY_NAMES', ['parmetis', 'metis']),
-                define('TPL_ParMETIS_INCLUDE_DIRS', [
-                    spec['parmetis'].headers.directories[0],
-                    spec['metis'].headers.directories[0]
-                ]),
+                define('TPL_ParMETIS_INCLUDE_DIRS',
+                    spec['parmetis'].headers.directories +
+                    spec['metis'].headers.directories
+                ),
             ])
 
         if spec.satisfies('^superlu-dist@4.0:'):


### PR DESCRIPTION
It is too simplistic to assume the path to a dependency's include directory as being `prefix.include`.  For example, this path doesn't even exist for `intel-mkl` (unfortunately).  The end result is that Trilinos will build but a bogus path will be injected into its installed CMake files so that future packages which use its artifacts die a horrible death.  This PR fixes the `*_INCLUDE_DIRS` definition to point to where each dependency has advertised its headers to reside.