### PR TITLE
ASP-based solver: allow configuring target selection

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -15,3 +15,16 @@ concretizer:
   # as possible, rather than building. If `false`, we'll always give you a fresh
   # concretization.
   reuse: false
+  # Options that tune which targets are considered for concretization. The
+  # concretization process is very sensitive to the number targets, and the time
+  # needed to reach a solution increases noticeably with the number of targets
+  # considered.
+  targets:
+    # Determine whether we want to target specific or generic microarchitectures.
+    # An example of the first kind might be for instance "skylake" or "bulldozer",
+    # while generic microarchitectures are for instance "aarch64" or "x86_64_v4".
+    granularity: microarchitectures
+    # If "false" allow targets that are incompatible with the current host (for
+    # instance concretize with target "icelake" while running on "haswell").
+    # If "true" only allow targets that are compatible with the host.
+    host_compatible: false

--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -219,26 +219,29 @@ Concretizer options
 but you can also use ``concretizer.yaml`` to customize aspects of the
 algorithm it uses to select the dependencies you install:
 
-.. _code-block: yaml
+.. literalinclude:: _spack_root/etc/spack/defaults/concretizer.yaml
+   :language: yaml
 
-   concretizer:
-     # Whether to consider installed packages or packages from buildcaches when
-     # concretizing specs. If `true`, we'll try to use as many installs/binaries
-     # as possible, rather than building. If `false`, we'll always give you a fresh
-     # concretization.
-     reuse: false
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Reuse already installed packages
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-^^^^^^^^^^^^^^^^
-``reuse``
-^^^^^^^^^^^^^^^^
-
-This controls whether Spack will prefer to use installed packages (``true``), or
+The ``reuse`` attribute controls whether Spack will prefer to use installed packages (``true``), or
 whether it will do a "fresh" installation and prefer the latest settings from
-``package.py`` files and ``packages.yaml`` (``false``). .
+``package.py`` files and ``packages.yaml`` (``false``).
+You can use:
 
-You can use ``spack install --reuse`` to enable reuse for a single installation,
-and you can use ``spack install --fresh`` to do a fresh install if ``reuse`` is
-enabled by default.
+.. code-block:: console
+
+   % spack install --reuse <spec>
+
+to enable reuse for a single installation, and you can use:
+
+.. code-block:: console
+
+   spack install --fresh <spec>
+
+to do a fresh install if ``reuse`` is enabled by default.
 
 .. note::
 
@@ -246,6 +249,40 @@ enabled by default.
    in the next Spack release. You will still be able to use ``spack install --fresh``
    to get the old behavior.
 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Selection of the target microarchitectures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The options under the ``targets`` attribute control which targets are considered during a solve.
+Currently the options in this section are only configurable from the ``concretization.yaml`` file
+and there are no corresponding command line arguments to enable them for a single solve.
+
+The ``granularity`` option can take two possible values: ``microarchitectures`` and ``generic``.
+If set to:
+
+.. code-block:: yaml
+
+   concretizer:
+     targets:
+       granularity: microarchitectures
+
+Spack will consider all the microarchitectures known to ``archspec`` to label nodes for
+compatibility. If instead the option is set to:
+
+.. code-block:: yaml
+
+   concretizer:
+     targets:
+       granularity: generic
+
+Spack will consider only generic microarchitectures. For instance, when running on an
+Haswell node, Spack will consider ``haswell`` as the best target in the former case and
+``x86_64_v3`` as the best target in the latter case.
+
+The ``host_compatible`` option is a Boolean option that determines whether or not the
+microarchitectures considered during the solve are constrained to be compatible with the
+host Spack is currently running on. For instance, if this option is set to ``true``, a
+user cannot concretize for ``target=icelake`` while running on an Haswell node.
 
 .. _package-preferences:
 

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -15,6 +15,16 @@ properties = {
         'additionalProperties': False,
         'properties': {
             'reuse': {'type': 'boolean'},
+            'targets': {
+                'type': 'object',
+                'properties': {
+                    'host_compatible': {'type': 'boolean'},
+                    'granularity': {
+                        'type': 'string',
+                        'enum': ['generic', 'microarchitectures']
+                    }
+                }
+            },
         }
     }
 }

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1479,8 +1479,11 @@ class SpackSolverSetup(object):
                 self.target_ranges(spec, None)
                 continue
 
-            if target not in candidate_targets:
+            if target not in candidate_targets and not host_compatible:
                 candidate_targets.append(target)
+                for ancestor in target.ancestors:
+                    if ancestor not in candidate_targets:
+                        candidate_targets.append(ancestor)
 
         i = 0
         for target in candidate_targets:

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -1499,7 +1499,7 @@ class TestConcretize(object):
         with spack.config.override('concretizer:targets', {'granularity': 'generic'}):
             assert s.concretized().satisfies('target=x86_64')
 
-    def test_host_compatible_concretization(self, monkeypatch):
+    def test_host_compatible_concretization(self):
         if spack.config.get('config:concretizer') == 'original':
             pytest.skip(
                 'Original concretizer cannot account for host compatibility'
@@ -1515,3 +1515,15 @@ class TestConcretize(object):
         with spack.config.override('concretizer:targets', {'host_compatible': True}):
             with pytest.raises(spack.error.SpackError):
                 s.concretized()
+
+    def test_add_microarchitectures_on_explicit_request(self):
+        if spack.config.get('config:concretizer') == 'original':
+            pytest.skip(
+                'Original concretizer cannot account for host compatibility'
+            )
+
+        # Check that if we consider only "generic" targets, we can still solve for
+        # specific microarchitectures on explicit requests
+        with spack.config.override('concretizer:targets', {'granularity': 'generic'}):
+            s = Spec('python target=k10').concretized()
+        assert s.satisfies('target=k10')

--- a/lib/spack/spack/test/data/config/concretizer.yaml
+++ b/lib/spack/spack/test/data/config/concretizer.yaml
@@ -1,0 +1,5 @@
+concretizer:
+  # reuse is missing on purpose, see "test_concretizer_arguments"
+  targets:
+    granularity: microarchitectures
+    host_compatible: false


### PR DESCRIPTION
fixes #29672 

This commit adds a new `concretizer:targets` configuration section, and two options under it.
 1.  `concretizer:targets:granularity` allows switching from considering only generic targets to consider all possible microarchitectures.
 2. `concretizer:targets:host_compatible` instead controls whether we can concretize for microarchitectures that are incompatible with the current host.

Modifications:

- [x] Add new handles to configure the solver
- [x] Add documentation
- [x] Add unit tests