### PR TITLE
dakota: run acceptance tests

### DIFF
--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -69,6 +69,6 @@ class Dakota(CMakePackage):
             )
 
         if self.run_tests:
-            args += ['-DCMAKE_CTEST_ARGUMENTS=-L;Accept']
+            args += ["-DCMAKE_CTEST_ARGUMENTS=-L;Accept"]
 
         return args

--- a/var/spack/repos/builtin/packages/dakota/package.py
+++ b/var/spack/repos/builtin/packages/dakota/package.py
@@ -68,4 +68,7 @@ class Dakota(CMakePackage):
                 ]
             )
 
+        if self.run_tests:
+            args += ['-DCMAKE_CTEST_ARGUMENTS=-L;Accept']
+
         return args


### PR DESCRIPTION
When testing installation with `--run-test=root`, run only the acceptance tests as documented by the dakota [installation](https://dakota.sandia.gov/content/configure-compile-and-install-dakota) and [testing](https://dakota.sandia.gov/content/test-built-dakota) docs