### PR TITLE
environment.py: concretize together by default

### DIFF
--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -274,17 +274,17 @@ Concretizing
 ^^^^^^^^^^^^
 
 Once some user specs have been added to an environment, they can be
-concretized. *By default specs are concretized separately*, one after
-the other. This mode of operation permits to deploy a full
-software stack where multiple configurations of the same package
-need to be installed alongside each other. Central installations done
-at HPC centers by system administrators or user support groups
-are a common case that fits in this behavior.
-Environments *can also be configured to concretize all
+concretized. By default, environments *concretize all
 the root specs in a self-consistent way* to ensure that
 each package in the environment comes with a single configuration. This
 mode of operation is usually what is required by software developers that
 want to deploy their development environment.
+Alternatively, environments can be *concretized separately*. This mode
+of operation permits to deploy a full
+software stack where multiple configurations of the same package
+need to be installed alongside each other. Central installations done
+at HPC centers by system administrators or user support groups
+are a common case that fits in this behavior.
 
 Regardless of which mode of operation has been chosen, the following
 command will ensure all the root specs are concretized according to the

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -766,8 +766,8 @@ class Environment(object):
             self.views = {}
         # Retrieve the current concretization strategy
         configuration = config_dict(self.yaml)
-        # default concretization to separately
-        self.concretization = configuration.get('concretization', 'separately')
+        # default concretization to together
+        self.concretization = configuration.get('concretization', 'together')
 
         # Retrieve dev-build packages:
         self.dev_specs = configuration.get('develop', {})


### PR DESCRIPTION
We have somewhat conflicting defaults, namely `view: true` and
`concretization: separately`.

This leads to post-install errors when merging different flavors of the
same package into the default view.

It makes more sense to either disable views or do consistent
concretization by default.

Our docs hint that `concretization: separately` is aimed at system
administrators, which is likely a small percentage of spack users.
By now many people use environments to just build stuff, given that
repeated concretization is slow, `spack install x` doesn't even show
what gets built, etc, all better when using environments. And for those
users consistent concretization makes more sense.