### PR TITLE
openpmix: add munge dependency

### DIFF
--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -76,6 +76,7 @@ class Pmix(AutotoolsPackage):
     depends_on("automake", type=("build"), when="@master")
     depends_on("libtool", type=("build"), when="@master")
     depends_on("perl", type=("build"), when="@master")
+    depends_on("munge")
     depends_on('curl', when="+restful")
     depends_on('jansson@2.11:', when="+restful")
     depends_on('pandoc', type='build', when='+docs')


### PR DESCRIPTION
The Open PMIx pkg-config file includes a dependency on munge, even though the package can be built
without munge support.  If one uses an external PMIx with Open MPI, the configury check for PMIx
within Open MPI will fail as the pkg-config call against pmix returns an error status since
it doesn't know how to find munge.

Adding a dependency on munge to the pmix spack package addresses this problem.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>