### PR TITLE
coreutils: new versions 9.0, 9.1

### DIFF
--- a/var/spack/repos/builtin/packages/coreutils/package.py
+++ b/var/spack/repos/builtin/packages/coreutils/package.py
@@ -18,6 +18,8 @@ class Coreutils(AutotoolsPackage, GNUMirrorPackage):
 
     tags = ['core-packages']
 
+    version('9.1', sha256='61a1f410d78ba7e7f37a5a4f50e6d1320aca33375484a3255eddf17a38580423')
+    version('9.0', sha256='ce30acdf4a41bc5bb30dd955e9eaa75fa216b4e3deb08889ed32433c7b3b97ce')
     version('8.32', sha256='4458d8de7849df44ccab15e16b1548b285224dbba5f08fac070c1c0e0bcc4cfa')
     version('8.31', sha256='ff7a9c918edce6b4f4b2725e3f9b37b0c4d193531cac49a48b56c4d0d3a9e9fd')
     version('8.30', sha256='e831b3a86091496cdba720411f9748de81507798f6130adeaef872d206e1b057')


### PR DESCRIPTION
This PR adds the two latest versions of `coreutils`.