### PR TITLE
spack audit: fix spurious failures for target/platform conflicts

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -323,7 +323,7 @@ def _unknown_variants_in_directives(pkgs, error_cls):
                 vrn = spack.spec.Spec(conflict)
                 try:
                     vrn.constrain(trigger)
-                except Exception as e:
+                except Exception:
                     # If one of the conflict/trigger includes a platform and the other
                     # includes an os or target, the constraint will fail if the current
                     # platform is not the plataform in the conflict/trigger. Audit the

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -324,9 +324,16 @@ def _unknown_variants_in_directives(pkgs, error_cls):
                 try:
                     vrn.constrain(trigger)
                 except Exception as e:
-                    msg = 'Generic error in conflict for package "{0}": '
-                    errors.append(error_cls(msg.format(pkg.name), [str(e)]))
-                    continue
+                    # If one of the conflict/trigger includes a platform and the other
+                    # includes an os or target, the constraint will fail if the current
+                    # platform is not the plataform in the conflict/trigger. Audit the
+                    # conflict and trigger separately in that case.
+                    # When os and target constraints can be created independently of
+                    # the platform, TODO change this back to add an error.
+                    errors.extend(_analyze_variants_in_directive(
+                        pkg, spack.spec.Spec(trigger),
+                        directive='conflicts', error_cls=error_cls
+                    ))
                 errors.extend(_analyze_variants_in_directive(
                     pkg, vrn, directive='conflicts', error_cls=error_cls
                 ))

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -16,7 +16,10 @@ import spack.config
     # The package use a non existing variant in a depends_on directive
     (['wrong-variant-in-depends-on'], 'PKG-DIRECTIVES'),
     # This package has no issues
-    (['mpileaks'], None)
+    (['mpileaks'], None),
+    # This package has a conflict with a trigger which cannot constrain the constraint
+    # Should not raise an error
+    (['unconstrainable-conflict'], None),
 ])
 def test_package_audits(packages, failing_check, mock_packages):
     reports = spack.audit.run_group('packages', pkgs=packages)

--- a/var/spack/repos/builtin.mock/packages/unconstrainable-conflict/package.py
+++ b/var/spack/repos/builtin.mock/packages/unconstrainable-conflict/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+class UnconstrainableConflict(Package):
+    """Package with a conflict whose trigger cannot constrain its constraint."""
+
+    homepage = "http://www.example.com"
+    url      = "http://www.example.com/unconstrainable-conflict-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    # Two conflicts so there's always one that is not the current platform
+    conflicts('target=x86_64', when='platform=darwin')
+    conflicts('target=aarch64', when='platform=linux')


### PR DESCRIPTION
Currently, abstract target/os constraints inherently include the platform on which Spack is running. This leads to situations where valid constraints/triggers in a `conflicts` directive are not mutually constrainable.

The `spack audit` code was raising an error if it could not constrain the constraint spec by each of its triggers. This led to spurious CI failures in #28850

Includes regression test, and TODO comment to revert if/when targets/os are handled differently.

@sethrj this should fix the CI failure for your PR.