### PR TITLE
Fix neovim install on M1

### DIFF
--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -39,7 +39,7 @@ class Lua(Package):
 
     provides('lua-lang')
 
-    depends_on('ncurses+termlib')
+    depends_on('ncurses~termlib')
     depends_on('readline')
     # luarocks needs unzip for some packages (e.g. lua-luaposix)
     depends_on('unzip', type='run')

--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -29,7 +29,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     variant('symlinks', default=False,
             description='Enables symlinks. Needed on AFS filesystem.')
-    variant('termlib', default=True,
+    variant('termlib', default=False,
             description='Enables termlib features. This is an extra '
                         'lib and optional internal dependency.')
     # Build ncurses with ABI compaitibility.

--- a/var/spack/repos/builtin/packages/neovim/ncurses.patch
+++ b/var/spack/repos/builtin/packages/neovim/ncurses.patch
@@ -1,0 +1,12 @@
+--- a/cmake/FindLibTermkey.cmake
++++ b/cmake/FindLibTermkey.cmake
+@@ -19,7 +19,7 @@ list(APPEND LIBTERMKEY_NAMES termkey)
+ find_library(LIBTERMKEY_LIBRARY NAMES ${LIBTERMKEY_NAMES}
+   HINTS ${PC_LIBTERMKEY_LIBDIR} ${PC_LIBTERMKEY_LIBRARY_DIRS})
+ 
+-set(LIBTERMKEY_LIBRARIES ${LIBTERMKEY_LIBRARY})
++set(LIBTERMKEY_LIBRARIES ${LIBTERMKEY_LIBRARY} ncurses)
+ set(LIBTERMKEY_INCLUDE_DIRS ${LIBTERMKEY_INCLUDE_DIR})
+ 
+ include(FindPackageHandleStandardArgs)
+

--- a/var/spack/repos/builtin/packages/neovim/package.py
+++ b/var/spack/repos/builtin/packages/neovim/package.py
@@ -53,5 +53,7 @@ class Neovim(CMakePackage):
     depends_on('libluv@1.30.0:', type='link', when='@0.4:,stable')
     depends_on('tree-sitter', when='@0.5:')
 
+    patch('ncurses.patch')
+
     def cmake_args(self):
         return ['-DPREFER_LUA=ON']


### PR DESCRIPTION
With #29228 and #29229 in, the `spack install neovim` fails with:
```
     1022    undef: _tigetstr
     1023    undef: _cur_term
     1024    undef: _setupterm
  >> 1025    Undefined symbols for architecture arm64:
     1026      "_tigetstr", referenced from:
     1027          _try_load_terminfo_key in libtermkey.a(driver-ti.o)
     1028      "_cur_term", referenced from:
     1029          _load_terminfo in libtermkey.a(driver-ti.o)
     1030      "_setupterm", referenced from:
     1031          _new_driver in libtermkey.a(driver-ti.o)
     1032          _load_terminfo in libtermkey.a(driver-ti.o)
     1033    ld: symbol(s) not found for architecture arm64
```
While linking the `nvim` executable. These symbols seem to be coming from `ncurses`, but linking `ncurses` explicitly didn't seem to fix it. However, the current PR fixes it. One must turn off `termlib` in `ncurses` and then one must explicitly link it. Then `nvim` builds just fine. I am opening this PR as a Draft, because the `+termlib` seems hardwired in `lua`, so I don't know how to fix this properly. Also just adding `ncurses` in the cmake for `neovim` doesn't feel right, one should explicitly depend on `ncurses` and then find it using cmake. I don't have time to work on that. But this PR might be helpful to others to finish this work. Either way, neovim seems to work fine now.