### PR TITLE
rocmlibs: cleanup amdgpu_target variant behaviour

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -251,9 +251,9 @@ class Hip(CMakePackage):
         self.set_variables(env)
 
         if 'amdgpu_target' in dependent_spec.variants:
-            arch = dependent_spec.variants['amdgpu_target'].value
-            if arch != 'none':
-                env.set('HCC_AMDGPU_TARGET', ','.join(arch))
+            arch = dependent_spec.variants['amdgpu_target']
+            if 'none' not in arch and 'auto' not in arch:
+                env.set('HCC_AMDGPU_TARGET', ','.join(arch.value))
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         self.setup_dependent_build_environment(env, dependent_spec)

--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -37,7 +37,8 @@ class Hip(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.16.8:', type='build', when='@4.5.0:')
+    depends_on('cmake@3.4.3:', type='build')
     depends_on('perl@5.10:', type=('build', 'run'))
     depends_on('gl@4.5:')
 

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -33,6 +33,11 @@ class Rccl(CMakePackage):
     version('3.7.0', sha256='8273878ff71aac2e7adf5cc8562d2933034c6c6b3652f88fbe3cd4f2691036e3', deprecated=True)
     version('3.5.0', sha256='290b57a66758dce47d0bfff3f5f8317df24764e858af67f60ddcdcadb9337253', deprecated=True)
 
+    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-',
+                      'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
+                      'gfx1030')
+
+    variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     patch('0001-Fix-numactl-path-issue.patch', when='@3.7.0:4.3.2')
@@ -63,6 +68,9 @@ class Rccl(CMakePackage):
                 'NUMACTL_DIR',
                 self.spec['numactl'].prefix
             ))
+
+        if self.spec.variants['amdgpu_target'].value != 'auto':
+            args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -69,7 +69,7 @@ class Rccl(CMakePackage):
                 self.spec['numactl'].prefix
             ))
 
-        if self.spec.variants['amdgpu_target'].value != 'auto':
+        if 'auto' not in self.spec.variants['amdgpu_target']:
             args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -89,7 +89,7 @@ class Rocalution(CMakePackage):
             self.define('BUILD_CLIENTS_SAMPLES', 'OFF')
         ]
 
-        if self.spec.variants['amdgpu_target'].value != 'auto':
+        if 'auto' not in self.spec.variants['amdgpu_target']:
             args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -48,9 +48,14 @@ class Rocalution(CMakePackage):
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('rocblas@' + ver, when='@' + ver)
-        depends_on('rocprim@' + ver, when='@' + ver)
-        depends_on('rocsparse@' + ver, when='@' + ver)
+        for tgt in ['auto', *amdgpu_targets]:
+            rocblas_tgt = tgt if tgt != 'gfx900:xnack-' else 'gfx900'
+            depends_on('rocblas@{0} amdgpu_target={1}'.format(ver, rocblas_tgt),
+                       when='@{0} amdgpu_target={1}'.format(ver, tgt))
+            depends_on('rocprim@{0} amdgpu_target={1}'.format(ver, tgt),
+                       when='@{0} amdgpu_target={1}'.format(ver, tgt))
+            depends_on('rocsparse@{0} amdgpu_target={1}'.format(ver, tgt),
+                       when='@{0} amdgpu_target={1}'.format(ver, tgt))
         depends_on('comgr@' + ver, when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
@@ -58,7 +63,9 @@ class Rocalution(CMakePackage):
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0',
                 '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
-        depends_on('rocrand@' + ver, when='@' + ver)
+        for tgt in ['auto', *amdgpu_targets]:
+            depends_on('rocrand@{0} amdgpu_target={1}'.format(ver, tgt),
+                       when='@{0} amdgpu_target={1}'.format(ver, tgt))
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -36,6 +36,11 @@ class Rocalution(CMakePackage):
     version('3.7.0', sha256='4d6b20aaaac3bafb7ec084d684417bf578349203b0f9f54168f669e3ec5699f8', deprecated=True)
     version('3.5.0', sha256='be2f78c10c100d7fd9df5dd2403a44700219c2cbabaacf2ea50a6e2241df7bfe', deprecated=True)
 
+    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-',
+                      'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
+                      'gfx1030')
+
+    variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     depends_on('cmake@3.5:', type='build')
@@ -75,6 +80,9 @@ class Rocalution(CMakePackage):
             self.define('SUPPORT_MPI', 'OFF'),
             self.define('BUILD_CLIENTS_SAMPLES', 'OFF')
         ]
