### PR TITLE
use spack-bundled gzip to build automake

### DIFF
--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -13,6 +13,8 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
     homepage = 'https://www.gnu.org/software/automake/'
     gnu_mirror_path = 'automake/automake-1.15.tar.gz'
 
+    maintainers = ['cosmicexplorer']
+
     version('1.16.5', sha256='07bd24ad08a64bc17250ce09ec56e921d6343903943e99ccf63bbf0705e34605')
     version('1.16.3', sha256='ce010788b51f64511a1e9bb2a1ec626037c6d0e7ede32c1c103611b9d3cba65f')
     version('1.16.2', sha256='b2f361094b410b4acbf4efba7337bdb786335ca09eb2518635a09fb7319ca5c1')

--- a/var/spack/repos/builtin/packages/automake/package.py
+++ b/var/spack/repos/builtin/packages/automake/package.py
@@ -25,6 +25,7 @@ class Automake(AutotoolsPackage, GNUMirrorPackage):
 
     depends_on('autoconf', type='build')
     depends_on('perl', type=('build', 'run'))
+    depends_on('gzip', type='build')
 
     build_directory = 'spack-build'
 


### PR DESCRIPTION
### Problem

Note that I use Alpine Linux, which by default provides `gzip` via busybox:
```bash
# cosmicexplorer@terrestrial-gamma-ray-flash: ~/tools/automake 16:12:59 
; gzip --version                 
gzip: unrecognized option: version
BusyBox v1.35.0 (2022-02-01 23:11:20 UTC) multi-call binary.

Usage: gzip [-cfkdt123456789] [FILE]...

Compress FILEs (or stdin)

        -1..9   Compression level
        -d      Decompress
        -c      Write to stdout
        -f      Force
        -k      Keep input files
        -t      Test integrity
```

So, just now in my terminal:
```bash
; spack dev-build automake@master
... (truncated)
case 'amhello-1.0.tar.gz' in \
*.tar.gz*) \
  eval GZIP= gzip --best -dc amhello-1.0.tar.gz | ${TAR-tar} xf - ;;\
*.tar.bz2*) \
  bzip2 -dc amhello-1.0.tar.bz2 | ${TAR-tar} xf - ;;\
*.tar.lz*) \
  lzip -dc amhello-1.0.tar.lz | ${TAR-tar} xf - ;;\
*.tar.xz*) \
  xz -dc amhello-1.0.tar.xz | ${TAR-tar} xf - ;;\
*.tar.Z*) \
  uncompress -c amhello-1.0.tar.Z | ${TAR-tar} xf - ;;\
*.shar.gz*) \
  eval GZIP= gzip --best -dc amhello-1.0.shar.gz | unshar ;;\
*.zip*) \
  unzip amhello-1.0.zip ;;\
*.tar.zst*) \
  zstd -dc amhello-1.0.tar.zst | ${TAR-tar} xf - ;;\
esac
gzip: unrecognized option: best
BusyBox v1.35.0 (2022-02-01 23:11:20 UTC) multi-call binary.

Usage: gzip [-cfkdt123456789] [FILE]...

Compress FILEs (or stdin)

        -1..9   Compression level
        -d      Decompress
        -c      Write to stdout
        -f      Force
        -k      Keep input files
        -t      Test integrity
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
make[1]: *** [Makefile:621: distcheck] Error 2
make[1]: Leaving directory '/home/cosmicexplorer/tools/automake/doc/amhello'
make: *** [Makefile:3766: /home/cosmicexplorer/tools/automake/doc/amhello-1.0.tar.gz] Error 1
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'V=1'

2 errors found in build log:
     262        -c      Write to stdout
     263        -f      Force
     264        -k      Keep input files
     265        -t      Test integrity
     266    tar: This does not look like a tar archive
     267    tar: Exiting with failure status due to previous errors
  >> 268    make[1]: *** [Makefile:621: distcheck] Error 2
     269    make[1]: Leaving directory '/home/cosmicexplorer/tools/automake/doc/amhello'
  >> 270    make: *** [Makefile:3766: /home/cosmicexplorer/tools/automake/doc/amhello-1.0.tar.gz] Error 1

See build log for details:
  /home/cosmicexplorer/tools/automake/spack-build-out.txt

```

### Solution
- Provide `gzip` during the `automake` build with spack's `gzip` package by adding a `depends_on()` declaration.

### Result
`spack dev-build automake@master` succeeds on Alpine Linux!