### PR TITLE
Revert "Ensure "spack unit-test" can bootstrap clingo (#28572)"

### DIFF
--- a/lib/spack/spack/cmd/unit_test.py
+++ b/lib/spack/spack/cmd/unit_test.py
@@ -22,7 +22,6 @@ import llnl.util.filesystem
 import llnl.util.tty.color as color
 from llnl.util.tty.colify import colify
 
-import spack.bootstrap
 import spack.paths
 
 description = "run spack's unit tests (wrapper around pytest)"
@@ -176,12 +175,6 @@ def add_back_pytest_args(args, unknown_args):
 
 def unit_test(parser, args, unknown_args):
     global pytest
-
-    # Ensure clingo is available before switching to the
-    # mock configuration used by unit tests
-    with spack.bootstrap.ensure_bootstrap_configuration():
-        spack.bootstrap.ensure_clingo_importable_or_raise()
-
     if pytest is None:
         vendored_pytest_dir = os.path.join(
             spack.paths.external_path, 'pytest-fallback'

--- a/lib/spack/spack/test/data/config/bootstrap.yaml
+++ b/lib/spack/spack/test/data/config/bootstrap.yaml
@@ -6,7 +6,7 @@ bootstrap:
       Buildcache generated from a public workflow using Github Actions.
       The sha256 checksum of binaries is checked before installation.
     info:
-      url: file:///home/spack/production/spack/mirrors/clingo
+      url: file:///home/culpo/production/spack/mirrors/clingo
       homepage: https://github.com/alalazo/spack-bootstrap-mirrors
       releases: https://github.com/alalazo/spack-bootstrap-mirrors/releases
   trusted: {}


### PR DESCRIPTION
This reverts commit 3cf5df7e3b43166dc626a44885a9353c7365091d.

This is to check if the slowdown in CI is affected in any way by reverting the commit.