### PR TITLE
Tests: Move has_test_method from test command to package module

### DIFF
--- a/lib/spack/spack/cmd/test.py
+++ b/lib/spack/spack/cmd/test.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 
 import argparse
 import fnmatch
-import inspect
 import os
 import re
 import shutil
@@ -207,24 +206,13 @@ environment variables:
                    fail_first=args.fail_first)
 
 
-def has_test_method(pkg):
-    if not inspect.isclass(pkg):
-        tty.die('{0}: is not a class, it is {1}'.format(pkg, type(pkg)))
-
-    pkg_base = spack.package.PackageBase
-    return (
-        (issubclass(pkg, pkg_base) and pkg.test != pkg_base.test) or
-        (isinstance(pkg, pkg_base) and pkg.test.__func__ != pkg_base.test)
-    )
-
-
 def test_list(args):
     """List installed packages with available tests."""
     tagged = set(spack.repo.path.packages_with_tags(*args.tag)) if args.tag \
         else set()
 
     def has_test_and_tags(pkg_class):
-        return has_test_method(pkg_class) and \
+        return spack.package.has_test_method(pkg_class) and \
             (not args.tag or pkg_class.name in tagged)
 
     if args.list_all:

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2618,6 +2618,17 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 fn()
 
 
+def has_test_method(pkg):
+    """Returns True if the package defines its own stand-alone test method."""
+    if not inspect.isclass(pkg):
+        tty.die('{0}: is not a class, it is {1}'.format(pkg, type(pkg)))
+
+    return (
+        (issubclass(pkg, PackageBase) and pkg.test != PackageBase.test) or
+        (isinstance(pkg, PackageBase) and pkg.test.__func__ != PackageBase.test)
+    )
+
+
 def test_process(pkg, kwargs):
     with tty.log.log_output(pkg.test_log_file) as logger:
         with logger.force_echo():

--- a/lib/spack/spack/test/cmd/test.py
+++ b/lib/spack/spack/test/cmd/test.py
@@ -12,7 +12,6 @@ import spack.cmd.install
 import spack.config
 import spack.package
 import spack.store
-from spack.cmd.test import has_test_method
 from spack.main import SpackCommand
 
 install = SpackCommand('install')
@@ -224,14 +223,6 @@ def test_test_list(
     install(pkg_with_tests)
     output = spack_test("list")
     assert pkg_with_tests in output
-
-
-def test_has_test_method_fails(capsys):
-    with pytest.raises(SystemExit):
-        has_test_method('printing-package')
-
-    captured = capsys.readouterr()[1]
-    assert 'is not a class' in captured
 
 
 def test_hash_change(mock_test_stage, mock_packages, mock_archive, mock_fetch,

--- a/lib/spack/spack/test/packages.py
+++ b/lib/spack/spack/test/packages.py
@@ -373,3 +373,11 @@ def test_fetch_options(mock_packages, config):
     assert isinstance(fetcher, spack.fetch_strategy.URLFetchStrategy)
     assert fetcher.digest == '00000000000000000000000000000012'
     assert fetcher.extra_options == {'cookie': 'baz'}
+
+
+def test_has_test_method_fails(capsys):
+    with pytest.raises(SystemExit):
+        spack.package.has_test_method('printing-package')
+
+    captured = capsys.readouterr()[1]
+    assert 'is not a class' in captured


### PR DESCRIPTION
The `has_test_method` checks a package for having a stand-alone test method defined.  It belongs with the package, not the `test` subcommand.  There are some pending PRs that would benefit from having the method in the core, and not command, modules.

This PR moves the method and an associated unit test to a more visible module.