### PR TITLE
oracle-instant-client: workaround for broken symlinks

### DIFF
--- a/var/spack/repos/builtin/packages/oracle-instant-client/package.py
+++ b/var/spack/repos/builtin/packages/oracle-instant-client/package.py
@@ -5,10 +5,9 @@
 
 import glob
 
+import spack.relocate as relocate
 from spack import *
 
-import spack.relocate as relocate
-import llnl.util.tty as tty
 
 def oracleclient_releases():
     releases = [
@@ -110,7 +109,8 @@ class OracleInstantClient(Package):
         install_tree(join_path('odbc', 'help'), prefix.doc)
         install_tree(join_path('sdk', 'sdk', 'include'), prefix.include)
 
-        # Fix broken symlinks: `zipfile` does not correctly handle symlinks when unpacking
+        # Fix broken symlinks: `zipfile` does not correctly
+        # handle symlinks when unpacking
         for fn in glob.glob(join_path(prefix, 'lib', '*.so*')):
             m_type, m_subtype = relocate.mime_type(fn)
             if m_type == 'text':


### PR DESCRIPTION
@haralmha reported that some packages can't link with `oracle-instant-client`:
```
     2035    /usr/bin/ld:/build/hahansen/Spack/packages/oracle-instant-client/21.1.0.0.0/x86_64-centos7-gcc11.2.0-opt/7luec/lib/libclntsh.so: file format not recognized; treating as linker script
  >> 2036    /usr/bin/ld:/build/hahansen/Spack/packages/oracle-instant-client/21.1.0.0.0/x86_64-centos7-gcc11.2.0-opt/7luec/lib/libclntsh.so:1: syntax error
  >> 2037    collect2: error: ld returned 1 exit status
```

It turns out that python's `ZipFile` doesn't handle symlinks, extracts them as plain files. There are at least two ([[1]](https://bugs.python.org/issue18595), [[2]](https://bugs.python.org/issue27318)) open issues asking for symlink support. 

This PR adds a crude hack to recreate these symliks. An alternative solution is to use `unzip` utility (either globally in Spack or just for this package).