### PR TITLE
mercury: add version 2.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/mercury/package.py
+++ b/var/spack/repos/builtin/packages/mercury/package.py
@@ -15,6 +15,7 @@ class Mercury(CMakePackage):
     maintainers = ['soumagne']
     tags = ['e4s']
     version('master', branch='master', submodules=True)
+    version('2.1.0', sha256='9a58437161e9273b1b1c484d2f1a477a89eea9afe84575415025d47656f3761b')
     version('2.0.1', sha256='335946d9620ac669643ffd9861a5fb3ee486834bab674b7779eaac9d6662e3fa')
     version('2.0.0', sha256='9e80923712e25df56014309df70660e828dbeabbe5fcc82ee024bcc86e7eb6b7')
     version('1.0.1', sha256='02febd56c401ef7afa250caf28d012b37dee842bfde7ee16fcd2f741b9cf25b3')
@@ -22,11 +23,11 @@ class Mercury(CMakePackage):
     version('0.9.0', sha256='40868e141cac035213fe79400f8926823fb1f5a0651fd7027cbe162b063843ef')
 
     variant('bmi', default=False, description='Use BMI plugin')
-    variant('cci', default=False, description='Use CCI plugin')
     variant('mpi', default=False, description='Use MPI plugin')
-    variant('ofi', default=True,  description='Use OFI libfabric plugin')
+    variant('ofi', default=True, when='@1.0.0:', description='Use OFI libfabric plugin')
     # NOTE: the sm plugin does not require any package dependency.
     variant('sm',  default=True,  description='Use shared-memory plugin')
