### PR TITLE
libtheora: disable docs by default

### DIFF
--- a/var/spack/repos/builtin/packages/libtheora/package.py
+++ b/var/spack/repos/builtin/packages/libtheora/package.py
@@ -15,11 +15,13 @@ class Libtheora(AutotoolsPackage):
     version('1.1.1',       sha256='f36da409947aa2b3dcc6af0a8c2e3144bc19db2ed547d64e9171c59c66561c61')
     version('1.1.0',       sha256='3d7b4fb1c115f1a530afd430eed2e8861fa57c8b179ec2d5a5d8f1cd0c7a4268')
 
+    variant('doc', default=False, description="Build documentation")
+
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
-    depends_on('doxygen',  type='build')
+    depends_on('doxygen', when='+doc', type='build')
     depends_on('libogg')
     depends_on('libpng')
 
@@ -35,3 +37,8 @@ class Libtheora(AutotoolsPackage):
                '--build=arm-linux')
         else:
             sh('./autogen.sh', 'prefix={0}'.format(prefix))
+
+    def configure_args(self):
+        args = []
+        args += self.enable_or_disable('doc')
+        return args


### PR DESCRIPTION
Avoids the expensive Doxygen dependency by default.