### PR TITLE
bucky: fix compile errors with newer gccs

### DIFF
--- a/var/spack/repos/builtin/packages/bucky/package.py
+++ b/var/spack/repos/builtin/packages/bucky/package.py
@@ -20,14 +20,16 @@ class Bucky(MakefilePackage):
     # Compilation requires gcc
     conflicts('%cce')
     conflicts('%apple-clang')
-    conflicts('%clang')
-    conflicts('%intel')
     conflicts('%nag')
     conflicts('%pgi')
     conflicts('%xl')
     conflicts('%xl_r')
 
     build_directory = 'src'
+
+    def edit(self, spec, prefix):
+        with working_dir(self.build_directory):
+            filter_file('g++', spack_cxx, 'makefile', string=True)
 
     def install(self, spec, prefix):
         with working_dir('src'):
@@ -37,3 +39,8 @@ class Bucky(MakefilePackage):
         install_tree('data', prefix.data)
         install_tree('doc', prefix.doc)
         install_tree('scripts', prefix.scripts)
+
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('%gcc@5:') and name.lower() == 'cxxflags':
+            flags.append(self.compiler.cxx98_flag)
+        return (flags, None, None)

--- a/var/spack/repos/builtin/packages/bucky/package.py
+++ b/var/spack/repos/builtin/packages/bucky/package.py
@@ -14,6 +14,7 @@ class Bucky(MakefilePackage):
 
     homepage = "https://www.stat.wisc.edu/~ane/bucky/index.html"
     url      = "http://dstats.net/download/http://www.stat.wisc.edu/~ane/bucky/v1.4/bucky-1.4.4.tgz"
+    maintainers = ['snehring']
 
     version('1.4.4', sha256='1621fee0d42314d9aa45d0082b358d4531e7d1d1a0089c807c1b21fbdc4e4592')
 


### PR DESCRIPTION
Newer dialects cause errors, cxx98 seems fine.

I am suspect of the compiler conflicts in this, I tested with clang and oneapi without issue after I added the makefile change.

I suspect the others would be fine too, but I don't have them available to test.
