### PR TITLE
py-ply: get sources from pypi

### DIFF
--- a/var/spack/repos/builtin/packages/py-ply/package.py
+++ b/var/spack/repos/builtin/packages/py-ply/package.py
@@ -7,9 +7,10 @@ from spack import *
 
 
 class PyPly(PythonPackage):
-    """PLY is nothing more than a straightforward lex/yacc implementation."""
+    """Python Lex & Yacc."""
+
     homepage = "http://www.dabeaz.com/ply"
-    url      = "https://www.dabeaz.com/ply/ply-3.11.tar.gz"
+    pypi = "ply/ply-3.11.tar.gz"
 
     version('3.11', sha256='00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3')
     version('3.8', sha256='e7d1bdff026beb159c9942f7a17e102c375638d9478a7ecd4cc0c76afd8de0b8')

--- a/var/spack/repos/builtin/packages/py-ply/package.py
+++ b/var/spack/repos/builtin/packages/py-ply/package.py
@@ -14,3 +14,5 @@ class PyPly(PythonPackage):
 
     version('3.11', sha256='00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3')
     version('3.8', sha256='e7d1bdff026beb159c9942f7a17e102c375638d9478a7ecd4cc0c76afd8de0b8')
+
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
This also removes problems with the SSL certificate from the original url:

```
$ spack versions py-ply
==> Safe versions (already checksummed):
  3.11  3.8
==> Warning: Spack was unable to fetch url list due to a certificate verification problem. You can try running spack -k, which will not check SSL certificates. Use this at your own risk.
==> Warning: Spack was unable to fetch url list due to a certificate verification problem. You can try running spack -k, which will not check SSL certificates. Use this at your own risk.
==> Remote versions (not yet checksummed):
==> Warning: Found no unchecksummed versions for py-ply
```