### PR TITLE
Best-effort co-concretization for environments with explicit conflicts

### DIFF
--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -70,8 +70,10 @@ def compare_specs(a, b, to_string=False, color=None):
 
     # psid doesn't matter because we're just comparing the clauses
     # tell asp to generate clauses without psids
-    a_facts = set(t for t in setup.spec_clauses(asp.no_psid, a, body=True, expand_hashes=True))
-    b_facts = set(t for t in setup.spec_clauses(asp.no_psid, b, body=True, expand_hashes=True))
+    a_facts = set(t for t in setup.spec_clauses(
+        asp.no_psid, a, body=True, expand_hashes=True))
+    b_facts = set(t for t in setup.spec_clauses(
+        asp.no_psid, b, body=True, expand_hashes=True))
 
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -68,8 +68,9 @@ def compare_specs(a, b, to_string=False, color=None):
     # Prepare a solver setup to parse differences
     setup = asp.SpackSolverSetup()
 
-    a_facts = set(t for t in setup.spec_clauses(a, body=True, expand_hashes=True))
-    b_facts = set(t for t in setup.spec_clauses(b, body=True, expand_hashes=True))
+    # psid index doesn't matter
+    a_facts = set(t for t in setup.spec_clauses(0, a, body=True, expand_hashes=True))
+    b_facts = set(t for t in setup.spec_clauses(0, b, body=True, expand_hashes=True))
 
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -68,12 +68,8 @@ def compare_specs(a, b, to_string=False, color=None):
     # Prepare a solver setup to parse differences
     setup = asp.SpackSolverSetup()
 
-    # psid doesn't matter because we're just comparing the clauses
-    # tell asp to generate clauses without psids
-    a_facts = set(t for t in setup.spec_clauses(
-        asp.no_psid, a, body=True, expand_hashes=True))
-    b_facts = set(t for t in setup.spec_clauses(
-        asp.no_psid, b, body=True, expand_hashes=True))
+    a_facts = set(t for t in setup.spec_clauses(a, body=True, expand_hashes=True))
+    b_facts = set(t for t in setup.spec_clauses(b, body=True, expand_hashes=True))
 
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))

--- a/lib/spack/spack/cmd/diff.py
+++ b/lib/spack/spack/cmd/diff.py
@@ -68,9 +68,10 @@ def compare_specs(a, b, to_string=False, color=None):
     # Prepare a solver setup to parse differences
     setup = asp.SpackSolverSetup()
 
-    # psid index doesn't matter
-    a_facts = set(t for t in setup.spec_clauses(0, a, body=True, expand_hashes=True))
-    b_facts = set(t for t in setup.spec_clauses(0, b, body=True, expand_hashes=True))
+    # psid doesn't matter because we're just comparing the clauses
+    # tell asp to generate clauses without psids
+    a_facts = set(t for t in setup.spec_clauses(asp.no_psid, a, body=True, expand_hashes=True))
+    b_facts = set(t for t in setup.spec_clauses(asp.no_psid, b, body=True, expand_hashes=True))
 
     # We want to present them to the user as simple key: values
     intersect = sorted(a_facts.intersection(b_facts))

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -118,7 +118,13 @@ def solve(parser, args):
         opt, _, _ = min(result.answers)
         if ("opt" in dump) and (not args.format):
             tty.msg("Best of %d considered solutions." % result.nmodels)
