### PR TITLE
dd4hep, podio: add new versions, fix tests

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -24,6 +24,7 @@ class Dd4hep(CMakePackage):
     tags = ['hep']
 
     version('master', branch='master')
+    version('1.20.1', sha256='18c18a125583c39cb808c602e052cc2379aa3a8029aa78dbb40bcc31f1deb798')
     version('1.20', sha256='cf6af0c486d5c84e8c8a8e40ea16cec54d4ed78bffcef295a0eeeaedf51cab59')
     version('1.19', sha256='d2eccf5e8402ba7dab2e1d7236e12ee4db9b1c5e4253c40a140bf35580db1d9b')
     version('1.18', sha256='1e909a42b969dfd966224fa8ab1eca5aa05136baf3c00a140f2f6d812b497152')
@@ -90,7 +91,8 @@ class Dd4hep(CMakePackage):
     depends_on('intel-tbb', when='+tbb')
     depends_on('lcio', when="+lcio")
     depends_on('edm4hep', when="+edm4hep")
-    depends_on('py-pytest', type="test")
+    depends_on('podio', when="+edm4hep")
+    depends_on('py-pytest', type=('build', 'test'))
 
     # See https://github.com/AIDASoft/DD4hep/pull/771
     conflicts('^cmake@3.16:3.17.0', when='@1.15',
@@ -181,7 +183,7 @@ class Dd4hep(CMakePackage):
 
     # instead add custom check step that runs after installation
     @run_after('install')
-    def install_check(self):
+    def build_test(self):
         with working_dir(self.build_directory):
             if self.run_tests:
                 ninja('test')

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -17,6 +17,7 @@ class Podio(CMakePackage):
     tags = ["hep", "key4hep"]
 
     version('master', branch='master')
+    version('0.14.1', sha256='361ac3f3ec6f5a4830729ab45f96c19f0f62e9415ff681f7c6cdb4ebdb796f72')
     version('0.14', sha256='47f99f1190dc71d6deb52a2b1831250515dbd5c9e0f263c3c8553ffc5b260dfb')
     version('0.13.2', sha256='645f6915ca6f34789157c0a9dc8b0e9ec901e019b96eb8a68fb39011602e92eb')
     version('0.13.1', sha256='2ae561c2a0e46c44245aa2098772374ad246c9fcb1956875c95c69c963501353')
@@ -56,6 +57,12 @@ class Podio(CMakePackage):
 
     def setup_run_environment(self, env):
         env.prepend_path('PYTHONPATH', self.prefix.python)
+        env.prepend_path('LD_LIBRARY_PATH', self.spec['podio'].libs.directories[0])
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.prepend_path('PYTHONPATH', self.prefix.python)
+        env.prepend_path('LD_LIBRARY_PATH', self.spec['podio'].libs.directories[0])
+        env.prepend_path('ROOT_INCLUDE_PATH', self.prefix.include)
 
     def url_for_version(self, version):
         """Translate version numbers to ilcsoft conventions.


### PR DESCRIPTION
Not sure why `pytest` was not available for the tests when it was only a test dependency - would be happy to keep it as such if there is a way.