### PR TITLE
hdf5-vol-log:  new version 1.1

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
@@ -17,7 +17,7 @@ class Hdf5VolLog(AutotoolsPackage):
 
     version('master-1.1', branch='master')
 
-    version('1.1.0', tag='logvol.1.1.0')
+    version('1.1.0', commit='ca146fa7d320ec5c0b397669b330c78fceeabb57')
 
     depends_on('hdf5@1.13.0:')
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
@@ -13,7 +13,7 @@ class Hdf5VolLog(AutotoolsPackage):
     homepage = 'https://github.com/DataLib-ECP/vol-log-based'
     url      = 'https://github.com/DataLib-ECP/vol-log-based'
     git = 'https://github.com/DataLib-ECP/vol-log-based.git'
-    maintainers = ['hyoklee','lrknox']
+    maintainers = ['hyoklee', 'lrknox']
 
     version('master-1.1', branch='master')
 

--- a/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
@@ -13,9 +13,11 @@ class Hdf5VolLog(AutotoolsPackage):
     homepage = 'https://github.com/DataLib-ECP/vol-log-based'
     url      = 'https://github.com/DataLib-ECP/vol-log-based'
     git = 'https://github.com/DataLib-ECP/vol-log-based.git'
-    maintainers = ['hyoklee']
+    maintainers = ['hyoklee','lrknox']
 
-    version('master', commit='28b854e50c53166010d97eccdc23f7f3ef6a5b03')
+    version('master-1.1', branch='master')
+
+    version('1.1.0', tag='logvol.1.1.0')
 
     depends_on('hdf5@1.13.0:')
     depends_on('autoconf', type='build')

--- a/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-log/package.py
@@ -15,9 +15,9 @@ class Hdf5VolLog(AutotoolsPackage):
     git = 'https://github.com/DataLib-ECP/vol-log-based.git'
     maintainers = ['hyoklee']
 
-    version('master', commit='b13778efd9e0c79135a9d7352104985408078d45')
+    version('master', commit='28b854e50c53166010d97eccdc23f7f3ef6a5b03')
 
-    depends_on('hdf5@1.12.1:')
+    depends_on('hdf5@1.13.0:')
     depends_on('autoconf', type='build')
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')


### PR DESCRIPTION
Replaced version 'master' with a commit from last November with version '1.1.0' for the latest release and 'master-1.1' to build the master branch code.  "spack install hdf5-vol-log" successfully builds either version.  Only version 'master-1.1' currently passes all tests when running "spack install --test=root hdf5-vol-log@master-1.1".  There is no test output, but with --keep-stage the spack-build-03-build-out.txt file can be grepped for "# PASS:" and "# FAIL:"  with these results:
```
# PASS:  7
# PASS:  1
# PASS:  2
# PASS:  0
# PASS:  13
# PASS:  4
# FAIL:  0
# FAIL:  0
# FAIL:  0
# FAIL:  0
# FAIL:  0
# FAIL:  0
```