### PR TITLE
xyce: Add cxxstd variant with only valid value of 11

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -38,7 +38,12 @@ class Xyce(CMakePackage):
     variant('mpi', default=True, description='Enable MPI support')
     depends_on('mpi', when='+mpi')
 
+    # any option other than cxxstd=11 would be ignored in Xyce
+    # this defaults to 11, consistent with what will be used,
+    # and produces an error if any other value is attempted
+    cxxstd_choices = ['11']
     variant('shared', default=False, description='Enable shared libraries for Xyce')
+    variant('cxxstd', default='11', values=cxxstd_choices, multi=False)
 
     variant('pymi', default=False, description='Enable Python Model Interpreter for Xyce')
     depends_on('python@3:', type=('build', 'link', 'run'), when='+pymi')
@@ -57,6 +62,10 @@ class Xyce(CMakePackage):
     # The default settings for various Trilinos variants would require the
     # installation of many more packages than are needed for Xyce.
     depends_on('trilinos~float~ifpack2~ml~muelu~zoltan2')
+
+    # ensures trilinos built with same cxxstd as Xyce (which Xyce was tested against)
+    for cxxstd_ in cxxstd_choices:
+        depends_on('trilinos cxxstd={0}'.format(cxxstd_), when='cxxstd={0}'.format(cxxstd_))
 
     def cmake_args(self):
         spec = self.spec
@@ -82,6 +91,7 @@ class Xyce(CMakePackage):
             options.append('-DCMAKE_CXX_COMPILER:STRING={0}'.format(self.compiler.cxx))
 
         options.append(self.define_from_variant('BUILD_SHARED_LIBS', 'shared'))
+        options.append(self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'))
 
         if '+pymi' in spec:
             pybind11 = spec['py-pybind11']


### PR DESCRIPTION
Xyce contains the CMake logic:

```
set(CMAKE_CXX_STANDARD 11) 
```

so all other `CMAKE_CXX_STANDARD` values will be ignored. This PR adds the variant `cxxstd` to the Xyce recipe with a default value of 11 and a valid option of only 11. Also, the `cxxstd=` is propagated to Trilinos, because only Trilinos 12.12.1 is used as a dependency, and this version of Trilinos was designed and tested for `-std=c++11`.