### PR TITLE
glew,vapor: Move depends_on("glu") from glew to vapor

### DIFF
--- a/var/spack/repos/builtin/packages/glew/package.py
+++ b/var/spack/repos/builtin/packages/glew/package.py
@@ -13,7 +13,7 @@ class Glew(CMakePackage):
     version('2.1.0',  sha256='04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95')
     version('2.0.0',  sha256='c572c30a4e64689c342ba1624130ac98936d7af90c3103f9ce12b8a0c5736764')
 
-    depends_on("glu")
+    depends_on("gl")  # glu is optional if -DGLEW_NO_GLU is used by dependents
     depends_on('libsm')
     depends_on('libice')
 

--- a/var/spack/repos/builtin/packages/vapor/package.py
+++ b/var/spack/repos/builtin/packages/vapor/package.py
@@ -21,7 +21,7 @@ class Vapor(CMakePackage):
     version('3.5.0', sha256='f055d488c6f5bda5174a63990b6b6600037f7ce73ac68d39ad0f371d67f2d685')
     version('3.3.0', sha256='41c13d206cfcfa4146155d524106de2eb74e7b59af1e2f8c1c3056c15d508a93')
 
-    depends_on('gl')  # GUI
+    depends_on('glu')  # GUI
     depends_on('qt@5.13.2:+opengl+dbus')  # GUI
     depends_on('netcdf-c@4.7.0:')
     depends_on('udunits@2.2.26:')


### PR DESCRIPTION
@samfux84 asked in #26630:
> This PR also made a change to the glew package which is not discussed at all. Why was the "gl" dependency changed to "glu" in the glew package?

Answer: In #26630, when fixing the build of `vapor`, I assumed "glu" was needed by `glew` because it included `glu.h`.

But it appears that `glew` can be used without `glu` when `GLEW_NO_GLU` is defined and this is documented in the announcement of glew-1.6.0:

> https://www.geeks3d.com/20110430/opengl-glew-1-6-0-available/
> * Define GLEW_NO_GLU for no glu dependency

It is therefore the duty of users of `glew` to decide if they use `glu`,
and then they need to have a `depends_on("glu")`.

Thus, move the `depends_on("glu")` which I changed from `"gl"` (thus restoring the `depends_on("gl")` in #26630 to `vapor`, which itself uses glu and is therefore the package which needs the dependency on `glu`.