### PR TITLE
Revert "Pin the version of "coverage" in CI to 6.2 (#28638)"

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -126,7 +126,7 @@ jobs:
               patchelf cmake bison libbison-dev kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov "coverage[toml]<=6.2"
+          pip install --upgrade pip six setuptools pytest codecov coverage[toml]
           # ensure style checks are not skipped in unit tests for python >= 3.6
           # note that true/false (i.e., 1/0) are opposite in conditions in python and bash
           if python -c 'import sys; sys.exit(not sys.version_info >= (3, 6))'; then
@@ -189,7 +189,7 @@ jobs:
           sudo apt-get install -y coreutils kcov csh zsh tcsh fish dash bash
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov coverage[toml]==6.2
+          pip install --upgrade pip six setuptools pytest codecov coverage[toml]
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
@@ -257,7 +257,7 @@ jobs:
               patchelf kcov
     - name: Install Python packages
       run: |
-          pip install --upgrade pip six setuptools pytest codecov coverage[toml]==6.2 clingo
+          pip install --upgrade pip six setuptools pytest codecov coverage[toml] clingo
     - name: Setup git configuration
       run: |
           # Need this for the git tests to succeed.
@@ -300,7 +300,7 @@ jobs:
     - name: Install Python packages
       run: |
           pip install --upgrade pip six setuptools
-          pip install --upgrade pytest codecov coverage[toml]==6.2
+          pip install --upgrade pytest codecov coverage[toml]
     - name: Setup Homebrew packages
       run: |
         brew install dash fish gcc gnupg2 kcov
@@ -342,7 +342,7 @@ jobs:
         python-version: '3.10'
     - name: Install Python packages
       run: |
-        pip install --upgrade pip six setuptools pytest codecov coverage[toml]==6.2
+        pip install --upgrade pip six setuptools pytest codecov coverage[toml]
     - name: Package audits (with coverage)
       if: ${{ needs.changes.outputs.with_coverage == 'true' }}
       run: |


### PR DESCRIPTION
This reverts commit b9b1665cb28e8115959e344a8bdaa507647a9ef1.

It seems `coverage` released a new patch version that might fix the locking issue, see https://github.com/nedbat/coveragepy/issues/1310#issuecomment-1027521713