### PR TITLE
Allow for multiple dependencies/dependents from the same package

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -956,3 +956,12 @@ def nullcontext(*args, **kwargs):
 
 class UnhashableArguments(TypeError):
     """Raise when an @memoized function receives unhashable arg or kwarg values."""
+
+
+def enum(**kwargs):
+    """Return an enum-like class.
+
+    Args:
+        **kwargs: explicit dictionary of enums
+    """
+    return type('Enum', (object,), kwargs)

--- a/lib/spack/spack/cmd/deactivate.py
+++ b/lib/spack/spack/cmd/deactivate.py
@@ -8,9 +8,9 @@ import llnl.util.tty as tty
 import spack.cmd
 import spack.cmd.common.arguments as arguments
 import spack.environment as ev
+import spack.graph
 import spack.store
 from spack.filesystem_view import YamlFilesystemView
-from spack.graph import topological_sort
 
 description = "deactivate a package extension"
 section = "extensions"
@@ -68,11 +68,8 @@ def deactivate(parser, args):
             tty.msg("Deactivating %s and all dependencies." %
                     pkg.spec.short_spec)
 
-            topo_order = topological_sort(spec)
-            index = spec.index()
-
-            for name in topo_order:
-                espec = index[name]
+            nodes_in_topological_order = spack.graph.topological_sort(spec)
+            for espec in reversed(nodes_in_topological_order):
                 epkg = espec.package
                 if epkg.extends(pkg.extendee_spec):
                     if epkg.is_activated(view) or args.force:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -961,7 +961,7 @@ class Database(object):
         counts = {}
         for key, rec in self._data.items():
             counts.setdefault(key, 0)
-            for dep in rec.spec.dependencies(_tracked_deps):
+            for dep in rec.spec.dependencies(deptype=_tracked_deps):
                 dep_key = dep.dag_hash()
                 counts.setdefault(dep_key, 0)
                 counts[dep_key] += 1
@@ -1078,7 +1078,7 @@ class Database(object):
         # Retrieve optional arguments
         installation_time = installation_time or _now()
 
-        for dep in spec.dependencies(_tracked_deps):
+        for dep in spec.dependencies(deptype=_tracked_deps):
             dkey = dep.dag_hash()
             if dkey not in self._data:
                 extra_args = {
@@ -1120,9 +1120,7 @@ class Database(object):
             )
 
             # Connect dependencies from the DB to the new copy.
-            for name, dep in six.iteritems(
-                    spec.dependencies_dict(_tracked_deps)
-            ):
+            for dep in spec.edges_to_dependencies(deptype=_tracked_deps):
                 dkey = dep.spec.dag_hash()
                 upstream, record = self.query_by_spec_hash(dkey)
                 new_spec._add_dependency(record.spec, dep.deptypes)
@@ -1185,7 +1183,7 @@ class Database(object):
         if rec.ref_count == 0 and not rec.installed:
             del self._data[key]
 
-            for dep in spec.dependencies(_tracked_deps):
+            for dep in spec.dependencies(deptype=_tracked_deps):
                 self._decrement_ref_count(dep)
 
     def _increment_ref_count(self, spec):
@@ -1213,13 +1211,10 @@ class Database(object):
 
         del self._data[key]
 
-        for dep in rec.spec.dependencies(_tracked_deps):
-            # FIXME: the two lines below needs to be updated once #11983 is
-            # FIXME: fixed. The "if" statement should be deleted and specs are
-            # FIXME: to be removed from dependents by hash and not by name.
-            # FIXME: See https://github.com/spack/spack/pull/15777#issuecomment-607818955
-            if dep._dependents.get(spec.name):
-                del dep._dependents[spec.name]
+        # Remove any reference to this node from dependencies and
+        # decrement the reference count
+        rec.spec.detach_node(deptype=_tracked_deps)
+        for dep in rec.spec.dependencies(deptype=_tracked_deps):
             self._decrement_ref_count(dep)
 
         if rec.deprecated_for:
@@ -1527,7 +1522,8 @@ class Database(object):
             # us anyway (so e.g. they should never uninstall specs)
             upstream_results.extend(upstream_db._query(*args, **kwargs) or [])
 
-        local_results = set(self.query_local(*args, **kwargs))
+        local_results = self.query_local(*args, **kwargs)
+        local_results = set(local_results)
 
         results = list(local_results) + list(
             x for x in upstream_results if x not in local_results)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -28,6 +28,8 @@ import sys
 import time
 from typing import Dict  # novm
 
+import six
+
 try:
     import uuid
     _use_uuid = True

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1213,7 +1213,7 @@ class Database(object):
 
         # Remove any reference to this node from dependencies and
         # decrement the reference count
-        rec.spec.detach_node(deptype=_tracked_deps)
+        rec.spec.detach(deptype=_tracked_deps)
         for dep in rec.spec.dependencies(deptype=_tracked_deps):
             self._decrement_ref_count(dep)
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1520,8 +1520,7 @@ class Database(object):
             # us anyway (so e.g. they should never uninstall specs)
             upstream_results.extend(upstream_db._query(*args, **kwargs) or [])
 
-        local_results = self.query_local(*args, **kwargs)
-        local_results = set(local_results)
+        local_results = set(self.query_local(*args, **kwargs))
 
         results = list(local_results) + list(
             x for x in upstream_results if x not in local_results)

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -28,8 +28,6 @@ import sys
 import time
 from typing import Dict  # novm
 
-import six
-
 try:
     import uuid
     _use_uuid = True

--- a/lib/spack/spack/dependency.py
+++ b/lib/spack/spack/dependency.py
@@ -58,7 +58,7 @@ def canonical_deptype(deptype):
         if bad:
             raise ValueError(
                 'Invalid dependency types: %s' % ','.join(str(t) for t in bad))
-        return tuple(sorted(deptype))
+        return tuple(sorted(set(deptype)))
 
     raise ValueError('Invalid dependency type: %s' % repr(deptype))
 

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -73,7 +73,7 @@ def topological_sort(spec, deptype='all'):
     deptype = spack.dependency.canonical_deptype(deptype)
 
     # Work on a copy so this is nondestructive.
