### PR TITLE
glm: add develop version

### DIFF
--- a/var/spack/repos/builtin/packages/glm/package.py
+++ b/var/spack/repos/builtin/packages/glm/package.py
@@ -14,25 +14,33 @@ class Glm(CMakePackage):
     homepage = "https://github.com/g-truc/glm"
     url = "https://github.com/g-truc/glm/archive/0.9.9.8.tar.gz"
 
+    version('develop', git="https://github.com/g-truc/glm.git")
     version('0.9.9.8', sha256='7d508ab72cb5d43227a3711420f06ff99b0a0cb63ee2f93631b162bfe1fe9592')
     version('0.9.7.1', sha256='285a0dc8f762b4e523c8710fbd97accaace0c61f45bc8be2bdb0deed07b0e6f3')
 
     depends_on('cmake@2.6:', type='build')
     depends_on('cmake@3.2:', type='build', when='@0.9.9.0:')
+    depends_on('cmake@3.2:', type='build', when='@develop')
 
     # CMake install target was removed in version 0.9.9.6
-    @when('@0.9.9.6:')
+    @when('@0.9.9.6:0.9.9.8')
     def cmake(self, spec, prefix):
         pass
 
-    @when('@0.9.9.6:')
+    @when('@0.9.9.6:0.9.9.8')
     def build(self, spec, prefix):
         pass
 
-    @when('@0.9.9.6:')
+    @when('@0.9.9.6:0.9.9.8')
     def install(self, spec, prefix):
         mkdirp(prefix.include.glm)
         ignore_cmakelists = lambda p: p.endswith('CMakeLists.txt')
         install_tree('glm', prefix.include.glm, ignore=ignore_cmakelists)
         mkdirp(prefix.lib64.cmake)
         install_tree('cmake', prefix.lib64.cmake)
+
+    @when('@develop')
+    def cmake_args(self):
+        return [
+            self.define('GLM_TEST_ENABLE', self.run_tests)
+        ]

--- a/var/spack/repos/builtin/packages/glm/package.py
+++ b/var/spack/repos/builtin/packages/glm/package.py
@@ -13,14 +13,14 @@ class Glm(CMakePackage):
 
     homepage = "https://github.com/g-truc/glm"
     url = "https://github.com/g-truc/glm/archive/0.9.9.8.tar.gz"
+    git = "https://github.com/g-truc/glm.git"
 
-    version('develop', git="https://github.com/g-truc/glm.git")
+    version('develop', branch="master")
     version('0.9.9.8', sha256='7d508ab72cb5d43227a3711420f06ff99b0a0cb63ee2f93631b162bfe1fe9592')
     version('0.9.7.1', sha256='285a0dc8f762b4e523c8710fbd97accaace0c61f45bc8be2bdb0deed07b0e6f3')
 
     depends_on('cmake@2.6:', type='build')
     depends_on('cmake@3.2:', type='build', when='@0.9.9.0:')
-    depends_on('cmake@3.2:', type='build', when='@develop')
 
     # CMake install target was removed in version 0.9.9.6
     @when('@0.9.9.6:0.9.9.8')


### PR DESCRIPTION
The released versions do not properly install via cmake which leads to
errors when linking against the library.  These upstream problems have
been addressed on the glm development branch.

Partially addresses #28486 