### PR TITLE
llvm: add llvm_config helper

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -11,12 +11,6 @@ import llnl.util.tty as tty
 
 import spack.build_environment
 import spack.util.executable
-from llnl.util.filesystem import install_tree, working_dir, join_path, copy, ancestor, mkdirp
-from spack.build_systems.cmake import CMakePackage
-from spack.build_systems.cuda import CudaPackage
-from spack.directives import *
-from spack.package import run_before, run_after
-from spack.util.executable import Executable, which, ProcessError
 
 
 class Llvm(CMakePackage, CudaPackage):
@@ -716,9 +710,8 @@ class Llvm(CMakePackage, CudaPackage):
         with working_dir(self.build_directory):
             install_tree("bin", join_path(self.prefix, "libexec", "llvm"))
 
-    @classmethod
-    def llvm_config(*args, **kwargs):
-        lc = which("llvm-config")
+    def llvm_config(self, *args, **kwargs):
+        lc = Executable(self.prefix.bin.join('llvm-config'))
         if not kwargs.get('output'):
             kwargs['output']=str
         ret = lc(*args, **kwargs)
@@ -726,11 +719,10 @@ class Llvm(CMakePackage, CudaPackage):
             return ret.split()
         return ret
 
-    @classmethod
-    def llvm_libs(*args):
+    def llvm_libs(self, *args):
         if not args:
             args = ["all"]
-        return Llvm.llvm_config("--libs", *args, output="list")
+        return self.llvm_config("--libs", *args, output="list")
 
 def get_llvm_targets_to_build(spec):
     targets = spec.variants['targets'].value

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -11,6 +11,12 @@ import llnl.util.tty as tty
 
 import spack.build_environment
 import spack.util.executable
+from llnl.util.filesystem import install_tree, working_dir, join_path, copy, ancestor, mkdirp
+from spack.build_systems.cmake import CMakePackage
+from spack.build_systems.cuda import CudaPackage
+from spack.directives import *
+from spack.package import run_before, run_after
+from spack.util.executable import Executable, which, ProcessError
 
 
 class Llvm(CMakePackage, CudaPackage):
@@ -710,6 +716,21 @@ class Llvm(CMakePackage, CudaPackage):
         with working_dir(self.build_directory):
             install_tree("bin", join_path(self.prefix, "libexec", "llvm"))
 
+    @classmethod
+    def llvm_config(*args, **kwargs):
+        lc = which("llvm-config")
+        if not kwargs.get('output'):
+            kwargs['output']=str
+        ret = lc(*args, **kwargs)
+        if kwargs.get('output') == "list":
+            return ret.split()
+        return ret
+
+    @classmethod
+    def llvm_libs(*args):
+        if not args:
+            args = ["all"]
+        return Llvm.llvm_config("--libs", *args, output="list")
 
 def get_llvm_targets_to_build(spec):
     targets = spec.variants['targets'].value

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -713,7 +713,7 @@ class Llvm(CMakePackage, CudaPackage):
     def llvm_config(self, *args, **kwargs):
         lc = Executable(self.prefix.bin.join('llvm-config'))
         if not kwargs.get('output'):
-            kwargs['output']=str
+            kwargs['output'] = str
         ret = lc(*args, **kwargs)
         if kwargs.get('output') == "list":
             return ret.split()
@@ -723,6 +723,7 @@ class Llvm(CMakePackage, CudaPackage):
         if not args:
             args = ["all"]
         return self.llvm_config("--libs", *args, output="list")
+
 
 def get_llvm_targets_to_build(spec):
     targets = spec.variants['targets'].value

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -719,11 +719,6 @@ class Llvm(CMakePackage, CudaPackage):
             return ret.split()
         return ret
 
-    def llvm_libs(self, *args):
-        if not args:
-            args = ["all"]
-        return self.llvm_config("--libs", *args, output="list")
-
 
 def get_llvm_targets_to_build(spec):
     targets = spec.variants['targets'].value


### PR DESCRIPTION
Add a helper as a base to build better libs etc. methods.  This should help with #28621 @glennpj.

As @haampie pointed out, llvm-config does *not* get along very well with `libllvm.so`, it's supposed to (it even has an option specifically for that case) but it doesn't.  If someone needs that, they should use libdir then libnames to get the appropriate setup then build the path themself.  For anything else though, shared-libs, static-libs, paths, flags, it works reliably in my experience.

The imports are not really related, but reduce the number of error prompts on this file by an immense amount when linting.