-    spec = spec.copy(deps=deptype)
+    spec = spec.copy(deps=True)
     nodes = spec.index(deptype=deptype)
 
     def dependencies(specs):

--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -44,7 +44,6 @@ can take a number of specs as input.
 """
 import itertools
 import sys
-
 from heapq import heapify, heappop, heappush
 
 from llnl.util.tty.color import ColorStream

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -227,8 +227,9 @@ def _packages_needed_to_bootstrap_compiler(compiler, architecture, pkgs):
     dep.concretize()
     # mark compiler as depended-on by the packages that use it
     for pkg in pkgs:
-        dep._dependents[pkg.name] = spack.spec.DependencySpec(
-            pkg.spec, dep, ('build',))
+        dep._dependents.add(
+            spack.spec.DependencySpec(pkg.spec, dep, ('build',))
+        )
     packages = [(s.package, False) for
                 s in dep.traverse(order='post', root=False)]
     packages.append((dep.package, True))

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1909,6 +1909,12 @@ class SpecBuilder(object):
 
     def depends_on(self, pkg, dep, type):
         dependencies = self._specs[pkg].edges_to_dependencies(name=dep)
+
+        # TODO: assertion to be removed when cross-compilation is handled correctly
+        msg = ("Current solver does not handle multiple dependency edges "
+               "of the same name")
+        assert len(dependencies) < 2, msg
+
         if not dependencies:
             self._specs[pkg].add_dependency_edge(self._specs[dep], (type,))
         else:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1259,9 +1259,10 @@ class SpackSolverSetup(object):
         # add all clauses from dependencies
         if transitive:
             if spec.concrete:
-                for dep_name, dep in spec.dependencies_dict().items():
-                    for dtype in dep.deptypes:
-                        clauses.append(fn.depends_on(spec.name, dep_name, dtype))
+                # TODO: We need to distinguish 2 specs from the same package later
+                for edge in spec.edges_to_dependencies():
+                    for dtype in edge.deptypes:
+                        clauses.append(fn.depends_on(spec.name, edge.spec.name, dtype))
 
             for dep in spec.traverse(root=False):
                 if spec.concrete:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1907,12 +1907,12 @@ class SpecBuilder(object):
         )
 
     def depends_on(self, pkg, dep, type):
-        dependency = self._specs[pkg]._dependencies.get(dep)
-        if not dependency:
-            self._specs[pkg]._add_dependency(
-                self._specs[dep], (type,))
+        dependencies = self._specs[pkg].edges_to_dependencies(name=dep)
+        if not dependencies:
+            self._specs[pkg].add_dependency_edge(self._specs[dep], (type,))
         else:
-            dependency.add_type(type)
+            # TODO: This assumes that each solve unifies dependencies
+            dependencies[0].add_type(type)
 
     def reorder_flags(self):
         """Order compiler flags on specs in predefined order.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4728,7 +4728,7 @@ def merge_abstract_anonymous_specs(*abstract_specs):
 
         # Update with additional constraints from other spec
         for name in current_spec_constraint.dep_difference(merged_spec):
-            edge = current_spec_constraint.get_dependency(name)
+            edge = next(iter(current_spec_constraint.edges_to_dependencies(name)))
             merged_spec._add_dependency(edge.spec.copy(), edge.deptypes)
 
     return merged_spec

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1269,7 +1269,7 @@ class Spec(object):
     def external(self):
         return bool(self.external_path) or bool(self.external_modules)
 
-    def reset_dependencies(self):
+    def clear_dependencies(self):
         """Trim the dependencies of this spec."""
         self._dependencies.clear()
 
@@ -2592,8 +2592,8 @@ class Spec(object):
                         for dep in spec.dependencies():
                             del dep._dependents.edges[spec.name]
                         changed = True
-                        spec.reset_dependencies()
-                    replacement.reset_dependencies()
+                        spec.clear_dependencies()
+                    replacement.clear_dependencies()
                     replacement.architecture = self.architecture
 
                 # TODO: could this and the stuff in _dup be cleaned up?
@@ -2941,7 +2941,7 @@ class Spec(object):
                 for spec in flat_deps.values():
                     if not spec.concrete:
                         spec.reset_edges()
-                self.reset_dependencies()
+                self.clear_dependencies()
 
             return flat_deps
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4615,6 +4615,18 @@ class Spec(object):
         assert other.concrete
         assert other.name in self
 
+        # Check, for the time being, that we don't have DAG with multiple
+        # specs from the same package
+        def multiple_specs(root):
+            counter = collections.Counter([node.name for node in root.traverse()])
+            _, max_number = counter.most_common()[0]
+            return max_number > 1
+
+        if multiple_specs(self) or multiple_specs(other):
+            msg = ('Either "{0}" or "{1}" contain multiple specs from the same '
+                   'package, which cannot be handled by splicing at the moment')
+            raise ValueError(msg.format(self, other))
+
         # Multiple unique specs with the same name will collide, so the
         # _dependents of these specs should not be trusted.
         # Variants may also be ignored here for now...

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -871,25 +871,25 @@ class _EdgeMap(Mapping):
 
         dependency_types = dp.canonical_deptype(dependency_types)
         # Start from all the edges we store
-        selected = [d for d in itertools.chain.from_iterable(self.values())]
+        selected = (d for d in itertools.chain.from_iterable(self.values()))
 
         # Filter by parent name
         if parent:
-            selected = [d for d in selected if d.parent.name == parent]
+            selected = (d for d in selected if d.parent.name == parent)
 
         # Filter by child name
         if child:
-            selected = [d for d in selected if d.spec.name == child]
+            selected = (d for d in selected if d.spec.name == child)
 
         # Filter by allowed dependency types
         if dependency_types:
-            selected = [
+            selected = (
                 dep for dep in selected
-                if any(d in dependency_types for d in dep.deptypes)
-                or not dep.deptypes
-            ]
+                if not dep.deptypes or
+                any(d in dependency_types for d in dep.deptypes)
+            )
 
-        return selected
+        return list(selected)
 
     def clear(self):
         self.edges.clear()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -850,7 +850,7 @@ class _EdgeMap(Mapping):
 
         return clone
 
