### PR TITLE
Mesa: Constrain compatible LLVM version

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -98,6 +98,7 @@ class Mesa(MesonPackage):
 
     # Variant dependencies
     depends_on('libllvm@6:', when='+llvm')
+    depends_on('libllvm@:13', when='@:21 +llvm')
     depends_on('libx11',  when='+glx')
     depends_on('libxcb',  when='+glx')
     depends_on('libxext', when='+glx')


### PR DESCRIPTION
Base on release date, not actual compatibility. LLVM version compatibility is not well documented in Mesa for upper version limits.

@chuckatkins @srekolam 

The motivation of the change is to prevent building Mesa with LLVM that does not provide a compatible API. This was an issue when attempting to build the latest 5.x ROCm stack.