### PR TITLE
gdbm@1.22: fix build on MacOS

### DIFF
--- a/var/spack/repos/builtin/packages/gdbm/package.py
+++ b/var/spack/repos/builtin/packages/gdbm/package.py
@@ -31,7 +31,7 @@ class Gdbm(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on("readline")
 
-    patch('macOS.patch', when='@1.21: platform=darwin')
+    patch('macOS.patch', when='@1.21 platform=darwin')
     patch('gdbm.patch', when='@:1.18 %gcc@10:')
     patch('gdbm.patch', when='@:1.18 %clang@11:')
     patch('gdbm.patch', when='@:1.18 %cce@11:')


### PR DESCRIPTION
```
[+] /Users/xsdk/builds/cYLkqamb/0/xsdk-project/spack-xsdk/opt/spack/darwin-catalina-skylake/apple-clang-12.0.0/sqlite-3.37.1-vtjnq35fdshm3wjsh6wflk7wg7lpndrd
==> Installing gdbm-1.22-yuithn7l3fp3je7lhgqfefpck5epaooi
==> No binary for gdbm-1.22-yuithn7l3fp3je7lhgqfefpck5epaooi found: installing from source
1 out of 1 hunk FAILED -- saving rejects to file src/gdbmshell.c.rej
/Users/xsdk/builds/cYLkqamb/0/xsdk-project/spack-xsdk/lib/spack/spack/target.py:137: UserWarning: microarchitecture specific optimizations are not supported yet on mixed compiler toolchains [check apple-clang@12.0.0 for further details]
  warnings.warn(msg.format(compiler))
==> Fetching https://ftpmirror.gnu.org/gdbm/gdbm-1.22.tar.gz
==> Fetching https://ftp.gnu.org/gnu/gdbm/gdbm-1.22.tar.gz
==> Patch /Users/xsdk/builds/cYLkqamb/0/xsdk-project/spack-xsdk/var/spack/repos/builtin/packages/gdbm/macOS.patch failed.
==> Error: ProcessError: Command exited with status 1:
    '/usr/bin/patch' '-s' '-p' '1' '-i' '/Users/xsdk/builds/cYLkqamb/0/xsdk-project/spack-xsdk/var/spack/repos/builtin/packages/gdbm/macOS.patch' '-d' '.'
```

ref: https://github.com/spack/spack/pull/28302