### PR TITLE
Add checksum for relax@root6

### DIFF
--- a/var/spack/repos/builtin/packages/relax/package.py
+++ b/var/spack/repos/builtin/packages/relax/package.py
@@ -15,8 +15,6 @@ class Relax(CMakePackage):
 
     tags = ['hep']
 
-    # The RELAX project stopped using a fixed release model since it moved to
-    # ROOT 6, so any package checksum is a lie...
     version('root6', sha256='1d24b1a0884bbe99d60f7d02fea45d59695c158ab5e53516ac3fb780eb460bb4')
 
     depends_on('clhep')

--- a/var/spack/repos/builtin/packages/relax/package.py
+++ b/var/spack/repos/builtin/packages/relax/package.py
@@ -17,7 +17,7 @@ class Relax(CMakePackage):
 
     # The RELAX project stopped using a fixed release model since it moved to
     # ROOT 6, so any package checksum is a lie...
-    version('root6')
+    version('root6', sha256='1d24b1a0884bbe99d60f7d02fea45d59695c158ab5e53516ac3fb780eb460bb4')
 
     depends_on('clhep')
     depends_on('gsl')


### PR DESCRIPTION
Without the checksum added, the fetching raises "NoDigestError: Attempt to check URLFetchStrategy with no digest" (although the comment in the recipe says that "checksum is a lie...").