### PR TITLE
grep: prevent recursive symlink

### DIFF
--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -14,3 +14,5 @@ class Grep(AutotoolsPackage):
 
     version('3.7', sha256='5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c')
     version('3.3', sha256='b960541c499619efd6afe1fa795402e4733c8e11ebf9fafccc0bb4bccdc5b514')
+
+    build_directory = 'spack-build'


### PR DESCRIPTION
At least on macOS, `configure` will create a `GNUmakefile` symlink that ends up symlinking to itself, so you end up in infinite recursion during building. Building in a separate directory from source solves the issue for me.

Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0.