### PR TITLE
Enable GCS urls as valid

### DIFF
--- a/lib/spack/spack/test/cmd/mirror.py
+++ b/lib/spack/spack/test/cmd/mirror.py
@@ -210,6 +210,13 @@ def test_mirror_crud(tmp_scope, capsys):
         output = mirror('list', '--scope', tmp_scope)
         assert 'No mirrors configured' in output
 
+        # Test GCS Mirror
+        mirror('add', '--scope', tmp_scope,
+               'mirror', 'gs://spack-test')
+
+        output = mirror('remove', '--scope', tmp_scope, 'mirror')
+        assert 'Removed mirror' in output
+
 
 def test_mirror_nonexisting(tmp_scope):
     with pytest.raises(SpackCommandError):

--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -59,6 +59,11 @@ def test_url_parse():
     assert(parsed.netloc == 'path')
     assert(parsed.path == '/to/resource')
 
+    parsed = url_util.parse('gs://path/to/resource')
+    assert(parsed.scheme == 'gs')
+    assert(parsed.netloc == 'path')
+    assert(parsed.path == '/to/resource')
+
     spack_root = spack.paths.spack_root
     parsed = url_util.parse('file://$spack')
     assert(parsed.scheme == 'file')

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -343,7 +343,7 @@ def parse_git_url(url):
 
 
 def require_url_format(url):
-    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|/)', url)
+    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|/)', url)
     assert ut is not None
 
 


### PR DESCRIPTION
This PR enables GCS urls as valid.

Additionally, it adds some tests to ensure GCS urls continue to be valid in the future.