### PR TITLE
Makefile generator for parallel spack install of environments

### DIFF
--- a/lib/spack/docs/conf.py
+++ b/lib/spack/docs/conf.py
@@ -23,7 +23,10 @@ import subprocess
 import sys
 from glob import glob
 
+from docutils.statemachine import StringList
+from sphinx.domains.python import PythonDomain
 from sphinx.ext.apidoc import main as sphinx_apidoc
+from sphinx.parsers import RSTParser
 
 # -- Spack customizations -----------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -82,9 +85,6 @@ todo_include_todos = True
 #
 # Disable duplicate cross-reference warnings.
 #
-from sphinx.domains.python import PythonDomain
-
-
 class PatchedPythonDomain(PythonDomain):
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
         if 'refspecific' in node:
@@ -92,8 +92,20 @@ class PatchedPythonDomain(PythonDomain):
         return super(PatchedPythonDomain, self).resolve_xref(
             env, fromdocname, builder, typ, target, node, contnode)
 
+#
+# Disable tabs to space expansion in code blocks
+# since Makefiles require tabs.
+#
+class NoTabExpansionRSTParser(RSTParser):
+    def parse(self, inputstring, document):
+        if isinstance(inputstring, str):
+            lines = inputstring.splitlines()
+            inputstring = StringList(lines, document.current_source)
+        super().parse(inputstring, document)
+
 def setup(sphinx):
     sphinx.add_domain(PatchedPythonDomain, override=True)
+    sphinx.add_source_parser(NoTabExpansionRSTParser, override=True)
 
 # -- General configuration -----------------------------------------------------
 

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -363,7 +363,7 @@ the Environment and then install the concretized specs.
       [myenv]$ spack install & spack install & spack install & spack install
 
    Another option is to generate a ``Makefile`` and run ``make -j<N>`` to control
-   the number of parallel install processes. See :ref:`env-generate-makefile`
+   the number of parallel install processes. See :ref:`env-generate-depfile`
    for details.
 
 
@@ -930,11 +930,11 @@ The ``spack env deactivate`` command will remove the default view of
 the environment from the user's path.
 
 
-.. _env-generate-makefile:
+.. _env-generate-depfile:
 
 
 ------------------------------------------
-Generated ``Makefile``\s from Environments
+Generating Depfiles from Environments
 ------------------------------------------
 
 Spack can generate ``Makefile``\s to make it easier to build multiple
@@ -949,7 +949,7 @@ A typical workflow is as follows:
    spack env create -d .
    spack -e . add perl
    spack -e . concretize
-   spack -e . env generate-makefile > Makefile
+   spack -e . env depfile > Makefile
    make -j8 -O
 
 This creates an environment in the current working directory, and after
@@ -979,7 +979,7 @@ depends on the environment installation:
    	$(SPACK) -e . concretize -f
 
    env.mk: spack.lock
-   	$(SPACK) -e . env generate-makefile --target-prefix env > $@
+   	$(SPACK) -e . env depfile -o $@ --make-target-prefix env
 
    after_install: env/env
    	@echo This executes after the environment has been installed

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -950,7 +950,7 @@ A typical workflow is as follows:
    spack -e . add perl
    spack -e . concretize
    spack -e . env depfile > Makefile
-   make -j8 -O
+   make --output-sync=recurse -j8
 
 This creates an environment in the current working directory, and after
 concretization, generates a ``Makefile``. Then ``make`` starts at most
@@ -959,10 +959,10 @@ start.
 
 .. tip::
 
-   GNU make version 4.0+ supports output synchronization through the ``-O``
-   and ``--output-sync`` flags, which ensure that output is printed
-   orderly. Color output can be forced through
-   ``make SPACK_COLOR=always -O -j<N>``.
+   GNU Make version 4.3 and above have great support for output synchronization
+   through the ``-O`` and ``--output-sync`` flags, which ensure that output is
+   printed orderly per package install. To get synchronized output with colors,
+   use ``make SPACK_COLOR=always --output-sync=recurse -j<N>``.
 
 The following advanced example shows how we can create a target that
 depends on the environment installation:

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -970,7 +970,7 @@ By default the following phony convenience targets are available:
    printed orderly per package install. To get synchronized output with colors,
    use ``make -j<N> SPACK_COLOR=always --output-sync=recurse``.
 
-The following advanced example shows how generated targets can be used in
+The following advanced example shows how generated targets can be used in a
 ``Makefile``:
 
 .. code:: Makefile

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -988,7 +988,7 @@ The following advanced example shows how generated targets can be used in
    	$(SPACK) -e . env depfile -o $@ --make-target-prefix spack
    
    fetch: spack/fetch
