### PR TITLE
trilinos: add adelus, aprepro and teuchos variants

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -94,9 +94,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('x11',          default=False, description='Compile with X11 when +exodus')
 
     # Package options (alphabet order)
+    variant('adelus',       default=False, description='Compile with Adelus')
     variant('amesos',       default=True, description='Compile with Amesos')
     variant('amesos2',      default=True, description='Compile with Amesos2')
     variant('anasazi',      default=True, description='Compile with Anasazi')
+    variant('aprepro',      default=False, description='Compile with Aprepro from SEACAS')
     variant('aztec',        default=True, description='Compile with Aztec')
     variant('belos',        default=True, description='Compile with Belos')
     variant('chaco',        default=False, description='Compile with Chaco from SEACAS')
@@ -128,8 +130,10 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('teko',         default=False, description='Compile with Teko')
     variant('tempus',       default=False, description='Compile with Tempus')
     variant('thyra',        default=False, description='Compile with Thyra')
+    variant('teuchos',      default=False, description='Compile with Teuchos')
     variant('tpetra',       default=True, description='Compile with Tpetra')
     variant('trilinoscouplings', default=False, description='Compile with TrilinosCouplings')
+    variant('triutils',     default=False, description='Compile with Triutils')
     variant('zoltan',       default=False, description='Compile with Zoltan')
     variant('zoltan2',      default=False, description='Compile with Zoltan2')
 
@@ -527,6 +531,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         # ################## Trilinos Packages #####################
 
         options.extend([
+            define_trilinos_enable('Adelus'),
             define_trilinos_enable('Amesos'),
             define_trilinos_enable('Amesos2'),
             define_trilinos_enable('Anasazi'),
@@ -565,8 +570,10 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('Teko'),
             define_trilinos_enable('Tempus'),
             define_trilinos_enable('Thyra'),
+            define_trilinos_enable('Teuchos'),
             define_trilinos_enable('Tpetra'),
             define_trilinos_enable('TrilinosCouplings'),
+            define_trilinos_enable('Triutils'),
             define_trilinos_enable('Zoltan'),
             define_trilinos_enable('Zoltan2'),
             define_from_variant('EpetraExt_BUILD_BTF', 'epetraextbtf'),
@@ -582,6 +589,16 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             options.extend([
                 define('Trilinos_EXTRA_REPOSITORIES', 'DataTransferKit'),
                 define_trilinos_enable('DataTransferKit', True),
+            ])
+
+        if '+aprepro' in spec:
+            options.extend([
+                define_trilinos_enable('SEACAS', True),
+                define_trilinos_enable('SEACASAprepro', True),
+            ])
+        else:
+            options.extend([
+                define_trilinos_enable('SEACASAprepro', False),
             ])
 
         if '+exodus' in spec:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -255,6 +255,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     # Known requirements from tribits dependencies
     conflicts('~thyra', when='+stratimikos')
     conflicts('+aztec', when='~fortran')
+    conflicts('+aztec', when='~triutils')
     conflicts('+basker', when='~amesos2')
     conflicts('+ifpack2', when='~belos')
     conflicts('+intrepid', when='~sacado')
@@ -537,6 +538,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('Amesos'),
             define_trilinos_enable('Amesos2'),
             define_trilinos_enable('Anasazi'),
+            define_trilinos_enable('AztecOO', 'aztec'),
             define_trilinos_enable('Belos'),
             define_trilinos_enable('Epetra'),
             define_trilinos_enable('EpetraExt'),
@@ -588,11 +590,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_from_variant('Amesos2_ENABLE_Basker', 'basker'),
             define_from_variant('Amesos2_ENABLE_LAPACK', 'amesos2'),
         ])
-
-        if '+aztec' in spec and '+triutils' in spec:
-            options.extend([
-                define_trilinos_enable('AztecOO', 'aztec'),
-            ])
 
         if '+dtk' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -129,10 +129,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('teko',         default=False, description='Compile with Teko')
     variant('tempus',       default=False, description='Compile with Tempus')
     variant('thyra',        default=False, description='Compile with Thyra')
-    variant('teuchos',      default=False, description='Compile with Teuchos')
     variant('tpetra',       default=True, description='Compile with Tpetra')
     variant('trilinoscouplings', default=False, description='Compile with TrilinosCouplings')
-    variant('triutils',     default=False, description='Compile with Triutils')
     variant('zoltan',       default=False, description='Compile with Zoltan')
     variant('zoltan2',      default=False, description='Compile with Zoltan2')
 
@@ -253,7 +251,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('~thyra', when='+stratimikos')
     conflicts('+adelus', when='~kokkos')
     conflicts('+aztec', when='~fortran')
-    conflicts('+aztec', when='~triutils')
     conflicts('+basker', when='~amesos2')
     conflicts('+ifpack2', when='~belos')
     conflicts('+intrepid', when='~sacado')
@@ -571,10 +568,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('Teko'),
             define_trilinos_enable('Tempus'),
             define_trilinos_enable('Thyra'),
