### PR TITLE
add six.raise_from() to preserve exception traceback

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -39,6 +39,7 @@ from contextlib import contextmanager
 from typing import List  # novm
 
 import ruamel.yaml as yaml
+import six
 from ruamel.yaml.error import MarkedYAMLError
 from six import iteritems
 
@@ -975,7 +976,7 @@ def validate(data, schema, filename=None):
             line_number = e.instance.lc.line + 1
         else:
             line_number = None
-        raise ConfigFormatError(e, data, filename, line_number)
+        raise six.raise_from(ConfigFormatError(e, data, filename, line_number), e)
     # return the validated data so that we can access the raw data
     # mostly relevant for environments
     return test_data

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -734,7 +734,10 @@ class Database(object):
             with open(filename, 'r') as f:
                 fdata = sjson.load(f)
         except Exception as e:
-            raise CorruptDatabaseError("error parsing database:", str(e))
+            raise six.raise_from(
+                CorruptDatabaseError("error parsing database:", str(e)),
+                e,
+            )
 
         if fdata is None:
             return

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -12,6 +12,7 @@ import tempfile
 from contextlib import contextmanager
 
 import ruamel.yaml as yaml
+import six
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
@@ -344,13 +345,13 @@ class DirectoryLayout(object):
                     os.unlink(path)
                     os.remove(metapath)
                 except OSError as e:
-                    raise RemoveFailedError(spec, path, e)
+                    raise six.raise_from(RemoveFailedError(spec, path, e), e)
 
         elif os.path.exists(path):
             try:
                 shutil.rmtree(path)
             except OSError as e:
-                raise RemoveFailedError(spec, path, e)
+                raise six.raise_from(RemoveFailedError(spec, path, e), e)
 
         path = os.path.dirname(path)
         while path != self.root:

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -9,8 +9,9 @@ import re
 import shutil
 import sys
 
+import six
+
 import llnl.util.filesystem as fs
-import llnl.util.tty as tty
 
 import spack.error
 import spack.paths
@@ -292,8 +293,10 @@ class TestSuite(object):
                 test_suite._hash = content_hash
                 return test_suite
         except Exception as e:
-            tty.debug(e)
-            raise sjson.SpackJSONError("error parsing JSON TestSuite:", str(e))
+            raise six.raise_from(
+                sjson.SpackJSONError("error parsing JSON TestSuite:", str(e)),
+                e,
+            )
 
 
 def _add_msg_to_file(filename, msg):

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -69,6 +69,10 @@ class Mirror(object):
         self._push_url = push_url
         self._name = name
 
+    def __eq__(self, other):
+        return (self._fetch_url == other._fetch_url and
+                self._push_url == other._push_url)
+
     def to_json(self, stream=None):
         return sjson.dump(self.to_dict(), stream)
 
@@ -246,6 +250,9 @@ class MirrorCollection(Mapping):
             for name, mirror in (
                 mirrors.items() if mirrors is not None else
                 spack.config.get('mirrors', scope=scope).items()))
+
+    def __eq__(self, other):
+        return self._mirrors == other._mirrors
 
     def to_json(self, stream=None):
         return sjson.dump(self.to_dict(True), stream)

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -81,12 +81,21 @@ class Mirror(object):
             data = syaml.load(stream)
             return Mirror.from_dict(data, name)
         except yaml_error.MarkedYAMLError as e:
-            raise syaml.SpackYAMLError("error parsing YAML spec:", str(e))
+            raise six.raise_from(
+                syaml.SpackYAMLError("error parsing YAML mirror:", str(e)),
+                e,
+            )
 
     @staticmethod
     def from_json(stream, name=None):
-        d = sjson.load(stream)
-        return Mirror.from_dict(d, name)
+        try:
+            d = sjson.load(stream)
+            return Mirror.from_dict(d, name)
+        except Exception as e:
+            raise six.raise_from(
+                sjson.SpackJSONError("error parsing JSON mirror:", str(e)),
+                e,
+            )
 
     def to_dict(self):
         if self._push_url is None:
@@ -251,12 +260,21 @@ class MirrorCollection(Mapping):
             data = syaml.load(stream)
             return MirrorCollection(data)
         except yaml_error.MarkedYAMLError as e:
-            raise syaml.SpackYAMLError("error parsing YAML spec:", str(e))
+            raise six.raise_from(
+                syaml.SpackYAMLError("error parsing YAML mirror collection:", str(e)),
+                e,
+            )
 
     @staticmethod
     def from_json(stream, name=None):
