### PR TITLE
mesa, mesa18: Change defaults on llvm variant in order to get leaner builds

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -44,7 +44,7 @@ class Mesa(MesonPackage):
     depends_on('zlib@1.2.3:')
 
     # Internal options
-    variant('llvm', default=True, description="Enable LLVM.")
+    variant('llvm', default=False, description="Enable LLVM.")
     _SWR_AUTO_VALUE = 'auto'
     _SWR_ENABLED_VALUES = (_SWR_AUTO_VALUE, 'avx', 'avx2', 'knl', 'skx')
     _SWR_DISABLED_VALUES = ('none',)

--- a/var/spack/repos/builtin/packages/mesa18/package.py
+++ b/var/spack/repos/builtin/packages/mesa18/package.py
@@ -41,7 +41,7 @@ class Mesa18(AutotoolsPackage):
     depends_on('ncurses+termlib')
 
     # Internal options
-    variant('llvm', default=True, description="Enable LLVM.")
+    variant('llvm', default=False, description="Enable LLVM.")
     _SWR_ENABLED_VALUES = ('avx', 'avx2', 'knl', 'skx')
     variant('swr', values=any_combination_of(*_SWR_ENABLED_VALUES),
             description="Enable the SWR driver.")


### PR DESCRIPTION
 All of the variants modified here are really expensive to turn on and not required for many builds, so I think it improves the user experience of spack overall to turn them off by default. Apologies to those who assume the current defaults in their workflows and a reminder that the new concretizer makes it easier for packages to explicitly depend on e.g. `mesa+llvm`.