### PR TITLE
Bash: fix messed up display for long lines when terminal prompt is colorized

### DIFF
--- a/lib/spack/llnl/util/tty/color.py
+++ b/lib/spack/llnl/util/tty/color.py
@@ -153,7 +153,7 @@ class match_to_ansi(object):
     def escape(self, s):
         """Returns a TTY escape sequence for a color"""
         if self.color:
-            return "\033[%sm" % s
+            return "\[\033[%sm\]" % s
         else:
             return ''
 
@@ -207,12 +207,12 @@ def colorize(string, **kwargs):
 
 def clen(string):
     """Return the length of a string, excluding ansi color sequences."""
-    return len(re.sub(r'\033[^m]*m', '', string))
+    return len(re.sub(r'\[\033[^m]*m\]', '', string))
 
 
 def cextra(string):
     """Length of extra color characters in a string"""
-    return len(''.join(re.findall(r'\033[^m]*m', string)))
+    return len(''.join(re.findall(r'\[\033[^m]*m\]', string)))
 
 
 def cwrite(string, stream=None, color=None):


### PR DESCRIPTION
This is an attempt to resolve https://github.com/spack/spack/issues/29881

I tested this with bash on my system where I had this problem, and it works perfectly.

From the source code, it looks like that `bash` and `fish` are using the `colorize` function, `csh` does not.

I also installed `fish` and ran `spack env activate -p`, then a few commands, then `spack env deactivate` and didn't have any problem. But I didn't use `fish` before, so I don't know whether this fix was needed for `fish`. Definitely needed for `bash`.

Would be great if others could give this a try on their systems with their shells.