### PR TITLE
opa-psm2: Updating to 11.2.206

### DIFF
--- a/var/spack/repos/builtin/packages/opa-psm2/package.py
+++ b/var/spack/repos/builtin/packages/opa-psm2/package.py
@@ -12,6 +12,7 @@ class OpaPsm2(MakefilePackage):
     homepage = "https://github.com/cornelisnetworks/opa-psm2"
     url      = "https://github.com/cornelisnetworks/opa-psm2/archive/PSM2_10.3-8.tar.gz"
 
+    version('11.2.206', sha256='08aa41f41bdb485ee037d3f7e32dd45e79858ce38e744d33b9db2af60e3c627a')
     version('11.2.185', sha256='8c0446e989feb4a3822791e4a3687060916f7c4612d1e8e493879be66f10db09')
     version('11.2.77', sha256='5cc33d1e19d871a5861efe0bb897526f404b4bf2b88ac58bb277db96ac5ecb54')
     version('11.2.68', sha256='42e16a14fc8c90b50855dcea46af3315bee32fb1ae89d83060f9b2ebdce1ec26')


### PR DESCRIPTION
This version fixes build errors with newer gcc versions.