### PR TITLE
[geant4-data] depends_on g4ensdfstate also @11

### DIFF
--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -49,6 +49,7 @@ class Geant4Data(BundlePackage):
     depends_on("g4saiddata@2.0", when='@11.0.0:11.0')
     depends_on("g4abla@3.1", when='@11.0.0:11.0')
     depends_on("g4incl@1.0", when='@11.0.0:11.0')
+    depends_on("g4ensdfstate@2.3", when='@11.0.0:11.0')
 
     # geant4@10.7.X
     depends_on("g4ndl@4.6", when='@10.7.0:10.7')


### PR DESCRIPTION
I guess that one got dropped by mistake in the geant4 upgrade...

As an aside, it'd be great if this change in the datasets didn't trigger a recompile of geant4 itself :-/

Maintainer tag: @drbenmorgan
