### PR TITLE
zip: add external detection

### DIFF
--- a/var/spack/repos/builtin/packages/zip/package.py
+++ b/var/spack/repos/builtin/packages/zip/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 
 class Zip(MakefilePackage):
     """Zip is a compression and file packaging/archive utility."""
@@ -26,6 +28,14 @@ class Zip(MakefilePackage):
     patch('08-hardening-build-fix-1.patch')
     patch('09-hardening-build-fix-2.patch')
     patch('10-remove-build-date.patch')
+
+    executables = ['^zip$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'This is Zip (\S+)', output)
+        return match.group(1) if match else None
 
     def url_for_version(self, version):
         return 'http://downloads.sourceforge.net/infozip/zip{0}.tar.gz'.format(version.joined)


### PR DESCRIPTION
Tested on macOS 10.15.7. Output looks like:
```console
$ zip --version
Copyright (c) 1990-2008 Info-ZIP - Type 'zip "-L"' for software license.
This is Zip 3.0 (July 5th 2008), by Info-ZIP.
Currently maintained by E. Gordon.  Please send bug reports to
the authors using the web page at www.info-zip.org; see README for details.

Latest sources and executables are at ftp://ftp.info-zip.org/pub/infozip,
as of above date; see http://www.info-zip.org/ for other sites.

Compiled with gcc 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.29.20) (-macos10.15-objc-selector-opts) for Unix (Mac OS X) on Jun  5 2020.

Zip special compilation options:
	USE_EF_UT_TIME       (store Universal Time)
	SYMLINK_SUPPORT      (symbolic links supported)
	LARGE_FILE_SUPPORT   (can read and write large files on file system)
	ZIP64_SUPPORT        (use Zip64 to store large files in archives)
	STORE_UNIX_UIDs_GIDs (store UID/GID sizes/values using new extra field)
	UIDGID_16BIT         (old Unix 16-bit UID/GID extra field also used)
	[encryption, version 2.91 of 05 Jan 2007] (modified for Zip 3)

Encryption notice:
	The encryption code of this program is not copyrighted and is
	put in the public domain.  It was originally written in Europe
	and, to the best of our knowledge, can be freely distributed
	in both source and object forms from any country, including
	the USA under License Exception TSU of the U.S. Export
	Administration Regulations (section 740.13(e)) of 6 June 2002.

Zip environment options:
             ZIP:  [none]
          ZIPOPT:  [none]
```