### PR TITLE
scotch: use libesmumps instead of libptesmumps for +mpi+esmumps

### DIFF
--- a/var/spack/repos/builtin/packages/scotch/package.py
+++ b/var/spack/repos/builtin/packages/scotch/package.py
@@ -87,10 +87,12 @@ class Scotch(CMakePackage):
 
         if '+mpi' in self.spec:
             libraries = ['libptscotch', 'libptscotcherr'] + libraries
-            if '+esmumps' in self.spec:
+
+        if '+esmumps' in self.spec:
+            if '~mpi' in self.spec or self.spec.version >= Version('7.0.0'):
+                libraries = ['libesmumps'] + libraries
+            else:
                 libraries = ['libptesmumps'] + libraries
-        elif '~mpi+esmumps' in self.spec:
-            libraries = ['libesmumps'] + libraries
 
         scotchlibs = find_libraries(
             libraries, root=self.prefix, recursive=True, shared=shared


### PR DESCRIPTION
`scotch +mpi+esmumps` no longer generates a `libptesmumps` library since the switch to CMake in 7.x. (https://gitlab.inria.fr/scotch/scotch/-/blob/v7.0.0/src/esmumps/CMakeLists.txt#L92)
This PR adds `libesmumps` to its libs instead.

Fixes `mumps +ptscotch` build failures.