### PR TITLE
ucx: fix opt

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -54,7 +54,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
             description='Enable logging')
     variant('debug', default=False,
             description='Enable debugging')
-    variant('opt', default='0', values=('0', '1', '2', '3'), multi=False,
+    variant('opt', default='3', values=('0', '1', '2', '3'), multi=False,
             description='Set optimization level')
     variant('assertions', default=False,
             description='Enable assertions')

--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -160,7 +160,7 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
         config_args.extend(self.enable_or_disable('optimizations'))
         config_args.append('--enable-compiler-opt=' +
-                           self.spec.variant['opt'].value)
+                           self.spec.variants['opt'].value)
         config_args.extend(self.enable_or_disable('assertions'))
         config_args.extend(self.enable_or_disable('logging'))
 


### PR DESCRIPTION
- `variant` -> `variants`
- default to opt=3 instead of 0

