### PR TITLE
Harden variant '+external-libfabric' for indirect MPI reference.

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -26,6 +26,7 @@ from llnl.util.filesystem import (
 
 from spack.build_environment import dso_suffix
 from spack.package import InstallError, PackageBase, run_after
+from spack.spec import Spec
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
 from spack.util.prefix import Prefix
@@ -1006,7 +1007,9 @@ class IntelPackage(PackageBase):
             if self.version_yearlike >= ver('2019'):
                 d = ancestor(self.component_lib_dir('mpi'))
                 if '+external-libfabric' in self.spec:
-                    result += self.spec['libfabric'].libs
+                    spec = Spec('libfabric')
+                    spec.concretize()
+                    result += spec['libfabric'].libs
                 else:
                     result += find_libraries(['libfabric'],
                                              os.path.join(d, 'libfabric', 'lib'))

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -88,7 +88,9 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
         # Find libfabric for libmpi.so
         if '+external-libfabric' in self.spec:
-            libs += self.spec['libfabric'].libs
+            spec = spec.Spec('libfabric')
+            spec.concretize()
+            libs += spec['libfabric'].libs
         else:
             libs += find_libraries(['libfabric'],
                                    join_path(self.component_path, 'libfabric', 'lib'))

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -88,7 +88,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
         # Find libfabric for libmpi.so
         if '+external-libfabric' in self.spec:
-            spec = spec.Spec('libfabric')
+            spec = spack.spec.Spec('libfabric')
             spec.concretize()
             libs += spec['libfabric'].libs
         else:


### PR DESCRIPTION
When `intel-mpi` is called indirectly by e.g. `spack install openfoam` then the resulting spec for the MPI will not contain the sub-string 'libfabric'. Hence, a call to `spec['libfabric']` inside `intel-mpi/package.py` will fail. The workaround I have found is to build a new Spec object around libfabric and use this to determine the libraries in case '+xternal-libfabric' is set.
The same applies to `intel-oneapi-mpi`.

This is an addition to https://github.com/spack/spack/pull/27292

Taging maintiner @rscohn2. 
