### PR TITLE
Use the appropriate function to remove files in the stage directory

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -27,7 +27,7 @@ from llnl.util.symlink import symlink
 from spack.util.executable import Executable
 from spack.util.path import path_to_os_path, system_path_filter
 
-is_windows  = _platform == 'win32'
+is_windows = _platform == 'win32'
 
 if not is_windows:
     import grp
@@ -1194,24 +1194,23 @@ def remove_linked_tree(path):
     # as git leaves readonly files that Python handles
     # poorly on Windows. Remove readonly status and try again
     def onerror(func, path, exe_info):
-        statinfo = os.stat(path)
-        initial_mode = ((statinfo.st_mode & stat.S_IRWXU) |
-                        (statinfo.st_mode & stat.S_IRWXG) |
-                        (statinfo.st_mode & stat.S_IRWXO))
-        os.chmod(path, initial_mode | stat.S_IWUSR)
+        os.chmod(path, stat.S_IWUSR)
         try:
             func(path)
         except Exception as e:
             tty.warn(e)
-            os.chmod(path, initial_mode)
             pass
+
+    kwargs = {'ignore_errors': True}
+    if is_windows:
+        kwargs = {'onerror': onerror}
 
     if os.path.exists(path):
         if os.path.islink(path):
-            shutil.rmtree(os.path.realpath(path), onerror=onerror)
+            shutil.rmtree(os.path.realpath(path), **kwargs)
             os.unlink(path)
         else:
-            shutil.rmtree(path, onerror=onerror)
+            shutil.rmtree(path, **kwargs)
 
 
 @contextmanager

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1194,11 +1194,13 @@ def remove_linked_tree(path):
     # as git leaves readonly files that Python handles
     # poorly on Windows. Remove readonly status and try again
     def onerror(func, path, exe_info):
-        os.chmod(path, stat.S_IWUSR)
+        statinfo = os.stat(path)
+        os.chmod(path, statinfo.st_mode | stat.S_IWUSR)
         try:
             func(path)
         except Exception as e:
             tty.warn(e)
+            os.chmod(path, statinfo.st_mode)
             pass
 
     if os.path.exists(path):

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -1195,12 +1195,15 @@ def remove_linked_tree(path):
     # poorly on Windows. Remove readonly status and try again
     def onerror(func, path, exe_info):
         statinfo = os.stat(path)
-        os.chmod(path, statinfo.st_mode | stat.S_IWUSR)
+        initial_mode = ((statinfo.st_mode & stat.S_IRWXU) |
+                        (statinfo.st_mode & stat.S_IRWXG) |
+                        (statinfo.st_mode & stat.S_IRWXO))
+        os.chmod(path, initial_mode | stat.S_IWUSR)
         try:
             func(path)
         except Exception as e:
             tty.warn(e)
-            os.chmod(path, statinfo.st_mode)
+            os.chmod(path, initial_mode)
             pass
 
     if os.path.exists(path):

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -823,7 +823,10 @@ def purge():
         for stage_dir in os.listdir(root):
             if stage_dir.startswith(stage_prefix) or stage_dir == '.lock':
                 stage_path = os.path.join(root, stage_dir)
-                remove_linked_tree(stage_path)
+                if os.path.isdir(stage_path):
+                    remove_linked_tree(stage_path)
+                else:
+                    os.remove(stage_path)
 
 
 def get_checksums_for_versions(url_dict, name, **kwargs):

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -866,3 +866,17 @@ def test_visit_directory_tree_follow_none(noncyclical_dir_structure):
         j('b'),
     ]
     assert not visitor.symlinked_dirs_after
+
+
+@pytest.mark.regression('29687')
+@pytest.mark.parametrize('initial_mode', [
+    stat.S_IRUSR | stat.S_IXUSR,
+    stat.S_IWGRP
+])
+def test_remove_linked_tree_doesnt_change_file_permission(tmpdir, initial_mode):
+    file_instead_of_dir = tmpdir.ensure('foo')
+    file_instead_of_dir.chmod(initial_mode)
+    initial_stat = os.stat(str(file_instead_of_dir))
+    fs.remove_linked_tree(str(file_instead_of_dir))
+    final_stat = os.stat(str(file_instead_of_dir))
+    assert final_stat == initial_stat

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -875,6 +875,9 @@ def test_visit_directory_tree_follow_none(noncyclical_dir_structure):
 ])
 @pytest.mark.skipif(sys.platform == 'win32', reason='Windows might change permissions')
 def test_remove_linked_tree_doesnt_change_file_permission(tmpdir, initial_mode):
+    # Here we test that a failed call to remove_linked_tree, due to passing a file
+    # as an argument instead of a directory, doesn't leave the file with different
+    # permissions as a side effect of trying to handle the error.
     file_instead_of_dir = tmpdir.ensure('foo')
     file_instead_of_dir.chmod(initial_mode)
     initial_stat = os.stat(str(file_instead_of_dir))

--- a/lib/spack/spack/test/llnl/util/filesystem.py
+++ b/lib/spack/spack/test/llnl/util/filesystem.py
@@ -873,6 +873,7 @@ def test_visit_directory_tree_follow_none(noncyclical_dir_structure):
     stat.S_IRUSR | stat.S_IXUSR,
     stat.S_IWGRP
 ])
+@pytest.mark.skipif(sys.platform == 'win32', reason='Windows might change permissions')
 def test_remove_linked_tree_doesnt_change_file_permission(tmpdir, initial_mode):
     file_instead_of_dir = tmpdir.ensure('foo')
     file_instead_of_dir.chmod(initial_mode)


### PR DESCRIPTION
fixes #29687 

We shouldn't be using "remove_linked_tree" to remove the lock file, since that function expects to receive a directory path as an argument.

Modifications:
- [x] Fix the handling of the lockfile in the stage directory
- [x] Ensure that "remove_linked_tree" doesn't silently change the permission of files when it fails
- [x] Add unit tests to avoid regressions