### PR TITLE
py-pyzmq: Add ZMQ_PREFIX setting

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -47,6 +47,8 @@ class PyPyzmq(PythonPackage):
             'C_INCLUDE_PATH', self.spec['libzmq'].headers.directories[0])
         env.prepend_path(
             'LIBRARY_PATH', self.spec['libzmq'].libs.directories[0])
+        env.prepend_path(
+            'ZMQ_PREFIX', self.spec['libzmq'].prefix)
 
     # Needed for `spack test run py-pyzmq`
     setup_run_environment = setup_build_environment


### PR DESCRIPTION
This defines ZMQ_PREFIX to point to the spack installed libzmq
in the build environment.

It should fix  #27921