### PR TITLE
Feature/gcta redo

### DIFF
--- a/var/spack/repos/builtin/packages/gcta/package.py
+++ b/var/spack/repos/builtin/packages/gcta/package.py
@@ -3,27 +3,89 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install gcta
+#
+# You can edit this file again by typing:
+#
+#     spack edit gcta
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
 from spack import *
 
 
-class Gcta(Package):
-
+class Gcta(CMakePackage):
     """GCTA (Genome-wide Complex Trait Analysis) was originally designed to
     estimate the proportion of phenotypic variance explained by all genome-wide
     SNPs for complex traits (the GREML method), and has subsequently extended
     for many other analyses to better understand the genetic architecture of
     complex traits. GCTA currently supports the following analyses."""
 
-    homepage = "https://cnsgenomics.com/software/gcta/#Overview"
-    url      = "http://cnsgenomics.com/software/gcta/gcta_1.91.2beta.zip"
+    homepage = "https://github.com/jianyangqt/gcta"
+    url      = "https://github.com/jianyangqt/gcta/archive/refs/tags/v1.91.2.tar.gz"
+    git      = "https://github.com/jianyangqt/gcta.git"
+    maintainers = ['snehring']
 
-    version('1.91.2beta_mac', 'ce0882ad35dd9474ffe40911da369274700af1ecb9916c0a355b7bad14850234')
-    version('1.91.2beta', '192efb767be1c7ca9c2dac5d2c2317a97c7a9db1f801168d19ad2a51b98d9b10', preferred=True)
+    version('1.94.0beta',  commit='746e3975ddb463fc7bd15b03c6cc64b023eca497', submodules=True)
+    version('1.91.2',      sha256='0609d0fba856599a2acc66adefe87725304117acc226360ec2aabf8a0ac64e85')
 
-    conflicts('@1.91.2beta', when='platform=darwin')
-    conflicts('@1.91.2beta_mac', when='platform=linux')
+    conflicts('target=aarch64:', when='@:1.91.2', msg='aarch64 support added in 1.94.0')
+
+    depends_on('cmake@3.1:', type='build')
+    depends_on('intel-mkl@2017:', type=('build', 'link'), when='target=x86_64:')
+    depends_on('openblas', type=('build', 'link'), when='target=aarch64:')
+    depends_on('eigen@3.3.1', type=('build', 'link'), when='@1.91.2')
+    depends_on('eigen@3.3.7:', type=('build', 'link'), when='@1.94.0beta:')
+    depends_on('boost@1.4:', type=('build', 'link'), when='@1.94.0beta:')
+    depends_on('zlib', type=('build', 'link'))
+    depends_on('sqlite@3.3.1:', type=('build', 'link'), when='@1.94.0beta:')
+    depends_on('zstd@1.4.4:', type=('build', 'link'), when='@1.94.0beta:')
+    depends_on('spectra', type=('build', 'link'), when='@1.94.0beta:')
+    depends_on('gsl', type=('build', 'link'), when='@1.94.0beta:')
+
+    def patch(self):
+        # allow us to specify the locations with cmake_args
+        strings = [
+            'SET(EIGEN3_INCLUDE_DIR "$ENV{EIGEN3_INCLUDE_DIR}")',
+            'SET(SPECTRA_LIB "$ENV{SPECTRA_LIB}")',
+            'SET(BOOST_LIB "$ENV{BOOST_LIB}")',
+            'SET(OPENBLAS "$ENV{OPENBLAS}")',
+            'SET(MKLROOT "$ENV{MKLROOT}")'
+        ]
+        for s in strings:
+            filter_file(s, '', 'CMakeLists.txt', string=True)
+
+    def cmake_args(self):
+        eigen = self.spec['eigen'].prefix.include
+        args = [self.define('EIGEN3_INCLUDE_DIR', eigen)]
+        if self.spec.satisfies('@1.94.0beta:'):
+            spectra = self.spec['spectra'].prefix.include
+            boost = self.spec['boost'].prefix.include
+            deps = [
+                self.define('SPECTRA_LIB', spectra),
+                self.define('BOOST_LIB', boost),
+            ]
+            args.extend(deps)
+
+        if self.spec.satisfies('target=x86_64:'):
+            mkl = self.spec['intel-mkl'].prefix
+            args.append(self.define('MKLROOT', mkl))
+        elif self.spec.satisfies('target=aarch64:'):
+            openblas = self.spec['openblas'].prefix
+            args.append(self.define('OPENBLAS', openblas))
+
+        return args
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        install('gcta64', join_path(prefix.bin, 'gcta64'))
-        set_executable(join_path(prefix.bin, 'gcta64'))
+        with working_dir(self.build_directory):
+            install('gcta64', join_path(prefix.bin, 'gcta64'))

