### PR TITLE
ci: base branch not develop fixes

### DIFF
--- a/.github/workflows/setup_git.sh
+++ b/.github/workflows/setup_git.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env sh
 git config --global user.email "spack@example.com"
 git config --global user.name "Test User"
-# With fetch-depth: 0 we have a remote develop
-# but not a local branch. Don't do this on develop
-if [ "$(git branch --show-current)" != "develop" ]
-then
-  git branch develop origin/develop
+
+# create a local pr base branch
+if [[ -n $GITHUB_BASE_REF ]]; then
+    git fetch origin "${GITHUB_BASE_REF}:${GITHUB_BASE_REF}"
 fi

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -211,6 +211,7 @@ jobs:
           git clone "${{ github.server_url }}/${{ github.repository }}.git" && cd spack
           git fetch origin "${{ github.ref }}:test-branch"
           git checkout test-branch
+          . .github/workflows/setup_git.sh
           bin/spack unit-test -x
     - name: Run unit tests (only package tests)
       if: ${{ needs.changes.outputs.with_coverage == 'false' }}
@@ -223,6 +224,7 @@ jobs:
           git clone "${{ github.server_url }}/${{ github.repository }}.git" && cd spack
           git fetch origin "${{ github.ref }}:test-branch"
           git checkout test-branch
+          . .github/workflows/setup_git.sh
           bin/spack unit-test -x -m "not maybeslow" -k "package_sanity"
 
   # Test RHEL8 UBI with platform Python. This job is run

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -24,8 +24,19 @@ style_data = os.path.join(spack.paths.test_path, 'data', 'style')
 
 style = spack.main.SpackCommand("style")
 
+
+def has_develop_branch():
+    git = which('git')
+    if not git:
+        return False
+    git("show-ref", "--verify", "--quiet",
+        "refs/heads/develop", fail_on_error=False)
+    return git.returncode == 0
+
+
 # spack style requires git to run -- skip the tests if it's not there
-pytestmark = pytest.mark.skipif(not which('git'), reason='requires git')
+pytestmark = pytest.mark.skipif(not has_develop_branch(),
+                                reason='requires git with develop branch')
 
 # The style tools have requirements to use newer Python versions.  We simplify by
 # requiring Python 3.6 or higher to run spack style.

--- a/lib/spack/spack/test/package_sanity.py
+++ b/lib/spack/spack/test/package_sanity.py
@@ -206,8 +206,12 @@ def test_prs_update_old_api():
     """Ensures that every package modified in a PR doesn't contain
     deprecated calls to any method.
     """
+    ref = os.getenv("GITHUB_BASE_REF")
+    if not ref:
+        pytest.skip("No base ref found")
+
     changed_package_files = [
-        x for x in style.changed_files() if style.is_package(x)
+        x for x in style.changed_files(base=ref) if style.is_package(x)
     ]
     failing = []
     for file in changed_package_files:

--- a/share/spack/qa/run-style-tests
+++ b/share/spack/qa/run-style-tests
@@ -14,15 +14,15 @@
 # Usage:
 #     run-flake8-tests
 #
-. "$(dirname $0)/setup.sh"
+. "$(dirname "$0")/setup.sh"
 
-BASE=""
-if [ -n "$GITHUB_BASE_REF" ]; then
-    BASE="--base ${GITHUB_BASE_REF}"
+args=()
+if [[ -n $GITHUB_BASE_REF ]]; then
+    args+=("--base" "${GITHUB_BASE_REF}")
 fi
 
 # verify that the code style is correct
-spack style --root-relative $BASE
+spack style --root-relative "${args[@]}"
 
 # verify that the license headers are present
 spack license verify


### PR DESCRIPTION
Fix some issues where tests assume that the base ref is always the develop branch, which is not the case in the backports pr.
