### PR TITLE
MEEP: update version and libctl

### DIFF
--- a/var/spack/repos/builtin/packages/libctl/package.py
+++ b/var/spack/repos/builtin/packages/libctl/package.py
@@ -11,10 +11,12 @@ class Libctl(AutotoolsPackage):
     control files for scientific simulations."""
 
     homepage = "http://ab-initio.mit.edu/wiki/index.php/Libctl"
-    url      = "http://ab-initio.mit.edu/libctl/libctl-3.2.2.tar.gz"
-    list_url = "http://ab-initio.mit.edu/libctl/old"
+    git      = "https://github.com/NanoComp/libctl.git"
+    url      = "https://github.com/NanoComp/libctl/releases/download/v4.2.0/libctl-4.2.0.tar.gz"
 
-    version('3.2.2', sha256='8abd8b58bc60e84e16d25b56f71020e0cb24d75b28bc5db86d50028197c7efbc')
+    version('4.2.0', sha256='0341ad6ea260ecda2efb3d4b679abb3d05ca6211792381979b036177a9291975')
+    version('3.2.2', sha256='8abd8b58bc60e84e16d25b56f71020e0cb24d75b28bc5db86d50028197c7efbc',
+            url='http://ab-initio.mit.edu/libctl/libctl-3.2.2.tar.gz')
 
     depends_on('guile')
 
@@ -27,4 +29,5 @@ class Libctl(AutotoolsPackage):
                 spec['guile'].prefix.bin, 'guile')),
             'GUILE_CONFIG={0}'.format(join_path(
                 spec['guile'].prefix.bin, 'guile-config')),
+            'LIBS=-lm',
         ]

--- a/var/spack/repos/builtin/packages/meep/package.py
+++ b/var/spack/repos/builtin/packages/meep/package.py
@@ -11,12 +11,18 @@ class Meep(AutotoolsPackage):
     software package developed at MIT to model electromagnetic systems."""
 
     homepage = "http://ab-initio.mit.edu/wiki/index.php/Meep"
-    url      = "http://ab-initio.mit.edu/meep/meep-1.3.tar.gz"
-    list_url = "http://ab-initio.mit.edu/meep/old"
+    git      = "https://github.com/NanoComp/meep.git"
+    url      = "https://github.com/NanoComp/meep/archive/refs/tags/v1.21.0.tar.gz"
 
-    version('1.3',   sha256='564c1ff1b413a3487cf81048a45deabfdac4243a1a37ce743f4fcf0c055fd438')
-    version('1.2.1', sha256='f1f0683e5688d231f7dd1863939677148fc27a6744c03510e030c85d6c518ea5')
-    version('1.1.1', sha256='7a97b5555da1f9ea2ec6eed5c45bd97bcd6ddbd54bdfc181f46c696dffc169f2')
+    version('master', branch='master')
+
+    version('1.21.0', sha256='71911cd2f38b15bdafe9a27ad111f706f24717894d5f9b6f9f19c6c10a0d5896')
+    version('1.3',   sha256='564c1ff1b413a3487cf81048a45deabfdac4243a1a37ce743f4fcf0c055fd438',
+            url='http://ab-initio.mit.edu/meep/meep-1.3.tar.gz')
+    version('1.2.1', sha256='f1f0683e5688d231f7dd1863939677148fc27a6744c03510e030c85d6c518ea5',
+            url='http://ab-initio.mit.edu/meep/meep-1.2.1.tar.gz')
+    version('1.1.1', sha256='7a97b5555da1f9ea2ec6eed5c45bd97bcd6ddbd54bdfc181f46c696dffc169f2',
+            url='http://ab-initio.mit.edu/meep/old/meep-1.1.1.tar.gz')
 
     variant('blas',    default=True, description='Enable BLAS support')
     variant('lapack',  default=True, description='Enable LAPACK support')
@@ -27,11 +33,17 @@ class Meep(AutotoolsPackage):
     variant('hdf5',    default=True, description='Enable HDF5 support')
     variant('gsl',     default=True, description='Enable GSL support')
 
+
+    depends_on('autoconf', type='build', when='@1.21.0')
+    depends_on('automake', type='build', when='@1.21.0')
+    depends_on('libtool', type='build', when='@1.21.0')
+
+
     depends_on('blas',        when='+blas')
     depends_on('lapack',      when='+lapack')
     depends_on('harminv',     when='+harminv')
     depends_on('guile',       when='+guile')
-    depends_on('libctl@3.2:', when='+libctl')
+    depends_on('libctl',      when='+libctl')
     depends_on('mpi',         when='+mpi')
     depends_on('hdf5~mpi',    when='+hdf5~mpi')
     depends_on('hdf5+mpi',    when='+hdf5+mpi')
@@ -71,6 +83,9 @@ class Meep(AutotoolsPackage):
             config_args.append('--with-hdf5')
         else:
             config_args.append('--without-hdf5')
+
+        if spec.satisfies('@1.21.0:'):
+            config_args.append('--enable-maintainer-mode')
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/meep/package.py
+++ b/var/spack/repos/builtin/packages/meep/package.py
@@ -33,11 +33,9 @@ class Meep(AutotoolsPackage):
     variant('hdf5',    default=True, description='Enable HDF5 support')
     variant('gsl',     default=True, description='Enable GSL support')
 
-
     depends_on('autoconf', type='build', when='@1.21.0')
     depends_on('automake', type='build', when='@1.21.0')
     depends_on('libtool', type='build', when='@1.21.0')
-
 
     depends_on('blas',        when='+blas')
     depends_on('lapack',      when='+lapack')


### PR DESCRIPTION
Issues building MEEP during the hackathon.
Bumped to latest version, which needed version bump for libctl.
Slight changes to config settings required to build correctly.