### PR TITLE
rocm: add gfx90a

### DIFF
--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -91,7 +91,7 @@ class ROCmPackage(PackageBase):
     # Possible architectures
     amdgpu_targets = (
         'gfx701', 'gfx801', 'gfx802', 'gfx803',
-        'gfx900', 'gfx906', 'gfx908', 'gfx1010',
+        'gfx900', 'gfx906', 'gfx908', 'gfx90a', 'gfx1010',
         'gfx1011', 'gfx1012'
     )
 


### PR DESCRIPTION
@sameershende 

This PR simply adds recognition of the `gfx90a` AMD GPU Target as a valid value.

See https://llvm.org/docs/AMDGPU/AMDGPUAsmGFX90a.html?highlight=gfx90a.