### PR TITLE
casper: fix compilation errors on newer compilers

### DIFF
--- a/var/spack/repos/builtin/packages/casper/package.py
+++ b/var/spack/repos/builtin/packages/casper/package.py
@@ -24,7 +24,7 @@ class Casper(MakefilePackage):
 
     def flag_handler(self, name, flags):
         if name in ['cxxflags', 'CXXFLAGS']:
-            flags.append('-std=c++03')
+            flags.append(self.compiler.cxx98_flag)
         return (flags, None, None)
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/casper/package.py
+++ b/var/spack/repos/builtin/packages/casper/package.py
@@ -23,7 +23,7 @@ class Casper(MakefilePackage):
     conflicts('%gcc@7.1.0')
 
     def flag_handler(self, name, flags):
-        if name in ['cxxflags', 'CXXFLAGS']:
+        if name.lower() == 'cxxflags':
             flags.append(self.compiler.cxx98_flag)
         return (flags, None, None)
 

--- a/var/spack/repos/builtin/packages/casper/package.py
+++ b/var/spack/repos/builtin/packages/casper/package.py
@@ -22,6 +22,11 @@ class Casper(MakefilePackage):
 
     conflicts('%gcc@7.1.0')
 
+    def flag_handler(self, name, flags):
+        if name in ['cxxflags', 'CXXFLAGS']:
+            flags.append('-std=c++03')
+        return (flags, None, None)
+
     def install(self, spec, prefix):
         install_tree('.', prefix)
 


### PR DESCRIPTION
Newer dialects break this. 98/03 seems to be the most recent that it will accept.