### PR TITLE
Fix for OpenFOAM pthread issue for AOCC 3.2

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -559,6 +559,14 @@ class Openfoam(Package):
             filter_file(r'trapFpe\s+\d+\s*;', 'trapFpe 0;',
                         controlDict, backup=False)
 
+    @when('%aocc@3.2.0')
+    @run_before('configure')
+    def make_amd_rules(self):
+        general_rules = 'wmake/rules/General'
+        src = join_path(general_rules, 'Clang')
+        filter_file('clang++', spack_cxx + ' -pthread', join_path(src, 'c++'),
+                    backup=False, string=True)
+
     @when('@1812: %fj')
     @run_before('configure')
     def make_fujitsu_rules(self):

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -559,9 +559,13 @@ class Openfoam(Package):
             filter_file(r'trapFpe\s+\d+\s*;', 'trapFpe 0;',
                         controlDict, backup=False)
 
-    @when('%aocc@3.2.0')
+    @when('@:2106 %aocc@3.2.0')
     @run_before('configure')
     def make_amd_rules(self):
+        """Due to the change in the linker behavior in AOCC v3.2, it is now
+        issuing diagnostic messages for the unreferenced symbols in the
+        shared objects as it may lead to run time failures.
+        """
         general_rules = 'wmake/rules/General'
         src = join_path(general_rules, 'Clang')
         filter_file('clang++', spack_cxx + ' -pthread', join_path(src, 'c++'),

--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -559,7 +559,7 @@ class Openfoam(Package):
             filter_file(r'trapFpe\s+\d+\s*;', 'trapFpe 0;',
                         controlDict, backup=False)
 
-    @when('@:2106 %aocc@3.2.0')
+    @when('@:2106 %aocc@3.2.0:')
     @run_before('configure')
     def make_amd_rules(self):
         """Due to the change in the linker behavior in AOCC v3.2, it is now


### PR DESCRIPTION
- OpenFOAM build was failing due to below error with AOCC 3.2

> ld.lld: error: /usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so: undefined reference to pthread_create [--no-allow-shlib-undefined]

- Due to the change in the linker behavior (aocc 3.2), it is now issuing diagnostic messages for the unreferenced symbols in the shared objects as it may lead to run time failures.