### PR TITLE
Add conflict for Asio/CUDA to HPX package

### DIFF
--- a/var/spack/repos/builtin/packages/asio/package.py
+++ b/var/spack/repos/builtin/packages/asio/package.py
@@ -16,11 +16,17 @@ class Asio(AutotoolsPackage):
     git = "https://github.com/chriskohlhoff/asio.git"
     maintainers = ["msimberg"]
 
+    version('1.21.0', sha256='5d2d2dcb7bfb39bff941cabbfc8c27ee322a495470bf0f3a7c5238648cf5e6a9')
     version('1.20.0', sha256='34a8f07be6f54e3753874d46ecfa9b7ab7051c4e3f67103c52a33dfddaea48e6')
     version('1.19.2', sha256='5ee191aee825dfb1325cbacf643d599b186de057c88464ea98f1bae5ba4ff47a')
     version('1.19.1', sha256='2555e0a29256de5c77d6a34b14faefd28c76555e094ba0371acb0b91d483520e')
     version('1.19.0', sha256='11bc0e22fcdfb3f0b77574ac33760a3592c0dac7e7eece7668b823c158243629')
     version('1.18.2', sha256='8d67133b89e0f8b212e9f82fdcf1c7b21a978d453811e2cd941c680e72c2ca32')
+    version('1.18.1', sha256='39c721b987b7a0d2fe2aee64310bd128cd8cc10f43481604d18cb2d8b342fd40')
+    version('1.18.0', sha256='820688d1e0387ff55194ae20036cbae0fb3c7d11b7c3f46492369723c01df96f')
+    version('1.17.0', sha256='46406a830f8334b3789e7352ed7309a39c7c30b685b0499d289eda4fd4ae2067')
+    version('1.16.1', sha256='e40bbd531530f08318b7c7d7e84e457176d8eae6f5ad2e3714dc27b9131ecd35')
+    version('1.16.0', sha256='c87410ea62de6245aa239b9ed2057edf01d7f66acc3f5e50add9a29343c87512')
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -146,6 +146,10 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     # Patches and one-off conflicts
 
+    # Certain Asio headers don't compile with nvcc from 1.17.0 onwards with
+    # C++17. Starting with CUDA 11.3 they compile again.
+    conflicts("asio@1.17.0:", when="+cuda cxxstd=17 ^cuda@:11.2")
+
     # Boost and HIP don't work together in certain versions:
     # https://github.com/boostorg/config/issues/392. Boost 1.78.0 and HPX 1.8.0
     # both include a fix.


### PR DESCRIPTION
HPX includes Asio headers which don't compile with nvcc in C++17 mode. Asio 1.16.1 and earlier does not have this problem. Likewise CUDA 11.3 and upwards does not have this problem either.

Adds more Asio versions, one of which is 1.16.1 to allow compilation with CUDA <= 11.2.

General question: I would imagine other packages may have this conflict as well and it'd be nice to add a single conflict to Asio. However, that may be too restrictive as not all packages that depend on Asio include the problematic header, and not all of the packages that depend on Asio and CUDA compile the Asio headers with nvcc. Is there a precedence for how to best deal with conflicts like these?