### PR TITLE
add runtime dependency on `node-js@4.0:` for `yarn`

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -18,6 +18,8 @@ class NodeJs(Package):
     list_url = "https://nodejs.org/dist/"
     list_depth = 1
 
+    maintainers = ['cosmicexplorer']
+
     # Current (latest features)
     version('15.3.0',  sha256='cadfa384a5f14591b84ce07a1afe529f28deb0d43366fb0ae4e78afba96bfaf2')
     version('14.16.1', sha256='5f5080427abddde7f22fd2ba77cd2b8a1f86253277a1eec54bc98a202728ce80')

--- a/var/spack/repos/builtin/packages/yarn/package.py
+++ b/var/spack/repos/builtin/packages/yarn/package.py
@@ -12,6 +12,8 @@ class Yarn(Package):
     homepage = "https://yarnpkg.com"
     url      = "https://github.com/yarnpkg/yarn/releases/download/v1.22.4/yarn-v1.22.4.tar.gz"
 
+    depends_on('node-js@4.0:', type='run')
+
     version('1.22.4', sha256='bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58')
     version('1.22.2', sha256='de4cff575ae7151f8189bf1d747f026695d768d0563e2860df407ab79c70693d')
     version('1.22.1', sha256='3af905904932078faa8f485d97c928416b30a86dd09dcd76e746a55c7f533b72')

--- a/var/spack/repos/builtin/packages/yarn/package.py
+++ b/var/spack/repos/builtin/packages/yarn/package.py
@@ -12,6 +12,8 @@ class Yarn(Package):
     homepage = "https://yarnpkg.com"
     url      = "https://github.com/yarnpkg/yarn/releases/download/v1.22.4/yarn-v1.22.4.tar.gz"
 
+    maintainers = ['cosmicexplorer']
+
     depends_on('node-js@4.0:', type='run')
 
     version('1.22.4', sha256='bc5316aa110b2f564a71a3d6e235be55b98714660870c5b6b2d2d3f12587fb58')


### PR DESCRIPTION
Just tried to `spack install yarn`, which succeeded, but failed at runtime:

```bash
; yarn install . 
Yarn requires Node.js 4.0 or higher to be installed.
```

This PR adds a `type='run'` dependency to the `yarn` package, which fixes this error.