### PR TITLE
netcdf-fortran: add compat bound for netcdf-c

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -34,6 +34,7 @@ class NetcdfFortran(AutotoolsPackage):
     variant('doc', default=False, description='Enable building docs')
 
     depends_on('netcdf-c')
+    depends_on('netcdf-c@4.7.4:', when='@4.5.3:')  # nc_def_var_szip required
     depends_on('doxygen', when='+doc', type='build')
 
     # The default libtool.m4 is too old to handle NAG compiler properly:


### PR DESCRIPTION
See https://github.com/Unidata/netcdf-fortran/commit/a28e5f85318ea4357ab06cbc0e230eb411f60626 / https://github.com/Unidata/netcdf-fortran/commit/4e6c3542860436178afc4f98f0b126e05bf03a38. A great example of semver, where new features are introduced in a patch release of a dependency, and relied on in patch release of the dependent.