### PR TITLE
Fix r- package downloads from list_url

### DIFF
--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -53,7 +53,7 @@ class RPackage(PackageBase):
         if self.cran:
             return (
                 'https://cloud.r-project.org/src/contrib/'
-                + self.cran + '_' + str(list(self.versions)[0]) + '.tar.gz'
+                + self.cran + '_' + str(0) + '.tar.gz'
             )
 
     @property


### PR DESCRIPTION
Fixes #29204

When the cran attribute is set, a url attribute is derived. This was
using the first version found in the array of versions. The expectation
wsa that if that version was not present at the URL that it would fall
back to list_url. That was not happening. Instead, the version in the
derived url was always associated with the url and was not falling back
to list_url. Thus, if the most recent version of a package in spack was
older than what was in CRAN, the download would fail, because the
archive had been moved. Using an older version for the derived url
would work but sometimes there is only one version present in spack
until the package is updated. Instead, use a fake version that would
never exist in the wild so that spack does not lock what it thinks is
the most current version to the url attribute.