### PR TITLE
[gaudi] new versions 36.1 36.2 36.3

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -65,7 +65,8 @@ class Gaudi(CMakePackage):
     depends_on('zlib')
 
     # todo: this should be a test dependency only,
-    depends_on('py-nose', when="@35.0", type=('build', 'run'))
+    depends_on('py-nose', when="@35.0:36.1", type=('build', 'run'))
+    depends_on('py-pytest', when='@36.2:', type=('build', 'run'))
 
     # Adding these dependencies triggers the build of most optional components
     depends_on('cppgsl', when='+optional')

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -17,7 +17,7 @@ class Gaudi(CMakePackage):
 
     version('master', branch='master')
     version('36.3', sha256='9ac228d8609416afe4dea6445c6b3ccebac6fab1e46121fcc3a056e24a5d6640')
-    version('36.2', sha256='a1b4bb597941a7a5b8d60382674f0b4ca5349c540471cd3d4454efbe7b9a09b9')
+    version('36.2', sha256='a1b4bb597941a7a5b8d60382674f0b4ca5349c540471cd3d4454efbe7b9a09b9', preferred=True)
     version('36.1', sha256='9f718c832313676249e5c3ac76ba4346978ee2328f8cdcb29176498b080402e9')
     version('36.0', sha256='8a0458cef5b616532f9db7cca9fa0e892e602b64c9e93dc0cc6d972e03034830')
     version('35.0', sha256='c01b822f9592a7bf875b9997cbeb3c94dea97cb13d523c12649dbbf5d69b5fa6')

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -16,6 +16,7 @@ class Gaudi(CMakePackage):
     tags = ['hep']
 
     version('master', branch='master')
+    version('36.3', sha256='9ac228d8609416afe4dea6445c6b3ccebac6fab1e46121fcc3a056e24a5d6640')
     version('36.2', sha256='a1b4bb597941a7a5b8d60382674f0b4ca5349c540471cd3d4454efbe7b9a09b9')
     version('36.1', sha256='9f718c832313676249e5c3ac76ba4346978ee2328f8cdcb29176498b080402e9')
     version('36.0', sha256='8a0458cef5b616532f9db7cca9fa0e892e602b64c9e93dc0cc6d972e03034830')

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -16,6 +16,8 @@ class Gaudi(CMakePackage):
     tags = ['hep']
 
     version('master', branch='master')
+    version('36.2', sha256='a1b4bb597941a7a5b8d60382674f0b4ca5349c540471cd3d4454efbe7b9a09b9')
+    version('36.1', sha256='9f718c832313676249e5c3ac76ba4346978ee2328f8cdcb29176498b080402e9')
     version('36.0', sha256='8a0458cef5b616532f9db7cca9fa0e892e602b64c9e93dc0cc6d972e03034830')
     version('35.0', sha256='c01b822f9592a7bf875b9997cbeb3c94dea97cb13d523c12649dbbf5d69b5fa6')
     version('34.0', sha256='28fc4abb5a6b08da5a6b1300451c7e8487f918b055939877219d454abf7668ae')

--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -17,7 +17,7 @@ class Gaudi(CMakePackage):
 
     version('master', branch='master')
     version('36.3', sha256='9ac228d8609416afe4dea6445c6b3ccebac6fab1e46121fcc3a056e24a5d6640')
-    version('36.2', sha256='a1b4bb597941a7a5b8d60382674f0b4ca5349c540471cd3d4454efbe7b9a09b9', preferred=True)
+    version('36.2', sha256='a1b4bb597941a7a5b8d60382674f0b4ca5349c540471cd3d4454efbe7b9a09b9')
     version('36.1', sha256='9f718c832313676249e5c3ac76ba4346978ee2328f8cdcb29176498b080402e9')
     version('36.0', sha256='8a0458cef5b616532f9db7cca9fa0e892e602b64c9e93dc0cc6d972e03034830')
     version('35.0', sha256='c01b822f9592a7bf875b9997cbeb3c94dea97cb13d523c12649dbbf5d69b5fa6')


### PR DESCRIPTION
Quoting [v36r3](https://gitlab.cern.ch/gaudi/Gaudi/-/tags/v36r3): "This is a bugfix release with a couple of changes that technically are backward incompatible
because they fix issues that might have gone unnoticed."

For this reason, I am marking v36r2 as preferred to give dependents an opportunity to test (all dependents are in third-party repositories).

Maintainers tag: @drbenmorgan @vvolkl 