### PR TITLE
Testing: Summarize test results and add verbose output

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -337,7 +337,7 @@ def _report_suite_results(test_suite, args, constraints):
                 pkg_id, status = line.split()
                 results[pkg_id] = status
 
-        failed, untested = 0, 0
+        failed, skipped, untested = 0, 0, 0
         for pkg_id in test_specs:
             if pkg_id in results:
                 status = results[pkg_id]
@@ -345,6 +345,8 @@ def _report_suite_results(test_suite, args, constraints):
                     failed += 1
                 elif status == 'NO-TESTS':
                     untested += 1
+                elif status == 'SKIPPED':
+                    skipped += 1
 
                 if args.failed and status != 'FAILED':
                     continue
@@ -358,7 +360,8 @@ def _report_suite_results(test_suite, args, constraints):
                             msg += '\n{0}'.format(''.join(f.readlines()))
                 tty.msg(msg)
 
-        spack.install_test.write_test_summary(failed, untested, len(test_specs))
+        spack.install_test.write_test_summary(
+            failed, skipped, untested, len(test_specs))
     else:
         msg = "Test %s has no results.\n" % test_suite.name
         msg += "        Check if it is running with "

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -337,9 +337,15 @@ def _report_suite_results(test_suite, args, constraints):
                 pkg_id, status = line.split()
                 results[pkg_id] = status
 
+        failed, untested = 0, 0
         for pkg_id in test_specs:
             if pkg_id in results:
                 status = results[pkg_id]
+                if status == 'FAILED':
+                    failed += 1
+                elif status == 'NO-TESTS':
+                    untested += 1
+
                 if args.failed and status != 'FAILED':
                     continue
 
@@ -351,6 +357,8 @@ def _report_suite_results(test_suite, args, constraints):
                         with open(log_file, 'r') as f:
                             msg += '\n{0}'.format(''.join(f.readlines()))
                 tty.msg(msg)
+
+        spack.install_test.write_test_summary(failed, untested, len(test_specs))
     else:
         msg = "Test %s has no results.\n" % test_suite.name
         msg += "        Check if it is running with "

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -94,6 +94,16 @@ def write_test_suite_file(suite):
         sjson.dump(suite.to_dict(), stream=f)
 
 
+def write_test_summary(num_failed, num_skipped, num_untested, num_specs):
+    failed = "{0} failed, ".format(num_failed) if num_failed else ''
+    skipped = "{0} skipped, ".format(num_skipped) if num_skipped else ''
+    no_tests = "{0} no-tests, ".format(num_untested) if num_untested else ''
+    num_passed = num_specs - num_failed - num_untested - num_skipped
+
+    print("{:=^80}".format(" {0}{1}{2}{3} passed of {4} specs "
+          .format(failed, no_tests, skipped, num_passed, num_specs)))
+
+
 class TestSuite(object):
     def __init__(self, specs, alias=None):
         # copy so that different test suites have different package objects
@@ -192,7 +202,7 @@ class TestSuite(object):
                 self.current_test_spec = None
                 self.current_base_spec = None
 
-        self.write_test_summary(skipped, untested)
+        write_test_summary(self.fails, skipped, untested, len(self.specs))
 
         if self.fails:
             raise TestSuiteFailure(self.fails)
@@ -270,16 +280,6 @@ class TestSuite(object):
     def write_test_result(self, spec, result):
         msg = "{0} {1}".format(self.test_pkg_id(spec), result)
         _add_msg_to_file(self.results_file, msg)
-
-    def write_test_summary(self, skipped, untested):
-        num_specs = len(self.specs)
-        failed = "{0} failed, ".format(self.fails) if self.fails else ''
-        no_tests = "{0} no-tests, ".format(untested) if untested else ''
-        skipped = "{0} skipped, ".format(skipped) if skipped else ''
-        passed = num_specs - self.fails - untested - skipped
-
-        print("{:=^80}".format("{0}{1}{2}{3} passed of {4} specs"
-              .format(failed, no_tests, skipped, passed, num_specs)))
 
     def write_reproducibility_data(self):
         for spec in self.specs:

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -177,12 +177,9 @@ class TestSuite(object):
                     if spec.external and not externals:
                         status = 'SKIPPED'
                         skipped += 1
