### PR TITLE
Add Clingo v5.5.1

### DIFF
--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -26,6 +26,7 @@ class Clingo(CMakePackage):
     version('master', branch='master', submodules=True)
     version('spack', commit='2a025667090d71b2c9dce60fe924feb6bde8f667', submodules=True)
 
+    version('5.5.1', sha256='b9cf2ba2001f8241b8b1d369b6f353e628582e2a00f13566e51c03c4dd61f67e')
     version('5.5.0', sha256='c9d7004a0caec61b636ad1c1960fbf339ef8fdee9719321fc1b6b210613a8499')
     version('5.4.1', sha256='ac6606388abfe2482167ce8fd4eb0737ef6abeeb35a9d3ac3016c6f715bfee02')
     version('5.4.0', sha256='e2de331ee0a6d254193aab5995338a621372517adcf91568092be8ac511c18f3')


### PR DESCRIPTION
Add Clingo v5.5.1 which includes multiple new features and performance improvements.

**Changelog:**
- extend theory class to get version information
- improve performance of Model.symbol
- tidy up clingo.hh header regarding C++17 deprecations
- fix error handling while solving in Python API
- fix various other bugs

Changelog can be found [here](https://github.com/potassco/clingo/releases/tag/v5.5.1).

**Test Plan:**
Clingo v5.5.1 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/actions/runs/1467454929). 