### PR TITLE
spack config update modules: top-level -> default

### DIFF
--- a/lib/spack/spack/schema/modules.py
+++ b/lib/spack/spack/schema/modules.py
@@ -8,6 +8,8 @@
 .. literalinclude:: _spack_root/lib/spack/spack/schema/modules.py
    :lines: 13-
 """
+import warnings
+
 import spack.schema.environment
 import spack.schema.projections
 
@@ -225,3 +227,39 @@ schema = {
     'additionalProperties': False,
     'properties': properties,
 }
+
+
+def update(data):
+    """Update the data in place to update deprecations.
+
+    Args:
+        data (dict): dictionary to be updated
+
+    Returns:
+        True if data was changed, False otherwise
+    """
+    changed = False
+
+    deprecated_top_level_keys = ('arch_folder', 'lmod', 'roots', 'enable',
+                                 'tcl', 'use_view')
+
+    # Don't update when we already have a default module set
+    if 'default' in data:
+        if any(key in data for key in deprecated_top_level_keys):
+            warnings.warn('Did not move top-level module properties into "default" '
+                          'module set, because the "default" module set is already '
+                          'defined')
+        return changed
+
+    default = {}
+
+    # Move deprecated top-level keys under "default" module set.
+    for key in deprecated_top_level_keys:
+        if key in data:
+            default[key] = data.pop(key)
+
+    if default:
+        changed = True
+        data['default'] = default
+
+    return changed

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -21,6 +21,7 @@ import spack.schema.compilers
 import spack.schema.config
 import spack.schema.env
 import spack.schema.mirrors
+import spack.schema.modules
 import spack.schema.packages
 import spack.schema.repos
 import spack.util.path as spack_path
@@ -1241,3 +1242,17 @@ def test_user_cache_path_is_overridable(working_env):
 def test_user_cache_path_is_default_when_env_var_is_empty(working_env):
     os.environ['SPACK_USER_CACHE_PATH'] = ''
     assert os.path.expanduser("~/.spack") == spack.paths._get_user_cache_path()
+
+
+def test_modules_config_update_toplevel_to_default_module_set():
+    data = {'enable': ['tcl', 'lmod']}
+    assert spack.schema.modules.update(data)
+    assert data == {'default': {'enable': ['tcl', 'lmod']}}
+
+
+def test_modules_config_update_toplevel_to_default_already_exists():
+    # We don't merge top-level keywords with those under default:, since
+    # that's something the user can better manage.
+    data = {'enable': ['tcl', 'lmod'], 'default': {'enable': ['tcl']}}
+    assert not spack.schema.modules.update(data)
+    assert data == {'enable': ['tcl', 'lmod'], 'default': {'enable': ['tcl']}}


### PR DESCRIPTION
make `spack config update modules` change

```yaml
modules:
  tcl:
    ...
```

to

```yaml
modules:
  default:
    tcl:
      ...
```

Makes it convenient to fix https://github.com/spack/spack/issues/28647