### PR TITLE
py-numpy, py-scipy: add rgommers as a maintainer

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -20,7 +20,7 @@ class PyNumpy(PythonPackage):
     pypi = "numpy/numpy-1.19.4.zip"
     git      = "https://github.com/numpy/numpy.git"
 
-    maintainers = ['adamjstewart']
+    maintainers = ['adamjstewart', 'rgommers']
 
     version('main', branch='main')
     version('1.22.2', sha256='076aee5a3763d41da6bef9565fdf3cb987606f567cd8b104aded2b38b7b47abf')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -12,7 +12,7 @@ class PyScipy(PythonPackage):
     pypi = "scipy/scipy-1.5.4.tar.gz"
     git = "https://github.com/scipy/scipy.git"
 
-    maintainers = ['adamjstewart']
+    maintainers = ['adamjstewart', 'rgommers']
 
     version('master', branch='master')
     version('1.8.0',  sha256='31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd')


### PR DESCRIPTION
@rgommers: per our email chain, adding you as maintainer to the `py-scipy` and `py-numpy` packages.

If you had submitted this yourself, Spackbot (https://github.com/apps/spackbot-app) would've invited you to the maintainers team (https://github.com/orgs/spack/teams/maintainers), but I invited you myself.  If you accept the invitation it'll give you triage access to the repo, and we'll request you for review whenever there are changes to these packages.  `maintainers` don't have privileges to write to the repo or merge to `develop` -- we have a core group of people who can do that, but they can help the core folks with reviews.

If you decide not to accept the invite and this gets merged, Spackbot will just nag you in comments whenever changes to your packages are proposed.