### PR TITLE
[WIP] parsing variant value assignments across dependencies in specs

### DIFF
--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -8,6 +8,7 @@ import re
 import shlex
 import sys
 from textwrap import dedent
+from typing import Callable, Dict, List, Tuple
 
 from six import string_types
 
@@ -36,17 +37,21 @@ class Token(object):
         return (self.type == other.type) and (self.value == other.value)
 
 
+_Lexicon = List['Tuple[str, Callable]']
+_Switches = Dict[str, List]
+
+
 class Lexer(object):
     """Base class for Lexers that keep track of line numbers."""
 
     def __init__(self, lexicon_and_mode_switches):
-        self.scanners = []
-        self.switchbook = []
-        for lexicon, mode_switches_dict in lexicon_and_mode_switches:
-            self.scanners.append(re.Scanner(lexicon))
-            self.switchbook.append(mode_switches_dict)
-
-        self.mode = 0
+        # type: (List[Tuple[str, _Lexicon, _Switches]]) -> None
+        self.scanners = {}      # type: Dict[str, _Lexicon]
+        self.switchbook = {}    # type: Dict[str, _Switches]
+        self.mode = lexicon_and_mode_switches[0][0]
+        for mode_name, lexicon, mode_switches_dict in lexicon_and_mode_switches:
+            self.scanners[mode_name] = re.Scanner(lexicon)  # type: ignore[attr-defined]
+            self.switchbook[mode_name] = mode_switches_dict
 
     def token(self, type, value=''):
         cur_scanner = self.scanners[self.mode]

--- a/lib/spack/spack/parse.py
+++ b/lib/spack/spack/parse.py
@@ -14,6 +14,14 @@ from six import string_types
 
 import spack.error
 
+_whitespace = re.compile("^\s+$")
+_quoted = re.compile("^['\"]$")
+
+
+def _should_ignore_token(value):
+    # type: (str) -> bool
+    return bool(_whitespace.match(value) or _quoted.match(value))
+
 
 class Token(object):
     """Represents tokens; generated from input by lexer and fed to parse()."""
@@ -144,10 +152,10 @@ class Parser(object):
             sys.exit(1)
 
     def setup(self, text):
-        if isinstance(text, string_types):
-            text = shlex.split(str(text))
-        self.text = text
-        self.push_tokens(self.lexer.lex(text))
+        print('input to parser: {0}'.format(text), file=sys.stderr)
+        self.text = [text]
+        print('output of lexer: {0}'.format(self.lexer.lex([text])), file=sys.stderr)
+        self.push_tokens(self.lexer.lex([text]))
 
     def parse(self, text):
         self.setup(text)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -4620,44 +4620,53 @@ class SpecLexer(spack.parse.Lexer):
     # specifically match version strings, variant names, compiler dependency
     # names (with '%').
     def __init__(self):
