### PR TITLE
hsakmt-roct: dont look for libudev or compiler support libs

### DIFF
--- a/var/spack/repos/builtin/packages/hsakmt-roct/0001-Remove-compiler-support-libraries-and-libudev-as-req.patch
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/0001-Remove-compiler-support-libraries-and-libudev-as-req.patch
@@ -1,0 +1,34 @@
+From 423bfb21eee3f75c5a116a88f7903a7dfb9ff89c Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Thu, 10 Feb 2022 13:50:55 +0100
+Subject: [PATCH] Remove compiler support libraries and libudev as required
+ dependencies
+
+---
+ CMakeLists.txt | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 077ab51..0af642e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -187,16 +187,6 @@ target_link_libraries ( ${HSAKMT_TARGET}
+ )
+ 
+ target_compile_options(${HSAKMT_TARGET} PRIVATE ${DRM_CFLAGS} ${HSAKMT_C_FLAGS})
+-if(NOT DISTRO_ID MATCHES "ubuntu")
+-  find_library(LIBGCC NAMES libgcc_s.so.1 REQUIRED)
+-  message(STATUS "LIBGCC:" ${LIBGCC})
+-  target_link_libraries( ${HSAKMT_TARGET} PRIVATE ${LIBGCC} )
+-else()
+-  find_library(UDEV NAMES libudev.so libudev.a REQUIRED)
+-  message(STATUS "UDEV:" ${UDEV})
+-  find_package(ZLIB REQUIRED)
+-  target_link_libraries( ${HSAKMT_TARGET} PRIVATE ${ZLIB} ${UDEV} )
+-endif()
+ 
+ ## Define default paths and packages.
+ if( CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT )
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/hsakmt-roct/package.py
+++ b/var/spack/repos/builtin/packages/hsakmt-roct/package.py
@@ -40,6 +40,10 @@ class HsakmtRoct(CMakePackage):
     depends_on('numactl')
     depends_on('libdrm', when='@4.5.0:')
 
+    # See https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/issues/72
+    # and https://github.com/spack/spack/issues/28398
+    patch('0001-Remove-compiler-support-libraries-and-libudev-as-req.patch', when='@4.5.0:')
+
     @property
     def install_targets(self):
         if self.version == Version('3.5.0'):


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/28398

See https://github.com/RadeonOpenCompute/ROCT-Thunk-Interface/issues/72