### PR TITLE
py-msgpack: add 1.0.3

### DIFF
--- a/var/spack/repos/builtin/packages/py-msgpack/package.py
+++ b/var/spack/repos/builtin/packages/py-msgpack/package.py
@@ -9,10 +9,14 @@ class PyMsgpack(PythonPackage):
 
     homepage = "https://msgpack.org/"
     pypi = "msgpack/msgpack-1.0.0.tar.gz"
+    git = "https://github.com/msgpack/msgpack-python"
 
+    version('1.0.3', sha256='51fdc7fb93615286428ee7758cecc2f374d5ff363bdd884c7ea622a7a327a81e')
     version('1.0.2', sha256='fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984')
     version('1.0.1', sha256='7033215267a0e9f60f4a5e4fb2228a932c404f237817caff8dc3115d9e7cd975')
     version('1.0.0', sha256='9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0')
     version('0.6.2', sha256='ea3c2f859346fcd55fc46e96885301d9c2f7a36d453f5d8f2967840efa1e1830')
 
+    depends_on('py-setuptools@35.0.2:', when='@1.0.3:', type='build')
     depends_on('py-setuptools', type='build')
+    depends_on('py-cython@0.29.13:0.29', type='build')

--- a/var/spack/repos/builtin/packages/py-msgpack/package.py
+++ b/var/spack/repos/builtin/packages/py-msgpack/package.py
@@ -17,6 +17,4 @@ class PyMsgpack(PythonPackage):
     version('1.0.0', sha256='9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0')
     version('0.6.2', sha256='ea3c2f859346fcd55fc46e96885301d9c2f7a36d453f5d8f2967840efa1e1830')
 
-    depends_on('py-setuptools@35.0.2:', when='@1.0.3:', type='build')
     depends_on('py-setuptools', type='build')
-    depends_on('py-cython@0.29.13:0.29', type='build')


### PR DESCRIPTION
https://github.com/msgpack/msgpack-python/tree/v1.0.3

The `py-cython` dependency for the older version can be found in `requirements.txt`