### PR TITLE
python: allow versions with garbage suffix

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -271,6 +271,8 @@ class Python(AutotoolsPackage):
         # Python 2 sends to STDERR, while Python 3 sends to STDOUT
         # Output looks like:
         #   Python 3.7.7
+        # On pre-production Ubuntu, this is also possible:
+        #   Python 3.10.2+
         output = Executable(exe)('-V', output=str, error=str)
         match = re.search(r'Python\s+([0-9a-zA-Z.\-]+)', output)
         return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -272,7 +272,7 @@ class Python(AutotoolsPackage):
         # Output looks like:
         #   Python 3.7.7
         output = Executable(exe)('-V', output=str, error=str)
-        match = re.search(r'Python\s+(\S+)', output)
+        match = re.search(r'Python\s+([0-9a-zA-Z.\-]+)', output)
         return match.group(1) if match else None
 
     @classmethod

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -272,7 +272,7 @@ class Python(AutotoolsPackage):
         # Output looks like:
         #   Python 3.7.7
         output = Executable(exe)('-V', output=str, error=str)
-        match = re.search(r'Python\s+([0-9a-zA-Z.\-]+)', output)
+        match = re.search(r'Python\s+([A-Za-z0-9_.-]+)', output)
         return match.group(1) if match else None
 
     @classmethod


### PR DESCRIPTION
Ubuntu 22.04 preview python prints version as 3.10.2+, the + causes
version parsing to fail and breaks detection.