### PR TITLE
omega-h: add v10.1.0 from fork

### DIFF
--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -18,7 +18,7 @@ class OmegaH(CMakePackage):
     maintainers = ['cwsmith']
     tags = ['e4s']
     version('main', branch='main')
-    version('10.1.0', commit='e88912368e101d940f006019585701a704295ab0',  git="https://github.com/SCOREC/omega_h.git")
+    version('scorec.10.1.0', commit='e88912368e101d940f006019585701a704295ab0',  git="https://github.com/SCOREC/omega_h.git")
     version('9.34.1', sha256='3a812da3b8df3e0e5d78055e91ad23333761bcd9ed9b2c8c13ee1ba3d702e46c')
     version('9.32.5', sha256='963a203e9117024cd48d829d82b8543cd9133477fdc15386113b594fdc3246d8')
     version('9.29.0', sha256='b41964b018909ffe9cea91c23a0509b259bfbcf56874fcdf6bd9f6a179938014')

--- a/var/spack/repos/builtin/packages/omega-h/package.py
+++ b/var/spack/repos/builtin/packages/omega-h/package.py
@@ -18,6 +18,7 @@ class OmegaH(CMakePackage):
     maintainers = ['cwsmith']
     tags = ['e4s']
     version('main', branch='main')
+    version('10.1.0', commit='e88912368e101d940f006019585701a704295ab0',  git="https://github.com/SCOREC/omega_h.git")
     version('9.34.1', sha256='3a812da3b8df3e0e5d78055e91ad23333761bcd9ed9b2c8c13ee1ba3d702e46c')
     version('9.32.5', sha256='963a203e9117024cd48d829d82b8543cd9133477fdc15386113b594fdc3246d8')
     version('9.29.0', sha256='b41964b018909ffe9cea91c23a0509b259bfbcf56874fcdf6bd9f6a179938014')


### PR DESCRIPTION
This PR adds Omega_h version 10.1.0 from a fork.

Is this an acceptable way to handle packages that have more than one repo or should a new package be created?  The majority of the functionality/APIs and cmake build systems are the same between the two repos.