### PR TITLE
Use depends_on over load in lmod

### DIFF
--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -96,13 +96,7 @@ class TestLmod(object):
         module_configuration('autoload_direct')
         content = modulefile_content(mpileaks_spec_string)
 
-        assert len([x for x in content if 'if not isloaded(' in x]) == 2
-        assert len([x for x in content if 'load(' in x]) == 2
-
-        # The configuration file doesn't set the verbose keyword
-        # that defaults to False
-        messages = [x for x in content if 'LmodMessage("Autoloading' in x]
-        assert len(messages) == 0
+        assert len([x for x in content if 'depends_on(' in x]) == 2
 
     def test_autoload_all(self, modulefile_content, module_configuration):
         """Tests the automatic loading of all dependencies."""
@@ -110,12 +104,7 @@ class TestLmod(object):
         module_configuration('autoload_all')
         content = modulefile_content(mpileaks_spec_string)
 
-        assert len([x for x in content if 'if not isloaded(' in x]) == 5
-        assert len([x for x in content if 'load(' in x]) == 5
-
-        # The configuration file sets the verbose keyword to True
-        messages = [x for x in content if 'LmodMessage("Autoloading' in x]
-        assert len(messages) == 5
+        assert len([x for x in content if 'depends_on(' in x]) == 5
 
     def test_alter_environment(self, modulefile_content, module_configuration):
         """Tests modifications to run-time environment."""
@@ -158,8 +147,7 @@ class TestLmod(object):
         module_configuration('blacklist')
         content = modulefile_content(mpileaks_spec_string)
 
-        assert len([x for x in content if 'if not isloaded(' in x]) == 1
-        assert len([x for x in content if 'load(' in x]) == 1
+        assert len([x for x in content if 'depends_on(' in x]) == 1
 
     def test_no_hash(self, factory, module_configuration):
         """Makes sure that virtual providers (in the hierarchy) always

--- a/share/spack/templates/modules/modulefile.lua
+++ b/share/spack/templates/modules/modulefile.lua
@@ -62,12 +62,7 @@ setenv("LMOD_{{ name|upper() }}_VERSION", "{{ version_part }}")
 
 {% block autoloads %}
 {% for module in autoload %}
-if not isloaded("{{ module }}") then
-{% if verbose %}
-    LmodMessage("Autoloading {{ module }}")
-{% endif %}
-    load("{{ module }}")
-end
+depends_on("{{ module }}")
 {% endfor %}
 {% endblock %}
 


### PR DESCRIPTION
With this PR, lmod files use `depends_on`, which replaces the custom `load(...)` logic, and allows lmod to do reference counting and such.

```
-- -*- lua -*-
-- Module file created by spack (https://github.com/spack/spack) on 2022-01-11 14:03:46.430132
--
-- zstd@1.5.0%gcc@10.3.0+programs arch=linux-ubuntu20.04-zen2/tlmj57a
--

whatis([[Name : zstd]])
whatis([[Version : 1.5.0]])
whatis([[Target : zen2]])
whatis([[Short description : Zstandard, or zstd as short version, is a fast lossless compression algorithm, targeting real-time compression scenarios at zlib-level and better compression ratios.]])

help([[Zstandard, or zstd as short version, is a fast lossless compression
algorithm, targeting real-time compression scenarios at zlib-level and
better compression ratios.]])


depends_on("lz4/1.9.3-pzu3c7r")
depends_on("lzma/4.32.7-7bq33x6")
depends_on("zlib/1.2.11-f55qopc")

prepend_path("LD_LIBRARY_PATH", "/tmp/tmp.V86PETebaK/store/linux-ubuntu20.04-zen2/gcc-10.3.0/zstd-1.5.0-tlmj57aayg3yw7gi6gy7grb3wwvpwcb2/lib", ":")
prepend_path("PATH", "/tmp/tmp.V86PETebaK/store/linux-ubuntu20.04-zen2/gcc-10.3.0/zstd-1.5.0-tlmj57aayg3yw7gi6gy7grb3wwvpwcb2/bin", ":")
prepend_path("MANPATH", "/tmp/tmp.V86PETebaK/store/linux-ubuntu20.04-zen2/gcc-10.3.0/zstd-1.5.0-tlmj57aayg3yw7gi6gy7grb3wwvpwcb2/share/man", ":")
prepend_path("PKG_CONFIG_PATH", "/tmp/tmp.V86PETebaK/store/linux-ubuntu20.04-zen2/gcc-10.3.0/zstd-1.5.0-tlmj57aayg3yw7gi6gy7grb3wwvpwcb2/lib/pkgconfig", ":")
prepend_path("CMAKE_PREFIX_PATH", "/tmp/tmp.V86PETebaK/store/linux-ubuntu20.04-zen2/gcc-10.3.0/zstd-1.5.0-tlmj57aayg3yw7gi6gy7grb3wwvpwcb2/", ":")
```

Notice that the order in paths are modified depends on the order of traversal, and it seems lmod traverses immediately when it sees `depends_on`. That is, with the above we do indeed post-order iteration of the dag as expected.
