### PR TITLE
py-jupyter-server: add 1.13.5

### DIFF
--- a/var/spack/repos/builtin/packages/py-jupyter-server/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-server/package.py
@@ -14,36 +14,7 @@ class PyJupyterServer(PythonPackage):
     homepage = "https://github.com/jupyter-server/jupyter_server"
     pypi     = "jupyter_server/jupyter_server-1.9.0.tar.gz"
 
-    import_modules = ['jupyter_server', 'jupyter_server.services',
-                      'jupyter_server.services.contents',
-                      'jupyter_server.services.kernels',
-                      'jupyter_server.services.config'
-                      'jupyter_server.services.security',
-                      'jupyter_server.services.sessions',
-                      'jupyter_server.services.nbconvert',
-                      'jupyter_server.services.api',
-                      'jupyter_server.services.kernelspecs',
-                      'jupyter_server.auth', 'jupyter_server.tests',
-                      'jupyter_server.tests.services',
-                      'jupyter_server.tests.services.contents',
-                      'jupyter_server.tests.services.kernels',
-                      'jupyter_server.tests.services.config',
-                      'jupyter_server.tests.services.sessions',
-                      'jupyter_server.tests.services.nbconvert',
-                      'jupyter_server.tests.services.api',
-                      'jupyter_server.tests.services.kernelspecs',
-                      'jupyter_server.tests.auth',
-                      'jupyter_server.tests.unix_sockets',
-                      'jupyter_server.tests.extension',
-                      'jupyter_server.tests.extension.mockextensions',
-                      'jupyter_server.tests.nbconvert',
-                      'jupyter_server.terminal', 'jupyter_server.i18n',
-                      'jupyter_server.base', 'jupyter_server.gateway',
-                      'jupyter_server.extension',
-                      'jupyter_server.prometheus', 'jupyter_server.view',
-                      'jupyter_server.nbconvert',
-                      'jupyter_server.files', 'jupyter_server.kernelspecs']
-
+    version('1.13.5', sha256='9e3e9717eea3bffab8cfb2ff330011be6c8bbd9cdae5b71cef169fcece2f19d3')
     version('1.11.2', sha256='c1f32e0c1807ab2de37bf70af97a36b4436db0bc8af3124632b1f4441038bf95')
     version('1.11.1', sha256='ab7ab1cc38512f15026cbcbb96300fb46ec8b24aa162263d9edd00e0a749b1e8')
     version('1.11.0', sha256='8ab4f484a4a2698f757cff0769d27b5d991e0232a666d54f4d6ada4e6a61330b')
@@ -51,6 +22,7 @@ class PyJupyterServer(PythonPackage):
     version('1.9.0', sha256='7d19006380f6217458a9db309b54e3dab87ced6c06329c61823907bef2a6f51b')
     version('1.6.1', sha256='242ddd0b644f10e030f917019b47c381e0f2d2b950164af45cbd791d572198ac')
 
+    depends_on('python@3.7:', when='@1.13.2:', type=('build', 'run'))
     depends_on('python@3.6:', type=('build', 'run'))
     # TODO: replace this after concretizer learns how to concretize separate build deps
     depends_on('py-jupyter-packaging11', when='@1.6.2:', type='build')
@@ -61,6 +33,7 @@ class PyJupyterServer(PythonPackage):
     depends_on('py-pyzmq@17:', type=('build', 'run'))
     depends_on('py-argon2-cffi', type=('build', 'run'))
     depends_on('py-ipython-genutils', type=('build', 'run'))
+    depends_on('py-traitlets@5:', when='@1.13.3:', type=('build', 'run'))
     depends_on('py-traitlets@4.2.1:', type=('build', 'run'))
     depends_on('py-jupyter-core@4.6.0:', type=('build', 'run'))
     depends_on('py-jupyter-client@6.1.1:', type=('build', 'run'))
@@ -71,4 +44,6 @@ class PyJupyterServer(PythonPackage):
     depends_on('py-prometheus-client', type=('build', 'run'))
     depends_on('py-anyio@3.1.0:3', type=('build', 'run'))
     depends_on('py-websocket-client', type=('build', 'run'))
-    depends_on('py-requests-unixsocket', type=('build', 'run'), when='@:1.11.1')
+    depends_on('py-packaging', when='@1.13.2:', type=('build', 'run'))
+    # for windows depends_on pywinpty@:1, when='@1.13.2:'
+    depends_on('py-requests-unixsocket', when='@:1.11.1', type=('build', 'run'))


### PR DESCRIPTION
https://github.com/jupyter-server/jupyter_server/tree/v1.13.5

The explicit definition of `import_modules` is not needed. Alle versions install with `--test=root` just fine without it.