### PR TITLE
Add fix for binutils 2.38 +gas makeinfo issue

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -67,6 +67,10 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     depends_on('m4', type='build', when='@:2.29 +gold')
     depends_on('bison', type='build', when='@:2.29 +gold')
 
+    # 2.38 with +gas needs makeinfo due to a bug, see:
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=28909
+    depends_on('texinfo', type='build', when='@2.38 +gas')
+    
     # 2.34 needs makeinfo due to a bug, see:
     # https://sourceware.org/bugzilla/show_bug.cgi?id=25491
     depends_on('texinfo', type='build', when='@2.34')

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -70,7 +70,6 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
     # 2.38 with +gas needs makeinfo due to a bug, see:
     # https://sourceware.org/bugzilla/show_bug.cgi?id=28909
     depends_on('texinfo', type='build', when='@2.38 +gas')
-    
     # 2.34 needs makeinfo due to a bug, see:
     # https://sourceware.org/bugzilla/show_bug.cgi?id=25491
     depends_on('texinfo', type='build', when='@2.34')


### PR DESCRIPTION
With `spack install binutils@2.38%gcc +gas`, the build will fail with a warning:

```
  >> 3579    WARNING: 'makeinfo' is missing on your system.
     3580             You should only need it if you modified a '.texi' file, or
     3581             any other file indirectly affecting the aspect of the manual.
     3582             You might want to install the Texinfo package:
     3583             <http://www.gnu.org/software/texinfo/>
     3584             The spurious makeinfo call might also be the consequence of
     3585             using a buggy 'make' (AIX, DU, IRIX), in which case you might
```

Adding the following build dependency fixes it:

```
depends_on('texinfo', type='build', when='@2.38 +gas')
```

See bug report here: https://sourceware.org/bugzilla/show_bug.cgi?id=28909

It seems a missing timestamp file is the cause. Maybe a patch could work instead of adding this build dependency, but I'm not sure how to create a patch for this.