### PR TITLE
ParaView: add proj, nlohmann-json dependencies needed in paraview@master

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -215,7 +215,7 @@ class Paraview(CMakePackage, CudaPackage):
     def paraview_subdir(self):
         """The paraview subdirectory name as paraview-major.minor"""
         if self.spec.version == Version('master'):
-            return 'paraview-5.9'
+            return 'paraview-5.10'
         else:
             return 'paraview-{0}'.format(self.spec.version.up_to(2))
 

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -173,6 +173,14 @@ class Paraview(CMakePackage, CudaPackage):
     # https://gitlab.kitware.com/paraview/paraview/-/merge_requests/4951
     depends_on('cli11@1.9.1', when='@5.10:')
 
+    # ParaView depends on nlohmann-json due to changes in MR
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8550
+    depends_on('nlohmann-json', when='@master')
+
+    # ParaView depends on proj@8.1.0 due to changes in MR
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8474
+    depends_on('proj@8.1.0', when='@master')
+
     patch('stl-reader-pv440.patch', when='@4.4.0')
 
     # Broken gcc-detection - improved in 5.1.0, redundant later


### PR DESCRIPTION
Adds `nlohmann-json` and `proj@8.1.0` as dependencies for `paraview@master`

Without these, `paraview@master` configure stage fails with:

`nlohmann-json`:
```console
  >> 210    CMake Error at VTK/CMake/vtkModule.cmake:4423 (message):
     211      Could not find the nlohmann_json external dependency.
     212    Call Stack (most recent call first):
     213      VTK/CMake/vtkModule.cmake:5017 (vtk_module_find_package)
     214      VTK/CMake/vtkModule.cmake:4888 (vtk_module_third_party_external)
     215      VTK/ThirdParty/nlohmannjson/CMakeLists.txt:1 (vtk_module_third_party)
```
`proj`:
```console
     192    -- Could NOT find LibPROJ (missing: LibPROJ_LIBRARY LibPROJ_INCLUDE_DIR)
  >> 193    CMake Error at VTK/CMake/vtkModule.cmake:4423 (message):
     194      Could not find the LibPROJ external dependency.
     195    Call Stack (most recent call first):
     196      VTK/CMake/vtkModule.cmake:5017 (vtk_module_find_package)
     197      VTK/CMake/vtkModule.cmake:4888 (vtk_module_third_party_external)
     198      VTK/ThirdParty/libproj/CMakeLists.txt:1 (vtk_module_third_party)
```