### PR TITLE
Make `compiler_info()` die when no compilers are found

### DIFF
--- a/lib/spack/spack/cmd/compiler.py
+++ b/lib/spack/spack/cmd/compiler.py
@@ -120,7 +120,7 @@ def compiler_info(args):
     compilers = spack.compilers.compilers_for_spec(cspec, scope=args.scope)
 
     if not compilers:
-        tty.error("No compilers match spec %s" % cspec)
+        tty.die("No compilers match spec %s" % cspec)
     else:
         for c in compilers:
             print(str(c.spec) + ":")


### PR DESCRIPTION
If this isn't the intended behavior, that's fine. But I think it should be :-)

Closes #28492