### PR TITLE
Move early exit for setup only argument

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -566,10 +566,6 @@ class PyclingoDriver(object):
             setup.setup(self, specs)
         timer.phase("setup")
 
-        # If we're only doing setup, just return an empty solve result
-        if setup_only:
-            return Result(specs)
-
         # read in the main ASP program and display logic -- these are
         # handwritten, not generated, so we load them as resources
         parent_dir = os.path.dirname(__file__)
@@ -587,6 +583,10 @@ class PyclingoDriver(object):
 
             path = os.path.join(parent_dir, 'concretize.lp')
             parse_files([path], visit)
+
+        # If we're only doing setup, just return an empty solve result
+        if setup_only:
+            return Result(specs)
 
         # Load the file itself
         self.control.load(os.path.join(parent_dir, 'concretize.lp'))


### PR DESCRIPTION
See https://github.com/spack/spack/pull/28468/files#r809156986

If we exit before generating the:
```
 error("Dependencies must have compatible OS's with their dependents").
 ...
```
facts we'll output a problem that is effectively different by the one solved by clingo during concretization.