### PR TITLE
Deprecate `spack:concretization` over `concretizer:unify` 

### DIFF
--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -33,4 +33,4 @@ concretizer:
   # environment can always be activated. When "false" perform concretization separately
   # on each root spec, allowing different versions and variants of the same package in
   # an environment.
-  unify: true
+  unify: false

--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -29,8 +29,8 @@ concretizer:
     # If "true" only allow targets that are compatible with the host.
     host_compatible: true
   # When "true" concretize root specs of environments together, so that each unique
-  # package in an environment corresponds to the same concrete spec. This ensures
-  # environment can always be activated. When "false" perform concretization separately
+  # package in an environment corresponds to one concrete spec. This ensures
+  # environments can always be activated. When "false" perform concretization separately
   # on each root spec, allowing different versions and variants of the same package in
   # an environment.
   unify: false

--- a/etc/spack/defaults/concretizer.yaml
+++ b/etc/spack/defaults/concretizer.yaml
@@ -28,3 +28,9 @@ concretizer:
     # instance concretize with target "icelake" while running on "haswell").
     # If "true" only allow targets that are compatible with the host.
     host_compatible: true
+  # When "true" concretize root specs of environments together, so that each unique
+  # package in an environment corresponds to the same concrete spec. This ensures
+  # environment can always be activated. When "false" perform concretization separately
+  # on each root spec, allowing different versions and variants of the same package in
+  # an environment.
+  unify: true

--- a/lib/spack/docs/containers.rst
+++ b/lib/spack/docs/containers.rst
@@ -59,7 +59,8 @@ other techniques to minimize the size of the final image:
    &&   echo "  specs:" \
    &&   echo "  - gromacs+mpi" \
    &&   echo "  - mpich" \
-   &&   echo "  concretization: together" \
+   &&   echo "  concretizer: together" \
+   &&   echo "    unify: true" \
    &&   echo "  config:" \
    &&   echo "    install_tree: /opt/software" \
    &&   echo "  view: /opt/view") > /opt/spack-environment/spack.yaml
@@ -245,7 +246,8 @@ software is respectively built and installed:
    &&   echo "  specs:" \
    &&   echo "  - gromacs+mpi" \
    &&   echo "  - mpich" \
-   &&   echo "  concretization: together" \
+   &&   echo "  concretizer:" \
+   &&   echo "    unify: true" \
    &&   echo "  config:" \
    &&   echo "    install_tree: /opt/software" \
    &&   echo "  view: /opt/view") > /opt/spack-environment/spack.yaml
@@ -366,7 +368,8 @@ produces, for instance, the following ``Dockerfile``:
    &&   echo "      externals:" \
    &&   echo "      - spec: cuda%gcc" \
    &&   echo "        prefix: /usr/local/cuda" \
-   &&   echo "  concretization: together" \
+   &&   echo "  concretizer:" \
+   &&   echo "    unify: true" \
    &&   echo "  config:" \
    &&   echo "    install_tree: /opt/software" \
    &&   echo "  view: /opt/view") > /opt/spack-environment/spack.yaml

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -281,8 +281,8 @@ need to be installed alongside each other. Central installations done
 at HPC centers by system administrators or user support groups
 are a common case that fits in this behavior.
 Environments *can also be configured to concretize all
-the root specs in a self-consistent way* to ensure that
-each package in the environment comes with a single configuration. This
+the root specs in a unified way* to ensure that
+each package in the environment corresponds to a single concrete spec. This
 mode of operation is usually what is required by software developers that
 want to deploy their development environment.
 
@@ -499,7 +499,7 @@ Spec concretization
 
 Specs can be concretized separately or together, as already
 explained in :ref:`environments_concretization`. The behavior active
-under any environment is determined by the ``concretization`` property:
+under any environment is determined by the ``concretizer:unify`` property:
 
 .. code-block:: yaml
 
