### PR TITLE
[rocm-smi-lib] Disable pdf generation with a patch

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-smi-lib/disable_pdf_generation_with_doxygen_and_latex.patch
+++ b/var/spack/repos/builtin/packages/rocm-smi-lib/disable_pdf_generation_with_doxygen_and_latex.patch
@@ -1,0 +1,69 @@
+diff --git a/rocm_smi/CMakeLists.txt b/rocm_smi/CMakeLists.txt
+index 90cad13..c398b3c 100755
+--- a/rocm_smi/CMakeLists.txt
++++ b/rocm_smi/CMakeLists.txt
+@@ -140,34 +140,34 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bindings_link
+ 
+ 
+ # Generate Doxygen documentation
+-find_package(Doxygen)
+-find_package(LATEX COMPONENTS PDFLATEX)
+-
+-if (DOXYGEN_FOUND AND LATEX_FOUND)
+-  set (RSMI_MANUAL_NAME "ROCm_SMI_Manual")
+-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
+-                                   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+-
+-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
+-        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
+-                "${COMMON_INC_DIR}/rocm_smi.h"
+-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
+-         COMMAND make  > /dev/null
+-         COMMAND cp  ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
+-                  ${CMAKE_CURRENT_SOURCE_DIR}/docs/${RSMI_MANUAL_NAME}_new.pdf
+-         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
+-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex)
+-
+-  add_custom_target(docs DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf)
+-
+-  add_dependencies(${ROCM_SMI_TARGET} docs)
+-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
+-                         DESTINATION ${ROCM_SMI}/docs/${RSMI_MANUAL_NAME}.pdf)
+-  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../README.md
+-                          DESTINATION ${ROCM_SMI}/docs/)
+-else()
+-  message("Doxygen or Latex is not found. Will not generate documents.")
+-endif(DOXYGEN_FOUND AND LATEX_FOUND)
++#find_package(Doxygen)
++#find_package(LATEX COMPONENTS PDFLATEX)
++#
++#if (DOXYGEN_FOUND AND LATEX_FOUND)
++#  set (RSMI_MANUAL_NAME "ROCm_SMI_Manual")
++#  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
++#                                   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
++#
++#  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
++#        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
++#        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
++#                "${COMMON_INC_DIR}/rocm_smi.h"
++#         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
++#  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
++#         COMMAND make  > /dev/null
++#         COMMAND cp  ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
++#                  ${CMAKE_CURRENT_SOURCE_DIR}/docs/${RSMI_MANUAL_NAME}_new.pdf
++#         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
++#         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex)
++#
++#  add_custom_target(docs DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf)
++#
++#  add_dependencies(${ROCM_SMI_TARGET} docs)
++#  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
++#                         DESTINATION ${ROCM_SMI}/docs/${RSMI_MANUAL_NAME}.pdf)
++#  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../README.md
++#                          DESTINATION ${ROCM_SMI}/docs/)
++#else()
++#  message("Doxygen or Latex is not found. Will not generate documents.")
++#endif(DOXYGEN_FOUND AND LATEX_FOUND)
+ 

--- a/var/spack/repos/builtin/packages/rocm-smi-lib/disable_pdf_generation_with_doxygen_and_latex.patch
+++ b/var/spack/repos/builtin/packages/rocm-smi-lib/disable_pdf_generation_with_doxygen_and_latex.patch
@@ -1,69 +1,15 @@
 diff --git a/rocm_smi/CMakeLists.txt b/rocm_smi/CMakeLists.txt
-index 90cad13..c398b3c 100755
+index 90cad13..02ea897 100755
 --- a/rocm_smi/CMakeLists.txt
 +++ b/rocm_smi/CMakeLists.txt
-@@ -140,34 +140,34 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bindings_link
+@@ -140,8 +140,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bindings_link
  
  
  # Generate Doxygen documentation
 -find_package(Doxygen)
 -find_package(LATEX COMPONENTS PDFLATEX)
--
--if (DOXYGEN_FOUND AND LATEX_FOUND)
--  set (RSMI_MANUAL_NAME "ROCm_SMI_Manual")
--  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
--                                   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
--
--  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
--        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
--        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
--                "${COMMON_INC_DIR}/rocm_smi.h"
--         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
--  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
--         COMMAND make  > /dev/null
--         COMMAND cp  ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
--                  ${CMAKE_CURRENT_SOURCE_DIR}/docs/${RSMI_MANUAL_NAME}_new.pdf
--         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
--         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex)
--
--  add_custom_target(docs DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf)
--
--  add_dependencies(${ROCM_SMI_TARGET} docs)
--  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
--                         DESTINATION ${ROCM_SMI}/docs/${RSMI_MANUAL_NAME}.pdf)
--  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../README.md
--                          DESTINATION ${ROCM_SMI}/docs/)
--else()
--  message("Doxygen or Latex is not found. Will not generate documents.")
--endif(DOXYGEN_FOUND AND LATEX_FOUND)
 +#find_package(Doxygen)
 +#find_package(LATEX COMPONENTS PDFLATEX)
-+#
-+#if (DOXYGEN_FOUND AND LATEX_FOUND)
-+#  set (RSMI_MANUAL_NAME "ROCm_SMI_Manual")
-+#  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
-+#                                   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-+#
-+#  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
-+#        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-+#        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/docs/amd_smi_doxygen.cfg
-+#                "${COMMON_INC_DIR}/rocm_smi.h"
-+#         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-+#  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
-+#         COMMAND make  > /dev/null
-+#         COMMAND cp  ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
-+#                  ${CMAKE_CURRENT_SOURCE_DIR}/docs/${RSMI_MANUAL_NAME}_new.pdf
-+#         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.tex
-+#         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex)
-+#
-+#  add_custom_target(docs DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf)
-+#
-+#  add_dependencies(${ROCM_SMI_TARGET} docs)
-+#  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf
-+#                         DESTINATION ${ROCM_SMI}/docs/${RSMI_MANUAL_NAME}.pdf)
-+#  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../README.md
-+#                          DESTINATION ${ROCM_SMI}/docs/)
-+#else()
-+#  message("Doxygen or Latex is not found. Will not generate documents.")
-+#endif(DOXYGEN_FOUND AND LATEX_FOUND)
  
+ if (DOXYGEN_FOUND AND LATEX_FOUND)
+   set (RSMI_MANUAL_NAME "ROCm_SMI_Manual")

--- a/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
+++ b/var/spack/repos/builtin/packages/rocm-smi-lib/package.py
@@ -40,6 +40,8 @@ class RocmSmiLib(CMakePackage):
     depends_on('cmake@3:', type='build')
     depends_on('python@3:', type=('build', 'run'), when='@3.9.0:')
 
+    patch('disable_pdf_generation_with_doxygen_and_latex.patch', when='@4.5.2:')
+
     def cmake_args(self):
         return [
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared')


### PR DESCRIPTION
- Installation often hangs building the documentation. This happens when
  doxygen and latex are found. To avoid the issue, comment-out that part
  of the code until an explicit cmake variable to disable documentation
  generation is available.