### PR TITLE
py-cffi: add compiler flags to fix build with clang

### DIFF
--- a/var/spack/repos/builtin/packages/py-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cffi/package.py
@@ -30,12 +30,12 @@ class PyCffi(PythonPackage):
 
     def flag_handler(self, name, flags):
         if self.spec.satisfies('%clang@13:'):
-          if name in ['cflags', 'cxxflags', 'cppflags']:
-              flags.append('-Wno-error=ignored-optimization-argument')
-              return (flags, None, None)
-          if name == 'ldflags':
-              flags.append('-flto')
-              return (flags, None, None)
+            if name in ['cflags', 'cxxflags', 'cppflags']:
+                flags.append('-Wno-error=ignored-optimization-argument')
+                return (flags, None, None)
+            if name == 'ldflags':
+                flags.append('-flto')
+                return (flags, None, None)
         return (flags, None, None)
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-cffi/package.py
+++ b/var/spack/repos/builtin/packages/py-cffi/package.py
@@ -28,6 +28,16 @@ class PyCffi(PythonPackage):
     depends_on('py-pycparser', type=('build', 'run'))
     depends_on('libffi')
 
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('%clang@13:'):
+          if name in ['cflags', 'cxxflags', 'cppflags']:
+              flags.append('-Wno-error=ignored-optimization-argument')
+              return (flags, None, None)
+          if name == 'ldflags':
+              flags.append('-flto')
+              return (flags, None, None)
+        return (flags, None, None)
+
     def setup_build_environment(self, env):
         # This sets the compiler (and flags) that distutils will use
         # to create the final shared library.  It will use the


### PR DESCRIPTION
For %clang@13.0.1, this avoids the
```
clang-13: warning: optimization flag '-ffat-lto-objects' is not supported [-Wignored-optimization-argument]
```
warning being turned into an error, and fixes this link error:
```
build/temp.linux-x86_64-3.10/c/_cffi_backend.o: file not recognized: file format not recognized
```