### PR TITLE
man-db: fix install prefix and library runtime

### DIFF
--- a/var/spack/repos/builtin/packages/man-db/package.py
+++ b/var/spack/repos/builtin/packages/man-db/package.py
@@ -35,8 +35,14 @@ class ManDb(AutotoolsPackage):
     depends_on('bzip2', type=('build', 'link', 'run'))
     depends_on('xz',    type=('build', 'link', 'run'))
 
+    # workaround for the installation of libraries to `lib/man-db/`
+    def setup_run_environment(self, env):
+        env.prepend_path('LD_LIBRARY_PATH', join_path(self.prefix.lib, "man-db"))
+
     def configure_args(self):
         args = [
+            # setting both prefix and DESTDIR results in wrong prefix
+            '--prefix=/',
             '--disable-setuid',
             # defaults to a location that needs root privs to write in
             '--with-systemdtmpfilesdir={0}/tmp'.format(self.prefix)


### PR DESCRIPTION
`man-db` installed some directories to `$prefix/$prefix` instead of `$prefix` (DESTDIR is needed for some other folders, like this everything seems to be in order)

Also adds a workaround for the `lib/man-db` libdir (while waiting for https://github.com/spack/spack/pull/29657). 

