### PR TITLE
cmake: build with %nvhpc

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -165,7 +165,11 @@ class Cmake(Package):
               msg='CMake <3.18 does not compile with GCC on macOS, '
                   'please use %apple-clang or a newer CMake release. '
                   'See: https://gitlab.kitware.com/cmake/cmake/-/issues/21135')
-    conflicts('%nvhpc')
+
+    # Seems like the vendored dependencies do not build with nvhpc, and linking with
+    # ncurses runs into issues.
+    conflicts('+ownlibs %nvhpc')
+    conflicts('+ncurses %nvhpc')
 
     # Really this should conflict since it's enabling or disabling openssl for
     # CMake's internal copy of curl.  Ideally we'd want a way to have the


### PR DESCRIPTION
Needs a couple of the other PRs so that the concretizer picks up the nvhpc-compilable deps for libarchive and curl
