### PR TITLE
Added support for find externals to also find library-only packages

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1969,6 +1969,38 @@ def search_paths_for_executables(*path_hints):
 
 
 @system_path_filter
+def search_paths_for_libraries(*path_hints):
+    """Given a list of path hints returns a list of paths where
+    to search for a shared library.
+
+    Args:
+        *path_hints (list of paths): list of paths taken into
+            consideration for a search
+
+    Returns:
+        A list containing the real path of every existing directory
+        in `path_hints` and its `lib` and `lib64` subdirectory if it exists.
+    """
+    library_paths = []
+    for path in path_hints:
+        if not os.path.isdir(path):
+            continue
+
+        path = os.path.abspath(path)
+        library_paths.append(path)
+
+        lib_dir = os.path.join(path, 'lib')
+        if os.path.isdir(lib_dir):
+            library_paths.append(lib_dir)
+
+        lib64_dir = os.path.join(path, 'lib64')
+        if os.path.isdir(lib64_dir):
+            library_paths.append(lib64_dir)
+
+    return library_paths
+
+
+@system_path_filter
 def partition_path(path, entry=None):
     """
     Split the prefixes of the path at the first occurrence of entry and

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1940,6 +1940,11 @@ def files_in(*search_paths):
     return files
 
 
+def is_readable_file(file_path):
+    """Return True if the path passed as argument is readable"""
+    return os.path.isfile(file_path) and os.access(file_path, os.R_OK)
+
+
 @system_path_filter
 def search_paths_for_executables(*path_hints):
     """Given a list of path hints returns a list of paths where

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -92,8 +92,6 @@ def external_find(args):
 
     detected_packages = spack.detection.by_executable(packages_to_check)
     detected_packages.update(spack.detection.by_library(packages_to_check))
