### PR TITLE
util-linux-uuid: add conflict for new version and old compilers

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -18,6 +18,8 @@ class UtilLinuxUuid(AutotoolsPackage):
     version('2.36.2', sha256='f5dbe79057e7d68e1a46fc04083fc558b26a49499b1b3f50e4f4893150970463')
     version('2.36',   sha256='82942cd877a989f6d12d4ce2c757fb67ec53d8c5cd9af0537141ec5f84a2eea3')
 
+    conflicts('%gcc@:4', when='@2.37:')
+
     depends_on('pkgconfig', type='build')
 
     provides('uuid')


### PR DESCRIPTION
The system compiler on RHEL7 fails to build the latest linux-uuid:
```
util-linux-uuid@2.37.4%gcc@4.8.5 arch=linux-rhel7-haswell
```
results in:
```
libtool: compile:  /projects/spack/lib/spack/env/gcc/gcc -DHAVE_CONFIG_H -I. -include config.h -I./include -DLOCALEDIR=\"/projects/spack/opt/spack/gcc-4.8.5/util-linux-uuid/as7m3v4/share/locale\" -D_PATH_RUNSTATEDIR=\"/projects/spack/opt/spack/gcc-4.8.5/util-linux-uuid/as7m3v4/var/run\" -D_PATH_SYSCONFSTATICDIR=\"/projects/spack/opt/spack/gcc-4.8.5/util-linux-uuid/as7m3v4/lib\" -fsigned-char -fno-common -Wall -Wextra -Wimplicit-function-declaration -Wmissing-declarations -Wmissing-parameter-type -Wmissing-prototypes -Wnested-externs -Wno-missing-field-initializers -Wpointer-arith -Wredundant-decls -Wsign-compare -Wstrict-prototypes -Wtype-limits -Wuninitialized -Wunused-but-set-parameter -Wunused-but-set-variable -Wunused-parameter -Wunused-result -Wunused-variable -Werror=sequence-point -I./libuuid/src -Ilibuuid/src -g -O2 -MT libuuid/src/la-unparse.lo -MD -MP -MF libuuid/src/.deps/la-unparse.Tpo -c libuuid/src/unparse.c  -fPIC -DPIC -o libuuid/src/.libs/la-unparse.o
libuuid/src/unparse.c:42:73: error: expected ';', ',' or ')' before 'fmt'
 static void uuid_fmt(const uuid_t uuid, char *buf, char const *restrict fmt)
```

It looks like it's assuming C99 by default so there may be a better way
to handle this... but this at least works