### PR TITLE
VTK-m: Add testing variant.

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -55,6 +55,7 @@ class VtkM(CMakePackage, CudaPackage):
     variant("rendering", default=True, description="build rendering support")
     variant("64bitids", default=False,
             description="enable 64 bits ids")
+    variant("testlib", default=False, description="build test library")
 
     # Device variants
     variant("cuda", default=False, description="build cuda support")
@@ -160,6 +161,10 @@ class VtkM(CMakePackage, CudaPackage):
                 print("64 bit ids enabled")
             else:
                 options.append("-DVTKm_USE_64BIT_IDS:BOOL=OFF")
+
+            # Support for the testing header files
+            if "+testlib" in spec and spec.satisfies('@1.7.0:'):
+                options.append("-DVTKm_ENABLE_TESTING_LIBRARY:BOOL=ON")
 
             if spec.variants["build_type"].value != 'Release':
                 options.append("-DVTKm_NO_ASSERT:BOOL=ON")


### PR DESCRIPTION
I added a `testing` variant to the VTK-m package. If enabled it sets `VTKm_ENABLE_TESTING_LIBRARY:BOOL=ON` otherwise it sets it to `OFF`.

I tested `spack install vtk-m` and it didn't install any testing files and then I tested `spack install vtk-m+testing` and it installed the testing header files as shown below.
```
find . -print | grep testing
./vtkm/testing
./vtkm/testing/Testing.h
./vtkm/testing/VecTraitsTests.h
./vtkm/cont/testing
./vtkm/cont/testing/vtkm_cont_testing_export.h
./vtkm/cont/testing/ExplicitTestData.h
./vtkm/cont/testing/MakeTestDataSet.h
./vtkm/cont/testing/Testing.h
./vtkm/cont/testing/TestingArrayHandles.h
./vtkm/cont/testing/TestingArrayHandleMultiplexer.h
./vtkm/cont/testing/TestingCellLocatorRectilinearGrid.h
./vtkm/cont/testing/TestingCellLocatorTwoLevel.h
./vtkm/cont/testing/TestingCellLocatorUniformGrid.h
./vtkm/cont/testing/TestingColorTable.h
./vtkm/cont/testing/TestingComputeRange.h
./vtkm/cont/testing/TestingDeviceAdapter.h
./vtkm/cont/testing/TestingDataSetExplicit.h
./vtkm/cont/testing/TestingDataSetSingleType.h
./vtkm/cont/testing/TestingFancyArrayHandles.h
./vtkm/cont/testing/TestingImplicitFunction.h
./vtkm/cont/testing/TestingPointLocatorSparseGrid.h
./vtkm/cont/testing/TestingRuntimeDeviceConfiguration.h
./vtkm/cont/testing/TestingSerialization.h
./vtkm/cont/testing/TestingVirtualObjectHandle.h
```