### PR TITLE
Add epics packages

### DIFF
--- a/var/spack/repos/builtin/packages/epics-base/package.py
+++ b/var/spack/repos/builtin/packages/epics-base/package.py
@@ -16,7 +16,7 @@ device and driver support."""
     homepage = "https://epics-controls.org"
     url      = "https://epics-controls.org/download/base/base-7.0.6.1.tar.gz"
 
-    # maintainers = ['glenn-horton-smith']
+    maintainers = ['glenn-horton-smith']
 
     version('7.0.6.1', sha256='8ff318f25e2b70df466f933636a2da85e4b0c841504b9e89857652a4786b6387')
 

--- a/var/spack/repos/builtin/packages/epics-base/package.py
+++ b/var/spack/repos/builtin/packages/epics-base/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import subprocess
-
 from spack import *
 
 
@@ -23,17 +21,23 @@ device and driver support."""
     version('7.0.6.1', sha256='8ff318f25e2b70df466f933636a2da85e4b0c841504b9e89857652a4786b6387')
 
     depends_on('readline')
+    depends_on('perl', type=('build', 'run'))
 
     @property
     def install_targets(self):
         return ['INSTALL_LOCATION={0}'.format(self.prefix), 'install']
 
     def get_epics_host_arch(self):
-        return subprocess.check_output(
-            "perl %s/perl/EpicsHostArch.pl" % self.prefix.lib,
-            shell=True).decode('utf8').strip()
+        perl = which('perl', required=True)
+        return perl('%s/perl/EpicsHostArch.pl' % self.prefix.lib,
+                    output=str, error=str).strip()
 
     def setup_build_environment(self, env):
+        env.set('EPICS_BASE', self.prefix)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        epics_host_arch = self.get_epics_host_arch()
+        env.set('EPICS_HOST_ARCH', epics_host_arch)
         env.set('EPICS_BASE', self.prefix)
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/epics-base/package.py
+++ b/var/spack/repos/builtin/packages/epics-base/package.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import subprocess
+
+from spack import *
+
 
 class EpicsBase(MakefilePackage):
     """This is the main core of EPICS, the Experimental Physics and Industrial
@@ -25,11 +27,11 @@ device and driver support."""
     @property
     def install_targets(self):
         return ['INSTALL_LOCATION={0}'.format(self.prefix), 'install']
-        
+
     def get_epics_host_arch(self):
         return subprocess.check_output(
-                "perl %s/perl/EpicsHostArch.pl" % self.prefix.lib,
-                shell=True).decode('utf8').strip()
+            "perl %s/perl/EpicsHostArch.pl" % self.prefix.lib,
+            shell=True).decode('utf8').strip()
 
     def setup_build_environment(self, env):
         env.set('EPICS_BASE', self.prefix)

--- a/var/spack/repos/builtin/packages/epics-base/package.py
+++ b/var/spack/repos/builtin/packages/epics-base/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import subprocess
+
+class EpicsBase(MakefilePackage):
+    """This is the main core of EPICS, the Experimental Physics and Industrial
+Control System, comprising the build system and tools, common and OS-interface
+libraries, network protocol client and server libraries, static and run-time
+database access routines, the database processing code, and standard record,
+device and driver support."""
+
+    homepage = "https://epics-controls.org"
+    url      = "https://epics-controls.org/download/base/base-7.0.6.1.tar.gz"
+
+    # maintainers = ['glenn-horton-smith']
+
+    version('7.0.6.1', sha256='8ff318f25e2b70df466f933636a2da85e4b0c841504b9e89857652a4786b6387')
+
+    depends_on('readline')
+
+    @property
+    def install_targets(self):
+        return ['INSTALL_LOCATION={0}'.format(self.prefix), 'install']
+        
+    def get_epics_host_arch(self):
+        return subprocess.check_output(
+                "perl %s/perl/EpicsHostArch.pl" % self.prefix.lib,
+                shell=True).decode('utf8').strip()
+
+    def setup_build_environment(self, env):
+        env.set('EPICS_BASE', self.prefix)
+
+    def setup_run_environment(self, env):
+        epics_host_arch = self.get_epics_host_arch()
+        env.set('EPICS_HOST_ARCH', epics_host_arch)
+        env.set('EPICS_BASE', self.prefix)
+        env.prepend_path('PATH', join_path(self.prefix.bin, epics_host_arch))

--- a/var/spack/repos/builtin/packages/epics-ca-gateway/package.py
+++ b/var/spack/repos/builtin/packages/epics-ca-gateway/package.py
@@ -17,7 +17,7 @@ class EpicsCaGateway(MakefilePackage):
     homepage = "https://epics.anl.gov/extensions/gateway/"
     url      = "https://github.com/epics-extensions/ca-gateway/archive/refs/tags/v2.1.3.tar.gz"
 
