### PR TITLE
Updating APEX package to new 2.5.0 version

### DIFF
--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -18,6 +18,7 @@ class Apex(CMakePackage):
 
     version('develop', branch='develop')
     version('master', branch='master')
+    version('2.5.0', sha256='d4a95f6226985acf2143e2b779b7bba3caf823564b04826b022f1a0c31093a0f')
     version('2.4.1', sha256='055d09dd36c529ebd3bab4defbec4ad1d227c004a291faf26e77e4ab79ce470c')
     version('2.4.0', sha256='15d8957da7b37d2c684a6f0f32aef65b0b26be6558da17963cf71f3fd3cfdf2f')
     version('2.3.2', sha256='acf37c024a2283cafbf206f508929208b62c8f800af22ad7c74c570863a31bb4')
@@ -35,7 +36,7 @@ class Apex(CMakePackage):
     variant('plugins', default=True, description='Enables Policy Plugin support')
     variant('binutils', default=True, description='Enables Binutils support')
     variant('otf2', default=True, description='Enables OTF2 support')
-    variant('gperftools', default=True, description='Enables Google PerfTools TCMalloc support')
+    variant('gperftools', default=darwin_default, description='Enables Google PerfTools TCMalloc support')
     variant('openmp', default=darwin_default, description='Enables OpenMP support')
     variant('papi', default=darwin_default, description='Enables PAPI support')
 


### PR DESCRIPTION
Adding new version, and disabling gperftools option by default on OSX because tcmalloc doesn't work with latest versions of OSX.