### PR TITLE
spack audit: add test for package detection

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -332,6 +332,8 @@ jobs:
       run: |
           . share/spack/setup-env.sh
           coverage run $(which spack) audit packages
+          coverage run $(which spack) audit externals --list
+          coverage run $(which spack) audit externals
           coverage combine
           coverage xml
     - name: Package audits (wwithout coverage)
@@ -339,6 +341,8 @@ jobs:
       run: |
           . share/spack/setup-env.sh
           $(which spack) audit packages
+          $(which spack) audit externals --list
+          $(which spack) audit externals
     - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # @v2.1.0
       if: ${{ needs.changes.outputs.with_coverage == 'true' }}
       with:

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -5362,6 +5362,94 @@ follows:
 
 .. _package-lifecycle:
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Add detection tests to packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To ensure that a software is detected correctly for multiple configurations
+and on different systems users can write a ``detection_test.yaml`` file and
+put it in the same directory as the corresponding ``package.py`` file.
+This YAML file contains enough information for Spack to mock an environment
+and try to check if the detection logic yields the results that are expected.
+
+As a general rule, attributes at the top-level of ``detection_test.yaml``
+represent search mechanisms and they all map to a list of tests that should confirm
+the validity of each package detection logic.
+
+The detection tests can be run with the following command:
+
+.. code-block:: console
+
+   $ spack audit externals
+
+Errors that have been detected are reported to screen.
+
+""""""""""""""""""""""""""
+Tests for PATH inspections
+""""""""""""""""""""""""""
+
+Detection tests insisting on ``PATH`` inspections are listed under
+the ``paths`` attribute:
+
+.. code-block:: yaml
+
+   paths:
+   - layout:
+     - subdir: [bin]
+       name: clang-3.9
+       output: |
+         echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+         echo "Target: x86_64-pc-linux-gnu"
+         echo "Thread model: posix"
+         echo "InstalledDir: /usr/bin"
+     - subdir: [bin]
+       name: clang++-3.9
+       output: |
+         echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+         echo "Target: x86_64-pc-linux-gnu"
+         echo "Thread model: posix"
+         echo "InstalledDir: /usr/bin"
+     results:
+     - spec: 'llvm@3.9.1 +clang~lld~lldb'
+
+Each test is performed by first creating a temporary directory structure as
+specified in the corresponding ``layout`` and by then running
+package detection and checking that the outcome matches the expected
+``results``. The exact details on how to specify both the ``layout`` and the
+``results`` are reported in the table below:
+
+.. list-table:: Test based on PATH inspections
+   :header-rows: 1
+
+   * - Option Name
+     - Description
+     - Allowed Values
+     - Required Field
+   * - ``layout``
+     - Specifies the filesystem tree used for the test
+     - List of objects
+     - Yes
+   * - ``layout:[0]:subdir``
+     - Subdirectory for this executable
+     - List of strings
+     - Yes
+   * - ``layout:[0]:name``
+     - Name of the executable
+     - A valid filename
+     - Yes
+   * - ``layout:[0]:output``
+     - Mock logic for the executable
+     - Any valid shell script
+     - Yes
+   * - ``results``
+     - List of expected results
+     - List of objects (empty if no result is expected)
+     - Yes
+   * - ``results:[0]:spec``
+     - A spec that is expected from detection
+     - Any valid spec
+     - Yes
+
 -----------------------------
 Style guidelines for packages
 -----------------------------

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -390,12 +390,21 @@ _spack_audit() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="configs packages-https packages list"
+        SPACK_COMPREPLY="configs externals packages-https packages list"
     fi
 }
 
 _spack_audit_configs() {
     SPACK_COMPREPLY="-h --help"
+}
+
+_spack_audit_externals() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --list"
+    else
+        SPACK_COMPREPLY=""
+    fi
 }
 
 _spack_audit_packages_https() {

--- a/var/spack/repos/builtin/packages/gcc/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/gcc/detection_test.yaml
@@ -1,0 +1,46 @@
+paths:
+  # Ubuntu 18.04, system compilers without Fortran
+  - layout:
+      - subdir: [bin]
+        name: gcc
+        output: "echo 7.5.0"
+      - subdir: [bin]
+        name: g++
+        output: "echo 7.5.0"
+    results:
+      - spec: "gcc@7.5.0 languages=c,c++"
+  # Mock a version < 7 of GCC that requires -dumpversion and
+  # errors with -dumpfullversion
+  - layout:
+      - subdir: [bin]
+        name: gcc-5
+        output: |
+          if [[ "$1" == "-dumpversion" ]] ; then
+            echo "5.5.0"
+          else
+            echo "gcc-5: fatal error: no input files"
+            echo "compilation terminated."
+            exit 1
+          fi
+      - subdir: [bin]
+        name: g++-5
+        output: "echo 5.5.0"
+      - subdir: [bin]
+        name: gfortran-5
+        output: "echo 5.5.0"
+    results:
+      - spec: "gcc@5.5.0 languages=c,c++,fortran"
+  # Multiple compilers present at the same time
+  - layout:
+      - subdir: [bin]
+        name: x86_64-linux-gnu-gcc-6
+        output: 'echo 6.5.0'
+      - subdir: [bin]
+        name: x86_64-linux-gnu-gcc-10
+        output: "echo 10.1.0"
+      - subdir: [bin]
+        name: x86_64-linux-gnu-g++-10
+        output: "echo 10.1.0"
+    results:
+      - spec: "gcc@6.5.0 languages=c"
+      - spec: "gcc@10.1.0 languages=c,c++"

--- a/var/spack/repos/builtin/packages/intel/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/intel/detection_test.yaml
@@ -1,0 +1,19 @@
+paths:
+  - layout:
+      - subdir: [bin, intel64]
+        name: icc
+        output: |
+          echo "icc (ICC) 18.0.5 20180823"
+          echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
+      - subdir: [bin, intel64]
+        name: icpc
+        output: |
+          echo "icpc (ICC) 18.0.5 20180823"
+          echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
+      - subdir: [bin, intel64]
+        name: ifort
+        output: |
+          echo "ifort (IFORT) 18.0.5 20180823"
+          echo "Copyright (C) 1985-2018 Intel Corporation.  All rights reserved."
+    results:
+      - spec: 'intel@18.0.5'

--- a/var/spack/repos/builtin/packages/llvm/detection_test.yaml
+++ b/var/spack/repos/builtin/packages/llvm/detection_test.yaml
@@ -1,0 +1,74 @@
+paths:
+  - layout:
+      - subdir: [bin]
+        name: clang-3.9
+        output: |
+          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+      - subdir: [bin]
+        name: clang++-3.9
+        output: |
+          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+    results:
+      - spec: 'llvm@3.9.1 +clang~lld~lldb'
+  # Multiple LLVM packages in the same prefix
+  - layout:
+      - subdir: [bin]
+        name: clang-8
+        output: |
+          echo "clang version 8.0.0-3~ubuntu18.04.2 (tags/RELEASE_800/final)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+      - subdir: [bin]
+        name: clang++-8
+        output: |
+          echo "clang version 8.0.0-3~ubuntu18.04.2 (tags/RELEASE_800/final)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+      - subdir: [bin]
+        name: ld.lld-8
+        output: 'echo "LLD 8.0.0 (compatible with GNU linkers)"'
+      - subdir: [bin]
+        name: lldb
+        output: 'echo "lldb version 8.0.0"'
+      - subdir: [bin]
+        name: clang-3.9
+        output: |
+          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+      - subdir: [bin]
+        name: clang++-3.9
+        output: |
+          echo "clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)"
+          echo "Target: x86_64-pc-linux-gnu"
+          echo "Thread model: posix"
+          echo "InstalledDir: /usr/bin"
+    results:
+      - spec: 'llvm@8.0.0+clang+lld+lldb'
+      - spec: 'llvm@3.9.1+clang~lld~lldb'
+  # Apple Clang should not be detected
+  - layout:
+    - subdir: [bin]
+      name: clang
+      output: |
+        echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
+        echo "Target: x86_64-apple-darwin19.5.0"
+        echo "Thread model: posix"
+        echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
+    - subdir: [bin]
+      name: 'clang++'
+      output: |
+        echo "Apple clang version 11.0.0 (clang-1100.0.33.8)"
+        echo "Target: x86_64-apple-darwin19.5.0"
+        echo "Thread model: posix"
+        echo "InstalledDir: /Library/Developer/CommandLineTools/usr/bin"
+    results: []


### PR DESCRIPTION
closes #21343
closes #18175

This PR adds a new type of audit, triggered by:
```console
$ spack audit externals
```
that verifies the detection of external packages. The overall mechanism is based on providing some metadata to mock the detection of software alongside the recipe in `package.py`. The PR is an alternative to the two at the top, that perform the same tests as unit tests. 

`spack audit externals` will be used in following PRs to replicate all the compiler detection unit tests at the level of each package providing a compiler. Moving these tests to packages is a required step towards compiler as dependencies.

## Notes
The metadata in the PR is in the form of a YAML file called `detection_test.yaml`, rather than a literal dictionary in `package.py` as tried in #21343. This is because having seen both options I like the YAML file better as it doesn't bloat the recipe - but of course I'm open to change that if there's a strong consensus towards coding a literal dictionary. Link to previous discussion on whether having a YAML or a dict literal is at https://github.com/spack/spack/pull/18175#discussion_r474862436