### PR TITLE
ucx: +cm dropped in 1.11

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -86,7 +86,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
             description="Compile with IB Tag Matching support")
     variant('dm', default=False,
             description="Compile with Device Memory support")
-    variant('cm', default=False,
+    variant('cm', default=False, when='@:1.10',
             description="Compile with IB Connection Manager support")
     variant('backtrace-detail', default=False,
             description="Enable using BFD support for detailed backtrace")


### PR DESCRIPTION
UCX dropped support for `--with-cm` in 1.11. (https://github.com/openucx/ucx/commit/9e73956ef47358a09fdb83ae8f0b02d603535e37)