### PR TITLE
petsc, petsc4py add in 'release' branch/version

### DIFF
--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -59,7 +59,7 @@ SEMVER_REGEX = re.compile(".+(?P<semver>([0-9]+)[.]([0-9]+)[.]([0-9]+)"
                           "(?:[+][0-9A-Za-z-]+)?)")
 
 # Infinity-like versions. The order in the list implies the comparison rules
-infinity_versions = ['develop', 'main', 'master', 'head', 'trunk']
+infinity_versions = ['develop', 'main', 'master', 'head', 'trunk', 'release']
 
 iv_min_len = min(len(s) for s in infinity_versions)
 

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -19,7 +19,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
     tags = ['e4s']
 
     version('main', branch='main')
-
+    version('release', branch='release')
     version('3.16.2', sha256='7ab257ae150d4837ac8d3872a1d206997962578785ec2427639ceac46d131bbc')
     version('3.16.1', sha256='909cf7bce7b6a0ddb2580a1ac9502aa01631ec4105c716594c1804f0ee1ea06a')
     version('3.16.0', sha256='5aaad7deea127a4790c8aa95c42fd9451ab10b5d6c68b226b92d4853002f438d')

--- a/var/spack/repos/builtin/packages/py-petsc4py/package.py
+++ b/var/spack/repos/builtin/packages/py-petsc4py/package.py
@@ -17,6 +17,7 @@ class PyPetsc4py(PythonPackage):
     maintainers = ['balay']
 
     version('main', branch='main')
+    version('release', branch='release')
     version('3.16.2', sha256='906634497ae9c59f2c97e12b935954e5ba95df2e764290c24fff6751b7510b04')
     version('3.16.1', sha256='c218358217c436947f8fd61f247f73ac65fa29ea3489ad00bef5827b1436b95f')
     version('3.16.0', sha256='4044accfdc2c80994e80e4e286478d1ba9ac358512d1b74c42e1327eadb0d802')


### PR DESCRIPTION
Includes changes from https://github.com/spack/spack/pull/27841 [so should be merge in order]