### PR TITLE
Petsc: Update Spack test dir

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -583,13 +583,13 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             join_path('src', 'snes', 'tutorials')
         ])
 
-    def run_ex50_test(self, runexe, runopt, w_dir, makefile_path):
+    def run_ex50_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex50"""
 
         self.run_test('make',
-                      options=['-f', 'ex50'],
+                      options=['ex50'],
                       purpose='test: compile ex50',
-                      work_dir=makefile_path)
+                      work_dir=w_dir)
 
         testexe = ['ex50', '-da_grid_x', '4', '-da_grid_y', '4']
         testdict = {
@@ -612,11 +612,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                               purpose=purpose_str,
                               work_dir=w_dir)
 
-    def run_ex7_test(self, runexe, runopt, w_dir, makefile_path):
+    def run_ex7_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex7 with cuda"""
 
         self.run_test('make',
-                      options=['-f', makefile_path, 'ex7'],
+                      options=['ex7'],
                       purpose='test: compile ex7',
                       work_dir=w_dir)
 
@@ -631,11 +631,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                       purpose=purpose_str,
                       work_dir=w_dir)
 
-    def run_ex3k_test(self, runexe, runopt, w_dir, makefile_path):
+    def run_ex3k_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex3.kokkos with kokkos"""
 
         self.run_test('make',
-                      options=['-f', makefile_path, 'ex3k.kokkos'],
+                      options=['ex3k.kokkos'],
                       purpose='test: compile ex3k.kokkos',
                       work_dir=w_dir)
 
@@ -664,17 +664,16 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'ksp', 'ksp', 'tutorials')
         skip_test = 'Skipping petsc test:'
-        makefile_path = join_path(w_dir, 'makefile')
 
         if os.path.isfile(join_path(w_dir, 'ex50.c')):
-            self.run_ex50_test(runexe, runopt, w_dir, makefile_path)
+            self.run_ex50_test(runexe, runopt, w_dir)
         else:
             tty.warn('{0} KSP tutorial example ex50 is missing'
                      .format(skip_test))
 
         if os.path.isfile(join_path(w_dir, 'ex7.c')):
             if '+cuda' in self.spec:
-                self.run_ex7_test(runexe, runopt, w_dir, makefile_path)
+                self.run_ex7_test(runexe, runopt, w_dir)
             else:
                 tty.msg('{0} KSP tutorial example ex7 requires +cuda'
                         .format(skip_test))
@@ -684,11 +683,10 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')
-        makefile_path = join_path(w_dir, 'makefile')
 
         if os.path.isfile(join_path(w_dir, 'ex3k.kokkos.cxx')):
             if '+kokkos' in self.spec:
-                self.run_ex3k_test(runexe, runopt, w_dir, makefile_path)
+                self.run_ex3k_test(runexe, runopt, w_dir)
             else:
                 tty.msg('{0} SNES tutorial example ex3k requires +kokkos'
                         .format(skip_test))

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -5,6 +5,7 @@
 import os
 
 from llnl.util import tty
+
 from spack.util.executable import which_string
 
 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -609,33 +609,31 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     def run_ex7_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex7 with cuda"""
 
-        make('ex7', parallel=False)
-        testexe = ['ex7', '-mat_type', 'aijcusparse',
-                   '-sub_pc_factor_mat_solver_type', 'cusparse',
-                   '-sub_ksp_type', 'preonly', '-sub_pc_type', 'ilu',
-                   '-use_gpu_aware_mpi', '0']
-        purpose_str = 'test: run ex7 example with +cuda'
-        self.run_test(runexe,
-                      options=runopt + testexe,
-                      purpose=purpose_str,
-                      work_dir=w_dir)
-        make('clean', parallel=False)
+        with working_dir(w_dir):
+            make('ex7', parallel=False)
+            testexe = ['ex7', '-mat_type', 'aijcusparse',
+                       '-sub_pc_factor_mat_solver_type', 'cusparse',
+                       '-sub_ksp_type', 'preonly', '-sub_pc_type', 'ilu',
+                       '-use_gpu_aware_mpi', '0']
+            purpose_str = 'test: run ex7 example with +cuda'
+            self.run_test(runexe,
+                          options=runopt + testexe,
+                          purpose=purpose_str,
+                          work_dir=w_dir)
 
     def run_ex3k_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex3k with kokkos"""
 
         with working_dir(w_dir):
-            if '+kokkos' in self.spec:
-                make('ex3k', parallel=False)
-                testexe = ['ex3k', '-view_initial', '-dm_vec_type', 'kokkos',
-                           '-dm_mat_type', 'aijkokkos', '-use_gpu_aware_mpi', '0',
-                           '-snes_monitor']
-                purpose_str = 'run ex3k example with +kokkos'
-                self.run_test(runexe,
-                              options=runopt + testexe,
-                              purpose=purpose_str,
-                              work_dir=w_dir)
-            make('clean', parallel=False)
+            make('ex3k', parallel=False)
+            testexe = ['ex3k', '-view_initial', '-dm_vec_type', 'kokkos',
+                       '-dm_mat_type', 'aijkokkos', '-use_gpu_aware_mpi', '0',
+                       '-snes_monitor']
+            purpose_str = 'run ex3k example with +kokkos'
+            self.run_test(runexe,
+                          options=runopt + testexe,
+                          purpose=purpose_str,
+                          work_dir=w_dir)
 
     def test(self):
         # solve Poisson equation in 2D to make sure nothing is broken:
@@ -668,6 +666,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                           'src', 'snes', 'tutorials')
 
         if os.path.exists(w_dir):
-            self.run_ex3k_test(runexe, runopt, w_dir)
+            if '+kokkos' in self.spec:
+                self.run_ex3k_test(runexe, runopt, w_dir)
         else:
             print('Skipping petsc test: SNES tutorial example is missing')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -581,8 +581,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             join_path('src', 'snes', 'tutorials')
         ])
 
-    def run_ex30_test(self, runexe, runopt, w_dir):
-        """Run stand alone test: ex30"""
+    def run_ex50_test(self, runexe, runopt, w_dir):
+        """Run stand alone test: ex50"""
 
         with working_dir(w_dir):
             testexe = ['ex50', '-da_grid_x', '4', '-da_grid_y', '4']

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -576,8 +576,10 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     def setup_build_tests(self):
         """Copy the build test files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources(join_path('src', 'ksp', 'ksp', 'tutorials'))
