### PR TITLE
cgdb: add depends_on('gdb', type='run')

### DIFF
--- a/var/spack/repos/builtin/packages/cgdb/package.py
+++ b/var/spack/repos/builtin/packages/cgdb/package.py
@@ -9,15 +9,17 @@ from spack import *
 class Cgdb(AutotoolsPackage):
     """A curses front-end to GDB"""
 
+    maintainers = ['tuxfan']
     homepage = 'https://cgdb.github.io'
     url      = 'https://cgdb.me/files/cgdb-0.7.1.tar.gz'
     git      = 'https://github.com/cgdb/cgdb.git'
 
-    version('master', branch='master', submodule=False, preferred=False)
+    version('master', branch='master', submodule=False, preferred=True)
     version('0.7.1', sha256='bb723be58ec68cb59a598b8e24a31d10ef31e0e9c277a4de07b2f457fe7de198')
     version('0.7.0', sha256='bf7a9264668db3f9342591b08b2cc3bbb08e235ba2372877b4650b70c6fb5423')
 
     # Required dependency
+    depends_on('gdb')
     depends_on('ncurses')
     depends_on('readline')
     depends_on('autoconf', type='build', when='@master')

--- a/var/spack/repos/builtin/packages/cgdb/package.py
+++ b/var/spack/repos/builtin/packages/cgdb/package.py
@@ -19,7 +19,7 @@ class Cgdb(AutotoolsPackage):
     version('0.7.0', sha256='bf7a9264668db3f9342591b08b2cc3bbb08e235ba2372877b4650b70c6fb5423')
 
     # Required dependency
-    depends_on('gdb')
+    depends_on('gdb', type='run')
     depends_on('ncurses')
     depends_on('readline')
     depends_on('autoconf', type='build', when='@master')


### PR DESCRIPTION
When using spack to install cgdb, a spack-built gdb is necessary to
avoid dynamic link errors.