### PR TITLE
config:terminal_title:true by default

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -197,4 +197,4 @@ config:
   # Whether to set the terminal title to display status information during
   # building and installing packages. This gives information about Spack's
   # current progress as well as the current and total number of packages.
-  terminal_title: false
+  terminal_title: true


### PR DESCRIPTION
This is a nice feature and people who don't like it are free to disable it
