### PR TITLE
Audit: Ensure stand-alone test method not included in build-phase testing

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -277,6 +277,24 @@ package_https_directives = AuditClass(
 
 
 @package_directives
+def _check_build_test_callbacks(pkgs, error_cls):
+    """Ensure stand-alone test method is not included in build-time callbacks"""
+    errors = []
+    for pkg_name in pkgs:
+        pkg = spack.repo.get(pkg_name)
+        test_callbacks = pkg.build_time_test_callbacks
+
+        if test_callbacks and 'test' in test_callbacks:
+            msg = ('{0} package contains "test" method in '
+                   'build_time_test_callbacks')
+            instr = ('Remove "test" from: [{0}]'
+                     .format(', '.join(test_callbacks)))
+            errors.append(error_cls(msg.format(pkg.name), [instr]))
+
+    return errors
+
+
+@package_directives
 def _check_patch_urls(pkgs, error_cls):
     """Ensure that patches fetched from GitHub have stable sha256 hashes."""
     github_patch_url_re = (

--- a/lib/spack/spack/test/audit.py
+++ b/lib/spack/spack/test/audit.py
@@ -17,6 +17,8 @@ import spack.config
     (['wrong-variant-in-depends-on'], 'PKG-DIRECTIVES'),
     # This package has a GitHub patch URL without full_index=1
     (['invalid-github-patch-url'], 'PKG-DIRECTIVES'),
+    # This package has a stand-alone 'test' method in build-time callbacks
+    (['test-build-callbacks'], 'PKG-DIRECTIVES'),
     # This package has no issues
     (['mpileaks'], None),
     # This package has a conflict with a trigger which cannot constrain the constraint

--- a/var/spack/repos/builtin.mock/packages/test-build-callbacks/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-build-callbacks/package.py
@@ -16,8 +16,8 @@ class TestBuildCallbacks(Package):
     version('1.0', '0123456789abcdef0123456789abcdef')
 
     phases = ['build', 'install']
-    # set to undefined method
-    build_time_test_callbacks = ['undefined-build-test']
+    # Include undefined method (runtime failure) and 'test' (audit failure)
+    build_time_test_callbacks = ['undefined-build-test', 'test']
     run_after('build')(Package._run_default_build_time_test_callbacks)
 
     def build(self, spec, prefix):


### PR DESCRIPTION
Per discussion with @becker33 and follow on to #26594, `"test"` should *not* be included in the post-build phase testing callbacks list.

For more information on adding post build- and install-time test methods to be run during `spack install`, refer to https://spack.readthedocs.io/en/latest/packaging_guide.html#adding-installation-phase-tests, which includes a table of build systems/packages that already have defined callbacks for one or both phases.

You can demonstrate use of the feature in this PR by adding `'test'` to a package's `build_time_test_callbacks` list of a package that inherits the behavior.  For example, if `'test'` is added to the (currently empty) list in `hpctoolkit`, the command yields the following output:

```
$ spack audit packages hpctoolkit
PKG-DIRECTIVES: 1 issue found
1. hpctoolkit package contains "test" method in build_time_test_callbacks
    Remove "test" from: [test]
```