### PR TITLE
VTK: Patch ADIOS2 module to fix cyclic dependency

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -69,6 +69,7 @@ class Paraview(CMakePackage, CudaPackage):
             description='Build editions include only certain modules. '
             'Editions are listed in decreasing order of size.')
 
+    conflicts('+adios2', when='@:5.10 ~mpi')
     conflicts('+python', when='+python3')
     # Python 2 support dropped with 5.9.0
     conflicts('+python', when='@5.9:')
@@ -144,7 +145,8 @@ class Paraview(CMakePackage, CudaPackage):
     # depends_on('hdf5~mpi', when='~mpi')
     depends_on('hdf5+hl+mpi', when='+hdf5+mpi')
     depends_on('hdf5+hl~mpi', when='+hdf5~mpi')
-    depends_on('adios2', when='+adios2')
+    depends_on('adios2+mpi', when='+adios2+mpi')
+    depends_on('adios2~mpi', when='+adios2~mpi')
     depends_on('jpeg')
     depends_on('jsoncpp')
     depends_on('libogg')
@@ -200,6 +202,10 @@ class Paraview(CMakePackage, CudaPackage):
 
     # Include limits header wherever needed to fix compilation with GCC 11
     patch('paraview-gcc11-limits.patch', when='@5.9.1 %gcc@11.1.0:')
+
+    # Fix IOADIOS2 module to work with kits
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8653
+    patch('vtk-adios2-module-no-kit.patch', when='@:5.10')
 
     def url_for_version(self, version):
         _urlfmt  = 'http://www.paraview.org/files/v{0}/ParaView-v{1}{2}.tar.{3}'

--- a/var/spack/repos/builtin/packages/paraview/vtk-adios2-module-no-kit.patch
+++ b/var/spack/repos/builtin/packages/paraview/vtk-adios2-module-no-kit.patch
@@ -1,0 +1,24 @@
+From 19cd0302104e94421813427071351aa5326e4dbb Mon Sep 17 00:00:00 2001
+From: Ryan Krattiger <ryan.krattiger@kitware.com>
+Date: Thu, 2 Dec 2021 16:58:10 -0600
+Subject: [PATCH] ADIOS2: Move IOADIOS2 to StandAlone kit
+
+---
+ IO/ADIOS2/vtk.module                   |  2 -
+ 1 files changed, 0 insertions(+), 2 deletions(-)
+
+diff --git a/VTK/IO/ADIOS2/vtk.module b/VTK/IO/ADIOS2/vtk.module
+index 5ee89b9a65e..b89e54d7683 100644
+--- a/VTK/IO/ADIOS2/vtk.module
++++ b/VTK/IO/ADIOS2/vtk.module
+@@ -3,7 +3,5 @@ NAME
+ LIBRARY_NAME
+   vtkIOADIOS2
+-KIT
+-  VTK::IO
+ DEPENDS
+   VTK::CommonCore
+   VTK::CommonExecutionModel
+-- 
+GitLab
+

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -77,6 +77,10 @@ class Vtk(CMakePackage):
     # use internal FindHDF5
     patch('internal_findHDF5.patch', when='@:8')
 
+    # Fix IOADIOS2 module to work with kits
+    # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8653
+    patch('vtk-adios2-module-no-kit.patch', when='@:9.0.3')
+
     # The use of the OpenGL2 backend requires at least OpenGL Core Profile
     # version 3.2 or higher.
     depends_on('gl@3.2:', when='+opengl2')

--- a/var/spack/repos/builtin/packages/vtk/vtk-adios2-module-no-kit.patch
+++ b/var/spack/repos/builtin/packages/vtk/vtk-adios2-module-no-kit.patch
@@ -1,0 +1,24 @@
+From 19cd0302104e94421813427071351aa5326e4dbb Mon Sep 17 00:00:00 2001
+From: Ryan Krattiger <ryan.krattiger@kitware.com>
+Date: Thu, 2 Dec 2021 16:58:10 -0600
+Subject: [PATCH] ADIOS2: Move IOADIOS2 to StandAlone kit
+
+---
+ IO/ADIOS2/vtk.module                   |  2 -
+ 1 files changed, 0 insertions(+), 2 deletions(-)
+
+diff --git a/IO/ADIOS2/vtk.module b/IO/ADIOS2/vtk.module
+index 5ee89b9a65e..b89e54d7683 100644
+--- a/IO/ADIOS2/vtk.module
++++ b/IO/ADIOS2/vtk.module
+@@ -3,7 +3,5 @@ NAME
+ LIBRARY_NAME
+   vtkIOADIOS2
+-KIT
+-  VTK::IO
+ DEPENDS
+   VTK::CommonCore
+   VTK::CommonExecutionModel
+-- 
+GitLab
+


### PR DESCRIPTION
@chuckatkins 

Ref.
https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8653

After enabling the ADIOS2 option for paraview it was discovered that the IOADIOS2 module could not build with MPI. These patches fix that issue.

Tested building ParaView 5.8.1 and 5.9.0 and VTK 9.0.3 with gcc 9.3.0

Note, this patch was also applied to VTK even though there is not an ADIOS2 variant yet. The variant will be added later, including the patch here to keep this information in one place.

Note, these patches only includes changes to the `vtk.module` file for IOADIOS2. The remaining changes from the MR in the VTK project are handled by not allowing `+adios2` when `~mpi`, this was done because the rest of the patch does not apply correctly. This should be fixed for ParaView 5.11.