### PR TITLE
ASP-based solver: don't sort when defining variant possible values

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1589,8 +1589,9 @@ class SpackSolverSetup(object):
 
         """
         # Tell the concretizer about possible values from specs we saw in
-        # spec_clauses()
-        for pkg, variant, value in sorted(self.variant_values_from_specs):
+        # spec_clauses(). We might want to order these facts by pkg and name
+        # if we are debugging.
+        for pkg, variant, value in self.variant_values_from_specs:
             self.gen.fact(fn.variant_possible_value(pkg, variant, value))
 
     def _facts_from_concrete_spec(self, spec, possible):


### PR DESCRIPTION
fixes #28260

Since we iterate over variants from different packages, the variant values may have types which are not comparable, which causes errors at runtime. This is not a *real* issue though, since we don't need the facts to be ordered. Thus, to avoid needless sorting, the sorted function has been removed and a comment has been added to tip any developer that might need to inspect these clauses for debugging to add back sorting on the first two items only.

It's kind of difficult to add a test for this, since it depends on whether Python sorting algorithm ever needs to compare the third value of a tuple being ordered.