### PR TITLE
trilinos: conflict with cuda >= 11.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -280,6 +280,12 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     # Old trilinos fails with new CUDA (see #27180)
     conflicts('@:13.0.1 +cuda', when='^cuda@11:')
 
+    # See discussion on the PR adding cuda@11.6 for details.
+    #
+    #     https://github.com/spack/spack/pull/28439
+    #
+    conflicts('+cuda', when='^cuda@11.6.0:')
+
     # stokhos fails on xl/xl_r
     conflicts('+stokhos', when='%xl')
     conflicts('+stokhos', when='%xl_r')


### PR DESCRIPTION
Introducing `cuda@11.6` caused trilinos to get stuck part way through the build.  See discussion [comments ](https://github.com/spack/spack/pull/28439#issuecomment-1017966604)for details.

This PR prevents trilinos from concretizing with `cuda@11.6.0:` until it can be fixed.