### PR TITLE
bazel: add patches to compile with gcc-11

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/gcc11_1.patch
+++ b/var/spack/repos/builtin/packages/bazel/gcc11_1.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/ijar/zlib_client.h b/third_party/ijar/zlib_client.h
+index ed6616362fcc..c4b051e0100c 100644
+--- a/third_party/ijar/zlib_client.h
++++ b/third_party/ijar/zlib_client.h
+@@ -16,6 +16,7 @@
+ #define THIRD_PARTY_IJAR_ZLIB_CLIENT_H_
+ 
+ #include <limits.h>
++#include <limits>
+ 
+ #include "third_party/ijar/common.h"
+ 

--- a/var/spack/repos/builtin/packages/bazel/gcc11_2.patch
+++ b/var/spack/repos/builtin/packages/bazel/gcc11_2.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/ijar/zlib_client.h b/third_party/ijar/zlib_client.h
+index c4b051e0100c..0a917ff0a99a 100644
+--- a/third_party/ijar/zlib_client.h
++++ b/third_party/ijar/zlib_client.h
+@@ -16,7 +16,9 @@
+ #define THIRD_PARTY_IJAR_ZLIB_CLIENT_H_
+ 
+ #include <limits.h>
++
+ #include <limits>
++#include <stdexcept>
+ 
+ #include "third_party/ijar/common.h"
+ 

--- a/var/spack/repos/builtin/packages/bazel/gcc11_3.patch
+++ b/var/spack/repos/builtin/packages/bazel/gcc11_3.patch
@@ -1,0 +1,17 @@
+diff --git a/third_party/ijar/mapped_file_unix.cc b/third_party/ijar/mapped_file_unix.cc
+index 6e3a90871844..65179e3290ec 100644
+--- a/third_party/ijar/mapped_file_unix.cc
++++ b/third_party/ijar/mapped_file_unix.cc
+@@ -15,10 +15,11 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <stdio.h>
+-#include <unistd.h>
+ #include <sys/mman.h>
++#include <unistd.h>
+ 
+ #include <algorithm>
++#include <limits>
+ 
+ #include "third_party/ijar/mapped_file.h"
+ 

--- a/var/spack/repos/builtin/packages/bazel/gcc11_4.patch
+++ b/var/spack/repos/builtin/packages/bazel/gcc11_4.patch
@@ -1,0 +1,44 @@
+--- a/third_party/grpc/grpc_1.33.1.patch
++++ b/third_party/grpc/grpc_1.33.1.patch
+@@ -58,6 +58,14 @@ index 09fcad95a2..9b737e5deb 100644
+      )
+  
+      native.bind(
++@@ -245,6 +245,7 @@ def grpc_deps():
++                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
++                 "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
++             ],
+++            patches = ["@com_github_grpc_grpc//:third_party/abseil-cpp/absl.patch"],
++         )
++
++     if "bazel_toolchains" not in native.existing_rules():
+ diff --git a/bazel/grpc_extra_deps.bzl b/bazel/grpc_extra_deps.bzl
+ index 4c1dfad2e8..f63c54ddef 100644
+ --- a/bazel/grpc_extra_deps.bzl
+@@ -120,3 +128,25 @@ index c047f0c515..7c24fbc617 100644
+          ":windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
+          ":android": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
+          "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h",
++
++--- /dev/null
+++++ b/third_party/abseil-cpp/absl.patch
++@@ -0,0 +1,18 @@
+++0e2c62da1dcaf6529abab952bdcc96c6de2d9506 by Abseil Team <absl-team@google.com>:
+++
+++Add missing <limits> include
+++
+++PiperOrigin-RevId: 339054753
+++
+++--
+++
+++--- absl/synchronization/internal/graphcycles.cc
++++++ absl/synchronization/internal/graphcycles.cc
+++@@ -37,6 +37,7 @@
+++ 
+++ #include <algorithm>
+++ #include <array>
++++#include <limits>
+++ #include "absl/base/internal/hide_ptr.h"
+++ #include "absl/base/internal/raw_logging.h"
+++ #include "absl/base/internal/spinlock.h"
+

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -114,7 +114,7 @@ class Bazel(Package):
     version("0.3.2", sha256="ca5caf7b2b48c7639f45d815b32e76d69650f3199eb8caa541d402722e3f6c10")
     version("0.3.1", sha256="218d0e28b4d1ee34585f2ac6b18d169c81404d93958815e73e60cc0368efcbb7")
     version("0.3.0", sha256="357fd8bdf86034b93902616f0844bd52e9304cccca22971ab7007588bf9d5fb3")
-    version("0.2.0", sha256="54669662f7751d9fc9959207e13d9a171bda15be9087703d3dbd3968fed12b27")
+    version("0.2.0", sha256="e9ba2740d9727ae6d0f9b1ac0c5df331814fd03518fe4b511396ed10780d5272")
     version("0.1.4", sha256="f3c395f5cd78cfef96f4008fe842f327bc8b03b77f46999387bc0ad223b5d970")
     version("0.1.1", sha256="c6ae19610b936a0aa940b44a3626d6e660fc457a8187d295cdf0b21169453d20")
 
