### PR TITLE
Convert git-over-ssh package URLs to canonical format

### DIFF
--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -343,7 +343,7 @@ def parse_git_url(url):
 
 
 def require_url_format(url):
-    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|/)', url)
+    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|/)', url)
     assert ut is not None
 
 

--- a/var/spack/repos/builtin/packages/liggghts/package.py
+++ b/var/spack/repos/builtin/packages/liggghts/package.py
@@ -13,7 +13,7 @@ class Liggghts(MakefilePackage):
     """Discrete element method particle simulation."""
     homepage = 'https://www.cfdem.com/media/DEM/docu/Manual.html'
     url = 'https://github.com/CFDEMproject/LIGGGHTS-PUBLIC/archive/3.8.0.tar.gz'
-    git = 'git@github.com:CFDEMproject/LIGGGHTS-PUBLIC.git'
+    git = 'ssh://git@github.com/CFDEMproject/LIGGGHTS-PUBLIC.git'
 
     version('3.8.0', sha256='9cb2e6596f584463ac2f80e3ff7b9588b7e3638c44324635b6329df87b90ab03')
 

--- a/var/spack/repos/builtin/packages/survey/package.py
+++ b/var/spack/repos/builtin/packages/survey/package.py
@@ -28,7 +28,7 @@ class Survey(CMakePackage):
     """
 
     homepage = "http://www.trenzasynergy.com"
-    git      = "git@gitlab.com:trenza/survey.git"
+    git      = "ssh://git@gitlab.com/trenza/survey.git"
 
     maintainers = ['jgalarowicz']
 

--- a/var/spack/repos/builtin/packages/talass/package.py
+++ b/var/spack/repos/builtin/packages/talass/package.py
@@ -15,7 +15,7 @@ class Talass(CMakePackage):
     alone."""
 
     homepage = "http://www.cedmav.org/research/project/16-talass.html"
-    git      = "git@bitbucket.org:cedmav/talass.git"
+    git      = "ssh://git@bitbucket.org/cedmav/talass.git"
 
     version('2018-10-29', commit='5d459c0dd89e733fa301391908a5b79fe2850ad7')
 


### PR DESCRIPTION
These packages were broken by #27021 and will be repaired in concert with #29749.