### PR TITLE
WarpX: 21.12

### DIFF
--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -27,6 +27,7 @@ class PyWarpx(PythonPackage):
 
     # NOTE: if you update the versions here, also see warpx
     version('develop', branch='development')
+    version('21.12', sha256='847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1')
     version('21.11', sha256='ce60377771c732033a77351cd3500b24b5d14b54a5adc7a622767b9251c10d0b')
     version('21.10', sha256='d372c573f0360094d5982d64eceeb0149d6620eb75e8fdbfdc6777f3328fb454')
     version('21.09', sha256='861a65f11846541c803564db133c8678b9e8779e69902ef1637b21399d257eab')
@@ -39,8 +40,8 @@ class PyWarpx(PythonPackage):
     variant('mpi', default=True,
             description='Enable MPI support')
 
-    for v in ['21.11', '21.10', '21.09', '21.08', '21.07', '21.06', '21.05',
-              '21.04', 'develop']:
+    for v in ['21.12', '21.11', '21.10', '21.09', '21.08', '21.07', '21.06',
+              '21.05', '21.04', 'develop']:
         depends_on('warpx@{0}'.format(v),
                    when='@{0}'.format(v),
                    type=['build', 'link'])

--- a/var/spack/repos/builtin/packages/warpx/2626.patch
+++ b/var/spack/repos/builtin/packages/warpx/2626.patch
@@ -1,0 +1,34 @@
+From 9785e706229622626133c4b03c7abd004f62023f Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Sat, 4 Dec 2021 15:28:13 -0800
+Subject: [PATCH] Fix: Installed Symlink LIB
+
+The latest patch to these routines broke our library alias in installs.
+
+By default, this variable is relative and needs the prefix appended.
+In some cases, e.g., if externally set, it can already be absolute. In that
+case, we skip adding the prefix.
+---
+ CMakeLists.txt | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 04092ba962..a549546ab9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -343,9 +343,14 @@ if(WarpX_LIB)
+     else()
+         set(mod_ext "so")
+     endif()
++    if(IS_ABSOLUTE CMAKE_INSTALL_LIBDIR)
++        set(ABS_INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
++    else()
++        set(ABS_INSTALL_LIB_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
++    endif()
+     install(CODE "file(CREATE_LINK
+         $<TARGET_FILE_NAME:shared>
+-        ${CMAKE_INSTALL_LIBDIR}/libwarpx.${lib_suffix}.${mod_ext}
++        ${ABS_INSTALL_LIB_DIR}/libwarpx.${lib_suffix}.${mod_ext}
+         COPY_ON_ERROR SYMBOLIC)")
+ endif()
+ 

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -25,6 +25,7 @@ class Warpx(CMakePackage):
 
     # NOTE: if you update the versions here, also see py-warpx
     version('develop', branch='development')
+    version('21.12', sha256='847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1')
     version('21.11', sha256='ce60377771c732033a77351cd3500b24b5d14b54a5adc7a622767b9251c10d0b')
     version('21.10', sha256='d372c573f0360094d5982d64eceeb0149d6620eb75e8fdbfdc6777f3328fb454')
     version('21.09', sha256='861a65f11846541c803564db133c8678b9e8779e69902ef1637b21399d257eab')
@@ -110,6 +111,11 @@ class Warpx(CMakePackage):
               msg='WarpX spectral solvers are not yet tested with SYCL '
                   '(use "warpx ~psatd")')
 
+    # The symbolic aliases for our +lib target were missing in the install
+    # location
+    # https://github.com/ECP-WarpX/WarpX/pull/2626
+    patch('2626.patch', when='@21.12')
+
     def cmake_args(self):
         spec = self.spec
 
@@ -134,6 +140,9 @@ class Warpx(CMakePackage):
             self.define_from_variant('WarpX_QED', 'qed'),
             self.define_from_variant('WarpX_QED_TABLE_GEN', 'qedtablegen'),
         ]
+
+        with when('+openpmd'):
+            args.append('-DWarpX_openpmd_internal=OFF')
 
         return args
 


### PR DESCRIPTION
Update `warpx` & `py-warpx` to the latest release, `21.12`.