### PR TITLE
flit: Add version for development branch

### DIFF
--- a/var/spack/repos/builtin/packages/flit/package.py
+++ b/var/spack/repos/builtin/packages/flit/package.py
@@ -15,9 +15,11 @@ class Flit(MakefilePackage):
     homepage = "https://pruners.github.io/flit"
     url      = "https://github.com/PRUNERS/FLiT"
     url      = "https://github.com/PRUNERS/FLiT/archive/v2.1.0.tar.gz"
+    git      = "https://github.com/PRUNERS/FLiT.git"
 
     tags = ['e4s']
 
+    version('develop', branch='devel')
     version('2.1.0', sha256='b31ffa02fda1ab0f5555acdc6edc353d93d53ae8ef85e099f83bcf1c83e70885')
 
     maintainers = ['mikebentley15']


### PR DESCRIPTION
This is needed to better support active CI efforts in the ECP Software Development Tools SDK.