### PR TITLE
added conduit 0.8.1 and patch to add algorithm for std sort

### DIFF
--- a/var/spack/repos/builtin/packages/conduit/bpparametis.patch
+++ b/var/spack/repos/builtin/packages/conduit/bpparametis.patch
@@ -1,0 +1,10 @@
+--- a/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp	2022-01-13 12:48:31.000000000 -0800
++++ b/src/libs/blueprint/conduit_blueprint_mpi_mesh_parmetis.cpp	2022-01-26 14:18:32.274814000 -0800
+@@ -22,6 +22,7 @@
+ 
+ #include <parmetis.h>
+ 
++#include <algorithm>
+ #include <unordered_map>
+ 
+ //-----------------------------------------------------------------------------

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -43,6 +43,7 @@ class Conduit(CMakePackage):
     # is to bridge any spack dependencies that are still using the name master
     version('master', branch='develop', submodules=True)
     # note: 2021-05-05 latest tagged release is now preferred instead of develop
+    version('0.8.1', sha256='488f22135a35136de592173131d123f7813818b7336c3b18e04646318ad3cbee')
     version('0.8.0', sha256='0607dcf9ced44f95e0b9549f5bbf7a332afd84597c52e293d7ca8d83117b5119')
     version('0.7.2', sha256='359fd176297700cdaed2c63e3b72d236ff3feec21a655c7c8292033d21d5228a')
     version('0.7.1', sha256='460a480cf08fedbf5b38f707f94f20828798327adadb077f80dbab048fd0a07d')
@@ -175,6 +176,7 @@ class Conduit(CMakePackage):
     # Tentative patch for fj compiler
     # Cmake will support fj compiler and this patch will be removed
     patch('fj_flags.patch', when='%fj')
+    patch('bpparametis.patch', when='@0.8.1')
 
     # Add missing include for numeric_limits
     # https://github.com/LLNL/conduit/pull/773


### PR DESCRIPTION
This adds version 0.8.1 of the conduit package and patches the build to address https://github.com/LLNL/conduit/issues/913.