### PR TITLE
pygmo: fix build

### DIFF
--- a/var/spack/repos/builtin/packages/pygmo/package.py
+++ b/var/spack/repos/builtin/packages/pygmo/package.py
@@ -19,17 +19,23 @@ class Pygmo(CMakePackage):
     version('master', branch='master')
     version('2.18.0', sha256='9f081cc973297894af09f713f889870ac452bfb32b471f9f7ba08a5e0bb9a125')
 
-    depends_on('pagmo2', type=('build', 'link'))
-    depends_on('mpi', type='build')
-    depends_on('py-pybind11@2.6.0:2.6.2', type='build')
-    depends_on('cmake@3.1:', type='build')
-
     variant('shared', default=True, description='Build shared libraries')
 
-    def cmake_args(self):
+    # Run-time dependencies
+    # https://github.com/esa/pygmo2/blob/master/doc/install.rst#dependencies
+    extends('python@3.4:')
+    depends_on('pagmo2@2.18:')
+    depends_on('boost@1.60:')
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-cloudpickle', type=('build', 'run'))
 
-        args = [
+    # Build-time dependencies
+    # https://github.com/esa/pygmo2/blob/master/doc/install.rst#installation-from-source
+    depends_on('py-pybind11@2.6:', type='build')
+    depends_on('cmake@3.17:', type='build')
+
+    def cmake_args(self):
+        return [
+            self.define('PYGMO_INSTALL_PATH', python_platlib),
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]
-
-        return args


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.9.9 and Apple Clang 12.0.0.

Also fixed the list of dependencies which including things that aren't needed and missed things that are needed.

Fixes #28696 