### PR TITLE
Regenerate views when specs already installed

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1515,7 +1515,6 @@ class Environment(object):
 
         if not specs_to_install:
             tty.msg('All of the packages are already installed')
-            return
 
         tty.debug('Processing {0} uninstalled specs'.format(
             len(specs_to_install)))

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1515,9 +1515,8 @@ class Environment(object):
 
         if not specs_to_install:
             tty.msg('All of the packages are already installed')
-
-        tty.debug('Processing {0} uninstalled specs'.format(
-            len(specs_to_install)))
+        else:
+            tty.debug('Processing {0} uninstalled specs'.format(len(specs_to_install)))
 
         specs_to_overwrite = self._get_overwrite_specs()
         tty.debug('{0} specs need to be overwritten'.format(


### PR DESCRIPTION
fixes #23923

With this PR:

```
$ spack env activate --temp
$ spack install zlib
==> All of the packages are already installed
==> Updating view at /tmp/spack-faiirgmt/.spack-env/view
$ spack install zlib
==> All of the packages are already installed
```

Before this PR:

```
$ spack env activate --temp
$ spack install zlib
==> All of the packages are already installed
$ spack install zlib
==> All of the packages are already installed
```

No view was generated
