### PR TITLE
Add a command to check Spack bootstrap status

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -881,9 +881,13 @@ def _core_requirements():
         'gzip': _missing_executable('gzip', 'compress/decompress code archives'),
         'unzip': _missing_executable('unzip', 'compress/decompress code archives'),
         'bzip2': _missing_executable('bzip2', 'compress/decompress code archives'),
-        'xz': _missing_executable('xz', 'compress/decompress code archives'),
         'git': _missing_executable('git', 'fetch/manage git repositories')
     }
+    if platform.system().lower() == 'linux':
+        _core_system_exes['xz'] = _missing_executable(
+            'xz', 'compress/decompress code archives'
+        )
+
     # Executables that are not bootstrapped yet
     result = [functools.partial(_system_executable, exe, msg)
               for exe, msg in _core_system_exes.items()]

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -951,7 +951,8 @@ def _development_requirements():
 
 def status_message(section):
     """Return a status message to be printed to screen that refers to the
-    section passed as argument.
+    section passed as argument and a bool which is True if there are missing
+    dependencies.
 
     Args:
         section (str): either 'core' or 'buildcache' or 'optional' or 'develop'
@@ -975,4 +976,4 @@ def status_message(section):
                 msg += "\n  " + err_msg
         msg += '\n'
         msg = msg.format(pass_token if not missing_software else fail_token)
-    return msg
+    return msg, missing_software

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -846,8 +846,8 @@ def _missing(name, purpose):
     return msg.format(name, purpose)
 
 
-def _system_executable(exes, msg):
-    """Query availability of executables to be found on the system"""
+def _required_system_executable(exes, msg):
+    """Search for an executable is the system path only."""
     if isinstance(exes, six.string_types):
         exes = (exes,)
     if spack.util.executable.which_string(*exes):
@@ -856,14 +856,16 @@ def _system_executable(exes, msg):
 
 
 def _required_python_module(module, query_spec, msg):
-    """Query availability of required Python modules"""
+    """Check if a Python module is available in the current interpreter or
+    if it can be loaded from the bootstrap store
+    """
     if _python_import(module) or _try_import_from_store(module, query_spec):
         return True, None
     return False, msg
 
 
 def _required_executable(exes, query_spec, msg):
-    """Query availability of required executables"""
+    """Search for an executable in the system path or in the bootstrap store."""
     if isinstance(exes, six.string_types):
         exes = (exes,)
     if (spack.util.executable.which_string(*exes) or
@@ -889,7 +891,7 @@ def _core_requirements():
         )
 
     # Executables that are not bootstrapped yet
-    result = [functools.partial(_system_executable, exe, msg)
+    result = [functools.partial(_required_system_executable, exe, msg)
               for exe, msg in _core_system_exes.items()]
     # Python modules
     result += [
@@ -910,7 +912,7 @@ def _buildcache_requirements():
         _buildcache_exes['otool'] = _missing('otool', 'required to relocate binaries')
 
     # Executables that are not bootstrapped yet
-    result = [functools.partial(_system_executable, exe, msg)
+    result = [functools.partial(_required_system_executable, exe, msg)
               for exe, msg in _buildcache_exes.items()]
 
     if platform.system().lower() == 'linux':
@@ -929,7 +931,7 @@ def _optional_requirements():
         'hg': _missing('hg', 'required to manage mercurial repositories')
     }
     # Executables that are not bootstrapped yet
-    result = [functools.partial(_system_executable, exe, msg)
+    result = [functools.partial(_required_system_executable, exe, msg)
               for exe, msg in _optional_exes.items()]
     return result
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -895,7 +895,7 @@ def _core_requirements():
     result += [
         functools.partial(
             _required_python_module, 'clingo', clingo_root_spec(),
-            'MISSING: "clingo" python module (required to concretize specs)'
+            _missing('clingo', 'required to concretize specs')
         )
     ]
     return result
@@ -964,23 +964,18 @@ def status_message(section):
     """
     pass_token, fail_token = '@*g{[PASS]}', '@*r{[FAIL]}'
 
