### PR TITLE
aws-parallelcluster: fix pyyaml dependency conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -53,8 +53,11 @@ class AwsParallelcluster(PythonPackage):
     depends_on('py-tabulate@0.8.5', when='@2.9: ^python@3.0:3.4', type=('build', 'run'))
     depends_on('py-tabulate@0.8.2:0.8.7', when='@2.9: ^python@:2,3.5:', type=('build', 'run'))
 
-    depends_on('py-pyyaml@5.2', when='@2.6:2.8 ^python@3.0:3.4', type=('build', 'run'))
-    depends_on('py-pyyaml@5.3.1:', when='@2.9: ^python@:2,3.5:', type=('build', 'run'))
+    depends_on('py-pyyaml@5.3.1:', when='@2.11:', type=('build', 'run'))
+    depends_on('py-pyyaml@5.3.1:', when='@2.9:2.10 ^python@:2,3.5:', type=('build', 'run'))
+    depends_on('py-pyyaml@5.2', when='@2.6:2.10 ^python@3.0:3.4', type=('build', 'run'))
+    depends_on('py-pyyaml@5.1.2:', when='@2.6:2.8 ^python@:2,3.5:', type=('build', 'run'))
+    depends_on('py-pyyaml@5.1.2:', when='@:2.5', type=('build', 'run'))
 
     depends_on('py-jinja2@2.10.1', when='@2.9: ^python@3.0:3.4', type=('build', 'run'))
     depends_on('py-jinja2@2.11.0:', when='@2.9: ^python@:2,3.5:', type=('build', 'run'))
@@ -66,9 +69,6 @@ class AwsParallelcluster(PythonPackage):
     depends_on('py-setuptools', when='@2.6:', type=('build', 'run'))
 
     depends_on('py-enum34@1.1.6:', when='^python@:3.3', type=('build', 'run'))
-
-    depends_on('py-pyyaml@5.1.2', when='@2.6: ^python@:2,3.5:', type=('build', 'run'))
-    depends_on('py-pyyaml@5.1.2:', when='@:2.5', type=('build', 'run'))
 
     # https://github.com/aws/aws-parallelcluster/pull/1633
     patch('enum34.patch', when='@:2.5.1')


### PR DESCRIPTION
For versions of aws-parallelcluster >= 2.9, the pyyaml dependency had to be >= 5.3.1 and == 5.1.2
at the same time making impossible to install ParallelCluster >= 2.9 from spack repository.
See issue: https://github.com/spack/spack/issues/28172

Fixed by limiting pyyaml 5.1.2 version to aws-parallelcluster < 2.8, according to this commit:
https://github.com/aws/aws-parallelcluster/commit/7255d314b7dfc186fc44afdb42aa6e9b1fae39e7

Tested with a manual installation of aws-parallelcluster@2.11.4

```
$ spack install aws-parallelcluster@2.11.4
...
==> Installing aws-parallelcluster-2.11.4-xz35yhjahwsxlgisyt7c4otl6cv6orwc
==> No binary for aws-parallelcluster-2.11.4-xz35yhjahwsxlgisyt7c4otl6cv6orwc found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/44/449537ccda57f91f4ec6ae0c94a8e2b1a789f08f80245fadb28f44a4351d5da4.tar.gz
==> No patches needed for aws-parallelcluster
==> aws-parallelcluster: Executing phase: 'install'
==> aws-parallelcluster: Successfully installed aws-parallelcluster-2.11.4-xz35yhjahwsxlgisyt7c4otl6cv6orwc
  Fetch: 0.98s.  Build: 1.09s.  Total: 2.07s.
[+] /home/ec2-user/spack/opt/spack/linux-amzn2-skylake_avx512/gcc-7.3.1/aws-parallelcluster-2.11.4-xz35yhjahwsxlgisyt7c4otl6cv6orwc
```