### PR TITLE
py-pandas: fix tests

### DIFF
--- a/var/spack/repos/builtin/packages/py-pandas/package.py
+++ b/var/spack/repos/builtin/packages/py-pandas/package.py
@@ -101,9 +101,13 @@ class PyPandas(PythonPackage):
 
     @property
     def import_modules(self):
-        modules = super(PythonPackage, self).import_modules
+        modules = super(__class__, self).import_modules
 
-        ignored_imports = ["pandas.tests", "pandas.plotting._matplotlib"]
+        ignored_imports = [
+            "pandas.tests",
+            "pandas.plotting._matplotlib",
+            "pandas.core._numba.kernels"
+        ]
 
         return [i for i in modules
                 if not any(map(i.startswith, ignored_imports))]


### PR DESCRIPTION
Tests did not run because super was referring to the wrong class. Should be either `super(PyPandas, self)` or `super(__class__, self)` to work.

`py-pandas` also imports `py-numba` in some parts, although it is not documented as a dependency, so I disabled these tests for now.