### PR TITLE
New package: py-sphinx-argparse

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinx-argparse/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-argparse/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PySphinxArgparse(PythonPackage):
+    """Sphinx extension to automatically document argparse-based commands."""
+
+    homepage = "https://pypi.org/project/sphinx-argparse"
+    pypi     = "sphinx-argparse/sphinx-argparse-0.3.1.tar.gz"
+
+    maintainers = ['sethrj']
+
+    version('0.3.1', sha256='82151cbd43ccec94a1530155f4ad34f251aaca6a0ffd5516d7fadf952d32dc1e')
+
+    depends_on('python@2.7.0:2.7,3.5:', type=('build', 'run'))
+    depends_on('py-sphinx@1.2.0:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Sphinx extension for autodocumenting commands created with the `argparse` module.