### PR TITLE
Gitlab pipelines no temp storage

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -96,7 +96,6 @@ spack:
             CI_JOB_SIZE: "default"
 
 
-    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
     service-job-attributes:
       before_script:

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -134,15 +134,12 @@ spack:
             KUBERNETES_CPU_REQUEST: "500m"
             KUBERNETES_MEMORY_REQUEST: "500M"
 
-
       - match: ['@:']
         runner-attributes:
           tags: ["spack", "public", "x86_64"]
           variables:
             CI_JOB_SIZE: "default"
 
-
-    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
     service-job-attributes:
       image: { "name": "ghcr.io/spack/e4s-ubuntu-18.04:v2021-10-18", "entrypoint": [""] }

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -47,7 +47,6 @@ spack:
         runner-attributes:
           tags:
           - omicron
-    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
     service-job-attributes:
       before_script:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -241,7 +241,6 @@ spack:
         runner-attributes:
           image: { "name": "ghcr.io/spack/e4s-ubuntu-20.04:v2021-10-18", "entrypoint": [""] }
           tags: ["spack", "public", "large", "ppc64le"]
-    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
     service-job-attributes:
       before_script:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -403,7 +403,6 @@ spack:
           variables:
             CI_JOB_SIZE: "default"
 
-    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
     service-job-attributes:
       before_script:

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -158,7 +158,7 @@ spack:
           tags: ["spack", "public", "x86_64"]
           variables:
             CI_JOB_SIZE: "default"
-    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
+
     service-job-attributes:
       before_script:
         - . "./share/spack/setup-env.sh"

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -134,7 +134,7 @@ spack:
           tags: ["spack", "public", "x86_64"]
           variables:
             CI_JOB_SIZE: default
-    temporary-storage-url-prefix: "s3://spack-binaries-prs/pipeline-storage"
+
     broken-specs-url: "s3://spack-binaries-develop/broken-specs"
     service-job-attributes:
       image: { "name": "ghcr.io/spack/tutorial-ubuntu-18.04:v2021-11-02", "entrypoint": [""] }
@@ -142,7 +142,6 @@ spack:
         - . "./share/spack/setup-env.sh"
         - spack --version
       tags: ["spack", "public", "x86_64"]
-
 
   cdash:
     build-group: Spack Tutorial


### PR DESCRIPTION
By removing this url, which we should not need as long as we have per-PR storage allocated, we can get rid of the `cleanup` jobs which seem to be failing frequently.