-    msg, test_fns = '', []
-    if section == 'core':
-        msg = "{0} @*{{Core Functionalities}}"
-        test_fns = _core_requirements()
-    elif section == 'buildcache':
-        msg = "{0} @*{{Binary packages}}"
-        test_fns = _buildcache_requirements()
-    elif section == 'optional':
-        msg = "{0} @*{{Optional Features}}"
-        test_fns = _optional_requirements()
-    elif section == 'develop':
-        msg = "{0} @*{{Development Dependencies}}"
-        test_fns = _development_requirements()
+    # Contain the header of the section and a list of requirements
+    spack_sections = {
+        'core': ("{0} @*{{Core Functionalities}}", _core_requirements),
+        'buildcache': ("{0} @*{{Binary packages}}", _buildcache_requirements),
+        'optional': ("{0} @*{{Optional Features}}", _optional_requirements),
+        'develop': ("{0} @*{{Development Dependencies}}", _development_requirements)
+    }
+    msg, test_fns = spack_sections[section]
 
     with ensure_bootstrap_configuration():
         missing_software = False
-        for test_fn in test_fns:
+        for test_fn in test_fns():
             ok, err_msg = test_fn()
             if not ok:
                 missing_software = True

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -840,10 +840,12 @@ def ensure_flake8_in_path_or_raise():
     return ensure_executables_in_path_or_raise([executable], abstract_spec=root_spec)
 
 
-def _missing(name, purpose):
+def _missing(name, purpose, system_only=True):
     """Message to be printed if an executable is not found"""
-    msg = 'MISSING "{0}": {1}'
-    return msg.format(name, purpose)
+    msg = '[{2}] MISSING "{0}": {1}'
+    if not system_only:
+        return msg.format(name, purpose, '@*y{{B}}')
+    return msg.format(name, purpose, '@*y{{-}}')
 
 
 def _required_system_executable(exes, msg):
@@ -896,7 +898,7 @@ def _core_requirements():
     # Python modules
     result.append(_required_python_module(
         'clingo', clingo_root_spec(),
-        _missing('clingo', 'required to concretize specs')
+        _missing('clingo', 'required to concretize specs', False)
     ))
     return result
 
@@ -904,7 +906,7 @@ def _core_requirements():
 def _buildcache_requirements():
     _buildcache_exes = {
         'file': _missing('file', 'required to analyze files for buildcaches'),
-        ('gpg2', 'gpg'): _missing('gpg2', 'required to sign/verify buildcaches')
+        ('gpg2', 'gpg'): _missing('gpg2', 'required to sign/verify buildcaches', False)
     }
     if platform.system().lower() == 'darwin':
         _buildcache_exes['otool'] = _missing('otool', 'required to relocate binaries')
@@ -916,7 +918,7 @@ def _buildcache_requirements():
     if platform.system().lower() == 'linux':
         result.append(_required_executable(
             'patchelf', patchelf_root_spec(),
-            _missing('patchelf', 'required to relocate binaries')
+            _missing('patchelf', 'required to relocate binaries', False)
         ))
 
     return result
@@ -937,13 +939,13 @@ def _optional_requirements():
 def _development_requirements():
     return [
         _required_executable('isort', isort_root_spec(),
-                             _missing('isort', 'required for style checks')),
+                             _missing('isort', 'required for style checks', False)),
         _required_executable('mypy', mypy_root_spec(),
-                             _missing('mypy', 'required for style checks')),
+                             _missing('mypy', 'required for style checks', False)),
         _required_executable('flake8', flake8_root_spec(),
-                             _missing('flake8', 'required for style checks')),
+                             _missing('flake8', 'required for style checks', False)),
         _required_executable('black', black_root_spec(),
-                             _missing('black', 'required for code formatting'))
+                             _missing('black', 'required for code formatting', False))
     ]
 
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -840,9 +840,9 @@ def ensure_flake8_in_path_or_raise():
     return ensure_executables_in_path_or_raise([executable], abstract_spec=root_spec)
 
 
