### PR TITLE
AMReX: +tiny_profile

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -78,6 +78,8 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
             description='Build particle classes')
     variant('plotfile_tools', default=False,
             description='Build plotfile_tools like fcompare')
+    variant('tiny_profile', default=False,
+            description='Enable tiny profiling')
     variant('hdf5',  default=False,
             description='Enable HDF5-based I/O')
     variant('hypre', default=False,
@@ -187,6 +189,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant('AMReX_AMRDATA', 'amrdata'),
             self.define_from_variant('AMReX_PARTICLES', 'particles'),
             self.define_from_variant('AMReX_PLOTFILE_TOOLS', 'plotfile_tools'),
+            self.define_from_variant('AMReX_TINY_PROFILE', 'tiny_profile'),
             self.define_from_variant('AMReX_HDF5', 'hdf5'),
             self.define_from_variant('AMReX_HYPRE', 'hypre'),
             self.define_from_variant('AMReX_PETSC', 'petsc'),

--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -19,7 +19,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
 
     tags = ['ecp', 'e4s']
 
-    maintainers = ['WeiqunZhang', 'asalmgren']
+    maintainers = ['WeiqunZhang', 'asalmgren', 'etpalmer63']
 
     version('develop', branch='development')
     version('22.02', sha256='5d8dd3fa3c416b04e70188e06b7e8fc2838d78b43a2cf33a285184c77f0c1e1e')


### PR DESCRIPTION
The tiny profiler options in AMReX are by default off but needed by WarpX. Adds a new variant to control it.