### PR TITLE
otf2/scorep: add versions 3.0/7.1

### DIFF
--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -13,17 +13,16 @@ class Otf2(AutotoolsPackage):
     """
 
     homepage = "https://www.vi-hps.org/projects/score-p"
-    url      = "https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.1.1.tar.gz"
+    url      = "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-3.0/otf2-3.0.tar.gz"
 
-    version('2.3',   sha256='36957428d37c40d35b6b45208f050fb5cfe23c54e874189778a24b0e9219c7e3', url='https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-2.3/otf2-2.3.tar.gz')
-    version('2.2',   sha256='d0519af93839dc778eddca2ce1447b1ee23002c41e60beac41ea7fe43117172d')
-    version('2.1.1', sha256='01591b42e76f396869ffc84672f4eaa90ee8ec2a8939755d9c0b5b8ecdcf47d3')
-    version('2.1',   sha256='8ad38ea0461099e34f00f2947af4409ce9b9c379e14c3f449ba162e51ac4cad3')
-    version('2.0',   sha256='bafe0ac08e0a13e71568e5774dc83bd305d907159b4ceeb53d2e9f6e29462754')
-    version('1.5.1', sha256='a4dc9f6c99376030b43a4c7b1ee77cfb530b03928ea688c6d1a380b3f4e8e488')
-    version('1.4',   sha256='fb5fe169003c01e40848e224f09c440014e9872e84d2ca02ce7fffdd3f879a2f')
-    version('1.3.1', sha256='c4605ace845d89fb1a19223137b92cc503b01e3db5eda8c9e0715d0cfcf2e4b9')
-    version('1.2.1', sha256='1db9fb0789de4a9c3c96042495e4212a22cb581f734a1593813adaf84f2288e4')
+    version('3.0',   sha256='6fff0728761556e805b140fd464402ced394a3c622ededdb618025e6cdaa6d8c')
+    version('2.3',   sha256='36957428d37c40d35b6b45208f050fb5cfe23c54e874189778a24b0e9219c7e3')
+    version('2.2',   sha256='d0519af93839dc778eddca2ce1447b1ee23002c41e60beac41ea7fe43117172d', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.2.tar.gz')
+    version('2.1.1', sha256='01591b42e76f396869ffc84672f4eaa90ee8ec2a8939755d9c0b5b8ecdcf47d3', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.1.1.tar.gz')
+    version('2.1',   sha256='8ad38ea0461099e34f00f2947af4409ce9b9c379e14c3f449ba162e51ac4cad3', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.1.tar.gz')
+    version('2.0',   sha256='bafe0ac08e0a13e71568e5774dc83bd305d907159b4ceeb53d2e9f6e29462754', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.0.tar.gz')
+    version('1.5.1', sha256='a4dc9f6c99376030b43a4c7b1ee77cfb530b03928ea688c6d1a380b3f4e8e488', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-1.5.1.tar.gz')
+    version('1.4',   sha256='fb5fe169003c01e40848e224f09c440014e9872e84d2ca02ce7fffdd3f879a2f', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-1.4.tar.gz')
 
     with when('@2.2 %cce'):
         depends_on('autoconf', type='build')
@@ -33,7 +32,7 @@ class Otf2(AutotoolsPackage):
 
     # Fix missing initialization of variable resulting in issues when used by
     # APEX/HPX: https://github.com/STEllAR-GROUP/hpx/issues/5239
-    patch('collective_callbacks.patch', when='@2.1:2.2')
+    patch('collective_callbacks.patch', when='@2.1:')
 
     # when using Cray's cs-prgenv, allow the build system to detect the systems as an XC
     patch('cray_ac_scorep_sys_detection-m4.patch', when='@2.2 %cce')

--- a/var/spack/repos/builtin/packages/otf2/package.py
+++ b/var/spack/repos/builtin/packages/otf2/package.py
@@ -17,12 +17,20 @@ class Otf2(AutotoolsPackage):
 
     version('3.0',   sha256='6fff0728761556e805b140fd464402ced394a3c622ededdb618025e6cdaa6d8c')
     version('2.3',   sha256='36957428d37c40d35b6b45208f050fb5cfe23c54e874189778a24b0e9219c7e3')
-    version('2.2',   sha256='d0519af93839dc778eddca2ce1447b1ee23002c41e60beac41ea7fe43117172d', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.2.tar.gz')
-    version('2.1.1', sha256='01591b42e76f396869ffc84672f4eaa90ee8ec2a8939755d9c0b5b8ecdcf47d3', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.1.1.tar.gz')
-    version('2.1',   sha256='8ad38ea0461099e34f00f2947af4409ce9b9c379e14c3f449ba162e51ac4cad3', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.1.tar.gz')
-    version('2.0',   sha256='bafe0ac08e0a13e71568e5774dc83bd305d907159b4ceeb53d2e9f6e29462754', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-2.0.tar.gz')
-    version('1.5.1', sha256='a4dc9f6c99376030b43a4c7b1ee77cfb530b03928ea688c6d1a380b3f4e8e488', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-1.5.1.tar.gz')
-    version('1.4',   sha256='fb5fe169003c01e40848e224f09c440014e9872e84d2ca02ce7fffdd3f879a2f', url='https://www.vi-hps.org/cms/upload/packages/otf2/otf2-1.4.tar.gz')
+    version('2.2',   sha256='d0519af93839dc778eddca2ce1447b1ee23002c41e60beac41ea7fe43117172d')
+    version('2.1.1', sha256='01591b42e76f396869ffc84672f4eaa90ee8ec2a8939755d9c0b5b8ecdcf47d3')
+    version('2.1',   sha256='8ad38ea0461099e34f00f2947af4409ce9b9c379e14c3f449ba162e51ac4cad3')
+    version('2.0',   sha256='bafe0ac08e0a13e71568e5774dc83bd305d907159b4ceeb53d2e9f6e29462754')
+    version('1.5.1', sha256='a4dc9f6c99376030b43a4c7b1ee77cfb530b03928ea688c6d1a380b3f4e8e488')
+    version('1.4',   sha256='fb5fe169003c01e40848e224f09c440014e9872e84d2ca02ce7fffdd3f879a2f')
+    version('1.3.1', sha256='c4605ace845d89fb1a19223137b92cc503b01e3db5eda8c9e0715d0cfcf2e4b9', deprecated=True)
+    version('1.2.1', sha256='1db9fb0789de4a9c3c96042495e4212a22cb581f734a1593813adaf84f2288e4', deprecated=True)
+
+    def url_for_version(self, version):
+        if version < Version('2.3'):
+            return 'https://www.vi-hps.org/cms/upload/packages/otf2/otf2-{0}.tar.gz'.format(version)
+
+        return 'https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-{0}/otf2-{0}.tar.gz'.format(version)
 
     with when('@2.2 %cce'):
         depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -13,18 +13,19 @@ class Scorep(AutotoolsPackage):
     """
 
     homepage = "https://www.vi-hps.org/projects/score-p"
