### PR TITLE
blat package: Adding -fcommon CFLAG for GCC 10

### DIFF
--- a/var/spack/repos/builtin/packages/blat/package.py
+++ b/var/spack/repos/builtin/packages/blat/package.py
@@ -23,4 +23,10 @@ class Blat(Package):
     def install(self, spec, prefix):
         filter_file('CC=.*', 'CC={0}'.format(spack_cc), 'inc/common.mk')
         mkdirp(prefix.bin)
-        make("BINDIR=%s" % prefix.bin)
+        if spec.satisfies('%gcc@10:'):
+            make(
+                "BINDIR=%s" % prefix.bin,
+                "CFLAGS=-fcommon",
+                )
+        else:
+            make("BINDIR=%s" % prefix.bin)


### PR DESCRIPTION
GCC 10+ defaults to -fno-common, which causes linker errors
https://gcc.gnu.org/gcc-10/porting_to.html