-        super(SpecLexer, self).__init__([
-            ([
-                # '^': dependency, or "AND":
-                (r'\^', lambda scanner, val: self.token(DEP,   val)),
-                # '@': begin a Version, VersionRange, or VersionList:
-                (r'\@', lambda scanner, val: self.token(AT,    val)),
-                # VersionRange syntax:
-                (r'\:', lambda scanner, val: self.token(COLON, val)),
-                # VersionList syntax:
-                (r'\,', lambda scanner, val: self.token(COMMA, val)),
-                # variant syntax:
-                (r'\+', lambda scanner, val: self.token(ON,    val)),
-                (r'\-', lambda scanner, val: self.token(OFF,   val)),
-                (r'\~', lambda scanner, val: self.token(OFF,   val)),
-                # Compiler dependency syntax:
-                (r'\%', lambda scanner, val: self.token(PCT,   val)),
-
-                # This is *not* used in version string parsing.
-                (r'\=', lambda scanner, val: self.token(EQ,    val)),
-
-                # Filenames match before identifiers, so no initial filename
-                # component is parsed as a spec (e.g., in subdir/spec.{yaml/json})
-                (r'[/\w.-]*/[/\w/-]+\.yaml[^\b]*',
-                 lambda scanner, v: self.token(FILE, v)),
-
-                # Hash match after filename. No valid filename can be a hash
-                # (files end w/.yaml), but a hash can match a filename prefix.
-                (r'/', lambda scanner, val: self.token(HASH, val)),
-
-                # Identifiers match after filenames and hashes.
-                (spec_id_re, lambda scanner, val: self.token(ID, val)),
-
-                # Gobble up all remaining whitespace between tokens.
-                (r'\s+', lambda scanner, val: None),
-            ], {1: [EQ]}),
-            ([(r'[\S].*', lambda scanner, val: self.token(VAL,    val)),
-              (r'\s+', lambda scanner, val: None)],
-             {0: [VAL]})])
+        super(SpecLexer, self).__init__(
+            [
+                (
+                    "BEGIN_PHASE",
+                    [
+                        # '^': dependency, or "AND":
+                        (r"\^", lambda scanner, val: self.token(DEP, val)),
+                        # '@': begin a Version, VersionRange, or VersionList:
+                        (r"\@", lambda scanner, val: self.token(AT, val)),
+                        # VersionRange syntax:
+                        (r"\:", lambda scanner, val: self.token(COLON, val)),
+                        # VersionList syntax:
+                        (r"\,", lambda scanner, val: self.token(COMMA, val)),
+                        # variant syntax:
+                        (r"\+", lambda scanner, val: self.token(ON, val)),
+                        (r"\-", lambda scanner, val: self.token(OFF, val)),
+                        (r"\~", lambda scanner, val: self.token(OFF, val)),
+                        # Compiler dependency syntax:
+                        (r"\%", lambda scanner, val: self.token(PCT, val)),
+                        # This is *not* used in version string parsing.
+                        (r"\=", lambda scanner, val: self.token(EQ, val)),
+                        # Filenames match before identifiers, so no initial filename
+                        # component is parsed as a spec (e.g., in subdir/spec.yaml)
+                        (
+                            r"[/\w.-]*/[/\w/-]+\.yaml[^\b]*",
+                            lambda scanner, v: self.token(FILE, v),
+                        ),
+                        # Hash match after filename. No valid filename can be a hash
+                        # (files end w/.yaml), but a hash can match a filename prefix.
+                        (r"/", lambda scanner, val: self.token(HASH, val)),
+                        # Identifiers match after filenames and hashes.
+                        (spec_id_re, lambda scanner, val: self.token(ID, val)),
+                        # Gobble up all remaining whitespace between tokens.
+                        (r"\s+", lambda scanner, val: None),
+                    ],
+                    {"EQUALS_PHASE": [EQ]},
+                ),
+                (
+                    "EQUALS_PHASE",
+                    [
+                        (r"[\S].*", lambda scanner, val: self.token(VAL, val)),
+                        (r'\s+', lambda scanner, val: None),
+                    ],
+                    {"BEGIN_PHASE": [VAL]},
+                ),
+            ]
+        )
 
 
 # Lexer is always the same for every parser.

--- a/lib/spack/spack/test/spec_syntax.py
+++ b/lib/spack/spack/test/spec_syntax.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import itertools
 import os
+import re
 import shlex
 
 import pytest
@@ -108,12 +109,19 @@ class TestSpecSyntax(object):
         output = sp.parse(spec)
 
         parsed = (" ".join(str(spec) for spec in output))
-        assert expected == parsed
+        # assert expected == parsed
+        assert re.sub(' +', '', expected) == re.sub(' +', '', parsed)
+
+    _tokens_to_ignore = frozenset([sp.WS, sp.Q1, sp.Q2])
 
     def check_lex(self, tokens, spec):
         """Check that the provided spec parses to the provided token list."""
         spec = shlex.split(str(spec))
-        lex_output = sp.SpecLexer().lex(spec)
+        lex_output = [
+            tok
+            for tok in sp.SpecLexer().lex(spec)
+            if tok.type not in self._tokens_to_ignore
+        ]
         assert len(tokens) == len(lex_output), "unexpected number of tokens"
         for tok, spec_tok in zip(tokens, lex_output):
             if tok.type == sp.ID or tok.type == sp.VAL:


### PR DESCRIPTION
**WIP; doesn't work yet**

### Problem

It is currently not possible to specify multiple variant values across multiple packages within a single spec. For example:
```bash 
$ spack spec 'emacs toolkit=gtk ^ gtkplus cflags=-Wno-error'
==> Error: invalid values for variant "toolkit" in package "emacs": ['gtk ^ gtkplus cflags=-Wno-error']
```

In this case, instead of identifying `toolkit=gtk` and moving on to parse `gtkplus` as a dependency with `^`, the spec parsing results in `toolkit=gtk ^ gtkplus cflags=-Wno-error`.

### Solution
- [x] Pull in #29093.
- [ ] **TODO:** Attempt to fix the parsing bug.

### Result
**TODO:** the following command succeeds
```bash
$ spack spec 'emacs toolkit=gtk ^ gtkplus cflags=-Wno-error'
...
```