### PR TITLE
thepeg: Add zlib dependency

### DIFF
--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -71,7 +71,7 @@ class Thepeg(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
-    depends_on('zlib',     type='build')
+    depends_on('zlib')
 
     variant('hepmc', default='2', values=('2', '3'), description='HepMC interface to build ')
 

--- a/var/spack/repos/builtin/packages/thepeg/package.py
+++ b/var/spack/repos/builtin/packages/thepeg/package.py
@@ -71,6 +71,7 @@ class Thepeg(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('zlib',     type='build')
 
     variant('hepmc', default='2', values=('2', '3'), description='HepMC interface to build ')
 
@@ -78,6 +79,7 @@ class Thepeg(AutotoolsPackage):
 
     def configure_args(self):
         args = ['--with-gsl=' + self.spec['gsl'].prefix, '--without-javagui']
+        args += ['--with-zlib=' + self.spec['zlib'].prefix]
 
         if self.spec.satisfies('@:1.8'):
             args += ['--with-LHAPDF=' + self.spec['lhapdf'].prefix]


### PR DESCRIPTION
Triggered by `configure: error: either specify a valid zlib installation with --with-zlib=DIR or disable zlib usage with --without-zlib` for thepeg@1.9.2