### PR TITLE
add a tagged/cksummed bmi release number

### DIFF
--- a/var/spack/repos/builtin/packages/bmi/package.py
+++ b/var/spack/repos/builtin/packages/bmi/package.py
@@ -11,10 +11,12 @@ class Bmi(AutotoolsPackage):
 
     homepage = 'https://github.com/radix-io/bmi/'
     git = 'https://github.com/radix-io/bmi.git'
+    url = 'https://github.com/radix-io/bmi/archive/v2.8.1.tar.gz'
 
     maintainers = ['carns']
 
     version('main', branch='main')
+    version('2.8.1', sha256='28aa4341f0456cf20ee762f712d7c749ab8f864003329f9327c18ea03fc7ffdb')
 
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')


### PR DESCRIPTION
- adds a newly created BMI version 2.8.1
- no functionality change from `@main`; this just follows better practice for package versioning

Fixes #29094