### PR TITLE
Kokkos Kernels: release maintenance

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -10,8 +10,8 @@ class KokkosKernels(CMakePackage, CudaPackage):
     for small matrices, that can be used in larger Kokkos parallel routines"""
 
     homepage = "https://github.com/kokkos/kokkos-kernels"
-    git = "https://github.com/kokkos/kokkos-kernels.git"
-    url = "https://github.com/kokkos/kokkos-kernels/archive/3.4.01.tar.gz"
+    git      = "https://github.com/kokkos/kokkos-kernels.git"
+    url      = "https://github.com/kokkos/kokkos-kernels/archive/3.5.00.tar.gz"
 
     tags = ['e4s']
 
@@ -19,8 +19,11 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     maintainers = ['lucbv', 'srajama1', 'brian-kelley']
 
+    # generate checksum for each release tarball with the following command
+    # openssl sha256 kokkos-kernels-x.y.z.tar.gz
     version('develop', branch='develop')
     version('master',  branch='master')
+    version('3.5.00', sha256="a03a41a047d95f9f07cd1e1d30692afdb75b5c705ef524e19c1d02fe60ccf8d1")
     version('3.4.01', sha256="f504aa4afbffb58fa7c4430d0fdb8fd5690a268823fa15eb0b7d58dab9d351e6")
     version('3.4.00', sha256="07ba11869e686cb0d47272d1ef494ccfbcdef3f93ff1c8b64ab9e136a53a227a")
     version('3.3.01', sha256="0f21fe6b5a8b6ae7738290e293aa990719aefe88b32f84617436bfd6074a8f77")
@@ -33,7 +36,16 @@ class KokkosKernels(CMakePackage, CudaPackage):
     depends_on("kokkos")
     depends_on("kokkos@master", when="@master")
     depends_on("kokkos@develop", when="@develop")
-    depends_on("cmake@3.10:", type='build')
+    depends_on("kokkos@3.5.00", when="@3.5.00")
+    depends_on("kokkos@3.4.01", when="@3.4.01")
+    depends_on("kokkos@3.4.00", when="@3.4.00")
+    depends_on("kokkos@3.3.01", when="@3.3.01")
+    depends_on("kokkos@3.3.00", when="@3.3.00")
+    depends_on("kokkos@3.2.01", when="@3.2.01")
+    depends_on("kokkos@3.2.00", when="@3.2.00")
+    depends_on("kokkos@3.1.00", when="@3.1.00")
+    depends_on("kokkos@3.0.00", when="@3.0.00")
+    depends_on("cmake@3.16:", type='build')
 
     backends = {
         'serial': (False,  "enable Serial backend (default)"),


### PR DESCRIPTION
Making some maintenance changes in the package
1. adding latest release 3.5.0
2. updating cmake requirement to match that of Kokkos
3. adding logic to depend on the right version of Kokkos by default