### PR TITLE
Bugfix: inherited packages

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -288,7 +288,7 @@ class DetectablePackageMeta(object):
             # This function should not be overridden by subclasses,
             # as it is not designed for bespoke pkg detection but rather
             # on a per-platform basis
-            if hasattr(cls, 'platform_executables'):
+            if 'platform_executables' in cls.__dict__.keys():
                 raise PackageError("Packages should not override platform_executables")
             cls.platform_executables = platform_executables
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/29568

This bug was introduced by https://github.com/spack/spack/pull/27021 and breaks all instances of one Spack package inheriting from another e.g. if you create an alternate Spack package repo and do:

```
from spack.pkg.builtin.mpich import Mpich as BuiltinMpich

class Mpich(BuiltinMpich):
...
```

We were doing a check in a metaclass to ensure that Package classes weren't defining a function themselves; this check failed (erroneously) if that Package class subclassed another package class (because the check examined all superclasses and thought the definition we automatically add was an offender). This PR makes sure to only check the definitions local to the instantiated class when looking for a definition that shouldn't be present.

TODOs

- [ ] Need to figure out how to add tests that would detect these sorts of issues in the future