### PR TITLE
Update quantum-espresso package

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -324,6 +324,11 @@ class QuantumEspresso(CMakePackage):
             self.define_from_variant('QE_ENABLE_LIBXC', 'libxc'),
         ]
 
+        # QE prefers taking MPI compiler wrappers as CMake compilers.
+        if '+mpi' in spec:
+            cmake_args.append(self.define('CMAKE_C_COMPILER', spec['mpi'].mpicc))
+            cmake_args.append(self.define('CMAKE_Fortran_COMPILER', spec['mpi'].mpifc))
+
         if not spec.satisfies('hdf5=none'):
             cmake_args.append(self.define('QE_ENABLE_HDF5', True))
 

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -48,15 +48,54 @@ class QuantumEspresso(CMakePackage):
              destination='.'
              )
 
-    variant('cmake', default=False, description='Builds via CMake')
-    conflicts('+cmake', when='@:6.7', msg='+cmake works since QE v6.8')
+    variant('cmake', default=True, description='Builds via CMake')
+    with when('+cmake'):
+        depends_on("cmake@3.14.0:", type="build")
+        conflicts('@:6.7', msg='+cmake works since QE v6.8')
+
+        variant('libxc', default=False, description='Uses libxc')
+        depends_on('libxc@5.1.2:', when='+libxc')
+
+        # TODO
+        #variant(
+        #    'gpu', default='none', description='Builds with GPU support',
+        #    values=('nvidia', 'none'), multi=False
+        #)
+
+    variant('openmp', default=False, description='Enables openMP support')
+    # Need OpenMP threaded FFTW and BLAS libraries when configured
+    # with OpenMP support
+    with when('+openmp'):
+        conflicts('^fftw~openmp')
+        conflicts('^amdfftw~openmp')
+        conflicts('^openblas threads=none')
+        conflicts('^openblas threads=pthreads')
+
+    # Apply upstream patches by default. Variant useful for 3rd party
+    # patches which are incompatible with upstream patches
+    desc = 'Apply recommended upstream patches. May need to be set '
+    desc = desc + 'to False for third party patches or plugins'
+    variant('patch', default=True, description=desc)
 
     variant('mpi', default=True, description='Builds with mpi support')
-    variant('openmp', default=False, description='Enables openMP support')
-    variant('scalapack', default=True, description='Enables scalapack support')
-    variant('elpa', default=False, description='Uses elpa as an eigenvalue solver')
-    variant('libxc', default=False, description='Uses libxc')
-    conflicts('+libxc', when='~cmake', msg='Using libxc requires building with CMake')
+    with when('+mpi'):
+        depends_on('mpi')
+        variant('scalapack', default=True, description='Enables scalapack support')
+
+    with when('+scalapack'):
+        depends_on('scalapack')
+        variant('elpa', default=False, description='Uses elpa as an eigenvalue solver')
+
+    with when('+elpa'):
+        # CMake builds only support elpa without openmp
+        depends_on('elpa~openmp', when='+cmake')
+        depends_on('elpa+openmp', when='+openmp~cmake')
+        depends_on('elpa~openmp', when='~openmp~cmake')
+        # Elpa is formally supported by @:5.4.0, but QE configure searches
+        # for it in the wrong folders (or tries to download it within
+        # the build directory). Instead of patching Elpa to provide the
+        # folder QE expects as a link, we issue a conflict here.
+        conflicts('@:5.4.0', msg='+elpa requires QE >= 6.0')
 
     # Support for HDF5 has been added starting in version 6.1.0 and is
     # still experimental, therefore we default to False for the variant
@@ -65,68 +104,9 @@ class QuantumEspresso(CMakePackage):
         values=('parallel', 'serial', 'none'), multi=False
     )
 
