### PR TITLE
julia: add patch reverting llvm rpath changes

### DIFF
--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -121,6 +121,10 @@ class Julia(MakefilePackage):
     # Fix gfortran abi detection https://github.com/JuliaLang/julia/pull/44026
     patch('fix-gfortran.patch', when='@1.7.0:1.7.2')
 
+    # Don't make julia run patchelf --set-rpath on llvm (presumably this should've
+    # only applied to libllvm when it's vendored by julia).
+    patch('revert-fix-rpath-of-libllvm.patch', when='@1.7.0:1.7')
+
     def patch(self):
         # The system-libwhich-libblastrampoline.patch causes a rebuild of docs as it
         # touches the main Makefile, so we reset the a/m-time to doc/_build's.

--- a/var/spack/repos/builtin/packages/julia/revert-fix-rpath-of-libllvm.patch
+++ b/var/spack/repos/builtin/packages/julia/revert-fix-rpath-of-libllvm.patch
@@ -1,0 +1,31 @@
+From 34b177cef31f8e6cd9e5251f7b0a8ea07a0fa328 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Sat, 26 Mar 2022 10:51:55 +0100
+Subject: [PATCH] Revert "Merge pull request #42788 from
+ JuliaLang/vc/freebsd_fix"
+
+This reverts commit 57f6f27e07258c8dccd06b405259ebfe448c16e7, reversing
+changes made to 13310eb4f0e40b8b2e7d77749fbf262f8029cf0f.
+---
+ Makefile | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index ec308a74f6..7cbb77ea06 100644
+--- a/Makefile
++++ b/Makefile
+@@ -369,11 +369,6 @@ ifeq ($(BUNDLE_DEBUG_LIBS),1)
+ endif
+ endif
+ 
+-	# Set rpath for LLVM.so which is `$ORIGIN/../lib` moving from `../lib` to `../lib/julia`.  We only need to do this for Linux/FreeBSD
+-ifneq (,$(findstring $(OS),Linux FreeBSD))
+-	$(PATCHELF) --set-rpath '$$ORIGIN:$$ORIGIN/$(reverse_private_libdir_rel)' $(DESTDIR)$(private_libdir)/libLLVM.$(SHLIB_EXT)
+-endif
+-
+ 
+ ifneq ($(LOADER_BUILD_DEP_LIBS),$(LOADER_INSTALL_DEP_LIBS))
+ 	# Next, overwrite relative path to libjulia-internal in our loader if $$(LOADER_BUILD_DEP_LIBS) != $$(LOADER_INSTALL_DEP_LIBS)
+-- 
+2.25.1
+


### PR DESCRIPTION
Closes #29727, julia changes libLLVM.so's rpath (probably their makefile misses a branch checking whether llvm is external or not)
