### PR TITLE
Release procedure: add a step to update docs

### DIFF
--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -1177,6 +1177,10 @@ completed, the steps to make the major release are:
    If CI is not passing, submit pull requests to ``develop`` as normal
    and keep rebasing the release branch on ``develop`` until CI passes.
 
+#. Make sure the entire documentation is up to date. If documentation
+   is outdated submit pull requests to ``develop`` as normal
+   and keep rebasing the release branch on ``develop``.
+
 #. Follow the steps in :ref:`publishing-releases`.
 
 #. Follow the steps in :ref:`merging-releases`.


### PR DESCRIPTION
This PR adds a step for each major release to ensure we do a pass over the documentation before publishing the release. This should ensure that we don't ship outdated docs that may confuse users.