### PR TITLE
Update Packages: py-celery py-kombu

### DIFF
--- a/var/spack/repos/builtin/packages/py-amqp/package.py
+++ b/var/spack/repos/builtin/packages/py-amqp/package.py
@@ -11,6 +11,7 @@ class PyAmqp(PythonPackage):
 
     pypi = "amqp/amqp-2.4.1.tar.gz"
 
+    version('5.0.9', sha256='1e5f707424e544078ca196e72ae6a14887ce74e02bd126be54b7c03c971bef18')
     version('5.0.1', sha256='9881f8e6fe23e3db9faa6cfd8c05390213e1d1b95c0162bc50552cad75bffa5f')
     version('2.6.1', sha256='70cdb10628468ff14e57ec2f751c7aa9e48e7e3651cfd62d431213c0c4e58f21')
     version('2.5.2', sha256='77f1aef9410698d20eaeac5b73a87817365f457a507d82edf292e12cbb83b08d')
@@ -18,7 +19,13 @@ class PyAmqp(PythonPackage):
     version('2.4.1', sha256='6816eed27521293ee03aa9ace300a07215b11fee4e845588a9b863a7ba30addb')
 
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+    depends_on('python@3.6:', type=('build', 'run'), when='@5.0.9:')
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-cython', type='build')
+
     depends_on('py-vine@1.1.3:4', when="@2", type=('build', 'run'))
-    depends_on('py-vine@5.0.0:5', when="@5.0.0:5", type=('build', 'run'))
+    depends_on('py-vine@5.0.0', when="@5.0.0:5", type=('build', 'run'))
+
+    def setup_build_environment(self, env):
+        env.set('CELERY_ENABLE_SPEEDUPS', True)

--- a/var/spack/repos/builtin/packages/py-celery/package.py
+++ b/var/spack/repos/builtin/packages/py-celery/package.py
@@ -11,6 +11,7 @@ class PyCelery(PythonPackage):
 
     pypi = "celery/celery-4.2.1.tar.gz"
 
+    version('5.2.3', sha256='e2cd41667ad97d4f6a2f4672d1c6a6ebada194c619253058b5f23704aaadaa82')
     version('5.0.0', sha256='313930fddde703d8e37029a304bf91429cd11aeef63c57de6daca9d958e1f255')
     version('4.4.7', sha256='d220b13a8ed57c78149acf82c006785356071844afe0b27012a4991d44026f9f')
     version('4.3.0', sha256='4c4532aa683f170f40bd76f928b70bc06ff171a959e06e71bf35f2f9d6031ef9')
@@ -46,19 +47,28 @@ class PyCelery(PythonPackage):
     # 'cosmosdbsql',
     # 's3',
 
+    depends_on('python@3.7:', type=('build', 'run'), when="@5.2.3:")
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'))
 
     depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-setuptools@59.1.1:59.6', type=('build', 'run'), when="@5.2.3:")
 
     depends_on('py-redis@3.2.0:', when='+redis', type=('build', 'run'))
+    depends_on('py-redis@3.4.1:3,4.0.2:', when='@5.2.3:+redis', type=('build', 'run'))
     depends_on('py-sqlalchemy', when='+sqlalchemy', type=('build', 'run'))
 
-    depends_on('py-click@7.0:7', when="@5.0.0:5", type=('build', 'run'))
-    depends_on('py-click-didyoumean@:0.0.3', when="@5.0.0:5", type=('build', 'run'))
-    depends_on('py-click-repl@:0.1.6', when="@5.0.0:5", type=('build', 'run'))
+    depends_on('py-click@7.0:7', when="@5.0.0:5.0", type=('build', 'run'))
+    depends_on('py-click@8.0.3:8', when="@5.2.0:", type=('build', 'run'))
+    depends_on('py-click-didyoumean@0.0.3:', when="@5.0.0:5", type=('build', 'run'))
+    depends_on('py-click-plugins@1.1.1:', when="@5.0.3:", type=('build', 'run'))
+    depends_on('py-click-repl@:0.1.6', when="@5.0.0:5.0", type=('build', 'run'))
+    depends_on('py-click-repl@0.2.0:', when="@5.2.0:", type=('build', 'run'))
     depends_on('py-pytz@2019.3:', type=('build', 'run'))
+    depends_on('py-pytz@2021.3:', type=('build', 'run'), when="@5.2.3")
     depends_on('py-billiard@3.6.3:3', type=('build', 'run'))
+    depends_on('py-billiard@3.6.4:3', type=('build', 'run'), when="@5.2.3")
     depends_on('py-kombu@4.6.11', when="@4.3.0:4",  type=('build', 'run'))
-    depends_on('py-kombu@5.0.0:', when="@5.0.0:5", type=('build', 'run'))
+    depends_on('py-kombu@5.0.0:', when="@5.0.0:5.0", type=('build', 'run'))
+    depends_on('py-kombu@5.2.3:5', when="@5.2.0:5.2", type=('build', 'run'))
     depends_on('py-vine@1.3.0', when="@4.3.0:4", type=('build', 'run'))
