### PR TITLE
NCCL: specify cuda_arch

### DIFF
--- a/var/spack/repos/builtin/packages/nccl/package.py
+++ b/var/spack/repos/builtin/packages/nccl/package.py
@@ -45,10 +45,19 @@ class Nccl(MakefilePackage, CudaPackage):
     patch('so_reuseport.patch', when='@2.3.7-1:2.4.8-1')
 
     conflicts('~cuda', msg='NCCL requires CUDA')
+    conflicts('cuda_arch=none',
+              msg='Must specify CUDA compute capabilities of your GPU, see '
+              'https://developer.nvidia.com/cuda-gpus')
 
     @property
     def build_targets(self):
-        return ['CUDA_HOME={0}'.format(self.spec['cuda'].prefix)]
+        cuda_arch = self.spec.variants['cuda_arch'].value
+        cuda_gencode = ' '.join(self.cuda_flags(cuda_arch))
+
+        return [
+            'CUDA_HOME={0}'.format(self.spec['cuda'].prefix),
+            'NVCC_GENCODE={0}'.format(cuda_gencode),
+        ]
 
     @property
     def install_targets(self):


### PR DESCRIPTION
From the `README.md`:

> By default, NCCL is compiled for all supported architectures. To accelerate the compilation and reduce the binary size, consider redefining `NVCC_GENCODE` (defined in `makefiles/common.mk`) to only include the architecture of the target platform :
> ```shell
> $ make -j src.build NVCC_GENCODE="-gencode=arch=compute_70,code=sm_70"
> ```

Successfully builds on RHEL 8.4 with GCC 8.5.0 and CUDA 11.4.2.