### PR TITLE
Add conflict with gcc versions strictly inferior to 9

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -14,7 +14,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/pika-org/pika/"
     url = "https://github.com/pika-org/pika/archive/0.0.0.tar.gz"
-    maintainers = ['msimberg', 'albestro', 'teonnik']
+    maintainers = ['msimberg', 'albestro', 'teonnik', 'aurianer']
 
     version('0.2.0', sha256='712bb519f22bdc9d5ee4ac374d251a54a0af4c9e4e7f62760b8ab9a177613d12')
     version('0.1.0', sha256='aa0ae2396cd264d821a73c4c7ecb118729bb3de042920c9248909d33755e7327')

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -45,7 +45,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     variant('examples', default=False, description='Build and install examples')
     variant('mpi', default=False, description='Enable MPI support')
-    variant('apex', default=False, description='Enable APEX support', when='@0.2.0:')
+    variant('apex', default=False, description='Enable APEX support', when='@0.2:')
 
     # Build dependencies
     depends_on('git', type='build')
@@ -54,6 +54,9 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     conflicts('%gcc@:6')
     conflicts('%clang@:6')
+    # Pika is requiring the std::filesystem support starting from version 0.2.0
+    conflicts('%gcc@:8', when='@0.2:')
+    conflicts('%clang@:8', when='@0.2:')
 
     # Other dependecies
     depends_on('hwloc@1.11.5:')


### PR DESCRIPTION
pika@0.2.0 is requiring `std::filesystem` support.