### PR TITLE
add emacs+deterministic_build+link_time_optimization+mailutils+json+krb5 variants

### DIFF
--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -138,15 +138,14 @@ dependency, since ``autoconf`` already depends on it.
 Using a custom autoreconf phase
 """""""""""""""""""""""""""""""
 
-In some cases, packages will provide a custom script to generate ``configure``,
-often named ``autogen.sh``. The default implementation of the autoreconf phase
-can be overridden to execute such a script.
+In some cases, it might be needed to replace the default implementation
+of the autoreconf phase with one running a script interpreter. In this
+example, the ``bash`` shell is used to run the ``autogen.sh`` script.
 
 .. code-block:: python
 
    def autoreconf(self, spec, prefix):
-       autogen = Executable("./autogen.sh")
-       autogen()
+       which('bash')('autogen.sh')
 
 """""""""""""""""""""""""""""""""""""""
 patching configure or Makefile.in files

--- a/lib/spack/docs/build_systems/autotoolspackage.rst
+++ b/lib/spack/docs/build_systems/autotoolspackage.rst
@@ -138,14 +138,15 @@ dependency, since ``autoconf`` already depends on it.
 Using a custom autoreconf phase
 """""""""""""""""""""""""""""""
 
-In some cases, it might be needed to replace the default implementation
-of the autoreconf phase with one running a script interpreter. In this
-example, the ``bash`` shell is used to run the ``autogen.sh`` script.
+In some cases, packages will provide a custom script to generate ``configure``,
+often named ``autogen.sh``. The default implementation of the autoreconf phase
+can be overridden to execute such a script.
 
 .. code-block:: python
 
    def autoreconf(self, spec, prefix):
-       which('bash')('autogen.sh')
+       autogen = Executable("./autogen.sh")
+       autogen()
 
 """""""""""""""""""""""""""""""""""""""
 patching configure or Makefile.in files

--- a/var/spack/repos/builtin/packages/acl/makefile-autoconf-only.patch
+++ b/var/spack/repos/builtin/packages/acl/makefile-autoconf-only.patch
@@ -1,0 +1,30 @@
+diff --git a/./Makefile b/./Makefile
+index dce32d30e3..60becd7a7e 100644
+--- a/./Makefile
++++ b/./Makefile
+@@ -62,24 +62,11 @@ endif
+ # versions will copy those files anyway, and don't understand -i.
+ LIBTOOLIZE_INSTALL = `libtoolize -n -i >/dev/null 2>/dev/null && echo -i`
+ 
+-configure include/builddefs:
++autoconf include/builddefs:
+ 	libtoolize -c $(LIBTOOLIZE_INSTALL) -f
+ 	cp include/install-sh .
+ 	aclocal -I m4
+ 	autoconf
+-	./configure \
+-		--prefix=/ \
+-		--exec-prefix=/ \
+-		--sbindir=/bin \
+-		--bindir=/usr/bin \
+-		--libdir=/lib \
+-		--libexecdir=/usr/lib \
+-		--enable-lib64=yes \
+-		--includedir=/usr/include \
+-		--mandir=/usr/share/man \
+-		--datadir=/usr/share \
+-		$$LOCAL_CONFIGURE_OPTIONS
+-	touch .census
+ 
+ include/config.h: include/builddefs
+ ## Recover from the removal of $@

