### PR TITLE
libxpm: Add setup_dependent_build_environment and fix when gettext dose not provide libintl

### DIFF
--- a/var/spack/repos/builtin/packages/libxpm/package.py
+++ b/var/spack/repos/builtin/packages/libxpm/package.py
@@ -27,9 +27,16 @@ class Libxpm(AutotoolsPackage, XorgPackage):
     depends_on('util-macros', type='build')
 
     def setup_build_environment(self, env):
+        # if gettext is installed with--without-included-gettext,
+        # libintl is not provided.
+        if 'intl' in self.spec['gettext'].libs.names:
+            env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
+                self.spec['gettext'].prefix.lib))
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
         # If libxpm is installed as an external package, gettext won't
         # be available in the spec. See
         # https://github.com/spack/spack/issues/9149 for details.
-        if 'gettext' in self.spec:
+        if 'gettext' in self.spec and 'intl' in self.spec['gettext'].libs.names:
             env.append_flags('LDFLAGS', '-L{0} -lintl'.format(
                 self.spec['gettext'].prefix.lib))


### PR DESCRIPTION
- Add setup_dependent_build_environment
- When gettext is external package and  the gettext configured with `--without-included-gettext` option, gettext dose not provide libintl. So if gettext dose not provide libintl, LDFLAGS environment variable is not set.