### PR TITLE
find_libraries: search for both .so and .dylib

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1638,12 +1638,18 @@ def find_libraries(libraries, root, shared=True, recursive=False):
         raise TypeError(message)
 
     # Construct the right suffix for the library
-    if shared is True:
-        suffix = 'dylib' if sys.platform == 'darwin' else 'so'
+    if shared:
+        # Used on both Linux and macOS
+        suffixes = ['so']
+        if sys.platform == 'darwin':
+            # Only used on macOS
+            suffixes.append('dylib')
     else:
-        suffix = 'a'
+        suffixes = ['a']
+
     # List of libraries we are searching with suffixes
-    libraries = ['{0}.{1}'.format(lib, suffix) for lib in libraries]
+    libraries = ['{0}.{1}'.format(lib, suffix) for lib in libraries
+                 for suffix in suffixes]
 
     if not recursive:
         # If not recursive, look for the libraries directly in root


### PR DESCRIPTION
On Linux, _all_ shared object libraries end in `.so`. On macOS, _most_ dynamic libraries end in `.dylib`, but _many_ still use `.so`. This can be due to a bug in their build system configuration, or for other reasons.

The vast majority of Python libraries on macOS use `.so` instead of `.dylib`. For example, with `py-numpy`:
```console
$ find . -name '*.dylib'
$ find . -name '*.so'
./lib/python3.9/site-packages/numpy/core/_operand_flag_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_multiarray_umath.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_simd.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_rational_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_umath_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_struct_ufunc_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/core/_multiarray_tests.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/linalg/lapack_lite.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/linalg/_umath_linalg.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/fft/_pocketfft_internal.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/bit_generator.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/mtrand.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_generator.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_pcg64.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_sfc64.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_mt19937.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_philox.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_bounded_integers.cpython-39-darwin.so
./lib/python3.9/site-packages/numpy/random/_common.cpython-39-darwin.so
```
Some packages like `py-torch` actually use both:
```console
$ find . -name '*.dylib'
./lib/python3.9/site-packages/torch/lib/libtorch_python.dylib
./lib/python3.9/site-packages/torch/lib/libtorch.dylib
./lib/python3.9/site-packages/torch/lib/libcaffe2_observers.dylib
./lib/python3.9/site-packages/torch/lib/libtorch_global_deps.dylib
./lib/python3.9/site-packages/torch/lib/libiomp5.dylib
./lib/python3.9/site-packages/torch/lib/libtorch_cpu.dylib
./lib/python3.9/site-packages/torch/lib/libc10.dylib
./lib/python3.9/site-packages/torch/lib/libcaffe2_detectron_ops.dylib
./lib/python3.9/site-packages/torch/lib/libshm.dylib
$ find . -name '*.so'
./lib/python3.9/site-packages/caffe2/python/caffe2_pybind11_state.cpython-39-darwin.so
./lib/python3.9/site-packages/torch/_dl.cpython-39-darwin.so
./lib/python3.9/site-packages/torch/_C.cpython-39-darwin.so
```
This PR allows `find_libraries` to handle these kinds of situations. The code is almost identical to what we use in `find_headers` where we want to handle multiple possible file extensions.