### PR TITLE
Bugfix/Heffte stand alone test

### DIFF
--- a/var/spack/repos/builtin/packages/heffte/package.py
+++ b/var/spack/repos/builtin/packages/heffte/package.py
@@ -3,6 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
+from llnl.util import tty
+
 from spack import *
 
 
@@ -104,12 +108,48 @@ class Heffte(CMakePackage, CudaPackage, ROCmPackage):
 
         return args
 
+    # TODO: Replace this method and its 'get' use for cmake path with
+    #   join_path(self.spec['cmake'].prefix.bin, 'cmake') once stand-alone
+    #   tests can access build dependencies through self.spec['cmake'].
+    def cmake_bin(self, set=True):
+        """(Hack) Set/get cmake dependency path."""
+        filepath = join_path(self.install_test_root, 'cmake_bin_path.txt')
+        if set:
+            with open(filepath, 'w') as out_file:
+                cmake_bin = join_path(self.spec['cmake'].prefix.bin, 'cmake')
+                out_file.write('{0}\n'.format(cmake_bin))
+        elif os.path.isfile(filepath):
+            with open(filepath, 'r') as in_file:
+                return in_file.read().strip()
+
+    @run_after('install')
+    def setup_smoke_test(self):
+        install_tree(self.prefix.share.heffte.testing,
+                     join_path(self.install_test_root, 'testing'))
+        self.cmake_bin(set=True)
+
     def test(self):
-        # using the tests installed in <prefix>/share/heffte/testing
-        cmake_dir = join_path(self.prefix, 'share', 'heffte', 'testing')
-        test_dir = join_path(self.test_suite.current_test_cache_dir,
-                             'test_install')
-        with working_dir(test_dir, create=True):
-            cmake(cmake_dir)
-            make()
-            make('test')
+        cmake_bin = self.cmake_bin(set=False)
+
+        if not cmake_bin:
+            tty.msg('Skipping heffte test: cmake_bin_path.txt not found')
+            return
+
+        # using the tests copied from <prefix>/share/heffte/testing
+        cmake_dir = self.test_suite.current_test_cache_dir.testing
+
+        if not self.run_test(cmake_bin,
+                             options=[cmake_dir],
+                             purpose='Generate the Makefile'):
+            tty.msg('Skipping heffte test: failed to generate Makefile')
+            return
+
+        if not self.run_test('make',
+                             purpose='Build test software'):
+            tty.msg('Skipping heffte test: failed to build test')
+            return
+
+        if not self.run_test('make',
+                             options=['test'],
+                             purpose='Run test'):
+            tty.msg('Failed heffte test: failed to run test')


### PR DESCRIPTION
Fixes [27979](https://github.com/spack/spack/issues/27979)

Test fails when the `cmake` in the user's path is not the one used to build `heffte`