### PR TITLE
raja: needs cmake@:3.20 when +rocm

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -58,6 +58,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on('camp@0.2.2', when='@0.14.0:')
     depends_on('camp@0.1.0', when='@0.12.0:0.13.0')
 
+    depends_on('cmake@:3.20', when='+rocm', type='build')
+
     with when('+rocm @0.12.0:'):
         depends_on('camp+rocm')
         for arch in ROCmPackage.amdgpu_targets:


### PR DESCRIPTION
`raja +rocm` needs `cmake@:3.20` for now

Building `raja +rocm` against newer cmake triggers the same issues described for `umpire` here https://github.com/spack/spack/issues/27873

@davidbeckingsale 