### PR TITLE
Allow adding or removing bootstrapping sources from cli

### DIFF
--- a/etc/spack/defaults/bootstrap.yaml
+++ b/etc/spack/defaults/bootstrap.yaml
@@ -10,9 +10,9 @@ bootstrap:
   # depending on its type.
   sources:
   - name: 'github-actions'
-    metadata: $spack/share/spack/bootstrap/github-actions/metadata.yaml
+    metadata: $spack/share/spack/bootstrap/github-actions
   - name: 'spack-install'
-    metadata: $spack/share/spack/bootstrap/spack-install/metadata.yaml
+    metadata: $spack/share/spack/bootstrap/spack-install
   trusted:
     # By default we trust bootstrapping from sources and from binaries
     # produced on Github via the workflow

--- a/etc/spack/defaults/bootstrap.yaml
+++ b/etc/spack/defaults/bootstrap.yaml
@@ -6,25 +6,13 @@ bootstrap:
   # by Spack is installed in a "store" subfolder of this root directory
   root: $user_cache_path/bootstrap
   # Methods that can be used to bootstrap software. Each method may or
-  # may not be able to bootstrap all of the software that Spack needs,
+  # may not be able to bootstrap all the software that Spack needs,
   # depending on its type.
   sources:
   - name: 'github-actions'
-    type: buildcache
-    description: |
-      Buildcache generated from a public workflow using Github Actions.
-      The sha256 checksum of binaries is checked before installation.
-    info:
-      url: https://mirror.spack.io/bootstrap/github-actions/v0.1
-      homepage: https://github.com/alalazo/spack-bootstrap-mirrors
-      releases: https://github.com/alalazo/spack-bootstrap-mirrors/releases
-  # This method is just Spack bootstrapping the software it needs from sources.
-  # It has been added here so that users can selectively disable bootstrapping
-  # from sources by "untrusting" it.
-  - name: spack-install
-    type: install
-    description: |
-      Specs built from sources by Spack. May take a long time.
+    metadata: $spack/share/spack/bootstrap/github-actions/metadata.yaml
+  - name: 'spack-install'
+    metadata: $spack/share/spack/bootstrap/spack-install/metadata.yaml
   trusted:
     # By default we trust bootstrapping from sources and from binaries
     # produced on Github via the workflow

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -16,7 +16,6 @@ import re
 import sys
 import sysconfig
 
-import ruamel.yaml
 import six
 
 import archspec.cpu
@@ -37,6 +36,7 @@ import spack.store
 import spack.user_environment
 import spack.util.executable
 import spack.util.path
+import spack.util.spack_yaml
 
 #: Name of the file containing metadata about the bootstrapping source
 METADATA_YAML_FILENAME = 'metadata.yaml'
@@ -994,6 +994,6 @@ def bootstrapping_sources(scope=None):
         metadata_dir = spack.util.path.canonicalize_path(entry['metadata'])
         metadata_yaml = os.path.join(metadata_dir, METADATA_YAML_FILENAME)
         with open(metadata_yaml) as f:
