### PR TITLE
binutils@2.38 %gcc: add -fPIC -fcommon -Wl,-z,notext

### DIFF
--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -171,7 +171,7 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
             if spec.satisfies('@:2.34 %gcc@10:'):
                 iflags.append('-fcommon')
             if spec.satisfies('%cce') or spec.satisfies('@2.38 %gcc'):
-                iflags.append('-fPIC -fcommon')
+                iflags.extend([self.compiler.cc_pic_flag, '-fcommon'])
         elif name == 'ldflags':
             if spec.satisfies('%cce') or spec.satisfies('@2.38 %gcc'):
                 iflags.append('-Wl,-z,notext')

--- a/var/spack/repos/builtin/packages/binutils/package.py
+++ b/var/spack/repos/builtin/packages/binutils/package.py
@@ -156,23 +156,24 @@ class Binutils(AutotoolsPackage, GNUMirrorPackage):
                     extradir)
 
     def flag_handler(self, name, flags):
+        spec = self.spec
         # Use a separate variable for injecting flags. This way, installing
         # `binutils cflags='-O2'` will still work as expected.
         iflags = []
         # To ignore the errors of narrowing conversions for
         # the Fujitsu compiler
         if name == 'cxxflags' and (
-            self.spec.satisfies('@:2.31.1') and
+            spec.satisfies('@:2.31.1') and
             self.compiler.name in ('fj', 'clang', 'apple-clang')
         ):
             iflags.append('-Wno-narrowing')
         elif name == 'cflags':
-            if self.spec.satisfies('@:2.34 %gcc@10:'):
+            if spec.satisfies('@:2.34 %gcc@10:'):
                 iflags.append('-fcommon')
-            if self.spec.satisfies('%cce'):
+            if spec.satisfies('%cce') or spec.satisfies('@2.38 %gcc'):
                 iflags.append('-fPIC -fcommon')
         elif name == 'ldflags':
-            if self.spec.satisfies('%cce'):
+            if spec.satisfies('%cce') or spec.satisfies('@2.38 %gcc'):
                 iflags.append('-Wl,-z,notext')
         return (iflags, None, flags)
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/30195, which appears to be an issue limited to `@2.38 %gcc` and not `@2.37` or `@2.36.1`