### PR TITLE
Perl: Fix (again) macOS 11

### DIFF
--- a/var/spack/repos/builtin/packages/perl/macos-11-version-check.patch
+++ b/var/spack/repos/builtin/packages/perl/macos-11-version-check.patch
@@ -16,7 +16,7 @@ index 1709d224f7c..fdfbdd4a3b9 100644
     # capturing its value and adding it to the flags.
      case "$MACOSX_DEPLOYMENT_TARGET" in
 -    10.*)
-+    [1-9][0-9].*)
++    [1-9][0-9].*|[1-9][0-9])
        add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
        add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
        ;;
@@ -34,7 +34,7 @@ index 1709d224f7c..fdfbdd4a3b9 100644
          prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
      case "$prodvers" in
 -    10.*)
-+    [1-9][0-9].*)
++    [1-9][0-9].*|[1-9][0-9])
        add_macosx_version_min ccflags $prodvers
        add_macosx_version_min ldflags $prodvers
        ;;


### PR DESCRIPTION
I think this (#19210 / #18660) needs to be written in a more general way, since one can set only the major version as well.

I saw on an Azure runner with macOS 11:
```
*** Unexpected MACOSX_DEPLOYMENT_TARGET=11
***
*** Please either set it to a valid macOS version number (e.g., 10.15) or to empty.
```
for Perl 5.34.1
```
/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/runner/spack-stage/spack-stage-perl-5.34.1-pi4awot23n4knuuugmvfjussoweu3ui4/spack-build-out.txt
```

This problem is also visible in Spack `macos-nightly` tests:
https://github.com/spack/spack/actions/workflows/macos_python.yml?query=workflow%3A%22macOS+builds+nightly%22

cc @zhiyuanzhai @johnwparent]

- [ ] patch untested, because I am a Linux user