### PR TITLE
solver: do not punish explicitly requested compiler mismatches

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1016,6 +1016,11 @@ compiler_mismatch(Package, Dependency)
      not node_compiler_set(Dependency, _),
      not compiler_match(Package, Dependency).
 
+compiler_mismatch_required(Package, Dependency)
+  :- depends_on(Package, Dependency),
+     node_compiler_set(Dependency, _),
+     not compiler_match(Package, Dependency).
+
 #defined node_compiler_set/2.
 #defined node_compiler_version_set/3.
 #defined compiler_supports_os/3.
@@ -1285,12 +1290,21 @@ opt_criterion(45, "preferred providers (non-roots)").
 }.
 
 % Try to minimize the number of compiler mismatches in the DAG.
-opt_criterion(40, "compiler mismatches").
+opt_criterion(40, "compiler mismatches that are not from CLI").
 #minimize{ 0@240: #true }.
 #minimize{ 0@40: #true }.
 #minimize{
     1@40+Priority,Package,Dependency
     : compiler_mismatch(Package, Dependency),
+      build_priority(Package, Priority)
+}.
+
+opt_criterion(39, "compiler mismatches that are not from CLI").
+#minimize{ 0@239: #true }.
+#minimize{ 0@39: #true }.
+#minimize{
+    1@39+Priority,Package,Dependency
+    : compiler_mismatch_required(Package, Dependency),
       build_priority(Package, Priority)
 }.
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -44,6 +44,8 @@ node_flag_set(Package, Flag, Value)  :- attr("node_flag_set", Package, Flag, Val
 
 node_compiler_version_set(Package, Compiler, Version)
   :- attr("node_compiler_version_set", Package, Compiler, Version).
+node_compiler_set(Package, Compiler)
+  :- attr("node_compiler_set", Package, Compiler).
 
 variant_default_value_from_cli(Package, Variant, Value)
   :- attr("variant_default_value_from_cli", Package, Variant, Value).

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -1011,6 +1011,7 @@ compiler_match(Package, Dependency)
 
 compiler_mismatch(Package, Dependency)
   :- depends_on(Package, Dependency),
+     not node_compiler_set(Dependency, _),
      not compiler_match(Package, Dependency).
 
 #defined node_compiler_set/2.

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -353,10 +353,15 @@ class TestConcretize(object):
         assert spec.satisfies("^openblas cflags='-O3'")
 
     def test_mixing_compilers_only_affects_subdag(self):
-        spack.config.set('packages:all:compiler', ['clang', 'gcc'])
-        spec = Spec('dt-diamond%gcc ^dt-diamond-bottom%clang').concretized()
+        spack.config.set("packages:all:compiler", ["clang", "gcc"])
+        spec = Spec("dt-diamond%gcc ^dt-diamond-bottom%clang").concretized()
         for dep in spec.traverse():
-            assert ('%clang' in dep) == (dep.name == 'dt-diamond-bottom')
+            assert ("%clang" in dep) == (dep.name == "dt-diamond-bottom")
+
+    def test_compiler_inherited_upwards(self):
+        spec = Spec("dt-diamond ^dt-diamond-bottom%clang").concretized()
+        for dep in spec.traverse():
+            assert "%clang" in dep
 
     def test_architecture_inheritance(self):
         """test_architecture_inheritance is likely to fail with an

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -352,6 +352,12 @@ class TestConcretize(object):
         assert set(spec.compiler_flags["cflags"]) == set(["-g"])
         assert spec.satisfies("^openblas cflags='-O3'")
 
+    def test_mixing_compilers_only_affects_subdag(self):
+        spack.config.set('packages:all:compiler', ['clang', 'gcc'])
+        spec = Spec('dt-diamond%gcc ^dt-diamond-bottom%clang').concretized()
+        for dep in spec.traverse():
+            assert ('%clang' in dep) == (dep.name == 'dt-diamond-bottom')
+
     def test_architecture_inheritance(self):
         """test_architecture_inheritance is likely to fail with an
         UnavailableCompilerVersionError if the architecture is concretized


### PR DESCRIPTION
Fixes a bug reported by @haampie on slack. Includes regression test.