### PR TITLE
tau: %clang needs cmake for build

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -93,6 +93,7 @@ class Tau(Package):
     variant('ppc64le', default=False, description='Build for IBM Power LE nodes')
     variant('x86_64', default=False, description='Force build for x86 Linux instead of auto-detect')
 
+    depends_on('cmake', type='build', when='%clang')
     depends_on('zlib', type='link')
     depends_on('pdt', when='+pdt')  # Required for TAU instrumentation
     depends_on('scorep', when='+scorep')

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -93,7 +93,7 @@ class Tau(Package):
     variant('ppc64le', default=False, description='Build for IBM Power LE nodes')
     variant('x86_64', default=False, description='Force build for x86 Linux instead of auto-detect')
 
-    depends_on('cmake', type='build', when='%clang')
+    depends_on('cmake@3.14:', type='build', when='%clang')
     depends_on('zlib', type='link')
     depends_on('pdt', when='+pdt')  # Required for TAU instrumentation
     depends_on('scorep', when='+scorep')


### PR DESCRIPTION
`tau %clang` requires `cmake` for the `LLVM Plugin` (according to output below)

Without this PR, this is the error you see trying to `spack install tau%clang +mpi +python` for example:

```
$> spack install tau%clang +mpi +python
...
==> Installing tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3
==> No binary for tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3 found: installing from source
==> Warning: microarchitecture specific optimizations are not supported yet on mixed compiler toolchains [check clang@13.0.0 for further details]
==> Fetching https://mirror.spack.io/_source-cache/archive/27/27e73c395dd2a42b91591ce4a76b88b1f67663ef13aa19ef4297c68f45d946c2.tar.gz
==> No patches needed for tau
==> tau: Executing phase: 'install'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'install'

15 errors found in build log:
     94      TAU: PDT: Using binary rewriting capabilities from PEBIL in tau_pebil_rewrite
     95      ====================================================
     96       Copy /tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/tools/src/contrib/CubeReader.jar to /spack/opt/spack/linux-ubuntu20.04-x86_64/clang
             -13.0.0/tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/x86_64/lib
     97      ====================================================
     98      ... done
     99      ***********************************************************************
  >> 100     grep: ./utils/FixMakefile.info: No such file or directory
  >> 101     grep: ./utils/FixMakefile.sed: No such file or directory
     102     NOTE: Saving configuration environment to /tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/.configure_env/b9693f2a7407817ef7ec08632f9276c4
     103     NOTE: flang compiler for Linux options used
     104     NOTE: using newer flang compiler-based instrumentation option
     105     NOTE: Using CLANG C++ compiler
     106     NOTE: Enabled Profiling. Compiling with -DPROFILING_ON
     107     NOTE: Building POSIX I/O wrapper

     ...

     224     rm -Rf build
     225     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/plugins/llvm'
     226     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/instrument'
     227     /bin/rm -f simple.o simple
     228     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/instrument'
     229     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/threads'
  >> 230     Makefile:16: /tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-python-pdt: No such file or d
             irectory
  >> 231     make[1]: *** No rule to make target '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-pytho
             n-pdt'.  Stop.
     232     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/threads'
     233     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/cthreads'
  >> 234     Makefile:16: /tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-python-pdt: No such file or d
             irectory
  >> 235     make[1]: *** No rule to make target '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-pytho
             n-pdt'.  Stop.
     236     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/cthreads'
     237     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/fortran'
     238     /bin/rm -f hello.o hello
     239     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/fortran'
     240     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/f90'
     241     /bin/rm -f cubes.o cubes
     242     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/f90'
     243     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/pi'
  >> 244     Makefile:16: /tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-python-pdt: No such file or d
             irectory
  >> 245     make[1]: *** No rule to make target '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-pytho
             n-pdt'.  Stop.
     246     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/pi'
     247     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/NPB2.3'
     248     rm -f core
     249     rm -f *~ */core */*~ */*.o */npbparams.h */*.obj */*.exe
     250     rm -f MPI_dummy/test MPI_dummy/libmpi.a
     251     rm -f sys/setparams sys/makesuite sys/setparams.h
     252     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/NPB2.3'
     253     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/autoinstrument'
  >> 254     Makefile:16: /tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-python-pdt: No such file or d
             irectory
  >> 255     make[1]: *** No rule to make target '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-pytho
             n-pdt'.  Stop.
     256     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/autoinstrument'
     257     make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/reduce'
  >> 258     Makefile:16: /tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-python-pdt: No such file or d
             irectory
  >> 259     make[1]: *** No rule to make target '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/x86_64/lib/Makefile.tau-clang-papi-mpi-pthread-pytho
             n-pdt'.  Stop.
     260     make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/examples/reduce'
     261     touch .clean
     262     Determining Configuration...
     263     System previously configured as a x86_64
     264     *********** RECURSIVELY MAKING SUBDIRECTORIES ***********
     265     *** COMPILING src/TraceInput DIRECTORY

     ...

     2504    make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/plugins/examples'
     2505    make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/plugins'
     2506    *** COMPILING plugins/llvm DIRECTORY
     2507    make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/plugins/llvm'
     2508    bash -c "if [ ! -d build ] ; then mkdir build ; fi"
     2509    cd build &&   .. -DLLVM_DIR=/bootstrap/base/install/linux-ubuntu20.04-x86_64/gcc-11.1.0/llvm-doe-13.0.0-a362ln4xexebtq577wxqgbxhsdehcn77/ -G 'Unix Makefiles' -DCMAKE_INSTALL_P
             REFIX=/spack/opt/spack/linux-ubuntu20.04-x86_64/clang-13.0.0/tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/x86_64/lib/shared-clang-papi-mpi-pthread-python-pdt/plugins -DCMAKE_CXX_
             COMPILER=/usr/bin/g++ && make -j install
  >> 2510    /bin/sh: 1: ..: Permission denied
  >> 2511    make[1]: *** [Makefile:11: install] Error 127
     2512    make[1]: Leaving directory '/tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-src/plugins/llvm'
  >> 2513    make: *** [Makefile:192: install] Error 2

See build log for details:
  /tmp/root/spack-stage/spack-stage-tau-2.31-jdpuebpp6gzcolg3d62k6b4vsc2zana3/spack-build-out.txt
```

And from the build log:
```
...
Default C++ compiler will be clang++
./configure: line 85: cmake: command not found
./configure: line 86: cmake: command not found
CMAKE VERSION:
WHICH CMAKE:
ERROR: cmake version 3.14+ is required for LLVM plugin. Trying module load cmake.
Lmod has detected the following error: The following module(s) are unknown:
"cmake"
...
```

@wspear @sameershende 