### PR TITLE
ParaView: Make build edition strings uppercase

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -318,7 +318,7 @@ class Paraview(CMakePackage, CudaPackage):
             if spec.satisfies('@5.8:'):
                 cmake_args.extend([
                     '-DPARAVIEW_BUILD_EDITION:STRING=%s' %
-                    spec.variants['build_edition'].value,
+                    spec.variants['build_edition'].value.upper(),
                     '-DPARAVIEW_USE_QT:BOOL=%s' % variant_bool('+qt'),
                     '-DPARAVIEW_BUILD_WITH_EXTERNAL=ON'])
                 if spec.satisfies('%cce'):


### PR DESCRIPTION
@danlipsa It seems the cmake argument for ParaView build_editions expects the strings to be all uppercase, at least for `canonical`

Without capitalization, cmake was ignoring arguments that have worked in the past:

```console
  Manually-specified variables were not used by the project:

    MPI_Fortran_COMPILER
    OpenGL_GL_PREFERENCE
    PARAVIEW_ENABLE_EXAMPLES
    PYTHON_EXECUTABLE
    VTK_MODULE_USE_EXTERNAL_ParaView_cgns
    VTK_MODULE_USE_EXTERNAL_VTK_gl2ps
    VTK_MODULE_USE_EXTERNAL_VTK_glew
    VTK_MODULE_USE_EXTERNAL_VTK_libharu
    VTK_OPENGL_HAS_OSMESA
```

With capitalization, at least for `canonical`, many of these are set as expected:

```console
  Manually-specified variables were not used by the project:

    MPI_Fortran_COMPILER
    PARAVIEW_ENABLE_EXAMPLES
    PYTHON_EXECUTABLE


-- Build files have been written to: /tmp/stam/spack-stage/spack-stage-paraview-5.9.1-ydbfmizfhppij5vjhrfnjsuo3eni3olg/spack-build-ydbfmiz
```

This PR adds `.upper()` to the string passed in the cmake argument.