### PR TITLE
Stage: preserve symlinks on recursive copy

### DIFF
--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -543,7 +543,7 @@ class Stage(object):
         for entry in hidden_entries + entries:
             if os.path.isdir(entry):
                 d = os.path.join(dest, os.path.basename(entry))
-                shutil.copytree(entry, d)
+                shutil.copytree(entry, d, symlinks=True)
             else:
                 shutil.copy2(entry, dest)
 


### PR DESCRIPTION
@becker33

`Stage.steal_source` uses `shutil.copytree`, which by default fails if the source directory contains any dangling symlinks. This avoids the issue by preserving symlinks rather than resolving them. 

The `ignore_dangling_symlinks` (documented in https://docs.python.org/3/library/shutil.html) option would be more-targeted but is only available for Python >= 3.2

