### PR TITLE
syntax fix

### DIFF
--- a/var/spack/repos/builtin/packages/pgplot/package.py
+++ b/var/spack/repos/builtin/packages/pgplot/package.py
@@ -57,6 +57,7 @@ class Pgplot(MakefilePackage):
         if '+png' in spec:
             libs += ' ' + self.spec['libpng'].libs.ld_flags
 
+        sub = {}
         if spec.satisfies('%gcc'):
             fib = " -fallow-invalid-boz" if spec.satisfies('%gcc@10:') else ""
 


### PR DESCRIPTION
If use a compiler other than 'gcc' and 'intel', the syntax error will turn out at line 120 in package.py.
"UnboundLocalError: local variable 'sub' referenced before assignment"