### PR TITLE
Fix spack install --v[tab] spec

### DIFF
--- a/share/spack/bash/spack-completion.in
+++ b/share/spack/bash/spack-completion.in
@@ -123,7 +123,7 @@ _bash_completion_spack() {
     # If the cursor is in the middle of the line, like:
     #     `spack -d [] install`
     # COMP_WORDS will not contain the empty character, so we have to add it.
-    if [[ "${COMP_LINE:$COMP_POINT:1}" == " " ]]
+    if [[ "${COMP_LINE:$COMP_POINT-1:1}" == " " ]]
     then
         cur=""
     fi

--- a/share/spack/qa/completion-test.sh
+++ b/share/spack/qa/completion-test.sh
@@ -70,6 +70,16 @@ _test_debug_functions() {
         emulate -L sh
     fi
 
+    # Test whether `spack install --verb[] spec` completes to `spack install --verbose spec`
+    COMP_LINE='spack install --verb spec'
+    COMP_POINT=20
+    COMP_WORDS=(spack install --verb spec)
+    COMP_CWORD=2
+    COMP_KEY=9
+    COMP_TYPE=64
+    _bash_completion_spack
+    contains "--verbose" echo "${COMPREPLY[@]}"
+
     # This is a particularly tricky case that involves the following situation:
     #     `spack -d [] install `
     # Here, [] represents the cursor, which is in the middle of the line.

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -123,7 +123,7 @@ _bash_completion_spack() {
     # If the cursor is in the middle of the line, like:
     #     `spack -d [] install`
     # COMP_WORDS will not contain the empty character, so we have to add it.
-    if [[ "${COMP_LINE:$COMP_POINT:1}" == " " ]]
+    if [[ "${COMP_LINE:$COMP_POINT-1:1}" == " " ]]
     then
         cur=""
     fi


### PR DESCRIPTION
Currently `spack install --v[tab] spec` completes to `spack install - spec`.

This regression was caused by #14393
