### PR TITLE
darwin: make sure MACOSX_DEPLOYMENT_TARGET has a minor component

### DIFF
--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -60,4 +60,13 @@ class Darwin(Platform):
         """
 
         os = self.operating_sys[pkg.spec.os]
-        env.set('MACOSX_DEPLOYMENT_TARGET', str(os.version))
+        version = os.version
+        if len(version) == 1:
+            # Version has only one component: add a minor version to prevent
+            # potential errors with `ld`,
+            # which fails with `-macosx_version_min 11`
+            # but succeeds with `-macosx_version_min 11.0`.
+            # Most compilers seem to perform this translation automatically,
+            # but older GCC does not.
+            version = str(version) + '.0'
+        env.set('MACOSX_DEPLOYMENT_TARGET', str(version))


### PR DESCRIPTION
Follow-on to #28797 . 

Older versions of GCC (8.3 and probably others) directly propagate `MACOSX_DEPLOYMENT_TARGET` to `ld` rather than padding with `.0.0` like newer ones. This leads to a failure:
```console
$ ld -macosx_version_min 11
ld: -macos_version_min value malformed: '11'
```
whereas `ld -macosx_version_min 11.0 ...` works.

So this commit tests for the macOS version having only a single component and adds `.0` if that's the case. This choice is consistent with what CMake does and ensures that libraries on the same major OS are all compatible.