### PR TITLE
Allow "spack install foo@git-hash" without terminal prompt

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1474,7 +1474,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
         checksum = spack.config.get('config:checksum')
         fetch = self.stage.managed_by_spack
-        if checksum and fetch and self.version not in self.versions:
+        if checksum and fetch and (self.version not in self.versions) \
+                and (not self.version.is_commit):
             tty.warn("There is no checksum on file to fetch %s safely." %
                      self.spec.cformat('{name}{@version}'))
 


### PR DESCRIPTION
Do not prompt user with checksum warning when using git commit hashes as versions. Spack was incorrectly reporting this as a potential problem.

For example: with this PR, you can do:

`spack stage conduit@6d5f05f5fd1b5c201aba9a356ff40d718e2d61bb`

without getting a prompt about missing checksums (on current develop, this prompt will be displayed in the terminal or will terminate the running instance of Spack if running as part of a script).