-        self.cache_extra_test_sources(join_path('src', 'snes', 'tutorials'))
+        self.cache_extra_test_sources([
+            join_path('src', 'ksp', 'ksp', 'tutorials'),
+            join_path('src', 'snes', 'tutorials')
+        ])
 
     def run_ex30_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex30"""

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -659,6 +659,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir)
+            else:
+                print('Skipping petsc test: KSP tutorial example ex7 requires +cuda')
         else:
             print('Skipping petsc tests: KSP tutorial examples are missing')
 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -653,7 +653,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                           'src', 'ksp', 'ksp', 'tutorials')
 
         if os.path.exists(w_dir):
-            self.run_ex30_test(runexe, runopt, w_dir)
+            self.run_ex50_test(runexe, runopt, w_dir)
 
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir)
@@ -668,5 +668,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         if os.path.exists(w_dir):
             if '+kokkos' in self.spec:
                 self.run_ex3k_test(runexe, runopt, w_dir)
+            else:
+                print('Skipping petsc test: SNES tutorial example ex3k requires +kokkos')
         else:
             print('Skipping petsc test: SNES tutorial example is missing')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -658,9 +658,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir)
             else:
-                print('Skipping petsc test: KSP tutorial example ex7 requires cuda')
+                print('Skipping petsc test: ' \
+                      'KSP tutorial example ex7 requires +cuda')
         else:
-            print('Skipping petsc tests: KSP tutorial examples are missing')
+            print('Skipping petsc tests: ' \
+                  'KSP tutorial examples are missing')
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')
@@ -669,6 +671,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             if '+kokkos' in self.spec:
                 self.run_ex3k_test(runexe, runopt, w_dir)
             else:
-                print('Skipping petsc test: SNES tutorial example ex3k requires kokkos')
+                print('Skipping petsc test: ' \
+                      'SNES tutorial example ex3k requires +kokkos')
         else:
-            print('Skipping petsc test: SNES tutorial example is missing')
+            print('Skipping petsc test: ' \
+                  'SNES tutorial example is missing')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -658,7 +658,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir)
             else:
-                print('Skipping petsc test: KSP tutorial example ex7 requires +cuda')
+                print('Skipping petsc test: KSP tutorial example ex7 requires cuda')
         else:
             print('Skipping petsc tests: KSP tutorial examples are missing')
 
@@ -669,6 +669,6 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             if '+kokkos' in self.spec:
                 self.run_ex3k_test(runexe, runopt, w_dir)
             else:
-                print('Skipping petsc test: SNES tutorial example ex3k requires +kokkos')
+                print('Skipping petsc test: SNES tutorial example ex3k requires kokkos')
         else:
             print('Skipping petsc test: SNES tutorial example is missing')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -583,13 +583,13 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             join_path('src', 'snes', 'tutorials')
         ])
 
-    def run_ex50_test(self, runexe, runopt, w_dir, makefile_dir):
+    def run_ex50_test(self, runexe, runopt, w_dir, makefile_path):
         """Run stand alone test: ex50"""
 
         self.run_test('make',
-                      options=['-f', makefile_dir, 'ex50'],
+                      options=['-f', 'ex50'],
                       purpose='test: compile ex50',
-                      work_dir=w_dir)
+                      work_dir=makefile_path)
 
         testexe = ['ex50', '-da_grid_x', '4', '-da_grid_y', '4']
         testdict = {
@@ -612,11 +612,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                               purpose=purpose_str,
                               work_dir=w_dir)
 
-    def run_ex7_test(self, runexe, runopt, w_dir, makefile_dir):
+    def run_ex7_test(self, runexe, runopt, w_dir, makefile_path):
         """Run stand alone test: ex7 with cuda"""
 
         self.run_test('make',
-                      options=['-f', makefile_dir, 'ex7'],
+                      options=['-f', makefile_path, 'ex7'],
                       purpose='test: compile ex7',
                       work_dir=w_dir)
 
@@ -631,11 +631,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                       purpose=purpose_str,
                       work_dir=w_dir)
 
-    def run_ex3k_test(self, runexe, runopt, w_dir, makefile_dir):
+    def run_ex3k_test(self, runexe, runopt, w_dir, makefile_path):
         """Run stand alone test: ex3.kokkos with kokkos"""
 
         self.run_test('make',
-                      options=['-f', makefile_dir, 'ex3k.kokkos'],
+                      options=['-f', makefile_path, 'ex3k.kokkos'],
                       purpose='test: compile ex3k.kokkos',
                       work_dir=w_dir)
 
@@ -664,17 +664,17 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'ksp', 'ksp', 'tutorials')
         skip_test = 'Skipping petsc test:'
-        makefile_dir = join_path(w_dir, 'makefile')
+        makefile_path = join_path(w_dir, 'makefile')
 
         if os.path.isfile(join_path(w_dir, 'ex50.c')):
-            self.run_ex50_test(runexe, runopt, w_dir, makefile_dir)
+            self.run_ex50_test(runexe, runopt, w_dir, makefile_path)
         else:
             tty.warn('{0} KSP tutorial example ex50 is missing'
                      .format(skip_test))
 
         if os.path.isfile(join_path(w_dir, 'ex7.c')):
             if '+cuda' in self.spec:
-                self.run_ex7_test(runexe, runopt, w_dir, makefile_dir)
+                self.run_ex7_test(runexe, runopt, w_dir, makefile_path)
             else:
                 tty.msg('{0} KSP tutorial example ex7 requires +cuda'
                         .format(skip_test))
@@ -684,11 +684,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')
-        makefile_dir = join_path(w_dir, 'makefile')
+        makefile_path = join_path(w_dir, 'makefile')
 
         if os.path.isfile(join_path(w_dir, 'ex3k.kokkos.cxx')):
             if '+kokkos' in self.spec:
-                self.run_ex3k_test(runexe, runopt, w_dir, makefile_dir)
+                self.run_ex3k_test(runexe, runopt, w_dir, makefile_path)
             else:
                 tty.msg('{0} SNES tutorial example ex3k requires +kokkos'
                         .format(skip_test))

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -651,6 +651,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'ksp', 'ksp', 'tutorials')
+        skip_test = 'Skipping petsc test:'
 
         if os.path.exists(w_dir):
             self.run_ex50_test(runexe, runopt, w_dir)
@@ -658,11 +659,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir)
             else:
-                print('Skipping petsc test: ' \
-                      'KSP tutorial example ex7 requires +cuda')
+                print('{0} KSP tutorial example ex7 requires +cuda'
+                      .format(skip_test))
         else:
-            print('Skipping petsc tests: ' \
-                  'KSP tutorial examples are missing')
+            print('{0} KSP tutorial examples are missing'
+                  .format(skip_test))
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')
@@ -671,8 +672,8 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             if '+kokkos' in self.spec:
                 self.run_ex3k_test(runexe, runopt, w_dir)
             else:
-                print('Skipping petsc test: ' \
-                      'SNES tutorial example ex3k requires +kokkos')
+                print('{0} SNES tutorial example ex3k requires +kokkos'
+                      .format(skip_test))
         else:
-            print('Skipping petsc test: ' \
-                  'SNES tutorial example is missing')
+            print('{0} SNES tutorial examples are missing'
+                  .format(skip_test))

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -584,56 +584,68 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     def run_ex50_test(self, runexe, runopt, w_dir, makefile_dir):
         """Run stand alone test: ex50"""
 
-        with working_dir(w_dir):
-            testexe = ['ex50', '-da_grid_x', '4', '-da_grid_y', '4']
-            testdict = {
-                None: [],
-                '+superlu-dist':
-                ['-pc_type', 'lu', '-pc_factor_mat_solver_type', 'superlu_dist'],
-                '+mumps':
-                ['-pc_type', 'lu', '-pc_factor_mat_solver_type', 'mumps'],
-                '+hypre':
-                ['-pc_type', 'hypre', '-pc_hypre_type', 'boomeramg'],
-                '+mkl-pardiso':
-                ['-pc_type', 'lu', '-pc_factor_mat_solver_type', 'mkl_pardiso'],
-            }
-            make('-f', makefile_dir, 'ex50', parallel=False)
-            for feature, featureopt in testdict.items():
-                if not feature or feature in self.spec:
-                    purpose_str = 'test: run ex50 example with {0}'.format(feature)
-                    self.run_test(runexe,
-                                  options=runopt + testexe + featureopt,
-                                  purpose=purpose_str,
-                                  work_dir=w_dir)
+        self.run_test('make',
+                      options=['-f', makefile_dir, 'ex50'],
+                      purpose='make stuff ---',
+                      work_dir=w_dir)
+
+        testexe = ['ex50', '-da_grid_x', '4', '-da_grid_y', '4']
+        testdict = {
+            None: [],
+            '+superlu-dist':
+            ['-pc_type', 'lu', '-pc_factor_mat_solver_type', 'superlu_dist'],
+            '+mumps':
+            ['-pc_type', 'lu', '-pc_factor_mat_solver_type', 'mumps'],
+            '+hypre':
+            ['-pc_type', 'hypre', '-pc_hypre_type', 'boomeramg'],
+            '+mkl-pardiso':
+            ['-pc_type', 'lu', '-pc_factor_mat_solver_type', 'mkl_pardiso'],
+        }
+
+        for feature, featureopt in testdict.items():
+            if not feature or feature in self.spec:
+                purpose_str = 'test: run ex50 example with {0}'.format(feature)
+                self.run_test(runexe,
+                              options=runopt + testexe + featureopt,
+                              purpose=purpose_str,
+                              work_dir=w_dir)
 
     def run_ex7_test(self, runexe, runopt, w_dir, makefile_dir):
         """Run stand alone test: ex7 with cuda"""
 
-        with working_dir(w_dir):
-            make('-f', makefile_dir, 'ex7', parallel=False)
-            testexe = ['ex7', '-mat_type', 'aijcusparse',
-                       '-sub_pc_factor_mat_solver_type', 'cusparse',
-                       '-sub_ksp_type', 'preonly', '-sub_pc_type', 'ilu',
-                       '-use_gpu_aware_mpi', '0']
-            purpose_str = 'test: run ex7 example with +cuda'
-            self.run_test(runexe,
-                          options=runopt + testexe,
-                          purpose=purpose_str,
-                          work_dir=w_dir)
+        self.run_test('make',
+                      options=['-f', makefile_dir, 'ex7'],
+                      purpose='make stuff ---',
+                      work_dir=w_dir)
+
+        testexe = ['ex7', '-mat_type', 'aijcusparse',
+                   '-sub_pc_factor_mat_solver_type', 'cusparse',
+                   '-sub_ksp_type', 'preonly', '-sub_pc_type', 'ilu',
+                   '-use_gpu_aware_mpi', '0']
+        purpose_str = 'test: run ex7 example with +cuda'
+
+        self.run_test(runexe,
+                      options=runopt + testexe,
+                      purpose=purpose_str,
+                      work_dir=w_dir)
 
     def run_ex3k_test(self, runexe, runopt, w_dir, makefile_dir):
         """Run stand alone test: ex3k with kokkos"""
 
-        with working_dir(w_dir):
-            make('-f', makefile_dir, 'ex3k', parallel=False)
-            testexe = ['ex3k', '-view_initial', '-dm_vec_type', 'kokkos',
-                       '-dm_mat_type', 'aijkokkos', '-use_gpu_aware_mpi', '0',
-                       '-snes_monitor']
-            purpose_str = 'run ex3k example with +kokkos'
-            self.run_test(runexe,
-                          options=runopt + testexe,
-                          purpose=purpose_str,
-                          work_dir=w_dir)
+        self.run_test('make',
+                      options=['-f', makefile_dir, 'ex3k.kokkos'],
+                      purpose='make stuff ---',
+                      work_dir=w_dir)
+
+        testexe = ['ex3k.kokkos', '-view_initial', '-dm_vec_type', 'kokkos',
+                   '-dm_mat_type', 'aijkokkos', '-use_gpu_aware_mpi', '0',
+                   '-snes_monitor']
+        purpose_str = 'run ex3k example with +kokkos'
+
+        self.run_test(runexe,
+                      options=runopt + testexe,
+                      purpose=purpose_str,
+                      work_dir=w_dir)
 
     def test(self):
         # solve Poisson equation in 2D to make sure nothing is broken:
@@ -642,12 +654,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         if ('+mpi' in self.spec):
             runexe = Executable(join_path(self.spec['mpi'].prefix.bin,
                                           'mpiexec')).command
-            runopt = ['-n', '4']
         else:
             runexe = Executable(join_path(self.prefix.lib.petsc.bin,
                                           'petsc-mpiexec.uni')).command
-            runopt = ['-n', '1']
 
+        runopt = ['-n', '1']
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'ksp', 'ksp', 'tutorials')
         skip_test = 'Skipping petsc test:'

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -607,7 +607,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                                   work_dir=w_dir)
 
     def run_ex7_test(self, runexe, runopt, w_dir):
-        """Run stand alone test: ex7"""
+        """Run stand alone test: ex7 with cuda"""
 
         make('ex7', parallel=False)
         testexe = ['ex7', '-mat_type', 'aijcusparse',

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -586,7 +586,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         self.run_test('make',
                       options=['-f', makefile_dir, 'ex50'],
-                      purpose='make stuff ---',
+                      purpose='test: compile ex50',
                       work_dir=w_dir)
 
         testexe = ['ex50', '-da_grid_x', '4', '-da_grid_y', '4']
@@ -615,7 +615,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         self.run_test('make',
                       options=['-f', makefile_dir, 'ex7'],
-                      purpose='make stuff ---',
+                      purpose='test: compile ex7',
                       work_dir=w_dir)
 
         testexe = ['ex7', '-mat_type', 'aijcusparse',
@@ -630,17 +630,17 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                       work_dir=w_dir)
 
     def run_ex3k_test(self, runexe, runopt, w_dir, makefile_dir):
-        """Run stand alone test: ex3k with kokkos"""
+        """Run stand alone test: ex3.kokkos with kokkos"""
 
         self.run_test('make',
                       options=['-f', makefile_dir, 'ex3k.kokkos'],
-                      purpose='make stuff ---',
+                      purpose='test: compile ex3k.kokkos',
                       work_dir=w_dir)
 
         testexe = ['ex3k.kokkos', '-view_initial', '-dm_vec_type', 'kokkos',
                    '-dm_mat_type', 'aijkokkos', '-use_gpu_aware_mpi', '0',
                    '-snes_monitor']
-        purpose_str = 'run ex3k example with +kokkos'
+        purpose_str = 'test: run ex3k.kokkos example with +kokkos'
 
         self.run_test(runexe,
                       options=runopt + testexe,
@@ -664,27 +664,31 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         skip_test = 'Skipping petsc test:'
         makefile_dir = join_path(self.prefix.share.petsc, 'Makefile.user')
 
-        if os.path.exists(w_dir):
+        if os.path.isfile(join_path(w_dir, 'ex50.c')):
             self.run_ex50_test(runexe, runopt, w_dir, makefile_dir)
+        else:
+            print('{0} KSP tutorial example ex50 is missing'
+                  .format(skip_test))
 
+        if os.path.isfile(join_path(w_dir, 'ex7.c')):
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir, makefile_dir)
             else:
                 print('{0} KSP tutorial example ex7 requires +cuda'
                       .format(skip_test))
         else:
-            print('{0} KSP tutorial examples are missing'
+            print('{0} KSP tutorial example ex7 is missing'
                   .format(skip_test))
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')
 
-        if os.path.exists(w_dir):
+        if os.path.isfile(join_path(w_dir, 'ex3k.kokkos.cxx')):
             if '+kokkos' in self.spec:
                 self.run_ex3k_test(runexe, runopt, w_dir, makefile_dir)
             else:
                 print('{0} SNES tutorial example ex3k requires +kokkos'
                       .format(skip_test))
         else:
-            print('{0} SNES tutorial examples are missing'
+            print('{0} SNES tutorial example ex3k.kokkos is missing'
                   .format(skip_test))

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -670,17 +670,17 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             self.run_ex50_test(runexe, runopt, w_dir, makefile_dir)
         else:
             tty.warn('{0} KSP tutorial example ex50 is missing'
-                  .format(skip_test))
+                     .format(skip_test))
 
         if os.path.isfile(join_path(w_dir, 'ex7.c')):
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir, makefile_dir)
             else:
                 tty.msg('{0} KSP tutorial example ex7 requires +cuda'
-                      .format(skip_test))
+                        .format(skip_test))
         else:
             tty.warn('{0} KSP tutorial example ex7 is missing'
-                  .format(skip_test))
+                     .format(skip_test))
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')
@@ -691,7 +691,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 self.run_ex3k_test(runexe, runopt, w_dir, makefile_dir)
             else:
                 tty.msg('{0} SNES tutorial example ex3k requires +kokkos'
-                      .format(skip_test))
+                        .format(skip_test))
         else:
             tty.warn('{0} SNES tutorial example ex3k.kokkos is missing'
-                  .format(skip_test))
+                     .format(skip_test))

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
 
+from llnl.util import tty
+
 
 class Petsc(Package, CudaPackage, ROCmPackage):
     """PETSc is a suite of data structures and routines for the scalable
