### PR TITLE
Add a new test to catch exit code failure

### DIFF
--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -868,7 +868,7 @@ def _main(argv=None):
         bootstrap_context = bootstrap.ensure_bootstrap_configuration()
 
     with bootstrap_context:
-        finish_parse_and_run(parser, cmd_name, env_format_error)
+        return finish_parse_and_run(parser, cmd_name, env_format_error)
 
 
 def finish_parse_and_run(parser, cmd_name, env_format_error):

--- a/lib/spack/spack/main.py
+++ b/lib/spack/spack/main.py
@@ -868,7 +868,7 @@ def _main(argv=None):
         bootstrap_context = bootstrap.ensure_bootstrap_configuration()
 
     with bootstrap_context:
-        return finish_parse_and_run(parser, cmd_name, env_format_error)
+        finish_parse_and_run(parser, cmd_name, env_format_error)
 
 
 def finish_parse_and_run(parser, cmd_name, env_format_error):

--- a/share/spack/qa/setup-env-test.sh
+++ b/share/spack/qa/setup-env-test.sh
@@ -200,3 +200,6 @@ despacktivate
 echo "Correct error exit codes for activate and deactivate"
 fails spack env activate nonexisiting_environment
 fails spack env deactivate
+
+echo "Correct error exit codes for unit-test when it fails"
+fails spack unit-test fail


### PR DESCRIPTION
fixes #29226

This introduces a new integration test that checks the return code of `spack unit-test` when it is supposed to fail.

This is to prevent bugs like the one introduced in #25601 in which CI didn't catch a missing return statement.

In retrospective it seems that the shell tests we have right now go through code paths which call `sys.exit` explicitly. This new test instead checks `spack unit-test` which relies on the return code from command invocation in case of errors.