### PR TITLE
py-pyqt5: add 5.15.6 and get sources from pypi

### DIFF
--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -159,6 +159,9 @@ class SIPPackage(PackageBase):
 
     @run_after('install')
     def extend_path_setup(self):
+        if self.spec['py-sip'].satisfies('@5:'):
+            return
+
         # See github issue #14121 and PR #15297
         module = self.spec['py-sip'].variants['module'].value
         if module != 'sip':

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import inspect
+
 from spack import *
 
 
@@ -12,11 +14,12 @@ class PyPyqt5(SIPPackage):
     Windows, OS X, Linux, iOS and Android. PyQt5 supports Qt v5."""
 
     homepage = "https://www.riverbankcomputing.com/software/pyqt/intro"
-    url      = "https://www.riverbankcomputing.com/static/Downloads/PyQt5/5.13.0/PyQt5_gpl-5.13.0.tar.gz"
-    list_url = "https://www.riverbankcomputing.com/software/pyqt/download5"
+    url = "https://files.pythonhosted.org/packages/source/P/PyQt5/PyQt5-5.15.2.tar.gz"
+    list_url = "https://pypi.org/simple/PyQt5/"
 
     sip_module = 'PyQt5.sip'
 
+    version('5.15.6', sha256='80343bcab95ffba619f2ed2467fd828ffeb0a251ad7225be5fc06dcc333af452')
     version('5.13.1', sha256='54b7f456341b89eeb3930e786837762ea67f235e886512496c4152ebe106d4af')
     version('5.13.0', sha256='0cdbffe5135926527b61cc3692dd301cd0328dd87eeaf1313e610787c46faff9')
     version('5.12.3', sha256='0db0fa37debab147450f9e052286f7a530404e2aaddc438e97a7dcdf56292110')
@@ -28,11 +31,30 @@ class PyPyqt5(SIPPackage):
     # sip: QOpenGLFramebufferObject is undefined
     depends_on('qt@5:+opengl')
     depends_on('python@2.6:', type=('build', 'run'))
-    depends_on('py-enum34', type=('build', 'run'), when='^python@:3.3')
-    depends_on('py-sip module=PyQt5.sip', type=('build', 'run'))
+    # contraints according to PKG-INFO
+    depends_on('python@3.6:', when='@5.15.2:', type=('build', 'run'))
+    depends_on('python@3.5:', when='@5.14:', type=('build', 'run'))
+    depends_on('py-pyqt5-sip@12.8:12', when='@5.15.0,5.15.1', type=('build', 'run'))
+    depends_on('py-pyqt5-sip@12.7:12', when='@5.14', type=('build', 'run'))
+    # contraints according to pyproject.toml
+    depends_on('py-sip@6.4:6', when='@5.15.6:', type=('build', 'run'))
+    depends_on('py-sip@5.3:6', when='@5.15.0:5.15.5', type=('build', 'run'))
+    depends_on('py-sip@5.0.1:5', when='@5.14', type=('build', 'run'))
+    depends_on('py-pyqt-builder@1.9:1', when='@5.15.3:', type=('build', 'run'))
+    depends_on('py-pyqt-builder@1.6:1', when='@5.15.2', type=('build', 'run'))
+    depends_on('py-pyqt-builder@1.1:1', when='@5.14:5.15.1', type=('build', 'run'))
+    # contraints according to configure.py
+    depends_on('py-sip@4.19.19:4 module=PyQt5.sip', when='@5.13', type=('build', 'run'))
+    depends_on('py-sip@4.19.14:4 module=PyQt5.sip', when='@5.12.3', type=('build', 'run'))
+    depends_on('py-enum34', when='^python@:3.3', type=('build', 'run'))
+
     depends_on('py-sip@:4.19.18 module=PyQt5.sip', type=('build', 'run'), when='@:5.13.0')
 
-    # https://www.riverbankcomputing.com/static/Docs/PyQt5/installation.html
+    @when('@5.14:')
+    def configure(self, spec, prefix):
+        pass
+
+    @when('@:5.13')
     def configure_args(self):
         args = [
             '--pyuic5-interpreter', self.spec['python'].command.path,
@@ -46,5 +68,35 @@ class PyPyqt5(SIPPackage):
                          '--qsci-api-destdir', self.prefix.share.qsci])
         return args
 
+    @when('@5.14:')
+    def build(self, spec, prefix):
+        with working_dir(self.stage.source_path):
+            sip = Executable(join_path(spec['py-sip'].prefix.bin, 'sip-install'))
+            sip(*self.build_args())
+
+    @when('@5.14:')
+    def build_args(self):
+        args = [
+            '--verbose',
+            '--confirm-license',
+            '--qmake', self.spec['qt'].prefix.bin.qmake,
+            '--target-dir', join_path(python_platlib, 'PyQt5'),
+            '--jobs', str(inspect.getmodule(self).make_jobs),
+        ]
+        if '+qsci_api' in self.spec:
+            args.extend(['--api-dir', self.prefix.share.qsci])
+
+        return args
+
+    @when('@5.14:')
+    def install(self, spec, prefix):
+        pass
+
+    @run_after('install')
+    def extend_path_setup(self):
+        if self.spec.satisfies('@:5.13'):
+            SIPPackage.extend_path_setup(self)
+
     def setup_run_environment(self, env):
-        env.prepend_path('QT_PLUGIN_PATH', self.prefix.plugins)
+        if self.spec.satisfies('@:5.13'):
+            env.prepend_path('QT_PLUGIN_PATH', self.prefix.plugins)

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -18,9 +18,9 @@ class PyPyqt5(SIPPackage):
     sip_module = 'PyQt5.sip'
 
     version('5.15.6', sha256='80343bcab95ffba619f2ed2467fd828ffeb0a251ad7225be5fc06dcc333af452')
-    version('5.13.1', sha256='54b7f456341b89eeb3930e786837762ea67f235e886512496c4152ebe106d4af')
-    version('5.13.0', sha256='0cdbffe5135926527b61cc3692dd301cd0328dd87eeaf1313e610787c46faff9')
-    version('5.12.3', sha256='0db0fa37debab147450f9e052286f7a530404e2aaddc438e97a7dcdf56292110')
+    version('5.13.1', sha256='54b7f456341b89eeb3930e786837762ea67f235e886512496c4152ebe106d4af', deprecated=True)
+    version('5.13.0', sha256='0cdbffe5135926527b61cc3692dd301cd0328dd87eeaf1313e610787c46faff9', deprecated=True)
+    version('5.12.3', sha256='0db0fa37debab147450f9e052286f7a530404e2aaddc438e97a7dcdf56292110', deprecated=True)
 
     # API files can be installed regardless if Qscintilla is installed or not
     variant('qsci_api', default=False, description='Install PyQt API file for QScintilla')

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -81,7 +81,7 @@ class PyPyqt5(SIPPackage):
             '--confirm-license',
             '--qmake', self.spec['qt'].prefix.bin.qmake,
             '--target-dir', join_path(python_platlib, 'PyQt5'),
-            '--jobs', str(inspect.getmodule(self).make_jobs),
+            '--jobs', str(make_jobs),
         ]
         if '+qsci_api' in self.spec:
             args.extend(['--api-dir', self.prefix.share.qsci])

--- a/var/spack/repos/builtin/packages/py-pyqt5/package.py
+++ b/var/spack/repos/builtin/packages/py-pyqt5/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import inspect
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/py-sip/package.py
+++ b/var/spack/repos/builtin/packages/py-sip/package.py
@@ -28,9 +28,10 @@ class PySip(PythonPackage):
 
     depends_on('python@3.6:', when='@6:', type=('build', 'run'))
     depends_on('python@3.5.1:', when='@5:', type=('build', 'run'))
-    depends_on('py-packaging', when='@5:', type='build')
+    depends_on('py-packaging', when='@5:', type=('build', 'run'))
+    depends_on('py-setuptools@30.3:', when='@6.2:', type=('build', 'run'))
     depends_on('py-setuptools@30.3:', when='@5:', type='build')
-    depends_on('py-toml', when='@5:', type='build')
+    depends_on('py-toml', when='@5:', type=('build', 'run'))
     depends_on('flex', when='@:4', type='build')
     depends_on('bison', when='@:4', type='build')
 


### PR DESCRIPTION
General: at the moment `py-pyqt5` does not build without #28870 (also before this PR).

The build system has changed to `sip-install` for newer versions.

Installs with `spack install --test=root` without problems for all 4 versions.

Side note: The tarballs for versions <=5.13 are not available on the original sources anymore but only via the spack mirror.