### PR TITLE
py-torchvision: adjust jpeg dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -88,7 +88,7 @@ class PyTorchvision(PythonPackage):
     depends_on('pil@5.3:8.2,8.4:', when='@0.10: backend=pil', type=('build', 'run'))
     depends_on('py-accimage', when='backend=accimage', type=('build', 'run'))
     depends_on('libpng@1.6.0:', when='backend=png')
-    depends_on('jpeg', when='backend=jpeg')
+    depends_on('jpeg')
 
     # Many of the datasets require additional dependencies to use.
     # These can be installed after the fact.


### PR DESCRIPTION
The jpeg dependency is needed for all of the backends.