### PR TITLE
Windows Support: Fixup Perl build

### DIFF
--- a/lib/spack/llnl/util/symlink.py
+++ b/lib/spack/llnl/util/symlink.py
@@ -11,9 +11,10 @@ from sys import platform as _platform
 
 from llnl.util import lang
 
-from spack.util.executable import Executable
-
 is_windows = _platform == 'win32'
+
+if is_windows:
+    from win32file import CreateHardLink
 
 
 def symlink(real_path, link_path):
@@ -53,16 +54,7 @@ def _win32_junction(path, link):
         path = os.path.join(parent, path)
         path = os.path.abspath(path)
 
-    command = "mklink"
-    default_args = [link, path]
-    if os.path.isdir(path):
-        # try using a junction
-        default_args.insert(0, '/J')
-    else:
-        # try using a hard link
-        default_args.insert(0, '/H')
-
-    Executable(command)(*default_args)
+    CreateHardLink(link, path)
 
 
 @lang.memoized

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -15,6 +15,7 @@
 import os
 import platform
 import re
+import sys
 from contextlib import contextmanager
 
 from llnl.util.lang import match_predicate
@@ -23,7 +24,7 @@ from llnl.util.symlink import symlink
 from spack import *
 from spack.operating_systems.mac_os import macos_version
 
-is_windows = str(spack.platforms.host()) == 'windows'
+is_windows = sys.platform == 'win32'
 
 
 class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
@@ -330,6 +331,8 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         if perl_lib_dirs:
             perl_lib_path = ':'.join(perl_lib_dirs)
             env.prepend_path('PERL5LIB', perl_lib_path)
+        if is_windows:
+            env.append_path('PATH', self.prefix.bin)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self._setup_dependent_env(env, dependent_spec,
@@ -361,6 +364,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
 
     def setup_build_environment(self, env):
         if is_windows:
+            env.append_path('PATH', self.prefix.bin)
             return
 
         spec = self.spec


### PR DESCRIPTION
Windows on Perl requires the script pl2bat.bat and Perl to be available to the installer via the PATH. The build and dependent environments of Perl on Windows have the install prefix bin added to the PATH. 

Additionally transition Windows symlink support to use the Win32file API.