### PR TITLE
geant4: new version 11.0.0 (preferred remains 10.7.3)

### DIFF
--- a/var/spack/repos/builtin/packages/clhep/package.py
+++ b/var/spack/repos/builtin/packages/clhep/package.py
@@ -18,6 +18,7 @@ class Clhep(CMakePackage):
 
     maintainers = ['drbenmorgan']
 
+    version('2.4.5.1', sha256='2517c9b344ad9f55974786ae6e7a0ef8b22f4abcbf506df91194ea2299ce3813')
     version('2.4.4.0', sha256='5df78c11733a091da9ae5a24ce31161d44034dd45f20455587db85f1ca1ba539')
     version('2.4.1.3', sha256='27c257934929f4cb1643aa60aeaad6519025d8f0a1c199bc3137ad7368245913')
     version('2.4.1.2', sha256='ff96e7282254164380460bc8cf2dff2b58944084eadcd872b5661eb5a33fa4b8')

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -17,6 +17,7 @@ class G4emlow(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('8.0', sha256='d919a8e5838688257b9248a613910eb2a7633059e030c8b50c0a2c2ad9fd2b3b')
     version('7.13', sha256='374896b649be776c6c10fea80abe6cf32f9136df0b6ab7c7236d571d49fb8c69')
     version('7.9.1', sha256='820c106e501c64c617df6c9e33a0f0a3822ffad059871930f74b8cc37f043ccb')
     version('7.9', sha256='4abf9aa6cda91e4612676ce4d2d8a73b91184533aa66f9aad19a53a8c4dc3aff')

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -18,6 +18,7 @@ class G4particlexs(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('4.0', sha256='9381039703c3f2b0fd36ab4999362a2c8b4ff9080c322f90b4e319281133ca95')
     version('3.1.1', sha256='66c17edd6cb6967375d0497add84c2201907a25e33db782ebc26051d38f2afda')
     version('3.1', sha256='404da84ead165e5cccc0bb795222f6270c9bf491ef4a0fd65195128b27f0e9cd')
     version('2.1', sha256='094d103372bbf8780d63a11632397e72d1191dc5027f9adabaf6a43025520b41')

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -17,6 +17,7 @@ class G4tendl(Package):
     maintainers = ['drbenmorgan']
 
     # Only versions relevant to Geant4 releases built by spack are added
+    version('1.4', sha256='4b7274020cc8b4ed569b892ef18c2e088edcdb6b66f39d25585ccee25d9721e0')
     version('1.3.2', sha256='3b2987c6e3bee74197e3bd39e25e1cc756bb866c26d21a70f647959fc7afb849')
     version('1.3', sha256='52ad77515033a5d6f995c699809b464725a0e62099b5e55bf07c8bdd02cd3bce')
 

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -49,7 +49,6 @@ class Geant4Data(BundlePackage):
     depends_on("g4saiddata@2.0", when='@11.0.0:11.0')
     depends_on("g4abla@3.1", when='@11.0.0:11.0')
     depends_on("g4incl@1.0", when='@11.0.0:11.0')
-    #depends_on("g4tenl@1.4", when='@11.0.0:11.0') #TODO
 
     # geant4@10.7.X
     depends_on("g4ndl@4.6", when='@10.7.0:10.7')

--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -18,6 +18,7 @@ class Geant4Data(BundlePackage):
 
     tags = ['hep']
 
+    version('11.0.0')
     version('10.7.3')
     version('10.7.2')
     version('10.7.1')
@@ -37,6 +38,19 @@ class Geant4Data(BundlePackage):
     # For clarity, declare deps on a Major-Minor version basis as
     # they generally don't change on the patch level
     # Can move to declaring on a dataset basis if needed
+    # geant4@11.0.X
+    depends_on("g4ndl@4.6", when='@11.0.0:11.0')
+    depends_on("g4emlow@8.0", when='@11.0.0:11.0')
+    depends_on("g4photonevaporation@5.7", when='@11.0.0:11.0')
+    depends_on("g4radioactivedecay@5.6", when='@11.0.0:11.0')
+    depends_on("g4particlexs@4.0", when='@11.0.0:11.0')
+    depends_on("g4pii@1.3", when='@11.0.0:11.0')
+    depends_on("g4realsurface@2.2", when='@11.0.0:11.0')
+    depends_on("g4saiddata@2.0", when='@11.0.0:11.0')
+    depends_on("g4abla@3.1", when='@11.0.0:11.0')
+    depends_on("g4incl@1.0", when='@11.0.0:11.0')
+    #depends_on("g4tenl@1.4", when='@11.0.0:11.0') #TODO
+
     # geant4@10.7.X
     depends_on("g4ndl@4.6", when='@10.7.0:10.7')
     depends_on("g4emlow@7.13", when='@10.7.0:10.7')

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -197,7 +197,7 @@ class Geant4(CMakePackage):
                 '-DQT_QMAKE_EXECUTABLE=%s' %
                 spec['qt'].prefix.bin.qmake)
 
-        options.append(self.define_from_variant('GEANT4_USE_VTK','vtk'))
+        options.append(self.define_from_variant('GEANT4_USE_VTK', 'vtk'))
 
         # Python
         if spec.version > Version('10.6.1'):

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -19,6 +19,7 @@ class Geant4(CMakePackage):
 
     maintainers = ['drbenmorgan']
 
+    version('11.0.0', sha256='dbfc6b5030a36936b46f56a0bede4b647d0160c178a5629d39ce392124e47936', deprecated=True)
     version('10.7.3', sha256='8615d93bd4178d34f31e19d67bc81720af67cdab1c8425af8523858dcddcf65b')
     version('10.7.2', sha256='593fc85883a361487b17548ba00553501f66a811b0a79039276bb75ad59528cf')
     version('10.7.1', sha256='2aa7cb4b231081e0a35d84c707be8f35e4edc4e97aad2b233943515476955293')

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -57,6 +57,7 @@ class Geant4(CMakePackage):
     variant('qt', default=False, description='Enable Qt support')
     variant('python', default=False, description='Enable Python bindings')
     variant('tbb', default=False, description='Use TBB as a tasking backend', when='@11:')
+    variant('vtk', default=False, description='Enable VTK support', when='@11:')
 
     depends_on('cmake@3.16:', type='build', when='@11.0.0:')
     depends_on('cmake@3.8:', type='build', when='@10.6.0:')
@@ -80,6 +81,7 @@ class Geant4(CMakePackage):
     depends_on("zlib")
 
     depends_on('tbb', when='+tbb')
+    depends_on('vtk@8.2:', when='+vtk')
 
     # Python, with boost requirement dealt with in cxxstd section
     depends_on('python@3:', when='+python')
@@ -201,6 +203,9 @@ class Geant4(CMakePackage):
             options.append(
                 '-DQT_QMAKE_EXECUTABLE=%s' %
                 spec['qt'].prefix.bin.qmake)
+
+        if '+vtk' in spec:
+            options.append('-DGEANT4_USE_VTK=ON')
 
         # Python
         if spec.version > Version('10.6.1'):

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -56,6 +56,7 @@ class Geant4(CMakePackage):
     variant('motif', default=False, description='Optional motif support')
     variant('qt', default=False, description='Enable Qt support')
     variant('python', default=False, description='Enable Python bindings')
+    variant('tbb', default=False, description='Use TBB as a tasking backend', when='@11:')
 
     depends_on('cmake@3.16:', type='build', when='@11.0.0:')
     depends_on('cmake@3.8:', type='build', when='@10.6.0:')
@@ -77,6 +78,8 @@ class Geant4(CMakePackage):
 
     depends_on("expat")
     depends_on("zlib")
+
+    depends_on('tbb', when='+tbb')
 
     # Python, with boost requirement dealt with in cxxstd section
     depends_on('python@3:', when='+python')
@@ -164,6 +167,8 @@ class Geant4(CMakePackage):
         # Multithreading
         options.append(self.define_from_variant('GEANT4_BUILD_MULTITHREADED',
                                                 'threads'))
+        options.append(self.define_from_variant('GEANT4_USE_TBB', 'tbb'))
+
         if '+threads' in spec:
             # Locked at global-dynamic to allow use cases that load the
             # geant4 libs at application runtime

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -19,8 +19,8 @@ class Geant4(CMakePackage):
 
     maintainers = ['drbenmorgan']
 
-    version('11.0.0', sha256='dbfc6b5030a36936b46f56a0bede4b647d0160c178a5629d39ce392124e47936', deprecated=True)
-    version('10.7.3', sha256='8615d93bd4178d34f31e19d67bc81720af67cdab1c8425af8523858dcddcf65b')
+    version('11.0.0', sha256='dbfc6b5030a36936b46f56a0bede4b647d0160c178a5629d39ce392124e47936')
+    version('10.7.3', sha256='8615d93bd4178d34f31e19d67bc81720af67cdab1c8425af8523858dcddcf65b', preferred=True)
     version('10.7.2', sha256='593fc85883a361487b17548ba00553501f66a811b0a79039276bb75ad59528cf')
     version('10.7.1', sha256='2aa7cb4b231081e0a35d84c707be8f35e4edc4e97aad2b233943515476955293')
     version('10.7.0', sha256='c991a139210c7f194720c900b149405090058c00beb5a0d2fac5c40c42a262d4')

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -50,9 +50,9 @@ class Geant4(CMakePackage):
     variant('qt', default=False, description='Enable Qt support')
     variant('python', default=False, description='Enable Python bindings')
 
-    depends_on('cmake@3.5:', type='build')
-    depends_on('cmake@3.15:', type='build', when='@11.0.0:')
+    depends_on('cmake@3.16:', type='build', when='@11.0.0:')
     depends_on('cmake@3.8:', type='build', when='@10.6.0:')
+    depends_on('cmake@3.5:', type='build')
 
     depends_on('geant4-data@11.0.0', when='@11.0.0')
     depends_on('geant4-data@10.7.3', when='@10.7.3')

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -38,14 +38,7 @@ class Geant4(CMakePackage):
             default=_cxxstd_values[0],
             values=_cxxstd_values,
             multi=False,
-            description='Use the specified C++ standard when building.',
-            when='@10')
-    variant('cxxstd',
-            default=_cxxstd_values[2],
-            values=_cxxstd_values,
-            multi=False,
-            description='Use the specified C++ standard when building.',
-            when='@11')
+            description='Use the specified C++ standard when building.')
     conflicts('cxxstd=11', when='@11:', msg='geant4@11: only supports cxxstd=17')
     conflicts('cxxstd=14', when='@11:', msg='geant4@11: only supports cxxstd=17')
 

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -39,6 +39,8 @@ class Geant4(CMakePackage):
             values=_cxxstd_values,
             multi=False,
             description='Use the specified C++ standard when building.')
