### PR TITLE
herwigpp: Add intermediate folder in lib to LD_LIBRARY_PATH

### DIFF
--- a/var/spack/repos/builtin/packages/herwigpp/package.py
+++ b/var/spack/repos/builtin/packages/herwigpp/package.py
@@ -23,6 +23,9 @@ class Herwigpp(AutotoolsPackage):
     depends_on('fastjet')
     depends_on('thepeg@1.9.2', when='@2.7.1')
 
+    def setup_build_environment(self, env):
+        env.prepend_path('LD_LIBRARY_PATH', self.spec['thepeg'].prefix.lib.ThePEG)
+
     def configure_args(self):
         args = ['--with-gsl=' + self.spec['gsl'].prefix,
                 '--with-thepeg=' + self.spec['thepeg'].prefix,


### PR DESCRIPTION
`./Herwig++: error while loading shared libraries: libThePEG.so.18: cannot open shared object file: No such file or directory` before the fix.