### PR TITLE
fujitsu frontistr: New package

### DIFF
--- a/var/spack/repos/builtin/packages/frontistr/package.py
+++ b/var/spack/repos/builtin/packages/frontistr/package.py
@@ -7,18 +7,9 @@
 from spack import *
 
 
-class Frontistr(CMakePackage):
-    """Open-Source Large-Scale Parallel FEM Program for
-        Nonlinear Structural Analysis"""
-
-    homepage = "https://www.frontistr.com/"
-    git      = "https://gitlab.com/FrontISTR-Commons/FrontISTR.git"
-    maintainers = ['hiroshi.okuda', 'kgoto', 'morita', 'inagaki', 'michioga']
-
-    version('5.1.1', tag='v5.1.1')
-    version('5.1', tag='v5.1')
-    version('5.0', tag='v5.0')
-    version('master', tag='master')
+class FrontistrBase(CMakePackage):
+    """Base class for building Frontistr, shared with the Fujitsu optimized version
+    of the package in the 'fujitsu-frontistr' package."""
 
     variant('build_type', default='RELEASE',
             description='CMake build type',
@@ -38,5 +29,24 @@ class Frontistr(CMakePackage):
         define = CMakePackage.define
         cmake_args = [
             define('WITH_ML', True),
+            define('REFINER_INCLUDE_PATH',
+                self.spec['revocap-refiner'].prefix.include),
+            define('REFINER_LIBRARIES',
+                join_path(self.spec['revocap-refiner'].prefix.lib,
+                    'libRcapRefiner.a'))
         ]
         return cmake_args
+
+class Frontistr(FrontistrBase):
+    """Open-Source Large-Scale Parallel FEM Program for
+        Nonlinear Structural Analysis"""
+
+    homepage = "https://www.frontistr.com/"
+    git      = "https://gitlab.com/FrontISTR-Commons/FrontISTR.git"
+    maintainers = ['hiroshi.okuda', 'kgoto', 'morita', 'inagaki', 'michioga']
+
+    version('5.2', tag='v5.2')
+    version('5.1.1', tag='v5.1.1')
+    version('5.1', tag='v5.1')
+    version('5.0', tag='v5.0')
+    version('master', tag='master')

--- a/var/spack/repos/builtin/packages/frontistr/package.py
+++ b/var/spack/repos/builtin/packages/frontistr/package.py
@@ -30,12 +30,13 @@ class FrontistrBase(CMakePackage):
         cmake_args = [
             define('WITH_ML', True),
             define('REFINER_INCLUDE_PATH',
-                self.spec['revocap-refiner'].prefix.include),
+                   self.spec['revocap-refiner'].prefix.include),
             define('REFINER_LIBRARIES',
-                join_path(self.spec['revocap-refiner'].prefix.lib,
-                    'libRcapRefiner.a'))
+                   join_path(self.spec['revocap-refiner'].prefix.lib,
+                             'libRcapRefiner.a'))
         ]
         return cmake_args
