### PR TITLE
Add BUILD_TESTING to standard CMake arguments

### DIFF
--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -176,6 +176,7 @@ class CMakePackage(PackageBase):
             '-G', generator,
             define('CMAKE_INSTALL_PREFIX', convert_to_posix_path(pkg.prefix)),
             define('CMAKE_BUILD_TYPE', build_type),
+            define('BUILD_TESTING', pkg.run_tests),
         ]
 
         # CMAKE_INTERPROCEDURAL_OPTIMIZATION only exists for CMake >= 3.9
@@ -361,6 +362,7 @@ class CMakePackage(PackageBase):
 
             * CMAKE_INSTALL_PREFIX
             * CMAKE_BUILD_TYPE
+            * BUILD_TESTING
 
         which will be set automatically.
 


### PR DESCRIPTION
CTest determines whether to enable tests using the [`BUILD_TESTING`](https://cmake.org/cmake/help/latest/module/CTest.html?highlight=build_testing) variable.
This should be used by projects to conditionally enable the compilation of tests.
Spack knowns which packages are requested to run tests and can thus automatically define this variable for CMake packages.

This addition should
* have no observable consequences, and
* reduce compile time for _every_ CMake project using `BUILD_TESTING`.