-    # Enables building Electron-phonon Wannier 'epw.x' executable
-    # http://epw.org.uk/Main/About
-    variant('epw', default=False,
-            description='Builds Electron-phonon Wannier executable')
-    conflicts('~epw', when='+cmake', msg='epw cannot be turned off when using CMake')
-
-    # Apply upstream patches by default. Variant useful for 3rd party
-    # patches which are incompatible with upstream patches
-    desc = 'Apply recommended upstream patches. May need to be set '
-    desc = desc + 'to False for third party patches or plugins'
-    variant('patch', default=True, description=desc)
-
-    # QMCPACK converter patch
-    # https://github.com/QMCPACK/qmcpack/tree/develop/external_codes/quantum_espresso
-    variant('qmcpack', default=False,
-            description='Build QE-to-QMCPACK wave function converter')
-
-    variant('environ', default=False,
-            description='Enables support for introducing environment effects '
-            'into atomistic first-principles simulations.'
-            'See http://quantum-environ.org/about.html')
-    conflicts('+environ', when='+cmake', msg='environ doesn\'t work with CMake')
-
-    # Dependencies
-    depends_on("cmake@3.14.0:", type="build", when='+cmake')
-    depends_on('blas')
-    depends_on('lapack')
-    depends_on('fftw-api@3')
-    depends_on('mpi', when='+mpi')
-    depends_on('scalapack', when='+scalapack+mpi')
-    # CMake builds only support elpa without openmp
-    depends_on('elpa~openmp', when='+elpa+cmake')
-    depends_on('elpa+openmp', when='+elpa+openmp~cmake')
-    depends_on('elpa~openmp', when='+elpa~openmp~cmake')
     # Versions of HDF5 prior to 1.8.16 lead to QE runtime errors
     depends_on('hdf5@1.8.16:+fortran+hl+mpi', when='hdf5=parallel')
     depends_on('hdf5@1.8.16:+fortran+hl~mpi', when='hdf5=serial')
-    depends_on('hdf5', when='+qmcpack')
-    # TODO: enable building EPW when ~mpi and ~cmake
-    depends_on('mpi', when='+epw~cmake')
-    depends_on('libxc@5.1.2:', when='+libxc')
-
-    # CONFLICTS SECTION
-    # Omitted for now due to concretizer bug
-    # MKL with 64-bit integers not supported.
-    # conflicts(
-    #     '^mkl+ilp64',
-    #     msg='Quantum ESPRESSO does not support MKL 64-bit integer variant'
-    # )
-
-    # We can't ask for scalapack or elpa if we don't want MPI
-    conflicts(
-        '+scalapack',
-        when='~mpi',
-        msg='scalapack is a parallel library and needs MPI support'
-    )
-
-    conflicts(
-        '+elpa',
-        when='~mpi',
-        msg='elpa is a parallel library and needs MPI support'
-    )
 
     # HDF5 support introduced in 6.1.0, but the configure had some limitations.
     # In recent tests (Oct 2019), GCC and Intel work with the HDF5 Spack
@@ -152,53 +132,75 @@ class QuantumEspresso(CMakePackage):
         msg='parallel HDF5 requires MPI support'
     )
 
-    # Elpa is formally supported by @:5.4.0, but QE configure searches
-    # for it in the wrong folders (or tries to download it within
-    # the build directory). Instead of patching Elpa to provide the
-    # folder QE expects as a link, we issue a conflict here.
-    conflicts('+elpa', when='@:5.4.0')
+    # QMCPACK converter patch
+    # https://github.com/QMCPACK/qmcpack/tree/develop/external_codes/quantum_espresso
+    variant('qmcpack', default=False,
+            description='Build QE-to-QMCPACK wave function converter')
 
-    # Some QMCPACK converters are incompatible with upstream patches.
-    # HDF5 is a hard requirement. Need to do two HDF5 cases explicitly
-    # since Spack lacks support for expressing NOT operation.
-    conflicts(
-        '@6.4+patch',
-        when='+qmcpack',
-        msg='QE-to-QMCPACK wave function converter requires '
-        'deactivatation of upstream patches'
-    )
-    conflicts(
-        '@6.3:6.4.0 hdf5=serial',
-        when='+qmcpack',
-        msg='QE-to-QMCPACK wave function converter only '
-        'supported with parallel HDF5'
-    )
-    conflicts(
-        'hdf5=none',
-        when='+qmcpack',
-        msg='QE-to-QMCPACK wave function converter requires HDF5'
-    )
+    with when('+qmcpack'):
+        # Some QMCPACK converters are incompatible with upstream patches.
+        # HDF5 is a hard requirement. Need to do two HDF5 cases explicitly
+        # since Spack lacks support for expressing NOT operation.
+        conflicts(
+            '@6.4+patch',
+            msg='QE-to-QMCPACK wave function converter requires '
+            'deactivatation of upstream patches'
+        )
+        conflicts(
+            '@6.3:6.4.0 hdf5=serial',
+            msg='QE-to-QMCPACK wave function converter only '
+            'supported with parallel HDF5'
+        )
+        conflicts(
+            'hdf5=none',
+            msg='QE-to-QMCPACK wave function converter requires HDF5'
+        )
 
-    # The first version of Q-E to feature integrated EPW is 6.0.0,
-    # as per http://epw.org.uk/Main/DownloadAndInstall .
-    # Complain if trying to install a version older than this.
-    conflicts('+epw', when='@:5',
-              msg='EPW only available from version 6.0.0 and on')
+    # Enables building Electron-phonon Wannier 'epw.x' executable
+    # http://epw.org.uk/Main/About
+    variant('epw', default=False,
+            description='Builds Electron-phonon Wannier executable')
+    conflicts('~epw', when='+cmake', msg='epw cannot be turned off when using CMake')
 
