### PR TITLE
environment.py: allow link:run

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -767,8 +767,8 @@ attribute allows the following values:
 
 #. ``link: all`` include root specs with their transient run and link type
    dependencies (default);
-#. ``link: run`` include root specs with their transient run type dependences;
-#. ``link: roots`` includes the root specs without their dependencies.
+#. ``link: run`` include root specs with their transient run type dependencies;
+#. ``link: roots`` include root specs without their dependencies.
 
 The ``link_type`` defaults to ``symlink`` but can also take the value
 of ``hardlink`` or ``copy``.

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -740,9 +740,10 @@ file snippet we define a view named ``mpis``, rooted at
 version, and compiler name to determine the path for a given
 package. This view selects all packages that depend on MPI, and
 excludes those built with the PGI compiler at version 18.5.
-All the dependencies of each root spec in the environment will be linked
-in the view due to the command ``link: all`` and the files in the view will
-be symlinks to the spack install directories.
+The root specs with their (transient) link and run type dependencies
+will be put in the view due to the  ``link: all`` option,
+and the files in the view will be symlinks to the spack install
+directories.
 
 .. code-block:: yaml
 
@@ -762,9 +763,22 @@ For more information on using view projections, see the section on
 :ref:`adding_projections_to_views`. The default for the ``select`` and
 ``exclude`` values is to select everything and exclude nothing. The
 default projection is the default view projection (``{}``). The ``link``
-defaults to ``all`` but can also be ``roots`` when only the root specs
-in the environment are desired in the view. The ``link_type`` defaults
-to ``symlink`` but can also take the value of ``hardlink`` or ``copy``.
+attribute allows the following values:
+
+#. ``link: all`` include root specs with their transient run and link type
+   dependencies (default);
+#. ``link: run`` include root specs with their transient run type dependences;
+#. ``link: roots`` includes the root specs without their dependencies.
+
+The ``link_type`` defaults to ``symlink`` but can also take the value
+of ``hardlink`` or ``copy``.
+
+.. tip::
+
+   The option ``link: run`` can be used to create small environment views for
+   Python packages. Python will be able to import packages *inside* of the view even
+   when the environment is not activated, and linked libraries will be located
+   *outside* of the view thanks to rpaths.
 
 Any number of views may be defined under the ``view`` heading in a
 Spack Environment.

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -740,7 +740,7 @@ file snippet we define a view named ``mpis``, rooted at
 version, and compiler name to determine the path for a given
 package. This view selects all packages that depend on MPI, and
 excludes those built with the PGI compiler at version 18.5.
-The root specs with their (transient) link and run type dependencies
+The root specs with their (transitive) link and run type dependencies
 will be put in the view due to the  ``link: all`` option,
 and the files in the view will be symlinks to the spack install
 directories.
@@ -765,9 +765,9 @@ For more information on using view projections, see the section on
 default projection is the default view projection (``{}``). The ``link``
 attribute allows the following values:
 
-#. ``link: all`` include root specs with their transient run and link type
+#. ``link: all`` include root specs with their transitive run and link type
    dependencies (default);
-#. ``link: run`` include root specs with their transient run type dependencies;
+#. ``link: run`` include root specs with their transitive run type dependencies;
 #. ``link: roots`` include root specs without their dependencies.
 
 The ``link_type`` defaults to ``symlink`` but can also take the value

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -589,20 +589,31 @@ def match_predicate(*args):
     return match
 
 
-def dedupe(sequence):
-    """Yields a stable de-duplication of an hashable sequence
+def dedupe(sequence, key=None):
+    """Yields a stable de-duplication of an hashable sequence by key
 
     Args:
         sequence: hashable sequence to be de-duplicated
+        key: callable applied on values before uniqueness test; identity
+            by default.
 
     Returns:
         stable de-duplication of the sequence
+
+    Examples:
+
+        Dedupe a list of integers:
+
+            [x for x in dedupe([1, 2, 1, 3, 2])] == [1, 2, 3]
+
+            [x for x in llnl.util.lang.dedupe([1,-2,1,3,2], key=abs)] == [1, -2, 3]
     """
     seen = set()
     for x in sequence:
-        if x not in seen:
+        x_key = x if key is None else key(x)
+        if x_key not in seen:
             yield x
-            seen.add(x)
+            seen.add(x_key)
 
 
 def pretty_date(time, now=None):

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -16,6 +16,7 @@ import six
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+from llnl.util.lang import dedupe
 
 import spack.bootstrap
 import spack.compilers
@@ -474,7 +475,7 @@ class ViewDescriptor(object):
     def specs_for_view(self, concretized_specs):
         """
         From the list of concretized user specs in the environment, flatten
