### PR TITLE
add option to minimize full debug cores. include warning message about performance

### DIFF
--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -123,33 +123,10 @@ class UnsatisfiableSpecError(SpecError):
     For original concretizer, provide the requirement that was violated when
     raising.
     """
-    def __init__(self, provided, required=None, constraint_type=None, conflicts=None):
-        # required is only set by the original concretizer.
-        # clingo concretizer handles error messages differently.
-        if required is not None:
-            assert not conflicts  # can't mix formats
-            super(UnsatisfiableSpecError, self).__init__(
-                "%s does not satisfy %s" % (provided, required))
-        else:
-            import spack.solver.asp as solver  # avoid circular import
-
-            indented = ['  %s\n' % conflict for conflict in conflicts]
-            conflict_msg = ''.join(indented)
-            issue = 'conflicts' if solver.full_cores else 'errors'
-            msg = '%s is unsatisfiable, %s are:\n%s' % (provided, issue, conflict_msg)
-
-            newline_indent = '\n    '
-            if not solver.full_cores:
-                msg += newline_indent + 'To see full clingo unsat cores, '
-                msg += 're-run with `spack --show-cores=full`'
-            if not solver.minimize_cores or not solver.full_cores:
-                # not solver.minimalize_cores and not solver.full_cores impossible
-                msg += newline_indent + 'For full, subset-minimal unsat cores, '
-                msg += 're-run with `spack --show-cores=minimized'
-                msg += newline_indent
-                msg += 'Warning: This may take (up to) hours for some specs'
-
-            super(UnsatisfiableSpecError, self).__init__(msg)
+    def __init__(self, provided, required, constraint_type):
+        # This is only the entrypoint for old concretizer errors
+        super(UnsatisfiableSpecError, self).__init__(
+            "%s does not satisfy %s" % (provided, required))
 
         self.provided = provided
         self.required = required

--- a/lib/spack/spack/error.py
+++ b/lib/spack/spack/error.py
@@ -14,6 +14,10 @@ import llnl.util.tty as tty
 #: this is module-scoped because it needs to be set very early
 debug = False
 
+#: whether we should write ASP unsat cores quickly in debug mode when the cores
+#: may be very large or take the time (sometimes hours) to minimize them
+minimize_cores = False
+
 
 class SpackError(Exception):
     """This is the superclass for all Spack errors.
@@ -134,7 +138,19 @@ class UnsatisfiableSpecError(SpecError):
             indented = ['  %s\n' % conflict for conflict in conflicts]
             conflict_msg = ''.join(indented)
             msg = '%s is unsatisfiable, conflicts are:\n%s' % (provided, conflict_msg)
+
+            newline_indent = '\n    '
+            if not debug:
+                msg += newline_indent
+                msg += 'To see full clingo unsat cores, re-run with `spack -d`'
+            if not debug or not minimize_cores:
+                msg += newline_indent
+                msg += 'For minimal full cores, re-run with `spack -d --minimize-cores'
+                msg += newline_indent
+                msg += 'Warning: This may take (up to) hours for some specs'
+
             super(UnsatisfiableSpecError, self).__init__(msg)
+
         self.provided = provided
         self.required = required
         self.constraint_type = constraint_type

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -41,6 +41,7 @@ import spack.modules
 import spack.paths
 import spack.platforms
 import spack.repo
+import spack.solver.asp
 import spack.spec
 import spack.store
 import spack.util.debug
@@ -380,6 +381,13 @@ def make_argument_parser(**kwargs):
     # stat names in groups of 7, for nice wrapping.
     stat_lines = list(zip(*(iter(stat_names),) * 7))
 
