### PR TITLE
Add 'cxi' (slingshot) variant

### DIFF
--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -55,7 +55,8 @@ class Libfabric(AutotoolsPackage):
                'udp',
                'usnic',
                'verbs',
-               'xpmem')
+               'xpmem',
+               'cxi')
 
     variant('fabrics',
             default='sockets,tcp,udp',


### PR DESCRIPTION
While it may be the case that only `/opt/cray/modulefiles/libfabric/1.13.0.0` on the early access 'crusher' machine has support for it, the 'cxi' provider is something a user could request.

Requires libfabric to be an external package using cray's libfabric... should  "install" fail with a message about external packaging if cxi variant requested?  (like spectrum-mpi and cray-mpich do?)