### PR TITLE
Add checksum for py-networkx@2.7.1 and fix python dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-networkx/package.py
+++ b/var/spack/repos/builtin/packages/py-networkx/package.py
@@ -13,6 +13,7 @@ class PyNetworkx(PythonPackage):
     homepage = "https://networkx.github.io/"
     pypi = "networkx/networkx-2.4.tar.gz"
 
+    version('2.7.1', sha256='d1194ba753e5eed07cdecd1d23c5cd7a3c772099bd8dbd2fea366788cf4de7ba')
     version('2.6.3', sha256='c0946ed31d71f1b732b5aaa6da5a0388a345019af232ce2f49c766e2d6795c51')
     version('2.5.1', sha256='109cd585cac41297f71103c3c42ac6ef7379f29788eb54cb751be5a663bb235a')
     version('2.4',  sha256='f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64')
@@ -27,6 +28,7 @@ class PyNetworkx(PythonPackage):
     depends_on('python@3.5:', type=('build', 'run'), when='@2.3:')
     depends_on('python@3.6:', type=('build', 'run'), when='@2.5:')
     depends_on('python@3.7:', type=('build', 'run'), when='@2.6:')
+    depends_on('python@3.8:', type=('build', 'run'), when='@2.7:')
     depends_on('py-setuptools', type='build')
     depends_on('py-decorator@3.4.0:', type=('build', 'run'), when='@:1')
     depends_on('py-decorator@4.1.0:', type=('build', 'run'), when='@2.0:2.1')


### PR DESCRIPTION
Python dependency has been fixed following [release notes](https://networkx.org/documentation/stable/release/release_2.7.1.html)