### PR TITLE
Fix leaky tests

### DIFF
--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -102,7 +102,7 @@ common_compile_args = (
 )
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def wrapper_environment():
     with set_env(
             SPACK_CC=real_cc,

--- a/lib/spack/spack/test/cmd/build_env.py
+++ b/lib/spack/spack/test/cmd/build_env.py
@@ -15,12 +15,12 @@ build_env = SpackCommand('build-env')
     ('zlib',),
     ('zlib', '--')
 ])
-@pytest.mark.usefixtures('config')
+@pytest.mark.usefixtures('config', 'mock_packages', 'working_env')
 def test_it_just_runs(pkg):
     build_env(*pkg)
 
 
-@pytest.mark.usefixtures('config')
+@pytest.mark.usefixtures('config', 'mock_packages', 'working_env')
 def test_error_when_multiple_specs_are_given():
     output = build_env('libelf libdwarf', fail_on_error=False)
     assert 'only takes one spec' in output
@@ -31,7 +31,7 @@ def test_error_when_multiple_specs_are_given():
     ('--',),
     (),
 ])
-@pytest.mark.usefixtures('config')
+@pytest.mark.usefixtures('config', 'mock_packages', 'working_env')
 def test_build_env_requires_a_spec(args):
     output = build_env(*args, fail_on_error=False)
     assert 'requires a spec' in output
@@ -40,7 +40,7 @@ def test_build_env_requires_a_spec(args):
 _out_file = 'env.out'
 
 
-@pytest.mark.usefixtures('config')
+@pytest.mark.usefixtures('config', 'mock_packages', 'working_env')
 def test_dump(tmpdir):
     with tmpdir.as_cwd():
         build_env('--dump', _out_file, 'zlib')
@@ -48,7 +48,7 @@ def test_dump(tmpdir):
             assert(any(line.startswith('PATH=') for line in f.readlines()))
 
 
-@pytest.mark.usefixtures('config')
+@pytest.mark.usefixtures('config', 'mock_packages', 'working_env')
 def test_pickle(tmpdir):
     with tmpdir.as_cwd():
         build_env('--pickle', _out_file, 'zlib')

--- a/lib/spack/spack/test/cmd/dev_build.py
+++ b/lib/spack/spack/test/cmd/dev_build.py
@@ -134,7 +134,7 @@ def mock_module_noop(*args):
 
 
 def test_dev_build_drop_in(tmpdir, mock_packages, monkeypatch,
-                           install_mockery):
+                           install_mockery, working_env):
     monkeypatch.setattr(os, 'execvp', print_spack_cc)
 
     monkeypatch.setattr(spack.build_environment, 'module', mock_module_noop)


### PR DESCRIPTION
- fix: cc.py should use a function not session scope
- fix: don't let build env vars leak to other tests
- fix: don't leak build env in dev_build test 