### PR TITLE
snap-korf: version update + fix for compilers newer than gcc5

### DIFF
--- a/var/spack/repos/builtin/packages/snap-korf/package.py
+++ b/var/spack/repos/builtin/packages/snap-korf/package.py
@@ -10,20 +10,33 @@ class SnapKorf(MakefilePackage):
 
     homepage = "http://korflab.ucdavis.edu/software.html"
     url      = "http://korflab.ucdavis.edu/Software/snap-2013-11-29.tar.gz"
+    git      = "https://github.com/KorfLab/SNAP.git"
 
+    version('2021-11-04', commit='62ff3120fceccb03b5eea9d21afec3167dedfa94')
     version('2013-11-29', sha256='e2a236392d718376356fa743aa49a987aeacd660c6979cee67121e23aeffc66a')
 
     depends_on('perl', type=('build', 'run'))
-    depends_on('boost')
-    depends_on('sqlite')
-    depends_on('sparsehash')
 
-    conflicts('%gcc@5:', when='@2013-11-29')
+    def edit(self, spec, prefix):
+        if spec.satisfies('@2013-11-29%gcc@6:'):
+            rstr = '\\1 -Wno-tautological-compare -Wno-misleading-indentation'
+            filter_file('(-Werror)', rstr, 'Zoe/Makefile')
+            rstr = '\\1 -Wno-error=format-overflow -Wno-misleading-indentation'
+            filter_file('(-Werror)', rstr, 'Makefile')
+
+        filter_file(r'(^const char \* zoeFunction;)', 'extern \\1',
+                    'Zoe/zoeTools.h')
+        filter_file(r'(^const char \* zoeConstructor;)', 'extern \\1',
+                    'Zoe/zoeTools.h')
+        filter_file(r'(^const char \* zoeMethod;)', 'extern \\1',
+                    'Zoe/zoeTools.h')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
 
-        progs  = ['snap', 'fathom', 'forge', 'depend', 'exonpairs', 'hmm-info']
+        progs  = ['snap', 'fathom', 'forge']
+        if spec.satisfies('@2013-11-29'):
+            progs = progs + ['depend', 'exonpairs', 'hmm-info']
         for p in progs:
             install(p, prefix.bin)
 


### PR DESCRIPTION
This also removes some unused dependencies 