@@ -509,10 +509,15 @@ under any environment is determined by the ``concretization`` property:
          - netcdf
          - nco
          - py-sphinx
-       concretization: together
+       concretizer:
+         unify: true
 
-which can currently take either one of the two allowed values ``together`` or ``separately``
-(the default).
+.. note::
+
+   The ``concretizer:unify`` config option was introduced in Spack 0.18 to
+   replace the ``concretization`` property. For reference,
+   ``concretization: separately`` is replaed by ``concretizer:unify:true``,
+   and ``concretization: together`` is replaced by ``concretizer:unify:false``.
 
 .. admonition:: Re-concretization of user specs
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -516,7 +516,7 @@ under any environment is determined by the ``concretizer:unify`` property:
 
    The ``concretizer:unify`` config option was introduced in Spack 0.18 to
    replace the ``concretization`` property. For reference,
-   ``concretization: separately`` is replaed by ``concretizer:unify:true``,
+   ``concretization: separately`` is replaced by ``concretizer:unify:true``,
    and ``concretization: together`` is replaced by ``concretizer:unify:false``.
 
 .. admonition:: Re-concretization of user specs

--- a/lib/spack/docs/pipelines.rst
+++ b/lib/spack/docs/pipelines.rst
@@ -115,7 +115,8 @@ And here's the spack environment built by the pipeline represented as a
 
    spack:
      view: false
-     concretization: separately
+     concretizer:
+       unify: false
 
      definitions:
      - pkgs:

--- a/lib/spack/docs/replace_conda_homebrew.rst
+++ b/lib/spack/docs/replace_conda_homebrew.rst
@@ -61,7 +61,7 @@ You can see the packages we added earlier in the ``specs:`` section. If you
 ever want to add more packages, you can either use ``spack add`` or manually
 edit this file.
 
-We also need to change the ``concretization:`` option. By default, Spack
+We also need to change the ``concretizer:unify`` option. By default, Spack
 concretizes each spec *separately*, allowing multiple versions of the same
 package to coexist. Since we want a single consistent environment, we want to
 concretize all of the specs *together*.
@@ -78,7 +78,8 @@ Here is what your ``spack.yaml`` looks like with this new setting:
      # add package specs to the `specs` list
      specs: [bash@5, python, py-numpy, py-scipy, py-matplotlib]
      view: true
-     concretization: together
+     concretizer:
+       unify: true
 
 ^^^^^^^^^^^^^^^^
 Symlink location

--- a/lib/spack/docs/spack.yaml
+++ b/lib/spack/docs/spack.yaml
@@ -25,4 +25,5 @@ spack:
   - subversion
   # Plotting
   - graphviz
-  concretization: together
+  concretizer:
+    unify: true

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1873,13 +1873,14 @@ class Environment(object):
         # them from being modified
         manifest_exists = os.path.exists(self.manifest_path)
         if manifest_exists and not is_latest_format(self.manifest_path):
