### PR TITLE
py-jupytext: add version 0.13.6

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupytext/package.py
+++ b/var/spack/repos/builtin/packages/py-jupytext/package.py
@@ -19,9 +19,15 @@ class PyJupytext(PythonPackage):
     version('1.13.6', sha256='c6c25918ddb6403d0d8504e08d35f6efc447baf0dbeb6a28b73adf39e866a0c4')
     version('1.13.0', sha256='fb220af65d2bd32d01c779b0e935c4c2b71e3f5f2f01bf1bab10d5f23fe121d4')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools@40.8.0:', type='build')
+    depends_on('py-wheel', type='build')
     depends_on('py-nbformat', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-toml', type=('build', 'run'))
     depends_on('py-mdit-py-plugins', type=('build', 'run'))
     depends_on('py-markdown-it-py@1.0:1', type=('build', 'run'))
+    # todo: in order to use jupytext as a jupyterlab extension,
+    # some additional dependencies need to be added (and checked):
+    # depends_on('py-jupyterlab@3.0.0:3', type=('build', 'run'))
+    # depends_on('py-jupyter-packaging')

--- a/var/spack/repos/builtin/packages/py-jupytext/package.py
+++ b/var/spack/repos/builtin/packages/py-jupytext/package.py
@@ -19,9 +19,8 @@ class PyJupytext(PythonPackage):
     version('1.13.6', sha256='c6c25918ddb6403d0d8504e08d35f6efc447baf0dbeb6a28b73adf39e866a0c4')
     version('1.13.0', sha256='fb220af65d2bd32d01c779b0e935c4c2b71e3f5f2f01bf1bab10d5f23fe121d4')
 
-    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('python@3.6:3', type=('build', 'run'))
     depends_on('py-setuptools@40.8.0:', type='build')
-    depends_on('py-wheel', type='build')
     depends_on('py-nbformat', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-toml', type=('build', 'run'))
@@ -29,5 +28,7 @@ class PyJupytext(PythonPackage):
     depends_on('py-markdown-it-py@1.0:1', type=('build', 'run'))
     # todo: in order to use jupytext as a jupyterlab extension,
     # some additional dependencies need to be added (and checked):
-    # depends_on('py-jupyterlab@3.0.0:3', type=('build', 'run'))
-    # depends_on('py-jupyter-packaging')
+    depends_on('py-jupyterlab@3', type=('build', 'run'))
+    # TODO: replace this after concretizer learns how to concretize separate build deps  
+    depends_on('py-jupyter-packaging7', type='build')                                    
+    # depends_on('py-jupyter-packaging@0.7.9:0.7', type='build')```

--- a/var/spack/repos/builtin/packages/py-jupytext/package.py
+++ b/var/spack/repos/builtin/packages/py-jupytext/package.py
@@ -29,6 +29,6 @@ class PyJupytext(PythonPackage):
     # todo: in order to use jupytext as a jupyterlab extension,
     # some additional dependencies need to be added (and checked):
     depends_on('py-jupyterlab@3', type=('build', 'run'))
-    # TODO: replace this after concretizer learns how to concretize separate build deps  
-    depends_on('py-jupyter-packaging7', type='build')                                    
+    # TODO: replace this after concretizer learns how to concretize separate build deps
+    depends_on('py-jupyter-packaging7', type='build')
     # depends_on('py-jupyter-packaging@0.7.9:0.7', type='build')```

--- a/var/spack/repos/builtin/packages/py-jupytext/package.py
+++ b/var/spack/repos/builtin/packages/py-jupytext/package.py
@@ -24,4 +24,4 @@ class PyJupytext(PythonPackage):
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-toml', type=('build', 'run'))
     depends_on('py-mdit-py-plugins', type=('build', 'run'))
-    depends_on('py-markdown-it-py@1.0:2', type=('build', 'run'))
+    depends_on('py-markdown-it-py@1.0:1', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-jupytext/package.py
+++ b/var/spack/repos/builtin/packages/py-jupytext/package.py
@@ -16,6 +16,7 @@ class PyJupytext(PythonPackage):
 
     maintainers = ['vvolkl']
 
+    version('1.13.6', sha256='c6c25918ddb6403d0d8504e08d35f6efc447baf0dbeb6a28b73adf39e866a0c4')
     version('1.13.0', sha256='fb220af65d2bd32d01c779b0e935c4c2b71e3f5f2f01bf1bab10d5f23fe121d4')
 
     depends_on('py-setuptools', type='build')
@@ -23,4 +24,4 @@ class PyJupytext(PythonPackage):
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-toml', type=('build', 'run'))
     depends_on('py-mdit-py-plugins', type=('build', 'run'))
-    depends_on('py-markdown-it-py@1.0:1', type=('build', 'run'))
+    depends_on('py-markdown-it-py@1.0:2', type=('build', 'run'))


### PR DESCRIPTION
From https://github.com/mwouts/jupytext/commit/da3fcc305db8369335b6fb4bc2fb2b5ed5f5feb2:

markdown-it-py v2.0 implements some internal changes, but won't affect jupytext