### PR TITLE
External pkgconfig

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -194,11 +194,16 @@ Specific limitations include:
 * Packages are not discoverable by default: For a package to be
   discoverable with ``spack external find``, it needs to add special
   logic. See :ref:`here <make-package-findable>` for more details.
-* The current implementation only collects and examines executable files,
-  so it is typically only useful for build/run dependencies (in some cases
-  if a library package also provides an executable, it may be possible to
-  extract a meaningful Spec by running the executable - for example the
-  compiler wrappers in MPI implementations).
+* The current implementation collects and examines executable files
+  and looks for pkg-config files in the default directories or those
+  specified with the PKG_CONFIG_PATH environment variable.
+  The former is typically only useful for build/run dependencies (in some
+  cases if a library package also provides an executable, it may be possible
+  to extract a meaningful Spec by running the executable - for example the
+  compiler wrappers in MPI implementations). Using custom extraction code
+  in packages it is generally possible to extract more information using
+  this method, thus the pkg-config method is only used as fallback
+  and is used for those packages which have not been found thru binaries.
 * The logic does not search through module files, it can only detect
   packages with executables defined in ``PATH``; you can help Spack locate
   externals which use module files by loading any associated modules for

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -5149,6 +5149,7 @@ The simplest way to make a package discoverable with
 
 1. Define the executables associated with the package
 2. Implement a method to determine the versions of these executables
+3. Rely on pkgconfig files to provide basic package information.
 
 ^^^^^^^^^^^^^^^^^
 Minimal detection
@@ -5406,6 +5407,30 @@ follows:
            )
 
 .. _package-lifecycle:
+
+^^^^^^^^^^^^^^^^^
+pkg-config Method
+^^^^^^^^^^^^^^^^^
+
+'pkg-config'-files are located in the default directories or those
+specified in the PKG_CONFIG_PATH environment variable. The search
+algorithm works as follows:
+
+1. Search for a pkg-config file whose name matches the package name
+   verbatim.
+2. If none is found, and the package name doesn't start with 'lib'
+   prepend this string and search again.
+3. If none is found and the package name starts with 'lib' remove
+   it and search again.
+
+Optionally, packages may provide a package level ``pkgconfigs`` attribute
+with a list of regular expressions to match the pkg-config file name:
+
+.. code-block:: python
+
+   class Foo(Package):
+
+       pkgconfigs = [ 'libfoo-2.*' ]
 
 -----------------------------
 Style guidelines for packages

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -184,6 +184,8 @@ def print_text_info(pkg):
         # mechanism. In this case, just inform the user it's detectable somehow.
         color.cprint('    True{0}'.format(
             ' (' + ', '.join(find_attributes) + ')' if find_attributes else ''))
+    elif hasattr(pkg, 'pkgconfigs'):
+        color.cprint('    True (pkgconfig)')
     else:
         color.cprint('    False')
 

