### PR TITLE
geant4: fix CMake-derived data path

### DIFF
--- a/var/spack/repos/builtin/packages/geant4-data/package.py
+++ b/var/spack/repos/builtin/packages/geant4-data/package.py
@@ -38,98 +38,115 @@ class Geant4Data(BundlePackage):
     # For clarity, declare deps on a Major-Minor version basis as
     # they generally don't change on the patch level
     # Can move to declaring on a dataset basis if needed
-    # geant4@11.0.X
-    depends_on("g4ndl@4.6", when='@11.0.0:11.0')
-    depends_on("g4emlow@8.0", when='@11.0.0:11.0')
-    depends_on("g4photonevaporation@5.7", when='@11.0.0:11.0')
-    depends_on("g4radioactivedecay@5.6", when='@11.0.0:11.0')
-    depends_on("g4particlexs@4.0", when='@11.0.0:11.0')
-    depends_on("g4pii@1.3", when='@11.0.0:11.0')
-    depends_on("g4realsurface@2.2", when='@11.0.0:11.0')
-    depends_on("g4saiddata@2.0", when='@11.0.0:11.0')
-    depends_on("g4abla@3.1", when='@11.0.0:11.0')
-    depends_on("g4incl@1.0", when='@11.0.0:11.0')
-    depends_on("g4ensdfstate@2.3", when='@11.0.0:11.0')
+    _datasets = {
+        '11.0:11': [
+            "g4ndl@4.6",
+            "g4emlow@8.0",
+            "g4photonevaporation@5.7",
+            "g4radioactivedecay@5.6",
+            "g4particlexs@4.0",
+            "g4pii@1.3",
+            "g4realsurface@2.2",
+            "g4saiddata@2.0",
+            "g4abla@3.1",
+            "g4incl@1.0",
+            "g4ensdfstate@2.3",
+        ],
+        '10.7.0:10.7': [
+            "g4ndl@4.6",
+            "g4emlow@7.13",
+            "g4photonevaporation@5.7",
+            "g4radioactivedecay@5.6",
+            "g4pii@1.3",
+            "g4realsurface@2.2",
+            "g4saiddata@2.0",
+            "g4abla@3.1",
+            "g4incl@1.0",
+            "g4ensdfstate@2.3",
+        ],
+        '10.7.1:10.7': [
+            "g4particlexs@3.1.1",
+        ],
+        '10.7.0': [
+            "g4particlexs@3.1",
+        ],
+        '10.6.0:10.6': [
+            "g4ndl@4.6",
+            "g4emlow@7.9",
+            "g4emlow@7.9.1",
+            "g4photonevaporation@5.5",
+            "g4radioactivedecay@5.4",
+            "g4particlexs@2.1",
+            "g4pii@1.3",
+            "g4realsurface@2.1.1",
+            "g4saiddata@2.0",
+            "g4abla@3.1",
+            "g4incl@1.0",
+            "g4ensdfstate@2.2",
+        ],
+        '10.5.0:10.5': [
+            "g4ndl@4.5",
+            "g4emlow@7.7",
+            "g4photonevaporation@5.3",
+            "g4radioactivedecay@5.3",
+            "g4particlexs@1.1",
+            "g4pii@1.3",
+            "g4realsurface@2.1.1",
+            "g4saiddata@2.0",
+            "g4abla@3.1",
+            "g4incl@1.0",
+            "g4ensdfstate@2.2",
+        ],
+        '10.4.0:10.4': [
+            "g4ndl@4.5",
+            "g4emlow@7.3",
+            "g4photonevaporation@5.2",
+            "g4radioactivedecay@5.2",
+            "g4neutronxs@1.4",
+            "g4pii@1.3",
+            "g4saiddata@1.1",
+            "g4abla@3.1",
+            "g4ensdfstate@2.2",
+        ],
+        '10.4.2:10.4': [
+            "g4realsurface@2.1.1",
+        ],
+        '10.4.0:10.4.1': [
+            "g4realsurface@2.1",
+        ],
+        '10.3.0:10.3': [
+            "g4ndl@4.5",
+            "g4emlow@6.50",
+            "g4neutronxs@1.4",
+            "g4pii@1.3",
+            "g4realsurface@1.0",
+            "g4saiddata@1.1",
+            "g4abla@3.0",
+            "g4ensdfstate@2.1",
+        ],
+        '10.3.1:10.3': [
+            "g4photonevaporation@4.3.2",
+            "g4radioactivedecay@5.1.1",
+        ],
+        '10.3.0': [
+            "g4photonevaporation@4.3",
+            "g4radioactivedecay@5.1",
+        ],
+    }
 
