### PR TITLE
zlib: Correct configure script for Darwin

### DIFF
--- a/var/spack/repos/builtin/packages/zlib/darwin.patch
+++ b/var/spack/repos/builtin/packages/zlib/darwin.patch
@@ -1,0 +1,23 @@
+--- a/configure
++++ b/configure
+@@ -348,6 +348,20 @@
+              SFLAGS=${CFLAGS-"-O -qmaxmem=8192"}
+              CFLAGS=${CFLAGS-"-O -qmaxmem=8192"}
+              LDSHARED=${LDSHARED-"xlc -G"} ;;
++  Darwin* | darwin*)
++             shared_ext='.dylib'
++             CFLAGS="${CFLAGS--O3}"
++             SFLAGS="${CFLAGS--O3} -fPIC"
++             SHAREDLIB=${SHAREDLIB-"libz$shared_ext"}
++             SHAREDLIBV=${SHAREDLIBV-"libz$shared_ext.$VER"}
++             SHAREDLIBM=${SHAREDLIBM-"libz$shared_ext.$VER1"}
++             LDSHARED=${LDSHARED-"$CC -dynamiclib -install_name $libdir/$SHAREDLIBM -compatibility_version $VER1 -current_version $VER3"}
++             if libtool -V 2>&1 | grep Apple > /dev/null; then
++                 AR="libtool"
++             else
++                 AR="/usr/bin/libtool"
++             fi
++             ARFLAGS="-o" ;;
+   # send working options for other systems to zlib@gzip.org
+   *)         SFLAGS=${CFLAGS-"-O"}
+              CFLAGS=${CFLAGS-"-O"}

--- a/var/spack/repos/builtin/packages/zlib/package.py
+++ b/var/spack/repos/builtin/packages/zlib/package.py
@@ -19,11 +19,10 @@ class Zlib(Package):
     # URL must remain http:// so Spack can bootstrap curl
     url = "https://zlib.net/fossils/zlib-1.2.11.tar.gz"
 
-    version('1.2.11', sha256='c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1')
-    # Due to the bug fixes, any installations of 1.2.9 or 1.2.10 should be
-    # immediately replaced with 1.2.11.
-    version('1.2.8', sha256='36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d')
-    version('1.2.3', sha256='1795c7d067a43174113fdf03447532f373e1c6c57c08d61d9e4e9be5e244b05e')
+    version('1.2.12', sha256='91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9')
+    version('1.2.11', sha256='c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1', deprecated=True)
+    version('1.2.8', sha256='36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d', deprecated=True)
+    version('1.2.3', sha256='1795c7d067a43174113fdf03447532f373e1c6c57c08d61d9e4e9be5e244b05e', deprecated=True)
 
     variant('pic', default=True,
             description='Produce position-independent code (for shared libs)')
@@ -33,6 +32,7 @@ class Zlib(Package):
             description='Enable -O2 for a more optimized lib')
 
     patch('w_patch.patch', when="@1.2.11%cce")
+    patch('darwin.patch')
 
     @property
     def libs(self):


### PR DESCRIPTION
zlib's configure script does not work correctly for non-GCC compilers on Darwin. The respective code is missing form the configure script. This pull requests adds the missing code. I also submitted the patch to the zlib maintainers as requested in the zlib configure script.

Without this patch, zlib's shared library is called `zlib.so`, and they are missing rpath information. With this patch, the shared library is called `zlib.dylib` and the rpath information is present.

Without the correct rpath information, a Spack-built GCC cannot link against a Spack-built zlib. Usually no one notices because GCC will fall back to the system zlib, which is almost surely guaranteed to be present. This failed for me since I updated to zlib 1.2.12 locally, while my system has not updated yet.