### PR TITLE
ELPA: add extra configure option to bypass MPI test during build

### DIFF
--- a/var/spack/repos/builtin/packages/elpa/package.py
+++ b/var/spack/repos/builtin/packages/elpa/package.py
@@ -177,5 +177,6 @@ class Elpa(AutotoolsPackage, CudaPackage, ROCmPackage):
             options.append('--enable-autotune-redistribute-matrix')
 
         options.append('--disable-silent-rules')
+        options.append('--without-threading-support-check-during-build')
 
         return options


### PR DESCRIPTION
I reported the issues on the ELPA page (https://github.com/marekandreas/elpa/issues/7). The problem is that ./configure script tries to execute MPI test, which is not possible on most HPC platforms (if you don't build on a compute node). The current fix is to add `--without-threading-support-check-during-build` flag to the configure options. IMO threading support in MPI should be assumed by default in the 21-st century. 