### PR TITLE
Revert GCS fetch strategy, to remove s3 interface

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1437,13 +1437,7 @@ class GCSFetchStrategy(URLFetchStrategy):
         basename = os.path.basename(parsed_url.path)
 
         with working_dir(self.stage.path):
-            import spack.util.s3 as s3_util
-            s3 = s3_util.create_s3_session(self.url,
-                                           connection=s3_util.get_mirror_connection(parsed_url), url_type="fetch")  # noqa: E501
-
-            headers = s3.get_object(Bucket=parsed_url.netloc,
-                                    Key=parsed_url.path.lstrip("/"))
-            stream = headers["Body"]
+            _, headers, stream = web_util.read_from_url(self.url)
 
             with open(basename, 'wb') as f:
                 shutil.copyfileobj(stream, f)


### PR DESCRIPTION
This PR reverts the GCS fetch strategy to before commit:
d7596125231e800ca41c60e379be2b8abb47d20d

The previous commit added some s3 syntax to handle connections, but
added them into the GCS fetch strategy in a way that prevents GCS from
working anymore.