### PR TITLE
veccore: drop useless variants and switch to new repository location

### DIFF
--- a/var/spack/repos/builtin/packages/veccore/package.py
+++ b/var/spack/repos/builtin/packages/veccore/package.py
@@ -16,9 +16,7 @@ class Veccore(CMakePackage, CudaPackage):
     maintainers = ['drbenmorgan', 'sethrj']
 
     version('master', branch='master')
-    # Note: 0.8.0 tag is currently unofficial but it is needed explicitly for
-    # VecGeom 1.1.18
-    version('0.8.0', commit='6038e4732394413b0661fede171c77e75ed9bd71')
+    version('0.8.0', sha256='0ee532445ee1345a4776542459d5b99226ec63a10509de2cc5629f78c6412520')
     version('0.7.0', sha256='8aa97e19c455382f1a3dae07ffa5e49f2982f09e75b25a3f98d7b94cd43d6001')
     version('0.6.0', sha256='e7ff874ba2a8201624795cbe11c84634863e4ac7da691a936772d4202ef54413')
     version('0.5.2', sha256='0cfaa830b9d10fb9df4ced5208a742623da08520fea5949461fe81637a27db15')
@@ -33,6 +31,10 @@ class Veccore(CMakePackage, CudaPackage):
             description='Use the specified C++ standard when building.')
     conflicts('cxxstd=14', when='@:0.5')
     conflicts('cxxstd=17', when='@:0.5')
+
+    patch('https://gitlab.cern.ch/VecGeom/VecCore/-/commit/54423f5423d55407d00d6c29ba15d17351ac1b39.diff',
+          sha256='3bf8a04d3626c45d8580a86b27d0db79a8277081df9014d5ccfae3cb683e5e66',
+          when='@:0.8.0 cxxstd=17')
 
     def cmake_args(self):
         define = CMakePackage.define

--- a/var/spack/repos/builtin/packages/veccore/package.py
+++ b/var/spack/repos/builtin/packages/veccore/package.py
@@ -6,41 +6,27 @@
 from spack import *
 
 
-class Veccore(CMakePackage, CudaPackage):
-    """SIMD Vectorization Library for VecGeom and GeantV"""
+class Veccore(CMakePackage):
+    """SIMD Vectorization Library for VecGeom and GeantV.
+
+    VecCore is a header-only (interface) library so no cmake arguments are
+    necessary.
+    """
 
     homepage = "https://gitlab.cern.ch/VecGeom/VecCore"
-    url = "https://gitlab.cern.ch/VecGeom/VecCore/-/archive/v0.6.0/VecCore-v0.6.0.tar.gz"
-    git = "https://gitlab.cern.ch/VecGeom/VecCore.git"
+    url = "https://github.com/root-project/veccore/archive/refs/tags/v0.8.0.tar.gz"
+    git = "https://github.com/root-project/veccore.git"
 
     maintainers = ['drbenmorgan', 'sethrj']
 
     version('master', branch='master')
