### PR TITLE
netcdf-fortran: do not build with MPI wrappers

### DIFF
--- a/var/spack/repos/builtin/packages/netcdf-fortran/package.py
+++ b/var/spack/repos/builtin/packages/netcdf-fortran/package.py
@@ -113,19 +113,26 @@ class NetcdfFortran(AutotoolsPackage):
                        self.spec.prefix))
 
     def configure_args(self):
-        config_args = self.enable_or_disable('shared')
-        config_args.append('--enable-static')
+        config_args = ['--enable-static']
+        config_args += self.enable_or_disable('shared')
+        config_args += self.enable_or_disable('doxygen', variant='doc')
 
-        # We need to build with MPI wrappers if either of the parallel I/O
-        # features is enabled in netcdf-c:
-        # https://www.unidata.ucar.edu/software/netcdf/docs/building_netcdf_fortran.html
         netcdf_c_spec = self.spec['netcdf-c']
         if '+mpi' in netcdf_c_spec or '+parallel-netcdf' in netcdf_c_spec:
-            config_args.append('CC=%s' % self.spec['mpi'].mpicc)
-            config_args.append('FC=%s' % self.spec['mpi'].mpifc)
-            config_args.append('F77=%s' % self.spec['mpi'].mpif77)
-
-        config_args += self.enable_or_disable('doxygen', variant='doc')
+            # Prefixing with 'mpiexec -n 4' is not necessarily the correct way
+            # to launch MPI programs on a particular machine (e.g. 'srun -n 4'
+            # with additional arguments might be the right one). Therefore, we
+            # make sure the parallel tests are not launched at all (although it
+            # is the default behaviour currently):
+            config_args.append('--disable-parallel-tests')
+            if self.spec.satisfies('@4.5.0:4.5.2'):
+                # Versions from 4.5.0 to 4.5.2 check whether the Fortran MPI
+                # interface is available and fail the configuration if it is
+                # not. However, the interface is needed for a subset of the test
+                # programs only (the library itself does not need it), which are
+                # not run by default and explicitly disabled above. To avoid the
+                # configuration failure, we set the following cache variable:
+                config_args.append('ac_cv_func_MPI_File_open=yes')
 
         return config_args
 


### PR DESCRIPTION
This prevents overlinking to MPI libraries and solves the problem reported in #30333.