### PR TITLE
assimp: remove -Werror to allow compilation on Intel oneAPI

### DIFF
--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -34,13 +34,14 @@ class Assimp(CMakePackage):
     depends_on('zlib')
     depends_on('boost')
 
+    def patch(self):
+        filter_file('-Werror', '', 'code/CMakeLists.txt')
+
     def cmake_args(self):
         args = [
             '-DASSIMP_BUILD_TESTS=OFF',
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]
-        if self.spec.satisfies('@:5.2.2 %oneapi'):
-            args.append('-DCMAKE_CXX_FLAGS=-Wno-tautological-constant-compare')
         return args
 
     def flag_handler(self, name, flags):

--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -39,6 +39,8 @@ class Assimp(CMakePackage):
             '-DASSIMP_BUILD_TESTS=OFF',
             self.define_from_variant('BUILD_SHARED_LIBS', 'shared'),
         ]
+        if self.spec.satisfies('@:5.2.2 %oneapi'):
+            args.append('-DCMAKE_CXX_FLAGS=-Wno-tautological-constant-compare')
         return args
 
     def flag_handler(self, name, flags):


### PR DESCRIPTION
On Intel oneAPI (at least 2022.0.2), tautological-constant-compare warnings cause compilation to fail. See also upstream bug report: https://github.com/assimp/assimp/issues/4450.