### PR TITLE
Add a command to generate a local mirror for bootstrapping

### DIFF
--- a/etc/spack/defaults/bootstrap.yaml
+++ b/etc/spack/defaults/bootstrap.yaml
@@ -10,9 +10,9 @@ bootstrap:
   # depending on its type.
   sources:
   - name: 'github-actions'
-    metadata: $spack/share/spack/bootstrap/github-actions/metadata.yaml
+    metadata: $spack/share/spack/bootstrap/github-actions
   - name: 'spack-install'
-    metadata: $spack/share/spack/bootstrap/spack-install/metadata.yaml
+    metadata: $spack/share/spack/bootstrap/spack-install
   trusted:
     # By default we trust bootstrapping from sources and from binaries
     # produced on Github via the workflow

--- a/etc/spack/defaults/bootstrap.yaml
+++ b/etc/spack/defaults/bootstrap.yaml
@@ -9,8 +9,10 @@ bootstrap:
   # may not be able to bootstrap all the software that Spack needs,
   # depending on its type.
   sources:
-  - name: 'github-actions'
-    metadata: $spack/share/spack/bootstrap/github-actions
+  - name: 'github-actions-v0.2'
+    metadata: $spack/share/spack/bootstrap/github-actions-v0.2
+  - name: 'github-actions-v0.1'
+    metadata: $spack/share/spack/bootstrap/github-actions-v0.1
   - name: 'spack-install'
     metadata: $spack/share/spack/bootstrap/spack-install
   trusted:

--- a/etc/spack/defaults/bootstrap.yaml
+++ b/etc/spack/defaults/bootstrap.yaml
@@ -6,34 +6,13 @@ bootstrap:
   # by Spack is installed in a "store" subfolder of this root directory
   root: $user_cache_path/bootstrap
   # Methods that can be used to bootstrap software. Each method may or
-  # may not be able to bootstrap all of the software that Spack needs,
+  # may not be able to bootstrap all the software that Spack needs,
   # depending on its type.
   sources:
-  - name: 'github-actions-v0.2'
-    type: buildcache
-    description: |
-      Buildcache generated from a public workflow using Github Actions.
-      The sha256 checksum of binaries is checked before installation.
-    info:
-      url: https://mirror.spack.io/bootstrap/github-actions/v0.2
-      homepage: https://github.com/spack/spack-bootstrap-mirrors
-      releases: https://github.com/spack/spack-bootstrap-mirrors/releases
-  - name: 'github-actions-v0.1'
-    type: buildcache
-    description: |
-      Buildcache generated from a public workflow using Github Actions.
-      The sha256 checksum of binaries is checked before installation.
-    info:
-      url: https://mirror.spack.io/bootstrap/github-actions/v0.1
-      homepage: https://github.com/spack/spack-bootstrap-mirrors
-      releases: https://github.com/spack/spack-bootstrap-mirrors/releases
-  # This method is just Spack bootstrapping the software it needs from sources.
-  # It has been added here so that users can selectively disable bootstrapping
-  # from sources by "untrusting" it.
-  - name: spack-install
-    type: install
-    description: |
-      Specs built from sources by Spack. May take a long time.
+  - name: 'github-actions'
+    metadata: $spack/share/spack/bootstrap/github-actions/metadata.yaml
+  - name: 'spack-install'
+    metadata: $spack/share/spack/bootstrap/spack-install/metadata.yaml
   trusted:
     # By default we trust bootstrapping from sources and from binaries
     # produced on Github via the workflow

