### PR TITLE
archspec: patch pyproject.toml to comply with PEP517

### DIFF
--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -2,6 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
+
+
 class PyArchspec(PythonPackage):
     """A library for detecting, labeling and reasoning about
     microarchitectures.
@@ -20,3 +23,10 @@ class PyArchspec(PythonPackage):
     depends_on('py-six@1.13.0:1', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
+
+    @run_before('install')
+    def remove_pyproject_toml(self):
+        # Needed to work around having to install
+        # poetry for deployment
+        with working_dir(self.build_directory):
+            os.remove('pyproject.toml')

--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -2,9 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import os
-
-
 class PyArchspec(PythonPackage):
     """A library for detecting, labeling and reasoning about
     microarchitectures.
@@ -30,4 +27,6 @@ class PyArchspec(PythonPackage):
         with working_dir(self.build_directory):
             if self.spec.satisfies('@:0.1.3'):
                 filter_file("poetry>=0.12", "poetry_core>=1.0.0", 'pyproject.toml')
-                filter_file("poetry.masonry.api", "poetry.core.masonry.api", 'pyproject.toml')
+                filter_file(
+                    "poetry.masonry.api", "poetry.core.masonry.api", 'pyproject.toml'
+                )

--- a/var/spack/repos/builtin/packages/py-archspec/package.py
+++ b/var/spack/repos/builtin/packages/py-archspec/package.py
@@ -23,10 +23,11 @@ class PyArchspec(PythonPackage):
     depends_on('py-six@1.13.0:1', type=('build', 'run'))
 
     depends_on('py-setuptools', type='build')
+    depends_on('py-poetry-core@1.0.0:', type='build')
 
-    @run_before('install')
-    def remove_pyproject_toml(self):
-        # Needed to work around having to install
-        # poetry for deployment
+    def patch(self):
+        # See https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
         with working_dir(self.build_directory):
-            os.remove('pyproject.toml')
+            if self.spec.satisfies('@:0.1.3'):
+                filter_file("poetry>=0.12", "poetry_core>=1.0.0", 'pyproject.toml')
+                filter_file("poetry.masonry.api", "poetry.core.masonry.api", 'pyproject.toml')


### PR DESCRIPTION
If `pyproject.toml` is in the folder, that is preferred to the `setup.py` packaged by poetry itself. 

Adding a dependency on `poetry` for deploying a pure Python package seems wasteful, since the package to be deployed just needs to be copied in place, and we don't want to built `rust` for that.