### PR TITLE
Upcxx 2022.3.0 update

### DIFF
--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -47,15 +47,16 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
 
     # The optional network backends:
     variant('conduits',
-            values=any_combination_of('smp', 'mpi', 'ibv', 'udp', 'ofi', 'ucx').with_default('smp'),
+            values=any_combination_of('smp', 'mpi', 'ibv',
+                                      'udp', 'ofi', 'ucx').with_default('smp'),
             description="The hardware-dependent network backends to enable.\n" +
-                        "(smp) = SMP conduit for single-node operation ;\n" +
-                        "(ibv) = Native InfiniBand verbs conduit ;\n" +
-                        "(udp) = Portable UDP conduit, for Ethernet networks ;\n" +
-                        "(mpi) = Low-performance/portable MPI conduit ;\n" +
-                        "(ofi) = EXPERIMENTAL Portable OFI conduit over libfabric ;\n" +
-                        "(ucx) = EXPERIMENTAL UCX conduit for Mellanox IB/RoCE ConnectX-5+ ;\n" +
-                        "For detailed recommendations, consult https://gasnet.lbl.gov")
+            "(smp) = SMP conduit for single-node operation ;\n" +
+            "(ibv) = Native InfiniBand verbs conduit ;\n" +
+            "(udp) = Portable UDP conduit, for Ethernet networks ;\n" +
+            "(mpi) = Low-performance/portable MPI conduit ;\n" +
+            "(ofi) = EXPERIMENTAL Portable OFI conduit over libfabric ;\n" +
+            "(ucx) = EXPERIMENTAL UCX conduit for Mellanox IB/RoCE ConnectX-5+ ;\n" +
+            "For detailed recommendations, consult https://gasnet.lbl.gov")
 
     variant('debug', default=False, description="Enable library debugging mode")
 

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -47,12 +47,14 @@ class Gasnet(Package):
 
     # The optional network backends:
     variant('conduits',
-            values=any_combination_of('smp', 'mpi', 'ibv', 'udp').with_default('smp'),
+            values=any_combination_of('smp', 'mpi', 'ibv', 'udp', 'ofi', 'ucx').with_default('smp'),
             description="The hardware-dependent network backends to enable.\n" +
                         "(smp) = SMP conduit for single-node operation ;\n" +
                         "(ibv) = Native InfiniBand verbs conduit ;\n" +
                         "(udp) = Portable UDP conduit, for Ethernet networks ;\n" +
                         "(mpi) = Low-performance/portable MPI conduit ;\n" +
+                        "(ofi) = EXPERIMENTAL Portable OFI conduit over libfabric ;\n" +
+                        "(ucx) = EXPERIMENTAL UCX conduit for Mellanox IB/RoCE ConnectX-5+ ;\n" +
                         "For detailed recommendations, consult https://gasnet.lbl.gov")
 
     variant('debug', default=False, description="Enable library debugging mode")
@@ -94,6 +96,8 @@ class Gasnet(Package):
             for c in spec.variants['conduits'].value:
                 options.append("--enable-" + c)
 
+            options.append("--enable-rpath")
+
             configure(*options)
             make()
             make('install')
@@ -126,6 +130,8 @@ class Gasnet(Package):
             'smp': ['env', 'GASNET_PSHM_NODES=' + ranks],
             'mpi': [join_path(self.prefix.bin, 'gasnetrun_mpi'), '-n', ranks],
             'ibv': [join_path(self.prefix.bin, 'gasnetrun_ibv'), '-n', ranks],
+            'ofi': [join_path(self.prefix.bin, 'gasnetrun_ofi'), '-n', ranks],
+            'ucx': [join_path(self.prefix.bin, 'gasnetrun_ucx'), '-n', ranks],
             'udp': [join_path(self.prefix.bin, 'amudprun'), '-spawn', 'L', '-np', ranks]
         }
 

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -8,7 +8,7 @@ import os
 from spack import *
 
 
