### PR TITLE
gawk: drop gettext by default

### DIFF
--- a/var/spack/repos/builtin/packages/gawk/package.py
+++ b/var/spack/repos/builtin/packages/gawk/package.py
@@ -31,7 +31,9 @@ class Gawk(AutotoolsPackage, GNUMirrorPackage):
     version('5.0.1', sha256='8e4e86f04ed789648b66f757329743a0d6dfb5294c3b91b756a474f1ce05a794')
     version('4.1.4', sha256='53e184e2d0f90def9207860531802456322be091c7b48f23fdc79cda65adc266')
 
-    depends_on('gettext')
+    variant('nls', default=False, description='Enable Native Language Support')
+
+    depends_on('gettext', when='+nls')
     depends_on('libsigsegv')
     depends_on('readline')
     depends_on('mpfr')
@@ -46,3 +48,6 @@ class Gawk(AutotoolsPackage, GNUMirrorPackage):
         output = Executable(exe)('--version', output=str, error=str)
         match = re.search(r'GNU Awk\s+([\d\.]+)', output)
         return match.group(1) if match else None
+
+    def configure_args(self):
+        return self.enable_or_disable('nls')


### PR DESCRIPTION
Reduces the number of packages to bootstrap gcc (which actually has
--disable-nls).
