### PR TITLE
py-async-timeout: fix checksum issue

### DIFF
--- a/var/spack/repos/builtin/packages/py-async-timeout/package.py
+++ b/var/spack/repos/builtin/packages/py-async-timeout/package.py
@@ -8,12 +8,12 @@ class PyAsyncTimeout(PythonPackage):
     """asyncio-compatible timeout context manager."""
 
     homepage = "https://github.com/aio-libs/async-timeout"
-    url      = "https://github.com/aio-libs/async-timeout/archive/v3.0.1.tar.gz"
+    pypi = "async-timeout/async-timeout-3.0.1.tar.gz"
 
     version('4.0.2', sha256='2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15')
     version('4.0.1', sha256='b930cb161a39042f9222f6efb7301399c87eeab394727ec5437924a36d6eef51')
-    version('4.0.0', sha256='2116e8c7412929579e1d4e1b3c5fdfe3835c2002a0189451d183148239c05a17')
-    version('3.0.1', sha256='d0a7a927ed6b922835e1b014dfcaa9982caccbb25131320582cc660af7c93949')
+    version('4.0.0', sha256='7d87a4e8adba8ededb52e579ce6bc8276985888913620c935094c2276fd83382')
+    version('3.0.1', sha256='0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f')
 
     depends_on('py-setuptools@45:', type='build')
     depends_on('python@3.5.3:', type=('build', 'run'), when='@3.0.1:')


### PR DESCRIPTION
Fixes a bug introduced in #28195. The new versions that were added used the checksums from the PyPI tarballs, not the GitHub tarballs. We might as well start using PyPI tarballs for this package instead.

@mdorier 