### PR TITLE
introduce GroupedExceptionHandler and use it to simplify bootstrap error handling

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -1032,15 +1032,15 @@ class GroupedExceptionHandler(object):
         # type: (str, Exception, List[str]) -> None
         self.exceptions.append((context, exc, tb))
 
-    def grouped_message(self):
-        # type: () -> str
+    def grouped_message(self, with_tracebacks=True):
+        # type: (bool) -> str
         """Print out an error message coalescing all the forwarded errors."""
         each_exception_message = [
-            '{0} raised {1}: {2}\n{3}'.format(
+            '{0} raised {1}: {2}{3}'.format(
                 context,
                 exc.__class__.__name__,
                 exc,
-                ''.join(tb),
+                '\n{0}'.format(''.join(tb)) if with_tracebacks else '',
             )
             for context, exc, tb in self.exceptions
         ]

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -11,7 +11,9 @@ import inspect
 import os
 import re
 import sys
+import traceback
 from datetime import datetime, timedelta
+from typing import List, Tuple
 
 import six
 from six import string_types
@@ -1009,3 +1011,64 @@ class TypedMutableSequence(MutableSequence):
 
     def __str__(self):
         return str(self.data)
+
+
+class GroupedExceptionHandler(object):
+    """A generic mechanism to coalesce multiple exceptions and preserve tracebacks."""
+
+    def __init__(self):
+        self.exceptions = []    # type: List[Tuple[str, Exception, List[str]]]
+
+    def __bool__(self):
+        """Whether any exceptions were handled."""
+        return bool(self.exceptions)
+
+    def forward(self, context):
+        # type: (str) -> GroupedExceptionForwarder
+        """Return a contextmanager which extracts tracebacks and prefixes a message."""
+        return GroupedExceptionForwarder(context, self)
+
+    def _receive_forwarded(self, context, exc, tb):
+        # type: (str, Exception, List[str]) -> None
+        self.exceptions.append((context, exc, tb))
+
+    def grouped_message(self):
+        # type: () -> str
+        """Print out an error message coalescing all the forwarded errors."""
+        each_exception_message = [
+            '{0} raised {1}: {2}\n{3}'.format(
+                context,
+                exc.__class__.__name__,
+                exc,
+                ''.join(tb),
+            )
+            for context, exc, tb in self.exceptions
+        ]
+        return 'due to the following failures:\n{0}'.format(
+            '\n'.join(each_exception_message)
+        )
+
+
+class GroupedExceptionForwarder(object):
+    """A contextmanager to capture exceptions and forward them to a
+    GroupedExceptionHandler."""
+
+    def __init__(self, context, handler):
+        # type: (str, GroupedExceptionHandler) -> None
+        self._context = context
+        self._handler = handler
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_value is not None:
+            self._handler._receive_forwarded(
+                self._context,
+                exc_value,
+                traceback.format_tb(tb),
+            )
+
+        # Suppress any exception from being re-raised:
+        # https://docs.python.org/3/reference/datamodel.html#object.__exit__.
+        return True

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -502,11 +502,11 @@ def ensure_module_importable_or_raise(module, abstract_spec=None):
     msg = 'cannot bootstrap the "{0}" Python module '.format(module)
     if abstract_spec:
         msg += 'from spec "{0}" '.format(abstract_spec)
-    if tty.is_stacktrace():
+    if tty.is_debug():
         msg += h.grouped_message(with_tracebacks=True)
     else:
         msg += h.grouped_message(with_tracebacks=False)
-        msg += '\nPlease run `spack --stacktrace spec zlib` to print stacktraces'
+        msg += '\nRun `spack --debug ...` for more detailed errors'
     raise ImportError(msg)
 
 
@@ -557,11 +557,11 @@ def ensure_executables_in_path_or_raise(executables, abstract_spec):
     msg = 'cannot bootstrap any of the {0} executables '.format(executables_str)
     if abstract_spec:
         msg += 'from spec "{0}" '.format(abstract_spec)
-    if tty.is_stacktrace():
+    if tty.is_debug():
         msg += h.grouped_message(with_tracebacks=True)
     else:
         msg += h.grouped_message(with_tracebacks=False)
-        msg += '\nPlease run `spack --stacktrace spec zlib` to print stacktraces'
+        msg += '\nRun `spack --debug ...` for more detailed errors'
     raise RuntimeError(msg)
 
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -21,6 +21,7 @@ import archspec.cpu
 
 import llnl.util.filesystem as fs
 import llnl.util.tty as tty
+from llnl.util.lang import GroupedExceptionHandler
 
 import spack.binary_distribution
 import spack.config
@@ -417,11 +418,10 @@ def _make_bootstrapper(conf):
     return _bootstrap_methods[btype](conf)
 
 
-def _source_is_trusted(conf):
+def _validate_source_is_trusted(conf):
     trusted, name = spack.config.get('bootstrap:trusted'), conf['name']
     if name not in trusted:
-        return False
-    return trusted[name]
+        raise ValueError('source is not trusted')
 
 
 def spec_for_current_python():
@@ -488,39 +488,22 @@ def ensure_module_importable_or_raise(module, abstract_spec=None):
     abstract_spec = abstract_spec or module
     source_configs = spack.config.get('bootstrap:sources', [])
 
-    excs_for_tb = []
-    errors = {}
+    h = GroupedExceptionHandler()
 
     for current_config in source_configs:
-        if not _source_is_trusted(current_config):
-            msg = ('[BOOTSTRAP MODULE {0}] Skipping source "{1}" since it is '
-                   'not trusted').format(module, current_config['name'])
-            tty.debug(msg)
-            continue
+        with h.forward(current_config['name']):
+            _validate_source_is_trusted(current_config)
 
-        b = _make_bootstrapper(current_config)
-        try:
+            b = _make_bootstrapper(current_config)
             if b.try_import(module, abstract_spec):
                 return
-        except Exception as e:
-            excs_for_tb.append(e)
-            msg = '[BOOTSTRAP MODULE {0}] Unexpected error "{1}"'
-            tty.debug(msg.format(module, str(e)))
-            errors[current_config['name']] = e
 
-    # We couldn't import in any way, so raise an import error
-    msg = 'cannot bootstrap the "{0}" Python module'.format(module)
+    assert h, 'expected at least one exception to have been raised at this point: while bootstrapping {0}'.format(module)  # noqa: E501
+    msg = 'cannot bootstrap the "{0}" Python module '.format(module)
     if abstract_spec:
-        msg += ' from spec "{0}"'.format(abstract_spec)
-    msg += ' due to the following failures:\n'
-    for method, err in errors.items():
-        msg += "    '{0}' raised {1}: {2}\n".format(
-            method, err.__class__.__name__, str(err))
-    msg += '    Please run `spack -d spec zlib` for more verbose error messages'
-
-    # Get exception traceback for the *last* exception of those that failed.
-    selected_exception_for_traceback = excs_for_tb[-1]
-    raise six.raise_from(ImportError(msg), selected_exception_for_traceback)
+        msg += 'from spec "{0}" '.format(abstract_spec)
+    msg += h.grouped_message()
+    raise ImportError(msg)
 
 
 def ensure_executables_in_path_or_raise(executables, abstract_spec):
@@ -543,18 +526,14 @@ def ensure_executables_in_path_or_raise(executables, abstract_spec):
 
     executables_str = ', '.join(executables)
     source_configs = spack.config.get('bootstrap:sources', [])
-    excs_for_tb = []
-    errors = {}
+
+    h = GroupedExceptionHandler()
 
     for current_config in source_configs:
-        if not _source_is_trusted(current_config):
-            msg = ('[BOOTSTRAP EXECUTABLES {0}] Skipping source "{1}" since it is '
-                   'not trusted').format(executables_str, current_config['name'])
-            tty.debug(msg)
-            continue
+        with h.forward(current_config['name']):
+            _validate_source_is_trusted(current_config)
 
-        b = _make_bootstrapper(current_config)
-        try:
+            b = _make_bootstrapper(current_config)
             if b.try_search_path(executables, abstract_spec):
                 # Additional environment variables needed
                 concrete_spec, cmd = b.last_search['spec'], b.last_search['command']
@@ -569,25 +548,13 @@ def ensure_executables_in_path_or_raise(executables, abstract_spec):
                     )
                 cmd.add_default_envmod(env_mods)
                 return cmd
