### PR TITLE
Fix bootstrap when install_missing_compilers is True and no gcc is found

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -278,17 +278,20 @@ class _BuildcacheBootstrapper(object):
             with spack.config.override(
                     'compilers', [{'compiler': compiler_entry}]
             ):
-                spec_str = '/' + pkg_hash
-                parser = argparse.ArgumentParser()
-                spack.cmd.buildcache.setup_parser(parser)
-                install_args = [
-                    'install',
-                    '--sha256', pkg_sha256,
-                    '--only-root',
-                    '-a', '-u', '-o', '-f', spec_str
-                ]
-                args = parser.parse_args(install_args)
-                spack.cmd.buildcache.installtarball(args)
+                # Prevent attempts to bootstrap a compiler when bootstrapping packages
+                # like clingo in case config:install_missing_compilers is set to true
+                with spack.concretize.enable_compiler_existence_check():
+                    spec_str = '/' + pkg_hash
+                    parser = argparse.ArgumentParser()
+                    spack.cmd.buildcache.setup_parser(parser)
+                    install_args = [
+                        'install',
+                        '--sha256', pkg_sha256,
+                        '--only-root',
+                        '-a', '-u', '-o', '-f', spec_str
+                    ]
+                    args = parser.parse_args(install_args)
+                    spack.cmd.buildcache.installtarball(args)
 
     def _install_and_test(
             self, abstract_spec, bincache_platform, bincache_data, test_fn


### PR DESCRIPTION
In this case, the bootstrap entered a circular import error when it saw
that importing clingo needs %gcc. When install_missing_compilers = true,
an attempt to bootstrap a gcc was made, but this fails when no gcc is
found on the system. This caused a circular import error.

While bootstrapping clingo or other bootstrap packages, enable the check
for the presence of the needed compiler (override install_missing_compilers)
to not attempt to bootstrap a compiler while not having any compilers.