### PR TITLE
New Package: py-python-dotenv

### DIFF
--- a/var/spack/repos/builtin/packages/py-python-dotenv/package.py
+++ b/var/spack/repos/builtin/packages/py-python-dotenv/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPythonDotenv(PythonPackage):
+    """Read key-value pairs from a .env file and set them as environment variables"""
+
+    homepage = "https://github.com/theskumar/python-dotenv"
+    pypi = "python-dotenv/python-dotenv-0.19.2.tar.gz"
+
+    maintainers = ['jcpunk']
+
+    version('0.19.2', sha256='a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f')
+
+    variant('cli', default=False, description="Add commandline tools")
+
+    depends_on('python@3.5:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+
+    depends_on('py-click@5:', when="+cli", type=('build', 'run'))


### PR DESCRIPTION
This adds the python-dotenv library and commandline tools for making it easier to switch and store environment variables.