### PR TITLE
aperture-photometry: update to v3.0.2 and url change

### DIFF
--- a/var/spack/repos/builtin/packages/aperture-photometry/package.py
+++ b/var/spack/repos/builtin/packages/aperture-photometry/package.py
@@ -12,7 +12,7 @@ class AperturePhotometry(Package):
     """Aperture Photometry Tool APT is software for astronomical research"""
 
     homepage = "http://www.aperturephotometry.org/"
-    url      = "http://web.ipac.caltech.edu/staff/laher/apt/APT_v2.8.4.tar.gz"
+    url      = "https://web.ipac.caltech.edu/staff/laher/apt/APT_v2.8.4.tar.gz"
     maintainers = ['snehring']
 
     version('3.0.2', '8ac430079825ba274567fb998dd693bb6f99490f5b896d4746178ba796bfdead')

--- a/var/spack/repos/builtin/packages/aperture-photometry/package.py
+++ b/var/spack/repos/builtin/packages/aperture-photometry/package.py
@@ -11,24 +11,24 @@ from spack import *
 class AperturePhotometry(Package):
     """Aperture Photometry Tool APT is software for astronomical research"""
 
-    homepage = "http://www.aperturephotometry.org/aptool/"
-    url      = "http://www.aperturephotometry.org/aptool/wp-content/plugins/download-monitor/download.php?id=1"
+    homepage = "http://www.aperturephotometry.org/"
+    url      = "http://web.ipac.caltech.edu/staff/laher/apt/APT_v2.8.4.tar.gz"
+    maintainers = ['snehring']
 
-    version('2.8.4', '28ae136c708a3ebcb83632230e119a03ca1a65499006ab69dc76e21b4921f465', extension='tar.gz')
-    version('2.8.2', 'cb29eb39a630dc5d17c02fb824c69571fe1870a910a6acf9115c5f76fd89dd7e', extension='tar.gz')
+    version('3.0.2', '8ac430079825ba274567fb998dd693bb6f99490f5b896d4746178ba796bfdead')
+    version('2.8.4', '28ae136c708a3ebcb83632230e119a03ca1a65499006ab69dc76e21b4921f465')
+    version('2.8.2', 'cb29eb39a630dc5d17c02fb824c69571fe1870a910a6acf9115c5f76fd89dd7e', deprecated=True)
 
     depends_on('java')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        jar_file = 'APT.jar'
-        install(jar_file, prefix.bin)
+        install('APT.jar', prefix.bin)
         java = join_path(self.spec['java'].prefix, 'bin', 'java')
         script_sh = join_path(os.path.dirname(__file__), "APT.sh")
         script = join_path(prefix.bin, "apt")
         install(script_sh, script)
         set_executable(script)
-        kwargs = {'ignore_absent': False, 'backup': False, 'string': False}
-        filter_file('^java', java, script, **kwargs)
+        filter_file('^java', java, script)
         filter_file('APT.jar', join_path(prefix.bin, 'APT.jar'),
-                    script, **kwargs)
+                    script)


### PR DESCRIPTION
This updates to the latest version available and also addresses changes to the download locations. The version 2.8.2 doesn't seem to be available any more, so I've marked it as deprecated.