### PR TITLE
Revert "charmpp: default backend to 'multicore' on macOS (#28443)"

### DIFF
--- a/var/spack/repos/builtin/packages/charmpp/package.py
+++ b/var/spack/repos/builtin/packages/charmpp/package.py
@@ -69,15 +69,9 @@ class Charmpp(Package):
     )
 
     # Communication mechanisms (choose exactly one)
-    # - Default to 'multicore' on macOS because that's probably the right choice
-    #   for a personal machine.
-    if sys.platform == "darwin":
-        backend_default = "multicore"
-    else:
-        backend_default = "netlrts"
     variant(
         "backend",
-        default=backend_default,
+        default="netlrts",
         values=("mpi", "multicore", "netlrts", "verbs", "gni",
                 "ucx", "ofi", "pami", "pamilrts"),
         description="Set the backend to use"


### PR DESCRIPTION
This reverts commit 8ccc4df6ff2954eb494bfda9633aaf8eb2e849b0.

#28443 did not work as intended. Since multicore+smp is a conflict (and smp is on by default), spack will select a different backend instead, building with the MPI(!) version by default on MacOS.

cc: @nilsvu 