### PR TITLE
py-torchgeo: add v0.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -20,12 +20,12 @@ class PyTorchgeo(PythonPackage):
     maintainers = ['adamjstewart', 'calebrob6']
 
     version('main', branch='main')
+    version('0.1.1', sha256='6e28132f75e9d8cb3a3a0e8b443aba3cde26c8f3140b9426139ee6e8f8058b26')
     version('0.1.0', sha256='44eb3cf10ab2ac63ff95e92fcd3807096bac3dcb9bdfe15a8edac9d440d2f323')
 
     variant('datasets', default=False, description='Install optional dataset dependencies')
     variant('style', default=False, description='Install style checking tools')
     variant('tests', default=False, description='Install testing tools')
-    variant('train', default=False, description='Install optional trainer dependencies')
 
     # Required dependencies
     depends_on('python@3.6:+bz2', type=('build', 'run'))
@@ -35,13 +35,18 @@ class PyTorchgeo(PythonPackage):
     depends_on('py-kornia@0.5.4:', type=('build', 'run'))
     depends_on('py-matplotlib', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-omegaconf@2.1:', type=('build', 'run'))
     depends_on('pil@2.9:', type=('build', 'run'))
     depends_on('py-pyproj@2.2:', type=('build', 'run'))
     depends_on('py-pytorch-lightning@1.3:', type=('build', 'run'))
     depends_on('py-rasterio@1.0.16:', type=('build', 'run'))
     depends_on('py-rtree@0.5:', type=('build', 'run'))
+    depends_on('py-scikit-learn@0.18:', type=('build', 'run'))
     depends_on('py-shapely@1.3:', type=('build', 'run'))
+    depends_on('py-segmentation-models-pytorch@0.2:', type=('build', 'run'))
+    depends_on('py-timm@0.2.1:', type=('build', 'run'))
     depends_on('py-torch@1.7:', type=('build', 'run'))
+    depends_on('py-torchmetrics', type=('build', 'run'))
     depends_on('py-torchvision@0.3:', type=('build', 'run'))
 
     # Optional dependencies
@@ -64,10 +69,3 @@ class PyTorchgeo(PythonPackage):
         depends_on('py-nbmake@0.1:', type='run')
         depends_on('py-pytest@6:', type='run')
         depends_on('py-pytest-cov@2.4:', type='run')
-
-    with when('+train'):
-        depends_on('py-omegaconf@2.1:', type='run')
-        depends_on('py-scikit-learn@0.18:', type='run')
-        depends_on('py-segmentation-models-pytorch@0.2:', type='run')
-        depends_on('py-timm@0.2.1:', type='run')
-        depends_on('py-torchmetrics', type='run')


### PR DESCRIPTION
Successfully builds and passes all import tests on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.

We decided to move the `+train` dependencies into the list of required dependencies since they are needed to import large portions of the library.