### PR TITLE
ROOT: allow c++20, default to c++14

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -192,7 +192,7 @@ class Root(CMakePackage):
 
     variant('cxxstd',
             default='11',
-            values=('11', '14', '17'),
+            values=('11', '14', '17', '20'),
             multi=False,
             description='Use the specified C++ standard when building.')
 
@@ -303,6 +303,10 @@ class Root(CMakePackage):
     conflicts('+tmva', when='~gsl', msg='TVMA requires GSL')
     conflicts('+tmva', when='~mlp', msg='TVMA requires MLP')
     conflicts('cxxstd=11', when='+root7', msg='root7 requires at least C++14')
+    conflicts('cxxstd=11', when='@6.25.02:', msg='This version of root '
+              'requires at least C++14')
+    conflicts('cxxstd=20', when='@:6.25.01', msg='C++20 support was added '
+              'in 6.25.02')
 
     # Feature removed in 6.18:
     for pkg in ('memstat', 'qt4', 'table'):


### PR DESCRIPTION
C++20 is enabled by this commit: https://github.com/root-project/root/commit/90a758269c43d65c7e211d5ebc1caa0646454194
C++11 is dropped by this commit: https://github.com/root-project/root/commit/0d6d2ff902bee4b6485aae19dba9d346c2138f69