### PR TITLE
gitlab ci: build e4s, radiuss, and dvsdk for x86_64_v3

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/data-vis-sdk/spack.yaml
@@ -18,7 +18,7 @@ spack:
     paraview:
       variants: +osmesa
     all:
-      target: [x86_64]
+      target: [x86_64_v3]
 
   # The spec will be gradually expanded to enable all the SDK components.
   # Currently disabled: ascent, catalyst, visit

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -20,7 +20,7 @@ spack:
         mpi:
           - mpich
       target:
-        - x86_64
+        - x86_64_v3
       variants: +mpi
     binutils:
       variants: +ld +gold +headers +libiberty ~nls
@@ -206,7 +206,7 @@ spack:
     #- umpire # unsatisfiable concretization conflict w/ blt
 
   - arch:
-    - '%gcc target=x86_64'
+    - '%gcc target=x86_64_v3'
 
 
   specs:

--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss/spack.yaml
@@ -12,7 +12,7 @@ spack:
 
   packages:
     all:
-      target: [x86_64]
+      target: [x86_64_v3]
 
       providers:
         mpi: [mvapich2]
@@ -20,7 +20,7 @@ spack:
   definitions:
     #- compilers: ['%gcc@8.3.1', '%clang@10.0.0']
     - compilers: ['%gcc@7.5.0']
-    
+
     # Note skipping spot since no spack package for it
     - radiuss:
       - ascent  # ^conduit@0.6.0


### PR DESCRIPTION
Change target architecture for the E4S, radiuss, and data-vis-sdk stacks tested in gitlab.