-    # geant4@10.7.X
-    depends_on("g4ndl@4.6", when='@10.7.0:10.7')
-    depends_on("g4emlow@7.13", when='@10.7.0:10.7')
-    depends_on("g4photonevaporation@5.7", when='@10.7.0:10.7')
-    depends_on("g4radioactivedecay@5.6", when='@10.7.0:10.7')
-    depends_on("g4particlexs@3.1.1", when='@10.7.1:10.7')
-    depends_on("g4particlexs@3.1", when='@10.7.0')
-    depends_on("g4pii@1.3", when='@10.7.0:10.7')
-    depends_on("g4realsurface@2.2", when='@10.7.0:10.7')
-    depends_on("g4saiddata@2.0", when='@10.7.0:10.7')
-    depends_on("g4abla@3.1", when='@10.7.0:10.7')
-    depends_on("g4incl@1.0", when='@10.7.0:10.7')
-    depends_on("g4ensdfstate@2.3", when='@10.7.0:10.7')
+    for _vers, _dsets in _datasets.items():
+        _vers = '@' + _vers
+        for _d in _dsets:
+            depends_on(_d, type=('build', 'run'), when=_vers)
 
-    # geant4@10.6.X
-    depends_on("g4ndl@4.6", when='@10.6.0:10.6')
-    depends_on("g4emlow@7.9", when='@10.6.0')
-    depends_on("g4emlow@7.9.1", when='@10.6.1:10.6')
-    depends_on("g4photonevaporation@5.5", when='@10.6.0:10.6')
-    depends_on("g4radioactivedecay@5.4", when='@10.6.0:10.6')
-    depends_on("g4particlexs@2.1", when='@10.6.0:10.6')
-    depends_on("g4pii@1.3", when='@10.6.0:10.6')
-    depends_on("g4realsurface@2.1.1", when='@10.6.0:10.6')
-    depends_on("g4saiddata@2.0", when='@10.6.0:10.6')
-    depends_on("g4abla@3.1", when='@10.6.0:10.6')
-    depends_on("g4incl@1.0", when='@10.6.0:10.6')
-    depends_on("g4ensdfstate@2.2", when='@10.6.0:10.6')
-
-    # geant4@10.5.X
-    depends_on("g4ndl@4.5", when='@10.5.0:10.5')
-    depends_on("g4emlow@7.7", when='@10.5.0:10.5')
-    depends_on("g4photonevaporation@5.3", when='@10.5.0:10.5')
-    depends_on("g4radioactivedecay@5.3", when='@10.5.0:10.5')
-    depends_on("g4particlexs@1.1", when='@10.5.0:10.5')
-    depends_on("g4pii@1.3", when='@10.5.0:10.5')
-    depends_on("g4realsurface@2.1.1", when='@10.5.0:10.5')
-    depends_on("g4saiddata@2.0", when='@10.5.0:10.5')
-    depends_on("g4abla@3.1", when='@10.5.0:10.5')
-    depends_on("g4incl@1.0", when='@10.5.0:10.5')
-    depends_on("g4ensdfstate@2.2", when='@10.5.0:10.5')
-
-    # geant4@10.4.X
-    depends_on("g4ndl@4.5", when='@10.4.0:10.4')
-    depends_on("g4emlow@7.3", when='@10.4.0:10.4')
-    depends_on("g4photonevaporation@5.2", when='@10.4.0:10.4')
-    depends_on("g4radioactivedecay@5.2", when='@10.4.0:10.4')
-    depends_on("g4neutronxs@1.4", when='@10.4.0:10.4')
-    depends_on("g4pii@1.3", when='@10.4.0:10.4')
-
-    depends_on("g4realsurface@2.1.1", when='@10.4.2:10.4')
-    depends_on("g4realsurface@2.1", when='@10.4.0:10.4.1')
-
-    depends_on("g4saiddata@1.1", when='@10.4.0:10.4')
-    depends_on("g4abla@3.1", when='@10.4.0:10.4')
-    depends_on("g4ensdfstate@2.2", when='@10.4.0:10.4')
-
-    # geant4@10.3.X
-    depends_on("g4ndl@4.5", when='@10.3.0:10.3')
-    depends_on("g4emlow@6.50", when='@10.3.0:10.3')
-
-    depends_on("g4photonevaporation@4.3.2", when='@10.3.1:10.3')
-    depends_on("g4photonevaporation@4.3", when='@10.3.0')
-
-    depends_on("g4radioactivedecay@5.1.1", when='@10.3.1:10.3')
-    depends_on("g4radioactivedecay@5.1", when='@10.3.0')
-
-    depends_on("g4neutronxs@1.4", when='@10.3.0:10.3')
-    depends_on("g4pii@1.3", when='@10.3.0:10.3')
-    depends_on("g4realsurface@1.0", when='@10.3.0:10.3')
-    depends_on("g4saiddata@1.1", when='@10.3.0:10.3')
-    depends_on("g4abla@3.0", when='@10.3.0:10.3')
-    depends_on("g4ensdfstate@2.1", when='@10.3.0:10.3')
+    @property
+    def datadir(self):
+        spec = self.spec
+        return join_path(spec.prefix.share,
+                         '{0}-{1}'.format(self.name, self.version.dotted))
 
     def install(self, spec, prefix):
