### PR TITLE
Python: add maintainers for Python 2

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -28,7 +28,7 @@ class Python(AutotoolsPackage):
     list_url = "https://www.python.org/ftp/python/"
     list_depth = 1
 
-    maintainers = ['adamjstewart', 'skosukhin']
+    maintainers = ['adamjstewart', 'skosukhin', 'scheibelp', 'varioustoxins']
 
     version('3.10.1', sha256='b76117670e7c5064344b9c138e141a377e686b9063f3a8a620ff674fa8ec90d3')
     version('3.10.0', sha256='c4e0cbad57c90690cb813fb4663ef670b4d0f587d8171e2c42bd4c9245bd2758')


### PR DESCRIPTION
Adds @scheibelp and @varioustoxins to the list of maintainers for our Python recipe. You'll likely get pinged on many issues/PRs related to Python. Feel free to ignore them unless they involve Python 2 or are a big change that is worth testing on Python 2. Although you're welcome to fix/review things related to Python 3 if you have time. Thanks for your help!

Once this is merged, I'll revert #28003. I'll likely still deprecate 3.1.5 just because we know it won't work once #28346 is merged (requires sysconfig which was added in 2.7/3.2). Other than that, I'm fine with keeping all other Python versions.