### PR TITLE
direnv: new version 2.31.0

### DIFF
--- a/var/spack/repos/builtin/packages/direnv/package.py
+++ b/var/spack/repos/builtin/packages/direnv/package.py
@@ -14,10 +14,12 @@ class Direnv(Package):
 
     maintainers = ['acastanedam']
 
+    version('2.31.0', sha256='f82694202f584d281a166bd5b7e877565f96a94807af96325c8f43643d76cb44')
     version('2.30.2', sha256='a2ee14ebdbd9274ba8bf0896eeb94e98947a056611058dedd4dbb43167e076f3')
     version('2.20.0', sha256='cc72525b0a5b3c2ab9a52a3696e95562913cd431f923bcc967591e75b7541bff')
     version('2.11.3', sha256='2d34103a7f9645059270763a0cfe82085f6d9fe61b2a85aca558689df0e7b006')
 
+    depends_on('go@1.16:', type='build', when='@2.28:')
     depends_on('go', type='build')
 
     def install(self, spec, prefix):


### PR DESCRIPTION
This PR adds the latest version of `direnv`. In addition, it sets a lower bound for the `go` version required by recent `direnv` versions (as specified in the [v2.28.0 release notes](https://github.com/direnv/direnv/releases/tag/v2.28.0)) to prevent build failures from using a version that is too old.