-      $(info Environment fetched!)
+   	$(info Environment fetched!)
 
    env: spack/env
    	$(info Environment installed!)

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -992,7 +992,8 @@ depends on the environment installation:
 When ``make`` is invoked, it wants to include ``env.makefile`` which does
 not yet exist, meaning it has to be "remade" from the target. This causes
 the environment to concretize and the ``Makefile`` to be generated. Then the
-``use_the_env`` target can execute and use the environment installation.
+``use_the_env`` target will trigger the environment to install, thanks to the
+generated ``env/all`` prerequisite.
 
 Note that ``env/all`` is used as an order-only prerequisite, because it is
 generated as a phony target.

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -959,9 +959,10 @@ start.
 
 .. tip::
 
-   GNU make version 4.0 supports the output sync feature under the ``-O``
-   or ``--output-sync``, which ensures that output is printed orderly.
-   Color output can be forced through ``make SPACK_COLOR=always -O -j<N>``.
+   GNU make version 4.0+ supports output synchronization through the ``-O``
+   and ``--output-sync`` flags, which ensure that output is printed
+   orderly. Color output can be forced through
+   ``make SPACK_COLOR=always -O -j<N>``.
 
 The following advanced example shows how we can create a target that
 depends on the environment installation:
@@ -990,7 +991,11 @@ depends on the environment installation:
 
 When ``make`` is invoked, it wants to include ``env.makefile`` which does
 not yet exist, meaning it has to be "remade" from the target. This causes
-the environment to concretize and the makefile to be generated. Then the
+the environment to concretize and the ``Makefile`` to be generated. Then the
 ``use_the_env`` target can execute and use the environment installation.
-Note that we typically don't want ``make clean`` to remake ``env.makefile``,
+
+Note that ``env/all`` is used as an order-only prerequisite, because it is
+generated as a phony target.
+
+Also note that we typically don't want ``make clean`` to remake ``env.makefile``,
 therefore the include is conditional.

--- a/lib/spack/docs/environments.rst
+++ b/lib/spack/docs/environments.rst
@@ -363,7 +363,7 @@ the Environment and then install the concretized specs.
       [myenv]$ spack install & spack install & spack install & spack install
 
    Another option is to generate a ``Makefile`` and run ``make -j<N>`` to control
-   the number of parallel spack install processes. See :ref:`env-generate-makefile`
+   the number of parallel install processes. See :ref:`env-generate-makefile`
    for details.
 
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -553,11 +553,14 @@ def env_generate_makefile(args):
 
     print("""SPACK ?= spack
 
+.PHONY: {} {}
+
 {}: {}
-\t@mkdir -p $(dir $@)
-\t@touch $@
-""".format(get_target('all'), ' '.join(
-        [get_target(s.dag_hash()) for _, s in env.concretized_specs()])))
+""".format(
+    get_target('all'),
+    get_target('clean'),
+    get_target('all'),
+    ' '.join([get_target(s.dag_hash()) for _, s in env.concretized_specs()])))
 
     # targets
     fmt = '{name}{@version}{%compiler}{variants}{arch=architecture}'
@@ -568,10 +571,9 @@ def env_generate_makefile(args):
         print("\t$(SPACK) -e '{}' install $(SPACK_INSTALL_FLAGS) --only-concrete "
               "--only=package --no-add /$(notdir $@) && touch $@\n".format(env.path))
 
-    print("{}:\n\trm -f -- {} {}".format(
+    print("{}:\n\trm -f -- {}".format(
         get_target('clean'),
-        ' '.join(get_target(t) for t in hash_to_deps_hashes.keys()),
-        get_target('all')))
+        ' '.join(get_target(t) for t in hash_to_deps_hashes.keys())))
 
 
 #: Dictionary mapping subcommand names and aliases to functions

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -551,16 +551,14 @@ def env_generate_makefile(args):
             hash_to_deps_hashes[s.dag_hash()] = ' '.join(
                 [get_target(dep.dag_hash()) for dep in s.dependencies()])
 
+    all_prereqs = ' '.join(get_target(s.dag_hash()) for _, s in env.concretized_specs())
+
     print("""SPACK ?= spack
 
 .PHONY: {} {}
 
 {}: {}
