### PR TITLE
Add patch to fix compilation of Boost with compilers not in path

### DIFF
--- a/var/spack/repos/builtin/packages/boost/bootstrap-compiler.patch
+++ b/var/spack/repos/builtin/packages/boost/bootstrap-compiler.patch
@@ -1,0 +1,13 @@
+diff --git a/bootstrap.sh b/bootstrap.sh
+index 654801e21f..3331483aa5 100755
+--- a/bootstrap.sh
++++ b/bootstrap.sh
+@@ -226,7 +226,7 @@ rm -f config.log
+ if test "x$BJAM" = x; then
+   $ECHO "Building B2 engine.."
+   pwd=`pwd`
+-  CXX= CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" ${TOOLSET}
++  CXXFLAGS= "$my_dir/tools/build/src/engine/build.sh" ${TOOLSET} --cxx="$CXX"
+   if [ $? -ne 0 ]; then
+       echo
+       echo "Failed to build B2 build engine"

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -301,6 +301,9 @@ class Boost(Package):
     # and https://github.com/spack/spack/pull/21408
     patch("bootstrap-toolset.patch", when="@1.75")
 
+    # Fix compiler used for building bjam during bootstrap
+    patch("bootstrap-compiler.patch", when="@1.76:")
+
     # Allow building context asm sources with GCC on Darwin
     # See https://github.com/spack/spack/pull/24889
     # and https://github.com/boostorg/context/issues/177


### PR DESCRIPTION
This is an attempt to fix compilation of Boost in certain sitations. The title is not quite the full story so I'll try to explain my failure condition without this patch.

In my case I was trying to build Boost >= 1.76 with clang built via spack. This change was made in Boost's `bootstrap.sh` for 1.76: https://github.com/boostorg/boost/commit/3e7d665fa57f0b2d00427d4ee5e627b9450cb18f#diff-99d5a2a8ca4290b61836b3ad37941f2b925e9ff3151c90dcd5ea82364e4122a1R229. It unsets `CXX` while building bjam, presumably because it thinks it can detect the correct compiler by itself. What happens in this situation is that spack's `CXX` gets unset, but the `TOOLSET` variable is set explicitly to `clang`. The `build.sh` script then assumes that because `TOOLSET` has been set to `clang` that `clang++` is in the path (https://github.com/boostorg/build/blob/d4352f0b1de0d28977f3d488c9be0c29fd1e6f9d/src/engine/build.sh#L165 and https://github.com/boostorg/build/blob/d4352f0b1de0d28977f3d488c9be0c29fd1e6f9d/src/engine/build.sh#L116). Compilation of bjam then fails because `clang++` isn't found. My assumption is that this doesn't show up as a problem on most systems because the toolset is most of the time `gcc` and there is almost always a `g++` in a system path which ends up compiling bjam in those cases.

This adds a patch from 1.76 onwards which explicitly sets the C++ compiler to `$CXX` for the `build.sh` call. Note that there's an earlier call to `build.sh` as well in the `bootstrap.sh` script, but that path is never taken so I haven't bothered patching that.

It'd be nice if someone else could test this on their system as well to see that I'm not breaking some other use case. It seems to work just fine for me.