### PR TITLE
Allow read-only access to file cache (when needed)

### DIFF
--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -5,6 +5,7 @@
 
 """Test Spack's FileCache."""
 import os
+import sys
 
 import pytest
 
@@ -59,6 +60,8 @@ def test_write_and_remove_cache_file(file_cache):
     assert not os.path.exists(file_cache._lock_path('test.yaml'))
 
 
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="Not supported on Windows (yet)")
 def test_cache_init_entry_fails(file_cache):
     """Test init_entry failures."""
     relpath = fs.join_path('test-dir', 'read-only-file.txt')

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -8,7 +8,9 @@ import os
 
 import pytest
 
-from spack.util.file_cache import FileCache
+import llnl.util.filesystem as fs
+
+from spack.util.file_cache import CacheError, FileCache
 
 
 @pytest.fixture()
@@ -55,3 +57,37 @@ def test_write_and_remove_cache_file(file_cache):
     # After removal both the file and the lock file should not exist
     assert not os.path.exists(file_cache.cache_path('test.yaml'))
     assert not os.path.exists(file_cache._lock_path('test.yaml'))
+
+
+def test_cache_init_entry_fails(file_cache):
+    """Test init_entry failures."""
+    relpath = fs.join_path('test-dir', 'read-only-file.txt')
+    cachefile = file_cache.cache_path(relpath)
+    fs.touchp(cachefile)
+
+    # Ensure directory causes exception
+    with pytest.raises(CacheError, match='not a file'):
+        file_cache.init_entry(os.path.dirname(relpath))
+
+    # Ensure non-readable file causes exception
+    os.chmod(cachefile, 0o200)
+    with pytest.raises(CacheError, match='Cannot access cache file'):
+        file_cache.init_entry(relpath)
+
+    # Ensure read-only parent causes exception
+    relpath = fs.join_path('test-dir', 'another-file.txxt')
+    cachefile = file_cache.cache_path(relpath)
+    os.chmod(os.path.dirname(cachefile), 0o400)
+    with pytest.raises(CacheError, match='Cannot access cache dir'):
+        file_cache.init_entry(relpath)
+
+
+def test_cache_write_readonly_cache_fails(file_cache):
+    """Test writing a read-only cached file."""
+    filename = 'read-only-file.txt'
+    path = file_cache.cache_path(filename)
+    fs.touch(path)
+    os.chmod(path, 0o400)
+
+    with pytest.raises(CacheError, match='Insufficient permissions to write'):
+        file_cache.write_transaction(filename)


### PR DESCRIPTION
Addresses one of the issues raised in #29688 

There are some use cases where we only need read-access to the file cache (e.g., stand-alone tests).  Requiring RW prevents running these tests on read-only file systems (e.g., at facilities).

This PR only requires an existing cache file be readable and ensures such a cache file is writeable prior to `write_transaction()` creating a context manager.  It also adds unit tests for several failure conditions that weren't previously covered.

TODO:

- [x] Add unit tests as needed 

