### PR TITLE
py-numpy: remove install_options

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -342,20 +342,6 @@ class PyNumpy(PythonPackage):
 
         env.set('NPY_LAPACK_ORDER', lapack)
 
-    def install_options(self, spec, prefix):
-        args = []
-
-        # From NumPy 1.10.0 on it's possible to do a parallel build.
-        # https://numpy.org/devdocs/user/building.html#parallel-builds
-        if self.version >= Version('1.10.0'):
-            # But Parallel build in Python 3.5+ is broken.  See:
-            # https://github.com/spack/spack/issues/7927
-            # https://github.com/scipy/scipy/issues/7112
-            if spec['python'].version < Version('3.5'):
-                args = ['-j', str(make_jobs)]
-
-        return args
-
     @run_after('install')
     @on_package_attributes(run_tests=True)
     def install_test(self):


### PR DESCRIPTION
Fixes a bug I introduced in #27798, the `-j` flag is only valid for `python setup.py build`, not `python setup.py install`.