### PR TITLE
added libpng version 1.5.30 to libpng package

### DIFF
--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -21,7 +21,7 @@ class Libpng(AutotoolsPackage):
     #     released on 15 April 2019.
 
     # Required for qt@3
-    version('1.5.30', sha256='6c32c7264f040cc6a4b11798c902a16bcd0626c7d7549fa4481264482f129514')
+    version('1.5.30', sha256='7d76275fad2ede4b7d87c5fd46e6f488d2a16b5a69dc968ffa840ab39ba756ed')
     version('1.2.57', sha256='0f4620e11fa283fedafb474427c8e96bf149511a1804bdc47350963ae5cf54d8')
 
     depends_on('zlib@1.0.4:')  # 1.2.5 or later recommended

--- a/var/spack/repos/builtin/packages/libpng/package.py
+++ b/var/spack/repos/builtin/packages/libpng/package.py
@@ -21,6 +21,7 @@ class Libpng(AutotoolsPackage):
     #     released on 15 April 2019.
 
     # Required for qt@3
+    version('1.5.30', sha256='6c32c7264f040cc6a4b11798c902a16bcd0626c7d7549fa4481264482f129514')
     version('1.2.57', sha256='0f4620e11fa283fedafb474427c8e96bf149511a1804bdc47350963ae5cf54d8')
 
     depends_on('zlib@1.0.4:')  # 1.2.5 or later recommended


### PR DESCRIPTION
[DAMASK](https://spack.readthedocs.io/en/latest/package_list.html#damask) requires a specific currently unavailable version of `libpng` in order to be used in conjunction with MSCMarc.