### PR TITLE
libiberty: Add versions 2.34.1 to 2.37

### DIFF
--- a/var/spack/repos/builtin/packages/libiberty/package.py
+++ b/var/spack/repos/builtin/packages/libiberty/package.py
@@ -19,6 +19,13 @@ class Libiberty(AutotoolsPackage, GNUMirrorPackage):
     gnu_mirror_path = "binutils/binutils-2.31.1.tar.xz"
     maintainers = ['mwkrentel']
 
+    version('2.37',   sha256='820d9724f020a3e69cb337893a0b63c2db161dadcb0e06fc11dc29eb1e84a32c')
+    version('2.36.1', sha256='e81d9edf373f193af428a0f256674aea62a9d74dfe93f65192d4eae030b0f3b0')
+    version('2.36',   sha256='5788292cc5bbcca0848545af05986f6b17058b105be59e99ba7d0f9eb5336fb8')
+    version('2.35.2', sha256='dcd5b0416e7b0a9b24bed76cd8c6c132526805761863150a26d016415b8bdc7b')
+    version('2.35.1', sha256='3ced91db9bf01182b7e420eab68039f2083aed0a214c0424e257eae3ddee8607')
+    version('2.35',   sha256='1b11659fb49e20e18db460d44485f09442c8c56d5df165de9461eb09c8302f85')
+    version('2.34',   sha256='f00b0e8803dc9bab1e2165bd568528135be734df3fabf8d0161828cd56028952')
     version('2.33.1', sha256='ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf')
     version('2.32',   sha256='0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04')
     version('2.31.1', sha256='5d20086ecf5752cc7d9134246e9588fa201740d540f7eb84d795b1f7a93bca86')


### PR DESCRIPTION
@alalazo @mwkrentel I definitely think this should be its own package as we don't want to force users to install all of binutils to get access to libiberty. However, this package has drifted away from the binutils one. Aside from adding a comment, is there a way we can make sure they stay synchronized?