### PR TITLE
Remove "setup_environment" and "setup_dependent_environment"

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2040,17 +2040,6 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         """
         return (None, None, flags)
 
-    def _get_legacy_environment_method(self, method_name):
-        legacy_fn = getattr(self, method_name, None)
-        name_prefix = method_name.split('_environment')[0]
-        if legacy_fn:
-            msg = '[DEPRECATED METHOD]\n"{0}" ' \
-                  'still defines the deprecated method "{1}" ' \
-                  '[should be split into "{2}_build_environment" and ' \
-                  '"{2}_run_environment"]'
-            tty.debug(msg.format(self.name, method_name, name_prefix))
-        return legacy_fn
-
     def setup_build_environment(self, env):
         """Sets up the build environment for a package.
 
@@ -2062,10 +2051,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 modifications to be applied when the package is built. Package authors
                 can call methods on it to alter the build environment.
         """
-        legacy_fn = self._get_legacy_environment_method('setup_environment')
-        if legacy_fn:
-            _ = spack.util.environment.EnvironmentModifications()
-            legacy_fn(env, _)
+        pass
 
     def setup_run_environment(self, env):
         """Sets up the run environment for a package.
@@ -2075,10 +2061,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 modifications to be applied when the package is run. Package authors
                 can call methods on it to alter the run environment.
         """
-        legacy_fn = self._get_legacy_environment_method('setup_environment')
-        if legacy_fn:
-            _ = spack.util.environment.EnvironmentModifications()
-            legacy_fn(_, env)
+        pass
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         """Sets up the build environment of packages that depend on this one.
@@ -2109,12 +2092,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 the dependent's state. Note that *this* package's spec is
                 available as ``self.spec``
         """
-        legacy_fn = self._get_legacy_environment_method(
-            'setup_dependent_environment'
-        )
-        if legacy_fn:
-            _ = spack.util.environment.EnvironmentModifications()
-            legacy_fn(env, _, dependent_spec)
+        pass
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         """Sets up the run environment of packages that depend on this one.
@@ -2136,12 +2114,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 the dependent's state. Note that *this* package's spec is
                 available as ``self.spec``
         """
-        legacy_fn = self._get_legacy_environment_method(
-            'setup_dependent_environment'
-        )
-        if legacy_fn:
-            _ = spack.util.environment.EnvironmentModifications()
-            legacy_fn(_, env, dependent_spec)
+        pass
 
     def setup_dependent_package(self, module, dependent_spec):
         """Set up Python module-scope variables for dependent packages.

--- a/var/spack/repos/builtin.mock/packages/callpath/package.py
+++ b/var/spack/repos/builtin.mock/packages/callpath/package.py
@@ -22,5 +22,5 @@ class Callpath(Package):
         make()
         make("install")
 
-    def setup_environment(self, senv, renv):
-        renv.set('FOOBAR', self.name)
+    def setup_run_environment(self, env):
+        env.set('FOOBAR', self.name)

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -54,20 +54,20 @@ class CmakeClient(CMakePackage):
     def setup_build_environment(self, spack_env):
         spack_cc    # Ensure spack module-scope variable is avaiabl
         check(from_cmake == "from_cmake",
-              "setup_environment couldn't read global set by cmake.")
+              "setup_build_environment couldn't read global set by cmake.")
 
         check(self.spec['cmake'].link_arg == "test link arg",
               "link arg on dependency spec not readable from "
-              "setup_environment.")
+              "setup_build_environment.")
 
-    def setup_dependent_build_environment(self, spack_env, dspec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         spack_cc    # Ensure spack module-scope variable is avaiable
         check(from_cmake == "from_cmake",
-              "setup_dependent_environment couldn't read global set by cmake.")
+              "setup_dependent_build_environment couldn't read global set by cmake.")
 
         check(self.spec['cmake'].link_arg == "test link arg",
               "link arg on dependency spec not readable from "
-              "setup_dependent_environment.")
+              "setup_dependent_build_environment.")
 
     def setup_dependent_package(self, module, dspec):
         spack_cc    # Ensure spack module-scope variable is avaiable

--- a/var/spack/repos/builtin.mock/packages/cmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake/package.py
@@ -22,13 +22,13 @@ class Cmake(Package):
     version('3.4.3',    '4cb3ff35b2472aae70f542116d616e63',
             url='https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz')
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_build_environment(self, env):
         spack_cc    # Ensure spack module-scope variable is avaiable
-        spack_env.set('for_install', 'for_install')
+        env.set('for_install', 'for_install')
 
