### PR TITLE
py-matplotlib: add v3.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-fonttools/package.py
+++ b/var/spack/repos/builtin/packages/py-fonttools/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyFonttools(PythonPackage):
+    """fontTools is a library for manipulating fonts, written in Python.
+
+    The project includes the TTX tool, that can convert TrueType and OpenType fonts to
+    and from an XML text format, which is also called TTX. It supports TrueType,
+    OpenType, AFM and to an extent Type 1 and some Mac-specific formats."""
+
+    homepage = "https://github.com/fonttools/fonttools"
+    pypi     = "fonttools/fonttools-4.28.1.zip"
+
+    version('4.28.1', sha256='8c8f84131bf04f3b1dcf99b9763cec35c347164ab6ad006e18d2f99fcab05529')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-matplotlib/matplotlibrc.patch
+++ b/var/spack/repos/builtin/packages/py-matplotlib/matplotlibrc.patch
@@ -1,0 +1,11 @@
+--- a/setup.py	2021-09-23 23:57:06.000000000 -0500
++++ b/setup.py	2021-11-18 14:29:50.000000000 -0600
+@@ -212,7 +212,7 @@
+         idx for idx, line in enumerate(template_lines)
+         if "#backend:" in line]
+     template_lines[backend_line_idx] = (
+-        "#backend: {}".format(setupext.options["backend"])
++        "#backend: {}\n".format(setupext.options["backend"])
+         if setupext.options["backend"]
+         else "##backend: Agg")
+     path.write_text("".join(template_lines))

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -24,6 +24,7 @@ class PyMatplotlib(PythonPackage):
         'matplotlib.testing.jpl_units', 'pylab'
     ]
 
+    version('3.5.0', sha256='38892a254420d95594285077276162a5e9e9c30b6da08bdc2a4d53331ad9a6fa')
     version('3.4.3', sha256='fc4f526dfdb31c9bd6b8ca06bf9fab663ca12f3ec9cdf4496fb44bc680140318')
     version('3.4.2', sha256='d8d994cefdff9aaba45166eb3de4f5211adb4accac85cbf97137e98f26ea0219')
     version('3.4.1', sha256='84d4c4f650f356678a5d658a43ca21a41fca13f9b8b00169c0b76e6a6a948908')
@@ -84,7 +85,7 @@ class PyMatplotlib(PythonPackage):
     variant('fonts', default=False,
             description='Enable support for system font detection')
 
-    # https://matplotlib.org/users/installing.html#dependencies
+    # https://matplotlib.org/stable/devel/dependencies.html
     # Required dependencies
     extends('python', ignore=r'bin/nosetests.*$|bin/pbr$')
     depends_on('python@2.7:2.8,3.4:', when='@:2', type=('build', 'link', 'run'))
@@ -149,7 +150,7 @@ class PyMatplotlib(PythonPackage):
     depends_on('pkgconfig', type='build')
 
     # Testing dependencies
-    # https://matplotlib.org/devel/testing.html#requirements
+    # https://matplotlib.org/stable/devel/development_setup.html#additional-dependencies-for-testing
     depends_on('py-pytest@3.6:', type='test')
     depends_on('ghostscript@9.0:', type='test')
     # depends_on('inkscape@:0', type='test')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -49,10 +49,6 @@ class PyMatplotlib(PythonPackage):
     version('2.2.2', sha256='4dc7ef528aad21f22be85e95725234c5178c0f938e2228ca76640e5e84d8cde8')
     version('2.0.2', sha256='0ffbc44faa34a8b1704bc108c451ecf87988f900ef7ce757b8e2e84383121ff1')
     version('2.0.0', sha256='36cf0985829c1ab2b8b1dae5e2272e53ae681bf33ab8bedceed4f0565af5f813')
-    version('1.5.3', sha256='a0a5dc39f785014f2088fed2c6d2d129f0444f71afbb9c44f7bdf1b14d86ebbc', deprecated=True)
-    version('1.5.1', sha256='3ab8d968eac602145642d0db63dd8d67c85e9a5444ce0e2ecb2a8fedc7224d40', deprecated=True)
-    version('1.4.3', sha256='61f201c6a82e89e4d9e324266203fad44f95fd8f36d8eec0d8690273e1182f75', deprecated=True)
-    version('1.4.2', sha256='17a3c7154f152d8dfed1f37517c0a8c5db6ade4f6334f684989c36dab84ddb54', deprecated=True)
 
     # https://matplotlib.org/tutorials/introductory/usage.html#backends
     # From `lib/matplotlib/rcsetup.py`:
@@ -184,7 +180,10 @@ class PyMatplotlib(PythonPackage):
 
         backend = self.spec.variants['backend'].value
 
-        with open('setup.cfg', 'w') as setup:
+        # https://github.com/matplotlib/matplotlib/pull/20871
+        setup_file = 'mplsetup.cfg' if self.spec.satisfies('@3.5:') else 'setup.cfg'
+
+        with open(setup_file, 'w') as setup:
             # Default backend
             setup.write('[rc_options]\n')
             setup.write('backend = ' + backend + '\n')

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -163,6 +163,8 @@ class PyMatplotlib(PythonPackage):
 
     conflicts('~image', when='@3.3:', msg='Pillow is no longer an optional dependency')
 
+    # https://github.com/matplotlib/matplotlib/pull/21662
+    patch('matplotlibrc.patch', when='@3.5.0')
     # Patch to pick up correct freetype headers
     patch('freetype-include-path.patch', when='@2.2.2:2.9.9')
 


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.

https://github.com/matplotlib/matplotlib/releases/tag/v3.5.0