### PR TITLE
New package: py-x21

### DIFF
--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -7,15 +7,18 @@ from spack import *
 
 
 class PyX21(PythonPackage):
+    """FIXME: I think this is for unpacking this authors
+    obfuscaded python libraries."""
 
+    homepage = "https://pypi.org/project/x21/"
     list_url = "https://pypi.org/simple/x21/"
 
     def url_for_version(self, version):
         url = "https://pypi.io/packages/cp{1}/x/x21/x21-{0}-cp{1}-cp{1}-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
         return url.format(version, self.spec['python'].version.up_to(2).joined)
 
-    # version('0.2.6', sha256='7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d', expand=False)
-    # version('0.2.4', sha256='83a7f3bb904a2564ff24da3d8b24bc3871fadc0db53e88aa1ee0a63a52af3c38', expand=False)
+    # NOTE: Due to the this package having different packages for each
+    # version of python, checksums have not been provided. 
     version('0.2.6', expand=False)
 
     depends_on('python@3.7:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -22,7 +22,5 @@ class PyX21(PythonPackage):
     depends_on('py-pynacl', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-tomli', type=('build', 'run'))
-# Requires-Dist: PyNaCl
-# Requires-Dist: setuptools
-# Requires-Dist: tomli
-# Requires-Dist: tomli-w
+    depends_on('py-tomli-w', type=('build', 'run'))
+    depends_on('py-pynacl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -13,9 +13,9 @@ class PyX21(PythonPackage):
     def url_for_version(self, version):
         url = "https://pypi.io/packages/cp{1}/x/x21/x21-{0}-cp{1}-cp{1}-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
         return url.format(version, self.spec['python'].version.up_to(2).joined)
- 
-    #version('0.2.6', sha256='7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d', expand=False)
-    #version('0.2.4', sha256='83a7f3bb904a2564ff24da3d8b24bc3871fadc0db53e88aa1ee0a63a52af3c38', expand=False)
+
+    # version('0.2.6', sha256='7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d', expand=False)
+    # version('0.2.4', sha256='83a7f3bb904a2564ff24da3d8b24bc3871fadc0db53e88aa1ee0a63a52af3c38', expand=False)
     version('0.2.6', expand=False)
 
     depends_on('python@3.7:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import sys
+
+from spack import *
 
 
 class PyX21(PythonPackage):

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -14,11 +14,20 @@ class PyX21(PythonPackage):
     list_url = "https://pypi.org/simple/x21/"
 
     def url_for_version(self, version):
-        url = "https://pypi.io/packages/cp{1}/x/x21/x21-{0}-cp{1}-cp{1}-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-        return url.format(version, self.spec['python'].version.up_to(2).joined)
+        url = "https://pypi.io/packages/cp{1}/x/x21/x21-{0}-cp{1}-cp{1}{2}-{3}.whl"
+
+        platform_string = {
+            'linux': "manylinux_2_17_x86_64.manylinux2014_x86_64",
+            'darwin': "macosx_10_9_x86_64"
+        }
+
+        return url.format(version,
+                          self.spec['python'].version.up_to(2).joined,
+                          'm' if self.spec.satisfies("^python@3.7.0:3.7") else '',
+                          platform_string[self.spec.platform])
 
     # NOTE: Due to the this package having different packages for each
-    # version of python, checksums have not been provided. 
+    # version of python and platform, checksums have not been provided.
     version('0.2.6', expand=False)
 
     depends_on('python@3.7:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyX21(PythonPackage):
+
+    list_url = "https://pypi.org/simple/x21/"
+
+    def url_for_version(self, version):
+        url = "https://pypi.io/packages/cp{1}/x/x21/x21-{0}-cp{1}-cp{1}-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        return url.format(version, self.spec['python'].version.up_to(2).joined)
+        
+    #version('0.2.6', sha256='7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d', expand=False)
+    #version('0.2.4', sha256='83a7f3bb904a2564ff24da3d8b24bc3871fadc0db53e88aa1ee0a63a52af3c38', expand=False)
+    version('0.2.6', expand=False)
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-pynacl', type=('build', 'run'))
+    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('py-tomli', type=('build', 'run'))
+# Requires-Dist: PyNaCl
+# Requires-Dist: setuptools
+# Requires-Dist: tomli
+# Requires-Dist: tomli-w

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -27,10 +27,21 @@ class PyX21(PythonPackage):
                           platform_string[self.spec.platform])
 
     # NOTE: Due to the this package having different packages for each
-    # version of python and platform, checksums have not been provided.
-    version('0.2.6', expand=False)
+    # version of python and platform type, checksums have been proveded
+    # here. Editing the version line below will likely be required to
+    # build on your system.
+    checksums = {
+        '0.2.6': {
+            'linux': {
+                '3.7': '8b35248d0b049dd09985d1a45c6fa36dd39db2c9d805a96028ec3bf9dc80e0dd',
+                '3.8': '64275052bcda784395bc613f750b8b5a6b1ddbfa4e7a590cb8e209543f0ca0c4',
+                '3.9': 'e20b29650fcbf0be116ac93511033bf10debc76261b7350e018ff91b92ff950d',
+                '3.10': '7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d'},
+            'darwin': {}}}
 
-    depends_on('python@3.7:', type=('build', 'run'))
+    version('0.2.6', sha256=checksums['0.2.6']['linux']['3.8'], expand=False)
+
+    depends_on('python@3.7:3.10', type=('build', 'run'))
     depends_on('py-pynacl', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-tomli', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -46,4 +46,3 @@ class PyX21(PythonPackage):
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-tomli', type=('build', 'run'))
     depends_on('py-tomli-w', type=('build', 'run'))
-    depends_on('py-pynacl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -13,7 +13,7 @@ class PyX21(PythonPackage):
     def url_for_version(self, version):
         url = "https://pypi.io/packages/cp{1}/x/x21/x21-{0}-cp{1}-cp{1}-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
         return url.format(version, self.spec['python'].version.up_to(2).joined)
-        
+ 
     #version('0.2.6', sha256='7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d', expand=False)
     #version('0.2.4', sha256='83a7f3bb904a2564ff24da3d8b24bc3871fadc0db53e88aa1ee0a63a52af3c38', expand=False)
     version('0.2.6', expand=False)

--- a/var/spack/repos/builtin/packages/py-x21/package.py
+++ b/var/spack/repos/builtin/packages/py-x21/package.py
@@ -4,11 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+import sys
 
 
 class PyX21(PythonPackage):
-    """FIXME: I think this is for unpacking this authors
-    obfuscaded python libraries."""
+    """Used for unpacking this author's obfuscated libraries"""
 
     homepage = "https://pypi.org/project/x21/"
     list_url = "https://pypi.org/simple/x21/"
@@ -16,32 +16,49 @@ class PyX21(PythonPackage):
     def url_for_version(self, version):
         url = "https://pypi.io/packages/cp{1}/x/x21/x21-{0}-cp{1}-cp{1}{2}-{3}.whl"
 
-        platform_string = {
-            'linux': "manylinux_2_17_x86_64.manylinux2014_x86_64",
-            'darwin': "macosx_10_9_x86_64"
-        }
+        if sys.platform == 'darwin':
+            platform_string = "macosx_10_9_x86_64"
+        elif sys.platform.startswith('linux'):
+            platform_string = "manylinux_2_17_x86_64.manylinux2014_x86_64"
 
-        return url.format(version,
-                          self.spec['python'].version.up_to(2).joined,
-                          'm' if self.spec.satisfies("^python@3.7.0:3.7") else '',
-                          platform_string[self.spec.platform])
+        py_ver = Version(version.string.split('y')[1])
 
-    # NOTE: Due to the this package having different packages for each
-    # version of python and platform type, checksums have been proveded
-    # here. Editing the version line below will likely be required to
-    # build on your system.
-    checksums = {
-        '0.2.6': {
-            'linux': {
-                '3.7': '8b35248d0b049dd09985d1a45c6fa36dd39db2c9d805a96028ec3bf9dc80e0dd',
-                '3.8': '64275052bcda784395bc613f750b8b5a6b1ddbfa4e7a590cb8e209543f0ca0c4',
-                '3.9': 'e20b29650fcbf0be116ac93511033bf10debc76261b7350e018ff91b92ff950d',
-                '3.10': '7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d'},
-            'darwin': {}}}
+        return url.format(version.string.split('-')[0],
+                          py_ver.joined,
+                          'm' if py_ver == Version('3.7') else '',
+                          platform_string)
 
-    version('0.2.6', sha256=checksums['0.2.6']['linux']['3.8'], expand=False)
+    if sys.platform == 'darwin':
+        version('0.2.6-py3.7',
+                sha256='7367b7c93fba520e70cc29731baec5b95e7be32d7615dad4f1f034cd21c194bd',
+                expand=False)
+        version('0.2.6-py3.8',
+                sha256='bbbfdb6b56562ecc81f0dc39e009713157011fbb50d47353eb25f633acf77204',
+                expand=False)
+        version('0.2.6-py3.9',
+                sha256='d7b4f06a71ac27d05ae774752b3ca396134916427f371b5995b07f0f43205043',
+                expand=False)
+        version('0.2.6-py3.10',
+                sha256='2cbda690757f1fc80edfe48fcb13f168068f1784f0cb8c300a0d8051714d0452',
+                expand=False)
+    elif sys.platform.startswith('linux'):
+        version('0.2.6-py3.7',
+                sha256='8b35248d0b049dd09985d1a45c6fa36dd39db2c9d805a96028ec3bf9dc80e0dd',
+                expand=False)
+        version('0.2.6-py3.8',
+                sha256='64275052bcda784395bc613f750b8b5a6b1ddbfa4e7a590cb8e209543f0ca0c4',
+                expand=False)
+        version('0.2.6-py3.9',
+                sha256='e20b29650fcbf0be116ac93511033bf10debc76261b7350e018ff91b92ff950d',
+                expand=False)
+        version('0.2.6-py3.10',
+                sha256='7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d',
+                expand=False)
 
-    depends_on('python@3.7:3.10', type=('build', 'run'))
+    depends_on('python@3.7.0:3.7',   type=('build', 'run'), when='@0.2.6-py3.7')
+    depends_on('python@3.8.0:3.8',   type=('build', 'run'), when='@0.2.6-py3.8')
+    depends_on('python@3.9.0:3.9',   type=('build', 'run'), when='@0.2.6-py3.9')
+    depends_on('python@3.10.0:3.10', type=('build', 'run'), when='@0.2.6-py3.10')
     depends_on('py-pynacl', type=('build', 'run'))
     depends_on('py-setuptools', type=('build', 'run'))
     depends_on('py-tomli', type=('build', 'run'))


### PR DESCRIPTION
@adamjstewart I know there is going to be a couple points here where you're going to want me to do some fixes. I'm submitting this early as a draft to ask for some guidance.

### 1. Description

Currently: 

```python
    """FIXME: I think this is for unpacking this authors
    obfuscaded python libraries."""
```

The package itself doesn't provide a description, so I'm basing this on how this gets called in some dependent packages (e.g. [colorio](https://pypi.org/project/colorio/)). Is this speculation good enough? And do you concur with my interpretation of it's use? (Regardless, it's going to be word smithed a bit to remove the "FIXME:" and "I think")

### 2. The checksum/URL situation

Each version has multiple different wheels depending on the platform being used and version of python. Currently I'm doing:

```python
    # NOTE: Due to the this package having different packages for each
    # version of python and platform type, checksums have been proveded
    # here. Editing the version line below will likely be required to
    # build on your system.
    checksums = {
        '0.2.6': {
            'linux': {
                '3.7': '8b35248d0b049dd09985d1a45c6fa36dd39db2c9d805a96028ec3bf9dc80e0dd',
                '3.8': '64275052bcda784395bc613f750b8b5a6b1ddbfa4e7a590cb8e209543f0ca0c4',
                '3.9': 'e20b29650fcbf0be116ac93511033bf10debc76261b7350e018ff91b92ff950d',
                '3.10': '7c5c58ff6dc81caac6815578f78cf545e719beb0bf4017f77120d38025d2bc7d'},
            'darwin': {}}}

    version('0.2.6', sha256=checksums['0.2.6']['linux']['3.8'], expand=False)
```

Resolving this issue by adding something along the lines of the following, would make the most sense to me; but I don't think it's currently possible. (Correct me if I'm wrong.)

```python
    def sha256_for_version(self, version):
        return checksums[version][self.spec.platform][self.spec['python'].version.up_to(2)]
```

How do you recommend dealing with this issue?