### PR TITLE
py-tensorflow-estimator: new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -17,6 +17,9 @@ class PyTensorflowEstimator(Package):
 
     maintainers = ['aweits']
 
+    version('2.7.0', sha256='e5164e802638d3cf110ecc17912be9d514a9d3354ec48e77200b9403dcc15965')
+    version('2.6.0', sha256='947705c60c50da0b4a8ceec1bc058aaf6bf567a7efdcd50d5173ebf6bafcf30f')
+    version('2.5.0', sha256='66661f30ea05d57377c45267ca770935fb8c54f85b7901f0a7deb91766fe9f45')
     version('2.4.0', sha256='e6ea12014c3d8c89a81ace95f8f8b7c39ffcd3e4e4626709e4aee0010eefd962')
     version('2.3.0', sha256='75403e7de7e8ec30ec0781ede56ed84cbe5e90daad64a9c242cd489c8fe63a17')
     version('2.2.0', sha256='2d68cb6e6442e7dcbfa2e092aa25bdcb0eda420536a829b85d732854a4c85d46')
@@ -26,6 +29,11 @@ class PyTensorflowEstimator(Package):
 
     extends('python')
 
+    depends_on('py-keras@2.7.0:2.7', type=('build', 'run'), when='@2.7.0')
+    depends_on('py-keras@2.6.0:2.6', type=('build', 'run'), when='@2.6.0')
+    depends_on('py-tensorflow@2.7.0:2.7', type=('build', 'run'), when='@2.7.0')
+    depends_on('py-tensorflow@2.6.0:2.6', type=('build', 'run'), when='@2.6.0')
+    depends_on('py-tensorflow@2.5.0:2.5', type=('build', 'run'), when='@2.5.0')
     depends_on('py-tensorflow@2.4.0:2.4', type=('build', 'run'), when='@2.4.0')
     depends_on('py-tensorflow@2.3.0:2.3', type=('build', 'run'), when='@2.3.0')
     depends_on('py-tensorflow@2.2.0:2.2', type=('build', 'run'), when='@2.2.0')

--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -44,7 +44,7 @@ class PyTensorflowEstimator(Package):
     depends_on('bazel@0.19.0:', type='build')
     depends_on('py-pip', type='build')
     depends_on('py-wheel', type='build')
-    depends_on('py-funcsigs@1.0.2:', type=('build', 'run'))
+    depends_on('py-funcsigs@1.0.2:', type=('build', 'run'), when='^python@:3.2')
 
     def install(self, spec, prefix):
         self.tmp_path = tempfile.mkdtemp(dir='/tmp', prefix='spack')


### PR DESCRIPTION
Add versions
- 2.5.0
- 2.6.0
- 2.7.0

Depends on the following PRs:
- #27138 
- #27991 