### PR TITLE
Bug fix for findutils: apply nonnull.patch only for versions 4.8.0+

### DIFF
--- a/var/spack/repos/builtin/packages/findutils/package.py
+++ b/var/spack/repos/builtin/packages/findutils/package.py
@@ -55,7 +55,7 @@ class Findutils(AutotoolsPackage, GNUMirrorPackage):
     # does not work for GCC on macOS
     # <https://savannah.gnu.org/bugs/?func=detailitem&item_id=59972>; we thus
     # disable this attribute manually
-    patch('nonnull.patch')
+    patch('nonnull.patch', when='@4.8.0:')
 
     build_directory = 'spack-build'
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/28856.