### PR TITLE
ELF: verify needed libraries are resolvable

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -202,6 +202,10 @@ config:
     # executables with many dependencies, in particular on slow filesystems.
     bind: false
 
+    # When set to true, installation will fail when needed libraries cannot be located
+    # directly or in rpaths.
+    strict: false
+
 
   # Set to 'false' to allow installation on filesystems that doesn't allow setgid bit
   # manipulation by unprivileged user (e.g. AFS)

--- a/lib/spack/spack/hooks/check_dynamic_linking_elf.py
+++ b/lib/spack/spack/hooks/check_dynamic_linking_elf.py
@@ -22,7 +22,6 @@ skip_list = frozenset(
         b"ld-linux-x86-64",
         b"libc",
         b"libdl",
-        b"libgcc_s",
         b"libm",
         b"libmemusage",
         b"libmvec",
@@ -53,6 +52,8 @@ skip_list = frozenset(
         b"libstdc++",
         b"libtsan",
         b"libubsan",
+        # systemd
+        b"libudev",
     ]
 )
 

--- a/lib/spack/spack/hooks/check_dynamic_linking_elf.py
+++ b/lib/spack/spack/hooks/check_dynamic_linking_elf.py
@@ -1,0 +1,203 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import io
+import os
+
+import llnl.util.tty as tty
+from llnl.util.filesystem import BaseDirectoryVisitor, visit_directory_tree
+from llnl.util.lang import stable_partition
+
+import spack.util.elf as elf
+
+skip_list = frozenset(
+    [
+        # kernel
+        b"linux-vdso",
+        # glibc
+        b"ld-linux-x86-64",
+        b"libc",
+        b"libdl",
+        b"libgcc_s",
+        b"libm",
+        b"libmemusage",
+        b"libmvec",
+        b"libnsl",
+        b"libnss_compat",
+        b"libnss_db",
+        b"libnss_dns",
+        b"libnss_files",
+        b"libnss_hesiod",
+        b"libpcprofile",
+        b"libpthread",
+        b"libresolv",
+        b"librt",
+        b"libSegFault",
+        b"libthread_db",
+        b"libutil",
+        # gcc
+        b"libasan",
+        b"libatomic",
+        b"libcc1",
+        b"libgcc_s",
+        b"libgfortran",
+        b"libgomp",
+        b"libitm",
+        b"liblsan",
+        b"libquadmath",
+        b"libssp",
+        b"libstdc++",
+        b"libtsan",
+        b"libubsan",
+    ]
+)
+
+
+def is_compatible(parent, child):
+    return (
+        child.elf_hdr.e_type == elf.ELF_CONSTANTS.ET_DYN
+        and parent.is_little_endian == child.is_little_endian
+        and parent.is_64_bit == child.is_64_bit
+        and parent.elf_hdr.e_machine == child.elf_hdr.e_machine
+    )
+
+
+def candidate_matches(current_elf, candidate_path):
+    try:
+        with open(candidate_path, "rb") as g:
+            return is_compatible(current_elf, elf.parse_elf(g))
+    except (IOError, elf.ElfParsingError):
+        return False
+
+
+def should_be_searched(needed_lib):
+    offset = needed_lib.find(b".so")
+    return offset == -1 or needed_lib[:offset] not in skip_list
+
+
+class Problem:
+    def __init__(self, resolved, unresolved):
+        self.resolved = resolved
+        self.unresolved = unresolved
+
+
+class ResolveSharedElfLibDepsVisitor(BaseDirectoryVisitor):
+    def __init__(self):
+        self.problems = {}
+
+    def visit_file(self, root, rel_path, depth):
+        # We work with byte strings for paths.
+        path = os.path.join(root, rel_path).encode("utf-8")
+
+        # For $ORIGIN interpolation: should not have trailing dir seperator.
+        origin = os.path.dirname(path)
+
+        # Retrieve the needed libs + rpaths.
+        try:
+            with open(path, "rb") as f:
+                parsed_elf = elf.parse_elf(f, interpreter=False, dynamic_section=True)
+        except (IOError, elf.ElfParsingError):
+            # Not dealing with a valid ELF file.
+            return
+
+        # If there's no needed libs all is good
+        if not parsed_elf.has_needed:
+            return
+
+        # Get the needed libs and rpaths (notice: byte strings)
+        # Don't force an encoding cause paths are just a bag of bytes.
+        needed_libs = parsed_elf.dt_needed_strs
+
+        rpaths = parsed_elf.dt_rpath_str.split(b":") if parsed_elf.has_rpath else []
+
+        # We only interpolate $ORIGIN, not $LIB and $PLATFORM, they're not really
+        # supported in general. Also remove empty paths.
+        rpaths = [x.replace(b"$ORIGIN", origin) for x in rpaths if x]
+
+        # Relative rpaths exist (they're relative to current working dir, really bad).
+        rpaths, rpaths_rel = stable_partition(rpaths, os.path.isabs)
+        if rpaths_rel:
+            raise Exception("Relative rpaths in {!r} detected {!r}".format(path, rpaths_rel))
+
+        # If there's a / in the needed lib, it's opened directly, otherwise it needs
+        # a search.
+        direct_libs, search_libs = stable_partition(needed_libs, lambda x: b"/" in x)
+
+        # Also direct libs can come in relative and absolute path flavor, we don't like
+        # finding libraries relative to the current working directory, so error when
+        # those are found.
+        direct_libs, direct_libs_rel = stable_partition(direct_libs, os.path.isabs)
+
+        if direct_libs_rel:
+            raise Exception("Needed libraries by relative path {!r}".format(direct_libs_rel))
+
+        # Now we remove the libraries that we consider system libraries.
+        search_libs = list(filter(should_be_searched, search_libs))
+
+        # Look for issues.
+        resolved = {}
+        unresolved = []
+
+        for lib in search_libs:
+            for rpath in rpaths:
+                candidate = os.path.join(rpath, lib)
+                if candidate_matches(parsed_elf, candidate):
+                    resolved[lib] = candidate
+                    break
+            else:
+                unresolved.append(lib)
+
+        # Check if directly opened libs are compatible
+        for lib in direct_libs:
+            if candidate_matches(parsed_elf, lib):
+                resolved[lib] = lib
+            else:
+                unresolved.append(lib)
+
+        # A problem :(
+        if unresolved:
+            self.problems[rel_path] = Problem(resolved, unresolved)
+
+    def visit_symlinked_file(self, root, rel_path, depth):
+        pass
+
+    def before_visit_dir(self, root, rel_path, depth):
+        return True
+
+    def before_visit_symlinked_dir(self, root, rel_path, depth):
+        return False
+
+
+def post_install(spec):
+    """
+    Check whether all ELF files participating in dynamic linking can locate libraries
+    in dt_needed referred to by name (not by path).
+    """
+    if spec.external:
+        return
+
+    visitor = ResolveSharedElfLibDepsVisitor()
+    visit_directory_tree(spec.prefix, visitor)
+
+    # All good?
+    if not visitor.problems:
+        return
+
+    # For now just list the issues (print it in ldd style, except we don't recurse)
+    output = io.StringIO()
+    output.write("Not all executables/libraries can resolve their dependencies:\n")
+    for path, problem in visitor.problems.items():
+        output.write(path)
+        output.write("\n")
+        for needed, full_path in problem.resolved.items():
+            if needed == full_path:
+                output.write("        {}\n".format(needed))
+            else:
+                output.write("        {} => {}\n".format(needed, full_path))
+        for not_found in problem.unresolved:
+            output.write("        {} => not found\n".format(not_found))
+        output.write("\n")
+
+    tty.error(output.getvalue())

