### PR TITLE
Bootstrap patchelf like GnuPG

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -78,6 +78,34 @@ jobs:
           spack -d solve zlib
           tree ~/.spack/bootstrap/store/
 
+  ubuntu-clingo-binaries-and-patchelf:
+    runs-on: ubuntu-latest
+    container: "ubuntu:latest"
+    steps:
+      - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          apt-get update -y && apt-get upgrade -y
+          apt-get install -y \
+              bzip2 curl file g++ gcc gfortran git gnupg2 gzip \
+              make patch unzip xz-utils python3 python3-dev tree
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
+      - name: Setup repo and non-root user
+        run: |
+          git --version
+          git fetch --unshallow
+          . .github/workflows/setup_git.sh
+          useradd -m spack-test
+          chown -R spack-test .
+      - name: Bootstrap clingo
+        shell: runuser -u spack-test -- bash {0}
+        run: |
+          source share/spack/setup-env.sh
+          spack -d solve zlib
+          tree ~/.spack/bootstrap/store/
+
+
   opensuse-clingo-sources:
     runs-on: ubuntu-latest
     container: "opensuse/leap:latest"

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -421,9 +421,12 @@ class _SourceBootstrapper(object):
             abstract_spec_str += ' os=fe'
 
         concrete_spec = spack.spec.Spec(abstract_spec_str)
-        concrete_spec.concretize()
+        if concrete_spec.name == 'patchelf':
+            concrete_spec._old_concretize(deprecation_warning=False)
+        else:
+            concrete_spec.concretize()
 
-        msg = "[BOOTSTRAP GnuPG] Try installing '{0}' from sources"
+        msg = "[BOOTSTRAP] Try installing '{0}' from sources"
         tty.debug(msg.format(abstract_spec_str))
         concrete_spec.package.do_install()
         if _executables_in_store(executables, concrete_spec, query_info=info):
@@ -753,9 +756,22 @@ def gnupg_root_spec():
 
 def ensure_gpg_in_path_or_raise():
     """Ensure gpg or gpg2 are in the PATH or raise."""
-    ensure_executables_in_path_or_raise(
+    return ensure_executables_in_path_or_raise(
         executables=['gpg2', 'gpg'], abstract_spec=gnupg_root_spec()
     )
+
+
+def patchelf_root_spec():
+    """Return the root spec used to bootstrap GnuPG"""
+    return _root_spec('patchelf')
+
+
+def ensure_patchelf_in_path_or_raise():
+    """Ensure gpg or gpg2 are in the PATH or raise."""
+    return ensure_executables_in_path_or_raise(
+        executables=['patchelf'], abstract_spec=patchelf_root_spec()
+    )
+
 
 ###
 # Development dependencies

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -784,12 +784,12 @@ def ensure_gpg_in_path_or_raise():
 
 
 def patchelf_root_spec():
-    """Return the root spec used to bootstrap GnuPG"""
-    return _root_spec('patchelf')
+    """Return the root spec used to bootstrap patchelf"""
+    return _root_spec('patchelf@0.13:')
 
 
 def ensure_patchelf_in_path_or_raise():
-    """Ensure gpg or gpg2 are in the PATH or raise."""
+    """Ensure patchelf is in the PATH or raise."""
     return ensure_executables_in_path_or_raise(
         executables=['patchelf'], abstract_spec=patchelf_root_spec()
     )

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -140,3 +140,13 @@ spack:
         with spack.bootstrap.ensure_bootstrap_configuration():
             pass
         assert str(spack.store.root) == '/tmp/store'
+
+
+def test_nested_use_of_context_manager(mutable_config):
+    """Test nested use of the context manager"""
+    user_config = spack.config.config
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        assert spack.config.config != user_config
+        with spack.bootstrap.ensure_bootstrap_configuration():
+            assert spack.config.config != user_config
+    assert spack.config.config == user_config

--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -183,7 +183,7 @@ def copy_binary():
 
 
 @pytest.mark.requires_executables(
-    '/usr/bin/gcc', 'strings', 'file'
+    '/usr/bin/gcc', 'patchelf', 'strings', 'file'
 )
 @skip_unless_linux
 def test_file_is_relocatable(source_file, is_relocatable):
@@ -198,7 +198,7 @@ def test_file_is_relocatable(source_file, is_relocatable):
     assert spack.relocate.file_is_relocatable(executable) is is_relocatable
 
 
-@pytest.mark.requires_executables('strings', 'file')
+@pytest.mark.requires_executables('patchelf', 'strings', 'file')
 @skip_unless_linux
 def test_patchelf_is_relocatable():
     patchelf = spack.relocate._patchelf()
@@ -286,7 +286,7 @@ def test_set_elf_rpaths_warning(mock_patchelf):
     assert output is None
 
 
-@pytest.mark.requires_executables('strings', 'file', 'gcc')
+@pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
 @skip_unless_linux
 def test_replace_prefix_bin(hello_world):
     # Compile an "Hello world!" executable and set RPATHs
@@ -299,7 +299,7 @@ def test_replace_prefix_bin(hello_world):
     assert '/foo/lib:/foo/lib64' in rpaths_for(executable)
 
 
-@pytest.mark.requires_executables('strings', 'file', 'gcc')
+@pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
 @skip_unless_linux
 def test_relocate_elf_binaries_absolute_paths(
         hello_world, copy_binary, tmpdir
@@ -324,7 +324,7 @@ def test_relocate_elf_binaries_absolute_paths(
     assert '/foo/lib:/usr/lib64' in rpaths_for(new_binary)
 
 
-@pytest.mark.requires_executables('strings', 'file', 'gcc')
+@pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
 @skip_unless_linux
 def test_relocate_elf_binaries_relative_paths(hello_world, copy_binary):
     # Create an executable, set some RPATHs, copy it to another location
@@ -345,7 +345,7 @@ def test_relocate_elf_binaries_relative_paths(hello_world, copy_binary):
     assert '/foo/lib:/foo/lib64:/opt/local/lib' in rpaths_for(new_binary)
 
 
-@pytest.mark.requires_executables('strings', 'file', 'gcc')
+@pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
 @skip_unless_linux
 def test_make_elf_binaries_relative(hello_world, copy_binary, tmpdir):
     orig_binary = hello_world(rpaths=[
@@ -369,7 +369,7 @@ def test_raise_if_not_relocatable(monkeypatch):
         )
 
 
-@pytest.mark.requires_executables('strings', 'file', 'gcc')
+@pytest.mark.requires_executables('patchelf', 'strings', 'file', 'gcc')
 @skip_unless_linux
 def test_relocate_text_bin(hello_world, copy_binary, tmpdir):
     orig_binary = hello_world(rpaths=[


### PR DESCRIPTION
Remove a custom bootstrapping procedure to use functions in `spack.bootstrap` instead