### PR TITLE
Prepare: openPMD-api 0.15.0-dev

### DIFF
--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -108,7 +108,7 @@ class OpenpmdApi(CMakePackage):
             ]
 
         args.append(self.define('openPMD_USE_INTERNAL_JSON', False))
-        if spec.satisfies('@:0.14.99'):  # pre C++17 releases
+        if spec.satisfies('@:0.14'):  # pre C++17 releases
             args.append(self.define('openPMD_USE_INTERNAL_VARIANT', False))
         if spec.satisfies('@0.15.0:'):
             args.append(self.define('openPMD_USE_INTERNAL_TOML11', False))
@@ -121,7 +121,7 @@ class OpenpmdApi(CMakePackage):
     def setup_run_environment(self, env):
         spec = self.spec
         # pre-load dependent CMake-PUBLIC header-only libs
-        if spec.satisfies('@:0.14.99'):  # pre C++17 releases
+        if spec.satisfies('@:0.14'):  # pre C++17 releases
             env.prepend_path('CMAKE_PREFIX_PATH', spec['mpark-variant'].prefix)
             env.prepend_path('CPATH', spec['mpark-variant'].prefix.include)
 
@@ -139,7 +139,7 @@ class OpenpmdApi(CMakePackage):
     def setup_dependent_build_environment(self, env, dependent_spec):
         spec = self.spec
         # pre-load dependent CMake-PUBLIC header-only libs
-        if spec.satisfies('@:0.14.99'):  # pre C++17 releases
+        if spec.satisfies('@:0.14'):  # pre C++17 releases
             env.prepend_path('CMAKE_PREFIX_PATH',
                              spec['mpark-variant'].prefix)
             env.prepend_path('CPATH', spec['mpark-variant'].prefix.include)

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -13,12 +13,13 @@ class OpenpmdApi(CMakePackage):
     url      = "https://github.com/openPMD/openPMD-api/archive/0.14.2.tar.gz"
     git      = "https://github.com/openPMD/openPMD-api.git"
 
-    maintainers = ['ax3l']
+    maintainers = ['ax3l', 'franzpoeschel']
 
     tags = ['e4s']
 
-    # C++14 up until here
+    # C++17 up until here
     version('develop', branch='dev')
+    # C++14 up until here
     version('0.14.4', sha256='42b7bcd043e772d63f0fe0e5e70da411f001db10096d5b8be797ffc88e786379')
     version('0.14.3', sha256='57282455e0fb1873b4def1894fadadd6425dfc8349eac7fcc68daf677c48b7ce')
     version('0.14.2', sha256='25c6b4bcd0ae1ba668b633b8514e66c402da54901c26861fc754fca55717c836')
@@ -47,11 +48,12 @@ class OpenpmdApi(CMakePackage):
             description='Enable Python bindings')
 
     depends_on('cmake@3.15.0:', type='build')
-    depends_on('mpark-variant@1.4.0:')
     depends_on('catch2@2.6.1:', type='test')
     depends_on('catch2@2.13.4:', type='test', when='@0.14.0:')
     depends_on('mpi@2.3:', when='+mpi')  # might become MPI 3.0+
     depends_on('nlohmann-json@3.9.1:')
+    depends_on('mpark-variant@1.4.0:', when='@:0.14.99')  # pre C++17 releases
+    depends_on('toml11@3.7.1:', when='@0.15.0:')
     with when('+hdf5'):
         depends_on('hdf5@1.8.13:')
         depends_on('hdf5@1.8.13: ~mpi', when='~mpi')
@@ -105,10 +107,12 @@ class OpenpmdApi(CMakePackage):
                 self.define('openPMD_USE_INTERNAL_PYBIND11', False)
             ]
 
-        args += [
-            self.define('openPMD_USE_INTERNAL_JSON', False),
-            self.define('openPMD_USE_INTERNAL_VARIANT', False)
-        ]
+        args.append(self.define('openPMD_USE_INTERNAL_JSON', False))
+        if spec.satisfies('@:0.14.99'):  # pre C++17 releases
+            args.append(self.define('openPMD_USE_INTERNAL_VARIANT', False))
+        if spec.satisfies('@0.15.0:'):
+            args.append(self.define('openPMD_USE_INTERNAL_TOML11', False))
+
         if self.run_tests:
             args.append(self.define('openPMD_USE_INTERNAL_CATCH', False))
 
@@ -117,8 +121,9 @@ class OpenpmdApi(CMakePackage):
     def setup_run_environment(self, env):
         spec = self.spec
         # pre-load dependent CMake-PUBLIC header-only libs
-        env.prepend_path('CMAKE_PREFIX_PATH', spec['mpark-variant'].prefix)
-        env.prepend_path('CPATH', spec['mpark-variant'].prefix.include)
+        if spec.satisfies('@:0.14.99'):  # pre C++17 releases
+            env.prepend_path('CMAKE_PREFIX_PATH', spec['mpark-variant'].prefix)
+            env.prepend_path('CPATH', spec['mpark-variant'].prefix.include)
 
         # more deps searched in openPMDConfig.cmake
         if spec.satisfies("+mpi"):
@@ -132,10 +137,12 @@ class OpenpmdApi(CMakePackage):
             env.prepend_path('CMAKE_PREFIX_PATH', spec['hdf5'].prefix)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
+        spec = self.spec
         # pre-load dependent CMake-PUBLIC header-only libs
-        env.prepend_path('CMAKE_PREFIX_PATH',
-                         self.spec['mpark-variant'].prefix)
-        env.prepend_path('CPATH', self.spec['mpark-variant'].prefix.include)
+        if spec.satisfies('@:0.14.99'):  # pre C++17 releases
+            env.prepend_path('CMAKE_PREFIX_PATH',
+                             spec['mpark-variant'].prefix)
+            env.prepend_path('CPATH', spec['mpark-variant'].prefix.include)
 
     def check(self):
         """CTest checks after the build phase"""

--- a/var/spack/repos/builtin/packages/openpmd-api/package.py
+++ b/var/spack/repos/builtin/packages/openpmd-api/package.py
@@ -110,7 +110,7 @@ class OpenpmdApi(CMakePackage):
         args.append(self.define('openPMD_USE_INTERNAL_JSON', False))
         if spec.satisfies('@:0.14'):  # pre C++17 releases
             args.append(self.define('openPMD_USE_INTERNAL_VARIANT', False))
-        if spec.satisfies('@0.15.0:'):
+        if spec.satisfies('@0.15:'):
             args.append(self.define('openPMD_USE_INTERNAL_TOML11', False))
 
         if self.run_tests:


### PR DESCRIPTION
Anticipate openPMD-api changes in the next major release that are already in `dev` (aka Spack `develop`):
- C++17 requirement
- drop: `mpark-variant` public dependency
- add: `toml11` private dependency

Also adds @franzpoeschel as co-maintainer for the Spack package.

- [x] depends on #29483