### PR TITLE
add package for flux-pmix

### DIFF
--- a/var/spack/repos/builtin/packages/flux-pmix/package.py
+++ b/var/spack/repos/builtin/packages/flux-pmix/package.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+from spack import *
+
+
+class FluxPmix(AutotoolsPackage):
+    """ A flux shell plugin to bootstrap openmpi v5+ """
+
+    homepage = "https://github.com/flux-framework/flux-pmix"
+    url      = "https://github.com/flux-framework/flux-pmix/releases/download/v0.1.0/flux-pmix-0.1.0.tar.gz"
+    git      = "https://github.com/flux-framework/flux-pmix.git"
+
+    maintainers = ['grondo']
+
+    version('main', branch='main')
+    version('0.2.0', sha256='d09f1fe6ffe54f83be4677e1e727640521d8110090515d94013eba0f58216934')
+
+    depends_on('flux-core@0.30.0:')
+    depends_on('pmix@v4.1.0:')
+    depends_on('openmpi')
+
+    depends_on('pkg-config', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+
+    def autoreconf(self, spec, prefix):
+        if not os.path.exists('configure'):
+            # Bootstrap with autotools
+            bash = which('bash')
+            bash('./autogen.sh')
+
+    @run_after('install')
+    def add_pluginpath(self):
+        rcfile = join_path(self.prefix.etc,
+                           'flux/shell/lua.d/mpi/openmpi@5.lua')
+        filter_file(r'pmix/pmix.so',
+                    join_path(self.prefix.lib,
+                              "flux/shell/plugins/pmix/pmix.so"), rcfile)
+
+    def setup_run_environment(self, env):
+        env.prepend_path('FLUX_SHELL_RC_PATH',
+                         join_path(self.prefix, 'etc/flux/shell/lua.d'))

--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -35,6 +35,7 @@ class Pmix(AutotoolsPackage):
     maintainers = ['rhc54']
 
     version('master', branch='master')
+    version('4.1.0',    sha256='145f05a6c621bfb3fc434776b615d7e6d53260cc9ba340a01f55b383e07c842e')
     version('3.2.1',    sha256='7e5db8ada5828cf85c12f70db6bfcf777d13e5c4c73b2206bb5e394d47066a2b')
     version('3.1.5',    sha256='88934195174455df478b996313095df25b51d0caf5a5cce01b22f0ccdc6c5cf7')
     version('3.1.3',    sha256='118acb9c4e10c4e481406dcffdfa762f314af50db75336bf8460e53b56dc439d')


### PR DESCRIPTION
This PR adds a package for flux-pmix, a job shell plugin for Flux which allows boostrapping OpenMPI v5.0+ executables.

Edit: requisite version of pmix 4.1.0 is also added as part of this pr