### PR TITLE
Add system compilers to `compilers.yaml`

### DIFF
--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -41,6 +41,7 @@ package:
 
    $ git clone -c feature.manyFiles=true https://github.com/spack/spack.git
    $ cd spack/bin
+   $ ./spack compiler find
    $ ./spack install libelf
 
 If you're new to spack and want to start using it, see :doc:`getting_started`,


### PR DESCRIPTION
As is, these instructions fail on my system with `No satisfying compiler available is compatible with a satisfying os`, despite recent compilers being available:
```
./spack compilers
==> Available compilers
-- clang opensuse_tumbleweed20220101-x86_64 ---------------------
clang@13.0.0  clang@12.0.1

-- gcc opensuse_tumbleweed20220101-x86_64 -----------------------
gcc@11.2.1  gcc@10.3.1
```
Seems that despite the compilers being found, they are not added to `.spack/linux/compilers.yaml`:

```
./spack compiler find
==> Added 3 new compilers to /home/brent/.spack/linux/compilers.yaml
    gcc@11.2.1  clang@13.0.1  clang@12.0.1
==> Compilers are defined in the following files:
    /home/brent/.spack/linux/compilers.yaml
```


Fixes #28911