### PR TITLE
py-nbconvert: add v6.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-nbconvert/package.py
+++ b/var/spack/repos/builtin/packages/py-nbconvert/package.py
@@ -10,6 +10,7 @@ class PyNbconvert(PythonPackage):
     homepage = "https://github.com/jupyter/nbconvert"
     pypi = "nbconvert/nbconvert-6.0.1.tar.gz"
 
+    version('6.3.0', sha256='5e77d6203854944520105e38f2563a813a4a3708e8563aa598928a3b5ee1081a')
     version('6.2.0', sha256='16ceecd0afaa8fd26c245fa32e2c52066c02f13aa73387fffafd84750baea863')
     version('6.0.1', sha256='db94117fbac29153834447e31b30cda337d4450e46e0bdb1a36eafbbf4435156')
     version('5.6.0', sha256='427a468ec26e7d68a529b95f578d5cbf018cb4c1f889e897681c2b6d11897695')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.