### PR TITLE
amr-wind: does not require hypre with unified memory any longer

### DIFF
--- a/var/spack/repos/builtin/packages/amr-wind/package.py
+++ b/var/spack/repos/builtin/packages/amr-wind/package.py
@@ -39,7 +39,7 @@ class AmrWind(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('hypre~int64+shared@2.20.0:', when='+hypre')
     depends_on('hypre+mpi', when='+hypre+mpi')
     for arch in CudaPackage.cuda_arch_values:
-        depends_on('hypre+unified-memory+cuda cuda_arch=%s' % arch,
+        depends_on('hypre+cuda cuda_arch=%s' % arch,
                    when='+cuda+hypre cuda_arch=%s' % arch)
     for arch in ROCmPackage.amdgpu_targets:
         depends_on('hypre+rocm amdgpu_target=%s' % arch,


### PR DESCRIPTION
@eugeneswalker 