### PR TITLE
Fix r-prettydoc dependency

### DIFF
--- a/var/spack/repos/builtin/packages/r-prettydoc/package.py
+++ b/var/spack/repos/builtin/packages/r-prettydoc/package.py
@@ -19,5 +19,5 @@ class RPrettydoc(RPackage):
 
     version('0.4.1', sha256='1094a69b026238d149435472b4f41c75151c7370a1be6c6332147c88ad4c4829')
 
-    depends_on('r-markdown@1.17:', type=('build', 'run'))
+    depends_on('r-rmarkdown@1.17:', type=('build', 'run'))
     depends_on('pandoc@1.12.3:', type='build')


### PR DESCRIPTION
The markdown dependency is `r-rmarkdown` rather than `r-markdown`.