### PR TITLE
Bazel: add post-installation tests

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -202,6 +202,9 @@ class Bazel(Package):
 
     @run_after('install')
     @on_package_attributes(run_tests=True)
+    def install_test(self):
+        self.test()
+
     def test(self):
         # https://github.com/Homebrew/homebrew-core/blob/master/Formula/bazel.rb
 

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -202,7 +202,7 @@ class Bazel(Package):
 
     @run_after('install')
     @on_package_attributes(run_tests=True)
-    def install_test(self):
+    def test(self):
         # https://github.com/Homebrew/homebrew-core/blob/master/Formula/bazel.rb
 
         # Bazel does not work properly on NFS, switch to /tmp


### PR DESCRIPTION
We already have tests for `spack install --test`, this uses those tests for `spack test` too.