### PR TITLE
strip -Werror: all specific or none

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -401,7 +401,8 @@ input_command="$*"
 # command line and recombine them with Spack arguments later.  We
 # parse these out so that we can make sure that system paths come
 # last, that package arguments come first, and that Spack arguments
-# are injected properly.
+# are injected properly.  Based on configuration, we also strip -Werror
+# arguments.
 #
 # All other arguments, including -l arguments, are treated as
 # 'other_args' and left in their original order.  This ensures that
@@ -483,6 +484,25 @@ while [ $# -ne 0 ]; do
             arg="${1#-l}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             append other_args_list "-l$arg"
+            ;;
+        -Werror=*)
+            case "$SPACK_KEEP_WERROR" in
+                'all' | 'specific')
+                    echo keeping specific
+                    append other_args_list "$1"
+            esac
+            shift
+            continue
+            ;;
+        -Werror*)
+            if [ "$SPACK_KEEP_WERROR" = 'all' ] ; then
+                append other_args_list "$1"
+                    echo keeping all
+                else
+                    echo stripping "$1"
+            fi
+            shift
+            continue
             ;;
         -Wl,*)
             arg="${1#-Wl,}"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -442,6 +442,7 @@ while [ $# -ne 0 ]; do
     fi
 
     if [ -n "${SPACK_COMPILER_FLAGS_KEEP}" ] ; then
+        # NOTE: the eval is required to allow `|` alternatives inside the variable
         eval "\
         case '$1' in
             $SPACK_COMPILER_FLAGS_KEEP)

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -441,6 +441,21 @@ while [ $# -ne 0 ]; do
         continue
     fi
 
+    eval "\
+    case '$1' in
+        $SPACK_COMPILER_FLAGS_KEEP)
+            echo keeping "$1"
+            append other_args_list "$1"
+            shift
+            continue
+            ;;
+        $SPACK_COMPILER_FLAGS_REMOVE)
+            echo removing "$1"
+            shift
+            continue
+            ;;
+    esac
+    "
     case "$1" in
         -isystem*)
             arg="${1#-isystem}"

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -441,21 +441,28 @@ while [ $# -ne 0 ]; do
         continue
     fi
 
-    eval "\
-    case '$1' in
-        $SPACK_COMPILER_FLAGS_KEEP)
-            echo keeping "$1"
-            append other_args_list "$1"
-            shift
-            continue
-            ;;
-        $SPACK_COMPILER_FLAGS_REMOVE)
-            echo removing "$1"
-            shift
-            continue
-            ;;
-    esac
-    "
+    if [ -n "${SPACK_COMPILER_FLAGS_KEEP}" ] ; then
+        eval "\
+        case '$1' in
+            $SPACK_COMPILER_FLAGS_KEEP)
+                append other_args_list "$1"
+                shift
+                continue
+                ;;
+        esac
+        "
+    fi
+    if [ -n "${SPACK_COMPILER_FLAGS_REMOVE}" ] ; then
+        eval "\
+        case '$1' in
+            $SPACK_COMPILER_FLAGS_REMOVE)
+                shift
+                continue
+                ;;
+        esac
+        "
+    fi
+
     case "$1" in
         -isystem*)
             arg="${1#-isystem}"
@@ -499,25 +506,6 @@ while [ $# -ne 0 ]; do
             arg="${1#-l}"
             if [ -z "$arg" ]; then shift; arg="$1"; fi
             append other_args_list "-l$arg"
-            ;;
-        -Werror=*)
-            case "$SPACK_KEEP_WERROR" in
-                'all' | 'specific')
-                    echo keeping specific
-                    append other_args_list "$1"
-            esac
-            shift
-            continue
-            ;;
-        -Werror*)
-            if [ "$SPACK_KEEP_WERROR" = 'all' ] ; then
-                append other_args_list "$1"
-                    echo keeping all
-                else
-                    echo stripping "$1"
-            fi
-            shift
-            continue
             ;;
         -Wl,*)
             arg="${1#-Wl,}"

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -242,6 +242,8 @@ def clean_environment():
         # show useful matches.
         env.set('LC_ALL', build_lang)
 
+    env.set('SPACK_KEEP_WERROR', spack.config.get('config:flags:werror'))
+
     # Remove any macports installs from the PATH.  The macports ld can
     # cause conflicts with the built-in linker on el capitan.  Solves
     # assembler issues, e.g.:

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -242,7 +242,7 @@ def clean_environment():
         # show useful matches.
         env.set('LC_ALL', build_lang)
 
