### PR TITLE
[assimp] new version 5.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -15,6 +15,7 @@ class Assimp(CMakePackage):
     git      = "https://github.com/assimp/assimp.git"
 
     version('master', branch='master')
+    version('5.1.3', sha256='50a7bd2c8009945e1833c591d16f4f7c491a3c6190f69d9d007167aadb175c35')
     version('5.0.1', sha256='11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc')
     version('4.0.1', sha256='60080d8ab4daaab309f65b3cffd99f19eb1af8d05623fff469b9b652818e286e')
 


### PR DESCRIPTION
Currently we have a package (dd4hep) that `depends_on('assimp@5.0.2:')`, but the most recent version other than master is 5.0.1. This adds a way to satisfy the dd4hep dependency without having to install a moving target like master.

The changelog for the 5.1 series is pretty long, but a search for build system changes didn't indicate anything that requires changes to the package.py.

Tested this build on `arch=linux-ubuntu21.10-skylake %gcc-11.2.0`.

No maintainer (no, thanks, spackbot). Some maintainers of direct dependents who might be interested: @drbenmorgan @vvolkl (dd4hep), @jppelteret  @luca-heltai (dealii), @RemiLacroix-IDRIS (vapor)