### PR TITLE
Intel oneAPI compilers: set rpath for lib/ directory

### DIFF
--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -118,7 +118,8 @@ class IntelOneapiCompilers(IntelOneApiPackage):
         # set rpath so 'spack compiler add' can check version strings
         # without setting LD_LIBRARY_PATH
         rpath = ':'.join(self._ld_library_path())
-        patch_dirs = [join_path('compiler', 'lib', 'intel64_lin'),
+        patch_dirs = [join_path('lib'),
+                      join_path('compiler', 'lib', 'intel64_lin'),
                       join_path('compiler', 'lib', 'intel64'),
                       'bin']
         for pd in patch_dirs:


### PR DESCRIPTION
When installing `intel-oneapi-compilers` (or loading as external, but this PR doesn't fix that), the library lookup for `libsycl.so` fails, e.g.
```console
spack install intel-oneapi-compilers@2022.0.2
ldd $(spack location -i intel-oneapi-compilers)/compiler/2022.0.2/linux/lib/libsycl.so
```
which returns
```console
        linux-vdso.so.1 (0x00007ffea515d000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f08d0e8c000)
        libOpenCL.so.1 => /lib/x86_64-linux-gnu/libOpenCL.so.1 (0x00007f08d0e7a000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f08d0e75000)
        libsvml.so => not found
        libirng.so => not found
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f08d0c5a000)
        libimf.so => not found
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f08d0b76000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f08d0b5c000)
        libintlc.so.5 => not found
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f08d0934000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f08d11bc000)
```
This is resolved with the `_ld_library_path` function in `intel-oneapi-compilers`, but this doesn't apply when the library is used as a compiler after `spack compiler add`.

This results in failures when building spack packages with `dpcpp`, e.g. (notes: [^1], [^2])
```console
sed -i 's/+sycl/+sycl %gcc/' $(spack location -p vecmem)/package.py
spack load intel-oneapi-compilers
spack compilers add
spack install vecmem%dpcpp +sycl ^cmake%oneapi
```
which returns
```console
     3     -- The CXX compiler identification is IntelLLVM 2022.0.0
     4     -- Detecting CXX compiler ABI info
     5     -- Detecting CXX compiler ABI info - failed
     6     -- Check for working CXX compiler: /opt/spack/lib/spack/env/oneapi/dpcpp
     7     -- Check for working CXX compiler: /opt/spack/lib/spack/env/oneapi/dpcpp - broken
  >> 8     CMake Error at /opt/software/linux-ubuntu21.10-skylake_avx512/oneapi-2022.0.0/cmake-3.23.0-m227o27mhx33zkcyds2tndzr7xpnn7ei/share/cmake-3.23/Modules/CMakeTestCXXCompiler.cmake:62 (message):
     9       The C++ compiler
     10    
     11        "/opt/spack/lib/spack/env/oneapi/dpcpp"
     12    
     13      is not able to compile a simple test program.
     14    

     ...

     24        /opt/software/linux-ubuntu21.10-skylake_avx512/oneapi-2022.0.0/cmake-3.23.0-m227o27mhx33zkcyds2tndzr7xpnn7ei/bin/cmake -E cmake_link_script CMakeFiles/cmTC_8f611.dir/link.txt --verbose=1
     25        /opt/spack/lib/spack/env/oneapi/dpcpp CMakeFiles/cmTC_8f611.dir/testCXXCompiler.cxx.o -o cmTC_8f611
     26        /usr/bin/ld: warning: libsvml.so, needed by /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so, n
           ot found (try using -rpath or -rpath-link)
     27        /usr/bin/ld: warning: libirng.so, needed by /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so, n
           ot found (try using -rpath or -rpath-link)
     28        /usr/bin/ld: warning: libimf.so, needed by /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so, no
           t found (try using -rpath or -rpath-link)
     29        /usr/bin/ld: warning: libintlc.so.5, needed by /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so
           , not found (try using -rpath or -rpath-link)
  >> 30    /usr/bin/ld: /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so: undefined reference to `_intel_fast_
           memcpy'
  >> 31        /usr/bin/ld: /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so: undefined reference to `__svml_c
           brtf4_ha'
  >> 32        /usr/bin/ld: /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so: undefined reference to `__svml_h
           ypot2_ha'
  >> 33        /usr/bin/ld: /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so: undefined reference to `__svml_h
           ypotf4_ha'
  >> 34        /usr/bin/ld: /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so: undefined reference to `__svml_e
           rfc2_ha'
  >> 35        /usr/bin/ld: /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so: undefined reference to `_intel_f
           ast_memset'
  >> 36        /usr/bin/ld: /opt/software/linux-ubuntu21.10-skylake_avx512/gcc-11.2.0/intel-oneapi-compilers-2022.0.2-b2f5p37euy24mi6l44mxhxo2dyst4eug/compiler/2022.0.2/linux/bin-llvm/../lib/libsycl.so: undefined reference to `__svml_c
           brt2_ha'
  >> 37        dpcpp: error: linker command failed with exit code 1 (use -v to see invocation)
  >> 38        gmake[1]: *** [CMakeFiles/cmTC_8f611.dir/build.make:100: cmTC_8f611] Error 1
     39        gmake[1]: Leaving directory '/home/wdconinc/.spack/stage/spack-stage-vecmem-0.8.0-kvknx2we7ta64cuqrp6v7n7uuhbo5o6k/spack-build-kvknx2w/CMakeFiles/CMakeTmp'
  >> 40        gmake: *** [Makefile:127: cmTC_8f611/fast] Error 2
```

This patch adds the necessary rpath entries to `libsycl.so` in the `lib/` directory (and to the other libraries in that same directory) so they find the correct references without setting LD_LIBRARY_PATH (as when they are used after `spack compiler add`).
```console
==> Installing vecmem-0.8.0-kvknx2we7ta64cuqrp6v7n7uuhbo5o6k
==> No binary for vecmem-0.8.0-kvknx2we7ta64cuqrp6v7n7uuhbo5o6k found: installing from source
==> Using cached archive: /home/wdconinc/.spack/cache/_source-cache/archive/a1/a13f7178c940d6bf3386e7e8f5eb158e6435882533bffe888d3c9775eeb2f20e.tar.gz
==> No patches needed for vecmem
==> vecmem: Executing phase: 'cmake'
==> vecmem: Executing phase: 'build'
==> vecmem: Executing phase: 'install'
==> vecmem: Successfully installed vecmem-0.8.0-kvknx2we7ta64cuqrp6v7n7uuhbo5o6k
  Fetch: 0.01s.  Build: 39.97s.  Total: 39.98s.
[+] /opt/software/linux-ubuntu21.10-skylake_avx512/dpcpp-2022.0.0/vecmem-0.8.0-kvknx2we7ta64cuqrp6v7n7uuhbo5o6k
```

Note that this doesn't resolve the same issue when using an external dpcpp, nor does it address a large number of other libraries which may or may not be used.

Maintainer tag: @rscohn2

[^1]: `sed -i 's/+sycl/+sycl %gcc/' $(spack location -p vecmem)/package.py` to allow vecmem to be compiled with dpcpp instead of pulling in hipsycl as a dependency.
[^2]: `spack install vecmem%dpcpp +sycl ^cmake%oneapi` to avoid using dpcpp for all dependencies, which are not guaranteed to be support the C++17 standard required by dpcpp.