### PR TITLE
py-appdirs: patch for encoding issue

### DIFF
--- a/var/spack/repos/builtin/packages/py-appdirs/decode-appdirs.patch
+++ b/var/spack/repos/builtin/packages/py-appdirs/decode-appdirs.patch
@@ -1,0 +1,21 @@
+diff --git a/setup.py b/setup.py
+index 293c1c4..122cd04 100644
+--- a/setup.py
++++ b/setup.py
+@@ -2,6 +2,7 @@
+ import sys
+ import os
+ import os.path
++from io import open
+ # appdirs is a dependency of setuptools, so allow installing without it.
+ try:
+     from setuptools import setup
+@@ -15,7 +16,7 @@ if sys.version_info < (2, 7):
+ 
+ 
+ def read(fname):
+-    inf = open(os.path.join(os.path.dirname(__file__), fname))
++    inf = open(os.path.join(os.path.dirname(__file__), fname), encoding='utf8')
+     out = "\n" + inf.read().replace("\r\n", "\n")
+     inf.close()
+     return out

--- a/var/spack/repos/builtin/packages/py-appdirs/package.py
+++ b/var/spack/repos/builtin/packages/py-appdirs/package.py
@@ -18,4 +18,5 @@ class PyAppdirs(PythonPackage):
     version('1.4.0', sha256='8fc245efb4387a4e3e0ac8ebcc704582df7d72ff6a42a53f5600bbb18fdaadc5')
 
     patch('setuptools-import.patch', when='@:1.4.0')
+    patch('decode-appdirs.patch', when='@1.4.4')
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Reading `appdirs.py` without explicitly requesting UTF-8 decoding results in the build process to fail for Python 3.6.
See https://github.com/ActiveState/appdirs/pull/152 for the upstream fix.