### PR TITLE
e4s ci: expand mac mini stack

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -17,8 +17,8 @@ spack:
 
   definitions:
   - easy_specs:
-    - bzip2
-    - zlib
+    - kokkos +openmp
+    - kokkos-kernels +openmp
 
   - arch:
     - '%apple-clang@13.0.0 target=m1'


### PR DESCRIPTION
E4S Mini MacOS Stack: Try something useful
* `kokkos`
* `kokkos-kernels`

@wspear 