### PR TITLE
mumps: install header files as compiled

### DIFF
--- a/var/spack/repos/builtin/packages/mumps/package.py
+++ b/var/spack/repos/builtin/packages/mumps/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import glob
 import os
 import sys
 
@@ -44,6 +45,8 @@ class Mumps(Package):
             description='Activate the compilation of cmumps and/or zmumps')
     variant('int64', default=False,
             description='Use int64_t/integer*8 as default index type')
+    variant("incfort", default=False,
+            description="Use explicit types size in fortran headers")
     variant('shared', default=True, description='Build shared libraries')
     variant('openmp', default=True,
             description='Compile MUMPS with OpenMP support')
@@ -75,6 +78,20 @@ class Mumps(Package):
               msg="You cannot use the ptscotch variant without mpi")
     conflicts('+blr_mt', when='~openmp',
               msg="You cannot use the blr_mt variant without openmp")
+
+    @when("+incfort")
+    def patch(self):
+        """Set the effective integer type used during compilation.
+        Usual usecase: building mumps with int and compiling a program that
+        includes these headers with '-fdefault-integer-8'.
+        """
+        headers = glob.glob("include/*.h")
+        intsize = 8 if "+int64" in self.spec else 4
+        filter_file("INTEGER *,", "INTEGER({0}),".format(intsize), *headers)
+        filter_file("INTEGER *::", "INTEGER({0}) ::".format(intsize), *headers)
+        for typ in ("REAL", "COMPLEX", "LOGICAL"):
+            filter_file("{0} *,".format(typ), "{0}(4),".format(typ), *headers)
+            filter_file("{0} *::".format(typ), "{0}(4) ::".format(typ), *headers)
 
     def write_makefile_inc(self):
         # The makefile variables LIBBLAS, LSCOTCH, LMETIS, and SCALAP are only


### PR DESCRIPTION
This patch installs the headers files (fortran) by changing the default `INTEGER` type with the kind used during compilation stage.
With `+int64`, it will use `INTEGER*8`. Otherwise, it will be `INTEGER*4`.
This is enabled with a new variant `+incfort`.

This is very interesting in this usecase: compiling mumps with *short* int and building a program that includes these headers with `-fdefault-integer-8/-i8`.