### PR TITLE
mmg: add vtk variant

### DIFF
--- a/var/spack/repos/builtin/packages/mmg/package.py
+++ b/var/spack/repos/builtin/packages/mmg/package.py
@@ -34,17 +34,17 @@ class Mmg(CMakePackage):
     variant('shared', default=True, description='Enables the build of shared libraries')
     variant('scotch', default=True, description='Enable SCOTCH library support')
     variant('doc', default=False, description='Build documentation')
+    variant('vtk', default=False, when='@5.5.0:', description='Enable VTK I/O support')
 
     depends_on('scotch', when='+scotch')
     depends_on('doxygen', when='+doc')
+    depends_on('vtk', when='+vtk')
 
     def cmake_args(self):
         args = []
 
-        if '+scotch' in self.spec:
-            args.append('-DUSE_SCOTCH=ON')
-        else:
-            args.append('-DUSE_SCOTCH=OFF')
+        args.append(self.define_from_variant('USE_SCOTCH', 'scotch'))
+        args.append(self.define_from_variant('USE_VTK', 'vtk'))
 
         if '+shared' in self.spec:
             args.append('-DLIBMMG3D_SHARED=ON')


### PR DESCRIPTION
mmg uses VTK for I/O since 5.5.0. (https://github.com/MmgTools/mmg/releases/tag/v5.5.0)
This is turned on by default, and it breaks builds in weird ways when VTK is detected somewhere.

This PR adds a vtk variant and its associated dependency to mmg. It's turned off by default.