### PR TITLE
Various package fixes for macOS

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -35,6 +35,7 @@ class GoBootstrap(Package):
 
     depends_on('git', type=('build', 'link', 'run'))
 
+    conflicts('os=monterey', msg="go-bootstrap won't build on new macOS")
     conflicts('target=aarch64:', when='platform=darwin',
               msg='Go bootstrap is too old for Apple Silicon')
 

--- a/var/spack/repos/builtin/packages/hdf5/fortran-kinds-2.patch
+++ b/var/spack/repos/builtin/packages/hdf5/fortran-kinds-2.patch
@@ -1,0 +1,24 @@
+From 598df49b738fd99df9f2671e4e967fd9c33ae8a9 Mon Sep 17 00:00:00 2001
+From: Seth R Johnson <johnsonsr@ornl.gov>
+Date: Wed, 16 Feb 2022 20:38:03 -0500
+Subject: [PATCH] Close file to work around GCC11.2/macOS12 bug
+
+---
+ m4/aclocal_fc.f90 | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/m4/aclocal_fc.f90 b/m4/aclocal_fc.f90
+index e9a11c0ab5..bfda49aa40 100644
+--- a/m4/aclocal_fc.f90
++++ b/m4/aclocal_fc.f90
+@@ -151,6 +151,7 @@ PROGRAM FC_AVAIL_KINDS
+      WRITE(8,'(I0)') max_decimal_prec
+      WRITE(8,'(I0)') num_ikinds
+      WRITE(8,'(I0)') num_rkinds
++     CLOSE(8)
+ END PROGRAM FC_AVAIL_KINDS
+ !---- END ----- Determine the available KINDs for REALs and INTEGERs
+ 
+-- 
+2.32.0
+

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -162,6 +162,14 @@ class Hdf5(CMakePackage):
 
     patch('fortran-kinds.patch', when='@1.10.7')
 
+    # This patch may only be needed with GCC11.2 on macOS, but it's valid for
+    # any of the head HDF5 versions as of 12/2021. Since it's impossible to
+    # tell what Fortran version is part of a mixed apple-clang toolchain on
+    # macOS (which is the norm), and this might be an issue for other compilers
+    # as well, we just apply it to all platforms.
+    # See https://github.com/HDFGroup/hdf5/issues/1157
+    patch('fortran-kinds-2.patch', when='@1.10.8,1.12.1')
+
     # The argument 'buf_size' of the C function 'h5fget_file_image_c' is
     # declared as intent(in) though it is modified by the invocation. As a
     # result, aggressive compilers such as Fujitsu's may do a wrong

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+import sys
 
 
 class Libzmq(AutotoolsPackage):
@@ -37,7 +37,7 @@ class Libzmq(AutotoolsPackage):
     variant("docs", default=True,
             description="Build documentation")
 
-    variant("libbsd", default=True,
+    variant("libbsd", default=(sys.platform != 'darwin'),
             description="Use strlcpy from libbsd " +
                         "(will use own implementation if false)")
 
@@ -51,10 +51,10 @@ class Libzmq(AutotoolsPackage):
     depends_on('docbook-xml', type='build', when='+docs')
     depends_on('docbook-xsl', type='build', when='+docs')
 
-    depends_on('libbsd', when='@4.3.3: platform=linux +libbsd')
-    depends_on('libbsd', when='@4.3.3: platform=cray +libbsd')
+    depends_on('libbsd', when='+libbsd')
 
     conflicts('%gcc@8:', when='@:4.2.2')
+    conflicts('+libbsd', when='@:4.3.2')
 
     # Fix aggressive compiler warning false positive
     patch('https://github.com/zeromq/libzmq/commit/92b2c38a2c51a1942a380c7ee08147f7b1ca6845.patch', sha256='8ebde83ee148989f9118d36ebaf256532627b8a6e7a486842110623331972edb', when='@4.2.3:4.3.4 %gcc@11:')

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -37,7 +37,7 @@ class Libzmq(AutotoolsPackage):
     variant("docs", default=True,
             description="Build documentation")
 
-    variant("libbsd", default=(sys.platform != 'darwin'),
+    variant("libbsd", when='@4.3.3:', default=(sys.platform != 'darwin'),
             description="Use strlcpy from libbsd " +
                         "(will use own implementation if false)")
 
@@ -54,7 +54,6 @@ class Libzmq(AutotoolsPackage):
     depends_on('libbsd', when='+libbsd')
 
     conflicts('%gcc@8:', when='@:4.2.2')
-    conflicts('+libbsd', when='@:4.3.2')
 
     # Fix aggressive compiler warning false positive
     patch('https://github.com/zeromq/libzmq/commit/92b2c38a2c51a1942a380c7ee08147f7b1ca6845.patch', sha256='8ebde83ee148989f9118d36ebaf256532627b8a6e7a486842110623331972edb', when='@4.2.3:4.3.4 %gcc@11:')

--- a/var/spack/repos/builtin/packages/py-sphinx-argparse/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-argparse/package.py
@@ -18,5 +18,5 @@ class PySphinxArgparse(PythonPackage):
 
     depends_on('python@2.7.0:2.7,3.5:', type=('build', 'run'))
     depends_on('py-sphinx@1.2.0:', type=('build', 'run'))
-    depends_on('py-poetry', type='build')
+    depends_on('py-poetry-core', type='build')
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-sphinx-argparse/package.py
+++ b/var/spack/repos/builtin/packages/py-sphinx-argparse/package.py
@@ -18,4 +18,5 @@ class PySphinxArgparse(PythonPackage):
 
     depends_on('python@2.7.0:2.7,3.5:', type=('build', 'run'))
     depends_on('py-sphinx@1.2.0:', type=('build', 'run'))
+    depends_on('py-poetry', type='build')
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -528,7 +528,6 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
             define_trilinos_enable('TrilinosCouplings'),
             define_trilinos_enable('Zoltan'),
             define_trilinos_enable('Zoltan2'),
-            define_tpl_enable('Cholmod', False),
             define_from_variant('EpetraExt_BUILD_BTF', 'epetraextbtf'),
             define_from_variant('EpetraExt_BUILD_EXPERIMENTAL',
                                 'epetraextexperimental'),
@@ -687,6 +686,13 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 define('TPL_Netcdf_PARALLEL', True),
                 define('PNetCDF_ROOT', spec['parallel-netcdf'].prefix),
             ])
+
+        options.append(define_tpl_enable('Cholmod', False))
+
+        if spec.satisfies('platform=darwin'):
+            # Don't let TriBITS define `libdl` as an absolute path to
+            # the MacOSX{nn.n}.sdk since that breaks at every xcode update
+            options.append(define_tpl_enable('DLlib', False))
 
         # ################# Explicit template instantiation #################
 


### PR DESCRIPTION
- HDF5: work around https://github.com/HDFGroup/hdf5/issues/1157 by explicitly closing the file
- Trilinos: fix SDK-related breakages caused by using absolute paths to libdl
- py-sphinx-argparse: make an implicit dependency explicit
- libzmq: fix a collision between #28503 and #20893 regarding libbsd requirements
- go-bootstrap: fails to build on monterey (closes #29011)