+
+        if self.spec.variants['amdgpu_target'].value != 'auto':
+            args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
 
 from spack import *
 
@@ -48,7 +49,7 @@ class Rocalution(CMakePackage):
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
-        for tgt in ['auto', *amdgpu_targets]:
+        for tgt in itertools.chain(['auto'], amdgpu_targets):
             rocblas_tgt = tgt if tgt != 'gfx900:xnack-' else 'gfx900'
             depends_on('rocblas@{0} amdgpu_target={1}'.format(ver, rocblas_tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
@@ -63,7 +64,7 @@ class Rocalution(CMakePackage):
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0',
                 '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
-        for tgt in ['auto', *amdgpu_targets]:
+        for tgt in itertools.chain(['auto'], amdgpu_targets):
             depends_on('rocrand@{0} amdgpu_target={1}'.format(ver, tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
 

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -37,7 +37,7 @@ class Rocblas(CMakePackage):
                       'gfx1012', 'gfx1030')
 
     variant('amdgpu_target', default='gfx906:xnack-', values=amdgpu_targets, multi=True)
-    variant('tensile', default=False, description='Use Tensile as a backend')
+    variant('tensile', default=True, description='Use Tensile as a backend')
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     # gfx906, gfx908,gfx803,gfx900 are valid for @:4.0.0

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -36,7 +36,7 @@ class Rocblas(CMakePackage):
                       'gfx90a:xnack-', 'gfx1010', 'gfx1011',
                       'gfx1012', 'gfx1030')
 
-    variant('amdgpu_target', default='gfx906:xnack-', values=amdgpu_targets, multi=True)
+    variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('tensile', default=True, description='Use Tensile as a backend')
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
@@ -149,8 +149,8 @@ class Rocblas(CMakePackage):
                 arch_define_name = 'Tensile_ARCHITECTURE'
 
         # See https://github.com/ROCmSoftwarePlatform/rocBLAS/commit/c1895ba4bb3f4f5947f3818ebd155cf71a27b634
-        args.append(self.define(arch_define_name,
-                    self.spec.variants['amdgpu_target'].value))
+        if self.spec.variants['amdgpu_target'].value != 'auto':
+            args.append(self.define_from_variant(arch_define_name, 'amdgpu_target'))
 
         # See https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1196
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -149,7 +149,7 @@ class Rocblas(CMakePackage):
                 arch_define_name = 'Tensile_ARCHITECTURE'
 
         # See https://github.com/ROCmSoftwarePlatform/rocBLAS/commit/c1895ba4bb3f4f5947f3818ebd155cf71a27b634
-        if self.spec.variants['amdgpu_target'].value != 'auto':
+        if 'auto' not in self.spec.variants['amdgpu_target']:
             args.append(self.define_from_variant(arch_define_name, 'amdgpu_target'))
 
         # See https://github.com/ROCmSoftwarePlatform/rocBLAS/issues/1196

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -62,8 +62,9 @@ class Rocfft(CMakePackage):
 
         if 'auto' not in tgt:
             if '@:3.8.0' in self.spec:
-                args.append(self.define('CMAKE_CXX_FLAGS',
-                                        '--amdgpu-target={0}'.format(",".join(tgt.value))))
+                args.append(self.define(
+                    'CMAKE_CXX_FLAGS',
+                    '--amdgpu-target={0}'.format(",".join(tgt.value))))
             else:
                 args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
@@ -71,7 +72,8 @@ class Rocfft(CMakePackage):
         tgt_sram = self.spec.variants['amdgpu_target_sram_ecc']
 
         if 'auto' not in tgt_sram and self.spec.satisfies('@3.9.0:4.0.0'):
-            args.append(self.define_from_variant('AMDGPU_TARGETS_SRAM_ECC', 'amdgpu_target_sram_ecc'))
+            args.append(self.define_from_variant(
+                'AMDGPU_TARGETS_SRAM_ECC', 'amdgpu_target_sram_ecc'))
 
         # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -58,20 +58,20 @@ class Rocfft(CMakePackage):
 
     def cmake_args(self):
         args = []
-        tgt = self.spec.variants['amdgpu_target'].value
+        tgt = self.spec.variants['amdgpu_target']
 
-        if tgt != 'auto':
+        if 'auto' not in tgt:
             if '@:3.8.0' in self.spec:
                 args.append(self.define('CMAKE_CXX_FLAGS',
-                                        '--amdgpu-target={0}'.format(",".join(tgt))))
+                                        '--amdgpu-target={0}'.format(",".join(tgt.value))))
             else:
