### PR TITLE
py-horovod: add versions 0.22+, fix aarch64 build

### DIFF
--- a/var/spack/repos/builtin/packages/py-horovod/eigen.patch
+++ b/var/spack/repos/builtin/packages/py-horovod/eigen.patch
@@ -1,0 +1,711 @@
+--- spack-src/third_party/eigen/Eigen/src/Core/arch/NEON/PacketMath.h.orig	2022-03-02 16:22:53.000000000 +0900
++++ spack-src/third_party/eigen/Eigen/src/Core/arch/NEON/PacketMath.h	2022-03-03 14:11:43.000000000 +0900
+@@ -1922,13 +1922,13 @@
+ template<> EIGEN_STRONG_INLINE void pstoreu<uint64_t>(uint64_t* to, const Packet2ul& from)
+ { EIGEN_DEBUG_UNALIGNED_STORE vst1q_u64(to,from); }
+ 
+-template<> EIGEN_DEVICE_FUNC inline Packet2f pgather<float, Packet2f>(const float* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2f pgather<float, Packet2f>(const float* from, Index stride)
+ {
+   Packet2f res = vld1_dup_f32(from);
+   res = vld1_lane_f32(from + 1*stride, res, 1);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet4f pgather<float, Packet4f>(const float* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4f pgather<float, Packet4f>(const float* from, Index stride)
+ {
+   Packet4f res = vld1q_dup_f32(from);
+   res = vld1q_lane_f32(from + 1*stride, res, 1);
+@@ -1936,14 +1936,14 @@
+   res = vld1q_lane_f32(from + 3*stride, res, 3);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet4c pgather<int8_t, Packet4c>(const int8_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4c pgather<int8_t, Packet4c>(const int8_t* from, Index stride)
+ {
+   Packet4c res;
+   for (int i = 0; i != 4; i++)
+     reinterpret_cast<int8_t*>(&res)[i] = *(from + i * stride);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet8c pgather<int8_t, Packet8c>(const int8_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8c pgather<int8_t, Packet8c>(const int8_t* from, Index stride)
+ {
+   Packet8c res = vld1_dup_s8(from);
+   res = vld1_lane_s8(from + 1*stride, res, 1);
+@@ -1955,7 +1955,7 @@
+   res = vld1_lane_s8(from + 7*stride, res, 7);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet16c pgather<int8_t, Packet16c>(const int8_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet16c pgather<int8_t, Packet16c>(const int8_t* from, Index stride)
+ {
+   Packet16c res = vld1q_dup_s8(from);
+   res = vld1q_lane_s8(from + 1*stride, res, 1);
+@@ -1975,14 +1975,14 @@
+   res = vld1q_lane_s8(from + 15*stride, res, 15);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet4uc pgather<uint8_t, Packet4uc>(const uint8_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4uc pgather<uint8_t, Packet4uc>(const uint8_t* from, Index stride)
+ {
+   Packet4uc res;
+   for (int i = 0; i != 4; i++)
+     reinterpret_cast<uint8_t*>(&res)[i] = *(from + i * stride);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet8uc pgather<uint8_t, Packet8uc>(const uint8_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8uc pgather<uint8_t, Packet8uc>(const uint8_t* from, Index stride)
+ {
+   Packet8uc res = vld1_dup_u8(from);
+   res = vld1_lane_u8(from + 1*stride, res, 1);
+@@ -1994,7 +1994,7 @@
+   res = vld1_lane_u8(from + 7*stride, res, 7);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet16uc pgather<uint8_t, Packet16uc>(const uint8_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet16uc pgather<uint8_t, Packet16uc>(const uint8_t* from, Index stride)
+ {
+   Packet16uc res = vld1q_dup_u8(from);
+   res = vld1q_lane_u8(from + 1*stride, res, 1);
+@@ -2014,7 +2014,7 @@
+   res = vld1q_lane_u8(from + 15*stride, res, 15);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet4s pgather<int16_t, Packet4s>(const int16_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4s pgather<int16_t, Packet4s>(const int16_t* from, Index stride)
+ {
+   Packet4s res = vld1_dup_s16(from);
+   res = vld1_lane_s16(from + 1*stride, res, 1);
+@@ -2022,7 +2022,7 @@
+   res = vld1_lane_s16(from + 3*stride, res, 3);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet8s pgather<int16_t, Packet8s>(const int16_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8s pgather<int16_t, Packet8s>(const int16_t* from, Index stride)
+ {
+   Packet8s res = vld1q_dup_s16(from);
+   res = vld1q_lane_s16(from + 1*stride, res, 1);
+@@ -2034,7 +2034,7 @@
+   res = vld1q_lane_s16(from + 7*stride, res, 7);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet4us pgather<uint16_t, Packet4us>(const uint16_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4us pgather<uint16_t, Packet4us>(const uint16_t* from, Index stride)
+ {
+   Packet4us res = vld1_dup_u16(from);
+   res = vld1_lane_u16(from + 1*stride, res, 1);
+@@ -2042,7 +2042,7 @@
+   res = vld1_lane_u16(from + 3*stride, res, 3);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet8us pgather<uint16_t, Packet8us>(const uint16_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8us pgather<uint16_t, Packet8us>(const uint16_t* from, Index stride)
+ {
+   Packet8us res = vld1q_dup_u16(from);
+   res = vld1q_lane_u16(from + 1*stride, res, 1);
+@@ -2054,13 +2054,13 @@
+   res = vld1q_lane_u16(from + 7*stride, res, 7);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet2i pgather<int32_t, Packet2i>(const int32_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2i pgather<int32_t, Packet2i>(const int32_t* from, Index stride)
+ {
+   Packet2i res = vld1_dup_s32(from);
+   res = vld1_lane_s32(from + 1*stride, res, 1);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet4i pgather<int32_t, Packet4i>(const int32_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4i pgather<int32_t, Packet4i>(const int32_t* from, Index stride)
+ {
+   Packet4i res = vld1q_dup_s32(from);
+   res = vld1q_lane_s32(from + 1*stride, res, 1);
+@@ -2068,13 +2068,13 @@
+   res = vld1q_lane_s32(from + 3*stride, res, 3);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet2ui pgather<uint32_t, Packet2ui>(const uint32_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2ui pgather<uint32_t, Packet2ui>(const uint32_t* from, Index stride)
+ {
+   Packet2ui res = vld1_dup_u32(from);
+   res = vld1_lane_u32(from + 1*stride, res, 1);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet4ui pgather<uint32_t, Packet4ui>(const uint32_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4ui pgather<uint32_t, Packet4ui>(const uint32_t* from, Index stride)
+ {
+   Packet4ui res = vld1q_dup_u32(from);
+   res = vld1q_lane_u32(from + 1*stride, res, 1);
+@@ -2082,37 +2082,37 @@
+   res = vld1q_lane_u32(from + 3*stride, res, 3);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet2l pgather<int64_t, Packet2l>(const int64_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2l pgather<int64_t, Packet2l>(const int64_t* from, Index stride)
+ {
+   Packet2l res = vld1q_dup_s64(from);
+   res = vld1q_lane_s64(from + 1*stride, res, 1);
+   return res;
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet2ul pgather<uint64_t, Packet2ul>(const uint64_t* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2ul pgather<uint64_t, Packet2ul>(const uint64_t* from, Index stride)
+ {
+   Packet2ul res = vld1q_dup_u64(from);
+   res = vld1q_lane_u64(from + 1*stride, res, 1);
+   return res;
+ }
+ 
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<float, Packet2f>(float* to, const Packet2f& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<float, Packet2f>(float* to, const Packet2f& from, Index stride)
+ {
+   vst1_lane_f32(to + stride*0, from, 0);
+   vst1_lane_f32(to + stride*1, from, 1);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<float, Packet4f>(float* to, const Packet4f& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<float, Packet4f>(float* to, const Packet4f& from, Index stride)
+ {
+   vst1q_lane_f32(to + stride*0, from, 0);
+   vst1q_lane_f32(to + stride*1, from, 1);
+   vst1q_lane_f32(to + stride*2, from, 2);
+   vst1q_lane_f32(to + stride*3, from, 3);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<int8_t, Packet4c>(int8_t* to, const Packet4c& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<int8_t, Packet4c>(int8_t* to, const Packet4c& from, Index stride)
+ {
+   for (int i = 0; i != 4; i++)
+     *(to + i * stride) = reinterpret_cast<const int8_t*>(&from)[i];
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<int8_t, Packet8c>(int8_t* to, const Packet8c& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<int8_t, Packet8c>(int8_t* to, const Packet8c& from, Index stride)
+ {
+   vst1_lane_s8(to + stride*0, from, 0);
+   vst1_lane_s8(to + stride*1, from, 1);
+@@ -2123,7 +2123,7 @@
+   vst1_lane_s8(to + stride*6, from, 6);
+   vst1_lane_s8(to + stride*7, from, 7);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<int8_t, Packet16c>(int8_t* to, const Packet16c& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<int8_t, Packet16c>(int8_t* to, const Packet16c& from, Index stride)
+ {
+   vst1q_lane_s8(to + stride*0, from, 0);
+   vst1q_lane_s8(to + stride*1, from, 1);
+@@ -2142,12 +2142,12 @@
+   vst1q_lane_s8(to + stride*14, from, 14);
+   vst1q_lane_s8(to + stride*15, from, 15);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<uint8_t, Packet4uc>(uint8_t* to, const Packet4uc& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<uint8_t, Packet4uc>(uint8_t* to, const Packet4uc& from, Index stride)
+ {
+   for (int i = 0; i != 4; i++)
+     *(to + i * stride) = reinterpret_cast<const uint8_t*>(&from)[i];
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<uint8_t, Packet8uc>(uint8_t* to, const Packet8uc& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<uint8_t, Packet8uc>(uint8_t* to, const Packet8uc& from, Index stride)
+ {
+   vst1_lane_u8(to + stride*0, from, 0);
+   vst1_lane_u8(to + stride*1, from, 1);
+@@ -2158,7 +2158,7 @@
+   vst1_lane_u8(to + stride*6, from, 6);
+   vst1_lane_u8(to + stride*7, from, 7);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<uint8_t, Packet16uc>(uint8_t* to, const Packet16uc& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<uint8_t, Packet16uc>(uint8_t* to, const Packet16uc& from, Index stride)
+ {
+   vst1q_lane_u8(to + stride*0, from, 0);
+   vst1q_lane_u8(to + stride*1, from, 1);
+@@ -2177,14 +2177,14 @@
+   vst1q_lane_u8(to + stride*14, from, 14);
+   vst1q_lane_u8(to + stride*15, from, 15);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<int16_t, Packet4s>(int16_t* to, const Packet4s& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<int16_t, Packet4s>(int16_t* to, const Packet4s& from, Index stride)
+ {
+   vst1_lane_s16(to + stride*0, from, 0);
+   vst1_lane_s16(to + stride*1, from, 1);
+   vst1_lane_s16(to + stride*2, from, 2);
+   vst1_lane_s16(to + stride*3, from, 3);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<int16_t, Packet8s>(int16_t* to, const Packet8s& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<int16_t, Packet8s>(int16_t* to, const Packet8s& from, Index stride)
+ {
+   vst1q_lane_s16(to + stride*0, from, 0);
+   vst1q_lane_s16(to + stride*1, from, 1);
+@@ -2195,14 +2195,14 @@
+   vst1q_lane_s16(to + stride*6, from, 6);
+   vst1q_lane_s16(to + stride*7, from, 7);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<uint16_t, Packet4us>(uint16_t* to, const Packet4us& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<uint16_t, Packet4us>(uint16_t* to, const Packet4us& from, Index stride)
+ {
+   vst1_lane_u16(to + stride*0, from, 0);
+   vst1_lane_u16(to + stride*1, from, 1);
+   vst1_lane_u16(to + stride*2, from, 2);
+   vst1_lane_u16(to + stride*3, from, 3);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<uint16_t, Packet8us>(uint16_t* to, const Packet8us& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<uint16_t, Packet8us>(uint16_t* to, const Packet8us& from, Index stride)
+ {
+   vst1q_lane_u16(to + stride*0, from, 0);
+   vst1q_lane_u16(to + stride*1, from, 1);
+@@ -2213,36 +2213,36 @@
+   vst1q_lane_u16(to + stride*6, from, 6);
+   vst1q_lane_u16(to + stride*7, from, 7);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<int32_t, Packet2i>(int32_t* to, const Packet2i& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<int32_t, Packet2i>(int32_t* to, const Packet2i& from, Index stride)
+ {
+   vst1_lane_s32(to + stride*0, from, 0);
+   vst1_lane_s32(to + stride*1, from, 1);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<int32_t, Packet4i>(int32_t* to, const Packet4i& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<int32_t, Packet4i>(int32_t* to, const Packet4i& from, Index stride)
+ {
+   vst1q_lane_s32(to + stride*0, from, 0);
+   vst1q_lane_s32(to + stride*1, from, 1);
+   vst1q_lane_s32(to + stride*2, from, 2);
+   vst1q_lane_s32(to + stride*3, from, 3);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<uint32_t, Packet2ui>(uint32_t* to, const Packet2ui& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<uint32_t, Packet2ui>(uint32_t* to, const Packet2ui& from, Index stride)
+ {
+   vst1_lane_u32(to + stride*0, from, 0);
+   vst1_lane_u32(to + stride*1, from, 1);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<uint32_t, Packet4ui>(uint32_t* to, const Packet4ui& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<uint32_t, Packet4ui>(uint32_t* to, const Packet4ui& from, Index stride)
+ {
+   vst1q_lane_u32(to + stride*0, from, 0);
+   vst1q_lane_u32(to + stride*1, from, 1);
+   vst1q_lane_u32(to + stride*2, from, 2);
+   vst1q_lane_u32(to + stride*3, from, 3);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<int64_t, Packet2l>(int64_t* to, const Packet2l& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<int64_t, Packet2l>(int64_t* to, const Packet2l& from, Index stride)
+ {
+   vst1q_lane_s64(to + stride*0, from, 0);
+   vst1q_lane_s64(to + stride*1, from, 1);
+ }
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<uint64_t, Packet2ul>(uint64_t* to, const Packet2ul& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<uint64_t, Packet2ul>(uint64_t* to, const Packet2ul& from, Index stride)
+ {
+   vst1q_lane_u64(to + stride*0, from, 0);
+   vst1q_lane_u64(to + stride*1, from, 1);
+@@ -2457,23 +2457,23 @@
+ template<> EIGEN_STRONG_INLINE uint64_t predux<Packet2ul>(const Packet2ul& a)
+ { return vgetq_lane_u64(a, 0) + vgetq_lane_u64(a, 1); }
+ 
+-template<> EIGEN_DEVICE_FUNC inline Packet4c predux_half_dowto4(const Packet8c& a)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4c predux_half_dowto4(const Packet8c& a)
+ {
+   return vget_lane_s32(vreinterpret_s32_s8(vadd_s8(a,
+       vreinterpret_s8_s32(vrev64_s32(vreinterpret_s32_s8(a))))), 0);
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet8c predux_half_dowto4(const Packet16c& a)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8c predux_half_dowto4(const Packet16c& a)
+ { return vadd_s8(vget_high_s8(a), vget_low_s8(a)); }
+-template<> EIGEN_DEVICE_FUNC inline Packet4uc predux_half_dowto4(const Packet8uc& a)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4uc predux_half_dowto4(const Packet8uc& a)
+ {
+   return vget_lane_u32(vreinterpret_u32_u8(vadd_u8(a,
+       vreinterpret_u8_u32(vrev64_u32(vreinterpret_u32_u8(a))))), 0);
+ }
+-template<> EIGEN_DEVICE_FUNC inline Packet8uc predux_half_dowto4(const Packet16uc& a)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8uc predux_half_dowto4(const Packet16uc& a)
+ { return vadd_u8(vget_high_u8(a), vget_low_u8(a)); }
+-template<> EIGEN_DEVICE_FUNC inline Packet4s predux_half_dowto4(const Packet8s& a)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4s predux_half_dowto4(const Packet8s& a)
+ { return vadd_s16(vget_high_s16(a), vget_low_s16(a)); }
+-template<> EIGEN_DEVICE_FUNC inline Packet4us predux_half_dowto4(const Packet8us& a)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4us predux_half_dowto4(const Packet8us& a)
+ { return vadd_u16(vget_high_u16(a), vget_low_u16(a)); }
+ 
+ // Other reduction functions:
+@@ -2752,13 +2752,13 @@
+   return vget_lane_u32(vpmax_u32(tmp, tmp), 0);
+ }
+ 
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet2f, 2>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet2f, 2>& kernel)
+ {
+   const float32x2x2_t z = vzip_f32(kernel.packet[0], kernel.packet[1]);
+   kernel.packet[0] = z.val[0];
+   kernel.packet[1] = z.val[1];
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4f, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4f, 4>& kernel)
+ {
+   const float32x4x2_t tmp1 = vzipq_f32(kernel.packet[0], kernel.packet[1]);
+   const float32x4x2_t tmp2 = vzipq_f32(kernel.packet[2], kernel.packet[3]);
+@@ -2768,7 +2768,7 @@
+   kernel.packet[2] = vcombine_f32(vget_low_f32(tmp1.val[1]), vget_low_f32(tmp2.val[1]));
+   kernel.packet[3] = vcombine_f32(vget_high_f32(tmp1.val[1]), vget_high_f32(tmp2.val[1]));
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4c, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4c, 4>& kernel)
+ {
+   const int8x8_t a = vreinterpret_s8_s32(vset_lane_s32(kernel.packet[2], vdup_n_s32(kernel.packet[0]), 1));
+   const int8x8_t b = vreinterpret_s8_s32(vset_lane_s32(kernel.packet[3], vdup_n_s32(kernel.packet[1]), 1));
+@@ -2781,7 +2781,7 @@
+   kernel.packet[2] = vget_lane_s32(vreinterpret_s32_s16(zip16.val[1]), 0);
+   kernel.packet[3] = vget_lane_s32(vreinterpret_s32_s16(zip16.val[1]), 1);
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet8c, 8>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet8c, 8>& kernel)
+ {
+   int8x8x2_t zip8[4];
+   uint16x4x2_t zip16[4];
+@@ -2811,7 +2811,7 @@
+     }
+   }
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet16c, 16>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet16c, 16>& kernel)
+ {
+   int8x16x2_t zip8[8];
+   uint16x8x2_t zip16[8];
+@@ -2858,7 +2858,7 @@
+     }
+   }
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4uc, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4uc, 4>& kernel)
+ {
+   const uint8x8_t a = vreinterpret_u8_u32(vset_lane_u32(kernel.packet[2], vdup_n_u32(kernel.packet[0]), 1));
+   const uint8x8_t b = vreinterpret_u8_u32(vset_lane_u32(kernel.packet[3], vdup_n_u32(kernel.packet[1]), 1));
+@@ -2871,7 +2871,7 @@
+   kernel.packet[2] = vget_lane_u32(vreinterpret_u32_u16(zip16.val[1]), 0);
+   kernel.packet[3] = vget_lane_u32(vreinterpret_u32_u16(zip16.val[1]), 1);
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet8uc, 8>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet8uc, 8>& kernel)
+ {
+   uint8x8x2_t zip8[4];
+   uint16x4x2_t zip16[4];
+@@ -2901,7 +2901,7 @@
+     }
+   }
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet16uc, 16>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet16uc, 16>& kernel)
+ {
+   uint8x16x2_t zip8[8];
+   uint16x8x2_t zip16[8];
+@@ -2946,7 +2946,7 @@
+     }
+   }
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4s, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4s, 4>& kernel)
+ {
+   const int16x4x2_t zip16_1 = vzip_s16(kernel.packet[0], kernel.packet[1]);
+   const int16x4x2_t zip16_2 = vzip_s16(kernel.packet[2], kernel.packet[3]);
+@@ -2960,7 +2960,7 @@
+   kernel.packet[3] = vreinterpret_s16_u32(zip32_2.val[1]);
+ }
+ 
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet8s, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet8s, 4>& kernel)
+ {
+   const int16x8x2_t zip16_1 = vzipq_s16(kernel.packet[0], kernel.packet[1]);
+   const int16x8x2_t zip16_2 = vzipq_s16(kernel.packet[2], kernel.packet[3]);
+@@ -2974,7 +2974,7 @@
+   kernel.packet[3] = vreinterpretq_s16_u32(zip32_2.val[1]);
+ }
+ 
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet16uc, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet16uc, 4>& kernel)
+ {
+   const uint8x16x2_t zip8_1 = vzipq_u8(kernel.packet[0], kernel.packet[1]);
+   const uint8x16x2_t zip8_2 = vzipq_u8(kernel.packet[2], kernel.packet[3]);
+@@ -2988,7 +2988,7 @@
+   kernel.packet[3] = vreinterpretq_u8_u16(zip16_2.val[1]);
+ }
+ 
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet8s, 8>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet8s, 8>& kernel)
+ {
+   const int16x8x2_t zip16_1 = vzipq_s16(kernel.packet[0], kernel.packet[1]);
+   const int16x8x2_t zip16_2 = vzipq_s16(kernel.packet[2], kernel.packet[3]);
+@@ -3009,7 +3009,7 @@
+   kernel.packet[6] = vreinterpretq_s16_u32(vcombine_u32(vget_low_u32(zip32_2.val[1]), vget_low_u32(zip32_4.val[1])));
+   kernel.packet[7] = vreinterpretq_s16_u32(vcombine_u32(vget_high_u32(zip32_2.val[1]), vget_high_u32(zip32_4.val[1])));
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4us, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4us, 4>& kernel)
+ {
+   const uint16x4x2_t zip16_1 = vzip_u16(kernel.packet[0], kernel.packet[1]);
+   const uint16x4x2_t zip16_2 = vzip_u16(kernel.packet[2], kernel.packet[3]);
+@@ -3022,7 +3022,7 @@
+   kernel.packet[2] = vreinterpret_u16_u32(zip32_2.val[0]);
+   kernel.packet[3] = vreinterpret_u16_u32(zip32_2.val[1]);
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet8us, 8>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet8us, 8>& kernel)
+ {
+   const uint16x8x2_t zip16_1 = vzipq_u16(kernel.packet[0], kernel.packet[1]);
+   const uint16x8x2_t zip16_2 = vzipq_u16(kernel.packet[2], kernel.packet[3]);
+@@ -3043,13 +3043,13 @@
+   kernel.packet[6] = vreinterpretq_u16_u32(vcombine_u32(vget_low_u32(zip32_2.val[1]), vget_low_u32(zip32_4.val[1])));
+   kernel.packet[7] = vreinterpretq_u16_u32(vcombine_u32(vget_high_u32(zip32_2.val[1]), vget_high_u32(zip32_4.val[1])));
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet2i, 2>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet2i, 2>& kernel)
+ {
+   const int32x2x2_t z = vzip_s32(kernel.packet[0], kernel.packet[1]);
+   kernel.packet[0] = z.val[0];
+   kernel.packet[1] = z.val[1];
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4i, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4i, 4>& kernel)
+ {
+   const int32x4x2_t tmp1 = vzipq_s32(kernel.packet[0], kernel.packet[1]);
+   const int32x4x2_t tmp2 = vzipq_s32(kernel.packet[2], kernel.packet[3]);
+@@ -3059,13 +3059,13 @@
+   kernel.packet[2] = vcombine_s32(vget_low_s32(tmp1.val[1]), vget_low_s32(tmp2.val[1]));
+   kernel.packet[3] = vcombine_s32(vget_high_s32(tmp1.val[1]), vget_high_s32(tmp2.val[1]));
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet2ui, 2>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet2ui, 2>& kernel)
+ {
+   const uint32x2x2_t z = vzip_u32(kernel.packet[0], kernel.packet[1]);
+   kernel.packet[0] = z.val[0];
+   kernel.packet[1] = z.val[1];
+ }
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4ui, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4ui, 4>& kernel)
+ {
+   const uint32x4x2_t tmp1 = vzipq_u32(kernel.packet[0], kernel.packet[1]);
+   const uint32x4x2_t tmp2 = vzipq_u32(kernel.packet[2], kernel.packet[3]);
+@@ -3075,7 +3075,7 @@
+   kernel.packet[2] = vcombine_u32(vget_low_u32(tmp1.val[1]), vget_low_u32(tmp2.val[1]));
+   kernel.packet[3] = vcombine_u32(vget_high_u32(tmp1.val[1]), vget_high_u32(tmp2.val[1]));
+ }
+-EIGEN_DEVICE_FUNC inline void
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void
+ ptranspose(PacketBlock<Packet2l, 2>& kernel)
+ {
+ #if EIGEN_ARCH_ARM64
+@@ -3094,7 +3094,7 @@
+   kernel.packet[1] = vcombine_s64(tmp[0][1], tmp[1][1]);
+ #endif
+ }
+-EIGEN_DEVICE_FUNC inline void
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void
+ ptranspose(PacketBlock<Packet2ul, 2>& kernel)
+ {
+ #if EIGEN_ARCH_ARM64
+@@ -3114,37 +3114,37 @@
+ #endif
+ }
+ 
+-template<> EIGEN_DEVICE_FUNC inline Packet2f pselect( const Packet2f& mask, const Packet2f& a, const Packet2f& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2f pselect( const Packet2f& mask, const Packet2f& a, const Packet2f& b)
+ { return vbsl_f32(vreinterpret_u32_f32(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet4f pselect(const Packet4f& mask, const Packet4f& a, const Packet4f& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4f pselect(const Packet4f& mask, const Packet4f& a, const Packet4f& b)
+ { return vbslq_f32(vreinterpretq_u32_f32(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet8c pselect(const Packet8c& mask, const Packet8c& a, const Packet8c& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8c pselect(const Packet8c& mask, const Packet8c& a, const Packet8c& b)
+ { return vbsl_s8(vreinterpret_u8_s8(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet16c pselect(const Packet16c& mask, const Packet16c& a, const Packet16c& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet16c pselect(const Packet16c& mask, const Packet16c& a, const Packet16c& b)
+ { return vbslq_s8(vreinterpretq_u8_s8(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet8uc pselect(const Packet8uc& mask, const Packet8uc& a, const Packet8uc& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8uc pselect(const Packet8uc& mask, const Packet8uc& a, const Packet8uc& b)
+ { return vbsl_u8(mask, a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet16uc pselect(const Packet16uc& mask, const Packet16uc& a, const Packet16uc& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet16uc pselect(const Packet16uc& mask, const Packet16uc& a, const Packet16uc& b)
+ { return vbslq_u8(mask, a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet4s pselect(const Packet4s& mask, const Packet4s& a, const Packet4s& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4s pselect(const Packet4s& mask, const Packet4s& a, const Packet4s& b)
+ { return vbsl_s16(vreinterpret_u16_s16(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet8s pselect(const Packet8s& mask, const Packet8s& a, const Packet8s& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8s pselect(const Packet8s& mask, const Packet8s& a, const Packet8s& b)
+ { return vbslq_s16(vreinterpretq_u16_s16(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet4us pselect(const Packet4us& mask, const Packet4us& a, const Packet4us& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4us pselect(const Packet4us& mask, const Packet4us& a, const Packet4us& b)
+ { return vbsl_u16(mask, a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet8us pselect(const Packet8us& mask, const Packet8us& a, const Packet8us& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8us pselect(const Packet8us& mask, const Packet8us& a, const Packet8us& b)
+ { return vbslq_u16(mask, a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet2i pselect(const Packet2i& mask, const Packet2i& a, const Packet2i& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2i pselect(const Packet2i& mask, const Packet2i& a, const Packet2i& b)
+ { return vbsl_s32(vreinterpret_u32_s32(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet4i pselect(const Packet4i& mask, const Packet4i& a, const Packet4i& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4i pselect(const Packet4i& mask, const Packet4i& a, const Packet4i& b)
+ { return vbslq_s32(vreinterpretq_u32_s32(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet2ui pselect(const Packet2ui& mask, const Packet2ui& a, const Packet2ui& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2ui pselect(const Packet2ui& mask, const Packet2ui& a, const Packet2ui& b)
+ { return vbsl_u32(mask, a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet4ui pselect(const Packet4ui& mask, const Packet4ui& a, const Packet4ui& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4ui pselect(const Packet4ui& mask, const Packet4ui& a, const Packet4ui& b)
+ { return vbslq_u32(mask, a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet2l pselect(const Packet2l& mask, const Packet2l& a, const Packet2l& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2l pselect(const Packet2l& mask, const Packet2l& a, const Packet2l& b)
+ { return vbslq_s64(vreinterpretq_u64_s64(mask), a, b); }
+-template<> EIGEN_DEVICE_FUNC inline Packet2ul pselect(const Packet2ul& mask, const Packet2ul& a, const Packet2ul& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2ul pselect(const Packet2ul& mask, const Packet2ul& a, const Packet2ul& b)
+ { return vbslq_u64(mask, a, b); }
+ 
+ /**
+@@ -3441,7 +3441,7 @@
+   return pandnot<Packet4us>(a, b);
+ }
+ 
+-template<> EIGEN_DEVICE_FUNC inline Packet4bf pselect(const Packet4bf& mask, const Packet4bf& a,
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4bf pselect(const Packet4bf& mask, const Packet4bf& a,
+                                                       const Packet4bf& b)
+ {
+   return pselect<Packet4us>(mask, a, b);
+@@ -3507,7 +3507,7 @@
+   return preverse<Packet4us>(a);
+ }
+ 
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4bf, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4bf, 4>& kernel)
+ {
+   PacketBlock<Packet4us, 4> k;
+   k.packet[0] = kernel.packet[0];
+@@ -3739,7 +3739,7 @@
+ template<> EIGEN_STRONG_INLINE void pstoreu<double>(double* to, const Packet2d& from)
+ { EIGEN_DEBUG_UNALIGNED_STORE vst1q_f64(to,from); }
+ 
+-template<> EIGEN_DEVICE_FUNC inline Packet2d pgather<double, Packet2d>(const double* from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2d pgather<double, Packet2d>(const double* from, Index stride)
+ {
+   Packet2d res = pset1<Packet2d>(0.0);
+   res = vld1q_lane_f64(from + 0*stride, res, 0);
+@@ -3747,7 +3747,7 @@
+   return res;
+ }
+ 
+-template<> EIGEN_DEVICE_FUNC inline void pscatter<double, Packet2d>(double* to, const Packet2d& from, Index stride)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<double, Packet2d>(double* to, const Packet2d& from, Index stride)
+ {
+   vst1q_lane_f64(to + stride*0, from, 0);
+   vst1q_lane_f64(to + stride*1, from, 1);
+@@ -3791,7 +3791,7 @@
+ { return vgetq_lane_f64(vpmaxq_f64(a,a), 0); }
+ 
+ 
+-EIGEN_DEVICE_FUNC inline void
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void
+ ptranspose(PacketBlock<Packet2d, 2>& kernel)
+ {
+   const float64x2_t tmp1 = vzip1q_f64(kernel.packet[0], kernel.packet[1]);
+@@ -3801,7 +3801,7 @@
+   kernel.packet[1] = tmp2;
+ }
+ 
+-template<> EIGEN_DEVICE_FUNC inline Packet2d pselect( const Packet2d& mask, const Packet2d& a, const Packet2d& b)
++template<> EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet2d pselect( const Packet2d& mask, const Packet2d& a, const Packet2d& b)
+ { return vbslq_f64(vreinterpretq_u64_f64(mask), a, b); }
+ 
+ template<> EIGEN_STRONG_INLINE Packet2d pldexp<Packet2d>(const Packet2d& a, const Packet2d& exponent)
+@@ -3914,7 +3914,7 @@
+ };
+ 
+ template<>
+-EIGEN_DEVICE_FUNC Packet4hf predux_half_dowto4<Packet8hf>(const Packet8hf& a) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4hf predux_half_dowto4<Packet8hf>(const Packet8hf& a) {
+   return vadd_f16(vget_low_f16(a), vget_high_f16(a));
+ }
+ 
+@@ -4193,23 +4193,23 @@
+   return vcombine_f16(lo, hi);
+ }
+ 
+-EIGEN_DEVICE_FUNC inline Packet8hf pinsertfirst(const Packet8hf& a, Eigen::half b) { return vsetq_lane_f16(b.x, a, 0); }
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8hf pinsertfirst(const Packet8hf& a, Eigen::half b) { return vsetq_lane_f16(b.x, a, 0); }
+ 
+-EIGEN_DEVICE_FUNC inline Packet4hf pinsertfirst(const Packet4hf& a, Eigen::half b) { return vset_lane_f16(b.x, a, 0); }
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4hf pinsertfirst(const Packet4hf& a, Eigen::half b) { return vset_lane_f16(b.x, a, 0); }
+ 
+ template <>
+-EIGEN_DEVICE_FUNC inline Packet8hf pselect(const Packet8hf& mask, const Packet8hf& a, const Packet8hf& b) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8hf pselect(const Packet8hf& mask, const Packet8hf& a, const Packet8hf& b) {
+   return vbslq_f16(vreinterpretq_u16_f16(mask), a, b);
+ }
+ 
+ template <>
+-EIGEN_DEVICE_FUNC inline Packet4hf pselect(const Packet4hf& mask, const Packet4hf& a, const Packet4hf& b) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4hf pselect(const Packet4hf& mask, const Packet4hf& a, const Packet4hf& b) {
+   return vbsl_f16(vreinterpret_u16_f16(mask), a, b);
+ }
+ 
+-EIGEN_DEVICE_FUNC inline Packet8hf pinsertlast(const Packet8hf& a, Eigen::half b) { return vsetq_lane_f16(b.x, a, 7); }
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8hf pinsertlast(const Packet8hf& a, Eigen::half b) { return vsetq_lane_f16(b.x, a, 7); }
+ 
+-EIGEN_DEVICE_FUNC inline Packet4hf pinsertlast(const Packet4hf& a, Eigen::half b) { return vset_lane_f16(b.x, a, 3); }
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4hf pinsertlast(const Packet4hf& a, Eigen::half b) { return vset_lane_f16(b.x, a, 3); }
+ 
+ template <>
+ EIGEN_STRONG_INLINE void pstore<Eigen::half>(Eigen::half* to, const Packet8hf& from) {
+@@ -4232,7 +4232,7 @@
+ }
+ 
+ template <>
+-EIGEN_DEVICE_FUNC inline Packet8hf pgather<Eigen::half, Packet8hf>(const Eigen::half* from, Index stride) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet8hf pgather<Eigen::half, Packet8hf>(const Eigen::half* from, Index stride) {
+   Packet8hf res = pset1<Packet8hf>(Eigen::half(0.f));
+   res = vsetq_lane_f16(from[0 * stride].x, res, 0);
+   res = vsetq_lane_f16(from[1 * stride].x, res, 1);
+@@ -4246,7 +4246,7 @@
+ }
+ 
+ template <>
+-EIGEN_DEVICE_FUNC inline Packet4hf pgather<Eigen::half, Packet4hf>(const Eigen::half* from, Index stride) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE Packet4hf pgather<Eigen::half, Packet4hf>(const Eigen::half* from, Index stride) {
+   Packet4hf res = pset1<Packet4hf>(Eigen::half(0.f));
+   res = vset_lane_f16(from[0 * stride].x, res, 0);
+   res = vset_lane_f16(from[1 * stride].x, res, 1);
+@@ -4256,7 +4256,7 @@
+ }
+ 
+ template <>
+-EIGEN_DEVICE_FUNC inline void pscatter<Eigen::half, Packet8hf>(Eigen::half* to, const Packet8hf& from, Index stride) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<Eigen::half, Packet8hf>(Eigen::half* to, const Packet8hf& from, Index stride) {
+   to[stride * 0].x = vgetq_lane_f16(from, 0);
+   to[stride * 1].x = vgetq_lane_f16(from, 1);
+   to[stride * 2].x = vgetq_lane_f16(from, 2);
+@@ -4268,7 +4268,7 @@
+ }
+ 
+ template <>
+-EIGEN_DEVICE_FUNC inline void pscatter<Eigen::half, Packet4hf>(Eigen::half* to, const Packet4hf& from, Index stride) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void pscatter<Eigen::half, Packet4hf>(Eigen::half* to, const Packet4hf& from, Index stride) {
+   to[stride * 0].x = vget_lane_f16(from, 0);
+   to[stride * 1].x = vget_lane_f16(from, 1);
+   to[stride * 2].x = vget_lane_f16(from, 2);
+@@ -4422,7 +4422,7 @@
+   return h;
+ }
+ 
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet8hf, 4>& kernel)
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet8hf, 4>& kernel)
+ {
+   EIGEN_ALIGN16 Eigen::half in[4][8];
+ 
+@@ -4451,7 +4451,7 @@
+   kernel.packet[3] = pload<Packet8hf>(out[3]);
+ }
+ 
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet4hf, 4>& kernel) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet4hf, 4>& kernel) {
+   EIGEN_ALIGN16 float16x4x4_t tmp_x4;
+   float16_t* tmp = (float16_t*)&kernel;
+   tmp_x4 = vld4_f16(tmp);
+@@ -4462,7 +4462,7 @@
+   kernel.packet[3] = tmp_x4.val[3];
+ }
+ 
+-EIGEN_DEVICE_FUNC inline void ptranspose(PacketBlock<Packet8hf, 8>& kernel) {
++EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE void ptranspose(PacketBlock<Packet8hf, 8>& kernel) {
+   float16x8x2_t T_1[4];
+ 
+   T_1[0] = vuzpq_f16(kernel.packet[0], kernel.packet[1]);
+@@ -4498,3 +4498,4 @@
+ } // end namespace Eigen
+ 
+ #endif // EIGEN_PACKET_MATH_NEON_H
++

--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -17,6 +17,7 @@ class PyHorovod(PythonPackage, CudaPackage):
     maintainers = ['adamjstewart', 'aweits', 'tgaddair']
 
     version('master', branch='master', submodules=True)
+    version('0.23.0', tag='v0.23.0', submodules=True)
     version('0.21.3', tag='v0.21.3', submodules=True)
     version('0.21.2', tag='v0.21.2', submodules=True)
     version('0.21.1', tag='v0.21.1', submodules=True)
@@ -108,6 +109,11 @@ class PyHorovod(PythonPackage, CudaPackage):
 
     # https://github.com/horovod/horovod/pull/1835
     patch('fma.patch', when='@0.19.0:0.19.1')
+
+    # This patch modifies Eigen to enable the compilation on aarch64 system.
+    # See the following URL for more detail:
+    # https://gitlab.com/libeigen/eigen/-/commit/fd1dcb6b45a2c797ad4c4d6cc7678ee70763b4ed
+    patch('eigen.patch', when='@0.21: target=aarch64:')
 
     @property
     def import_modules(self):

--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -126,8 +126,8 @@ class PyHorovod(PythonPackage, CudaPackage):
     # https://github.com/horovod/horovod/pull/1835
     patch('fma.patch', when='@0.19.0:0.19.1')
 
-    # This patch modifies Eigen to enable the compilation on aarch64 system.
-    # See the following URL for more detail:
+    # Patch vendored copy of eigen to fix build on aarch64
+    # https://github.com/horovod/horovod/issues/3605
     # https://gitlab.com/libeigen/eigen/-/commit/fd1dcb6b45a2c797ad4c4d6cc7678ee70763b4ed
     patch('eigen.patch', when='@0.21: target=aarch64:')
 
@@ -146,8 +146,7 @@ class PyHorovod(PythonPackage, CudaPackage):
 
         if 'frameworks=pytorch' in self.spec:
             modules.extend([
-                'horovod.torch', 'horovod.torch.mpi_lib',
-                'horovod.torch.elastic', 'horovod.torch.mpi_lib_impl'
+                'horovod.torch', 'horovod.torch.elastic'
             ])
 
         if 'frameworks=mxnet' in self.spec:
@@ -242,4 +241,4 @@ class PyHorovod(PythonPackage, CudaPackage):
 
     def test(self):
         super(PyHorovod, self).test()
-        run_test(self.prefix.bin.horovodrun, '--check-build')
+        self.run_test(self.prefix.bin.horovodrun, '--check-build')

--- a/var/spack/repos/builtin/packages/py-horovod/package.py
+++ b/var/spack/repos/builtin/packages/py-horovod/package.py
@@ -17,7 +17,14 @@ class PyHorovod(PythonPackage, CudaPackage):
     maintainers = ['adamjstewart', 'aweits', 'tgaddair']
 
     version('master', branch='master', submodules=True)
+    version('0.25.0', tag='v0.25.0', submodules=True)
+    version('0.24.3', tag='v0.24.3', submodules=True)
+    version('0.24.2', tag='v0.24.2', submodules=True)
+    version('0.24.1', tag='v0.24.1', submodules=True)
+    version('0.24.0', tag='v0.24.0', submodules=True)
     version('0.23.0', tag='v0.23.0', submodules=True)
+    version('0.22.1', tag='v0.22.1', submodules=True)
+    version('0.22.0', tag='v0.22.0', submodules=True)
     version('0.21.3', tag='v0.21.3', submodules=True)
     version('0.21.2', tag='v0.21.2', submodules=True)
     version('0.21.1', tag='v0.21.1', submodules=True)
@@ -44,7 +51,7 @@ class PyHorovod(PythonPackage, CudaPackage):
     # https://github.com/horovod/horovod/blob/master/docs/install.rst
     variant('frameworks', default='pytorch',
             description='Deep learning frameworks to build support for',
-            values=('tensorflow', 'pytorch', 'mxnet', 'keras', 'spark', 'ray'),
+            values=('tensorflow', 'keras', 'pytorch', 'mxnet', 'spark', 'ray'),
             multi=True)
     variant('controllers', default='mpi',
             description='Controllers to coordinate work between processes',
@@ -54,6 +61,11 @@ class PyHorovod(PythonPackage, CudaPackage):
             values=('nccl', 'mpi', 'gloo', 'ccl'), multi=False)
     variant('cuda', default=True, description='Build with CUDA')
     variant('rocm', default=False, description='Build with ROCm')
+
+    # Build dependencies
+    depends_on('cmake@3.13:', type='build', when='@0.24:')
+    depends_on('cmake@2.8.12:', type='build', when='@0.20:')
+    depends_on('pkgconfig', type='build')
 
     # Required dependencies
     depends_on('python@3.6:',    type=('build', 'run'), when='@0.20:')
@@ -67,38 +79,42 @@ class PyHorovod(PythonPackage, CudaPackage):
     # Framework dependencies
     depends_on('py-tensorflow@1.1.0:',  type=('build', 'link', 'run'), when='frameworks=tensorflow')
     depends_on('py-tensorflow@1.15:',   type=('build', 'link', 'run'), when='frameworks=tensorflow @0.20:')
-    depends_on('py-tensorflow-estimator', type=('build', 'run'), when='frameworks=tensorflow')
+    depends_on('py-tensorflow-estimator', type=('build', 'run'),       when='frameworks=tensorflow')
+    depends_on('py-keras@2.0.8,2.1.2:', type=('build', 'run'),         when='frameworks=keras')
     depends_on('py-torch@0.4.0:',       type=('build', 'link', 'run'), when='frameworks=pytorch')
     depends_on('py-torch@1.2:',         type=('build', 'link', 'run'), when='frameworks=pytorch @0.20:')
+    depends_on('py-torch@1.5:',         type=('build', 'link', 'run'), when='frameworks=pytorch @0.25:')
     depends_on('py-torchvision',        type=('build', 'run'),         when='frameworks=pytorch @:0.19.1')
     depends_on('py-cffi@1.4.0:',        type=('build', 'run'),         when='frameworks=pytorch')
+    depends_on('py-pytorch-lightning',  type=('build', 'run'),         when='frameworks=pytorch @0.22:0.23')
+    depends_on('py-pytorch-lightning@1.3.8', type=('build', 'run'),    when='frameworks=pytorch @0.24')
+    depends_on('py-pytorch-lightning@1.3.8:1.5.9', type=('build', 'run'), when='frameworks=pytorch @0.25:')
     depends_on('mxnet@1.4.1:+python',   type=('build', 'link', 'run'), when='frameworks=mxnet')
-    depends_on('py-keras@2.0.8,2.1.2:', type=('build', 'run'),         when='frameworks=keras')
-    depends_on('py-h5py@:2',        type=('build', 'run'),         when='frameworks=spark')
+    depends_on('py-h5py@:2',            type=('build', 'run'),         when='frameworks=spark @:0.23')
     depends_on('py-numpy',              type=('build', 'run'),         when='frameworks=spark')
     depends_on('py-petastorm@0.8.2',    type=('build', 'run'),         when='frameworks=spark @:0.19.1')
     depends_on('py-petastorm@0.9.0:',   type=('build', 'run'),         when='frameworks=spark @0.19.2:0.21.0')
     depends_on('py-petastorm@0.9.8:',   type=('build', 'run'),         when='frameworks=spark @0.21.1:')
+    depends_on('py-petastorm@0.11:',    type=('build', 'run'),         when='frameworks=spark @0.22:')
     depends_on('py-pyarrow@0.15.0:',    type=('build', 'run'),         when='frameworks=spark')
     depends_on('py-pyspark@2.3.2:',     type=('build', 'run'),         when='frameworks=spark ^python@:3.7')
     depends_on('py-pyspark@3.0.0:',     type=('build', 'run'),         when='frameworks=spark ^python@3.8:')
+    depends_on('py-fsspec',             type=('build', 'run'),         when='frameworks=spark @0.22.1:0.24.1')
+    depends_on('py-fsspec@2021.07:',    type=('build', 'run'),         when='frameworks=spark @0.24.2:')
     depends_on('py-ray',                type=('build', 'run'),         when='frameworks=ray')
-
-    # Build dependencies
-    depends_on('cmake@2.8.12:', type='build', when='@0.20:')
-    depends_on('pkgconfig', type='build')
+    depends_on('py-aioredis@:1',        type=('build', 'run'),         when='frameworks=ray @0.23:')
 
     # Controller dependencies
     depends_on('mpi', when='controllers=mpi')
-    # There does not appear to be a way to use an external Gloo installation
     depends_on('cmake', type='build', when='controllers=gloo')
     depends_on('libuv@1.26:', when='controllers=gloo platform=darwin')
 
     # Tensor Operations dependencies
     depends_on('nccl@2:', when='tensor_ops=nccl')
     depends_on('mpi', when='tensor_ops=mpi')
-    # There does not appear to be a way to use an external Gloo installation
     depends_on('cmake', type='build', when='tensor_ops=gloo')
+    depends_on('libuv@1.26:', when='tensor_ops=gloo platform=darwin')
+    depends_on('intel-oneapi-ccl', when='tensor_ops=ccl')
 
     conflicts('cuda_arch=none', when='+cuda',
               msg='Must specify CUDA compute capabilities of your GPU, see '
@@ -166,7 +182,7 @@ class PyHorovod(PythonPackage, CudaPackage):
         # Build system
         env.set('PKG_CONFIG_EXECUTABLE',
                 self.spec['pkgconfig'].prefix.bin.join('pkg-config'))
-        if '^cmake' in self.spec:
+        if 'cmake' in self.spec:
             env.set('HOROVOD_CMAKE', self.spec['cmake'].command.path)
         env.set('MAKEFLAGS', '-j{0}'.format(make_jobs))
 
@@ -187,11 +203,11 @@ class PyHorovod(PythonPackage, CudaPackage):
             env.set('HOROVOD_WITHOUT_MXNET', 1)
 
         # Controllers
-        if 'controllers=mpi' in self.spec:
+        if 'controllers=mpi' in self.spec or 'tensor_ops=mpi' in self.spec:
             env.set('HOROVOD_WITH_MPI', 1)
         else:
             env.set('HOROVOD_WITHOUT_MPI', 1)
-        if 'controllers=gloo' in self.spec:
+        if 'controllers=gloo' in self.spec or 'tensor_ops=gloo' in self.spec:
             env.set('HOROVOD_WITH_GLOO', 1)
         else:
             env.set('HOROVOD_WITHOUT_GLOO', 1)

--- a/var/spack/repos/builtin/packages/py-petastorm/package.py
+++ b/var/spack/repos/builtin/packages/py-petastorm/package.py
@@ -12,11 +12,13 @@ class PyPetastorm(PythonPackage):
     Tensorflow, Pytorch, and other Python-based ML training frameworks."""
 
     homepage = "https://github.com/uber/petastorm"
-    pypi = "petastorm/petastorm-0.8.2.tar.gz"
+    url = "https://github.com/uber/petastorm/archive/refs/tags/v0.11.4.tar.gz"
 
     maintainers = ['adamjstewart']
-    version('0.9.8', sha256='66009b7ad3f08b0485a748f12b2095a0d2470e04f0c63de43cd5b099f270c268')
-    version('0.8.2', sha256='7782c315e1ee8d15c7741e3eea41e77b9efce661cf58aa0220a801db64f52f91')
+
+    version('0.11.4', sha256='7090dfc86f110e641d95798bcc75f8b1ca14cd56ed3feef491baaa6849629e51')
+    version('0.9.8', sha256='571855224411b88b759ba5d48b288ad2ba09997ebd259292f72b9246144b8101')
+    version('0.8.2', sha256='1bf4f26ce0b14f7334c0c29868154f1e600021a044f7565a5ad766b5ecdde911')
 
     depends_on('python@3:', when='@0.9.8:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
@@ -33,3 +35,4 @@ class PyPetastorm(PythonPackage):
     depends_on('py-pyarrow@0.12.0:', type=('build', 'run'), when='@:0.8.2')
     depends_on('py-pyarrow@0.17.1:', type=('build', 'run'), when='@0.9.8:')
     depends_on('py-six@1.5.0:', type=('build', 'run'))
+    depends_on('py-fsspec', type=('build', 'run'), when='@0.11.4:')


### PR DESCRIPTION
- Add version 0.23.0
- Fix to enable the compilation of py-horovod on aarch64 system. This fix avoids the multiple definitions that occur when building Eigen. This is discussed in [GitLab: libeigen/eigen/Commits/fd1dcb6b](https://gitlab.com/libeigen/eigen/-/commit/fd1dcb6b45a2c797ad4c4d6cc7678ee70763b4ed).

Related to: https://github.com/horovod/horovod/issues/3605, https://github.com/horovod/horovod/issues/3587, https://github.com/horovod/horovod/issues/3579