### PR TITLE
libgit2: add mmap variant, disabling it makes it work on filesystems that do not implement mmap

### DIFF
--- a/var/spack/repos/builtin/packages/libgit2/package.py
+++ b/var/spack/repos/builtin/packages/libgit2/package.py
@@ -57,7 +57,7 @@ class Libgit2(CMakePackage):
     variant('ssh', default=True, description='Enable SSH support')
     variant('curl', default=False, description='Enable libcurl support (only supported through v0.27)')
 
-    variant('mmap', default=True, description='Enable mmap support', when='@1.1.1:1.1,1.2:')
+    variant('mmap', default=True, description='Enable mmap support', when='@1.1.1:')
 
     # Build Dependencies
     depends_on('cmake@2.8:', type='build', when="@:0.28")
@@ -74,7 +74,7 @@ class Libgit2(CMakePackage):
     conflicts('+curl', when='@0.28:')
 
     def flag_handler(self, name, flags):
-        if name == 'cflags' and not self.spec.variants['mmap'].value:
+        if name == 'cflags' and not self.spec.variants.get('mmap', False):
             flags.append('-DNO_MMAP')
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/libgit2/package.py
+++ b/var/spack/repos/builtin/packages/libgit2/package.py
@@ -57,6 +57,8 @@ class Libgit2(CMakePackage):
     variant('ssh', default=True, description='Enable SSH support')
     variant('curl', default=False, description='Enable libcurl support (only supported through v0.27)')
 
+    variant('mmap', default=True, description='Enable mmap support', when='@1.1.1:1.1,1.2:')
+
     # Build Dependencies
     depends_on('cmake@2.8:', type='build', when="@:0.28")
     depends_on('cmake@3.5:', type='build', when="@0.99:")
@@ -70,6 +72,11 @@ class Libgit2(CMakePackage):
     depends_on('curl', when='+curl')
 
     conflicts('+curl', when='@0.28:')
+
+    def flag_handler(self, name, flags):
+        if name == 'cflags' and not self.spec.variants['mmap'].value:
+            flags.append('-DNO_MMAP')
+        return (flags, None, None)
 
     def cmake_args(self):
         args = []


### PR DESCRIPTION
On some cray systems you can't use mmap $HOME/x on compute nodes,
and the sledgehammer approach is to disable mmap entirely.
