### PR TITLE
Fix building container images

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -74,6 +74,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9 # @v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -12,6 +12,7 @@ on:
       - develop
     paths:
       - '.github/workflows/build-containers.yml'
+      - 'share/spack/docker/*'
   # Let's also build & tag Spack containers on releases.
   release:
     types: [published]

--- a/share/spack/docker/amazonlinux-2.dockerfile
+++ b/share/spack/docker/amazonlinux-2.dockerfile
@@ -63,7 +63,6 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # TODO: add a command to Spack that (re)creates the package cache
-RUN spack bootstrap untrust spack-install
 RUN spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]

--- a/share/spack/docker/ubuntu-1604.dockerfile
+++ b/share/spack/docker/ubuntu-1604.dockerfile
@@ -67,7 +67,6 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # TODO: add a command to Spack that (re)creates the package cache
-RUN spack bootstrap untrust spack-install
 RUN spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]

--- a/share/spack/docker/ubuntu-1804.dockerfile
+++ b/share/spack/docker/ubuntu-1804.dockerfile
@@ -67,7 +67,6 @@ WORKDIR /root
 SHELL ["docker-shell"]
 
 # TODO: add a command to Spack that (re)creates the package cache
-RUN spack bootstrap untrust spack-install
 RUN spack spec hdf5+mpi
 
 ENTRYPOINT ["/bin/bash", "/opt/spack/share/spack/docker/entrypoint.bash"]


### PR DESCRIPTION
Patchelf is bootstrapped from sources, so we cannot disable that mechanism until a finer selection is possible in the configuration.