### PR TITLE
ucx: nvhpc hangs with -O2 and -O3 (miscompiles?)

### DIFF
--- a/var/spack/repos/builtin/packages/ucx/package.py
+++ b/var/spack/repos/builtin/packages/ucx/package.py
@@ -130,6 +130,15 @@ class Ucx(AutotoolsPackage, CudaPackage):
 
     conflicts('~shared', when='~static', msg='Please select at least one of +static or +shared')
 
+    # Force -O1 for %nvhpc. osu-micro-benchmarks with openmpi, ucx and
+    # infiniband hangs for larger message sizes with -O2 and -O3 using nvidia
+    # compilers. Also conflict with opt=0 to force at least minimal
+    # optimizations, the concretizer doesn't automatically favor opt=1 over
+    # opt=0.
+    conflicts('opt=3', when='%nvhpc')
+    conflicts('opt=2', when='%nvhpc')
+    conflicts('opt=0', when='%nvhpc')
+
     configure_abs_path = 'contrib/configure-release'
 
     @when('@1.9-dev')


### PR DESCRIPTION
When running osu-micro-benchmarks (for example osu_allgather) configured with openmpi + ucx + infiniband, all compiled with %nvhpc, the benchmarks consistently hang for larger message sizes (> 65536). Leaving everything the same except for swapping ucx%nvhpc with ucx%gcc fixes the problem. Also when changing the optimization flags in ucx%nvhpc to -O1 fixes the problem. Maybe nvhpc miscompiles something, or there is undefined behavior in ucx?
