### PR TITLE
cleanup spack.parse.Lexer

### DIFF
--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -8,6 +8,7 @@ import re
 import shlex
 import sys
 from textwrap import dedent
+from typing import Callable, Dict, List, Tuple
 
 from six import string_types
 
@@ -39,19 +40,23 @@ class Token(object):
         return (self.type == other.type) and (self.value == other.value)
 
 
+_Lexicon = List['Tuple[str, Callable]']
+_Switches = Dict[str, List]
+
+
 class Lexer(object):
     """Base class for Lexers that keep track of line numbers."""
 
     __slots__ = "scanners", "mode", "switchbook"
 
     def __init__(self, lexicon_and_mode_switches):
-        self.scanners = []
-        self.switchbook = []
-        for lexicon, mode_switches_dict in lexicon_and_mode_switches:
-            self.scanners.append(re.Scanner(lexicon))
-            self.switchbook.append(mode_switches_dict)
-
-        self.mode = 0
+        # type: (List[Tuple[str, _Lexicon, _Switches]]) -> None
+        self.scanners = {}      # type: Dict[str, _Lexicon]
+        self.switchbook = {}    # type: Dict[str, _Switches]
+        self.mode = lexicon_and_mode_switches[0][0]
+        for mode_name, lexicon, mode_switches_dict in lexicon_and_mode_switches:
+            self.scanners[mode_name] = re.Scanner(lexicon)  # type: ignore[attr-defined]
+            self.switchbook[mode_name] = mode_switches_dict
 
     def token(self, type, value=''):
         cur_scanner = self.scanners[self.mode]

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -124,7 +124,7 @@ class Lexer(object):
                 for tok in self.lex_word(word):
                     yield tok
         except LexWordError as e:
-            raise six.raise_from(LexError(text, e), e)
+            raise six.raise_from(LexError(text, e), e)  # type: ignore[attr-defined]
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -121,7 +121,10 @@ class Parser(object):
 
     def push_tokens(self, iterable):
         """Adds all tokens in some iterable to the token stream."""
-        self.tokens = itertools.chain(iter(iterable), iter([self.next]), self.tokens)
+        self._push_token_stream(iter(iterable))
+
+    def _push_token_stream(self, stream):
+        self.tokens = itertools.chain(stream, iter([self.next]), self.tokens)
         self.gettok()
 
     def accept(self, id):
@@ -161,7 +164,8 @@ class Parser(object):
             text = sp.convert_to_posix_path(text)
             text = shlex.split(str(text))
         self.text = text
-        self.push_tokens(list(self.lexer.lex(text)))
+
+        self._push_token_stream(self.lexer.lex(text))
 
     @abc.abstractmethod
     def do_parse(self):

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -95,10 +95,13 @@ class Lexer(object):
                     # scan in other mode
                     self.mode = other_mode  # swap 0/1
                     remainder_was_used = True
-                    tokens = tokens[: i + 1] + self.lex_word(
-                        word[word.index(t.value) + len(t.value) :]
-                    )
+                    already_matched = tokens[: i + 1]
+                    input_for_next_recursion = word[word.index(t.value) + len(t.value) :]
+                    recursion_output = self.lex_word(input_for_next_recursion)
+                    tokens = already_matched + list(recursion_output)
                     break
+            if remainder_was_used:
+                break
 
         if remainder and not remainder_was_used:
             raise LexError("Invalid character", word, word.index(remainder))

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -7,6 +7,7 @@ import itertools
 import re
 import shlex
 import sys
+from textwrap import dedent
 
 from six import string_types
 
@@ -41,46 +42,43 @@ class Token(object):
 class Lexer(object):
     """Base class for Lexers that keep track of line numbers."""
 
-    __slots__ = "scanner0", "scanner1", "mode", "mode_switches_01", "mode_switches_10"
+    __slots__ = "scanners", "mode", "switchbook"
 
