### PR TITLE
Updated kallisto package to version 0.48.0

### DIFF
--- a/var/spack/repos/builtin/packages/kallisto/package.py
+++ b/var/spack/repos/builtin/packages/kallisto/package.py
@@ -13,6 +13,7 @@ class Kallisto(CMakePackage):
     homepage = "https://pachterlab.github.io/kallisto"
     url      = "https://github.com/pachterlab/kallisto/archive/v0.43.1.tar.gz"
 
+    version('0.48.0', sha256='1797ac4d1f0771e3f1f25dd7972bded735fcb43f853cf52184d3d9353a6269b0')
     version('0.46.2', sha256='c447ca8ddc40fcbd7d877d7c868bc8b72807aa8823a8a8d659e19bdd515baaf2')
     version('0.43.1', sha256='7baef1b3b67bcf81dc7c604db2ef30f5520b48d532bf28ec26331cb60ce69400')
 


### PR DESCRIPTION
Updated to the most recent version of kallisto (0.48.0) which, additionally, solved a build problem.