### PR TITLE
cray platform: unload cray-mpich

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -825,12 +825,13 @@ def setup_package(pkg, dirty, context='build'):
         for mod in pkg.compiler.modules:
             load_module(mod)
 
-    # kludge to handle cray libsci being automatically loaded by PrgEnv
-    # modules on cray platform. Module unload does no damage when
+    # kludge to handle cray mpich and libsci being automatically loaded by
+    # PrgEnv modules on cray platform. Module unload does no damage when
     # unnecessary
     on_cray, _ = _on_cray()
     if on_cray:
-        module('unload', 'cray-libsci')
+        for mod in ['cray-mpich', 'cray-libsci']:
+            module('unload', mod)
 
     if target.module_name:
         load_module(target.module_name)


### PR DESCRIPTION
`PrgEnv` modules might automatically load not only `cray-libsci` but `cray-mpich` too, therefore, we should unload the latter as well.

We should probably unload everything from https://github.com/spack/spack/blob/b2717a8abf02e580898f746bfe763072fc0139c1/lib/spack/spack/platforms/cray.py#L93 but I am not familiar with the rest of the modules on the list.