### PR TITLE
Add or-tools package.

### DIFF
--- a/var/spack/repos/builtin/packages/or-tools/package.py
+++ b/var/spack/repos/builtin/packages/or-tools/package.py
@@ -16,7 +16,6 @@ class OrTools(CMakePackage):
     version('7.8', sha256='d93a9502b18af51902abd130ff5f23768fcf47e266e6d1f34b3586387aa2de68')
     variant('coin', default=False)
     depends_on('cmake@3.14:', type='build')
-    depends_on('protobuf@3.12.2:')
     depends_on('gflags@2.2.2')
     depends_on('glog@0.4.0')
     depends_on('protobuf@3.12.2')

--- a/var/spack/repos/builtin/packages/or-tools/package.py
+++ b/var/spack/repos/builtin/packages/or-tools/package.py
@@ -14,26 +14,23 @@ class OrTools(CMakePackage):
     maintainers = ['hyoklee']
 
     version('7.8', sha256='d93a9502b18af51902abd130ff5f23768fcf47e266e6d1f34b3586387aa2de68')
-    variant('coin', default=False)
+    variant('coin', default=False, description='Enable COIN-OR solvers.')
     depends_on('cmake@3.14:', type='build')
-    depends_on('gflags@2.2.2')
-    depends_on('glog@0.4.0')
-    depends_on('protobuf@3.12.2')
-    depends_on('abseil-cpp@20200225.2')
-    depends_on('cbc@2.10.5')
-    depends_on('cgl@0.60.3')
-    depends_on('clp@1.17.4')
-    depends_on('osi@0.108.6')
-    depends_on('coinutils@2.11.4', when='+coin')
+    depends_on('gflags@2.2.2:')
+    depends_on('glog@0.4.0:')
+    depends_on('protobuf@3.12.2:')
+    depends_on('abseil-cpp@20200225.2:')
+    depends_on('cbc@2.10.5:')
+    depends_on('cgl@0.60.3:')
+    depends_on('clp@1.17.4:')
+    depends_on('osi@0.108.6:')
+    depends_on('coinutils@2.11.4:', when='+coin')
 
     def cmake_args(self):
         cmake_args = []
         cmake_args.append('-DBUILD_DEPS=OFF')
         cmake_args.append('-DBUILD_PYTHON=OFF')
-        if '+coin' in self.spec:
-            cmake_args.append('-DUSE_COINOR=ON')
-        else:
-            cmake_args.append('-DUSE_COINOR=OFF')
+        cmake_args.append(self.define_from_variant('USE_COINOR', 'coin'))
         cmake_args.append('-DUSE_SCIP=ON')
         cmake_args.append('-DBUILD_SCIP=ON')
         cmake_args.append('-DBUILD_TESTING=OFF')

--- a/var/spack/repos/builtin/packages/or-tools/package.py
+++ b/var/spack/repos/builtin/packages/or-tools/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+class OrTools(CMakePackage):
+    """This project hosts operations research tools developed at
+    Google and made available as open source under the Apache 2.0
+    License."""
+
+    homepage = "https://developers.google.com/optimization/"
+    url      = "https://github.com/google/or-tools/archive/v7.8.tar.gz"
+    maintainers = ['hyoklee']
+
+    version('7.8', sha256='d93a9502b18af51902abd130ff5f23768fcf47e266e6d1f34b3586387aa2de68')
+    variant('coin', default=False)
+    depends_on('cmake@3.14:', type='build')
+    depends_on('protobuf@3.12.2:')
+    depends_on('gflags@2.2.2')
+    depends_on('glog@0.4.0')
+    depends_on('protobuf@3.12.2')
+    depends_on('abseil-cpp@20200225.2')
+    depends_on('cbc@2.10.5')
+    depends_on('cgl@0.60.3')
+    depends_on('clp@1.17.4')
+    depends_on('osi@0.108.6')
+    depends_on('coinutils@2.11.4', when='+coin')
+
+    def cmake_args(self):
+        cmake_args = []
+        cmake_args.append('-DBUILD_DEPS=OFF')
+        cmake_args.append('-DBUILD_PYTHON=OFF')
+        if '+coin' in self.spec:
+            cmake_args.append('-DUSE_COINOR=ON')
+        else:
+            cmake_args.append('-DUSE_COINOR=OFF')
+        cmake_args.append('-DUSE_SCIP=ON')
+        cmake_args.append('-DBUILD_SCIP=ON')
+        cmake_args.append('-DBUILD_TESTING=OFF')
+        return cmake_args


### PR DESCRIPTION
This is a OR-tools package for C++ users with minimal dependency for fast installation. 
While py-or-tools package requires manual download for dependency, this one doesn't.
This package will be useful for C/C++ packages that depend on OR-Tools.

This will close #29839. 