### PR TITLE
Allow conditional possible values in variants

### DIFF
--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1423,6 +1423,37 @@ other similar operations:
             ).with_default('auto').with_non_feature_values('auto'),
         )
 
+"""""""""""""""""""""""""""
+Conditional Possible Values
+"""""""""""""""""""""""""""
+
+There are cases where a variant may take multiple values, and the list of allowed values
+expand over time. Think for instance at the C++ standard with which we might compile
+Boost, which can take one of multiple possible values with the latest standards
+only available from a certain version on.
+
+To model a similar situation we can use *conditional possible values* in the variant declaration:
+
+.. code-block:: python
+
+   variant(
+       'cxxstd', default='98',
+       values=(
+           '98', '11', '14',
+           # C++17 is not supported by Boost < 1.63.0.
+           Value('17', when='@1.63.0:'),
+           # C++20/2a is not support by Boost < 1.73.0
+           Value('2a', when='@1.73.0:')
+       ),
+       multi=False,
+       description='Use the specified C++ standard when building.',
+   )
+
+The snippet above allows ``98``, ``11`` and ``14`` as unconditional possible values for the
+``cxxstd`` variant, while ``17`` and ``2a`` are only allowed if the version is greater or
+equal to ``1.63.0`` or ``1.73.0`` respectively.
+
+
 ^^^^^^^^^^^^^^^^^^^^
 Conditional Variants
 ^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1441,9 +1441,9 @@ To model a similar situation we can use *conditional possible values* in the var
        values=(
            '98', '11', '14',
            # C++17 is not supported by Boost < 1.63.0.
-           Value('17', when='@1.63.0:'),
+           conditional('17', when='@1.63.0:'),
            # C++20/2a is not support by Boost < 1.73.0
-           Value('2a', when='@1.73.0:')
+           conditional('2a', '2b', when='@1.73.0:')
        ),
        multi=False,
        description='Use the specified C++ standard when building.',

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -1450,8 +1450,8 @@ To model a similar situation we can use *conditional possible values* in the var
    )
 
 The snippet above allows ``98``, ``11`` and ``14`` as unconditional possible values for the
-``cxxstd`` variant, while ``17`` and ``2a`` are only allowed if the version is greater or
-equal to ``1.63.0`` or ``1.73.0`` respectively.
+``cxxstd`` variant, while ``17`` requires a version greater or equal to ``1.63.0``
+and both ``2a`` and ``2b`` require a version greater or equal to ``1.73.0``.
 
 
 ^^^^^^^^^^^^^^^^^^^^

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 import six
 from six import string_types
 
-from llnl.util.compat import MutableMapping, zip_longest
+from llnl.util.compat import MutableMapping, MutableSequence, zip_longest
 
 # Ignore emacs backups when listing modules
 ignore_modules = [r'^\.#', '~$']
