### PR TITLE
cmake: improve `~/+ownlibs`

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -157,8 +157,8 @@ class Cmake(Package):
     variant('ownlibs', default=True,  description='Use CMake-provided third-party libraries')
     variant('qt',      default=False, description='Enables the build of cmake-gui')
     variant('doc',     default=False, description='Enables the generation of html and man page documentation')
-    variant('openssl', default=True,  description="Enable openssl for curl bootstrapped by CMake when using +ownlibs")
-    variant('ncurses', default=os.name != 'nt',  description='Enables the build of the ncurses gui')
+    variant('openssl', default=True,  description="Enable OpenSSL for curl bootstrapped by CMake", when='+ownlibs')
+    variant('ncurses', default=os.name != 'nt', description='Enables the build of the ncurses gui')
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts('%gcc platform=darwin', when='@:3.17',
@@ -171,12 +171,6 @@ class Cmake(Package):
     conflicts('+ownlibs %nvhpc')
     conflicts('+ncurses %nvhpc')
 
-    # Really this should conflict since it's enabling or disabling openssl for
-    # CMake's internal copy of curl.  Ideally we'd want a way to have the
-    # openssl variant disabled when ~ownlibs but there's not really a way to
-    # tie the values of those togethor, so for now we're just going to ignore
-    # the openssl variant entirely when ~ownlibs
-    # conflicts('~ownlibs', when='+openssl')
 
     depends_on('curl',           when='~ownlibs')
     depends_on('expat',          when='~ownlibs')

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -171,23 +171,21 @@ class Cmake(Package):
     conflicts('+ownlibs %nvhpc')
     conflicts('+ncurses %nvhpc')
 
+    with when('~ownlibs'):
+        depends_on('curl')
+        # cmake really wants expat to be used instead of libxml2...
+        depends_on('libarchive@3.1.0: xar=expat')
+        depends_on('libarchive@3.3.3:', when='@3.15.0:')
+        depends_on('libuv@1.0.0:')
+        depends_on('libuv@:1.10', when='@:3.11')
+        depends_on('libuv@1.10.0:', when='@3.12.0:')
+        depends_on('rhash', when='@3.8.0:')
 
-    depends_on('curl',           when='~ownlibs')
-    depends_on('expat',          when='~ownlibs')
-    depends_on('zlib',           when='~ownlibs')
-    depends_on('bzip2',          when='~ownlibs')
-    depends_on('xz',             when='~ownlibs')
-    depends_on('libarchive@3.1.0:', when='~ownlibs')
-    depends_on('libarchive@3.3.3:',     when='@3.15.0:~ownlibs')
-    depends_on('libuv@1.0.0:1.10',   when='@3.7.0:3.10.3~ownlibs')
-    depends_on('libuv@1.10.0:1.10',  when='@3.11.0:3.11~ownlibs')
-    depends_on('libuv@1.10.0:',  when='@3.12.0:~ownlibs')
-    depends_on('rhash',          when='@3.8.0:~ownlibs')
     depends_on('qt',             when='+qt')
     depends_on('python@2.7.11:', when='+doc', type='build')
     depends_on('py-sphinx',      when='+doc', type='build')
-    depends_on('openssl', when='+openssl+ownlibs')
-    depends_on('openssl@:1.0', when='@:3.6.9+openssl+ownlibs')
+    depends_on('openssl',        when='+openssl')
+    depends_on('openssl@:1.0',   when='@:3.6.9+openssl')
     depends_on('ncurses',        when='+ncurses')
 
     # Cannot build with Intel, should be fixed in 3.6.2
@@ -322,7 +320,7 @@ class Cmake(Package):
         rpaths = spack.build_environment.get_rpaths(self)
         prefixes = spack.build_environment.get_cmake_prefix_path(self)
         args.extend([
-            '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF',
+            '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON',
             '-DCMAKE_INSTALL_RPATH={0}'.format(";".join(str(v) for v in rpaths)),
             '-DCMAKE_PREFIX_PATH={0}'.format(";".join(str(v) for v in prefixes))
         ])

--- a/var/spack/repos/builtin/packages/mono/package.py
+++ b/var/spack/repos/builtin/packages/mono/package.py
@@ -23,9 +23,7 @@ class Mono(AutotoolsPackage):
             description='Point SpecialFolder.CommonApplicationData folder '
             'into Spack installation instead of /usr/share')
 
-    # Spack's openssl interacts badly with mono's vendored
-    # "boringssl", don't drag it in w/ cmake
-    depends_on('cmake~openssl', type=('build'))
+    depends_on('cmake', type=('build'))
     depends_on('iconv')
     depends_on('perl', type=('build'))
     depends_on('python', type=('build'))


### PR DESCRIPTION
- Make openssl variant depend on +ownlibs
- Fix dependencies when ~ownlibs

With the latest libuv (which includes a configure script, so no more autotools as deps) we now get:

```console
$ spack spec cmake~ownlibs~ncurses ^curl tls=mbedtls ^libarchive compression=zlib
Input spec
--------------------------------
cmake~ncurses~ownlibs
    ^curl tls=mbedtls
    ^libarchive compression=zlib

Concretized
--------------------------------
cmake@3.23.0%gcc@11.2.0~doc~ncurses~ownlibs~qt build_type=Release arch=linux-ubuntu20.04-zen2
    ^curl@7.78.0%gcc@11.2.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2~nghttp2 tls=mbedtls arch=linux-ubuntu20.04-zen2
        ^mbedtls@2.28.0%gcc@11.2.0+pic build_type=Release libs=static arch=linux-ubuntu20.04-zen2
        ^pkgconf@1.8.0%gcc@11.2.0 arch=linux-ubuntu20.04-zen2
        ^zlib@1.2.11%gcc@11.2.0+optimize+pic+shared arch=linux-ubuntu20.04-zen2
    ^libarchive@3.5.2%gcc@11.2.0+iconv compression=zlib crypto=mbedtls libs=shared,static programs=none xar=expat arch=linux-ubuntu20.04-zen2
        ^expat@2.4.6%gcc@11.2.0+libbsd arch=linux-ubuntu20.04-zen2
            ^libbsd@0.11.5%gcc@11.2.0 arch=linux-ubuntu20.04-zen2
                ^libmd@1.0.4%gcc@11.2.0 arch=linux-ubuntu20.04-zen2
        ^libiconv@1.16%gcc@11.2.0 libs=shared,static arch=linux-ubuntu20.04-zen2
    ^libuv@1.44.1%gcc@11.2.0 arch=linux-ubuntu20.04-zen2
    ^rhash@1.4.2%gcc@11.2.0 patches=093518c,3fbfe46 arch=linux-ubuntu20.04-zen2
```

