### PR TITLE
ci: add e4s macos stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -102,6 +102,48 @@ default:
 #     strategy: depend
 
 ########################################
+# E4S Mac Stack
+########################################
+.e4s-mac:
+  variables:
+    SPACK_CI_STACK_NAME: e4s-mac
+  allow_failure: True
+
+e4s-mac-pr-generate:
+  extends: [ ".e4s-mac", ".pr-generate"]
+  tags:
+  - omicron
+  timeout: 60 minutes
+
+e4s-mac-develop-generate:
+  extends: [ ".e4s-mac", ".develop-generate"]
+  tags:
+  - omicron
+  timeout: 60 minutes
+
+e4s-mac-pr-build:
+  extends: [ ".e4s-mac", ".pr-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: e4s-mac-pr-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: e4s-mac-pr-generate
+
+e4s-mac-develop-build:
+  extends: [ ".e4s-mac", ".develop-build" ]
+  trigger:
+    include:
+      - artifact: jobs_scratch_dir/cloud-ci-pipeline.yml
+        job: e4s-mac-develop-generate
+    strategy: depend
+  needs:
+    - artifacts: True
+      job: e4s-mac-develop-generate
+
+########################################
 # E4S pipeline
 ########################################
 .e4s:
@@ -110,6 +152,7 @@ default:
 
 e4s-pr-generate:
   extends: [ ".e4s", ".pr-generate"]
+  tags:
 
 e4s-develop-generate:
   extends: [ ".e4s", ".develop-generate"]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -1,0 +1,62 @@
+spack:
+  view: false
+  concretization: separately
+
+  config:
+    concretizer: clingo
+    install_tree:
+      root: $SPACK_ROOT/opt/spack
+      padded_length: 512
+      projections:
+        all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
+
+  packages:
+    all:
+      compiler: [apple-clang@13.0.0]
+      target: [m1]
+
+  definitions:
+  - easy_specs:
+    - zlib
+
+  - arch:
+    - '%apple-clang@13.0.0 target=m1'
+
+  specs:
+
+  - matrix:
+    - - $easy_specs
+    - - $arch
+
+  mirrors: { "mirror": "s3://spack-binaries-develop/e4s-mac" }
+
+  gitlab-ci:
+
+    script:
+      - . "./share/spack/setup-env.sh"
+      - spack --version
+      - cd ${SPACK_CONCRETE_ENV_DIR}
+      - spack env activate --without-view .
+      - spack config add "config:install_tree:projections:${SPACK_JOB_SPEC_PKG_NAME}:'morepadding/{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'"
+      - mkdir -p ${SPACK_ARTIFACTS_ROOT}/user_data
+      - spack -d ci rebuild > >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_out.txt) 2> >(tee ${SPACK_ARTIFACTS_ROOT}/user_data/pipeline_err.txt >&2)
+
+    mappings:
+      - match: ['os=monterey']
+        runner-attributes:
+          tags:
+          - omicron
+    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
+    broken-specs-url: "s3://spack-binaries-develop/broken-specs"
+    service-job-attributes:
+      before_script:
+        - . "./share/spack/setup-env.sh"
+        - spack --version
+      tags:
+      - omicron
+
+  cdash:
+    build-group: E4S Mac
+    url: https://cdash.spack.io
+    project: Spack Testing
+    site: Cloud Gitlab Infrastructure


### PR DESCRIPTION
Adding a very simple, easy-to-build stack to assess capacity of macOS runners to service CI jobs.

@scottwittenburg 