### PR TITLE
INST-21855-deploy-oneAPI-2022.1.2-to-Spack

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -13,6 +13,7 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
 
     maintainers = ['rscohn2']
 
+    # oneAPI Collective Communications Library
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/oneccl.html'
 
     depends_on('intel-oneapi-mpi')
@@ -22,7 +23,6 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18472/l_oneapi_ccl_p_2021.5.1.494_offline.sh',
                 sha256='237f45d3c43447460e36eb7d68ae3bf611aa282015e57c7fe06c2004d368a68e',
                 expand=False)
-                
         version('2021.5.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18371/l_oneapi_ccl_p_2021.5.0.478_offline.sh',
                 sha256='47584ad0269fd13bcfbc2cd0bb029bdcc02b723070abcb3d5e57f9586f4e74f8',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -22,6 +22,7 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18472/l_oneapi_ccl_p_2021.5.1.494_offline.sh',
                 sha256='237f45d3c43447460e36eb7d68ae3bf611aa282015e57c7fe06c2004d368a68e',
                 expand=False)
+                
         version('2021.5.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18371/l_oneapi_ccl_p_2021.5.0.478_offline.sh',
                 sha256='47584ad0269fd13bcfbc2cd0bb029bdcc02b723070abcb3d5e57f9586f4e74f8',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -18,6 +18,10 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on('intel-oneapi-mpi')
 
     if platform.system() == 'Linux':
+        version('2021.5.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18472/l_oneapi_ccl_p_2021.5.1.494_offline.sh',
+                sha256='237f45d3c43447460e36eb7d68ae3bf611aa282015e57c7fe06c2004d368a68e',
+                expand=False)
         version('2021.5.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18371/l_oneapi_ccl_p_2021.5.0.478_offline.sh',
                 sha256='47584ad0269fd13bcfbc2cd0bb029bdcc02b723070abcb3d5e57f9586f4e74f8',

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -22,6 +22,16 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     depends_on('patchelf', type='build')
 
     if platform.system() == 'Linux':
+        version('2022.0.2',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh',
+                sha256='ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3',
+                expand=False)
+        resource(name='fortran-installer',
+                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18481/l_fortran-compiler_p_2022.0.2.83_offline.sh',
+                 sha256='78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c',
+                 expand=False,
+                 placement='fortran-installer',
+                 when='@2022.0.2')
         version('2022.0.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh',
                 sha256='c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onedal.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.3',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18480/l_daal_oneapi_p_2021.5.3.832_offline.sh',
+                sha256='6d3503cf7be2908bbb7bd18e67b8f2e96ad9aec53d4813c9be620adaa2db390f',
+                expand=False)
         version('2021.5.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18432/l_daal_oneapi_p_2021.5.1.803_offline.sh',
                 sha256='bba7bee3caef14fbb54ad40615222e5da429496455edf7375f11fd84a72c87ba',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onednn.html'
 
     if platform.system() == 'Linux':
+        version('2022.0.2',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18476/l_onednn_p_2022.0.2.43_offline.sh',
+                sha256='a2a953542b4f632b51a2527d84bd76c3140a41c8085420da4237e2877c27c280',
+                expand=False)
         version('2022.0.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18441/l_onednn_p_2022.0.1.26_offline.sh',
                 sha256='8339806300d83d2629952e6e2f2758b52f517c072a20b7b7fc5642cf1e2a5410',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -16,6 +16,10 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.2',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18474/l_ipp_oneapi_p_2021.5.2.544_offline.sh',
+                sha256='ba48d91ab1447d0ae3d3a5448e3f08e460393258b60630c743be88281e51608e',
+                expand=False)
         version('2021.5.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18440/l_ipp_oneapi_p_2021.5.1.522_offline.sh',
                 sha256='be99f9b0b2cc815e017188681ab997f3ace94e3010738fa6f702f2416dac0de4',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -17,6 +17,10 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18470/l_ippcp_oneapi_p_2021.5.1.462_offline.sh',
+                sha256='7ec058abbc1cdfd240320228d6426c65e5a855fd3a27e11fbd1ad2523f64812a',
+                expand=False)
         version('2021.5.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18364/l_ippcp_oneapi_p_2021.5.0.445_offline.sh',
                 sha256='e71aee288cc970b9c9fe21f7d5c300dbc2a4ea0687c7028f200d6b87e6c895a1',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -17,6 +17,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html'
 
     if platform.system() == 'Linux':
+        version('2022.0.2',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18483/l_onemkl_p_2022.0.2.136_offline.sh',
+                sha256='134b748825a474acc862bb4a7fada99741a15b7627cfaa6ba0fb05ec0b902b5e',
+                expand=False)
         version('2022.0.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18444/l_onemkl_p_2022.0.1.117_offline.sh',
                 sha256='22afafbe2f3762eca052ac21ec40b845ff2f3646077295c88c2f37f80a0cc160',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -17,6 +17,10 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18471/l_mpi_oneapi_p_2021.5.1.515_offline.sh',
+                sha256='b992573959e39752e503e691564a0d876b099547c38b322d5775c5b06ec07a7f',
+                expand=False)
         version('2021.5.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18370/l_mpi_oneapi_p_2021.5.0.495_offline.sh',
                 sha256='3aae53fe77f7c6aac7a32b299c25d6ca9a00ba4e2d512a26edd90811e59e7471',

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -17,6 +17,10 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onetbb.html'
 
     if platform.system() == 'Linux':
+        version('2021.5.1',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18473/l_tbb_oneapi_p_2021.5.1.738_offline.sh',
+                sha256='c154749f1f370e4cde11a0a7c80452d479e2dfa53ff2b1b97003d9c0d99c91e3',
+                expand=False)
         version('2021.5.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18380/l_tbb_oneapi_p_2021.5.0.707_offline.sh',
                 sha256='6ff7890a74a43ae02e0fa2d9c5533fce70a49dff8e73278b546a0995367fec5e',


### PR DESCRIPTION
Add oneAPI packages from the 2022.1.2 release
oneapi-test CI results: https://github.com/VladimirUspenskii/oneapi-spack-tests/actions/runs/1789365251

