### PR TITLE
ExaGO: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -15,9 +15,11 @@ class Exago(CMakePackage, CudaPackage):
     git = 'https://gitlab.pnnl.gov/exasgd/frameworks/exago.git'
     maintainers = ['ashermancinelli', 'CameronRutherford']
 
-    version('1.0.0', tag='v1.0.0')
-    version('0.99.2', tag='v0.99.2')
-    version('0.99.1', tag='v0.99.1')
+    version('1.1.1', commit='0e0a3f27', submodules=True)
+    version('1.1.0', commit='dc8dd855', submodules=True)
+    version('1.0.0', commit='230d7df2')
+    version('0.99.2', commit='56961641')
+    version('0.99.1', commit='0ae426c7')
     version('master', branch='master')
     version('develop', branch='develop')
 

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -15,6 +15,7 @@ class Exago(CMakePackage, CudaPackage):
     git = 'https://gitlab.pnnl.gov/exasgd/frameworks/exago.git'
     maintainers = ['ashermancinelli', 'CameronRutherford']
 
+    version('1.1.2', commit='db3bb16e', submodules=True)
     version('1.1.1', commit='0e0a3f27', submodules=True)
     version('1.1.0', commit='dc8dd855', submodules=True)
     version('1.0.0', commit='230d7df2')
@@ -36,9 +37,13 @@ class Exago(CMakePackage, CudaPackage):
     depends_on('mpi', when='+mpi')
     depends_on('blas')
     depends_on('cuda', when='+cuda')
+
     depends_on('raja', when='+raja')
     depends_on('raja+cuda', when='+raja+cuda')
+    depends_on('raja@0.14.0:', when='@1.1.0: +raja')
+
     depends_on('umpire', when='+raja')
+    depends_on('umpire@6.0.0:', when='@1.1.0: +raja')
 
     # Some allocator code in Umpire only works with static libs
     depends_on('umpire+cuda~shared', when='+raja+cuda')
@@ -53,6 +58,7 @@ class Exago(CMakePackage, CudaPackage):
     # HiOp dependency logic
     depends_on('hiop+raja', when='+hiop+raja')
     depends_on('hiop@0.3.99:', when='@0.99:+hiop')
+    depends_on('hiop@0.5.1:', when='@1.1.0:+hiop')
     depends_on('hiop+cuda', when='+hiop+cuda')
     depends_on('hiop~mpi', when='+hiop~mpi')
     depends_on('hiop+mpi', when='+hiop+mpi')


### PR DESCRIPTION
Updates ExaGO package with new tagged versions. Use commit hashes instead of tags, and enable git submodules.

CC @CameronRutherford 