### PR TITLE
intel-oneapi-mpi: set I_MPI_ROOT in setup_dependent_build_environment

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -75,6 +75,8 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         env.set('MPIF90', join_path(dir, 'mpif90'))
         env.set('MPIFC', join_path(dir, 'mpifc'))
 
+        env.set('I_MPI_ROOT', self.component_path)
+
     @property
     def headers(self):
         include_path = join_path(self.component_path, 'include')


### PR DESCRIPTION
  * setting I_MPI_ROOT is sometimes needed for find_package(MPI) in cmake to work