### PR TITLE
Superlu: Update Spack test dir

### DIFF
--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -115,13 +115,9 @@ class Superlu(CMakePackage):
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        if self.version == Version('5.2.2'):
+        if self.spec.satisfies('@5.2.2:'):
             # Include dir was hardcoded in 5.2.2
             filter_file(r'INCLUDEDIR  = -I\.\./SRC',
-                        'INCLUDEDIR = -I' + self.prefix.include,
-                        join_path(self.examples_src_dir, 'Makefile'))
-
-        filter_file(r'INCLUDEDIR  = -I\.\./SRC',
                         'INCLUDEDIR = -I' + self.prefix.include,
                         join_path(self.examples_src_dir, 'Makefile'))
 

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -172,14 +172,17 @@ class Superlu(CMakePackage):
         return config_args
 
     def run_superlu_test(self, test_dir, exe, args):
-        self.run_test('make',
-                      options=args,
-                      purpose='test: compile {0} example'.format(exe),
-                      work_dir=test_dir)
+        if not self.run_test('make',
+                             options=args,
+                             purpose='test: compile {0} example'.format(exe),
+                             work_dir=test_dir):
+            tty.warn('Skipping test: failed to compile example')
+            return
 
-        self.run_test(exe,
-                      purpose='test: run {0} example'.format(exe),
-                      work_dir=test_dir)
+        if not self.run_test(exe,
+                             purpose='test: run {0} example'.format(exe),
+                             work_dir=test_dir):
+            tty.warn('Skipping test: failed to run example')
 
     def test(self):
         config_args = self._generate_make_hdr_for_test()

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -171,13 +171,9 @@ class Superlu(CMakePackage):
 
         return config_args
 