@@ -662,33 +664,34 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'ksp', 'ksp', 'tutorials')
         skip_test = 'Skipping petsc test:'
-        makefile_dir = join_path(self.prefix.share.petsc, 'Makefile.user')
+        makefile_dir = join_path(w_dir, 'makefile')
 
         if os.path.isfile(join_path(w_dir, 'ex50.c')):
             self.run_ex50_test(runexe, runopt, w_dir, makefile_dir)
         else:
-            print('{0} KSP tutorial example ex50 is missing'
+            tty.warn('{0} KSP tutorial example ex50 is missing'
                   .format(skip_test))
 
         if os.path.isfile(join_path(w_dir, 'ex7.c')):
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir, makefile_dir)
             else:
-                print('{0} KSP tutorial example ex7 requires +cuda'
+                tty.msg('{0} KSP tutorial example ex7 requires +cuda'
                       .format(skip_test))
         else:
-            print('{0} KSP tutorial example ex7 is missing'
+            tty.warn('{0} KSP tutorial example ex7 is missing'
                   .format(skip_test))
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')
+        makefile_dir = join_path(w_dir, 'makefile')
 
         if os.path.isfile(join_path(w_dir, 'ex3k.kokkos.cxx')):
             if '+kokkos' in self.spec:
                 self.run_ex3k_test(runexe, runopt, w_dir, makefile_dir)
             else:
-                print('{0} SNES tutorial example ex3k requires +kokkos'
+                tty.msg('{0} SNES tutorial example ex3k requires +kokkos'
                       .format(skip_test))
         else:
-            print('{0} SNES tutorial example ex3k.kokkos is missing'
+            tty.warn('{0} SNES tutorial example ex3k.kokkos is missing'
                   .format(skip_test))

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -617,9 +617,10 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             make('ex50', parallel=False)
             for feature, featureopt in testdict.items():
                 if not feature or feature in spec:
+                    purpose_str = 'test: run ex50 example with {0}'.format(feature)
                     self.run_test(runexe,
-                                  options=[runopt + testexe + featureopt],
-                                  purpose='test: run ex50 example with {0}'.format(feature),
+                                  options=runopt + testexe + featureopt,
+                                  purpose=purpose_str,
                                   work_dir=w_dir)
             if '+cuda' in spec:
                 make('ex7', parallel=False)
@@ -627,9 +628,10 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                            '-sub_pc_factor_mat_solver_type', 'cusparse',
                            '-sub_ksp_type', 'preonly', '-sub_pc_type', 'ilu',
                            '-use_gpu_aware_mpi', '0']
+                purpose_str = 'test: run ex7 example with +cuda'
                 self.run_test(runexe,
-                              options=[runopt + testexe],
-                              purpose='test: run ex50 example with {0}'.format(feature),
+                              options=runopt + testexe,
+                              purpose=purpose_str,
                               work_dir=w_dir)
             make('clean', parallel=False)
 
@@ -646,8 +648,9 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 testexe = ['ex3k', '-view_initial', '-dm_vec_type', 'kokkos',
                            '-dm_mat_type', 'aijkokkos', '-use_gpu_aware_mpi', '0',
                            '-snes_monitor']
+                purpose_str = 'run ex3k example with +kokkos'
                 self.run_test(runexe,
-                              options=[runopt + testexe],
-                              purpose='test: run ex3k example with +kokkos',
+                              options=runopt + testexe,
+                              purpose=purpose_str,
                               work_dir=w_dir)
             make('clean', parallel=False)

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -581,7 +581,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             join_path('src', 'snes', 'tutorials')
         ])
 
-    def run_ex50_test(self, runexe, runopt, w_dir):
+    def run_ex50_test(self, runexe, runopt, w_dir, makefile_dir):
         """Run stand alone test: ex50"""
 
         with working_dir(w_dir):
@@ -597,7 +597,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 '+mkl-pardiso':
                 ['-pc_type', 'lu', '-pc_factor_mat_solver_type', 'mkl_pardiso'],
             }
