### PR TITLE
gcc: avoid excessive stat calls

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -521,9 +521,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
                 ','.join(spec.variants['languages'].value)),
             # Drop gettext dependency
             '--disable-nls',
-            # Avoid excessive realpath/stat calls for every header file
-            '--disable-canonical-system-headers'
         ]
+
+        # Avoid excessive realpath/stat calls for every system header
+        # by making -fno-canonical-system-headers the default.
+        if self.version >= Version('4.8.0'):
+            options.append('--disable-canonical-system-headers')
 
         # Use installed libz
         if self.version >= Version('6'):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -520,7 +520,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             '--enable-languages={0}'.format(
                 ','.join(spec.variants['languages'].value)),
             # Drop gettext dependency
-            '--disable-nls',
+            '--disable-nls'
         ]
 
         # Avoid excessive realpath/stat calls for every system header

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -520,7 +520,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             '--enable-languages={0}'.format(
                 ','.join(spec.variants['languages'].value)),
             # Drop gettext dependency
-            '--disable-nls'
+            '--disable-nls',
+            # Avoid excessive realpath/stat calls for every header file
+            '--disable-canonical-system-headers'
         ]
 
         # Use installed libz


### PR DESCRIPTION
For about a decade GCC has an option `-f[no-]canonical-system-headers`
which basically runs `realpath` on all "system headers", to possibly
reduce the length of paths in diagnostics when enabled. [1]

Spack usually installs the "system headers" of GCC in very deeply nested
directories. Calling `realpath` there results in stat calls on every
level, for every header file. On some slow filesystem,
`-fno-canonical-system-headers` resulted in 5x speedup to compile hello
world in C, meaning that ./configure scripts would be much faster when
disabling the "feature" by default.

Users can still do -fcanonical-system-headers, the pr just sets the default value.

[1] https://codereview.appspot.com/6495088
