### PR TITLE
BLT version conflicts

### DIFF
--- a/var/spack/repos/builtin/packages/raja/package.py
+++ b/var/spack/repos/builtin/packages/raja/package.py
@@ -51,7 +51,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
     variant('tests', default=False, description='Build tests')
 
     depends_on('blt')
-    depends_on('blt@0.4.1:', type='build', when='@0.14.0:')
+    depends_on('blt@0.5.0:', type='build', when='@0.14.1:')
+    depends_on('blt@0.4.1', type='build', when='@0.14.0')
     depends_on('blt@0.4.0:', type='build', when='@0.13.0')
     depends_on('blt@0.3.6:', type='build', when='@:0.12.0')
 

--- a/var/spack/repos/builtin/packages/umpire/package.py
+++ b/var/spack/repos/builtin/packages/umpire/package.py
@@ -75,7 +75,8 @@ class Umpire(CachedCMakePackage, CudaPackage, ROCmPackage):
     depends_on('cmake@3.9:', when='+cuda', type='build')
     depends_on('cmake@:3.20', when='+rocm', type='build')
 
-    depends_on('blt@0.4.1:', type='build', when='@6.0.0:')
+    depends_on('blt@0.5.0:', type='build', when='@6.0.1:')
+    depends_on('blt@0.4.1', type='build', when='@6.0.0')
     depends_on('blt@0.4.0:', type='build', when='@4.1.3:5.0.1')
     depends_on('blt@0.3.6:', type='build', when='@:4.1.2')
 


### PR DESCRIPTION
Fixes #29412. I created this before i noticed #29432.

Locks down BLT versions for previous release of Umpire and Raja.  This should work with the upcoming releases.

I don't care which one gets merged. 

@eugeneswalker @davidbeckingsale 