### PR TITLE
default gcc~bootstrap

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -103,7 +103,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             default=False,
             description='Target nvptx offloading to NVIDIA GPUs')
     variant('bootstrap',
-            default=True,
+            default=False,
             description='Enable 3-stage bootstrap')
     variant('graphite',
             default=False,


### PR DESCRIPTION
### Problem

`gcc` takes much longer to build when `+bootstrap` is enabled. Since `gcc languages=jit` must be built to provide e.g. `libgccjit`, any user of `libgccjit` has to wait for gcc to build itself three times instead of two.

Is there any security concern to doing this?

### Solution

- Default the `bootstrap` variant of `gcc` to `False`.

### Result
`spack install gcc` is faster!