### PR TITLE
seacas: fix x11 dependency

### DIFF
--- a/var/spack/repos/builtin/packages/seacas/package.py
+++ b/var/spack/repos/builtin/packages/seacas/package.py
@@ -96,6 +96,7 @@ class Seacas(CMakePackage):
     with when('+metis'):
         depends_on('metis+int64+real64')
         depends_on('parmetis+int64', when='+mpi')
+    depends_on('libx11', when='+x11')
 
     # The Faodel TPL is only supported in seacas@2021-04-05:
     depends_on('faodel@1.2108.1:+mpi', when='+faodel +mpi')


### PR DESCRIPTION
`seacas`  installation failed with the following error
```
1 error found in build log:
     478    which will disable it and will recursively disable all of the
     479    downstream packages that have required dependencies on it.
     480    When you reconfigure, just grep the cmake stdout for 'X11'
     481    and then follow the disables that occur as a result to see what impact
     482    this TPL disable has on the configuration of SEACASProj.
     483    
  >> 484    CMake Error at cmake/tribits/core/package_arch/TribitsProcessEnabledTpl.cmake:144 (message):
     485      ERROR: TPL_X11_NOT_FOUND=TRUE, aborting!
     486    Call Stack (most recent call first):
     487      cmake/tribits/core/package_arch/TribitsGlobalMacros.cmake:1604 (tribits_process_enabled_tpl)
     488      cmake/tribits/core/package_arch/TribitsProjectImpl.cmake:196 (tribits_process_enabled_tpls)
     489      cmake/tribits/core/package_arch/TribitsProject.cmake:93 (tribits_project_impl)
     490      CMakeLists.txt:46 (TRIBITS_PROJECT)
```
Adding `libx11` as dependency fixed this.