### PR TITLE
LAPACK: add API compatibility versions

### DIFF
--- a/var/spack/repos/builtin/packages/atlas/package.py
+++ b/var/spack/repos/builtin/packages/atlas/package.py
@@ -50,6 +50,7 @@ class Atlas(Package):
 
     provides('blas')
     provides('lapack')
+    provides('lapack@3.6.1')
 
     parallel = False
 

--- a/var/spack/repos/builtin/packages/intel-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-mkl/package.py
@@ -77,6 +77,8 @@ class IntelMkl(IntelPackage):
 
     provides('blas')
     provides('lapack')
+    provides('lapack@3.9.0', when='@2020.4')
+    provides('lapack@3.7.0', when='@11.3')
     provides('scalapack')
     provides('mkl')
     provides('fftw-api@3', when='@2017:')

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -33,6 +33,7 @@ class NetlibLapack(CMakePackage):
     version('3.4.0', sha256='a7139ef97004d0e3c4c30f1c52d508fd7ae84b5fbaf0dd8e792c167dc306c3e9')
     version('3.3.1', sha256='56821ab51c29369a34e5085728f92c549a9aa926f26acf7eeac87b61eed329e4')
 
+    # netlib-lapack is the reference implementation of LAPACK
     for ver in [
         '3.9.1', '3.9.0', '3.8.0', '3.7.1', '3.7.0', '3.6.1',
         '3.6.0', '3.5.0', '3.4.2', '3.4.1', '3.4.0', '3.3.1'

--- a/var/spack/repos/builtin/packages/netlib-lapack/package.py
+++ b/var/spack/repos/builtin/packages/netlib-lapack/package.py
@@ -33,6 +33,12 @@ class NetlibLapack(CMakePackage):
     version('3.4.0', sha256='a7139ef97004d0e3c4c30f1c52d508fd7ae84b5fbaf0dd8e792c167dc306c3e9')
     version('3.3.1', sha256='56821ab51c29369a34e5085728f92c549a9aa926f26acf7eeac87b61eed329e4')
 
+    for ver in [
+        '3.9.1', '3.9.0', '3.8.0', '3.7.1', '3.7.0', '3.6.1',
+        '3.6.0', '3.5.0', '3.4.2', '3.4.1', '3.4.0', '3.3.1'
+    ]:
+        provides('lapack@' + ver, when='@' + ver)
+
     variant('shared', default=True, description="Build shared library version")
     variant('external-blas', default=False,
             description='Build lapack with an external blas')

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -64,6 +64,8 @@ class Openblas(MakefilePackage):
     # virtual dependency
     provides('blas')
     provides('lapack')
+    provides('lapack@3.9.1:', when='@0.3.15:')
+    provides('lapack@3.7.0', when='@0.2.20')
 
     # OpenBLAS >=3.0 has an official way to disable internal parallel builds
     patch('make.patch', when='@0.2.16:0.2.20')

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -86,6 +86,8 @@ class PyScipy(PythonPackage):
     # http://www.scipy.org/scipylib/building/linux.html#step-4-build-numpy-1-5-0
     depends_on('blas')
     depends_on('lapack')
+    # https://github.com/scipy/scipy/wiki/Dropping-support-for-Accelerate
+    depends_on('lapack@3.4.1:', when='@1.2:')
 
     # https://github.com/scipy/scipy/issues/12860
     patch('https://git.sagemath.org/sage.git/plain/build/pkgs/scipy/patches/extern_decls.patch?id=711fe05025795e44b84233e065d240859ccae5bd',

--- a/var/spack/repos/builtin/packages/veclibfort/package.py
+++ b/var/spack/repos/builtin/packages/veclibfort/package.py
@@ -25,7 +25,8 @@ class Veclibfort(Package):
 
     # virtual dependency
     provides('blas')
-    provides('lapack')
+    # https://github.com/scipy/scipy/wiki/Dropping-support-for-Accelerate
+    provides('lapack@3.2.1')
 
     @property
     def libs(self):


### PR DESCRIPTION
Certain packages like SciPy require minimal versions of the LAPACK API. This PR adds compatibility versions when known.

LAPACK providers:

- [ ] amdlibflame
- [x] atlas
- [ ] cray-libsci
- [ ] flexiblas
- [ ] fujitsu-ssl2
- [x] intel-mkl
- [ ] intel-oneapi-mkl
- [ ] intel-parallel-studio
- [ ] libflame
- [x] netlib-lapack
- [ ] nvhpc
- [x] openblas
- [x] veclibfort

Not sure where to find compatibility versions for the other providers. The authors of https://github.com/scipy/scipy/wiki/Dropping-support-for-Accelerate seem to have some idea. @rgommers can you or anyone else who helped write that wiki help with the other packages? I would like to specify as many as possible, we don't need to get all of them.

Fixes #29808 