### PR TITLE
Several updates to the ArrayFire package

### DIFF
--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -13,6 +13,7 @@ class Arrayfire(CMakePackage, CudaPackage):
 
     homepage = "https://arrayfire.org/docs/index.htm"
     git      = "https://github.com/arrayfire/arrayfire.git"
+    maintainers = ['umar456']
 
     version('master')
     version('3.8.1', tag='v3.8.1')

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -21,7 +21,6 @@ class Arrayfire(CMakePackage, CudaPackage):
     version('3.7.2', submodules=True, tag='v3.7.2')
     version('3.7.0', submodules=True, tag='v3.7.0')
 
-    variant('cuda',   default=False, description='Enable CUDA backend')
     variant('forge',  default=False, description='Enable graphics library')
     variant('opencl', default=False, description='Enable OpenCL backend')
 
@@ -37,6 +36,9 @@ class Arrayfire(CMakePackage, CudaPackage):
 
     depends_on('fontconfig', when='+forge')
     depends_on('glfw@3.1.4:', when='+forge')
+
+    conflicts('cuda_arch=none', when='+cuda',
+          msg='CUDA architecture is required')
 
     @property
     def libs(self):
@@ -64,13 +66,10 @@ class Arrayfire(CMakePackage, CudaPackage):
         ])
 
         if '+cuda' in self.spec:
-            cuda_arch_list = self.spec.variants['cuda_arch'].value
-            cuda_arch = cuda_arch_list[0]
-            if cuda_arch != 'none':
-                arch_list_string = ['{}.{}'.format(arch[:-1], arch[-1])
-                                    for arch in cuda_arch_list]
-                args.append(self.define('CUDA_architecture_build_targets',
-                                        arch_list_string))
+            arch_list = ['{}.{}'.format(arch[:-1], arch[-1])
+                                for arch in self.spec.variants['cuda_arch'].value]
+            args.append(self.define('CUDA_architecture_build_targets',
+                                    arch_list))
 
         if '^mkl' in self.spec:
             if self.version >= Version('3.8.0'):

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Arrayfire(CMakePackage, CudaPackage):
@@ -24,12 +23,7 @@ class Arrayfire(CMakePackage, CudaPackage):
     variant('forge',   default=False, description='Enable graphics library')
     variant('opencl', default=False, description='Enable OpenCL backend')
 
-    depends_on('boost@1.65:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost@1.75:')
     depends_on('fftw-api@3:')
     depends_on('blas')
     depends_on('cuda@7.5:', when='+cuda')

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -38,7 +38,7 @@ class Arrayfire(CMakePackage, CudaPackage):
     depends_on('glfw@3.1.4:', when='+forge')
 
     conflicts('cuda_arch=none', when='+cuda',
-          msg='CUDA architecture is required')
+              msg='CUDA architecture is required')
 
     @property
     def libs(self):
@@ -67,7 +67,7 @@ class Arrayfire(CMakePackage, CudaPackage):
 
         if '+cuda' in self.spec:
             arch_list = ['{}.{}'.format(arch[:-1], arch[-1])
-                                for arch in self.spec.variants['cuda_arch'].value]
+                         for arch in self.spec.variants['cuda_arch'].value]
             args.append(self.define('CUDA_architecture_build_targets',
                                     arch_list))
 

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -16,10 +16,10 @@ class Arrayfire(CMakePackage, CudaPackage):
     maintainers = ['umar456']
 
     version('master')
-    version('3.8.1', tag='v3.8.1')
-    version('3.7.3', submodules=True, tag='v3.7.3')
-    version('3.7.2', submodules=True, tag='v3.7.2')
-    version('3.7.0', submodules=True, tag='v3.7.0')
+    version('3.8.1', commit='823e8e399fe8c120c6ec7ec75f09e6106b3074ca', tag='v3.8.1')
+    version('3.7.3', commit='59ac7b980d1ae124aae914fb29cbf086c948954d', submodules=True, tag='v3.7.3')
+    version('3.7.2', commit='218dd2c99300e77496239ade76e94b0def65d032', submodules=True, tag='v3.7.2')
+    version('3.7.0', commit='fbea2aeb6f7f2d277dcb0ab425a77bb18ed22291', submodules=True, tag='v3.7.0')
 
     variant('forge',  default=False, description='Enable graphics library')
     variant('opencl', default=False, description='Enable OpenCL backend')

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -65,6 +65,19 @@ class Arrayfire(CMakePackage, CudaPackage):
             self.define_from_variant('AF_BUILD_FORGE', 'forge'),
             self.define_from_variant('AF_BUILD_OPENCL', 'opencl'),
         ])
+
+        if '+cuda' in self.spec:
+            cuda_arch_list = self.spec.variants['cuda_arch'].value
+            cuda_arch = cuda_arch_list[0]
+            if cuda_arch == 'none':
+                args.append(self.define('CUDA_architecture_build_targets', 'Auto'))
+            else:
+                arch_list_string = []
+                for arch in cuda_arch_list:
+                    arch_list_string.append('{}.{}'.format(arch[:-1], arch[-1]))
+                args.append(self.define('CUDA_architecture_build_targets',
+                                        ';'.join(arch_list_string)))
+
         if '^mkl' in self.spec:
             args.append('-DUSE_CPU_MKL=ON')
             if '%intel' not in self.spec:

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -25,7 +25,7 @@ class Arrayfire(CMakePackage, CudaPackage):
     variant('forge',  default=False, description='Enable graphics library')
     variant('opencl', default=False, description='Enable OpenCL backend')
 
