### PR TITLE
py-matplotlib: fix config for oneapi compiler

### DIFF
--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -209,6 +209,7 @@ class PyMatplotlib(PythonPackage):
                 config.write('[libs]\n')
                 config.write('system_freetype = True\n')
                 config.write('system_qhull = True\n')
+                # avoids error where link time opt is used for compile but not link
                 if self.spec.satisfies('%clang') or self.spec.satisfies('%oneapi'):
                     config.write('enable_lto = False\n')
 

--- a/var/spack/repos/builtin/packages/py-matplotlib/package.py
+++ b/var/spack/repos/builtin/packages/py-matplotlib/package.py
@@ -209,7 +209,7 @@ class PyMatplotlib(PythonPackage):
                 config.write('[libs]\n')
                 config.write('system_freetype = True\n')
                 config.write('system_qhull = True\n')
-                if self.spec.satisfies('%clang'):
+                if self.spec.satisfies('%clang') or self.spec.satisfies('%oneapi'):
                     config.write('enable_lto = False\n')
 
     @run_after('build')


### PR DESCRIPTION
Resolves #24327 

oneapi compiler is based on clang and needs the same workaround.

It is compiling objects with
```
icpx -flto
```
But not using ```-flto``` for link