+
 
 class Frontistr(FrontistrBase):
     """Open-Source Large-Scale Parallel FEM Program for
@@ -45,6 +46,7 @@ class Frontistr(FrontistrBase):
     git      = "https://gitlab.com/FrontISTR-Commons/FrontISTR.git"
     maintainers = ['hiroshi.okuda', 'kgoto', 'morita', 'inagaki', 'michioga']
 
+    version('5.3', tag='v5.3')
     version('5.2', tag='v5.2')
     version('5.1.1', tag='v5.1.1')
     version('5.1', tag='v5.1')

--- a/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
@@ -21,6 +21,11 @@ class FujitsuFrontistr(FrontistrBase):
     version('5.2', sha256='ebf73a96c33ae7c9e616c99f9ce07ec90d802764dbf6abf627b0083c3bbd2b2e')
     version('5.0', sha256='7a3a2dd0f834048fb71cc254c9da6c2637fb23110e79b5efaf208d6f69a5b30a')
 
+    variant('static', default=True, description='Build with static linkage')
+    depends_on('metis ~shared', when='+static')
+    depends_on('mumps ~shared', when='+static')
+    depends_on('trilinos ~shared', when='+static')
+
     def url_for_version(self, version):
         url = "https://github.com/fujitsu/FrontISTR/archive/refs/tags/v{0}_tuned.tar.gz"
         return url.format(version)
@@ -30,12 +35,15 @@ class FujitsuFrontistr(FrontistrBase):
         args = super(FujitsuFrontistr, self).cmake_args()
         if self.spec.satisfies('%fj'):
             args.extend([
-                define('CMAKE_C_FLAGS', '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
-                define('CMAKE_CXX_FLAGS', '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
-                define('CMAKE_Fortran_FLAGS', '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
+                define('CMAKE_C_FLAGS',
+                       '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
+                define('CMAKE_CXX_FLAGS',
+                       '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
+                define('CMAKE_Fortran_FLAGS',
+                       '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
                 define('CMAKE_Fortran_MODDIR_FLAG', 'M'),
-                define('OpenMP_C_FLAGS', '-Kopenmp -Kparallel'),
-                define('OpenMP_CXX_FLAGS', '-Kopenmp -Kparallel'),
-                define('OpenMP_Fortran_FLAGS', '-Kopenmp -Kparallel')
+                define('OpenMP_C_FLAGS', '-Kopenmp'),
+                define('OpenMP_CXX_FLAGS', '-Kopenmp'),
+                define('OpenMP_Fortran_FLAGS', '-Kopenmp')
             ])
         return args

--- a/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
+++ b/var/spack/repos/builtin/packages/fujitsu-frontistr/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+from spack.pkg.builtin.frontistr import FrontistrBase
+
+
+class FujitsuFrontistr(FrontistrBase):
+    """This is a fork repository of the FrontISTR tuned for A64FX."""
+
+    _name = 'fujitsu-frontistr'
+    homepage = "https://www.frontistr.com/"
+    url = "https://github.com/fujitsu/FrontISTR/archive/refs/tags/v5.2_tuned.tar.gz"
+    git      = "https://github.com/fujitsu/FrontISTR"
+    maintainers = ['kinagaki-fj', 'kinagaki', 'm-shunji']
+
+    version('master', branch='fj-master')
+    version('5.2', sha256='ebf73a96c33ae7c9e616c99f9ce07ec90d802764dbf6abf627b0083c3bbd2b2e')
+    version('5.0', sha256='7a3a2dd0f834048fb71cc254c9da6c2637fb23110e79b5efaf208d6f69a5b30a')
+
+    def url_for_version(self, version):
+        url = "https://github.com/fujitsu/FrontISTR/archive/refs/tags/v{0}_tuned.tar.gz"
+        return url.format(version)
+
+    def cmake_args(self):
+        define = CMakePackage.define
+        args = super(FujitsuFrontistr, self).cmake_args()
+        if self.spec.satisfies('%fj'):
+            args.extend([
+                define('CMAKE_C_FLAGS', '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
+                define('CMAKE_CXX_FLAGS', '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
+                define('CMAKE_Fortran_FLAGS', '-Kcmodel=large -Nlst=t -Kocl -Kfast -Kzfill -Koptmsg=2'),
+                define('CMAKE_Fortran_MODDIR_FLAG', 'M'),
+                define('OpenMP_C_FLAGS', '-Kopenmp -Kparallel'),
+                define('OpenMP_CXX_FLAGS', '-Kopenmp -Kparallel'),
+                define('OpenMP_Fortran_FLAGS', '-Kopenmp -Kparallel')
+            ])
+        return args


### PR DESCRIPTION
fujitsu-frontistr is  a fork repository of the FrontISTR tuned for A64FX.
This PR add slso add Frontistr version 5.2 and 5.3.