-    depends_on('boost@1.75:')
+    depends_on('boost@1.70:')
     depends_on('fftw-api@3:')
     depends_on('blas')
     depends_on('cuda@7.5:', when='+cuda')

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -24,7 +24,6 @@ class Arrayfire(CMakePackage, CudaPackage):
     variant('cuda',   default=False, description='Enable CUDA backend')
     variant('forge',  default=False, description='Enable graphics library')
     variant('opencl', default=False, description='Enable OpenCL backend')
-    variant('tests',  default=False, description='Build test binaries')
 
     depends_on('boost@1.75:')
     depends_on('fftw-api@3:')
@@ -61,20 +60,17 @@ class Arrayfire(CMakePackage, CudaPackage):
             self.define_from_variant('AF_BUILD_CUDA', 'cuda'),
             self.define_from_variant('AF_BUILD_FORGE', 'forge'),
             self.define_from_variant('AF_BUILD_OPENCL', 'opencl'),
-            self.define_from_variant('BUILD_TESTING', 'tests'),
+            self.define('BUILD_TESTING', self.run_tests),
         ])
 
         if '+cuda' in self.spec:
             cuda_arch_list = self.spec.variants['cuda_arch'].value
             cuda_arch = cuda_arch_list[0]
-            if cuda_arch == 'none':
-                args.append(self.define('CUDA_architecture_build_targets', 'Auto'))
-            else:
-                arch_list_string = []
-                for arch in cuda_arch_list:
-                    arch_list_string.append('{}.{}'.format(arch[:-1], arch[-1]))
+            if cuda_arch != 'none':
+                arch_list_string = ['{}.{}'.format(arch[:-1], arch[-1])
+                                    for arch in cuda_arch_list]
                 args.append(self.define('CUDA_architecture_build_targets',
-                                        ';'.join(arch_list_string)))
+                                        arch_list_string))
 
         if '^mkl' in self.spec:
             if self.version >= Version('3.8.0'):

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -14,13 +14,14 @@ class Arrayfire(CMakePackage, CudaPackage):
     homepage = "https://arrayfire.org/docs/index.htm"
     git      = "https://github.com/arrayfire/arrayfire.git"
 
-    version('master', submodules=True)
+    version('master')
+    version('3.8.1', tag='v3.8.1')
     version('3.7.3', submodules=True, tag='v3.7.3')
     version('3.7.2', submodules=True, tag='v3.7.2')
     version('3.7.0', submodules=True, tag='v3.7.0')
 
-    variant('cuda',   default=False, description='Enable Cuda backend')
-    variant('forge',   default=False, description='Enable graphics library')
+    variant('cuda',   default=False, description='Enable CUDA backend')
+    variant('forge',  default=False, description='Enable graphics library')
     variant('opencl', default=False, description='Enable OpenCL backend')
     variant('tests',  default=False, description='Build test binaries')
 
@@ -75,8 +76,18 @@ class Arrayfire(CMakePackage, CudaPackage):
                                         ';'.join(arch_list_string)))
 
         if '^mkl' in self.spec:
-            args.append('-DUSE_CPU_MKL=ON')
+            if self.version >= Version('3.8.0'):
+                args.append(self.define('AF_COMPUTE_LIBRARY', 'Intel-MKL'))
+            else:
+                args.append(self.define('USE_CPU_MKL', True))
+                args.append(self.define('USE_OPENCL_MKL', True))
             if '%intel' not in self.spec:
-                args.append('-DMKL_THREAD_LAYER=GNU OpenMP')
+                args.append(self.define('MKL_THREAD_LAYER', 'GNU OpenMP'))
+        else:
+            if self.version >= Version('3.8.0'):
+                args.append(self.define('AF_COMPUTE_LIBRARY', 'FFTW/LAPACK/BLAS'))
+            else:
+                args.append(self.define('USE_CPU_MKL', False))
+                args.append(self.define('USE_OPENCL_MKL', False))
 
         return args

--- a/var/spack/repos/builtin/packages/arrayfire/package.py
+++ b/var/spack/repos/builtin/packages/arrayfire/package.py
@@ -22,6 +22,7 @@ class Arrayfire(CMakePackage, CudaPackage):
     variant('cuda',   default=False, description='Enable Cuda backend')
     variant('forge',   default=False, description='Enable graphics library')
     variant('opencl', default=False, description='Enable OpenCL backend')
+    variant('tests',  default=False, description='Build test binaries')
 
     depends_on('boost@1.75:')
     depends_on('fftw-api@3:')
@@ -58,6 +59,7 @@ class Arrayfire(CMakePackage, CudaPackage):
             self.define_from_variant('AF_BUILD_CUDA', 'cuda'),
             self.define_from_variant('AF_BUILD_FORGE', 'forge'),
             self.define_from_variant('AF_BUILD_OPENCL', 'opencl'),
+            self.define_from_variant('BUILD_TESTING', 'tests'),
         ])
 
         if '+cuda' in self.spec:


### PR DESCRIPTION
* Use the `cuda_arch` variable to determine which compute capability to support
* Reduce the boost requirement to use only headers. Increase the version to 1.75 to avoid errors with older versions
* Disable building test binaries by default. Add a variant to build if necessary
* Add version 3.8.1 builds. Fixes issues with non-MKL builds when targeting version 3.8.1