### PR TITLE
New package: ufcx

### DIFF
--- a/var/spack/repos/builtin/packages/ufcx/package.py
+++ b/var/spack/repos/builtin/packages/ufcx/package.py
@@ -7,7 +7,7 @@ from spack import *
 
 
 class Ufcx(CMakePackage):
-    """FFCx provides the ufcx.h interface header for finite element kernels, 
+    """FFCx provides the ufcx.h interface header for finite element kernels,
        used by DOLFINx. ufcx.h can be installed from the FFCx repo without
        making it dependent on Python.
     """

--- a/var/spack/repos/builtin/packages/ufcx/package.py
+++ b/var/spack/repos/builtin/packages/ufcx/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Ufcx(CMakePackage):
+    """FFCx provides the ufcx.h interface header for finite element kernels, 
+       used by DOLFINx. ufcx.h can be installed from the FFCx repo without
+       making it dependent on Python.
+    """
+
+    homepage = 'https://github.com/FEniCS/ffcx'
+    git = 'https://github.com/FEniCS/ffcx.git'
+    url = 'https://github.com/FEniCS/ffcx/archive/refs/heads/main.zip'
+    maintainers = ['ma595']
+
+    version('main', branch='main')
+
+    root_cmakelists_dir = 'cmake'


### PR DESCRIPTION
FFCx provides the ufcx.h interface header for finite element kernels, used by DOLFINx. ufcx.h is installed by FFCx within the Python site packages, but it is sometimes helpful to install only the header file (using cmake). For instance, this package will enable the DOLFINx package to be built without having an explicit runtime dependency on Python.

