### PR TITLE
py-cryptography: add 3.4.8 and 35.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -14,13 +14,14 @@ class PyCryptography(PythonPackage):
     homepage = "https://github.com/pyca/cryptography"
     pypi = "cryptography/cryptography-1.8.1.tar.gz"
 
+    version('35.0.0', sha256='9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d')
+    version('3.4.8', sha256='94cc5ed4ceaefcbe5bf38c8fba6a21fc1d365bb8fb826ea1688e3370b2e24a1c')
     version('3.4.7', sha256='3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713')
-    version('2.7',   sha256='e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6')
+    version('2.7', sha256='e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6')
     version('2.3.1', sha256='8d10113ca826a4c29d5b85b2c4e045ffa8bad74fb525ee0eceb1d38d4c70dfd6')
     version('1.8.1', sha256='323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190')
 
-    variant('idna', default=False, description='Deprecated U-label support')
-    conflicts('+idna', when='@:2.4,3.1:')
+    variant('idna', default=False, when='@2.5:3.0', description='Deprecated U-label support')
 
     # dependencies taken from https://github.com/pyca/cryptography/blob/master/setup.py
     depends_on('python@3.6:',         when='@3.4:',   type=('build', 'run'))


### PR DESCRIPTION
https://github.com/pyca/cryptography/tree/35.0.0

The newest version is no typo but the versioning scheme was changed for the project:
https://cryptography.io/en/latest/api-stability/#version-35-0-0