### PR TITLE
viennarna: new version

### DIFF
--- a/var/spack/repos/builtin/packages/viennarna/package.py
+++ b/var/spack/repos/builtin/packages/viennarna/package.py
@@ -15,6 +15,7 @@ class Viennarna(AutotoolsPackage):
     homepage = "https://www.tbi.univie.ac.at/RNA/"
     url      = "https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_4_x/ViennaRNA-2.4.3.tar.gz"
 
+    version('2.5.0', sha256='b85544650ee316743173ec9b30497cc4c559f1bfb8f66d16c563f780afd8c0c5')
     version('2.4.3', sha256='4cda6e22029b34bb9f5375181562f69e4a780a89ead50fe952891835e9933ac0')
     version('2.3.5', sha256='26b62a00da21bc5597b580ab8fef4e624234ec446d7d3cb0ce22803a5d7074ca')
 
@@ -36,7 +37,7 @@ class Viennarna(AutotoolsPackage):
         args = self.enable_or_disable('sse')
         args += self.with_or_without('python')
         args += self.with_or_without('perl')
-        if self.spec.satisfies('@2.4.3:'):
+        if self.spec.satisfies('@2.4.3'):
             args.append('--without-swig')
 
         if 'python@3:' in self.spec:


### PR DESCRIPTION
New version also resolves build errors with gcc10+

Not sure why the scripting interface was being disabled for 2.4.3 and above, but I've restricted that to just 2.4.3 since 2.5.0 builds fine without it disabled.