### PR TITLE
umpire: needs cmake@:3.20 when +rocm

### DIFF
--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -73,6 +73,7 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', when='+cuda', type='build')
+    depends_on('cmake@:3.20', when='+rocm', type='build')
 
     depends_on('blt@0.4.1:', type='build', when='@6.0.0:')
     depends_on('blt@0.4.0:', type='build', when='@4.1.3:5.0.1')


### PR DESCRIPTION
`umpire +rocm` needs `cmake@:3.20` for now

Closes https://github.com/spack/spack/issues/27873

@davidbeckingsale 