### PR TITLE
herwig3: new version 7.2.2; depends_on thepeg new version 2.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/herwig3/package.py
+++ b/var/spack/repos/builtin/packages/herwig3/package.py
@@ -15,6 +15,7 @@ class Herwig3(AutotoolsPackage):
     tags = ["hep"]
 
     version("7.2.3", sha256="5599899379b01b09e331a2426d78d39b7f6ec126db2543e9d340aefe6aa50f84")
+    version("7.2.2", sha256="53e06b386df5bc20fe268b6c8ba50f1e62b6744e577d383ec836ea3fc672c383")
     version("7.2.1", sha256="d4fff32f21c5c08a4b2e563c476b079859c2c8e3b78d853a8a60da96d5eea686")
 
     depends_on("autoconf", type="build")
@@ -24,6 +25,7 @@ class Herwig3(AutotoolsPackage):
     depends_on("lhapdf")
     depends_on("lhapdfsets", type="build")
     depends_on("thepeg@2.2.1", when="@7.2.1")
+    depends_on("thepeg@2.2.2", when="@7.2.2")
     depends_on("thepeg@2.2.3", when="@7.2.3")
     depends_on("evtgen")
 

--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -17,6 +17,7 @@ class Thepeg(AutotoolsPackage):
     # The commented out versions exist, but may need patches
     # and/or recipe changes
     version("2.2.3", sha256="f21473197a761fc32917b08a8d24d2bfaf93ff57f3441fd605da99ac9de5d50b")
+    version("2.2.2", sha256="97bf55d4391b0a070a3303d3845f8160afec403f1573dfb0e857709ad6262e3e")
     version("2.2.1", sha256="63abc7215e6ad45c11cf9dac013738e194cc38556a8368b850b70ab1b57ea58f")
     version("2.2.0", sha256="d3e1474811b7d9f61a4a98db1e9d60d8ef8f913a50de4cae4dc2cc4f98e6fbf8")
     # version('2.1.7', sha256='2e15727afc1fbfb158fa42ded31c4b1e5b51c25ed6bb66a38233e1fc594329c8')


### PR DESCRIPTION
This is a new version of the Herwig++ 7.2.2 particle physics event generator (https://herwig.hepforge.org) and the required ThePEG version 2.2.2. No changes to build system from what I can tell (no clear access to changeset or release notes in their mercurial repo).

I don't think there is a hard version requirement on ThePEG, so I'm going to leave this as a draft until I can evaluate if we can also use
```diff
-    depends_on('thepeg@2.2.1', when='@7.2.1', type='link')
-    depends_on('thepeg@2.2.2', when='@7.2.2', type='link')
+    depends_on('thepeg@2.2.1:', when='@7.2.1', type='link')
+    depends_on('thepeg@2.2.2:', when='@7.2.2', type='link')
```

Maintainers (or at least past contributors): @iarspider @vvolkl @haralmha 