### PR TITLE
Demote UnknownNamespaceError from --reuse with upstreams into a warning

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2036,8 +2036,15 @@ class SpecBuilder(object):
         # function will loop forever.
         roots = [spec.root for spec in self._specs.values()]
         roots = dict((id(r), r) for r in roots)
-        for root in roots.values():
-            spack.spec.Spec.inject_patches_variant(root)
+        try:
+          for root in roots.values():
+              spack.spec.Spec.inject_patches_variant(root)
+        except spack.repo.UnknownNamespaceError as e:
+          msg = """Upstream contains installations of packages from an unknown namespace.
+              Add the spack repo defining this namespace to make use of them.
+              {0}"""
+          tty.warn(msg.format(e))
+          pass
 
         # Add external paths to specs with just external modules
         for s in self._specs.values():

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2037,14 +2037,14 @@ class SpecBuilder(object):
         roots = [spec.root for spec in self._specs.values()]
         roots = dict((id(r), r) for r in roots)
         try:
-          for root in roots.values():
-              spack.spec.Spec.inject_patches_variant(root)
+            for root in roots.values():
+                spack.spec.Spec.inject_patches_variant(root)
         except spack.repo.UnknownNamespaceError as e:
-          msg = """Upstream contains installations of packages from an unknown namespace.
-              Add the spack repo defining this namespace to make use of them.
-              {0}"""
-          tty.warn(msg.format(e))
-          pass
+            msg = """Upstream contains installations of packages from an unknown namespace.
+                Add the spack repo defining this namespace to make use of them.
+                {0}"""
+            tty.warn(msg.format(e))
+            pass
 
         # Add external paths to specs with just external modules
         for s in self._specs.values():


### PR DESCRIPTION
closes #30092 

When concretizing with the --reuse flag, spack goes through all
installations and errors if a package comes from an unknown namespace.
This makes certain upstreams really hard to use. It's a likely scenario that an upstream contains installations from several spack repos,
and it is an unnecessary burden to setup all those repos that may not be
of interest to the user.