### PR TITLE
cuda: use stage dir instead of /tmp during install

### DIFF
--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -120,7 +120,7 @@ _versions = {
     '6.5.14': {
         'Linux-x86_64': ('f3e527f34f317314fe8fcd8c85f10560729069298c0f73105ba89225db69da48', 'https://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_linux_64.run')},
     '6.0.37': {
-        'Linux-x86_64': ('991e436c7a6c94ec67cf44204d136adfef87baa3ded270544fa211179779bc40', '//developer.download.nvidia.com/compute/cuda/6_0/rel/installers/cuda_6.0.37_linux_64.run')},
+        'Linux-x86_64': ('991e436c7a6c94ec67cf44204d136adfef87baa3ded270544fa211179779bc40', 'https://developer.download.nvidia.com/compute/cuda/6_0/rel/installers/cuda_6.0.37_linux_64.run')},
 }
 
 

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -232,11 +232,13 @@ class Cuda(Package):
             install_shell(*arguments)
 
         # CUDA 10.1+ has different cmdline options for the installer
+        mkdir(join_path(self.stage.path, 'tmp'))  # use stage dir instead of /tmp
         arguments = [
             runfile,            # the install script
             '--silent',         # disable interactive prompts
             '--override',       # override compiler version checks
             '--toolkit',        # install CUDA Toolkit
+            '--tmpdir=%s' % join_path(self.stage.path, 'tmp'),  # use stage dir as /tmp
         ]
 
         if spec.satisfies('@10.1:'):

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -232,14 +232,17 @@ class Cuda(Package):
             install_shell(*arguments)
 
         # CUDA 10.1+ has different cmdline options for the installer
-        mkdir(join_path(self.stage.path, 'tmp'))  # use stage dir instead of /tmp
         arguments = [
             runfile,            # the install script
             '--silent',         # disable interactive prompts
             '--override',       # override compiler version checks
             '--toolkit',        # install CUDA Toolkit
-            '--tmpdir=%s' % join_path(self.stage.path, 'tmp'),  # use stage dir as /tmp
         ]
+
+        if spec.satisfies('@7:'):
+            # use stage dir instead of /tmp
+            mkdir(join_path(self.stage.path, 'tmp'))
+            arguments.append('--tmpdir=%s' % join_path(self.stage.path, 'tmp'))
 
         if spec.satisfies('@10.1:'):
             arguments.append('--installpath=%s' % prefix)   # Where to install


### PR DESCRIPTION
Avoids running out of space on /tmp (happens easily when partition is small)