-class Gasnet(Package):
+class Gasnet(Package, CudaPackage, ROCmPackage):
     """GASNet is a language-independent, networking middleware layer that
        provides network-independent, high-performance communication primitives
        including Remote Memory Access (RMA) and Active Messages (AM). It has been
@@ -59,7 +59,15 @@ class Gasnet(Package):
 
     variant('debug', default=False, description="Enable library debugging mode")
 
+    variant('cuda', default=False,
+            description='Enables support for the CUDA memory kind in some conduits')
+
+    variant('rocm', default=False,
+            description='Enables support for the ROCm/HIP memory kind in some conduits')
+
     depends_on('mpi', when='conduits=mpi')
+    depends_on('cuda', when='+cuda')
+    depends_on('hip@4.5.0:', when='+rocm')
 
     depends_on('autoconf@2.69', type='build', when='@master:')
     depends_on('automake@1.16:', type='build', when='@master:')
@@ -86,6 +94,12 @@ class Gasnet(Package):
 
             if '+debug' in spec:
                 options.append("--enable-debug")
+
+            if '+cuda' in spec:
+                options.append("--enable-kind-cuda-uva")
+
+            if '+rocm' in spec:
+                options.append("--enable-kind-hip")
 
             if 'conduits=mpi' in spec:
                 options.append("--enable-mpi-compat")

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -36,6 +36,7 @@ class Gasnet(Package):
     version('main',    branch='stable')
     version('master',  branch='master')
 
+    version('2022.3.0',  sha256='91b59aa84c0680c807e00d3d1d8fa7c33c1aed50b86d1616f93e499620a9ba09')
     version('2021.9.0',  sha256='1b6ff6cdad5ecf76b92032ef9507e8a0876c9fc3ee0ab008de847c1fad0359ee')
     version('2021.3.0',  sha256='8a40fb3fa8bacc3922cd4d45217816fcb60100357ab97fb622a245567ea31747')
     version('2020.10.0', sha256='ed17baf7fce90499b539857ee37b3eea961aa475cffbde77e4c607a34ece06a0')

--- a/var/spack/repos/builtin/packages/gasnet/package.py
+++ b/var/spack/repos/builtin/packages/gasnet/package.py
@@ -67,11 +67,11 @@ class Gasnet(Package, CudaPackage, ROCmPackage):
             description='Enables support for the ROCm/HIP memory kind in some conduits')
 
     depends_on('mpi', when='conduits=mpi')
-    depends_on('cuda', when='+cuda')
-    depends_on('hip@4.5.0:', when='+rocm')
 
     depends_on('autoconf@2.69', type='build', when='@master:')
     depends_on('automake@1.16:', type='build', when='@master:')
+
+    conflicts('hip@:4.4.0', when='+rocm')
 
     def install(self, spec, prefix):
         if spec.satisfies('@master:'):

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -12,9 +12,11 @@ def is_CrayXC():
     return (spack.platforms.host().name == 'cray') and \
            (os.environ.get('CRAYPE_NETWORK_TARGET') == "aries")
 
+
 def is_CrayEX():
     return (spack.platforms.host().name == 'cray') and \
-           (os.environ.get('CRAYPE_NETWORK_TARGET') in ['ofi','ucx'])
+           (os.environ.get('CRAYPE_NETWORK_TARGET') in ['ofi', 'ucx'])
+
 
 def cross_detect():
     if is_CrayXC():
@@ -150,14 +152,15 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
                 provider = 'cxi'
             else:
                 provider = 'verbs;ofi_rxm'
-           
+
             # Append the recommended options for Cray Shasta
             options.append('--with-pmi-version=cray')
             options.append('--with-pmi-runcmd=\'srun -n %N -- %C\'')
             options.append('--disable-ibv')
             options.append('--enable-ofi')
             options.append('--with-ofi-provider=' + provider)
-            env['GASNET_CONFIGURE_ARGS'] = '--with-ofi-spawner=pmi ' + env['GASNET_CONFIGURE_ARGS']
+            env['GASNET_CONFIGURE_ARGS'] = \
+                '--with-ofi-spawner=pmi ' + env['GASNET_CONFIGURE_ARGS']
 
         if '+gasnet' in spec:
             options.append('--with-gasnet=' + spec['gasnet'].prefix.src)
@@ -176,7 +179,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
 
         if '+rocm' in spec:
             options.append('--enable-hip')
-            options.append('--with-ld-flags=' + \
+            options.append('--with-ld-flags=' +
                            self.compiler.cc_rpath_arg + spec['hip'].prefix.lib)
 
         env['GASNET_CONFIGURE_ARGS'] = '--enable-rpath ' + env['GASNET_CONFIGURE_ARGS']

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -39,6 +39,7 @@ class Upcxx(Package):
     version('develop', branch='develop')
     version('master',  branch='master')
 
+    version('2022.3.0', sha256='72bccfc9dfab5c2351ee964232b3754957ecfdbe6b4de640e1b1387d45019496')
     version('2021.9.0', sha256='9299e17602bcc8c05542cdc339897a9c2dba5b5c3838d6ef2df7a02250f42177')
     version('2021.3.0', sha256='3433714cd4162ffd8aad9a727c12dbf1c207b7d6664879fc41259a4b351595b7')
     version('2020.11.0', sha256='f6f212760a485a9f346ca11bb4751e7095bbe748b8e5b2389ff9238e9e321317',

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -79,9 +79,9 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
     depends_on('gasnet conduits=none', when='+gasnet')
 
     depends_on('mpi', when='+mpi')
-    depends_on('cuda', when='+cuda')
-    depends_on('hip@4.5.0:', when='+rocm')
     depends_on('python@2.7.5:', type=("build", "run"))
+
+    conflicts('hip@:4.4.0', when='+rocm')
 
     # All flags should be passed to the build-env in autoconf-like vars
     flag_handler = env_flags


### PR DESCRIPTION
This PR updates packages [UPC++](https://upcxx.lbl.gov) and [GASNet-EX](https://gasnet.lbl.gov)  from the [LBNL Pagoda group](https://go.lbl.gov/class) to the 2022.3.0 release.

This notably includes adding support for HPE Cray EX "Shasta" systems with Slingshot-10/11 networks, along with AMD ROCm HIP support and improvements to the NVIDIA CUDA support.