### PR TITLE
llvm: fix build with Fujitsu compiler, and conflicts gcc@8.4 on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/llvm12-thread.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm12-thread.patch
@@ -1,0 +1,31 @@
+diff --git a/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake b/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake
+index e3c2a580396e..5f76992d193e 100644
+--- a/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake
++++ b/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake
+@@ -249,3 +249,6 @@ if (NOT LIBOMPTARGET_CUDA_TOOLKIT_ROOT_DIR_PRESET AND
+     endif()
+   endif()
+ endif()
++
++find_package(Threads REQUIRED)
++set(OPENMP_PTHREAD_LIB ${CMAKE_THREAD_LIBS_INIT})
+diff --git a/openmp/libomptarget/src/CMakeLists.txt b/openmp/libomptarget/src/CMakeLists.txt
+index 15e6c3bbaf1f..3e5a73504a08 100644
+--- a/openmp/libomptarget/src/CMakeLists.txt
++++ b/openmp/libomptarget/src/CMakeLists.txt
+@@ -30,6 +30,7 @@ if(OPENMP_STANDALONE_BUILD OR (NOT OPENMP_ENABLE_LIBOMPTARGET_PROFILING))
+   add_library(omptarget SHARED ${LIBOMPTARGET_SRC_FILES})
+   target_link_libraries(omptarget
+     ${CMAKE_DL_LIBS}
++    ${OPENMP_PTHREAD_LIB}
+     "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports")
+ else()
+   set(LLVM_LINK_COMPONENTS
+@@ -37,6 +38,7 @@ else()
+     )
+   add_llvm_library(omptarget SHARED ${LIBOMPTARGET_SRC_FILES}
+       LINK_LIBS ${CMAKE_DL_LIBS}
++      ${OPENMP_PTHREAD_LIB}
+       "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports"
+       )
+   target_compile_definitions(omptarget PUBLIC OMPTARGET_PROFILE_ENABLED)

--- a/var/spack/repos/builtin/packages/llvm/llvm13-fujitsu.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm13-fujitsu.patch
@@ -1,0 +1,15 @@
+--- spack-src/libcxx/include/__config.org	2022-02-03 14:36:11.000000000 +0900
++++ spack-src/libcxx/include/__config	2022-02-04 08:39:59.000000000 +0900
+@@ -52,7 +52,11 @@
+ #  elif __cplusplus <= 201703L
+ #    define _LIBCPP_STD_VER 17
+ #  elif __cplusplus <= 202002L
+-#    define _LIBCPP_STD_VER 20
++#    if defined(__FUJITSU) || defined(__CLANG_FUJITSU)
++#      define _LIBCPP_STD_VER 17
++#    else
++#      define _LIBCPP_STD_VER 20
++#    endif
+ #  else
+ #    define _LIBCPP_STD_VER 21  // current year, or date of c++2b ratification
+ #  endif

--- a/var/spack/repos/builtin/packages/llvm/llvm13-thread.patch
+++ b/var/spack/repos/builtin/packages/llvm/llvm13-thread.patch
@@ -1,0 +1,19 @@
+--- spack-src/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake.org	2022-02-08 14:58:13.000000000 +0900
++++ spack-src/openmp/libomptarget/cmake/Modules/LibomptargetGetDependencies.cmake	2022-02-08 13:58:53.000000000 +0900
+@@ -276,4 +276,5 @@
+   endif()
+ endif()
+
+-set(OPENMP_PTHREAD_LIB ${LLVM_PTHREAD_LIB})
++find_package(Threads REQUIRED)
++set(OPENMP_PTHREAD_LIB ${CMAKE_THREAD_LIBS_INIT})
+--- spack-src/openmp/libomptarget/src/CMakeLists.txt.org	2022-02-09 08:49:35.000000000 +0900
++++ spack-src/openmp/libomptarget/src/CMakeLists.txt	2022-02-09 08:50:18.000000000 +0900
+@@ -36,6 +36,7 @@
+ endif()
+ target_link_libraries(omptarget PRIVATE
+   ${CMAKE_DL_LIBS}
++  ${OPENMP_PTHREAD_LIB}
+   "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports")
+ 
+ # Install libomptarget under the lib destination folder.

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -347,6 +347,13 @@ class Llvm(CMakePackage, CudaPackage):
 
     patch('llvm-gcc11.patch', when='@9:11%gcc@11:')
 
+    # add -lpthread to build OpenMP libraries with Fujitsu compiler
+    patch('llvm12-thread.patch', when='@12 %fj')
+    patch('llvm13-thread.patch', when='@13: %fj')
+
+    # avoid build failed with Fujitsu compiler
+    patch('llvm13-fujitsu.patch', when='@13.0.0 %fj')
+
     # The functions and attributes below implement external package
     # detection for LLVM. See:
     #

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -238,6 +238,8 @@ class Llvm(CMakePackage, CudaPackage):
     conflicts("%gcc@:5.0", when="@8:")
     # clang/lib: a lambda parameter cannot shadow an explicitly captured entity
     conflicts("%clang@8:", when="@:4")
+    # Internal compiler error on gcc 8.4 on aarch64 https://bugzilla.redhat.com/show_bug.cgi?id=1958295
+    conflicts('%gcc@8.4:8.4.9', when='@12: target=aarch64:')
 
     # When these versions are concretized, but not explicitly with +libcxx, these
     # conflicts will enable clingo to set ~libcxx, making the build successful:

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -354,7 +354,7 @@ class Llvm(CMakePackage, CudaPackage):
     patch('llvm13-thread.patch', when='@13: %fj')
 
     # avoid build failed with Fujitsu compiler
-    patch('llvm13-fujitsu.patch', when='@13.0.0 %fj')
+    patch('llvm13-fujitsu.patch', when='@13 %fj')
 
     # The functions and attributes below implement external package
     # detection for LLVM. See:

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -351,7 +351,7 @@ class Llvm(CMakePackage, CudaPackage):
 
     # add -lpthread to build OpenMP libraries with Fujitsu compiler
     patch('llvm12-thread.patch', when='@12 %fj')
-    patch('llvm13-thread.patch', when='@13: %fj')
+    patch('llvm13-thread.patch', when='@13 %fj')
 
     # avoid build failed with Fujitsu compiler
     patch('llvm13-fujitsu.patch', when='@13 %fj')


### PR DESCRIPTION
- Add -lpthread to build OpenMP libraries with Fujitsu compiler
-  avoid build failed with Fujitsu compiler
- Add conflicts gcc@8.4 on aarch64 https://bugzilla.redhat.com/show_bug.cgi?id=1958295