### PR TITLE
[mesa] meson stage needs python3.8+

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -35,7 +35,7 @@ class Mesa(MesonPackage):
     depends_on('cmake', type='build')
     depends_on('flex', type='build')
     depends_on('gettext', type='build')
-    depends_on('python@3:', type='build')
+    depends_on('python@3.8:', type='build')
     depends_on('py-mako@0.8.0:', type='build')
     depends_on('expat')
     depends_on('zlib@1.2.3:')


### PR DESCRIPTION
`importlib.metadata` is only available from python3.8

Maintainers: @chuckatkins, @v-dobrev