### PR TITLE
gmp,mpc,mpfr: libs=static,shared variant

### DIFF
--- a/var/spack/repos/builtin/packages/gmp/package.py
+++ b/var/spack/repos/builtin/packages/gmp/package.py
@@ -28,10 +28,8 @@ class Gmp(AutotoolsPackage, GNUMirrorPackage):
     depends_on('libtool', type='build')
     depends_on('m4', type='build')
 
-    variant('static', default=False, description='Build static library')
-    variant('shared', default=True, description='Build shared library')
-
-    conflicts('~shared', when='~static', msg='Please select at least one of +static or +shared')
+    variant('libs', default='shared,static', values=('shared', 'static'),
+            multi=True, description='Build shared libs, static libs or both')
 
     # gmp's configure script seems to be broken; it sometimes misdetects
     # shared library support. Regenerating it fixes the issue.
@@ -49,8 +47,7 @@ class Gmp(AutotoolsPackage, GNUMirrorPackage):
 
     def configure_args(self):
         args = ['--enable-cxx']
-        args.extend(self.enable_or_disable('static'))
-        args.extend(self.enable_or_disable('shared'))
-        if self.spec.satisfies('+static'):
+        args += self.enable_or_disable('libs')
+        if 'libs=static' in self.spec:
             args.append('--with-pic')
         return args

--- a/var/spack/repos/builtin/packages/mpc/package.py
+++ b/var/spack/repos/builtin/packages/mpc/package.py
@@ -20,6 +20,9 @@ class Mpc(AutotoolsPackage, GNUMirrorPackage):
     version('1.0.3', sha256='617decc6ea09889fb08ede330917a00b16809b8db88c29c31bfbb49cbf88ecc3')
     version('1.0.2', sha256='b561f54d8a479cee3bc891ee52735f18ff86712ba30f036f8b8537bae380c488')
 
+    variant('libs', default='shared,static', values=('shared', 'static'),
+            multi=True, description='Build shared libs, static libs or both')
+
     # Could also be built against mpir instead
     depends_on('gmp@4.3.2:')
     depends_on('gmp@5.0.0:', when='@1.1.0:')
@@ -29,7 +32,9 @@ class Mpc(AutotoolsPackage, GNUMirrorPackage):
 
     def configure_args(self):
         spec = self.spec
-        return [
+        args = [
             '--with-mpfr={0}'.format(spec['mpfr'].prefix),
             '--with-gmp={0}'.format(spec['gmp'].prefix)
         ]
+        args += self.enable_or_disable('libs')
+        return args

--- a/var/spack/repos/builtin/packages/mpfr/package.py
+++ b/var/spack/repos/builtin/packages/mpfr/package.py
@@ -34,10 +34,8 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
     depends_on('autoconf-archive', when='@4.0.2:', type='build')
     depends_on('texinfo', when='@4.1.0', type='build')
 
-    variant('static', default=False, description='Build static library')
-    variant('shared', default=True, description='Build shared library')
-
-    conflicts('~static', when='~shared', msg='Please select at least one of +static or +shared')
+    variant('libs', default='shared,static', values=('shared', 'static'),
+            multi=True, description='Build shared libs, static libs or both')
 
     force_autoreconf = True
 
@@ -68,8 +66,7 @@ class Mpfr(AutotoolsPackage, GNUMirrorPackage):
         args = [
             '--with-gmp=' + self.spec['gmp'].prefix,
         ]
-        args.extend(self.enable_or_disable('static'))
-        args.extend(self.enable_or_disable('shared'))
-        if self.spec.satisfies('+static'):
+        args += self.enable_or_disable('libs')
+        if 'libs=static' in self.spec:
             args.append('--with-pic')
         return args


### PR DESCRIPTION
To improve gcc startup speed, it's good to link statically.

@iarspider already did something along these lines, but for autotools the `libs=shared,static` variants seems nicer since it's been used in other places too, and doesn't require a conflict on ~shared ~static.
