### PR TITLE
Support of Intel oneAPI 2022.1.1 release

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from os.path import dirname
+
 from spack.compiler import Compiler
 
 
@@ -105,3 +107,11 @@ class Oneapi(Compiler):
     @property
     def stdcxx_libs(self):
         return ('-cxxlib', )
+
+    def setup_custom_environment(self, pkg, env):
+        # workaround bug in icpx driver where it requires sycl-post-link is on the PATH
+        # It is located in the same directory as the driver. Error message:
+        #   clang++: error: unable to execute command:
+        #   Executable "sycl-post-link" doesn't exist!
+        if self.cxx:
+            env.prepend_path('PATH', dirname(self.cxx))

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -184,13 +184,6 @@ def test_intel_version_detection(version_str, expected_version):
         'InstalledDir: /made/up/path',
         '2021.4.0'
     ),
-    (  # ICX/ICPX
-        'Intel(R) oneAPI DPC++/C++ Compiler 2022.0.0 (2022.0.0.20211123)\n'
-        'Target: x86_64-unknown-linux-gnu\n'
-        'Thread model: posix\n'
-        'InstalledDir: /made/up/path',
-        '2022.0.1'
-    ),
     (  # IFX
         'ifx (IFORT) 2021.1.2 Beta 20201214\n'
         'Copyright (C) 1985-2020 Intel Corporation. All rights reserved.',
@@ -214,7 +207,7 @@ def test_intel_version_detection(version_str, expected_version):
     (  # IFX
         'ifx (IFORT) 2022.0.0 20211123\n'
         'Copyright (C) 1985-2021 Intel Corporation. All rights reserved.',
-        '2022.0.1'
+        '2022.0.0'
     ),
 ])
 def test_oneapi_version_detection(version_str, expected_version):

--- a/lib/spack/spack/test/compilers/detection.py
+++ b/lib/spack/spack/test/compilers/detection.py
@@ -184,6 +184,13 @@ def test_intel_version_detection(version_str, expected_version):
         'InstalledDir: /made/up/path',
         '2021.4.0'
     ),
