### PR TITLE
Python: default to 3.9

### DIFF
--- a/var/spack/repos/builtin/packages/py-hatchet/package.py
+++ b/var/spack/repos/builtin/packages/py-hatchet/package.py
@@ -23,7 +23,7 @@ class PyHatchet(PythonPackage):
     version('1.0.0', sha256='efd218bc9152abde0a8006489a2c432742f00283a114c1eeb6d25abc10f5862d')
 
     # https://github.com/hatchet/hatchet/issues/428
-    depends_on('python@2.7:3.8', type=('build', 'run'))
+    depends_on('python@2.7:3.8', when='@:1.3.0', type=('build', 'run'))
     depends_on('python@2.7:', when='@1.3.1:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-hatchet/package.py
+++ b/var/spack/repos/builtin/packages/py-hatchet/package.py
@@ -22,7 +22,9 @@ class PyHatchet(PythonPackage):
     version('1.0.1', sha256='e5a4b455ab6bfbccbce3260673d9af8d1e4b21e19a2b6d0b6c1e1d7727613b7a')
     version('1.0.0', sha256='efd218bc9152abde0a8006489a2c432742f00283a114c1eeb6d25abc10f5862d')
 
-    depends_on('python@2.7,3:', type=('build', 'run'))
+    # https://github.com/hatchet/hatchet/issues/428
+    depends_on('python@2.7:3.8', type=('build', 'run'))
+    depends_on('python@2.7:', when='@1.3.1:', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
     depends_on('py-matplotlib', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -39,6 +39,24 @@ class PyPyzmq(PythonPackage):
     depends_on('py-py', type=('build', 'run'), when='@:22')
     depends_on('py-cffi', type=('build', 'run'), when='@:22')
 
+    @run_before('install')
+    def setup(self):
+        """Create config file listing dependency information."""
+
+        with open('setup.cfg', 'w') as config:
+            config.write("""\
+[global]
+zmq_prefix = {0}
+
+[build_ext]
+library_dirs = {1}
+include_dirs = {2}
+""".format(
+                self.spec['libzmq'].prefix,
+                self.spec['libzmq'].libs.directories[0],
+                self.spec['libzmq'].headers.directories[0],
+            ))
+
     def setup_build_environment(self, env):
         # Needed for `spack install --test=root py-pyzmq`
         # Fixes import failure for zmq.backend.cffi

--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -27,8 +27,9 @@ class PyPyzmq(PythonPackage):
     version('14.7.0', sha256='77994f80360488e7153e64e5959dc5471531d1648e3a4bff14a714d074a38cc2')
 
     # Python 3.9 build issues
-    depends_on('python@2.7:2.8,3.3:3.8', type=('build', 'run'), when='@18:')
-    depends_on('python@3.6:3.8', type=('build', 'run'), when='@22.3.0:')
+    depends_on('python@3.6:3.8', type=('build', 'run'), when='@22:')
+    depends_on('python@2.7,3.3:3.8', type=('build', 'run'), when='@16:18')
+    depends_on('python@2.6:2.7,3.2:3.8', type=('build', 'run'), when='@:14')
     depends_on('py-cython@0.16:', type='build')
     depends_on('py-cython@0.20:', type='build', when='@18:')
     depends_on('py-cython@0.29:', type='build', when='@22.3.0:')

--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -26,8 +26,9 @@ class PyPyzmq(PythonPackage):
     version('16.0.2', sha256='0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d')
     version('14.7.0', sha256='77994f80360488e7153e64e5959dc5471531d1648e3a4bff14a714d074a38cc2')
 
-    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'), when='@18:')
-    depends_on('python@3.6:', type=('build', 'run'), when='@22.3.0:')
+    # Python 3.9 build issues
+    depends_on('python@2.7:2.8,3.3:3.8', type=('build', 'run'), when='@18:')
+    depends_on('python@3.6:3.8', type=('build', 'run'), when='@22.3.0:')
     depends_on('py-cython@0.16:', type='build')
     depends_on('py-cython@0.20:', type='build', when='@18:')
     depends_on('py-cython@0.29:', type='build', when='@22.3.0:')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -27,16 +27,19 @@ class Python(AutotoolsPackage):
 
     maintainers = ['adamjstewart', 'skosukhin']
 
-    version('3.9.9',  sha256='2cc7b67c1f3f66c571acc42479cdf691d8ed6b47bee12c9b68430413a17a44ea')
+    version('3.10.1', sha256='b76117670e7c5064344b9c138e141a377e686b9063f3a8a620ff674fa8ec90d3')
+    version('3.10.0', sha256='c4e0cbad57c90690cb813fb4663ef670b4d0f587d8171e2c42bd4c9245bd2758')
+    version('3.9.9',  sha256='2cc7b67c1f3f66c571acc42479cdf691d8ed6b47bee12c9b68430413a17a44ea', preferred=True)
     version('3.9.8',  sha256='7447fb8bb270942d620dd24faa7814b1383b61fa99029a240025fd81c1db8283')
     version('3.9.7',  sha256='a838d3f9360d157040142b715db34f0218e535333696a5569dc6f854604eb9d1')
     version('3.9.6',  sha256='d0a35182e19e416fc8eae25a3dcd4d02d4997333e4ad1f2eee6010aadc3fe866')
     version('3.9.5',  sha256='e0fbd5b6e1ee242524430dee3c91baf4cbbaba4a72dd1674b90fda87b713c7ab')
     version('3.9.4',  sha256='66c4de16daa74a825cf9da9ddae1fe020b72c3854b73b1762011cc33f9e4592f')
+    version('3.9.3',  sha256='3afeb61a45b5a2e6f1c0f621bd8cf925a4ff406099fdb3d8c97b993a5f43d048')
     version('3.9.2',  sha256='7899e8a6f7946748830d66739f2d8f2b30214dad956e56b9ba216b3de5581519')
     version('3.9.1',  sha256='29cb91ba038346da0bd9ab84a0a55a845d872c341a4da6879f462e94c741f117')
     version('3.9.0',  sha256='df796b2dc8ef085edae2597a41c1c0a63625ebd92487adaef2fed22b567873e8')
-    version('3.8.12', sha256='316aa33f3b7707d041e73f246efedb297a70898c4b91f127f66dc8d80c596f1a', preferred=True)
+    version('3.8.12', sha256='316aa33f3b7707d041e73f246efedb297a70898c4b91f127f66dc8d80c596f1a')
     version('3.8.11', sha256='b77464ea80cec14581b86aeb7fb2ff02830e0abc7bcdc752b7b4bdfcd8f3e393')
     version('3.8.10', sha256='b37ac74d2cbad2590e7cd0dd2b3826c29afe89a734090a87bf8c03c45066cb65')
     version('3.8.9',  sha256='9779ec1df000bf86914cdd40860b88da56c1e61db59d37784beca14a259ac9e9')
@@ -207,7 +210,8 @@ class Python(AutotoolsPackage):
     patch('tkinter.patch', when='@:2.8,3.3:3.7 platform=darwin')
     # Patch the setup script to deny that tcl/x11 exists rather than allowing
     # autodetection of (possibly broken) system components
-    patch('tkinter-3.8.patch', when='@3.8: ~tkinter')
+    patch('tkinter-3.8.patch', when='@3.8:3.9 ~tkinter')
+    patch('tkinter-3.10.patch', when='@3.10: ~tkinter')
 
     # Ensure that distutils chooses correct compiler option for RPATH on cray:
     patch('cray-rpath-2.3.patch', when='@2.3:3.0.1 platform=cray')

--- a/var/spack/repos/builtin/packages/python/tkinter-3.10.patch
+++ b/var/spack/repos/builtin/packages/python/tkinter-3.10.patch
@@ -1,0 +1,11 @@
+--- a/setup.py	2021-12-06 12:23:39.000000000 -0600
++++ b/setup.py	2021-12-14 10:30:33.000000000 -0600
+@@ -2099,6 +2099,8 @@
+         #
+         # Detection stops at the first successful method.
+ 
++        return False
++
+         # Check for Tcl and Tk at the locations indicated by _TCLTK_INCLUDES
+         # and _TCLTK_LIBS environment variables.
+         if self.detect_tkinter_fromenv():

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -103,7 +103,8 @@ class Tau(Package):
     depends_on('elf', when='+elf')
     # TAU requires the ELF header support, libiberty and demangle.
     depends_on('binutils@:2.33.1+libiberty+headers+plugins', when='+binutils')
-    depends_on('python@2.7:', when='+python')
+    # Build errors with Python 3.9
+    depends_on('python@2.7:3.8', when='+python')
     depends_on('libunwind', when='+libunwind')
     depends_on('mpi', when='+mpi', type=('build', 'run', 'link'))
     depends_on('cuda', when='+cuda')


### PR DESCRIPTION
Both [Anaconda](https://www.anaconda.com/products/individual) and [Homebrew](https://formulae.brew.sh/formula/python@3.9) now default to Python 3.9, so Spack should follow suit.

I also added Python 3.10 while I was at it. Confirmed that it builds successfully on macOS 10.15.7 with Apple Clang 12.0.0. I'm unable to test the Cray and Fujitsu patches.

Fixes #27921