### PR TITLE
py-torch: search blas libraries when BLAS=Generic

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/generic_blas.patch
+++ b/var/spack/repos/builtin/packages/py-torch/generic_blas.patch
@@ -1,0 +1,16 @@
+--- spack-src/cmake/Dependencies.cmake.orig     2022-03-07 14:40:07.000000000 +0900
++++ spack-src/cmake/Dependencies.cmake  2022-03-07 14:37:07.000000000 +0900
+@@ -187,7 +187,12 @@
+   set(BLAS_LIBRARIES ${vecLib_LINKER_LIBS})
+ elseif(BLAS STREQUAL "Generic")
+   # On Debian family, the CBLAS ABIs have been merged into libblas.so
+-  find_library(BLAS_LIBRARIES blas)
++  if(ENV{GENERIC_BLAS_LIBRARIES} STREQUAL "")
++    set(GENERIC_BLAS "blas")
++  else()
++    set(GENERIC_BLAS $ENV{GENERIC_BLAS_LIBRARIES})
++  endif()
++  find_library(BLAS_LIBRARIES NAMES ${GENERIC_BLAS})
+   message("-- Using BLAS: ${BLAS_LIBRARIES}")
+   list(APPEND Caffe2_PUBLIC_DEPENDENCY_LIBS ${BLAS_LIBRARIES})
+   set(GENERIC_BLAS_FOUND TRUE)

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -207,6 +207,9 @@ class PyTorch(PythonPackage, CudaPackage):
     patch('https://github.com/pytorch/pytorch/commit/c075f0f633fa0136e68f0a455b5b74d7b500865c.patch',
           sha256='e69e41b5c171bfb00d1b5d4ee55dd5e4c8975483230274af4ab461acd37e40b8', when='@1.10.0+distributed~tensorpipe')
 
+    # To search blas library to GENERIC_BLAS_LIBRARIES environment variable
+    patch('generic_blas.patch', when='@1.6:')
+
     @property
     def libs(self):
         # TODO: why doesn't `python_platlib` work here?
@@ -365,6 +368,7 @@ class PyTorch(PythonPackage, CudaPackage):
         else:
             env.set('BLAS', 'Generic')
             env.set('WITH_BLAS', 'generic')
+            env.set('GENERIC_BLAS_LIBRARIES', ';'.join(self.spec['blas'].libs.names))
 
         # Don't use vendored third-party libraries when possible
         env.set('BUILD_CUSTOM_PROTOBUF', 'OFF')


### PR DESCRIPTION
When we use py-torch with unregistered blas, spack set BLAS=Generic.
py-torch is searched only libblas.
If the blas package's blas library name is not libblas, s`pack install py-torch` is failed.

This PR set blas lirary names to GENERIC_BLAS_LIBRARIES environment variable, and py-torch is found blas library. 