-        spec = self.spec
-        data = '{0}-{1}'.format(self.name, self.version.dotted)
-        datadir = join_path(spec.prefix.share, data)
-
-        with working_dir(datadir, create=True):
+        with working_dir(self.datadir, create=True):
             for s in spec.dependencies():
                 for d in glob.glob('{0}/data/*'.format(s.prefix.share)):
                     os.symlink(d, os.path.basename(d))

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+import os
 
 
 class Geant4(CMakePackage):
@@ -56,19 +56,10 @@ class Geant4(CMakePackage):
     depends_on('cmake@3.8:', type='build', when='@10.6.0:')
     depends_on('cmake@3.5:', type='build')
 
-    depends_on('geant4-data@11.0.0', type='run', when='@11.0.0')
-    depends_on('geant4-data@10.7.3', type='run', when='@10.7.3')
-    depends_on('geant4-data@10.7.2', type='run', when='@10.7.2')
-    depends_on('geant4-data@10.7.1', type='run', when='@10.7.1')
-    depends_on('geant4-data@10.7.0', type='run', when='@10.7.0')
-    depends_on('geant4-data@10.6.3', type='run', when='@10.6.3')
-    depends_on('geant4-data@10.6.2', type='run', when='@10.6.2')
-    depends_on('geant4-data@10.6.1', type='run', when='@10.6.1')
-    depends_on('geant4-data@10.6.0', type='run', when='@10.6.0')
-    depends_on('geant4-data@10.5.1', type='run', when='@10.5.1')
-    depends_on('geant4-data@10.4.3', type='run', when='@10.4.3')
-    depends_on('geant4-data@10.4.0', type='run', when='@10.4.0')
-    depends_on('geant4-data@10.3.3', type='run', when='@10.3.3')
+    for _vers in ["11.0.0", "10.7.3", "10.7.2", "10.7.1", "10.7.0", "10.6.3",
+                  "10.6.2", "10.6.1", "10.6.0", "10.5.1", "10.4.3", "10.4.0",
+                  "10.3.3"]:
+        depends_on('geant4-data@' + _vers, type='run', when='@' + _vers)
 
     depends_on("expat")
     depends_on("zlib")
@@ -169,8 +160,11 @@ class Geant4(CMakePackage):
             # geant4 libs at application runtime
             options.append('-DGEANT4_BUILD_TLS_MODEL=global-dynamic')
 
-        # never install the data with geant4
-        options.append('-DGEANT4_INSTALL_DATA=OFF')
+        # Never install the data with geant4, but point to the dependent
+        # geant4-data's install directory to correctly set up the
+        # Geant4Config.cmake values for Geant4_DATASETS .
+        options.append(self.define('GEANT4_INSTALL_DATA', False))
+        options.append(self.define('GEANT4_INSTALL_DATADIR', self.datadir))
 
         # Vecgeom
         if '+vecgeom' in spec:
@@ -201,3 +195,10 @@ class Geant4(CMakePackage):
                                                     'python'))
 
         return options
+
+    @property
+    def datadir(self):
+         dataspec = self.spec['geant4-data']
+         return join_path(dataspec.prefix.share,
+                          '{0}-{1}'.format(dataspec.name,
+                                           dataspec.version.dotted))

--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 
 class Geant4(CMakePackage):
     """Geant4 is a toolkit for the simulation of the passage of particles
@@ -198,7 +196,8 @@ class Geant4(CMakePackage):
 
     @property
     def datadir(self):
-         dataspec = self.spec['geant4-data']
-         return join_path(dataspec.prefix.share,
-                          '{0}-{1}'.format(dataspec.name,
-                                           dataspec.version.dotted))
+        dataspec = self.spec['geant4-data']
+        return join_path(
+            dataspec.prefix.share,
+            '{0}-{1}'.format(dataspec.name, dataspec.version.dotted)
+        )


### PR DESCRIPTION
Geant4 expects data to be data to be available at build time, and it writes the path to the data (whether external or internally downloaded) to the CMake configure file that it installs. Before #28581, `geant4-data` was a build/link/run dependency, but it should not have been `link`, which unnecessarily propagated rpath/link paths.  

https://github.com/spack/spack/pull/28388#issuecomment-1018612751 makes the point that since the executable part of Geant4 doesn't depend on the data, it shouldn't require a rebuild of Geant4 to change its data dependencies. However, this is only true if the config file isn't used to interrogate the "correct" geant4 data path, and some projects such as [Celeritas](https://github.com/celeritas-project/celeritas) use CMake to set up unit tests.

I tried to symlink the default geant4-installed data directory to the `geant4-data` directory in a `@run_after("install")`, but that failed I think because `geant4-data` isn't a build dependency. So instead I've restored the `GEANT4_INSTALL_DATA` path so that it points to the originally configured geant4 data directory. It doesn't do any extra copying nor data downloading, the `geant4-data` is still a runtime dependency, but in the typical case it will now behave like it used to and have valid paths in  `${Geant4_DATASETS}`.

I also rewrote some of the `depends_on` blocks as loops to make it easier to change the dependency types in the future if needed. In doing so I corrected the `geant4-data` dependencies to `('build', 'run')` from the default.