### PR TITLE
Buildcaches: Use full hash as key for buildcache and ci 

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -158,7 +158,7 @@ def get_job_name(phase, strip_compiler, spec, osarch, build_group):
     item_idx += 1
 
     format_str += '/{{{0}}}'.format(item_idx)
-    format_args.append(spec.dag_hash(7))
+    format_args.append(spec.full_hash(7))
     item_idx += 1
 
     format_str += ' {{{0}}}'.format(item_idx)
@@ -208,7 +208,7 @@ def format_root_spec(spec, main_phase, strip_compiler):
 
 
 def spec_deps_key(s):
-    return '{0}/{1}'.format(s.name, s.dag_hash(7))
+    return '{0}/{1}'.format(s.name, s.full_hash(7))
 
 
 def _add_dependency(spec_label, dep_label, deps):

--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -350,9 +350,12 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False,
         matches = []
         tty.msg("buildcache spec(s) matching %s \n" % pkg)
         for spec in sorted(specs):
+            tty.msg('  checking {0}'.format(spec.name))
             if pkg.startswith('/'):
                 pkghash = pkg.replace('/', '')
-                if spec.dag_hash().startswith(pkghash):
+                if spec._full_hash.startswith(pkghash):
+                    matches.append(spec)
+                elif spec.dag_hash().startswith(pkghash):
                     matches.append(spec)
             else:
                 if spec.satisfies(pkg):
@@ -919,7 +922,7 @@ def buildcache_sync(args):
     tty.debug('Syncing the following specs:')
     for s in env.all_specs():
         tty.debug('  {0}{1}: {2}'.format(
-            '* ' if s in env.roots() else '  ', s.name, s.dag_hash()))
+            '* ' if s in env.roots() else '  ', s.name, s.full_hash()))
 
         buildcache_rel_paths.extend([
             os.path.join(

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -225,7 +225,8 @@ def do_uninstall(env, specs, force):
         is_ready = lambda x: True
 
     while packages:
-        ready = [x for x in packages if is_ready(x.spec.dag_hash())]
+        ready = [x for x in packages if is_ready(
+            x.spec._cached_hash(hash=spack.store.db.key_hash_type))]
         if not ready:
             msg = 'unexpected error [cannot proceed uninstalling specs with' \
                   ' remaining dependents {0}]'

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -754,6 +754,8 @@ class Database(object):
         except Exception as e:
             raise CorruptDatabaseError("error parsing database:", str(e))
 
+        tty.msg('Database reading from {0}'.format(filename))
+
         if fdata is None:
             return
 

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -320,7 +320,7 @@ class DirectoryLayout(object):
             return spec.external_path
         if self.check_upstream:
             upstream, record = spack.store.db.query_by_spec_hash(
-                spec.dag_hash())
+                spec._cached_hash(hash=spack.store.db.key_hash_type))
             if upstream:
                 raise SpackError(
                     "Internal error: attempted to call path_for_spec on"

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1423,7 +1423,8 @@ class Environment(object):
 
         # if it is a direct dev build, check whether the code changed
         # we already know it is installed
-        _, record = spack.store.db.query_by_spec_hash(spec.dag_hash())
+        _, record = spack.store.db.query_by_spec_hash(
+            spec._cached_hash(hash=spack.store.db.key_hash_type))
         mtime = fs.last_modification_time_recursive(dev_path_var.value)
         return mtime > record.installation_time
 

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -381,7 +381,8 @@ def get_module(
     try:
         upstream = spec.package.installed_upstream
     except spack.repo.UnknownPackageError:
-        upstream, record = spack.store.db.query_by_spec_hash(spec.dag_hash())
+        upstream, record = spack.store.db.query_by_spec_hash(
+            spec._cached_hash(hash=spack.store.db.key_hash_type))
     if upstream:
         module = (spack.modules.common.upstream_module_index
                   .upstream_module(spec, module_type))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -725,7 +725,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     def installed_upstream(self):
         if not hasattr(self, '_installed_upstream'):
             upstream, record = spack.store.db.query_by_spec_hash(
-                self.spec.dag_hash())
+                self.spec._cached_hash(hash=spack.store.db.key_hash_type))
             self._installed_upstream = upstream
 
         return self._installed_upstream

--- a/lib/spack/spack/schema/database_index.py
+++ b/lib/spack/spack/schema/database_index.py
@@ -52,6 +52,7 @@ schema = {
                     },
                 },
                 'version': {'type': 'string'},
+                'key_hash_type': {'type': 'string'}
             }
         },
     },

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1497,7 +1497,7 @@ class Spec(object):
 
         if self._prefix is None:
             upstream, record = spack.store.db.query_by_spec_hash(
-                self.dag_hash())
+                self._cached_hash(hash=spack.store.db.key_hash_type))
             if record and record.path:
                 self.prefix = record.path
             else:
@@ -1585,7 +1585,11 @@ class Spec(object):
 
     def dag_hash_bit_prefix(self, bits):
         """Get the first <bits> bits of the DAG hash as an integer type."""
