### PR TITLE
assimp: new version 5.2.1

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -17,6 +17,7 @@ class Assimp(CMakePackage):
     maintainers = ['wdconinc']
 
     version('master', branch='master')
+    version('5.2.1', sha256='c9cbbc8589639cd8c13f65e94a90422a70454e8fa150cf899b6038ba86e9ecff')
     version('5.1.4', sha256='bd32cdc27e1f8b7ac09d914ab92dd81d799c97e9e47315c1f40dcb7c6f7938c6')
     version('5.1.3', sha256='50a7bd2c8009945e1833c591d16f4f7c491a3c6190f69d9d007167aadb175c35')
     version('5.0.1', sha256='11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc')


### PR DESCRIPTION
No build system changes.

Version 5.2.0 is not included since it didn't follow the version url convention (https://github.com/assimp/assimp/issues/4357). Now that a newer bugfix version is available, there seems on reason to introduce an url_for_version for just a single older version.

```console
==> Installing assimp-5.2.1-awd5mjcg4b7qyph5rjppqx7xzrwrsdz4
==> No binary for assimp-5.2.1-awd5mjcg4b7qyph5rjppqx7xzrwrsdz4 found: installing from source
==> Fetching https://github.com/assimp/assimp/archive/v5.2.1.tar.gz
==> No patches needed for assimp
==> assimp: Executing phase: 'cmake'
==> assimp: Executing phase: 'build'
==> assimp: Executing phase: 'install'
==> assimp: Successfully installed assimp-5.2.1-awd5mjcg4b7qyph5rjppqx7xzrwrsdz4
  Fetch: 8.65s.  Build: 3m 12.78s.  Total: 3m 21.43s.
[+] /opt/software/linux-ubuntu21.10-skylake/gcc-11.2.0/assimp-5.2.1-awd5mjcg4b7qyph5rjppqx7xzrwrsdz4
```