### PR TITLE
module_cmd.py: use posix awk; fix stderr redirection

### DIFF
--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -25,26 +25,24 @@ _test_template = "'. %s 2>&1' % args[1]"
 
 
 def test_module_function_change_env(tmpdir, working_env, monkeypatch):
-    monkeypatch.setattr(spack.util.module_cmd, '_cmd_template', _test_template)
     src_file = str(tmpdir.join('src_me'))
     with open(src_file, 'w') as f:
         f.write('export TEST_MODULE_ENV_VAR=TEST_SUCCESS\n')
 
     os.environ['NOT_AFFECTED'] = "NOT_AFFECTED"
-    module('load', src_file)
+    module('load', src_file, module_template=_test_template)
 
     assert os.environ['TEST_MODULE_ENV_VAR'] == 'TEST_SUCCESS'
     assert os.environ['NOT_AFFECTED'] == "NOT_AFFECTED"
 
 
 def test_module_function_no_change(tmpdir, monkeypatch):
-    monkeypatch.setattr(spack.util.module_cmd, '_cmd_template', _test_template)
     src_file = str(tmpdir.join('src_me'))
     with open(src_file, 'w') as f:
         f.write('echo TEST_MODULE_FUNCTION_PRINT')
 
     old_env = os.environ.copy()
-    text = module('show', src_file)
+    text = module('show', src_file, module_template=_test_template)
 
     assert text == 'TEST_MODULE_FUNCTION_PRINT\n'
     assert os.environ == old_env

--- a/lib/spack/spack/test/module_parsing.py
+++ b/lib/spack/spack/test/module_parsing.py
@@ -8,6 +8,7 @@ import os
 import pytest
 
 import spack
+import spack.util.module_cmd
 from spack.util.module_cmd import (
     get_path_args_from_module_line,
     get_path_from_module_contents,
@@ -21,28 +22,26 @@ test_module_lines = ['prepend-path LD_LIBRARY_PATH /path/to/lib',
                      'setenv LDFLAGS -L/path/to/lib',
                      'prepend-path PATH /path/to/bin']
 
-_test_template = "'. %s 2>&1' % args[1]"
 
-
-def test_module_function_change_env(tmpdir, working_env, monkeypatch):
+def test_module_function_change_env(tmpdir, working_env):
     src_file = str(tmpdir.join('src_me'))
     with open(src_file, 'w') as f:
         f.write('export TEST_MODULE_ENV_VAR=TEST_SUCCESS\n')
 
     os.environ['NOT_AFFECTED'] = "NOT_AFFECTED"
-    module('load', src_file, module_template=_test_template)
+    module('load', src_file, module_template='. {0} 2>&1'.format(src_file))
 
     assert os.environ['TEST_MODULE_ENV_VAR'] == 'TEST_SUCCESS'
     assert os.environ['NOT_AFFECTED'] == "NOT_AFFECTED"
 
 
-def test_module_function_no_change(tmpdir, monkeypatch):
+def test_module_function_no_change(tmpdir):
     src_file = str(tmpdir.join('src_me'))
     with open(src_file, 'w') as f:
         f.write('echo TEST_MODULE_FUNCTION_PRINT')
 
     old_env = os.environ.copy()
-    text = module('show', src_file, module_template=_test_template)
+    text = module('show', src_file, module_template='. {0} 2>&1'.format(src_file))
 
     assert text == 'TEST_MODULE_FUNCTION_PRINT\n'
     assert os.environ == old_env

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -50,7 +50,7 @@ def module(*args, **kwargs):
         # Update os.environ with new dict
         os.environ.clear()
         if sys.version_info >= (3, 2):
-            os.environb.update(environ)
+            os.environb.update(environ)  # novermin
         else:
             os.environ.update(environ)
 

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -39,7 +39,9 @@ def module(*args):
                                          executable="/bin/bash")
 
             env_dict = {}
-            for entry in module_p.communicate()[0].strip(b'\0').split(b'\0'):
+            output = module_p.communicate()[0]
+            print(output)
+            for entry in output.strip(b'\0').split(b'\0'):
                 key, value = entry.split(b'=', 1)
                 # We'd really like to just pass byte strings to os.environ,
                 # but Python 3 does not allow that :( In Python 2, strings

--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -19,7 +19,8 @@ import llnl.util.tty as tty
 module_change_commands = ['load', 'swap', 'unload', 'purge', 'use', 'unuse']
 
 # This awk script is a posix alternative to `env -0`
-awk_cmd = r"""awk 'BEGIN{for(name in ENVIRON) printf "%s", name"="ENVIRON[name]"\0"}'"""
+awk_cmd = (r"""awk 'BEGIN{for(name in ENVIRON)"""
+           r"""printf("%s=%s%c", name, ENVIRON[name], 0)}'""")
 
 
 def module(*args, **kwargs):


### PR DESCRIPTION
On posix systems, use `awk` instead of `python` to retrieve the `env`

```
time spack -e zlib build-env zlib
```
goes from 7.011s to 4.071s best of 5.

Edit:

- Also fixes this issue https://github.com/koalaman/shellcheck/wiki/SC2069 of in correct stderr redirection.
- Gets rid of very weird use of `eval` + `monkeypatch`.