### PR TITLE
gdal: changing behavior of configure for +xml2 with 3.0+

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -414,7 +414,7 @@ class Gdal(AutotoolsPackage):
             args.append('--with-curl=no')
 
         if '+xml2' in spec:
-            if spec.satisfies('@:2.4.4'):
+            if spec.satisfies('@:2'):
                 args.append('--with-xml2={0}'.format(
                     join_path(spec['libxml2'].prefix.bin, 'xml2-config')))
             else:

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -414,8 +414,11 @@ class Gdal(AutotoolsPackage):
             args.append('--with-curl=no')
 
         if '+xml2' in spec:
-            args.append('--with-xml2={0}'.format(
-                join_path(spec['libxml2'].prefix.bin, 'xml2-config')))
+            if spec.satisfies('@:2.4.4'):
+                args.append('--with-xml2={0}'.format(
+                    join_path(spec['libxml2'].prefix.bin, 'xml2-config')))
+            else:
+                args.append('--with-xml2=yes')
         else:
             args.append('--with-xml2=no')
 


### PR DESCRIPTION
Between 2.4 and 3 the behavior of the configure script for --with-xml2 seemingly changed from accepting a path to xml2 to being just 'yes' or 'no'.