-            tty.msg("Optimization Criteria:")
+            debug = spack.config.get('config:debug')
+            if debug:
+                tty.msg("Optimization Criteria:")
+            else:
+                msg = "Non-optimal Optimization Criteria:"
+                msg += " (to see full criteria run in debug mode)"
+                tty.msg(msg)
 
             maxlen = max(len(s[2]) for s in result.criteria)
             color.cprint(
@@ -127,6 +133,11 @@ def solve(parser, args):
 
             fmt = "  @K{%%-8d}  %%-%ds%%9s  %%7s" % maxlen
             for i, (idx, build_idx, name) in enumerate(result.criteria, 1):
+                # Only print 0-valued opt criteria in debug mode
+                if not opt[idx] and (not build_idx or not opt[build_idx]):
+                    if not spack.config.get('config:debug'):
+                        continue
+
                 color.cprint(
                     fmt % (
                         i,

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -105,7 +105,7 @@ def solve(parser, args):
     # dump generated ASP program
     result = asp.solve(
         specs, dump=dump, models=models, timers=args.timers, stats=args.stats,
-        reuse=args.reuse,
+        reuse=args.reuse, allow_split=True
     )
     if 'solutions' not in dump:
         return

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -125,13 +125,7 @@ def solve(parser, args):
         opt, _, _ = min(result.answers)
         if ("opt" in dump) and (not args.format):
             tty.msg("Best of %d considered solutions." % result.nmodels)
-            debug = spack.config.get('config:debug')
-            if debug:
-                tty.msg("Optimization Criteria:")
-            else:
-                msg = "Non-optimal Optimization Criteria:"
-                msg += " (to see full criteria run in debug mode)"
-                tty.msg(msg)
+            tty.msg("Optimization Criteria:")
 
             maxlen = max(len(s[2]) for s in result.criteria)
             color.cprint(
@@ -140,11 +134,6 @@ def solve(parser, args):
 
             fmt = "  @K{%%-8d}  %%-%ds%%9s  %%7s" % maxlen
             for i, (idx, build_idx, name) in enumerate(result.criteria, 1):
-                # Only print 0-valued opt criteria in debug mode
-                if not opt[idx] and (not build_idx or not opt[build_idx]):
-                    if not spack.config.get('config:debug'):
-                        continue
-
                 color.cprint(
                     fmt % (
                         i,

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -68,6 +68,13 @@ def setup_parser(subparser):
     subparser.add_argument(
         '--stats', action='store_true', default=False,
         help='print out statistics from clingo')
+    diffs_parser = subparser.add_mutually_exclusive_group()
+    diffs_parser.add_argument(
+        '--multi-root', action='store_true', default=True, dest='multi_root',
+        help='concretize specs together as much as possible')
+    diffs_parser.add_argument(
+        '--single-root', action='store_false', default=True, dest='multi_root',
+        help='concretize specs together or raise an error')
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages")
 
@@ -105,7 +112,7 @@ def solve(parser, args):
     # dump generated ASP program
     result = asp.solve(
         specs, dump=dump, models=models, timers=args.timers, stats=args.stats,
-        reuse=args.reuse, multi_root=True
+        reuse=args.reuse, multi_root=args.multi_root
     )
     if 'solutions' not in dump:
         return

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -105,7 +105,7 @@ def solve(parser, args):
     # dump generated ASP program
     result = asp.solve(
         specs, dump=dump, models=models, timers=args.timers, stats=args.stats,
-        reuse=args.reuse, allow_split=True
+        reuse=args.reuse, multi_root=True
     )
     if 'solutions' not in dump:
         return

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -751,7 +751,7 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
     concretization_kwargs = {
         'tests': kwargs.get('tests', False),
         'reuse': kwargs.get('reuse', False),
-        'allow_split': kwargs.get('allow_split', False),
+        'multi_root': kwargs.get('multi_root', False),
     }
     result = spack.solver.asp.solve(abstract_specs, **concretization_kwargs)
     result.raise_if_unsat()
@@ -786,7 +786,7 @@ def _concretize_specs_together_original(*abstract_specs, **kwargs):
 
         return spack.repo.Repo(repo_path)
 
-    if kwargs.get('allow_split', False):
+    if kwargs.get('multi_root', False):
         # This feature cannot be implemented in the old concretizer
         raise Exception
 

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -789,7 +789,7 @@ def _concretize_specs_together_original(*abstract_specs, **kwargs):
     if kwargs.get('multi_root', False):
         # This feature cannot be implemented in the old concretizer
         msg = '`concretization: togethere_where_possible`'
-        msg +- ' cannot be implemented with original concretizer'
+        msg += ' cannot be implemented with original concretizer'
         raise spack.error.SpackError(msg)
 
     abstract_specs = [spack.spec.Spec(s) for s in abstract_specs]

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -750,7 +750,8 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
     import spack.solver.asp
     concretization_kwargs = {
         'tests': kwargs.get('tests', False),
-        'reuse': kwargs.get('reuse', False)
+        'reuse': kwargs.get('reuse', False),
+        'allow_split': kwargs.get('allow_split', False),
     }
     result = spack.solver.asp.solve(abstract_specs, **concretization_kwargs)
     result.raise_if_unsat()
@@ -784,6 +785,10 @@ def _concretize_specs_together_original(*abstract_specs, **kwargs):
             f.write(template.render(specs=[str(s) for s in split_specs]))
 
         return spack.repo.Repo(repo_path)
+
+    if kwargs.get('allow_split', False):
+        # This feature cannot be implemented in the old concretizer
+        raise Exception
 
     abstract_specs = [spack.spec.Spec(s) for s in abstract_specs]
     concretization_repository = make_concretization_repository(abstract_specs)

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -788,7 +788,9 @@ def _concretize_specs_together_original(*abstract_specs, **kwargs):
 
     if kwargs.get('multi_root', False):
         # This feature cannot be implemented in the old concretizer
-        raise Exception
+        msg = '`concretization: togethere_where_possible`'
+        msg +- ' cannot be implemented with original concretizer'
+        raise spack.error.SpackError(msg)
 
     abstract_specs = [spack.spec.Spec(s) for s in abstract_specs]
     concretization_repository = make_concretization_repository(abstract_specs)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1111,6 +1111,9 @@ class Environment(object):
             self.specs_by_hash = {}
 
         # Pick the right concretization strategy
+        if self.concretization == 'together_where_possible':
+            return self._concretize_together(tests=tests, reuse=reuse, allow_split=True)
+
         if self.concretization == 'together':
             return self._concretize_together(tests=tests, reuse=reuse)
 
@@ -1120,7 +1123,7 @@ class Environment(object):
         msg = 'concretization strategy not implemented [{0}]'
         raise SpackEnvironmentError(msg.format(self.concretization))
 
-    def _concretize_together(self, tests=False, reuse=False):
+    def _concretize_together(self, tests=False, reuse=False, allow_split=False):
         """Concretization strategy that concretizes all the specs
         in the same DAG.
         """
@@ -1141,7 +1144,7 @@ class Environment(object):
             if count > 1:
                 duplicates.append(name)
 
-        if duplicates:
+        if duplicates and not allow_split:
             msg = ('environment that are configured to concretize specs'
                    ' together cannot contain more than one spec for each'
                    ' package [{0}]'.format(', '.join(duplicates)))
@@ -1153,7 +1156,7 @@ class Environment(object):
         self.specs_by_hash = {}
 
         concrete_specs = spack.concretize.concretize_specs_together(
-            *self.user_specs, tests=tests, reuse=reuse
+            *self.user_specs, tests=tests, reuse=reuse, allow_split=allow_split
         )
         concretized_specs = [x for x in zip(self.user_specs, concrete_specs)]
         for abstract, concrete in concretized_specs:

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1112,7 +1112,7 @@ class Environment(object):
 
         # Pick the right concretization strategy
         if self.concretization == 'together_where_possible':
-            return self._concretize_together(tests=tests, reuse=reuse, allow_split=True)
+            return self._concretize_together(tests=tests, reuse=reuse, multi_root=True)
 
         if self.concretization == 'together':
             return self._concretize_together(tests=tests, reuse=reuse)
@@ -1123,7 +1123,7 @@ class Environment(object):
         msg = 'concretization strategy not implemented [{0}]'
         raise SpackEnvironmentError(msg.format(self.concretization))
 
-    def _concretize_together(self, tests=False, reuse=False, allow_split=False):
+    def _concretize_together(self, tests=False, reuse=False, multi_root=False):
         """Concretization strategy that concretizes all the specs
         in the same DAG.
         """
@@ -1144,7 +1144,7 @@ class Environment(object):
             if count > 1:
                 duplicates.append(name)
 
-        if duplicates and not allow_split:
+        if duplicates and not multi_root:
             msg = ('environment that are configured to concretize specs'
                    ' together cannot contain more than one spec for each'
                    ' package [{0}]'.format(', '.join(duplicates)))
@@ -1156,7 +1156,7 @@ class Environment(object):
         self.specs_by_hash = {}
 
         concrete_specs = spack.concretize.concretize_specs_together(
-            *self.user_specs, tests=tests, reuse=reuse, allow_split=allow_split
+            *self.user_specs, tests=tests, reuse=reuse, multi_root=multi_root
         )
         concretized_specs = [x for x in zip(self.user_specs, concrete_specs)]
         for abstract, concrete in concretized_specs:

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -150,7 +150,7 @@ schema = {
                     },
                     'concretization': {
                         'type': 'string',
-                        'enum': ['together', 'separately'],
+                        'enum': ['together', 'separately', 'together_where_possible'],
                         'default': 'separately'
                     }
                 }

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -99,6 +99,7 @@ DeclaredVersion = collections.namedtuple(
     'DeclaredVersion', ['version', 'idx', 'origin']
 )
 
+
 # Class for negating version ranges
 # This allows us to sort ascending by inverse version order
 class _InvertedVersion(object):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -499,12 +499,14 @@ template_pkg_opt = 'opt_criterion({0}, "number of non-identical {1} nodes").'
 template_pkg_null = '#minimize {{ 0@{0} : #true}}.'
 template_pkg_present = ('#minimize {{ 1@{0},PSID1,PSID2 : '
                         'package_not_equal(PSID1, PSID2, "{1}"), '
+                        'representative(PSID1, "{1}"), '
                         'node(PSID1, "{1}"), node(PSID2, "{1}") }}.')
 
 template_virtual_opt = 'opt_criterion({0}, "number of non-identical {1} providers").'
 template_virtual_null = '#minimize {{ 0@{0} : #true}}.'
 template_virtual_present = ('#minimize {{ 1@{0},PSID1,PSID2 : '
-                            'virtual_not_equal(PSID1, PSID2, "{1}")}}.')
+                            'virtual_not_equal(PSID1, PSID2, "{1}"), '
+                            'representative_virtual(PSID1, "{1}")}}.')
 
 
 class PyclingoDriver(object):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -746,10 +746,15 @@ class SpackSolverSetup(object):
             trigger_id = self.condition(spack.spec.Spec(trigger), name=pkg.name)
             self.gen.fact(fn.conflict_trigger(trigger_id))
 
-            for constraint, _ in constraints:
-                msg = "%s has conflict between %s and %s" % (pkg.name, trigger, constraint)
+            for constraint, msg in constraints:
+                if not msg:
+                    msg = "%s has conflict between %s and %s" % (
+                        pkg.name, trigger, constraint)
                 constraint_id = self.condition(constraint, name=pkg.name)
-                self.gen.fact(fn.conflict(pkg.name, trigger_id, constraint_id, msg), assumption=True)
+                self.gen.fact(
+                    fn.conflict(pkg.name, trigger_id, constraint_id, msg),
+                    assumption=True
+                )
                 self.gen.newline()
 
     def available_compilers(self):
@@ -1150,7 +1155,8 @@ class SpackSolverSetup(object):
             raise RuntimeError(msg)
         return clauses
 
-    def _spec_clauses(self, idx, spec, body=False, transitive=True, expand_hashes=False):
+    def _spec_clauses(
+            self, idx, spec, body=False, transitive=True, expand_hashes=False):
         """Return a list of clauses for a spec mandates are true.
 
         Arguments:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -521,22 +521,6 @@ def bootstrap_clingo():
         from clingo import parse_files
 
 
-template_pkg_opt = 'opt_criterion({0}, "number of non-identical {1} nodes").'
-template_pkg_null = '#minimize {{ 0@{0} : #true}}.'
-template_pkg_present = ('#minimize {{ 1@{0},PSID1,PSID2 : '
-                        'package_not_equal(PSID1, PSID2, "{1}"), '
-                        'representative(PSID1, "{1}"), '
-                        'representative(PSID2, "{1}"), '
-                        'node(PSID1, "{1}"), node(PSID2, "{1}") }}.')
-
-template_virtual_opt = 'opt_criterion({0}, "number of non-identical {1} providers").'
-template_virtual_null = '#minimize {{ 0@{0} : #true}}.'
-template_virtual_present = ('#minimize {{ 1@{0},PSID1,PSID2 : '
-                            'virtual_not_equal(PSID1, PSID2, "{1}"), '
-                            'representative_virtual(PSID1, "{1}"), '
-                            'representative_virtual(PSID2, "{1}")}}.')
-
-
 class PyclingoDriver(object):
     def __init__(self, cores=True, asp=None):
         """Driver for the Python clingo interface.
@@ -611,32 +595,6 @@ class PyclingoDriver(object):
         with self.control.backend() as backend:
             self.backend = backend
             solver_setup.setup(self, specs_by_psid, tests=tests, reuse=reuse)
-
-            dynamic_minimization_criteria = []
-            for i, pkg in enumerate(sorted(set(solver_setup.possible_pkgs))):
-                priority = high_fixed_priority_offset + i
-                dynamic_minimization_criteria.extend([
-                    template_pkg_opt.format(priority, pkg),
-                    template_pkg_null.format(priority),
-                    template_pkg_present.format(priority, pkg)
-                ])
-            virtual_offset = len(set(solver_setup.possible_pkgs))
-            for i, virt in enumerate(sorted(set(solver_setup.possible_virtuals))):
-                priority = high_fixed_priority_offset + i + virtual_offset
-                dynamic_minimization_criteria.extend([
-                    template_virtual_opt.format(priority, virt),
-                    template_virtual_null.format(priority),
-                    template_virtual_present.format(priority, virt)
-                ])
-            self.h1("Per-package minimization of unique nodes")
-            self.out.write('\n'.join(dynamic_minimization_criteria))
-            self.newline()
-
-            tmpdir = tempfile.mkdtemp()
-            tmpfile = os.path.join(tmpdir, 'tmp.lp')
-            with open(tmpfile, 'w') as f:
-                f.write('\n'.join(dynamic_minimization_criteria))
-            self.control.load(tmpfile)
 
         timer.phase("setup")
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -526,13 +526,15 @@ template_pkg_null = '#minimize {{ 0@{0} : #true}}.'
 template_pkg_present = ('#minimize {{ 1@{0},PSID1,PSID2 : '
                         'package_not_equal(PSID1, PSID2, "{1}"), '
                         'representative(PSID1, "{1}"), '
+                        'representative(PSID2, "{1}"), '
                         'node(PSID1, "{1}"), node(PSID2, "{1}") }}.')
 
 template_virtual_opt = 'opt_criterion({0}, "number of non-identical {1} providers").'
 template_virtual_null = '#minimize {{ 0@{0} : #true}}.'
 template_virtual_present = ('#minimize {{ 1@{0},PSID1,PSID2 : '
                             'virtual_not_equal(PSID1, PSID2, "{1}"), '
-                            'representative_virtual(PSID1, "{1}")}}.')
+                            'representative_virtual(PSID1, "{1}"), '
+                            'representative_virtual(PSID2, "{1}")}}.')
 
 
 class PyclingoDriver(object):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -617,6 +617,9 @@ class PyclingoDriver(object):
             path = os.path.join(parent_dir, 'concretize.lp')
             parse_files([path], visit)
 
+        if set(dump) == {'asp'}:
+            return
+
         # Load the file itself
         self.control.load(os.path.join(parent_dir, 'concretize.lp'))
         self.control.load(os.path.join(parent_dir, "display.lp"))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -604,10 +604,10 @@ class PyclingoDriver(object):
             self.backend = backend
             solver_setup.setup(self, specs_by_psid, tests=tests, reuse=reuse)
 
-            strings = []
+            dynamic_minimization_criteria = []
             for i, pkg in enumerate(sorted(set(solver_setup.possible_pkgs))):
                 priority = high_fixed_priority_offset + i
-                strings.extend([
+                dynamic_minimization_criteria.extend([
                     template_pkg_opt.format(priority, pkg),
                     template_pkg_null.format(priority),
                     template_pkg_present.format(priority, pkg)
@@ -615,19 +615,19 @@ class PyclingoDriver(object):
             virtual_offset = len(set(solver_setup.possible_pkgs))
             for i, virt in enumerate(sorted(set(solver_setup.possible_virtuals))):
                 priority = high_fixed_priority_offset + i + virtual_offset
-                strings.extend([
+                dynamic_minimization_criteria.extend([
                     template_virtual_opt.format(priority, virt),
                     template_virtual_null.format(priority),
                     template_virtual_present.format(priority, virt)
                 ])
             self.h1("Per-package minimization of unique nodes")
-            self.out.write('\n'.join(strings))
+            self.out.write('\n'.join(dynamic_minimization_criteria))
             self.newline()
 
             tmpdir = tempfile.mkdtemp()
             tmpfile = os.path.join(tmpdir, 'tmp.lp')
             with open(tmpfile, 'w') as f:
-                f.write('\n'.join(strings))
+                f.write('\n'.join(dynamic_minimization_criteria))
             self.control.load(tmpfile)
 
         timer.phase("setup")

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -99,6 +99,31 @@ DeclaredVersion = collections.namedtuple(
     'DeclaredVersion', ['version', 'idx', 'origin']
 )
 
+# Class for negating version ranges
+# This allows us to sort ascending by inverse version order
+class _InvertedVersion(object):
+    def __init__(self, version):
+        self.version = version
+
+    def __eq__(self, other):
+        return self.version == other.version
+
+    def __lt__(self, other):
+        return self.version > other.version
+
+    def __gt__(self, other):
+        return self.version < other.version
+
+    def __ne__(self, other):
+        return self.version != other.version
+
+    def __le__(self, other):
+        return self.version >= other.version
+
+    def __ge__(self, other):
+        return self.version <= other.version
+
+
 # Below numbers are used to map names of criteria to the order
 # they appear in the solution. See concretize.lp
 
@@ -745,7 +770,8 @@ class SpackSolverSetup(object):
             # 2. Externals
             # 3. Package preferences
             # 4. Directives in package.py
-            return version.origin, version.idx
+            # 5. Version itself (in reverse order)
+            return version.origin, version.idx, _InvertedVersion(version.version)
 
         pkg = packagize(pkg)
         declared_versions = self.declared_versions[pkg.name]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -148,17 +148,21 @@ def build_criteria_names(costs, tuples):
     num_criteria = len(priorities_names)
     num_build = (num_criteria - num_fixed - num_high_fixed) // 2
 
-    high_fixed = priorities_names[:num_high_fixed]
-    build = priorities_names[num_high_fixed:num_high_fixed + num_build]
-    fixed = priorities_names[num_high_fixed + num_build:num_high_fixed + num_build + num_fixed]
-    installed = priorities_names[num_high_fixed + num_build + num_fixed:]
+    build_start_idx = num_high_fixed
+    fixed_start_idx = num_high_fixed + num_build
+    installed_start_idx = num_high_fixed + num_build + num_fixed
+
+    high_fixed = priorities_names[:build_start_idx]
+    build = priorities_names[build_start_idx:fixed_start_idx]
+    fixed = priorities_names[fixed_start_idx:installed_start_idx]
+    installed = priorities_names[installed_start_idx:]
 
     # mapping from priority to index in cost list
     indices = dict((p, i) for i, (p, n) in enumerate(priorities_names))
 
     # make a list that has each name with its build and non-build priority
     criteria = [(p - high_fixed_priority_offset + 2 * num_build, None, name)
-                 for p, name in high_fixed]
+                for p, name in high_fixed]
     criteria += [
         (p - fixed_priority_offset + num_build, None, name) for p, name in fixed
     ]

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1012,7 +1012,6 @@ class SpackSolverSetup(object):
 
         return condition_id
 
-
     def impose(self, condition_id, imposed_spec, node=True, name=None, body=False):
         # impose clauses are abstract, do not require psid
         imposed_constraints = self.spec_clauses(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1187,16 +1187,8 @@ class SpackSolverSetup(object):
             return
 
         preferred = preferred_targets[0]
-
-        if self.gen.multi_root:
-            for idx in range(len(self.specs)):
-                self.gen.fact(fn.package_target_weight(
-                    idx, str(preferred.architecture.target), pkg_name, -30))
-        else:
-            # Only one process space for a single root, use 0
-            self.gen.fact(fn.package_target_weight(
-                0, str(preferred.architecture.target), pkg_name, -30
-            ))
+        self.gen.fact(fn.package_target_weight(
+            str(preferred.architecture.target), pkg_name, -30))
 
     def flag_defaults(self):
         self.gen.h2("Compiler flag defaults")

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -969,13 +969,13 @@ equality_attr("external_spec_selected").
 % Try to minimize the number of nodes of a given package
 % asp.py will generate statements of the following form for each literal "package"
 % indexed in an arbitrary but deterministic order.
-%opt_criterion(300+index, "number of non-identical package nodes").
-%#minimize { 0@300+index: #true }.
-%#minimize { 1@300+index,PSID1,PSID2 : package_not_equal(PSID1, PSID2, "package"), representative(PSID1, "package" }.
+opt_criterion(300, "number of non-identical package nodes").
+#minimize { 0@300: #true }.
+#minimize { 1@300,PSID1,PSID2,Package : package_not_equal(PSID1, PSID2, Package), representative(PSID1, Package), representative(PSID2, Package) }.
 % asp.py will generate statements of a similar form for each literal "virtual"
-%opt_criterion(300+index, "number of virtual providers")
-%#minimize { 0@300+index, #true }.
-%#minimize { 1@300+index,PSID1,PSID2 : virtual_not_equal(PSID1, PSID2, "virtual"), representative_virtual(PSID1, "virtual") }.
+opt_criterion(301, "number of virtual providers").
+#minimize { 0@301: #true }.
+#minimize { 1@301,PSID1,PSID2,Virtual : virtual_not_equal(PSID1, PSID2, Virtual), representative_virtual(PSID1, Virtual), representative_virtual(PSID2, Virtual) }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -918,6 +918,15 @@ package_not_equal(PSID1, PSID2, Package)
     not package_equal(PSID1, PSID2, Package),
     PSID1 < PSID2.
 
+% Do not tie this to whether the virtual node exists
+% because we want `mpi` and `mpich` to co-concretize
+virtual_not_equal(PSID1, PSID2, Virtual)
+ :- node(PSID1, Provider1), node(PSID2, Provider2),
+    possible_provider(Provider1, Virtual),
+    possible_provider(Provider2, Virtual),
+    PSID1 < PSID2,
+    Provider1 != Provider2.
+
 equality_attr("hash").
 equality_attr("depends_on").
 equality_attr("version").
@@ -947,6 +956,10 @@ equality_attr("external_spec_selected").
 %opt_criterion(300+index, "number of non-identical package nodes").
 %#minimize { 0@300+index: #true }.
 %#minimize { 1@300+index,PSID1,PSID2 : package_not_equal(PSID1, PSID2, "package") }.
+% asp.py will generate statements of a similar form for each literal "virtual"
+%opt_criterion(300+index, "number of virtual providers")
+%#minimize { 0@300+index, #true }.
+%#minimize { 1@300+index,PSID1,PSID2 : virtual_not_equal(PSID1, PSID2, "virtual") }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -940,7 +940,8 @@ virtual_not_equal(PSID1, PSID2, Virtual)
  :- node(PSID1, Provider1), node(PSID2, Provider2),
     possible_provider(Provider1, Virtual),
     possible_provider(Provider2, Virtual),
-    not virtual_equal(PSID1, PSID2, Virtual).
+    not virtual_equal(PSID1, PSID2, Virtual),
+    PSID1 < PSID2.
 
 equality_attr("hash").
 equality_attr("depends_on").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -870,6 +870,10 @@ representative(PSID, Package)
  :- node(PSID, Package),
     not package_equal(_, PSID, Package).
 
+representative_virtual(PSID, Virtual)
+  :- virtual_node(PSID, Virtual),
+     virtual_not_equal(_, PSID, Virtual).
+
 % Minimizing builds is tricky. We want a minimizing criterion
 
 % because we want to reuse what is avaialble, but
@@ -955,11 +959,11 @@ equality_attr("external_spec_selected").
 % indexed in an arbitrary but deterministic order.
 %opt_criterion(300+index, "number of non-identical package nodes").
 %#minimize { 0@300+index: #true }.
-%#minimize { 1@300+index,PSID1,PSID2 : package_not_equal(PSID1, PSID2, "package") }.
+%#minimize { 1@300+index,PSID1,PSID2 : package_not_equal(PSID1, PSID2, "package"), representative(PSID1, "package" }.
 % asp.py will generate statements of a similar form for each literal "virtual"
 %opt_criterion(300+index, "number of virtual providers")
 %#minimize { 0@300+index, #true }.
-%#minimize { 1@300+index,PSID1,PSID2 : virtual_not_equal(PSID1, PSID2, "virtual") }.
+%#minimize { 1@300+index,PSID1,PSID2 : virtual_not_equal(PSID1, PSID2, "virtual"), representative_virtual(PSID1, "virtual") }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -45,7 +45,7 @@ attr(Name, PSID, A1)         :- literal_process_space(LiteralID, PSID), literal(
 attr(Name, PSID, A1, A2)     :- literal_process_space(LiteralID, PSID), literal(LiteralID, Name, A1, A2).
 attr(Name, PSID, A1, A2, A3) :- literal_process_space(LiteralID, PSID), literal(LiteralID, Name, A1, A2, A3).
 
-% For these two atoms we only need implications in one direction
+% For these atoms we only need implications in one direction
 root(PSID, Package)         :- attr("root", PSID, Package).
 virtual_root(PSID, Package) :- attr("virtual_root", PSID, Package).
 
@@ -59,11 +59,6 @@ node_compiler_version_set(PSID, Package, Compiler, Version)
 
 variant_default_value_from_cli(PSID, Package, Variant, Value)
   :- attr("variant_default_value_from_cli", PSID, Package, Variant, Value).
-
-% Minimize the number of PSID in the solution
-opt_criterion(302, "number of psids").
-#minimize { 0@302 : #true }.
-#minimize { 1@302,PSID : literal_process_space(_, PSID) }.
 
 #defined literal/1.
 #defined literal/2.
@@ -262,6 +257,18 @@ virtual_node(PSID, Virtual)
 % The provider must be selected among the possible providers.
 1 { provider(PSID, Package, Virtual) : possible_provider(Package, Virtual) } 1
   :- virtual_node(PSID, Virtual), error("Virtual packages must be satisfied by a unique provider").
+
+% In any case we cannot have more than one provider for the same
+% virtual in the same process space
+:- 2 { provider(PSID, _, Virtual) }, virtual(Virtual),  process_space(PSID).
+
+% Keep track of every use of a provider, so that we can penalize it. This is
+% important when we have more than one PSID so that the best providers are
+% used the most.
+provider_used_by(PSID, Provider, Package, Virtual, Weight)
+  :- provider_weight(PSID, Provider, Virtual, Weight),
+     depends_on(PSID, Package, Provider),
+     node(PSID, Package).
 
 % virtual roots imply virtual nodes, and that one provider is a root
 virtual_node(PSID, Virtual) :- virtual_root(PSID, Virtual).
@@ -905,20 +912,6 @@ build(PSID, Package)
  :- not hash(PSID, Package, _),
     node(PSID, Package).
 
-build_representative(PSID, Package)
- :- not hash(PSID, Package, _),
-    representative(PSID, Package).
-
-representative(PSID, Package)
- :- node(PSID, Package),
-    not package_equal(_, PSID, Package).
-
-% Virtual representative may be a concrete root that provides the virtual
-representative_virtual(PSID, Virtual):
-  :- node(PSID, Provider),
-     possible_provider(Provider, Virtual),
-     not virtual_equal(_, PSID, Virtual).
-
 % Minimizing builds is tricky. We want a minimizing criterion
 
 % because we want to reuse what is avaialble, but
@@ -941,45 +934,6 @@ build_priority(PSID, Package, 0)
  :- not build(PSID, Package), node(PSID, Package).
 
 #defined installed_hash/2.
-
-%-----------------------------------------------------------------------------
-% How many of each package do we need?
-%-----------------------------------------------------------------------------
-% If two roots provide the same spec for the same package,
-% we only count it once in the optimizations
-% because we only have to build it once
-% We will then minimize within each package
-% for the number of PSIDs that are not handled by another PSID
-package_equal(PSID1, PSID2, Package)
- :- node(PSID1, Package);
-    node(PSID2, Package);
-    attr(Name, PSID1, Package) : attr(Name, PSID2, Package), equality_attr(Name);
-    attr(Name, PSID1, Package, A1) : attr(Name, PSID2, Package, A1), equality_attr(Name);
-    attr(Name, PSID1, Package, A1, A2) : attr(Name, PSID2, Package, A1, A2), equality_attr(Name);
-    attr(Name, PSID2, Package) : attr(Name, PSID1, Package), equality_attr(Name);
-    attr(Name, PSID2, Package, A1) : attr(Name, PSID1, Package, A1), equality_attr(Name);
-    attr(Name, PSID2, Package, A1, A2) : attr(Name, PSID1, Package, A1, A2), equality_attr(Name);
-    package_equal(PSID1, PSID2, Dependency) : depends_on(PSID1, Package, Dependebcy);
-    PSID1 < PSID2.
-
-package_not_equal(PSID1, PSID2, Package)
- :- node(PSID1, Package), node(PSID2, Package),
-    not package_equal(PSID1, PSID2, Package),
-    PSID1 < PSID2.
-
-% Do not tie this to whether the virtual node exists
-% because we want `mpi` and `mpich` to co-concretize
-virtual_equal(PSID1, PSID2, Virtual)
- :- node(PSID1, Provider), node(PSID2, Provider),
-    possible_provider(Provider, Virtual),
-    package_equal(PSID1, PSID2, Provider).
-
-virtual_not_equal(PSID1, PSID2, Virtual)
- :- node(PSID1, Provider1), node(PSID2, Provider2),
-    possible_provider(Provider1, Virtual),
-    possible_provider(Provider2, Virtual),
-    not virtual_equal(PSID1, PSID2, Virtual),
-    PSID1 < PSID2.
 
 equality_attr("hash").
 equality_attr("depends_on").
@@ -1004,21 +958,15 @@ equality_attr("external_spec_selected").
 %   2. a `#minimize{ 0@2 : #true }.` statement that ensures the criterion
 %      is displayed (clingo doesn't display sums over empty sets by default)
 
-% Try to minimize the number of nodes of a given package
-% asp.py will generate statements of the following form for each literal "package"
-% indexed in an arbitrary but deterministic order.
-opt_criterion(300, "number of non-identical package nodes").
-#minimize { 0@300: #true }.
-#minimize { 1@300,PSID1,PSID2,Package : package_not_equal(PSID1, PSID2, Package), representative(PSID1, Package), representative(PSID2, Package) }.
-% asp.py will generate statements of a similar form for each literal "virtual"
-opt_criterion(301, "number of virtual providers").
-#minimize { 0@301: #true }.
-#minimize { 1@301,PSID1,PSID2,Virtual : virtual_not_equal(PSID1, PSID2, Virtual), representative_virtual(PSID1, Virtual), representative_virtual(PSID2, Virtual) }.
+% Minimize the number of PSID in the solution
+opt_criterion(300, "number of psids").
+#minimize { 0@300 : #true }.
+#minimize { 1@300,PSID : literal_process_space(_, PSID) }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").
 #minimize { 0@100: #true }.
-#minimize { 1@100,Package,PSID : build_representative(PSID, Package), optimize_for_reuse() }.
+#minimize { 1@100,Package : build(PSID, Package), optimize_for_reuse() }.
 #defined optimize_for_reuse/0.
 
 % Minimize the number of deprecated versions being used
@@ -1091,8 +1039,8 @@ opt_criterion(9, "preferred providers (non-roots)").
 #minimize{ 0@209: #true }.
 #minimize{ 0@9: #true }.
 #minimize{
-    Weight@9+Priority,Provider,Virtual,PSID
-    : provider_weight(PSID, Provider, Virtual, Weight), not root(PSID, Provider),
+    Weight@9+Priority,Provider,Package,Virtual,PSID
+    : provider_used_by(PSID, Provider, Package, Virtual, Weight),
       build_priority(PSID, Provider, Priority)
 }.
 
@@ -1186,6 +1134,4 @@ opt_criterion(1, "non-preferred targets").
 #heuristic variant_value(PSID, Package, Variant, Value) : variant_default_value(PSID, Package, Variant, Value), node(PSID, Package). [10, true]
 #heuristic provider(PSID, Package, Virtual) : possible_provider_weight(PSID, Package, Virtual, 0, _), virtual_node(PSID, Virtual). [10, true]
 #heuristic node(PSID, Package) : possible_provider_weight(PSID, Package, Virtual, 0, _), virtual_node(PSID, Virtual). [10, true]
-#heuristic literal_process_space(LiteralID, 0) : literal(LiteralID). [10, true]
-#heuristic package_equal(PSID1, PSID2, Package) : node(PSID1, Package), node(PSID2, Package). [10, true]
 #heuristic literal_process_space(LiteralID, 0) : literal(LiteralID). [10, true]

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -651,7 +651,7 @@ target_weight(PSID, Target, Package, Weight)
   :- default_target_weight(Target, Weight),
      node(PSID, Package),
      not derive_target_from_parent(PSID, _, Package),
-     not package_target_weight(PSID, Target, Package, _).
+     not package_target_weight(Target, Package, _).
 
 % TODO: Need to account for the case of more than one parent
 % TODO: each of which sets different targets
@@ -661,7 +661,8 @@ target_weight(PSID, Target, Dependency, Weight)
      target_weight(PSID, Target, Package, Weight).
 
 target_weight(PSID, Target, Package, Weight)
-  :- package_target_weight(PSID, Target, Package, Weight).
+  :- node(PSID, Package),
+     package_target_weight(Target, Package, Weight).
 
 % can't use targets on node if the compiler for the node doesn't support them
 :- node_target(PSID, Package, Target),
@@ -683,7 +684,7 @@ node_target_weight(PSID, Package, Weight)
 
 derive_target_from_parent(PSID, Parent, Package)
   :- depends_on(PSID, Parent, Package),
-     not package_target_weight(PSID, _, Package, _).
+     not package_target_weight(_, Package, _).
 
 % compatibility rules for targets among nodes
 node_target_match(PSID, Parent, Dependency)
@@ -700,7 +701,7 @@ node_target_mismatch(PSID, Parent, Dependency)
    error("No satisfying package's target is compatible with this machine").
 
 #defined node_target_set/3.
-#defined package_target_weight/4.
+#defined package_target_weight/3.
 
 %-----------------------------------------------------------------------------
 % Compiler semantics

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -855,7 +855,7 @@ impose(PSID, Hash) :- hash(PSID, Package, Hash).
 build(PSID, Package)
  :- not hash(PSID, Package, _),
     node(PSID, Package),
-    not handled_by_another_root(PSID, Package).
+    not handled_by_another_process_space(PSID, Package).
 
 % Minimizing builds is tricky. We want a minimizing criterion
 
@@ -869,7 +869,8 @@ build(PSID, Package)
 % topmost-priority criterion to reuse what is installed.
 %
 % The priority ranges are:
-%   200+        Shifted priorities for build nodes; correspond to priorities 0 - 99.
+%   300+        Unshifted priorities that supersede build nodes.
+%   200 - 299   Shifted priorities for build nodes; correspond to priorities 0 - 99.
 %   100 - 199   Unshifted priorities. Currently only includes minimizing #builds.
 %   0   -  99   Priorities for non-built nodes.
 build_priority(PSID, Package, 200)
@@ -901,9 +902,19 @@ prefer_satisfier(ID1, ID2, Package)
  :- roots_equivalent_for_package(ID1, ID2, Package),
     ID1 < ID2.
 
-handled_by_another_root(PSID, Package)
+handled_by_another_process_space(PSID, Package)
  :- node(PSID, Package),
     prefer_satisfier(_, PSID, Package).
+
+% Only want to penalize the optimization for duplicates
+% Don't penalize for the first instance of a given package.
+% Arbitrarily choosing the "lowest" PSID to not penalize
+duplicate(PSID, Package)
+ :- node(PSID, Package),
+    node(OtherPSID, Package),
+    PSID != OtherPSID,
+    not roots_equivalent_for_package(PSID, OtherPSID, Package),
+    PSID > OtherPSID.
 
 %-----------------------------------------------------------------------------
 % How to optimize the spec (high to low priority)
@@ -912,6 +923,11 @@ handled_by_another_root(PSID, Package)
 %   1. an opt_criterion(ID, Name) fact that describes the criterion, and
 %   2. a `#minimize{ 0@2 : #true }.` statement that ensures the criterion
 %      is displayed (clingo doesn't display sums over empty sets by default)
+
+% Try to minimize the number of nodes of a given package
+opt_criterion(300, "agreement of nodes across process spaces").
+#minimize { 0@300: #true }.
+#minimize { 1@300,Package,PSID : duplicate(PSID, Package) }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -871,10 +871,6 @@ representative(PSID, Package)
  :- node(PSID, Package),
     not package_equal(_, PSID, Package).
 
-representative_virtual(PSID, Virtual)
-  :- virtual_node(PSID, Virtual),
-     not virtual_equal(_, PSID, Virtual).
-
 % Virtual representative may be a concrete root that provides the virtual
 representative_virtual(PSID, Virtual):
   :- node(PSID, Provider),

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -864,7 +864,10 @@ build(PSID, Package)
 
 build_representative(PSID, Package)
  :- not hash(PSID, Package, _),
-    node(PSID, Package),
+    representative(PSID, Package).
+
+representative(PSID, Package)
+ :- node(PSID, Package),
     not package_equal(_, PSID, Package).
 
 % Minimizing builds is tricky. We want a minimizing criterion
@@ -939,9 +942,11 @@ equality_attr("external_spec_selected").
 %      is displayed (clingo doesn't display sums over empty sets by default)
 
 % Try to minimize the number of nodes of a given package
-opt_criterion(300, "agreement of nodes across process spaces").
-#minimize { 0@300: #true }.
-#minimize { 1@300,Package,PSID1,PSID2 : package_not_equal(PSID1, PSID2, Package) }.
+% asp.py will generate statements of the following form for each literal "package"
+% indexed in an arbitrary but deterministic order.
+%opt_criterion(300+index, "number of non-identical package nodes").
+%#minimize { 0@300+index: #true }.
+%#minimize { 1@300+index,PSID1,PSID2 : package_not_equal(PSID1, PSID2, "package") }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -873,7 +873,13 @@ representative(PSID, Package)
 
 representative_virtual(PSID, Virtual)
   :- virtual_node(PSID, Virtual),
-     virtual_not_equal(_, PSID, Virtual).
+     not virtual_equal(_, PSID, Virtual).
+
+% Virtual representative may be a concrete root that provides the virtual
+representative_virtual(PSID, Virtual):
+  :- node(PSID, Provider),
+     possible_provider(Provider, Virtual),
+     not virtual_equal(_, PSID, Virtual).
 
 % Minimizing builds is tricky. We want a minimizing criterion
 
@@ -925,12 +931,16 @@ package_not_equal(PSID1, PSID2, Package)
 
 % Do not tie this to whether the virtual node exists
 % because we want `mpi` and `mpich` to co-concretize
+virtual_equal(PSID1, PSID2, Virtual)
+ :- node(PSID1, Provider), node(PSID2, Provider),
+    possible_provider(Provider, Virtual),
+    package_equal(PSID1, PSID2, Provider).
+
 virtual_not_equal(PSID1, PSID2, Virtual)
  :- node(PSID1, Provider1), node(PSID2, Provider2),
     possible_provider(Provider1, Virtual),
     possible_provider(Provider2, Virtual),
-    PSID1 < PSID2,
-    Provider1 != Provider2.
+    not virtual_equal(PSID1, PSID2, Virtual).
 
 equality_attr("hash").
 equality_attr("depends_on").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -800,7 +800,6 @@ node_flag_inherited(PSID, Dependency, FlagType, Flag)
 node_flag_set(PSID, Package) :- node_flag_set(PSID, Package, _, _).
 
 % remember where flags came from
-% TODO: I don't think we use node_flag_source
 node_flag_source(PSID, Package, Package) :- node_flag_set(PSID, Package).
 node_flag_source(PSID, Dependency, Q)
  :- node_flag_source(PSID, Package, Q),
@@ -832,7 +831,6 @@ node_flag(PSID, Package, FlagType, Flag)
  :- node_flag_inherited(PSID, Package, FlagType, Flag).
 
 % if no node flags are set for a type, there are no flags.
-% TODO: I don't think this is used anywhere
 no_flags(PSID, Package, FlagType)
  :- not node_flag(PSID, Package, FlagType, _), node(PSID, Package), flag_type(FlagType).
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -12,16 +12,22 @@
 %-----------------------------------------------------------------------------
 
 % each node must have a single version
-:- not 1 { version(PSID, Package, _) } 1, node(PSID, Package).
+:- not 1 { version(PSID, Package, _) } 1, node(PSID, Package),
+   error("Every node must have exactly one version").
 
 % each node must have a single platform, os and target
-:- not 1 { node_platform(PSID, Package, _) } 1, node(PSID, Package), error("A node must have exactly one platform").
-:- not 1 { node_os(PSID, Package, _) } 1, node(PSID, Package).
-:- not 1 { node_target(PSID, Package, _) } 1, node(PSID, Package).
+:- not 1 { node_platform(PSID, Package, _) } 1, node(PSID, Package),
+   error("Every node must have exactly one platform").
+:- not 1 { node_os(PSID, Package, _) } 1, node(PSID, Package),
+   error("Every node must have exactly one os").
+:- not 1 { node_target(PSID, Package, _) } 1, node(PSID, Package),
+   error("Every node must have exactly one target").
 
 % each node has a single compiler associated with it
-:- not 1 { node_compiler(PSID, Package, _) } 1, node(PSID, Package).
-:- not 1 { node_compiler_version(PSID, Package, _, _) } 1, node(PSID, Package).
+:- not 1 { node_compiler(PSID, Package, _) } 1, node(PSID, Package),
+   error("Every node must have exactly one compiler").
+:- not 1 { node_compiler_version(PSID, Package, _, _) } 1, node(PSID, Package),
+   error("Every node must have exactly one compiler_version").
 
 %-----------------------------------------------------------------------------
 % Version semantics
@@ -850,10 +856,16 @@ no_flags(PSID, Package, FlagType)
 impose(PSID, Hash) :- hash(PSID, Package, Hash).
 
 % if we haven't selected a hash for a package, we'll be building it
+% don't count it if it's a duplicate of another node
+% (arbitrarily, we are choosing the lower-numbered PSID as the one to count)
 build(PSID, Package)
  :- not hash(PSID, Package, _),
+    node(PSID, Package).
+
+build_representative(PSID, Package)
+ :- not hash(PSID, Package, _),
     node(PSID, Package),
-    not handled_by_another_process_space(PSID, Package).
+    not roots_equivalent_for_package(_, PSID, Package).
 
 % Minimizing builds is tricky. We want a minimizing criterion
 
@@ -889,30 +901,33 @@ build_priority(PSID, Package, 0)
 roots_equivalent_for_package(PSID1, PSID2, Package)
  :- node(PSID1, Package);
     node(PSID2, Package);
-    attr(Name, PSID1, Package) : attr(Name, PSID2, Package);
-    attr(Name, PSID1, Package, A1) : attr(Name, PSID2, Package, A1);
-    attr(Name, PSID1, Package, A1, A2) : attr(Name, PSID2, Package, A1, A2);
-    attr(Name, PSID2, Package) : attr(Name, PSID1, Package);
-    attr(Name, PSID2, Package, A1) : attr(Name, PSID1, Package, A1);
-    attr(Name, PSID2, Package, A1, A2) : attr(Name, PSID1, Package, A1, A2).
+    attr(Name, PSID1, Package) : attr(Name, PSID2, Package), equality_attr(Name);
+    attr(Name, PSID1, Package, A1) : attr(Name, PSID2, Package, A1), equality_attr(Name);
+    attr(Name, PSID1, Package, A1, A2) : attr(Name, PSID2, Package, A1, A2), equality_attr(Name);
+    attr(Name, PSID2, Package) : attr(Name, PSID1, Package), equality_attr(Name);
+    attr(Name, PSID2, Package, A1) : attr(Name, PSID1, Package, A1), equality_attr(Name);
+    attr(Name, PSID2, Package, A1, A2) : attr(Name, PSID1, Package, A1, A2), equality_attr(Name);
+    PSID1 < PSID2.
 
-prefer_satisfier(ID1, ID2, Package)
- :- roots_equivalent_for_package(ID1, ID2, Package),
-    ID1 < ID2.
+roots_different_for_package(PSID1, PSID2, Package)
+ :- node(PSID1, Package), node(PSID2, Package),
+    not roots_equivalent_for_package(PSID1, PSID2, Package),
+    PSID1 < PSID2.
 
-handled_by_another_process_space(PSID, Package)
- :- node(PSID, Package),
-    prefer_satisfier(_, PSID, Package).
-
-% Only want to penalize the optimization for duplicates
-% Don't penalize for the first instance of a given package.
-% Arbitrarily choosing the "lowest" PSID to not penalize
-duplicate(PSID, Package)
- :- node(PSID, Package),
-    node(OtherPSID, Package),
-    PSID != OtherPSID,
-    not roots_equivalent_for_package(PSID, OtherPSID, Package),
-    PSID > OtherPSID.
+equality_attr("hash").
+equality_attr("depends_on").
+equality_attr("version").
+equality_attr("variant_value").
+equality_attr("node_platform").
+equality_attr("node_os").
+equality_attr("node_target").
+equality_attr("node_compiler").
+equality_attr("node_compiler_version").
+equality_attr("node_flag").
+equality_attr("node_flag_compiler_default").
+equality_attr("node_flag_source").
+equality_attr("no_flags").
+equality_attr("external_spec_selected").
 
 %-----------------------------------------------------------------------------
 % How to optimize the spec (high to low priority)
@@ -924,13 +939,13 @@ duplicate(PSID, Package)
 
 % Try to minimize the number of nodes of a given package
 opt_criterion(300, "agreement of nodes across process spaces").
-#minimize { 0@300: #true }.
-#minimize { 1@300,Package,PSID : duplicate(PSID, Package) }.
+#maximize { 0@300: #true }.
+#maximize { 1@300,Package,PSID1,PSID2 : roots_equivalent_for_package(PSID1, PSID2, Package) }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").
 #minimize { 0@100: #true }.
-#minimize { 1@100,Package,PSID : build(PSID, Package), optimize_for_reuse() }.
+#minimize { 1@100,Package,PSID : build_representative(PSID, Package), optimize_for_reuse() }.
 #defined optimize_for_reuse/0.
 
 % Minimize the number of deprecated versions being used

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -865,7 +865,7 @@ build(PSID, Package)
 build_representative(PSID, Package)
  :- not hash(PSID, Package, _),
     node(PSID, Package),
-    not roots_equivalent_for_package(_, PSID, Package).
+    not package_equal(_, PSID, Package).
 
 % Minimizing builds is tricky. We want a minimizing criterion
 
@@ -898,7 +898,7 @@ build_priority(PSID, Package, 0)
 % because we only have to build it once
 % We will then minimize within each package
 % for the number of PSIDs that are not handled by another PSID
-roots_equivalent_for_package(PSID1, PSID2, Package)
+package_equal(PSID1, PSID2, Package)
  :- node(PSID1, Package);
     node(PSID2, Package);
     attr(Name, PSID1, Package) : attr(Name, PSID2, Package), equality_attr(Name);
@@ -907,11 +907,12 @@ roots_equivalent_for_package(PSID1, PSID2, Package)
     attr(Name, PSID2, Package) : attr(Name, PSID1, Package), equality_attr(Name);
     attr(Name, PSID2, Package, A1) : attr(Name, PSID1, Package, A1), equality_attr(Name);
     attr(Name, PSID2, Package, A1, A2) : attr(Name, PSID1, Package, A1, A2), equality_attr(Name);
+    package_equal(PSID1, PSID2, Dependency) : depends_on(PSID1, Package, Dependebcy);
     PSID1 < PSID2.
 
-roots_different_for_package(PSID1, PSID2, Package)
+package_not_equal(PSID1, PSID2, Package)
  :- node(PSID1, Package), node(PSID2, Package),
-    not roots_equivalent_for_package(PSID1, PSID2, Package),
+    not package_equal(PSID1, PSID2, Package),
     PSID1 < PSID2.
 
 equality_attr("hash").
@@ -939,8 +940,8 @@ equality_attr("external_spec_selected").
 
 % Try to minimize the number of nodes of a given package
 opt_criterion(300, "agreement of nodes across process spaces").
-#maximize { 0@300: #true }.
-#maximize { 1@300,Package,PSID1,PSID2 : roots_equivalent_for_package(PSID1, PSID2, Package) }.
+#minimize { 0@300: #true }.
+#minimize { 1@300,Package,PSID1,PSID2 : package_not_equal(PSID1, PSID2, Package) }.
 
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -757,8 +757,6 @@ compiler_mismatch(PSID, Package, Dependency)
   :- depends_on(PSID, Package, Dependency),
      not compiler_match(PSID, Package, Dependency).
 
-% TODO: node_compiler_set is not used
-%#defined node_compiler_set/2.
 #defined node_compiler_version_set/4.
 #defined compiler_supports_os/3.
 #defined allow_compiler/2.

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -30,6 +30,48 @@
    error("Every node must have exactly one compiler_version").
 
 %-----------------------------------------------------------------------------
+% Map literal input specs to psids
+%-----------------------------------------------------------------------------
+
+#const maxpsids=2.
+
+possible_psids(0..maxpsids).
+
+% Each input spec must have a single PSID
+1 { literal_process_space(LiteralID, PSID) : possible_psids(PSID) } 1 :- literal(LiteralID).
+
+% Map constraint on the literal ID to the correct PSID
+attr(Name, PSID, A1)         :- literal_process_space(LiteralID, PSID), literal(LiteralID, Name, A1).
+attr(Name, PSID, A1, A2)     :- literal_process_space(LiteralID, PSID), literal(LiteralID, Name, A1, A2).
+attr(Name, PSID, A1, A2, A3) :- literal_process_space(LiteralID, PSID), literal(LiteralID, Name, A1, A2, A3).
+
+% For these two atoms we only need implications in one direction
+root(PSID, Package)         :- attr("root", PSID, Package).
+virtual_root(PSID, Package) :- attr("virtual_root", PSID, Package).
+
+node_platform_set(PSID, Package, Platform) :- attr("node_platform_set", PSID, Package, Platform).
+node_os_set(PSID, Package, OS)             :- attr("node_os_set", PSID, Package, OS).
+node_target_set(PSID, Package, Target)     :- attr("node_target_set", PSID, Package, Target).
+node_flag_set(PSID, Package, Flag, Value)  :- attr("node_flag_set", PSID, Package, Flag, Value).
+
+node_compiler_version_set(PSID, Package, Compiler, Version)
+  :- attr("node_compiler_version_set", PSID, Package, Compiler, Version).
+
+variant_default_value_from_cli(PSID, Package, Variant, Value)
+  :- attr("variant_default_value_from_cli", PSID, Package, Variant, Value).
+
+% Minimize the number of PSID in the solution
+opt_criterion(302, "number of psids").
+#minimize { 0@302 : #true }.
+#minimize { 1@302,PSID : literal_process_space(_, PSID) }.
+
+#defined literal/1.
+#defined literal/2.
+#defined literal/3.
+#defined literal/4.
+#defined literal/5.
+
+%-----------------------------------------------------------------------------
 % Version semantics
 %-----------------------------------------------------------------------------
 
@@ -1144,3 +1186,6 @@ opt_criterion(1, "non-preferred targets").
 #heuristic variant_value(PSID, Package, Variant, Value) : variant_default_value(PSID, Package, Variant, Value), node(PSID, Package). [10, true]
 #heuristic provider(PSID, Package, Virtual) : possible_provider_weight(PSID, Package, Virtual, 0, _), virtual_node(PSID, Virtual). [10, true]
 #heuristic node(PSID, Package) : possible_provider_weight(PSID, Package, Virtual, 0, _), virtual_node(PSID, Virtual). [10, true]
+#heuristic literal_process_space(LiteralID, 0) : literal(LiteralID). [10, true]
+#heuristic package_equal(PSID1, PSID2, Package) : node(PSID1, Package), node(PSID2, Package). [10, true]
+#heuristic literal_process_space(LiteralID, 0) : literal(LiteralID). [10, true]

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -12,16 +12,16 @@
 %-----------------------------------------------------------------------------
 
 % each node must have a single version
-:- not 1 { version(Package, _) } 1, node(Package).
+:- not 1 { version(PSID, Package, _) } 1, node(PSID, Package).
 
 % each node must have a single platform, os and target
-:- not 1 { node_platform(Package, _) } 1, node(Package), error("A node must have exactly one platform").
-:- not 1 { node_os(Package, _) } 1, node(Package).
-:- not 1 { node_target(Package, _) } 1, node(Package).
+:- not 1 { node_platform(PSID, Package, _) } 1, node(PSID, Package), error("A node must have exactly one platform").
+:- not 1 { node_os(PSID, Package, _) } 1, node(PSID, Package).
+:- not 1 { node_target(PSID, Package, _) } 1, node(PSID, Package).
 
 % each node has a single compiler associated with it
-:- not 1 { node_compiler(Package, _) } 1, node(Package).
-:- not 1 { node_compiler_version(Package, _, _) } 1, node(Package).
+:- not 1 { node_compiler(PSID, Package, _) } 1, node(PSID, Package).
+:- not 1 { node_compiler_version(PSID, Package, _, _) } 1, node(PSID, Package).
 
 %-----------------------------------------------------------------------------
 % Version semantics
@@ -42,28 +42,27 @@ version_declared(Package, Version) :- version_declared(Package, Version, _).
 
 % If something is a package, it has only one version and that must be a
 % declared version.
-1 { version(Package, Version) : version_declared(Package, Version) } 1
- :- node(Package), error("Each node must have exactly one version").
+1 { version(PSID, Package, Version) : version_declared(Package, Version) } 1
+ :- node(PSID, Package), error("Each node must have exactly one version").
 
 % A virtual package may have or not a version, but never has more than one
-:- virtual_node(Package), 2 { version(Package, _) }.
+:- virtual_node(PSID, Virtual), 2 { version(PSID, Virtual, _) }.
 
 % If we select a deprecated version, mark the package as deprecated
-deprecated(Package, Version) :- version(Package, Version), deprecated_version(Package, Version).
+deprecated(PSID, Package, Version) :- version(PSID, Package, Version), deprecated_version(Package, Version).
 
-possible_version_weight(Package, Weight)
- :- version(Package, Version),
+possible_version_weight(PSID, Package, Weight)
+ :- version(PSID, Package, Version),
     version_declared(Package, Version, Weight).
 
-1 { version_weight(Package, Weight) : possible_version_weight(Package, Weight) } 1 :- node(Package), error("Internal error: Package version must have a unique weight").
+1 { version_weight(PSID, Package, Weight) : possible_version_weight(PSID, Package, Weight) } 1 :- node(PSID, Package), error("Internal error: Package version must have a unique weight").
 
 % version_satisfies implies that exactly one of the satisfying versions
-% is the package's version, and vice versa.
-1 { version(Package, Version) : version_satisfies(Package, Constraint, Version) } 1
-  :- version_satisfies(Package, Constraint),
+1 { version(PSID, Package, Version) : version_satisfies(Package, Constraint, Version) } 1
+  :- node_version_satisfies(PSID, Package, Constraint),
      error("no version satisfies the given constraints").
-version_satisfies(Package, Constraint)
-  :- version(Package, Version), version_satisfies(Package, Constraint, Version).
+node_version_satisfies(PSID, Package, Constraint)
+  :- version(PSID, Package, Version), version_satisfies(Package, Constraint, Version).
 
 #defined version_satisfies/3.
 #defined deprecated_version/2.
@@ -80,24 +79,26 @@ version_satisfies(Package, Constraint)
 %-----------------------------------------------------------------------------
 % conditions are specified with `condition_requirement` and hold when
 % corresponding spec attributes hold.
-condition_holds(ID) :-
-  condition(ID);
-  attr(Name, A1)         : condition_requirement(ID, Name, A1);
-  attr(Name, A1, A2)     : condition_requirement(ID, Name, A1, A2);
-  attr(Name, A1, A2, A3) : condition_requirement(ID, Name, A1, A2, A3).
 
-% condition_holds(ID) implies all imposed_constraints, unless do_not_impose(ID)
+condition_holds(PSID, ID) :-
+  condition(ID);
+  attr(Name, PSID, A1) : condition_requirement(ID, Name, A1);
+  attr(Name, PSID, A1, A2) : condition_requirement(ID, Name, A1, A2);
+  attr(Name, PSID, A1, A2, A3) : condition_requirement(ID, Name, A1, A2, A3);
+  process_space(PSID).
+
+% condition_holds(PSID, ID) implies all imposed_constraints, unless do_not_impose(PSID, ID)
 % is derived. This allows imposed constraints to be canceled in special cases.
-impose(ID) :- condition_holds(ID), not do_not_impose(ID).
+impose(PSID, ID) :- condition_holds(PSID, ID), not do_not_impose(PSID, ID).
 
 % conditions that hold impose constraints on other specs
-attr(Name, A1)         :- impose(ID), imposed_constraint(ID, Name, A1).
-attr(Name, A1, A2)     :- impose(ID), imposed_constraint(ID, Name, A1, A2).
-attr(Name, A1, A2, A3) :- impose(ID), imposed_constraint(ID, Name, A1, A2, A3).
+attr(Name, PSID, Package)         :- impose(PSID, ID), imposed_constraint(ID, Name, Package).
+attr(Name, PSID, Package, A1)     :- impose(PSID, ID), imposed_constraint(ID, Name, Package, A1).
+attr(Name, PSID, Package, A1, A2) :- impose(PSID, ID), imposed_constraint(ID, Name, Package, A1, A2).
 
 % we cannot have additional variant values when we are working with concrete specs
-:- node(Package), hash(Package, Hash),
-   variant_value(Package, Variant, Value),
+:- node(PSID, Package), hash(PSID, Package, Hash),
+   variant_value(PSID, Package, Variant, Value),
    not imposed_constraint(Hash, "variant_value", Package, Variant, Value).
 
 #defined condition/1.
@@ -111,59 +112,69 @@ attr(Name, A1, A2, A3) :- impose(ID), imposed_constraint(ID, Name, A1, A2, A3).
 %-----------------------------------------------------------------------------
 % Concrete specs
 %-----------------------------------------------------------------------------
+% TODO: I don't think this is used anywhere
 % if a package is assigned a hash, it's concrete.
-concrete(Package) :- hash(Package, _), node(Package).
+concrete(PSID, Package) :- hash(PSID, Package, _), node(PSID, Package).
 
 %-----------------------------------------------------------------------------
 % Dependency semantics
 %-----------------------------------------------------------------------------
 % Dependencies of any type imply that one package "depends on" another
-depends_on(Package, Dependency) :- depends_on(Package, Dependency, _).
+depends_on(PSID, Package, Dependency)
+ :- depends_on(PSID, Package, Dependency, _).
 
 % a dependency holds if its condition holds and if it is not external or
 % concrete. We chop off dependencies for externals, and dependencies of
 % concrete specs don't need to be resolved -- they arise from the concrete
 % specs themselves.
-dependency_holds(Package, Dependency, Type) :-
+dependency_holds(PSID, Package, Dependency, Type) :-
   dependency_condition(ID, Package, Dependency),
   dependency_type(ID, Type),
-  condition_holds(ID),
-  build(Package),
-  not external(Package).
+  condition_holds(PSID, ID),
+  build(PSID, Package),
+  not external(PSID, Package).
 
 % We cut off dependencies of externals (as we don't really know them).
 % Don't impose constraints on dependencies that don't exist.
-do_not_impose(ID) :-
-  not dependency_holds(Package, Dependency, _),
-  dependency_condition(ID, Package, Dependency).
+do_not_impose(PSID, ID) :-
+  not dependency_holds(PSID, Package, Dependency, _),
+  dependency_condition(ID, Package, Dependency),
+  node(PSID, Package).
 
 % declared dependencies are real if they're not virtual AND
 % the package is not an external.
 % They're only triggered if the associated dependnecy condition holds.
-depends_on(Package, Dependency, Type)
- :- dependency_holds(Package, Dependency, Type),
+depends_on(PSID, Package, Dependency, Type)
+ :- dependency_holds(PSID, Package, Dependency, Type),
     not virtual(Dependency).
 
 % every root must be a node
-node(Package) :- root(Package).
+node(PSID, Package) :- root(PSID, Package).
+
+% if a node is defined with a process space ID, that PSID is a process space
+process_space(PSID) :- root(PSID, _).
 
 % dependencies imply new nodes
-node(Dependency) :- node(Package), depends_on(Package, Dependency).
+node(PSID, Dependency) :- node(PSID, Package), depends_on(PSID, Package, Dependency).
 
 % all nodes in the graph must be reachable from some root
 % this ensures a user can't say `zlib ^libiconv` (neither of which have any
 % dependencies) and get a two-node unconnected graph
-needed(Package) :- root(Package).
-needed(Dependency) :- needed(Package), depends_on(Package, Dependency).
-:- node(Package), not needed(Package),
+needed(PSID, Package) :- root(PSID, Package).
+needed(PSID, Dependency) :- needed(PSID, Package),
+                              depends_on(PSID, Package, Dependency).
+:- node(PSID, Package), not needed(PSID, Package),
    error("All dependencies must be reachable from root").
 
 % Avoid cycles in the DAG
 % some combinations of conditional dependencies can result in cycles;
 % this ensures that we solve around them
-path(Parent, Child) :- depends_on(Parent, Child).
-path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
-:- path(A, B), path(B, A), error("Cyclic dependencies are not allowed").
+path(PSID, Parent, Child) :- depends_on(PSID, Parent, Child).
+path(PSID, Parent, Descendant)
+ :- path(PSID, Parent, A),
+    depends_on(PSID, A, Descendant).
+:- path(PSID, A, B), path(PSID, B, A),
+   error("Cyclic dependencies are not allowed").
 
 #defined error/1.
 
@@ -173,14 +184,15 @@ path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
 %-----------------------------------------------------------------------------
 % Conflicts
 %-----------------------------------------------------------------------------
-:- node(Package),
-   conflict(Package, TriggerID, ConstraintID),
-   condition_holds(TriggerID),
-   condition_holds(ConstraintID),
-   not external(Package),  % ignore conflicts for externals
+
+:- node(PSID, Package),
+   conflict(Package, TriggerID, ConstraintID, _),
+   condition_holds(PSID, TriggerID),
+   condition_holds(PSID, ConstraintID),
+   not external(PSID, Package),  % ignore conflicts for externals
    error("A conflict was triggered").
 
-#defined conflict/3.
+#defined conflict/4.
 
 %-----------------------------------------------------------------------------
 % Virtual dependencies
@@ -188,44 +200,44 @@ path(Parent, Descendant) :- path(Parent, A), depends_on(A, Descendant).
 
 % if a package depends on a virtual, it's not external and we have a
 % provider for that virtual then it depends on the provider
-depends_on(Package, Provider, Type)
-  :- dependency_holds(Package, Virtual, Type),
-     provider(Provider, Virtual),
-     not external(Package).
+depends_on(PSID, Package, Provider, Type)
+  :- dependency_holds(PSID, Package, Virtual, Type),
+     provider(PSID, Provider, Virtual),
+     not external(PSID, Package).
 
 % dependencies on virtuals also imply that the virtual is a virtual node
-virtual_node(Virtual)
-  :- dependency_holds(Package, Virtual, Type),
-     virtual(Virtual), not external(Package).
+virtual_node(PSID, Virtual)
+  :- dependency_holds(PSID, Package, Virtual, Type),
+     virtual(Virtual), not external(PSID, Package).
 
 % If there's a virtual node, we must select one and only one provider.
 % The provider must be selected among the possible providers.
-1 { provider(Package, Virtual) : possible_provider(Package, Virtual) } 1
-  :- virtual_node(Virtual), error("Virtual packages must be satisfied by a unique provider").
+1 { provider(PSID, Package, Virtual) : possible_provider(Package, Virtual) } 1
+  :- virtual_node(PSID, Virtual), error("Virtual packages must be satisfied by a unique provider").
 
 % virtual roots imply virtual nodes, and that one provider is a root
-virtual_node(Virtual) :- virtual_root(Virtual).
+virtual_node(PSID, Virtual) :- virtual_root(PSID, Virtual).
 
 % If we asked for a virtual root and we have a provider for that,
 % then the provider is the root package.
-root(Package) :- virtual_root(Virtual), provider(Package, Virtual).
+root(PSID, Package) :- virtual_root(PSID, Virtual), provider(PSID, Package, Virtual).
 
 % If we asked for a root package and that root provides a virtual,
 % the root is a provider for that virtual. This rule is mostly relevant
 % for environments that are concretized together (e.g. where we
 % asks to install "mpich" and "hdf5+mpi" and we want "mpich" to
 % be the mpi provider)
-provider(Package, Virtual) :- node(Package), virtual_condition_holds(Package, Virtual).
+provider(PSID, Package, Virtual) :- node(PSID, Package), virtual_condition_holds(PSID, Package, Virtual).
 
 % The provider provides the virtual if some provider condition holds.
-virtual_condition_holds(Provider, Virtual) :-
+virtual_condition_holds(PSID, Provider, Virtual) :-
    provider_condition(ID, Provider, Virtual),
-   condition_holds(ID),
+   condition_holds(PSID, ID),
    virtual(Virtual).
 
 % A package cannot be the actual provider for a virtual if it does not
 % fulfill the conditions to provide that virtual
-:- provider(Package, Virtual), not virtual_condition_holds(Package, Virtual),
+:- provider(PSID, Package, Virtual), not virtual_condition_holds(PSID, Package, Virtual),
    error("Internal error: virtual when provides not respected").
 
 #defined possible_provider/2.
@@ -237,258 +249,256 @@ virtual_condition_holds(Provider, Virtual) :-
 % A provider may have different possible weights depending on whether it's an external
 % or not, or on preferences expressed in packages.yaml etc. This rule ensures that
 % we select the weight, among the possible ones, that minimizes the overall objective function.
-1 { provider_weight(Dependency, Virtual, Weight, Reason) :
-    possible_provider_weight(Dependency, Virtual, Weight, Reason) } 1
- :- provider(Dependency, Virtual), error("Internal error: package provider weights must be unique").
+1 { provider_weight(PSID, Dependency, Virtual, Weight, Reason) :
+    possible_provider_weight(PSID, Dependency, Virtual, Weight, Reason) } 1
+ :- provider(PSID, Dependency, Virtual), error("Internal error: package provider weights must be unique").
 
 % Get rid or the reason for enabling the possible weight (useful for debugging)
-provider_weight(Dependency, Virtual, Weight) :- provider_weight(Dependency, Virtual, Weight, _).
+provider_weight(PSID, Dependency, Virtual, Weight) :- provider_weight(PSID, Dependency, Virtual, Weight, _).
 
 % A provider that is an external can use a weight of 0
-possible_provider_weight(Dependency, Virtual, 0, "external")
-  :- provider(Dependency, Virtual),
-     external(Dependency).
+possible_provider_weight(PSID, Dependency, Virtual, 0, "external")
+  :- provider(PSID, Dependency, Virtual),
+     external(PSID, Dependency).
 
 % A provider mentioned in packages.yaml can use a weight
 % according to its priority in the list of providers
-possible_provider_weight(Dependency, Virtual, Weight, "packages_yaml")
-  :- provider(Dependency, Virtual),
-     depends_on(Package, Dependency),
+possible_provider_weight(PSID, Dependency, Virtual, Weight, "packages_yaml")
+  :- provider(PSID, Dependency, Virtual),
+     depends_on(PSID, Package, Dependency),
      pkg_provider_preference(Package, Virtual, Dependency, Weight).
 
 % A provider mentioned in the default configuration can use a weight
 % according to its priority in the list of providers
-possible_provider_weight(Dependency, Virtual, Weight, "default")
-  :- provider(Dependency, Virtual),
+possible_provider_weight(PSID, Dependency, Virtual, Weight, "default")
+  :- provider(PSID, Dependency, Virtual),
      default_provider_preference(Virtual, Dependency, Weight).
 
 % Any provider can use 100 as a weight, which is very high and discourage its use
-possible_provider_weight(Dependency, Virtual, 100, "fallback") :- provider(Dependency, Virtual).
+possible_provider_weight(PSID, Dependency, Virtual, 100, "fallback") :- provider(PSID, Dependency, Virtual).
 
 #defined possible_provider/2.
 #defined provider_condition/3.
-#defined required_provider_condition/3.
-#defined required_provider_condition/4.
-#defined required_provider_condition/5.
 
 %-----------------------------------------------------------------------------
 % Spec Attributes
 %-----------------------------------------------------------------------------
 % Equivalencies of the form:
 %
-%   name(Arg1, Arg2, ...) :- attr("name", Arg1, Arg2, ...).
-%   attr("name", Arg1, Arg2, ...) :- name(Arg1, Arg2, ...).
+%   name(Arg1, Arg2, ...) :- attr("name", PSID, Arg1, Arg2, ...).
+%   attr("name", PSID, Arg1, Arg2, ...) :- name(Arg1, Arg2, ...).
 %
 % These allow us to easily define conditional dependency and conflict rules
 % without enumerating all spec attributes every time.
-node(Package)                          :- attr("node", Package).
-hash(Package, Hash)                    :- attr("hash", Package, Hash).
-version(Package, Version)              :- attr("version", Package, Version).
-version_satisfies(Package, Constraint) :- attr("version_satisfies", Package, Constraint).
-node_platform(Package, Platform)       :- attr("node_platform", Package, Platform).
-node_os(Package, OS)                   :- attr("node_os", Package, OS).
-node_target(Package, Target)           :- attr("node_target", Package, Target).
-node_target_satisfies(Package, Target) :- attr("node_target_satisfies", Package, Target).
-variant_value(Package, Variant, Value) :- attr("variant_value", Package, Variant, Value).
-variant_set(Package, Variant, Value)   :- attr("variant_set", Package, Variant, Value).
-node_flag(Package, FlagType, Flag)     :- attr("node_flag", Package, FlagType, Flag).
-node_compiler(Package, Compiler)       :- attr("node_compiler", Package, Compiler).
-depends_on(Package, Dependency, Type)  :- attr("depends_on", Package, Dependency, Type).
-node_compiler_version(Package, Compiler, Version)
-  :- attr("node_compiler_version", Package, Compiler, Version).
-node_compiler_version_satisfies(Package, Compiler, Version)
-  :- attr("node_compiler_version_satisfies", Package, Compiler, Version).
+node(PSID, Package)                          :- attr("node", PSID, Package).
+hash(PSID, Package, Hash)                    :- attr("hash", PSID, Package, Hash).
+version(PSID, Package, Version)              :- attr("version", PSID, Package, Version).
+node_version_satisfies(PSID, Package, Constraint) :- attr("node_version_satisfies", PSID, Package, Constraint).
+node_platform(PSID, Package, Platform)       :- attr("node_platform", PSID, Package, Platform).
+node_os(PSID, Package, OS)                   :- attr("node_os", PSID, Package, OS).
+node_target(PSID, Package, Target)           :- attr("node_target", PSID, Package, Target).
+node_target_satisfies(PSID, Package, Target) :- attr("node_target_satisfies", PSID, Package, Target).
+variant_value(PSID, Package, Variant, Value) :- attr("variant_value", PSID, Package, Variant, Value).
+variant_set(PSID, Package, Variant, Value)   :- attr("variant_set", PSID, Package, Variant, Value).
+node_flag(PSID, Package, FlagType, Flag)     :- attr("node_flag", PSID, Package, FlagType, Flag).
+node_compiler(PSID, Package, Compiler)       :- attr("node_compiler", PSID, Package, Compiler).
+depends_on(PSID, Package, Dependency, Type)  :- attr("depends_on", PSID, Package, Dependency, Type).
+node_compiler_version(PSID, Package, Compiler, Version)
+  :- attr("node_compiler_version", PSID, Package, Compiler, Version).
+node_compiler_version_satisfies(PSID, Package, Compiler, Version)
+  :- attr("node_compiler_version_satisfies", PSID, Package, Compiler, Version).
 
-attr("node", Package)                          :- node(Package).
-attr("hash", Package, Hash)                    :- hash(Package, Hash).
-attr("version", Package, Version)              :- version(Package, Version).
-attr("version_satisfies", Package, Constraint) :- version_satisfies(Package, Constraint).
-attr("node_platform", Package, Platform)       :- node_platform(Package, Platform).
-attr("node_os", Package, OS)                   :- node_os(Package, OS).
-attr("node_target", Package, Target)           :- node_target(Package, Target).
-attr("node_target_satisfies", Package, Target) :- node_target_satisfies(Package, Target).
-attr("variant_value", Package, Variant, Value) :- variant_value(Package, Variant, Value).
-attr("variant_set", Package, Variant, Value)   :- variant_set(Package, Variant, Value).
-attr("node_flag", Package, FlagType, Flag)     :- node_flag(Package, FlagType, Flag).
-attr("node_compiler", Package, Compiler)       :- node_compiler(Package, Compiler).
-attr("depends_on", Package, Dependency, Type)  :- depends_on(Package, Dependency, Type).
-attr("node_compiler_version", Package, Compiler, Version)
-  :- node_compiler_version(Package, Compiler, Version).
-attr("node_compiler_version_satisfies", Package, Compiler, Version)
-  :- node_compiler_version_satisfies(Package, Compiler, Version).
+attr("node", PSID, Package)                          :- node(PSID, Package).
+attr("hash", PSID, Package, Hash)                    :- hash(PSID, Package, Hash).
+attr("version", PSID, Package, Version)              :- version(PSID, Package, Version).
+attr("node_version_satisfies", PSID, Package, Constraint) :- node_version_satisfies(PSID, Package, Constraint).
+attr("node_platform", PSID, Package, Platform)       :- node_platform(PSID, Package, Platform).
+attr("node_os", PSID, Package, OS)                   :- node_os(PSID, Package, OS).
+attr("node_target", PSID, Package, Target)           :- node_target(PSID, Package, Target).
+attr("node_target_satisfies", PSID, Package, Target) :- node_target_satisfies(PSID, Package, Target).
+attr("variant_value", PSID, Package, Variant, Value) :- variant_value(PSID, Package, Variant, Value).
+attr("variant_set", PSID, Package, Variant, Value)   :- variant_set(PSID, Package, Variant, Value).
+attr("node_flag", PSID, Package, FlagType, Flag)     :- node_flag(PSID, Package, FlagType, Flag).
+attr("node_compiler", PSID, Package, Compiler)       :- node_compiler(PSID, Package, Compiler).
+attr("depends_on", PSID, Package, Dependency, Type)  :- depends_on(PSID, Package, Dependency, Type).
+attr("node_compiler_version", PSID, Package, Compiler, Version)
+  :- node_compiler_version(PSID, Package, Compiler, Version).
+attr("node_compiler_version_satisfies", PSID, Package, Compiler, Version)
+  :- node_compiler_version_satisfies(PSID, Package, Compiler, Version).
 
 % do not warn if generated program contains none of these.
-#defined depends_on/3.
+#defined depends_on/4.
 #defined declared_dependency/3.
 #defined virtual/1.
-#defined virtual_node/1.
-#defined virtual_root/1.
-#defined virtual_condition_holds/2.
-#defined external/1.
+#defined virtual_node/2.
+#defined virtual_root/2.
+#defined virtual_condition_holds/3.
+#defined external/2.
 #defined external_spec/2.
 #defined external_version_declared/4.
 #defined external_only/1.
 #defined pkg_provider_preference/4.
 #defined default_provider_preference/3.
-#defined version_satisfies/2.
-#defined node_compiler_version_satisfies/3.
-#defined root/1.
+#defined node_version_satisfies/3.
+#defined node_compiler_version_satisfies/4.
+#defined root/2.
 
 %-----------------------------------------------------------------------------
 % External semantics
 %-----------------------------------------------------------------------------
 
 % if a package is external its version must be one of the external versions
-1 { external_version(Package, Version, Weight):
+1 { external_version(PSID, Package, Version, Weight):
     version_declared(Package, Version, Weight, "external") } 1
-    :- external(Package), error("External package version does not satisfy external spec").
+    :- external(PSID, Package), error("External package version does not satisfy external spec").
 
-version_weight(Package, Weight) :- external_version(Package, Version, Weight).
-version(Package, Version) :- external_version(Package, Version, Weight).
+version_weight(PSID, Package, Weight) :- external_version(PSID, Package, Version, Weight).
+version(PSID, Package, Version) :- external_version(PSID, Package, Version, Weight).
 
 % if a package is not buildable (external_only), only externals are allowed
-external(Package) :- external_only(Package), node(Package).
+external(PSID, Package) :- external_only(Package), node(PSID, Package).
 
 % a package is a real_node if it is not external
-real_node(Package) :- node(Package), not external(Package).
+% TODO: We don't use this anywhere
+real_node(PSID, Package) :- node(PSID, Package), not external(PSID, Package).
 
 % a package is external if we are using an external spec for it
-external(Package) :- external_spec_selected(Package, _).
+external(PSID, Package) :- external_spec_selected(PSID, Package, _).
 
 % we can't use the weight for an external version if we don't use the
 % corresponding external spec.
-:- version(Package, Version),
-   version_weight(Package, Weight),
+:- version(PSID, Package, Version),
+   version_weight(PSID, Package, Weight),
    version_declared(Package, Version, Weight, "external"),
-   not external(Package),
+   not external(PSID, Package),
    error("Internal error: external weight used for internal spec").
 
 % determine if an external spec has been selected
-external_spec_selected(Package, LocalIndex) :-
-    external_conditions_hold(Package, LocalIndex),
-    node(Package).
+external_spec_selected(PSID, Package, LocalIndex) :-
+    external_conditions_hold(PSID, Package, LocalIndex),
+    node(PSID, Package).
 
-external_conditions_hold(Package, LocalIndex) :-
-    possible_external(ID, Package, LocalIndex), condition_holds(ID).
+external_conditions_hold(PSID, Package, LocalIndex) :-
+    possible_external(ID, Package, LocalIndex), condition_holds(PSID, ID).
 
 % it cannot happen that a spec is external, but none of the external specs
 % conditions hold.
-:- external(Package), not external_conditions_hold(Package, _),
+:- external(PSID, Package),
+   not external_conditions_hold(PSID, Package, _),
    error("External package does not satisfy external spec").
 
 #defined possible_external/3.
-#defined external_spec_index/3.
-#defined external_spec_condition/3.
-#defined external_spec_condition/4.
-#defined external_spec_condition/5.
 
 %-----------------------------------------------------------------------------
 % Variant semantics
 %-----------------------------------------------------------------------------
 % a variant is a variant of a package if it is a variant under some condition
 % and that condition holds
-variant(Package, Variant) :- variant_condition(ID, Package, Variant),
-                             condition_holds(ID).
+variant(PSID, Package, Variant) :- variant_condition(ID, Package, Variant),
+                             condition_holds(PSID, ID).
 
 % a variant cannot be set if it is not a variant on the package
-:- variant_set(Package, Variant),
-   not variant(Package, Variant),
-   build(Package),
+:- variant_set(PSID, Package, Variant),
+   not variant(PSID, Package, Variant),
+   build(PSID, Package),
    error("Unsatisfied conditional variants cannot be set").
 
 % a variant cannot take on a value if it is not a variant of the package
-:- variant_value(Package, Variant, _),
-   not variant(Package, Variant),
-   build(Package),
+:- variant_value(PSID, Package, Variant, _),
+   not variant(PSID, Package, Variant),
+   build(PSID, Package),
    error("Unsatisfied conditional variants cannot take on a variant value").
 
 % if a variant is sticky and not set its value is the default value
-variant_value(Package, Variant, Value) :-
-  variant(Package, Variant),
-  not variant_set(Package, Variant),
+variant_value(PSID, Package, Variant, Value) :-
+  variant(PSID, Package, Variant),
+  not variant_set(PSID, Package, Variant),
   variant_sticky(Package, Variant),
-  variant_default_value(Package, Variant, Value),
-  build(Package).
+  variant_default_value(PSID, Package, Variant, Value),
+  build(PSID, Package).
 
 % one variant value for single-valued variants.
 1 {
-  variant_value(Package, Variant, Value)
+  variant_value(PSID, Package, Variant, Value)
   : variant_possible_value(Package, Variant, Value)
 } 1
- :- node(Package),
-    variant(Package, Variant),
+ :- node(PSID, Package),
+    variant(PSID, Package, Variant),
     variant_single_value(Package, Variant),
-    build(Package),
+    build(PSID, Package),
     error("Single valued variants must have a single value").
 
 % at least one variant value for multi-valued variants.
 1 {
- variant_value(Package, Variant, Value)
+ variant_value(PSID, Package, Variant, Value)
  : variant_possible_value(Package, Variant, Value)
 }
- :- node(Package),
-    variant(Package, Variant),
+ :- node(PSID, Package),
+    variant(PSID, Package, Variant),
     not variant_single_value(Package, Variant),
-    build(Package),
+    build(PSID, Package),
     error("Internal error: All variants must have a value").
 
 % if a variant is set to anything, it is considered 'set'.
-variant_set(Package, Variant) :- variant_set(Package, Variant, _).
+variant_set(PSID, Package, Variant) :- variant_set(PSID, Package, Variant, _).
 
 % A variant cannot have a value that is not also a possible value
 % This only applies to packages we need to build -- concrete packages may
 % have been built w/different variants from older/different package versions.
-:- variant_value(Package, Variant, Value),
+:- variant_value(PSID, Package, Variant, Value),
    not variant_possible_value(Package, Variant, Value),
-   build(Package),
+   build(PSID, Package),
    error("Variant set to invalid value").
 
 % Some multi valued variants accept multiple values from disjoint sets.
 % Ensure that we respect that constraint and we don't pick values from more
 % than one set at once
-:- variant_value(Package, Variant, Value1),
-   variant_value(Package, Variant, Value2),
+:- variant_value(PSID, Package, Variant, Value1),
+   variant_value(PSID, Package, Variant, Value2),
    variant_value_from_disjoint_sets(Package, Variant, Value1, Set1),
    variant_value_from_disjoint_sets(Package, Variant, Value2, Set2),
    Set1 < Set2,
-   build(Package),
+   build(PSID, Package),
    error("Variant values selected from multiple disjoint sets").
 
 % variant_set is an explicitly set variant value. If it's not 'set',
 % we revert to the default value. If it is set, we force the set value
-variant_value(Package, Variant, Value)
- :- node(Package),
-    variant(Package, Variant),
-    variant_set(Package, Variant, Value).
+variant_value(PSID, Package, Variant, Value)
+ :- node(PSID, Package),
+    variant(PSID, Package, Variant),
+    variant_set(PSID, Package, Variant, Value).
 
 % The rules below allow us to prefer default values for variants
 % whenever possible. If a variant is set in a spec, or if it is
 % specified in an external, we score it as if it was a default value.
-variant_not_default(Package, Variant, Value)
- :- variant_value(Package, Variant, Value),
-    not variant_default_value(Package, Variant, Value),
+variant_not_default(PSID, Package, Variant, Value)
+ :- variant_value(PSID, Package, Variant, Value),
+    not variant_default_value(PSID, Package, Variant, Value),
     % variants set explicitly on the CLI don't count as non-default
-    not variant_set(Package, Variant, Value),
+    not variant_set(PSID, Package, Variant, Value),
     % variants set on externals that we could use don't count as non-default
     % this makes spack prefer to use an external over rebuilding with the
     % default configuration
-    not external_with_variant_set(Package, Variant, Value),
-    node(Package).
+    not external_with_variant_set(PSID, Package, Variant, Value),
+    node(PSID, Package).
 
 
 % A default variant value that is not used
-variant_default_not_used(Package, Variant, Value)
-  :- variant_default_value(Package, Variant, Value),
-     not variant_value(Package, Variant, Value),
-     node(Package).
+variant_default_not_used(PSID, Package, Variant, Value)
+  :- variant_default_value(PSID, Package, Variant, Value),
+     not variant_value(PSID, Package, Variant, Value),
+     node(PSID, Package).
 
 % The variant is set in an external spec
-external_with_variant_set(Package, Variant, Value)
- :- variant_value(Package, Variant, Value),
+% TODO: I think this has a subtle bug
+% What if the package is set external by a different external condition
+% than the one that conveys the requirement?
+external_with_variant_set(PSID, Package, Variant, Value)
+ :- variant_value(PSID, Package, Variant, Value),
     condition_requirement(ID, "variant_value", Package, Variant, Value),
     possible_external(ID, Package, _),
-    external(Package),
-    node(Package).
+    external(PSID, Package),
+    node(PSID, Package).
 
 % The default value for a variant in a package is what is prescribed:
 %
@@ -497,24 +507,26 @@ external_with_variant_set(Package, Variant, Value)
 % 3. In the package.py file (if there are no settings in
 %    packages.yaml and the command line)
 %
-variant_default_value(Package, Variant, Value)
+variant_default_value(PSID, Package, Variant, Value)
  :- variant_default_value_from_package_py(Package, Variant, Value),
     not variant_default_value_from_packages_yaml(Package, Variant, _),
-    not variant_default_value_from_cli(Package, Variant, _).
+    not variant_default_value_from_cli(PSID, Package, Variant, _),
+    node(PSID, Package).
 
-variant_default_value(Package, Variant, Value)
+variant_default_value(PSID, Package, Variant, Value)
  :- variant_default_value_from_packages_yaml(Package, Variant, Value),
-    not variant_default_value_from_cli(Package, Variant, _).
+    not variant_default_value_from_cli(PSID, Package, Variant, _),
+    node(PSID, Package).
 
-variant_default_value(Package, Variant, Value) :- variant_default_value_from_cli(Package, Variant, Value).
+variant_default_value(PSID, Package, Variant, Value) :- variant_default_value_from_cli(PSID, Package, Variant, Value).
 
 % Treat 'none' in a special way - it cannot be combined with other
 % values even if the variant is multi-valued
 :- 2 {
-     variant_value(Package, Variant, Value) : variant_possible_value(Package, Variant, Value)
+     variant_value(PSID, Package, Variant, Value) : variant_possible_value(Package, Variant, Value)
    },
-   variant_value(Package, Variant, "none"),
-   build(Package),
+   variant_value(PSID, Package, Variant, "none"),
+   build(PSID, Package),
    error("Variant value 'none' cannot be combined with any other value").
 
 % patches and dev_path are special variants -- they don't have to be
@@ -522,22 +534,22 @@ variant_default_value(Package, Variant, Value) :- variant_default_value_from_cli
 % when assigned a value.
 auto_variant("dev_path").
 auto_variant("patches").
-variant(Package, Variant)
-  :- variant_set(Package, Variant, _), auto_variant(Variant).
+variant(PSID, Package, Variant)
+  :- variant_set(PSID, Package, Variant, _), auto_variant(Variant).
 variant_single_value(Package, "dev_path")
-  :- variant_set(Package, "dev_path", _).
+  :- variant_set(PSID, Package, "dev_path", _).
 
 % suppress warnings about this atom being unset.  It's only set if some
 % spec or some package sets it, and without this, clingo will give
 % warnings like 'info: atom does not occur in any rule head'.
-#defined variant/2.
+#defined variant/3.
 #defined variant_sticky/2.
-#defined variant_set/3.
+#defined variant_set/4.
 #defined variant_condition/3.
 #defined variant_single_value/2.
-#defined variant_default_value/3.
+#defined variant_default_value/4.
 #defined variant_possible_value/3.
-#defined variant_default_value_from_cli/3.
+#defined variant_default_value_from_cli/4.
 #defined variant_default_value_from_packages_yaml/3.
 #defined variant_default_value_from_package_py/3.
 #defined variant_value_from_disjoint_sets/4.
@@ -547,19 +559,20 @@ variant_single_value(Package, "dev_path")
 %-----------------------------------------------------------------------------
 
 % if no platform is set, fall back to the default
-node_platform(Package, Platform)
- :- node(Package),
-    not node_platform_set(Package),
+% TODO: rename node_platform_default -- node_* implies attribute of node
+node_platform(PSID, Package, Platform)
+ :- node(PSID, Package),
+    not node_platform_set(PSID, Package),
     node_platform_default(Platform).
 
 % setting platform on a node is a hard constraint
-node_platform(Package, Platform)
- :- node(Package), node_platform_set(Package, Platform).
+node_platform(PSID, Package, Platform)
+ :- node(PSID, Package), node_platform_set(PSID, Package, Platform).
 
 % platform is set if set to anything
-node_platform_set(Package) :- node_platform_set(Package, _).
+node_platform_set(PSID, Package) :- node_platform_set(PSID, Package, _).
 
-#defined node_platform_set/2.  % avoid warnings
+#defined node_platform_set/3.  % avoid warnings
 
 %-----------------------------------------------------------------------------
 % OS semantics
@@ -568,32 +581,32 @@ node_platform_set(Package) :- node_platform_set(Package, _).
 os(OS) :- os(OS, _).
 
 % one os per node
-1 { node_os(Package, OS) : os(OS) } 1 :-
-   node(Package), error("Each node must have exactly one OS").
+1 { node_os(PSID, Package, OS) : os(OS) } 1 :-
+   node(PSID, Package), error("Each node must have exactly one OS").
 
 % can't have a non-buildable OS on a node we need to build
-:- build(Package), node_os(Package, OS), not buildable_os(OS),
+:- build(PSID, Package), node_os(PSID, Package, OS), not buildable_os(OS),
    error("No available OS can be built for").
 
 % can't have dependencies on incompatible OS's
-:- depends_on(Package, Dependency),
-   node_os(Package, PackageOS),
-   node_os(Dependency, DependencyOS),
+:- depends_on(PSID, Package, Dependency),
+   node_os(PSID, Package, PackageOS),
+   node_os(PSID, Dependency, DependencyOS),
    not os_compatible(PackageOS, DependencyOS),
-   build(Package),
+   build(PSID, Package),
    error("Dependencies must have compatible OS's with their dependents").
 
 % give OS choice weights according to os declarations
-node_os_weight(Package, Weight)
- :- node(Package),
-    node_os(Package, OS),
+node_os_weight(PSID, Package, Weight)
+ :- node(PSID, Package),
+    node_os(PSID, Package, OS),
     os(OS, Weight).
 
 % match semantics for OS's
-node_os_match(Package, Dependency) :-
-   depends_on(Package, Dependency), node_os(Package, OS), node_os(Dependency, OS).
-node_os_mismatch(Package, Dependency) :-
-   depends_on(Package, Dependency), not node_os_match(Package, Dependency).
+node_os_match(PSID, Package, Dependency) :-
+   depends_on(PSID, Package, Dependency), node_os(PSID, Package, OS), node_os(PSID, Dependency, OS).
+node_os_mismatch(PSID, Package, Dependency) :-
+   depends_on(PSID, Package, Dependency), not node_os_match(PSID, Package, Dependency).
 
 % every OS is compatible with itself. We can use `os_compatible` to declare
 os_compatible(OS, OS) :- os(OS).
@@ -603,86 +616,85 @@ os_compatible(OS, OS) :- os(OS).
 os_compatible("bigsur", "catalina").
 
 % If an OS is set explicitly respect the value
-node_os(Package, OS) :- node_os_set(Package, OS), node(Package).
+node_os(PSID, Package, OS) :- node_os_set(PSID, Package, OS), node(PSID, Package).
 
-#defined node_os_set/2.
+#defined node_os_set/3.
 #defined os_compatible/2.
 
 %-----------------------------------------------------------------------------
 % Target semantics
 %-----------------------------------------------------------------------------
-
 % Each node has only one target chosen among the known targets
-1 { node_target(Package, Target) : target(Target) } 1 :- node(Package), error("Each node must have exactly one target").
+1 { node_target(PSID, Package, Target) : target(Target) } 1 :- node(PSID, Package), error("Each node must have exactly one target").
 
 % If a node must satisfy a target constraint the choice is reduced among the targets
 % that satisfy that constraint
-1 { node_target(Package, Target) : target_satisfies(Constraint, Target) } 1
-  :- node_target_satisfies(Package, Constraint), error("Each node must have exactly one target").
+1 { node_target(PSID, Package, Target) : target_satisfies(Constraint, Target) } 1
+  :- node_target_satisfies(PSID, Package, Constraint), error("Each node must have exactly one target").
 
 % If a node has a target and the target satisfies a constraint, then the target
 % associated with the node satisfies the same constraint
-node_target_satisfies(Package, Constraint)
-  :- node_target(Package, Target), target_satisfies(Constraint, Target).
+node_target_satisfies(PSID, Package, Constraint)
+  :- node_target(PSID, Package, Target), target_satisfies(Constraint, Target).
 
 #defined target_satisfies/2.
 
 % The target weight is either the default target weight
 % or a more specific per-package weight if set
-target_weight(Target, Package, Weight)
+target_weight(PSID, Target, Package, Weight)
   :- default_target_weight(Target, Weight),
-     node(Package),
-     not derive_target_from_parent(_, Package),
-     not package_target_weight(Target, Package, _).
+     node(PSID, Package),
+     not derive_target_from_parent(PSID, _, Package),
+     not package_target_weight(PSID, Target, Package, _).
 
 % TODO: Need to account for the case of more than one parent
 % TODO: each of which sets different targets
-target_weight(Target, Dependency, Weight)
-  :- depends_on(Package, Dependency),
-     derive_target_from_parent(Package, Dependency),
-     target_weight(Target, Package, Weight).
+target_weight(PSID, Target, Dependency, Weight)
+  :- depends_on(PSID, Package, Dependency),
+     derive_target_from_parent(PSID, Package, Dependency),
+     target_weight(PSID, Target, Package, Weight).
 
-target_weight(Target, Package, Weight)
-  :- package_target_weight(Target, Package, Weight).
+target_weight(PSID, Target, Package, Weight)
+  :- package_target_weight(PSID, Target, Package, Weight).
 
 % can't use targets on node if the compiler for the node doesn't support them
-:- node_target(Package, Target),
+:- node_target(PSID, Package, Target),
    not compiler_supports_target(Compiler, Version, Target),
-   node_compiler(Package, Compiler),
-   node_compiler_version(Package, Compiler, Version),
-   build(Package),
+   node_compiler(PSID, Package, Compiler),
+   node_compiler_version(PSID, Package, Compiler, Version),
+   build(PSID, Package),
    error("No satisfying compiler available is compatible with a satisfying target").
 
 % if a target is set explicitly, respect it
-node_target(Package, Target)
- :- node(Package), node_target_set(Package, Target).
+node_target(PSID, Package, Target)
+ :- node(PSID, Package), node_target_set(PSID, Package, Target).
 
 % each node has the weight of its assigned target
-node_target_weight(Package, Weight)
- :- node(Package),
-    node_target(Package, Target),
-    target_weight(Target, Package, Weight).
+node_target_weight(PSID, Package, Weight)
+ :- node(PSID, Package),
+    node_target(PSID, Package, Target),
+    target_weight(PSID, Target, Package, Weight).
 
-derive_target_from_parent(Parent, Package)
-  :- depends_on(Parent, Package),
-     not package_target_weight(_, Package, _).
+derive_target_from_parent(PSID, Parent, Package)
+  :- depends_on(PSID, Parent, Package),
+     not package_target_weight(PSID, _, Package, _).
 
 % compatibility rules for targets among nodes
-node_target_match(Parent, Dependency)
-  :- depends_on(Parent, Dependency),
-     node_target(Parent, Target),
-     node_target(Dependency, Target).
+node_target_match(PSID, Parent, Dependency)
+  :- depends_on(PSID, Parent, Dependency),
+     node_target(PSID, Parent, Target),
+     node_target(PSID, Dependency, Target).
 
-node_target_mismatch(Parent, Dependency)
-  :- depends_on(Parent, Dependency),
-     not node_target_match(Parent, Dependency).
+node_target_mismatch(PSID, Parent, Dependency)
+  :- depends_on(PSID, Parent, Dependency),
+     not node_target_match(PSID, Parent, Dependency).
 
 % disallow reusing concrete specs that don't have a compatible target
-:- node(Package), node_target(Package, Target), not target(Target),
+:- node(PSID, Package), node_target(PSID, Package, Target), not target(Target),
    error("No satisfying package's target is compatible with this machine").
 
-#defined node_target_set/2.
-#defined package_target_weight/3.
+#defined node_target_set/3.
+#defined package_target_weight/4.
 
 %-----------------------------------------------------------------------------
 % Compiler semantics
@@ -691,75 +703,78 @@ compiler(Compiler) :- compiler_version(Compiler, _).
 
 % There must be only one compiler set per built node. The compiler
 % is chosen among available versions.
-1 { node_compiler_version(Package, Compiler, Version) : compiler_version(Compiler, Version) } 1 :-
-    node(Package),
-    build(Package),
+1 { node_compiler_version(PSID, Package, Compiler, Version) : compiler_version(Compiler, Version) } 1 :-
+    node(PSID, Package),
+    build(PSID, Package),
     error("Each node must have exactly one compiler").
 
 % Sometimes we just need to know the compiler and not the version
-node_compiler(Package, Compiler) :- node_compiler_version(Package, Compiler, _).
+node_compiler(PSID, Package, Compiler) :- node_compiler_version(PSID, Package, Compiler, _).
 
 % We can't have a compiler be enforced and select the version from another compiler
-:- node_compiler(Package, Compiler1),
-   node_compiler_version(Package, Compiler2, _),
+:- node_compiler(PSID, Package, Compiler1),
+   node_compiler_version(PSID, Package, Compiler2, _),
    Compiler1 != Compiler2,
    error("Internal error: mismatch between selected compiler and compiler version").
 
 % If the compiler of a node must satisfy a constraint, then its version
 % must be chosen among the ones that satisfy said constraint
-1 { node_compiler_version(Package, Compiler, Version)
+1 { node_compiler_version(PSID, Package, Compiler, Version)
     : compiler_version_satisfies(Compiler, Constraint, Version) } 1 :-
-    node_compiler_version_satisfies(Package, Compiler, Constraint),
+    node_compiler_version_satisfies(PSID, Package, Compiler, Constraint),
     error("Internal error: node compiler version mismatch").
 
 % If the node is associated with a compiler and the compiler satisfy a constraint, then
 % the compiler associated with the node satisfy the same constraint
-node_compiler_version_satisfies(Package, Compiler, Constraint)
-  :- node_compiler_version(Package, Compiler, Version),
+node_compiler_version_satisfies(PSID, Package, Compiler, Constraint)
+  :- node_compiler_version(PSID, Package, Compiler, Version),
      compiler_version_satisfies(Compiler, Constraint, Version),
-     build(Package).
+     build(PSID, Package).
 
 #defined compiler_version_satisfies/3.
 
 % If the compiler version was set from the command line,
 % respect it verbatim
-node_compiler_version(Package, Compiler, Version) :- node_compiler_version_set(Package, Compiler, Version).
+node_compiler_version(PSID, Package, Compiler, Version) :- node_compiler_version_set(PSID, Package, Compiler, Version).
 
 % Cannot select a compiler if it is not supported on the OS
 % Compilers that are explicitly marked as allowed
 % are excluded from this check
-:- node_compiler_version(Package, Compiler, Version), node_os(Package, OS),
+:- node_compiler_version(PSID, Package, Compiler, Version), node_os(PSID, Package, OS),
    not compiler_supports_os(Compiler, Version, OS),
    not allow_compiler(Compiler, Version),
-   build(Package),
+   build(PSID, Package),
    error("No satisfying compiler available is compatible with a satisfying os").
 
 % If a package and one of its dependencies don't have the
 % same compiler there's a mismatch.
-compiler_match(Package, Dependency)
-  :- depends_on(Package, Dependency),
-     node_compiler_version(Package, Compiler, Version),
-     node_compiler_version(Dependency, Compiler, Version).
+compiler_match(PSID, Package, Dependency)
+  :- depends_on(PSID, Package, Dependency),
+     node_compiler_version(PSID, Package, Compiler, Version),
+     node_compiler_version(PSID, Dependency, Compiler, Version).
 
-compiler_mismatch(Package, Dependency)
-  :- depends_on(Package, Dependency),
-     not compiler_match(Package, Dependency).
+compiler_mismatch(PSID, Package, Dependency)
+  :- depends_on(PSID, Package, Dependency),
+     not compiler_match(PSID, Package, Dependency).
 
-#defined node_compiler_set/2.
-#defined node_compiler_version_set/3.
+% TODO: node_compiler_set is not used
+%#defined node_compiler_set/2.
+#defined node_compiler_version_set/4.
 #defined compiler_supports_os/3.
 #defined allow_compiler/2.
 
 % compilers weighted by preference according to packages.yaml
-compiler_weight(Package, Weight)
- :- node_compiler_version(Package, Compiler, V),
+% TODO rename node_compiler_preference, it's package specific not node
+% specific
+compiler_weight(PSID, Package, Weight)
+ :- node_compiler_version(PSID, Package, Compiler, V),
     node_compiler_preference(Package, Compiler, V, Weight).
-compiler_weight(Package, Weight)
- :- node_compiler_version(Package, Compiler, V),
+compiler_weight(PSID, Package, Weight)
+ :- node_compiler_version(PSID, Package, Compiler, V),
     not node_compiler_preference(Package, Compiler, V, _),
     default_compiler_preference(Compiler, V, Weight).
-compiler_weight(Package, 100)
- :- node_compiler_version(Package, Compiler, Version),
+compiler_weight(PSID, Package, 100)
+ :- node_compiler_version(PSID, Package, Compiler, Version),
     not node_compiler_preference(Package, Compiler, Version, _),
     not default_compiler_preference(Compiler, Version, _).
 
@@ -770,68 +785,79 @@ compiler_weight(Package, 100)
 % Compiler flags
 %-----------------------------------------------------------------------------
 % propagate flags when compilers match
-inherit_flags(Package, Dependency)
- :- depends_on(Package, Dependency),
-    node_compiler(Package, Compiler),
-    node_compiler(Dependency, Compiler),
+% TODO: What is flag_type doing here?
+inherit_flags(PSID, Package, Dependency)
+ :- depends_on(PSID, Package, Dependency),
+    node_compiler(PSID, Package, Compiler),
+    node_compiler(PSID, Dependency, Compiler),
     compiler(Compiler), flag_type(FlagType).
-node_flag_inherited(Dependency, FlagType, Flag)
- :- node_flag_set(Package, FlagType, Flag), inherit_flags(Package, Dependency).
-node_flag_inherited(Dependency, FlagType, Flag)
- :- node_flag_inherited(Package, FlagType, Flag),
-    inherit_flags(Package, Dependency).
+node_flag_inherited(PSID, Dependency, FlagType, Flag)
+ :- node_flag_set(PSID, Package, FlagType, Flag),
+    inherit_flags(PSID, Package, Dependency).
+node_flag_inherited(PSID, Dependency, FlagType, Flag)
+ :- node_flag_inherited(PSID, Package, FlagType, Flag),
+    inherit_flags(PSID, Package, Dependency).
 
 % node with flags set to anythingg is "set"
-node_flag_set(Package) :- node_flag_set(Package, _, _).
+node_flag_set(PSID, Package) :- node_flag_set(PSID, Package, _, _).
 
 % remember where flags came from
-node_flag_source(Package, Package) :- node_flag_set(Package).
-node_flag_source(Dependency, Q)
- :- node_flag_source(Package, Q), inherit_flags(Package, Dependency).
+% TODO: I don't think we use node_flag_source
+node_flag_source(PSID, Package, Package) :- node_flag_set(PSID, Package).
+node_flag_source(PSID, Dependency, Q)
+ :- node_flag_source(PSID, Package, Q),
+    inherit_flags(PSID, Package, Dependency).
 
 % compiler flags from compilers.yaml are put on nodes if compiler matches
-node_flag(Package, FlagType, Flag)
- :- not node_flag_set(Package),
+% TODO: compilers could differ only in flags. Need a compiler ID to
+% differentiate
+node_flag(PSID, Package, FlagType, Flag)
+ :- not node_flag_set(PSID, Package),
     compiler_version_flag(Compiler, Version, FlagType, Flag),
-    node_compiler_version(Package, Compiler, Version),
+    node_compiler_version(PSID, Package, Compiler, Version),
     flag_type(FlagType),
     compiler(Compiler),
     compiler_version(Compiler, Version).
 
-node_flag_compiler_default(Package)
- :- not node_flag_set(Package),
+% TODO: This doesn't appear to be used
+node_flag_compiler_default(PSID, Package)
+ :- not node_flag_set(PSID, Package),
     compiler_version_flag(Compiler, Version, FlagType, Flag),
-    node_compiler_version(Package, Compiler, Version),
+    node_compiler_version(PSID, Package, Compiler, Version),
     flag_type(FlagType),
     compiler(Compiler),
     compiler_version(Compiler, Version).
 
 % if a flag is set to something or inherited, it's included
-node_flag(Package, FlagType, Flag) :- node_flag_set(Package, FlagType, Flag).
-node_flag(Package, FlagType, Flag)
- :- node_flag_inherited(Package, FlagType, Flag).
+node_flag(PSID, Package, FlagType, Flag) :- node_flag_set(PSID, Package, FlagType, Flag).
+node_flag(PSID, Package, FlagType, Flag)
+ :- node_flag_inherited(PSID, Package, FlagType, Flag).
 
 % if no node flags are set for a type, there are no flags.
-no_flags(Package, FlagType)
- :- not node_flag(Package, FlagType, _), node(Package), flag_type(FlagType).
+% TODO: I don't think this is used anywhere
+no_flags(PSID, Package, FlagType)
+ :- not node_flag(PSID, Package, FlagType, _), node(PSID, Package), flag_type(FlagType).
 
 #defined compiler_version_flag/4.
-#defined node_flag/3.
-#defined node_flag_set/3.
+#defined node_flag/4.
+#defined node_flag_set/4.
 
 
 %-----------------------------------------------------------------------------
 % Installed packages
 %-----------------------------------------------------------------------------
 % the solver is free to choose at most one installed hash for each package
-{ hash(Package, Hash) : installed_hash(Package, Hash) } 1
- :- node(Package), error("Internal error: package must resolve to at most one hash").
+{ hash(PSID, Package, Hash) : installed_hash(Package, Hash) } 1
+ :- node(PSID, Package), error("Internal error: package must resolve to at most one hash").
 
 % if a hash is selected, we impose all the constraints that implies
-impose(Hash) :- hash(Package, Hash).
+impose(PSID, Hash) :- hash(PSID, Package, Hash).
 
 % if we haven't selected a hash for a package, we'll be building it
-build(Package) :- not hash(Package, _), node(Package).
+build(PSID, Package)
+ :- not hash(PSID, Package, _),
+    node(PSID, Package),
+    not handled_by_another_root(PSID, Package).
 
 % Minimizing builds is tricky. We want a minimizing criterion
 
@@ -848,10 +874,38 @@ build(Package) :- not hash(Package, _), node(Package).
 %   200+        Shifted priorities for build nodes; correspond to priorities 0 - 99.
 %   100 - 199   Unshifted priorities. Currently only includes minimizing #builds.
 %   0   -  99   Priorities for non-built nodes.
-build_priority(Package, 200) :- build(Package), node(Package).
-build_priority(Package, 0)   :- not build(Package), node(Package).
+build_priority(PSID, Package, 200)
+ :- build(PSID, Package), node(PSID, Package).
+build_priority(PSID, Package, 0)
+ :- not build(PSID, Package), node(PSID, Package).
 
 #defined installed_hash/2.
+
+%-----------------------------------------------------------------------------
+% How many of each package do we need?
+%-----------------------------------------------------------------------------
+% If two roots provide the same spec for the same package,
+% we only count it once in the optimizations
+% because we only have to build it once
+% We will then minimize within each package
+% for the number of PSIDs that are not handled by another PSID
+roots_equivalent_for_package(PSID1, PSID2, Package)
+ :- node(PSID1, Package);
+    node(PSID2, Package);
+    attr(Name, PSID1, Package) : attr(Name, PSID2, Package);
+    attr(Name, PSID1, Package, A1) : attr(Name, PSID2, Package, A1);
+    attr(Name, PSID1, Package, A1, A2) : attr(Name, PSID2, Package, A1, A2);
+    attr(Name, PSID2, Package) : attr(Name, PSID1, Package);
+    attr(Name, PSID2, Package, A1) : attr(Name, PSID1, Package, A1);
+    attr(Name, PSID2, Package, A1, A2) : attr(Name, PSID1, Package, A1, A2).
+
+prefer_satisfier(ID1, ID2, Package)
+ :- roots_equivalent_for_package(ID1, ID2, Package),
+    ID1 < ID2.
+
+handled_by_another_root(PSID, Package)
+ :- node(PSID, Package),
+    prefer_satisfier(_, PSID, Package).
 
 %-----------------------------------------------------------------------------
 % How to optimize the spec (high to low priority)
@@ -864,7 +918,7 @@ build_priority(Package, 0)   :- not build(Package), node(Package).
 % Try hard to reuse installed packages (i.e., minimize the number built)
 opt_criterion(100, "number of packages to build (vs. reuse)").
 #minimize { 0@100: #true }.
-#minimize { 1@100,Package : build(Package), optimize_for_reuse() }.
+#minimize { 1@100,Package,PSID : build(PSID, Package), optimize_for_reuse() }.
 #defined optimize_for_reuse/0.
 
 % Minimize the number of deprecated versions being used
@@ -872,52 +926,52 @@ opt_criterion(15, "deprecated versions used").
 #minimize{ 0@215: #true }.
 #minimize{ 0@15: #true }.
 #minimize{
-    1@15+Priority,Package
-    : deprecated(Package, _),
-      build_priority(Package, Priority)
+    1@15+Priority,Package,PSID
+    : deprecated(PSID, Package, _),
+      build_priority(PSID, Package, Priority)
 }.
 
 % Minimize the:
 % 1. Version weight
 % 2. Number of variants with a non default value, if not set
-% for the root(Package)
+% for the root(PSID, Package)
 opt_criterion(14, "version weight").
 #minimize{ 0@214: #true }.
 #minimize{ 0@14: #true }.
 #minimize {
-    Weight@14+Priority
-    : root(Package),version_weight(Package, Weight),
-      build_priority(Package, Priority)
+    Weight@14+Priority,PSID
+    : root(PSID, Package),version_weight(PSID, Package, Weight),
+      build_priority(PSID, Package, Priority)
 }.
 
 opt_criterion(13, "number of non-default variants (roots)").
 #minimize{ 0@213: #true }.
 #minimize{ 0@13: #true }.
 #minimize {
-    1@13+Priority,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value),
-      root(Package),
-      build_priority(Package, Priority)
+    1@13+Priority,Package,Variant,Value,PSID
+    : variant_not_default(PSID, Package, Variant, Value),
+      root(PSID, Package),
+      build_priority(PSID, Package, Priority)
 }.
 
 opt_criterion(12, "preferred providers for roots").
 #minimize{ 0@212 : #true }.
 #minimize{ 0@12: #true }.
 #minimize{
-    Weight@12+Priority,Provider,Virtual
-    : provider_weight(Provider, Virtual, Weight),
-      root(Provider),
-      build_priority(Provider, Priority)
+    Weight@12+Priority,Provider,Virtual,PSID
+    : provider_weight(PSID, Provider, Virtual, Weight),
+      root(PSID, Provider),
+      build_priority(PSID, Provider, Priority)
 }.
 
 opt_criterion(11, "default values of variants not being used (roots)").
 #minimize{ 0@211: #true }.
 #minimize{ 0@11: #true }.
 #minimize{
-    1@11+Priority,Package,Variant,Value
-    : variant_default_not_used(Package, Variant, Value),
-      root(Package),
-      build_priority(Package, Priority)
+    1@11+Priority,Package,Variant,Value,PSID
+    : variant_default_not_used(PSID, Package, Variant, Value),
+      root(PSID, Package),
+      build_priority(PSID, Package, Priority)
 }.
 
 % Try to use default variants or variants that have been set
@@ -925,10 +979,10 @@ opt_criterion(10, "number of non-default variants (non-roots)").
 #minimize{ 0@210: #true }.
 #minimize{ 0@10: #true }.
 #minimize {
-    1@10+Priority,Package,Variant,Value
-    : variant_not_default(Package, Variant, Value),
-      not root(Package),
-      build_priority(Package, Priority)
+    1@10+Priority,Package,Variant,Value,PSID
+    : variant_not_default(PSID, Package, Variant, Value),
+      not root(PSID, Package),
+      build_priority(PSID, Package, Priority)
 }.
 
 % Minimize the weights of the providers, i.e. use as much as
@@ -937,9 +991,9 @@ opt_criterion(9, "preferred providers (non-roots)").
 #minimize{ 0@209: #true }.
 #minimize{ 0@9: #true }.
 #minimize{
-    Weight@9+Priority,Provider,Virtual
-    : provider_weight(Provider, Virtual, Weight), not root(Provider),
-      build_priority(Provider, Priority)
+    Weight@9+Priority,Provider,Virtual,PSID
+    : provider_weight(PSID, Provider, Virtual, Weight), not root(PSID, Provider),
+      build_priority(PSID, Provider, Priority)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.
@@ -947,9 +1001,9 @@ opt_criterion(8, "compiler mismatches").
 #minimize{ 0@208: #true }.
 #minimize{ 0@8: #true }.
 #minimize{
-    1@8+Priority,Package,Dependency
-    : compiler_mismatch(Package, Dependency),
-      build_priority(Package, Priority)
+    1@8+Priority,Package,Dependency,PSID
+    : compiler_mismatch(PSID, Package, Dependency),
+      build_priority(RootId, Package, Priority)
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.
@@ -957,18 +1011,18 @@ opt_criterion(7, "OS mismatches").
 #minimize{ 0@207: #true }.
 #minimize{ 0@7: #true }.
 #minimize{
-    1@7+Priority,Package,Dependency
-    : node_os_mismatch(Package, Dependency),
-      build_priority(Package, Priority)
+    1@7+Priority,Package,Dependency,PSID
+    : node_os_mismatch(PSID, Package, Dependency),
+      build_priority(PSID, Package, Priority)
 }.
 
 opt_criterion(6, "non-preferred OS's").
 #minimize{ 0@206: #true }.
 #minimize{ 0@6: #true }.
 #minimize{
-    Weight@6+Priority,Package
-    : node_os_weight(Package, Weight),
-      build_priority(Package, Priority)
+    Weight@6+Priority,Package,PSID
+    : node_os_weight(PSID, Package, Weight),
+      build_priority(PSID, Package, Priority)
 }.
 
 % Choose more recent versions for nodes
@@ -976,9 +1030,9 @@ opt_criterion(5, "version badness").
 #minimize{ 0@205: #true }.
 #minimize{ 0@5: #true }.
 #minimize{
-    Weight@5+Priority,Package
-    : version_weight(Package, Weight),
-      build_priority(Package, Priority)
+    Weight@5+Priority,Package,PSID
+    : version_weight(PSID, Package, Weight),
+      build_priority(PSID, Package, Priority)
 }.
 
 % Try to use all the default values of variants
@@ -986,10 +1040,10 @@ opt_criterion(4, "default values of variants not being used (non-roots)").
 #minimize{ 0@204: #true }.
 #minimize{ 0@4: #true }.
 #minimize{
-    1@4+Priority,Package,Variant,Value
-    : variant_default_not_used(Package, Variant, Value),
-      not root(Package),
-      build_priority(Package, Priority)
+    1@4+Priority,Package,Variant,Value,PSID
+    : variant_default_not_used(PSID, Package, Variant, Value),
+      not root(PSID, Package),
+      build_priority(PSID, Package, Priority)
 }.
 
 % Try to use preferred compilers
@@ -997,9 +1051,9 @@ opt_criterion(3, "non-preferred compilers").
 #minimize{ 0@203: #true }.
 #minimize{ 0@3: #true }.
 #minimize{
-    Weight@3+Priority,Package
-    : compiler_weight(Package, Weight),
-      build_priority(Package, Priority)
+    Weight@3+Priority,Package,PSID
+    : compiler_weight(PSID, Package, Weight),
+      build_priority(PSID, Package, Priority)
 }.
 
 % Minimize the number of mismatches for targets in the DAG, try
@@ -1008,27 +1062,27 @@ opt_criterion(2, "target mismatches").
 #minimize{ 0@202: #true }.
 #minimize{ 0@2: #true }.
 #minimize{
-    1@2+Priority,Package,Dependency
-    : node_target_mismatch(Package, Dependency),
-      build_priority(Package, Priority)
+    1@2+Priority,Package,Dependency,PSID
+    : node_target_mismatch(PSID, Package, Dependency),
+      build_priority(PSID, Package, Priority)
 }.
 
 opt_criterion(1, "non-preferred targets").
 #minimize{ 0@201: #true }.
 #minimize{ 0@1: #true }.
 #minimize{
