### PR TITLE
SIPPackage: fix build system

### DIFF
--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -102,17 +102,13 @@ class SIPPackage(PackageBase):
 
         args = self.configure_args()
 
-        python_include_dir = os.path.basename(
-            inspect.getmodule(self).python_include_dir
-        )
-
         args.extend([
             '--verbose',
             '--confirm-license',
             '--qmake', spec['qt'].prefix.bin.qmake,
             '--sip', spec['py-sip'].prefix.bin.sip,
-            '--sip-incdir', join_path(spec['py-sip'].prefix.include,
-                                      python_include_dir),
+            '--sip-incdir', join_path(spec['py-sip'].prefix,
+                                      spec['python'].package.include),
             '--bindir', prefix.bin,
             '--destdir', inspect.getmodule(self).python_platlib,
         ])

--- a/var/spack/repos/builtin/packages/py-sip/package.py
+++ b/var/spack/repos/builtin/packages/py-sip/package.py
@@ -53,7 +53,8 @@ class PySip(PythonPackage):
                 '--sip-module={0}'.format(spec.variants['module'].value),
                 '--bindir={0}'.format(prefix.bin),
                 '--destdir={0}'.format(python_platlib),
-                '--incdir={0}'.format(spec['python'].package.include),
+                '--incdir={0}'.format(join_path(
+                    prefix, spec['python'].package.include)),
                 '--sipdir={0}'.format(prefix.share.sip),
                 '--stubsdir={0}'.format(python_platlib),
             ]


### PR DESCRIPTION
Fixes a bug I introduced in #28346. I removed `python_include_dir` but left behind a reference to it in `SIPPackage`, and made a mistake when referencing the new variable in `py-sip`. Confirmed that things are working now and was able to install `py-pyqt5` without issue.