### PR TITLE
py-notebook: fix py-nbconvert dep

### DIFF
--- a/var/spack/repos/builtin/packages/py-notebook/package.py
+++ b/var/spack/repos/builtin/packages/py-notebook/package.py
@@ -55,6 +55,8 @@ class PyNotebook(PythonPackage):
     depends_on('py-jupyter-client@5.3.1:', type=('build', 'run'), when='@6.0.0:6.0.1')
     depends_on('py-jupyter-client@5.3.4:', type=('build', 'run'), when='@6.0.2:')
     depends_on('py-nbformat',         type=('build', 'run'))
+    # https://github.com/jupyter/notebook/pull/6286
+    depends_on('py-nbconvert@5:', type=('build', 'run'), when='@5.5:')
     depends_on('py-nbconvert',        type=('build', 'run'))
     depends_on('py-ipykernel',        type=('build', 'run'))
     depends_on('py-send2trash',        type=('build', 'run'), when='@6:')


### PR DESCRIPTION
Basically the same issue as #28965. The lack of separate concretization of build deps means we can't install newer version of `py-nbconvert`, so by default we get an old version that isn't compatible with modern `py-notebook`.