### PR TITLE
ParaView: Require Ninja for builds

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -99,6 +99,9 @@ class Paraview(CMakePackage, CudaPackage):
 
     depends_on('cmake@3.3:', type='build')
 
+    generator = 'Ninja'
+    depends_on('ninja', type='build')
+
     # Workaround for
     # adding the following to your packages.yaml
     # packages:


### PR DESCRIPTION
This should/may fix all/some of the build slow down issues being observed when building ParaView.