### PR TITLE
macos: make fewer calls to sw_vers

### DIFF
--- a/lib/spack/spack/operating_systems/mac_os.py
+++ b/lib/spack/spack/operating_systems/mac_os.py
@@ -7,12 +7,15 @@ import os
 import platform as py_platform
 import re
 
+import llnl.util.lang
+
 from spack.util.executable import Executable
 from spack.version import Version
 
 from ._operating_system import OperatingSystem
 
 
+@llnl.util.lang.memoized
 def macos_version():
     """Get the current macOS version as a version object.
 
@@ -59,6 +62,7 @@ def macos_version():
     return Version(py_platform.mac_ver()[0])
 
 
+@llnl.util.lang.memoized
 def macos_cltools_version():
     """Find the last installed version of the CommandLineTools.
 
@@ -82,6 +86,7 @@ def macos_cltools_version():
     return None
 
 
+@llnl.util.lang.memoized
 def macos_sdk_path():
     """Return path to the active macOS SDK.
     """


### PR DESCRIPTION
In a typical call to spack, the OperatingSystem gets instantiated multiple times. For macOS, each one requires a call to `sw_vers`, which is done through the somewhat verbose Executable helper class. Memoizing reduces the call count from "spac spec" from three to one.