### PR TITLE
Adding support for spack sbom

### DIFF
--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -216,6 +216,33 @@ the ``mpich`` will be build with the installed versions, if possible.
 You can use the :ref:`spack spec -I <cmd-spack-spec>` command to see what
 will be reused and what will be built before you install.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Generate a software bill of materials (sbom)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Spack has support to generate a `CycloneDX Software Bill of Materials <https://cyclonedx.org/specification/overview/>`_,
+called an "SBOM." This is a `json data structure <https://cyclonedx.org/docs/1.3/json/>`_
+that describes the install tree and dependencies, and is becoming important to
+generate for understanding what is installed. By default since the files can be big,
+we do not generate them for installs. However, you can request an sbom to be generated
+in the install directory as follows:
+
+.. code-block:: console
+
+    $ spack install --sbom zlib
+
+The sbom is then generated in the package metadata directory, which you can find as follows:
+
+.. code-block:: console
+
+    $ spack sbom path zlib
+    ./opt/spack/linux-ubuntu20.04-skylake/gcc-9.3.0/zlib-1.2.11-7dhzpqdz36kcfncmvqlaznfsxzpttpmq/.spack/sbom.json
+
+
+And you can further view or inspect it with :ref:_cmd-spack-sbom, an associated
+command.
+
+
 .. _cmd-spack-uninstall:
 
 ^^^^^^^^^^^^^^^^^^^
@@ -721,6 +748,35 @@ structured the way you want:
       "version": "6.1",
       "hash": "zvaa4lhlhilypw5quj3akyd3apbq5gap"
     }
+
+
+.. _cmd-spack-sbom:
+
+^^^^^^^^^^^^^^
+``spack sbom``
+^^^^^^^^^^^^^^
+
+The spack sbom command allows you to easily find or inspect existing sboms, or
+or generate an sbom for an already installed package on the fly. If you've already generated
+an sbom and just need the path, do:
+
+
+.. code-block:: console
+
+    $ spack sbom path zlib
+    ./opt/spack/linux-ubuntu20.04-skylake/gcc-9.3.0/zlib-1.2.11-7dhzpqdz36kcfncmvqlaznfsxzpttpmq/.spack/sbom.json
+
+You can also dump the full json to your terminal with ``show``:
+
+.. code-block:: console
+
+    $ spack sbom show zlib
+
+Or finally, request creation of an sbom for a package that does not have one:
+
+.. code-block:: console
+
+    $ spack sbom create expat@2.4.1
 
 
 ^^^^^^^^^^^^^^

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -20,6 +20,7 @@ import spack.fetch_strategy
 import spack.monitor
 import spack.paths
 import spack.report
+import spack.sbom
 from spack.error import SpackError
 from spack.installer import PackageInstaller
 
@@ -41,6 +42,7 @@ def update_kwargs_from_args(args, kwargs):
         'verbose': args.verbose or args.install_verbose,
         'fake': args.fake,
         'dirty': args.dirty,
+        'generate_sbom': args.generate_sbom,
         'use_cache': args.use_cache,
         'cache_only': args.cache_only,
         'include_build_deps': args.include_build_deps,
@@ -94,6 +96,9 @@ the dependencies"""
     subparser.add_argument(
         '--dont-restage', action='store_true',
         help="if a partial install is detected, don't delete prior state")
+    subparser.add_argument(
+        '--sbom', action='store_true', dest='generate_sbom', default=False,
+        help="generate a software bill of materials in the package directory.")
 
     cache_group = subparser.add_mutually_exclusive_group()
     cache_group.add_argument(
@@ -202,9 +207,12 @@ def install_specs(cli_args, kwargs, specs):
         kwargs (dict):  keyword arguments
         specs (list):  list of (abstract, concrete) spec tuples
     """
-
     # handle active environment, if any
     env = ev.active_environment()
+
+    # Flag to indicate we should enable sbom generation (hook)
+    if kwargs.get('generate_sbom', False) is True:
+        spack.sbom.generate_sbom = True
 
     try:
         if env:

