### PR TITLE
py-tensorboard-plugin-wit: install wheel

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard-plugin-wit/package.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import tempfile
+from spack import *
 
 
-class PyTensorboardPluginWit(Package):
+class PyTensorboardPluginWit(PythonPackage):
     """The What-If Tool makes it easy to efficiently and
        intuitively explore up to two models' performance
        on a dataset. Investigate model performances for
@@ -16,75 +16,16 @@ class PyTensorboardPluginWit(Package):
        that requires minimal code."""
 
     homepage = "https://pypi.org/project/tensorboard-plugin-wit/"
-    url      = "https://github.com/PAIR-code/what-if-tool/archive/v1.7.0.tar.gz"
-    git      = "https://github.com/pair-code/what-if-tool.git"
+    # Could also build from source, but this package requires an older version of bazel
+    # than tensorflow supports, so we can't build both from source in the same DAG until
+    # Spack supports separate concretization of build deps.
+    url = "https://pypi.io/packages/py3/t/tensorboard_plugin_wit/tensorboard_plugin_wit-1.8.0-py3-none-any.whl"
 
     maintainers = ['aweits']
 
-    version('master', branch='master')
-    version('1.8.0', sha256='1e4de1bbf6ae61c4d27b114ec2e1093bc4765b8c2bbb2cc5d43e2075b08a5fea')
-    version('1.7.0', sha256='30dcab9065b02c3f1476f4fb92b27f6feb6c00cdb281699c44d8e69c86745247')
+    version('1.8.1', sha256='ff26bdd583d155aa951ee3b152b3d0cffae8005dc697f72b44a8e8c2a77a8cbe', expand=False)
+    version('1.8.0', sha256='2a80d1c551d741e99b2f197bb915d8a133e24adb8da1732b840041860f91183a', expand=False)
+    version('1.7.0', sha256='ee775f04821185c90d9a0e9c56970ee43d7c41403beb6629385b39517129685b', expand=False)
 
-    # Bazel 3.7+ does not work
-    # https://github.com/PAIR-code/what-if-tool/issues/140
-    depends_on('bazel@0.26.1:3.6', type='build')
-    depends_on('py-pip', type='build')
-    depends_on('py-wheel', type='build')
     depends_on('py-setuptools@36.2.0:', type='build')
-    depends_on('python@2.7:2.8,3.2:', type=('build', 'run'))
-    depends_on('py-wheel', type='build')
-
-    extends('python')
-
-    patch('tboard_shellenv.patch')
-
-    # On Ubuntu, sh -> dash, and the script contains tools like pushd that require bash
-    patch('https://patch-diff.githubusercontent.com/raw/PAIR-code/what-if-tool/pull/154.patch',
-          sha256='b40fbc73fb07ed933f9d845b65fdbf7a94644f7ec7ca8637eda002171e71bbb6',
-          when='@:1.8.0')
-
-    phases = ['setup', 'build', 'install']
-
-    def setup_build_environment(self, env):
-        self.tmp_path = tempfile.mkdtemp(dir='/tmp', prefix='spack')
-        env.set('TEST_TMPDIR', self.tmp_path)
-
-    def setup(self, spec, prefix):
-        builddir = join_path(self.stage.source_path, 'spack-build')
-        mkdirp(builddir)
-        filter_file(r'dest=.*',
-                    'dest="{0}"'.format(builddir),
-                    'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
-        filter_file(r'pip install .*',
-                    '',
-                    'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
-        filter_file(r'command \-v .*',
-                    '',
-                    'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
-        filter_file(r'virtualenv venv',
-                    '',
-                    'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
-        filter_file('unset PYTHON_HOME',
-                    'export PYTHONPATH="{0}"'.format(env['PYTHONPATH']),
-                    'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
-        filter_file('python setup.py',
-                    '{0} setup.py'.format(spec['python'].command.path),
-                    'tensorboard_plugin_wit/pip_package/build_pip_package.sh')
-
-    def build(self, spec, prefix):
-        bazel('--nohome_rc',
-              '--nosystem_rc',
-              '--output_user_root=' + self.tmp_path,
-              'run',
-              # watch https://github.com/bazelbuild/bazel/issues/7254
-              '--define=EXECUTOR=remote',
-              '--verbose_failures',
-              '--subcommands=pretty_print',
-              '--spawn_strategy=local',
-              'tensorboard_plugin_wit/pip_package:build_pip_package')
-
-    def install(self, spec, prefix):
-        with working_dir('spack-build/release'):
-            args = std_pip_args + ['--prefix=' + prefix, '.']
-            pip(*args)
-        remove_linked_tree(self.tmp_path)
+    depends_on('python@3', type=('build', 'run'))


### PR DESCRIPTION
Extracted from #27138 to make that PR smaller and so that people who are having trouble building this package (me) can build it immediately.

@tgamblin this is another case of a package where separate concretization of build deps is required just to build. Modern TF requires newer Bazel than WIT supports. Same problem affects `py-jupyter-packaging`.

Successfully installs on macOS 10.15.7 with Python 3.9.9 and Apple Clang 12.0.0.