### PR TITLE
satsuma2: new version and build error fix

### DIFF
--- a/var/spack/repos/builtin/packages/satsuma2/package.py
+++ b/var/spack/repos/builtin/packages/satsuma2/package.py
@@ -19,6 +19,8 @@ class Satsuma2(CMakePackage):
     version('2021-03-04', commit='37c5f386819614cd3ce96016b423ddc4df1d86ec')
     version('2016-11-22', commit='da694aeecf352e344b790bea4a7aaa529f5b69e6')
 
+    maintainers = ['snehring']
+
     def patch(self):
         filter_file('(^#include <unistd.h>$)', '\\1\n#include <memory>',
                     'analysis/SatsumaSynteny2.cc')

--- a/var/spack/repos/builtin/packages/satsuma2/package.py
+++ b/var/spack/repos/builtin/packages/satsuma2/package.py
@@ -16,7 +16,12 @@ class Satsuma2(CMakePackage):
     homepage = "https://github.com/bioinfologics/satsuma2"
     git      = "https://github.com/bioinfologics/satsuma2.git"
 
+    version('2021-03-04', commit='37c5f386819614cd3ce96016b423ddc4df1d86ec')
     version('2016-11-22', commit='da694aeecf352e344b790bea4a7aaa529f5b69e6')
+
+    def patch(self):
+        filter_file('(^#include <unistd.h>$)', '\\1\n#include <memory>',
+                    'analysis/SatsumaSynteny2.cc')
 
     def install(self, spec, prefix):
         install_tree(join_path(self.build_directory, 'bin'), prefix.bin)


### PR DESCRIPTION
This bumps satsuma2 up a couple years worth of commits and also fixes build errors on newer gcc versions.

Presumably this did compile (probably with 4.8.5) at some point, but from what I can tell this header still exists as far back as rhel7, so it should be fine to do across the board.