### PR TITLE
Fix partially specified arch specs in provides(when=...)

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -512,18 +512,27 @@ class ArchSpec(object):
         return ':' not in str(self.target) and ',' not in str(self.target)
 
     def to_dict(self):
-        d = syaml.syaml_dict([
-            ('platform', self.platform),
-            ('platform_os', self.os),
-            ('target', self.target.to_dict_or_value())])
+        arch_components = []
+        if self.platform:
+            arch_components.append(('platform', self.platform))
+        if self.os:
+            arch_components.append(('platform_os', self.os))
+        if self.target:
+            arch_components.append(('target', self.target.to_dict_or_value()))
+        d = syaml.syaml_dict(arch_components)
         return syaml.syaml_dict([('arch', d)])
 
     @staticmethod
     def from_dict(d):
         """Import an ArchSpec from raw YAML/JSON data"""
         arch = d['arch']
-        target = spack.target.Target.from_dict_or_value(arch['target'])
-        return ArchSpec((arch['platform'], arch['platform_os'], target))
+        return ArchSpec(
+            (
+                arch.get('platform', None),
+                arch.get('platform_os', None),
+                spack.target.Target.from_dict_or_value(arch.get('target', None)),
+            )
+        )
 
     def __str__(self):
         return "%s-%s-%s" % (self.platform, self.os, self.target)

--- a/lib/spack/spack/target.py
+++ b/lib/spack/spack/target.py
@@ -79,6 +79,9 @@ class Target(object):
 
     @staticmethod
     def from_dict_or_value(dict_or_value):
+        if not dict_or_value:
+            return None
+
         # A string here represents a generic target (like x86_64 or ppc64) or
         # a custom micro-architecture
         if isinstance(dict_or_value, six.string_types):


### PR DESCRIPTION
Prior to this if you try to specify a partial arch spec in `provides` then various exceptions are thrown for trying to operate on `None` values:
```
class Opengl(BundlePackage):
    ...
    provides("glx@1.4", when="platform=linux")
...
$ spack spec opengl
==> Error: 'NoneType' object has no attribute 'to_dict_or_value'
$ spack --debug spec opengl
...
  File "/home/local/KHQ/chuck.atkins/Code/spack/lib/spack/spack/spec.py", line 518, in to_dict
    ('target', self.target.to_dict_or_value())])
AttributeError: 'NoneType' object has no attribute 'to_dict_or_value'
```
With these changes `provides("foo", when="platform=linux") works.