### PR TITLE
SpecParser: use normalized and absolutized for 'dev_path'

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4774,7 +4774,10 @@ class SpecParser(spack.parse.Parser):
                 if hasattr(pkg, 'git'):
                     spec.version.generate_commit_lookup(pkg)
             # normalize and absolutize 'dev_path'
-            if 'dev_path' in spec.variants and isinstance(spec.variants['dev_path'], vt.AbstractVariant):
+            if (
+                'dev_path' in spec.variants and
+                isinstance(spec.variants['dev_path'], vt.AbstractVariant)
+            ):
                 path = os.path.abspath(spec.variants['dev_path'].value[0])
                 new_variant = vt.SingleValuedVariant('dev_path', path)
                 spec.variants.substitute(new_variant)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4774,7 +4774,7 @@ class SpecParser(spack.parse.Parser):
                 if hasattr(pkg, 'git'):
                     spec.version.generate_commit_lookup(pkg)
             # normalize and absolutize 'dev_path'
-            if 'dev_path' in spec.variants:
+            if 'dev_path' in spec.variants and isinstance(spec.variants['dev_path'], vt.AbstractVariant):
                 path = os.path.abspath(spec.variants['dev_path'].value[0])
                 new_variant = vt.SingleValuedVariant('dev_path', path)
                 spec.variants.substitute(new_variant)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4761,6 +4761,7 @@ class SpecParser(spack.parse.Parser):
             raise SpecParseError(e)
 
         # Generate lookups for git-commit-based versions
+        # and normalize and absolutize 'dev_path' variants
         for spec in specs:
             # Cannot do lookups for versions in anonymous specs
             # Only allow Version objects to use git for now
@@ -4772,6 +4773,11 @@ class SpecParser(spack.parse.Parser):
                 pkg = spec.package
                 if hasattr(pkg, 'git'):
                     spec.version.generate_commit_lookup(pkg)
+            # normalize and absolutize 'dev_path'
+            if 'dev_path' in spec.variants:
+                path = os.path.abspath(spec.variants['dev_path'].value[0])
+                new_variant = vt.SingleValuedVariant('dev_path', path)
+                spec.variants.substitute(new_variant)
 
         return specs
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4773,10 +4773,11 @@ class SpecParser(spack.parse.Parser):
                 pkg = spec.package
                 if hasattr(pkg, 'git'):
                     spec.version.generate_commit_lookup(pkg)
-            # normalize and absolutize 'dev_path'
+            # normalize and absolutize 'dev_path' if it is not a wildcard
             if (
                 'dev_path' in spec.variants and
-                isinstance(spec.variants['dev_path'], vt.AbstractVariant)
+                isinstance(spec.variants['dev_path'], vt.AbstractVariant) and
+                spec.variants['dev_path'].value[0] != '*'
             ):
                 path = os.path.abspath(spec.variants['dev_path'].value[0])
                 new_variant = vt.SingleValuedVariant('dev_path', path)


### PR DESCRIPTION
A `spack dev-build --source-path /tmd/sed sed` uses the absolute and normalized path: https://github.com/spack/spack/blob/e199d7ef6b554035a9870bdd664ab1d77ef4d7d1/lib/spack/spack/cmd/dev_build.py#L84

but `spack spec sed dev_path=/tmp/sed` does this not. 

Hence using a relative path, or with a additional `/` this results in different specs and hashes. For example:
```
$ spack spec -L sed dev_path=/tmp/sed
Input spec
--------------------------------
sed dev_path=/tmp/sed

Concretized
--------------------------------
4apuqj52ixhmkvgmdismqmfzawrhtui7  sed@4.2.2%gcc@11.1.0 dev_path=/tmp/sed arch=linux-archrolling-skylake
```
vs
```
$ spack spec -L sed dev_path=/tmp/sed/
Input spec
--------------------------------
sed dev_path=/tmp/sed/

Concretized
--------------------------------
l37qyv73qkjpeqq5t7tg5x2bj3d7m2vm  sed@4.2.2%gcc@11.1.0 dev_path=/tmp/sed/ arch=linux-archrolling-skylake
```

So this PR fixes this and replace the 'dev_path' with the absolute and normalized path

