### PR TITLE
Allow blas symbol suffix in suite-sparse

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -70,6 +70,30 @@ class SuiteSparse(Package):
 
     conflicts('%gcc@:4.8', when='@5.2.0:', msg='gcc version must be at least 4.9 for suite-sparse@5.2.0:')
 
+    def symbol_suffix_blas(self, spec, args):
+        """When using BLAS with a special symbol suffix we use defines to
+        replace blas symbols, e.g. dgemm_ becomes dgemm_64_ when
+        symbol_suffix=64_."""
+
+        # Currently only OpenBLAS does this.
+        if not spec.satisfies('^openblas'):
+            return
+
+        suffix = spec['openblas'].variants['symbol_suffix'].value
+        if suffix == 'none':
+            return
+
+        symbols = (
+            'dtrsv_', 'dgemv_', 'dtrsm_', 'dgemm_', 'dsyrk_', 'dger_', 'dscal_',
+            'dpotrf_', 'ztrsv_', 'zgemv_', 'ztrsm_', 'zgemm_', 'zherk_',
+            'zgeru_', 'zscal_', 'zpotrf_',
+            'dnrm2_', 'dlarf_', 'dlarfg_', 'dlarft_', 'dlarfb_', 'dznrm2_',
+            'zlarf_', 'zlarfg_', 'zlarft_', 'zlarfb_'
+        )
+
+        for symbol in symbols:
+            args.append('CFLAGS+=-D{0}={1}{2}'.format(symbol, symbol, suffix))
+
     def install(self, spec, prefix):
         # The build system of SuiteSparse is quite old-fashioned.
         # It's basically a plain Makefile which include an header
@@ -124,6 +148,9 @@ class SuiteSparse(Package):
             spec.satisfies('^intel-mkl+ilp64') or
             spec.satisfies('^intel-parallel-studio+mkl+ilp64')):
             make_args.append('UMFPACK_CONFIG=-DLONGBLAS="long long"')
+
+        # Handle symbol suffix of some BLAS'es (e.g. 64_ or _64 for ilp64)
+        self.symbol_suffix_blas(spec, make_args)
 
         # SuiteSparse defaults to using '-fno-common -fexceptions' in
         # CFLAGS, but not all compilers use the same flags for these


### PR DESCRIPTION
Make suite-sparse work when a symbol suffix is set in openblas through defines `-Ddgemm_=dgemm_<suffix>` etc.
