### PR TITLE
refactor powershell setup to make it sourceable

### DIFF
--- a/bin/spack_pwsh.ps1
+++ b/bin/spack_pwsh.ps1
@@ -3,57 +3,5 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-Push-Location $PSScriptRoot/..
-$Env:SPACK_ROOT = $PWD.Path
-Push-Location $PWD/..
-$Env:spackinstdir = $PWD.Path
-Pop-Location
-
-Set-Variable -Name python_pf_ver -Value (Get-Command -Name python -ErrorAction SilentlyContinue).Path
-
-# If python_pf_ver is not defined, we cannot find Python on the Path
-# We next look for Spack vendored copys
-if ($null -eq $python_pf_ver)
-{
-    $python_pf_ver_list = Resolve-Path -Path "$PWD\Python*"
-    if ($python_pf_ver_list.Length -gt 0)
-    {
-        $py_path = $python_pf_ver_list[$python_pf_ver_list.Length-1].Path
-        $py_exe = "$py_path\python.exe"
-    }
-    else {
-        Write-Error -Message "Python was not found on system"
-        Write-Output "Please install Python or add Python to the PATH"
-    }
-}
-else{
-    Set-Variable -Name py_exe -Value $python_pf_ver
-}
-
-if (!$null -eq $py_path)
-{
-    $Env:Path = "$py_path;$Env:Path"
-}
-
-if (!$null -eq $py_exe)
-{
-    Invoke-Expression "$py_exe $Env:SPACK_ROOT\bin\haspywin.py"
-    Invoke-Expression "$py_exe $Env:SPACK_ROOT\bin\spack external find python" | Out-Null
-}
-
-$Env:Path = "$Env:SPACK_ROOT\bin;$Env:Path"
-$Env:EDITOR = "notepad"
-
-
-Write-Output "*****************************************************************"
-Write-Output "**************** Spack Package Manager **************************"
-Write-Output "*****************************************************************"
-
-$command = 'function global:prompt
-{
-    $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf
-    "[spack] PS $pth>"
-}'
-$bytesc = [System.Text.Encoding]::Unicode.GetBytes($command)
-$encoded_command = [Convert]::ToBase64String($bytesc)
-powershell.exe -NoLogo -encodedCommand $encoded_command -NoExit
+$Env:SPACK_PS1_PATH="$PSScriptRoot\..\share\spack\setup-env.ps1"
+& (Get-Process -Id $pid).Path -NoExit { . $Env:SPACK_PS1_PATH }

--- a/bin/spack_pwsh.ps1
+++ b/bin/spack_pwsh.ps1
@@ -4,4 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 $Env:SPACK_PS1_PATH="$PSScriptRoot\..\share\spack\setup-env.ps1"
-& (Get-Process -Id $pid).Path -NoExit { . $Env:SPACK_PS1_PATH }
+& (Get-Process -Id $pid).Path -NoExit {
+     . $Env:SPACK_PS1_PATH ; 
+    Push-Location $ENV:SPACK_ROOT
+ }

--- a/share/spack/setup-env.ps1
+++ b/share/spack/setup-env.ps1
@@ -42,7 +42,10 @@ if (!$null -eq $py_exe)
 }
 
 $Env:Path = "$Env:SPACK_ROOT\bin;$Env:Path"
-$Env:EDITOR = "notepad"
+if ($null -eq $Env:EDITOR)
+{
+    $Env:EDITOR = "notepad"
+}
 
 
 Write-Output "*****************************************************************"

--- a/share/spack/setup-env.ps1
+++ b/share/spack/setup-env.ps1
@@ -1,0 +1,59 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+Push-Location $PSScriptRoot/../..
+$Env:SPACK_ROOT = $PWD.Path
+Push-Location $PWD/..
+$Env:spackinstdir = $PWD.Path
+Pop-Location
+
+Set-Variable -Name python_pf_ver -Value (Get-Command -Name python -ErrorAction SilentlyContinue).Path
+
+# If python_pf_ver is not defined, we cannot find Python on the Path
+# We next look for Spack vendored copys
+if ($null -eq $python_pf_ver)
+{
+    $python_pf_ver_list = Resolve-Path -Path "$PWD\Python*"
+    if ($python_pf_ver_list.Length -gt 0)
+    {
+        $py_path = $python_pf_ver_list[$python_pf_ver_list.Length-1].Path
+        $py_exe = "$py_path\python.exe"
+    }
+    else {
+        Write-Error -Message "Python was not found on system"
+        Write-Output "Please install Python or add Python to the PATH"
+    }
+}
+else{
+    Set-Variable -Name py_exe -Value $python_pf_ver
+}
+
+if (!$null -eq $py_path)
+{
+    $Env:Path = "$py_path;$Env:Path"
+}
+
+if (!$null -eq $py_exe)
+{
+    Invoke-Expression "$py_exe $Env:SPACK_ROOT\bin\haspywin.py"
+    Invoke-Expression "$py_exe $Env:SPACK_ROOT\bin\spack external find python" | Out-Null
+}
+
+$Env:Path = "$Env:SPACK_ROOT\bin;$Env:Path"
+$Env:EDITOR = "notepad"
+
+
+Write-Output "*****************************************************************"
+Write-Output "**************** Spack Package Manager **************************"
+Write-Output "*****************************************************************"
+
+function global:prompt
+{
+    $pth = $(Convert-Path $(Get-Location)) | Split-Path -leaf
+    "[spack] PS $pth>"
+}
+Pop-Location
+
+

--- a/share/spack/setup-env.ps1
+++ b/share/spack/setup-env.ps1
@@ -59,4 +59,3 @@ function global:prompt
 }
 Pop-Location
 
-


### PR DESCRIPTION
Was playing with this again today, mainly looking at how to run something akin to just "spack" from a regular shell, or to be able to invoke spack directly from WSL, and in the process really wanted to be able to just source the environment.  This refactors the current powershell setup to make the environment changes sourceable with the `.` operator and then uses that to implement the launch.  It also re-works the bin file to get the name of the enclosing powershell process to support powershell core, for which the binary name is `pwsh` rather than `powershell.exe` in some environments.