### PR TITLE
Specify dependencies to py-setuptools@:57.99 for packages using 2to3

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -155,8 +155,8 @@ class Gdal(AutotoolsPackage):
     depends_on('python@2.0:', type=('build', 'link', 'run'), when='@3.2:+python')
     depends_on('python', type=('build', 'link', 'run'), when='+python')
     # swig/python/setup.py
-    depends_on('py-setuptools@:57', type='build', when='@:3.0.4+python')
-    depends_on('py-setuptools', type='build', when='@3.1.0:+python')
+    depends_on('py-setuptools@:57', type='build', when='@:3.0+python')
+    depends_on('py-setuptools', type='build', when='@3.1:+python')
     depends_on('py-numpy@1.0.0:', type=('build', 'run'), when='+python')
     depends_on('java@7:', type=('build', 'link', 'run'), when='@3.2:+java')
     depends_on('java@6:', type=('build', 'link', 'run'), when='@2.4:+java')

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -155,7 +155,8 @@ class Gdal(AutotoolsPackage):
     depends_on('python@2.0:', type=('build', 'link', 'run'), when='@3.2:+python')
     depends_on('python', type=('build', 'link', 'run'), when='+python')
     # swig/python/setup.py
-    depends_on('py-setuptools@:57', type='build', when='+python')
+    depends_on('py-setuptools@:57', type='build', when='@:3.0.4+python')
+    depends_on('py-setuptools', type='build', when='@3.1.0:+python')
     depends_on('py-numpy@1.0.0:', type=('build', 'run'), when='+python')
     depends_on('java@7:', type=('build', 'link', 'run'), when='@3.2:+java')
     depends_on('java@6:', type=('build', 'link', 'run'), when='@2.4:+java')

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -155,7 +155,7 @@ class Gdal(AutotoolsPackage):
     depends_on('python@2.0:', type=('build', 'link', 'run'), when='@3.2:+python')
     depends_on('python', type=('build', 'link', 'run'), when='+python')
     # swig/python/setup.py
-    depends_on('py-setuptools', type='build', when='+python')
+    depends_on('py-setuptools@:57.99', type='build', when='+python')
     depends_on('py-numpy@1.0.0:', type=('build', 'run'), when='+python')
     depends_on('java@7:', type=('build', 'link', 'run'), when='@3.2:+java')
     depends_on('java@6:', type=('build', 'link', 'run'), when='@2.4:+java')

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -155,7 +155,7 @@ class Gdal(AutotoolsPackage):
     depends_on('python@2.0:', type=('build', 'link', 'run'), when='@3.2:+python')
     depends_on('python', type=('build', 'link', 'run'), when='+python')
     # swig/python/setup.py
-    depends_on('py-setuptools@:57.99', type='build', when='+python')
+    depends_on('py-setuptools@:57', type='build', when='+python')
     depends_on('py-numpy@1.0.0:', type=('build', 'run'), when='+python')
     depends_on('java@7:', type=('build', 'link', 'run'), when='@3.2:+java')
     depends_on('java@6:', type=('build', 'link', 'run'), when='@2.4:+java')

--- a/var/spack/repos/builtin/packages/py-genshi/package.py
+++ b/var/spack/repos/builtin/packages/py-genshi/package.py
@@ -15,4 +15,4 @@ class PyGenshi(PythonPackage):
     version('0.6.1', sha256='fed947f11dbcb6792bb7161701ec3b9804055ad68c8af0ab4f0f9b25e9a18dbd')
     version('0.6', sha256='32aaf76a03f88efa04143bf80700399e6d84eead818fdd19d763fd76af972a4b')
 
-    depends_on("py-setuptools", type='build')
+    depends_on("py-setuptools@:57.99", type='build')

--- a/var/spack/repos/builtin/packages/py-genshi/package.py
+++ b/var/spack/repos/builtin/packages/py-genshi/package.py
@@ -15,4 +15,4 @@ class PyGenshi(PythonPackage):
     version('0.6.1', sha256='fed947f11dbcb6792bb7161701ec3b9804055ad68c8af0ab4f0f9b25e9a18dbd')
     version('0.6', sha256='32aaf76a03f88efa04143bf80700399e6d84eead818fdd19d763fd76af972a4b')
 
-    depends_on("py-setuptools@:57.99", type='build')
+    depends_on("py-setuptools@:57", type='build')

--- a/var/spack/repos/builtin/packages/py-nose/package.py
+++ b/var/spack/repos/builtin/packages/py-nose/package.py
@@ -16,4 +16,4 @@ class PyNose(PythonPackage):
     version('1.3.6', sha256='f61e0909a743eed37b1207e38a8e7b4a2fe0a82185e36f2be252ef1b3f901758')
     version('1.3.4', sha256='76bc63a4e2d5e5a0df77ca7d18f0f56e2c46cfb62b71103ba92a92c79fab1e03')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools@:57.99', type='build')

--- a/var/spack/repos/builtin/packages/py-nose/package.py
+++ b/var/spack/repos/builtin/packages/py-nose/package.py
@@ -16,4 +16,4 @@ class PyNose(PythonPackage):
     version('1.3.6', sha256='f61e0909a743eed37b1207e38a8e7b4a2fe0a82185e36f2be252ef1b3f901758')
     version('1.3.4', sha256='76bc63a4e2d5e5a0df77ca7d18f0f56e2c46cfb62b71103ba92a92c79fab1e03')
 
-    depends_on('py-setuptools@:57.99', type='build')
+    depends_on('py-setuptools@:57', type='build')


### PR DESCRIPTION
py-setuptools >= 58.0.0 removed support for 2to3: https://setuptools.pypa.io/en/latest/history.html#v58-0-0. This triggers the error `use_2to3 is invalid.`.