### PR TITLE
lordec update and gatb-core

### DIFF
--- a/var/spack/repos/builtin/packages/gatb-core/package.py
+++ b/var/spack/repos/builtin/packages/gatb-core/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class GatbCore(CMakePackage):
+    """GATB - The Genome Analysis Toolbox with de-Bruijn graph"""
+
+    homepage = "https://gatb.inria.fr/software/gatb-core/"
+    git      = "https://github.com/GATB/gatb-core.git"
+
+    depends_on('cmake@3.1.0:', type='build')
+
+    version('1.4.2', tag='v1.4.2')
+    version('1.4.1', tag='v1.4.1')
+
+    root_cmakelists_dir = 'gatb-core'

--- a/var/spack/repos/builtin/packages/lordec/package.py
+++ b/var/spack/repos/builtin/packages/lordec/package.py
@@ -14,12 +14,33 @@ class Lordec(MakefilePackage):
     homepage = "http://www.atgc-montpellier.fr/lordec/"
     url      = "https://gite.lirmm.fr/lordec/lordec-releases/uploads/e3116a5f251e46e47f7a3b7ddb2bd7f6/lordec-src_0.8.tar.gz"
 
+    version('0.9', sha256='8108b82a8404fbf44c7e300d3abb43358ccc28993f90546168a20ca82536923b')
     version('0.8', sha256='3894a7c57649a3545b598f92a48d55eda66d729ab51606b00470c50611b12823')
 
-    depends_on('boost')
-    depends_on('cmake@3.1.0:', type='build')
+    def url_for_version(self, version):
+        if version == Version('0.8'):
+            return "https://gite.lirmm.fr/lordec/lordec-releases/uploads/e3116a5f251e46e47f7a3b7ddb2bd7f6/lordec-src_0.8.tar.gz"
+        if version == Version('0.9'):
+            return "https://gite.lirmm.fr/lordec/lordec-releases/uploads/800a96d81b3348e368a0ff3a260a88e1/lordec-src_0.9.tar.bz2"
+
+    depends_on('boost@1.48.0:1.64.0', type=['build', 'link'])
+    depends_on('gatb-core@1.4.1:', type=['build', 'link', 'run'])
+    depends_on('zlib', type=['build', 'link'])
 
     build_targets = ['clean', 'all']
 
+    def edit(self, spec, prefix):
+        lbstr = 'AUTOMATIC_LIBBOOST_LOCAL_INSTALL=no'
+        filter_file('^AUTOMATIC_LIBBOOST_LOCAL_INSTALL.*$', lbstr, 'Makefile')
+        filter_file('gatb_v.*gatb_core.hpp', '', 'Makefile')
+
     def install(self, spec, prefix):
-        install_tree('.', prefix.bin)
+        mkdir(prefix.include)
+        install('*.h', prefix.include)
+        mkdir(prefix.bin)
+        binaries = ['lordec-correct', 'lordec-stat', 'lordec-trim',
+                    'lordec-trim-split', 'lordec-build-SR-graph']
+        for binary in binaries:
+            install(binary, prefix.bin)
+        mkdir(prefix.tools)
+        install('lordec_sge_slurm_wrapper.sh', prefix.tools)


### PR DESCRIPTION
This adds a new version to lordec among other things.

I ran into build errors with this as it pulls in a dep with wget, then I decided I'd pull out the dependency it was fetching into a new package.

gatb-core vendors a lot of its deps and there's no easy way to make it not do that with cmake, so I figured I'd let that ride. Especially since they're statically compiled into it anyway.