--- a/lib/spack/docs/bootstrapping.rst
+++ b/lib/spack/docs/bootstrapping.rst
@@ -1,0 +1,160 @@
+.. Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+   Spack Project Developers. See the top-level COPYRIGHT file for details.
+
+   SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+.. _bootstrapping:
+
+=============
+Bootstrapping
+=============
+
+In the :ref:`Getting started <getting_started>` Section we already mentioned that
+Spack can bootstrap some of its dependencies, including ``clingo``. In fact, there
+is an entire command dedicated to the management of every aspect of bootstrapping:
+
+.. command-output:: spack bootstrap --help
+
+The first thing to know to understand bootstrapping in Spack is that each of
+Spack's dependencies is bootstrapped lazily; i.e. the first time it is needed and
+can't be found. You can readily check if any prerequisite for using Spack
+is missing by running:
+
+.. code-block:: console
+
+   % spack bootstrap status
+   Spack v0.17.1 - python@3.8
+
+   [FAIL] Core Functionalities
+     [B] MISSING "clingo": required to concretize specs
+
+   [FAIL] Binary packages
+     [B] MISSING "gpg2": required to sign/verify buildcaches
+
+
+   Spack will take care of bootstrapping any missing dependency marked as [B]. Dependencies marked as [-] are instead required to be found on the system.
+
+In the case of the output shown above Spack detected that both ``clingo`` and ``gnupg``
+are missing and it's giving detailed information on why they are needed and whether
+they can be bootstrapped. Running a command that concretize a spec, like:
+
+.. code-block:: console
+
+   % spack solve zlib
+   ==> Bootstrapping clingo from pre-built binaries
+   ==> Fetching https://mirror.spack.io/bootstrap/github-actions/v0.1/build_cache/darwin-catalina-x86_64/apple-clang-12.0.0/clingo-bootstrap-spack/darwin-catalina-x86_64-apple-clang-12.0.0-clingo-bootstrap-spack-p5on7i4hejl775ezndzfdkhvwra3hatn.spack
+   ==> Installing "clingo-bootstrap@spack%apple-clang@12.0.0~docs~ipo+python build_type=Release arch=darwin-catalina-x86_64" from a buildcache
+   [ ... ]
+
+triggers the bootstrapping of clingo from pre-built binaries as expected.
+
+-----------------------
+The Bootstrapping store
+-----------------------
+
+The software installed for bootstrapping purposes is deployed in a separate store.
+Its location can be checked with the following command:
+
+.. code-block:: console
+
+   % spack bootstrap root
+
+It can also be changed with the same command by just specifying the newly desired path:
+
+.. code-block:: console
+
+   % spack bootstrap root /opt/spack/bootstrap
+
+You can check what is installed in the bootstrapping store at any time using:
+
+.. code-block:: console
+
+   % spack find -b
+   ==> Showing internal bootstrap store at "/Users/spack/.spack/bootstrap/store"
+   ==> 11 installed packages
+   -- darwin-catalina-x86_64 / apple-clang@12.0.0 ------------------
+   clingo-bootstrap@spack  libassuan@2.5.5  libgpg-error@1.42  libksba@1.5.1  pinentry@1.1.1  zlib@1.2.11
+   gnupg@2.3.1             libgcrypt@1.9.3  libiconv@1.16      npth@1.6       python@3.8
+
+In case it is needed you can remove all the software in the current bootstrapping store with:
+
+.. code-block:: console
+
+   % spack clean -b
+   ==> Removing bootstrapped software and configuration in "/Users/spack/.spack/bootstrap"
+
+   % spack find -b
+   ==> Showing internal bootstrap store at "/Users/spack/.spack/bootstrap/store"
+   ==> 0 installed packages
+
+--------------------------------------------
+Enabling and disabling bootstrapping methods
+--------------------------------------------
+
+Bootstrapping is always performed by trying the methods listed by:
+
+.. command-output:: spack bootstrap list
+
+in the order they appear, from top to bottom. By default Spack is
+configured to try first bootstrapping from pre-built binaries and to
+fall-back to bootstrapping from sources if that failed.
+
+If need be, you can disable bootstrapping altogether by running:
+
+.. code-block:: console
+
+   % spack bootstrap disable
+
+in which case it's your responsibility to ensure Spack runs in an
+environment where all its prerequisites are installed. You can
+also configure Spack to skip certain bootstrapping methods by *untrusting*
+them. For instance:
+
+.. code-block:: console
+
+   % spack bootstrap untrust github-actions
+   ==> "github-actions" is now untrusted and will not be used for bootstrapping
+
+tells Spack to skip trying to bootstrap from binaries. To add the "github-actions" method back you can:
+
+.. code-block:: console
+
+   % spack bootstrap trust github-actions
+
+There is also an option to reset the bootstrapping configuration to Spack's defaults:
+
+.. code-block:: console
+
+   % spack bootstrap reset
+   ==> Bootstrapping configuration is being reset to Spack's defaults. Current configuration will be lost.
+   Do you want to continue? [Y/n]
+   %
+
+----------------------------------------
+Creating a mirror for air-gapped systems
+----------------------------------------
+
+Spack's default configuration for bootstrapping relies on the user having
+access to the internet, either to fetch pre-compiled binaries or source tarballs.
+Sometimes though Spack is deployed on air-gapped systems where such access is denied.
+
+To help with similar situations Spack has a command that recreates, in a local folder
+of choice, a mirror containing the source tarballs and/or binary packages needed for
+bootstrapping.
+
+.. code-block:: console
+
+   % spack bootstrap mirror --binary-packages /opt/bootstrap
+   ==> Adding "clingo-bootstrap@spack+python %apple-clang target=x86_64" and dependencies to the mirror at /opt/bootstrap/local-mirror
+   ==> Adding "gnupg@2.3: %apple-clang target=x86_64" and dependencies to the mirror at /opt/bootstrap/local-mirror
+   ==> Adding "patchelf@0.13.1:0.13.99 %apple-clang target=x86_64" and dependencies to the mirror at /opt/bootstrap/local-mirror
+   ==> Adding binary packages from "https://github.com/alalazo/spack-bootstrap-mirrors/releases/download/v0.1-rc.2/bootstrap-buildcache.tar.gz" to the mirror at /opt/bootstrap/local-mirror
+
+   To register the mirror on the platform where it's supposed to be used run the following command(s):
+     % spack bootstrap add --trust local-sources /opt/bootstrap/metadata/sources
+     % spack bootstrap add --trust local-binaries /opt/bootstrap/metadata/binaries
+
+
+This command needs to be run on a machine with internet access and the resulting folder
+has to be moved over to the air-gapped system. Once the local sources are added using the
+commands suggested at the prompt, they can be used to bootstrap Spack.

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -63,6 +63,7 @@ or refer to the full manual below.
 
    configuration
    config_yaml