-                args.append(self.define('AMDGPU_TARGETS', tgt))
+                args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         # From version 3.9 and above we have AMDGPU_TARGETS_SRAM_ECC
-        tgt_sram = self.spec.variants['amdgpu_target_sram_ecc'].value
+        tgt_sram = self.spec.variants['amdgpu_target_sram_ecc']
 
-        if tgt_sram != 'auto' and self.spec.satisfies('@3.9.0:4.0.0'):
-            args.append(self.define('AMDGPU_TARGETS_SRAM_ECC', tgt_sram))
+        if 'auto' not in tgt_sram and self.spec.satisfies('@3.9.0:4.0.0'):
+            args.append(self.define_from_variant('AMDGPU_TARGETS_SRAM_ECC', 'amdgpu_target_sram_ecc'))
 
         # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -32,14 +32,14 @@ class Rocfft(CMakePackage):
     version('3.5.0', sha256='629f02cfecb7de5ad2517b6a8aac6ed4de60d3a9c620413c4d9db46081ac2c88', deprecated=True)
 
     amdgpu_targets = (
-        'none', 'gfx701', 'gfx801', 'gfx802', 'gfx803',
+        'gfx701', 'gfx801', 'gfx802', 'gfx803',
         'gfx900', 'gfx906', 'gfx908', 'gfx1010',
         'gfx1011', 'gfx1012'
     )
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
-    variant('amdgpu_target', default='gfx701', multi=True, values=amdgpu_targets)
-    variant('amdgpu_target_sram_ecc', default='none', multi=True, values=amdgpu_targets)
+    variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
+    variant('amdgpu_target_sram_ecc', values=auto_or_any_combination_of(*amdgpu_targets))
 
     depends_on('cmake@3:', type='build')
     depends_on('python@3:', type='build', when='@5.0.0:')
@@ -60,18 +60,18 @@ class Rocfft(CMakePackage):
         args = []
         tgt = self.spec.variants['amdgpu_target'].value
 
-        if tgt[0] != 'none':
+        if tgt != 'auto':
             if '@:3.8.0' in self.spec:
                 args.append(self.define('CMAKE_CXX_FLAGS',
                                         '--amdgpu-target={0}'.format(",".join(tgt))))
             else:
-                args.append(self.define('AMDGPU_TARGETS', ";".join(tgt)))
+                args.append(self.define('AMDGPU_TARGETS', tgt))
 
         # From version 3.9 and above we have AMDGPU_TARGETS_SRAM_ECC
         tgt_sram = self.spec.variants['amdgpu_target_sram_ecc'].value
 
-        if tgt_sram[0] != 'none' and self.spec.satisfies('@3.9.0:4.0.0'):
-            args.append(self.define('AMDGPU_TARGETS_SRAM_ECC', ";".join(tgt_sram)))
+        if tgt_sram != 'auto' and self.spec.satisfies('@3.9.0:4.0.0'):
+            args.append(self.define('AMDGPU_TARGETS_SRAM_ECC', tgt_sram))
 
         # See https://github.com/ROCmSoftwarePlatform/rocFFT/issues/322
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -61,7 +61,7 @@ class Rocprim(CMakePackage):
             self.define('BUILD_EXAMPLE', 'OFF')
         ]
 
-        if self.spec.variants['amdgpu_target'].value != 'auto':
+        if 'auto' not in self.spec.variants['amdgpu_target']:
             args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -30,6 +30,11 @@ class Rocprim(CMakePackage):
     version('3.7.0', sha256='225209a0cbd003c241821c8a9192cec5c07c7f1a6ab7da296305fc69f5f6d365', deprecated=True)
     version('3.5.0', sha256='29302dbeb27ae88632aa1be43a721f03e7e597c329602f9ca9c9c530c1def40d', deprecated=True)
 
