### PR TITLE
e4s mini mac stack: add bzip2

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -17,6 +17,7 @@ spack:
 
   definitions:
   - easy_specs:
+    - bzip2
     - zlib
 
   - arch:


### PR DESCRIPTION
Expanding the E4S Mini Mac stack ever so slightly: adding `bzip2`

@scottwittenburg 