### PR TITLE
Fix support for amber20 + ambertools21

### DIFF
--- a/var/spack/repos/builtin/packages/amber/package.py
+++ b/var/spack/repos/builtin/packages/amber/package.py
@@ -155,6 +155,10 @@ class Amber(Package, CudaPackage):
     conflicts('+openmp', when='%pgi',
               msg='OpenMP not available for the pgi compiler')
 
+    def url_for_version(self, version):
+        url = "file://{0}/Amber{1}.tar.bz2".format(os.getcwd(), version)
+        return url
+
     def setup_build_environment(self, env):
         amber_src = self.stage.source_path
         env.set('AMBERHOME', amber_src)

--- a/var/spack/repos/builtin/packages/amber/package.py
+++ b/var/spack/repos/builtin/packages/amber/package.py
@@ -104,6 +104,8 @@ class Amber(Package, CudaPackage):
         patch(patch_url_str.format(ver, num),
               sha256=checksum, level=0, when='@{0}'.format(ver))
 
+    # Patch to fix sebomd_module.F90
+    patch('sebomd_fix.patch', when='@20')
     # Patch to add ppc64le in config.guess
     patch('ppc64le.patch', when='@18: target=ppc64le:')
 

--- a/var/spack/repos/builtin/packages/amber/package.py
+++ b/var/spack/repos/builtin/packages/amber/package.py
@@ -132,6 +132,7 @@ class Amber(Package, CudaPackage):
     depends_on('bison', type='build')
     depends_on('netcdf-fortran')
     depends_on('parallel-netcdf', when='@20:')  # when='AmberTools@21:'
+    depends_on('tcsh', type=('build'), when='@20')  # when='AmberTools@21:'
     # Potential issues with openmpi 4
     # (http://archive.ambermd.org/201908/0105.html)
     depends_on('mpi', when='+mpi')
@@ -188,6 +189,10 @@ class Amber(Package, CudaPackage):
             compiler = 'clang'
         else:
             raise InstallError('Unknown compiler, exiting!!!')
+
+        # Alternative way to make csh/tcsh detection work with modules
+        filter_file(r'-x /bin/csh', 'command -v csh &> /dev/null/',
+                    'AmberTools/src/configure2', string=True)
 
         # Base configuration
         conf = Executable('./configure')

--- a/var/spack/repos/builtin/packages/amber/package.py
+++ b/var/spack/repos/builtin/packages/amber/package.py
@@ -104,8 +104,10 @@ class Amber(Package, CudaPackage):
         patch(patch_url_str.format(ver, num),
               sha256=checksum, level=0, when='@{0}'.format(ver))
 
-    # Patch to fix sebomd_module.F90
+    # Patch to move the namelist sebomd after the variable declarations
+    # Taken from http://archive.ambermd.org/202105/0098.html
     patch('sebomd_fix.patch', when='@20')
+
     # Patch to add ppc64le in config.guess
     patch('ppc64le.patch', when='@18: target=ppc64le:')
 

--- a/var/spack/repos/builtin/packages/amber/sebomd_fix.patch
+++ b/var/spack/repos/builtin/packages/amber/sebomd_fix.patch
@@ -1,0 +1,78 @@
+--- a/ambertools_tmpdir/AmberTools/src/sander/sebomd_module.F90	2019-08-01 09:29:43.000000000 -0300
++++ b/ambertools_tmpdir/AmberTools/src/sander/sebomd_module.F90	2022-03-30 09:07:07.635303955 -0300
+@@ -121,37 +121,6 @@
+     implicit none
+     integer :: stat
+ 
+-    namelist /sebomd/ hamiltonian, &
+-                      modif, &
+-                      ncore, &
+-                      dbuff1, &
+-                      dbuff2, &
+-                      charge_out, &
+-                      bond_order_out, &
+-                      lambda, &
+-                      peptk, &
+-                      method, &
+-                      charge, &
+-                      longrange, &
+-                      fullscf, &
+-                      ntwc, &
+-                      ntwb, &
+-                      chtype, &
+-                      chewald, &
+-                      screen, &
+-                      guess, &
+-                      pdump, &
+-                      ipolyn, &
+-                      nresidue, &
+-                      ntwh, &
+-                      iprec, &
+-                      peptcorr, &
+-                      debugmsg, &
+-                      debugforces, &
+-                      diag_routine, &
+-                      dpmax, &
+-                      bocut
+-   
+     character(10) :: hamiltonian
+     character(10) :: modif
+     integer :: method
+@@ -183,6 +152,37 @@
+     integer :: debugforces
+     integer :: diag_routine
+ 
++    namelist /sebomd/ hamiltonian, &
++                      modif, &
++                      ncore, &
++                      dbuff1, &
++                      dbuff2, &
++                      charge_out, &
++                      bond_order_out, &
++                      lambda, &
++                      peptk, &
++                      method, &
++                      charge, &
++                      longrange, &
++                      fullscf, &
++                      ntwc, &
++                      ntwb, &
++                      chtype, &
++                      chewald, &
++                      screen, &
++                      guess, &
++                      pdump, &
++                      ipolyn, &
++                      nresidue, &
++                      ntwh, &
++                      iprec, &
++                      peptcorr, &
++                      debugmsg, &
++                      debugforces, &
++                      diag_routine, &
++                      dpmax, &
++                      bocut
++   
+     hamiltonian =   sebomd_obj%hamiltonian
+     modif =   sebomd_obj%modif
+     method =   sebomd_obj%method


### PR DESCRIPTION
Currently, the package assumes that tcsh/csh is already installed on the system; it may not be, so add it as a dependency and patch AmberTools way of checking for it's existence
Aditionally, currently AmberTools21 ships with a broken sander module. Apply patch as detailed in mailing list
Finally, fix the spotty behaviour for versioning where sometimes amber@18 will correctly search for the file and other times it wont