### PR TITLE
Python: ensurepip should use `install` instead of `upgrade`

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -492,7 +492,7 @@ class Python(AutotoolsPackage):
 
         if spec.satisfies('@2.7.9:2,3.4:'):
             if '+ensurepip' in spec:
-                config_args.append('--with-ensurepip')
+                config_args.append('--with-ensurepip=install')
             else:
                 config_args.append('--without-ensurepip')
 


### PR DESCRIPTION
This fixes https://github.com/spack/spack/issues/28552, by ensuring that `setuptools` and `pip` are installed, and no attempt at upgrading is made.

@adamjstewart 