### PR TITLE
mysqlpp: adding new version 3.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/mysqlpp/package.py
+++ b/var/spack/repos/builtin/packages/mysqlpp/package.py
@@ -16,6 +16,7 @@ class Mysqlpp(AutotoolsPackage):
     homepage = "https://tangentsoft.com/mysqlpp/home"
     url      = "https://tangentsoft.com/mysqlpp/releases/mysql++-3.2.5.tar.gz"
 
+    version('3.3.0', sha256='449cbc46556cc2cc9f9d6736904169a8df6415f6960528ee658998f96ca0e7cf')
     version('3.2.5', sha256='839cfbf71d50a04057970b8c31f4609901f5d3936eaa86dab3ede4905c4db7a8')
 
     depends_on('mysql-client')


### PR DESCRIPTION
Version upgrade. Seems to resolve compile errors with newer gccs.