### PR TITLE
rocm-cmake: remove ldconfig variant

### DIFF
--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -8,8 +8,8 @@ from spack import *
 
 
 class RocmCmake(CMakePackage):
-    """ROCM cmake modules provides cmake modules for common build tasks
-       needed for the ROCM software stack"""
+    """rocm-cmake provides CMake modules for common build tasks
+       in the ROCm software stack"""
 
     homepage = "https://github.com/RadeonOpenCompute/rocm-cmake"
     git      = "https://github.com/RadeonOpenCompute/rocm-cmake.git"

--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -33,11 +33,5 @@ class RocmCmake(CMakePackage):
     version('3.5.0', sha256='5fc09e168879823160f5fdf4fd1ace2702d36545bf733e8005ed4ca18c3e910f', deprecated=True)
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
-    variant('ldconfig', default=True, description='ROCm ldconfig')
 
     depends_on('cmake@3:', type='build')
-
-    def cmake_args(self):
-        return [
-            self.define_from_variant('ROCM_DISABLE_LDCONFIG', 'ldconfig')
-        ]

--- a/var/spack/repos/builtin/packages/rocm-cmake/package.py
+++ b/var/spack/repos/builtin/packages/rocm-cmake/package.py
@@ -35,3 +35,4 @@ class RocmCmake(CMakePackage):
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
     depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.6:', type='build', when='@4.1.0:')


### PR DESCRIPTION
The packages built for `rocm-cmake~ldconfig` and `rocm-cmake+ldconfig` are identical, so the variant is unnecessary. I also tweaked the package description slightly and tightened up the CMake version requirements.
    
The `ROCM_DISABLE_LDCONFIG` option changes how `rocm_create_package` generates DEB and RPM packages with CPack. rocm-cmake itself uses `rocm_create_package`, however, this option is has no effect because Spack does not build the CPack packages. It is also unnecessary on rocm-cmake, because rocm-cmake does not contain any shared libraries for ldconfig to configure. The rocm-cmake package is purely composed of CMake scripts.