### PR TITLE
netcdf-c: prevent overlinking to a system installation of libcurl

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack import *
 
 
@@ -17,7 +19,7 @@ class NetcdfC(AutotoolsPackage):
 
     maintainers = ['skosukhin', 'WardF']
 
-    version('master', branch='master')
+    version('main', branch='main')
     version('4.8.1',   sha256='bc018cc30d5da402622bf76462480664c6668b55eb16ba205a0dfb8647161dd0')
     version('4.8.0',   sha256='aff58f02b1c3e91dc68f989746f652fe51ff39e6270764e484920cb8db5ad092')
     version('4.7.4',   sha256='99930ad7b3c4c1a8e8831fb061cb02b2170fc8e5ccaeda733bd99c3b9d31666b')
@@ -75,9 +77,9 @@ class NetcdfC(AutotoolsPackage):
     #         description='Enable CDM Remote support')
 
     # The patch for 4.7.0 touches configure.ac. See force_autoreconf below.
-    depends_on('autoconf', type='build', when='@4.7.0')
-    depends_on('automake', type='build', when='@4.7.0')
-    depends_on('libtool', type='build', when='@4.7.0')
+    depends_on('autoconf', type='build', when='@4.7.0,main')
+    depends_on('automake', type='build', when='@4.7.0,main')
+    depends_on('libtool', type='build', when='@4.7.0,main')
 
     depends_on("m4", type='build')
     depends_on("hdf~netcdf", when='+hdf4')
@@ -127,6 +129,11 @@ class NetcdfC(AutotoolsPackage):
     def force_autoreconf(self):
         # The patch for 4.7.0 touches configure.ac.
         return self.spec.satisfies('@4.7.0')
+
+    @when('@4.6.3:')
+    def autoreconf(self, spec, prefix):
+        if not os.path.exists(self.configure_abs_path):
+            Executable('./bootstrap')()
 
     def configure_args(self):
         cflags = []

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -174,6 +174,9 @@ class NetcdfC(AutotoolsPackage):
             ldflags.append(curl_libs.search_flags)
             # TODO: figure out how to get correct flags via headers.cpp_flags
             cppflags.append('-I' + curl.prefix.include)
+        elif self.spec.satisfies('@4.8.0:'):
+            # Prevent overlinking to a system installation of libcurl:
+            config_args.append('ac_cv_lib_curl_curl_easy_setopt=no')
 
         if self.spec.satisfies('@4.4:'):
             if '+mpi' in self.spec:


### PR DESCRIPTION
Starting version `4.8.0` (the `main` is currently affected as well), the configure script started overlinking to `libcurl`. In the case of Spack, that means that `libnetcdf.so` might get overlinked to a system installation of the library if such one exists. The only variant that we currently support and that enables the real dependency on `libcurl` is `dap`. Therefore, we override the check for `libcurl` when `~dap` by calling the configure script with additional cache argument `ac_cv_lib_curl_curl_easy_setopt=no` (see [here](https://github.com/Unidata/netcdf-c/blob/1666f8070110dda16b606c186a626cd3b39f6dea/configure.ac#L158)).

Additionally, `master` version is renamed to `main` following the renaming of the branch upstream and Spack can now generate the configure script for it. The default implementation of the method does not work because it calls `autoreconf -fvi` with additional `-I` flags, which fails if the `m4` directory doesn't exist (regardless of the values provided with `-I` flags). If there is no `-I` flags, which is what implemented in the `./bootstrap` script, the absence of the `m4` directory triggers just a warning. At least on my system. In any case, the upstream developers support the bootstrapping script (starting version `4.6.3`) and it makes sense to use it.