### PR TITLE
py-pymol: Remove invalid constraint, add new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-pymol/package.py
+++ b/var/spack/repos/builtin/packages/py-pymol/package.py
@@ -13,8 +13,9 @@ class PyPymol(PythonPackage):
        movies. Open Source PyMOL is free to everyone!"""
 
     homepage = "https://pymol.org"
-    url      = "https://github.com/schrodinger/pymol-open-source/archive/v2.4.0.tar.gz"
+    url      = "https://github.com/schrodinger/pymol-open-source/archive/v2.5.0.tar.gz"
 
+    version('2.5.0', sha256='aa828bf5719bd9a14510118a93182a6e0cadc03a574ba1e327e1e9780a0e80b3')
     version('2.4.0', sha256='5ede4ce2e8f53713c5ee64f5905b2d29bf01e4391da7e536ce8909d6b9116581')
     version('2.3.0', sha256='62aa21fafd1db805c876f89466e47513809f8198395e1f00a5f5cc40d6f40ed0')
 
@@ -28,7 +29,7 @@ class PyPymol(PythonPackage):
     depends_on('py-pmw', type=('build', 'run'))
     depends_on('libmmtf-cpp', type=('build', 'run', 'link'))
     depends_on('msgpack-c', type=('build', 'run'))
-    depends_on('libpng@1.5.13', type=('build', 'run'))
+    depends_on('libpng', type=('build', 'run'))
 
     def setup_build_environment(self, env):
         include = []


### PR DESCRIPTION
**Short story:**

PyMol package specification had impossible constraint. It was working with old concretizer, but it doesn't work with new one.

**Long story**:

`spack install py-pymol` was working in Spack `1.16.3`, but it stopped in `1.17.0`. The commit that breaks it (`git bisect`) is the one that changes default concretizer. `1.17.0` works if the old concretizer is selected.

Constraint `libpng@1.5.13` is invalid, because there is no such version of `libpng` in Spack packages. 

I checked few versions of Spack back and there was no such version in the past either.

All three listed versions of PyMol (`2.5.0`, `2.4.0` and `2.3.0`) seems to be fine without this constraint so I assume it is not needed for it. Also https://pymolwiki.org/index.php/Linux_Install doesn't specify any particular version of `libpng`.

# Test

```bash
spack install py-pymol py-pymol@2.4.0 py-pymol@2.3.0
```

```bash
spack load py-pymol
pymol
```

```bash
spack load py-pymol@2.4.0
pymol
```

```bash
spack load py-pymol@2.3.0
pymol
```