### PR TITLE
py-trojanzoo-sphinx-theme: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-trojanzoo-sphinx-theme/package.py
+++ b/var/spack/repos/builtin/packages/py-trojanzoo-sphinx-theme/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyTrojanzooSphinxTheme(PythonPackage):
+    """TrojanZoo Sphinx Theme"""
+
+    homepage = "https://github.com/ain-soph/trojanzoo_sphinx_theme"
+    pypi     = "trojanzoo_sphinx_theme/trojanzoo_sphinx_theme-0.1.0.tar.gz"
+
+    version('0.1.0', sha256='7b80d70ec84279156dcb9668d3a8a135be1d0d54e20f554fc03ad22d9ff5e7b3')
+
+    depends_on('python@3:', type=('build', 'run'))
+    depends_on('py-setuptools@40.9:', type='build')
+    depends_on('py-sphinx@4.2:', type=('build', 'run'))
+    depends_on('py-docutils@0.17.1:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.

Depends on #27933 