### PR TITLE
AOCC patches for WRF 3.9 and 4.2

### DIFF
--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -111,7 +111,7 @@ class Wrf(Package):
     patch("patches/3.9/add_aarch64.patch", when="@3.9.1.1")
     patch("patches/3.9/configure_aocc_2.3.patch", when="@3.9.1.1 %aocc@:2.4.0")
     patch("patches/3.9/configure_aocc_3.0.patch", when="@3.9.1.1 %aocc@3.0.0")
-    patch("patches/3.9/configure_aocc_3.1.patch", when="@3.9.1.1 %aocc@3.1.0")
+    patch("patches/3.9/configure_aocc_3.1.patch", when="@3.9.1.1 %aocc@3.1.0:3.3.0")
     patch("patches/3.9/fujitsu.patch", when="@3.9.1.1 %fj")
 
     # These patches deal with netcdf & netcdf-fortran being two diff things
@@ -138,7 +138,9 @@ class Wrf(Package):
     patch("patches/4.2/tirpc_detect.patch", when="@4.2")
     patch("patches/4.2/add_aarch64.patch", when="@4.2:")
     patch("patches/4.2/configure_aocc_2.3.patch", when="@4.2 %aocc@:2.4.0")
-    patch("patches/4.2/configure_aocc_3.0.patch", when="@4.2 %aocc@3.0.0:3.2.0")
+    patch("patches/4.2/configure_aocc_3.0.patch", when="@4.2 %aocc@3.0.0")
+    patch("patches/4.2/configure_aocc_3.1.patch", when="@4.2 %aocc@3.1.0")
+    patch("patches/4.2/configure_aocc_3.2.patch", when="@4.2 %aocc@3.2.0")
     patch("patches/4.2/hdf5_fix.patch", when="@4.2 %aocc")
     patch("patches/4.2/derf_fix.patch", when="@4.2 %aocc")
     # Various syntax fixes found by FPT tool

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_2.3.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_2.3.patch
@@ -1,10 +1,10 @@
---- WRF-3.9.1.1/arch/configure_new.defaults	2021-03-10 10:08:07.885236847 +0530
-+++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-04-12 13:24:05.880139431 +0530
-@@ -1917,6 +1917,50 @@
+--- WRF-3.9.1.1/arch/configure_new.defaults	2017-08-29 01:59:47.000000000 +0530
++++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-12-10 11:52:04.703569774 +0530
+@@ -1917,6 +1917,51 @@
  CC_TOOLS        =      $(SCC) 
  
  #insert new stanza here
-+#############################################################
++##############################################################
 +#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
 +#
 +DESCRIPTION     =       AMD AOCC ($SFC/$SCC): EPYC
@@ -23,22 +23,22 @@
 +RWORDSIZE       =       $(NATIVE_RWORDSIZE)
 +PROMOTION       =
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
-+LIBMVEC         =       -mllvm -vector-library=LIBMVEC -Mstack_arrays
-+AOCCOPT         =       -O3 -m64 -Ofast -ffast-math
++LIBMVEC         =       -mllvm -vector-library=LIBMVEC
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math -Mstack_arrays
 +CFLAGS_LOCAL    =       -w $(AOCCOPT)
 +LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
 +CPLUSPLUSLIB    =
 +ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
-+FCOPTIM         =       $(AOCCOPT) -fopenmp
++FCOPTIM         =       $(AOCCOPT) $(OMP)
 +FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
-+FCNOOPT         =       -O0 -DFCNOOPT -fopenmp
++FCNOOPT         =       -O0 -DFCNOOPT $(OMP)
 +FCDEBUG         =       #-g
 +FORMAT_FIXED    =       -Mfixed
 +FORMAT_FREE     =       -Mfreeform
 +FCSUFFIX        =
 +BYTESWAPIO      =       -Mbyteswapio