+    conflicts('cxxstd=11', when='@11.0.0:')
+    conflicts('cxxstd=14', when='@11.0.0:')
 
     variant('threads', default=True, description='Build with multithreading')
     variant('vecgeom', default=False, description='Enable vecgeom support')
@@ -49,8 +51,10 @@ class Geant4(CMakePackage):
     variant('python', default=False, description='Enable Python bindings')
 
     depends_on('cmake@3.5:', type='build')
+    depends_on('cmake@3.15:', type='build', when='@11.0.0:')
     depends_on('cmake@3.8:', type='build', when='@10.6.0:')
 
+    depends_on('geant4-data@11.0.0', when='@11.0.0')
     depends_on('geant4-data@10.7.3', when='@10.7.3')
     depends_on('geant4-data@10.7.2', when='@10.7.2')
     depends_on('geant4-data@10.7.1', when='@10.7.1')
@@ -75,6 +79,9 @@ class Geant4(CMakePackage):
 
     for std in _cxxstd_values:
         # CLHEP version requirements to be reviewed
+        depends_on('clhep@2.4.5.1: cxxstd=' + std,
+                   when='@11.0.0: cxxstd=' + std)
+
         depends_on('clhep@2.4.4.0: cxxstd=' + std,
                    when='@10.7.0: cxxstd=' + std)
 
