### PR TITLE
spack ci: remove relate-CDash-builds functionality

### DIFF
--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -2065,14 +2065,13 @@ def download_buildcache_entry(file_descriptions, mirror_url=None):
 
 
 def download_single_spec(
-        concrete_spec, destination, require_cdashid=False, mirror_url=None
+        concrete_spec, destination, mirror_url=None
 ):
     """Download the buildcache files for a single concrete spec.
 
     Args:
         concrete_spec: concrete spec to be downloaded
         destination (str): path where to put the downloaded buildcache
-        require_cdashid (bool): if False the `.cdashid` file is optional
         mirror_url (str): url of the mirror from which to download
     """
     tarfile_name = tarball_name(concrete_spec, '.spack')
@@ -2090,10 +2089,6 @@ def download_single_spec(
                     tarball_name(concrete_spec, '.spec.yaml')],
             'path': destination,
             'required': True,
-        }, {
-            'url': [tarball_name(concrete_spec, '.cdashid')],
-            'path': destination,
-            'required': require_cdashid,
         },
     ]
 

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -1026,16 +1026,7 @@ def generate_gitlab_ci_yaml(env, print_summary, output_file,
                     cdash_build_name = get_cdash_build_name(
                         release_spec, build_group)
                     all_job_names.append(cdash_build_name)
-
-                    related_builds = []      # Used for relating CDash builds
-                    if spec_label in dependencies:
-                        related_builds = (
-                            [spec_labels[d]['spec'].name
-                                for d in dependencies[spec_label]])
-
                     job_vars['SPACK_CDASH_BUILD_NAME'] = cdash_build_name
-                    job_vars['SPACK_RELATED_BUILDS_CDASH'] = ';'.join(
-                        sorted(related_builds))
 
                 variables.update(job_vars)
 
@@ -1340,8 +1331,7 @@ def configure_compilers(compiler_action, scope=None):
     return None
 
 
-def get_concrete_specs(env, root_spec, job_name, related_builds,
-                       compiler_action):
+def get_concrete_specs(env, root_spec, job_name, compiler_action):
     spec_map = {
         'root': None,
         'deps': {},
@@ -1367,10 +1357,6 @@ def get_concrete_specs(env, root_spec, job_name, related_builds,
 
     spec_map['root'] = concrete_root
     spec_map[job_name] = concrete_root[job_name]
-
-    if related_builds:
-        for dep_job_name in related_builds.split(';'):
-            spec_map['deps'][dep_job_name] = concrete_root[dep_job_name]
 
     return spec_map
 
@@ -1416,67 +1402,6 @@ def register_cdash_build(build_name, base_url, project, site, track):
         print("Registering build in CDash failed: {0}".format(e))
 
     return (build_id, build_stamp)
-
-
-def relate_cdash_builds(spec_map, cdash_base_url, job_build_id, cdash_project,
-                        cdashids_mirror_urls):
-    if not job_build_id:
-        return
-
-    dep_map = spec_map['deps']
-
-    headers = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-    }
-
-    cdash_api_url = '{0}/api/v1/relateBuilds.php'.format(cdash_base_url)
-
-    for dep_pkg_name in dep_map:
-        tty.debug('Fetching cdashid file for {0}'.format(dep_pkg_name))
-        dep_spec = dep_map[dep_pkg_name]
-        dep_build_id = None
-
-        for url in cdashids_mirror_urls:
-            try:
-                if url:
-                    dep_build_id = read_cdashid_from_mirror(dep_spec, url)
-                    break
-            except web_util.SpackWebError:
-                tty.debug('Did not find cdashid for {0} on {1}'.format(
-                    dep_pkg_name, url))
-        else:
-            tty.warn('Did not find cdashid for {0} anywhere'.format(
-                dep_pkg_name))
-            return
-
-        payload = {
-            "project": cdash_project,
-            "buildid": job_build_id,
-            "relatedid": dep_build_id,
-            "relationship": "depends on"
-        }
-
-        enc_data = json.dumps(payload).encode('utf-8')
-
-        opener = build_opener(HTTPHandler)
-
-        request = Request(cdash_api_url, data=enc_data, headers=headers)
-
-        try:
-            response = opener.open(request)
-            response_code = response.getcode()
-
-            if response_code != 200 and response_code != 201:
-                msg = 'Relate builds ({0} -> {1}) failed (resp code = {2})'.format(
-                    job_build_id, dep_build_id, response_code)
-                tty.warn(msg)
-                return
-
-            response_text = response.read()
-            tty.debug('Relate builds response: {0}'.format(response_text))
-        except Exception as e:
-            print("Relating builds in CDash failed: {0}".format(e))
 
 
 def write_cdashid_to_mirror(cdashid, spec, mirror_url):

--- a/lib/spack/spack/ci.py
+++ b/lib/spack/spack/ci.py
@@ -5,7 +5,6 @@
 
 import base64
 import copy
-import datetime
 import json
 import os
 import re
@@ -1333,7 +1332,6 @@ def configure_compilers(compiler_action, scope=None):
 def get_concrete_specs(env, root_spec, job_name, compiler_action):
     spec_map = {
         'root': None,
-        'deps': {},
     }
 
     if compiler_action == 'FIND_ANY':
@@ -1358,49 +1356,6 @@ def get_concrete_specs(env, root_spec, job_name, compiler_action):
     spec_map[job_name] = concrete_root[job_name]
 
     return spec_map
-
-
-def register_cdash_build(build_name, base_url, project, site, track):
-    url = base_url + '/api/v1/addBuild.php'
-    time_stamp = datetime.datetime.now().strftime('%Y%m%d-%H%M')
-    build_id = None
-    build_stamp = '{0}-{1}'.format(time_stamp, track)
-    payload = {
-        "project": project,
-        "site": site,
-        "name": build_name,
-        "stamp": build_stamp,
-    }
-
-    tty.debug('Registering cdash build to {0}, payload:'.format(url))
-    tty.debug(payload)
-
-    enc_data = json.dumps(payload).encode('utf-8')
-
-    headers = {
-        'Content-Type': 'application/json',
-    }
-
-    opener = build_opener(HTTPHandler)
-
-    request = Request(url, data=enc_data, headers=headers)
-
-    try:
-        response = opener.open(request)
-        response_code = response.getcode()
-
-        if response_code != 200 and response_code != 201:
-            msg = 'Adding build failed (response code = {0}'.format(response_code)
-            tty.warn(msg)
-            return (None, None)
-
-        response_text = response.read()
-        response_json = json.loads(response_text)
-        build_id = response_json['buildid']
-    except Exception as e:
-        print("Registering build in CDash failed: {0}".format(e))
-
-    return (build_id, build_stamp)
 
 
 def _push_mirror_contents(env, specfile_path, sign_binaries, mirror_url):

--- a/lib/spack/spack/ci_optimization.py
+++ b/lib/spack/spack/ci_optimization.py
@@ -308,8 +308,7 @@ def optimizer(yaml):
     # try factoring out commonly repeated portions
     common_job = {
         'variables': {
-            'SPACK_COMPILER_ACTION': 'NONE',
-            'SPACK_RELATED_BUILDS_CDASH': ''
+            'SPACK_COMPILER_ACTION': 'NONE'
         },
 
         'after_script': ['rm -rf "./spack"'],

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -400,7 +400,6 @@ def ci_rebuild(args):
             bindist.download_single_spec(
                 job_spec,
                 build_cache_dir,
-                require_cdashid=False,
                 mirror_url=matching_mirror
             )
 
@@ -553,12 +552,6 @@ def ci_rebuild(args):
                 env, job_spec_yaml_path, buildcache_mirror_url, sign_binaries
             )
 
-            if cdash_build_id:
-                tty.debug('Writing cdashid ({0}) to remote mirror: {1}'.format(
-                    cdash_build_id, buildcache_mirror_url))
-                spack_ci.write_cdashid_to_mirror(
-                    cdash_build_id, job_spec, buildcache_mirror_url)
-
         # Create another copy of that buildcache in the per-pipeline
         # temporary storage mirror (this is only done if either
         # artifacts buildcache is enabled or a temporary storage url
@@ -567,12 +560,6 @@ def ci_rebuild(args):
             spack_ci.push_mirror_contents(
                 env, job_spec_yaml_path, pipeline_mirror_url, sign_binaries
             )
-
-            if cdash_build_id:
-                tty.debug('Writing cdashid ({0}) to remote mirror: {1}'.format(
-                    cdash_build_id, pipeline_mirror_url))
-                spack_ci.write_cdashid_to_mirror(
-                    cdash_build_id, job_spec, pipeline_mirror_url)
 
         # If this is a develop pipeline, check if the spec that we just built is
         # on the broken-specs list. If so, remove it.

--- a/lib/spack/spack/cmd/ci.py
+++ b/lib/spack/spack/cmd/ci.py
@@ -373,9 +373,6 @@ def ci_rebuild(args):
                          pipeline_mirror_url,
                          cfg.default_modify_scope())
 
-    cdash_build_id = None
-    cdash_build_stamp = None
-
     # Check configured mirrors for a built spec with a matching full hash
     matches = bindist.get_mirrors_for_spec(
         job_spec, full_hash_match=True, index_only=False)
@@ -426,15 +423,8 @@ def ci_rebuild(args):
     if not verify_binaries:
         install_args.append('--no-check-signature')
 
-    # If CDash reporting is enabled we register this build with
-    # the specified CDash instance.
     if enable_cdash:
-        tty.debug('CDash: Registering build')
-        (cdash_build_id,
-            cdash_build_stamp) = spack_ci.register_cdash_build(
-            cdash_build_name, cdash_base_url, cdash_project,
-            cdash_site, job_spec_buildgroup)
-
+        # Add additional arguments to `spack install` for CDash reporting.
         cdash_upload_url = '{0}/submit.php?project={1}'.format(
             cdash_base_url, cdash_project_enc)
 
@@ -442,7 +432,7 @@ def ci_rebuild(args):
             '--cdash-upload-url', cdash_upload_url,
             '--cdash-build', cdash_build_name,
             '--cdash-site', cdash_site,
-            '--cdash-buildstamp', cdash_build_stamp,
+            '--cdash-track', job_spec_buildgroup,
         ])
 
     # A compiler action of 'FIND_ANY' means we are building a bootstrap

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -18,7 +18,6 @@ import spack.ci_optimization as ci_opt
 import spack.config as cfg
 import spack.environment as ev
 import spack.error
