### PR TITLE
blat: update to version 37

### DIFF
--- a/var/spack/repos/builtin/packages/blat/package.py
+++ b/var/spack/repos/builtin/packages/blat/package.py
@@ -23,7 +23,12 @@ class Blat(Package):
 
     @when('@37')
     def patch(self):
-        filter_file(',src\/hg\/', ',NOMATCHME', 'inc/userApp.mk')
+        filter_file(r',src\/hg\/', ',NOMATCHME', 'inc/userApp.mk')
+
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('@35') and name.lower() == 'cflags':
+            flags.append('-fcommon')
+        return (flags, None, None)
 
     def setup_build_environment(self, env):
         env.set('MACHTYPE', 'x86_64')

--- a/var/spack/repos/builtin/packages/blat/package.py
+++ b/var/spack/repos/builtin/packages/blat/package.py
@@ -11,11 +11,19 @@ class Blat(Package):
        alignment algorithm."""
 
     homepage = "https://genome.ucsc.edu/FAQ/FAQblat.html"
-    url      = "https://users.soe.ucsc.edu/~kent/src/blatSrc35.zip"
+    url      = "https://genome-test.gi.ucsc.edu/~kent/src/blatSrc35.zip"
+    maintainers = ['snehring']
 
+    version('37', sha256='88ee2b272d42ab77687c61d200b11f1d58443951069feb7e10226a2509f84cf2')
     version('35', sha256='06d9bcf114ec4a4b21fef0540a0532556b6602322a5a2b33f159dc939ae53620')
 
     depends_on('libpng')
+    depends_on('libuuid', when='@37:')
+    depends_on('mysql-client', when='@37:')
+
+    @when('@37')
+    def patch(self):
+        filter_file(',src\/hg\/', ',NOMATCHME', 'inc/userApp.mk')
 
     def setup_build_environment(self, env):
         env.set('MACHTYPE', 'x86_64')


### PR DESCRIPTION
Updates to version 37, which resolves a number of compiler errors with newer compilers. Adds in some new dependencies in this version and addresses a build error unique to this version. I spoke with the developer over email and he believes this is an acceptable work around. Unclear on when a new version which addresses the issue may be released.