### PR TITLE
Add julia-specific patches of libuv

### DIFF
--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -7,7 +7,8 @@ class Libuv(AutotoolsPackage):
     homepage = "https://libuv.org"
     url = "https://github.com/libuv/libuv/archive/v1.9.0.tar.gz"
 
-    version('1.42.0', sha256='371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764')
+    version('1.42.0-julia', sha256='5c1f23da14a8cdd1876cde9fe2a08096558fab4725844f486b1c6cfb82e96f70', url='https://github.com/JuliaLang/libuv/tarball/julia-uv2-1.42.0')
+    version('1.42.0', sha256='371e5419708f6aaeb8656671f89400b92a9bba6443369af1bb70bcd6e4b3c764', preferred=True)
     version('1.41.1', sha256='62c29d1d76b0478dc8aaed0ed1f874324f6cd2d6ff4cb59a44026c09e818cd53')
     version('1.41.0', sha256='6cfeb5f4bab271462b4a2cc77d4ecec847fdbdc26b72019c27ae21509e6f94fa')
     version('1.40.0', sha256='70fe1c9ba4f2c509e8166c0ca2351000237da573bb6c82092339207a9715ba6b')


### PR DESCRIPTION
libuv is maintained partly by julia, and they keep a bunch of patches on
top of official releases. I think it's worth creating a dedicated
version, since they merge their release branch with the tagged libuv
version to the master branch, which results in big patch files.
