### PR TITLE
llvm: set LLVM_LINK_LLVM_DYLIB=ON when +llvm_dylib

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -119,7 +119,7 @@ spack:
     - libnrm
     - libquo
     - libunwind
-    - llvm +all_targets +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
+    - llvm +all_targets +clang +compiler-rt +libcxx +lld +lldb +build_llvm_dylib +flang ~cuda
     - loki
     - mercury
     - metall

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -130,7 +130,7 @@ spack:
     - libnrm
     - libquo
     - libunwind
-    - llvm +all_targets +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
+    - llvm +all_targets +clang +compiler-rt +libcxx +lld +lldb +build_llvm_dylib +flang ~cuda
     - loki
     - mercury
     - metall


### PR DESCRIPTION
This is on top of #27448 so that clang can locate libclang when it builds runtimes