### PR TITLE
e4s ci: rename cdash build group to E4S not New PR testing...

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -269,7 +269,7 @@ spack:
       tags: ["spack", "public", "medium", "x86_64"]
 
   cdash:
-    build-group: New PR testing workflow
+    build-group: E4S
     url: https://cdash.spack.io
     project: Spack Testing
     site: Cloud Gitlab Infrastructure


### PR DESCRIPTION
@scottwittenburg What do you think?