-            current.update(ruamel.yaml.load(f))
+            current.update(spack.util.spack_yaml.load(f))
         list_of_sources.append(current)
     return list_of_sources

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -92,6 +92,9 @@ def setup_parser(subparser):
     )
     _add_scope_option(add)
     add.add_argument(
+        '--trust', action='store_true',
+        help='trust the source immediately upon addition')
+    add.add_argument(
         'name', help='name of the new source of software'
     )
     add.add_argument(
@@ -294,6 +297,8 @@ def _add(args):
 
     msg = 'New bootstrapping source "{0}" added in the "{1}" configuration scope'
     llnl.util.tty.msg(msg.format(args.name, write_scope))
+    if args.trust:
+        _trust(args)
 
 
 def _remove(args):

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -95,7 +95,7 @@ def setup_parser(subparser):
         'name', help='name of the new source of software'
     )
     add.add_argument(
-        'metadata', help='location of the metadata file'
+        'metadata_dir', help='directory where to find metadata files'
     )
 
     remove = sp.add_parser(
@@ -275,16 +275,21 @@ def _add(args):
         raise RuntimeError(msg.format(args.name))
 
     # Check that the metadata file exists
-    file = spack.util.path.canonicalize_path(args.metadata)
+    metadata_dir = spack.util.path.canonicalize_path(args.metadata_dir)
+    if not os.path.exists(metadata_dir) or not os.path.isdir(metadata_dir):
+        raise RuntimeError(
+            'the directory "{0}" does not exist'.format(args.metadata_dir)
+        )
+
+    file = os.path.join(metadata_dir, 'metadata.yaml')
     if not os.path.exists(file):
-        msg = 'the file "{0}" does not exist'
-        raise RuntimeError(msg.format(args.metadata))
+        raise RuntimeError('the file "{0}" does not exist'.format(file))
 
     # Insert the new source as the highest priority one
     write_scope = args.scope or spack.config.default_modify_scope(section='bootstrap')
     sources = spack.config.get('bootstrap:sources', scope=write_scope) or []
     sources = [
-        {'name': args.name, 'metadata': args.metadata}
+        {'name': args.name, 'metadata': args.metadata_dir}
     ] + sources
     spack.config.set('bootstrap:sources', sources, scope=write_scope)
 

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -101,7 +101,6 @@ def setup_parser(subparser):
     remove = sp.add_parser(
         'remove', help='remove a bootstrapping source'
     )
-    _add_scope_option(remove)
     remove.add_argument(
         'name', help='name of the source to be removed'
     )

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -137,10 +137,7 @@ def _root(args):
 
 
 def _list(args):
-    sources = spack.config.get(
-        'bootstrap:sources', default=None, scope=args.scope
-    )
-
+    sources = spack.bootstrap.bootstrapping_sources(scope=args.scope)
     if not sources:
         llnl.util.tty.msg(
             "No method available for bootstrapping Spack's dependencies"

--- a/lib/spack/spack/schema/bootstrap.py
+++ b/lib/spack/spack/schema/bootstrap.py
@@ -9,12 +9,10 @@ _source_schema = {
     'type': 'object',
     'properties': {
         'name': {'type': 'string'},
-        'description': {'type': 'string'},
-        'type': {'type': 'string'},
-        'info': {'type': 'object'}
+        'metadata': {'type': 'string'}
     },
     'additionalProperties': False,
-    'required': ['name', 'description', 'type']
+    'required': ['name', 'metadata']
 }
 
 properties = {

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -135,11 +135,9 @@ def test_trust_or_untrust_fails_with_no_method(mutable_config):
 def test_trust_or_untrust_fails_with_more_than_one_method(mutable_config):
     wrong_config = {'sources': [
         {'name': 'github-actions',
-         'type': 'buildcache',
-         'description': ''},
+         'metadata': '$spack/share/spack/bootstrap/github-actions/metadata.yaml'},
         {'name': 'github-actions',
-         'type': 'buildcache',
-         'description': 'Another entry'}],
+         'metadata': '$spack/share/spack/bootstrap/github-actions/metadata.yaml'}],
         'trusted': {}
     }
     with spack.config.override('bootstrap', wrong_config):

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -135,9 +135,9 @@ def test_trust_or_untrust_fails_with_no_method(mutable_config):
 def test_trust_or_untrust_fails_with_more_than_one_method(mutable_config):
     wrong_config = {'sources': [
         {'name': 'github-actions',
-         'metadata': '$spack/share/spack/bootstrap/github-actions/metadata.yaml'},
+         'metadata': '$spack/share/spack/bootstrap/github-actions'},
         {'name': 'github-actions',
-         'metadata': '$spack/share/spack/bootstrap/github-actions/metadata.yaml'}],
+         'metadata': '$spack/share/spack/bootstrap/github-actions'}],
         'trusted': {}
     }
     with spack.config.override('bootstrap', wrong_config):

