### PR TITLE
Drop preferred hdf5 version

### DIFF
--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -123,7 +123,7 @@ class Conduit(CMakePackage):
     depends_on("hdf5~cxx", when="+hdf5~hdf5_compat+shared")
     depends_on("hdf5~shared~cxx", when="+hdf5~hdf5_compat~shared")
 
-    # conduit uses a <1.10 api version.
+    # conduit uses a <=1.10 api version.
     depends_on("hdf5@:1.10", when="+hdf5")
 
     # we need to hand this to conduit so it can properly

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -124,7 +124,7 @@ class Conduit(CMakePackage):
     depends_on("hdf5~shared~cxx", when="+hdf5~hdf5_compat~shared")
 
     # conduit uses a <=1.10 api version.
-    depends_on("hdf5@:1.10", when="+hdf5")
+    depends_on("hdf5@:1.10", when="@:0.7 +hdf5")
 
     # we need to hand this to conduit so it can properly
     # handle downstream linking of zlib reqed by hdf5

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -122,6 +122,10 @@ class Conduit(CMakePackage):
     depends_on("hdf5@1.8.19:1.8~shared~cxx", when="+hdf5+hdf5_compat~shared")
     depends_on("hdf5~cxx", when="+hdf5~hdf5_compat+shared")
     depends_on("hdf5~shared~cxx", when="+hdf5~hdf5_compat~shared")
+
+    # conduit uses a <1.10 api version.
+    depends_on("hdf5@:1.10", when="+hdf5")
+
     # we need to hand this to conduit so it can properly
     # handle downstream linking of zlib reqed by hdf5
     depends_on("zlib", when="+hdf5")

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -38,10 +38,7 @@ class Hdf5(CMakePackage):
     version('1.13.0', sha256='3049faf900f0c52e09ea4cddfb83af057615f2fc1cc80eb5202dd57b09820115')
     version('1.12.1', sha256='79c66ff67e666665369396e9c90b32e238e501f345afd2234186bfb8331081ca')
     version('1.12.0', sha256='a62dcb276658cb78e6795dd29bf926ed7a9bc4edf6e77025cd2c689a8f97c17a')
-    # HDF5 1.12 broke API compatibility, so we currently prefer the latest
-    # 1.10 release.  packages that want later versions of HDF5 should specify,
-    # e.g., depends_on("hdf5@1.12:") to get 1.12 or higher.
-    version('1.10.8', sha256='d341b80d380dd763753a0ebe22915e11e87aac4e44a084a850646ff934d19c80', preferred=True)
+    version('1.10.8', sha256='d341b80d380dd763753a0ebe22915e11e87aac4e44a084a850646ff934d19c80')
     version('1.10.7', sha256='7a1a0a54371275ce2dfc5cd093775bb025c365846512961e7e5ceaecb437ef15')
     version('1.10.6', sha256='5f9a3ee85db4ea1d3b1fa9159352aebc2af72732fc2f58c96a3f0768dba0e9aa')
     version('1.10.5', sha256='6d4ce8bf902a97b050f6f491f4268634e252a63dadd6656a1a9be5b7b7726fa8')

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -59,6 +59,7 @@ class Silo(AutotoolsPackage):
     patch('H5EPR_SEMI_COLON.patch', when='@:4.11 ^hdf5@1.10.8:1.10,1.12.1:1.12')
 
     conflicts('hdf5@1.10.8:', when="@:4.10.2")
+    conflicts('hdf5@1.13.0:', when="@:4.11")
     conflicts('+hzip', when="@4.11-bsd")
     conflicts('+fpzip', when="@4.11-bsd")
     conflicts('+hzip', when="@4.10.2-bsd")


### PR DESCRIPTION
The recommendation is a bit backward to me... packages should define their compatibility with hdf5. Some packages are compatible with any api, and they now get an old version by default.

If packages are incompatible they should specify bounds, we should not default to providing old versions of hdf5.
