### PR TITLE
[intel compiler] Fix link time error with `LLVMgold.so`

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1360,7 +1360,8 @@ class IntelPackage(PackageBase):
             # in compiler releases, then we need to search for libimf.so instead
             # of this static path.
             for lib in LLVMgold_libs:
-                p = subprocess.Popen(['patchelf', '--print-rpath', lib], stdout=subprocess.PIPE)
+                p = subprocess.Popen(['patchelf', '--print-rpath', lib],
+                                     stdout=subprocess.PIPE)
                 rpath = ':'.join([str(p.communicate()[0].decode()).strip(),
                                   '$ORIGIN/../compiler/lib/intel64_lin'])
                 subprocess.call(['patchelf', '--set-rpath', rpath, lib])

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1362,8 +1362,9 @@ class IntelPackage(PackageBase):
             for lib in LLVMgold_libs:
                 if not self.spec.satisfies('^patchelf'):
                     raise spack.error.SpackError(
-                        'Attempting to patch RPATH in LLVMgold.so.
-                        `patchelf` dependency should be set in package.py')
+                        'Attempting to patch RPATH in LLVMgold.so.'
+                        + '`patchelf` dependency should be set in package.py'
+                    )
                 patchelf = Executable('patchelf')
                 rpath = ':'.join([patchelf('--print-rpath', lib, output=str).strip(),
                                   '$ORIGIN/../compiler/lib/intel64_lin'])

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1359,8 +1359,10 @@ class IntelPackage(PackageBase):
             # is the location of libimf.so. If this relative location is changed
             # in compiler releases, then we need to search for libimf.so instead
             # of this static path.
-            rpath = "$ORIGIN/../lib:$ORIGIN/../compiler/lib/intel64_lin"
             for lib in LLVMgold_libs:
+                p = subprocess.Popen(['patchelf', '--print-rpath', lib], stdout=subprocess.PIPE)
+                rpath = ':'.join([str(p.communicate()[0].decode()).strip(),
+                                  '$ORIGIN/../compiler/lib/intel64_lin'])
                 subprocess.call(['patchelf', '--set-rpath', rpath, lib])
 
     # Check that self.prefix is there after installation

--- a/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
+++ b/var/spack/repos/builtin/packages/intel-parallel-studio/package.py
@@ -13,6 +13,8 @@ class IntelParallelStudio(IntelPackage):
 
     maintainers = ['rscohn2', 'danvev']
 
+    depends_on('patchelf', type='build')
+
     # As of 2016, the product comes in three "editions" that vary by scope.
     #
     # In Spack, select the edition via the version number in the spec, e.g.:

--- a/var/spack/repos/builtin/packages/intel/package.py
+++ b/var/spack/repos/builtin/packages/intel/package.py
@@ -14,6 +14,8 @@ class Intel(IntelPackage):
 
     maintainers = ['rscohn2', 'danvev']
 
+    depends_on('patchelf', type='build')
+
     # Same as in ../intel-parallel-studio/package.py, Composer Edition,
     # but the version numbering in Spack differs.
     version('20.0.4',              sha256='ac1efeff608a8c3a416e6dfe20364061e8abf62d35fbaacdffe3fc9676fc1aa3', url='https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/17117/parallel_studio_xe_2020_update4_composer_edition.tgz')


### PR DESCRIPTION
fixes https://github.com/spack/spack/issues/10308
fixes https://github.com/spack/spack/issues/18606
fixes https://github.com/spack/spack/issues/17100
fixes https://github.com/spack/spack/issues/21237
fixes https://github.com/spack/spack/issues/4261

The Intel compiler will, at link time, call `ld -plugin LLVMgold.so`, which expects libraries like `libimfo.so` to be found either in the `LD_LIBRARY_PATH` or in `LLVMgold.so`s RPATH. As `LLVMgold.so` already uses RUNPATH, I used that to extend this to the necessary library locations.