### PR TITLE
lua: add fetcher for luarocks

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -33,6 +33,7 @@ class Lua(Package):
     variant("pcfile", default=False, description="Add patch for lua.pc generation")
     variant('shared', default=True,
             description='Builds a shared version of the library')
+    variant('fetcher', default='curl', values=('curl', 'wget'), description='Fetcher to use in the LuaRocks package manager')
 
     extendable = True
 
@@ -42,6 +43,11 @@ class Lua(Package):
     depends_on('readline')
     # luarocks needs unzip for some packages (e.g. lua-luaposix)
     depends_on('unzip', type='run')
+
+    # luarocks needs a fetcher (curl/wget), unfortunately I have not found
+    # how to force a choice for curl or wget, but curl seems the default.
+    depends_on('curl', when='fetcher=curl', type='run')
+    depends_on('wget', when='fetcher=wget', type='run')
 
     patch(
         "http://lua.2524044.n2.nabble.com/attachment/7666421/0/pkg-config.patch",


### PR DESCRIPTION
`curl` is not a required system dependency of Spack anymore (thanks to urllib),
so it should be added to lua(rocks) to make it work out of the box without system
dependencies.
