### PR TITLE
direnv-prefix: fix path for direnv installation

### DIFF
--- a/var/spack/repos/builtin/packages/direnv/package.py
+++ b/var/spack/repos/builtin/packages/direnv/package.py
@@ -12,6 +12,8 @@ class Direnv(Package):
     homepage = "https://direnv.net/"
     url      = "https://github.com/direnv/direnv/archive/v2.11.3.tar.gz"
 
+    maintainers = ['acastanedam']
+
     version('2.30.2', sha256='a2ee14ebdbd9274ba8bf0896eeb94e98947a056611058dedd4dbb43167e076f3')
     version('2.20.0', sha256='cc72525b0a5b3c2ab9a52a3696e95562913cd431f923bcc967591e75b7541bff')
     version('2.11.3', sha256='2d34103a7f9645059270763a0cfe82085f6d9fe61b2a85aca558689df0e7b006')
@@ -19,4 +21,4 @@ class Direnv(Package):
     depends_on('go', type='build')
 
     def install(self, spec, prefix):
-        make('install', "DESTDIR=%s" % prefix)
+        make('install', "PREFIX=%s" % prefix)


### PR DESCRIPTION
Setting Spack's `$prefix` to `$DESTDIR` and not to `$PREFIX` install the
package in `$prefix/usr/local` and not in `$prefix`, thus when it is
loaded the executable `direnv` in not "seen" by the environment.