### PR TITLE
libogg: patch stdint include, add v1.3.5

### DIFF
--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -13,5 +13,12 @@ class Libogg(AutotoolsPackage):
     homepage = "https://www.xiph.org/ogg/"
     url      = "http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz"
 
+    version('1.3.5', sha256='0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664')
     version('1.3.4', sha256='fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e')
     version('1.3.2', sha256='e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692')
+
+    # Backport a patch that fixes an unsigned typedef problem on macOS:
+    # https://github.com/xiph/ogg/pull/64
+    patch('https://github.com/xiph/ogg/commit/c8fca6b4a02d695b1ceea39b330d4406001c03ed.patch',
+          sha256='c66dcf5dd775752148e664b262f98ea9fda7ed204ed40d64e3769c036e3c2c98',
+          when='@1.3.4 platform=darwin')


### PR DESCRIPTION
Installing `libtheora` failed on macOS 12.0.1 before this patch, at least with AppleClang 13 and with GCC 11.2.

If anyone knows details about when `<sys/types.h>` and `<stdint.h>` are available, please speak up :)

Edit: This is fixed upstream by https://github.com/xiph/ogg/pull/64