### PR TITLE
WarpX/HiPACE: noacc PSATD also needs FFTW

### DIFF
--- a/var/spack/repos/builtin/packages/hipace/package.py
+++ b/var/spack/repos/builtin/packages/hipace/package.py
@@ -42,6 +42,10 @@ class Hipace(CMakePackage):
         depends_on('openpmd-api@0.14.2:')
         depends_on('openpmd-api ~mpi', when='~mpi')
         depends_on('openpmd-api +mpi', when='+mpi')
+    with when('compute=noacc'):
+        depends_on('fftw@3: ~mpi', when='~mpi')
+        depends_on('fftw@3: +mpi', when='+mpi')
+        depends_on('pkgconfig', type='build')
     with when('compute=omp'):
         depends_on('fftw@3: +openmp')
         depends_on('fftw ~mpi', when='~mpi')

--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -95,6 +95,11 @@ class Warpx(CMakePackage):
         depends_on('rocfft', when='+psatd')
         depends_on('rocprim')
         depends_on('rocrand')
+    with when('compute=noacc'):
+        with when('+psatd'):
+            depends_on('fftw@3: ~mpi', when='~mpi')
+            depends_on('fftw@3: +mpi', when='+mpi')
+            depends_on('pkgconfig', type='build')
     with when('compute=omp'):
         depends_on('llvm-openmp', when='%apple-clang')
         with when('+psatd'):


### PR DESCRIPTION
Forgot to add that `compute=noacc` also needs FFTW3 for PSATD builds.