### PR TITLE
[miniconda3] added extend python to miniconda3 package

### DIFF
--- a/var/spack/repos/builtin/packages/miniconda3/package.py
+++ b/var/spack/repos/builtin/packages/miniconda3/package.py
@@ -39,6 +39,8 @@ class Miniconda3(Package):
 
     homepage = "https://conda.io/miniconda.html"
 
+    extends('python')
+
     for ver, packages in _versions.items():
         key = "{0}-{1}".format(platform.system(), platform.machine())
         pkg = packages.get(key)


### PR DESCRIPTION
The `miniconda3` package is not a python package per-se (it does not inherit from `PythonPackage`) but it has a Python API internally, hence `PYTHONPATH` should be updated when the package is loaded. This PR adds `extends('python')` to enable that.