--- a/lib/spack/spack/detection/__init__.py
+++ b/lib/spack/spack/detection/__init__.py
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 from .common import DetectedPackage, executable_prefix, update_configuration
-from .path import by_executable, executables_in_path
+from .path import by_executable, by_pkgconfig, executables_in_path
 
 __all__ = [
     'DetectedPackage',
+    'by_pkgconfig',
     'by_executable',
     'executables_in_path',
     'executable_prefix',

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -202,7 +202,8 @@ def by_pkgconfig(packages_to_check):
          packages_to_check (list): list of packages to be detected.
     """
     pkg_to_entries = collections.defaultdict(list)
-    if not spawn.find_executable('pkg-config'):
+    if not (os.access(os.environ.get('PKG_CONFIG', ''), os.X_OK)
+            or spawn.find_executable('pkg-config')):
         llnl.util.tty.debug('pkg-config binary not installed')
         return pkg_to_entries
     pkgconfig_packages = pkgconfig.list_all()

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -6,6 +6,7 @@
 and running executables.
 """
 import collections
+import distutils.spawn as spawn
 import os
 import os.path
 import re
@@ -26,6 +27,21 @@ from .common import (
     find_win32_additional_install_paths,
     is_executable,
 )
+
+try:
+    import pkgconfig
+except ImportError:
+    class Pkgconfig:
+        def list_all(self):
+            return []
+
+        def modversion(self, pkgname):
+            return {}
+
+        def variables(self, pkgname):
+            return {}
+
+    pkgconfig = Pkgconfig()
 
 
 def executables_in_path(path_hints=None):
@@ -174,5 +190,74 @@ def by_executable(packages_to_check, path_hints=None):
                 pkg_to_entries[pkg.name].append(
                     DetectedPackage(spec=spec, prefix=pkg_prefix)
                 )
+
+    return pkg_to_entries
+
+
+def by_pkgconfig(packages_to_check):
+    """Return the list of packages have have been detected on the system
+    using pkg-config.
+
+    Args:
+         packages_to_check (list): list of packages to be detected.
+    """
+    pkg_to_entries = collections.defaultdict(list)
+    if not spawn.find_executable('pkg-config'):
+        llnl.util.tty.debug('pkg-config binary not installed')
+        return pkg_to_entries
+    pkgconfig_packages = pkgconfig.list_all()
+    if not pkgconfig_packages:
+        llnl.util.tty.debug('No pkgconfig info avaiable or pkgconfig module not loaded')
+        return pkg_to_entries
+    for pkg in packages_to_check:
+        pkgname = None
+        if hasattr(pkg, 'pkgconfigs'):
+            for pkgcfg_pattern in pkg.pkgconfigs:
+                compiled_re = re.compile(pkgcfg_pattern)
+                for pkgcfg in pkgconfig_packages:
+                    if compiled_re.search(pkgcfg):
+                        pkgname = pkgcfg
+                        break
+        if not pkgname:
+            pkgname = pkg.name
+            if pkgname not in pkgconfig_packages:
+                if pkgname.startswith('lib'):
+                    pkgname = pkg.name[3:]
+                else:
+                    pkgname = 'lib' + pkg.name
+                if pkgname not in pkgconfig_packages:
+                    continue
+        try:
+            external_path = pkgconfig.variables(pkgname)['prefix']
+        except Exception as e:
+            llnl.util.tty.debug('pkgconfig package {0} doesn\'t set prefix error={1}'.
+                                format(pkg.name, str(e)))
+            continue
+
+        spec_str = '{0}@{1} '.format(
+            pkg.name, pkgconfig.modversion(pkgname))
+        try:
+            spec = spack.spec.Spec(
+                spec_str,
+                external_path=external_path
+            )
+        except Exception as e:
+            msg = 'Parsing failed [spec_str="{0}", error={1}]'
+            llnl.util.tty.debug(msg.format(spec_str, str(e)))
+            continue
+
+        spec = spack.spec.Spec.from_detection(spec)
+        try:
+            spec.validate_detection()
+        except Exception as e:
+            msg = ('"{0}" has been detected on the system but will '
+                   'not be added to packages.yaml [reason={1}]')
+            llnl.util.tty.warn(msg.format(spec, str(e)))
+            continue
+
+        pkg_to_entries[pkg.name].append(
+            DetectedPackage(spec=spec,
+                            prefix=external_path)
+        )
 
     return pkg_to_entries

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -71,6 +71,7 @@ def test_info_noversion(mock_packages, info_lines, mock_print):
 @pytest.mark.parametrize('pkg_query,expected', [
     ('zlib', 'False'),
     ('gcc', 'True (version, variants)'),
+    ('libxml2', 'True (pkgconfig)'),
 ])
 @pytest.mark.usefixtures('mock_print')
 def test_is_externally_detectable(pkg_query, expected, parser, info_lines):

--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -46,6 +46,8 @@ class Libxml2(AutotoolsPackage):
     patch('nvhpc-configure.patch', when='%nvhpc')
     patch('nvhpc-elfgcchack.patch', when='%nvhpc')
 
+    pkgconfigs = ['libxml-2.*']
+
     @property
     def headers(self):
         include_dir = self.spec.prefix.include.libxml2


### PR DESCRIPTION
This patchset extends the 'spack external find' methods to a search for pkgconfig files. This will aid detecting libraries which do not provide binaries that can be checked. Since this detection method only allows to obtain information about the package availability, its version and 'prefix' path: it is not able to detect variants. Therefore, the detection method using executibles is given precedence over this one.
It adds the requirement for the 'pkgconfig' python package which relies on 'pkg-config' to be installed. The detection method will not be used if the 'pkg-config' binary cannot be found in the include path.

I put this feature up for discussion, I'm open to change requests. For instance, this method can be made optional if that's preferred.