-            make('ex50', parallel=False)
+            make('-f', makefile_dir, 'ex50', parallel=False)
             for feature, featureopt in testdict.items():
                 if not feature or feature in self.spec:
                     purpose_str = 'test: run ex50 example with {0}'.format(feature)
@@ -606,11 +606,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                                   purpose=purpose_str,
                                   work_dir=w_dir)
 
-    def run_ex7_test(self, runexe, runopt, w_dir):
+    def run_ex7_test(self, runexe, runopt, w_dir, makefile_dir):
         """Run stand alone test: ex7 with cuda"""
 
         with working_dir(w_dir):
-            make('ex7', parallel=False)
+            make('-f', makefile_dir, 'ex7', parallel=False)
             testexe = ['ex7', '-mat_type', 'aijcusparse',
                        '-sub_pc_factor_mat_solver_type', 'cusparse',
                        '-sub_ksp_type', 'preonly', '-sub_pc_type', 'ilu',
@@ -621,11 +621,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                           purpose=purpose_str,
                           work_dir=w_dir)
 
-    def run_ex3k_test(self, runexe, runopt, w_dir):
+    def run_ex3k_test(self, runexe, runopt, w_dir, makefile_dir):
         """Run stand alone test: ex3k with kokkos"""
 
         with working_dir(w_dir):
