### PR TITLE
Fix command line scopes with other flags

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -819,12 +819,12 @@ def _main(argv=None):
     # scopes, then environment configuration here.
     # ------------------------------------------------------------------------
 
-    # ensure options on spack command come before everything
-    setup_main_options(args)
-
     # make spack.config aware of any command line configuration scopes
     if args.config_scopes:
         spack.config.command_line_scopes = args.config_scopes
+
+    # ensure options on spack command come before everything
+    setup_main_options(args)
 
     # activate an environment if one was specified on the command line
     env_format_error = None


### PR DESCRIPTION
Fixes #28417

The issue I found is: since 2bd513d6591161d271221bb76bc1420bd3c2b3e3 (spack 0.17), if a config-changing flag is set, then the`spack.config.config` singleton was initialized in `setup_main_options` *before* `spack.config.command_line_scopes` had been set. So the command line scopes were not taken into account during the config initialization.
