### PR TITLE
Trilinos: add linker flags to improve behavior

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -421,9 +421,11 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
         elif name == 'ldflags':
             if is_cce:
                 flags.append('-fuse-ld=gold')
-            if spec.satisfies('platform=linux'):
+            if spec.satisfies('platform=linux ~cuda'):
                 # TriBITS explicitly links libraries against all transitive
-                # dependencies, leading to O(N^2) library resolution.
+                # dependencies, leading to O(N^2) library resolution. When
+                # CUDA is enabled (possibly only with MPI as well) the linker
+                # flag does not propagate correctly.
                 flags.append('-Wl,--as-needed')
             elif spec.satisfies('+stk +shared platform=darwin'):
                 flags.append('-Wl,-undefined,dynamic_lookup')


### PR DESCRIPTION
TriBITS links all transitive dependencies for libraries, resulting in
huge dependency trees and longer shared library load times. STK also
relies on missing definitions, so I added a flag for fixing that use
case on darwin (which prohibits missing definitions by default).

Before:
```console
$ libtree libstratimikos.so | wc -l
772
```
After:
```
$ libtree libstratimikos.so | wc -l
143
```
for
```
trilinos@13.0.1~adios2+amesos+amesos2+anasazi+aztec~basker+belos~boost~chaco~complex~cuda~cuda_rdc~debug~dtk+epetra+epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings~exodus+explicit_template_instantiation~float+fortran~gtest~hdf5~hypre+ifpack+ifpack2+intrepid~intrepid2~ipo~isorropia+kokkos~mesquite~minitensor+ml~mpi~muelu~mumps~nox~openmp~panzer~phalanx~piro~python~rocm~rocm_rdc~rol~rythmos+sacado~scorec+shards+shared~shylu~stk~stokhos+stratimikos~strumpack~suite-sparse~superlu~superlu-dist~teko~tempus+thyra+tpetra~trilinoscouplings~wrapper~x11~zoltan~zoltan2
build_type=RelWithDebInfo cxxstd=14 gotype=long_long
```

(Thanks @haampie for libtree!)