### PR TITLE
Allow to download git over ssh

### DIFF
--- a/lib/spack/spack/test/util/util_url.py
+++ b/lib/spack/spack/test/util/util_url.py
@@ -64,6 +64,11 @@ def test_url_parse():
     assert(parsed.netloc == 'path')
     assert(parsed.path == '/to/resource')
 
+    parsed = url_util.parse('git@bitbucket.org:name/repo.git')
+    assert(parsed.scheme == 'git')
+    assert(parsed.netloc == 'bitbucket.org:name')
+    assert(parsed.path == '/repo.git')
+
     spack_root = spack.paths.spack_root
     parsed = url_util.parse('file://$spack')
     assert(parsed.scheme == 'file')

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -343,7 +343,7 @@ def parse_git_url(url):
 
 
 def require_url_format(url):
-    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|git://|/)', url)
+    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|git://|git@|/)', url)
     if not ut:
         raise ValueError('Invalid url format from url: %s' % url)
 


### PR DESCRIPTION
This commit allows to set:

    git = "git@bitbucket.org:name/repo.git"

As is done in several builtin packages as well as very useful for
internal proprietary packages that can only be downloaded over ssh from
a private github/bitbucket/gitlab repository.

Without this commit, the following fails:

    $ spack install talass
    [...]
      File "/.../spack/lib/spack/spack/fetch_strategy.py", line 883, in mirror_id
        repo_path = url_util.parse(self.url).path
      File "/.../spack/lib/spack/spack/util/url.py", line 79, in parse
        require_url_format(url)
      File "/.../spack/lib/spack/spack/util/url.py", line 347, in require_url_format
        assert ut is not None
    AssertionError

But with this commit it works:

    $ spack install talass
    [...]
    Cloning into 'talass'...
    remote: Enumerating objects: 27704, done.
    remote: Counting objects: 100% (253/253), done.
    ...