### PR TITLE
e2fsprogs: fix non-root install

### DIFF
--- a/var/spack/repos/builtin/packages/e2fsprogs/package.py
+++ b/var/spack/repos/builtin/packages/e2fsprogs/package.py
@@ -20,3 +20,9 @@ class E2fsprogs(AutotoolsPackage):
 
     def setup_run_environment(self, env):
         env.prepend_path('PATH', self.prefix.sbin)
+
+    def configure_args(self):
+        # avoid installing things in /etc
+        return ['--without-udev-rules-dir',
+                '--without-crond-dir',
+                '--without-systemd-unit-dir']


### PR DESCRIPTION
e2fsprogs tries to install a few things in the system /etc and /usr/lib (if it detects crond, systemd, udev), leading to install failures:
```
/bin/install: cannot create regular file '/usr/lib/udev/rules.d/96-e2scrub.rules': Permission denied
/bin/install: cannot create regular file '/etc/cron.d/e2scrub_all': Permission denied
/bin/install: cannot create regular file '/usr/lib/systemd/system/e2scrub@@.service': Permission denied
```
This disables installing these components.  (They could also be moved to a package-specific directory, but they probably aren't very helpful in this context anyway.)