### PR TITLE
Extends: support spec, not just package name

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -466,7 +466,8 @@ def extends(spec, type=('build', 'run'), **kwargs):
             return
 
         _depends_on(pkg, spec, when=when, type=type)
-        pkg.extendees[spec] = (spack.spec.Spec(spec), kwargs)
+        spec_obj = spack.spec.Spec(spec)
+        pkg.extendees[spec_obj.name] = (spec_obj, kwargs)
     return _execute_extends
 
 

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -54,7 +54,7 @@ def test_constraints_from_context_are_merged(mock_packages):
 
 
 @pytest.mark.regression('27754')
-def test_extends_spec(mock_packages):
+def test_extends_spec(config, mock_packages):
     extender = spack.spec.Spec('extends-spec').concretized()
     extendee = spack.spec.Spec('extendee').concretized()
 

--- a/lib/spack/spack/test/directives.py
+++ b/lib/spack/spack/test/directives.py
@@ -51,3 +51,12 @@ def test_constraints_from_context_are_merged(mock_packages):
 
     assert pkg_cls.dependencies
     assert spack.spec.Spec('@0.14:15 ^b@3.8:4.0') in pkg_cls.dependencies['c']
+
+
+@pytest.mark.regression('27754')
+def test_extends_spec(mock_packages):
+    extender = spack.spec.Spec('extends-spec').concretized()
+    extendee = spack.spec.Spec('extendee').concretized()
+
+    assert extender.dependencies
+    assert extender.package.extends(extendee)

--- a/var/spack/repos/builtin.mock/packages/extends-spec/package.py
+++ b/var/spack/repos/builtin.mock/packages/extends-spec/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class ExtendsSpec(Package):
+    """Package that tests if the extends directive supports a spec."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/example-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    extends('extendee@1:')


### PR DESCRIPTION
### Motivation

Previously, the `extends` directive did not support specs, only package names. This meant that something like:
```python
extends('python@3.6:')
```
would add a dependency on `python@3.6:`, but the package didn't actually extend anything. Package authors would have to instead use:
```python
extends('python')
depends_on('python@3.6:', type=('build', 'run'))
```
to mean the same thing. Although it isn't hard to convert the former into the latter, it's unintuitive that one of our directives doesn't handle specs when all the others do. There are already packages in Spack that use the former convention (and are currently broken), including `py-pymatgen` and every `octave-*` package.

### Alternatives

We could instead modify `spack.package.PackageBase.extends()` to do the same thing, although I think this is a bit simpler.

P.S. How/where would I add unit tests for this?