### PR TITLE
Feature/composed boost pkg deps p1

### DIFF
--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -8,6 +8,7 @@ import numbers
 from spack import *
 from spack.pkg.builtin.boost import Boost
 
+
 def is_multiple_32(x):
     """multiple of 32 """
     try:
@@ -42,7 +43,7 @@ class Abyss(AutotoolsPackage):
     depends_on('mpi')
     depends_on('boost@:1.50.0,1.53.0:', when='@2.0.2:')
     depends_on('boost@:1.50.0,1.53.0:1.59.0', when='@:1.5.2')
-    #Maintainers: Is boost really a dependency? In what conditions?
+    # Maintainers: Is boost really a dependency? In what conditions?
     depends_on(Boost.with_default_variants)
     depends_on('sparsehash')
     depends_on('sqlite')

--- a/var/spack/repos/builtin/packages/abyss/package.py
+++ b/var/spack/repos/builtin/packages/abyss/package.py
@@ -6,7 +6,7 @@
 import numbers
 
 from spack import *
-
+from spack.pkg.builtin.boost import Boost
 
 def is_multiple_32(x):
     """multiple of 32 """
@@ -42,6 +42,8 @@ class Abyss(AutotoolsPackage):
     depends_on('mpi')
     depends_on('boost@:1.50.0,1.53.0:', when='@2.0.2:')
     depends_on('boost@:1.50.0,1.53.0:1.59.0', when='@:1.5.2')
+    #Maintainers: Is boost really a dependency? In what conditions?
+    depends_on(Boost.with_default_variants)
     depends_on('sparsehash')
     depends_on('sqlite')
     depends_on('libtool')

--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -6,7 +6,6 @@
 import sys
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Apex(CMakePackage):
@@ -66,12 +65,7 @@ class Apex(CMakePackage):
     depends_on('hip', when='+hip')
     depends_on('roctracer-dev', when='+hip')
     depends_on('rocm-smi-lib', when='+hip')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when='+boost')
-    depends_on('boost@1.54:', when='+boost')
+    depends_on('boost@1.54: +exception+chrono+system+atomic+container+regex+thread', when='+boost')
 
     # Conflicts
     conflicts('+jemalloc', when='+gperftools')

--- a/var/spack/repos/builtin/packages/aspcud/package.py
+++ b/var/spack/repos/builtin/packages/aspcud/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Aspcud(CMakePackage):
@@ -22,12 +21,7 @@ class Aspcud(CMakePackage):
     version('1.9.5', sha256='9cd3a9490d377163d87b16fa1a10cc7254bc2dbb9f60e846961ac8233f3835cf')
     version('1.9.4', sha256='3645f08b079e1cc80e24cd2d7ae5172a52476d84e3ec5e6a6c0034492a6ea885')
 
