### PR TITLE
GDAL: don't add system paths to env vars

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -6,6 +6,8 @@
 import os
 import sys
 
+from spack.util.environment import filter_system_paths
+
 
 class Gdal(AutotoolsPackage):
     """GDAL (Geospatial Data Abstraction Library) is a translator library for
@@ -223,7 +225,7 @@ class Gdal(AutotoolsPackage):
         libs = []
         for dep in self.spec.dependencies(deptype='link'):
             query = self.spec[dep.name]
-            libs.extend(query.libs.directories)
+            libs.extend(filter_system_paths(query.libs.directories))
         if sys.platform == 'darwin':
             env.prepend_path('DYLD_FALLBACK_LIBRARY_PATH', ':'.join(libs))
         else:


### PR DESCRIPTION
Issue reported via email:

> I am having an issue with the gdal spack packaging. It is generating module files that put /usr/lib64 near the front of LD_LIBRARY_PATH, which hides any library that exists elsewhere but also has a version in /usr/lib64.
>
> The problem occurs when any of the gdal dependencies are in packages.yaml from /usr/lib64. (e.g. json-c, libtiff, xz). When their library paths get added, they hide other libraries that might also have versions in /usr/lib64. 