-    Weight@1+Priority,Package
-    : node_target_weight(Package, Weight),
-      build_priority(Package, Priority)
+    Weight@1+Priority,Package,PSID
+    : node_target_weight(PSID, Package, Weight),
+      build_priority(PSID, Package, Priority)
 }.
 
 %-----------------
 % Domain heuristic
 %-----------------
-#heuristic version(Package, Version) : version_declared(Package, Version, 0), node(Package). [10, true]
-#heuristic version_weight(Package, 0) : version_declared(Package, Version, 0), node(Package). [10, true]
-#heuristic node_target(Package, Target) : default_target_weight(Target, 0), node(Package). [10, true]
-#heuristic node_target_weight(Package, 0) : node(Package). [10, true]
-#heuristic variant_value(Package, Variant, Value) : variant_default_value(Package, Variant, Value), node(Package). [10, true]
-#heuristic provider(Package, Virtual) : possible_provider_weight(Package, Virtual, 0, _), virtual_node(Virtual). [10, true]
-#heuristic node(Package) : possible_provider_weight(Package, Virtual, 0, _), virtual_node(Virtual). [10, true]
+#heuristic version(PSID, Package, Version) : version_declared(Package, Version, 0), node(PSID, Package). [10, true]
+#heuristic version_weight(PSID, Package, 0) : version_declared(Package, Version, 0), node(PSID, Package). [10, true]
+#heuristic node_target(PSID, Package, Target) : default_target_weight(Target, 0), node(PSID, Package). [10, true]
+#heuristic node_target_weight(PSID, Package, 0) : node(PSID, Package). [10, true]
+#heuristic variant_value(PSID, Package, Variant, Value) : variant_default_value(PSID, Package, Variant, Value), node(PSID, Package). [10, true]
+#heuristic provider(PSID, Package, Virtual) : possible_provider_weight(PSID, Package, Virtual, 0, _), virtual_node(PSID, Virtual). [10, true]
+#heuristic node(PSID, Package) : possible_provider_weight(PSID, Package, Virtual, 0, _), virtual_node(PSID, Virtual). [10, true]

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -28,6 +28,7 @@
 #show external_spec_selected/3.
 
 #show build/2.
