### PR TITLE
old concretizer: update deprecation warning

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2655,11 +2655,11 @@ class Spec(object):
         import spack.concretize
 
         # Add a warning message to inform users that the original concretizer
-        # will be removed in v0.18.0
+        # will be removed
         if deprecation_warning:
             msg = ('the original concretizer is currently being used.\n\tUpgrade to '
                    '"clingo" at your earliest convenience. The original concretizer '
-                   'will be removed from Spack starting at v0.18.0')
+                   'will be removed from Spack in a future version.')
             warnings.warn(msg)
 
         if not self.name:


### PR DESCRIPTION
The old concretizer is currently too useful to remove. People use it as the workaround for at least two things:

1. Bad error messages from the clingo concretizer
2. Struggles with bootstrapping clingo on air-gapped or very old systems

we have ongoing work that *may* land in v0.18.0 to fix both of those issues, but even if those are both successful there will not be time for everyone to migrate before the release.

Once both issues are resolved, we will choose a specific version in which to remove the deprecated concretizer.