### PR TITLE
Add a top-level `concretizer` config scope and `--fresh` option

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------------
+# This is the default spack configuration file.
+#
+# Settings here are versioned with Spack and are intended to provide
+# sensible defaults out of the box. Spack maintainers should edit this
+# file to keep it current.
+#
+# Users can override these settings by editing
+# `$SPACK_ROOT/etc/spack/concretizer.yaml`, `~/.spack/concretizer.yaml`,
+# or by adding a `concretizer:` section to an environment.
+# -------------------------------------------------------------------------
+concretizer:
+  # Whether to consider installed packages or packages from buildcaches when
+  # concretizing specs. If `true`, we'll try to use as many installs/binaries
+  # as possible, rather than building. If `false`, we'll always give you a fresh
+  # concretization.
+  reuse: false

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -155,14 +155,17 @@ config:
 
   # The concretization algorithm to use in Spack. Options are:
   #
-  #   'original': Spack's original greedy, fixed-point concretizer. This
-  #       algorithm can make decisions too early and will not backtrack
-  #       sufficiently for many specs.
-  #
   #   'clingo': Uses a logic solver under the hood to solve DAGs with full
   #       backtracking and optimization for user preferences. Spack will
   #       try to bootstrap the logic solver, if not already available.
   #
+  #   'original': Spack's original greedy, fixed-point concretizer. This
+  #       algorithm can make decisions too early and will not backtrack
+  #       sufficiently for many specs. This will soon be deprecated in
+  #       favor of clingo.
+  #
+  # See `concretizer.yaml` for more settings you can fine-tune when
+  # using clingo.
   concretizer: clingo
 
 

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -194,9 +194,9 @@ Reusing installed dependencies
 
 .. warning::
 
-   The ``--reuse`` option described here is experimental, and it will
-   likely be replaced with a different option and configuration settings
-   in the next Spack release.
+   The ``--reuse`` option described here will become the default installation
+   method in the next Spack version, and you will be able to get the current
+   behavior by using ``spack install --fresh``.
 
 By default, when you run ``spack install``, Spack tries to build a new
 version of the package you asked for, along with updated versions of
@@ -215,6 +215,9 @@ is not installed, but dependencies like ``hwloc`` and ``libfabric`` are,
 the ``mpich`` will be build with the installed versions, if possible.
 You can use the :ref:`spack spec -I <cmd-spack-spec>` command to see what
 will be reused and what will be built before you install.
+
+You can configure Spack to use the ``--reuse`` behavior by default in
+``concretizer.yaml``.
 
 .. _cmd-spack-uninstall:
 
@@ -1280,7 +1283,7 @@ Normally users don't have to bother specifying the architecture if they
 are installing software for their current host, as in that case the
 values will be detected automatically.  If you need fine-grained control
 over which packages use which targets (or over *all* packages' default
-target), see :ref:`concretization-preferences`.
+target), see :ref:`package-preferences`.
 
 .. admonition:: Cray machines
 

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -209,11 +209,49 @@ Specific limitations include:
   then Spack will not add a new external entry (``spack config blame packages``
   can help locate all external entries).
 
-.. _concretization-preferences:
+.. _concretizer-options:
 
---------------------------
-Concretization Preferences
---------------------------
+----------------------
+Concretizer options
+----------------------
+
+``packages.yaml`` gives the concretizer preferences for specific packages,
+but you can also use ``concretizer.yaml`` to customize aspects of the
+algorithm it uses to select the dependencies you install:
+
+.. _code-block: yaml
+
+   concretizer:
+     # Whether to consider installed packages or packages from buildcaches when
+     # concretizing specs. If `true`, we'll try to use as many installs/binaries
+     # as possible, rather than building. If `false`, we'll always give you a fresh
+     # concretization.
+     reuse: false
+
+^^^^^^^^^^^^^^^^
+``reuse``
+^^^^^^^^^^^^^^^^
+
+This controls whether Spack will prefer to use installed packages (``true``), or
+whether it will do a "fresh" installation and prefer the latest settings from
+``package.py`` files and ``packages.yaml`` (``false``). .
+
+You can use ``spack install --reuse`` to enable reuse for a single installation,
+and you can use ``spack install --fresh`` to do a fresh install if ``reuse`` is
+enabled by default.
+
+.. note::
+
+   ``reuse: false`` is the current default, but ``reuse: true`` will be the default
+   in the next Spack release. You will still be able to use ``spack install --fresh``
+   to get the old behavior.
+
+
+.. _package-preferences:
+
+-------------------
+Package Preferences
+-------------------
 
 Spack can be configured to prefer certain compilers, package
 versions, dependencies, and variants during concretization.
@@ -268,6 +306,7 @@ The syntax for the ``provider`` section differs slightly from other
 concretization rules.  A provider lists a value that packages may
 ``depend_on`` (e.g, MPI) and a list of rules for fulfilling that
 dependency.
+
 
 .. _package_permissions:
 

--- a/lib/spack/docs/build_systems/intelpackage.rst
+++ b/lib/spack/docs/build_systems/intelpackage.rst
@@ -649,7 +649,7 @@ follow `the next section <intel-install-libs_>`_ instead.
 
    * If you specified a custom variant (for example ``+vtune``) you may want to add this as your
      preferred variant in the packages configuration for the ``intel-parallel-studio`` package
