### PR TITLE
qt: depends_on assimp@5.0 when @5.14: +opengl

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -131,6 +131,8 @@ class Qt(Package):
     patch('qt5-15-gcc-10.patch', when='@5.12.7:5.15 %gcc@8:')
     patch('qt514.patch', when='@5.14')
     patch('qt514-isystem.patch', when='@5.14.2')
+    # https://bugreports.qt.io/browse/QTBUG-84037
+    patch('qt514-quick3d-assimp.patch', when='@5.14:5')
     # https://bugreports.qt.io/browse/QTBUG-90395
     patch('https://src.fedoraproject.org/rpms/qt5-qtbase/raw/6ae41be8260f0f5403367eb01f7cd8319779674a/f/qt5-qtbase-gcc11.patch',
           sha256='9378afd071ad5c0ec8f7aef48421e4b9fab02f24c856bee9c0951143941913c5',
@@ -154,6 +156,7 @@ class Qt(Package):
     # Dependencies, then variant- and version-specific dependencies
     depends_on("icu4c")
     depends_on("jpeg")
+    depends_on('gmake')
     depends_on("libmng")
     depends_on("libtiff")
     depends_on("libxml2")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -156,7 +156,6 @@ class Qt(Package):
     # Dependencies, then variant- and version-specific dependencies
     depends_on("icu4c")
     depends_on("jpeg")
-    depends_on('gmake')
     depends_on("libmng")
     depends_on("libtiff")
     depends_on("libxml2")

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -176,7 +176,7 @@ class Qt(Package):
     depends_on("libpng", when='@4:')
     depends_on("dbus", when='@4:+dbus')
     depends_on("gl", when='@4:+opengl')
-    depends_on("assimp@5.0", when='@5.14:+opengl')
+    depends_on("assimp@5.0.0:5.0", when='@5.14:+opengl')
 
     depends_on("harfbuzz", when='@5:')
     depends_on("double-conversion", when='@5.7:')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -173,6 +173,7 @@ class Qt(Package):
     depends_on("libpng", when='@4:')
     depends_on("dbus", when='@4:+dbus')
     depends_on("gl", when='@4:+opengl')
+    depends_on("assimp@5.0", when='@5.14:+opengl')
 
     depends_on("harfbuzz", when='@5:')
     depends_on("double-conversion", when='@5.7:')
@@ -551,6 +552,12 @@ class Qt(Package):
                 # but qt-5.6.3 does not recognize this option
                 '-no-nis',
             ])
+
+        if '+opengl' in spec:
+            if version >= Version('5.14'):
+                use_spack_dep('assimp')
+            else:
+                config_args.append('-no-assimp')
 
         # COMPONENTS
 

--- a/var/spack/repos/builtin/packages/qt/qt514-quick3d-assimp.patch
+++ b/var/spack/repos/builtin/packages/qt/qt514-quick3d-assimp.patch
@@ -1,0 +1,13 @@
+diff --git a/qtquick3d/src/plugins/assetimporters/assimp/assimp.pro b/qtquick3d/src/plugins/assetimporters/assimp/assimp.pro
+index ca5c499e..174a075b 100644
+--- a/qtquick3d/src/plugins/assetimporters/assimp/assimp.pro
++++ b/qtquick3d/src/plugins/assetimporters/assimp/assimp.pro
+@@ -10,7 +10,7 @@ QT_FOR_CONFIG += assetimporters-private
+ include($$OUT_PWD/../qtassetimporters-config.pri)
+ 
+ qtConfig(system-assimp):!if(cross_compile:host_build) {
+-    QMAKE_USE_PRIVATE += assimp
++    QMAKE_USE_PRIVATE += quick3d-assimp
+ } else {
+     include(../../../3rdparty/assimp/assimp.pri)
+ }


### PR DESCRIPTION
This addresses (in largest part) #28181 by having `qt` depend on `assimp` when `+opengl`.

Qt [requires](https://github.com/qt/qtquick3d/blob/5.14.0/src/plugins/assetimporters/configure.json#L16) assimp>=5.0.0 for all versions qt@5.14:5 and qt@6:.

Starting with qt@6.3: it [requires](https://github.com/qt/qtquick3d/blob/6.3/src/plugins/assetimporters/configure.cmake#L19) assimp>=5.1, though that Qt version is not in spack, so it can't be a depends_on, yet.

Because of changes in assimp (https://github.com/assimp/assimp/pull/3952 and https://github.com/assimp/assimp/pull/4184) which are in all 5.1 releases, the assetimporterplugin fails to compile with assimp@5.1 due to undefined `AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS` [until](https://github.com/qt/qtquick3d/blob/6.2.2/src/plugins/assetimporters/assimp/assimpimporter.cpp#L1421) qt@6.2.2. It would make sense to make this a `conflicts('^assimp@5.1:', when='@:6.2')`, but again this would fail as long as qt@6 is not in spack yet.

All this to explain why we currently depend on a closed range assimp@5.0 and not an open ended version range...

This successfully concretizes and builds
```yaml
spack:
  specs:
  - qt +opengl ^mesa -llvm
  - pkg-config
  - assimp
  concretization: together
  view: /opt/qt
```
where it previously failed.

However
```console
ldd $(spack location -i qt)/lib/libQt5Quick3DAssetImport.so.5.15.2  | grep assimp
```
is empty so I'm going to mark this as WIP until there has been some more testing...

Maintainer: @sethrj 