### PR TITLE
beagle: adding 5.4, making java dep more flexible.

### DIFF
--- a/var/spack/repos/builtin/packages/beagle/package.py
+++ b/var/spack/repos/builtin/packages/beagle/package.py
@@ -13,7 +13,10 @@ class Beagle(Package):
        ungenotyped markers."""
 
     homepage = "https://faculty.washington.edu/browning/beagle/beagle.html"
+    maintainers = ['snehring']
 
+    version('5.4', sha256='bcdc78b7229b2e7ffd779bc6131a9c45a1bdb509afbb9fac41e6d5cb39aed19c',
+            expand=False, url='https://faculty.washington.edu/browning/beagle/beagle.19Apr22.7c0.jar')
     version('5.1', sha256='994f926a4ec0eac665631f37c4a961d3f75c966c71841079275364013c90996c',
             expand=False, url='https://faculty.washington.edu/browning/beagle/beagle.25Nov19.28d.jar')
     version('5.0', sha256='8390fe18b53786b676b67dddae6d1c086d6225e518f6a82047f4138196b48621',
@@ -21,7 +24,7 @@ class Beagle(Package):
     version('4.1', sha256='6c94610b278fc108c3e80b1134226911be1fc92b7d378ba648ac3eb97c5a3207',
             expand=False, url='https://faculty.washington.edu/browning/beagle/beagle.27Jan18.7e1.jar')
 
-    depends_on('java@8', type='run')
+    depends_on('java@8:', type='run')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
Adding latest update.

Also the java dep seems to be flexible. I ran through the example on the homepage with both openjdk11 and openjdk17, and it seems fine.