### PR TITLE
[acts] Add version 18

### DIFF
--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -129,7 +129,7 @@ class Acts(CMakePackage, CudaPackage):
     variant('autodiff', default=False, description='Build the auto-differentiation plugin', when='@1.2:')
     variant('dd4hep', default=False, description='Build the DD4hep plugin', when='+tgeo')
     variant('digitization', default=False, description='Build the geometric digitization plugin', when='@:16')
-    # FIXME: Cannot build Exa.TrkX plugin & examples yet as Spack doesn't have RAPIDS cuGraph
+    # FIXME: Can't build Exa.TrkX plugin+examples yet, missing cuGraph dep
     variant('fatras', default=False, description='Build the FAst TRAcking Simulation package', when='@0.16:')
     variant('fatras_geant4', default=False, description='Build Geant4 Fatras package')
     variant('identification', default=False, description='Build the Identification plugin')


### PR DESCRIPTION
...and along the way...

- Keep long lists in alphabetical order for easier reading
- Add a placeholder for Exa.TrkX plugin since we're missing a dep on the Spack side
- Add support for the ONNX plugin since Spack now has an ONNX runtime package
- Use spack's pybind11 package now that we're given the option to do so

Pending test build on my side, then should be good to go