### PR TITLE
gnuplot: Add version 5.4.3 and add workaround for not found DSO

### DIFF
--- a/var/spack/repos/builtin/packages/gnuplot/package.py
+++ b/var/spack/repos/builtin/packages/gnuplot/package.py
@@ -27,6 +27,7 @@ class Gnuplot(AutotoolsPackage):
     # dependency of readline. Fix it with a small patch
     patch('term_include.patch')
 
+    version('5.4.3', sha256='51f89bbab90f96d3543f95235368d188eb1e26eda296912256abcd3535bd4d84')
     version('5.4.2', sha256='e57c75e1318133951d32a83bcdc4aff17fed28722c4e71f2305cfc2ae1cae7ba')
     version('5.2.8', sha256='60a6764ccf404a1668c140f11cc1f699290ab70daa1151bb58fed6139a28ac37')
     version('5.2.7', sha256='97fe503ff3b2e356fe2ae32203fc7fd2cf9cef1f46b60fe46dc501a228b9f4ed')
@@ -157,4 +158,5 @@ class Gnuplot(AutotoolsPackage):
         # TODO: --with-aquaterm  depends_on('aquaterm')
         options.append('--without-aquaterm')
 
+        os.environ['LDFLAGS'] = ("-Wl,--copy-dt-needed-entries")
         return options


### PR DESCRIPTION
libiconv was not found with gcc11:
```
  >> 388    /bin/ld: encoding.o: undefined reference to symbol 'libiconv'
  >> 389    /build/hahansen/Spack/packages/libiconv/1.16/x86_64-centos7-gcc11.2.0-opt/lqfel/lib/libiconv.so.2: error adding symbols: DSO missing from command line
```
Added workaround suggested in https://stackoverflow.com/questions/19901934/libpthread-so-0-error-adding-symbols-dso-missing-from-command-line.