-            make('ex3k', parallel=False)
+            make('-f', makefile_dir, 'ex3k', parallel=False)
             testexe = ['ex3k', '-view_initial', '-dm_vec_type', 'kokkos',
                        '-dm_mat_type', 'aijkokkos', '-use_gpu_aware_mpi', '0',
                        '-snes_monitor']
@@ -644,20 +644,20 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                                           'mpiexec')).command
             runopt = ['-n', '4']
         else:
-            runexe = Executable(join_path(self.prefix,
-                                          'lib', 'petsc', 'bin',
+            runexe = Executable(join_path(self.prefix.lib.petsc.bin,
                                           'petsc-mpiexec.uni')).command
             runopt = ['-n', '1']
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'ksp', 'ksp', 'tutorials')
         skip_test = 'Skipping petsc test:'
+        makefile_dir = join_path(self.prefix.share.petsc, 'Makefile.user')
 
         if os.path.exists(w_dir):
-            self.run_ex50_test(runexe, runopt, w_dir)
+            self.run_ex50_test(runexe, runopt, w_dir, makefile_dir)
 
             if '+cuda' in self.spec:
-                self.run_ex7_test(runexe, runopt, w_dir)
+                self.run_ex7_test(runexe, runopt, w_dir, makefile_dir)
             else:
                 print('{0} KSP tutorial example ex7 requires +cuda'
                       .format(skip_test))
@@ -670,7 +670,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         if os.path.exists(w_dir):
             if '+kokkos' in self.spec:
-                self.run_ex3k_test(runexe, runopt, w_dir)
+                self.run_ex3k_test(runexe, runopt, w_dir, makefile_dir)
             else:
                 print('{0} SNES tutorial example ex3k requires +kokkos'
                       .format(skip_test))

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -5,6 +5,7 @@
 import os
 
 from llnl.util import tty
+from spack.util.executable import which_string
 
 
 class Petsc(Package, CudaPackage, ROCmPackage):
@@ -621,6 +622,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                                      work_dir=w_dir):
                     tty.warn('Skipping petsc test: '
                              'failed to run ex50 with {0}'.format(feature))