--- a/lib/spack/spack/cmd/sbom.py
+++ b/lib/spack/spack/cmd/sbom.py
@@ -1,0 +1,71 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import llnl.util.tty as tty
+
+import spack.cmd
+import spack.sbom
+import spack.util.spack_json as sjson
+from spack.error import SpackError
+
+description = "generate or view software bill of materials (sbom)"
+section = "build"
+level = "long"
+
+
+def setup_parser(subparser):
+    sp = subparser.add_subparsers(metavar='SUBCOMMAND', dest='sbom_command')
+
+    # Find (view) an existing path of an sbom
+    path_parser = sp.add_parser('path', description="get the path to an existing sbom")
+
+    # Create an sbom on the fly
+    create_parser = sp.add_parser('create',
+                                  description="create an sbom if it does not exist.")
+
+    # Show the file contents in the terminal
+    show_parser = sp.add_parser('show',
+                                description="dump an existing sbom to the terminal.")
+
+    # Every parser accepts a spec
+    for parser in [create_parser, path_parser, show_parser]:
+        parser.add_argument("spec", help="spec name for sbom")
+
+
+def sbom(parser, args, **kwargs):
+    try:
+        specs = spack.cmd.parse_specs([args.spec], concretize=True)
+    except SpackError as e:
+        tty.die(e)
+
+    # Just generate for one spec
+    spec = specs[0]
+
+    # Do not proceed if spec isn't installed!
+    if not spec.install_status():
+        tty.die("That spec is not installed. Try spack install with --sbom.")
+
+    # sbom required to exist for show and path
+    if args.sbom_command in ["show", "path"]:
+        sbom_file = spack.sbom.find_sbom(spec)
+        if not sbom_file:
+            tty.die("sbom for that spec does not exist. Use spack sbom create.")
+
+        if args.sbom_command == "path":
+            tty.info(sbom_file)
+        elif args.sbom_command == "show":
+            with open(sbom_file, 'r') as f:
+                print(sjson.dump(sjson.load(f.read())))
+
+    # Show the path of an existing sbom
+    elif args.sbom_command == "path":
+        path = spack.sbom.find_sbom(spec)
+        if not path:
+            tty.die("sbom for that spec does not exist. Use spack sbom create.")
+        tty.info(path)
+
+    elif args.sbom_command == "create":
+        sbom_file = spack.sbom.create_sbom(spec)
+        tty.info("sbom generated successfully: %s" % sbom_file)

--- a/lib/spack/spack/hooks/sbom.py
+++ b/lib/spack/spack/hooks/sbom.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import llnl.util.tty as tty
+
+import spack.sbom
+
+
+def on_install_success(spec):
+    """On the success of an install generate an sbom.
+    """
+    if not spack.sbom.generate_sbom:
+        tty.debug("sbom generation not requested for %s" % spec)
+        return
+
+    tty.debug("Running hooks.sbom.on_install_success for %s" % spec)
+
+    # Write sbom to the metadata directory
+    spack.sbom.create_sbom(spec)

