### PR TITLE
py-torchgeo: add v0.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -34,6 +34,7 @@ class PyTorchgeo(PythonPackage):
     depends_on('py-dataclasses', when='@0.2: ^python@3.6', type=('build', 'run'))
     depends_on('py-einops', type=('build', 'run'))
     depends_on('py-fiona@1.5:', type=('build', 'run'))
+    depends_on('py-kornia@0.5.11:', when='@0.2:', type=('build', 'run'))
     depends_on('py-kornia@0.5.4:', type=('build', 'run'))
     depends_on('py-matplotlib', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -20,6 +20,7 @@ class PyTorchgeo(PythonPackage):
     maintainers = ['adamjstewart', 'calebrob6']
 
     version('main', branch='main')
+    version('0.2.0', sha256='968c4bf68c7e487bf495f2f306d8bb0f5824eb67e24b26772a510e753e04ba4c')
     version('0.1.1', sha256='6e28132f75e9d8cb3a3a0e8b443aba3cde26c8f3140b9426139ee6e8f8058b26')
     version('0.1.0', sha256='44eb3cf10ab2ac63ff95e92fcd3807096bac3dcb9bdfe15a8edac9d440d2f323')
 
@@ -30,6 +31,7 @@ class PyTorchgeo(PythonPackage):
     # Required dependencies
     depends_on('python@3.6:+bz2', type=('build', 'run'))
     depends_on('py-setuptools@42:', type='build')
+    depends_on('py-dataclasses', when='@0.2: ^python@3.6', type=('build', 'run'))
     depends_on('py-einops', type=('build', 'run'))
     depends_on('py-fiona@1.5:', type=('build', 'run'))
     depends_on('py-kornia@0.5.4:', type=('build', 'run'))
@@ -42,17 +44,21 @@ class PyTorchgeo(PythonPackage):
     depends_on('py-rasterio@1.0.16:', type=('build', 'run'))
     depends_on('py-rtree@0.5:', type=('build', 'run'))
     depends_on('py-scikit-learn@0.18:', type=('build', 'run'))
-    depends_on('py-shapely@1.3:', type=('build', 'run'))
     depends_on('py-segmentation-models-pytorch@0.2:', type=('build', 'run'))
+    depends_on('py-shapely@1.3:', type=('build', 'run'))
     depends_on('py-timm@0.2.1:', type=('build', 'run'))
     depends_on('py-torch@1.7:', type=('build', 'run'))
     depends_on('py-torchmetrics', type=('build', 'run'))
+    depends_on('py-torchvision@0.10:', when='@0.2:', type=('build', 'run'))
     depends_on('py-torchvision@0.3:', type=('build', 'run'))
 
     # Optional dependencies
     with when('+datasets'):
         depends_on('py-h5py', type='run')
+        depends_on('py-laspy@2:', when='@0.2:', type='run')
+        depends_on('open3d@0.11.2:+python', when='@0.2:', type='run')
         depends_on('opencv+python3+imgcodecs+tiff+jpeg+png', type='run')
+        depends_on('py-pandas@0.19.1:', when='@0.2:', type='run')
         depends_on('py-pycocotools', type='run')
         depends_on('py-radiant-mlhub@0.2.1:', type='run')
         depends_on('py-rarfile@3:', type='run')


### PR DESCRIPTION
Successfully builds and passes all import tests on macOS 10.15.7 with Python 3.8.12 and Apple Clang 12.0.0.