### PR TITLE
py-pyzmq: fix deptype of libzmq

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -34,8 +34,8 @@ class PyPyzmq(PythonPackage):
     depends_on('py-cython@0.20:', type='build', when='@18:')
     depends_on('py-cython@0.29:', type='build', when='@22.3.0:')
     depends_on('py-gevent', type=('build', 'run'))
-    depends_on('libzmq', type=('build', 'run'))
-    depends_on('libzmq@3.2:', type=('build', 'run'), when='@22.3.0:')
+    depends_on('libzmq', type=('build', 'link'))
+    depends_on('libzmq@3.2:', type=('build', 'link'), when='@22.3.0:')
     depends_on('py-setuptools', type='build', when='@22.3.0:')
     # Only when python is provided by 'pypy'
     depends_on('py-py', type=('build', 'run'), when='@:22')


### PR DESCRIPTION
#27543 changed the deptype of py-pyzmql -> libzmq from build,link (default) to build,run. This is incorrect, as libzmq is linked as a shared library, and breaks dependent builds, like py-jupyterlab-server, which fails with:
```
ImportError: .../lib/python3.8/site-packages/zmq/backend/cython/message.cpython-38-x86_64-linux-gnu.so: undefined symbol: zmq_msg_gets
```
(because it's picking up the wrong libzmq from the system). Changing this back (explicitly) fixes things.