### PR TITLE
Add Intel compiler support for zen3

### DIFF
--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -1543,6 +1543,14 @@
             "name": "znver3",
             "flags": "-march={name} -mtune={name}"
           }
+        ],
+        "intel": [
+            {
+                "versions": "16.0:",
+                "warnings": "Intel's compilers may or may not optimize to the same degree for non-Intel microprocessors for optimizations that are not unique to Intel microprocessors",
+                "name": "core-avx2",
+                "flags": "-march={name} -mtune={name}"
+            }
         ]
       }
     },


### PR DESCRIPTION
Leaving flags `core-avx2` as with zen2 as I don't have any better idea. Please edit if you know better.