@@ -976,3 +976,41 @@ def enum(**kwargs):
         **kwargs: explicit dictionary of enums
     """
     return type('Enum', (object,), kwargs)
+
+
+class TypedMutableSequence(MutableSequence):
+    """Base class that behaves like a list, just with a different type.
+
+    Client code can inherit from this base class:
+
+        class Foo(TypedMutableSequence):
+            pass
+
+    and later perform checks based on types:
+
+        if isinstance(l, Foo):
+            # do something
+    """
+    def __init__(self, iterable):
+        self.data = list(iterable)
+
+    def __getitem__(self, item):
+        return self.data[item]
+
+    def __setitem__(self, key, value):
+        self.data[key] = value
+
+    def __delitem__(self, key):
+        del self.data[key]
+
+    def __len__(self):
+        return len(self.data)
+
+    def insert(self, index, item):
+        self.data.insert(index, item)
+
+    def __repr__(self):
+        return repr(self.data)
+
+    def __str__(self):
+        return str(self.data)

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -73,9 +73,9 @@ from spack.package import (
 from spack.spec import InvalidSpecDetected, Spec
 from spack.util.executable import *
 from spack.variant import (
-    Value,
     any_combination_of,
     auto_or_any_combination_of,
+    conditional,
     disjoint_sets,
 )
 from spack.version import Version, ver

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -72,5 +72,10 @@ from spack.package import (
 )
 from spack.spec import InvalidSpecDetected, Spec
 from spack.util.executable import *
-from spack.variant import any_combination_of, auto_or_any_combination_of, disjoint_sets
+from spack.variant import (
+    Value,
+    any_combination_of,
+    auto_or_any_combination_of,
+    disjoint_sets,
+)
 from spack.version import Version, ver

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -878,6 +878,13 @@ class SpackSolverSetup(object):
 
             for value in sorted(values):
                 self.gen.fact(fn.variant_possible_value(pkg.name, name, value))
+                if hasattr(value, 'when'):
+                    required = spack.spec.Spec('{0}={1}'.format(name, value))
+                    imposed = spack.spec.Spec(value.when)
+                    imposed.name = pkg.name
+                    self.condition(
+                        required_spec=required, imposed_spec=imposed, name=pkg.name
+                    )
 
             if variant.sticky:
                 self.gen.fact(fn.variant_sticky(pkg.name, name))

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1410,3 +1410,18 @@ class TestConcretize(object):
 
         # Here there is no known satisfying version - use the one on the spec.
         assert ver("2.7.21") == Spec("python@2.7.21").concretized().version
+
+    @pytest.mark.parametrize('spec_str', [
+        'conditional-values-in-variant@1.62.0 cxxstd=17',
+        'conditional-values-in-variant@1.62.0 cxxstd=2a',
+        'conditional-values-in-variant@1.72.0 cxxstd=2a',
+    ])
+    def test_conditional_values_in_variants(self, spec_str):
+        if spack.config.get('config:concretizer') == 'original':
+            pytest.skip(
+                "Original concretizer doesn't resolve concrete versions to known ones"
+            )
+
+        s = Spec(spec_str)
+        with pytest.raises((RuntimeError, spack.error.UnsatisfiableSpecError)):
+            s.concretize()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1419,9 +1419,22 @@ class TestConcretize(object):
     def test_conditional_values_in_variants(self, spec_str):
         if spack.config.get('config:concretizer') == 'original':
             pytest.skip(
-                "Original concretizer doesn't resolve concrete versions to known ones"
+                "Original concretizer doesn't resolve conditional values in variants"
             )
 
         s = Spec(spec_str)
         with pytest.raises((RuntimeError, spack.error.UnsatisfiableSpecError)):
             s.concretize()
+
+    def test_conditional_values_in_conditional_variant(self):
+        """Test that conditional variants play well with conditional possible values"""
+        if spack.config.get('config:concretizer') == 'original':
+            pytest.skip(
+                "Original concretizer doesn't resolve conditional values in variants"
+            )
+
+        s = Spec('conditional-values-in-variant@1.50.0').concretized()
+        assert 'cxxstd' not in s.variants
+
+        s = Spec('conditional-values-in-variant@1.60.0').concretized()
+        assert 'cxxstd' in s.variants

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1415,6 +1415,8 @@ class TestConcretize(object):
         'conditional-values-in-variant@1.62.0 cxxstd=17',
         'conditional-values-in-variant@1.62.0 cxxstd=2a',
         'conditional-values-in-variant@1.72.0 cxxstd=2a',
+        # Ensure disjoint set of values work too
+        'conditional-values-in-variant@1.72.0 staging=flexpath',
     ])
     def test_conditional_values_in_variants(self, spec_str):
         if spack.config.get('config:concretizer') == 'original':

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -12,6 +12,7 @@ import inspect
 import itertools
 import re
 
+import six
 from six import StringIO
 
 import llnl.util.lang as lang
@@ -850,6 +851,27 @@ def disjoint_sets(*sets):
         a properly initialized instance of DisjointSetsOfValues
     """
     return DisjointSetsOfValues(*sets).allow_empty_set().with_default('none')
+
+
+@functools.total_ordering
+class Value(object):
+    """Conditional value that might be used in variants."""
+    def __init__(self, value, when):
+        self.value = value
+        self.when = when
+
+    def __str__(self):
+        return str(self.value)
+
+    def __eq__(self, other):
+        if isinstance(other, six.string_types):
+            return self.value == other
+        return self.value == other.value
+
+    def __lt__(self, other):
+        if isinstance(other, six.string_types):
+            return self.value < other
+        return self.value < other.value
 
 
 class DuplicateVariantError(error.SpecError):

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -900,8 +900,11 @@ class _ConditionalVariantValues(lang.TypedMutableSequence):
     """A list, just with a different type"""
 
 
-def conditional(*values, when):
+def conditional(*values, **kwargs):
     """Conditional values that can be used in variant declarations."""
+    if len(kwargs) != 1 and 'when' not in kwargs:
+        raise ValueError('conditional statement expects a "when=" parameter only')
+    when = kwargs['when']
     return _ConditionalVariantValues([Value(x, when=when) for x in values])
 
 

