### PR TITLE
e4s: new specs: nccmp, nco, wannier90, lammps

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -138,6 +138,7 @@ spack:
     - hypre
     - kokkos +openmp
     - kokkos-kernels +openmp
+    - lammps
     - legion
     - libnrm
     - libquo
@@ -149,6 +150,8 @@ spack:
     - mfem
     - mpark-variant
     - mpifileutils ~xattr
+    - nccmp
+    - nco
     - ninja
     - nrm
     - omega-h
@@ -193,6 +196,7 @@ spack:
     - upcxx
     - variorum
     - veloc
+    - wannier90
     - zfp
     #- dealii
     #- geopm


### PR DESCRIPTION
E4S CI: Add specs:
* nccmp
* nco
* wannier90
* lammps

@wspear @sameershende @scottwittenburg 