### PR TITLE
valgrind: add version 3.18

### DIFF
--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -24,6 +24,8 @@ class Valgrind(AutotoolsPackage, SourcewarePackage):
     git      = "git://sourceware.org/git/valgrind.git"
 
     version('develop', branch='master')
+    version('3.18.1', sha256='00859aa13a772eddf7822225f4b46ee0d39afbe071d32778da4d99984081f7f5')
+    version('3.18.0', sha256='8da880f76592fe8284db98e68f6dc9095485bc2ecc88bc05b7df1f278ae7f657')
     version('3.17.0', sha256='ad3aec668e813e40f238995f60796d9590eee64a16dff88421430630e69285a2')
     version('3.16.1', sha256='c91f3a2f7b02db0f3bc99479861656154d241d2fdb265614ba918cc6720a33ca')
     version('3.15.0', sha256='417c7a9da8f60dd05698b3a7bc6002e4ef996f14c13f0ff96679a16873e78ab1')


### PR DESCRIPTION
Add checksums for valgrind  3.18.0 and 3.18.1.