-    def __init__(self, lexicon0, mode_switches_01=[], lexicon1=[], mode_switches_10=[]):
-        self.scanner0 = re.Scanner(lexicon0)
-        self.mode_switches_01 = mode_switches_01
-        self.scanner1 = re.Scanner(lexicon1)
-        self.mode_switches_10 = mode_switches_10
+    def __init__(self, lexicon_and_mode_switches):
+        self.scanners = []
+        self.switchbook = []
+        for lexicon, mode_switches_dict in lexicon_and_mode_switches:
+            self.scanners.append(re.Scanner(lexicon))
+            self.switchbook.append(mode_switches_dict)
+
         self.mode = 0
 
-    def token(self, type, value=""):
-        if self.mode == 0:
-            return Token(type, value, self.scanner0.match.start(0), self.scanner0.match.end(0))
-        else:
-            return Token(type, value, self.scanner1.match.start(0), self.scanner1.match.end(0))
+    def token(self, type, value=''):
+        cur_scanner = self.scanners[self.mode]
+        return Token(type, value,
+                     cur_scanner.match.start(0),
+                     cur_scanner.match.end(0))
 
     def lex_word(self, word):
-        scanner = self.scanner0
-        mode_switches = self.mode_switches_01
-        if self.mode == 1:
-            scanner = self.scanner1
-            mode_switches = self.mode_switches_10
+        scanner = self.scanners[self.mode]
+        mode_switches_dict = self.switchbook[self.mode]
 
         tokens, remainder = scanner.scan(word)
-        remainder_used = 0
+        remainder_was_used = False
 
         for i, t in enumerate(tokens):
-            if t.type in mode_switches:
-                # Combine post-switch tokens with remainder and
-                # scan in other mode
-                self.mode = 1 - self.mode  # swap 0/1
-                remainder_used = 1
-                tokens = tokens[: i + 1] + self.lex_word(
-                    word[word.index(t.value) + len(t.value) :]
-                )
-                break
+            for other_mode, mode_switches in mode_switches_dict.items():
+                if t.type in mode_switches:
+                    # Combine post-switch tokens with remainder and
+                    # scan in other mode
+                    self.mode = other_mode  # swap 0/1
+                    remainder_was_used = True
+                    tokens = tokens[:i + 1] + self.lex_word(
+                        word[word.index(t.value) + len(t.value):])
+                    break
 
-        if remainder and not remainder_used:
-            msg = "Invalid character, '{0}',".format(remainder[0])
-            msg += " in '{0}' at index {1}".format(word, word.index(remainder))
-            raise LexError(msg, word, word.index(remainder))
+        if remainder and not remainder_was_used:
+            raise LexError("Invalid character", word, word.index(remainder))
 
         return tokens
 
@@ -161,7 +159,7 @@ class Parser(object):
 
 
 class ParseError(spack.error.SpackError):
-    """Raised when we don't hit an error while parsing."""
+    """Raised when we hit an error while parsing."""
 
     def __init__(self, message, string, pos):
         super(ParseError, self).__init__(message)
@@ -173,4 +171,11 @@ class LexError(ParseError):
     """Raised when we don't know how to lex something."""
 
     def __init__(self, message, string, pos):
-        super(LexError, self).__init__(message, string, pos)
+        bad_char = string[pos]
+        printed = dedent("""\
+        {0}: '{1}'
+        -------
+        {2}
+        {3}^
+        """).format(message, bad_char, string, pos * ' ')
+        super(LexError, self).__init__(printed, string, pos)

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -9,7 +9,7 @@ import re
 import shlex
 import sys
 from textwrap import dedent
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Tuple
 
 import six
 
@@ -22,7 +22,7 @@ class Token(object):
 
     __slots__ = "type", "value", "start", "end"
 
-    def __init__(self, type, value='', start=0, end=0):
+    def __init__(self, type, value="", start=0, end=0):
         # type: (Any, str, int, int) -> None
         self.type = type
         self.value = value
