### PR TITLE
Switch lmod default all:autoload from none to direct

### DIFF
--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -46,7 +46,13 @@ modules:
     enable:
       - tcl
 
+    tcl:
+      all:
+        autoload: direct
+
     # Default configurations if lmod is enabled
     lmod:
+      all:
+        autoload: direct
       hierarchy:
         - mpi

--- a/etc/spack/defaults/modules.yaml
+++ b/etc/spack/defaults/modules.yaml
@@ -48,7 +48,7 @@ modules:
 
     tcl:
       all:
-        autoload: direct
+        autoload: none
 
     # Default configurations if lmod is enabled
     lmod:

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -621,20 +621,12 @@ by its dependency; when the dependency is autoloaded, the executable will be in 
 PATH. Similarly for scripting languages such as Python, packages and their dependencies
 have to be loaded together.
 
-As of Spack 0.18.0, autoloading is enabled in the default configuration:
+Autoloading is enabled by default for LMod, as it has great builtin support for through
+the ``depends_on`` function. For Environment Modules it is disabled by default.
+
+Autoloading can also be enabled conditionally:
 
 .. code-block:: yaml
-
-    modules:
-      default:
-        tcl:
-          all:
-            autoload: direct
-        lmod:
-          all:
-            autoload: direct
-
-For more fine-grained control, autoloading can be disabled or enabled conditionally:
 
     modules:
       default:
@@ -647,24 +639,15 @@ For more fine-grained control, autoloading can be disabled or enabled conditiona
 The configuration file above will produce module files that will
 load their direct dependencies if the package installed depends on ``python``.
 The allowed values for the ``autoload`` statement are either ``none``,
-``direct`` or ``all``.  The default is ``none``.
-
-.. tip::
-  Building external software
-     Setting ``autoload`` to ``direct`` for all packages can be useful
-     when building software outside of a Spack installation that depends on
-     artifacts in that installation.  E.g. (adjust ``lmod`` vs ``tcl``
-     as appropriate):
-
-  .. code-block:: yaml
-
+``direct`` or ``all``.
 
 .. note::
   TCL prerequisites
      In the ``tcl`` section of the configuration file it is possible to use
      the ``prerequisites`` directive that accepts the same values as
      ``autoload``. It will produce module files that have a ``prereq``
