### PR TITLE
Suite sparse tbb issues

### DIFF
--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -165,7 +165,7 @@ class SuiteSparse(Package):
             make_args += ['CFLAGS+=-DBLAS_NO_UNDERSCORE']
 
         # Intel TBB in SuiteSparseQR
-        if 'tbb' in spec:
+        if '+tbb' in spec:
             make_args += [
                 'SPQR_CONFIG=-DHAVE_TBB',
                 'TBB=%s' % spec['tbb'].libs.ld_flags,

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -70,15 +70,17 @@ class SuiteSparse(Package):
 
     conflicts('%gcc@:4.8', when='@5.2.0:', msg='gcc version must be at least 4.9 for suite-sparse@5.2.0:')
 
-    # The @2021.x versions of tbb dropped the task_scheduler_init.h header and 
-    # related stuff (which have long been deprecated).  This appears to be 
+    # The @2021.x versions of tbb dropped the task_scheduler_init.h header and
+    # related stuff (which have long been deprecated).  This appears to be
     # rather problematic for suite-sparse (see e.g.
     # https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/SPQR/Source/spqr_parallel.cpp)
     # Have Spack complain if +tbb and trying to use a 2021.x version of tbb
     conflicts('+tbb', when='^intel-oneapi-tbb@2021:',
-        msg='suite-sparse needs task_scheduler_init.h dropped in recent tbb libs')
+              msg='suite-sparse needs task_scheduler_init.h dropped in '
+              'recent tbb libs')
     conflicts('+tbb', when='^intel-tbb@2021:',
-        msg='suite-sparse needs task_scheduler_init.h dropped in recent tbb libs')
+              msg='suite-sparse needs task_scheduler_init.h dropped in '
+              'recent tbb libs')
 
     def symbol_suffix_blas(self, spec, args):
         """When using BLAS with a special symbol suffix we use defines to

--- a/var/spack/repos/builtin/packages/suite-sparse/package.py
+++ b/var/spack/repos/builtin/packages/suite-sparse/package.py
@@ -70,6 +70,16 @@ class SuiteSparse(Package):
 
     conflicts('%gcc@:4.8', when='@5.2.0:', msg='gcc version must be at least 4.9 for suite-sparse@5.2.0:')
 
+    # The @2021.x versions of tbb dropped the task_scheduler_init.h header and 
+    # related stuff (which have long been deprecated).  This appears to be 
+    # rather problematic for suite-sparse (see e.g.
+    # https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/master/SPQR/Source/spqr_parallel.cpp)
+    # Have Spack complain if +tbb and trying to use a 2021.x version of tbb
+    conflicts('+tbb', when='^intel-oneapi-tbb@2021:',
+        msg='suite-sparse needs task_scheduler_init.h dropped in recent tbb libs')
+    conflicts('+tbb', when='^intel-tbb@2021:',
+        msg='suite-sparse needs task_scheduler_init.h dropped in recent tbb libs')
+
     def symbol_suffix_blas(self, spec, args):
         """When using BLAS with a special symbol suffix we use defines to
         replace blas symbols, e.g. dgemm_ becomes dgemm_64_ when


### PR DESCRIPTION
This consists of 2 commits to address the 2 issues in #28053

1. Fix check for tbb so that does not erroneously ignore ~tbb simply because a dependency package depends on tbb
2. Raise a conflict if +tbb and trying to use a 2021.x version of tbb

The latter is a bit inelegant (explicitly checking for intel-oneapi-tbb@2021: and intel-tbb@2021: ) --- I do not know if there is a better way to check the tbb version