### PR TITLE
petsc: Add libspqr.so to list of suite-sparse libraries

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -425,7 +425,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 ('superlu-dist', 'superlu_dist', True, True),
                 ('scotch', 'ptscotch', True, True),
                 ('suite-sparse:umfpack,klu,cholmod,btf,ccolamd,colamd,camd,amd, \
-                suitesparseconfig', 'suitesparse', True, True),
+                suitesparseconfig,spqr', 'suitesparse', True, True),
                 ('hdf5:hl,fortran', 'hdf5', True, True),
                 'zlib',
                 'mumps',


### PR DESCRIPTION
Should fix  #28477