### PR TITLE
py-astropy: remove install_options

### DIFF
--- a/var/spack/repos/builtin/packages/py-astropy/package.py
+++ b/var/spack/repos/builtin/packages/py-astropy/package.py
@@ -81,9 +81,6 @@ class PyAstropy(PythonPackage):
             '--use-system-expat'
         ]
 
-        if spec.satisfies('^python@3:'):
-            args.extend(['-j', str(make_jobs)])
-
         return args
 
     @run_after('install')


### PR DESCRIPTION
Fixes a bug I introduced in #27798. Before #27798, we ran:
```console
$ python setup.py build -j4
$ python setup.py install ...
```
After #27798, we now run `pip install .` which runs:
```console
$ python setup.py install -j4 ...
```
However, the `-j` flag is apparently only valid for the build phase, not for the install phase. Removed the flag and now `py-astropy` successfully installs for me.