### PR TITLE
mpich: no longer a need for custom urls

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -24,13 +24,6 @@ class Mpich(AutotoolsPackage):
     tags = ['e4s']
     executables = ['^mpichversion$']
 
-    def url_for_version(self, version):
-        if (version >= Version('4.0')):
-            url = "https://github.com/pmodels/mpich/releases/download/v{0}/mpich-{0}.tar.gz"
-        else:
-            url = "https://www.mpich.org/static/downloads/{0}/mpich-{0}.tar.gz"
-        return url.format(version)
-
     version('develop', submodules=True)
     version('4.0.1', sha256='66a1fe8052734af2eb52f47808c4dfef4010ceac461cb93c42b99acfb1a43687')
     version('4.0', sha256='df7419c96e2a943959f7ff4dc87e606844e736e30135716971aba58524fbff64')


### PR DESCRIPTION
Now that we set the `User-Agent: Spackbot/<version>` in the fetcher (#29919), we can
download from mpich's website. This improves `spack checksum mpich` too.