--- a/var/spack/repos/builtin/packages/gcta/package.py
+++ b/var/spack/repos/builtin/packages/gcta/package.py
@@ -24,16 +24,16 @@ class Gcta(CMakePackage):
     conflicts('target=aarch64:', when='@:1.91.2', msg='aarch64 support added in 1.94.0')
 
     depends_on('cmake@3.1:', type='build')
-    depends_on('intel-mkl@2017:', type=('build', 'link'), when='target=x86_64:')
-    depends_on('openblas', type=('build', 'link'), when='target=aarch64:')
-    depends_on('eigen@3.3.1', type=('build', 'link'), when='@1.91.2')
-    depends_on('eigen@3.3.7:', type=('build', 'link'), when='@1.94.0beta:')
-    depends_on('boost@1.4:', type=('build', 'link'), when='@1.94.0beta:')
-    depends_on('zlib', type=('build', 'link'))
-    depends_on('sqlite@3.3.1:', type=('build', 'link'), when='@1.94.0beta:')
-    depends_on('zstd@1.4.4:', type=('build', 'link'), when='@1.94.0beta:')
-    depends_on('spectra', type=('build', 'link'), when='@1.94.0beta:')
-    depends_on('gsl', type=('build', 'link'), when='@1.94.0beta:')
+    depends_on('intel-mkl@2017:', when='target=x86_64:')
+    depends_on('openblas', when='target=aarch64:')
+    depends_on('eigen@3.3.1', when='@1.91.2')
+    depends_on('eigen@3.3.7:', when='@1.94.0beta:')
+    depends_on('boost@1.79:', when='@1.94.0beta:')
+    depends_on('zlib')
+    depends_on('sqlite@3.3.1:', when='@1.94.0beta:')
+    depends_on('zstd@1.4.4:', when='@1.94.0beta:')
+    depends_on('spectra', when='@1.94.0beta:')
+    depends_on('gsl', when='@1.94.0beta:')
 
     def patch(self):
         # allow us to specify the locations with cmake_args

--- a/var/spack/repos/builtin/packages/gcta/package.py
+++ b/var/spack/repos/builtin/packages/gcta/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install gcta
-#
-# You can edit this file again by typing:
-#
-#     spack edit gcta
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/spectra/package.py
+++ b/var/spack/repos/builtin/packages/spectra/package.py
@@ -3,23 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-# If you submit this package back to Spack as a pull request,
-# please first remove this boilerplate and all FIXME comments.
-#
-# This is a template package file for Spack.  We've put "FIXME"
-# next to all the things you'll want to change. Once you've handled
-# them, you can save this file and test your package like this:
-#
-#     spack install spectra
-#
-# You can edit this file again by typing:
-#
-#     spack edit spectra
-#
-# See the Spack documentation for more information on packaging.
-# ----------------------------------------------------------------------------
-
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/spectra/package.py
+++ b/var/spack/repos/builtin/packages/spectra/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install spectra
+#
+# You can edit this file again by typing:
+#
+#     spack edit spectra
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack import *
+
+
+class Spectra(CMakePackage):
+    """
+    Spectra stands for Sparse Eigenvalue Computation Toolkit as a Redesigned
+    ARPACK. It is a C++ library for large scale eigenvalue problems,
+    built on top of Eigen, an open source linear algebra library.
+
+    Spectra is implemented as a header-only C++ library, whose only
+    dependency, Eigen, is also header-only. Hence Spectra can be easily
+    embedded in C++ projects that require calculating eigenvalues of
+    large matrices.
+    """
+
+    homepage = "https://spectralib.org/"
+    url      = "https://github.com/yixuan/spectra/archive/refs/tags/v1.0.1.tar.gz"
+    maintainers = ['snehring']
+
+    version('1.0.1', sha256='919e3fbc8c539a321fd5a0766966922b7637cc52eb50a969241a997c733789f3')
+    version('1.0.0', sha256='45228b7d77b916b5384245eb13aa24bc994f3b0375013a8ba6b85adfd2dafd67')
+    version('0.9.0', sha256='2966757d432e8fba5958c2a05ad5674ce34eaae3718dd546c1ba8760b80b7a3d')
+
+    depends_on('cmake@3.5:')
+    depends_on('eigen')


### PR DESCRIPTION
I don't know if I was feeling especially lazy when I did the original version of this, but the way they're doing binaries is more complicated now. So let's switch to proper source builds.

The latest version adds a few dependencies, including a new package 'spectra'.

The CMakeLists.txt for gcta sets -msse2, but the spack compiler wrappers still seem to do the correct thing based on the specified target, so instead of creating a variant or anything I'm going to let it ride.