### PR TITLE
Initial Support for CMake Modules

### DIFF
--- a/var/spack/repos/builtin/packages/lanl-cmake-modules/package.py
+++ b/var/spack/repos/builtin/packages/lanl-cmake-modules/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class LanlCmakeModules(CMakePackage):
+    '''CMake modules for projects that have not yet adopted modern CMake.
+    '''
+
+    maintainers = ['tuxfan']
+    homepage = 'https://tuxfan.github.io/lanl-cmake-modules'
+    git      = 'https://github.com/tuxfan/lanl-cmake-modules.git'
+
+    version('develop', branch='develop')


### PR DESCRIPTION
Several projects have not yet added modern CMake support. This package
adds find_package support for some of these projects.

The spack module in this pull request is pretty much empty. The actual guts of the project are in the github project referenced in the package, i.e., git@github.com:tuxfan/cmake-extra-modules.git. I'm hoping that we can get this into spack so that several projects can share these. In a perfect world, cmake would support these directly, or we would contribute them. However, even if this were so, it would still require that projects update to a new cmake release. The scripts in this project should work with any cmake version after 3.12.