@@ -43,7 +43,7 @@ class Token(object):
         return (self.type == other.type) and (self.value == other.value)
 
 
-_Lexicon = List['Tuple[str, Any]']
+_Lexicon = List["Tuple[str, Any]"]
 _Switches = Dict[str, List]
 
 
@@ -54,7 +54,7 @@ class Lexer(object):
 
     def __init__(self, lexicon_and_mode_switches):
         # type: (List[Tuple[str, _Lexicon, _Switches]]) -> None
-        self.scanners = {}    # type: Dict[str, re.Scanner] # type: ignore[name-defined]
+        self.scanners = {}  # type: Dict[str, re.Scanner] # type: ignore[name-defined]
         self.switchbook = {}  # type: Dict[str, _Switches]
         self.mode = lexicon_and_mode_switches[0][0]
         for mode_name, lexicon, mode_switches_dict in lexicon_and_mode_switches:
@@ -69,12 +69,10 @@ class Lexer(object):
             self.scanners[mode_name] = re.Scanner(transformed_lexicon)  # type: ignore[attr-defined] # noqa: E501
             self.switchbook[mode_name] = mode_switches_dict
 
-    def token(self, type, value=''):
+    def token(self, type, value=""):
         # type: (Any, str) -> Token
         cur_scanner = self.scanners[self.mode]
-        return Token(type, value,
-                     cur_scanner.match.start(0),
-                     cur_scanner.match.end(0))
+        return Token(type, value, cur_scanner.match.start(0), cur_scanner.match.end(0))
 
     def _transform_token_callback(self, tok):
         if tok is None:
@@ -97,8 +95,9 @@ class Lexer(object):
                     # scan in other mode
                     self.mode = other_mode  # swap 0/1
                     remainder_was_used = True
-                    tokens = tokens[:i + 1] + self.lex_word(
-                        word[word.index(t.value) + len(t.value):])
+                    tokens = tokens[: i + 1] + self.lex_word(
+                        word[word.index(t.value) + len(t.value) :]
+                    )
                     break
 
         if remainder and not remainder_was_used:
@@ -204,10 +203,12 @@ class LexError(ParseError):
 
     def __init__(self, message, string, pos):
         bad_char = string[pos]
-        printed = dedent("""\
+        printed = dedent(
+            """\
         {0}: '{1}'
         -------
         {2}
         {3}^
-        """).format(message, bad_char, string, pos * ' ')
+        """
+        ).format(message, bad_char, string, pos * " ")
         super(LexError, self).__init__(printed, string, pos)

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -44,7 +44,7 @@ class Token(object):
 
 
 _Lexicon = List["Tuple[str, Any]"]
-_Switches = Dict[str, List]
+_Switches = "Dict[str, List[Any]]"
 
 
 class Lexer(object):

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5004,45 +5004,57 @@ class SpecLexer(spack.parse.Lexer):
 
     """Parses tokens that make up spack specs."""
 
+    # TODO: Determine whether using >2 lexer modes would allow us to create
+    # a separate entry (likely defined the same as `spec_id_re` at first) to
+    # specifically match version strings, variant names, compiler dependency
+    # names (with '%').
     def __init__(self):
         # Spec strings require posix-style paths on Windows
         # because the result is later passed to shlex
