### PR TITLE
version bump elpa libxc

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -14,6 +14,7 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     homepage = 'https://elpa.mpcdf.mpg.de/'
     url = 'https://elpa.mpcdf.mpg.de/software/tarball-archive/Releases/2015.11.001/elpa-2015.11.001.tar.gz'
 
+    version('2021.05.002_bugfix', sha256='deabc48de5b9e4b2f073d749d335c8f354a7ce4245b643a23b7951cd6c90224b')
     version('2021.05.001', sha256='a4f1a4e3964f2473a5f8177f2091a9da5c6b5ef9280b8272dfefcbc3aad44d41')
     version('2020.05.001', sha256='66ff1cf332ce1c82075dc7b5587ae72511d2bcb3a45322c94af6b01996439ce5')
     version('2019.11.001', sha256='10374a8f042e23c7e1094230f7e2993b6f3580908a213dbdf089792d05aff357')
@@ -66,10 +67,17 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
     @property
     def headers(self):
         suffix = '_openmp' if self.spec.satisfies('+openmp') else ''
+
+        # upstream sometimes adds tarball suffixes not part of the internal version
+        elpa_version = str(self.spec.version)
+        for vsuffix in ("_bugfix", ):
+            if elpa_version.endswith(vsuffix):  # implementation of py3.9 removesuffix
+                elpa_version = elpa_version[:-len(vsuffix)]
+
         incdir = os.path.join(
             self.spec.prefix.include,
-            'elpa{suffix}-{version!s}'.format(
-                suffix=suffix, version=self.spec.version))
+            'elpa{suffix}-{version}'.format(
+                suffix=suffix, version=elpa_version))
 
         hlist = find_all_headers(incdir)
         hlist.directories = [incdir]

--- a/var/spack/repos/builtin/packages/libxc/package.py
+++ b/var/spack/repos/builtin/packages/libxc/package.py
@@ -13,6 +13,7 @@ class Libxc(AutotoolsPackage, CudaPackage):
     homepage = "https://tddft.org/programs/libxc/"
     url      = "https://www.tddft.org/programs/libxc/down.php?file=2.2.2/libxc-2.2.2.tar.gz"
 
+    version('5.1.7', sha256='1a818fdfe5c5f74270bc8ef0c59064e8feebcd66b8f642c08aecc1e7d125be34')
     version('5.1.5', sha256='02e4615a22dc3ec87a23efbd3d9be5bfad2445337140bad1720699571c45c3f9')
     version('5.1.3', sha256='0350defdd6c1b165e4cf19995f590eee6e0b9db95a6b221d28cecec40f4e85cd')
     version('5.1.2', sha256='180d52b5552921d1fac8a10869dd30708c0fb41dc202a3bbee0e36f43872718a')


### PR DESCRIPTION
- elpa: add version 2021.05.002, filter _bugfix in version for inc. dir
- libxc: add version 5.1.7
