### PR TITLE
docs: add (config.yaml) to sections for faster lookup by config file

### DIFF
--- a/lib/spack/docs/build_settings.rst
+++ b/lib/spack/docs/build_settings.rst
@@ -5,9 +5,9 @@
 
 .. _build-settings:
 
-===================
-Build Customization
-===================
+================================
+Package Settings (packages.yaml)
+================================
 
 Spack allows you to customize how your software is built through the
 ``packages.yaml`` file.  Using it, you can make Spack prefer particular

--- a/lib/spack/docs/config_yaml.rst
+++ b/lib/spack/docs/config_yaml.rst
@@ -5,9 +5,9 @@
 
 .. _config-yaml:
 
-==============
-Basic Settings
-==============
+============================
+Spack Settings (config.yaml)
+============================
 
 Spack's basic configuration options are set in ``config.yaml``.  You can
 see the default settings by looking at

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -5,9 +5,9 @@
 
 .. _environments:
 
-============
-Environments
-============
+=========================
+Environments (spack.yaml)
+=========================
 
 An environment is used to group together a set of specs for the
 purpose of building, rebuilding and deploying in a coherent fashion.

--- a/lib/spack/docs/mirrors.rst
+++ b/lib/spack/docs/mirrors.rst
@@ -5,9 +5,9 @@
 
 .. _mirrors:
 
-=======
-Mirrors
-=======
+======================
+Mirrors (mirrors.yaml)
+======================
 
 Some sites may not have access to the internet for fetching packages.
 These sites will need a local repository of tarballs from which they

--- a/lib/spack/docs/module_file_support.rst
+++ b/lib/spack/docs/module_file_support.rst
@@ -5,9 +5,9 @@
 
 .. _modules:
 
-=======
-Modules
-=======
+======================
+Modules (modules.yaml)
+======================
 
 The use of module systems to manage user environment in a controlled way
 is a common practice at HPC centers that is often embraced also by

--- a/lib/spack/docs/repositories.rst
+++ b/lib/spack/docs/repositories.rst
@@ -5,9 +5,9 @@
 
 .. _repositories:
 
-=============================
-Package Repositories
-=============================
+=================================
+Package Repositories (repos.yaml)
+=================================
 
 Spack comes with thousands of built-in package recipes in
 ``var/spack/repos/builtin/``.  This is a **package repository** -- a


### PR DESCRIPTION
Make navigation to documentation for `(config|packages|mirrors|repos|modules|spack).yaml` a bit easier for new users.

![Screenshot from 2022-04-19 11-09-47](https://user-images.githubusercontent.com/194764/163971193-b21aee5b-df7f-4851-9404-b5aa5df0ac5f.png)
