### PR TITLE
libtermkey: constrain dependency as needed by neovim

### DIFF
--- a/var/spack/repos/builtin/packages/libtermkey/package.py
+++ b/var/spack/repos/builtin/packages/libtermkey/package.py
@@ -19,7 +19,7 @@ class Libtermkey(Package):
     version('0.14', sha256='3d114d4509499b80a583ea39cd35f18268aacf4a7bbf56c142cd032632005c79')
 
     depends_on('libtool', type='build')
-    depends_on('ncurses')
+    depends_on('unibilium')
     depends_on('pkgconfig')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
Close #29231 #29238

Some premises:
- `libtermkey` is deprecated (http://www.leonerd.org.uk/code/libtermkey/)
- `libtermkey` github repository is read-only (https://github.com/neovim/libtermkey), so it may not be possible/easy to fix/patch/update it
- `libtermkey` exists in spack just because it is a dependency of `neovim`

IMHO, after looking at `libtermkey` and `neovim` sources:
- `libtermkey` does not correctly expose its dependencies via its pkg-config script (IMHO it should expose its required dependency, begin it one of `unibilium`, `tinfo`, `ncursesw` or `ncurses`, which is detected by the `Makefile` [in this exact order of priority](https://github.com/neovim/libtermkey/blob/b7fe3af141c53cce71a244282b69ea860452120a/Makefile#L24-L35))
- `neovim` CMake management of `libtermkey` is a bit hacky and error-prone

According to `neovim` (last) [CMakeLists.txt](https://github.com/neovim/neovim/blob/cf0266fae1b24ced577dfb8673c11efd4ceb1627/CMakeLists.txt#L457-L480), when `FEAT_TUI=on` both `unibilium` and `libtermkey` are needed.

Since `unibilium` is a dependency of `libtermkey`, I would say that it may be reasonable to think that `libtermkey` has to be built with `unibilium` instead of `ncurses`. I don't know the compatibility of `unibilium`/`ncurses`/`tinfo`. If they are interchangeable, this may not be a big problem.

But, this "relationship" enforced in `neovim`, about the presence of `unibilium` and `libtermkey` at the same time, could be exploited to be sure that when linking against `libtermkey` we also get indirectly its dependency `unibilium`.

It's not a clean and straightforward way, but I think it should do the job.


I would ask @certik if he is so kind to test also this branch, i.e. building `neovim` from this branch.