### PR TITLE
Umpire: Turn `ENABLE_DOCS` back off

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -192,6 +192,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
         entries.append(cmake_cache_option(
             "ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
         entries.append(cmake_cache_option("ENABLE_EXAMPLES", '+examples' in spec))
+        entries.append(cmake_cache_option("ENABLE_DOCS", False))
         entries.append(cmake_cache_option("BUILD_SHARED_LIBS", '+shared' in spec))
         entries.append(cmake_cache_option("ENABLE_TESTS", 'tests=none' not in spec))
 


### PR DESCRIPTION
This option got mistakenly turned back on at some point. Spack users should never build these due to them being online here https://umpire.readthedocs.io/en/develop/.

For reasons I don't feel like investigating, the docs are taking almost 20 minutes to build in rzansel, which is how I noticed this.