### PR TITLE
[py-xonsh] added py-xonsh package

### DIFF
--- a/var/spack/repos/builtin/packages/py-xonsh/package.py
+++ b/var/spack/repos/builtin/packages/py-xonsh/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+
+class PyXonsh(PythonPackage):
+    """Python-powered, cross-platform, Unix-gazing shell language and command prompt."""
+
+    homepage = "https://xon.sh/"
+    pypi     = "xonsh/xonsh-0.11.0.tar.gz"
+
+    maintainers = ['mdorier']
+
+    version('0.11.0', sha256='0d9c3d9a4e8b8199ae697fbc9d1e0ae55085cdbdd4306d04813350996f9c15dc')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-xonsh/package.py
+++ b/var/spack/repos/builtin/packages/py-xonsh/package.py
@@ -17,5 +17,5 @@ class PyXonsh(PythonPackage):
 
     version('0.11.0', sha256='0d9c3d9a4e8b8199ae697fbc9d1e0ae55085cdbdd4306d04813350996f9c15dc')
 
-    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
This PR adds the py-xonsh package, providing the [xonsh](https://xon.sh/) python-powered shell.