### PR TITLE
Use stable URLs and `?full_index=1` for all github patches

### DIFF
--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -8,30 +8,30 @@ import spack.audit
 import spack.config
 
 
-@pytest.mark.parametrize('packages,failing_check', [
+@pytest.mark.parametrize('packages,expected_error', [
     # A non existing variant is used in a conflict directive
     (['wrong-variant-in-conflicts'], 'PKG-DIRECTIVES'),
     # The package declares a non-existing dependency
     (['missing-dependency'], 'PKG-DIRECTIVES'),
     # The package use a non existing variant in a depends_on directive
     (['wrong-variant-in-depends-on'], 'PKG-DIRECTIVES'),
+    # This package has a GitHub patch URL without full_index=1
+    (['invalid-github-patch-url'], 'PKG-DIRECTIVES'),
     # This package has no issues
     (['mpileaks'], None),
     # This package has a conflict with a trigger which cannot constrain the constraint
     # Should not raise an error
     (['unconstrainable-conflict'], None),
 ])
-def test_package_audits(packages, failing_check, mock_packages):
+def test_package_audits(packages, expected_error, mock_packages):
     reports = spack.audit.run_group('packages', pkgs=packages)
 
-    for check, errors in reports:
-        # Check that we have errors only if there is an expected failure
-        # and that the tag matches our expectations
-        if bool(failing_check):
-            assert check == failing_check
-            assert errors
-        else:
-            assert not errors
+    # Check that errors were reported only for the expected failure
+    actual_errors = [check for check, errors in reports if errors]
+    if expected_error:
+        assert [expected_error] == actual_errors
+    else:
+        assert not actual_errors
 
 
 # Data used in the test below to audit the double definition of a compiler

--- a/var/spack/repos/builtin.mock/packages/invalid-github-patch-url/package.py
+++ b/var/spack/repos/builtin.mock/packages/invalid-github-patch-url/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class InvalidGithubPatchUrl(Package):
+    """Package that has a GitHub patch URL that fails auditing."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/patch-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    patch(
+        'https://github.com/spack/spack/commit/cc76c0f5f9f8021cfb7423a226bd431c00d791ce.patch',
+        sha256='6057c3a8d50a23e93e5642be5a78df1e45d7de85446c2d7a63e3d0d88712b369',
+    )

--- a/var/spack/repos/builtin/packages/adios/package.py
+++ b/var/spack/repos/builtin/packages/adios/package.py
@@ -106,8 +106,8 @@ class Adios(AutotoolsPackage):
     patch('zfp051.patch', when='@1.11.0:1.13.1')
 
     # Fix a bug in configure.ac that causes automake issues on RHEL 7.7
-    patch('https://github.com/ornladios/ADIOS/pull/207.patch', when='@1.12.0: +mpi',
-          sha256='01113e9efb929d71c28bf33cc8b7f215d85195ec700e99cb41164e2f8f830640')
+    patch('https://github.com/ornladios/ADIOS/pull/207.patch?full_index=1', when='@1.12.0: +mpi',
+          sha256='aea47e56013b57c2d5d36e23e0ae6010541c3333a84003784437768c2e350b05')
 
     def validate(self, spec):
         """Checks if incompatible variants have been activated at the same time

--- a/var/spack/repos/builtin/packages/adios2/package.py
+++ b/var/spack/repos/builtin/packages/adios2/package.py
@@ -131,8 +131,8 @@ class Adios2(CMakePackage):
 
     # Add missing include <memory>
     # https://github.com/ornladios/adios2/pull/2710
-    patch('https://github.com/ornladios/adios2/pull/2710.patch', when='@:2.7.1',
-          sha256='8d301e8232baf4049b547f22bd73774309662017a62dac36360d2965907062bf')
+    patch('https://github.com/ornladios/adios2/pull/2710.patch?full_index=1', when='@:2.7.1',
+          sha256='8221073d1b2f8944395a88a5d60a15c7370646b62f5fc6309867bbb6a8c2096c')
 
     @when('%fj')
     def patch(self):

--- a/var/spack/repos/builtin/packages/bart/package.py
+++ b/var/spack/repos/builtin/packages/bart/package.py
@@ -19,8 +19,8 @@ class Bart(MakefilePackage, CudaPackage):
     version('0.5.00', sha256='30eedcda0f0ef3808157542e0d67df5be49ee41e4f41487af5c850632788f643')
 
     # patch to fix build with MKL
-    patch('https://github.com/mrirecon/bart/commit/b62ca4972d5ac41a44217a5c27123c15daae74db.patch',
-          sha256='8fd1be181da928448da750b32d45ee6dce7ba6af0424617c4f8d653cf3f05445',
+    patch('https://github.com/mrirecon/bart/commit/b62ca4972d5ac41a44217a5c27123c15daae74db.patch?full_index=1',
+          sha256='501ca985df2324fc02e32cc4ffb32ce5c235fe83a59f5b853eb78ad0f2d6629c',
           when='@0.5.00')
 
     # patch to fix Makefile for openblas and cuda

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -308,14 +308,14 @@ class Boost(Package):
 
     # Fix float128 support when building with CUDA and Cray compiler
     # See https://github.com/boostorg/config/pull/378
-    patch("https://github.com/boostorg/config/commit/fee1ad07968386b6d547f089311b7a2c1bf7fa55.patch",
-          sha256="3b159d65a0d3d2df2a21c6bf56ffaba943fce92d2d41d628b2c4d2e924e0f421",
+    patch("https://github.com/boostorg/config/commit/fee1ad07968386b6d547f089311b7a2c1bf7fa55.patch?full_index=1",
+          sha256="666eec8cfb0f71a87443ab27d179a9771bda32bcb8ff5e16afa3767f7b7f1e70",
           when="@:1.76%cce",
           level=2)
 
     # Fix building with Intel compilers
-    patch("https://github.com/bfgroup/b2/commit/23212066f0f20358db54568bb16b3fe1d76f88ce.patch",
-          sha256="93f4aad8f88d1437e50d95a2d066390ef3753b99ef5de24f7a46bc083bd6df06",
+    patch("https://github.com/bfgroup/b2/commit/23212066f0f20358db54568bb16b3fe1d76f88ce.patch?full_index=1",
+          sha256="4849671f9df4b8f3c962130d7f6d44eba3b20d113e84f9faade75e6469e90310",
           when="@1.77.0",
           working_dir="tools/build")
 

--- a/var/spack/repos/builtin/packages/claw/package.py
+++ b/var/spack/repos/builtin/packages/claw/package.py
@@ -36,14 +36,14 @@ class Claw(CMakePackage):
 
     # Enable parsing of source files with calls to TRACEBACKQQ from the Intel
     # Fortran run-time library:
-    patch('https://github.com/claw-project/claw-compiler/commit/e9fe6dbd291454ce34dd58f21d102f7f1bdff874.patch',
-          sha256='82033a576966143f3b1fd66f4d5b5604704b615b3e08afa4901fc1c29caefbe2',
+    patch('https://github.com/claw-project/claw-compiler/commit/e9fe6dbd291454ce34dd58f21d102f7f1bdff874.patch?full_index=1',
+          sha256='262799fde57cb32f1514db22a7757e994bd8b97090ce0a5f55249fd56d0e5c29',
           when='@:2.0.2%intel')
 
     # Fix the dependency preprocessing for compilers that cannot use
     # redirection > to save file (cce is currently the only known case):
-    patch('https://github.com/claw-project/claw-compiler/commit/4d8bc7a794af3651b8b61501388fc00096b23a85.patch',
-          sha256='0a55110c67d7755741e1c86c2f71341286e7502a81ac29958ce80273e87bc8e1',
+    patch('https://github.com/claw-project/claw-compiler/commit/4d8bc7a794af3651b8b61501388fc00096b23a85.patch?full_index=1',
+          sha256='a20427456560070e284ff44edb658383b635042be91d2ffbe7aeb7afbd8f02bc',
           when='@2.0.2%cce')
 
     # Cache ANT dependencies in the stage directory.

--- a/var/spack/repos/builtin/packages/clfft/package.py
+++ b/var/spack/repos/builtin/packages/clfft/package.py
@@ -26,8 +26,8 @@ class Clfft(CMakePackage):
     # See https://github.com/spack/spack/pull/22303 for reference
     depends_on(Boost.with_default_variants, when='+client')
 
-    patch('https://github.com/clMathLibraries/clFFT/commit/eea7dbc888367b8dbea602ba539eb1a9cbc118d9.patch',
-          sha256='3148d5937077def301b30b913bc2437df869204fca1de4385ccd46e3b98b13aa', when='@2.12.2')
+    patch('https://github.com/clMathLibraries/clFFT/commit/eea7dbc888367b8dbea602ba539eb1a9cbc118d9.patch?full_index=1',
+          sha256='9ee126955f0bb9469c8302d8b08672d60a493d3373dbad06bdfda0b5c7893488', when='@2.12.2')
 
     root_cmakelists_dir = 'src'
 

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -173,8 +173,8 @@ class Conduit(CMakePackage):
 
     # Add missing include for numeric_limits
     # https://github.com/LLNL/conduit/pull/773
-    patch('https://github.com/LLNL/conduit/pull/773.patch', when='@:0.7.2',
-          sha256='89d1829ad52f503f6179e43efddf998c239a95c14ca1f248463a3f61ad7d5cf7')
+    patch('https://github.com/LLNL/conduit/pull/773.patch?full_index=1', when='@:0.7.2',
+          sha256='784d74942a63acf698c31b39848b46b4b755bf06faa6aa6fb81be61783ec0c30')
 
     ###################################
     # build phases used by this package

--- a/var/spack/repos/builtin/packages/cp2k/package.py
+++ b/var/spack/repos/builtin/packages/cp2k/package.py
@@ -206,8 +206,8 @@ class Cp2k(MakefilePackage, CudaPackage):
     conflicts('+cuda', when='cuda_arch=none', msg=cuda_msg)
 
     # Fix 2- and 3-center integral calls to libint
-    patch("https://github.com/cp2k/cp2k/commit/5eaf864ed2bd21fb1b05a9173bb77a815ad4deda.patch",
-          sha256="18e58ba8fdde5c507bece48ec064f7f2b80e59d1b7cfe6b7a639e5f64f84d43f",
+    patch("https://github.com/cp2k/cp2k/commit/5eaf864ed2bd21fb1b05a9173bb77a815ad4deda.patch?full_index=1",
+          sha256="3617abb877812c4b933f601438c70f95e21c6161bea177277b1d4125fd1c0bf9",
           when="@8.2")
 
     @property

--- a/var/spack/repos/builtin/packages/dealii/package.py
+++ b/var/spack/repos/builtin/packages/dealii/package.py
@@ -231,25 +231,25 @@ class Dealii(CMakePackage, CudaPackage):
 
     # Explicitly provide a destructor in BlockVector,
     # otherwise deal.II may fail to build with Intel compilers.
-    patch('https://github.com/dealii/dealii/commit/a89d90f9993ee9ad39e492af466b3595c06c3e25.patch',
-          sha256='4282b32e96f2f5d376eb34f3fddcc4615fcd99b40004cca784eb874288d1b31c',
+    patch('https://github.com/dealii/dealii/commit/a89d90f9993ee9ad39e492af466b3595c06c3e25.patch?full_index=1',
+          sha256='72304bc6c3fb4549cf53ed533a00311d12827d48817e2038efd3a8ef6c43d149',
           when='@9.0.1')
 
     # https://github.com/dealii/dealii/pull/7935
-    patch('https://github.com/dealii/dealii/commit/f8de8c5c28c715717bf8a086e94f071e0fe9deab.patch',
-          sha256='61f217744b70f352965be265d2f06e8c1276685e2944ca0a88b7297dd55755da',
+    patch('https://github.com/dealii/dealii/commit/f8de8c5c28c715717bf8a086e94f071e0fe9deab.patch?full_index=1',
+          sha256='4aba56b01d816ca950b1625f436840df253f145650e3a3eba51e7f2696ec7dc0',
           when='@9.0.1 ^boost@1.70.0:')
 
     # Fix TBB version check
     # https://github.com/dealii/dealii/pull/9208
-    patch('https://github.com/dealii/dealii/commit/80b13fe5a2eaefc77fa8c9266566fa8a2de91edf.patch',
-          sha256='6f876dc8eadafe2c4ec2a6673864fb451c6627ca80511b6e16f3c401946fdf33',
+    patch('https://github.com/dealii/dealii/commit/80b13fe5a2eaefc77fa8c9266566fa8a2de91edf.patch?full_index=1',
+          sha256='3da530766050a0cea80106684347055bdb78528a1869ce99e8fbf8fc83074fd0',
           when='@9.0.0:9.1.1')
 
     # Explicitly include a boost header, otherwise deal.II fails to compile
     # https://github.com/dealii/dealii/pull/11438
-    patch('https://github.com/dealii/dealii/commit/3b815e21c4bfd82c792ba80e4d90314c8bb9edc9.patch',
-          sha256='5f9f411ab9336bf49d8293b9936344bad6e1cf720955b9d8e8b29883593b0ed9',
+    patch('https://github.com/dealii/dealii/commit/3b815e21c4bfd82c792ba80e4d90314c8bb9edc9.patch?full_index=1',
+          sha256='90ae9ddefe77fffd297bba6b070ab68d07306d4ef525ee994e8c49cef68f76f3',
           when='@9.2.0 ^boost@1.72.0:')
 
     # Check for sufficiently modern versions

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -137,8 +137,8 @@ class Eccodes(CMakePackage):
     patch('cmake_install_rpath.patch', when='@:2.10')
 
     # Fix a bug preventing cmake from finding NetCDF:
-    patch('https://github.com/ecmwf/ecbuild/commit/3916c7d22575c45166fcc89edcbe02a6e9b81aa2.patch',
-          sha256='857454528b666c52eb36ef3aa5d40ae018981b44e129bb8df3c2d3d560e3fa03',
+    patch('https://github.com/ecmwf/ecbuild/commit/3916c7d22575c45166fcc89edcbe02a6e9b81aa2.patch?full_index=1',
+          sha256='9dcc4affaaa850d4b7247baa939d0f9ffedea132369f1afc3f248dbf720386c9',
           when='@:2.4.0+netcdf')
 
     @when('%nag+fortran')

--- a/var/spack/repos/builtin/packages/enzo/package.py
+++ b/var/spack/repos/builtin/packages/enzo/package.py
@@ -32,7 +32,7 @@ class Enzo(MakefilePackage):
     patch('for_aarch64.patch', when='target=aarch64:')
 
     # https://github.com/enzo-project/enzo-dev/pull/158
-    patch('https://github.com/enzo-project/enzo-dev/commit/0191ff5ad9ad2c7639d44823e84cd0115e7a2970.patch', sha256='01328a5f5fe72ac5af31661deb6891ea160264b67a470d6ce91b71b001845810', when='@2.6.1 ^hdf5@1.12.0:')
+    patch('https://github.com/enzo-project/enzo-dev/commit/0191ff5ad9ad2c7639d44823e84cd0115e7a2970.patch?full_index=1', sha256='f6db2fef04d3ffe4f05ef589d0593b2ab7ab6d63088abf9b76c7bacf835625c0', when='@2.6.1 ^hdf5@1.12.0:')
 
     def flag_handler(self, name, flags):
         if name == 'fflags':

--- a/var/spack/repos/builtin/packages/fdb/package.py
+++ b/var/spack/repos/builtin/packages/fdb/package.py
@@ -47,8 +47,8 @@ class Fdb(CMakePackage):
     patch('metkit_1.7.0.patch', when='@:5.7.10+tools^metkit@1.7.0:')
 
     # Download test data before running a test:
-    patch('https://github.com/ecmwf/fdb/commit/86e06b60f9a2d76a389a5f49bedd566d4c2ad2b2.patch',
-          sha256='e2254577e6d84a61d394eddcf42f894582f5daaf58d8962c609e41be0e3471b3',
+    patch('https://github.com/ecmwf/fdb/commit/86e06b60f9a2d76a389a5f49bedd566d4c2ad2b2.patch?full_index=1',
+          sha256='8b4bf3a473ec86fd4d7672faa7d74292dde443719299f2ba59a2c8501d6f0906',
           when='@5.7.1:5.7.10+tools')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/ferret/package.py
+++ b/var/spack/repos/builtin/packages/ferret/package.py
@@ -36,8 +36,8 @@ class Ferret(Package):
     depends_on("curl")
 
     # Make Java dependency optional with older versions of Ferret
-    patch('https://github.com/NOAA-PMEL/Ferret/commit/c7eb70a0b17045c8ca7207d586bfea77a5340668.patch',
-          sha256='5bd581db4578c013faed375844b206fbe71f93fe9ce60f8f9f41d64abc6a5972',
+    patch('https://github.com/NOAA-PMEL/Ferret/commit/c7eb70a0b17045c8ca7207d586bfea77a5340668.patch?full_index=1',
+          sha256='6dd0a6b11c103b0097fba3da06d6e655da9770e8f568a15968d9b64a0f3c2315',
           level=1, working_dir='FERRET', when='@:6')
 
     resource(name='datasets',

--- a/var/spack/repos/builtin/packages/flatbuffers/package.py
+++ b/var/spack/repos/builtin/packages/flatbuffers/package.py
@@ -41,9 +41,8 @@ class Flatbuffers(CMakePackage):
     # Silences false positive "-Wstringop-overflow" on GCC 10+
     # https://github.com/google/flatbuffers/issues/5950
     # Possibly affects earlier releases but I haven't tried to apply it.
-    patch('https://patch-diff.githubusercontent.com/raw/google/flatbuffers/pull/'
-          '6020.patch',
-          sha256='4a9a18abc776407f3f97e02c40f349cfb24fe7ddb41df952271d894777a31c88',
+    patch('https://github.com/google/flatbuffers/pull/6020.patch?full_index=1',
+          sha256='579cb6fa4430d4304b93c7a1df7e922f3c3ec614c445032877ad328c209d5462',
           when='@1.12.0:%gcc@10:')
 
     @run_after('install')

--- a/var/spack/repos/builtin/packages/flex/package.py
+++ b/var/spack/repos/builtin/packages/flex/package.py
@@ -49,7 +49,9 @@ class Flex(AutotoolsPackage):
     # - https://github.com/spack/spack/issues/8152
     # - https://github.com/spack/spack/issues/6942
     # - https://github.com/westes/flex/issues/241
-    patch('https://github.com/westes/flex/commit/24fd0551333e7eded87b64dd36062da3df2f6380.patch', sha256='09c22e5c6fef327d3e48eb23f0d610dcd3a35ab9207f12e0f875701c677978d3', when='@2.6.4')
+    patch('https://github.com/westes/flex/commit/24fd0551333e7eded87b64dd36062da3df2f6380.patch?full_index=1',
+          sha256='f8b85a00849bfb58c9b68e177b369f1e060ed8758253ff8daa57a873eae7b7a5',
+          when='@2.6.4')
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -256,7 +256,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         if macos_version() >= Version('10.14'):
             # Fix system headers for Mojave SDK:
             # https://github.com/Homebrew/homebrew-core/pull/39041
-            patch('https://raw.githubusercontent.com/Homebrew/formula-patches/master/gcc/8.3.0-xcode-bug-_Atomic-fix.patch',
+            patch('https://raw.githubusercontent.com/Homebrew/formula-patches/b8b8e65e/gcc/8.3.0-xcode-bug-_Atomic-fix.patch',
                   sha256='33ee92bf678586357ee8ab9d2faddf807e671ad37b97afdd102d5d153d03ca84',
                   when='@6:8.3')
         if macos_version() >= Version('10.15'):

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -187,8 +187,8 @@ class Gdal(AutotoolsPackage):
     conflicts('+pcre2', when='+pcre', msg='+pcre2 and +pcre are mutually exclusive')
 
     # https://github.com/OSGeo/gdal/issues/3782
-    patch('https://github.com/OSGeo/gdal/pull/3786.patch', when='@3.3.0', level=2,
-          sha256='5e14c530289bfa1257277357baa8d485f852ea480152fb150d152c85af8d01f8')
+    patch('https://github.com/OSGeo/gdal/pull/3786.patch?full_index=1', when='@3.3.0', level=2,
+          sha256='9f9824296e75b34b3e78284ec772a5ac8f8ba92c17253ea9ca242caf766767ce')
 
     executables = ['^gdal-config$']
 

--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -43,8 +43,8 @@ class Geos(CMakePackage):
 
     generator = 'Ninja'
 
-    patch('https://patch-diff.githubusercontent.com/raw/libgeos/geos/pull/461.patch',
-          sha256='58795ae79f168851f27aa488a589796f9a7563d368ffa32e1fe315eb71699877',
+    patch('https://github.com/libgeos/geos/pull/461.patch?full_index=1',
+          sha256='ab78db7ff2e8fc89e899b8233cf77d90b24d88940dd202c4219decba479c8d35',
           when='@3.8:')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/ghostscript/package.py
+++ b/var/spack/repos/builtin/packages/ghostscript/package.py
@@ -49,9 +49,9 @@ class Ghostscript(AutotoolsPackage):
     patch('nogoto.patch', when='%fj@:4.1.0')
 
     # Related bug report: https://bugs.ghostscript.com/show_bug.cgi?id=702985
-    patch("https://github.com/ArtifexSoftware/ghostpdl/commit/41ef9a0bc36b9db7115fbe9623f989bfb47bbade.patch",
+    patch("https://github.com/ArtifexSoftware/ghostpdl/commit/41ef9a0bc36b9db7115fbe9623f989bfb47bbade.patch?full_index=1",
           when='@:9.53.3^freetype@2.10.3:',
-          sha256="49c353106d97c40b3b2c78f72ce34e3eef66e6b04861c313f87bad11ab4189e6")
+          sha256="f3c2e56aa552a030c6db2923276ff2d140e39c511f92d9ef6c74a24776940af7")
 
     def url_for_version(self, version):
         baseurl = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs{0}/ghostscript-{1}.tar.gz"

--- a/var/spack/repos/builtin/packages/gotcha/package.py
+++ b/var/spack/repos/builtin/packages/gotcha/package.py
@@ -23,8 +23,8 @@ class Gotcha(CMakePackage):
 
     variant('test', default=False, description='Build tests for Gotcha')
     patch(
-        'https://github.com/LLNL/GOTCHA/commit/e82b4a1ecb634075d8f5334b796c888c86da0427.patch',
-        sha256='9f7814fd3c3362c156bc617c755e7e50c2f9125ed4540e36f60e4d93884f1ce6',
+        'https://github.com/LLNL/GOTCHA/commit/e82b4a1ecb634075d8f5334b796c888c86da0427.patch?full_index=1',
+        sha256='3f05e61b00a1cd53ebc489e9ca5dc70b9767068bba30dba973cdbef9b14774e6',
         when='@0.0.2:1.0.2')
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/h5z-zfp/package.py
+++ b/var/spack/repos/builtin/packages/h5z-zfp/package.py
@@ -25,8 +25,8 @@ class H5zZfp(MakefilePackage):
     depends_on('hdf5',         when='~fortran')
     depends_on('zfp bsws=8')
 
-    patch('https://github.com/LLNL/H5Z-ZFP/commit/983a1870cefff5fdb643898a14eda855c2c231e4.patch',
-          sha256='64a624880ca944ebcc174f66d739dd0458a6dab2f0bccc6ed99bf4c0c9b9e388', when='@1.0.1')
+    patch('https://github.com/LLNL/H5Z-ZFP/commit/983a1870cefff5fdb643898a14eda855c2c231e4.patch?full_index=1',
+          sha256='07a53b8b0d4c1df62a3f9f21b30ad0eb90f26b38eb6cacc0de6482fd8f5daea2', when='@1.0.1')
     patch('config.make.patch', when='@0.7.0:0.8.0')
     patch('config.make.0.7.0.patch', when='@0.7.0')
     patch('Makefile.0.7.0.patch', when='@0.7.0')

--- a/var/spack/repos/builtin/packages/hpcg/package.py
+++ b/var/spack/repos/builtin/packages/hpcg/package.py
@@ -23,8 +23,8 @@ class Hpcg(AutotoolsPackage):
 
     variant('openmp', default=True, description='Enable OpenMP support')
 
-    patch('https://github.com/hpcg-benchmark/hpcg/commit/e9e0b7e6cae23e1f30dd983c2ce2d3bd34d56f75.patch', sha256='23b9de83042eb7a8207fdddcfa79ae2cc1a17e8e623e2224c7751d7c328ee482', when='%gcc@9:')
-    patch('https://github.com/hpcg-benchmark/hpcg/commit/e9e0b7e6cae23e1f30dd983c2ce2d3bd34d56f75.patch', sha256='23b9de83042eb7a8207fdddcfa79ae2cc1a17e8e623e2224c7751d7c328ee482', when='%aocc')
+    patch('https://github.com/hpcg-benchmark/hpcg/commit/e9e0b7e6cae23e1f30dd983c2ce2d3bd34d56f75.patch?full_index=1', sha256='722c13837b287e979442f8372274aa5910a290aa39f1ed1ff646116be08dcae9', when='%gcc@9:')
+    patch('https://github.com/hpcg-benchmark/hpcg/commit/e9e0b7e6cae23e1f30dd983c2ce2d3bd34d56f75.patch?full_index=1', sha256='722c13837b287e979442f8372274aa5910a290aa39f1ed1ff646116be08dcae9', when='%aocc')
 
     depends_on('mpi@1.1:')
 

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -131,8 +131,8 @@ class Hpctoolkit(AutotoolsPackage):
     # Fix the build for old revs with gcc 10.x.
     patch('gcc10-enum.patch', when='@2020.01.01:2020.08 %gcc@10.0:')
 
-    patch('https://github.com/HPCToolkit/hpctoolkit/commit/511afd95b01d743edc5940c84e0079f462b2c23e.patch',
-          sha256='fd0fd7419f66a1feba8046cff9df7f27abce8629ee2708b8a9daa12c1b51243c',
+    patch('https://github.com/HPCToolkit/hpctoolkit/commit/511afd95b01d743edc5940c84e0079f462b2c23e.patch?full_index=1',
+          sha256='c8371b929f45dafae37d2ef17880fcfb86de893beebaec501a282bc04b61ef64',
           when='@2019.08.01:2021.03 %gcc@11.0:')
 
     flag_handler = AutotoolsPackage.build_system_flags

--- a/var/spack/repos/builtin/packages/icu4c/package.py
+++ b/var/spack/repos/builtin/packages/icu4c/package.py
@@ -38,8 +38,8 @@ class Icu4c(AutotoolsPackage):
     conflicts('%gcc@:4', when='@67.1:',
               msg="Older GCC compilers have immature C++11 support")
 
-    patch('https://github.com/unicode-org/icu/commit/ddfc30860354cbcb78c2c0bcf800be5ab44a9e4f.patch',
-          sha256='dfc501d78ddfabafe09dc1a7aa70f96b799164b18f6a57d616a9d48aaf989333',
+    patch('https://github.com/unicode-org/icu/commit/ddfc30860354cbcb78c2c0bcf800be5ab44a9e4f.patch?full_index=1',
+          sha256='6be0b8068b0f5047dad7f4f6f655529304f1abbc551c93223c6f41dafc1e8acc',
           level=2, when='@58.0:59')
 
     configure_directory = 'source'

--- a/var/spack/repos/builtin/packages/ior/package.py
+++ b/var/spack/repos/builtin/packages/ior/package.py
@@ -33,8 +33,8 @@ class Ior(AutotoolsPackage):
 
     # The build for 3.2.0 fails if hdf5 is enabled
     # See https://github.com/hpc/ior/pull/124
-    patch('https://github.com/hpc/ior/commit/1dbca5c293f95074f9887ddb2043fa984670fb4d.patch',
-          sha256='f28d6638a74a09e147e9fa870930e54a82ff580d1c232add47a67c375e255ada',
+    patch('https://github.com/hpc/ior/commit/1dbca5c293f95074f9887ddb2043fa984670fb4d.patch?full_index=1',
+          sha256='ce7fa0eabf408f9b712c478a08aa62d68737d213901707ef8cbfc3aec02e2713',
           when='@3.2.0 +hdf5')
 
     @run_before('autoreconf')

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -175,8 +175,8 @@ class Lammps(CMakePackage, CudaPackage):
 
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")
-    patch("https://github.com/lammps/lammps/commit/562300996285fdec4ef74542383276898555af06.patch",
-          sha256="7e1610dad4d8203b45ca6dc2c1f97d02a40f98a5e9778f51a3dbcc30ea1dc717",
+    patch("https://github.com/lammps/lammps/commit/562300996285fdec4ef74542383276898555af06.patch?full_index=1",
+          sha256="e6f1b62bbfdc79d632f4cea98019202d0dd25aa4ae61a70df1164cb4f290df79",
           when="@20200721 +cuda")
 
     root_cmakelists_dir = 'cmake'

--- a/var/spack/repos/builtin/packages/libfabric/package.py
+++ b/var/spack/repos/builtin/packages/libfabric/package.py
@@ -75,8 +75,8 @@ class Libfabric(AutotoolsPackage):
 
     # For version 1.9.0:
     # headers: fix forward-declaration of enum fi_collective_op with C++
-    patch('https://github.com/ofiwg/libfabric/commit/2e95b0efd85fa8a3d814128e34ec57ffd357460e.patch',
-          sha256='71f06e8bf0adeccd425b194ac524e4d596469e9dab9e7a4f8bb209e6b9a454f4',
+    patch('https://github.com/ofiwg/libfabric/commit/2e95b0efd85fa8a3d814128e34ec57ffd357460e.patch?full_index=1',
+          sha256='456693e28bb1fc41a0bbb94b97ae054e7d28f81ca94795d7f294243da58c6376',
           when='@1.9.0')
 
     depends_on('rdma-core', when='fabrics=verbs')

--- a/var/spack/repos/builtin/packages/libfuse/package.py
+++ b/var/spack/repos/builtin/packages/libfuse/package.py
@@ -51,10 +51,10 @@ class Libfuse(MesonPackage):
     patch('0001-Do-not-run-install-script.patch', when='@3: ~system_install')
     patch('https://src.fedoraproject.org/rpms/fuse3/raw/0519b7bf17c4dd1b31ee704d49f8ed94aa5ba6ab/f/fuse3-gcc11.patch', sha256='3ad6719d2393b46615b5787e71778917a7a6aaa189ba3c3e0fc16d110a8414ec', when='@3: %gcc@11:')
 
-    patch('https://github.com/libfuse/libfuse/commit/6d55007027dfe7b75a74899f497f075046cc5404.patch', sha256='d8c54ae932f2e7179dd05081a4a8e7aefd23553a0ef354fa25b1456386d96932', when='@:2')
-    patch('https://github.com/libfuse/libfuse/commit/5d38afc8a5b4a2a6e27aad7a1840046e99cd826d.patch', sha256='7f3e8e54966aca8cb64096bea2cbd4d2679b47f9c1355fe9d442ba8464d74372', when='@:2')
+    patch('https://github.com/libfuse/libfuse/commit/6d55007027dfe7b75a74899f497f075046cc5404.patch?full_index=1', sha256='2e265d31628175ce9dcea1ca2e423fdbed9469e2ace6b24a7fe7a72cb54b1da9', when='@:2')
+    patch('https://github.com/libfuse/libfuse/commit/5d38afc8a5b4a2a6e27aad7a1840046e99cd826d.patch?full_index=1', sha256='6b7ea8451d29944adb2fdc1bd119c93e74fe54431b1315f148a071015343ec1a', when='@:2')
     # https://bugs.gentoo.org/803923
-    patch('https://github.com/libfuse/libfuse/commit/5a43d0f724c56f8836f3f92411e0de1b5f82db32.patch', sha256='1e8b0a1b2bbaa335d92a3c46e31c928dcd53abe011214a0cbbfa7c11a3a68f1a', when='@:2')
+    patch('https://github.com/libfuse/libfuse/commit/5a43d0f724c56f8836f3f92411e0de1b5f82db32.patch?full_index=1', sha256='94d5c6d9785471147506851b023cb111ef2081d1c0e695728037bbf4f64ce30a', when='@:2')
 
     executables = ['^fusermount3?$']
 

--- a/var/spack/repos/builtin/packages/libgeotiff/package.py
+++ b/var/spack/repos/builtin/packages/libgeotiff/package.py
@@ -36,11 +36,11 @@ class Libgeotiff(AutotoolsPackage):
 
     # Patches required to fix rounding issues in unit tests
     # https://github.com/OSGeo/libgeotiff/issues/16
-    patch('https://github.com/OSGeo/libgeotiff/commit/7cb9b68ea72fb2a6023bb98796fd3ba6dc7b64a1.patch',
-          sha256='9485efc0a62a02207d34ac0c4d22e421c975b6ce85397c5e557c0105a232aaa3',
+    patch('https://github.com/OSGeo/libgeotiff/commit/7cb9b68ea72fb2a6023bb98796fd3ba6dc7b64a1.patch?full_index=1',
+          sha256='bae1441ba8cd1d4e94b8d6a080db64b768dd537faa7e2fb8c04133f68e71d304',
           level=2, when='@1.5.0:1.5.1')
-    patch('https://github.com/OSGeo/libgeotiff/commit/4b41ca6ce332f0c21504c2da3da850275d9da5ae.patch',
-          sha256='e0d45d3c34bf92df2d1d140957f110dc84759420e68a97e1e3d6ab90c81777d8',
+    patch('https://github.com/OSGeo/libgeotiff/commit/4b41ca6ce332f0c21504c2da3da850275d9da5ae.patch?full_index=1',
+          sha256='b368cdf5755f2ddf69d974bf86691440dcc861c41d86280780626f5a31f33b13',
           level=2, when='@1.5.0:1.5.1')
     # Patch required to fix absolute path issue in unit tests
     # https://github.com/OSGeo/libgeotiff/issues/16

--- a/var/spack/repos/builtin/packages/libogg/package.py
+++ b/var/spack/repos/builtin/packages/libogg/package.py
@@ -19,6 +19,6 @@ class Libogg(AutotoolsPackage):
 
     # Backport a patch that fixes an unsigned typedef problem on macOS:
     # https://github.com/xiph/ogg/pull/64
-    patch('https://github.com/xiph/ogg/commit/c8fca6b4a02d695b1ceea39b330d4406001c03ed.patch',
-          sha256='c66dcf5dd775752148e664b262f98ea9fda7ed204ed40d64e3769c036e3c2c98',
+    patch('https://github.com/xiph/ogg/commit/c8fca6b4a02d695b1ceea39b330d4406001c03ed.patch?full_index=1',
+          sha256='0f4d289aecb3d5f7329d51f1a72ab10c04c336b25481a40d6d841120721be485',
           when='@1.3.4 platform=darwin')

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -56,7 +56,7 @@ class Libzmq(AutotoolsPackage):
     conflicts('%gcc@8:', when='@:4.2.2')
 
     # Fix aggressive compiler warning false positive
-    patch('https://github.com/zeromq/libzmq/commit/92b2c38a2c51a1942a380c7ee08147f7b1ca6845.patch', sha256='8ebde83ee148989f9118d36ebaf256532627b8a6e7a486842110623331972edb', when='@4.2.3:4.3.4 %gcc@11:')
+    patch('https://github.com/zeromq/libzmq/commit/92b2c38a2c51a1942a380c7ee08147f7b1ca6845.patch?full_index=1', sha256='310b8aa57a8ea77b7ac74debb3bf928cbafdef5e7ca35beaac5d9c61c7edd239', when='@4.2.3:4.3.4 %gcc@11:')
 
     def url_for_version(self, version):
         if version <= Version('4.1.4'):

--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -35,16 +35,16 @@ class Likwid(Package):
     version('4.3.1', sha256='4b40a96717da54514274d166f9b71928545468091c939c1d74109733279eaeb1')
     version('4.3.0', sha256='86fc5f82c80fcff1a643394627839ec79f1ca2bcfad30000eb7018da592588b4')
 
-    patch('https://github.com/RRZE-HPC/likwid/commit/e0332ace8fe8ca7dcd4b4477a25e37944f173a5c.patch',
+    patch('https://github.com/RRZE-HPC/likwid/commit/e0332ace8fe8ca7dcd4b4477a25e37944f173a5c.patch?full_index=1',
           when='@5.0.1',
-          sha256='c3b8f939a46b425665577ce764d4fba080a23cab5999c53db71655fd54d7e0b1')
-    patch('https://github.com/RRZE-HPC/likwid/commit/d2d0ef333b5e0997d7c80fc6ac1a473b5e47d084.patch',
+          sha256='13211de1b9f256b547e1565240c2c9d063855b17d70bd7379442789aa3424246')
+    patch('https://github.com/RRZE-HPC/likwid/commit/d2d0ef333b5e0997d7c80fc6ac1a473b5e47d084.patch?full_index=1',
           when='@4.3.4',
-          sha256='636cbf40669261fdb36379d67253be2b731cfa7b6d610d232767d72fbdf08bc0')
+          sha256='f14cd6bc5870e4665fe465dabaff965a5fdee19c6d669a1ec5ce2b143dcdde4b')
     patch('https://github.com/RRZE-HPC/likwid/files/5341379/likwid-lua5.1.patch.txt',
           when='@5.0.2^lua@5.1',
           sha256='bc56253c1e3436b5ba7bf4c5533d0391206900c8663c008f771a16376975e416')
-    patch('https://github.com/RRZE-HPC/likwid/releases/download/v5.1.0/likwid-mpirun-5.1.0.patch',
+    patch('https://github.com/RRZE-HPC/likwid/releases/download/v5.1.0/likwid-mpirun-5.1.0.patch?full_index=1',
           when='@5.1.0',
           sha256='62da145da0a09de21020f9726290e1daf7437691bab8a92d7254bc192d5f3061')
     variant('fortran', default=True, description='with fortran interface')

--- a/var/spack/repos/builtin/packages/madx/package.py
+++ b/var/spack/repos/builtin/packages/madx/package.py
@@ -24,8 +24,8 @@ class Madx(CMakePackage):
     variant('x11', default=True, description='Turn on plotting using X11')
 
     # patch for gcc-11 to avoid error due to variable shadowing
-    patch('https://github.com/MethodicalAcceleratorDesign/MAD-X/commit/e7a434290df675b894f70026ce0c7c217330cce5.patch',
-          sha256='ba9d00692250ab1eeeb7235a4ba7d899ecbbb4588f3ec08afc22d228dc1ea437',
+    patch('https://github.com/MethodicalAcceleratorDesign/MAD-X/commit/e7a434290df675b894f70026ce0c7c217330cce5.patch?full_index=1',
+          sha256='d09c26f10b6b69d2cb209fee317f90804d92b419026d5181007559119daf33f6',
           when='@:5.07.00')
 
     depends_on('cmake@2.8:', type='build')

--- a/var/spack/repos/builtin/packages/mariadb-c-client/package.py
+++ b/var/spack/repos/builtin/packages/mariadb-c-client/package.py
@@ -61,8 +61,8 @@ class MariadbCClient(CMakePackage):
     depends_on('krb5')
 
     # patch needed for cmake-3.20
-    patch('https://github.com/mariadb-corporation/mariadb-connector-c/commit/242cab8c.patch',
-          sha256='bcfa0a73a34654495f5dea3cecdcb7de911c7c2446240aeaa674a4b2ab46f58c', when='@:3.1.12')
+    patch('https://github.com/mariadb-corporation/mariadb-connector-c/commit/242cab8c.patch?full_index=1',
+          sha256='760fd19cd8d4d756a0799ed9110cfd2898237e43835fefe3668079c5b87fc36d', when='@:3.1.12')
 
     def url_for_version(self, version):
         url = "https://downloads.mariadb.com/Connectors/c/connector-c-{0}/mariadb-connector-c-{1}-src.tar.gz"

--- a/var/spack/repos/builtin/packages/mariadb/package.py
+++ b/var/spack/repos/builtin/packages/mariadb/package.py
@@ -62,8 +62,8 @@ class Mariadb(CMakePackage):
     conflicts('%gcc@9.1.0:', when='@:5.5')
 
     # patch needed for cmake-3.20
-    patch('https://github.com/mariadb-corporation/mariadb-connector-c/commit/242cab8c.patch',
-          sha256='bcfa0a73a34654495f5dea3cecdcb7de911c7c2446240aeaa674a4b2ab46f58c',
+    patch('https://github.com/mariadb-corporation/mariadb-connector-c/commit/242cab8c.patch?full_index=1',
+          sha256='760fd19cd8d4d756a0799ed9110cfd2898237e43835fefe3668079c5b87fc36d',
           working_dir='libmariadb',
           when='@10.2.8:10.4.12')
 

--- a/var/spack/repos/builtin/packages/mongo-c-driver/package.py
+++ b/var/spack/repos/builtin/packages/mongo-c-driver/package.py
@@ -35,7 +35,9 @@ class MongoCDriver(Package):
     variant('zlib', default=True, description='Enable zlib support.')
     variant('zstd', default=True, description='Enable zstd support.')
 
-    patch('https://github.com/mongodb/mongo-c-driver/pull/466.patch', sha256='713a872217d11aba04a774785a2824d26b566543c270a1fa386114f5200fda20', when='@1.8.1')
+    patch('https://github.com/mongodb/mongo-c-driver/pull/466.patch?full_index=1',
+          sha256='d8802d91226c176ba46d5b82413757121331d556a3a3d57ab65b70e175cab296',
+          when='@1.8.1')
 
     depends_on('cmake@3.1:', type='build', when='@1.10.0:')
 

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -104,8 +104,8 @@ with '-Wl,-commons,use_dylibs' and without
     # See https://github.com/pmodels/mpich/issues/4038
     # and https://github.com/pmodels/mpich/pull/3540
     # landed in v3.4b1 v3.4a3
-    patch('https://github.com/pmodels/mpich/commit/8a851b317ee57366cd15f4f28842063d8eff4483.patch',
-          sha256='eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774',
+    patch('https://github.com/pmodels/mpich/commit/8a851b317ee57366cd15f4f28842063d8eff4483.patch?full_index=1',
+          sha256='d2dafc020941d2d8cab82bc1047e4a6a6d97736b62b06e2831d536de1ac01fd0',
           when='@3.3:3.3.99 +hwloc')
 
     # fix MPI_Barrier segmentation fault
@@ -119,8 +119,8 @@ with '-Wl,-commons,use_dylibs' and without
     # and https://github.com/pmodels/mpich/pull/3578
     # Even though there is no version 3.3.0, we need to specify 3.3:3.3.0 in
     # the when clause, otherwise the patch will be applied to 3.3.1, too.
-    patch('https://github.com/pmodels/mpich/commit/b324d2de860a7a2848dc38aefb8c7627a72d2003.patch',
-          sha256='c7d4ecf865dccff5b764d9c66b6a470d11b0b1a5b4f7ad1ffa61079ad6b5dede',
+    patch('https://github.com/pmodels/mpich/commit/b324d2de860a7a2848dc38aefb8c7627a72d2003.patch?full_index=1',
+          sha256='5f48d2dd8cc9f681cf710b864f0d9b00c599f573a75b1e1391de0a3d697eba2d',
           when='@3.3:3.3.0')
 
     # This patch for Libtool 2.4.2 enables shared libraries for NAG and is

--- a/var/spack/repos/builtin/packages/mumax/package.py
+++ b/var/spack/repos/builtin/packages/mumax/package.py
@@ -35,8 +35,8 @@ class Mumax(MakefilePackage, CudaPackage):
 
     conflicts('~cuda', msg='mumax requires cuda')
 
-    patch('https://github.com/mumax/3/commit/2cf5c9a6985c9eb16a124c6bd96aed75b4a30c24.patch',
-          sha256='a43b2ca6c9f9edfb1fd6d916a599f85a57c8bb3f9ee38148b1988fd82feec8ad',
+    patch('https://github.com/mumax/3/commit/2cf5c9a6985c9eb16a124c6bd96aed75b4a30c24.patch?full_index=1',
+          sha256='4bbb95aacdac7e2cbcb37ee8adcfb9464e69965f984c264ff094dc1cca10589b',
           when='@3.10beta')
 
     @property

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -42,10 +42,16 @@ class NetcdfC(AutotoolsPackage):
 
     # configure fails if curl is not installed.
     # See https://github.com/Unidata/netcdf-c/issues/1390
-    patch('https://github.com/Unidata/netcdf-c/commit/e5315da1e748dc541d50796fb05233da65e86b6b.patch', sha256='10a1c3f7fa05e2c82457482e272bbe04d66d0047b237ad0a73e87d63d848b16c', when='@4.7.0')
+    patch('https://github.com/Unidata/netcdf-c/commit/e5315da1e748dc541d50796fb05233da65e86b6b.patch?full_index=1',
+          sha256='c551ca2f5b6bcefa07dd7f8b7bac426a5df9861e091df1ab99167d8d401f963f',
+          when='@4.7.0')
     # fix headers
-    patch('https://github.com/Unidata/netcdf-c/pull/1505.patch', sha256='f52db13c61b9c19aafe03c2a865163b540e9f6dee36e3a5f808f05fac59f2030', when='@4.7.2')
-    patch('https://github.com/Unidata/netcdf-c/pull/1508.patch', sha256='56532470875b9a97f3cf2a7d9ed16ef1612df3265ee38880c109428322ff3a40', when='@4.7.2')
+    patch('https://github.com/Unidata/netcdf-c/pull/1505.patch?full_index=1',
+          sha256='495b3e5beb7f074625bcec2ca76aebd339e42719e9c5ccbedbdcc4ffb81a7450',
+          when='@4.7.2')
+    patch('https://github.com/Unidata/netcdf-c/pull/1508.patch?full_index=1',
+          sha256='19e7f31b96536928621b1c29bb6d1a57bcb7aa672cea8719acf9ac934cdd2a3e',
+          when='@4.7.2')
 
     # See https://github.com/Unidata/netcdf-c/pull/1752
     patch('4.7.3-spectrum-mpi-pnetcdf-detect.patch', when='@4.7.3:4.7.4 +parallel-netcdf')

--- a/var/spack/repos/builtin/packages/ocaml/package.py
+++ b/var/spack/repos/builtin/packages/ocaml/package.py
@@ -31,8 +31,9 @@ class Ocaml(Package):
     # #9969, #9981: Added mergeable flag to ELF sections containing mergeable
     # constants.  Fixes compatibility with the integrated assembler in clang 11.0.0.
     # (Jacob Young, review by Nicolas Ojeda Bar)
-    patch('https://patch-diff.githubusercontent.com/raw/ocaml/ocaml/pull/9981.patch',
-          sha256='3b1ca67eb124f5460a077d9575f579ef9d2f0416424761ae9d6c701550c5b75b', when="@:4.11.0 %clang@11:")
+    patch('https://github.com/ocaml/ocaml/pull/9981.patch?full_index=1',
+          sha256='12700c697f0d5227e8eddd62e4308ec3cd67c0a5a5a1b7eec376686a5fd63a5c',
+          when="@:4.11.0 %clang@11:")
     depends_on('ncurses')
 
     sanity_check_file = ['bin/ocaml']

--- a/var/spack/repos/builtin/packages/ocl-icd/package.py
+++ b/var/spack/repos/builtin/packages/ocl-icd/package.py
@@ -47,8 +47,8 @@ OpenCL ICD loaders."""
 
     # upstream patch to fix compatibility with the latest version of the
     # official khronos OpenCL C headers release, ie opencl-c-headers@2021.04.29
-    patch('https://github.com/OCL-dev/ocl-icd/commit/aed1832c81c0971ea001e12d41e04df834257f94.patch',
-          sha256='c6bb2813e2a59ac9b79b86d7f421c3e6446c0f9d8a4c850e5641fb7273ab3b43', when='@2.3.0')
+    patch('https://github.com/OCL-dev/ocl-icd/commit/aed1832c81c0971ea001e12d41e04df834257f94.patch?full_index=1',
+          sha256='90fef5c4b341848c82d484a2329339c4762c2451259378fbda60cc86b3216616', when='@2.3.0')
 
     def flag_handler(self, name, flags):
         if name == 'cflags' and self.spec.satisfies('@:2.2.12'):

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -93,14 +93,14 @@ class Openblas(MakefilePackage):
     # https://github.com/xianyi/OpenBLAS/issues/1735#issuecomment-422954465
     # https://github.com/xianyi/OpenBLAS/issues/1761#issuecomment-421039174
     # https://github.com/xianyi/OpenBLAS/pull/1765
-    patch('https://github.com/xianyi/OpenBLAS/commit/4d183e5567346f80f2ef97eb98f8601c47f8cb56.patch',
-          sha256='714aea33692304a50bd0ccde42590c176c82ded4a8ac7f06e573dc8071929c33',
+    patch('https://github.com/xianyi/OpenBLAS/commit/4d183e5567346f80f2ef97eb98f8601c47f8cb56.patch?full_index=1',
+          sha256='9b02860bd78252ed9f09abb65a62fff22c0aeca002757d503f5b643a11b744bf',
           when='@0.3.3')
 
     # Fix parallel build issues on filesystems
     # with missing sub-second timestamp resolution
-    patch('https://github.com/xianyi/OpenBLAS/commit/79ea839b635d1fd84b6ce8a47e086f01d64198e6.patch',
-          sha256='f1b066a4481a50678caeb7656bf3e6764f45619686ac465f257c8017a2dc1ff0',
+    patch('https://github.com/xianyi/OpenBLAS/commit/79ea839b635d1fd84b6ce8a47e086f01d64198e6.patch?full_index=1',
+          sha256='1cbadd897d037e6015384aaad70efe0d9eac4382482ee01e3fbe89cde2a1ebea',
           when='@0.3.0:0.3.3')
 
     # Fix https://github.com/xianyi/OpenBLAS/issues/2431
@@ -114,8 +114,8 @@ class Openblas(MakefilePackage):
     # should be included in post 0.3.10 versions. Application to earlier
     # versions was not tested.
     # See also https://github.com/xianyi/OpenBLAS/issues/2870
-    patch('https://github.com/xianyi/OpenBLAS/commit/f42e84d46c52f4ee1e05af8f365cd85de8a77b95.patch',
-          sha256='7b1eec78d1b1f55d3a3f1249696be7da0e2e1cd3b7fadae852e97dc860f8a7fd',
+    patch('https://github.com/xianyi/OpenBLAS/commit/f42e84d46c52f4ee1e05af8f365cd85de8a77b95.patch?full_index=1',
+          sha256='d38396ed602c3b655ad8cfc3d70b72726c567643578bf65466527f3a57bbd495',
           when='@0.3.8:0.3.10 %apple-clang@12.0.0:')
 
     # Add conditions to f_check to determine the Fujitsu compiler

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -108,16 +108,16 @@ class OpenfoamOrg(Package):
     assets = ['bin/foamEtcFile']
 
     # Version-specific patches
-    patch('https://github.com/OpenFOAM/OpenFOAM-7/commit/ef33cf38ac9b811072a8970c71fbda35a90f6641.patch',
-          sha256='73103e6b1bdbf3b1e0d517cbbd11562e98c6e9464df5f43e5125e9a5b457d1c5', when='@7')
+    patch('https://github.com/OpenFOAM/OpenFOAM-7/commit/ef33cf38ac9b811072a8970c71fbda35a90f6641.patch?full_index=1',
+          sha256='05d17e17f94e6fe8188a9c0b91ed34c9b62259414589d908c152a4c40fe6b7e2', when='@7')
     patch('50-etc.patch', when='@5.0:5.9')
     patch('41-etc.patch', when='@4.1')
     patch('41-site.patch', when='@4.1:')
     patch('240-etc.patch', when='@:2.4.0')
     patch('isnan.patch', when='@:2.4.0')
     # Add support for SYSTEMMPI
-    patch('https://github.com/OpenFOAM/OpenFOAM-2.3.x/commit/ae9a670c99472787f3a5446ac2b522bf3519b796.patch',
-          sha256='6c4c535baca3ce64035d512265c4ce8effd39de7602c923c5e19985db68b632a', when='@:2.3.1')
+    patch('https://github.com/OpenFOAM/OpenFOAM-2.3.x/commit/ae9a670c99472787f3a5446ac2b522bf3519b796.patch?full_index=1',
+          sha256='7e843fa2533d12f392d9d5389daa6f08ef68a8d329438b53e7aa204bc710bf57', when='@:2.3.1')
 
     # The openfoam architecture, compiler information etc
     _foam_arch = None

--- a/var/spack/repos/builtin/packages/p4est/package.py
+++ b/var/spack/repos/builtin/packages/p4est/package.py
@@ -39,12 +39,12 @@ class P4est(AutotoolsPackage):
     depends_on('zlib')
 
     # from sc upstream, correct the default libraries
-    patch('https://github.com/cburstedde/libsc/commit/b506aab224b988fec210cc212469f2c4f58b2d04.patch',
-          sha256='e9418b1a9347a409be241cd185519b31950e42a7f55b6fb80ce53097657098ee',
+    patch('https://github.com/cburstedde/libsc/commit/b506aab224b988fec210cc212469f2c4f58b2d04.patch?full_index=1',
+          sha256='e03437c5b580deacdfa0e8112d0a3d40af1f5e4757fe1dd00347d0523f6c16d5',
           working_dir='sc',
           when='@2.0')
-    patch('https://github.com/cburstedde/libsc/commit/b45a51a7ef97883a3d4dcbd05cb2c77890a76f75.patch',
-          sha256='8fb829e34e3a1e28afdd6e56e0bdc1d377af569b7ccb9e9d8da0eeb5829ed27e',
+    patch('https://github.com/cburstedde/libsc/commit/b45a51a7ef97883a3d4dcbd05cb2c77890a76f75.patch?full_index=1',
+          sha256='f5c9f784408481b12babd802cc3bedde2a8c4f84de4fd58c54017690b7520a01',
           working_dir='sc',
           when='@2.0')
 

--- a/var/spack/repos/builtin/packages/py-astor/package.py
+++ b/var/spack/repos/builtin/packages/py-astor/package.py
@@ -22,6 +22,6 @@ class PyAstor(PythonPackage):
     # Build fails with newer versions of setuptools
     # https://github.com/berkerpeksag/astor/issues/162
     # https://github.com/berkerpeksag/astor/pull/163
-    patch('https://github.com/berkerpeksag/astor/pull/163/commits/30059dac4eb832e58ab2109db84508b294ba366d.patch',
+    patch('https://github.com/berkerpeksag/astor/pull/163/commits/30059dac4eb832e58ab2109db84508b294ba366d.patch?full_index=1',
           sha256='edc5eeddabe153b08e938f52edaeb2d880ee3128082967f310db0f98510fe6e0',
           when='@0.8.0')

--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -37,8 +37,8 @@ class PyShapely(PythonPackage):
     depends_on('py-pytest-cov', type='test')
 
     # https://github.com/Toblerity/Shapely/pull/891
-    patch('https://github.com/Toblerity/Shapely/commit/98f6b36710bbe05b4ab59231cb0e08b06fe8b69c.patch',
-          sha256='4984cd0590beb5091f213948a953f70cea08ea11c5db1de07ba98c19e3d13f06',
+    patch('https://github.com/Toblerity/Shapely/commit/98f6b36710bbe05b4ab59231cb0e08b06fe8b69c.patch?full_index=1',
+          sha256='8583cdc97648277fa4faea8bd88d49e43390e87f697b966bd2b4290fba945ba0',
           when='@:1.7.0')
 
     @when('^python@3.7:')

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -330,8 +330,8 @@ class PyTensorflow(Package, CudaPackage):
     patch('1-1_fcc_tf_patch.patch', when='@2.1.0:2.1%fj')
 
     # do not import contrib.cloud if not available
-    patch('https://github.com/tensorflow/tensorflow/commit/ed62ac8203999513dfae03498e871ea35eb60cc4.patch',
-          sha256='c37d14622a86b164e2411ea45a04f756ac61b2044d251f19ab17733c508e5305', when='@1.14.0')
+    patch('https://github.com/tensorflow/tensorflow/commit/ed62ac8203999513dfae03498e871ea35eb60cc4.patch?full_index=1',
+          sha256='ff02e249532a5661b123108734a39534992d81da90f0c8187bf4e151a865effc', when='@1.14.0')
     # import_contrib_cloud patch for older versions
     patch('contrib_cloud_1.10.patch', when='@1.10:1.13')
     patch('contrib_cloud_1.9.patch', when='@1.9')

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -170,13 +170,13 @@ class PyTorch(PythonPackage, CudaPackage):
 
     # Fix BLAS being overridden by MKL
     # https://github.com/pytorch/pytorch/issues/60328
-    patch('https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/59220.patch',
-          sha256='e37afffe45cf7594c22050109942370e49983ad772d12ebccf508377dc9dcfc9',
+    patch('https://github.com/pytorch/pytorch/pull/59220.patch?full_index=1',
+          sha256='6d5717267f901e8ee493dfacd08734d9bcc48ad29a76ca9ef702368e96bee675',
           when='@1.2:')
 
     # Fixes build on older systems with glibc <2.12
-    patch('https://patch-diff.githubusercontent.com/raw/pytorch/pytorch/pull/55063.patch',
-          sha256='e17eaa42f5d7c18bf0d7c37d7b0910127a01ad53fdce3e226a92893356a70395',
+    patch('https://github.com/pytorch/pytorch/pull/55063.patch?full_index=1',
+          sha256='2229bcbf20fbe88aa9f7318f89c126ec7f527875ffe689a763c78abfa127a65c',
           when='@1.1:1.8.1')
 
     # Fixes CMake configuration error when XNNPACK is disabled
@@ -194,8 +194,8 @@ class PyTorch(PythonPackage, CudaPackage):
 
     # Fixes compilation with Clang 9.0.0 and Apple Clang 11.0.3
     # https://github.com/pytorch/pytorch/pull/37086
-    patch('https://github.com/pytorch/pytorch/commit/e921cd222a8fbeabf5a3e74e83e0d8dfb01aa8b5.patch',
-          sha256='17561b16cd2db22f10c0fe1fdcb428aecb0ac3964ba022a41343a6bb8cba7049',
+    patch('https://github.com/pytorch/pytorch/commit/e921cd222a8fbeabf5a3e74e83e0d8dfb01aa8b5.patch?full_index=1',
+          sha256='0f3ad037a95af9d34b1d085050c1e7771fd00f0b89e5b3a276097b7c9f4fabf8',
           when='@1.1:1.5')
 
     # Removes duplicate definition of getCusparseErrorString
@@ -208,8 +208,8 @@ class PyTorch(PythonPackage, CudaPackage):
 
     # Fix compilation of +distributed~tensorpipe
     # https://github.com/pytorch/pytorch/issues/68002
-    patch('https://github.com/pytorch/pytorch/commit/c075f0f633fa0136e68f0a455b5b74d7b500865c.patch',
-          sha256='e69e41b5c171bfb00d1b5d4ee55dd5e4c8975483230274af4ab461acd37e40b8', when='@1.10.0+distributed~tensorpipe')
+    patch('https://github.com/pytorch/pytorch/commit/c075f0f633fa0136e68f0a455b5b74d7b500865c.patch?full_index=1',
+          sha256='41271e494a3a60a65a8dd45ac053d1a6e4e4d5b42c2dac589ac67524f61ac41e', when='@1.10.0+distributed~tensorpipe')
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -188,18 +188,18 @@ class Qmcpack(CMakePackage, CudaPackage):
 
     # Backport several patches from recent versions of QMCPACK
     # The test_numerics unit test is broken prior to QMCPACK 3.3.0
-    patch_url = 'https://patch-diff.githubusercontent.com/raw/QMCPACK/qmcpack/pull/621.patch'
-    patch_checksum = 'e2ff7a6f0f006856085d4aab6d31f32f16353e41f760a33a7ef75f3ecce6a5d6'
+    patch_url = 'https://github.com/QMCPACK/qmcpack/pull/621.patch?full_index=1'
+    patch_checksum = '54484b722df264dae3fd0c1094883b17431617e278eeba2cffbd720b36c9e21a'
     patch(patch_url, sha256=patch_checksum, when='@3.1.0:3.3.0')
 
     # FindMKL.cmake has an issues prior to QMCPACK 3.3.0
-    patch_url = 'https://patch-diff.githubusercontent.com/raw/QMCPACK/qmcpack/pull/623.patch'
-    patch_checksum = '3eb9dec05fd1a544318ff84cd8b5926cfc6b46b375c7f3b012ccf0b50cf617b7'
+    patch_url = 'https://github.com/QMCPACK/qmcpack/pull/623.patch?full_index=1'
+    patch_checksum = '9e444d627ab22ad5f31797aec0c0d662463055955eff1c84fbde274e0259db6b'
     patch(patch_url, sha256=patch_checksum, when='@3.1.0:3.3.0')
 
     # git-rev files for not git builds issues prior to QMCPACK 3.3.0
-    patch_url = 'https://patch-diff.githubusercontent.com/raw/QMCPACK/qmcpack/pull/643.patch'
-    patch_checksum = 'c066c79901a612cf8848135e0d544efb114534cca70b90bfccc8ed989d3d9dde'
+    patch_url = 'https://github.com/QMCPACK/qmcpack/pull/643.patch?full_index=1'
+    patch_checksum = 'd6410e7843f6c062bf9aa8ecf107e573b35c32022927d63f8cf5ad36ccf873c3'
     patch(patch_url, sha256=patch_checksum, when='@3.1.0:3.3.0')
 
     # the default flag_handler for Spack causes problems for QMCPACK

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -118,8 +118,8 @@ class Qt(Package):
     # https://bugreports.qt.io/browse/QTBUG-58038
     patch('qt5-8-freetype.patch', when='@5.8.0 +gui')
     # https://codereview.qt-project.org/c/qt/qtbase/+/245425
-    patch('https://github.com/qt/qtbase/commit/a52d7861edfb5956de38ba80015c4dd0b596259b.patch',
-          sha256='c49b228c27e3ad46ec3af4bac0e9985af5b5b28760f238422d32e14f98e49b1e',
+    patch('https://github.com/qt/qtbase/commit/a52d7861edfb5956de38ba80015c4dd0b596259b.patch?full_index=1',
+          sha256='c113b4e31fc648d15d6d401f7625909d84f88320172bd1fbc5b100cc2cbf71e9',
           working_dir='qtbase',
           when='@5.10:5.12.0 %gcc@9:')
     # https://github.com/Homebrew/homebrew-core/pull/5951

--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -220,30 +220,30 @@ class QuantumEspresso(CMakePackage):
               msg='6.4.x is the latest QE series supported by Environ')
 
     # 7.0
-    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-7.0.diff'
+    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-7.0.diff'
     patch_checksum = 'ef60641d8b953b4ba21d9c662b172611305bb63786996ad6e81e7609891677ff'
     patch(patch_url, sha256=patch_checksum, when='@7.0+qmcpack')
 
     # 6.8
-    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.8.diff'
+    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.8.diff'
     patch_checksum = '69f7fbd72aba810c35a0b034188e45bea8f9f11d3150c0715e1b3518d5c09248'
     patch(patch_url, sha256=patch_checksum, when='@6.8+qmcpack')
 
     # 6.7
-    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.7.0.diff'
+    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.7.0.diff'
     patch_checksum = '72564c168231dd4a1279a74e76919af701d47cee9a851db6e205753004fe9bb5'
     patch(patch_url, sha256=patch_checksum, when='@6.7+qmcpack')
 
     # 6.4.1
-    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.4.1.diff'
+    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.4.1.diff'
     patch_checksum = '57cb1b06ee2653a87c3acc0dd4f09032fcf6ce6b8cbb9677ae9ceeb6a78f85e2'
     patch(patch_url, sha256=patch_checksum, when='@6.4.1+qmcpack')
     # 6.4
-    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.4.diff'
+    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.4.diff'
     patch_checksum = 'ef08f5089951be902f0854a4dbddaa7b01f08924cdb27decfade6bef0e2b8994'
     patch(patch_url, sha256=patch_checksum, when='@6.4:6.4.0+qmcpack')
     # 6.3
-    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/develop/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.3.diff'
+    patch_url = 'https://raw.githubusercontent.com/QMCPACK/qmcpack/v3.13.0/external_codes/quantum_espresso/add_pw2qmcpack_to_qe-6.3.diff'
     patch_checksum = '2ee346e24926479f5e96f8dc47812173a8847a58354bbc32cf2114af7a521c13'
     patch(patch_url, sha256=patch_checksum, when='@6.3+qmcpack')
 

--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -38,8 +38,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     version('0.4.0', tag='v0.4.0', submodules="True")
 
     # export targets when building pre-2.4.0 release with BLT 0.4.0+
-    patch('https://github.com/LLNL/RAJA/commit/eca1124ee4af380d6613adc6012c307d1fd4176b.patch',
-          sha256='57dd531a50ac791b4bb214d34a4bf3fca1349354927c72915b7ccd20524701a9',
+    patch('https://github.com/LLNL/RAJA/commit/eca1124ee4af380d6613adc6012c307d1fd4176b.patch?full_index=1',
+          sha256='12bb78c00b6683ad3e7fd4e3f87f9776bae074b722431b79696bc862816735ef',
           when='@:0.13.0 ^blt@0.4:')
 
     variant('openmp', default=True, description='Build OpenMP backend')

--- a/var/spack/repos/builtin/packages/samrai/package.py
+++ b/var/spack/repos/builtin/packages/samrai/package.py
@@ -63,7 +63,7 @@ class Samrai(AutotoolsPackage):
     patch('no-tool-build.patch', when='@3.0.0:%gcc')
 
     # 2.4.4 needs a lot of patches to fix ADL and performance problems
-    patch('https://github.com/IBAMR/IBAMR/releases/download/v0.3.0/ibamr-samrai-fixes.patch',
+    patch('https://github.com/IBAMR/IBAMR/releases/download/v0.3.0/ibamr-samrai-fixes.patch?full_index=1',
           sha256='1d088b6cca41377747fa0ae8970440c20cb68988bbc34f9032d5a4e6aceede47',
           when='@2.4.4')
 

--- a/var/spack/repos/builtin/packages/slurm-drmaa/package.py
+++ b/var/spack/repos/builtin/packages/slurm-drmaa/package.py
@@ -24,8 +24,8 @@ class SlurmDrmaa(AutotoolsPackage):
     version('1.1.2', sha256='5bfe25d501de83729df3c8c8f28535b9da3e99aea7738e259903abd6f1f5c836')
 
     # Remove this patch when it is merged into main:
-    patch('https://patch-diff.githubusercontent.com/raw/natefoo/slurm-drmaa/pull/62.patch',
-          sha256='86bba5e2683f33e59f7e9193aa5fa948eb6a5507d44768f2f6d756a33fef7b74',
+    patch('https://github.com/natefoo/slurm-drmaa/pull/62.patch?full_index=1',
+          sha256='ec8d2963c731f7054f7d3c130232e731bc92366280100e108d93a3685fddfca7',
           when='@main')
 
     depends_on('autoconf', type='build', when='@main')

--- a/var/spack/repos/builtin/packages/spectre/package.py
+++ b/var/spack/repos/builtin/packages/spectre/package.py
@@ -142,56 +142,56 @@ class Spectre(CMakePackage):
     patch('install-pre-2022.01.03.patch', when='@:2022.01.03')
     # - Backport experimental support for Charm++ v7+
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/a2203824ef38ec79a247703ae8cd215befffe391.patch',
-        sha256='eb6094028530d9f28cb9c91a90b4af908cc537c8525fb4c81b11c74fd0354932',
+        'https://github.com/sxs-collaboration/spectre/commit/a2203824ef38ec79a247703ae8cd215befffe391.patch?full_index=1',
+        sha256='e1b22e5ebeb814c07f4aff690b7b4f3a7ba1f06ea4bc91468c68637521a458a7',
         when='@:2022.01.03 ^charmpp@7.0.0:')
     # - Backport IWYU toggle to avoid CMake configuration issues
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/cffeba1bc24bf7c00ec8bac710f02d3db36fa111.patch',
-        sha256='912877d4f553adff8b6df8264c50600c1e6d5a9c3ad18be0b86c9d801c07699c',
+        'https://github.com/sxs-collaboration/spectre/commit/cffeba1bc24bf7c00ec8bac710f02d3db36fa111.patch?full_index=1',
+        sha256='a3752024b743aeba6f7a53d26bf583e1e46adbd08a2e6f74470a777dde7b2dff',
         when='@:2022.01.03')
     # - Backport patch for Boost 1.77
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/001fc190a6ec73ad6c19ada9444d04a2320f2b96.patch',
-        sha256='bf539feb01d01e178889828dbbe5e990e8ee58c9e971d8634845c70a7cfb42a9',
+        'https://github.com/sxs-collaboration/spectre/commit/001fc190a6ec73ad6c19ada9444d04a2320f2b96.patch?full_index=1',
+        sha256='96b3a3cb49ee30206eb70d1160feda84b7e7b4e1c7dd81ba7138b5c4fa718622',
         when='@:2022.01.03 ^boost@1.77:')
     # - Backport patch for Python 3.10 in tests
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/82ff2c39cdae0ecc1e42bdf4564506a4ca869818.patch',
-        sha256='5a5a3abf102e92812933e7318daabe2ca0a5a00d81d9663731c527e5dc6c8ced',
+        'https://github.com/sxs-collaboration/spectre/commit/82ff2c39cdae0ecc1e42bdf4564506a4ca869818.patch?full_index=1',
+        sha256='36cdb5e48f6b49306709057e5e6ca37a44258ad6ecf918c1e87a71d7121e36ba',
         when='@:2022.01.03 ^python@3.10:')
     # - Backport patch for hdf5+mpi
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/eb887635f5e2b394ae2c7e96170e9d907eb315cf.patch',
-        sha256='eb50b31af79d1e6b6535503bc30a9c5efd2ce36bd3638a2b3ab02af44bac6de3',
+        'https://github.com/sxs-collaboration/spectre/commit/eb887635f5e2b394ae2c7e96170e9d907eb315cf.patch?full_index=1',
+        sha256='ccc4631541d6aca996ced358a3ee43d3f8b8eb62fd7bec4534685445688d4d84',
         when='@:2022.01.03 ^hdf5+mpi')
     # - Backport `BUILD_TESTING` toggle, based on upstream patch:
     #   https://github.com/sxs-collaboration/spectre/commit/79bed6cad6e95efadf48a5846f389e90801202d4
     patch('build-testing-pre-2022.01.03.patch', when='@:2022.01.03')
     # - Backport `PYTHONPATH` in CTest environment
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/ada1d15d5963bd22581dd8966599e1529a99645d.patch',
-        sha256='160d55bb2537ea8f3937cea59a9a0fd56a2bfef856bb7fd8e9dceb504c04836c',
+        'https://github.com/sxs-collaboration/spectre/commit/ada1d15d5963bd22581dd8966599e1529a99645d.patch?full_index=1',
+        sha256='6ae3d5b08bd3f0e743e1043c9363e32db2a4f9c549eb958ff989f1e7f3078f6c',
         when='@:2022.01.03')
     # - Backport executable name CTest labels
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/1b61e62a27b02b658cc6a74c4d46af1f5b5d0a4d.patch',
-        sha256='07be176ca4dda74a2dd8e71c31dab638a9f3567c3a58eb7fddbfde001646fb8c',
+        'https://github.com/sxs-collaboration/spectre/commit/1b61e62a27b02b658cc6a74c4d46af1f5b5d0a4d.patch?full_index=1',
+        sha256='aeb41c30dd7a8bf61b79efbb79cfa81372cfc2e870a2b494fc583a8bd554c703',
         when='@:2022.01.03')
     # - Backport fix for PCH builds with Spack
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/4bb3f25f905f83d8295a28a8036f6971dc4e75a2.patch',
-        sha256='cd39217614a40f080d812e20220044aa8b26b9413324a7cd7a304e2378a2b426',
+        'https://github.com/sxs-collaboration/spectre/commit/4bb3f25f905f83d8295a28a8036f6971dc4e75a2.patch?full_index=1',
+        sha256='6e8ec4584b6b03866594d0744c041012c68f6b2382abaa9abeec39cd2f2a6480',
         when='@:2022.01.03')
     # - Backport installation of shared libs
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/b7c54a2a20c6d62aae6b1c97e3468d4cd39ed6ad.patch',
-        sha256='29ad44594ecfd6442a64d2cb57ed2d712cb8d93707c6bceea8030a9a2682b7ed',
+        'https://github.com/sxs-collaboration/spectre/commit/b7c54a2a20c6d62aae6b1c97e3468d4cd39ed6ad.patch?full_index=1',
+        sha256='5ce050c73bab007c0bea9c1f4ae4fb5cd5abab820eeb89cf6cb81f8856d07c30',
         when='@:2022.01.03 +shared')
     # - Fix an issue with Boost pre v1.67
     patch(
-        'https://github.com/sxs-collaboration/spectre/commit/b229e939f15362aca892d4480a9182daf88305d4.patch',
-        sha256='06a41506d3652b5cb9127ae0e7e9b506f013bde695e478621a1540f46ed1e5bb',
+        'https://github.com/sxs-collaboration/spectre/commit/b229e939f15362aca892d4480a9182daf88305d4.patch?full_index=1',
+        sha256='87811b73d72d60cf82cd85e464b42843add50c3be858c7c8272936aeb8574933',
         when='@2022.02.08 ^boost@:1.66')
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/tix/package.py
+++ b/var/spack/repos/builtin/packages/tix/package.py
@@ -22,25 +22,25 @@ class Tix(AutotoolsPackage):
     extends('tcl', type=('build', 'link', 'run'))
     depends_on('tk', type=('build', 'link', 'run'))
 
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/panic.patch',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/panic.patch',
           sha256='1be1a1c7453f6ab8771f90d7e7c0f8959490104752a16a8755bbb7287a841a96',
           level=0)
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/implicit.patch',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/implicit.patch',
           sha256='8a2720368c7757896814684147029d8318b9aa3b0914b3f37dd5e8a8603a61d3',
           level=0)
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-generic-tixGrSort.c.diff',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/patch-generic-tixGrSort.c.diff',
           sha256='99b33cc307f71bcf9cc6f5a44b588f22956884ce3f1e4c716ad64c79cf9c5f41',
           level=0)
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-missing-headers.diff',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/patch-missing-headers.diff',
           sha256='d9f789dcfe5f4c5ee4589a18f9f410cdf162e41d35d00648c1ef37831f4a2b2b',
           level=0)
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-tk_x11.diff',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/patch-tk_x11.diff',
           sha256='1e28d8eee1aaa956a00571cf495a4775e72a993958dff1cabfbc5f102e327a6f',
           level=0)
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-tk_aqua.diff',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/patch-tk_aqua.diff',
           sha256='41a717f5d95f61b4b8196ca6f14ece8f4764d4ba58fb2e1ae15e3240ee5ac534',
           level=0, when='platform=darwin')
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tix/files/patch-dyld_variable.diff',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tix/files/patch-dyld_variable.diff',
           sha256='719eb2e4d8c5d6aae897e5f676cf5ed1a0005c1bd07fd9b18705d81a005f592b',
           level=0, when='platform=darwin')
 

--- a/var/spack/repos/builtin/packages/tk/package.py
+++ b/var/spack/repos/builtin/packages/tk/package.py
@@ -40,10 +40,10 @@ class Tk(AutotoolsPackage, SourceforgePackage):
     # https://core.tcl-lang.org/tk/tktview/3598664fffffffffffff
     # https://core.tcl-lang.org/tk/info/8b679f597b1d17ad
     # https://core.tcl-lang.org/tk/info/997b17c343444e48
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tk/files/patch-unix-Makefile.in.diff',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tk/files/patch-unix-Makefile.in.diff',
           sha256='54bba3d2b3550b7e2c636881c1a3acaf6e1eb743f314449a132864ff47fd0010',
           level=0, when='@:8.6.11 platform=darwin')
-    patch('https://raw.githubusercontent.com/macports/macports-ports/master/x11/tk/files/patch-dyld_fallback_library_path.diff',
+    patch('https://raw.githubusercontent.com/macports/macports-ports/v2.7.0-archive/x11/tk/files/patch-dyld_fallback_library_path.diff',
           sha256='9ce6512f1928db9987986f4d3540207c39429395d5234bd6489ba9d86a6d9c31',
           level=0, when='platform=darwin')
 

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -399,8 +399,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     # avoid calling deprecated functions with CUDA-11
     patch('fix_cxx14_cuda11.patch', when='@13.0.0:13.0.1 cxxstd=14 ^cuda@11:')
     # Allow building with +teko gotype=long
-    patch('https://github.com/trilinos/Trilinos/commit/b17f20a0b91e0b9fc5b1b0af3c8a34e2a4874f3f.patch',
-          sha256='dee6c55fe38eb7f6367e1896d6bc7483f6f9ab8fa252503050cc0c68c6340610',
+    patch('https://github.com/trilinos/Trilinos/commit/b17f20a0b91e0b9fc5b1b0af3c8a34e2a4874f3f.patch?full_index=1',
+          sha256='063a38f402439fa39fd8d57315a321e6510adcd04aec5400a88e744aaa60bc8e',
           when='@13.0.0:13.0.1 +teko gotype=long')
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -56,8 +56,8 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     patch('missing_header_for_numeric_limits.patch', when='@4.1:5.0.1')
 
     # export targets when building pre-6.0.0 release with BLT 0.4.0+
-    patch('https://github.com/LLNL/Umpire/commit/5773ce9af88952c8d23f9bcdcb2e503ceda40763.patch',
-          sha256='f5c691752e4833a936bce224bbe0fe884d3afa84c5e5a4a481f59a12840159c9',
+    patch('https://github.com/LLNL/Umpire/commit/5773ce9af88952c8d23f9bcdcb2e503ceda40763.patch?full_index=1',
+          sha256='f3b21335ce5cf9c0fecc852a94dfec90fb5703032ac97f9fee104af9408d8899',
           when='@:5.0.1 ^blt@0.4:')
 
     variant('fortran', default=False, description='Build C/Fortran API')

--- a/var/spack/repos/builtin/packages/votca-tools/package.py
+++ b/var/spack/repos/builtin/packages/votca-tools/package.py
@@ -36,9 +36,9 @@ class VotcaTools(CMakePackage):
     version('1.4', sha256='41638122e7e59852af61d391b4ab8c308fd2e16652f768077e13a99d206ec5d3', deprecated=True)
 
     # https://github.com/votca/tools/pull/229, fix mkl in exported target
-    patch("https://github.com/votca/tools/pull/229.patch", sha256="250d0b679e5d3104e3c8d6adf99751b71386c7ed4cbdae1c75408717ef3f401f", when="@1.6:1.6.0+mkl")
+    patch("https://github.com/votca/tools/pull/229.patch?full_index=1", sha256="2a9ef179904d5057f36a5ce533c002d8f5880dc4b3eba569825f4a7e7f055eb1", when="@1.6:1.6.0+mkl")
     # https://github.com/votca/tools/pull/361, fix build with newer glibc/gcc, fixed in stable and 2021.1
-    patch("https://github.com/votca/tools/commit/6bb7e35ba7d1a31247eafb323be2777ec0439cfe.patch", sha256="3c9fa5ac9cf45c54ac475bcb22350793efaccd6b5154e3d30c24b8aa754fe47b", when="@2021:2021.0")
+    patch("https://github.com/votca/tools/commit/6bb7e35ba7d1a31247eafb323be2777ec0439cfe.patch?full_index=1", sha256="5a67eaf362755412b9825558bedb53fac3204713effd60c59f14c54eb1ad52b9", when="@2021:2021.0")
 
     variant('mkl', default=False, description='Build with MKL support')
     conflicts('+mkl', when='@1.4:1.5')

--- a/var/spack/repos/builtin/packages/wrf/package.py
+++ b/var/spack/repos/builtin/packages/wrf/package.py
@@ -147,18 +147,18 @@ class Wrf(Package):
     patch("patches/4.2/hdf5_fix.patch", when="@4.2: %aocc")
     patch("patches/4.2/derf_fix.patch", when="@4.2 %aocc")
     # Various syntax fixes found by FPT tool
-    patch("https://github.com/wrf-model/WRF/commit/6502d5d9c15f5f9a652dec244cc12434af737c3c.patch",
-          sha256="d685a77c82d770f2af4e66711effa0cb115e2bc6e601de4cb92f15b138c6c85b", when="@4.2 %fj")
+    patch("https://github.com/wrf-model/WRF/commit/6502d5d9c15f5f9a652dec244cc12434af737c3c.patch?full_index=1",
+          sha256="c5162c23a132b377132924f8f1545313861c6cee5a627e9ebbdcf7b7b9d5726f", when="@4.2 %fj")
     patch("patches/4.2/configure_fujitsu.patch", when="@4 %fj")
 
     patch("patches/4.3/Makefile.patch", when="@4.3:")
     patch("patches/4.3/arch.postamble.patch", when="@4.3:")
     patch("patches/4.3/fujitsu.patch", when="@4.3: %fj")
     # Syntax errors in physics routines
-    patch("https://github.com/wrf-model/WRF/commit/7c6fd575b7a8fe5715b07b38db160e606c302956.patch",
-          sha256="bc24b6c8a073837404dbd33b0a4402843bd4771441dd766899d9274583db683f", when="@4.3.1")
-    patch("https://github.com/wrf-model/WRF/commit/238a7d219b7c8e285db28fe4f0c96ebe5068d91c.patch",
-          sha256="d3fe347fd57c0f989744113c0bc8faf98bab2dd4e88867efa4b154c2b4265636", when="@4.3.1")
+    patch("https://github.com/wrf-model/WRF/commit/7c6fd575b7a8fe5715b07b38db160e606c302956.patch?full_index=1",
+          sha256="1ce97f4fd09e440bdf00f67711b1c50439ac27595ea6796efbfb32e0b9a1f3e4", when="@4.3.1")
+    patch("https://github.com/wrf-model/WRF/commit/238a7d219b7c8e285db28fe4f0c96ebe5068d91c.patch?full_index=1",
+          sha256="27c7268f6c84b884d21e4afad0bab8554b06961cf4d6bfd7d0f5a457dcfdffb1", when="@4.3.1")
 
     depends_on("pkgconfig", type=("build"))
     depends_on("libtirpc")


### PR DESCRIPTION
It looks like something changed and the hashes of many auto-generated GitHub patches have changed.

Fixes #29227