### PR TITLE
Testing: Optionally run tests on externally installed packages

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -55,6 +55,10 @@ def setup_parser(subparser):
         help="Stop after the first failed package."
     )
     run_parser.add_argument(
+        '--test-externals', action='store_true',
+        help="Test packages that are externally installed."
+    )
+    run_parser.add_argument(
         '--keep-stage',
         action='store_true',
         help='Keep testing directory for debugging'
@@ -204,7 +208,8 @@ environment variables:
     with reporter('test', test_suite.stage):
         test_suite(remove_directory=not args.keep_stage,
                    dirty=args.dirty,
-                   fail_first=args.fail_first)
+                   fail_first=args.fail_first,
+                   test_externals=args.test_externals)
 
 
 def has_test_method(pkg):

--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -55,7 +55,7 @@ def setup_parser(subparser):
         help="Stop after the first failed package."
     )
     run_parser.add_argument(
-        '--test-externals', action='store_true',
+        '--externals', action='store_true',
         help="Test packages that are externally installed."
     )
     run_parser.add_argument(
@@ -209,7 +209,7 @@ environment variables:
         test_suite(remove_directory=not args.keep_stage,
                    dirty=args.dirty,
                    fail_first=args.fail_first,
-                   test_externals=args.test_externals)
+                   externals=args.externals)
 
 
 def has_test_method(pkg):

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -128,7 +128,7 @@ class TestSuite(object):
         remove_directory = kwargs.get('remove_directory', True)
         dirty = kwargs.get('dirty', False)
         fail_first = kwargs.get('fail_first', False)
-        test_externals = kwargs.get('test_externals', False)
+        externals = kwargs.get('externals', False)
 
         for spec in self.specs:
             try:
@@ -150,10 +150,7 @@ class TestSuite(object):
                 fs.mkdirp(test_dir)
 
                 # run the package tests
-                spec.package.do_test(
-                    dirty=dirty,
-                    test_externals=test_externals
-                )
+                spec.package.do_test(dirty=dirty, externals=externals)
 
                 # Clean up on success
                 if remove_directory:
@@ -166,7 +163,7 @@ class TestSuite(object):
                     status = 'PASSED'
                 else:
                     self.ensure_stage()
-                    if spec.external and not test_externals:
+                    if spec.external and not externals:
                         status = 'SKIPPED'
                         msg = 'Skipped external package'
                     else:

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -160,7 +160,18 @@ class TestSuite(object):
                 # Log test status based on whether any non-pass-only test
                 # functions were called
                 tested = os.path.exists(self.tested_file_for_spec(spec))
-                status = 'PASSED' if tested else 'NO-TESTS'
+                if tested:
+                    status = 'PASSED'
+                else:
+                    self.ensure_stage()
+                    if spec.external:
+                        status = 'SKIPPED'
+                        msg = 'Skipped external package'
+                    else:
+                        status = 'NO-TESTS'
+                        msg = 'No tests to run'
+                    _add_msg_to_file(self.log_file_for_spec(spec), msg)
+
                 self.write_test_result(spec, status)
             except BaseException as exc:
                 self.fails += 1

--- a/lib/spack/spack/install_test.py
+++ b/lib/spack/spack/install_test.py
@@ -128,6 +128,7 @@ class TestSuite(object):
         remove_directory = kwargs.get('remove_directory', True)
         dirty = kwargs.get('dirty', False)
         fail_first = kwargs.get('fail_first', False)
+        test_externals = kwargs.get('test_externals', False)
 
         for spec in self.specs:
             try:
@@ -150,7 +151,8 @@ class TestSuite(object):
 
                 # run the package tests
                 spec.package.do_test(
-                    dirty=dirty
+                    dirty=dirty,
+                    test_externals=test_externals
                 )
 
                 # Clean up on success
@@ -164,7 +166,7 @@ class TestSuite(object):
                     status = 'PASSED'
                 else:
                     self.ensure_stage()
-                    if spec.external:
+                    if spec.external and not test_externals:
                         status = 'SKIPPED'
                         msg = 'Skipped external package'
                     else:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1791,7 +1791,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 fsys.mkdirp(os.path.dirname(dest_path))
                 fsys.copy(src_path, dest_path)
 
