### PR TITLE
concretizer: make `--reuse` the default behavior

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -14,4 +14,4 @@ concretizer:
   # concretizing specs. If `true`, we'll try to use as many installs/binaries
   # as possible, rather than building. If `false`, we'll always give you a fresh
   # concretization.
-  reuse: false
+  reuse: true

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -1,6 +1,9 @@
 spack:
   view: false
+
   concretization: separately
+  concretizer:
+    reuse: false
 
   config:
     install_tree:

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -1,6 +1,9 @@
 spack:
   view: false
+
   concretization: separately
+  concretizer:
+    reuse: false
 
   config:
     install_tree:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -1,6 +1,9 @@
 spack:
   view: false
+
   concretization: separately
+  concretizer:
+    reuse: false
 
   config:
     concretizer: clingo

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -1,6 +1,9 @@
 spack:
   view: false
+
   concretization: separately
+  concretizer:
+    reuse: false
 
   config:
     concretizer: clingo

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -1,5 +1,8 @@
 spack:
   concretization: separately
+  concretizer:
+    reuse: false
+
   view: false
 
   config:
@@ -20,7 +23,7 @@ spack:
   definitions:
     #- compilers: ['%gcc@8.3.1', '%clang@10.0.0']
     - compilers: ['%gcc@7.5.0']
-    
+
     # Note skipping spot since no spack package for it
     - radiuss:
       - ascent  # ^conduit@0.6.0

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -1,6 +1,9 @@
 spack:
   view: false
+
   concretization: separately
+  concretizer:
+    reuse: false
 
   config:
     install_tree:


### PR DESCRIPTION
To avoid repeated rebuilds in most cases, and to better enable users to use binaries out of the box, we want to switch to `--reuse` as the default concretization behavior.  This means that when users build, they'll build by default against a) things they already have installed and/or b) binary caches, where possible.

That's a good default CLI behavior, but there are places where we do not want `--reuse` to be the default -- namely CI.  CI should be ensuring that the *latest* configuration continues to work properly, regardless of any state in the local installation or binary caches.  I've changed the default for each of our CI environments here. I am debating whether `spack ci` should just inherit settings from some common base config scope with "good" settings for CI.  That is probably a future PR but it's worth thinking about.  All our CI environments currently override a few things -- disabling the view, not doing reuse concretization, etc.

This is draft for now, as we want to fix some outstanding bugs with `--reuse` first, and also merge #28504 at about the same time. See #24223 for more context.

- [x] change default concretization strategy to `reuse`
- [x] use `reuse: false` in all CI environments
- [ ] update documentation 
- [ ] ensure that serious bugs are fixed with reuse before this gets merged