### PR TITLE
py-charset-normalizer: add 2.0.12

### DIFF
--- a/var/spack/repos/builtin/packages/py-charset-normalizer/package.py
+++ b/var/spack/repos/builtin/packages/py-charset-normalizer/package.py
@@ -13,6 +13,7 @@ class PyCharsetNormalizer(PythonPackage):
     homepage = 'https://github.com/ousret/charset_normalizer'
     pypi     = 'charset-normalizer/charset-normalizer-2.0.7.tar.gz'
 
+    version('2.0.12', sha256='2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597')
     version('2.0.7', sha256='e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0')
 
     depends_on('python@3.5:', type=('build', 'run'))


### PR DESCRIPTION
https://github.com/Ousret/charset_normalizer/tree/2.0.12