### PR TITLE
LBANN SW stack unsupported compiler

### DIFF
--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -81,6 +81,9 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
                 arch_str = ";".join(archs)
                 args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
+            if spec.satisfies('%cce') and spec.satisfies('^cuda+allow-unsupported-compilers'):
+                args.append('-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler')
+
         if spec.satisfies('@0.5:'):
             args.extend([
                 '-DALUMINUM_ENABLE_HOST_TRANSFER:BOOL=%s' % ('+ht' in spec),

--- a/var/spack/repos/builtin/packages/aluminum/package.py
+++ b/var/spack/repos/builtin/packages/aluminum/package.py
@@ -81,7 +81,8 @@ class Aluminum(CMakePackage, CudaPackage, ROCmPackage):
                 arch_str = ";".join(archs)
                 args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
-            if spec.satisfies('%cce') and spec.satisfies('^cuda+allow-unsupported-compilers'):
+            if (spec.satisfies('%cce') and
+                spec.satisfies('^cuda+allow-unsupported-compilers')):
                 args.append('-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler')
 
         if spec.satisfies('@0.5:'):

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -167,7 +167,8 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
                 arch_str = ";".join(archs)
                 args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
-            if spec.satisfies('%cce') and spec.satisfies('^cuda+allow-unsupported-compilers'):
+            if (spec.satisfies('%cce') and
+                spec.satisfies('^cuda+allow-unsupported-compilers')):
                 args.append('-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler')
 
         if '+cuda' in spec or '+distconv' in spec:

--- a/var/spack/repos/builtin/packages/dihydrogen/package.py
+++ b/var/spack/repos/builtin/packages/dihydrogen/package.py
@@ -167,6 +167,9 @@ class Dihydrogen(CMakePackage, CudaPackage, ROCmPackage):
                 arch_str = ";".join(archs)
                 args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
+            if spec.satisfies('%cce') and spec.satisfies('^cuda+allow-unsupported-compilers'):
+                args.append('-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler')
+
         if '+cuda' in spec or '+distconv' in spec:
             args.append('-DcuDNN_DIR={0}'.format(
                 spec['cudnn'].prefix))

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -178,7 +178,8 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
                 arch_str = ";".join(archs)
                 args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
-            if spec.satisfies('%cce') and spec.satisfies('^cuda+allow-unsupported-compilers'):
+            if (spec.satisfies('%cce') and
+                spec.satisfies('^cuda+allow-unsupported-compilers')):
                 args.append('-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler')
 
         if '+rocm' in spec:

--- a/var/spack/repos/builtin/packages/hydrogen/package.py
+++ b/var/spack/repos/builtin/packages/hydrogen/package.py
@@ -69,6 +69,8 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('cmake@3.21.0:', type='build', when='@1.5.2:')
     depends_on('cmake@3.17.0:', type='build', when='@:1.5.1')
+    depends_on('cmake@3.22.0:', type='build', when='%cce')
+
     depends_on('mpi')
     depends_on('hwloc@1.11:')
     depends_on('hwloc +cuda +nvml', when='+cuda')
@@ -175,6 +177,9 @@ class Hydrogen(CMakePackage, CudaPackage, ROCmPackage):
             if archs != 'none':
                 arch_str = ";".join(archs)
                 args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
+
+            if spec.satisfies('%cce') and spec.satisfies('^cuda+allow-unsupported-compilers'):
+                args.append('-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler')
 
         if '+rocm' in spec:
             args.extend([

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -325,7 +325,8 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
                 arch_str = ";".join(archs)
                 args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
-            if spec.satisfies('%cce') and spec.satisfies('^cuda+allow-unsupported-compilers'):
+            if (spec.satisfies('%cce') and
+                spec.satisfies('^cuda+allow-unsupported-compilers')):
                 args.append('-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler')
 
         if spec.satisfies('@:0.90') or spec.satisfies('@0.95:'):

--- a/var/spack/repos/builtin/packages/lbann/package.py
+++ b/var/spack/repos/builtin/packages/lbann/package.py
@@ -325,6 +325,9 @@ class Lbann(CMakePackage, CudaPackage, ROCmPackage):
                 arch_str = ";".join(archs)
                 args.append('-DCMAKE_CUDA_ARCHITECTURES=%s' % arch_str)
 
+            if spec.satisfies('%cce') and spec.satisfies('^cuda+allow-unsupported-compilers'):
+                args.append('-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler')
+
         if spec.satisfies('@:0.90') or spec.satisfies('@0.95:'):
             args.append(
                 '-DHydrogen_DIR={0}/CMake/hydrogen'.format(


### PR DESCRIPTION
Added support for using unsupported compilers with NVHPC on Cray systems.