### PR TITLE
llvm: use LIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -560,7 +560,7 @@ class Llvm(CMakePackage, CudaPackage):
         # CMAKE_INSTALL_RPATH to it, which fails, causing installation to fail. The
         # easiest workaround is to just statically link libc++abi.a into libc++.so,
         # so that linking with -lc++ or -stdlib=libc++ is enough.
-        cmake_args.append(define('LIBCXX_ENABLE_STATIC_ABI_LIBRARY', 'ON'))
+        cmake_args.append(define('LIBCXX_ENABLE_STATIC_ABI_LIBRARY', True))
 
         if "+all_targets" not in spec:  # all is default on cmake
 

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -556,6 +556,12 @@ class Llvm(CMakePackage, CudaPackage):
         cmake_args.append(from_variant("LLVM_BUILD_LLVM_DYLIB", "llvm_dylib"))
         cmake_args.append(from_variant("LLVM_USE_SPLIT_DWARF", "split_dwarf"))
 
+        # By default on Linux, libc++.so is a linker script, and CMake tries to add the
+        # CMAKE_INSTALL_RPATH to it, which fails, causing installation to fail. The
+        # easiest workaround is to just statically link libc++abi.a into libc++.so,
+        # so that linking with -lc++ or -stdlib=libc++ is enough.
+        cmake_args.append(define('LIBCXX_ENABLE_STATIC_ABI_LIBRARY', 'ON'))
+
         if "+all_targets" not in spec:  # all is default on cmake
 
             targets = ["NVPTX", "AMDGPU"]
@@ -593,12 +599,6 @@ class Llvm(CMakePackage, CudaPackage):
                     break
             cmake_args.append(define("GCC_INSTALL_PREFIX", gcc_prefix))
 
-        if spec.satisfies("@4.0.0:"):
-            if spec.satisfies("platform=cray") or spec.satisfies(
-                "platform=linux"
-            ):
-                cmake_args.append(define("CMAKE_BUILD_WITH_INSTALL_RPATH", "1"))
-
         if self.spec.satisfies("~code_signing platform=darwin"):
             cmake_args.append(define('LLDB_USE_SYSTEM_DEBUGSERVER', True))
 
@@ -610,16 +610,6 @@ class Llvm(CMakePackage, CudaPackage):
             cmake_args.append(define("LLVM_ENABLE_RUNTIMES", runtimes))
 
         return cmake_args
-
-    @run_before("build")
-    def pre_install(self):
-        with working_dir(self.build_directory):
-            # When building shared libraries these need to be installed first
-            make("install-LLVMTableGen")
-            if self.spec.version >= Version("4.0.0"):
-                # LLVMDemangle target was added in 4.0.0
-                make("install-LLVMDemangle")
-            make("install-LLVMSupport")
 
     @run_after("install")
     def post_install(self):


### PR DESCRIPTION
The previous workaround of using CMAKE_INSTALL_RPATH=ON was to
avoid CMake trying to write an RPATH into the linker script libcxx.so,
which is nonsensical. See commit f86ed1e.

However, CMAKE_INSTALL_RPATH=ON seems to disable the build RPATH, which
breaks LLVM during the build when it has to locate its build-time shared
libraries (e.g. libLLVM.so). That required yet another workaround, where
some shared libraries were installed "by hand", so that they were picked
up from the install libdir. See commit 8a81229.

This was a dirty workaround, and also makes it impossible to use ninja,
since we explicitly invoked make.

This commit removes the two old workaround, and sets
LIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON, so that libc++abi.a is linked into
libc++.so, which makes it enough to link with -lc++ or invoke clang++
with -stdlib=libc++, so that our install succeeds and linking LLVM's c++
standard lib is still easy.