+                    return
 
     def run_ex7_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex7 with cuda"""
@@ -689,14 +691,12 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
     def test(self):
         # solve Poisson equation in 2D to make sure nothing is broken:
-        env['PETSC_DIR'] = self.prefix
-        env['PETSC_ARCH'] = ''
         if ('+mpi' in self.spec):
-            runexe = Executable(join_path(self.spec['mpi'].prefix.bin,
-                                          'mpiexec')).command
+            mpi_path = self.spec['mpi'].prefix.bin
+            runexe = which_string('mpiexec', 'srun', path=mpi_path)
         else:
-            runexe = Executable(join_path(self.prefix.lib.petsc.bin,
-                                          'petsc-mpiexec.uni')).command
+            runexe = join_path(self.prefix.lib.petsc.bin,
+                               'petsc-mpiexec.uni')
 
         runopt = ['-n', '1']
         w_dir = join_path(self.test_suite.current_test_cache_dir,

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -591,10 +591,13 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                      'KSP tutorial example ex50 is missing')
             return
 
-        self.run_test('make',
-                      options=['ex50'],
-                      purpose='test: compile ex50',
-                      work_dir=w_dir)
+        if not self.run_test('make',
+                             options=['ex50'],
+                             purpose='test: compile ex50',
+                             work_dir=w_dir):
+            tty.warn('Skipping petsc test: '
+                     'failed to compile ex50')
+            return
 
         testexe = ['ex50', '-da_grid_x', '4', '-da_grid_y', '4']
         testdict = {
@@ -612,10 +615,12 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         for feature, featureopt in testdict.items():
             if not feature or feature in self.spec:
                 purpose_str = 'test: run ex50 example with {0}'.format(feature)
-                self.run_test(runexe,
-                              options=runopt + testexe + featureopt,
-                              purpose=purpose_str,
-                              work_dir=w_dir)
+                if not self.run_test(runexe,
+                                     options=runopt + testexe + featureopt,
+                                     purpose=purpose_str,
+                                     work_dir=w_dir):
+                    tty.warn('Skipping petsc test: '
+                             'failed to run ex50 with {0}'.format(feature))
 
     def run_ex7_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex7 with cuda"""
