### PR TITLE
github: add default value for spack spec and error message

### DIFF
--- a/.github/ISSUE_TEMPLATE/build_error.yml
+++ b/.github/ISSUE_TEMPLATE/build_error.yml
@@ -16,19 +16,29 @@ body:
     attributes:
       label: Steps to reproduce the issue
       description: |
-        Fill in the exact spec you are trying to build and the relevant part of the error message
-      placeholder: |
+        Fill in the console output from the exact spec you are trying to build.
+      value: |
         ```console
-        $ spack install <spec>
+        $ spack spec -I <spec>
         ...
         ```
+  - type: textarea
+    id: error
+    attributes:
+      label: Error message
+      description: |
+        Please post the error message from spack inside the `<details>` tag below:
+      value: |
+        <details><summary>Error message</summary><pre>
+        ...
+        </pre></details>
     validations:
       required: true
   - type: textarea
     id: information
     attributes:
       label: Information on your system
-      description: Please include the output of `spack debug report`
+      description: Please include the output of `spack debug report`.
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
Usually people don't post the actual package spec when reporting build errors. The spec often includes critical clues to debugging: such as whether a dependency was an external, what system and compiler are being used, what variants have been selected due to environment and user preferences.

This adds default values for users to fill in for the output, since currently those are displayed as "placeholders" rather than "values". (This may be a recent change on github's part due to the issue template feature being in beta.):
<img width="851" alt="Screen Shot 2022-02-05 at 16 55 09" src="https://user-images.githubusercontent.com/741229/152660406-9ad86c15-6c83-4d87-981e-fc6a997217b7.png">

I don't think I can test this on the issue template on this branch, unless one of the higher-level admins can help?