### PR TITLE
hapcut2: adding new version 1.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/hapcut2/package.py
+++ b/var/spack/repos/builtin/packages/hapcut2/package.py
@@ -13,15 +13,33 @@ class Hapcut2(MakefilePackage):
 
     homepage = "https://github.com/vibansal/HapCUT2"
     git      = "https://github.com/vibansal/HapCUT2.git"
+    maintainers = ['snehring']
 
+    version('v1.3.1', commit='c6481d5fd0618dc3e82b2eb8c2b4835d9a4f6da7')
     version('2017-07-10', commit='2966b94c2c2f97813b757d4999b7a6471df1160e',
-            submodules=True)
+            submodules=True, deprecated=True)
 
-    depends_on('zlib', type='link')
+    depends_on('htslib@1.3:')
+    depends_on('curl')
+    depends_on('openssl')
+    depends_on('xz')
+    depends_on('bzip2')
+    depends_on('zlib')
+
+    @when('@v1.3.1:')
+    def edit(self, spec, prefix):
+        filter_file('CC=.*$', '', 'Makefile')
+        filter_file('CFLAGS=.*$', 'CFLAGS=-Wall -g -O3 -D_GNU_SOURCE', 'Makefile')
+        with working_dir('hairs-src'):
+            filter_file(r'(keyvalue\* keypointer;)', 'extern \\1',
+                        'hashtable.h')
+            filter_file(r'(keypointer = ht->blist\[hash\];)', 'keyvalue* \\1',
+                        'hashtable.c')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         with working_dir('build'):
-            install('extractFOSMID', prefix.bin)
+            if self.spec.satisfies('@2017-07-10'):
+                install('extractFOSMID', prefix.bin)
             install('extractHAIRS', prefix.bin)
             install('HAPCUT2', prefix.bin)


### PR DESCRIPTION
We've got tags and releases now, so let's use their versioning scheme.

The older version of this included a vendored htslib, this changed a few years ago, so now we can just add htslib as a dependency and it'll find that automatically.

There are a few additional dependencies that aren't in the original recipe from looking at the makefile.

This also resolves a build error with gcc10+ in hashtable.h and hashtable.c and makes the makefile a little more spack friendly.
I put in https://github.com/vibansal/HapCUT2/pull/123 to address these upstream, and assuming they are merged I can tighten up the version restriction for the edit in the future.