### PR TITLE
Add checksum for py-awkward@1.5.1 and fix rapidjson dependecy

### DIFF
--- a/var/spack/repos/builtin/packages/py-awkward/package.py
+++ b/var/spack/repos/builtin/packages/py-awkward/package.py
@@ -15,6 +15,7 @@ class PyAwkward(PythonPackage):
 
     maintainers = ['vvolkl']
 
+    version('1.5.1', sha256='c0357c62223fefcfc7a7565389dbd4db900623bf10eccf2bc8e87586ec59b38d')
     version('1.4.0', sha256='25ae6114d5962c717cb87e3bc30a2f6eaa232b252cf8c51ba805b8f04664ae0d')
     version('1.3.0', sha256='b6021694adec9813842bad1987b837e439dabaf5b0dff9041201d238fca71fb4')
     version('1.2.3', sha256='7d727542927a926f488fa62d04e2c5728c72660f17f822e627f349285f295063')
@@ -32,5 +33,5 @@ class PyAwkward(PythonPackage):
     depends_on('py-numpy@1.13.1:', type=('build', 'run'))
     depends_on('py-pybind11', type=('build', 'link'))
     depends_on('dlpack', when="@1.0.0:")
-    depends_on('rapidjson')
+    depends_on('rapidjson@:1.1.0')
     depends_on('cmake', type='build')


### PR DESCRIPTION
For the _rapidjson_ dependency, it turns out that the issue [#1924](https://github.com/Tencent/rapidjson/issues/1924) is still present in the latest version. Enforcing version < 1.1.0 skips the issue.