### PR TITLE
edit to dockerfile template, so that any command can be executed

### DIFF
--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -62,5 +62,6 @@ RUN {% if os_package_update %}{{ os_packages_final.update }} \
 {% for label, value in labels.items() %}
 LABEL "{{ label }}"="{{ value }}"
 {% endfor %}
-ENTRYPOINT ["/bin/bash", "--rcfile", "/etc/profile", "-l"]
+ENTRYPOINT ["/bin/bash", "--rcfile", "/etc/profile", "-l", "-c", "$*", "--" ]
+CMD [ "/bin/bash" ]
 {% endif %}


### PR DESCRIPTION
Hi, I am proposing this change to the Jinja template for Dockerfiles generate by `spack containerize`.

Current ENTRYPOINT (no CMD defined): 
```
ENTRYPOINT ["/bin/bash", "--rcfile", "/etc/profile", "-l"]
```

Proposed ENTRYPOINT + CMD:
```
ENTRYPOINT ["/bin/bash", "--rcfile", "/etc/profile", "-l", "-c", "$*", "--" ]
CMD [ "/bin/bash" ]
```

As context, I work at a HPC centre, and I have quite extensive experience in designing and deploying containers on HPC and Cloud. 
However, I have to admit, I was unable to understand the rationale for the current ENTRYPOINT in the template.
In fact, I tried to build a `blast` container using the current template, and then subsequently ran it using Docker.  Without editing the entrypoint with `--entrypoint`, I was only able to execute the bash shell. Any other command would fail.

Therefore, I am hereby proposing a small change in the Dockerfile template. The new version still provides a login bash shell as default command, but in addition it also allows execution of any shell command or application binary (with their arguments) that is given as argument when running the container with Docker.
The proposed implementation makes use of the bash flag `-c`, as per bash documentation.

I would be glad to hear your feedback on this topic.
Best regards, Marco