-    url      = "https://www.vi-hps.org/cms/upload/packages/scorep/scorep-4.1.tar.gz"
+    url      = "https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-7.1/scorep-7.1.tar.gz"
 
-    version('7.0',   sha256='68f24a68eb6f94eaecf500e17448f566031946deab74f2cba072ee8368af0996', url='https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-7.0/scorep-7.0.tar.gz')
-    version('6.0',   sha256='5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8')
-    version('5.0',   sha256='0651614eacfc92ffbe5264a3efebd0803527ae6e8b11f7df99a56a02c37633e1')
-    version('4.1',   sha256='7bb6c1eecdd699b4a3207caf202866778ee01f15ff39a9ec198fcd872578fe63')
-    version('4.0',   sha256='c050525606965950ad9b35c14077b88571bcf9bfca08599279a3d8d1bb00e655')
-    version('3.1',   sha256='49efe8a4e02afca752452809e1b21cba42e8ccb0a0772f936d4459d94e198540')
-    version('3.0',   sha256='c9e7fe0a8239b3bbbf7628eb15f7e90de9c36557818bf3d01aecce9fec2dc0be')
-    version('2.0.2', sha256='d19498408781048f0e9039a1a245bce6b384f09fbe7d3643105b4e2981ecd610')
-    version('1.4.2', sha256='d7f3fcca2efeb2f5d5b5f183b3b2c4775e66cbb3400ea2da841dd0428713ebac')
-    version('1.3',   sha256='dcfd42bd05f387748eeefbdf421cb3cd98ed905e009303d70b5f75b217fd1254')
+    version('7.1',   sha256='98dea497982001fb82da3429ca55669b2917a0858c71abe2cfe7cd113381f1f7')
+    version('7.0',   sha256='68f24a68eb6f94eaecf500e17448f566031946deab74f2cba072ee8368af0996')
+    version('6.0',   sha256='5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-6.0.tar.gz')
+    version('5.0',   sha256='0651614eacfc92ffbe5264a3efebd0803527ae6e8b11f7df99a56a02c37633e1', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-5.0.tar.gz')
+    version('4.1',   sha256='7bb6c1eecdd699b4a3207caf202866778ee01f15ff39a9ec198fcd872578fe63', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-4.1.tar.gz')
+    version('4.0',   sha256='c050525606965950ad9b35c14077b88571bcf9bfca08599279a3d8d1bb00e655', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-4.0.tar.gz')
+    version('3.1',   sha256='49efe8a4e02afca752452809e1b21cba42e8ccb0a0772f936d4459d94e198540', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-3.1.tar.gz')
+    version('3.0',   sha256='c9e7fe0a8239b3bbbf7628eb15f7e90de9c36557818bf3d01aecce9fec2dc0be', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-3.0.tar.gz')
+    version('2.0.2', sha256='d19498408781048f0e9039a1a245bce6b384f09fbe7d3643105b4e2981ecd610', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-2.0.2.tar.gz')
+    version('1.4.2', sha256='d7f3fcca2efeb2f5d5b5f183b3b2c4775e66cbb3400ea2da841dd0428713ebac', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-1.4.2.tar.gz')
+    version('1.3',   sha256='dcfd42bd05f387748eeefbdf421cb3cd98ed905e009303d70b5f75b217fd1254', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-1.3.tar.gz')
 
     patch('gcc7.patch', when='@1.4:3')
     patch('gcc10.patch', when='@3.1:6.0')
@@ -41,7 +42,7 @@ class Scorep(AutotoolsPackage):
     # two components of cube -- cubew and cubelib.
 
     # SCOREP 7
-    depends_on('otf2@2.3:', when='@7:')
+    depends_on('otf2@2.3:2.3.99', when='@7:')
     depends_on('cubew@4.6:', when='@7:')
     depends_on('cubelib@4.6:', when='@7:')
     depends_on('opari2@2.0.6:', when='@7:')

--- a/var/spack/repos/builtin/packages/scorep/package.py
+++ b/var/spack/repos/builtin/packages/scorep/package.py
@@ -17,15 +17,21 @@ class Scorep(AutotoolsPackage):
 
     version('7.1',   sha256='98dea497982001fb82da3429ca55669b2917a0858c71abe2cfe7cd113381f1f7')
     version('7.0',   sha256='68f24a68eb6f94eaecf500e17448f566031946deab74f2cba072ee8368af0996')
-    version('6.0',   sha256='5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-6.0.tar.gz')
-    version('5.0',   sha256='0651614eacfc92ffbe5264a3efebd0803527ae6e8b11f7df99a56a02c37633e1', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-5.0.tar.gz')
-    version('4.1',   sha256='7bb6c1eecdd699b4a3207caf202866778ee01f15ff39a9ec198fcd872578fe63', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-4.1.tar.gz')
-    version('4.0',   sha256='c050525606965950ad9b35c14077b88571bcf9bfca08599279a3d8d1bb00e655', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-4.0.tar.gz')
-    version('3.1',   sha256='49efe8a4e02afca752452809e1b21cba42e8ccb0a0772f936d4459d94e198540', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-3.1.tar.gz')
-    version('3.0',   sha256='c9e7fe0a8239b3bbbf7628eb15f7e90de9c36557818bf3d01aecce9fec2dc0be', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-3.0.tar.gz')
-    version('2.0.2', sha256='d19498408781048f0e9039a1a245bce6b384f09fbe7d3643105b4e2981ecd610', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-2.0.2.tar.gz')
-    version('1.4.2', sha256='d7f3fcca2efeb2f5d5b5f183b3b2c4775e66cbb3400ea2da841dd0428713ebac', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-1.4.2.tar.gz')
-    version('1.3',   sha256='dcfd42bd05f387748eeefbdf421cb3cd98ed905e009303d70b5f75b217fd1254', url='https://www.vi-hps.org/cms/upload/packages/scorep/scorep-1.3.tar.gz')
+    version('6.0',   sha256='5dc1023eb766ba5407f0b5e0845ec786e0021f1da757da737db1fb71fc4236b8')
+    version('5.0',   sha256='0651614eacfc92ffbe5264a3efebd0803527ae6e8b11f7df99a56a02c37633e1')
+    version('4.1',   sha256='7bb6c1eecdd699b4a3207caf202866778ee01f15ff39a9ec198fcd872578fe63')
+    version('4.0',   sha256='c050525606965950ad9b35c14077b88571bcf9bfca08599279a3d8d1bb00e655')
+    version('3.1',   sha256='49efe8a4e02afca752452809e1b21cba42e8ccb0a0772f936d4459d94e198540')
+    version('3.0',   sha256='c9e7fe0a8239b3bbbf7628eb15f7e90de9c36557818bf3d01aecce9fec2dc0be')
+    version('2.0.2', sha256='d19498408781048f0e9039a1a245bce6b384f09fbe7d3643105b4e2981ecd610')
+    version('1.4.2', sha256='d7f3fcca2efeb2f5d5b5f183b3b2c4775e66cbb3400ea2da841dd0428713ebac')
+    version('1.3',   sha256='dcfd42bd05f387748eeefbdf421cb3cd98ed905e009303d70b5f75b217fd1254')
+
+    def url_for_version(self, version):
+        if version < Version('7.0'):
+            return 'https://www.vi-hps.org/cms/upload/packages/scorep/scorep-{0}.tar.gz'.format(version)
+
+        return 'https://perftools.pages.jsc.fz-juelich.de/cicd/scorep/tags/scorep-{0}/scorep-{0}.tar.gz'.format(version)
 
     patch('gcc7.patch', when='@1.4:3')
     patch('gcc10.patch', when='@3.1:6.0')

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -97,7 +97,7 @@ class Tau(Package):
     depends_on('zlib', type='link')
     depends_on('pdt', when='+pdt')  # Required for TAU instrumentation
     depends_on('scorep', when='+scorep')
-    depends_on('otf2@2.1:', when='+otf2')
+    depends_on('otf2@2.1:2.3', when='+otf2')
     depends_on('likwid', when='+likwid')
     depends_on('papi', when='+papi')
     depends_on('libdwarf', when='+libdwarf')


### PR DESCRIPTION
additional changes:
- updated the default URLs
- removed ancient versions of OTF2
- enabled patch for OTF2 also for newer versions
- updated OTF2 dependency in Score-P