### PR TITLE
CPU Architecture Support

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -337,7 +337,6 @@ class Legion(CMakePackage):
         options.append('-DLegion_MAX_FIELDS=%d' % maxfields)
 
         options.append('-DBUILD_MARCH:STRING={0}'.format(self.spec.architecture.target))
-        
         return options
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -198,9 +198,6 @@ class Legion(CMakePackage):
     variant('max_fields', values=int, default=512,
             description="Maximum number of fields allowed in a logical region.")
 
-    variant('native', default=False,
-            description="Enable native/host processor optimizaton target.")
-
     def cmake_args(self):
         spec = self.spec
         cmake_cxx_flags = []
@@ -339,10 +336,8 @@ class Legion(CMakePackage):
             maxfields = maxfields << 1
         options.append('-DLegion_MAX_FIELDS=%d' % maxfields)
 
-        if '+native' in spec:
-            # default is off.
-            options.append('-DBUILD_MARCH:STRING=native')
-
+        options.append('-DBUILD_MARCH:STRING={0}'.format(self.spec.architecture.target))
+        
         return options
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -336,7 +336,7 @@ class Legion(CMakePackage):
             maxfields = maxfields << 1
         options.append('-DLegion_MAX_FIELDS=%d' % maxfields)
 
-        options.append('-DBUILD_MARCH:STRING={0}'.format(self.spec.architecture.target))
+        options.append('-DBUILD_MARCH:STRING=')
         return options
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -336,8 +336,8 @@ class Legion(CMakePackage):
             maxfields = maxfields << 1
         options.append('-DLegion_MAX_FIELDS=%d' % maxfields)
 
-        #This disables Legion's CMake build system's logic for targeting the native
-        #CPU architecture in favor of Spack-provided compiler flags
+        # This disables Legion's CMake build system's logic for targeting the native
+        # CPU architecture in favor of Spack-provided compiler flags
         options.append('-DBUILD_MARCH:STRING=')
         return options
 

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -336,6 +336,8 @@ class Legion(CMakePackage):
             maxfields = maxfields << 1
         options.append('-DLegion_MAX_FIELDS=%d' % maxfields)
 
+        #This disables Legion's CMake build system's logic for targeting the native
+        #CPU architecture in favor of Spack-provided compiler flags
         options.append('-DBUILD_MARCH:STRING=')
         return options
 


### PR DESCRIPTION
This commit removes the `native` variant in favor of Spack's built-in support for specifying a target cpu architecture.  It also passes this information to the Legion build system so that it correctly passes the architecture to GASNet when built internally