### PR TITLE
py-tensorboard-data-server: install from wheel

### DIFF
--- a/var/spack/repos/builtin/packages/py-tensorboard-data-server/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard-data-server/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import glob
-
 from spack import *
 
 
@@ -12,34 +10,9 @@ class PyTensorboardDataServer(PythonPackage):
     """Fast data loading for TensorBoard"""
 
     homepage = "https://github.com/tensorflow/tensorboard/tree/master/tensorboard/data/server"
-    git      = "https://github.com/tensorflow/tensorboard"
+    url      = "https://pypi.io/packages/py3/t/tensorboard-data-server/tensorboard_data_server-0.6.1-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/tensorboard-data-server/"
 
-    version('0.6.1', commit='6acf0be88b5727e546dd64a8b9b12d790601d561')
+    version('0.6.1', sha256='809fe9887682d35c1f7d1f54f0f40f98bb1f771b14265b453ca051e2ce58fca7', expand=False)
 
     depends_on('python@3.6:', type=('build', 'run'))
-    depends_on('py-setuptools', type='build')
-    depends_on('rust', type='build')
-
-    def setup_build_environment(self, env):
-        env.set('CARGO_HOME', self.stage.source_path)
-
-    def install(self, spec, prefix):
-        with working_dir(join_path('tensorboard', 'data', 'server')):
-            cargo = which('cargo')
-            cargo('build', '--release')
-
-        with working_dir(join_path('tensorboard', 'data', 'server',
-                                   'pip_package')):
-            python('build.py',
-                   '--out-dir={0}'.format(self.stage.source_path),
-                   '--server-binary={0}'.format(join_path(self.stage.source_path,
-                                                          'tensorboard',
-                                                          'data',
-                                                          'server',
-                                                          'target',
-                                                          'release',
-                                                          'rustboard')))
-
-        wheel = glob.glob('*.whl')[0]
-        args = std_pip_args + ['--prefix=' + prefix, wheel]
-        pip(*args)


### PR DESCRIPTION
I'm unable to build `py-tensorboard-data-server` from source on my system, see #29477. This PR switches the package to install directly from the PyPI wheel. This is inline with what we already do for `py-tensorboard-plugin-wit`.

P.S. If anyone knows how to fix my problem in #29477 I'm happy to do that instead.

@aweits @glennpj 