+#show literal_process_space/2.
 
 % names of optimization criteria
 #show opt_criterion/2.

--- a/lib/spack/spack/solver/display.lp
+++ b/lib/spack/spack/solver/display.lp
@@ -11,26 +11,26 @@
 
 % Spec-related functions.
 % Used to build the result of the solve.
-#show node/1.
-#show hash/2.
-#show depends_on/3.
-#show version/2.
-#show variant_value/3.
-#show node_platform/2.
-#show node_os/2.
-#show node_target/2.
-#show node_compiler/2.
-#show node_compiler_version/3.
-#show node_flag/3.
-#show node_flag_compiler_default/1.
-#show node_flag_source/2.
-#show no_flags/2.
-#show external_spec_selected/2.
+#show node/2.
+#show hash/3.
+#show depends_on/4.
+#show version/3.
+#show variant_value/4.
+#show node_platform/3.
+#show node_os/3.
+#show node_target/3.
+#show node_compiler/3.
+#show node_compiler_version/4.
+#show node_flag/4.
+#show node_flag_compiler_default/2.
+#show node_flag_source/3.
+#show no_flags/3.
+#show external_spec_selected/3.
 
-#show build/1.
+#show build/2.
 
 % names of optimization criteria
 #show opt_criterion/2.
 
 % deprecated packages