-    env.set('SPACK_KEEP_WERROR', spack.config.get('config:flags:werror'))
+    env.set('SPACK_KEEP_WERROR', spack.config.get('config:flags:keep_werror'))
 
     # Remove any macports installs from the PATH.  The macports ld can
     # cause conflicts with the built-in linker on el capitan.  Solves

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -242,7 +242,18 @@ def clean_environment():
         # show useful matches.
         env.set('LC_ALL', build_lang)
 
-    env.set('SPACK_KEEP_WERROR', spack.config.get('config:flags:keep_werror'))
+    remove_flags = set()
+    keep_flags = set()
+    if spack.config.get('config:flags:keep_werror') == 'all':
+        keep_flags.add('-Werror*')
+    else:
+        if spack.config.get('config:flags:keep_werror') == 'specific':
+            keep_flags.add('-Werror=*')
+        remove_flags.add('-Werror*')
+    keep_flags.add('-Some-flag*')
+    remove_flags.add('-bah*')
+    env.set('SPACK_COMPILER_FLAGS_KEEP', ' | '.join(keep_flags))
+    env.set('SPACK_COMPILER_FLAGS_REMOVE', ' | '.join(remove_flags))
 
     # Remove any macports installs from the PATH.  The macports ld can
     # cause conflicts with the built-in linker on el capitan.  Solves

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -250,8 +250,8 @@ def clean_environment():
         if spack.config.get('config:flags:keep_werror') == 'specific':
             keep_flags.add('-Werror=*')
         remove_flags.add('-Werror*')
-    env.set('SPACK_COMPILER_FLAGS_KEEP', ' | '.join(keep_flags))
-    env.set('SPACK_COMPILER_FLAGS_REMOVE', ' | '.join(remove_flags))
+    env.set('SPACK_COMPILER_FLAGS_KEEP', '|'.join(keep_flags))
+    env.set('SPACK_COMPILER_FLAGS_REMOVE', '|'.join(remove_flags))
 
     # Remove any macports installs from the PATH.  The macports ld can
     # cause conflicts with the built-in linker on el capitan.  Solves

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -250,8 +250,6 @@ def clean_environment():
         if spack.config.get('config:flags:keep_werror') == 'specific':
             keep_flags.add('-Werror=*')
         remove_flags.add('-Werror*')
-    keep_flags.add('-Some-flag*')
-    remove_flags.add('-bah*')
     env.set('SPACK_COMPILER_FLAGS_KEEP', ' | '.join(keep_flags))
     env.set('SPACK_COMPILER_FLAGS_REMOVE', ' | '.join(remove_flags))
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -105,6 +105,9 @@ config_defaults = {
         'build_stage': '$tempdir/spack-stage',
         'concretizer': 'clingo',
         'license_dir': spack.paths.default_license_dir,
+        'flags': {
+            'werror': 'none',
+        },
     }
 }
 

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -106,7 +106,7 @@ config_defaults = {
         'concretizer': 'clingo',
         'license_dir': spack.paths.default_license_dir,
         'flags': {
-            'werror': 'none',
+            'keep_werror': 'none',
         },
     }
 }

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -91,7 +91,13 @@ properties = {
             'additional_external_search_paths': {
                 'type': 'array',
                 'items': {'type': 'string'}
-            }
+            },
+            'flags': {
+                'type': 'object',
+                'properties': {
+                    'werror': { 'type': 'string', 'enum': ['all','specific','none'], },
+                },
+            },
         },
         'deprecatedProperties': {
             'properties': ['module_roots'],

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -95,7 +95,7 @@ properties = {
             'flags': {
                 'type': 'object',
                 'properties': {
-                    'werror': { 'type': 'string', 'enum': ['all','specific','none'], },
+                    'keep_werror': { 'type': 'string', 'enum': ['all','specific','none'], },
                 },
             },
         },

--- a/lib/spack/spack/schema/config.py
+++ b/lib/spack/spack/schema/config.py
@@ -95,7 +95,10 @@ properties = {
             'flags': {
                 'type': 'object',
                 'properties': {
-                    'keep_werror': { 'type': 'string', 'enum': ['all','specific','none'], },
+                    'keep_werror': {
+                        'type': 'string',
+                        'enum': ['all', 'specific', 'none'],
+                    },
                 },
             },
         },

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -14,9 +14,8 @@ import pytest
 
 import spack.build_environment
 import spack.config
-from spack.config import config
-from spack.paths import build_env_path
 import spack.spec
+from spack.paths import build_env_path
 from spack.util.environment import set_env, system_dirs
 from spack.util.executable import Executable, ProcessError
 
@@ -688,25 +687,26 @@ def test_keep_and_remove(wrapper_environment):
             werror + ["-llib1", "-Wl,--rpath"]
         )
 
