### PR TITLE
Don't run GitHub Actions in users' forks

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,6 +22,7 @@ on:
 jobs:
 
   fedora-clingo-sources:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     container: "fedora:latest"
     steps:
@@ -49,6 +50,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   ubuntu-clingo-sources:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     container: "ubuntu:latest"
     steps:
@@ -79,6 +81,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   opensuse-clingo-sources:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     container: "opensuse/leap:latest"
     steps:
@@ -105,6 +108,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   macos-clingo-sources:
+    if: startsWith(github.repository, 'spack/')
     runs-on: macos-latest
     steps:
       - name: Install dependencies
@@ -121,6 +125,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   macos-clingo-binaries:
+    if: startsWith(github.repository, 'spack/')
     runs-on: macos-latest
     strategy:
       matrix:
@@ -141,6 +146,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   ubuntu-clingo-binaries:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -163,6 +169,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   ubuntu-gnupg-binaries:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     container: "ubuntu:latest"
     steps:
@@ -191,6 +198,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   ubuntu-gnupg-sources:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     container: "ubuntu:latest"
     steps:
@@ -221,6 +229,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   macos-gnupg-binaries:
+    if: startsWith(github.repository, 'spack/')
     runs-on: macos-latest
     steps:
       - name: Install dependencies
@@ -237,6 +246,7 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   macos-gnupg-sources:
+    if: startsWith(github.repository, 'spack/')
     runs-on: macos-latest
     steps:
       - name: Install dependencies

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   deploy-images:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   install_gcc:
+    if: startsWith(github.repository, 'spack/')
     name: gcc with clang
     runs-on: macos-latest
     steps:
@@ -35,6 +36,7 @@ jobs:
         spack install -v --fail-fast gcc@9.2.0 %apple-clang
 
   install_jupyter_clang:
+    if: startsWith(github.repository, 'spack/')
     name: jupyter
     runs-on: macos-latest
     timeout-minutes: 700
@@ -49,6 +51,7 @@ jobs:
         spack install -v --fail-fast py-jupyterlab %apple-clang
 
   install_scipy_clang:
+    if: startsWith(github.repository, 'spack/')
     name: scipy, mpl, pd
     runs-on: macos-latest
     steps:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -13,6 +13,7 @@ jobs:
   # Validate that the code can be run on all the Python versions
   # supported by Spack
   validate:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
@@ -29,6 +30,7 @@ jobs:
       run: vermin --backport argparse --violations --backport typing -t=2.7- -t=3.5- -vvv var/spack/repos
   # Run style checks on the files that have been changed
   style:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
@@ -50,6 +52,7 @@ jobs:
           share/spack/qa/run-style-tests
   # Check which files have been updated by the PR
   changes:
+    if: startsWith(github.repository, 'spack/')
     runs-on: ubuntu-latest
     # Set job outputs to values from filter step
     outputs:
@@ -92,6 +95,7 @@ jobs:
 
   # Run unit tests with different configurations on linux
   unittests:
+    if: startsWith(github.repository, 'spack/')
     needs: [ validate, style, changes ]
     runs-on: ubuntu-latest
     strategy:
@@ -157,6 +161,7 @@ jobs:
         flags: unittests,linux,${{ matrix.concretizer }}
   # Test shell integration
   shell:
+    if: startsWith(github.repository, 'spack/')
     needs: [ validate, style, changes ]
     runs-on: ubuntu-latest
     steps:
@@ -197,6 +202,7 @@ jobs:
   # Test RHEL8 UBI with platform Python. This job is run
   # only on PRs modifying core Spack
   rhel8-platform-python:
+    if: startsWith(github.repository, 'spack/')
     needs: [ validate, style, changes ]
     runs-on: ubuntu-latest
     if: ${{ needs.changes.outputs.with_coverage == 'true' }}
@@ -223,6 +229,7 @@ jobs:
           spack unit-test -k 'not cvs and not svn and not hg' -x --verbose
   # Test for the clingo based solver (using clingo-cffi)
   clingo-cffi:
+    if: startsWith(github.repository, 'spack/')
     needs: [ validate, style, changes ]
     runs-on: ubuntu-latest
     steps:
@@ -269,6 +276,7 @@ jobs:
         flags: unittests,linux,clingo
   # Run unit tests on MacOS
   build:
+    if: startsWith(github.repository, 'spack/')
     needs: [ validate, style, changes ]
     runs-on: macos-latest
     strategy:


### PR DESCRIPTION
Currently, Spack's GitHub Actions run in users' forks. In this PR I add a condition to every "job" in every workflow that requires GitHub repository name to start with `spack/` in order for the job to execute (unfortunately, there are no per-workflow conditions).