-     as described in :ref:`concretization-preferences`. Otherwise you will have to specify
+     as described in :ref:`package-preferences`. Otherwise you will have to specify
      the variant everytime ``intel-parallel-studio`` is being used as ``mkl``, ``fftw`` or ``mpi``
      implementation to avoid pulling in a different variant.
 
@@ -811,13 +811,13 @@ by one of the following means:
      $ spack install libxc@3.0.0%intel
 
 
-* Alternatively, request Intel compilers implicitly by concretization preferences.
+* Alternatively, request Intel compilers implicitly by package preferences.
   Configure the order of compilers in the appropriate ``packages.yaml`` file,
   under either an ``all:`` or client-package-specific entry, in a
   ``compiler:`` list. Consult the Spack documentation for
   `Configuring Package Preferences <https://spack-tutorial.readthedocs.io/en/latest/tutorial_configuration.html#configuring-package-preferences>`_
   and
-  :ref:`Concretization Preferences <concretization-preferences>`.
+  :ref:`Package Preferences <package-preferences>`.
 
 Example: ``etc/spack/packages.yaml`` might simply contain:
 
@@ -867,7 +867,7 @@ virtual package, in order of decreasing preference.  To learn more about the
 ``providers:`` settings, see the Spack tutorial for
 `Configuring Package Preferences <https://spack-tutorial.readthedocs.io/en/latest/tutorial_configuration.html#configuring-package-preferences>`_
 and the section
-:ref:`Concretization Preferences <concretization-preferences>`.
+:ref:`Package Preferences <package-preferences>`.
 
 Example: The following fairly minimal example for ``packages.yaml`` shows how
 to exclusively use the standalone ``intel-mkl`` package for all the linear

--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -13,11 +13,15 @@ Spack has many configuration files.  Here is a quick list of them, in
 case you want to skip directly to specific docs:
 
 * :ref:`compilers.yaml <compiler-config>`
+* :ref:`concretizer.yaml <concretizer-options>`
 * :ref:`config.yaml <config-yaml>`
 * :ref:`mirrors.yaml <mirrors>`
 * :ref:`modules.yaml <modules>`
 * :ref:`packages.yaml <build-settings>`
 * :ref:`repos.yaml <repositories>`
+
+You can also add any of these as inline configuration in ``spack.yaml``
+in an :ref:`environment <environment-configuration>`.
 
 -----------
 YAML Format

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -2858,7 +2858,7 @@ be concretized on their system.  For example, one user may prefer packages
 built with OpenMPI and the Intel compiler.  Another user may prefer
 packages be built with MVAPICH and GCC.
 
-See the :ref:`concretization-preferences` section for more details.
+See the :ref:`package-preferences` section for more details.
 
 
 .. _group_when_spec:

--- a/lib/spack/spack/cmd/__init__.py
+++ b/lib/spack/spack/cmd/__init__.py
@@ -154,7 +154,6 @@ def parse_specs(args, **kwargs):
     concretize = kwargs.get('concretize', False)
     normalize = kwargs.get('normalize', False)
     tests = kwargs.get('tests', False)
-    reuse = kwargs.get('reuse', False)
 
     try:
         sargs = args
@@ -163,7 +162,7 @@ def parse_specs(args, **kwargs):
         specs = spack.spec.parse(sargs)
         for spec in specs:
             if concretize:
-                spec.concretize(tests=tests, reuse=reuse)  # implies normalize
+                spec.concretize(tests=tests)  # implies normalize
             elif normalize:
                 spec.normalize(tests=tests)
 

--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -322,11 +322,68 @@ the build yourself.  Format: %%Y%%m%%d-%%H%%M-[cdash-track]"""
     )
 
 
-@arg
-def reuse():
-    return Args(
-        '--reuse', action='store_true', default=False,
-        help='reuse installed dependencies'
+class ConfigSetAction(argparse.Action):
+    """Generic action for setting spack config options from CLI.
+
+    This works like a ``store_const`` action but you can set the
+    ``dest`` to some Spack configuration path (like ``concretizer:reuse``)
+    and the ``const`` will be stored there using ``spack.config.set()``
+    """
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 const,
+                 default=None,
+                 required=False,
+                 help=None,
+                 metavar=None):
+        # save the config option we're supposed to set
+        self.config_path = dest
+
+        # destination is translated to a legal python identifier by
+        # substituting '_' for ':'.
+        dest = dest.replace(":", "_")
+
+        super(ConfigSetAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=0,
+            const=const,
+            default=default,
+            required=required,
+            help=help
+        )
+
+    def __call__(self, parser, namespace, values, option_string):
+        # Retrieve the name of the config option and set it to
+        # the const from the constructor or a value from the CLI.
+        # Note that this is only called if the argument is actually
+        # specified on the command line.
+        spack.config.set(self.config_path, self.const, scope="command_line")
+
+
+def add_concretizer_args(subparser):
+    """Add a subgroup of arguments for controlling concretization.
+
+    These will appear in a separate group called 'concretizer arguments'.
+    There's no need to handle them in your command logic -- they all use
+    ``ConfigSetAction``, which automatically handles setting configuration
+    options.
+
+    If you *do* need to access a value passed on the command line, you can
+    get at, e.g., the ``concretizer:reuse`` via ``args.concretizer_reuse``.
+    Just substitute ``_`` for ``:``.
+    """
+    subgroup = subparser.add_argument_group("concretizer arguments")
+    subgroup.add_argument(
+        '-U', '--fresh', action=ConfigSetAction, dest="concretizer:reuse",
+        const=False, default=None,
+        help='do not reuse installed deps; build newest configuration'
+    )
+    subgroup.add_argument(
+        '--reuse', action=ConfigSetAction, dest="concretizer:reuse",
+        const=True, default=None,
+        help='reuse installed dependencies/buildcaches when possible'
     )
 
 

--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -13,7 +13,6 @@ level = "long"
 
 
 def setup_parser(subparser):
-    spack.cmd.common.arguments.add_common_arguments(subparser, ['reuse'])
     subparser.add_argument(
         '-f', '--force', action='store_true',
         help="Re-concretize even if already concretized.")
@@ -23,6 +22,8 @@ def setup_parser(subparser):
         help="""Concretize with test dependencies. When 'root' is chosen, test
 dependencies are only added for the environment's root specs. When 'all' is
 chosen, test dependencies are enabled for all packages in the environment.""")
+
+    spack.cmd.common.arguments.add_concretizer_args(subparser)
 
 
 def concretize(parser, args):
@@ -36,8 +37,6 @@ def concretize(parser, args):
         tests = False
 
     with env.write_transaction():
-        concretized_specs = env.concretize(
-            force=args.force, tests=tests, reuse=args.reuse
-        )
+        concretized_specs = env.concretize(force=args.force, tests=tests)
         ev.display_specs(concretized_specs)
         env.write()

--- a/lib/spack/spack/cmd/dev_build.py
+++ b/lib/spack/spack/cmd/dev_build.py
@@ -19,7 +19,7 @@ level = "long"
 
 
 def setup_parser(subparser):
-    arguments.add_common_arguments(subparser, ['jobs', 'reuse'])
+    arguments.add_common_arguments(subparser, ['jobs'])
     subparser.add_argument(
         '-d', '--source-path', dest='source_path', default=None,
         help="path to source directory. defaults to the current directory")
@@ -59,6 +59,8 @@ packages. If neither are chosen, don't run tests for any packages.""")
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
 