+    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-',
+                      'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
+                      'gfx1030')
+
+    variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
@@ -55,6 +60,9 @@ class Rocprim(CMakePackage):
             self.define('BUILD_BENCHMARK', 'OFF'),
             self.define('BUILD_EXAMPLE', 'OFF')
         ]
+
+        if self.spec.variants['amdgpu_target'].value != 'auto':
+            args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -34,6 +34,11 @@ class Rocrand(CMakePackage):
     version('3.7.0', sha256='5e43fe07afe2c7327a692b3b580875bae6e6ee790e044c053fffafbfcbc14860', deprecated=True)
     version('3.5.0', sha256='592865a45e7ef55ad9d7eddc8082df69eacfd2c1f3e9c57810eb336b15cd5732', deprecated=True)
 
+    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-', 'gfx908:xnack-',
+                      'gfx90a:xnack-', 'gfx90a:xnack+',
+                      'gfx1030')
+
+    variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     depends_on('cmake@3.10.2:', type='build', when='@4.5.0:')
@@ -94,6 +99,9 @@ class Rocrand(CMakePackage):
             self.define('BUILD_BENCHMARK', 'OFF'),
             self.define('BUILD_TEST', self.run_tests)
         ]
+
+        if self.spec.variants['amdgpu_target'].value != 'auto':
+            args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -100,7 +100,7 @@ class Rocrand(CMakePackage):
             self.define('BUILD_TEST', self.run_tests)
         ]
 
-        if self.spec.variants['amdgpu_target'].value != 'auto':
+        if 'auto' not in self.spec.variants['amdgpu_target']:
             args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -83,13 +83,13 @@ class Rocsolver(CMakePackage):
         if self.spec.satisfies('@3.7.0:'):
             args.append(self.define_from_variant('OPTIMAL', 'optimal'))
 
-        tgt = self.spec.variants['amdgpu_target'].value
-        if tgt != 'auto':
+        tgt = self.spec.variants['amdgpu_target']
+        if 'auto' not in tgt:
             if '@:3.8.0' in self.spec:
                 args.append(self.define('CMAKE_CXX_FLAGS',
-                                        '--amdgpu-target={0}'.format(",".join(tgt))))
+                                        '--amdgpu-target={0}'.format(",".join(tgt.value))))
             else:
-                args.append(self.define('AMDGPU_TARGETS', tgt))
+                args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
+
 from spack import *
 
 