-    version('0.8.0', sha256='0ee532445ee1345a4776542459d5b99226ec63a10509de2cc5629f78c6412520')
-    version('0.7.0', sha256='8aa97e19c455382f1a3dae07ffa5e49f2982f09e75b25a3f98d7b94cd43d6001')
-    version('0.6.0', sha256='e7ff874ba2a8201624795cbe11c84634863e4ac7da691a936772d4202ef54413')
-    version('0.5.2', sha256='0cfaa830b9d10fb9df4ced5208a742623da08520fea5949461fe81637a27db15')
-    version('0.5.1', sha256='5ef3a8d8692d8f82641aae76b58405b8b3a1539a8f21b23d66a5df8327eeafc4')
-    version('0.5.0', sha256='aba3e0217c0cd829290c9fe63f1db865838aa25312ae0a09effdcb186f7771be')
-    version('0.4.2', sha256='4a3bb944bce63dc1dc9757ba53624b822e1aff5ed088d542039a20227ed2b715')
-
-    variant('cxxstd',
-            default='11',
-            values=('11', '14', '17'),
-            multi=False,
-            description='Use the specified C++ standard when building.')
-    conflicts('cxxstd=14', when='@:0.5')
-    conflicts('cxxstd=17', when='@:0.5')
-
-    patch('https://gitlab.cern.ch/VecGeom/VecCore/-/commit/54423f5423d55407d00d6c29ba15d17351ac1b39.diff',
-          sha256='3bf8a04d3626c45d8580a86b27d0db79a8277081df9014d5ccfae3cb683e5e66',
-          when='@:0.8.0 cxxstd=17')
-
-    def cmake_args(self):
-        define = CMakePackage.define
-        return [
-            define('VC', False),
-            define('UMESIMD', False),
-            self.define_from_variant('CMAKE_CXX_STANDARD', 'cxxstd'),
-            self.define_from_variant('CUDA'),
-        ]
+    version('0.8.0', sha256='2f8e49f2b609bf15a776026fbec899b3d5d4ba30f033d4fdac4b07a5220a4fd3')
+    version('0.7.0', sha256='61d9fc4be815c5c98088c2796763d3ed82ba4bad5a69b7892c1c2e7e1e53d311')
+    version('0.6.0', sha256='db404d745906efec2a76175995e847af9174df5a8da1e5ccdb241c773d7c8df9')
+    version('0.5.2', sha256='6c8740342bfa1d9c6ef55a19f57b95674a94e5f9ea156e9b329635718b0b4049')
+    version('0.5.1', sha256='20f4ab8f599b9d12becc3e27e8dbb0f4ec0aa2de958053eb550020a9c95a6d62')
+    version('0.5.0', sha256='5b52205c1213574fa43d6362b60b0e16239035cf64106f8841d7beb7e32bdd03')
+    version('0.4.2', sha256='79f418e466c211d0a5ff1d9127a82d84bceefe5321878cd37e77f50bc91f4cc2')
+    version('0.4.1', sha256='59ffe668c061acde89afb33749f4eb8bab35dd5f6e51f632758794c1a745aabf')
+    version('0.4.0', sha256='0a38b958c92647c30b5709d17edaf39d241b92b988f1040c0fbe24932b42927e')
+    version('0.3.2', sha256='d72b03df00f5e94b2d07f78ab3af6d9d956c19e9a1fae07267b48f6fc8d7713f')

--- a/var/spack/repos/builtin/packages/vecgeom/package.py
+++ b/var/spack/repos/builtin/packages/vecgeom/package.py
@@ -51,10 +51,10 @@ class Vecgeom(CMakePackage, CudaPackage):
     variant('shared', default=True,
             description='Build shared libraries')
 
-    depends_on('veccore@0.8.0', type=('build', 'link'), when='@1.1.18:')
-    depends_on('veccore@0.5.2:', type=('build', 'link'), when='@1.1.0:')
-    depends_on('veccore@0.4.2', type=('build', 'link'), when='@:1.0')
-    depends_on('veccore+cuda', type=('build', 'link'), when='+cuda')
+    depends_on('veccore')
+    depends_on('veccore@0.8.0', when='@1.1.18:')
+    depends_on('veccore@0.5.2:', when='@1.1.0:')
+    depends_on('veccore@0.4.2', when='@:1.0')
 
     conflicts('+cuda', when='@:1.1.5')
 
@@ -70,7 +70,6 @@ class Vecgeom(CMakePackage, CudaPackage):
     for std in _cxxstd_values:
         depends_on('geant4 cxxstd=' + std, when='+geant4 cxxstd=' + std)
         depends_on('root cxxstd=' + std, when='+root cxxstd=' + std)
-        depends_on('veccore cxxstd=' + std, when='cxxstd=' + std)
         depends_on('xerces-c cxxstd=' + std, when='+gdml cxxstd=' + std)
 
     def cmake_args(self):


### PR DESCRIPTION
VecCore has changed its home from gitlab.cern to github/root. Furthermore, since VecCore is a header-only library there's no difference in the installed code based on the previous variants.

See https://gitlab.cern.ch/VecGeom/VecCore/-/merge_requests/1 for further discussion.