-+FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) -fopenmp
-+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS -fopenmp
++FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) $(OMP)
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS $(OMP) $(AOCCOPT)
 +MODULE_SRCH_FLAG =
 +TRADFLAG        =       -traditional
 +CPP             =       /lib/cpp -P
@@ -48,6 +48,7 @@
 +RANLIB          =       llvm-ranlib
 +RLFLAGS         =
 +CC_TOOLS        =       $(SCC)
++
  
  ###########################################################
  #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_3.0.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_3.0.patch
@@ -1,10 +1,10 @@
---- WRF-3.9.1.1/arch/configure_new.defaults	2021-03-10 10:08:07.885236847 +0530
-+++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-03-13 18:30:42.191344515 +0530
-@@ -1917,6 +1917,50 @@
+--- WRF-3.9.1.1/arch/configure_new.defaults	2017-08-29 01:59:47.000000000 +0530
++++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-12-10 11:54:16.762574843 +0530
+@@ -1917,6 +1917,51 @@
  CC_TOOLS        =      $(SCC) 
  
  #insert new stanza here
-+#############################################################
++##############################################################
 +#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
 +#
 +DESCRIPTION     =       AMD AOCC ($SFC/$SCC): EPYC
@@ -23,22 +23,22 @@
 +RWORDSIZE       =       $(NATIVE_RWORDSIZE)
 +PROMOTION       =
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
-+LIBMVEC         =       -mllvm -vector-library=LIBMVEC-X86 -mllvm -enable-boscc -Mstack_arrays
-+AOCCOPT         =       -O3 -m64 -Ofast -ffast-math
++LIBMVEC         =       -fveclib=AMDLIBM -mllvm -enable-boscc
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math -Mstack_arrays
 +CFLAGS_LOCAL    =       -w $(AOCCOPT)
 +LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
 +CPLUSPLUSLIB    =
 +ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
-+FCOPTIM         =       $(AOCCOPT) -fopenmp
++FCOPTIM         =       $(AOCCOPT) $(OMP)
 +FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
-+FCNOOPT         =       -O0 -DFCNOOPT -fopenmp
++FCNOOPT         =       -O0 -DFCNOOPT $(OMP)
 +FCDEBUG         =       #-g
 +FORMAT_FIXED    =       -Mfixed
 +FORMAT_FREE     =       -Mfreeform
 +FCSUFFIX        =
 +BYTESWAPIO      =       -Mbyteswapio
-+FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) -fopenmp
-+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS -fopenmp
++FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) $(OMP)
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS $(OMP) $(AOCCOPT)
 +MODULE_SRCH_FLAG =
 +TRADFLAG        =       -traditional
 +CPP             =       /lib/cpp -P
@@ -48,6 +48,7 @@
 +RANLIB          =       llvm-ranlib
 +RLFLAGS         =
 +CC_TOOLS        =       $(SCC)
++
  
  ###########################################################
  #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_3.1.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/3.9/configure_aocc_3.1.patch
@@ -1,6 +1,6 @@
---- WRF-3.9.1.1/arch/configure_new.defaults	2021-03-10 10:08:07.885236847 +0530
-+++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-08-12 08:58:35.442165745 +0530
-@@ -1917,6 +1917,50 @@
+--- WRF-3.9.1.1/arch/configure_new.defaults	2017-08-29 01:59:47.000000000 +0530
++++ WRF-3.9.1.1/arch/configure_new_aocc.defaults	2021-12-10 11:55:17.933577191 +0530
+@@ -1917,6 +1917,51 @@
  CC_TOOLS        =      $(SCC) 
  
  #insert new stanza here
@@ -23,22 +23,22 @@
 +RWORDSIZE       =       $(NATIVE_RWORDSIZE)
 +PROMOTION       =
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
-+LIBMVEC         =       -mllvm -vector-library=LIBMVEC-X86 -mllvm -enable-loop-vectorization-with-conditions -Mstack_arrays
-+AOCCOPT         =       -O3 -m64 -Ofast -ffast-math
++LIBMVEC         =       -fveclib=AMDLIBM -mllvm -enable-loop-vectorization-with-conditions
++AOCCOPT         =       -O3 -m64 -Ofast -ffast-math -Mstack_arrays
 +CFLAGS_LOCAL    =       -w $(AOCCOPT)
 +LDFLAGS_LOCAL   =       -lm -ltirpc -lamdlibm  -ljemalloc -lmvec $(AOCCOPT)
 +CPLUSPLUSLIB    =
 +ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
