### PR TITLE
commands: Propgate command return value as exit code

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -868,7 +868,7 @@ def _main(argv=None):
         bootstrap_context = bootstrap.ensure_bootstrap_configuration()
 
     with bootstrap_context:
-        finish_parse_and_run(parser, cmd_name, env_format_error)
+        return finish_parse_and_run(parser, cmd_name, env_format_error)
 
 
 def finish_parse_and_run(parser, cmd_name, env_format_error):


### PR DESCRIPTION
This fixes an issue that started causing return value from spack commands not to be propagated back to the shell as the exit code.