-                        msg = 'Skipped external package'
                     else:
                         status = 'NO-TESTS'
                         untested += 1
-                        msg = 'No tests to run'
-                    _add_msg_to_file(self.log_file_for_spec(spec), msg)
 
                 self.write_test_result(spec, status)
             except BaseException as exc:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1820,6 +1820,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
             return
 
         kwargs = {'dirty': dirty, 'fake': False, 'context': 'test'}
+        if tty.is_verbose():
+            kwargs['verbose'] = True
         spack.build_environment.start_build_process(self, test_process, kwargs)
 
     def test(self):
@@ -2641,7 +2643,8 @@ def has_test_method(pkg):
 
 
 def test_process(pkg, kwargs):
-    with tty.log.log_output(pkg.test_log_file) as logger:
+    verbose = kwargs.get('verbose', False)
+    with tty.log.log_output(pkg.test_log_file, verbose) as logger:
         with logger.force_echo():
             tty.msg('Testing package {0}'
                     .format(pkg.test_suite.test_pkg_id(pkg.spec)))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1813,13 +1813,10 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         self.tested_file = self.test_suite.tested_file_for_spec(self.spec)
         fsys.touch(self.test_log_file)  # Otherwise log_parse complains
 
-        if self.spec.external and not externals:
-            with open(self.test_log_file, 'w') as ofd:
-                ofd.write('Testing package {0}\n'
-                          .format(self.test_suite.test_pkg_id(self.spec)))
-            return
-
-        kwargs = {'dirty': dirty, 'fake': False, 'context': 'test'}
+        kwargs = {
+            'dirty': dirty, 'fake': False, 'context': 'test',
+            'externals': externals
+        }
         if tty.is_verbose():
             kwargs['verbose'] = True
         spack.build_environment.start_build_process(self, test_process, kwargs)
@@ -2642,12 +2639,25 @@ def has_test_method(pkg):
     )
 
 
+def print_test_message(logger, msg, verbose):
+    if verbose:
+        with logger.force_echo():
+            print(msg)
+    else:
+        print(msg)
+
+
 def test_process(pkg, kwargs):
     verbose = kwargs.get('verbose', False)
+    externals = kwargs.get('externals', False)
     with tty.log.log_output(pkg.test_log_file, verbose) as logger:
         with logger.force_echo():
             tty.msg('Testing package {0}'
                     .format(pkg.test_suite.test_pkg_id(pkg.spec)))
+
+        if pkg.spec.external and not externals:
+            print_test_message(logger, 'Skipped external package', verbose)
+            return
 
         # use debug print levels for log file to record commands
         old_debug = tty.is_debug()
@@ -2729,6 +2739,8 @@ def test_process(pkg, kwargs):
             # non-pass-only methods
             if ran_actual_test_function:
                 fsys.touch(pkg.tested_file)
+            else:
+                print_test_message(logger, 'No tests to run',  verbose)
 
 
 inject_flags = PackageBase.inject_flags

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -176,10 +176,9 @@ class InfoCollector(object):
                     skip_externals = pkg.spec.external and not externals
                     if do_fn.__name__ == 'do_test' and skip_externals:
                         package['result'] = 'skipped'
-                        package['stdout'] = 'Skipped external package'
                     else:
                         package['result'] = 'success'
-                        package['stdout'] = fetch_log(pkg, do_fn, self.dir)
+                    package['stdout'] = fetch_log(pkg, do_fn, self.dir)
                     package['installed_from_binary_cache'] = \
                         pkg.installed_from_binary_cache
                     if do_fn.__name__ == '_install_task' and installed_already:

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -268,6 +268,7 @@ def test_test_results_none(mock_packages, mock_test_stage):
 @pytest.mark.parametrize('status,expected', [
     ('FAILED', '1 failed'),
     ('NO-TESTS', '1 no-tests'),
+    ('SKIPPED', '1 skipped'),
     ('PASSED', '1 passed'),
 ])
 def test_test_results_status(mock_packages, mock_test_stage, status, expected):

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -211,6 +211,7 @@ def test_test_list_all(mock_packages):
         "printing-package",
         "py-extension1",
         "py-extension2",
+        "simple-standalone-test",
         "test-error",
         "test-fail",
     ])
