### PR TITLE
Expand external find for Windows

### DIFF
--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -196,7 +196,7 @@ def find_win32_additional_install_paths():
     windows_search_ext.extend([os.environ[key] for key
                               in os.environ.keys() if
                               add_path(key)])
-    windows_search_ext.append("C:\\PrograData\\chocolatey\\bin")
+    windows_search_ext.append("C:\\ProgramData\\chocolatey\\bin")
     windows_search_ext.append(os.path.join(user, ".nuget", "packages"))
     windows_search_ext.extend(
         spack.config.get("config:additional_external_search_paths", default=[])

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -215,6 +215,6 @@ def compute_windows_program_path_for_package(pkg):
     """
     program_files = 'C:\\Program Files {}\\{}'
 
-    return[program_files.format(arch, ) for
+    return[program_files.format(arch, name) for
            arch, name in itertools.product(("", "(x86)"),
            (pkg.name, pkg.name.capitalize()))]

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -210,7 +210,7 @@ def compute_windows_program_path_for_package(pkg):
     program files location, return list of best guesses
 
     Args:
-        pkg (spack.Package): package for which
+        pkg (spack.package.Package): package for which
                            Program Files location is to be computed
     """
     program_files = 'C:\\Program Files {}\\{}'

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -198,6 +198,7 @@ def find_win32_additional_install_paths():
                               add_path()])
     windows_search_ext.append("C:\\PrograData\\chocolatey\\bin")
     windows_search_ext.append(os.path.join(user, ".nuget", "packages"))
+    windows_search_ext.extend(spack.config.get("config:additional_external_search_paths"))
 
     return windows_search_ext
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -175,3 +175,9 @@ def update_configuration(detected_packages, scope=None, buildable=True):
     spack.config.set('packages', pkgs_cfg, scope=scope)
 
     return all_new_specs
+
+
+def find_win32_install_paths():
+    program_files = '"C:\\Program Files {}\\*\\"'
+
+    return [program_files.format(arch) for arch in ("","(x86)")]

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -210,7 +210,7 @@ def compute_windows_program_path_for_package(pkg):
     program files location, return list of best guesses
 
     Args:
-        pkg spack.Package: package for which
+        pkg (spack.Package): package for which
                            Program Files location is to be computed
     """
     program_files = 'C:\\Program Files {}\\{}'

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -195,10 +195,12 @@ def find_win32_additional_install_paths():
     add_path = lambda key: re.search(cuda_re, key) or key in path_ext_keys
     windows_search_ext.extend([os.environ[key] for key
                               in os.environ.keys() if
-                              add_path()])
+                              add_path(key)])
     windows_search_ext.append("C:\\PrograData\\chocolatey\\bin")
     windows_search_ext.append(os.path.join(user, ".nuget", "packages"))
-    windows_search_ext.extend(spack.config.get("config:additional_external_search_paths"))
+    windows_search_ext.extend(
+        spack.config.get("config:additional_external_search_paths", default=[])
+    )
 
     return windows_search_ext
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -20,6 +20,7 @@ import spack.util.environment
 
 from .common import (
     DetectedPackage,
+    find_win32_install_paths,
     _convert_to_iterable,
     executable_prefix,
     is_executable,
@@ -56,6 +57,7 @@ def executables_in_path(path_hints=None):
                          "CMake", "Ninja")
             for path in msvc_paths]
         path_hints = msvc_ninja_paths + path_hints
+        path_hints.extend(find_win32_install_paths())
 
     search_paths = llnl.util.filesystem.search_paths_for_executables(*path_hints)
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -20,11 +20,39 @@ import spack.util.environment
 
 from .common import (
     DetectedPackage,
-    find_win32_install_paths,
     _convert_to_iterable,
+    compute_windows_program_path_for_package,
     executable_prefix,
+    find_win32_additional_install_paths,
     is_executable,
 )
+
+
+def determine_search_paths(path_hints):
+    """Get the paths of all executables available from provided hints
+
+    For convenience, this is constructed as a dictionary where the keys are
+    the executable paths and the values are the names of the executables
+    (i.e. the basename of the executable path).
+
+    There may be multiple paths with the same basename. In this case it is
+    assumed there are two different instances of the executable.
+
+    Args:
+        path_hints (list): list of paths to be searched. If None the list will be
+            constructed based on the PATH environment variable.
+    """
+    search_paths = llnl.util.filesystem.search_paths_for_executables(*path_hints)
+
+    path_to_exe = {}
+    # Reverse order of search directories so that an exe in the first PATH
+    # entry overrides later entries
+    for search_path in reversed(search_paths):
+        for exe in os.listdir(search_path):
+            exe_path = os.path.join(search_path, exe)
+            if is_executable(exe_path):
+                path_to_exe[exe_path] = exe
+    return path_to_exe
 
 
 def executables_in_path(path_hints=None):
@@ -57,19 +85,8 @@ def executables_in_path(path_hints=None):
                          "CMake", "Ninja")
             for path in msvc_paths]
         path_hints = msvc_ninja_paths + path_hints
-        path_hints.extend(find_win32_install_paths())
-
-    search_paths = llnl.util.filesystem.search_paths_for_executables(*path_hints)
-
-    path_to_exe = {}
-    # Reverse order of search directories so that an exe in the first PATH
-    # entry overrides later entries
-    for search_path in reversed(search_paths):
-        for exe in os.listdir(search_path):
-            exe_path = os.path.join(search_path, exe)
-            if is_executable(exe_path):
-                path_to_exe[exe_path] = exe
-    return path_to_exe
+        path_hints.extend(find_win32_additional_install_paths())
+    return determine_search_paths(path_hints)
 
 
 def _group_by_prefix(paths):
@@ -96,6 +113,12 @@ def by_executable(packages_to_check, path_hints=None):
                 if sys.platform == 'win32':
                     exe = exe.replace('$', r'\.exe$')
                 exe_pattern_to_pkgs[exe].append(pkg)
+
+        path_to_exe_name.update(
+            determine_search_paths(
+                compute_windows_program_path_for_package(pkg)
+            )
+        )
 
     pkg_to_found_exes = collections.defaultdict(set)
     for exe_pattern, pkgs in exe_pattern_to_pkgs.items():

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -103,6 +103,10 @@ properties = {
                 'type': 'string',
                 'enum': ['urllib', 'curl']
             },
+            'additional_external_search_paths': {
+                'type': 'array',
+                'items': {'type': 'string'}
+            }
         },
     },
 }

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -194,7 +194,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
             args.append('CCTYPE=%s' % self.compiler.msvc_version)
         else:
             raise RuntimeError("Perl unsupported for non MSVC compilers on Windows")
-        args.append('INST_TOP="%s"' % self.prefix.replace('/', '\\'))
+        args.append('INST_TOP=%s' % self.prefix.replace('/', '\\'))
         args.append("INST_ARCH=\\$(ARCHNAME)")
         if self.spec.satisfies('~shared'):
             args.append("ALL_STATIC=%s" % "define")


### PR DESCRIPTION
Add a number of common Windows install paths/locations i.e.

- Nuget/Chocolately/Conan install paths
- MSMPI, ONEAPI, MatLab install root
- Various Cuda version install roots
- Does a search of the various Program Files directories

Adds a config option for users to configure their own additional search paths. At the moment this extension to the config is only leveraged on Windows systems but this can be amended. 

