### PR TITLE
perl: conflict with unpatched releases for %nvhpc

### DIFF
--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -109,6 +109,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
     # the mini Perl environment to bootstrap installation.
     patch('nvhpc-5.30.patch', when='@5.30.0:5.30 %nvhpc')
     patch('nvhpc-5.32.patch', when='@5.32.0:5.32 %nvhpc')
+    conflicts('@5.34.0:', when='%nvhpc')  # todo, add patches...
     conflicts('@5.32.0:', when='%nvhpc@:20.11',
               msg='The NVIDIA compilers are incompatible with version 5.32 and later')
 


### PR DESCRIPTION
There are no build script patches like https://github.com/spack/spack/pull/21975 for `perl@5.34:%nvhpc`, so add a conflict for now

Hopefully NVIDIA can fix the Perl configure script upstream so we don't have to
patch literally every perl release.

Ping @samcmill

