### PR TITLE
Add 'stable' to the list of infinity version names.

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -705,7 +705,8 @@ as follows:
 
 #. The following special strings are considered larger than any other
    numeric or non-numeric version component, and satisfy the following
-   order between themselves: ``develop > main > master > head > trunk``.
+   order between themselves:
+   ``develop > main > master > head > trunk > stable``.
 
 #. Numbers are ordered numerically, are less than special strings, and
    larger than other non-numeric components.

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -59,7 +59,7 @@ SEMVER_REGEX = re.compile(".+(?P<semver>([0-9]+)[.]([0-9]+)[.]([0-9]+)"
                           "(?:[+][0-9A-Za-z-]+)?)")
 
 # Infinity-like versions. The order in the list implies the comparison rules
-infinity_versions = ['develop', 'main', 'master', 'head', 'trunk']
+infinity_versions = ['develop', 'main', 'master', 'head', 'trunk', 'stable']
 
 iv_min_len = min(len(s) for s in infinity_versions)
 

--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -16,7 +16,7 @@ class Libunwind(AutotoolsPackage):
     maintainers = ['mwkrentel']
 
     version('master', branch='master')
-    version('1.5-head', branch='v1.5-stable')
+    version('1.5-stable', branch='v1.5-stable')
     version('1.5.0', sha256='90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017')
     version('1.4.0', sha256='df59c931bd4d7ebfd83ee481c943edf015138089b8e50abed8d9c57ba9338435')
     version('1.3.1', sha256='43997a3939b6ccdf2f669b50fdb8a4d3205374728c2923ddc2354c65260214f8')
@@ -62,10 +62,10 @@ class Libunwind(AutotoolsPackage):
 
     # The libunwind releases contain the autotools generated files,
     # but the git repo snapshots do not.
-    depends_on('autoconf', type='build', when='@master,1.5-head')
-    depends_on('automake', type='build', when='@master,1.5-head')
-    depends_on('libtool',  type='build', when='@master,1.5-head')
-    depends_on('m4',       type='build', when='@master,1.5-head')
+    depends_on('autoconf', type='build', when='@master,1.5-stable')
+    depends_on('automake', type='build', when='@master,1.5-stable')
+    depends_on('libtool',  type='build', when='@master,1.5-stable')
+    depends_on('m4',       type='build', when='@master,1.5-stable')
 
     depends_on('xz', type='link', when='+xz')
     depends_on('zlib', type='link', when='+zlib')


### PR DESCRIPTION
Rename libunwind 1.5-head to 1.5-stable.

----------

I grep'd packages to find which other packages use version name
'stable' and found these with their maintainers.

hipsycl   [@nazavode]
hpx       [@msimberg, @albestro, @teonnik]
legion    [@pmccormick, @streichler]
neovim    [@albestro]
votca-*   [@junghans]

Anyone have a problem with this change?

Note that this will move the version higher in the order, probably
to where you really want it.

I also checked that no other package asks for libunwind 1.5-head.

Also, gasnet [@PHHargrove, @bonachea] uses version name 'main' for
branch stable, probably for the same reason that used 'head' for
libunwind, to get the order right.  Would you like to change that to
'stable'?