### PR TITLE
Make _enable_or_disable(...) return an empty array for conditional variants whose condition is not met

### DIFF
--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -420,6 +420,24 @@ Or when one variant controls multiple flags:
    config_args += self.with_or_without('memchecker', variant='debug_tools')
    config_args += self.with_or_without('profiler', variant='debug_tools')
 
+
+""""""""""""""""""""
+Conditional variants
+""""""""""""""""""""
+
+When a variant is conditional and its condition is not met on the concrete spec, the
+``with_or_without`` and ``enable_or_disable`` methods will simply return an empty list.
+
+For example:
+
+.. code-block:: python
+
+   variant('profiler', when='@2.0:')
+   config_args += self.with_or_without('profiler)
+
+will neither add ``--with-profiler`` nor ``--without-profiler`` when the version is
+below ``2.0``.
+
 """"""""""""""""""""
 Activation overrides
 """"""""""""""""""""

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -498,6 +498,9 @@ To resolve this problem, please try the following:
 
             for ``<spec-name> foo=x +bar``
 
+        Note: returns an empty list when the variant is conditional and its condition
+              is not met.
+
         Returns:
             list: list of strings that corresponds to the activation/deactivation
             of the variant that has been processed
@@ -518,6 +521,9 @@ To resolve this problem, please try the following:
         if variant not in self.variants:
             msg = '"{0}" is not a variant of "{1}"'
             raise KeyError(msg.format(variant, self.name))
+
+        if variant not in spec.variants:
+            return []
 
         # Create a list of pairs. Each pair includes a configuration
         # option and whether or not that option is activated

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -437,3 +437,11 @@ def test_cmake_define_from_variant_conditional(config, mock_packages):
     s = Spec('cmake-conditional-variants-test').concretized()
     assert 'example' not in s.variants
     assert s.package.define_from_variant('EXAMPLE', 'example') == ''
+
+
+def test_autotools_args_from_conditional_variant(config, mock_packages):
+    """Test that _activate_or_not returns an empty string when a condition on a variant
+    is not met. When this is the case, the variant is not set in the spec."""
+    s = Spec('autotools-conditional-variants-test').concretized()
+    assert 'example' not in s.variants
+    assert len(s.package._activate_or_not('example', 'enable', 'disable')) == 0

--- a/var/spack/repos/builtin.mock/packages/autotools-conditional-variants-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/autotools-conditional-variants-test/package.py
@@ -1,0 +1,11 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class AutotoolsConditionalVariantsTest(AutotoolsPackage):
+    homepage = "https://www.example.com"
+    has_code = False
+    version('1.0')
+    variant('example', default=True, description='nope', when='@2.0:')


### PR DESCRIPTION
Solves #27494 for Autotools
