### PR TITLE
binutils: add auto_rpath variant for ld

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/0001-Copy-the-needed-libraries-directory-paths-as-rpaths.patch
+++ b/var/spack/repos/builtin/packages/binutils/0001-Copy-the-needed-libraries-directory-paths-as-rpaths.patch
@@ -1,0 +1,121 @@
+From 3f1a2dff9557c937a08eabaf34d5ff44de74cc61 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Thu, 17 Mar 2022 16:59:59 +0100
+Subject: [PATCH] Copy the needed libraries directory paths as rpaths
+
+---
+ ld/ldelf.c  | 57 ++++++++++++++++++++++++++++++++++++++++++++++++++---
+ ld/ldfile.c |  1 +
+ ld/ldfile.h |  2 ++
+ 3 files changed, 57 insertions(+), 3 deletions(-)
+
+diff --git a/ld/ldelf.c b/ld/ldelf.c
+index 4094640b3f7..346476b21fb 100644
+--- a/ld/ldelf.c
++++ b/ld/ldelf.c
+@@ -1614,7 +1614,7 @@ void
+ ldelf_before_allocation (char *audit, char *depaudit,
+ 			 const char *default_interpreter_name)
+ {
+-  const char *rpath;
++  char *rpath;
+   asection *sinterp;
+   bfd *abfd;
+   struct bfd_link_hash_entry *ehdr_start = NULL;
+@@ -1669,7 +1669,58 @@ ldelf_before_allocation (char *audit, char *depaudit,
+      by dynamic linking.  */
+   rpath = command_line.rpath;
+   if (rpath == NULL)
+-    rpath = (const char *) getenv ("LD_RUN_PATH");
++    rpath = getenv ("LD_RUN_PATH");
++
++  search_dirs_type * search;
++
++  // Loop over every directory in search order, then figure out if it
++  // has been used to locate any library that's being linked.
++  // If so, append it to the rpaths.
++  for (search = search_head; search != NULL; search = search->next) {
++    size_t searchdir_len = strlen(search->name);
++    if (search->consumed) {
++      for (abfd = link_info.input_bfds; abfd; abfd = abfd->link.next) {
++        if (bfd_get_format (abfd) == bfd_object && ((abfd->flags) & DYNAMIC) != 0 && bfd_get_flavour (abfd) == bfd_target_elf_flavour && (elf_dyn_lib_class (abfd) & (DYN_AS_NEEDED | DYN_NO_NEEDED)) == 0 && elf_dt_name (abfd) != NULL) {
++          // check we're using the same path.
++          char * libdir = strrchr(abfd->filename, '/');
++          if (libdir == NULL) continue;
++          size_t libdir_len = libdir - abfd->filename;
++          if (searchdir_len != libdir_len) continue;
++          if (strncmp(search->name, abfd->filename, libdir_len) != 0) continue;
++
++          // prepend cwd if relative path
++          char extra_rpath[PATH_MAX];
++          size_t extra_rpath_len = searchdir_len;
++          if (search->name[0] != '/') {
++            if (getcwd(extra_rpath, sizeof(extra_rpath)) == NULL) continue;
++            size_t cwd_len = strlen(extra_rpath);
++
++            // Can't fit the concatenated path; ignore it.
++            extra_rpath_len = cwd_len + 1 + searchdir_len;
++            if (extra_rpath_len >= PATH_MAX) continue;
++            memcpy(extra_rpath + cwd_len + 1, search->name, searchdir_len + 1);
++          } else {
++            memcpy(extra_rpath, search->name, searchdir_len + 1);
++          }
++
++          if (rpath == NULL) {
++            rpath = (char *) xmalloc (extra_rpath_len + 1);
++            memcpy(rpath, extra_rpath, extra_rpath_len + 1);
++          } else {
++            size_t rpath_len = strlen (rpath);
++            char * buf = (char *) xmalloc (rpath_len + extra_rpath_len + 2);
++            memcpy(buf, rpath, rpath_len);
++            buf[rpath_len] = config.rpath_separator;
++            memcpy(buf + rpath_len + 1, extra_rpath, extra_rpath_len + 1);
++            free (rpath);
++            rpath = buf;
++          }
++
++          break;
++        }
++      }
++    }
++  }
+ 
+   for (abfd = link_info.input_bfds; abfd; abfd = abfd->link.next)
+     if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
+@@ -1833,7 +1884,7 @@ ldelf_open_dynamic_archive (const char *arch, search_dirs_type *search,
+       free (string);
+       return false;
+     }
+-
++  search->consumed = true;
+   entry->filename = string;
+ 
+   /* We have found a dynamic object to include in the link.  The ELF
+diff --git a/ld/ldfile.c b/ld/ldfile.c
+index 731ae5f7aed..eb6725adf79 100644
+--- a/ld/ldfile.c
++++ b/ld/ldfile.c
+@@ -106,6 +106,7 @@ ldfile_add_library_path (const char *name, bool cmdline)
+   new_dirs = (search_dirs_type *) xmalloc (sizeof (search_dirs_type));
+   new_dirs->next = NULL;
+   new_dirs->cmdline = cmdline;
++  new_dirs->consumed = 0;
+   *search_tail_ptr = new_dirs;
+   search_tail_ptr = &new_dirs->next;
+ 
+diff --git a/ld/ldfile.h b/ld/ldfile.h
+index 097fdd09346..b9738fbe901 100644
+--- a/ld/ldfile.h
++++ b/ld/ldfile.h
+@@ -36,6 +36,8 @@ typedef struct search_dirs {
+   const char *name;
+   /* TRUE if this is from the command line.  */
+   bool cmdline;
++  /* TRUE if this search path is used */
++  bool consumed;
+ } search_dirs_type;
+ 
+ extern search_dirs_type *search_head;
+-- 
+2.25.1
+

--- a/var/spack/repos/builtin/packages/binutils/0001-Copy-the-needed-libraries-directory-paths-as-rpaths.patch
+++ b/var/spack/repos/builtin/packages/binutils/0001-Copy-the-needed-libraries-directory-paths-as-rpaths.patch
@@ -1,16 +1,16 @@
-From 3f1a2dff9557c937a08eabaf34d5ff44de74cc61 Mon Sep 17 00:00:00 2001
+From f3fccbd3add01519dd38d5ed9ec0c88d0f86a9ce Mon Sep 17 00:00:00 2001
 From: Harmen Stoppels <harmenstoppels@gmail.com>
 Date: Thu, 17 Mar 2022 16:59:59 +0100
 Subject: [PATCH] Copy the needed libraries directory paths as rpaths
 
 ---
- ld/ldelf.c  | 57 ++++++++++++++++++++++++++++++++++++++++++++++++++---
+ ld/ldelf.c  | 58 ++++++++++++++++++++++++++++++++++++++++++++++++++---
  ld/ldfile.c |  1 +
  ld/ldfile.h |  2 ++
- 3 files changed, 57 insertions(+), 3 deletions(-)
+ 3 files changed, 58 insertions(+), 3 deletions(-)
 
 diff --git a/ld/ldelf.c b/ld/ldelf.c
-index 4094640b3f7..346476b21fb 100644
+index 4094640b3f7..aa8530ee8c2 100644
 --- a/ld/ldelf.c
 +++ b/ld/ldelf.c
 @@ -1614,7 +1614,7 @@ void
@@ -22,7 +22,7 @@ index 4094640b3f7..346476b21fb 100644
    asection *sinterp;
    bfd *abfd;
    struct bfd_link_hash_entry *ehdr_start = NULL;
-@@ -1669,7 +1669,58 @@ ldelf_before_allocation (char *audit, char *depaudit,
+@@ -1669,7 +1669,59 @@ ldelf_before_allocation (char *audit, char *depaudit,
       by dynamic linking.  */
    rpath = command_line.rpath;
    if (rpath == NULL)
@@ -56,6 +56,7 @@ index 4094640b3f7..346476b21fb 100644
 +            // Can't fit the concatenated path; ignore it.
 +            extra_rpath_len = cwd_len + 1 + searchdir_len;
 +            if (extra_rpath_len >= PATH_MAX) continue;
++            extra_rpath[cwd_len] = '/';
 +            memcpy(extra_rpath + cwd_len + 1, search->name, searchdir_len + 1);
 +          } else {
 +            memcpy(extra_rpath, search->name, searchdir_len + 1);
@@ -82,7 +83,7 @@ index 4094640b3f7..346476b21fb 100644
  
    for (abfd = link_info.input_bfds; abfd; abfd = abfd->link.next)
      if (bfd_get_flavour (abfd) == bfd_target_elf_flavour)
-@@ -1833,7 +1884,7 @@ ldelf_open_dynamic_archive (const char *arch, search_dirs_type *search,
+@@ -1833,7 +1885,7 @@ ldelf_open_dynamic_archive (const char *arch, search_dirs_type *search,
        free (string);
        return false;
      }

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -50,9 +50,13 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     variant('interwork', default=False, description='Enable interwork.')
     variant('libs', default='shared,static', values=('shared', 'static'),
             multi=True, description='Build shared libs, static libs or both')
+    variant('auto_rpath', default=False, description='Enable a patch that automatically'
+                                                     ' adds rpaths for directories of'
+                                                     ' needed libraries.')
 
     patch('cr16.patch', when='@:2.29.1')
     patch('update_symbol-2.26.patch', when='@2.26')
+    patch('0001-Copy-the-needed-libraries-directory-paths-as-rpaths.patch', when='+auto_rpath')
 
     # 2.36 is missing some dependencies, this patch allows a parallel build.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=27482

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -694,6 +694,10 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                      self.spec.format('{name}{@version}')))
             return
 
+        # ld automatically adds rpaths already
+        if self.spec.satisifes('+binutils ^binutils+auto_rpath'):
+            return
+
         gcc = self.spec['gcc'].command
         lines = gcc('-dumpspecs', output=str).splitlines(True)
         specs_file = join_path(self.spec_dir, 'specs')


### PR DESCRIPTION
An attempt to improve Spack's heuristic of rpath'ing `<prefix>/lib(64)?`, by
patching the GNU `ld` linker to register directories of libraries added to
`DT_NEEDED` as rpaths, in the linker's search order.

For example, `gcc main.c -L. -lf` would automatically `$PWD` as an rpath to
`a.out`.

How to use this: probably easiest to create an environment view:

```
spack:
  specs:
  - gcc +binutils~bootstrap ^binutils+auto_rpath
  view:
    default:
      root: /path/to/view
      link_type: symlink
      link: run
```

Run `export PATH="/path/to/view/bin:$PATH"`. `spack compiler find`. Then the bit where spack adds rpaths for dependencies can be removed:

```diff
diff --git a/lib/spack/spack/build_environment.py b/lib/spack/spack/build_environment.py
index 5f9e1d8100..b7460510bc 100644
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -431,8 +431,6 @@ def update_compiler_args_for_dep(dep):
                     dep_link_dirs.append(default_lib_prefix)
 
             _prepend_all(link_dirs, dep_link_dirs)
-            if dep in rpath_deps:
-                _prepend_all(rpath_dirs, dep_link_dirs)
 
             try:
                 _prepend_all(include_dirs, query.headers.directories)
```
