### PR TITLE
llvm: make targets a multivalued variant

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -128,7 +128,7 @@ spack:
     - libnrm
     - libquo
     - libunwind
-    - llvm +all_targets +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
+    - llvm targets=AMDGPU,NVPTX +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
     - loki
     - mercury
     - metall

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -128,7 +128,7 @@ spack:
     - libnrm
     - libquo
     - libunwind
-    - llvm targets=AMDGPU,NVPTX +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
+    - llvm targets=amdgpu,nvptx +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
     - loki
     - mercury
     - metall

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -139,7 +139,7 @@ spack:
     - libnrm
     - libquo
     - libunwind
-    - llvm +all_targets +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
+    - llvm targets=AMDGPU,NVPTX +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
     - loki
     - mercury
     - metall

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -139,7 +139,7 @@ spack:
     - libnrm
     - libquo
     - libunwind
-    - llvm targets=AMDGPU,NVPTX +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
+    - llvm targets=amdgpu,nvptx +clang +compiler-rt +libcxx +lld +lldb +llvm_dylib +flang ~cuda
     - loki
     - mercury
     - metall

--- a/var/spack/repos/builtin/packages/iwyu/package.py
+++ b/var/spack/repos/builtin/packages/iwyu/package.py
@@ -32,15 +32,8 @@ class Iwyu(CMakePackage):
     depends_on('llvm+clang@8.0:8', when='@0.12')
     depends_on('llvm+clang@7.0:7', when='@0.11')
 
-    # Non-X86 CPU use all_targets variants because iwyu use X86AsmParser
-    depends_on('llvm', when='target=aarch64:')
-    depends_on('llvm', when='target=arm:')
-    depends_on('llvm', when='target=ppc:')
-    depends_on('llvm', when='target=ppcle:')
-    depends_on('llvm', when='target=ppc64:')
-    depends_on('llvm', when='target=ppc64le:')
-    depends_on('llvm', when='target=sparc:')
-    depends_on('llvm', when='target=sparc64:')
+    # iwyu uses X86AsmParser
+    depends_on('llvm targets=x86')
 
     @when('@0.14:')
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/iwyu/package.py
+++ b/var/spack/repos/builtin/packages/iwyu/package.py
@@ -33,14 +33,14 @@ class Iwyu(CMakePackage):
     depends_on('llvm+clang@7.0:7', when='@0.11')
 
     # Non-X86 CPU use all_targets variants because iwyu use X86AsmParser
-    depends_on('llvm+all_targets', when='target=aarch64:')
-    depends_on('llvm+all_targets', when='target=arm:')
-    depends_on('llvm+all_targets', when='target=ppc:')
-    depends_on('llvm+all_targets', when='target=ppcle:')
-    depends_on('llvm+all_targets', when='target=ppc64:')
-    depends_on('llvm+all_targets', when='target=ppc64le:')
-    depends_on('llvm+all_targets', when='target=sparc:')
-    depends_on('llvm+all_targets', when='target=sparc64:')
+    depends_on('llvm', when='target=aarch64:')
+    depends_on('llvm', when='target=arm:')
+    depends_on('llvm', when='target=ppc:')
+    depends_on('llvm', when='target=ppcle:')
+    depends_on('llvm', when='target=ppc64:')
+    depends_on('llvm', when='target=ppc64le:')
+    depends_on('llvm', when='target=sparc:')
+    depends_on('llvm', when='target=sparc64:')
 
     @when('@0.14:')
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -139,7 +139,7 @@ class Llvm(CMakePackage, CudaPackage):
     )
     variant(
         "targets",
-        default="all",
+        default="nvptx,amdgpu",
         description=("What targets to build. Spack's target family is always added "
                      "(e.g. X86 is automatically enabled when targeting znver2)."),
         values=("all", "aarch64", "amdgpu", "arm", "avr", "bpf", "cppbackend",

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -139,10 +139,10 @@ class Llvm(CMakePackage, CudaPackage):
     )
     variant(
         "targets",
-        default="nvptx,amdgpu",
+        default="none",
         description=("What targets to build. Spack's target family is always added "
                      "(e.g. X86 is automatically enabled when targeting znver2)."),
-        values=("all", "aarch64", "amdgpu", "arm", "avr", "bpf", "cppbackend",
+        values=("all", "none", "aarch64", "amdgpu", "arm", "avr", "bpf", "cppbackend",
                 "hexagon", "lanai", "mips", "msp430", "nvptx", "powerpc", "riscv",
                 "sparc", "systemz", "webassembly", "x86", "xcore"),
         multi=True
@@ -728,7 +728,10 @@ def get_llvm_targets_to_build(spec):
         "xcore": "XCore"
     }
 
-    llvm_targets = set(spack_to_cmake[target] for target in targets)
+    if 'none' in targets:
+        llvm_targets = set()
+    else:
+        llvm_targets = set(spack_to_cmake[target] for target in targets)
 
     if spec.target.family in ("x86", "x86_64"):
         llvm_targets.add("X86")

--- a/var/spack/repos/builtin/packages/zig/package.py
+++ b/var/spack/repos/builtin/packages/zig/package.py
@@ -17,6 +17,6 @@ class Zig(CMakePackage):
         default='Release', description='CMake build type'
     )
 
-    depends_on('llvm@11.0.0:')
+    depends_on('llvm@11.0.0: targets=all')
 
     provides('ziglang')

--- a/var/spack/repos/builtin/packages/zig/package.py
+++ b/var/spack/repos/builtin/packages/zig/package.py
@@ -17,6 +17,6 @@ class Zig(CMakePackage):
         default='Release', description='CMake build type'
     )
 
-    depends_on('llvm@11.0.0: +all_targets')
+    depends_on('llvm@11.0.0:')
 
     provides('ziglang')


### PR DESCRIPTION
This allow one to have two packages that depend on say `llvm targets=NVPTX` and
`llvm targets=AMDGPU` which Spack would merge into `targets=NVPTX,AMDGPU`.

The default is `targets=auto`, which corresponds with
`LLVM_TARGETS_TO_BUILD=all`, and gives a reasonable user experience when just
running `spack install llvm+clang`.

With this change, Spack will always add LLVM's host arch as an enabled target,
so even if you don't specify `targets=X86`, if your Spack target arch is say
`znver2`, it will add `X86` to `LLVM_TARGETS_TO_BUILD`. This is mostly so that
the user doesn't have to do the mapping from spack -> LLVM target, and can just
depend on the "special" targets.


