### PR TITLE
namd: Fix issue when building with interface=python ^python@3.8

### DIFF
--- a/var/spack/repos/builtin/packages/namd/namd-python38.patch
+++ b/var/spack/repos/builtin/packages/namd/namd-python38.patch
@@ -1,0 +1,17 @@
+diff -Naur spack-src/config spack-src.patched/config
+--- spack-src/config	2020-08-05 13:51:21.000000000 -0400
++++ spack-src.patched/config	2021-12-30 17:59:44.574264378 -0500
+@@ -501,7 +501,12 @@
+       echo "Using $PYTHON_CONFIG to configure Python."
+       PYTHON_PREFIX=$($PYTHON_CONFIG --prefix)
+       PYTHON_INCFLAGS=$($PYTHON_CONFIG --includes)
+-      PYTHON_LDFLAGS=$($PYTHON_CONFIG --ldflags)
++      # Payerle 2021-12-30: python@3.8 python-config omits -lpython unless --embed given
++      # Try first with embed, and if fails, try w/out embed
++      PYTHON_LDFLAGS=$($PYTHON_CONFIG --ldflags --embed)
++      if echo "$PYTHON_LDFLAGS" | grep -q '^Usage'; then
++	      PYTHON_LDFLAGS=$($PYTHON_CONFIG --ldflags)
++      fi
+       if ! echo "$PYTHON_LDFLAGS" | grep -q -- '-L'; then
+         echo "$PYTHON_CONFIG did not return a -L flag: using Anaconda?"
+         if [ -d "$PYTHON_PREFIX/lib" ]; then

--- a/var/spack/repos/builtin/packages/namd/package.py
+++ b/var/spack/repos/builtin/packages/namd/package.py
@@ -39,6 +39,8 @@ class Namd(MakefilePackage, CudaPackage):
     # allowed
     patch('inherited-member-2.13.patch', when='@2.13')
     patch('inherited-member-2.14.patch', when='@2.14')
+    # Handle change in python-config for python@3.8:
+    patch('namd-python38.patch', when='interface=python ^python@3.8:')
 
     depends_on('charmpp@6.10.1:', when="@2.14:")
     depends_on('charmpp@6.8.2', when="@2.13")


### PR DESCRIPTION
Fixes #28213

Patch to add --embed flag to config-python when interface=python and
using python@3.8:
This is because python@3.8 changed behavior of python-config --ldflags
(and --libs) such that it no longer includes -lpython unless --embed
flag is used.

This shoudl fix #28213

See e.g. https://github.com/mesonbuild/meson/issues/5629