+    spack.cmd.common.arguments.add_concretizer_args(subparser)
+
 
 def dev_build(self, args):
     if not args.spec:
@@ -86,7 +88,7 @@ def dev_build(self, args):
     # Forces the build to run out of the source directory.
     spec.constrain('dev_path=%s' % source_path)
 
-    spec.concretize(reuse=args.reuse)
+    spec.concretize()
     package = spack.repo.get(spec)
 
     if package.installed:

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -78,7 +78,7 @@ the dependencies"""
     subparser.add_argument(
         '-u', '--until', type=str, dest='until', default=None,
         help="phase to stop after when installing (default None)")
-    arguments.add_common_arguments(subparser, ['jobs', 'reuse'])
+    arguments.add_common_arguments(subparser, ['jobs'])
     subparser.add_argument(
         '--overwrite', action='store_true',
         help="reinstall an existing spec, even if it has dependents")
@@ -181,6 +181,8 @@ packages. If neither are chosen, don't run tests for any packages."""
     )
     arguments.add_cdash_args(subparser, False)
     arguments.add_common_arguments(subparser, ['yes_to_all', 'spec'])
+
+    spack.cmd.common.arguments.add_concretizer_args(subparser)
 
 
 def default_log_file(spec):
@@ -339,7 +341,7 @@ environment variables:
 
             if not args.only_concrete:
                 with env.write_transaction():
-                    concretized_specs = env.concretize(tests=tests, reuse=args.reuse)
+                    concretized_specs = env.concretize(tests=tests)
                     ev.display_specs(concretized_specs)
 
                     # save view regeneration for later, so that we only do it
@@ -397,9 +399,7 @@ environment variables:
     kwargs['tests'] = tests
 
     try:
-        specs = spack.cmd.parse_specs(
-            args.spec, concretize=True, tests=tests, reuse=args.reuse
-        )
+        specs = spack.cmd.parse_specs(args.spec, concretize=True, tests=tests)
     except SpackError as e:
         tty.debug(e)
         reporter.concretization_report(e.message)

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -44,7 +44,7 @@ def setup_parser(subparser):
 
     # Below are arguments w.r.t. spec display (like spack spec)
     arguments.add_common_arguments(
-        subparser, ['long', 'very_long', 'install_status', 'reuse']
+        subparser, ['long', 'very_long', 'install_status']
     )
     subparser.add_argument(
         '-y', '--yaml', action='store_const', dest='format', default=None,
@@ -70,6 +70,8 @@ def setup_parser(subparser):
         help='print out statistics from clingo')
     subparser.add_argument(
         'specs', nargs=argparse.REMAINDER, help="specs of packages")
+
+    spack.cmd.common.arguments.add_concretizer_args(subparser)
 
 
 def solve(parser, args):
@@ -104,7 +106,6 @@ def solve(parser, args):
 
     # set up solver parameters
     solver = asp.Solver()
-    solver.reuse = args.reuse
     solver.dump = dump
     solver.models = models
     solver.timers = args.timers

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -88,11 +88,11 @@ def solve(parser, args):
         'hashes': args.long or args.very_long
     }
 
