### PR TITLE
llvm: flang implies mlir

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -197,6 +197,8 @@ class Llvm(CMakePackage, CudaPackage):
     # Introduced in version 11 as a part of LLVM and not a separate package.
     conflicts("+flang", when="@:10")
 
+    conflicts('~mlir', when='+flang', msg='flang implies MLIR')
+
     # Older LLVM do not build with newer compilers, and vice versa
     conflicts("%gcc@11:", when="@:7")
     conflicts("%gcc@8:", when="@:5")

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -197,7 +197,7 @@ class Llvm(CMakePackage, CudaPackage):
     # Introduced in version 11 as a part of LLVM and not a separate package.
     conflicts("+flang", when="@:10")
 
-    conflicts('~mlir', when='+flang', msg='flang implies MLIR')
+    conflicts('~mlir', when='+flang', msg='Flang requires MLIR')
 
     # Older LLVM do not build with newer compilers, and vice versa
     conflicts("%gcc@11:", when="@:7")


### PR DESCRIPTION
When flang is on mlir is enabled by default, so we should not allow ~mlir+flang
