### PR TITLE
ncurses: install correct separate ncurses/ncursesw headers

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -101,7 +101,8 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
             '--enable-overwrite',
             '--without-ada',
             '--enable-pc-files',
-            '--with-pkg-config-libdir={0}/lib/pkgconfig'.format(self.prefix)
+            '--with-pkg-config-libdir={0}/lib/pkgconfig'.format(self.prefix),
+            '--disable-overwrite'
         ]
 
         nwide_opts = ['--disable-widec',
@@ -148,14 +149,11 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         with working_dir('build_ncursesw'):
             make('install')
 
-        # fix for packages like hstr that use "#include <ncurses/ncurses.h>"
-        headers = glob.glob(os.path.join(prefix.include, '*'))
-        for p_dir in ['ncurses', 'ncursesw']:
-            path = os.path.join(prefix.include, p_dir)
-            if not os.path.exists(path):
-                os.makedirs(path)
-            for header in headers:
-                install(header, path)
+        # fix for packages that use "#include <ncurses.h>" (use wide by default)
+        headers = glob.glob(os.path.join(prefix.include, 'ncursesw', '*.h'))
+        for header in headers:
+            h = os.path.basename(header)
+            os.symlink(os.path.join('ncursesw', h), os.path.join(prefix.include, h))
 
     @property
     def libs(self):


### PR DESCRIPTION
See #27369 for primary motivation, though this is a general problem with the ncurses install.  The non-wide headers are not being installed anywhere.  Normally they would be available as `include/ncurses.h` or `include/ncurses/ncurses.h` but both of this are wide (ncursesw) headers.  As such, they do not match the installed `libncurses.so` library so building a non-wide ncurses application results in broken applications (especially when dealing with colors and background colors, where relevant datatypes have changed).

This installs the non-wide headers into `include/ncurses`, and the wide headers into `include/ncursesw`.  This leaves the problem of what to put in `include`.  Some distributions put nothing, so you're forced to choose, which seems like the safest option, except that as a result many things will fall back to the system `/usr/include/ncurses.h`, which is bad.  Most distributions put non-wide headers in `include` and wide in `include/ncursesw`, so I've chosen to link the non-wide ncurses headers into top-level include to be more broadly consistent with standards.  Some distributions put wide headers in include as well, and there's an argument for leaving it this way to minimize the change (so non-wide are only in include/ncurses).  I'm open to this as well if people prefer.

As a broader comment, I think it might make more sense and simplify things to separate ncurses and ncursesw with a variant so dependents could choose more clearly which they wanted, but this may make concretization problematic in spack where both get pulled in.

I have tested this with python and a few other ncurses apps but by no means everything.