### PR TITLE
Don't allow replacement of root develop specs with --reuse

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1668,13 +1668,15 @@ class SpackSolverSetup(object):
         # Specs from local store
         with spack.store.db.read_transaction():
             for spec in spack.store.db.query(installed=True):
-                self._facts_from_concrete_spec(spec, possible)
+                if not spec.satisfies('dev_path=*'):
+                    self._facts_from_concrete_spec(spec, possible)
 
         # Specs from configured buildcaches
         try:
             index = spack.binary_distribution.update_cache_and_get_specs()
             for spec in index:
-                self._facts_from_concrete_spec(spec, possible)
+                if not spec.satisfies('dev_path=*'):
+                    self._facts_from_concrete_spec(spec, possible)
         except (spack.binary_distribution.FetchCacheError, IndexError):
             # this is raised when no mirrors had indices.
             # TODO: update mirror configuration so it can indicate that the source cache

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -828,7 +828,7 @@ no_flags(Package, FlagType)
  :- node(Package), error("Internal error: package must resolve to at most one hash").
 
 % you can't choose an installed hash for a dev spec
-:- hash(Package, Hash), variant_set(Package, "dev_path", _).
+:- hash(Package, Hash), variant_value(Package, "dev_path", _).
 
 % if a hash is selected, we impose all the constraints that implies
 impose(Hash) :- hash(Package, Hash).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -827,6 +827,9 @@ no_flags(Package, FlagType)
 { hash(Package, Hash) : installed_hash(Package, Hash) } 1
  :- node(Package), error("Internal error: package must resolve to at most one hash").
 
+% you can't choose an installed hash for a dev spec
+:- hash(Package, Hash), variant_set(Package, "dev_path", _).
+
 % if a hash is selected, we impose all the constraints that implies
 impose(Hash) :- hash(Package, Hash).
 

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1139,42 +1139,37 @@ class TestConcretize(object):
         assert s.external == is_external
         assert s.satisfies(expected)
 
-    def test_reuse_does_not_overwrite_root_dev_specs(self, tmpdir, mock_packages, install_mockery, mock_fetch):
-        with tmpdir.as_cwd():
-            # potential parameters
-            package_name = 'dev-build-test-install'
-            package_version = '0.0.0'
-            # have to setup paths to get concretization to work
-            dev_path = '%s/%s' % (tmpdir.strpath, package_name)
-            os.makedirs(dev_path)
-            spec_str = package_name
-            dev_spec_str = '%s@%s dev_path=%s' % (package_name,
-                                                  package_version, dev_path)
-            # concretize and install a non-dev version
-            s = Spec(spec_str).concretized()
-            s.package.do_install(fake=True)
-            # concretize a dev version
-            dev_spec = Spec(dev_spec_str).concretized(reuse=True)
-            assert dev_spec.dag_hash() is not s.dag_hash()
+    def test_reuse_does_not_overwrite_root_dev_specs(
+            self, tmpdir, mock_packages, install_mockery, mock_fetch):
+        # potential parameters
+        package_name = 'dev-build-test-install'
+        package_version = '0.0.0'
+        spec_str = package_name
+        dev_spec_str = '%s@%s dev_path=/fake' % (package_name,
+                                                 package_version)
+        # concretize and install a non-dev version
+        s = Spec(spec_str).concretized()
+        s.package.do_install(fake=True)
+        # concretize a dev version
+        dev_spec = Spec(dev_spec_str).concretized(reuse=True)
+        assert dev_spec.dag_hash() is not s.dag_hash()
 
