### PR TITLE
enable globbing for spec architectures

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -77,6 +77,7 @@ specs to avoid ambiguity.  Both are provided because ~ can cause shell
 expansion when it is the first character in an id typed on the command line.
 """
 import collections
+import fnmatch
 import itertools
 import operator
 import os
@@ -378,11 +379,12 @@ class ArchSpec(object):
             other_attribute = getattr(other, attribute)
             self_attribute = getattr(self, attribute)
             if strict or self.concrete:
-                if other_attribute and self_attribute != other_attribute:
+                if other_attribute and \
+                   not fnmatch.fnmatch(self_attribute, other_attribute):
                     return False
             else:
                 if other_attribute and self_attribute and \
-                        self_attribute != other_attribute:
+                   not fnmatch.fnmatch(self_attribute, other_attribute):
                     return False
 
         # Check target
@@ -400,7 +402,8 @@ class ArchSpec(object):
         if self.target is None:
             return False
 
-        return bool(self.target_intersection(other))
+        return bool(self.target_intersection(other)) or \
+            fnmatch.fnmatch(str(self.target), str(other.target))
 
     def target_constrain(self, other):
         if not other.target_satisfies(self, strict=False):

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -918,6 +918,15 @@ class TestSpecSematics(object):
                 for x in ('cflags', 'cxxflags', 'fflags')
             )
 
+    @pytest.mark.parametrize('pattern,concrete', [
+        ('*-*-*', 'linux-alpine3-zen3'),
+        ('linux-alpine*-*', 'linux-alpine3-zen3'),
+        ('linux-alpine*-zen*', 'linux-alpine3-zen3'),
+    ])
+    def test_wildcard_architecture(self, pattern, concrete):
+        assert (Spec('arch={}'.format(concrete))
+                .satisfies(Spec('arch={}'.format(pattern))))
+
     def test_combination_of_wildcard_or_none(self):
         # Test that using 'none' and another value raises
         with pytest.raises(spack.variant.InvalidVariantValueCombinationError):


### PR DESCRIPTION
### Problem

It's impossible to match against anything other than an exact architecture in a `when` clause. This requires workarounds e.g. #29087. We would like to be able to e.g. match against any version of Alpine Linux, with something like `arch=linux-alpine*-*`.

### Solution
- Allow matching against `*` for any component of `ArchSpec`.
- Add testing.

### Result
The following works on my Alpine Linux installation:
```python
>>> from spack.spec import ArchSpec, Spec
>>> ArchSpec.default_arch()
ArchSpec(('linux', 'alpine3', 'zen3'))
>>> ArchSpec.default_arch().satisfies(Spec('arch=linux-alpine*-*').architecture)
True
```

For #29087, this would allow wrapping those `patch(...)` directives within a single `with when('arch=linux-alpine*-*'):` clause instead of having to implement them dynamically with `FilePatch::apply`.