### PR TITLE
openmpi: add variant for romio

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -243,6 +243,7 @@ class Openmpi(AutotoolsPackage):
             description="Build support for the Singularity container")
     variant('lustre', default=False,
             description="Lustre filesystem library support")
+    variant('romio', default=True, description='Enable ROMIO support')
     # Adding support to build a debug version of OpenMPI that activates
     # Memchecker, as described here:
     #
@@ -729,6 +730,9 @@ class Openmpi(AutotoolsPackage):
                     '--disable-java',
                     '--disable-mpi-java'
                 ])
+
+        if '~romio' in spec:
+            config_args.append('--disable-io-romio')
 
         # SQLite3 support
         if spec.satisfies('@1.7.3:1'):


### PR DESCRIPTION
Add a variant to allow for disabling the build of the internal
romio build.

Related to https://github.com/open-mpi/ompi/issues/9715

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>