### PR TITLE
ncbi-rmblastn: add missing dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
+++ b/var/spack/repos/builtin/packages/ncbi-rmblastn/package.py
@@ -35,6 +35,8 @@ class NcbiRmblastn(AutotoolsPackage):
         when='@2.9.0'
     )
     depends_on('cpio', type='build')
+    depends_on('boost')
+    depends_on('lzo')
 
     configure_directory = 'c++'
 
@@ -48,5 +50,7 @@ class NcbiRmblastn(AutotoolsPackage):
             "--without-debug",
             "--without-krb5",
             "--without-openssl",
-            "--with-projects=scripts/projects/rmblastn/project.lst"]
+            "--without-libuv",
+            "--with-projects=scripts/projects/rmblastn/project.lst",
+        ]
         return args


### PR DESCRIPTION
missing dependencies
- boost
- lzo

Also, turn off libuv. This does not build properly with libuv so it is
not a dependency. However, configure will look for libuv on the system
and try to use it if found, thus breaking the build.