### PR TITLE
vecgeom: add v1.1.19

### DIFF
--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -20,6 +20,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     maintainers = ['drbenmorgan', 'sethrj']
 
     version('master', branch='master')
+    version('1.1.19', sha256='4c586b57fd4e30be044366c9be983249c7fa8bec629624523f5f69fd9caaa05b')
     version('1.1.18', sha256='2780640233a36e0d3c767140417015be1893c1ad695ccc0bd3ee0767bc9fbed8')
     version('1.1.17', sha256='2e95429b795311a6986320d785bedcd9dace9f8e7b7f6bd778d23a4ff23e0424')
     version('1.1.16', sha256='2fa636993156d9d06750586e8a1ac1701ae2be62dea07964e2369698ae521d02')
@@ -50,7 +51,7 @@ class Vecgeom(CMakePackage, CudaPackage):
     variant('shared', default=True,
             description='Build shared libraries')
 
-    depends_on('veccore@0.8.0', type=('build', 'link'), when='@1.1.18')
+    depends_on('veccore@0.8.0', type=('build', 'link'), when='@1.1.18:')
     depends_on('veccore@0.5.2:', type=('build', 'link'), when='@1.1.0:')
     depends_on('veccore@0.4.2', type=('build', 'link'), when='@:1.0')
     depends_on('veccore+cuda', type=('build', 'link'), when='+cuda')
@@ -93,11 +94,15 @@ class Vecgeom(CMakePackage, CudaPackage):
             define('VECGEOM_VECTOR', target_instructions),
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
             self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'),
-            self.define_from_variant('CUDA'),
             self.define_from_variant('GDML'),
             self.define_from_variant('GEANT4'),
             self.define_from_variant('ROOT'),
         ]
+
+        if self.spec.satisfies('@:1.1.18'):
+            options.append(self.define_from_variant('CUDA'))
+        else:
+            options.append(self.define_from_variant('VECGEOM_ENABLE_CUDA', 'cuda'))
 
         # Set testing flags
         build_tests = self.run_tests


### PR DESCRIPTION
Simple version bump with the latest tag, plus small adjustment to CUDA build args due to migration of build to use native CMake CUDA support.