### PR TITLE
Fix build of libnetworkit/py-networkit

### DIFF
--- a/var/spack/repos/builtin/packages/libnetworkit/package.py
+++ b/var/spack/repos/builtin/packages/libnetworkit/package.py
@@ -33,6 +33,7 @@ class Libnetworkit(CMakePackage):
     variant('doc', default=False, description='Enables the build with sphinx documentation')
 
     depends_on('libtlx')
+    depends_on('llvm-openmp', when='%apple-clang')
     depends_on('py-sphinx', when='+doc', type='build')
 
     patch('0001-Name-agnostic-import-of-tlx-library.patch', when='@6.1:8.1')

--- a/var/spack/repos/builtin/packages/py-networkit/package.py
+++ b/var/spack/repos/builtin/packages/py-networkit/package.py
@@ -47,4 +47,4 @@ class PyNetworkit(PythonPackage):
 
     def install_options(self, spec, prefix):
         # Enable ext. core-library + parallel build
-        return ['--networkit-external-core', '-j{0}'.format(make_jobs)]
+        return ['-j{0}'.format(make_jobs)]


### PR DESCRIPTION
Fixes a couple of build issues I noticed:

1. libnetworkit requires OpenMP, but Apple Clang doesn't have OpenMP
2. I broke the `py-networkit` package in #27798

Before #27798, we ran:
```console
$ python setup.py build --networkit-external-core
$ python setup.py install ...
```
After #27798, we run `pip install .` which runs:
```console
$ python setup.py install --networkit-external-core ...
```
However, this flag is only valid for build, not for install. Removing this flag allows the build to succeed for me.

P.S. I noticed a build issue on RHEL 8 where the libnetworkit build fails to find tlx and crashes, not sure what is going on there.