### PR TITLE
Python: add ensurepip variant

### DIFF
--- a/var/spack/repos/builtin/packages/py-build/package.py
+++ b/var/spack/repos/builtin/packages/py-build/package.py
@@ -16,7 +16,7 @@ class PyBuild(PythonPackage):
 
     variant('virtualenv', default=False, description='Install optional virtualenv dependency')
 
-    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('python@3.6:+ensurepip', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-packaging@19:', type=('build', 'run'))
     depends_on('py-pep517@0.9.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
 import json
 import os
 import platform
@@ -154,12 +155,13 @@ class Python(AutotoolsPackage):
     variant('nis',      default=False, description='Build nis module')
     variant('zlib',     default=True,  description='Build zlib module')
     variant('bz2',      default=True,  description='Build bz2 module')
-    variant('lzma',     default=True,  description='Build lzma module')
+    variant('lzma',     default=True,  description='Build lzma module', when='@3.3:')
     variant('pyexpat',  default=True,  description='Build pyexpat module')
     variant('ctypes',   default=True,  description='Build ctypes module')
     variant('tkinter',  default=False, description='Build tkinter module')
     variant('uuid',     default=True,  description='Build uuid module')
     variant('tix',      default=False, description='Build Tix module')
+    variant('ensurepip', default=True, description='Build ensurepip module', when='@2.7.9:2,3.4:')
 
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('gettext +libxml2', when='+libxml2')
@@ -272,7 +274,7 @@ class Python(AutotoolsPackage):
 
         variants = ''
         for module in ['readline', 'sqlite3', 'dbm', 'nis',
-                       'zlib', 'bz2', 'lzma', 'ctypes', 'uuid']:
+                       'zlib', 'bz2', 'ctypes', 'uuid']:
             try:
                 python('-c', 'import ' + module, error=os.devnull)
                 variants += '+' + module
@@ -294,7 +296,23 @@ class Python(AutotoolsPackage):
         except ProcessError:
             variants += '~pyexpat'
 
-        # Some modules changed names in Python 3
+        # Some modules are version-dependent
+        if Version(version_str) >= Version('3.3'):
+            try:
+                python('-c', 'import lzma', error=os.devnull)
+                variants += '+lzma'
+            except ProcessError:
+                variants += '~lzma'
+
+        if Version(version_str) in ver('2.7.9:2,3.4:'):
+            # The ensurepip module is always available, but won't work if built with
+            # --without-ensurepip. A more reliable check to see if the package was built
+            # with --with-ensurepip is to check for the presence of a pip executable.
+            if glob.glob(os.path.join(os.path.dirname(exes[0]), 'pip*')):
+                variants += '+ensurepip'
+            else:
+                variants += '~ensurepip'
+
         if Version(version_str) >= Version('3'):
             try:
                 python('-c', 'import tkinter', error=os.devnull)
@@ -463,8 +481,11 @@ class Python(AutotoolsPackage):
                 raise ValueError(
                     '+ucs4 variant not compatible with Python 3.3 and beyond')
 
-        if spec.satisfies('@3:'):
-            config_args.append('--without-ensurepip')
+        if spec.satisfies('@2.7.9:2,3.4:'):
+            if '+ensurepip' in spec:
+                config_args.append('--with-ensurepip')
+            else:
+                config_args.append('--without-ensurepip')
 
         if '+pic' in spec:
             cflags.append(self.compiler.cc_pic_flag)
@@ -640,6 +661,10 @@ class Python(AutotoolsPackage):
                     self.command('-c', 'import tkinter.tix')
                 else:
                     self.command('-c', 'import Tix')
+
+            # Ensure that ensurepip module works
+            if '+ensurepip' in spec:
+                self.command('-c', 'import ensurepip')
 
     # ========================================================================
     # Set up environment to make install easy for python extensions.


### PR DESCRIPTION
Many users are surprised that `spack install python` does not install `pip` (#2065). Some packages actually require a version of Python built with `--ensurepip` (https://github.com/pypa/build/issues/266). This PR adds an `+ensurepip` variant to the Python package. 

I think the only thing we should think about is whether to default to `+ensurepip` or `~ensurepip`. I'm also a bit concerned with how this will interact with #27798. We may need to make the dependency on `py-pip` in `PythonPackage` conditional on the Python variant.

Note that the `ensurepip` module is available in Python even if `--without-ensurepip` is used. The module seems to work fine, but when you create a venv it doesn't contain `pip`. This causes tools like `build` to fail.

Closes #2065