### PR TITLE
Add back CUDA conflicts for GCC and Clang + Add CUDA 11.4.3 and 11.4.4

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -106,7 +106,9 @@ class CudaPackage(PackageBase):
         # This implies that the last one in the list has to be updated at
         # each release of a new cuda minor version.
         conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
+        conflicts('%gcc@11:', when='+cuda ^cuda@:11.4')
         conflicts('%gcc@12:', when='+cuda ^cuda@:11.6')
+        conflicts('%clang@12:', when='+cuda ^cuda@:11.4')
         conflicts('%clang@13:', when='+cuda ^cuda@:11.5')
         conflicts('%clang@14:', when='+cuda ^cuda@:11.6')
 

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -106,7 +106,7 @@ class CudaPackage(PackageBase):
         # This implies that the last one in the list has to be updated at
         # each release of a new cuda minor version.
         conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
-        conflicts('%gcc@11:', when='+cuda ^cuda@:11.4')
+        conflicts('%gcc@11:', when='+cuda ^cuda@:11.4.0')
         conflicts('%gcc@12:', when='+cuda ^cuda@:11.6')
         conflicts('%clang@12:', when='+cuda ^cuda@:11.4')
         conflicts('%clang@13:', when='+cuda ^cuda@:11.5')

--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -108,7 +108,7 @@ class CudaPackage(PackageBase):
         conflicts('%gcc@10:', when='+cuda ^cuda@:11.0')
         conflicts('%gcc@11:', when='+cuda ^cuda@:11.4.0')
         conflicts('%gcc@12:', when='+cuda ^cuda@:11.6')
-        conflicts('%clang@12:', when='+cuda ^cuda@:11.4')
+        conflicts('%clang@12:', when='+cuda ^cuda@:11.4.0')
         conflicts('%clang@13:', when='+cuda ^cuda@:11.5')
         conflicts('%clang@14:', when='+cuda ^cuda@:11.6')
 

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -37,6 +37,14 @@ _versions = {
         'Linux-aarch64': ('6ea9d520cc956cc751a5ac54f4acc39109627f4e614dd0b1a82cc86f2aa7d8c4', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_sbsa.run'),
         'Linux-x86_64': ('ae0a1693d9497cf3d81e6948943e3794636900db71c98d58eefdacaf7f1a1e4c', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux.run'),
         'Linux-ppc64le': ('95baefdc5adf165189407b119861ffb2e9800fd94d7fc81d10fb81ed36dc12db', 'https://developer.download.nvidia.com/compute/cuda/11.5.0/local_installers/cuda_11.5.0_495.29.05_linux_ppc64le.run')},
+    '11.4.4': {
+        'Linux-aarch64': ('c5c08531e48e8fdc2704fa1c1f7195f2c7edd2ee10a466d0e24d05b77d109435', 'https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux_sbsa.run'),
+        'Linux-x86_64': ('44545a7abb4b66dfc201dcad787b5e8352e5b7ddf3e3cc5b2e9177af419c25c8', 'https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux.run'),
+        'Linux-ppc64le': ('c71cd4e6c05fde11c0485369a73e7f356080e7a18f0e3ad7244e8fc03a9dd3e2', 'https://developer.download.nvidia.com/compute/cuda/11.4.4/local_installers/cuda_11.4.4_470.82.01_linux_ppc64le.run')},
+    '11.4.3': {
+        'Linux-aarch64': ('e02db34a487ea3de3eec9db80efd09f12eb69d55aca686cecaeae96a9747b1d4', 'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux_sbsa.run'),
+        'Linux-x86_64': ('749183821ffc051e123f12ebdeb171b263d55b86f0dd7c8f23611db1802d6c37', 'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux.run'),
+        'Linux-ppc64le': ('08f29cc3ed0b3b82dd9b007186237be2352bb552f99230c450a25e768f5754ee', 'https://developer.download.nvidia.com/compute/cuda/11.4.3/local_installers/cuda_11.4.3_470.82.01_linux_ppc64le.run')},
     '11.4.2': {
         'Linux-aarch64': ('f2c4a52e06329606c8dfb7c5ea3f4cb4c0b28f9d3fdffeeb734fcc98daf580d8', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux_sbsa.run'),
         'Linux-x86_64': ('bbd87ca0e913f837454a796367473513cddef555082e4d86ed9a38659cc81f0a', 'https://developer.download.nvidia.com/compute/cuda/11.4.2/local_installers/cuda_11.4.2_470.57.02_linux.run'),


### PR DESCRIPTION
In https://github.com/spack/spack/pull/28439 a couple of lines with still valid conflicts has been removed.

From https://github.com/spack/spack/pull/28439#issuecomment-1015448823 it seems that something changed from https://github.com/spack/spack/pull/25054#issuecomment-885543526. For instance, picking the line about CUDA 11.4.0 the two sources above says:

```
11.4.0-devel-ubuntu18.04/host_config.h:#error -- unsupported clang version! clang version must be less than 13 and greater than 3.2
11.4.0-devel-ubuntu18.04/host_config.h:#error -- unsupported GNU version! gcc versions later than 11 are not supported!
```

so "supported CLANG < 13 and GCC <= 11", while the other one says

```
11.4.0  #error -- unsupported clang version! clang version must be less than 12 and greater than 3.2
11.4.0  #error -- unsupported GNU version! gcc versions later than 10 are not supported!
```

so "supported CLANG < 12 and GCC <= 10".

Anyhow, from actual evidence I had (thanks @msimberg for pointing that out), at least for CUDA 11.2.0 and GCC 11 the conflicts is still there.

For this reason, after coordinating with @haampie, I start this PR by adding back the old conflicts for both GCC and CLANG, waiting for updates about the correct version of CUDA to use (is it 11.4.0 or do we have to use the older 11.3.1?).

Thanks for the support @haampie.