### PR TITLE
Pass blas link flags to ipopt configure when ^coinhsl+blas

### DIFF
--- a/var/spack/repos/builtin/packages/ipopt/package.py
+++ b/var/spack/repos/builtin/packages/ipopt/package.py
@@ -109,14 +109,19 @@ class Ipopt(AutotoolsPackage):
                     "--with-mumps-cflags=%s" % mumps_dir.include])
 
         if 'coinhsl' in spec:
+            hsl_ld_flags = '-ldl {0}'.format(spec['coinhsl'].libs.ld_flags)
+
+            if spec.satisfies('^coinhsl+blas'):
+                hsl_ld_flags += ' {0}'.format(spec['blas'].libs.ld_flags)
+
             if spec.satisfies('@:3.12.13'):
                 args.extend([
-                    '--with-hsl-lib=%s' % spec['coinhsl'].libs.ld_flags,
+                    '--with-hsl-lib=%s' % hsl_ld_flags,
                     '--with-hsl-incdir=%s' % spec['coinhsl'].prefix.include])
             else:
                 args.extend([
                     "--with-hsl",
-                    "--with-hsl-lflags=%s" % spec['coinhsl'].libs.ld_flags,
+                    "--with-hsl-lflags=%s" % hsl_ld_flags,
                     "--with-hsl-cflags=%s" % spec['coinhsl'].prefix.include])
 
         if 'metis' in spec:


### PR DESCRIPTION
Ipopt configure script will fail to find coinhsl when `^coinhsl+blas` and blas link flags aren't passed to configure script along with hsl link flags. Same for libdl, though I can't quite nail down when ipopt configure script needs `-ldl` in lflags. I'm assuming it's safe to always link to libdl.