### PR TITLE
Fix issue when propagating cuda with other variant

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -119,15 +119,12 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
 
     depends_on('py-cinemasci', when='+cinema')
 
-    paraview_base_spec = 'paraview +mpi +python3 +kits'
+    dav_sdk_depends_on('paraview +mpi +python3 +kits',
+                       when='+paraview',
+                       propagate=['hdf5', 'adios2'] + cuda_arch_variants)
     # Want +shared when not using cuda
-    dav_sdk_depends_on(paraview_base_spec + '+shared ~cuda',
-                       when='+paraview ~cuda',
-                       propagate=['hdf5', 'adios2'])
-    # Can't have +shared when using cuda, propagate cuda_arch_variants
-    dav_sdk_depends_on(paraview_base_spec + '~shared +cuda',
-                       when='+paraview +cuda',
-                       propagate=cuda_arch_variants)
+    dav_sdk_depends_on('paraview ~shared +cuda', when='+paraview +cuda')
+    dav_sdk_depends_on('paraview +shared ~cuda', when='+paraview ~cuda')
 
     dav_sdk_depends_on('visit', when='+visit')
 


### PR DESCRIPTION
+cuda was hiding propagation of hdf5 and adios2 to paraview

@chuckatkins I found this while debuging on perlmutter, simplified it so it was less convoluted.