### PR TITLE
git: install keychain helper on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -390,7 +390,6 @@ class Git(AutotoolsPackage):
             with working_dir('contrib/credential/osxkeychain'):
                 make()
 
-
     def install(self, spec, prefix):
         args = ["install"]
         if '~nls' in self.spec:

--- a/var/spack/repos/builtin/packages/git/package.py
+++ b/var/spack/repos/builtin/packages/git/package.py
@@ -5,7 +5,6 @@
 
 import os
 import re
-import sys
 
 from spack import *
 
@@ -374,7 +373,7 @@ class Git(AutotoolsPackage):
 
     @run_after('configure')
     def filter_rt(self):
-        if sys.platform == 'darwin':
+        if self.spec.satisfies('platform=darwin'):
             # Don't link with -lrt; the system has no (and needs no) librt
             filter_file(r' -lrt$', '', 'Makefile')
 
@@ -387,11 +386,20 @@ class Git(AutotoolsPackage):
             args.append('NO_GETTEXT=1')
         make(*args)
 
+        if spec.satisfies('platform=darwin'):
+            with working_dir('contrib/credential/osxkeychain'):
+                make()
+
+
     def install(self, spec, prefix):
         args = ["install"]
         if '~nls' in self.spec:
             args.append('NO_GETTEXT=1')
         make(*args)
+
+        if spec.satisfies('platform=darwin'):
+            install('contrib/credential/osxkeychain/git-credential-osxkeychain',
+                    join_path(prefix, "libexec", "git-core"))
 
     @run_after('install')
     def install_completions(self):


### PR DESCRIPTION
This installs the `git-credential-osxkeychain` on `darwin` platforms. This utility is always installed in the macOS homebrew install of git, so I assume it is pretty stable. 