### PR TITLE
Add Scotch v7.0.1, now supporting CMake

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -285,14 +285,9 @@ class Scotch(CMakePackage):
             self.define_from_variant('BUILD_LIBSCOTCHMETIS', 'metis'),
             self.define_from_variant('INSTALL_METIS_HEADERS', 'metis'),
             self.define_from_variant('BUILD_LIBESMUMPS', 'esmumps'),
-            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
+            self.define_from_variant('BUILD_PTSCOTCH', 'mpi')
         ]
-
-        if '+mpi' in spec:
-            args.append('-DBUILD_PTSCOTCH=ON')
-            # TODO check if MPI_THREAD_MULTIPLE is supported?
-        else:
-            args.append('-DBUILD_PTSCOTCH=OFF')
 
         # TODO should we enable/disable THREADS?
 

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -15,6 +15,8 @@ class Scotch(CMakePackage):
     url      = "https://gitlab.inria.fr/scotch/scotch/-/archive/v7.0.1/scotch-v7.0.1.tar.gz"
     list_url = "https://gforge.inria.fr/frs/?group_id=248"
 
+    maintainers = ['pghysels']
+
     version('7.0.1', sha256='0618e9bc33c02172ea7351600fce4fccd32fe00b3359c4aabb5e415f17c06fed')
     version('6.1.3', sha256='4e54f056199e6c23d46581d448fcfe2285987e5554a0aa527f7931684ef2809e')
     version('6.1.2', sha256='9c2c75c75f716914a2bd1c15dffac0e29a2f8069b2df1ad2b6207c984b699450')

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -100,7 +100,7 @@ class Scotch(CMakePackage):
 
         return scotchlibs + zlibs
 
-    @when('@:6.9.99')
+    @when('@:6')
     def patch(self):
         self.configure()
 
@@ -108,7 +108,7 @@ class Scotch(CMakePackage):
     # file that contains all of the configuration variables and their desired
     # values for the installation.  This function writes this file based on
     # the given installation variants.
-    @when('@:6.9.99')
+    @when('@:6')
     def configure(self):
         makefile_inc = []
         cflags = [
@@ -222,7 +222,7 @@ class Scotch(CMakePackage):
             with open('Makefile.inc', 'w') as fh:
                 fh.write('\n'.join(makefile_inc))
 
-    @when('@:6.9.99')
+    @when('@:6')
     def install(self, spec, prefix):
         targets = ['scotch']
         if '+mpi' in self.spec:
@@ -271,11 +271,11 @@ class Scotch(CMakePackage):
         install_tree('include', prefix.include)
         install_tree('man/man1', prefix.share.man.man1)
 
-    @when("@:6.9.99")
+    @when("@:6")
     def cmake(self, spec, prefix):
         self.configure()
 
-    @when("@:6.9.99")
+    @when("@:6")
     def build(self, spec, prefix):
         pass
 

--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -283,6 +283,7 @@ class Scotch(CMakePackage):
             self.define_from_variant('BUILD_LIBSCOTCHMETIS', 'metis'),
             self.define_from_variant('INSTALL_METIS_HEADERS', 'metis'),
             self.define_from_variant('BUILD_LIBESMUMPS', 'esmumps'),
+            self.define_from_variant('BUILD_SHARED_LIBS', 'shared')
         ]
 
         if '+mpi' in spec:


### PR DESCRIPTION
I'm not sure if/when to enable/disable the MPI_THREAD_MULTIPLE and THREADS options in Scotch's CMake.

For v7.0.1 I do not see a compression option in the CMake installer.

