### PR TITLE
install --overwrite: use rename instead of tmpdir

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -782,7 +782,9 @@ def replace_directory_transaction(directory_name):
 
     # Note: directory_name is normalized here, meaning the trailing slash is dropped,
     # so dirname is the directory's parent not the directory itself.
-    tmpdir = tempfile.mkdtemp(dir=os.path.dirname(directory_name))
+    tmpdir = tempfile.mkdtemp(
+        dir=os.path.dirname(directory_name),
+        prefix='.backup')
 
     # We have to jump through hoops to support Windows, since
     # os.rename(directory_name, tmpdir) errors there.

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -2018,11 +2018,10 @@ def build_process(pkg, install_args):
 
 
 class OverwriteInstall(object):
-    def __init__(self, installer, database, task, tmp_root=None):
+    def __init__(self, installer, database, task):
         self.installer = installer
         self.database = database
         self.task = task
-        self.tmp_root = tmp_root
 
     def install(self):
         """
@@ -2032,7 +2031,7 @@ class OverwriteInstall(object):
         install error if installation fails.
         """
         try:
-            with fs.replace_directory_transaction(self.task.pkg.prefix, self.tmp_root):
+            with fs.replace_directory_transaction(self.task.pkg.prefix):
                 self.installer._install_task(self.task)
         except fs.CouldNotRestoreDirectoryBackup as e:
             self.database.remove(self.task.pkg.spec)

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -1222,9 +1222,13 @@ def test_overwrite_install_backup_failure(temporary_store, config, mock_packages
     """
     class InstallerThatAccidentallyDeletesTheBackupDir:
         def _install_task(self, task):
-            # Remove the backup directory so that restoring goes terribly wrong
-            # (the backup folder has a random prefix, so glob it.)
-            for backup in glob.iglob(task.pkg.prefix + "*"):
+            # Remove the backup directory, which is at the same level as the prefix,
+            # starting with .backup
+            backup_glob = os.path.join(
+                os.path.dirname(os.path.normpath(task.pkg.prefix)),
+                '.backup*'
+            )
+            for backup in glob.iglob(backup_glob):
                 shutil.rmtree(backup)
             raise Exception("Some fatal install error")
 


### PR DESCRIPTION
I tried to use --overwrite on nvhpc, but nvhpc's install size is 16GB. Seems
better to do `os.rename` in the same directory than moving the directory to
/tmp.

