### PR TITLE
compiler.py: early return in compiler_environment when no modules

### DIFF
--- a/lib/spack/spack/compiler.py
+++ b/lib/spack/spack/compiler.py
@@ -598,6 +598,11 @@ class Compiler(object):
 
     @contextlib.contextmanager
     def compiler_environment(self):
+        # yield immediately if no modules
+        if not self.modules:
+            yield
+            return
+
         # store environment to replace later
         backup_env = os.environ.copy()
 


### PR DESCRIPTION
No need to touch `os.environ` when there are no modules for the compiler