-    def select_by(self, parent=None, child=None, dependency_types='all'):
+    def select(self, parent=None, child=None, dependency_types='all'):
         """Select a list of edges and return them.
 
         If an edge:
@@ -1320,7 +1320,7 @@ class Spec(object):
         """
         return [
             d for d in
-            self._dependents.select_by(parent=name, dependency_types=deptype)
+            self._dependents.select(parent=name, dependency_types=deptype)
         ]
 
     def edges_to_dependencies(self, name=None, deptype='all'):
@@ -1333,7 +1333,7 @@ class Spec(object):
         """
         return [
             d for d in
-            self._dependencies.select_by(child=name, dependency_types=deptype)
+            self._dependencies.select(child=name, dependency_types=deptype)
         ]
 
     def dependencies(self, name=None, deptype='all'):
@@ -1345,7 +1345,7 @@ class Spec(object):
         """
         return [
             d.spec for d in
-            self._dependencies.select_by(child=name, dependency_types=deptype)
+            self._dependencies.select(child=name, dependency_types=deptype)
         ]
 
     def dependents(self, name=None, deptype='all'):
@@ -1357,7 +1357,7 @@ class Spec(object):
         """
         return [
             d.parent for d in
-            self._dependents.select_by(parent=name, dependency_types=deptype)
+            self._dependents.select(parent=name, dependency_types=deptype)
         ]
 
     def _dependencies_dict(self, deptype='all'):
@@ -1371,7 +1371,7 @@ class Spec(object):
         """
         _sort_fn = lambda x: (x.spec.name,) + _sort_by_dep_types(x)
         _group_fn = lambda x: x.spec.name