-    def test_reuse_does_not_overwrite_dependent_dev_specs(self, tmpdir, mock_packages, install_mockery, mock_fetch):
-        with tmpdir.as_cwd():
-            # potential parameters
-            root_spec = 'dev-build-test-dependent'
-            package_name = 'dev-build-test-install'
-            package_version = '0.0.0'
-            # have to setup paths to get concretization to work
-            dev_path = '%s/%s' % (tmpdir.strpath, package_name)
-            os.makedirs(dev_path)
-            spec_str = root_spec
-            dev_spec_str = '%s ^%s@%s dev_path=%s' % (root_spec, package_name,
-                                                      package_version, dev_path)
-            # concretize and install a non-dev version
-            s = Spec(spec_str).concretized()
-            s.package.do_install(fake=True)
-            # concretize a dev version
-            dev_spec = Spec(dev_spec_str).concretized(reuse=True)
-            assert dev_spec.dag_hash() is not s.dag_hash()
+    def test_reuse_does_not_overwrite_dependent_dev_specs(
+            self, tmpdir, mock_packages, install_mockery, mock_fetch):
+        # potential parameters
+        root_spec = 'dev-build-test-dependent'
+        package_name = 'dev-build-test-install'
+        package_version = '0.0.0'
+
+        spec_str = root_spec
+        dev_spec_str = '%s ^%s@%s dev_path=/fake' % (root_spec, package_name,
+                                                     package_version)
+        # concretize and install a non-dev version
+        s = Spec(spec_str).concretized()
+        s.package.do_install(fake=True)
+        # concretize a dev version
+        dev_spec = Spec(dev_spec_str).concretized(reuse=True)
+        assert dev_spec.dag_hash() is not s.dag_hash()
 
 
     @pytest.mark.regression('20292')

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1138,36 +1138,31 @@ class TestConcretize(object):
         assert s.satisfies(expected)
 
     def test_reuse_does_not_overwrite_root_dev_specs(
-            self, tmpdir, mock_packages, install_mockery, mock_fetch):
+            self, mock_packages, install_mockery, mock_fetch):
         # potential parameters
         package_name = 'dev-build-test-install'
-        package_version = '0.0.0'
-        spec_str = package_name
-        dev_spec_str = '%s@%s dev_path=/fake' % (package_name,
-                                                 package_version)
+        dev_spec_str = '%s dev_path=/fake' % package_name
         # concretize and install a non-dev version
-        s = Spec(spec_str).concretized()
+        s = Spec(package_name).concretized()
         s.package.do_install(fake=True)
         # concretize a dev version
-        dev_spec = Spec(dev_spec_str).concretized(reuse=True)
-        assert dev_spec.dag_hash() is not s.dag_hash()
+        with spack.config.override("concretizer:reuse", True):
+            dev_spec = Spec(dev_spec_str).concretized()
+        assert dev_spec.dag_hash() != s.dag_hash()
 
     def test_reuse_does_not_overwrite_dependent_dev_specs(
-            self, tmpdir, mock_packages, install_mockery, mock_fetch):
+            self, mock_packages, install_mockery, mock_fetch):
         # potential parameters
         root_spec = 'dev-build-test-dependent'
-        package_name = 'dev-build-test-install'
-        package_version = '0.0.0'
-
-        spec_str = root_spec
-        dev_spec_str = '%s ^%s@%s dev_path=/fake' % (root_spec, package_name,
-                                                     package_version)
+        dependency_spec = 'dev-build-test-install'
+        dev_spec_str = '%s ^%s dev_path=/fake' % (root_spec, dependency_spec)
         # concretize and install a non-dev version
-        s = Spec(spec_str).concretized()
+        s = Spec(root_spec).concretized()
         s.package.do_install(fake=True)
         # concretize a dev version
-        dev_spec = Spec(dev_spec_str).concretized(reuse=True)
-        assert dev_spec.dag_hash() is not s.dag_hash()
+        with spack.config.override("concretizer:reuse", True):
+            dev_spec = Spec(dev_spec_str).concretized()
+        assert dev_spec.dag_hash() != s.dag_hash()
 
     @pytest.mark.regression('20292')
     @pytest.mark.parametrize('context', [

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
 import sys
 
 import jinja2
@@ -333,7 +332,6 @@ class TestConcretize(object):
         assert s[a].version == ver(b)
 
     def test_concretize_two_virtuals(self):
-
         """Test a package with multiple virtual dependencies."""
         Spec('hypre').concretize()
 
@@ -1170,7 +1168,6 @@ class TestConcretize(object):
         # concretize a dev version
         dev_spec = Spec(dev_spec_str).concretized(reuse=True)
         assert dev_spec.dag_hash() is not s.dag_hash()
-
 
     @pytest.mark.regression('20292')
     @pytest.mark.parametrize('context', [


### PR DESCRIPTION
Based off conversations with @tgamblin, this makes it so `--reuse` will never replace a develop spec since we always want to build those.