+
 @pytest.mark.parametrize('cfg_override,initial,expected,must_be_gone', [
     # Set and unset variables
     ('config:flags:keep_werror:all',
-     ['-Werror','-Werror=specific', '-bah'],
-     ['-Werror','-Werror=specific', '-bah'],
+     ['-Werror', '-Werror=specific', '-bah'],
+     ['-Werror', '-Werror=specific', '-bah'],
      [],
      ),
     ('config:flags:keep_werror:specific',
-     ['-Werror','-Werror=specific', '-bah'],
+     ['-Werror', '-Werror=specific', '-bah'],
      ['-Werror=specific', '-bah'],
      ['-Werror'],
      ),
     ('config:flags:keep_werror:none',
-     ['-Werror','-Werror=specific', '-bah'],
+     ['-Werror', '-Werror=specific', '-bah'],
      ['-bah'],
-     ['-Werror','-Werror=specific'],
+     ['-Werror', '-Werror=specific'],
      ),
 ])
-@pytest.mark.usefixtures('wrapper_environment','mutable_config')
+@pytest.mark.usefixtures('wrapper_environment', 'mutable_config')
 def test_flag_modification(cfg_override, initial, expected, must_be_gone):
     spack.config.add(cfg_override)
     env = spack.build_environment.clean_environment()

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -131,8 +131,7 @@ def wrapper_environment():
             SPACK_DTAGS_TO_ADD='--disable-new-dtags',
             SPACK_DTAGS_TO_STRIP='--enable-new-dtags',
             SPACK_COMPILER_FLAGS_KEEP='',
-            SPACK_COMPILER_FLAGS_REMOVE='-Werror*',
-            ):
+            SPACK_COMPILER_FLAGS_REMOVE='-Werror*',):
         yield
 
 
@@ -679,7 +678,10 @@ def test_keep_and_remove(wrapper_environment):
             SPACK_COMPILER_FLAGS_REMOVE='-Werror*|-llib1|-Wl*',
     ):
         check_args_contents(
-            cc, test_args + werror_all, werror_specific, werror + ["-llib1", "-Wl,--rpath"]
+            cc,
+            test_args + werror_all,
+            werror_specific,
+            werror + ["-llib1", "-Wl,--rpath"]
         )
 
 

--- a/lib/spack/spack/test/cc.py
+++ b/lib/spack/spack/test/cc.py
@@ -688,23 +688,26 @@ def test_keep_and_remove(wrapper_environment):
             werror + ["-llib1", "-Wl,--rpath"]
         )
 
-@pytest.mark.parametrize('cfg_override,initial,expected', [
+@pytest.mark.parametrize('cfg_override,initial,expected,must_be_gone', [
     # Set and unset variables
     ('config:flags:keep_werror:all',
      ['-Werror','-Werror=specific', '-bah'],
      ['-Werror','-Werror=specific', '-bah'],
+     [],
      ),
     ('config:flags:keep_werror:specific',
      ['-Werror','-Werror=specific', '-bah'],
      ['-Werror=specific', '-bah'],
+     ['-Werror'],
      ),
     ('config:flags:keep_werror:none',
      ['-Werror','-Werror=specific', '-bah'],
      ['-bah'],
+     ['-Werror','-Werror=specific'],
      ),
 ])
 @pytest.mark.usefixtures('wrapper_environment','mutable_config')
-def test_flag_modification(cfg_override, initial, expected):
+def test_flag_modification(cfg_override, initial, expected, must_be_gone):
     spack.config.add(cfg_override)
     env = spack.build_environment.clean_environment()
     env.apply_modifications()
@@ -712,7 +715,7 @@ def test_flag_modification(cfg_override, initial, expected):
         cc,
         test_args + initial,
         expected,
-        []
+        must_be_gone
     )
 
 


### PR DESCRIPTION
Add a config option to strip `-Werror*` or `-Werror=*` from compile lines everywhere.

```yaml
config:
    keep_werror: false
```

By default, we strip all `-Werror` arguments out of compile lines, to avoid unwanted failures when upgrading compilers.  You can re-enable `-Werror` in your builds if you really want to, with either:

```yaml
config:
    keep_werror: all
```

or to keep *just* specific `-Werror=XXX` args:

```yaml
config:
    keep_werror: specific
```

This should make swapping in newer versions of compilers much smoother when maintainers have decided to enable `-Werror` by default.