### PR TITLE
Add a CI job to audit all the packages in the built-in repository

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -314,3 +314,32 @@ jobs:
       with:
         files: ./coverage.xml
         flags: unittests,macos
+
+  # Run audits on all the packages in the built-in repository
+  package-audits:
+    needs: [ validate, style, changes ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
+    - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
+      with:
+        python-version: 3.9
+    - name: Install Python packages
+      run: |
+        pip install --upgrade pip six setuptools pytest codecov coverage[toml]
+    - name: Package audits (with coverage)
+      if: ${{ needs.changes.outputs.with_coverage == 'true' }}
+      run: |
+          . share/spack/setup-env.sh
+          coverage run $(which spack) audit packages
+          coverage combine
+          coverage xml
+    - name: Package audits (wwithout coverage)
+      if: ${{ needs.changes.outputs.with_coverage == 'false' }}
+      run: |
+          . share/spack/setup-env.sh
+          $(which spack) audit packages
+    - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # @v2.1.0
+      if: ${{ needs.changes.outputs.with_coverage == 'true' }}
+      with:
+        flags: unittests,linux,audits

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -146,7 +146,7 @@ class Acts(CMakePackage, CudaPackage):
     depends_on('boost @1.71: +filesystem +program_options +test', when='@0.10.4:')
     depends_on('cmake @3.14:', type='build')
     depends_on('dd4hep @1.11:', when='+dd4hep')
-    depends_on('dd4hep @1.11: +geant4', when='+dd4hep +geant4')
+    depends_on('dd4hep @1.11: +ddg4', when='+dd4hep +geant4')
     depends_on('eigen @3.3.7:')
     depends_on('geant4', when='+fatras_geant4')
     depends_on('geant4', when='+geant4')

--- a/var/spack/repos/builtin/packages/aoflagger/package.py
+++ b/var/spack/repos/builtin/packages/aoflagger/package.py
@@ -15,7 +15,7 @@ class Aoflagger(CMakePackage):
 
     version('2.10.0', sha256='3ec1188d37101acf2029575ebc09c50b19c158c88a12b55ac5d25a96bd8fc18d')
 
-    depends_on('casacore+python+fftw@1.10:')
+    depends_on('casacore+python~fftpack@1.10:')
     depends_on('fftw~mpi@3.0:')
     depends_on('boost+python@:1.66.99')
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/camellia/package.py
+++ b/var/spack/repos/builtin/packages/camellia/package.py
@@ -20,7 +20,7 @@ class Camellia(CMakePackage):
 
     variant('moab', default=True, description='Compile with MOAB to include support for reading standard mesh formats')
 
-    depends_on('trilinos+amesos+amesos2+belos+epetra+epetraext+exodus+ifpack+ifpack2+intrepid+intrepid2+kokkos+ml+muelu+sacado+shards+tpetra+zoltan+mumps+superlu-dist+hdf5+zlib+mpi@master,12.12.1:')
+    depends_on('trilinos+amesos+amesos2+belos+epetra+epetraext+exodus+ifpack+ifpack2+intrepid+intrepid2+kokkos+ml+muelu+sacado+shards+tpetra+zoltan+mumps+superlu-dist+hdf5+mpi@master,12.12.1:')
     depends_on('moab@:4', when='+moab')
 
     # Cameilla needs hdf5 but the description "hdf5@:1.8" is

--- a/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-argonavis/package.py
@@ -18,8 +18,6 @@ class CbtfArgonavis(CMakePackage):
     version('1.9.4', branch='1.9.4')
     version('1.9.3', branch='1.9.3')
 
-    variant('cti', default=False,
-            description="Build MRNet with the CTI startup option")
     variant('crayfe', default=False,
             description="build only the FE tool using the runtime_dir \
                          to point to target build.")
@@ -41,18 +39,12 @@ class CbtfArgonavis(CMakePackage):
     depends_on("boost@1.70.0:")
 
     # For MRNet
-    depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti', type=('build', 'link', 'run'))
-    depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop~cti', type=('build', 'link', 'run'))
-    depends_on("mrnet@5.0.1-3+cti", when='@1.9.3:9999+cti', type=('build', 'link', 'run'))
-    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.3:9999~cti', type=('build', 'link', 'run'))
+    depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop', type=('build', 'link', 'run'))
+    depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.3:9999', type=('build', 'link', 'run'))
 
     # For CBTF
     depends_on("cbtf@develop", when='@develop', type=('build', 'link', 'run'))
     depends_on("cbtf@1.9.3:9999", when='@1.9.3:9999', type=('build', 'link', 'run'))
-
-    # For CBTF with cti
-    depends_on("cbtf@develop+cti", when='@develop+cti', type=('build', 'link', 'run'))
-    depends_on("cbtf@1.9.3:9999+cti", when='@1.9.3:9999+cti', type=('build', 'link', 'run'))
 
     # For CBTF with runtime
     depends_on("cbtf@develop+runtime", when='@develop+runtime', type=('build', 'link', 'run'))
@@ -67,9 +59,6 @@ class CbtfArgonavis(CMakePackage):
     # For CBTF-KRELL
     depends_on("cbtf-krell@develop", when='@develop', type=('build', 'link', 'run'))
     depends_on("cbtf-krell@1.9.3:9999", when='@1.9.3:9999', type=('build', 'link', 'run'))
-
-    depends_on('cbtf-krell@develop+cti', when='@develop+cti', type=('build', 'link', 'run'))
-    depends_on('cbtf-krell@1.9.3:9999+cti', when='@1.9.3:9999+cti', type=('build', 'link', 'run'))
 
     depends_on('cbtf-krell@develop+runtime', when='@develop+runtime', type=('build', 'link', 'run'))
     depends_on('cbtf-krell@1.9.3:9999+runtime', when='@1.9.3:9999+runtime', type=('build', 'link', 'run'))

--- a/var/spack/repos/builtin/packages/cbtf-krell/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-krell/package.py
@@ -40,8 +40,6 @@ class CbtfKrell(CMakePackage):
     variant('build_type', default='RelWithDebInfo',
             description='The build type to build',
             values=('Debug', 'Release', 'RelWithDebInfo'))
-    variant('cti', default=False,
-            description="Build MRNet with the CTI startup option")
     variant('crayfe', default=False,
             description="build only the FE tool using the runtime_dir \
                          to point to target build.")
@@ -66,10 +64,7 @@ class CbtfKrell(CMakePackage):
     depends_on("dyninst@10.1.0", when='@1.9.3:9999')
 
     # For MRNet
-    depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti', type=('build', 'link', 'run'))
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop', type=('build', 'link', 'run'))
-
-    depends_on("mrnet@5.0.1-3+cti", when='@1.9.3:9999+cti', type=('build', 'link', 'run'))
     depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.3:9999', type=('build', 'link', 'run'))
 
     # For Xerces-C
@@ -78,10 +73,6 @@ class CbtfKrell(CMakePackage):
     # For CBTF
     depends_on("cbtf@develop", when='@develop', type=('build', 'link', 'run'))
     depends_on("cbtf@1.9.3:9999", when='@1.9.3:9999', type=('build', 'link', 'run'))
-
-    # For CBTF with cti
-    depends_on("cbtf@develop+cti", when='@develop+cti', type=('build', 'link', 'run'))
-    depends_on("cbtf@1.9.3:9999+cti", when='@1.9.3:9999+cti', type=('build', 'link', 'run'))
 
     # For CBTF with runtime
     depends_on("cbtf@develop+runtime", when='@develop+runtime', type=('build', 'link', 'run'))

--- a/var/spack/repos/builtin/packages/cbtf-lanl/package.py
+++ b/var/spack/repos/builtin/packages/cbtf-lanl/package.py
@@ -25,15 +25,10 @@ class CbtfLanl(CMakePackage):
     variant('runtime', default=False,
             description="build only the runtime libraries and collectors.")
 
-    variant('cti', default=False,
-            description="Build MRNet with the CTI startup option")
-
     depends_on("cmake@3.0.2:", type='build')
 
     # For MRNet
-    depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')
-    depends_on("mrnet@5.0.1-3+cti", when='@1.9.3:9999+cti')
     depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.3:9999')
 
     # For Xerces-C
@@ -43,10 +38,6 @@ class CbtfLanl(CMakePackage):
     depends_on("cbtf@develop", when='@develop')
     depends_on("cbtf@1.9.3:9999", when='@1.9.3:9999')
 
-    # For CBTF with cti
-    depends_on("cbtf@develop+cti", when='@develop+cti')
-    depends_on("cbtf@1.9.3:9999+cti", when='@1.9.3:9999+cti')
-
     # For CBTF with runtime
     depends_on("cbtf@develop+runtime", when='@develop+runtime')
     depends_on("cbtf@1.9.3:9999+runtime", when='@1.9.3:9999+runtime')
@@ -54,9 +45,6 @@ class CbtfLanl(CMakePackage):
     # For CBTF-KRELL
     depends_on("cbtf-krell@develop", when='@develop')
     depends_on("cbtf-krell@1.9.3:9999", when='@1.9.3:9999')
-
-    depends_on('cbtf-krell@develop+cti', when='@develop+cti')
-    depends_on('cbtf-krell@1.9.3:9999+cti', when='@1.9.3:9999+cti')
 
     depends_on('cbtf-krell@develop+runtime', when='@develop+runtime')
     depends_on('cbtf-krell@1.9.3:9999+runtime', when='@1.9.3:9999+runtime')

--- a/var/spack/repos/builtin/packages/cbtf/package.py
+++ b/var/spack/repos/builtin/packages/cbtf/package.py
@@ -21,9 +21,6 @@ class Cbtf(CMakePackage):
     version('1.9.4', branch='1.9.4')
     version('1.9.3', branch='1.9.3')
 
-    variant('cti', default=False,
-            description="Build MRNet with the CTI startup option")
-
     variant('runtime', default=False,
             description="build only the runtime libraries and collectors.")
 
@@ -42,9 +39,7 @@ class Cbtf(CMakePackage):
     depends_on("boost@1.70.0:")
 
     # For MRNet
-    depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti')
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop')
-    depends_on("mrnet@5.0.1-3+cti", when='@1.9.3:9999+cti')
     depends_on("mrnet@5.0.1-3+lwthreads", when='@1.9.3:9999')
 
     # For Xerces-C

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -57,7 +57,6 @@ class Dd4hep(CMakePackage):
     # variants for subpackages
     variant('ddcad', default=True, description="Enable CAD interface based on Assimp")
     variant('ddg4', default=True, description="Enable the simulation part based on Geant4")
-    variant('ddg4', default=True, description="Enable the simulation part based on Geant4")
     variant('ddrec', default=True, description="Build DDRec subpackage.")
     variant('dddetectors', default=True, description="Build DDDetectors subpackage.")
     variant('ddcond', default=True, description="Build DDCond subpackage.")

--- a/var/spack/repos/builtin/packages/flecsale/package.py
+++ b/var/spack/repos/builtin/packages/flecsale/package.py
@@ -20,8 +20,8 @@ class Flecsale(CMakePackage):
 
     depends_on("pkgconfig", type='build')
     depends_on("cmake@3.1:", type='build')
-    depends_on("flecsi~mpi", when='~mpi')
-    depends_on("flecsi+mpi", when='+mpi')
+    depends_on("flecsi backend=serial", when='~mpi')
+    conflicts("^flecsi backend=serial", when='+mpi')
     depends_on("python")
     depends_on("openssl")
     depends_on("boost~mpi", when='~mpi')

--- a/var/spack/repos/builtin/packages/flecsi/package.py
+++ b/var/spack/repos/builtin/packages/flecsi/package.py
@@ -138,7 +138,7 @@ class Flecsi(CMakePackage, CudaPackage):
     # Unit tests require flog support
     conflicts('+unit_tests', when='~flog')
     # Disallow conduit=none when using legion as a backend
-    conflicts('legion conduit=none', when='backend=legion')
+    conflicts('^legion conduit=none', when='backend=legion')
     # Due to overhauls of Legion and Gasnet spackages
     #   flecsi@:1.9 can no longer be built with a usable legion
     conflicts('backend=legion', when='@:1.9')

--- a/var/spack/repos/builtin/packages/grnboost/package.py
+++ b/var/spack/repos/builtin/packages/grnboost/package.py
@@ -22,7 +22,7 @@ class Grnboost(Package):
 
     depends_on('sbt', type='build')
     depends_on('java', type=('build', 'run'))
-    depends_on('xgboost+jvm-packages', type='run')
+    depends_on('xgboost', type='run')
     depends_on('spark+hadoop', type='run')
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/nalu/package.py
+++ b/var/spack/repos/builtin/packages/nalu/package.py
@@ -35,7 +35,7 @@ class Nalu(CMakePackage):
     # Cannot build Trilinos as a shared library with STK on Darwin
     # which is why we have a 'shared' variant for Nalu
     # https://github.com/trilinos/Trilinos/issues/2994
-    depends_on('trilinos+mpi+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+shards~hypre@master')
+    depends_on('trilinos+mpi+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+shards~hypre@master')
     depends_on('trilinos~shared', when='~shared')
     # Optional dependencies
     depends_on('tioga', when='+tioga+shared')

--- a/var/spack/repos/builtin/packages/open-iscsi/package.py
+++ b/var/spack/repos/builtin/packages/open-iscsi/package.py
@@ -21,7 +21,7 @@ class OpenIscsi(MakefilePackage):
 
     depends_on('gettext')
     depends_on('uuid')
-    depends_on('util-linux+libmount')
+    depends_on('util-linux')
     depends_on('kmod')
     depends_on('open-isns')
     depends_on('libtool', type='build')

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -39,8 +39,6 @@ class OpenspeedshopUtils(CMakePackage):
 
     variant('runtime', default=False,
             description="build only the runtime libraries and collectors.")
-    variant('cti', default=False,
-            description="Build MRNet with the CTI startup option")
     variant('crayfe', default=False,
             description="build only the FE tool using the runtime_dir \
                          to point to target build.")
@@ -107,9 +105,6 @@ class OpenspeedshopUtils(CMakePackage):
     depends_on('cbtf-krell@develop+crayfe', when='@develop+crayfe', type=('build', 'link', 'run'))
     depends_on('cbtf-krell@1.9.3:9999+crayfe', when='@2.4.0:9999+crayfe', type=('build', 'link', 'run'))
 
-    depends_on('cbtf-krell@develop+cti', when='@develop+cti', type=('build', 'link', 'run'))
-    depends_on('cbtf-krell@1.9.3:9999+cti', when='@2.4.0:9999+cti', type=('build', 'link', 'run'))
-
     depends_on('cbtf-krell@develop+mpich', when='@develop+mpich', type=('build', 'link', 'run'))
     depends_on('cbtf-krell@1.9.3:9999+mpich', when='@2.4.0:9999+mpich', type=('build', 'link', 'run'))
 
@@ -132,10 +127,7 @@ class OpenspeedshopUtils(CMakePackage):
     depends_on("cbtf-argonavis@1.9.3:9999", when='@2.4.0:9999+cuda', type=('build', 'link', 'run'))
 
     # For MRNet
-    depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti', type=('build', 'link', 'run'))
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop', type=('build', 'link', 'run'))
-
-    depends_on("mrnet@5.0.1-3:+cti", when='@2.4.0:9999+cti', type=('build', 'link', 'run'))
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@2.4.0:9999', type=('build', 'link', 'run'))
 
     patch('arm.patch', when='target=aarch64:')

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -32,8 +32,6 @@ class Openspeedshop(CMakePackage):
 
     variant('runtime', default=False,
             description="build only the runtime libraries and collectors.")
-    variant('cti', default=False,
-            description="Build MRNet with the CTI startup option")
     variant('crayfe', default=False,
             description="build only the FE tool using the runtime_dir \
                          to point to target build.")
@@ -105,9 +103,6 @@ class Openspeedshop(CMakePackage):
     depends_on('cbtf-krell@develop+crayfe', when='@develop+crayfe', type=('build', 'link', 'run'))
     depends_on('cbtf-krell@1.9.3:9999+crayfe', when='@2.4.0:9999+crayfe', type=('build', 'link', 'run'))
 
-    depends_on('cbtf-krell@develop+cti', when='@develop+cti', type=('build', 'link', 'run'))
-    depends_on('cbtf-krell@1.9.3:9999+cti', when='@2.4.0:9999+cti', type=('build', 'link', 'run'))
-
     depends_on('cbtf-krell@develop+mpich', when='@develop+mpich', type=('build', 'link', 'run'))
     depends_on('cbtf-krell@1.9.3:9999+mpich', when='@2.4.0:9999+mpich', type=('build', 'link', 'run'))
 
@@ -130,10 +125,7 @@ class Openspeedshop(CMakePackage):
     depends_on("cbtf-argonavis@1.9.3:9999", when='@2.4.0:9999+cuda', type=('build', 'link', 'run'))
 
     # For MRNet
-    depends_on("mrnet@5.0.1-3:+cti", when='@develop+cti', type=('build', 'link', 'run'))
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@develop', type=('build', 'link', 'run'))
-
-    depends_on("mrnet@5.0.1-3:+cti", when='@2.4.0:9999+cti', type=('build', 'link', 'run'))
     depends_on("mrnet@5.0.1-3:+lwthreads", when='@2.4.0:9999', type=('build', 'link', 'run'))
 
     patch('arm.patch', when='target=aarch64:')

--- a/var/spack/repos/builtin/packages/percept/package.py
+++ b/var/spack/repos/builtin/packages/percept/package.py
@@ -25,7 +25,7 @@ class Percept(CMakePackage):
     depends_on('opennurbs@percept')
     depends_on('boost+graph+mpi')
     depends_on('yaml-cpp+pic~shared@0.5.3:')
-    depends_on('trilinos~shared+exodus+mpi+tpetra+epetra+epetraext+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+zlib+aztec+sacado~openmp+shards+intrepid@master,12.14.1:')
+    depends_on('trilinos~shared+exodus+mpi+tpetra+epetra+epetraext+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist+superlu+hdf5+aztec+sacado~openmp+shards+intrepid@master,12.14.1:')
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/phyluce/package.py
+++ b/var/spack/repos/builtin/packages/phyluce/package.py
@@ -31,7 +31,7 @@ class Phyluce(PythonPackage):
     depends_on('mafft', type='run')
     depends_on('muscle', type='run')
     depends_on('picard', type='run')
-    depends_on('raxml+pthreads+sse', type='run')
+    depends_on('raxml+pthreads', type='run')
     depends_on('samtools', type='run')
     depends_on('seqtk', type='run')
     depends_on('spades', type='run')

--- a/var/spack/repos/builtin/packages/py-mmcv/package.py
+++ b/var/spack/repos/builtin/packages/py-mmcv/package.py
@@ -20,7 +20,7 @@ class PyMmcv(PythonPackage):
     depends_on('py-addict', type=('build', 'run'))
     depends_on('py-numpy@1.11.1:', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
-    depends_on('opencv+python', type=('build', 'run'))
+    depends_on('opencv+python3', type=('build', 'run'))
     depends_on('py-cython', type='build')
 
     patch('opencv_for0.5.1.patch', when='@0.5.1')

--- a/var/spack/repos/builtin/packages/py-pythonqwt/package.py
+++ b/var/spack/repos/builtin/packages/py-pythonqwt/package.py
@@ -14,7 +14,7 @@ class PyPythonqwt(PythonPackage):
 
     version('0.5.5', sha256='1f13cc8b555a57f8fe0f806d6c2f6d847050e4d837649503932b81316d12788a')
 
-    variant('doc', default=False, description="Build documentation.")
+    variant('docs', default=False, description="Build documentation.")
 
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy@1.3:',   type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/sollve/package.py
+++ b/var/spack/repos/builtin/packages/sollve/package.py
@@ -133,7 +133,6 @@ class Sollve(CMakePackage):
              revision=372427, destination='projects',
              when='@1.0a2+internal_unwind', placement='libunwind')
 
-    conflicts('+clang_extra', when='~clang')
     conflicts('+lldb',        when='~clang')
 
     conflicts('%gcc@:5.0')


### PR DESCRIPTION
This PR adds a new job to the "unit tests" GA workflow that runs `spack audit packages` to ensure there are no detectable issues in the built-in repository.

Modifications:
- [x] Add a new job to GA workflow to audit packages
- [x] Fix the 26 issues that have been reported