### PR TITLE
libefence: add package for the Electric Fence library from B. Perens

### DIFF
--- a/var/spack/repos/builtin/packages/libefence/package.py
+++ b/var/spack/repos/builtin/packages/libefence/package.py
@@ -24,4 +24,5 @@ class Libefence(MakefilePackage):
         make()
 
     def install(self, spec, prefix):
-        make('install', 'LIB_INSTALL_DIR=' + prefix.lib, 'MAN_INSTALL_DIR=' + prefix.man.man3, parallel=False)
+        make('install', 'LIB_INSTALL_DIR=' + prefix.lib,
+             'MAN_INSTALL_DIR=' + prefix.man.man3, parallel=False)

--- a/var/spack/repos/builtin/packages/libefence/package.py
+++ b/var/spack/repos/builtin/packages/libefence/package.py
@@ -1,0 +1,27 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Libefence(MakefilePackage):
+    """Electric Fence (or eFence) is a memory debugger written by Bruce Perens.
+    It consists of a library which programmers can link into their code to override
+    the C standard library memory management functions. eFence triggers a program
+    crash when the memory error occurs, so a debugger can be used to inspect the
+    code that caused the error."""
+
+    homepage = "https://en.wikipedia.org/wiki/Electric_Fence"
+    url      = "https://deb.debian.org/debian/pool/main/e/electric-fence/electric-fence_2.2.6.tar.gz"
+
+    maintainers = ['cessenat']
+
+    version('2.2.6', sha256='a949e0dedb06cbcd444566cce1457223f2c41abd3513f21663f30f19ccc48e24')
+
+    def build(self, spec, prefix):
+        make()
+
+    def install(self, spec, prefix):
+        make('install', 'LIB_INSTALL_DIR=' + prefix.lib, 'MAN_INSTALL_DIR=' + prefix.man.man3, parallel=False)

--- a/var/spack/repos/builtin/packages/libefence/package.py
+++ b/var/spack/repos/builtin/packages/libefence/package.py
@@ -13,7 +13,7 @@ class Libefence(MakefilePackage):
     crash when the memory error occurs, so a debugger can be used to inspect the
     code that caused the error."""
 
-    homepage = "https://en.wikipedia.org/wiki/Electric_Fence"
+    homepage = "https://packages.debian.org/unstable/electric-fence"
     url      = "https://deb.debian.org/debian/pool/main/e/electric-fence/electric-fence_2.2.6.tar.gz"
 
     maintainers = ['cessenat']


### PR DESCRIPTION
I'm not sure this package satisfies the requirements for spack witb respect to:
- I was unable to find a homepage, so I use the wikipedia one,
- I was unable to find a git repo.
Nevertheless, I do appreciate this lib, that is provided with Ubuntu 20 for instance.
One very easily finds memory errors. OK valgrind find mem errots too, but with many (to my opinion) false positive.