### PR TITLE
e4s ci: uncomment umpire

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -193,6 +193,7 @@ spack:
     - trilinos +amesos +amesos2 +anasazi +aztec +belos +boost +epetra +epetraext +ifpack +ifpack2 +intrepid +intrepid2 +isorropia +kokkos +ml +minitensor +muelu +nox +piro +phalanx +rol +rythmos +sacado +stk +shards +shylu +stokhos +stratimikos +teko +tempus +tpetra +trilinoscouplings +zoltan +zoltan2 +superlu-dist gotype=long_long
     - turbine
     - umap
+    - umpire
     - unifyfs@0.9.1
     - upcxx
     - variorum
@@ -203,7 +204,6 @@ spack:
     #- geopm
     #- qt
     #- qwt
-    #- umpire # unsatisfiable concretization conflict w/ blt
 
   - arch:
     - '%gcc target=x86_64'


### PR DESCRIPTION
At some point in the past there was a concretization conflict affecting `umpire` -- I believe this has been resolved now. Try uncommenting `umpire` in list of E4S CI specs.

@wspear 