### PR TITLE
Python: set default config_vars

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -77,15 +77,13 @@ def _try_import_from_store(module, query_spec, query_info=None):
     installed_specs = spack.store.db.query(query_spec, installed=True)
 
     for candidate_spec in installed_specs:
-        version = candidate_spec['python'].version
-        lib_spd = ['lib', 'python{}'.format(version.up_to(2)), 'site-packages']
-        lib64_spd = ['lib64', 'python{}'.format(version.up_to(2)), 'site-packages']
-        lib_debian = ['lib', 'python{}'.format(version.up_to(1)), 'dist-packages']
+        pkg = candidate_spec['python'].package
+        purelib = pkg.config_vars['python_lib']['false']['false']
+        platlib = pkg.config_vars['python_lib']['true']['false']
 
         module_paths = [
-            os.path.join(candidate_spec.prefix, *lib_debian),
-            os.path.join(candidate_spec.prefix, *lib_spd),
-            os.path.join(candidate_spec.prefix, *lib64_spd)
+            os.path.join(candidate_spec.prefix, purelib),
+            os.path.join(candidate_spec.prefix, platlib),
         ]
         sys.path.extend(module_paths)
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -77,17 +77,15 @@ def _try_import_from_store(module, query_spec, query_info=None):
     installed_specs = spack.store.db.query(query_spec, installed=True)
 
     for candidate_spec in installed_specs:
-        python_spec = candidate_spec['python']
-        lib_spd = python_spec.package.default_site_packages_dir
-        lib64_spd = lib_spd.replace('lib/', 'lib64/')
-        lib_debian_derivative = os.path.join(
-            'lib', 'python{0}'.format(python_spec.version.up_to(1)), 'dist-packages'
-        )
+        version = candidate_spec['python'].version
+        lib_spd = ['lib', 'python{}'.format(version.up_to(2)), 'site-packages']
+        lib64_spd = ['lib64', 'python{}'.format(version.up_to(2)), 'site-packages']
+        lib_debian = ['lib', 'python{}'.format(version.up_to(1)), 'dist-packages']
 
         module_paths = [
-            os.path.join(candidate_spec.prefix, lib_debian_derivative),
-            os.path.join(candidate_spec.prefix, lib_spd),
-            os.path.join(candidate_spec.prefix, lib64_spd)
+            os.path.join(candidate_spec.prefix, *lib_debian),
+            os.path.join(candidate_spec.prefix, *lib_spd),
+            os.path.join(candidate_spec.prefix, *lib64_spd)
         ]
         sys.path.extend(module_paths)
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -758,9 +758,16 @@ for plat_specific in [True, False]:
         if dag_hash not in self._config_vars:
             # Default config vars
             version = self.version.up_to(2)
+            try:
+                cc = self.compiler.cc
+                cxx = self.compiler.cxx
+            except TypeError:
+                cc = 'cc'
+                cxx = 'c++'
+
             config = {
-                'CC': self.compiler.cc,
-                'CXX': self.compiler.cxx,
+                'CC': cc,
+                'CXX': cxx,
                 'INCLUDEPY': self.prefix.include.join('python{}').format(version),
                 'LIBDEST': self.prefix.lib.join('python{}').format(version),
                 'LIBDIR': self.prefix.lib,
@@ -768,8 +775,8 @@ for plat_specific in [True, False]:
                     'config-{0}-{1}').format(version, sys.platform),
                 'LDLIBRARY': 'libpython{}.{}'.format(version, dso_suffix),
                 'LIBRARY': 'libpython{}.a'.format(version),
