### PR TITLE
Update spp version

### DIFF
--- a/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
+++ b/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
@@ -14,9 +14,9 @@ class RPhantompeakqualtools(RPackage):
 
     homepage = "https://github.com/kundajelab/phantompeakqualtools"
     url      = "https://github.com/hms-dbmi/spp/archive/refs/tags/1.15.2.tar.gz"
-    
+
     version('1.15', sha256='172516b0f1f2a8132f22ab6fbfe41fb5943d675c2be02c733fcd5aa9651c6d22')
-    
+ 
     depends_on('boost@1.41.0:')
     depends_on('r-catools', type=('build', 'run'))
     depends_on('r-snow', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
+++ b/var/spack/repos/builtin/packages/r-phantompeakqualtools/package.py
@@ -13,18 +13,16 @@ class RPhantompeakqualtools(RPackage):
        package."""
 
     homepage = "https://github.com/kundajelab/phantompeakqualtools"
-    url      = "https://github.com/kundajelab/phantompeakqualtools/raw/master/spp_1.14.tar.gz"
-
-    version('1.14', sha256='d03be6163e82aed72298e54a92c181570f9975a395f57a69b21ac02b1001520b')
-
+    url      = "https://github.com/hms-dbmi/spp/archive/refs/tags/1.15.2.tar.gz"
+    
+    version('1.15', sha256='172516b0f1f2a8132f22ab6fbfe41fb5943d675c2be02c733fcd5aa9651c6d22')
+    
     depends_on('boost@1.41.0:')
     depends_on('r-catools', type=('build', 'run'))
     depends_on('r-snow', type=('build', 'run'))
     depends_on('r-snowfall', type=('build', 'run'))
     depends_on('r-bitops', type=('build', 'run'))
     depends_on('r-rsamtools', type=('build', 'run'))
-
-    conflicts('%gcc@6:')
 
     def setup_build_environment(self, env):
         env.set('BOOST_ROOT', self.spec['boost'].prefix)


### PR DESCRIPTION
The following changes resolve the compiler-related conflict, allowing to use gcc > 6.

### System info
* **Spack:** 0.17.0-62-8d021a2915
* **Python:** 3.8.10
* **Platform:** linux-ubuntu20.04-skylake
* **Concretizer:** clingo

```
$ spack compilers
==> Available compilers
-- gcc ubuntu20.04-x86_64 ---------------------------------------
gcc@9.3.0
```

See this: https://github.com/kundajelab/phantompeakqualtools/issues/17#issuecomment-614837676