### PR TITLE
Remove '==> OpenFOAM bashrc env: ' from module

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -459,7 +459,7 @@ class Openfoam(Package):
 
                 env.extend(mods)
                 minimal = False
-                tty.info('OpenFOAM bashrc env: {0}'.format(bashrc))
+                tty.debug('OpenFOAM bashrc env: {0}'.format(bashrc))
             except Exception:
                 minimal = True
 


### PR DESCRIPTION
It seems that spack reads the output of `setup_run_environment` to build the actual spack modules and lmod modules. So, any output here will used verbatim on the shell.

This patch fixes https://github.com/spack/spack/issues/26733

Adding maintainers: @olesenm
