### PR TITLE
PythonPackage: add default libs/headers attributes

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -185,8 +185,10 @@ class PythonPackage(PackageBase):
     def headers(self):
         """Discover header files in platlib."""
 
-        root = inspect.getmodule(self).platlib
-        headers = find_all_headers(root)
+        # Headers may be in either location
+        include = inspect.getmodule(self).include
+        platlib = inspect.getmodule(self).platlib
+        headers = find_all_headers(include) + find_all_headers(platlib)
 
         if headers:
             return headers

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -14,7 +14,6 @@ from llnl.util.filesystem import (
     find,
     find_all_headers,
     find_libraries,
-    get_filetype,
     is_nonsymlink_exe_with_shebang,
     path_contains_subdirectory,
     same_path,

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -193,8 +193,8 @@ class PythonPackage(PackageBase):
         if headers:
             return headers
 
-        msg = 'Unable to locate {} headers in {}'
-        raise NoHeadersError(msg.format(self.spec.name, root))
+        msg = 'Unable to locate {} headers in {} or {}'
+        raise NoHeadersError(msg.format(self.spec.name, include, platlib))
 
     @property
     def libs(self):

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -181,6 +181,7 @@ class PythonPackage(PackageBase):
         with working_dir(self.build_directory):
             pip(*args)
 
+    @property
     def headers(self):
         """Discover header files in platlib."""
 
@@ -193,6 +194,7 @@ class PythonPackage(PackageBase):
         msg = 'Unable to locate {} headers in {}'
         raise NoHeadersError(msg.format(self.spec.name, root))
 
+    @property
     def libs(self):
         """Discover libraries in platlib."""
 

--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -35,8 +35,3 @@ class PyMpi4py(PythonPackage):
     @when('@3.1:')
     def install_options(self, spec, prefix):
         return ['--mpicc=%s -shared' % spec['mpi'].mpicc]
-
-    @property
-    def headers(self):
-        headers = find_all_headers(self.prefix.lib)
-        return headers

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -260,24 +260,6 @@ class PyTorch(PythonPackage, CudaPackage):
     patch('https://github.com/pytorch/pytorch/commit/c74c0c571880df886474be297c556562e95c00e0.patch?full_index=1',
           sha256='8ff7d285e52e4718bad1ca01ceb3bb6471d7828329036bb94222717fcaa237da', when='@:1.9.1 ^cuda@11.4.100:')
 
-    @property
-    def libs(self):
-        # TODO: why doesn't `python_platlib` work here?
-        root = join_path(
-            self.prefix, self.spec['python'].package.platlib, 'torch', 'lib'
-        )
-        return find_libraries('libtorch', root)
-
-    @property
-    def headers(self):
-        # TODO: why doesn't `python_platlib` work here?
-        root = join_path(
-            self.prefix, self.spec['python'].package.platlib, 'torch', 'include'
-        )
-        headers = find_all_headers(root)
-        headers.directories = [root]
-        return headers
-
     @when('@1.5.0:')
     def patch(self):
         # https://github.com/pytorch/pytorch/issues/52208


### PR DESCRIPTION
This likely needs a bit more thought and testing, but this is a good draft of what I think we should do for Python libraries.

Note that we only search `platlib`, not `purelib`. For most packages (at least ones that use setuptools), all files are installed to `platlib` if the package is not pure-Python. If things are installed in purelib instead of platlib, there likely aren't any libraries/headers anyway.

Closes #14513 
Closes #22475