### PR TITLE
WIP, MAINT: correct py-scipy pythran bound

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -73,7 +73,7 @@ class PyScipy(PythonPackage):
     depends_on('py-numpy@1.16.5:1.22+blas+lapack', when='@1.6.2:', type=('build', 'link', 'run'))
     depends_on('py-cython@0.29.18:2', when='@1.7:', type='build')
     depends_on('py-pythran@0.9.11', when='@1.7.0:1.7.1', type=('build', 'link'))
-    depends_on('py-pythran@0.9.12:0.9', when='@1.7.2:', type=('build', 'link'))
+    depends_on('py-pythran@0.9.12:0.10.0', when='@1.7.2:', type=('build', 'link'))
     depends_on('py-pytest', type='test')
 
     # NOTE: scipy picks up Blas/Lapack from numpy, see


### PR DESCRIPTION
* correct the upper bound for the version
of `pythran` to be used with latest stable
release of SciPy (`1.7.x` series)

* this was preventing a concretization for me
locally

For reference: https://github.com/scipy/scipy/blob/maintenance/1.7.x/pyproject.toml#L16

It may have just been a typo since the max is less than min?