### PR TITLE
netcdf-c: fix configure check for the -fno-strict-aliasing flag

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-c/4.8.1-no-strict-aliasing-config.patch
+++ b/var/spack/repos/builtin/packages/netcdf-c/4.8.1-no-strict-aliasing-config.patch
@@ -1,0 +1,31 @@
+--- a/configure
++++ b/configure
+@@ -3307,8 +3307,6 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+-CFLAGS="${CFLAGS} -fno-strict-aliasing"
+-
+ # Expand $ac_aux_dir to an absolute path.
+ am_aux_dir=`cd "$ac_aux_dir" && pwd`
+ 
+@@ -4161,6 +4159,9 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
+ 
++
++CFLAGS="${CFLAGS} -fno-strict-aliasing"
++
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+--- a/configure.ac
++++ b/configure.ac
+@@ -61,6 +61,7 @@ AC_CONFIG_HEADERS([config.h])
+ ##
+ SAVE_CFLAGS="${CFLAGS}"
+ AC_LANG_PUSH([C])
++AC_LANG_COMPILER_REQUIRE
+ CFLAGS="${CFLAGS} -fno-strict-aliasing"
+ 
+ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([

--- a/var/spack/repos/builtin/packages/netcdf-c/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-c/package.py
@@ -56,6 +56,9 @@ class NetcdfC(AutotoolsPackage):
     # See https://github.com/Unidata/netcdf-c/pull/1752
     patch('4.7.3-spectrum-mpi-pnetcdf-detect.patch', when='@4.7.3:4.7.4 +parallel-netcdf')
 
+    # See https://github.com/Unidata/netcdf-c/pull/2293
+    patch('4.8.1-no-strict-aliasing-config.patch', when='@4.8.1:')
+
     variant('mpi', default=True,
             description='Enable parallel I/O for netcdf-4')
     variant('parallel-netcdf', default=False,


### PR DESCRIPTION
This fixes the compilation of versions `@4.8.1:` with compilers that do not recognize the flag `-fno-strict-aliasing` (e.g. `pgi@19.9`).

The problem is reported upstream: https://github.com/Unidata/netcdf-c/pull/2293