-        selected_edges = self._dependencies.select_by(dependency_types=deptype)
+        selected_edges = self._dependencies.select(dependency_types=deptype)
         result = {}
         for key, group in itertools.groupby(
                 sorted(selected_edges, key=_sort_fn), key=_group_fn

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -792,6 +792,8 @@ class _EdgeMap(Mapping):
         msg = 'unexpected value for "store_by" argument'
         assert store_by in ('child', 'parent'), msg
 
+        #: This dictionary maps a package name to a list of edges
+        #: i.e. to a list of DependencySpec objects
         self.edges = {}
         self.store_by_child = (store_by == 'child')
 
@@ -1290,10 +1292,12 @@ class Spec(object):
                     dep._dependents.add(edge)
 
     def _get_dependency(self, name):
-        # TODO: revisit for the case of multiple dependencies
-        # TODO: from the same package? Check if this function
-        # TODO: is used only in contexts going back to the
-        # TODO: original concretization algorithm
+        # WARNING: This function is an implementation detail of the
+        # WARNING: original concretizer. Since with that greedy
+        # WARNING: algorithm we don't allow multiple nodes from
+        # WARNING: the same package in a DAG, here we hard-code
+        # WARNING: using index 0 i.e. we assume that we have only
+        # WARNING: one edge from package "name"
         dep = self._dependencies.get(name)
         if dep is not None:
             return dep[0]
@@ -3436,9 +3440,12 @@ class Spec(object):
         for name in self.common_dependencies(other):
             changed |= self[name].constrain(other[name], deps=False)
             if name in self._dependencies:
-                # TODO: revisit the lines below, they may need to change
-                # TODO: in case of multiple nodes from the same package
-                # TODO: For now hard-code using index 0
+                # WARNING: This function is an implementation detail of the
+                # WARNING: original concretizer. Since with that greedy
+                # WARNING: algorithm we don't allow multiple nodes from
+                # WARNING: the same package in a DAG, here we hard-code
+                # WARNING: using index 0 i.e. we assume that we have only
+                # WARNING: one edge from package "name"
                 edges_from_name = self._dependencies[name]
                 changed |= edges_from_name[0].update_deptypes(
                     other._dependencies[name][0].deptypes)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -837,7 +837,7 @@ class _EdgeMap(Mapping):
 
         return clone
 
-    def select(self, parent=None, child=None, dependency_types='all'):
+    def select(self, parent=None, child=None, deptypes='all'):
         """Select a list of edges and return them.
 
         If an edge:
@@ -848,15 +848,15 @@ class _EdgeMap(Mapping):
         Args:
             parent (str): name of the parent package
             child (str): name of the child package
-            dependency_types: allowed dependency types
+            deptypes: allowed dependency types
 
         Returns:
             List of DependencySpec objects
         """
-        if not dependency_types:
+        if not deptypes:
             return []
 
-        dependency_types = dp.canonical_deptype(dependency_types)
+        deptypes = dp.canonical_deptype(deptypes)
         # Start from all the edges we store
         selected = (d for d in itertools.chain.from_iterable(self.values()))
 
@@ -869,11 +869,11 @@ class _EdgeMap(Mapping):
             selected = (d for d in selected if d.spec.name == child)
 
         # Filter by allowed dependency types
-        if dependency_types:
+        if deptypes:
             selected = (
                 dep for dep in selected
                 if not dep.deptypes or
-                any(d in dependency_types for d in dep.deptypes)
+                any(d in deptypes for d in dep.deptypes)
             )
 
         return list(selected)
@@ -1307,7 +1307,7 @@ class Spec(object):
         """
         return [
             d for d in
-            self._dependents.select(parent=name, dependency_types=deptype)
+            self._dependents.select(parent=name, deptypes=deptype)
         ]
 
     def edges_to_dependencies(self, name=None, deptype='all'):
@@ -1320,7 +1320,7 @@ class Spec(object):
         """
         return [
             d for d in
-            self._dependencies.select(child=name, dependency_types=deptype)
+            self._dependencies.select(child=name, deptypes=deptype)
         ]
 
     def dependencies(self, name=None, deptype='all'):
@@ -1352,7 +1352,7 @@ class Spec(object):
         """
         _sort_fn = lambda x: (x.spec.name,) + _sort_by_dep_types(x)
         _group_fn = lambda x: x.spec.name
-        selected_edges = self._dependencies.select(dependency_types=deptype)
+        selected_edges = self._dependencies.select(deptypes=deptype)
         result = {}
         for key, group in itertools.groupby(
                 sorted(selected_edges, key=_sort_fn), key=_group_fn

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1302,10 +1302,10 @@ class Spec(object):
         # WARNING: the same package in a DAG, here we hard-code
         # WARNING: using index 0 i.e. we assume that we have only
         # WARNING: one edge from package "name"
-        dep = self._dependencies.get(name)
-        if dep is not None:
-            return dep[0]
-        raise InvalidDependencyError(self.name, name)
+        deps = self.edges_to_dependencies(name=name)
+        err_msg = 'expected only 1 "{0}" dependency, but got {1}'
+        assert len(deps) == 1, err_msg.format(name, len(deps))
+        return deps[0]
 
     def edges_from_dependents(self, name=None, deptype='all'):
         """Return a list of edges connecting this node in the DAG

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1278,7 +1278,7 @@ class Spec(object):
         self._dependencies.clear()
         self._dependents.clear()
 
-    def detach_node(self, deptype='all'):
+    def detach(self, deptype='all'):
         """Remove any reference that dependencies have of this node.
 
         Args:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -777,6 +777,10 @@ def _sort_by_dep_types(dspec):
     )
 
 
+#: Enum for edge directions
+EdgeDirection = lang.enum(parent=0, child=1)
+
+
 @lang.lazy_lexicographic_ordering
 class _EdgeMap(Mapping):
     """Represent a collection of edges (DependencySpec objects) in the DAG.
@@ -787,15 +791,15 @@ class _EdgeMap(Mapping):
 
     Edges are stored in a dictionary and keyed by package name.
     """
-    def __init__(self, store_by='child'):
+    def __init__(self, store_by=EdgeDirection.child):
         # Sanitize input arguments
         msg = 'unexpected value for "store_by" argument'
-        assert store_by in ('child', 'parent'), msg
+        assert store_by in (EdgeDirection.child, EdgeDirection.parent), msg
 
         #: This dictionary maps a package name to a list of edges
         #: i.e. to a list of DependencySpec objects
         self.edges = {}
-        self.store_by_child = (store_by == 'child')
+        self.store_by_child = (store_by == EdgeDirection.child)
 
     def __getitem__(self, key):
         return self.edges[key]
@@ -1190,8 +1194,8 @@ class Spec(object):
         self.architecture = None
         self.compiler = None
         self.compiler_flags = FlagMap(self)
-        self._dependents = _EdgeMap(store_by='parent')
-        self._dependencies = _EdgeMap(store_by='child')
+        self._dependents = _EdgeMap(store_by=EdgeDirection.parent)
+        self._dependencies = _EdgeMap(store_by=EdgeDirection.child)
         self.namespace = None
 
         self._hash = None
@@ -3715,8 +3719,8 @@ class Spec(object):
             else None
         self.compiler = other.compiler.copy() if other.compiler else None
         if cleardeps:
-            self._dependents = _EdgeMap(store_by='parent')
-            self._dependencies = _EdgeMap(store_by='child')
+            self._dependents = _EdgeMap(store_by=EdgeDirection.parent)
+            self._dependencies = _EdgeMap(store_by=EdgeDirection.child)
         self.compiler_flags = other.compiler_flags.copy()
         self.compiler_flags.spec = self
         self.variants = other.variants.copy()

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1658,25 +1658,25 @@ class Spec(object):
 
             # This code determines direction and yields the children/parents
             if direction == 'children':
-                edges = self._dependencies
+                edges = self.edges_to_dependencies
+                key_fn = lambda dspec: dspec.spec.name
                 succ = lambda dspec: dspec.spec
             elif direction == 'parents':
-                edges = self._dependents
+                edges = self.edges_from_dependents
+                key_fn = lambda dspec: dspec.parent.name
                 succ = lambda dspec: dspec.parent
             else:
                 raise ValueError('Invalid traversal direction: %s' % direction)
 
-            for name in sorted(edges):
-                edges_from_name = edges[name]
-                for dspec in edges_from_name:
-                    dt = dspec.deptypes
-                    if dt and not any(d in deptype for d in dt):
-                        continue
+            for dspec in sorted(edges(), key=key_fn):
+                dt = dspec.deptypes
+                if dt and not any(d in deptype for d in dt):
+                    continue
 
-                    for child in succ(dspec).traverse_edges(
-                            visited, d + 1, deptype, dspec, **kwargs
-                    ):
-                        yield child
+                for child in succ(dspec).traverse_edges(
+                        visited, d + 1, deptype, dspec, **kwargs
+                ):
+                    yield child
 
         # Postorder traversal yields after successors
         if yield_me and order == 'post':

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1272,7 +1272,7 @@ class Spec(object):
         self._dependencies.clear()
 
     def reset_edges(self):
-        """Trim the dependents of this spec."""
+        """Trim the dependencies and dependents of this spec."""
         self._dependencies.clear()
         self._dependents.clear()
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -837,7 +837,7 @@ class _EdgeMap(Mapping):
 
         return clone
 
-    def select(self, parent=None, child=None, deptypes='all'):
+    def select(self, parent=None, child=None, deptypes=dp.all_deptypes):
         """Select a list of edges and return them.
 
         If an edge:
@@ -845,10 +845,13 @@ class _EdgeMap(Mapping):
         - Matches the parent and/or child name, if passed
         then it is selected.
 
+        The deptypes argument needs to be canonical, since the method won't
+        convert it for performance reason.
+
         Args:
             parent (str): name of the parent package
             child (str): name of the child package
-            deptypes: allowed dependency types
+            deptypes (tuple): allowed dependency types in canonical form
 
         Returns:
             List of DependencySpec objects
@@ -856,7 +859,6 @@ class _EdgeMap(Mapping):
         if not deptypes:
             return []
 
-        deptypes = dp.canonical_deptype(deptypes)
         # Start from all the edges we store
         selected = (d for d in itertools.chain.from_iterable(self.values()))
 
@@ -1305,6 +1307,7 @@ class Spec(object):
             name (str): filter dependents by package name
             deptype (str or tuple): allowed dependency types
         """
+        deptype = dp.canonical_deptype(deptype)
         return [
             d for d in
             self._dependents.select(parent=name, deptypes=deptype)
@@ -1318,6 +1321,7 @@ class Spec(object):
             name (str): filter dependencies by package name
             deptype (str or tuple): allowed dependency types
         """
+        deptype = dp.canonical_deptype(deptype)
         return [
             d for d in
             self._dependencies.select(child=name, deptypes=deptype)
@@ -1352,6 +1356,7 @@ class Spec(object):
         """
         _sort_fn = lambda x: (x.spec.name,) + _sort_by_dep_types(x)
         _group_fn = lambda x: x.spec.name
+        deptype = dp.canonical_deptype(deptype)
         selected_edges = self._dependencies.select(deptypes=deptype)
         result = {}
         for key, group in itertools.groupby(

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1273,7 +1273,7 @@ class Spec(object):
         """Trim the dependencies of this spec."""
         self._dependencies.clear()
 
-    def reset_edges(self):
+    def clear_edges(self):
         """Trim the dependencies and dependents of this spec."""
         self._dependencies.clear()
         self._dependents.clear()
@@ -2940,7 +2940,7 @@ class Spec(object):
             if not copy:
                 for spec in flat_deps.values():
                     if not spec.concrete:
-                        spec.reset_edges()
+                        spec.clear_edges()
                 self.clear_dependencies()
 
             return flat_deps

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -667,8 +667,7 @@ class DependencySpec(object):
     def __init__(self, parent, spec, deptypes):
         self.parent = parent
         self.spec = spec
-        deptypes = dp.canonical_deptype(deptypes)
-        self.deptypes = tuple(sorted(set(deptypes)))
+        self.deptypes = dp.canonical_deptype(deptypes)
 
     def update_deptypes(self, deptypes):
         deptypes = set(deptypes)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1343,10 +1343,7 @@ class Spec(object):
             name (str): filter dependencies by package name
             deptype (str or tuple): allowed dependency types
         """
-        return [
-            d.spec for d in
-            self._dependencies.select(child=name, dependency_types=deptype)
-        ]
+        return [d.spec for d in self.edges_to_dependencies(name, deptype=deptype)]
 
     def dependents(self, name=None, deptype='all'):
         """Return a list of direct dependents (nodes in the DAG).
@@ -1355,10 +1352,7 @@ class Spec(object):
             name (str): filter dependents by package name
             deptype (str or tuple): allowed dependency types
         """
-        return [
-            d.parent for d in
-            self._dependents.select(parent=name, dependency_types=deptype)
-        ]
+        return [d.parent for d in self.edges_from_dependents(name, deptype=deptype)]
 
     def _dependencies_dict(self, deptype='all'):
         """Return a dictionary, keyed by package name, of the direct

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -615,7 +615,7 @@ class TestConcretize(object):
         assert s.concrete
 
         # Remove the dependencies and reset caches
-        s.reset_dependencies()
+        s.clear_dependencies()
         s._concrete = False
 
         assert not s.concrete

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -176,13 +176,17 @@ class TestConcretize(object):
 
     def test_concretize_mention_build_dep(self):
         spec = check_concretize('cmake-client ^cmake@3.4.3')
+
         # Check parent's perspective of child
-        dependency = spec.dependencies_dict()['cmake']
-        assert set(dependency.deptypes) == set(['build'])
+        to_dependencies = spec.edges_to_dependencies(name='cmake')
+        assert len(to_dependencies) == 1
+        assert set(to_dependencies[0].deptypes) == set(['build'])
+
         # Check child's perspective of parent
         cmake = spec['cmake']
-        dependent = cmake.dependents_dict()['cmake-client']
-        assert set(dependent.deptypes) == set(['build'])
+        from_dependents = cmake.edges_from_dependents(name='cmake-client')
+        assert len(from_dependents) == 1
+        assert set(from_dependents[0].deptypes) == set(['build'])
 
     def test_concretize_preferred_version(self):
         spec = check_concretize('python')
@@ -379,30 +383,37 @@ class TestConcretize(object):
     def test_virtual_is_fully_expanded_for_callpath(self):
         # force dependence on fake "zmpi" by asking for MPI 10.0
         spec = Spec('callpath ^mpi@10.0')
-        assert 'mpi' in spec._dependencies
+        assert len(spec.dependencies(name='mpi')) == 1
         assert 'fake' not in spec
+
         spec.concretize()
-        assert 'zmpi' in spec._dependencies
-        assert all('mpi' not in d._dependencies for d in spec.traverse())
-        assert 'zmpi' in spec
-        assert 'mpi' in spec
-        assert 'fake' in spec._dependencies['zmpi'].spec
+        assert len(spec.dependencies(name='zmpi')) == 1
+        assert all(not d.dependencies(name='mpi') for d in spec.traverse())
+        assert all(x in spec for x in ('zmpi', 'mpi'))
+
+        edges_to_zmpi = spec.edges_to_dependencies(name='zmpi')
+        assert len(edges_to_zmpi) == 1
+        assert 'fake' in edges_to_zmpi[0].spec
 
     def test_virtual_is_fully_expanded_for_mpileaks(
             self
     ):
         spec = Spec('mpileaks ^mpi@10.0')
-        assert 'mpi' in spec._dependencies
+        assert len(spec.dependencies(name='mpi')) == 1
         assert 'fake' not in spec
+
         spec.concretize()
-        assert 'zmpi' in spec._dependencies
-        assert 'callpath' in spec._dependencies
-        assert 'zmpi' in spec._dependencies['callpath'].spec._dependencies
-        assert 'fake' in spec._dependencies['callpath'].spec._dependencies[
-            'zmpi'].spec._dependencies  # NOQA: ignore=E501
-        assert all('mpi' not in d._dependencies for d in spec.traverse())
-        assert 'zmpi' in spec
-        assert 'mpi' in spec
+        assert len(spec.dependencies(name='zmpi')) == 1
+        assert len(spec.dependencies(name='callpath')) == 1
+
+        callpath = spec.dependencies(name='callpath')[0]
+        assert len(callpath.dependencies(name='zmpi')) == 1
+
+        zmpi = callpath.dependencies(name='zmpi')[0]
+        assert len(zmpi.dependencies(name='fake')) == 1
+
+        assert all(not d.dependencies(name='mpi') for d in spec.traverse())
+        assert all(x in spec for x in ('zmpi', 'mpi'))
 
     def test_my_dep_depends_on_provider_of_my_virtual_dep(self):
         spec = Spec('indirect-mpich')
@@ -604,7 +615,7 @@ class TestConcretize(object):
         assert s.concrete
 
         # Remove the dependencies and reset caches
-        s._dependencies.clear()
+        s.reset_dependencies()
         s._concrete = False
 
         assert not s.concrete

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -754,10 +754,11 @@ def mock_store(tmpdir_factory, mock_repo_path, mock_configuration_scopes,
 
 
 @pytest.fixture(scope='function')
-def database(mock_store, mock_packages, config, monkeypatch):
+def database(mock_store, mock_packages, config):
     """This activates the mock store, packages, AND config."""
     with spack.store.use_store(str(mock_store)) as store:
         yield store.db
+        # Force reading the database again between tests
         store.db.last_seen_verifier = ''
 
 

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -3,42 +3,29 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from six import StringIO
+import pytest
+import six
 
+import spack.graph
 import spack.repo
-from spack.graph import AsciiGraph, graph_dot, topological_sort
-from spack.spec import Spec
+import spack.spec
 
 
-def test_topo_sort(mock_packages):
-    """Test topo sort gives correct order."""
-    s = Spec('mpileaks').normalized()
-
-    topo = topological_sort(s)
-
-    assert topo.index('mpileaks') < topo.index('callpath')
-    assert topo.index('mpileaks') < topo.index('mpi')
-    assert topo.index('mpileaks') < topo.index('dyninst')
-    assert topo.index('mpileaks') < topo.index('libdwarf')
-    assert topo.index('mpileaks') < topo.index('libelf')
-
-    assert topo.index('callpath') < topo.index('mpi')
-    assert topo.index('callpath') < topo.index('dyninst')
-    assert topo.index('callpath') < topo.index('libdwarf')
-    assert topo.index('callpath') < topo.index('libelf')
-
-    assert topo.index('dyninst') < topo.index('libdwarf')
-    assert topo.index('dyninst') < topo.index('libelf')
-
-    assert topo.index('libdwarf') < topo.index('libelf')
+@pytest.mark.parametrize('spec_str', ['mpileaks', 'callpath'])
+def test_topo_sort(spec_str, config, mock_packages):
+    """Ensure nodes are ordered topologically"""
+    s = spack.spec.Spec(spec_str).concretized()
+    nodes = spack.graph.topological_sort(s)
+    for idx, current in enumerate(nodes):
+        assert all(following not in current for following in nodes[idx + 1:])
 
 
-def test_static_graph_mpileaks(mock_packages):
+def test_static_graph_mpileaks(config, mock_packages):
     """Test a static spack graph for a simple package."""
-    s = Spec('mpileaks').normalized()
+    s = spack.spec.Spec('mpileaks').normalized()
 
-    stream = StringIO()
-    graph_dot([s], static=True, out=stream)
+    stream = six.StringIO()
+    spack.graph.graph_dot([s], static=True, out=stream)
 
     dot = stream.getvalue()
 
@@ -62,72 +49,64 @@ def test_static_graph_mpileaks(mock_packages):
 
 def test_dynamic_dot_graph_mpileaks(mock_packages, config):
     """Test dynamically graphing the mpileaks package."""
-    s = Spec('mpileaks').concretized()
-
-    stream = StringIO()
-    graph_dot([s], static=False, out=stream)
-
+    s = spack.spec.Spec('mpileaks').concretized()
+    stream = six.StringIO()
+    spack.graph.graph_dot([s], static=False, out=stream)
     dot = stream.getvalue()
-    print(dot)
 
-    mpileaks_hash, mpileaks_lbl = s.dag_hash(), s.format('{name}')
-    mpi_hash, mpi_lbl = s['mpi'].dag_hash(), s['mpi'].format('{name}')
-    callpath_hash, callpath_lbl = (
-        s['callpath'].dag_hash(), s['callpath'].format('{name}'))
-    dyninst_hash, dyninst_lbl = (
-        s['dyninst'].dag_hash(), s['dyninst'].format('{name}'))
-    libdwarf_hash, libdwarf_lbl = (
-        s['libdwarf'].dag_hash(), s['libdwarf'].format('{name}'))
-    libelf_hash, libelf_lbl = (
-        s['libelf'].dag_hash(), s['libelf'].format('{name}'))
+    nodes_to_check = ['mpileaks', 'mpi', 'callpath', 'dyninst', 'libdwarf', 'libelf']
+    hashes = {}
+    for name in nodes_to_check:
+        current = s[name]
+        current_hash = current.dag_hash()
+        hashes[name] = current_hash
+        assert '  "{0}" [label="{1}"]\n'.format(
+            current_hash, spack.graph.node_label(current)
+        ) in dot
 
-    assert '  "%s" [label="%s"]\n' % (mpileaks_hash, mpileaks_lbl) in dot
-    assert '  "%s" [label="%s"]\n' % (callpath_hash, callpath_lbl) in dot
-    assert '  "%s" [label="%s"]\n' % (mpi_hash,      mpi_lbl) in dot
-    assert '  "%s" [label="%s"]\n' % (dyninst_hash,  dyninst_lbl) in dot
-    assert '  "%s" [label="%s"]\n' % (libdwarf_hash, libdwarf_lbl) in dot
-    assert '  "%s" [label="%s"]\n' % (libelf_hash, libelf_lbl) in dot
-
-    assert '  "%s" -> "%s"\n' % (dyninst_hash, libdwarf_hash)  in dot
-    assert '  "%s" -> "%s"\n' % (callpath_hash, dyninst_hash)  in dot
-    assert '  "%s" -> "%s"\n' % (mpileaks_hash, mpi_hash)  in dot
-    assert '  "%s" -> "%s"\n' % (libdwarf_hash, libelf_hash)  in dot
-    assert '  "%s" -> "%s"\n' % (callpath_hash, mpi_hash)  in dot
-    assert '  "%s" -> "%s"\n' % (mpileaks_hash, callpath_hash)  in dot
-    assert '  "%s" -> "%s"\n' % (dyninst_hash, libelf_hash)  in dot
+    dependencies_to_check = [
+        ('dyninst', 'libdwarf'),
+        ('callpath', 'dyninst'),
+        ('mpileaks', 'mpi'),
+        ('libdwarf', 'libelf'),
+        ('callpath', 'mpi'),
+        ('mpileaks', 'callpath'),
+        ('dyninst', 'libelf')
+    ]
+    for parent, child in dependencies_to_check:
+        assert '  "{0}" -> "{1}"\n'.format(hashes[parent], hashes[child]) in dot
 
 
-def test_ascii_graph_mpileaks(mock_packages):
-    """Test dynamically graphing the mpileaks package."""
-    s = Spec('mpileaks').normalized()
+def test_ascii_graph_mpileaks(config, mock_packages, monkeypatch):
+    monkeypatch.setattr(
+        spack.graph.AsciiGraph, '_node_label',
+        lambda self, node: node.name
+    )
+    s = spack.spec.Spec('mpileaks').concretized()
 
-    stream = StringIO()
-    graph = AsciiGraph()
+    stream = six.StringIO()
+    graph = spack.graph.AsciiGraph()
     graph.write(s, out=stream, color=False)
-    string = stream.getvalue()
+    graph_str = stream.getvalue()
+    graph_str = '\n'.join([line.rstrip() for line in graph_str.split('\n')])
 
-    # Some lines in spack graph still have trailing space
-    # TODO: fix this.
-    string = '\n'.join([line.rstrip() for line in string.split('\n')])
-
-    assert string == r'''o  mpileaks
+    assert graph_str == r'''o mpileaks
 |\
-| o  callpath
+| o callpath
 |/|
-o |  mpi
+o | mpich
  /
-o  dyninst
+o dyninst
 |\
-| o  libdwarf
+o | libdwarf
 |/
-o  libelf
+o libelf
 '''
 
 
-def test_topo_sort_filtered(mock_packages):
-    """Test topo sort gives correct order when filtering link deps."""
-    s = Spec('both-link-and-build-dep-a').normalized()
+def test_topological_sort_filtering_dependency_types(config, mock_packages):
+    s = spack.spec.Spec('both-link-and-build-dep-a').concretized()
 
-    topo = topological_sort(s, deptype=('link',))
-
-    assert topo == ['both-link-and-build-dep-a', 'both-link-and-build-dep-c']
+    nodes = spack.graph.topological_sort(s, deptype=('link',))
+    names = [s.name for s in nodes]
+    assert names == ['both-link-and-build-dep-c', 'both-link-and-build-dep-a']

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import sys
 
 import pytest
 import six
@@ -77,6 +78,9 @@ def test_dynamic_dot_graph_mpileaks(mock_packages, config):
         assert '  "{0}" -> "{1}"\n'.format(hashes[parent], hashes[child]) in dot
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 6), reason="Ordering might not be consistent"
+)
 def test_ascii_graph_mpileaks(config, mock_packages, monkeypatch):
     monkeypatch.setattr(
         spack.graph.AsciiGraph, '_node_label',

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -624,6 +624,23 @@ class TestSpecDag(object):
         copy_ids = set(id(s) for s in copy.traverse())
         assert not orig_ids.intersection(copy_ids)
 
+    def test_copy_through_spec_build_interface(self):
+        """Check that copying dependencies using id(node) as a fast identifier of the
+        node works when the spec is wrapped in a SpecBuildInterface object.
+        """
+        s = Spec('mpileaks').concretized()
+
+        c0 = s.copy()
+        assert c0 == s
+
+        # Single indirection
+        c1 = s['mpileaks'].copy()
+        assert c0 == c1 == s
+
+        # Double indirection
+        c2 = s['mpileaks']['mpileaks'].copy()
+        assert c0 == c1 == c2 == s
+
     """
     Here is the graph with deptypes labeled (assume all packages have a 'dt'
     prefix). Arrows are marked with the deptypes ('b' for 'build', 'l' for

--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -18,10 +18,10 @@ from spack.util.mock_package import MockPackageMultiRepo
 def check_links(spec_to_check):
     for spec in spec_to_check.traverse():
         for dependent in spec.dependents():
-            assert spec.name in dependent.dependencies_dict()
+            assert dependent.edges_to_dependencies(name=spec.name)
 
         for dependency in spec.dependencies():
-            assert spec.name in dependency.dependents_dict()
+            assert dependency.edges_from_dependents(name=spec.name)
 
 
 @pytest.fixture()
@@ -297,9 +297,16 @@ class TestSpecDag(object):
         # Normalize then add conflicting constraints to the DAG (this is an
         # extremely unlikely scenario, but we test for it anyway)
         mpileaks.normalize()
-        mpileaks._dependencies['mpich'].spec = Spec('mpich@1.0')
-        mpileaks._dependencies['callpath']. \
-            spec._dependencies['mpich'].spec = Spec('mpich@2.0')
+
+        mpileaks.edges_to_dependencies(
+            name='mpich'
+        )[0].spec = Spec('mpich@1.0')
+
+        mpileaks.edges_to_dependencies(
+            name='callpath'
+        )[0].spec.edges_to_dependencies(
+            name='mpich'
+        )[0].spec = Spec('mpich@2.0')
 
         with pytest.raises(spack.spec.InconsistentSpecError):
             mpileaks.flat_dependencies(copy=False)
@@ -790,21 +797,25 @@ class TestSpecDag(object):
             }
         })
 