@@ -251,3 +252,40 @@ def test_hash_change(mock_test_stage, mock_packages, mock_archive, mock_fetch,
     # The results should be obtainable
     results_output = spack_test('results')
     assert 'PASSED' in results_output
+
+
+def test_test_results_none(mock_packages, mock_test_stage):
+    name = 'trivial'
+    spec = spack.spec.Spec('trivial-smoke-test').concretized()
+    suite = spack.install_test.TestSuite([spec], name)
+    suite.ensure_stage()
+    spack.install_test.write_test_suite_file(suite)
+    results = spack_test('results', name)
+    assert 'has no results' in results
+    assert 'if it is running' in results
+
+
+@pytest.mark.parametrize('status,expected', [
+    ('FAILED', '1 failed'),
+    ('NO-TESTS', '1 no-tests'),
+    ('PASSED', '1 passed'),
+])
+def test_test_results_status(mock_packages, mock_test_stage, status, expected):
+    name = 'trivial'
+    spec = spack.spec.Spec('trivial-smoke-test').concretized()
+    suite = spack.install_test.TestSuite([spec], name)
+    suite.ensure_stage()
+    spack.install_test.write_test_suite_file(suite)
+    suite.write_test_result(spec, status)
+
+    for opt in ['', '--failed', '--log']:
+        args = ['results', name]
+        if opt:
+            args.insert(1, opt)
+
+        results = spack_test(*args)
+        if opt == '--failed' and status != 'FAILED':
+            assert status not in results
+        else:
+            assert status in results
+        assert expected in results

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -149,6 +149,23 @@ def test_test_spec_run_once(mock_packages, install_mockery, mock_test_stage):
         test_suite()
 
 
+def test_test_spec_verbose(mock_packages, install_mockery, mock_test_stage):
+    spec = spack.spec.Spec('simple-standalone-test').concretized()
+    test_suite = spack.install_test.TestSuite([spec])
+
+    test_suite(verbose=True)
+    passed, msg = False, False
+    with open(test_suite.log_file_for_spec(spec), 'r') as fd:
+        for line in fd:
+            if 'simple stand-alone test' in line:
+                msg = True
+            elif 'PASSED' in line:
+                passed = True
+
+    assert msg
+    assert passed
+
+
 def test_get_test_suite():
     assert not spack.install_test.get_test_suite('nothing')
 

--- a/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class SimpleStandaloneTest(Package):
+    """This package has a simple stand-alone test features."""
+    homepage = "http://www.example.com/simple_test"
+    url      = "http://www.unit-test-should-replace-this-url/simple_test-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    def test(self):
+        msg = 'simple stand-alone test'
+        self.run_test('python',
+                      ['-c', 'print("{0}")'.format(msg)],
+                      expected=[msg],
+                      purpose='test: running {0}'.format(msg))

--- a/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/simple-standalone-test/package.py
@@ -15,7 +15,6 @@ class SimpleStandaloneTest(Package):
 
     def test(self):
         msg = 'simple stand-alone test'
-        self.run_test('python',
-                      ['-c', 'print("{0}")'.format(msg)],
+        self.run_test('echo', [msg],
                       expected=[msg],
                       purpose='test: running {0}'.format(msg))


### PR DESCRIPTION
Fixes #20375 

This PR adds a quick summary of test results -- from `spack test run` *and* `spack test results` -- in the form `[<#> failed, ][<#> no-tests,  ][, <#> skipped>,] <#> passed of <#> specs`.

Details from running the tests can be output using Spack's `--verbose` option.  (They have always been available in `spack test results -l` for packages with tests to run as well.)

Before this PR:

```
$ spack test run caliper papi tar target=cascadelake
==> Spack test cpqwyjikavj6bmlvf4v4oayaekhel2ju
==> Testing package caliper-2.7.0-spjcnyp
==> Testing package papi-6.0.0.1-xvpwwn3
```

With this PR and no verbose option:

```
$ spack test run caliper papi tar target=cascadelake
==> Spack test cpqwyjikavj6bmlvf4v4oayaekhel2ju
==> Testing package caliper-2.7.0-spjcnyp
==> Testing package papi-6.0.0.1-xvpwwn3
==> Testing package tar-1.26-5tpf6bf
================== 1 no-tests, 1 skipped, 1 passed of 3 specs ==================
```

When using the abbreviated `verbose` option:

```
$ spack -v test run caliper papi tar target=cascadelake
==> Spack test cpqwyjikavj6bmlvf4v4oayaekhel2ju
==> Testing package caliper-2.7.0-spjcnyp
==> [2022-02-22-17:07:41.388715] Installing /usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-cascadelake/intel-19.0.4.227/caliper-2.7.0-spjcnypkqsvlxf5ueopvbecs4pm6qtff/.spack/test to /g/g21/dahlgren/.spack/test/cpqwyjikavj6bmlvf4v4oayaekhel2ju/caliper-2.7.0-spjcnyp/cache/caliper
==> [2022-02-22-17:07:41.451475] test: compile cxx-example example
==> [2022-02-22-17:07:41.451764] '/usr/WS1/dahlgren/spack/lib/spack/env/intel/icpc' '-L/usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-cascadelake/intel-19.0.4.227/caliper-2.7.0-spjcnypkqsvlxf5ueopvbecs4pm6qtff/lib64' '-I/usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-cascadelake/intel-19.0.4.227/caliper-2.7.0-spjcnypkqsvlxf5ueopvbecs4pm6qtff/include' '/g/g21/dahlgren/.spack/test/cpqwyjikavj6bmlvf4v4oayaekhel2ju/caliper-2.7.0-spjcnyp/cache/caliper/examples/apps/cxx-example.cpp' '-o' 'cxx-example' '-std=c++11' '-lcaliper' '-lstdc++'
PASSED
==> [2022-02-22-17:07:41.998398] test: run cxx-example example
==> [2022-02-22-17:07:41.998802] './cxx-example'
PASSED
==> Testing package papi-6.0.0.1-xvpwwn3
No tests to run
==> Testing package tar-1.26-5tpf6bf
Skipped external package
================== 1 no-tests, 1 skipped, 1 passed of 3 specs ==================
```

The results command outputs are:

```
$ spack test results
==> Results for test suite 'cpqwyjikavj6bmlvf4v4oayaekhel2ju':
==>   caliper-2.7.0-spjcnyp PASSED
==>   papi-6.0.0.1-xvpwwn3 NO-TESTS
==>   tar-1.26-5tpf6bf SKIPPED
================== 1 no-tests, 1 skipped, 1 passed of 3 specs ==================

$ spack test results -l
==> Results for test suite 'cpqwyjikavj6bmlvf4v4oayaekhel2ju':
==>   caliper-2.7.0-spjcnyp PASSED
==> Testing package caliper-2.7.0-spjcnyp
==> [2022-02-22-17:07:41.388715] Installing /usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-cascadelake/intel-19.0.4.227/caliper-2.7.0-spjcnypkqsvlxf5ueopvbecs4pm6qtff/.spack/test to /g/g21/dahlgren/.spack/test/cpqwyjikavj6bmlvf4v4oayaekhel2ju/caliper-2.7.0-spjcnyp/cache/caliper
==> [2022-02-22-17:07:41.451475] test: compile cxx-example example
==> [2022-02-22-17:07:41.451764] '/usr/WS1/dahlgren/spack/lib/spack/env/intel/icpc' '-L/usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-cascadelake/intel-19.0.4.227/caliper-2.7.0-spjcnypkqsvlxf5ueopvbecs4pm6qtff/lib64' '-I/usr/WS1/dahlgren/spack/opt/spack/linux-rhel7-cascadelake/intel-19.0.4.227/caliper-2.7.0-spjcnypkqsvlxf5ueopvbecs4pm6qtff/include' '/g/g21/dahlgren/.spack/test/cpqwyjikavj6bmlvf4v4oayaekhel2ju/caliper-2.7.0-spjcnyp/cache/caliper/examples/apps/cxx-example.cpp' '-o' 'cxx-example' '-std=c++11' '-lcaliper' '-lstdc++'
PASSED
==> [2022-02-22-17:07:41.998398] test: run cxx-example example
==> [2022-02-22-17:07:41.998802] './cxx-example'
PASSED

==>   papi-6.0.0.1-xvpwwn3 NO-TESTS
==> Testing package papi-6.0.0.1-xvpwwn3
No tests to run

==>   tar-1.26-5tpf6bf SKIPPED
==> Testing package tar-1.26-5tpf6bf
Skipped external package

================== 1 no-tests, 1 skipped, 1 passed of 3 specs ==================
```