### PR TITLE
fxdiv: skip googletest and googlebenchmark for header only library

### DIFF
--- a/var/spack/repos/builtin/packages/fxdiv/package.py
+++ b/var/spack/repos/builtin/packages/fxdiv/package.py
@@ -23,25 +23,8 @@ class Fxdiv(CMakePackage):
 
     generator = 'Ninja'
 
-    resource(
-        name='googletest',
-        url='https://github.com/google/googletest/archive/release-1.10.0.zip',
-        sha256='94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91',
-        destination='deps',
-        placement='googletest',
-    )
-    resource(
-        name='googlebenchmark',
-        url='https://github.com/google/benchmark/archive/v1.5.0.zip',
-        sha256='2d22dd3758afee43842bb504af1a8385cccb3ee1f164824e4837c1c1b04d92a0',
-        destination='deps',
-        placement='googlebenchmark',
-    )
-
     def cmake_args(self):
         return [
-            self.define('GOOGLETEST_SOURCE_DIR',
-                        join_path(self.stage.source_path, 'deps', 'googletest')),
-            self.define('GOOGLEBENCHMARK_SOURCE_DIR',
-                        join_path(self.stage.source_path, 'deps', 'googlebenchmark')),
+            self.define('FXDIV_BUILD_TESTS', False),
+            self.define('FXDIV_BUILD_BENCHMARKS', False)
         ]


### PR DESCRIPTION
Package added by @adamjstewart, it's not clear to me what the utility of having the `googletest` and `googlebenchmark` libraries is for this header only library.  Those are developer targets, not needed for installation.  They add ~45 things to compile, whereas without them essentially cmake is just being used as an install wrapper.

There were compilation failures with `gcc@11` so locally I just deleted them rather than trying to figure out how to patch a `resource` that is missing some `#include` statements resulting in compilation failure.