### PR TITLE
py-scipy: remove -j flag

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -105,14 +105,6 @@ class PyScipy(PythonPackage):
         args = []
         if spec.satisfies('%fj'):
             args.extend(['config_fc', '--fcompiler=fujitsu'])
-
-        # Build in parallel
-        # Known problems with Python 3.5+
-        # https://github.com/spack/spack/issues/7927
-        # https://github.com/scipy/scipy/issues/7112
-        if not spec.satisfies('^python@3.5:'):
-            args.extend(['-j', str(make_jobs)])
-
         return args
 
     @run_after('install')


### PR DESCRIPTION
Fixes a bug I introduced in #27798, the `-j` flag is only valid for `python setup.py build`, not `python setup.py install`.

@t-karatsu @tkameyama you may want to check that the Fujitsu stuff still works.