### PR TITLE
edm4hep: Add dependencies to py-jinja2 and py-pyyaml

### DIFF
--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -35,6 +35,8 @@ class Edm4hep(CMakePackage):
     depends_on('root@6.08:')
     depends_on('podio@0.14:', when='@0.4:')
     depends_on('podio@0.13.0:0.13', when='@:0.3')
+    depends_on('py-jinja2')
+    depends_on('py-pyyaml')
 
     depends_on('hepmc@:2', type='test', when='@:0.4.0')
     depends_on('hepmc3', type='test', when='@0.4.1:')

--- a/var/spack/repos/builtin/packages/edm4hep/package.py
+++ b/var/spack/repos/builtin/packages/edm4hep/package.py
@@ -35,8 +35,8 @@ class Edm4hep(CMakePackage):
     depends_on('root@6.08:')
     depends_on('podio@0.14:', when='@0.4:')
     depends_on('podio@0.13.0:0.13', when='@:0.3')
-    depends_on('py-jinja2')
-    depends_on('py-pyyaml')
+    depends_on('py-jinja2', type='build')
+    depends_on('py-pyyaml', type='build')
 
     depends_on('hepmc@:2', type='test', when='@:0.4.0')
     depends_on('hepmc3', type='test', when='@0.4.1:')


