### PR TITLE
[acts] Support v15, embrace conditional variants

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -39,6 +39,7 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version('main', branch='main')
     version('master', branch='main', deprecated=True)  # For compatibility
+    version('15.0.0', commit='0fef9e0831a90e946745390882aac871b211eaac', submodules=True)
     version('14.1.0', commit='e883ab6acfe5033509ad1c27e8e2ba980dfa59f6', submodules=True)
     version('14.0.0', commit='f902bef81b60133994315c13f7d32d60048c79d8', submodules=True)
     version('13.0.0', commit='ad05672e48b693fd37156f1ad62ed57aa82f858c', submodules=True)

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -112,7 +112,7 @@ class Acts(CMakePackage, CudaPackage):
 
     # Variants that affect the core Acts library
     variant('benchmarks', default=False, description='Build the performance benchmarks', when='@0.16:')
-    variant('examples', default=False, description='Build the examples', when='@:0.23: +digitization +fatras +identification +json +tgeo')
+    variant('examples', default=False, description='Build the examples', when='@0.23: +digitization +fatras +identification +json +tgeo')
     variant('integration_tests', default=False, description='Build the integration tests')
     variant('unit_tests', default=False, description='Build the unit tests')
     variant('log_failure_threshold', default='MAX', description='Log level above which examples should auto-crash')

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -111,31 +111,31 @@ class Acts(CMakePackage, CudaPackage):
     version('0.08.0', commit='99eedb38f305e3a1cd99d9b4473241b7cd641fa9')
 
     # Variants that affect the core Acts library
-    variant('benchmarks', default=False, description='Build the performance benchmarks')
-    variant('examples', default=False, description='Build the examples')
+    variant('benchmarks', default=False, description='Build the performance benchmarks', when='@0.16:')
+    variant('examples', default=False, description='Build the examples', when='@:0.23: +digitization +fatras +identification +json +tgeo')
     variant('integration_tests', default=False, description='Build the integration tests')
     variant('unit_tests', default=False, description='Build the unit tests')
     variant('log_failure_threshold', default='MAX', description='Log level above which examples should auto-crash')
 
     # Variants that enable / disable Acts plugins
-    variant('autodiff', default=False, description='Build the auto-differentiation plugin')
-    variant('dd4hep', default=False, description='Build the DD4hep plugin')
+    variant('autodiff', default=False, description='Build the auto-differentiation plugin', when='@1.2:')
+    variant('dd4hep', default=False, description='Build the DD4hep plugin', when='+tgeo')
     variant('digitization', default=False, description='Build the geometric digitization plugin')
-    variant('fatras', default=False, description='Build the FAst TRAcking Simulation package')
+    variant('fatras', default=False, description='Build the FAst TRAcking Simulation package', when='@0.16:')
     variant('fatras_geant4', default=False, description='Build Geant4 Fatras package')
     variant('identification', default=False, description='Build the Identification plugin')
     variant('json', default=False, description='Build the Json plugin')
     variant('legacy', default=False, description='Build the Legacy package')
     # FIXME: Cannot build ONNX plugin as Spack doesn't have an ONNX runtime
     # FIXME: Cannot build SyCL plugin yet as Spack doesn't have SyCL support
-    variant('tgeo', default=False, description='Build the TGeo plugin')
-    variant('alignment', default=False, description='Build the alignment package')
+    variant('tgeo', default=False, description='Build the TGeo plugin', when='+identification')
+    variant('alignment', default=False, description='Build the alignment package', when='@13:')
 
     # Variants that only affect Acts examples for now
-    variant('geant4', default=False, description='Build the Geant4-based examples')
-    variant('hepmc3', default=False, description='Build the HepMC3-based examples')
-    variant('pythia8', default=False, description='Build the Pythia8-based examples')
-    variant('python', default=False, description='Build python bindings for the examples')
+    variant('geant4', default=False, description='Build the Geant4-based examples', when='@0.23: +examples')
+    variant('hepmc3', default=False, description='Build the HepMC3-based examples', when='@0.23: +examples')
+    variant('pythia8', default=False, description='Build the Pythia8-based examples', when='@0.23: +examples')
+    variant('python', default=False, description='Build python bindings for the examples', when='@14: +examples')
     variant('analysis', default=False, description='Build analysis applications in the examples')
 
     # Build dependencies
@@ -160,27 +160,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on('root @6.10: cxxstd=14', when='+tgeo @:0.8.0')
     depends_on('root @6.20: cxxstd=17', when='+tgeo @0.8.1:')
 
-    # Some variant combinations do not make sense
-    conflicts('+autodiff', when='@:1.01')
-    conflicts('+benchmarks', when='@:0.15')
-    conflicts('+dd4hep', when='-tgeo')
-    conflicts('+examples', when='@:0.22')
-    conflicts('+examples', when='-digitization')
-    conflicts('+examples', when='-fatras')
-    conflicts('+examples', when='-identification')
-    conflicts('+examples', when='-json')
-    conflicts('+examples', when='-tgeo')
-    conflicts('+fatras', when='@:0.15')
-    conflicts('+geant4', when='@:0.22')
-    conflicts('+geant4', when='-examples')
-    conflicts('+hepmc3', when='@:0.22')
-    conflicts('+hepmc3', when='-examples')
-    conflicts('+pythia8', when='@:0.22')
-    conflicts('+pythia8', when='-examples')
-    conflicts('+python', when='@:13')
-    conflicts('+python', when='-examples')
-    conflicts('+tgeo', when='-identification')
-    conflicts('+alignment', when='@:12')
+    # ACTS has been using C++17 for a while, which precludes use of old GCC
     conflicts('%gcc@:7', when='@0.23:')
 
     def cmake_args(self):


### PR DESCRIPTION
This PR adds support for ACTS v15 and leverages Spack's new conditional variant mechanism to greatly reduce the number of conflict statements (which were formerly used to encode "this variant exists since ACTS version N" and "variant X depends on variant Y" facts).

~~I'll keep it as a draft while it's undergoing a test build, and if it builds on my side I think it's good to go.~~

@wdconinc FYI.