### PR TITLE
Revert "butterflypack: add v2.1.1 (#29151)"

### DIFF
--- a/var/spack/repos/builtin/packages/butterflypack/package.py
+++ b/var/spack/repos/builtin/packages/butterflypack/package.py
@@ -22,11 +22,10 @@ class Butterflypack(CMakePackage):
 
     homepage = "https://github.com/liuyangzhuan/ButterflyPACK"
     git      = "https://github.com/liuyangzhuan/ButterflyPACK.git"
-    url      = "https://github.com/liuyangzhuan/ButterflyPACK/archive/v2.1.1.tar.gz"
+    url      = "https://github.com/liuyangzhuan/ButterflyPACK/archive/v2.1.0.tar.gz"
     maintainers = ['liuyangzhuan']
 
     version('master', branch='master')
-    version('2.1.1', sha256='85f14f1a42950f9d63a4d4c81f3814bfa486537ee94aa98108cd1606b9d3f78f')
     version('2.1.0', sha256='ac76cc8d431797c1a3641b23124e3de5eb8c3a3afb71c336e7ba69c6cdf150ef')
     version('2.0.0', sha256='84f0e5ac40997409f3c80324238a07f9c700a1263b84140ed97275d67b577b80')
     version('1.2.1', sha256='cd61b0e033f55a932f13d9902e28a7abbf029c279cec9ab1b2a063525d036fa2')


### PR DESCRIPTION
This reverts commit b7794cdac8de9eca93f7678c93d95368bba2a820.

#29151 was failing Gitlab CI tests. We didn't notice because of of the bug fixed in #29223