### PR TITLE
strace: new version 5.17

### DIFF
--- a/var/spack/repos/builtin/packages/strace/package.py
+++ b/var/spack/repos/builtin/packages/strace/package.py
@@ -17,6 +17,7 @@ class Strace(AutotoolsPackage):
 
     conflicts('platform=darwin', msg='strace runs only on Linux.')
 
+    version('5.17', sha256='5fb298dbd1331fd1e1bc94c5c32395860d376101b87c6cd3d1ba9f9aa15c161f')
     version('5.12', sha256='29171edf9d252f89c988a4c340dfdec662f458cb8c63d85431d64bab5911e7c4')
     version('5.11', sha256='ffe340b10c145a0f85734271e9cce56457d23f21a7ea5931ab32f8cf4e793879')
     version('5.10', sha256='fe3982ea4cd9aeb3b4ba35f6279f0b577a37175d3282be24b9a5537b56b8f01c')


### PR DESCRIPTION
This PR adds the latest version of `strace`.