### PR TITLE
r-rpostgresql: Remove the autotools resources

### DIFF
--- a/var/spack/repos/builtin/packages/r-rpostgresql/package.py
+++ b/var/spack/repos/builtin/packages/r-rpostgresql/package.py
@@ -27,11 +27,3 @@ class RRpostgresql(RPackage):
     depends_on('r@2.9.0:', type=('build', 'run'))
     depends_on('r-dbi@0.3:', type=('build', 'run'))
     depends_on('postgresql')
-
-    depends_on('automake', type='build')
-
-    patch_config_files = True
-
-    @run_before('install')
-    def patch_config_guess(self):
-        AutotoolsPackage._do_patch_config_files(self)


### PR DESCRIPTION
This essentially reverts #18917 as it seems to no longer be necessary
due to recent autotools changes in core spack.