### PR TITLE
spack ci: add support for running stand-alone tests

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -65,6 +65,7 @@ import spack.subprocess_context
 import spack.user_environment
 import spack.util.path
 from spack.error import NoHeadersError, NoLibrariesError
+from spack.installer import InstallError
 from spack.util.cpus import cpus_available
 from spack.util.environment import (
     EnvironmentModifications,
@@ -1280,15 +1281,6 @@ def get_package_context(traceback, context=3):
         lines.append(marked)
 
     return lines
-
-
-class InstallError(spack.error.SpackError):
-    """Raised by packages when a package fails to install.
-
-    Any subclass of InstallError will be annotated by Spack with a
-    ``pkg`` attribute on failure, which the caller can use to get the
-    package for which the exception was raised.
-    """
 
 
 class ChildError(InstallError):

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -640,3 +640,8 @@ def find_environment(args):
         return ev.Environment(env)
 
     raise ev.SpackEnvironmentError("no environment in %s" % env)
+
+
+def first_line(docstring):
+    """Return the first line of the docstring."""
+    return docstring.split("\n")[0]

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -236,6 +236,7 @@ def install_specs(specs, install_kwargs, cli_args):
     except spack.build_environment.InstallError as e:
         if cli_args.show_log_on_error:
             e.print_context()
+            assert e.pkg, "Expected InstallError to include the associated package"
             if not os.path.exists(e.pkg.build_log_path):
                 tty.error("'spack install' created no log.")
             else:

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -29,17 +29,14 @@ section = "admin"
 level = "long"
 
 
-def first_line(docstring):
-    """Return the first line of the docstring."""
-    return docstring.split("\n")[0]
-
-
 def setup_parser(subparser):
     sp = subparser.add_subparsers(metavar="SUBCOMMAND", dest="test_command")
 
     # Run
     run_parser = sp.add_parser(
-        "run", description=test_run.__doc__, help=first_line(test_run.__doc__)
+        "run",
+        description=test_run.__doc__,
+        help=spack.cmd.first_line(test_run.__doc__),
     )
 
     alias_help_msg = "Provide an alias for this test-suite"
@@ -83,7 +80,9 @@ def setup_parser(subparser):
 
     # List
     list_parser = sp.add_parser(
-        "list", description=test_list.__doc__, help=first_line(test_list.__doc__)
+        "list",
+        description=test_list.__doc__,
+        help=spack.cmd.first_line(test_list.__doc__),
     )
     list_parser.add_argument(
         "-a",
@@ -97,7 +96,9 @@ def setup_parser(subparser):
 
     # Find
     find_parser = sp.add_parser(
-        "find", description=test_find.__doc__, help=first_line(test_find.__doc__)
+        "find",
+        description=test_find.__doc__,
+        help=spack.cmd.first_line(test_find.__doc__),
     )
     find_parser.add_argument(
         "filter",
@@ -107,7 +108,9 @@ def setup_parser(subparser):
 
     # Status
     status_parser = sp.add_parser(
-        "status", description=test_status.__doc__, help=first_line(test_status.__doc__)
+        "status",
+        description=test_status.__doc__,
+        help=spack.cmd.first_line(test_status.__doc__),
     )
     status_parser.add_argument(
         "names", nargs=argparse.REMAINDER, help="Test suites for which to print status"
@@ -115,7 +118,9 @@ def setup_parser(subparser):
 
     # Results
     results_parser = sp.add_parser(
-        "results", description=test_results.__doc__, help=first_line(test_results.__doc__)
+        "results",
+        description=test_results.__doc__,
+        help=spack.cmd.first_line(test_results.__doc__),
     )
     results_parser.add_argument(
         "-l", "--logs", action="store_true", help="print the test log for each matching package"
@@ -142,7 +147,9 @@ def setup_parser(subparser):
 
     # Remove
     remove_parser = sp.add_parser(
-        "remove", description=test_remove.__doc__, help=first_line(test_remove.__doc__)
+        "remove",
+        description=test_remove.__doc__,
+        help=spack.cmd.first_line(test_remove.__doc__),
     )
     arguments.add_common_arguments(remove_parser, ["yes_to_all"])
     remove_parser.add_argument(
@@ -191,6 +198,16 @@ environment variables:
         matching = spack.store.db.query_local(spec, hashes=hashes)
         if spec and not matching:
             tty.warn("No installed packages match spec %s" % spec)
+            """
+            TODO: Need to write out a log message and/or CDASH Testing
+              output that package not installed IF continue to process
+              these issues here.
+
+            if args.log_format:
+                # Proceed with the spec assuming the test process
+                # to ensure report package as skipped (e.g., for CI)
+                specs_to_test.append(spec)
+            """
         specs_to_test.extend(matching)
 
     # test_stage_dir

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1694,7 +1694,7 @@ class Environment(object):
         spec for already concretized but not yet installed specs.
         """
         # use a transaction to avoid overhead of repeated calls
-        # to `package.installed`
+        # to `package.spec.installed`
         with spack.store.db.read_transaction():
             concretized = dict(self.concretized_specs())
             for spec in self.user_specs:

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -12,6 +12,7 @@ import sys
 import six
 
 import llnl.util.filesystem as fs
+import llnl.util.tty as tty
 
 import spack.error
 import spack.paths
@@ -180,6 +181,9 @@ class TestSuite(object):
                     if spec.external and not externals:
                         status = "SKIPPED"
                         skipped += 1
+                    elif not spec.installed:
+                        status = "SKIPPED"
+                        skipped += 1
                     else:
                         status = "NO-TESTS"
                         untested += 1
@@ -187,6 +191,7 @@ class TestSuite(object):
                 self.write_test_result(spec, status)
             except BaseException as exc:
                 self.fails += 1
+                tty.debug("Test failure: {0}".format(str(exc)))
                 if isinstance(exc, (SyntaxError, TestSuiteSpecError)):
                     # Create the test log file and report the error.
                     self.ensure_stage()

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -820,7 +820,7 @@ class PackageInstaller(object):
             if spack.store.db.prefix_failed(dep):
                 action = "'spack install' the dependency"
                 msg = "{0} is marked as an install failure: {1}".format(dep_id, action)
-                raise InstallError(err.format(request.pkg_id, msg))
+                raise InstallError(err.format(request.pkg_id, msg), pkg=dep_pkg)
 
             # Attempt to get a read lock to ensure another process does not
             # uninstall the dependency while the requested spec is being
@@ -828,7 +828,7 @@ class PackageInstaller(object):
             ltype, lock = self._ensure_locked("read", dep_pkg)
             if lock is None:
                 msg = "{0} is write locked by another process".format(dep_id)
-                raise InstallError(err.format(request.pkg_id, msg))
+                raise InstallError(err.format(request.pkg_id, msg), pkg=request.pkg)
 
             # Flag external and upstream packages as being installed
             if dep_pkg.spec.external or dep_pkg.spec.installed_upstream:
@@ -883,6 +883,7 @@ class PackageInstaller(object):
                     "Install prefix collision for {0}".format(task.pkg_id),
                     long_msg="Prefix directory {0} already used by another "
                     "installed spec.".format(task.pkg.spec.prefix),
+                    pkg=task.pkg,
                 )
 
             # Make sure the installation directory is in the desired state
@@ -1571,7 +1572,8 @@ class PackageInstaller(object):
                 raise InstallError(
                     "Cannot proceed with {0}: {1} uninstalled {2}: {3}".format(
                         pkg_id, task.priority, dep_str, ",".join(task.uninstalled_deps)
-                    )
+                    ),
+                    pkg=pkg,
                 )
 
             # Skip the installation if the spec is not being installed locally
@@ -1596,7 +1598,7 @@ class PackageInstaller(object):
                 spack.hooks.on_install_failure(task.request.pkg.spec)
 
                 if self.fail_fast:
-                    raise InstallError(fail_fast_err)
+                    raise InstallError(fail_fast_err, pkg=pkg)
 
                 continue
 
@@ -1718,7 +1720,7 @@ class PackageInstaller(object):
                     )
                 # Terminate if requested to do so on the first failure.
                 if self.fail_fast:
-                    raise InstallError("{0}: {1}".format(fail_fast_err, str(exc)))
+                    raise InstallError("{0}: {1}".format(fail_fast_err, str(exc)), pkg=pkg)
 
                 # Terminate at this point if the single explicit spec has
                 # failed to install.
@@ -1727,7 +1729,7 @@ class PackageInstaller(object):
 
                 # Track explicit spec id and error to summarize when done
                 if task.explicit:
-                    failed_explicits.append((pkg_id, str(exc)))
+                    failed_explicits.append((pkg, pkg_id, str(exc)))
 
             finally:
                 # Remove the install prefix if anything went wrong during
@@ -1750,19 +1752,38 @@ class PackageInstaller(object):
         # Ensure we properly report if one or more explicit specs failed
         # or were not installed when should have been.
         missing = [
-            request.pkg_id
+            (request.pkg, request.pkg_id)
             for request in self.build_requests
             if request.install_args.get("install_package") and request.pkg_id not in self.installed
         ]
+
         if failed_explicits or missing:
-            for pkg_id, err in failed_explicits:
+            for _, pkg_id, err in failed_explicits:
                 tty.error("{0}: {1}".format(pkg_id, err))
 
-            for pkg_id in missing:
+            for _, pkg_id in missing:
                 tty.error("{0}: Package was not installed".format(pkg_id))
 
+            pkg = None
+            if len(failed_explicits) > 0:
+                pkg = failed_explicits[0][0]
+                ids = [pkg_id for _, pkg_id, _ in failed_explicits]
+                tty.debug(
+                    "Associating installation failure with first failed "
+                    "explicit package ({0}) from {1}".format(ids[0], ", ".join(ids))
+                )
+
+            if not pkg and len(missing) > 0:
+                pkg = missing[0][0]
+                ids = [pkg_id for _, pkg_id in missing]
+                tty.debug(
+                    "Associating installation failure with first "
+                    "missing package ({0}) from {1}".format(ids[0], ", ".join(ids))
+                )
+
             raise InstallError(
-                "Installation request failed.  Refer to " "reported errors for failing package(s)."
+                "Installation request failed.  Refer to reported errors for failing package(s).",
+                pkg=pkg,
             )
 
 
@@ -2060,7 +2081,7 @@ class BuildTask(object):
         # queue.
         if status == STATUS_REMOVED:
             msg = "Cannot create a build task for {0} with status '{1}'"
-            raise InstallError(msg.format(self.pkg_id, status))
+            raise InstallError(msg.format(self.pkg_id, status), pkg=pkg)
 
         self.status = status
 
@@ -2351,10 +2372,15 @@ class BuildRequest(object):
 
 
 class InstallError(spack.error.SpackError):
-    """Raised when something goes wrong during install or uninstall."""
+    """Raised when something goes wrong during install or uninstall.
 
-    def __init__(self, message, long_msg=None):
+    The error can be annotated with a ``pkg`` attribute to allow the
+    caller to get the package for which the exception was raised.
+    """
+
+    def __init__(self, message, long_msg=None, pkg=None):
         super(InstallError, self).__init__(message, long_msg)
+        self.pkg = pkg
 
 
 class BadInstallPhase(InstallError):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -2840,6 +2840,10 @@ def test_process(pkg, kwargs):
             print_test_message(logger, "Skipped tests for external package", verbose)
             return
 
+        if not pkg.spec.installed:
+            print_test_message(logger, "Skipped not installed package", verbose)
+            return
+
         # run test methods from the package and all virtuals it
         # provides virtuals have to be deduped by name
         v_names = list(set([vspec.name for vspec in pkg.virtuals_provided]))
@@ -2910,6 +2914,9 @@ def test_process(pkg, kwargs):
             # non-pass-only methods
             if ran_actual_test_function:
                 fsys.touch(pkg.tested_file)
+                # log one more test message to provide a completion timestamp
+                # for CDash reporting
+                tty.msg("Completed testing")
             else:
                 print_test_message(logger, "No tests to run", verbose)
 

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -245,6 +245,7 @@ class collect_info(object):
         self.cls = cls
         self.function = function
         self.filename = None
+        self.ctest_parsing = getattr(args, "ctest_parsing", False)
         if args.cdash_upload_url:
             self.format_name = "cdash"
             self.filename = "cdash_report"
@@ -271,10 +272,10 @@ class collect_info(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.format_name:
-            # Close the collector and restore the
-            # original PackageInstaller._install_task
+            # Close the collector and restore the original function
             self.collector.__exit__(exc_type, exc_val, exc_tb)
 
             report_data = {"specs": self.collector.specs}
+            report_data["ctest-parsing"] = self.ctest_parsing
             report_fn = getattr(self.report_writer, "%s_report" % self.type)
             report_fn(self.filename, report_data)

--- a/lib/spack/spack/reporters/extract.py
+++ b/lib/spack/spack/reporters/extract.py
@@ -1,0 +1,212 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+import re
+import xml.sax.saxutils
+from datetime import datetime
+
+import llnl.util.tty as tty
+
+# The keys here represent the only recognized (ctest/cdash) status values
+completed = {
+    "failed": "Completed",
+    "passed": "Completed",
+    "notrun": "No tests to run",
+}
+
+log_regexp = re.compile(r"^==> \[([0-9:.\-]*)(?:, [0-9]*)?\] (.*)")
+returns_regexp = re.compile(r"\[([0-9 ,]*)\]")
+
+skip_msgs = ["Testing package", "Results for", "Detected the following"]
+skip_regexps = [re.compile(r"{0}".format(msg)) for msg in skip_msgs]
+
+status_values = ["FAILED", "PASSED", "NO-TESTS"]
+status_regexps = [re.compile(r"^({0})".format(stat)) for stat in status_values]
+
+
+def add_part_output(part, line):
+    if part:
+        part["loglines"].append(xml.sax.saxutils.escape(line))
+
+
+def elapsed(current, previous):
+    if not (current and previous):
+        return 0
+
+    diff = current - previous
+    tty.debug("elapsed = %s - %s = %s" % (current, previous, diff))
+    return diff.total_seconds()
+
+
+def expected_failure(line):
+    if not line:
+        return False
+
+    match = returns_regexp.search(line)
+    xfail = "0" not in match.group(0) if match else False
+    return xfail
+
+
+def new_part():
+    return {
+        "command": None,
+        "completed": "Unknown",
+        "desc": None,
+        "elapsed": None,
+        "name": None,
+        "loglines": [],
+        "output": None,
+        "status": "passed",
+    }
+
+
+def part_name(source):
+    # TODO: Should be passed the package prefix and only remove it
+    elements = []
+    for e in source.replace("'", "").split(" "):
+        elements.append(os.path.basename(e) if os.sep in e else e)
+    return "_".join(elements)
+
+
+def process_part_end(part, curr_time, last_time):
+    if part:
+        if not part["elapsed"]:
+            part["elapsed"] = elapsed(curr_time, last_time)
+
+        stat = part["status"]
+        if stat in completed:
+            if stat == "passed" and expected_failure(part["desc"]):
+                part["completed"] = "Expected to fail"
+            elif part["completed"] == "Unknown":
+                part["completed"] = completed[stat]
+        part["output"] = "\n".join(part["loglines"])
+
+
+def timestamp(time_string):
+    return datetime.strptime(time_string, "%Y-%m-%d-%H:%M:%S.%f")
+
+
+def skip(line):
+    for regex in skip_regexps:
+        match = regex.search(line)
+        if match:
+            return match
+
+
+def status(line):
+    for regex in status_regexps:
+        match = regex.search(line)
+        if match:
+            stat = match.group(0)
+            stat = "notrun" if stat == "NO-TESTS" else stat
+            return stat.lower()
+
+
+def extract_test_parts(default_name, outputs):
+    parts = []
+    part = {}
+    testdesc = ""
+    last_time = None
+    curr_time = None
+    for line in outputs:
+        line = line.strip()
+        if not line:
+            add_part_output(part, line)
+            continue
+
+        if skip(line):
+            continue
+
+        # Skipped tests start with "Skipped" and end with "package"
+        if line.startswith("Skipped") and line.endswith("package"):
+            part = new_part()
+            part["command"] = "Not Applicable"
+            part["completed"] = line
+            part["elapsed"] = 0.0
+            part["name"] = default_name
+            part["status"] = "notrun"
+            parts.append(part)
+            continue
+
+        # Process Spack log messages
+        if line.find("==>") != -1:
+            match = log_regexp.search(line)
+            if match:
+                curr_time = timestamp(match.group(1))
+                msg = match.group(2)
+
+                # Skip logged message for caching build-time data
+                if msg.startswith("Installing"):
+                    continue
+
+                # New command means the start of a new test part
+                if msg.startswith("'") and msg.endswith("'"):
+                    # Update the last part processed
+                    process_part_end(part, curr_time, last_time)
+
+                    part = new_part()
+                    part["command"] = msg
+                    part["name"] = part_name(msg)
+                    parts.append(part)
+
+                    # Save off the optional test description if it was
+                    # tty.debuged *prior to* the command and reset
+                    if testdesc:
+                        part["desc"] = testdesc
+                        testdesc = ""
+
+                else:
+                    # Update the last part processed since a new log message
+                    # means a non-test action
+                    process_part_end(part, curr_time, last_time)
+
+                    if testdesc:
+                        # We had a test description but no command so treat
+                        # as a new part (e.g., some import tests)
+                        part = new_part()
+                        part["name"] = "_".join(testdesc.split())
+                        part["command"] = "unknown"
+                        part["desc"] = testdesc
+                        parts.append(part)
+                        process_part_end(part, curr_time, curr_time)
+
+                    # Assuming this is a description for the next test part
+                    testdesc = msg
+
+            else:
+                tty.debug("Did not recognize test output '{0}'".format(line))
+
+            # Each log message potentially represents a new test part so
+            # save off the last timestamp
+            last_time = curr_time
+            continue
+
+        # Check for status values
+        stat = status(line)
+        if stat:
+            if part:
+                part["status"] = stat
+                add_part_output(part, line)
+            else:
+                tty.warn("No part to add status from '{0}'".format(line))
+            continue
+
+        add_part_output(part, line)
+
+    # Process the last lingering part IF it didn't generate status
+    process_part_end(part, curr_time, last_time)
+
+    # If no parts, create a skeleton to flag that the tests are not run
+    if not parts:
+        part = new_part()
+        stat = "notrun"
+        part["command"] = "Not Applicable"
+        part["completed"] = completed[stat]
+        part["elapsed"] = 0.0
+        part["name"] = default_name
+        part["status"] = stat
+        parts.append(part)
+
+    return parts

--- a/lib/spack/spack/reporters/junit.py
+++ b/lib/spack/spack/reporters/junit.py
@@ -3,11 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os.path
 import posixpath
 
-import spack.build_environment
-import spack.fetch_strategy
-import spack.package_base
+import spack.tengine
 from spack.reporter import Reporter
 
 __all__ = ["JUnit"]
@@ -23,6 +22,11 @@ class JUnit(Reporter):
         self.template_file = posixpath.join("reports", "junit.xml")
 
     def build_report(self, filename, report_data):
+        if not (os.path.splitext(filename))[1]:
+            # Ensure the report name will end with the proper extension;
+            # otherwise, it currently defaults to the "directory" name.
+            filename = filename + ".xml"
+
         # Write the report
         with open(filename, "w") as f:
             env = spack.tengine.make_environment()

--- a/lib/spack/spack/schema/gitlab_ci.py
+++ b/lib/spack/spack/schema/gitlab_ci.py
@@ -101,6 +101,12 @@ core_shared_properties = union_dicts(
         "signing-job-attributes": runner_selector_schema,
         "rebuild-index": {"type": "boolean"},
         "broken-specs-url": {"type": "string"},
+        "broken-tests-packages": {
+            "type": "array",
+            "items": {
+                "type": "string",
+            },
+        },
     },
 )
 

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -78,7 +78,7 @@ repos:
     )
 
 
-def test_config_edit():
+def test_config_edit(mutable_config, working_env):
     """Ensure `spack config edit` edits the right paths."""
 
     dms = spack.config.default_modify_scope("compilers")

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -49,11 +49,12 @@ def test_install_package_and_dependency(
     tmpdir, mock_packages, mock_archive, mock_fetch, config, install_mockery
 ):
 
+    log = "test"
     with tmpdir.as_cwd():
-        install("--log-format=junit", "--log-file=test.xml", "libdwarf")
+        install("--log-format=junit", "--log-file={0}".format(log), "libdwarf")
 
     files = tmpdir.listdir()
-    filename = tmpdir.join("test.xml")
+    filename = tmpdir.join("{0}.xml".format(log))
     assert filename in files
 
     content = filename.open().read()

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -186,7 +186,7 @@ def test_cdash_output_test_error(
         report_dir = tmpdir.join("cdash_reports")
         print(tmpdir.listdir())
         assert report_dir in tmpdir.listdir()
-        report_file = report_dir.join("test-error_Test.xml")
+        report_file = report_dir.join("test-error_Testing.xml")
         assert report_file in report_dir.listdir()
         content = report_file.open().read()
         assert "FAILED: Command exited with status 1" in content
@@ -205,7 +205,7 @@ def test_cdash_upload_clean_test(
         spack_test("run", "--log-file=cdash_reports", "--log-format=cdash", "printing-package")
         report_dir = tmpdir.join("cdash_reports")
         assert report_dir in tmpdir.listdir()
-        report_file = report_dir.join("printing-package_Test.xml")
+        report_file = report_dir.join("printing-package_Testing.xml")
         assert report_file in report_dir.listdir()
         content = report_file.open().read()
         assert "</Test>" in content

--- a/lib/spack/spack/test/reporters.py
+++ b/lib/spack/spack/test/reporters.py
@@ -1,0 +1,175 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import pytest
+
+import llnl.util.filesystem as fs
+import llnl.util.tty as tty
+
+import spack.reporters.cdash
+import spack.reporters.extract
+import spack.spec
+from spack.util.pattern import Bunch
+
+# Use a path variable to appease Spack style line length checks
+fake_install_prefix = fs.join_path(
+    "usr",
+    "spack",
+    "spack",
+    "opt",
+    "spack",
+    "linux-rhel7-broadwell",
+    "intel-19.0.4.227",
+    "fake-1.0",
+)
+fake_install_test_root = fs.join_path(fake_install_prefix, ".spack", "test")
+fake_test_cache = fs.join_path(
+    "usr", "spack", ".spack", "test", "abcdefg", "fake-1.0-abcdefg", "cache", "fake"
+)
+
+
+def test_reporters_extract_no_parts(capfd):
+    # This test ticks three boxes:
+    #  1) has Installing, which is skipped;
+    #  2) does not define any test parts;
+    #  3) has a status value without a part so generates a warning
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+==> [2022-02-11-17:14:38.875259] Installing {0} to {1}
+NO-TESTS
+""".format(
+        fake_install_test_root, fake_test_cache
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+    err = capfd.readouterr()[1]
+
+    assert len(parts) == 1
+    assert parts[0]["status"] == "notrun"
+    assert "No part to add status" in err
+
+
+def test_reporters_extract_no_command():
+    # This test ticks 2 boxes:
+    # 1) has a test description with no command or status
+    # 2) has a test description, command, and status
+    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake")
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+==> [2022-02-15-18:44:21.250165] command with no status
+==> [2022-02-15-18:44:21.250175] running test program
+==> [2022-02-15-18:44:21.250200] '{0}'
+PASSED
+""".format(
+        fake_bin
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+    assert len(parts) == 2
+    assert parts[0]["command"] == "unknown"
+    assert parts[1]["loglines"] == ["PASSED"]
+    assert parts[1]["elapsed"] == 0.0
+
+
+def test_reporters_extract_missing_desc():
+    fake_bin = fs.join_path(fake_install_prefix, "bin", "importer")
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+==> [2022-02-15-18:44:21.250165] '{0}' '-c' 'import fake.bin'
+PASSED
+==> [2022-02-15-18:44:21.250200] '{0}' '-c' 'import fake.util'
+PASSED
+""".format(
+        fake_bin
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+
+    assert len(parts) == 2
+    assert parts[0]["desc"] is None
+    assert parts[1]["desc"] is None
+
+
+def test_reporters_extract_xfail():
+    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake-app")
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+==> [2022-02-15-18:44:21.250165] Expecting return code in [3]
+==> [2022-02-15-18:44:21.250200] '{0}'
+PASSED
+""".format(
+        fake_bin
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+
+    assert len(parts) == 1
+    parts[0]["completed"] == "Expected to fail"
+
+
+@pytest.mark.parametrize("state", [("not installed"), ("external")])
+def test_reporters_extract_skipped(state):
+    expected = "Skipped {0} package".format(state)
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+{0}
+""".format(
+        expected
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+
+    assert len(parts) == 1
+    parts[0]["completed"] == expected
+
+
+def test_reporters_skip():
+    # This test ticks 3 boxes:
+    # 1) covers an as yet uncovered skip messages
+    # 2) covers debug timestamps
+    # 3) unrecognized output
+    fake_bin = fs.join_path(fake_install_prefix, "bin", "fake")
+    unknown_message = "missing timestamp"
+    outputs = """
+==> Testing package fake-1.0-abcdefg
+==> [2022-02-15-18:44:21.250165, 123456] Detected the following modules: fake1
+==> {0}
+==> [2022-02-15-18:44:21.250175, 123456] running fake program
+==> [2022-02-15-18:44:21.250200, 123456] '{1}'
+INVALID
+Results for test suite abcdefghijklmn
+""".format(
+        unknown_message, fake_bin
+    ).splitlines()
+
+    parts = spack.reporters.extract.extract_test_parts("fake", outputs)
+
+    assert len(parts) == 1
+    assert fake_bin in parts[0]["command"]
+    assert parts[0]["loglines"] == ["INVALID"]
+    assert parts[0]["elapsed"] == 0.0
+
+
+def test_reporters_report_for_package_no_stdout(tmpdir, monkeypatch, capfd):
+    class MockCDash(spack.reporters.cdash.CDash):
+        def upload(*args, **kwargs):
+            # Just return (Do NOT try to upload the report to the fake site)
+            return
+
+    args = Bunch(
+        cdash_upload_url="https://fake-upload",
+        package="fake-package",
+        cdash_build="fake-cdash-build",
+        cdash_site="fake-site",
+        cdash_buildstamp=None,
+        cdash_track="fake-track",
+    )
+    monkeypatch.setattr(tty, "_debug", 1)
+
+    reporter = MockCDash(args)
+    pkg_data = {"name": "fake-package"}
+    reporter.test_report_for_package(tmpdir.strpath, pkg_data, 0, False)
+    err = capfd.readouterr()[1]
+    assert "Skipping report for" in err
+    assert "No generated output" in err

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -242,10 +242,13 @@ spack:
       - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
       - if [[ -r /mnt/key/intermediate_ci_signing_key.gpg ]]; then spack gpg trust /mnt/key/intermediate_ci_signing_key.gpg; fi
       - if [[ -r /mnt/key/spack_public_key.gpg ]]; then spack gpg trust /mnt/key/spack_public_key.gpg; fi
-      - spack -d ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+      - spack -d ci rebuild --tests > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
 
     image: ecpe4s/ubuntu22.04-runner-x86_64:2022-07-01
     
+    broken-tests-packages:
+      - gptune
+
     mappings:
       - match:
           - hipblas

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -612,7 +612,7 @@ _spack_ci_rebuild_index() {
 }
 
 _spack_ci_rebuild() {
-    SPACK_COMPREPLY="-h --help"
+    SPACK_COMPREPLY="-h --help -t --tests --fail-fast"
 }
 
 _spack_ci_reproduce_build() {

--- a/share/spack/templates/reports/cdash/Site.xml
+++ b/share/spack/templates/reports/cdash/Site.xml
@@ -2,6 +2,9 @@
 <Site BuildName="{{ buildname }}"
       BuildStamp="{{ buildstamp }}"
       Name="{{ site }}"
+      Generator="{{ generator }}"
+      Hostname="{{ hostname }}"
       OSName="{{ osname }}"
+      OSRelease="{{ osrelease }}"
+      VendorString="{{ target }}"
 >
-

--- a/share/spack/templates/reports/cdash/Testing.xml
+++ b/share/spack/templates/reports/cdash/Testing.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This file has been modeled after the examples at this url:
+
+    https://www.paraview.org/Wiki/CDash:XML
+-->
+<Site BuildName="{{ buildname }}"
+      BuildStamp="{{ buildstamp }}"
+      Name="{{ site }}"
+      Generator="{{ generator }}"
+      Hostname="{{ hostname }}"
+      OSName="{{ osname }}"
+      OSRelease="{{ osrelease }}"
+      VendorString="{{ target }}"
+>
+  <Testing>
+    <StartTestTime>{{ testing.starttime }}</StartTestTime>
+{% for part in testing.parts %}
+    <Test Status="{{ part.status }}">
+      <Name>{{ part.name }}</Name>
+      <FullCommandLine>{{ part.command }}</FullCommandLine>
+      <Results>
+        <NamedMeasurement type="numeric/double" name="Execution Time">
+          <Value>{{ part.elapsed }}</Value>
+        </NamedMeasurement>
+{% if part.desc %}
+        <NamedMeasurement type="text/string" name="Description">
+          <Value>{{ part.desc }}</Value>
+        </NamedMeasurement>
+{% endif %}
+        <NamedMeasurement type="text/string" name="Completion Status">
+          <Value>{{ part.completed }}</Value>
+        </NamedMeasurement>
+{% if part.output %}
+        <Measurement>
+          <Value>{{ part.output }}</Value>
+        </Measurement>
+{% endif %}
+      </Results>
+    </Test>
+{% endfor %}
+    <EndTestTime>{{ testing.endtime }}</EndTestTime>
+  </Testing>
+</Site>


### PR DESCRIPTION
The goal of this work is to run stand-alone tests from `spack ci` when the `--tests` option is used.  When the option is used, the stand-alone tests are run **after** a **successful** (re)build of the package.  Test results are collected and report(able) using CDash.

This PR adds the following features:
- Adds `-t` and `--tests` to `spack ci rebuild` to run stand-alone tests;
- Adds `--fail-fast` to stop stand-alone tests after the first failure;
- Ensures a *single* `InstallError` across packages (i.e., removes second class from build environment);
- Captures skipping tests for externals and uninstalled packages (for CDash reporting);
- Copies test logs and outputs to the CI artifacts directory to facilitate debugging;
- Parses stand-alone test results to report outputs from each `run_test` as separate test parts (CDash reporting);
- Logs a test completion message to allow capture of timing of the last `run_test` part;
- Adds the runner description to the CDash site to better distinguish entries in CDash tables;
- Adds `gitlab-ci` `broken-tests-packages` to CI configuration to skip stand-alone testing for packages with known issues;
- Changes `spack ci --help` so description of each subcommand is a single, concise line;
- Changes `spack ci <subcommand> --help` to provide the full description of each command (versus no description); and
- Ensures `junit` test log file ends in an `.xml` extension (versus default where it does not).

Update (2022 Mar 28): Handling of concretization failures that do not get reported to CDash is expected to be addressed in a subsequent issue/PR.

Update (2022 Apr 7): `spack ci rebuild --tests` should not be be trying to run tests for job spec dependencies, only the job spec.  If the build jobs of dependency specs fail to upload to the build cache (e.g., configuration, permissions), then those jobs should be failing.  (TBD: Should this PR ensure that check or is it better to have a separate PR?)

Tasks:

- [x] Include the equivalent of the architecture information, or at least the host target, in the CDash output
- [x] Upload stand-alone test results files as  `test` artifacts
- [x] Confirm tests are run in GitLab
- [x] Ensure CDash results are uploaded as artifacts
- [x] Resolve issues with CDash build-and test results appearing on same row of the table 
- [x] Add unit tests  as needed
- [x] Investigate why some (dependency) packages don't have test results (e.g., related from other pipelines)
~- [ ] Possibly add full hash in build name -- Scott Wittenburg is working on a significant change in this area ATM~
- [x] Ensure proper parsing and reporting of skipped tests (as `not run`) .. post- #28701 merge
~~- [ ] Determine why concretization failure jobs and associated reports -- actually just `Update.xml` -- are not showing up in CDash~~
- [x] Restore the proper CDash URLand or mirror ONCE out-of-band testing completed