### PR TITLE
Feature/composed boost pkg deps p3

### DIFF
--- a/var/spack/repos/builtin/packages/salmon/package.py
+++ b/var/spack/repos/builtin/packages/salmon/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.pkg.builtin.boost import Boost
-
 
 class Salmon(CMakePackage):
     """Salmon is a tool for quantifying the expression of transcripts using
@@ -24,14 +22,8 @@ class Salmon(CMakePackage):
             values=('DEBUG', 'RELEASE'))
 
     depends_on('tbb')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
-    depends_on('boost@:1.66.0', when='@:0.14.1')
-    depends_on('boost@1.72.0:', when='@1.4.0:')
-
+    depends_on('boost@1.66.0:+program_options+exception+filesystem+system+chrono+serialization+random+graph+timer+iostreams+math+thread+container', when='@:0.14.1')
+    depends_on('boost@1.72.0:+program_options+exception+filesystem+system+chrono+serialization+random+graph+timer+iostreams+math+thread+container', when='@1.4.0:')
     depends_on('cereal')
     depends_on('jemalloc')
     depends_on('xz')

--- a/var/spack/repos/builtin/packages/scallop/package.py
+++ b/var/spack/repos/builtin/packages/scallop/package.py
@@ -17,10 +17,7 @@ class Scallop(AutotoolsPackage):
     version('0.10.3', sha256='04eb3ab27ed8c7ae38e1780d6b2af16b6a2c01807ffafd59e819d33bfeff58a0')
 
     depends_on('clp')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
+    # Fixme: There does not seem to be any dependency on boost, please consider removing
     depends_on(Boost.with_default_variants)
     depends_on('htslib@1.5:')
 

--- a/var/spack/repos/builtin/packages/scallop/package.py
+++ b/var/spack/repos/builtin/packages/scallop/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Scallop(AutotoolsPackage):
@@ -19,6 +18,7 @@ class Scallop(AutotoolsPackage):
     depends_on('clp')
     depends_on('boost')
     depends_on('htslib@1.5:')
+
     def configure_args(self):
         return [
             '--with-clp={0}'.format(self.spec['clp'].prefix),

--- a/var/spack/repos/builtin/packages/scallop/package.py
+++ b/var/spack/repos/builtin/packages/scallop/package.py
@@ -17,10 +17,8 @@ class Scallop(AutotoolsPackage):
     version('0.10.3', sha256='04eb3ab27ed8c7ae38e1780d6b2af16b6a2c01807ffafd59e819d33bfeff58a0')
 
     depends_on('clp')
-    # Fixme: There does not seem to be any dependency on boost, please consider removing
-    depends_on(Boost.with_default_variants)
+    depends_on('boost')
     depends_on('htslib@1.5:')
-
     def configure_args(self):
         return [
             '--with-clp={0}'.format(self.spec['clp'].prefix),

--- a/var/spack/repos/builtin/packages/seqan/package.py
+++ b/var/spack/repos/builtin/packages/seqan/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Seqan(CMakePackage):
@@ -25,12 +24,7 @@ class Seqan(CMakePackage):
     depends_on('python@2.7.0:', type='build')
     depends_on('py-nose', type='build')
     depends_on('py-sphinx', type='build')
-    depends_on('boost', type=('build', 'link'))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception+math+serialization+container', type=('build', 'link'))
     depends_on('zlib', type=('build', 'link'))
     depends_on('bzip2', type=('build', 'link'))
 

--- a/var/spack/repos/builtin/packages/shapeit4/package.py
+++ b/var/spack/repos/builtin/packages/shapeit4/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Shapeit4(MakefilePackage):
@@ -19,11 +18,7 @@ class Shapeit4(MakefilePackage):
     maintainers = ['ilbiondo']
 
     depends_on('htslib')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception+container+iostreams+program_options')
     depends_on('bzip2')
     depends_on('xz')
 

--- a/var/spack/repos/builtin/packages/simgrid/package.py
+++ b/var/spack/repos/builtin/packages/simgrid/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Simgrid(CMakePackage):
@@ -74,12 +73,8 @@ class Simgrid(CMakePackage):
     variant('mc', default=False, description='Model checker')
 
     # does not build correctly with some old compilers -> rely on packages
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when='@:3.21')
     depends_on('boost@:1.69.0', when='@:3.21')
+    depends_on('boost+exception')
 
     conflicts('%gcc@10:', when='@:3.23',
               msg='simgrid <= v3.23 cannot be built with gcc >= 10,'

--- a/var/spack/repos/builtin/packages/source-highlight/package.py
+++ b/var/spack/repos/builtin/packages/source-highlight/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
@@ -26,10 +25,7 @@ class SourceHighlight(AutotoolsPackage, GNUMirrorPackage):
           sha256='45087b174b2b128a8dc81b0728f8ae63213d255ceef6dabfcba27c94e2a75ce9',
           when='%gcc@11:')
 
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost+exception+regex')
 
     # git version needs autotools
     depends_on('m4', when='@master')

--- a/var/spack/repos/builtin/packages/strelka/package.py
+++ b/var/spack/repos/builtin/packages/strelka/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Strelka(CMakePackage):
@@ -33,9 +32,4 @@ class Strelka(CMakePackage):
     depends_on('zlib')
     depends_on('bzip2')
     depends_on('cmake@2.8.5:', type='build')
-    depends_on('boost@1.56.0:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost@1.56.0: +program_options+exception+filesystem+system+chrono+serialization+timer+container+test+math')

--- a/var/spack/repos/builtin/packages/sympol/package.py
+++ b/var/spack/repos/builtin/packages/sympol/package.py
@@ -18,10 +18,7 @@ class Sympol(CMakePackage):
     depends_on("cmake@2.6:", type="build")
 
     depends_on("bliss")
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
+    # Maintainers: Does this package truly depend on boost?
     depends_on(Boost.with_default_variants)
     depends_on("gmp")
     depends_on("lrslib")

--- a/var/spack/repos/builtin/packages/sympol/package.py
+++ b/var/spack/repos/builtin/packages/sympol/package.py
@@ -18,7 +18,7 @@ class Sympol(CMakePackage):
     depends_on("cmake@2.6:", type="build")
 
     depends_on("bliss")
-    # Maintainers: Does this package truly depend on boost?
+depends_on('boost+math+program_options+test')
     depends_on(Boost.with_default_variants)
     depends_on("gmp")
     depends_on("lrslib")

--- a/var/spack/repos/builtin/packages/sympol/package.py
+++ b/var/spack/repos/builtin/packages/sympol/package.py
@@ -18,7 +18,7 @@ class Sympol(CMakePackage):
     depends_on("cmake@2.6:", type="build")
 
     depends_on("bliss")
-depends_on('boost+math+program_options+test')
+    depends_on('boost+math+program_options+test')
     depends_on(Boost.with_default_variants)
     depends_on("gmp")
     depends_on("lrslib")

--- a/var/spack/repos/builtin/packages/templight-tools/package.py
+++ b/var/spack/repos/builtin/packages/templight-tools/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class TemplightTools(CMakePackage):
@@ -16,9 +15,4 @@ class TemplightTools(CMakePackage):
     version('develop', branch='master')
 
     depends_on('cmake @2.8.7:', type='build')
-    depends_on('boost @1.48.1: +filesystem +graph +program_options +test')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost @1.48.1: +exception+filesystem+system+graph+program_options+test+container')

--- a/var/spack/repos/builtin/packages/tfel/package.py
+++ b/var/spack/repos/builtin/packages/tfel/package.py
@@ -7,7 +7,6 @@
 # 18/12/2018: fix python detection
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Tfel(CMakePackage):
@@ -132,13 +131,8 @@ class Tfel(CMakePackage):
     depends_on('py-numpy', when='+python_bindings',
                type=('build', 'link', 'run'))
     # As boost+py has py runtime dependency, boost+py needs types link and run as well:
-    depends_on('boost+python+numpy', when='+python_bindings',
+    depends_on('boost+python+numpy+exception+container', when='+python_bindings',
                type=('build', 'link', 'run'))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when='+python_bindings')
 
     extends('python', when='+python_bindings')
 

--- a/var/spack/repos/builtin/packages/tophat/package.py
+++ b/var/spack/repos/builtin/packages/tophat/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Tophat(AutotoolsPackage):
@@ -25,12 +24,7 @@ class Tophat(AutotoolsPackage):
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
-    depends_on('boost@1.47:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost@1.47:+exception+chrono+system+random+atomic+thread')
     depends_on('bowtie2', type='run')
 
     parallel = False

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -10,7 +10,6 @@ from spack import *
 from spack.build_environment import dso_suffix
 from spack.error import NoHeadersError
 from spack.operating_systems.mac_os import macos_version
-from spack.pkg.builtin.boost import Boost
 from spack.pkg.builtin.kokkos import Kokkos
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
@@ -323,9 +322,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('adios2', when='+adios2')
     depends_on('blas')
-    depends_on(Boost.with_default_variants, when='+boost')
+    depends_on('boost+graph+math+exception+stacktrace', when='+boost')
     # Need to revisit the requirement of STK
-    depends_on(Boost.with_default_variants, when='+stk')
+    depends_on('boost+graph+math+exception+stacktrace', when='+stk')
 
     #
     depends_on('cgns', when='+exodus')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -10,8 +10,8 @@ from spack import *
 from spack.build_environment import dso_suffix
 from spack.error import NoHeadersError
 from spack.operating_systems.mac_os import macos_version
-from spack.pkg.builtin.kokkos import Kokkos
 from spack.pkg.builtin.boost import Boost
+from spack.pkg.builtin.kokkos import Kokkos
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -10,8 +10,8 @@ from spack import *
 from spack.build_environment import dso_suffix
 from spack.error import NoHeadersError
 from spack.operating_systems.mac_os import macos_version
-from spack.pkg.builtin.boost import Boost
 from spack.pkg.builtin.kokkos import Kokkos
+from spack.pkg.builtin.boost import Boost
 
 # Trilinos is complicated to build, as an inspiration a couple of links to
 # other repositories which build it:
@@ -323,16 +323,12 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('adios2', when='+adios2')
     depends_on('blas')
-    depends_on('boost', when='+boost')
+    depends_on(Boost.with_default_variants, when='+boost')
     # Need to revisit the requirement of STK
-    depends_on('boost', when='+stk')
+    depends_on(Boost.with_default_variants, when='+stk')
 
     #
     depends_on('cgns', when='+exodus')
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when='+boost')
     depends_on('hdf5+hl', when='+hdf5')
     depends_on('hypre~internal-superlu~int64', when='+hypre')
     depends_on('kokkos-nvcc-wrapper', when='+wrapper')

--- a/var/spack/repos/builtin/packages/valgrind/package.py
+++ b/var/spack/repos/builtin/packages/valgrind/package.py
@@ -7,7 +7,6 @@ import glob
 import sys
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Valgrind(AutotoolsPackage, SourcewarePackage):
@@ -55,12 +54,7 @@ Otherwise with (Apple's) clang there is a linker error:
 clang: error: unknown argument: '-static-libubsan'
 """)
     depends_on('mpi', when='+mpi')
