### PR TITLE
dos2unix: add the external find feature for dos2unix

### DIFF
--- a/var/spack/repos/builtin/packages/dos2unix/package.py
+++ b/var/spack/repos/builtin/packages/dos2unix/package.py
@@ -19,6 +19,10 @@ class Dos2unix(MakefilePackage):
 
     depends_on('gettext')
 
+    tags = ['build-tools']
+
+    executables = [r'^dos2unix$']
+
     @property
     def build_targets(self):
         targets = [
@@ -29,3 +33,9 @@ class Dos2unix(MakefilePackage):
 
     def install(self, spec, prefix):
         make('prefix={0}'.format(prefix), 'install')
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'^dos2unix\s+([\d\.]+)', output)
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/dos2unix/package.py
+++ b/var/spack/repos/builtin/packages/dos2unix/package.py
@@ -19,8 +19,6 @@ class Dos2unix(MakefilePackage):
 
     depends_on('gettext')
 
-    tags = ['build-tools']
-
     executables = [r'^dos2unix$']
 
     @property

--- a/var/spack/repos/builtin/packages/dos2unix/package.py
+++ b/var/spack/repos/builtin/packages/dos2unix/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import re
+
 from spack import *
 
 


### PR DESCRIPTION
I added the tags attribute as 'build-tools' (it is in a way for perl-fth) but I'm not sure it shouldn't be labelled as 'core-packages' instead ?
Thanks @alalazo if you can advise and review.