-        assert s['b']._dependencies['c'].deptypes == ('build',)
-        assert s['d']._dependencies['e'].deptypes == ('build', 'link')
-        assert s['e']._dependencies['f'].deptypes == ('run',)
+        assert s['b'].edges_to_dependencies(
+            name='c'
+        )[0].deptypes == ('build',)
+        assert s['d'].edges_to_dependencies(
+            name='e'
+        )[0].deptypes == ('build', 'link')
+        assert s['e'].edges_to_dependencies(
+            name='f'
+        )[0].deptypes == ('run',)
 
-        assert s['b']._dependencies['c'].deptypes == ('build',)
-        assert s['d']._dependencies['e'].deptypes == ('build', 'link')
-        assert s['e']._dependencies['f'].deptypes == ('run',)
-
-        assert s['c']._dependents['b'].deptypes == ('build',)
-        assert s['e']._dependents['d'].deptypes == ('build', 'link')
-        assert s['f']._dependents['e'].deptypes == ('run',)
-
-        assert s['c']._dependents['b'].deptypes == ('build',)
-        assert s['e']._dependents['d'].deptypes == ('build', 'link')
-        assert s['f']._dependents['e'].deptypes == ('run',)
+        assert s['c'].edges_from_dependents(
+            name='b'
+        )[0].deptypes == ('build',)
+        assert s['e'].edges_from_dependents(
+            name='d'
+        )[0].deptypes == ('build', 'link')
+        assert s['f'].edges_from_dependents(
+            name='e'
+        )[0].deptypes == ('run',)
 
     def check_diamond_deptypes(self, spec):
         """Validate deptypes in dt-diamond spec.
@@ -813,17 +824,21 @@ class TestSpecDag(object):
         depend on the same dependency in different ways.
 
         """