-import spack.main as spack_main
 import spack.paths as spack_paths
 import spack.spec as spec
 import spack.util.gpg
@@ -170,27 +169,6 @@ def test_register_cdash_build(monkeypatch):
         build_name, base_url, project, site, track)
 
     assert(build_id == 42)
-
-
-@pytest.mark.skipif(sys.platform == 'win32',
-                    reason="Not supported on Windows (yet)")
-def test_read_write_cdash_ids(config, tmp_scope, tmpdir, mock_packages):
-    working_dir = tmpdir.join('working_dir')
-    mirror_dir = working_dir.join('mirror')
-    mirror_url = 'file://{0}'.format(mirror_dir.strpath)
-
-    mirror_cmd = spack_main.SpackCommand('mirror')
-    mirror_cmd('add', '--scope', tmp_scope, 'test_mirror', mirror_url)
-
-    mock_spec = spec.Spec('archive-files').concretized()
-    orig_cdashid = '42'
-
-    ci.write_cdashid_to_mirror(orig_cdashid, mock_spec, mirror_url)
-
-    # Now read it back
-    read_cdashid = ci.read_cdashid_from_mirror(mock_spec, mirror_url)
-
-    assert(str(read_cdashid) == orig_cdashid)
 
 
 def test_download_and_extract_artifacts(tmpdir, monkeypatch, working_env):
