### PR TITLE
add_files_to_view: flip incorrect default

### DIFF
--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -216,7 +216,7 @@ class PythonPackage(PackageBase):
 
         return conflicts
 
-    def add_files_to_view(self, view, merge_map, skip_if_exists=False):
+    def add_files_to_view(self, view, merge_map, skip_if_exists=True):
         bin_dir = self.spec.prefix.bin
         python_prefix = self.extendee_spec.prefix
         python_is_external = self.extendee_spec.external

--- a/lib/spack/spack/filesystem_view.py
+++ b/lib/spack/spack/filesystem_view.py
@@ -810,7 +810,7 @@ class SimpleFilesystemView(FilesystemView):
                 full_src = os.path.join(src_root, src_rel)
                 full_dst = os.path.join(self._root, dst_rel)
                 merge_map[full_src] = full_dst
-            spec.package.add_files_to_view(self, merge_map, skip_if_exists=True)
+            spec.package.add_files_to_view(self, merge_map, skip_if_exists=False)
 
         # Finally create the metadata dirs.
         self.link_metadata(specs)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -479,7 +479,7 @@ class PackageViewMixin(object):
         """
         return set(dst for dst in merge_map.values() if os.path.lexists(dst))
 
-    def add_files_to_view(self, view, merge_map, skip_if_exists=False):
+    def add_files_to_view(self, view, merge_map, skip_if_exists=True):
         """Given a map of package files to destination paths in the view, add
         the files to the view. By default this adds all files. Alternative
         implementations may skip some files, for example if other packages

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -1365,7 +1365,7 @@ config.update(get_paths())
                                             self.spec
                                         ))
 
-    def add_files_to_view(self, view, merge_map, skip_if_exists=False):
+    def add_files_to_view(self, view, merge_map, skip_if_exists=True):
         bin_dir = self.spec.prefix.bin if sys.platform != 'win32'\
             else self.spec.prefix
         for src, dst in merge_map.items():


### PR DESCRIPTION
The default in environment views is to skip the `lexists(...)` check, since the
`[Source|Destination]MergeVisitor` already drop link actions on conflicts.

During review the name of this keyword arg flipped meaning, but the values did not...
