### PR TITLE
r-v8: add 3.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/r-v8/package.py
+++ b/var/spack/repos/builtin/packages/r-v8/package.py
@@ -13,13 +13,15 @@ class RV8(RPackage):
     cran = "V8"
 
     version('3.6.0', sha256='a3969898bf4a7c13d3130fae0d385cd048d46372ff4a412917b914b159261377')
-    version('3.4.0', sha256='f5c8a2a03cc1be9f504f47711a0fcd1b962745139c9fb2a10fbd79c4ae103fbd')
+    version('3.4.0', sha256='f5c8a2a03cc1be9f504f47711a0fcd1b962745139c9fb2a10fbd79c4ae103fbd',
+            deprecated=True)
 
     depends_on('r-rcpp@0.12.12:', type=('build', 'run'))
     depends_on('r-jsonlite@1.0:', type=('build', 'run'))
     depends_on('r-curl@1.0:', type=('build', 'run'))
 
     conflicts('@3.4.0', when='target=aarch64:')
+    conflicts('@3.4.0', when='%gcc@5:')
 
     def setup_build_environment(self, env):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/r-v8/package.py
+++ b/var/spack/repos/builtin/packages/r-v8/package.py
@@ -10,14 +10,14 @@ class RV8(RPackage):
     """V8: Embedded JavaScript and WebAssembly Engine for R"""
 
     homepage = "https://github.com/jeroen/v8"
-    url      = "https://cloud.r-project.org/src/contrib/V8_3.4.0.tar.gz"
-    list_url = "https://cloud.r-project.org/src/contrib/Archive/V8"
+    cran = "V8"
 
+    version('3.6.0', sha256='a3969898bf4a7c13d3130fae0d385cd048d46372ff4a412917b914b159261377')
     version('3.4.0', sha256='f5c8a2a03cc1be9f504f47711a0fcd1b962745139c9fb2a10fbd79c4ae103fbd')
 
-    depends_on('r-curl@1.0:', type=('build', 'run'))
-    depends_on('r-jsonlite@1.0:', type=('build', 'run'))
     depends_on('r-rcpp@0.12.12:', type=('build', 'run'))
+    depends_on('r-jsonlite@1.0:', type=('build', 'run'))
+    depends_on('r-curl@1.0:', type=('build', 'run'))
 
     conflicts('@3.4.0', when='target=aarch64:')
 


### PR DESCRIPTION
I ran into the same error for `r-v8` as described in #27634. For me updating the package solved the problem (the old version is still broken).