### PR TITLE
Tests: remove test_get_stage_root_in_spack 

### DIFF
--- a/lib/spack/spack/test/stage.py
+++ b/lib/spack/spack/test/stage.py
@@ -10,7 +10,6 @@ import getpass
 import os
 import shutil
 import stat
-import tempfile
 
 import pytest
 
@@ -824,29 +823,6 @@ class TestStage(object):
             else:
                 assert os.path.exists(test_path)
                 shutil.rmtree(test_path)
-
-    def test_get_stage_root_in_spack(self, clear_stage_root):
-        """Ensure an instance path is an accessible build stage path."""
-        base = canonicalize_path(os.path.join('$spack', '.spack-test-stage'))
-        mkdirp(base)
-        test_path = tempfile.mkdtemp(dir=base)
-
-        try:
-            with spack.config.override('config:build_stage',  test_path):
-                path = spack.stage.get_stage_root()
-
-                assert 'spack' in path.split(os.path.sep)
-
-                # Make sure cached stage path value was changed appropriately
-                assert spack.stage._stage_root in (
-                    test_path, os.path.join(test_path, getpass.getuser()))
-
-                # Make sure the directory exists
-                assert os.path.isdir(spack.stage._stage_root)
-
-        finally:
-            # Clean up regardless of outcome
-            shutil.rmtree(base)
 
     def test_stage_constructor_no_fetcher(self):
         """Ensure Stage constructor with no URL or fetch strategy fails."""


### PR DESCRIPTION
This is a partial fix for #22920 in that it removes the most obvious test that makes changes under the Spack instance. 