### PR TITLE
intel-oneapi-mpi: preliminary external detection

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -74,7 +74,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
             exe (str): absolute path to the executable being examined
         """
         versions = [str(v) for v in cls.versions]
-        output = Executable(exe)('--version', output=str, error=str)
+        output = Executable(exe)('-v', output=str, error=str)
         match = re.search(r'MPI Library ([\d\.]+)', output)
         vers = match.group(1) if match else None
         return vers if vers and vers in versions else None

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -73,7 +73,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         Arguments:
             exe (str): absolute path to the executable being examined
         """
-        versions = [ str(v) for v in cls.versions ]
+        versions = [str(v) for v in cls.versions]
         output = Executable(exe)('--version', output=str, error=str)
         match = re.search(r'icpc \(ICC\)\s+([\d\.]+)', output)
         vers = match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -75,7 +75,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         """
         versions = [str(v) for v in cls.versions]
         output = Executable(exe)('--version', output=str, error=str)
-        match = re.search(r'icpc \(ICC\)\s+([\d\.]+)', output)
+        match = re.search(r'MPI Library ([\d\.]+)', output)
         vers = match.group(1) if match else None
         return vers if vers and vers in versions else None
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 import platform
+import re
 
 from spack.package import *
 
@@ -22,6 +22,8 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     maintainers = ['rscohn2', ]
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html'
+
+    executables = [r'^mpiicpc$']  # one should be sufficient
 
     if platform.system() == 'Linux':
         version('2021.6.0',
@@ -62,6 +64,20 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     depends_on('libfabric', when='+external-libfabric', type=('link', 'run'))
 
     provides('mpi@:3.1')
+
+    @classmethod
+    def determine_version(cls, exe):
+        """Return the version of the provided executable or ``None`` if
+        the version cannot be determined.
+
+        Arguments:
+            exe (str): absolute path to the executable being examined
+        """
+        versions = [ str(v) for v in cls.versions ]
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'icpc \(ICC\)\s+([\d\.]+)', output)
+        vers = match.group(1) if match else None
+        return vers if vers and vers in versions else None
 
     @property
     def component_dir(self):


### PR DESCRIPTION
This PR allows `spack external find intel-oneapi-mpi` to find and determine the version of the package *provided* that version is one listed in the package.

It has been manually tested on the  UO `saturn` and `jupiter` machines.  It will find the version on the former but does not detect the one on the latter (since it is a beta version).  It *could* use the exe path if that is deemed appropriate but I will leave that decision up to the experts.

TODO

- [ ] Ensure changes are made that work across several machines