### PR TITLE
exago: add pkgconfig dependency

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -41,6 +41,7 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('~hiop~ipopt', msg="ExaGO needs at least one solver enabled")
 
     # Dependencides
+    depends_on('pkgconfig', type='build')
     depends_on('mpi', when='+mpi')
     depends_on('blas')
     depends_on('cuda', when='+cuda')


### PR DESCRIPTION
ExaGo needs `pkgconfig` for build. In a minimal container environment where there pkgconfig provider installed you get:

```
$> spack install exago ...
...
1 error found in build log:
     24    -- Looking for pthread_create in pthreads - not found
     25    -- Looking for pthread_create in pthread
     26    -- Looking for pthread_create in pthread - found
     27    -- Found Threads: TRUE
     28    -- hip::amdhip64 is SHARED_LIBRARY
     29    -- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
  >> 30    CMake Error at /spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-11.1.0/cmake-3.23.1-n2yk46ck5ckqimr2f743in34htag3bxi/share/cmake-3.23/Modules/FindPkgC
           onfig.cmake:659 (message):
     31      pkg-config tool not found
     32    Call Stack (most recent call first):
     33      /spack/opt/spack/linux-ubuntu20.04-x86_64/gcc-11.1.0/cmake-3.23.1-n2yk46ck5ckqimr2f743in34htag3bxi/share/cmake-3.23/Modules/FindPkgConfig.cmake:8
           25 (_pkg_check_modules_internal)
     34      CMakeLists.txt:222 (pkg_check_modules)
     35
     36
```

@CameronRutherford
@ashermancinelli