### PR TITLE
py-pyodbc: remove install_options

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyodbc/package.py
+++ b/var/spack/repos/builtin/packages/py-pyodbc/package.py
@@ -16,9 +16,6 @@ class PyPyodbc(PythonPackage):
 
     version('4.0.26', sha256='e52700b5d24a846483b5ab80acd9153f8e593999c9184ffea11596288fb33de3')
 
-    depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
+    depends_on('python@2.7:2.8,3.4:', type=('build', 'link', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('unixodbc',        type=('build', 'run'))
-
-    def install_options(self, spec, prefix):
-        return ['--rpath=%s' % spec['unixodbc'].prefix.lib]
+    depends_on('unixodbc')


### PR DESCRIPTION
Fixes a bug I introduced in #27798. Before #27798 we ran:
```console
$ python setup.py build --rpath
$ python setup.py install ...
```
After #27798 we run `pip install .` which runs:
```console
$ python setup.py install --rpath ...
```
However, the `--rpath` flag is only valid for the build phase, not the install phase. After removing `install_options` and changing the deptypes to link, the build succeeds and RPATHs to `unixodbc` correctly, so it seems like `--rpath` isn't needed.