### PR TITLE
Stabilize the concretization of ecp-data-vis-sdk by preferring conduit@0.7.2

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -10,6 +10,9 @@ spack:
         all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
 
   packages:
+    conduit:
+      version:
+        - "0.7.2"
     mesa:
       variants: ~glx +osmesa
     paraview:


### PR DESCRIPTION
Currently we are oscillating between two "optimal" concretizations, one of which is known not to build.