### PR TITLE
WarpX: 22.01

### DIFF
--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -18,7 +18,7 @@ class PyWarpx(PythonPackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url      = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/21.12.tar.gz"
+    url      = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.01.tar.gz"
     git      = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers = ['ax3l', 'dpgrote', 'RemiLehe']
@@ -27,6 +27,7 @@ class PyWarpx(PythonPackage):
 
     # NOTE: if you update the versions here, also see warpx
     version('develop', branch='development')
+    version('22.01', sha256='e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28')
     version('21.12', sha256='847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1')
     version('21.11', sha256='ce60377771c732033a77351cd3500b24b5d14b54a5adc7a622767b9251c10d0b')
     version('21.10', sha256='d372c573f0360094d5982d64eceeb0149d6620eb75e8fdbfdc6777f3328fb454')
@@ -40,20 +41,25 @@ class PyWarpx(PythonPackage):
     variant('mpi', default=True,
             description='Enable MPI support')
 
-    for v in ['21.12', '21.11', '21.10', '21.09', '21.08', '21.07', '21.06',
-              '21.05', '21.04', 'develop']:
+    for v in ['22.01',
+              '21.12', '21.11', '21.10', '21.09', '21.08', '21.07', '21.06',
+              '21.05', '21.04',
+              'develop']:
         depends_on('warpx@{0}'.format(v),
                    when='@{0}'.format(v),
                    type=['build', 'link'])
 
-    depends_on('python@3.6:3.9', type=('build', 'run'))
+    depends_on('python@3.6:3.9', type=('build', 'run'), when='@:21.12')
+    depends_on('python@3.6:3.10', type=('build', 'run'), when='@22.01:')
     depends_on('py-numpy@1.15.0:1', type=('build', 'run'))
     depends_on('py-mpi4py@2.1.0:', type=('build', 'run'), when='+mpi')
     depends_on('py-periodictable@1.5:1', type=('build', 'run'))
     depends_on('py-picmistandard@0.0.14', type=('build', 'run'), when='@21.03:21.11')
     depends_on('py-picmistandard@0.0.16', type=('build', 'run'), when='@21.12')
+    depends_on('py-picmistandard@0.0.18', type=('build', 'run'), when='@22.01')
     depends_on('py-setuptools@42:', type='build')
     depends_on('py-cmake@3.15:3', type='build')
+    depends_on('py-cmake@3.18:3', type='build', when='@22.01:')
     depends_on('py-wheel', type='build')
     depends_on('warpx +lib ~mpi +shared', type=('build', 'link'), when='~mpi')
     depends_on('warpx +lib +mpi +shared', type=('build', 'link'), when='+mpi')

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -50,7 +50,7 @@ class PyWarpx(PythonPackage):
                    type=['build', 'link'])
 
     depends_on('python@3.6:3.9', type=('build', 'run'), when='@:21.12')
-    depends_on('python@3.6:3.10', type=('build', 'run'), when='@22.01:')
+    depends_on('python@3.6:', type=('build', 'run'), when='@22.01:')
     depends_on('py-numpy@1.15.0:1', type=('build', 'run'))
     depends_on('py-mpi4py@2.1.0:', type=('build', 'run'), when='+mpi')
     depends_on('py-periodictable@1.5:1', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -17,7 +17,7 @@ class Warpx(CMakePackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url      = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/21.12.tar.gz"
+    url      = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.01.tar.gz"
     git      = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers = ['ax3l', 'dpgrote', 'MaxThevenet', 'RemiLehe']
@@ -25,6 +25,7 @@ class Warpx(CMakePackage):
 
     # NOTE: if you update the versions here, also see py-warpx
     version('develop', branch='development')
+    version('22.01', sha256='e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28')
     # 22.01+ requires C++17 or newer
     version('21.12', sha256='847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1')
     version('21.11', sha256='ce60377771c732033a77351cd3500b24b5d14b54a5adc7a622767b9251c10d0b')
@@ -85,27 +86,31 @@ class Warpx(CMakePackage):
     depends_on('ascent +mpi', when='+ascent +mpi')
     depends_on('boost@1.66.0: +math', when='+qedtablegen')
     depends_on('cmake@3.15.0:', type='build')
-    depends_on('cuda@9.2.88:', when='compute=cuda')
-    depends_on('llvm-openmp', when='%apple-clang compute=omp')
+    depends_on('cmake@3.18.0:', type='build', when='@22.01:')
     depends_on('mpi', when='+mpi')
+    with when('compute=cuda'):
+        depends_on('cuda@9.2.88:')
+        depends_on('cuda@11.0:', when='@22.01:')
+    with when('compute=hip'):
+        depends_on('rocfft', when='+psatd')
+        depends_on('rocprim')
+        depends_on('rocrand')
+    with when('compute=omp'):
+        depends_on('llvm-openmp', when='%apple-clang')
+        with when('+psatd'):
+            depends_on('fftw@3: +openmp')
+            depends_on('fftw ~mpi', when='~mpi')
+            depends_on('fftw +mpi', when='+mpi')
+            depends_on('pkgconfig', type='build')
     with when('+psatd dims=rz'):
         depends_on('lapackpp')
         depends_on('blaspp')
         depends_on('blaspp +cuda', when='compute=cuda')
-    with when('+psatd compute=omp'):
-        depends_on('fftw@3: +openmp')
-        depends_on('fftw ~mpi', when='~mpi')
-        depends_on('fftw +mpi', when='+mpi')
-        depends_on('pkgconfig', type='build')
     with when('+openpmd'):
         depends_on('openpmd-api@0.13.1:')
         depends_on('openpmd-api@0.14.2:', when='@21.09:')
         depends_on('openpmd-api ~mpi', when='~mpi')
         depends_on('openpmd-api +mpi', when='+mpi')
-    with when('compute=hip'):
-        depends_on('rocfft', when='+psatd')
-        depends_on('rocprim')
-        depends_on('rocrand')
 
     conflicts('dims=1', when='@:21.12',
               msg='WarpX 1D support starts in 22.01+')
@@ -164,17 +169,20 @@ class Warpx(CMakePackage):
     examples_src_dir = 'Examples/Physics_applications/laser_acceleration/'
 
     def _get_input_options(self, post_install):
+        spec = self.spec
         examples_dir = join_path(
             self.install_test_root if post_install else self.stage.source_path,
             self.examples_src_dir)
-        dims = self.spec.variants['dims'].value
+        dims = spec.variants['dims'].value
         inputs_nD = {'1': 'inputs_1d', '2': 'inputs_2d', '3': 'inputs_3d',
-                     'rz': 'inputs_2d_rz'}
+                     'rz': 'inputs_rz'}
+        if spec.satisfies('@:21.12'):
+            inputs_nD['rz'] = 'inputs_2d_rz'
         inputs = join_path(examples_dir, inputs_nD[dims])
 
         cli_args = [inputs, "max_step=50", "diag1.intervals=10"]
         # test openPMD output if compiled in
-        if '+openpmd' in self.spec:
+        if '+openpmd' in spec:
             cli_args.append('diag1.format=openpmd')
         return cli_args
 


### PR DESCRIPTION
Update `warpx` & `py-warpx` to the latest release, `22.01`.