### PR TITLE
trilinos: version 12 ruse cmake 3.21 or older

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -260,6 +260,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     )
     conflicts('+adios2', when='@:12.14.1')
     conflicts('cxxstd=11', when='@master:')
+    conflicts('cxxstd=17', when='@:12')
     conflicts('cxxstd=11', when='+wrapper ^cuda@6.5.14')
     conflicts('cxxstd=14', when='+wrapper ^cuda@6.5.14:8.0.61')
     conflicts('cxxstd=17', when='+wrapper ^cuda@6.5.14:10.2.89')
@@ -293,6 +294,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     # Fortran mangling fails on Apple M1 (see spack/spack#25900)
     conflicts('@:13.0.1 +fortran', when='target=m1')
 
+    conflicts('cmake@3.22.0:3.22.1', when='@:12')
     # ###################### Dependencies ##########################
 
     depends_on('adios2', when='+adios2')
@@ -325,7 +327,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('superlu@4.3 +pic', when='+superlu')
     depends_on('swig', when='+python')
     depends_on('zlib', when='+zoltan')
-    depends_on('cmake@:3.21', type='build', when='@:12')
 
     # Trilinos' Tribits config system is limited which makes it very tricky to
     # link Amesos with static MUMPS, see

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -263,8 +263,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('cxxstd=11', when='+wrapper ^cuda@6.5.14')
     conflicts('cxxstd=14', when='+wrapper ^cuda@6.5.14:8.0.61')
     conflicts('cxxstd=17', when='+wrapper ^cuda@6.5.14:10.2.89')
-    conflicts('cxxstd=14', when='@:12')
-    conflicts('cxxstd=17', when='@:12')
 
     # Multi-value gotype only applies to trilinos through 12.14
     conflicts('gotype=all', when='@12.15:')
@@ -327,6 +325,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('superlu@4.3 +pic', when='+superlu')
     depends_on('swig', when='+python')
     depends_on('zlib', when='+zoltan')
+    depends_on('cmake@:3.21', type='build', when='@:12')
 
     # Trilinos' Tribits config system is limited which makes it very tricky to
     # link Amesos with static MUMPS, see

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -463,7 +463,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('ALL_OPTIONAL_PACKAGES', False),
             define_trilinos_enable('ALL_PACKAGES', False),
             define_trilinos_enable('CXX11', True),
-            define('Trilinos_CXX11_FLAGS', ' '),
             define_trilinos_enable('DEBUG', 'debug'),
             define_trilinos_enable('EXAMPLES', False),
             define_trilinos_enable('SECONDARY_TESTED_CODE', True),
@@ -527,6 +526,10 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_from_variant('Amesos2_ENABLE_Basker', 'basker'),
             define_from_variant('Amesos2_ENABLE_LAPACK', 'amesos2'),
         ])
+
+        if spec.version < Version('13'):
+            # Suppress TriBITS flags in favor of CMake's built-in flags
+            options.append(define('Trilinos_CXX11_FLAGS', ' '))
 
         if '+dtk' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -263,6 +263,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('cxxstd=11', when='+wrapper ^cuda@6.5.14')
     conflicts('cxxstd=14', when='+wrapper ^cuda@6.5.14:8.0.61')
     conflicts('cxxstd=17', when='+wrapper ^cuda@6.5.14:10.2.89')
+    conflicts('cxxstd=14', when='@:12')
+    conflicts('cxxstd=17', when='@:12')
 
     # Multi-value gotype only applies to trilinos through 12.14
     conflicts('gotype=all', when='@12.15:')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -260,6 +260,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     )
     conflicts('+adios2', when='@:12.14.1')
     conflicts('cxxstd=11', when='@master:')
+    conflicts('cxxstd=14', when='@:12')
     conflicts('cxxstd=17', when='@:12')
     conflicts('cxxstd=11', when='+wrapper ^cuda@6.5.14')
     conflicts('cxxstd=14', when='+wrapper ^cuda@6.5.14:8.0.61')
@@ -294,7 +295,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     # Fortran mangling fails on Apple M1 (see spack/spack#25900)
     conflicts('@:13.0.1 +fortran', when='target=m1')
 
-    conflicts('cmake@3.22.0:3.22.1', when='@:12')
     # ###################### Dependencies ##########################
 
     depends_on('adios2', when='+adios2')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -260,7 +260,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     )
     conflicts('+adios2', when='@:12.14.1')
     conflicts('cxxstd=11', when='@master:')
-    conflicts('cxxstd=14', when='@:12')
     conflicts('cxxstd=17', when='@:12')
     conflicts('cxxstd=11', when='+wrapper ^cuda@6.5.14')
     conflicts('cxxstd=14', when='+wrapper ^cuda@6.5.14:8.0.61')
@@ -464,6 +463,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('ALL_OPTIONAL_PACKAGES', False),
             define_trilinos_enable('ALL_PACKAGES', False),
             define_trilinos_enable('CXX11', True),
+            define('Trilinos_CXX11_FLAGS', ' '),
             define_trilinos_enable('DEBUG', 'debug'),
             define_trilinos_enable('EXAMPLES', False),
             define_trilinos_enable('SECONDARY_TESTED_CODE', True),


### PR DESCRIPTION
trilinos 12 dose not support cxxstd=14.
support cxxstd=14 issue is https://github.com/trilinos/Trilinos/issues/6260
pull request  (https://github.com/trilinos/Trilinos/pull/6814) is merged at version 13.0.0.
This PR is fixed cxxstd=11 when version 12 or before.