### PR TITLE
Give more concretization detail under -v, not -d

### DIFF
--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -123,7 +123,8 @@ class UnsatisfiableSpecError(SpecError):
     For original concretizer, provide the requirement that was violated when
     raising.
     """
-    def __init__(self, provided, required=None, constraint_type=None, conflicts=None):
+    def __init__(self, provided, required=None, constraint_type=None, conflicts=None,
+                 verbose=False):
         # required is only set by the original concretizer.
         # clingo concretizer handles error messages differently.
         if required is not None:
@@ -134,6 +135,8 @@ class UnsatisfiableSpecError(SpecError):
             indented = ['  %s\n' % conflict for conflict in conflicts]
             conflict_msg = ''.join(indented)
             msg = '%s is unsatisfiable, conflicts are:\n%s' % (provided, conflict_msg)
+            if not verbose:
+                msg += '  concretize with spack -v for more details'
             super(UnsatisfiableSpecError, self).__init__(msg)
         self.provided = provided
         self.required = required

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -393,10 +393,11 @@ class Result(object):
         if len(constraints) == 1:
             constraints = constraints[0]
 
-        debug = spack.config.get('config:debug', False)
-        conflicts = self.format_cores() if debug else self.format_minimal_cores()
+        conflicts = (self.format_cores() if tty.is_verbose() else
+                     self.format_minimal_cores())
 
-        raise spack.error.UnsatisfiableSpecError(constraints, conflicts=conflicts)
+        raise spack.error.UnsatisfiableSpecError(constraints, conflicts=conflicts,
+                                                 verbose=tty.is_verbose())
 
     @property
     def specs(self):
@@ -512,10 +513,9 @@ class PyclingoDriver(object):
 
         atom = self.backend.add_atom(symbol)
 
-        # in debug mode, make all facts choices/assumptions
+        # in verbose mode, make all facts choices/assumptions
         # otherwise, only if we're generating cores and assumption=True
-        debug = spack.config.get('config:debug', False)
-        choice = debug or (self.cores and assumption)
+        choice = tty.is_verbose() or (self.cores and assumption)
 
         self.backend.add_rule([atom], [], choice=choice)
         if choice:

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import contextlib
 import sys
 
 import jinja2
@@ -10,9 +11,11 @@ import pytest
 import archspec.cpu
 
 import llnl.util.lang
+import llnl.util.tty as tty
 
 import spack.compilers
 import spack.concretize
+import spack.config
 import spack.error
 import spack.platforms
 import spack.repo
@@ -21,6 +24,14 @@ from spack.concretize import find_spec
 from spack.spec import Spec
 from spack.util.mock_package import MockPackageMultiRepo
 from spack.version import ver
+
+
+@contextlib.contextmanager
+def verbose_tty():
+    v = tty.is_verbose()
+    tty.set_verbose(True)
+    yield
+    tty.set_verbose(v)
 
 
 def check_spec(abstract, concrete):
@@ -561,10 +572,10 @@ class TestConcretize(object):
         if spack.config.get('config:concretizer') == 'original':
             pytest.skip('Testing debug statements specific to new concretizer')
 
-        spack.config.set('config:debug', True)
         s = Spec(conflict_spec)
         with pytest.raises(spack.error.SpackError) as e:
-            s.concretize()
+            with verbose_tty():
+                s.concretize()
 
         assert "conflict_trigger(" in e.value.message
 


### PR DESCRIPTION
we shouldn't train users to use `-d` for everything

Before:

```
$ ./bin/spack -d spec zlib@3: 2>&1 | wc -l
1407

```

After:

```
$ ./bin/spack -v spec zlib@3: 2>&1 | wc -l
458
```

I guess it does justice to the `--verbose` flag indeed :upside_down_face:.

Without `-v`:

```
$ ./bin/spack spec zlib@3: 
Input spec
--------------------------------
zlib@3:

Concretized
--------------------------------
==> Error: zlib@3: is unsatisfiable, conflicts are:
  no version satisfies the given constraints
  concretize with spack -v for more details
```