### PR TITLE
Set r version constraint on r-affy

### DIFF
--- a/var/spack/repos/builtin/packages/r-affy/package.py
+++ b/var/spack/repos/builtin/packages/r-affy/package.py
@@ -23,7 +23,7 @@ class RAffy(RPackage):
     version('1.56.0', commit='d36a7b8f05b1ef60162d94e75037d45c48f88871')
     version('1.54.0', commit='a815f02906fcf491b28ed0a356d6fce95a6bd20e')
 
-    depends_on('r@2.8.0:', type=('build', 'run'))
+    depends_on('r@2.8.0:4.0', type=('build', 'run'), when='@:1.68.0')
     depends_on('r-biocgenerics@0.1.12:', type=('build', 'run'))
     depends_on('r-biobase@2.5.5:', type=('build', 'run'))
     depends_on('r-affyio@1.13.3:', type=('build', 'run'))


### PR DESCRIPTION
This package does not build with `r@4.1:`. The BioConductor packages will need to be updated.