### PR TITLE
Update available Uncrustify versions

### DIFF
--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -38,6 +38,12 @@ class Uncrustify(Package):
             make()
             make('install')
 
+    @when('@0.63')
+    def install(self, spec, prefix):
+        configure('--prefix={0}'.format(self.prefix))
+        make()
+        make('install')
+
     @when('@:0.62')
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(self.prefix))

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -52,3 +52,5 @@ class Uncrustify(Package):
         configure('--prefix={0}'.format(self.prefix))
         make()
         make('install')
+
+    patch('uncrustify-includes.patch', when='@0.73')

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -35,7 +35,7 @@ class Uncrustify(Package):
     depends_on('automake', type='build', when='@0.63')
     depends_on('autoconf', type='build', when='@0.63')
 
-    @when('@0.64:,develop')
+    @when('@0.64:')
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):
             cmake('..', *std_cmake_args)

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -11,25 +11,27 @@ class Uncrustify(Package):
 
     homepage = "http://uncrustify.sourceforge.net/"
     git      = "https://github.com/uncrustify/uncrustify"
-    url      = "https://sourceforge.net/projects/uncrustify/files/uncrustify/uncrustify-0.61/uncrustify-0.61.tar.gz"
+    url      = "https://sourceforge.net/projects/uncrustify/files/uncrustify/uncrustify-0.69/uncrustify-0.69.tar.gz"
 
     version('master', branch='master')
-    version('0.74', commit='62048b01507304653ea98a74b31e0edbadaf7496')
-    version('0.73', commit='25b765b4ccf1fc50302df3779188ccd402962ee0')
-    version('0.72', commit='1d3d8fa5e81bece0fac4b81316b0844f7cc35926')
-    version('0.71', commit='64d82fd66f9eeeba14a591aa0939d495eccd1bc6')
-    version('0.70', commit='51f64d6e62f5ea84f2c428c0478d01b1fbf6948c')
-    version('0.69', commit='a7a8fb35d653e0b49e1c86f2eb8a2970025d5989')
-    version('0.68', commit='86bc346e01c16c96e4baff8132e024ca13772ce9')
-    version('0.67', commit='00321aa37802ae9ae78459957498a3c933b8254f')
-    version('0.66', commit='80f549b6f026d0b4cf14eae3a1ba8a7389642e45')
-    version('0.65', commit='9056763eb1c8c3837fd718eba03facdd4d8c179d')
-    version('0.64', commit='1d7d97fb637dcb05ebc5fe57ee1020e2a659210d')
-    version('0.63', commit='44ce0f156396b79ddf3ed9242023a14e9665b76f')
-    version('0.62', commit='5987f2223f16b993dbece1360363eef9515fe5e8')
+    version('0.74', commit='62048b')
+    version('0.73', commit='25b765')
+    version('0.72', commit='1d3d8f')
+    version('0.71', commit='64d82f')
+    version('0.70', commit='51f64d')
+    version('0.69', commit='a7a8fb')
+    version('0.68', commit='86bc34')
+    version('0.67', commit='00321a')
+    version('0.66', commit='80f549')
+    version('0.65', commit='905676')
+    version('0.64', commit='1d7d97')
+    version('0.63', commit='44ce0f')
+    version('0.62', commit='5987f2')
     version('0.61', sha256='1df0e5a2716e256f0a4993db12f23d10195b3030326fdf2e07f8e6421e172df9')
 
     depends_on('cmake', type='build', when='@0.64:')
+    depends_on('automake', type='build', when='@0.63')
+    depends_on('autoconf', type='build', when='@0.63')
 
     @when('@0.64:,master')
     def install(self, spec, prefix):
@@ -40,6 +42,7 @@ class Uncrustify(Package):
 
     @when('@0.63')
     def install(self, spec, prefix):
+        which('bash')('autogen.sh')
         configure('--prefix={0}'.format(self.prefix))
         make()
         make('install')

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -12,7 +12,7 @@ class Uncrustify(Package):
     homepage = "http://uncrustify.sourceforge.net/"
     git      = "https://github.com/uncrustify/uncrustify"
     url      = "https://sourceforge.net/projects/uncrustify/files/uncrustify/uncrustify-0.69/uncrustify-0.69.tar.gz"
-    
+
     maintainers = ['gmaurel']
 
     version('master', branch='master')

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -12,6 +12,8 @@ class Uncrustify(Package):
     homepage = "http://uncrustify.sourceforge.net/"
     git      = "https://github.com/uncrustify/uncrustify"
     url      = "https://sourceforge.net/projects/uncrustify/files/uncrustify/uncrustify-0.69/uncrustify-0.69.tar.gz"
+    
+    maintainers = ['gmaurel']
 
     version('master', branch='master')
     version('0.74', commit='62048b')