--- a/lib/spack/spack/sbom.py
+++ b/lib/spack/spack/sbom.py
@@ -1,0 +1,231 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# Generate a software bill of materials for a spack package
+# Original development work: https://github.com/spack/spack-sbom
+# https://www.ntia.gov/files/ntia/publications/howto_guide_for_sbom_generation_v1.pdf
+
+import os
+import uuid
+from datetime import datetime
+
+import llnl.util.tty as tty
+
+import spack.config
+import spack.main
+import spack.spec
+import spack.util.spack_json as sjson
+
+# Generate the sbom? They can be large, so default is no.
+generate_sbom = False
+
+# Use CycloneDX which is a simplified format approved by standards committees
+# https://cyclonedx.org/docs/1.3/json
+# https://cyclonedx.org/use-cases/
+template = {
+    "bomFormat": "CycloneDX",
+    # The version of the CycloneDX specification a BOM is written to
+    "specVersion": "1.3",
+    "serialNumber": "",
+    # The version WE are generating for the package - this would increment
+    "version": 1,
+    # Will be populated with metadata
+    "metadata": {},
+}
+
+
+def generate_timestamp_now():
+    return str(datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+
+def get_component(spec):
+    """
+    Given a spec, get a component for it.
+    """
+    # Anything with "lib" is a library, otherwise application
+    component_type = "lib" if "lib" in spec.package.name else "application"
+
+    # Must be concrets
+    spec.concretize()
+
+    component = {
+        # Note that "application" might also be a suitable choice
+        # https://cyclonedx.org/docs/1.3/json/#metadata_component_type
+        "type": component_type,
+        # Specifies the scope of the component. If scope is not specified,
+        # 'required' scope should be assumed by the consumer of the BOM
+        # Let's explicitly state that :)
+        "scope": "required",
+        # The name of the component, often shortened
+        # Examples: commons-lang3 and jquery
+        "name": spec.package.name,
+        # Associated mime-type. Spack doesn't have one officially
+        # This is what @vsoch using for oras push to an OCI registry
+        "mime-type": "application/vnd.spack.package",
+        # The grouping name or identifier. This will often be a shortened,
+        # single name of the company or project that produced the component,
+        # or the source package or domain name. Whitespace and special chars
+        # should be avoided. Examples include: apache, org.apache.commons.
+        "group": "spack.io",
+        # The component version, ideally semver
+        "version": str(spec.version),
+        # An optional identifier which can be used to reference the component
+        # elsewhere in the BOM. Every bom-ref should be unique.
+        # We can use the build hash since it's unique to this spec
+        "bom-ref": str(spec),
+        # Excluded
+        # publisher: The person(s) or organization(s) that published it
+        # author: The person(s) or organization(s) that authored the component
+        # supplier: The organization that supplied the component.
+        # licenses: spack doesn't have enough metadata to make a call
+        # copyright: An optional copyright notice
+        # purl: spack doesn't have these
+        # swid: ISO-IEC 19770-2 Software Identification (SWID) Tags
+        # pedigree: Component pedigree (document complex supply chain scenarios)
+        # components: components referenced within
+        # evidence: evidence collected through various forms of analysis.
+        # properites: extra name/value keypairs
+    }
+
+    # Specifies a description for the component
+    # Only add if not empty!
+    description = spec.package.format_doc()
+    if description:
+        component["description"] = description
+
+    # Add hashes, whichever might exist
+    # I looked for all unique hash types on 11/28
+    # names = set()
+    # for package in spack.repo.all_package_names():
+    #    spec = spack.spec.Spec(package)
+    #    for _, version in spec.package.versions.items():
+    #        for alg, _ in version.items():
+    #            names.add(alg)
+
+    component["hashes"] = []
+    for key, hashvalue in spec.package.versions.get(spec.version, {}).items():
+
+        # Covers both sha256 and sha256sum
+        if key.startswith("sha256"):
+            component["hashes"].append({"alg": "SHA-256", "content": hashvalue})
+
+    # External references?
+    if spec.package.all_urls:
+        component["externalReferences"] = []
+        for url in spec.package.all_urls:
+            component["externalReferences"].append({"type": "website", "url": url})
+
+    # Finally, custom spack metadata (properties)
+    component["properties"] = {
+        "spack:build_hash": spec.build_hash(),
+        "spack:dag_hash": spec.dag_hash(),
+        "spack:spec": str(spec),
+        "spack:build_spec": str(spec.build_spec),
+        "spack:architecture": str(spec.architecture),
+        "spack:variants": str(spec.variants),
+        "spack:compiler": str(spec.compiler),
+    }
+    return component
+
+
+def find_sbom(spec):
+    """
+    Find the path of an sbom, if it exists, otherwise return None
+    """
+    if os.path.exists(spec.sbom):
+        return spec.sbom
+
+
+def create_sbom(spec):
+    """
+    Create an sbom for a spec in the install directory.
+    """
+    if os.path.exists(spec.sbom):
+        tty.die("sbom already exists: %s" % spec.sbom)
+
+    # If more versions are ever supported, we can add them here.
+    sbom = generate_cyclonedx(spec)
+    with open(spec.sbom, 'w') as f:
+        sjson.dump(sbom, stream=f)
+    return spec.sbom
+
+
+def generate_cyclonedx(pkg):
+    """
+    Generates a CycloneDX sbom based on best practices suggested in the guide.
+    """
+    bom = template.copy()
+    if isinstance(pkg, spack.spec.Spec):
+        spec = pkg
+    else:
+        spec = spack.spec.Spec(pkg)
+
+    # Every BOM generated should have a unique serial number, even if contents
+    # being generated have not changed over time. The process/tool responsible
+    # for creating the BOM should create random UUID's for every BOM generated.
+    bom["serialNumber"] = "urn:uuid:" + str(uuid.uuid4())
+
+    # The date and time (timestamp) when the document was created.
+    metadata = {"timestamp": generate_timestamp_now()}
+
+    # The tool(s) used in the creation of the BOM.
+    metadata["tools"] = [
+        {
+            "vendor": "Lawrence Livermore National Lab",
+            "name": "Spack",
+            "version": spack.main.get_version(),
+        }
+    ]
+
+    # The person(s) who created the BOM. should be under authors
+    # Automatic generation won't have authors
+
+    # The component that the BOM describes.
+    metadata["component"] = get_component(spec)
+
+    # Skipped:
+    # manufacture: The organization that manufactured the component.
+    # supplier: The organization that supplied the component.
+
+    # Assume icenses under the bom describe spack, but not the component
+    metadata["licenses"] = [
+        {"license": {"name": "MIT"}},
+        {"license": {"name": "Apache-2.0"}},
+    ]
+    bom["metadata"] = metadata
+
+    # We might also assume that properties on this level could be for spack
+    # Could put more spack properties here.
+    deps = spec.dependencies()
+    components = {}
+
+    # Let's include all nested dependencies
+    if deps:
+        while deps:
+            dep = deps.pop(0)
+            deps = deps + dep.dependencies()
+
+            if str(dep) not in components:
+                components[str(dep)] = get_component(dep)
+
+    if components:
+        bom["components"] = components
+
+    # Finally, add direct dependencies
+    deps = spec.dependencies()
+    if deps:
+        bom["dependencies"] = []
+        for dep in deps:
+            # The bom-ref identifiers of the components that
+            # are dependencies of this dependency object.
+            dependsOn = [str(x) for x in dep.dependencies()]
+            bom["dependencies"].append({"ref": str(dep), "dependsOn": dependsOn})
+
+    # Add an external reference for spack packages, GitHub, etc.
+    bom["externalReferences"] = [
+        {"type": "website", "url": "https://github.com/spack/spack"},
+        {"type": "website", "url": "https://spack.github.io/packages"},
+    ]
+    return bom

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1502,6 +1502,13 @@ class Spec(object):
     def prefix(self, value):
         self._prefix = spack.util.prefix.Prefix(value)
 
+    @property
+    def sbom(self):
+        """
+        Get the sbom file associated with a spec (doesn't need to exist)
+        """
+        return os.path.join(self.prefix, ".spack", "sbom.json")
+
     def _spec_hash(self, hash):
         """Utility method for computing different types of Spec hashes.
 

--- a/lib/spack/spack/test/sbom.py
+++ b/lib/spack/spack/test/sbom.py
@@ -1,0 +1,75 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+
+import pytest
+
+import spack.sbom
+import spack.spec
+import spack.util.spack_json as sjson
+from spack.main import SpackCommand
+
+sbom_cmd = SpackCommand('sbom')
+
+
+@pytest.fixture(autouse=True)
+def restore_generation_state():
+    """
+    Restore original state before and after tests
+    """
+    spack.sbom.generate_sbom = False
+    yield
+    spack.sbom.generate_sbom = False
+
+
+def test_sbom_install_flag(install_mockery, mock_fetch):
+    """
+    Mock installing package with sbom
+    """
+    # Install with --sbom generates it
+    spec = spack.spec.Spec("dttop")
+    spec.concretize()
+    spec.package.do_install(force=True)
+    spack.sbom.create_sbom(spec)
+    assert os.path.exists(spec.sbom)
+
+
+def test_sbom_install_flag_absent(install_mockery, mock_fetch):
+    # Install without --sbom does not generates it
+    spec = spack.spec.Spec("dttop")
+    spec.concretize()
+    spec.package.do_install(force=True)
+    assert not os.path.exists(spec.sbom)
+
+
+def test_sbom_create(install_mockery, mock_fetch):
+    """
+    Sbom show should output json
+    """
+    spec = spack.spec.Spec("dttop")
+    spec.concretize()
+    spec.package.do_install(force=True)
+    assert not os.path.exists(spec.sbom)
+    out = sbom_cmd('create', 'dttop')
+    assert "sbom generated successfully" in out
+    assert os.path.exists(spec.sbom)
+
+    # We can't create if not installed
+    spec.package.do_uninstall(force=True)
+    out = sbom_cmd('create', 'dttop', fail_on_error=False)
+    assert "not installed" in out
+
+
+def test_sbom_show_path(install_mockery, mock_fetch):
+    """
+    Sbom show should output json
+    """
+    spec = spack.spec.Spec("dttop")
+    spec.concretize()
+    spec.package.do_install(force=True)
+    spack.sbom.create_sbom(spec)
+    out = sbom_cmd('show', 'dttop')
+    sjson.load(out)

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -337,7 +337,7 @@ _spack() {
     then
         SPACK_COMPREPLY="-h --help -H --all-help --color -c --config -C --config-scope -d --debug --show-cores --timestamp --pdb -e --env -D --env-dir -E --no-env --use-env-repo -k --insecure -l --enable-locks -L --disable-locks -m --mock -p --profile --sorted-profile --lines -v --verbose --stacktrace -V --version --print-shell-vars"
     else
-        SPACK_COMPREPLY="activate add analyze arch audit blame bootstrap build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers mark mirror module monitor patch pkg providers pydoc python reindex remove rm repo resource restage solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
+        SPACK_COMPREPLY="activate add analyze arch audit blame bootstrap build-env buildcache cd checksum ci clean clone commands compiler compilers concretize config containerize create deactivate debug dependencies dependents deprecate dev-build develop diff docs edit env extensions external fetch find gc gpg graph help info install license list load location log-parse maintainers mark mirror module monitor patch pkg providers pydoc python reindex remove rm repo resource restage sbom solve spec stage style tags test test-env tutorial undevelop uninstall unit-test unload url verify versions view"
     fi
 }
 
@@ -1166,7 +1166,7 @@ _spack_info() {
 _spack_install() {
     if $list_options
     then
-        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --reuse --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --use-cache --no-cache --cache-only --monitor --monitor-save-local --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
+        SPACK_COMPREPLY="-h --help --only -u --until -j --jobs --reuse --overwrite --fail-fast --keep-prefix --keep-stage --dont-restage --sbom --use-cache --no-cache --cache-only --monitor --monitor-save-local --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --include-build-deps --no-check-signature --require-full-hash-match --show-log-on-error --source -n --no-checksum --deprecated -v --verbose --fake --only-concrete --no-add -f --file --clean --dirty --test --run-tests --log-format --log-file --help-cdash --cdash-upload-url --cdash-build --cdash-site --cdash-track --cdash-buildstamp -y --yes-to-all"
     else
         _all_packages
     fi
@@ -1647,6 +1647,10 @@ _spack_restage() {
     else
         _all_packages
     fi
+}
+
+_spack_sbom() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_solve() {


### PR DESCRIPTION
We want to be able to generate software bills of material (sboms) for spack packages. These changes add:

 -  a new install flag --sbom that asks to generate one in the install directory
 -  a command group spack sbom to view an existing path, show an existing sbom in the terminal, or create a new sbom on te fly
 - tests and documentation for that.

CycloneDX seems to be a reasonable format to choose, however we could add more in the future if needed. I've also implemented this as a hook so it was easy to add post install success. 

Signed-off-by: vsoch <vsoch@users.noreply.github.com>