### PR TITLE
Fixing the -lregionFaModels linking issue in OpenFOAM 2112

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam/package.py
+++ b/var/spack/repos/builtin/packages/openfoam/package.py
@@ -579,6 +579,15 @@ class Openfoam(Package):
         filter_file('clang++', spack_cxx + ' -pthread', join_path(src, 'c++'),
                     backup=False, string=True)
 
+    @when('@2112 %aocc@3.2.0:')
+    @run_before('configure')
+    def fix_issue(self):
+        """Fix for undefined references in Clang Linker (v2112)"""
+        general_rules = 'wmake/rules/General/'
+        src = join_path(general_rules, 'Amd')
+        filter_file('LINK_LIBS   =', 'LINK_LIBS   = -lregionFaModels',
+                    join_path(src, 'link-c++'), backup=False, string=True)
+
     @when('@1812: %fj')
     @run_before('configure')
     def make_fujitsu_rules(self):


### PR DESCRIPTION
Building `OpenFOAM 2112` with `AOCC Clang (v3.2.0)` is throwing below linker issue 

```
ld.lld: error: undefined symbol: typeinfo for Foam::regionModels::regionFaModel

>>> referenced by MPPICInterFoam.C

v2112/build/linux64AmdDPInt32Opt/applications/solvers/multiphase/MPPICInterFoam/MPPICInterFoam.o:(void Foam::SurfaceFilmModel<Foam::KinematicCloud<Foam::Cloud<Foam::KinematicParcel<Foam::particle> > > >::inject<Foam::KinematicCloud<Foam::Cloud<Foam::KinematicParcel<Foam::particle> > > >(Foam::KinematicCloud<Foam::Cloud<Foam::KinematicParcel<Foam::particle> > >&))
clang-13: error: linker command failed with exit code 1 (use -v to see invocation)

```

Linking with `-lregionFaModels`  in `link-c++` file resolving the issue.