-    # maintainers = ['glenn-horton-smith']
+    maintainers = ['glenn-horton-smith']
 
     version('2.1.3', sha256='f6e9dba46951a168d3208fc57054138759d56ebd8a7c07b496e8f5b8a56027d7')
 

--- a/var/spack/repos/builtin/packages/epics-ca-gateway/package.py
+++ b/var/spack/repos/builtin/packages/epics-ca-gateway/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class EpicsCaGateway(MakefilePackage):
+    """The EPICS Channel Access PV Gateway is both a Channel Access
+    server and Channel Access client. It provides a means for many
+    clients to access a process variable, while making only one
+    connection to the server that owns the process variable. It also
+    provides additional access security beyond that on the server.
+    The clients and the server may be on different subnets."""
+
+    homepage = "https://epics.anl.gov/extensions/gateway/"
+    url      = "https://github.com/epics-extensions/ca-gateway/archive/refs/tags/v2.1.3.tar.gz"
+
+    # maintainers = ['glenn-horton-smith']
+
+    version('2.1.3', sha256='f6e9dba46951a168d3208fc57054138759d56ebd8a7c07b496e8f5b8a56027d7')
+
+    depends_on('epics-base')
+    depends_on('epics-pcas')
+
+    @property
+    def install_targets(self):
+        return ['INSTALL_LOCATION={0}'.format(self.prefix), 'install']
+
+    def edit(self, spec, prefix):
+        with open('configure/RELEASE.local', 'w') as release_file:
+            release_file.write('EPICS_BASE = ' + env['EPICS_BASE'] + '\n')
+            release_file.write('PCAS = ' + spec['epics-pcas'].prefix)
+
+    def setup_run_environment(self, envmod):
+        envmod.prepend_path('PATH', join_path(self.prefix.bin, env['EPICS_HOST_ARCH']))

--- a/var/spack/repos/builtin/packages/epics-pcas/package.py
+++ b/var/spack/repos/builtin/packages/epics-pcas/package.py
@@ -18,7 +18,7 @@ class EpicsPcas(MakefilePackage):
 
     version('4.13.3', sha256='5004e39339c8e592fcb9b4275c84143635c6e688c0fbe01f17dafe19850398a0')
 
-    depends_on('epics-base')
+    depends_on('epics-base', type=('build', 'link', 'run'))
 
     @property
     def install_targets(self):
@@ -27,9 +27,6 @@ class EpicsPcas(MakefilePackage):
     def edit(self, spec, prefix):
         with open('configure/RELEASE.local', 'w') as release_file:
             release_file.write('EPICS_BASE = ' + env['EPICS_BASE'] + '\n')
-
-    def setup_build_environment(self, envmod):
-        envmod.set('EPICS_BASE', env['EPICS_BASE'])
 
     def setup_run_environment(self, envmod):
         envmod.prepend_path('PATH', join_path(self.prefix.bin, env['EPICS_HOST_ARCH']))

--- a/var/spack/repos/builtin/packages/epics-pcas/package.py
+++ b/var/spack/repos/builtin/packages/epics-pcas/package.py
@@ -13,7 +13,7 @@ class EpicsPcas(MakefilePackage):
     homepage = "https://github.com/epics-modules/pcas"
     url      = "https://github.com/epics-modules/pcas/archive/refs/tags/v4.13.3.tar.gz"
 
-    # maintainers = ['glenn-horton-smith']
+    maintainers = ['glenn-horton-smith']
 
     version('4.13.3', sha256='5004e39339c8e592fcb9b4275c84143635c6e688c0fbe01f17dafe19850398a0')
 

--- a/var/spack/repos/builtin/packages/epics-pcas/package.py
+++ b/var/spack/repos/builtin/packages/epics-pcas/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+class EpicsPcas(MakefilePackage):
+    """EPICS Portable Channel Access Server and Generic Data Descriptor
+    C++ libraries, split off from EPICS Base 3.16.1 as a separate module
+    for EPICS 7."""
+
+    homepage = "https://github.com/epics-modules/pcas"
+    url      = "https://github.com/epics-modules/pcas/archive/refs/tags/v4.13.3.tar.gz"
+
+    # maintainers = ['glenn-horton-smith']
+
+    version('4.13.3', sha256='5004e39339c8e592fcb9b4275c84143635c6e688c0fbe01f17dafe19850398a0')
+
+    depends_on('epics-base')
+
+    @property
+    def install_targets(self):
+        return ['INSTALL_LOCATION={0}'.format(self.prefix), 'install']
+
+    def edit(self, spec, prefix):
+        with open('configure/RELEASE.local', 'w') as release_file:
+            release_file.write('EPICS_BASE = ' + env['EPICS_BASE'] + '\n')
+
+    def setup_build_environment(self, envmod):
+        envmod.set('EPICS_BASE', env['EPICS_BASE'])
+
+    def setup_run_environment(self, envmod):
+        envmod.prepend_path('PATH', join_path(self.prefix.bin, env['EPICS_HOST_ARCH']))

