### PR TITLE
Apply llvm7_intel.patch with intel@19.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -342,7 +342,7 @@ class Llvm(CMakePackage, CudaPackage):
     patch("llvm_python_path.patch", when="@11.0.0")
 
     # Workaround for issue https://github.com/spack/spack/issues/18197
-    patch('llvm7_intel.patch', when='@7 %intel@18.0.2,19.0.4')
+    patch('llvm7_intel.patch', when='@7 %intel@18.0.2,19.0.4,19.1.3')
 
     # Remove cyclades support to build against newer kernel headers
     # https://reviews.llvm.org/D102059

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -342,7 +342,7 @@ class Llvm(CMakePackage, CudaPackage):
     patch("llvm_python_path.patch", when="@11.0.0")
 
     # Workaround for issue https://github.com/spack/spack/issues/18197
-    patch('llvm7_intel.patch', when='@7 %intel@18.0.2,19.0.4,19.1.3')
+    patch('llvm7_intel.patch', when='@7 %intel@18.0.2,19.0.0:19.1.99')
 
     # Remove cyclades support to build against newer kernel headers
     # https://reviews.llvm.org/D102059


### PR DESCRIPTION
This MR simply applies `llvm7_intel.patch` to `intel@19.1.3` compiler version as well.