### PR TITLE
Adjust binutils detection

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -89,8 +89,8 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('--version', output=str, error=str)
-        match = re.search(r'GNU Binutils.*\) (\S+)', output)
-        return match.group(1) if match else None
+        match = re.search(r'GNU (nm|readelf).* (\S+)', output)
+        return Version(match.group(2)).dotted.up_to(3) if match else None
 
     def setup_build_environment(self, env):
 


### PR DESCRIPTION
The `spack external find binutils` command was failing to find my system
binutils because the regex was not matching. The name of the executable
follows the string 'GNU' that I tested with three different
installations so I changed the regex to look for that. On my CentOS-7
system, the version had the RPM details so I set the version to capture
the first three parts of the version.