-+FCOPTIM         =       $(AOCCOPT) -fopenmp
++FCOPTIM         =       $(AOCCOPT) $(OMP)
 +FCREDUCEDOPT    =       -O2 -Ofast -ffast-math
-+FCNOOPT         =       -O0 -DFCNOOPT -fopenmp
++FCNOOPT         =       -O0 -DFCNOOPT $(OMP)
 +FCDEBUG         =       #-g
 +FORMAT_FIXED    =       -Mfixed
 +FORMAT_FREE     =       -Mfreeform
 +FCSUFFIX        =
 +BYTESWAPIO      =       -Mbyteswapio
-+FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) -fopenmp
-+FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS -fopenmp
++FCBASEOPTS_NO_G =       $(FORMAT_FREE) $(BYTESWAPIO) $(OMP)
++FCBASEOPTS      =       $(FCBASEOPTS_NO_G) $(FCDEBUG) -DBASEOPTS $(OMP) $(AOCCOPT)
 +MODULE_SRCH_FLAG =
 +TRADFLAG        =       -traditional
 +CPP             =       /lib/cpp -P
@@ -48,6 +48,7 @@
 +RANLIB          =       llvm-ranlib
 +RLFLAGS         =
 +CC_TOOLS        =       $(SCC)
++
  
  ###########################################################
  #ARCH    Fujitsu FX10/FX100 Linux x86_64 SPARC64IXfx/SPARC64Xlfx, mpifrtpx and mpifccpx compilers #serial smpar dmpar dm+sm

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/configure_aocc_3.1.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/configure_aocc_3.1.patch
@@ -1,10 +1,10 @@
 --- WRF-4.2/arch/configure.defaults	2020-04-23 22:38:37.000000000 +0530
-+++ WRF-4.2/arch/configure_aocc.defaults	2021-12-10 16:07:57.093159118 +0530
-@@ -1975,6 +1975,56 @@
++++ WRF-4.2/arch/configure_aocc.defaults	2021-12-10 17:14:17.584311920 +0530
+@@ -1975,6 +1975,57 @@
                       $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
  
  #insert new stanza here
-+##AOCC 3.0
++##AOCC 3.2
 +##############################################################
 +#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
 +#
@@ -25,9 +25,10 @@
 +PROMOTION       =
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
 +AOCCOPT         =       -mllvm -disable-loop-idiom-memset -mllvm -inline-threshold=3000 \
-+						-mllvm -inlinehint-threshold=10000 -mllvm -vectorize-noncontigous-memory-aggressively \
-+						-mllvm -vectorizer-maximize-bandwidth=true -mllvm -enable-boscc \
-+						-fveclib=AMDLIBM -finline-aggressive -finline-hint-functions -Mstack_arrays -Ofast
++                        -mllvm -inlinehint-threshold=10000 -mllvm -vectorize-noncontigous-memory-aggressively \
++                        -mllvm -vectorizer-maximize-bandwidth=true -mllvm -enable-loop-vectorization-with-conditions \
++                        -fveclib=AMDLIBM -finline-aggressive -finline-hint-functions -Mstack_arrays -Ofast
++CFLAGS_LOCAL    =       -w -c -m64 -Ofast -ffast-math
 +CFLAGS_LOCAL    =       -w -c -m64 -Ofast -ffast-math
 +LDFLAGS_LOCAL   =       -m64 -Wl,-mllvm -Wl,-vectorize-noncontigous-memory-aggressively \
 +                        -Ofast -Mstack_arrays -fveclib=AMDLIBM -lamdlibm -lm

