### PR TITLE
concretize: show what's changed in human-readable format

### DIFF
--- a/lib/spack/spack/cmd/concretize.py
+++ b/lib/spack/spack/cmd/concretize.py
@@ -3,9 +3,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
+from six import StringIO
+
+import llnl.util.tty as tty
+
 import spack.cmd
 import spack.cmd.common.arguments
-import spack.environment as ev
+import spack.spec
 
 description = 'concretize an environment and write a lockfile'
 section = "environments"
@@ -26,6 +32,166 @@ chosen, test dependencies are enabled for all packages in the environment.""")
     spack.cmd.common.arguments.add_concretizer_args(subparser)
 
 
+def subtract_spec_constraints(lhs, rhs):
+    # Subtraction in the set of constraints (not in the solution space)
+    # returns an abstract spec:
+    # Spec(zlib+pic%gcc) - Spec(zlib~pic%gcc) = Spec(zlib+pic).
+    # Spec(zlib+pic)     - Spec(zlib+pic)     = Spec()
+
+    # For now require concrete specs
+    assert lhs.concrete and rhs.concrete and lhs.name == rhs.name
+    out = spack.spec.Spec()
+    out.name = lhs.name
+    out.versions = None if lhs.versions == rhs.versions else lhs.versions.copy()
+    out.architecture = (None if lhs.architecture == rhs.architecture
+                        else lhs.architecture.copy())
+    out.compiler = None if lhs.compiler == rhs.compiler else lhs.compiler.copy()
+    out.compiler_flags = (None if lhs.compiler_flags == rhs.compiler_flags
+                          else lhs.compiler_flags.copy())
+    out.variants = lhs.variants.copy()
+    for key in rhs.variants:
+        if key in out.variants and out.variants[key] == rhs.variants[key]:
+            del out.variants[key]
+    return out
+
+
+def get_sorted_specs_of_environment(env):
+    roots = [env.specs_by_hash[key].copy(deps=True) for key in env.specs_by_hash]
+    roots.sort()
+    return roots
+
+
+def empty_spec(s):
+    return (not s.versions and not s.architecture and not s.compiler and
+            not s.compiler_flags and not s.variants)
+
+
+def print_deletion(spec, depth, io):
+    if depth:
+        io.write("    " * depth)
+        io.write('^')
+    io.write(spec.cformat(r'{name}{@version}{%compiler}{variants}{arch=architecture}'))
+    io.write(" => dropped")
+    io.write('\n')
+
+
+def print_insertion(spec, depth, io):
+    if depth:
+        io.write("    " * depth)
+        io.write('^')
+    io.write(spec.cformat(r'{name}{@version}{%compiler}{variants}{arch=architecture}'))
+    io.write(" => new")
+    io.write('\n')
+
+
+def print_equal(name, depth, io):
+    if depth:
+        io.write("    " * depth)
+        io.write('^')
+    io.write(name)
+    io.write('\n')
+
+
+def print_mutation(lhs_min_rhs, rhs_min_lhs, depth, io):
+    if depth:
+        io.write("    " * depth)
+        io.write('^')
+    io.write(lhs_min_rhs.name)
+    io.write('{')
+    fmt = r'{@version}{%compiler}{variants}{arch=architecture}'
+    io.write(lhs_min_rhs.cformat(fmt))
+    io.write(" => ")
+    io.write(rhs_min_lhs.cformat(fmt))
+    io.write("}\n")
+
+
+def handle_stack(stack, depth, io):
+    n = len(stack)
+    for i in range(n):
+        print_equal(stack[i], depth - n + i, io)
+    stack[:] = []
+
+
+def recursive_diff(before, after, visited, stack, depth=0, io=sys.stdout):
+    lhs_specs_iterator, rhs_specs_iterator = iter(before), iter(after)
+    lhs_spec, rhs_spec = next(lhs_specs_iterator, None), next(rhs_specs_iterator, None)
+
+    changed = False
+
+    while lhs_spec or rhs_spec:
+        # Skip over what we've seen before
+        if id(lhs_spec) in visited:
+            lhs_spec = next(lhs_specs_iterator, None)
+            continue
+
+        if id(rhs_spec) in visited:
+            rhs_spec = next(rhs_specs_iterator, None)
+            continue
+
+        # Handle hitting the end of the lists
+        if rhs_spec is None:
+            handle_stack(stack, depth, io)
+            print_deletion(lhs_spec, depth=depth, io=io)
+            visited.add(id(lhs_spec))
+            changed = True
+            lhs_spec = next(lhs_specs_iterator, None)
+            continue
+
+        if lhs_spec is None:
+            handle_stack(stack, depth, io)
+            print_insertion(rhs_spec, depth=depth, io=io)
+            visited.add(id(rhs_spec))
+            changed = True
+            rhs_spec = next(rhs_specs_iterator, None)
+            continue
+
+        # Handle end of package groups
+        if lhs_spec.name < rhs_spec.name:
+            handle_stack(stack, depth, io)
+            print_deletion(lhs_spec, depth=depth, io=io)
+            visited.add(id(lhs_spec))
+            changed = True
+            lhs_spec = next(lhs_specs_iterator, None)
+            continue
+
+        if lhs_spec.name > rhs_spec.name:
+            handle_stack(stack, depth, io)
+            print_insertion(rhs_spec, depth=depth, io=io)
+            visited.add(id(rhs_spec))
+            changed = True
+            rhs_spec = next(rhs_specs_iterator, None)
+            continue
+
+        lhs_min_rhs = subtract_spec_constraints(lhs_spec, rhs_spec)
+        rhs_min_lhs = subtract_spec_constraints(rhs_spec, lhs_spec)
+
+        # If this spec is not mutated, remember it, maybe its children are.
+        if empty_spec(lhs_min_rhs) and empty_spec(rhs_min_lhs):
+            stack.append(lhs_spec.name)
+        else:
+            handle_stack(stack, depth, io)
+            print_mutation(lhs_min_rhs, rhs_min_lhs, depth, io)
+            changed = True
+
+        visited.add(id(lhs_spec))
+        visited.add(id(rhs_spec))
+
+        deps_changed = recursive_diff(
+            lhs_spec.dependencies(), rhs_spec.dependencies(), visited,
+            stack, depth + 1, io)
+
+        # Pop if list is not flushed already
+        if stack:
+            stack.pop()
+
+        changed |= deps_changed
+
+        lhs_spec = next(lhs_specs_iterator, None)
+        rhs_spec = next(rhs_specs_iterator, None)
+
+    return changed
+
+
 def concretize(parser, args):
     env = spack.cmd.require_active_env(cmd_name='concretize')
 
@@ -37,6 +203,17 @@ def concretize(parser, args):
         tests = False
 
     with env.write_transaction():
-        concretized_specs = env.concretize(force=args.force, tests=tests)
-        ev.display_specs(concretized_specs)
+        before = get_sorted_specs_of_environment(env)
+        env.concretize(force=args.force, tests=tests)
+        after = get_sorted_specs_of_environment(env)
+
+        out = StringIO()
+        if recursive_diff(before, after, set(), [], io=out):
+            sys.stdout.write(out.getvalue())
+
+            # if we're about to overwrite changes, prompt first
+            if sys.stdin.isatty() and before:
+                if not tty.get_yes_or_no('Persist changes?', default=True):
+                    return
+
         env.write()


### PR DESCRIPTION
Instead of printing the new concretized environment, show the changes to the environment.

This is useful when
- concretizing the same spack.yaml after upgrading Spack
- adding/removing constraints in a previously concretized spack.yaml

What's printed is:
- changed specs
  - only changes are printed
  - arrows: :arrow_up: for (version) upgrades, :arrow_down: for downgrades
- new specs
- removed specs

Changes are defined as the set difference `-` of specs as a bag of constraints, effectively the following is printed:

```
(old - new) => (new - old)
```

![Screenshot from 2022-02-11 14-47-21](https://user-images.githubusercontent.com/194764/153603248-823b7b75-e5d5-40db-ba17-6d70d15e98ad.png)

The above example shows the effect of adding a version constraint in spack.yaml, as a result the version was decreased, a patch was added, and a dependency was removed.

Another example, toggling a variant on a root spec:

![Screenshot from 2022-02-11 15-22-59](https://user-images.githubusercontent.com/194764/153608620-52436a13-647b-475d-9563-472375bfaee3.png)


(loosely inspired by [Pkg.jl](https://github.com/JuliaLang/Pkg.jl)) 