### PR TITLE
structure: fixing build errors with gcc10+ removing unused dep

### DIFF
--- a/var/spack/repos/builtin/packages/structure/package.py
+++ b/var/spack/repos/builtin/packages/structure/package.py
@@ -15,11 +15,12 @@ class Structure(MakefilePackage):
 
     version('2.3.4', sha256='f2b72b9189a514f53e921bbdc1aa3dbaca7ac34a8467af1f972c7e4fc9c0bb37')
 
-    depends_on('jdk', type=('build', 'run'))
-
     def url_for_version(self, version):
         url = "http://web.stanford.edu/group/pritchardlab/structure_software/release_versions/v{0}/structure_kernel_source.tar.gz"
         return url.format(version)
+
+    def edit(self, spec, prefix):
+        filter_file(r'(CFLAGS =.*$)', '\\1 -fcommon', 'Makefile')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/structure/package.py
+++ b/var/spack/repos/builtin/packages/structure/package.py
@@ -19,6 +19,7 @@ class Structure(MakefilePackage):
         url = "http://web.stanford.edu/group/pritchardlab/structure_software/release_versions/v{0}/structure_kernel_source.tar.gz"
         return url.format(version)
 
+    @when('%gcc@10:')
     def edit(self, spec, prefix):
         filter_file(r'(CFLAGS =.*$)', '\\1 -fcommon', 'Makefile')
 


### PR DESCRIPTION
Fixing the compilation errors from the various non extern global variables with -fcommon is easier than the changes that would be necessary to do it properly. 

Also this had java as a build and run dep, but I couldn't find it being used anywhere