### PR TITLE
diamond: updating to 2.0.15

### DIFF
--- a/var/spack/repos/builtin/packages/diamond/package.py
+++ b/var/spack/repos/builtin/packages/diamond/package.py
@@ -12,6 +12,7 @@ class Diamond(CMakePackage):
 
     homepage = "https://ab.inf.uni-tuebingen.de/software/diamond"
     url      = "https://github.com/bbuchfink/diamond/archive/v2.0.9.tar.gz"
+    maintainers = ['snehring']
 
     version('2.0.15', sha256='cc8e1f3fd357d286cf6585b21321bd25af69aae16ae1a8f605ea603c1886ffa4')
     version('2.0.14', sha256='3eaef2b957e4ba845eac27a2ca3249aae4259ff1fe0ff5a21b094481328fdc53')

--- a/var/spack/repos/builtin/packages/diamond/package.py
+++ b/var/spack/repos/builtin/packages/diamond/package.py
@@ -13,6 +13,7 @@ class Diamond(CMakePackage):
     homepage = "https://ab.inf.uni-tuebingen.de/software/diamond"
     url      = "https://github.com/bbuchfink/diamond/archive/v2.0.9.tar.gz"
 
+    version('2.0.15', sha256='cc8e1f3fd357d286cf6585b21321bd25af69aae16ae1a8f605ea603c1886ffa4')
     version('2.0.14', sha256='3eaef2b957e4ba845eac27a2ca3249aae4259ff1fe0ff5a21b094481328fdc53')
     version('2.0.11', sha256='41f3197aaafff9c42763fb7658b67f730ebc6dd3c0533c9c3d54bd3166e93f24')
     version('2.0.9', sha256='3019f1adb6411c6669a3a17351d0338ae02f6b3cab3c8a3bac91cf334dcda620')


### PR DESCRIPTION
They cut a new release that fixes a bug and also the build issue I was seeing when build_type=RelWithDebInfo