+   bootstrapping
    build_settings
    environments
    containers

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -351,8 +351,16 @@ class _BuildcacheBootstrapper(object):
 class _SourceBootstrapper(object):
     """Install the software needed during bootstrapping from sources."""
     def __init__(self, conf):
+        self.name = conf['name']
+        self.url = conf['info']['url']
         self.conf = conf
         self.last_search = None
+
+    @property
+    def mirror_scope(self):
+        return spack.config.InternalConfigScope(
+            'bootstrap_source', {'mirrors:': {self.name: self.url}}
+        )
 
     def try_import(self, module, abstract_spec_str):
         info = {}
@@ -383,7 +391,8 @@ class _SourceBootstrapper(object):
         tty.debug(msg.format(module, abstract_spec_str))
 
         # Install the spec that should make the module importable
-        concrete_spec.package.do_install(fail_fast=True)
+        with spack.config.override(self.mirror_scope):
+            concrete_spec.package.do_install(fail_fast=True)
 
         if _try_import_from_store(module, query_spec=concrete_spec, query_info=info):
             self.last_search = info
@@ -408,7 +417,8 @@ class _SourceBootstrapper(object):
 
         msg = "[BOOTSTRAP] Try installing '{0}' from sources"
         tty.debug(msg.format(abstract_spec_str))
-        concrete_spec.package.do_install()
+        with spack.config.override(self.mirror_scope):
+            concrete_spec.package.do_install()
         if _executables_in_store(executables, concrete_spec, query_info=info):
             self.last_search = info
             return True

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -833,6 +833,19 @@ def ensure_flake8_in_path_or_raise():
     return ensure_executables_in_path_or_raise([executable], abstract_spec=root_spec)
 
 
+def all_root_specs(development=False):
+    """Return a list of all the root specs that may be used to bootstrap Spack.
+
+    Args:
+        development (bool): if True include dev dependencies
+    """
+    specs = [clingo_root_spec(), gnupg_root_spec(), patchelf_root_spec()]
+    if development:
+        specs += [isort_root_spec(), mypy_root_spec(),
+                  black_root_spec(), flake8_root_spec()]
+    return specs
+
+
 def _missing(name, purpose, system_only=True):
     """Message to be printed if an executable is not found"""
     msg = '[{2}] MISSING "{0}": {1}'

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -437,6 +437,8 @@ class _SourceBootstrapper(object):
             self.last_search = info
             return True
 
+        tty.info("Bootstrapping {0} from sources".format(abstract_spec_str))
+
         # If we compile code from sources detecting a few build tools
         # might reduce compilation time by a fair amount
         _add_externals_if_missing()

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 
 import contextlib
+import copy
 import fnmatch
 import functools
 import json
@@ -211,6 +212,7 @@ class _BuildcacheBootstrapper(object):
     def __init__(self, conf):
         self.name = conf['name']
         self.url = conf['info']['url']
+        self.metadata_file = conf['metadata']
         self.last_search = None
 
     @staticmethod
@@ -233,8 +235,9 @@ class _BuildcacheBootstrapper(object):
     def _read_metadata(self, package_name):
         """Return metadata about the given package."""
         json_filename = '{0}.json'.format(package_name)
