### PR TITLE
Support DASK backend in XARRAY.

### DIFF
--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -29,6 +29,7 @@ class PyXarray(PythonPackage):
     version('0.9.1', sha256='89772ed0e23f0e71c3fb8323746374999ecbe79c113e3fadc7ae6374e6dc0525')
 
     variant('io', default=False, description='Build io backends')
+    variant('parallel', default=False, description='Build parallel backend')
 
     depends_on('python@2.7:2.8,3.5:',   when='@0.11:',  type=('build', 'run'))
     depends_on('python@3.5:',           when='@0.12',   type=('build', 'run'))
@@ -63,4 +64,4 @@ class PyXarray(PythonPackage):
     depends_on('py-rasterio', when='+io', type=('build', 'run'))
     depends_on('py-cfgrib',   when='+io', type=('build', 'run'))
     depends_on('py-pooch',    when='+io', type=('build', 'run'))
-    depends_on('py-dask',     when='+io', type=('build', 'run'))
+    depends_on('py-dask+array+dataframe+distributed+diagnostics+delayed', when='+parallel', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-xarray/package.py
+++ b/var/spack/repos/builtin/packages/py-xarray/package.py
@@ -63,3 +63,4 @@ class PyXarray(PythonPackage):
     depends_on('py-rasterio', when='+io', type=('build', 'run'))
     depends_on('py-cfgrib',   when='+io', type=('build', 'run'))
     depends_on('py-pooch',    when='+io', type=('build', 'run'))
+    depends_on('py-dask',     when='+io', type=('build', 'run'))


### PR DESCRIPTION
I am not super familiar with DASK or XARRAY, but I believe this is the write patch to support DASK as a backend for XARRAY. Based on my reading of this webpage:
https://xarray.pydata.org/en/stable/user-guide/dask.html
