### PR TITLE
hipblas: add headers() for dependent packages to get header location

### DIFF
--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -69,3 +69,8 @@ class Hipblas(CMakePackage):
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)
+
+    @property
+    def headers(self):
+        return find_headers('hipblas', self.prefix.include, recursive=False) \
+            or None


### PR DESCRIPTION
Added functionality to retrieve header file location for dependent packages