### PR TITLE
iwyu: add 0.17 and improve llvm target requirements

### DIFF
--- a/var/spack/repos/builtin/packages/iwyu/package.py
+++ b/var/spack/repos/builtin/packages/iwyu/package.py
@@ -16,6 +16,7 @@ class Iwyu(CMakePackage):
 
     maintainers = ['sethrj']
 
+    version('0.17', sha256='eca7c04f8b416b6385ed00e33669a7fa4693cd26cb72b522cde558828eb0c665')
     version('0.16', sha256='8d6fc9b255343bc1e5ec459e39512df1d51c60e03562985e0076036119ff5a1c')
     version('0.15', sha256='2bd6f2ae0d76e4a9412f468a5fa1af93d5f20bb66b9e7bf73479c31d789ac2e2')
     version('0.14', sha256='43184397db57660c32e3298a6b1fd5ab82e808a1f5ab0591d6745f8d256200ef')
@@ -25,6 +26,7 @@ class Iwyu(CMakePackage):
 
     patch('iwyu-013-cmake.patch', when='@0.13:0.14')
 
+    depends_on('llvm+clang@13.0:13', when='@0.17')
     depends_on('llvm+clang@12.0:12', when='@0.16')
     depends_on('llvm+clang@11.0:11', when='@0.15')
     depends_on('llvm+clang@10.0:10', when='@0.14')

--- a/var/spack/repos/builtin/packages/iwyu/package.py
+++ b/var/spack/repos/builtin/packages/iwyu/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+import archspec
 
 
 class Iwyu(CMakePackage):
@@ -34,8 +34,10 @@ class Iwyu(CMakePackage):
     depends_on('llvm+clang@8.0:8', when='@0.12')
     depends_on('llvm+clang@7.0:7', when='@0.11')
 
-    # iwyu uses X86AsmParser
-    depends_on('llvm targets=x86')
+    # iwyu uses X86AsmParser so must have the x86 target on non-x86 arch
+    _arches = set(str(x.family) for x in archspec.cpu.TARGETS.values())
+    for _arch in _arches - set(['x86', 'x86_64']):
+        depends_on('llvm targets=x86', when='arch={0}:'.format(_arch))
 
     @when('@0.14:')
     def cmake_args(self):


### PR DESCRIPTION
IWYU requires (or at least as of 0.16 and clang 12) x86 symbols, which is enabled explicitly by 'targets=x86' but works on x86/x86_64 devices when 'targets=none'.