### PR TITLE
ParaView: Add 5.10.0-RC2 release

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -27,7 +27,7 @@ class Paraview(CMakePackage, CudaPackage):
     tags = ['e4s']
 
     version('master', branch='master', submodules=True)
-    version('5.10.0-RC1', sha256='468d02962abfd5869c46f32fd9dee3095cb00264237edf2659f09a1c0990ec37')
+    version('5.10.0-RC2', sha256='6523577d4f8d0be6182e53c6b59e176c44a051c5f7d743bbda612cc095b18ff6')
     version('5.9.1', sha256='0d486cb6fbf55e428845c9650486f87466efcb3155e40489182a7ea85dfd4c8d', preferred=True)
     version('5.9.0', sha256='b03258b7cddb77f0ee142e3e77b377e5b1f503bcabc02bfa578298c99a06980d')
     version('5.8.1', sha256='7653950392a0d7c0287c26f1d3a25cdbaa11baa7524b0af0e6a1a0d7d487d034')


### PR DESCRIPTION
Finally! After a quiet month, ParaView 5.10.0 second release candidate is out :tada: :tada: :tada:

This bring few bug-fixes that polish some issues from the previous release candidates

Let me know if we need to change anything else in the package

ViB