### PR TITLE
package npb 3.4.1 update

### DIFF
--- a/var/spack/repos/builtin/packages/npb/package.py
+++ b/var/spack/repos/builtin/packages/npb/package.py
@@ -197,12 +197,12 @@ class Npb(MakefilePackage):
 
                         # Class E, F is not available for IS at @3.3.1
                         # Class F is not available for IS at @3.4.1
-                        if name == 'is' and classname in ('E', 'F') \
-                            and spec.satisfies('@3.3.1'):
-                            continue
-                        elif name == 'is' and classname in ('F') \
-                            and spec.satisfies('@3.4.1:'):
-                            continue
+                        if name == 'is' 
+                            if classname in ('E'):
+                                if spec.satisfies('@3.3.1'):
+                                    continue
+                            if classname in ('F'):
+                                continue
 
                         if 'implementation=mpi' in spec and spec.satisfies('@3.3.1'):
                             for nproc in nprocs:

--- a/var/spack/repos/builtin/packages/npb/package.py
+++ b/var/spack/repos/builtin/packages/npb/package.py
@@ -33,7 +33,7 @@ class Npb(MakefilePackage):
 
     version('3.3.1', sha256='4a8ea679b1df69f583c544c47198b3c26a50ec2bb6f8f69aef66c04c9a747d2d')
     version('3.4.1', sha256='f3a43467da6e84a829ea869156d3ea86c17932136bb413a4b6dab23018a28881')
-    
+
     # Valid Benchmark Names
     valid_names = (
         'is',  # Integer Sort, random memory access

--- a/var/spack/repos/builtin/packages/npb/package.py
+++ b/var/spack/repos/builtin/packages/npb/package.py
@@ -32,7 +32,8 @@ class Npb(MakefilePackage):
     url      = "https://www.nas.nasa.gov/assets/npb/NPB3.3.1.tar.gz"
 
     version('3.3.1', sha256='4a8ea679b1df69f583c544c47198b3c26a50ec2bb6f8f69aef66c04c9a747d2d')
-
+    version('3.4.1', sha256='f3a43467da6e84a829ea869156d3ea86c17932136bb413a4b6dab23018a28881')
+    
     # Valid Benchmark Names
     valid_names = (
         'is',  # Integer Sort, random memory access

--- a/var/spack/repos/builtin/packages/npb/package.py
+++ b/var/spack/repos/builtin/packages/npb/package.py
@@ -198,10 +198,10 @@ class Npb(MakefilePackage):
                         # Class E, F is not available for IS at @3.3.1
                         # Class F is not available for IS at @3.4.1
                         if name == 'is' 
-                            if classname in ('E'):
+                            if classname == 'E':
                                 if spec.satisfies('@3.3.1'):
                                     continue
-                            if classname in ('F'):
+                            if classname == 'F':
                                 continue
 
                         if 'implementation=mpi' in spec and spec.satisfies('@3.3.1'):

--- a/var/spack/repos/builtin/packages/npb/package.py
+++ b/var/spack/repos/builtin/packages/npb/package.py
@@ -197,10 +197,12 @@ class Npb(MakefilePackage):
 
                         # Class E, F is not available for IS at @3.3.1
                         # Class F is not available for IS at @3.4.1
-                        if name == 'is' and classname in ('E','F') and spec.satisfies('@3.3.1') :
-                             continue
-                        elif name == 'is' and classname in ('F') and spec.satisfies('@3.4.1:'):
-                             continue
+                        if name == 'is' and classname in ('E', 'F') \
+                            and spec.satisfies('@3.3.1'):
+                            continue
+                        elif name == 'is' and classname in ('F') \
+                            and spec.satisfies('@3.4.1:'):
+                            continue
 
                         if 'implementation=mpi' in spec and spec.satisfies('@3.3.1'):
                             for nproc in nprocs:

--- a/var/spack/repos/builtin/packages/npb/package.py
+++ b/var/spack/repos/builtin/packages/npb/package.py
@@ -52,7 +52,7 @@ class Npb(MakefilePackage):
         'W',            # Workstation size
         'A', 'B', 'C',  # standard test problems
                         # ~4X size increase going from one class to the next
-        'D', 'E',       # large test problems
+        'D', 'E', 'F'   # large test problems
                         # ~16X size increase from each of the previous classes
     )
 
@@ -117,6 +117,7 @@ class Npb(MakefilePackage):
         if 'implementation=mpi' in spec:
             definitions = {
                 # Parallel Fortran
+                'MPIFC':      spec['mpi'].mpifc,
                 'MPIF77':     spec['mpi'].mpif77,
                 'FLINK':      spec['mpi'].mpif77,
                 'FMPI_LIB':   spec['mpi'].libs.ld_flags,
@@ -138,6 +139,7 @@ class Npb(MakefilePackage):
         elif 'implementation=openmp' in spec:
             definitions = {
                 # Parallel Fortran
+                'FC':         spack_fc,
                 'F77':        spack_f77,
                 'FLINK':      spack_f77,
                 'F_LIB':      '',
@@ -189,15 +191,18 @@ class Npb(MakefilePackage):
             with open('config/suite.def', 'w') as suite_def:
                 for name in names:
                     for classname in classes:
-                        # Classes C, D and E are not available for DT
-                        if name == 'dt' and classname in ('C', 'D', 'E'):
+                        # Classes C, D, E  and F are not available for DT
+                        if name == 'dt' and classname in ('C', 'D', 'E', 'F'):
                             continue
 
-                        # Class E is not available for IS
-                        if name == 'is' and classname == 'E':
-                            continue
+                        # Class E, F is not available for IS at @3.3.1
+                        # Class F is not available for IS at @3.4.1
+                        if name == 'is' and classname in ('E','F') and spec.satisfies('@3.3.1') :
+                             continue
+                        elif name == 'is' and classname in ('F') and spec.satisfies('@3.4.1:'):
+                             continue
 
-                        if 'implementation=mpi' in spec:
+                        if 'implementation=mpi' in spec and spec.satisfies('@3.3.1'):
                             for nproc in nprocs:
                                 suite_def.write('{0}\t{1}\t{2}\n'.format(
                                     name, classname, nproc))

--- a/var/spack/repos/builtin/packages/npb/package.py
+++ b/var/spack/repos/builtin/packages/npb/package.py
@@ -197,7 +197,7 @@ class Npb(MakefilePackage):
 
                         # Class E, F is not available for IS at @3.3.1
                         # Class F is not available for IS at @3.4.1
-                        if name == 'is' 
+                        if name == 'is':
                             if classname == 'E':
                                 if spec.satisfies('@3.3.1'):
                                     continue


### PR DESCRIPTION
The following part was modified through the change log of version 3.4

> The Class F problem has been added to seven of the benchmarks (BT, SP, LU, CG, MG, FT, and EP).
> The Class E problem has been added to the IS benchmark.

-> Refer to above,  Classes C, D, E  and F are not available for DT.
 And  Class E, F is not available for IS at @3.3.1, Class F is not available for IS at @3.4.1.

> Because of dynamic memory allocation, compilations for different process counts are no longer necessary. The number of processes is solely determined and checked at runtime.

-> In version 3.4.1, 'the number of processes'  option does not apply.

> The MPIF77 or F77 flag in make.def is renamed to MPIFC or FC to reflect the fact that a Fortran 90 or newer compiler is required.

->MPIFC and FC flags were added.