### PR TITLE
py-pyjwt: Remove upper bound for py-crytography version

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyjwt/package.py
+++ b/var/spack/repos/builtin/packages/py-pyjwt/package.py
@@ -21,4 +21,6 @@ class PyPyjwt(PythonPackage):
     depends_on('python@3.6:', when='@2.1.0:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-cryptography@1.4:', when='+crypto', type=('build', 'run'))
-    depends_on('py-cryptography@3.3.1:3', when='@2.1.0:+crypto', type=('build', 'run'))
+    # Remove upper bound on py-cryptography version.
+    # See https://github.com/jpadilla/pyjwt/pull/693
+    depends_on('py-cryptography@3.3.1:', when='@2.1.0:+crypto', type=('build', 'run'))


### PR DESCRIPTION
py-cryptography is now incrementing major version even when there
are no backwards incompatible changes, so pyjwt have dropped the
upper limit on py-cryptography versions.

See https://github.com/jpadilla/pyjwt/pull/693