@@ -85,6 +92,8 @@ class Geant4(CMakePackage):
         depends_on('xerces-c netaccessor=curl cxxstd=' + std, when='cxxstd=' + std)
 
         # Vecgeom specific versions for each Geant4 version
+        depends_on('vecgeom@1.1.18:1.1 cxxstd=' + std,
+                   when='@11.0.0: +vecgeom cxxstd=' + std)
         depends_on('vecgeom@1.1.8:1.1 cxxstd=' + std,
                    when='@10.7.0: +vecgeom cxxstd=' + std)
         depends_on('vecgeom@1.1.5 cxxstd=' + std,

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -204,8 +204,7 @@ class Geant4(CMakePackage):
                 '-DQT_QMAKE_EXECUTABLE=%s' %
                 spec['qt'].prefix.bin.qmake)
 
-        if '+vtk' in spec:
-            options.append('-DGEANT4_USE_VTK=ON')
+        options.append(self.define_from_variant('GEANT4_USE_VTK','vtk'))
 
         # Python
         if spec.version > Version('10.6.1'):

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -20,6 +20,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     maintainers = ['drbenmorgan', 'sethrj']
 
     version('master', branch='master')
+    version('1.1.18', sha256='2780640233a36e0d3c767140417015be1893c1ad695ccc0bd3ee0767bc9fbed8')
     version('1.1.17', sha256='2e95429b795311a6986320d785bedcd9dace9f8e7b7f6bd778d23a4ff23e0424')
     version('1.1.16', sha256='2fa636993156d9d06750586e8a1ac1701ae2be62dea07964e2369698ae521d02')
     version('1.1.15', sha256='0ee9897eb12d8d560dc0c9e56e8fdb78d0111f651a984df24e983da035bd1c70')


