### PR TITLE
trilinos: Fix cxxstd effects for Trilinos versions <13

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -260,7 +260,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         msg='Cannot build Trilinos with STK as a shared library on Darwin.'
     )
     conflicts('+adios2', when='@:12.14.1')
-    conflicts('cxxstd=11', when='@13:')
+    conflicts('cxxstd=11', when='@13.2:')
     conflicts('cxxstd=17', when='@:12')
     conflicts('cxxstd=11', when='+wrapper ^cuda@6.5.14')
     conflicts('cxxstd=14', when='+wrapper ^cuda@6.5.14:8.0.61')


### PR DESCRIPTION
Follow on to https://github.com/spack/spack/pull/28582#event-5969023553, fixing `Trilinos_CXX11_FLAGS`, because that solution only fixed 12.18.1 and broke versions previous to that.