### PR TITLE
rocblas: add spack test support

### DIFF
--- a/var/spack/repos/builtin/packages/rocblas/0002-Fix-rocblas-clients-blas.patch
+++ b/var/spack/repos/builtin/packages/rocblas/0002-Fix-rocblas-clients-blas.patch
@@ -1,0 +1,24 @@
+diff -r -u a/clients/benchmarks/CMakeLists.txt b/clients/benchmarks/CMakeLists.txt
+--- a/clients/benchmarks/CMakeLists.txt	2021-11-12 12:22:24.359556397 -0700
++++ b/clients/benchmarks/CMakeLists.txt	2021-11-12 14:21:31.246604351 -0700
+@@ -52,6 +52,8 @@
+ target_link_libraries( rocblas-bench PRIVATE rocblas_fortran_client roc::rocblas lapack cblas )
+ if(LINK_BLIS)
+   target_link_libraries( rocblas-bench PRIVATE ${BLIS_LIBRARY} )
++else()
++  target_link_libraries( rocblas-bench PRIVATE blas )
+ endif()
+ 
+ if( CUDA_FOUND )
+diff -r -u a/clients/gtest/CMakeLists.txt b/clients/gtest/CMakeLists.txt
+--- a/clients/gtest/CMakeLists.txt	2021-11-12 12:22:24.359556397 -0700
++++ b/clients/gtest/CMakeLists.txt	2021-11-12 14:20:59.057676192 -0700
+@@ -132,6 +132,8 @@
+ target_link_libraries( rocblas-test PRIVATE rocblas_fortran_client roc::rocblas lapack cblas ${GTEST_LIBRARIES} )
+ if(LINK_BLIS)
+   target_link_libraries( rocblas-test PRIVATE ${BLIS_LIBRARY} )
++else()
++  target_link_libraries( rocblas-test PRIVATE blas )
+ endif()
+ 
+ 

--- a/var/spack/repos/builtin/packages/rocblas/0003-Fix-rocblas-gentest.patch
+++ b/var/spack/repos/builtin/packages/rocblas/0003-Fix-rocblas-gentest.patch
@@ -1,0 +1,9 @@
+diff -r -u a/clients/common/rocblas_gentest.py b/clients/common/rocblas_gentest.py
+--- a/clients/common/rocblas_gentest.py	2021-11-12 12:22:24.359556397 -0700
++++ b/clients/common/rocblas_gentest.py	2021-11-12 12:22:41.464044040 -0700
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python3
++#!/usr/bin/env python3
+ """Copyright 2018-2020 Advanced Micro Devices, Inc.
+ Expand rocBLAS YAML test data file into binary Arguments records"""
+ 

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -139,10 +139,7 @@ class Rocblas(CMakePackage):
             self.define('Tensile_COMPILER', 'hipcc'),
             self.define('Tensile_LOGIC', 'asm_full'),
             self.define('Tensile_CODE_OBJECT_VERSION', 'V3'),
-            self.define(
-                'BUILD_WITH_TENSILE_HOST',
-                'ON' if '@3.7.0:' in self.spec else 'OFF'
-            )
+            self.define('BUILD_WITH_TENSILE_HOST', '@3.7.0:' in self.spec)
         ]
         if self.run_tests:
             args.append(self.define('LINK_BLIS', 'OFF'))

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -59,8 +59,9 @@ class Rocblas(CMakePackage):
     depends_on('netlib-lapack@3.7.1:', type='test')
 
     def check(self):
-        exe = join_path(self.build_directory, 'clients', 'staging', 'rocblas-test')
-        self.run_test(exe, options=['--gtest_filter=*quick*-*known_bug*'])
+        if '@4.2.0:' in self.spec:
+            exe = join_path(self.build_directory, 'clients', 'staging', 'rocblas-test')
+            self.run_test(exe, options=['--gtest_filter=*quick*-*known_bug*'])
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2']:
@@ -128,7 +129,8 @@ class Rocblas(CMakePackage):
     def cmake_args(self):
         tensile = join_path(self.stage.source_path, 'Tensile')
         args = [
-            self.define('BUILD_CLIENTS_TESTS', self.run_tests),
+            self.define('BUILD_CLIENTS_TESTS',
+                        self.run_tests and '@4.2.0:' in self.spec),
             self.define('BUILD_CLIENTS_BENCHMARKS', 'OFF'),
             self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
             self.define('RUN_HEADER_TESTING', 'OFF'),


### PR DESCRIPTION
This change adds support for building the rocblas-test client and teaches spack how to run the fast subset of tests. I also tried to narrow down the cmake, python and rocm dependencies a bit. It takes ages to build Tensile, so I've only tested on 4.3.1 thus far.

rocBLAS also supports using blis as a reference library. That would make the tests significantly faster, but the CMake for using blas is more or less the same for rocblas, hipblas (#27074), rocsolver (#26919) and hipsolver, so I figured I'd start with that.

To give it a spin, try:
```
spack install --verbose --test=root rocblas@4.3.1
```

@haampie @srekolam @arjun-raj-kuppala