### PR TITLE
libiconv,lmod: improvements for static builds

### DIFF
--- a/var/spack/repos/builtin/packages/libiconv/package.py
+++ b/var/spack/repos/builtin/packages/libiconv/package.py
@@ -31,6 +31,7 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         args = ['--enable-extra-encodings']
 
         args += self.enable_or_disable('libs')
+        args.append('--with-pic')
 
         # A hack to patch config.guess in the libcharset sub directory
         copy('./build-aux/config.guess',

--- a/var/spack/repos/builtin/packages/lmod/package.py
+++ b/var/spack/repos/builtin/packages/lmod/package.py
@@ -45,7 +45,7 @@ class Lmod(AutotoolsPackage):
     version('6.4.1',  sha256='a260b4e42269a80b517c066ba8484658362ea095e80767a2376bbe33d9b070a5')
     version('6.3.7',  sha256='55ddb52cbdc0e2e389b3405229336df9aabfa582c874f5df2559ea264e2ee4ae')
 
-    depends_on('lua@5.1:')
+    depends_on('lua+shared@5.1:')
     depends_on('lua-luaposix', type=('build', 'run'))
     depends_on('lua-luafilesystem', type=('build', 'run'))
     depends_on('tcl', type=('build', 'link', 'run'))


### PR DESCRIPTION
- Lmod fails to build against `lua~shared` because it can't detect the posix library
- Build PIC for libiconv, see #25357