### PR TITLE
qt: mark conflict between older versions and with newer xcode

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -154,6 +154,7 @@ class Qt(Package):
 
     conflicts('%gcc@10:', when='@5.9:5.12.6 +opengl')
     conflicts('%gcc@11:', when='@5.8')
+    conflicts('%apple-clang@13:', when='@:5.13')
 
     # Build-only dependencies
     depends_on("pkgconfig", type='build')


### PR DESCRIPTION
qt@5.9.9 on xcode 13.2 (apple-clang-13.0.0):
<details><summary>Build error</summary>
Info: creating super cache file /private/var/folders/h6/qtysxyvn6hg3w2_b05tvppfc0tzbv7/T/b1n/spack-stage/spack-stage-qt-5.9.9-qzmvdntd5b43xbd654njwp7llkie2w4m/spack-src/.qmake.super
Command line: -prefix /Users/Shared/ornldev/code/spack/opt/spack/gcc-11.2.0/qt/qzmvdnt -v -opensource -no-opengl -release -confirm-license -optimized-qmake -no-pch -system-freetype -L/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/freetype/siiqezo/lib -I/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/freetype/siiqezo/include/freetype2 -no-openssl -no-sql-db2 -no-sql-ibase -no-sql-oci -no-sql-tds -no-sql-mysql -no-sql-odbc -no-sql-psql -no-sql-sqlite -no-sql-sqlite2 -shared -system-pcre -L/Users/Shared/ornldev/code/spack/opt/spack/gcc-11.2.0/pcre2/uutrjcb/lib -I/Users/Shared/ornldev/code/spack/opt/spack/gcc-11.2.0/pcre2/uutrjcb/include -system-harfbuzz -L/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/harfbuzz/i2p2k53/lib -I/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/harfbuzz/i2p2k53/include -system-doubleconversion -L/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/double-conversion/bohkhlz/lib -I/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/double-conversion/bohkhlz/include -system-libpng -L/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/libpng/hfch2de/lib -I/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/libpng/hfch2de/include -system-libjpeg -L/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/libjpeg-turbo/udjlkwj/lib -I/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/libjpeg-turbo/udjlkwj/include -system-zlib -L/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/zlib/dyvjhhi/lib -I/Users/Shared/ornldev/code/spack/opt/spack/apple-clang-13.0.0/zlib/dyvjhhi/include -nomake examples -nomake tools -no-dbus -framework -platform macx-g++ -no-eglfs -no-directfb -no-gtk -no-xinput2 -skip connectivity -skip webengine -skip wayland -skip multimedia
Info: creating stash file /private/var/folders/h6/qtysxyvn6hg3w2_b05tvppfc0tzbv7/T/b1n/spack-stage/spack-stage-qt-5.9.9-qzmvdntd5b43xbd654njwp7llkie2w4m/spack-src/.qmake.stash
Project ERROR: failed to parse default search paths from compiler output
</details>

Since https://github.com/microsoft/vcpkg/issues/21055 is only needed for the newer Apple SDK (tied to the xcode/apple-clang versions) and newer Qt versions, I'm assuming older versions are incompatible rather than trying to bisect to a working Qt.