-def _missing_executable(name, purpose):
+def _missing(name, purpose):
     """Message to be printed if an executable is not found"""
-    msg = 'MISSING: "{0}" executable (required to {1})'
+    msg = 'MISSING "{0}": {1}'
     return msg.format(name, purpose)
 
 
@@ -874,18 +874,18 @@ def _required_executable(exes, query_spec, msg):
 
 def _core_requirements():
     _core_system_exes = {
-        'make': _missing_executable('make', 'build software from sources'),
-        'patch': _missing_executable('patch', 'patch source code before building'),
-        'bash': _missing_executable('bash',  'use Spack compiler wrapper'),
-        'tar': _missing_executable('tar', 'manage code archives'),
-        'gzip': _missing_executable('gzip', 'compress/decompress code archives'),
-        'unzip': _missing_executable('unzip', 'compress/decompress code archives'),
-        'bzip2': _missing_executable('bzip2', 'compress/decompress code archives'),
-        'git': _missing_executable('git', 'fetch/manage git repositories')
+        'make': _missing('make', 'required to build software from sources'),
+        'patch': _missing('patch', 'required to patch source code before building'),
+        'bash': _missing('bash', 'required for Spack compiler wrapper'),
+        'tar': _missing('tar', 'required to manage code archives'),
+        'gzip': _missing('gzip', 'required to compress/decompress code archives'),
+        'unzip': _missing('unzip', 'required to compress/decompress code archives'),
+        'bzip2': _missing('bzip2', 'required to compress/decompress code archives'),
+        'git': _missing('git', 'required to fetch/manage git repositories')
     }
     if platform.system().lower() == 'linux':
