### PR TITLE
sherpa: fix build of recola interface

### DIFF
--- a/var/spack/repos/builtin/packages/recola/package.py
+++ b/var/spack/repos/builtin/packages/recola/package.py
@@ -25,6 +25,8 @@ class Recola(CMakePackage):
 
     version('2.2.4', sha256='16bdefb633d51842b4d32c39a43118d7052302cd63be456a473557e9b7e0316e')
     version('2.2.3', sha256='db0f5e448ed603ac4073d4bbf36fd74f401a22876ad390c0d02c815a78106c5f')
+    version('1.4.3', url='https://recola.hepforge.org/downloads/?f=recola-1.4.3.tar.gz',
+            sha256='f6a7dce6e1f09821ba919524f786557984f216c001ab63e7793e8aa9a8560ceb')
 
     depends_on('collier')
     depends_on('recola-sm')

--- a/var/spack/repos/builtin/packages/recola/package.py
+++ b/var/spack/repos/builtin/packages/recola/package.py
@@ -23,6 +23,7 @@ class Recola(CMakePackage):
     variant('python', default=True,
             description="Build py-recola python bindings.")
 
+    version('2.2.4', sha256='16bdefb633d51842b4d32c39a43118d7052302cd63be456a473557e9b7e0316e')
     version('2.2.3', sha256='db0f5e448ed603ac4073d4bbf36fd74f401a22876ad390c0d02c815a78106c5f')
 
     depends_on('collier')

--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -85,7 +85,10 @@ class Sherpa(AutotoolsPackage):
     depends_on('rivet',     when='+rivet')
     depends_on('fastjet',   when='+fastjet')
     depends_on('openloops', when='+openloops')
-    depends_on('recola',    when='+recola')
+    # sherpa builds with recola2 with the patch below,
+    # but the authors have validated only recola1
+    # see https://gitlab.com/sherpa-team/sherpa/-/issues/356
+    depends_on('recola@1',    when='+recola')
     depends_on('root',      when='+root')
     depends_on('lhapdf',    when='+lhapdf')
     depends_on('gzip',      when='+gzip')

--- a/var/spack/repos/builtin/packages/sherpa/package.py
+++ b/var/spack/repos/builtin/packages/sherpa/package.py
@@ -102,6 +102,12 @@ class Sherpa(AutotoolsPackage):
                     '#ifdef ARCH_DARWIN\n#include <sys/sysctl.h>\n#endif',
                     'ATOOLS/Org/Run_Parameter.C')
 
+        if self.spec.satisfies('^recola@2:'):
+            filter_file(r'#include "recola.h"',
+                        '#include "recola.hpp"',
+                        'AddOns/Recola/Recola_Interface.H',
+                        string=True)
+
     def configure_args(self):
         args = []
         args.append('--enable-shared')


### PR DESCRIPTION
See https://gitlab.com/sherpa-team/sherpa/-/issues/356

Adding a new recola version as well, builds fine with the new patch.