### PR TITLE
Fix typo in package exempi: 'polatform' --> 'platform'

### DIFF
--- a/var/spack/repos/builtin/packages/exempi/package.py
+++ b/var/spack/repos/builtin/packages/exempi/package.py
@@ -37,7 +37,7 @@ class Exempi(AutotoolsPackage):
     def configure_args(self):
         args = ['--with-boost={0}'.format(self.spec['boost'].prefix)]
 
-        if self.spec.satisfies('polatform=darwin'):
+        if self.spec.satisfies('platform=darwin'):
             args += ['--with-darwinports', '--with-fink']
 
         return args


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/29232 by correcting the typo
```
        if self.spec.satisfies('polatform=darwin'):
```
to
```
        if self.spec.satisfies('platform=darwin'):
```