### PR TITLE
Update: py-cmake

### DIFF
--- a/var/spack/repos/builtin/packages/py-cmake/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake/package.py
@@ -27,5 +27,17 @@ class PyCmake(PythonPackage):
     depends_on('cmake@3.21.4', type=('build', 'link', 'run'), when='@3.21.4')
     depends_on('cmake@3.18.0', type=('build', 'link', 'run'), when='@3.18.0')
 
+    # see:
+    #   https://github.com/scikit-build/cmake-python-distributions/issues/227
+    #   https://github.com/spack/spack/pull/28760#issuecomment-1029362288
+    for v in ['3.22.2', '3.21.4', '3.18.0']:
+        resource(name='cmake-src',
+                 git='https://gitlab.kitware.com/cmake/cmake.git',
+                 commit='v{0}'.format(v), when='@{0}'.format(v),
+                 destination='cmake-src', placement='cmake-src')
+
     def install_options(self, spec, prefix):
-        return ['-DBUILD_CMAKE_FROM_SOURCE=OFF']
+        return [
+            '-DBUILD_CMAKE_FROM_SOURCE=ON',
+            '-DCMakeProject_SOURCE_DIR=cmake-src'
+        ]

--- a/var/spack/repos/builtin/packages/py-cmake/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake/package.py
@@ -19,6 +19,7 @@ class PyCmake(PythonPackage):
     version('3.21.4', sha256='30fa5ed8a5ad66dcd263adb87f3ce3dc2d0ec0ac3958f5becff577e4b62cd065')
     version('3.18.0', sha256='52b98c5ee70b5fa30a8623e96482227e065292f78794eb085fdf0fecb204b79b')
 
+    depends_on('ninja', type='build')
     depends_on('py-scikit-build@0.12:', type='build')
     depends_on('py-setuptools@42:', type='build')
     depends_on('git', type='build')

--- a/var/spack/repos/builtin/packages/py-cmake/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake/package.py
@@ -9,20 +9,20 @@ from spack import *
 class PyCmake(PythonPackage):
     """CMake is an open-source, cross-platform family of tools designed to
     build, test and package software
-
-    Repository: https://github.com/scikit-build/cmake-python-distributions
     """
 
     homepage = "https://cmake.org"
-    pypi = "cmake/cmake-3.21.4.tar.gz"
+    git = "https://github.com/scikit-build/cmake-python-distributions.git"
+    pypi = "cmake/cmake-3.22.2.tar.gz"
 
+    version('3.22.2', sha256='b5bd5eeb488b13cf64ec963800f3d979eaeb90b4382861b86909df503379e219')
     version('3.21.4', sha256='30fa5ed8a5ad66dcd263adb87f3ce3dc2d0ec0ac3958f5becff577e4b62cd065')
     version('3.18.0', sha256='52b98c5ee70b5fa30a8623e96482227e065292f78794eb085fdf0fecb204b79b')
 
     depends_on('py-scikit-build@0.12:', type='build')
     depends_on('py-setuptools@42:', type='build')
-    depends_on('py-wheel', type='build')
     depends_on('git', type='build')
+    depends_on('cmake@3.22.2', type=('build', 'link', 'run'), when='@3.22.2')
     depends_on('cmake@3.21.4', type=('build', 'link', 'run'), when='@3.21.4')
     depends_on('cmake@3.18.0', type=('build', 'link', 'run'), when='@3.18.0')
 

--- a/var/spack/repos/builtin/packages/py-cmake/package.py
+++ b/var/spack/repos/builtin/packages/py-cmake/package.py
@@ -9,16 +9,20 @@ from spack import *
 class PyCmake(PythonPackage):
     """CMake is an open-source, cross-platform family of tools designed to
     build, test and package software
+
+    Repository: https://github.com/scikit-build/cmake-python-distributions
     """
 
-    homepage = "https://cmake.org/"
-    pypi = "cmake/cmake-3.18.0.tar.gz"
+    homepage = "https://cmake.org"
+    pypi = "cmake/cmake-3.21.4.tar.gz"
 
     version('3.21.4', sha256='30fa5ed8a5ad66dcd263adb87f3ce3dc2d0ec0ac3958f5becff577e4b62cd065')
     version('3.18.0', sha256='52b98c5ee70b5fa30a8623e96482227e065292f78794eb085fdf0fecb204b79b')
 
     depends_on('py-scikit-build@0.12:', type='build')
     depends_on('py-setuptools@42:', type='build')
+    depends_on('py-wheel', type='build')
+    depends_on('git', type='build')
     depends_on('cmake@3.21.4', type=('build', 'link', 'run'), when='@3.21.4')
     depends_on('cmake@3.18.0', type=('build', 'link', 'run'), when='@3.18.0')
 


### PR DESCRIPTION
Add additional dependencies as declared by the `py-cmake` repository.

Note: for either from-source or from-binary builds, this downloads additional software via the network. We might want to propose upstream patches with @jcfr and @henryiii to make this work on nodes without internet connection.