### PR TITLE
gromacs: add fast math flags when AOCC

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -257,7 +257,7 @@ class Gromacs(CMakePackage):
                 '-DGMX_THREAD_MPI:BOOL=ON'])
 
         if self.spec.satisfies('%aocc'):
-            opt_flags = '-Ofast -ffast-math'
+            opt_flags = '-Ofast '
             options.append(self.define('CMAKE_C_FLAGS_RELEASE', opt_flags))
             options.append(self.define('CMAKE_CXX_FLAGS_RELEASE', opt_flags))
 

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -256,6 +256,11 @@ class Gromacs(CMakePackage):
                 '-DGMX_MPI:BOOL=OFF',
                 '-DGMX_THREAD_MPI:BOOL=ON'])
 
+        if self.spec.satisfies('%aocc'):
+            opt_flags = '-Ofast -ffast-math'
+            options.append(self.define('CMAKE_C_FLAGS_RELEASE', opt_flags))
+            options.append(self.define('CMAKE_CXX_FLAGS_RELEASE', opt_flags))
+
         if self.spec.satisfies('@2020:'):
             options.append('-DGMX_INSTALL_LEGACY_API=ON')
 


### PR DESCRIPTION
Adding Optimization flags `-Ofast` `-ffast-math` for AOCC compiler
