### PR TITLE
igv: changing to 'all platforms' version. Adding igvtools variant.

### DIFF
--- a/var/spack/repos/builtin/packages/igv/package.py
+++ b/var/spack/repos/builtin/packages/igv/package.py
@@ -13,24 +13,31 @@ class Igv(Package):
     next-generation sequence data, and genomic annotations."""
 
     homepage = "https://software.broadinstitute.org/software/igv/home"
-    url      = "https://data.broadinstitute.org/igv/projects/downloads/2.8/IGV_Linux_2.8.0.zip"
+    url      = "https://data.broadinstitute.org/igv/projects/downloads/2.8/IGV_2.8.0.zip"
 
     maintainers = ['snehring']
 
-    version('2.8.0', sha256='897f683645b02c4da55424110b885071c2b9dd51bc180174e2a9b10788bf3257')
+    version('2.12.3', sha256='c87a109deb35994e1b28dee80b5acfd623ec3257f031fcd9cfce008cd32a4cf2')
+    version('2.8.0', sha256='33f3ac57017907b931f90c35b63b2de2e4f8d2452f0fbb5be39d30288fc9b2c6')
 
-    # They ship with 11, out of an abundance of caution I'm going to restrict
-    # it to just 11.
+    depends_on('java@11:', type='run')
 
-    depends_on('java@11:11.99', type='run')
+    variant('igvtools', default=False, description='Include igvtools')
 
+    def url_for_version(self, version):
+        url = 'https://data.broadinstitute.org/igv/projects/downloads/{0}/IGV_{1}.zip'
+        return url.format(version.up_to(2), version)
+        
     def install(self, spec, prefix):
-        # Binary dist, just copy what we need, which should be the lib
-        # directory, the two script, and the arg file
         install_tree('lib', prefix.lib)
         mkdirp(prefix.bin)
-        filter_file('^prefix=.*$', 'prefix=' + prefix,
-                    'igv.sh', 'igv_hidpi.sh')
-        install('igv.sh', prefix.bin)
-        install('igv_hidpi.sh', prefix.bin)
         install('igv.args', prefix)
+        files = ['igv.sh', 'igv_hidpi.sh']
+        if '+igvtools' in spec:
+            files.extend(['igvtools', 'igvtools_gui', 'igvtools_gui_hidpi'])
+        for f in files:
+            filter_file('^prefix=.*$', 'prefix=' + prefix, f)
+            filter_file(' java ', ' {0} '.format(spec['java'].prefix.bin.java),
+                        f)
+            set_executable(f)
+            install(f, prefix.bin) 

--- a/var/spack/repos/builtin/packages/igv/package.py
+++ b/var/spack/repos/builtin/packages/igv/package.py
@@ -27,7 +27,7 @@ class Igv(Package):
     def url_for_version(self, version):
         url = 'https://data.broadinstitute.org/igv/projects/downloads/{0}/IGV_{1}.zip'
         return url.format(version.up_to(2), version)
-        
+
     def install(self, spec, prefix):
         install_tree('lib', prefix.lib)
         mkdirp(prefix.bin)
@@ -40,4 +40,4 @@ class Igv(Package):
             filter_file(' java ', ' {0} '.format(spec['java'].prefix.bin.java),
                         f)
             set_executable(f)
-            install(f, prefix.bin) 
+            install(f, prefix.bin)


### PR DESCRIPTION
The difference between the 'linux' distribution and the 'all platforms' seems to be whether or not they include an openjdk. Since we don't use it anyway, I've decided to switch to the all platforms version. 

This has the added benefit of including the igvtools util as well. So I've added a variant for that.