### PR TITLE
Force GCC to always provide a C++14 flag

### DIFF
--- a/lib/spack/spack/compilers/gcc.py
+++ b/lib/spack/spack/compilers/gcc.py
@@ -78,10 +78,8 @@ class Gcc(spack.compiler.Compiler):
                 self, "the C++14 standard", "cxx14_flag", "< 4.8")
         elif self.real_version < ver('4.9'):
             return "-std=c++1y"
-        elif self.real_version < ver('6.0'):
-            return "-std=c++14"
         else:
-            return ""
+            return "-std=c++14"
 
     @property
     def cxx17_flag(self):

--- a/lib/spack/spack/test/compilers/basics.py
+++ b/lib/spack/spack/test/compilers/basics.py
@@ -501,7 +501,7 @@ def test_gcc_flags():
     unsupported_flag_test("cxx14_flag", "gcc@4.7")
     supported_flag_test("cxx14_flag", "-std=c++1y", "gcc@4.8")
     supported_flag_test("cxx14_flag", "-std=c++14", "gcc@4.9")
-    supported_flag_test("cxx14_flag", "", "gcc@6.0")
+    supported_flag_test("cxx14_flag", "-std=c++14", "gcc@6.0")
     unsupported_flag_test("cxx17_flag", "gcc@4.9")
     supported_flag_test("cxx17_flag", "-std=c++1z", "gcc@5.0")
     supported_flag_test("cxx17_flag", "-std=c++17", "gcc@6.0")


### PR DESCRIPTION
Updated gnu logic so that the c++14 flag for g++ is always propagated.
This fixes issues with build systems that error out if passed an empty
string for a flag.