### PR TITLE
py-nbsphinx: add v0.8.8

### DIFF
--- a/var/spack/repos/builtin/packages/py-nbsphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-nbsphinx/package.py
@@ -18,6 +18,7 @@ class PyNbsphinx(PythonPackage):
     homepage = "https://nbsphinx.readthedocs.io"
     pypi     = "nbsphinx/nbsphinx-0.8.0.tar.gz"
 
+    version('0.8.8', sha256='b5090c824b330b36c2715065a1a179ad36526bff208485a9865453d1ddfc34ec')
     version('0.8.7', sha256='ff91b5b14ceb1a9d44193b5fc3dd3617e7b8ab59c788f7710049ce5faff2750c')
     version('0.8.1', sha256='24d59aa3a1077ba58d9769c64c38fb05b761a1af21c1ac15f6393500cd008ea6')
     version('0.8.0', sha256='369c16fe93af14c878d61fb3e81d838196fb35b27deade2cd7b95efe1fe56ea0')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.