### PR TITLE
Update: bamtools to version 2.5.2

### DIFF
--- a/var/spack/repos/builtin/packages/bamtools/package.py
+++ b/var/spack/repos/builtin/packages/bamtools/package.py
@@ -12,8 +12,9 @@ class Bamtools(CMakePackage):
     """C++ API & command-line toolkit for working with BAM data."""
 
     homepage = "https://github.com/pezmaster31/bamtools"
-    url      = "https://github.com/pezmaster31/bamtools/archive/v2.4.0.tar.gz"
+    url      = "https://github.com/pezmaster31/bamtools/archive/v2.5.2.tar.gz"
 
+    version('2.5.2', sha256='4d8b84bd07b673d0ed41031348f10ca98dd6fa6a4460f9b9668d6f1d4084dfc8')
     version('2.5.1', sha256='4abd76cbe1ca89d51abc26bf43a92359e5677f34a8258b901a01f38c897873fc')
     version('2.5.0', sha256='85e02e04998a67cbda7ab68cdab36cee133db024e814b34e06bb617b627caf9c')
     version('2.4.1', sha256='933a0c1a83c88c1dac8078c0c0e82f6794c75cb927265399404bc2cc2611204b')


### PR DESCRIPTION
Updating bamtools to version 2.5.2, also fixes a build issue.