### PR TITLE
Make dd4hep boost deps explicit

### DIFF
--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
-
 
 class Dd4hep(CMakePackage):
     """DD4hep is a software framework for providing a complete solution for

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -5,6 +5,7 @@
 
 from spack import *
 
+
 class Dd4hep(CMakePackage):
     """DD4hep is a software framework for providing a complete solution for
        full detector description (geometry, materials, visualization, readout,

--- a/var/spack/repos/builtin/packages/dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/dd4hep/package.py
@@ -82,10 +82,8 @@ class Dd4hep(CMakePackage):
     depends_on('cmake @3.12:', type='build')
     depends_on('ninja', type='build')
     depends_on('boost @1.49:')
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost +iostreams', when='+ddg4')
+    depends_on('boost +system +filesystem', when='%gcc@:7')
     depends_on('root @6.08: +gdml +math +python')
     depends_on('root @6.08: +gdml +math +python +x +opengl', when="+ddeve")
 


### PR DESCRIPTION
Source: `grep -i boost` in the DD4hep source tree + checking which Boost modules have associated variants.