### PR TITLE
quantum-espresso add CMake and libxc variants

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -324,11 +324,11 @@ class QuantumEspresso(CMakePackage):
             self.define_from_variant('QE_ENABLE_LIBXC', 'libxc'),
         ]
 
-        if not 'hdf5=none' in spec:
-            cmake_args.append( self.define('QE_ENABLE_HDF5', True) )
+        if not spec.satisfies('hdf5=none'):
+            cmake_args.append(self.define('QE_ENABLE_HDF5', True))
 
         if '+qmcpack' in spec:
-            cmake_args.append( self.define_from_variant('QE_ENABLE_PW2QMCPACK', 'qmcpack') )
+            cmake_args.append(self.define('QE_ENABLE_PW2QMCPACK', True))
 
         return cmake_args
 

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-class QuantumEspresso(Package):
+class QuantumEspresso(CMakePackage):
     """Quantum ESPRESSO is an integrated suite of Open-Source computer codes
     for electronic-structure calculations and materials modeling at the
     nanoscale. It is based on density-functional theory, plane waves, and
@@ -48,6 +48,9 @@ class QuantumEspresso(Package):
              destination='.'
              )
 
+    variant('cmake', default=False, description='Builds via CMake')
+    conflicts('+cmake', when='@:6.7', msg='+cmake works since QE v6.8')
+
     variant('mpi', default=True, description='Builds with mpi support')
     variant('openmp', default=False, description='Enables openMP support')
     variant('scalapack', default=True, description='Enables scalapack support')
@@ -64,6 +67,7 @@ class QuantumEspresso(Package):
     # http://epw.org.uk/Main/About
     variant('epw', default=False,
             description='Builds Electron-phonon Wannier executable')
+    conflicts('~epw', when='+cmake', msg='epw cannot be turned off when using CMake')
 
     # Apply upstream patches by default. Variant useful for 3rd party
     # patches which are incompatible with upstream patches
@@ -80,21 +84,25 @@ class QuantumEspresso(Package):
             description='Enables support for introducing environment effects '
             'into atomistic first-principles simulations.'
             'See http://quantum-environ.org/about.html')
+    conflicts('+environ', when='+cmake', msg='environ doesn\'t work with CMake')
 
     # Dependencies
+    depends_on("cmake@3.14.0:", type="build", when='+cmake')
     depends_on('blas')
     depends_on('lapack')
     depends_on('fftw-api@3')
     depends_on('mpi', when='+mpi')
     depends_on('scalapack', when='+scalapack+mpi')
-    depends_on('elpa+openmp', when='+elpa+openmp')
-    depends_on('elpa~openmp', when='+elpa~openmp')
+    # CMake builds only support elpa without openmp
+    depends_on('elpa~openmp', when='+elpa+cmake')
+    depends_on('elpa+openmp', when='+elpa+openmp~cmake')
+    depends_on('elpa~openmp', when='+elpa~openmp~cmake')
     # Versions of HDF5 prior to 1.8.16 lead to QE runtime errors
     depends_on('hdf5@1.8.16:+fortran+hl+mpi', when='hdf5=parallel')
     depends_on('hdf5@1.8.16:+fortran+hl~mpi', when='hdf5=serial')
     depends_on('hdf5', when='+qmcpack')
-    # TODO: enable building EPW when ~mpi
-    depends_on('mpi', when='+epw')
+    # TODO: enable building EPW when ~mpi and ~cmake
+    depends_on('mpi', when='+epw~cmake')
 
     # CONFLICTS SECTION
     # Omitted for now due to concretizer bug
@@ -178,8 +186,8 @@ class QuantumEspresso(Package):
     # Constraints may be relaxed as successful reports
     # of different compiler+mpi combinations arrive
 
-    # TODO: enable building EPW when ~mpi
-    conflicts('+epw', when='~mpi', msg='EPW needs MPI')
+    # TODO: enable building EPW when ~mpi and ~cmake
+    conflicts('+epw', when='~mpi~cmake', msg='EPW needs MPI')
 
     # EPW doesn't gets along well with OpenMPI 2.x.x
     conflicts('+epw', when='^openmpi@2.0.0:2',
@@ -204,6 +212,11 @@ class QuantumEspresso(Package):
 
     conflicts('@6.5:', when='+environ',
               msg='6.4.x is the latest QE series supported by Environ')
+
+    # 6.8
+    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.8.diff'
+    patch_checksum = '69f7fbd72aba810c35a0b034188e45bea8f9f11d3150c0715e1b3518d5c09248'
+    patch(patch_url, sha256=patch_checksum, when='@6.8+qmcpack')
 
     # 6.7
     patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.7.0.diff'
@@ -297,7 +310,37 @@ class QuantumEspresso(Package):
     # extlibs_makefile updated to work with fujitsu compilers
     patch('fj-fox.patch', when='+patch %fj')
 
+    def cmake_args(self):
+        spec = self.spec
+        #define = CMakePackage.define
+
+        cmake_args = [
+            self.define_from_variant('QE_ENABLE_MPI', 'mpi'),
+            self.define_from_variant('QE_ENABLE_OPENMP', 'openmp'),
+            self.define_from_variant('QE_ENABLE_SCALAPACK', 'scalapack'),
+            self.define_from_variant('QE_ENABLE_ELPA', 'elpa'),
+            self.define_from_variant('QE_ENABLE_PW2QMCPACK', 'qmcpack'),
+        ]
+
+        if not 'hdf5=none' in spec:
+            cmake_args.append( self.define('QE_ENABLE_HDF5', True) )
+
+        if '+qmcpack' in spec:
+            cmake_args.append( self.define_from_variant('QE_ENABLE_PW2QMCPACK', 'qmcpack') )
+
+        return cmake_args
+
+    @when("~cmake")
+    def cmake(self, spec, prefix):
+        print("Bypass cmake stage when building via configure")
+
+    @when("~cmake")
+    def build(self, spec, prefix):
+        print("Bypass build stage when building via configure")
+
+    @when("~cmake")
     def install(self, spec, prefix):
+        print("Override install stage when building via configure")
 
         prefix_path = prefix.bin if '@:5.4.0' in spec else prefix
         options = ['-prefix={0}'.format(prefix_path)]

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -55,6 +55,8 @@ class QuantumEspresso(CMakePackage):
     variant('openmp', default=False, description='Enables openMP support')
     variant('scalapack', default=True, description='Enables scalapack support')
     variant('elpa', default=False, description='Uses elpa as an eigenvalue solver')
+    variant('libxc', default=False, description='Uses libxc')
+    conflicts('+libxc', when='~cmake', msg='Using libxc requires building with CMake')
 
     # Support for HDF5 has been added starting in version 6.1.0 and is
     # still experimental, therefore we default to False for the variant
@@ -103,6 +105,7 @@ class QuantumEspresso(CMakePackage):
     depends_on('hdf5', when='+qmcpack')
     # TODO: enable building EPW when ~mpi and ~cmake
     depends_on('mpi', when='+epw~cmake')
+    depends_on('libxc@5.1.2:', when='+libxc')
 
     # CONFLICTS SECTION
     # Omitted for now due to concretizer bug
@@ -312,14 +315,13 @@ class QuantumEspresso(CMakePackage):
 
     def cmake_args(self):
         spec = self.spec
-        #define = CMakePackage.define
 
         cmake_args = [
             self.define_from_variant('QE_ENABLE_MPI', 'mpi'),
             self.define_from_variant('QE_ENABLE_OPENMP', 'openmp'),
             self.define_from_variant('QE_ENABLE_SCALAPACK', 'scalapack'),
             self.define_from_variant('QE_ENABLE_ELPA', 'elpa'),
-            self.define_from_variant('QE_ENABLE_PW2QMCPACK', 'qmcpack'),
+            self.define_from_variant('QE_ENABLE_LIBXC', 'libxc'),
         ]
 
         if not 'hdf5=none' in spec:

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -15,7 +15,7 @@ class QuantumEspresso(CMakePackage):
     url = 'https://gitlab.com/QEF/q-e/-/archive/qe-6.6/q-e-qe-6.6.tar.gz'
     git = 'https://gitlab.com/QEF/q-e.git'
 
-    maintainers = ['naromero77']
+    maintainers = ['ye-luo']
 
     version('develop', branch='develop')
     version('6.8', sha256='654855c69864de7ece5ef2f2c0dea2d32698fe51192a8646b1555b0c57e033b2')


### PR DESCRIPTION
Add CMake support for >= v6.8
Add libxc support, closes #24178

As @naromero77 requested in #27607, put myself as the maintainer for now.