### PR TITLE
mpich: fix the detection of the package

### DIFF
--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -23,10 +23,10 @@ class Gcc(spack.compiler.Compiler):
     # Subclasses use possible names of Fortran 90 compiler
     fc_names = ['gfortran']
 
-    # MacPorts builds gcc versions with prefixes and -mp-X.Y suffixes.
+    # MacPorts builds gcc versions with prefixes and -mp-X or -mp-X.Y suffixes.
     # Homebrew and Linuxbrew may build gcc with -X, -X.Y suffixes.
     # Old compatibility versions may contain XY suffixes.
-    suffixes = [r'-mp-\d+\.\d+', r'-\d+\.\d+', r'-\d+', r'\d\d']
+    suffixes = [r'-mp-\d+(?:\.\d+)?', r'-\d+(?:\.\d+)?', r'\d\d']
 
     # Named wrapper links within build_env_path
     link_paths = {'cc': 'gcc/gcc',

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -231,7 +231,8 @@ with '-Wl,-commons,use_dylibs' and without
             actual_compiler = None
             # check if the compiler actually matches the one we want
             for spack_compiler in spack_compilers:
-                if os.path.dirname(spack_compiler.cc) == path:
+                if (spack_compiler.cc and
+                        os.path.dirname(spack_compiler.cc) == path):
                     actual_compiler = spack_compiler
                     break
             return actual_compiler.spec if actual_compiler else None
@@ -250,72 +251,72 @@ with '-Wl,-commons,use_dylibs' and without
 
         results = []
         for exe in exes:
-            variants = ''
+            variants = []
             output = Executable(exe)(output=str, error=str)
             if re.search(r'--with-hwloc-prefix=embedded', output):
-                variants += '~hwloc'
+                variants.append('~hwloc')
 
             if re.search(r'--with-pm=hydra', output):
-                variants += '+hydra'
+                variants.append('+hydra')
             else:
-                variants += '~hydra'
+                variants.append('~hydra')
 
             match = re.search(r'--(\S+)-romio', output)
             if match and is_enabled(match.group(1)):
-                variants += '+romio'
+                variants.append('+romio')
             elif match and is_disabled(match.group(1)):
-                variants += '~romio'
+                variants.append('~romio')
 
             if re.search(r'--with-ibverbs', output):
-                variants += '+verbs'
+                variants.append('+verbs')
             elif re.search(r'--without-ibverbs', output):
-                variants += '~verbs'
+                variants.append('~verbs')
 
             match = re.search(r'--enable-wrapper-rpath=(\S+)', output)
             if match and is_enabled(match.group(1)):
-                variants += '+wrapperrpath'
+                variants.append('+wrapperrpath')
             match = re.search(r'--enable-wrapper-rpath=(\S+)', output)
             if match and is_disabled(match.group(1)):
-                variants += '~wrapperrpath'
+                variants.append('~wrapperrpath')
 
             if re.search(r'--disable-fortran', output):
-                variants += '~fortran'
+                variants.append('~fortran')
 
             match = re.search(r'--with-slurm=(\S+)', output)
             if match and is_enabled(match.group(1)):
-                variants += '+slurm'
+                variants.append('+slurm')
 
             if re.search(r'--enable-libxml2', output):
-                variants += '+libxml2'
+                variants.append('+libxml2')
             elif re.search(r'--disable-libxml2', output):
-                variants += '~libxml2'
+                variants.append('~libxml2')
 
             if re.search(r'--with-thread-package=argobots', output):
-                variants += '+argobots'
+                variants.append('+argobots')
 
             if re.search(r'--with-pmi=no', output):
-                variants += ' pmi=off'
+                variants.append('pmi=off')
             elif re.search(r'--with-pmi=simple', output):
-                variants += ' pmi=pmi'
+                variants.append('pmi=pmi')
             elif re.search(r'--with-pmi=pmi2/simple', output):
-                variants += ' pmi=pmi2'
+                variants.append('pmi=pmi2')
             elif re.search(r'--with-pmix', output):
-                variants += ' pmi=pmix'
+                variants.append('pmi=pmix')
 
             match = re.search(r'MPICH Device:\s+(ch3|ch4)', output)
             if match:
-                variants += ' device=' + match.group(1)
+                variants.append('device=' + match.group(1))
 
             match = re.search(r'--with-device=ch.\S+(ucx|ofi|mxm|tcp)', output)
             if match:
-                variants += ' netmod=' + match.group(1)
+                variants.append('netmod=' + match.group(1))
 
             match = re.search(r'MPICH CC:\s+(\S+)', output)
             compiler_spec = get_spack_compiler_spec(
                 os.path.dirname(match.group(1)))
             if compiler_spec:
-                variants += '%' + str(compiler_spec)
-            results.append(variants)
+                variants.append('%' + str(compiler_spec))
+            results.append(' '.join(variants))
         return results
 
     def setup_build_environment(self, env):


### PR DESCRIPTION
This mainly addresses problems on `darwin` with MacPorts-built `mpich`.

1. Fix `Warning: error detecting "mpich" from prefix /opt/local/bin [expected str, bytes or os.PathLike object, not NoneType]` by checking whether `spack_compiler.cc` is set before using its value (`Spack` falsely detects `apple-clang` in `/opt/local/bin` that is mixed with `gfortran` but does not have `cc`).
2. Fix the detection of MacPorts-built `gcc`, which has suffix `-mp-10` on my system.
3. Fix incorrect concatenation of a multi-valued variant with a compiler spec (`Warning: error detecting "mpich" from prefix /opt/local/bin [invalid values for variant "device" in package "mpich": ['ch4%gcc@10.3.0']`)