### PR TITLE
SCons: added versions 4.0.0-4.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -10,10 +10,15 @@ class Scons(PythonPackage):
     """SCons is a software construction tool"""
 
     homepage = "https://scons.org"
-    pypi = "scons/scons-3.1.1.tar.gz"
+    pypi = "SCons/SCons-4.3.0.tar.gz"
 
     tags = ['build-tools']
 
+    version('4.3.0', sha256='d47081587e3675cc168f1f54f0d74a69b328a2fc90ec4feb85f728677419b879')
+    version('4.2.0', sha256='691893b63f38ad14295f5104661d55cb738ec6514421c6261323351c25432b0a')
+    version('4.1.0.post1', sha256='ecb062482b9d80319b56758c0341eb717735437f86a575bac3552804428bd73e')
+    version('4.0.1', sha256='722ed104b5c624ecdc89bd4e02b094d2b14d99d47b5d0501961e47f579a2007c')
+    version('4.0.0', sha256='de8599189ee87bb84234e3d6e30bef0298d6364713979856927576b252c411f3')
     version('3.1.2', sha256='8aaa483c303efeb678e6f7c776c8444a482f8ddc3ad891f8b6cdd35264da9a1f')
     version('3.1.1', sha256='fd44f8f2a4562e7e5bc8c63c82b01e469e8115805a3e9c2923ee54cdcd6678b3')
     version('3.1.0', sha256='94e0d0684772d3e6d9368785296716e0ed6ce757270b3ed814e5aa72d3163890')
@@ -25,10 +30,14 @@ class Scons(PythonPackage):
 
     # Python 3 support was added in SCons 3.0.0
     depends_on('python@:2', when='@:2', type=('build', 'run'))
+    # Python 2 support was dropped in SCons 4.0.0
+    depends_on('python@3.5:', when='@4:4.2.0')
+    # Python 3.5 support was dropped in SCons 4.3.0
+    depends_on('python@3.6:', when='@4.3.0:')
     depends_on('py-setuptools', type=('build', 'run'))
 
     patch('fjcompiler.patch', when='%fj')
-    patch('py3-hashbang.patch', when='^python@3:')
+    patch('py3-hashbang.patch', when='@:3^python@3:')  # not needed for @4.0.0:
 
     def setup_run_environment(self, env):
         env.prepend_path('PYTHONPATH', self.prefix.lib.scons)

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -39,6 +39,14 @@ class Scons(PythonPackage):
     patch('fjcompiler.patch', when='%fj')
     patch('py3-hashbang.patch', when='@:3^python@3:')  # not needed for @4.0.0:
 
+    def url_for_version(self, version):
+        url = 'https://files.pythonhosted.org/packages/source/{0}/{1}/{1}-{2}.tar.gz'
+        if version >= Version('4.0.0'):
+            name = 'SCons'
+        else:
+            name = 'scons'
+        return url.format(name[0], name, version)
+
     def setup_run_environment(self, env):
         env.prepend_path('PYTHONPATH', self.prefix.lib.scons)
 


### PR DESCRIPTION
I've added new versions of SCons. I fixed the `pypi` package attribute because it was preventing fetching of the newer archives. The older (3.1.2 and below) were fetched from Spack's mirror, so I don't know how this change affects the mirroring, feel free to suggest edits if something's wrong. Cheers!