### PR TITLE
fenics-basix: make xtensor-blas dependency explicit

### DIFF
--- a/var/spack/repos/builtin/packages/fenics-basix/package.py
+++ b/var/spack/repos/builtin/packages/fenics-basix/package.py
@@ -23,6 +23,7 @@ class FenicsBasix(CMakePackage):
     depends_on("cmake@3.18:", type="build")
     depends_on("xtl@0.7.2:")
     depends_on("xtensor@0.23.10:")
+    depends_on("xtensor-blas@0.19.1:")
     depends_on("blas")
     depends_on("lapack")
 

--- a/var/spack/repos/builtin/packages/xsimd/package.py
+++ b/var/spack/repos/builtin/packages/xsimd/package.py
@@ -17,6 +17,12 @@ class Xsimd(CMakePackage):
 
     version("develop", branch="master")
     version("8.0.5", sha256="0e1b5d973b63009f06a3885931a37452580dbc8d7ca8ad40d4b8c80d2a0f84d7")
+    version("8.0.4", sha256="5197529e7ca715ddfcae7c5c4097879c86dae6ef85f3f67c402e2e6c5e803c41")
+    version("8.0.3", sha256="d1d41253c4f82eaf2f369d7fcb4142e35076cf8675b9d94caa06ecf883024344")
+    version("8.0.2", sha256="91ef266f28ab4e62cb43f28630b6519ac9fbce3aeab5e538de8bd02401a616f3")
+    version("8.0.1", sha256="21b4700e9ef70f6c9a86952047efd8272317df4e6fee35963de9394fd9c5677f")
+    version("8.0.0", sha256="6b0e74f419cde47b61a314db167ebefe38c4d066db5ae7ac4341f717485f7228")
+    version("7.6.0", sha256="eaf47f1a316ef6c3287b266161eeafc5aa61226ce5ac6c13502546435b790252")
     version("7.5.0", sha256="45337317c7f238fe0d64bb5d5418d264a427efc53400ddf8e6a964b6bcb31ce9")
     version("7.4.10", sha256="df00f476dea0c52ffebad60924e3f0db2a016b80d508f8d5a2399a74c0d134cd")
     version("7.4.9", sha256="f6601ffb002864ec0dc6013efd9f7a72d756418857c2d893be0644a2f041874e")

--- a/var/spack/repos/builtin/packages/xtensor-blas/package.py
+++ b/var/spack/repos/builtin/packages/xtensor-blas/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install xtensor-blas
-#
-# You can edit this file again by typing:
-#
-#     spack edit xtensor-blas
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/xtensor-blas/package.py
+++ b/var/spack/repos/builtin/packages/xtensor-blas/package.py
@@ -1,0 +1,45 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install xtensor-blas
+#
+# You can edit this file again by typing:
+#
+#     spack edit xtensor-blas
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class XtensorBlas(CMakePackage):
+    """xtensor-blas"""
+
+    homepage = "https://xtensor-stack.github.io"
+    url      = "https://github.com/xtensor-stack/xtensor-blas/archive/refs/tags/1.0.0.tar.gz"
+    git = "git://github.com/xtensor-stack/xtensor-blas.git"
+
+    version('develop', branch='master')
+    version('0.20.0', sha256='272f5d99bb7511a616bfe41b13a000e63de46420f0b32a25fa4fb935b462c7ff')
+    version('0.19.2', sha256='ef678c0e3f581cc8d61ea002c904c76513c8b0f798f9c9acaf980a835f9d09aa')
+    version('0.19.1', sha256='c77cc4e2297ebd22d0d1c6e8d0a6cf0975176afa8cb99dbfd5fb2be625a0248f')
+    version('0.19.0', sha256='0fa8001afa2d9f7fb1d3c101ae04565f39ef2880a84acec216e699ed14950cb4')
+
+    depends_on('cmake@3.1:', type='build')
+    depends_on('xtensor@0.24.0:', when='@0.20:')
+    depends_on('xtensor', when='@:0.20')
+
+    # C++14 support
+    conflicts('%gcc@:4.8')
+    conflicts('%clang@:3.5')

