### PR TITLE
Package-level submodule attribute: support explicit versions

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1575,6 +1575,10 @@ def _from_merged_attrs(fetcher, pkg, version):
 
     attrs['fetch_options'] = pkg.fetch_options
     attrs.update(pkg.versions[version])
+
+    if fetcher.url_attr == 'git' and hasattr(pkg, 'submodules'):
+        attrs.setdefault('submodules', pkg.submodules)
+
     return fetcher(**attrs)
 
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1364,6 +1364,9 @@ def mock_git_repository(tmpdir_factory):
         ),
         'commit': Bunch(
             revision=r1, file=r1_file, args={'git': url, 'commit': r1}
+        ),
+        'master-no-per-version-git': Bunch(
+            revision='master', file=r0_file, args={'branch': 'master'}
         )
     }
 

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1365,6 +1365,9 @@ def mock_git_repository(tmpdir_factory):
         'commit': Bunch(
             revision=r1, file=r1_file, args={'git': url, 'commit': r1}
         ),
+        # In this case, the version() args do not include a 'git' key:
+        # this is the norm for packages, so this tests how the fetching logic
+        # would most-commonly assemble a Git fetcher
         'master-no-per-version-git': Bunch(
             revision='master', file=r0_file, args={'branch': 'master'}
         )

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -150,6 +150,11 @@ def test_fetch_pkg_attr_submodule_init(
         mutable_mock_repo,
         monkeypatch,
         mock_stage):
+    """In this case the version() args do not contain a 'git' URL, so
+    the fetcher must be assembled using the Package-level 'git' attribute.
+    This test ensures that the submodules are properly initialized and the
+    expected branch file is present.
+    """
 
     t = mock_git_repository.checks['master-no-per-version-git']
     pkg_class = spack.repo.path.get_pkg_class('git-test')
@@ -169,7 +174,7 @@ def test_fetch_pkg_attr_submodule_init(
     for root, dirs, files in os.walk(spec.package.stage.source_path):
         collected_fnames.update(files)
     # The submodules generate files with the prefix "r0_file_"
-    assert set(['r0_file_0', 'r0_file_1']) < collected_fnames
+    assert set(['r0_file_0', 'r0_file_1', t.file]) < collected_fnames
 
 
 @pytest.mark.skipif(str(spack.platforms.host()) == 'windows',

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -82,7 +82,9 @@ def test_bad_git(tmpdir, mock_bad_git):
             fetcher.fetch()
 
 
-@pytest.mark.parametrize("type_of_test", ['master', 'branch', 'tag', 'commit'])
+@pytest.mark.parametrize("type_of_test",
+                         ['master', 'branch', 'tag', 'commit',
+                          'master-no-per-version-git'])
 @pytest.mark.parametrize("secure", [True, False])
 def test_fetch(type_of_test,
                secure,
@@ -103,6 +105,17 @@ def test_fetch(type_of_test,
     # Retrieve the right test parameters
     t = mock_git_repository.checks[type_of_test]
     h = mock_git_repository.hash
+
+    if type_of_test == 'master-no-per-version-git':
+        import pdb; pdb.set_trace()
+
+    pkg_class = spack.repo.path.get_pkg_class('git-test')
+    if type_of_test == 'master-no-per-version-git':
+        # For this test, the version args don't specify 'git' (which is
+        # the majority of version specifications)
+        monkeypatch.setattr(pkg_class, 'git', mock_git_repository.url)
+    else:
+        monkeypatch.delattr(pkg_class, 'git')
 
     # Construct the package under test
     spec = Spec('git-test')

--- a/var/spack/repos/builtin.mock/packages/git-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/git-test/package.py
@@ -9,6 +9,8 @@ from spack import *
 class GitTest(Package):
     """Mock package that uses git for fetching."""
     homepage = "http://www.git-fetch-example.com"
+    # To be set by test
+    git = None
 
     submodules = True
 

--- a/var/spack/repos/builtin/packages/axom/package.py
+++ b/var/spack/repos/builtin/packages/axom/package.py
@@ -38,21 +38,20 @@ class Axom(CachedCMakePackage, CudaPackage):
     git      = "https://github.com/LLNL/axom.git"
     tags     = ['radiuss']
 
-    version('main', branch='main', submodules=True)
-    version('develop', branch='develop', submodules=True)
-    version('0.6.1', tag='v0.6.1', submodules=True)
-    version('0.6.0', tag='v0.6.0', submodules=True)
-    version('0.5.0', tag='v0.5.0', submodules=True)
-    version('0.4.0', tag='v0.4.0', submodules=True)
-    version('0.3.3', tag='v0.3.3', submodules=True)
-    version('0.3.2', tag='v0.3.2', submodules=True)
-    version('0.3.1', tag='v0.3.1', submodules=True)
-    version('0.3.0', tag='v0.3.0', submodules=True)
-    version('0.2.9', tag='v0.2.9', submodules=True)
+    version('main', branch='main')
+    version('develop', branch='develop')
+    version('0.6.1', tag='v0.6.1')
+    version('0.6.0', tag='v0.6.0')
+    version('0.5.0', tag='v0.5.0')
+    version('0.4.0', tag='v0.4.0')
+    version('0.3.3', tag='v0.3.3')
+    version('0.3.2', tag='v0.3.2')
+    version('0.3.1', tag='v0.3.1')
+    version('0.3.0', tag='v0.3.0')
+    version('0.2.9', tag='v0.2.9')
 
     @property
     def submodules(self):
-        # All git checkouts should also initialize submodules
         return True
 
     patch('scr_examples_gtest.patch', when='@0.6.0:0.6.1')


### PR DESCRIPTION
https://github.com/spack/spack/pull/30037 added the option of setting a package-level `submodules` attribute (or property, if submodule use is conditioned on e.g. version) which made it automatically initialize submodules for ad-hoc git commit versions (i.e. versions that are Git commit hashes, that are not explicitly recorded in the Spec).

The intent would be that this would also allow for removing `submodules=True` from the explicit `version()` declarations, but I got that wrong. This:

* Fixes that
* Adds a git fetching logic test where the fetching logic sets up a fetcher based on the `git` attribute at the package level (vs. specified as part of the args for an individual `version()` directive, which is more rare) and confirms that submodules are initialized in this case
* Also updates the `axom` package to remove `submodules=True` from the individual `version()` declarations.

@white238 this is a follow up to https://github.com/spack/spack/pull/30037#discussion_r850161379