### PR TITLE
assimp: new version 5.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -17,6 +17,7 @@ class Assimp(CMakePackage):
     maintainers = ['wdconinc']
 
     version('master', branch='master')
+    version('5.2.2', sha256='ad76c5d86c380af65a9d9f64e8fc57af692ffd80a90f613dfc6bd945d0b80bb4')
     version('5.2.1', sha256='c9cbbc8589639cd8c13f65e94a90422a70454e8fa150cf899b6038ba86e9ecff')
     version('5.1.4', sha256='bd32cdc27e1f8b7ac09d914ab92dd81d799c97e9e47315c1f40dcb7c6f7938c6')
     version('5.1.3', sha256='50a7bd2c8009945e1833c591d16f4f7c491a3c6190f69d9d007167aadb175c35')


### PR DESCRIPTION
No build system change, bugfix release, release notes at https://github.com/assimp/assimp/releases/tag/v5.2.2.