### PR TITLE
Provide meaningful message for empty environment installs

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -348,6 +348,10 @@ environment variables:
                     env.write(regenerate=False)
 
             specs = env.all_specs()
+            if not specs:
+                tty.error('`spack install` requires at least one spec.')
+                tty.die('Environment {0} has no specs'.format(env.name))
+
             if not args.log_file and not reporter.filename:
                 reporter.filename = default_log_file(specs[0])
             reporter.specs = specs

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -348,21 +348,22 @@ environment variables:
                     env.write(regenerate=False)
 
             specs = env.all_specs()
-            if not specs:
-                tty.error('`spack install` requires at least one spec.')
-                tty.die('Environment {0} has no specs'.format(env.name))
+            if specs:
+                if not args.log_file and not reporter.filename:
+                    reporter.filename = default_log_file(specs[0])
+                reporter.specs = specs
 
-            if not args.log_file and not reporter.filename:
-                reporter.filename = default_log_file(specs[0])
-            reporter.specs = specs
+                # Tell the monitor about the specs
+                if args.use_monitor and specs:
+                    monitor.new_configuration(specs)
 
-            # Tell the monitor about the specs
-            if args.use_monitor and specs:
-                monitor.new_configuration(specs)
+                tty.msg("Installing environment {0}".format(env.name))
+                with reporter('build'):
+                    env.install_all(**kwargs)
 
-            tty.msg("Installing environment {0}".format(env.name))
-            with reporter('build'):
-                env.install_all(**kwargs)
+            else:
+                msg = '{0} environment has no specs to install'.format(env.name)
+                tty.msg(msg)
 
             tty.debug("Regenerating environment views for {0}"
                       .format(env.name))

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1109,4 +1109,5 @@ def test_install_empty_env(tmpdir, mock_packages, mock_fetch,
         out = install(fail_on_error=False)
 
     assert env_name in out
-    assert 'requires at least one spec' in out
+    assert 'environment' in out
+    assert 'no specs to install' in out

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -1099,3 +1099,14 @@ def test_install_env_with_tests_root(tmpdir, mock_packages, mock_fetch,
         add('depb')
         install('--test', 'root')
         assert not os.path.exists(test_dep.prefix)
+
+
+def test_install_empty_env(tmpdir, mock_packages, mock_fetch,
+                           install_mockery, mutable_mock_env_path):
+    env_name = 'empty'
+    env('create', env_name)
+    with ev.read(env_name):
+        out = install(fail_on_error=False)
+
+    assert env_name in out
+    assert 'requires at least one spec' in out


### PR DESCRIPTION
Not sure if this is the goal, but this PR provides a meaningful error message before terminating the `spack install` of an empty environment.  Without this change, 

```
$ spack install
==> Error: list index out of range
```

with the change, a ~an error~ message about no specs is output before ~terminating~ calling the code to regenerate the view:

```
$ spack install
==> <env-name> environment has no specs to install
```

The reason for terminating is because we do that if no specs are provided on the command line.  If that is not the desired behavior, this PR can be changed.