-    # Below goes some constraints as shown in the link above.
-    # Constraints may be relaxed as successful reports
-    # of different compiler+mpi combinations arrive
+    with when('+epw'):
+        # The first version of Q-E to feature integrated EPW is 6.0.0,
+        # as per http://epw.org.uk/Main/DownloadAndInstall .
+        # Complain if trying to install a version older than this.
+        conflicts('@:5', msg='EPW only available from version 6.0.0 and on')
 
-    # TODO: enable building EPW when ~mpi and ~cmake
-    conflicts('+epw', when='~mpi~cmake', msg='EPW needs MPI')
+        # Below goes some constraints as shown in the link above.
+        # Constraints may be relaxed as successful reports
+        # of different compiler+mpi combinations arrive
 
-    # EPW doesn't gets along well with OpenMPI 2.x.x
-    conflicts('+epw', when='^openmpi@2.0.0:2',
-              msg='OpenMPI version incompatible with EPW')
+        # TODO: enable building EPW when ~mpi and ~cmake
+        conflicts('~mpi', when='~cmake', msg='EPW needs MPI when ~cmake')
 
-    # EPW also doesn't gets along well with PGI 17.x + OpenMPI 1.10.7
-    conflicts('+epw', when='^openmpi@1.10.7%pgi@17.0:17.12',
-              msg='PGI+OpenMPI version combo incompatible with EPW')
+        # EPW doesn't gets along well with OpenMPI 2.x.x
+        conflicts('^openmpi@2.0.0:2',
+                  msg='OpenMPI version incompatible with EPW')
+
+        # EPW also doesn't gets along well with PGI 17.x + OpenMPI 1.10.7
+        conflicts('^openmpi@1.10.7%pgi@17.0:17.12',
+                  msg='PGI+OpenMPI version combo incompatible with EPW')
+
+    variant('environ', default=False,
+            description='Enables support for introducing environment effects '
+            'into atomistic first-principles simulations.'
+            'See http://quantum-environ.org/about.html')
+    conflicts('+environ', when='+cmake', msg='environ doesn\'t work with CMake')
+
+    # Dependencies not affected by variants
+    depends_on('blas')
+    depends_on('lapack')
+    depends_on('fftw-api@3')
+
+    # CONFLICTS SECTION
+    # Omitted for now due to concretizer bug
+    # MKL with 64-bit integers not supported.
+    # conflicts(
+    #     '^mkl+ilp64',
+    #     msg='Quantum ESPRESSO does not support MKL 64-bit integer variant'
+    # )
 
     # PATCHES SECTION
     # THIRD-PARTY PATCHES
@@ -225,18 +227,6 @@ class QuantumEspresso(CMakePackage):
     patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.7.0.diff'
     patch_checksum = '72564c168231dd4a1279a74e76919af701d47cee9a851db6e205753004fe9bb5'
     patch(patch_url, sha256=patch_checksum, when='@6.7+qmcpack')
-
-    # 6.8
-    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.8.diff'
-    patch_checksum = '69f7fbd72aba810c35a0b034188e45bea8f9f11d3150c0715e1b3518d5c09248'
-    patch(patch_url, sha256=patch_checksum, when='@6.8+qmcpack')
-
-    # Need OpenMP threaded FFTW and BLAS libraries when configured
-    # with OpenMP support
-    conflicts('^fftw~openmp', when='+openmp')
-    conflicts('^amdfftw~openmp', when='+openmp')
-    conflicts('^openblas threads=none', when='+openmp')
-    conflicts('^openblas threads=pthreads', when='+openmp')
 
     # 6.4.1
     patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.4.1.diff'

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -57,10 +57,10 @@ class QuantumEspresso(CMakePackage):
         depends_on('libxc@5.1.2:', when='+libxc')
 
         # TODO
-        #variant(
-        #    'gpu', default='none', description='Builds with GPU support',
-        #    values=('nvidia', 'none'), multi=False
-        #)
+        # variant(
+        #     'gpu', default='none', description='Builds with GPU support',
+        #     values=('nvidia', 'none'), multi=False
+        # )
 
     variant('openmp', default=False, description='Enables openMP support')
     # Need OpenMP threaded FFTW and BLAS libraries when configured


### PR DESCRIPTION
1. pass MPI wrappers as CMake compilers.
2. consolidate variant dependency with `with when()`
3. Use CMake build system by default for QE >= 6.8