### PR TITLE
[spdlog] Fix fmt dependency by adding a variant

### DIFF
--- a/var/spack/repos/builtin/packages/spdlog/package.py
+++ b/var/spack/repos/builtin/packages/spdlog/package.py
@@ -45,13 +45,17 @@ class Spdlog(CMakePackage):
 
     variant('shared', default=True,
             description='Build shared libraries (v1.4.0+)')
+    variant('external_fmt', default=False,
+            description='Use external fmt library')
+
 
     depends_on('cmake@3.2:', when='@:1.7.0', type='build')
     depends_on('cmake@3.10:', when='@1.8.0:', type='build')
 
-    depends_on('fmt@5.3:')
-    depends_on('fmt@7:', when='@1.7:')
-    depends_on('fmt@8:', when='@1.9:')
+    with when('+external_fmt'):
+        depends_on('fmt@5.3:')
+        depends_on('fmt@7:', when='@1.7:')
+        depends_on('fmt@8:', when='@1.9:')
 
     def cmake_args(self):
         args = []
@@ -59,11 +63,12 @@ class Spdlog(CMakePackage):
         if self.spec.version >= Version('1.4.0'):
             args.extend([
                 self.define_from_variant('SPDLOG_BUILD_SHARED', 'shared'),
-                self.define('SPDLOG_FMT_EXTERNAL', 'ON'),
                 # tests and examples
                 self.define('SPDLOG_BUILD_TESTS', self.run_tests),
                 self.define('SPDLOG_BUILD_EXAMPLE', self.run_tests),
 
             ])
+            if '+external_fmt' in self.spec:
+                args.append(self.define('SPDLOG_FMT_EXTERNAL', 'ON'))
 
         return args


### PR DESCRIPTION
This PR fixes a problem introduced by https://github.com/spack/spack/pull/30051:

spdlog ships with its own fmt library unless `SPDLOG_FMT_EXTERNAL` is set to `ON` (its default value being `OFF`). Some codes rely on spdlog's bundled fmt library instead of the standalone fmt library, and spdlog's fmt library doesn't have the same structure of headers than the standalone fmt, leading to these codes breaking.

The present PR adds the `external_fmt` variant to optionally enable building spdlog with the external fmt library, but sets its default value to False, in line with the corresponding `SPDLOG_FMT_EXTERNAL` default value.