### PR TITLE
libdrm: add -fcommon to CFLAGS for %aocc

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -33,6 +33,6 @@ class Libdrm(AutotoolsPackage):
             # Needed to fix build for spack/spack#1740, but breaks newer
             # builds/compilers
             args.append('LIBS=-lrt')
-        if self.spec.satisfies('%gcc@10.0.0:') or self.spec.satisfies('%clang@12.0.0:'):
+        if self.spec.satisfies('%gcc@10.0.0:') or self.spec.satisfies('%clang@11.0.0:') or self.spec.satisfies('%aocc@2.3.0:'):
             args.append('CFLAGS=-fcommon')
         return args


### PR DESCRIPTION
libdrm fails to build without `-fcommon` on newer compilers.
This patch adds Clang 11.0.0 and AMD's LLVM-based AOCC to the compilers that require `-fcommon`. (https://releases.llvm.org/11.0.0/tools/clang/docs/ReleaseNotes.html#modified-compiler-flags)