### PR TITLE
py-torch: fix python_platlib reference

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -205,12 +205,18 @@ class PyTorch(PythonPackage, CudaPackage):
 
     @property
     def libs(self):
-        root = join_path(python_platlib, 'torch', 'lib')
+        # TODO: why doesn't `python_platlib` work here?
+        root = join_path(
+            self.prefix, self.spec['python'].package.platlib, 'torch', 'lib'
+        )
         return find_libraries('libtorch', root)
 
     @property
     def headers(self):
-        root = join_path(python_platlib, 'torch', 'include')
+        # TODO: why doesn't `python_platlib` work here?
+        root = join_path(
+            self.prefix, self.spec['python'].package.platlib, 'torch', 'include'
+        )
         headers = find_all_headers(root)
         headers.directories = [root]
         return headers


### PR DESCRIPTION
Fixes a bug I introduced in #28346. For some reason, `python_platlib` isn't defined inside the `libs`/`headers` methods, even though it's defined in the rest of the build phases. Also, if I try to use `inspect.getmodule(self).python_platlib`, Spack ends up using the `_default_libs_handler` instead. @alalazo any idea what's going on here?