### PR TITLE
assimp: patch for issue that prevents 5.1: from working with qt

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -23,6 +23,10 @@ class Assimp(CMakePackage):
     version('5.0.1', sha256='11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc')
     version('4.0.1', sha256='60080d8ab4daaab309f65b3cffd99f19eb1af8d05623fff469b9b652818e286e')
 
+    patch('https://patch-diff.githubusercontent.com/raw/assimp/assimp/pull/4203.patch',
+          sha256='a227714a215023184536e38b4bc7f8341f635e16bfb3b0ea029d420c29aacd2d',
+          when='@5.1:5.2.2')
+
     variant('shared',  default=True,
             description='Enables the build of shared libraries')
 

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -182,7 +182,7 @@ class Qt(Package):
     depends_on("libpng", when='@4:')
     depends_on("dbus", when='@4:+dbus')
     depends_on("gl", when='@4:+opengl')
-    depends_on("assimp@5.0.0:5.0", when='@5.14:+opengl')
+    depends_on("assimp@5.0.0:5", when='@5.14:+opengl')
 
     depends_on("harfbuzz", when='@5:')
     depends_on("double-conversion", when='@5.7:')


### PR DESCRIPTION
This patch to assimp (https://github.com/assimp/assimp/pull/4203) allows qt to compile with assimp@5.1: and newer. This resolves a mutual exclusion between `dd4hep +ddcad` (which needs assimp@5.1:) and `qt +opengl` (which needs assimp@5:5.0).

Maintainer tag for qt: @sethrj