### PR TITLE
New version: py-testpath 0.5.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-testpath/package.py
+++ b/var/spack/repos/builtin/packages/py-testpath/package.py
@@ -13,4 +13,7 @@ class PyTestpath(PythonPackage):
     homepage = "https://github.com/jupyter/testpath"
     pypi = "testpath/testpath-0.4.2.tar.gz"
 
+    version('0.5.0', sha256='1acf7a0bcd3004ae8357409fc33751e16d37ccc650921da1094a86581ad1e417')
     version('0.4.2', sha256='b694b3d9288dbd81685c5d2e7140b81365d46c29f5db4bc659de5aa6b98780f8')
+
+    depends_on('python@3.5:', type=('build', 'run'), when='@0.5.0:')


### PR DESCRIPTION
Pypi source contains `setup.py` script, so the old `python setup.py` method works.