### PR TITLE
mesa: enable the `swr` variant if +llvm, instead of using conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -42,7 +42,7 @@ class HipRocclr(CMakePackage):
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
-    depends_on('mesa~llvm@21: swr=none', type='link')
+    depends_on('mesa~llvm@21:', type='link')
     depends_on('libelf', type='link', when="@3.7.0:3.8.0")
     depends_on('numactl', type='link', when="@3.7.0:")
 

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -50,10 +50,8 @@ class Mesa(MesonPackage):
     _SWR_DISABLED_VALUES = ('none',)
     variant('swr', default=_SWR_AUTO_VALUE,
             values=_SWR_DISABLED_VALUES + _SWR_ENABLED_VALUES,
-            multi=True,
+            multi=True, when='+llvm',
             description="Enable the SWR driver.")
-    for swr_enabled_value in _SWR_ENABLED_VALUES:
-        conflicts('~llvm', when='swr={0}'.format(swr_enabled_value))
 
     # Front ends
     variant('osmesa', default=True, description="Enable the OSMesa frontend.")


### PR DESCRIPTION
fixes #28994

This is picking version 4.5.2 since now mesa is not penalized for a variant that makes no sense when `~llvm`:
<details>
<summary>$ spacl solve spfft+rocm</summary>

```
==> Best of 5 considered solutions.
==> Optimization Criteria:
  Priority  Criterion                                            Installed  ToBuild
  1         number of packages to build (vs. reuse)                      -        0
  2         deprecated versions used                                     0        0
  3         version weight                                               0        0
  4         number of non-default variants (roots)                       0        0
  5         preferred providers for roots                                0        0
  6         default values of variants not being used (roots)            0        1
  7         number of non-default variants (non-roots)                   0        0
  8         preferred providers (non-roots)                              0        1
  9         compiler mismatches                                          0        0
  10        OS mismatches                                                0        0
  11        non-preferred OS's                                           0        0
  12        version badness                                              0        4
  13        default values of variants not being used (non-roots)        0        2
  14        non-preferred compilers                                      0        0
  15        target mismatches                                            0        0
  16        non-preferred targets                                        0        0

spfft@1.0.5%gcc@11.2.0~cuda~fortran~gpu_direct~ipo+mpi+openmp+rocm~single_precision~static amdgpu_target=gfx803,gfx900,gfx906 build_type=Release arch=linux-ubuntu20.04-icelake
    ^cmake@3.22.2%gcc@11.2.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=linux-ubuntu20.04-icelake
        ^ncurses@6.2%gcc@11.2.0~symlinks+termlib abi=none arch=linux-ubuntu20.04-icelake
            ^pkgconf@1.8.0%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
        ^openssl@1.1.1m%gcc@11.2.0~docs certs=system arch=linux-ubuntu20.04-icelake
            ^perl@5.34.0%gcc@11.2.0+cpanm+shared+threads arch=linux-ubuntu20.04-icelake
                ^berkeley-db@18.1.40%gcc@11.2.0+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=linux-ubuntu20.04-icelake
                ^bzip2@1.0.8%gcc@11.2.0~debug~pic+shared arch=linux-ubuntu20.04-icelake
                    ^diffutils@3.8%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                        ^libiconv@1.16%gcc@11.2.0 libs=shared,static arch=linux-ubuntu20.04-icelake
                ^gdbm@1.19%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^readline@8.1%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^zlib@1.2.11%gcc@11.2.0+optimize+pic+shared arch=linux-ubuntu20.04-icelake
    ^fftw@3.3.10%gcc@11.2.0+mpi~openmp~pfft_patches precision=double,float arch=linux-ubuntu20.04-icelake
        ^openmpi@4.1.2%gcc@11.2.0~atomics~cuda~cxx~cxx_exceptions+gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi~pmix+romio~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu20.04-icelake
            ^hwloc@2.7.0%gcc@11.2.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml~opencl+pci~rocm+shared arch=linux-ubuntu20.04-icelake
                ^libpciaccess@0.16%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^libtool@2.4.6%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                        ^m4@1.4.19%gcc@11.2.0+sigsegv patches=9dc5fbd0d5cb1037ab1e6d0ecc74a30df218d0a94bdd5a02759a97f62daca573,bfdffa7c2eb01021d5849b36972c069693654ad826c1a20b53534009a4ec7a89 arch=linux-ubuntu20.04-icelake
                            ^libsigsegv@2.13%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^util-macros@1.19.3%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^libxml2@2.9.12%gcc@11.2.0~python arch=linux-ubuntu20.04-icelake
                    ^xz@5.2.5%gcc@11.2.0~pic libs=shared,static arch=linux-ubuntu20.04-icelake
            ^libevent@2.1.12%gcc@11.2.0+openssl arch=linux-ubuntu20.04-icelake
            ^numactl@2.0.14%gcc@11.2.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,ff37630df599cfabf0740518b91ec8daaf18e8f288b19adaae5364dc1f6b2296 arch=linux-ubuntu20.04-icelake
                ^autoconf@2.69%gcc@11.2.0 patches=35c449281546376449766f92d49fc121ca50e330e60fefcfc9be2af3253082c2,7793209b33013dc0f81208718c68440c5aae80e7a1c4b8d336e382525af791a7,a49dd5bac3b62daa0ff688ab4d508d71dbd2f4f8d7e2a02321926346161bf3ee arch=linux-ubuntu20.04-icelake
                ^automake@1.16.5%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^openssh@8.8p1%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^libedit@3.1-20210216%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
    ^hip@4.5.2%gcc@11.2.0~ipo build_type=Release patches=24ca25a169f4bac849464cf7c6dd0885d6475e701fbc4e08e976ba16e4f2e9a6,2a4190477b7d9206b9cd8d70770ba0bc007273cbe54772efb12f9ca2e37c0392 arch=linux-ubuntu20.04-icelake
        ^comgr@4.5.2%gcc@11.2.0~ipo build_type=Release arch=linux-ubuntu20.04-icelake
            ^llvm-amdgpu@4.5.2%gcc@11.2.0~ipo~link_llvm_dylib~llvm_dylib+openmp+rocm-device-libs build_type=Release patches=d999f3b235e655ee07f6dd2590302082feaa06d32c5c6b53aae9c5cf1e45b644 arch=linux-ubuntu20.04-icelake
                ^libelf@0.8.13%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^perl-data-dumper@2.173%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^python@3.9.10%gcc@11.2.0+bz2+ctypes+dbm~debug+ensurepip+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93189bc278fbc37a50ed7f183bd8aaf249a8e1670a465f0db6bb4f8cf87,4c2457325f2b608b1b6a2c63087df8c26e07db3e3d493caf36a56f0ecf6fb768,f2fd060afc4b4618fe8104c4c5d771f36dc55b1db5a4623785a4ea707ec72fb4 arch=linux-ubuntu20.04-icelake
                    ^expat@2.4.4%gcc@11.2.0+libbsd arch=linux-ubuntu20.04-icelake
                        ^libbsd@0.11.3%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                            ^libmd@1.0.3%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^gettext@0.21%gcc@11.2.0+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-ubuntu20.04-icelake
                        ^tar@1.34%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^libffi@3.3%gcc@11.2.0 patches=26f26c6f29a7ce9bf370ad3ab2610f99365b4bdd7b82e7c31df41a3370d685c0 arch=linux-ubuntu20.04-icelake
                    ^sqlite@3.37.1%gcc@11.2.0+column_metadata+dynamic_extensions+fts~functions+rtree arch=linux-ubuntu20.04-icelake
                    ^util-linux-uuid@2.36.2%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^z3@4.8.14%gcc@11.2.0~gmp~ipo~python build_type=RelWithDebInfo arch=linux-ubuntu20.04-icelake
            ^rocm-cmake@4.5.2%gcc@11.2.0~ipo+ldconfig build_type=Release arch=linux-ubuntu20.04-icelake
        ^hsa-rocr-dev@4.5.2%gcc@11.2.0+image~ipo+shared build_type=Release patches=71e6851d9be8113bfb8d71b66a3171e0d0401bae5e6f161c9e7fe32558261a46 arch=linux-ubuntu20.04-icelake
            ^hsakmt-roct@4.5.2%gcc@11.2.0~ipo+shared build_type=Release patches=f926273de05bb4755faa93e5b1dcb4ad52a3f6ed19c52523eefaa30b27c7323c arch=linux-ubuntu20.04-icelake
                ^libdrm@2.4.100%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^docbook-xml@4.5%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^docbook-xsl@1.79.2%gcc@11.2.0 patches=a92c39715c54949ba9369add1809527b8f155b7e2a2b2e30cb4b39ee715f2e30 arch=linux-ubuntu20.04-icelake
                    ^libpthread-stubs@0.4%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^xxd-standalone@8.2.1201%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
        ^mesa@21.3.1%gcc@11.2.0+glx~llvm+opengl~opengles+osmesa~strip buildtype=debugoptimized default_library=shared patches=ada85be0f30bdd61a7c4eb24afec741da81bc411f7227e2d9014c862eef58b64 arch=linux-ubuntu20.04-icelake
            ^bison@3.8.2%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^flex@2.6.3%gcc@11.2.0+lex~nls arch=linux-ubuntu20.04-icelake
                ^findutils@4.8.0%gcc@11.2.0 patches=440b9543365b4692a2e6e0b5674809659846658d34d1dfc542c4397c8d668b92 arch=linux-ubuntu20.04-icelake
            ^glproto@1.4.17%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^libunwind@1.5.0%gcc@11.2.0~block_signals~conservative_checks~cxx_exceptions~debug~debug_frame+docs~pic+tests+weak_backtrace~xz~zlib components=none libs=shared,static arch=linux-ubuntu20.04-icelake
            ^libx11@1.7.0%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^inputproto@2.3.2%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^kbproto@1.0.7%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^libxcb@1.14%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^libxau@1.0.8%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                        ^xproto@7.0.31%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^libxdmcp@1.1.2%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^xcb-proto@1.14.1%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^xextproto@7.3.0%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^xtrans@1.3.5%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^libxext@1.3.3%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^libxt@1.1.5%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^libice@1.0.9%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^libsm@1.2.3%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^meson@0.61.2%gcc@11.2.0 patches=aa6c50d5a2aeb1a487d16f6712be4357fefb923aae37ab830699b07338388287 arch=linux-ubuntu20.04-icelake
                ^ninja@1.10.2%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^py-pip@21.3.1%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^py-setuptools@59.4.0%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^py-wheel@0.37.0%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^py-mako@1.1.5%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^py-markupsafe@2.0.1%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
            ^xrandr@1.5.0%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                ^libxrandr@1.5.0%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^libxrender@0.9.10%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                        ^renderproto@0.11.1%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
                    ^randrproto@1.5.0%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
        ^rocminfo@4.5.2%gcc@11.2.0~ipo build_type=Release arch=linux-ubuntu20.04-icelake
        ^roctracer-dev-api@4.5.2%gcc@11.2.0 arch=linux-ubuntu20.04-icelake
    ^hipfft@4.5.2%gcc@11.2.0~ipo build_type=Release arch=linux-ubuntu20.04-icelake
        ^rocfft@4.5.2%gcc@11.2.0~ipo amdgpu_target=gfx701 amdgpu_target_sram_ecc=none build_type=Release arch=linux-ubuntu20.04-icelake
```

</summary>