### PR TITLE
Add wi4mpi recipe

### DIFF
--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -50,19 +50,6 @@ class Wi4mpi(CMakePackage):
     def setup_run_environment(self, env):
         env.set('WI4MPI_ROOT', self.prefix)
         env.set('WI4MPI_VERSION', self.version)
-        if '%gcc' in self.spec:
-            env.set('WI4MPI_CC', "gcc")
-            env.set('WI4MPI_CXX', "g++")
-            env.set('WI4MPI_FC', "gfortran")
-        elif '%intel' in self.spec:
-            env.set('WI4MPI_CC', "icc")
-            env.set('WI4MPI_CXX', "icpc")
-            env.set('WI4MPI_FC', "ifort")
-        elif '%clang' in self.spec:
-            env.set('WI4MPI_CC', "clang")
-            env.set('WI4MPI_CXX', "clang++")
-            env.set('WI4MPI_FC', "flang")
-        elif '%pgi' in self.spec:
-            env.set('WI4MPI_CC', "pgcc")
-            env.set('WI4MPI_CXX', "pgc++")
-            env.set('WI4MPI_FC', "pgfortran")
+        env.set('WI4MPI_CC', self.compiler.cc)
+        env.set('WI4MPI_CXX', self.compiler.cxx)
+        env.set('WI4MPI_FC', self.compiler.fc)

--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -41,8 +41,10 @@ class Wi4mpi(CMakePackage):
             wi4mpi_build_type = 'NORMAL'
         elif self.spec.variants["build_type"].value == "Debug":
             wi4mpi_build_type = 'DEBUG'
-        args = ["-DWI4MPI_REALEASE=" + wi4mpi_build_type,
-                "-DWI4MPI_COMPILER=" + compiler]
+        args = [
+            self.define('WI4MPI_REALEASE', wi4mpi_build_type),
+            self.define('WI4MPI_COMPILER', compiler)
+        ]
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -3,14 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack import *
-from spack.util.environment import set_env
 
 
 class Wi4mpi(CMakePackage):
-    """WI4MPI: Wrapper Interface For MPI performing a light translation between MPI constants and MPI objects from an MPI implementation to another one"""
+    """WI4MPI: Wrapper Interface For MPI performing a light translation between MPI constants 
+    and MPI objects from an MPI implementation to another one"""
 
     homepage = "https://github.com/cea-hpc/wi4mpi"
     url      = "https://github.com/cea-hpc/wi4mpi/archive/v3.4.1.tar.gz"
@@ -22,8 +20,8 @@ class Wi4mpi(CMakePackage):
     version('3.2.1', sha256='0d928cb930b6cb1ae648eca241db59812ee0e5c041faf2f57728bbb6ee4e36df')
     version('3.2.0', sha256='3322f6823dbec1d58a1fcf163b2bcdd7b9cd75dc6c7f78865fc6cb0a91bf6f94')
     variant('build_type', default='Release',
-        description='The build type to build',
-        values=('Debug', 'Release', 'RelWithDebInfo'))
+            description='The build type to build',
+            values=('Debug', 'Release', 'RelWithDebInfo'))
 
     depends_on('mpi')
 
@@ -43,7 +41,7 @@ class Wi4mpi(CMakePackage):
             wi4mpi_build_type = 'NORMAL'
         elif self.spec.variants["build_type"].value == "Debug":
             wi4mpi_build_type = 'DEBUG'
-        args = ["-DWI4MPI_REALEASE="+wi4mpi_build_type, "-DWI4MPI_COMPILER="+compiler]
+        args = ["-DWI4MPI_REALEASE=" + wi4mpi_build_type, "-DWI4MPI_COMPILER=" + compiler]
         return args
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -1,0 +1,65 @@
+# Copyright 2013-2019 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+from spack.util.environment import set_env
+import os
+
+
+class Wi4mpi(CMakePackage):
+    """WI4MPI: Wrapper Interface For MPI performing a light translation between MPI constants and MPI objects from an MPI implementation to another one"""
+
+    homepage = "https://github.com/cea-hpc/wi4mpi"
+    url      = "https://github.com/cea-hpc/wi4mpi/archive/v3.4.1.tar.gz"
+
+    version('3.4.1', sha256='92bf6738216426069bc07bff19cd7c933e33e397a941ff9f89a639380fab3737')
+    version('3.3.0', sha256='fb7fb3b591144e90b3d688cf844c2246eb185f54e1da6baef857e035ef730d96')
+    version('3.2.2', sha256='23ac69740577d66a68ddd5360670f0a344e3c47a5d146033c63a67e54e56c66f')
+    version('3.2.1', sha256='0d928cb930b6cb1ae648eca241db59812ee0e5c041faf2f57728bbb6ee4e36df')
+    version('3.2.0', sha256='3322f6823dbec1d58a1fcf163b2bcdd7b9cd75dc6c7f78865fc6cb0a91bf6f94')
+    variant('build_type', default='Release',
+        description='The build type to build',
+        values=('Debug', 'Release', 'RelWithDebInfo'))
+
+    depends_on('mpi')
+
+    def cmake_args(self):
+        if '%gcc' in self.spec:
+            compiler = "GNU"
+        elif '%intel' in self.spec:
+            compiler = "INTEL"
+        elif '%clang' in self.spec:
+            compiler = "LLVM"
+        elif '%pgi' in self.spec:
+            compiler = "PGI"
+        else:
+            tty.error("Could not determine compiler used")
+        wi4mpi_build_type = 'RELEASE'
+        if self.spec.variants["build_type"].value == "RelWithDebInfo":
+            wi4mpi_build_type = 'NORMAL'
+        elif self.spec.variants["build_type"].value == "Debug":
+            wi4mpi_build_type = 'DEBUG'
+        args = ["-DWI4MPI_REALEASE="+wi4mpi_build_type, "-DWI4MPI_COMPILER="+compiler]
+        return args
+
+    def setup_run_environment(self, env):
+        env.set('WI4MPI_ROOT', self.prefix)
+        if '%gcc' in self.spec:
+            env.set('WI4MPI_CC', "gcc")
+            env.set('WI4MPI_CXX', "g++")
+            env.set('WI4MPI_FC', "gfortran")
+        elif '%intel' in self.spec:
+            env.set('WI4MPI_CC', "icc")
+            env.set('WI4MPI_CXX', "icpc")
+            env.set('WI4MPI_FC', "ifort")
+        elif '%clang' in self.spec:
+            env.set('WI4MPI_CC', "clang")
+            env.set('WI4MPI_CXX', "clang++")
+            env.set('WI4MPI_FC', "flang")
+        elif '%pgi' in self.spec:
+            env.set('WI4MPI_CC', "pgcc")
+            env.set('WI4MPI_CXX', "pgc++")
+            env.set('WI4MPI_FC', "pgfortran")
+

