### PR TITLE
nss: set C++ compiler

### DIFF
--- a/var/spack/repos/builtin/packages/nss/package.py
+++ b/var/spack/repos/builtin/packages/nss/package.py
@@ -38,6 +38,7 @@ class Nss(MakefilePackage):
         # We cannot use nss_build_all because this will try to build nspr.
         targets = ['all', 'latest']
 
+        targets.append('CCC={}'.format(spack_cxx))
         targets.append('USE_64=1')
         targets.append('BUILD_OPT=1')
 


### PR DESCRIPTION
Its makefile reads the C++ compiler from `CCC`.
Fixes #29194.