### PR TITLE
Allow PyTorch to forward gcc-toolchain cxxcflag to CUDA toolchains

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -301,6 +301,10 @@ class PyTorch(PythonPackage, CudaPackage):
                                        in
                                        self.spec.variants['cuda_arch'].value)
             env.set('TORCH_CUDA_ARCH_LIST', torch_cuda_arch)
+            if self.spec.satisfies('%clang'):
+                for flag in self.spec.compiler_flags['cxxflags']:
+                    if 'gcc-toolchain' in flag:
+                        env.set('CMAKE_CUDA_FLAGS', '=-Xcompiler={0}'.format(flag))
 
         enable_or_disable('rocm')
 


### PR DESCRIPTION
When using clang and passing the `gcc-toolchain` flag it needs to get propagated through CUDA to the underlying host compiler.