-    def run_superlu_test(self, test_dir, exe):
-        self.run_test(os.environ['CC'],
-                      options=['-I{0}'.format(self.prefix.include),
-                               '-L{0}'.format(self.prefix.lib),
-                               '-L{0}'.format(self.spec['blas'].prefix.lib),
-                               join_path(test_dir, 'superlu.c'), '-o', exe,
-                               '-lsuperlu', '-lopenblas'],
+    def run_superlu_test(self, test_dir, exe, args):
+        self.run_test('make',
+                      options=args,
                       purpose='test: compile {0} example'.format(exe),
                       work_dir=test_dir)
 
@@ -202,17 +198,11 @@ class Superlu(CMakePackage):
 
         test_dir = join_path(self.test_suite.current_test_cache_dir,
                              self.examples_src_dir)
+        exe = 'superlu'
 
-        if not os.path.exists(test_dir):
-            tty.warn('Skipping superlu test: missing required {0}'.format(test_dir))
+        if not os.path.isfile(join_path(test_dir, '{0}.c'.format(exe))):
+            tty.warn('Skipping superlu test:'
+                     'missing file {0}.c'.format(exe))
             return
 
-        #self.run_superlu_test(test_dir, 'superlu')
-        #return
-
-        with working_dir(test_dir, create=False):
-            make(*args, parallel=False)
-            self.run_test('./superlu',
-                          purpose='Smoke test for superlu',
-                          work_dir='.')
-            make('clean')
+        self.run_superlu_test(test_dir, exe, args)

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -5,6 +5,8 @@
 
 import os
 
+from llnl.util import tty
+
 
 class Superlu(CMakePackage):
     """SuperLU is a general purpose library for the direct solution of large,
@@ -177,7 +179,7 @@ class Superlu(CMakePackage):
         self.run_test(os.environ['CC'],
                       options=['-I{0}'.format(self.prefix.include),
                                '-L{0}'.format(self.prefix.lib),
-                               '-L{0}'.format(self.spec['openblas'].prefix.lib),
+                               '-L{0}'.format(self.spec['blas'].prefix.lib),
                                join_path(test_dir, 'superlu.c'), '-o', exe,
                                '-lsuperlu', '-lopenblas'],
                       purpose='test: compile {0} example'.format(exe),
@@ -201,13 +203,12 @@ class Superlu(CMakePackage):
         if self.version < Version('5.2.2'):
             args.append('HEADER=' + self.prefix.include)
         args.append('superlu')
-        args.append('-L{0}'.format(self.spec['openblas'].prefix.lib))
 
         test_dir = join_path(self.test_suite.current_test_cache_dir,
                              self.examples_src_dir)
 
         if not os.path.exists(test_dir):
-            print('Skipping superlu test: missing required {0}'.format(test_dir))
+            tty.warn('Skipping superlu test: missing required {0}'.format(test_dir))
             return
 
         self.run_superlu_test(test_dir, 'superlu')
@@ -216,7 +217,6 @@ class Superlu(CMakePackage):
         with working_dir(test_dir, create=False):
             make(*args, parallel=False)
             self.run_test('./superlu',
-                          options=[],
                           purpose='Smoke test for superlu',
                           work_dir='.')
             make('clean')

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -136,9 +136,9 @@ class Superlu(CMakePackage):
             'ARCH       = ar',
             'ARCHFLAGS  = cr',
             'RANLIB     = {0}'.format('ranlib' if which('ranlib') else 'echo'),
-            'CC         = {0}'.format('cc'),
-            'FORTRAN    = {0}'.format('fc'),
-            'LOADER     = {0}'.format('cc'),
+            'CC         = {0}'.format(env['CC']),
+            'FORTRAN    = {0}'.format(env['FC']),
+            'LOADER     = {0}'.format(env['CC']),
             'CFLAGS     = -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_',
             'NOOPTS     = -O0'
         ])
@@ -162,9 +162,9 @@ class Superlu(CMakePackage):
             'ARCH       = ar',
             'ARCHFLAGS  = cr',
             'RANLIB     = {0}'.format('ranlib' if which('ranlib') else 'echo'),
-            'CC         = {0}'.format(self.compiler.cc),
-            'FORTRAN    = {0}'.format(self.compiler.fc),
-            'LOADER     = {0}'.format(self.compiler.cc),
+            'CC         = {0}'.format(env['CC']),
+            'FORTRAN    = {0}'.format(env['FC']),
+            'LOADER     = {0}'.format(env['CC']),
             'CFLAGS     = -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_',
             'NOOPTS     = -O0'
         ])

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -194,7 +194,7 @@ class Superlu(CMakePackage):
         with working_dir(test_dir, create=False):
             make(*args, parallel=False)
             self.run_test('./superlu',
-                          options=['-I{0}'.format(join_path(self.prefix, 'include'))],
+                          options=['-I{0}'.format(self.prefix.include)],
                           purpose='Smoke test for superlu',
                           work_dir='.')
             make('clean')

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -136,9 +136,9 @@ class Superlu(CMakePackage):
             'ARCH       = ar',
             'ARCHFLAGS  = cr',
             'RANLIB     = {0}'.format('ranlib' if which('ranlib') else 'echo'),
-            'CC         = {0}'.format(self.compiler.cc),
-            'FORTRAN    = {0}'.format(self.compiler.fc),
-            'LOADER     = {0}'.format(self.compiler.cc),
+            'CC         = {0}'.format('cc'),
+            'FORTRAN    = {0}'.format('fc'),
+            'LOADER     = {0}'.format('cc'),
             'CFLAGS     = -O3 -DNDEBUG -DUSE_VENDOR_BLAS -DPRNTlevel=0 -DAdd_',
             'NOOPTS     = -O0'
         ])
@@ -207,8 +207,8 @@ class Superlu(CMakePackage):
             tty.warn('Skipping superlu test: missing required {0}'.format(test_dir))
             return
 
-        self.run_superlu_test(test_dir, 'superlu')
-        return
+        #self.run_superlu_test(test_dir, 'superlu')
+        #return
 
         with working_dir(test_dir, create=False):
             make(*args, parallel=False)

--- a/var/spack/repos/builtin/packages/superlu/package.py
+++ b/var/spack/repos/builtin/packages/superlu/package.py
@@ -188,7 +188,7 @@ class Superlu(CMakePackage):
                              self.examples_src_dir)
 
         if not os.path.exists(test_dir):
-            print('Skipping superlu test')
+            print('Skipping superlu test: missing required {0}'.format(test_dir))
             return
 
         with working_dir(test_dir, create=False):


### PR DESCRIPTION
Fixes [27975](https://github.com/spack/spack/issues/27975)
Re-work parallel-netcdf from building in the install test root to using the test suite cache directory.