### PR TITLE
qt: depends_on zstd@1.3 when @5.13:

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -178,6 +178,7 @@ class Qt(Package):
     depends_on("double-conversion", when='@5.7:')
     depends_on("pcre2+multibyte", when='@5.9:')
     depends_on("llvm", when='@5.11: +doc')
+    depends_on("zstd@1.3:", when='@5.13:')
 
     with when('+webkit'):
         patch(


### PR DESCRIPTION
As of `qt@5.13:`, there is a [dependency](https://github.com/qt/qtbase/blob/30f4ca4e4fbc1d8cf86808dbeb00ec3c046f6c1c/configure.json#L183) on `zstd@1.3:` which is used as the default compression algorithm. When zstd is installed in an enviroment, qt will pick it up but spack will not be aware of this dependency. Requiring zstd as a dependency is therefore likely preferred.

Zstd is small (2.7M installed size on my system) and very likely already installed as a dependency of another package (libtiff, root, rsync, squashfs, or even spack itself).

Maintainer tag: @sethrj 