### PR TITLE
hiop: Enable barebones testing

### DIFF
--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -3,9 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
 import os
+
 import llnl.util.tty as tty
+
+from spack import *
 
 
 class Hiop(CMakePackage, CudaPackage, ROCmPackage):

--- a/var/spack/repos/builtin/packages/hiop/package.py
+++ b/var/spack/repos/builtin/packages/hiop/package.py
@@ -235,8 +235,8 @@ class Hiop(CMakePackage, CudaPackage, ROCmPackage):
             ])
 
         for i, test in enumerate(tests):
-            exe, *args = test
-            exe = os.path.join(self.prefix.bin, exe)
+            exe = os.path.join(self.prefix.bin, test[0])
+            args = test[1:]
             reason = 'test {0}: "{1}"'.format(i, ' '.join(test))
             self.run_test(exe, args, [], 0, installed=False,
                           purpose=reason, skip_missing=True,


### PR DESCRIPTION
Run 6 test cases representative of the entire HiOp test suite. Based off of Umpire and RAJA packages.