### PR TITLE
py-pymumps: remove install_options

### DIFF
--- a/var/spack/repos/builtin/packages/py-pymumps/package.py
+++ b/var/spack/repos/builtin/packages/py-pymumps/package.py
@@ -27,18 +27,3 @@ class PyPymumps(PythonPackage):
     # Patch to add libmumps_common.so to library dependencies
     # See https://github.com/PyMumps/pymumps/issues/13
     patch('py-pymumps.setup.patch')
-
-    def install_options(self, spec, prefix):
-        # Requires --library-dirs,
-        # '--libraries', spec['mumps'].prefix.libs, does not cut it
-        args = ['--include-dirs',
-                spec['mumps'].prefix.include,
-                '--library-dirs',
-                spec['mumps'].libs.directories[0],
-                '--rpath',
-                spec['mumps'].libs.directories[0],
-                '-l', 'dmumps',
-                '-l', 'mumps_common',
-                '-l', 'pord',
-                ]
-        return args


### PR DESCRIPTION
Fixes a bug I introduced in #27798. Before #27798, we ran:
```console
$ python setup.py build --include-dirs ...
$ python setup.py install
```
After #27798 we now run `pip install .` which runs:
```console
$ python setup.py install --include-dirs ...
```
However, these flags are only valid for the build phase, not for the install phase. Removing these args allows me to successfully build the package, and the package still correctly RPATHs to the right mumps installation, so I don't think they are actually needed. However, my mumps installation seems to be missing a lot of symbols:
```console
$ ldd -r /u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mumps-5.4.0-l2jllxnhy25r6kc5dcgvh4afxshbbnw3/lib/libmumps_common.so
...
undefined symbol: firstPostorder	(/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mumps-5.4.0-l2jllxnhy25r6kc5dcgvh4afxshbbnw3/lib/libmumps_common.so)
undefined symbol: nextPostorder	(/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mumps-5.4.0-l2jllxnhy25r6kc5dcgvh4afxshbbnw3/lib/libmumps_common.so)
undefined symbol: GOMP_parallel	(/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mumps-5.4.0-l2jllxnhy25r6kc5dcgvh4afxshbbnw3/lib/libmumps_common.so)
undefined symbol: SPACE_ordering	(/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mumps-5.4.0-l2jllxnhy25r6kc5dcgvh4afxshbbnw3/lib/libmumps_common.so)
undefined symbol: omp_get_thread_num	(/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mumps-5.4.0-l2jllxnhy25r6kc5dcgvh4afxshbbnw3/lib/libmumps_common.so)
undefined symbol: omp_get_num_threads	(/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mumps-5.4.0-l2jllxnhy25r6kc5dcgvh4afxshbbnw3/lib/libmumps_common.so)
undefined symbol: freeElimTree	(/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mumps-5.4.0-l2jllxnhy25r6kc5dcgvh4afxshbbnw3/lib/libmumps_common.so)
```
This is causing all imports of `pymumps` to fail. Maybe @payerle can take a look at this?