### PR TITLE
Hdf5: fix constraint

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -108,8 +108,8 @@ class Hdf5(CMakePackage):
     conflicts('+java', when='@:1.9')
     # The Java wrappers cannot be built without shared libs.
     conflicts('+java', when='~shared')
-    # Fortran cannot be built with shared
-    conflicts('+fortran', when='+shared@:1.8')
+    # Fortran fails built with shared for old HDF5 versions
+    conflicts('+fortran', when='+shared@:1.8.15')
 
     # There are several officially unsupported combinations of the features:
     # 1. Thread safety is not guaranteed via high-level C-API but in some cases


### PR DESCRIPTION
See https://github.com/spack/spack/pull/29132#discussion_r825061135 : I had encountered a build failure when silo concretized to `^hdf5@1.8.15+shared+fortran+cxx`, but the version constraint I added was too general. This PR allows newer 1.8 versions to build as expected.

```
CMake Error at CMakeLists.txt:814 (message):
   **** Shared FORTRAN libraries are unsupported ****
```