### PR TITLE
Updates to add/remove conflicts for Apple silicon (M1/aarch64)

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -35,6 +35,9 @@ class GoBootstrap(Package):
 
     depends_on('git', type=('build', 'link', 'run'))
 
+    conflicts('target=aarch64', when='platform=darwin',
+              msg='Go bootstrap is too old for Apple Silicon')
+
     def patch(self):
         if self.spec.satisfies('@:1.4.3'):
             # NOTE: Older versions of Go attempt to download external files that have

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -35,7 +35,7 @@ class GoBootstrap(Package):
 
     depends_on('git', type=('build', 'link', 'run'))
 
-    conflicts('target=aarch64', when='platform=darwin',
+    conflicts('target=aarch64:', when='platform=darwin',
               msg='Go bootstrap is too old for Apple Silicon')
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
-import platform
 import re
 
 import llnl.util.tty as tty
@@ -128,12 +127,7 @@ class Go(Package):
     provides('golang')
 
     depends_on('git', type=('build', 'link', 'run'))
-    # TODO: Make non-c self-hosting compilers feasible without backflips
-    # should be a dep on external go compiler
-    if platform.machine() == 'aarch64':
-        depends_on('gcc languages=go', type='build')
-    else:
-        depends_on('go-bootstrap', type='build')
+    depends_on('go-bootstrap', type='build')
 
     # https://github.com/golang/go/issues/17545
     patch('time_test.patch', when='@1.6.4:1.7.4')

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -253,6 +253,9 @@ class Python(AutotoolsPackage):
 
     conflicts('%nvhpc')
 
+    conflicts('@:2.7', when='platform=darwin target=aarch64:',
+              msg='Python 2.7 is too old for Apple Silicon')
+
     # Used to cache various attributes that are expensive to compute
     _config_vars = {}
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -250,6 +250,8 @@ class Qt(Package):
     else:
         conflicts('platform=darwin', when='@:4.8.6',
                   msg="QT 4 for macOS is only patched for 4.8.7")
+        conflicts('target=aarch64', when='@:5.15.3',
+                  msg='Apple Silicon requires a very new version of qt')
 
     use_xcode = True
 
@@ -262,7 +264,7 @@ class Qt(Package):
 
     def url_for_version(self, version):
         # URL keeps getting more complicated with every release
-        url = self.list_url.replace('http:', 'https:')
+        url = self.list_url
 
         if version < Version('5.12') and version.up_to(2) != Version('5.9'):
             # As of 28 April 2021:
@@ -715,6 +717,12 @@ class Qt(Package):
                 '-no-pulseaudio',
                 '-no-alsa',
             ])
+
+        if spec.satisfies('platform=darwin target=aarch64'):
+            # https://www.qt.io/blog/qt-on-apple-silicon
+            # Not currently working for qt@5
+            config_args.extend(['-device-option',
+                                'QMAKE_APPLE_DEVICE_ARCHS=arm64'])
 
         configure(*config_args)
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -250,7 +250,7 @@ class Qt(Package):
     else:
         conflicts('platform=darwin', when='@:4.8.6',
                   msg="QT 4 for macOS is only patched for 4.8.7")
-        conflicts('target=aarch64', when='@:5.15.3',
+        conflicts('target=aarch64:', when='@:5.15.3',
                   msg='Apple Silicon requires a very new version of qt')
 
     use_xcode = True
@@ -718,7 +718,7 @@ class Qt(Package):
                 '-no-alsa',
             ])
 
-        if spec.satisfies('platform=darwin target=aarch64'):
+        if spec.satisfies('platform=darwin target=aarch64:'):
             # https://www.qt.io/blog/qt-on-apple-silicon
             # Not currently working for qt@5
             config_args.extend(['-device-option',

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -288,9 +288,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('+stokhos', when='%xl')
     conflicts('+stokhos', when='%xl_r')
 
-    # Fortran mangling fails on Apple M1 (see spack/spack#25900)
-    conflicts('@:13.0.1 +fortran', when='target=m1')
-
     # ###################### Dependencies ##########################
 
     depends_on('adios2', when='+adios2')


### PR DESCRIPTION
- trilinos: remove conflict (see https://github.com/spack/spack/issues/25900)
- qt: add conflict (https://www.qt.io/blog/qt-on-apple-silicon)
- go: remove broken aarch64 support (#16083, #14900, #15509)