### PR TITLE
Bug/caliper stand alone

### DIFF
--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import llnl.util.tty as tty
 import os
 import sys
+
+from llnl.util import tty
 
 from spack import *
 

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import llnl.util.tty as tty
 
 from spack import *
 
@@ -155,7 +156,7 @@ class Caliper(CMakePackage, CudaPackage):
         test_dir = join_path(self.test_suite.current_test_cache_dir, 'examples', 'apps')
 
         if not os.path.isfile(join_path(test_dir, 'cxx-example.cpp')):
-            print('Skipping caliper test: file does not exist')
+            tty.msg('Skipping caliper test: file does not exist')
             return
 
         exe = 'cxx-example'

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -161,14 +161,14 @@ class Caliper(CMakePackage, CudaPackage):
         exe = 'cxx-example'
 
         if os.path.exists(self.prefix.lib):
-            lib_dir = 'lib'
+            lib_dir = self.prefix.lib
         else:
-            lib_dir = 'lib64'
+            lib_dir = self.prefix.lib64
 
         self.run_test(exe='gcc',
                       options=['{0}'.format(join_path(test_dir, 'cxx-example.cpp')),
-                               '-L{0}'.format(join_path(self.prefix, lib_dir)),
-                               '-I{0}'.format(join_path(self.prefix, 'include')),
+                               '-L{0}'.format(lib_dir),
+                               '-I{0}'.format(self.prefix.include),
                                '-std=c++11', '-lcaliper', '-lstdc++', '-o', exe],
                       purpose='test: compile {0} example'.format(exe),
                       work_dir=test_dir)

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -154,15 +154,20 @@ class Caliper(CMakePackage, CudaPackage):
 
         test_dir = join_path(self.test_suite.current_test_cache_dir, 'examples', 'apps')
 
-        if not os.path.exists(test_dir):
-            print('Skipping caliper test')
+        if not os.path.isfile(join_path(test_dir, 'cxx-example.cpp')):
+            print('Skipping caliper test: file does not exist')
             return
 
         exe = 'cxx-example'
 
+        if os.path.exists(self.prefix.lib):
+            lib_dir = 'lib'
+        else:
+            lib_dir = 'lib64'
+
         self.run_test(exe='gcc',
                       options=['{0}'.format(join_path(test_dir, 'cxx-example.cpp')),
-                               '-L{0}'.format(join_path(self.prefix, 'lib64')),
+                               '-L{0}'.format(join_path(self.prefix, lib_dir)),
                                '-I{0}'.format(join_path(self.prefix, 'include')),
                                '-std=c++11', '-lcaliper', '-lstdc++', '-o', exe],
                       purpose='test: compile {0} example'.format(exe),

--- a/var/spack/repos/builtin/packages/caliper/package.py
+++ b/var/spack/repos/builtin/packages/caliper/package.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import llnl.util.tty as tty
 import os
 import sys
-import llnl.util.tty as tty
 
 from spack import *
 


### PR DESCRIPTION
Fixes [#27985](https://github.com/spack/spack/issues/27985)

Caliper's stand alone test fails if it cannot find the library files.