### PR TITLE
Mesa: Check correct LLVM variant for dylib

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -183,7 +183,7 @@ class Mesa(MesonPackage):
                     native_config.write("llvm-config = '{0}'\n".format(llvm_config))
             args.append('-Dllvm=enabled')
             args.append(opt_enable(
-                '+link_dylib' in spec['llvm'], 'shared-llvm'))
+                '+llvm_dylib' in spec['llvm'], 'shared-llvm'))
         else:
             args.append('-Dllvm=disabled')
 

--- a/var/spack/repos/builtin/packages/mesa18/package.py
+++ b/var/spack/repos/builtin/packages/mesa18/package.py
@@ -136,7 +136,7 @@ class Mesa18(AutotoolsPackage):
         if '+llvm' in spec:
             args.append('--enable-llvm')
             args.append('--with-llvm-prefix=%s' % spec['llvm'].prefix)
-            if '+link_dylib' in spec['llvm']:
+            if '+llvm_dylib' in spec['llvm']:
                 args.append('--enable-llvm-shared-libs')
             else:
                 args.append('--disable-llvm-shared-libs')


### PR DESCRIPTION
Typo in variant check for LLVM DyLib option in mesa(18) packages.