### PR TITLE
spack find external support for OpenCV and OpenBLAS

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -110,17 +110,16 @@ def path_contains_subdirectory(path, root):
     return norm_path.startswith(norm_root)
 
 
-def library_extensions():
-    """This generates the library filenames that may appear on any OS.
-    """
-    return ['a', 'la', 'so', 'tbd', 'dylib']
+"""This generates the library filenames that may appear on any OS.
+"""
+library_extensions = ['a', 'la', 'so', 'tbd', 'dylib']
 
 
 def possible_library_filenames(library_names):
     """Given a collection of library names like 'libfoo', generate the set of
     library filenames that may be found on the system (e.g. libfoo.so).
     """
-    lib_extensions = library_extensions()
+    lib_extensions = library_extensions
     return set(
         '.'.join((lib, extension)) for lib, extension in
         itertools.product(library_names, lib_extensions))

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -110,8 +110,7 @@ def path_contains_subdirectory(path, root):
     return norm_path.startswith(norm_root)
 
 
-"""This generates the library filenames that may appear on any OS.
-"""
+#: This generates the library filenames that may appear on any OS.
 library_extensions = ['a', 'la', 'so', 'tbd', 'dylib']
 
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -64,9 +64,9 @@ __all__ = [
     'is_exe',
     'join_path',
     'last_modification_time_recursive',
+    'library_extensions',
     'mkdirp',
     'partition_path',
-    'possible_lib_extensions',
     'prefixes',
     'remove_dead_links',
     'remove_directory_contents',
@@ -110,7 +110,7 @@ def path_contains_subdirectory(path, root):
     return norm_path.startswith(norm_root)
 
 
-def possible_lib_extensions():
+def library_extensions():
     """This generates the library filenames that may appear on any OS.
     """
     return ['a', 'la', 'so', 'tbd', 'dylib']
@@ -120,7 +120,7 @@ def possible_library_filenames(library_names):
     """Given a collection of library names like 'libfoo', generate the set of
     library filenames that may be found on the system (e.g. libfoo.so).
     """
-    lib_extensions = possible_lib_extensions()
+    lib_extensions = library_extensions()
     return set(
         '.'.join((lib, extension)) for lib, extension in
         itertools.product(library_names, lib_extensions))

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -64,9 +64,9 @@ __all__ = [
     'is_exe',
     'join_path',
     'last_modification_time_recursive',
-    'lib_extensions',
     'mkdirp',
     'partition_path',
+    'possible_lib_extensions',
     'prefixes',
     'remove_dead_links',
     'remove_directory_contents',
@@ -110,7 +110,7 @@ def path_contains_subdirectory(path, root):
     return norm_path.startswith(norm_root)
 
 
-def lib_extensions():
+def possible_lib_extensions():
     """This generates the library filenames that may appear on any OS.
     """
     return ['a', 'la', 'so', 'tbd', 'dylib']
@@ -120,7 +120,7 @@ def possible_library_filenames(library_names):
     """Given a collection of library names like 'libfoo', generate the set of
     library filenames that may be found on the system (e.g. libfoo.so).
     """
-    lib_extensions = lib_extensions()
+    lib_extensions = possible_lib_extensions()
     return set(
         '.'.join((lib, extension)) for lib, extension in
         itertools.product(library_names, lib_extensions))

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -64,6 +64,7 @@ __all__ = [
     'is_exe',
     'join_path',
     'last_modification_time_recursive',
+    'lib_extensions',
     'mkdirp',
     'partition_path',
     'prefixes',
@@ -109,12 +110,17 @@ def path_contains_subdirectory(path, root):
     return norm_path.startswith(norm_root)
 
 
+def lib_extensions():
+    """This generates the library filenames that may appear on any OS.
+    """
+    return ['a', 'la', 'so', 'tbd', 'dylib']
+
+
 def possible_library_filenames(library_names):
     """Given a collection of library names like 'libfoo', generate the set of
-    library filenames that may be found on the system (e.g. libfoo.so). This
-    generates the library filenames that may appear on any OS.
+    library filenames that may be found on the system (e.g. libfoo.so).
     """
-    lib_extensions = ['a', 'la', 'so', 'tbd', 'dylib']
+    lib_extensions = lib_extensions()
     return set(
         '.'.join((lib, extension)) for lib, extension in
         itertools.product(library_names, lib_extensions))

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -184,8 +184,9 @@ def print_detectable(pkg):
     color.cprint('')
     color.cprint(section_title('Externally Detectable: '))
 
-    # If the package has an 'executables' field, it can detect an installation
-    if hasattr(pkg, 'executables'):
+    # If the package has an 'executables' of 'libraries' field, it
+    # can detect an installation
+    if hasattr(pkg, 'executables') or hasattr(pkg, 'libraries'):
         find_attributes = []
         if hasattr(pkg, 'determine_version'):
             find_attributes.append('version')

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -74,7 +74,8 @@ def executables_in_path(path_hints=None):
 
 
 def libraries_in_ld_library_path(path_hints=None):
-    """Get the paths of all libraries available from LD_LIBRARY_PATH.
+    """Get the paths of all libraries available from LD_LIBRARY_PATH,
+    LIBRARY_PATH, DYLD_LIBRARY_PATH, and DYLD_FALLBACK_LIBRARY_PATH.
 
     For convenience, this is constructed as a dictionary where the keys are
     the library paths and the values are the names of the libraries
@@ -85,12 +86,14 @@ def libraries_in_ld_library_path(path_hints=None):
 
     Args:
         path_hints (list): list of paths to be searched. If None the list will be
-            constructed based on the LD_LIBRARY_PATH environment variable.
+            constructed based on the set of LD_LIBRARY_PATH, LIBRARY_PATH,
+            DYLD_LIBRARY_PATH, and DYLD_FALLBACK_LIBRARY_PATH environment
+            variables.
     """
     path_hints = path_hints or \
-        spack.util.environment.get_path('LIBRARY_PATH') or \
-        spack.util.environment.get_path('LD_LIBRARY_PATH') or \
-        spack.util.environment.get_path('DYLD_LIBRARY_PATH') or \
+        spack.util.environment.get_path('LIBRARY_PATH') + \
+        spack.util.environment.get_path('LD_LIBRARY_PATH') + \
+        spack.util.environment.get_path('DYLD_LIBRARY_PATH') + \
         spack.util.environment.get_path('DYLD_FALLBACK_LIBRARY_PATH')
     search_paths = llnl.util.filesystem.search_paths_for_libraries(*path_hints)
 

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -88,8 +88,10 @@ def libraries_in_ld_library_path(path_hints=None):
             constructed based on the LD_LIBRARY_PATH environment variable.
     """
     path_hints = path_hints or \
+        spack.util.environment.get_path('LIBRARY_PATH') or \
         spack.util.environment.get_path('LD_LIBRARY_PATH') or \
-        spack.util.environment.get_path('DYLD_LIBRARY_PATH')
+        spack.util.environment.get_path('DYLD_LIBRARY_PATH') or \
+        spack.util.environment.get_path('DYLD_FALLBACK_LIBRARY_PATH')
     search_paths = llnl.util.filesystem.search_paths_for_libraries(*path_hints)
 
     path_to_lib = {}

--- a/lib/spack/spack/detection/path.py
+++ b/lib/spack/spack/detection/path.py
@@ -87,7 +87,9 @@ def libraries_in_ld_library_path(path_hints=None):
         path_hints (list): list of paths to be searched. If None the list will be
             constructed based on the LD_LIBRARY_PATH environment variable.
     """
-    path_hints = path_hints or spack.util.environment.get_path('LD_LIBRARY_PATH')
+    path_hints = path_hints or \
+        spack.util.environment.get_path('LD_LIBRARY_PATH') or \
+        spack.util.environment.get_path('DYLD_LIBRARY_PATH')
     search_paths = llnl.util.filesystem.search_paths_for_libraries(*path_hints)
 
     path_to_lib = {}

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -152,7 +152,7 @@ class Openblas(MakefilePackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = filesystem.possible_lib_extensions()
+        lib_extensions = filesystem.library_extensions()
         for ext in lib_extensions:
             match = re.search(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.%s' % ext,
                               lib)

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -149,11 +149,8 @@ class Openblas(MakefilePackage):
 
     @classmethod
     def determine_version(cls, lib):
-        print(f'I received library string {lib}')
-#        print(os.readlink(lib))
         match = re.search(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.so',
                           lib)
-        print(f'I found library {match.group(1)} with version {match.group(3)}')
         return match.group(3) if match else None
 
     @property

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -8,6 +8,8 @@ import re
 
 from spack import *
 from spack.package_test import compare_output_file, compile_c_and_execute
+from llnl.util import filesystem
+
 
 
 class Openblas(MakefilePackage):
@@ -149,9 +151,14 @@ class Openblas(MakefilePackage):
 
     @classmethod
     def determine_version(cls, lib):
-        match = re.search(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.so',
-                          lib)
-        return match.group(3) if match else None
+        ver = None
+        lib_extensions = filesystem.lib_extensions()
+        for ext in lib_extensions:
+            match = re.search(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.%s' % ext,
+                              lib)
+            if match:
+                ver = match.group(3)
+        return ver
 
     @property
     def parallel(self):

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -154,18 +154,8 @@ class Openblas(MakefilePackage):
         ver = None
         lib_extensions = filesystem.library_extensions()
         for ext in lib_extensions:
-#            pattern = None
-#            if ext == 'dylib':
-                # Brew on Darwin doesn't have the architecture name as part of the
-                # library
             match = re.search(r'lib(\S*?)-r(\d+\.\d+\.\d+)\.%s' %
                               ext, lib)
-            #     pattern = re.compile(r'lib(\S*?)([_\S]*?)-r(\d+\.\d+\.\d+)\.%s' %
-            #                          ext)
-            # else:
-            #     pattern = re.compile(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.%s' %
-            #                          ext)
-#            match = pattern.search(lib)
             if match:
                 ver = match.group(2)
         return ver

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -154,10 +154,20 @@ class Openblas(MakefilePackage):
         ver = None
         lib_extensions = filesystem.library_extensions()
         for ext in lib_extensions:
-            match = re.search(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.%s' % ext,
-                              lib)
+#            pattern = None
+#            if ext == 'dylib':
+                # Brew on Darwin doesn't have the architecture name as part of the
+                # library
+            match = re.search(r'lib(\S*?)-r(\d+\.\d+\.\d+)\.%s' %
+                              ext, lib)
+            #     pattern = re.compile(r'lib(\S*?)([_\S]*?)-r(\d+\.\d+\.\d+)\.%s' %
+            #                          ext)
+            # else:
+            #     pattern = re.compile(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.%s' %
+            #                          ext)
+#            match = pattern.search(lib)
             if match:
-                ver = match.group(3)
+                ver = match.group(2)
         return ver
 
     @property

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -6,7 +6,7 @@
 import os
 import re
 
-from llnl.util import filesystem
+from llnl.util.filesystem import library_extensions
 
 from spack import *
 from spack.package_test import compare_output_file, compile_c_and_execute
@@ -152,7 +152,7 @@ class Openblas(MakefilePackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = filesystem.library_extensions
+        lib_extensions = library_extensions
         for ext in lib_extensions:
             match = re.search(r'lib(\S*?)-r(\d+\.\d+\.\d+)\.%s' %
                               ext, lib)

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -6,10 +6,10 @@
 import os
 import re
 
-from spack import *
-from spack.package_test import compare_output_file, compile_c_and_execute
 from llnl.util import filesystem
 
+from spack import *
+from spack.package_test import compare_output_file, compile_c_and_execute
 
 
 class Openblas(MakefilePackage):

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -152,8 +152,7 @@ class Openblas(MakefilePackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = library_extensions
-        for ext in lib_extensions:
+        for ext in library_extensions:
             match = re.search(r'lib(\S*?)-r(\d+\.\d+\.\d+)\.%s' %
                               ext, lib)
             if match:

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -152,7 +152,7 @@ class Openblas(MakefilePackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = filesystem.library_extensions()
+        lib_extensions = filesystem.library_extensions
         for ext in lib_extensions:
             match = re.search(r'lib(\S*?)-r(\d+\.\d+\.\d+)\.%s' %
                               ext, lib)

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -17,6 +17,8 @@ class Openblas(MakefilePackage):
     url      = 'https://github.com/xianyi/OpenBLAS/archive/v0.2.19.tar.gz'
     git      = 'https://github.com/xianyi/OpenBLAS.git'
 
+    libraries = ['libopenblas']
+
     version('develop', branch='develop')
     version('0.3.20', sha256='8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c')
     version('0.3.19', sha256='947f51bfe50c2a0749304fbe373e00e7637600b0a47b78a51382aeb30ca08562')
@@ -144,6 +146,15 @@ class Openblas(MakefilePackage):
     conflicts('threads=openmp @:0.2.19', when='%clang', msg='OpenBLAS @:0.2.19 does not support OpenMP with clang!')
 
     depends_on('perl', type='build')
+
+    @classmethod
+    def determine_version(cls, lib):
+        print(f'I received library string {lib}')
+#        print(os.readlink(lib))
+        match = re.search(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.so',
+                          lib)
+        print(f'I found library {match.group(1)} with version {match.group(3)}')
+        return match.group(3) if match else None
 
     @property
     def parallel(self):

--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -152,7 +152,7 @@ class Openblas(MakefilePackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = filesystem.lib_extensions()
+        lib_extensions = filesystem.possible_lib_extensions()
         for ext in lib_extensions:
             match = re.search(r'lib(\S*?)_(\S*?)-r(\d+\.\d+\.\d+)\.%s' % ext,
                               lib)

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -886,7 +886,7 @@ class Opencv(CMakePackage, CudaPackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = filesystem.possible_lib_extensions()
+        lib_extensions = filesystem.library_extensions()
         for ext in lib_extensions:
             if 'platform=darwin':
                 # Darwin switches the order of the version compared to Linux
@@ -903,7 +903,7 @@ class Opencv(CMakePackage, CudaPackage):
     def determine_variants(cls, libs, version_str):
         results = []
         variants = []
-        lib_extensions = filesystem.possible_lib_extensions()
+        lib_extensions = filesystem.library_extensions()
         for lib in libs:
             for ext in lib_extensions:
                 if 'platform=darwin':

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -5,7 +5,7 @@
 
 import re
 
-from llnl.util import filesystem
+from llnl.util.filesystem import library_extensions
 
 
 class Opencv(CMakePackage, CudaPackage):
@@ -886,7 +886,7 @@ class Opencv(CMakePackage, CudaPackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = filesystem.library_extensions
+        lib_extensions = library_extensions
         for ext in lib_extensions:
             pattern = None
             if ext == 'dylib':
@@ -905,7 +905,7 @@ class Opencv(CMakePackage, CudaPackage):
     def determine_variants(cls, libs, version_str):
         results = []
         variants = []
-        lib_extensions = filesystem.library_extensions
+        lib_extensions = library_extensions
         for lib in libs:
             for ext in lib_extensions:
                 pattern = None

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -902,7 +902,6 @@ class Opencv(CMakePackage, CudaPackage):
 
     @classmethod
     def determine_variants(cls, libs, version_str):
-        results = []
         variants = []
         for lib in libs:
             for ext in library_extensions:
@@ -917,8 +916,7 @@ class Opencv(CMakePackage, CudaPackage):
                 match = pattern.search(lib)
                 if match and not match.group(2) == 'core':
                     variants.append('+' + match.group(2))
-        results.append(' '.join(variants))
-        return results
+        return ' '.join(variants)
 
     def cmake_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -886,7 +886,7 @@ class Opencv(CMakePackage, CudaPackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = filesystem.library_extensions()
+        lib_extensions = filesystem.library_extensions
         for ext in lib_extensions:
             pattern = None
             if ext == 'dylib':
@@ -905,7 +905,7 @@ class Opencv(CMakePackage, CudaPackage):
     def determine_variants(cls, libs, version_str):
         results = []
         variants = []
-        lib_extensions = filesystem.library_extensions()
+        lib_extensions = filesystem.library_extensions
         for lib in libs:
             for ext in lib_extensions:
                 pattern = None

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -5,6 +5,7 @@
 
 import re
 
+
 class Opencv(CMakePackage, CudaPackage):
     """OpenCV (Open Source Computer Vision Library) is an open source computer
     vision and machine learning software library."""
@@ -242,7 +243,7 @@ class Opencv(CMakePackage, CudaPackage):
     for mod in modules:
         # At least one of these modules must be enabled to build OpenCV
         variant(mod, default=False, description="Include opencv_{0} module".format(mod))
-        lib = f'libopencv_{mod}'
+        lib = 'libopencv_'+mod
         libraries.append(lib)
 
     # module conflicts and dependencies

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -243,7 +243,7 @@ class Opencv(CMakePackage, CudaPackage):
     for mod in modules:
         # At least one of these modules must be enabled to build OpenCV
         variant(mod, default=False, description="Include opencv_{0} module".format(mod))
-        lib = 'libopencv_'+mod
+        lib = 'libopencv_' + mod
         libraries.append(lib)
 
     # module conflicts and dependencies
@@ -895,7 +895,7 @@ class Opencv(CMakePackage, CudaPackage):
             match = re.search(r'lib(\S*?)_(\S*)\.so\.(\d+\.\d+\.\d+)',
                               lib)
             if match and not match.group(2) == 'core':
-                variants.append(f'+{match.group(2)}')
+                variants.append('+' + match.group(2))
         results.append(' '.join(variants))
         return results
 

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -892,7 +892,7 @@ class Opencv(CMakePackage, CudaPackage):
             if ext == 'dylib':
                 # Darwin switches the order of the version compared to Linux
                 pattern = re.compile(r'lib(\S*?)_(\S*)\.(\d+\.\d+\.\d+)\.%s' %
-                                  ext)
+                                     ext)
             else:
                 pattern = re.compile(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' %
                                      ext)
@@ -908,10 +908,11 @@ class Opencv(CMakePackage, CudaPackage):
         lib_extensions = filesystem.library_extensions()
         for lib in libs:
             for ext in lib_extensions:
+                pattern = None
                 if ext == 'dylib':
                     # Darwin switches the order of the version compared to Linux
                     pattern = re.compile(r'lib(\S*?)_(\S*)\.(\d+\.\d+\.\d+)\.%s' %
-                                      ext)
+                                         ext)
                 else:
                     pattern = re.compile(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' %
                                          ext)

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -5,6 +5,8 @@
 
 import re
 
+from llnl.util import filesystem
+
 
 class Opencv(CMakePackage, CudaPackage):
     """OpenCV (Open Source Computer Vision Library) is an open source computer
@@ -883,19 +885,26 @@ class Opencv(CMakePackage, CudaPackage):
 
     @classmethod
     def determine_version(cls, lib):
-        match = re.search(r'lib(\S*?)_(\S*?)\.so\.(\d+\.\d+\.\d+)',
-                          lib)
-        return match.group(3) if match else None
+        ver = None
+        lib_extensions = filesystem.lib_extensions()
+        for ext in lib_extensions:
+            match = re.search(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' % ext,
+                              lib)
+            if match:
+                ver = match.group(3)
+        return ver
 
     @classmethod
     def determine_variants(cls, libs, version_str):
         results = []
         variants = []
+        lib_extensions = filesystem.lib_extensions()
         for lib in libs:
-            match = re.search(r'lib(\S*?)_(\S*)\.so\.(\d+\.\d+\.\d+)',
-                              lib)
-            if match and not match.group(2) == 'core':
-                variants.append('+' + match.group(2))
+            for ext in lib_extensions:
+                match = re.search(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' % ext,
+                                  lib)
+                if match and not match.group(2) == 'core':
+                    variants.append('+' + match.group(2))
         results.append(' '.join(variants))
         return results
 

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -886,10 +886,15 @@ class Opencv(CMakePackage, CudaPackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = filesystem.lib_extensions()
+        lib_extensions = filesystem.possible_lib_extensions()
         for ext in lib_extensions:
-            match = re.search(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' % ext,
-                              lib)
+            if 'platform=darwin':
+                # Darwin switches the order of the version compared to Linux
+                match = re.search(r'lib(\S*?)_(\S*)\.(\d+\.\d+\.\d+)\.%s' %
+                                  ext, lib)
+            else:
+                match = re.search(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' %
+                                  ext, lib)
             if match:
                 ver = match.group(3)
         return ver
@@ -898,11 +903,16 @@ class Opencv(CMakePackage, CudaPackage):
     def determine_variants(cls, libs, version_str):
         results = []
         variants = []
-        lib_extensions = filesystem.lib_extensions()
+        lib_extensions = filesystem.possible_lib_extensions()
         for lib in libs:
             for ext in lib_extensions:
-                match = re.search(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' % ext,
-                                  lib)
+                if 'platform=darwin':
+                    # Darwin switches the order of the version compared to Linux
+                    match = re.search(r'lib(\S*?)_(\S*)\.(\d+\.\d+\.\d+)\.%s' %
+                                      ext, lib)
+                else:
+                    match = re.search(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' %
+                                      ext, lib)
                 if match and not match.group(2) == 'core':
                     variants.append('+' + match.group(2))
         results.append(' '.join(variants))

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -903,6 +903,7 @@ class Opencv(CMakePackage, CudaPackage):
     @classmethod
     def determine_variants(cls, libs, version_str):
         variants = []
+        remaining_modules = set(Opencv.modules)
         for lib in libs:
             for ext in library_extensions:
                 pattern = None
@@ -916,6 +917,12 @@ class Opencv(CMakePackage, CudaPackage):
                 match = pattern.search(lib)
                 if match and not match.group(2) == 'core':
                     variants.append('+' + match.group(2))
+                    remaining_modules.remove(match.group(2))
+
+        # If libraries are not found, mark those variants as disabled
+        for mod in remaining_modules:
+            variants.append('~' + mod)
+
         return ' '.join(variants)
 
     def cmake_args(self):

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -888,13 +888,15 @@ class Opencv(CMakePackage, CudaPackage):
         ver = None
         lib_extensions = filesystem.library_extensions()
         for ext in lib_extensions:
-            if 'platform=darwin':
+            pattern = None
+            if ext == 'dylib':
                 # Darwin switches the order of the version compared to Linux
-                match = re.search(r'lib(\S*?)_(\S*)\.(\d+\.\d+\.\d+)\.%s' %
-                                  ext, lib)
+                pattern = re.compile(r'lib(\S*?)_(\S*)\.(\d+\.\d+\.\d+)\.%s' %
+                                  ext)
             else:
-                match = re.search(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' %
-                                  ext, lib)
+                pattern = re.compile(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' %
+                                     ext)
+            match = pattern.search(lib)
             if match:
                 ver = match.group(3)
         return ver
@@ -906,13 +908,14 @@ class Opencv(CMakePackage, CudaPackage):
         lib_extensions = filesystem.library_extensions()
         for lib in libs:
             for ext in lib_extensions:
-                if 'platform=darwin':
+                if ext == 'dylib':
                     # Darwin switches the order of the version compared to Linux
-                    match = re.search(r'lib(\S*?)_(\S*)\.(\d+\.\d+\.\d+)\.%s' %
-                                      ext, lib)
+                    pattern = re.compile(r'lib(\S*?)_(\S*)\.(\d+\.\d+\.\d+)\.%s' %
+                                      ext)
                 else:
-                    match = re.search(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' %
-                                      ext, lib)
+                    pattern = re.compile(r'lib(\S*?)_(\S*)\.%s\.(\d+\.\d+\.\d+)' %
+                                         ext)
+                match = pattern.search(lib)
                 if match and not match.group(2) == 'core':
                     variants.append('+' + match.group(2))
         results.append(' '.join(variants))

--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -886,8 +886,7 @@ class Opencv(CMakePackage, CudaPackage):
     @classmethod
     def determine_version(cls, lib):
         ver = None
-        lib_extensions = library_extensions
-        for ext in lib_extensions:
+        for ext in library_extensions:
             pattern = None
             if ext == 'dylib':
                 # Darwin switches the order of the version compared to Linux
@@ -905,9 +904,8 @@ class Opencv(CMakePackage, CudaPackage):
     def determine_variants(cls, libs, version_str):
         results = []
         variants = []
-        lib_extensions = library_extensions
         for lib in libs:
-            for ext in lib_extensions:
+            for ext in library_extensions:
                 pattern = None
                 if ext == 'dylib':
                     # Darwin switches the order of the version compared to Linux


### PR DESCRIPTION
Added support for finding the OpenCV package via the find external
command.  Included support for identifying variants based on available
shared libraries.

Added support to finding the OpenBLAS package via the find external
command.

Enabled pacakges to show that they can be discovered via the find
external command in the info message.