### PR TITLE
Allow :pserver: prefixes in URLs

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1104,8 +1104,12 @@ class CvsFetchStrategy(VCSFetchStrategy):
         if not (self.branch or self.date):
             # We need a branch or a date to make a checkout reproducible
             return None
-        repo_path = url_util.parse(self.url).path
-        result = os.path.sep.join(['cvs', repo_path])
+        # Special-case handling because this is not actually a URL
+        elements = self.url.split(':')
+        final = elements[-1]
+        path_re = r'^\d*([^0-9]+$)'
+        path = re.match(path_re, final).groups(1)
+        result = os.path.sep.join(['cvs', path])
         if self.branch:
             result += '%branch=' + self.branch
         if self.date:

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1107,9 +1107,10 @@ class CvsFetchStrategy(VCSFetchStrategy):
         # Special-case handling because this is not actually a URL
         elements = self.url.split(':')
         final = elements[-1]
-        path_re = r'^\d*([^0-9]+$)'
-        path = re.match(path_re, final).groups(1)
-        result = os.path.sep.join(['cvs', path])
+        elements = final.split('/')
+        # Everything before the first slash is a port number
+        elements = elements[1:]
+        result = os.path.sep.join(['cvs'] + elements)
         if self.branch:
             result += '%branch=' + self.branch
         if self.date:

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -343,7 +343,9 @@ def parse_git_url(url):
 
 
 def require_url_format(url):
-    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|/)', url)
+    # `:pserver:` is the prefix used for remote CVS repositories.
+    # The CVS protocol predates the URL standard, hence the non-standard shape.
+    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|:pserver:|/)', url)
     assert ut is not None
 
 

--- a/lib/spack/spack/util/url.py
+++ b/lib/spack/spack/util/url.py
@@ -343,9 +343,7 @@ def parse_git_url(url):
 
 
 def require_url_format(url):
-    # `:pserver:` is the prefix used for remote CVS repositories.
-    # The CVS protocol predates the URL standard, hence the non-standard shape.
-    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|git://|:pserver:|/)', url)
+    ut = re.search(r'^(file://|http://|https://|ftp://|s3://|gs://|ssh://|git://|/)', url)
     assert ut is not None
 
 


### PR DESCRIPTION
This is necessary to make CVS repositories work again.