-    depends_on('boost', when='+boost')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants, when='+boost')
+    depends_on('boost+exception+chrono+system+atomic+thread', when='+boost')
 
     depends_on("autoconf", type='build', when='@develop')
     depends_on("automake", type='build', when='@develop')

--- a/var/spack/repos/builtin/packages/votca-csg/package.py
+++ b/var/spack/repos/builtin/packages/votca-csg/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class VotcaCsg(CMakePackage):
@@ -39,9 +38,6 @@ class VotcaCsg(CMakePackage):
     for v in ["1.4", "1.4.1", "1.5", "1.5.1", "1.6", "1.6.1", "1.6.2",
               "1.6.3", "1.6.4", "2021", "2021.1", "2021.2", "stable"]:
         depends_on('votca-tools@%s' % v, when="@%s:%s.0" % (v, v))
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on("boost+exception+filesystem+system+serialization+container+math+regex")
     depends_on("gromacs~mpi@5.1:2019")
     depends_on("hdf5~mpi")

--- a/var/spack/repos/builtin/packages/votca-csgapps/package.py
+++ b/var/spack/repos/builtin/packages/votca-csgapps/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class VotcaCsgapps(CMakePackage):
@@ -34,8 +33,4 @@ class VotcaCsgapps(CMakePackage):
     for v in ["1.4", "1.4.1", "1.5", "1.5.1", "1.6", "1.6.1", "1.6.2",
               "1.6.3", "1.6.4"]:
         depends_on('votca-csg@%s' % v, when="@%s:%s.0" % (v, v))
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on("boost+exception+math+serialization+container")

--- a/var/spack/repos/builtin/packages/votca-tools/package.py
+++ b/var/spack/repos/builtin/packages/votca-tools/package.py
@@ -5,7 +5,6 @@
 
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class VotcaTools(CMakePackage):
@@ -48,10 +47,7 @@ class VotcaTools(CMakePackage):
     depends_on("fftw-api@3")
     depends_on("gsl", when="@1.4:1.4.9999")
     depends_on("eigen@3.3:", when="@stable,1.5:")
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on("boost+exception+filesystem+system+container+math+program_options")
     depends_on("sqlite", when="@1.4:1.5")
     depends_on('mkl', when='+mkl')
 


### PR DESCRIPTION
depends on PR #28960 
depends on PR #28959 
depends on PR #28623

Following the commits from the PR #28623, all the packages depending upon boost have been replaced with Boost.with_default_variants. This commit removes the Boost.with_default_variants to variants that packages are precisely dependent upon through build analysis conducted under @trws. This is the second batch of 20 packages with updated boost dependencies.

The focus of this PR is the commit (1e8a18d) as the rest are being reviewed under dependent PRs.