### PR TITLE
Mixed compilers: drop warning message to debug level

### DIFF
--- a/lib/spack/spack/target.py
+++ b/lib/spack/spack/target.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import functools
-import warnings
 
 import six
 
@@ -134,7 +133,7 @@ class Target(object):
                 msg = ('microarchitecture specific optimizations are not '
                        'supported yet on mixed compiler toolchains [check'
                        ' {0.name}@{0.version} for further details]')
-                warnings.warn(msg.format(compiler))
+                tty.debug(msg.format(compiler))
                 return ''
 
         # Try to check if the current compiler comes with a version number or


### PR DESCRIPTION
### Rationale

I can't tell you how many times users have seen this warning message, thought it was an error message, freaked out, and killed the install process because they didn't want to waste time compiling something that may be broken. For the vast majority of users of mixed compiler toolchains, using non-mixed compiler toolchains is not an option. There is also no other way to silence this warning message and it appears almost any time you run any Spack command.

### Implementation

This PR drops the warning message down to the level of debug. It is still present if you run `spack --debug`, but is silent the rest of the time.

### Alternatives

I would also be happy if the following silenced this warning message:
```yaml
packages:
  all:
    target: [x86_64]
```
but this doesn't seem to work at the moment. Also, this alternative only helps advanced users, it doesn't help new users. Although we could display this as an option in the warning message if users want to silence it.