--- a/var/spack/repos/builtin/packages/epics-pcas/package.py
+++ b/var/spack/repos/builtin/packages/epics-pcas/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 
+
 class EpicsPcas(MakefilePackage):
     """EPICS Portable Channel Access Server and Generic Data Descriptor
     C++ libraries, split off from EPICS Base 3.16.1 as a separate module

--- a/var/spack/repos/builtin/packages/epics-snmp/package.py
+++ b/var/spack/repos/builtin/packages/epics-snmp/package.py
@@ -14,7 +14,7 @@ class EpicsSnmp(MakefilePackage):
     homepage = "https://groups.nscl.msu.edu/controls/files/devSnmp.html"
     url      = "https://groups.nscl.msu.edu/controls/files/epics-snmp-1.1.0.3.zip"
 
-    # maintainers = ['glenn-horton-smith']
+    maintainers = ['glenn-horton-smith']
 
     version('1.1.0.3', sha256='fe8b2cb25412555a639e3513f48a4da4c4cc3cc43425176349338be27b1e26d3')
 

--- a/var/spack/repos/builtin/packages/epics-snmp/package.py
+++ b/var/spack/repos/builtin/packages/epics-snmp/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class EpicsSnmp(MakefilePackage):
-    """This module provides EPICS device-layer support for hardware 
+    """This module provides EPICS device-layer support for hardware
     devices that communicate via SNMP (Simple Network Management
     Protocol)."""
 
@@ -26,12 +26,14 @@ class EpicsSnmp(MakefilePackage):
         return ['INSTALL_LOCATION={0}'.format(self.prefix), 'install']
 
     def edit(self, spec, prefix):
-        config_release = FileFilter('configure/RELEASE',
+        config_release = FileFilter(
+            'configure/RELEASE',
             'NventSGP/configure/RELEASE', 'WienerCrate/configure/RELEASE')
         config_release.filter('EPICS_BASE *=.*', 'EPICS_BASE = ' + env['EPICS_BASE'])
         makefile = FileFilter('snmpApp/src/Makefile')
-        makefile.filter('USR_CPPFLAGS', 
-            'USR_CPPFLAGS += `net-snmp-config --cflags`\nUSR_CPPFLAGS')    
+        makefile.filter(
+            'USR_CPPFLAGS',
+            'USR_CPPFLAGS += `net-snmp-config --cflags`\nUSR_CPPFLAGS')
 
     def setup_run_environment(self, envmod):
         envmod.prepend_path('PATH', join_path(self.prefix.bin, env['EPICS_HOST_ARCH']))

--- a/var/spack/repos/builtin/packages/epics-snmp/package.py
+++ b/var/spack/repos/builtin/packages/epics-snmp/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class EpicsSnmp(MakefilePackage):
+    """This module provides EPICS device-layer support for hardware 
+    devices that communicate via SNMP (Simple Network Management
+    Protocol)."""
+
+    homepage = "https://groups.nscl.msu.edu/controls/files/devSnmp.html"
+    url      = "https://groups.nscl.msu.edu/controls/files/epics-snmp-1.1.0.3.zip"
+
+    # maintainers = ['glenn-horton-smith']
+
+    version('1.1.0.3', sha256='fe8b2cb25412555a639e3513f48a4da4c4cc3cc43425176349338be27b1e26d3')
+
+    depends_on('epics-base')
+    depends_on('net-snmp')
+
+    @property
+    def install_targets(self):
+        return ['INSTALL_LOCATION={0}'.format(self.prefix), 'install']
+
+    def edit(self, spec, prefix):
+        config_release = FileFilter('configure/RELEASE',
+            'NventSGP/configure/RELEASE', 'WienerCrate/configure/RELEASE')
+        config_release.filter('EPICS_BASE *=.*', 'EPICS_BASE = ' + env['EPICS_BASE'])
+        makefile = FileFilter('snmpApp/src/Makefile')
+        makefile.filter('USR_CPPFLAGS', 
+            'USR_CPPFLAGS += `net-snmp-config --cflags`\nUSR_CPPFLAGS')    
+
+    def setup_run_environment(self, envmod):
+        envmod.prepend_path('PATH', join_path(self.prefix.bin, env['EPICS_HOST_ARCH']))


### PR DESCRIPTION
This adds packages for epics-base (the core of the Experimental Physics and Industrial Control System) and for some extensions and drivers (epics-snmp for SNMP drivers, epics-ca-gateway for the Channel Access Gateway, and epics-pcas for the Portable Channel Access library that is required by epics-ca-gateway.)

I am not a developer of any of these, but I'm willing to maintain the packages.