### PR TITLE
trilinos: Enable LAPACK functionality in amesos2

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -523,6 +523,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_from_variant('EpetraExt_BUILD_GRAPH_REORDERINGS',
                                 'epetraextgraphreorderings'),
             define_from_variant('Amesos2_ENABLE_Basker', 'basker'),
+            define_from_variant('Amesos2_ENABLE_LAPACK', 'amesos2'),
         ])
 
         if '+dtk' in spec:


### PR DESCRIPTION
It's not clear why this flag wasn't previously always on: perhaps a tribits logic error in the amesos2 package? Since it's formatted like an automatic variable that TriBITS would inject if LAPACK were a tribits dependency (which it's not).

Compiled and installed, verifying the Amesos2 lapack wrappers were available with:
```
spack install trilinos+amesos2~mpi~amesos~anasazi~aztec~epetra~epetraext
```