-        json_path = os.path.join(
-            spack.paths.share_path, 'bootstrap', self.name, json_filename
+        json_dir = os.path.dirname(self.metadata_file)
+        json_path = spack.util.path.canonicalize_path(
+            os.path.join(json_dir, json_filename)
         )
         with open(json_path) as f:
             data = json.load(f)
@@ -965,9 +968,13 @@ def bootstrapping_sources(scope=None):
         scope (str or None): if a valid configuration scope is given, return the
             list only from that scope
     """
-    source_configs = spack.config.get('bootstrap:sources', [], scope=scope)
+    source_configs = spack.config.get('bootstrap:sources', default=None, scope=scope)
+    source_configs = source_configs or []
+    list_of_sources = []
     for entry in source_configs:
+        current = copy.copy(entry)
         metadata_file = spack.util.path.canonicalize_path(entry['metadata'])
         with open(metadata_file) as f:
-            entry.update(ruamel.yaml.load(f))
-    return source_configs
+            current.update(ruamel.yaml.load(f))
+        list_of_sources.append(current)
+    return list_of_sources

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -320,14 +320,12 @@ class _BuildcacheBootstrapper(object):
         if os.path.isabs(self.url):
             return spack.util.url.format(self.url)
 
-        # Relative paths
-        if self.url.startswith('.'):
-            return spack.util.url.format(
-                os.path.join(self.metadata_dir, self.url)
-            )
+        # Check for :// and assume it's an url if we find it
+        if '://' in self.url:
+            return self.url
 
-        # By default assume it's already a url
-        return self.url
+        # Otherwise, it's a relative path
+        return spack.util.url.format(os.path.join(self.metadata_dir, self.url))
 
     @property
     def mirror_scope(self):
@@ -379,14 +377,12 @@ class _SourceBootstrapper(object):
         if os.path.isabs(self.url):
             return spack.util.url.format(self.url)
 
-        # Relative paths
-        if self.url.startswith('.'):
-            return spack.util.url.format(
-                os.path.join(self.metadata_dir, self.url)
-            )
+        # Check for :// and assume it's an url if we find it
+        if '://' in self.url:
+            return self.url
 
-        # By default assume it's already a url
-        return self.url
+        # Otherwise, it's a relative path
+        return spack.util.url.format(os.path.join(self.metadata_dir, self.url))
 
     @property
     def mirror_scope(self):

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -40,6 +40,9 @@ import spack.util.environment
 import spack.util.executable
 import spack.util.path
 
+#: Name of the file containing metadata about the bootstrapping source
+METADATA_YAML_FILENAME = 'metadata.yaml'
+
 #: Map a bootstrapper type to the corresponding class
 _bootstrap_methods = {}
 
@@ -212,7 +215,7 @@ class _BuildcacheBootstrapper(object):
     def __init__(self, conf):
         self.name = conf['name']
         self.url = conf['info']['url']
-        self.metadata_file = conf['metadata']
+        self.metadata_dir = spack.util.path.canonicalize_path(conf['metadata'])
         self.last_search = None
 
     @staticmethod
@@ -235,10 +238,8 @@ class _BuildcacheBootstrapper(object):
     def _read_metadata(self, package_name):
         """Return metadata about the given package."""
         json_filename = '{0}.json'.format(package_name)
-        json_dir = os.path.dirname(self.metadata_file)
-        json_path = spack.util.path.canonicalize_path(
-            os.path.join(json_dir, json_filename)
-        )
+        json_dir = self.metadata_dir
+        json_path = os.path.join(json_dir, json_filename)
         with open(json_path) as f:
             data = json.load(f)
         return data
@@ -973,8 +974,9 @@ def bootstrapping_sources(scope=None):
     list_of_sources = []
     for entry in source_configs:
         current = copy.copy(entry)
-        metadata_file = spack.util.path.canonicalize_path(entry['metadata'])
-        with open(metadata_file) as f:
+        metadata_dir = spack.util.path.canonicalize_path(entry['metadata'])
+        metadata_yaml = os.path.join(metadata_dir, METADATA_YAML_FILENAME)
+        with open(metadata_yaml) as f:
             current.update(ruamel.yaml.load(f))
         list_of_sources.append(current)
     return list_of_sources

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -16,7 +16,6 @@ import re
 import sys
 import sysconfig
 
-import ruamel.yaml
 import six
 
 import archspec.cpu
@@ -39,6 +38,7 @@ import spack.user_environment
 import spack.util.environment
 import spack.util.executable
 import spack.util.path
+import spack.util.spack_yaml
 
 #: Name of the file containing metadata about the bootstrapping source
 METADATA_YAML_FILENAME = 'metadata.yaml'
@@ -977,6 +977,6 @@ def bootstrapping_sources(scope=None):
         metadata_dir = spack.util.path.canonicalize_path(entry['metadata'])
         metadata_yaml = os.path.join(metadata_dir, METADATA_YAML_FILENAME)
         with open(metadata_yaml) as f:
-            current.update(ruamel.yaml.load(f))
+            current.update(spack.util.spack_yaml.load(f))
         list_of_sources.append(current)
     return list_of_sources

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -524,7 +524,6 @@ def ensure_module_importable_or_raise(module, abstract_spec=None):
         return
 
     abstract_spec = abstract_spec or module
-    source_configs = spack.config.get('bootstrap:sources', [])
 
     h = GroupedExceptionHandler()
 
@@ -567,7 +566,6 @@ def ensure_executables_in_path_or_raise(executables, abstract_spec):
         return cmd
 
     executables_str = ', '.join(executables)
-    source_configs = spack.config.get('bootstrap:sources', [])
 
     h = GroupedExceptionHandler()
 

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -92,6 +92,9 @@ def setup_parser(subparser):
     )
     _add_scope_option(add)
     add.add_argument(
+        '--trust', action='store_true',
+        help='trust the source immediately upon addition')
+    add.add_argument(
         'name', help='name of the new source of software'
     )
     add.add_argument(
@@ -294,6 +297,8 @@ def _add(args):
 
     msg = 'New bootstrapping source "{0}" added in the "{1}" configuration scope'
     llnl.util.tty.msg(msg.format(args.name, write_scope))
+    if args.trust:
+        _trust(args)
 
 
 def _remove(args):

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -95,7 +95,7 @@ def setup_parser(subparser):
         'name', help='name of the new source of software'
     )
     add.add_argument(
-        'metadata', help='location of the metadata file'
+        'metadata_dir', help='directory where to find metadata files'
     )
 
     remove = sp.add_parser(
@@ -275,16 +275,21 @@ def _add(args):
         raise RuntimeError(msg.format(args.name))
 
     # Check that the metadata file exists
-    file = spack.util.path.canonicalize_path(args.metadata)
+    metadata_dir = spack.util.path.canonicalize_path(args.metadata_dir)
+    if not os.path.exists(metadata_dir) or not os.path.isdir(metadata_dir):
+        raise RuntimeError(
+            'the directory "{0}" does not exist'.format(args.metadata_dir)
+        )
+
+    file = os.path.join(metadata_dir, 'metadata.yaml')
     if not os.path.exists(file):
-        msg = 'the file "{0}" does not exist'
-        raise RuntimeError(msg.format(args.metadata))
+        raise RuntimeError('the file "{0}" does not exist'.format(file))
 
     # Insert the new source as the highest priority one
     write_scope = args.scope or spack.config.default_modify_scope(section='bootstrap')
     sources = spack.config.get('bootstrap:sources', scope=write_scope) or []
     sources = [
-        {'name': args.name, 'metadata': args.metadata}
+        {'name': args.name, 'metadata': args.metadata_dir}
     ] + sources
     spack.config.set('bootstrap:sources', sources, scope=write_scope)
 

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -101,7 +101,6 @@ def setup_parser(subparser):
     remove = sp.add_parser(
         'remove', help='remove a bootstrapping source'
     )
-    _add_scope_option(remove)
     remove.add_argument(
         'name', help='name of the source to be removed'
     )

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -137,10 +137,7 @@ def _root(args):
 
 
 def _list(args):
-    sources = spack.config.get(
-        'bootstrap:sources', default=None, scope=args.scope
-    )
-
+    sources = spack.bootstrap.bootstrapping_sources(scope=args.scope)
     if not sources:
         llnl.util.tty.msg(
             "No method available for bootstrapping Spack's dependencies"

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -158,7 +158,7 @@ def setup_parser(subparser):
     )
     mirror.add_argument(
         metavar='DIRECTORY', dest='root_dir',
-        help='root directory where to create the mirror and metadata'
+        help='root directory in which to create the mirror and metadata'
     )
 
 

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -30,13 +30,16 @@ level = "long"
 # Tarball to be downloaded if binary packages are requested in a local mirror
 BINARY_TARBALL = 'https://github.com/alalazo/spack-bootstrap-mirrors/releases/download/v0.1-rc.2/bootstrap-buildcache.tar.gz'
 
+#: Subdirectory where to create the mirror
+LOCAL_MIRROR_DIR = 'local-mirror'
+
 # Metadata for a generated binary mirror
 BINARY_METADATA = {
     'type': 'buildcache',
     'description': ('Buildcache copied from a public tarball available on Github.'
                     'The sha256 checksum of binaries is checked before installation.'),
     'info': {
-        'url': None,
+        'url': os.path.join('..', '..', LOCAL_MIRROR_DIR),
         'homepage': 'https://github.com/alalazo/spack-bootstrap-mirrors',
         'releases': 'https://github.com/alalazo/spack-bootstrap-mirrors/releases',
         'tarball': BINARY_TARBALL
@@ -51,7 +54,7 @@ SOURCE_METADATA = {
     'type': 'install',
     'description': 'Mirror with software needed to bootstrap Spack',
     'info': {
-        'url': None
+        'url': os.path.join('..', '..', LOCAL_MIRROR_DIR)
     }
 }
 
@@ -376,7 +379,7 @@ def _remove(args):
 
 
 def _mirror(args):
-    mirror_dir = os.path.join(args.root_dir, 'local-mirror')
+    mirror_dir = os.path.join(args.root_dir, LOCAL_MIRROR_DIR)
 
     for spec_str in spack.bootstrap.all_root_specs(development=args.dev):
         msg = 'Adding "{0}" and dependencies to the mirror at {1}'
@@ -404,7 +407,6 @@ def _mirror(args):
         metadata_yaml = os.path.join(
             args.root_dir, 'metadata', subdir, 'metadata.yaml'
         )
-        metadata['info']['url'] = 'file://' + os.path.abspath(mirror_dir)
         llnl.util.filesystem.mkdirp(os.path.dirname(metadata_yaml))
         with open(metadata_yaml, mode='w') as f:
             spack.util.spack_yaml.dump(metadata, stream=f)

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -31,7 +31,7 @@ level = "long"
 BINARY_TARBALL = 'https://github.com/spack/spack-bootstrap-mirrors/releases/download/v0.2/bootstrap-buildcache.tar.gz'
 
 #: Subdirectory where to create the mirror
-LOCAL_MIRROR_DIR = 'local-mirror'
+LOCAL_MIRROR_DIR = 'bootstrap_cache'
 
 # Metadata for a generated binary mirror
 BINARY_METADATA = {

--- a/lib/spack/spack/cmd/bootstrap.py
+++ b/lib/spack/spack/cmd/bootstrap.py
@@ -28,7 +28,7 @@ level = "long"
 
 
 # Tarball to be downloaded if binary packages are requested in a local mirror
-BINARY_TARBALL = 'https://github.com/alalazo/spack-bootstrap-mirrors/releases/download/v0.1-rc.2/bootstrap-buildcache.tar.gz'
+BINARY_TARBALL = 'https://github.com/spack/spack-bootstrap-mirrors/releases/download/v0.2/bootstrap-buildcache.tar.gz'
 
 #: Subdirectory where to create the mirror
 LOCAL_MIRROR_DIR = 'local-mirror'
@@ -40,14 +40,14 @@ BINARY_METADATA = {
                     'The sha256 checksum of binaries is checked before installation.'),
     'info': {
         'url': os.path.join('..', '..', LOCAL_MIRROR_DIR),
-        'homepage': 'https://github.com/alalazo/spack-bootstrap-mirrors',
-        'releases': 'https://github.com/alalazo/spack-bootstrap-mirrors/releases',
+        'homepage': 'https://github.com/spack/spack-bootstrap-mirrors',
+        'releases': 'https://github.com/spack/spack-bootstrap-mirrors/releases',
         'tarball': BINARY_TARBALL
     }
 }
 
-CLINGO_JSON = '$spack/share/spack/bootstrap/github-actions/clingo.json'
-GNUPG_JSON = '$spack/share/spack/bootstrap/github-actions/gnupg.json'
+CLINGO_JSON = '$spack/share/spack/bootstrap/github-actions-v0.2/clingo.json'
+GNUPG_JSON = '$spack/share/spack/bootstrap/github-actions-v0.2/gnupg.json'
 
 # Metadata for a generated source mirror
 SOURCE_METADATA = {

--- a/lib/spack/spack/schema/bootstrap.py
+++ b/lib/spack/spack/schema/bootstrap.py
@@ -9,12 +9,10 @@ _source_schema = {
     'type': 'object',
     'properties': {
         'name': {'type': 'string'},
-        'description': {'type': 'string'},
-        'type': {'type': 'string'},
-        'info': {'type': 'object'}
+        'metadata': {'type': 'string'}
     },
     'additionalProperties': False,
-    'required': ['name', 'description', 'type']
+    'required': ['name', 'metadata']
 }
 
 properties = {

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -139,9 +139,9 @@ def test_trust_or_untrust_fails_with_no_method(mutable_config):
 def test_trust_or_untrust_fails_with_more_than_one_method(mutable_config):
     wrong_config = {'sources': [
         {'name': 'github-actions',
-         'metadata': '$spack/share/spack/bootstrap/github-actions/metadata.yaml'},
+         'metadata': '$spack/share/spack/bootstrap/github-actions'},
         {'name': 'github-actions',
-         'metadata': '$spack/share/spack/bootstrap/github-actions/metadata.yaml'}],
+         'metadata': '$spack/share/spack/bootstrap/github-actions'}],
         'trusted': {}
     }
     with spack.config.override('bootstrap', wrong_config):

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -156,9 +156,9 @@ def test_add_failures_for_non_existing_files(mutable_config, tmpdir, use_existin
         _bootstrap('add', 'mock-mirror', metadata_dir)
 
 
-def test_add_failures_for_already_existing_name(mutable_config, tmpdir):
+def test_add_failures_for_already_existing_name(mutable_config):
     with pytest.raises(RuntimeError, match='already exist'):
-        _bootstrap('add', 'github-actions', str(tmpdir))
+        _bootstrap('add', 'github-actions', 'some-place')
 
 
 def test_remove_failure_for_non_existing_names(mutable_config):

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -186,6 +186,7 @@ def test_remove_and_add_a_source(mutable_config):
 
 
 @pytest.mark.maybeslow
+@pytest.mark.skipif(sys.platform == 'win32', reason="Not supported on Windows (yet)")
 def test_bootstrap_mirror_metadata(mutable_config, linux_os, monkeypatch, tmpdir):
     """Test that `spack bootstrap mirror` creates a folder that can be ingested by
     `spack bootstrap add`. Here we don't download data, since that would be an

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -177,6 +177,8 @@ def test_remove_and_add_a_source(mutable_config):
     assert not sources
 
     # Add it back and check we restored the initial state
-    _bootstrap('add', 'github-actions', '$spack/share/spack/bootstrap/github-actions')
+    _bootstrap(
+        'add', 'github-actions', '$spack/share/spack/bootstrap/github-actions-v0.2'
+    )
     sources = spack.bootstrap.bootstrapping_sources()
     assert len(sources) == 1

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -139,11 +139,9 @@ def test_trust_or_untrust_fails_with_no_method(mutable_config):
 def test_trust_or_untrust_fails_with_more_than_one_method(mutable_config):
     wrong_config = {'sources': [
         {'name': 'github-actions',
-         'type': 'buildcache',
-         'description': ''},
+         'metadata': '$spack/share/spack/bootstrap/github-actions/metadata.yaml'},
         {'name': 'github-actions',
-         'type': 'buildcache',
-         'description': 'Another entry'}],
+         'metadata': '$spack/share/spack/bootstrap/github-actions/metadata.yaml'}],
         'trusted': {}
     }
     with spack.config.override('bootstrap', wrong_config):