-            msg = ('The environment "{0}" needs to be written to disk, but '
+            ver = '.'.join(str(s) for s in spack.spack_version_info[:2])
+            msg = ('The environment "{}" needs to be written to disk, but '
                    'is currently using a deprecated format. Please update it '
                    'using:\n\n'
-                   '\tspack env update {0}\n\n'
-                   'Note that previous versions of Spack will not be able to '
+                   '\tspack env update {}\n\n'
+                   'Note that versions of Spack older than {} may not be able to '
                    'use the updated configuration.')
-            raise RuntimeError(msg.format(self.name))
+            raise RuntimeError(msg.format(self.name, self.name, ver))
 
         # ensure path in var/spack/environments
         fs.mkdirp(self.path)

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -766,8 +766,11 @@ class Environment(object):
             self.views = {}
         # Retrieve the current concretization strategy
         configuration = config_dict(self.yaml)
-        # default concretization to separately
-        self.concretization = configuration.get('concretization', 'separately')
+
+        # Let `concretization` overrule `concretize:unify` config for now.
+        unify = spack.config.get('concretizer:unify')
+        self.concretization = configuration.get(
+            'concretization', 'together' if unify else 'separately')
 
         # Retrieve dev-build packages:
         self.dev_specs = configuration.get('develop', {})

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -89,7 +89,9 @@ spack:
   # add package specs to the `specs` list
   specs: []
   view: true
-"""
+  concretizer:
+    unify: {}
+""".format(spack.config.get('concretizer:unify'))
 #: regex for validating enviroment names
 valid_environment_name_re = r'^\w[\w-]*$'
 

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -79,8 +79,9 @@ lockfile_name = 'spack.lock'
 env_subdir_name = '.spack-env'
 
 
-#: default spack.yaml file to put in new environments
-default_manifest_yaml = """\
+def default_manifest_yaml():
+    """default spack.yaml file to put in new environments"""
+    return """\
 # This is a Spack Environment file.
 #
 # It describes a set of packages to be installed, along with
@@ -91,7 +92,9 @@ spack:
   view: true
   concretizer:
     unify: {}
-""".format(spack.config.get('concretizer:unify'))
+""".format('true' if spack.config.get('concretizer:unify') else 'false')
+
+
 #: regex for validating enviroment names
 valid_environment_name_re = r'^\w[\w-]*$'
 
@@ -634,11 +637,11 @@ class Environment(object):
             # the init file.
             with fs.open_if_filename(init_file) as f:
                 if hasattr(f, 'name') and f.name.endswith('.lock'):
-                    self._read_manifest(default_manifest_yaml)
+                    self._read_manifest(default_manifest_yaml())
                     self._read_lockfile(f)
                     self._set_user_specs_from_lockfile()
                 else:
-                    self._read_manifest(f, raw_yaml=default_manifest_yaml)
+                    self._read_manifest(f, raw_yaml=default_manifest_yaml())
 
                 # Rewrite relative develop paths when initializing a new
                 # environment in a different location from the spack.yaml file.
@@ -702,7 +705,7 @@ class Environment(object):
         default_manifest = not os.path.exists(self.manifest_path)
         if default_manifest:
             # No manifest, use default yaml
-            self._read_manifest(default_manifest_yaml)
+            self._read_manifest(default_manifest_yaml())
         else:
             with open(self.manifest_path) as f:
                 self._read_manifest(f)

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -5,6 +5,7 @@
 """This module contains jsonschema files for all of Spack's YAML formats."""
 
 import six
+import warnings
 
 import llnl.util.lang
 import llnl.util.tty
@@ -52,7 +53,7 @@ def _make_validator():
 
         is_error = deprecated['error']
         if not is_error:
-            llnl.util.tty.warn(msg)
+            warnings.warn(msg)
         else:
             import jsonschema
             yield jsonschema.ValidationError(msg)

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 """This module contains jsonschema files for all of Spack's YAML formats."""
 
-import six
 import warnings
+
+import six
 
 import llnl.util.lang
 import llnl.util.tty

--- a/lib/spack/spack/schema/__init__.py
+++ b/lib/spack/spack/schema/__init__.py
@@ -51,6 +51,8 @@ def _make_validator():
             msg = msg_str_or_func.format(properties=deprecated_properties)
         else:
             msg = msg_str_or_func(instance, deprecated_properties)
+            if msg is None:
+                return
 
         is_error = deprecated['error']
         if not is_error:

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -25,6 +25,12 @@ properties = {
                     }
                 }
             },
+            'unify': {
+                'oneOf': [
+                    {'type': 'boolean'},
+                    {'type': 'string', 'enum': []}  # Todo: 'when_possible' option.
+                ]
+            }
         }
     }
 }

