### PR TITLE
py-pyside2: fix various build issues

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyside2/package.py
+++ b/var/spack/repos/builtin/packages/py-pyside2/package.py
@@ -17,6 +17,7 @@ class PyPyside2(PythonPackage):
     # https://wiki.qt.io/Qt_for_Python_Development_Getting_Started
 
     version('develop', tag='dev')
+    version('5.15.2.1', tag='v5.15.2.1', submodules=True)
     version('5.14.2.1', tag='v5.14.2.1', submodules=True)
     version('5.13.2', tag='v5.13.2', submodules=True)
     version('5.13.1', tag='v5.13.1', submodules=True)
@@ -26,12 +27,16 @@ class PyPyside2(PythonPackage):
     variant('doc', default=False, description='Enables the generation of html and man page documentation')
 
     depends_on('python@2.7.0:2.7,3.5.0:3.5,3.6.1:', type=('build', 'run'))
+    depends_on('python@2.7.0:2.7,3.5.0:3.5,3.6.1:3.8', when='@:5.14', type=('build', 'run'))
 
     depends_on('cmake@3.1:', type='build')
     depends_on('llvm@6:', type='build')
     depends_on('py-setuptools', type='build')
+    depends_on('py-packaging', type='build')
     depends_on('py-wheel', type='build')
-    depends_on('qt@5.11:+opengl', type=('build', 'run'))
+    # https://bugreports.qt.io/browse/PYSIDE-1385
+    depends_on('py-wheel@:0.34', when='@:5.14', type='build')
+    depends_on('qt@5.11:+opengl')
 
     depends_on('graphviz', when='+doc', type='build')
     depends_on('libxml2@2.6.32:', when='+doc', type='build')
@@ -47,6 +52,10 @@ class PyPyside2(PythonPackage):
         if self.run_tests:
             args.append('--build-tests')
         return args
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=' + prefix,
+               *self.install_options(spec, prefix))
 
     @run_after('install')
     def install_docs(self):


### PR DESCRIPTION
Fixes some build issues that I introduced in #27798. The pyside2 build system must be doing something hacky because `pip install .` doesn't work, only `python setup.py install`.

Other bugs I noticed: missing packaging dep, older versions only support older Python/wheel.

Unfortunately I still see the following build issue:
```
/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/qt-5.15.2-fmje75cmuy2k7rm6j3hzorzi7cpsowzc/include/QtGui/qopengl.h:141:13: fatal: 'GL/gl.h' file not found
```
However, earlier in the log I see:
```
-- GL Headers path:/u/stewart1/spack/opt/spack/linux-rhel8-zen/gcc-8.5.0/mesa-21.3.1-tipravmzsrv6ocqtytbdzlhj7ovoqild/include/GL/gl.h
```
I think this is a bug in their build system. Would report this but they don't use GitHub. Anyway, the package is better now that it was before, so I think this should be merged as is. Someone else can investigate the GL issue.