+    # help message for --show-cores
+    show_cores_help = 'provide additional information on concretization failures\n'
+    show_cores_help += 'off (default): show only the violated rule\n'
+    show_cores_help += 'full: show raw unsat cores from clingo\n'
+    show_cores_help += 'minimized: show subset-minimal unsat cores '
+    show_cores_help += '(Warning: this may take hours for some specs)'
+
     parser.add_argument(
         '-h', '--help',
         dest='help', action='store_const', const='short', default=None,
@@ -404,9 +412,8 @@ def make_argument_parser(**kwargs):
         help="write out debug messages "
              "(more d's for more verbosity: -d, -dd, -ddd, etc.)")
     parser.add_argument(
-        '--minimize-cores', action='store_true',
-        help=("minimize concretizer cores when run in debug mode"
-              " (Warning: may take hours for some specs)"))
+        '--show-cores', choices=["off", "full", "minimized"], default="off",
+        help=show_cores_help)
     parser.add_argument(
         '--timestamp', action='store_true',
         help="Add a timestamp to tty output")
@@ -490,8 +497,12 @@ def setup_main_options(args):
         spack.config.set('config:debug', True, scope='command_line')
         spack.util.environment.tracing_enabled = True
 
-    if args.minimize_cores:
-        spack.error.minimize_cores = True
+    if args.show_cores != "off":
+        # minimize_cores defaults to true, turn it off if we're showing full core
+        # but don't want to wait to minimize it.
+        spack.solver.asp.full_cores = True
+        if args.show_cores == 'full':
+            spack.solver.asp.minimize_cores = False
 
     if args.timestamp:
         tty.set_timestamp(True)

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -404,6 +404,10 @@ def make_argument_parser(**kwargs):
         help="write out debug messages "
              "(more d's for more verbosity: -d, -dd, -ddd, etc.)")
     parser.add_argument(
+        '--minimize-cores', action='store_true',
+        help=("minimize concretizer cores when run in debug mode"
+              " (Warning: may take hours for some specs)"))
+    parser.add_argument(
         '--timestamp', action='store_true',
         help="Add a timestamp to tty output")
     parser.add_argument(
@@ -485,6 +489,9 @@ def setup_main_options(args):
         spack.util.debug.register_interrupt_handler()
         spack.config.set('config:debug', True, scope='command_line')
         spack.util.environment.tracing_enabled = True
+
+    if args.minimize_cores:
+        spack.error.minimize_cores = True
 
     if args.timestamp:
         tty.set_timestamp(True)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -393,8 +393,11 @@ class Result(object):
         if len(constraints) == 1:
             constraints = constraints[0]
 
+        # debug cores may be costly to minimize
+        # only minimize them if explicitly requested
         debug = spack.config.get('config:debug', False)
-        conflicts = self.format_cores() if debug else self.format_minimal_cores()
+        raw_cores = debug and not spack.error.minimize_cores
+        conflicts = self.format_cores() if raw_cores else self.format_minimal_cores()
 
         raise spack.error.UnsatisfiableSpecError(constraints, conflicts=conflicts)
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -557,11 +557,13 @@ class TestConcretize(object):
         with pytest.raises(spack.error.SpackError):
             s.concretize()
 
-    def test_conflicts_new_concretizer_debug(self, conflict_spec, mutable_config):
+    def test_conflicts_show_cores(self, conflict_spec, monkeypatch):
         if spack.config.get('config:concretizer') == 'original':
             pytest.skip('Testing debug statements specific to new concretizer')
 
-        spack.config.set('config:debug', True)
+        monkeypatch.setattr(spack.solver.asp, 'full_cores', True)
+        monkeypatch.setattr(spack.solver.asp, 'minimize_cores', False)
+
         s = Spec(conflict_spec)
         with pytest.raises(spack.error.SpackError) as e:
             s.concretize()

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -335,7 +335,7 @@ _spacktivate() {
 _spack() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
+        SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --minimize-cores --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         SPACK_COMPREPLY="activate add analyze arch audit blame bootstrap build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers mark mirror module monitor patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -335,7 +335,7 @@ _spacktivate() {
 _spack() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --minimize-cores --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
+        SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --show-cores --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
         SPACK_COMPREPLY="activate add analyze arch audit blame bootstrap build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers mark mirror module monitor patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi


### PR DESCRIPTION
Getting good error messages out of clingo has proven tricky. One option is to simply take the performance hit on failed specs and spend the time to minimize the full ASP unsat core.

This PR provides a command line option exposing this ability to users, and appropriate warning messages about the potential performance costs.