### PR TITLE
net-snmp update to latest recommended release (5.9.1)

### DIFF
--- a/var/spack/repos/builtin/packages/net-snmp/package.py
+++ b/var/spack/repos/builtin/packages/net-snmp/package.py
@@ -10,9 +10,10 @@ class NetSnmp(AutotoolsPackage):
     """A SNMP application library, tools and daemon."""
 
     homepage = "http://www.net-snmp.org/"
-    url      = "https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9/net-snmp-5.9.tar.gz"
+    url      = "https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.1/net-snmp-5.9.1.tar.gz/download"
 
     version('5.9', sha256='04303a66f85d6d8b16d3cc53bde50428877c82ab524e17591dfceaeb94df6071')
+    version('5.9.1', sha256='eb7fd4a44de6cddbffd9a92a85ad1309e5c1054fb9d5a7dd93079c8953f48c3f')
 
     depends_on('perl-extutils-makemaker')
     depends_on('ncurses')

--- a/var/spack/repos/builtin/packages/net-snmp/package.py
+++ b/var/spack/repos/builtin/packages/net-snmp/package.py
@@ -12,8 +12,8 @@ class NetSnmp(AutotoolsPackage):
     homepage = "http://www.net-snmp.org/"
     url      = "https://sourceforge.net/projects/net-snmp/files/net-snmp/5.9.1/net-snmp-5.9.1.tar.gz/download"
 
-    version('5.9', sha256='04303a66f85d6d8b16d3cc53bde50428877c82ab524e17591dfceaeb94df6071')
     version('5.9.1', sha256='eb7fd4a44de6cddbffd9a92a85ad1309e5c1054fb9d5a7dd93079c8953f48c3f')
+    version('5.9', sha256='04303a66f85d6d8b16d3cc53bde50428877c82ab524e17591dfceaeb94df6071')
 
     depends_on('perl-extutils-makemaker')
     depends_on('ncurses')

--- a/var/spack/repos/builtin/packages/net-snmp/package.py
+++ b/var/spack/repos/builtin/packages/net-snmp/package.py
@@ -21,3 +21,6 @@ class NetSnmp(AutotoolsPackage):
     def configure_args(self):
         args = ['--with-defaults', 'LIBS=-ltinfo']
         return args
+
+    def install(self, spec, prefix):
+        make('install', parallel=False)


### PR DESCRIPTION
This adds the recently released version 5.9.1.  The net-snmp/CHANGES file says there are "Many bug fixes".