### PR TITLE
hdf5: remove redundant dependency on numactl

### DIFF
--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -86,9 +86,6 @@ class Hdf5(CMakePackage):
 
     depends_on('mpi', when='+mpi')
     depends_on('java', type=('build', 'run'), when='+java')
-    # numactl does not currently build on darwin
-    if sys.platform != 'darwin':
-        depends_on('numactl', when='+mpi+fortran')
     depends_on('szip', when='+szip')
     depends_on('zlib@1.1.2:')
 

--- a/var/spack/repos/builtin/packages/hdf5/package.py
+++ b/var/spack/repos/builtin/packages/hdf5/package.py
@@ -5,7 +5,6 @@
 
 import os
 import shutil
-import sys
 
 import llnl.util.tty as tty
 


### PR DESCRIPTION
The dependency of `hdf5` on `numactl` was introduced in #5372 by @ax3l. However, I could not find any indications in the source code of `hdf5` that the package really depends on `numactl`. To me, it looks like it was some sort of a workaround for the mixed `clang+gfortran` toolchain. I tried to reproduce the problem but couldn't. All the following specs were installed successfully with this PR:
```
hdf5@1.10.1%clang+fortran+mpi ^openmpi@2.1.1
hdf5@1.10.1%clang+fortran+mpi ^openmpi@4.1.1
hdf5@1.10.7%clang+fortran+mpi ^openmpi@2.1.1
hdf5@1.10.7%clang+fortran+mpi ^openmpi@4.1.1
```

Where `%clang` is `Clang 12.0.1` mixed with `Gfortran 6.3.0`.