### PR TITLE
yaksa: Add new package

### DIFF
--- a/var/spack/repos/builtin/packages/yaksa/package.py
+++ b/var/spack/repos/builtin/packages/yaksa/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Yaksa(AutotoolsPackage):
+    """Yaksa is a high-performance datatype engine for expressing,
+    managing and manipulating data present in noncontiguous memory
+    regions. It provides portable abstractions for structured
+    noncontiguous data layouts that are much more comprehensive compared
+    with traditional I/O vectors.
+
+    Yaksa imitates parts of the MPI Datatype system, but adds additional
+    functionality that would allow it to be used independent of MPI. It
+    provides routines for packing/unpacking, creating I/O vectors (array
+    of contiguous segments) and flattening/unflattening datatypes into
+    process-portable formats.
+
+    Yaksa's backend includes support for CPUs as well as different
+    GPUs."""
+
+    homepage = "https://www.yaksa.org"
+    url      = "https://github.com/pmodels/yaksa/archive/refs/tags/v0.2.tar.gz"
+    maintainers = ['raffenet', 'yfguo', 'hzhou']
+
+    version('0.2', sha256='9401cb6153dc8c34ddb9781bbabd418fd26b0a27b5da3294ecc21af7be9c86f2')
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+    depends_on('python@3:', type='build')
+
+    def autoreconf(self, spec, prefix):
+        sh = which('sh')
+        sh('autogen.sh')

--- a/var/spack/repos/builtin/packages/yaksa/package.py
+++ b/var/spack/repos/builtin/packages/yaksa/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Yaksa(AutotoolsPackage):
+class Yaksa(AutotoolsPackage, CudaPackage):
     """Yaksa is a high-performance datatype engine for expressing,
     managing and manipulating data present in noncontiguous memory
     regions. It provides portable abstractions for structured
@@ -37,3 +37,9 @@ class Yaksa(AutotoolsPackage):
     def autoreconf(self, spec, prefix):
         sh = which('sh')
         sh('autogen.sh')
+
+    def configure_args(self):
+        config_args = []
+        config_args += self.with_or_without('cuda', activation_value='prefix')
+
+        return config_args


### PR DESCRIPTION
Yaksa is primarily used as an MPICH dependency, but can be built as a standalone library.