### PR TITLE
py-oauthlib: Drop upper limit on py-cryptography version

### DIFF
--- a/var/spack/repos/builtin/packages/py-oauthlib/package.py
+++ b/var/spack/repos/builtin/packages/py-oauthlib/package.py
@@ -28,6 +28,8 @@ class PyOauthlib(PythonPackage):
     depends_on('py-blinker',              type=('build', 'run'), when='+extras')
     depends_on('py-blinker@1.4:',          type=('build', 'run'), when='+extras @3.1.1:')
     depends_on('py-cryptography',         type=('build', 'run'), when='+extras')
-    depends_on('py-cryptography@3.0.0:3', type=('build', 'run'), when='+extras @3.1.1:')
+    # No upper bound on py-cryptography version;
+    # see  https://github.com/oauthlib/oauthlib/pull/777
+    depends_on('py-cryptography@3.0.0:', type=('build', 'run'), when='+extras @3.1.1:')
     depends_on('python@2.7:2.8,3.4:',     type=('build', 'run'))
     depends_on('python@3.6:',             type=('build', 'run'), when='@3.1.1:')


### PR DESCRIPTION
py-cryptography now increments major versions even if there are
no backwards incompatible changes, so oauthlib package dropped the
upper limit on py-cryptography versions.

See e.g. https://github.com/oauthlib/oauthlib/pull/777