### PR TITLE
findutils: Ensure __nonnull is defined

### DIFF
--- a/var/spack/repos/builtin/packages/findutils/nonnull.patch
+++ b/var/spack/repos/builtin/packages/findutils/nonnull.patch
@@ -1,0 +1,11 @@
+--- a/gl/lib/malloc/dynarray-skeleton.c
++++ b/gl/lib/malloc/dynarray-skeleton.c
+@@ -85,6 +85,8 @@
+        (if DYNARRAY_FINAL_TYPE is not defined)
+ */
+ 
+ #include <malloc/dynarray.h>
++#undef __nonnull
++#define __nonnull(x)
+ 
+ #include <errno.h>

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -51,6 +51,10 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
     patch('nvhpc.patch', when='@4.6.0 %nvhpc')
     # Workaround bug where __LONG_WIDTH__ is not defined
     patch('nvhpc-long-width.patch', when='@4.8.0:4.8 %nvhpc')
+    # Auto-detecting whether `__attribute__((__nonnull__(...)))` is supported
+    # does not work for GCC on macOS
+    # <https://savannah.gnu.org/bugs/?func=detailitem&item_id=59972>; we thus
+    # disable this attribute manually
     patch('nonnull.patch')
 
     build_directory = 'spack-build'

--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -51,6 +51,7 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
     patch('nvhpc.patch', when='@4.6.0 %nvhpc')
     # Workaround bug where __LONG_WIDTH__ is not defined
     patch('nvhpc-long-width.patch', when='@4.8.0:4.8 %nvhpc')
+    patch('nonnull.patch')
 
     build_directory = 'spack-build'
 


### PR DESCRIPTION
This cures a build error with gcc on macOS.