### PR TITLE
gtkplus: fix generation of configure_args

### DIFF
--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -114,7 +114,7 @@ class Gtkplus(MesonPackage):
 
     @when('@:3.20.10')
     def meson(self, spec, prefix):
-        configure(*self.configure_args)
+        configure(*self.configure_args())
 
     @when('@:3.20.10')
     def build(self, spec, prefix):


### PR DESCRIPTION
This PR is a one-liner that fixes the `gtkplus` build. I am not sure how `gtkplus` could possibly build without this fix.