### PR TITLE
hsa-rocr-dev, llvm-amdgpu: change dependency libelf to elf

### DIFF
--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -63,6 +63,8 @@ class HsaRocrDev(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
+        # hsa-rocr-dev wants the directory containing the header files, but
+        # libelf adds an extra path (include/libelf) compared to elfutils
         libelf_include = os.path.dirname(
             find_headers('libelf', spec['elf'].prefix.include, recursive=True)[0])
 

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
+import os.path
+
 from spack import *
 
 
@@ -43,7 +45,7 @@ class HsaRocrDev(CMakePackage):
     # Note, technically only necessary when='@3.7: +image', but added to all
     # to work around https://github.com/spack/spack/issues/23951
     depends_on('xxd', when='+image', type='build')
-    depends_on('libelf@0.8:', type='link')
+    depends_on('elf', type='link')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', 'master']:
@@ -61,7 +63,9 @@ class HsaRocrDev(CMakePackage):
     def cmake_args(self):
         spec = self.spec
 
-        libelf_include = spec['libelf'].prefix.include.libelf
+        libelf_include = os.path.dirname(
+            find_headers('libelf', spec['elf'].prefix.include, recursive=True)[0])
+
         args = [
             self.define('LIBELF_INCLUDE_DIRS', libelf_include),
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared')

--- a/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
+++ b/var/spack/repos/builtin/packages/hsa-rocr-dev/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-import os.path
+import os
 
 from spack import *
 

--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -63,7 +63,7 @@ class LlvmAmdgpu(CMakePackage):
     # openmp dependencies
     depends_on("perl-data-dumper", type=("build"), when='+openmp')
     depends_on("hwloc", when='+openmp')
-    depends_on('libelf', type='link', when='+openmp')
+    depends_on('elf', type='link', when='+openmp')
 
     # Will likely only be fixed in LLVM 12 upstream
     patch('fix-system-zlib-ncurses.patch', when='@3.5.0:3.8.0')


### PR DESCRIPTION
Change the libelf dependency to the virtual elf for two rocm packages.
This allows other packages (hpctoolkit) to combine rocm and dyninst
(with elfutils) while still being able to build rocm with libelf when
needed, eg darwin.

----------

The all-spack build (no external packages) for hsa-rocr-dev is
currently broken, see #29381.  But there is a simple workaround.
Add this to hsa-rocr-dev right after the other patches.

```
def patch(self):
    with working_dir('src'):
        filter_file('hsakmt 1.0', 'hsakmt 0.1', 'CMakeLists.txt')
```