--- a/var/spack/repos/builtin/packages/wrf/patches/4.2/configure_aocc_3.2.patch
+++ b/var/spack/repos/builtin/packages/wrf/patches/4.2/configure_aocc_3.2.patch
@@ -1,10 +1,10 @@
 --- WRF-4.2/arch/configure.defaults	2020-04-23 22:38:37.000000000 +0530
-+++ WRF-4.2/arch/configure_aocc.defaults	2021-12-10 16:07:57.093159118 +0530
-@@ -1975,6 +1975,56 @@
++++ WRF-4.2/arch/configure_aocc.defaults	2021-12-10 17:04:39.829289741 +0530
+@@ -1975,6 +1975,58 @@
                       $(WRF_SRC_ROOT_DIR)/frame/pack_utils.o
  
  #insert new stanza here
-+##AOCC 3.0
++##AOCC 3.2
 +##############################################################
 +#ARCH    AMD EPYC Linux x86_64 AOCC Compilers #dm+sm
 +#
@@ -25,15 +25,17 @@
 +PROMOTION       =
 +ARCH_LOCAL      =       -DNONSTANDARD_SYSTEM_SUBR -DWRF_USE_CLM
 +AOCCOPT         =       -mllvm -disable-loop-idiom-memset -mllvm -inline-threshold=3000 \
-+						-mllvm -inlinehint-threshold=10000 -mllvm -vectorize-noncontigous-memory-aggressively \
-+						-mllvm -vectorizer-maximize-bandwidth=true -mllvm -enable-boscc \
-+						-fveclib=AMDLIBM -finline-aggressive -finline-hint-functions -Mstack_arrays -Ofast
++                        -mllvm -inlinehint-threshold=10000 -mllvm -vectorize-noncontigous-memory-aggressively \
++                        -mllvm -vectorizer-maximize-bandwidth=true -mllvm -enable-loop-vectorization-with-conditions \
++                        -mllvm -enable-loop-distribute-adv -mllvm -enable-loop-reversal -mllvm -enable-gather \
++                        -mllvm -legalize-vector-library-calls -mllvm -adce-remove-omp-calls \
++                        -fveclib=AMDLIBM -finline-aggressive -finline-hint-functions -Mstack_arrays -Ofast
 +CFLAGS_LOCAL    =       -w -c -m64 -Ofast -ffast-math
 +LDFLAGS_LOCAL   =       -m64 -Wl,-mllvm -Wl,-vectorize-noncontigous-memory-aggressively \
 +                        -Ofast -Mstack_arrays -fveclib=AMDLIBM -lamdlibm -lm
 +CPLUSPLUSLIB    =
 +ESMF_LDFLAG     =       $(CPLUSPLUSLIB)
-+FCOPTIM         =       -Ofast -ftree-vectorize -funroll-loops -Mbyteswapio -ffast-math -finline-aggressive -finline-hint-functions -Mstack_arrays -Menable-vectorize-pragmas=true
++FCOPTIM         =       -Ofast -ftree-vectorize -funroll-loops -Mbyteswapio -ffast-math -finline-aggressive -finline-hint-functions -Mstack_arrays
 +FCREDUCEDOPT    =       -O3 -ffast-math -Mstack_arrays -DFCREDUCEDOPT
 +FCNOOPT         =       -O0 -ffast-math
 +FCDEBUG         =       #-g


### PR DESCRIPTION
- Updated few flags in `AOCC` patches for `WRF v.3.9.1.1`

- Added 2 new patches for `AOCC 3.1` and `3.2` for compiling `WRF v4.2`

Raised the same request earlier : https://github.com/spack/spack/pull/27952
 Re-initiating the pull request as there were intermediate merges after the pull request. 

We have also raised the pull request with WRF for AOCC support, once going forward we may not need to add new patches for WRF from AOCC side.

Ref link: https://github.com/wrf-model/WRF/pull/1684