### PR TITLE
spack recipe for AOCC 3.2.0 release

### DIFF
--- a/var/spack/repos/builtin/packages/aocc/package.py
+++ b/var/spack/repos/builtin/packages/aocc/package.py
@@ -32,6 +32,8 @@ class Aocc(Package):
 
     maintainers = ['amd-toolchain-support']
 
+    version(ver="3.2.0", sha256='8493525b3df77f48ee16f3395a68ad4c42e18233a44b4d9282b25dbb95b113ec',
+            url='https://developer.amd.com/wordpress/media/files/aocc-compiler-3.2.0.tar')
     version(ver="3.1.0", sha256='1948104a430506fe5e445c0c796d6956109e7cc9fc0a1e32c9f1285cfd566d0c',
             url='https://developer.amd.com/wordpress/media/files/aocc-compiler-3.1.0.tar')
     version(ver="3.0.0", sha256='4ff269b1693856b9920f57e3c85ce488c8b81123ddc88682a3ff283979362227',


### PR DESCRIPTION
What's new in AOCC 3.2
1) Based on LLVM 13.0 (llvm.org, October 4, 2021)
2) Fortran Flang compiler improvements
2.a) Address, Memory, Thread and Safe stack sanitization support
2.b) (NO)FREEFORM pragma is supported
2.c) Debuggability support for Fortran namelist and macros
3) Compliance to standards
3.a) Improved OpenMP 4.5 support for Fortran
3.a.i) Supporting clauses 'depend' and 'use_device_ptr'
3.a.ii) Supporting directives 'do,' 'ordered,' 'task,' and parallel'
3.b) Improved F2008 support
3.b.i) The Value attribute is permitted for non-allocatable, non-pointer, non-coarray
3.c) AOCC Flang debuggability upgraded to support the Dwarf 5 standards
4) Tested on RHEL 8, CentOS 8, SLES 15, and Ubuntu 20.04 LTS
5) AOCC Clang and Flang compiler details are no longer separate documents but fully integrated within the following AOCC 3.2 User Guide
5.a) https://developer.amd.com/wp-content/resources/57222_AOCC_UG_Rev_3.2.pdf