### PR TITLE
julia: add llvm targets constraint

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -48,7 +48,7 @@ class Julia(MakefilePackage):
     # Note, we just use link_llvm_dylib so that we not only get a libLLVM,
     # but also so that llvm-config --libfiles gives only the dylib. Without
     # it it also gives static libraries, and breaks Julia's build.
-    depends_on('llvm version_suffix=jl +link_llvm_dylib ~internal_unwind')
+    depends_on('llvm targets=amdgpu,bpf,nvptx,webassembly version_suffix=jl +link_llvm_dylib ~internal_unwind')
     depends_on('libuv')
 
     with when('@1.7.0:1.7'):


### PR DESCRIPTION
Require AMDGPU & NVPTX as well as BPF and WebAssembly targets in LLVM when building julia
