### PR TITLE
go: add 1.18 and 1.17.8

### DIFF
--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -42,6 +42,8 @@ class Go(Package):
 
     maintainers = ['alecbcs']
 
+    version('1.18', sha256='38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6')
+    version('1.17.8', sha256='2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a')
     version('1.17.7', sha256='c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d')
     version('1.17.3', sha256='705c64251e5b25d5d55ede1039c6aa22bea40a7a931d14c370339853643c3df0', deprecated=True)
     version('1.17.2',  sha256='2255eb3e4e824dd7d5fcdc2e7f84534371c186312e546fb1086a34c17752f431', deprecated=True)


### PR DESCRIPTION
Adding latest [Go releases](https://go.dev/doc/devel/release)