--- a/var/spack/repos/builtin/packages/xtensor-blas/package.py
+++ b/var/spack/repos/builtin/packages/xtensor-blas/package.py
@@ -10,26 +10,26 @@ class XtensorBlas(CMakePackage):
     """BLAS extension to xtensor"""
 
     homepage = "https://xtensor-stack.github.io"
-    url      = "https://github.com/xtensor-stack/xtensor-blas/archive/refs/tags/0.20.0.tar.gz"
+    url = "https://github.com/xtensor-stack/xtensor-blas/archive/refs/tags/0.20.0.tar.gz"
     git = "git://github.com/xtensor-stack/xtensor-blas.git"
 
-    version('develop', branch='master')
-    version('0.20.0', sha256='272f5d99bb7511a616bfe41b13a000e63de46420f0b32a25fa4fb935b462c7ff')
-    version('0.19.2', sha256='ef678c0e3f581cc8d61ea002c904c76513c8b0f798f9c9acaf980a835f9d09aa')
-    version('0.19.1', sha256='c77cc4e2297ebd22d0d1c6e8d0a6cf0975176afa8cb99dbfd5fb2be625a0248f')
-    version('0.19.0', sha256='0fa8001afa2d9f7fb1d3c101ae04565f39ef2880a84acec216e699ed14950cb4')
-    version('0.18.0', sha256='fba992bc08323bc40fd04d6549e50e43b97942624a51e08129102d18c135eec0')
-    version('0.17.2', sha256='2798c7e230d0c4b2d357bba20a0ef23a2b774d892be31ebbf702cb9935ea9f64')
+    version("develop", branch="master")
+    version("0.20.0", sha256="272f5d99bb7511a616bfe41b13a000e63de46420f0b32a25fa4fb935b462c7ff")
+    version("0.19.2", sha256="ef678c0e3f581cc8d61ea002c904c76513c8b0f798f9c9acaf980a835f9d09aa")
+    version("0.19.1", sha256="c77cc4e2297ebd22d0d1c6e8d0a6cf0975176afa8cb99dbfd5fb2be625a0248f")
+    version("0.19.0", sha256="0fa8001afa2d9f7fb1d3c101ae04565f39ef2880a84acec216e699ed14950cb4")
+    version("0.18.0", sha256="fba992bc08323bc40fd04d6549e50e43b97942624a51e08129102d18c135eec0")
+    version("0.17.2", sha256="2798c7e230d0c4b2d357bba20a0ef23a2b774d892be31ebbf702cb9935ea9f64")
 
-    depends_on('cmake@3.1:', type='build')
+    depends_on("cmake@3.1:", type="build")
     # the information below can be found in the xtensor-blas README
-    depends_on('xtensor@0.24.0:', when='@0.20:')
-    depends_on('xtensor@0.23.3:', when='@0.19.1:0.19.2')
-    depends_on('xtensor@0.23.0:', when='@0.19.0')
-    depends_on('xtensor@0.22.0:', when='@0.18.0')
-    depends_on('xtensor@0.21.4:', when='@0.17.2')
-    depends_on('xtensor@0.21.2:', when='@:0.17.1')
+    depends_on("xtensor@0.24.0:", when="@0.20:")
+    depends_on("xtensor@0.23.3:", when="@0.19.1:0.19.2")
+    depends_on("xtensor@0.23.0:", when="@0.19.0")
+    depends_on("xtensor@0.22.0:", when="@0.18.0")
+    depends_on("xtensor@0.21.4:", when="@0.17.2")
+    depends_on("xtensor@0.21.2:", when="@:0.17.1")
 
     # C++14 support
-    conflicts('%gcc@:4.8')
-    conflicts('%clang@:3.5')
+    conflicts("%gcc@:4.8")
+    conflicts("%clang@:3.5")

--- a/var/spack/repos/builtin/packages/xtensor-blas/package.py
+++ b/var/spack/repos/builtin/packages/xtensor-blas/package.py
@@ -27,7 +27,7 @@ class XtensorBlas(CMakePackage):
     """xtensor-blas"""
 
     homepage = "https://xtensor-stack.github.io"
-    url      = "https://github.com/xtensor-stack/xtensor-blas/archive/refs/tags/1.0.0.tar.gz"
+    url      = "https://github.com/xtensor-stack/xtensor-blas/archive/refs/tags/0.20.0.tar.gz"
     git = "git://github.com/xtensor-stack/xtensor-blas.git"
 
     version('develop', branch='master')
