### PR TITLE
change ofstream to fix deprecated boost::filesystem

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -45,6 +45,8 @@ class Gaudi(CMakePackage):
     # fixes for the cmake config which could not find newer boost versions
     patch("link_target_fixes.patch", when="@33.0:34")
     patch("link_target_fixes32.patch", when="@:32.2")
+    # remove use std::ofstream instead of deprecated boost::filesystem
+    patch("rm-boost-ofstream.patch", when="@34:")
 
     # These dependencies are needed for a minimal Gaudi build
     depends_on('aida')

--- a/var/spack/repos/builtin/packages/gaudi/rm-boost-ofstream.patch
+++ b/var/spack/repos/builtin/packages/gaudi/rm-boost-ofstream.patch
@@ -1,0 +1,22 @@
+diff --git a/GaudiHive/src/PRGraph/PrecedenceRulesGraph.cpp b/GaudiHive/src/PRGraph/PrecedenceRulesGraph.cpp
+index 0f013d0b6..97d5e135c 100644
+--- a/GaudiHive/src/PRGraph/PrecedenceRulesGraph.cpp
++++ b/GaudiHive/src/PRGraph/PrecedenceRulesGraph.cpp
+@@ -629,7 +629,7 @@ namespace concurrency {
+   //---------------------------------------------------------------------------
+ 
+   void PrecedenceRulesGraph::dumpPrecRules( const boost::filesystem::path& fileName, const EventSlot& slot ) {
+-    boost::filesystem::ofstream myfile;
++    std::ofstream myfile;
+     myfile.open( fileName, std::ios::app );
+ 
+     // Declare properties to dump
+@@ -670,7 +670,7 @@ namespace concurrency {
+ 
+   //---------------------------------------------------------------------------
+   void PrecedenceRulesGraph::dumpPrecTrace( const boost::filesystem::path& fileName, const EventSlot& slot ) {
+-    boost::filesystem::ofstream myfile;
++    std::ofstream myfile;
+     myfile.open( fileName, std::ios::app );
+ 
+     // Fill runtimes (as this could not be done on the fly during trace assembling)


### PR DESCRIPTION
Gaudi is failing with new boost::filesystem which has deprecated ofstream in 1.79

see https://github.com/prusa3d/PrusaSlicer/issues/8238

Should be fixed upstream, but I cannot log into the gitlab site for gaudi