-        filename_reg = (
-            r"[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*"
-            if not is_windows
-            else r"([A-Za-z]:)*?[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*"
-        )
-        super(SpecLexer, self).__init__(
-            [
-                (
-                    r"\@([\w.\-]*\s*)*(\s*\=\s*\w[\w.\-]*)?",
-                    lambda scanner, val: self.token(VER, val),
-                ),
-                (r"\:", lambda scanner, val: self.token(COLON, val)),
-                (r"\,", lambda scanner, val: self.token(COMMA, val)),
-                (r"\^", lambda scanner, val: self.token(DEP, val)),
-                (r"\+", lambda scanner, val: self.token(ON, val)),
-                (r"\-", lambda scanner, val: self.token(OFF, val)),
-                (r"\~", lambda scanner, val: self.token(OFF, val)),
-                (r"\%", lambda scanner, val: self.token(PCT, val)),
-                (r"\=", lambda scanner, val: self.token(EQ, val)),
+        filename_reg = r'[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*' if not is_windows\
+            else r'([A-Za-z]:)*?[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*'
+        super(SpecLexer, self).__init__([
+            ([
+                # '^': dependency, or "AND":
+                (r'\^', lambda scanner, val: self.token(DEP,   val)),
+                # '@': begin a Version, VersionRange, or VersionList:
+                (r'\@', lambda scanner, val: self.token(AT,    val)),
+                # VersionRange syntax:
+                (r'\:', lambda scanner, val: self.token(COLON, val)),
+                # VersionList syntax:
+                (r'\,', lambda scanner, val: self.token(COMMA, val)),
+                # variant syntax:
+                (r'\+', lambda scanner, val: self.token(ON,    val)),
+                (r'\-', lambda scanner, val: self.token(OFF,   val)),
+                (r'\~', lambda scanner, val: self.token(OFF,   val)),
+                # Compiler dependency syntax:
+                (r'\%', lambda scanner, val: self.token(PCT,   val)),
+
+            # Filenames match before identifiers, so no initial filename
+            # component is parsed as a spec (e.g., in subdir/spec.yaml/json)
+            (filename_reg,
+             lambda scanner, v: self.token(FILE, v)),
+                # This is *not* used in version string parsing.
+                (r'\=', lambda scanner, val: self.token(EQ,    val)),
+
                 # Filenames match before identifiers, so no initial filename
-                # component is parsed as a spec (e.g., in subdir/spec.yaml/json)
-                (filename_reg, lambda scanner, v: self.token(FILE, v)),
+                # component is parsed as a spec (e.g., in subdir/spec.{yaml/json})
+                (r'[/\w.-]*/[/\w/-]+\.yaml[^\b]*',
+                 lambda scanner, v: self.token(FILE, v)),
+
                 # Hash match after filename. No valid filename can be a hash
                 # (files end w/.yaml), but a hash can match a filename prefix.
-                (r"/", lambda scanner, val: self.token(HASH, val)),
+                (r'/', lambda scanner, val: self.token(HASH, val)),
+
                 # Identifiers match after filenames and hashes.
                 (spec_id_re, lambda scanner, val: self.token(ID, val)),
-                (r"\s+", lambda scanner, val: None),
-            ],
-            [EQ],
-            [
-                (r"[\S].*", lambda scanner, val: self.token(VAL, val)),
-                (r"\s+", lambda scanner, val: None),
-            ],
-            [VAL],
-        )
+
+                # Gobble up all remaining whitespace between tokens.
+                (r'\s+', lambda scanner, val: None),
+            ], {1: [EQ]}),
+            ([(r'[\S].*', lambda scanner, val: self.token(VAL,    val)),
+              (r'\s+', lambda scanner, val: None)],
+             {0: [VAL]})])
 
 
 # Lexer is always the same for every parser.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5013,48 +5013,53 @@ class SpecLexer(spack.parse.Lexer):
         # because the result is later passed to shlex
         filename_reg = r'[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*' if not is_windows\
             else r'([A-Za-z]:)*?[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*'