-     statement instead of automatically loading other modules.
+     statement, which can be used to autoload dependencies in some versions
+     of Environment Modules.
 
 ------------------------
 Maintaining Module Files

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -615,17 +615,34 @@ modifications to either ``CPATH`` or ``LIBRARY_PATH``.
 Autoload dependencies
 """""""""""""""""""""
 
-In some cases it can be useful to have module files that automatically load
-their dependencies.  This may be the case for Python extensions, if not
-activated using ``spack activate``:
+Often it is required for a module to have its (transient) dependencies loaded as well.
+One example where this is useful is when one package needs to use executables provided
+by its dependency; when the dependency is autoloaded, the executable will be in the
+PATH. Similarly for scripting languages such as Python, packages and their dependencies
+have to be loaded together.
+
+As of Spack 0.18.0, autoloading is enabled in the default configuration:
 
 .. code-block:: yaml
 
-   modules:
-     default:
-       tcl:
-         ^python:
-           autoload: 'direct'
+    modules:
+      default:
+        tcl:
+          all:
+            autoload: direct
+        lmod:
+          all:
+            autoload: direct
+
+For more fine-grained control, autoloading can be disabled or enabled conditionally:
+
+    modules:
+      default:
+        tcl:
+          all:
+            autoload: none
+          ^python:
+            autoload: direct
 
 The configuration file above will produce module files that will
 load their direct dependencies if the package installed depends on ``python``.
@@ -641,11 +658,6 @@ The allowed values for the ``autoload`` statement are either ``none``,
 
   .. code-block:: yaml
 
-     modules:
-       default:
-         lmod:
-           all:
-             autoload: 'direct'
 
 .. note::
   TCL prerequisites

--- a/lib/spack/spack/modules/common.py
+++ b/lib/spack/spack/modules/common.py
@@ -191,7 +191,7 @@ def merge_config_rules(configuration, spec):
     # Transform keywords for dependencies or prerequisites into a list of spec
 
     # Which modulefiles we want to autoload
-    autoload_strategy = spec_configuration.get('autoload', 'none')
+    autoload_strategy = spec_configuration.get('autoload', 'direct')
     spec_configuration['autoload'] = dependencies(spec, autoload_strategy)
 
     # Which instead we want to mark as prerequisites

--- a/lib/spack/spack/test/data/modules/lmod/alter_environment.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/alter_environment.yaml
@@ -8,6 +8,7 @@ lmod:
     - mpi
 
   all:
+    autoload: none
     filter:
       environment_blacklist:
         - CMAKE_PREFIX_PATH

--- a/lib/spack/spack/test/data/modules/lmod/autoload_all.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/autoload_all.yaml
@@ -8,4 +8,4 @@ lmod:
   verbose: true
 
   all:
-    autoload: 'all'
+    autoload: all

--- a/lib/spack/spack/test/data/modules/lmod/autoload_direct.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/autoload_direct.yaml
@@ -7,4 +7,4 @@ lmod:
     - mpi
 
   all:
-    autoload: 'direct'
+    autoload: direct

--- a/lib/spack/spack/test/data/modules/lmod/blacklist.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/blacklist.yaml
@@ -9,4 +9,4 @@ lmod:
     - callpath
 
   all:
-    autoload: 'direct'
+    autoload: direct

--- a/lib/spack/spack/test/data/modules/lmod/complex_hierarchy.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/complex_hierarchy.yaml
@@ -17,4 +17,4 @@ lmod:
   verbose: false
 
   all:
-    autoload: 'all'
+    autoload: all

--- a/lib/spack/spack/test/data/modules/lmod/core_compilers_empty.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/core_compilers_empty.yaml
@@ -1,6 +1,8 @@
 enable:
   - lmod
 lmod:
+  all:
+    autoload: none
   core_compilers: []
   hierarchy:
     - mpi

--- a/lib/spack/spack/test/data/modules/lmod/missing_core_compilers.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/missing_core_compilers.yaml
@@ -1,5 +1,7 @@
 enable:
   - lmod
 lmod:
+  all:
+    autoload: none
   hierarchy:
     - mpi

--- a/lib/spack/spack/test/data/modules/lmod/module_path_separator.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/module_path_separator.yaml
@@ -1,5 +1,7 @@
 enable:
   - lmod
 lmod:
+  all:
+    autoload: none
   core_compilers:
     - 'clang@3.3'

--- a/lib/spack/spack/test/data/modules/lmod/no_arch.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/no_arch.yaml
@@ -2,5 +2,7 @@ enable:
   - lmod
 arch_folder: false
 lmod:
+  all:
+    autoload: none
   core_compilers:
     - 'clang@3.3'

--- a/lib/spack/spack/test/data/modules/lmod/no_hash.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/no_hash.yaml
@@ -1,6 +1,8 @@
 enable:
   - lmod
 lmod:
+  all:
+    autoload: none
   hash_length: 0
 
   core_compilers:

--- a/lib/spack/spack/test/data/modules/lmod/non_virtual_in_hierarchy.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/non_virtual_in_hierarchy.yaml
@@ -8,4 +8,4 @@ lmod:
     - openblas
 
   all:
-    autoload: 'direct'
+    autoload: direct

--- a/lib/spack/spack/test/data/modules/lmod/override_template.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/override_template.yaml
@@ -8,3 +8,4 @@ lmod:
 
   all:
     template: 'override_from_modules.txt'
+    autoload: none

--- a/lib/spack/spack/test/data/modules/lmod/projections.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/projections.yaml
@@ -1,6 +1,8 @@
 enable:
   - lmod
 lmod:
+  all:
+    autoload: none
   projections:
     all: '{name}/v{version}'
     mpileaks: '{name}-mpiprojection'

--- a/lib/spack/spack/test/data/modules/lmod/with_view.yaml
+++ b/lib/spack/spack/test/data/modules/lmod/with_view.yaml
@@ -2,5 +2,7 @@ enable:
   - lmod
 use_view: default
 lmod:
+  all:
+    autoload: none
   core_compilers:
     - 'clang@3.3'

--- a/lib/spack/spack/test/data/modules/tcl/alter_environment.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/alter_environment.yaml
@@ -2,6 +2,7 @@ enable:
   - tcl
 tcl:
   all:
+    autoload: none
     filter:
       environment_blacklist:
         - CMAKE_PREFIX_PATH

--- a/lib/spack/spack/test/data/modules/tcl/autoload_all.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/autoload_all.yaml
@@ -3,4 +3,4 @@ enable:
 tcl:
   verbose: true
   all:
-    autoload: 'all'
+    autoload: all

--- a/lib/spack/spack/test/data/modules/tcl/autoload_direct.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/autoload_direct.yaml
@@ -2,4 +2,4 @@ enable:
   - tcl
 tcl:
   all:
-    autoload: 'direct'
+    autoload: direct

--- a/lib/spack/spack/test/data/modules/tcl/autoload_with_constraints.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/autoload_with_constraints.yaml
@@ -1,8 +1,9 @@
 enable:
   - tcl
 tcl:
+  all:
+    autoload: none
   ^mpich2:
-    autoload: 'direct'
-
+    autoload: direct
   ^python:
-    autoload: 'direct'
+    autoload: direct

--- a/lib/spack/spack/test/data/modules/tcl/blacklist.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/blacklist.yaml
@@ -7,4 +7,4 @@ tcl:
     - callpath
     - mpi
   all:
-    autoload: 'direct'
+    autoload: direct

--- a/lib/spack/spack/test/data/modules/tcl/blacklist_implicits.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/blacklist_implicits.yaml
@@ -3,4 +3,4 @@ enable:
 tcl:
   blacklist_implicits: true
   all:
-    autoload: 'direct'
+    autoload: direct

--- a/lib/spack/spack/test/data/modules/tcl/conflicts.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/conflicts.yaml
@@ -4,6 +4,7 @@ tcl:
   projections:
     all: '{name}/{version}-{compiler.name}'
   all:
+    autoload: none
     conflict:
       - '{name}'
       - 'intel/14.0.1'

--- a/lib/spack/spack/test/data/modules/tcl/invalid_naming_scheme.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/invalid_naming_scheme.yaml
@@ -1,6 +1,8 @@
 enable:
   - tcl
 tcl:
+  all:
+    autoload: none
   # {variants} is not allowed in the naming scheme, see #2884
   projections:
     all: '{name}/{version}-{compiler.name}-{variants}'

--- a/lib/spack/spack/test/data/modules/tcl/invalid_token_in_env_var_name.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/invalid_token_in_env_var_name.yaml
@@ -2,6 +2,7 @@ enable:
   - tcl
 tcl:
   all:
+    autoload: none
     filter:
       environment_blacklist:
         - CMAKE_PREFIX_PATH

--- a/lib/spack/spack/test/data/modules/tcl/naming_scheme.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/naming_scheme.yaml
@@ -1,4 +1,6 @@
 enable:
   - tcl
 tcl:
+  all:
+    autoload: none
   naming_scheme: '{name}/{version}-{compiler.name}'

--- a/lib/spack/spack/test/data/modules/tcl/no_arch.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/no_arch.yaml
@@ -2,5 +2,7 @@ enable:
   - tcl
 arch_folder: false
 tcl:
+  all:
+    autoload: none
   projections:
     all: ''

--- a/lib/spack/spack/test/data/modules/tcl/override_config.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/override_config.yaml
@@ -2,6 +2,7 @@ enable:
   - tcl
 tcl:
   all:
+    autoload: none
     suffixes:
       '^mpich': mpich
   mpileaks:

--- a/lib/spack/spack/test/data/modules/tcl/override_template.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/override_template.yaml
@@ -2,4 +2,5 @@ enable:
   - tcl
 tcl:
   all:
+    autoload: none
     template: 'override_from_modules.txt'

--- a/lib/spack/spack/test/data/modules/tcl/prerequisites_all.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/prerequisites_all.yaml
@@ -2,4 +2,5 @@ enable:
   - tcl
 tcl:
   all:
-    prerequisites: 'all'
+    autoload: none
+    prerequisites: all

--- a/lib/spack/spack/test/data/modules/tcl/prerequisites_direct.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/prerequisites_direct.yaml
@@ -2,4 +2,5 @@ enable:
   - tcl
 tcl:
   all:
-    prerequisites: 'direct'
+    autoload: none
+    prerequisites: direct

--- a/lib/spack/spack/test/data/modules/tcl/projections.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/projections.yaml
@@ -1,6 +1,8 @@
 enable:
   - tcl
 tcl:
+  all:
+    autoload: none
   projections:
     all: '{name}/{version}-{compiler.name}'
     mpileaks: '{name}-mpiprojection'

--- a/lib/spack/spack/test/data/modules/tcl/suffix.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/suffix.yaml
@@ -1,6 +1,8 @@
 enable:
   - tcl
 tcl:
+  all:
+    autoload: none
   mpileaks:
     suffixes:
       '+opt': baz

--- a/lib/spack/spack/test/data/modules/tcl/wrong_conflicts.yaml
+++ b/lib/spack/spack/test/data/modules/tcl/wrong_conflicts.yaml
@@ -4,5 +4,6 @@ tcl:
   projections:
     all: '{name}/{version}-{compiler.name}'
   all:
+    autoload: none
     conflict:
       - '{name}/{compiler.name}'


### PR DESCRIPTION
To make the behavior of `spack env activate` / `spack load` and `module load`
of spack-generated modules more alike, I'm proposing to set `autoload: direct`
as a default from Spack 0.18.0.

People who like to do dependency management by hand can still do that by
overriding config to use `autoload: none`, so it's not terribly breaking.

This is mostly nice for people who use `lmod`, since `lmod` has reasonable
support for managing dependencies. For `tcl` we are stuck with our
if-not-loaded-load logic, but that's OK...

