### PR TITLE
add patch for clang compile

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/nouveau-clang.patch
+++ b/var/spack/repos/builtin/packages/libdrm/nouveau-clang.patch
@@ -1,0 +1,14 @@
+diff --git a/nouveau/Makefile.am b/nouveau/Makefile.am
+index 5574fd8..75ab27c 100644
+--- a/nouveau/Makefile.am
++++ b/nouveau/Makefile.am
+@@ -5,8 +5,7 @@ AM_CFLAGS = \
+ 	-fvisibility=hidden \
+ 	-I$(top_srcdir) \
+ 	$(PTHREADSTUBS_CFLAGS) \
+-	-I$(top_srcdir)/include/drm \
+-	-DDEBUG
++	-I$(top_srcdir)/include/drm
+ 
+ libdrm_nouveau_la_LTLIBRARIES = libdrm_nouveau.la
+ libdrm_nouveau_ladir = $(libdir)

--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -25,6 +25,11 @@ class Libdrm(AutotoolsPackage):
     depends_on('docbook-xsl', type='build')
     depends_on('libpciaccess@0.10:')
     depends_on('libpthread-stubs')
+    depends_on('automake@1.15.1', type='build', when='%clang')
+    depends_on('autoconf', type='build', when='%clang')
+
+    #clang linker has multiple defines
+    patch('nouveau-clang.patch', when='%clang')
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
This patch is necessary in order to remove code that fails on clang