@@ -354,7 +332,6 @@ def test_ci_workarounds():
                     'jobs_scratch_dir',
                     'cdash_report',
                     name + '.spec.json',
-                    name + '.cdashid',
                     name
                 ],
                 'when': 'always'

--- a/lib/spack/spack/test/ci.py
+++ b/lib/spack/spack/test/ci.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import itertools as it
-import json
 import os
 import sys
 
@@ -148,27 +147,6 @@ class FakeWebResponder(object):
         self._read.pop()
         self._content.pop()
         return None
-
-
-@pytest.mark.maybeslow
-def test_register_cdash_build(monkeypatch):
-    build_name = 'Some pkg'
-    base_url = 'http://cdash.fake.org'
-    project = 'spack'
-    site = 'spacktests'
-    track = 'Experimental'
-
-    response_obj = {
-        'buildid': 42
-    }
-
-    fake_responder = FakeWebResponder(
-        content_to_read=[json.dumps(response_obj)])
-    monkeypatch.setattr(ci, 'build_opener', lambda handler: fake_responder)
-    build_id, build_stamp = ci.register_cdash_build(
-        build_name, base_url, project, site, track)
-
-    assert(build_id == 42)
 
 
 def test_download_and_extract_artifacts(tmpdir, monkeypatch, working_env):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -767,7 +767,6 @@ spack:
             'SPACK_JOB_SPEC_PKG_NAME': 'archive-files',
             'SPACK_COMPILER_ACTION': 'NONE',
             'SPACK_CDASH_BUILD_NAME': '(specs) archive-files',
