### PR TITLE
py-pyzmq: adjust constraints for python-3.9

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyzmq/package.py
+++ b/var/spack/repos/builtin/packages/py-pyzmq/package.py
@@ -26,9 +26,10 @@ class PyPyzmq(PythonPackage):
     version('16.0.2', sha256='0322543fff5ab6f87d11a8a099c4c07dd8a1719040084b6ce9162bcdf5c45c9d')
     version('14.7.0', sha256='77994f80360488e7153e64e5959dc5471531d1648e3a4bff14a714d074a38cc2')
 
+    depends_on('python@3.6:', type=('build', 'run'), when='@22:')
+    depends_on('python@2.7,3.3:', type=('build', 'run'), when='@18.1')
     # Python 3.9 build issues
-    depends_on('python@3.6:3.8', type=('build', 'run'), when='@22:')
-    depends_on('python@2.7,3.3:3.8', type=('build', 'run'), when='@16:18')
+    depends_on('python@2.7,3.3:3.8', type=('build', 'run'), when='@16:18.0')
     depends_on('python@2.6:2.7,3.2:3.8', type=('build', 'run'), when='@:14')
     depends_on('py-cython@0.16:', type='build')
     depends_on('py-cython@0.20:', type='build', when='@18:')


### PR DESCRIPTION
Version 18.1 builds with python-3.9