### PR TITLE
py-scs: fix CUDA build

### DIFF
--- a/var/spack/repos/builtin/packages/py-scs/package.py
+++ b/var/spack/repos/builtin/packages/py-scs/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class PyScs(PythonPackage):
+class PyScs(PythonPackage, CudaPackage):
     """SCS: splitting conic solver"""
 
     homepage = "https://github.com/cvxgrp/scs"
@@ -15,7 +15,6 @@ class PyScs(PythonPackage):
 
     version('2.1.1-2', sha256='f816cfe3d4b4cff3ac2b8b96588c5960ddd2a3dc946bda6b09db04e7bc6577f2')
 
-    variant('cuda', default=False, description="Also compile the GPU CUDA version of SCS")
     variant('float32', default=False, description="Use 32 bit (single precision) floats, default is 64 bit")
     variant('extra_verbose', default=False, description="Extra verbose SCS (for debugging)")
     variant('int32', default=False, description="Use 32 bit ints")


### PR DESCRIPTION
Package was missing a CUDA dependency. Successfully builds on RHEL 8.4 with GCC 8.5.0, CUDA 11.5, and Python 3.9.9.