-    depends_on('boost@1.74:', type=('build'), when='@1.9.5:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, type=('build'), when='@1.9.5:')
+    depends_on('boost@1.74:+exception+serialization+container', type=('build'), when='@1.9.5:')
     depends_on('cmake', type=('build'))
     depends_on('re2c', type=('build'))
     depends_on('clingo')

--- a/var/spack/repos/builtin/packages/biobloom/package.py
+++ b/var/spack/repos/builtin/packages/biobloom/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Biobloom(AutotoolsPackage):
@@ -16,10 +15,7 @@ class Biobloom(AutotoolsPackage):
 
     version('2.2.0', sha256='5d09f8690f0b6402f967ac09c5b0f769961f3fe3791000f8f73af6af7324f02c')
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception+math+serialization+container')
     depends_on('sdsl-lite')
     depends_on('sparsehash')
     depends_on('zlib')

--- a/var/spack/repos/builtin/packages/bridger/package.py
+++ b/var/spack/repos/builtin/packages/bridger/package.py
@@ -17,10 +17,9 @@ class Bridger(MakefilePackage, SourceforgePackage):
     sourceforge_mirror_path = "rnaseqassembly/Bridger_r2014-12-01.tar.gz"
 
     version('2014-12-01', sha256='8fbec8603ea8ad2162cbd0c658e4e0a4af6453bdb53310b4b7e0d112e40b5737')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
+    #Maintainers: It looks like the following is the dependency here but needs to be verified by maintainers
+    #depends_on('boost + exception + filesystem + system + serialization + graph')
+    #If sp, then have to uncomment the previous line and remove the "Boost" package references from this file
     depends_on(Boost.with_default_variants)
     depends_on('perl', type='run')
 

--- a/var/spack/repos/builtin/packages/bridger/package.py
+++ b/var/spack/repos/builtin/packages/bridger/package.py
@@ -17,9 +17,11 @@ class Bridger(MakefilePackage, SourceforgePackage):
     sourceforge_mirror_path = "rnaseqassembly/Bridger_r2014-12-01.tar.gz"
 
     version('2014-12-01', sha256='8fbec8603ea8ad2162cbd0c658e4e0a4af6453bdb53310b4b7e0d112e40b5737')
-    #Maintainers: It looks like the following is the dependency here but needs to be verified by maintainers
-    #depends_on('boost + exception + filesystem + system + serialization + graph')
-    #If sp, then have to uncomment the previous line and remove the "Boost" package references from this file
+    # Maintainers: It looks like the following is the dependency here but needs to
+    # be verified by maintainers
+    # depends_on('boost + exception + filesystem + system + serialization + graph')
+    # If sp, then have to uncomment the previous line and remove the "Boost" package
+    # references from this file
     depends_on(Boost.with_default_variants)
     depends_on('perl', type='run')
 

--- a/var/spack/repos/builtin/packages/bridger/package.py
+++ b/var/spack/repos/builtin/packages/bridger/package.py
@@ -6,7 +6,6 @@
 from os import symlink
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Bridger(MakefilePackage, SourceforgePackage):
@@ -17,12 +16,7 @@ class Bridger(MakefilePackage, SourceforgePackage):
     sourceforge_mirror_path = "rnaseqassembly/Bridger_r2014-12-01.tar.gz"
 
     version('2014-12-01', sha256='8fbec8603ea8ad2162cbd0c658e4e0a4af6453bdb53310b4b7e0d112e40b5737')
-    # Maintainers: It looks like the following is the dependency here but needs to
-    # be verified by maintainers
-    # depends_on('boost + exception + filesystem + system + serialization + graph')
-    # If sp, then have to uncomment the previous line and remove the "Boost" package
-    # references from this file
-    depends_on(Boost.with_default_variants)
+    depends_on('boost + exception + filesystem + system + serialization + graph')
     depends_on('perl', type='run')
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/casper/package.py
+++ b/var/spack/repos/builtin/packages/casper/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Casper(MakefilePackage):
@@ -19,11 +18,7 @@ class Casper(MakefilePackage):
     version('0.8.2', sha256='3005e165cebf8ce4e12815b7660a833e0733441b5c7e5ecbfdccef7414b0c914')
 
     depends_on('jellyfish@2.2.3:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception')
 
     conflicts('%gcc@7.1.0')
 

--- a/var/spack/repos/builtin/packages/cgal/package.py
+++ b/var/spack/repos/builtin/packages/cgal/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Cgal(CMakePackage):
@@ -53,12 +52,7 @@ class Cgal(CMakePackage):
     depends_on('cmake@2.8.11:', type='build')
 
     # Essential Third Party Libraries
-    depends_on('boost+thread+system')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception+math+random+container')
     depends_on('gmp')
     depends_on('mpfr')
 

--- a/var/spack/repos/builtin/packages/cpprestsdk/package.py
+++ b/var/spack/repos/builtin/packages/cpprestsdk/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Cpprestsdk(CMakePackage):
@@ -19,12 +18,7 @@ class Cpprestsdk(CMakePackage):
     version('2.10.16', git='https://github.com/Microsoft/cpprestsdk', branch='v2.10.16', submodules=True)
     version('2.9.1', sha256='537358760acd782f4d2ed3a85d92247b4fc423aff9c85347dc31dbb0ab9bab16')
 
-    depends_on('boost@:1.69.0')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost@1.69.0: +random+chrono+locale+filesystem+system+exception+regex+thread+date_time')
     depends_on('openssl')
 
     # Ref: https://github.com/microsoft/cpprestsdk/commit/f9f518e4ad84577eb684ad8235181e4495299af4

--- a/var/spack/repos/builtin/packages/damaris/package.py
+++ b/var/spack/repos/builtin/packages/damaris/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Damaris(CMakePackage):
@@ -29,12 +28,7 @@ class Damaris(CMakePackage):
 
     depends_on('mpi')
     depends_on('cmake@3.18.0:', type=('build'))
-    depends_on('boost +thread+log+filesystem+date_time @1.67:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost +exception+locale+system+serialization+chrono+atomic+container+regex+thread+log+filesystem+date_time @1.67:')
     depends_on('xsd')
     depends_on('xerces-c')
     depends_on('hdf5@1.8.20:', when='+hdf5')

--- a/var/spack/repos/builtin/packages/denovogear/package.py
+++ b/var/spack/repos/builtin/packages/denovogear/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Denovogear(CMakePackage):
@@ -20,12 +19,7 @@ class Denovogear(CMakePackage):
     version('1.1.0', sha256='f818f80cd67183294c8aae312cad8311e6a9abede1f687567bb079d29f79c005')
 
     depends_on('cmake@3.1:', type=('build'))
-    depends_on('boost@1.47:1.60', type=('build'))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, type=('build'))
+    depends_on('boost@1.47:1.60 +exception+filesystem+system+serialization+graph+iostreams+regex+math+container', type=('build'))
     depends_on('htslib@1.2:', type=('build'))
     depends_on('eigen', type=('build'))
     depends_on('zlib', type=('link'))