-        super(SpecLexer, self).__init__([
-            ([
-                # '^': dependency, or "AND":
-                (r'\^', lambda scanner, val: self.token(DEP,   val)),
-                # '@': begin a Version, VersionRange, or VersionList:
-                (r'\@', lambda scanner, val: self.token(AT,    val)),
-                # VersionRange syntax:
-                (r'\:', lambda scanner, val: self.token(COLON, val)),
-                # VersionList syntax:
-                (r'\,', lambda scanner, val: self.token(COMMA, val)),
-                # variant syntax:
-                (r'\+', lambda scanner, val: self.token(ON,    val)),
-                (r'\-', lambda scanner, val: self.token(OFF,   val)),
-                (r'\~', lambda scanner, val: self.token(OFF,   val)),
-                # Compiler dependency syntax:
-                (r'\%', lambda scanner, val: self.token(PCT,   val)),
-
-            # Filenames match before identifiers, so no initial filename
-            # component is parsed as a spec (e.g., in subdir/spec.yaml/json)
-            (filename_reg,
-             lambda scanner, v: self.token(FILE, v)),
-                # This is *not* used in version string parsing.
-                (r'\=', lambda scanner, val: self.token(EQ,    val)),
-
-                # Filenames match before identifiers, so no initial filename
-                # component is parsed as a spec (e.g., in subdir/spec.{yaml/json})
-                (r'[/\w.-]*/[/\w/-]+\.yaml[^\b]*',
-                 lambda scanner, v: self.token(FILE, v)),
-
-                # Hash match after filename. No valid filename can be a hash
-                # (files end w/.yaml), but a hash can match a filename prefix.
-                (r'/', lambda scanner, val: self.token(HASH, val)),
-
-                # Identifiers match after filenames and hashes.
-                (spec_id_re, lambda scanner, val: self.token(ID, val)),
-
-                # Gobble up all remaining whitespace between tokens.
-                (r'\s+', lambda scanner, val: None),
-            ], {1: [EQ]}),
-            ([(r'[\S].*', lambda scanner, val: self.token(VAL,    val)),
-              (r'\s+', lambda scanner, val: None)],
-             {0: [VAL]})])
+        super(SpecLexer, self).__init__(
+            [
+                (
+                    "BEGIN_PHASE",
+                    [
+                        # '^': dependency, or "AND":
+                        (r"\^", lambda scanner, val: self.token(DEP, val)),
+                        # '@': begin a Version, VersionRange, or VersionList:
+                        (r"\@", lambda scanner, val: self.token(AT, val)),
+                        # VersionRange syntax:
+                        (r"\:", lambda scanner, val: self.token(COLON, val)),
+                        # VersionList syntax:
+                        (r"\,", lambda scanner, val: self.token(COMMA, val)),
+                        # variant syntax:
+                        (r"\+", lambda scanner, val: self.token(ON, val)),
+                        (r"\-", lambda scanner, val: self.token(OFF, val)),
+                        (r"\~", lambda scanner, val: self.token(OFF, val)),
+                        # Compiler dependency syntax:
+                        (r"\%", lambda scanner, val: self.token(PCT, val)),
+                        # This is *not* used in version string parsing.
+                        (r"\=", lambda scanner, val: self.token(EQ, val)),
+                        # Filenames match before identifiers, so no initial filename
+                        # component is parsed as a spec (e.g., in subdir/spec.yaml)
+                        (
+                            filename_reg,
+                            lambda scanner, v: self.token(FILE, v),
+                        ),
+                        # Hash match after filename. No valid filename can be a hash
+                        # (files end w/.yaml), but a hash can match a filename prefix.
+                        (r"/", lambda scanner, val: self.token(HASH, val)),
+                        # Identifiers match after filenames and hashes.
+                        (spec_id_re, lambda scanner, val: self.token(ID, val)),
+                        # Gobble up all remaining whitespace between tokens.
+                        (r"\s+", lambda scanner, val: None),
+                    ],
+                    {"EQUALS_PHASE": [EQ]},
+                ),
+                (
+                    "EQUALS_PHASE",
+                    [
+                        (r"[\S].*", lambda scanner, val: self.token(VAL, val)),
+                        (r"\s+", lambda scanner, val: None),
+                    ],
+                    {"BEGIN_PHASE": [VAL]},
+                ),
+            ]
+        )
 
 
 # Lexer is always the same for every parser.

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5000,14 +5000,15 @@ HASH, DEP, VER, COLON, COMMA, ON, OFF, PCT, EQ, ID, VAL, FILE = range(12)
 spec_id_re = r"\w[\w.-]*"
 
 
