### PR TITLE
python: add distutils variant to work around incomplete system installs

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -211,6 +211,9 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("libedit", when="+lldb")
     depends_on("py-six", when="@5.0.0: +lldb +python")
 
+    # libcxx dependencies (merge_archives.py)
+    depends_on("python +distutils", when="+libcxx", type='build')
+
     # gold support, required for some features
     depends_on("binutils+gold+ld+plugins", when="+gold")
 

--- a/var/spack/repos/builtin/packages/py-pip/package.py
+++ b/var/spack/repos/builtin/packages/py-pip/package.py
@@ -26,6 +26,7 @@ class PyPip(Package):
     version('9.0.1',  sha256='690b762c0a8460c303c089d5d0be034fb15a5ea2b75bdf565f40421f542fefb0', expand=False)
 
     extends('python')
+    depends_on('python +distutils', type=('build', 'run'))
     depends_on('python@3.6:', when='@21:', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.5:', when='@19.2:', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.4:', when='@18:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -167,6 +167,12 @@ class Python(AutotoolsPackage):
     variant('tix',      default=False, description='Build Tix module')
     variant('ensurepip', default=True, description='Build ensurepip module', when='@2.7.9:2,3.4:')
 
+    # We always build with distutils; this variant only exists to make life easier when
+    # using an external Python on e.g. Ubuntu which does not have python3-distutils
+    # installed.
+    variant('distutils', default=True, description='Build distutils module')
+    conflicts('~distutils')
+
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('gettext +libxml2', when='+libxml2')
     depends_on('gettext ~libxml2', when='~libxml2')
@@ -306,6 +312,13 @@ class Python(AutotoolsPackage):
             variants += '+pyexpat'
         except ProcessError:
             variants += '~pyexpat'
+
+        # On some systems distutils provides nothing but a version, so be more precise.
+        try:
+            python('-c', 'import distutils.spawn', error=os.devnull)
+            variants += '+distutils'
+        except ProcessError:
+            variants += '~distutils'
 
         # Some modules are version-dependent
         if Version(version_str) >= Version('3.3'):


### PR DESCRIPTION
This adds a variant `python +distutils` which can't be turned off
through concretization, meaning that all spack installs of python
have distutils by default.

On some Debian systems however, distutils is some sort of shim
package, and has to be installed separately.

So, on those systems we can detect `python ~distutils` through
`spack external find python`, which makes Spack build Python
properly in some cases (e.g. pip, llvm), instead of throwing
cryptic error messages.