### PR TITLE
config add: fix parsing of validator error to infer type from oneOf

### DIFF
--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -1092,11 +1092,11 @@ def get_valid_type(path):
         jsonschema_error = e.validation_error
         if jsonschema_error.validator == 'type':
             return types[jsonschema_error.validator_value]()
-        elif jsonschema_error.validator == 'anyOf':
+        elif jsonschema_error.validator in ('anyOf', 'oneOf'):
             for subschema in jsonschema_error.validator_value:
-                anyof_type = subschema.get('type')
-                if anyof_type is not None:
-                    return types[anyof_type]()
+                schema_type = subschema.get('type')
+                if schema_type is not None:
+                    return types[schema_type]()
     else:
         return type(None)
     raise ConfigError("Cannot determine valid type for path '%s'." % path)

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -238,10 +238,12 @@ def test_config_add_ordered_dict(mutable_empty_config):
   second: /path/to/second
 """
 
+
 def test_config_add_interpret_oneof(mutable_empty_config):
     # Regression test for a bug that would raise a validation error
     config('add', 'packages:all:target:[x86_64]')
     config('add', 'packages:all:variants:~shared')
+
 
 def test_config_add_invalid_fails(mutable_empty_config):
     config('add', 'packages:all:variants:+debug')

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -238,6 +238,10 @@ def test_config_add_ordered_dict(mutable_empty_config):
   second: /path/to/second
 """
 
+def test_config_add_interpret_oneof(mutable_empty_config):
+    # Regression test for a bug that would raise a validation error
+    config('add', 'packages:all:target:[x86_64]')
+    config('add', 'packages:all:variants:~shared')
 
 def test_config_add_invalid_fails(mutable_empty_config):
     config('add', 'packages:all:variants:+debug')


### PR DESCRIPTION
The `spack config add` command works to infer the type of a config entry from the existing value or the validation error raised when adding `None`.

There was a bug reported by @rhd on Spack slack that the following shell code raised an error
```
spack config add packages:all:target:[x86_64]
spack config add packages:all:variants:~shared
```
In the opposite order, those commands would succeed.

The bug occurred because we checked the JSONValidationError for `type` or `anyOf`, but did not check and interpred `oneOf`. That is fixed in this PR.

Includes regression test.