### PR TITLE
vtk: update package using changed variable names

### DIFF
--- a/var/spack/repos/builtin/packages/gl2ps/package.py
+++ b/var/spack/repos/builtin/packages/gl2ps/package.py
@@ -13,6 +13,7 @@ class Gl2ps(CMakePackage):
     homepage = "https://www.geuz.org/gl2ps/"
     url      = "https://geuz.org/gl2ps/src/gl2ps-1.3.9.tgz"
 
+    version('1.4.2', sha256='8d1c00c1018f96b4b97655482e57dcb0ce42ae2f1d349cd6d4191e7848d9ffe9')
     version('1.4.0', sha256='03cb5e6dfcd87183f3b9ba3b22f04cd155096af81e52988cc37d8d8efe6cf1e2')
     version('1.3.9', sha256='8a680bff120df8bcd78afac276cdc38041fed617f2721bade01213362bcc3640')
 

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -86,7 +86,7 @@ class Seacas(CMakePackage):
     # Everything should be compiled position independent (-fpic)
 
     depends_on('netcdf-c@4.8.0:+mpi+parallel-netcdf', when='+mpi')
-    depends_on('netcdf-c@4.8.0:~mpi~parallel-netcdf', when='~mpi')
+    depends_on('netcdf-c@4.8.0:~mpi', when='~mpi')
     depends_on('hdf5+hl~mpi', when='~mpi')
     depends_on('cgns@4.2.0:+mpi+scoping', when='+cgns +mpi')
     depends_on('cgns@4.2.0:~mpi+scoping', when='+cgns ~mpi')

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -127,7 +127,7 @@ class Seacas(CMakePackage):
                 '-DMPI_BASE_DIR:PATH=%s'      % spec['mpi'].prefix,
             ])
         else:
-            '-DTPL_ENABLE_MPI:BOOL=OFF',
+            '-DTPL_ENABLE_MPI:BOOL=OFF'
 
         options.extend([
             '-DSEACASProj_ENABLE_TESTS:BOOL=ON',

--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -86,7 +86,7 @@ class Seacas(CMakePackage):
     # Everything should be compiled position independent (-fpic)
 
     depends_on('netcdf-c@4.8.0:+mpi+parallel-netcdf', when='+mpi')
-    depends_on('netcdf-c@4.8.0:~mpi', when='~mpi')
+    depends_on('netcdf-c@4.8.0:~mpi~parallel-netcdf', when='~mpi')
     depends_on('hdf5+hl~mpi', when='~mpi')
     depends_on('cgns@4.2.0:+mpi+scoping', when='+cgns +mpi')
     depends_on('cgns@4.2.0:~mpi+scoping', when='+cgns ~mpi')
@@ -126,6 +126,8 @@ class Seacas(CMakePackage):
                 '-DTPL_ENABLE_MPI:BOOL=ON',
                 '-DMPI_BASE_DIR:PATH=%s'      % spec['mpi'].prefix,
             ])
