### PR TITLE
[acts] use variants['cuda_arch'] only when +cuda

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -219,9 +219,10 @@ class Acts(CMakePackage, CudaPackage):
         log_failure_threshold = spec.variants['log_failure_threshold'].value
         args.append("-DACTS_LOG_FAILURE_THRESHOLD={0}".format(log_failure_threshold))
 
-        cuda_arch = spec.variants['cuda_arch'].value
-        if cuda_arch != 'none':
-            args.append('-DCUDA_FLAGS=-arch=sm_{0}'.format(cuda_arch[0]))
+        if '+cuda' in spec:
+            cuda_arch = spec.variants['cuda_arch'].value
+            if cuda_arch != 'none':
+                args.append('-DCUDA_FLAGS=-arch=sm_{0}'.format(cuda_arch[0]))
 
         if 'root' in spec:
             cxxstd = spec['root'].variants['cxxstd'].value


### PR DESCRIPTION
Since #27185, the `cuda_arch` variant values are conditional on `+cuda`. This means that for `-cuda` specs, the installation fails with:
```
==> acts: Executing phase: 'cmake'
==> Error: KeyError: 'cuda_arch'

/home/wdconinc/git/spack/var/spack/repos/builtin/packages/acts/package.py:222, in cmake_args:
        219        log_failure_threshold = spec.variants['log_failure_threshold'].value
        220        args.append("-DACTS_LOG_FAILURE_THRESHOLD={0}".format(log_failure_threshold))
        221
  >>    222        cuda_arch = spec.variants['cuda_arch'].value
        223        if cuda_arch != 'none':
        224            args.append('-DCUDA_FLAGS=-arch=sm_{0}'.format(cuda_arch[0]))
        225
```

This PR ensures that `spec.variants['cuda_arch'].value` is only accessed when `+cuda` is in the spec.

Maintainer tag: @HadrienG2 