### PR TITLE
Nalu wind: simplify version dependencies with trilinos

### DIFF
--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -52,14 +52,14 @@ class NaluWind(CMakePackage, CudaPackage):
 
     depends_on('mpi')
     depends_on('yaml-cpp@0.5.3:')
-    depends_on('trilinos@master,develop +exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest')
+    depends_on('trilinos@master: +exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest')
     depends_on('trilinos~cuda~wrapper', when='~cuda')
     # Cannot build Trilinos as a shared library with STK on Darwin
     # https://github.com/trilinos/Trilinos/issues/2994
     depends_on('trilinos~shared', when=(sys.platform == 'darwin'))
     depends_on('openfast@2.6.0 +cxx', when='+openfast')
-    depends_on('tioga@master,develop', when='+tioga')
-    depends_on('hypre@develop,2.18.2: ~int64+mpi~superlu-dist', when='+hypre')
+    depends_on('tioga@master:', when='+tioga')
+    depends_on('hypre@2.18.2: ~int64+mpi~superlu-dist', when='+hypre')
     depends_on('kokkos-nvcc-wrapper', type='build', when='+cuda')
     for _arch in CudaPackage.cuda_arch_values:
         depends_on('trilinos~shared+cuda+cuda_rdc+wrapper cuda_arch={0}'.format(_arch),

--- a/var/spack/repos/builtin/packages/nalu-wind/package.py
+++ b/var/spack/repos/builtin/packages/nalu-wind/package.py
@@ -52,16 +52,17 @@ class NaluWind(CMakePackage, CudaPackage):
 
     depends_on('mpi')
     depends_on('yaml-cpp@0.5.3:')
-    depends_on('trilinos@master,develop ~cuda~wrapper+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest', when='~cuda')
+    depends_on('trilinos@master,develop +exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest')
+    depends_on('trilinos~cuda~wrapper', when='~cuda')
     # Cannot build Trilinos as a shared library with STK on Darwin
     # https://github.com/trilinos/Trilinos/issues/2994
-    depends_on('trilinos@master,develop ~cuda~wrapper+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre~shared+gtest', when=(sys.platform == 'darwin'))
+    depends_on('trilinos~shared', when=(sys.platform == 'darwin'))
     depends_on('openfast@2.6.0 +cxx', when='+openfast')
     depends_on('tioga@master,develop', when='+tioga')
     depends_on('hypre@develop,2.18.2: ~int64+mpi~superlu-dist', when='+hypre')
     depends_on('kokkos-nvcc-wrapper', type='build', when='+cuda')
     for _arch in CudaPackage.cuda_arch_values:
-        depends_on('trilinos@master,develop ~shared+exodus+tpetra+muelu+belos+ifpack2+amesos2+zoltan+stk+boost~superlu-dist~superlu+hdf5+shards~hypre+gtest+cuda+cuda_rdc+wrapper cuda_arch={0}'.format(_arch),
+        depends_on('trilinos~shared+cuda+cuda_rdc+wrapper cuda_arch={0}'.format(_arch),
                    when='+cuda cuda_arch={0}'.format(_arch))
         depends_on('hypre@develop +mpi+cuda~int64~superlu-dist cuda_arch={0}'.format(_arch),
                    when='+hypre+cuda cuda_arch={0}'.format(_arch))


### PR DESCRIPTION
See #28516 . With this change we could define `version('master.527e5c', commit='527e5c342119758cf22409a69c4b2fa508c0a12c')` in trilinos and similar with `tioga` to allow the concretization to succeed.