### PR TITLE
soapdenovo2: fixing compiler errors in gcc10+

### DIFF
--- a/var/spack/repos/builtin/packages/soapdenovo2/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo2/package.py
@@ -19,6 +19,14 @@ class Soapdenovo2(MakefilePackage):
     version('242', sha256='a0043ceb41bc17a1c3fd2b8abe4f9029a60ad3edceb2b15af3c2cfabd36aa11b')
     version('240', sha256='cc9e9f216072c0bbcace5efdead947e1c3f41f09baec5508c7b90f933a090909')
 
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('%gcc@10:'):
+            if name == 'cflags' or name == 'CFLAGS':
+                flags.append('-fcommon')
+            if name == 'cxxflags' or name == 'CXXFLAGS':
+                flags.append('-fcommon')
+        return (flags, None, None)
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('SOAPdenovo-63mer', prefix.bin)


### PR DESCRIPTION
Another one of these where it's just easier to restore the older compiler behavior (-fcommon) for newer gccs.