-    # maybe this line is
-    # detected_packaes.update(spack.detection.by_library([p for p in packages_to_check if p not in detected_packages]))
 
     new_entries = spack.detection.update_configuration(
         detected_packages, scope=args.scope, buildable=not args.not_buildable

--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -91,6 +91,10 @@ def external_find(args):
         packages_to_check = spack.repo.path.all_packages()
 
     detected_packages = spack.detection.by_executable(packages_to_check)
+    detected_packages.update(spack.detection.by_library(packages_to_check))
+    # maybe this line is
+    # detected_packaes.update(spack.detection.by_library([p for p in packages_to_check if p not in detected_packages]))
+
     new_entries = spack.detection.update_configuration(
         detected_packages, scope=args.scope, buildable=not args.not_buildable
     )

--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from .common import DetectedPackage, executable_prefix, update_configuration
-from .path import by_library, by_executable, executables_in_path
+from .path import by_executable, by_library, executables_in_path
 
 __all__ = [
     'DetectedPackage',

--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from .common import DetectedPackage, executable_prefix, update_configuration
-from .path import by_executable, executables_in_path
+from .path import by_library, by_executable, executables_in_path
 
 __all__ = [
     'DetectedPackage',
+    'by_library',
     'by_executable',
     'executables_in_path',
     'executable_prefix',

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -170,7 +170,7 @@ def library_prefix(library_dir):
         idx = components.index('lib')
         return os.sep.join(components[:idx])
     else:
-        return None
+        return library_dir
 
 
 def update_configuration(detected_packages, scope=None, buildable=True):

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -178,7 +178,6 @@ def library_prefix(library_dir):
         return None
 
 
-
 def update_configuration(detected_packages, scope=None, buildable=True):
     """Add the packages passed as arguments to packages.yaml
 

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -114,11 +114,6 @@ def is_executable(file_path):
     return os.path.isfile(file_path) and os.access(file_path, os.X_OK)
 
 
-def is_readable(file_path):
-    """Return True if the path passed as argument is readable"""
-    return os.path.isfile(file_path) and os.access(file_path, os.R_OK)
-
-
 def _convert_to_iterable(single_val_or_multiple):
     x = single_val_or_multiple
     if x is None:

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -114,6 +114,11 @@ def is_executable(file_path):
     return os.path.isfile(file_path) and os.access(file_path, os.X_OK)
 
 
+def is_readable(file_path):
+    """Return True if the path passed as argument is readable"""
+    return os.path.isfile(file_path) and os.access(file_path, os.R_OK)
+
+
 def _convert_to_iterable(single_val_or_multiple):
     x = single_val_or_multiple
     if x is None:
@@ -148,6 +153,30 @@ def executable_prefix(executable_dir):
         return executable_dir
     idx = components.index('bin')
     return os.sep.join(components[:idx])
+
+
+def library_prefix(library_dir):
+    """Given a directory where an library is found, guess the prefix
+    (i.e. the "root" directory of that installation) and return it.
+
+    Args:
+        library_dir: directory where an library is found
+    """
+    # Given a prefix where an library is found, assuming that prefix
+    # contains /lib/ or /lib64/, strip off the 'lib' or 'lib64' directory
+    # to get a Spack-compatible prefix
+    assert os.path.isdir(library_dir)
+
+    components = library_dir.split(os.sep)
+    if 'lib64' in components:
+        idx = components.index('lib64')
+        return os.sep.join(components[:idx])
+    elif 'lib' in components:
+        idx = components.index('lib')
+        return os.sep.join(components[:idx])
+    else:
+        return None
+
 
 
 def update_configuration(detected_packages, scope=None, buildable=True):

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -70,13 +70,13 @@ def executables_in_path(path_hints=None):
     for search_path in reversed(search_paths):
         for exe in os.listdir(search_path):
             exe_path = os.path.join(search_path, exe)
-            if is_readable(exe_path):
+            if is_executable(exe_path):
                 path_to_exe[exe_path] = exe
     return path_to_exe
 
 
-def libraries_in_path(path_hints=None):
-    """Get the paths of all libraries available from the current PATH.
+def libraries_in_ld_library_path(path_hints=None):
+    """Get the paths of all libraries available from LD_LIBRARY_PATH.
 
     For convenience, this is constructed as a dictionary where the keys are
     the library paths and the values are the names of the libraries
@@ -98,7 +98,7 @@ def libraries_in_path(path_hints=None):
     for search_path in reversed(search_paths):
         for lib in os.listdir(search_path):
             lib_path = os.path.join(search_path, lib)
-            if is_executable(lib_path):
+            if is_readable(lib_path):
                 path_to_lib[lib_path] = lib
     return path_to_lib
 
@@ -126,7 +126,7 @@ def by_library(packages_to_check, path_hints=None):
         path_hints (list): list of paths to be searched. If None the list will be
             constructed based on the LD_LIBRARY_PATH environment variable.
     """
-    path_to_lib_name = libraries_in_path(path_hints=path_hints)
+    path_to_lib_name = libraries_in_ld_library_path(path_hints=path_hints)
     lib_pattern_to_pkgs = collections.defaultdict(list)
     for pkg in packages_to_check:
         if hasattr(pkg, 'libraries'):
@@ -150,7 +150,6 @@ def by_library(packages_to_check, path_hints=None):
                 "{0} must define 'determine_spec_details' in order"
                 " for Spack to detect externally-provided instances"
                 " of the package.".format(pkg.name))
-            print("Skipping test")
             continue
 
         for prefix, libs_in_prefix in sorted(_group_by_prefix(libs)):

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -110,6 +110,9 @@ def _group_by_prefix(paths):
     return groups.items()
 
 
+# TODO consolidate this with by_executable
+# Packages should be able to define both .libraries and .executables in the future
+# determine_spec_details should get all relevant libraries and executables in one call
 def by_library(packages_to_check, path_hints=None):
     # Techniques for finding libraries is determined on a per recipe basis in
     # the determine_version class method. Some packages will extract the

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -24,7 +24,6 @@ from .common import (
     compute_windows_program_path_for_package,
     executable_prefix,
     find_win32_additional_install_paths,
-    library_prefix,
     is_executable,
     is_readable,
     library_prefix,

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -180,7 +180,8 @@ def by_library(packages_to_check, path_hints=None):
                 pkg_prefix = library_prefix(prefix)
 
                 if not pkg_prefix:
-                    msg = "no lib/ or lib64/ dir found in {0}. Cannot add it as a Spack package"
+                    msg = "no lib/ or lib64/ dir found in {0}. Cannot "
+                    "add it as a Spack package"
                     llnl.util.tty.debug(msg.format(prefix))
                     continue
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -25,7 +25,6 @@ from .common import (
     executable_prefix,
     find_win32_additional_install_paths,
     is_executable,
-    is_readable,
     library_prefix,
 )
 
@@ -97,7 +96,7 @@ def libraries_in_ld_library_path(path_hints=None):
     for search_path in reversed(search_paths):
         for lib in os.listdir(search_path):
             lib_path = os.path.join(search_path, lib)
-            if is_readable(lib_path):
+            if llnl.util.filesystem.is_readable_file(lib_path):
                 path_to_lib[lib_path] = lib
     return path_to_lib
 
@@ -153,11 +152,6 @@ def by_library(packages_to_check, path_hints=None):
             continue
 
         for prefix, libs_in_prefix in sorted(_group_by_prefix(libs)):
-            # TODO: multiple instances of a package can live in the same
-            # prefix, and a package implementation can return multiple specs
-            # for one prefix, but without additional details (e.g. about the
-            # naming scheme which differentiates them), the spec won't be
-            # usable.
             try:
                 specs = _convert_to_iterable(
                     pkg.determine_spec_details(prefix, libs_in_prefix)

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -111,13 +111,11 @@ def _group_by_prefix(paths):
 
 
 def by_library(packages_to_check, path_hints=None):
-    # What tool will we use? Is that per-package?
-    # Use that tool (maybe get it on per-package basis)
-    # Call determine_spec_details on each package?
-    # Do we need separate determine_spec_details_exe and determine_spec_details_lib?
-    # How do we get compiler information?
-    #   for things in /usr we can lookup by OS
-    # Or should enabling this be an assertion that the compiler doesn't matter?
+    # Techniques for finding libraries is determined on a per recipe basis in
+    # the determine_version class method. Some packages will extract the
+    # version number from a shared libraries filename.
+    # Other libraries could use the strings function to extract it as described
+    # in https://unix.stackexchange.com/questions/58846/viewing-linux-library-executable-version-info
     """Return the list of packages that have been detected on the system,
     searching by LD_LIBRARY_PATH.
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -27,6 +27,7 @@ from .common import (
     library_prefix,
     is_executable,
     is_readable,
+    library_prefix,
 )
 
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -93,8 +93,8 @@ def libraries_in_ld_library_path(path_hints=None):
     search_paths = llnl.util.filesystem.search_paths_for_libraries(*path_hints)
 
     path_to_lib = {}
-    # Reverse order of search directories so that a lib in the first PATH
-    # entry overrides later entries
+    # Reverse order of search directories so that a lib in the first
+    # LD_LIBRARY_PATH entry overrides later entries
     for search_path in reversed(search_paths):
         for lib in os.listdir(search_path):
             lib_path = os.path.join(search_path, lib)

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -140,12 +140,8 @@ def by_library(packages_to_check, path_hints=None):
                 for pkg in pkgs:
                     pkg_to_found_libs[pkg].add(path)
 
-    print(path_to_lib_name)
-    print(lib_pattern_to_pkgs)
-    print(pkg_to_found_libs)
-
     pkg_to_entries = collections.defaultdict(list)
-    resolved_specs = {}  # spec -> exe found for the spec
+    resolved_specs = {}  # spec -> lib found for the spec
 
     for pkg, libs in pkg_to_found_libs.items():
         if not hasattr(pkg, 'determine_spec_details'):
@@ -279,10 +275,10 @@ def by_executable(packages_to_check, path_hints=None):
                 )
 
             for spec in specs:
-                pkg_prefix = library_prefix(prefix)
+                pkg_prefix = executable_prefix(prefix)
 
                 if not pkg_prefix:
-                    msg = "no lib/ or lib64/ dir found in {0}. Cannot add it as a Spack package"
+                    msg = "no bin/ dir found in {0}. Cannot add it as a Spack package"
                     llnl.util.tty.debug(msg.format(prefix))
                     continue
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -178,7 +178,7 @@ class DetectablePackageMeta(object):
     """
     def __init__(cls, name, bases, attr_dict):
         if hasattr(cls, 'executables') and hasattr(cls, 'libraries'):
-            msg = "a package can have either an 'executables' or a 'libraries' attribute"
+            msg = "a package can have either an 'executables' or 'libraries' attribute"
             msg += " [package '{0.name}' defines both]"
             raise ValueError(msg.format(cls))
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -177,12 +177,18 @@ class DetectablePackageMeta(object):
     for the detection function.
     """
     def __init__(cls, name, bases, attr_dict):
+        if hasattr(cls, 'executables') and hasattr(cls, 'libraries'):
+            msg = "a package can have either an 'executables' or a 'libraries' attribute"
+            msg += " [package '{0.name}' defines both]"
+            raise ValueError(msg.format(cls))
+
         # On windows, extend the list of regular expressions to look for
         # filenames ending with ".exe"
         # (in some cases these regular expressions include "$" to avoid
         # pulling in filenames with unexpected suffixes, but this allows
         # for example detecting "foo.exe" when the package writer specified
         # that "foo" was a possible executable.
+
         # If a package has the executables or libraries  attribute then it's
         # assumed to be detectable
         if hasattr(cls, 'executables') or hasattr(cls, 'libraries'):
@@ -209,7 +215,7 @@ class DetectablePackageMeta(object):
                 Args:
                     prefix (str): the directory containing the executables
                                   or libraries
-                    objs_in_prefix (set): the executables and libraries that
+                    objs_in_prefix (set): the executables or libraries that
                                           match the regex
 
                 Returns:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -183,7 +183,9 @@ class DetectablePackageMeta(object):
         # pulling in filenames with unexpected suffixes, but this allows
         # for example detecting "foo.exe" when the package writer specified
         # that "foo" was a possible executable.
-        if hasattr(cls, 'executables'):
+        # If a package has the executables attribute then it's
+        # assumed to be detectable
+        if hasattr(cls, 'executables') or hasattr(cls, 'libraries'):
             @property
             def platform_executables(self):
                 def to_windows_exe(exe):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -180,7 +180,7 @@ class DetectablePackageMeta(object):
         if hasattr(cls, 'executables') and hasattr(cls, 'libraries'):
             msg = "a package can have either an 'executables' or 'libraries' attribute"
             msg += " [package '{0.name}' defines both]"
-            raise ValueError(msg.format(cls))
+            raise spack.error.SpackError(msg.format(cls))
 
         # On windows, extend the list of regular expressions to look for
         # filenames ending with ".exe"

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
+
 from spack import *
 
 
@@ -15,6 +18,7 @@ class Hipblas(CMakePackage):
     url      = "https://github.com/ROCmSoftwarePlatform/hipBLAS/archive/rocm-5.0.2.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
+    libraries = ['libhipblas.so']
 
     version('5.0.2', sha256='201772bfc422ecb2c50e898dccd7d3d376cf34a2b795360e34bf71326aa37646')
     version('5.0.0', sha256='63cffe748ed4a86fc80f408cb9e8a9c6c55c22a2b65c0eb9a76360b97bbb9d41')
@@ -53,6 +57,16 @@ class Hipblas(CMakePackage):
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r'lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)',
+                          lib)
+        if match:
+            ver = '{0}.{1}.{2}'.format(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        else:
+            ver = None
+        return ver
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -5,7 +5,6 @@
 
 import re
 
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -62,7 +62,9 @@ class Hipblas(CMakePackage):
         match = re.search(r'lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)',
                           lib)
         if match:
-            ver = '{0}.{1}.{2}'.format(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+            ver = '{0}.{1}.{2}'.format(int(match.group(1)),
+                                       int(match.group(2)),
+                                       int(match.group(3)))
         else:
             ver = None
         return ver

--- a/var/spack/repos/builtin/packages/nccl/package.py
+++ b/var/spack/repos/builtin/packages/nccl/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
+
 from spack import *
 
 
@@ -13,6 +16,7 @@ class Nccl(MakefilePackage, CudaPackage):
     url      = "https://github.com/NVIDIA/nccl/archive/v2.7.3-1.tar.gz"
 
     maintainers = ['adamjstewart']
+    libraries = ['libnccl.so']
 
     version('2.11.4-1', sha256='db4e9a0277a64f9a31ea9b5eea22e63f10faaed36dded4587bbc8a0d8eceed10')
     version('2.10.3-1', sha256='55de166eb7dcab9ecef2629cdb5fb0c5ebec4fae03589c469ebe5dcb5716b3c5')
@@ -48,6 +52,12 @@ class Nccl(MakefilePackage, CudaPackage):
     conflicts('cuda_arch=none',
               msg='Must specify CUDA compute capabilities of your GPU, see '
               'https://developer.nvidia.com/cuda-gpus')
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r'lib\S*\.so\.(\d+\.\d+\.\d+)',
+                          lib)
+        return match.group(1) if match else None
 
     @property
     def build_targets(self):

--- a/var/spack/repos/builtin/packages/nccl/package.py
+++ b/var/spack/repos/builtin/packages/nccl/package.py
@@ -5,7 +5,6 @@
 
 import re
 
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
+
 from spack import *
 
 
@@ -17,6 +20,7 @@ class Rccl(CMakePackage):
     url      = "https://github.com/ROCmSoftwarePlatform/rccl/archive/rocm-5.0.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
+    libraries = ['librccl.so']
 
     version('5.0.2', sha256='a2377ad2332b93d3443a8ee74f4dd9f965ae8cbbfad473f8f57ca17905389a39')
     version('5.0.0', sha256='80eb70243f11b80e215458a67c278cd5a655f6e486289962b92ba3504e50af5c')
@@ -52,6 +56,16 @@ class Rccl(CMakePackage):
         depends_on('numactl@2:', when='@' + ver)
     for ver in ['4.5.0', '4.5.2', '5.0.0', '5.0.2']:
         depends_on('rocm-smi-lib@' + ver, when='@' + ver)
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r'lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)',
+                          lib)
+        if match:
+            ver = '{0}.{1}.{2}'.format(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        else:
+            ver = None
+        return ver
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -61,7 +61,9 @@ class Rccl(CMakePackage):
         match = re.search(r'lib\S*\.so\.\d+\.\d+\.(\d)(\d\d)(\d\d)',
                           lib)
         if match:
-            ver = '{0}.{1}.{2}'.format(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+            ver = '{0}.{1}.{2}'.format(int(match.group(1)),
+                                       int(match.group(2)),
+                                       int(match.group(3)))
         else:
             ver = None
         return ver

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -5,7 +5,6 @@
 
 import re
 
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/rdma-core/package.py
+++ b/var/spack/repos/builtin/packages/rdma-core/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack import *
 
 
@@ -11,6 +13,7 @@ class RdmaCore(CMakePackage):
 
     homepage = "https://github.com/linux-rdma/rdma-core"
     url      = "https://github.com/linux-rdma/rdma-core/releases/download/v17.1/rdma-core-17.1.tar.gz"
+    libraries = ['librdmacm.so']
 
     version('39.0', sha256='f6eaf0de9fe386e234e00a18a553f591143f50e03342c9fdd703fa8747bf2378')
     version('34.0', sha256='3d9ccf66468cf78f4c39bebb8bd0c5eb39150ded75f4a88a3455c4f625408be8')
@@ -33,6 +36,12 @@ class RdmaCore(CMakePackage):
     depends_on('libnl')
     conflicts('platform=darwin', msg='rdma-core requires FreeBSD or Linux')
     conflicts('%intel', msg='rdma-core cannot be built with intel (use gcc instead)')
+
+    @classmethod
+    def determine_version(cls, lib):
+        match = re.search(r'lib\S*\.so\.\d+\.\d+\.(\d+\.\d+)',
+                          lib)
+        return match.group(1) if match else None
 
 # NOTE: specify CMAKE_INSTALL_RUNDIR explicitly to prevent rdma-core from
 #       using the spack staging build dir (which may be a very long file


### PR DESCRIPTION
Similar to the existing ability to find externals via a executable
binary, this allows a package to define a shared library object that
can be used to find a detectable version of an installed package.
Requires a `libraries = [lib<SHARED_LIB>.so]` field in the recipe as
well as the `determine_version` class function.