### PR TITLE
go: mark conflict for ancient compilers

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -142,6 +142,9 @@ class Go(Package):
     # The fix for this issue has been merged into the 1.8 tree.
     patch('misc-cgo-testcshared.patch', level=0, when='@1.6.4:1.7.5')
 
+    # Unrecognized option '-fno-lto'
+    conflicts('%gcc@:4', when='@1.17:')
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('version', output=str, error=str)


### PR DESCRIPTION
On gcc@4.4.7 (rhel6 linux):
```
  >> 484    cc1: error: unrecognized command line option "-fno-lto"
     485
  >> 486    go tool dist: FAILED: /tmp/s3j/spack-stage/spack-stage-go-1.17.3-nckrddwg37ez7xzmzskoiwbvwxgwzshu/spack-src/pkg/tool/linux_amd64/go_boo
            tstrap install -gcflags=all= -ldflags=all= std cmd: exit status 2
```