-                'LDSHARED': self.compiler.cc,
-                'LDCXXSHARED': self.compiler.cxx,
+                'LDSHARED': cc,
+                'LDCXXSHARED': cxx,
                 'PYTHONFRAMEWORKPREFIX': '/System/Library/Frameworks',
                 'prefix': self.prefix,
                 'config_h_filename': self.prefix.include.join('python{}').join(

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -761,7 +761,7 @@ for plat_specific in [True, False]:
             try:
                 cc = self.compiler.cc
                 cxx = self.compiler.cxx
-            except TypeError:
+            except (TypeError, NoCompilerForSpecError):
                 cc = 'cc'
                 cxx = 'c++'
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -14,6 +14,7 @@ from llnl.util.filesystem import get_filetype, path_contains_subdirectory
 from llnl.util.lang import match_predicate
 
 from spack import *
+from spack.build_environment import dso_suffix
 from spack.util.environment import is_system_path
 from spack.util.prefix import Prefix
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -758,8 +758,8 @@ for plat_specific in [True, False]:
             # Default config vars
             version = self.version.up_to(2)
             config = {
-                'CC': self.compiler.cc
-                'CXX': self.compiler.cxx
+                'CC': self.compiler.cc,
+                'CXX': self.compiler.cxx,
                 'INCLUDEPY': self.prefix.include.join('python{}').format(version),
                 'LIBDEST': self.prefix.lib.join('python{}').format(version),
                 'LIBDIR': self.prefix.lib,
@@ -767,8 +767,8 @@ for plat_specific in [True, False]:
                     'config-{0}-{1}').format(version, sys.platform),
                 'LDLIBRARY': 'libpython{}.{}'.format(version, dso_suffix),
                 'LIBRARY': 'libpython{}.a'.format(version),
-                'LDSHARED': self.compiler.cc
-                'LDCXXSHARED': self.compiler.cxx
+                'LDSHARED': self.compiler.cc,
+                'LDCXXSHARED': self.compiler.cxx,
                 'PYTHONFRAMEWORKPREFIX': '/System/Library/Frameworks',
                 'prefix': self.prefix,
                 'config_h_filename': self.prefix.include.join('python{}').join(

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -761,7 +761,7 @@ for plat_specific in [True, False]:
             try:
                 cc = self.compiler.cc
                 cxx = self.compiler.cxx
-            except (TypeError, NoCompilerForSpecError):
+            except TypeError:
                 cc = 'cc'
                 cxx = 'c++'
 
@@ -961,7 +961,7 @@ for plat_specific in [True, False]:
         Returns:
             str: site-packages directory
         """
-        return self.config_vars['python_lib']['true']['false']
+        return self.config_vars['python_lib']['false']['false']
 
     @property
     def easy_install_file(self):

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -15,6 +15,7 @@ from llnl.util.lang import match_predicate
 
 from spack import *
 from spack.build_environment import dso_suffix
+from spack.compilers import NoCompilerForSpecError
 from spack.util.environment import is_system_path
 from spack.util.prefix import Prefix
 
@@ -761,7 +762,7 @@ for plat_specific in [True, False]:
             try:
                 cc = self.compiler.cc
                 cxx = self.compiler.cxx
-            except TypeError:
+            except (TypeError, NoCompilerForSpecError):
                 cc = 'cc'
                 cxx = 'c++'
 

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -837,9 +837,8 @@ for plat_specific in [True, False]:
         and symlinks it to ``/usr/local``. Users may not know the actual
         installation directory and add ``/usr/local`` to their
         ``packages.yaml`` unknowingly. Query the python executable to
-        determine exactly where it is installed. Fall back on
-        ``spec['python'].prefix`` if that doesn't work."""
-
+        determine exactly where it is installed.
+        """
         return Prefix(self.config_vars['prefix'])
 
     @property

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import re
+import sys
 
 import llnl.util.tty as tty
 from llnl.util.filesystem import get_filetype, path_contains_subdirectory
@@ -752,11 +753,54 @@ for plat_specific in [True, False]:
 """ % self.print_string("json.dumps(config)")
 
         dag_hash = self.spec.dag_hash()
+
         if dag_hash not in self._config_vars:
+            # Default config vars
+            version = self.version.up_to(2)
+            config = {
+                'CC': self.compiler.cc
+                'CXX': self.compiler.cxx
+                'INCLUDEPY': self.prefix.include.join('python{}').format(version),
+                'LIBDEST': self.prefix.lib.join('python{}').format(version),
+                'LIBDIR': self.prefix.lib,
+                'LIBPL': self.prefix.lib.join('python{0}').join(
+                    'config-{0}-{1}').format(version, sys.platform),
+                'LDLIBRARY': 'libpython{}.{}'.format(version, dso_suffix),
+                'LIBRARY': 'libpython{}.a'.format(version),
+                'LDSHARED': self.compiler.cc
+                'LDCXXSHARED': self.compiler.cxx
+                'PYTHONFRAMEWORKPREFIX': '/System/Library/Frameworks',
+                'prefix': self.prefix,
+                'config_h_filename': self.prefix.include.join('python{}').join(
+                    'pyconfig.h').format(version),
+                'makefile_filename': self.prefix.lib.join('python{0}').join(
+                    'config-{0}-{1}').Makefile.format(version, sys.platform),
+                'python_inc': {
+                    # plat_specific
+                    'true': os.path.join('include64', 'python{}'.format(version)),
+                    'false': os.path.join('include', 'python{}'.format(version)),
+                },
+                'python_lib': {
+                    # plat_specific
+                    'true': {
+                        # standard_lib
+                        'true': os.path.join('lib64', 'python{}'.format(version)),
+                        'false': os.path.join(
+                            'lib64', 'python{}'.format(version), 'site-packages'),
+                    },
+                    'false': {
+                        # standard_lib
+                        'true': os.path.join('lib', 'python{}'.format(version)),
+                        'false': os.path.join(
+                            'lib', 'python{}'.format(version), 'site-packages'),
+                    },
+                },
+            }
+
             try:
-                config = json.loads(self.command('-c', cmd, output=str))
+                config.update(json.loads(self.command('-c', cmd, output=str)))
             except (ProcessError, RuntimeError):
-                config = {}
+                pass
             self._config_vars[dag_hash] = config
         return self._config_vars[dag_hash]
 
@@ -787,11 +831,7 @@ for plat_specific in [True, False]:
         determine exactly where it is installed. Fall back on
         ``spec['python'].prefix`` if that doesn't work."""
 
-        if 'prefix' in self.config_vars:
-            prefix = self.config_vars['prefix']
-        else:
-            prefix = self.prefix
-        return Prefix(prefix)
+        return Prefix(self.config_vars['prefix'])
 
     @property
     def libs(self):
@@ -846,14 +886,9 @@ for plat_specific in [True, False]:
 
     @property
     def headers(self):
-        if 'config_h_filename' in self.config_vars:
-            config_h = self.config_vars['config_h_filename']
+        config_h = self.config_vars['config_h_filename']
 
-            if not os.path.exists(config_h):
-                includepy = self.config_vars['INCLUDEPY']
-                msg = 'Unable to locate {0} headers in {1}'
-                raise RuntimeError(msg.format(self.name, includepy))
-
+        if os.path.exists(config_h):
             headers = HeaderList(config_h)
         else:
             headers = find_headers(
@@ -876,10 +911,7 @@ for plat_specific in [True, False]:
         Returns:
             str: include files directory
         """
-        try:
-            return self.config_vars['python_inc']['false']
-        except KeyError:
-            return os.path.join('include', 'python{0}'.format(self.version.up_to(2)))
+        return self.config_vars['python_inc']['false']
 
     @property
     def python_lib_dir(self):
@@ -900,10 +932,7 @@ for plat_specific in [True, False]:
         Returns:
             str: standard library directory
         """
-        try:
-            return self.config_vars['python_lib']['false']['true']
-        except KeyError:
-            return os.path.join('lib', 'python{0}'.format(self.version.up_to(2)))
+        return self.config_vars['python_lib']['false']['true']
 
     @property
     def site_packages_dir(self):
@@ -924,15 +953,7 @@ for plat_specific in [True, False]:
         Returns:
             str: site-packages directory
         """
-        try:
-            return self.config_vars['python_lib']['true']['false']
-        except KeyError:
-            return self.default_site_packages_dir
-
-    @property
-    def default_site_packages_dir(self):
-        python_dir = 'python{0}'.format(self.version.up_to(2))
-        return os.path.join('lib', python_dir, 'site-packages')
+        return self.config_vars['python_lib']['true']['false']
 
     @property
     def easy_install_file(self):


### PR DESCRIPTION
We need to extract a lot of information from Python's build system in order to support Python packages. This information is drastically different based on Python version, OS, architecture, and how Python was built (apt, yum, conda, spack, etc.). Python may have shared libraries, static libraries, framework libraries, or no libraries. To get this information, we query `distutils.sysconfig`. However, if we are cross-compiling Python, it may not run at all, and even if not, not all these keys are always set. 

This PR adds default values to `config_vars` in case any or all of these keys are missing. This means that we can always assume these keys exist, although they may not always be correct. An alternative would be to continue to add try-except statements around all access points, but I think this is a better solution.

Fixes #28274 @benpm