### PR TITLE
DAMASK 3.0.0alpha6

### DIFF
--- a/var/spack/repos/builtin/packages/damask-grid/package.py
+++ b/var/spack/repos/builtin/packages/damask-grid/package.py
@@ -12,14 +12,16 @@ class DamaskGrid(CMakePackage):
 
     maintainers = ['MarDiehl']
 
-    version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
+    version('3.0.0-alpha6', sha256='de6748c285558dec8f730c4301bfa56b4078c130ff80e3095faf76202f8d2109')
     version('3.0.0-alpha5', sha256='2d2b10901959c26a5bb5c52327cdafc7943bc1b36b77b515b0371221703249ae')
+    version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
 
+    depends_on('petsc@3.16.5:3.16',             when='@3.0.0-alpha6')
+    depends_on('petsc@3.14.0:3.14,3.15.1:3.16', when='@3.0.0-alpha5')
+    depends_on('petsc@3.14.0:3.14,3.15.1:3.15', when='@3.0.0-alpha4')
     depends_on('pkgconfig', type='build')
     depends_on('cmake@3.10:', type='build')
     depends_on('petsc+mpi+hdf5')
-    depends_on('petsc@3.14.0:3.14,3.15.1:3.15', when='@3.0.0-alpha4')
-    depends_on('petsc@3.14.0:3.14,3.15.1:3.16', when='@3.0.0-alpha5')
     depends_on('hdf5@1.10:+mpi+fortran')
     depends_on('fftw+mpi')
 

--- a/var/spack/repos/builtin/packages/damask-mesh/package.py
+++ b/var/spack/repos/builtin/packages/damask-mesh/package.py
@@ -12,14 +12,16 @@ class DamaskMesh(CMakePackage):
 
     maintainers = ['MarDiehl']
 
-    version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
+    version('3.0.0-alpha6', sha256='de6748c285558dec8f730c4301bfa56b4078c130ff80e3095faf76202f8d2109')
     version('3.0.0-alpha5', sha256='2d2b10901959c26a5bb5c52327cdafc7943bc1b36b77b515b0371221703249ae')
+    version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
 
+    depends_on('petsc@3.16.5:3.16',             when='@3.0.0-alpha6')
+    depends_on('petsc@3.14.0:3.14,3.15.1:3.16', when='@3.0.0-alpha5')
+    depends_on('petsc@3.14.0:3.14,3.15.1:3.15', when='@3.0.0-alpha4')
     depends_on('pkgconfig', type='build')
     depends_on('cmake@3.10:', type='build')
     depends_on('petsc+mpi+hdf5')
-    depends_on('petsc@3.14.0:3.14,3.15.1:3.15', when='@3.0.0-alpha4')
-    depends_on('petsc@3.14.0:3.14,3.15.1:3.16', when='@3.0.0-alpha5')
     depends_on('hdf5@1.10:+mpi+fortran')
 
     patch('CMakeDebugRelease.patch', when='@3.0.0-alpha4')

--- a/var/spack/repos/builtin/packages/damask/package.py
+++ b/var/spack/repos/builtin/packages/damask/package.py
@@ -25,13 +25,18 @@ class Damask(BundlePackage):
 
     maintainers = ['MarDiehl']
 
-    version('3.0.0-alpha4')
+    version('3.0.0-alpha6')
     version('3.0.0-alpha5')
+    version('3.0.0-alpha4')
 
-    depends_on('damask-grid@3.0.0-alpha4', when='@3.0.0-alpha4', type='run')
-    depends_on('damask-mesh@3.0.0-alpha4', when='@3.0.0-alpha4', type='run')
-    depends_on('py-damask@3.0.0-alpha4',   when='@3.0.0-alpha4', type='run')
+    depends_on('damask-grid@3.0.0-alpha6', when='@3.0.0-alpha6', type='run')
+    depends_on('damask-mesh@3.0.0-alpha6', when='@3.0.0-alpha6', type='run')
+    depends_on('py-damask@3.0.0-alpha6',   when='@3.0.0-alpha6', type='run')
 
     depends_on('damask-grid@3.0.0-alpha5', when='@3.0.0-alpha5', type='run')
     depends_on('damask-mesh@3.0.0-alpha5', when='@3.0.0-alpha5', type='run')
     depends_on('py-damask@3.0.0-alpha5',   when='@3.0.0-alpha5', type='run')
+
+    depends_on('damask-grid@3.0.0-alpha4', when='@3.0.0-alpha4', type='run')
+    depends_on('damask-mesh@3.0.0-alpha4', when='@3.0.0-alpha4', type='run')
+    depends_on('py-damask@3.0.0-alpha4',   when='@3.0.0-alpha4', type='run')

--- a/var/spack/repos/builtin/packages/py-damask/package.py
+++ b/var/spack/repos/builtin/packages/py-damask/package.py
@@ -12,9 +12,11 @@ class PyDamask(PythonPackage):
 
     maintainers = ['MarDiehl']
 
-    version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
+    version('3.0.0-alpha6', sha256='de6748c285558dec8f730c4301bfa56b4078c130ff80e3095faf76202f8d2109')
     version('3.0.0-alpha5', sha256='2d2b10901959c26a5bb5c52327cdafc7943bc1b36b77b515b0371221703249ae')
+    version('3.0.0-alpha4', sha256='0bb8bde43b27d852b1fb6e359a7157354544557ad83d87987b03f5d629ce5493')
 
+    depends_on('python@3.8:', type=('build', 'run'), when='@3.0.0-alpha6:')
     depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-setuptools@40.6:', type='build')
     depends_on('vtk+python', type=('build', 'run'))


### PR DESCRIPTION
regular update.
damask-grid and damask-mesh require relatively new PETSc version due to recently introduced fix.