### PR TITLE
py-numpy fails with --test root unless py-test is build dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -111,7 +111,7 @@ class PyNumpy(PythonPackage):
     depends_on('lapack', when='+lapack')
 
     depends_on('py-nose@1.0.0:', when='@:1.14', type='test')
-    depends_on('py-pytest', when='@1.15:', type='test')
+    depends_on('py-pytest', when='@1.15:', type=('build', 'test'))
     depends_on('py-hypothesis', when='@1.19:', type='test')
 
     # Allows you to specify order of BLAS/LAPACK preference

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -80,7 +80,7 @@ class PyScipy(PythonPackage):
     depends_on('python@3.7:3.9', when='@1.6.2:1.7.1', type=('build', 'link', 'run'))
     depends_on('python@3.7:3.10', when='@1.7.2:1.7', type=('build', 'link', 'run'))
     depends_on('python@3.8:3.10', when='@1.8:', type=('build', 'link', 'run'))
-    depends_on('py-pytest', type='test')
+    depends_on('py-pytest', type=('build', 'test'))
 
     # NOTE: scipy picks up Blas/Lapack from numpy, see
     # http://www.scipy.org/scipylib/building/linux.html#step-4-build-numpy-1-5-0


### PR DESCRIPTION
When --test root is flagged in spack install, py-numpy is failing on
power unless py-test is listed as a build dependency.