### PR TITLE
Patch for version 2.40.1 and beyond

### DIFF
--- a/var/spack/repos/builtin/packages/at-spi2-core/package.py
+++ b/var/spack/repos/builtin/packages/at-spi2-core/package.py
@@ -35,6 +35,10 @@ class AtSpi2Core(MesonPackage):
     depends_on('python', type='build')
     depends_on('gobject-introspection')
 
+    @when('@2.40.1:')
+    def patch(self):
+        filter_file('dbus_broker.found\(\)', 'false','bus/meson.build')
+
     def url_for_version(self, version):
         """Handle gnome's version-based custom URLs."""
         url = 'http://ftp.gnome.org/pub/gnome/sources/at-spi2-core'

--- a/var/spack/repos/builtin/packages/at-spi2-core/package.py
+++ b/var/spack/repos/builtin/packages/at-spi2-core/package.py
@@ -37,7 +37,7 @@ class AtSpi2Core(MesonPackage):
 
     @when('@2.40.1:')
     def patch(self):
-        filter_file('dbus_broker.found\(\)', 'false','bus/meson.build')
+        filter_file(r'dbus_broker.found\(\)', 'false', 'bus/meson.build')
 
     def url_for_version(self, version):
         """Handle gnome's version-based custom URLs."""


### PR DESCRIPTION
at-spi2-core is automatically selecting dbus-broker and enabling systemd if it finds dbus-broker-launch which some systems might have even without systemd being part of the actual spack environment. This is not ideal for a spack package.