### PR TITLE
Add ssh to filter of valid urls

### DIFF
--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -343,7 +343,7 @@ def parse_git_url(url):
 
 
 def require_url_format(url):
-    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|/)', url)
+    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|/)', url)
     assert ut is not None
 
 


### PR DESCRIPTION
Support SSH urls in url filter.

Fixes #29706