### PR TITLE
llvm: add missing system libs

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -204,8 +204,10 @@ class Llvm(CMakePackage, CudaPackage):
     depends_on("libelf", when="+cuda")  # libomptarget
     depends_on("libffi", when="+cuda")  # libomptarget
 
-    # ncurses dependency
+    # llvm-config --system-libs libraries.
     depends_on("ncurses+termlib")
+    depends_on("zlib")
+    depends_on("libxml2")
 
     # lldb dependencies
     depends_on("swig", when="+lldb")


### PR DESCRIPTION
```
$ ./bin/llvm-config --link-static --system-libs
-lrt -ldl -lpthread -lm -lz -ltinfo -lxml2
```

`libz` and `libxml2` were missing. Note that `--link-static` above is because I looked at `llvm +llvm_dylib`, which only returns the libLLVM.so library by default. Probably `llvm ~llvm_dylib` returns those `-l` flags without `--link-static` too.

Reported by @vchuravy 
