### PR TITLE
express: specify patch version range

### DIFF
--- a/var/spack/repos/builtin/packages/express/package.py
+++ b/var/spack/repos/builtin/packages/express/package.py
@@ -28,8 +28,8 @@ class Express(CMakePackage):
 
     # patch from the debian package repo:
     # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811859
-    patch('gcc-6.patch', when='%gcc@6.0.0:')
-    patch('gcc-6.patch', when='%fj')
+    patch('gcc-6.patch', when='@:1.5.2%gcc@6.0.0:')
+    patch('gcc-6.patch', when='@:1.5.2%fj')
 
     def patch(self):
         with working_dir('src'):


### PR DESCRIPTION
The gcc-6.patch [fix](https://github.com/adarob/eXpress/pull/19) was incorporated into the most recent release. Sorry, should have caught this with the last express PR.

