### PR TITLE
py-mpi4py: fix install_options

### DIFF
--- a/var/spack/repos/builtin/packages/py-mpi4py/package.py
+++ b/var/spack/repos/builtin/packages/py-mpi4py/package.py
@@ -32,6 +32,7 @@ class PyMpi4py(PythonPackage):
     depends_on('py-cython@0.27.0:', when='@master', type='build')
     depends_on('py-3to2', when='@3.1: ^python@:2', type='build')
 
+    @when('@3.1:')
     def install_options(self, spec, prefix):
         return ['--mpicc=%s -shared' % spec['mpi'].mpicc]
 


### PR DESCRIPTION
Fixes a bug introduced by #27798. We previously ran:
```console
$ python setup.py build --mpicc=...
$ python setup.py install
```
After #27798, we run `pip install`, which runs:
```console
$ python setup.py install --mpicc=...
```
At least in older versions of mpi4py, the `--mpicc` flag is only valid for the build phase, not the install phase. In newer versions of mpi4py, the `--mpicc` flag doesn't seem to break anything, but it's also unclear if it's actually being used.

It looks like this flag was added by @TiffanyAnn in #12191, maybe she can investigate.

Fixes #28748