### PR TITLE
fix r-htmltools latest version

### DIFF
--- a/var/spack/repos/builtin/packages/r-fastmap/package.py
+++ b/var/spack/repos/builtin/packages/r-fastmap/package.py
@@ -20,4 +20,5 @@ class RFastmap(RPackage):
     url      = "https://cloud.r-project.org/src/contrib/fastmap_1.0.1.tar.gz"
     list_url = "https://cloud.r-project.org/src/contrib/Archive/fastmap"
 
+    version('1.1.0', sha256='9113e526b4c096302cfeae660a06de2c4c82ae4e2d3d6ef53af6de812d4c822b')
     version('1.0.1', sha256='4778b05dfebd356f8df980dfeff3b973a72bca14898f870e5c40c1d84db9faec')

--- a/var/spack/repos/builtin/packages/r-htmltools/package.py
+++ b/var/spack/repos/builtin/packages/r-htmltools/package.py
@@ -25,5 +25,5 @@ class RHtmltools(RPackage):
     depends_on('r-base64enc', when='@0.5.1:', type=('build', 'run'))
     depends_on('r-rlang@0.4.10:', when='@0.5.2:', type=('build', 'run'))
     depends_on('r-rlang', when='@0.5.1:', type=('build', 'run'))
-    depends_on('r-fastmap', when='@0.5.2:', type=('build', 'run'))
+    depends_on('r-fastmap@1.1.0:', when='@0.5.2:', type=('build', 'run'))
     depends_on('r-rcpp', when=' @:0.3.6', type=('build', 'run'))


### PR DESCRIPTION
The lastest version of r-htmltools needs version 1.1.0 of r-fastmap.
This is not specified in the DESCRIPTION file.

Fixes #28089.