### PR DESCRIPTION
This adds support for new major geant4 version 11.0.0, [release notes](https://geant4-data.web.cern.ch/ReleaseNotes/ReleaseNotes.11.0.html).

Keeping preferred version at 10.7.3 (until 11.1.0?) since breakage is expected in downstream versions due to several interface changes. 

Dependency and requirement changes:
- `clhep@2.4.5.1:` (new version added)
- `vecgeom@1.1.18:` (new version added)
- `cmake@3.16:`
- `cxxstd=17:` (added conflicts with 11 and 14)
- updated `geant4-data` sets G4EMLOW-8.0, G4PARTICLEXS-4.0 (new versions added)

Test: successful build of `geant4@11.0.0+ipo~motif+opengl+python+qt+threads+vecgeom~x11 build_type=RelWithDebInfo cxxstd=17` on `%gcc@11.2.0 arch=linux-ubuntu21.10-skylake`

Maintainer tag: @drbenmorgan (EIC will require the geant4@11 features in the very near future)

TODO:
- [x] change now-deprecated GEANT4_BUILD_CXXSTD into standard CMAKE_CXX_STANDARD with allowed values 17, 20, 23,
- [x] support new GEANT4_USE_TBB,
- [x] support new GEANT4_USE_VTK visualization for `vtk@8.2:`
- [x] (decided not to do this) support new GEANT4_BUILD_SANITIZER (do we care?),
- [x] (decided not to do this) support new GEANT4_USE_Pythia8 (seems only used in one example)
- [x] add the optional G4TENDL `geant4-data` set for ParticleHP physics list proton-nucleus scattering as part of this PR (with variant in `geant4-data` that defaults to False since at 870 MB =~ sum of all other data sets),
- [x] (decided not to do this)if optional G4TENDL is set by variant, then apply the same to G4RealSurface which is also optional,
