### PR TITLE
Vtkm rocm package

### DIFF
--- a/var/spack/repos/builtin/packages/mesa18/package.py
+++ b/var/spack/repos/builtin/packages/mesa18/package.py
@@ -33,7 +33,7 @@ class Mesa18(AutotoolsPackage):
     depends_on('flex', type='build')
     depends_on('gettext', type='build')
     depends_on('pkgconfig', type='build')
-    depends_on('python', type='build')
+    depends_on('python@:2.7', type='build')
     depends_on('py-mako@0.8.0:', type='build')
     depends_on('libxml2')
     depends_on('zlib')


### PR DESCRIPTION
@vicentebolea @chuckatkins 

I tested this with 1.6.0 and 1.7.0-rc1 on rigel,

I ran into a mesa18 issue which requires python@:2.7 due to an API begin removed in 3, I included it here so the tests would pass.