### PR TITLE
VisIt - Remove upper range restriction on llvm.

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -212,7 +212,8 @@ class Visit(CMakePackage):
     depends_on('python@3.7', when='+python')
     # llvm@12.0.1, @11.1.0, @10.0.1 fail in build phase with gcc 6.1.0.
     # llvm@9.0.1 fails in cmake phase with gcc 6.1.0.
-    depends_on('llvm@6:8', when='^mesa')
+    # llvm@12.0.1, llvm@8.0.1 fail in build phase with gcc 11.2.0
+    depends_on('llvm@6:', when='^mesa')
     depends_on('mesa+glx', when='^mesa')
     depends_on('mesa-glu', when='^mesa')
     # VisIt doesn't build with hdf5@1.12 and hdf5@1.10 produces files that


### PR DESCRIPTION
I changed the range restriction on llvm from ``6:8`` to just ``6:``. I also added a comment noting some failures of llvm to build with gcc 11.2.0.

I tested this on spock.olcf.ornl.gov using:
```
spack install visit ^python+shared ^mesa+opengl ^llvm@11.0.1
```