### PR TITLE
vecgeom: add patch for @1.1.18 +cuda

### DIFF
--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -61,6 +61,10 @@ class Vecgeom(CMakePackage, CudaPackage):
     patch('https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/7094dd180ef694f2abb7463cafcedfb8b8ed30a1.diff',
           sha256='34f1a6899616e40bce33d80a38a9b409f819cbaab07b2e3be7f4ec4bedb52b29',
           when='@1.1.7 +cuda')
+    # Fix installed target properties to not propagate flags to nvcc
+    patch('https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/ac398bd109dd9175e4a898cd4b62571a3cc88252.diff',
+          sha256='a9ba136d3ed4282ec950069da2199f22beadea27d89a4264d8773ba329e253df',
+          when='@1.1.18 +cuda ^cuda@:11.4')
 
     for std in _cxxstd_values:
         depends_on('geant4 cxxstd=' + std, when='+geant4 cxxstd=' + std)


### PR DESCRIPTION
This is a backported patch from @drbenmorgan to VecGeom for less recent CUDA installations to fix VecGeom.

@paulromano Sorry for not pushing this earlier -- I remember you encountered this error.