### PR TITLE
py-pyvcf: constrain py-setuptools to 0.57

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyvcf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyvcf/package.py
@@ -15,7 +15,7 @@ class PyPyvcf(PythonPackage):
     version('0.6.8', sha256='e9d872513d179d229ab61da47a33f42726e9613784d1cb2bac3f8e2642f6f9d9')
     version('0.6.0', sha256='d9ec3bbedb64fa35c2648a9c41fdefaedd3912ff597a436e073d27aeccf5de7c')
 
-    depends_on('py-setuptools', type='build')
+    depends_on('py-setuptools@:57', type='build')
     depends_on('py-argparse', when='^python@:2.6,3.0:3.1', type=('build', 'run'))
     depends_on('py-counter', when='^python@:2.6', type=('build', 'run'))
     depends_on('py-ordereddict', when='^python@:2.6', type=('build', 'run'))


### PR DESCRIPTION
This package can not use setuptools newer than 0.57 due to needing
features removed in later versions of setuptools.