### PR TITLE
Detecting "Cray" as "linux" during bootstrap

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -650,9 +650,7 @@ def _ensure_bootstrap_configuration():
     bootstrap_store_path = store_path()
     user_configuration = _read_and_sanitize_configuration()
     with spack.environment.no_active_environment():
-        # Disable detecting CRAY as a valid platform during bootstrap. This
-        # is based on the implementation of the detection method in platforms/cray.py
-        with spack.util.environment.set_env(MODULEPATH=''):
+        with spack.platforms.prevent_cray_detection():
             with spack.platforms.use_platform(spack.platforms.real_host()):
                 with spack.repo.use_repositories(spack.paths.packages_path):
                     with spack.store.use_store(bootstrap_store_path):

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -33,6 +33,7 @@ import spack.repo
 import spack.spec
 import spack.store
 import spack.user_environment
+import spack.util.environment
 import spack.util.executable
 import spack.util.path
 
@@ -65,12 +66,6 @@ def _try_import_from_store(module, query_spec, query_info=None):
     """
     # If it is a string assume it's one of the root specs by this module
     if isinstance(query_spec, six.string_types):
-        bincache_platform = spack.platforms.real_host()
-        if str(bincache_platform) == 'cray':
-            bincache_platform = spack.platforms.linux.Linux()
-            with spack.platforms.use_platform(bincache_platform):
-                query_spec = str(spack.spec.Spec(query_spec))
-
         # We have to run as part of this python interpreter
         query_spec += ' ^' + spec_for_current_python()
 
@@ -231,10 +226,6 @@ class _BuildcacheBootstrapper(object):
         abstract_spec = spack.spec.Spec(abstract_spec_str)
         # On Cray we want to use Linux binaries if available from mirrors
         bincache_platform = spack.platforms.real_host()
-        if str(bincache_platform) == 'cray':
-            bincache_platform = spack.platforms.Linux()
-            with spack.platforms.use_platform(bincache_platform):
-                abstract_spec = spack.spec.Spec(abstract_spec_str)
         return abstract_spec, bincache_platform
 
     def _read_metadata(self, package_name):
@@ -372,9 +363,6 @@ class _SourceBootstrapper(object):
         # Try to build and install from sources
         with spack_python_interpreter():
             # Add hint to use frontend operating system on Cray
-            if str(spack.platforms.host()) == 'cray':
-                abstract_spec_str += ' os=fe'
-
             concrete_spec = spack.spec.Spec(
                 abstract_spec_str + ' ^' + spec_for_current_python()
             )
@@ -405,10 +393,6 @@ class _SourceBootstrapper(object):
         # If we compile code from sources detecting a few build tools
         # might reduce compilation time by a fair amount
         _add_externals_if_missing()
-
-        # Add hint to use frontend operating system on Cray
-        if str(spack.platforms.host()) == 'cray':
-            abstract_spec_str += ' os=fe'
 
         concrete_spec = spack.spec.Spec(abstract_spec_str)
         if concrete_spec.name == 'patchelf':
@@ -666,21 +650,28 @@ def _ensure_bootstrap_configuration():
     bootstrap_store_path = store_path()
     user_configuration = _read_and_sanitize_configuration()
     with spack.environment.no_active_environment():
-        with spack.platforms.use_platform(spack.platforms.real_host()):
-            with spack.repo.use_repositories(spack.paths.packages_path):
-                with spack.store.use_store(bootstrap_store_path):
-                    # Default configuration scopes excluding command line
-                    # and builtin but accounting for platform specific scopes
-                    config_scopes = _bootstrap_config_scopes()
-                    with spack.config.use_configuration(*config_scopes):
-                        # We may need to compile code from sources, so ensure we have
-                        # compilers for the current platform before switching parts.
-                        _add_compilers_if_missing()
-                        spack.config.set('bootstrap', user_configuration['bootstrap'])
-                        spack.config.set('config', user_configuration['config'])
-                        with spack.modules.disable_modules():
-                            with spack_python_interpreter():
-                                yield
+        # Disable detecting CRAY as a valid platform during bootstrap. This
+        # is based on the implementation of the detection method in platforms/cray.py
+        with spack.util.environment.set_env(MODULEPATH=''):
+            with spack.platforms.use_platform(spack.platforms.real_host()):
+                with spack.repo.use_repositories(spack.paths.packages_path):
+                    with spack.store.use_store(bootstrap_store_path):
+                        # Default configuration scopes excluding command line
+                        # and builtin but accounting for platform specific scopes
+                        config_scopes = _bootstrap_config_scopes()
+                        with spack.config.use_configuration(*config_scopes):
+                            # We may need to compile code from sources, so ensure we
+                            # have compilers for the current platform
+                            _add_compilers_if_missing()
+                            spack.config.set(
+                                'bootstrap', user_configuration['bootstrap']
+                            )
+                            spack.config.set(
+                                'config', user_configuration['config']
+                            )
+                            with spack.modules.disable_modules():
+                                with spack_python_interpreter():
+                                    yield
 
 
 def _read_and_sanitize_configuration():

--- a/lib/spack/spack/platforms/__init__.py
+++ b/lib/spack/spack/platforms/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import contextlib
 
-from ._functions import _host, by_name, platforms
+from ._functions import _host, by_name, platforms, prevent_cray_detection, reset
 from ._platform import Platform
 from .cray import Cray
 from .darwin import Darwin
@@ -19,7 +19,9 @@ __all__ = [
     'Test',
     'platforms',
     'host',
-    'by_name'
+    'by_name',
+    'reset',
+    'prevent_cray_detection'
 ]
 
 #: The "real" platform of the host running Spack. This should not be changed

--- a/lib/spack/spack/platforms/_functions.py
+++ b/lib/spack/spack/platforms/_functions.py
@@ -2,7 +2,11 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import contextlib
+
 import llnl.util.lang
+
+import spack.util.environment
 
 from .cray import Cray
 from .darwin import Darwin
@@ -20,6 +24,13 @@ def _host():
         if platform_cls.detect():
             return platform_cls()
     return None
+
+
+def reset():
+    """The result of the host search is memoized. In case it needs to be recomputed
+    we must clear the cache, which is what this function does.
+    """
+    _host.cache.clear()
 
 
 @llnl.util.lang.memoized
@@ -45,3 +56,14 @@ def by_name(name):
     """
     platform_cls = cls_by_name(name)
     return platform_cls() if platform_cls else None
+
+
+@contextlib.contextmanager
+def prevent_cray_detection():
+    """Context manager that prevents the detection of the Cray platform"""
+    reset()
+    try:
+        with spack.util.environment.set_env(MODULEPATH=''):
+            yield
+    finally:
+        reset()


### PR DESCRIPTION
fixes #28315

Bootstrapping on Spack is not working on Perlmutter because the backend OS is misdetected as the frontend OS. While this is an issue on its own the bootstrapping procedure doesn't need to know about the Cray platform at all when bootstrapping. In fact in  many places we take care of mapping Cray to Linux manually e.g. for installing binary packages.

This PR solves the issues occurring at bootstrapping by:
1. Adding a context manager to disable the detection of a system as being Cray
2. Using the context manager above to setup the bootstrapping configuration, instead of manually mapping Cray to Linux in a few relevant places

The overall result is that during bootstrapping a Cray system will be considered the same as Linux, so no custom code to inspect module files etc. will be considered to build `clingo` or `patchelf`.

Tried on Perlmutter, Cori, Piz Daint.

@shahzebsiddiqui @kwryankrattiger @mwkrentel 
