### PR TITLE
diffutils: nvhpc not 11 compliant for __builtin_add_overflow

### DIFF
--- a/var/spack/repos/builtin/packages/diffutils/intprops-workaround-nvc-22.1-bug.patch
+++ b/var/spack/repos/builtin/packages/diffutils/intprops-workaround-nvc-22.1-bug.patch
@@ -1,0 +1,17 @@
+diff --git a/lib/intprops.h b/lib/intprops.h
+index 9d10028..1540e3e 100644
+--- a/lib/intprops.h
++++ b/lib/intprops.h
+@@ -232,7 +232,11 @@
+    (A, B, P) work when P is non-null.  */
+ /* __builtin_{add,sub}_overflow exists but is not reliable in GCC 5.x and 6.x,
+    see <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98269>.  */
+-#if 7 <= __GNUC__ && !defined __ICC
++#ifdef __EDG__
++/* EDG-based compilers like nvc 22.1 cannot add 64-bit signed to unsigned
++   <https://bugs.gnu.org/53256>.  */
++# define _GL_HAS_BUILTIN_ADD_OVERFLOW 0
++#elif 7 <= __GNUC__ && !defined __ICC
+ # define _GL_HAS_BUILTIN_ADD_OVERFLOW 1
+ #elif defined __has_builtin
+ # define _GL_HAS_BUILTIN_ADD_OVERFLOW __has_builtin (__builtin_add_overflow)

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -24,6 +24,7 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     build_directory = 'spack-build'
 
     patch('nvhpc.patch', when='@3.7 %nvhpc')
+    patch('intprops-workaround-nvc-22.1-bug.patch', sha256='146b7021bb0a304a3d1c0638956c4e735c2076d292d238f2806efadc972d99e5', when='@3.8 %nvhpc')
 
     depends_on('iconv')
 


### PR DESCRIPTION
nvhpc even latest 22.1 fails to compile diffutils 3.8 because it erroneously pretends to be 11 compliant but this is not true.
Paul Eggert from UCLA gave me a patch for latest diffutils master, I adapted it for diffutils 3.8.


