### PR TITLE
expat: Add latest release 2.4.3 with security fixes

### DIFF
--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -14,10 +14,10 @@ class Expat(AutotoolsPackage):
     homepage = "https://libexpat.github.io/"
     url      = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
-    version('2.4.1', sha256='2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40')
-    version('2.4.0', sha256='8c59142ef88913bc0a8b6e4c58970c034210ca552e6271f52f6cd6cce3708424')
-    # deprecate all releases before 2.4.0 because of CVE-2013-0340
-    # ("billion laughs attack")
+    version('2.4.3', sha256='6f262e216a494fbf42d8c22bc841b3e117c21f2467a19dc4c27c991b5622f986')
+    # deprecate all releases before 2.4.3 because of security issues
+    version('2.4.1', sha256='2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40', deprecated=True)
+    version('2.4.0', sha256='8c59142ef88913bc0a8b6e4c58970c034210ca552e6271f52f6cd6cce3708424', deprecated=True)
     version('2.3.0', sha256='f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586', deprecated=True)
     version('2.2.10', sha256='b2c160f1b60e92da69de8e12333096aeb0c3bf692d41c60794de278af72135a5', deprecated=True)
     version('2.2.9', sha256='f1063084dc4302a427dabcca499c8312b3a32a29b7d2506653ecc8f950a9a237', deprecated=True)


### PR DESCRIPTION
Hi!

[libexpat 2.4.3](https://github.com/libexpat/libexpat/releases/tag/R_2_4_3) with **security fixes** has been released, the upstream [change log](https://github.com/libexpat/libexpat/blob/R_2_4_3/expat/Changes) has more details.

Thanks for updating! :pray: 

Best, Sebastian