### PR TITLE
Add missing required depends_on package references to survey

### DIFF
--- a/var/spack/repos/builtin/packages/survey/package.py
+++ b/var/spack/repos/builtin/packages/survey/package.py
@@ -68,6 +68,9 @@ class Survey(CMakePackage):
     depends_on("py-psutil", type=('build', 'run'))
     depends_on("py-sqlalchemy", type=('build', 'run'))
     depends_on("py-pyyaml", type=('build', 'run'))
+    depends_on("py-seaborn", type=('build', 'run'))
+    depends_on("py-jinja2", type=('build', 'run'))
+    depends_on("py-matplotlib", type=('build', 'run'))
 
     extends('python')
 

--- a/var/spack/repos/builtin/packages/survey/package.py
+++ b/var/spack/repos/builtin/packages/survey/package.py
@@ -68,9 +68,9 @@ class Survey(CMakePackage):
     depends_on("py-psutil", type=('build', 'run'))
     depends_on("py-sqlalchemy", type=('build', 'run'))
     depends_on("py-pyyaml", type=('build', 'run'))
-    depends_on("py-seaborn", type=('build', 'run'))
-    depends_on("py-jinja2", type=('build', 'run'))
-    depends_on("py-matplotlib", type=('build', 'run'))
+    depends_on("py-seaborn", type=('build', 'run'), when='@1.0.3:')
+    depends_on("py-jinja2", type=('build', 'run'), when='@1.0.3:')
+    depends_on("py-matplotlib", type=('build', 'run'), when='@1.0.3:')
 
     extends('python')
 


### PR DESCRIPTION
Add missing required depends_on package references to survey.  They are needed for release 1.0.3 but were mistakenly left out of the PR. 