### PR TITLE
py-pyupgrade: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyupgrade/package.py
+++ b/var/spack/repos/builtin/packages/py-pyupgrade/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyPyupgrade(PythonPackage):
+    """A tool to automatically upgrade syntax for newer versions."""
+
+    homepage = "https://github.com/asottile/pyupgrade"
+    pypi     = "pyupgrade/pyupgrade-2.31.1.tar.gz"
+
+    version('2.31.1', sha256='22e0ad6dd39c4381805cb059f1e691b6315c62c0ebcec98a5f29d22cd186a72a')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-tokenize-rt@3.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-tokenize-rt/package.py
+++ b/var/spack/repos/builtin/packages/py-tokenize-rt/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyTokenizeRt(PythonPackage):
+    """A wrapper around the stdlib `tokenize` which roundtrips."""
+
+    homepage = "https://github.com/asottile/tokenize-rt"
+    pypi     = "tokenize_rt/tokenize_rt-4.2.1.tar.gz"
+
+    version('4.2.1', sha256='0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94')
+
+    depends_on('python@3.6.1:', type=('build', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 10.15.7 with Python 3.9.10 and Apple Clang 12.0.0. Tested and it also works when used as a tool.

@alalazo this is a really useful tool that lets you automatically update code when you drop support for older Python versions. For example, it can automatically replace `'%s' % 'foo'` with `'{0}'.format('foo')` in Python 2.6, `'{}'.format('foo')` in Python 2.7, and `f'{foo}'` in Python 3.6. We should consider using this at some point to further reduce the number of correct ways to write the same thing.