--- a/lib/spack/spack/hooks/check_dynamic_linking_elf.py
+++ b/lib/spack/spack/hooks/check_dynamic_linking_elf.py
@@ -9,9 +9,9 @@ import os
 import llnl.util.tty as tty
 from llnl.util.filesystem import BaseDirectoryVisitor, visit_directory_tree
 from llnl.util.lang import stable_partition
+
 import spack.config
 import spack.error
-
 import spack.util.elf as elf
 
 skip_list = frozenset(

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -28,6 +28,7 @@ properties = {
                         "properties": {
                             "type": {"type": "string", "enum": ["rpath", "runpath"]},
                             "bind": {"type": "boolean"},
+                            "strict": {"type": "boolean"},
                         },
                     },
                 ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -8,6 +8,8 @@ spack:
   config:
     build_jobs: 32
     concretizer: clingo
+    shared_linking:
+      strict: true
     install_tree:
       root: /home/software/spack
       padded_length: 512


### PR DESCRIPTION
This commit adds a post-install hook that walks over the prefix and
verifies that each ELF executable/library that takes part in shared
linking can in fact resolve its direct depenendencies.

This is slightly simpler than running `ldd` in the sense that it is not
recursive (we only care about the package) and its verification logic is
very minimal (we require ET_DYN type elf files for libs, and they should
match the class / data / isa of the parent).

Also it is platform independent, so we don't have to worry about calling
the correct `ldd`.

This check does not *fail* the install, it just prints it as an error
message.

## Examples

### `llvm` 

```
In [1]: import spack.hooks.check_dynamic_linking_elf

In [2]: spec = spack.store.db.query("llvm")[0]

In [3]: spack.hooks.check_dynamic_linking_elf.post_install(spec)

==> Error: Not all executables/libraries can resolve their dependencies:
bin/llvm-omp-device-info
        libomp.so => /home/harmen/spack/opt/spack/linux-ubuntu22.04-zen2/gcc-11.2.0/llvm-15.0.0-neuno6erto7nzlbttmzuepmgujk3c76t/bin/../lib/libomp.so
        libomptarget.so.15 => /home/harmen/spack/opt/spack/linux-ubuntu22.04-zen2/gcc-11.2.0/llvm-15.0.0-neuno6erto7nzlbttmzuepmgujk3c76t/bin/../lib/libomptarget.so.15
        libhwloc.so.15 => not found

lib/libomp.so
        libhwloc.so.15 => not found

lib/libompd.so
        libomp.so => not found
        libhwloc.so.15 => not found

lib/libomptarget.rtl.amdgpu.so.15
        libelf.so.1 => not found
        libz.so.1 => not found
        libtinfo.so.6 => not found

lib/libomptarget.rtl.cuda.so.15
        libelf.so.1 => not found
        libz.so.1 => not found
        libtinfo.so.6 => not found

lib/libomptarget.rtl.x86_64.so.15
        libffi.so.8 => not found
        libelf.so.1 => not found
        libz.so.1 => not found
        libtinfo.so.6 => not found

lib/libomptarget.so.15
        libz.so.1 => not found
        libtinfo.so.6 => not found

libexec/llvm/llvm-omp-device-info
        libomp.so => not found
        libomptarget.so.15 => not found
        libhwloc.so.15 => not found
```

### `python`

```
lib/python3.9/lib-dynload/_crypt.cpython-39-x86_64-linux-gnu.so
        libcrypt.so.1 => not found

lib/python3.9/lib-dynload/nis.cpython-39-x86_64-linux-gnu.so
        libtirpc.so.3 => not found
```

### `perl`
```
lib/5.36.0/x86_64-linux-thread-multi/CORE/libperl.so
        libcrypt.so.1 => not found
```

## Performance

For me it takes `97.2 ms` to process the LLVM prefix (6.8GB)