### PR TITLE
Fix py-astroid recipe

### DIFF
--- a/var/spack/repos/builtin/packages/py-astroid/package.py
+++ b/var/spack/repos/builtin/packages/py-astroid/package.py
@@ -39,12 +39,12 @@ class PyAstroid(PythonPackage):
     depends_on('py-lazy-object-proxy', type=('build', 'run'))
     # Starting with astroid 2.3.1, astroid's dependencies were restricted
     # to a given minor version, c.f. commit e1b4e11.
-    depends_on('py-lazy-object-proxy@1.4.0:1.4', when='@2.3.1:', type=('build', 'run'))
+    depends_on('py-lazy-object-proxy@1.4.0:1.4', when='@2.3.1:2.7.2', type=('build', 'run'))
     depends_on('py-lazy-object-proxy@1.4.0:', when='@2.7.3:', type=('build', 'run'))
     depends_on('py-six', type=('build', 'run'), when='@:2.7.2')
     depends_on('py-six@1.12:1', when='@2.3.3:2.7.2', type=('build', 'run'))
     depends_on('py-wrapt', when='@:2.2', type=('build', 'run'))
-    depends_on('py-wrapt@1.11:1.12', when='@2.3.3:', type=('build', 'run'))
+    depends_on('py-wrapt@1.11:1.12', when='@2.3.3:2.8.2', type=('build', 'run'))
     depends_on('py-wrapt@1.11:1.13', when='@2.8.3:', type=('build', 'run'))
     depends_on('py-enum34@1.1.3:', when='^python@:3.3', type=('build', 'run'))
     depends_on('py-singledispatch', when='^python@:3.3', type=('build', 'run'))


### PR DESCRIPTION
Prevent downgrade of py-lazy-object-proxy and py-wrapt 