### PR TITLE
SCR release v3.0, including components

### DIFF
--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -27,6 +27,7 @@ class Axl(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('0.6.0', sha256='86edb35f99b63c0ffb9dd644a019a63b062923b4efc95c377e92a1b13e79f537')
     version('0.5.0', sha256='9f3bbb4de563896551bdb68e889ba93ea1984586961ad8c627ed766bff020acf')
     version('0.4.0', sha256='0530142629d77406a00643be32492760c2cf12d1b56c6b6416791c8ff5298db2')
     version('0.3.0', sha256='737d616b669109805f7aed1858baac36c97bf0016e1115b5c56ded05d792613e')
@@ -35,6 +36,9 @@ class Axl(CMakePackage):
 
     depends_on('kvtree')
     depends_on('zlib', type='link')
+
+    depends_on('kvtree@main', when='@main')
+    depends_on('kvtree@1.3.0', when='@0.6.0')
 
     variant('async_api', default='daemon',
             description='Set of async transfer APIs to enable',

--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -45,6 +45,8 @@ class Axl(CMakePackage):
             values=['cray_dw', 'intel_cppr', 'daemon', 'none'], multi=True,
             validator=async_api_validator)
 
+    variant('pthreads', default=True, description='Enable Pthread support', when='@0.6:')
+
     variant('bbapi', default=True, description='Enable IBM BBAPI support')
 
     variant('bbapi_fallback', default=False,
@@ -83,5 +85,8 @@ class Axl(CMakePackage):
         else:
             if spec.satisfies('platform=cray'):
                 args.append(self.define('AXL_LINK_STATIC', True))
+
+        if spec.satisfies('@0.6.0:'):
+            args.append(self.define_from_variant('ENABLE_PTHREADS', 'pthreads'))
 
         return args

--- a/var/spack/repos/builtin/packages/axl/package.py
+++ b/var/spack/repos/builtin/packages/axl/package.py
@@ -27,6 +27,7 @@ class Axl(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('0.7.0', sha256='840ef61eadc9aa277d128df08db4cdf6cfa46b8fcf47b0eee0972582a61fbc50')
     version('0.6.0', sha256='86edb35f99b63c0ffb9dd644a019a63b062923b4efc95c377e92a1b13e79f537')
     version('0.5.0', sha256='9f3bbb4de563896551bdb68e889ba93ea1984586961ad8c627ed766bff020acf')
     version('0.4.0', sha256='0530142629d77406a00643be32492760c2cf12d1b56c6b6416791c8ff5298db2')

--- a/var/spack/repos/builtin/packages/dtcmp/package.py
+++ b/var/spack/repos/builtin/packages/dtcmp/package.py
@@ -14,6 +14,8 @@ class Dtcmp(AutotoolsPackage):
     url      = "https://github.com/LLNL/dtcmp/releases/download/v1.0.3/dtcmp-1.0.3.tar.gz"
     git      = "https://github.com/LLNL/dtcmp.git"
 
+    maintainers = ['gonsie', 'camstan', 'adammoody']
+
     version('main', branch='main')
     version('1.1.4', sha256='dd83d8cecd68e13b78b68e88675cc5847cde06742b7740e140b98f4a08127dd3')
     version('1.1.3', sha256='90b32cadd0ff2f4fa7fc916f8dcfdbe6918e3e285e0292a2470772478ca0aab5')

--- a/var/spack/repos/builtin/packages/dtcmp/package.py
+++ b/var/spack/repos/builtin/packages/dtcmp/package.py
@@ -25,6 +25,9 @@ class Dtcmp(AutotoolsPackage):
     depends_on('mpi')
     depends_on('lwgrp')
 
+    depends_on('lwgrp@main', when='@main')
+    depends_on('lwgrp@1.0.5', when='@1.1.4')
+
     variant('shared', default=True, description='Build with shared libraries')
     depends_on('lwgrp+shared', when='+shared')
     depends_on('lwgrp~shared', when='~shared')

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -17,6 +17,7 @@ class Er(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('0.2.0', sha256='9ddfe2b63682ed0e89685f9b7d5259ef82b802aba55c8ee78cc15a7adbad6bc0')
     version('0.1.0', sha256='543afc1c48bb2c67f48c32f6c9efcbf7bb27f2e622ff76f2c2ce5618c77aacfc')
     version('0.0.4', sha256='c456d34719bb57774adf6d7bc2fa9917ecb4a9de442091023c931a2cb83dfd37')
     version('0.0.3', sha256='243b2b46ea274e17417ef5873c3ed7ba16dacdfdaf7053d1de5434e300de796b')
@@ -28,8 +29,15 @@ class Er(CMakePackage):
     depends_on('shuffile')
     depends_on('zlib', type='link')
 
-    variant('shared', default=True, description='Build with shared libraries')
+    depends_on('kvtree@1.3')
+
+
     deps = ['kvtree', 'rankstr', 'redset', 'shuffile']
+    for dep in deps:
+        depends_on(dep + '@main', when='@main')
+
+
+    variant('shared', default=True, description='Build with shared libraries')
     for dep in deps:
         depends_on(dep + '+shared', when='@0.1: +shared')
         depends_on(dep + '~shared', when='@0.1: ~shared')

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -31,11 +31,9 @@ class Er(CMakePackage):
 
     depends_on('kvtree@1.3')
 
-
     deps = ['kvtree', 'rankstr', 'redset', 'shuffile']
     for dep in deps:
         depends_on(dep + '@main', when='@main')
-
 
     variant('shared', default=True, description='Build with shared libraries')
     for dep in deps:

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -29,7 +29,7 @@ class Er(CMakePackage):
     depends_on('shuffile')
     depends_on('zlib', type='link')
 
-    depends_on('kvtree@1.3')
+    depends_on('kvtree@1.3', when='@0.2.0')
 
     deps = ['kvtree', 'rankstr', 'redset', 'shuffile']
     for dep in deps:

--- a/var/spack/repos/builtin/packages/er/package.py
+++ b/var/spack/repos/builtin/packages/er/package.py
@@ -17,6 +17,7 @@ class Er(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('0.3.0', sha256='01bc71bfb2ebb015ccb948f2bb9138b70972a3e8be0e53f9a4844e46b106a36c')
     version('0.2.0', sha256='9ddfe2b63682ed0e89685f9b7d5259ef82b802aba55c8ee78cc15a7adbad6bc0')
     version('0.1.0', sha256='543afc1c48bb2c67f48c32f6c9efcbf7bb27f2e622ff76f2c2ce5618c77aacfc')
     version('0.0.4', sha256='c456d34719bb57774adf6d7bc2fa9917ecb4a9de442091023c931a2cb83dfd37')

--- a/var/spack/repos/builtin/packages/kvtree/package.py
+++ b/var/spack/repos/builtin/packages/kvtree/package.py
@@ -18,6 +18,7 @@ class Kvtree(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('1.3.0', sha256='8281e075772d3534183c46133553d5765455d79ed98a895743663db891755ca9')
     version('1.2.0', sha256='ecd4b8bc479c33ab4f23fc764445a3bb353a1d15c208d011f5577a32c182477f')
     version('1.1.1', sha256='4776bd55a559b7f9bb594454ae6b14ebff0087c93c3d59ac7d1ab27df4aa4d74')
     version('1.1.0', sha256='3e6c003e7b8094d7c2d1529a973d68a68f953ffa63dcde5f4c7c7e81ddf06564')

--- a/var/spack/repos/builtin/packages/rankstr/package.py
+++ b/var/spack/repos/builtin/packages/rankstr/package.py
@@ -17,6 +17,7 @@ class Rankstr(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('0.2.0', sha256='a3f7fd8015156c1b600946af759a03e099e05c83e7b2da6bac394fe7c0d4efae')
     version('0.1.0', sha256='b68239d67b2359ecc067cc354f86ccfbc8f02071e60d28ae0a2449f2e7f88001')
     version('0.0.3', sha256='d32052fbecd44299e13e69bf2dd7e5737c346404ccd784b8c2100ceed99d8cd3')
     version('0.0.2', sha256='b88357bf88cdda9565472543225d6b0fa50f0726f6e2d464c92d31a98b493abb')

--- a/var/spack/repos/builtin/packages/redset/package.py
+++ b/var/spack/repos/builtin/packages/redset/package.py
@@ -17,6 +17,7 @@ class Redset(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('0.2.0', sha256='0438b0ba56dafcd5694a8fceeb5a932901307353e056ab29817d30b8387f787f')
     version('0.1.0', sha256='baa75de0d0d6de64ade50cff3d38ee89fd136ce69869182bdaefccf5be5d286d')
     version('0.0.5', sha256='4db4ae59ab9d333a6d1d80678dedf917d23ad461c88b6d39466fc4bf6467d1ee')
     version('0.0.4', sha256='c33fce458d5582f01ad632c6fae8eb0a03eaef00e3c240c713b03bb95e2787ad')

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -33,8 +33,8 @@ class Scr(CMakePackage):
     version('legacy',  branch='legacy')
 
     version('3.0.0',  sha256='e204d3e99a49efac50b4bedc7ac05f55a05f1a65429500d919900c82490532cc', preferred=True)
-    version('3.0rc2', sha256='4b2a718af56b3683e428d25a2269c038e9452db734221d370e3023a491477fad')
-    version('3.0rc1', sha256='bd31548a986f050024429d8ee3644eb135f047f98a3d503a40c5bd4a85291308')
+    version('3.0rc2', sha256='4b2a718af56b3683e428d25a2269c038e9452db734221d370e3023a491477fad', deprecated=True)
+    version('3.0rc1', sha256='bd31548a986f050024429d8ee3644eb135f047f98a3d503a40c5bd4a85291308', deprecated=True)
     version('2.0.0', sha256='471978ae0afb56a20847d3989b994fbd680d1dea21e77a5a46a964b6e3deed6b')
     version('1.2.2', sha256='764a85638a9e8762667ec1f39fa5f7da7496fca78de379a22198607b3e027847', deprecated=True)
     version('1.2.1', sha256='23acab2dc7203e9514455a5168f2fd57bc590affb7a1876912b58201513628fe', deprecated=True)

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -32,6 +32,7 @@ class Scr(CMakePackage):
     version('develop', branch='develop')
     version('legacy',  branch='legacy')
 
+    version('3.0.0',  sha256='e204d3e99a49efac50b4bedc7ac05f55a05f1a65429500d919900c82490532cc', preferred=True)
     version('3.0rc2', sha256='4b2a718af56b3683e428d25a2269c038e9452db734221d370e3023a491477fad')
     version('3.0rc1', sha256='bd31548a986f050024429d8ee3644eb135f047f98a3d503a40c5bd4a85291308')
     version('2.0.0', sha256='471978ae0afb56a20847d3989b994fbd680d1dea21e77a5a46a964b6e3deed6b')
@@ -59,13 +60,22 @@ class Scr(CMakePackage):
     depends_on('shuffile@0.0.4',  when='@3.0rc1')
     depends_on('spath@0.0.2',     when='@3.0rc1')
 
-    depends_on('axl@0.5.0:',      when='@3.0rc2:')
-    depends_on('er@0.1.0:',       when='@3.0rc2:')
-    depends_on('kvtree@1.2.0:',   when='@3.0rc2:')
-    depends_on('rankstr@0.1.0:',  when='@3.0rc2:')
-    depends_on('redset@0.1.0:',   when='@3.0rc2:')
-    depends_on('shuffile@0.1.0:', when='@3.0rc2:')
-    depends_on('spath@0.1.0:',    when='@3.0rc2:')
+    depends_on('axl@0.5.0:',      when='@3.0rc2')
+    depends_on('er@0.1.0:',       when='@3.0rc2')
+    depends_on('kvtree@1.2.0:',   when='@3.0rc2')
+    depends_on('rankstr@0.1.0:',  when='@3.0rc2')
+    depends_on('redset@0.1.0:',   when='@3.0rc2')
+    depends_on('shuffile@0.1.0:', when='@3.0rc2')
+    depends_on('spath@0.1.0:',    when='@3.0rc2')
+
+    depends_on('axl@0.6.0',       when='@3.0.0:')
+    depends_on('er@0.2.0',        when='@3.0.0:')
+    depends_on('kvtree@1.3.0',    when='@3.0.0:')
+    depends_on('rankstr@0.1.0',   when='@3.0.0:')
+    depends_on('redset@0.2.0',    when='@3.0.0:')
+    depends_on('shuffile@0.2.0',  when='@3.0.0:')
+    depends_on('spath@0.2.0',     when='@3.0.0:')
+    depends_on('dtcmp@1.1.4',     when='@3.0.0:')
 
     # DTCMP is an optional dependency up until 3.x, required thereafter
     variant('dtcmp', default=True, when='@:2',
@@ -81,10 +91,11 @@ class Scr(CMakePackage):
     depends_on('libyogrt', when='+libyogrt')
 
     # PDSH required up to 3.0rc1, optional thereafter
-    variant('pdsh', default=True, when='@3.0rc2:',
+    # TODO spack currently assumes 3.0.0 = 3.0 = 3 < 3.0rc1 < 3.0rc2
+    variant('pdsh', default=True, when='@3.0.0,3.0rc2:',
             description='Enable use of PDSH')
     depends_on('pdsh+static_modules', type=('build', 'run'), when='+pdsh')
-    depends_on('pdsh+static_modules', type=('build', 'run'), when='@:3.0rc1')
+    depends_on('pdsh+static_modules', type=('build', 'run'), when='@:2,3.0rc1')
 
     variant('scr_config', default='scr.conf',
             description='Location for SCR to find its system config file. '

--- a/var/spack/repos/builtin/packages/scr/package.py
+++ b/var/spack/repos/builtin/packages/scr/package.py
@@ -32,7 +32,7 @@ class Scr(CMakePackage):
     version('develop', branch='develop')
     version('legacy',  branch='legacy')
 
-    version('3.0.0',  sha256='e204d3e99a49efac50b4bedc7ac05f55a05f1a65429500d919900c82490532cc', preferred=True)
+    version('3.0', sha256='e204d3e99a49efac50b4bedc7ac05f55a05f1a65429500d919900c82490532cc', preferred=True)
     version('3.0rc2', sha256='4b2a718af56b3683e428d25a2269c038e9452db734221d370e3023a491477fad', deprecated=True)
     version('3.0rc1', sha256='bd31548a986f050024429d8ee3644eb135f047f98a3d503a40c5bd4a85291308', deprecated=True)
     version('2.0.0', sha256='471978ae0afb56a20847d3989b994fbd680d1dea21e77a5a46a964b6e3deed6b')

--- a/var/spack/repos/builtin/packages/shuffile/package.py
+++ b/var/spack/repos/builtin/packages/shuffile/package.py
@@ -17,6 +17,7 @@ class Shuffile(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('0.2.0', sha256='467ffef72214c109b69f09d03e42be5e9254f13751b09c71168c14fa99117521')
     version('0.1.0', sha256='9e730cc8b7937517a9cffb08c031d9f5772306341c49d17b87b7f349d55a6d5e')
     version('0.0.4', sha256='f0249ab31fc6123103ad67b1eaf799277c72adcf0dfcddf8c3a18bad2d45031d')
     version('0.0.3', sha256='a3f685526a1146a5ad8dbacdc5f9c2e1152d9761a1a179c1db34f55afc8372f6')

--- a/var/spack/repos/builtin/packages/spath/package.py
+++ b/var/spack/repos/builtin/packages/spath/package.py
@@ -17,7 +17,7 @@ class Spath(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
-    version('0.2.0', sha256='86a9458db898ad266358f8df198ac7c1f00a51289fbcb4572f4604f11708881c')
+    version('0.2.0', sha256='2de8a25547b53ef064664d79b543141bc3020219f40ff0e1076f676e13a9e77a')
     version('0.1.0', sha256='2cfc635b2384d3f92973c7aea173dabe47da112d308f5098e6636e4b2f4a704c')
     version('0.0.2', sha256='7a65be59c3d27e92ed4718fba1a97a4a1c68e0a552b54de13d58afe3d8199cf7')
     version('0.0.1', sha256='f41c0ac74e6fb8acfd0c072d756db0fc9c00441f22be492cc4ad25f7fb596a24')

--- a/var/spack/repos/builtin/packages/spath/package.py
+++ b/var/spack/repos/builtin/packages/spath/package.py
@@ -17,6 +17,7 @@ class Spath(CMakePackage):
     maintainers = ['CamStan', 'gonsie']
 
     version('main',  branch='main')
+    version('0.2.0', sha256='86a9458db898ad266358f8df198ac7c1f00a51289fbcb4572f4604f11708881c')
     version('0.1.0', sha256='2cfc635b2384d3f92973c7aea173dabe47da112d308f5098e6636e4b2f4a704c')
     version('0.0.2', sha256='7a65be59c3d27e92ed4718fba1a97a4a1c68e0a552b54de13d58afe3d8199cf7')
     version('0.0.1', sha256='f41c0ac74e6fb8acfd0c072d756db0fc9c00441f22be492cc4ad25f7fb596a24')


### PR DESCRIPTION
Includes:
- SCR 3.0.0
- AXL 0.6.0
- ER 0.2.0
- KVTree 1.3.0
- Rankstr 0.2.0
- Redset 0.2.0
- Shuffile v0.2.0
- Spath v0.2.0