### PR TITLE
Use mesa package for the rocm recipes

### DIFF
--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -42,7 +42,7 @@ class HipRocclr(CMakePackage):
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
-    depends_on('mesa18~llvm@18.3: swr=none', type='link')
+    depends_on('mesa~llvm@21: swr=none', type='link')
     depends_on('libelf', type='link', when="@3.7.0:3.8.0")
     depends_on('numactl', type='link', when="@3.7.0:")
 

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -37,7 +37,7 @@ class Hip(CMakePackage):
 
     depends_on('cmake@3:', type='build')
     depends_on('perl@5.10:', type=('build', 'run'))
-    depends_on('mesa18~llvm@18.3:')
+    depends_on('mesa~llvm@21:')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1']:

--- a/var/spack/repos/builtin/packages/rocm-opencl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-opencl/package.py
@@ -38,7 +38,7 @@ class RocmOpencl(CMakePackage):
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
-    depends_on('mesa18~llvm@18.3:', type='link')
+    depends_on('mesa~llvm@21:', type='link')
     depends_on('numactl', type='link', when='@3.7.0:')
 
     for d_version, d_shasum in [

--- a/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
+++ b/var/spack/repos/builtin/packages/rocm-openmp-extras/package.py
@@ -86,7 +86,7 @@ class RocmOpenmpExtras(Package):
     version('3.9.0', sha256=versions_dict['3.9.0']['aomp'])
 
     depends_on('cmake@3:', type='build')
-    depends_on('mesa18~llvm@18.3:', type=('build', 'link'))
+    depends_on('mesa~llvm@21:', type=('build', 'link'))
     depends_on('py-setuptools', type='build')
     depends_on('python@3:', type='build')
     depends_on('perl-data-dumper', type='build')


### PR DESCRIPTION
i have found 4 instances mesa18 spack package currently being used inside the rocm recipes - hip-rocclr , hip, rocm-opencl and rocm-openmp-extras.
I have replaced each of these instances with mesa package and rebuilt all the rocm recipes for 4.5.0 . I ran a few hip examples as well as a few other tests as part of the sanity tests.
