### PR TITLE
update version for 'crusher'

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -18,6 +18,7 @@ class CrayMpich(Package):
 
     maintainers = ['haampie']
 
+    version('8.1.12')
     version('8.1.7')
     version('8.1.0')
     version('8.0.16')


### PR DESCRIPTION
While it still needs to be an 'external', the early access 'crusher' system has the module 'cray-mpich/8.1.12'