### PR TITLE
py-torchgeo: specify libtiff variants

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -57,6 +57,7 @@ class PyTorchgeo(PythonPackage):
     with when('+datasets'):
         depends_on('py-h5py', type='run')
         depends_on('py-laspy@2:', when='@0.2:', type='run')
+        depends_on('libtiff+jpeg+zlib')
         depends_on('open3d@0.11.2:+python', when='@0.2:', type='run')
         depends_on('opencv+python3+imgcodecs+tiff+jpeg+png', type='run')
         depends_on('py-pandas@0.19.1:', when='@0.2:', type='run')


### PR DESCRIPTION
The LandCover.ai dataset requires libtiff to be built with jpeg/zlib compression support. I'm sure other datasets require other variants (libdeflate? zstd?) but we can add those when we encounter them.