### PR TITLE
install dir message should be debug message

### DIFF
--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1328,8 +1328,7 @@ class PackageInstaller(object):
             pkg (spack.package.Package): the package to be built and installed
         """
         if not os.path.exists(pkg.spec.prefix):
-            tty.verbose('Creating the installation directory {0}'
-                        .format(pkg.spec.prefix))
+            tty.debug('Creating the installation directory {0}'.format(pkg.spec.prefix))
             spack.store.layout.create_install_directory(pkg.spec)
         else:
             # Set the proper group for the prefix


### PR DESCRIPTION
it seems a bit excessive to always print "Creating the installation directory [some path]" with spack install -v, since it's already printed after installation
