### PR TITLE
canonicalize_path: add arch information to substitutions

### DIFF
--- a/lib/spack/docs/configuration.rst
+++ b/lib/spack/docs/configuration.rst
@@ -405,6 +405,17 @@ Spack understands several special variables. These are:
 * ``$user``: name of the current user
 * ``$user_cache_path``: user cache directory (``~/.spack`` unless
   :ref:`overridden <local-config-overrides>`)
+* ``$architecture``: the architecture triple of the current host, as
+  detected by Spack.
+* ``$arch``: alias for ``$architecture``.
+* ``$platform``: the platform of the current host, as detected by Spack.
+* ``$operating_system``: the operating system of the current host, as
+  detected by the ``distro`` python module.
+* ``$os``: alias for ``$operating_system``.
+* ``$target``: the ISA target for the current host, as detected by
+  ArchSpec. E.g. ``skylake`` or ``neoverse-n1``.
+* ``$target_family``. The target family for the current host, as
+  detected by ArchSpec. E.g. ``x86_64`` or ``aarch64``.
 
 Note that, as with shell variables, you can write these as ``$varname``
 or with braces to distinguish the variable from surrounding characters:

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -385,9 +385,12 @@ def test_substitute_config_variables(mock_low_high_config, monkeypatch):
         os.path.join('foo', '$platform', 'bar')
     ) == os.path.abspath(os.path.join('foo', 'test', 'bar'))
 
+    host_target = spack.platforms.host().target('default_target')
+    host_target_family = str(host_target.microarchitecture.family)
     assert spack_path.canonicalize_path(
         os.path.join('foo', '$target_family', 'bar')
-    ) == os.path.abspath(os.path.join('foo', platform.machine(), 'bar'))
+    ) == os.path.abspath(os.path.join('foo', host_target_family, 'bar'))
+
 
 packages_merge_low = {"packages": {"foo": {"variants": ["+v1"]}, "bar": {"variants": ["+v2"]}}}
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -6,7 +6,6 @@
 import collections
 import getpass
 import os
-import platform
 import sys
 import tempfile
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -6,6 +6,7 @@
 import collections
 import getpass
 import os
+import platform
 import sys
 import tempfile
 
@@ -379,6 +380,14 @@ def test_substitute_config_variables(mock_low_high_config, monkeypatch):
         os.path.join(mock_low_high_config.scopes["low"].path, os.path.join("foo", "bar", "baz"))
     )
 
+    # test architecture information is in replacements
+    assert spack_path.canonicalize_path(
+        os.path.join('foo', '$platform', 'bar')
+    ) == os.path.abspath(os.path.join('foo', 'test', 'bar'))
+
+    assert spack_path.canonicalize_path(
+        os.path.join('foo', '$target_family', 'bar')
+    ) == os.path.abspath(os.path.join('foo', platform.machine(), 'bar'))
 
 packages_merge_low = {"packages": {"foo": {"variants": ["+v1"]}, "bar": {"variants": ["+v2"]}}}
 

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -381,14 +381,14 @@ def test_substitute_config_variables(mock_low_high_config, monkeypatch):
 
     # test architecture information is in replacements
     assert spack_path.canonicalize_path(
-        os.path.join('foo', '$platform', 'bar')
-    ) == os.path.abspath(os.path.join('foo', 'test', 'bar'))
+        os.path.join("foo", "$platform", "bar")
+    ) == os.path.abspath(os.path.join("foo", "test", "bar"))
 
-    host_target = spack.platforms.host().target('default_target')
+    host_target = spack.platforms.host().target("default_target")
     host_target_family = str(host_target.microarchitecture.family)
     assert spack_path.canonicalize_path(
-        os.path.join('foo', '$target_family', 'bar')
-    ) == os.path.abspath(os.path.join('foo', host_target_family, 'bar'))
+        os.path.join("foo", "$target_family", "bar")
+    ) == os.path.abspath(os.path.join("foo", host_target_family, "bar"))
 
 
 packages_merge_low = {"packages": {"foo": {"variants": ["+v1"]}, "bar": {"variants": ["+v2"]}}}

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -27,16 +27,37 @@ is_windows = sys.platform == "win32"
 __all__ = ["substitute_config_variables", "substitute_path_variables", "canonicalize_path"]
 
 
+def architecture():
+    # break circular import
+    import spack.platforms
+    import spack.spec
+
+    host_platform = spack.platforms.host()
+    host_os = host_platform.operating_system('default_os')
+    host_target = host_platform.target('default_target')
+
+    return spack.spec.ArchSpec((str(host_platform), str(host_os), str(host_target)))
+
+
 # Substitutions to perform
 def replacements():
     # break circular import from spack.util.executable
     import spack.paths
+
+    arch = architecture()
 
     return {
         "spack": spack.paths.prefix,
         "user": getpass.getuser(),
         "tempdir": tempfile.gettempdir(),
         "user_cache_path": spack.paths.user_cache_path,
+        "architecture": str(arch),
+        "arch": str(arch),
+        "platform": str(arch.platform),
+        "operating_system": str(arch.os),
+        "os": str(arch.os),
+        "target": str(arch.target),
+        "target_family": str(arch.target.microarchitecture.family)
     }
 
 
@@ -245,6 +266,13 @@ def substitute_config_variables(path):
     - $tempdir           Default temporary directory returned by tempfile.gettempdir()
     - $user              The current user's username
     - $user_cache_path   The user cache directory (~/.spack, unless overridden)
+    - $architecture      The spack architecture triple for the current system
+    - $arch              The spack architecture triple for the current system
+    - $platform          The spack platform for the current system
+    - $os                The OS of the current system
+    - $operating_system  The OS of the current system
+    - $target            The ISA target detected for the system
+    - $target_family     The family of the target detected for the system
 
     These are substituted case-insensitively into the path, and users can
     use either ``$var`` or ``${var}`` syntax for the variables. $env is only

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -33,8 +33,8 @@ def architecture():
     import spack.spec
 
     host_platform = spack.platforms.host()
-    host_os = host_platform.operating_system('default_os')
-    host_target = host_platform.target('default_target')
+    host_os = host_platform.operating_system("default_os")
+    host_target = host_platform.target("default_target")
 
     return spack.spec.ArchSpec((str(host_platform), str(host_os), str(host_target)))
 
@@ -57,7 +57,7 @@ def replacements():
         "operating_system": str(arch.os),
         "os": str(arch.os),
         "target": str(arch.target),
-        "target_family": str(arch.target.microarchitecture.family)
+        "target_family": str(arch.target.microarchitecture.family),
     }
 
 


### PR DESCRIPTION
fixes #29815

This will allow users to use `include: [$arch/packages.yaml]` to include architecture-specific configs in their environments.

Requested by @elfprince13 on slack.

Includes unit test