### PR TITLE
AOCC support for VASP

### DIFF
--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -132,7 +132,7 @@ class Vasp(MakefilePackage):
         filter_file('^FFTW[ ]{0,}?=.*$', 'FFTW ?=', 'makefile.include')
         filter_file('^MPI_INC[ ]{0,}=.*$', 'MPI_INC ?=', 'makefile.include')
         filter_file('-DscaLAPACK.*$\n', '', 'makefile.include')
-        filter_file('^SCALAPACK[ ]{0,}=.*$', '', 'makefile.include')
+        filter_file('^SCALAPACK[ ]{0,}=.*$', 'SCALAPACK ?=', 'makefile.include')
 
         if '+cuda' in spec:
             filter_file('^OBJECTS_GPU[ ]{0,}=.*$',

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -135,7 +135,7 @@ class Vasp(MakefilePackage):
         filter_file('^FFTW[ ]{0,}?=.*$', 'FFTW ?=', 'makefile.include')
         filter_file('^MPI_INC[ ]{0,}=.*$', 'MPI_INC ?=', 'makefile.include')
         filter_file('-DscaLAPACK.*$\n', '', 'makefile.include')
-        filter_file('^SCALAPACK*$', '', 'makefile.include')
+        filter_file('^SCALAPACK.*$', '', 'makefile.include')
 
         if '+cuda' in spec:
             filter_file('^OBJECTS_GPU[ ]{0,}=.*$',

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -20,6 +20,7 @@ class Vasp(MakefilePackage):
     url      = "file://{0}/vasp.5.4.4.pl2.tgz".format(os.getcwd())
     manual_download = True
 
+    version('6.2.0', sha256='49e7ba351bd634bc5f5f67a8ef1e38e64e772857a1c02f602828898a84197e25')
     version('6.1.1', sha256='e37a4dfad09d3ad0410833bcd55af6b599179a085299026992c2d8e319bf6927')
     version('5.4.4.pl2', sha256='98f75fd75399a23d76d060a6155f4416b340a1704f256a00146f89024035bc8e')
     version('5.4.4', sha256='5bd2449462386f01e575f9adf629c08cb03a13142806ffb6a71309ca4431cfb3')
@@ -29,6 +30,8 @@ class Vasp(MakefilePackage):
              tag='V1.0',
              when='+vaspsol')
 
+    variant('openmp', default=False,
+            description='Enable OPENMP build')
     variant('scalapack', default=False,
             description='Enables build with SCALAPACK')
 
@@ -42,14 +45,15 @@ class Vasp(MakefilePackage):
     depends_on('rsync', type='build')
     depends_on('blas')
     depends_on('lapack')
-    depends_on('fftw')
+    depends_on('fftw-api')
     depends_on('mpi', type=('build', 'link', 'run'))
-    depends_on('netlib-scalapack', when='+scalapack')
+    depends_on('scalapack', when='+scalapack')
     depends_on('cuda', when='+cuda')
     depends_on('qd', when='%nvhpc')
 
     conflicts('%gcc@:8', msg='GFortran before 9.x does not support all features needed to build VASP')
     conflicts('+vaspsol', when='+cuda', msg='+vaspsol only available for CPU')
+    conflicts('+openmp', when='@:6.1.1', msg='openmp support started from 6.2')
 
     parallel = False
 
@@ -68,6 +72,38 @@ class Vasp(MakefilePackage):
             filter_file('/opt/pgi/qd-2.3.17/install/lib',
                         spec['qd'].prefix.lib, make_include)
             filter_file('^SCALAPACK[ ]{0,}=.*$', 'SCALAPACK ?=', make_include)
+        elif '%aocc' in spec:
+            if '+openmp' in spec:
+                copy(
+                    join_path('arch', 'makefile.include.linux_gnu_omp'),
+                    join_path('arch', 'makefile.include.linux_aocc_omp')
+                )
+                make_include = join_path('arch', 'makefile.include.linux_aocc_omp')
+            else:
+                copy(
+                    join_path('arch', 'makefile.include.linux_gnu'),
+                    join_path('arch', 'makefile.include.linux_aocc')
+                )
+                make_include = join_path('arch', 'makefile.include.linux_aocc')
+            filter_file(
+                'gcc', '{0} {1}'.format(spack_cc, '-Mfree'),
+                make_include, string=True
+            )
+            filter_file('g++', spack_cxx, make_include, string=True)
+            filter_file('^CFLAGS_LIB[ ]{0,}=.*$',
+                        'CFLAGS_LIB = -O3', make_include)
+            filter_file('^FFLAGS_LIB[ ]{0,}=.*$',
+                        'FFLAGS_LIB = -O2', make_include)
+            filter_file('^SCALAPACK[ ]{0,}=.*$',
+                        'SCALAPACK ?=', make_include)
+            filter_file('^OFLAG[ ]{0,}=.*$',
+                        'OFLAG = -O3', make_include)
+            filter_file('^FC[ ]{0,}=.*$',
+                        'FC = {0}'.format(spec['mpi'].mpifc),
+                        make_include, string=True)
+            filter_file('^FCL[ ]{0,}=.*$',
+                        'FCL = {0}'.format(spec['mpi'].mpifc),
+                        make_include, string=True)
         else:
             make_include = join_path('arch',
                                      'makefile.include.linux_' +
@@ -118,8 +154,14 @@ class Vasp(MakefilePackage):
         if '%nvhpc' in self.spec:
             cpp_options.extend(['-DHOST=\\"LinuxPGI\\"', '-DPGI16',
                                 '-Dqd_emulate'])
+        elif '%aocc' in self.spec:
+            cpp_options.extend(['-DHOST=\\"LinuxGNU\\"',
+                                '-Dfock_dblbuf'])
+            if '+openmp' in self.spec:
+                cpp_options.extend(['-D_OPENMP'])
         else:
             cpp_options.append('-DHOST=\\"LinuxGNU\\"')
+
         if self.spec.satisfies('@6:'):
             cpp_options.append('-Dvasp6')
 
@@ -129,10 +171,12 @@ class Vasp(MakefilePackage):
             fflags.append('-w')
         elif '%nvhpc' in spec:
             fflags.extend(['-Mnoupcase', '-Mbackslash', '-Mlarge_arrays'])
+        elif '%aocc' in spec:
+            fflags.extend(['-fno-fortran-main', '-Mbackslash', '-ffast-math'])
 
         spack_env.set('BLAS', spec['blas'].libs.ld_flags)
         spack_env.set('LAPACK', spec['lapack'].libs.ld_flags)
-        spack_env.set('FFTW', spec['fftw'].prefix)
+        spack_env.set('FFTW', spec['fftw-api'].prefix)
         spack_env.set('MPI_INC', spec['mpi'].prefix.include)
 
         if '%nvhpc' in spec:
@@ -140,7 +184,7 @@ class Vasp(MakefilePackage):
 
         if '+scalapack' in spec:
             cpp_options.append('-DscaLAPACK')
-            spack_env.set('SCALAPACK', spec['netlib-scalapack'].libs.ld_flags)
+            spack_env.set('SCALAPACK', spec['scalapack'].libs.ld_flags)
 
         if '+cuda' in spec:
             cpp_gpu = ['-DCUDA_GPU', '-DRPROMU_CPROJ_OVERLAP',

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -31,7 +31,8 @@ class Vasp(MakefilePackage):
              when='+vaspsol')
 
     variant('openmp', default=False,
-            description='Enable OPENMP build')
+            description='Enable openmp build')
+
     variant('scalapack', default=False,
             description='Enables build with SCALAPACK')
 
@@ -60,7 +61,10 @@ class Vasp(MakefilePackage):
     def edit(self, spec, prefix):
 
         if '%gcc' in spec:
-            make_include = join_path('arch', 'makefile.include.linux_gnu')
+            if '+openmp' in spec:
+                make_include = join_path('arch', 'makefile.include.linux_gnu_omp')
+            else:
+                make_include = join_path('arch', 'makefile.include.linux_gnu')
         elif '%nvhpc' in spec:
             make_include = join_path('arch', 'makefile.include.linux_pgi')
             filter_file('-pgc++libs', '-c++libs', make_include, string=True)
@@ -105,9 +109,14 @@ class Vasp(MakefilePackage):
                         'FCL = {0}'.format(spec['mpi'].mpifc),
                         make_include, string=True)
         else:
