### PR TITLE
libseccomp: add 2.5.3 and switch to tar.gz releases

### DIFF
--- a/var/spack/repos/builtin/packages/libseccomp/package.py
+++ b/var/spack/repos/builtin/packages/libseccomp/package.py
@@ -10,16 +10,14 @@ class Libseccomp(AutotoolsPackage):
     """The main libseccomp repository"""
 
     homepage = "https://github.com/seccomp/libseccomp"
-    url      = "https://github.com/seccomp/libseccomp/archive/v2.3.3.zip"
+    url      = 'https://github.com/seccomp/libseccomp/releases/download/v2.5.3/libseccomp-2.5.3.tar.gz'
 
-    version('2.3.3', sha256='627e114b3be2e66ed8d88b90037498333384d9bea822423662a44c3a8520e187')
+    version('2.5.3', sha256='59065c8733364725e9721ba48c3a99bbc52af921daf48df4b1e012fbc7b10a76')
+    version('2.3.3', sha256='7fc28f4294cc72e61c529bedf97e705c3acf9c479a8f1a3028d4cd2ca9f3b155')
 
     variant('python', default=True, description="Build Python bindings")
 
-    depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
-    depends_on('libtool', type='build')
-    depends_on('m4', type='build')
+    depends_on('gperf',     type='build', when='@2.5:')
     depends_on("py-cython", type="build", when="+python")
 
     def configure_args(self):


### PR DESCRIPTION
Obsoletes the dependencies for `autoreconf` and `unzip` for `.zip` file unpacking.

For review: Of course, the switch from `.zip` to `.tar.gz` and from `tag/archive` to **release** archive means a new checksum for 2.3.3 too.