### PR TITLE
py-numpy: add v1.22.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -23,6 +23,7 @@ class PyNumpy(PythonPackage):
     maintainers = ['adamjstewart']
 
     version('main', branch='main')
+    version('1.22.0', sha256='a955e4128ac36797aaffd49ab44ec74a71c11d6938df83b1285492d277db5397')
     version('1.21.5', sha256='6a5928bc6241264dce5ed509e66f33676fc97f464e7a919edc672fb5532221ee')
     version('1.21.4', sha256='e6c76a87633aa3fa16614b61ccedfae45b91df2767cf097aa9c933932a7ed1e0')
     version('1.21.3', sha256='63571bb7897a584ca3249c86dd01c10bcb5fe4296e3568b2e9c1a55356b6410e')
@@ -93,7 +94,8 @@ class PyNumpy(PythonPackage):
     depends_on('python@3.5:', type=('build', 'link', 'run'), when='@1.17:1.18')
     depends_on('python@3.6:', type=('build', 'link', 'run'), when='@1.19')
     depends_on('python@3.7:', type=('build', 'link', 'run'), when='@1.20:1.21.1')
-    depends_on('python@3.7:3.10', type=('build', 'link', 'run'), when='@1.21.2:')
+    depends_on('python@3.7:3.10', type=('build', 'link', 'run'), when='@1.21.2:1.21')
+    depends_on('python@3.8:', type=('build', 'link', 'run'), when='@1.22:')
     depends_on('py-setuptools', type=('build', 'run'))
     # Check pyproject.toml for updates to the required cython version
     depends_on('py-cython@0.29.13:2', when='@1.18.0:', type='build')


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.9.9 and Apple Clang 12.0.0.

https://github.com/numpy/numpy/releases/tag/v1.22.0