### PR TITLE
Fix overloaded argparse keys

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -412,8 +412,6 @@ def env_status(args):
 def env_loads_setup_parser(subparser):
     """list modules for an installed environment '(see spack module loads)'"""
     subparser.add_argument(
-        'env', nargs='?', help='name of env to generate loads file for')
-    subparser.add_argument(
         '-n', '--module-set-name', default='default',
         help='module set for which to generate load operations')
     subparser.add_argument(
@@ -448,19 +446,19 @@ def env_loads(args):
 def env_update_setup_parser(subparser):
     """update environments to the latest format"""
     subparser.add_argument(
-        metavar='env', dest='env',
+        metavar='env', dest='update_env',
         help='name or directory of the environment to activate'
     )
     spack.cmd.common.arguments.add_common_arguments(subparser, ['yes_to_all'])
 
 
 def env_update(args):
-    manifest_file = ev.manifest_file(args.env)
+    manifest_file = ev.manifest_file(args.update_env)
     backup_file = manifest_file + ".bkp"
     needs_update = not ev.is_latest_format(manifest_file)
 
     if not needs_update:
-        tty.msg('No update needed for the environment "{0}"'.format(args.env))
+        tty.msg('No update needed for the environment "{0}"'.format(args.update_env))
         return
 
     proceed = True
@@ -470,7 +468,7 @@ def env_update(args):
                'Spack that are older than this version may not be able to '
                'read it. Spack stores backups of the updated environment '
                'which can be retrieved with "spack env revert"')
-        tty.msg(msg.format(args.env))
+        tty.msg(msg.format(args.update_env))
         proceed = tty.get_yes_or_no('Do you want to proceed?', default=False)
 
     if not proceed:
@@ -478,20 +476,20 @@ def env_update(args):
 
     ev.update_yaml(manifest_file, backup_file=backup_file)
     msg = 'Environment "{0}" has been updated [backup={1}]'
-    tty.msg(msg.format(args.env, backup_file))
+    tty.msg(msg.format(args.update_env, backup_file))
 
 
 def env_revert_setup_parser(subparser):
     """restore environments to their state before update"""
     subparser.add_argument(
-        metavar='env', dest='env',
+        metavar='env', dest='revert_env',
         help='name or directory of the environment to activate'
     )
     spack.cmd.common.arguments.add_common_arguments(subparser, ['yes_to_all'])
 
 
 def env_revert(args):
-    manifest_file = ev.manifest_file(args.env)
+    manifest_file = ev.manifest_file(args.revert_env)
     backup_file = manifest_file + ".bkp"
 
     # Check that both the spack.yaml and the backup exist, the inform user

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -38,7 +38,7 @@ def update_kwargs_from_args(args, kwargs):
         'keep_stage': args.keep_stage,
         'restage': not args.dont_restage,
         'install_source': args.install_source,
-        'verbose': args.verbose,
+        'verbose': args.verbose or args.install_verbose,
         'fake': args.fake,
         'dirty': args.dirty,
         'use_cache': args.use_cache,
@@ -130,7 +130,7 @@ remote spec matches that of the local spec""")
         help="install source files in prefix")
     arguments.add_common_arguments(subparser, ['no_checksum', 'deprecated'])
     subparser.add_argument(
-        '-v', '--verbose', action='store_true',
+        '-v', '--verbose', action='store_true', dest='install_verbose',
         help="display verbose build output while installing")
     subparser.add_argument(
         '--fake', action='store_true',
@@ -285,6 +285,8 @@ def install_specs(cli_args, kwargs, specs):
 
 
 def install(parser, args, **kwargs):
+    # TODO: unify args.verbose?
+    tty.set_verbose(args.verbose or args.install_verbose)
 
     if args.help_cdash:
         parser = argparse.ArgumentParser(

--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -23,7 +23,7 @@ level = "long"
 
 def setup_parser(subparser):
     subparser.add_argument(
-        '-V', '--version', action='store_true',
+        '-V', '--version', action='store_true', dest='python_version',
         help='print the Python version number and exit')
     subparser.add_argument(
         '-c', dest='python_command', help='command to execute')
@@ -42,7 +42,7 @@ def setup_parser(subparser):
 
 
 def python(parser, args, unknown_args):
-    if args.version:
+    if args.python_version:
         print('Python', platform.python_version())
         return
 

--- a/lib/spack/spack/reporters/cdash.py
+++ b/lib/spack/spack/reporters/cdash.py
@@ -62,7 +62,6 @@ class CDash(Reporter):
 
     def __init__(self, args):
         Reporter.__init__(self, args)
-        tty.set_verbose(args.verbose)
         self.success = True
         self.template_dir = os.path.join('reports', 'cdash')
         self.cdash_upload_url = args.cdash_upload_url

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -868,7 +868,7 @@ def test_env_loads(install_mockery, mock_fetch):
         install('--fake')
 
     with ev.read('test'):
-        env('loads', 'test')
+        env('loads')
 
     e = ev.read('test')
 

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -969,12 +969,7 @@ _spack_env_st() {
 }
 
 _spack_env_loads() {
-    if $list_options
-    then
-        SPACK_COMPREPLY="-h --help -n --module-set-name -m --module-type --input-only -p --prefix -x --exclude -r --dependencies"
-    else
-        _environments
-    fi
+    SPACK_COMPREPLY="-h --help -n --module-set-name -m --module-type --input-only -p --prefix -x --exclude -r --dependencies"
 }
 
 _spack_env_view() {


### PR DESCRIPTION
- Fix overloaded env dest in argparse
- Fix tests

Should fix the tests on python 3.9.x.

It's a bug on our side, but I guess we relied on this bug in python: https://github.com/python/cpython/commit/a18d52269ab6071a605d6c72f6af585a4c533ca4

Note that this PR removes the unused argument in `spack env loads [env]` since that uses the active env only