-_filename_re_base = r'[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*'
-_windows_filename_prefix = r'([A-Za-z]:)*?'
+_filename_re_base = r"[/\w.-]*/[/\w/-]+\.(yaml|json)[^\b]*"
+_windows_filename_prefix = r"([A-Za-z]:)*?"
 # Spec strings require posix-style paths on Windows
 # because the result is later passed to shlex.
-_windows_filename_re = f"{_windows_filename_prefix}{_filename_re_base}"
+_windows_filename_re = _windows_filename_prefix + _filename_re_base
 
 #: Regex for literal filenames.
 filename_reg = _windows_filename_re if is_windows else _filename_re_base
+
 
 class SpecLexer(spack.parse.Lexer):
 
@@ -5021,44 +5022,44 @@ class SpecLexer(spack.parse.Lexer):
         super(SpecLexer, self).__init__(
             [
                 (
-                    'BEGIN_PHASE',
+                    "BEGIN_PHASE",
                     [
-                        # '^': dependency, or "AND":
-                        (re.escape('^'), DEP),
                         # '@': begin a Version, VersionRange, or VersionList:
-                        (re.escape('@'), AT),
+                        (r"@([\w.\-]*\s*)*(\s*\=\s*\w[\w.\-]*)?", VER),
                         # VersionRange syntax:
-                        (re.escape(':'), COLON),
+                        (re.escape(":"), COLON),
                         # VersionList syntax:
-                        (re.escape(','), COMMA),
+                        (re.escape(","), COMMA),
+                        # '^': dependency, or "AND":
+                        (re.escape("^"), DEP),
                         # variant syntax:
-                        (re.escape('+'), ON),
-                        (re.escape('-'), OFF),
-                        (re.escape('~'), OFF),
+                        (re.escape("+"), ON),
+                        (re.escape("-"), OFF),
+                        (re.escape("~"), OFF),
                         # Compiler dependency syntax:
-                        (re.escape('%'), PCT),
+                        (re.escape("%"), PCT),
                         # This is *not* used in version string parsing.
-                        (re.escape('='), EQ),
+                        (re.escape("="), EQ),
                         # Filenames match before identifiers, so no initial filename
                         # component is parsed as a spec (e.g., in subdir/spec.yaml)
                         (filename_reg, FILE),
                         # Hash match after filename. No valid filename can be a hash
                         # (files end w/.yaml), but a hash can match a filename prefix.
-                        (re.escape('/'), HASH),
+                        (re.escape("/"), HASH),
                         # Identifiers match after filenames and hashes.
                         (spec_id_re, ID),
                         # Gobble up all remaining whitespace between tokens.
-                        (r'\s+', None),
+                        (r"\s+", None),
                     ],
-                    {'EQUALS_PHASE': [EQ]},
+                    {"EQUALS_PHASE": [EQ]},
                 ),
                 (
-                    'EQUALS_PHASE',
+                    "EQUALS_PHASE",
                     [
-                        (r'[\S].*', VAL),
-                        (r'\s+', None),
+                        (r"[\S].*", VAL),
+                        (r"\s+", None),
                     ],
-                    {'BEGIN_PHASE': [VAL]},
+                    {"BEGIN_PHASE": [VAL]},
                 ),
             ]
         )

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5019,42 +5019,39 @@ class SpecLexer(spack.parse.Lexer):
                     "BEGIN_PHASE",
                     [
                         # '^': dependency, or "AND":
-                        (r"\^", lambda scanner, val: self.token(DEP, val)),
+                        (r"\^", DEP),
                         # '@': begin a Version, VersionRange, or VersionList:
-                        (r"\@", lambda scanner, val: self.token(AT, val)),
+                        (r"\@", AT),
                         # VersionRange syntax:
-                        (r"\:", lambda scanner, val: self.token(COLON, val)),
+                        (r"\:", COLON),
                         # VersionList syntax:
-                        (r"\,", lambda scanner, val: self.token(COMMA, val)),
+                        (r"\,", COMMA),
                         # variant syntax:
-                        (r"\+", lambda scanner, val: self.token(ON, val)),
-                        (r"\-", lambda scanner, val: self.token(OFF, val)),
-                        (r"\~", lambda scanner, val: self.token(OFF, val)),
+                        (r"\+", ON),
+                        (r"\-", OFF),
+                        (r"\~", OFF),
                         # Compiler dependency syntax:
-                        (r"\%", lambda scanner, val: self.token(PCT, val)),
+                        (r"\%", PCT),
                         # This is *not* used in version string parsing.
-                        (r"\=", lambda scanner, val: self.token(EQ, val)),
+                        (r"\=", EQ),
                         # Filenames match before identifiers, so no initial filename
                         # component is parsed as a spec (e.g., in subdir/spec.yaml)
-                        (
-                            filename_reg,
-                            lambda scanner, v: self.token(FILE, v),
-                        ),
+                        (filename_reg, FILE),
                         # Hash match after filename. No valid filename can be a hash
                         # (files end w/.yaml), but a hash can match a filename prefix.
-                        (r"/", lambda scanner, val: self.token(HASH, val)),
+                        (r"/", HASH),
                         # Identifiers match after filenames and hashes.
-                        (spec_id_re, lambda scanner, val: self.token(ID, val)),
+                        (spec_id_re, ID),
                         # Gobble up all remaining whitespace between tokens.
-                        (r"\s+", lambda scanner, val: None),
+                        (r"\s+", None),
                     ],
                     {"EQUALS_PHASE": [EQ]},
                 ),
                 (
                     "EQUALS_PHASE",
                     [
-                        (r"[\S].*", lambda scanner, val: self.token(VAL, val)),
-                        (r"\s+", lambda scanner, val: None),
+                        (r"[\S].*", VAL),
+                        (r"\s+", None),
                     ],
                     {"BEGIN_PHASE": [VAL]},
                 ),

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4995,6 +4995,7 @@ class LazySpecCache(collections.defaultdict):
 
 #: These are possible token types in the spec grammar.
 HASH, DEP, VER, COLON, COMMA, ON, OFF, PCT, EQ, ID, VAL, FILE = range(12)
