### PR TITLE
vtk-m: update latest release

### DIFF
--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -28,6 +28,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     version('master', branch='master')
     version('release', branch='release')
+    version('1.8.0-rc1', sha256="99e344c89ecb84b04cc0f0b9fdf042b9a4ae3144bb4deeca8e90f098ab8a569b")
     version('1.7.1', sha256="7ea3e945110b837a8c2ba49b41e45e1a1d8d0029bb472b291f7674871dbbbb63", preferred=True)
     version('1.7.0', sha256="a86667ac22057462fc14495363cfdcc486da125b366cb568ec23c86946439be4")
     version('1.6.0', sha256="14e62d306dd33f82eb9ddb1d5cee987b7a0b91bf08a7a02ca3bce3968c95fd76")

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -20,7 +20,7 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
     architectures."""
 
     homepage = "https://m.vtk.org/"
-    maintainers = ['robertmaynard', 'kmorel', 'vicentebolea']
+    maintainers = ['kmorel', 'vicentebolea']
 
     url      = "https://gitlab.kitware.com/vtk/vtk-m/-/archive/v1.5.1/vtk-m-v1.5.1.tar.gz"
     git      = "https://gitlab.kitware.com/vtk/vtk-m.git"


### PR DESCRIPTION
Finally! After a quite summer, VTK-m v1.8.0-rc1 is finally out :tada: :tada: :tada:

This bring exiting new features, and bugfixes, find the tentative release notes at https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/1.8/release-notes.md

Let me know if we need to change anything else in the package

ViB