### PR TITLE
[rivet] --with-hepmc3 should use hepmc3 prefix

### DIFF
--- a/var/spack/repos/builtin/packages/rivet/package.py
+++ b/var/spack/repos/builtin/packages/rivet/package.py
@@ -168,7 +168,7 @@ class Rivet(AutotoolsPackage):
         if self.spec.variants['hepmc'].value == '2':
             args += ['--with-hepmc=' + self.spec['hepmc'].prefix]
         else:
-            args += ['--with-hepmc3=' + self.spec['hepmc'].prefix]
+            args += ['--with-hepmc3=' + self.spec['hepmc3'].prefix]
 
         if self.spec.satisfies('@:1'):
             args += ['--with-boost-incpath=' + self.spec['boost'].includes]


### PR DESCRIPTION
The previous version, `'--with-hepmc3=' + self.spec['hepmc'].prefix`, ends up putting the (empty) hepmc(2) prefix in the library linker list, resulting in the error:
```
     614    libtool: link: ranlib .libs/libRivetAnalysisTools.a
     615    libtool: link: ( cd ".libs" && rm -f "libRivetAnalysisTools.la" && ln -s "../libRivetAnalysisTools.la" "libRivetAnalysisTools.la" )
     616    make[2]: Leaving directory '/home/wdconinc/.spack/stage/spack-stage-rivet-3.1.4-lphues43oironi27qiyi5ntfe66taqll/spack-src/src/AnalysisTools'
     617    make[2]: Entering directory '/home/wdconinc/.spack/stage/spack-stage-rivet-3.1.4-lphues43oironi27qiyi5ntfe66taqll/spack-src/src'
     618    /bin/bash ../libtool  --tag=CC   --mode=link /home/wdconinc/git/spack/lib/spack/env/gcc/gcc  -g -O2 -export-dynamic -avoid-version -L/opt/software/linux-ubuntu21.10-skylake/gcc-11.2.0/yoda-1.9.0-5ab4x46uqjof3xjki75okc56razw
            fnuo/lib -L  -L/usr/lib -L/usr/lib -o libRivet.la -rpath /opt/software/linux-ubuntu21.10-skylake/gcc-11.2.0/rivet-3.1.4-lphues43oironi27qiyi5ntfe66taqll/lib  Core/libRivetCore.la Projections/libRivetProjections.la Tools/lib
            RivetTools.la AnalysisTools/libRivetAnalysisTools.la -lYODA -ldl -lm -Wl,-rpath,/opt/software/linux-ubuntu21.10-skylake/gcc-11.2.0/fastjet-3.3.3-3gacqzwwhixwlezvjsjwnawngm4mtupi/lib -L/opt/software/linux-ubuntu21.10-skylake
            /gcc-11.2.0/fastjet-3.3.3-3gacqzwwhixwlezvjsjwnawngm4mtupi/lib -lfastjettools -lfastjet -lm -lfastjetplugins -lsiscone_spherical -lsiscone    -L/lib/x86_64-linux-gnu -L/lib/../lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib/../l
            ib  -lgfortran -lm -lquadmath -L/opt/software/linux-ubuntu21.10-skylake/gcc-11.2.0/fjcontrib-1.044-remjayzdrkszoeguhgfexihieakv6ap2/lib -lfastjetcontribfragile -lfastjettools -lHepMC3 -lHepMC3search  -lz
     619    libtool:   error: require no space between '-L' and '-L/usr/lib'
  >> 620    make[2]: *** [Makefile:532: libRivet.la] Error 1
     621    make[2]: Leaving directory '/home/wdconinc/.spack/stage/spack-stage-rivet-3.1.4-lphues43oironi27qiyi5ntfe66taqll/spack-src/src'
  >> 622    make[1]: *** [Makefile:553: all-recursive] Error 1
     623    make[1]: Leaving directory '/home/wdconinc/.spack/stage/spack-stage-rivet-3.1.4-lphues43oironi27qiyi5ntfe66taqll/spack-src/src'
  >> 624    make: *** [Makefile:560: all-recursive] Error 1
```

I confirmed that this error does not occur after this PR is applied.

No maintainers, but @bernhardkaindl @vvolkl @iarspider may be willing to review.