--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -147,3 +147,36 @@ def test_trust_or_untrust_fails_with_more_than_one_method(mutable_config):
     with spack.config.override('bootstrap', wrong_config):
         with pytest.raises(RuntimeError, match='more than one'):
             _bootstrap('trust', 'github-actions')
+
+
+@pytest.mark.parametrize('use_existing_dir', [True, False])
+def test_add_failures_for_non_existing_files(mutable_config, tmpdir, use_existing_dir):
+    metadata_dir = str(tmpdir) if use_existing_dir else '/foo/doesnotexist'
+    with pytest.raises(RuntimeError, match='does not exist'):
+        _bootstrap('add', 'mock-mirror', metadata_dir)
+
+
+def test_add_failures_for_already_existing_name(mutable_config, tmpdir):
+    with pytest.raises(RuntimeError, match='already exist'):
+        _bootstrap('add', 'github-actions', str(tmpdir))
+
+
+def test_remove_failure_for_non_existing_names(mutable_config):
+    with pytest.raises(RuntimeError, match='cannot find'):
+        _bootstrap('remove', 'mock-mirror')
+
+
+def test_remove_and_add_a_source(mutable_config):
+    # Check we start with a single bootstrapping source
+    sources = spack.bootstrap.bootstrapping_sources()
+    assert len(sources) == 1
+
+    # Remove it and check the result
+    _bootstrap('remove', 'github-actions')
+    sources = spack.bootstrap.bootstrapping_sources()
+    assert not sources
+
+    # Add it back and check we restored the initial state
+    _bootstrap('add', 'github-actions', '$spack/share/spack/bootstrap/github-actions')
+    sources = spack.bootstrap.bootstrapping_sources()
+    assert len(sources) == 1

