### PR TITLE
FEniCS: avoid HDF5 version 1.12+

### DIFF
--- a/var/spack/repos/builtin/packages/fenics/package.py
+++ b/var/spack/repos/builtin/packages/fenics/package.py
@@ -100,8 +100,8 @@ class Fenics(CMakePackage):
     depends_on('boost+filesystem+program_options+system+iostreams+timer+regex+chrono@1.68.0', when='@:2018')
 
     depends_on('mpi', when='+mpi')
-    depends_on('hdf5+hl+fortran', when='+hdf5+petsc')
-    depends_on('hdf5+hl', when='+hdf5~petsc')
+    depends_on('hdf5@:1.10+hl+fortran', when='+hdf5+petsc')
+    depends_on('hdf5@:1.10+hl', when='+hdf5~petsc')
     depends_on('metis+real64', when='+parmetis')
     depends_on('parmetis', when='+parmetis')
     depends_on('scotch~metis', when='+scotch~mpi')


### PR DESCRIPTION
The new HDF5 version 1.12 API causes compiler errors due to modified
function prototypes.

The error message with FEniCS 2019.1 and HDF5 1.12.0:
```
/tmp/conradsc/spack-stage/spack-stage-fenics-2019.1.0.post0-bklvt4attuqpap4j7gtn
s6xpodrs2dga/spack-src/dolfin/io/HDF5Interface.cpp: In static member function 'static bool dolfin::HDF5Interface::has_group(hid_t, std::string)':
/tmp/conradsc/spack-stage/spack-stage-fenics-2019.1.0.post0-bklvt4attuqpap4j7gtns6xpodrs2dga/spack-src/dolfin/io/HDF5Interface.cpp:285:22: error: too few arguments to function 'herr_t H5Oget_info_by_name3(hid_t, const char*, H5O_info2_t*, unsigned int, hid_t)'
  285 |   H5Oget_info_by_name(hdf5_file_handle, group_name.c_str(), &object_info,
      |                      ^
In file included from /ccc/products2/hdf5-1.12.0/Rhel_8__aarch64-a64fx/gcc--11.1.0__openmpi--4.0.5/parallel/include/H5Apublic.h:22,
                 from /ccc/products2/hdf5-1.12.0/Rhel_8__aarch64-a64fx/gcc--11.1.0__openmpi--4.0.5/parallel/include/hdf5.h:23,
                 from /tmp/conradsc/spack-stage/spack-stage-fenics-2019.1.0.post0-bklvt4attuqpap4j7gtns6xpodrs2dga/spack-src/dolfin/io/HDF5Interface.h:32,
                 from /tmp/conradsc/spack-stage/spack-stage-fenics-2019.1.0.post0-bklvt4attuqpap4j7gtns6xpodrs2dga/spack-src/dolfin/io/HDF5Attribute.h:30,
                 from /tmp/conradsc/spack-stage/spack-stage-fenics-2019.1.0.post0-bklvt4attuqpap4j7gtns6xpodrs2dga/spack-src/dolfin/io/HDF5File.h:32,
                 from /tmp/conradsc/spack-stage/spack-stage-fenics-2019.1.0.post0-bklvt4attuqpap4j7gtns6xpodrs2dga/spack-src/dolfin/io/HDF5Interface.cpp:26:
/ccc/products2/hdf5-1.12.0/Rhel_8__aarch64-a64fx/gcc--11.1.0__openmpi--4.0.5/parallel/include/H5Opublic.h:188:15: note: declared here
  188 | H5_DLL herr_t H5Oget_info_by_name3(hid_t loc_id, const char *name, H5O_info2_t *oinfo,
      |               ^~~~~~~~~~~~~~~~~~~~
```