### PR TITLE
otf: specify zlib prefix explicitly

### DIFF
--- a/var/spack/repos/builtin/packages/otf/package.py
+++ b/var/spack/repos/builtin/packages/otf/package.py
@@ -14,6 +14,8 @@ class Otf(AutotoolsPackage):
     homepage = "http://tu-dresden.de/die_tu_dresden/zentrale_einrichtungen/zih/forschung/projekte/otf/index_html/document_view?set_language=en"
     url      = "https://wwwpub.zih.tu-dresden.de/%7Emlieber/dcount/dcount.php?package=otf&get=OTF-1.12.5salmon.tar.gz"
 
+    maintainers = ['michaelkuhn']
+
     version('1.12.5salmon', sha256='0a8427360dedb38e8ddca30f14d95f826420c550337c5a79dbb754904e194088')
 
     depends_on('zlib')
@@ -23,7 +25,9 @@ class Otf(AutotoolsPackage):
 
         args.append('--without-mpi')
         args.append('--without-vtf3')
-        args.append('--with-zlib')
-        args.append('--with-zlibsymbols')
         args.append('--without-zoidfs')
+
+        args.append('--with-zlib')
+        args.append('--with-zlib-dir={0}'.format(self.spec['zlib'].prefix))
+
         return args


### PR DESCRIPTION
This causes `otfconfig` to also list zlib's library directory. Otherwise, `-lz` cannot be found. Also remove `--with-zlibsymbols`, which doesn't seem to be supported anymore.