### PR TITLE
is_system_path: return False if path is None

### DIFF
--- a/lib/spack/spack/test/util/environment.py
+++ b/lib/spack/spack/test/util/environment.py
@@ -22,6 +22,8 @@ def prepare_environment_for_tests():
 def test_is_system_path():
     assert(envutil.is_system_path('/usr/bin'))
     assert(not envutil.is_system_path('/nonsense_path/bin'))
+    assert(not envutil.is_system_path(''))
+    assert(not envutil.is_system_path(None))
 
 
 test_paths = ['/usr/bin',

--- a/lib/spack/spack/util/environment.py
+++ b/lib/spack/spack/util/environment.py
@@ -59,7 +59,7 @@ def is_system_path(path):
     Returns:
         True or False
     """
-    return os.path.normpath(path) in system_dirs
+    return path and os.path.normpath(path) in system_dirs
 
 
 def filter_system_paths(paths):


### PR DESCRIPTION
fixes #28006
fixes #22268

A bit of defensive programming in that a `None` (or empty string) is automatically rejected as a system path.

This change should prevent the erroneous TypeError reporting for issues such as #28006 and #22268.