+    variant('ucx', default=False, when='@2.1.0:', description='Use UCX plugin')
     # NOTE: if boostsys is False, mercury will install its own copy
     # of the preprocessor headers.
     variant('boostsys', default=True,
@@ -36,7 +37,7 @@ class Mercury(CMakePackage):
     # NOTE: the 'udreg' variant requires that the MPICH_GNI_NDREG_ENTRIES=1024
     #   environment variable be set at run time to avoid conflicts with
     #   Cray-MPICH if libfabric and MPI are used at the same time
-    variant('udreg', default=False,
+    variant('udreg', default=False, when='@1.0.0:+ofi',
             description='Enable udreg on supported Cray platforms')
     variant('debug', default=False,
             description='Enable Mercury to print debug output')
@@ -44,16 +45,16 @@ class Mercury(CMakePackage):
             description='Checksum verify all request/response messages')
 
     depends_on('cmake@2.8.12.2:', type='build')
-    # depends_on('cci', when='+cci')  # TODO: add CCI package
     depends_on('bmi', when='+bmi')
     depends_on('mpi', when='+mpi')
-    depends_on('libfabric@1.5:', when='+ofi')
-    depends_on('openpa@1.0.3:', when='%gcc@:4.8')
+    with when('+ofi'):
+        depends_on('libfabric@1.5:', when='@:2.0.1')
+        depends_on('libfabric@1.7:', when='@2.1.0:')
+    # openpa dependency is removed in 2.1.0
+    depends_on('openpa@1.0.3:', when='@:2.0.1%gcc@:4.8')
     depends_on('boost@1.48:', when='+boostsys')
     depends_on('boost', when='@:0.9')  # internal boost headers were added in 1.0.0
-
-    conflicts('+ofi', when='@:0.9')    # libfabric support was added in 1.0.0
-    conflicts('~ofi', when='+udreg')   # udreg option is specific to OFI
+    depends_on('ucx+thread_multiple', when='+ucx')
 
     # Fix CMake check_symbol_exists
     # See https://github.com/mercury-hpc/mercury/issues/299
@@ -68,52 +69,63 @@ class Mercury(CMakePackage):
     def cmake_args(self):
         """Populate cmake arguments for Mercury."""
         spec = self.spec
-        variant_bool = lambda feature: str(feature in spec)
+        define = self.define
+        define_from_variant = self.define_from_variant
         parallel_tests = '+mpi' in spec and self.run_tests
 
         cmake_args = [
-            '-DBUILD_SHARED_LIBS:BOOL=%s' % variant_bool('+shared'),
-            '-DBUILD_TESTING:BOOL=%s' % str(self.run_tests),
-            '-DMERCURY_ENABLE_PARALLEL_TESTING:BOOL=%s' % str(parallel_tests),
-            '-DMERCURY_USE_BOOST_PP:BOOL=ON',
-            '-DMERCURY_USE_CHECKSUMS:BOOL=%s' % variant_bool('+checksum'),
-            '-DMERCURY_USE_SYSTEM_MCHECKSUM:BOOL=OFF',
-            '-DMERCURY_USE_XDR:BOOL=OFF',
-            '-DNA_USE_BMI:BOOL=%s' % variant_bool('+bmi'),
-            '-DNA_USE_CCI:BOOL=%s' % variant_bool('+cci'),
-            '-DNA_USE_MPI:BOOL=%s' % variant_bool('+mpi'),
-            '-DNA_USE_SM:BOOL=%s'  % variant_bool('+sm'),
+            define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            define('BUILD_TESTING', self.run_tests),
+            define('MERCURY_USE_BOOST_PP', True),
+            define_from_variant('MERCURY_USE_CHECKSUMS', 'checksum'),
+            define('MERCURY_USE_SYSTEM_MCHECKSUM', False),
+            define('MERCURY_USE_XDR', False),
+            define_from_variant('NA_USE_BMI', 'bmi'),
+            define_from_variant('NA_USE_MPI', 'mpi'),
+            define_from_variant('NA_USE_SM', 'sm'),
         ]
+
+        if '@2.1.0:' in spec:
+            cmake_args.append(
+                define_from_variant('NA_USE_UCX', 'ucx')
+            )
 
         if '@2.0.0:' in spec:
             cmake_args.extend([
-                '-DMERCURY_ENABLE_DEBUG:BOOL=%s' % variant_bool('+debug'),
+                define_from_variant('MERCURY_ENABLE_DEBUG', 'debug'),
+                define('MERCURY_TESTING_ENABLE_PARALLEL', parallel_tests),
             ])
 
         # Previous versions of mercury had more extensive CMake options
         if '@:1.0.1' in spec:
             cmake_args.extend([
-                '-DMERCURY_ENABLE_POST_LIMIT:BOOL=OFF',
-                '-DMERCURY_ENABLE_VERBOSE_ERROR=%s' % variant_bool('+debug'),
-                '-DMERCURY_USE_EAGER_BULK:BOOL=ON',
-                '-DMERCURY_USE_SELF_FORWARD:BOOL=ON',
+                define('MERCURY_ENABLE_PARALLEL_TESTING', parallel_tests),
+                define('MERCURY_ENABLE_POST_LIMIT', False),
+                define_from_variant('MERCURY_ENABLE_VERBOSE_ERROR', 'debug'),
+                define('MERCURY_USE_EAGER_BULK', True),
+                define('MERCURY_USE_SELF_FORWARD', True),
             ])
 
         if '@1.0.0:' in spec:
             cmake_args.extend([
-                '-DMERCURY_USE_SYSTEM_BOOST:BOOL=%s'
-                % variant_bool('+boostsys'),
-                '-DNA_USE_OFI:BOOL=%s' % variant_bool('+ofi'),
+                define_from_variant('MERCURY_USE_SYSTEM_BOOST', 'boostsys'),
+                define_from_variant('NA_USE_OFI', 'ofi'),
             ])
 
         if '+ofi' in spec:
-            cmake_args.append(
-                '-DNA_OFI_GNI_USE_UDREG:BOOL=%s' % variant_bool('+udreg')
-            )
-            if self.run_tests:
+            ofi_fabrics = spec['libfabric'].variants['fabrics'].value
+            if 'gni' in ofi_fabrics:
                 cmake_args.append(
-                    '-DNA_OFI_TESTING_PROTOCOL:STRING={0}'.format(
-                        ';'.join(spec['libfabric'].variants['fabrics'].value)
+                    define_from_variant('NA_OFI_GNI_USE_UDREG', 'udreg')
+                )
+            if self.run_tests:
+                supported = ['sockets', 'tcp', 'verbs', 'psm2', 'gni']
+                ofi_test_fabrics = list(
+                    filter(lambda x: x in supported, ofi_fabrics)
+                )
+                cmake_args.append(
+                    define('NA_OFI_TESTING_PROTOCOL', format(
+                        ';'.join(ofi_test_fabrics))
                     )
                 )
 


### PR DESCRIPTION
remove unused CCI variant

remove dependency on openpa with 2.1.0

add ucx variant

fix libfabric testing and handling of providers