### PR TITLE
openblas: fix on M1

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -265,6 +265,9 @@ class Openblas(MakefilePackage):
             'FC={0}'.format(spack_fc),
         ]
 
+        if self.spec.os == 'monterey':
+            make_defs.append('MACOSX_DEPLOYMENT_TARGET=11.0')
+
         # force OpenBLAS to use externally defined parallel build
         if self.spec.version < Version('0.3'):
             make_defs.append('MAKE_NO_J=1')  # flag defined by our make.patch

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -251,6 +251,14 @@ class Openblas(MakefilePackage):
         else:
             args.append('TARGET=' + microarch.name.upper())
 
+        if self.spec.target == 'm1' and self.spec.platform == 'darwin':
+            # M1 support, otherwise fails in the linking stage.
+            #
+            # See also
+            # https://github.com/xianyi/OpenBLAS/issues/3032#issuecomment-743808777
+            # and following comments
+            args.append('MACOSX_DEPLOYMENT_TARGET=11.0')
+
         return args
 
     @property
@@ -264,9 +272,6 @@ class Openblas(MakefilePackage):
             'CC={0}'.format(spack_cc),
             'FC={0}'.format(spack_fc),
         ]
-
-        if self.spec.os == 'monterey':
-            make_defs.append('MACOSX_DEPLOYMENT_TARGET=11.0')
 
         # force OpenBLAS to use externally defined parallel build
         if self.spec.version < Version('0.3'):


### PR DESCRIPTION
Sets a required variable when building on `darwin-monterey-m1`.
Otherwise the following failure is observed:
```
  >> 26641    Undefined symbols for architecture arm64:
     26642      "___chkstk_darwin", referenced from:
     26643          _sgemv_ in libopenblas-r0.3.19.a(sgemv.o)
     26644          _sger_ in libopenblas-r0.3.19.a(sger.o)
     26645          _cblas_sgemv in libopenblas-r0.3.19.a(cblas_sgemv.o)
     26646          _cblas_sger in libopenblas-r0.3.19.a(cblas_sger.o)
     26647          _dgemv_ in libopenblas-r0.3.19.a(dgemv.o)
     26648          _dger_ in libopenblas-r0.3.19.a(dger.o)
     26649          _cblas_dgemv in libopenblas-r0.3.19.a(cblas_dgemv.o)
     26650          ...
     26651    ld: symbol(s) not found for architecture arm64
```
