### PR TITLE
rocm-smi: project moved (deprecate)

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-smi/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi/package.py
@@ -13,8 +13,7 @@ class RocmSmi(MakefilePackage):
     """This tool exposes functionality for clock and temperature
        management of your ROCm enabled system
 
-       Note: According to its README, after ROCm 3.9, this project
-             moved to
+       Note: After ROCm 3.9, this project moved to
              https://github.com/RadeonOpenCompute/rocm_smi_lib/tree/master/python_smi_tools
              The spack package is called: rocm-smi-lib"""
 

--- a/var/spack/repos/builtin/packages/rocm-smi/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi/package.py
@@ -15,7 +15,8 @@ class RocmSmi(MakefilePackage):
 
        Note: According to its README, after ROCm 3.9, this project
              moved to
-             https://github.com/RadeonOpenCompute/rocm_smi_lib/tree/master/python_smi_tools"""
+             https://github.com/RadeonOpenCompute/rocm_smi_lib/tree/master/python_smi_tools
+             The spack package is called: rocm-smi-lib"""
 
     homepage = "https://github.com/RadeonOpenCompute/ROC-smi"
     url      = "https://github.com/RadeonOpenCompute/ROC-smi/archive/rocm-4.1.0.tar.gz"

--- a/var/spack/repos/builtin/packages/rocm-smi/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi/package.py
@@ -11,20 +11,24 @@ from spack import *
 
 class RocmSmi(MakefilePackage):
     """This tool exposes functionality for clock and temperature
-       management of your ROCm enabled system"""
+       management of your ROCm enabled system
+
+       Note: According to its README, after ROCm 3.9, this project
+             moved to
+             https://github.com/RadeonOpenCompute/rocm_smi_lib/tree/master/python_smi_tools"""
 
     homepage = "https://github.com/RadeonOpenCompute/ROC-smi"
     url      = "https://github.com/RadeonOpenCompute/ROC-smi/archive/rocm-4.1.0.tar.gz"
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
-    version('4.1.0', sha256='5f9f551f93f673f4b508f47a7f24bce903288ffb08fa9e4c8e0956a4a57865c2')
-    version('4.0.0', sha256='bf8738ae81c0a02d83eb9437b93dc153fb63f659f3b04d454024e30678b43575')
-    version('3.10.0', sha256='b1c7e529e8fcc53fb6b40a4126651da0ab07bcb91faac99519ba9660412ea4ed')
-    version('3.9.0', sha256='af3cc6d5e2296f47b1873339faad2d27cf2f24725771bf34c7f644d20cc6ef3b')
-    version('3.8.0', sha256='248d9bddc3353c74defd57f203df0648278a4613f2af7fb838d92a4bc8de575d')
-    version('3.7.0', sha256='4e34b3b4e409bb89677882f47d9988d56bc2d9bb9893f0712c22a4b73789e06a')
-    version('3.5.0', sha256='4f46e947c415a4ac12b9f6989f15a42afe32551706b4f48476fba3abf92e8e7c')
+    version('4.1.0', sha256='5f9f551f93f673f4b508f47a7f24bce903288ffb08fa9e4c8e0956a4a57865c2', deprecated=True)
+    version('4.0.0', sha256='bf8738ae81c0a02d83eb9437b93dc153fb63f659f3b04d454024e30678b43575', deprecated=True)
+    version('3.10.0', sha256='b1c7e529e8fcc53fb6b40a4126651da0ab07bcb91faac99519ba9660412ea4ed', deprecated=True)
+    version('3.9.0', sha256='af3cc6d5e2296f47b1873339faad2d27cf2f24725771bf34c7f644d20cc6ef3b', deprecated=True)
+    version('3.8.0', sha256='248d9bddc3353c74defd57f203df0648278a4613f2af7fb838d92a4bc8de575d', deprecated=True)
+    version('3.7.0', sha256='4e34b3b4e409bb89677882f47d9988d56bc2d9bb9893f0712c22a4b73789e06a', deprecated=True)
+    version('3.5.0', sha256='4f46e947c415a4ac12b9f6989f15a42afe32551706b4f48476fba3abf92e8e7c', deprecated=True)
 
     depends_on('python@3:', type='run')
 


### PR DESCRIPTION
According to its README, this project moved.

@srekolam @arjun-raj-kuppala do we need a new package for this tool in Spack or does it get shipped with the `hip` package? :)
Update: the new Spack package is called `rocm-smi-lib`.

References:
- https://github.com/RadeonOpenCompute/ROC-smi#rocm-system-management-interface
- https://github.com/RadeonOpenCompute/rocm_smi_lib/tree/master/python_smi_tools