-#show deprecated/2.
+#show deprecated/3.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2627,9 +2627,11 @@ class Spec(object):
                          if spec.package.provides(name)]
             name = providers[0]
 
-        assert name in answer
+        # Packages are keyed by process space and name
+        key = ('0', name)  # only root process space when concretizing a single spec
+        assert key in answer
 
-        concretized = answer[name]
+        concretized = answer[key]
         self._dup(concretized)
         self._mark_concrete()
 

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -35,12 +35,12 @@ def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):
     assert len(c['a_not_b']) == len(c['b_not_a'])
 
     # ensure that variant diffs are in here the result
-    assert ['variant_value', 'mpileaks debug False'] in c['a_not_b']
-    assert ['variant_value', 'mpileaks debug True'] in c['b_not_a']
+    assert ['variant_value', '0 mpileaks debug False'] in c['a_not_b']
+    assert ['variant_value', '0 mpileaks debug True'] in c['b_not_a']
 
     # ensure that hash diffs are in here the result
-    assert ['hash', 'mpileaks %s' % specA.dag_hash()] in c['a_not_b']
-    assert ['hash', 'mpileaks %s' % specB.dag_hash()] in c['b_not_a']
+    assert ['hash', '0 mpileaks %s' % specA.dag_hash()] in c['a_not_b']
+    assert ['hash', '0 mpileaks %s' % specB.dag_hash()] in c['b_not_a']
 
 
 def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
