### PR TITLE
cinemaci/h5py: Extend python needed

### DIFF
--- a/var/spack/repos/builtin/packages/py-cinemasci/package.py
+++ b/var/spack/repos/builtin/packages/py-cinemasci/package.py
@@ -19,10 +19,10 @@ class PyCinemasci(PythonPackage):
 
     version('1.3', sha256='c024ca9791de9d78e5dad3fd11e8f87d8bc1afa5830f2697d7ec4116a5d23c20')
 
+    extends('python')
+
     variant('mpi', default=False, description='Enable MPI')
 
-    depends_on('hdf5 ~mpi', when='~mpi')
-    depends_on('hdf5 +mpi', when='+mpi')
     depends_on('pil', type=('build', 'run'))
     depends_on('python@3:', type=('build', 'run'))
     depends_on('py-h5py~mpi', when='~mpi', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-h5py/package.py
+++ b/var/spack/repos/builtin/packages/py-h5py/package.py
@@ -33,6 +33,8 @@ class PyH5py(PythonPackage):
     version('2.5.0', sha256='9833df8a679e108b561670b245bcf9f3a827b10ccb3a5fa1341523852cfac2f6')
     version('2.4.0', sha256='faaeadf4b8ca14c054b7568842e0d12690de7d5d68af4ecce5d7b8fc104d8e60')
 
+    extends('python')
+
     variant('mpi', default=True, description='Build with MPI support')
 
     # Python versions


### PR DESCRIPTION
Add `exends('python')` to `py-cinemasci` and `py-h5py`. Without this running cinemasci fails to import h5py and so on.

@chuckatkins 