### PR TITLE
bin/spack: use -B flag to avoid writing .py[co] files

### DIFF
--- a/bin/spack
+++ b/bin/spack
@@ -15,7 +15,7 @@ SPACK_PREFERRED_PYTHONS="python3 python python2 /usr/libexec/platform-python"
 for cmd in "${SPACK_PYTHON:-}" ${SPACK_PREFERRED_PYTHONS}; do
     if command -v > /dev/null "$cmd"; then
         export SPACK_PYTHON="$(command -v "$cmd")"
-        exec "${SPACK_PYTHON}" "$0" "$@"
+        exec "${SPACK_PYTHON}" -B "$0" "$@"
     fi
 done
 


### PR DESCRIPTION
I wonder if Spack should invoke Python with `-B` flag to avoid creating `.py[oc]` files and `__pycache__` directories.