-            define_trilinos_enable('Teuchos'),
             define_trilinos_enable('Tpetra'),
             define_trilinos_enable('TrilinosCouplings'),
-            define_trilinos_enable('Triutils'),
+            define_trilinos_enable('Triutils', True),
             define_trilinos_enable('Zoltan'),
             define_trilinos_enable('Zoltan2'),
             define_from_variant('EpetraExt_BUILD_BTF', 'epetraextbtf'),

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -98,7 +98,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('amesos',       default=True, description='Compile with Amesos')
     variant('amesos2',      default=True, description='Compile with Amesos2')
     variant('anasazi',      default=True, description='Compile with Anasazi')
-    variant('aprepro',      default=False, description='Compile with Aprepro from SEACAS')
     variant('aztec',        default=True, description='Compile with Aztec')
     variant('belos',        default=True, description='Compile with Belos')
     variant('chaco',        default=False, description='Compile with Chaco from SEACAS')
@@ -129,8 +128,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('stratimikos',  default=False, description='Compile with Stratimikos')
     variant('teko',         default=False, description='Compile with Teko')
     variant('tempus',       default=False, description='Compile with Tempus')
+<<<<<<< HEAD
     variant('thyra',        default=False, description='Compile with Thyra')
     variant('teuchos',      default=False, description='Compile with Teuchos')
+=======
+>>>>>>> Respond to coments in PR #28935
     variant('tpetra',       default=True, description='Compile with Tpetra')
     variant('trilinoscouplings', default=False, description='Compile with TrilinosCouplings')
     variant('triutils',     default=False, description='Compile with Triutils')
@@ -569,8 +571,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('Stratimikos'),
             define_trilinos_enable('Teko'),
             define_trilinos_enable('Tempus'),
+<<<<<<< HEAD
             define_trilinos_enable('Thyra'),
             define_trilinos_enable('Teuchos'),
+=======
+>>>>>>> Respond to coments in PR #28935
             define_trilinos_enable('Tpetra'),
             define_trilinos_enable('TrilinosCouplings'),
             define_trilinos_enable('Triutils'),
@@ -589,16 +594,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             options.extend([
                 define('Trilinos_EXTRA_REPOSITORIES', 'DataTransferKit'),
                 define_trilinos_enable('DataTransferKit', True),
-            ])
-
-        if '+aprepro' in spec:
-            options.extend([
-                define_trilinos_enable('SEACAS', True),
-                define_trilinos_enable('SEACASAprepro', True),
-            ])
-        else:
-            options.extend([
-                define_trilinos_enable('SEACASAprepro', False),
             ])
 
         if '+exodus' in spec:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -537,7 +537,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('Amesos'),
             define_trilinos_enable('Amesos2'),
             define_trilinos_enable('Anasazi'),
-            define_trilinos_enable('AztecOO', 'aztec'),
             define_trilinos_enable('Belos'),
             define_trilinos_enable('Epetra'),
             define_trilinos_enable('EpetraExt'),
@@ -589,6 +588,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_from_variant('Amesos2_ENABLE_Basker', 'basker'),
             define_from_variant('Amesos2_ENABLE_LAPACK', 'amesos2'),
         ])
+
+        if '+aztec' in spec and '+triutils' in spec:
+            options.extend([
+                define_trilinos_enable('AztecOO', 'aztec'),
+            ])
 
         if '+dtk' in spec:
             options.extend([

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -128,11 +128,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('stratimikos',  default=False, description='Compile with Stratimikos')
     variant('teko',         default=False, description='Compile with Teko')
     variant('tempus',       default=False, description='Compile with Tempus')
-<<<<<<< HEAD
     variant('thyra',        default=False, description='Compile with Thyra')
     variant('teuchos',      default=False, description='Compile with Teuchos')
-=======
->>>>>>> Respond to coments in PR #28935
     variant('tpetra',       default=True, description='Compile with Tpetra')
     variant('trilinoscouplings', default=False, description='Compile with TrilinosCouplings')
     variant('triutils',     default=False, description='Compile with Triutils')
@@ -254,6 +251,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     # Known requirements from tribits dependencies
     conflicts('~thyra', when='+stratimikos')
+    conflicts('+adelus', when='~kokkos')
     conflicts('+aztec', when='~fortran')
     conflicts('+aztec', when='~triutils')
     conflicts('+basker', when='~amesos2')
@@ -572,11 +570,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('Stratimikos'),
             define_trilinos_enable('Teko'),
             define_trilinos_enable('Tempus'),
-<<<<<<< HEAD
             define_trilinos_enable('Thyra'),
             define_trilinos_enable('Teuchos'),
-=======
->>>>>>> Respond to coments in PR #28935
             define_trilinos_enable('Tpetra'),
             define_trilinos_enable('TrilinosCouplings'),
             define_trilinos_enable('Triutils'),


### PR DESCRIPTION
Gemma uses a different stack than most FE codes. All new
variants are off by default and this shoudl not affect
current users.