### PR TITLE
libdrm: add docs variants and missing dependency

### DIFF
--- a/var/spack/repos/builtin/packages/libdrm/package.py
+++ b/var/spack/repos/builtin/packages/libdrm/package.py
@@ -33,8 +33,9 @@ class Libdrm(Package):
     depends_on('libpciaccess@0.10:')
     depends_on('libpthread-stubs')
 
-    # 2.4.90 is the first version to use meson.
-    depends_on('meson', type='build', when='@2.4.90:')
+    # 2.4.90 is the first version to use meson, spack defaults to meson since
+    # 2.4.101.
+    depends_on('meson', type='build', when='@2.4.101:')
 
     # >= 2.4.104 uses reStructuredText for man pages.
     with when('@2.4.104: +docs'):
@@ -68,7 +69,7 @@ class Libdrm(Package):
                 ninja('test')
             ninja('install')
 
-    @when('@:2.4.89')
+    @when('@:2.4.100')
     def configure_args(self):
         args = []
         args.append('--enable-static')
@@ -82,7 +83,7 @@ class Libdrm(Package):
             args.append('CFLAGS=-fcommon')
         return args
 
-    @when('@:2.4.89')
+    @when('@:2.4.100')
     def install(self, spec, prefix):
         configure('--prefix={0}'.format(prefix), *self.configure_args())
         make()


### PR DESCRIPTION
some fixes to make libdrm build for me

- https://gitlab.freedesktop.org/mesa/drm/-/commit/5f7deb50787b82038cc35fb1e31b761e33e5a341 (first in 2.4.90, requires `xsltproc` from `libxslt`)
- https://gitlab.freedesktop.org/mesa/drm/-/commit/05b0a955d33a7a1d6a3171f4051fa4ed2f3327a6 (first in 2.4.104, requires rst2man from py-docutils)