### PR TITLE
Trilinos: Add UVM variant

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -77,7 +77,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('openmp', default=False, description='Enable OpenMP')
     variant('python', default=False, description='Build PyTrilinos wrappers')
     variant('shared', default=True, description='Enables the build of shared libraries')
-    variant('wrapper', default=False, description="Use nvcc-wrapper for CUDA build")
+    variant('uvm', default=False, when='@13.2:', description='Turn on UVM for CUDA build')
+    variant('wrapper', default=False, description='Use nvcc-wrapper for CUDA build')
 
     # TPLs (alphabet order)
     variant('adios2',       default=False, description='Enable ADIOS2')
@@ -285,6 +286,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('@:13.0.1 +cuda', when='^cuda@11:')
     # Build hangs with CUDA 11.6 (see #28439)
     conflicts('+cuda +stokhos', when='^cuda@11.6:')
+    # Cuda UVM must be enabled prior to 13.2
+    # See https://github.com/spack/spack/issues/28869
+    conflicts('~uvm', when='@:13.1.999 +cuda')
 
     # stokhos fails on xl/xl_r
     conflicts('+stokhos', when='%xl')
@@ -736,8 +740,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                                   else 'OpenMP'),
             ])
             if '+cuda' in spec:
-                # See https://github.com/spack/spack/issues/28869
-                use_uvm = (spec.version < Version(13.2))
+                use_uvm = '+uvm' in spec
                 options.extend([
                     define_kok_enable('CUDA_UVM', use_uvm),
                     define_kok_enable('CUDA_LAMBDA', True),

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -77,7 +77,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     variant('openmp', default=False, description='Enable OpenMP')
     variant('python', default=False, description='Build PyTrilinos wrappers')
     variant('shared', default=True, description='Enables the build of shared libraries')
-    variant('uvm', default=False, when='@13.2:', description='Turn on UVM for CUDA build')
+    variant('uvm', default=False, when='@13.2: +cuda', description='Turn on UVM for CUDA build')
     variant('wrapper', default=False, description='Use nvcc-wrapper for CUDA build')
 
     # TPLs (alphabet order)

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -288,7 +288,7 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('+cuda +stokhos', when='^cuda@11.6:')
     # Cuda UVM must be enabled prior to 13.2
     # See https://github.com/spack/spack/issues/28869
-    conflicts('~uvm', when='@:13.1.999 +cuda')
+    conflicts('~uvm', when='@:13.1 +cuda')
 
     # stokhos fails on xl/xl_r
     conflicts('+stokhos', when='%xl')


### PR DESCRIPTION
Nalu-Wind currently doesn't work with UVM disabled. We're working on removing the dependency, but we aren't there yet.
@sethrj @keitat @kuberry @jrood-nrel @tsmith4 