### PR TITLE
PyTorch: specify CUDA version incompatibility

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -128,9 +128,11 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('benchmark', when='@1.6:+test')
 
     # Optional dependencies
-    depends_on('cuda@7.5:', when='+cuda', type=('build', 'link', 'run'))
-    depends_on('cuda@9:', when='@1.1:+cuda', type=('build', 'link', 'run'))
-    depends_on('cuda@9.2:', when='@1.6:+cuda', type=('build', 'link', 'run'))
+    # https://discuss.pytorch.org/t/compiling-1-10-1-from-source-with-gcc-11-and-cuda-11-5/140971
+    depends_on('cuda@9.2:', when='@1.11:+cuda', type=('build', 'link', 'run'))
+    depends_on('cuda@9.2:11.4', when='@1.6:+cuda', type=('build', 'link', 'run'))
+    depends_on('cuda@9:11.4', when='@1.1:+cuda', type=('build', 'link', 'run'))
+    depends_on('cuda@7.5:11.4', when='+cuda', type=('build', 'link', 'run'))
     depends_on('cudnn@6:7', when='@:1.0+cudnn')
     depends_on('cudnn@7.0:7', when='@1.1:1.5+cudnn')
     depends_on('cudnn@7:', when='@1.6:+cudnn')


### PR DESCRIPTION
Latest version of PyTorch doesn't support the latest version of CUDA. CUDA 11.5 works with master and will work with the 1.12 release coming in a couple months.