--- a/lib/spack/spack/test/data/config/bootstrap.yaml
+++ b/lib/spack/spack/test/data/config/bootstrap.yaml
@@ -1,5 +1,5 @@
 bootstrap:
   sources:
   - name: 'github-actions'
-    metadata: $spack/share/spack/bootstrap/github-actions/metadata.yaml
+    metadata: $spack/share/spack/bootstrap/github-actions
   trusted: {}

--- a/lib/spack/spack/test/data/config/bootstrap.yaml
+++ b/lib/spack/spack/test/data/config/bootstrap.yaml
@@ -1,5 +1,5 @@
 bootstrap:
   sources:
   - name: 'github-actions'
-    metadata: $spack/share/spack/bootstrap/github-actions
+    metadata: $spack/share/spack/bootstrap/github-actions-v0.2
   trusted: {}

--- a/lib/spack/spack/test/data/config/bootstrap.yaml
+++ b/lib/spack/spack/test/data/config/bootstrap.yaml
@@ -1,12 +1,5 @@
 bootstrap:
   sources:
   - name: 'github-actions'
-    type: buildcache
-    description: |
-      Buildcache generated from a public workflow using Github Actions.
-      The sha256 checksum of binaries is checked before installation.
-    info:
-      url: file:///home/spack/production/spack/mirrors/clingo
-      homepage: https://github.com/alalazo/spack-bootstrap-mirrors
-      releases: https://github.com/alalazo/spack-bootstrap-mirrors/releases
+    metadata: $spack/share/spack/bootstrap/github-actions/metadata.yaml
   trusted: {}

