### PR TITLE
valgrind: default to ~ubsan

### DIFF
--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -40,7 +40,7 @@ class Valgrind(AutotoolsPackage, SourcewarePackage):
             description='Activates boost support for valgrind')
     variant('only64bit', default=True,
             description='Sets --enable-only64bit option for valgrind')
-    variant('ubsan', default=sys.platform != 'darwin',
+    variant('ubsan', default=False,
             description='Activates ubsan support for valgrind')
 
     conflicts('+ubsan', when='%apple-clang',


### PR DESCRIPTION
See #18222. I believe our `valgrind` package is missing a dependency but I'm not sure which package is supposed to provide the `ubsan` library. For now I think it's best to default to `~ubsan`.