### PR TITLE
OpenSSL enable quotes in build arguments

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -186,6 +186,8 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
         else:
             host_make = make
 
+        host_make()
+
         if self.run_tests:
             host_make('test', parallel=False)  # 'VERBOSE=1'
 

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -147,8 +147,8 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
                      % join_path(prefix, 'etc', 'openssl')]
         if spec.satisfies('platform=windows'):
             base_args.extend([
-                'CC=%s' % os.environ.get('CC'),
-                'CXX=%s' % os.environ.get('CXX'),
+                'CC=\"%s\"' % os.environ.get('CC'),
+                'CXX=\"%s\"' % os.environ.get('CXX'),
                 'VC-WIN64A',
             ])
             if spec.satisfies('~shared'):

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -100,6 +100,7 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
     depends_on('zlib')
     depends_on('perl@5.14.0:', type=('build', 'test'))
     depends_on('ca-certificates-mozilla', type=('build', 'run'), when='certs=mozilla')
+    depends_on('nasm', when='platform=windows')
 
     @classmethod
     def determine_version(cls, exe):
@@ -164,7 +165,9 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
         # On Windows, we use perl for configuration and build through MSVC
         # nmake.
         if spec.satisfies('platform=windows'):
-            Executable('perl')('Configure', *base_args)
+            # The configure executable requires that paths with spaces
+            # on Windows be wrapped in quotes
+            Executable('perl')('Configure', *base_args, ignore_quotes=True)
         else:
             Executable('./config')(*base_args)
 


### PR DESCRIPTION
This is required to support building on Windows due to spaces in common compiler install directories and how nmake arguments are parsed.

Addresses #29576 depends on #29905