### PR TITLE
Kassiopeia: depend_on version failed to parse

### DIFF
--- a/var/spack/repos/builtin/packages/kassiopeia/package.py
+++ b/var/spack/repos/builtin/packages/kassiopeia/package.py
@@ -48,7 +48,7 @@ class Kassiopeia(CMakePackage):
 
     depends_on('cmake@3.13:', type='build')
     depends_on('zlib')
-    depends_on('root@6.0.0:', when='+root')
+    depends_on('root@6:', when='+root')
     depends_on('vtk@6.1:', when='+vtk')
     depends_on('mpi', when='+mpi')
     depends_on('tbb', when='+tbb')


### PR DESCRIPTION
`root@6.0.0:` looks for an actual version `6.0.0` which is not in spack. Changing to `@6:` achieves the same. Of course, somewhat redundant since no ROOT version before 6 is in spack anyway.