### PR TITLE
silo: fix DOMAIN/RANGE patch for 4.11-bsd

### DIFF
--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -100,7 +100,7 @@ class Silo(AutotoolsPackage):
         # hasn't yet made it into silo.
         # https://github.com/LLNL/fpzip/blob/master/src/pcmap.h
 
-        if self.spec.satisfies('@4.10.2-bsd'):
+        if str(self.spec.version).endswith('-bsd'):
             # The files below don't exist in the BSD licenced version
             return
 


### PR DESCRIPTION
There's a hardcoded '10.2-bsd' but the patch does not apply to '11-bsd' either.