### PR TITLE
[mesa] new versions: bugfix 21.2.6, minor 21.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -39,6 +39,7 @@ class Mesa(MesonPackage):
     depends_on('gettext', type='build')
     depends_on('python@3:', type='build')
     depends_on('py-mako@0.8.0:', type='build')
+    depends_on('unwind')
     depends_on('expat')
     depends_on('zlib@1.2.3:')
 

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -19,6 +19,8 @@ class Mesa(MesonPackage):
     url = "https://archive.mesa3d.org/mesa-20.2.1.tar.xz"
 
     version('master', tag='master')
+    version('21.3.1', sha256='2b0dc2540cb192525741d00f706dbc4586349185dafc65729c7fda0800cc474d')
+    version('21.2.6', sha256='1e7e22d93c6e8859fa044b1121119d26b2e67e4184b92ebb81c66497dc80c954')
     version('21.2.5', sha256='8e49585fb760d973723dab6435d0c86f7849b8305b1e6d99f475138d896bacbb')
     version('21.2.4', sha256='fe6ede82d1ac02339da3c2ec1820a379641902fd351a52cc01153f76eff85b44')
     version('21.2.3', sha256='7245284a159d2484770e1835a673e79e4322a9ddf43b17859668244946db7174')


### PR DESCRIPTION
This adds the recent bugfix version of the 21.2 series, and the first recommended version of the 21.3 series. Per the mesa release notes, 21.3.0 is not recommended for stable installations, so it is not included in the list of versions in package.py.

As reported in #25913, `mesa` depends on `unwind`, which is made explicit here. The discussion in that PR indicates that `libunwind` works on `aarch64` and `arm`. There are no conflicts in `libunwind` to indicate otherwise. There does not seem to be a way to specify a `depends_on('unwind', when='target!=arm')` so this now effectively introduces the `unwind` dependency for all targets, but (as before) does not use it for `arm` and `aarch64`.

References:
- [21.2.6 release notes](https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/docs/relnotes/21.2.6.rst)
- [21.3.0 release notes](https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/docs/relnotes/21.3.0.rst) (for new features in 21.3 series)
- [21.3.1 release notes](https://gitlab.freedesktop.org/mesa/mesa/-/blob/main/docs/relnotes/21.3.1.rst)