--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -51,14 +51,6 @@ class Acl(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         make("autoconf")
 
-    # The "make configure" target in the unpatched Makefile touched this file after executing the
-    # hardcoded ./configure command line. The purpose of this file is not documented, and this step
-    # may not be necessary.
-    @when("@:2.2.52")
-    @run_after("configure")
-    def touch_census(self):
-        touch(".census")
-
     def flag_handler(self, name, flags):
         if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")

--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -27,6 +27,7 @@ class Acl(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
+    depends_on("bash", type="build")
     depends_on("gettext")
 
     depends_on("attr")
@@ -37,8 +38,7 @@ class Acl(AutotoolsPackage):
     # In 2.2.53 and later, the codebase provides a nice autogen script.
     @when("@2.2.53:")
     def autoreconf(self, spec, prefix):
-        autogen = Executable("./autogen.sh")
-        autogen()
+        which("bash")("./autogen.sh")
 
     # Before 2.2.53, the project's script to generate ./configure was contained in a Makefile which
     # both generated the ./configure file and then executed a hardcoded ./configure command line

--- a/var/spack/repos/builtin/packages/acl/package.py
+++ b/var/spack/repos/builtin/packages/acl/package.py
@@ -10,8 +10,12 @@ class Acl(AutotoolsPackage):
     """Commands for Manipulating POSIX Access Control Lists."""
 
     homepage = "https://savannah.nongnu.org/projects/acl"
-    url = "https://git.savannah.nongnu.org/cgit/acl.git/snapshot/acl-2.2.53.tar.gz"
+    url = "https://git.savannah.nongnu.org/cgit/acl.git/snapshot/acl-2.3.1.tar.gz"
 
+    maintainers("cosmicexplorer")
+
+    version("2.3.1", sha256="8cad1182cc5703c3e8bf7a220fc267f146246f088d1ba5dd72d8b02736deedcc")
+    version("2.3.0", sha256="3659cf37ca29c0493f7d692d81dba5e1032b966d14674b6f0d637ff92afca4be")
     version("2.2.53", sha256="9e905397ac10d06768c63edd0579c34b8431555f2ea8e8f2cee337b31f856805")
     version("2.2.52", sha256="f3f31d2229c903184ff877aa0ee658b87ec20fec8aebb51e65eaa68d7b24e629")
     version("2.2.51", sha256="31a43d96a274a39bfcb805fb903d45840515344884d224cef166b482693a9f48")
@@ -23,14 +27,41 @@ class Acl(AutotoolsPackage):
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
     depends_on("libtool", type="build")
-    depends_on("attr")
     depends_on("gettext")
+
+    depends_on("attr")
+    # The configure step fails to find attr/xattr.h for these versions of acl unless this exact
+    # version of attr is used.
+    depends_on("attr@2.4.47", when="@:2.2.51")
+
+    # In 2.2.53 and later, the codebase provides a nice autogen script.
+    @when("@2.2.53:")
+    def autoreconf(self, spec, prefix):
+        autogen = Executable("./autogen.sh")
+        autogen()
+
+    # Before 2.2.53, the project's script to generate ./configure was contained in a Makefile which
+    # both generated the ./configure file and then executed a hardcoded ./configure command line
+    # with hardcoded install prefixes pointing to / and /usr. This patch removes the
+    # "make configure" target and replaces it with a "make autoconf" target that stops after
+    # generating the ./configure script, allowing spack to take over afterwards.
+    patch("makefile-autoconf-only.patch", when="@:2.2.52")
+
+    @when("@:2.2.52")
+    def autoreconf(self, spec, prefix):
+        make("autoconf")
+
+    # The "make configure" target in the unpatched Makefile touched this file after executing the
+    # hardcoded ./configure command line. The purpose of this file is not documented, and this step
+    # may not be necessary.
+    @when("@:2.2.52")
+    @run_after("configure")
+    def touch_census(self):
+        touch(".census")
 
     def flag_handler(self, name, flags):
         if name == "ldlibs" and "intl" in self.spec["gettext"].libs.names:
             flags.append("-lintl")
-        return self.build_system_flags(name, flags)
-
-    def autoreconf(self, spec, prefix):
-        bash = which("bash")
-        bash("./autogen.sh")
+        # For some reason, self.build_system_flags(...) fails to link libintl, and results in link
+        # errors for functions in that library. self.inject_flags(...) seems to fix this.
+        return self.inject_flags(name, flags)

--- a/var/spack/repos/builtin/packages/attr/package.py
+++ b/var/spack/repos/builtin/packages/attr/package.py
@@ -28,16 +28,14 @@ class Attr(AutotoolsPackage):
             url = "http://download.savannah.gnu.org/releases/attr/attr-{0}.src.tar.gz"
         return url.format(version)
 
+    # Ref. https://www.linuxfromscratch.org/blfs/view/7.5/postlfs/attr.html
     def configure_args(self):
         args = []
         args.append("--disable-static")
         return args
 
-    # Ref. https://www.linuxfromscratch.org/blfs/view/7.5/postlfs/attr.html
-    @when("@2.4.48:")
-    def install(self, spec, prefix):
-        make("install")
-
     @when("@:2.4.47")
     def install(self, spec, prefix):
+        make("install", "install-dev", "install-lib")
+
         make("install", "install-dev", "install-lib")

--- a/var/spack/repos/builtin/packages/attr/package.py
+++ b/var/spack/repos/builtin/packages/attr/package.py
@@ -12,6 +12,11 @@ class Attr(AutotoolsPackage):
     homepage = "https://savannah.nongnu.org/projects/attr"
     url = "http://download.savannah.gnu.org/releases/attr/attr-2.4.47.src.tar.gz"
 
+    maintainers("cosmicexplorer")
+
+    # FIXME: spack does not validate any of the checksums for this package for some reason!
+    version("2.5.1", sha256="bae1c6949b258a0d68001367ce0c741cebdacdd3b62965d17e5eb23cd78adaf8")
+    version("2.5.0", sha256="421501c3f7a56ab12e2c34a187bcae44f7d141f965ade18d01e6261d138f163b")
     version("2.4.48", sha256="5ead72b358ec709ed00bbf7a9eaef1654baad937c001c044fe8b74c57f5324e7")
     version("2.4.47", sha256="25772f653ac5b2e3ceeb89df50e4688891e21f723c460636548971652af0a859")
     version("2.4.46", sha256="dcd69bdca7ff166bc45141eddbcf21967999a6b66b0544be12a1cc2fd6340e1f")
@@ -29,8 +34,10 @@ class Attr(AutotoolsPackage):
         return args
 
     # Ref. https://www.linuxfromscratch.org/blfs/view/7.5/postlfs/attr.html
+    @when("@2.4.48:")
     def install(self, spec, prefix):
-        if self.version >= Version("2.4.48"):
-            make("install")
-        else:
-            make("install", "install-dev", "install-lib")
+        make("install")
+
+    @when("@:2.4.47")
+    def install(self, spec, prefix):
+        make("install", "install-dev", "install-lib")

--- a/var/spack/repos/builtin/packages/attr/package.py
+++ b/var/spack/repos/builtin/packages/attr/package.py
@@ -21,6 +21,10 @@ class Attr(AutotoolsPackage):
     version("2.4.47", sha256="25772f653ac5b2e3ceeb89df50e4688891e21f723c460636548971652af0a859")
     version("2.4.46", sha256="dcd69bdca7ff166bc45141eddbcf21967999a6b66b0544be12a1cc2fd6340e1f")
 
+    variant("nls", default=True, description="Enable Native Language Support")
+
+    depends_on("gettext", when="+nls")
+
     def url_for_version(self, version):
         if version >= Version("2.4.48"):
             url = "http://download.savannah.gnu.org/releases/attr/attr-{0}.tar.gz"
@@ -32,6 +36,18 @@ class Attr(AutotoolsPackage):
     def configure_args(self):
         args = []
         args.append("--disable-static")
+
+        if "+nls" in self.spec:
+            args.extend(
+                [
+                    "LDFLAGS={0}".format(self.spec["gettext"].libs.search_flags),
+                    "LIBS=-lintl",
+                    "--enable-nls",
+                ]
+            )
+        else:
+            args.append("--disable-nls")
+
         return args
 
     @when("@:2.4.47")

--- a/var/spack/repos/builtin/packages/emacs/package.py
+++ b/var/spack/repos/builtin/packages/emacs/package.py
@@ -3,9 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-import sys
-
 from spack.package import *
 
 
@@ -13,10 +10,10 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     """The Emacs programmable text editor."""
 
     homepage = "https://www.gnu.org/software/emacs"
-    git = "git://git.savannah.gnu.org/emacs.git"
+    git = "https://git.savannah.gnu.org/git/emacs.git"
     gnu_mirror_path = "emacs/emacs-24.5.tar.gz"
 
-    maintainers("alecbcs")
+    maintainers("alecbcs", "cosmicexplorer")
 
     version("master", branch="master")
     version("28.2", sha256="a6912b14ef4abb1edab7f88191bfd61c3edd7085e084de960a4f86485cb7cad8")
@@ -36,12 +33,32 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
         "toolkit",
         default="gtk",
         values=("gtk", "athena"),
+        when="+X",
         description="Select an X toolkit (gtk, athena)",
     )
     variant("tls", default=True, description="Build Emacs with gnutls")
     variant("native", default=False, when="@28:", description="enable native compilation of elisp")
     variant("treesitter", default=False, when="@29:", description="Build with tree-sitter support")
-    variant("json", default=False, when="@27:", description="Build with json support")
+    variant(
+        "deterministic_build",
+        default=False,
+        description="Make the build more deterministic by omitting names, time stamps, etc. from the output.",  # noqa: E501
+    )
+    variant(
+        "link_time_optimization",
+        default=False,
+        description="build with link-time optimization (experimental)",
+    )
+    variant("mailutils", default=False, description="build with GNU mailutils")
+    variant("kerberos5", default=False, description="support Kerberos version 5 authenticated POP")
+    variant(
+        "json",
+        default=False,
+        when="@27:",
+        description="use the native json library for json parsing",
+    )
+    variant("imagemagick", default=False, description="build with imagemagick")
+    variant("sound", default="alsa", values=("alsa", "no"), description="Build with sound support")
 
     depends_on("pkgconfig", type="build")
     depends_on("gzip", type="build")
@@ -50,51 +67,99 @@ class Emacs(AutotoolsPackage, GNUMirrorPackage):
     depends_on("pcre")
     depends_on("zlib")
     depends_on("libxml2")
-    depends_on("libtiff", when="+X")
-    depends_on("libpng", when="+X")
-    depends_on("libxpm", when="+X")
-    depends_on("giflib", when="+X")
-    depends_on("libx11", when="+X")
-    depends_on("libxaw", when="+X toolkit=athena")
-    depends_on("gtkplus", when="+X toolkit=gtk")
-    depends_on("gnutls", when="+tls")
-    depends_on("jpeg")
-    depends_on("tree-sitter", when="+treesitter")
-    depends_on("m4", type="build", when="@master:")
-    depends_on("autoconf", type="build", when="@master:")
-    depends_on("automake", type="build", when="@master:")
-    depends_on("libtool", type="build", when="@master:")
-    depends_on("texinfo", type="build", when="@master:")
-    depends_on("gcc@11: +strip languages=jit", when="+native")
-    depends_on("jansson@2.7:", when="+json")
 
+    # Window system deps.
+    with when("+X"):
+        depends_on("libx11")
+
+        depends_on("libxaw", when="toolkit=athena")
+        depends_on("gtkplus", when="toolkit=gtk")
+
+    depends_on("gnutls", when="+tls")
+
+    # Image processing.
+    depends_on("libtiff")
+    depends_on("libpng")
+    depends_on("libxpm")
+    depends_on("giflib")
+    depends_on("jpeg")
+
+    depends_on("tree-sitter", when="+treesitter")
+
+    # TODO: this should really be checking for a version from any git ref, but we don't
+    # currently have the ability to select for that in a `when` clause.
+    with when("@master:"):
+        depends_on("m4", type="build")
+        depends_on("autoconf", type="build")
+        depends_on("automake", type="build")
+        depends_on("libtool", type="build")
+        depends_on("texinfo", type="build")
+
+    # Native compilation depends on libgccjit, which will work regardless of the
+    # compiler that emacs is compiled with.
+    depends_on("gcc@11: languages=jit", when="+native")
+
+    depends_on("mailutils", when="+mailutils")
+    depends_on("krb5", when="+kerberos5")
+    depends_on("gmp")
+
+    depends_on("acl")
+    depends_on("imagemagick", when="+imagemagick")
+    depends_on("alsa-lib", when="sound=alsa")
+
+    depends_on("jansson", when="+json")
+
+    conflicts("+native", when="@:27", msg="native compilation requires emacs 28 or later")
+
+    # TODO: explain what was fixed in 26.3 on catalina in msg=?
     conflicts("@:26.3", when="platform=darwin os=catalina")
 
     @when("platform=darwin")
     def setup_build_environment(self, env):
-        # on macOS, emacs' config does search hard enough for ncurses'
-        # termlib `-ltinfo` lib, which results in linker errors
+        # On macOS, emacs's config doesn't search hard enough for ncurses's
+        # termlib `-ltinfo` lib, which results in linker errors.
         if "+termlib" in self.spec["ncurses"]:
             env.append_flags("LDFLAGS", "-ltinfo")
 
     def configure_args(self):
         spec = self.spec
 
-        toolkit = spec.variants["toolkit"].value
+        args = []
+        args += self.with_or_without("x", variant="X")
         if "+X" in spec:
-            args = ["--with-x", "--with-x-toolkit={0}".format(toolkit)]
-        else:
-            args = ["--without-x"]
+            toolkit = spec.variants["toolkit"].value
+            # TODO: make this use case (a `values=` variant gated on another variant
+            # with `when="+X"`) work with self.with_or_without()!
+            args.append("--with-x-toolkit={0}".format(toolkit))
 
         # On OS X/macOS, do not build "nextstep/Emacs.app", because
-        # doing so throws an error at build-time
-        if sys.platform == "darwin":
+        # doing so throws an error at build-time.
+        if "platform=darwin" in spec:
+            # TODO: make selecting by platform/os/architecture work with
+            # self.with_or_without() instead of just by variant!
             args.append("--without-ns")
 
+        # Register dependencies to provide to the configure script.
         args += self.with_or_without("native-compilation", variant="native")
         args += self.with_or_without("gnutls", variant="tls")
         args += self.with_or_without("tree-sitter", variant="treesitter")
+        args += self.with_or_without("mailutils")
+        args += self.with_or_without("imagemagick")
+        args += self.with_or_without("kerberos5")
         args += self.with_or_without("json")
+
+        args += self.enable_or_disable("link-time-optimization", variant="link_time_optimization")
+
+        if "+deterministic_build" in spec:
+            # TODO: allow negating a boolean variant with self.enable_or_disable() so
+            # that a build option can be *dis*abled when the variant is *en*abled!
+            args.append("--disable-build-details")
+
+        if self.spec.variants["sound"].value == "alsa":
+            # TODO: figure out how self.with_or_without() is supposed to work with
+            # a `values=` variant at all; it seems to produce "--with-*=..." for *all*
+            # values of the specified variant, not just the *selected* value!
+            args.append("--with-sound=alsa")
 
         return args
 

--- a/var/spack/repos/builtin/packages/font-util/package.py
+++ b/var/spack/repos/builtin/packages/font-util/package.py
@@ -12,12 +12,15 @@ class FontUtil(AutotoolsPackage, XorgPackage):
     homepage = "https://cgit.freedesktop.org/xorg/font/util"
     xorg_mirror_path = "font/font-util-1.3.1.tar.gz"
 
+    maintainers = ["cosmicexplorer"]
+
     version("1.4.0", sha256="30b90fe52347916be9b08f95f717f17c9c1f58bef8cabb49014d0fdd2b0df643")
     version("1.3.2", sha256="f115a3735604de1e852a4bf669be0269d8ce8f21f8e0e74ec5934b31dadc1e76")
     version("1.3.1", sha256="34ebb0c9c14e0a392cdd5ea055c92489ad88d55ae148b2f1cfded0f3f63f2b5b")
 
     depends_on("autoconf", type="build")
     depends_on("automake", type="build")
+    depends_on("gawk", type="build")
 
     depends_on("pkgconfig", type="build")
     depends_on("util-macros", type="build")
@@ -25,6 +28,8 @@ class FontUtil(AutotoolsPackage, XorgPackage):
     depends_on("bdftopcf", type="build")
     depends_on("mkfontscale", type="build")
     depends_on("mkfontdir", type="build")
+
+    executables = ["bdftruncate", "ucs2any"]
 
     font_baseurl = "https://www.x.org/archive/individual/font/"
     default_fonts = []

--- a/var/spack/repos/builtin/packages/gtkplus/package.py
+++ b/var/spack/repos/builtin/packages/gtkplus/package.py
@@ -13,6 +13,8 @@ class Gtkplus(MesonPackage):
     homepage = "https://www.gtk.org/"
     url = "https://download.gnome.org/sources/gtk+/3.24/gtk+-3.24.26.tar.xz"
 
+    maintainers = ["cosmicexplorer"]
+
     version("3.24.29", sha256="f57ec4ade8f15cab0c23a80dcaee85b876e70a8823d9105f067ce335a8268caa")
     version("3.24.26", sha256="2cc1b2dc5cad15d25b6abd115c55ffd8331e8d4677745dd3ce6db725b4fff1e9")
     version(
@@ -78,7 +80,7 @@ class Gtkplus(MesonPackage):
         )
 
         # https://gitlab.gnome.org/GNOME/gtk/-/issues/3776
-        if self.spec.satisfies("@3:%gcc@11:"):
+        if self.spec.satisfies("@3:%gcc@10:"):
             filter_file("    '-Werror=array-bounds',", "", "meson.build", string=True)
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -16,6 +16,8 @@ class Krb5(AutotoolsPackage):
     list_url = "https://kerberos.org/dist/krb5/"
     list_depth = 1
 
+    maintainers = ["cosmicexplorer"]
+
     version("1.20.1", sha256="704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851")
     version("1.19.4", sha256="41f5981c5a4de0a26b3937e679a116cd5b3739641fd253124aac91f7179b54eb")
     version("1.19.3", sha256="56d04863cfddc9d9eb7af17556e043e3537d41c6e545610778676cf551b9dcd0")
@@ -70,9 +72,11 @@ class Krb5(AutotoolsPackage):
     def configure_args(self):
         args = ["--without-system-verto"]
 
+        args += self.enable_or_disable("shared")
+        # TODO: allow negating a boolean variant with self.enable_or_disable() so
+        # that a build option can be *dis*abled when the variant is *en*abled!
         if "~shared" in self.spec:
             args.append("--enable-static")
-            args.append("--disable-shared")
         else:
             args.append("--disable-static")
 

--- a/var/spack/repos/builtin/packages/mailutils/package.py
+++ b/var/spack/repos/builtin/packages/mailutils/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Mailutils(AutotoolsPackage):
+    """Mailutils is a swiss army knife of electronic mail handling.
+    It offers a rich set of utilities and daemons for processing e-mail."""
+
+    homepage = "https://mailutils.org/"
+    url = "https://ftp.gnu.org/gnu/mailutils/mailutils-3.13.tar.gz"
+
+    maintainers = ["cosmicexplorer"]
+
+    version("3.13", sha256="41234389452805e5a47cec4fd57c61feee0cdaa6de94d0ded0cd33e778f58de2")
+
+    variant("gdbm", default=False, description="Build with gnu DBM support")
+    variant("berkeley-db", default=False, description="Build with berkeley DB support")
+    variant("guile", default=False, description="Build with guile support")
+
+    depends_on("libiconv")
+    depends_on("gettext")
+    depends_on("readline")
+    depends_on("gnutls")
+    depends_on("gdbm", when="+gdbm")
+    depends_on("berkeley-db", when="+berkeley-db")
+    depends_on("guile", when="+guile")
+    depends_on("m4", type="build")
+    depends_on("texinfo", type="build")
+    depends_on("ncurses+termlib")
+
+    def configure_args(self):
+        args = ["LIBS=-ltinfo"]
+
+        args += self.with_or_without("dbm", variant="gdbm")
+        args += self.with_or_without("gdbm")
+        args += self.with_or_without("berkeley-db")
+        args += self.with_or_without("guile")
+
+        return args


### PR DESCRIPTION
### Problem
There are some features exposed by emacs's `./configure` script which aren't currently threaded through to spack's variants for the `emacs` package, including link-time optimization.

### Solution
- Add appropriate dependencies and command line arguments for `+mailutils+json+krb5` variants.
- Add command line arguments to enable LTO for the `+link_time_optimization` variant.
- Enable a reproducible build with `+deterministic_build`.

### Result
This command now succeeds:
```bash
$ spack install emacs@master+X+tls+native+lto+mailutils+krb5+json
```