### PR TITLE
rapidjson: Add version 1.2.0-2022-03-09

### DIFF
--- a/var/spack/repos/builtin/packages/rapidjson/package.py
+++ b/var/spack/repos/builtin/packages/rapidjson/package.py
@@ -13,6 +13,11 @@ class Rapidjson(CMakePackage):
     url = "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz"
 
     version(
+        "1.2.0-2022-03-09",
+        git="https://github.com/Tencent/rapidjson.git",
+        commit="8261c1ddf43f10de00fd8c9a67811d1486b2c784"
+    )
+    version(
         "1.2.0-2021-08-13",
         git="https://github.com/Tencent/rapidjson.git",
         commit="00dbcf2c6e03c47d6c399338b6de060c71356464",


### PR DESCRIPTION
Includes PR https://github.com/Tencent/rapidjson/pull/1940 which fixes https://github.com/Tencent/rapidjson/issues/1924 causing errors for newer compilers on centos