### PR TITLE
OpenMPI: Correct slurm-pmi conflict version

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -352,7 +352,7 @@ class Openmpi(AutotoolsPackage):
     # knem support was added in 1.5
     conflicts('fabrics=knem', when='@:1.4')
 
-    conflicts('schedulers=slurm ~pmi', when='@1.5.4:2',
+    conflicts('schedulers=slurm ~pmi', when='@1.5.4:',
               msg='+pmi is required for openmpi(>=1.5.5) to work with SLURM.')
     conflicts('schedulers=loadleveler', when='@3.0.0:',
               msg='The loadleveler scheduler is not supported with '


### PR DESCRIPTION
The conflict `when` clause doesn't match the conflict message `+pmi is required for openmpi(>=1.5.5) to work with SLURM.`  This allows the package to be installed as `-pmi schedulers=slurm` but it doesn't work for users.

This fix instead generates the conflict:

```
$ spack install openmpi@4.1.2 -pmi schedulers=slurm
==> Error: openmpi@4.1.2~pmi schedulers=slurm is unsatisfiable, errors are:
  A conflict was triggered
  no version satisfies the given constraints

    To see full clingo unsat cores, re-run with `spack --show-cores=full`
    For full, subset-minimal unsat cores, re-run with `spack --show-cores=minimized
    Warning: This may take (up to) hours for some specs
25.492u 1.509s 0:28.37 95.1%	0+0k 1160+1184io 0pf+0w
```