### PR TITLE
perl-forks: handle non-threaded perl

### DIFF
--- a/var/spack/repos/builtin/packages/perl-forks/package.py
+++ b/var/spack/repos/builtin/packages/perl-forks/package.py
@@ -19,3 +19,7 @@ class PerlForks(PerlPackage):
     depends_on('perl-devel-symdump', type=('build', 'run'))
     depends_on('perl-list-moreutils', type=('build', 'run'))
     depends_on('perl-sys-sigaction', type=('build', 'run'))
+
+    def setup_build_environment(self, env):
+        if 'perl~threads' in self.spec:
+            env.set('FORKS_SIMULATE_USEITHREADS', '1')


### PR DESCRIPTION
If the perl that perl-forks is built against is non-threaded the build
system will drop into interactive mode to ask about simulating ithreads.
This causes the build to hang. Set FORKS_SIMULATE_USEITHREADS to avoid
going into interactive mode.