### PR TITLE
py-fiscalyear: add v0.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-fiscalyear/package.py
+++ b/var/spack/repos/builtin/packages/py-fiscalyear/package.py
@@ -21,11 +21,14 @@ class PyFiscalyear(PythonPackage):
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('0.4.0', sha256='12857a48bd7b97bda78d833b29e81f30ec5aa018241f690e714b472b25fa1b47')
     version('0.3.2', sha256='0697b2af4ab2d4c6188fac33d340f31dea9b0e1f0d3666d6752faeedd744f019')
     version('0.3.1', sha256='5964b4be71453c1fa5da804343cea866e0299aff874aa59ae186a8a9b9ff62d0')
     version('0.3.0', sha256='64f97b3a0ab6b2857d09f0016bd3aae37646a454a5c2c66e907fef03ae54a816')
     version('0.2.0', sha256='f513616aeb03046406c56d7c69cd9e26f6a12963c71c1410cc3d4532a5bfee71')
     version('0.1.0', sha256='3fde4a12eeb72da446beb487e078adf1223a92d130520e589b82d7d1509701a2')
 
+    depends_on('python@3.6:', when='@0.4:', type=('build', 'run'))
     depends_on('python@2.5:', type=('build', 'run'))
+    depends_on('py-setuptools@42:', when='@0.4:', type='build')
     depends_on('py-setuptools', type='build')


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.9.10 and Apple Clang 12.0.0.