### PR TITLE
Gcc add missing dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -113,6 +113,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     # https://gcc.gnu.org/install/prerequisites.html
     depends_on('gmp@4.3.2:')
+    depends_on('gawk@3.1.5:') # mawk is not sufficient for go support
     # GCC 7.3 does not compile with newer releases on some platforms, see
     #   https://github.com/spack/spack/issues/6902#issuecomment-433030376
     depends_on('mpfr@2.4.2:3.1.6', when='@:9.9')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -114,6 +114,13 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     # https://gcc.gnu.org/install/prerequisites.html
     depends_on('gmp@4.3.2:')
     depends_on('gawk@3.1.5:') # mawk is not sufficient for go support
+    depends_on('texinfo@4.7:', type='build')
+    # dependencies required for git versions
+    depends_on('m4@1.4.6:', type='build')
+    depends_on('automake@1.15.1:', type='build')
+    depends_on('autoconf@2.69:', type='build')
+
+
     # GCC 7.3 does not compile with newer releases on some platforms, see
     #   https://github.com/spack/spack/issues/6902#issuecomment-433030376
     depends_on('mpfr@2.4.2:3.1.6', when='@:9.9')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -117,9 +117,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     depends_on('gawk@3.1.5:')
     depends_on('texinfo@4.7:', type='build')
     # dependencies required for git versions
-    depends_on('m4@1.4.6:', type='build')
-    depends_on('automake@1.15.1:', type='build')
-    depends_on('autoconf@2.69:', type='build')
+    depends_on('m4@1.4.6:', when='@master', type='build')
+    depends_on('automake@1.15.1:', when='@master', type='build')
+    depends_on('autoconf@2.69:', when='@master', type='build')
 
     # GCC 7.3 does not compile with newer releases on some platforms, see
     #   https://github.com/spack/spack/issues/6902#issuecomment-433030376

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -116,6 +116,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     # mawk is not sufficient for go support
     depends_on('gawk@3.1.5:')
     depends_on('texinfo@4.7:', type='build')
+    depends_on('libtool', type='build')
     # dependencies required for git versions
     depends_on('m4@1.4.6:', type='build')
     depends_on('automake@1.15.1:', type='build')

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -113,13 +113,13 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
 
     # https://gcc.gnu.org/install/prerequisites.html
     depends_on('gmp@4.3.2:')
-    depends_on('gawk@3.1.5:') # mawk is not sufficient for go support
+    # mawk is not sufficient for go support
+    depends_on('gawk@3.1.5:')
     depends_on('texinfo@4.7:', type='build')
     # dependencies required for git versions
     depends_on('m4@1.4.6:', type='build')
     depends_on('automake@1.15.1:', type='build')
     depends_on('autoconf@2.69:', type='build')
-
 
     # GCC 7.3 does not compile with newer releases on some platforms, see
     #   https://github.com/spack/spack/issues/6902#issuecomment-433030376

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -114,7 +114,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     # https://gcc.gnu.org/install/prerequisites.html
     depends_on('gmp@4.3.2:')
     # mawk is not sufficient for go support
-    depends_on('gawk@3.1.5:')
+    depends_on('gawk@3.1.5:', type='build')
     depends_on('texinfo@4.7:', type='build')
     # dependencies required for git versions
     depends_on('m4@1.4.6:', when='@master', type='build')


### PR DESCRIPTION
Building gcc with golang support requires gnu awk extensions, so the default mawk on some systems causes problems, lack of texinfo caused problems in minimal containers as well.  The autotools are here to better support building from master or another commit version.