### PR TITLE
Add additional AMD GPU targets from LLVM documentation

### DIFF
--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
 from spack import *
 
 
@@ -29,13 +28,12 @@ class Rocblas(CMakePackage):
     version('3.7.0', sha256='9425db5f8e8b6f7fb172d09e2a360025b63a4e54414607709efc5acb28819642', deprecated=True)
     version('3.5.0', sha256='8560fabef7f13e8d67da997de2295399f6ec595edfd77e452978c140d5f936f0', deprecated=True)
 
-    tensile_architecture = ('all', 'gfx906', 'gfx908', 'gfx803', 'gfx900',
-                            'gfx906:xnack-', 'gfx908:xnack-', 'gfx90a:xnack+',
-                            'gfx90a:xnack-', 'gfx1010', 'gfx1011',
-                            'gfx1012', 'gfx1030')
-
-    variant('tensile_architecture', default='all', values=tensile_architecture, multi=True)
-    variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
+    variant('tensile_architecture',
+            values=spack.variant.any_combination_of(
+                *ROCmPackage.amdgpu_targets_with_feature('xnack')))
+    variant('build_type', default='Release',
+            values=("Release", "Debug", "RelWithDebInfo"),
+            description='CMake build type')
 
     # gfx906, gfx908,gfx803,gfx900 are valid for @:4.0.0
     # gfx803,gfx900,gfx:xnack-,gfx908:xnack- are valid gpus for @4.1.0:4.2.0

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -16,16 +16,6 @@ class Rocsolver(CMakePackage):
 
     maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
-    amdgpu_targets = (
-        'none', 'gfx803', 'gfx900', 'gfx906:xnack-', 'gfx908:xnack-',
-        'gfx90a:xnack-', 'gfx90a:xnack+', 'gfx1010', 'gfx1011', 'gfx1012', 'gfx1030'
-    )
-    variant('amdgpu_target', default='gfx906:xnack-', multi=True, values=amdgpu_targets)
-    variant('optimal', default=True,
-            description='This option improves performance at the cost of increased binary \
-            size and compile time by adding specialized kernels \
-            for small matrix sizes')
-
     version('4.5.2', sha256='4639322bd1e77fedfdeb9032633bde6211a0b1cc16a612db7754f873f18a492f')
     version('4.5.0', sha256='0295862da941f31f4d43b19195b79331bd17f5968032f75c89d2791a6f8c1e8c')
     version('4.3.1', sha256='c6e7468d7041718ce6e1c7f50ec80a552439ac9cfed2dc3f753ae417dda5724f')
@@ -39,7 +29,15 @@ class Rocsolver(CMakePackage):
     version('3.7.0', sha256='8c1c630595952806e658c539fd0f3056bd45bafc22b57f0dd10141abefbe4595', deprecated=True)
     version('3.5.0', sha256='d655e8c762fb9e123b9fd7200b4258512ceef69973de4d0588c815bc666cb358', deprecated=True)
 
-    variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
+    variant('amdgpu_target',
+            values=spack.variant.any_combination_of(
+                *ROCmPackage.amdgpu_targets_with_feature('xnack')))
+    variant('optimal', default=True,
+            description='This option improves performance at the cost of ' +
+                        'increased binary size and compile time by adding ' +
+                        'specialized kernels for small matrix sizes')
+    variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"),
+            description='CMake build type')
 
     depends_on('cmake@3.8:', type='build', when='@4.1.0:')
     depends_on('cmake@3.5:', type='build')


### PR DESCRIPTION
Add additional AMD GPU targets from the AMD-forked LLVM documentation.  This also expands the feature-modified target values and moves the knowledge of them to the base ROCmPackage.