### PR TITLE
py-zope-interface: add 5.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-zope-interface/package.py
+++ b/var/spack/repos/builtin/packages/py-zope-interface/package.py
@@ -15,6 +15,7 @@ class PyZopeInterface(PythonPackage):
     homepage = "https://github.com/zopefoundation/zope.interface"
     pypi = "zope.interface/zope.interface-4.5.0.tar.gz"
 
+    version('5.4.0', sha256='5dba5f530fec3f0988d83b78cc591b58c0b6eb8431a85edd1569a0539a8a5a0e')
     version('5.1.0', sha256='40e4c42bd27ed3c11b2c983fecfb03356fae1209de10686d03c02c8696a1d90e')
     version('4.5.0', sha256='57c38470d9f57e37afb460c399eb254e7193ac7fb8042bd09bdc001981a9c74c')
 


### PR DESCRIPTION
https://github.com/zopefoundation/zope.interface/tree/5.4.0