### PR TITLE
aws-parallelcluster: Add v2.11.5

### DIFF
--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -13,12 +13,13 @@ class AwsParallelcluster(PythonPackage):
     tool to deploy and manage HPC clusters in the AWS cloud."""
 
     homepage = "https://github.com/aws/aws-parallelcluster"
-    pypi = "aws-parallelcluster/aws-parallelcluster-2.11.4.tar.gz"
+    pypi = "aws-parallelcluster/aws-parallelcluster-2.11.5.tar.gz"
 
     maintainers = [
         'demartinofra', 'enrico-usai', 'lukeseawalker',
     ]
 
+    version('2.11.5', sha256='7499f88387cbe2cb73f9fddeee3363117f7ef1524d6a73e77bb07900040baebb')
     version('2.11.4', sha256='449537ccda57f91f4ec6ae0c94a8e2b1a789f08f80245fadb28f44a4351d5da4')
     version('2.11.3', sha256='7c1d74123f2f670846aed8fe1fcca5908bb46ec014e2dfc7d3ec8994447a37a0')
     version('2.11.2', sha256='60d96a5ea4dca4816ceffc4546549743abd1f6207c62f016c9c348adc64b2ec0')


### PR DESCRIPTION
Add version 2.11.5

Tested manual installation.
```
$ . spack/share/spack/setup-env.sh

$ spack install aws-parallelcluster@2.11.5
...
==> Installing aws-parallelcluster-2.11.5-lyx3ne7kb4axi2qiw7mgfwpwn2h7eyfm
==> No binary for aws-parallelcluster-2.11.5-lyx3ne7kb4axi2qiw7mgfwpwn2h7eyfm found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/a/aws-parallelcluster/aws-parallelcluster-2.11.5.tar.gz
==> No patches needed for aws-parallelcluster
==> aws-parallelcluster: Executing phase: 'install'
==> aws-parallelcluster: Successfully installed aws-parallelcluster-2.11.5-lyx3ne7kb4axi2qiw7mgfwpwn2h7eyfm
  Fetch: 2.72s.  Build: 1.70s.  Total: 4.42s.

$ spack load aws-parallelcluster@2.11.5

$ pcluster version
2.11.5
```