### PR TITLE
WarpX: 22.02

### DIFF
--- a/var/spack/repos/builtin/packages/py-picmistandard/package.py
+++ b/var/spack/repos/builtin/packages/py-picmistandard/package.py
@@ -16,6 +16,7 @@ class PyPicmistandard(PythonPackage):
     maintainers = ['ax3l', 'dpgrote', 'RemiLehe']
 
     version('develop', branch='master')
+    version('0.0.19', sha256='4b7ba1330964fbfd515e8ea2219966957c1386e0896b92d36bd9e134afb02f5a')
     version('0.0.18', sha256='68c208c0c54b4786e133bb13eef0dd4824998da4906285987ddee84e6d195e71')
     # 0.15 - 0.17 have broken install logic: missing requirements.txt on pypi
     version('0.0.16', sha256='b7eefdae1c43119984226b2df358c86fdeef7495084e47b3575e3d07e790ba30',

--- a/var/spack/repos/builtin/packages/py-warpx/package.py
+++ b/var/spack/repos/builtin/packages/py-warpx/package.py
@@ -18,7 +18,7 @@ class PyWarpx(PythonPackage):
     """
 
     homepage = "https://ecp-warpx.github.io"
-    url      = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.01.tar.gz"
+    url      = "https://github.com/ECP-WarpX/WarpX/archive/refs/tags/22.02.tar.gz"
     git      = "https://github.com/ECP-WarpX/WarpX.git"
 
     maintainers = ['ax3l', 'dpgrote', 'RemiLehe']
@@ -27,6 +27,7 @@ class PyWarpx(PythonPackage):
 
     # NOTE: if you update the versions here, also see warpx
     version('develop', branch='development')
+    version('22.02', sha256='d74b593d6f396e037970c5fbe10c2e5d71d557a99c97d40e4255226bc6c26e42')
     version('22.01', sha256='e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28')
     version('21.12', sha256='847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1')
     version('21.11', sha256='ce60377771c732033a77351cd3500b24b5d14b54a5adc7a622767b9251c10d0b')
@@ -41,7 +42,7 @@ class PyWarpx(PythonPackage):
     variant('mpi', default=True,
             description='Enable MPI support')
 
-    for v in ['22.01',
+    for v in ['22.02', '22.01',
               '21.12', '21.11', '21.10', '21.09', '21.08', '21.07', '21.06',
               '21.05', '21.04',
               'develop']:
@@ -57,6 +58,7 @@ class PyWarpx(PythonPackage):
     depends_on('py-picmistandard@0.0.14', type=('build', 'run'), when='@21.03:21.11')
     depends_on('py-picmistandard@0.0.16', type=('build', 'run'), when='@21.12')
     depends_on('py-picmistandard@0.0.18', type=('build', 'run'), when='@22.01')
+    depends_on('py-picmistandard@0.0.19', type=('build', 'run'), when='@22.02')
     depends_on('py-setuptools@42:', type='build')
     depends_on('py-cmake@3.15:3', type='build')
     depends_on('py-cmake@3.18:3', type='build', when='@22.01:')

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -25,6 +25,7 @@ class Warpx(CMakePackage):
 
     # NOTE: if you update the versions here, also see py-warpx
     version('develop', branch='development')
+    version('22.02', sha256='d74b593d6f396e037970c5fbe10c2e5d71d557a99c97d40e4255226bc6c26e42')
     version('22.01', sha256='e465ffadabb7dc360c63c4d3862dc08082b5b0e77923d3fb05570408748b0d28')
     # 22.01+ requires C++17 or newer
     version('21.12', sha256='847c98aac20c73d94c823378803c82be9a14139f1c14ea483757229b452ce4c1')


### PR DESCRIPTION
Update `warpx` & `py-warpx` to the latest release, `22.02`.