### PR TITLE
Add Htslib v1.14, Samtools v1.14, and Bcftools v1.14

### DIFF
--- a/var/spack/repos/builtin/packages/bcftools/package.py
+++ b/var/spack/repos/builtin/packages/bcftools/package.py
@@ -13,6 +13,8 @@ class Bcftools(AutotoolsPackage):
     homepage = "https://samtools.github.io/bcftools/"
     url      = "https://github.com/samtools/bcftools/releases/download/1.3.1/bcftools-1.3.1.tar.bz2"
 
+    version('1.14', sha256='b7ef88ae89fcb55658c5bea2e8cb8e756b055e13860036d6be13756782aa19cb')
+    version('1.13', sha256='13bfa1da2a5edda8fa51196a47a0b4afb3fef17516451e4f0e78477f3dd30b90')
     version('1.12', sha256='7a0e6532b1495b9254e38c6698d955e5176c1ee08b760dfea2235ee161a024f5')
     version('1.10.2', sha256='f57301869d0055ce3b8e26d8ad880c0c1989bf25eaec8ea5db99b60e31354e2c')
     version('1.9', sha256='6f36d0e6f16ec4acf88649fb1565d443acf0ba40f25a9afd87f14d14d13070c8')
@@ -38,6 +40,8 @@ class Bcftools(AutotoolsPackage):
     depends_on('perl', when='@1.8:~perl-filters', type='run')
     depends_on('perl', when='@1.8:+perl-filters', type=('build', 'run'))
 
+    depends_on('htslib@1.14', when='@1.14')
+    depends_on('htslib@1.13', when='@1.13')
     depends_on('htslib@1.12', when='@1.12')
     depends_on('htslib@1.10.2', when='@1.10.2')
     depends_on('htslib@1.9', when='@1.9')

--- a/var/spack/repos/builtin/packages/htslib/package.py
+++ b/var/spack/repos/builtin/packages/htslib/package.py
@@ -12,6 +12,7 @@ class Htslib(AutotoolsPackage):
     homepage = "https://github.com/samtools/htslib"
     url      = "https://github.com/samtools/htslib/releases/download/1.13/htslib-1.13.tar.bz2"
 
+    version('1.14', sha256='ed221b8f52f4812f810eebe0cc56cd8355a5c9d21c62d142ac05ad0da147935f')
     version('1.13', sha256='f2407df9f97f0bb6b07656579e41a1ca5100464067b6b21bf962a2ea4b0efd65')
     version('1.12', sha256='2280141b46e953ba4ae01b98335a84f8e6ccbdb6d5cdbab7f70ee4f7e3b6f4ca')
     version('1.10.2', sha256='e3b543de2f71723830a1e0472cf5489ec27d0fbeb46b1103e14a11b7177d1939')

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -14,6 +14,7 @@ class Samtools(Package):
     homepage = "https://www.htslib.org"
     url      = "https://github.com/samtools/samtools/releases/download/1.13/samtools-1.13.tar.bz2"
 
+    version('1.14', sha256='9341dabaa98b0ea7d60fd47e42af25df43a7d3d64d8e654cdf852974546b7d74')
     version('1.13', sha256='616ca2e051cc8009a1e9c01cfd8c7caf8b70916ddff66f3b76914079465f8c60')
     version('1.12', sha256='6da3770563b1c545ca8bdf78cf535e6d1753d6383983c7929245d5dba2902dcb')
     version('1.10', sha256='7b9ec5f05d61ec17bd9a82927e45d8ef37f813f79eb03fe06c88377f1bd03585')
@@ -34,6 +35,7 @@ class Samtools(Package):
     depends_on('python', type='run')
 
     # htslib became standalone @1.3.1, must use corresponding version
+    depends_on('htslib@1.14', when='@1.14')
     depends_on('htslib@1.13', when='@1.13')
     depends_on('htslib@1.12', when='@1.12')
     depends_on('htslib@1.11', when='@1.11')


### PR DESCRIPTION
Add Htslib v1.14, Samtools v1.14, and Bcftools v1.14 which include multiple bug fixes and new features.

**Changelog:**
Full changelog for Htslib v1.14 can be found [here](https://github.com/samtools/htslib/releases/tag/1.14).
Full changelog for Samtools v1.14 can be found [here](https://github.com/samtools/samtools/releases/tag/1.14).
Full changelog for Bcftools v1.14 can be found [here](https://github.com/samtools/bcftools/releases/tag/1.14).

**Test Plan:**
Htslib v1.14 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/actions/runs/1372645144).
Samtools v1.14 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/actions/runs/1373177328).
Bcftools v1.14 built successfully within the Autamus Workflow [here](https://github.com/autamus/registry/actions/runs/1473163899).