### PR TITLE
fastjet: use mirror for sources

### DIFF
--- a/var/spack/repos/builtin/packages/fastjet/package.py
+++ b/var/spack/repos/builtin/packages/fastjet/package.py
@@ -13,7 +13,11 @@ class Fastjet(AutotoolsPackage):
     """
 
     homepage = "http://fastjet.fr/"
-    url      = "http://fastjet.fr/repo/fastjet-3.3.3.tar.gz"
+    # The server that hosts fastjet.fr rejects range request
+    # which causes spack to fail during fetching. Until this is fixed, use
+    # a mirror instead of the upstream url
+    # url  = "http://fastjet.fr/repo/fastjet-3.4.0.tar.gz"
+    url      = "https://lcgpackages.web.cern.ch/tarFiles/sources/fastjet-3.3.4.tar.gz"
 
     tags = ['hep']
 


### PR DESCRIPTION
as a workaround for https://github.com/spack/spack/issues/20050