### PR TITLE
[opencascade] new version 7.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/opencascade/package.py
+++ b/var/spack/repos/builtin/packages/opencascade/package.py
@@ -18,6 +18,8 @@ class Opencascade(CMakePackage):
 
     maintainers = ['wdconinc']
 
+    version('7.6.0', extension='tar.gz',
+            sha256='e7f989d52348c3b3acb7eb4ee001bb5c2eed5250cdcceaa6ae97edc294f2cabd')
     version('7.5.3', extension='tar.gz',
             sha256='cc3d3fd9f76526502c3d9025b651f45b034187430f231414c97dda756572410b')
     version('7.5.2', extension='tar.gz',


### PR DESCRIPTION
New version; no changes to build system expected after going through changes in CMakeLists.txt.

Tested the build as `opencascade@7.6.0%gcc@11.1.0~freeimage+ipo~rapidjson+tbb~vtk build_type=RelWithDebInfo arch=linux-ubuntu21.04-skylake`.