### PR TITLE
bugfix: `installed` and `installed_upstream` should not assert

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1197,7 +1197,6 @@ class Spec(object):
         self._package_hash = None
         self._dunder_hash = None
         self._package = None
-        self._installed_upstream = None
 
         # Most of these are internal implementation details that can be
         # set by internal Spack calls in the constructor.
@@ -1562,8 +1561,9 @@ class Spec(object):
         Returns:
             True if the package has been installed, False otherwise.
         """
-        msg = "a spec must be concrete to be queried for installation status"
-        assert self.concrete, msg
+        if not self.concrete:
+            return False
+
         try:
             # If the spec is in the DB, check the installed
             # attribute of the record
@@ -1575,12 +1575,16 @@ class Spec(object):
 
     @property
     def installed_upstream(self):
-        msg = "a spec must be concrete to be queried for installation status"
-        assert self.concrete, msg
-        if getattr(self, '_installed_upstream', None) is None:
-            upstream, _ = spack.store.db.query_by_spec_hash(self.dag_hash())
-            self._installed_upstream = upstream
-        return self._installed_upstream
+        """Whether the spec is installed in an upstream repository.
+
+        Returns:
+            True if the package is installed in an upstream, False otherwise.
+        """
+        if not self.concrete:
+            return False
+
+        upstream, _ = spack.store.db.query_by_spec_hash(self.dag_hash())
+        return upstream
 
     def traverse(self, **kwargs):
         direction = kwargs.get('direction', 'children')

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -284,7 +284,7 @@ def test_check_last_phase_error(install_mockery):
     assert pkg.last_phase in err
 
 
-def test_installer_ensure_ready_errors(install_mockery):
+def test_installer_ensure_ready_errors(install_mockery, monkeypatch):
     const_arg = installer_args(['trivial-install-test-package'], {})
     installer = create_installer(const_arg)
     spec = installer.build_requests[0].pkg.spec
@@ -300,14 +300,14 @@ def test_installer_ensure_ready_errors(install_mockery):
 
     # Force an upstream package error
     spec.external_path, spec.external_modules = path, modules
-    spec._installed_upstream = True
+    monkeypatch.setattr(spack.spec.Spec, "installed_upstream", True)
     msg = fmt.format('is upstream')
     with pytest.raises(inst.UpstreamPackageError, match=msg):
         installer._ensure_install_ready(spec.package)
 
     # Force an install lock error, which should occur naturally since
     # we are calling an internal method prior to any lock-related setup
-    spec._installed_upstream = False
+    monkeypatch.setattr(spack.spec.Spec, "installed_upstream", False)
     assert len(installer.locks) == 0
     with pytest.raises(inst.InstallLockError, match=fmt.format('not locked')):
         installer._ensure_install_ready(spec.package)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1258,3 +1258,20 @@ def test_merge_anonymous_spec_with_named_spec(anonymous, named, expected):
     changed = s.constrain(named)
     assert changed
     assert s == Spec(expected)
+
+
+def test_spec_installed(install_mockery, database):
+    """Test whether Spec.installed works."""
+    # a known installed spec should say that it's installed
+    specs = database.query()
+    spec = specs[0]
+    assert spec.installed
+    assert spec.copy().installed
+
+    # an abstract spec should say it's not installed
+    spec = Spec("not-a-real-package")
+    assert not spec.installed
+
+    # 'a' is not in the mock DB and is not installed
+    spec = Spec("a").concretized()
+    assert not spec.installed


### PR DESCRIPTION
Fix bug introduced in #30191. `Spec.installed` and `Spec.installed_upstream` should just return `False` for abstract specs, as they can be called in that context.

- [x] `Spec.installed` returns `False` now instead of asserting that the `Spec` is concrete.
- [x] `Spec.installed_upstream` returns `False` now instead of asserting that the `Spec` is concrete.
- [x] `Spec.installed_upstream` no longer caches its result, as install status seems like a bad thing to cache -- it can easily be invalidated. Calling code should use transactions if there are peformance issues, as with other places in Spack.
- [x] add tests for `Spec.installed` and `Spec.installed_upstream`