### PR TITLE
nalu-wind: Remove unnecessary CMAKE_C_COMPILER

### DIFF
--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -78,7 +78,6 @@ class NaluWind(CMakePackage, CudaPackage):
         args = [
             self.define_from_variant('CMAKE_POSITION_INDEPENDENT_CODE', 'pic'),
             self.define('CMAKE_CXX_COMPILER', spec['mpi'].mpicxx),
-            self.define('CMAKE_C_COMPILER', spec['mpi'].mpicc),
             self.define('CMAKE_Fortran_COMPILER', spec['mpi'].mpifc),
             self.define('Trilinos_DIR', spec['trilinos'].prefix),
             self.define('YAML_DIR', spec['yaml-cpp'].prefix),


### PR DESCRIPTION
I just noticed Nalu-Wind doesn't specify the C language https://github.com/Exawind/nalu-wind/blob/3343b72905a4da831687910d2c90e1de60eb38f0/CMakeLists.txt#L3 so this removes a CMake configure warning where `CMAKE_C_COMPILER` is unused.

@eugeneswalker @psakievich 