### PR TITLE
link_tree.py, filesystem.py: follow symlinks which point to subdirs (of symlink dir)

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -908,13 +908,11 @@ def traverse_tree(source_root, dest_root, rel_path='', **kwargs):
             # When follow_nonexisting isn't set, don't descend into dirs
             # in source that do not exist in dest
             if not follow_nonexisting and not os.path.exists(dest_child):
-                print("Not entering", dest_child)
                 continue
 
             # When a symlink, ensure it's inside the prefix.
             if os.path.islink(source_child):
                 if not follow_links:
-                    print("Not following", source_child, "cause disabled")
                     continue
 
                 # isdir already made sure the symlink exists
@@ -922,7 +920,6 @@ def traverse_tree(source_root, dest_root, rel_path='', **kwargs):
 
                 # Symlink to dir out of the prefix
                 if not symlink_dir_realpath.startswith(canonical_real_source_path):
-                    print("Not following", source_child, "cause not in prefix")
                     continue
 
             for t in traverse_tree(source_root, dest_root, rel_child, **kwargs):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -474,7 +474,7 @@ def copy_tree(src, dest, symlinks=True, ignore=None, _permissions=False):
         mkdirp(abs_dest)
 
         for s, d in traverse_tree(abs_src, abs_dest, order='pre',
-                                  follow_symlinks=not symlinks,
+                                  follow_links=not symlinks,
                                   ignore=ignore,
                                   follow_nonexisting=True):
             if os.path.islink(s):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -927,7 +927,7 @@ def traverse_tree(source_root, dest_root, rel_path='', follow_nonexisting=True,
                 yield t
 
         # Treat as a file.
-        elif not ignore(os.path.join(rel_path, f)):
+        elif not ignore(rel_child):
             yield (source_child, dest_child)
 
     if order == 'post':

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -911,6 +911,8 @@ def traverse_tree(source_root, dest_root, rel_path='', follow_nonexisting=True,
             # When a symlink, ensure it's inside the prefix.
             if os.path.islink(source_child):
                 if not follow_links:
+                    # When not following symlinks, yield it "as a symlink".
+                    yield (source_child, dest_child)
                     continue
 
                 # isdir already made sure the symlink exists

--- a/lib/spack/llnl/util/link_tree.py
+++ b/lib/spack/llnl/util/link_tree.py
@@ -62,8 +62,8 @@ class LinkTree(object):
 
     def find_dir_conflicts(self, dest_root, ignore):
         conflicts = []
-        kwargs = {'follow_nonexisting': False, 'ignore': ignore}
-        for src, dest in traverse_tree(self._root, dest_root, **kwargs):
+        for src, dest in traverse_tree(self._root, dest_root, ignore=ignore,
+                                       follow_links=True, follow_nonexisting=False):
             if os.path.isdir(src):
                 if os.path.exists(dest) and not os.path.isdir(dest):
                     conflicts.append("File blocks directory: %s" % dest)


### PR DESCRIPTION
Closes #26377

Packages like cuda and intel-mkl have this structure:

```
<prefix>/lib64 -> some/dir/levels/deep/lib64
```

And they are full of libs

```
<prefix>/lib64/libcusolver.so
```

but Spack fails to create the links for those as it skips over
symlinked directories.

```console
$ ls <view>/lib64/libcusolver.so
ls: cannot access '<view/lib64/libcusolver.so': No such file or directory
```

with this patch we now do get

```
$ readlink <view>/lib64/libcusolver.so
<prefix>/lib64/libcusolver.so
```

---

- `traverse_tree(follow_links=True)`: enter symlinked directories as long as their
   realpath path is within the source prefix
- `merge_directories` always follow links; this will effectively replace symlinks to
   directories inside the source prefix with actual directories in the destination
   prefix (which is required if you want to merge `<prefix a>/lib` and `<prefix b>/lib`
   into `<view>/lib`, and `<prefix a>/lib` is a symlink to a subdir.
- Fixes kwarg bugs introduced in 6b90017efa1f3157fe4be7d0c7b199b6e51b9fa8 and 638cc64571fd038f5ae7f47a664399b9f2629d66