### PR TITLE
Ecp sdk update package contraints

### DIFF
--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -95,7 +95,7 @@ class Adios2(CMakePackage):
     depends_on('libzmq', when='+dataman')
     depends_on('dataspaces@1.8.0:', when='+dataspaces')
 
-    depends_on('hdf5', when='+hdf5')
+    depends_on('hdf5~mpi', when='+hdf5~mpi')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
 
     depends_on('c-blosc', when='@2.4: +blosc')

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -77,7 +77,7 @@ class Conduit(CMakePackage):
     # set to false for systems that implicitly link mpi
     variant('blt_find_mpi', default=True, description='Use BLT CMake Find MPI logic')
     variant("hdf5", default=True, description="Build Conduit HDF5 support")
-    variant("hdf5_compat", default=True,
+    variant("hdf5_compat", default=True, when='+hdf5',
             description="Build Conduit with HDF5 1.8.x (compatibility mode)")
     variant("silo", default=False, description="Build Conduit Silo support")
     variant("adios", default=False, description="Build Conduit ADIOS support")

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -30,7 +30,6 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
     variant('veloc', default=False, description="Enable VeloC")
 
     # Vis
-    variant('sensei', default=False, description="Enable Sensei")
     variant('ascent', default=False, description="Enable Ascent")
     variant('paraview', default=False, description="Enable ParaView")
     variant('sz', default=False, description="Enable SZ")
@@ -41,6 +40,8 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
     variant('cinema', default=False, description="Enable Cinema")
 
     # Outstanding build issues
+    variant('sensei', default=False, description="Enable Sensei")
+    conflicts('+sensei')
     variant('visit', default=False, description="Enable VisIt")
     conflicts('+visit')
 
@@ -100,7 +101,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
                        when='+faodel',
                        propagate=['hdf5'])
 
-    dav_sdk_depends_on('hdf5 +shared+mpi+fortran', when='+hdf5')
+    dav_sdk_depends_on('hdf5@1.12: +shared+mpi+fortran', when='+hdf5')
 
     dav_sdk_depends_on('parallel-netcdf+shared+fortran', when='+pnetcdf')
 
@@ -114,8 +115,11 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
     dav_sdk_depends_on('sensei@develop +vtkio +python ~miniapps', when='+sensei',
                        propagate=dict(propagate_to_sensei))
 
+    # Need to explicitly turn off conduit hdf5_compat in order to build
+    # hdf5@1.12 which is required for SDK
     dav_sdk_depends_on('ascent+shared+mpi+fortran+openmp+python+vtkh+dray',
                        when='+ascent')
+    dav_sdk_depends_on('ascent ^conduit ~hdf5_compat', when='+acsent +hdf5')
 
     depends_on('py-cinemasci', when='+cinema')
 

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -50,6 +50,16 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
         # Do the basic depends_on
         depends_on(spec, when=when)
 
+        # Strip spec string to just the base spec name
+        # ie. A +c ~b -> A
+        spec = Spec(spec).name
+
+        if '+' in when and len(when.split()) == 1:
+            when_not = when.replace('+', '~')
+            # If the package is in the spec tree then it must
+            # be enabled in the SDK.
+            conflicts(when_not, '^' + spec)
+
         # Skip if there is nothing to propagate
         if not propagate:
             return
@@ -57,10 +67,6 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
         # Map the propagated variants to the dependency variant
         if not type(propagate) is dict:
             propagate = dict([(v, v) for v in propagate])
-
-        # Strip spec string to just the base spec name
-        # ie. A +c ~b -> A
-        spec = Spec(spec).name
 
         # Determine the base variant
         base_variant = ''
@@ -119,7 +125,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
     # hdf5@1.12 which is required for SDK
     dav_sdk_depends_on('ascent+shared+mpi+fortran+openmp+python+vtkh+dray',
                        when='+ascent')
-    dav_sdk_depends_on('ascent ^conduit ~hdf5_compat', when='+acsent +hdf5')
+    depends_on('ascent ^conduit ~hdf5_compat', when='+ascent +hdf5')
 
     depends_on('py-cinemasci', when='+cinema')
 
@@ -127,8 +133,8 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
                        when='+paraview',
                        propagate=['hdf5', 'adios2'] + cuda_arch_variants)
     # Want +shared when not using cuda
-    dav_sdk_depends_on('paraview ~shared +cuda', when='+paraview +cuda')
-    dav_sdk_depends_on('paraview +shared ~cuda', when='+paraview ~cuda')
+    depends_on('paraview ~shared +cuda', when='+paraview +cuda')
+    depends_on('paraview +shared ~cuda', when='+paraview ~cuda')
 
     dav_sdk_depends_on('visit', when='+visit')
 


### PR DESCRIPTION
@chuckatkins 

Updates to ECP packages contraints.

* SDK requires HDF5@1.12:. Updated specs for ascent/conduit to not use `hdf5_compt`.
* SDK requires all packages under the SDK be built using the SDK spec. Add conflicts to ensure if an SDK package is in the spec tree it requires that SDK has it enabled.