### PR TITLE
Add completion of locals to spack python

### DIFF
--- a/lib/spack/spack/cmd/python.py
+++ b/lib/spack/spack/cmd/python.py
@@ -118,6 +118,10 @@ def python_interpreter(args):
     else:
         # Provides readline support, allowing user to use arrow keys
         console.push('import readline')
+        # Provide tabcompletion
+        console.push('from rlcompleter import Completer')
+        console.push('readline.set_completer(Completer(locals()).complete)')
+        console.push('readline.parse_and_bind("tab: complete")')
 
         console.interact("Spack version %s\nPython %s, %s %s"
                          % (spack.spack_version, platform.python_version(),


### PR DESCRIPTION
I spent the morning debugging in the `spack python` shell without tabcompletion until I noticed, that I can make it use ipython. Nevertheless, the regular python REPL does support tabcompletion out of the box nowadays and it would be great if the spack shell would too.