-    def do_test(self, dirty=False):
+    def do_test(self, dirty=False, test_externals=False):
         if self.test_requires_compiler:
             compilers = spack.compilers.compilers_for_spec(
                 self.spec.compiler, arch_spec=self.spec.architecture)
@@ -1808,7 +1808,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         self.tested_file = self.test_suite.tested_file_for_spec(self.spec)
         fsys.touch(self.test_log_file)  # Otherwise log_parse complains
 
-        if self.spec.external:
+        if self.spec.external and not test_externals:
             with open(self.test_log_file, 'w') as ofd:
                 ofd.write('Testing package {0}\n'
                           .format(self.test_suite.test_pkg_id(self.spec)))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1791,7 +1791,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 fsys.mkdirp(os.path.dirname(dest_path))
                 fsys.copy(src_path, dest_path)
 
-    def do_test(self, dirty=False, test_externals=False):
+    def do_test(self, dirty=False, externals=False):
         if self.test_requires_compiler:
             compilers = spack.compilers.compilers_for_spec(
                 self.spec.compiler, arch_spec=self.spec.architecture)
@@ -1808,7 +1808,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         self.tested_file = self.test_suite.tested_file_for_spec(self.spec)
         fsys.touch(self.test_log_file)  # Otherwise log_parse complains
 
-        if self.spec.external and not test_externals:
+        if self.spec.external and not externals:
             with open(self.test_log_file, 'w') as ofd:
                 ofd.write('Testing package {0}\n'
                           .format(self.test_suite.test_pkg_id(self.spec)))

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1808,6 +1808,12 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         self.tested_file = self.test_suite.tested_file_for_spec(self.spec)
         fsys.touch(self.test_log_file)  # Otherwise log_parse complains
 
+        if self.spec.external:
+            with open(self.test_log_file, 'w') as ofd:
+                ofd.write('Testing package {0}\n'
+                          .format(self.test_suite.test_pkg_id(self.spec)))
+            return
+
         kwargs = {'dirty': dirty, 'fake': False, 'context': 'test'}
         spack.build_environment.start_build_process(self, test_process, kwargs)
 

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -171,8 +171,14 @@ class InfoCollector(object):
                 value = None
                 try:
                     value = do_fn(instance, *args, **kwargs)
-                    package['result'] = 'success'
-                    package['stdout'] = fetch_log(pkg, do_fn, self.dir)
+
+                    if do_fn.__name__ == 'do_test' and pkg.spec.external:
+                        package['result'] = 'skipped'
+                        package['stdout'] = 'Skipped external package'
+                    else:
+                        package['result'] = 'success'
+                        package['stdout'] = fetch_log(pkg, do_fn, self.dir)
+
                     package['installed_from_binary_cache'] = \
                         pkg.installed_from_binary_cache
                     if do_fn.__name__ == '_install_task' and installed_already:

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -172,8 +172,8 @@ class InfoCollector(object):
                 try:
                     value = do_fn(instance, *args, **kwargs)
 
-                    test_externals = kwargs.get('test_externals', False)
-                    skip_externals = pkg.spec.external and not test_externals
+                    externals = kwargs.get('externals', False)
+                    skip_externals = pkg.spec.external and not externals
                     if do_fn.__name__ == 'do_test' and skip_externals:
                         package['result'] = 'skipped'
                         package['stdout'] = 'Skipped external package'

--- a/lib/spack/spack/report.py
+++ b/lib/spack/spack/report.py
@@ -172,13 +172,14 @@ class InfoCollector(object):
                 try:
                     value = do_fn(instance, *args, **kwargs)
 
-                    if do_fn.__name__ == 'do_test' and pkg.spec.external:
+                    test_externals = kwargs.get('test_externals', False)
+                    skip_externals = pkg.spec.external and not test_externals
+                    if do_fn.__name__ == 'do_test' and skip_externals:
                         package['result'] = 'skipped'
                         package['stdout'] = 'Skipped external package'
                     else:
                         package['result'] = 'success'
                         package['stdout'] = fetch_log(pkg, do_fn, self.dir)
-
                     package['installed_from_binary_cache'] = \
                         pkg.installed_from_binary_cache
                     if do_fn.__name__ == '_install_task' and installed_already:

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -87,6 +87,27 @@ def test_do_test(mock_packages, install_mockery, mock_test_stage):
     assert os.path.exists(data_filename)
 
 