--- a/share/spack/bootstrap/github-actions-v0.1/metadata.yaml
+++ b/share/spack/bootstrap/github-actions-v0.1/metadata.yaml
@@ -1,0 +1,8 @@
+type: buildcache
+description: |
+  Buildcache generated from a public workflow using Github Actions.
+  The sha256 checksum of binaries is checked before installation.
+info:
+  url: https://mirror.spack.io/bootstrap/github-actions/v0.1
+  homepage: https://github.com/alalazo/spack-bootstrap-mirrors
+  releases: https://github.com/alalazo/spack-bootstrap-mirrors/releases

--- a/share/spack/bootstrap/github-actions-v0.2/metadata.yaml
+++ b/share/spack/bootstrap/github-actions-v0.2/metadata.yaml
@@ -3,6 +3,6 @@ description: |
   Buildcache generated from a public workflow using Github Actions.
   The sha256 checksum of binaries is checked before installation.
 info:
-  url: https://mirror.spack.io/bootstrap/github-actions/v0.1
+  url: https://mirror.spack.io/bootstrap/github-actions/v0.2
   homepage: https://github.com/spack/spack-bootstrap-mirrors
   releases: https://github.com/spack/spack-bootstrap-mirrors/releases

--- a/share/spack/bootstrap/spack-install/metadata.yaml
+++ b/share/spack/bootstrap/spack-install/metadata.yaml
@@ -1,0 +1,6 @@
+# This method is just Spack bootstrapping the software it needs from sources.
+# It has been added here so that users can selectively disable bootstrapping
+# from sources by "untrusting" it.
+type: install
+description: |
+  Specs built from sources by Spack. May take a long time.

