### PR TITLE
mujoco: Add version 2.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/mujoco/package.py
+++ b/var/spack/repos/builtin/packages/mujoco/package.py
@@ -45,7 +45,7 @@ class Mujoco(Package):
             url = "https://github.com/deepmind/mujoco/releases/download/{0}/mujoco-{0}-{1}-x86_64.tar.gz"
             url_version = version
 
-        return url.format(version, system_map[platform.system()])
+        return url.format(url_version, system_map[platform.system()])
 
     def install(self, spec, prefix):
         copy_tree('.', prefix)

--- a/var/spack/repos/builtin/packages/mujoco/package.py
+++ b/var/spack/repos/builtin/packages/mujoco/package.py
@@ -52,8 +52,6 @@ class Mujoco(Package):
 
     def setup_run_environment(self, env):
         env.prepend_path('CPATH', prefix.include)
-        if self.spec.version == Version('2.1.0'):
-            # In 2.1.0 the libraries are in the bin-folder
-            env.prepend_path('LD_LIBRARY_PATH', prefix.bin)
-            if platform.system() == 'Darwin':
-                env.prepend_path('DYLD_LIBRARY_PATH', prefix.bin)
+        env.prepend_path('LD_LIBRARY_PATH', prefix.bin)
+        if platform.system() == 'Darwin':
+            env.prepend_path('DYLD_LIBRARY_PATH', prefix.bin)

--- a/var/spack/repos/builtin/packages/mujoco/package.py
+++ b/var/spack/repos/builtin/packages/mujoco/package.py
@@ -16,6 +16,9 @@ class Mujoco(Package):
     homepage = "https://mujoco.org/"
 
     mujoco_releases = {
+        '2.1.1': {
+            'Linux-x86_64':  'd422720fc53f161992b264847d6173eabbe3a3710aa0045d68738ee942f3246e',
+        },
         '2.1.0': {
             'Linux-x86_64':  'a436ca2f4144c38b837205635bbd60ffe1162d5b44c87df22232795978d7d012',
             'Darwin-x86_64':  '50226f859d9d3742fa57e1a0a92d656197ec5786f75bfa50ae00eb80fae25e90',
@@ -30,20 +33,27 @@ class Mujoco(Package):
 
     def url_for_version(self, version):
 
-        url = "https://mujoco.org/download/mujoco{0}-{1}-x86_64.tar.gz"
-
         system_map = {
             'Linux': 'linux',
             'Darwin': 'macos',
         }
 
-        return url.format(version.joined, system_map[platform.system()])
+        if version == Version('2.1.0'):
+            url = "https://mujoco.org/download/mujoco{0}-{1}-x86_64.tar.gz"
+            url_version = version.joined
+        else:
+            url = "https://github.com/deepmind/mujoco/releases/download/{0}/mujoco-{0}-{1}-x86_64.tar.gz"
+            url_version = version
+
+        return url.format(version, system_map[platform.system()])
 
     def install(self, spec, prefix):
         copy_tree('.', prefix)
 
     def setup_run_environment(self, env):
         env.prepend_path('CPATH', prefix.include)
-        env.prepend_path('LD_LIBRARY_PATH', prefix.bin)
-        if platform.system() == 'Darwin':
-            env.prepend_path('DYLD_LIBRARY_PATH', prefix.bin)
+        if self.spec.version == Version('2.1.0'):
+            # In 2.1.0 the libraries are in the bin-folder
+            env.prepend_path('LD_LIBRARY_PATH', prefix.bin)
+            if platform.system() == 'Darwin':
+                env.prepend_path('DYLD_LIBRARY_PATH', prefix.bin)


### PR DESCRIPTION
- New download url syntax
- MacOS support has switched to dmg-packages
- New versions use standard library paths