-        d = sjson.load(stream)
-        return MirrorCollection(d)
+        try:
+            d = sjson.load(stream)
+            return MirrorCollection(d)
+        except Exception as e:
+            raise six.raise_from(
+                sjson.SpackJSONError("error parsing JSON mirror collection:", str(e)),
+                e,
+            )
 
     def to_dict(self, recursive=False):
         return syaml_dict(sorted(

--- a/lib/spack/spack/s3_handler.py
+++ b/lib/spack/spack/s3_handler.py
@@ -5,6 +5,7 @@
 
 from io import BufferedReader
 
+import six
 import six.moves.urllib.error as urllib_error
 import six.moves.urllib.request as urllib_request
 import six.moves.urllib.response as urllib_response
@@ -79,11 +80,11 @@ class UrllibS3Handler(urllib_request.HTTPSHandler):
                 except ClientError as err2:
                     if err.response['Error']['Code'] == 'NoSuchKey':
                         # raise original error
-                        raise urllib_error.URLError(err)
+                        raise six.raise_from(urllib_error.URLError(err), err)
 
-                    raise urllib_error.URLError(err2)
+                    raise six.raise_from(urllib_error.URLError(err2), err2)
 
-            raise urllib_error.URLError(err)
+            raise six.raise_from(urllib_error.URLError(err), err)
 
 
 S3OpenerDirector = urllib_request.build_opener(UrllibS3Handler())

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2183,7 +2183,10 @@ class Spec(object):
             data = yaml.load(stream)
             return Spec.from_dict(data)
         except yaml.error.MarkedYAMLError as e:
-            raise syaml.SpackYAMLError("error parsing YAML spec:", str(e))
+            raise six.raise_from(
+                syaml.SpackYAMLError("error parsing YAML spec:", str(e)),
+                e,
+            )
 
     @staticmethod
     def from_json(stream):
@@ -2196,8 +2199,10 @@ class Spec(object):
             data = sjson.load(stream)
             return Spec.from_dict(data)
         except Exception as e:
-            tty.debug(e)
-            raise sjson.SpackJSONError("error parsing JSON spec:", str(e))
+            raise six.raise_from(
+                sjson.SpackJSONError("error parsing JSON spec:", str(e)),
+                e,
+            )
 
     @staticmethod
     def from_detection(spec_str, extra_attributes=None):
@@ -2734,7 +2739,10 @@ class Spec(object):
             # with inconsistent constraints.  Users cannot produce
             # inconsistent specs like this on the command line: the
             # parser doesn't allow it. Spack must be broken!
-            raise InconsistentSpecError("Invalid Spec DAG: %s" % e.message)
+            raise six.raise_from(
+                InconsistentSpecError("Invalid Spec DAG: %s" % e.message),
+                e,
+            )
 
     def index(self, deptype='all'):
         """Return DependencyMap that points to all the dependencies in this
@@ -4767,7 +4775,7 @@ class SpecParser(spack.parse.Parser):
                         self.unexpected_token()
 
         except spack.parse.ParseError as e:
-            raise SpecParseError(e)
+            raise six.raise_from(SpecParseError(e), e)
 
         # Generate lookups for git-commit-based versions
         for spec in specs:

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -365,6 +365,31 @@ def test_setup_spack_repro_version(tmpdir, capfd, last_two_git_commits,
     assert('Unable to merge {0}'.format(c1) in err)
 
 
+@pytest.mark.parametrize(
+    "obj, proto",
+    [
+        ({}, []),
+    ],
+)
+def test_ci_opt_argument_checking(obj, proto):
+    """Check that matches() and subkeys() return False when `proto` is not a dict."""
+    assert not ci_opt.matches(obj, proto)
+    assert not ci_opt.subkeys(obj, proto)
+
+
+@pytest.mark.parametrize(
+    "yaml",
+    [
+        {'extends': 1},
+    ],
+)
+def test_ci_opt_add_extends_non_sequence(yaml):
+    """Check that add_extends() exits if 'extends' is not a sequence."""
+    yaml_copy = yaml.copy()
+    ci_opt.add_extends(yaml, None)
+    assert yaml == yaml_copy
+
+
 def test_ci_workarounds():
     fake_root_spec = 'x' * 544
     fake_spack_ref = 'x' * 40

--- a/lib/spack/spack/test/spec_yaml.py
+++ b/lib/spack/spack/test/spec_yaml.py
@@ -23,7 +23,7 @@ import spack.version
 from spack import repo
 from spack.spec import Spec, save_dependency_specfiles
 from spack.util.mock_package import MockPackageMultiRepo
-from spack.util.spack_yaml import syaml_dict
+from spack.util.spack_yaml import SpackYAMLError, syaml_dict
 
 if sys.version_info >= (3, 3):
     from collections.abc import Iterable, Mapping  # novm
@@ -54,6 +54,34 @@ def test_normal_spec(mock_packages):
     spec.normalize()
     check_yaml_round_trip(spec)
     check_json_round_trip(spec)
+
+
+@pytest.mark.parametrize(
+    "invalid_yaml",
+    [
+        "playing_playlist: {{ action }} playlist {{ playlist_name }}"
+    ]
+)
+def test_invalid_yaml_spec(invalid_yaml):
+    with pytest.raises(SpackYAMLError) as e:
+        Spec.from_yaml(invalid_yaml)
+    exc_msg = str(e.value)
+    assert exc_msg.startswith("error parsing YAML spec:")
+    assert invalid_yaml in exc_msg
+
+
+@pytest.mark.parametrize(
+    "invalid_json, error_message",
+    [
+        ("{13:", "Expecting property name")
+    ]
+)
+def test_invalid_json_spec(invalid_json, error_message):
+    with pytest.raises(sjson.SpackJSONError) as e:
+        Spec.from_json(invalid_json)
+    exc_msg = str(e.value)
+    assert exc_msg.startswith("error parsing JSON spec:")
+    assert error_message in exc_msg
 
 
 def test_external_spec(config, mock_packages):


### PR DESCRIPTION
### Problem
In several cases where we re-raise an exception, we lose the traceback pointing to the original source of the exception. Python 3's `raise <exception> from <exception>` syntax was created to join these exception tracebacks.

### Solution
Since we still support python 2.7, we can't use `raise ... from ...` directly, but `six.raise_from()` will do this when running in python 3. We use `six.raise_from()` calls whenever we re-raise a new exception.

Separately, some of these exception re-raises are not currently tested. In order to pass `codecov/patch`, we need to add a few further tests to cover the branches we modified to use `six.raise_from()`. These uncovered branches all occur in the methods to parse `Spec`, `Mirror`, and `MirrorCollection` from YAML/JSON.

### Result
We now have full exception tracebacks in all cases where we re-raise an exception!