### PR TITLE
bootstrap: fix bootstrapping GnuPG from different macOS versions

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -575,7 +575,9 @@ def ensure_executables_in_path_or_raise(executables, abstract_spec):
                         root=True, order='post', deptype=('link', 'run')
                 ):
                     env_mods.extend(
-                        spack.user_environment.environment_modifications_for_spec(dep)
+                        spack.user_environment.environment_modifications_for_spec(
+                            dep, set_package_py_globals=False
+                        )
                     )
                 cmd.add_default_envmod(env_mods)
                 return cmd

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -856,7 +856,9 @@ def _make_runnable(pkg, env):
             env.prepend_path('PATH', bin_dir)
 
 
-def modifications_from_dependencies(spec, context, custom_mods_only=True):
+def modifications_from_dependencies(
+        spec, context, custom_mods_only=True, set_package_py_globals=True
+):
     """Returns the environment modifications that are required by
     the dependencies of a spec and also applies modifications
     to this spec's package at module scope, if need be.
@@ -889,6 +891,11 @@ def modifications_from_dependencies(spec, context, custom_mods_only=True):
         spec (spack.spec.Spec): spec for which we want the modifications
         context (str): either 'build' for build-time modifications or 'run'
             for run-time modifications
+        custom_mods_only (bool): if True returns only custom modifications, if False
+            returns custom and default modifications
+        set_package_py_globals (bool): whether or not to set the global variables in the
+            package.py files (this may be problematic when using buildcaches that have
+            been built on a different but compatible OS)
     """
     if context not in ['build', 'run', 'test']:
         raise ValueError(
@@ -962,7 +969,8 @@ def modifications_from_dependencies(spec, context, custom_mods_only=True):
         # PKG_CONFIG_PATH)
         if dep in custom_mod_deps:
             dpkg = dep.package
-            set_module_variables_for_package(dpkg)
+            if set_package_py_globals:
+                set_module_variables_for_package(dpkg)
             # Allow dependencies to modify the module
             dpkg.setup_dependent_package(spec.package.module, spec)
             if context == 'build':

--- a/lib/spack/spack/user_environment.py
+++ b/lib/spack/spack/user_environment.py
@@ -65,11 +65,19 @@ def unconditional_environment_modifications(view):
     return env
 
 
-def environment_modifications_for_spec(spec, view=None):
+def environment_modifications_for_spec(spec, view=None, set_package_py_globals=True):
     """List of environment (shell) modifications to be processed for spec.
 
     This list is specific to the location of the spec or its projection in
-    the view."""
+    the view.
+
+    Args:
+        spec (spack.spec.Spec): spec for which to list the environment modifications
+        view: view associated with the spec passed as first argument
+        set_package_py_globals (bool): whether or not to set the global variables in the
+            package.py files (this may be problematic when using buildcaches that have
+            been built on a different but compatible OS)
+    """
     spec = spec.copy()
     if view and not spec.external:
         spec.prefix = prefix.Prefix(view.get_projection_for_spec(spec))
@@ -86,12 +94,13 @@ def environment_modifications_for_spec(spec, view=None):
     # before asking for package-specific modifications
     env.extend(
         spack.build_environment.modifications_from_dependencies(
-            spec, context='run'
+            spec, context='run', set_package_py_globals=set_package_py_globals
         )
     )
 
-    # Package specific modifications
-    spack.build_environment.set_module_variables_for_package(spec.package)
+    if set_package_py_globals:
+        spack.build_environment.set_module_variables_for_package(spec.package)
+
     spec.package.setup_run_environment(env)
 
     return env


### PR DESCRIPTION
Due to changes in #27485, which introduced setting custom environment modifications for spec executables that are bootstrapped, using GnuPG on macOS versions which are different from the one in which it was built in CI stopped working.

The cause of the issue is that, to set variables at the `package.py` module level we need a compiler entry compatible with the OS used to build GnuPG (in this case `Catalina`). When run e.g. on a more recent OS, like `Monterey` we have this error:
```console
% spack gpg list
==> Bootstrapping gnupg from pre-built binaries
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/libgpg-error-1.42/darwin-catalina-x86_64-apple-clang-12.0.0-libgpg-error-1.42-hph66gvb7vlinpzwoytxq27ojb7gtl2j.spack
==> Installing "libgpg-error@1.42%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13"  arch=darwin-catalina-x86_64" from a buildcache
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/libiconv-1.16/darwin-catalina-x86_64-apple-clang-12.0.0-libiconv-1.16-ckpif6rcf7mxdmceyv6sqvtnwfqi7fmc.spack
==> Installing "libiconv@1.16%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13"  arch=darwin-catalina-x86_64" from a buildcache
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/npth-1.6/darwin-catalina-x86_64-apple-clang-12.0.0-npth-1.6-fjuoy73whriauk3bt6ma5fwet6iric7y.spack
==> Installing "npth@1.6%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13"  arch=darwin-catalina-x86_64" from a buildcache
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/zlib-1.2.11/darwin-catalina-x86_64-apple-clang-12.0.0-zlib-1.2.11-qo6otxqnn6mxpw4zhqc4wdwqmgcfjdfe.spack
==> Installing "zlib@1.2.11%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13" +optimize+pic+shared arch=darwin-catalina-x86_64" from a buildcache
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/libassuan-2.5.5/darwin-catalina-x86_64-apple-clang-12.0.0-libassuan-2.5.5-2upi74qccouj4k6d7wultp2u5fntayi3.spack
==> Installing "libassuan@2.5.5%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13"  arch=darwin-catalina-x86_64" from a buildcache
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/libgcrypt-1.9.3/darwin-catalina-x86_64-apple-clang-12.0.0-libgcrypt-1.9.3-xzhvvm44cfxwvgqgkpbeucpnl4dbj4p2.spack
==> Installing "libgcrypt@1.9.3%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13"  arch=darwin-catalina-x86_64" from a buildcache
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/libksba-1.5.1/darwin-catalina-x86_64-apple-clang-12.0.0-libksba-1.5.1-aodyg5mzfule3vimuetmzulv5mzdx37g.spack
==> Installing "libksba@1.5.1%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13"  arch=darwin-catalina-x86_64" from a buildcache
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/pinentry-1.1.1/darwin-catalina-x86_64-apple-clang-12.0.0-pinentry-1.1.1-ihqcvdm5okxuvnln463l7h4flbkhrp44.spack
==> Installing "pinentry@1.1.1%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13"  gui=tty arch=darwin-catalina-x86_64" from a buildcache
==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/gnupg-2.3.1/darwin-catalina-x86_64-apple-clang-12.0.0-gnupg-2.3.1-47vilwybwuxved7jov7esiad3qlkv5rp.spack
==> Installing "gnupg@2.3.1%apple-clang@12.0.0 cflags="-mmacosx-version-min=10.13"  arch=darwin-catalina-x86_64" from a buildcache
==> Error: cannot bootstrap any of the gpg2, gpg executables from spec "gnupg@2.3: %apple-clang target=x86_64"
```
This PR fixes the issue by explicitly avoid setting variables at the `package.py` level during bootstrapping. With this modification the GnuPG executable built on `Catalina` works on any version of the OS > 10.13, including later versions:
```
% spack gpg list
...
/Users/culpo/PycharmProjects/spack/opt/spack/gpg/pubring.kbx
------------------------------------------------------------
pub   rsa4096 2021-10-26 [SC]
...
% spack arch
darwin-monterey-cannonlake
```