### PR TITLE
nvtop: rework package

### DIFF
--- a/var/spack/repos/builtin/packages/nvtop/package.py
+++ b/var/spack/repos/builtin/packages/nvtop/package.py
@@ -7,16 +7,26 @@ from spack import *
 
 
 class Nvtop(CMakePackage, CudaPackage):
-    """Nvtop stands for NVidia TOP, a (h)top like task monitor for NVIDIA GPUs.
-    It can handle multiple GPUs and print information about them
-    in a htop familiar way."""
+    """Nvtop stands for Neat Videocard TOP, a (h)top like task monitor
+    for AMD and NVIDIA GPUS. It can handle multiple GPUs and print
+    information about them in a htop familiar way"""
 
     homepage = "https://github.com/Syllo/nvtop"
-    url      = "https://github.com/Syllo/nvtop/archive/1.1.0.tar.gz"
+    url      = "https://github.com/Syllo/nvtop/archive/refs/tags/2.0.1.zip"
 
-    version('1.1.0', sha256='00470cde8fc48d5a5ed7c96402607e474414d94b562b21189bdde1dbe6b1d1f3')
+    maintainers = ['marcost2']
+
+    version('2.0.1', sha256='ef18ce85d632eb1c22d3a3653976b2c088260039702df39fd0181f7cd3ae277d')
+    version('2.0.0', sha256='1651f34274c334a682f280dcb2f28d9642d44c7b22afe8c431cab91345b50f31')
+    version('1.2.2', sha256='543cbfdae3241fab1ea022402734c12e69d5988583193adaab69fdfae6e14c84')
+    version('1.2.1', sha256='197992cdd0e2e151fce91a7ba56f717e4d85b317c396001e8dbd84dc2ba363cd')
+
+    variant('support', values=('nvidia', 'amd'), default='nvidia,amd', multi=True,
+            description='Which GPU vendors to build support for')
 
     depends_on('ncurses')
+    depends_on('libdrm', when='support=amd')
 
     def cmake_args(self):
-        return [self.define('NVML_RETRIEVE_HEADER_ONLINE', True)]
+        return [self.define('NVIDIA_SUPPORT', self.spec.satisfies('support=nvidia')),
+                self.define('AMDGPU_SUPPORT', self.spec.satisfies('support=amd'))]

--- a/var/spack/repos/builtin/packages/strace/package.py
+++ b/var/spack/repos/builtin/packages/strace/package.py
@@ -17,6 +17,7 @@ class Strace(AutotoolsPackage):
 
     conflicts('platform=darwin', msg='strace runs only on Linux.')
 
+    version('5.17', sha256='5fb298dbd1331fd1e1bc94c5c32395860d376101b87c6cd3d1ba9f9aa15c161f')
     version('5.12', sha256='29171edf9d252f89c988a4c340dfdec662f458cb8c63d85431d64bab5911e7c4')
     version('5.11', sha256='ffe340b10c145a0f85734271e9cce56457d23f21a7ea5931ab32f8cf4e793879')
     version('5.10', sha256='fe3982ea4cd9aeb3b4ba35f6279f0b577a37175d3282be24b9a5537b56b8f01c')


### PR DESCRIPTION
* Add new versions and remove version 1.1 (it depended on some NVML headers that
  were a pain, and newer versions didn't drop any devices)
* Add Nvidia and AMD variants with proper cmake configs and dependencies
* Add self as maintainer