### PR TITLE
ECP-SDK/VTK-m: Make ROCm + VTK-m contraints

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class EcpDataVisSdk(BundlePackage, CudaPackage):
+class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     """ECP Data & Vis SDK"""
 
     homepage = "https://github.com/chuckatkins/ecp-data-viz-sdk"
@@ -95,6 +95,8 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
     ############################################################
     cuda_arch_variants = ['cuda_arch={0}'.format(x)
                           for x in CudaPackage.cuda_arch_values]
+    amdgpu_target_variants = ['amdgpu_target={0}'.format(x)
+                          for x in ROCmPackage.amdgpu_targets]
 
     dav_sdk_depends_on('adios2+shared+mpi+fortran+python+blosc+sst+ssc+dataman',
                        when='+adios2',
@@ -151,7 +153,9 @@ class EcpDataVisSdk(BundlePackage, CudaPackage):
 
     dav_sdk_depends_on('vtk-m+shared+mpi+openmp+rendering',
                        when='+vtkm',
-                       propagate=['cuda'] + cuda_arch_variants)
+                       propagate=['cuda'] + cuda_arch_variants + amdgpu_target_variants)
+    depends_on('vtk-m +rocm', when='+vtkm +rocm ^vtk-m@1.7:')
+    depends_on('vtk-m ~rocm', when='+vtkm +rocm ^vtk-m@:1.6')
 
     # +python is currently broken in sz
     # dav_sdk_depends_on('sz+shared+fortran+python+random_access',

--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -96,7 +96,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     cuda_arch_variants = ['cuda_arch={0}'.format(x)
                           for x in CudaPackage.cuda_arch_values]
     amdgpu_target_variants = ['amdgpu_target={0}'.format(x)
-                          for x in ROCmPackage.amdgpu_targets]
+                              for x in ROCmPackage.amdgpu_targets]
 
     dav_sdk_depends_on('adios2+shared+mpi+fortran+python+blosc+sst+ssc+dataman',
                        when='+adios2',
@@ -153,9 +153,13 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
 
     dav_sdk_depends_on('vtk-m+shared+mpi+openmp+rendering',
                        when='+vtkm',
-                       propagate=['cuda'] + cuda_arch_variants + amdgpu_target_variants)
+                       propagate=['cuda'] + cuda_arch_variants)
     depends_on('vtk-m +rocm', when='+vtkm +rocm ^vtk-m@1.7:')
-    depends_on('vtk-m ~rocm', when='+vtkm +rocm ^vtk-m@:1.6')
+    for amdgpu_target in amdgpu_target_variants:
+        depends_on('vtk-m {0}'.format(amdgpu_target),
+                   when='+vtkm {0} ^vtk-m@1.7:'.format(amdgpu_target))
+
+    # depends_on('vtk-m ~rocm', when='+vtkm +rocm ^vtk-m@:1.6')
 
     # +python is currently broken in sz
     # dav_sdk_depends_on('sz+shared+fortran+python+random_access',

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -61,7 +61,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     # Device variants
     # CudaPackage provides cuda variant
     # ROCmPackage provides rocm variant
-    variant("kokkos", default=False, description="build using Kokkos backend")
+    variant("kokkos", default=False, when='@1.6:', description="build using Kokkos backend")
     variant("cuda_native", default=True, description="build using native cuda backend", when="+cuda")
     variant("openmp", default=(sys.platform != 'darwin'), description="build openmp support")
     variant("tbb", default=(sys.platform == 'darwin'), description="build TBB support")
@@ -94,6 +94,11 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocm-cmake@3.7:", when="+rocm")
     depends_on("hip@3.7:", when="+rocm")
 
+    # The rocm variant is only valid options for >= 1.7. It would be better if
+    # this could be expressed as a when clause to disable the rocm variant,
+    # but that is not currently possible since when clauses are stacked,
+    # not overwritten.
+    conflicts('+rocm', when='@:1.6')
     conflicts("+rocm", when="+cuda")
     conflicts("+rocm", when="~kokkos", msg="VTK-m does not support HIP without Kokkos")
 


### PR DESCRIPTION
* VTK-m:
  * set contraint for when rocm/kokkos are available.
* SDK:
  * Make ROCmPackage and propagate amdgpu_arch and rocm variant to VTK-m if the selected package version is >= 1.7

Note: Because of the extra weight in the +vtkm +rocm constraint, the SDK will prefer VTK-m 1.6 by default (in my testing) so it is required to add  `^vtk-m@1.7` to the spec in order to get a rocm compatible VTK-m spec.