### PR TITLE
"branch" spelling mistake in libbeato

### DIFF
--- a/var/spack/repos/builtin/packages/libbeato/package.py
+++ b/var/spack/repos/builtin/packages/libbeato/package.py
@@ -14,4 +14,4 @@ class Libbeato(AutotoolsPackage):
     homepage = "https://github.com/CRG-Barcelona/libbeato"
     git      = "https://github.com/CRG-Barcelona/libbeato.git"
 
-    version('master', brancch='master')
+    version('master', branch='master')


### PR DESCRIPTION
I was browsing package metadata, as one does on a Sunday, and stumbled across a new kind of version attribute - brancch! I suspect this is supposed to be "branch."