### PR TITLE
hepmcanalysis: Use same cxx value as root

### DIFF
--- a/var/spack/repos/builtin/packages/hepmcanalysis/package.py
+++ b/var/spack/repos/builtin/packages/hepmcanalysis/package.py
@@ -25,7 +25,7 @@ class Hepmcanalysis(MakefilePackage):
     patch('lcg.patch')
 
     def patch(self):
-        filter_file(r"TDirectory::CurrentDirectory()->",
+        filter_file(r"TDirectory::CurrentDirectory\(\)->",
                     r"TDirectory::CurrentDirectory().",
                     "src/baseAnalysis.cc")
         filter_file(r"CXXFLAGS(.*)", r"CXXFLAGS\1 -std=c++" +

--- a/var/spack/repos/builtin/packages/hepmcanalysis/package.py
+++ b/var/spack/repos/builtin/packages/hepmcanalysis/package.py
@@ -24,6 +24,11 @@ class Hepmcanalysis(MakefilePackage):
 
     patch('lcg.patch')
 
+    def patch(self):
+        filter_file("TDirectory::CurrentDirectory()->",
+                    "TDirectory::CurrentDirectory().",
+                    "src/baseAnalysis.cc")
+
     def edit(self, spec, prefix):
         filter_file(r"CXXFLAGS(.*)", r"CXXFLAGS\1 -std=c++" +
                     self.spec['root'].variants['cxxstd'].value, "config.mk")

--- a/var/spack/repos/builtin/packages/hepmcanalysis/package.py
+++ b/var/spack/repos/builtin/packages/hepmcanalysis/package.py
@@ -22,17 +22,11 @@ class Hepmcanalysis(MakefilePackage):
     depends_on('root')
     depends_on('clhep')
 
-    variant('cxxstd',
-            default='11',
-            values=('11', '14', '17'),
-            multi=False,
-            description='Use the specified C++ standard when building.')
-
     patch('lcg.patch')
 
     def edit(self, spec, prefix):
         filter_file(r"CXXFLAGS(.*)", r"CXXFLAGS\1 -std=c++" +
-                    self.spec.variants['cxxstd'].value, "config.mk")
+                    self.spec['root'].variants['cxxstd'].value, "config.mk")
 
     def setup_build_environment(self, env):
         env.set("HepMCdir", self.spec['hepmc'].prefix)

--- a/var/spack/repos/builtin/packages/hepmcanalysis/package.py
+++ b/var/spack/repos/builtin/packages/hepmcanalysis/package.py
@@ -25,8 +25,8 @@ class Hepmcanalysis(MakefilePackage):
     patch('lcg.patch')
 
     def patch(self):
-        filter_file(r"TDirectory::CurrentDirectory\(\)->",
-                    r"TDirectory::CurrentDirectory().",
+        filter_file(r"TDirectory::CurrentDirectory\(\)",
+                    r"gDirectory",
                     "src/baseAnalysis.cc")
         filter_file(r"CXXFLAGS(.*)", r"CXXFLAGS\1 -std=c++" +
                     self.spec['root'].variants['cxxstd'].value, "config.mk")

--- a/var/spack/repos/builtin/packages/hepmcanalysis/package.py
+++ b/var/spack/repos/builtin/packages/hepmcanalysis/package.py
@@ -24,13 +24,10 @@ class Hepmcanalysis(MakefilePackage):
 
     patch('lcg.patch')
 
-    @run_before('build')
     def patch(self):
-        filter_file("TDirectory::CurrentDirectory()->",
-                    "TDirectory::CurrentDirectory().",
+        filter_file(r"TDirectory::CurrentDirectory()->",
+                    r"TDirectory::CurrentDirectory().",
                     "src/baseAnalysis.cc")
-
-    def edit(self, spec, prefix):
         filter_file(r"CXXFLAGS(.*)", r"CXXFLAGS\1 -std=c++" +
                     self.spec['root'].variants['cxxstd'].value, "config.mk")
 

--- a/var/spack/repos/builtin/packages/hepmcanalysis/package.py
+++ b/var/spack/repos/builtin/packages/hepmcanalysis/package.py
@@ -24,6 +24,7 @@ class Hepmcanalysis(MakefilePackage):
 
     patch('lcg.patch')
 
+    @run_before('build')
     def patch(self):
         filter_file("TDirectory::CurrentDirectory()->",
                     "TDirectory::CurrentDirectory().",


### PR DESCRIPTION
Latest root versions use cxx17, such that cxx11 as a default in hepmcanalysis will trigger `error: 'string_view' in namespace 'std' does not name a type`.