--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack import *
 from spack.util.environment import set_env
 

--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 from spack import *
 from spack.util.environment import set_env
-import os
 
 
 class Wi4mpi(CMakePackage):
@@ -13,6 +13,7 @@ class Wi4mpi(CMakePackage):
 
     homepage = "https://github.com/cea-hpc/wi4mpi"
     url      = "https://github.com/cea-hpc/wi4mpi/archive/v3.4.1.tar.gz"
+    maintainers = ['adrien-cotte', 'marcjoos-cea']
 
     version('3.4.1', sha256='92bf6738216426069bc07bff19cd7c933e33e397a941ff9f89a639380fab3737')
     version('3.3.0', sha256='fb7fb3b591144e90b3d688cf844c2246eb185f54e1da6baef857e035ef730d96')
@@ -46,6 +47,7 @@ class Wi4mpi(CMakePackage):
 
     def setup_run_environment(self, env):
         env.set('WI4MPI_ROOT', self.prefix)
+        env.set('WI4MPI_VERSION', self.version)
         if '%gcc' in self.spec:
             env.set('WI4MPI_CC', "gcc")
             env.set('WI4MPI_CXX', "g++")

--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class Wi4mpi(CMakePackage):
-    """WI4MPI: Wrapper Interface For MPI performing a light translation between MPI constants 
+    """WI4MPI: Wrapper Interface For MPI performing a light translation between MPI constants
     and MPI objects from an MPI implementation to another one"""
 
     homepage = "https://github.com/cea-hpc/wi4mpi"
@@ -41,7 +41,8 @@ class Wi4mpi(CMakePackage):
             wi4mpi_build_type = 'NORMAL'
         elif self.spec.variants["build_type"].value == "Debug":
             wi4mpi_build_type = 'DEBUG'
-        args = ["-DWI4MPI_REALEASE=" + wi4mpi_build_type, "-DWI4MPI_COMPILER=" + compiler]
+        args = ["-DWI4MPI_REALEASE=" + wi4mpi_build_type, 
+                "-DWI4MPI_COMPILER=" + compiler]
         return args
 
     def setup_run_environment(self, env):
@@ -63,4 +64,3 @@ class Wi4mpi(CMakePackage):
             env.set('WI4MPI_CC', "pgcc")
             env.set('WI4MPI_CXX', "pgc++")
             env.set('WI4MPI_FC', "pgfortran")
-

--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -7,8 +7,8 @@ from spack import *
 
 
 class Wi4mpi(CMakePackage):
-    """WI4MPI: Wrapper Interface For MPI performing a light translation between MPI constants
-    and MPI objects from an MPI implementation to another one"""
+    """WI4MPI: Wrapper Interface For MPI performing a light translation between MPI
+    constants and MPI objects from an MPI implementation to another one"""
 
     homepage = "https://github.com/cea-hpc/wi4mpi"
     url      = "https://github.com/cea-hpc/wi4mpi/archive/v3.4.1.tar.gz"
@@ -41,7 +41,7 @@ class Wi4mpi(CMakePackage):
             wi4mpi_build_type = 'NORMAL'
         elif self.spec.variants["build_type"].value == "Debug":
             wi4mpi_build_type = 'DEBUG'
-        args = ["-DWI4MPI_REALEASE=" + wi4mpi_build_type, 
+        args = ["-DWI4MPI_REALEASE=" + wi4mpi_build_type,
                 "-DWI4MPI_COMPILER=" + compiler]
         return args
 


### PR DESCRIPTION
This PR adds `wi4mpi` package; WI4MPI is a Wrapper Interface For MPI performing a light translation between MPI constants and MPI objects from an MPI implementation to another one.