-        return spack.util.hash.base32_prefix_bits(self.dag_hash(), bits)
+        return self.hash_bit_prefix(bits, hash=ht.dag_hash)
+
+    def hash_bit_prefix(self, bits, hash=ht.dag_hash):
+        return spack.util.hash.base32_prefix_bits(
+            self._cached_hash(hash=hash), bits)
 
     def to_node_dict(self, hash=ht.dag_hash):
         """Create a dictionary representing the state of this Spec.
@@ -2585,7 +2589,8 @@ class Spec(object):
         deprecated = []
         with spack.store.db.read_transaction():
             for x in root.traverse():
-                _, rec = spack.store.db.query_by_spec_hash(x.dag_hash())
+                _, rec = spack.store.db.query_by_spec_hash(
+                    x._cached_hash(hash=spack.store.db.key_hash_type))
                 if rec and rec.deprecated_for:
                     deprecated.append(rec)
         if deprecated:

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -254,7 +254,9 @@ def test_default_rpaths_install_nondefault_layout(mirror_dir):
 
     # Install some packages with dependent packages
     # test install in non-default install path scheme
-    buildcache_cmd('install', '-au', cspec.name, sy_spec.name)
+    op = buildcache_cmd('install', '-au', cspec.name, sy_spec.name, fail_on_error=False, output=str)
+    print('spack buildcache install -au {0} {1}'.format(cspec.name, sy_spec.name))
+    print(op)
 
     # Test force install in non-default install path scheme
     buildcache_cmd('install', '-auf', cspec.name)
@@ -583,7 +585,9 @@ def test_update_sbang(tmpdir, test_mirror):
         assert new_spec.dag_hash() == old_spec.dag_hash()
 
         # Install package from buildcache
-        buildcache_cmd('install', '-a', '-u', '-f', new_spec.name)
+        outie = buildcache_cmd('install', '-a', '-u', '-f', new_spec.name, fail_on_error=False, output=str)
+        print('spack buildcache install -a -u -f {0}'.format(new_spec.name))
+        print(outie)
 
         # Continue blowing away caches
         bindist.clear_spec_cache()
@@ -615,9 +619,10 @@ def test_update_sbang(tmpdir, test_mirror):
 # Need one where the platform has been changed to the test platform.
 def test_install_legacy_yaml(test_legacy_mirror, install_mockery_mutable_config,
                              mock_packages):
-    install_cmd('--no-check-signature', '--cache-only', '-f', legacy_mirror_dir
+    oup = install_cmd('--no-check-signature', '--cache-only', '-f', legacy_mirror_dir
                 + '/build_cache/test-debian6-core2-gcc-4.5.0-zlib-' +
-                '1.2.11-t5mczux3tfqpxwmg7egp7axy2jvyulqk.spec.yaml')
+                '1.2.11-t5mczux3tfqpxwmg7egp7axy2jvyulqk.spec.yaml', fail_on_error=False, output=str)
+    print(oup)
     uninstall_cmd('-y', '/t5mczux3tfqpxwmg7egp7axy2jvyulqk')
 
 

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1061,6 +1061,8 @@ def test_cache_install_full_hash_match(
     # Check that even if the full hash changes, we install from binary when
     # we don't explicitly require the full hash to match
     install_output = install('--no-check-signature', s.name, output=str)
+    print("spack install --no-check-signature {0}".format(s.name))
+    print(install_output)
     assert expect_extract_msg in install_output
 
     uninstall('-y', s.name)

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -32,6 +32,7 @@ import spack.config
 import spack.database
 import spack.directory_layout
 import spack.environment as ev
+import spack.hash_types as ht
 import spack.package
 import spack.package_prefs
 import spack.paths
@@ -836,10 +837,15 @@ def install_mockery(temporary_store, config, mock_packages):
 
 
 @pytest.fixture(scope='function')
-def temporary_store(tmpdir):
+def temporary_store(tmpdir, request):
     """Hooks a temporary empty store for the test function."""
+    hash_type = ht.dag_hash
+    if request and hasattr(request, 'param'):
+        hash_type = request.param
+
     temporary_store_path = tmpdir.join('opt')
-    with spack.store.use_store(str(temporary_store_path)) as s:
+    store = spack.store.Store(str(temporary_store_path), db_key_hash_type=hash_type)
+    with spack.store.use_store(store) as s:
         yield s
     temporary_store_path.remove()
 


### PR DESCRIPTION
This PR changes spack to use the full hash as the key for binary mirrors (and, as such, requires #26952), while continuing to use the DAG hash as the key for installs.  

Some expected benefits of using the full hash to key buildcaches:

- There's a one-to-many relationship between DAG hash and full hashes, so before this change, only one of those full hashes could be present in a binary mirror at one time.
- Keying buildcaches by full hash will remove need to splice `spec.json` files in the process of updating a buildcache index, speeding up the process and making it less error-prone.

Some questions/issues raised by this PR:

- [ ] What's the best way to handle (or not) backwards compatibility with buildcaches generated by older spacks, e.g.:
  * [ ] We need to figure out what to do about bootstrapping mirrors, which currently contain binaries using the DAG hash (file naming and in the index), and #26952 makes it an error if spack encounters a buildcache index keyed by DAG hash.
  * [ ] Also, gitlab pipelines using this branch fail on existing binary mirrors due to above issue.
- [ ] With this change, we will no longer be able to support users *not* providing `--require-full-hash-match` in the same way we supported before, unless the mirror containing the target binary pkg has an index.  To be clear, this is the case where you would otherwise be satisfied with only the DAG hash matching, and would not want to constrain the installation further by insisting on full hash match.  We have ensured this functionality is preserved by testing it with  `lib/spack/spack/test/cmd/install.py::test_cache_install_full_hash_match`, which is now failing.  