-        _core_system_exes['xz'] = _missing_executable(
-            'xz', 'compress/decompress code archives'
+        _core_system_exes['xz'] = _missing(
+            'xz', 'required to compress/decompress code archives'
         )
 
     # Executables that are not bootstrapped yet
@@ -903,11 +903,11 @@ def _core_requirements():
 
 def _buildcache_requirements():
     _buildcache_exes = {
-        'file': _missing_executable('file', 'analyze files for buildcaches'),
-        ('gpg2', 'gpg'): _missing_executable('gpg2', 'sign/verify buildcaches')
+        'file': _missing('file', 'required to analyze files for buildcaches'),
+        ('gpg2', 'gpg'): _missing('gpg2', 'required to sign/verify buildcaches')
     }
     if platform.system().lower() == 'darwin':
-        _buildcache_exes['otool'] = _missing_executable('otool', 'relocate binaries')
+        _buildcache_exes['otool'] = _missing('otool', 'required to relocate binaries')
 
     # Executables that are not bootstrapped yet
     result = [functools.partial(_system_executable, exe, msg)
@@ -916,7 +916,7 @@ def _buildcache_requirements():
     if platform.system().lower() == 'linux':
         result.append(functools.partial(
             _required_executable, 'patchelf', patchelf_root_spec(),
-            _missing_executable('patchelf', 'relocate binaries')
+            _missing('patchelf', 'required to relocate binaries')
         ))
 
     return result
@@ -924,9 +924,9 @@ def _buildcache_requirements():
 
 def _optional_requirements():
     _optional_exes = {
-        'zstd': _missing_executable('zstd', 'compress/decompress code archives'),
-        'svn': _missing_executable('svn', 'manage subversion repositories'),
-        'hg': _missing_executable('hg', 'manage mercurial repositories')
+        'zstd': _missing('zstd', 'required to compress/decompress code archives'),
+        'svn': _missing('svn', 'required to manage subversion repositories'),
+        'hg': _missing('hg', 'required to manage mercurial repositories')
     }
     # Executables that are not bootstrapped yet
     result = [functools.partial(_system_executable, exe, msg)
@@ -938,19 +938,19 @@ def _development_requirements():
     return [
         functools.partial(
             _required_executable, 'isort', isort_root_spec(),
-            'MISSING: "isort" executable (required for style checks)'
+            _missing('isort', 'required for style checks')
         ),
         functools.partial(
             _required_executable, 'mypy', mypy_root_spec(),
-            'MISSING: "mypy" executable (required for style checks)'
+            _missing('mypy', 'required for style checks')
         ),
         functools.partial(
             _required_executable, 'flake8', flake8_root_spec(),
-            'MISSING: "flake8" executable (required for style checks)'
+            _missing('flake8', 'required for style checks')
         ),
         functools.partial(
             _required_executable, 'black', black_root_spec(),
-            'MISSING: "black" executable (required for code formatting)'
+            _missing('black', 'required for code formatting')
         )
     ]
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -962,10 +962,7 @@ def status_message(section):
     Args:
         section (str): either 'core' or 'buildcache' or 'optional' or 'develop'
     """
-    ok_token, ko_token = "\U0001F44D", "\U0001F44E"
-    if sys.version_info[:2] == (2, 7):
-        ok_token = '[PASS]'
-        ko_token = '[FAIL]'
+    pass_token, fail_token = '@*g{[PASS]}', '@*r{[FAIL]}'
 
     msg, test_fns = '', []
     if section == 'core':
@@ -989,5 +986,5 @@ def status_message(section):
                 missing_software = True
                 msg += "\n  " + err_msg
         msg += '\n'
-        msg = msg.format(ok_token if not missing_software else ko_token)
+        msg = msg.format(pass_token if not missing_software else fail_token)
     return msg

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -2,7 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-from __future__ import print_function, unicode_literals
+from __future__ import print_function
 
 import contextlib
 import fnmatch
@@ -963,6 +963,9 @@ def status_message(section):
         section (str): either 'core' or 'buildcache' or 'optional' or 'develop'
     """
     ok_token, ko_token = "\U0001F44D", "\U0001F44E"
+    if sys.version_info[:2] == (2, 7):
+        ok_token = '[PASS]'
+        ko_token = '[FAIL]'
 
     msg, test_fns = '', []
     if section == 'core':

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -231,11 +231,14 @@ def _status(args):
     )
     print(llnl.util.tty.color.colorize(header))
     print()
-    for current_section in sections:
-        status_msg = spack.bootstrap.status_message(section=current_section)
-        if status_msg:
-            print(llnl.util.tty.color.colorize(status_msg))
-    print()
+    # Use the context manager here to avoid swapping between user and
+    # bootstrap config many times
+    with spack.bootstrap.ensure_bootstrap_configuration():
+        for current_section in sections:
+            status_msg = spack.bootstrap.status_message(section=current_section)
+            if status_msg:
+                print(llnl.util.tty.color.colorize(status_msg))
+        print()
 
 
 def bootstrap(parser, args):

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -233,11 +233,19 @@ def _status(args):
     print()
     # Use the context manager here to avoid swapping between user and
     # bootstrap config many times
+    missing = False
     with spack.bootstrap.ensure_bootstrap_configuration():
         for current_section in sections:
-            status_msg = spack.bootstrap.status_message(section=current_section)
+            status_msg, fail = spack.bootstrap.status_message(section=current_section)
+            missing = missing or fail
             if status_msg:
                 print(llnl.util.tty.color.colorize(status_msg))
+        print()
+    legend = ('Spack will take care of bootstrapping any missing dependency marked'
+              ' as [@*y{B}]. Dependencies marked as [@*y{-}] are instead required'
+              ' to be found on the system.')
+    if missing:
+        print(llnl.util.tty.color.colorize(legend))
         print()
 
 

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -10,6 +10,8 @@ import shutil
 import llnl.util.tty
 import llnl.util.tty.color
 
+import spack
+import spack.bootstrap
 import spack.cmd.common.arguments
 import spack.config
 import spack.main
@@ -31,6 +33,16 @@ def _add_scope_option(parser):
 
 def setup_parser(subparser):
     sp = subparser.add_subparsers(dest='subcommand')
+
+    status = sp.add_parser('status', help='get the status of Spack')
+    status.add_argument(
+        '--optional', action='store_true', default=False,
+        help='show the status of rarely used optional dependencies'
+    )
+    status.add_argument(
+        '--dev', action='store_true', default=False,
+        help='show the status of dependencies needed to develop Spack'
+    )
 
     enable = sp.add_parser('enable', help='enable bootstrapping')
     _add_scope_option(enable)
@@ -207,8 +219,28 @@ def _untrust(args):
     llnl.util.tty.msg(msg.format(args.name))
 
 
+def _status(args):
+    sections = ['core', 'buildcache']
+    if args.optional:
+        sections.append('optional')
+    if args.dev:
+        sections.append('develop')
+
+    header = "@*b{{Spack v{0} - {1}}}".format(
+        spack.spack_version, spack.bootstrap.spec_for_current_python()
+    )
+    print(llnl.util.tty.color.colorize(header))
+    print()
+    for current_section in sections:
+        status_msg = spack.bootstrap.status_message(section=current_section)
+        if status_msg:
+            print(llnl.util.tty.color.colorize(status_msg))
+    print()
+
+
 def bootstrap(parser, args):
     callbacks = {
+        'status': _status,
         'enable': _enable_or_disable,
         'disable': _enable_or_disable,
         'reset': _reset,

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -156,7 +156,9 @@ def test_nested_use_of_context_manager(mutable_config):
     (None, False),
     ('/foo/bin', True)
 ])
-def test_status_function_find_files(mutable_config, monkeypatch, path_ev, expected_missing):
+def test_status_function_find_files(
+        mutable_config, monkeypatch, path_ev, expected_missing
+):
     if spack.config.get('config:concretizer') == 'original':
         pytest.skip('Skip the test for the original concretizer')
 

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -150,3 +150,18 @@ def test_nested_use_of_context_manager(mutable_config):
         with spack.bootstrap.ensure_bootstrap_configuration():
             assert spack.config.config != user_config
     assert spack.config.config == user_config
+
+
+@pytest.mark.parametrize('path_ev,expected_missing', [
+    (None, False),
+    ('/foo/bin', True)
+])
+def test_status_function_find_files(mutable_config, monkeypatch, path_ev, expected_missing):
+    if spack.config.get('config:concretizer') == 'original':
+        pytest.skip('Skip the test for the original concretizer')
+
+    if path_ev is not None:
+        monkeypatch.setenv('PATH', path_ev)
+
+    _, missing = spack.bootstrap.status_message('core')
+    assert missing is expected_missing

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -38,6 +38,7 @@ bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
 spack -p --lines 20 spec mpileaks%gcc ^dyninst@10.0.0 ^elfutils@0.170
+$coverage_run $(which spack) bootstrap status
 
 #-----------------------------------------------------------
 # Run unit tests with code coverage

--- a/share/spack/qa/run-unit-tests
+++ b/share/spack/qa/run-unit-tests
@@ -38,7 +38,7 @@ bin/spack help -a
 
 # Profile and print top 20 lines for a simple call to spack spec
 spack -p --lines 20 spec mpileaks%gcc ^dyninst@10.0.0 ^elfutils@0.170
-$coverage_run $(which spack) bootstrap status
+$coverage_run $(which spack) bootstrap status --dev --optional
 
 #-----------------------------------------------------------
 # Run unit tests with code coverage

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -434,8 +434,12 @@ _spack_bootstrap() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="enable disable reset root list trust untrust"
+        SPACK_COMPREPLY="status enable disable reset root list trust untrust"
     fi
+}
+
+_spack_bootstrap_status() {
+    SPACK_COMPREPLY="-h --help --optional --dev"
 }
 
 _spack_bootstrap_enable() {


### PR DESCRIPTION
This PR adds a command that pokes the environment, Python interpreter and bootstrap store to check if dependencies needed by Spack are available. If any is missing, it shows a comprehensible message:
![Screenshot from 2021-12-22 10-05-47](https://user-images.githubusercontent.com/4199709/147066516-bf41b29d-5221-4d01-88ab-f875e123214a.png)

Missing software marked with a `[B]` is currently bootstrappable.