### PR TITLE
[root] depends_on fcgi and re-enabled +http support

### DIFF
--- a/var/spack/repos/builtin/packages/fcgi/package.py
+++ b/var/spack/repos/builtin/packages/fcgi/package.py
@@ -13,8 +13,15 @@ class Fcgi(AutotoolsPackage):
     applications that have been written for the Web."""
 
     homepage = "https://fastcgi-archives.github.io/"
-    url      = "https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz"
+    url      = "https://github.com/FastCGI-Archives/fcgi2/archive/refs/tags/2.4.2.tar.gz"
 
-    version('2.4.1-SNAP-0910052249', sha256='829dc89a0a372c7b0b172303ec9b42e9d20615d6d0e9fc81570fdac6c41a0f30')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+
+    version('2.4.2', sha256='1fe83501edfc3a7ec96bb1e69db3fd5ea1730135bd73ab152186fd0b437013bc')
+    version('2.4.1-SNAP-0910052249',
+            sha256='829dc89a0a372c7b0b172303ec9b42e9d20615d6d0e9fc81570fdac6c41a0f30',
+            url='https://github.com/FastCGI-Archives/FastCGI.com/raw/master/original_snapshot/fcgi-2.4.1-SNAP-0910052249.tar.gz')
 
     parallel = False

--- a/var/spack/repos/builtin/packages/root/README.md
+++ b/var/spack/repos/builtin/packages/root/README.md
@@ -14,10 +14,6 @@ Requires `libgapiUI` from ALICE.
 
 #### `gfal`
 
-#### `http`
-
-ROOT looks for and uses the FastCGI package on the system if found, creating a possible non-portable dependency. There is currently no `fastcgi` recipe, nor any way to unconditionally disable the search for the package.
-
 #### `monalisa`
 
 Monitoring with Monalisa depends on `libapmoncpp`.
@@ -66,7 +62,7 @@ Support for several options was discontinued in ROOT without prior support in th
 
 ### Other fixed or unsupported options
 
-### `arrow=OFF`
+#### `arrow=OFF`
 
 #### `asimage=ON`, `astiff=ON`, `builtin_afterimage=ON`
 
@@ -143,8 +139,6 @@ Representing the obsolete `qt` and `qtgsi` ROOT build options.
 #### `table`
 
 ### Temporarily conflicting variants
-
-The `http` variant is currently an unconditional conflict due to the non-portable dependency mentioned above.
 
 ## Permanently removed variants
 

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -245,6 +245,7 @@ class Root(CMakePackage):
     depends_on('davix @0.7.1:', when='+davix')
     depends_on('dcap',      when='+dcache')
     depends_on('cfitsio',   when='+fits')
+    depends_on('fcgi',      when='+http')
     depends_on('fftw',      when='+fftw')
     depends_on('graphviz',  when='+graphviz')
     depends_on('gsl',       when='+gsl')
@@ -292,10 +293,6 @@ class Root(CMakePackage):
 
     # ROOT <6.14 was incompatible with Python 3.7+
     conflicts('^python@3.7:', when='@:6.13 +python')
-
-    # See README.md
-    conflicts('+http',
-              msg='HTTP server currently unsupported due to dependency issues')
 
     # Incompatible variants
     conflicts('+opengl', when='~x', msg='OpenGL requires X')


### PR DESCRIPTION
Since `root +http` was [disabled](https://github.com/spack/spack/commit/ae3eac0b1946ce76b578c9c40d994a601a223761), we [now have](https://github.com/spack/spack/commit/c85dc3a5b431409bed5b0753f04049641f4d3761) a FastCGI package `fcgi` which allows `root +http` to work again. In EIC we depend on `root +http` for a dd4hep geometry web display tool.

Tests: successfully built with +http:
```
-- linux-ubuntu21.10-skylake / gcc@11.2.0 -----------------------
6s6cguw root@6.24.06~aqua+davix~dcache~emacs+examples+fftw~fits+fortran+gdml+gminimal~graphviz+gsl+http~ipo~jemalloc+math~memstat+minuit+mlp~mysql+opengl~oracle~postgres~pythia6+pythia8+python~qt4~r+roofit+root7+rpath~shadow~spectrum~sqlite+ssl~table+tbb+threads+tmva+unuran+vc+vdt~veccore~vmc+x+xml+xrootd build_type=RelWithDebInfo cxxstd=17 patches=22af3471f3fd87c0fe8917bf9c811c6d806de6c8b9867d30a1e3d383a1b929d7
```

Maintainer tags:
- fcgi: @darmac 
- root: @HadrienG2 @chissg @drbenmorgan @vvolkl