### PR TITLE
Add patch to install missing header in APEX

### DIFF
--- a/var/spack/repos/builtin/packages/apex/install-includes.patch
+++ b/var/spack/repos/builtin/packages/apex/install-includes.patch
@@ -1,0 +1,12 @@
+diff --git a/src/apex/CMakeLists.standalone b/src/apex/CMakeLists.standalone
+index 5acfa34..bb43bd5 100644
+--- a/src/apex/CMakeLists.standalone
++++ b/src/apex/CMakeLists.standalone
+@@ -143,6 +143,7 @@ INSTALL(FILES apex.h
+     profiler.hpp
+     task_wrapper.hpp
+     task_identifier.hpp
++    dependency_tree.hpp
+     DESTINATION include)
+ 
+ INSTALL(TARGETS apex RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -71,6 +71,12 @@ class Apex(CMakePackage):
     conflicts('+jemalloc', when='+gperftools')
     conflicts('+plugins', when='~activeharmony')
 
+    # Patches
+
+    # This patch ensures that the missing dependency_tree.hpp header is
+    # installed
+    patch('install-includes.patch', when='@2.3.2:2.4.1')
+
     def cmake_args(self):
         args = []
         spec = self.spec


### PR DESCRIPTION
This makes sure the `dependency_tree.hpp` header is installed (required from 2.3.2 onwards).