-            'SPACK_RELATED_BUILDS_CDASH': '',
             'SPACK_REMOTE_MIRROR_URL': mirror_url,
             'SPACK_PIPELINE_TYPE': 'spack_protected_branch',
             'CI_JOB_URL': ci_job_url,
@@ -940,7 +939,7 @@ spack:
         env_cmd('create', 'test', './spack.yaml')
         with ev.read('test') as env:
             spec_map = ci.get_concrete_specs(
-                env, 'patchelf', 'patchelf', '', 'FIND_ANY')
+                env, 'patchelf', 'patchelf', 'FIND_ANY')
             concrete_spec = spec_map['patchelf']
             spec_json = concrete_spec.to_json(hash=ht.build_hash)
             json_path = str(tmpdir.join('spec.json'))
@@ -1285,7 +1284,7 @@ spack:
         env_cmd('create', 'test', './spack.yaml')
         with ev.read('test') as env:
             spec_map = ci.get_concrete_specs(
-                env, 'callpath', 'callpath', '', 'FIND_ANY')
+                env, 'callpath', 'callpath', 'FIND_ANY')
             concrete_spec = spec_map['callpath']
             spec_yaml = concrete_spec.to_yaml(hash=ht.build_hash)
             yaml_path = str(tmpdir.join('spec.yaml'))

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -951,8 +951,6 @@ spack:
             # env, spec, json_path, mirror_url, build_id, sign_binaries
             ci.push_mirror_contents(env, json_path, mirror_url, True)
 
-            ci.write_cdashid_to_mirror('42', concrete_spec, mirror_url)
-
             buildcache_path = os.path.join(mirror_dir.strpath, 'build_cache')
 
             # Now test the --prune-dag (default) option of spack ci generate
@@ -1034,10 +1032,10 @@ spack:
             if not os.path.exists(dl_dir.strpath):
                 os.makedirs(dl_dir.strpath)
             buildcache_cmd('download', '--spec-file', json_path, '--path',
-                           dl_dir.strpath, '--require-cdashid')
+                           dl_dir.strpath)
             dl_dir_list = os.listdir(dl_dir.strpath)
 
-            assert(len(dl_dir_list) == 3)
+            assert(len(dl_dir_list) == 2)
 
 
 def test_push_mirror_contents_exceptions(monkeypatch, capsys):

--- a/lib/spack/spack/test/cmd/ci.py
+++ b/lib/spack/spack/test/cmd/ci.py
@@ -743,8 +743,6 @@ spack:
     def fake_cdash_register(build_name, base_url, project, site, track):
         return ('fakebuildid', 'fakestamp')
 
-    monkeypatch.setattr(ci, 'register_cdash_build', fake_cdash_register)
-
     monkeypatch.setattr(spack.cmd.ci, 'CI_REBUILD_INSTALL_BASE_ARGS', [
         'notcommand'
     ])

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -548,7 +548,7 @@ _spack_buildcache_check() {
 }
 
 _spack_buildcache_download() {
-    SPACK_COMPREPLY="-h --help -s --spec --spec-file -p --path -c --require-cdashid"
+    SPACK_COMPREPLY="-h --help -s --spec --spec-file -p --path"
 }
 
 _spack_buildcache_get_buildcache_name() {


### PR DESCRIPTION
This was a seldom used feature. Removing it will make it easier for us to reorganize our CDash projects & build groups in the future by eliminating the needs to keep track of CDash build ids in our binary mirrors.