### PR TITLE
exago: use hipcc for +rocm builds

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -121,6 +121,8 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
         #     self.define('HIP_CLANG_INCLUDE_PATH',
         #         '/opt/rocm-X.Y.Z/llvm/lib/clang/14.0.0/include/'))
         if '+rocm' in spec:
+            args.append(self.define('CMAKE_CXX_COMPILER', spec['hip'].hipcc))
+
             rocm_arch_list = spec.variants['amdgpu_target'].value
             if rocm_arch_list[0] != 'none':
                 args.append(self.define('GPU_TARGETS', rocm_arch_list))


### PR DESCRIPTION
Similar to https://github.com/spack/spack/pull/30182 we should use hipcc as cxx compiler for `+rocm` builds.

Without this you get:
```
$> spack install exago +rocm amdgpu_target=gfx90a ...
...
  >> 518    g++-11: error: unrecognized command-line option '--offload-arch=gfx90a'
  >> 519    make[2]: *** [src/opflow/CMakeFiles/OPFLOW_obj_static.dir/build.make:121: src/opflow/CMakeFiles/OPFLOW_obj_static.dir/model/current_bal_cartesian/
            ibcar.cpp.o] Error 1
  >> 520    g++-11: error: unrecognized command-line option '--offload-arch=gfx90a'
     521    make[2]: *** Waiting for unfinished jobs....
  >> 522    make[2]: *** [src/opflow/CMakeFiles/OPFLOW_obj_static.dir/build.make:107: src/opflow/CMakeFiles/OPFLOW_obj_static.dir/interface/opflowoutput.cpp.o
            ] Error 1
...
```

@CameronRutherford
@ashermancinelli