### PR TITLE
Identify zen3 architecture on AWS hpc6a instances

### DIFF
--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -1519,8 +1519,7 @@
         "popcnt",
         "clwb",
         "vaes",
-        "vpclmulqdq",
-        "pku"
+        "vpclmulqdq"
       ],
       "compilers": {
         "gcc": [


### PR DESCRIPTION
The AWS EC2 virtualization does not expose the `pku` flag on zen3 based hpc6a instances. The remaining `vpclmulqdq` should suffice to distinguish zen2 from zen3.