### PR TITLE
Expand Spack on Windows build test

### DIFF
--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -75,9 +75,11 @@ jobs:
     - name: Build Test
       run: |
         spack compiler find
-        spack external find cmake
         spack external find ninja
-        spack -d install abseil-cpp
+        spack external find cmake
+        spack -d install python
+        spack -d install netlib-lapack
+        spack -d install hdf5
   # TODO: johnwparent - reduce the size of the installer operations
   # make-installer:
   #   runs-on: windows-latest

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -60,7 +60,7 @@ jobs:
     - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       with:
         flags: unittests,windows
-  build-abseil:
+  pkg-build-test:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
Add a number of integral packages to the Windows build test:
* CMake
* Ninja
* netlib-lapack
* Perl
* Python
* OpenSSL

This PR depends on #29711 and the resolution of #29576 