### PR TITLE
Preserve Permissions on Zipfile extraction

### DIFF
--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -52,7 +52,7 @@ def _unzip(archive_file):
         archive_file (str): absolute path of the file to be decompressed
     """
     exe = 'unzip'
-    arg = '-xf'
+    arg = '-q'
     if is_windows:
         exe = 'tar'
         arg = '-xf'


### PR DESCRIPTION
#24556 merged in support for Python's .zip file support via `ZipFile`, however as per #30200 `ZipFile` does not preserve file permissions of the extracted contents. This PR subclasses `ZipFile` to allow the propagation of permissions.