--- a/lib/spack/spack/schema/concretizer.py
+++ b/lib/spack/spack/schema/concretizer.py
@@ -26,10 +26,12 @@ properties = {
                 }
             },
             'unify': {
-                'oneOf': [
-                    {'type': 'boolean'},
-                    {'type': 'string', 'enum': []}  # Todo: 'when_possible' option.
-                ]
+                'type': 'boolean'
+                # Todo: add when_possible.
+                # 'oneOf': [
+                #     {'type': 'boolean'},
+                #     {'type': 'string', 'enum': ['when_possible']}
+                # ]
             }
         }
     }

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -16,8 +16,13 @@ import spack.schema.merged
 import spack.schema.packages
 import spack.schema.projections
 
+warned_about_concretization = False
+
 
 def deprecate_concretization(instance, props):
+    global warned_about_concretization
+    if warned_about_concretization:
+        return None
     # Deprecate `spack:concretization` in favor of `spack:concretizer:unify`.
     concretization_to_unify = {'together': 'true', 'separately': 'false'}
     concretization = instance['concretization']

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -16,6 +16,7 @@ import spack.schema.merged
 import spack.schema.packages
 import spack.schema.projections
 
+
 def deprecate_concretization(instance, props):
     # Deprecate `spack:concretization` in favor of `spack:concretizer:unify`.
     concretization_to_unify = {'together': 'true', 'separately': 'false'}
@@ -26,6 +27,7 @@ def deprecate_concretization(instance, props):
         'concretization:{} will be deprecated from Spack 0.19 in favor of the new '
         'concretizer:unify:{} config option.'.format(concretization, unify)
     )
+
 
 #: legal first keys in the schema
 keys = ('spack', 'env')

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -24,8 +24,8 @@ def deprecate_concretization(instance, props):
     unify = concretization_to_unify[concretization]
 
     return (
-        'concretization:{} will be deprecated from Spack 0.19 in favor of the new '
-        'concretizer:unify:{} config option.'.format(concretization, unify)
+        'concretization:{} is deprecated and will be removed in Spack 0.19 in favor of '
+        'the new concretizer:unify:{} config option.'.format(concretization, unify)
     )
 
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -23,7 +23,7 @@ def deprecate_concretization(instance, props):
     unify = concretization_to_unify[concretization]
 
     return (
-        'concretization:{} will be deprecated after Spack 0.19 in favor of the new '
+        'concretization:{} will be deprecated from Spack 0.19 in favor of the new '
         'concretizer:unify:{} config option.'.format(concretization, unify)
     )
 

--- a/lib/spack/spack/schema/env.py
+++ b/lib/spack/spack/schema/env.py
@@ -16,6 +16,17 @@ import spack.schema.merged
 import spack.schema.packages
 import spack.schema.projections
 
+def deprecate_concretization(instance, props):
+    # Deprecate `spack:concretization` in favor of `spack:concretizer:unify`.
+    concretization_to_unify = {'together': 'true', 'separately': 'false'}
+    concretization = instance['concretization']
+    unify = concretization_to_unify[concretization]
+
+    return (
+        'concretization:{} will be deprecated after Spack 0.19 in favor of the new '
+        'concretizer:unify:{} config option.'.format(concretization, unify)
+    )
+
 #: legal first keys in the schema
 keys = ('spack', 'env')
 
