### PR TITLE
numactl: add explicit macos conflict

### DIFF
--- a/var/spack/repos/builtin/packages/numactl/package.py
+++ b/var/spack/repos/builtin/packages/numactl/package.py
@@ -33,6 +33,9 @@ class Numactl(AutotoolsPackage):
     # libtool@develop returns UNKOWN as a version tag and fails
     conflicts('libtool@develop')
 
+    # Numerous errors when trying to build on darwin
+    conflicts('platform=darwin')
+
     def autoreconf(self, spec, prefix):
         bash = which('bash')
         bash('./autogen.sh')


### PR DESCRIPTION
A lot of packages have `if sys.platform != 'darwin': depends_on('numactl')`, but if one gets forgotten this should at least prevent some unnecessary build errors.