-        except Exception as e:
-            msg = '[BOOTSTRAP EXECUTABLES {0}] Unexpected error "{1}"'
-            excs_for_tb.append(e)
-            tty.debug(msg.format(executables_str, str(e)))
-            errors[current_config['name']] = e
 
-    # We couldn't import in any way, so raise an import error
-    msg = 'cannot bootstrap any of the {0} executables'.format(executables_str)
+    assert h, 'expected at least one exception to have been raised at this point: while bootstrapping {0}'.format(executables_str)  # noqa: E501
+    msg = 'cannot bootstrap any of the {0} executables '.format(executables_str)
     if abstract_spec:
-        msg += ' from spec "{0}"'.format(abstract_spec)
-    msg += ' due to the following failures:\n'
-    for method, err in errors.items():
-        msg += "    '{0}' raised {1}: {2}\n".format(
-            method, err.__class__.__name__, str(err))
-    msg += '    Please run `spack -d spec zlib` for more verbose error messages'
-
-    # Get exception traceback for the *last* exception of those that failed.
-    selected_exception_for_traceback = excs_for_tb[-1]
-    raise six.raise_from(RuntimeError(msg), selected_exception_for_traceback)
+        msg += 'from spec "{0}" '.format(abstract_spec)
+    msg += h.grouped_message()
+    raise RuntimeError(msg)
 
 
 def _python_import(module):

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -502,7 +502,11 @@ def ensure_module_importable_or_raise(module, abstract_spec=None):
     msg = 'cannot bootstrap the "{0}" Python module '.format(module)
     if abstract_spec:
         msg += 'from spec "{0}" '.format(abstract_spec)
