### PR TITLE
Adiak: Use correct CMake MPI variables

### DIFF
--- a/var/spack/repos/builtin/packages/adiak/package.py
+++ b/var/spack/repos/builtin/packages/adiak/package.py
@@ -30,8 +30,8 @@ class Adiak(CMakePackage):
     def cmake_args(self):
         args = []
         if self.spec.satisfies('+mpi'):
-            args.append('-DMPICXX=%s' % self.spec['mpi'].mpicxx)
-            args.append('-DMPICC=%s' % self.spec['mpi'].mpicc)
+            args.append('-DMPI_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx)
+            args.append('-DMPI_C_COMPILER=%s' % self.spec['mpi'].mpicc)
             args.append('-DENABLE_MPI=ON')
         else:
             args.append('-DENABLE_MPI=OFF')


### PR DESCRIPTION
CMake uses `MPI_C_COMPILER` and `MPI_CXX_COMPILER` in the FindMPI.cmake module.

https://cmake.org/cmake/help/latest/module/FindMPI.html#variables-for-using-mpi