### PR TITLE
Improve debug info from concretizer

### DIFF
--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -557,6 +557,16 @@ class TestConcretize(object):
         with pytest.raises(spack.error.SpackError):
             s.concretize()
 
+    @pytest.mark.skipif(spack.config.get('config:concretizer') == 'original',
+                        reason="Specific to new concretizer")
+    def test_conflicts_new_concretizer_debug(self, conflict_spec, mutable_config):
+        spack.config.set('config:debug', True)
+        s = Spec(conflict_spec)
+        with pytest.raises(spack.error.SpackError) as e:
+            s.concretize()
+
+        assert "conflict_trigger(" in e.value.message
+
     def test_conflict_in_all_directives_true(self):
         s = Spec('when-directives-true')
         with pytest.raises(spack.error.SpackError):

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -557,9 +557,10 @@ class TestConcretize(object):
         with pytest.raises(spack.error.SpackError):
             s.concretize()
 
-    @pytest.mark.skipif(spack.config.get('config:concretizer') == 'original',
-                        reason="Specific to new concretizer")
     def test_conflicts_new_concretizer_debug(self, conflict_spec, mutable_config):
+        if spack.config.get('config:concretizer') == 'original':
+            pytest.skip('Testing debug statements specific to new concretizer')
+
         spack.config.set('config:debug', True)
         s = Spec(conflict_spec)
         with pytest.raises(spack.error.SpackError) as e:


### PR DESCRIPTION
Previously, there was no way to get the full unsat core for debugging. This PR makes 2 changes to the concretizer behavior in debug mode.

1. All facts are assumptions, and therefore eligible to be in the core
2. Cores are not minimized, because the performance is prohibitive for full cores