--- a/var/spack/repos/builtin/packages/dimemas/package.py
+++ b/var/spack/repos/builtin/packages/dimemas/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Dimemas(AutotoolsPackage):
@@ -22,12 +21,7 @@ class Dimemas(AutotoolsPackage):
 
     depends_on('bison', type=('build', 'link', 'run'))
     depends_on('flex', type=('build', 'link', 'run'))
-    depends_on('boost@1.65.0+program_options cxxstd=11', type=('build', 'link'))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, type=('build', 'link'))
+    depends_on('boost@1.65.0+container+math+exception+program_options cxxstd=11', type=('build', 'link'))
 
     def autoreconf(self, spec, prefix):
         autoreconf('--install', '--verbose', '--force')

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -44,7 +44,7 @@ class Dyninst(CMakePackage):
     variant('stat_dysect', default=False,
             description="Patch for STAT's DySectAPI")
 
-    boost_libs = '+atomic+chrono+date_time+filesystem+system+thread+timer'
+    boost_libs = '+atomic+chrono+date_time+filesystem+system+thread+timer+container+random+exception'
 
     depends_on('boost@1.61.0:' + boost_libs, when='@10.1.0:')
     depends_on('boost@1.61.0:1.69' + boost_libs, when='@:10.0')

--- a/var/spack/repos/builtin/packages/dyninst/package.py
+++ b/var/spack/repos/builtin/packages/dyninst/package.py
@@ -44,7 +44,8 @@ class Dyninst(CMakePackage):
     variant('stat_dysect', default=False,
             description="Patch for STAT's DySectAPI")
 
-    boost_libs = '+atomic+chrono+date_time+filesystem+system+thread+timer+container+random+exception'
+    boost_libs = '+atomic+chrono+date_time+filesystem+system+thread+timer'
+    '+container+random+exception'
 
     depends_on('boost@1.61.0:' + boost_libs, when='@10.1.0:')
     depends_on('boost@1.61.0:1.69' + boost_libs, when='@:10.0')

--- a/var/spack/repos/builtin/packages/dysco/package.py
+++ b/var/spack/repos/builtin/packages/dysco/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Dysco(CMakePackage):
@@ -17,9 +16,4 @@ class Dysco(CMakePackage):
 
     depends_on('casacore')
     depends_on('gsl')
-    depends_on('boost+date_time+python')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+date_time+python+container+exception')

--- a/var/spack/repos/builtin/packages/erne/package.py
+++ b/var/spack/repos/builtin/packages/erne/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 
+
 class Erne(AutotoolsPackage):
     """The Extended Randomized Numerical alignEr using BWT"""
 

--- a/var/spack/repos/builtin/packages/erne/package.py
+++ b/var/spack/repos/builtin/packages/erne/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
-
 
 class Erne(AutotoolsPackage):
     """The Extended Randomized Numerical alignEr using BWT"""
@@ -18,12 +16,7 @@ class Erne(AutotoolsPackage):
     variant('mpi', default=False,
             description='Build with OpenMPI support')
 
-    depends_on('boost@1.40.0:', type=('build', 'link', 'run'))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, type=('build', 'link', 'run'))
+    depends_on('boost@1.40.0: +exception+filesystem+system+chrono+serialization+random+atomic+iostreams+regex+thread+container', type=('build', 'link', 'run'))
     depends_on('openmpi', type=('build', 'run'), when='+mpi')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/express/package.py
