### PR TITLE
Fix module support for oneapi compilers

### DIFF
--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -200,6 +200,10 @@ class LmodConfiguration(BaseConfiguration):
         if self.spec.name == 'intel-oneapi-compilers':
             provides['compiler'] = spack.spec.CompilerSpec(str(self.spec))
             provides['compiler'].name = 'oneapi'
+        # Special case for oneapi classic
+        if self.spec.name == 'intel-oneapi-compilers-classic':
+            provides['compiler'] = spack.spec.CompilerSpec(str(self.spec))
+            provides['compiler'].name = 'intel'
 
         # All the other tokens in the hierarchy must be virtual dependencies
         for x in self.hierarchy_tokens:

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -196,6 +196,10 @@ class LmodConfiguration(BaseConfiguration):
         if self.spec.name == 'llvm-amdgpu':
             provides['compiler'] = spack.spec.CompilerSpec(str(self.spec))
             provides['compiler'].name = 'rocmcc'
+        # Special case for oneapi
+        if self.spec.name == 'intel-oneapi-compilers':
+            provides['compiler'] = spack.spec.CompilerSpec(str(self.spec))
+            provides['compiler'].name = 'oneapi'
 
         # All the other tokens in the hierarchy must be virtual dependencies
         for x in self.hierarchy_tokens:

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -1,0 +1,50 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+@IntelOneApiPackage.update_description
+class IntelOneapiCompilersClassic(Package):
+    """Relies on intel-oneapi-compilers to install the compilers, and
+    configures modules for icc/icpc/ifort.
+
+    """
+
+    maintainers = ['rscohn2']
+
+    homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
+
+    has_code = False
+
+    phases = []
+
+    for ver in ['2022.1.0',
+                '2022.0.2',
+                '2022.0.1',
+                '2021.4.0',
+                '2021.3.0',
+                '2021.2.0',
+                '2021.1.2']:
+        version(ver)
+        depends_on('intel-oneapi-compilers@' + ver, when='@' + ver)
+
+    def setup_run_environment(self, env):
+        """Adds environment variables to the generated module file.
+
+        These environment variables come from running:
+
+        .. code-block:: console
+
+           $ source {prefix}/{component}/{version}/env/vars.sh
+
+        and from setting CC/CXX/F77/FC
+        """
+        bin = join_path(self.spec['intel-oneapi-compilers'].prefix,
+                        'compile', 'linux', 'bin', 'intel64')
+        env.set('CC', join_path(bin, 'icc'))
+        env.set('CXX', join_path(bin, 'icpc'))
+        env.set('F77', join_path(bin, 'ifort'))
+        env.set('FC', join_path(bin, 'ifort'))

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -29,7 +29,7 @@ class IntelOneapiCompilersClassic(Package):
                 '2021.2.0',
                 '2021.1.2']:
         version(ver)
-        depends_on('intel-oneapi-compilers@' + ver, when='@' + ver)
+        depends_on('intel-oneapi-compilers@' + ver, when='@' + ver, type='run')
 
     def setup_run_environment(self, env):
         """Adds environment variables to the generated module file.

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -96,10 +96,6 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                  placement='fortran-installer',
                  when='@2021.1.2')
 
-    variant('CC', default='icx',
-            values=('icx', 'icc', 'dpcpp'), multi=False,
-            description='Set CC & friends in run environment')
-
     @property
     def component_dir(self):
         return 'compiler'
@@ -161,17 +157,8 @@ class IntelOneapiCompilers(IntelOneApiPackage):
         """
         super(IntelOneapiCompilers, self).setup_run_environment(env)
 
-        if 'CC=icc' in self.spec:
-            bin = join_path(self.component_path, 'linux', 'bin', 'intel64')
-            env.set('CC', join_path(bin, 'icc'))
-            env.set('CXX', join_path(bin, 'icpc'))
-            env.set('F77', join_path(bin, 'ifort'))
-            env.set('FC', join_path(bin, 'ifort'))
-        else:
-            bin = join_path(self.component_path, 'linux', 'bin')
-            env.set('CC', join_path(bin, 'icx'))
-            env.set('CXX', join_path(bin,
-                                     'dpcpp' if 'CC=dpcpp' in self.spec
-                                     else 'icpx'))
-            env.set('F77', join_path(bin, 'ifx'))
-            env.set('FC', join_path(bin, 'ifx'))
+        bin = join_path(self.component_path, 'linux', 'bin')
+        env.set('CC', join_path(bin, 'icx'))
+        env.set('CXX', join_path(bin, 'icpx'))
+        env.set('F77', join_path(bin, 'ifx'))
+        env.set('FC', join_path(bin, 'ifx'))


### PR DESCRIPTION
CC/CXX/FC/F77 will be set in the run environment and the module file. This makes the behavior consistent with other spack packages that include compilers: intel-parallel-studio, dpcpp, nvhpc, pgi.

Also fixes lmod problem identified in #30608.

Split out module support for icc by creating a new package intel-oneapi-compilers-classic

Users of icx can use intel-oneapi-compilers, users of icc use intel-oneapi-compilers-classic

Both packages install both compilers because the intel installer that we depend upon always installs both. intel-oneapi-compilers-classic depends on intel-oneapi-compilers and does not install anything additional.
```