### PR TITLE
updated v2.11.6

### DIFF
--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -13,12 +13,13 @@ class AwsParallelcluster(PythonPackage):
     tool to deploy and manage HPC clusters in the AWS cloud."""
 
     homepage = "https://github.com/aws/aws-parallelcluster"
-    pypi = "aws-parallelcluster/aws-parallelcluster-2.11.5.tar.gz"
+    pypi = "aws-parallelcluster/aws-parallelcluster-2.11.6.tar.gz"
 
     maintainers = [
         'demartinofra', 'enrico-usai', 'lukeseawalker',
     ]
 
+    version('2.11.6', sha256='4df4bcf966f523bcdf5b4f68ed0ef347eebae70a074cd098b15bc8a6be27217c')
     version('2.11.5', sha256='7499f88387cbe2cb73f9fddeee3363117f7ef1524d6a73e77bb07900040baebb')
     version('2.11.4', sha256='449537ccda57f91f4ec6ae0c94a8e2b1a789f08f80245fadb28f44a4351d5da4')
     version('2.11.3', sha256='7c1d74123f2f670846aed8fe1fcca5908bb46ec014e2dfc7d3ec8994447a37a0')
@@ -49,7 +50,7 @@ class AwsParallelcluster(PythonPackage):
 
     depends_on('py-configparser@3.5.0:3.8.1', when='^python@:2', type=('build', 'run'))
 
-    depends_on('py-tabulate@0.8.2:0.8.9', when='@2.11:', type=('build', 'run'))
+    depends_on('py-tabulate@0.8.3:0.8.9', when='@2.11:', type=('build', 'run'))
     depends_on('py-tabulate@0.8.2:0.8.3', when='@:2.8', type=('build', 'run'))
     depends_on('py-tabulate@0.8.5', when='@2.9: ^python@3.0:3.4', type=('build', 'run'))
     depends_on('py-tabulate@0.8.2:0.8.7', when='@2.9: ^python@:2,3.5:', type=('build', 'run'))
@@ -60,9 +61,11 @@ class AwsParallelcluster(PythonPackage):
     depends_on('py-pyyaml@5.1.2:', when='@2.6:2.8 ^python@:2,3.5:', type=('build', 'run'))
     depends_on('py-pyyaml@5.1.2:', when='@:2.5', type=('build', 'run'))
 
+    depends_on('py-jinja2@2.11.3:', when='@2.11:', type=('build', 'run'))
     depends_on('py-jinja2@2.10.1', when='@2.9: ^python@3.0:3.4', type=('build', 'run'))
     depends_on('py-jinja2@2.11.0:', when='@2.9: ^python@:2,3.5:', type=('build', 'run'))
 
+    depends_on('py-boto3@1.17.27:', when='@2.11:', type=('build', 'run'))
     depends_on('py-boto3@1.16.14:', when='@2.10:', type=('build', 'run'))
     depends_on('py-boto3@1.14.3:', when='@2.8:2.9', type=('build', 'run'))
     depends_on('py-boto3@1.10.15:', when='@:2.7', type=('build', 'run'))


### PR DESCRIPTION
### Changes
Updated aws-parallelcluster to v2.11.6

### Tests
Local installation:

```
==> Installing aws-parallelcluster-2.11.6-nqgszeypas2cnx4ar5lfcoo7dxwpwzxd
==> No binary for aws-parallelcluster-2.11.6-nqgszeypas2cnx4ar5lfcoo7dxwpwzxd found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/a/aws-parallelcluster/aws-parallelcluster-2.11.6.tar.gz
==> No patches needed for aws-parallelcluster
==> aws-parallelcluster: Executing phase: 'install'
==> aws-parallelcluster: Successfully installed aws-parallelcluster-2.11.6-nqgszeypas2cnx4ar5lfcoo7dxwpwzxd
  Fetch: 2.68s.  Build: 2.21s.  Total: 4.89s.
```