### PR TITLE
vtk-m +cuda: conflicts with cuda_arch=none

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -89,6 +89,9 @@ class VtkM(CMakePackage, CudaPackage):
 
     conflicts("+hip", when="+cuda")
 
+    conflicts("+cuda", when="cuda_arch=none",
+              msg="vtk-m +cuda requires that cuda_arch be set")
+
     def cmake_args(self):
         spec = self.spec
         options = []


### PR DESCRIPTION
`vtk-m +cuda` conflicts with `cuda_arch=none`

Fixes https://github.com/spack/spack/issues/27915