### PR TITLE
mpich: fix macos problem with `-flat-namespace`

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -203,6 +203,9 @@ with '-Wl,-commons,use_dylibs' and without
     # see https://github.com/pmodels/mpich/pull/5031
     conflicts('%clang@:7', when='@3.4:3.4.1')
 
+    # see https://github.com/pmodels/mpich/issues/5530
+    conflicts('~two_level_namespace', when='platform=darwin')
+
     @run_after('configure')
     def patch_cce(self):
         # Configure misinterprets output from the cce compiler

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -83,7 +83,7 @@ spack package at this time.''',
 
     variant(
         'two_level_namespace',
-        default=False,
+        default=(sys.platform == 'darwin'),
         description='''Build shared libraries and programs
 built with the mpicc/mpifort/etc. compiler wrappers
 with '-Wl,-commons,use_dylibs' and without


### PR DESCRIPTION
After a long period working around the problem with `flat-namespace` flag in MPICH wrappers, I've seen the light thanks to @eschnett!

https://github.com/pmodels/mpich/issues/5530

As reported in the above issue `--enable-two-level-namespace` is the solution on macOS.