### PR TITLE
spack audit: fix API calls to variants

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -389,9 +389,8 @@ def _unknown_variants_in_dependencies(pkgs, error_cls):
                 dependency_variants = dependency_edge.spec.variants
                 for name, value in dependency_variants.items():
                     try:
-                        dependency_pkg.variants[name].validate_or_raise(
-                            value, pkg=dependency_pkg
-                        )
+                        v, _ = dependency_pkg.variants[name]
+                        v.validate_or_raise(value, pkg=dependency_pkg)
                     except Exception as e:
                         summary = (pkg_name + ": wrong variant used for a "
                                    "dependency in a 'depends_on' directive")
@@ -419,7 +418,8 @@ def _analyze_variants_in_directive(pkg, constraint, directive, error_cls):
     errors = []
     for name, v in constraint.variants.items():
         try:
-            pkg.variants[name].validate_or_raise(v, pkg=pkg)
+            variant, _ = pkg.variants[name]
+            variant.validate_or_raise(v, pkg=pkg)
         except variant_exceptions as e:
             summary = pkg.name + ': wrong variant in "{0}" directive'
             summary = summary.format(directive)


### PR DESCRIPTION
This broke in #24858 when `package.variants` became a tuple. Right now the command is unusable:
```console
$ spack -d audit packages
==> [2021-11-30-10:05:03.813401] Imported audit from built-in commands
==> [2021-11-30-10:05:03.815805] Imported audit from built-in commands
==> [2021-11-30-10:05:03.816424] Reading config file /home/culpo/PycharmProjects/spack/etc/spack/defaults/repos.yaml
==> [2021-11-30-10:05:03.877291] Reading config file /home/culpo/PycharmProjects/spack/etc/spack/defaults/config.yaml
Traceback (most recent call last):
  File "/home/culpo/PycharmProjects/spack/bin/spack", line 98, in <module>
    sys.exit(spack.main.main())
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/main.py", line 882, in main
    return _main(argv)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/main.py", line 865, in _main
    return _invoke_command(command, parser, args, unknown)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/main.py", line 535, in _invoke_command
    return_val = command(parser, args)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/cmd/audit.py", line 88, in audit
    subcommands[args.subcommand](parser, args)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/cmd/audit.py", line 53, in packages
    reports = spack.audit.run_group(args.subcommand, pkgs=pkgs)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/audit.py", line 141, in run_group
    errors = run_check(check, **kwargs)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/audit.py", line 156, in run_check
    return CALLBACKS[tag].run(**kwargs)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/audit.py", line 124, in run
    errors.extend(fn(**kwargs))
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/audit.py", line 330, in _unknown_variants_in_directives
    errors.extend(_analyze_variants_in_directive(
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/audit.py", line 422, in _analyze_variants_in_directive
    v.validate_or_raise(v, pkg=pkg)
  File "/home/culpo/PycharmProjects/spack/lib/spack/spack/variant.py", line 115, in validate_or_raise
    value = vspec.value
AttributeError: 'Variant' object has no attribute 'value'
```