@@ -144,7 +144,7 @@ class Bazel(Package):
     patch("unix_cc_configure-0.10.patch", when="@0.10:0.14")
     patch("unix_cc_configure-0.5.3.patch", when="@0.5.3:0.9")
     patch("cc_configure-0.5.0.patch", when="@0.5.0:0.5.2")
-    patch("cc_configure-0.3.0.patch", when="@:0.4")
+    patch("cc_configure-0.3.0.patch", when="@0.3:0.4")
 
     # Set CC and CXX
     patch("compile-0.29.patch", when="@0.29:")
@@ -154,7 +154,7 @@ class Bazel(Package):
     patch("compile-0.9.patch", when="@0.9:0.12")
     patch("compile-0.6.patch", when="@0.6:0.8")
     patch("compile-0.4.patch", when="@0.4:0.5")
-    patch("compile-0.3.patch", when="@:0.3")
+    patch("compile-0.3.patch", when="@0.2:0.3")
 
     # Disable dependency search
     patch("cppcompileaction-0.3.2.patch", when="@0.3.2:+nodepfail")
@@ -183,8 +183,8 @@ class Bazel(Package):
     # patches for compiling bazel-4.1:4 with gcc-11
     # these are derived from
     # https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/29084/
-    patch("gcc11_1.patch", when="@0.3:4%gcc@11:")
-    patch("gcc11_2.patch", when="@0.3:4%gcc@11:")
+    patch("gcc11_1.patch", when="@0.3.2:4%gcc@11:")
+    patch("gcc11_2.patch", when="@0.3.2:4%gcc@11:")
     patch("gcc11_3.patch", when="@0.3:4%gcc@11:")
     patch("gcc11_4.patch", when="@4.1:4%gcc@11:")
 

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -180,18 +180,18 @@ class Bazel(Package):
     # https://blog.bazel.build/2021/05/21/bazel-4-1.html
     conflicts("platform=darwin target=aarch64:", when="@:4.0")
 
-    # patches for compiling bazel-4.1: with gcc-11
+    # patches for compiling bazel-4.1:4 with gcc-11
     # these are derived from
     # https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/29084/
-    patch('gcc11_1.patch', when='@4.1:%gcc@11:')
-    patch('gcc11_2.patch', when='@4.1:%gcc@11:')
-    patch('gcc11_3.patch', when='@4.1:%gcc@11:')
-    patch('gcc11_4.patch', when='@4.1:%gcc@11:')
+    patch('gcc11_1.patch', when='@0.3:4%gcc@11:')
+    patch('gcc11_2.patch', when='@0.3:4%gcc@11:')
+    patch('gcc11_3.patch', when='@0.3:4%gcc@11:')
+    patch('gcc11_4.patch', when='@4.1:4%gcc@11:')
 
     # bazel-4.0.0 does not compile with gcc-11
     # newer versions of grpc and abseil dependencies are needed but are not in
     # bazel-4.0.0
-    conflicts('@4.0.0', when='%gcc@11:')
+    conflicts('@:0.2,4.0.0', when='%gcc@11:')
 
     executables = ['^bazel$']
 

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -180,7 +180,20 @@ class Bazel(Package):
     # https://blog.bazel.build/2021/05/21/bazel-4-1.html
     conflicts("platform=darwin target=aarch64:", when="@:4.0")
 
-    executables = ["^bazel$"]
+    # patches for compiling bazel-4.1: with gcc-11
+    # these are derived from
+    # https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/29084/
+    patch('gcc11_1.patch', when='@4.1:%gcc@11:')
+    patch('gcc11_2.patch', when='@4.1:%gcc@11:')
+    patch('gcc11_3.patch', when='@4.1:%gcc@11:')
+    patch('gcc11_4.patch', when='@4.1:%gcc@11:')
+
+    # bazel-4.0.0 does not compile with gcc-11
+    # newer versions of grpc and abseil dependencies are needed but are not in
+    # bazel-4.0.0
+    conflicts('@4.0.0', when='%gcc@11:')
+
+    executables = ['^bazel$']
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -183,17 +183,17 @@ class Bazel(Package):
     # patches for compiling bazel-4.1:4 with gcc-11
     # these are derived from
     # https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/29084/
-    patch('gcc11_1.patch', when='@0.3:4%gcc@11:')
-    patch('gcc11_2.patch', when='@0.3:4%gcc@11:')
-    patch('gcc11_3.patch', when='@0.3:4%gcc@11:')
-    patch('gcc11_4.patch', when='@4.1:4%gcc@11:')
+    patch("gcc11_1.patch", when="@0.3:4%gcc@11:")
+    patch("gcc11_2.patch", when="@0.3:4%gcc@11:")
+    patch("gcc11_3.patch", when="@0.3:4%gcc@11:")
+    patch("gcc11_4.patch", when="@4.1:4%gcc@11:")
 
     # bazel-4.0.0 does not compile with gcc-11
     # newer versions of grpc and abseil dependencies are needed but are not in
     # bazel-4.0.0
-    conflicts('@:0.2,4.0.0', when='%gcc@11:')
+    conflicts("@:0.2,4.0.0", when="%gcc@11:")
 
-    executables = ['^bazel$']
+    executables = ["^bazel$"]
 
     @classmethod
     def determine_version(cls, exe):


### PR DESCRIPTION
Bazel does not currently build with GCC-11. There are patches available on the bazel project site for Alpine Linux that should work. The problem is that java-tools also needs patching.