### PR TITLE
ASP-based solver: reduce input facts and add heuristic

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1405,9 +1405,12 @@ class SpackSolverSetup(object):
             for target in supported:
                 best_targets.add(target.name)
                 self.gen.fact(fn.compiler_supports_target(
-                    compiler.name, compiler.version, target.name))
-                self.gen.fact(fn.compiler_supports_target(
-                    compiler.name, compiler.version, uarch.family.name))
+                    compiler.name, compiler.version, target.name
+                ))
+
+            self.gen.fact(fn.compiler_supports_target(
+                compiler.name, compiler.version, uarch.family.name
+            ))
 
         # add any targets explicitly mentioned in specs
         for spec in specs:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1566,9 +1566,10 @@ class SpackSolverSetup(object):
                 allowed_targets.append(test_target)
             return allowed_targets
 
+        cache = {}
         for target_constraint in sorted(self.target_constraints):
             # Construct the list of allowed targets for this constraint
-            allowed_targets, cache = [], {}
+            allowed_targets = []
             for single_constraint in str(target_constraint).split(','):
                 if single_constraint not in cache:
                     cache[single_constraint] = _all_targets_satisfiying(

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -716,7 +716,7 @@ class SpackSolverSetup(object):
         if str(target) in archspec.cpu.TARGETS:
             return [single_target_fn(spec.name, target)]
 
-        self.target_constraints.add((spec.name, target))
+        self.target_constraints.add(target)
         return [fn.node_target_satisfies(spec.name, target)]
 
     def conflict_rules(self, pkg):
@@ -1217,8 +1217,7 @@ class SpackSolverSetup(object):
                 clauses.append(
                     fn.node_compiler_version_satisfies(
                         spec.name, spec.compiler.name, spec.compiler.versions))
-                self.compiler_version_constraints.add(
-                    (spec.name, spec.compiler))
+                self.compiler_version_constraints.add(spec.compiler)
 
         # compiler flags
         for flag_type, flags in spec.compiler_flags.items():
@@ -1538,9 +1537,7 @@ class SpackSolverSetup(object):
     def define_compiler_version_constraints(self):
         compiler_list = spack.compilers.all_compiler_specs()
         compiler_list = list(sorted(set(compiler_list)))
-        constraints = set(c[1] for c in self.compiler_version_constraints)
-
-        for constraint in sorted(constraints):
+        for constraint in sorted(self.compiler_version_constraints):
             for compiler in compiler_list:
                 if compiler.satisfies(constraint):
                     self.gen.fact(fn.compiler_version_satisfies(
@@ -1569,8 +1566,7 @@ class SpackSolverSetup(object):
                 allowed_targets.append(test_target)
             return allowed_targets
 
-        constraints = set(c[1] for c in self.target_constraints)
-        for target_constraint in sorted(constraints):
+        for target_constraint in sorted(self.target_constraints):
             # Construct the list of allowed targets for this constraint
             allowed_targets, cache = [], {}
             for single_constraint in str(target_constraint).split(','):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -535,10 +535,9 @@ class PyclingoDriver(object):
 
         # Initialize the control object for the solver
         self.control = clingo.Control()
-        self.control.configuration.solve.models = nmodels
-        self.control.configuration.asp.trans_ext = 'all'
-        self.control.configuration.asp.eq = '5'
         self.control.configuration.configuration = 'tweety'
+        self.control.configuration.solve.models = nmodels
+        self.control.configuration.solver.heuristic = 'Domain'
         self.control.configuration.solve.parallel_mode = '1'
         self.control.configuration.solver.opt_strategy = "usc,one"
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1571,11 +1571,10 @@ class SpackSolverSetup(object):
                 allowed_targets.append(test_target)
             return allowed_targets
 
-        cache = {}
-        for spec_name, target_constraint in sorted(self.target_constraints):
-
+        constraints = set(c[1] for c in self.target_constraints)
+        for target_constraint in sorted(constraints):
             # Construct the list of allowed targets for this constraint
-            allowed_targets = []
+            allowed_targets, cache = [], {}
             for single_constraint in str(target_constraint).split(','):
                 if single_constraint not in cache:
                     cache[single_constraint] = _all_targets_satisfiying(
@@ -1584,11 +1583,7 @@ class SpackSolverSetup(object):
                 allowed_targets.extend(cache[single_constraint])
 
             for target in allowed_targets:
-                self.gen.fact(
-                    fn.node_target_satisfies(
-                        spec_name, target_constraint, target
-                    )
-                )
+                self.gen.fact(fn.target_satisfies(target_constraint, target))
             self.gen.newline()
 
     def define_variant_values(self):

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1536,18 +1536,14 @@ class SpackSolverSetup(object):
     def define_compiler_version_constraints(self):
         compiler_list = spack.compilers.all_compiler_specs()
         compiler_list = list(sorted(set(compiler_list)))
+        constraints = set(c[1] for c in self.compiler_version_constraints)
 
-        for pkg_name, cspec in self.compiler_version_constraints:
+        for constraint in sorted(constraints):
             for compiler in compiler_list:
-                if compiler.satisfies(cspec):
-                    self.gen.fact(
-                        fn.node_compiler_version_satisfies(
-                            pkg_name,
-                            cspec.name,
-                            cspec.versions,
-                            compiler.version
-                        )
-                    )
+                if compiler.satisfies(constraint):
+                    self.gen.fact(fn.compiler_version_satisfies(
+                        constraint.name, constraint.versions, compiler.version
+                    ))
         self.gen.newline()
 
     def define_target_constraints(self):

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -15,7 +15,7 @@
 :- not 1 { version(Package, _) } 1, node(Package).
 
 % each node must have a single platform, os and target
-:- not 1 { node_platform(Package, _) } 1, node(Package).
+:- not 1 { node_platform(Package, _) } 1, node(Package), error("A node must have exactly one platform").
 :- not 1 { node_os(Package, _) } 1, node(Package).
 :- not 1 { node_target(Package, _) } 1, node(Package).
 
@@ -34,7 +34,7 @@ version_declared(Package, Version, Weight) :- version_declared(Package, Version,
 % We can't emit the same version **with the same weight** from two different sources
 :- version_declared(Package, Version, Weight, Origin1),
    version_declared(Package, Version, Weight, Origin2),
-   Origin1 != Origin2,
+   Origin1 < Origin2,
    error("Internal error: two versions with identical weights").
 
 % versions are declared w/priority -- declared with priority implies declared
@@ -450,7 +450,7 @@ variant_set(Package, Variant) :- variant_set(Package, Variant, _).
    variant_value(Package, Variant, Value2),
    variant_value_from_disjoint_sets(Package, Variant, Value1, Set1),
    variant_value_from_disjoint_sets(Package, Variant, Value2, Set2),
-   Set1 != Set2,
+   Set1 < Set2,
    build(Package),
    error("Variant values selected from multiple disjoint sets").
 
@@ -545,9 +545,6 @@ variant_single_value(Package, "dev_path")
 %-----------------------------------------------------------------------------
 % Platform semantics
 %-----------------------------------------------------------------------------
-
-% one platform per node
-:- M = #count { Platform : node_platform(Package, Platform) }, M !=1, node(Package), error("A node must have exactly one platform").
 
 % if no platform is set, fall back to the default
 node_platform(Package, Platform)

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -708,20 +708,21 @@ node_compiler(Package, Compiler) :- node_compiler_version(Package, Compiler, _).
    Compiler1 != Compiler2,
    error("Internal error: mismatch between selected compiler and compiler version").
 
-% define node_compiler_version_satisfies/3 from node_compiler_version_satisfies/4
-% version_satisfies implies that exactly one of the satisfying versions
-% is the package's version, and vice versa.
+% If the compiler of a node must satisfy a constraint, then its version
+% must be chosen among the ones that satisfy said constraint
 1 { node_compiler_version(Package, Compiler, Version)
-    : node_compiler_version_satisfies(Package, Compiler, Constraint, Version) } 1 :-
+    : compiler_version_satisfies(Compiler, Constraint, Version) } 1 :-
     node_compiler_version_satisfies(Package, Compiler, Constraint),
     error("Internal error: node compiler version mismatch").
 
+% If the node is associated with a compiler and the compiler satisfy a constraint, then
+% the compiler associated with the node satisfy the same constraint
 node_compiler_version_satisfies(Package, Compiler, Constraint)
   :- node_compiler_version(Package, Compiler, Version),
-     node_compiler_version_satisfies(Package, Compiler, Constraint, Version),
+     compiler_version_satisfies(Compiler, Constraint, Version),
      build(Package).
 
-#defined node_compiler_version_satisfies/4.
+#defined compiler_version_satisfies/3.
 
 % If the compiler version was set from the command line,
 % respect it verbatim

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -614,15 +614,21 @@ node_os(Package, OS) :- node_os_set(Package, OS), node(Package).
 %-----------------------------------------------------------------------------
 % Target semantics
 %-----------------------------------------------------------------------------
-% one target per node -- optimization will pick the "best" one
+
+% Each node has only one target chosen among the known targets
 1 { node_target(Package, Target) : target(Target) } 1 :- node(Package), error("Each node must have exactly one target").
 
-% node_target_satisfies semantics
-1 { node_target(Package, Target) : node_target_satisfies(Package, Constraint, Target) } 1
+% If a node must satisfy a target constraint the choice is reduced among the targets
+% that satisfy that constraint
+1 { node_target(Package, Target) : target_satisfies(Constraint, Target) } 1
   :- node_target_satisfies(Package, Constraint), error("Each node must have exactly one target").
+
+% If a node has a target and the target satisfies a constraint, then the target
+% associated with the node satisfies the same constraint
 node_target_satisfies(Package, Constraint)
-  :- node_target(Package, Target), node_target_satisfies(Package, Constraint, Target).
-#defined node_target_satisfies/3.
+  :- node_target(Package, Target), target_satisfies(Constraint, Target).
+
+#defined target_satisfies/2.
 
 % The target weight is either the default target weight
 % or a more specific per-package weight if set

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1021,3 +1021,14 @@ opt_criterion(1, "non-preferred targets").
     : node_target_weight(Package, Weight),
       build_priority(Package, Priority)
 }.
+
+%-----------------
+% Domain heuristic
+%-----------------
+#heuristic version(Package, Version) : version_declared(Package, Version, 0), node(Package). [10, true]
+#heuristic version_weight(Package, 0) : version_declared(Package, Version, 0), node(Package). [10, true]
+#heuristic node_target(Package, Target) : default_target_weight(Target, 0), node(Package). [10, true]
+#heuristic node_target_weight(Package, 0) : node(Package). [10, true]
+#heuristic variant_value(Package, Variant, Value) : variant_default_value(Package, Variant, Value), node(Package). [10, true]
+#heuristic provider(Package, Virtual) : possible_provider_weight(Package, Virtual, 0, _), virtual_node(Virtual). [10, true]
+#heuristic node(Package) : possible_provider_weight(Package, Virtual, 0, _), virtual_node(Virtual). [10, true]


### PR DESCRIPTION
This PR tries to optimize the solve time for `clingo` by introducing domain heuristic. The paper discussing heuristic in clingo can be found [here](https://www.cs.uni-potsdam.de/wv/publications/DBLP_conf/aaai/GebserKROSW13.pdf). The use of the options and the directives need to be double checked, since I'm not sure they are as good as they can be.

Nonetheless, this new configuration for solving reduces greatly the number of choices and conflicts needed by the solver to reach an optimal solution. With this PR:

<details>
  <summary>$ spack solve --timers --stats -l hdf5</summary>

```
Time:
    setup:         3.8259
    load:          0.0190
    ground:        1.3420
    solve:         1.9143
Total: 7.1247

Statistics:
{'problem': {'generator': {'acyc_edges': 0.0,
                           'complexity': 1449971.0,
                           'constraints': 101615.0,
                           'constraints_binary': 1085497.0,
                           'constraints_ternary': 260069.0,
                           'vars': 363417.0,
                           'vars_eliminated': 0.0,
                           'vars_frozen': 188707.0},
             'lp': {'atoms': 299403.0,
                    'atoms_aux': 98.0,
                    'bodies': 540790.0,
                    'bodies_tr': 542658.0,
                    'count_bodies': 5016.0,
                    'count_bodies_tr': 937.0,
                    'disjunctions': 0.0,
                    'disjunctions_non_hcf': 0.0,
                    'eqs': 672168.0,
                    'eqs_atom': 75991.0,
                    'eqs_body': 151524.0,
                    'eqs_other': 444653.0,
                    'gammas': 0.0,
                    'rules': 661266.0,
                    'rules_acyc': 0.0,
                    'rules_choice': 10501.0,
                    'rules_heuristic': 2368.0,
                    'rules_minimize': 31.0,
                    'rules_normal': 648366.0,
                    'rules_tr': 714953.0,
                    'rules_tr_acyc': 0.0,
                    'rules_tr_choice': 10501.0,
                    'rules_tr_heuristic': 2355.0,
                    'rules_tr_minimize': 31.0,
                    'rules_tr_normal': 702066.0,
                    'sccs': 1455.0,
                    'sccs_non_hcf': 0.0,
                    'sum_bodies': 0.0,
                    'sum_bodies_tr': 0.0,
                    'ufs_nodes': 103963.0},
             'lpStep': {'atoms': 299403.0,
                        'atoms_aux': 98.0,
                        'bodies': 540790.0,
                        'bodies_tr': 542658.0,
                        'count_bodies': 5016.0,
                        'count_bodies_tr': 937.0,
                        'disjunctions': 0.0,
                        'disjunctions_non_hcf': 0.0,
                        'eqs': 672168.0,
                        'eqs_atom': 75991.0,
                        'eqs_body': 151524.0,
                        'eqs_other': 444653.0,
                        'gammas': 0.0,
                        'rules': 661266.0,
                        'rules_acyc': 0.0,
                        'rules_choice': 10501.0,
                        'rules_heuristic': 2368.0,
                        'rules_minimize': 31.0,
                        'rules_normal': 648366.0,
                        'rules_tr': 714953.0,
                        'rules_tr_acyc': 0.0,
                        'rules_tr_choice': 10501.0,
                        'rules_tr_heuristic': 2355.0,
                        'rules_tr_minimize': 31.0,
                        'rules_tr_normal': 702066.0,
                        'sccs': 1455.0,
                        'sccs_non_hcf': 0.0,
                        'sum_bodies': 0.0,
                        'sum_bodies_tr': 0.0,
                        'ufs_nodes': 103963.0}},
 'solving': {'solvers': {'choices': 1396.0,
                         'conflicts': 21.0,
                         'conflicts_analyzed': 18.0,
                         'restarts': 0.0,
                         'restarts_last': 15.0}},
 'summary': {'call': 0.0,
             'concurrency': 1.0,
             'costs': [0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       3.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0],
             'exhausted': 1.0,
             'lower': [0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       3.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0],
             'models': {'enumerated': 3.0, 'optimal': 1.0},
             'result': 1.0,
             'signal': 0.0,
             'times': {'cpu': 7.100045,
                       'sat': 0.07400894165039062,
                       'solve': 0.36090898513793945,
                       'total': 7.100867986679077,
                       'unsat': 0.02135014533996582},
             'winner': 0.0},
 'user_accu': {},
 'user_step': {}}
==> Best of 3 considered solutions.
==> Optimization Criteria:
  Priority  Criterion                                            Installed  ToBuild
  1         number of packages to build (vs. reuse)                      -        0
  2         deprecated versions used                                     0        0
  3         version weight                                               0        0
  4         number of non-default variants (roots)                       0        0
  5         preferred providers for roots                                0        0
  6         default values of variants not being used (roots)            0        0
  7         number of non-default variants (non-roots)                   0        0
  8         preferred providers (non-roots)                              0        0
  9         compiler mismatches                                          0        0
  10        OS mismatches                                                0        0
  11        non-preferred OS's                                           0        0
  12        version badness                                              0        3
  13        default values of variants not being used (non-roots)        0        0
  14        non-preferred compilers                                      0        0
  15        target mismatches                                            0        0
  16        non-preferred targets                                        0        0

ahqceuw  hdf5@1.12.1%gcc@9.3.0~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-ubuntu20.04-icelake
e32qi6r      ^cmake@3.22.2%gcc@9.3.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=linux-ubuntu20.04-icelake
wevrxpl          ^ncurses@6.2%gcc@9.3.0~symlinks+termlib abi=none arch=linux-ubuntu20.04-icelake
5u2zrji              ^pkgconf@1.8.0%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
spy577h          ^openssl@1.1.1m%gcc@9.3.0~docs certs=system arch=linux-ubuntu20.04-icelake
5fknwft              ^perl@5.34.0%gcc@9.3.0+cpanm+shared+threads arch=linux-ubuntu20.04-icelake
bca2ndl                  ^berkeley-db@18.1.40%gcc@9.3.0+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=linux-ubuntu20.04-icelake
m6msmwh                  ^bzip2@1.0.8%gcc@9.3.0~debug~pic+shared arch=linux-ubuntu20.04-icelake
t3p6jzn                      ^diffutils@3.8%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
ueh6r5u                          ^libiconv@1.16%gcc@9.3.0 libs=shared,static arch=linux-ubuntu20.04-icelake
q5oia5x                  ^gdbm@1.19%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
23mubk3                      ^readline@8.1%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
ech7q6s                  ^zlib@1.2.11%gcc@9.3.0+optimize+pic+shared arch=linux-ubuntu20.04-icelake
lksg534      ^openmpi@4.1.2%gcc@9.3.0~atomics~cuda~cxx~cxx_exceptions+gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi~pmix+romio~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu20.04-icelake
cjbql7h          ^hwloc@2.7.0%gcc@9.3.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml~opencl+pci~rocm+shared arch=linux-ubuntu20.04-icelake
f3ujejk              ^libpciaccess@0.16%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
w2merzt                  ^libtool@2.4.6%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
qal57j2                      ^m4@1.4.19%gcc@9.3.0+sigsegv patches=9dc5fbd0d5cb1037ab1e6d0ecc74a30df218d0a94bdd5a02759a97f62daca573,bfdffa7c2eb01021d5849b36972c069693654ad826c1a20b53534009a4ec7a89 arch=linux-ubuntu20.04-icelake
basfgy2                          ^libsigsegv@2.13%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
rh46vik                  ^util-macros@1.19.3%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
umfo2pm              ^libxml2@2.9.12%gcc@9.3.0~python arch=linux-ubuntu20.04-icelake
essg37l                  ^xz@5.2.5%gcc@9.3.0~pic libs=shared,static arch=linux-ubuntu20.04-icelake
slmazbc          ^libevent@2.1.12%gcc@9.3.0+openssl arch=linux-ubuntu20.04-icelake
2semoyz          ^numactl@2.0.14%gcc@9.3.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,ff37630df599cfabf0740518b91ec8daaf18e8f288b19adaae5364dc1f6b2296 arch=linux-ubuntu20.04-icelake
6ago2g2              ^autoconf@2.69%gcc@9.3.0 patches=35c449281546376449766f92d49fc121ca50e330e60fefcfc9be2af3253082c2,7793209b33013dc0f81208718c68440c5aae80e7a1c4b8d336e382525af791a7,a49dd5bac3b62daa0ff688ab4d508d71dbd2f4f8d7e2a02321926346161bf3ee arch=linux-ubuntu20.04-icelake
7cfs7rx              ^automake@1.16.5%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
l2d3u54          ^openssh@8.8p1%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
7elophq              ^libedit@3.1-20210216%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
```

</details>

while on `develop`:

<details>
  <summary>$ spack solve --timers --stats -l hdf5</summary>

```
Time:
    setup:         3.8822
    load:          0.0193
    ground:        1.2874
    solve:         2.6909
Total: 7.9101

Statistics:
{'problem': {'generator': {'acyc_edges': 0.0,
                           'complexity': 1423677.0,
                           'constraints': 100815.0,
                           'constraints_binary': 1072300.0,
                           'constraints_ternary': 247772.0,
                           'vars': 361420.0,
                           'vars_eliminated': 0.0,
                           'vars_frozen': 186718.0},
             'lp': {'atoms': 288416.0,
                    'atoms_aux': 98.0,
                    'bodies': 519700.0,
                    'bodies_tr': 521973.0,
                    'count_bodies': 4611.0,
                    'count_bodies_tr': 937.0,
                    'disjunctions': 0.0,
                    'disjunctions_non_hcf': 0.0,
                    'eqs': 623357.0,
                    'eqs_atom': 64774.0,
                    'eqs_body': 141497.0,
                    'eqs_other': 417086.0,
                    'gammas': 0.0,
                    'rules': 626152.0,
                    'rules_acyc': 0.0,
                    'rules_choice': 6447.0,
                    'rules_heuristic': 0.0,
                    'rules_minimize': 31.0,
                    'rules_normal': 619674.0,
                    'rules_tr': 669727.0,
                    'rules_tr_acyc': 0.0,
                    'rules_tr_choice': 6447.0,
                    'rules_tr_heuristic': 0.0,
                    'rules_tr_minimize': 31.0,
                    'rules_tr_normal': 663249.0,
                    'sccs': 665.0,
                    'sccs_non_hcf': 0.0,
                    'sum_bodies': 0.0,
                    'sum_bodies_tr': 0.0,
                    'ufs_nodes': 78606.0},
             'lpStep': {'atoms': 288416.0,
                        'atoms_aux': 98.0,
                        'bodies': 519700.0,
                        'bodies_tr': 521973.0,
                        'count_bodies': 4611.0,
                        'count_bodies_tr': 937.0,
                        'disjunctions': 0.0,
                        'disjunctions_non_hcf': 0.0,
                        'eqs': 623357.0,
                        'eqs_atom': 64774.0,
                        'eqs_body': 141497.0,
                        'eqs_other': 417086.0,
                        'gammas': 0.0,
                        'rules': 626152.0,
                        'rules_acyc': 0.0,
                        'rules_choice': 6447.0,
                        'rules_heuristic': 0.0,
                        'rules_minimize': 31.0,
                        'rules_normal': 619674.0,
                        'rules_tr': 669727.0,
                        'rules_tr_acyc': 0.0,
                        'rules_tr_choice': 6447.0,
                        'rules_tr_heuristic': 0.0,
                        'rules_tr_minimize': 31.0,
                        'rules_tr_normal': 663249.0,
                        'sccs': 665.0,
                        'sccs_non_hcf': 0.0,
                        'sum_bodies': 0.0,
                        'sum_bodies_tr': 0.0,
                        'ufs_nodes': 78606.0}},
 'solving': {'solvers': {'choices': 69404.0,
                         'conflicts': 183.0,
                         'conflicts_analyzed': 179.0,
                         'restarts': 1.0,
                         'restarts_last': 0.0}},
 'summary': {'call': 0.0,
             'concurrency': 1.0,
             'costs': [0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       3.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0],
             'exhausted': 1.0,
             'lower': [0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       3.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0,
                       0.0],
             'models': {'enumerated': 9.0, 'optimal': 1.0},
             'result': 1.0,
             'signal': 0.0,
             'times': {'cpu': 7.8792789999999995,
                       'sat': 0.6879580020904541,
                       'solve': 1.0534520149230957,
                       'total': 7.8795530796051025,
                       'unsat': 0.007893085479736328},
             'winner': 0.0},
 'user_accu': {},
 'user_step': {}}
==> Best of 9 considered solutions.
==> Optimization Criteria:
  Priority  Criterion                                            Installed  ToBuild
  1         number of packages to build (vs. reuse)                      -        0
  2         deprecated versions used                                     0        0
  3         version weight                                               0        0
  4         number of non-default variants (roots)                       0        0
  5         preferred providers for roots                                0        0
  6         default values of variants not being used (roots)            0        0
  7         number of non-default variants (non-roots)                   0        0
  8         preferred providers (non-roots)                              0        0
  9         compiler mismatches                                          0        0
  10        OS mismatches                                                0        0
  11        non-preferred OS's                                           0        0
  12        version badness                                              0        3
  13        default values of variants not being used (non-roots)        0        0
  14        non-preferred compilers                                      0        0
  15        target mismatches                                            0        0
  16        non-preferred targets                                        0        0

ahqceuw  hdf5@1.12.1%gcc@9.3.0~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-ubuntu20.04-icelake
e32qi6r      ^cmake@3.22.2%gcc@9.3.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=linux-ubuntu20.04-icelake
wevrxpl          ^ncurses@6.2%gcc@9.3.0~symlinks+termlib abi=none arch=linux-ubuntu20.04-icelake
5u2zrji              ^pkgconf@1.8.0%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
spy577h          ^openssl@1.1.1m%gcc@9.3.0~docs certs=system arch=linux-ubuntu20.04-icelake
5fknwft              ^perl@5.34.0%gcc@9.3.0+cpanm+shared+threads arch=linux-ubuntu20.04-icelake
bca2ndl                  ^berkeley-db@18.1.40%gcc@9.3.0+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=linux-ubuntu20.04-icelake
m6msmwh                  ^bzip2@1.0.8%gcc@9.3.0~debug~pic+shared arch=linux-ubuntu20.04-icelake
t3p6jzn                      ^diffutils@3.8%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
ueh6r5u                          ^libiconv@1.16%gcc@9.3.0 libs=shared,static arch=linux-ubuntu20.04-icelake
q5oia5x                  ^gdbm@1.19%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
23mubk3                      ^readline@8.1%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
ech7q6s                  ^zlib@1.2.11%gcc@9.3.0+optimize+pic+shared arch=linux-ubuntu20.04-icelake
lksg534      ^openmpi@4.1.2%gcc@9.3.0~atomics~cuda~cxx~cxx_exceptions+gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi~pmix+romio~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu20.04-icelake
cjbql7h          ^hwloc@2.7.0%gcc@9.3.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml~opencl+pci~rocm+shared arch=linux-ubuntu20.04-icelake
f3ujejk              ^libpciaccess@0.16%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
w2merzt                  ^libtool@2.4.6%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
qal57j2                      ^m4@1.4.19%gcc@9.3.0+sigsegv patches=9dc5fbd0d5cb1037ab1e6d0ecc74a30df218d0a94bdd5a02759a97f62daca573,bfdffa7c2eb01021d5849b36972c069693654ad826c1a20b53534009a4ec7a89 arch=linux-ubuntu20.04-icelake
basfgy2                          ^libsigsegv@2.13%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
rh46vik                  ^util-macros@1.19.3%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
umfo2pm              ^libxml2@2.9.12%gcc@9.3.0~python arch=linux-ubuntu20.04-icelake
essg37l                  ^xz@5.2.5%gcc@9.3.0~pic libs=shared,static arch=linux-ubuntu20.04-icelake
slmazbc          ^libevent@2.1.12%gcc@9.3.0+openssl arch=linux-ubuntu20.04-icelake
2semoyz          ^numactl@2.0.14%gcc@9.3.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,ff37630df599cfabf0740518b91ec8daaf18e8f288b19adaae5364dc1f6b2296 arch=linux-ubuntu20.04-icelake
6ago2g2              ^autoconf@2.69%gcc@9.3.0 patches=35c449281546376449766f92d49fc121ca50e330e60fefcfc9be2af3253082c2,7793209b33013dc0f81208718c68440c5aae80e7a1c4b8d336e382525af791a7,a49dd5bac3b62daa0ff688ab4d508d71dbd2f4f8d7e2a02321926346161bf3ee arch=linux-ubuntu20.04-icelake
7cfs7rx              ^automake@1.16.5%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
l2d3u54          ^openssh@8.8p1%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
7elophq              ^libedit@3.1-20210216%gcc@9.3.0 arch=linux-ubuntu20.04-icelake
```

</details>

Choices pass from 69404 to 1396 and conflicts from 183 to 21