@@ -61,6 +72,11 @@ schema = {
             'type': 'object',
             'default': {},
             'additionalProperties': False,
+            'deprecatedProperties': {
+                'properties': ['concretization'],
+                'message': deprecate_concretization,
+                'error': False
+            },
             'properties': union_dicts(
                 # merged configuration scope schemas
                 spack.schema.merged.properties,

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -486,7 +486,7 @@ def test_config_remove_from_env(mutable_empty_config, mutable_mock_env_path):
         config('rm', 'config:dirty')
         output = config('get')
 
-    expected = ev.default_manifest_yaml
+    expected = ev.default_manifest_yaml()
     expected += """  config: {}
 
 """

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2358,6 +2358,26 @@ def test_old_format_cant_be_updated_implicitly(packages_yaml_v015):
         add('hdf5')
 
 
+@pytest.mark.parametrize('concretization,unify', [
+    ('together', 'true'),
+    ('separately', 'false')
+])
+def test_update_concretization_to_concretizer_unify(concretization, unify, tmpdir):
+    spack_yaml = """\
+spack:
+  concretization: {}
+""".format(concretization)
+    tmpdir.join('spack.yaml').write(spack_yaml)
+    # Update the environment
+    env('update', '-y', str(tmpdir))
+    with open(str(tmpdir.join('spack.yaml'))) as f:
+        assert f.read() == """\
+spack:
+  concretizer:
+    unify: {}
+""".format(unify)
+
+
 @pytest.mark.regression('18147')
 def test_can_update_attributes_with_override(tmpdir):
     spack_yaml = """

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2251,7 +2251,7 @@ def test_env_write_only_non_default():
     with open(e.manifest_path, 'r') as f:
         yaml = f.read()
 
-    assert yaml == ev.default_manifest_yaml
+    assert yaml == ev.default_manifest_yaml()
 
 
 @pytest.mark.regression('20526')

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2391,7 +2391,8 @@ spack:
         modules:
         - libelf/3.18.1
 
-  concretization: together
+  concretizer:
+    unify: false
 """
     abspath = tmpdir.join('spack.yaml')
     abspath.write(spack_yaml)

--- a/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/build_systems/spack.yaml
@@ -1,9 +1,9 @@
 spack:
   view: false
-  concretization: separately
 
   concretizer:
     reuse: false
+    unify: false
 
   config:
     install_tree:

--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -1,9 +1,9 @@
 spack:
   view: false
-  concretization: separately
 
   concretizer:
     reuse: false
+    unify: false
 
   config:
     install_tree:

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -1,9 +1,9 @@
 spack:
   view: false
-  concretization: separately
 
   concretizer:
     reuse: false
+    unify: false
 
   config:
     concretizer: clingo

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-on-power/spack.yaml
@@ -1,9 +1,9 @@
 spack:
   view: false
-  concretization: separately
 
   concretizer:
     reuse: false
+    unify: false
 
   config:
     concretizer: clingo

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -1,9 +1,9 @@
 spack:
   view: false
-  concretization: separately
 
   concretizer:
     reuse: false
+    unify: false
 
   config:
     concretizer: clingo

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -1,9 +1,9 @@
 spack:
-  concretization: separately
   view: false
 
   concretizer:
     reuse: false
+    unify: false
 
   config:
     concretizer: clingo

--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -1,9 +1,9 @@
 spack:
   view: false
-  concretization: separately
 
   concretizer:
     reuse: false
+    unify: false
 
   config:
     install_tree:


### PR DESCRIPTION
Now that we have `concretizer` configuration, we can use it for environments.

1. Introduce `spack:concretizer:unify:true|false` in favor of `spack:concretization:together|separately`.
2. Add a `spack env update` path. This update makes environments incompatible with Spack 0.17, but forward compatible with 0.19 once we remove `spack:concretization`.
3. Add a deprecation warning for `concretization`.
4. Store the default value `spack:concretizer:unify` in new `spack.yaml` files to make it easier for us to change the default of `unify: false` to `unify: true` in 0.19. (Downside being that new environments in 0.18 are incompatible with 0.17 by default).
5. Turn `default_manifest_yaml` into a function (should be private API?) so we can use spack.config in it.

Further changes:
1. Silence `deprecatedProperties` by allowing `return None` from the callback to signal it's not necessary to print yet another deprecation warning.
2. Spack refused to save old format `spack.yaml` saying it's forward incompatible, ironically this error is backwards incompatible, so I've changed it into a warning.

We don't really have to introduce yet another flag `spack env create --unify=...` because `spack -e . config add concretizer:unify:...` exists.