### PR TITLE
level-zero: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -105,7 +105,7 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on('zlib+shared')
 
     depends_on('cuda', when='+cuda')
-    depends_on('level-zero', when='+level_zero')
+    depends_on('oneapi-level-zero', when='+level_zero')
     depends_on('intel-xed', when='target=x86_64:')
     depends_on('memkind', type=('build', 'run'), when='@2021.05.01:')
     depends_on('papi', when='+papi')
@@ -172,7 +172,7 @@ class Hpctoolkit(AutotoolsPackage):
             args.append('--with-cuda=%s' % spec['cuda'].prefix)
 
         if '+level_zero' in spec:
-            args.append('--with-level0=%s' % spec['level-zero'].prefix)
+            args.append('--with-level0=%s' % spec['oneapi-level-zero'].prefix)
 
         if spec.satisfies('@:2020.09'):
             args.append('--with-gotcha=%s' % spec['gotcha'].prefix)

--- a/var/spack/repos/builtin/packages/hpctoolkit/package.py
+++ b/var/spack/repos/builtin/packages/hpctoolkit/package.py
@@ -64,6 +64,9 @@ class Hpctoolkit(AutotoolsPackage):
             description='Needed when MPICXX builds static binaries '
             'for the compute nodes.')
 
+    variant('level_zero', default=False,
+            description='Support Level Zero on Intel GPUs (2022.04.15 or later).')
+
     variant('cuda', default=False,
             description='Support CUDA on NVIDIA GPUs (2020.03.01 or later).')
 
@@ -102,6 +105,7 @@ class Hpctoolkit(AutotoolsPackage):
     depends_on('zlib+shared')
 
     depends_on('cuda', when='+cuda')
+    depends_on('level-zero', when='+level_zero')
     depends_on('intel-xed', when='target=x86_64:')
     depends_on('memkind', type=('build', 'run'), when='@2021.05.01:')
     depends_on('papi', when='+papi')
@@ -166,6 +170,9 @@ class Hpctoolkit(AutotoolsPackage):
 
         if '+cuda' in spec:
             args.append('--with-cuda=%s' % spec['cuda'].prefix)
+
+        if '+level_zero' in spec:
+            args.append('--with-level0=%s' % spec['level-zero'].prefix)
 
         if spec.satisfies('@:2020.09'):
             args.append('--with-gotcha=%s' % spec['gotcha'].prefix)

--- a/var/spack/repos/builtin/packages/level-zero/package.py
+++ b/var/spack/repos/builtin/packages/level-zero/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class LevelZero(CMakePackage):
+    """oneAPI Level Zero Specification Headers and Loader"""
+
+    homepage = "https://spec.oneapi.io/versions/latest/elements/l0/source/index.html"
+    url      = "https://github.com/oneapi-src/level-zero/archive/refs/tags/v1.7.15.tar.gz"
+
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('1.7.15', sha256='c39bb05a8e5898aa6c444e1704105b93d3f1888b9c333f8e7e73825ffbfb2617')
+    version('1.7.9',  sha256='b430a7f833a689c899b32172a31c3bca1d16adcad8ff866f240a3a8968433de7')
+    version('1.7.4',  sha256='23a3f393f6e8f7ed694e0d3248d1ac1b92f2b6964cdb4d747abc23328050513b')
+    version('1.6.2',  sha256='ef124adc7a011b672e661fbe38873d7db6546c068a4a03610fdc5118b6b6cbf7')
+    version('1.5.4',  sha256='0332215bd00f49e3cc75cf0cfb0111b5e8b7f41046f0b85e29725f00c26bf750')
+    version('1.5',    sha256='f93523b412522713bb28d54e2326cac0c342a0cd2662f524c17a65887cf868e8')
+    version('1.4.1',  sha256='2878fa29cbf5cea677a00f6dde6eb42d147c98c8d2a99fefece284d85cd1476b')
+    version('1.3.7',  sha256='e84c7f36316257eb46f74b41aef5c37fb593a8821497e45dfeda81aceba0abbc')
+    version('1.3.6',  sha256='c2b3bd6e4ee3cc874bdcc32bc8705bd217ffc46b194c77e27b23b8391c0c9704')
+    version('1.2.3',  sha256='69689429fcdaef74fa8395785aca65f5652e410bd6c56f47b2b64692c098892b')

