### PR TITLE
Refactor bootstrap of "spack style" dependencies

### DIFF
--- a/lib/spack/spack/analyzers/libabigail.py
+++ b/lib/spack/spack/analyzers/libabigail.py
@@ -2,8 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 import os
 
 import llnl.util.tty as tty
@@ -16,6 +14,7 @@ import spack.hooks
 import spack.monitor
 import spack.package
 import spack.repo
+import spack.util.executable
 
 from .analyzer_base import AnalyzerBase
 
@@ -40,13 +39,12 @@ class Libabigail(AnalyzerBase):
         tty.debug("Preparing to use Libabigail, will install if missing.")
 
         with spack.bootstrap.ensure_bootstrap_configuration():
-
             # libabigail won't install lib/bin/share without docs
             spec = spack.spec.Spec("libabigail+docs")
-            spec.concretize()
-
-            self.abidw = spack.bootstrap.get_executable(
-                "abidw", spec=spec, install=True)
+            spack.bootstrap.ensure_executables_in_path_or_raise(
+                ["abidw"], abstract_spec=spec
+            )
+            self.abidw = spack.util.executable.which('abidw')
 
     def run(self):
         """

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -558,7 +558,9 @@ def ensure_executables_in_path_or_raise(executables, abstract_spec):
                 env_mods = spack.util.environment.EnvironmentModifications()
                 cmd = spack.util.executable.which(*executables)
                 concrete_spec = spack.store.db.query(abstract_spec, installed=True)[0]
-                for dep in concrete_spec.traverse(root=True, order='post'):
+                for dep in concrete_spec.traverse(
+                        root=True, order='post', deptype=('link', 'run')
+                ):
                     env_mods.extend(
                         spack.user_environment.environment_modifications_for_spec(dep)
                     )

--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -48,10 +48,10 @@ exclude_directories = [
 #: double-check the results of other tools (if, e.g., --fix was provided)
 #: The list maps an executable name to a spack spec needed to install it.
 tool_order = [
-    ("isort", "py-isort@4.3.5:"),
-    ("mypy", "py-mypy@0.900:"),
-    ("black", "py-black"),
-    ("flake8", "py-flake8"),
+    ("isort", spack.bootstrap.ensure_isort_in_path_or_raise),
+    ("mypy", spack.bootstrap.ensure_mypy_in_path_or_raise),
+    ("black", spack.bootstrap.ensure_black_in_path_or_raise),
+    ("flake8", spack.bootstrap.ensure_flake8_in_path_or_raise),
 ]
 
 #: tools we run in spack style
@@ -387,40 +387,33 @@ def style(parser, args):
 
         file_list = [prefix_relative(p) for p in file_list]
 
-    returncode = 0
+    return_code = 0
     with working_dir(args.root):
         if not file_list:
             file_list = changed_files(args.base, args.untracked, args.all)
         print_style_header(file_list, args)
 
-        # run tools in order defined in tool_order
-        returncode = 0
-        for tool_name, tool_spec in tool_order:
-            if getattr(args, tool_name):
+        commands = {}
+        with spack.bootstrap.ensure_bootstrap_configuration():
+            for tool_name, bootstrap_fn in tool_order:
+                # Skip the tool if it was not requested
+                if not getattr(args, tool_name):
+                    continue
+
+                commands[tool_name] = bootstrap_fn()
+
+            for tool_name, bootstrap_fn in tool_order:
+                # Skip the tool if it was not requested
+                if not getattr(args, tool_name):
+                    continue
+
                 run_function, required = tools[tool_name]
                 print_tool_header(tool_name)
+                return_code |= run_function(commands[tool_name], file_list, args)
 
-                try:
-                    # Bootstrap tools so we don't need to require install
-                    with spack.bootstrap.ensure_bootstrap_configuration():
-                        spec = spack.spec.Spec(tool_spec)
-                        cmd = None
-                        cmd = spack.bootstrap.get_executable(
-                            tool_name, spec=spec, install=True
-                        )
-                        if not cmd:
-                            color.cprint("  @y{%s not in PATH, skipped}" % tool_name)
-                            continue
-                        returncode |= run_function(cmd, file_list, args)
-
-                except Exception as e:
-                    raise spack.error.SpackError(
-                        "Couldn't bootstrap %s:" % tool_name, str(e)
-                    )
-
-    if returncode == 0:
+    if return_code == 0:
         tty.msg(color.colorize("@*{spack style checks were clean}"))
     else:
         tty.error(color.colorize("@*{spack style found errors}"))
 
-    return returncode
+    return return_code

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -30,7 +30,8 @@ pytestmark = pytest.mark.skipif(not which('git'), reason='requires git')
 # The style tools have requirements to use newer Python versions.  We simplify by
 # requiring Python 3.6 or higher to run spack style.
 skip_old_python = pytest.mark.skipif(
-    sys.version_info < (3, 6), reason='requires Python 3.6 or higher')
+    sys.version_info < (3, 6), reason='requires Python 3.6 or higher'
+)
 
 
 @pytest.fixture(scope="function")
@@ -151,18 +152,6 @@ def test_style_is_package(tmpdir):
     )
     assert not spack.cmd.style.is_package("lib/spack/spack/spec.py")
     assert not spack.cmd.style.is_package("lib/spack/external/pytest.py")
-
-
-@skip_old_python
-def test_bad_bootstrap(monkeypatch):
-    """Ensure we fail gracefully when we can't bootstrap spack style."""
-    monkeypatch.setattr(spack.cmd.style, "tool_order", [
-        ("isort", "py-isort@4.3:4.0"),  # bad spec to force concretization failure
-    ])
-    # zero out path to ensure we don't find isort
-    with pytest.raises(spack.error.SpackError) as e:
-        style(env={"PATH": ""})
-        assert "Couldn't bootstrap isort" in str(e)
 
 
 @pytest.fixture


### PR DESCRIPTION
Modifications:
- [x] Remove `spack.bootstrap.get_executable` in favor of `spack.bootstrap.ensure_executables_in_path_or_raise` so that executables are always bootstrapped using a single code path.
