### PR TITLE
gxsview: vtk9 no longer builds libvtkjpeg...

### DIFF
--- a/var/spack/repos/builtin/packages/gxsview/package.py
+++ b/var/spack/repos/builtin/packages/gxsview/package.py
@@ -27,6 +27,8 @@ class Gxsview(QMakePackage):
     depends_on('vtk@8.0:+qt+opengl2')  # +mpi+python are optional
     conflicts('%gcc@:7.2.0', msg='Requires C++17 compiler support')  # need C++17 standard
 
+    patch('vtk9.patch', when='^vtk@9:')
+
     build_directory = 'gui'
 
     def qmake_args(self):

--- a/var/spack/repos/builtin/packages/gxsview/vtk9.patch
+++ b/var/spack/repos/builtin/packages/gxsview/vtk9.patch
@@ -1,0 +1,26 @@
+diff --git a/gui/vtk9.pri b/gui/vtk9.pri
+index 15fdd91..ca452e0 100644
+--- a/gui/vtk9.pri
++++ b/gui/vtk9.pri
+@@ -60,21 +60,8 @@ LIBS += \
+   -lvtkRenderingUI$$VTK_VER_SUFFIX \
+   -lvtkRenderingVolume$$VTK_VER_SUFFIX \
+   -lvtkRenderingVtkJS$$VTK_VER_SUFFIX \
+-  -lvtkdoubleconversion$$VTK_VER_SUFFIX \
+-  -lvtkexpat$$VTK_VER_SUFFIX \
+-  -lvtkfreetype$$VTK_VER_SUFFIX \
+-  -lvtkglew$$VTK_VER_SUFFIX \
+-  -lvtkgl2ps$$VTK_VER_SUFFIX \
+-  -lvtkjpeg$$VTK_VER_SUFFIX \
+-  -lvtkjsoncpp$$VTK_VER_SUFFIX \
+   -lvtkloguru$$VTK_VER_SUFFIX \
+-  -lvtklz4$$VTK_VER_SUFFIX \
+-  -lvtklzma$$VTK_VER_SUFFIX \
+   -lvtkmetaio$$VTK_VER_SUFFIX \
+-  -lvtkpng$$VTK_VER_SUFFIX \
+-  -lvtkpugixml$$VTK_VER_SUFFIX \
+   -lvtksys$$VTK_VER_SUFFIX \
+-  -lvtktiff$$VTK_VER_SUFFIX \
+-  -lvtkzlib$$VTK_VER_SUFFIX \
+   -lvtkViewsContext2D$$VTK_VER_SUFFIX \
+   -lvtkViewsCore$$VTK_VER_SUFFIX \


### PR DESCRIPTION
gwview gui/vtk9.pri file is patched so as to no longer hard link with libvtkjpeg, and many other libs that vtk9 no longer builds since commit https://github.com/spack/spack/pull/27467
This patch happens to be backwards compatible with vtk/package.py prior to this commit.