@@ -629,10 +634,13 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                      'KSP tutorial example ex7 is missing')
             return
 
-        self.run_test('make',
-                      options=['ex7'],
-                      purpose='test: compile ex7',
-                      work_dir=w_dir)
+        if not self.run_test('make',
+                             options=['ex7'],
+                             purpose='test: compile ex7',
+                             work_dir=w_dir):
+            tty.warn('Skipping petsc test: '
+                     'failed to compile ex7')
+            return
 
         testexe = ['ex7', '-mat_type', 'aijcusparse',
                    '-sub_pc_factor_mat_solver_type', 'cusparse',
@@ -640,10 +648,12 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                    '-use_gpu_aware_mpi', '0']
         purpose_str = 'test: run ex7 example with +cuda'
 
-        self.run_test(runexe,
-                      options=runopt + testexe,
-                      purpose=purpose_str,
-                      work_dir=w_dir)
+        if not self.run_test(runexe,
+                             options=runopt + testexe,
+                             purpose=purpose_str,
+                             work_dir=w_dir):
+            tty.warn('Skipping petsc test: '
+                     'failed to run ex7')
 
     def run_ex3k_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex3.kokkos with kokkos"""
@@ -657,20 +667,25 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                      'SNES tutorial example ex3k is missing')
             return
 
-        self.run_test('make',
+        if not self.run_test('make',
                       options=['ex3k.kokkos'],
                       purpose='test: compile ex3k.kokkos',
-                      work_dir=w_dir)
+                      work_dir=w_dir):
+            tty.warn('Skipping petsc test: '
+                     'failed to compile ex3k.kokkos')
+            return
 
         testexe = ['ex3k.kokkos', '-view_initial', '-dm_vec_type', 'kokkos',
                    '-dm_mat_type', 'aijkokkos', '-use_gpu_aware_mpi', '0',
                    '-snes_monitor']
         purpose_str = 'test: run ex3k.kokkos example with +kokkos'
 
-        self.run_test(runexe,
-                      options=runopt + testexe,
-                      purpose=purpose_str,
-                      work_dir=w_dir)
+        if not self.run_test(runexe,
+                             options=runopt + testexe,
+                             purpose=purpose_str,
+                             work_dir=w_dir):
+            tty.warn('Skipping petsc test: '
+                     'failed to run ex3k.kokkos')
 
     def test(self):
         # solve Poisson equation in 2D to make sure nothing is broken:

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -660,7 +660,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             if '+cuda' in self.spec:
                 self.run_ex7_test(runexe, runopt, w_dir)
         else:
-            print('Skipping petsc test: KSP tutorial example is missing')
+            print('Skipping petsc tests: KSP tutorial examples are missing')
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -618,7 +618,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             for feature, featureopt in testdict.items():
                 if not feature or feature in spec:
                     self.run_test(runexe,
-                                  options=runopt + testexe + featureopt,
+                                  options=[runopt + testexe + featureopt],
                                   purpose='test: run ex50 example with {0}'.format(feature),
                                   work_dir=w_dir)
             if '+cuda' in spec:
@@ -634,7 +634,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             make('clean', parallel=False)
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
-                             'src', 'snes', 'tutorials')
+                          'src', 'snes', 'tutorials')
 
         if not os.path.exists(w_dir):
             print('Skipping petsc test: SNES tutorial example is missing')

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -622,7 +622,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         make('clean', parallel=False)
 
     def run_ex3k_test(self, runexe, runopt, w_dir):
-        """Run stand alone test: ex3k"""
+        """Run stand alone test: ex3k with kokkos"""
 
         with working_dir(w_dir):
             if '+kokkos' in self.spec:

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -625,7 +625,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     def run_ex7_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex7 with cuda"""
 
