### PR TITLE
libunwind: mark v1.5.0 as preferred

### DIFF
--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -19,7 +19,7 @@ class Libunwind(AutotoolsPackage):
     version('1.6-stable', branch='v1.6-stable')
     version('1.6.2', sha256='4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976')
     version('1.5-stable', branch='v1.5-stable')
-    version('1.5.0', sha256='90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017')
+    version('1.5.0', sha256='90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017', preferred=True)
     version('1.4.0', sha256='df59c931bd4d7ebfd83ee481c943edf015138089b8e50abed8d9c57ba9338435')
     version('1.3.1', sha256='43997a3939b6ccdf2f669b50fdb8a4d3205374728c2923ddc2354c65260214f8')
     version('1.2.1', sha256='3f3ecb90e28cbe53fba7a4a27ccce7aad188d3210bb1964a923a731a27a75acb')


### PR DESCRIPTION
Commit 26ff44388f52531f875bae25a98766b59ed3eb3d made the Gitlab pipeline failing on `develop` (while it was not failing in the original PR) due to errors in the fetcher.

This change preserves the new versions, but will give some time for use to sync our tarball mirror for better reliability (thanks @mwkrentel for the suggestion).