### PR TITLE
trilinos: fix x11 noheaderserror

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -564,8 +564,8 @@ class Trilinos(CMakePackage, CudaPackage):
             libs = depspec.libs
             try:
                 options.extend([
-                    define(trilinos_name + '_INCLUDE_DIRS', 
-                        depspec.headers.directories),
+                    define(trilinos_name + '_INCLUDE_DIRS',
+                           depspec.headers.directories),
                 ])
             except NoHeadersError:
                 # Handle case were depspec does not have headers

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -10,6 +10,7 @@ from spack import *
 from spack.build_environment import dso_suffix
 from spack.operating_systems.mac_os import macos_version
 from spack.pkg.builtin.kokkos import Kokkos
+from spack.error import NoHeadersError
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:
@@ -561,8 +562,16 @@ class Trilinos(CMakePackage, CudaPackage):
                 return
             depspec = spec[spack_name]
             libs = depspec.libs
+            try:
+                options.extend([
+                    define(trilinos_name + '_INCLUDE_DIRS', 
+                        depspec.headers.directories),
+                ])
+            except NoHeadersError:
+                # Handle case were depspec does not have headers
+                pass
+
             options.extend([
-                define(trilinos_name + '_INCLUDE_DIRS', depspec.headers.directories),
                 define(trilinos_name + '_ROOT', depspec.prefix),
                 define(trilinos_name + '_LIBRARY_NAMES', libs.names),
                 define(trilinos_name + '_LIBRARY_DIRS', libs.directories),

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -8,9 +8,9 @@ import sys
 
 from spack import *
 from spack.build_environment import dso_suffix
+from spack.error import NoHeadersError
 from spack.operating_systems.mac_os import macos_version
 from spack.pkg.builtin.kokkos import Kokkos
-from spack.error import NoHeadersError
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -578,23 +578,24 @@ class Trilinos(CMakePackage, CudaPackage):
             ])
 
         # Enable these TPLs explicitly from variant options.
+        # Format is (TPL name, variant name, Spack spec name)
         tpl_variant_map = [
-            ('ADIOS2', 'adios2'),
-            ('Boost', 'boost'),
-            ('CUDA', 'cuda'),
-            ('HDF5', 'hdf5'),
-            ('HYPRE', 'hypre'),
-            ('MUMPS', 'mumps'),
-            ('UMFPACK', 'suite-sparse'),
-            ('SuperLU', 'superlu'),
-            ('SuperLUDist', 'superlu-dist'),
-            ('X11', 'x11'),
+            ('ADIOS2', 'adios2', 'adios2'),
+            ('Boost', 'boost', 'boost'),
+            ('CUDA', 'cuda', 'cuda'),
+            ('HDF5', 'hdf5', 'hdf5'),
+            ('HYPRE', 'hypre', 'hypre'),
+            ('MUMPS', 'mumps', 'mumps'),
+            ('UMFPACK', 'suite-sparse', 'suite-sparse'),
+            ('SuperLU', 'superlu', 'superlu'),
+            ('SuperLUDist', 'superlu-dist', 'superlu-dist'),
+            ('X11', 'x11', 'libx11'),
         ]
         if spec.satisfies('@13.0.2:'):
             tpl_variant_map.append(('STRUMPACK', 'strumpack'))
 
-        for tpl_name, var_name in tpl_variant_map:
-            define_tpl(tpl_name, var_name, spec.variants[var_name].value)
+        for tpl_name, var_name, spec_name in tpl_variant_map:
+            define_tpl(tpl_name, spec_name, spec.variants[var_name].value)
 
         # Enable these TPLs based on whether they're in our spec; prefer to
         # require this way so that packages/features disable availability

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -592,7 +592,7 @@ class Trilinos(CMakePackage, CudaPackage):
             ('X11', 'x11', 'libx11'),
         ]
         if spec.satisfies('@13.0.2:'):
-            tpl_variant_map.append(('STRUMPACK', 'strumpack'))
+            tpl_variant_map.append(('STRUMPACK', 'strumpack', 'strumpack'))
 
         for tpl_name, var_name, spec_name in tpl_variant_map:
             define_tpl(tpl_name, spec_name, spec.variants[var_name].value)


### PR DESCRIPTION
This PR addresses two issues related to the define_tpl method in cmake_args:

1. Add a try/except block to handle dependencies which do not include headers (at issue in #27646 )
2. Add support for variant name differing from the name of the package being depended on, in particular for x11/libx11 (at issue in #27965)

