### PR TITLE
zstd: bring back libs=shared,static and compression=zlib,lz4,lzma variants

### DIFF
--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -35,8 +35,8 @@ class Zstd(MakefilePackage):
     variant('programs', default=False, description='Build executables')
     variant('libs', default='shared,static', values=('shared', 'static'),
             multi=True, description='Build shared libs, static libs or both')
-    variant('compression', default='none', values=('none', 'zlib', 'lz4', 'lzma'),
-            multi=True, when='+programs',
+    variant('compression', when='+programs',
+            values=any_combination_of('zlib', 'lz4', 'lzma'),
             description='Enable support for additional compression methods in programs')
 
     depends_on('zlib', when='compression=zlib')

--- a/var/spack/repos/builtin/packages/zstd/package.py
+++ b/var/spack/repos/builtin/packages/zstd/package.py
@@ -36,7 +36,7 @@ class Zstd(MakefilePackage):
     variant('libs', default='shared,static', values=('shared', 'static'),
             multi=True, description='Build shared libs, static libs or both')
     variant('compression', default='none', values=('none', 'zlib', 'lz4', 'lzma'),
-            when='+programs',
+            multi=True, when='+programs',
             description='Enable support for additional compression methods in programs')
 
     depends_on('zlib', when='compression=zlib')


### PR DESCRIPTION
Should make building `gcc+binutils ^zstd libs=static` a bit easier (this
is the case where we don't control the compiler wrappers of gcc because
of bootstrapping, nor of ld because of how gcc invokes the linker).
