### PR TITLE
cp2k fix build with elpa and without cuda

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -486,11 +486,11 @@ class Cp2k(MakefilePackage, CudaPackage):
 
             # Currently AOCC support only static libraries of ELPA
             if '%aocc' in spec:
-                libs.append(join_path(elpa.prefix.lib,
+                libs.append(join_path(elpa.libs.directories[0],
                             ('libelpa{elpa_suffix}.a'
                                 .format(elpa_suffix=elpa_suffix))))
             else:
-                libs.append(join_path(elpa.prefix.lib,
+                libs.append(join_path(elpa.libs.directories[0],
                             ('libelpa{elpa_suffix}.{dso_suffix}'
                                 .format(elpa_suffix=elpa_suffix,
                                         dso_suffix=dso_suffix))))
@@ -661,7 +661,7 @@ class Cp2k(MakefilePackage, CudaPackage):
         ]
 
     def build(self, spec, prefix):
-        if len(spec.variants['cuda_arch'].value) > 1:
+        if '+cuda' in spec and len(spec.variants['cuda_arch'].value) > 1:
             raise InstallError("cp2k supports only one cuda_arch at a time")
 
         # Apparently the Makefile bases its paths on PWD


### PR DESCRIPTION
- cp2k: fix build issues without cuda, and with elpa on openSUSE
- elpa: add version 2021.05.002, filter _bugfix in version for inc. dir
- libxc: add version 5.1.7
- py-typed-ast: add version 1.5.0, which should compile on macOS with clang
