### PR TITLE
zlib: Update to 1.2.12

### DIFF
--- a/var/spack/repos/builtin/packages/mfem/package.py
+++ b/var/spack/repos/builtin/packages/mfem/package.py
@@ -335,7 +335,9 @@ class Mfem(Package, CudaPackage, ROCmPackage):
             '/usr/lib64',
             '/usr/lib',
             '/usr/local/lib64',
-            '/usr/local/lib']
+            '/usr/local/lib',
+            '/usr/lib/x86_64-linux-gnu',
+        ]
 
         def is_sys_lib_path(dir):
             return dir in sys_lib_paths

--- a/var/spack/repos/builtin/packages/zlib/configure-cc.patch
+++ b/var/spack/repos/builtin/packages/zlib/configure-cc.patch
@@ -1,0 +1,24 @@
+From 05796d3d8d5546cf1b4dfe2cd72ab746afae505d Mon Sep 17 00:00:00 2001
+From: Mark Adler <madler@alumni.caltech.edu>
+Date: Mon, 28 Mar 2022 18:34:10 -0700
+Subject: [PATCH] Fix configure issue that discarded provided CC definition.
+
+---
+ configure | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure b/configure
+index 52ff4a04e..3fa3e8618 100755
+--- a/configure
++++ b/configure
+@@ -174,7 +174,10 @@ if test -z "$CC"; then
+   else
+     cc=${CROSS_PREFIX}cc
+   fi
++else
++  cc=${CC}
+ fi
++
+ cflags=${CFLAGS-"-O3"}
+ # to force the asm version use: CFLAGS="-O3 -DASMV" ./configure
+ case "$cc" in

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -32,6 +32,7 @@ class Zlib(Package):
             description='Enable -O2 for a more optimized lib')
 
     patch('w_patch.patch', when="@1.2.11%cce")
+    patch('configure-cc.patch', when='@1.2.12')
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -19,11 +19,10 @@ class Zlib(Package):
     # URL must remain http:// so Spack can bootstrap curl
     url = "https://zlib.net/fossils/zlib-1.2.11.tar.gz"
 
-    version('1.2.11', sha256='c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1')
-    # Due to the bug fixes, any installations of 1.2.9 or 1.2.10 should be
-    # immediately replaced with 1.2.11.
-    version('1.2.8', sha256='36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d')
-    version('1.2.3', sha256='1795c7d067a43174113fdf03447532f373e1c6c57c08d61d9e4e9be5e244b05e')
+    version('1.2.12', sha256='91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9')
+    version('1.2.11', sha256='c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1', deprecated=True)
+    version('1.2.8', sha256='36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d', deprecated=True)
+    version('1.2.3', sha256='1795c7d067a43174113fdf03447532f373e1c6c57c08d61d9e4e9be5e244b05e', deprecated=True)
 
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')


### PR DESCRIPTION
Update to version 1.2.12.
Mark older versions as deprecated because they have security bugs.