### PR TITLE
ci: Catch Exceptions when attempting to register a CDash build

### DIFF
--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1271,6 +1271,7 @@ def get_concrete_specs(env, root_spec, job_name, related_builds,
 def register_cdash_build(build_name, base_url, project, site, track):
     url = base_url + '/api/v1/addBuild.php'
     time_stamp = datetime.datetime.now().strftime('%Y%m%d-%H%M')
+    build_id = None
     build_stamp = '{0}-{1}'.format(time_stamp, track)
     payload = {
         "project": project,
@@ -1292,17 +1293,20 @@ def register_cdash_build(build_name, base_url, project, site, track):
 
     request = Request(url, data=enc_data, headers=headers)
 
-    response = opener.open(request)
-    response_code = response.getcode()
+    try:
+        response = opener.open(request)
+        response_code = response.getcode()
 
-    if response_code != 200 and response_code != 201:
-        msg = 'Adding build failed (response code = {0}'.format(response_code)
-        tty.warn(msg)
-        return (None, None)
+        if response_code != 200 and response_code != 201:
+            msg = 'Adding build failed (response code = {0}'.format(response_code)
+            tty.warn(msg)
+            return (None, None)
 
-    response_text = response.read()
-    response_json = json.loads(response_text)
-    build_id = response_json['buildid']
+        response_text = response.read()
+        response_json = json.loads(response_text)
+        build_id = response_json['buildid']
+    except Exception as e:
+        print("Registering build in CDash failed: {0}".format(e))
 
     return (build_id, build_stamp)
 

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -433,17 +433,17 @@ def ci_rebuild(args):
             cdash_build_name, cdash_base_url, cdash_project,
             cdash_site, job_spec_buildgroup)
 
+        cdash_upload_url = '{0}/submit.php?project={1}'.format(
+            cdash_base_url, cdash_project_enc)
+
+        install_args.extend([
+            '--cdash-upload-url', cdash_upload_url,
+            '--cdash-build', cdash_build_name,
+            '--cdash-site', cdash_site,
+            '--cdash-buildstamp', cdash_build_stamp,
+        ])
+
         if cdash_build_id is not None:
-            cdash_upload_url = '{0}/submit.php?project={1}'.format(
-                cdash_base_url, cdash_project_enc)
-
-            install_args.extend([
-                '--cdash-upload-url', cdash_upload_url,
-                '--cdash-build', cdash_build_name,
-                '--cdash-site', cdash_site,
-                '--cdash-buildstamp', cdash_build_stamp,
-            ])
-
             tty.debug('CDash: Relating build with dependency builds')
             spack_ci.relate_cdash_builds(
                 spec_map, cdash_base_url, cdash_build_id, cdash_project,


### PR DESCRIPTION
This PR also slightly changes the behavior in ci_rebuild().
We now still attempt to submit `spack install` results to CDash
even if the initial registration failed due to connection issues.

This commit follows in the spirit of #24299. We do not want `spack install`
to exit with a non-zero status when something goes wrong while attempting to
report results to CDash.