### PR TITLE
exago +cuda, +rocm: pass amdgpu_target, cuda_arch to dependencies, as appropriate

### DIFF
--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -47,18 +47,12 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('cuda', when='+cuda')
     depends_on('raja', when='+raja')
 
-    depends_on('raja+cuda', when='+raja+cuda')
     depends_on('raja@0.14.0:', when='@1.1.0: +raja')
     depends_on('umpire', when='+raja')
     depends_on('umpire@6.0.0:', when='@1.1.0: +raja')
 
     # Some allocator code in Umpire only works with static libs
     depends_on('umpire+cuda~shared', when='+raja+cuda')
-
-    # For some versions of RAJA package, camp cuda variant does not get set
-    # correctly, so we must explicitly depend on it even though we don't use
-    # camp
-    depends_on('camp+cuda', when='+raja+cuda')
 
     depends_on('cmake@3.18:', type='build')
 
@@ -68,13 +62,22 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('hiop@0.5.1:', when='@1.1.0:+hiop')
     depends_on('hiop@0.5.3:', when='@1.3.0:+hiop')
 
-    depends_on('hiop+cuda', when='+hiop+cuda')
     depends_on('hiop~mpi', when='+hiop~mpi')
     depends_on('hiop+mpi', when='+hiop+mpi')
 
     depends_on('petsc@3.13:3.14', when='@:1.2.99')
     depends_on('petsc@3.16.0:3.16', when='@1.3.0:')
     depends_on('petsc~mpi', when='~mpi')
+
+    for arch in CudaPackage.cuda_arch_values:
+        cuda_dep = "+cuda cuda_arch={0}".format(arch)
+        depends_on("hiop {0}".format(cuda_dep), when=cuda_dep)
+        depends_on("raja {0}".format(cuda_dep), when="+raja {0}".format(cuda_dep))
+
+        # For some versions of RAJA package, camp cuda variant does not get set
+        # correctly, so we must explicitly depend on it even though we don't use
+        # camp
+        depends_on("camp {0}".format(cuda_dep), when="+raja {0}".format(cuda_dep))
 
     for arch in ROCmPackage.amdgpu_targets:
         rocm_dep = "+rocm amdgpu_target={0}".format(arch)

--- a/var/spack/repos/builtin/packages/exago/package.py
+++ b/var/spack/repos/builtin/packages/exago/package.py
@@ -48,7 +48,6 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('raja', when='+raja')
 
     depends_on('raja+cuda', when='+raja+cuda')
-    depends_on('raja+rocm', when='+raja+rocm')
     depends_on('raja@0.14.0:', when='@1.1.0: +raja')
     depends_on('umpire', when='+raja')
     depends_on('umpire@6.0.0:', when='@1.1.0: +raja')
@@ -70,13 +69,17 @@ class Exago(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('hiop@0.5.3:', when='@1.3.0:+hiop')
 
     depends_on('hiop+cuda', when='+hiop+cuda')
-    depends_on('hiop+rocm', when='+hiop+rocm')
     depends_on('hiop~mpi', when='+hiop~mpi')
     depends_on('hiop+mpi', when='+hiop+mpi')
 
     depends_on('petsc@3.13:3.14', when='@:1.2.99')
     depends_on('petsc@3.16.0:3.16', when='@1.3.0:')
     depends_on('petsc~mpi', when='~mpi')
+
+    for arch in ROCmPackage.amdgpu_targets:
+        rocm_dep = "+rocm amdgpu_target={0}".format(arch)
+        depends_on("hiop {0}".format(rocm_dep), when=rocm_dep)
+        depends_on("raja {0}".format(rocm_dep), when="+raja {0}".format(rocm_dep))
 
     depends_on('ipopt', when='+ipopt')
 

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -65,7 +65,11 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('mpi', when='+mpi')
 
-    depends_on('magma+cuda', when='+cuda')
+    for arch in CudaPackage.cuda_arch_values:
+        cuda_dep = "+cuda cuda_arch={0}".format(arch)
+        depends_on("magma {0}".format(cuda_dep), when=cuda_dep)
+        depends_on("raja {0}".format(cuda_dep), when="+raja {0}".format(cuda_dep))
+        depends_on("umpire ~shared {0}".format(cuda_dep), when="+raja {0}".format(cuda_dep))
 
     for arch in ROCmPackage.amdgpu_targets:
         rocm_dep = "+rocm amdgpu_target={0}".format(arch)
@@ -73,12 +77,13 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("raja {0}".format(rocm_dep), when="+raja {0}".format(rocm_dep))
         depends_on("umpire {0}".format(rocm_dep), when="+raja {0}".format(rocm_dep))
 
-    # Depends on Magma when +rocm or +cuda
     magma_ver_constraints = (
         ('2.5.4', '0.4'),
         ('2.6.1', '0.4.6'),
         ('2.6.2', '0.5.4'),
     )
+
+    # Depends on Magma when +rocm or +cuda
     for (magma_v, hiop_v) in magma_ver_constraints:
         depends_on('magma@{0}:'.format(magma_v), when='@{0}:+cuda'.format(hiop_v))
         depends_on('magma@{0}:'.format(magma_v), when='@{0}:+rocm'.format(hiop_v))
@@ -86,9 +91,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('raja', when='+raja')
     depends_on('raja+openmp', when='+raja~cuda~rocm')
     depends_on('raja@0.14.0:', when='@0.5.0:+raja')
-    depends_on('raja+cuda', when='+raja+cuda')
     depends_on('umpire', when='+raja')
-    depends_on('umpire+cuda~shared', when='+raja+cuda')
     depends_on('umpire@6.0.0:', when='@0.5.0:+raja')
     depends_on('hip', when='+rocm')
     depends_on('hipblas', when='+rocm')


### PR DESCRIPTION
Same logic as https://github.com/spack/spack/pull/30184 but applied to `exago +rocm` and `exago +cuda` dependencies

And for `hiop +cuda` pass `cuda_arch` to dependencies

@CameronRutherford @ashermancinelli 