### PR TITLE
m4: move patches hosted at savannah into the repo

### DIFF
--- a/var/spack/repos/builtin/packages/m4/checks-198.sysval.1.patch
+++ b/var/spack/repos/builtin/packages/m4/checks-198.sysval.1.patch
@@ -1,0 +1,27 @@
+From a1354086d92efa06f5866b008a019f6d801367ca Mon Sep 17 00:00:00 2001
+From: Eric Blake <eblake@redhat.com>
+Date: Sat, 29 May 2021 06:51:53 -0500
+Subject: doc: Minor formatting tweak.
+
+* doc/m4.texi (Sysval): Fix overfull /hbox.
+---
+ doc/m4.texi | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/doc/m4.texi b/doc/m4.texi
+index 94ac851d..247f2be5 100644
+--- a/doc/m4.texi
++++ b/doc/m4.texi
+@@ -6756,7 +6756,8 @@ ifdef(`__unix__', ,
+ ')m4exit(`77')')dnl
+ changequote(`[', `]')
+ @result{}
+-syscmd([/bin/sh -c 'kill -9 $$'; st=$?; test $st = 137 || test $st = 265])
++syscmd([/bin/sh -c 'kill -9 $$'; st=$?;
++test $st = 137 || test $st = 265])
+ @result{}
+ ifelse(sysval, [0], , [errprint([ skipping: shell does not send signal 9
+ ])m4exit([77])])dnl
+-- 
+cgit v1.2.1
+

--- a/var/spack/repos/builtin/packages/m4/checks-198.sysval.2.patch
+++ b/var/spack/repos/builtin/packages/m4/checks-198.sysval.2.patch
@@ -1,0 +1,31 @@
+From cd7f4d153ccccf601751e9fa82424412f6ecfc96 Mon Sep 17 00:00:00 2001
+From: Eric Blake <eblake@redhat.com>
+Date: Tue, 1 Jun 2021 08:10:51 -0500
+Subject: tests: Fix 198.sysval
+
+In my attempt to avoid test failures on Haiku, I caused test failures
+on platforms where sh is noisy when reporting a killed sub-process.
+
+* doc/m4.texi (Sysval): Avoid stderr noise during test.
+Fixes: 17011ea76a (tests: Skip signal detection on Haiku)
+Fixes: https://lists.gnu.org/archive/html/bug-m4/2021-05/msg00029.html
+---
+ doc/m4.texi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/doc/m4.texi b/doc/m4.texi
+index 247f2be5..3b833b2a 100644
+--- a/doc/m4.texi
++++ b/doc/m4.texi
+@@ -6756,7 +6756,7 @@ ifdef(`__unix__', ,
+ ')m4exit(`77')')dnl
+ changequote(`[', `]')
+ @result{}
+-syscmd([/bin/sh -c 'kill -9 $$'; st=$?;
++syscmd([@{ /bin/sh -c 'kill -9 $$'; @} 2>/dev/null; st=$?;
+ test $st = 137 || test $st = 265])
+ @result{}
+ ifelse(sysval, [0], , [errprint([ skipping: shell does not send signal 9
+-- 
+cgit v1.2.1
+

--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -36,10 +36,8 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     patch('https://src.fedoraproject.org/rpms/m4/raw/5d147168d4b93f38a4833f5dd1d650ad88af5a8a/f/m4-1.4.18-glibc-change-work-around.patch', sha256='fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8', when='@1.4.18')
     # from: https://www.mail-archive.com/m4-patches@gnu.org/msg01208.html
     # tests: Fix failing test checks/198.sysval with upstream patch for doc/m4.texi
-    patch('http://git.savannah.gnu.org/cgit/m4.git/patch/?id=a1354086',
-          sha256='bfdffa7c2eb01021d5849b36972c069693654ad826c1a20b53534009a4ec7a89', when='@1.4.19')
-    patch('http://git.savannah.gnu.org/cgit/m4.git/patch/?id=cd7f4d15',
-          sha256='9dc5fbd0d5cb1037ab1e6d0ecc74a30df218d0a94bdd5a02759a97f62daca573', when='@1.4.19')
+    patch('checks-198.sysval.1.patch', when='@1.4.19')
+    patch('checks-198.sysval.2.patch', when='@1.4.19')
 
     variant('sigsegv', default=True,
             description="Build the libsigsegv dependency")


### PR DESCRIPTION
These URLs were giving 404's to me and to some of our users -- they do not seem to be reliable, so moving them into the tree.