### PR TITLE
geant4-data: add external find functionality to geant4 data packages

### DIFF
--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -45,7 +45,8 @@ class G4abla(Package):
         path = os.environ.get('G4ABLADATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4ABLA(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4ABLA(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4abla@' + version)

--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -20,6 +20,9 @@ class G4abla(Package):
     version('3.1', sha256='7698b052b58bf1b9886beacdbd6af607adc1e099fc730ab6b21cf7f090c027ed')
     version('3.0', sha256='99fd4dcc9b4949778f14ed8364088e45fa4ff3148b3ea36f9f3103241d277014')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'G4ABLA{0}'
@@ -34,3 +37,16 @@ class G4abla(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4ABLA.%s.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4ABLADATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4ABLA(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4abla@' + version)
+        s.external_path = prefix
+        return s

--- a/var/spack/repos/builtin/packages/g4abla/package.py
+++ b/var/spack/repos/builtin/packages/g4abla/package.py
@@ -40,7 +40,8 @@ class G4abla(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4ABLADATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -45,7 +45,8 @@ class G4emlow(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4LEDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -25,6 +25,9 @@ class G4emlow(Package):
     version('7.3', sha256='583aa7f34f67b09db7d566f904c54b21e95a9ac05b60e2bfb794efb569dba14e')
     version('6.50', sha256='c97be73fece5fb4f73c43e11c146b43f651c6991edd0edf8619c9452f8ab1236')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'G4EMLOW{0}'
@@ -39,3 +42,16 @@ class G4emlow(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("https://geant4-data.web.cern.ch/geant4-data/datasets/G4EMLOW.%s.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4LEDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4EMLOW(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4emlow@' + version)
+        s.external_path = prefix
+        return s

--- a/var/spack/repos/builtin/packages/g4emlow/package.py
+++ b/var/spack/repos/builtin/packages/g4emlow/package.py
@@ -50,7 +50,8 @@ class G4emlow(Package):
         path = os.environ.get('G4LEDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4EMLOW(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4EMLOW(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4emlow@' + version)

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -46,7 +46,8 @@ class G4ensdfstate(Package):
         path = os.environ.get('G4ENSDFSTATEDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4ENSDFSTATE(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4ENSDFSTATE(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4ensdfstate@' + version)

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -21,6 +21,9 @@ class G4ensdfstate(Package):
     version('2.2', sha256='dd7e27ef62070734a4a709601f5b3bada6641b111eb7069344e4f99a01d6e0a6')
     version('2.1', sha256='933e7f99b1c70f24694d12d517dfca36d82f4e95b084c15d86756ace2a2790d9')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'G4ENSDFSTATE{0}'
@@ -35,3 +38,16 @@ class G4ensdfstate(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4ENSDFSTATE.%s.tar.gz" % version
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4ENSDFSTATEDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4ENSDFSTATE(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4ensdfstate@' + version)
+        s.external_path = prefix
+        return s

--- a/var/spack/repos/builtin/packages/g4ensdfstate/package.py
+++ b/var/spack/repos/builtin/packages/g4ensdfstate/package.py
@@ -41,7 +41,8 @@ class G4ensdfstate(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4ENSDFSTATEDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -45,7 +45,8 @@ class G4incl(Package):
         path = os.environ.get('G4INCLDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4INCL(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4INCL(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4incl@' + version)

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -40,7 +40,8 @@ class G4incl(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4INCLDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4incl/package.py
+++ b/var/spack/repos/builtin/packages/g4incl/package.py
@@ -20,6 +20,9 @@ class G4incl(Package):
     # Only versions relevant to Geant4 releases built by spack are added
     version('1.0', sha256='716161821ae9f3d0565fbf3c2cf34f4e02e3e519eb419a82236eef22c2c4367d')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', "G4INCL{0}"
@@ -34,3 +37,16 @@ class G4incl(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4INCL.%s.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4INCLDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4INCL(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4incl@' + version)
+        s.external_path = prefix
+        return s

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -39,7 +39,8 @@ class G4ndl(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4NEUTRONHPDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -44,7 +44,8 @@ class G4ndl(Package):
         path = os.environ.get('G4NEUTRONHPDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4NDL(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4NDL(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4ndl@' + version)

--- a/var/spack/repos/builtin/packages/g4ndl/package.py
+++ b/var/spack/repos/builtin/packages/g4ndl/package.py
@@ -19,6 +19,9 @@ class G4ndl(Package):
     version('4.6', sha256='9d287cf2ae0fb887a2adce801ee74fb9be21b0d166dab49bcbee9408a5145408')
     version('4.5', sha256='cba928a520a788f2bc8229c7ef57f83d0934bb0c6a18c31ef05ef4865edcdf8e')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'G4NDL{0}'
@@ -33,3 +36,16 @@ class G4ndl(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4NDL.%s.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4NEUTRONHPDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4NDL(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4ndl@' + version)
+        s.external_path = prefix
+        return s

--- a/var/spack/repos/builtin/packages/g4neutronxs/package.py
+++ b/var/spack/repos/builtin/packages/g4neutronxs/package.py
@@ -21,6 +21,9 @@ class G4neutronxs(Package):
     # Dataset not used after Geant4 10.4.x
     version('1.4', sha256='57b38868d7eb060ddd65b26283402d4f161db76ed2169437c266105cca73a8fd')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'G4NEUTRONXS{0}'
@@ -35,3 +38,16 @@ class G4neutronxs(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4NEUTRONXS.%s.tar.gz" % version
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4NEUTRONXSDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4NEUTRONXS(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4neutronxs@' + version)
+        s.external_path = prefix
+        return s

--- a/var/spack/repos/builtin/packages/g4neutronxs/package.py
+++ b/var/spack/repos/builtin/packages/g4neutronxs/package.py
@@ -46,7 +46,8 @@ class G4neutronxs(Package):
         path = os.environ.get('G4NEUTRONXSDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4NEUTRONXS(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4NEUTRONXS(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4neutronxs@' + version)

--- a/var/spack/repos/builtin/packages/g4neutronxs/package.py
+++ b/var/spack/repos/builtin/packages/g4neutronxs/package.py
@@ -41,7 +41,8 @@ class G4neutronxs(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4NEUTRONXSDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -49,7 +49,8 @@ class G4particlexs(Package):
         path = os.environ.get('G4PARTICLEXSDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4PARTICLEXS(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4PARTICLEXS(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4particlexs@' + version)

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -44,7 +44,8 @@ class G4particlexs(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4PARTICLEXSDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4particlexs/package.py
+++ b/var/spack/repos/builtin/packages/g4particlexs/package.py
@@ -24,6 +24,9 @@ class G4particlexs(Package):
     version('2.1', sha256='094d103372bbf8780d63a11632397e72d1191dc5027f9adabaf6a43025520b41')
     version('1.1', sha256='100a11c9ed961152acfadcc9b583a9f649dda4e48ab314fcd4f333412ade9d62')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', "G4PARTICLEXS{0}"
@@ -38,3 +41,16 @@ class G4particlexs(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4PARTICLEXS.%s.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4PARTICLEXSDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4PARTICLEXS(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4particlexs@' + version)
+        s.external_path = prefix
+        return s

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -23,6 +23,9 @@ class G4photonevaporation(Package):
     version('5.2', sha256='83607f8d36827b2a7fca19c9c336caffbebf61a359d0ef7cee44a8bcf3fc2d1f')
     version('4.3.2', sha256='d4641a6fe1c645ab2a7ecee09c34e5ea584fb10d63d2838248bfc487d34207c7')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data',
@@ -39,3 +42,16 @@ class G4photonevaporation(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4PhotonEvaporation.%s.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4LEVELGAMMADATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/PhotonEvaporation(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4photonevaporation@' + version)
+        s.external_path = prefix
+        return s

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -45,7 +45,8 @@ class G4photonevaporation(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4LEVELGAMMADATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4photonevaporation/package.py
+++ b/var/spack/repos/builtin/packages/g4photonevaporation/package.py
@@ -50,7 +50,8 @@ class G4photonevaporation(Package):
         path = os.environ.get('G4LEVELGAMMADATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/PhotonEvaporation(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/PhotonEvaporation(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4photonevaporation@' + version)

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -44,7 +44,8 @@ class G4pii(Package):
         path = os.environ.get('G4PIIDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4PII(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4PII(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4pii@' + version)

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -19,6 +19,9 @@ class G4pii(Package):
     # Only versions relevant to Geant4 releases built by spack are added
     version('1.3', sha256='6225ad902675f4381c98c6ba25fc5a06ce87549aa979634d3d03491d6616e926')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'G4PII{0}'
@@ -33,3 +36,17 @@ class G4pii(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("https://geant4-data.web.cern.ch/geant4-data/datasets/G4PII.1.3.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4PIIDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4PII(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4pii@' + version)
+        s.external_path = prefix
+        return s
+

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -39,7 +39,8 @@ class G4pii(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4PIIDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4pii/package.py
+++ b/var/spack/repos/builtin/packages/g4pii/package.py
@@ -51,4 +51,3 @@ class G4pii(Package):
         s = Spec.from_detection('g4pii@' + version)
         s.external_path = prefix
         return s
-

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -50,7 +50,8 @@ class G4radioactivedecay(Package):
         path = os.environ.get('G4RADIOACTIVEDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/RadioactiveDecay(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/RadioactiveDecay(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4radioactivedecay@' + version)

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -57,4 +57,3 @@ class G4radioactivedecay(Package):
         s = Spec.from_detection('g4radioactivedecay@' + version)
         s.external_path = prefix
         return s
-

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -23,6 +23,9 @@ class G4radioactivedecay(Package):
     version('5.2', sha256='99c038d89d70281316be15c3c98a66c5d0ca01ef575127b6a094063003e2af5d')
     version('5.1.1', sha256='f7a9a0cc998f0d946359f2cb18d30dff1eabb7f3c578891111fc3641833870ae')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data',
@@ -39,3 +42,17 @@ class G4radioactivedecay(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4RadioactiveDecay.%s.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4RADIOACTIVEDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/RadioactiveDecay(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4radioactivedecay@' + version)
+        s.external_path = prefix
+        return s
+

--- a/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
+++ b/var/spack/repos/builtin/packages/g4radioactivedecay/package.py
@@ -45,7 +45,8 @@ class G4radioactivedecay(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4RADIOACTIVEDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -48,7 +48,8 @@ class G4realsurface(Package):
         path = os.environ.get('G4REALSURFACEDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/RealSurface(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/RealSurface(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4realsurface@' + version)

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -22,6 +22,9 @@ class G4realsurface(Package):
     version('2.1', sha256='2a287adbda1c0292571edeae2082a65b7f7bd6cf2bf088432d1d6f889426dcf3')
     version('1.0', sha256='3e2d2506600d2780ed903f1f2681962e208039329347c58ba1916740679020b1')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'RealSurface{0}'
@@ -37,3 +40,17 @@ class G4realsurface(Package):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/{0}RealSurface.{1}.tar.gz".format(
             "G4" if version > Version('1.0') else "", version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4REALSURFACEDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/RealSurface(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4realsurface@' + version)
+        s.external_path = prefix
+        return s
+

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -55,4 +55,3 @@ class G4realsurface(Package):
         s = Spec.from_detection('g4realsurface@' + version)
         s.external_path = prefix
         return s
-

--- a/var/spack/repos/builtin/packages/g4realsurface/package.py
+++ b/var/spack/repos/builtin/packages/g4realsurface/package.py
@@ -43,7 +43,8 @@ class G4realsurface(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4REALSURFACEDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -45,7 +45,8 @@ class G4saiddata(Package):
         path = os.environ.get('G4SAIDXSDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4SAIDDATA(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4SAIDDATA(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4saiddata@' + version)

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -20,6 +20,9 @@ class G4saiddata(Package):
     version('2.0', sha256='1d26a8e79baa71e44d5759b9f55a67e8b7ede31751316a9e9037d80090c72e91')
     version('1.1', sha256='a38cd9a83db62311922850fe609ecd250d36adf264a88e88c82ba82b7da0ed7f')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', 'G4SAIDDATA{0}'
@@ -34,3 +37,17 @@ class G4saiddata(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return "http://geant4-data.web.cern.ch/geant4-data/datasets/G4SAIDDATA.%s.tar.gz" % version
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4SAIDXSDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4SAIDDATA(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4saiddata@' + version)
+        s.external_path = prefix
+        return s
+

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -40,7 +40,8 @@ class G4saiddata(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4SAIDXSDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4saiddata/package.py
+++ b/var/spack/repos/builtin/packages/g4saiddata/package.py
@@ -52,4 +52,3 @@ class G4saiddata(Package):
         s = Spec.from_detection('g4saiddata@' + version)
         s.external_path = prefix
         return s
-

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -53,4 +53,3 @@ class G4tendl(Package):
         s = Spec.from_detection('g4tendl@' + version)
         s.external_path = prefix
         return s
-

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -46,7 +46,8 @@ class G4tendl(Package):
         path = os.environ.get('G4TENDLDATA', None)
         if not path:
             return
-        match = re.match('^(?P<prefix>.*?)/share/data/G4TENDL(?P<version>.*?)$', path)
+        pattern = '^(?P<prefix>.*?)/share/data/G4TENDL(?P<version>.*?)$'
+        match = re.match(pattern, path)
         prefix = match.group('prefix')
         version = match.group('version')
         s = Spec.from_detection('g4tendl@' + version)

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -41,7 +41,8 @@ class G4tendl(Package):
 
     @classmethod
     def determine_spec_details(cls, prefix, exes_in_prefix):
-        import os, re
+        import os
+        import re
         path = os.environ.get('G4TENDLDATA', None)
         if not path:
             return

--- a/var/spack/repos/builtin/packages/g4tendl/package.py
+++ b/var/spack/repos/builtin/packages/g4tendl/package.py
@@ -21,6 +21,9 @@ class G4tendl(Package):
     version('1.3.2', sha256='3b2987c6e3bee74197e3bd39e25e1cc756bb866c26d21a70f647959fc7afb849')
     version('1.3', sha256='52ad77515033a5d6f995c699809b464725a0e62099b5e55bf07c8bdd02cd3bce')
 
+    # use geant4-config for version info
+    executables = [r'^geant4-config$']
+
     def install(self, spec, prefix):
         mkdirp(join_path(prefix.share, 'data'))
         install_path = join_path(prefix.share, 'data', "G4TENDL{0}"
@@ -35,3 +38,17 @@ class G4tendl(Package):
     def url_for_version(self, version):
         """Handle version string."""
         return ("http://geant4-data.web.cern.ch/geant4-data/datasets/G4TENDL.%s.tar.gz" % version)
+
+    @classmethod
+    def determine_spec_details(cls, prefix, exes_in_prefix):
+        import os, re
+        path = os.environ.get('G4TENDLDATA', None)
+        if not path:
+            return
+        match = re.match('^(?P<prefix>.*?)/share/data/G4TENDL(?P<version>.*?)$', path)
+        prefix = match.group('prefix')
+        version = match.group('version')
+        s = Spec.from_detection('g4tendl@' + version)
+        s.external_path = prefix
+        return s
+


### PR DESCRIPTION
This adds `spack external find` functionality to geant4 data packages, inspired by `lhapdfsets`

An `executables = [r'^geant4-config$']` is necessary, it seems, for all packages to show up in the `spack external list`.

There's a lot of duplication in these package recipes, so I started playing around with a virtual base package Geant4DataPackage that might lead to more easily maintainable code, but didn't manage to make it work yet.

@vvolkl @drbenmorgan 