--- a/var/spack/repos/builtin/packages/level-zero/package.py
+++ b/var/spack/repos/builtin/packages/level-zero/package.py
@@ -12,7 +12,7 @@ class LevelZero(CMakePackage):
     homepage = "https://spec.oneapi.io/versions/latest/elements/l0/source/index.html"
     url      = "https://github.com/oneapi-src/level-zero/archive/refs/tags/v1.7.15.tar.gz"
 
-    # maintainers = ['github_user1', 'github_user2']
+    maintainers = ['rscohn2']
 
     version('1.7.15', sha256='c39bb05a8e5898aa6c444e1704105b93d3f1888b9c333f8e7e73825ffbfb2617')
     version('1.7.9',  sha256='b430a7f833a689c899b32172a31c3bca1d16adcad8ff866f240a3a8968433de7')

--- a/var/spack/repos/builtin/packages/oneapi-level-zero/package.py
+++ b/var/spack/repos/builtin/packages/oneapi-level-zero/package.py
@@ -6,10 +6,17 @@
 from spack import *
 
 
-class LevelZero(CMakePackage):
-    """oneAPI Level Zero Specification Headers and Loader"""
+class OneapiLevelZero(CMakePackage):
+    """oneAPI Level Zero Loader.
 
-    homepage = "https://spec.oneapi.io/versions/latest/elements/l0/source/index.html"
+    Applications that need low-level control of a oneAPI level zero
+    device link against the loader. The loader depends on a separately
+    installed level zero driver. See
+    https://dgpu-docs.intel.com/technologies/level-zero.html for
+    information on how to install the driver.
+    """
+
+    homepage = "https://dgpu-docs.intel.com/technologies/level-zero.html"
     url      = "https://github.com/oneapi-src/level-zero/archive/refs/tags/v1.7.15.tar.gz"
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -117,7 +117,7 @@ class Tau(Package):
     depends_on('roctracer-dev', when='+roctracer')
     depends_on('hsa-rocr-dev', when='+rocm')
     depends_on('java', type='run')  # for paraprof
-    depends_on('level-zero', when='+level_zero')
+    depends_on('oneapi-level-zero', when='+level_zero')
 
     # Elf only required from 2.28.1 on
     conflicts('+elf', when='@:2.28.0')
@@ -264,7 +264,7 @@ class Tau(Package):
             options.append("-cuda=%s" % spec['cuda'].prefix)
 
         if '+level_zero' in spec:
-            options.append("-level_zero=%s" % spec['level-zero'].prefix)
+            options.append("-level_zero=%s" % spec['oneapi-level-zero'].prefix)
 
         if '+opencl' in spec:
             options.append("-opencl")

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -117,6 +117,7 @@ class Tau(Package):
     depends_on('roctracer-dev', when='+roctracer')
     depends_on('hsa-rocr-dev', when='+rocm')
     depends_on('java', type='run') # for paraprof
+    depends_on('level-zero', when='+level_zero')
 
     # Elf only required from 2.28.1 on
     conflicts('+elf', when='@:2.28.0')
@@ -263,7 +264,7 @@ class Tau(Package):
             options.append("-cuda=%s" % spec['cuda'].prefix)
 
         if '+level_zero' in spec:
-            options.append("-level_zero")
+            options.append("-level_zero=%s" % spec['level-zero'].prefix)
 
         if '+opencl' in spec:
             options.append("-opencl")

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -116,7 +116,7 @@ class Tau(Package):
     depends_on('rocprofiler-dev', when='+rocprofiler')
     depends_on('roctracer-dev', when='+roctracer')
     depends_on('hsa-rocr-dev', when='+rocm')
-    depends_on('java', type='run') # for paraprof
+    depends_on('java', type='run')  # for paraprof
     depends_on('level-zero', when='+level_zero')
 
     # Elf only required from 2.28.1 on


### PR DESCRIPTION
This is an attempt to get the ball rolling on Level Zero support in Spack. This package can be used to compile/link code with Level Zero dependencies like MPICH. I do not know who the maintainers of the package should be, so have left that blank for now.