### PR TITLE
Add a symbol suffix option to LLVM

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -154,6 +154,8 @@ class Llvm(CMakePackage, CudaPackage):
             description="Enable code-signing on macOS")
     variant("python", default=False, description="Install python bindings")
 
+    variant('version_suffix', default='none', description="Add a symbol suffix")
+
     extends("python", when="+python")
 
     # Build dependency
@@ -464,6 +466,10 @@ class Llvm(CMakePackage, CudaPackage):
             define("LIBOMP_USE_HWLOC", True),
             define("LIBOMP_HWLOC_INSTALL_DIR", spec["hwloc"].prefix),
         ]
+
+        version_suffix = spec.variants['version_suffix'].value
+        if version_suffix != 'none':
+            cmake_args.append(define('LLVM_VERSION_SUFFIX', version_suffix))
 
         if python.version >= Version("3"):
             cmake_args.append(define("Python3_EXECUTABLE", python.command.path))


### PR DESCRIPTION
Julia uses this to add a `jl` symbol suffix, which is maybe a bit niche,
but it seems required, and other uses can just ignore it.
