### PR TITLE
VTK-m: Add CMake definition to suppress CMP0104

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -458,6 +458,8 @@ class Paraview(CMakePackage, CudaPackage):
                     raise InstallError("Incompatible cuda_arch=" + requested_arch[0])
 
             cmake_args.append(self.define('VTKm_CUDA_Architecture', cuda_arch_value))
+            # CMAKE_CUDA_ARCHITECTURES is ignored by VTK-m but we need to this to
+            # suppress warnings which CMake (>3.18) generate in its absence. 
             if '@3.18:' in spec['cmake']:
                 cmake_args.append(
                     self.define('CMAKE_CUDA_ARCHITECTURES', requested_arch[0]))

--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -458,6 +458,9 @@ class Paraview(CMakePackage, CudaPackage):
                     raise InstallError("Incompatible cuda_arch=" + requested_arch[0])
 
             cmake_args.append(self.define('VTKm_CUDA_Architecture', cuda_arch_value))
+            if '@3.18:' in spec['cmake']:
+                cmake_args.append(
+                    self.define('CMAKE_CUDA_ARCHITECTURES', requested_arch[0]))
 
         if 'darwin' in spec.architecture:
             cmake_args.extend([

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -186,11 +186,16 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
                         vtkm_cuda_arch = gpu_name_table[cuda_arch]
                         options.append('-DVTKm_CUDA_Architecture={0}'.format(
                                        vtkm_cuda_arch))
+                        if spec['cmake'].satisfies('@3.18:'):
+                            options.append(
+                                self.define('CMAKE_CUDA_ARCHITECTURES', cuda_arch))
                 else:
                     # this fix is necessary if compiling platform has cuda, but
                     # no devices (this is common for front end nodes on hpc
                     # clusters). We choose volta as a lowest common denominator
                     options.append("-DVTKm_CUDA_Architecture=volta")
+                    if spec['cmake'].satisfies('@3.18:'):
+                        options.append(self.define('CMAKE_CUDA_ARCHITECTURES', 70))
             else:
                 options.append("-DVTKm_ENABLE_CUDA:BOOL=OFF")
 


### PR DESCRIPTION
Added CMAKE_CUDA_ARCHITECTURES=<cuda_arch[0]> to ParaView and VTK-m projects.

Warnings present on perlmutter when building `paraview +cuda`

@chuckatkins 