### PR TITLE
WarpX 22.04+: Fix RZ Test

### DIFF
--- a/var/spack/repos/builtin/packages/warpx/package.py
+++ b/var/spack/repos/builtin/packages/warpx/package.py
@@ -192,6 +192,9 @@ class Warpx(CMakePackage):
         # test openPMD output if compiled in
         if '+openpmd' in spec:
             cli_args.append('diag1.format=openpmd')
+            # RZ: New openPMD thetaMode output
+            if dims == 'rz' and spec.satisfies('@22.04:'):
+                cli_args.append('diag1.fields_to_plot=Er Et Ez Br Bt Bz jr jt jz rho')
         return cli_args
 
     def check(self):


### PR DESCRIPTION
In WarpX 22.04, we introduced the openPMD `thetaMode` for fields in RZ geometry. That means we need to name the fields differently than the reconstructured Cartesian slice that we default to in plotfiles.

cc @RTSandberg