### PR TITLE
py-vermin: add latest version 1.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/openloops/get-process-list.py
+++ b/var/spack/repos/builtin/packages/openloops/get-process-list.py
@@ -8,7 +8,7 @@ class my_html_parser(HTMLParser):
         pass
 
     def __init__(self):
-        super().__init__()
+        super(HTMLParser, self).__init__()
         self.state = 0
         self.processes = []
 

--- a/var/spack/repos/builtin/packages/py-charm4py/package.py
+++ b/var/spack/repos/builtin/packages/py-charm4py/package.py
@@ -66,7 +66,7 @@ class PyCharm4py(PythonPackage):
 
     def install_args(self, spec, prefix):
         # Have the parent class version set prefix
-        args = super().install_args(spec, prefix)
+        args = super(PythonPackage, self).install_args(spec, prefix)
         if '+mpi' in spec:
             args.append('--mpi')
         return args

--- a/var/spack/repos/builtin/packages/py-vermin/package.py
+++ b/var/spack/repos/builtin/packages/py-vermin/package.py
@@ -8,10 +8,11 @@ class PyVermin(PythonPackage):
     """Concurrently detect the minimum Python versions needed to run code."""
 
     homepage = "https://github.com/netromdk/vermin"
-    url      = "https://github.com/netromdk/vermin/archive/v1.3.1.tar.gz"
+    url      = "https://github.com/netromdk/vermin/archive/v1.3.2.tar.gz"
 
     maintainers = ['netromdk']
 
+    version('1.3.2', sha256='2818eaea24c5be5dae1f374ddb2377e9cfaad04d0a3372ad129cffc46cec5404')
     version('1.3.1', sha256='ddcdaad5a708a483af192075f5d2eaaaf3aa4661b5101ddafa40d7837eeb5368')
     version('1.3.0', sha256='adf2b6ea34c01c3a81fc4fa78c2e5fa6c8dd6d35327a8e5a4caeeaef7ec21668')
     version('1.2.2', sha256='d0343b2a78d7e4de67dfd2d882eeaf8b241db724f7e67f83bdd4111edb97f1e2')


### PR DESCRIPTION
[Release 1.3.2](https://github.com/netromdk/vermin/releases/tag/v1.3.2)

Added a check for `super()` used without arguments which requires Python 3.0+.

Was based on @adamjstewart's comment [here](https://github.com/spack/spack/pull/27930#discussion_r767286150).