### PR TITLE
expat: Add latest release 2.4.4 with security fixes

### DIFF
--- a/var/spack/repos/builtin/packages/expat/package.py
+++ b/var/spack/repos/builtin/packages/expat/package.py
@@ -14,8 +14,9 @@ class Expat(AutotoolsPackage):
     homepage = "https://libexpat.github.io/"
     url      = "https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.bz2"
 
-    version('2.4.3', sha256='6f262e216a494fbf42d8c22bc841b3e117c21f2467a19dc4c27c991b5622f986')
-    # deprecate all releases before 2.4.3 because of security issues
+    version('2.4.4', sha256='14c58c2a0b5b8b31836514dfab41bd191836db7aa7b84ae5c47bc0327a20d64a')
+    # deprecate all releases before 2.4.4 because of security issues
+    version('2.4.3', sha256='6f262e216a494fbf42d8c22bc841b3e117c21f2467a19dc4c27c991b5622f986', deprecated=True)
     version('2.4.1', sha256='2f9b6a580b94577b150a7d5617ad4643a4301a6616ff459307df3e225bcfbf40', deprecated=True)
     version('2.4.0', sha256='8c59142ef88913bc0a8b6e4c58970c034210ca552e6271f52f6cd6cce3708424', deprecated=True)
     version('2.3.0', sha256='f122a20eada303f904d5e0513326c5b821248f2d4d2afbf5c6f1339e511c0586', deprecated=True)


### PR DESCRIPTION
Hi!

[libexpat 2.4.4](https://github.com/libexpat/libexpat/releases/tag/R_2_4_4) with **security fixes** has been released, the upstream [change log](https://github.com/libexpat/libexpat/blob/R_2_4_4/expat/Changes) has more details.

Thanks for updating! :pray: 

Best, Sebastian