### PR TITLE
Kokkos Kernels: updating the package for release 3.6.00

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos-kernels/package.py
+++ b/var/spack/repos/builtin/packages/kokkos-kernels/package.py
@@ -11,7 +11,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
 
     homepage = "https://github.com/kokkos/kokkos-kernels"
     git      = "https://github.com/kokkos/kokkos-kernels.git"
-    url      = "https://github.com/kokkos/kokkos-kernels/archive/3.5.00.tar.gz"
+    url      = "https://github.com/kokkos/kokkos-kernels/archive/3.6.00.tar.gz"
 
     tags = ['e4s']
 
@@ -23,6 +23,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
     # openssl sha256 kokkos-kernels-x.y.z.tar.gz
     version('develop', branch='develop')
     version('master',  branch='master')
+    version('3.6.00', sha256="2753643fd643b9eed9f7d370e0ff5fa957211d08a91aa75398e31cbc9e5eb0a5")
     version('3.5.00', sha256="a03a41a047d95f9f07cd1e1d30692afdb75b5c705ef524e19c1d02fe60ccf8d1")
     version('3.4.01', sha256="f504aa4afbffb58fa7c4430d0fdb8fd5690a268823fa15eb0b7d58dab9d351e6")
     version('3.4.00', sha256="07ba11869e686cb0d47272d1ef494ccfbcdef3f93ff1c8b64ab9e136a53a227a")
@@ -36,6 +37,7 @@ class KokkosKernels(CMakePackage, CudaPackage):
     depends_on("kokkos")
     depends_on("kokkos@master", when="@master")
     depends_on("kokkos@develop", when="@develop")
+    depends_on("kokkos@3.6.00", when="@3.6.00")
     depends_on("kokkos@3.5.00", when="@3.5.00")
     depends_on("kokkos@3.4.01", when="@3.4.01")
     depends_on("kokkos@3.4.00", when="@3.4.00")


### PR DESCRIPTION
This reflects the release of Kokkos and Kokkos Kernels 3.6.00
To be merged this requires PR #30315