### PR TITLE
p7zip: fix build on gcc 11

### DIFF
--- a/var/spack/repos/builtin/packages/p7zip/gcc11.patch
+++ b/var/spack/repos/builtin/packages/p7zip/gcc11.patch
@@ -1,0 +1,22 @@
+diff --git a/CPP/7zip/Archive/Wim/WimHandler.cpp b/CPP/7zip/Archive/Wim/WimHandler.cpp
+index 27d3298..673d52e 100644
+--- a/CPP/7zip/Archive/Wim/WimHandler.cpp
++++ b/CPP/7zip/Archive/Wim/WimHandler.cpp
+@@ -305,7 +305,7 @@ STDMETHODIMP CHandler::GetArchiveProperty(PROPID propID, PROPVARIANT *value)
+         {
+           res.Add_Space_if_NotEmpty();
+           res += k_Methods[i];
+-          numMethods++;
++          numMethods = true;
+         }
+       }
+ 
+@@ -315,7 +315,7 @@ STDMETHODIMP CHandler::GetArchiveProperty(PROPID propID, PROPVARIANT *value)
+         ConvertUInt32ToString(methodUnknown, temp);
+         res.Add_Space_if_NotEmpty();
+         res += temp;
+-        numMethods++;
++        numMethods = true;
+       }
+ 
+       if (numMethods == 1 && chunkSizeBits != 0)

--- a/var/spack/repos/builtin/packages/p7zip/package.py
+++ b/var/spack/repos/builtin/packages/p7zip/package.py
@@ -14,6 +14,12 @@ class P7zip(MakefilePackage):
     version('16.02', sha256='5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f')
 
     patch('gcc10.patch', when='%gcc@10:', sha256='96914025b9f431fdd75ae69768162d57751413634622f9df1a4bc4960e7e8fe1')
+
+    # Replace boolean increments with assignments of true (which is
+    # semantically equivalent). Use of increment operators on booleans is
+    # forbidden by C++17, the default standard targeted by GCC 11.
+    patch('gcc11.patch', when='%gcc@11:', sha256='39dd15f2dfc86eeee8c3a13ffde65c2ca919433cfe97ea126fbdc016afc587d1')
+
     # all3 includes 7z, 7za, and 7zr
     build_targets = ['all3']
 


### PR DESCRIPTION
Fixes the following build failure when building with gcc 11:

         478    ../../../../CPP/7zip/Archive/Wim/WimHandler.cpp: In member function 'virtual LONG NArchive::NWim::CHandler::GetArchiveProperty(PROPID, PROPVARIANT*)':
      >> 479    ../../../../CPP/7zip/Archive/Wim/WimHandler.cpp:308:11: error: use of an operand of type 'bool' in 'operator++' is forbidden in C++17
         480      308 |           numMethods++;
         481          |           ^~~~~~~~~~
      >> 482    ../../../../CPP/7zip/Archive/Wim/WimHandler.cpp:318:9: error: use of an operand of type 'bool' in 'operator++' is forbidden in C++17
         483      318 |         numMethods++;
         484          |         ^~~~~~~~~~
