### PR TITLE
r-hdf5r: use pkg-config to find hdf5

### DIFF
--- a/var/spack/repos/builtin/packages/r-hdf5r/configure.patch
+++ b/var/spack/repos/builtin/packages/r-hdf5r/configure.patch
@@ -1,0 +1,98 @@
+diff -ru a/configure b/configure
+--- a/configure	2021-11-15 13:13:34.000000000 -0600
++++ b/configure	2021-12-07 15:08:23.118115118 -0600
+@@ -3673,43 +3673,15 @@
+         with_hdf5="no"
+         with_hdf5_fortran="no"
+     else
+-                HDF5_SHOW=$(eval $H5CC -show)
+ 
+-                HDF5_CC=$(eval $H5CC -show | $AWK '{print $1}')
+-        if test "$HDF5_CC" = "ccache"; then
+-            HDF5_CC=$(eval $H5CC -show | $AWK '{print $2}')
+-        fi
+-
+-
+-                HDF5_VERSION=$(eval $H5CC -showconfig | $GREP 'HDF5 Version:' \
+-            | $AWK '{print $3}')
++                HDF5_VERSION=$(eval pkg-config --modversion hdf5)
+         HDF5_MAJOR_VERSION=$(echo $HDF5_VERSION | $AWK -F \. '{print $1}')
+         HDF5_MINOR_VERSION=$(echo $HDF5_VERSION | $AWK -F \. {'print $2'})
+         HDF5_REVISION_VERSION=$(echo $HDF5_VERSION | $AWK -F \. {'print $3'})
+ 
+-                                                                                HDF5_tmp_flags=$(eval $H5CC -showconfig \
+-            | $GREP 'FLAGS\|Extra libraries:' \
+-            | $AWK -F: '{printf("%s "), $2}' )
+-
+-                HDF5_tmp_inst=$(eval $H5CC -showconfig \
+-            | $GREP 'Installation point:' \
+-            | $AWK '{print $NF}' )
+-
+-                HDF5_CPPFLAGS="-I${HDF5_tmp_inst}/include"
+-
+-                for arg in $HDF5_SHOW $HDF5_tmp_flags ; do
+-          case "$arg" in
+-            -I*) echo $HDF5_CPPFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
+-                  || HDF5_CPPFLAGS="$arg $HDF5_CPPFLAGS"
+-              ;;
+-            -L*) echo $HDF5_LDFLAGS | $GREP -e "$arg" 2>&1 >/dev/null \
+-                  || HDF5_LDFLAGS="$arg $HDF5_LDFLAGS"
+-              ;;
+-            -l*) echo $HDF5_LIBS | $GREP -e "$arg" 2>&1 >/dev/null \
+-                  || HDF5_LIBS="$arg $HDF5_LIBS"
+-              ;;
+-          esac
+-        done
++
++                HDF5_CPPFLAGS=$(eval pkg-config --cflags hdf5)
++                HDF5_LDFLAGS=$(eval pkg-config --libs hdf5)
+ 
+         HDF5_LIBS="$HDF5_LIBS -lhdf5"
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (version $HDF5_VERSION)" >&5
+@@ -3725,7 +3697,6 @@
+         ax_lib_hdf5_save_CPPFLAGS=$CPPFLAGS
+         ax_lib_hdf5_save_LIBS=$LIBS
+         ax_lib_hdf5_save_LDFLAGS=$LDFLAGS
+-        CC=$HDF5_CC
+         CPPFLAGS=$HDF5_CPPFLAGS
+         LIBS=$HDF5_LIBS
+         LDFLAGS=$HDF5_LDFLAGS
+@@ -3893,20 +3864,6 @@
+             with_hdf5_fortran="yes"
+ 
+ 
+-                        for arg in `$H5FC -show`
+-            do
+-              case "$arg" in #(
+-                -I*) echo $HDF5_FFLAGS | $GREP -e "$arg" >/dev/null \
+-                      || HDF5_FFLAGS="$arg $HDF5_FFLAGS"
+-                  ;;#(
+-                -L*) echo $HDF5_FFLAGS | $GREP -e "$arg" >/dev/null \
+-                      || HDF5_FFLAGS="$arg $HDF5_FFLAGS"
+-                                                               echo $HDF5_FFLAGS | $GREP -e "-I${arg#-L}" >/dev/null \
+-                      || HDF5_FFLAGS="-I${arg#-L} $HDF5_FFLAGS"
+-                  ;;
+-              esac
+-            done
+-
+                         for arg in $HDF5_LIBS
+             do
+               case "$arg" in #(
+@@ -4384,8 +4341,6 @@
+     as_fn_error $? "${GREP} does not support option -o" "$LINENO" 5
+   fi
+ 
+-  LIBS=`${H5CC} -show | ${GREP} -o " \-[lL][^[:space:]]\+" | tr "\n" " "`
+-
+ 
+     HDF5R_LIBS="${LIBS} -L. -lhdf5_hl -lhdf5 -lz -lm"
+ 
+@@ -4447,8 +4402,6 @@
+ 
+ 
+ 
+-  HDF5R_CPPFLAGS=`${H5CC} -show -c myconftest.c | ${GREP} -o "\-I[^[:space:]]\+" | tr "\n" " "`
+-
+   rm -f myconftest.c
+ fi
+ 