-    msg += h.grouped_message()
+    if tty.is_stacktrace():
+        msg += h.grouped_message(with_tracebacks=True)
+    else:
+        msg += h.grouped_message(with_tracebacks=False)
+        msg += '\nPlease run `spack --stacktrace spec zlib` to print stacktraces'
     raise ImportError(msg)
 
 
@@ -553,7 +557,11 @@ def ensure_executables_in_path_or_raise(executables, abstract_spec):
     msg = 'cannot bootstrap any of the {0} executables '.format(executables_str)
     if abstract_spec:
         msg += 'from spec "{0}" '.format(abstract_spec)
-    msg += h.grouped_message()
+    if tty.is_stacktrace():
+        msg += h.grouped_message(with_tracebacks=True)
+    else:
+        msg += h.grouped_message(with_tracebacks=False)
+        msg += '\nPlease run `spack --stacktrace spec zlib` to print stacktraces'
     raise RuntimeError(msg)
 
 

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -66,18 +66,16 @@ def test_raising_exception_module_importable():
     with pytest.raises(
         ImportError,
         match='cannot bootstrap the "asdf" Python module',
-    ) as cm:
+    ):
         spack.bootstrap.ensure_module_importable_or_raise("asdf")
-    assert len(cm.traceback) == 3
 
 
 def test_raising_exception_executables_in_path():
     with pytest.raises(
         RuntimeError,
         match="cannot bootstrap any of the asdf, fdsa executables",
-    ) as cm:
+    ):
         spack.bootstrap.ensure_executables_in_path_or_raise(["asdf", "fdsa"], "python")
-    assert len(cm.traceback) == 3
 
 
 @pytest.mark.regression('25603')

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -62,6 +62,24 @@ def test_raising_exception_if_bootstrap_disabled(mutable_config):
         spack.bootstrap.store_path()
 
 
+def test_raising_exception_module_importable():
+    with pytest.raises(
+        ImportError,
+        match='cannot bootstrap the "asdf" Python module',
+    ) as cm:
+        spack.bootstrap.ensure_module_importable_or_raise("asdf")
+    assert len(cm.traceback) == 3
+
+
+def test_raising_exception_executables_in_path():
+    with pytest.raises(
+        RuntimeError,
+        match="cannot bootstrap any of the asdf, fdsa executables",
+    ) as cm:
+        spack.bootstrap.ensure_executables_in_path_or_raise(["asdf", "fdsa"], "python")
+    assert len(cm.traceback) == 3
+
+
 @pytest.mark.regression('25603')
 def test_bootstrap_deactivates_environments(active_mock_environment):
     assert spack.environment.active_environment() == active_mock_environment

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -285,7 +285,12 @@ def test_grouped_exception():
     with h.forward('top-level'):
         raise TypeError('ok')
 
-    assert h.grouped_message() == dedent("""\
+    assert h.grouped_message(with_tracebacks=False) == dedent("""\
+    due to the following failures:
+    inner method raised ValueError: wow!
+    top-level raised TypeError: ok""")
+
+    assert h.grouped_message(with_tracebacks=True) == dedent("""\
     due to the following failures:
     inner method raised ValueError: wow!
       File "/home/cosmicexplorer/tools/s1/lib/spack/spack/test/llnl/util/lang.py", \

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -293,15 +293,15 @@ def test_grouped_exception():
     assert h.grouped_message(with_tracebacks=True) == dedent("""\
     due to the following failures:
     inner method raised ValueError: wow!
-      File "/home/cosmicexplorer/tools/s1/lib/spack/spack/test/llnl/util/lang.py", \
+      File "{0}", \
 line 283, in test_grouped_exception
         inner()
-      File "/home/cosmicexplorer/tools/s1/lib/spack/spack/test/llnl/util/lang.py", \
+      File "{0}", \
 line 280, in inner
         raise ValueError('wow!')
 
     top-level raised TypeError: ok
-      File "/home/cosmicexplorer/tools/s1/lib/spack/spack/test/llnl/util/lang.py", \
+      File "{0}", \
 line 286, in test_grouped_exception
         raise TypeError('ok')
-    """)
+    """).format(__file__)


### PR DESCRIPTION
### Problem

We don't provide exception tracebacks in a couple places where we re-raise exceptions from methods called by our bootstrapping code. This recently made an error in #22235 harder to debug until @haampie helped.

### Solution

In both of these places, we attempt to perform one of many bootstrap strategies, and if all of them fail, we report the failures. In order to do this while preserving the tracebacks, we:
- Introduce `llnl.util.lang.GroupedExceptionHandler`.
- Use `GroupedExceptionHandler` as a contextmanager in our executable and python import bootstrap methods.
- Convert `_source_is_trusted()` into `_validate_source_is_trusted()`, and make it raise an exception instead of printing a message with `tty.debug()`.
- Produce an exception at the end with `GroupedExceptionHandler.grouped_message()`.

### Result
We re-raise an exception in a place we previously didn't, and we now have greater traceback context for that exception, and this should produce much more output than before, which just showed the exception message when failing to bootstrap isort. We also avoid having to tell the user to run `spack -d spec zlib` at the bottom, since we always print out all the relevant context without debug being enabled.