### PR TITLE
freetype: new package and Intel no longer conflicts from 2.10.3

### DIFF
--- a/var/spack/repos/builtin/packages/freetype/package.py
+++ b/var/spack/repos/builtin/packages/freetype/package.py
@@ -17,6 +17,7 @@ class Freetype(AutotoolsPackage):
 
     maintainers = ['michaelkuhn']
 
+    version('2.11.1', sha256='f8db94d307e9c54961b39a1cc799a67d46681480696ed72ecf78d4473770f09b')
     version('2.11.0', sha256='a45c6b403413abd5706f3582f04c8339d26397c4304b78fa552f2215df64101f')
     version('2.10.4', sha256='5eab795ebb23ac77001cfb68b7d4d50b5d6c7469247b0b01b2c953269f658dac')
     version('2.10.2', sha256='e09aa914e4f7a5d723ac381420949c55c0b90b15744adce5d1406046022186ab')
@@ -31,8 +32,8 @@ class Freetype(AutotoolsPackage):
     depends_on('libpng')
     depends_on('pkgconfig', type='build')
 
-    conflicts('%intel', when='@2.8:',
-              msg='freetype-2.8 and above cannot be built with icc (does not '
+    conflicts('%intel', when='@2.8:2.10.2',
+              msg='freetype-2.8 to 2.10.2 cannot be built with icc (does not '
               'support __builtin_shuffle)')
 
     patch('windows.patch', when='@2.9.1')


### PR DESCRIPTION
freetype since 2.10.3 no longer needs '`__builtin_shuffle`' when compiling with Intel.
There is also a new release 2.11.1