--- a/share/spack/bootstrap/spack-install/metadata.yaml
+++ b/share/spack/bootstrap/spack-install/metadata.yaml
@@ -3,4 +3,6 @@
 # from sources by "untrusting" it.
 type: install
 description: |
-  Specs built from sources by Spack. May take a long time.
+  Specs built from sources downloaded from the Spack public mirror.
+info:
+  url: https://mirror.spack.io

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -488,7 +488,7 @@ _spack_bootstrap_untrust() {
 _spack_bootstrap_add() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help --scope --trust"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -434,7 +434,7 @@ _spack_bootstrap() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="status enable disable reset root list trust untrust"
+        SPACK_COMPREPLY="status enable disable reset root list trust untrust add remove"
     fi
 }
 
@@ -477,6 +477,24 @@ _spack_bootstrap_trust() {
 }
 
 _spack_bootstrap_untrust() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --scope"
+    else
+        SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_bootstrap_add() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --scope"
+    else
+        SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_bootstrap_remove() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help --scope"

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -497,7 +497,7 @@ _spack_bootstrap_add() {
 _spack_bootstrap_remove() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --scope"
+        SPACK_COMPREPLY="-h --help"
     else
         SPACK_COMPREPLY=""
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -434,7 +434,7 @@ _spack_bootstrap() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="status enable disable reset root list trust untrust add remove"
+        SPACK_COMPREPLY="status enable disable reset root list trust untrust add remove mirror"
     fi
 }
 
@@ -498,6 +498,15 @@ _spack_bootstrap_remove() {
     if $list_options
     then
         SPACK_COMPREPLY="-h --help"
+    else
+        SPACK_COMPREPLY=""
+    fi
+}
+
+_spack_bootstrap_mirror() {
+    if $list_options
+    then
+        SPACK_COMPREPLY="-h --help --binary-packages --dev"
     else
         SPACK_COMPREPLY=""
     fi


### PR DESCRIPTION
fixes #28540 
fixes #28510 

closes #26306

This PR builds on #28392 by adding a convenience command to create a local mirror that can be used to bootstrap Spack. This is to overcome the inconvenience in setting up this mirror manually, which has been reported when trying to setup Spack on air-gapped systems.

Using this PR the user can create a bootstrapping mirror, on a machine with internet access, by:
```console
% spack bootstrap mirror --binary-packages /opt/bootstrap
==> Adding "clingo-bootstrap@spack+python %apple-clang target=x86_64" and dependencies to the mirror at /opt/bootstrap/local-mirror
==> Adding "gnupg@2.3: %apple-clang target=x86_64" and dependencies to the mirror at /opt/bootstrap/local-mirror
==> Adding "patchelf@0.13.1:0.13.99 %apple-clang target=x86_64" and dependencies to the mirror at /opt/bootstrap/local-mirror
==> Adding binary packages from "https://github.com/alalazo/spack-bootstrap-mirrors/releases/download/v0.1-rc.2/bootstrap-buildcache.tar.gz" to the mirror at /opt/bootstrap/local-mirror

To register the mirror on the platform where it's supposed to be used run the following command(s):
  % spack bootstrap add --trust local-sources /opt/bootstrap/metadata/sources
  % spack bootstrap add --trust local-binaries /opt/bootstrap/metadata/binaries
```
The mirror has to be moved over to the air-gapped system, and registered using the commands shown at prompt. The command has options to:
1. Add pre-built binaries downloaded from Github (default is not to add them)
2. Add development dependencies for Spack (currently the Python packages needed to use `spack style`)

Modifications:
- [x] Add the `spack bootstrap mirror` command
- [x] Add documentation 