### PR TITLE
version.py: set is_commit in constructor

### DIFF
--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -167,7 +167,7 @@ class VersionStrComponent(object):
 
 class Version(object):
     """Class to represent versions"""
-    __slots__ = ['version', 'separators', 'string', 'commit_lookup']
+    __slots__ = ['version', 'separators', 'string', 'is_commit', 'commit_lookup']
 
     def __init__(self, string):
         if not isinstance(string, str):
@@ -189,6 +189,8 @@ class Version(object):
         )
         self.separators = tuple(m[2] for m in segments)
 
+        self.is_commit = len(self.string) == 40 and COMMIT_VERSION.match(self.string)
+
     def _cmp(self, other_lookups=None):
         commit_lookup = self.commit_lookup or other_lookups
 
@@ -204,15 +206,6 @@ class Version(object):
                 return prev_tuple + dist_suffix
 
         return self.version
-
-    @property
-    def is_commit(self):
-        """
-        Determine if the original string is referencing a commit.
-        """
-        if self.string in infinity_versions:
-            return False
-        return COMMIT_VERSION.match(self.string) is not None
 
     @property
     def dotted(self):


### PR DESCRIPTION
Speeds up comparison on `Version` by ~2.5x, e.g.

```python
In [1]: v = spack.version.Version('1.0.0'); w = spack.version.Version('1.0.2')

In [2]: %timeit v < w

# before
1.47 µs ± 5.59 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

# after
535 ns ± 1.75 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

Seems like it's 5% to 10% reduction in `setup` phase time of the ASP solver.