--- a/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 class ConditionalValuesInVariant(Package):
-    """Mimic the real netlib-lapack, that may be built on top of an
-    optimized blas.
-    """
+    """Package with conditional possible values in a variant"""
     homepage = "https://dev.null"
 
     version('1.73.0')
     version('1.72.0')
     version('1.62.0')
+    version('1.60.0')
+    version('1.50.0')
 
     variant(
         'cxxstd', default='98',
@@ -22,5 +22,6 @@ class ConditionalValuesInVariant(Package):
             Value('2a', when='@1.73.0:')
         ),
         multi=False,
-        description='Use the specified C++ standard when building.'
+        description='Use the specified C++ standard when building.',
+        when='@1.60.0:'
     )

--- a/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
@@ -17,11 +17,18 @@ class ConditionalValuesInVariant(Package):
         values=(
             '98', '11', '14',
             # C++17 is not supported by Boost < 1.63.0.
-            Value('17', when='@1.63.0:'),
+            conditional('17', when='@1.63.0:'),
             # C++20/2a is not support by Boost < 1.73.0
-            Value('2a', when='@1.73.0:')
+            conditional('2a', when='@1.73.0:')
         ),
         multi=False,
         description='Use the specified C++ standard when building.',
         when='@1.60.0:'
+    )
+
+    variant(
+        'staging', values=any_combination_of(
+            conditional('flexpath', 'dataspaces', when='@1.73.0:')
+        ),
+        description='Enable dataspaces and/or flexpath staging transports'
     )

--- a/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
+++ b/var/spack/repos/builtin.mock/packages/conditional-values-in-variant/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+class ConditionalValuesInVariant(Package):
+    """Mimic the real netlib-lapack, that may be built on top of an
+    optimized blas.
+    """
+    homepage = "https://dev.null"
+
+    version('1.73.0')
+    version('1.72.0')
+    version('1.62.0')
+
+    variant(
+        'cxxstd', default='98',
+        values=(
+            '98', '11', '14',
+            # C++17 is not supported by Boost < 1.63.0.
+            Value('17', when='@1.63.0:'),
+            # C++20/2a is not support by Boost < 1.73.0
+            Value('2a', when='@1.73.0:')
+        ),
+        multi=False,
+        description='Use the specified C++ standard when building.'
+    )

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -143,9 +143,9 @@ class Boost(Package):
             values=(
                 '98', '11', '14',
                 # C++17 is not supported by Boost < 1.63.0.
-                Value('17', when='@1.63.0:'),
+                conditional('17', when='@1.63.0:'),
                 # C++20/2a is not support by Boost < 1.73.0
-                Value('2a', when='@1.73.0:')
+                conditional('2a', when='@1.73.0:')
             ),
             multi=False,
             description='Use the specified C++ standard when building.')

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -140,7 +140,13 @@ class Boost(Package):
 
     variant('cxxstd',
             default='98',
-            values=('98', '11', '14', '17', '2a'),
+            values=(
+                '98', '11', '14',
+                # C++17 is not supported by Boost < 1.63.0.
+                Value('17', when='@1.63.0:'),
+                # C++20/2a is not support by Boost < 1.73.0
+                Value('2a', when='@1.73.0:')
+            ),
             multi=False,
             description='Use the specified C++ standard when building.')
     variant('debug', default=False,
@@ -192,12 +198,6 @@ class Boost(Package):
     conflicts('+fiber', when='@:1.61')  # Fiber since 1.62.0.
     conflicts('cxxstd=98', when='+fiber')  # Fiber requires >=C++11.
     conflicts('~context', when='+fiber')  # Fiber requires Context.
-
-    # C++20/2a is not support by Boost < 1.73.0
-    conflicts('cxxstd=2a', when='@:1.72')
-
-    # C++17 is not supported by Boost<1.63.0.
-    conflicts('cxxstd=17', when='@:1.62')
 
     conflicts('+taggedlayout', when='+versionedlayout')
     conflicts('+numpy', when='~python')


### PR DESCRIPTION
Allow declaring possible values for variants with an associated condition. If the variant takes one of those values, the condition is imposed as a further constraint.

The idea of this PR is to implement part of the mechanisms needed for modeling [packages with multiple build-systems]( https://github.com/spack/seps/pull/3). After this PR the build-system directive can be implemented as:
```python
variant(
    'build-system',
    default='cmake',
    values=(
        'autotools',
        conditional('cmake', when='@X.Y:')
    ), 
    description='...',
)
```

Modifications:
- [x] Allow conditional possible values in variants
- [x] Add a unit-test for the feature
- [x] Add documentation