### PR TITLE
ParaView/VTK: Update hdf5 constraints

### DIFF
--- a/var/spack/repos/builtin/packages/paraview/package.py
+++ b/var/spack/repos/builtin/packages/paraview/package.py
@@ -147,6 +147,7 @@ class Paraview(CMakePackage, CudaPackage):
     # depends_on('hdf5~mpi', when='~mpi')
     depends_on('hdf5+hl+mpi', when='+hdf5+mpi')
     depends_on('hdf5+hl~mpi', when='+hdf5~mpi')
+    depends_on('hdf5@1.10:', when='+hdf5 @5.10:')
     depends_on('adios2+mpi', when='+adios2+mpi')
     depends_on('adios2~mpi', when='+adios2~mpi')
     depends_on('jpeg')

--- a/var/spack/repos/builtin/packages/vtk/package.py
+++ b/var/spack/repos/builtin/packages/vtk/package.py
@@ -110,6 +110,7 @@ class Vtk(CMakePackage):
     depends_on('glew')
     # set hl variant explicitly, similar to issue #7145
     depends_on('hdf5+hl')
+    depends_on('hdf5@1.10:', when='@9.1:')
     depends_on('jpeg')
     depends_on('jsoncpp')
     depends_on('libxml2')


### PR DESCRIPTION
hdf5@1.10: is required my newer version of vtkHDFReader

@chuckatkins 