### PR TITLE
py-numpy: build in parallel

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -345,6 +345,11 @@ class PyNumpy(PythonPackage):
 
         env.set('NPY_LAPACK_ORDER', lapack)
 
+        env.set('NPY_NUM_BUILD_JOBS', make_jobs)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.set('NPY_NUM_BUILD_JOBS', make_jobs)
+
     @run_after('install')
     @on_package_attributes(run_tests=True)
     def install_test(self):


### PR DESCRIPTION
@rgommers can you see if this improves build times? May have to explicitly convert `make_jobs` to a string, I can never remember. This can be controlled from the command line using `spack install -j#`, so `-j1` for serial or `-j16` for parallel. By default, Spack uses the number of cores on the system (capped at 16 I think). 