+    (  # ICX/ICPX
+        'Intel(R) oneAPI DPC++/C++ Compiler 2022.0.0 (2022.0.0.20211123)\n'
+        'Target: x86_64-unknown-linux-gnu\n'
+        'Thread model: posix\n'
+        'InstalledDir: /made/up/path',
+        '2022.0.1'
+    ),
     (  # IFX
         'ifx (IFORT) 2021.1.2 Beta 20201214\n'
         'Copyright (C) 1985-2020 Intel Corporation. All rights reserved.',
@@ -203,6 +210,11 @@ def test_intel_version_detection(version_str, expected_version):
         'ifx (IFORT) 2021.4.0 Beta 20210924\n'
         'Copyright (C) 1985-2021 Intel Corporation. All rights reserved.',
         '2021.4.0'
+    ),
+    (  # IFX
+        'ifx (IFORT) 2022.0.0 20211123\n'
+        'Copyright (C) 1985-2021 Intel Corporation. All rights reserved.',
+        '2022.0.1'
     ),
 ])
 def test_oneapi_version_detection(version_str, expected_version):

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -19,6 +19,10 @@ class IntelOneapiAdvisor(IntelOneApiPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/advisor.html'
 
     if platform.system() == 'Linux':
+        version('2022.0.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18369/l_oneapi_advisor_p_2022.0.0.92_offline.sh',
+                sha256='f1c4317c2222c56fb2e292513f7eec7ec27eb1049d3600cb975bc08ed1477993',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18220/l_oneapi_advisor_p_2021.4.0.389_offline.sh',
                 sha256='dd948f7312629d9975e12a57664f736b8e011de948771b4c05ad444438532be8',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -18,6 +18,10 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on('intel-oneapi-mpi')
 
     if platform.system() == 'Linux':
+        version('2021.5.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18371/l_oneapi_ccl_p_2021.5.0.478_offline.sh',
+                sha256='47584ad0269fd13bcfbc2cd0bb029bdcc02b723070abcb3d5e57f9586f4e74f8',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18188/l_oneapi_ccl_p_2021.4.0.433_offline.sh',
                 sha256='004031629d97ef99267d8ea962b666dc4be1560d7d32bd510f97bc81d9251ef6',

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -22,6 +22,16 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     depends_on('patchelf', type='build')
 
     if platform.system() == 'Linux':
+        version('2022.0.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh',
+                sha256='c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a',
+                expand=False)
+        resource(name='fortran-installer',
+                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18436/l_fortran-compiler_p_2022.0.1.70_offline.sh',
+                 sha256='2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1',
+                 expand=False,
+                 placement='fortran-installer',
+                 when='@2022.0.1')
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh',
                 sha256='9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onedal.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18432/l_daal_oneapi_p_2021.5.1.803_offline.sh',
+                sha256='bba7bee3caef14fbb54ad40615222e5da429496455edf7375f11fd84a72c87ba',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18218/l_daal_oneapi_p_2021.4.0.729_offline.sh',
                 sha256='61da9d2a40c75edadff65d052fd84ef3db1da5d94f86ad3956979e6988549dda',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onednn.html'
 
     if platform.system() == 'Linux':
+        version('2022.0.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18441/l_onednn_p_2022.0.1.26_offline.sh',
+                sha256='8339806300d83d2629952e6e2f2758b52f517c072a20b7b7fc5642cf1e2a5410',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18221/l_onednn_p_2021.4.0.467_offline.sh',
                 sha256='30cc601467f6a94b3d7e14f4639faf0b12fdf6d98df148b07acdb4dfdfb971db',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
     homepage = 'https://github.com/oneapi-src/oneDPL'
 
     if platform.system() == 'Linux':
+        version('2021.6.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18372/l_oneDPL_p_2021.6.0.501_offline.sh',
+                sha256='0225f133a6c38b36d08635986870284a958e5286c55ca4b56a4058bd736f8f4f',
+                expand=False)
         version('2021.5.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18189/l_oneDPL_p_2021.5.0.445_offline.sh',
                 sha256='7d4adf300a18f779c3ab517070c61dba10e3952287d5aef37c38f739e9041a68',

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -17,6 +17,10 @@ class IntelOneapiInspector(IntelOneApiPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/inspector.html'
 
     if platform.system() == 'Linux':
+        version('2022.0.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18363/l_inspector_oneapi_p_2022.0.0.56_offline.sh',
+                sha256='79a0eb2ae3f1de1e3456076685680c468702922469c3fda3e074718fb0bea741',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18239/l_inspector_oneapi_p_2021.4.0.266_offline.sh',
                 sha256='c8210cbcd0e07cc75e773249a5e4a02cf34894ec80a213939f3a20e6c5705274',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -16,6 +16,10 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18440/l_ipp_oneapi_p_2021.5.1.522_offline.sh',
+                sha256='be99f9b0b2cc815e017188681ab997f3ace94e3010738fa6f702f2416dac0de4',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18219/l_ipp_oneapi_p_2021.4.0.459_offline.sh',
                 sha256='1a7a8fe5502ae61c10f5c432b7662c6fa542e5832a40494eb1c3a2d8e27c9f3e',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -17,6 +17,10 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18364/l_ippcp_oneapi_p_2021.5.0.445_offline.sh',
+                sha256='e71aee288cc970b9c9fe21f7d5c300dbc2a4ea0687c7028f200d6b87e6c895a1',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18187/l_ippcp_oneapi_p_2021.4.0.401_offline.sh',
                 sha256='2ca2320f733ee75b4a27865185a1b0730879fe2c47596e570b1bd50d0b8ac608',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -17,6 +17,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html'
 
     if platform.system() == 'Linux':
+        version('2022.0.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18444/l_onemkl_p_2022.0.1.117_offline.sh',
+                sha256='22afafbe2f3762eca052ac21ec40b845ff2f3646077295c88c2f37f80a0cc160',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18222/l_onemkl_p_2021.4.0.640_offline.sh',
                 sha256='9ad546f05a421b4f439e8557fd0f2d83d5e299b0d9bd84bdd86be6feba0c3915',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -17,6 +17,10 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18370/l_mpi_oneapi_p_2021.5.0.495_offline.sh',
+                sha256='3aae53fe77f7c6aac7a32b299c25d6ca9a00ba4e2d512a26edd90811e59e7471',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18186/l_mpi_oneapi_p_2021.4.0.441_offline.sh',
                 sha256='cc4b7072c61d0bd02b1c431b22d2ea3b84b967b59d2e587e77a9e7b2c24f2a29',

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -17,6 +17,10 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onetbb.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18380/l_tbb_oneapi_p_2021.5.0.707_offline.sh',
+                sha256='6ff7890a74a43ae02e0fa2d9c5533fce70a49dff8e73278b546a0995367fec5e',
+                expand=False)
         version('2021.4.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18194/l_tbb_oneapi_p_2021.4.0.643_offline.sh',
                 sha256='33332012ff8ffe7987b1a20bea794d76f7d8050ccff04fa6e1990974c336ee24',

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -16,6 +16,10 @@ class IntelOneapiVpl(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onevpl.html'
 
     if platform.system() == 'Linux':
+        version('2022.0.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18375/l_oneVPL_p_2022.0.0.58_offline.sh',
+                sha256='600b8566e1aa523b97291bed6b08f69a04bc7c4c75c035942a64a38f45a1a7f0',
+                expand=False)
         version('2021.6.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18190/l_oneVPL_p_2021.6.0.458_offline.sh',
                 sha256='40c50008be3f03d17cc8c0c34324593c1d419ee4c45af5543aa5a2d5fb11071f',

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -19,6 +19,10 @@ class IntelOneapiVtune(IntelOneApiPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/vtune-profiler.html'
 
     if platform.system() == 'Linux':
+        version('2022.0.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18406/l_oneapi_vtune_p_2022.0.0.94_offline.sh',
+                sha256='aa4d575c22e7be0c950b87d67d9e371f470f682906864c4f9b68e530ecd22bd7',
+                expand=False)
         version('2021.7.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18086/l_oneapi_vtune_p_2021.7.1.492_offline.sh',
                 sha256='4cf17078ae6e09f26f70bd9d0b726af234cc30c342ae4a8fda69941b40139b26',


### PR DESCRIPTION
@tldahlgren @scheibelp: Would it be possible to merge this today or tomorrow? The people who do the oneapi releases want everything done by Wednesday.

Testing results are here: https://github.com/rscohn2/oneapi-spack-tests/runs/4586693872?check_suite_focus=true

Release update came from @andreyeg-intel and @ekarpovi. @rscohn2 added the workaround for the compiler.