### PR TITLE
Tetgen: add new versions 1.5.1 and 1.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/tetgen/package.py
+++ b/var/spack/repos/builtin/packages/tetgen/package.py
@@ -18,12 +18,14 @@ class Tetgen(Package):
 
     homepage = "https://wias-berlin.de/software/tetgen/"
 
+    version('1.6.0', sha256='87b5e61ebd3a471fc4f2cdd7124c2b11dd6639f4feb1f941a5d2f5110d05ce39', url='http://www.tetgen.org/1.5/src/tetgen1.6.0.tar.gz')
+    version('1.5.1', sha256='e46a4434a3e7c00044c8f4f167e18b6f4a85be7d22838c8f948ce8cc8c01b850', url='http://www.tetgen.org/1.5/src/tetgen1.5.1.tar.gz', preferred=True)
     version('1.5.0', sha256='4d114861d5ef2063afd06ef38885ec46822e90e7b4ea38c864f76493451f9cf3', url='http://www.tetgen.org/1.5/src/tetgen1.5.0.tar.gz')
     version('1.4.3', sha256='952711bb06b7f64fd855eb24c33f08e3faf40bdd54764de10bbe5ed5b0dce034', url='http://www.tetgen.org/files/tetgen1.4.3.tar.gz')
 
     variant('pic', default=True, description='Builds the library in pic mode.')
     variant('debug', default=False, description='Builds the library in debug mode.')
-    variant('except', default=False, description='Replaces asserts with exceptions for better C++ compatibility.')
+    variant('except', default=False, description='Replaces asserts with exceptions for better C++ compatibility.', when='@:1.5.0')
 
     patch('tetgen-1.5.0-free.patch', when='@1.5.0')
 


### PR DESCRIPTION
Version 1.5.1 and 1.6.0 were released in 2018 and 2020, respectively, I think it's time to add them now.

Note that the `except` variant is only applicable to versions up to 1.5.0 since the newer versions already removed the use of `assert`.