### PR TITLE
Power9 build fix for ctffind4

### DIFF
--- a/var/spack/repos/builtin/packages/ctffind/package.py
+++ b/var/spack/repos/builtin/packages/ctffind/package.py
@@ -29,6 +29,7 @@ class Ctffind(AutotoolsPackage):
     depends_on('jpeg')
 
     patch('configure.patch', when='@4.1.8')
+    patch('power9.patch', when='@4.1.14 target=power9le')
 
     def configure_args(self):
         config_args = []

--- a/var/spack/repos/builtin/packages/ctffind/power9.patch
+++ b/var/spack/repos/builtin/packages/ctffind/power9.patch
@@ -1,0 +1,16 @@
+diff -ur a/src/core/matrix.cpp b/src/core/matrix.cpp
+--- a/src/core/matrix.cpp	2020-05-08 18:28:30.000000000 +0100
++++ b/src/core/matrix.cpp	2022-04-26 14:45:23.414518732 +0100
+@@ -4,7 +4,11 @@
+ // think i got it from a book i had about game programming in c.. it's probably slower than what the compiler would do these days.
+ 
+ #define AL_PI        3.14159265358979323846
+-#define _AL_SINCOS(x, s, c)  __asm__ ("fsincos" : "=t" (c), "=u" (s) : "0" (x))
++#if defined(__i386__) || defined(__x86_64__)
++#define _AL_SINCOS(x, s, c) __asm__ ("fsincos" : "=t" (c), "=u" (s) : "0" (x))
++#else
++#define _AL_SINCOS(x, s, c) s = sinf(x); c = cosf(x);
++#endif
+ #define FLOATSINCOS(x, s, c)  _AL_SINCOS((x) * AL_PI / 128.0, s ,c)
+ 
+ #define MAKE_ROTATION_f(x, y, z)


### PR DESCRIPTION
Only tested against the latest version, which is why it only applies the patch
when using 4.1.14.

Fix comes from:

https://grigoriefflab.umassmed.edu/forum/software/ctffind_ctftilt/installing_ctffind_4114_ibm_power9