### PR TITLE
libtermkey: Update to the latest release

### DIFF
--- a/var/spack/repos/builtin/packages/libtermkey/package.py
+++ b/var/spack/repos/builtin/packages/libtermkey/package.py
@@ -11,6 +11,7 @@ class Libtermkey(Package):
     homepage = "http://www.leonerd.org.uk/code/libtermkey/"
     url      = "http://www.leonerd.org.uk/code/libtermkey/libtermkey-0.18.tar.gz"
 
+    version('0.22', sha256='6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600')
     version('0.18', sha256='239746de41c845af52bb3c14055558f743292dd6c24ac26c2d6567a5a6093926')
     version('0.17', sha256='68949364ed5eaad857b3dea10071cde74b00b9f236dfbb702169f246c3cef389')
     version('0.16', sha256='6c8136efa5d0b3277014a5d4519ea81190079c82656b7db1655a1bd147326a70')
@@ -19,6 +20,7 @@ class Libtermkey(Package):
 
     depends_on('libtool', type='build')
     depends_on('ncurses')
+    depends_on('pkgconfig')
 
     def install(self, spec, prefix):
         make()


### PR DESCRIPTION
And add a missing dependency.

Fixes #26672.