### PR TITLE
[mochi-thallium] added version 0.10.1 and corrected cereal dependency

### DIFF
--- a/var/spack/repos/builtin/packages/mochi-thallium/package.py
+++ b/var/spack/repos/builtin/packages/mochi-thallium/package.py
@@ -16,6 +16,7 @@ class MochiThallium(CMakePackage):
     maintainers = ['mdorier']
 
     version('main', branch='main')
+    version('0.10.1', sha256='5a8dc1f1622f4186b02fbabd47a8a33ca6be3d07757010f3d63d30e9f74fec8c')
     version('0.10.0', sha256='5319e25a42deab7c639e980885fe3be717cda2c2c693a1906f5a6c79b31edef8')
     version('0.9.1', sha256='dee884d0e054c838807f9c17781acfa99b26e3be1cc527bf09ceaa997336b3e4')
     version('0.9', sha256='6b867b73f5dd76ea160d83782980149f33ae3567c370cee63d945e2e94609331')
@@ -52,7 +53,8 @@ class MochiThallium(CMakePackage):
     depends_on('mochi-margo@0.6:', when='@0.5:')
     depends_on('mochi-margo@0.5:', when='@0.4:0.4.2')
     depends_on('mochi-margo@0.4:', when='@:0.3.4')
-    depends_on('cereal', when='+cereal')
+    depends_on('cereal@:1.3.0', when='@0.4.1:0.10.0 +cereal')
+    depends_on('cereal@1.3.1:', when='@0.10.1: +cereal')
     # thallium relies on std::decay_t
     conflicts('%gcc@:4.9.0')
 

--- a/var/spack/repos/builtin/packages/mochi-thallium/package.py
+++ b/var/spack/repos/builtin/packages/mochi-thallium/package.py
@@ -53,8 +53,9 @@ class MochiThallium(CMakePackage):
     depends_on('mochi-margo@0.6:', when='@0.5:')
     depends_on('mochi-margo@0.5:', when='@0.4:0.4.2')
     depends_on('mochi-margo@0.4:', when='@:0.3.4')
-    depends_on('cereal@:1.3.0', when='@0.4.1:0.10.0 +cereal')
-    depends_on('cereal@1.3.1:', when='@0.10.1: +cereal')
+    with when('+cereal'):
+        depends_on('cereal@:1.3.0', when='@0.4.1:0.10.0')
+        depends_on('cereal@1.3.1:', when='@0.10.1:')
     # thallium relies on std::decay_t
     conflicts('%gcc@:4.9.0')
 


### PR DESCRIPTION
The recent addition of versions 1.3.1 and 1.3.2 or the cereal package broke mochi-thallium (cereal's cmake target was renamed from `cereal` to `cereal::cereal` in these new versions). This PR (1) adds a new version of thallium (0.10.1) which corrects its cmake file to properly find the newer cereal, (2) forces the use of cereal up to 1.3.0 for older versions of thallium, and (3) forces the use of cereal 1.3.1 and above for thallium 0.10.1 and above.