### PR TITLE
py-progressbar2: add v3.55.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-progressbar2/package.py
+++ b/var/spack/repos/builtin/packages/py-progressbar2/package.py
@@ -13,6 +13,7 @@ class PyProgressbar2(PythonPackage):
     homepage = "https://github.com/WoLpH/python-progressbar"
     pypi = "progressbar2/progressbar2-3.50.1.tar.gz"
 
+    version('3.55.0', sha256='86835d1f1a9317ab41aeb1da5e4184975e2306586839d66daf63067c102f8f04')
     version('3.50.1', sha256='2c21c14482016162852c8265da03886c2b4dea6f84e5a817ad9b39f6bd82a772')
     version('3.39.3', sha256='8e5b5419e04193bb7c3fea71579937bbbcd64c26472b929718c2fe7ec420fe39')
 


### PR DESCRIPTION
Extracting this from #27271 

Successfully builds on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.