### PR TITLE
grace: workaround for buffer overflows

### DIFF
--- a/var/spack/repos/builtin/packages/grace/package.py
+++ b/var/spack/repos/builtin/packages/grace/package.py
@@ -37,6 +37,14 @@ class Grace(AutotoolsPackage):
         # currently and would require to run "autoreconf".
         filter_file('<fftw.h>', '<dfftw.h>',
                     'configure', 'src/fourier.c')
+        filter_file('char   filename[128];',
+                    'char   filename[4096];',
+                    'T1lib/type1/scanfont.c',
+                    string=True)
+        filter_file('char CurFontName[120];',
+                    'char CurFontName[4096];',
+                    'T1lib/type1/fontfcn.c',
+                    string=True)
 
     def configure_args(self):
         args = []


### PR DESCRIPTION
spack paths can be long and this overflows (at least) these buffers
inside of the bundled T1lib inside of the grace distribution, leading
to crashes on startup.