### PR TITLE
gaussian: adding tcsh dependency

### DIFF
--- a/var/spack/repos/builtin/packages/gaussian/package.py
+++ b/var/spack/repos/builtin/packages/gaussian/package.py
@@ -18,6 +18,19 @@ class Gaussian(Package):
     version('16-B.01', sha256='0b2cf60aa85d2c8c8e7547446e60e8e8cb67eec20e5f13c4a3e4e7616dcdf122')
     version('09-D.01', sha256='ef14885b5e334b6ec44a93bfd7225c634247dc946416af3087ab055bf05f54cd')
 
+    depends_on('tcsh')
+
+    def patch(self):
+        csh = join_path(self.spec['tcsh'].prefix.bin, 'csh')
+        tcsh = join_path(self.spec['tcsh'].prefix.bin, 'tcsh')
+        dirs = ['bsd', 'tests']
+        for d in dirs:
+            for f in next(os.walk(d))[2]:
+                filter_file('^#!/bin/csh',
+                            '#!{0}'.format(csh), join_path(d, f))
+                filter_file('^#!/bin/tcsh',
+                            '#!{0}'.format(tcsh), join_path(d, f))
+
     @property
     def ver(self):
         return self.version.string.split('-')[0]


### PR DESCRIPTION
The Gaussian install script (along with many of the other scripts in the bsd and tests dirs) requires csh to run. I only noticed this recently when building in a stripped down build environment I'm using to build environments for our clusters.

Also, the sha256sum for the archive we got from Gaussian differs, but I don't really know if there's an 'authoritative' one so I'm leaving that unchanged.