### PR TITLE
Revert "gettext: find external"

### DIFF
--- a/var/spack/repos/builtin/packages/gettext/package.py
+++ b/var/spack/repos/builtin/packages/gettext/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import re
-
 from spack import *
 
 
@@ -13,8 +11,6 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
 
     homepage = "https://www.gnu.org/software/gettext/"
     gnu_mirror_path = "gettext/gettext-0.20.1.tar.xz"
-
-    executables = [r'^gettext$']
 
     version('0.21',     sha256='d20fcbb537e02dcf1383197ba05bd0734ef7bf5db06bdb241eb69b7d16b73192')
     version('0.20.2',   sha256='b22b818e644c37f6e3d1643a1943c32c3a9bff726d601e53047d2682019ceaba')
@@ -54,13 +50,6 @@ class Gettext(AutotoolsPackage, GNUMirrorPackage):
     patch('nvhpc-builtin.patch', when='%nvhpc')
     patch('nvhpc-export-symbols.patch', when='%nvhpc')
     patch('nvhpc-long-width.patch', when='%nvhpc')
-
-    @classmethod
-    def determine_version(cls, exe):
-        gettext = Executable(exe)
-        output = gettext('--version', output=str, error=str)
-        match = re.match(r'gettext(?: \(.+\)) ([\d.]+)', output)
-        return match.group(1) if match else None
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
Reverts spack/spack#28610

Seems like external find support for `gettext` should improve, it's currently mostly causing issues (reported by @vsoch and also https://github.com/spack/spack/issues/25353#issuecomment-1041868116)