### PR TITLE
vecgeom/veccore: fix version interdependency

### DIFF
--- a/var/spack/repos/builtin/packages/veccore/package.py
+++ b/var/spack/repos/builtin/packages/veccore/package.py
@@ -16,6 +16,10 @@ class Veccore(CMakePackage, CudaPackage):
     maintainers = ['drbenmorgan', 'sethrj']
 
     version('master', branch='master')
+    # Note: 0.8.0 tag is currently unofficial but it is needed explicitly for
+    # VecGeom 1.1.18
+    version('0.8.0', commit='6038e4732394413b0661fede171c77e75ed9bd71')
+    version('0.7.0', sha256='8aa97e19c455382f1a3dae07ffa5e49f2982f09e75b25a3f98d7b94cd43d6001')
     version('0.6.0', sha256='e7ff874ba2a8201624795cbe11c84634863e4ac7da691a936772d4202ef54413')
     version('0.5.2', sha256='0cfaa830b9d10fb9df4ced5208a742623da08520fea5949461fe81637a27db15')
     version('0.5.1', sha256='5ef3a8d8692d8f82641aae76b58405b8b3a1539a8f21b23d66a5df8327eeafc4')

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -50,6 +50,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     variant('shared', default=True,
             description='Build shared libraries')
 
+    depends_on('veccore@0.8.0', type=('build', 'link'), when='@1.1.18')
     depends_on('veccore@0.5.2:', type=('build', 'link'), when='@1.1.0:')
     depends_on('veccore@0.4.2', type=('build', 'link'), when='@:1.0')
     depends_on('veccore+cuda', type=('build', 'link'), when='+cuda')


### PR DESCRIPTION
VecGeom 1.1.18 requires *exactly* version 0.8.0 of VecCore, which hasn't been tagged. The CMake logic inside VecGeom silently overrides the "disable vendored copy" option that spack sets, so vecgeom@1.1.18 always ends up installing a vendored copy of veccore alongside vecgeom. This causes a conflict when building an environment with the spack-provided (but ignored) version of veccore, leading downstream packages to choke:
```
CMake Error at /rnsdhpc/code/spack/opt/spack/apple-clang/cmake/7zgbrwt/share/cmake-3.22/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):
  Could not find a configuration file for package "VecCore" that is
  compatible with requested version "0.8.0".

  The following configuration files were considered but not accepted:

    /rnsdhpc/code/spack/var/spack/environments/celeritas/.spack-env/view/lib/cmake/VecCore/VecCoreConfig.cmake, version: 0.6.0
```

@drbenmorgan I recommend respecting the `BUILTIN_VECCORE` option in VecGeom if defined, and officially tagging 0.8.0 of VecCore so that it's available.