### PR TITLE
New version v4.0.0 for ip library

### DIFF
--- a/var/spack/repos/builtin/packages/ip/package.py
+++ b/var/spack/repos/builtin/packages/ip/package.py
@@ -16,7 +16,8 @@ class Ip(CMakePackage):
 
     maintainers = ['t-brown', 'kgerheiser', 'edwardhartnett', 'Hang-Lei-NOAA']
 
-    version('3.3.3', sha256='d5a569ca7c8225a3ade64ef5cd68f3319bcd11f6f86eb3dba901d93842eb3633')
+    version('4.0.0', sha256='a2ef0cc4e4012f9cb0389fab6097407f4c623eb49772d96eb80c44f804aa86b8')
+    version('3.3.3', sha256='d5a569ca7c8225a3ade64ef5cd68f3319bcd11f6f86eb3dba901d93842eb3633', preferred=True)
 
     depends_on('sp')
 


### PR DESCRIPTION
Keep 3.3.3 the preferred version until other packages can be updated