+        else:
+            '-DTPL_ENABLE_MPI:BOOL=OFF',
 
         options.extend([
             '-DSEACASProj_ENABLE_TESTS:BOOL=ON',

--- a/var/spack/repos/builtin/packages/utf8/package.py
+++ b/var/spack/repos/builtin/packages/utf8/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Utf8(Package):
+    """A simple, portable and lightweight generic library for handling UTF-8
+    encoded strings."""
+
+    homepage = "http://utfcpp.sourceforge.net/"
+    url      = "https://sourceforge.net/projects/utfcpp/files/utf8cpp_2x/Release%202.3.4/utf8_v2_3_4.zip"
+
+    version('2.3.4', sha256='3373cebb25d88c662a2b960c4d585daf9ae7b396031ecd786e7bb31b15d010ef')
+
+    def install(self, spec, prefix):
+        install_tree('doc', prefix.share.doc)
+        install_tree('source', prefix.include)

--- a/var/spack/repos/builtin/packages/utf8cpp/package.py
+++ b/var/spack/repos/builtin/packages/utf8cpp/package.py
@@ -6,14 +6,17 @@
 from spack import *
 
 
-class Utf8(Package):
+class Utf8cpp(Package):
     """A simple, portable and lightweight generic library for handling UTF-8
     encoded strings."""
 
     homepage = "http://utfcpp.sourceforge.net/"
-    url      = "https://sourceforge.net/projects/utfcpp/files/utf8cpp_2x/Release%202.3.4/utf8_v2_3_4.zip"
 
     version('2.3.4', sha256='3373cebb25d88c662a2b960c4d585daf9ae7b396031ecd786e7bb31b15d010ef')
+
+    def url_for_version(self, version):
+        url = "https://sourceforge.net/projects/utfcpp/files/utf8cpp_2x/Release%20{0}/utf8_v{1}.zip"
+        return url.format(version, version.underscored)
 
     def install(self, spec, prefix):
         install_tree('doc', prefix.share.doc)

--- a/var/spack/repos/builtin/packages/vtk/internal_findHDF5.patch
+++ b/var/spack/repos/builtin/packages/vtk/internal_findHDF5.patch
@@ -1,0 +1,16 @@
+diff -ru a/CMake/FindHDF5.cmake b/CMake/FindHDF5.cmake
+--- a/CMake/FindHDF5.cmake	2019-01-30 11:15:13.000000000 -0600
++++ b/CMake/FindHDF5.cmake	2021-11-15 18:01:39.314264619 -0600
+@@ -3,11 +3,7 @@
+ # (BUG #0014363).
+ 
+ # include the default FindHDF5.cmake.
+-if(CMAKE_VERSION VERSION_LESS 3.6.1)
+-  include(${CMAKE_CURRENT_LIST_DIR}/NewCMake/FindHDF5.cmake)
+-else()
+-  include(${CMAKE_ROOT}/Modules/FindHDF5.cmake)
+-endif()
++include(${CMAKE_CURRENT_LIST_DIR}/NewCMake/FindHDF5.cmake)
+ 
+ if(HDF5_FOUND AND (HDF5_IS_PARALLEL OR HDF5_ENABLE_PARALLEL))
+   include(vtkMPI)

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -105,8 +105,7 @@ class Vtk(CMakePackage):
     depends_on('freetype')
     depends_on('glew')
     # set hl variant explicitly, similar to issue #7145
-    depends_on('hdf5+hl~mpi', when='~mpi')
-    depends_on('hdf5+hl+mpi', when='+mpi')
+    depends_on('hdf5+hl')
     depends_on('jpeg')
     depends_on('jsoncpp')
     depends_on('libxml2')
@@ -123,7 +122,7 @@ class Vtk(CMakePackage):
     depends_on('pugixml', when='@9:')
     depends_on('libogg')
     depends_on('libtheora')
-    depends_on('utf8', when='@9:')
+    depends_on('utf8cpp', when='@9:')
     depends_on('gl2ps', when='@8.1:')
     depends_on('gl2ps@1.4.1:', when='@9:')
     depends_on('proj@4', when='@8.2')
@@ -248,6 +247,8 @@ class Vtk(CMakePackage):
             qmake_exe = os.path.join(qt_bin, 'qmake')
 
             # https://github.com/martijnkoopman/Qt-VTK-viewer/blob/master/doc/Build-VTK.md
+            # The content of the above link changes over time with versions.
+            # Older commits have information on VTK-8.
             if spec.satisfies('@:8'):
                 cmake_args.extend([
                     '-DVTK_QT_VERSION:STRING={0}'.format(qt_ver),

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -21,6 +21,7 @@ class Vtk(CMakePackage):
 
     maintainers = ['chuckatkins', 'danlipsa']
 
+    version('9.1.0', sha256='8fed42f4f8f1eb8083107b68eaa9ad71da07110161a3116ad807f43e5ca5ce96')
     version('9.0.3', sha256='bc3eb9625b2b8dbfecb6052a2ab091fc91405de4333b0ec68f3323815154ed8a')
     version('9.0.1', sha256='1b39a5e191c282861e7af4101eaa8585969a2de05f5646c9199a161213a622c7')
     version('9.0.0', sha256='15def4e6f84d72f82386617fe595ec124dda3cbd13ea19a0dcd91583197d8715')
@@ -73,6 +74,9 @@ class Vtk(CMakePackage):
     # Broken downstream FindMPI
     patch('vtkm-findmpi-downstream.patch', when='@9.0.0')
 
+    # use internal FindHDF5
+    patch('internal_findHDF5.patch', when='@:8')
+
     # The use of the OpenGL2 backend requires at least OpenGL Core Profile
     # version 3.2 or higher.
     depends_on('gl@3.2:', when='+opengl2')
@@ -101,7 +105,8 @@ class Vtk(CMakePackage):
     depends_on('freetype')
     depends_on('glew')
     # set hl variant explicitly, similar to issue #7145
-    depends_on('hdf5+hl')
+    depends_on('hdf5+hl~mpi', when='~mpi')
+    depends_on('hdf5+hl+mpi', when='+mpi')
     depends_on('jpeg')
     depends_on('jsoncpp')
     depends_on('libxml2')
@@ -115,6 +120,18 @@ class Vtk(CMakePackage):
     depends_on('eigen', when='@8.2.0:')
     depends_on('double-conversion', when='@8.2.0:')
     depends_on('sqlite', when='@8.2.0:')
+    depends_on('pugixml', when='@9:')
+    depends_on('libogg')
+    depends_on('libtheora')
+    depends_on('utf8', when='@9:')
+    depends_on('gl2ps', when='@8.1:')
+    depends_on('gl2ps@1.4.1:', when='@9:')
+    depends_on('proj@4', when='@8.2')
+    depends_on('proj@4:7', when='@9:')
+    depends_on('cgns@4.1.1:+mpi', when='@9.1: +mpi')
+    depends_on('cgns@4.1.1:~mpi', when='@9.1: ~mpi')
+    depends_on('seacas@2021-05-12:+mpi', when='@9.1: +mpi')
+    depends_on('seacas@2021-05-12:~mpi', when='@9.1: ~mpi')
 
     # For finding Fujitsu-MPI wrapper commands
     patch('find_fujitsu_mpi.patch', when='@:8.2.0%fj')
@@ -147,38 +164,45 @@ class Vtk(CMakePackage):
             # (solves #26314)
             '-DCMAKE_INSTALL_LIBDIR:PATH=lib',
 
-            # In general, we disable use of VTK "ThirdParty" libs, preferring
-            # spack-built versions whenever possible
-            '-DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON',
-
-            # However, in a few cases we can't do without them yet
-            '-DVTK_USE_SYSTEM_GL2PS:BOOL=OFF',
-            '-DVTK_USE_SYSTEM_LIBHARU=OFF',
-
-            '-DNETCDF_DIR={0}'.format(spec['netcdf-c'].prefix),
-            '-DNETCDF_C_ROOT={0}'.format(spec['netcdf-c'].prefix),
-            '-DNETCDF_CXX_ROOT={0}'.format(spec['netcdf-cxx'].prefix),
-
             # Allow downstream codes (e.g. VisIt) to override VTK's classes
             '-DVTK_ALL_NEW_OBJECT_FACTORY:BOOL=ON',
-
-            # Disable wrappers for other languages.
-            '-DVTK_WRAP_JAVA=OFF',
-            '-DVTK_WRAP_TCL=OFF',
         ]
 
-        # Some variable names have changed
-        if spec.satisfies('@8.2.0:'):
+        # Disable wrappers for other languages.
+        cmake_args.append('-DVTK_WRAP_JAVA=OFF')
+        if spec.satisfies('@:8.1'):
+            cmake_args.append('-DVTK_WRAP_TCL=OFF')
+
+        # In general, we disable use of VTK "ThirdParty" libs, preferring
+        # spack-built versions whenever possible but there are exceptions.
+        if spec.satisfies('@:8'):
             cmake_args.extend([
-                '-DVTK_USE_SYSTEM_OGG:BOOL=OFF',
-                '-DVTK_USE_SYSTEM_THEORA:BOOL=OFF',
-                '-DVTK_USE_SYSTEM_LIBPROJ:BOOL=OFF',
-                '-DVTK_USE_SYSTEM_PUGIXML:BOOL=OFF',
+                '-DVTK_USE_SYSTEM_LIBRARIES:BOOL=ON',
+                '-DVTK_USE_SYSTEM_LIBHARU=OFF',
             ])
+            if spec.satisfies('@:8.0'):
+                cmake_args.append('-DVTK_USE_SYSTEM_GL2PS=OFF')
         else:
             cmake_args.extend([
-                '-DVTK_USE_SYSTEM_OGGTHEORA:BOOL=OFF',
+                '-DVTK_USE_EXTERNAL:BOOL=ON',
+                '-DVTK_MODULE_USE_EXTERNAL_VTK_libharu:BOOL=OFF',
+                '-DVTK_MODULE_USE_EXTERNAL_VTK_pegtl:BOOL=OFF',
+                '-DHDF5_ROOT={0}'.format(spec['hdf5'].prefix),
+            ])
+            if spec.satisfies('@9.1:'):
+                cmake_args.extend([
+                    '-DVTK_MODULE_USE_EXTERNAL_VTK_exprtk:BOOL=OFF',
+                    # uses an unreleased version of fmt
+                    '-DVTK_MODULE_USE_EXTERNAL_VTK_fmt:BOOL=OFF',
+                ])
+
+        # Some variable names have changed
+        if spec.satisfies('@8.2.0'):
+            cmake_args.append('-DVTK_USE_SYSTEM_PUGIXML:BOOL=OFF')
+        elif spec.satisfies('@:8.1'):
+            cmake_args.extend([
                 '-DVTK_USE_SYSTEM_LIBPROJ4:BOOL=OFF',
+                '-DNETCDF_CXX_ROOT={0}'.format(spec['netcdf-cxx'].prefix),
             ])
 
         if '+mpi' in spec:
@@ -191,17 +215,22 @@ class Vtk(CMakePackage):
                 cmake_args.extend([
                     '-DVTK_USE_MPI=ON'
                 ])
+        else:
+            '-DVTK_USE_MPI=OFF'
 
         if '+ffmpeg' in spec:
-            cmake_args.extend(['-DModule_vtkIOFFMPEG:BOOL=ON'])
+            if spec.satisfies('@:8'):
+                cmake_args.append('-DModule_vtkIOFFMPEG:BOOL=ON')
+            else:
+                cmake_args.append('-DVTK_MODULE_ENABLE_VTK_IOFFMPEG:STRING=YES')
 
         # Enable/Disable wrappers for Python.
         if '+python' in spec:
-            cmake_args.extend([
-                '-DVTK_WRAP_PYTHON=ON',
-                '-DPYTHON_EXECUTABLE={0}'.format(spec['python'].command.path),
-            ])
-            if '+mpi' in spec:
+            cmake_args.append('-DVTK_WRAP_PYTHON=ON')
+            if spec.satisfies('@:8'):
+                cmake_args.append(
+                    '-DPYTHON_EXECUTABLE={0}'.format(spec['python'].command.path))
+            if '+mpi' in spec and spec.satisfies('@:8'):
                 cmake_args.append('-DVTK_USE_SYSTEM_MPI4PY:BOOL=ON')
             if spec.satisfies('@9.0.0: ^python@3:'):
                 cmake_args.append('-DVTK_PYTHON_VERSION=3')
@@ -218,14 +247,14 @@ class Vtk(CMakePackage):
             qt_bin = spec['qt'].prefix.bin
             qmake_exe = os.path.join(qt_bin, 'qmake')
 
-            cmake_args.extend([
-                # Enable Qt support here.
-                '-DVTK_QT_VERSION:STRING={0}'.format(qt_ver),
-                '-DQT_QMAKE_EXECUTABLE:PATH={0}'.format(qmake_exe),
-                '-DVTK_Group_Qt:BOOL=ON',
-            ])
             # https://github.com/martijnkoopman/Qt-VTK-viewer/blob/master/doc/Build-VTK.md
-            if spec.satisfies('@9.0.0:'):
+            if spec.satisfies('@:8'):
+                cmake_args.extend([
+                    '-DVTK_QT_VERSION:STRING={0}'.format(qt_ver),
+                    '-DQT_QMAKE_EXECUTABLE:PATH={0}'.format(qmake_exe),
+                    '-DVTK_Group_Qt:BOOL=ON',
+                ])
+            else:
                 cmake_args.extend([
                     '-DVTK_GROUP_ENABLE_Qt:STRING=YES',
                     '-DVTK_MODULE_ENABLE_VTK_GUISupportQt:STRING=YES',
@@ -235,37 +264,54 @@ class Vtk(CMakePackage):
             # VTK to build with qt~webkit versions (see the documentation for
             # more info: http://www.vtk.org/Wiki/VTK/Tutorials/QtSetup).
             if '~webkit' in spec['qt']:
-                cmake_args.extend([
-                    '-DVTK_Group_Qt:BOOL=OFF',
-                    '-DModule_vtkGUISupportQt:BOOL=ON',
-                    '-DModule_vtkGUISupportQtOpenGL:BOOL=ON',
-                ])
+                if spec.satisfies('@:8'):
+                    cmake_args.extend([
+                        '-DVTK_Group_Qt:BOOL=OFF',
+                        '-DModule_vtkGUISupportQt:BOOL=ON',
+                        '-DModule_vtkGUISupportQtOpenGL:BOOL=ON',
+                    ])
+                else:
+                    cmake_args.extend([
+                        '-DVTK_GROUP_ENABLE_Qt:STRING=NO',
+                        '-DVTK_MODULE_ENABLE_VTK_GUISupportQt:STRING=YES',
+                    ])
 
         if '+xdmf' in spec:
             if spec.satisfies('^cmake@3.12:'):
                 # This policy exists only for CMake >= 3.12
                 cmake_args.extend(["-DCMAKE_POLICY_DEFAULT_CMP0074=NEW"])
 
-            cmake_args.extend([
-                # Enable XDMF Support here
-                "-DModule_vtkIOXdmf2:BOOL=ON",
-                "-DModule_vtkIOXdmf3:BOOL=ON",
-                "-DBOOST_ROOT={0}".format(spec['boost'].prefix),
-                "-DBOOST_LIBRARY_DIR={0}".format(spec['boost'].prefix.lib),
-                "-DBOOST_INCLUDE_DIR={0}".format(spec['boost'].prefix.include),
-                "-DBOOST_NO_SYSTEM_PATHS:BOOL=ON",
-                # This is needed because VTK has multiple FindBoost
-                # and they stick to system boost if there's a system boost
-                # installed with CMake
-                "-DBoost_NO_BOOST_CMAKE:BOOL=ON",
-                "-DHDF5_ROOT={0}".format(spec['hdf5'].prefix),
-                # The xdmf project does not export any CMake file...
-                "-DVTK_USE_SYSTEM_XDMF3:BOOL=OFF",
-                "-DVTK_USE_SYSTEM_XDMF2:BOOL=OFF"
-            ])
+            if spec.satisfies('@:8'):
+                cmake_args.extend([
+                    # Enable XDMF Support here
+                    "-DModule_vtkIOXdmf2:BOOL=ON",
+                    "-DModule_vtkIOXdmf3:BOOL=ON",
+                    "-DBOOST_ROOT={0}".format(spec['boost'].prefix),
+                    "-DBOOST_LIBRARY_DIR={0}".format(spec['boost'].prefix.lib),
+                    "-DBOOST_INCLUDE_DIR={0}".format(spec['boost'].prefix.include),
+                    "-DBOOST_NO_SYSTEM_PATHS:BOOL=ON",
+                    # This is needed because VTK has multiple FindBoost
+                    # and they stick to system boost if there's a system boost
+                    # installed with CMake
+                    "-DBoost_NO_BOOST_CMAKE:BOOL=ON",
+                    # The xdmf project does not export any CMake file...
+                    "-DVTK_USE_SYSTEM_XDMF3:BOOL=OFF",
+                    "-DVTK_USE_SYSTEM_XDMF2:BOOL=OFF"
+                ])
+            else:
+                cmake_args.extend([
+                    '-DVTK_MODULE_ENABLE_VTK_xdmf2:STRING=YES',
+                    '-DVTK_MODULE_ENABLE_VTK_xdmf3:STRING=YES',
+                    '-DVTK_MODULE_ENABLE_VTK_IOXdmf2:STRING=YES',
+                    '-DVTK_MODULE_ENABLE_VTK_IOXdmf3:STRING=YES',
+                ])
 
             if '+mpi' in spec:
-                cmake_args.extend(["-DModule_vtkIOParallelXdmf3:BOOL=ON"])
+                if spec.satisfies('@:8'):
+                    cmake_args.append("-DModule_vtkIOParallelXdmf3:BOOL=ON")
+                else:
+                    cmake_args.append(
+                        '-DVTK_MODULE_ENABLE_VTK_IOParallelXdmf3:STRING=YES')
 
         cmake_args.append('-DVTK_RENDERING_BACKEND:STRING=' + opengl_ver)
 


### PR DESCRIPTION
This PR updates the vtk package to use new variable names and adds some
external dependencies.

- add version 1.4.2 to gl2ps package. This is needed to use gl2ps as a
  dependency.
- new package: utf8. This can now be sued as a dependency for version 9.
- use the package provided FindHDF5.cmake for versions up to 8. Version
  9 already uses an internal version.
- adjust the hdf dependencies to match the ~mpi and +mpi variants
- add external dependencies when possible
    - pugixml
    - libogg
    - libtheora
    - utf8
    - gl2ps
    - proj
- turn off configuring MPI if ~mpi
- use new variables for version 9
- remove unused variables depending on version