### PR TITLE
Update samrai package.py to add "--enable-shared" option as "+shared"

### DIFF
--- a/var/spack/repos/builtin/packages/samrai/package.py
+++ b/var/spack/repos/builtin/packages/samrai/package.py
@@ -92,7 +92,7 @@ class Samrai(AutotoolsPackage):
 
         if '+silo' in self.spec:
             options.append('--with-silo=%s' % self.spec['silo'].prefix)
-            
+
         if '+shared' in self.spec:
             options.append('--enable-shared')
 

--- a/var/spack/repos/builtin/packages/samrai/package.py
+++ b/var/spack/repos/builtin/packages/samrai/package.py
@@ -44,6 +44,8 @@ class Samrai(AutotoolsPackage):
             description='Compile with reduced optimization and debugging on')
     variant('silo', default=False,
             description='Compile with support for silo')
+    variant('shared', default=False,
+            description='Build shared libraries')
 
     depends_on('mpi')
     depends_on('zlib')
@@ -90,6 +92,9 @@ class Samrai(AutotoolsPackage):
 
         if '+silo' in self.spec:
             options.append('--with-silo=%s' % self.spec['silo'].prefix)
+            
+        if '+shared' in self.spec:
+            options.append('--enable-shared')
 
         if self.spec.satisfies('@3.0:3.11'):
             options.append('--with-boost=%s' % self.spec['boost'].prefix)


### PR DESCRIPTION
I need samrai compiled as a shared library.