### PR TITLE
find: deprecate `spack find --bootstrap` for `spack --bootstrap find`

### DIFF
--- a/lib/spack/spack/cmd/find.py
+++ b/lib/spack/spack/cmd/find.py
@@ -203,6 +203,12 @@ def display_env(env, args, decorator):
 
 def find(parser, args):
     if args.bootstrap:
+        tty.warn(
+            "`spack find --bootstrap` is deprecated and will be removed in v0.19.",
+            "Use `spack --bootstrap find` instead."
+        )
+
+    if args.bootstrap:
         bootstrap_store_path = spack.bootstrap.store_path()
         with spack.bootstrap.ensure_bootstrap_configuration():
             msg = 'Showing internal bootstrap store at "{0}"'

--- a/lib/spack/spack/test/cmd/find.py
+++ b/lib/spack/spack/test/cmd/find.py
@@ -333,3 +333,8 @@ def test_find_loaded(database, working_env):
     output = find('--loaded')
     expected = find()
     assert output == expected
+
+
+def test_bootstrap_deprecated():
+    output = find('--bootstrap')
+    assert "`spack find --bootstrap` is deprecated" in output


### PR DESCRIPTION
Since adding the `spack --bootstrap` argument in #25601, we don't need `spack find --bootstrap` anymore.

- [x] Deprecate `spack find --bootstrap`, to be removed in v0.19
- [x] Add a recommendation to use `spack --bootstrap find`
- [x] Simple test