### PR TITLE
Update `gpg publish` to work with mirror arguments

### DIFF
--- a/lib/spack/spack/cmd/gpg.py
+++ b/lib/spack/spack/cmd/gpg.py
@@ -8,6 +8,7 @@ import os
 
 import spack.binary_distribution
 import spack.cmd.common.arguments as arguments
+import spack.mirror
 import spack.paths
 import spack.util.gpg
 
@@ -200,8 +201,13 @@ def gpg_verify(args):
 def gpg_publish(args):
     """publish public keys to a build cache"""
 
-    # TODO(opadron): switch to using the mirror args once #17547 is merged
-    mirror = args.directory
+    mirror = None
+    if args.directory:
+        mirror = spack.mirror.Mirror(args.directory, args.directory)
+    elif args.mirror_name:
+        mirror = spack.mirror.MirrorCollection().lookup(args.mirror_name)
+    elif args.mirror_url:
+        mirror = spack.mirror.Mirror(args.mirror_url, args.mirror_url)
 
     spack.binary_distribution.push_keys(
         mirror, keys=args.keys, regenerate_index=args.rebuild_index)

--- a/lib/spack/spack/test/cmd/gpg.py
+++ b/lib/spack/spack/test/cmd/gpg.py
@@ -20,9 +20,29 @@ from spack.util.executable import ProcessError
 #: spack command used by tests below
 gpg = SpackCommand('gpg')
 bootstrap = SpackCommand('bootstrap')
+mirror = SpackCommand('mirror')
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32",
                                 reason="does not run on windows")
+
+
+@pytest.fixture
+def tmp_scope():
+    """Creates a temporary configuration scope"""
+
+    base_name = 'internal-testing-scope'
+    current_overrides = set(
+        x.name for x in
+        spack.config.config.matching_scopes(r'^{0}'.format(base_name)))
+
+    num_overrides = 0
+    scope_name = base_name
+    while scope_name in current_overrides:
+        scope_name = '{0}{1}'.format(base_name, num_overrides)
+        num_overrides += 1
+
+    with spack.config.override(spack.config.InternalConfigScope(scope_name)):
+        yield scope_name
 
 
 # test gpg command detection
@@ -60,7 +80,7 @@ def test_no_gpg_in_path(tmpdir, mock_gnupghome, monkeypatch, mutable_config):
 
 
 @pytest.mark.maybeslow
-def test_gpg(tmpdir, mock_gnupghome):
+def test_gpg(tmpdir, tmp_scope, mock_gnupghome):
     # Verify a file with an empty keyring.
     with pytest.raises(ProcessError):
         gpg('verify', os.path.join(mock_gpg_data_path, 'content.txt'))
@@ -172,3 +192,24 @@ def test_gpg(tmpdir, mock_gnupghome):
 
     # Verification should now succeed again.
     gpg('verify', str(test_path))
+
+    # Publish the keys using a directory path
+    test_path = tmpdir.join('dir_cache')
+    os.makedirs('%s' % test_path)
+    gpg('publish', '--rebuild-index', '-d', str(test_path))
+    assert os.path.exists('%s/build_cache/_pgp/index.json' % test_path)
+
+    # Publish the keys using a mirror url
+    test_path = tmpdir.join('url_cache')
+    os.makedirs('%s' % test_path)
+    test_url = 'file://%s' % test_path
+    gpg('publish', '--rebuild-index', '--mirror-url', test_url)
+    assert os.path.exists('%s/build_cache/_pgp/index.json' % test_path)
+
+    # Publish the keys using a mirror name
+    test_path = tmpdir.join('named_cache')
+    os.makedirs('%s' % test_path)
+    mirror_url = 'file://%s' % test_path
+    mirror('add', '--scope', tmp_scope, 'gpg', mirror_url)
+    gpg('publish', '--rebuild-index', '-m', 'gpg')
+    assert os.path.exists('%s/build_cache/_pgp/index.json' % test_path)


### PR DESCRIPTION
This PR updates the `gpg publish` command to work with the mirror
arguments, when trying to push keys to a mirror.