### PR TITLE
Fix: HDF5 1.10.8/1.13.0 CMake Path

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -382,7 +382,7 @@ class Hdf5(CMakePackage):
                                         spec['mpi'].mpifc))
 
         # work-around for https://github.com/HDFGroup/hdf5/issues/1320
-        if spec.satisfies('@1.10.8') and sys.platform != 'windows':
+        if spec.satisfies('@1.10.8,1.13.0'):
             args.append(self.define('HDF5_INSTALL_CMAKE_DIR',
                                     'share/cmake/hdf5'))
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -381,6 +381,11 @@ class Hdf5(CMakePackage):
                 args.append(self.define('CMAKE_Fortran_COMPILER',
                                         spec['mpi'].mpifc))
 
+        # work-around for https://github.com/HDFGroup/hdf5/issues/1320
+        if spec.satisfies('@1.10.8') and sys.platform != 'windows':
+            args.append(self.define('HDF5_INSTALL_CMAKE_DIR',
+                                    'share/cmake/hdf5'))
+
         return args
 
     @run_after('install')


### PR DESCRIPTION
Fix the broken CMake config package path in HDF5 1.10.8 via a Spack based work-around.

Upstream: https://github.com/HDFGroup/hdf5/issues/1320

Close #28084
Close #28083
Close #28074