### PR TITLE
Background process priority for build and test processes

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -137,6 +137,9 @@ config:
   # user's environment.
   build_language: C
 
+  # The build and test process priority, as unix nice (see man nice).
+  # A higher number means lower priority. Set to null to disable.
+  build_nice: 5
 
   # When set to true, concurrent instances of Spack will use locks to
   # avoid modifying the install tree, database file, etc. If false, Spack

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1110,7 +1110,12 @@ def _setup_pkg_and_run(
         os_nice = getattr(os, "nice", None)  # Not avail on Windows
         nice = spack.config.get("config:build_nice", None)
         if os_nice is not None and nice is not None:
-            os_nice(nice)
+            try:
+                os_nice(nice)
+            except Exception as e:
+                # Different machines can have different restrictions, so do no crash on invalid
+                # (non-permitted) nice level
+                tty.warn(f"Could not set build_nice to {nice}: {e}")
 
         if not kwargs.get("fake", False):
             kwargs["unmodified_env"] = os.environ.copy()

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1107,6 +1107,11 @@ def _setup_pkg_and_run(
 
         pkg = serialized_pkg.restore()
 
+        os_nice = getattr(os, "nice", None)  # Not avail on Windows
+        nice = spack.config.get("config:build_nice", None)
+        if os_nice is not None and nice is not None:
+            os_nice(nice)
+
         if not kwargs.get("fake", False):
             kwargs["unmodified_env"] = os.environ.copy()
             kwargs["env_modifications"] = setup_package(

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -81,6 +81,7 @@ properties: Dict[str, Any] = {
             "dirty": {"type": "boolean"},
             "build_language": {"type": "string"},
             "build_jobs": {"type": "integer", "minimum": 1},
+            "build_nice": {"anyOf": [{"type": "integer"}, {"type": "null"}]},
             "ccache": {"type": "boolean"},
             "concretizer": {"type": "string", "enum": ["original", "clingo"]},
             "db_lock_timeout": {"type": "integer", "minimum": 1},


### PR DESCRIPTION
Add a new `config:build_nice` config (default to `5`) to set build and test process priorities to a background level.

Does nothing on windows (or any system that does not have `os.nice`).

See https://github.com/spack/spack/issues/1607, it was never actually merged ?
