### PR TITLE
py-pillow: add v9.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow-simd/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow-simd/package.py
@@ -15,8 +15,9 @@ class PyPillowSimd(PyPillowBase):
     homepage = "https://github.com/uploadcare/pillow-simd"
     pypi = "Pillow-SIMD/Pillow-SIMD-7.0.0.post3.tar.gz"
 
+    version('9.0.0.post1', sha256='918541cfaa90ba3c0e1bae5da31ba1b1f52b09c0009bd90183b787af4e018263')
     version('7.0.0.post3', sha256='c27907af0e7ede1ceed281719e722e7dbf3e1dbfe561373978654a6b64896cb7')
     version('6.2.2.post1', sha256='d29b673ac80091797f1e8334458be307e4ac4ab871b0e495cfe56cb7b1d7704e')
 
-    for ver in ['6.2.2.post1', '7.0.0.post3']:
+    for ver in ['6.2.2.post1', '7.0.0.post3', '9.0.0.post1']:
         provides('pil@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/py-pillow/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow/package.py
@@ -103,6 +103,7 @@ class PyPillow(PyPillowBase):
     homepage = "https://python-pillow.org/"
     pypi = "Pillow/Pillow-7.2.0.tar.gz"
 
+    version('9.0.0', sha256='ee6e2963e92762923956fe5d3479b1fdc3b76c83f290aad131a2f98c3df0593e')
     version('8.4.0', sha256='b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed')
     version('8.0.0', sha256='59304c67d12394815331eda95ec892bf54ad95e0aa7bc1ccd8e0a4a5a25d4bf3')
     version('7.2.0', sha256='97f9e7953a77d5a70f49b9a48da7776dc51e9b738151b22dacf101641594a626')
@@ -117,6 +118,7 @@ class PyPillow(PyPillowBase):
     version('3.0.0', sha256='ad50bef540fe5518a4653c3820452a881b6a042cb0f8bb7657c491c6bd3654bb', deprecated=True)
 
     for ver in [
+        '9.0.0',
         '8.4.0', '8.0.0',
         '7.2.0', '7.0.0',
         '6.2.2', '6.2.1', '6.2.0', '6.0.0',


### PR DESCRIPTION
`py-pillow-simd` finally supports Python 3.9!

Successfully builds on macOS 10.15.7 with Python 3.9.9 and Apple Clang 12.0.0.