### PR TITLE
[acts] Fix autodiff version requirement

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -142,7 +142,7 @@ class Acts(CMakePackage, CudaPackage):
     # Build dependencies
     # FIXME: Use spack's vecmem package once there is one
     # (https://github.com/acts-project/acts/pull/998)
-    depends_on('autodiff @0.5.11:', when='@1.2: +autodiff')
+    depends_on('autodiff @0.5.11:0.5.99', when='@1.2: +autodiff')
     depends_on('boost @1.62:1.69 +program_options +test', when='@:0.10.3')
     depends_on('boost @1.71: +filesystem +program_options +test', when='@0.10.4:')
     depends_on('cmake @3.14:', type='build')


### PR DESCRIPTION
ACTS is not compatible with current versions of autodiff because of API changes in the 0.6.x series. Upstream issue: https://github.com/acts-project/acts/issues/1135 .