### PR TITLE
Add --os option to containerize

### DIFF
--- a/lib/spack/spack/cmd/containerize.py
+++ b/lib/spack/spack/cmd/containerize.py
@@ -24,6 +24,11 @@ def setup_parser(subparser):
         help='list all the OS that can be used in the bootstrap phase and exit'
     )
     subparser.add_argument(
+        '--os', type=str, dest='os', default=None,
+        help='OS to use in the bootstrap phase'
+    )
+
+    subparser.add_argument(
         '--last-stage',
         choices=('bootstrap', 'build', 'final'),
         default='final',
@@ -46,6 +51,9 @@ def containerize(parser, args):
         raise ValueError(msg.format(config_file))
 
     config = spack.container.validate(config_file)
+
+    if args.os:
+        config['spack']['container']['images']['os'] = args.os
 
     # If we have a monitor request, add monitor metadata to config
     if args.use_monitor:

--- a/share/spack/spack-completion.bash
+++ b/share/spack/spack-completion.bash
@@ -802,7 +802,7 @@ _spack_config_revert() {
 }
 
 _spack_containerize() {
-    SPACK_COMPREPLY="-h --help --monitor --monitor-save-local --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --list-os --last-stage"
+    SPACK_COMPREPLY="-h --help --monitor --monitor-save-local --monitor-tags --monitor-keep-going --monitor-host --monitor-prefix --list-os --os --last-stage"
 }
 
 _spack_create() {


### PR DESCRIPTION
`spack containerize` already takes a `--list-os` but currently requires that each `spack.yaml` be modified individually to build against anything but Spack's hardcoded distribution preference.  This patch introduces a corresponding `--os` option to select any valid listing from `images.json` which contains the profiles listed by `--list-os`.

I maintain that the lack of this feature introduces unnecessary complexity into any affected documentation and/or automation; the former is reasonably low-impact, but not being able to automate generation of recipes in a repeatable and unattended fashion is somewhat more troublesome.  This being my first PR, I am perfectly content to move this to an issue for further discussion and/or to rework or extend it as needed, but since the patch proved much more trivial than I expected I thought I'd begin by simply presenting the code.