### PR TITLE
py-cython: add 3.0.0a9

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -9,9 +9,11 @@ from spack import *
 class PyCython(PythonPackage):
     """The Cython compiler for writing C extensions for the Python language."""
 
+    homepage = "https://github.com/cython/cython"
     pypi = "cython/Cython-0.29.21.tar.gz"
 
-    version('0.29.24', sha256='cdf04d07c3600860e8c2ebaad4e8f52ac3feb212453c1764a49ac08c827e8443')
+    version('3.0.0a9', sha256='23931c45877432097cef9de2db2dc66322cbc4fc3ebbb42c476bb2c768cecff0')
+    version('0.29.24', sha256='cdf04d07c3600860e8c2ebaad4e8f52ac3feb212453c1764a49ac08c827e8443', preferred=True)
     version('0.29.23', sha256='6a0d31452f0245daacb14c979c77e093eb1a546c760816b5eed0047686baad8e')
     version('0.29.22', sha256='df6b83c7a6d1d967ea89a2903e4a931377634a297459652e4551734c48195406')
     version('0.29.21', sha256='e57acb89bd55943c8d8bf813763d20b9099cc7165c0f16b707631a7654be9cad')
@@ -32,7 +34,8 @@ class PyCython(PythonPackage):
     version('0.23.4',  sha256='fec42fecee35d6cc02887f1eef4e4952c97402ed2800bfe41bbd9ed1a0730d8e')
     version('0.21.2',  sha256='b01af23102143515e6138a4d5e185c2cfa588e0df61c0827de4257bac3393679')
 
-    depends_on('python@2.6:2.8,3.3:', when='@0.23:', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2,3.4:', when='@3.0a1:', type=('build', 'link', 'run'))
+    depends_on('python@2.6:2,3.3:', when='@0.23:', type=('build', 'link', 'run'))
     depends_on('python@:2', when='@:0.22', type=('build', 'link', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('gdb@7.2:', type='test')

--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -34,7 +34,7 @@ class PyCython(PythonPackage):
     version('0.23.4',  sha256='fec42fecee35d6cc02887f1eef4e4952c97402ed2800bfe41bbd9ed1a0730d8e')
     version('0.21.2',  sha256='b01af23102143515e6138a4d5e185c2cfa588e0df61c0827de4257bac3393679')
 
-    depends_on('python@2.7:2,3.4:', when='@3.0a1:', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2,3.4:', when='@3:', type=('build', 'link', 'run'))
     depends_on('python@2.6:2,3.3:', when='@0.23:', type=('build', 'link', 'run'))
     depends_on('python@:2', when='@:0.22', type=('build', 'link', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))


### PR DESCRIPTION
https://github.com/cython/cython/tree/3.0.0a9

I have to update to this version to be able to update `py-gevent`.
Since this `py-cython` version is an alpha release I did not want to break anything for the other packages and added a preference to 0.29.24. Once the proper release is out, we can remove the preference again.