### PR TITLE
buildcache: fix error handling on failed list

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -364,6 +364,7 @@ def list_fn(args):
     try:
         specs = bindist.update_cache_and_get_specs()
     except bindist.FetchCacheError as e:
+        specs = []
         tty.error(e)
 
     if not args.allarch:


### PR DESCRIPTION
Error reported on slack.

```
[imjelde@lblhcbpr20 spack]$ spack buildcache list
==> Error: Multiple errors during fetching:
        Error 1: RuntimeError: Unable to read index hash https://mirror.spack.io/build_cache/index.json.hash due to SpackWebError: Download failed: HTTP Error 404: Not Found
        Error 2: RuntimeError: Unable to read index https://mirror.spack.io/build_cache/index.json due to SpackWebError: Download failed: HTTP Error 404: Not Found
==> Error: local variable 'specs' referenced before assignment
```

This fixes the variable reference error, not the underlying buildcache access error. 