### PR TITLE
Add `spack bootstrap dependencies`

### DIFF
--- a/lib/spack/spack/test/cmd/bootstrap.py
+++ b/lib/spack/spack/test/cmd/bootstrap.py
@@ -13,6 +13,11 @@ import spack.main
 _bootstrap = spack.main.SpackCommand('bootstrap')
 
 
+def test_dependencies(no_compilers_yaml):
+    output = _bootstrap('dependencies')
+    assert 'clingo-bootstrap@spack' in output
+
+
 @pytest.mark.parametrize('scope', [
     None, 'site', 'system', 'user'
 ])

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -434,7 +434,7 @@ _spack_bootstrap() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="status enable disable reset root list trust untrust"
+        SPACK_COMPREPLY="status enable disable dependencies reset root list trust untrust"
     fi
 }
 
@@ -448,6 +448,10 @@ _spack_bootstrap_enable() {
 
 _spack_bootstrap_disable() {
     SPACK_COMPREPLY="-h --help --scope"
+}
+
+_spack_bootstrap_dependencies() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_bootstrap_reset() {


### PR DESCRIPTION
This PR adds the command `spack bootstrap dependencies` which prints the dependency of clingo-bootstrap such that the list can be passed to `spack mirror create` with the help of, e.g., `xargs`.

This command simplifies bootstrapping Spack on computers with restricted internet access with the following steps:

1. Untrust `github-actions` on the machine with restricted internet acces to avoid unnecessary waiting.
2. Have `spack bootstrap dependencies` print a machine-readable list of dependencies on the machine with restricted internet acces.
3. Copy-and-paste the output into `spack mirror create` on a machine with internet access.
4. Upload the Spack cache with scp to the machine with restricted internet access.
5. Run `spack spec zlib` on the machine with restricted internet access.

closes #28540
