### PR TITLE
umpire: fix gcc@10.3.0 conflict

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -104,9 +104,8 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     # https://github.com/LLNL/Umpire/issues/653
     # This range looks weird, but it ensures the concretizer looks at it as a
-    # range, not as a concrete version, so that it also matches compilers
-    # specified as `gcc@10.3.0-identifier`. See #8957.
-    conflicts('%gcc@10.3.0:10.3.0.0', when='+cuda')
+    # range, not as a concrete version, so that it also matches 10.3.* versions.
+    conflicts('%gcc@10.3.0:10.4.0', when='+cuda')
 
     def _get_sys_type(self, spec):
         sys_type = spec.architecture

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -105,7 +105,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     # https://github.com/LLNL/Umpire/issues/653
     # This range looks weird, but it ensures the concretizer looks at it as a
     # range, not as a concrete version, so that it also matches 10.3.* versions.
-    conflicts('%gcc@10.3.0:10.4.0', when='+cuda')
+    conflicts('%gcc@10.3.0:10.3', when='+cuda')
 
     def _get_sys_type(self, spec):
         sys_type = spec.architecture


### PR DESCRIPTION
It is a followup of https://github.com/spack/spack/pull/26028, and I can add that it affects also an older version of umpire (e.g. `umpire@4.1.2`).

Apparently the previous conflict was not working correctly.

Just to be clear, there not seems to be any gcc@10.4.0 version, it is used just as a (reasonable?) upper bound, based on the hope that the GCC bug reported here
https://github.com/spack/spack/pull/25980 is actually the problem with umpire (unfortunately I did not have the chance to test it) and it is already fixed in newer versions (i.e. >=11).