### PR TITLE
sentieon-genomics: add version 202112.02, remove manual download

### DIFF
--- a/var/spack/repos/builtin/packages/sentieon-genomics/package.py
+++ b/var/spack/repos/builtin/packages/sentieon-genomics/package.py
@@ -18,6 +18,7 @@ class SentieonGenomics(Package):
     homepage = "https://www.sentieon.com/"
     # url is from the permalink documented in dockerfile at
     # https://github.com/Sentieon/sentieon-docker/blob/master/Dockerfile
+    # See also: https://github.com/spack/spack/pull/30145/files#r853275635
     url      = "https://s3.amazonaws.com/sentieon-release/software/sentieon-genomics-201808.01.tar.gz"
     maintainers = ['snehring']
 

--- a/var/spack/repos/builtin/packages/sentieon-genomics/package.py
+++ b/var/spack/repos/builtin/packages/sentieon-genomics/package.py
@@ -10,6 +10,10 @@ class SentieonGenomics(Package):
     """Sentieon provides complete solutions for secondary DNA analysis.
     Our software improves upon BWA, GATK, Mutect, and Mutect2 based pipelines.
     The Sentieon tools are deployable on any CPU-based computing system.
+
+    Use of this software is subject to the EULA at:
+    https://www.sentieon.com/EULA/eula-aws.html
+
     Please set the path to the sentieon license server with:
 
     export SENTIEON_LICENSE=[FQDN]:[PORT]

--- a/var/spack/repos/builtin/packages/sentieon-genomics/package.py
+++ b/var/spack/repos/builtin/packages/sentieon-genomics/package.py
@@ -16,6 +16,8 @@ class SentieonGenomics(Package):
     """
 
     homepage = "https://www.sentieon.com/"
+    # url is from the permalink documented in dockerfile at
+    # https://github.com/Sentieon/sentieon-docker/blob/master/Dockerfile
     url      = "https://s3.amazonaws.com/sentieon-release/software/sentieon-genomics-201808.01.tar.gz"
     maintainers = ['snehring']
 

--- a/var/spack/repos/builtin/packages/sentieon-genomics/package.py
+++ b/var/spack/repos/builtin/packages/sentieon-genomics/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os.path
-
 from spack import *
 
 
@@ -15,17 +13,13 @@ class SentieonGenomics(Package):
     Please set the path to the sentieon license server with:
 
     export SENTIEON_LICENSE=[FQDN]:[PORT]
-
-    Note: A manual download is required.
-    Spack will search your current directory for the download file.
-    Alternatively, add this file to a mirror so that Spack can find it.
-    For instructions on how to set up a mirror, see
-    https://spack.readthedocs.io/en/latest/mirrors.html"""
+    """
 
     homepage = "https://www.sentieon.com/"
-    url      = "file://{0}/sentieon-genomics-201808.01.tar.gz".format(os.getcwd())
-    manual_download = True
+    url      = "https://s3.amazonaws.com/sentieon-release/software/sentieon-genomics-201808.01.tar.gz"
+    maintainers = ['snehring']
 
+    version('202112.02', sha256='033943df7958550fd42b410d34ae91a8956a905fc90ca8baa93d2830f918872c')
     version('201808.07', sha256='fb66b18a7b99e44968eb2c3a6a5b761d6b1e70fba9f7dfc4e5db3a74ab3d3dd9')
     version('201808.01', sha256='6d77bcd5a35539549b28eccae07b19a3b353d027720536e68f46dcf4b980d5f7')
 


### PR DESCRIPTION
They document the path in their dockerfile recipe, I think we can include it here.