### PR TITLE
rocmlibs: relax rocm-cmake version requirements

### DIFF
--- a/var/spack/repos/builtin/packages/comgr/package.py
+++ b/var/spack/repos/builtin/packages/comgr/package.py
@@ -47,6 +47,8 @@ class Comgr(CMakePackage):
     depends_on('z3', type='link')
     depends_on('ncurses', type='link')
 
+    depends_on('rocm-cmake@3.5.0:', type='build')
+
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2',
                 'master']:
@@ -56,6 +58,5 @@ class Comgr(CMakePackage):
         # aomp may not build rocm-device-libs as part of llvm-amdgpu, so make
         # that a conditional dependency
         depends_on('rocm-device-libs@' + ver, when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     root_cmakelists_dir = join_path('lib', 'comgr')

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -36,6 +36,8 @@ class Hipblas(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
+    depends_on('cmake@3.5:', type='build')
+
     depends_on('googletest@1.10.0:', type='test')
     depends_on('netlib-lapack@3.7.1:', type='test')
     depends_on('boost@1.64.0:1.76.0 cxxstd=14', type='test')
@@ -55,7 +57,7 @@ class Hipblas(CMakePackage):
         depends_on('rocsolver@' + ver, when='@' + ver)
         depends_on('rocblas@' + ver, type='link', when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     @classmethod
     def determine_version(cls, lib):

--- a/var/spack/repos/builtin/packages/hipblas/package.py
+++ b/var/spack/repos/builtin/packages/hipblas/package.py
@@ -55,7 +55,7 @@ class Hipblas(CMakePackage):
                 '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('rocsolver@' + ver, when='@' + ver)
-        depends_on('rocblas@' + ver, type='link', when='@' + ver)
+        depends_on('rocblas@' + ver, when='@' + ver)
         depends_on('comgr@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/hipcub/package.py
+++ b/var/spack/repos/builtin/packages/hipcub/package.py
@@ -32,7 +32,8 @@ class Hipcub(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.10.2:', type='build', when='@4.2.0:')
+    depends_on('cmake@3.5.1:', type='build')
     depends_on('numactl', type='link', when='@3.7.0:')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
@@ -40,7 +41,7 @@ class Hipcub(CMakePackage):
                 '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('rocprim@' + ver, when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/hipfft/package.py
+++ b/var/spack/repos/builtin/packages/hipfft/package.py
@@ -33,11 +33,11 @@ class Hipfft(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.5:', type='build')
 
     for ver in ['4.1.0', '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('rocfft@' + ver, when='@' + ver)
 

--- a/var/spack/repos/builtin/packages/hipfort/package.py
+++ b/var/spack/repos/builtin/packages/hipfort/package.py
@@ -30,13 +30,14 @@ class Hipfort(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.0.2:', type='build')
+
+    depends_on('rocm-cmake@3.8.0:', type='build')
 
     for ver in ['3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0',
                 '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
         depends_on('hip@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/hipsolver/package.py
+++ b/var/spack/repos/builtin/packages/hipsolver/package.py
@@ -27,11 +27,13 @@ class Hipsolver(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
+    depends_on('cmake@3.5:', type='build')
+
     for ver in ['4.5.0', '4.5.2', '5.0.0', '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('rocblas@' + ver, when='@' + ver)
         depends_on('rocsolver@' + ver, when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/hipsparse/package.py
+++ b/var/spack/repos/builtin/packages/hipsparse/package.py
@@ -33,15 +33,15 @@ class Hipsparse(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.5:', type='build')
     depends_on('git', type='build')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('rocsparse@' + ver,                when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                         when='@' + ver)
+        depends_on('rocsparse@' + ver,                   when='@' + ver)
     for ver in ['3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0',
                 '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:
         depends_on('rocprim@' + ver, when='@' + ver)

--- a/var/spack/repos/builtin/packages/migraphx/package.py
+++ b/var/spack/repos/builtin/packages/migraphx/package.py
@@ -44,7 +44,7 @@ class Migraphx(CMakePackage):
     patch('0001-Adding-nlohmann-json-include-directory.patch', when='@3.9.0:')
     patch('0002-restrict-python-2.7-usage.patch', when='@3.9.0:')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.5:', type='build')
     depends_on('protobuf', type='link')
     depends_on('blaze', type='build')
     depends_on('nlohmann-json', type='link')
@@ -56,11 +56,11 @@ class Migraphx(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
-        depends_on('rocblas@' + ver,                  when='@' + ver)
-        depends_on('miopen-hip@' + ver,               when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                         when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,                 when='@' + ver)
+        depends_on('rocblas@' + ver,                     when='@' + ver)
+        depends_on('miopen-hip@' + ver,                  when='@' + ver)
 
     @property
     def cmake_python_hints(self):

--- a/var/spack/repos/builtin/packages/miopen-hip/package.py
+++ b/var/spack/repos/builtin/packages/miopen-hip/package.py
@@ -34,7 +34,7 @@ class MiopenHip(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.5:', type='build')
     depends_on('pkgconfig', type='build')
 
     # TODO: replace this with an explicit list of components of Boost,
@@ -52,7 +52,7 @@ class MiopenHip(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
         depends_on('hip@' + ver,                      when='@' + ver)
         depends_on('rocm-clang-ocl@' + ver,           when='@' + ver)
         depends_on('rocblas@' + ver,                  when='@' + ver)

--- a/var/spack/repos/builtin/packages/miopen-opencl/package.py
+++ b/var/spack/repos/builtin/packages/miopen-opencl/package.py
@@ -34,7 +34,7 @@ class MiopenOpencl(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.5:', type='build')
     depends_on('boost@1.67.0:1.73.0', type='link')
 
     # TODO: replace this with an explicit list of components of Boost,
@@ -50,9 +50,9 @@ class MiopenOpencl(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('rocm-opencl@' + ver,              when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                         when='@' + ver)
+        depends_on('rocm-opencl@' + ver,                 when='@' + ver)
 
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -46,14 +46,14 @@ class Rccl(CMakePackage):
     patch('0001-Fix-numactl-path-issue.patch', when='@3.7.0:4.3.2')
     patch('0002-Fix-numactl-rocm-smi-path-issue.patch', when='@4.5.0:')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.5:', type='build')
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
-        depends_on('rocm-cmake@' + ver,   type='build', when='@' + ver)
-        depends_on('hip@' + ver,                        when='@' + ver)
-        depends_on('comgr@' + ver,                      when='@' + ver)
-        depends_on('hsa-rocr-dev@' + ver,               when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                         when='@' + ver)
+        depends_on('comgr@' + ver,                       when='@' + ver)
+        depends_on('hsa-rocr-dev@' + ver,                when='@' + ver)
 
     for ver in ['3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0',
                 '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -59,7 +59,7 @@ class Rocalution(CMakePackage):
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
         depends_on('comgr@' + ver, when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0',
                 '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -68,10 +68,10 @@ class Rocblas(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:
-        depends_on('hip@' + ver,                        when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,                when='@' + ver)
-        depends_on('rocminfo@' + ver,     type='build', when='@' + ver)
-        depends_on('rocm-cmake@%s:'% ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                         when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,                 when='@' + ver)
+        depends_on('rocminfo@' + ver,     type='build',  when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0']:
         depends_on('rocm-smi@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -68,10 +68,10 @@ class Rocblas(CMakePackage):
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:
-        depends_on('hip@' + ver,                       when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,               when='@' + ver)
-        depends_on('rocm-cmake@' + ver,  type='build', when='@' + ver)
-        depends_on('rocminfo@' + ver,    type='build', when='@' + ver)
+        depends_on('hip@' + ver,                        when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,                when='@' + ver)
+        depends_on('rocminfo@' + ver,     type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:'% ver, type='build', when='@' + ver)
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0']:
         depends_on('rocm-smi@' + ver, type='build', when='@' + ver)

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -48,8 +48,8 @@ class Rocfft(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2']:
-        depends_on('hip@' + ver,                      when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('hip@' + ver,                         when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     patch('0001-Improve-compilation-by-using-sqlite-recipe-for-rocfft.patch', when='@5.0.0:5.0.2')
 

--- a/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
+++ b/var/spack/repos/builtin/packages/rocm-clang-ocl/package.py
@@ -33,13 +33,13 @@ class RocmClangOcl(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.5:', type='build')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2',
                 'master']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver,                 when='@' + ver)
 
         # support both builtin and standalone device libs
         depends_on('rocm-device-libs@' + ver, when='@{0} ^llvm-amdgpu ~rocm-device-libs'.format(ver))

--- a/var/spack/repos/builtin/packages/rocm-device-libs/package.py
+++ b/var/spack/repos/builtin/packages/rocm-device-libs/package.py
@@ -35,9 +35,13 @@ class RocmDeviceLibs(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.13.4:', type='build', when='@3.9.0:')
+    depends_on('cmake@3.4.3:', type='build')
+
     depends_on('zlib', type='link', when='@3.9.0:')
     depends_on('texinfo', type='link', when='@3.9.0:')
+
+    depends_on('rocm-cmake@3.5.0:', type='build')
 
     # Make sure llvm is not built with rocm-device-libs (that is, it's already
     # built with rocm-device-libs as an external project).
@@ -46,8 +50,7 @@ class RocmDeviceLibs(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2',
                 'master']:
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver,              when='@' + ver)
+        depends_on('llvm-amdgpu@' + ver, when='@' + ver)
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -37,7 +37,8 @@ class Rocprim(CMakePackage):
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.10.2:', type='build', when='@4.2.0:')
+    depends_on('cmake@3.5.1:', type='build')
     depends_on('numactl', type='link', when='@3.7.0:')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
@@ -47,7 +48,7 @@ class Rocprim(CMakePackage):
         depends_on('comgr@' + ver, when='@' + ver)
         depends_on('hsa-rocr-dev@' + ver, when='@' + ver)
         depends_on('llvm-amdgpu@' + ver, when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -49,7 +49,7 @@ class Rocrand(CMakePackage):
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -65,7 +65,7 @@ class Rocsolver(CMakePackage):
         for tgt in itertools.chain(['auto'], amdgpu_targets):
             depends_on('rocblas@{0} amdgpu_target={1}'.format(ver, tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -43,7 +43,7 @@ class Rocsparse(CMakePackage):
     version('3.7.0', sha256='db561ae5e8ee117f7c539a9ef6ee49c13b82ba9f702b22c76e741cca245386a9', deprecated=True)
     version('3.5.0', sha256='9ca6bae7da78abbb47143c3d77ff4a8cd7d63979875fc7ebc46b400769fd9cb5', deprecated=True)
 
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.5:', type='build')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0', '5.0.2']:
@@ -51,7 +51,7 @@ class Rocsparse(CMakePackage):
         for tgt in itertools.chain(['auto'], amdgpu_targets):
             depends_on('rocprim@{0} amdgpu_target={1}'.format(ver, tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/rocthrust/package.py
+++ b/var/spack/repos/builtin/packages/rocthrust/package.py
@@ -35,7 +35,8 @@ class Rocthrust(CMakePackage):
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"),
             description='CMake build type')
-    depends_on('cmake@3:', type='build')
+    depends_on('cmake@3.10.2:', type='build', when='@4.2.0:')
+    depends_on('cmake@3.5.1:', type='build')
     depends_on('numactl', when='@3.7.0:')
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
@@ -43,7 +44,7 @@ class Rocthrust(CMakePackage):
                 '5.0.2']:
         depends_on('hip@' + ver, when='@' + ver)
         depends_on('rocprim@' + ver, when='@' + ver)
-        depends_on('rocm-cmake@' + ver, type='build', when='@' + ver)
+        depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -91,7 +91,6 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     for amdgpu_value in ROCmPackage.amdgpu_targets:
         depends_on("kokkos amdgpu_target=%s" % amdgpu_value, when="+kokkos +rocm amdgpu_target=%s" % amdgpu_value)
 
-    depends_on("rocm-cmake@3.7:", when="+rocm")
     depends_on("hip@3.7:", when="+rocm")
 
     # The rocm variant is only valid options for >= 1.7. It would be better if


### PR DESCRIPTION
The rocm-cmake modules tend to be backwards-compatible, to the extent that most ROCm math libraries were downloading and building the `rocm-cmake` master branch for a long while without anybody noticing. It was only noticed when someone tried compiling without an internet connection. That was fixed in 97f0c3ccd9f0a40896998a7580150a514ec3bc37.

Some packages, like comgr, barely use rocm-cmake for anything, and we can easily set a very minimal version requirement. For most packages, however, it would be a lot of effort to determine the minimum rocm-cmake version required for each release. For those packages, I just turned the exact version requirement into a minimum version requirement.

Since I was looking through the CMakeLists.txt for a large number of libraries, I also took note of the `cmake_minimum_required` and adjusted the cmake minimum requirements to match.

Also:
+ A minor tweak to the hipBLAS dependency list. `rocblas.h` is needed at build-time.
+ Removed dependency on rocm-cmake from vtk-m, since it looks like a mistake. I can't find anywhere that it actually uses rocm-cmake functionality.