-        assert spec['dt-diamond']._dependencies[
-            'dt-diamond-left'].deptypes == ('build', 'link')
+        assert spec['dt-diamond'].edges_to_dependencies(
+            name='dt-diamond-left'
+        )[0].deptypes == ('build', 'link')
 
-        assert spec['dt-diamond']._dependencies[
-            'dt-diamond-right'].deptypes == ('build', 'link')
+        assert spec['dt-diamond'].edges_to_dependencies(
+            name='dt-diamond-right'
+        )[0].deptypes == ('build', 'link')
 
-        assert spec['dt-diamond-left']._dependencies[
-            'dt-diamond-bottom'].deptypes == ('build',)
+        assert spec['dt-diamond-left'].edges_to_dependencies(
+            name='dt-diamond-bottom'
+        )[0].deptypes == ('build',)
 
-        assert spec['dt-diamond-right'] ._dependencies[
-            'dt-diamond-bottom'].deptypes == ('build', 'link', 'run')
+        assert spec['dt-diamond-right'].edges_to_dependencies(
+            name='dt-diamond-bottom'
+        )[0].deptypes == ('build', 'link', 'run')
 
     def check_diamond_normalized_dag(self, spec):
 
@@ -989,3 +1004,54 @@ class TestSpecDag(object):
         assert 'version-test-pkg' in out
         out = s.tree(deptypes=('link', 'run'))
         assert 'version-test-pkg' not in out
