### PR TITLE
Avoid `gtk-doc` to avoid unsolvable constraints when installing `gtkplus`

### DIFF
--- a/var/spack/repos/builtin/packages/libcroco/package.py
+++ b/var/spack/repos/builtin/packages/libcroco/package.py
@@ -15,12 +15,19 @@ class Libcroco(AutotoolsPackage):
     version('0.6.13', sha256='767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4')
     version('0.6.12', sha256='ddc4b5546c9fb4280a5017e2707fbd4839034ed1aba5b7d4372212f34f84f860')
 
+    variant('doc', default=False, description='Build documentation with gtk-doc')
+
     depends_on('glib')
     depends_on('libxml2')
-    depends_on('gtk-doc', type='build')
+    depends_on('gtk-doc', type='build', when='+doc')
     depends_on('pkgconfig', type='build')
 
     def configure_args(self):
-        # macOS ld does not support this flag
-        # https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libcroco.rb
-        return ['--disable-Bsymbolic']
+        args = [
+            '--enable-gtk-doc=' + 'yes' if spec.variants['doc'].value else 'no'
+        ]
+        if sys.platform == 'darwin':
+            # macOS ld does not support this flag
+            # https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libcroco.rb
+            args.append('--disable-Bsymbolic')
+        return args

--- a/var/spack/repos/builtin/packages/libcroco/package.py
+++ b/var/spack/repos/builtin/packages/libcroco/package.py
@@ -24,7 +24,7 @@ class Libcroco(AutotoolsPackage):
 
     def configure_args(self):
         args = [
-            '--enable-gtk-doc=' + 'yes' if spec.variants['doc'].value else 'no'
+            '--enable-gtk-doc=' + ('yes' if self.spec.variants['doc'].value else 'no')
         ]
         # macOS ld does not support this flag
         # https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libcroco.rb

--- a/var/spack/repos/builtin/packages/libcroco/package.py
+++ b/var/spack/repos/builtin/packages/libcroco/package.py
@@ -26,8 +26,7 @@ class Libcroco(AutotoolsPackage):
         args = [
             '--enable-gtk-doc=' + 'yes' if spec.variants['doc'].value else 'no'
         ]
-        if sys.platform == 'darwin':
-            # macOS ld does not support this flag
-            # https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libcroco.rb
-            args.append('--disable-Bsymbolic')
+        # macOS ld does not support this flag
+        # https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libcroco.rb
+        args.append('--disable-Bsymbolic')
         return args

--- a/var/spack/repos/builtin/packages/librsvg/package.py
+++ b/var/spack/repos/builtin/packages/librsvg/package.py
@@ -53,5 +53,5 @@ class Librsvg(AutotoolsPackage):
 
     def configure_args(self):
         return [
-            '--enable-gtk-doc=' + 'yes' if spec.variants['doc'].value else 'no'
+            '--enable-gtk-doc=' + ('yes' if self.spec.variants['doc'].value else 'no')
         ]

--- a/var/spack/repos/builtin/packages/librsvg/package.py
+++ b/var/spack/repos/builtin/packages/librsvg/package.py
@@ -17,10 +17,12 @@ class Librsvg(AutotoolsPackage):
     version('2.50.0', sha256='b3fadba240f09b9c9898ab20cb7311467243e607cf8f928b7c5f842474ee3df4')
     version('2.44.14', sha256='6a85a7868639cdd4aa064245cc8e9d864dad8b8e9a4a8031bb09a4796bc4e303')
 
+    variant('doc', default=False, description='Build documentation with gtk-doc')
+
     depends_on("gobject-introspection", type='build')
     depends_on("pkgconfig", type='build')
     depends_on("rust", type='build')
-    depends_on('gtk-doc', type='build')
+    depends_on('gtk-doc', type='build', when='+doc')
     depends_on("cairo+gobject")
     depends_on("gdk-pixbuf")
     depends_on("glib")
@@ -48,3 +50,8 @@ class Librsvg(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         env.prepend_path('XDG_DATA_DIRS', self.prefix.share)
+
+    def configure_args(self):
+        return [
+            '--enable-gtk-doc=' + 'yes' if spec.variants['doc'].value else 'no'
+        ]


### PR DESCRIPTION
Per issue #27565, there is an unsatisfiable constraint due to `gtk-doc`'s dependence on fixed version `docbook-xml@4.3`. This prevents installation of `gtkplus@3:` because another part of its dependency chain depends on fixed version `docbook-xml@4.4` (details in issue). This PR solves the unsatisfiable constraint by making the `gtk-doc` dependence optional (and disabled by default).

The variant name `doc` seems to be slightly preferred over `docs` (45 vs. 39 cases), so that is what is used here.

With these changes, I can confirm that `gtkplus@3:` installs (with `%gcc@11 arch=linux-ubuntu21.04-skylake`) using the current develop branch.

Other notes:
- One more package, `ctpl`, depends on `gtk-doc` but has no entries in `configure.ac` to make the `gtk-doc` dependence optional.
- Newer versions of `librsvg` and `libcroco` are available, but this in turn requires upgrades to other dependencies. When I found myself upgrading rust from 1.51 to 1.57 I figured that the risk for collateral damage was getting larger than I'm comfortable with in the scope of this PR.