+#  0,   1,   2,     3,     4,  5,   6,   7,  8,  9,  10,   11
 
 #: Regex for fully qualified spec names. (e.g., builtin.hdf5)
 spec_id_re = r"\w[\w.-]*"

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -151,7 +151,7 @@ class TestSpecSyntax(object):
     def check_lex(self, tokens, spec):
         """Check that the provided spec parses to the provided token list."""
         spec = shlex.split(str(spec))
-        lex_output = sp.SpecLexer().lex(spec)
+        lex_output = list(sp.SpecLexer().lex(spec))
         assert len(tokens) == len(lex_output), "unexpected number of tokens"
         for tok, spec_tok in zip(tokens, lex_output):
             if tok.type in (sp.ID, sp.VAL, sp.VER):


### PR DESCRIPTION
### Problem
The `SpecLexer` works fine, but is a little hard to extend, which we may wish to do when expanding the spec syntax as in #24025.

### Solution
- Rewrite the `Lexer` interface to allow navigation between multiple lexer modes by name.
- Also avoid the need to manually write out `lambda scanner, val: ...` in subclasses of `Lexer` for a more declarative interface.

### Result
The spec lexing code should be a little easier to follow. The path to extend the spec syntax as proposed in https://github.com/spack/spack/discussions/20256#discussioncomment-248931 should also be more clear now.