--- a/lib/spack/spack/test/data/config/bootstrap.yaml
+++ b/lib/spack/spack/test/data/config/bootstrap.yaml
@@ -1,12 +1,5 @@
 bootstrap:
   sources:
   - name: 'github-actions'
-    type: buildcache
-    description: |
-      Buildcache generated from a public workflow using Github Actions.
-      The sha256 checksum of binaries is checked before installation.
-    info:
-      url: file:///home/culpo/production/spack/mirrors/clingo
-      homepage: https://github.com/alalazo/spack-bootstrap-mirrors
-      releases: https://github.com/alalazo/spack-bootstrap-mirrors/releases
+    metadata: $spack/share/spack/bootstrap/github-actions/metadata.yaml
   trusted: {}

--- a/lib/spack/spack/test/data/config/bootstrap.yaml
+++ b/lib/spack/spack/test/data/config/bootstrap.yaml
@@ -1,5 +1,5 @@
 bootstrap:
   sources:
   - name: 'github-actions'
-    metadata: $spack/share/spack/bootstrap/github-actions/metadata.yaml
+    metadata: $spack/share/spack/bootstrap/github-actions
   trusted: {}

--- a/share/spack/bootstrap/github-actions/metadata.yaml
+++ b/share/spack/bootstrap/github-actions/metadata.yaml
@@ -1,0 +1,8 @@
+type: buildcache
+description: |
+  Buildcache generated from a public workflow using Github Actions.
+  The sha256 checksum of binaries is checked before installation.
+info:
+  url: https://mirror.spack.io/bootstrap/github-actions/v0.1
+  homepage: https://github.com/alalazo/spack-bootstrap-mirrors
+  releases: https://github.com/alalazo/spack-bootstrap-mirrors/releases

--- a/share/spack/bootstrap/spack-install/metadata.yaml
+++ b/share/spack/bootstrap/spack-install/metadata.yaml
@@ -1,0 +1,6 @@
+# This method is just Spack bootstrapping the software it needs from sources.
+# It has been added here so that users can selectively disable bootstrapping
+# from sources by "untrusting" it.
+type: install
+description: |
+  Specs built from sources by Spack. May take a long time.

--- a/share/spack/bootstrap/spack-install/metadata.yaml
+++ b/share/spack/bootstrap/spack-install/metadata.yaml
@@ -3,4 +3,6 @@
 # from sources by "untrusting" it.
 type: install
 description: |
-  Specs built from sources by Spack. May take a long time.
+  Specs built from sources downloaded from the Spack public mirror.
+info:
+  url: https://mirror.spack.io

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -488,7 +488,7 @@ _spack_bootstrap_untrust() {
 _spack_bootstrap_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --trust"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -434,7 +434,7 @@ _spack_bootstrap() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="status enable disable reset root list trust untrust"
+        SPACK_COMPREPLY="status enable disable reset root list trust untrust add remove"
     fi
 }
 
@@ -477,6 +477,24 @@ _spack_bootstrap_trust() {
 }
 
 _spack_bootstrap_untrust() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --scope"
+    else
+        SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_bootstrap_add() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --scope"
+    else
+        SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_bootstrap_remove() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help --scope"

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -497,7 +497,7 @@ _spack_bootstrap_add() {
 _spack_bootstrap_remove() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
closes #26306 

In certain cases, in particular when working on air-gapped networks, it might be of interest to easily point Spack to an alternative source of software to be used during bootstrapping. This PR introduces two additional subcommands to allow adding and removing bootstrapping sources from Spack's configuration.

Modifications:
- [x] Reworked `bootstrap.yaml` schema to push each source metadata in a separate folder
- [x] Add `spack bootstrap add` and `spack bootstrap remove` to add and remove additional sources of software for bootstrapping   