### PR TITLE
bump up the version for nlohmann-json to 3.10.5 release

### DIFF
--- a/var/spack/repos/builtin/packages/nlohmann-json/package.py
+++ b/var/spack/repos/builtin/packages/nlohmann-json/package.py
@@ -13,6 +13,7 @@ class NlohmannJson(CMakePackage):
     url      = "https://github.com/nlohmann/json/archive/v3.1.2.tar.gz"
     maintainers = ['ax3l']
 
+    version('3.10.5', sha256='5daca6ca216495edf89d167f808d1d03c4a4d929cef7da5e10f135ae1540c7e4')
     version('3.10.4', sha256='1155fd1a83049767360e9a120c43c578145db3204d2b309eba49fbbedd0f4ed3')
     version('3.10.3', sha256='e0d7c1b120cac47fa7f14a41d10a5d390f67d423d8e97b9d6834887285d6873c')
     version('3.10.2', sha256='081ed0f9f89805c2d96335c3acfa993b39a0a5b4b4cef7edb68dd2210a13458c')


### PR DESCRIPTION
while compiling the migraphx@4.3.1 using gcc@7.5.0 i have found an issue  as below - 
In file included from /tmp/root/spack-stage/spack-stage-migraphx-4.3.1-ey5yaly3fpmvztxubs3wcntyi7ygwoqo/spack-src/src/json.cpp:4:

/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.5.0/nlohmann-json-3.10.4-rfh3txjx7dsshn4ousfrodq3lil6effd/include/nlohmann/json.hpp:3954:14: fatal error: 'filesystem' file not found

    #include <filesystem>


that is similar to the issue reported in https://github.com/nlohmann/json/issues/3090 .
Since the fix is in the latest release of this nlohmann-json, i have tried with the latest version and that is fixing the build issue that i encountered. I am able to build successfully 