### PR TITLE
py-pil: deprecate package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pil/package.py
+++ b/var/spack/repos/builtin/packages/py-pil/package.py
@@ -12,7 +12,7 @@ class PyPil(PythonPackage):
     homepage = "https://pillow.readthedocs.io/en/stable/"
     url      = "http://effbot.org/media/downloads/Imaging-1.1.7.tar.gz"
 
-    version('1.1.7', sha256='895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211')
+    version('1.1.7', sha256='895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211', deprecated=True)
 
     provides('pil')
     provides('pil@1.1.7', when='@1.1.7')


### PR DESCRIPTION
PIL only ever supported Python 2, hasn't had a release in over a decade, and is no longer available for download. Pillow supports both Python 2 and 3 and is superior in every way. I don't think there's any reason to keep PIL.