### PR TITLE
Bugfix for environment containing empty library paths.

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -715,8 +715,11 @@ def get_rpaths(pkg):
     # Second module is our compiler mod name. We use that to get rpaths from
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:
-        rpaths.append(path_from_modules([pkg.compiler.modules[1]]))
-    rpaths = filter(None, rpaths)
+        path = path_from_modules([pkg.compiler.modules[1]])
+        if path is None:
+            raise ValueError('No path found for compiler module {0}'.format(pkg.compiler.modules[1]))
+        rpaths.append(path)
+
     return list(dedupe(filter_system_paths(rpaths)))
 
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -716,6 +716,7 @@ def get_rpaths(pkg):
     # module show output.
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:
         rpaths.append(path_from_modules([pkg.compiler.modules[1]]))
+    rpaths = filter(None, rpaths)
     return list(dedupe(filter_system_paths(rpaths)))
 
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -717,7 +717,9 @@ def get_rpaths(pkg):
     if pkg.compiler.modules and len(pkg.compiler.modules) > 1:
         path = path_from_modules([pkg.compiler.modules[1]])
         if path is None:
-            raise ValueError('No path found for compiler module {0}'.format(pkg.compiler.modules[1]))
+            raise ValueError(
+                "No path found for compiler module {0}".format(pkg.compiler.modules[1])
+            )
         rpaths.append(path)
 
     return list(dedupe(filter_system_paths(rpaths)))


### PR DESCRIPTION
This fixes cryptic error messages generated by `get_rpaths` trying to process lists containing None or empty string values.

I was seeing messages like:
```
$ spack install -v libsigsegv@2.13%clang@12.0.0
==> Installing libsigsegv-2.13-oowjyvf2ojbr4itgodtjxqi5j4apb6wb
==> No binary for libsigsegv-2.13-oowjyvf2ojbr4itgodtjxqi5j4apb6wb found: installing from source
==> Error: TypeError: expected str, bytes or os.PathLike object, not NoneType

spack/lib/spack/spack/build_environment.py:1044, in _setup_pkg_and_run:
       1041        tb_string = traceback.format_exc()
       1042
       1043        # build up some context from the offending package so we can
  >>   1044        # show that, too.
       1045        package_context = get_package_context(tb)
       1046
       1047        logfile = None
```

Modifying line 1041 to throw an exception lead to a better error message:
```
$ spack install -v libsigsegv@2.13%clang@12.0.0
==> Installing libsigsegv-2.13-oowjyvf2ojbr4itgodtjxqi5j4apb6wb
==> No binary for libsigsegv-2.13-oowjyvf2ojbr4itgodtjxqi5j4apb6wb found: installing from source
Process Process-1:
Traceback (most recent call last):
  File "spack/lib/spack/spack/build_environment.py", line 1026, in _setup_pkg_and_run
    kwargs['env_modifications'] = setup_package(
  File "spack/lib/spack/spack/build_environment.py", line 766, in setup_package
    set_module_variables_for_package(pkg)
  File "spack/lib/spack/spack/build_environment.py", line 579, in set_module_variables_for_package
    _set_variables_for_single_module(pkg, mod)
  File "spack/lib/spack/spack/build_environment.py", line 522, in _set_variables_for_single_module
    m.std_cmake_args = spack.build_systems.cmake.CMakePackage._std_args(pkg)
  File "spack/lib/spack/spack/build_systems/cmake.py", line 187, in _std_args
    spack.build_environment.get_rpaths(pkg)),
  File "spack/lib/spack/spack/build_environment.py", line 691, in get_rpaths
    return list(dedupe(filter_system_paths(rpaths)))
  File "spack/lib/spack/spack/util/environment.py", line 67, in filter_system_paths
    return [p for p in paths if not is_system_path(p)]
  File "spack/lib/spack/spack/util/environment.py", line 67, in <listcomp>
    return [p for p in paths if not is_system_path(p)]
  File "spack/lib/spack/spack/util/environment.py", line 62, in is_system_path
    return os.path.normpath(path) in system_dirs
  File "/opt/cray/pe/python/3.8.5.1/lib/python3.8/posixpath.py", line 336, in normpath
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not NoneType

During handling of the above exception, another exception occurred: ...
```
This fix removes None paths before filtering out system paths.