### PR TITLE
Add git to filter of valid urls

### DIFF
--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -343,7 +343,7 @@ def parse_git_url(url):
 
 
 def require_url_format(url):
-    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|/)', url)
+    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|git://|/)', url)
     assert ut is not None
 
 


### PR DESCRIPTION
Support `git:` urls in url filter.

The `cln` package was broken with #27021. This pull request fixes the broken `git:` link.