### PR TITLE
gpi-space: fix boost dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gpi-space/package.py
+++ b/var/spack/repos/builtin/packages/gpi-space/package.py
@@ -49,7 +49,7 @@ class GpiSpace(CMakePackage):
                type=("build", "run"))
     depends_on("pkgconf",
                type="build")
-    depends_on("boost@1.62.0:1.63.0 +coroutine +context cxxstd=14")
+    depends_on("boost@1.62.0:1.63.0 +atomic +chrono +coroutine +context +date_time +filesystem +iostreams +program_options +random +regex +serialization +test +timer cxxstd=14")
     depends_on("hwloc@1.10: +libudev ~shared ~libxml2")
     depends_on("libssh2@1.7:")
     depends_on("openssl@0.9:")


### PR DESCRIPTION
This adjusts the `Boost` dependency which now requires to load most of its components explicitely.