### PR TITLE
brigand: only build tests when requested

### DIFF
--- a/var/spack/repos/builtin/packages/brigand/package.py
+++ b/var/spack/repos/builtin/packages/brigand/package.py
@@ -14,8 +14,16 @@ class Brigand(CMakePackage):
     url      = "https://github.com/edouarda/brigand/archive/1.0.0.tar.gz"
     git      = "https://github.com/edouarda/brigand.git"
 
+    maintainers = ['nilsleiffischer']
+
     version('master', branch='master')
     version('1.3.0', sha256='2468107c5b9ab0b56d84797dfc6636d0aae0507ae9cd6cb1acc1de85e5787acd')
     version('1.2.0', sha256='4287fa7278cc000a63e90f1a1b903952b7f606b1a3cf95c23a422d2fe96ca50d')
     version('1.1.0', sha256='afdcc6909ebff6994269d3039c31698c2b511a70280072f73382b26855221f64')
     version('1.0.0', sha256='8daf7686ff39792f851ef1977323808b80aab31c5f38ef0ba4e6a8faae491f8d')
+
+    def cmake_args(self):
+        args = [
+            self.define('BUILD_TESTING', self.run_tests)
+        ]
+        return args


### PR DESCRIPTION
Brigand is a header-only library, so we don't need to build anything unless tests are requested.