+def test_test_external(mock_packages, install_mockery, mock_test_stage):
+    def ensure_results_skipped(filename):
+        assert os.path.exists(filename)
+        have = False
+        with open(filename, 'r') as fd:
+            for line in fd:
+                if 'Skipped' in line or 'SKIPPED' in line:
+                    have = True
+                    break
+        assert have
+
+    spec = spack.spec.Spec('trivial-smoke-test', ).concretized()
+    spec.external_path = '/path/to/external/trivial-smoke-test'
+    test_suite = spack.install_test.TestSuite([spec])
+
+    test_suite()
+
+    ensure_results_skipped(test_suite.log_file_for_spec(spec))
+    ensure_results_skipped(test_suite.results_file)
+
+
 def test_test_stage_caches(mock_packages, install_mockery, mock_test_stage):
     def ensure_current_cache_fail(test_suite):
         with pytest.raises(spack.install_test.TestSuiteSpecError):

--- a/lib/spack/spack/test/test_suite.py
+++ b/lib/spack/spack/test/test_suite.py
@@ -89,7 +89,7 @@ def test_do_test(mock_packages, install_mockery, mock_test_stage):
 
 @pytest.mark.parametrize('arguments,status,msg', [
     ({}, 'SKIPPED', 'Skipped'),
-    ({'test_externals': True}, 'NO-TESTS', 'No tests'),
+    ({'externals': True}, 'NO-TESTS', 'No tests'),
 ])
 def test_test_external(mock_packages, install_mockery, mock_test_stage,
                        arguments, status, msg):

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1706,7 +1706,7 @@ _spack_test() {
 _spack_test_run() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --alias --fail-fast --fail-first --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --clean --dirty"
+        SPACK_COMPREPLY="-h --help --alias --fail-fast --fail-first --test-externals --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --clean --dirty"
     else
         _installed_packages
     fi

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1706,7 +1706,7 @@ _spack_test() {
 _spack_test_run() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --alias --fail-fast --fail-first --test-externals --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --clean --dirty"
+        SPACK_COMPREPLY="-h --help --alias --fail-fast --fail-first --externals --keep-stage --log-format --log-file --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp --help-cdash --clean --dirty"
     else
         _installed_packages
     fi


### PR DESCRIPTION
Fixes #24014 

Since Spack does not install external packages, this PR skips them *by default* when running stand-alone tests.  The assumption is that such packages have likely undergone an acceptance test process.  However, the tests *can* be run against installed externals using `spack test run --externals`.

```
$ spack test run -h
usage: spack test run [-h] [--alias ALIAS] [--fail-fast] [--fail-first]
                      [--externals] [--keep-stage]
                      [--log-format {None,junit,cdash}] [--log-file LOG_FILE]
                      [--help-cdash] [--clean | --dirty]
                      ...

Run tests for the specified installed packages.

    If no specs are listed, run tests for all packages in the current
    environment or all installed packages if there is no active environment.
    

positional arguments:
  installed_specs       one or more installed package specs

optional arguments:
  --alias ALIAS         Provide an alias for this test-suite for subsequent access.
  --clean               unset harmful variables in the build environment (default)
  --dirty               preserve user environment in spack's build environment (danger!)
  --externals      Test packages that are externally installed.
  --fail-fast           Stop tests for each package after the first failure.
  --fail-first          Stop after the first failed package.
  --help-cdash          Show usage instructions for CDash reporting
  --keep-stage          Keep testing directory for debugging
  --log-file LOG_FILE   filename for the log file. if not passed a default will be used
  --log-format {None,junit,cdash}
                        format to be used for log files
  -h, --help            show this help message and exit
```

Results from running tests against externally installed packages *without the option* are, for example:

```
$ spack test run openmpi xz
==> Spack test h53e5oth7pwfqtm4d6z6nt3doc32iy34

$ spack test results
==> Results for test suite 'h53e5oth7pwfqtm4d6z6nt3doc32iy34':
==>   openmpi-4.1.2-37vuqvc SKIPPED
==>   xz-5.2.2-iwgisde SKIPPED
==>   xz-5.2.2-i5m6iu6 SKIPPED

$ spack test results -l
==> Results for test suite 'h53e5oth7pwfqtm4d6z6nt3doc32iy34':
==>   openmpi-4.1.2-37vuqvc SKIPPED
Testing package openmpi-4.1.2-37vuqvc
Skipped external package

==>   xz-5.2.2-iwgisde SKIPPED
Testing package xz-5.2.2-iwgisde
Skipped external package

==>   xz-5.2.2-i5m6iu6 SKIPPED
Testing package xz-5.2.2-i5m6iu6
Skipped external package

```

The `junit` output from `spack test run --log-format junit openmpi xz` is:

```
<?xml version="1.0" encoding="UTF-8"?>
<!--
    This file has been modeled after the basic
    specifications at this url:

    http://help.catchsoftware.com/display/ET/JUnit+Format
-->
<testsuites>
    <testsuite name="openmpi_37vuqvc"
               errors="0"
               tests="1"
               failures="0"
               time="0.002861499786376953"
               timestamp="Tue, 01 Feb 2022 18:20:42" >
        <properties>
            <property name="architecture" value="linux-rhel7-skylake_avx512" />
            <property name="compiler" value="gcc@8.3.1" />
        </properties>
        <testcase classname="openmpi"
                  name="37vuqvcq7pp2yeattawjomxfrw6a5mo3"
                  time="0.002861499786376953">
            <skipped />
            <system-out>
Skipped external package
            </system-out>
        </testcase>
    </testsuite>
    <testsuite name="xz_iwgisde"
               errors="0"
               tests="1"
               failures="0"
               time="0.002824068069458008"
               timestamp="Tue, 01 Feb 2022 18:20:42" >
        <properties>
            <property name="architecture" value="linux-rhel7-skylake_avx512" />
            <property name="compiler" value="gcc@8.3.1" />
        </properties>
        <testcase classname="xz"
                  name="iwgisdepiy7nislfoooycg4arjqjlc5s"
                  time="0.002824068069458008">
            <skipped />
            <system-out>
Skipped external package
            </system-out>
        </testcase>
    </testsuite>
    <testsuite name="xz_i5m6iu6"
               errors="0"
               tests="1"
               failures="0"
               time="0.002808094024658203"
               timestamp="Tue, 01 Feb 2022 18:20:42" >
        <properties>
            <property name="architecture" value="linux-rhel7-cascadelake" />
            <property name="compiler" value="intel@19.0.4.227" />
        </properties>
        <testcase classname="xz"
                  name="i5m6iu6vcvp5mbmyh5ah6vfdbzvfjzgo"
                  time="0.002808094024658203">
            <skipped />
            <system-out>
Skipped external package
            </system-out>
        </testcase>
    </testsuite>
```

Results when using `--externals`:

```
$ spack test run --externals openmpi xz
==> Spack test h53e5oth7pwfqtm4d6z6nt3doc32iy34
==> Testing package openmpi-4.1.2-37vuqvc
==> Error: TestFailure: 9 tests failed.
<..snip..>

See test log for details:
  /g/g21/dahlgren/.spack/test/h53e5oth7pwfqtm4d6z6nt3doc32iy34/openmpi-4.1.2-37vuqvc-test-out.txt

==> Testing package xz-5.2.2-iwgisde
==> Testing package xz-5.2.2-i5m6iu6
==> Error: 1 test(s) in the suite failed.

$ spack test results
==> Results for test suite 'h53e5oth7pwfqtm4d6z6nt3doc32iy34':
==>   openmpi-4.1.2-37vuqvc FAILED
==>   xz-5.2.2-iwgisde NO-TESTS
==>   xz-5.2.2-i5m6iu6 NO-TESTS

$ spack test results -l
==> Results for test suite 'h53e5oth7pwfqtm4d6z6nt3doc32iy34':
==>   openmpi-4.1.2-37vuqvc FAILED
==> Testing package openmpi-4.1.2-37vuqvc
<..snip..>

==>   xz-5.2.2-iwgisde NO-TESTS
==> Testing package xz-5.2.2-iwgisde
No tests to run

==>   xz-5.2.2-i5m6iu6 NO-TESTS
==> Testing package xz-5.2.2-i5m6iu6
No tests to run
```