### PR TITLE
qt: patch version 5 with XCode 13.2

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -147,6 +147,11 @@ class Qt(Package):
           sha256='84b099109d08adf177adf9d3542b6215ec3e42138041d523860dbfdcb59fdaae',
           working_dir='qtwebsockets',
           when='@5.14: %gcc@11:')
+    # https://github.com/microsoft/vcpkg/issues/21055
+    patch('qt5-macos12.patch',
+          working_dir='qtbase',
+          when='@5.14: %apple-clang@13:')
+
     conflicts('%gcc@10:', when='@5.9:5.12.6 +opengl')
     conflicts('%gcc@11:', when='@5.8')
 

--- a/var/spack/repos/builtin/packages/qt/qt5-macos12.patch
+++ b/var/spack/repos/builtin/packages/qt/qt5-macos12.patch
@@ -1,0 +1,12 @@
+diff --git a/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h b/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+index e070ba97..07c75b04 100644
+--- a/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
++++ b/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h
+@@ -40,6 +40,7 @@
+ #ifndef QIOSURFACEGRAPHICSBUFFER_H
+ #define QIOSURFACEGRAPHICSBUFFER_H
+ 
++#include <CoreGraphics/CGColorSpace.h>
+ #include <qpa/qplatformgraphicsbuffer.h>
+ #include <private/qcore_mac_p.h>
+ 


### PR DESCRIPTION
Fixes
```
In file included from qiosurfacegraphicsbuffer.mm:40:
./qiosurfacegraphicsbuffer.h:54:32: error: unknown type name 'CGColorSpaceRef'; did you mean 'QColorSpace'?
    void setColorSpace(QCFType<CGColorSpaceRef> colorSpace);
                               ^~~~~~~~~~~~~~~
                               QColorSpace
../../../../include/QtCore/../../src/corelib/kernel/qmetatype.h:2090:1: note: 'QColorSpace' declared here
QT_FOR_EACH_STATIC_GUI_CLASS(QT_FORWARD_DECLARE_STATIC_TYPES_ITER)
^
../../../../include/QtCore/../../src/corelib/kernel/qmetatype.h:178:24: note: expanded from macro 'QT_FOR_EACH_STATIC_GUI_CLASS'
    F(QColorSpace, 87, QColorSpace) \
                       ^
```
see https://github.com/microsoft/vcpkg/issues/21055 .

This is a problem with the "macOS 12 SDK" being included with Xcode 13.2, rather than a problem with buildint on monterey. Using apple-clang@13 is a better match than `os=monterey` since this actually fails on bigsur as well.