### PR TITLE
landsfcutil: support Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/landsfcutil/package.py
+++ b/var/spack/repos/builtin/packages/landsfcutil/package.py
@@ -27,3 +27,9 @@ class Landsfcutil(CMakePackage):
             env.set('LANDSFCUTIL_LIB' + suffix, lib[0])
             env.set('LANDSFCUTIL_INC' + suffix,
                     join_path(self.prefix, 'include_' + suffix))
+
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('%fj'):
+            if name == 'fflags':
+                flags.append('-Free')
+        return (None, None, flags)


### PR DESCRIPTION
Add "-Free" Fortran flag to compile landsfcutil with Fujitsu compiler.