### PR TITLE
updating pcre package

### DIFF
--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -12,7 +12,7 @@ class Pcre(AutotoolsPackage):
     pattern matching using the same syntax and semantics as Perl 5."""
 
     homepage = "https://www.pcre.org"
-    url      = "https://ftp.pcre.org/pub/pcre/pcre-8.42.tar.bz2"
+    url      = "https://sourceforge.net/projects/pcre/files/pcre/8.42/pcre-8.42.tar.bz2/download"
 
     version('8.44', sha256='19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d')
     version('8.43', sha256='91e762520003013834ac1adb4a938d53b22a216341c061b0cf05603b290faf6b')

--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -22,6 +22,7 @@ class Pcre(AutotoolsPackage):
     version('8.39', sha256='b858099f82483031ee02092711689e7245586ada49e534a06e678b8ea9549e8b')
     version('8.38', sha256='b9e02d36e23024d6c02a2e5b25204b3a4fa6ade43e0a5f869f254f49535079df')
 
+    maintainers = ['drkennetz']
     patch('intel.patch', when='@8.38')
 
     variant('jit', default=False,


### PR DESCRIPTION
The ftp url for pcre is dead and the package has moved to sourceforge. The sha256sum for the sourceforge download is the same as the one in the previous package.py, and this has been tested. 