### PR TITLE
OpenMC: new version 0.13.0

### DIFF
--- a/var/spack/repos/builtin/packages/openmc/package.py
+++ b/var/spack/repos/builtin/packages/openmc/package.py
@@ -8,18 +8,22 @@ from spack import *
 
 
 class Openmc(CMakePackage):
-    """The OpenMC project aims to provide a fully-featured Monte Carlo particle
-       transport code based on modern methods. It is a constructive solid
-       geometry, continuous-energy transport code that uses ACE format cross
-       sections. The project started under the Computational Reactor Physics
-       Group at MIT."""
+    """OpenMC is a community-developed Monte Carlo neutron and photon transport
+       simulation code. It is capable of performing fixed source, k-eigenvalue, and
+       subcritical multiplication calculations on models built using either a
+       constructive solid geometry or CAD representation. OpenMC supports both
+       continuous-energy and multigroup transport. The continuous-energy particle
+       interaction data is based on a native HDF5 format that can be generated from ACE
+       files produced by NJOY. Parallelism is enabled via a hybrid MPI and OpenMP
+       programming model."""
 
     homepage = "https://docs.openmc.org/"
-    url = "https://github.com/openmc-dev/openmc/tarball/v0.12.2"
+    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.0"
     git = "https://github.com/openmc-dev/openmc.git"
 
     version('develop', branch='develop', submodules=True)
     version('master', branch='master', submodules=True)
+    version('0.13.0', tag='v0.13.0', submodules=True)
     version('0.12.2', tag='v0.12.2', submodules=True)
     version('0.12.1', tag='v0.12.1', submodules=True)
     version('0.12.0', tag='v0.12.0', submodules=True)

--- a/var/spack/repos/builtin/packages/openmc/package.py
+++ b/var/spack/repos/builtin/packages/openmc/package.py
@@ -23,10 +23,10 @@ class Openmc(CMakePackage):
 
     version('develop', branch='develop', submodules=True)
     version('master', branch='master', submodules=True)
-    version('0.13.0', tag='v0.13.0', submodules=True)
-    version('0.12.2', tag='v0.12.2', submodules=True)
-    version('0.12.1', tag='v0.12.1', submodules=True)
-    version('0.12.0', tag='v0.12.0', submodules=True)
+    version('0.13.0', commit='cff247e35785e7236d67ccf64a3401f0fc50a469', submodules=True)
+    version('0.12.2', commit='cbfcf908f8abdc1ef6603f67872dcf64c5c657b1', submodules=True)
+    version('0.12.1', commit='36913589c4f43b7f843332181645241f0f10ae9e', submodules=True)
+    version('0.12.0', commit='93d6165ecb455fc57242cd03a3f0805089c0e0b9', submodules=True)
     version('0.11.0', sha256='19a9d8e9c3b581e9060fbd96d30f1098312d217cb5c925eb6372a5786d9175af')
     version('0.10.0', sha256='47650cb45e2c326ae439208d6f137d75ad3e5c657055912d989592c6e216178f')
 

--- a/var/spack/repos/builtin/packages/py-openmc/package.py
+++ b/var/spack/repos/builtin/packages/py-openmc/package.py
@@ -7,18 +7,22 @@ from spack import *
 
 
 class PyOpenmc(PythonPackage):
-    """The OpenMC project aims to provide a fully-featured Monte Carlo particle
-       transport code based on modern methods. It is a constructive solid
-       geometry, continuous-energy transport code that uses ACE format cross
-       sections. The project started under the Computational Reactor Physics
-       Group at MIT."""
+    """OpenMC is a community-developed Monte Carlo neutron and photon transport
+       simulation code. It is capable of performing fixed source, k-eigenvalue, and
+       subcritical multiplication calculations on models built using either a
+       constructive solid geometry or CAD representation. OpenMC supports both
+       continuous-energy and multigroup transport. The continuous-energy particle
+       interaction data is based on a native HDF5 format that can be generated from ACE
+       files produced by NJOY. Parallelism is enabled via a hybrid MPI and OpenMP
+       programming model."""
 
     homepage = "https://docs.openmc.org/"
-    url = "https://github.com/openmc-dev/openmc/tarball/v0.12.2"
+    url = "https://github.com/openmc-dev/openmc/tarball/v0.13.0"
     git = "https://github.com/openmc-dev/openmc.git"
 
     version('develop', branch='develop')
     version('master', branch='master')
+    version('0.13.0', tag='v0.13.0', submodules=True)
     version('0.12.2', tag='v0.12.2', submodules=True)
     version('0.12.1', tag='v0.12.1', submodules=True)
     version('0.12.0', tag='v0.12.0', submodules=True)
@@ -27,7 +31,7 @@ class PyOpenmc(PythonPackage):
     variant('mpi', default=False, description='Enable MPI support')
 
     # keep py-openmc and openmc at the same version
-    for ver in ['develop', 'master', '0.12.2', '0.12.1', '0.12.0', '0.11.0']:
+    for ver in ['develop', 'master', '0.13.0', '0.12.2', '0.12.1', '0.12.0', '0.11.0']:
         depends_on(
             'openmc+mpi@{0}'.format(ver), when='@{0}+mpi'.format(ver),
             type=('build', 'run')
@@ -38,7 +42,7 @@ class PyOpenmc(PythonPackage):
         )
 
     depends_on('git', type='build')
-    depends_on('python@3.5:', type=('build', 'run'))
+    depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-cython', type='build')
     depends_on('py-h5py~mpi', when='~mpi', type=('build', 'run'))
     depends_on('py-h5py+mpi', when='+mpi', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-openmc/package.py
+++ b/var/spack/repos/builtin/packages/py-openmc/package.py
@@ -42,7 +42,8 @@ class PyOpenmc(PythonPackage):
         )
 
     depends_on('git', type='build')
-    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('python@3.6:', type=('build', 'run'), when='@0.13:')
+    depends_on('python@3.5:', type=('build', 'run'), when='@:0.12')
     depends_on('py-cython', type='build')
     depends_on('py-h5py~mpi', when='~mpi', type=('build', 'run'))
     depends_on('py-h5py+mpi', when='+mpi', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-openmc/package.py
+++ b/var/spack/repos/builtin/packages/py-openmc/package.py
@@ -22,10 +22,10 @@ class PyOpenmc(PythonPackage):
 
     version('develop', branch='develop')
     version('master', branch='master')
-    version('0.13.0', tag='v0.13.0', submodules=True)
-    version('0.12.2', tag='v0.12.2', submodules=True)
-    version('0.12.1', tag='v0.12.1', submodules=True)
-    version('0.12.0', tag='v0.12.0', submodules=True)
+    version('0.13.0', commit='cff247e35785e7236d67ccf64a3401f0fc50a469', submodules=True)
+    version('0.12.2', commit='cbfcf908f8abdc1ef6603f67872dcf64c5c657b1', submodules=True)
+    version('0.12.1', commit='36913589c4f43b7f843332181645241f0f10ae9e', submodules=True)
+    version('0.12.0', commit='93d6165ecb455fc57242cd03a3f0805089c0e0b9', submodules=True)
     version('0.11.0', sha256='19a9d8e9c3b581e9060fbd96d30f1098312d217cb5c925eb6372a5786d9175af')
 
     variant('mpi', default=False, description='Enable MPI support')


### PR DESCRIPTION
This PR adds version 0.13.0 for packages openmc and py-openmc.