### PR TITLE
apfel: depend on python also for ~python variant

### DIFF
--- a/var/spack/repos/builtin/packages/apfel/package.py
+++ b/var/spack/repos/builtin/packages/apfel/package.py
@@ -20,7 +20,7 @@ class Apfel(AutotoolsPackage):
     version('3.0.4', sha256='c7bfae7fe2dc0185981850f2fe6ae4842749339d064c25bf525b4ef412bbb224')
 
     depends_on('swig', when='+python')
-    depends_on('python', when='+python', type=('build', 'run'))
+    depends_on('python', type=('build', 'run'))
     depends_on('lhapdf', when='+lhapdf', type=('build', 'run'))
 
     variant('python', description='Build python wrapper', default=False)


### PR DESCRIPTION
`configure: error: Python Executable not found` when installing apfel@3.0.4~python.