### PR TITLE
core: fix CMakePackage.define for libs/headers

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -10,6 +10,8 @@ import platform
 import re
 from typing import List  # novm
 
+import six
+
 from llnl.util.compat import Sequence
 from llnl.util.filesystem import working_dir
 
@@ -223,7 +225,7 @@ class CMakePackage(PackageBase):
             value = "ON" if value else "OFF"
         else:
             kind = 'STRING'
-            if isinstance(value, Sequence) and not isinstance(value, str):
+            if isinstance(value, Sequence) and not isinstance(value, six.string_types):
                 value = ";".join(str(v) for v in value)
             else:
                 value = str(value)

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -10,6 +10,7 @@ import platform
 import re
 from typing import List  # novm
 
+from llnl.util.compat import Sequence
 from llnl.util.filesystem import working_dir
 
 import spack.build_environment
@@ -222,7 +223,7 @@ class CMakePackage(PackageBase):
             value = "ON" if value else "OFF"
         else:
             kind = 'STRING'
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, Sequence) and not isinstance(value, str):
                 value = ";".join(str(v) for v in value)
             else:
                 value = str(value)

--- a/lib/spack/spack/test/build_systems.py
+++ b/lib/spack/spack/test/build_systems.py
@@ -313,6 +313,9 @@ class TestCMakePackage(object):
             arg = pkg.define('MULTI', cls(['right', 'up']))
             assert arg == '-DMULTI:STRING=right;up'
 
+        arg = pkg.define('MULTI', fs.FileList(['/foo', '/bar']))
+        assert arg == '-DMULTI:STRING=/foo;/bar'
+
         arg = pkg.define('ENABLE_TRUTH', False)
         assert arg == '-DENABLE_TRUTH:BOOL=OFF'
         arg = pkg.define('ENABLE_TRUTH', True)


### PR DESCRIPTION
The 'libs' property returned by a spec is not a list nor tuple. Closes #28836.