### PR TITLE
Make patchelf test use the realpath

### DIFF
--- a/lib/spack/spack/test/relocate.py
+++ b/lib/spack/spack/test/relocate.py
@@ -241,7 +241,7 @@ def test_file_is_relocatable(source_file, is_relocatable):
 
 @pytest.mark.requires_executables('patchelf', 'strings', 'file')
 def test_patchelf_is_relocatable():
-    patchelf = spack.relocate._patchelf()
+    patchelf = os.path.realpath(spack.relocate._patchelf())
     assert llnl.util.filesystem.is_exe(patchelf)
     assert spack.relocate.file_is_relocatable(patchelf)
 


### PR DESCRIPTION
I think this test should be removed, but when it stays, it should at
least follow the symlink, cause it fails for me if I let spack build
patchelf and have a symlink in a view.
