### PR TITLE
patch include paths for gcc@11's libsanitizer on alpine linux

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/alpine-missing-includes.patch
+++ b/var/spack/repos/builtin/packages/gcc/alpine-missing-includes.patch
@@ -1,0 +1,298 @@
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_netbsd.cpp b/libsanitizer/sanitizer_common/sanitizer_platform_limits_netbsd.cpp
+index c8f2aa5..7446b06 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_netbsd.cpp
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_netbsd.cpp
+@@ -300,20 +300,12 @@ typedef struct {
+ #include <dev/pci/pciio.h>
+ #include <dev/pci/tweio.h>
+ #include <dev/pcmcia/if_cnwioctl.h>
+-#include <net/bpf.h>
+-#include <net/if_gre.h>
+-#include <net/ppp_defs.h>
+-#include <net/if_ppp.h>
+-#include <net/if_pppoe.h>
+-#include <net/if_sppp.h>
+-#include <net/if_srt.h>
+-#include <net/if_tap.h>
+-#include <net/if_tun.h>
+-#include <net/npf.h>
+-#include <net/pfvar.h>
+-#include <net/slip.h>
+-#include <netbt/hci.h>
+-#include <netinet/ip_compat.h>
++#if __has_include(<net/if_ppp.h>)
++#include <net/if_ppp.h>
++#else
++#include <linux/ppp-ioctl.h>
++#include <linux/ppp_defs.h>
++#endif
+ #if __has_include(<netinet/ip_fil.h>)
+ #include <netinet/ip_fil.h>
+ #include <netinet/ip_nat.h>
+@@ -511,7 +497,6 @@ struct urio_command {
+ #include <ttyent.h>
+ #include <fts.h>
+ #include <regex.h>
+-#include <fstab.h>
+ #include <stringlist.h>
+ 
+ #if defined(__x86_64__)
+@@ -563,7 +548,7 @@ unsigned struct_FTS_sz = sizeof(FTS);
+ unsigned struct_FTSENT_sz = sizeof(FTSENT);
+ unsigned struct_regex_sz = sizeof(regex_t);
+ unsigned struct_regmatch_sz = sizeof(regmatch_t);
+-unsigned struct_fstab_sz = sizeof(struct fstab);
++unsigned struct_fstab_sz = 0;
+ unsigned struct_utimbuf_sz = sizeof(struct utimbuf);
+ unsigned struct_itimerspec_sz = sizeof(struct itimerspec);
+ unsigned struct_timex_sz = sizeof(struct timex);
+@@ -650,7 +650,6 @@ uptr __sanitizer_in_addr_sz(int af) {
+ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ 
+ int glob_nomatch = GLOB_NOMATCH;
+-int glob_altdirfunc = GLOB_ALTDIRFUNC;
+ 
+ unsigned path_max = PATH_MAX;
+ 
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_freebsd.cpp b/libsanitizer/sanitizer_common/sanitizer_platform_limits_freebsd.cpp
+index b1c15be..6c5509e 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_freebsd.cpp
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_freebsd.cpp
+@@ -53,7 +53,6 @@
+ //
+ #include <dirent.h>
+ #include <dlfcn.h>
+-#include <fstab.h>
+ #include <fts.h>
+ #include <glob.h>
+ #include <grp.h>
+@@ -134,7 +133,7 @@ unsigned struct_shminfo_sz = sizeof(struct shminfo);
+ unsigned struct_shm_info_sz = sizeof(struct shm_info);
+ unsigned struct_regmatch_sz = sizeof(regmatch_t);
+ unsigned struct_regex_sz = sizeof(regex_t);
+-unsigned struct_fstab_sz = sizeof(struct fstab);
++unsigned struct_fstab_sz = 0;
+ unsigned struct_FTS_sz = sizeof(FTS);
+ unsigned struct_FTSENT_sz = sizeof(FTSENT);
+ unsigned struct_StringList_sz = sizeof(StringList);
+@@ -165,7 +165,6 @@ uptr __sanitizer_in_addr_sz(int af) {
+ 
+ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ int glob_nomatch = GLOB_NOMATCH;
+-int glob_altdirfunc = GLOB_ALTDIRFUNC;
+ 
+ unsigned path_max = PATH_MAX;
+ 
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 025e575..7b035d1 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -58,7 +58,6 @@
+ #endif
+ 
+ #if !SANITIZER_ANDROID
+-#include <fstab.h>
+ #include <sys/mount.h>
+ #include <sys/timeb.h>
+ #include <utmpx.h>
+@@ -114,8 +113,27 @@ typedef struct user_fpregs elf_fpregset_t;
+ #include <glob.h>
+ #include <obstack.h>
+ #include <mqueue.h>
+-#include <net/if_ppp.h>
+-#include <netax25/ax25.h>
+-#include <netipx/ipx.h>
+-#include <netrom/netrom.h>
++#if __has_include(<net/if_ppp.h>)
++#include <net/if_ppp.h>
++#else
++#include <linux/ppp-ioctl.h>
++#include <linux/ppp_defs.h>
++#endif
++#if __has_include(<netax25/ax25.h>)
++#include <netax25/ax25.h>
++#else
++#include <linux/ax25.h>
++#endif
++#if __has_include(<netipx/ipx.h>)
++#include <netipx/ipx.h>
++#else
++#include <linux/libc-compat.h>
++#endif
++#if __has_include(<netrom/netrom.h>)
++#include <netrom/netrom.h>
++#else
++#include <linux/netrom.h>
++#endif
++#include <termios.h>
++#include <stdio.h>
+ #if HAVE_RPC_XDR_H
+@@ -202,7 +199,7 @@ namespace __sanitizer {
+ #endif // (SANITIZER_MAC && !TARGET_CPU_ARM64) && !SANITIZER_IOS
+ 
+ #if !SANITIZER_ANDROID
+-  unsigned struct_fstab_sz = sizeof(struct fstab);
++  unsigned struct_fstab_sz = 0;
+   unsigned struct_statfs_sz = sizeof(struct statfs);
+   unsigned struct_sockaddr_sz = sizeof(struct sockaddr);
+   unsigned ucontext_t_sz = sizeof(ucontext_t);
+@@ -297,7 +296,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+   int glob_nomatch = GLOB_NOMATCH;
+-  int glob_altdirfunc = GLOB_ALTDIRFUNC;
+ #endif
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID &&  
+@@ -418,7 +438,7 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_input_id_sz = sizeof(struct input_id);
+   unsigned struct_mtpos_sz = sizeof(struct mtpos);
+   unsigned struct_rtentry_sz = sizeof(struct rtentry);
+-  unsigned struct_termio_sz = sizeof(struct termio);
++  unsigned struct_termio_sz = 0;
+   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
+   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
+   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);
+@@ -444,19 +464,19 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+ #endif // SANITIZER_LINUX
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-  unsigned struct_ax25_parms_struct_sz = sizeof(struct ax25_parms_struct);
++  unsigned struct_ax25_parms_struct_sz = 0;
+ #if EV_VERSION > (0x010000)
+   unsigned struct_input_keymap_entry_sz = sizeof(struct input_keymap_entry);
+ #else
+   unsigned struct_input_keymap_entry_sz = 0;
+ #endif
+-  unsigned struct_ipx_config_data_sz = sizeof(struct ipx_config_data);
++  unsigned struct_ipx_config_data_sz = 0;
+   unsigned struct_kbdiacrs_sz = sizeof(struct kbdiacrs);
+   unsigned struct_kbentry_sz = sizeof(struct kbentry);
+   unsigned struct_kbkeycode_sz = sizeof(struct kbkeycode);
+   unsigned struct_kbsentry_sz = sizeof(struct kbsentry);
+   unsigned struct_mtconfiginfo_sz = sizeof(struct mtconfiginfo);
+-  unsigned struct_nr_parms_struct_sz = sizeof(struct nr_parms_struct);
++  unsigned struct_nr_parms_struct_sz = 0;
+   unsigned struct_scc_modem_sz = sizeof(struct scc_modem);
+   unsigned struct_scc_stat_sz = sizeof(struct scc_stat);
+   unsigned struct_serial_multiport_struct_sz
+@@ -871,20 +891,19 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_SCSI_IOCTL_PROBE_HOST = SCSI_IOCTL_PROBE_HOST;
+   unsigned IOCTL_SCSI_IOCTL_TAGGED_DISABLE = SCSI_IOCTL_TAGGED_DISABLE;
+   unsigned IOCTL_SCSI_IOCTL_TAGGED_ENABLE = SCSI_IOCTL_TAGGED_ENABLE;
+-  unsigned IOCTL_SIOCAIPXITFCRT = SIOCAIPXITFCRT;
+-  unsigned IOCTL_SIOCAIPXPRISLT = SIOCAIPXPRISLT;
++  unsigned IOCTL_SIOCAIPXPRISLT = 0;
+   unsigned IOCTL_SIOCAX25ADDUID = SIOCAX25ADDUID;
+   unsigned IOCTL_SIOCAX25DELUID = SIOCAX25DELUID;
+-  unsigned IOCTL_SIOCAX25GETPARMS = SIOCAX25GETPARMS;
++  unsigned IOCTL_SIOCAX25GETPARMS = 0;
+   unsigned IOCTL_SIOCAX25GETUID = SIOCAX25GETUID;
+   unsigned IOCTL_SIOCAX25NOUID = SIOCAX25NOUID;
+-  unsigned IOCTL_SIOCAX25SETPARMS = SIOCAX25SETPARMS;
++  unsigned IOCTL_SIOCAX25SETPARMS = 0;
+   unsigned IOCTL_SIOCDEVPLIP = SIOCDEVPLIP;
+-  unsigned IOCTL_SIOCIPXCFGDATA = SIOCIPXCFGDATA;
++  unsigned IOCTL_SIOCIPXCFGDATA = 0;
+   unsigned IOCTL_SIOCNRDECOBS = SIOCNRDECOBS;
+-  unsigned IOCTL_SIOCNRGETPARMS = SIOCNRGETPARMS;
+-  unsigned IOCTL_SIOCNRRTCTL = SIOCNRRTCTL;
+-  unsigned IOCTL_SIOCNRSETPARMS = SIOCNRSETPARMS;
++  unsigned IOCTL_SIOCNRGETPARMS = 0;
++  unsigned IOCTL_SIOCNRRTCTL = 0;
++  unsigned IOCTL_SIOCNRSETPARMS = 0;
+   unsigned IOCTL_TIOCGSERIAL = TIOCGSERIAL;
+   unsigned IOCTL_TIOCSERGETMULTI = TIOCSERGETMULTI;
+   unsigned IOCTL_TIOCSERSETMULTI = TIOCSERSETMULTI;
+@@ -960,12 +979,6 @@ CHECK_TYPE_SIZE(glob_t);
+ CHECK_SIZE_AND_OFFSET(glob_t, gl_pathc);
+ CHECK_SIZE_AND_OFFSET(glob_t, gl_pathv);
+ CHECK_SIZE_AND_OFFSET(glob_t, gl_offs);
+-CHECK_SIZE_AND_OFFSET(glob_t, gl_flags);
+-CHECK_SIZE_AND_OFFSET(glob_t, gl_closedir);
+-CHECK_SIZE_AND_OFFSET(glob_t, gl_readdir);
+-CHECK_SIZE_AND_OFFSET(glob_t, gl_opendir);
+-CHECK_SIZE_AND_OFFSET(glob_t, gl_lstat);
+-CHECK_SIZE_AND_OFFSET(glob_t, gl_stat);
+ #endif
+ 
+ CHECK_TYPE_SIZE(addrinfo);
+@@ -993,13 +1006,10 @@ CHECK_TYPE_SIZE(msghdr);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_name);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_namelen);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_iov);
+-CHECK_SIZE_AND_OFFSET(msghdr, msg_iovlen);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_control);
+-CHECK_SIZE_AND_OFFSET(msghdr, msg_controllen);
+ CHECK_SIZE_AND_OFFSET(msghdr, msg_flags);
+ 
+ CHECK_TYPE_SIZE(cmsghdr);
+-CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_len);
+ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_level);
+ CHECK_SIZE_AND_OFFSET(cmsghdr, cmsg_type);
+ 
+@@ -1114,7 +1124,6 @@ CHECK_SIZE_AND_OFFSET(ipc_perm, key);
+ CHECK_SIZE_AND_OFFSET(ipc_perm, seq);
+ # else
+ CHECK_SIZE_AND_OFFSET(ipc_perm, __key);
+-CHECK_SIZE_AND_OFFSET(ipc_perm, __seq);
+ # endif
+ CHECK_SIZE_AND_OFFSET(ipc_perm, uid);
+ CHECK_SIZE_AND_OFFSET(ipc_perm, gid);
+@@ -1170,7 +1179,6 @@ CHECK_SIZE_AND_OFFSET(ifaddrs, ifa_data);
+ #endif
+ 
+ #if SANITIZER_LINUX
+-COMPILER_CHECK(sizeof(__sanitizer_struct_mallinfo) == sizeof(struct mallinfo));
+ #endif
+ 
+ #if !SANITIZER_ANDROID
+@@ -1220,22 +1228,6 @@ COMPILER_CHECK(__sanitizer_XDR_FREE == XDR_FREE);
+ #endif
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+-COMPILER_CHECK(sizeof(__sanitizer_FILE) <= sizeof(FILE));
+-CHECK_SIZE_AND_OFFSET(FILE, _flags);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_read_ptr);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_read_end);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_read_base);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_write_ptr);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_write_end);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_write_base);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_buf_base);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_buf_end);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_save_base);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_backup_base);
+-CHECK_SIZE_AND_OFFSET(FILE, _IO_save_end);
+-CHECK_SIZE_AND_OFFSET(FILE, _markers);
+-CHECK_SIZE_AND_OFFSET(FILE, _chain);
+-CHECK_SIZE_AND_OFFSET(FILE, _fileno);
+ #endif
+ 
+ #if SANITIZER_LINUX && !SANITIZER_ANDROID
+diff --git a/libsanitizer/interception/interception_linux.cpp b/libsanitizer/interception/interception_linux.cpp
+index 6883608..77668a4 100644
+--- a/libsanitizer/interception/interception_linux.cpp
++++ b/libsanitizer/interception/interception_linux.cpp
+@@ -66,7 +66,7 @@ bool InterceptFunction(const char *name, uptr *ptr_to_real, uptr func,
+ // Android and Solaris do not have dlvsym
+ #if !SANITIZER_ANDROID && !SANITIZER_SOLARIS
+ static void *GetFuncAddr(const char *name, const char *ver) {
+-  return dlvsym(RTLD_NEXT, name, ver);
++  return dlsym(RTLD_NEXT, name);
+ }
+ 
+ bool InterceptFunction(const char *name, const char *ver, uptr *ptr_to_real,
+diff --git a/libsanitizer/asan/asan_linux.cpp b/libsanitizer/asan/asan_linux.cpp
+index fb1a442..d78da63 100644
+--- a/libsanitizer/asan/asan_linux.cpp
++++ b/libsanitizer/asan/asan_linux.cpp
+@@ -83,7 +83,6 @@ bool IsSystemHeapAddress (uptr addr) { return false; }
+ 
+ void *AsanDoesNotSupportStaticLinkage() {
+-  // This will fail to link with -static.
+-  return &_DYNAMIC;  // defined in link.h
++  return 0;
+ }
+ 
+ #if ASAN_PREMAP_SHADOW

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -477,6 +477,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                             'typedef void* dispatch_block_t',
                             new_header)
 
+        patches = []
         # Alpine Linux requires multiple other patches to avoid compile errors due to
         # their use of musl libc and a few other things.
         # TODO: enable matching against a glob in a 'when' clause so we could do e.g.
@@ -486,10 +487,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             # This *should* be made to work against any alpine gcc, but these patches
             # are finicky and currently only work against the 11.x series.
             if spec.version >= Version('11'):
-                patches = [
+                patches.extend([
                     FilePatch(Gcc, 'pragma-poison.patch', 1, '.'),
                     FilePatch(Gcc, 'alpine-missing-includes.patch', 1, '.'),
-                ]
+                ])
             else:
                 tty.warn('Spack only supports building gcc@11: on Alpine Linux.')
         for patch in patches:

--- a/var/spack/repos/builtin/packages/gcc/pragma-poison.patch
+++ b/var/spack/repos/builtin/packages/gcc/pragma-poison.patch
@@ -1,0 +1,26 @@
+diff --git a/gcc/system.h b/gcc/system.h
+index a3f5948..95d5b4e 100644
+--- a/gcc/system.h
++++ b/gcc/system.h
+@@ -907,7 +907,7 @@ extern void fancy_abort (const char *, int, const char *)
+ #undef calloc
+ #undef strdup
+ #undef strndup
+- #pragma GCC poison calloc strdup strndup
++ #pragma GCC poison strdup strndup
+ 
+ #if !defined(FLEX_SCANNER) && !defined(YYBISON)
+ #undef malloc
+diff --git a/libcpp/system.h b/libcpp/system.h2
+index ee5fbe2..56f4bdc 100644
+--- a/libcpp/system.h
++++ b/libcpp/system.h
+@@ -428,7 +428,7 @@ extern void fancy_abort (const char *, int, const char *) ATTRIBUTE_NORETURN;
+ #undef strdup
+ #undef malloc
+ #undef realloc
+- #pragma GCC poison calloc strdup
++ #pragma GCC poison strdup
+  #pragma GCC poison malloc realloc
+ 
+ /* Libiberty macros that are no longer used in GCC.  */


### PR DESCRIPTION
### Problem
`spack install gcc@11.2.0` fails on Alpine Linux when building gcc's `libsanitizer` (which cannot be disabled via `./configure`). This patch fixes that.

### Solution
- Add two patches to `gcc@11:` to make it build successfully on Alpine.
    - Ensure those patches are enabled only on Alpine by modifying the `patch()` method.

### Result
This command succeeds on my Alpine install:
```bash
$ spack install 'gcc@11.2.0 languages=c,c++,fortran,jit'
```