### PR TITLE
Configure nvhpc GCC from Spack variables

### DIFF
--- a/var/spack/repos/builtin/packages/nvhpc/package.py
+++ b/var/spack/repos/builtin/packages/nvhpc/package.py
@@ -5,7 +5,6 @@
 #
 # Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
 
-import os
 import platform
 
 from spack import *
@@ -123,22 +122,42 @@ class Nvhpc(Package):
     conflicts('%intel')
     conflicts('%xl')
 
-    def install(self, spec, prefix):
-        # Enable the silent installation feature
-        os.environ['NVHPC_SILENT'] = "true"
-        os.environ['NVHPC_ACCEPT_EULA'] = "accept"
-        os.environ['NVHPC_INSTALL_DIR'] = prefix
+    def _version_prefix(self):
+        return join_path(
+            self.prefix, 'Linux_%s' % self.spec.target.family, self.version)
 
-        if spec.variants['install_type'].value == 'network':
-            os.environ['NVHPC_INSTALL_TYPE'] = "network"
-            os.environ['NVHPC_INSTALL_LOCAL_DIR'] = \
-                "%s/%s/%s/share_objects" % \
-                (prefix, 'Linux_%s' % spec.target.family, self.version)
+    def setup_build_environment(self, env):
+        env.set('NVHPC_SILENT', 'true')
+        env.set('NVHPC_ACCEPT_EULA', 'accept')
+        env.set('NVHPC_INSTALL_DIR', self.prefix)
+
+        if self.spec.variants['install_type'].value == 'network':
+            local_dir = join_path(self._version_prefix(), 'share_objects')
+            env.set('NVHPC_INSTALL_TYPE', 'network')
+            env.set('NVHPC_INSTALL_LOCAL_DIR', local_dir)
         else:
-            os.environ['NVHPC_INSTALL_TYPE'] = "single"
+            env.set('NVHPC_INSTALL_TYPE', 'single')
+
+    def install(self, spec, prefix):
+        compilers_bin = join_path(self._version_prefix(), 'compilers', 'bin')
+        install = Executable('./install')
+        makelocalrc = Executable(join_path(compilers_bin, 'makelocalrc'))
+
+        makelocalrc_args = [
+            '-gcc', self.compiler.cc,
+            '-gpp', self.compiler.cxx,
+            '-g77', self.compiler.f77,
+            '-x', compilers_bin
+        ]
+        if self.spec.variants['install_type'].value == 'network':
+            local_dir = join_path(self._version_prefix(), 'share_objects')
+            makelocalrc_args.extend(['-net', local_dir])
 
         # Run install script
-        os.system("./install")
+        install()
+
+        # Update localrc to use Spack gcc
+        makelocalrc(*makelocalrc_args)
 
     def setup_run_environment(self, env):
         prefix = Prefix(join_path(self.prefix,


### PR DESCRIPTION
This is https://github.com/spack/spack/pull/24654 rebased on develop with a small modification to the patch. The reason for the changes is unchanged from https://github.com/spack/spack/pull/24654.

I've replaced the specific patch (https://github.com/spack/spack/pull/24654/files#diff-cf482bcc3e73486f18429a2cf2092deee184fe53c6d55cc464e325ebb044e838) with a patch function that is meant to apply to all versions and architectures. It works for me on x86_64. However, I have not tested this on aarch64 and ppc64le.