### PR TITLE
Add license dir to config

### DIFF
--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -34,8 +34,7 @@ config:
     - $spack/share/spack/templates
 
   # Directory where licenses should be located
-  license_dir:
-    - $spack/etc/spack/licenses
+  license_dir: $spack/etc/spack/licenses
 
   # Temporary locations Spack can try to use for builds.
   #

--- a/etc/spack/defaults/config.yaml
+++ b/etc/spack/defaults/config.yaml
@@ -33,6 +33,10 @@ config:
   template_dirs:
     - $spack/share/spack/templates
 
+  # Directory where licenses should be located
+  license_dir:
+    - $spack/etc/spack/licenses
+
   # Temporary locations Spack can try to use for builds.
   #
   # Recommended options are given below.

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -88,7 +88,7 @@ all_schemas.update(dict((key, spack.schema.env.schema)
 
 #: Path to the default configuration
 configuration_defaults_path = (
-    'defaults', os.path.join(spack.paths.etc_path, 'spack', 'defaults')
+    'defaults', os.path.join(spack.paths.etc_path, 'defaults')
 )
 
 #: Hard-coded default values for some key configuration options.
@@ -104,6 +104,7 @@ config_defaults = {
         'build_jobs': min(16, cpus_available()),
         'build_stage': '$tempdir/spack-stage',
         'concretizer': 'clingo',
+        'license_dir': spack.paths.default_license_dir,
     }
 }
 
@@ -815,7 +816,7 @@ def _config():
     # Site configuration is per spack instance, for sites or projects
     # No site-level configs should be checked into spack by default.
     configuration_paths.append(
-        ('site', os.path.join(spack.paths.etc_path, 'spack')),
+        ('site', os.path.join(spack.paths.etc_path)),
     )
 
     # User configuration can override both spack defaults and site config

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -53,6 +53,7 @@ import spack.repo
 import spack.store
 import spack.url
 import spack.util.environment
+import spack.util.path
 import spack.util.web
 from spack.filesystem_view import YamlFilesystemView
 from spack.install_test import TestFailure, TestSuite
@@ -60,7 +61,6 @@ from spack.installer import InstallError, PackageInstaller
 from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
-import spack.util.path
 from spack.util.prefix import Prefix
 from spack.version import Version
 

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -940,7 +940,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     def global_license_dir(self):
         """Returns the directory where global license files for all
            packages are stored."""
-        return spack.config.get('config:license_dir', os.path.join(spack.paths.prefix, 'etc', 'spack', 'licenses'))
+        return spack.config.get('config:license_dir', 
+            os.path.join(spack.paths.prefix, 'etc', 'spack', 'licenses'))
 
     @property
     def global_license_file(self):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -60,7 +60,7 @@ from spack.installer import InstallError, PackageInstaller
 from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
-from spack.util.path import win_exe_ext
+import spack.util.path
 from spack.util.prefix import Prefix
 from spack.version import Version
 
@@ -200,9 +200,9 @@ class DetectablePackageMeta(object):
             def platform_executables(self):
                 def to_windows_exe(exe):
                     if exe.endswith('$'):
-                        exe = exe.replace('$', '%s$' % win_exe_ext())
+                        exe = exe.replace('$', '%s$' % spack.util.path.win_exe_ext())
                     else:
-                        exe += win_exe_ext()
+                        exe += spack.util.path.win_exe_ext()
                     return exe
                 plat_exe = []
                 if hasattr(self, 'executables'):
@@ -437,6 +437,11 @@ class PackageMeta(
             if '.' in self._name:
                 self._name = self._name[self._name.rindex('.') + 1:]
         return self._name
+
+    @property
+    def global_license_dir(self):
+        """Returns the directory where license files for all packages are stored."""
+        return spack.util.path.canonicalize_path(spack.config.get('config:license_dir'))
 
 
 def run_before(*phases):
@@ -938,11 +943,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     @property
     def global_license_dir(self):
-        """Returns the directory where global license files for all
-           packages are stored."""
-        return spack.config.get('config:license_dir',
-                                os.path.join(spack.paths.prefix,
-                                             'etc', 'spack', 'licenses'))
+        """Returns the directory where global license files are stored."""
+        return type(self).global_license_dir
 
     @property
     def global_license_file(self):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -940,7 +940,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     def global_license_dir(self):
         """Returns the directory where global license files for all
            packages are stored."""
-        return os.path.join(spack.paths.prefix, 'etc', 'spack', 'licenses')
+        return spack.config.get('config:license_dir', os.path.join(spack.paths.prefix, 'etc', 'spack', 'licenses'))
 
     @property
     def global_license_file(self):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -941,7 +941,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         """Returns the directory where global license files for all
            packages are stored."""
         return spack.config.get('config:license_dir',
-                                os.path.join(spack.paths.prefix, 
+                                os.path.join(spack.paths.prefix,
                                              'etc', 'spack', 'licenses'))
 
     @property

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -940,8 +940,9 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
     def global_license_dir(self):
         """Returns the directory where global license files for all
            packages are stored."""
-        return spack.config.get('config:license_dir', 
-            os.path.join(spack.paths.prefix, 'etc', 'spack', 'licenses'))
+        return spack.config.get('config:license_dir',
+                                os.path.join(spack.paths.prefix, 
+                                             'etc', 'spack', 'licenses'))
 
     @property
     def global_license_file(self):

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -43,8 +43,12 @@ test_path             = os.path.join(module_path, "test")
 hooks_path            = os.path.join(module_path, "hooks")
 opt_path              = os.path.join(prefix, "opt")
 share_path            = os.path.join(prefix, "share", "spack")
-etc_path              = os.path.join(prefix, "etc")
+etc_path              = os.path.join(prefix, "etc", "spack")
 
+#
+# Things in $spack/etc/spack
+#
+default_license_dir   = os.path.join(etc_path, "licenses")
 
 #
 # Things in $spack/var/spack

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -56,6 +56,7 @@ properties = {
                 'type': 'array',
                 'items': {'type': 'string'}
             },
+            'license_dir': {'type': 'string'},
             'source_cache': {'type': 'string'},
             'misc_cache': {'type': 'string'},
             'connect_timeout': {'type': 'integer', 'minimum': 0},

--- a/lib/spack/spack/test/bindist.py
+++ b/lib/spack/spack/test/bindist.py
@@ -78,13 +78,13 @@ def config_directory(tmpdir_factory):
     tmpdir = tmpdir_factory.mktemp('test_configs')
     # restore some sane defaults for packages and config
     config_path = py.path.local(spack.paths.etc_path)
-    modules_yaml = config_path.join('spack', 'defaults', 'modules.yaml')
-    os_modules_yaml = config_path.join('spack', 'defaults', '%s' %
+    modules_yaml = config_path.join('defaults', 'modules.yaml')
+    os_modules_yaml = config_path.join('defaults', '%s' %
                                        platform.system().lower(),
                                        'modules.yaml')
-    packages_yaml = config_path.join('spack', 'defaults', 'packages.yaml')
-    config_yaml = config_path.join('spack', 'defaults', 'config.yaml')
-    repos_yaml = config_path.join('spack', 'defaults', 'repos.yaml')
+    packages_yaml = config_path.join('defaults', 'packages.yaml')
+    config_yaml = config_path.join('defaults', 'config.yaml')
+    repos_yaml = config_path.join('defaults', 'repos.yaml')
     tmpdir.ensure('site', dir=True)
     tmpdir.ensure('user', dir=True)
     tmpdir.ensure('site/%s' % platform.system().lower(), dir=True)

--- a/lib/spack/spack/test/cmd/external.py
+++ b/lib/spack/spack/test/cmd/external.py
@@ -32,7 +32,7 @@ def _platform_executables(monkeypatch):
     def _win_exe_ext():
         return '.bat'
 
-    monkeypatch.setattr(spack.package, 'win_exe_ext', _win_exe_ext)
+    monkeypatch.setattr(spack.util.path, 'win_exe_ext', _win_exe_ext)
 
 
 def define_plat_exe(exe):

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -18,6 +18,7 @@ import spack.config
 import spack.environment as ev
 import spack.main
 import spack.paths
+import spack.repo
 import spack.schema.compilers
 import spack.schema.config
 import spack.schema.env
@@ -1155,6 +1156,19 @@ def test_bad_path_double_override(config):
                        match='Meaningless second override'):
         with spack.config.override('bad::double:override::directive', ''):
             pass
+
+
+def test_license_dir_config(mutable_config, mock_packages):
+    """Ensure license directory is customizable"""
+    assert spack.config.get("config:license_dir") == spack.paths.default_license_dir
+    assert spack.package.Package.global_license_dir == spack.paths.default_license_dir
+    assert spack.repo.get("a").global_license_dir == spack.paths.default_license_dir
+
+    rel_path = os.path.join(os.path.sep, "foo", "bar", "baz")
+    spack.config.set("config:license_dir", rel_path)
+    assert spack.config.get("config:license_dir") == rel_path
+    assert spack.package.Package.global_license_dir == rel_path
+    assert spack.repo.get("a").global_license_dir == rel_path
 
 
 @pytest.mark.regression('22547')

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -576,7 +576,7 @@ def default_config():
 
     This ensures we can test the real default configuration without having
     tests fail when the user overrides the defaults that we test against."""
-    defaults_path = os.path.join(spack.paths.etc_path, 'spack', 'defaults')
+    defaults_path = os.path.join(spack.paths.etc_path, 'defaults')
     if is_windows:
         defaults_path = os.path.join(defaults_path, "windows")
     with spack.config.use_configuration(defaults_path) as defaults_config:


### PR DESCRIPTION
Allow the user to specify a new location for the licenses that Spack touches. Defaults to the current location of /etc/spack/licenses.