-        the dags, and filter installed specs, remove duplicates on dag hash.
+        the dags, and filter selected, installed specs, remove duplicates on dag hash.
         """
         specs = []
 
@@ -487,16 +488,7 @@ class ViewDescriptor(object):
                 specs.append(s)
 
         # De-dupe by dag hash
-        hashes = set()
-        specs_unique = []
-        for s in specs:
-            hash = s.dag_hash()
-            if hash in hashes:
-                continue
-            hashes.add(hash)
-            specs_unique.append(s)
-
-        specs = specs_unique
+        specs = dedupe(specs, key=lambda s: s.dag_hash())
 
         # Filter selected, installed specs
         with spack.store.db.read_transaction():

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -498,9 +498,9 @@ class ViewDescriptor(object):
 
         specs = specs_unique
 
-        # Filter installed specs
+        # Filter selected, installed specs
         with spack.store.db.read_transaction():
-            specs = [s for s in specs if s.package.installed]
+            specs = [s for s in specs if s in self and s.package.installed]
 
         return specs
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -124,7 +124,7 @@ schema = {
                                             },
                                             'link': {
                                                 'type': 'string',
-                                                'pattern': '(roots|all)',
+                                                'pattern': '(roots|all|run)',
                                             },
                                             'link_type': {
                                                 'type': 'string'

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1983,7 +1983,7 @@ spack:
     with ev.Environment(envdir):
         install()
 
-    # make sure transient run type deps are in the view
+    # make sure transitive run type deps are in the view
     for pkg in ('dtrun1', 'dtrun3'):
         assert os.path.exists(os.path.join(viewdir, pkg))
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -386,23 +386,23 @@ def test_environment_status(capsys, tmpdir):
 
 def test_env_status_broken_view(
     mutable_mock_env_path, mock_archive, mock_fetch, mock_packages,
-    install_mockery
+    install_mockery, tmpdir
 ):
-    with ev.create('test'):
+    env_dir = str(tmpdir)
+    with ev.Environment(env_dir):
         install('trivial-install-test-package')
 
-        # switch to a new repo that doesn't include the installed package
-        # test that Spack detects the missing package and warns the user
-        new_repo = MockPackageMultiRepo()
-        with spack.repo.use_repositories(new_repo):
+    # switch to a new repo that doesn't include the installed package
+    # test that Spack detects the missing package and warns the user
+    with spack.repo.use_repositories(MockPackageMultiRepo()):
+        with ev.Environment(env_dir):
             output = env('status')
-            assert 'In environment test' in output
-            assert 'Environment test includes out of date' in output
+            assert 'includes out of date packages or repos' in output
 
-        # Test that the warning goes away when it's fixed
+    # Test that the warning goes away when it's fixed
+    with ev.Environment(env_dir):
         output = env('status')
-        assert 'In environment test' in output
-        assert 'Environment test includes out of date' not in output
+        assert 'includes out of date packages or repos' not in output
 
 
 def test_env_activate_broken_view(

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1962,6 +1962,37 @@ env:
                                  (spec.version, spec.compiler.name)))
 
 
+def test_view_link_run(tmpdir, mock_fetch, mock_packages, mock_archive,
+                       install_mockery):
+    yaml = str(tmpdir.join('spack.yaml'))
+    viewdir = str(tmpdir.join('view'))
+    envdir = str(tmpdir)
+    with open(yaml, 'w') as f:
+        f.write("""
+spack:
+  specs:
+  - dttop
+
+  view:
+    combinatorial:
+      root: %s
+      link: run
+      projections:
+        all: '{name}'""" % viewdir)
+
+    with ev.Environment(envdir):
+        install()
+
+    # make sure transient run type deps are in the view
+    for pkg in ('dtrun1', 'dtrun3'):
+        assert os.path.exists(os.path.join(viewdir, pkg))
+
+    # and non-run-type deps are not.
+    for pkg in ('dtlink1', 'dtlink2', 'dtlink3', 'dtlink4', 'dtlink5'
+                'dtbuild1', 'dtbuild2', 'dtbuild3'):
+        assert not os.path.exists(os.path.join(viewdir, pkg))
+
+
 @pytest.mark.parametrize('link_type', ['hardlink', 'copy', 'symlink'])
 def test_view_link_type(link_type, tmpdir, mock_fetch, mock_packages, mock_archive,
                         install_mockery):

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 import pytest
 
 import llnl.util.lang
-from llnl.util.lang import match_predicate, memoized, pretty_date, stable_args
+from llnl.util.lang import dedupe, match_predicate, memoized, pretty_date, stable_args
 
 
 @pytest.fixture()
@@ -265,3 +265,8 @@ def test_memoized_unhashable(args, kwargs):
     key = stable_args(*args, **kwargs)
     assert str(key) in exc_msg
     assert "function 'f'" in exc_msg
+
+
+def test_dedupe():
+    assert [x for x in dedupe([1, 2, 1, 3, 2])] == [1, 2, 3]
+    assert [x for x in dedupe([1, -2, 1, 3, 2], key=abs)] == [1, -2, 3]


### PR DESCRIPTION
Some users want minimal views, excluding transitive link-type dependencies, since
those type of dependencies are covered by rpaths and the symlinked
libraries in the view aren't used anyways.

With this change, an environment like this:

```yaml
spack:
  specs: ['py-flake8']
  view:
    default:
      root: view
      link: run
```

includes `['py-flake8', 'py-mccabe', 'python', 'py-pycodestyle', 'py-setuptools', 'py-pyflakes']`, but no link type deps of python.

With `link: all` it would includes a lot of "unnecessary" specs: `['py-flake8', 'py-mccabe', 'python', 'bzip2', 'expat', 'libbsd', 'libmd', 'gdbm', 'readline', 'ncurses', 'gettext', 'libiconv', 'libxml2', 'xz', 'zlib', 'tar', 'libffi', 'openssl', 'sqlite', 'util-linux-uuid', 'py-pycodestyle', 'py-setuptools', 'py-pyflakes']` even when build type deps are already omitted.

This is a requirement to get #29317 in.