### PR TITLE
Feature/composed boost pkg deps p2

### DIFF
--- a/var/spack/repos/builtin/packages/heaptrack/package.py
+++ b/var/spack/repos/builtin/packages/heaptrack/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Heaptrack(CMakePackage):
@@ -16,12 +15,7 @@ class Heaptrack(CMakePackage):
 
     version('1.1.0', sha256='bd247ac67d1ecf023ec7e2a2888764bfc03e2f8b24876928ca6aa0cdb3a07309')
 
-    depends_on('boost@1.41:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost@1.41: +program_options+exception+filesystem+system+iostreams+container')
     depends_on('cmake@2.8.9:', type='build')
     depends_on('elfutils')
     depends_on('libunwind')

--- a/var/spack/repos/builtin/packages/hssp/package.py
+++ b/var/spack/repos/builtin/packages/hssp/package.py
@@ -35,10 +35,6 @@ class Hssp(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
     depends_on('boost@1.48:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/hyperscan/package.py
+++ b/var/spack/repos/builtin/packages/hyperscan/package.py
@@ -6,7 +6,6 @@
 import platform
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 _versions = {
     'v5.2.1': {
@@ -28,9 +27,6 @@ class Hyperscan(CMakePackage):
         if pkg:
             version(ver, sha256=pkg[0], url=pkg[1])
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception+serialization+random+graph+container')
     depends_on('pcre')
     depends_on('ragel', type='build')

--- a/var/spack/repos/builtin/packages/iq-tree/package.py
+++ b/var/spack/repos/builtin/packages/iq-tree/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class IqTree(CMakePackage):
@@ -27,10 +26,7 @@ class IqTree(CMakePackage):
 
     # Depends on Eigen3 and zlib
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on("boost+container+math+exception")
     depends_on("eigen")
     depends_on("zlib")
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/isaac-server/package.py
+++ b/var/spack/repos/builtin/packages/isaac-server/package.py
@@ -33,7 +33,7 @@ class IsaacServer(CMakePackage):
     depends_on('jpeg', type='link')
     depends_on('jansson@:2.9', type='link', when='@:1.5.1')
     depends_on('jansson', type='link')
-    depends_on('boost@1.56.0:', type='link')
+    depends_on('boost@1.56.0:+serialization', type='link')
     depends_on('libwebsockets@2.1.1:', type='link')
     # depends_on('gstreamer@1.0', when='+gstreamer')
 

--- a/var/spack/repos/builtin/packages/jali/package.py
+++ b/var/spack/repos/builtin/packages/jali/package.py
@@ -33,11 +33,9 @@ class Jali(CMakePackage):
 
     depends_on('mpi')
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when='@:1.1.5')
-
+    # Fixme: Can the maintainers please confirm if this is a required dependency
+    depends_on('boost')
+    depends_on(Boost.with_default_variants)
     depends_on('mstk@3.3.5: +exodusii+parallel~use_markers partitioner=all', when='+mstk')
 
     depends_on('zoltan -fortran')

--- a/var/spack/repos/builtin/packages/launchmon/package.py
+++ b/var/spack/repos/builtin/packages/launchmon/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Launchmon(AutotoolsPackage):
@@ -25,11 +24,7 @@ class Launchmon(AutotoolsPackage):
     depends_on('libgcrypt')
     depends_on('libgpg-error')
     depends_on("elf", type='link')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on("boost+exception")
     depends_on("spectrum-mpi", when='arch=ppc64le')
 
     patch('launchmon-char-conv.patch', when='@1.0.2')

--- a/var/spack/repos/builtin/packages/libint/package.py
+++ b/var/spack/repos/builtin/packages/libint/package.py
@@ -57,10 +57,7 @@ class Libint(AutotoolsPackage):
     depends_on('libtool', type='build')
 
     # Libint 2 dependencies
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
+    # Fixme: Can maintainers please confirm that this is a required dependency
     depends_on(Boost.with_default_variants, when='@2:')
     depends_on('gmp', when='@2:')
 

--- a/var/spack/repos/builtin/packages/libkml/package.py
+++ b/var/spack/repos/builtin/packages/libkml/package.py
@@ -26,11 +26,8 @@ class Libkml(CMakePackage):
 
     # See DEPENDENCIES
     depends_on('cmake@2.8:', type='build')
+    # FIXME: Can the maintainers confirm if this is a required dependency
     depends_on('boost@1.44.0:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
     depends_on('expat@2.1.0:')
     depends_on('minizip@1.2.8:')

--- a/var/spack/repos/builtin/packages/magics/package.py
+++ b/var/spack/repos/builtin/packages/magics/package.py
@@ -7,7 +7,6 @@ import glob
 import os
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Magics(CMakePackage):
@@ -73,11 +72,7 @@ class Magics(CMakePackage):
     # https://github.com/OSGeo/PROJ/wiki/proj.h-adoption-status
     depends_on('proj@:5', when='@:4.2.6')
     depends_on('proj@6:', when='@4.3:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception')
     depends_on('expat')
 
     # Magics (at least up to version 2.34.3) should directly and

--- a/var/spack/repos/builtin/packages/masurca/package.py
+++ b/var/spack/repos/builtin/packages/masurca/package.py
@@ -22,10 +22,6 @@ class Masurca(Package):
     version('3.2.9', sha256='795ad4bd42e15cf3ef2e5329aa7e4f2cdeb7e186ce2e350a45127e319db2904b')
 
     depends_on('perl', type=('build', 'run'))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants)
     depends_on('zlib')
     patch('arm.patch', when='target=aarch64:')

--- a/var/spack/repos/builtin/packages/mgis/package.py
+++ b/var/spack/repos/builtin/packages/mgis/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Mgis(CMakePackage):
@@ -63,12 +62,8 @@ class Mgis(CMakePackage):
     depends_on('tfel@rliv-3.3', when="@rliv-1.1")
     depends_on('tfel@rliv-3.2', when="@rliv-1.0")
     depends_on('tfel@master', when="@master")
-    depends_on('boost+python+numpy', when='+python',
+    depends_on('boost+python+numpy+exception+container', when='+python',
                type=('build', 'link', 'run'))
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when='+python')
     depends_on('py-numpy', when='+python',
                type=('build', 'link', 'run'))
 

--- a/var/spack/repos/builtin/packages/modern-wheel/package.py
+++ b/var/spack/repos/builtin/packages/modern-wheel/package.py
@@ -6,7 +6,6 @@
 import sys
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class ModernWheel(CMakePackage):
@@ -35,13 +34,8 @@ class ModernWheel(CMakePackage):
     # https://gitlab.kitware.com/cmake/cmake/issues/17575
     # Until then, just assume that we cannot correctly configure
     # ModernWheel with Boost >= 1.66.0.
-    depends_on('boost           +system +filesystem', when='@:1.1')
-    depends_on('boost@:1.65 +system +filesystem', when='@1.2:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost +exception+test+system +filesystem', when='@:1.1')
+    depends_on('boost@:1.65 +exception+test+system +filesystem', when='@1.2:')
 
     # add virtual destructor to BaseMultiParms class.
     patch('add_virtual_destructor.patch')

--- a/var/spack/repos/builtin/packages/multiverso/package.py
+++ b/var/spack/repos/builtin/packages/multiverso/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Multiverso(CMakePackage):
@@ -20,11 +19,7 @@ class Multiverso(CMakePackage):
     version('0.2', sha256='40e86543968faa2fe203cf0b004a4c7905303db0c860efe4ce4e1f27e46394fc')
 
     depends_on('mpi')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception+test')
 
     patch('cmake-143187.patch', when='@143187')
 

--- a/var/spack/repos/builtin/packages/muster/package.py
+++ b/var/spack/repos/builtin/packages/muster/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Muster(CMakePackage):
@@ -20,9 +19,6 @@ class Muster(CMakePackage):
     version('1.0.1', sha256='71e2fcdd7abf7ae5cc648a5f310e1c5369e4889718eab2a045e747c590d2dd71')
     version('1.0',   sha256='370a670419e391494fcca0294882ee5f83c5d8af94ca91ac4182235332bd56d6')
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception+serialization+random')
     depends_on('mpi')
     depends_on('cmake@2.8:', type='build')

--- a/var/spack/repos/builtin/packages/nektar/package.py
+++ b/var/spack/repos/builtin/packages/nektar/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Nektar(CMakePackage):
@@ -28,12 +27,7 @@ class Nektar(CMakePackage):
 
     depends_on('blas')
     depends_on('lapack')
-    depends_on('boost@1.56.0: +iostreams')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost@1.56.0: +iostreams+exception+filesystem+system+chrono+serialization+atomic+regex+math+thread+container')
     depends_on('tinyxml', when='platform=darwin')
 
     depends_on('mpi', when='+mpi')

--- a/var/spack/repos/builtin/packages/pajeng/package.py
+++ b/var/spack/repos/builtin/packages/pajeng/package.py
@@ -37,7 +37,7 @@ class Pajeng(CMakePackage):
     variant('tools', default=True, description="Build auxiliary tools")
     variant('gui', default=False, description="The PajeNG visualization tool")
 
-    depends_on('boost')
+    depends_on('boost+exception+regex')
     depends_on('flex')
     depends_on('bison')
     depends_on('qt@:4+opengl', when='@:1.3.2+gui')

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Precice(CMakePackage):
@@ -49,18 +48,11 @@ class Precice(CMakePackage):
     depends_on('cmake@3.5:', type='build')
     depends_on('cmake@3.10.2:', type='build', when='@1.4:')
     depends_on('pkgconfig', type='build', when='@2.2:')
-    depends_on('boost@1.60.0:')
-    depends_on('boost@1.65.1:', when='@1.4:')
-    depends_on('boost@:1.72', when='@:2.0.2')
-    depends_on('boost@:1.74', when='@:2.1.1')
-
-    # See https://github.com/precice/precice/pull/1250
+    depends_on('boost@1.60.0:+program_options+chrono+locale+filesystem+system+log+exception+atomic+test+container+regex+math+thread')
+    depends_on('boost@1.65.1:+program_options+chrono+locale+filesystem+system+log+exception+atomic+test+container+regex+math+thread', when='@1.4:')
+    depends_on('boost@1.72:+program_options+chrono+locale+filesystem+system+log+exception+atomic+test+container+regex+math+thread', when='@:2.0.2')
+    depends_on('boost@1.74:+program_options+chrono+locale+filesystem+system+log+exception+atomic+test+container+regex+math+thread', when='@:2.1.1')
     conflicts('boost@1.79.0')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
     depends_on('eigen@3.2:')
     depends_on('eigen@:3.3.7', type='build', when='@:1.5')  # bug in prettyprint
     depends_on('libxml2')

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -6,7 +6,6 @@
 import llnl.util.tty as tty
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Qmcpack(CMakePackage, CudaPackage):
@@ -157,12 +156,8 @@ class Qmcpack(CMakePackage, CudaPackage):
     depends_on('cmake@3.4.3:', when='@:3.5.0', type='build')
     depends_on('cmake@3.6.0:', when='@3.6.0:', type='build')
     depends_on('cmake@3.14.0:', when='@3.10.0:', type='build')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, type='build')
-    depends_on('boost@1.61.0:', when='@3.6.0:', type='build')
+    depends_on('boost+exception+serialization+random', type='build')
+    depends_on('boost@1.61.0:+exception+serialization+random', when='@3.6.0:', type='build')
     depends_on('libxml2')
     depends_on('mpi', when='+mpi')
     depends_on('python@3:', when='@3.9:')


### PR DESCRIPTION
depends on PR #28959 
depends on PR #28623

Following the commits from the PR https://github.com/spack/spack/pull/28623, all the packages depending upon boost have been replaced with Boost.with_default_variants. This commit removes the Boost.with_default_variants to variants that packages are precisely dependent upon through build analysis conducted under @trws. This is the second batch of 20 packages with updated boost dependencies.
The focus of this PR is only the final commit (72a576b) as the rest are part of dependent PRs
