### PR TITLE
Windows: Add option to build CMake's internal curl with winsspi

### DIFF
--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -268,7 +268,7 @@ class Cmake(Package):
 
     def setup_build_environment(self, env):
         spec = self.spec
-        if '+ownlibs' in spec and '+winssl' not in spec:
+        if '+ownlibs' in spec and 'platform=windows' in spec:
             env.set('OPENSSL_ROOT_DIR', spec['openssl'].prefix)
 
     def bootstrap_args(self):

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -268,7 +268,7 @@ class Cmake(Package):
 
     def setup_build_environment(self, env):
         spec = self.spec
-        if '+ownlibs' in spec and 'platform=windows' in spec:
+        if '+ownlibs' in spec and 'platform=windows' not in spec:
             env.set('OPENSSL_ROOT_DIR', spec['openssl'].prefix)
 
     def bootstrap_args(self):

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -196,6 +196,9 @@ class Cmake(Package):
         depends_on('python@2.7.11:', type='build')
         depends_on('py-sphinx', type='build')
 
+    # TODO: update curl package to build with Windows SSL implementation
+    # at which point we can build with +ownlibs on Windows
+    conflicts('~ownlibs', when='platform=windows')
     # Cannot build with Intel, should be fixed in 3.6.2
     # https://gitlab.kitware.com/cmake/cmake/issues/16226
     patch('intel-c-gnu11.patch', when='@3.6.0:3.6.1')


### PR DESCRIPTION
CMake's internal copy of curl used with the `+ownlibs` variant has the ability to link against the winsspi.dll, a Windows native implementation of SSL. This PR exposes another variant of the CMake package on Windows allowing users to build CMake with winsspi, rather than OpenSSL.

Some small, Windows specific cleanup was also done in this PR.