### PR TITLE
gpi-2_fix_deps: setup 'gawk' and 'sed' dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/gpi-2/package.py
+++ b/var/spack/repos/builtin/packages/gpi-2/package.py
@@ -60,7 +60,9 @@ class Gpi2(AutotoolsPackage):
     depends_on('libtool',  type='build', when='@1.4.0:')
     depends_on('m4',       type='build', when='@1.4.0:')
 
-    depends_on('gawk', type='run')
+    depends_on('sed', type=('build', 'run'))
+    depends_on('gawk', type=('build', 'run'), when='@:1.3.3')
+    depends_on('gawk', type=('run'), when='@1.4.0:')
     depends_on('openssh', type='run')
 
     depends_on('mpi', when='+mpi')


### PR DESCRIPTION
For gpi-2 versions less or equal than 1.3.3, `sed` and `gawk` are checked by the custom install script, so formally they must be considered, apart from `run`, as `build` dependencies. For more recent versions, `sed` is still a `run` and `build` dependency, but `gawk` is just a `run` dependency.