### PR TITLE
darwin: robust macos version detection

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -44,11 +44,15 @@ def macos_version():
     if env_ver:
         return Version(env_ver)
 
-    swvers = Executable('sw_vers')
-    output = swvers(output=str, fail_on_error=False)
-    match = re.search(r'ProductVersion:\s*([0-9.]+)', output)
-    if match:
-        return Version(match.group(1))
+    try:
+        swvers = Executable('sw_vers')
+    except Exception:  # Change to FileNotFoundError if py3
+        pass
+    else:
+        output = swvers(output=str, fail_on_error=False)
+        match = re.search(r'ProductVersion:\s*([0-9.]+)', output)
+        if match:
+            return Version(match.group(1))
 
     # Fall back to python-reported version, which can be inaccurate around
     # macOS 11 (e.g. showing 10.16 for macOS 12)

--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -45,11 +45,11 @@ def macos_version():
         return Version(env_ver)
 
     try:
-        swvers = Executable('sw_vers')
-    except Exception:  # Change to FileNotFoundError if py3
+        output = Executable('sw_vers')(output=str, fail_on_error=False)
+    except Exception:
+        # FileNotFoundError, or spack.util.executable.ProcessError
         pass
     else:
-        output = swvers(output=str, fail_on_error=False)
         match = re.search(r'ProductVersion:\s*([0-9.]+)', output)
         if match:
             return Version(match.group(1))

--- a/lib/spack/spack/platforms/darwin.py
+++ b/lib/spack/spack/platforms/darwin.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import platform
+import platform as py_platform
 
 import archspec.cpu
 
@@ -38,7 +38,7 @@ class Darwin(Platform):
 
     @classmethod
     def detect(cls):
-        return 'darwin' in platform.system().lower()
+        return 'darwin' in py_platform.system().lower()
 
     def setup_platform_environment(self, pkg, env):
         """Specify deployment target based on target OS version.


### PR DESCRIPTION
I just installed Monterey and was surprised to see that spack identified my system as "10.16" (the "compatibility" version for macOS 11). This is because the old anaconda3 python being used by spack was clearly built some time ago and its `platform.mac_ver()` was reporting the build rather than current system.

I've changed the macos version detection heuristic to prefer the builtin `sw_vers` command, which will reliably return the operating system version.

As an override to *that* mechanism I'm letting spack use the `MACOSX_DEPLOYMENT_TARGET` environment variable, which is designed to specify the targeted OS and so makes perfect sense here:
```console
$ MACOSX_DEPLOYMENT_TARGET=10.14 spack arch
darwin-mojave-skylake
$ MACOSX_DEPLOYMENT_TARGET=10.15 spack arch
darwin-catalina-skylake
$ MACOSX_DEPLOYMENT_TARGET=11 spack arch
darwin-bigsur-skylake
$ MACOSX_DEPLOYMENT_TARGET=12 spack arch
darwin-monterey-skylake
```

This change is orthogonal to #28948.