### PR TITLE
mpich: Add datatype engine variant

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -104,7 +104,7 @@ with '-Wl,-commons,use_dylibs' and without
     variant(
         'datatype-engine',
         default='auto',
-        description='''controls the datatype engine to use''',
+        description='controls the datatype engine to use',
         values=('dataloop', 'yaksa', 'auto'),
         when='@3.4:',
         multi=False

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -101,6 +101,19 @@ with '-Wl,-commons,use_dylibs' and without
                         'communications. Set MPIR_CVAR_CH4_NUM_VCIS=<N> to '
                         'enable multiple vcis at runtime.')
 
+    variant(
+        'datatype-engine',
+        default='auto',
+        description='''controls the datatype engine to use''',
+        values=('dataloop', 'yaksa', 'auto'),
+        when='@3.4:',
+        multi=False
+    )
+    depends_on('yaksa', when='@4.0: device=ch4 datatype-engine=auto')
+    depends_on('yaksa', when='@4.0: device=ch4 datatype-engine=yaksa')
+    depends_on('yaksa+cuda', when='+cuda ^yaksa')
+    conflicts('datatype-engine=yaksa', when='device=ch3')
+
     # Todo: cuda can be a conditional variant, but it does not seem to work when
     # overriding the variant from CudaPackage.
     conflicts('+cuda', when='@:3.3')
@@ -454,7 +467,9 @@ with '-Wl,-commons,use_dylibs' and without
             '--{0}-romio'.format('enable' if '+romio' in spec else 'disable'),
             '--{0}-ibverbs'.format('with' if '+verbs' in spec else 'without'),
             '--enable-wrapper-rpath={0}'.format('no' if '~wrapperrpath' in
-                                                spec else 'yes')
+                                                spec else 'yes'),
+            '--with-yaksa={0}'.format(
+                spec['yaksa'].prefix if '^yaksa' in spec else 'embedded'),
         ]
 
         if '~fortran' in spec:
@@ -527,6 +542,13 @@ with '-Wl,-commons,use_dylibs' and without
         if '+vci' in spec:
             config_args.append('--enable-thread-cs=per-vci')
             config_args.append('--with-ch4-max-vcis=default')
+
+        if 'datatype-engine=yaksa' in spec:
+            config_args.append('--with-datatype-engine=yaksa')
+        elif 'datatype-engine=dataloop' in spec:
+            config_args.append('--with-datatype-engine=dataloop')
+        elif 'datatype-engine=auto' in spec:
+            config_args.append('--with-datatye-engine=auto')
 
         return config_args
 


### PR DESCRIPTION
Starting with MPICH 3.4, we offer different datatype engine options
(dataloop or yaksa). The default is 'auto', which will choose based on
the device configuration. Starting with MPICH 4.0, building against an
external yaksa library is supported.