### PR TITLE
darwin: propagate build environment variables for Autotools

### DIFF
--- a/var/spack/repos/builtin/packages/graphviz/package.py
+++ b/var/spack/repos/builtin/packages/graphviz/package.py
@@ -139,6 +139,9 @@ class Graphviz(AutotoolsPackage):
         bash('./autogen.sh', 'NOCONFIG')
 
     def setup_build_environment(self, env):
+        # Set MACOSX_DEPLOYMENT_TARGET to 10.x due to old configure
+        super(Graphviz, self).setup_build_environment(env)
+
         if '+quartz' in self.spec:
             env.set('OBJC', self.compiler.cc)
 


### PR DESCRIPTION
Both OpenMPI and GraphViz show failures due to overriding the default autoconf build environment variables. We may have to do something similar for other packages as they appear... alternatively, once libtool fixes their macOS build we could just autoreconf affected packages?

- https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44605
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97865
- https://trac.macports.org/ticket/61584

Perhaps we should just take the approach of patching libtool (like homebrew https://github.com/Homebrew/formula-patches/commit/e5fbd46a25e35663059296833568667c7b572d9a ) and forcing autoreconf on bigsur+ ?