### PR TITLE
intel-xed: add version 2022.04.17

### DIFF
--- a/var/spack/repos/builtin/packages/intel-xed/2019-python3.patch
+++ b/var/spack/repos/builtin/packages/intel-xed/2019-python3.patch
@@ -1,0 +1,12 @@
+Old revs call python instead of python3.
+
+diff --git a/mfile.py b/mfile.py
+index b6889c6..b43b442 100755
+--- a/mfile.py
++++ b/mfile.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # -*- python -*-
+ #BEGIN_LEGAL
+ #

--- a/var/spack/repos/builtin/packages/intel-xed/package.py
+++ b/var/spack/repos/builtin/packages/intel-xed/package.py
@@ -18,7 +18,8 @@ class IntelXed(Package):
     mbuild_git = 'https://github.com/intelxed/mbuild.git'
 
     # Current versions now have actual releases and tags.
-    version('master', branch='master')
+    version('main', branch='main')
+    version('2022.04.17', tag='v2022.04.17')
     version('12.0.1', tag='12.0.1')
     version('11.2.0', tag='11.2.0')
 
@@ -26,10 +27,10 @@ class IntelXed(Package):
     version('10.2019.03', commit='b7231de4c808db821d64f4018d15412640c34113')
 
     resource(name='mbuild', placement='mbuild', git=mbuild_git,
-             branch='master', when='@master')
+             branch='main', when='@main')
 
     resource(name='mbuild', placement='mbuild', git=mbuild_git,
-             commit='3e8eb33aada4153c21c4261b35e5f51f6e2019e8', when='@:999')
+             commit='09b6654be0c52bf1df44e88c88b411a67b624cbd', when='@:9999')
 
     variant('debug', default=False, description='Enable debug symbols')
     variant('pic', default=False,
@@ -39,6 +40,7 @@ class IntelXed(Package):
     depends_on('python@3.4:', type='build')
 
     patch('1201-segv.patch', when='@12.0.1')
+    patch('2019-python3.patch', when='@10.2019.03')
 
     conflicts('target=ppc64:', msg='intel-xed only runs on x86')
     conflicts('target=ppc64le:', msg='intel-xed only runs on x86')


### PR DESCRIPTION
1. Add version 2022.04.17 (new numbering scheme) and update mbuild resource.
2. Branch 'master' is now 'main'.
3. Old rev 10.2019.03 needs a patch for python vs python3.