### PR TITLE
Work around an `UnknownPackageError` with upstream repos

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2531,7 +2531,13 @@ class Spec(object):
         # depends_on(..., patch=...)
         for dspec in root.traverse_edges(deptype=all,
                                          cover='edges', root=False):
-            pkg_deps = dspec.parent.package_class.dependencies
+            try:
+                pkg_deps = dspec.parent.package_class.dependencies
+            except spack.repo.UnknownPackageError:
+                # The package may not be available if it is defined in an
+                # upstream repo
+                continue
+
             if dspec.spec.name not in pkg_deps:
                 continue
 


### PR DESCRIPTION
When an upstream repo defines a package, it is not available locally. This leads to an `UnknownPackageError` during concretization. This PR is a possible workaround, though I would be happy to close this PR in favor of a better solution.

The issue is this:

- A Spack install tree, say `/spack/opt/spack`, contains an additional package. In my case our cluster administrator has added a custom package for [healpix](https://healpix.jpl.nasa.gov) because Spack didn't have one at the time.
- I cloned a new Spack, say in `/home/spack`, and added `/spack/opt/spack` as an upstream.
- When I now run `spack concretize` I get an `UnknownPackageError`:

```
==> [2021-12-30-15:18:30.484112] UnknownPackageError: Package 'chealpix' not found in repository '/spack/var/spack/repos/builtin'
==> [2021-12-30-15:18:30.484215] Error: Package 'chealpix' not found in repository '/spack/var/spack/repos/builtin'
Traceback (most recent call last):
  File "/spack/lib/spack/spack/main.py", line 900, in main
    return _main(argv)
  File "/spack/lib/spack/spack/main.py", line 883, in _main
    return _invoke_command(command, parser, args, unknown)
  File "/spack/lib/spack/spack/main.py", line 553, in _invoke_command
    return_val = command(parser, args)
  File "/spack/lib/spack/spack/cmd/concretize.py", line 39, in concretize
    concretized_specs = env.concretize(
  File "/spack/lib/spack/spack/environment/environment.py", line 1115, in concretize
    return self._concretize_together(tests=tests, reuse=reuse)
  File "/spack/lib/spack/spack/environment/environment.py", line 1155, in _concretize_together
    concrete_specs = spack.concretize.concretize_specs_together(
  File "/spack/lib/spack/spack/concretize.py", line 746, in concretize_specs_together
    return _concretize_specs_together_new(*abstract_specs, **kwargs)
  File "/spack/lib/spack/spack/concretize.py", line 755, in _concretize_specs_together_new
    result = spack.solver.asp.solve(abstract_specs, **concretization_kwargs)
  File "/spack/lib/spack/spack/solver/asp.py", line 2053, in solve
    return driver.solve(
  File "/spack/lib/spack/spack/solver/asp.py", line 621, in solve
    answers = builder.build_specs(tuples)
  File "/spack/lib/spack/spack/solver/asp.py", line 1995, in build_specs
    spack.spec.Spec.inject_patches_variant(root)
  File "/spack/lib/spack/spack/spec.py", line 2535, in inject_patches_variant
    pkg_deps = dspec.parent.package_class.dependencies
  File "/spack/lib/spack/spack/spec.py", line 1305, in package_class
    return spack.repo.path.get_pkg_class(self.fullname)
  File "/spack/lib/spack/spack/repo.py", line 647, in get_pkg_class
    return self.repo_for_pkg(pkg_name).get_pkg_class(pkg_name)
  File "/spack/lib/spack/spack/repo.py", line 1107, in get_pkg_class
    module = self._get_pkg_module(pkg_name)
  File "/spack/lib/spack/spack/repo.py", line 1067, in _get_pkg_module
    raise UnknownPackageError(pkg_name, self)
spack.repo.UnknownPackageError: Package 'chealpix' not found in repository '/spack/var/spack/repos/builtin'
```

This is `spack debug report`:

* **Spack:** 0.17.1-677-c2e1a12cdf
* **Python:** 3.8.7
* **Platform:** linux-centos7-haswell
* **Concretizer:** clingo