@@ -60,7 +62,7 @@ class Rocsolver(CMakePackage):
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
-        for tgt in ['auto', *amdgpu_targets]:
+        for tgt in itertools.chain(['auto'], amdgpu_targets):
             depends_on('rocblas@{0} amdgpu_target={1}'.format(ver, tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -17,10 +17,10 @@ class Rocsolver(CMakePackage):
     maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
     amdgpu_targets = (
-        'none', 'gfx803', 'gfx900', 'gfx906:xnack-', 'gfx908:xnack-',
+        'gfx803', 'gfx900', 'gfx906:xnack-', 'gfx908:xnack-',
         'gfx90a:xnack-', 'gfx90a:xnack+', 'gfx1010', 'gfx1011', 'gfx1012', 'gfx1030'
     )
-    variant('amdgpu_target', default='gfx906:xnack-', multi=True, values=amdgpu_targets)
+    variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('optimal', default=True,
             description='This option improves performance at the cost of increased binary \
             size and compile time by adding specialized kernels \
@@ -64,7 +64,6 @@ class Rocsolver(CMakePackage):
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     def cmake_args(self):
-        tgt = self.spec.variants['amdgpu_target'].value
         args = [
             self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
             self.define('BUILD_CLIENTS_TESTS', self.run_tests),
@@ -80,12 +79,13 @@ class Rocsolver(CMakePackage):
         if self.spec.satisfies('@3.7.0:'):
             args.append(self.define_from_variant('OPTIMAL', 'optimal'))
 
-        if tgt[0] != 'none':
+        tgt = self.spec.variants['amdgpu_target'].value
+        if tgt != 'auto':
             if '@:3.8.0' in self.spec:
                 args.append(self.define('CMAKE_CXX_FLAGS',
                                         '--amdgpu-target={0}'.format(",".join(tgt))))
             else:
-                args.append(self.define('AMDGPU_TARGETS', ";".join(tgt)))
+                args.append(self.define('AMDGPU_TARGETS', tgt))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -60,7 +60,9 @@ class Rocsolver(CMakePackage):
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('rocblas@' + ver, when='@' + ver)
+        for tgt in ['auto', *amdgpu_targets]:
+            depends_on('rocblas@{0} amdgpu_target={1}'.format(ver, tgt),
+                       when='@{0} amdgpu_target={1}'.format(ver, tgt))
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -86,8 +86,9 @@ class Rocsolver(CMakePackage):
         tgt = self.spec.variants['amdgpu_target']
         if 'auto' not in tgt:
             if '@:3.8.0' in self.spec:
-                args.append(self.define('CMAKE_CXX_FLAGS',
-                                        '--amdgpu-target={0}'.format(",".join(tgt.value))))
+                args.append(self.define(
+                    'CMAKE_CXX_FLAGS',
+                    '--amdgpu-target={0}'.format(",".join(tgt.value))))
             else:
                 args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -63,7 +63,7 @@ class Rocsparse(CMakePackage):
             self.define('BUILD_CLIENTS_BENCHMARKS', 'OFF')
         ]
 
-        if self.spec.variants['amdgpu_target'].value != 'auto':
+        if 'auto' not in self.spec.variants['amdgpu_target']:
             args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
 
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -46,7 +46,9 @@ class Rocsparse(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('rocprim@' + ver, when='@' + ver)
+        for tgt in ['auto', *amdgpu_targets]:
+            depends_on('rocprim@{0} amdgpu_target={1}'.format(ver, tgt),
+                       when='@{0} amdgpu_target={1}'.format(ver, tgt))
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import itertools
+
 from spack import *
 
 
@@ -46,7 +48,7 @@ class Rocsparse(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
-        for tgt in ['auto', *amdgpu_targets]:
+        for tgt in itertools.chain(['auto'], amdgpu_targets):
             depends_on('rocprim@{0} amdgpu_target={1}'.format(ver, tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
         depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -19,6 +19,11 @@ class Rocsparse(CMakePackage):
 
     maintainers = ['srekolam', 'arjun-raj-kuppala']
 
+    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-', 'gfx908:xnack-',
+                      'gfx90a:xnack-', 'gfx90a:xnack+',
+                      'gfx1030')
+
+    variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     version('5.0.2', sha256='c9d9e1b7859e1c5aa5050f5dfdf86245cbd7c1296c0ce60d9ca5f3e22a9b748b')
@@ -53,6 +58,10 @@ class Rocsparse(CMakePackage):
             self.define('BUILD_CLIENTS_TESTS', 'OFF'),
             self.define('BUILD_CLIENTS_BENCHMARKS', 'OFF')
         ]
+
+        if self.spec.variants['amdgpu_target'].value != 'auto':
+            args.append(self.define_from_variant('AMDGPU_TARGETS', 'amdgpu_target'))
+
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 


### PR DESCRIPTION
This change builds on #28846 to apply a consistent amdgpu_target variant behaviour across all the ROCm math and communication libraries. There's two main things I've done:

1. Define the amdgpu_target variant values with `auto_or_any_combination_of` on all ROCm math and communication libraries that contain GPU code. When `auto` is supplied, the `AMDGPU_TARGETS` cache variable is left unset. In this case, the libraries will default to building for all supported architectures. This takes a _long_ time, but it's the safest default.
2. Propagate the amdgpu_target variant between ROCm math library dependencies. e.g. `spack spec rocsolver amdgpu_target=gfx906:xnack-,gfx1010` will include `^rocblas@4.5.2%gcc@9.3.0~ipo amdgpu_target=gfx1010,gfx906:xnack-`

This change was motivated by comments in https://github.com/spack/spack/pull/28846#discussion_r805200534 and https://github.com/spack/spack/pull/27535#issuecomment-987482569.