### PR TITLE
openssh: new version 9.0p1

### DIFF
--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -23,6 +23,7 @@ class Openssh(AutotoolsPackage):
 
     tags = ['core-packages']
 
+    version('9.0p1', sha256='03974302161e9ecce32153cfa10012f1e65c8f3750f573a73ab1befd5972a28a')
     version('8.9p1', sha256='fd497654b7ab1686dac672fb83dfb4ba4096e8b5ffcdaccd262380ae58bec5e7')
     version('8.8p1', sha256='4590890ea9bb9ace4f71ae331785a3a5823232435161960ed5fc86588f331fe9')
     version('8.7p1', sha256='7ca34b8bb24ae9e50f33792b7091b3841d7e1b440ff57bc9fabddf01e2ed1e24')


### PR DESCRIPTION
This PR adds the latest version of `openssh`.