### PR TITLE
flux-core: add v0.36.0-0.38.0, flux-sched: add v0.21.0-0.22.0

### DIFF
--- a/var/spack/repos/builtin/packages/flux-core/package.py
+++ b/var/spack/repos/builtin/packages/flux-core/package.py
@@ -20,6 +20,9 @@ class FluxCore(AutotoolsPackage):
 
     version('master', branch='master')
 
+    version('0.38.0', sha256='69d150c3d48b5985bca606e1a4de12282eb76233b6b730de1a9fff4136faf65f')
+    version('0.37.0', sha256='4779f739da573c02df32a834179cc0c157688f6e82bb4cd2049eb0aa59fffffc')
+    version('0.36.0', sha256='04def00d8679a30f51c030791b69a536176725b19dc13e7bfc0df58d0041e975')
     version('0.35.0', sha256='28094c77d0a0d34f8fd71c9b397ae25dd7a4b138aad83f02e75c5a182c76b32b')
     version('0.34.0', sha256='e045b0a4f38d1a08280c2acc7f6e03a06e3715282ff84d9a0d1037b86e0aae33')
     version('0.33.0', sha256='b6f07fb6c0fc36bf300852d71df527778c46517bf61e26c7f54c6978898df2f1')
@@ -49,6 +52,7 @@ class FluxCore(AutotoolsPackage):
     variant('docs', default=False, description='Build flux manpages')
     variant('cuda', default=False, description='Build dependencies with support for CUDA')
 
+    depends_on("libarchive", when="@0.38.0:")
     depends_on("ncurses@6.2", when="@0.32.0:")
     depends_on("libzmq@4.0.4:")
     depends_on("czmq@3.0.1:")
@@ -71,7 +75,6 @@ class FluxCore(AutotoolsPackage):
     depends_on("jansson")
     depends_on("jansson@2.10:", when="@0.21.0:")
     depends_on("pkgconfig")
-    depends_on("yaml-cpp")
     depends_on("lz4")
 
     depends_on("asciidoc", type='build', when="+docs")

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -19,6 +19,9 @@ class FluxSched(AutotoolsPackage):
     maintainers = ['grondo']
 
     version('master', branch='master')
+    version('0.22.0', sha256='33cab21b667eeccd5665c5f139293b7b3e17cd3847e5fb2633c0dbacb33c611f')
+    version('0.21.1', sha256='4dbe8a2e06a816535ef43f34cec960c1e4108932438cd6dbb1d0040423f4477d')
+    version('0.21.0', sha256='156fe5b078a7c0b2075a1f1925ec9303a608c846c93187272f52c23eea24e06d')
     version('0.20.0', sha256='1d2074e1458ba1e7a1d4c33341b9f09769559cd1b8c68edc32097e220c4240b8')
     version('0.19.0', sha256='8dffa8eaec95a81286f621639ef851c52dc4c562d365971233bbd91100c31ed2')
     version('0.18.0', sha256='a4d8a6444fdb7b857b26f47fdea57992b486c9522f4ff92d5a6f547d95b586ae')
@@ -61,6 +64,7 @@ class FluxSched(AutotoolsPackage):
     depends_on("flux-core@0.29.0:", when='@0.18.0', type=('build', 'run', 'link'))
     depends_on("flux-core@0.30.0:", when='@0.19.0', type=('build', 'run', 'link'))
     depends_on("flux-core@0.31.0:", when='@0.19.0', type=('build', 'run', 'link'))
+    depends_on("flux-core@0.38.0:", when='@0.21.0', type=('build', 'run', 'link'))
     depends_on("flux-core@master", when='@master', type=('build', 'run', 'link'))
 
     # Need autotools when building on master:


### PR DESCRIPTION
Add latest flux-core and flux-sched releases.

Also remove yaml-cpp dependency from flux-core, which hasn't been required since v0.11.0.