### PR TITLE
py-pandas: add v1.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -14,6 +14,7 @@ class PyPandas(PythonPackage):
 
     maintainers = ['adamjstewart']
 
+    version('1.4.0',  sha256='cdd76254c7f0a1583bd4e4781fb450d0ebf392e10d3f12e92c95575942e37df5')
     version('1.3.5',  sha256='1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1')
     version('1.3.4',  sha256='a2aa18d3f0b7d538e21932f637fbfe8518d085238b429e4790a35e1e44a96ffc')
     version('1.3.3',  sha256='272c8cb14aa9793eada6b1ebe81994616e647b5892a370c7135efb2924b701df')
@@ -55,6 +56,7 @@ class PyPandas(PythonPackage):
 
     # Required dependencies
     # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#dependencies
+    depends_on('python@3.8:', type=('build', 'run'), when='@1.4:')
     depends_on('python@3.7.1:', type=('build', 'run'), when='@1.2:')
     depends_on('python@3.6.1:', type=('build', 'run'), when='@1:')
     depends_on('python@3.5.3:', type=('build', 'run'), when='@0.25:')
@@ -67,17 +69,20 @@ class PyPandas(PythonPackage):
     depends_on('py-setuptools@38.6.0:', type='build', when='@1.3:')
     depends_on('py-setuptools@51.0.0:', type='build', when='@1.3.2:')
     depends_on('py-numpy', type=('build', 'run'))
-    # 'NUMPY_IMPORT_ARRAY_RETVAL' was removed in numpy@0.19
+    # 'NUMPY_IMPORT_ARRAY_RETVAL' was removed in numpy@1.19
     depends_on('py-numpy@:1.18', type=('build', 'run'), when='@:0.25')
     depends_on('py-numpy@1.13.3:', type=('build', 'run'), when='@0.25:')
     depends_on('py-numpy@1.15.4:', type=('build', 'run'), when='@1.1:')
     depends_on('py-numpy@1.16.5:', type=('build', 'run'), when='@1.2:')
     depends_on('py-numpy@1.17.3:', type=('build', 'run'), when='@1.3:')
+    depends_on('py-numpy@1.18.5:', type=('build', 'run'), when='@1.4:')
     depends_on('py-python-dateutil', type=('build', 'run'))
     depends_on('py-python-dateutil@2.6.1:', type=('build', 'run'), when='@0.25:')
     depends_on('py-python-dateutil@2.7.3:', type=('build', 'run'), when='@1.1:')
+    depends_on('py-python-dateutil@2.8.1:', type=('build', 'run'), when='@1.4:')
     depends_on('py-pytz@2017.2:', type=('build', 'run'))
     depends_on('py-pytz@2017.3:', type=('build', 'run'), when='@1.2:')
+    depends_on('py-pytz@2020.1:', type=('build', 'run'), when='@1.4:')
 
     # Recommended dependencies
     # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#recommended-dependencies
@@ -85,8 +90,10 @@ class PyPandas(PythonPackage):
     depends_on('py-numexpr@2.6.2:', type=('build', 'run'), when='@0.25:')
     depends_on('py-numexpr@2.6.8:', type=('build', 'run'), when='@1.2:')
     depends_on('py-numexpr@2.7.0:', type=('build', 'run'), when='@1.3:')
+    depends_on('py-numexpr@2.7.1:', type=('build', 'run'), when='@1.4:')
     depends_on('py-bottleneck', type=('build', 'run'))
     depends_on('py-bottleneck@1.2.1:', type=('build', 'run'), when='@0.25:')
+    depends_on('py-bottleneck@1.3.1:', type=('build', 'run'), when='@1.4:')
 
     # Optional dependencies
     # https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html#optional-dependencies


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.9.9 and Apple Clang 12.0.0.