### PR TITLE
maq: adding perl dep, addressing gcc errors

### DIFF
--- a/var/spack/repos/builtin/packages/maq/package.py
+++ b/var/spack/repos/builtin/packages/maq/package.py
@@ -17,4 +17,15 @@ class Maq(AutotoolsPackage):
     version('0.7.1', sha256='e1671e0408b0895f5ab943839ee8f28747cf5f55dc64032c7469b133202b6de2')
     version('0.5.0', sha256='c292c19baf291b2415b460d687d43a71ece00a7d178cc5984bc8fc30cfce2dfb')
 
-    conflicts('%gcc@4.7.0:', when='@0.7.1')
+    depends_on('perl', type='run')
+
+    def patch(self):
+        with working_dir('scripts'):
+            scripts = ['farm-run.pl', 'maq_eval.pl', 'maq.pl', 'maq_plot.pl']
+            for s in scripts:
+                filter_file('/usr/bin/perl', self.spec['perl'].prefix.bin.perl, s)
+
+    def flag_handler(self, name, flags):
+        if name.lower() == 'cxxflags':
+            flags.append('-fpermissive')
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/maq/package.py
+++ b/var/spack/repos/builtin/packages/maq/package.py
@@ -13,6 +13,7 @@ class Maq(AutotoolsPackage):
     homepage = "http://maq.sourceforge.net/"
     url      = "https://downloads.sourceforge.net/project/maq/maq/0.7.1/maq-0.7.1.tar.bz2"
     list_url = "https://sourceforge.net/projects/maq/files/maq/"
+    maintainers = ['snehring']
 
     version('0.7.1', sha256='e1671e0408b0895f5ab943839ee8f28747cf5f55dc64032c7469b133202b6de2')
     version('0.5.0', sha256='c292c19baf291b2415b460d687d43a71ece00a7d178cc5984bc8fc30cfce2dfb')


### PR DESCRIPTION
This has a missing perl dependency, some of the outputs are perl scripts. So this adds that and fixes the shebangs/other references to /usr/bin/perl.

The perhaps more controversial change is the removal of the gcc conflict, which seems to have only been there because of build errors in newer gccs. These seem to be resolved with the -fpermissive flag.

This project has not released anything new since 2008, so I'm assuming gcc just decided to enforce standards a little better in the intervening years. The errors themselves seem to be a scoping issue or something within stdhash.hh.