### PR TITLE
Fix professor recipe

### DIFF
--- a/var/spack/repos/builtin/packages/professor/package.py
+++ b/var/spack/repos/builtin/packages/professor/package.py
@@ -32,4 +32,4 @@ class Professor(Package):
         make()
         make('PREFIX={0}'.format(prefix), "install")
         if self.spec.satisfies('~interactive'):
-            os.remove(join_path(prefix.bin, 'prof-I'))
+            os.remove(join_path(prefix.bin, 'prof2-I'))

--- a/var/spack/repos/builtin/packages/professor/package.py
+++ b/var/spack/repos/builtin/packages/professor/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 
 from spack import *
 
@@ -16,13 +17,19 @@ class Professor(Package):
 
     version('2.3.3', sha256='60c5ba00894c809e2c31018bccf22935a9e1f51c0184468efbdd5d27b211009f')
 
-    depends_on('wxwidgets')
+    variant('interactive', default=True,
+            description='Install prof-I (Interactive parametrization explorer)')
+
     depends_on('yoda')
     depends_on('eigen')
     depends_on('py-cython')
     depends_on('py-iminuit')
     depends_on('py-matplotlib')
+    depends_on('py-matplotlib backend=wx', when='+interactive')
+    depends_on('root')
 
     def install(self, spec, prefix):
         make()
         make('PREFIX={0}'.format(prefix), "install")
+        if self.spec.satisfies('~interactive'):
+            os.remove(join_path(prefix.bin, 'prof-I'))

--- a/var/spack/repos/builtin/packages/professor/package.py
+++ b/var/spack/repos/builtin/packages/professor/package.py
@@ -28,6 +28,11 @@ class Professor(Package):
     depends_on('py-matplotlib backend=wx', when='+interactive')
     depends_on('root')
 
+    extends('python')
+
+    def setup_build_environment(self, env):
+        env.set('PROF_VERSION', self.spec.version)
+
     def install(self, spec, prefix):
         make()
         make('PREFIX={0}'.format(prefix), "install")


### PR DESCRIPTION
* Add dependency on ROOT
* Remove direct dependency on wxwidgets
    * `prof-I` tool requires matplotlib with wxwidgets backend, made that optional
* Set `PROF2_VERSION` to properly set .egg file name
* Extend python to fix installation of Python modules