### PR TITLE
[pythia8] bugfix for pythia8 +fastjet

### DIFF
--- a/var/spack/repos/builtin/packages/pythia8/package.py
+++ b/var/spack/repos/builtin/packages/pythia8/package.py
@@ -97,8 +97,12 @@ class Pythia8(AutotoolsPackage):
             args += '--without-mg5mes'
 
         args += self.with_or_without('hepmc3', activation_value='prefix')
-        args += self.with_or_without('fastjet3', activation_value='prefix',
-                                     variant='fastjet')
+
+        if '+fastjet' in self.spec:
+            args += '--with-fastjet3=' + self.spec['fastjet'].prefix
+        else:
+            args += '--without-fastjet3'
+
         args += self.with_or_without('evtgen', activation_value='prefix')
         args += self.with_or_without('root', activation_value='prefix')
         args += self.with_or_without('rivet', activation_value='prefix')


### PR DESCRIPTION
`spack install pythia +fastjet` trips up over `self.with_or_without('fastjet3', activation_value='prefix', variant='fastjet')` because it tries to use the prefix of the spec `fastjet3`. This PR solves the issue just like `madgraph5amc` a few lines above.

Maintainer tag: @ChristianTackeGSI