### PR TITLE
patch cache: fix bug finding inherited packages

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -373,6 +373,21 @@ class PackageMeta(
         return '%s.%s' % (self.namespace, self.name)
 
     @property
+    def fullnames(self):
+        """
+        Fullnames for this package and any packages from which it inherits.
+        """
+        fullnames = []
+        for cls in inspect.getmro(self):
+            namespace = getattr(cls, 'namespace', None)
+            if namespace:
+                fullnames.append('%s.%s' % (namespace, self.name))
+            if namespace == 'builtin':
+                # builtin packages cannot inherit from other repos
+                break
+        return fullnames
+
+    @property
     def name(self):
         """The name of this package.
 
@@ -870,6 +885,10 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     def fullname(self):
         """Name of this package, including namespace: namespace.name."""
         return type(self).fullname
+
+    @property
+    def fullnames(self):
+        return type(self).fullnames
 
     @property
     def name(self):

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -348,8 +348,12 @@ class PatchCache(object):
                 "Couldn't find patch for package %s with sha256: %s"
                 % (pkg.fullname, sha256))
 
-        patch_dict = sha_index.get(pkg.fullname)
-        if not patch_dict:
+        # Find patches for this class or any class it inherits from
+        for fullname in pkg.fullnames:
+            patch_dict = sha_index.get(fullname)
+            if patch_dict:
+                break
+        else:
             raise NoSuchPatchError(
                 "Couldn't find patch for package %s with sha256: %s"
                 % (pkg.fullname, sha256))


### PR DESCRIPTION
fixes #27902

Fixes a bug reported by @mplegendre offline. In a large manifest with multiple repos, inherited packages in the custom repo were failing to find patches defined in the builtin repo.

The solution is to search for the patch under every fullname associated with the package or any package it inherits from.