### PR TITLE
Fix R build in containers

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -78,6 +78,7 @@ class R(AutotoolsPackage):
     depends_on('pcre2', when='@4:')
     depends_on('readline')
     depends_on('xz')
+    depends_on('which', type=('build', 'run'))
     depends_on('zlib@1.2.5:')
     depends_on('cairo+X+gobject+pdf', when='+X')
     depends_on('pango+X', when='+X')


### PR DESCRIPTION
R needs which as a build and run dependency on linux/unix systems, but it may not be provided in a
minimal container.