### PR TITLE
add cudnn v8.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/cudnn/package.py
+++ b/var/spack/repos/builtin/packages/cudnn/package.py
@@ -9,6 +9,12 @@ import platform
 from spack import *
 
 _versions = {
+    # cuDNN 8.3.1
+    '8.3.1.22-11.5': {
+        'Linux-x86_64': 'f5ff3c69b6a8a9454289b42eca1dd41c3527f70fcf49428eb80502bcf6b02f6e',
+        'Linux-ppc64le': '1d2419a20ee193dc6a3a0ba87e79f408286d3d317c9831cbc1f0b7a268c100b0',
+        'Linux-aarch64': 'ff23a881366c0ee79b973a8921c6dd400628a321557550ad4e0a26a21caad263'},
+
     # cuDNN 8.2.4
     '8.2.4.15-11.4': {
         'Linux-x86_64': '0e5d2df890b9967efa6619da421310d97323565a79f05a1a8cb9b7165baad0d7',
@@ -210,14 +216,26 @@ class Cudnn(Package):
             depends_on(cuda_req, when=cudnn_ver_req)
 
     def url_for_version(self, version):
-        url = 'https://developer.download.nvidia.com/compute/redist/cudnn/v{0}/cudnn-{1}-{2}-v{3}.tgz'
         # Get the system and machine arch for building the file path
         sys = "{0}-{1}".format(platform.system(), platform.machine())
         # Munge it to match Nvidia's naming scheme
-        sys_key = sys.lower().replace('x86_64', 'x64').replace('darwin', 'osx') \
+        sys_key = sys.lower()
+        if version < Version('8.3.1'):
+            sys_key = sys_key.replace('x86_64', 'x64').replace('darwin', 'osx') \
                              .replace('aarch64', 'aarch64sbsa')
 
-        if version >= Version('7.2'):
+        if version >= Version('8.3.1'):
+            # NOTE: upload layout changed for 8.3.1, they include a 10.2
+            # artifact for cuda@10.2 x86_64, but the runtime is only supported
+            # for cuda@11.  See
+            # https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html
+            # As such, hacking the `directory` to include the extra
+            # local_installers/11.5 is included as this may not happen again.
+            directory = version[:3]
+            ver = version[:4]
+            cuda = version[4:]
+            directory = '{0}/local_installers/{1}'.format(directory, cuda)
+        elif version >= Version('7.2'):
             directory = version[:3]
             ver = version[:4]
             cuda = version[4:]
@@ -234,7 +252,13 @@ class Cudnn(Package):
             ver = version[:2]
             cuda = version[2:]
 
-        return url.format(directory, cuda, sys_key, ver)
+        # 8.3.1 switched to xzip tarballs and reordered url parts.
+        if version >= Version('8.3.1'):
+            url = 'https://developer.download.nvidia.com/compute/redist/cudnn/v{0}/cudnn-{1}-{2}_cuda{3}-archive.tar.xz'
+            return url.format(directory, sys_key, ver, cuda)
+        else:
+            url = 'https://developer.download.nvidia.com/compute/redist/cudnn/v{0}/cudnn-{1}-{2}-v{3}.tgz'
+            return url.format(directory, cuda, sys_key, ver)
 
     def setup_run_environment(self, env):
         if 'target=ppc64le: platform=linux' in self.spec:


### PR DESCRIPTION
CC maintainers: @adamjstewart  @bvanessen

I'm not exactly thrilled about the url change implementation.  It's kind of clean, but if you look at v8.3.0 or the others, it's not clear why this [`local_installers` directory](https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.1/local_installers) exists from the [release notes](https://docs.nvidia.com/deeplearning/cudnn/release-notes/rel_8.html).  I kind of anticipate that this `local_installers` directory may not be incorporated in their next release.

When I run `spack info cudnn` the urls for the older archives appear valid (can `wget` them and resolve / start downloading), but I am not sure about the new urls -- I only get the url reported for `x86_64`.  Note the change to `sys_key` local variable, the [v8.3.1 // cuda 11.5 installer directory](https://developer.download.nvidia.com/compute/redist/cudnn/v8.3.1/local_installers/11.5/) contains:

-  cudnn-linux-ppc64le-8.3.1.22_cuda11.5-archive.tar.xz 822MB 2021-11-23 01:09
- cudnn-linux-sbsa-8.3.1.22_cuda11.5-archive.tar.xz 819MB 2021-11-23 01:09
- cudnn-linux-x86_64-8.3.1.22_cuda11.5-archive.tar.xz 818MB 2021-11-23 01:10

The one that concerns me is `sbsa`, the version dictionary is using `Linux-aarch64`, but I haven't the slightest clue how to test this code or even what these architectures are :upside_down_face: 