### PR TITLE
Remove the hardcoded /tmp directory

### DIFF
--- a/var/spack/repos/builtin/packages/nix/package.py
+++ b/var/spack/repos/builtin/packages/nix/package.py
@@ -87,9 +87,9 @@ class Nix(AutotoolsPackage):
 
     def installcheck(self):
         # We have to clean this tmpdir ourself later as it contains readonly directories
-        self.test_path = tempfile.mkdtemp(dir='/tmp',
-                                          prefix='tmp-spack-check-nix-{0}-'.
-                                                 format(self.spec.version))
+        self.test_path = tempfile.mkdtemp(
+            prefix='tmp-spack-check-nix-{0}-'.format(self.spec.version)
+        )
         mkdir(self.test_path + '/nix-test')
         mkdir(self.test_path + '/tests')
         os.environ['TMPDIR'] = self.test_path

--- a/var/spack/repos/builtin/packages/py-dm-tree/package.py
+++ b/var/spack/repos/builtin/packages/py-dm-tree/package.py
@@ -28,7 +28,7 @@ class PyDmTree(PythonPackage):
         remove_linked_tree(self.tmp_path)
 
     def patch(self):
-        self.tmp_path = tempfile.mkdtemp(dir='/tmp', prefix='spack')
+        self.tmp_path = tempfile.mkdtemp(prefix='spack')
         env['TEST_TMPDIR'] = self.tmp_path
         env['HOME'] = self.tmp_path
         args = [

--- a/var/spack/repos/builtin/packages/py-keras/package.py
+++ b/var/spack/repos/builtin/packages/py-keras/package.py
@@ -84,7 +84,7 @@ class PyKeras(PythonPackage):
 
     @when('@2.5.0:')
     def install(self, spec, prefix):
-        self.tmp_path = tempfile.mkdtemp(dir='/tmp', prefix='spack')
+        self.tmp_path = tempfile.mkdtemp(prefix='spack')
         env['HOME'] = self.tmp_path
 
         args = [

--- a/var/spack/repos/builtin/packages/py-tensorboard/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard/package.py
@@ -71,7 +71,7 @@ class PyTensorboard(Package):
                     '.bazelrc')
 
     def setup_build_environment(self, env):
-        self.tmp_path = tempfile.mkdtemp(dir='/tmp', prefix='spack')
+        self.tmp_path = tempfile.mkdtemp(prefix='spack')
         env.set('TEST_TMPDIR', self.tmp_path)
 
     def configure(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-estimator/package.py
@@ -47,7 +47,7 @@ class PyTensorflowEstimator(Package):
     depends_on('py-funcsigs@1.0.2:', type=('build', 'run'), when='^python@:3.2')
 
     def install(self, spec, prefix):
-        self.tmp_path = tempfile.mkdtemp(dir='/tmp', prefix='spack')
+        self.tmp_path = tempfile.mkdtemp(prefix='spack')
         env['TEST_TMPDIR'] = self.tmp_path
         env['HOME'] = self.tmp_path
 

--- a/var/spack/repos/builtin/packages/py-tensorflow-probability/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow-probability/package.py
@@ -44,7 +44,7 @@ class PyTensorflowProbability(Package):
     depends_on('bazel@3.2.0:', type='build')
 
     def install(self, spec, prefix):
-        self.tmp_path = tempfile.mkdtemp(dir='/tmp', prefix='spack')
+        self.tmp_path = tempfile.mkdtemp(prefix='spack')
         env['TEST_TMPDIR'] = self.tmp_path
         env['HOME'] = self.tmp_path
 


### PR DESCRIPTION
Hardcoding `/tmp` could cause the build to fail on systems where `/tmp` doesn't exist or it's not big enough.

Probably `/tmp` was hardcoded because Bazel does not work properly on NFS, but this can be solved by setting the tmp directory to be local.

For reference, from the tempfile module docs:
> The default directory is chosen from a platform-dependent list, but the
user of the application can control the directory location by setting
the TMPDIR, TEMP or TMP environment variables