### PR TITLE
Update CMake to 3.21 in LBANN-related projects

### DIFF
--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -42,7 +42,7 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
             ' Put/Get and IPC RMA functionality')
     variant('rccl', default=False, description='Builds with support for NCCL communication lib')
 
-    depends_on('cmake@3.17.0:', type='build')
+    depends_on('cmake@3.21.0:', type='build')
     depends_on('mpi')
     depends_on('nccl@2.7.0-0:', when='+nccl')
     depends_on('hwloc@1.11:')

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -42,7 +42,8 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
             ' Put/Get and IPC RMA functionality')
     variant('rccl', default=False, description='Builds with support for NCCL communication lib')
 
-    depends_on('cmake@3.21.0:', type='build')
+    depends_on('cmake@3.21.0:', type='build', when='@1.0.1:')
+    depends_on('cmake@3.17.0:', type='build', when='@:1.0.0')
     depends_on('mpi')
     depends_on('nccl@2.7.0-0:', when='+nccl')
     depends_on('hwloc@1.11:')

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -67,7 +67,8 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('~openmp', when='+omp_taskloops')
     conflicts('+cuda', when='+rocm', msg='CUDA and ROCm support are mutually exclusive')
 
-    depends_on('cmake@3.21.0:', type='build')
+    depends_on('cmake@3.21.0:', type='build', when='@1.5.2:')
+    depends_on('cmake@3.17.0:', type='build', when='@:1.5.1')
     depends_on('mpi')
     depends_on('hwloc@1.11:')
     depends_on('hwloc +cuda +nvml', when='+cuda')

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -67,7 +67,7 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('~openmp', when='+omp_taskloops')
     conflicts('+cuda', when='+rocm', msg='CUDA and ROCm support are mutually exclusive')
 
-    depends_on('cmake@3.17.0:', type='build')
+    depends_on('cmake@3.21.0:', type='build')
     depends_on('mpi')
     depends_on('hwloc@1.11:')
     depends_on('hwloc +cuda +nvml', when='+cuda')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -106,7 +106,8 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('+gold', when='platform=darwin', msg="gold does not work on Darwin")
     conflicts('+lld', when='platform=darwin', msg="lld does not work on Darwin")
 
-    depends_on('cmake@3.21.0:', type='build')
+    depends_on('cmake@3.21.0:', type='build', when='@0.103:')
+    depends_on('cmake@3.17.0:', type='build', when='@:0.102')
 
     # Specify the correct versions of Hydrogen
     depends_on('hydrogen@:1.3.4', when='@0.95:0.100')

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -106,7 +106,7 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('+gold', when='platform=darwin', msg="gold does not work on Darwin")
     conflicts('+lld', when='platform=darwin', msg="lld does not work on Darwin")
 
-    depends_on('cmake@3.17.0:', type='build')
+    depends_on('cmake@3.21.0:', type='build')
 
     # Specify the correct versions of Hydrogen
     depends_on('hydrogen@:1.3.4', when='@0.95:0.100')


### PR DESCRIPTION
The minimum CMake version has been updated to 3.21 in LBANN (https://github.com/LLNL/lbann/pull/2027), Hydrogen (https://github.com/LLNL/Elemental/pull/132), and Aluminum (https://github.com/LLNL/Aluminum/pull/142) in order to take advantage of its improved support for the CUDA SDK. Pinging @benson31 and @bvanessen.