-""".format(
-    get_target('all'),
-    get_target('clean'),
-    get_target('all'),
-    ' '.join([get_target(s.dag_hash()) for _, s in env.concretized_specs()])))
+""".format(get_target('all'), get_target('clean'), get_target('all'), all_prereqs))
 
     # targets
     fmt = '{name}{@version}{%compiler}{variants}{arch=architecture}'

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -560,7 +560,7 @@ def env_depfile(args):
         # have /abs/path/to/env/metadir/{all,clean} targets. But it *does* make
         # sense to have a prefix like `env/all`, `env/fetch`, `env/clean` when they are
         # supposed to be included
-        if name in ('all', 'fetch', 'clean') and os.path.isabs(target_prefix):
+        if name in ('all', 'fetch-all', 'clean') and os.path.isabs(target_prefix):
             return name
         else:
             return os.path.join(target_prefix, name)
@@ -599,11 +599,11 @@ def env_depfile(args):
 {}: {}
 \t@mkdir -p $(dir $@) && touch $@
 
-""".format(get_target('all'), get_target('fetch'), get_target('clean'),
+""".format(get_target('all'), get_target('fetch-all'), get_target('clean'),
            get_target('all'), get_target('env'),
-           get_target('fetch'), get_target('do-fetch'),
+           get_target('fetch-all'), get_target('fetch'),
            get_target('env'), ' '.join(root_install_targets),
-           get_target('do-fetch'), ' '.join(all_fetch_targets)))
+           get_target('fetch'), ' '.join(all_fetch_targets)))
 
     # Targets are of the form <prefix>/<name>: [<prefix>/<depname>]...,
     # The prefix can be an empty string, in that case we don't add the `/`.
@@ -646,7 +646,7 @@ def env_depfile(args):
     buf.write("{}:\n\trm -f -- {} {} {} {}\n".format(
         get_target('clean'),
         get_target('env'),
-        get_target('do-fetch'),
+        get_target('fetch'),
         ' '.join(all_fetch_targets),
         ' '.join(all_install_targets)))
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -554,7 +554,14 @@ def env_depfile(args):
         target_prefix = args.make_target_prefix
 
     def get_target(name):
-        return os.path.join(target_prefix, name)
+        # The `all` and `clean` targets are phony. It doesn't make sense to have
+        # /abs/path/to/env/metadir/{all,clean} targets. But it *does* make
+        # sense to have a prefix like `env/all` and `env/clean` when they are
+        # supposed to be included
+        if (name == 'all' or name == 'clean') and os.path.isabs(target_prefix):
+            return name
+        else:
+            return os.path.join(target_prefix, name)
 
     for _, spec in env.concretized_specs():
         for s in spec.traverse(root=True):

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -560,7 +560,7 @@ def env_generate_makefile(args):
 {}: {}
 
 {}: {}
-\t@mkdir -p $(dir $@)
+\t@mkdir -p $(dir $@) && touch $@
 """.format(get_target('all'), get_target('clean'),
            get_target('all'), get_target('env'),
            get_target('env'), all_prereqs))

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -558,7 +558,12 @@ def env_generate_makefile(args):
 .PHONY: {} {}
 
 {}: {}
-""".format(get_target('all'), get_target('clean'), get_target('all'), all_prereqs))
+
+{}: {}
+\t@mkdir -p $(dir $@)
+""".format(get_target('all'), get_target('clean'),
+           get_target('all'), get_target('env'),
+           get_target('env'), all_prereqs))
 
     # targets
     fmt = '{name}{@version}{%compiler}{variants}{arch=architecture}'
@@ -569,8 +574,9 @@ def env_generate_makefile(args):
         print("\t$(SPACK) -e '{}' install $(SPACK_INSTALL_FLAGS) --only-concrete "
               "--only=package --no-add /$(notdir $@) && touch $@\n".format(env.path))
 
-    print("{}:\n\trm -f -- {}".format(
+    print("{}:\n\trm -f -- {} {}".format(
         get_target('clean'),
+        get_target('env'),
         ' '.join(get_target(t) for t in hash_to_deps_hashes.keys())))
 
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -597,7 +597,7 @@ def env_depfile(args):
         buf.write("{}: {}\n".format(get_target(parent), prereqs))
         buf.write("\t$(info Installing {})\n".format(hash_to_spec[parent].format(fmt)))
         buf.write("\t@mkdir -p $(dir $@)\n")
-        buf.write("\t$(SPACK) -e '{}' install $(SPACK_INSTALL_FLAGS) "
+        buf.write("\t+$(SPACK) -e '{}' install $(SPACK_INSTALL_FLAGS) "
                   "--only-concrete  --only=package --no-add /$(notdir $@) && "
                   "touch $@\n\n".format(env.path))
 

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -553,10 +553,10 @@ def env_generate_makefile(args):
 
     print("""SPACK ?= spack
 