@@ -33,7 +35,7 @@ class Uncrustify(Package):
     depends_on('automake', type='build', when='@0.63')
     depends_on('autoconf', type='build', when='@0.63')
 
-    @when('@0.64:,master')
+    @when('@0.64:,develop')
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):
             cmake('..', *std_cmake_args)

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -10,14 +10,28 @@ class Uncrustify(Package):
     """Source Code Beautifier for C, C++, C#, ObjectiveC, Java, and others."""
 
     homepage = "http://uncrustify.sourceforge.net/"
-    url      = "http://downloads.sourceforge.net/project/uncrustify/uncrustify/uncrustify-0.61/uncrustify-0.61.tar.gz"
+    git      = "https://github.com/uncrustify/uncrustify"
+    url      = "https://sourceforge.net/projects/uncrustify/files/uncrustify/uncrustify-0.61/uncrustify-0.61.tar.gz"
 
-    version('0.67', sha256='54f15c8ebddef120522db21f38fac1dd3b0a285fbf60a8b71f9e333e96cf6ddc')
+    version('master', branch='master')
+    version('0.74', commit='62048b01507304653ea98a74b31e0edbadaf7496')
+    version('0.73', commit='25b765b4ccf1fc50302df3779188ccd402962ee0')
+    version('0.72', commit='1d3d8fa5e81bece0fac4b81316b0844f7cc35926')
+    version('0.71', commit='64d82fd66f9eeeba14a591aa0939d495eccd1bc6')
+    version('0.70', commit='51f64d6e62f5ea84f2c428c0478d01b1fbf6948c')
+    version('0.69', commit='a7a8fb35d653e0b49e1c86f2eb8a2970025d5989')
+    version('0.68', commit='86bc346e01c16c96e4baff8132e024ca13772ce9')
+    version('0.67', commit='00321aa37802ae9ae78459957498a3c933b8254f')
+    version('0.66', commit='80f549b6f026d0b4cf14eae3a1ba8a7389642e45')
+    version('0.65', commit='9056763eb1c8c3837fd718eba03facdd4d8c179d')
+    version('0.64', commit='1d7d97fb637dcb05ebc5fe57ee1020e2a659210d')
+    version('0.63', commit='44ce0f156396b79ddf3ed9242023a14e9665b76f')
+    version('0.62', commit='5987f2223f16b993dbece1360363eef9515fe5e8')
     version('0.61', sha256='1df0e5a2716e256f0a4993db12f23d10195b3030326fdf2e07f8e6421e172df9')
 
     depends_on('cmake', type='build', when='@0.64:')
 
-    @when('@0.64:')
+    @when('@0.64:,master')
     def install(self, spec, prefix):
         with working_dir('spack-build', create=True):
             cmake('..', *std_cmake_args)

--- a/var/spack/repos/builtin/packages/uncrustify/uncrustify-includes.patch
+++ b/var/spack/repos/builtin/packages/uncrustify/uncrustify-includes.patch
@@ -1,0 +1,26 @@
+diff -Naur spack-src/src/output.cpp spack-src.patched/src/output.cpp
+--- spack-src/src/output.cpp	2021-11-23 17:28:36.000000000 +0100
++++ spack-src.patched/src/output.cpp	2021-11-23 18:26:42.000000000 +0100
+@@ -20,9 +20,7 @@
+ #include <regex>
+ #include <set>
+
+-#ifdef WIN32
+ #include <map>                    // to get std::map
+-#endif // WIN32
+
+
+ constexpr static auto LCURRENT = LOUTPUT;
+diff -Naur spack-src/src/tokenize.cpp spack-src.patched/src/tokenize.cpp
+--- spack-src/src/tokenize.cpp	2021-11-23 17:28:36.000000000 +0100
++++ spack-src.patched/src/tokenize.cpp	2021-11-23 18:26:30.000000000 +0100
+@@ -17,9 +17,7 @@
+
+ #include <regex>
+
+-#ifdef WIN32
+ #include <stack>            // to get std::stack
+-#endif // WIN32
+
+
+ #define LE_COUNT(x)    cpd.le_counts[static_cast<size_t>(LE_ ## x)]


### PR DESCRIPTION
After changing my package manager recently from brew to spack I realised that there were a lot of uncrustify versions missing.
So I added all minor releases that are available in their [git repo](https://github.com/uncrustify/uncrustify).
Also added a patch to make `v0.73` installable which was only fixed in `v0.74`.

PS: although I am pretty new to using spack I already see that the current version of using a general `Package` is not the best solution since it is actually a `AutotoolsPackage` for versions `<v0.64` and a `CMakePackge`for the rest. However I did not have the time yet to read fully into the API to make this PR perfect. If the maintainers think it is good as it is or has any quick edits let me know.

Closes uncrustify/uncrustify#3400.