### PR TITLE
py-build: add virtualenv variant

### DIFF
--- a/var/spack/repos/builtin/packages/py-build/package.py
+++ b/var/spack/repos/builtin/packages/py-build/package.py
@@ -14,6 +14,8 @@ class PyBuild(PythonPackage):
 
     version('0.7.0', sha256='1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f')
 
+    variant('virtualenv', default=False, description='Install optional virtualenv dependency')
+
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-packaging@19:', type=('build', 'run'))
@@ -21,3 +23,4 @@ class PyBuild(PythonPackage):
     depends_on('py-tomli@1:', type=('build', 'run'))
     depends_on('py-colorama', when='platform=windows', type=('build', 'run'))
     depends_on('py-importlib-metadata@0.22:', when='^python@:3.7', type=('build', 'run'))
+    depends_on('py-virtualenv@20.0.35:', when='+virtualenv', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.