### PR TITLE
ACTS now requires/is compatible with autodiff 0.6

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -143,7 +143,8 @@ class Acts(CMakePackage, CudaPackage):
     # Build dependencies
     # FIXME: Use spack's vecmem package once there is one
     # (https://github.com/acts-project/acts/pull/998)
-    depends_on('autodiff @0.5.11:0.5.99', when='@1.2: +autodiff')
+    depends_on('autodiff @0.6:', when='@develop +autodiff')
+    depends_on('autodiff @0.5.11:0.5.99', when='@1.2:16 +autodiff')
     depends_on('boost @1.62:1.69 +program_options +test', when='@:0.10.3')
     depends_on('boost @1.71: +filesystem +program_options +test', when='@0.10.4:')
     depends_on('cmake @3.14:', type='build')


### PR DESCRIPTION
Follow-up to #28440 now that ACTS has been made compatible with current autodiff (which unfortunately also broke compatibility with older autodiff).