### PR TITLE
Bugfix: Simplify preferred-test versions; set checksum defaults

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -25,17 +25,17 @@ level = "long"
 
 def setup_parser(subparser):
     subparser.add_argument(
-        '--keep-stage', action='store_true',
+        '--keep-stage', action='store_true', default=False,
         help="don't clean up staging area when command completes")
     sp = subparser.add_mutually_exclusive_group()
     sp.add_argument(
-        '-b', '--batch', action='store_true',
+        '-b', '--batch', action='store_true', default=False,
         help="don't ask which versions to checksum")
     sp.add_argument(
-        '-l', '--latest', action='store_true',
+        '-l', '--latest', action='store_true', default=False,
         help="checksum the latest available version only")
     sp.add_argument(
-        '-p', '--preferred', action='store_true',
+        '-p', '--preferred', action='store_true', default=False,
         help="checksum the preferred version only")
     arguments.add_common_arguments(subparser, ['package'])
     subparser.add_argument(

--- a/lib/spack/spack/test/cmd/audit.py
+++ b/lib/spack/spack/test/cmd/audit.py
@@ -41,7 +41,7 @@ def test_audit_packages_https(mutable_config, mock_packages):
     assert audit.returncode == 1
 
     # This uses http and should fail
-    audit('packages-https', "preferred-test", fail_on_error=False)
+    audit('packages-https', "test-dependency", fail_on_error=False)
     assert audit.returncode == 1
 
     # providing one or more package names with https should work

--- a/lib/spack/spack/test/cmd/checksum.py
+++ b/lib/spack/spack/test/cmd/checksum.py
@@ -30,7 +30,7 @@ def test_checksum_args(arguments, expected):
 
 
 @pytest.mark.parametrize('arguments,expected', [
-    (['--batch', 'preferred-test'], 'versions of preferred-test'),
+    (['--batch', 'preferred-test'], 'version of preferred-test'),
     (['--latest', 'preferred-test'], 'Found 1 version'),
     (['--preferred', 'preferred-test'], 'Found 1 version'),
 ])
@@ -47,7 +47,7 @@ def test_checksum_interactive(
     monkeypatch.setattr(tty, 'get_number', _get_number)
 
     output = spack_checksum('preferred-test')
-    assert 'versions of preferred-test' in output
+    assert 'version of preferred-test' in output
     assert 'version(' in output
 
 

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -176,16 +176,16 @@ class TestConcretizePreferences(object):
 
     def test_preferred(self):
         """"Test packages with some version marked as preferred=True"""
-        spec = Spec('preferred-test')
+        spec = Spec('python')
         spec.concretize()
-        assert spec.version == Version('0.2.15')
+        assert spec.version == Version('2.7.11')
 
         # now add packages.yaml with versions other than preferred
         # ensure that once config is in place, non-preferred version is used
-        update_packages('preferred-test', 'version', ['0.2.16'])
-        spec = Spec('preferred-test')
+        update_packages('python', 'version', ['3.5.0'])
+        spec = Spec('python')
         spec.concretize()
-        assert spec.version == Version('0.2.16')
+        assert spec.version == Version('3.5.0')
 
     def test_develop(self):
         """Test concretization with develop-like versions"""

--- a/var/spack/repos/builtin.mock/packages/preferred-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/preferred-test/package.py
@@ -7,11 +7,9 @@ from spack import *
 
 
 class PreferredTest(Package):
-    """Dummy package with develop version and preffered version"""
-    homepage = "http://www.openblas.net"
-    url      = "http://github.com/xianyi/OpenBLAS/archive/v0.2.15.tar.gz"
+    """Dummy package with develop version and preferred version"""
+    homepage = "https://github.com/LLNL/mpileaks"
+    url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
 
-    version('develop', git='https://github.com/dummy/repo.git')
-    version('0.2.16', 'b1190f3d3471685f17cfd1ec1d252ac9')
-    version('0.2.15', 'b1190f3d3471685f17cfd1ec1d252ac9', preferred=True)
-    version('0.2.14', 'b1190f3d3471685f17cfd1ec1d252ac9')
+    version('develop', git='https://github.com/LLNL/mpileaks.git')
+    version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825', preferred=True)


### PR DESCRIPTION
Fixes #28021  (hopefully)

This PR simplifies the `preferred-test` mock package such that it leverages the repo of a relatively small, stable package with only one version. Doing so results in fewer fetches (1 versus many) during checksum testing, hopefully reducing the window for cleaning up the post-fetch stage directory.

The PR also peripherally sets `checksum` arguments to include defaults to be explicit.