### PR TITLE
gdb: Remove python+debug dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gdb/package.py
+++ b/var/spack/repos/builtin/packages/gdb/package.py
@@ -66,7 +66,7 @@ class Gdb(AutotoolsPackage, GNUMirrorPackage):
     depends_on('texinfo', type='build')
 
     # Optional dependencies
-    depends_on('python+debug', when='+python', type=('build', 'link', 'run'))
+    depends_on('python', when='+python', type=('build', 'link', 'run'))
     depends_on('python@:3.6', when='@:8.1+python', type=('build', 'link', 'run'))
     depends_on('xz', when='+xz')
     depends_on('source-highlight', when='+source-highlight')


### PR DESCRIPTION
It seems to be possible to build and run `gdb` with python support without explicitly requiring a python debug build. One of the reasons to remove this is that this will require a python debug build for environments with gdb in it.

This might need some version ranges to ensure that things work always, but I have the following:
```console
$ spack find -dv gdb
-- linux-centos7-x86_64 / gcc@10.3.0 ----------------------------
gdb@11.1~gold~ld~lto+python~quad+source-highlight+tui+xz patches=7590c95
    gmp@6.2.1
    ncurses@6.2~symlinks+termlib abi=none
    source-highlight@3.1.9
        boost@1.78.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options+python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=b8569d7 visibility=hidden
            bzip2@1.0.8~debug~pic+shared
            python@3.9.10+bz2+ctypes+dbm~debug+ensurepip+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix~tkinter~ucs4+uuid+zlib patches=0d98e93,4c24573,f2fd060
                expat@2.4.6+libbsd
                    libbsd@0.11.5
                        libmd@1.0.4
                gdbm@1.19
                    readline@8.1
                gettext@0.21+bzip2+curses+git~libunistring+libxml2+tar+xz
                    libiconv@1.16 libs=shared,static
                    libxml2@2.9.12~python
                        xz@5.2.5~pic libs=shared,static
                        zlib@1.2.11+optimize+pic+shared
                    tar@1.34
                libffi@3.4.2
                openssl@1.1.1m~docs certs=system
                sqlite@3.37.2+column_metadata+dynamic_extensions+fts~functions+rtree
                util-linux-uuid@2.37.4
```

And I can at least do the following in `gdb`
```console
$ gdb
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-120.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
(gdb) python
>import sysconfig
>print(sysconfig.get_config_var('Py_DEBUG'))
>end
0
```