-.PHONY: {}
-
 {}: {}
-""".format(get_target('all'), get_target('all'), ' '.join(
+\t@mkdir -p $(dir $@)
+\t@touch $@
+""".format(get_target('all'), ' '.join(
         [get_target(s.dag_hash()) for _, s in env.concretized_specs()])))
 
     # targets
@@ -568,9 +568,10 @@ def env_generate_makefile(args):
         print("\t$(SPACK) -e '{}' install $(SPACK_INSTALL_FLAGS) --only-concrete "
               "--only=package --no-add /$(notdir $@) && touch $@\n".format(env.path))
 
-    print("{}:\n\trm -f -- {}".format(
+    print("{}:\n\trm -f -- {} {}".format(
         get_target('clean'),
-        ' '.join(get_target(t) for t in hash_to_deps_hashes.keys())))
+        ' '.join(get_target(t) for t in hash_to_deps_hashes.keys()),
+        get_target('all')))
 
 
 #: Dictionary mapping subcommand names and aliases to functions

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -626,14 +626,13 @@ def setup_parser(subparser):
             aliases = []
 
         # add commands to subcommands dict
-        safe_name = name.replace('-', '_')
-        function_name = 'env_%s' % safe_name
+        function_name = 'env_%s' % name
         function = globals()[function_name]
         for alias in [name] + aliases:
             subcommand_functions[alias] = function
 
         # make a subparser and run the command's setup function on it
-        setup_parser_cmd_name = 'env_%s_setup_parser' % safe_name
+        setup_parser_cmd_name = 'env_%s_setup_parser' % name
         setup_parser_cmd = globals()[setup_parser_cmd_name]
 
         subsubparser = sp.add_parser(

--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -534,6 +534,9 @@ def env_depfile_setup_parser(subparser):
              'path to the directory makedeps under the environment metadata dir is '
              'used. Can be set to an empty string --make-target-prefix \'\'.')
     subparser.add_argument(
+        '--make-disable-jobserver', default=True, action='store_false',
+        dest='jobserver', help='disable POSIX jobserver support.')
+    subparser.add_argument(
         '-o', '--output', default=None, metavar='FILE',
         help='write the depfile to FILE rather than to stdout')
     subparser.add_argument(
@@ -565,23 +568,28 @@ def env_depfile(args):
         else:
             return os.path.join(target_prefix, name)
 
+    def get_install_target(name):
+        return os.path.join(target_prefix, '.install', name)
+
+    def get_fetch_target(name):
+        return os.path.join(target_prefix, '.fetch', name)
+
     for _, spec in env.concretized_specs():
         for s in spec.traverse(root=True):
             hash_to_spec[s.dag_hash()] = s
             hash_to_prereqs[s.dag_hash()] = [
-                get_target(dep.dag_hash()) for dep in s.dependencies()]
+                get_install_target(dep.dag_hash()) for dep in s.dependencies()]
 
     root_dags = [s.dag_hash() for _, s in env.concretized_specs()]
 
     # Root specs without deps are the prereqs for the environment target
-    root_install_targets = [get_target(dag) for dag in root_dags]
+    root_install_targets = [get_install_target(h) for h in root_dags]
 
     # All package install targets, not just roots.
-    all_install_targets = [get_target(dag) for dag in hash_to_spec.keys()]
+    all_install_targets = [get_install_target(h) for h in hash_to_spec.keys()]
 
     # Fetch targets for all packages in the environment, not just roots.
-    all_fetch_targets = [
-        get_target(os.path.join('fetch', dag)) for dag in hash_to_spec.keys()]
+    all_fetch_targets = [get_fetch_target(h) for h in hash_to_spec.keys()]
 
     buf = six.StringIO()
 
@@ -594,16 +602,33 @@ def env_depfile(args):
 {}: {}
 
 {}: {}
-\t@mkdir -p $(dir $@) && touch $@
+\t@touch $@
 
 {}: {}
