### PR TITLE
CI: test Spack with Python 3.10

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -152,7 +152,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Install dependencies
         run: |
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
       - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
     - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
     - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
     - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: spack install
       run: |
         . .github/workflows/install_spack.sh

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
     - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install Python Packages
       run: |
         pip install --upgrade pip
@@ -36,7 +36,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install Python packages
       run: |
         pip install --upgrade pip six setuptools types-six
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
         concretizer: ['original', 'clingo']
     steps:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
@@ -165,7 +165,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install System packages
       run: |
           sudo apt-get -y update
@@ -231,7 +231,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install System packages
       run: |
           sudo apt-get -y update
@@ -323,7 +323,7 @@ jobs:
     - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # @v2
     - uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # @v2
       with:
-        python-version: 3.9
+        python-version: '3.10'
     - name: Install Python packages
       run: |
         pip install --upgrade pip six setuptools pytest codecov coverage[toml]

--- a/lib/spack/docs/contribution_guide.rst
+++ b/lib/spack/docs/contribution_guide.rst
@@ -71,7 +71,7 @@ locally to speed up the review process.
    new release that is causing problems. If this is the case, please file an issue.
 
 
-We currently test against Python 2.7 and 3.5-3.9 on both macOS and Linux and
+We currently test against Python 2.7 and 3.5-3.10 on both macOS and Linux and
 perform 3 types of tests:
 
 .. _cmd-spack-unit-test:

--- a/lib/spack/docs/tables/system_prerequisites.csv
+++ b/lib/spack/docs/tables/system_prerequisites.csv
@@ -1,5 +1,5 @@
 Name, Supported Versions, Notes, Requirement Reason
-Python, 2.7/3.5-3.9, , Interpreter for Spack
+Python, 2.7/3.5-3.10, , Interpreter for Spack
 C/C++ Compilers, , , Building software
 make, , , Build software
 patch, , , Build software


### PR DESCRIPTION
Python 3.10 is now released and will soon be available in Spack. We should start testing Spack with 3.10 to make sure there aren't any issues. This PR may end up being an experiment to fix Python 3.10 support.

Note that the use of quotes around Python versions in YAML is not a style preference but an actual requirement: https://github.com/actions/setup-python/issues/160