### PR TITLE
eztrace: new version and refactor for cmake/autotools build

### DIFF
--- a/var/spack/repos/builtin/packages/eztrace/package.py
+++ b/var/spack/repos/builtin/packages/eztrace/package.py
@@ -19,18 +19,19 @@ class Eztrace(Package):
     version('1.1-13', sha256='6144d04fb62b3ccad41af0268cd921161f168d0cca3f6c210c448bb0b07be7e0')
     version('1.1-10', sha256='63d1af2db38b04efa817614574f381e7536e12db06a2c75375d1795adda3d1d8')
 
+    # dependencies for eztrace 1.x and 2.x
     depends_on('mpi')
     depends_on('opari2')
     depends_on('binutils')
 
-# eztrace 1.x dependencies
+    # eztrace 1.x dependencies
     depends_on('autoconf@2.71', type='build', when="@:1")
     depends_on('automake', type='build', when="@:1")
     depends_on('libtool', type='build', when="@:1")
     # Does not work on Darwin due to MAP_POPULATE
     conflicts('platform=darwin', when='@:1')
 
-# eztrace 2.x dependencies
+    # eztrace 2.x dependencies
     depends_on('cmake@3.1:', type='build', when="@2.0:")
     depends_on('otf2', when="@2.0:")
 

--- a/var/spack/repos/builtin/packages/eztrace/package.py
+++ b/var/spack/repos/builtin/packages/eztrace/package.py
@@ -40,7 +40,7 @@ class Eztrace(Package):
 
     @when('@2.0:')
     def install(self, spec, prefix):
-    # Since eztrace 2.0, the build system uses CMake
+        # Since eztrace 2.0, the build system uses CMake
         spec = self.spec
         args = [
             "-DCMAKE_INSTALL_PREFIX=$prefix",

--- a/var/spack/repos/builtin/packages/eztrace/package.py
+++ b/var/spack/repos/builtin/packages/eztrace/package.py
@@ -34,15 +34,13 @@ class Eztrace(Package):
     depends_on('cmake@3.1:', type='build', when="@2.0:")
     depends_on('otf2', when="@2.0:")
 
-
     def url_for_version(self, version):
         url = "https://gitlab.com/eztrace/eztrace/-/archive/{0}/eztrace-{1}.tar.gz"
         return url.format(version, version)
 
-
-    # Since eztrace 2.0, the build system uses CMake
     @when('@2.0:')
     def install(self, spec, prefix):
+    # Since eztrace 2.0, the build system uses CMake
         spec = self.spec
         args = [
             "-DCMAKE_INSTALL_PREFIX=$prefix",

--- a/var/spack/repos/builtin/packages/eztrace/package.py
+++ b/var/spack/repos/builtin/packages/eztrace/package.py
@@ -24,11 +24,11 @@ class Eztrace(Package):
     depends_on('binutils')
 
 # eztrace 1.x dependencies
-    depends_on('autoconf@2.71', type='build', when="@:2.0")
-    depends_on('automake', type='build', when="@:2.0")
-    depends_on('libtool', type='build', when="@:2.0")
+    depends_on('autoconf@2.71', type='build', when="@:1")
+    depends_on('automake', type='build', when="@:1")
+    depends_on('libtool', type='build', when="@:1")
     # Does not work on Darwin due to MAP_POPULATE
-    conflicts('platform=darwin', when='@:2.0')
+    conflicts('platform=darwin', when='@:1')
 
 # eztrace 2.x dependencies
     depends_on('cmake@3.1:', type='build', when="@2.0:")
@@ -64,7 +64,7 @@ class Eztrace(Package):
             make('install')
 
     # Until eztrace 2.0, the build system uses autoconf
-    @when('@:1.99')
+    @when('@:1')
     def install(self, spec, prefix):
         if self.spec.satisfies('%fj'):
             env.set('LDFLAGS', '--linkfortran')
@@ -76,7 +76,7 @@ class Eztrace(Package):
         make()
         make("install")
 
-    @when('@:1.99')
+    @when('@:1')
     def patch(self):
         filter_file(
             '"DEFAULT_OUTFILE"',
@@ -85,7 +85,7 @@ class Eztrace(Package):
             string=True
         )
 
-    @when('@:1.99')
+    @when('@:1')
     def fix_libtool(self):
         if self.spec.satisfies('%fj'):
             libtools = ['extlib/gtg/libtool',

--- a/var/spack/repos/builtin/packages/eztrace/package.py
+++ b/var/spack/repos/builtin/packages/eztrace/package.py
@@ -14,21 +14,31 @@ class Eztrace(Package):
     maintainers = ['trahay']
     git = "https://gitlab.com/eztrace/eztrace.git"
 
-    version('1.1-10', tag='eztrace-1.1-10')
-    version('1.1-13', tag='eztrace-1.1-13')
     version('master',  branch='master')
-    version('2.0-rc1', tag='2.0-rc1')
-
-    depends_on('autoconf', type='build', when="@:2.0")
-    depends_on('automake', type='build', when="@:2.0")
-    depends_on('libtool', type='build', when="@:2.0")
-
-    depends_on('cmake@3.1:', type='build', when="@2.0:")
-    depends_on('otf2', when="@2.0:")
+    version('2.0-rc1', sha256='2ad322df5aeb0c668ebadbfeb3b21c8841831b2c15944d86d1d217f738fee74e')
+    version('1.1-13', sha256='6144d04fb62b3ccad41af0268cd921161f168d0cca3f6c210c448bb0b07be7e0')
+    version('1.1-10', sha256='63d1af2db38b04efa817614574f381e7536e12db06a2c75375d1795adda3d1d8')
 
     depends_on('mpi')
     depends_on('opari2')
     depends_on('binutils')
+
+# eztrace 1.x dependencies
+    depends_on('autoconf@2.71', type='build', when="@:2.0")
+    depends_on('automake', type='build', when="@:2.0")
+    depends_on('libtool', type='build', when="@:2.0")
+    # Does not work on Darwin due to MAP_POPULATE
+    conflicts('platform=darwin', when='@:2.0')
+
+# eztrace 2.x dependencies
+    depends_on('cmake@3.1:', type='build', when="@2.0:")
+    depends_on('otf2', when="@2.0:")
+
+
+    def url_for_version(self, version):
+        url = "https://gitlab.com/eztrace/eztrace/-/archive/{0}/eztrace-{1}.tar.gz"
+        return url.format(version, version)
+
 
     # Since eztrace 2.0, the build system uses CMake
     @when('@2.0:')


### PR DESCRIPTION
Update eztrace package to include version 2.0 as well as the git version.
