### PR TITLE
database: fix reindex with uninstalled deps

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1104,7 +1104,8 @@ class Database(object):
                     tty.warn(
                         'Dependency missing: may be deprecated or corrupted:',
                         path, str(e))
-            self._installed_prefixes.add(path)
+            if installed:
+                self._installed_prefixes.add(path)
         elif spec.external_path:
             path = spec.external_path
             installed = True
@@ -1209,7 +1210,7 @@ class Database(object):
 
         # This install prefix is now free for other specs to use, even if the
         # spec is only marked uninstalled.
-        if not rec.spec.external:
+        if not rec.spec.external and rec.installed:
             self._installed_prefixes.remove(rec.path)
 
         if rec.ref_count > 0:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1141,8 +1141,7 @@ class Database(object):
             new_spec._full_hash = spec._full_hash
 
         else:
-            # If it is already there, mark it as installed and update
-            # installation time
+            # It is already in the database
             self._data[key].installed = installed
             self._data[key].installation_time = installation_time
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1143,7 +1143,7 @@ class Database(object):
         else:
             # It is already in the database
             self._data[key].installed = installed
-            self._data[key].installation_time = installation_time
+            self._data[key].installation_time = _now()
 
         self._data[key].explicit = explicit
 

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1099,13 +1099,13 @@ class Database(object):
             try:
                 directory_layout.ensure_installed(spec)
                 installed = True
-            except DirectoryLayoutError as e:
-                if key not in self._data:
-                    tty.warn(
-                        'Dependency missing: may be deprecated or corrupted:',
-                        path, str(e))
-            if installed:
                 self._installed_prefixes.add(path)
+            except DirectoryLayoutError as e:
+                msg = ("{0} is being {1} in the database with prefix {2}, "
+                       "but this directory does not contain an installation of "
+                       "the spec, due to: {3}")
+                action = "updated" if key in self._data else "registered"
+                tty.warn(msg.format(spec.short_spec, action, path, str(e)))
         elif spec.external_path:
             path = spec.external_path
             installed = True

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1093,10 +1093,9 @@ class Database(object):
                 self._add(dep, directory_layout, **extra_args)
 
         # Make sure the directory layout agrees whether the spec is installed
-        installed = bool(spec.external)
-        path = None
         if not spec.external and directory_layout:
             path = directory_layout.path_for_spec(spec)
+            installed = False
             try:
                 directory_layout.ensure_installed(spec)
                 installed = True
@@ -1105,15 +1104,15 @@ class Database(object):
                     tty.warn(
                         'Dependency missing: may be deprecated or corrupted:',
                         path, str(e))
+            self._installed_prefixes.add(path)
         elif spec.external_path:
             path = spec.external_path
+            installed = True
+        else:
+            path = None
+            installed = True
 
         if key not in self._data:
-            # Create a new install record
-            if path in self._installed_prefixes:
-                raise Exception("Install prefix collision.")
-            if installed:
-                self._installed_prefixes.add(path)
             # Create a new install record with no deps initially.
             new_spec = spec.copy(deps=False)
             extra_args = {

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -246,7 +246,8 @@ class DirectoryLayout(object):
         spec_file_path = self.spec_file_path(spec)
 
         if not os.path.isdir(path):
-            raise InconsistentInstallDirectoryError("Install prefix does not exist")
+            raise InconsistentInstallDirectoryError(
+                "Install prefix {0} does not exist.".format(path))
 
         if not os.path.isfile(spec_file_path):
             raise InconsistentInstallDirectoryError(
@@ -255,7 +256,7 @@ class DirectoryLayout(object):
 
         installed_spec = self.read_spec(spec_file_path)
         if installed_spec == spec:
-            return path
+            return
 
         # DAG hashes currently do not include build dependencies.
         #
@@ -268,7 +269,7 @@ class DirectoryLayout(object):
             # may be installed. This means for example that for two instances
             # that differ only in CMake version used to build, only one will
             # be installed.
-            return path
+            return
 
         if spec.dag_hash() == installed_spec.dag_hash():
             raise SpecHashCollisionError(spec, installed_spec)

--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -234,13 +234,19 @@ class DirectoryLayout(object):
 
         self.write_spec(spec, self.spec_file_path(spec))
 
-    def check_installed(self, spec):
+    def ensure_installed(self, spec):
+        """
+        Throws DirectoryLayoutError if:
+        1. spec prefix does not exist
+        2. spec prefix does not contain a spec file
+        3. the spec file does not correspond to the spec
+        """
         _check_concrete(spec)
         path = self.path_for_spec(spec)
         spec_file_path = self.spec_file_path(spec)
 
         if not os.path.isdir(path):
-            return None
+            raise InconsistentInstallDirectoryError("Install prefix does not exist")
 
         if not os.path.isfile(spec_file_path):
             raise InconsistentInstallDirectoryError(

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -883,7 +883,7 @@ class MockLayout(object):
     def path_for_spec(self, spec):
         return '/'.join([self.root, spec.name + '-' + spec.dag_hash()])
 
-    def check_installed(self, spec):
+    def ensure_installed(self, spec):
         return True
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -884,7 +884,7 @@ class MockLayout(object):
         return '/'.join([self.root, spec.name + '-' + spec.dag_hash()])
 
     def ensure_installed(self, spec):
-        return True
+        pass
 
 
 @pytest.fixture()

--- a/lib/spack/spack/test/database.py
+++ b/lib/spack/spack/test/database.py
@@ -940,7 +940,7 @@ def test_reindex_when_prefix_removed_means_not_installed(mutable_database, capfd
 
     # Reindexing should warn about libelf not being found on the filesystem
     err = capfd.readouterr()[1]
-    assert 'Dependency missing' in err
+    assert 'this directory does not contain an installation of the spec' in err
 
     # And we should still have libelf in the database, but not installed.
     assert not mutable_database.query_one('libelf', installed=True)


### PR DESCRIPTION
When a prefix of a dep is removed, and the db is reindexed, it is added
through the dependent, but until now it incorrectly listed the spec as
'installed'.

It also fixes an issue when the same spec was added multiple times, it would
always be marked installed, even though it was not.

Lastly it fixes some edge cases where removing an uninstalled, non-external
spec errored if it had never been installed in the database in the first place
(e.g. prefix of some root spec is gone, it's added back on spack reindex
through the old index.json -- but due to a bug you would not be able to
remove this missing entry from the database.)