### PR TITLE
podman: new package (with dependencies)

### DIFF
--- a/var/spack/repos/builtin/packages/cni-plugins/package.py
+++ b/var/spack/repos/builtin/packages/cni-plugins/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class CniPlugins(Package):
+    """Standard networking plugins for container networking"""
+
+    homepage    = 'https://github.com/containernetworking/plugins'
+    url         = 'https://github.com/containernetworking/plugins/archive/v1.0.1.tar.gz'
+    maintainers = ['bernhardkaindl']
+
+    version('1.0.1', sha256='2ba3cd9f341a7190885b60d363f6f23c6d20d975a7a0ab579dd516f8c6117619')
+
+    depends_on('go', type='build')
+
+    def install(self, spec, prefix):
+        utils = 'github.com/containernetworking/plugins/pkg/utils/buildversion'
+        which('./build_linux.sh')(
+            '-ldflags',
+            '-extldflags -static -X {0}.BuildVersion={1}'.format(utils, self.version),
+        )
+        install_tree('bin', prefix.bin)

--- a/var/spack/repos/builtin/packages/conmon/package.py
+++ b/var/spack/repos/builtin/packages/conmon/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Conmon(MakefilePackage):
+    """An OCI container runtime monitor"""
+
+    homepage    = 'https://github.com/containers/conmon'
+    url         = 'https://github.com/containers/conmon/archive/v2.0.30.tar.gz'
+    maintainers = ['bernhardkaindl']
+
+    version('2.0.30', sha256='4b0a98fbe8a63c42f60edac25c19aa6606caa7b1e4fe7846fc7f7de0b566ba25')
+
+    depends_on('go',         type='build')
+    depends_on('go-md2man',  type='build')
+    depends_on('pkgconfig',  type='build')
+    depends_on('libseccomp')
+    depends_on('glib')
+
+    def install(self, spec, prefix):
+        make('install', 'PREFIX=' + prefix)

--- a/var/spack/repos/builtin/packages/libslirp/package.py
+++ b/var/spack/repos/builtin/packages/libslirp/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libslirp(MesonPackage):
+    """General purpose TCP-IP emulator"""
+
+    homepage    = 'https://gitlab.freedesktop.org/slirp/libslirp'
+    url         = 'https://gitlab.freedesktop.org/slirp/libslirp/-/archive/v4.6.1/libslirp-v4.6.1.tar.gz'
+    maintainers = ['bernhardkaindl']
+
+    version('4.6.1', sha256='69ad4df0123742a29cc783b35de34771ed74d085482470df6313b6abeb799b11')
+
+    depends_on('pkgconfig', type='build')
+    depends_on('glib')

