### PR TITLE
Ruby: Fix Issues with SSL certificate installation

### DIFF
--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -56,7 +56,7 @@ class Ruby(AutotoolsPackage):
     resource(
         name='rubygems-updated-ssl-cert',
         url='https://raw.githubusercontent.com/rubygems/rubygems/master/lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem',
-        sha256='df68841998b7fd098a9517fe971e97890be0fc93bbe1b2a1ef63ebdea3111c80',
+        sha256='6bdc59f897631af7811e3201cbc58e5999de2600ae8667454a34514eecfd8381',
         when='+openssl',
         destination='',
         placement='rubygems-updated-ssl-cert',

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import re
-
+import os
 
 class Ruby(AutotoolsPackage):
     """A dynamic, open source programming language with a focus on
@@ -128,11 +128,9 @@ class Ruby(AutotoolsPackage):
             rubygems_updated_cert_path = join_path(self.stage.source_path,
                                                    'rubygems-updated-ssl-cert',
                                                    'GlobalSignRootCA_R3.pem')
-            rubygems_certs_path = join_path(self.spec.prefix.lib,
-                                            'ruby',
-                                            '{0}.0'.format(self.spec.version.
-                                                           up_to(2)),
-                                            'rubygems',
+            rubygems_path = Executable(self.prefix.bin.gem)('which', 'rubygems', output=str, error=str)
+            rubygems_path = os.path.splitext(rubygems_path)[0]
+            rubygems_certs_path = join_path(rubygems_path,
                                             'ssl_certs')
             install(rubygems_updated_cert_path, rubygems_certs_path)
 

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import re
 import os
+import re
+
 
 class Ruby(AutotoolsPackage):
     """A dynamic, open source programming language with a focus on
@@ -128,7 +129,8 @@ class Ruby(AutotoolsPackage):
             rubygems_updated_cert_path = join_path(self.stage.source_path,
                                                    'rubygems-updated-ssl-cert',
                                                    'GlobalSignRootCA_R3.pem')
-            rubygems_path = Executable(self.prefix.bin.gem)('which', 'rubygems', output=str, error=str)
+            rubygems_path = Executable(self.prefix.bin.gem)('which', 'rubygems',
+                                                            output=str, error=str)
             rubygems_path = os.path.splitext(rubygems_path)[0]
             rubygems_certs_path = join_path(rubygems_path,
                                             'ssl_certs')

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -55,7 +55,7 @@ class Ruby(AutotoolsPackage):
 
     resource(
         name='rubygems-updated-ssl-cert',
-        url='https://raw.githubusercontent.com/rubygems/rubygems/master/lib/rubygems/ssl_certs/index.rubygems.org/GlobalSignRootCA.pem',
+        url='https://raw.githubusercontent.com/rubygems/rubygems/master/lib/rubygems/ssl_certs/rubygems.org/GlobalSignRootCA_R3.pem',
         sha256='df68841998b7fd098a9517fe971e97890be0fc93bbe1b2a1ef63ebdea3111c80',
         when='+openssl',
         destination='',

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -127,7 +127,7 @@ class Ruby(AutotoolsPackage):
         if self.spec.satisfies("+openssl"):
             rubygems_updated_cert_path = join_path(self.stage.source_path,
                                                    'rubygems-updated-ssl-cert',
-                                                   'GlobalSignRootCA.pem')
+                                                   'GlobalSignRootCA_R3.pem')
             rubygems_certs_path = join_path(self.spec.prefix.lib,
                                             'ruby',
                                             '{0}.0'.format(self.spec.version.


### PR DESCRIPTION
This is a WIP. There are some issues with SSL certificate installation on some environment (sles15) where spack install ruby would fail.

I will be updating this PR as we make progress on the issue.