-\t@mkdir -p $(dir $@) && touch $@
+\t@touch $@
+
+{}:
+\t@mkdir -p {} {}
+
+{}: | {}
+\t$(info Fetching $(SPEC))
+\t$(SPACK) -e '{}' fetch $(SPACK_FETCH_FLAGS) /$(notdir $@) && touch $@
+
+{}: {}
+\t$(info Installing $(SPEC))
+\t{}$(SPACK) -e '{}' install $(SPACK_INSTALL_FLAGS) --only-concrete --only=package \
+--no-add /$(notdir $@) && touch $@
 
 """.format(get_target('all'), get_target('fetch-all'), get_target('clean'),
            get_target('all'), get_target('env'),
            get_target('fetch-all'), get_target('fetch'),
            get_target('env'), ' '.join(root_install_targets),
-           get_target('fetch'), ' '.join(all_fetch_targets)))
+           get_target('fetch'), ' '.join(all_fetch_targets),
+           get_target('dirs'), get_target('.fetch'), get_target('.install'),
+           get_target('.fetch/%'), get_target('dirs'),
+           env.path,
+           get_target('.install/%'), get_target('.fetch/%'),
+           '+' if args.jobserver else '', env.path))
 
     # Targets are of the form <prefix>/<name>: [<prefix>/<depname>]...,
     # The prefix can be an empty string, in that case we don't add the `/`.
@@ -613,31 +638,20 @@ def env_depfile(args):
     # this.
     fmt = '{name}{@version}{%compiler}{variants}{arch=architecture}'
 
-    # Fetch targets: they don't need prereqs.
-    buf.write('\n# Fetch targets\n\n')
+    # Set SPEC for each hash
+    buf.write('# Set the human-readable spec for each target\n')
     for dag_hash in hash_to_prereqs.keys():
-        fetch_tgt = '{}'.format(get_target(os.path.join('fetch', dag_hash)))
         formatted_spec = hash_to_spec[dag_hash].format(fmt)
+        buf.write("{}: SPEC = {}\n".format(get_target('%/' + dag_hash), formatted_spec))
+    buf.write('\n')
 
-        # Fetch target for this spec, doesn't need prereqs.
-        buf.write("{}:\n".format(fetch_tgt))
-        buf.write("\t$(info Fetching {})\n".format(formatted_spec))
-        buf.write("\t@mkdir -p $(dir $@)\n")
-        buf.write("\t$(SPACK) -e '{}' fetch $(SPACK_FETCH_FLAGS) /$(notdir $@) && "
-                  "touch $@\n\n".format(env.path))
-
-    # Installing targets: they need package deps as prereqs & their own sources.
-    buf.write('\n# Install targets\n\n')
-    for parent, prereqs in hash_to_prereqs.items():
-        fetch_tgt = '{}'.format(get_target(os.path.join('fetch', parent)))
-        formatted_spec = hash_to_spec[parent].format(fmt)
-        buf.write("{}: {} {}\n".format(
-            get_target(parent), fetch_tgt, ' '.join(prereqs)))
-        buf.write("\t$(info Installing {})\n".format(formatted_spec))
-        buf.write("\t@mkdir -p $(dir $@)\n")
-        buf.write("\t+$(SPACK) -e '{}' install $(SPACK_INSTALL_FLAGS) "
-                  "--only-concrete  --only=package --no-add /$(notdir $@) && "
-                  "touch $@\n\n".format(env.path))
+    # Set install dependencies
+    buf.write('# Install dependencies\n')
+    for parent, children in hash_to_prereqs.items():
+        if not children:
+            continue
+        buf.write('{}: {}\n'.format(get_install_target(parent), ' '.join(children)))
+    buf.write('\n')
 
     # Clean target: remove target files but not their folders, cause
     # --make-target-prefix can be any existing directory we do not control,

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -20,6 +20,7 @@ import spack.fetch_strategy
 import spack.monitor
 import spack.paths
 import spack.report
+import spack.spec
 from spack.error import SpackError
 from spack.installer import PackageInstaller
 

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -20,7 +20,6 @@ import spack.fetch_strategy
 import spack.monitor
 import spack.paths
 import spack.report
-import spack.spec
 from spack.error import SpackError
 from spack.installer import PackageInstaller
 

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2859,20 +2859,22 @@ def test_environment_query_spec_by_hash(mock_stage, mock_fetch, install_mockery)
         assert e.matching_spec('libelf').installed
 
 
-def test_environment_depfile_makefile(tmpdir, mock_packages):
+def test_environment_depfile_makefile(mock_packages):
     env('create', 'test')
-    makefile_path = str(tmpdir.join('Makefile'))
     with ev.read('test'):
         add('libdwarf')
         concretize()
-    with ev.read('test'):
-        env('depfile', '-o', makefile_path)
-        make = Executable('make')
-        # do a dry run
-        make_output = make('-C', str(tmpdir), '-n', output=str)
-        assert 'Installing libelf' in make_output
-        assert 'Installing libdwarf' in make_output
+    with ev.read('test') as e:
+        makefile_1 = env('depfile')
+        assert e.env_subdir_path in makefile_1
+        assert 'Installing libelf' in makefile_1
+        assert 'Installing libdwarf' in makefile_1
 
+        makefile_2 = env('depfile', '--make-target-prefix', 'some_prefix')
+        assert not e.env_subdir_path in makefile_2
+        assert 'some_prefix' in makefile_2
+        assert 'Installing libelf' in makefile_2
+        assert 'Installing libdwarf' in makefile_2
 
 def test_environment_depfile_out(tmpdir, mock_packages):
     env('create', 'test')

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -25,7 +25,6 @@ from spack.cmd.env import _env_create
 from spack.main import SpackCommand, SpackCommandError
 from spack.spec import Spec
 from spack.stage import stage_prefix
-from spack.util.executable import Executable
 from spack.util.mock_package import MockPackageMultiRepo
 from spack.util.path import substitute_path_variables
 
@@ -2871,10 +2870,11 @@ def test_environment_depfile_makefile(mock_packages):
         assert 'Installing libdwarf' in makefile_1
 
         makefile_2 = env('depfile', '--make-target-prefix', 'some_prefix')
-        assert not e.env_subdir_path in makefile_2
+        assert e.env_subdir_path not in makefile_2
         assert 'some_prefix' in makefile_2
         assert 'Installing libelf' in makefile_2
         assert 'Installing libdwarf' in makefile_2
+
 
 def test_environment_depfile_out(tmpdir, mock_packages):
     env('create', 'test')

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -912,7 +912,7 @@ _spack_env() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="activate deactivate create remove rm list ls status st loads view update revert"
+        SPACK_COMPREPLY="activate deactivate create remove rm list ls status st loads view update revert generate-makefile"
     fi
 }
 
@@ -1001,6 +1001,10 @@ _spack_env_revert() {
     else
         _environments
     fi
+}
+
+_spack_env_generate_makefile() {
+    SPACK_COMPREPLY="-h --help"
 }
 
 _spack_extensions() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -912,7 +912,7 @@ _spack_env() {
     then
         SPACK_COMPREPLY="-h --help"
     else
-        SPACK_COMPREPLY="activate deactivate create remove rm list ls status st loads view update revert generate-makefile"
+        SPACK_COMPREPLY="activate deactivate create remove rm list ls status st loads view update revert depfile"
     fi
 }
 
@@ -1003,8 +1003,8 @@ _spack_env_revert() {
     fi
 }
 
-_spack_env_generate_makefile() {
-    SPACK_COMPREPLY="-h --help --target-prefix"
+_spack_env_depfile() {
+    SPACK_COMPREPLY="-h --help --make-target-prefix -o --output -G --generator"
 }
 
 _spack_extensions() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1004,7 +1004,7 @@ _spack_env_revert() {
 }
 
 _spack_env_generate_makefile() {
-    SPACK_COMPREPLY="-h --help"
+    SPACK_COMPREPLY="-h --help --target-prefix"
 }
 
 _spack_extensions() {

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -1004,7 +1004,7 @@ _spack_env_revert() {
 }
 
 _spack_env_depfile() {
-    SPACK_COMPREPLY="-h --help --make-target-prefix -o --output -G --generator"
+    SPACK_COMPREPLY="-h --help --make-target-prefix --make-disable-jobserver -o --output -G --generator"
 }
 
 _spack_extensions() {


### PR DESCRIPTION
`make` solves a lot of headaches that would otherwise have to be implemented in Spack:

1. Parallelism over packages through multiple `spack install` processes
2. Orderly output of parallel package installs thanks to `make --sync-output=recurse` or `make -Orecurse` (works well in GNU Make 4.3; macOS is unfortunately on a 16 years old 3.x version, but it's one `spack install gmake` away...)
3. Shared jobserver across packages, which means a single `-j` to rule them all, instead of manually finding a balance between `#spack install processes` & `#jobs per package` (See #30302).

This pr adds the `spack env depfile` command that generates a Makefile with dag hashes as
targets, and dag hashes of dependencies as prerequisites, and a command
along the lines of `spack install --only=packages /hash` to just install
a single package.

It exposes two convenient phony targets: `all`, `fetch-all`. The former installs the environment, the latter just fetches all sources. So one can either use `make all -j16` directly or run `make fetch-all -j16` on a login node and `make all -j16` on a compute node. 

Example:

```yaml
spack:
  specs: [perl]
  view: false
```

running

```
$ spack -e . env depfile --make-target-prefix env | tee Makefile
```
generates

```Makefile
SPACK ?= spack

.PHONY: env/all env/fetch-all env/clean

env/all: env/env

env/fetch-all: env/fetch

env/env: env/.install/cdqldivylyxocqymwnfzmzc5sx2zwvww
	@touch $@

env/fetch: env/.fetch/cdqldivylyxocqymwnfzmzc5sx2zwvww env/.fetch/gv5kin2xnn33uxyfte6k4a3bynhmtxze env/.fetch/cuymc7e5gupwyu7vza5d4vrbuslk277p env/.fetch/7vangk4jvsdgw6u6oe6ob63pyjl5cbgk env/.fetch/hyb7ehxxyqqp2hiw56bzm5ampkw6cxws env/.fetch/yfz2agazed7ohevqvnrmm7jfkmsgwjao env/.fetch/73t7ndb5w72hrat5hsax4caox2sgumzu env/.fetch/trvdyncxzfozxofpm3cwgq4vecpxixzs env/.fetch/sbzszb7v557ohyd6c2ekirx2t3ctxfxp env/.fetch/c4go4gxlcznh5p5nklpjm644epuh3pzc
	@touch $@

env/dirs:
	@mkdir -p env/.fetch env/.install

env/.fetch/%: | env/dirs
	$(info Fetching $(SPEC))
	$(SPACK) -e '/tmp/tmp.7PHPSIRACv' fetch $(SPACK_FETCH_FLAGS) /$(notdir $@) && touch $@

env/.install/%: env/.fetch/%
	$(info Installing $(SPEC))
	+$(SPACK) -e '/tmp/tmp.7PHPSIRACv' install $(SPACK_INSTALL_FLAGS) --only-concrete --only=package --no-add /$(notdir $@) && touch $@

# Set the human-readable spec for each target
env/%/cdqldivylyxocqymwnfzmzc5sx2zwvww: SPEC = perl@5.34.1%gcc@10.3.0+cpanm+shared+threads arch=linux-ubuntu20.04-zen2
env/%/gv5kin2xnn33uxyfte6k4a3bynhmtxze: SPEC = berkeley-db@18.1.40%gcc@10.3.0+cxx~docs+stl patches=b231fcc arch=linux-ubuntu20.04-zen2
env/%/cuymc7e5gupwyu7vza5d4vrbuslk277p: SPEC = bzip2@1.0.8%gcc@10.3.0~debug~pic+shared arch=linux-ubuntu20.04-zen2
env/%/7vangk4jvsdgw6u6oe6ob63pyjl5cbgk: SPEC = diffutils@3.8%gcc@10.3.0 arch=linux-ubuntu20.04-zen2
env/%/hyb7ehxxyqqp2hiw56bzm5ampkw6cxws: SPEC = libiconv@1.16%gcc@10.3.0 libs=shared,static arch=linux-ubuntu20.04-zen2
env/%/yfz2agazed7ohevqvnrmm7jfkmsgwjao: SPEC = gdbm@1.19%gcc@10.3.0 arch=linux-ubuntu20.04-zen2
env/%/73t7ndb5w72hrat5hsax4caox2sgumzu: SPEC = readline@8.1%gcc@10.3.0 arch=linux-ubuntu20.04-zen2
env/%/trvdyncxzfozxofpm3cwgq4vecpxixzs: SPEC = ncurses@6.2%gcc@10.3.0~symlinks+termlib abi=none arch=linux-ubuntu20.04-zen2
env/%/sbzszb7v557ohyd6c2ekirx2t3ctxfxp: SPEC = pkgconf@1.8.0%gcc@10.3.0 arch=linux-ubuntu20.04-zen2
env/%/c4go4gxlcznh5p5nklpjm644epuh3pzc: SPEC = zlib@1.2.12%gcc@10.3.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu20.04-zen2

# Install dependencies
env/.install/cdqldivylyxocqymwnfzmzc5sx2zwvww: env/.install/gv5kin2xnn33uxyfte6k4a3bynhmtxze env/.install/cuymc7e5gupwyu7vza5d4vrbuslk277p env/.install/yfz2agazed7ohevqvnrmm7jfkmsgwjao env/.install/c4go4gxlcznh5p5nklpjm644epuh3pzc
env/.install/cuymc7e5gupwyu7vza5d4vrbuslk277p: env/.install/7vangk4jvsdgw6u6oe6ob63pyjl5cbgk
env/.install/7vangk4jvsdgw6u6oe6ob63pyjl5cbgk: env/.install/hyb7ehxxyqqp2hiw56bzm5ampkw6cxws
env/.install/yfz2agazed7ohevqvnrmm7jfkmsgwjao: env/.install/73t7ndb5w72hrat5hsax4caox2sgumzu
env/.install/73t7ndb5w72hrat5hsax4caox2sgumzu: env/.install/trvdyncxzfozxofpm3cwgq4vecpxixzs
env/.install/trvdyncxzfozxofpm3cwgq4vecpxixzs: env/.install/sbzszb7v557ohyd6c2ekirx2t3ctxfxp

env/clean:
	rm -f -- env/env env/fetch env/.fetch/cdqldivylyxocqymwnfzmzc5sx2zwvww env/.fetch/gv5kin2xnn33uxyfte6k4a3bynhmtxze env/.fetch/cuymc7e5gupwyu7vza5d4vrbuslk277p env/.fetch/7vangk4jvsdgw6u6oe6ob63pyjl5cbgk env/.fetch/hyb7ehxxyqqp2hiw56bzm5ampkw6cxws env/.fetch/yfz2agazed7ohevqvnrmm7jfkmsgwjao env/.fetch/73t7ndb5w72hrat5hsax4caox2sgumzu env/.fetch/trvdyncxzfozxofpm3cwgq4vecpxixzs env/.fetch/sbzszb7v557ohyd6c2ekirx2t3ctxfxp env/.fetch/c4go4gxlcznh5p5nklpjm644epuh3pzc env/.install/cdqldivylyxocqymwnfzmzc5sx2zwvww env/.install/gv5kin2xnn33uxyfte6k4a3bynhmtxze env/.install/cuymc7e5gupwyu7vza5d4vrbuslk277p env/.install/7vangk4jvsdgw6u6oe6ob63pyjl5cbgk env/.install/hyb7ehxxyqqp2hiw56bzm5ampkw6cxws env/.install/yfz2agazed7ohevqvnrmm7jfkmsgwjao env/.install/73t7ndb5w72hrat5hsax4caox2sgumzu env/.install/trvdyncxzfozxofpm3cwgq4vecpxixzs env/.install/sbzszb7v557ohyd6c2ekirx2t3ctxfxp env/.install/c4go4gxlcznh5p5nklpjm644epuh3pzc
```

Then with `make -O` you get very nice orderly output when packages are built in parallel:
```console
$ make -Orecurse -j16
spack -e . install --only-concrete --only=package /c4go4gxlcznh5p5nklpjm644epuh3pzc && touch c4go4gxlcznh5p5nklpjm644epuh3pzc
==> Installing zlib-1.2.12-c4go4gxlcznh5p5nklpjm644epuh3pzc
...
  Fetch: 0.00s.  Build: 0.88s.  Total: 0.88s.
[+] /tmp/tmp.b1eTyAOe85/store/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.12-c4go4gxlcznh5p5nklpjm644epuh3pzc
spack -e . install --only-concrete --only=package /sbzszb7v557ohyd6c2ekirx2t3ctxfxp && touch sbzszb7v557ohyd6c2ekirx2t3ctxfxp
==> Installing pkgconf-1.8.0-sbzszb7v557ohyd6c2ekirx2t3ctxfxp
...
  Fetch: 0.00s.  Build: 3.96s.  Total: 3.96s.
[+] /tmp/tmp.b1eTyAOe85/store/linux-ubuntu20.04-zen2/gcc-10.3.0/pkgconf-1.8.0-sbzszb7v557ohyd6c2ekirx2t3ctxfxp
```

For Perl, at least for me, using `make -j16` versus `spack -e . install -j16` speeds up the builds from 3m32.623s to 2m22.775s, as some configure scripts run in parallel.

Another nice feature is you can do Makefile "metaprogramming" and depend on packages built by Spack. This example fetches all sources (in parallel) first, print a message, and only then build packages (in parallel).

```Makefile
SPACK ?= spack

.PHONY: env

all: env

spack.lock: spack.yaml
	$(SPACK) -e . concretize -f

env.mk: spack.lock
	$(SPACK) -e . env depfile -o $@ --make-target-prefix spack

fetch: spack/fetch
	@echo Fetched all packages && touch $@

env: fetch spack/env
	@echo This executes after the environment has been installed

clean:
	rm -rf spack/ env.mk spack.lock

ifeq (,$(filter clean,$(MAKECMDGOALS)))
include env.mk
endif
```

Idea by @trws, thanks!