### PR TITLE
exabayes: specify c++11

### DIFF
--- a/var/spack/repos/builtin/packages/exabayes/package.py
+++ b/var/spack/repos/builtin/packages/exabayes/package.py
@@ -35,3 +35,9 @@ class Exabayes(AutotoolsPackage):
         else:
             args.append('--disable-mpi')
         return args
+
+    def flag_handler(self, name, flags):
+        if name.lower() == 'cxxflags':
+            # manual cites need for c++11
+            flags.append(self.compiler.cxx11_flag)
+        return (flags, None, None)


### PR DESCRIPTION
gcc11 defaults to c++17, which causes build errors with this. The manual [specifies](https://cme.h-its.org/exelixis/web/software/exabayes/manual/index.html#comp-src) c++11, so it should be safe to do this across the board.