### PR TITLE
fakexrandr: mkdir for install

### DIFF
--- a/var/spack/repos/builtin/packages/fakexrandr/package.py
+++ b/var/spack/repos/builtin/packages/fakexrandr/package.py
@@ -49,5 +49,5 @@ class Fakexrandr(MakefilePackage):
     # If it does not exist, process will stop.
     @run_before('install')
     def make_target_dir(self):
-        mkdir(self.prefix.lib)
-        mkdir(self.prefix.bin)
+        mkdirp(self.prefix.lib)
+        mkdirp(self.prefix.bin)

--- a/var/spack/repos/builtin/packages/fakexrandr/package.py
+++ b/var/spack/repos/builtin/packages/fakexrandr/package.py
@@ -44,3 +44,10 @@ class Fakexrandr(MakefilePackage):
 
         if 'platform=darwin' in spec:
             makefile.filter('ldconfig', '')
+
+    # In Makefile, install commands check the target dir.
+    # If it does not exist, process will stop.
+    @run_before('install')
+    def make_target_dir(self):
+        mkdir(self.prefix.lib)
+        mkdir(self.prefix.bin)


### PR DESCRIPTION
This patch fixes a bug of unexisted target directory. 

In Makefile, install commands check the target dir.
If it does not exist, process will stop. 
So, this patch creates target directories before 'install' stage.

BTW, In install commands, the "ldconfig" is unnecessary.
And sometimes it will fail.  I want to fix it in next patch.