### PR TITLE
trinotate: update to version 3.2.2

### DIFF
--- a/var/spack/repos/builtin/packages/trinotate/package.py
+++ b/var/spack/repos/builtin/packages/trinotate/package.py
@@ -17,6 +17,7 @@ class Trinotate(Package):
     homepage = "https://trinotate.github.io/"
     url      = "https://github.com/Trinotate/Trinotate/archive/Trinotate-v3.1.1.tar.gz"
 
+    version('3.2.2', sha256='1c41258a544cccb332f77b73f7397b457d5f3d7ce0038505369aeecc1e0650c2')
     version('3.1.1', sha256='f8af0fa5dbeaaf5a085132cd4ac4f4206b05cc4630f0a17a672c586691f03843')
 
     depends_on('trinity', type='run')


### PR DESCRIPTION
Update package trinotate to version 3.2.2