### PR TITLE
proposal: `cmakeflags` (similar to `cxxflags`, but for cmake arguments)

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -328,6 +328,12 @@ class CMakePackage(PackageBase):
                 self.cmake_flag_args.append(libs_string.format(lang,
                                                                libs_flags))
 
+    def extra_cmake_args(self):
+        cmake_flags = self.spec.variants.get("cmakeflags", None)
+        if not cmake_flags:
+            return []
+        return [entry for entry in cmake_flags.value.split(' ')]
+
     @property
     def build_dirname(self):
         """Returns the directory name to use when building the package
@@ -361,6 +367,7 @@ class CMakePackage(PackageBase):
         """Runs ``cmake`` in the build directory"""
         options = self.std_cmake_args
         options += self.cmake_args()
+        options += self.extra_cmake_args()
         options.append(os.path.abspath(self.root_cmakelists_dir))
         with working_dir(self.build_directory, create=True):
             inspect.getmodule(self).cmake(*options)

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -329,10 +329,10 @@ class CMakePackage(PackageBase):
                                                                libs_flags))
 
     def extra_cmake_args(self):
-        cmake_flags = self.spec.variants.get("cmakeflags", None)
-        if not cmake_flags:
-            return []
-        return [entry for entry in cmake_flags.value.split(' ')]
+        cmake_flags = self.spec.variants.get("cmakeflags")
+        if cmake_flags:
+            return cmake_flags.value
+        return []
 
     @property
     def build_dirname(self):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -58,6 +58,7 @@ __all__ = ['DirectiveError', 'DirectiveMeta']
 
 #: These are variant names used by Spack internally; packages can't use them
 reserved_names = ['patches', 'dev_path']
+reserved_names += ['cmakeflags']
 
 #: Names of possible directives. This list is populated elsewhere in the file and then
 #: added to `__all__` at the bottom.

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1839,11 +1839,15 @@ class SpecBuilder(object):
             return
 
         if name == 'cmakeflags':
-            self._specs[pkg].variants.setdefault(
-                name,
-                spack.variant.SingleValuedVariant(name, value)
-            )
-            return
+            variants = self._specs[pkg].variants
+            if not variants.get(name):
+                variants.setdefault(
+                    name,
+                    spack.variant.MultiValuedVariant(name, value)
+                )
+            else:
+                variants[name].append(value)
+        return
 
         self._specs[pkg].update_variant_validate(name, value)
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1893,7 +1893,7 @@ class SpecBuilder(object):
         flags will appear last on the compile line, in the order they
         were specified.
 
-        The solver determines wihch flags are on nodes; this routine
+        The solver determines which flags are on nodes; this routine
         imposes order afterwards.
         """
         # nodes with no flags get flag order from compiler

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1838,6 +1838,13 @@ class SpecBuilder(object):
             )
             return
 
+        if name == 'cmakeflags':
+            self._specs[pkg].variants.setdefault(
+                name,
+                spack.variant.SingleValuedVariant(name, value)
+            )
+            return
+
         self._specs[pkg].update_variant_validate(name, value)
 
     def version(self, pkg, version):

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -519,6 +519,8 @@ variant(Package, Variant)
 variant_single_value(Package, "dev_path")
   :- variant_set(Package, "dev_path", _).
 
+auto_variant("cmakeflags").
+
 % suppress warnings about this atom being unset.  It's only set if some
 % spec or some package sets it, and without this, clingo will give
 % warnings like 'info: atom does not occur in any rule head'.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1211,7 +1211,7 @@ class Spec(object):
             assert(self.compiler_flags is not None)
             self.compiler_flags[name] = spack.compiler.tokenize_flags(value)
         elif name == 'cmakeflags':
-            self.variants[name] = vt.SingleValuedVariant(name, value)
+            self.variants[name] = vt.MultiValuedVariant(name, value)
         else:
             # FIXME:
             # All other flags represent variants. 'foo=true' and 'foo=false'
@@ -1906,7 +1906,8 @@ class Spec(object):
                 if name in _valid_compiler_flags:
                     spec.compiler_flags[name] = value
                 elif name == 'cmakeflags':
-                    spec.variants[name] = vt.SingleValuedVariant(name, value)
+                    spec.variants[name] = vt.MultiValuedVariant.from_node_dict(
+                        name, value)
                 else:
                     spec.variants[name] = vt.MultiValuedVariant.from_node_dict(
                         name, value)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1210,6 +1210,8 @@ class Spec(object):
         elif name in valid_flags:
             assert(self.compiler_flags is not None)
             self.compiler_flags[name] = spack.compiler.tokenize_flags(value)
+        elif name == 'cmakeflags':
+            self.variants[name] = vt.SingleValuedVariant(name, value)
         else:
             # FIXME:
             # All other flags represent variants. 'foo=true' and 'foo=false'
