### PR TITLE
libzmq: add variants "docs", "libbsd"

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -34,6 +34,9 @@ class Libzmq(AutotoolsPackage):
     variant("drafts", default=False,
             description="Build and install draft classes and methods")
 
+    variant("docs", default=True,
+            description="Build documentation")
+
     depends_on("libsodium", when='+libsodium')
     depends_on("libsodium@:1.0.3", when='+libsodium@:4.1.2')
 
@@ -41,8 +44,8 @@ class Libzmq(AutotoolsPackage):
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool', type='build', when='@develop')
     depends_on('pkgconfig', type='build')
-    depends_on('docbook-xml', type='build')
-    depends_on('docbook-xsl', type='build')
+    depends_on('docbook-xml', type='build +docs')
+    depends_on('docbook-xsl', type='build +docs')
 
     depends_on('libbsd', type='link', when='@4.3.3: platform=linux')
     depends_on('libbsd', type='link', when='@4.3.3: platform=cray')
@@ -71,6 +74,8 @@ class Libzmq(AutotoolsPackage):
 
         if '+libsodium' in self.spec:
             config_args.append('--with-libsodium')
+        if '~docs' in self.spec:
+            config_args.append('--without-docs')
         if 'clang' in self.compiler.cc:
             config_args.append("CFLAGS=-Wno-gnu")
             config_args.append("CXXFLAGS=-Wno-gnu")

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -36,9 +36,10 @@ class Libzmq(AutotoolsPackage):
 
     variant("docs", default=True,
             description="Build documentation")
-    
+
     variant("libbsd", default=True,
-            description="Use strlcpy from libbsd (will use own implementation if false)")
+            description="Use strlcpy from libbsd " +
+                        "(will use own implementation if false)")
 
     depends_on("libsodium", when='+libsodium')
     depends_on("libsodium@:1.0.3", when='+libsodium@:4.1.2')

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -36,6 +36,9 @@ class Libzmq(AutotoolsPackage):
 
     variant("docs", default=True,
             description="Build documentation")
+    
+    variant("libbsd", default=True,
+            description="Use strcpl from libbsd (will use own implementation if false)")
 
     depends_on("libsodium", when='+libsodium')
     depends_on("libsodium@:1.0.3", when='+libsodium@:4.1.2')
@@ -47,8 +50,8 @@ class Libzmq(AutotoolsPackage):
     depends_on('docbook-xml', type='build', when='+docs')
     depends_on('docbook-xsl', type='build', when='+docs')
 
-    depends_on('libbsd', type='link', when='@4.3.3: platform=linux')
-    depends_on('libbsd', type='link', when='@4.3.3: platform=cray')
+    depends_on('libbsd', type='link', when='@4.3.3: platform=linux +libbsd')
+    depends_on('libbsd', type='link', when='@4.3.3: platform=cray +libbsd')
 
     conflicts('%gcc@8:', when='@:4.2.2')
 

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -44,8 +44,8 @@ class Libzmq(AutotoolsPackage):
     depends_on('automake', type='build', when='@develop')
     depends_on('libtool', type='build', when='@develop')
     depends_on('pkgconfig', type='build')
-    depends_on('docbook-xml', type='build +docs')
-    depends_on('docbook-xsl', type='build +docs')
+    depends_on('docbook-xml', type='build', when='+docs')
+    depends_on('docbook-xsl', type='build', when='+docs')
 
     depends_on('libbsd', type='link', when='@4.3.3: platform=linux')
     depends_on('libbsd', type='link', when='@4.3.3: platform=cray')

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -38,7 +38,7 @@ class Libzmq(AutotoolsPackage):
             description="Build documentation")
     
     variant("libbsd", default=True,
-            description="Use strcpl from libbsd (will use own implementation if false)")
+            description="Use strlcpy from libbsd (will use own implementation if false)")
 
     depends_on("libsodium", when='+libsodium')
     depends_on("libsodium@:1.0.3", when='+libsodium@:4.1.2')

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -51,8 +51,8 @@ class Libzmq(AutotoolsPackage):
     depends_on('docbook-xml', type='build', when='+docs')
     depends_on('docbook-xsl', type='build', when='+docs')
 
-    depends_on('libbsd', type='link', when='@4.3.3: platform=linux +libbsd')
-    depends_on('libbsd', type='link', when='@4.3.3: platform=cray +libbsd')
+    depends_on('libbsd', when='@4.3.3: platform=linux +libbsd')
+    depends_on('libbsd', when='@4.3.3: platform=cray +libbsd')
 
     conflicts('%gcc@8:', when='@:4.2.2')
 

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -75,6 +75,7 @@ class Libzmq(AutotoolsPackage):
         config_args = []
 
         config_args.extend(self.enable_or_disable("drafts"))
+        config_args.append(self.enable_or_disable("libbsd"))
 
         if '+libsodium' in self.spec:
             config_args.append('--with-libsodium')

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -75,7 +75,7 @@ class Libzmq(AutotoolsPackage):
         config_args = []
 
         config_args.extend(self.enable_or_disable("drafts"))
-        config_args.append(self.enable_or_disable("libbsd"))
+        config_args.extend(self.enable_or_disable("libbsd"))
 
         if '+libsodium' in self.spec:
             config_args.append('--with-libsodium')


### PR DESCRIPTION
* `docs`: whether to build and install documentation.
* `libbsd`: whether  to link with libbsd - libzmq will use [own implementation](https://github.com/zeromq/libzmq/blob/v4.3.4/src/compat.hpp#L45) of `strlcpy` if libbsd is not available.