### PR TITLE
cray-mpich: add variant 'wrappers'

### DIFF
--- a/var/spack/repos/builtin/packages/cray-mpich/package.py
+++ b/var/spack/repos/builtin/packages/cray-mpich/package.py
@@ -29,6 +29,10 @@ class CrayMpich(Package):
     version('7.7.14')
     version('7.7.13')
 
+    # cray-mpich 8.1.7: features MPI compiler wrappers
+    variant('wrappers', default=True, when='@8.1.7:',
+            description='enable MPI wrappers')
+
     provides('mpi@3')
 
     canonical_names = {
@@ -59,17 +63,16 @@ class CrayMpich(Package):
                 return os.path.dirname(os.path.normpath(libdir))
 
     def setup_run_environment(self, env):
-        if(self.spec.satisfies('@:8.1.6')):
-            env.set('MPICC', spack_cc)
-            env.set('MPICXX', spack_cxx)
-            env.set('MPIF77', spack_fc)
-            env.set('MPIF90', spack_fc)
-        else:
-            # cray-mpich 8.1.7: features MPI compiler wrappers
+        if '+wrappers' in self.spec:
             env.set('MPICC', join_path(self.prefix.bin, 'mpicc'))
             env.set('MPICXX', join_path(self.prefix.bin, 'mpicxx'))
             env.set('MPIF77', join_path(self.prefix.bin, 'mpif77'))
             env.set('MPIF90', join_path(self.prefix.bin, 'mpif90'))
+        else:
+            env.set('MPICC', spack_cc)
+            env.set('MPICXX', spack_cxx)
+            env.set('MPIF77', spack_fc)
+            env.set('MPIF90', spack_fc)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         self.setup_run_environment(env)
@@ -81,17 +84,16 @@ class CrayMpich(Package):
 
     def setup_dependent_package(self, module, dependent_spec):
         spec = self.spec
-        if(spec.satisfies('@:8.1.6')):
+        if '+wrappers' in spec:
+            spec.mpicc = join_path(self.prefix.bin, 'mpicc')
+            spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
+            spec.mpifc = join_path(self.prefix.bin, 'mpif90')
+            spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
+        else:
             spec.mpicc = spack_cc
             spec.mpicxx = spack_cxx
             spec.mpifc = spack_fc
             spec.mpif77 = spack_f77
-        else:
-            # cray-mpich 8.1.7: features MPI compiler wrappers
-            spec.mpicc  = join_path(self.prefix.bin, 'mpicc')
-            spec.mpicxx = join_path(self.prefix.bin, 'mpicxx')
-            spec.mpifc  = join_path(self.prefix.bin, 'mpif90')
-            spec.mpif77 = join_path(self.prefix.bin, 'mpif77')
 
     def install(self, spec, prefix):
         raise InstallError(


### PR DESCRIPTION
I have stumbled upon a Cray system with `cray-mpich@8.1.12` that does not have the wrappers for some of the available compilers. They were there a couple of weeks ago but then were removed. I don't know the exact reason for that but with these changes I could slightly adjust my `package.yaml` and proceed.