### PR TITLE
relion: add version 4.0-beta

### DIFF
--- a/var/spack/repos/builtin/packages/relion/package.py
+++ b/var/spack/repos/builtin/packages/relion/package.py
@@ -14,9 +14,12 @@ class Relion(CMakePackage, CudaPackage):
 
     homepage = "http://www2.mrc-lmb.cam.ac.uk/relion"
     git      = "https://github.com/3dem/relion.git"
-    url      = "https://github.com/3dem/relion/archive/3.1.0.zip"
+    url      = "https://github.com/3dem/relion/archive/3.1.3.zip"
 
-    version('3.1.3', sha256='e67277200b54d1814045cfe02c678a58d88eb8f988091573453c8568bfde90fc')
+    # New 4.0-beta
+    version('4.0-beta', commit='e3537c82cf7a816df805f4e54c0bc12475803524')
+
+    version('3.1.3', sha256='e67277200b54d1814045cfe02c678a58d88eb8f988091573453c8568bfde90fc', preferred=True)
     version('3.1.2', sha256='dcdf6f214f79a03d29f0fed2de58054efa35a9d8401543bdc52bfb177987931f')
     version('3.1.1', sha256='63e9b77e1ba9ec239375020ad6ff631424d1a5803cba5c608c09fd44d20b1618')
     version('3.1.0', sha256='8a7e751fa6ebcdf9f36046499b3d88e170c4da86d5ff9ad1914b5f3d178867a8')


### PR DESCRIPTION
This commit updates the relion package:
1. add version 4.0-beta to available versions ;
2. update stable version to 3.1.3.

The package installation was tested under gcc/8.4.0 using mvapich2.

