### PR TITLE
eccodes: update package

### DIFF
--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -82,6 +82,12 @@ class Eccodes(CMakePackage):
             ).with_default('auto'),
             description="List of definitions to install")
 
+    variant('samples',
+            values=disjoint_sets(
+                ('auto',), ('default',),
+            ).with_default('auto'),
+            description="List of samples to install")
+
     depends_on('netcdf-c', when='+netcdf')
     # Cannot be built with openjpeg@2.0.x.
     depends_on('openjpeg@1.5.0:1.5,2.1.0:2.3', when='jp2k=openjpeg')
@@ -316,6 +322,12 @@ class Eccodes(CMakePackage):
         if 'auto' not in definitions:
             args.append(self.define('ENABLE_INSTALL_ECCODES_DEFINITIONS',
                                     'default' in definitions))
+
+        samples = self.spec.variants['samples'].value
+
+        if 'auto' not in samples:
+            args.append(self.define('ENABLE_INSTALL_ECCODES_SAMPLES',
+                                    'default' in samples))
 
         return args
 

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -73,6 +73,11 @@ class Eccodes(CMakePackage):
     # CMAKE_INSTALL_RPATH must be a semicolon-separated list.
     patch('cmake_install_rpath.patch', when='@:2.10')
 
+    # Fix a bug preventing cmake from finding NetCDF:
+    patch('https://github.com/ecmwf/ecbuild/commit/3916c7d22575c45166fcc89edcbe02a6e9b81aa2.patch',
+          sha256='857454528b666c52eb36ef3aa5d40ae018981b44e129bb8df3c2d3d560e3fa03',
+          when='@:2.4.0+netcdf')
+
     @run_before('cmake')
     def check_fortran(self):
         if '+fortran' in self.spec and self.compiler.fc is None:

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -42,6 +42,8 @@ class Eccodes(CMakePackage):
     variant('python', default=False,
             description='Enable the Python 2 interface')
     variant('fortran', default=False, description='Enable the Fortran support')
+    variant('shared', default=True,
+            description='Build shared versions of the libraries')
 
     depends_on('netcdf-c', when='+netcdf')
     # Cannot be built with openjpeg@2.0.x.
@@ -102,6 +104,8 @@ class Eccodes(CMakePackage):
                     '2' if self.spec.satisfies('@2.20.0:') else ''),
                 'python'),
             self.define_from_variant('ENABLE_FORTRAN', 'fortran'),
+            self.define('BUILD_SHARED_LIBS',
+                        'BOTH' if '+shared' in self.spec else 'OFF'),
             self.define('ENABLE_TESTS', self.run_tests),
             # Examples are not installed and are just part of the test suite:
             self.define('ENABLE_EXAMPLES', self.run_tests),

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -55,6 +55,7 @@ class Eccodes(CMakePackage):
     version('2.5.0', sha256='18ab44bc444168fd324d07f7dea94f89e056f5c5cd973e818c8783f952702e4e')
     version('2.2.0', sha256='1a4112196497b8421480e2a0a1164071221e467853486577c4f07627a702f4c3')
 
+    variant('tools', default=False, description='Build the command line tools')
     variant('netcdf', default=False,
             description='Enable GRIB to NetCDF conversion tool')
     variant('jp2k', default='openjpeg', values=('openjpeg', 'jasper', 'none'),
@@ -111,6 +112,14 @@ class Eccodes(CMakePackage):
 
     conflicts('+openmp', when='+pthreads',
               msg='Cannot enable both POSIX threads and OMP')
+
+    conflicts('+netcdf', when='~tools',
+              msg='Cannot enable the NetCDF conversion tool '
+                  'when the command line tools are disabled')
+
+    conflicts('~tools', when='@:2.18.0',
+              msg='The command line tools can be disabled '
+                  'only starting version 2.19.0')
 
     for center, definitions in _definitions.items():
         kwargs = definitions.get('conflicts', None)
@@ -271,6 +280,7 @@ class Eccodes(CMakePackage):
         jp2k = self.spec.variants['jp2k'].value
 
         args = [
+            self.define_from_variant('ENABLE_BUILD_TOOLS', 'tools'),
             self.define_from_variant('ENABLE_NETCDF', 'netcdf'),
             self.define('ENABLE_JPG', jp2k != 'none'),
             self.define('ENABLE_JPG_LIBJASPER', jp2k == 'jasper'),


### PR DESCRIPTION
1. General refactoring using the "new" methods of `CMakePackage`.
2. A patch fixing a `cmake`-time problem with NetCDF location for older versions of `eccodes`.
3. Add variant `shared` (the static libraries, which were never installed before this MR, are now always installed).
4. Enable building of the Fortran interface with NAG compiler.
5. Add property `libs`.
6. Add variants `definitions` and `samples` allowing installation of extra definitions and samples from different weather services.
7. Add variant `tools` (defaults to `False`) to control whether the command line tools should be installed.