### PR TITLE
Fixing pthread-stack-min-fix.patch patch version range

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -312,7 +312,7 @@ class Boost(Package):
 
     # Fix issues with PTHREAD_STACK_MIN not being a DEFINED constant in newer glibc
     # See https:://github.com/spack/spack/issues/28273
-    patch("pthread-stack-min-fix.patch", when="@1.69.0:1.73.0")
+    patch("pthread-stack-min-fix.patch", when="@1.69.0:1.72.0")
 
     def patch(self):
         # Disable SSSE3 and AVX2 when using the NVIDIA compiler

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -311,7 +311,7 @@ class Boost(Package):
           working_dir="tools/build")
 
     # Fix issues with PTHREAD_STACK_MIN not being a DEFINED constant in newer glibc
-    # See https:://github.com/spack/spack/issues/28273
+    # See https://github.com/spack/spack/issues/28273
     patch("pthread-stack-min-fix.patch", when="@1.69.0:1.72.0")
 
     def patch(self):


### PR DESCRIPTION
fixes #28436

pthread-stack-min-fix.patch should no be applied to 1.73.0
