### PR TITLE
spack spec: add '--format' argument

### DIFF
--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -34,12 +34,16 @@ for further documentation regarding the spec syntax, see:
     arguments.add_common_arguments(
         subparser, ['long', 'very_long', 'install_status']
     )
-    subparser.add_argument(
+    format_group = subparser.add_mutually_exclusive_group()
+    format_group.add_argument(
         '-y', '--yaml', action='store_const', dest='format', default=None,
         const='yaml', help='print concrete spec as YAML')
-    subparser.add_argument(
+    format_group.add_argument(
         '-j', '--json', action='store_const', dest='format', default=None,
         const='json', help='print concrete spec as JSON')
+    format_group.add_argument(
+        '--format', action='store', default=None,
+        help='print concrete spec with the specified format string')
     subparser.add_argument(
         '-c', '--cover', action='store',
         default='nodes', choices=['nodes', 'edges', 'paths'],
@@ -98,8 +102,10 @@ def spec(parser, args):
             if args.format == 'yaml':
                 # use write because to_yaml already has a newline.
                 sys.stdout.write(output.to_yaml(hash=hash_type))
-            else:
+            elif args.format == 'json':
                 print(output.to_json(hash=hash_type))
+            else:
+                print(output.format(args.format))
             continue
 
         with tree_context():

--- a/lib/spack/spack/test/cmd/spec.py
+++ b/lib/spack/spack/test/cmd/spec.py
@@ -16,8 +16,6 @@ pytestmark = pytest.mark.usefixtures('config', 'mutable_mock_repo')
 
 spec = SpackCommand('spec')
 
-base32_alphabet = 'abcdefghijklmnopqrstuvwxyz234567'
-
 
 def test_spec():
     output = spec('mpileaks')
@@ -82,22 +80,8 @@ def test_spec_json():
 
 
 def test_spec_format(database, config):
-    output = spec('--format', '{name}-{^mpi.name}', 'mpileaks')
+    output = spec('--format', '{name}-{^mpi.name}', 'mpileaks^mpich')
     assert output.rstrip('\n') == "mpileaks-mpich"
-
-    output = spec('--format', '{name}-{version}-{compiler.name}-{^mpi.name}',
-                  'mpileaks')
-    assert "installed package" not in output
-    assert output.rstrip('\n') == "mpileaks-2.3-gcc-mpich"
-
-    output = spec('--format', '{name}-{^mpi.name}-{hash:7}',
-                  'mpileaks')
-    output = output.rstrip('\n')
-    assert output[:-7] == "mpileaks-mpich-"
-
-    # hashes are in base32
-    for c in output[-7:]:
-        assert c in base32_alphabet
 
 
 def _parse_types(string):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1670,7 +1670,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -I --install-status -y --yaml -j --json -c --cover -N --namespaces --hash-type -t --types -U --fresh --reuse"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -I --install-status -y --yaml -j --json --format -c --cover -N --namespaces --hash-type -t --types -U --fresh --reuse"
     else
         _all_packages
     fi


### PR DESCRIPTION
This PR adds a `--format` argument to `spack spec` similar to `spack find --format`. Useful for specs that aren't installed yet and if one don't want to use `jq` to parse thourgh the `json` output, especially if there is no `jq` installed so one can avoid installing this.