### PR TITLE
py-build: python+ensurepip not required

### DIFF
--- a/var/spack/repos/builtin/packages/py-build/isolation.patch
+++ b/var/spack/repos/builtin/packages/py-build/isolation.patch
@@ -1,0 +1,10 @@
+--- a/src/build/env.py	2021-09-16 16:20:01.000000000 -0500
++++ b/src/build/env.py	2022-01-23 15:08:26.000000000 -0600
+@@ -254,6 +254,7 @@
+     """
+     import venv
+ 
++    os.environ.pop('PYTHONPATH', None)
+     venv.EnvBuilder(with_pip=True, symlinks=_fs_supports_symlink()).create(path)
+     executable, script_dir, purelib = _find_executable_and_scripts(path)
+ 

--- a/var/spack/repos/builtin/packages/py-build/package.py
+++ b/var/spack/repos/builtin/packages/py-build/package.py
@@ -16,7 +16,7 @@ class PyBuild(PythonPackage):
 
     variant('virtualenv', default=False, description='Install optional virtualenv dependency')
 
-    depends_on('python@3.6:+ensurepip', type=('build', 'run'))
+    depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-packaging@19:', type=('build', 'run'))
     depends_on('py-pep517@0.9.1:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-build/package.py
+++ b/var/spack/repos/builtin/packages/py-build/package.py
@@ -24,3 +24,7 @@ class PyBuild(PythonPackage):
     depends_on('py-colorama', when='platform=windows', type=('build', 'run'))
     depends_on('py-importlib-metadata@0.22:', when='^python@:3.7', type=('build', 'run'))
     depends_on('py-virtualenv@20.0.35:', when='+virtualenv', type=('build', 'run'))
+
+    # https://github.com/pypa/build/issues/266
+    # https://github.com/pypa/build/issues/406
+    patch('isolation.patch', when='@0.7.0')


### PR DESCRIPTION
As far as I can tell, it doesn't matter how Python was configured, build simply doesn't work if pip is in `PYTHONPATH`. See https://github.com/pypa/build/issues/266#issuecomment-1019408854 for more discussion.