### PR TITLE
amdscalapack: Remove build_type variant

### DIFF
--- a/var/spack/repos/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/builtin/packages/amdscalapack/package.py
@@ -32,7 +32,7 @@ class Amdscalapack(ScalapackBase):
         'build_type',
         default='Release',
         description='CMake build type',
-        values=('Release', 'RelWithDebInfo'))
+        values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
     variant(
         'ilp64',
         default=False,

--- a/var/spack/repos/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/builtin/packages/amdscalapack/package.py
@@ -29,11 +29,6 @@ class Amdscalapack(ScalapackBase):
     version('2.2', sha256='2d64926864fc6d12157b86e3f88eb1a5205e7fc157bf67e7577d0f18b9a7484c')
 
     variant(
-        'build_type',
-        default='Release',
-        description='CMake build type',
-        values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
-    variant(
         'ilp64',
         default=False,
         description='Build with ILP64 support')


### PR DESCRIPTION
Unfortunately when people make their own `build_type` variant, it breaks the ability to use
```
all:
   variants: build_type=Debug
```
etc. This fixes it for `amdscalapack`.