### PR TITLE
frontier-client: Adapt pacparser_setmyip function to new pacparser release

### DIFF
--- a/var/spack/repos/builtin/packages/frontier-client/package.py
+++ b/var/spack/repos/builtin/packages/frontier-client/package.py
@@ -26,6 +26,21 @@ class FrontierClient(MakefilePackage):
 
     patch('frontier-client.patch', level=0)
 
+    @when('^pacparser@1.3.9:')
+    def patch(self):
+        filter_file('static void (*pp_setmyip)(const char *);',
+                    'static int (*pp_setmyip)(const char *);',
+                    'client/pacparser-dlopen.c', string=True)
+        filter_file('void pacparser_setmyip(const char *ip)',
+                    'int pacparser_setmyip(const char *ip)',
+                    'client/pacparser-dlopen.c', string=True)
+        filter_file(r'  if\(\!pp_dlhandle\)\n    return;',
+                    r'  if\(\!pp_dlhandle\)\n    return 0;',
+                    'client/pacparser-dlopen.c')
+        filter_file('  (*pp_setmyip)(ip);',
+                    '  return (*pp_setmyip)(ip);',
+                    'client/pacparser-dlopen.c', string=True)
+
     def edit(self, spec, prefix):
         makefile = FileFilter('client/Makefile')
         makefile.filter('EXPAT_DIR}/lib', 'EXPAT_DIR}/lib64')

--- a/var/spack/repos/builtin/packages/frontier-client/package.py
+++ b/var/spack/repos/builtin/packages/frontier-client/package.py
@@ -26,6 +26,11 @@ class FrontierClient(MakefilePackage):
 
     patch('frontier-client.patch', level=0)
 
+    # pacparser changed the function return type from void to
+    # int from v1.3.9, whereas frontier-client has not tagged
+    # any new versions in a while. Therefore, the patch below
+    # serves as a (temporary) fix. See 
+    # https://github.com/spack/spack/pull/29936
     @when('^pacparser@1.3.9:')
     def patch(self):
         filter_file('static void (*pp_setmyip)(const char *);',

--- a/var/spack/repos/builtin/packages/frontier-client/package.py
+++ b/var/spack/repos/builtin/packages/frontier-client/package.py
@@ -29,7 +29,7 @@ class FrontierClient(MakefilePackage):
     # pacparser changed the function return type from void to
     # int from v1.3.9, whereas frontier-client has not tagged
     # any new versions in a while. Therefore, the patch below
-    # serves as a (temporary) fix. See 
+    # serves as a (temporary) fix. See
     # https://github.com/spack/spack/pull/29936
     @when('^pacparser@1.3.9:')
     def patch(self):


### PR DESCRIPTION
Pacparser 1.3.9 changed the `pacparser_setmyip` function return type from void( https://github.com/manugarg/pacparser/blob/v1.3.8/src/pacparser.h#L110-L111) to int (https://github.com/manugarg/pacparser/blob/v1.3.9/src/pacparser.h#L111-L112). frontier-client hasn't had a new release recently, and hence the function implementation is not yet overridden: https://github.com/fermitools/frontier/blob/v2_9_1/client/pacparser-dlopen.c#L94-L99, which triggers this error when frontier-client depends on the newest pacparser release:
```
2 errors found in build log:
     34    gcc -Wall -g -O2 -DFRONTIER_DEBUG -fPIC -DPIC -I/build/hahansen/Spack/packages/expat/2.4.8/x86_64-centos7-gcc11.2.0-opt/zxlf6/include  -I/build/hahansen/Spack/packages/pacparser/1.3.9/x86_64-centos7-
           gcc11.2.0-opt/pi43o/include  -I./include -I. -c memdata.c
     35    gcc -Wall -g -O2 -DFRONTIER_DEBUG -fPIC -DPIC -I/build/hahansen/Spack/packages/expat/2.4.8/x86_64-centos7-gcc11.2.0-opt/zxlf6/include  -I/build/hahansen/Spack/packages/pacparser/1.3.9/x86_64-centos7-
           gcc11.2.0-opt/pi43o/include  -I./include -I. -c frontier_log.c
     36    gcc -Wall -g -O2 -DFRONTIER_DEBUG -fPIC -DPIC -I/build/hahansen/Spack/packages/expat/2.4.8/x86_64-centos7-gcc11.2.0-opt/zxlf6/include  -I/build/hahansen/Spack/packages/pacparser/1.3.9/x86_64-centos7-
           gcc11.2.0-opt/pi43o/include  -I./include -I. -c frontier_error.c
     37    gcc -DFNAPI_VERSION="\"2.9.1\"" -Wall -g -O2 -DFRONTIER_DEBUG -fPIC -DPIC -I/build/hahansen/Spack/packages/expat/2.4.8/x86_64-centos7-gcc11.2.0-opt/zxlf6/include  -I/build/hahansen/Spack/packages/pac
           parser/1.3.9/x86_64-centos7-gcc11.2.0-opt/pi43o/include  -I./include -I. -c frontier_config.c
     38    gcc -Wall -g -O2 -DFRONTIER_DEBUG -fPIC -DPIC -I/build/hahansen/Spack/packages/expat/2.4.8/x86_64-centos7-gcc11.2.0-opt/zxlf6/include  -I/build/hahansen/Spack/packages/pacparser/1.3.9/x86_64-centos7-
           gcc11.2.0-opt/pi43o/include  -I./include -I. -c fn-mem.c
     39    gcc -Wall -g -O2 -DFRONTIER_DEBUG -fPIC -DPIC -I/build/hahansen/Spack/packages/expat/2.4.8/x86_64-centos7-gcc11.2.0-opt/zxlf6/include  -I/build/hahansen/Spack/packages/pacparser/1.3.9/x86_64-centos7-
           gcc11.2.0-opt/pi43o/include  -I./include -I. -c pacparser-dlopen.c
  >> 40    pacparser-dlopen.c:94:6: error: conflicting types for 'pacparser_setmyip'; have 'void(const char *)'
     41       94 | void pacparser_setmyip(const char *ip)
     42          |      ^~~~~~~~~~~~~~~~~
     43    In file included from pacparser-dlopen.c:17:
     44    /build/hahansen/Spack/packages/pacparser/1.3.9/x86_64-centos7-gcc11.2.0-opt/pi43o/include/pacparser.h:111:5: note: previous declaration of 'pacparser_setmyip' with type 'int(const char *)'
     45      111 | int pacparser_setmyip(const char *ip                 // Custom IP address.
     46          |     ^~~~~~~~~~~~~~~~~
  >> 47    make: *** [pacparser-dlopen.o] Error 1

```