### PR TITLE
Provide config option to decide the hash-type (hash, full_hash, etc.) used by the db as key. 

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -19,7 +19,7 @@ config:
   install_tree:
     root: $spack/opt/spack
     projections:
-      all: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH}"
+      all: "${ARCHITECTURE}/${COMPILERNAME}-${COMPILERVER}/${PACKAGE}-${VERSION}-${HASH_TYPE}"
     # install_tree can include an optional padded length (int or boolean)
     # default is False (do not pad)
     # if padded_length is True, Spack will pad as close to the system max path
@@ -172,6 +172,11 @@ config:
   # therefore generally be left untouched.
   db_lock_timeout: 3
 
+  # What type of hash should the db use as a key to store entries. The value
+  # also controls the installation path directory in the case of using the
+  # value 'HASH_TYPE' in the projections. The type 'hash' uses the 'dag_hash'
+  # value. This is the default/legacy mechanism. 
+  hash_type: 'hash'
 
   # How long to wait when attempting to modify a package (e.g. to install it).
   # This value should typically be 'null' (never time out) unless the Spack

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -15,6 +15,7 @@ import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.environment as ev
 import spack.error
+import spack.hash_types as ht
 import spack.package
 import spack.repo
 import spack.store
@@ -86,7 +87,8 @@ def find_matching_specs(env, specs, allow_multiple_matches=False, force=False):
     for spec in specs:
         install_query = [InstallStatuses.INSTALLED, InstallStatuses.DEPRECATED]
         matching = spack.store.db.query_local(spec, hashes=hashes,
-                                              installed=install_query)
+                                              installed=install_query,
+                                              hash_type=ht.dag_hash)
         # For each spec provided, make sure it refers to only one package.
         # Fail and ask user to be unambiguous if it doesn't
         if not allow_multiple_matches and len(matching) > 1:
@@ -225,7 +227,8 @@ def do_uninstall(env, specs, force):
         is_ready = lambda x: True
 
     while packages:
-        ready = [x for x in packages if is_ready(x.spec.dag_hash())]
+        ready = [x for x in packages
+                 if is_ready(x.spec._cached_hash(spack.store.db._hash))]
         if not ready:
             msg = 'unexpected error [cannot proceed uninstalling specs with' \
                   ' remaining dependents {0}]'

--- a/lib/spack/spack/hash_types.py
+++ b/lib/spack/spack/hash_types.py
@@ -8,6 +8,7 @@
 import spack.dependency as dp
 
 hashes = []
+hash_dict = {}
 
 
 class SpecHashDescriptor(object):
@@ -25,6 +26,7 @@ class SpecHashDescriptor(object):
         self.package_hash = package_hash
         self.name = name
         hashes.append(self)
+        hash_dict[name] = self
         # Allow spec hashes to have an alternate computation method
         self.override = override
 

--- a/lib/spack/spack/schema/database_index.py
+++ b/lib/spack/spack/schema/database_index.py
@@ -52,6 +52,7 @@ schema = {
                     },
                 },
                 'version': {'type': 'string'},
+                'hash_type': {'type': 'string'},
             }
         },
     },


### PR DESCRIPTION
The PR provides a configuration option that defines the type of a hash to be used by the spack-DB.  

The config option can be referenced by the projection option and create installation paths that include different hash-types. So, when hash_type='full_hash' spack supports multiple installations of the same package with different dependencies. Moreover, the lock mechanism uses the hash_type value to create the respective locks. Therefore, when hash_type='full_hash' spack supports concurrent installations of the same package with different dependencies. 

To summarize, the lock mechanism, the spack-DB key values and, the directory prefixes should have a mechanism to control their behavior. This branch is an initial effort towards that direction. 