### PR TITLE
Python: fix build with Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/python/fj-rpath-3.9.patch
+++ b/var/spack/repos/builtin/packages/python/fj-rpath-3.9.patch
@@ -1,0 +1,11 @@
+--- spack-src/Lib/distutils/unixccompiler.py.org	2022-01-31 14:42:34.000000000 +0900
++++ spack-src/Lib/distutils/unixccompiler.py	2022-01-31 14:43:19.000000000 +0900
+@@ -212,7 +212,7 @@
+ 
+     def _is_gcc(self, compiler_name):
+         # clang uses same syntax for rpath as gcc
+-        return any(name in compiler_name for name in ("gcc", "g++", "clang"))
++        return any(name in compiler_name for name in ("gcc", "g++", "clang", "fcc", "FCC"))
+ 
+     def runtime_library_dir_option(self, dir):
+         # XXX Hackish, at the very least.  See Python bug #445902:

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -225,7 +225,8 @@ class Python(AutotoolsPackage):
 
     # Ensure that distutils chooses correct compiler option for RPATH on fj:
     patch('fj-rpath-2.3.patch', when='@2.3:3.0.1 %fj')
-    patch('fj-rpath-3.1.patch', when='@3.1:3  %fj')
+    patch('fj-rpath-3.1.patch', when='@3.1:3.9.7,3.10.0  %fj')
+    patch('fj-rpath-3.9.patch', when='@3.9.8:3.9,3.10.1:  %fj')
 
     # Fixes an alignment problem with more aggressive optimization in gcc8
     # https://github.com/python/cpython/commit/0b91f8a668201fc58fa732b8acc496caedfdbae0
@@ -421,6 +422,11 @@ class Python(AutotoolsPackage):
 
         env.unset('PYTHONPATH')
         env.unset('PYTHONHOME')
+
+        # avoid build error on fugaku
+        if spec.satisfies('@3.10.0 arch=linux-rhel8-a64fx'):
+            if spec.satisfies('%gcc') or spec.satisfies('%fj'):
+                env.unset('LC_ALL')
 
     def flag_handler(self, name, flags):
         # python 3.8 requires -fwrapv when compiled with intel


### PR DESCRIPTION
- rpath patch for Fujitsu compiler is update for python 3.9.7 and later.
- Unset LC_ALL to avoid a segmentation fault during build python 3.10.0