### PR TITLE
llvm-doe: rename @clacc to @develop.clacc for proper version matching

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-doe/package.py
+++ b/var/spack/repos/builtin/packages/llvm-doe/package.py
@@ -32,7 +32,7 @@ class LlvmDoe(CMakePackage, CudaPackage):
     version('doe', branch='doe', preferred=True)
     version('upstream', branch='llvm.org/main')
     version('bolt', branch='bolt/main')
-    version('clacc', branch='clacc/master')
+    version('develop.clacc', branch='clacc/main')
     version('pragma-clang-loop', branch='sollve/pragma-clang-loop')
     version('pragma-omp-tile', branch='sollve/pragma-omp-tile')
     version('13.0.0', branch='llvm.org/llvmorg-13.0.0')


### PR DESCRIPTION
Rename `@clacc` to `@develop.clacc` so that `clacc` builds are considered like `@develop` for the purpose of evaluating `when=` statements

Currently, `llvm-doe@clacc` build fails because various `conflict` statements get erroneously triggered due to Spack considering `@clacc` as a very low version number. Build issues are resolved by changing the version name to `@develop.clacc`

@vlkale @wspear