### PR TITLE
e4s ci: packages: prefer openturns@1.18

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -49,6 +49,8 @@ spack:
       variants: +termlib
     openblas:
       variants: threads=openmp
+    openturns:
+      version: [1.18]
     trilinos:
       variants: +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     xz:


### PR DESCRIPTION
E4S CI: Prefer `openturns@1.18` so that concretizer doesn't select `openturns@master`

@adamjstewart @tgamblin @sethrj @trws @wspear 