### PR TITLE
cp2k: fix dependency libraries

### DIFF
--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -490,7 +490,7 @@ class Cp2k(MakefilePackage, CudaPackage):
                             ('libelpa{elpa_suffix}.a'
                                 .format(elpa_suffix=elpa_suffix))))
             else:
-                libs.append(join_path(elpa.prefix.lib,
+                libs.append(join_path(elpa.libs.directories[0],
                             ('libelpa{elpa_suffix}.{dso_suffix}'
                                 .format(elpa_suffix=elpa_suffix,
                                         dso_suffix=dso_suffix))))

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -486,11 +486,11 @@ class Cp2k(MakefilePackage, CudaPackage):
 
             # Currently AOCC support only static libraries of ELPA
             if '%aocc' in spec:
-                libs.append(join_path(elpa.libs.directories[0],
+                libs.append(join_path(elpa.prefix.lib,
                             ('libelpa{elpa_suffix}.a'
                                 .format(elpa_suffix=elpa_suffix))))
             else:
-                libs.append(join_path(elpa.libs.directories[0],
+                libs.append(join_path(elpa.prefix.lib,
                             ('libelpa{elpa_suffix}.{dso_suffix}'
                                 .format(elpa_suffix=elpa_suffix,
                                         dso_suffix=dso_suffix))))

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -74,7 +74,13 @@ class Libint(AutotoolsPackage):
             return "{0}/v{1}.tar.gz".format(base_url, version)
 
     def autoreconf(self, spec, prefix):
-        which('bash')('autogen.sh')
+        if self.spec.satisfies("@:1.1.6"):
+            libtoolize()
+            aclocal('-I', 'lib/autoconf')
+            autoconf()
+        else:
+            # autogen.sh file will be available from v2 and above
+            which('bash')('autogen.sh')
 
         if '@2.6.0:' in spec:
             # skip tarball creation and removal of dir with generated code
@@ -103,9 +109,14 @@ class Libint(AutotoolsPackage):
     def configure_args(self):
 
         config_args = [
-            '--enable-shared',
-            '--with-boost={0}'.format(self.spec['boost'].prefix)
+            '--enable-shared'
         ]
+
+        if self.spec.satisfies("@2.0.0:"):
+            # --with-boost option available only form version 2 and above
+            config_args.extend([
+                '--with-boost={0}'.format(self.spec['boost'].prefix)
+                ])
 
         # Optimization flag names have changed in libint 2
         if self.version < Version('2.0.0'):

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -116,7 +116,7 @@ class Libint(AutotoolsPackage):
             # --with-boost option available only form version 2 and above
             config_args.extend([
                 '--with-boost={0}'.format(self.spec['boost'].prefix)
-                ])
+            ])
 
         # Optimization flag names have changed in libint 2
         if self.version < Version('2.0.0'):

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -113,7 +113,7 @@ class Libint(AutotoolsPackage):
         ]
 
         if self.spec.satisfies("@2.0.0:"):
-            # --with-boost option available only form version 2 and above
+            # --with-boost option available only from version 2 and above
             config_args.extend([
                 '--with-boost={0}'.format(self.spec['boost'].prefix)
             ])

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -74,13 +74,13 @@ class Libint(AutotoolsPackage):
             return "{0}/v{1}.tar.gz".format(base_url, version)
 
     def autoreconf(self, spec, prefix):
-        if self.spec.satisfies("@:1.1.6"):
+        if self.spec.satisfies("@2:"):
+            which('bash')('autogen.sh')
+        else:
+            # Fall back since autogen is not available
             libtoolize()
             aclocal('-I', 'lib/autoconf')
             autoconf()
-        else:
-            # autogen.sh file will be available from v2 and above
-            which('bash')('autogen.sh')
 
         if '@2.6.0:' in spec:
             # skip tarball creation and removal of dir with generated code
@@ -112,7 +112,7 @@ class Libint(AutotoolsPackage):
             '--enable-shared'
         ]
 
-        if self.spec.satisfies("@2.0.0:"):
+        if self.spec.satisfies("@2:"):
             # --with-boost option available only from version 2 and above
             config_args.extend([
                 '--with-boost={0}'.format(self.spec['boost'].prefix)


### PR DESCRIPTION
- while building` libint 1.1.6` with `AOCC`, it is found that recipe has been modified recently and it won't work for versions below 2.0.0
- In this pull request we are addressing build issues of  `libint` and `elpa`

**libint**
- Restored` libtoolize() `for versions `1.1.6` and below
- `--with-boost` is applicable only from `v2.0.0` and above

**elpa**
- `elpa = spec['elpa']` doesn't have `libs()` method, so restoring it back to `elpa.prefix.lib`