### PR TITLE
New version for openCARP packages, v8.2

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -16,6 +16,7 @@ class Meshtool(MakefilePackage):
 
     version('master', branch='master')
     # Version to use with openCARP releases
+    version('ocv8.2', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')
     version('oc8.1', commit="6c5cfbd067120901f15a04bf63beec409bda6dc9")
     version('oc7.0', commit="6c5cfbd067120901f15a04bf63beec409bda6dc9")
 

--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -16,7 +16,7 @@ class Meshtool(MakefilePackage):
 
     version('master', branch='master')
     # Version to use with openCARP releases
-    version('ocv8.2', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')
+    version('oc8.2', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')
     version('oc8.1', commit="6c5cfbd067120901f15a04bf63beec409bda6dc9")
     version('oc7.0', commit="6c5cfbd067120901f15a04bf63beec409bda6dc9")
 

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -18,7 +18,8 @@ class Opencarp(CMakePackage):
 
     maintainers = ['MarieHouillon']
 
-    version('8.1', commit='28eb2e97', submodules=False, no_cache=True, preferred=True)
+    version('v8.2', commit='dbfd16fd', submodules=False, no_cache=True, preferred=True)
+    version('8.1', commit='28eb2e97', submodules=False, no_cache=True)
     version('7.0', commit='78da9195', submodules=False, no_cache=True)
     version('master', branch='master', submodules=False, no_cache=True)
 
@@ -40,7 +41,7 @@ class Opencarp(CMakePackage):
     depends_on('py-carputils')
     depends_on('meshtool')
     # Use specific versions of carputils and meshtool for releases
-    for ver in ['7.0', '8.1']:
+    for ver in ['v8.2', '7.0', '8.1']:
         depends_on('py-carputils@oc' + ver, when='@' + ver + ' +carputils')
         depends_on('meshtool@oc' + ver, when='@' + ver + ' +meshtool')
 

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -18,7 +18,7 @@ class Opencarp(CMakePackage):
 
     maintainers = ['MarieHouillon']
 
-    version('v8.2', commit='dbfd16fd', submodules=False, no_cache=True, preferred=True)
+    version('8.2', commit='dbfd16fd', submodules=False, no_cache=True, preferred=True)
     version('8.1', commit='28eb2e97', submodules=False, no_cache=True)
     version('7.0', commit='78da9195', submodules=False, no_cache=True)
     version('master', branch='master', submodules=False, no_cache=True)
@@ -41,7 +41,7 @@ class Opencarp(CMakePackage):
     depends_on('py-carputils')
     depends_on('meshtool')
     # Use specific versions of carputils and meshtool for releases
-    for ver in ['v8.2', '7.0', '8.1']:
+    for ver in ['8.2', '7.0', '8.1']:
         depends_on('py-carputils@oc' + ver, when='@' + ver + ' +carputils')
         depends_on('meshtool@oc' + ver, when='@' + ver + ' +meshtool')
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -14,6 +14,7 @@ class PyCarputils(PythonPackage):
 
     version('master', branch='master')
     # Version to use with openCARP releases
+    version('ocv8.2', commit='')
     version('oc8.1', commit='a4210fcb0fe17226a1744ee9629f85b629decba3')
     version('oc7.0', commit='4c04db61744f2fb7665594d7c810699c5c55c77c')
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -14,7 +14,7 @@ class PyCarputils(PythonPackage):
 
     version('master', branch='master')
     # Version to use with openCARP releases
-    version('ocv8.2', commit='')
+    version('oc8.2', commit='e60f639c0f39ad71c8ae11814de1f3aa726e8352')
     version('oc8.1', commit='a4210fcb0fe17226a1744ee9629f85b629decba3')
     version('oc7.0', commit='4c04db61744f2fb7665594d7c810699c5c55c77c')
 


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py-carputils.