### PR TITLE
Fix the dsfmt package shared libs

### DIFF
--- a/var/spack/repos/builtin/packages/dsfmt/package.py
+++ b/var/spack/repos/builtin/packages/dsfmt/package.py
@@ -10,7 +10,7 @@ class Dsfmt(MakefilePackage):
     """Double precision SIMD-oriented Fast Mersenne Twister"""
 
     homepage = "http://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/SFMT/"
-    url      = "http://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/SFMT/dSFMT-src-2.2.3.tar.gz"
+    url      = "https://github.com/MersenneTwister-Lab/dSFMT/archive/v2.2.4.tar.gz"
 
     maintainers = ['haampie']
 
@@ -18,14 +18,15 @@ class Dsfmt(MakefilePackage):
     # so we add it for them.
     patch('targets.patch')
 
-    version('2.2.3', sha256='82344874522f363bf93c960044b0a6b87b651c9565b6312cf8719bb8e4c26a0e')
+    version('2.2.5', sha256='b7bc498cd140b4808963b1ff9f33b42a491870f54775c1060ecad0e02bcaffb4')
+    version('2.2.4', sha256='39682961ecfba621a98dbb6610b6ae2b7d6add450d4f08d8d4edd0e10abd8174')
 
     @property
     def libs(self):
         return find_libraries('libdSFMT', root=self.prefix, recursive=True)
 
-    def make(self, spec, prefix):
-        make('library')
+    def build(self, spec, prefix):
+        make('build-library')
 
     def install(self, spec, prefix):
         make('PREFIX={0}'.format(prefix), 'install')

--- a/var/spack/repos/builtin/packages/dsfmt/targets.patch
+++ b/var/spack/repos/builtin/packages/dsfmt/targets.patch
@@ -1,28 +1,25 @@
-From a78e6df557b1dfaead886fdac9fda0a3a9086493 Mon Sep 17 00:00:00 2001
-From: Harmen Stoppels <harmenstoppels@gmail.com>
-Date: Mon, 8 Nov 2021 10:18:54 +0100
-Subject: [PATCH] Add a library/install target
-
----
- Makefile | 7 +++++++
- 1 file changed, 7 insertions(+)
-
 diff --git a/Makefile b/Makefile
-index 5cc4ed6..a9dcd99 100644
+index 5cc4ed6..adc09c5 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -196,3 +196,10 @@ test-sse2-M216091: test.c dSFMT.c dSFMT.h
+@@ -196,3 +196,20 @@ test-sse2-M216091: test.c dSFMT.c dSFMT.h
  
  clean:
  	rm -f *.o *~ test-*-M*
 +
-+library: dSFMT.c
-+	$(CC) $(CCFLAGS) -shared -fPIC dSFMT.c -o libdSFMT.so
++ifeq ($(OS), WINNT)
++  SHLIB_EXT := dll
++else ifeq ($(OS), Darwin)
++  SHLIB_EXT := dylib
++else
++  SHLIB_EXT := so
++endif
 +
-+install: library
++build-library: dSFMT.c
++	$(CC) $(CCFLAGS) -shared -fPIC -DDSFMT_MEXP=19937 -DDSFMT_DO_NOT_USE_OLD_NAMES -DDSFMT_SHLIB $< -o libdSFMT.$(SHLIB_EXT)
++	echo 1 > $@
++
++install: build-library
 +	install -d $(PREFIX)/lib/
 +	install -m 644 libdSFMT.so $(PREFIX)/lib/
-\ No newline at end of file
--- 
-2.25.1
-
++


### PR DESCRIPTION
Turns out the github repo was more up to date, and includes info on how to properly create a shared lib, which was adjusted for in the patch. The 2.2.3 version should not be used as a shared lib, so that's removed. Nobody uses this package yet, it's not in 0.17.0, so that should be fine.