### PR TITLE
Use gccgo to bootstrap go on aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -37,7 +37,7 @@ class GoBootstrap(Package):
 
     conflicts('os=monterey', msg="go-bootstrap won't build on new macOS")
     conflicts('target=aarch64:',
-              msg='Go bootstrap is too old to support aarch64 architectures')
+              msg='Go bootstrap doesn't support aarch64 architectures')
 
     def patch(self):
         if self.spec.satisfies('@:1.4.3'):

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -36,7 +36,7 @@ class GoBootstrap(Package):
     depends_on('git', type=('build', 'link', 'run'))
 
     conflicts('os=monterey', msg="go-bootstrap won't build on new macOS")
-    conflicts('target=aarch64:', 
+    conflicts('target=aarch64:',
               msg='Go bootstrap is too old to support aarch64 architectures')
 
     def patch(self):

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -37,7 +37,7 @@ class GoBootstrap(Package):
 
     conflicts('os=monterey', msg="go-bootstrap won't build on new macOS")
     conflicts('target=aarch64:',
-              msg='Go bootstrap doesn't support aarch64 architectures')
+              msg="Go bootstrap doesn't support aarch64 architectures")
 
     def patch(self):
         if self.spec.satisfies('@:1.4.3'):

--- a/var/spack/repos/builtin/packages/go-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/go-bootstrap/package.py
@@ -36,8 +36,8 @@ class GoBootstrap(Package):
     depends_on('git', type=('build', 'link', 'run'))
 
     conflicts('os=monterey', msg="go-bootstrap won't build on new macOS")
-    conflicts('target=aarch64:', when='platform=darwin',
-              msg='Go bootstrap is too old for Apple Silicon')
+    conflicts('target=aarch64:', 
+              msg='Go bootstrap is too old to support aarch64 architectures')
 
     def patch(self):
         if self.spec.satisfies('@:1.4.3'):

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import platform
 import re
 
 import llnl.util.tty as tty
@@ -130,7 +131,20 @@ class Go(Package):
     provides('golang')
 
     depends_on('git', type=('build', 'link', 'run'))
-    depends_on('go-bootstrap', type='build')
+
+    # aarch64 machines (including Macs with Apple silicon) can't use
+    # go-bootstrap becuase it pre-dates aarch64 support in Go.  These machines
+    # have to rely on Go support in gcc (which may require compiling a version
+    # of gcc with Go support just to satisfy this requirement).  However,
+    # there's also a bug in some versions of GCC's Go front-end that prevents
+    # these versions from properly bootstrapping Go.  (See issue #47771
+    # https://github.com/golang/go/issues/47771 )  On the 10.x branch, we need
+    # at least 10.4.  On the 11.x branch, we need at least 11.3.
+
+    if platform.machine() == 'aarch64':
+        depends_on('gcc@10.4.0:10,11.3.0: languages=go', type='build')
+    else:
+        depends_on('go-bootstrap', type='build')       
 
     # https://github.com/golang/go/issues/17545
     patch('time_test.patch', when='@1.6.4:1.7.4')

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -144,7 +144,7 @@ class Go(Package):
     if platform.machine() == 'aarch64':
         depends_on('gcc@10.4.0:10,11.3.0: languages=go', type='build')
     else:
-        depends_on('go-bootstrap', type='build')       
+        depends_on('go-bootstrap', type='build')
 
     # https://github.com/golang/go/issues/17545
     patch('time_test.patch', when='@1.6.4:1.7.4')

--- a/var/spack/repos/builtin/packages/go/package.py
+++ b/var/spack/repos/builtin/packages/go/package.py
@@ -133,7 +133,7 @@ class Go(Package):
     depends_on('git', type=('build', 'link', 'run'))
 
     # aarch64 machines (including Macs with Apple silicon) can't use
-    # go-bootstrap becuase it pre-dates aarch64 support in Go.  These machines
+    # go-bootstrap because it pre-dates aarch64 support in Go.  These machines
     # have to rely on Go support in gcc (which may require compiling a version
     # of gcc with Go support just to satisfy this requirement).  However,
     # there's also a bug in some versions of GCC's Go front-end that prevents


### PR DESCRIPTION
fixes #14900

This PR essentially reverts the go and go-bootstrap changes from pull #28850 so that users on aarch64 platforms can bootstrap go using gccgo.  Also, it adds checks for the proper versions of gcc in order to address the issue in golang/go#47771.