### PR TITLE
ginkgo: fix stand-alone test directory / install_test

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -167,19 +167,18 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
         with working_dir(smoke_test_path):
             make("install")
 
-        # Above installs tests and data needed for running the tests that
-        # adhere to a relative structure to obtain the data. It is generally
-        # safer for tests to run from the test stage so all files are copied
-        # to the install test root. This allows Spack to automatically copy
-        # them to the test stage prior to running test().
-        install_tree(self.prefix.smoke_tests, self.install_test_root)
-
     def test(self):
         """Run the smoke tests."""
         # For now only 1.4.0 and later releases support this scheme.
         if self.spec.satisfies('@:1.3.0'):
             print("SKIPPED: smoke tests not supported with this Ginkgo version.")
             return
+
+        # The installation process installs tests and associated data
+        # in a non-standard subdirectory. Consequently, those files must
+        # be manually copied to the test stage here.
+        install_tree(self.prefix.smoke_tests,
+                     self.test_suite.current_test_cache_dir)
 
         # Perform the test(s) created by setup_build_tests.
         files = [('test_install', [r'REFERENCE',

--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -167,19 +167,28 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
         with working_dir(smoke_test_path):
             make("install")
 
+        # Above installs tests and data needed for running the tests that
+        # adhere to a relative structure to obtain the data. It is generally
+        # safer for tests to run from the test stage so all files are copied
+        # to the install test root. This allows Spack to automatically copy
+        # them to the test stage prior to running test().
+        install_tree(self.prefix.smoke_tests, self.install_test_root)
+
     def test(self):
         """Run the smoke tests."""
         # For now only 1.4.0 and later releases support this scheme.
         if self.spec.satisfies('@:1.3.0'):
             print("SKIPPED: smoke tests not supported with this Ginkgo version.")
             return
+
+        # Perform the test(s) created by setup_build_tests.
         files = [('test_install', [r'REFERENCE',
                                    r'correctly detected and is complete']),
                  ('test_install_cuda', [r'CUDA',
                                         r'correctly detected and is complete']),
                  ('test_install_hip', [r'HIP',
                                        r'correctly detected and is complete'])]
-        smoke_test_path = join_path(self.prefix, 'smoke_tests')
         for f, expected in files:
-            self.run_test(f, [], expected, skip_missing=True, installed=True,
-                          work_dir=smoke_test_path)
+            self.run_test(f, [], expected, skip_missing=True, installed=False,
+                          purpose="test: Running {0}".format(f),
+                          work_dir=self.test_suite.current_test_cache_dir)


### PR DESCRIPTION
Fixes #27984 

This PR ensures the files created at build-time are copied to a test cache directory to allow Spack to automatically copy them to the test stage directory when running `spack test run`.  It has been tested for `test_install` but I have not been able to build with `+cuda` (or tried `+rocm`) to confirm the other two tests work.

The main goal is to ensure these tests are run from the test stage directory, not `self.prefix`, since doing so from the latter could cause issues if/when tests are added that write to `work_dir`.

NOTE:  I have reservations about the nature of these tests since the package is providing libraries.  It is a better test/demonstration, from a stand-alone testing perspective, to have the tests built against the installed headers and libraries, whether after the software is installed or during execution of `spack test run`.  Caching build-time files is described at https://spack.readthedocs.io/en/latest/packaging_guide.html#adding-build-time-files.

Examples of different approaches can be found in the following packages:
- [kokkos](https://github.com/spack/spack/blob/e0f044561e9b3cb384bfb0f364555e5875b1a492/var/spack/repos/builtin/packages/kokkos/package.py#L290) (see `setup_build_tests` for one way of building the tests; note this package still needs to be changed to *not* use `self.install_test_root`)
- [OpenMPI](https://github.com/spack/spack/blob/e0f044561e9b3cb384bfb0f364555e5875b1a492/var/spack/repos/builtin/packages/openmpi/package.py#L983) (see `_test_examples`)
- [hypre](https://github.com/spack/spack/blob/e0f044561e9b3cb384bfb0f364555e5875b1a492/var/spack/repos/builtin/packages/hypre/package.py#L244) (see `cache_test_sources` and `test`)