### PR TITLE
Improve Racket package features + build performance

### DIFF
--- a/var/spack/repos/builtin/packages/racket/package.py
+++ b/var/spack/repos/builtin/packages/racket/package.py
@@ -42,7 +42,7 @@ class Racket(Package):
             configure_args = [self.toggle(spec, 'cs'),
                               self.toggle(spec, 'bc'),
                               self.toggle(spec, 'jit')]
-            toggle_shared = self.toggle(spec,'shared')
+            toggle_shared = self.toggle(spec, 'shared')
             if sys.platform == 'darwin':
                 configure_args += ["--enable-macprefix"]
                 if "+xonx" in spec:

--- a/var/spack/repos/builtin/packages/racket/package.py
+++ b/var/spack/repos/builtin/packages/racket/package.py
@@ -30,6 +30,7 @@ class Racket(Package):
     variant('jit', default=True, description="Just-in-Time Compilation")
 
     parallel = False
+    extendable = True
 
     def toggle(self, spec, variant):
         toggle_text = ("enable" if spec.variants[variant].value else "disable")

--- a/var/spack/repos/builtin/packages/racket/package.py
+++ b/var/spack/repos/builtin/packages/racket/package.py
@@ -11,27 +11,58 @@ class Racket(Package):
 
     homepage = "https://www.racket-lang.org"
 
-    maintainers = ['arjunguha']
+    maintainers = ['arjunguha','elfprince13']
 
-    version('8.3.0', 'c4af1a10b957e5fa0daac2b5ad785cda79805f76d11482f550626fa68f07b949')
+    version('8.3','3b963cd29ae119e1acc2c6dc4781bd9f25027979589caaae3fdfc021aac2324b')
 
     depends_on('libffi', type=('build', 'link', 'run'))
     depends_on('patchutils')
+    depends_on('libtool',type=('build'))
 
     phases = ['configure', 'build', 'install']
 
     def url_for_version(self, version):
-        url = "http://mirror.racket-lang.org/installers/{0}/racket-src.tgz"
-        return url.format(version.up_to(2))
+        return "https://mirror.racket-lang.org/installers/{0}/racket-minimal-{0}-src-builtpkgs.tgz".format(version)
 
+
+    variant('cs', default=True, description='Build Racket CS (new ChezScheme VM)')
+    variant('bc', default=False, description='Build Racket BC (old MZScheme VM)')
+    variant('shared', default=True, description="Enable shared")
+    variant('jit', default=True, description="Just-in-Time Compilation")
+
+    parallel = False
+
+    def toggle(self, spec, variant):
+        print("{0}? {1}".format(variant, spec.variants[variant].value))
+        return "--{0}-{1}".format(("enable" if spec.variants[variant].value else "disable"), variant)
+    
     def configure(self, spec, prefix):
         with working_dir('src'):
-            configure = Executable('./configure')
-            configure("--prefix", prefix)
-
+            configure = Executable("./configure")
+            configure_args = [self.toggle(spec, 'cs'), self.toggle(spec, 'bc'), self.toggle(spec, 'jit')]
+            toggle_shared = self.toggle(spec,'shared')
+            if sys.platform == 'darwin':
+                configure_args += ["--enable-macprefix"]
+                if "+xonx" in spec:
+                    configure_args += ["--enable-xonx", toggle_shared]
+            else:
+                configure_args += [toggle_shared]
+            configure_args += ["--prefix={0}".format(prefix)]
+            configure(*configure_args)
+    
     def build(self, spec, prefix):
         with working_dir('src'):
-            make()
+            if spec.variants["bc"].value:
+                make("bc")
+            if spec.variants["cs"].value:
+                make("cs")
+
+    def install(self, spec, prefix):
+        with working_dir('src'):
+            if spec.variants["bc"].value:
+                make('install-bc')
+            if spec.variants["cs"].value:
+                make('install-cs')
 
     def install(self, spec, prefix):
         with working_dir('src'):

--- a/var/spack/repos/builtin/packages/racket/package.py
+++ b/var/spack/repos/builtin/packages/racket/package.py
@@ -63,7 +63,3 @@ class Racket(Package):
                 make('install-bc')
             if spec.variants["cs"].value:
                 make('install-cs')
-
-    def install(self, spec, prefix):
-        with working_dir('src'):
-            make('install')

--- a/var/spack/repos/builtin/packages/racket/package.py
+++ b/var/spack/repos/builtin/packages/racket/package.py
@@ -11,19 +11,18 @@ class Racket(Package):
 
     homepage = "https://www.racket-lang.org"
 
-    maintainers = ['arjunguha','elfprince13']
+    maintainers = ['arjunguha', 'elfprince13']
 
-    version('8.3','3b963cd29ae119e1acc2c6dc4781bd9f25027979589caaae3fdfc021aac2324b')
+    version('8.3', '3b963cd29ae119e1acc2c6dc4781bd9f25027979589caaae3fdfc021aac2324b')
 
     depends_on('libffi', type=('build', 'link', 'run'))
     depends_on('patchutils')
-    depends_on('libtool',type=('build'))
+    depends_on('libtool', type=('build'))
 
     phases = ['configure', 'build', 'install']
 
     def url_for_version(self, version):
         return "https://mirror.racket-lang.org/installers/{0}/racket-minimal-{0}-src-builtpkgs.tgz".format(version)
-
 
     variant('cs', default=True, description='Build Racket CS (new ChezScheme VM)')
     variant('bc', default=False, description='Build Racket BC (old MZScheme VM)')
@@ -33,13 +32,15 @@ class Racket(Package):
     parallel = False
 
     def toggle(self, spec, variant):
-        print("{0}? {1}".format(variant, spec.variants[variant].value))
-        return "--{0}-{1}".format(("enable" if spec.variants[variant].value else "disable"), variant)
-    
+        toggle_text = ("enable" if spec.variants[variant].value else "disable")
+        return "--{0}-{1}".format(toggle_text, variant)
+
     def configure(self, spec, prefix):
         with working_dir('src'):
             configure = Executable("./configure")
-            configure_args = [self.toggle(spec, 'cs'), self.toggle(spec, 'bc'), self.toggle(spec, 'jit')]
+            configure_args = [self.toggle(spec, 'cs'),
+                              self.toggle(spec, 'bc'),
+                              self.toggle(spec, 'jit')]
             toggle_shared = self.toggle(spec,'shared')
             if sys.platform == 'darwin':
                 configure_args += ["--enable-macprefix"]
@@ -49,7 +50,7 @@ class Racket(Package):
                 configure_args += [toggle_shared]
             configure_args += ["--prefix={0}".format(prefix)]
             configure(*configure_args)
-    
+
     def build(self, spec, prefix):
         with working_dir('src'):
             if spec.variants["bc"].value:


### PR DESCRIPTION
Make a number of changes:
- Add variants for various common build flags, including support for both versions of the Racket VM environment.
- Prevent `-j` flags to `make`, which has been known to cause problems with Racket builds.
- Prefer the minimal release to improve install times. Bells and whistles carry their own runtime dependencies and should be installed via `raco`. An enterprising user may even create a `RacoPackage` class to make spack aware of `raco` installed packages.
- Match the official version numbering scheme.

Discussed these changes with @arjunguha on Slack.