### PR TITLE
Add a section for generic yaml anchors in spack.yaml

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -273,6 +273,7 @@ def _write_yaml(data, str_or_file):
     """Write YAML to a file preserving comments and dict order."""
     filename = getattr(str_or_file, 'name', None)
     spack.config.validate(data, spack.schema.env.schema, filename)
+    #return
     syaml.dump_config(data, str_or_file, default_flow_style=False)
 
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -92,6 +92,13 @@ schema = {
                             },
                         },
                     },
+                    'anchors': {
+                        'type': 'array',
+                        'default': [],
+                        'items': {
+                            'type': 'string'
+                        }
+                    },
                     'definitions': {
                         'type': 'array',
                         'default': [],

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1304,13 +1304,21 @@ spack:
       buildable: false
 """)
     with tmpdir.as_cwd():
-        env('create', 'test', './spack.yaml')
-        test = ev.read('test')
-        assert Spec('libelf') in test.user_specs
-        assert (test.yaml['spack']['packages']['libelf']['externals'][0]['spec']
-                == '$spec')
-        assert (test.yaml['spack']['packages']['libelf']['externals'][0]['prefix']
-                == '$loc')
+        env('create', '-d', '.', './spack.yaml')
+        with ev.Environment('.') as pre:
+            assert Spec('libelf') in pre.user_specs
+            assert (pre.yaml['spack']['packages']['libelf']['externals'][0]['spec']
+                    == '$spec')
+            assert (pre.yaml['spack']['packages']['libelf']['externals'][0]['prefix']
+                    == '$loc')
+            # this calls _update_and_write_manifest but it is not overwriting the
+            # anchors like I see when I try to use this feature
+            pre.write()
+        with ev.Environment('.') as post:
+            assert (post.yaml['spack']['packages']['libelf']['externals'][0]['spec']
+                    == '$spec')
+            assert (post.yaml['spack']['packages']['libelf']['externals'][0]['prefix']
+                    == '$loc')
 
 
 def test_stack_yaml_definitions(tmpdir):

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1287,6 +1287,32 @@ def test_env_activate_view_fails(
     assert "To set up shell support" in out
 
 
+def test_define_and_use_basic_yaml_anchors(tmpdir):
+    filename = str(tmpdir.join('spack.yaml'))
+    with open(filename, 'w') as f:
+        f.write("""\
+spack:
+  anchors:
+    - &spec libelf@test
+    - &loc /usr
+  specs: [mpileaks, libelf]
+  packages:
+    libelf:
+      externals:
+      - spec: $spec
+        prefix: $loc
+      buildable: false
+""")
+    with tmpdir.as_cwd():
+        env('create', 'test', './spack.yaml')
+        test = ev.read('test')
+        assert Spec('libelf') in test.user_specs
+        assert (test.yaml['spack']['packages']['libelf']['externals'][0]['spec']
+                == '$spec')
+        assert (test.yaml['spack']['packages']['libelf']['externals'][0]['prefix']
+                == '$loc')
+
+
 def test_stack_yaml_definitions(tmpdir):
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:
@@ -1313,6 +1339,7 @@ env:
   definitions:
     - packages: [mpileaks, callpath]
     - mpis: [mpich, openmpi]
+
   specs:
     - matrix:
       - [$packages]

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1314,6 +1314,7 @@ spack:
                     == '$' + anchors[0])
             assert (pre.yaml['spack']['packages']['libelf']['externals'][0]['prefix']
                     == '$' + anchors[1])
+            assert (pre.yaml['spack']['anchors'][0] == '&' + anchors[0])
             # this calls _update_and_write_manifest but it is not overwriting the
             # anchors like I see when I try to use this feature
             pre.write()


### PR DESCRIPTION
The intent of this PR is to allow for generalized variables that can be used throughout the `spack.yaml` file.  For example, if I have several externals installed in the same location it would be nice to just use a variable or alias to specify them, especially if the path is long, or I want to be able to switch it later. As I iterated over this concept it dawned on me that YAML already has this exact functionality through anchors and aliases.  

This PR creates a dedicated place to define anchors in the `spack.yaml` file.  I imagine allowing a wider variety of schema in this section as time goes on, but for starters I'm just doing an array of strings which can be used to generate a list of variables (anchors really) which can then be used throughout the `spack.yaml`

A couple of issues:

1. I'm not sure if these anchors will propogate to includes files.
2. During concretization spack's process overwrites all the aliases and anchors with the anchor values.  This is a broader issue, but I'm interested to see if I can just turn this behavior off for yaml anchors as part of this PR. 

pinging @becker33 (initial discussion of this idea on slack) @scheibelp (wisdom reagarding the overwriting issues) @tgamblin (I see your name in the git history next to all the code containing the work `anchor`) 