### PR TITLE
ncurses: add query parameters to select wide/nowide; readline: use wide only

### DIFF
--- a/var/spack/repos/builtin/packages/ncurses/package.py
+++ b/var/spack/repos/builtin/packages/ncurses/package.py
@@ -155,11 +155,47 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
             h = os.path.basename(header)
             os.symlink(os.path.join('ncursesw', h), os.path.join(prefix.include, h))
 
+    def query_parameter_options(self):
+        """Use query parameters passed to spec (e.g., "spec[ncurses:wide]")
+        to select wide, non-wide, or default/both."""
+        query_parameters = self.spec.last_query.extra_parameters
+        return 'nowide' in query_parameters, 'wide' in query_parameters
+
+    @property
+    def headers(self):
+        nowide, wide = self.query_parameter_options()
+        include = self.prefix.include
+        hdirs = []
+        if not (nowide or wide):
+            # default (top-level, wide)
+            hdirs.append(include)
+        if nowide:
+            hdirs.append(include.ncurses)
+        if wide:
+            hdirs.append(include.ncursesw)
+
+        headers = HeaderList([])
+        for hdir in hdirs:
+            headers = headers + find_headers('*', root=hdir, recursive=False).headers
+        headers.directories = hdirs
+        return headers
+
     @property
     def libs(self):
-        libraries = ['libncurses', 'libncursesw']
+        nowide, wide = self.query_parameter_options()
+        if not (nowide or wide):
+            # default (both)
+            nowide = True
+            wide = True
 
+        libs = ['libncurses']
         if '+termlib' in self.spec:
-            libraries += ['libtinfo', 'libtinfow']
+            libs.append('libtinfo')
+        wlibs = [lib + 'w' for lib in libs]
 
+        libraries = []
+        if nowide:
+            libraries.extend(libs)
+        if wide:
+            libraries.extend(wlibs)
         return find_libraries(libraries, root=self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/readline/package.py
+++ b/var/spack/repos/builtin/packages/readline/package.py
@@ -29,7 +29,7 @@ class Readline(AutotoolsPackage, GNUMirrorPackage):
     patch('readline-6.3-upstream_fixes-1.patch', when='@6.3')
 
     def build(self, spec, prefix):
-        make('SHLIB_LIBS=' + spec['ncurses'].libs.ld_flags)
+        make('SHLIB_LIBS=' + spec['ncurses:wide'].libs.ld_flags)
 
     def patch(self):
         # Remove flags not recognized by the NVIDIA compiler


### PR DESCRIPTION
Following on #27369, this adds query options to ncurses so you can select `spec['ncurses:wide']` or `spec['ncurses:nowide']` to get only the corresponding headers and libs.

It also changes readline to use wide ncurses (libncursesw) only. This is probably a better fix than #27375 as it lets python detect the correct ncurses library from readline without additional patching.