### PR TITLE
py-mayavi: fix vtk not discoverable

### DIFF
--- a/var/spack/repos/builtin/packages/py-mayavi/package.py
+++ b/var/spack/repos/builtin/packages/py-mayavi/package.py
@@ -26,3 +26,9 @@ class PyMayavi(PythonPackage):
     depends_on('py-traitsui@6:', type=('build', 'run'))
     depends_on('vtk+python', type=('build', 'run'))
     depends_on('py-pyqt5', type=('build', 'run'))
+
+    def patch(self):
+        # to remove Error when starting `mayavi2`:
+        # pkg_resources.DistributionNotFound: The 'vtk' distribution was not
+        # found and is required by mayavi
+        filter_file('vtk', '', 'mayavi/__init__.py', string=True)


### PR DESCRIPTION
This PR fixes that the mayavi application (calling `mayavi2`) fails with [1] because vtk is not discoverable by pkg_resources. Unfortunately the application still does not start for me, but I will open an issue for that.

[1]:
```
$ mayavi2
Traceback (most recent call last):
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-mayavi-4.7.3-mdifgrxqjires35i2u4qtny4danabk3n/bin/mayavi2", line 34, in <module>
    sys.exit(load_entry_point('mayavi==4.7.3', 'gui_scripts', 'mayavi2')())
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-mayavi-4.7.3-mdifgrxqjires35i2u4qtny4danabk3n/bin/mayavi2", line 26, in importlib_load_entry_point
    return next(matches).load()
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/python-3.8.12-ki22qjbudhz5hudrexeghc3xvjehgbhr/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/python-3.8.12-ki22qjbudhz5hudrexeghc3xvjehgbhr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-mayavi-4.7.3-mdifgrxqjires35i2u4qtny4danabk3n/lib/python3.8/site-packages/mayavi/scripts/mayavi2.py", line 464, in <module>
    from mayavi.plugins.app import Mayavi, setup_logger
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-mayavi-4.7.3-mdifgrxqjires35i2u4qtny4danabk3n/lib/python3.8/site-packages/mayavi/plugins/app.py", line 19, in <module>
    from .mayavi_workbench_application import MayaviWorkbenchApplication
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-mayavi-4.7.3-mdifgrxqjires35i2u4qtny4danabk3n/lib/python3.8/site-packages/mayavi/plugins/mayavi_workbench_application.py", line 13, in <module>
    from envisage.ui.workbench.api import WorkbenchApplication
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-envisage-6.0.1-erndgoonl6w4w3xpdwzulibj657m6ph4/lib/python3.8/site-packages/envisage/ui/workbench/api.py", line 13, in <module>
    from .workbench import Workbench
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-envisage-6.0.1-erndgoonl6w4w3xpdwzulibj657m6ph4/lib/python3.8/site-packages/envisage/ui/workbench/workbench.py", line 16, in <module>
    from envisage.api import IApplication
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-envisage-6.0.1-erndgoonl6w4w3xpdwzulibj657m6ph4/lib/python3.8/site-packages/envisage/api.py", line 70, in <module>
    from .egg_plugin_manager import EggPluginManager
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-envisage-6.0.1-erndgoonl6w4w3xpdwzulibj657m6ph4/lib/python3.8/site-packages/envisage/egg_plugin_manager.py", line 18, in <module>
    import pkg_resources
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-setuptools-58.2.0-hjgczo5aalred6ycf54d53q4fwfdhhaq/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3243, in <module>
    def _initialize_master_working_set():
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-setuptools-58.2.0-hjgczo5aalred6ycf54d53q4fwfdhhaq/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3226, in _call_aside
    f(*args, **kwargs)
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-setuptools-58.2.0-hjgczo5aalred6ycf54d53q4fwfdhhaq/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3255, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-setuptools-58.2.0-hjgczo5aalred6ycf54d53q4fwfdhhaq/lib/python3.8/site-packages/pkg_resources/__init__.py", line 568, in _build_master
    ws.require(__requires__)
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-setuptools-58.2.0-hjgczo5aalred6ycf54d53q4fwfdhhaq/lib/python3.8/site-packages/pkg_resources/__init__.py", line 886, in require
    needed = self.resolve(parse_requirements(requirements))
  File "$spack/opt/spack/linux-fedora32-haswell/gcc-11.2.0/py-setuptools-58.2.0-hjgczo5aalred6ycf54d53q4fwfdhhaq/lib/python3.8/site-packages/pkg_resources/__init__.py", line 772, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'vtk' distribution was not found and is required by mayavi
```