### PR TITLE
gfsio: support Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/gfsio/package.py
+++ b/var/spack/repos/builtin/packages/gfsio/package.py
@@ -25,3 +25,9 @@ class Gfsio(CMakePackage):
         for suffix in ('4', ''):
             env.set('GFSIO_LIB' + suffix, lib[0])
             env.set('GFSIO_INC' + suffix, join_path(self.prefix, 'include'))
+
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('%fj'):
+            if name == 'fflags':
+                flags.append('-Free')
+        return (None, None, flags)


### PR DESCRIPTION
Add "-Free" Fortran flags to compile gfsio with Fujitsu compiler. 