### PR TITLE
charmpp: use CMake for versions 7.0.0+

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -101,6 +101,10 @@ class Charmpp(Package):
     variant("production", default=True, description="Build charm++ with all optimizations")
     variant("tracing", default=False, description="Enable tracing modules")
 
+    # Versions 7.0.0+ use CMake by default when it's available. It's more
+    # robust.
+    depends_on('cmake@3.4:', when='@7.0.0:', type='build')
+
     depends_on("mpi", when="backend=mpi")
     depends_on("papi", when="+papi")
     depends_on("cuda", when="+cuda")


### PR DESCRIPTION
I had build issues on a system that didn't have CMake installed, so `buildold` was used as a fallback and failed. This PR makes sure CMake is available on v7.0.0+, where it is used by default.