### PR TITLE
py-rtree: add v1.0.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -12,12 +12,17 @@ class PyRtree(PythonPackage):
     homepage = "https://github.com/Toblerity/rtree"
     pypi = "Rtree/Rtree-0.8.3.tar.gz"
 
+    maintainers = ['adamjstewart']
+
+    version('1.0.0', sha256='d0483482121346b093b9a42518d40f921adf445915b7aea307eb26768c839682')
     version('0.9.7', sha256='be8772ca34699a9ad3fb4cfe2cfb6629854e453c10b3328039301bbfc128ca3e')
     version('0.8.3', sha256='6cb9cf3000963ea6a3db777a597baee2bc55c4fc891e4f1967f262cc96148649')
 
+    depends_on('python@3.7:', when='@1:', type=('build', 'run'))
     depends_on('python@3:', when='@0.9.4:', type=('build', 'run'))
+    depends_on('py-setuptools@39.2:', when='@1:', type='build')
     depends_on('py-setuptools', type='build')
-    depends_on('py-wheel', when='@0.9.4:', type='build')
+    depends_on('py-typing-extensions@3.7:', when='@1: ^python@:3.7', type=('build', 'run'))
     depends_on('libspatialindex@1.8.5:')
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-rtree/package.py
+++ b/var/spack/repos/builtin/packages/py-rtree/package.py
@@ -12,7 +12,7 @@ class PyRtree(PythonPackage):
     homepage = "https://github.com/Toblerity/rtree"
     pypi = "Rtree/Rtree-0.8.3.tar.gz"
 
-    maintainers = ['adamjstewart']
+    maintainers = ['adamjstewart', 'hobu']
 
     version('1.0.0', sha256='d0483482121346b093b9a42518d40f921adf445915b7aea307eb26768c839682')
     version('0.9.7', sha256='be8772ca34699a9ad3fb4cfe2cfb6629854e453c10b3328039301bbfc128ca3e')


### PR DESCRIPTION
Successfully builds and passes import tests on macOS 10.15.7 with Python 3.9.10 and Apple Clang 12.0.0.

@hobu let me know if you want to be listed as a maintainer for this build recipe.