### PR TITLE
adding in new version of KaHiP 3.12-3.14 

### DIFF
--- a/var/spack/repos/builtin/packages/kahip/package.py
+++ b/var/spack/repos/builtin/packages/kahip/package.py
@@ -28,8 +28,13 @@ class Kahip(CMakePackage):
     maintainers = ["ma595"]
 
     version('develop', branch='master')
+    version('3.14', sha256='9da04f3b0ea53b50eae670d6014ff54c0df2cb40f6679b2f6a96840c1217f242')
+    version('3.13', sha256='fae21778a4ce8e59ccb98e5cbb6c01f0af7e594657d21f6c0eb2c6e74398deb1')
+    version('3.12', sha256='df923b94b552772d58b4c1f359b3f2e4a05f7f26ab4ebd00a0ab7d2579f4c257')
     version('3.11', sha256='347575d48c306b92ab6e47c13fa570e1af1e210255f470e6aa12c2509a8c13e3')
     version('2.00', sha256='1cc9e5b12fea559288d377e8b8b701af1b2b707de8e550d0bda18b36be29d21d', url='https://algo2.iti.kit.edu/schulz/software_releases/KaHIP_2.00.tar.gz', deprecated=True)
+    
+    variant('deterministic', default=False, description='Compile with the deterministic seed')
 
     depends_on('scons', type='build', when='@2:2.10')
     depends_on('argtable')
@@ -37,6 +42,8 @@ class Kahip(CMakePackage):
 
     conflicts('%apple-clang')
     conflicts('%clang')
+
+    conflicts('+deterministic @:3.12')
 
     # Fix SConstruct files to be python3 friendly (convert print from a
     # statement to a function)
@@ -61,6 +68,12 @@ class Kahip(CMakePackage):
 
         for f in files:
             filter_file('NCORES=.*', 'NCORES={0}'.format(make_jobs), f)
+
+    @when("@3.13:")
+    def cmake_args(self):
+        return [
+                self.define_from_variant('DETERMINISTIC_PARHIP', 'deterministic')
+            ]
 
     @when("@:2.10")
     def cmake(self, spac, prefix):

--- a/var/spack/repos/builtin/packages/kahip/package.py
+++ b/var/spack/repos/builtin/packages/kahip/package.py
@@ -33,7 +33,7 @@ class Kahip(CMakePackage):
     version('3.12', sha256='df923b94b552772d58b4c1f359b3f2e4a05f7f26ab4ebd00a0ab7d2579f4c257')
     version('3.11', sha256='347575d48c306b92ab6e47c13fa570e1af1e210255f470e6aa12c2509a8c13e3')
     version('2.00', sha256='1cc9e5b12fea559288d377e8b8b701af1b2b707de8e550d0bda18b36be29d21d', url='https://algo2.iti.kit.edu/schulz/software_releases/KaHIP_2.00.tar.gz', deprecated=True)
-    
+
     variant('deterministic', default=False, description='Compile with the deterministic seed')
 
     depends_on('scons', type='build', when='@2:2.10')
@@ -71,9 +71,7 @@ class Kahip(CMakePackage):
 
     @when("@3.13:")
     def cmake_args(self):
-        return [
-                self.define_from_variant('DETERMINISTIC_PARHIP', 'deterministic')
-            ]
+        return [self.define_from_variant('DETERMINISTIC_PARHIP', 'deterministic')]
 
     @when("@:2.10")
     def cmake(self, spac, prefix):


### PR DESCRIPTION
Added in 3 new versions of KaHiP. Also added in deterministic variant that will compile the library to be deterministic instead of using a random seed for decomposition.