### PR TITLE
distcc: add 3.3.5 for gcc@10

### DIFF
--- a/var/spack/repos/builtin/packages/distcc/package.py
+++ b/var/spack/repos/builtin/packages/distcc/package.py
@@ -13,6 +13,7 @@ class Distcc(AutotoolsPackage):
     homepage = "https://github.com/distcc/distcc"
     url      = "https://github.com/distcc/distcc/archive/v3.3.3.tar.gz"
 
+    version('3.3.5', sha256='13a4b3ce49dfc853a3de550f6ccac583413946b3a2fa778ddf503a9edc8059b0')
     version('3.3.3', sha256='b7f37d314704fbaf006d747514ff6e4d0d722102ef7d2aea132f97cf170f5169')
 
     depends_on('popt')


### PR DESCRIPTION
distcc 3.3.3 won't bulid with gcc@10.  This is fixed in https://github.com/distcc/distcc/commit/377969cc762569f4a5ec409a1e7ad6a7be3e51b3