### PR TITLE
petsc: archive configure.log make.log from the build

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -519,7 +519,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         python('configure', '--prefix=%s' % prefix, *options)
 
         # PETSc has its own way of doing parallel make.
-        make('MAKE_NP=%s' % make_jobs, parallel=False)
+        make('V=1 MAKE_NP=%s' % make_jobs, parallel=False)
         make("install")
 
         if self.run_tests:
@@ -540,6 +540,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         # Set up PETSC_DIR for everyone using PETSc package
         env.set('PETSC_DIR', self.prefix)
         env.unset('PETSC_ARCH')
+
+    @property
+    def archive_files(self):
+        return [join_path(self.stage.source_path, 'configure.log'),
+                join_path(self.stage.source_path, 'make.log')]
 
     @property
     def headers(self):


### PR DESCRIPTION
Also enable verbose build

This is similar to autoconf packages saving config.log

```
util-macros-1.19.3-2jaahtfhtyk3m6kxps2fitqv34c2rb45/.spack/archived-files/spack-src:
total 8
-rw-r--r--. 1 balay ecp    0 Nov 25 10:01 removed_la_files.txt
-rw-r--r--. 1 balay ecp 7110 Nov 25 10:01 config.log
```