### PR TITLE
openmpi: extend version range for cray flags

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -685,7 +685,7 @@ class Openmpi(AutotoolsPackage):
         if 'fabrics=auto' not in spec:
             config_args.extend(self.with_or_without('fabrics'))
 
-        if spec.satisfies('@2.0.0'):
+        if spec.satisfies('@2.0.0:'):
             if 'fabrics=xpmem' in spec and 'platform=cray' in spec:
                 config_args.append('--with-cray-xpmem')
             else:


### PR DESCRIPTION
- Observed build failure of OpenMPI 4.x with `fabrics=xpmem` on non-cray platforms because of missing explicit mention of this flag `--without-cray-xpmem`
