### PR TITLE
spack audit: add a new check on deprecated, non-buildable externals

### DIFF
--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -78,7 +78,15 @@ _double_compiler_definition = [
             {"spec": "mpileaks@1.0.0", "prefix": "/"},
             {"spec": "mpileaks@1.0.0", "prefix": "/usr"},
         ]}
-    }, 'CFG-PACKAGES')
+    }, 'CFG-PACKAGES'),
+    # Non-buildable externals with deprecated versions
+    ('packages', {
+        "openssl": {
+            "buildable": False,
+            "externals": [
+                {"spec": "openssl@1.0.2k", "prefix": "/usr"},
+            ]}
+    }, 'CFG-PACKAGES'),
 ])
 def test_config_audits(config_section, data, failing_check):
     with spack.config.override(config_section, data):


### PR DESCRIPTION
closes #28829

This PR adds a new check to `spack audit configs`. This will help diagnosing issues like in #28829 where a custom user configuration containing deprecated, non-buildable external specs was driving clingo towards DAGs that would not use them.

Using the command with the `spack.yaml` from the issue returns:
```console
$ spack -e . audit configs 
CFG-COMPILER: 0 issues found.
CFG-PACKAGES: 2 issues found
1. The external spec "libtool" is not buildable and contains deprecated versions. This can cause unexpected optimal configurations from clingo.
    "libtool@2.4.2" is a deprecated version, consider removing it
2. The external spec "openssl" is not buildable and contains deprecated versions. This can cause unexpected optimal configurations from clingo.
    "openssl@1.0.2k" is a deprecated version, consider removing it
```