### PR TITLE
cray-mpich module conflicts with non cray-pe mpi

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -831,6 +831,7 @@ def setup_package(pkg, dirty, context='build'):
     on_cray, _ = _on_cray()
     if on_cray:
         module('unload', 'cray-libsci')
+        module('unload', 'cray-mpich')
 
     if target.module_name:
         load_module(target.module_name)


### PR DESCRIPTION
When building in a cray environment and specifying a non cray-pe mpi compiler the auto-loaded cray-mpich module can cause linking errors like this:

```
 /usr/bin/ld: warning: libfabric.so.1, needed by /opt/cray/pe/mpich/8.1.13/ofi/gnu/9.1/lib/libmpifort_gnu_91.so, not found (try using -rpath or -rp
            ath-link)
  >> 702    /usr/bin/ld: /opt/cray/pe/mpich/8.1.13/ofi/gnu/9.1/lib/libmpi_gnu_91.so: undefined reference to `fi_strerror@@FABRIC_1.0'
```

Unloading cray-mpich avoids this issue.

@shahzebsiddiqui 
@sameershende 