+++ b/var/spack/repos/builtin/packages/express/package.py
@@ -7,7 +7,6 @@ import glob
 import os.path
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Express(CMakePackage):
@@ -22,10 +21,7 @@ class Express(CMakePackage):
     version('1.5.2', sha256='25a63cca3dac6bd0daf04d2f0b2275e47d2190c90522bd231b1d7a875a59a52e')
     version('1.5.1', sha256='fa3522de9cc25f1ede22fa196928912a6da2a2038681911115ec3e4da3d61293')
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+date_time+exception+filesystem+system+chrono+atomic+container+math+thread+program_options')
     depends_on('bamtools')
     depends_on('zlib')
 

--- a/var/spack/repos/builtin/packages/faodel/package.py
+++ b/var/spack/repos/builtin/packages/faodel/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Faodel(CMakePackage):
@@ -37,12 +36,7 @@ class Faodel(CMakePackage):
     variant('serializer', default='xdr',    values=('xdr', 'cereal'),             description='Use Cereal to serialize NNTI data structures else XDR')
 
     depends_on('mpi', when='+mpi')
-    depends_on('boost@1.60.0:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost@1.60.0: +program_options+exception+locale+system+chrono+log+serialization+atomic+container+regex+thread+date_time')
     depends_on('cmake@3.8.0:', type='build')
     depends_on('hdf5+mpi', when='+hdf5+mpi')
     depends_on('hdf5~mpi', when='+hdf5~mpi')

--- a/var/spack/repos/builtin/packages/flann/package.py
+++ b/var/spack/repos/builtin/packages/flann/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Flann(CMakePackage):
@@ -66,12 +65,7 @@ class Flann(CMakePackage):
     depends_on("hdf5",     when="+hdf5")
     # HDF5_IS_PARALLEL actually comes from hdf5+mpi
     # https://github.com/mariusmuja/flann/blob/06a49513138009d19a1f4e0ace67fbff13270c69/CMakeLists.txt#L108-L112
-    depends_on("boost+mpi+system+serialization+thread", when="+mpi ^hdf5+mpi")
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when="+mpi ^hdf5+mpi")
+    depends_on("boost+mpi+system+serialization+thread+regex+graph+chrono+exception", when="+mpi ^hdf5+mpi")
 
     # Doc deps
     depends_on("texlive", when="+doc")

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -6,7 +6,6 @@
 import os
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class FluxSched(AutotoolsPackage):
@@ -41,14 +40,9 @@ class FluxSched(AutotoolsPackage):
     variant('cuda', default=False, description='Build dependencies with support for CUDA')
 
     # Needs to be seen if tis is needed once we remove the default variants
-    depends_on("boost+graph@1.53.0,1.59.0:")
+    depends_on("boost+exception+filesystem+system+serialization+graph+container+regex@1.53.0,1.59.0: ")
     depends_on("py-pyyaml@3.10:", type=('build', 'run'))
     depends_on("py-jsonschema@2.3:", type=('build', 'run'))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
     depends_on("libedit")
     depends_on("libxml2@2.9.1:")
     # pin yaml-cpp to 0.6.3 due to issue #886

--- a/var/spack/repos/builtin/packages/folly/package.py
+++ b/var/spack/repos/builtin/packages/folly/package.py
@@ -26,11 +26,8 @@ class Folly(CMakePackage):
 
     # folly requires gcc 5+ and a version of boost compiled with >= C++14
     variant('cxxstd', default='14', values=('14', '17'), multi=False, description='Use the specified C++ standard when building.')
-    # Boost library dependencies:
-    # CMake threw errors when program_options and thread were not included.
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on('boost+container+context+exception+filesystem+program_options+regex+serialization+system+thread cxxstd=14', when='cxxstd=14')
-    depends_on('boost+container+context+exception+filesystem+program_options+regex+serialization+system+thread cxxstd=17', when='cxxstd=17')
+    depends_on('boost+context+container+exception+filesystem+program_options+regex+serialization+system+thread cxxstd=14', when='cxxstd=14')
+    depends_on('boost+context+container+exception+filesystem+program_options+regex+serialization+system+thread cxxstd=17', when='cxxstd=17')
 
     # required dependencies
     depends_on('gflags')


### PR DESCRIPTION
depends on PR #28623

Following the commits from the PR #28623, all the packages depending upon boost have been replaced with  Boost.with_default_variants. This commit removes the Boost.with_default_variants to variants that packages are precisely dependent upon through build analysis conducted under @trws. This is the first batch of 20 packages with updated boost dependencies.

The focus of this PR is only the final commit (fe4e266) as the rest are part of #28623