### PR TITLE
py-cryptography@35: tell cargo to use cli git, not cargo internal git…

### DIFF
--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -48,6 +48,10 @@ class PyCryptography(PythonPackage):
     depends_on('openssl@:1.0', when='@:1.8.1')
     depends_on('openssl')
 
+    # To fix https://github.com/spack/spack/issues/29669
+    # https://community.home-assistant.io/t/error-failed-building-wheel-for-cryptography/352020/14
+    # We use CLI git instead of Cargo's internal git library
+    # See reference: https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
     depends_on('git', type='build', when='@35:')
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -47,3 +47,9 @@ class PyCryptography(PythonPackage):
     depends_on('py-ipaddress',          type=('build', 'run'), when='^python@:3.3')
     depends_on('openssl@:1.0', when='@:1.8.1')
     depends_on('openssl')
+
+    depends_on('git', type='build', when='@35:')
+
+    def setup_build_environment(self, env):
+        if self.spec.satisfies('@35:'):
+            env.set('CARGO_NET_GIT_FETCH_WITH_CLI', 'true')


### PR DESCRIPTION
`py-cryptography`: tell Cargo to use cli `git` for build instead of internal git library

See related issue:
https://community.home-assistant.io/t/error-failed-building-wheel-for-cryptography/352020/14

And documentation on the relevant environment variable:
https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Fixes https://github.com/spack/spack/issues/29669

@adamjstewart @srekolam 