### PR TITLE
openmpi: main no longer depends on pandoc

### DIFF
--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -276,7 +276,6 @@ class Openmpi(AutotoolsPackage, CudaPackage):
     depends_on('automake @1.13.4:', type='build', when='@main')
     depends_on('libtool @2.4.2:',   type='build', when='@main')
     depends_on('m4',                type='build', when='@main')
-    depends_on('pandoc', type='build', when='@main')
 
     depends_on('perl',     type='build')
     depends_on('pkgconfig', type='build')


### PR DESCRIPTION
we switched to an optional sphinx based way of
generating docs, so remove pandoc, which can cause
issues with latex conflicts.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>