### PR TITLE
py-sip: add 5.5.0 and 6.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-sip/package.py
+++ b/var/spack/repos/builtin/packages/py-sip/package.py
@@ -8,16 +8,14 @@ import os
 from spack import *
 
 
-class PySip(Package):
-    """SIP is a tool that makes it very easy to create Python bindings for C
-       and C++ libraries."""
+class PySip(PythonPackage):
+    """A Python bindings generator for C/C++ libraries."""
 
-    homepage = "https://www.riverbankcomputing.com/software/sip/intro"
-    url      = "https://www.riverbankcomputing.com/hg/sip/archive/4.19.21.tar.gz"
-    list_url = "https://www.riverbankcomputing.com/hg/sip/archive"
-    hg       = "https://www.riverbankcomputing.com/hg/sip"
+    homepage = "https://www.riverbankcomputing.com/software/sip"
+    pypi = "sip/sip-6.4.0.tar.gz"
 
-    version('develop', hg=hg)  # wasn't actually able to clone this
+    version('6.4.0', sha256='42ec368520b8da4a0987218510b1b520b4981e4405086c1be384733affc2bcb0')
+    version('5.5.0', sha256='5d024c419b30fea8a6de8c71a560c7ab0bc3c221fbfb14d55a5b865bd58eaac5')
     version('4.19.21', sha256='3bfd58e875a87471c00e008f25a01d8312885aa01efc4f688e5cac861c8676e4')
     version('4.19.20', sha256='475f85277a6601c406ade508b6c935b9f2a170c16fd3ae9dd4cdee7a4f7f340d')
     version('4.19.19', sha256='348cd6229b095a3090e851555814f5147bffcb601cec891f1038eb6b38c9d856')
@@ -25,47 +23,59 @@ class PySip(Package):
     version('4.19.15', sha256='02bff1ac89253e12cdf1406ad39f841d0e264b0d96a7de13dfe9e29740df2053')
     version('4.19.13', sha256='92193fcf990503bf29f03e290efc4ee1812d556efc18acf5c8b88c090177a630')
 
-    variant('module', default='sip', description='Name of private SIP module',
+    variant('module', default='sip', when='@:4', description='Name of private SIP module',
             values=str, multi=False)
 
-    extends('python')
+    depends_on('python@3.6:', when='@6:', type=('build', 'run'))
+    depends_on('python@3.5.1:', when='@5:', type=('build', 'run'))
+    depends_on('py-packaging', when='@5:', type='build')
+    depends_on('py-setuptools@30.3:', when='@5:', type='build')
+    depends_on('py-toml', when='@5:', type='build')
+    depends_on('flex', when='@:4', type='build')
+    depends_on('bison', when='@:4', type='build')
 
-    depends_on('flex', type='build')
-    depends_on('bison', type='build')
-
-    # https://www.riverbankcomputing.com/static/Docs/sip/installation.html
+    # needed for @:4
     phases = ['configure', 'build', 'install']
+
+    def url_for_version(self, version):
+        if version < Version('5.0.0'):
+            return "https://www.riverbankcomputing.com/hg/sip/archive/{0}.tar.gz".format(version.dotted)
+        return super(PySip, self).url_for_version(version)
 
     @run_before('configure')
     def prepare(self):
-        if not os.path.exists('configure.py'):
+        if self.spec.satisfies('@:4') and not os.path.exists('configure.py'):
             python('build.py', 'prepare')
 
     def configure(self, spec, prefix):
-        args = [
-            '--sip-module={0}'.format(spec.variants['module'].value),
-            '--bindir={0}'.format(prefix.bin),
-            '--destdir={0}'.format(site_packages_dir),
-            '--incdir={0}'.format(python_include_dir),
-            '--sipdir={0}'.format(prefix.share.sip),
-            '--stubsdir={0}'.format(site_packages_dir),
-        ]
+        if self.spec.satisfies('@:4'):
+            args = [
+                '--sip-module={0}'.format(spec.variants['module'].value),
+                '--bindir={0}'.format(prefix.bin),
+                '--destdir={0}'.format(site_packages_dir),
+                '--incdir={0}'.format(python_include_dir),
+                '--sipdir={0}'.format(prefix.share.sip),
+                '--stubsdir={0}'.format(site_packages_dir),
+            ]
 
-        python('configure.py', *args)
+            python('configure.py', *args)
 
+    @when('@:4')
     def build(self, spec, prefix):
         make()
 
+    @when('@:4')
     def install(self, spec, prefix):
         make('install')
 
     @run_after('install')
     def extend_path_setup(self):
-        # See github issue #14121 and PR #15297
-        module = self.spec.variants['module'].value
-        if module != 'sip':
-            module = module.split('.')[0]
-            with working_dir(site_packages_dir):
-                with open(os.path.join(module, '__init__.py'), 'w') as f:
-                    f.write('from pkgutil import extend_path\n')
-                    f.write('__path__ = extend_path(__path__, __name__)\n')
+        if self.spec.satisfies('@:4'):
+            # See github issue #14121 and PR #15297
+            module = self.spec.variants['module'].value
+            if module != 'sip':
+                module = module.split('.')[0]
+                with working_dir(site_packages_dir):
+                    with open(os.path.join(module, '__init__.py'), 'w') as f:
+                        f.write('from pkgutil import extend_path\n')
+                        f.write('__path__ = extend_path(__path__, __name__)\n')


### PR DESCRIPTION
https://www.riverbankcomputing.com/hg/sip/file/6.4.0

Newer versions are available on pypi and the build system was changed to use setuptools. In addition the module variant was removed. I think the modules where outsourced into individual packages, e.g. PyQt5.sip into [pyqt5-sip](https://pypi.org/project/PyQt5-sip/) but I made sure that the old packages incl. modules still work.

Tested installation (including `--test=root`) for versions 4.19.21, 5.5.0, 6.4.0
Also tested that `py-pyqt5` which depends on `py-sip module=PyQt5.sip` still builds correctly (concretizes to use `py-sip@4.19.21` as before)