### PR TITLE
fp16, cpuinfo, pthreadpool, *nnpack: build tests/benchmarks only when self.run_tests

### DIFF
--- a/var/spack/repos/builtin/packages/cpuinfo/package.py
+++ b/var/spack/repos/builtin/packages/cpuinfo/package.py
@@ -48,4 +48,7 @@ class Cpuinfo(CMakePackage):
                         join_path(self.stage.source_path, 'deps', 'googletest')),
             self.define('GOOGLEBENCHMARK_SOURCE_DIR',
                         join_path(self.stage.source_path, 'deps', 'googlebenchmark')),
+            self.define('CPUINFO_BUILD_UNIT_TESTS', self.run_tests),
+            self.define('CPUINFO_BUILD_MOCK_TESTS', self.run_tests),
+            self.define('CPUINFO_BUILD_BENCHMARKS', self.run_tests),
         ]

--- a/var/spack/repos/builtin/packages/fp16/package.py
+++ b/var/spack/repos/builtin/packages/fp16/package.py
@@ -54,4 +54,6 @@ class Fp16(CMakePackage):
                         join_path(self.stage.source_path, 'deps', 'googletest')),
             self.define('GOOGLEBENCHMARK_SOURCE_DIR',
                         join_path(self.stage.source_path, 'deps', 'googlebenchmark')),
+            self.define('FP16_BUILD_TESTS', self.run_tests),
+            self.define('FP16_BUILD_BENCHMARKS', self.run_tests),
         ]

--- a/var/spack/repos/builtin/packages/nnpack/package.py
+++ b/var/spack/repos/builtin/packages/nnpack/package.py
@@ -115,4 +115,5 @@ class Nnpack(CMakePackage):
                         join_path(self.stage.source_path, 'deps', 'pthreadpool')),
             self.define('GOOGLETEST_SOURCE_DIR',
                         join_path(self.stage.source_path, 'deps', 'googletest')),
+            self.define('NNPACK_BUILD_TESTS', self.run_tests),
         ]

--- a/var/spack/repos/builtin/packages/pthreadpool/package.py
+++ b/var/spack/repos/builtin/packages/pthreadpool/package.py
@@ -57,4 +57,6 @@ class Pthreadpool(CMakePackage):
                         join_path(self.stage.source_path, 'deps', 'googletest')),
             self.define('GOOGLEBENCHMARK_SOURCE_DIR',
                         join_path(self.stage.source_path, 'deps', 'googlebenchmark')),
+            self.define('PTHREADPOOL_BUILD_TESTS', self.run_tests),
+            self.define('PTHREADPOOL_BUILD_BENCHMARKS', self.run_tests),
         ]

--- a/var/spack/repos/builtin/packages/qnnpack/package.py
+++ b/var/spack/repos/builtin/packages/qnnpack/package.py
@@ -87,4 +87,6 @@ class Qnnpack(CMakePackage):
                         join_path(self.stage.source_path, 'deps', 'googlebenchmark')),
             self.define('GOOGLETEST_SOURCE_DIR',
                         join_path(self.stage.source_path, 'deps', 'googletest')),
+            self.define('QNNPACK_BUILD_TESTS', self.run_tests),
+            self.define('QNNPACK_BUILD_BENCHMARKS', self.run_tests),
         ]

--- a/var/spack/repos/builtin/packages/xnnpack/package.py
+++ b/var/spack/repos/builtin/packages/xnnpack/package.py
@@ -101,4 +101,6 @@ class Xnnpack(CMakePackage):
                         join_path(self.stage.source_path, 'deps', 'googlebenchmark')),
             self.define('PSIMD_SOURCE_DIR',
                         join_path(self.stage.source_path, 'deps', 'psimd')),
+            self.define('XNNPACK_BUILD_TESTS', self.run_tests),
+            self.define('XNNPACK_BUILD_BENCHMARKS', self.run_tests),
         ]


### PR DESCRIPTION
These packages have googletest and googlebenchmark included as resources. With recent compilers (Intel oneAPI in particular), some of the older pinned versions in the included resources are leading to compilation issues. Since the issues are in googletest and googlebenchmark which are only needed for tests and not for the packages' functionality, it is reasonable to only enable these tests when the user requests for tests to be run (it is of course also reasonable to fix the actual underlying issue, which requires more understanding of what is actually failing). This allows these packages to be inestalled again on recent compilers, even if the tests will still fail.

Altenatives:
- Updating the pinned versions of googletest and googlebenchmark for these packages: though this seems to work in at least the few cases I tried, it is not really scalable.
- Change the resources into actual test dependencies. This would require a new package for googlebenchmark, and because these packages point to the source dir of googletest and googlebenchmark, it is not clear that an installed version would work without changes to the build system of these packages.

Originator, if not maintainer: @adamjstewart 