### PR TITLE
Fixed h5z-zfp with mpi.

### DIFF
--- a/var/spack/repos/builtin/packages/h5z-zfp/package.py
+++ b/var/spack/repos/builtin/packages/h5z-zfp/package.py
@@ -23,6 +23,7 @@ class H5zZfp(MakefilePackage):
 
     depends_on('hdf5+fortran', when='+fortran')
     depends_on('hdf5',         when='~fortran')
+    depends_on('mpi',          when='^hdf5+mpi')
     depends_on('zfp bsws=8')
 
     patch('https://github.com/LLNL/H5Z-ZFP/commit/983a1870cefff5fdb643898a14eda855c2c231e4.patch?full_index=1',
@@ -34,14 +35,19 @@ class H5zZfp(MakefilePackage):
 
     @property
     def make_defs(self):
+        cc = spack_cc
+        fc = spack_fc
+        if '^hdf5+mpi' in self.spec:
+            cc = self.spec['mpi'].mpicc
+            fc = self.spec['mpi'].mpifc
         make_defs = [
             'PREFIX=%s' % prefix,
-            'CC=%s' % spack_cc,
+            'CC=%s' % cc,
             'HDF5_HOME=%s' % self.spec['hdf5'].prefix,
             'ZFP_HOME=%s' % self.spec['zfp'].prefix]
 
-        if '+fortran' in self.spec and spack_fc:
-            make_defs += ['FC=%s' % spack_fc]
+        if '+fortran' in self.spec and fc:
+            make_defs += ['FC=%s' % fc]
         else:
             make_defs += ['FC=']
 


### PR DESCRIPTION
h5z-zfp includes files from hdf5 when compiling.  Those require MPI.

So, I had to add an extra test for this transitive MPI dependency in order to successfully compile the following combination:
```
$ spack spec -lINt conduit+hdf5+mpi+zfp
Input spec
--------------------------------
 -   [    ]  .conduit+hdf5+mpi+zfp

Concretized
--------------------------------
 -   yp2m3iu  [    ]  builtin.conduit@0.8.2%gcc@8.4.0~adios+blt_find_mpi~doc~doxygen+fortran+hdf5+hdf5_compat~ipo+mpi+parmetis~python+shared~silo+test+zfp build_type=RelWithDebInfo arch=linux-ubuntu18.04-skylake
[+]  wkdbayj  [b   ]      ^builtin.cmake@3.22.3%gcc@8.4.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=linux-ubuntu18.04-skylake
[+]  pnf4v5j  [bl  ]          ^builtin.ncurses@6.2%gcc@8.4.0~symlinks+termlib abi=none arch=linux-ubuntu18.04-skylake
[+]  7qc22vn  [b r ]              ^builtin.pkgconf@1.8.0%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
[+]  hat454o  [bl  ]          ^builtin.openssl@1.1.1n%gcc@8.4.0~docs~shared certs=system arch=linux-ubuntu18.04-skylake
[+]  lcv3hdp  [b   ]              ^builtin.perl@5.34.0%gcc@8.4.0+cpanm+shared+threads arch=linux-ubuntu18.04-skylake
[+]  vc425ec  [bl  ]                  ^builtin.berkeley-db@18.1.40%gcc@8.4.0+cxx~docs+stl patches=b231fcc arch=linux-ubuntu18.04-skylake
[+]  2qp2dx3  [bl  ]                  ^builtin.bzip2@1.0.8%gcc@8.4.0~debug~pic+shared arch=linux-ubuntu18.04-skylake
[+]  j2itsz3  [b   ]                      ^builtin.diffutils@3.8%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
[+]  cgf2q7i  [bl  ]                          ^builtin.libiconv@1.16%gcc@8.4.0 libs=shared,static arch=linux-ubuntu18.04-skylake
[+]  kkep3r6  [bl  ]                  ^builtin.gdbm@1.19%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
[+]  k5ovejf  [bl  ]                      ^builtin.readline@8.1%gcc@8.4.0 arch=linux-ubuntu18.04-skylake
[+]  mg2gy4g  [bl  ]                  ^builtin.zlib@1.2.11%gcc@8.4.0+optimize+pic+shared arch=linux-ubuntu18.04-skylake
 -   2spejtf  [bl  ]      ^builtin.h5z-zfp@1.0.1%gcc@8.4.0~fortran patches=07a53b8 arch=linux-ubuntu18.04-skylake
[+]  5csm5x5  [bl  ]          ^builtin.hdf5@1.8.22%gcc@8.4.0~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-ubuntu18.04-skylake
[+]  rfjvyjf  [bl  ]              ^builtin.openmpi@2.1.1-8%gcc@8.4.0~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi~pmix+romio~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none patches=51e39ef,d7f08ae schedulers=none arch=linux-ubuntu18.04-skylake
[+]  it2xyyv  [bl  ]          ^builtin.zfp@0.5.5%gcc@8.4.0~aligned~c~cuda~fasthash~fortran~ipo~openmp~profile~python+shared~strided~twoway bsws=8 build_type=RelWithDebInfo arch=linux-ubuntu18.04-skylake
[+]  vbmafk6  [bl  ]      ^builtin.metis@5.1.0%gcc@8.4.0~gdb~int64~real64+shared build_type=Release patches=4991da9,b1225da arch=linux-ubuntu18.04-skylake
[+]  56zoq72  [bl  ]      ^builtin.parmetis@4.0.3%gcc@8.4.0~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f89253,50ed208,704b84f arch=linux-ubuntu18.04-skylake
```

The original error message was:
```
==> Installing h5z-zfp-1.0.1-2spejtfdwhfs7xayj2u7tunjauvccwkt
==> No binary for h5z-zfp-1.0.1-2spejtfdwhfs7xayj2u7tunjauvccwkt found: installing from source
==> Using cached archive: /home/spack/var/spack/cache/_source-cache/archive/b9/b9ed91dab8e2ef82dc6706b4242c807fb352875e3b21c217dd00782dd1a22b24.tar.gz
==> Using cached archive: /home/spack/var/spack/cache/_source-cache/archive/07/07a53b8b0d4c1df62a3f9f21b30ad0eb90f26b38eb6cacc0de6482fd8f5daea2
==> Applied patch https://github.com/LLNL/H5Z-ZFP/commit/983a1870cefff5fdb643898a14eda855c2c231e4.patch?full_index=1
==> h5z-zfp: Executing phase: 'edit'
==> h5z-zfp: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j12' 'PREFIX=/home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/h5z-zfp-1.0.1-2spejtfdwhfs7xayj2u7tunjauvccwkt' 'CC=/home/spack/lib/spack/env/gcc/gcc' 'HDF5_HOME=/home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf' 'ZFP_HOME=/home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/zfp-0.5.5-it2xyyv7vsoxllkiqo5jmnadwcwfrsh6' 'FC=' 'all'

12 errors found in build log:
  >> 5     grep: /H5Zzfp_plugin.h: No such file or directory
     6     cd src; make  ZFP_HOME=/home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0
           /zfp-0.5.5-it2xyyv7vsoxllkiqo5jmnadwcwfrsh6  PREFIX=/home/spack/opt/spack/linux-
           ubuntu18.04-skylake/gcc-8.4.0/h5z-zfp-1.0.1-2spejtfdwhfs7xayj2u7tunjauvccwkt all
     7     make[1]: Entering directory '/tmp/spack-stage/spack-stage-h5z-zfp-1.0.1-2spejtfd
           whfs7xayj2u7tunjauvccwkt/spack-src/src'
     8     /home/spack/lib/spack/env/gcc/gcc -c H5Zzfp.c -o H5Zzfp_lib.o -DH5Z_ZFP_AS_LIB -
           fPIC -I. -I/home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/zfp-0.5.5-i
           t2xyyv7vsoxllkiqo5jmnadwcwfrsh6/include -I/home/spack/opt/spack/linux-ubuntu18.0
           4-skylake/gcc-8.4.0/hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf
     9     /home/spack/lib/spack/env/gcc/gcc -c H5Zzfp_props.c -o H5Zzfp_props.o -fPIC -I. 
           -I/home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/zfp-0.5.5-it2xyyv7vs
           oxllkiqo5jmnadwcwfrsh6/include -I/home/spack/opt/spack/linux-ubuntu18.04-skylake
           /gcc-8.4.0/hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf
     10    /home/spack/lib/spack/env/gcc/gcc -c H5Zzfp.c -o H5Zzfp_plugin.o -fPIC -I. -I/ho
           me/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/zfp-0.5.5-it2xyyv7vsoxllk
           iqo5jmnadwcwfrsh6/include -I/home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-
           8.4.0/hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf
     11    In file included from /home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/
           hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf/include/hdf5.h:22,
     12                     from H5Zzfp_props.c:4:
  >> 13    /home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/hdf5-1.8.22-5csm5x5frc
           xa3jy2zuhjwbsqiju52nbf/include/H5public.h:63:10: fatal error: mpi.h: No such file or
            directory
     14     #include <mpi.h>
     15              ^~~~~~~
     16    compilation terminated.
  >> 17    Makefile:26: recipe for target 'H5Zzfp_props.o' failed
  >> 18    make[1]: *** [H5Zzfp_props.o] Error 1
     19    make[1]: *** Waiting for unfinished jobs....
     20    In file included from /home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/
           hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf/include/hdf5.h:22,
     21                     from /home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/
           hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf/include/H5PLextern.h:21,
     22                     from H5Zzfp.c:39:
  >> 23    /home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/hdf5-1.8.22-5csm5x5frc
           xa3jy2zuhjwbsqiju52nbf/include/H5public.h:63:10: fatal error: mpi.h: No such file or
            directory
     24     #include <mpi.h>
     25              ^~~~~~~
     26    compilation terminated.
  >> 27    Makefile:11: recipe for target 'H5Zzfp_lib.o' failed
  >> 28    make[1]: *** [H5Zzfp_lib.o] Error 1
     29    In file included from /home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/
           hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf/include/hdf5.h:22,
     30                     from /home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/
           hdf5-1.8.22-5csm5x5frcxa3jy2zuhjwbsqiju52nbf/include/H5PLextern.h:21,
     31                     from H5Zzfp.c:39:
  >> 32    /home/spack/opt/spack/linux-ubuntu18.04-skylake/gcc-8.4.0/hdf5-1.8.22-5csm5x5frc
           xa3jy2zuhjwbsqiju52nbf/include/H5public.h:63:10: fatal error: mpi.h: No such file or
            directory
     33     #include <mpi.h>
     34              ^~~~~~~
     35    compilation terminated.
  >> 36    Makefile:7: recipe for target 'H5Zzfp_plugin.o' failed
  >> 37    make[1]: *** [H5Zzfp_plugin.o] Error 1
     38    make[1]: Leaving directory '/tmp/spack-stage/spack-stage-h5z-zfp-1.0.1-2spejtfdw
           hfs7xayj2u7tunjauvccwkt/spack-src/src'
  >> 39    Makefile:30: recipe for target 'all' failed
  >> 40    make: *** [all] Error 2

See build log for details:
  /tmp/spack-stage/spack-stage-h5z-zfp-1.0.1-2spejtfdwhfs7xayj2u7tunjauvccwkt/spack-build-out.txt

==> Warning: Skipping build of conduit-0.8.2-yp2m3iu2irstchhaeb452eb65zztjzli since h5z-zfp-1.0.1-2spejtfdwhfs7xayj2u7tunjauvccwkt failed
==> Error: conduit-0.8.2-yp2m3iu2irstchhaeb452eb65zztjzli: Package was not installed
```

This is now fixed, and compilation works fine.