### PR TITLE
Intel needs c99 standard specified under intel.

### DIFF
--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -141,7 +141,6 @@ class Mesa(MesonPackage):
             if name == 'cflags':
                 flags.append('-std=c99')
         return super(Mesa, self).flag_handler(name, flags)
-  
 
     def meson_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/mesa/package.py
+++ b/var/spack/repos/builtin/packages/mesa/package.py
@@ -136,6 +136,13 @@ class Mesa(MesonPackage):
             "_llvm_method = 'config-tool'",
             "meson.build")
 
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('%intel'):
+            if name == 'cflags':
+                flags.append('-std=c99')
+        return super(Mesa, self).flag_handler(name, flags)
+  
+
     def meson_args(self):
         spec = self.spec
         args = [


### PR DESCRIPTION
When building mesa under TCE we found we needed to specify `-std=c99`when building with intel compilers. 