-            make_include = join_path('arch',
-                                     'makefile.include.linux_' +
-                                     spec.compiler.name)
+            if '+openmp' in spec:
+                make_include = join_path('arch',
+                                         'makefile.include.linux_{0}_omp'.
+                                         format(spec.compiler.name))
+            else:
+                make_include = join_path('arch',
+                                         'makefile.include.linux_' +
+                                         spec.compiler.name)
 
         os.rename(make_include, 'makefile.include')
 

--- a/var/spack/repos/builtin/packages/vasp/package.py
+++ b/var/spack/repos/builtin/packages/vasp/package.py
@@ -75,7 +75,6 @@ class Vasp(MakefilePackage):
                         spec['qd'].prefix.include, make_include)
             filter_file('/opt/pgi/qd-2.3.17/install/lib',
                         spec['qd'].prefix.lib, make_include)
-            filter_file('^SCALAPACK[ ]{0,}=.*$', 'SCALAPACK ?=', make_include)
         elif '%aocc' in spec:
             if '+openmp' in spec:
                 copy(
@@ -98,8 +97,6 @@ class Vasp(MakefilePackage):
                         'CFLAGS_LIB = -O3', make_include)
             filter_file('^FFLAGS_LIB[ ]{0,}=.*$',
                         'FFLAGS_LIB = -O2', make_include)
-            filter_file('^SCALAPACK[ ]{0,}=.*$',
-                        'SCALAPACK ?=', make_include)
             filter_file('^OFLAG[ ]{0,}=.*$',
                         'OFLAG = -O3', make_include)
             filter_file('^FC[ ]{0,}=.*$',
@@ -135,7 +132,7 @@ class Vasp(MakefilePackage):
         filter_file('^FFTW[ ]{0,}?=.*$', 'FFTW ?=', 'makefile.include')
         filter_file('^MPI_INC[ ]{0,}=.*$', 'MPI_INC ?=', 'makefile.include')
         filter_file('-DscaLAPACK.*$\n', '', 'makefile.include')
-        filter_file('^SCALAPACK.*$', '', 'makefile.include')
+        filter_file('^SCALAPACK[ ]{0,}=.*$', '', 'makefile.include')
 
         if '+cuda' in spec:
             filter_file('^OBJECTS_GPU[ ]{0,}=.*$',


### PR DESCRIPTION
- Replaced `fftw `with `fftw-api` to support all FFTW implementations
- Replaced `netlib-scalapack` with `scalapack` to support all scalapack implementations
- Added `VASP v6.2.0` version support
- Created AOCC compatible makefiles from GNU Makefiles and added AOCC specific flags
- Added `openmp` variant, which is supported from v6.2.0 onwards