### PR TITLE
ea-utils: new version, cleanup, and newer gcc compat

### DIFF
--- a/var/spack/repos/builtin/packages/ea-utils/package.py
+++ b/var/spack/repos/builtin/packages/ea-utils/package.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack import *
 
 
@@ -13,20 +15,39 @@ class EaUtils(MakefilePackage):
 
     homepage = "https://expressionanalysis.github.io/ea-utils/"
     url = "https://github.com/ExpressionAnalysis/ea-utils/archive/1.04.807.tar.gz"
+    git = "https://github.com/ExpressionAnalysis/ea-utils.git"
+    maintainers = ['snehring']
 
+    version('2021-10-20', commit='10c21926a4dce4289d5052acfd73b8e744d4fede')
     version('1.04.807', sha256='aa09d25e6aa7ae71d2ce4198a98e58d563f151f8ff248e4602fa437f12b8d05f')
 
-    depends_on('subversion')
+    depends_on('sparsehash')
     depends_on('zlib')
     depends_on('gsl')
     depends_on('bamtools')
-    # perl module required for make check, which is included in the default
-    # target
-    depends_on('perl', type='build')
+    depends_on('perl', type=['build', 'run'])
 
     build_directory = 'clipper'
 
     def edit(self, spec, prefix):
-        with working_dir('clipper'):
-            makefile = FileFilter('Makefile')
-            makefile.filter('/usr', prefix)
+        with working_dir(self.build_directory):
+            filter_file('/usr', prefix, 'Makefile')
+            # remove tests from all rule
+            filter_file(r'^all:.*$', 'all: $(BIN)', 'Makefile')
+            # remove the vendored sparsehash
+            filter_file(' sparsehash', '', 'Makefile')
+            # replace system perl references
+            for f in next(os.walk(os.getcwd()))[2]:
+                filter_file('/usr/bin/perl', spec['perl'].prefix.bin.perl, f)
+            # fix up test script require path
+            tests = ['join.t', 'mcf.t', 'multx.t']
+            rep = 'require "{0}";'.format(os.path.join(os.getcwd(),
+                                          't', 'test-prep.pl'))
+            for f in tests:
+                filter_file(r'^require.*$', rep, os.path.join(os.getcwd(),
+                            't', f))
+
+    def flag_handler(self, name, flags):
+        if name.lower() == 'cxxflags':
+            flags.append(self.compiler.cxx11_flag)
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/ea-utils/package.py
+++ b/var/spack/repos/builtin/packages/ea-utils/package.py
@@ -19,7 +19,8 @@ class EaUtils(MakefilePackage):
     maintainers = ['snehring']
 
     version('2021-10-20', commit='10c21926a4dce4289d5052acfd73b8e744d4fede')
-    version('1.04.807', sha256='aa09d25e6aa7ae71d2ce4198a98e58d563f151f8ff248e4602fa437f12b8d05f')
+    version('1.04.807', sha256='aa09d25e6aa7ae71d2ce4198a98e58d563f151f8ff248e4602fa437f12b8d05f',
+            deprecated=True)
 
     depends_on('sparsehash')
     depends_on('zlib')


### PR DESCRIPTION
They've not tagged a release in a while, but there have been commits that look like fixes, so added the most recent commit to master.

The subversion requirement was really only required for the vendored sparsehash, which I've removed in favor of using the spack provided one.

A handful of the installed executables are actually perl scripts, so that's a run dep, and I cleaned up any references to /usr/bin/perl with the perl path (there are a few).

This also ran tests as part of the all target, I removed that. They should still run with the check target with changes I made.