### PR TITLE
optimize instantiation and comparison of versions

### DIFF
--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -48,7 +48,7 @@ __all__ = ['Version', 'VersionRange', 'VersionList', 'ver']
 VALID_VERSION = re.compile(r'^[A-Za-z0-9_.-]+$')
 
 # regex for a commit version
-COMMIT_VERSION = re.compile(r'^[a-z0-9]{40}$')
+COMMIT_VERSION = re.compile(r'^[a-f0-9]{40}$')
 
 # regex for version segments
 SEGMENT_REGEX = re.compile(r'(?:(?P<num>[0-9]+)|(?P<str>[a-zA-Z]+))(?P<sep>[_.-]*)')
@@ -167,7 +167,7 @@ class VersionStrComponent(object):
 
 class Version(object):
     """Class to represent versions"""
-    __slots__ = ['version', 'separators', 'string', 'is_commit', 'commit_lookup']
+    __slots__ = ['version', 'separators', 'string', 'commit_lookup', 'is_commit', 'commit_version']
 
     def __init__(self, string):
         if not isinstance(string, str):
@@ -182,7 +182,7 @@ class Version(object):
 
         # An object that can lookup git commits to compare them to versions
         self.commit_lookup = None
-
+        self.commit_version = None
         segments = SEGMENT_REGEX.findall(string)
         self.version = tuple(
             int(m[0]) if m[0] else VersionStrComponent(m[1]) for m in segments
@@ -195,6 +195,8 @@ class Version(object):
         commit_lookup = self.commit_lookup or other_lookups
 
         if self.is_commit and commit_lookup:
+            if self.commit_version is not None:
+                return self.commit_version
             commit_info = commit_lookup.get(self.string)
             if commit_info:
                 prev_version, distance = commit_info
@@ -203,7 +205,8 @@ class Version(object):
                 # If commit is exactly a known version, no distance suffix
                 prev_tuple = Version(prev_version).version if prev_version else ()
                 dist_suffix = (VersionStrComponent(''), distance) if distance else ()
-                return prev_tuple + dist_suffix
+                self.commit_version = prev_tuple + dist_suffix
+                return self.commit_version
 
         return self.version
 

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -167,7 +167,14 @@ class VersionStrComponent(object):
 
 class Version(object):
     """Class to represent versions"""
-    __slots__ = ['version', 'separators', 'string', 'commit_lookup', 'is_commit', 'commit_version']
+    __slots__ = [
+        "version",
+        "separators",
+        "string",
+        "commit_lookup",
+        "is_commit",
+        "commit_version",
+    ]
 
     def __init__(self, string):
         if not isinstance(string, str):


### PR DESCRIPTION
Re-work the checks and comparisons around commit versions, when no
commit version is involved the overhead is now in the noise, where one
is the overhead is now constant rather than linear.

This extends on @haampie's patch to cache `is_commit` by caching the actual commit version once when it's first requested.  My original testing found it to be about 10x faster than re-calculating it repeatedly.

I also tightened in the commit_version regex to match hex hashes.
