### PR TITLE
ffmpeg: libx264 variant, fix license variants.

### DIFF
--- a/var/spack/repos/builtin/packages/ffmpeg/package.py
+++ b/var/spack/repos/builtin/packages/ffmpeg/package.py
@@ -65,6 +65,7 @@ class Ffmpeg(AutotoolsPackage):
     variant('openssl', default=False, description='needed for https support')
     variant('sdl2', default=False, description='sdl2 support')
     variant('shared', default=True, description='build shared libraries')
+    variant('libx264', default=False, description='H.264 encoding')
 
     depends_on('alsa-lib', when='platform=linux')
     depends_on('libiconv')
@@ -92,6 +93,7 @@ class Ffmpeg(AutotoolsPackage):
     depends_on('snappy', when='+libsnappy')
     depends_on('speex', when='+libspeex')
     depends_on('xz', when='+lzma')
+    depends_on('x264', when='+libx264')
 
     # TODO: enable when libxml2 header issue is resolved
     # conflicts('+libxml2', when='@:3')
@@ -162,15 +164,19 @@ class Ffmpeg(AutotoolsPackage):
 
         variant_opts = [
             'bzlib',
+            'gpl',
             'libmp3lame',
             'libopenjpeg',
             'libopus',
             'libspeex',
             'libvorbis',
             'libvpx',
+            'libx264',
             'avresample',
+            'nonfree',
             'openssl',
             'shared',
+            'version3',
         ]
 
         if spec.satisfies('@2.0:'):

--- a/var/spack/repos/builtin/packages/x264/package.py
+++ b/var/spack/repos/builtin/packages/x264/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.directives import depends_on, version
+
+
+class X264(AutotoolsPackage):
+    """Software library and application for encoding video streams"""
+
+    homepage = "https://www.videolan.org/developers/x264.html"
+    git = "https://code.videolan.org/videolan/x264.git"
+
+    version("20210613", commit="5db6aa6cab1b146e07b60cc1736a01f21da01154")
+
+    depends_on("nasm")
+
+    def configure_args(self):
+        return ["--enable-shared", "--enable-pic"]


### PR DESCRIPTION
Prior to this patch, setting `+gpl` did not pass `--enable-gpl` and did not allow GPL-only codecs to be enabled.