### PR TITLE
nwchem: FFTW3 library inclusion

### DIFF
--- a/var/spack/repos/builtin/packages/nwchem/package.py
+++ b/var/spack/repos/builtin/packages/nwchem/package.py
@@ -24,10 +24,14 @@ class Nwchem(Package):
     version('6.8.1', sha256='fd20f9ca1b410270a815e77e052ec23552f828526cd252709f798f589b2a6431',
             url='https://github.com/nwchemgit/nwchem/releases/download/6.8.1-release/nwchem-6.8.1-release.revision-v6.8-133-ge032219-srconly.2018-06-14.tar.bz2')
 
+    variant('openmp', default=False, description='Enables OpenMP support')
+    variant('mpipr', default=False, description='Enables ARMCI with progress rank')
+
     depends_on('blas')
     depends_on('lapack')
     depends_on('mpi')
     depends_on('scalapack')
+    depends_on('fftw-api')
     depends_on('python@3:', when='@7:', type=('build', 'link', 'run'))
     depends_on('python@2.7:2.8', when='@:6', type=('build', 'link', 'run'))
     conflicts('%gcc@10:', when='@:6', msg='NWChem versions prior to 7.0.0 do not build with GCC 10')
@@ -36,6 +40,7 @@ class Nwchem(Package):
         scalapack = spec['scalapack'].libs
         lapack = spec['lapack'].libs
         blas = spec['blas'].libs
+        fftw = spec['fftw-api'].libs
         # see https://nwchemgit.github.io/Compiling-NWChem.html
         args = []
         args.extend([
@@ -45,14 +50,19 @@ class Nwchem(Package):
             'CC=%s' % os.path.basename(spack_cc),
             'FC=%s' % os.path.basename(spack_fc),
             'USE_MPI=y',
+            'USE_BLAS=y',
+            'USE_FFTW3=y',
             'PYTHONVERSION=%s' % spec['python'].version.up_to(2),
             'BLASOPT=%s' % ((lapack + blas).ld_flags),
             'BLAS_LIB=%s' % blas.ld_flags,
             'LAPACK_LIB=%s' % lapack.ld_flags,
             'SCALAPACK_LIB=%s' % scalapack.ld_flags,
+            'FFTW3_LIB=%s' % fftw.ld_flags,
+            'FFTW3_INCLUDE={0}'.format(spec['fftw-api'].prefix.include),
             'NWCHEM_MODULES=all python',
             'NWCHEM_LONG_PATHS=Y',  # by default NWCHEM_TOP is 64 char max
-            'USE_NOIO=Y'  # skip I/O algorithms
+            'USE_NOIO=Y',  # skip I/O algorithms
+            'USE_NOFSCHECK=TRUE'  # FSCHECK, caused problems like code crashes
         ])
         if spec.version < Version('7.0.0'):
             args.extend([
@@ -89,6 +99,12 @@ class Nwchem(Package):
             target = 'LINUX64'
 
         args.extend(['NWCHEM_TARGET=%s' % target])
+
+        if '+openmp' in spec:
+            args.extend(['USE_OPENMP=y'])
+
+        if '+mpipr' in spec:
+            args.extend(['ARMCI_NETWORK=MPI-PR'])
 
         with working_dir('src'):
             make('nwchem_config', *args)


### PR DESCRIPTION
- FFTW3 library inclusion
- `OpenMP` support
- `USE_NOFSCHECK=TRUE`  # FSCHECK, caused problems like code crashes, hence making NOFSCHECK=NO
- Added few default install arguments like `USE_BLAS=y`, `USE_FFTW3=y`
- Giving more flexibility to add `ARMCI_NETWORK`, please find: https://nwchemgit.github.io/ARMCI.html