### PR TITLE
Changing openmp library from llvm-amdgpu to rocm-opemnp-extras

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -36,7 +36,7 @@ class LlvmAmdgpu(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
     variant('rocm-device-libs', default=True, description='Build ROCm device libs as external LLVM project instead of a standalone spack package.')
-    variant('openmp', default=True, description='Enable OpenMP')
+    variant('openmp', default=False, description='Enable OpenMP')
     variant(
         'llvm_dylib',
         default=False,

--- a/var/spack/repos/builtin/packages/rocm-tensile/0003-require-openmp-extras-when-tensile-use-openmp-is-on.patch
+++ b/var/spack/repos/builtin/packages/rocm-tensile/0003-require-openmp-extras-when-tensile-use-openmp-is-on.patch
@@ -1,0 +1,26 @@
+diff --git a/HostLibraryTests/CMakeLists.txt b/HostLibraryTests/CMakeLists.txt
+index e571904f..78509e67 100644
+--- a/HostLibraryTests/CMakeLists.txt
++++ b/HostLibraryTests/CMakeLists.txt
+@@ -91,7 +91,7 @@ if(TENSILE_USE_OPENMP AND NOT TARGET custom_openmp_cxx)
+ 
+     if(TENSILE_USE_HIP)
+         target_compile_options(custom_openmp_cxx INTERFACE "-fopenmp")
+-        target_link_options(custom_openmp_cxx INTERFACE "-fopenmp")
++        target_link_options(custom_openmp_cxx INTERFACE "-fopenmp" INTERFACE "-Wl,-L${OPENMP_EXTRAS_DIR}/lib/")
+     else ()
+         find_package(OpenMP REQUIRED)
+         target_link_libraries(custom_openmp_cxx INTERFACE OpenMP::OpenMP_CXX)
+diff --git a/Tensile/Source/CMakeLists.txt b/Tensile/Source/CMakeLists.txt
+index aa9a51f6..6a6a2e6a 100644
+--- a/Tensile/Source/CMakeLists.txt
++++ b/Tensile/Source/CMakeLists.txt
+@@ -71,7 +71,7 @@ if(TENSILE_NEW_CLIENT)
+ 
+         if(TENSILE_USE_HIP)
+             target_compile_options(custom_openmp_cxx INTERFACE "-fopenmp")
+-            target_link_options(custom_openmp_cxx INTERFACE "-fopenmp")
++            target_link_options(custom_openmp_cxx INTERFACE "-fopenmp" INTERFACE "-Wl,-L${OPENMP_EXTRAS_DIR}/lib/")
+         else ()
+             find_package(OpenMP REQUIRED)
+             target_link_libraries(custom_openmp_cxx INTERFACE OpenMP::OpenMP_CXX)

--- a/var/spack/repos/builtin/packages/rocm-tensile/package.py
+++ b/var/spack/repos/builtin/packages/rocm-tensile/package.py
@@ -48,8 +48,8 @@ class RocmTensile(CMakePackage):
         depends_on('rocm-cmake@' + ver, type='build',  when='@' + ver)
         depends_on('hip@' + ver,                       when='@' + ver)
         depends_on('comgr@' + ver,                     when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,               when='@' + ver + '+openmp')
-        depends_on('llvm-amdgpu@' + ver + '~openmp',   when='@' + ver + '~openmp')
+        depends_on('rocm-openmp-extras@' + ver,        when='@' + ver + '+openmp')
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver + '~openmp')
         depends_on('rocminfo@' + ver,    type='build', when='@' + ver)
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0']:
@@ -63,6 +63,7 @@ class RocmTensile(CMakePackage):
     # Not yet landed in 3.7.0, nor 3.8.0.
     patch('0001-fix-compile-error.patch', when='@3.7.0:3.8.0')
     patch('0002-require-openmp-when-tensile-use-openmp-is-on.patch', when='@3.9.0:4.0.0')
+    patch('0003-require-openmp-extras-when-tensile-use-openmp-is-on.patch', when='@4.5.0:' + '+openmp')
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)
@@ -87,7 +88,7 @@ class RocmTensile(CMakePackage):
             self.define('Tensile_LOGIC', 'asm_full'),
             self.define('Tensile_CODE_OBJECT_VERSION', 'V3'),
             self.define('Boost_USE_STATIC_LIBS', 'OFF'),
-            self.define('TENSILE_USE_OPENMP', 'ON'),
+            self.define_from_variant('TENSILE_USE_OPENMP', 'openmp'),
             self.define(
                 'BUILD_WITH_TENSILE_HOST',
                 'ON' if '@3.7.0:' in self.spec else 'OFF'
@@ -103,6 +104,9 @@ class RocmTensile(CMakePackage):
         if self.spec.satisfies('^cmake@3.21.0:3.21.2'):
             args.append(self.define('__skip_rocmclang', 'ON'))
 
+        if '+openmp' in self.spec:
+            args.append(self.define('OPENMP_EXTRAS_DIR',
+                        self.spec['rocm-openmp-extras'].prefix))
         return args
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Linking openmp library from openmp-extras instead of llvm-amdgpu