--- a/var/spack/repos/builtin/packages/podman/package.py
+++ b/var/spack/repos/builtin/packages/podman/package.py
@@ -1,0 +1,81 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Podman(Package):
+    """An optionally rootless and daemonless container engine: alias docker=podman"""
+
+    homepage    = 'https://podman.io'
+    url         = 'https://github.com/containers/podman/archive/v3.4.2.tar.gz'
+    maintainers = ['bernhardkaindl']
+
+    version('3.4.2', sha256='b0c4f9a11eb500b1d440d5e51a6c0c632aa4ac458e2dc0362f50f999eb7fbf31')
+
+    depends_on('go',          type='build')
+    depends_on('go-md2man',   type='build')
+    depends_on('pkgconfig',   type='build')
+    depends_on('cni-plugins', type='run')
+    depends_on('conmon',      type='run')
+    depends_on('runc',        type='run')
+    depends_on('slirp4netns', type='run')
+    depends_on('gpgme')
+    depends_on('libassuan')
+    depends_on('libgpg-error')
+    depends_on('libseccomp')
+
+    def patch(self):
+        defs = FileFilter('vendor/github.com/containers/common/pkg/config/default.go')
+
+        # Prepend the provided runc executable to podman's built-in runc search path
+        defs.filter(
+            '"runc": {',
+            '"runc": {' + '"{0}",'.format(self.spec['runc'].prefix.sbin.runc)
+        )
+        # Prepend the provided conmon executable to podman's built-in conmon search path
+        defs.filter(
+            r'ConmonPath = \[\]string{',
+            'ConmonPath = []string{' +
+            '\n        "{0}",'.format(self.spec['conmon'].prefix.bin.conmon)
+        )
+        # Prepend the provided cni-plugins directory to the cni-plugin search path
+        defs.filter(
+            r'DefaultCNIPluginDirs = \[\]string{',
+            'DefaultCNIPluginDirs = []string{' +
+            '\n        "{0}",'.format(self.spec['cni-plugins'].prefix.bin)
+        )
+        # Set the default path for slirp4netns to the provided slirp4netns executable
+        defs.filter(
+            'cniConfig := _cniConfigDir',
+            'cniConfig := _cniConfigDir' +
+            '\n        defaultEngineConfig.NetworkCmdPath = "{0}"'.format(
+                self.spec['slirp4netns'].prefix.bin.slirp4netns
+            )
+        )
+        # Use the podman install prefix as fallback path for finding container.conf
+        filter_file(
+            r'/usr',
+            self.prefix,
+            'vendor/github.com/containers/common/pkg/config/config.go',
+        )
+
+    def install(self, spec, prefix):
+        # Set default policy.json to be located in the install prefix (documented)
+        env['EXTRA_LDFLAGS'] = (
+            '-X github.com/containers/image/v5/signature.systemDefaultPolicyPath=' +
+            prefix + '/etc/containers/policy.json'
+        )
+        # Build and installation needs to be in two separate make calls
+        # The devicemapper and btrfs drivers are (so far) not enabled in this recipe
+        tags = 'seccomp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs'
+        make('-e', 'BUILDTAGS=' + tags)
+        make('install', 'PREFIX=' + prefix)
+        # Install an initial etc/containers/policy.json (configured in prefix above)
+        mkdirp(prefix.etc.containers)
+        install('test/policy.json', prefix.etc.containers)
+        # Cleanup directory trees which are created as part of the go build process
+        remove_linked_tree(prefix.src)
+        remove_linked_tree(prefix.pkg)

--- a/var/spack/repos/builtin/packages/runc/package.py
+++ b/var/spack/repos/builtin/packages/runc/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Runc(MakefilePackage):
+    """CLI tool for spawning containers on Linux according to the OCI specification"""
+
+    homepage    = 'https://github.com/opencontainers/runc'
+    url         = 'https://github.com/opencontainers/runc/releases/download/v1.0.2/runc.tar.xz'
+    maintainers = ['bernhardkaindl']
+
+    version('1.0.2', sha256='740acb49e33eaf4958b5109c85363c1d3900f242d4cab47fbdbefa6f8f3c6909')
+
+    depends_on('go',          type='build')
+    depends_on('go-md2man',   type='build')
+    depends_on('pkgconfig',   type='build')
+    depends_on('libseccomp')
+
+    def install(self, spec, prefix):
+        make('install', 'PREFIX=' + prefix)

--- a/var/spack/repos/builtin/packages/slirp4netns/package.py
+++ b/var/spack/repos/builtin/packages/slirp4netns/package.py
@@ -1,0 +1,25 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Slirp4netns(AutotoolsPackage):
+    """User-mode networking for unprivileged network namespaces"""
+
+    homepage    = 'https://github.com/rootless-containers/slirp4netns'
+    url         = 'https://github.com/rootless-containers/slirp4netns/archive/v1.1.12.tar.gz'
+    maintainers = ['bernhardkaindl']
+
+    version('1.1.12', sha256='279dfe58a61b9d769f620b6c0552edd93daba75d7761f7c3742ec4d26aaa2962')
+
+    depends_on('autoconf',  type='build', when='@1.1.12')
+    depends_on('automake',  type='build', when='@1.1.12')
+    depends_on('libtool',   type='build', when='@1.1.12')
+    depends_on('pkgconfig', type='build')
+    depends_on('glib')
+    depends_on('libcap')
+    depends_on('libseccomp')
+    depends_on('libslirp')


### PR DESCRIPTION
When the uidmap tools are installed on a system, this allows to run
containers as unprivileged user (rootless and daemonless) slimilar
to singularity, but using a familiar CLI: `alias docker=podman`

This is helpful to run e.g. `spack` builds in containers to reproduce
build failures from CI without requiring a installation of `docker`.
The required dependencies of podman are added as well.