### PR TITLE
curl: find external

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
 import sys
 
 from spack import *
@@ -15,6 +16,8 @@ class Curl(AutotoolsPackage):
     homepage = "https://curl.se/"
     # URL must remain http:// so Spack can bootstrap curl
     url      = "http://curl.haxx.se/download/curl-7.78.0.tar.bz2"
+
+    executables = ['^curl$']
 
     version('7.80.0', sha256='dd0d150e49cd950aff35e16b628edf04927f0289df42883750cf952bb858189c')
     version('7.79.1', sha256='de62c4ab9a9316393962e8b94777a570bb9f71feb580fb4475e412f2f9387851')
@@ -102,6 +105,35 @@ class Curl(AutotoolsPackage):
 
     # curl queries pkgconfig for openssl compilation flags
     depends_on('pkgconfig', type='build')
+
+    @classmethod
+    def determine_version(cls, exe):
+        curl = Executable(exe)
+        output = curl('--version', output=str, error=str)
+        match = re.match(r'curl ([\d.]+)', output)
+        return match.group(1) if match else None
+
+    @classmethod
+    def determine_variants(cls, exes, version):
+        for exe in exes:
+            variants = ''
+            curl = Executable(exe)
+            output = curl('--version', output=str, error='str')
+            if 'nghttp2' in output:
+                variants += '+nghttp2'
+            protocols_match = re.search(r'Protocols: (.*)\n', output)
+            if protocols_match:
+                protocols = protocols_match.group(1).strip().split(' ')
+                if 'ldap' in protocols:
+                    variants += '+ldap'
+            features_match = re.search(r'Features: (.*)\n', output)
+            if features_match:
+                features = features_match.group(1).strip().split(' ')
+                if 'GSS-API' in features:
+                    variants += '+gssapi'
+            # TODO: Determine TLS backend if needed.
+            # TODO: Determine more variants.
+            return variants
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
I noticed that `curl` is not found on the system. Here's a basic implementation, unless there was a reason for avoiding the system-installed version?