### PR TITLE
Checksum match

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2564,7 +2564,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         try:
             return spack.util.web.find_versions_of_archive(
-                self.all_urls, self.list_url, self.list_depth, concurrency
+                self.all_urls, self.list_url, self.list_depth, concurrency, reference_package=self
             )
         except spack.util.web.NoNetworkConnectionError as e:
             tty.die("Package.fetch_versions couldn't connect to:", e.url,

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2564,7 +2564,11 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         try:
             return spack.util.web.find_versions_of_archive(
-                self.all_urls, self.list_url, self.list_depth, concurrency, reference_package=self
+                self.all_urls,
+                self.list_url,
+                self.list_depth,
+                concurrency,
+                reference_package=self,
             )
         except spack.util.web.NoNetworkConnectionError as e:
             tty.die("Package.fetch_versions couldn't connect to:", e.url,

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -645,17 +645,21 @@ def find_versions_of_archive(
                 ver = spack.url.parse_version(url)
                 if ver in matched:
                     continue
-                tty.debug(url)
                 versions[ver] = url
                 # prevent this version from getting overwritten
-                if reference_package is not None:
+                if url in archive_urls:
+                    matched.add(ver)
+                elif reference_package is not None:
                     if url == reference_package.url_for_version(ver):
+                        matched.add(ver)
+                else:
+                    extrapolated_urls = [spack.url.substitute_version(u, ver) for u in archive_urls]
+                    if url in extrapolated_urls:
                         matched.add(ver)
             except spack.url.UndetectableVersionError:
                 continue
 
     from pprint import pprint
-    tty.debug(versions)
     return versions
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -577,7 +577,7 @@ def find_versions_of_archive(
         list_depth (int): max depth to follow links on list_url pages.
             Defaults to 0.
         concurrency (int): maximum number of concurrent requests
-        reference_package (Package or None): a spack package instance
+        reference_package (spack.package.Package or None): a spack package
             used as a reference for url detection.  Uses the url_for_version
             method on the package to produce reference urls which, if found,
             are preferred.

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -578,7 +578,7 @@ def find_versions_of_archive(
             Defaults to 0.
         concurrency (int): maximum number of concurrent requests
         reference_package (Package or None): a spack package instance
-            Used as a reference for url detection.  Uses the url_for_version
+            used as a reference for url detection.  Uses the url_for_version
             method on the package to produce reference urls which, if found,
             are preferred.
     """

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -562,7 +562,7 @@ def _urlopen(req, *args, **kwargs):
 
 
 def find_versions_of_archive(
-        archive_urls, list_url=None, list_depth=0, concurrency=32, reference_package=None
+    archive_urls, list_url=None, list_depth=0, concurrency=32, reference_package=None
 ):
     """Scrape web pages for new versions of a tarball.
 
@@ -653,13 +653,14 @@ def find_versions_of_archive(
                     if url == reference_package.url_for_version(ver):
                         matched.add(ver)
                 else:
-                    extrapolated_urls = [spack.url.substitute_version(u, ver) for u in archive_urls]
+                    extrapolated_urls = [
+                        spack.url.substitute_version(u, ver) for u in archive_urls
+                    ]
                     if url in extrapolated_urls:
                         matched.add(ver)
             except spack.url.UndetectableVersionError:
                 continue
 
-    from pprint import pprint
     return versions
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -577,6 +577,10 @@ def find_versions_of_archive(
         list_depth (int): max depth to follow links on list_url pages.
             Defaults to 0.
         concurrency (int): maximum number of concurrent requests
+        reference_package (Package or None): a spack package instance
+            Used as a reference for url detection.  Uses the url_for_version
+            method on the package to produce reference urls which, if found,
+            are preferred.
     """
     if not isinstance(archive_urls, (list, tuple)):
         archive_urls = [archive_urls]


### PR DESCRIPTION
This is a minimal change toward getting the right archive from places
like github in checksum and create.  The heuristic is:


* if an archive url exists, prefer it and take its version
  * if a reference package is available
    * generate a url from the package with pkg.url_from_version
    * if they match
      * stop considering other URLs for this version
      * otherwise, continue replacing the url for the version
  * otherwise use specified archive url list to generate a list of urls with
    substitute_version
    * if url matches one in the list, use it and don't re-assign it
* if all else fails, just keep assigning over the url repeatedly like it used to

I doubt this will always work, but it should address a variety of
versions of this bug.  A good test right now is `spack checksum gh`,
which checksums macos binaries without this, and the correct source
packages with it.



fixes https://github.com/spack/spack/issues/15985
fixes https://github.com/spack/spack/issues/14129
fixes https://github.com/spack/spack/issues/13940