+
+
+def test_synthetic_construction_of_split_dependencies_from_same_package(
+        mock_packages, config
+):
+    # Construct in a synthetic way (i.e. without using the solver)
+    # the following spec:
+    #
+    #          b
+    #  build /   \ link,run
+    #    c@2.0   c@1.0
+    #
+    # To demonstrate that a spec can now hold two direct
+    # dependencies from the same package
+    root = Spec('b').concretized()
+    link_run_spec = Spec('c@1.0').concretized()
+    build_spec = Spec('c@2.0').concretized()
+
+    root.add_dependency_edge(link_run_spec, deptype='link')
+    root.add_dependency_edge(link_run_spec, deptype='run')
+    root.add_dependency_edge(build_spec, deptype='build')
+
+    # Check dependencies from the perspective of root
+    assert len(root.dependencies()) == 2
+    assert all(x.name == 'c' for x in root.dependencies())
+
+    assert '@2.0' in root.dependencies(name='c', deptype='build')[0]
+    assert '@1.0' in root.dependencies(name='c', deptype=('link', 'run'))[0]
+
+    # Check parent from the perspective of the dependencies
+    assert len(build_spec.dependents()) == 1
+    assert len(link_run_spec.dependents()) == 1
+    assert build_spec.dependents() == link_run_spec.dependents()
+    assert build_spec != link_run_spec
+
+
+def test_synthetic_construction_bootstrapping(mock_packages, config):
+    # Construct the following spec:
+    #
+    #  b@2.0
+    #    | build
+    #  b@1.0
+    #
+    root = Spec('b@2.0').concretized()
+    bootstrap = Spec('b@1.0').concretized()
+
+    root.add_dependency_edge(bootstrap, deptype='build')
+
+    assert len(root.dependencies()) == 1
+    assert root.dependencies()[0].name == 'b'
+    assert root.name == 'b'

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -415,6 +415,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         # default: 'gmp', => ('gmp', 'gmp', True, True)
         # any other combination needs a full tuple
         # if not (useinc || uselib): usedir - i.e (False, False)