-    def setup_dependent_environment(self, spack_env, run_env, dspec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         spack_cc    # Ensure spack module-scope variable is avaiable
-        spack_env.set('from_cmake', 'from_cmake')
+        env.set('from_cmake', 'from_cmake')
 
     def setup_dependent_package(self, module, dspec):
         spack_cc    # Ensure spack module-scope variable is avaiable

--- a/var/spack/repos/builtin.mock/packages/conflict-parent/package.py
+++ b/var/spack/repos/builtin.mock/packages/conflict-parent/package.py
@@ -23,5 +23,5 @@ class ConflictParent(Package):
         make()
         make("install")
 
-    def setup_environment(self, senv, renv):
-        renv.set('FOOBAR', self.name)
+    def setup_run_environment(self, env):
+        env.set('FOOBAR', self.name)

--- a/var/spack/repos/builtin.mock/packages/conflict/package.py
+++ b/var/spack/repos/builtin.mock/packages/conflict/package.py
@@ -23,5 +23,5 @@ class Conflict(Package):
         make()
         make("install")
 
-    def setup_environment(self, senv, renv):
-        renv.set('FOOBAR', self.name)
+    def setup_run_environment(self, env):
+        env.set('FOOBAR', self.name)

--- a/var/spack/repos/builtin.mock/packages/hash-test1/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test1/package.py
@@ -29,7 +29,7 @@ class HashTest1(Package):
     variant('variantx', default=False, description='Test variant X')
     variant('varianty', default=False, description='Test variant Y')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         pass
 
     @when('@:1.4')

--- a/var/spack/repos/builtin.mock/packages/hash-test2/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test2/package.py
@@ -25,7 +25,7 @@ class HashTest2(Package):
     variant('variantx', default=False, description='Test variant X')
     variant('varianty', default=False, description='Test variant Y')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         pass
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin.mock/packages/hash-test3/package.py
+++ b/var/spack/repos/builtin.mock/packages/hash-test3/package.py
@@ -24,7 +24,7 @@ class HashTest3(Package):
     variant('variantx', default=False, description='Test variant X')
     variant('varianty', default=False, description='Test variant Y')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         pass
 
     @when('@:1.4')

--- a/var/spack/repos/builtin.mock/packages/module-path-separator/package.py
+++ b/var/spack/repos/builtin.mock/packages/module-path-separator/package.py
@@ -12,11 +12,11 @@ class ModulePathSeparator(Package):
 
     version(1.0, '0123456789abcdef0123456789abcdef')
 
-    def setup_environment(self, senv, renv):
-        renv.append_path("COLON", "foo")
-        renv.prepend_path("COLON", "foo")
-        renv.remove_path("COLON", "foo")
+    def setup_run_environment(self, env):
+        env.append_path("COLON", "foo")
+        env.prepend_path("COLON", "foo")
+        env.remove_path("COLON", "foo")
 
-        renv.append_path("SEMICOLON", "bar", separator=";")
-        renv.prepend_path("SEMICOLON", "bar", separator=";")
-        renv.remove_path("SEMICOLON", "bar", separator=";")
+        env.append_path("SEMICOLON", "bar", separator=";")
+        env.prepend_path("SEMICOLON", "bar", separator=";")
+        env.remove_path("SEMICOLON", "bar", separator=";")

--- a/var/spack/repos/builtin.mock/packages/mpileaks/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpileaks/package.py
@@ -30,5 +30,5 @@ class Mpileaks(Package):
         touch(prefix.mpileaks)
         mkdirp(prefix.man)
 
-    def setup_environment(self, senv, renv):
-        renv.set('FOOBAR', self.name)
+    def setup_run_environment(self, env):
+        env.set('FOOBAR', self.name)

--- a/var/spack/repos/builtin/packages/metall/package.py
+++ b/var/spack/repos/builtin/packages/metall/package.py
@@ -45,11 +45,6 @@ class Metall(CMakePackage):
             args = ['-DINSTALL_HEADER_ONLY=ON']
             return args
 
-    # Set environmental variables for the build step
-    # setup_environment() was replaced by setup_build_environment()?
-    # (https://github.com/spack/spack/pull/11115)
-    # This page has not been updated?
-    # https://spack-tutorial.readthedocs.io/en/latest/tutorial_advanced_packaging.html
     def setup_build_environment(self, env):
         # Configure the directories for test
         if self.run_tests:

--- a/var/spack/repos/tutorial/packages/elpa/package.py
+++ b/var/spack/repos/tutorial/packages/elpa/package.py
@@ -44,7 +44,7 @@ class Elpa(AutotoolsPackage):
 
     build_directory = 'spack-build'
 
-    def setup_environment(self, spack_env, run_env):
+    def setup_run_environment(self, env):
         # TUTORIAL: set the following environment variables:
         #
         # CC=spec['mpi'].mpicc

--- a/var/spack/repos/tutorial/packages/mpich/package.py
+++ b/var/spack/repos/tutorial/packages/mpich/package.py
@@ -75,7 +75,7 @@ spack package at this time.''',
     conflicts('netmod=mxm', when='@:3.1.3')
     conflicts('netmod=tcp', when='device=ch4')
 
-    def setup_dependent_environment(self, spack_env, run_env, dependent_spec):
+    def setup_dependent_build_environment(self, env, dependent_spec):
         # TUTORIAL: set the following variables for dependents:
         #
         # MPICC=join_path(self.prefix.bin, 'mpicc')


### PR DESCRIPTION
fixes #29446

The new `setup_*_environment` functions have been falling back to calling the old functions and warn the user since #11115.

This commit removes the fallback behavior and any use of:
- `setup_environment`
- `setup_dependent_environment`

in the code base.