### PR TITLE
Add missing Boost dependencies to `pika+generic_coroutines` variant

### DIFF
--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -84,6 +84,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     # https://github.com/spack/spack/pull/17654
     # https://github.com/STEllAR-GROUP/hpx/issues/4829
     depends_on('boost+context', when='+generic_coroutines')
+    depends_on('boost+atomic+chrono+thread', when='@:0.3.0+generic_coroutines')
     _msg_generic_coroutines = 'This platform requires +generic_coroutines'
     conflicts('~generic_coroutines', when='platform=darwin', msg=_msg_generic_coroutines)
 


### PR DESCRIPTION
The Boost libraries `atomic`, `chrono`, and `thread` are required until pika 0.3.0 with `+generic_coroutines`. The libraries are no longer required on pika main.