### PR TITLE
Don't catch FetchCacheError, cause the remainder relies on its result

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -337,10 +337,7 @@ def match_downloaded_specs(pkgs, allow_multiple_matches=False, force=False,
     specs_from_cli = []
     has_errors = False
 
-    try:
-        specs = bindist.update_cache_and_get_specs()
-    except bindist.FetchCacheError as e:
-        tty.error(e)
+    specs = bindist.update_cache_and_get_specs()
 
     if not other_arch:
         arch = spack.spec.Spec.default_arch()
@@ -572,10 +569,7 @@ def install_tarball(spec, args):
 
 def listspecs(args):
     """list binary packages available from mirrors"""
-    try:
-        specs = bindist.update_cache_and_get_specs()
-    except bindist.FetchCacheError as e:
-        tty.error(e)
+    specs = bindist.update_cache_and_get_specs()
 
     if not args.allarch:
         arch = spack.spec.Spec.default_arch()


### PR DESCRIPTION
With the following environment:

```
$ cat spack.yaml
# This is a Spack Environment file.
#
# It describes a set of packages to be installed, along with
# configuration settings.
spack:
  # add package specs to the `specs` list
  specs: []
  view: false

  config:
    install_tree:
      root: /tmp/tmp.82RfP3XQ0J

  mirrors:
    local: file:///tmp/tmp.82RfP3XQ0J/bc
```

I still inherit default mirrors:

```
$ spack -e . mirror list
local           file:///tmp/tmp.82RfP3XQ0J/bc
spack-public    https://mirror.spack.io
```

And apparently there is no index file on `mirror.spack.io`, so that ultimately:

```
$ spack -d buildcache install -afu /7cwfjli
Traceback (most recent call last):
  File "/home/user/spack/bin/spack", line 100, in <module>
    sys.exit(spack.main.main())
  File "/home/user/spack/lib/spack/spack/main.py", line 882, in main
    return _main(argv)
  File "/home/user/spack/lib/spack/spack/main.py", line 865, in _main
    return _invoke_command(command, parser, args, unknown)
  File "/home/user/spack/lib/spack/spack/main.py", line 535, in _invoke_command
    return_val = command(parser, args)
  File "/home/user/spack/lib/spack/spack/cmd/buildcache.py", line 993, in buildcache
    args.func(args)
  File "/home/user/spack/lib/spack/spack/cmd/buildcache.py", line 528, in installtarball
    matches = match_downloaded_specs(pkgs, args.multiple, args.force,
  File "/home/user/spack/lib/spack/spack/cmd/buildcache.py", line 347, in match_downloaded_specs
    specs = [s for s in specs if s.satisfies(arch)]
UnboundLocalError: local variable 'specs' referenced before assignment
```

This PR just lets the exception bubble up. Which results in this behavior:

```
$ spack buildcache install -afu /7cwfjli
==> Error: Multiple errors during fetching:
        Error 1: RuntimeError: Unable to read index hash https://mirror.spack.io/build_cache/index.json.hash due to SpackWebError: Download failed: HTTP Error 404: Not Found
        Error 2: RuntimeError: Unable to read index https://mirror.spack.io/build_cache/index.json due to SpackWebError: Download failed: HTTP Error 404: Not Found
```

and is still bad, cause it shouldn't be a fatal error, just try the next mirror instead? It's a mirror after all, it can be down...

Hopefully other people can take this from here... @scottwittenburg / @opadron 