@@ -1903,6 +1905,8 @@ class Spec(object):
             for name, value in node['parameters'].items():
                 if name in _valid_compiler_flags:
                     spec.compiler_flags[name] = value
+                elif name == 'cmakeflags':
+                    spec.variants[name] = vt.SingleValuedVariant(name, value)
                 else:
                     spec.variants[name] = vt.MultiValuedVariant.from_node_dict(
                         name, value)

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -647,7 +647,7 @@ def substitute_abstract_variants(spec):
     Args:
         spec: spec on which to operate the substitution
     """
-    # This method needs to be best effort so that it works in matrix exlusion
+    # This method needs to be best effort so that it works in matrix exclusion
     # in $spack/lib/spack/spack/spec_list.py
     failed = []
     for name, v in spec.variants.items():


### PR DESCRIPTION
This PR is just a feasibility test to see if I was able to get something working and to ask you if it is something that, after polishing it, can be interesting as a feature.

### Extra cmake flags as part of the spec (with `cmakeflags`)

It allows the user to inject cmake variables to the configure call, without the need of altering the spack package.

```bash
spack spec -I zlib-ng cmakeflags="-Dexample1:BOOL=off -Dexample2=/dev/null"
Input spec
--------------------------------
 -   zlib-ng cmakeflags=-Dexample1:BOOL=off -Dexample2=/dev/null

Concretized
--------------------------------
 -   zlib-ng@2.0.0%apple-clang@13.0.0~compat~ipo+opt build_type=RelWithDebInfo cmakeflags=-Dexample1:BOOL=off -Dexample2=/dev/null arch=darwin-bigsur-skylake
[+]      ^cmake@3.22.1%apple-clang@13.0.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=darwin-bigsur-skylake
```


In the last line of this snippet it is possible to see that `'-Dexample1:BOOL=off'` and `'-Dexample2=/dev/null'` have been appended after other cmake variables set by the package.
```bash
spack -v install -u build zlib-ng cmakeflags="-Dexample1:BOOL=off -Dexample2=/dev/null"
[+] /usr/local (external cmake-3.22.1-3yfazipg7szx4t73zptknkgy743cskm2)
==> Installing zlib-ng-2.0.0-ruzgko2kk5i6mqdwwat2ses5hsyl4bfs
==> No binary for zlib-ng-2.0.0-ruzgko2kk5i6mqdwwat2ses5hsyl4bfs found: installing from source
/Users/ialberto/spack/lib/spack/spack/target.py:137: UserWarning: microarchitecture specific optimizations are not supported yet on mixed compiler toolchains [check apple-clang@13.0.0 for further details]
  warnings.warn(msg.format(compiler))
==> Using cached archive: /Users/ialberto/spack/var/spack/cache/_source-cache/archive/86/86993903527d9b12fc543335c19c1d33a93797b3d4d37648b5addae83679ecd8.tar.gz
==> No patches needed for zlib-ng
==> zlib-ng: Executing phase: 'cmake'
==> [2022-01-20-09:33:37.391038] 'cmake' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:STRING=/Users/ialberto/spack/opt/spack/darwin-bigsur-skylake/apple-clang-13.0.0/zlib-ng-2.0.0-ruzgko2kk5i6mqdwwat2ses5hsyl4bfs' '-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo' '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_FIND_FRAMEWORK:STRING=LAST' '-DCMAKE_FIND_APPBUNDLE:STRING=LAST' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF' '-DCMAKE_INSTALL_RPATH:STRING=/Users/ialberto/spack/opt/spack/darwin-bigsur-skylake/apple-clang-13.0.0/zlib-ng-2.0.0-ruzgko2kk5i6mqdwwat2ses5hsyl4bfs/lib;/Users/ialberto/spack/opt/spack/darwin-bigsur-skylake/apple-clang-13.0.0/zlib-ng-2.0.0-ruzgko2kk5i6mqdwwat2ses5hsyl4bfs/lib64' '-DCMAKE_PREFIX_PATH:STRING=' '-DZLIB_COMPAT:BOOL=OFF' '-DWITH_OPTIM:BOOL=ON' '-Dexample1:BOOL=off' '-Dexample2=/dev/null' '/var/folders/c9/v21gts9n7rs9cycnxcdzr__80000gn/T/ialberto/spack-stage/spack-stage-zlib-ng-2.0.0-ruzgko2kk5i6mqdwwat2ses5hsyl4bfs/spack-src'
```

### Why can this be interesting?
Because it will help to not "clutter" the spack package with all the variants possible and keep there just the interesting ones for the "public". At the same time, it will be possible for an advanced user to inject cmake parameters "for internal use" without altering the spack package (which is a bit hacky).

### A use-case
We have our package built by the CI via spack, but in order to test things on our system we need to enable specific cmake behavior via internal variables which are not meant to be "exposed" via the public package.

### WIP
Clearly it is just a feasibility test. I opened this PR to ask your feedback/interest before working on it. Suggestion about how to correctly add this feature are welcome.