### PR TITLE
py-tomopy: add v1.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-tomopy/package.py
+++ b/var/spack/repos/builtin/packages/py-tomopy/package.py
@@ -16,7 +16,9 @@ class PyTomopy(PythonPackage):
     git      = 'https://github.com/tomopy/tomopy.git'
 
     version('master', branch='master')
-    version('1.10.4', sha256='2f15edda11b4337a1a5560684fcf8f28a35c5035932b22b842ce728bd13fba01')
+    version('1.11.0', sha256='4e5691c2b083753692ba4376ce301578037071c83fc61a6ae9e5bc9e6fcd3d1f')
+    # Never was an official 1.10.4 release, checksum doesn't match for some reason
+    version('1.10.4', sha256='2f15edda11b4337a1a5560684fcf8f28a35c5035932b22b842ce728bd13fba01', deprecated=True)
     version('1.0.0', sha256='ee45f7a062e5a66d6f18a904d2e204e48d85a1ce1464156f9e2f6353057dfe4c')
 
     # GPU accel needs PTL which is a git submodule. Thus, we can only build it on master
@@ -40,6 +42,7 @@ class PyTomopy(PythonPackage):
     depends_on('py-six', type=('build', 'run'))
     depends_on('py-pywavelets', type=('build', 'run'))
     depends_on('py-dxchange', type=('build', 'run'))
+    depends_on('py-numexpr', when='@1.11:', type=('build', 'run'))
 
     @when('@1.10:')
     def install_options(self, spec, prefix):


### PR DESCRIPTION
Successfully installs and passes all import tests on RHEL 8.4 with Python 3.8.12 and GCC 8.5.0.