### PR TITLE
environment.py: reduce verbosity of updating view message

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -518,7 +518,8 @@ class ViewDescriptor(object):
             return
 
         # construct view at new_root
-        tty.msg("Updating view at {0}".format(self.root))
+        if specs:
+            tty.msg("Updating view at {0}".format(self.root))
 
         view = self.view(new=new_root)
         fs.mkdirp(new_root)


### PR DESCRIPTION
I think it still should create an empty dir if all specs are removed, so early
exit seems a bad strategy. Just reduce verbosity.

Before:

```console
$ spack env create helloworld
==> Updating view at /home/harmen/spack/var/spack/environments/helloworld/.spack-env/view
==> Created environment 'helloworld' in /home/harmen/spack/var/spack/environments/helloworld
==> You can activate this environment with:
==>   spack env activate helloworld
```

After:

```console
$ spack env create helloworld
==> Created environment 'helloworld' in /home/harmen/spack/var/spack/environments/helloworld
==> You can activate this environment with:
==>   spack env activate helloworld
```