-    depends_on('py-vine@5.0.0:', when="@5.0.0:5", type=('build', 'run'))
+    depends_on('py-vine@5.0.0:5', when="@5.0.0:5", type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-click-plugins/package.py
+++ b/var/spack/repos/builtin/packages/py-click-plugins/package.py
@@ -12,7 +12,9 @@ class PyClickPlugins(PythonPackage):
 
     pypi = "click-plugins/click-plugins-1.0.4.tar.gz"
 
+    version('1.1.1', sha256='46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b')
     version('1.0.4', sha256='dfed74b5063546a137de99baaaf742b4de4337ad2b3e1df5ec7c8a256adc0847')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-click@3.0:', type=('build', 'run'))
+    depends_on('py-click@4.0:', type=('build', 'run'), when='@1.1.1:')

--- a/var/spack/repos/builtin/packages/py-click-repl/package.py
+++ b/var/spack/repos/builtin/packages/py-click-repl/package.py
@@ -11,9 +11,11 @@ class PyClickRepl(PythonPackage):
     homepage = "https://github.com/click-contrib/click-repl"
     pypi = "click-repl/click-repl-0.1.6.tar.gz"
 
+    version('0.2.0', sha256='b0cac32a625c24cd1414cc323e314a79278e2310e41596a6e27997e1c9f99e72')
     version('0.1.6', sha256='b9f29d52abc4d6059f8e276132a111ab8d94980afe6a5432b9d996544afa95d5')
 
     depends_on('python@3.0:', type=('build', 'run'))
     depends_on('py-click', type=('build', 'run'))
     depends_on('py-prompt-toolkit', type=('build', 'run'))
+    depends_on('py-six', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-kombu/package.py
+++ b/var/spack/repos/builtin/packages/py-kombu/package.py
@@ -11,16 +11,25 @@ class PyKombu(PythonPackage):
 
     pypi = "kombu/kombu-4.3.0.tar.gz"
 
+    version('5.2.3', sha256='81a90c1de97e08d3db37dbf163eaaf667445e1068c98bfd89f051a40e9f6dbbd')
     version('5.0.2', sha256='f4965fba0a4718d47d470beeb5d6446e3357a62402b16c510b6a2f251e05ac3c')
     version('4.6.11', sha256='ca1b45faac8c0b18493d02a8571792f3c40291cf2bcf1f55afed3d8f3aa7ba74')
     version('4.6.6', sha256='1760b54b1d15a547c9a26d3598a1c8cdaf2436386ac1f5561934bc8a3cbbbd86')
     version('4.5.0', sha256='389ba09e03b15b55b1a7371a441c894fd8121d174f5583bbbca032b9ea8c9edd')
     version('4.3.0', sha256='529df9e0ecc0bad9fc2b376c3ce4796c41b482cf697b78b71aea6ebe7ca353c8')
 
+    depends_on('python@3.7:', type=('build', 'run'), when="@5.2.3:")
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'))
+
+    variant('redis', default=False, description="Use redis transport")
 
     depends_on('py-setuptools', type='build')
     depends_on('py-amqp@2.5.2:2.5', when="@:4.6.6", type=('build', 'run'))
     depends_on('py-amqp@2.6.0:2.6', when="@4.6.7:4", type=('build', 'run'))
-    depends_on('py-amqp@5.0.0:5', when="@5.0.0:", type=('build', 'run'))
-    depends_on('py-importlib-metadata@0.18:', type=('build', 'run'))
+    depends_on('py-amqp@5.0.0:5', when="@5.0.0:5.0.2", type=('build', 'run'))
+    depends_on('py-amqp@5.0.9:5.0', when="@5.2.3", type=('build', 'run'))
+    depends_on('py-vine', when="@5.1.0:", type=('build', 'run'))
+    depends_on('py-importlib-metadata@0.18:', type=('build', 'run'), when='python@:3.7')
+    depends_on('py-cached-property', type=('build', 'run'), when='python@:3.7')
+
+    depends_on('py-redis@3.4.1:3,4.0.2:', when='+redis', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pytz/package.py
+++ b/var/spack/repos/builtin/packages/py-pytz/package.py
@@ -12,6 +12,7 @@ class PyPytz(PythonPackage):
     homepage = "https://pythonhosted.org/pytz"
     pypi = "pytz/pytz-2019.3.tar.gz"
 
+    version('2021.3', sha256='acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326')
     version('2021.1', sha256='83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da')
     version('2020.1', sha256='c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048')
     version('2019.3', sha256='b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be')


### PR DESCRIPTION
This provides the latest upstream celery and kombu.  Kombu itself suggests running hiredis rather than pyredis, so I've added switches in place for that.