### PR TITLE
libunwind: restore version 1.6.2 to preferred

### DIFF
--- a/var/spack/repos/builtin/packages/libunwind/package.py
+++ b/var/spack/repos/builtin/packages/libunwind/package.py
@@ -19,7 +19,7 @@ class Libunwind(AutotoolsPackage):
     version('1.6-stable', branch='v1.6-stable')
     version('1.6.2', sha256='4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976')
     version('1.5-stable', branch='v1.5-stable')
-    version('1.5.0', sha256='90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017', preferred=True)
+    version('1.5.0', sha256='90337653d92d4a13de590781371c604f9031cdb50520366aa1e3a91e1efb1017')
     version('1.4.0', sha256='df59c931bd4d7ebfd83ee481c943edf015138089b8e50abed8d9c57ba9338435')
     version('1.3.1', sha256='43997a3939b6ccdf2f669b50fdb8a4d3205374728c2923ddc2354c65260214f8')
     version('1.2.1', sha256='3f3ecb90e28cbe53fba7a4a27ccce7aad188d3210bb1964a923a731a27a75acb')
@@ -64,10 +64,11 @@ class Libunwind(AutotoolsPackage):
 
     # The libunwind releases contain the autotools generated files,
     # but the git repo snapshots do not.
-    depends_on('autoconf', type='build', when='@master,1.5-stable,1.6-stable')
-    depends_on('automake', type='build', when='@master,1.5-stable,1.6-stable')
-    depends_on('libtool',  type='build', when='@master,1.5-stable,1.6-stable')
-    depends_on('m4',       type='build', when='@master,1.5-stable,1.6-stable')
+    reconf_versions = '@master,1.5-stable,1.6-stable'
+    depends_on('autoconf', type='build', when=reconf_versions)
+    depends_on('automake', type='build', when=reconf_versions)
+    depends_on('libtool',  type='build', when=reconf_versions)
+    depends_on('m4',       type='build', when=reconf_versions)
 
     depends_on('xz', type='link', when='+xz')
     depends_on('zlib', type='link', when='+zlib')


### PR DESCRIPTION
Version 1.6.2 is now available from mirror.spack.io, so this avoids
problems fetching from savannah.nongnu.org.

----------

Fetching now works from the AWS mirror, thus avoiding savannah.

```
$ spack fetch libunwind @1.6.2 
==> Fetching https://mirror.spack.io/_source-cache/archive/4a/4a6aec666991fb45d0889c44aede8ad6eb108071c3554fcdff671f9c94794976.tar.gz

```