@@ -35,10 +35,17 @@ class XtensorBlas(CMakePackage):
     version('0.19.2', sha256='ef678c0e3f581cc8d61ea002c904c76513c8b0f798f9c9acaf980a835f9d09aa')
     version('0.19.1', sha256='c77cc4e2297ebd22d0d1c6e8d0a6cf0975176afa8cb99dbfd5fb2be625a0248f')
     version('0.19.0', sha256='0fa8001afa2d9f7fb1d3c101ae04565f39ef2880a84acec216e699ed14950cb4')
+    version('0.18.0', sha256='fba992bc08323bc40fd04d6549e50e43b97942624a51e08129102d18c135eec0')
+    version('0.17.2', sha256='2798c7e230d0c4b2d357bba20a0ef23a2b774d892be31ebbf702cb9935ea9f64')
 
     depends_on('cmake@3.1:', type='build')
+    # the information below can be found in the xtensor-blas README
     depends_on('xtensor@0.24.0:', when='@0.20:')
-    depends_on('xtensor', when='@:0.20')
+    depends_on('xtensor@0.23.3:', when='@0.19.1:0.19.2')
+    depends_on('xtensor@0.23.0:', when='@0.19.0')
+    depends_on('xtensor@0.22.0:', when='@0.18.0')
+    depends_on('xtensor@0.21.4:', when='@0.17.2')
+    depends_on('xtensor@0.21.2:', when='@:0.17.1')
 
     # C++14 support
     conflicts('%gcc@:4.8')

--- a/var/spack/repos/builtin/packages/xtensor-blas/package.py
+++ b/var/spack/repos/builtin/packages/xtensor-blas/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class XtensorBlas(CMakePackage):

--- a/var/spack/repos/builtin/packages/xtensor-blas/package.py
+++ b/var/spack/repos/builtin/packages/xtensor-blas/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class XtensorBlas(CMakePackage):
-    """xtensor-blas"""
+    """BLAS extension to xtensor"""
 
     homepage = "https://xtensor-stack.github.io"
     url      = "https://github.com/xtensor-stack/xtensor-blas/archive/refs/tags/0.20.0.tar.gz"

--- a/var/spack/repos/builtin/packages/xtensor/package.py
+++ b/var/spack/repos/builtin/packages/xtensor/package.py
@@ -17,6 +17,7 @@ class Xtensor(CMakePackage):
 
     version("develop", branch="master")
     version("0.24.1", sha256="dd1bf4c4eba5fbcf386abba2627fcb4a947d14a806c33fde82d0cc1194807ee4")
+    version("0.24.0", sha256="37738aa0865350b39f048e638735c05d78b5331073b6329693e8b8f0902df713")
     version("0.23.10", sha256="2e770a6d636962eedc868fef4930b919e26efe783cd5d8732c11e14cf72d871c")
     version("0.23.4", sha256="c8377f8ec995762c89dea2fdf4ac06b53ba491a6f0df3421c4719355e42425d2")
     version("0.23.2", sha256="fde26dcf93f5d95996b8cc7e556b84930af41ff699492b7b20b2e3335e12f862")
@@ -35,6 +36,7 @@ class Xtensor(CMakePackage):
     depends_on("xsimd", when="@develop")
 
     depends_on("xsimd@8.0.5:", when="@0.24.1: +xsimd")
+    depends_on("xsimd@8.0.2:", when="@0.24.0 +xsimd")
     depends_on("xsimd@7.4.10:7", when="@0.23.4:0.23 +xsimd")
     depends_on("xsimd@7.4.9:7", when="@0.23.2 +xsimd")
     depends_on("xsimd@7.2.3:7", when="@0.20.7 +xsimd")


### PR DESCRIPTION
This pull request
* adds the [`xtensor-blas`](https://github.com/xtensor-stack/xtensor-blas) package,
* newer `xtensor` releases,
* newer `xsimd` releases, and
* makes the `fenics-basix` dependency on `xtensor-blas` explicit.

Without this dependency, the `fenics-basix` CMake setup downloads `xtensor-blas` (this is a header-only library). This does not work on supercomputers with restricted internet access.