### PR TITLE
Remove Windows branch artifact

### DIFF
--- a/.github/workflows/setup_git.ps1
+++ b/.github/workflows/setup_git.ps1
@@ -9,8 +9,3 @@ if ($(git branch --show-current) -ne "develop")
 {
     git branch develop origin/develop
 }
-
-if ($(git branch --show-current) -ne "features/windows-support")
-{
-    git branch features/windows-support origin/features/windows-support
-}


### PR DESCRIPTION
Repairs windows branch artifact causing current CI failures when creating local checkout of develop branch.