### PR TITLE
Allow CVS `:pserver:` pseudo-urls

### DIFF
--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -343,8 +343,9 @@ def parse_git_url(url):
 
 
 def require_url_format(url):
-    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|/)', url)
-    assert ut is not None
+    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|:pserver:|/)', url)
+    if ut is None:
+        raise ValueError("bad URL: %s" % url)
 
 
 def escape_file_url(url):


### PR DESCRIPTION
This change is necessary to handle CVS repositories. CVS predates the standardization of URLs, and uses a `:pserver:` prefix to denote remote repositories.

Also improve error handling (raise an exception instead of an assertion error).