+        direct_dependencies = [x.name for x in spec.dependencies()]
         for library in (
                 ('cuda', 'cuda', False, False),
                 ('hip', 'hip', True, False),
@@ -465,7 +466,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 useinc = True
                 uselib = True
 
-            library_requested = spacklibname.split(':')[0] in spec.dependencies_dict()
+            library_requested = spacklibname.split(':')[0] in direct_dependencies
             options.append(
                 '--with-{library}={value}'.format(
                     library=petsclibname,


### PR DESCRIPTION
fixes #11983 
closes #16447

same as #21683 which I cannot reopen after a force push for some reason

This PR changes the internal representation of `Spec` to allow for multiple dependencies or dependents stemming from the same package. This change permits to represent cases which are frequent in cross compiled environments or to bootstrap compilers.

Modifications:
- [x] Substitute `DependencyMap` with `_EdgeMap`. The main differences are that the latter does not support direct item assignment and can be modified only through its API. It also provides a `select_by` method to query items.
- [x] Reworked a few public APIs of `Spec` to get list of dependencies or related edges.
- [x] Added unit tests to prevent regression on #11983 and prove the synthetic construction of specs with multiple deps from the same package. 

Since #22845 went in first, this PR reuses that format and thus it should not change hashes. What happens is that in the list of dependencies we may have the same package being present multiple times with different associated specs.
