### PR TITLE
dicom3tools: fix build error with Fujitsu compiler

### DIFF
--- a/var/spack/repos/builtin/packages/dicom3tools/package.py
+++ b/var/spack/repos/builtin/packages/dicom3tools/package.py
@@ -52,6 +52,14 @@ class Dicom3tools(MakefilePackage):
         configure = Executable(join_path('.', 'Configure'))
         configure()
 
+        if spec.satisfies('%fj'):
+            filter_file('#define UseStandardHeadersWithoutExtension 0',
+                        '#define UseStandardHeadersWithoutExtension 1',
+                        'config/generic.cf')
+            filter_file('#define EmitUsingStdNameSpace 0',
+                        '#define EmitUsingStdNameSpace 1',
+                        'config/generic.cf')
+
         imake = which('imake')
         imake('-I./config', '-DDefaultUIDRoot={0}'.format(uid_root))
         make('World')


### PR DESCRIPTION
This patch fix a build error of header file not found with Fujitsu compiler.
If these two macros 'UseStandardHeadersWithoutExtension' and  'EmitUsingStdNameSpace' are defined, the new standard header files(such as <iostream>) will be used,  oherwise the old header files (such as <iostream.h>) will be used.