### PR TITLE
hiop: new version, new variant

### DIFF
--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -18,6 +18,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
     maintainers = ['ashermancinelli', 'CameronRutherford']
 
     # Most recent tagged snapshot is the preferred version when profiling.
+    version('0.6.1', commit='a9e2697b00aa13ecf0ae4783dd8a41dee11dc50e')
     version('0.6.0', commit='21af7eb0d6427be73546cf303abc84e834a5a55d')
     version('0.5.4', commit='a37a7a677884e95d1c0ad37936aef3778fc91c3e')
     version('0.5.3', commit='698e8d0fdc0ff9975d8714339ff8c782b70d85f9')
@@ -58,6 +59,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         'used for increased robustness and self-diagnostics',
     )
     variant('ginkgo', default=False, description='Enable/disable ginkgo solver')
+    variant('cusolver', default=False, description='Enable/disable cuSovler')
 
     depends_on('lapack')
     depends_on('blas')
@@ -109,6 +111,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         when='+cuda+raja',
         msg='umpire+cuda exports device code and requires static libs',
     )
+    conflicts('+cusolver', when='~cuda', msg='Cusolver requires CUDA')
 
     flag_handler = build_system_flags
 
@@ -141,6 +144,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant('HIOP_USE_COINHSL', 'sparse'),
             self.define_from_variant('HIOP_TEST_WITH_BSUB', 'jsrun'),
             self.define_from_variant('HIOP_USE_GINKGO', 'ginkgo'),
+            self.define_from_variant('HIOP_USE_CUSOLVER', 'cusolver'),
         ])
 
         # NOTE: If building with spack develop on a cluster, you may want to

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -112,6 +112,7 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
         msg='umpire+cuda exports device code and requires static libs',
     )
     conflicts('+cusolver', when='~cuda', msg='Cusolver requires CUDA')
+    conflicts('+cusolver', when='@:0.5', msg='Cusolver support was introduced in HiOp 0.6')
 
     flag_handler = build_system_flags
 

--- a/var/spack/repos/builtin/packages/magma/package.py
+++ b/var/spack/repos/builtin/packages/magma/package.py
@@ -23,8 +23,8 @@ class Magma(CMakePackage, CudaPackage, ROCmPackage):
     test_requires_compiler = True
 
     version('master', branch='master')
-    version('2.6.2rc1', commit='5959b8783e45f1809812ed96ae762f38ee701972')
-    version('2.6.1', sha256='6cd83808c6e8bc7a44028e05112b3ab4e579bcc73202ed14733f66661127e213', preferred=True)
+    version('2.6.2', sha256='75b554dab00903e2d10b972c913e50e7f88cbc62f3ae432b5a086c7e4eda0a71', preferred=True)
+    version('2.6.1', sha256='6cd83808c6e8bc7a44028e05112b3ab4e579bcc73202ed14733f66661127e213')
     version('2.6.0', sha256='50cdd384f44f06a34469e7125f8b2ffae13c1975d373c3f1510d91be2b7638ec')
     version('2.5.4', sha256='7734fb417ae0c367b418dea15096aef2e278a423e527c615aab47f0683683b67')
     version('2.5.3', sha256='c602d269a9f9a3df28f6a4f593be819abb12ed3fa413bba1ff8183de721c5ef6')


### PR DESCRIPTION
The phony magma version 2.6.2rc1 can now safely be removed, as v2.6.2 has fully been released. Adds cusolver variant.