### PR DESCRIPTION
This error occurred when trying to install edm4hep:
```
==> Installing edm4hep-0.4-72vsbtlchqxpvqx3x3ay4vmoffo2bvaa
==> No binary for edm4hep-0.4-72vsbtlchqxpvqx3x3ay4vmoffo2bvaa found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/bc/bcb729cd4a6f5917b8f073364fc950788111e178dd16b7e5218361f459c92a24.tar.gz
==> No patches needed for edm4hep
==> edm4hep: Executing phase: 'cmake'
==> Error: ProcessError: Command exited with status 1:
    'cmake' '-G' 'Unix Makefiles' '-DCMAKE_INSTALL_PREFIX:STRING=/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/edm4hep-0.4-72vsbtlchqxpvqx3x3ay4vmoffo2bvaa' '-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo' '-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=OFF' '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF' '-DCMAKE_INSTALL_RPATH:STRING=/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/edm4hep-0.4-72vsbtlchqxpvqx3x3ay4vmoffo2bvaa/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/edm4hep-0.4-72vsbtlchqxpvqx3x3ay4vmoffo2bvaa/lib64;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/root-6.24.06-nanzhgikec4g73tpeo2jf6tvrb5nqdo3/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxml2-2.9.12-s3p4otfheiuouq5bt6v3wo77cgh3fcf3/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libiconv-1.16-ysmxtkjp6q3ms4z6mpjqfcyrjp6r55nr/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xz-5.2.5-g2ga2av32mh2krepklj42jluye6f2cvb/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/zlib-1.2.11-3c6bs4ymmw5jrk25bfytaz2fxrd46z3c/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/openssl-1.1.1m-mywapix4cqow7x4wymsdae2vzplopp5n/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/util-linux-uuid-2.36.2-jxcbiki2u3a7oiux4ix6cydrcfat3ipe/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/freetype-2.11.1-wtlajio3lc4o4lzfmnxscpfvoqd5o2xl/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/bzip2-1.0.8-kwcnqct7d2kyrs3o55oqzyyojbed6r5e/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libpng-1.6.37-u7277cqwcs3pjzwr6te42by4mp4cccrs/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/ftgl-2.4.0-yzjae2hpxvm3jh53oclhmlpeu4mtcokh/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/mesa-21.3.1-4dt2c63hde3pyist2g5lu3j4ragct5p4/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/expat-2.4.4-cauloqka2pirtf6mz3p3fxlkurkmqupm/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libbsd-0.11.3-ysw6qfwvc7isxgtao27wgpjsdv3cuqzk/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libmd-1.0.3-7jbwhjphctficzfhnfau4vojmyvmjvqt/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/glproto-1.4.17-hxiv7zn42mntkk2bto5pzgo5iqpvlgqk/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libunwind-1.5.0-r6mqqimdyfeq4mhq66bqlyjfsnlvef5j/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libx11-1.7.0-uhpc2zzbslsym2gyxfywoghfwoaoi6aw/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/inputproto-2.3.2-7te46ytdvj3mxs5qvyn4ltftosncp65h/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/kbproto-1.0.7-o76op6hcqiankopups356d2dscifj6ko/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxcb-1.14-smqiv3bawoxofcka7xrl6mupkx7dvqe4/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libpthread-stubs-0.4-2ku6p7nugl7srmovfszh3va55hqwdhdm/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxau-1.0.8-bi27ikv5lilybykyntfnzyyg3eznqzfv/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xproto-7.0.31-bcdbslol3uak2cbjpjwyfera6fa34myh/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxdmcp-1.1.2-sxrueyz4uq62xye4575uoprqpvpw6cb4/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xcb-proto-1.14.1-7yr2fjl4itq2ln3sglj4q4dorwomnaqr/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xextproto-7.3.0-nimmzurw4nrkiqsv54hjior22r4oevzp/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxext-1.3.3-gzszx2q2frafr3wzq2ij5tss7mfqsoky/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxt-1.1.5-voh45wkvlk6jtkwzkl4q2gzjd46rytws/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libice-1.0.9-bfpsmwpww3oq2v7sqr2fxyasnqyppyop/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libsm-1.2.3-6cdhs6owf5dn4wrwd26ibyi4nhl6a7h4/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/llvm-11.1.0-bhkwlicmawyr6znk5eryzbqsqcwvjq5w/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/binutils-2.37-fwczw6svvzjqekpdayb3l4pcbzuy3vst/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/gettext-0.21-wgilpbhbulorxwgnyfiiqcjgxdk73gjv/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/ncurses-6.2-jpfyxqa242ptdyw3orflx6xamgafxyhw/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/hwloc-2.7.0-bs4yyyuybhufiicvl2zeaipuoyr4kxgp/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libpciaccess-0.16-jf74kkwogvjr46ziyz7hr6tsbwfqs3eu/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libedit-3.1-20210216-6piex6ukkp3o2rapy3a5gxlnvb2p4tea/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/pcre-8.44-prs7qcnpgmzwjtcsflkvbhpjq7gkrolr/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxrandr-1.5.0-ac77n2wacacjmaechy4r4bhxhtndtqlm/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxrender-0.9.10-hx7zaay5kncpkd637jsnez7xpvdg3fxw/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/renderproto-0.11.1-op2nhflpizsovbwdmpfu4267rwurzeki/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/randrproto-1.5.0-ufpejzbn2zdmze3cqxvapgdhyydmqzv6/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/mesa-glu-9.0.1-am64kwlfjc2zokq7pay6azwstl4p6bja/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/gl2ps-1.4.2-44ymjnmkf36evslkbi2f25xqodxakvgi/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxi-1.7.6-uzbr4op5sx6ub2zu32laet3v43gcofic/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/fixesproto-5.0-yz5pur6pmn7pugjuvbnc7we65wujy6ss/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxfixes-5.0.2-nus3yqyh7t2ux7eedav3js3ruqnyxnhy/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxxf86vm-1.1.4-r7qsbzwaeglbpkt4sezoemnmvtuevqv5/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xf86vidmodeproto-2.3.1-6w3b2ccu7glnvh66zy3lhkw6udgxevo5/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libdrm-2.4.100-5k3nnrcik7h6zou5widuwsyycyv45e6l/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxdamage-1.1.4-p2kc5k4io4iiaaxeobr4tdlukwasieos/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/damageproto-1.2.1-v6pervyj7bzvhwnahjbjzzsjwjrkch4w/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxmu-1.1.2-hz2z3jk73ds7u4oduntwc6ogcedcuy2o/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/gsl-2.7-oj4gotqwgnbwiabmdemldlc75loqoab5/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/intel-tbb-2020.3-rugen3ysgfhq5i56y6mq4yxqloo7nl33/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxft-2.3.2-52vs36ettmctlm24t3hqtcg4vivntidq/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/fontconfig-2.13.94-mnc4puswa6ws7deu6ngwzuo3acw4264w/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/font-util-1.3.2-x2vxknky4gg4cjsclrlmltw4rw42dcrk/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxpm-3.5.12-lpsfeljofvrn6urrx55uvo4cj26py5e6/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/lz4-1.9.3-gawultiwpvykrqm3454gp5q72soyvewj/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/openblas-0.3.19-sjj2qmfoxqzztuypvcceddja7dn3jxxp/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/unuran-1.8.1-fbsglzwkbmqc36gs7nyrs3htb7elmu7a/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/rngstreams-1.0.1-sakrzaqmko3ffmf7gakryremi2zba7eg/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/vdt-0.4.3-u2532pdxyiexiro7xzgf7ggwrzxqubsu/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xxhash-0.8.0-46qmxifplmqbubspjwnza3hiamuffmbr/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/zstd-1.5.0-qsq3clh62sufybkkzgbkqklvrp55b747/lib;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/podio-0.14-com5csw4ukvk6nnohzlzb4vrhheffaer/lib64;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/davix-0.7.6-fqxnjho4r5i5qten2ng2ibz5mdavqto6/lib64;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/freeglut-3.2.1-bxoraic3doh2j3pfhxdvpik2lclstw5c/lib64;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/glew-2.1.0-ooxum563qomx4w43vjthjcsd4ngki3kd/lib64;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libjpeg-turbo-2.1.0-fenyjtd3jehrycw2ipbgq7lelkb7vnnu/lib64;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/nlohmann-json-3.10.5-arvf64pfen3ijarefr3ulftrb4db6h6p/lib64' '-DCMAKE_PREFIX_PATH:STRING=/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/podio-0.14-com5csw4ukvk6nnohzlzb4vrhheffaer;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/root-6.24.06-nanzhgikec4g73tpeo2jf6tvrb5nqdo3;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/zstd-1.5.0-qsq3clh62sufybkkzgbkqklvrp55b747;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xxhash-0.8.0-46qmxifplmqbubspjwnza3hiamuffmbr;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/vdt-0.4.3-u2532pdxyiexiro7xzgf7ggwrzxqubsu;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/unuran-1.8.1-fbsglzwkbmqc36gs7nyrs3htb7elmu7a;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/rngstreams-1.0.1-sakrzaqmko3ffmf7gakryremi2zba7eg;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/openblas-0.3.19-sjj2qmfoxqzztuypvcceddja7dn3jxxp;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/nlohmann-json-3.10.5-arvf64pfen3ijarefr3ulftrb4db6h6p;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/lz4-1.9.3-gawultiwpvykrqm3454gp5q72soyvewj;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxpm-3.5.12-lpsfeljofvrn6urrx55uvo4cj26py5e6;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxft-2.3.2-52vs36ettmctlm24t3hqtcg4vivntidq;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/fontconfig-2.13.94-mnc4puswa6ws7deu6ngwzuo3acw4264w;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/font-util-1.3.2-x2vxknky4gg4cjsclrlmltw4rw42dcrk;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libjpeg-turbo-2.1.0-fenyjtd3jehrycw2ipbgq7lelkb7vnnu;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/intel-tbb-2020.3-rugen3ysgfhq5i56y6mq4yxqloo7nl33;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/gsl-2.7-oj4gotqwgnbwiabmdemldlc75loqoab5;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/glew-2.1.0-ooxum563qomx4w43vjthjcsd4ngki3kd;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/gl2ps-1.4.2-44ymjnmkf36evslkbi2f25xqodxakvgi;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxmu-1.1.2-hz2z3jk73ds7u4oduntwc6ogcedcuy2o;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxdamage-1.1.4-p2kc5k4io4iiaaxeobr4tdlukwasieos;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/damageproto-1.2.1-v6pervyj7bzvhwnahjbjzzsjwjrkch4w;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libdrm-2.4.100-5k3nnrcik7h6zou5widuwsyycyv45e6l;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/freeglut-3.2.1-bxoraic3doh2j3pfhxdvpik2lclstw5c;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxxf86vm-1.1.4-r7qsbzwaeglbpkt4sezoemnmvtuevqv5;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xf86vidmodeproto-2.3.1-6w3b2ccu7glnvh66zy3lhkw6udgxevo5;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxi-1.7.6-uzbr4op5sx6ub2zu32laet3v43gcofic;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxfixes-5.0.2-nus3yqyh7t2ux7eedav3js3ruqnyxnhy;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/fixesproto-5.0-yz5pur6pmn7pugjuvbnc7we65wujy6ss;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/ftgl-2.4.0-yzjae2hpxvm3jh53oclhmlpeu4mtcokh;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/mesa-glu-9.0.1-am64kwlfjc2zokq7pay6azwstl4p6bja;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/mesa-21.3.1-4dt2c63hde3pyist2g5lu3j4ragct5p4;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xrandr-1.5.0-ydu4epjmmfbheiqp5ajdwhkjkuacg3uu;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxrandr-1.5.0-ac77n2wacacjmaechy4r4bhxhtndtqlm;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/randrproto-1.5.0-ufpejzbn2zdmze3cqxvapgdhyydmqzv6;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxrender-0.9.10-hx7zaay5kncpkd637jsnez7xpvdg3fxw;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/renderproto-0.11.1-op2nhflpizsovbwdmpfu4267rwurzeki;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/llvm-11.1.0-bhkwlicmawyr6znk5eryzbqsqcwvjq5w;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/swig-4.0.2-u4pirvw3isndz6s7txmpptvkqfib3h7j;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/pcre-8.44-prs7qcnpgmzwjtcsflkvbhpjq7gkrolr;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libedit-3.1-20210216-6piex6ukkp3o2rapy3a5gxlnvb2p4tea;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/hwloc-2.7.0-bs4yyyuybhufiicvl2zeaipuoyr4kxgp;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libpciaccess-0.16-jf74kkwogvjr46ziyz7hr6tsbwfqs3eu;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/binutils-2.37-fwczw6svvzjqekpdayb3l4pcbzuy3vst;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxt-1.1.5-voh45wkvlk6jtkwzkl4q2gzjd46rytws;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libsm-1.2.3-6cdhs6owf5dn4wrwd26ibyi4nhl6a7h4;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libice-1.0.9-bfpsmwpww3oq2v7sqr2fxyasnqyppyop;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxext-1.3.3-gzszx2q2frafr3wzq2ij5tss7mfqsoky;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libx11-1.7.0-uhpc2zzbslsym2gyxfywoghfwoaoi6aw;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xtrans-1.3.5-kr2vcabfvut3yalplkp7ikxnhb7axrms;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xextproto-7.3.0-nimmzurw4nrkiqsv54hjior22r4oevzp;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxcb-1.14-smqiv3bawoxofcka7xrl6mupkx7dvqe4;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xcb-proto-1.14.1-7yr2fjl4itq2ln3sglj4q4dorwomnaqr;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxdmcp-1.1.2-sxrueyz4uq62xye4575uoprqpvpw6cb4;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxau-1.0.8-bi27ikv5lilybykyntfnzyyg3eznqzfv;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xproto-7.0.31-bcdbslol3uak2cbjpjwyfera6fa34myh;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libpthread-stubs-0.4-2ku6p7nugl7srmovfszh3va55hqwdhdm;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/kbproto-1.0.7-o76op6hcqiankopups356d2dscifj6ko;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/inputproto-2.3.2-7te46ytdvj3mxs5qvyn4ltftosncp65h;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libunwind-1.5.0-r6mqqimdyfeq4mhq66bqlyjfsnlvef5j;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/glproto-1.4.17-hxiv7zn42mntkk2bto5pzgo5iqpvlgqk;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/freetype-2.11.1-wtlajio3lc4o4lzfmnxscpfvoqd5o2xl;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libpng-1.6.37-u7277cqwcs3pjzwr6te42by4mp4cccrs;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/davix-0.7.6-fqxnjho4r5i5qten2ng2ibz5mdavqto6;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/python-3.9.10-xoj43243gtm76ubjqw7wkynusqz3f6sk;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/util-linux-uuid-2.36.2-jxcbiki2u3a7oiux4ix6cydrcfat3ipe;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/gettext-0.21-wgilpbhbulorxwgnyfiiqcjgxdk73gjv;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/tar-1.34-lbf7bxua3gc5n22cs2hjgikgkggkj7bi;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libxml2-2.9.12-s3p4otfheiuouq5bt6v3wo77cgh3fcf3;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/xz-5.2.5-g2ga2av32mh2krepklj42jluye6f2cvb;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/expat-2.4.4-cauloqka2pirtf6mz3p3fxlkurkmqupm;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libbsd-0.11.3-ysw6qfwvc7isxgtao27wgpjsdv3cuqzk;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libmd-1.0.3-7jbwhjphctficzfhnfau4vojmyvmjvqt;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/cmake-3.22.2-5z73n6l3lp3npdgqmgysomy3ejjn3ybj;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/openssl-1.1.1m-mywapix4cqow7x4wymsdae2vzplopp5n;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/zlib-1.2.11-3c6bs4ymmw5jrk25bfytaz2fxrd46z3c;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/bzip2-1.0.8-kwcnqct7d2kyrs3o55oqzyyojbed6r5e;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/libiconv-1.16-ysmxtkjp6q3ms4z6mpjqfcyrjp6r55nr;/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/ncurses-6.2-jpfyxqa242ptdyw3orflx6xamgafxyhw' '-DCMAKE_CXX_STANDARD:STRING=17' '-DBUILD_TESTING:BOOL=OFF' '/cvmfs/spack-stage/gitlab-runner/spack-stage-edm4hep-0.4-72vsbtlchqxpvqx3x3ay4vmoffo2bvaa/spack-src'
1 error found in build log:
     37    -- Detected GNU compatible linker
     38    -- Creating 'edm4hep' datamodel
     39    Traceback (most recent call last):
     40      File "/cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/spack/opt
           /spack/linux-centos8-skylake_avx512/gcc-8.5.0/podio-0.14-com5csw4ukv
           k6nnohzlzb4vrhheffaer/python/podio_class_generator.py", line 23, in 
           <module>
     41        import jinja2
     42    ModuleNotFoundError: No module named 'jinja2'
  >> 43    CMake Error at /cvmfs/gitlab-runner/VHY8orns/0/sft/sft-spack-repo/sp
           ack/opt/spack/linux-centos8-skylake_avx512/gcc-8.5.0/podio-0.14-com5
           csw4ukvk6nnohzlzb4vrhheffaer/lib64/cmake/podio/podioMacros.cmake:159
            (message):
     44      Could not generate datamodel 'edm4hep'.  Check your definition in
     45      '../edm4hep.yaml'
     46    Call Stack (most recent call first):
     47      edm4hep/CMakeLists.txt:4 (PODIO_GENERATE_DATAMODEL)
```
And the same for yaml after adding the py-jinja dependency (not sure why I would need the direct dependencies though, since they exist as indirect dependencies already...). But the installation succeeded after this addition