### PR TITLE
Single argument invocation

### DIFF
--- a/bin/spack_pwsh.ps1
+++ b/bin/spack_pwsh.ps1
@@ -37,8 +37,8 @@ if (!$null -eq $py_path)
 
 if (!$null -eq $py_exe)
 {
-    Invoke-Expression "$py_exe" "$Env:SPACK_ROOT\bin\haspywin.py"
-    Invoke-Expression "$py_exe" "$Env:SPACK_ROOT\bin\spack external find python" | Out-Null
+    Invoke-Expression "$py_exe $Env:SPACK_ROOT\bin\haspywin.py"
+    Invoke-Expression "$py_exe $Env:SPACK_ROOT\bin\spack external find python" | Out-Null
 }
 
 $Env:Path = "$Env:SPACK_ROOT\bin;$Env:Path"
@@ -54,6 +54,6 @@ $command = 'function global:prompt
     $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf
     "[spack] PS $pth>"
 }'
-$bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
-$encoded_command = [Convert]::ToBase64String($bytes)
+$bytesc = [System.Text.Encoding]::Unicode.GetBytes($command)
+$encoded_command = [Convert]::ToBase64String($bytesc)
 powershell.exe -NoLogo -encodedCommand $encoded_command -NoExit


### PR DESCRIPTION
Fixup bug with PWSH shell setup script support. This PR removes errors displayed before dropping into the Spack shell in Windows, which allows for proper env setup on PWSH.