### PR TITLE
Make esmf build when using hpcx-mpi

### DIFF
--- a/var/spack/repos/builtin/packages/esmf/package.py
+++ b/var/spack/repos/builtin/packages/esmf/package.py
@@ -190,7 +190,8 @@ class Esmf(MakefilePackage):
                 # The mpich 3 series split apart the Fortran and C bindings,
                 # so we link the Fortran libraries when building C programs:
                 os.environ['ESMF_CXXLINKLIBS'] = '-lmpifort'
-            elif '^openmpi' in spec:
+            elif '^openmpi' in spec or \
+                 '^hpcx-mpi' in spec:
                 os.environ['ESMF_COMM'] = 'openmpi'
             elif '^intel-parallel-studio+mpi' in spec or \
                  '^intel-mpi' in spec or \


### PR DESCRIPTION
Add detection for hpcx-mpi in esmf.

Closes #30268 