### PR TITLE
blis: add conflict with nvhpc/pgi

### DIFF
--- a/var/spack/repos/builtin/packages/blis/package.py
+++ b/var/spack/repos/builtin/packages/blis/package.py
@@ -51,6 +51,9 @@ class BlisBase(Package):
     provides('blas', when="+blas")
     provides('blas', when="+cblas")
 
+    conflicts('%nvhpc')
+    conflicts('%pgi')
+
     phases = ['configure', 'build', 'install']
 
     def configure_args(self):


### PR DESCRIPTION
BLIS doesn't build with NVHPC or PGI compilers (among many others) so I'm tagging the conflict to save people some time.
Fixes #29951.