### PR TITLE
new package: py-toposort

### DIFF
--- a/var/spack/repos/builtin/packages/py-toposort/package.py
+++ b/var/spack/repos/builtin/packages/py-toposort/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+class PyToposort(PythonPackage):
+    """Implements a topological sort algorithm."""
+
+    pypi = 'toposort/toposort-1.6.tar.gz'
+
+    maintainers = ['marcusboden']
+
+    version('1.6', 'a7428f56ef844f5055bb9e9e44b343983773ae6dce0fe5b101e08e27ffbd50ac')
+
+    depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-toposort/package.py
+++ b/var/spack/repos/builtin/packages/py-toposort/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack import *
+
 
 class PyToposort(PythonPackage):
     """Implements a topological sort algorithm."""


### PR DESCRIPTION
New python package that I need as a dependency for a newer snakemake version.

There is a newer version (1.7) available, but it doesn't use setup.py anymore. I will update it as soon as #27798 is merged.