### PR TITLE
fix gaussian-src package 16-C.01 gau-machine missing and Python errors on listdir

### DIFF
--- a/var/spack/repos/builtin/packages/gaussian-src/16-C.01-fix-gau-machine.patch
+++ b/var/spack/repos/builtin/packages/gaussian-src/16-C.01-fix-gau-machine.patch
@@ -1,0 +1,22 @@
+--- a/bsd/bldg16	2019-02-21 21:49:32.000000000 +0100
++++ b/bsd/bldg16	2022-03-10 08:59:57.000000000 +0100
+@@ -158,15 +158,16 @@
+   icc -Bstatic -o gau-machine $machflag bsd/machine.c
+ else
+   set zzz = `which ifort`
+-  if ($status) unsetenv LD_LIBRARY_PATH
++  # do not unset LD_LIBRARY path, there is an issue with PGI 18.10
++  #if ($status) unsetenv LD_LIBRARY_PATH
+   setenv NPES 1
+   cc -o gau-machine $machflag bsd/machine.c
+   unsetenv NPES
+   endif
+-set x = `gau-machine`
+-echo "machine type is $x"
+ set CWD=`pwd`
+ setenv PATH ${CWD}:${CWD}/bsd:${PATH}
++set x = `gau-machine`
++echo "machine type is $x"
+ if (! ($?g16root) ) setenv g16root "$CWD:h"
+ source $g16root/g16/bsd/g16.login
+ rehash

--- a/var/spack/repos/builtin/packages/gaussian-src/package.py
+++ b/var/spack/repos/builtin/packages/gaussian-src/package.py
@@ -36,6 +36,7 @@ class GaussianSrc(Package):
     patch('16-C.01-replace-deprecated-pgf77-with-pgfortran.patch', when='@16-C.01')
     patch('16-C.01-fix-building-c-code-with-pgcc.patch', when='@16-C.01')
     patch('16-C.01-fix-shebangs.patch', when='@16-C.01')
+    patch('16-C.01-fix-gau-machine.patch', when='@16-C.01')
 
     @property
     def g_name(self):
@@ -51,7 +52,7 @@ class GaussianSrc(Package):
     def install(self, spec, prefix):
         # Spacks strips the single dir inside the tarball, but Gaussian
         # needs it -> move them back
-        files = os.listdir()
+        files = os.listdir('.')
         mkdirp(self.g_name)
         for f in files:
             os.rename(f, join_path(self.g_name, f))
@@ -75,6 +76,7 @@ class GaussianSrc(Package):
 
             exes = [
                 self.g_name,
+                'gau-machine',
                 'gauopt',
                 'gauoptl',
                 'ghelp',


### PR DESCRIPTION
During build of Gaussian-src I have noticed that the gau-machine binary is missing. This is needed during build and for the login profile file bsd/g16.login or g16.profile. I have added this to the list of binaries to copy in the package.py. 
Also  the binary is used during build, but due to wrong order in the bldg16 makefile it fails. And the build of this binary fails with PGI 18.10 compiler. Therefore I have added a patch with fixes both issues.

Python complains that the listdir() function needs arguments (on Scientific Linux 7 with Python 3.9.0). Here I have changed it to listdir('.')

**Documentation**

For documentation I suggest to add one sentence that you must extract the source package from Gaussian, go to the tar folder and place the file wkssrc.tbz as gaussian-src-16-C.01.tar.gz, not the original tbz file. 

Also the PGI compiler always complained about
lib/libnuma.so: file not recognized: file truncated
See also [discussion on nvidia forum](https://forums.developer.nvidia.com/t/internal-compiler-error-too-many-assign-statements/136079/2) 
So it is fixed on newer PGI version. But for 18.10 I suggest to add a note. My solution was to edit compilers.yaml and add these options to the compiler:
```
- compiler:
    paths:
      cc: /opt/sw/rev/21.12/haswell/gcc-9.3.0/pgi-18.10-2nhhea/linux86-64/18.10/bin/pgcc
      cxx: /opt/sw/rev/21.12/haswell/gcc-9.3.0/pgi-18.10-2nhhea/linux86-64/18.10/bin/pgc++
      f77: /opt/sw/rev/21.12/haswell/gcc-9.3.0/pgi-18.10-2nhhea/linux86-64/18.10/bin/pgfortran
      fc: /opt/sw/rev/21.12/haswell/gcc-9.3.0/pgi-18.10-2nhhea/linux86-64/18.10/bin/pgfortran
    operating_system: scientific7
    target: x86_64
    modules: []
    environment:
      prepend_path:
        LD_LIBRARY_PATH: /usr/lib64
    extra_rpaths: []
    flags:
      cflags: -L/usr/lib64 -rpath=/usr/lib64
      fflags: -L/usr/lib64 -rpath=/usr/lib64
      cxxflags: -L/usr/lib64 -rpath=/usr/lib64
    spec: pgi@18.10

```
Compiler flags and  LD_LIBRARY_PATH were added to fix the compilation process.
