### PR TITLE
lhapdf: add python variant, change source tarball url to avoid python build failures

### DIFF
--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -11,24 +11,30 @@ class Lhapdf(AutotoolsPackage):
        used for evaluating PDFs from discretised data files. """
 
     homepage = "https://lhapdf.hepforge.org/"
-    url      = "https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.2.3.tar.gz"
+    git      = "https://gitlab.com/hepcedar/lhapdf"
+    # the tarballs from hepforge include bundled cython sources
+    # that may break the build when using incompatible python versions
+    # thus use the release tarball from gitlab that does not include lhapdf.cxx
+    url      = "https://gitlab.com/hepcedar/lhapdf/-/archive/lhapdf-6.4.0/lhapdf-lhapdf-6.4.0.tar.gz"
 
     tags = ['hep']
 
-    version('6.3.0', sha256='ed4d8772b7e6be26d1a7682a13c87338d67821847aa1640d78d67d2cef8b9b5d')
-    version('6.2.3', sha256='d6e63addc56c57b6286dc43ffc56d901516f4779a93a0f1547e14b32cfd82dd1')
+    version('6.4.0', sha256='155702c36df46de30c5f7fa249193a9a0eea614191de1606301e06cd8062fc29')
+    version('6.3.0', sha256='864468439c7662bbceed6c61c7132682ec83381a23c9c9920502fdd7329dd816')
+    version('6.2.3', sha256='37200a1ab70247250a141dfed7419d178f9a83bd23a4f8a38e203d4e27b41308')
+
+    variant('python', default=True, description="Build python bindings")
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
 
-    depends_on('python',        type=('build', 'run'))
-    depends_on('py-cython',     type='build')
-    depends_on('py-setuptools', type='build')
-
-    extends('python')
+    extends('python', when='+python')
+    depends_on('py-cython',     type='build', when='+python')
+    depends_on('py-setuptools', type='build', when='+python')
 
     def configure_args(self):
         args = ['FCFLAGS=-O3', 'CFLAGS=-O3', 'CXXFLAGS=-O3']
+        args.extend(self.enable_or_disable('python'))
         return args


### PR DESCRIPTION
This also makes https://github.com/spack/spack/pull/28800 obsolete.

The reason for the python build failures was that some cython sources are bundled with the tarball from hepforge. If cython is available when building, they *should* be regenerated, but due to a bug in the makefile they aren't. 

The most robust way to fix this is to use the tarball from gitlab, which ensures that cython generates its own sources.