### PR TITLE
libdrm@2.4.101: needs meson for build

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -32,6 +32,7 @@ class Libdrm(Package):
     depends_on('docbook-xsl', type='build')
     depends_on('libpciaccess@0.10:')
     depends_on('libpthread-stubs')
+    depends_on('meson', type='build', when='@2.4.101:')
 
     def url_for_version(self, version):
         if version <= Version('2.4.100'):


### PR DESCRIPTION
`libdrm@2.4.101:` looks like it needs `meson` as a build dependency

Fixes https://github.com/spack/spack/issues/29326

@wdconinc