### PR TITLE
assimp: depends on pkgconfig; disable bundled dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -31,7 +31,7 @@ class Assimp(CMakePackage):
     variant('shared',  default=True,
             description='Enables the build of shared libraries')
 
-    depends_on('pkgconfig')
+    depends_on('pkgconfig', type='build')
     depends_on('zlib')
     depends_on('boost')
 

--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -38,6 +38,8 @@ class Assimp(CMakePackage):
     def cmake_args(self):
         args = [
             '-DASSIMP_HUNTER_ENABLED=OFF',
+            '-DASSIMP_BUILD_ZLIB=OFF',
+            '-DASSIMP_BUILD_MINIZIP=OFF',
             '-DASSIMP_BUILD_TESTS=OFF',
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]

--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -31,11 +31,13 @@ class Assimp(CMakePackage):
     variant('shared',  default=True,
             description='Enables the build of shared libraries')
 
+    depends_on('pkgconfig')
     depends_on('zlib')
     depends_on('boost')
 
     def cmake_args(self):
         args = [
+            '-DASSIMP_HUNTER_ENABLED=OFF',
             '-DASSIMP_BUILD_TESTS=OFF',
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]


### PR DESCRIPTION
Without pkgconfig, assimp can pick up a local minizip or zlib. This PR adds pkgconfig and makes sure no bundled dependencies are used.