### PR TITLE
Added gcc macport suffixes for gcc >= 5

### DIFF
--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -23,10 +23,10 @@ class Gcc(spack.compiler.Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['gfortran']
 
-    # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
+    # MacPorts builds gcc versions with prefixes and -mp-X.Y or -mp-X suffixes.
     # Homebrew and Linuxbrew may build gcc with -X, -X.Y suffixes.
     # Old compatibility versions may contain XY suffixes.
-    suffixes = [r'-mp-\d+\.\d+', r'-\d+\.\d+', r'-\d+', r'\d\d']
+    suffixes = [r'-mp-\d+\.\d+', r'-mp-\d+', r'-\d+\.\d+', r'-\d+', r'\d\d']
 
     # Named wrapper links within build_env_path
     link_paths = {'cc': 'gcc/gcc',


### PR DESCRIPTION
gcc >= 5 compiled with macport was not discovered due to a missing suffix.