-        if not '+cuda' in self.spec:
+        if '+cuda' not in self.spec:
             tty.warn('Skipping petsc test: '
                      'KSP tutorial example ex7 requires +cuda')
             return
@@ -658,7 +658,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     def run_ex3k_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex3.kokkos with kokkos"""
 
-        if not '+kokkos' in self.spec:
+        if '+kokkos' not in self.spec:
             tty.warn('Skipping petsc test: '
                      'SNES tutorial example ex3k.kokkos requires +kokkos')
             return
@@ -668,9 +668,9 @@ class Petsc(Package, CudaPackage, ROCmPackage):
             return
 
         if not self.run_test('make',
-                      options=['ex3k.kokkos'],
-                      purpose='test: compile ex3k.kokkos',
-                      work_dir=w_dir):
+                             options=['ex3k.kokkos'],
+                             purpose='test: compile ex3k.kokkos',
+                             work_dir=w_dir):
             tty.warn('Skipping petsc test: '
                      'failed to compile ex3k.kokkos')
             return

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -608,7 +608,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         """Run stand alone test: ex7"""
 
         make('ex7', parallel=False)
-        testexe = ['ex7' , '-mat_type', 'aijcusparse',
+        testexe = ['ex7', '-mat_type', 'aijcusparse',
                    '-sub_pc_factor_mat_solver_type', 'cusparse',
                    '-sub_ksp_type', 'preonly', '-sub_pc_type', 'ilu',
                    '-use_gpu_aware_mpi', '0']
@@ -619,7 +619,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                       work_dir=w_dir)
         make('clean', parallel=False)
 
-    def  run_ex3k_test(self, runexe, runopt, w_dir):
+    def run_ex3k_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex3k"""
 
         with working_dir(w_dir):

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -586,6 +586,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     def run_ex50_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex50"""
 
+        if not os.path.isfile(join_path(w_dir, 'ex50.c')):
+            tty.warn('Skipping petsc test: '
+                     'KSP tutorial example ex50 is missing')
+            return
+
         self.run_test('make',
                       options=['ex50'],
                       purpose='test: compile ex50',
@@ -615,6 +620,15 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     def run_ex7_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex7 with cuda"""
 
+        if not '+cuda' in self.spec:
+            tty.warn('Skipping petsc test: '
+                     'KSP tutorial example ex7 requires +cuda')
+            return
+        if not os.path.isfile(join_path(w_dir, 'ex7.c')):
+            tty.warn('Skipping petsc test: '
+                     'KSP tutorial example ex7 is missing')
+            return
+
         self.run_test('make',
                       options=['ex7'],
                       purpose='test: compile ex7',
@@ -633,6 +647,15 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
     def run_ex3k_test(self, runexe, runopt, w_dir):
         """Run stand alone test: ex3.kokkos with kokkos"""
+
+        if not '+kokkos' in self.spec:
+            tty.warn('Skipping petsc test: '
+                     'SNES tutorial example ex3k.kokkos requires +kokkos')
+            return
+        if not os.path.isfile(join_path(w_dir, 'ex3k.kokkos.cxx')):
+            tty.warn('Skipping petsc test: '
+                     'SNES tutorial example ex3k is missing')
+            return
 
         self.run_test('make',
                       options=['ex3k.kokkos'],
@@ -663,33 +686,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         runopt = ['-n', '1']
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'ksp', 'ksp', 'tutorials')
-        skip_test = 'Skipping petsc test:'
 
-        if os.path.isfile(join_path(w_dir, 'ex50.c')):
-            self.run_ex50_test(runexe, runopt, w_dir)
-        else:
-            tty.warn('{0} KSP tutorial example ex50 is missing'
-                     .format(skip_test))
-
-        if os.path.isfile(join_path(w_dir, 'ex7.c')):
-            if '+cuda' in self.spec:
-                self.run_ex7_test(runexe, runopt, w_dir)
-            else:
-                tty.msg('{0} KSP tutorial example ex7 requires +cuda'
-                        .format(skip_test))
-        else:
-            tty.warn('{0} KSP tutorial example ex7 is missing'
-                     .format(skip_test))
+        self.run_ex50_test(runexe, runopt, w_dir)
+        self.run_ex7_test(runexe, runopt, w_dir)
 
         w_dir = join_path(self.test_suite.current_test_cache_dir,
                           'src', 'snes', 'tutorials')
 
-        if os.path.isfile(join_path(w_dir, 'ex3k.kokkos.cxx')):
-            if '+kokkos' in self.spec:
-                self.run_ex3k_test(runexe, runopt, w_dir)
-            else:
-                tty.msg('{0} SNES tutorial example ex3k requires +kokkos'
-                        .format(skip_test))
-        else:
-            tty.warn('{0} SNES tutorial example ex3k.kokkos is missing'
-                     .format(skip_test))
+        self.run_ex3k_test(runexe, runopt, w_dir)


### PR DESCRIPTION
Re-work `petsc` from building in the install test root to using the test suite cache directory.

UPDATE: The goal of this PR is to avoid permissions issues related to building under the package's install prefix for shared Spack instances and facility deployments.