### PR TITLE
Define 'libs' property for vtk-m and vtk-h

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -302,3 +302,19 @@ class VtkH(Package, CudaPackage):
         host_cfg_fname = os.path.abspath(host_cfg_fname)
         tty.info("spack generated conduit host-config file: " + host_cfg_fname)
         return host_cfg_fname
+
+    @property
+    def libs(self):
+        spec = self.spec
+        libnames = [
+            "vtkh_rendering_mpi",
+            "vtkh_compositing_mpi",
+            "vtkh_filters_mpi",
+            "vtkh_utils_mpi",
+            "vtkh_lodepng",
+            "vtkh_core_mpi",
+        ]
+        libnames = [("lib" + x) for x in libnames]
+        search_shared = spec.satisfies('+shared')
+        return find_libraries(libnames, spec.prefix, shared=search_shared,
+                              recursive=True)

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -382,3 +382,23 @@ Ran tests on: """ + expected_device + "\n"
         spec = self.spec
         if "@master" in spec:
             self.smoke_test()
+
+    @property
+    def libs(self):
+        spec = self.spec
+        vsuffix = str(spec.version[:2])
+        libnames = [
+            "vtkm_rendering",
+            "vtkm_filter_contour",
+            "vtkm_filter_gradient",
+            "vtkm_filter_extra",
+            "vtkm_source",
+            "vtkm_io",
+            "vtkm_filter_common",
+            "vtkm_cont",
+            "vtkm_worklet",
+            "vtkm_lodepng"
+        ]
+        libnames = ["lib{0}-{1}".format(x, vsuffix) for x in libnames]
+        return find_libraries(libnames, spec.prefix, shared=False,
+                              recursive=True)

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -382,23 +382,3 @@ Ran tests on: """ + expected_device + "\n"
         spec = self.spec
         if "@master" in spec:
             self.smoke_test()
-
-    @property
-    def libs(self):
-        spec = self.spec
-        vsuffix = str(spec.version[:2])
-        libnames = [
-            "vtkm_rendering",
-            "vtkm_filter_contour",
-            "vtkm_filter_gradient",
-            "vtkm_filter_extra",
-            "vtkm_source",
-            "vtkm_io",
-            "vtkm_filter_common",
-            "vtkm_cont",
-            "vtkm_worklet",
-            "vtkm_lodepng"
-        ]
-        libnames = ["lib{0}-{1}".format(x, vsuffix) for x in libnames]
-        return find_libraries(libnames, spec.prefix, shared=False,
-                              recursive=True)


### PR DESCRIPTION
With this, dependent packages can easily find provided libraries via the Spack API (e.g. `spec['vtk-h'].libs`)