--- a/var/spack/repos/builtin/packages/r-hdf5r/package.py
+++ b/var/spack/repos/builtin/packages/r-hdf5r/package.py
@@ -20,21 +20,15 @@ class RHdf5r(RPackage):
     url      = "https://cloud.r-project.org/src/contrib/hdf5r_1.2.0.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/hdf5r"
 
+    version('1.3.5',
+            sha256='87b75173ab226a9fbaa5b28289349f3c56b638629560a172994b8f9323c1622f')
     version('1.3.3', sha256='a0f83cbf21563e81dbd1a1bd8379623ed0c9c4df4e094c75013abfd7a5271545')
     version('1.2.0', sha256='58813e334fd3f9040038345a7186e5cb02090898883ac192477a76a5b8b4fe81')
 
     depends_on('r@3.2.2:', type=('build', 'run'))
     depends_on('r-r6', type=('build', 'run'))
     depends_on('r-bit64', type=('build', 'run'))
-    depends_on('hdf5@1.8.13:')
+    depends_on('hdf5@1.8.13:+hl')
+    depends_on('pkgconfig', type='build')
 
-    def configure_args(self):
-        if 'mpi' in self.spec:
-            args = [
-                '--with-hdf5={0}/h5pcc'.format(self.spec['hdf5'].prefix.bin),
-            ]
-        else:
-            args = [
-                '--with-hdf5={0}/h5cc'.format(self.spec['hdf5'].prefix.bin),
-            ]
-        return args
+    patch('configure.patch')

--- a/var/spack/repos/builtin/packages/r-hdf5r/package.py
+++ b/var/spack/repos/builtin/packages/r-hdf5r/package.py
@@ -31,4 +31,10 @@ class RHdf5r(RPackage):
     depends_on('hdf5@1.8.13:+hl')
     depends_on('pkgconfig', type='build')
 
+    # The configure script in the package uses the hdf5 h5cc compiler wrapper
+    # in the PATH to configure hdf5. That works fine if hdf5 was built with
+    # autotools but the hdf5 package in Spack is built with cmake. The compiler
+    # wrapper built with cmake does not support the '-show' or '-showconfig'
+    # flags. The following patch replaces those commands in the configure
+    # script with pkg-config commands.
     patch('configure.patch')


### PR DESCRIPTION
Since hdf5 was switched from autotools to cmake, the hdf5 compiler
wrappers can not be used to find and configure hdf5. This PR switches to
using pkg-config for configuration.