### PR TITLE
python: use ncursesw for curses module

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -361,6 +361,13 @@ class Python(AutotoolsPackage):
                 r'\1 None and \3'
             )
 
+        if '^ncurses' in self.spec:
+            with open('Modules/Setup', 'a') as sf:
+                # make sure the curses module uses ncursesw (#27369)
+                sf.write("*shared*\n"
+                         "_curses _cursesmodule.c -lncursesw\n"
+                         "_curses_panel _curses_panel.c -lpanel -lncursesw\n")
+
     def setup_build_environment(self, env):
         spec = self.spec
 
@@ -413,6 +420,11 @@ class Python(AutotoolsPackage):
             # finds them using pkg-config.
             cppflags = ' '.join('-I' + spec[dep.name].prefix.include
                                 for dep in link_deps)
+
+            if '^ncurses' in spec:
+                # make sure we get ncursesw (first)
+                cppflags = '-I{0}/ncursesw '.format(spec['ncurses'].prefix.include) \
+                    + cppflags
 
             # Currently, the only way to get SpecBuildInterface wrappers of the
             # dependencies (which we need to get their 'libs') is to get them


### PR DESCRIPTION
See #27369 for motivation.  This forces python to use the ncursesw include files and library to build the curses packages.  This is to ensure that (1) it uses a consistent, matching set of headers and libraries and (2) it uses specifically wide ncurses, as the curses python module does not behave well with non-wide.  Otherwise, python's `setup.py` by default uses whichever curses library comes first in the `ldd` linkage of readline, and explicitly adds `/usr/include/ncursesw` to the include path if it finds ncursesw.