### PR TITLE
Do not initialize config on spack compiler list

### DIFF
--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -320,9 +320,10 @@ An alias for ``spack compiler find``.
 ``spack compiler find``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-If you do not see a compiler in this list, but you want to use it with
-Spack, you can simply run ``spack compiler find`` with the path to
-where the compiler is installed.  For example:
+Lists the compilers currently available to Spack. If you do not see
+a compiler in this list, but you want to use it with Spack, you can
+simply run ``spack compiler find`` with the path to where the
+compiler is installed.  For example:
 
 .. code-block:: console
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -271,9 +271,10 @@ Compiler configuration
 ----------------------
 
 Spack has the ability to build packages with multiple compilers and
-compiler versions. Spack searches for compilers on your machine
-automatically the first time it is run. It does this by inspecting
-your ``PATH``.
+compiler versions. Compilers can be made available to Spack by
+specifying them manually in ``compilers.yaml``, or automatically by
+running ``spack compiler find``, but for convenience Spack will
+automatically detect compilers the first time it needs them.
 
 .. _cmd-spack-compilers:
 
@@ -281,7 +282,7 @@ your ``PATH``.
 ``spack compilers``
 ^^^^^^^^^^^^^^^^^^^
 
-You can see which compilers spack has found by running ``spack
+You can see which compilers are available to Spack by running ``spack
 compilers`` or ``spack compiler list``:
 
 .. code-block:: console

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -147,7 +147,7 @@ def compiler_info(args):
 
 def compiler_list(args):
     tty.msg("Available compilers")
-    index = index_by(spack.compilers.all_compilers(scope=args.scope),
+    index = index_by(spack.compilers.all_compilers(scope=args.scope, init_config=False),
                      lambda c: (c.spec.name, c.operating_system, c.target))
 
     # For a container, take each element which does not evaluate to false and

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -146,9 +146,21 @@ def compiler_info(args):
 
 
 def compiler_list(args):
+    compilers = spack.compilers.all_compilers(scope=args.scope, init_config=False)
+
+    # If no compilers are found, prompt to search for compilers.
+    if args.scope is None and len(compilers) == 0 and sys.stdout.isatty():
+        if not tty.get_yes_or_no("No compilers are configured, search for compilers?"):
+            return
+        compilers = spack.compilers.all_compilers(init_config=True)
+
+    if len(compilers) == 0:
+        tty.msg("No compilers available")
+        return
+
+    index = index_by(compilers, lambda c: (c.spec.name, c.operating_system, c.target))
+
     tty.msg("Available compilers")
-    index = index_by(spack.compilers.all_compilers(scope=args.scope, init_config=False),
-                     lambda c: (c.spec.name, c.operating_system, c.target))
 
     # For a container, take each element which does not evaluate to false and
     # convert it to a string. For elements which evaluate to False (e.g. None)

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -149,7 +149,7 @@ def compiler_list(args):
     compilers = spack.compilers.all_compilers(scope=args.scope, init_config=False)
 
     # If no compilers are found, prompt to search for compilers.
-    if args.scope is None and len(compilers) == 0 and sys.stdout.isatty():
+    if args.scope is None and len(compilers) == 0 and sys.stdin.isatty():
         if not tty.get_yes_or_no("No compilers available. Search for compilers?"):
             return
         compilers = spack.compilers.all_compilers(init_config=True)

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -150,7 +150,7 @@ def compiler_list(args):
 
     # If no compilers are found, prompt to search for compilers.
     if args.scope is None and len(compilers) == 0 and sys.stdout.isatty():
-        if not tty.get_yes_or_no("No compilers are configured, search for compilers?"):
+        if not tty.get_yes_or_no("No compilers available. Search for compilers?"):
             return
         compilers = spack.compilers.all_compilers(init_config=True)
 

--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -148,14 +148,15 @@ def compiler_info(args):
 def compiler_list(args):
     compilers = spack.compilers.all_compilers(scope=args.scope, init_config=False)
 
-    # If no compilers are found, prompt to search for compilers.
-    if args.scope is None and len(compilers) == 0 and sys.stdin.isatty():
-        if not tty.get_yes_or_no("No compilers available. Search for compilers?"):
-            return
-        compilers = spack.compilers.all_compilers(init_config=True)
-
+    # If there are no compilers in any scope, and we're outputting to a tty, give a
+    # hint to the user.
     if len(compilers) == 0:
-        tty.msg("No compilers available")
+        if not sys.stdout.isatty():
+            return
+        msg = "No compilers available"
+        if args.scope is None:
+            msg += ". Run `spack compiler find` to autodetect compilers"
+        tty.msg(msg)
         return
 
     index = index_by(compilers, lambda c: (c.spec.name, c.operating_system, c.target))

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -300,8 +300,8 @@ def find_specs_by_arch(compiler_spec, arch_spec, scope=None, init_config=True):
                                                init_config)]
 
 
-def all_compilers(scope=None):
-    config = get_compiler_config(scope)
+def all_compilers(scope=None, init_config=True):
+    config = get_compiler_config(scope, init_config=init_config)
     compilers = list()
     for items in config:
         items = items['compiler']

--- a/lib/spack/spack/test/cmd/compiler.py
+++ b/lib/spack/spack/test/cmd/compiler.py
@@ -10,6 +10,7 @@ import pytest
 
 import llnl.util.filesystem
 
+import spack.compilers
 import spack.main
 import spack.version
 
@@ -271,3 +272,13 @@ def test_compiler_find_path_order(
         'f77': str(clangdir.join('first_in_path', 'gfortran-8')),
         'fc': str(clangdir.join('first_in_path', 'gfortran-8')),
     }
+
+
+def test_compiler_list_empty(no_compilers_yaml, working_env, clangdir):
+    # Spack should not automatically search for compilers when listing them and none
+    # are available. And when stdout is not a tty like in tests, there should be no
+    # output and no error exit code.
+    os.environ['PATH'] = str(clangdir)
+    out = compiler('list')
+    assert not out
+    assert compiler.returncode == 0


### PR DESCRIPTION
`spack compiler list` should show the current config and not write new compilers to config.
