### PR TITLE
Default buildcache location needs url schema

### DIFF
--- a/lib/spack/spack/cmd/buildcache.py
+++ b/lib/spack/spack/cmd/buildcache.py
@@ -701,7 +701,7 @@ def update_index(mirror_url, update_keys=False):
 
 def update_index_fn(args):
     """Update a buildcache index."""
-    outdir = '.'
+    outdir = 'file://.'
     if args.mirror_url:
         outdir = args.mirror_url
 


### PR DESCRIPTION
Resolves path/URL parsing issues introduced by #27021