### PR TITLE
Fix "build systems" Gitlab pipeline

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -13,7 +13,6 @@ spack:
     - default_specs:
       - lz4  # MakefilePackage
       - mpich~fortran  # AutotoolsPackage
-      - tut  # WafPackage
       - py-setuptools  # PythonPackage
       - openjpeg  # CMakePackage
       - r-rcpp  # RPackage


### PR DESCRIPTION
Modifications:
- [x] Remove tut since it requires deprecated Python 3.6