### PR TITLE
libuv: remove bash dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libuv/package.py
+++ b/var/spack/repos/builtin/packages/libuv/package.py
@@ -31,5 +31,4 @@ class Libuv(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         # This is needed because autogen.sh generates on-the-fly
         # an m4 macro needed during configuration
-        bash = which("bash")
-        bash('autogen.sh')
+        Executable('./autogen.sh')()


### PR DESCRIPTION
Call the executable (which specifies #!/bin/sh) instead of requiring bash