-    # process dump options
-    dump = re.split(r'\s*,\s*', args.show)
-    if 'all' in dump:
-        dump = show_options
-    for d in dump:
+    # process output options
+    show = re.split(r'\s*,\s*', args.show)
+    if 'all' in show:
+        show = show_options
+    for d in show:
         if d not in show_options:
             raise ValueError(
                 "Invalid option for '--show': '%s'\nchoose from: (%s)"
@@ -105,23 +105,28 @@ def solve(parser, args):
     specs = spack.cmd.parse_specs(args.specs)
 
     # set up solver parameters
+    # Note: reuse and other concretizer prefs are passed as configuration
     solver = asp.Solver()
-    solver.dump = dump
-    solver.models = models
-    solver.timers = args.timers
-    solver.stats = args.stats
-
-    result = solver.solve(specs)
-    if 'solutions' not in dump:
+    output = sys.stdout if "asp" in show else None
+    result = solver.solve(
+        specs,
+        out=output,
+        models=models,
+        timers=args.timers,
+        stats=args.stats,
+        setup_only=(set(show) == {'asp'})
+    )
+    if 'solutions' not in show:
         return
 
     # die if no solution was found
     result.raise_if_unsat()
 
-    # dump the solutions as concretized specs
-    if 'solutions' in dump:
+    # show the solutions as concretized specs
+    if 'solutions' in show:
         opt, _, _ = min(result.answers)
-        if ("opt" in dump) and (not args.format):
+
+        if ("opt" in show) and (not args.format):
             tty.msg("Best of %d considered solutions." % result.nmodels)
             tty.msg("Optimization Criteria:")
 

--- a/lib/spack/spack/cmd/solve.py
+++ b/lib/spack/spack/cmd/solve.py
@@ -102,11 +102,15 @@ def solve(parser, args):
 
     specs = spack.cmd.parse_specs(args.specs)
 
-    # dump generated ASP program
-    result = asp.solve(
-        specs, dump=dump, models=models, timers=args.timers, stats=args.stats,
-        reuse=args.reuse,
-    )
+    # set up solver parameters
+    solver = asp.Solver()
+    solver.reuse = args.reuse
+    solver.dump = dump
+    solver.models = models
+    solver.timers = args.timers
+    solver.stats = args.stats
+
+    result = solver.solve(specs)
     if 'solutions' not in dump:
         return
 

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -32,7 +32,7 @@ for further documentation regarding the spec syntax, see:
     spack help --spec
 """
     arguments.add_common_arguments(
-        subparser, ['long', 'very_long', 'install_status', 'reuse']
+        subparser, ['long', 'very_long', 'install_status']
     )
     subparser.add_argument(
         '-y', '--yaml', action='store_const', dest='format', default=None,
@@ -55,6 +55,8 @@ for further documentation regarding the spec syntax, see:
         '-t', '--types', action='store_true', default=False,
         help='show dependency types')
     arguments.add_common_arguments(subparser, ['specs'])
+
+    spack.cmd.common.arguments.add_concretizer_args(subparser)
 
 
 @contextlib.contextmanager
@@ -83,21 +85,17 @@ def spec(parser, args):
     if args.install_status:
         tree_context = spack.store.db.read_transaction
 
-    concretize_kwargs = {
-        'reuse': args.reuse
-    }
-
     # Use command line specified specs, otherwise try to use environment specs.
     if args.specs:
         input_specs = spack.cmd.parse_specs(args.specs)
-        specs = [(s, s.concretized(**concretize_kwargs)) for s in input_specs]
+        specs = [(s, s.concretized()) for s in input_specs]
     else:
         env = ev.active_environment()
         if env:
-            env.concretize(**concretize_kwargs)
+            env.concretize()
             specs = env.concretized_specs()
         else:
-            tty.die("spack spec requires at least one spec or an active environmnt")
+            tty.die("spack spec requires at least one spec or an active environment")
 
     for (input, output) in specs:
         # With -y, just print YAML to output.

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -751,7 +751,6 @@ def _concretize_specs_together_new(*abstract_specs, **kwargs):
 
     solver = spack.solver.asp.Solver()
     solver.tests = kwargs.get('tests', False)
-    solver.reuse = kwargs.get('reuse', False)
 
     result = solver.solve(abstract_specs)
     result.raise_if_unsat()
@@ -789,15 +788,10 @@ def _concretize_specs_together_original(*abstract_specs, **kwargs):
     abstract_specs = [spack.spec.Spec(s) for s in abstract_specs]
     concretization_repository = make_concretization_repository(abstract_specs)
 
-    concretization_kwargs = {
-        'tests': kwargs.get('tests', False),
-        'reuse': kwargs.get('reuse', False)
-    }
-
     with spack.repo.additional_repository(concretization_repository):
         # Spec from a helper package that depends on all the abstract_specs
         concretization_root = spack.spec.Spec('concretizationroot')
-        concretization_root.concretize(**concretization_kwargs)
+        concretization_root.concretize(tests=kwargs.get("tests", False))
         # Retrieve the direct dependencies
         concrete_specs = [
             concretization_root[spec.name].copy() for spec in abstract_specs

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -748,11 +748,12 @@ def concretize_specs_together(*abstract_specs, **kwargs):
 
 def _concretize_specs_together_new(*abstract_specs, **kwargs):
     import spack.solver.asp
-    concretization_kwargs = {
-        'tests': kwargs.get('tests', False),
-        'reuse': kwargs.get('reuse', False)
-    }
-    result = spack.solver.asp.solve(abstract_specs, **concretization_kwargs)
+
+    solver = spack.solver.asp.Solver()
+    solver.tests = kwargs.get('tests', False)
+    solver.reuse = kwargs.get('reuse', False)
+
+    result = solver.solve(abstract_specs)
     result.raise_if_unsat()
     return [s.copy() for s in result.specs]
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -53,6 +53,7 @@ import spack.platforms
 import spack.schema
 import spack.schema.bootstrap
 import spack.schema.compilers
+import spack.schema.concretizer
 import spack.schema.config
 import spack.schema.env
 import spack.schema.mirrors
@@ -69,6 +70,7 @@ from spack.util.cpus import cpus_available
 #: Dict from section names -> schema for that section
 section_schemas = {
     'compilers': spack.schema.compilers.schema,
+    'concretizer': spack.schema.concretizer.schema,
     'mirrors': spack.schema.mirrors.schema,
     'repos': spack.schema.repos.schema,
     'packages': spack.schema.packages.schema,
@@ -101,7 +103,7 @@ config_defaults = {
         'dirty': False,
         'build_jobs': min(16, cpus_available()),
         'build_stage': '$tempdir/spack-stage',
-        'concretizer': 'original',
+        'concretizer': 'clingo',
     }
 }
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1083,7 +1083,7 @@ class Environment(object):
         """Returns true when the spec is built from local sources"""
         return spec.name in self.dev_specs
 
-    def concretize(self, force=False, tests=False, reuse=False):
+    def concretize(self, force=False, tests=False, reuse=None):
         """Concretize user_specs in this environment.
 
         Only concretizes specs that haven't been concretized yet unless
@@ -1120,7 +1120,7 @@ class Environment(object):
         msg = 'concretization strategy not implemented [{0}]'
         raise SpackEnvironmentError(msg.format(self.concretization))
 
-    def _concretize_together(self, tests=False, reuse=False):
+    def _concretize_together(self, tests=False, reuse=None):
         """Concretization strategy that concretizes all the specs
         in the same DAG.
         """
@@ -1160,7 +1160,7 @@ class Environment(object):
             self._add_concrete_spec(abstract, concrete)
         return concretized_specs
 
-    def _concretize_separately(self, tests=False, reuse=False):
+    def _concretize_separately(self, tests=False, reuse=None):
         """Concretization strategy that concretizes separately one
         user spec after the other.
         """
@@ -2009,7 +2009,7 @@ def display_specs(concretized_specs):
         print('')
 
 
-def _concretize_from_constraints(spec_constraints, tests=False, reuse=False):
+def _concretize_from_constraints(spec_constraints, tests=False, reuse=None):
     # Accept only valid constraints from list and concretize spec
     # Get the named spec even if out of order
     root_spec = [s for s in spec_constraints if s.name]

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1083,7 +1083,7 @@ class Environment(object):
         """Returns true when the spec is built from local sources"""
         return spec.name in self.dev_specs
 
-    def concretize(self, force=False, tests=False, reuse=None):
+    def concretize(self, force=False, tests=False):
         """Concretize user_specs in this environment.
 
         Only concretizes specs that haven't been concretized yet unless
@@ -1097,8 +1097,6 @@ class Environment(object):
                already concretized
             tests (bool or list or set): False to run no tests, True to test
                 all packages, or a list of package names to run tests for some
-            reuse (bool): if True try to maximize reuse of already installed
-                specs, if False don't account for installation status.
 
         Returns:
             List of specs that have been concretized. Each entry is a tuple of
@@ -1112,15 +1110,15 @@ class Environment(object):
 
         # Pick the right concretization strategy
         if self.concretization == 'together':
-            return self._concretize_together(tests=tests, reuse=reuse)
+            return self._concretize_together(tests=tests)
 
         if self.concretization == 'separately':
-            return self._concretize_separately(tests=tests, reuse=reuse)
+            return self._concretize_separately(tests=tests)
 
         msg = 'concretization strategy not implemented [{0}]'
         raise SpackEnvironmentError(msg.format(self.concretization))
 
-    def _concretize_together(self, tests=False, reuse=None):
+    def _concretize_together(self, tests=False):
         """Concretization strategy that concretizes all the specs
         in the same DAG.
         """
@@ -1153,14 +1151,14 @@ class Environment(object):
         self.specs_by_hash = {}
 
         concrete_specs = spack.concretize.concretize_specs_together(
-            *self.user_specs, tests=tests, reuse=reuse
+            *self.user_specs, tests=tests
         )
         concretized_specs = [x for x in zip(self.user_specs, concrete_specs)]
         for abstract, concrete in concretized_specs:
             self._add_concrete_spec(abstract, concrete)
         return concretized_specs
 
-    def _concretize_separately(self, tests=False, reuse=None):
+    def _concretize_separately(self, tests=False):
         """Concretization strategy that concretizes separately one
         user spec after the other.
         """
@@ -1185,7 +1183,7 @@ class Environment(object):
         ):
             if uspec not in old_concretized_user_specs:
                 root_specs.append(uspec)
-                arguments.append((uspec_constraints, tests, reuse))
+                arguments.append((uspec_constraints, tests))
 
         # Ensure we don't try to bootstrap clingo in parallel
         if spack.config.get('config:concretizer') == 'clingo':
@@ -2009,7 +2007,7 @@ def display_specs(concretized_specs):
         print('')
 
 
-def _concretize_from_constraints(spec_constraints, tests=False, reuse=None):
+def _concretize_from_constraints(spec_constraints, tests=False):
     # Accept only valid constraints from list and concretize spec
     # Get the named spec even if out of order
     root_spec = [s for s in spec_constraints if s.name]
@@ -2028,7 +2026,7 @@ def _concretize_from_constraints(spec_constraints, tests=False, reuse=None):
             if c not in invalid_constraints:
                 s.constrain(c)
         try:
-            return s.concretized(tests=tests, reuse=reuse)
+            return s.concretized(tests=tests)
         except spack.spec.InvalidDependencyError as e:
             invalid_deps_string = ['^' + d for d in e.invalid_deps]
             invalid_deps = [c for c in spec_constraints
@@ -2048,9 +2046,9 @@ def _concretize_from_constraints(spec_constraints, tests=False, reuse=None):
 
 
 def _concretize_task(packed_arguments):
-    spec_constraints, tests, reuse = packed_arguments
+    spec_constraints, tests = packed_arguments
     with tty.SuppressOutput(msg_enabled=False):
-        return _concretize_from_constraints(spec_constraints, tests, reuse)
+        return _concretize_from_constraints(spec_constraints, tests)
 
 
 def make_repo_path(root):

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+"""Schema for concretizer.yaml configuration file.
+
+.. literalinclude:: _spack_root/lib/spack/spack/schema/concretizer.py
+   :lines: 13-
+"""
+
+properties = {
+    'concretizer': {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'reuse': {'type': 'boolean'},
+        }
+    }
+}
+
+
+#: Full schema with metadata
+schema = {
+    '$schema': 'http://json-schema.org/draft-07/schema#',
+    'title': 'Spack concretizer configuration file schema',
+    'type': 'object',
+    'additionalProperties': False,
+    'properties': properties,
+}

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2060,7 +2060,11 @@ class Solver(object):
         self.set_default_configuration()
 
     def set_default_configuration(self):
-        self.reuse = False
+        # These properties are settable via spack configuration. `None`
+        # means go with the configuration setting; user can override.
+        self.reuse = None
+
+        # these are concretizer settings
         self.dump = ()
         self.models = 0
         self.timers = False
@@ -2078,6 +2082,9 @@ class Solver(object):
                 if s.virtual:
                     continue
                 spack.spec.Spec.ensure_valid_variants(s)
+
+        if self.reuse is None:
+            self.reuse = spack.config.get("concretizer:reuse", False)
 
         setup = SpackSolverSetup(reuse=self.reuse, tests=self.tests)
         return driver.solve(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2615,7 +2615,11 @@ class Spec(object):
         if self._concrete:
             return
 
-        result = spack.solver.asp.solve([self], tests=tests, reuse=reuse)
+        solver = spack.solver.asp.Solver()
+        solver.reuse = reuse
+        solver.tests = tests
+
+        result = solver.solve([self])
         result.raise_if_unsat()
 
         # take the best answer

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2605,7 +2605,7 @@ class Spec(object):
             msg += "    For each package listed, choose another spec\n"
             raise SpecDeprecatedError(msg)
 
-    def _new_concretize(self, tests=False, reuse=None):
+    def _new_concretize(self, tests=False):
         import spack.solver.asp
 
         if not self.name:
@@ -2616,10 +2616,7 @@ class Spec(object):
             return
 
         solver = spack.solver.asp.Solver()
-        solver.reuse = reuse
-        solver.tests = tests
-
-        result = solver.solve([self])
+        result = solver.solve([self], tests=tests)
         result.raise_if_unsat()
 
         # take the best answer
@@ -2637,23 +2634,17 @@ class Spec(object):
         self._dup(concretized)
         self._mark_concrete()
 
-    def concretize(self, tests=False, reuse=None):
+    def concretize(self, tests=False):
         """Concretize the current spec.
 
         Args:
             tests (bool or list): if False disregard 'test' dependencies,
                 if a list of names activate them for the packages in the list,
                 if True activate 'test' dependencies for all packages.
-            reuse (bool): if True try to maximize reuse of already installed
-                specs, if False don't account for installation status.
         """
         if spack.config.get('config:concretizer') == "clingo":
-            self._new_concretize(tests, reuse=reuse)
+            self._new_concretize(tests)
         else:
-            if reuse:
-                msg = ('maximizing reuse of installed specs is not '
-                       'possible with the original concretizer')
-                raise spack.error.SpecError(msg)
             self._old_concretize(tests)
 
     def _mark_root_concrete(self, value=True):
@@ -2678,7 +2669,7 @@ class Spec(object):
                 s.clear_cached_hashes()
             s._mark_root_concrete(value)
 
-    def concretized(self, tests=False, reuse=None):
+    def concretized(self, tests=False):
         """This is a non-destructive version of concretize().
 
         First clones, then returns a concrete version of this package
@@ -2688,11 +2679,9 @@ class Spec(object):
             tests (bool or list): if False disregard 'test' dependencies,
                 if a list of names activate them for the packages in the list,
                 if True activate 'test' dependencies for all packages.
-            reuse (bool): if True try to maximize reuse of already installed
-                specs, if False don't account for installation status.
         """
         clone = self.copy(caches=True)
-        clone.concretize(tests=tests, reuse=reuse)
+        clone.concretize(tests=tests)
         return clone
 
     def flat_dependencies(self, **kwargs):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2605,7 +2605,7 @@ class Spec(object):
             msg += "    For each package listed, choose another spec\n"
             raise SpecDeprecatedError(msg)
 
-    def _new_concretize(self, tests=False, reuse=False):
+    def _new_concretize(self, tests=False, reuse=None):
         import spack.solver.asp
 
         if not self.name:
@@ -2637,7 +2637,7 @@ class Spec(object):
         self._dup(concretized)
         self._mark_concrete()
 
-    def concretize(self, tests=False, reuse=False):
+    def concretize(self, tests=False, reuse=None):
         """Concretize the current spec.
 
         Args:
@@ -2678,7 +2678,7 @@ class Spec(object):
                 s.clear_cached_hashes()
             s._mark_root_concrete(value)
 
-    def concretized(self, tests=False, reuse=False):
+    def concretized(self, tests=False, reuse=None):
         """This is a non-destructive version of concretize().
 
         First clones, then returns a concrete version of this package

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -103,16 +103,8 @@ def test_bootstrap_search_for_compilers_with_environment_active(
 
 @pytest.mark.regression('26189')
 def test_config_yaml_is_preserved_during_bootstrap(mutable_config):
-    # Mock the command line scope
     expected_dir = '/tmp/test'
-    internal_scope = spack.config.InternalConfigScope(
-        name='command_line', data={
-            'config': {
-                'test_stage': expected_dir
-            }
-        }
-    )
-    spack.config.config.push_scope(internal_scope)
+    spack.config.set("config:test_stage", expected_dir, scope="command_line")
 
     assert spack.config.get('config:test_stage') == expected_dir
     with spack.bootstrap.ensure_bootstrap_configuration():

--- a/lib/spack/spack/test/cmd/common/arguments.py
+++ b/lib/spack/spack/test/cmd/common/arguments.py
@@ -11,6 +11,7 @@ import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.config
 import spack.environment as ev
+import spack.main
 
 
 @pytest.fixture()
@@ -112,3 +113,18 @@ def test_root_and_dep_match_returns_root(mock_packages, mutable_mock_env_path):
         env_spec2 = spack.cmd.matching_spec_from_env(
             spack.cmd.parse_specs(['b@1.0'])[0])
         assert env_spec2
+
+
+def test_concretizer_arguments(mutable_config, mock_packages):
+    """Ensure that ConfigSetAction is doing the right thing."""
+    spec = spack.main.SpackCommand("spec")
+
+    assert spack.config.get("concretizer:reuse", None) is None
+
+    spec("--reuse", "zlib")
+
+    assert spack.config.get("concretizer:reuse", None) is True
+
+    spec("--fresh", "zlib")
+
+    assert spack.config.get("concretizer:reuse", None) is False

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1345,7 +1345,7 @@ class TestConcretize(object):
         ('mpich~debug', True)
     ])
     def test_concrete_specs_are_not_modified_on_reuse(
-            self, mutable_database, spec_str, expect_installed
+            self, mutable_database, spec_str, expect_installed, config
     ):
         if spack.config.get('config:concretizer') == 'original':
             pytest.skip('Original concretizer cannot reuse specs')
@@ -1354,7 +1354,8 @@ class TestConcretize(object):
         # when reused specs are added to the mix. This prevents things
         # like additional constraints being added to concrete specs in
         # the answer set produced by clingo.
-        s = spack.spec.Spec(spec_str).concretized(reuse=True)
+        with spack.config.override("concretizer:reuse", True):
+            s = spack.spec.Spec(spec_str).concretized()
         assert s.package.installed is expect_installed
         assert s.satisfies(spec_str, strict=True)
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -612,19 +612,23 @@ def configuration_dir(tmpdir_factory, linux_os):
     shutil.rmtree(str(tmpdir))
 
 
+def _create_mock_configuration_scopes(configuration_dir):
+    """Create the configuration scopes used in `config` and `mutable_config`."""
+    scopes = [
+        spack.config.InternalConfigScope('_builtin', spack.config.config_defaults),
+    ]
+    scopes += [
+        spack.config.ConfigScope(name, str(configuration_dir.join(name)))
+        for name in ['site', 'system', 'user']
+    ]
+    scopes += [spack.config.InternalConfigScope('command_line')]
+    return scopes
+
+
 @pytest.fixture(scope='session')
 def mock_configuration_scopes(configuration_dir):
     """Create a persistent Configuration object from the configuration_dir."""
-    defaults = spack.config.InternalConfigScope(
-        '_builtin', spack.config.config_defaults
-    )
-    test_scopes = [defaults]
-    test_scopes += [
-        spack.config.ConfigScope(name, str(configuration_dir.join(name)))
-        for name in ['site', 'system', 'user']]
-    test_scopes.append(spack.config.InternalConfigScope('command_line'))
-
-    yield test_scopes
+    yield _create_mock_configuration_scopes(configuration_dir)
 
 
 @pytest.fixture(scope='function')
@@ -640,9 +644,7 @@ def mutable_config(tmpdir_factory, configuration_dir):
     mutable_dir = tmpdir_factory.mktemp('mutable_config').join('tmp')
     configuration_dir.copy(mutable_dir)
 
-    scopes = [spack.config.ConfigScope(name, str(mutable_dir.join(name)))
-              for name in ['site', 'system', 'user']]
-
+    scopes = _create_mock_configuration_scopes(mutable_dir)
     with spack.config.use_configuration(*scopes) as cfg:
         yield cfg
 
@@ -662,6 +664,8 @@ def mutable_empty_config(tmpdir_factory, configuration_dir):
 def no_compilers_yaml(mutable_config):
     """Creates a temporary configuration without compilers.yaml"""
     for scope, local_config in mutable_config.scopes.items():
+        if not local_config.path:  # skip internal scopes
+            continue
         compilers_yaml = os.path.join(local_config.path, 'compilers.yaml')
         if os.path.exists(compilers_yaml):
             os.remove(compilers_yaml)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -709,7 +709,7 @@ _spack_compilers() {
 }
 
 _spack_concretize() {
-    SPACK_COMPREPLY="-h --help --reuse -f --force --test"
+    SPACK_COMPREPLY="-h --help -f --force --test -U --fresh --reuse"
 }
 
 _spack_config() {
@@ -870,7 +870,7 @@ _spack_deprecate() {
 _spack_dev_build() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -j --jobs --reuse -d --source-path -i --ignore-dependencies -n --no-checksum --deprecated --keep-prefix --skip-patch -q --quiet --drop-in --test -b --before -u --until --clean --dirty"
+        SPACK_COMPREPLY="-h --help -j --jobs -d --source-path -i --ignore-dependencies -n --no-checksum --deprecated --keep-prefix --skip-patch -q --quiet --drop-in --test -b --before -u --until --clean --dirty -U --fresh --reuse"
     else
         _all_packages
     fi
@@ -1166,7 +1166,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --reuse --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-save-local --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-save-local --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all -U --fresh --reuse"
     else
         _all_packages
     fi
@@ -1652,7 +1652,7 @@ _spack_restage() {
 _spack_solve() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --show --models -l --long -L --very-long -I --install-status --reuse -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats"
+        SPACK_COMPREPLY="-h --help --show --models -l --long -L --very-long -I --install-status -y --yaml -j --json -c --cover -N --namespaces -t --types --timers --stats -U --fresh --reuse"
     else
         _all_packages
     fi
@@ -1661,7 +1661,7 @@ _spack_solve() {
 _spack_spec() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help -l --long -L --very-long -I --install-status --reuse -y --yaml -j --json -c --cover -N --namespaces --hash-type -t --types"
+        SPACK_COMPREPLY="-h --help -l --long -L --very-long -I --install-status -y --yaml -j --json -c --cover -N --namespaces --hash-type -t --types -U --fresh --reuse"
     else
         _all_packages
     fi


### PR DESCRIPTION
We want to make `--reuse` the default concretization strategy, but to do that we need to have some configuration so that users can revert if they need to.  Also, the concretizer is going to grow to have many more options, and we really need some structured place to specify them.

We currently have a couple places where concretizer options are specified (aside from the preferences in `packages.yaml`):
1. The `config:concretizer` option. This chooses the solver (`clingo` or `original`).
2. The `concretization` option in environments. This is not a top-level config section -- it's just for environments.

Extending either of these is awkward -- both are simple strings and we'd need to deprecate (or work around) the old config options to expand them into more extensive YAML options.  Also, we'd eventually like to have one place where concretizer configuration is specified.

To avoid overlapping with either of these and to allow the most extensibility in the future, this adds a new `concretizer` config section that can be used in and outside of environments. There are two options right now: `reuse` and `minimal`.  This can expand later.  My expectation is that we will soon deprecate `config:concretizer` and warn when the user doesn't use `clingo`, and we will eventually (sometime later) move the `together` / `separately` options from `concretization` into the top-level `concretizer` section.

`concretizer.yaml` currently looks like this:

```yaml
concretizer:
  # Whether to consider installed packages or packages from buildcaches when
  # concretizing specs. If `true`, we'll try to use as many installs/binaries
  # as possible, rather than building. If `false`, we'll always give you a fresh
  # concretization.
  reuse: false
```

Stay tuned for additional options like `--minimal`.

And there are *two* options on `spack install`, `spack spec`, etc.:

```
concretizer arguments:
  --fresh               do not reuse installed deps; build newest configuration
  --reuse               reuse installed dependencies/buildcaches when possible
```

`--fresh` is there for when we make `--reuse` the default.  I could not think of a more intuitive way to express what Spack's default install routine, but here is the rationale -- see if you like it:

1. Most package managers would call Spack's current default an "upgrade" install -- it prefers the latest versions.  However, it's more than that -- it looks at whatever preferences you've set up, and it may change variants and things based on what's in the repo.  So `--upgrade` didn't fully capture it (you might be "side-grading" or just re-concretizing).
2. The default install tends to create new builds.  I thought about `--new` for "new installation", but it might also reuse if there's a hash match, so `--new` didn't seem completely right.
3. People who do not like `--reuse`  -- e.g., people with CI use cases or nix/guix purists -- would call the default Spack install "deterministic", because it doesn't consider installation state.  It's reproducible for the same spack version and packages.  `--deterministic` and `--reproducible` seem too technical.

So I settled on `--fresh`, because I think it captures what we're doing -- making a fresh install from the latest packages.  It also gives us a term we can use pretty easily.

When we make `--reuse` the default, it'll make more sense, as Spack will tend to reuse what you already have, and you may want to start with a completely `--fresh` install once those installations become too old.

There are a few additional technical refactors in here to make this stuff easier; the details of those are in the commit messages.

- [x] refactor `spack.solver.asp.solve()` into a class
- [x] add a `concretizer` config section and default `concretizer.yaml`
- [x] fix up how we handle mock configuration in `conftest.py`
- [x] introduce a `ConfigSetAction` to automatically set config options with `argparse`
- [x] introduce `add_concretizer_args()` method to make concretizer arg handling consistent across commands
- [x] rework call chain from commands -> solver to reduce the number of arguments and rely on config
- [x] introduce `--fresh` concretizer arg
- [x] docs