### PR TITLE
py-sphinx: add v4.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-sphinx/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx/package.py
@@ -12,6 +12,8 @@ class PySphinx(PythonPackage):
     homepage = "https://www.sphinx-doc.org/en/master/"
     pypi = "Sphinx/Sphinx-3.2.0.tar.gz"
 
+    version('4.4.0', sha256='6caad9786055cb1fa22b4a365c1775816b876f91966481765d7d50e9f0dd35cc')
+    version('4.3.2', sha256='0a8836751a68306b3fe97ecbe44db786f8479c3bf4b80e3a7f5c838657b4698c')
     version('4.3.1', sha256='32a5b3e9a1b176cc25ed048557d4d3d01af635e6b76c5bc7a43b0a34447fbd45')
     version('4.1.2', sha256='3092d929cd807926d846018f2ace47ba2f3b671b309c7a89cd3306e80c826b13')
     version('4.1.1', sha256='23c846a1841af998cb736218539bb86d16f5eb95f5760b1966abcd2d584e62b8')
@@ -56,15 +58,17 @@ class PySphinx(PythonPackage):
     depends_on('py-jinja2@2.3:2', when='@:4.0.1', type=('build', 'run'))
     depends_on('py-pygments@2.0:', type=('build', 'run'))
     depends_on('py-docutils@0.14:0.17', when='@4:', type=('build', 'run'))
-    depends_on('py-docutils@0.12:', when='@:3', type=('build', 'run'))
+    depends_on('py-docutils@0.12:0.17', when='@:3', type=('build', 'run'))
     depends_on('py-snowballstemmer@1.1:', type=('build', 'run'))
     depends_on('py-babel@1.3:', type=('build', 'run'))
     depends_on('py-alabaster@0.7', type=('build', 'run'))
     depends_on('py-imagesize', when='@1.4:', type=('build', 'run'))
     depends_on('py-requests@2.5.0:', type=('build', 'run'))
-    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-setuptools', when='@:4.3', type=('build', 'run'))
+    depends_on('py-setuptools', when='@4.4:', type='build')
     depends_on('py-sphinx-rtd-theme@0.1:', when='@:1.3', type=('build', 'run'))
     depends_on('py-packaging', when='@1.7.4:', type=('build', 'run'))
+    depends_on('py-importlib-metadata@4.4:', when='@4.4: ^python@:3.9', type=('build', 'run'))
     depends_on('py-typing', when='@1.6.1', type=('build', 'run'))
     depends_on('py-typing', when='@1.6.2:^python@2.7:3.4', type=('build', 'run'))
     depends_on('py-colorama@0.3.5:', when='platform=windows', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds with Python 3.9.9 and GCC 8.5.0 on RHEL 8.4.