@@ -69,7 +69,7 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
 
     # spot check attributes in the intersection to ensure they describe the spec
     assert "intersect" in result
-    assert all(["node", dep] in result["intersect"] for dep in (
+    assert all(["node", "0 %s" % dep] in result["intersect"] for dep in (
         "mpileaks", "callpath", "dyninst", "libelf", "libdwarf", "mpich"
     ))
     assert all(
@@ -105,8 +105,8 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
                       "mpileaks/{0}".format(no_debug_hash))
     result = sjson.load(output)
 
-    assert ['hash', 'mpileaks %s' % debug_hash] in result['a_not_b']
-    assert ['variant_value', 'mpileaks debug True'] in result['a_not_b']
+    assert ['hash', '0 mpileaks %s' % debug_hash] in result['a_not_b']
+    assert ['variant_value', '0 mpileaks debug True'] in result['a_not_b']
 
-    assert ['hash', 'mpileaks %s' % no_debug_hash] in result['b_not_a']
-    assert ['variant_value', 'mpileaks debug False'] in result['b_not_a']
+    assert ['hash', '0 mpileaks %s' % no_debug_hash] in result['b_not_a']
+    assert ['variant_value', '0 mpileaks debug False'] in result['b_not_a']

--- a/lib/spack/spack/test/cmd/diff.py
+++ b/lib/spack/spack/test/cmd/diff.py
@@ -35,12 +35,12 @@ def test_diff_cmd(install_mockery, mock_fetch, mock_archive, mock_packages):
     assert len(c['a_not_b']) == len(c['b_not_a'])
 
     # ensure that variant diffs are in here the result
-    assert ['variant_value', '0 mpileaks debug False'] in c['a_not_b']
-    assert ['variant_value', '0 mpileaks debug True'] in c['b_not_a']
+    assert ['variant_value', 'mpileaks debug False'] in c['a_not_b']
+    assert ['variant_value', 'mpileaks debug True'] in c['b_not_a']
 
     # ensure that hash diffs are in here the result
-    assert ['hash', '0 mpileaks %s' % specA.dag_hash()] in c['a_not_b']
-    assert ['hash', '0 mpileaks %s' % specB.dag_hash()] in c['b_not_a']
+    assert ['hash', 'mpileaks %s' % specA.dag_hash()] in c['a_not_b']
+    assert ['hash', 'mpileaks %s' % specB.dag_hash()] in c['b_not_a']
 
 
 def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
@@ -69,7 +69,7 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
 
     # spot check attributes in the intersection to ensure they describe the spec
     assert "intersect" in result
-    assert all(["node", "0 %s" % dep] in result["intersect"] for dep in (
+    assert all(["node", "%s" % dep] in result["intersect"] for dep in (
         "mpileaks", "callpath", "dyninst", "libelf", "libdwarf", "mpich"
     ))
     assert all(
@@ -105,8 +105,8 @@ def test_load_first(install_mockery, mock_fetch, mock_archive, mock_packages):
                       "mpileaks/{0}".format(no_debug_hash))
     result = sjson.load(output)
 
-    assert ['hash', '0 mpileaks %s' % debug_hash] in result['a_not_b']
-    assert ['variant_value', '0 mpileaks debug True'] in result['a_not_b']
+    assert ['hash', 'mpileaks %s' % debug_hash] in result['a_not_b']
+    assert ['variant_value', 'mpileaks debug True'] in result['a_not_b']
 
-    assert ['hash', '0 mpileaks %s' % no_debug_hash] in result['b_not_a']
-    assert ['variant_value', '0 mpileaks debug False'] in result['b_not_a']
+    assert ['hash', 'mpileaks %s' % no_debug_hash] in result['b_not_a']
+    assert ['variant_value', 'mpileaks debug False'] in result['b_not_a']

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1387,7 +1387,7 @@ class TestConcretize(object):
         (['mpi', 'zmpi'], 2),
         (['mpi', 'mpich'], 1),
     ])
-    def test_best_effort_coconcretize(mock_packages, specs, expected):
+    def test_best_effort_coconcretize(self, mock_packages, specs, expected):
         import spack.solver.asp
         specs = [spack.spec.Spec(s) for s in specs]
         result = spack.solver.asp.solve(specs, reuse=False, multi_root=True)
@@ -1406,7 +1406,8 @@ class TestConcretize(object):
         (['hdf5', 'zmpi', 'mpich'], 'mpich', 2)
     ])
     def test_best_effort_coconcretize_preferences(
-            mock_packages, specs, expected_spec, occurances):
+            self, mock_packages, specs, expected_spec, occurances
+    ):
         """
         Test that package preferences are being respected during coconcretization.
         """

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1652,7 +1652,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --models -l --long -L --very-long -I --install-status --reuse -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats"
+        SPACK_COMPREPLY="-h --help --show --models -l --long -L --very-long -I --install-status --reuse -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats --multi-root --single-root"
     else
         _all_packages
     fi


### PR DESCRIPTION
Currently, environments can either be concretized fully together or fully separately. This works well for users who create environments for interoperable software and can use `concretization: together`. It does not allow environments with conflicting software to be concretized for maximal interoperability.

The primary use-case for this is facilities providing system software. Facilities provide multiple MPI implementations, but all software built against a given MPI ought to be interoperable.

This PR adds a `concretization` option `together_where_possible`. When this option is used, Spack will concretize specs in the environment separately, but will optimize for minimal differences in overlapping packages.

TODO:
- [x] tests
- [ ] documentation
- [x] improve optimization criterion for minimizing differences
- [x] minimize appearances of a given virtual

Stretch goal:
- [ ] dynamic optimization without writing to file