### PR TITLE
Allow packages with multiple build-systems (inheritance)

### DIFF
--- a/lib/spack/docs/build_systems/cmakepackage.rst
+++ b/lib/spack/docs/build_systems/cmakepackage.rst
@@ -130,8 +130,8 @@ Adding flags to cmake
 To add additional flags to the ``cmake`` call, simply override the
 ``cmake_args`` function. The following example defines values for the flags
 ``WHATEVER``, ``ENABLE_BROKEN_FEATURE``, ``DETECT_HDF5``, and ``THREADS`` with
-and without the :meth:`~spack.build_systems.cmake.CMakePackage.define` and
-:meth:`~spack.build_systems.cmake.CMakePackage.define_from_variant` helper functions:
+and without the :meth:`~spack.build_systems.cmake.CMakeWrapper.define` and
+:meth:`~spack.build_systems.cmake.CMakeWrapper.define_from_variant` helper functions:
 
 .. code-block:: python
 

--- a/lib/spack/docs/developer_guide.rst
+++ b/lib/spack/docs/developer_guide.rst
@@ -151,7 +151,7 @@ Package-related modules
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 :mod:`spack.package`
-  Contains the :class:`~spack.package.Package` class, which
+  Contains the :class:`~spack.package.PackageBase` class, which
   is the superclass for all packages in Spack.  Methods on ``Package``
   implement all phases of the :ref:`package lifecycle
   <package-lifecycle>` and manage the build process.

--- a/lib/spack/docs/packaging_guide.rst
+++ b/lib/spack/docs/packaging_guide.rst
@@ -3022,7 +3022,7 @@ The classes that are currently provided by Spack are:
 +----------------------------------------------------------+----------------------------------+
 |     **Base Class**                                       |           **Purpose**            |
 +==========================================================+==================================+
-| :class:`~spack.package.Package`                          | General base class not           |
+| :class:`~spack.build_systems.generic.Package`            | General base class not           |
 |                                                          | specialized for any build system |
 +----------------------------------------------------------+----------------------------------+
 | :class:`~spack.build_systems.makefile.MakefilePackage`   | Specialized class for packages   |
@@ -3118,7 +3118,7 @@ docs at :py:mod:`~.spack.build_systems`, or using the ``spack info`` command:
 Typically, phases have default implementations that fit most of the common cases:
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/autotools.py
-    :pyobject: AutotoolsPackage.configure
+    :pyobject: AutotoolsWrapper.configure
     :linenos:
 
 It is thus just sufficient for a packager to override a few
@@ -3153,7 +3153,7 @@ for the install phase is:
     For those not used to Python instance methods, this is the
     package itself.  In this case it's an instance of ``Foo``, which
     extends ``Package``.  For API docs on Package objects, see
-    :py:class:`Package <spack.package.Package>`.
+    :py:class:`Package <spack.build_systems.generic.Package>`.
 
 ``spec``
     This is the concrete spec object created by Spack from an

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -541,9 +541,9 @@ def _set_variables_for_single_module(pkg, module):
     if sys.platform == 'win32':
         m.nmake = Executable('nmake')
     # Standard CMake arguments
-    m.std_cmake_args = spack.build_systems.cmake.CMakePackage._std_args(pkg)
-    m.std_meson_args = spack.build_systems.meson.MesonPackage._std_args(pkg)
-    m.std_pip_args = spack.build_systems.python.PythonPackage._std_args(pkg)
+    m.std_cmake_args = spack.build_systems.cmake.CMakeWrapper._std_args(pkg)
+    m.std_meson_args = spack.build_systems.meson.MesonWrapper._std_args(pkg)
+    m.std_pip_args = spack.build_systems.python.PythonPipWrapper._std_args(pkg)
 
     # Put spack compiler paths in module scope.
     link_dir = spack.paths.build_env_path
@@ -714,22 +714,6 @@ def get_rpaths(pkg):
     return list(dedupe(filter_system_paths(rpaths)))
 
 
-def get_std_cmake_args(pkg):
-    """List of standard arguments used if a package is a CMakePackage.
-
-    Returns:
-        list: standard arguments that would be used if this
-        package were a CMakePackage instance.
-
-    Args:
-        pkg (spack.package.PackageBase): package under consideration
-
-    Returns:
-        list: arguments for cmake
-    """
-    return spack.build_systems.cmake.CMakePackage._std_args(pkg)
-
-
 def get_std_meson_args(pkg):
     """List of standard arguments used if a package is a MesonPackage.
 
@@ -743,7 +727,7 @@ def get_std_meson_args(pkg):
     Returns:
         list: arguments for meson
     """
-    return spack.build_systems.meson.MesonPackage._std_args(pkg)
+    return spack.build_systems.meson.MesonWrapper._std_args(pkg)
 
 
 def parent_class_modules(cls):

--- a/lib/spack/spack/build_systems/aspell_dict.py
+++ b/lib/spack/spack/build_systems/aspell_dict.py
@@ -21,7 +21,7 @@ from .autotools import AutotoolsPackage, autotools
 class AspellDictPackage(AutotoolsPackage):
     """Specialized class for building aspell dictionairies."""
 
-    extends('aspell')
+    extends('aspell', when='buildsystem=autotools')
 
     def view_destination(self, view):
         aspell_spec = self.spec['aspell']

--- a/lib/spack/spack/build_systems/aspell_dict.py
+++ b/lib/spack/spack/build_systems/aspell_dict.py
@@ -2,15 +2,13 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-# Why doesn't this work for me?
-# from spack import *
 from llnl.util.filesystem import filter_file
 
-from spack.build_systems.autotools import AutotoolsPackage
 from spack.directives import extends
 from spack.package import ExtensionError
 from spack.util.executable import which
+
+from .autotools import AutotoolsPackage, autotools
 
 
 #
@@ -40,6 +38,7 @@ class AspellDictPackage(AutotoolsPackage):
         filter_file(r'^dictdir=.*$', 'dictdir=/lib', 'configure')
         filter_file(r'^datadir=.*$', 'datadir=/lib', 'configure')
 
+    @autotools
     def configure(self, spec, prefix):
         aspell = spec['aspell'].prefix.bin.aspell
         prezip = spec['aspell'].prefix.bin.prezip

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -16,7 +16,8 @@ from llnl.util.filesystem import force_remove, working_dir
 import spack.builder
 import spack.package
 from spack.build_environment import InstallError
-from spack.directives import conflicts, depends_on
+from spack.directives import buildsystem, conflicts, depends_on
+from spack.multimethod import when
 from spack.operating_systems.mac_os import macos_version
 from spack.util.executable import Executable
 from spack.version import Version
@@ -60,12 +61,12 @@ class AutotoolsPackage(spack.package.PackageBase):
     #: system base class
     build_system_class = 'AutotoolsPackage'
 
-    build_system = 'autotools'
-
-    depends_on('gnuconfig', type='build', when='target=ppc64le:')
-    depends_on('gnuconfig', type='build', when='target=aarch64:')
-    depends_on('gnuconfig', type='build', when='target=riscv64:')
-    conflicts('platform=windows')
+    buildsystem('autotools')
+    with when('buildsystem=autotools'):
+        depends_on('gnuconfig', type='build', when='target=ppc64le:')
+        depends_on('gnuconfig', type='build', when='target=aarch64:')
+        depends_on('gnuconfig', type='build', when='target=riscv64:')
+        conflicts('platform=windows')
 
     def flags_to_build_system_args(self, flags):
         """Produces a list of all command line arguments to pass specified

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -61,6 +61,9 @@ class AutotoolsPackage(spack.package.PackageBase):
     #: system base class
     build_system_class = 'AutotoolsPackage'
 
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'autotools'
+
     buildsystem('autotools')
     with when('buildsystem=autotools'):
         depends_on('gnuconfig', type='build', when='target=ppc64le:')

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -29,30 +29,30 @@ autotools = spack.builder.BuilderMeta.make_decorator('autotools')
 class AutotoolsPackage(spack.package.PackageBase):
     """Specialized class for packages built using GNU Autotools.
 
-    This class provides four phases that can be overridden:
+    There are four phases that can be overridden:
 
-        1. :py:meth:`~.AutotoolsPackage.autoreconf`
-        2. :py:meth:`~.AutotoolsPackage.configure`
-        3. :py:meth:`~.AutotoolsPackage.build`
-        4. :py:meth:`~.AutotoolsPackage.install`
+        1. :py:meth:`~.AutotoolsWrapper.autoreconf`
+        2. :py:meth:`~.AutotoolsWrapper.configure`
+        3. :py:meth:`~.AutotoolsWrapper.build`
+        4. :py:meth:`~.AutotoolsWrapper.install`
 
     They all have sensible defaults and for many packages the only thing
     necessary will be to override the helper method
-    :meth:`~spack.build_systems.autotools.AutotoolsPackage.configure_args`.
+    :meth:`~spack.build_systems.autotools.AutotoolsWrapper.configure_args`.
     For a finer tuning you may also override:
 
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
         +===============================================+====================+
-        | :py:attr:`~.AutotoolsPackage.build_targets`   | Specify ``make``   |
+        | :py:attr:`~.AutotoolsWrapper.build_targets`   | Specify ``make``   |
         |                                               | targets for the    |
         |                                               | build phase        |
         +-----------------------------------------------+--------------------+
-        | :py:attr:`~.AutotoolsPackage.install_targets` | Specify ``make``   |
+        | :py:attr:`~.AutotoolsWrapper.install_targets` | Specify ``make``   |
         |                                               | targets for the    |
         |                                               | install phase      |
         +-----------------------------------------------+--------------------+
-        | :py:meth:`~.AutotoolsPackage.check`           | Run  build time    |
+        | :py:meth:`~.AutotoolsWrapper.check`           | Run  build time    |
         |                                               | tests if required  |
         +-----------------------------------------------+--------------------+
 
@@ -110,10 +110,10 @@ class AutotoolsWrapper(spack.builder.BuildWrapper):
     #: (currently only for Arm/Clang/Fujitsu/NVHPC compilers)
     patch_libtool = True
 
-    #: Targets for ``make`` during the :py:meth:`~.AutotoolsPackage.build`
+    #: Targets for ``make`` during the :py:meth:`~.AutotoolsWrapper.build`
     #: phase
     build_targets = []  # type: List[str]
-    #: Targets for ``make`` during the :py:meth:`~.AutotoolsPackage.install`
+    #: Targets for ``make`` during the :py:meth:`~.AutotoolsWrapper.install`
     #: phase
     install_targets = ['install']
 
@@ -399,7 +399,7 @@ To resolve this problem, please try the following:
         appropriately, otherwise raises an error.
 
         :raises RuntimeError: if a configure script is not found in
-            :py:meth:`~AutotoolsPackage.configure_directory`
+            :py:meth:`~AutotoolsWrapper.configure_directory`
         """
         # Check if a configure script is there. If not raise a RuntimeError.
         if not os.path.exists(self.configure_abs_path):
@@ -421,7 +421,7 @@ To resolve this problem, please try the following:
 
     def configure(self, spec, prefix):
         """Runs configure with the arguments specified in
-        :meth:`~spack.build_systems.autotools.AutotoolsPackage.configure_args`
+        :meth:`~spack.build_systems.autotools.AutotoolsWrapper.configure_args`
         and an appropriately set prefix.
         """
         options = getattr(self, 'configure_flag_args', [])
@@ -440,7 +440,7 @@ To resolve this problem, please try the following:
 
     def build(self, spec, prefix):
         """Makes the build targets specified by
-        :py:attr:``~.AutotoolsPackage.build_targets``
+        :py:attr:``~.AutotoolsWrapper.build_targets``
         """
         # See https://autotools.io/automake/silent.html
         params = ['V=1']
@@ -450,7 +450,7 @@ To resolve this problem, please try the following:
 
     def install(self, spec, prefix):
         """Makes the install targets specified by
-        :py:attr:``~.AutotoolsPackage.install_targets``
+        :py:attr:``~.AutotoolsWrapper.install_targets``
         """
         with working_dir(self.build_directory):
             inspect.getmodule(self).make(*self.install_targets)
@@ -476,8 +476,8 @@ To resolve this problem, please try the following:
             variant=None
     ):
         """This function contains the current implementation details of
-        :meth:`~spack.build_systems.autotools.AutotoolsPackage.with_or_without` and
-        :meth:`~spack.build_systems.autotools.AutotoolsPackage.enable_or_disable`.
+        :meth:`~spack.build_systems.autotools.AutotoolsWrapper.with_or_without` and
+        :meth:`~spack.build_systems.autotools.AutotoolsWrapper.enable_or_disable`.
 
         Args:
             name (str): name of the option that is being activated or not
@@ -631,7 +631,7 @@ To resolve this problem, please try the following:
 
     def enable_or_disable(self, name, activation_value=None, variant=None):
         """Same as
-        :meth:`~spack.build_systems.autotools.AutotoolsPackage.with_or_without`
+        :meth:`~spack.build_systems.autotools.AutotoolsWrapper.with_or_without`
         but substitute ``with`` with ``enable`` and ``without`` with ``disable``.
 
         Args:

--- a/lib/spack/spack/build_systems/bundle.py
+++ b/lib/spack/spack/build_systems/bundle.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import spack.builder
+import spack.package
+
+
+class BundlePackage(spack.package.PackageBase):
+    """General purpose bundle, or no-code, package class."""
+    #: This attribute is used in UI queries that require to know which
+    #: build-system class we are using
+    build_system_class = 'BundlePackage'
+
+    build_system = 'bundle'
+    #: Bundle packages do not have associated source or binary code.
+    has_code = False
+
+
+@spack.builder.builder('bundle')
+class BundleBuilder(spack.builder.Builder):
+    phases = ('install',)
+
+    class PackageWrapper(spack.builder.BuildWrapper):
+        def install(self, spec, prefix):
+            pass

--- a/lib/spack/spack/build_systems/bundle.py
+++ b/lib/spack/spack/build_systems/bundle.py
@@ -13,6 +13,9 @@ class BundlePackage(spack.package.PackageBase):
     #: build-system class we are using
     build_system_class = 'BundlePackage'
 
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'bundle'
+
     spack.directives.buildsystem('bundle')
     #: Bundle packages do not have associated source or binary code.
     has_code = False

--- a/lib/spack/spack/build_systems/bundle.py
+++ b/lib/spack/spack/build_systems/bundle.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import spack.builder
+import spack.directives
 import spack.package
 
 
@@ -12,7 +13,7 @@ class BundlePackage(spack.package.PackageBase):
     #: build-system class we are using
     build_system_class = 'BundlePackage'
 
-    build_system = 'bundle'
+    spack.directives.buildsystem('bundle')
     #: Bundle packages do not have associated source or binary code.
     has_code = False
 

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -81,6 +81,9 @@ class CMakePackage(PackageBase):
     #: system base class
     build_system_class = 'CMakePackage'
 
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'cmakelists'
+
     buildsystem('cmakelists')
     with when('buildsystem=cmakelists'):
         # https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -46,21 +46,21 @@ class CMakePackage(PackageBase):
 
     This class provides three phases that can be overridden:
 
-        1. :py:meth:`~.CMakePackage.cmake`
-        2. :py:meth:`~.CMakePackage.build`
-        3. :py:meth:`~.CMakePackage.install`
+        1. :py:meth:`~.CMakeWrapper.cmake`
+        2. :py:meth:`~.CMakeWrapper.build`
+        3. :py:meth:`~.CMakeWrapper.install`
 
     They all have sensible defaults and for many packages the only thing
-    necessary will be to override :py:meth:`~.CMakePackage.cmake_args`.
+    necessary will be to override :py:meth:`~.CMakeWrapper.cmake_args`.
     For a finer tuning you may also override:
 
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
         +===============================================+====================+
-        | :py:meth:`~.CMakePackage.root_cmakelists_dir` | Location of the    |
+        | :py:meth:`~.CMakeWrapper.root_cmakelists_dir` | Location of the    |
         |                                               | root CMakeLists.txt|
         +-----------------------------------------------+--------------------+
-        | :py:meth:`~.CMakePackage.build_directory`     | Directory where to |
+        | :py:meth:`~.CMakeWrapper.build_directory`     | Directory where to |
         |                                               | build the package  |
         +-----------------------------------------------+--------------------+
 
@@ -288,7 +288,7 @@ class CMakeWrapper(spack.builder.BuildWrapper):
         of ``cmake_var``.
 
         This utility function is similar to
-        :meth:`~spack.build_systems.autotools.AutotoolsPackage.with_or_without`.
+        :meth:`~spack.build_systems.autotools.AutotoolsWrapper.with_or_without`.
 
         Examples:
 

--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import spack.builder
+import spack.package
+
+# Decorator for the generic build system
+generic = spack.builder.BuilderMeta.make_decorator(build_system='generic')
+
+
+@spack.builder.builder('generic')
+class GenericBuilder(spack.builder.Builder):
+    """A builder for a generic build system, that require packagers
+    to implement an "install" phase.
+    """
+    #: A generic package has only the "install" phase
+    phases = ('install',)
+
+    class PackageWrapper(spack.builder.BuildWrapper):
+        # This will be used as a registration decorator in user
+        # packages, if need be
+        generic.run_after('install')(spack.package.PackageBase.sanity_check_prefix)
+        # On macOS, force rpaths for shared library IDs and remove duplicate rpaths
+        generic.run_after('install')(spack.package.PackageBase.apply_macos_rpath_fixups)
+
+
+class Package(spack.package.PackageBase):
+    """General purpose class with a single ``install`` phase that needs to be
+    coded by packagers.
+    """
+    #: This attribute is used in UI queries that require to know which
+    #: build-system class we are using
+    build_system_class = 'Package'
+    #: Build system used by this package (will become a variant)
+    build_system = 'generic'

--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -33,5 +33,7 @@ class Package(spack.package.PackageBase):
     #: This attribute is used in UI queries that require to know which
     #: build-system class we are using
     build_system_class = 'Package'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'generic'
     #: Build system used by this package (will become a variant)
     spack.directives.buildsystem('generic')

--- a/lib/spack/spack/build_systems/generic.py
+++ b/lib/spack/spack/build_systems/generic.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import spack.builder
+import spack.directives
 import spack.package
 
 # Decorator for the generic build system
@@ -33,4 +34,4 @@ class Package(spack.package.PackageBase):
     #: build-system class we are using
     build_system_class = 'Package'
     #: Build system used by this package (will become a variant)
-    build_system = 'generic'
+    spack.directives.buildsystem('generic')

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -21,27 +21,27 @@ class MakefilePackage(spack.package.PackageBase):
 
     This class provides three phases that can be overridden:
 
-        1. :py:meth:`~.MakefilePackage.edit`
-        2. :py:meth:`~.MakefilePackage.build`
-        3. :py:meth:`~.MakefilePackage.install`
+        1. :py:meth:`~.MakefileWrapper.edit`
+        2. :py:meth:`~.MakefileWrapper.build`
+        3. :py:meth:`~.MakefileWrapper.install`
 
-    It is usually necessary to override the :py:meth:`~.MakefilePackage.edit`
-    phase, while :py:meth:`~.MakefilePackage.build` and
-    :py:meth:`~.MakefilePackage.install` have sensible defaults.
+    It is usually necessary to override the :py:meth:`~.MakefileWrapper.edit`
+    phase, while :py:meth:`~.MakefileWrapper.build` and
+    :py:meth:`~.MakefileWrapper.install` have sensible defaults.
     For a finer tuning you may override:
 
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
         +===============================================+====================+
-        | :py:attr:`~.MakefilePackage.build_targets`    | Specify ``make``   |
+        | :py:attr:`~.MakefileWrapper.build_targets`    | Specify ``make``   |
         |                                               | targets for the    |
         |                                               | build phase        |
         +-----------------------------------------------+--------------------+
-        | :py:attr:`~.MakefilePackage.install_targets`  | Specify ``make``   |
+        | :py:attr:`~.MakefileWrapper.install_targets`  | Specify ``make``   |
         |                                               | targets for the    |
         |                                               | install phase      |
         +-----------------------------------------------+--------------------+
-        | :py:meth:`~.MakefilePackage.build_directory`  | Directory where the|
+        | :py:meth:`~.MakefileWrapper.build_directory`  | Directory where the|
         |                                               | Makefile is located|
         +-----------------------------------------------+--------------------+
     """
@@ -56,10 +56,10 @@ class MakefilePackage(spack.package.PackageBase):
 
 
 class MakefileWrapper(spack.builder.BuildWrapper):
-    #: Targets for ``make`` during the :py:meth:`~.MakefilePackage.build`
+    #: Targets for ``make`` during the :py:meth:`~.MakefileWrapper.build`
     #: phase
     build_targets = []  # type: List[str]
-    #: Targets for ``make`` during the :py:meth:`~.MakefilePackage.install`
+    #: Targets for ``make`` during the :py:meth:`~.MakefileWrapper.install`
     #: phase
     install_targets = ['install']
 
@@ -84,14 +84,14 @@ class MakefileWrapper(spack.builder.BuildWrapper):
         tty.msg('Using default implementation: skipping edit phase.')
 
     def build(self, spec, prefix):
-        """Calls make, passing :py:attr:`~.MakefilePackage.build_targets`
+        """Calls make, passing :py:attr:`~.MakefileWrapper.build_targets`
         as targets.
         """
         with working_dir(self.build_directory):
             inspect.getmodule(self).make(*self.build_targets)
 
     def install(self, spec, prefix):
-        """Calls make, passing :py:attr:`~.MakefilePackage.install_targets`
+        """Calls make, passing :py:attr:`~.MakefileWrapper.install_targets`
         as targets.
         """
         with working_dir(self.build_directory):

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -10,7 +10,7 @@ from llnl.util.filesystem import working_dir
 
 import spack.builder
 import spack.package
-from spack.directives import conflicts
+from spack.directives import buildsystem, conflicts
 
 # Decorator used to record callbacks and phases related to autotools
 makefile = spack.builder.BuilderMeta.make_decorator('makefile')
@@ -49,8 +49,7 @@ class MakefilePackage(spack.package.PackageBase):
     #: system base class
     build_system_class = 'MakefilePackage'
 
-    build_system = 'makefile'
-
+    buildsystem('makefile')
     conflicts('platform=windows')
 
 

--- a/lib/spack/spack/build_systems/makefile.py
+++ b/lib/spack/spack/build_systems/makefile.py
@@ -48,6 +48,8 @@ class MakefilePackage(spack.package.PackageBase):
     #: This attribute is used in UI queries that need to know the build
     #: system base class
     build_system_class = 'MakefilePackage'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'makefile'
 
     buildsystem('makefile')
     conflicts('platform=windows')

--- a/lib/spack/spack/build_systems/maven.py
+++ b/lib/spack/spack/build_systems/maven.py
@@ -2,16 +2,17 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 from llnl.util.filesystem import install_tree, working_dir
 
+import spack.builder
+import spack.package
 from spack.directives import depends_on
-from spack.package import PackageBase, run_after
 from spack.util.executable import which
 
+maven = spack.builder.BuilderMeta.make_decorator('maven')
 
-class MavenPackage(PackageBase):
+
+class MavenPackage(spack.package.PackageBase):
     """Specialized class for packages that are built using the
     Maven build system. See https://maven.apache.org/index.html
     for more information.
@@ -21,40 +22,45 @@ class MavenPackage(PackageBase):
     * build
     * install
     """
-    # Default phases
-    phases = ['build', 'install']
-
     # To be used in UI queries that require to know which
     # build-system class we are using
     build_system_class = 'MavenPackage'
 
+    build_system = 'maven'
+
     depends_on('java', type=('build', 'run'))
     depends_on('maven', type='build')
 
-    @property
-    def build_directory(self):
-        """The directory containing the ``pom.xml`` file."""
-        return self.stage.source_path
 
-    def build_args(self):
-        """List of args to pass to build phase."""
-        return []
+@spack.builder.builder('maven')
+class MavenBuilder(spack.builder.Builder):
+    phases = ('build', 'install')
 
-    def build(self, spec, prefix):
-        """Compile code and package into a JAR file."""
+    class PackageWrapper(spack.builder.BuildWrapper):
+        @property
+        def build_directory(self):
+            """The directory containing the ``pom.xml`` file."""
+            return self.stage.source_path
 
-        with working_dir(self.build_directory):
-            mvn = which('mvn')
-            if self.run_tests:
-                mvn('verify', *self.build_args())
-            else:
-                mvn('package', '-DskipTests', *self.build_args())
+        def build_args(self):
+            """List of args to pass to build phase."""
+            return []
 
-    def install(self, spec, prefix):
-        """Copy to installation prefix."""
+        def build(self, spec, prefix):
+            """Compile code and package into a JAR file."""
 
-        with working_dir(self.build_directory):
-            install_tree('.', prefix)
+            with working_dir(self.build_directory):
+                mvn = which('mvn')
+                if self.run_tests:
+                    mvn('verify', *self.build_args())
+                else:
+                    mvn('package', '-DskipTests', *self.build_args())
 
-    # Check that self.prefix is there after installation
-    run_after('install')(PackageBase.sanity_check_prefix)
+        def install(self, spec, prefix):
+            """Copy to installation prefix."""
+
+            with working_dir(self.build_directory):
+                install_tree('.', prefix)
+
+        # Check that self.prefix is there after installation
+        maven.run_after('install')(spack.package.PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/maven.py
+++ b/lib/spack/spack/build_systems/maven.py
@@ -6,7 +6,8 @@ from llnl.util.filesystem import install_tree, working_dir
 
 import spack.builder
 import spack.package
-from spack.directives import depends_on
+from spack.directives import buildsystem, depends_on
+from spack.multimethod import when
 from spack.util.executable import which
 
 maven = spack.builder.BuilderMeta.make_decorator('maven')
@@ -26,10 +27,10 @@ class MavenPackage(spack.package.PackageBase):
     # build-system class we are using
     build_system_class = 'MavenPackage'
 
-    build_system = 'maven'
-
-    depends_on('java', type=('build', 'run'))
-    depends_on('maven', type='build')
+    buildsystem('maven')
+    with when('buildsystem=maven'):
+        depends_on('java', type=('build', 'run'))
+        depends_on('maven', type='build')
 
 
 @spack.builder.builder('maven')

--- a/lib/spack/spack/build_systems/maven.py
+++ b/lib/spack/spack/build_systems/maven.py
@@ -27,6 +27,9 @@ class MavenPackage(spack.package.PackageBase):
     # build-system class we are using
     build_system_class = 'MavenPackage'
 
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'maven'
+
     buildsystem('maven')
     with when('buildsystem=maven'):
         depends_on('java', type=('build', 'run'))

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -48,6 +48,9 @@ class MesonPackage(spack.package.PackageBase):
     #: system base class
     build_system_class = 'MesonPackage'
 
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'mesonbuild'
+
     buildsystem('mesonbuild')
     with when('buildsystem=mesonbuild'):
         variant('buildtype', default='debugoptimized',

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -24,21 +24,21 @@ class MesonPackage(spack.package.PackageBase):
 
     This class provides three phases that can be overridden:
 
-        1. :py:meth:`~.MesonPackage.meson`
-        2. :py:meth:`~.MesonPackage.build`
-        3. :py:meth:`~.MesonPackage.install`
+        1. :py:meth:`~.MesonWrapper.meson`
+        2. :py:meth:`~.MesonWrapper.build`
+        3. :py:meth:`~.MesonWrapper.install`
 
     They all have sensible defaults and for many packages the only thing
-    necessary will be to override :py:meth:`~.MesonPackage.meson_args`.
+    necessary will be to override :py:meth:`~.MesonWrapper.meson_args`.
     For a finer tuning you may also override:
 
         +-----------------------------------------------+--------------------+
         | **Method**                                    | **Purpose**        |
         +===============================================+====================+
-        | :py:meth:`~.MesonPackage.root_mesonlists_dir` | Location of the    |
+        | :py:meth:`~.MesonWrapper.root_mesonlists_dir` | Location of the    |
         |                                               | root MesonLists.txt|
         +-----------------------------------------------+--------------------+
-        | :py:meth:`~.MesonPackage.build_directory`     | Directory where to |
+        | :py:meth:`~.MesonWrapper.build_directory`     | Directory where to |
         |                                               | build the package  |
         +-----------------------------------------------+--------------------+
 

--- a/lib/spack/spack/build_systems/meson.py
+++ b/lib/spack/spack/build_systems/meson.py
@@ -10,7 +10,8 @@ from llnl.util.filesystem import working_dir
 
 import spack.builder
 import spack.package
-from spack.directives import depends_on, variant
+from spack.directives import buildsystem, depends_on, variant
+from spack.multimethod import when
 
 mesonbuild = spack.builder.BuilderMeta.make_decorator('mesonbuild')
 
@@ -47,17 +48,16 @@ class MesonPackage(spack.package.PackageBase):
     #: system base class
     build_system_class = 'MesonPackage'
 
-    build_system = 'mesonbuild'
-
-    variant('buildtype', default='debugoptimized',
-            description='Meson build type',
-            values=('plain', 'debug', 'debugoptimized', 'release', 'minsize'))
-    variant('default_library', default='shared', values=('shared', 'static'),
-            multi=True, description='Build shared libs, static libs or both')
-    variant('strip', default=False, description='Strip targets on install')
-
-    depends_on('meson', type='build')
-    depends_on('ninja', type='build')
+    buildsystem('mesonbuild')
+    with when('buildsystem=mesonbuild'):
+        variant('buildtype', default='debugoptimized',
+                description='Meson build type',
+                values=('plain', 'debug', 'debugoptimized', 'release', 'minsize'))
+        variant('default_library', default='shared', values=('shared', 'static'),
+                multi=True, description='Build shared libs, static libs or both')
+        variant('strip', default=False, description='Strip targets on install')
+        depends_on('meson', type='build')
+        depends_on('ninja', type='build')
 
     def flags_to_build_system_args(self, flags):
         """Produces a list of all command line arguments to pass the specified

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -5,7 +5,8 @@
 import inspect
 
 import spack.builder
-from spack.directives import extends
+from spack.directives import buildsystem, extends
+from spack.multimethod import when
 from spack.package import PackageBase, run_after
 
 octave = spack.builder.BuilderMeta.make_decorator('octave')
@@ -25,9 +26,9 @@ class OctavePackage(PackageBase):
     # build-system class we are using
     build_system_class = 'OctavePackage'
 
-    build_system = 'octave'
-
-    extends('octave')
+    buildsystem('octave')
+    with when('buildsystem=octave'):
+        extends('octave')
 
 
 @spack.builder.builder('octave')

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -25,6 +25,8 @@ class OctavePackage(PackageBase):
     # To be used in UI queries that require to know which
     # build-system class we are using
     build_system_class = 'OctavePackage'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'octave'
 
     buildsystem('octave')
     with when('buildsystem=octave'):

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -2,11 +2,13 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import inspect
 
+import spack.builder
 from spack.directives import extends
 from spack.package import PackageBase, run_after
+
+octave = spack.builder.BuilderMeta.make_decorator('octave')
 
 
 class OctavePackage(PackageBase):
@@ -19,32 +21,35 @@ class OctavePackage(PackageBase):
     1. :py:meth:`~.OctavePackage.install`
 
     """
-    # Default phases
-    phases = ['install']
-
     # To be used in UI queries that require to know which
     # build-system class we are using
     build_system_class = 'OctavePackage'
 
+    build_system = 'octave'
+
     extends('octave')
 
-    def setup_build_environment(self, env):
-        # octave does not like those environment variables to be set:
-        env.unset('CC')
-        env.unset('CXX')
-        env.unset('FC')
 
-    def install(self, spec, prefix):
-        """Install the package from the archive file"""
-        inspect.getmodule(self).octave(
-            '--quiet',
-            '--norc',
-            '--built-in-docstrings-file=/dev/null',
-            '--texi-macros-file=/dev/null',
-            '--eval', 'pkg prefix %s; pkg install %s' %
-            (prefix, self.stage.archive_file))
+@spack.builder.builder('octave')
+class OctaveBuilder(spack.builder.Builder):
+    phases = ('install',)
 
-    # Testing
+    class PackageWrapper(spack.builder.BuildWrapper):
+        def setup_build_environment(self, env):
+            # octave does not like those environment variables to be set:
+            env.unset('CC')
+            env.unset('CXX')
+            env.unset('FC')
 
-    # Check that self.prefix is there after installation
-    run_after('install')(PackageBase.sanity_check_prefix)
+        def install(self, spec, prefix):
+            """Install the package from the archive file"""
+            inspect.getmodule(self).octave(
+                '--quiet',
+                '--norc',
+                '--built-in-docstrings-file=/dev/null',
+                '--texi-macros-file=/dev/null',
+                '--eval', 'pkg prefix %s; pkg install %s' %
+                (prefix, self.stage.archive_file))
+
+        # Check that self.prefix is there after installation
+        run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/octave.py
+++ b/lib/spack/spack/build_systems/octave.py
@@ -19,7 +19,7 @@ class OctavePackage(PackageBase):
 
     This class provides the following phases that can be overridden:
 
-    1. :py:meth:`~.OctavePackage.install`
+    1. :py:meth:`~.OctaveBuilder.PackageWrapper.install`
 
     """
     # To be used in UI queries that require to know which

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -2,11 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-"""Common utilities for managing intel oneapi packages.
-
-"""
-
+"""Common utilities for managing intel oneapi packages."""
 import getpass
 import platform
 import shutil
@@ -14,17 +10,16 @@ from os.path import basename, dirname, isdir
 
 from llnl.util.filesystem import find_headers, find_libraries, join_path
 
-from spack.package import Package
 from spack.util.environment import EnvironmentModifications
 from spack.util.executable import Executable
+
+from .generic import Package, generic
 
 
 class IntelOneApiPackage(Package):
     """Base class for Intel oneAPI packages."""
 
     homepage = 'https://software.intel.com/oneapi'
-
-    phases = ['install']
 
     # oneAPI license does not allow mirroring outside of the
     # organization (e.g. University/Company).
@@ -49,6 +44,7 @@ class IntelOneApiPackage(Package):
         """Path to component <prefix>/<component>/<version>."""
         return join_path(self.prefix, self.component_dir, str(self.spec.version))
 
+    @generic
     def install(self, spec, prefix, installer_path=None):
         """Shared install method for all oneapi packages."""
 

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -38,6 +38,8 @@ class PerlPackage(PackageBase):
     #: This attribute is used in UI queries that need to know the build
     #: system base class
     build_system_class = 'PerlPackage'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'perlbuild'
 
     buildsystem('perlbuild')
 

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -8,7 +8,7 @@ import os
 from llnl.util.filesystem import filter_file
 
 import spack.builder
-from spack.directives import extends
+from spack.directives import buildsystem, extends
 from spack.package import PackageBase, run_after
 from spack.util.executable import Executable
 
@@ -39,12 +39,12 @@ class PerlPackage(PackageBase):
     #: system base class
     build_system_class = 'PerlPackage'
 
-    build_system = 'perlbuild'
+    buildsystem('perlbuild')
 
     #: Callback names for build-time test
     build_time_test_callbacks = ['check']
 
-    extends('perl')
+    extends('perl', when='buildsystem=perlbuild')
 
 
 class PerlBuildWrapper(spack.builder.BuildWrapper):

--- a/lib/spack/spack/build_systems/perl.py
+++ b/lib/spack/spack/build_systems/perl.py
@@ -20,19 +20,19 @@ class PerlPackage(PackageBase):
 
     This class provides four phases that can be overridden if required:
 
-        1. :py:meth:`~.PerlPackage.configure`
-        2. :py:meth:`~.PerlPackage.build`
-        3. :py:meth:`~.PerlPackage.check`
-        4. :py:meth:`~.PerlPackage.install`
+        1. :py:meth:`~.PerlWrapper.configure`
+        2. :py:meth:`~.PerlWrapper.build`
+        3. :py:meth:`~.PerlWrapper.check`
+        4. :py:meth:`~.PerlWrapper.install`
 
     The default methods use, in order of preference:
         (1) Makefile.PL,
         (2) Build.PL.
 
     Some packages may need to override
-    :py:meth:`~.PerlPackage.configure_args`,
+    :py:meth:`~.PerlWrapper.configure_args`,
     which produces a list of arguments for
-    :py:meth:`~.PerlPackage.configure`.
+    :py:meth:`~.PerlWrapper.configure`.
     Arguments should not include the installation base directory.
     """
     #: This attribute is used in UI queries that need to know the build
@@ -49,10 +49,10 @@ class PerlPackage(PackageBase):
     extends('perl', when='buildsystem=perlbuild')
 
 
-class PerlBuildWrapper(spack.builder.BuildWrapper):
+class PerlWrapper(spack.builder.BuildWrapper):
     def configure_args(self):
         """Produces a list containing the arguments that must be passed to
-        :py:meth:`~.PerlPackage.configure`. Arguments should not include
+        :py:meth:`~.PerlWrapper.configure`. Arguments should not include
         the installation base directory, which is prepended automatically.
 
         :return: list of arguments for Makefile.PL or Build.PL
@@ -62,7 +62,7 @@ class PerlBuildWrapper(spack.builder.BuildWrapper):
     def configure(self, spec, prefix):
         """Runs Makefile.PL or Build.PL with arguments consisting of
         an appropriate installation base directory followed by the
-        list returned by :py:meth:`~.PerlPackage.configure_args`.
+        list returned by :py:meth:`~.PerlWrapper.configure_args`.
 
         :raise RuntimeError: if neither Makefile.PL or Build.PL exist
         """
@@ -119,4 +119,4 @@ class PerlBuilder(spack.builder.Builder):
     #: Phases of a Perl package
     phases = ('configure', 'build', 'install')
 
-    PackageWrapper = PerlBuildWrapper
+    PackageWrapper = PerlWrapper

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -20,7 +20,8 @@ from llnl.util.lang import match_predicate
 
 import spack.builder
 import spack.package
-from spack.directives import depends_on, extends
+from spack.directives import buildsystem, depends_on, extends
+from spack.multimethod import when
 
 python_pip = spack.builder.BuilderMeta.make_decorator('python_pip')
 
@@ -36,14 +37,14 @@ class PythonPackage(spack.package.PackageBase):
     # build-system class we are using
     build_system_class = 'PythonPackage'
 
-    build_system = 'python_pip'
-
-    extends('python')
-    depends_on('py-pip', type='build')
-    # FIXME: technically wheel is only needed when building from source, not when
-    # installing a downloaded wheel, but I don't want to add wheel as a dep to every
-    # package manually
-    depends_on('py-wheel', type='build')
+    buildsystem('python_pip')
+    with when('buildsystem=python_pip'):
+        extends('python')
+        depends_on('py-pip', type='build')
+        # FIXME: technically wheel is only needed when building from source, not when
+        # installing a downloaded wheel, but I don't want to add wheel as a dep to every
+        # package manually
+        depends_on('py-wheel', type='build')
 
     py_namespace = None
 

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -26,50 +26,7 @@ from spack.multimethod import when
 python_pip = spack.builder.BuilderMeta.make_decorator('python_pip')
 
 
-class PythonPackage(spack.package.PackageBase):
-    """Specialized class for packages that are built using pip."""
-    #: Package name, version, and extension on PyPI
-    pypi = None
-
-    maintainers = ['adamjstewart']
-
-    # To be used in UI queries that require to know which
-    # build-system class we are using
-    build_system_class = 'PythonPackage'
-    #: Legacy buildsystem attribute used to deserialize and install old specs
-    legacy_buildsystem = 'python_pip'
-
-    buildsystem('python_pip')
-    with when('buildsystem=python_pip'):
-        extends('python')
-        depends_on('py-pip', type='build')
-        # FIXME: technically wheel is only needed when building from source, not when
-        # installing a downloaded wheel, but I don't want to add wheel as a dep to every
-        # package manually
-        depends_on('py-wheel', type='build')
-
-    py_namespace = None
-
-    @property
-    def homepage(self):
-        if self.pypi:
-            name = self.pypi.split('/')[0]
-            return 'https://pypi.org/project/' + name + '/'
-
-    @property
-    def url(self):
-        if self.pypi:
-            return (
-                'https://files.pythonhosted.org/packages/source/'
-                + self.pypi[0] + '/' + self.pypi
-            )
-
-    @property
-    def list_url(self):
-        if self.pypi:
-            name = self.pypi.split('/')[0]
-            return 'https://pypi.org/simple/' + name + '/'
-
+class PythonExtension(spack.package.PackageBase):
     @property
     def import_modules(self):
         """Names of modules that the Python package provides.
@@ -190,6 +147,51 @@ class PythonPackage(spack.package.PackageBase):
                 os.remove(dst)
 
         view.remove_files(to_remove)
+
+
+class PythonPackage(PythonExtension):
+    """Specialized class for packages that are built using pip."""
+    #: Package name, version, and extension on PyPI
+    pypi = None
+
+    maintainers = ['adamjstewart']
+
+    # To be used in UI queries that require to know which
+    # build-system class we are using
+    build_system_class = 'PythonPackage'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'python_pip'
+
+    buildsystem('python_pip')
+    with when('buildsystem=python_pip'):
+        extends('python')
+        depends_on('py-pip', type='build')
+        # FIXME: technically wheel is only needed when building from source, not when
+        # installing a downloaded wheel, but I don't want to add wheel as a dep to every
+        # package manually
+        depends_on('py-wheel', type='build')
+
+    py_namespace = None
+
+    @property
+    def homepage(self):
+        if self.pypi:
+            name = self.pypi.split('/')[0]
+            return 'https://pypi.org/project/' + name + '/'
+
+    @property
+    def url(self):
+        if self.pypi:
+            return (
+                'https://files.pythonhosted.org/packages/source/'
+                + self.pypi[0] + '/' + self.pypi
+            )
+
+    @property
+    def list_url(self):
+        if self.pypi:
+            name = self.pypi.split('/')[0]
+            return 'https://pypi.org/simple/' + name + '/'
 
     def test(self):
         """Attempts to import modules of the installed package."""

--- a/lib/spack/spack/build_systems/python.py
+++ b/lib/spack/spack/build_systems/python.py
@@ -36,6 +36,8 @@ class PythonPackage(spack.package.PackageBase):
     # To be used in UI queries that require to know which
     # build-system class we are using
     build_system_class = 'PythonPackage'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'python_pip'
 
     buildsystem('python_pip')
     with when('buildsystem=python_pip'):

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -31,6 +31,8 @@ class QMakePackage(spack.package.PackageBase):
     #: This attribute is used in UI queries that need to know the build
     #: system base class
     build_system_class = 'QMakePackage'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'qmake'
 
     buildsystem('qmake')
     depends_on('qt', type='build', when='buildsystem=qmake')

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -21,12 +21,12 @@ class QMakePackage(spack.package.PackageBase):
 
     This class provides three phases that can be overridden:
 
-    1. :py:meth:`~.QMakePackage.qmake`
-    2. :py:meth:`~.QMakePackage.build`
-    3. :py:meth:`~.QMakePackage.install`
+    1. :py:meth:`~.QMakeBuilder.PackageWrapper.qmake`
+    2. :py:meth:`~.QMakeBuilder.PackageWrapper.build`
+    3. :py:meth:`~.QMakeBuilder.PackageWrapper.install`
 
     They all have sensible defaults and for many packages the only thing
-    necessary will be to override :py:meth:`~.QMakePackage.qmake_args`.
+    necessary will be to override :py:meth:`~.QMakeBuilder.PackageWrapper.qmake_args`.
     """
     #: This attribute is used in UI queries that need to know the build
     #: system base class
@@ -42,7 +42,7 @@ class QMakePackage(spack.package.PackageBase):
 class QMakeBuilder(spack.builder.Builder):
     phases = ('qmake', 'build', 'install')
 
-    class QMakeWrapper(spack.builder.BuildWrapper):
+    class PackageWrapper(spack.builder.BuildWrapper):
         #: Callback names for build-time test
         build_time_test_callbacks = ['check']
 

--- a/lib/spack/spack/build_systems/qmake.py
+++ b/lib/spack/spack/build_systems/qmake.py
@@ -8,7 +8,7 @@ from llnl.util.filesystem import working_dir
 
 import spack.builder
 import spack.package
-from spack.directives import depends_on
+from spack.directives import buildsystem, depends_on
 
 qmakebuild = spack.builder.BuilderMeta.make_decorator('qmake')
 
@@ -32,9 +32,8 @@ class QMakePackage(spack.package.PackageBase):
     #: system base class
     build_system_class = 'QMakePackage'
 
-    build_system = 'qmake'
-
-    depends_on('qt', type='build')
+    buildsystem('qmake')
+    depends_on('qt', type='build', when='buildsystem=qmake')
 
 
 @spack.builder.builder('qmake')

--- a/lib/spack/spack/build_systems/r.py
+++ b/lib/spack/spack/build_systems/r.py
@@ -2,15 +2,14 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 import inspect
 
 from spack.directives import extends
-from spack.package import PackageBase, run_after
+
+from .generic import Package, generic
 
 
-class RPackage(PackageBase):
+class RPackage(Package):
     """Specialized class for packages that are built using R.
 
     For more information on the R build system, see:
@@ -23,8 +22,6 @@ class RPackage(PackageBase):
     It has sensible defaults, and for many packages the only thing
     necessary will be to add dependencies
     """
-    phases = ['install']
-
     # package attributes that can be expanded to set the homepage, url,
     # list_url, and git values
     # For CRAN packages
@@ -77,6 +74,7 @@ class RPackage(PackageBase):
         """Arguments to pass to install via ``--configure-vars``."""
         return []
 
+    @generic
     def install(self, spec, prefix):
         """Installs an R package."""
 
@@ -101,6 +99,3 @@ class RPackage(PackageBase):
         ])
 
         inspect.getmodule(self).R(*args)
-
-    # Check that self.prefix is there after installation
-    run_after('install')(PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/racket.py
+++ b/lib/spack/spack/build_systems/racket.py
@@ -9,12 +9,13 @@ from llnl.util.filesystem import working_dir
 
 from spack.build_environment import SPACK_NO_PARALLEL_MAKE, determine_number_of_jobs
 from spack.directives import extends
-from spack.package import PackageBase
 from spack.util.environment import env_flag
 from spack.util.executable import Executable, ProcessError
 
+from .generic import Package, generic
 
-class RacketPackage(PackageBase):
+
+class RacketPackage(Package):
     """Specialized class for packages that are built using Racket's
     `raco pkg install` and `raco setup` commands.
 
@@ -25,9 +26,6 @@ class RacketPackage(PackageBase):
     """
     #: Package name, version, and extension on PyPI
     maintainers = ['elfprince13']
-
-    # Default phases
-    phases = ['install']
 
     # To be used in UI queries that require to know which
     # build-system class we are using
@@ -52,6 +50,7 @@ class RacketPackage(PackageBase):
             ret = os.path.join(ret, self.subdirectory)
         return ret
 
+    @generic
     def install(self, spec, prefix):
         """Install everything from build directory."""
         raco = Executable("raco")

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -26,6 +26,8 @@ class RubyPackage(spack.package.PackageBase):
     #: This attribute is used in UI queries that need to know the build
     #: system base class
     build_system_class = 'RubyPackage'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'ruby'
 
     buildsystem('ruby')
     extends('ruby', when='buildsystem=ruby')

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -7,7 +7,7 @@ import inspect
 
 import spack.builder
 import spack.package
-from spack.directives import extends
+from spack.directives import buildsystem, extends
 
 ruby = spack.builder.BuilderMeta.make_decorator('ruby')
 
@@ -27,9 +27,8 @@ class RubyPackage(spack.package.PackageBase):
     #: system base class
     build_system_class = 'RubyPackage'
 
-    build_system = 'ruby'
-
-    extends('ruby')
+    buildsystem('ruby')
+    extends('ruby', when='buildsystem=ruby')
 
 
 @spack.builder.builder('ruby')

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -2,15 +2,17 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import glob
 import inspect
 
+import spack.builder
+import spack.package
 from spack.directives import extends
-from spack.package import PackageBase, run_after
+
+ruby = spack.builder.BuilderMeta.make_decorator('ruby')
 
 
-class RubyPackage(PackageBase):
+class RubyPackage(spack.package.PackageBase):
     """Specialized class for building Ruby gems.
 
     This class provides two phases that can be overridden if required:
@@ -21,44 +23,49 @@ class RubyPackage(PackageBase):
 
     maintainers = ['Kerilk']
 
-    #: Phases of a Ruby package
-    phases = ['build', 'install']
-
     #: This attribute is used in UI queries that need to know the build
     #: system base class
     build_system_class = 'RubyPackage'
 
+    build_system = 'ruby'
+
     extends('ruby')
 
-    def build(self, spec, prefix):
-        """Build a Ruby gem."""
 
-        # ruby-rake provides both rake.gemspec and Rakefile, but only
-        # rake.gemspec can be built without an existing rake installation
-        gemspecs = glob.glob('*.gemspec')
-        rakefiles = glob.glob('Rakefile')
-        if gemspecs:
-            inspect.getmodule(self).gem('build', '--norc', gemspecs[0])
-        elif rakefiles:
-            jobs = inspect.getmodule(self).make_jobs
-            inspect.getmodule(self).rake('package', '-j{0}'.format(jobs))
-        else:
-            # Some Ruby packages only ship `*.gem` files, so nothing to build
-            pass
+@spack.builder.builder('ruby')
+class RubyBuilder(spack.builder.Builder):
+    phases = ('build', 'install')
 
-    def install(self, spec, prefix):
-        """Install a Ruby gem.
+    class PackageWrapper(spack.builder.BuildWrapper):
+        def build(self, spec, prefix):
+            """Build a Ruby gem."""
 
-        The ruby package sets ``GEM_HOME`` to tell gem where to install to."""
+            # ruby-rake provides both rake.gemspec and Rakefile, but only
+            # rake.gemspec can be built without an existing rake installation
+            gemspecs = glob.glob('*.gemspec')
+            rakefiles = glob.glob('Rakefile')
+            if gemspecs:
+                inspect.getmodule(self).gem('build', '--norc', gemspecs[0])
+            elif rakefiles:
+                jobs = inspect.getmodule(self).make_jobs
+                inspect.getmodule(self).rake('package', '-j{0}'.format(jobs))
+            else:
+                # Some Ruby packages only ship `*.gem` files, so nothing to build
+                pass
 
-        gems = glob.glob('*.gem')
-        if gems:
-            # if --install-dir is not used, GEM_PATH is deleted from the
-            # environement, and Gems required to build native extensions will
-            # not be found. Those extensions are built during `gem install`.
-            inspect.getmodule(self).gem(
-                'install', '--norc', '--ignore-dependencies',
-                '--install-dir', prefix, gems[0])
+        def install(self, spec, prefix):
+            """Install a Ruby gem.
 
-    # Check that self.prefix is there after installation
-    run_after('install')(PackageBase.sanity_check_prefix)
+            The ruby package sets ``GEM_HOME`` to tell gem where to install to."""
+
+            gems = glob.glob('*.gem')
+            if gems:
+                # if --install-dir is not used, GEM_PATH is deleted from the
+                # environement, and Gems required to build native extensions will
+                # not be found. Those extensions are built during `gem install`.
+                inspect.getmodule(self).gem(
+                    'install', '--norc', '--ignore-dependencies',
+                    '--install-dir', prefix, gems[0])
+
+        # Check that self.prefix is there after installation
+        ruby.run_after('install')(spack.package.PackageBase.sanity_check_prefix)

--- a/lib/spack/spack/build_systems/ruby.py
+++ b/lib/spack/spack/build_systems/ruby.py
@@ -17,8 +17,8 @@ class RubyPackage(spack.package.PackageBase):
 
     This class provides two phases that can be overridden if required:
 
-    #. :py:meth:`~.RubyPackage.build`
-    #. :py:meth:`~.RubyPackage.install`
+    #. :py:meth:`~.RubyBuilder.PackageWrapper.build`
+    #. :py:meth:`~.RubyBuilder.PackageWrapper.install`
     """
 
     maintainers = ['Kerilk']

--- a/lib/spack/spack/build_systems/scons.py
+++ b/lib/spack/spack/build_systems/scons.py
@@ -18,13 +18,13 @@ class SConsPackage(spack.package.PackageBase):
 
     This class provides the following phases that can be overridden:
 
-    1. :py:meth:`~.SConsPackage.build`
-    2. :py:meth:`~.SConsPackage.install`
+    1. :py:meth:`~.SConsBuilder.PackageWrapper.build`
+    2. :py:meth:`~.SConsBuilder.PackageWrapper.install`
 
     Packages that use SCons as a build system are less uniform than packages
     that use other build systems. Developers can add custom subcommands or
     variables that control the build. You will likely need to override
-    :py:meth:`~.SConsPackage.build_args` to pass the appropriate variables.
+    :py:meth:`~.SConsBuilder.PackageWrapper.build_args` to pass the appropriate variables.
     """
     #: To be used in UI queries that require to know which
     #: build-system class we are using
@@ -40,7 +40,7 @@ class SConsPackage(spack.package.PackageBase):
 
 
 @spack.builder.builder('scons')
-class SconsBuilder(spack.builder.Builder):
+class SConsBuilder(spack.builder.Builder):
     #: Phases of a SCons package
     phases = ('build', 'install')
 

--- a/lib/spack/spack/build_systems/scons.py
+++ b/lib/spack/spack/build_systems/scons.py
@@ -32,6 +32,8 @@ class SConsPackage(spack.package.PackageBase):
 
     #: Callback names for build-time test
     build_time_test_callbacks = ['build_test']
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'scons'
 
     buildsystem('scons')
     depends_on('scons', type='build', when='buildsystem=scons')

--- a/lib/spack/spack/build_systems/scons.py
+++ b/lib/spack/spack/build_systems/scons.py
@@ -6,7 +6,7 @@ import inspect
 
 import spack.builder
 import spack.package
-from spack.directives import depends_on
+from spack.directives import buildsystem, depends_on
 
 scons = spack.builder.BuilderMeta.make_decorator('scons')
 
@@ -30,12 +30,11 @@ class SConsPackage(spack.package.PackageBase):
     #: build-system class we are using
     build_system_class = 'SConsPackage'
 
-    build_system = 'scons'
-
     #: Callback names for build-time test
     build_time_test_callbacks = ['build_test']
 
-    depends_on('scons', type='build')
+    buildsystem('scons')
+    depends_on('scons', type='build', when='buildsystem=scons')
 
 
 @spack.builder.builder('scons')

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -40,6 +40,8 @@ class SIPPackage(spack.package.PackageBase):
 
     #: Callback names for install-time test
     install_time_test_callbacks = ['test']
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'sip'
 
     buildsystem('sip')
     with when('buildsystem=sip'):

--- a/lib/spack/spack/build_systems/sip.py
+++ b/lib/spack/spack/build_systems/sip.py
@@ -11,7 +11,8 @@ from llnl.util.filesystem import find, join_path, working_dir
 
 import spack.builder
 import spack.package
-from spack.directives import depends_on, extends
+from spack.directives import buildsystem, depends_on, extends
+from spack.multimethod import when
 
 sip = spack.builder.BuilderMeta.make_decorator('sip')
 
@@ -40,10 +41,11 @@ class SIPPackage(spack.package.PackageBase):
     #: Callback names for install-time test
     install_time_test_callbacks = ['test']
 
-    extends('python')
-
-    depends_on('qt')
-    depends_on('py-sip')
+    buildsystem('sip')
+    with when('buildsystem=sip'):
+        extends('python')
+        depends_on('qt')
+        depends_on('py-sip')
 
     @property
     def import_modules(self):

--- a/lib/spack/spack/build_systems/waf.py
+++ b/lib/spack/spack/build_systems/waf.py
@@ -7,7 +7,7 @@ import inspect
 from llnl.util.filesystem import working_dir
 
 import spack.builder
-from spack.directives import depends_on
+from spack.directives import buildsystem, depends_on
 
 wafbuild = spack.builder.BuilderMeta.make_decorator('waf')
 
@@ -43,12 +43,11 @@ class WafPackage(spack.package.PackageBase):
     # build-system class we are using
     build_system_class = 'WafPackage'
 
-    build_system = 'waf'
-
+    buildsystem('waf')
     # Much like AutotoolsPackage does not require automake and autoconf
     # to build, WafPackage does not require waf to build. It only requires
     # python to run the waf build script.
-    depends_on('python@2.5:', type='build')
+    depends_on('python@2.5:', type='build', when='buildsystem=waf')
 
 
 class WafWrapper(spack.builder.BuildWrapper):

--- a/lib/spack/spack/build_systems/waf.py
+++ b/lib/spack/spack/build_systems/waf.py
@@ -42,6 +42,8 @@ class WafPackage(spack.package.PackageBase):
     # To be used in UI queries that require to know which
     # build-system class we are using
     build_system_class = 'WafPackage'
+    #: Legacy buildsystem attribute used to deserialize and install old specs
+    legacy_buildsystem = 'waf'
 
     buildsystem('waf')
     # Much like AutotoolsPackage does not require automake and autoconf

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -213,7 +213,7 @@ class Builder(llnl.util.compat.Sequence):
     concrete spec), knows how to install it.
 
     Args:
-        pkg (spack.package.Package): package object to be built
+        pkg (spack.package.PackageBase): package object to be built
     """
 
     #: Sequence of phases. Must be defined in derived classes

--- a/lib/spack/spack/builder.py
+++ b/lib/spack/spack/builder.py
@@ -1,0 +1,288 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import copy
+import inspect
+from typing import Any, List, Optional, Tuple
+
+import six
+
+import llnl.util.compat
+
+import spack.build_environment
+
+#: Builder classes, as registered by the "builder" decorator
+BUILDER_CLS = {}
+
+
+def builder(name):
+    """Class decorator used to register a builder with a given name"""
+
+    def _decorator(cls):
+        cls.build_system = name
+        BUILDER_CLS[name] = cls
+        return cls
+
+    return _decorator
+
+
+_RUN_BEFORE_PACKAGE_ATTRIBUTE = "run_before_callbacks"
+_RUN_AFTER_PACKAGE_ATTRIBUTE = "run_after_callbacks"
+_PHASE_OVERRIDE_PACKAGE_ATTRIBUTE = "phase_overrides"
+
+
+class BuilderMeta(type):
+    #: Temporary stage for "run_before" decorators
+    _run_before_stage = []  # type: List[Any]
+    #: Temporary stage for "run_after" decorators
+    _run_after_stage = []  # type: List[Any]
+    #: Temporary stage for phase override decorators
+    _phases_stage = []  # type: List[Any]
+
+    def __new__(mcs, name, bases, attr_dict):
+
+        stage2attribute = [
+            ("_run_before_stage", _RUN_BEFORE_PACKAGE_ATTRIBUTE),
+            ("_run_after_stage", _RUN_AFTER_PACKAGE_ATTRIBUTE),
+            ("_phases_stage", _PHASE_OVERRIDE_PACKAGE_ATTRIBUTE),
+        ]
+
+        for stage_name, attribute_name in stage2attribute:
+            stage = getattr(BuilderMeta, stage_name)
+
+            # We don't have any callback registered, so move to the next attribute
+            if not stage:
+                continue
+
+            # If we are here we have callbacks. To get a complete list, get first what
+            # was attached to parent classes, then prepend what we have registered here.
+            #
+            # The order should be:
+            # 1. Callbacks are registered in order within the same class
+            # 2. Callbacks defined in derived classes precede those defined in base
+            #    classes
+            for base in bases:
+                callbacks_from_base = getattr(base, attribute_name, None)
+                if callbacks_from_base:
+                    break
+            callbacks_from_base = callbacks_from_base or []
+
+            # Set the attribute for the class to be created
+            callbacks = stage[:] + callbacks_from_base
+            attr_dict[attribute_name] = callbacks
+
+            # Reset the stage
+            setattr(BuilderMeta, stage_name, [])
+
+        return super(BuilderMeta, mcs).__new__(mcs, name, bases, attr_dict)
+
+    @staticmethod
+    def make_decorator(build_system):
+        class Decorator(object):
+            def __init__(self, build_system):
+                self.build_system = build_system
+
+            def __call__(self, fn):
+                key = (self.build_system, fn.__name__)
+                item = (key, fn)
+                BuilderMeta._phases_stage.append(item)
+
+            def run_after(self, phase, when=None):
+                def _decorator(fn):
+                    key = (self.build_system, phase, when)
+                    item = (key, fn)
+                    BuilderMeta._run_after_stage.append(item)
+                    return fn
+
+                return _decorator
+
+            def run_before(self, phase, when=None):
+                def _decorator(fn):
+                    key = (self.build_system, phase, when)
+                    item = (key, fn)
+                    BuilderMeta._run_before_stage.append(item)
+                    return fn
+
+                return _decorator
+
+        return Decorator(build_system)
+
+
+class InstallationPhase(object):
+    """Manages a single phase of the installation.
+
+    This descriptor stores at creation time the name of the method it should
+    search for execution. The method is retrieved at __get__ time, so that
+    it can be overridden by subclasses of whatever class declared the phases.
+
+    It also provides hooks to execute arbitrary callbacks before and after
+    the phase.
+    """
+
+    def __init__(self, name, builder):
+        self.name = name
+        self.builder = builder
+        self.phase_fn = self._select_phase_fn()
+        self.run_before = self._make_callbacks(_RUN_BEFORE_PACKAGE_ATTRIBUTE)
+        self.run_after = self._make_callbacks(_RUN_AFTER_PACKAGE_ATTRIBUTE)
+
+    def _make_callbacks(self, callbacks_attribute):
+        result = []
+        callbacks = getattr(self.builder.pkg, callbacks_attribute, [])
+        for (build_system, phase, condition), fn in callbacks:
+            # If the callback was specifically for another build system, move on
+            if build_system != self.builder.build_system and build_system is not None:
+                continue
+
+            # Same if it is for another phase
+            if phase != self.name:
+                continue
+
+            # If we have no condition or the callback satisfies a condition, register it
+            if condition is None or self.builder.pkg.spec.satisfies(condition):
+                result.append(fn)
+        return result
+
+    def __str__(self):
+        msg = '{0}: executing "{1}" phase'
+        return msg.format(self.builder, self.name)
+
+    def execute(self):
+        pkg = self.builder.pkg
+        self._on_phase_start(pkg)
+
+        for callback in self.run_before:
+            callback(pkg)
+
+        self.phase_fn(pkg, pkg.spec, pkg.prefix)
+
+        for callback in self.run_after:
+            callback(pkg)
+
+        self._on_phase_exit(pkg)
+
+    def _select_phase_fn(self):
+        package_cls = type(self.builder.pkg)
+        for current_cls in inspect.getmro(package_cls):
+            # Try to get first a specific override decorated for this build system
+            candidates = current_cls.__dict__.get(_PHASE_OVERRIDE_PACKAGE_ATTRIBUTE, [])
+            for (build_system, name), candidate_fn in candidates:
+                if build_system == self.builder.build_system and name == self.name:
+                    phase_fn = candidate_fn
+                    break
+            else:
+                phase_fn = current_cls.__dict__.get(self.name, None)
+
+            if phase_fn:
+                break
+
+        else:
+            msg = (
+                'unexpected error: package "{0.fullname}" must implement an '
+                '"{1}" phase for the "{2}" build system'
+            )
+            raise RuntimeError(
+                msg.format(self.builder.pkg, self.name, self.builder.build_system)
+            )
+
+        return phase_fn
+
+    def _on_phase_start(self, instance):
+        # If a phase has a matching stop_before_phase attribute,
+        # stop the installation process raising a StopPhase
+        if getattr(instance, "stop_before_phase", None) == self.name:
+            raise spack.build_environment.StopPhase(
+                "Stopping before '{0}' phase".format(self.name)
+            )
+
+    def _on_phase_exit(self, instance):
+        # If a phase has a matching last_phase attribute,
+        # stop the installation process raising a StopPhase
+        if getattr(instance, "last_phase", None) == self.name:
+            raise spack.build_environment.StopPhase(
+                "Stopping at '{0}' phase".format(self.name)
+            )
+
+    def copy(self):
+        return copy.deepcopy(self)
+
+
+class Builder(llnl.util.compat.Sequence):
+    """A builder is a class that, given a package object (i.e. associated with
+    concrete spec), knows how to install it.
+
+    Args:
+        pkg (spack.package.Package): package object to be built
+    """
+
+    #: Sequence of phases. Must be defined in derived classes
+    phases = None  # type: Optional[Tuple[str, ...]]
+    #: Build system name. Must also be defined in derived classes.
+    build_system = None  # type: Optional[str]
+
+    def __init__(self, pkg):
+        self.pkg = self.inject_build_methods(pkg)
+        self.callbacks = {}
+        for phase in self.phases:
+            self.callbacks[phase] = InstallationPhase(phase, self)
+
+    def inject_build_methods(self, pkg):
+        builder_cls = type(self)
+        return builder_cls.PackageWrapper(pkg)
+
+    def __getitem__(self, idx):
+        key = self.phases[idx]
+        return self.callbacks[key]
+
+    def __len__(self):
+        return len(self.phases)
+
+    def __repr__(self):
+        msg = "{0}({1})"
+        return msg.format(
+            type(self).__name__, self.package.spec.format("{name}/{hash:7}")
+        )
+
+    def __str__(self):
+        msg = '"{0}" builder for "{1}"'
+        return msg.format(
+            type(self).build_system, self.pkg.spec.format("{name}/{hash:7}")
+        )
+
+
+class BuildWrapper(six.with_metaclass(BuilderMeta, object)):
+    #: List of glob expressions. Each expression must either be
+    #: absolute or relative to the package source path.
+    #: Matching artifacts found at the end of the build process will be
+    #: copied in the same directory tree as _spack_build_logfile and
+    #: _spack_build_envfile.
+    archive_files = []  # type: List[str]
+
+    def __init__(self, package_object):
+        package_cls = type(package_object)
+        wrapper_cls = type(self)
+        bases = (package_cls, wrapper_cls)
+        new_cls_name = package_cls.__name__ + "BuildWrapper"
+        new_cls = type(new_cls_name, bases, {})
+        new_cls.__module__ = package_cls.__module__
+        for attribute_name in (
+            _RUN_BEFORE_PACKAGE_ATTRIBUTE,
+            _RUN_AFTER_PACKAGE_ATTRIBUTE,
+            _PHASE_OVERRIDE_PACKAGE_ATTRIBUTE,
+        ):
+            package_callbacks = getattr(package_cls, attribute_name, [])
+            wrapper_callbacks = getattr(wrapper_cls, attribute_name, [])
+            # FIXME: check that wrapper_cls has no phase overrides,
+            # FIXME: they should be simple callbacks
+            setattr(new_cls, attribute_name, package_callbacks + wrapper_callbacks)
+
+        self.__class__ = new_cls
+        self.__dict__ = package_object.__dict__
+
+
+# Create generic run_after and run_before decorators not tied to build-systems
+# for backward compatibility
+_ = BuilderMeta.make_decorator(build_system=None)
+run_after = _.run_after
+run_before = _.run_before

--- a/lib/spack/spack/cmd/info.py
+++ b/lib/spack/spack/cmd/info.py
@@ -215,11 +215,11 @@ def print_maintainers(pkg):
 def print_phases(pkg):
     """output installation phases"""
 
-    if hasattr(pkg, 'phases') and pkg.phases:
+    if hasattr(pkg.builder, 'phases') and pkg.builder.phases:
         color.cprint('')
         color.cprint(section_title('Installation Phases:'))
         phase_str = ''
-        for phase in pkg.phases:
+        for phase in pkg.builder.phases:
             phase_str += "    {0}".format(phase)
         color.cprint(phase_str)
 

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -221,7 +221,7 @@ def do_uninstall(env, specs, force):
         except spack.repo.UnknownEntityError:
             # The package.py file has gone away -- but still
             # want to uninstall.
-            spack.package.Package.uninstall_by_spec(item, force=True)
+            spack.package.PackageBase.uninstall_by_spec(item, force=True)
 
     # A package is ready to be uninstalled when nothing else references it,
     # unless we are requested to force uninstall it.

--- a/lib/spack/spack/detection/common.py
+++ b/lib/spack/spack/detection/common.py
@@ -240,7 +240,7 @@ def compute_windows_program_path_for_package(pkg):
     program files location, return list of best guesses
 
     Args:
-        pkg (spack.package.Package): package for which
+        pkg (spack.package.PackageBase): package for which
                            Program Files location is to be computed
     """
     if not is_windows:

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -17,6 +17,7 @@ definition to modify the package, for example:
 
 The available directives are:
 
+  * ``buildsystem``
   * ``conflicts``
   * ``depends_on``
   * ``extends``
@@ -49,13 +50,13 @@ from spack.resource import Resource
 from spack.version import Version, VersionChecksumError
 
 __all__ = ['DirectiveError', 'DirectiveMeta', 'version', 'conflicts', 'depends_on',
-           'extends', 'provides', 'patch', 'variant', 'resource']
+           'extends', 'provides', 'patch', 'variant', 'resource', 'buildsystem']
 
 #: These are variant names used by Spack internally; packages can't use them
 reserved_names = ['patches', 'dev_path']
 
 #: Names of possible directives. This list is populated elsewhere in the file.
-directive_names = []
+directive_names = ['buildsystem']
 
 _patch_order_index = 0
 
@@ -715,6 +716,17 @@ def resource(**kwargs):
         fetcher = from_kwargs(**kwargs)
         resources.append(Resource(name, fetcher, destination, placement))
     return _execute_resource
+
+
+def buildsystem(*values, default=None):
+    default = default or values[0]
+    return variant(
+        'buildsystem',
+        values=tuple(values),
+        description='Build-systems supported by the package',
+        default=default,
+        multi=False
+    )
 
 
 class DirectiveError(spack.error.SpackError):

--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -718,8 +718,8 @@ def resource(**kwargs):
     return _execute_resource
 
 
-def buildsystem(*values, default=None):
-    default = default or values[0]
+def buildsystem(*values, **kwargs):
+    default = kwargs.get('default', None) or values[0]
     return variant(
         'buildsystem',
         values=tuple(values),

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -126,7 +126,7 @@ def _handle_external_and_upstream(pkg, explicit):
     database if it is external package.
 
     Args:
-        pkg (spack.package.Package): the package whose installation is under
+        pkg (spack.package.PackageBase): the package whose installation is under
             consideration
         explicit (bool): the package was explicitly requested by the user
     Return:
@@ -535,7 +535,7 @@ def log(pkg):
     Copy provenance into the install directory on success
 
     Args:
-        pkg (spack.package.Package): the package that was built and installed
+        pkg (spack.package.PackageBase): the package that was built and installed
     """
     packages_dir = spack.store.layout.build_packages_path(pkg.spec)
 
@@ -791,7 +791,7 @@ class PackageInstaller(object):
         Creates and queus the initial build task for the package.
 
         Args:
-            pkg (spack.package.Package): the package to be built and installed
+            pkg (spack.package.PackageBase): the package to be built and installed
             request (BuildRequest or None): the associated install request
                  where ``None`` can be used to indicate the package was
                  explicitly requested by the user
@@ -1378,7 +1378,7 @@ class PackageInstaller(object):
         Write a small metadata file with the current spack environment.
 
         Args:
-            pkg (spack.package.Package): the package to be built and installed
+            pkg (spack.package.PackageBase): the package to be built and installed
         """
         if not os.path.exists(pkg.spec.prefix):
             tty.debug('Creating the installation directory {0}'.format(pkg.spec.prefix))
@@ -1452,7 +1452,7 @@ class PackageInstaller(object):
         known dependents.
 
         Args:
-            pkg (spack.package.Package): Package that has been installed locally,
+            pkg (spack.package.PackageBase): Package that has been installed locally,
                 externally or upstream
             dependent_ids (list or None): list of the package's
                 dependent ids, or None if the dependent ids are limited to
@@ -1541,7 +1541,7 @@ class PackageInstaller(object):
         Install the requested package(s) and or associated dependencies.
 
         Args:
-            pkg (spack.package.Package): the package to be built and installed"""
+            pkg (spack.package.PackageBase): the package to be built and installed"""
 
         self._init_queue()
         fail_fast_err = 'Terminating after first install failure'
@@ -2048,7 +2048,7 @@ class BuildTask(object):
         Instantiate a build task for a package.
 
         Args:
-            pkg (spack.package.Package): the package to be built and installed
+            pkg (spack.package.PackageBase): the package to be built and installed
             request (BuildRequest or None): the associated install request
                  where ``None`` can be used to indicate the package was
                  explicitly requested by the user
@@ -2239,7 +2239,7 @@ class BuildRequest(object):
         Instantiate a build request for a package.
 
         Args:
-            pkg (spack.package.Package): the package to be built and installed
+            pkg (spack.package.PackageBase): the package to be built and installed
             install_args (dict): the install arguments associated with ``pkg``
         """
         # Ensure dealing with a package that has a concrete spec

--- a/lib/spack/spack/mixins.py
+++ b/lib/spack/spack/mixins.py
@@ -6,10 +6,9 @@
 """This module contains additional behavior that can be attached to any given
 package.
 """
-import collections
 import os
 import sys
-from typing import Callable, DefaultDict, Dict, List  # novm
+from typing import Callable, DefaultDict, List  # novm
 
 if sys.version_info >= (3, 5):
     CallbackDict = DefaultDict[str, List[Callable]]
@@ -18,109 +17,7 @@ else:
 
 import llnl.util.filesystem
 
-__all__ = [
-    'filter_compiler_wrappers',
-    'PackageMixinsMeta',
-]
-
-
-class PackageMixinsMeta(type):
-    """This metaclass serves the purpose of implementing a declarative syntax
-    for package mixins.
-
-    Mixins are implemented below in the form of a function. Each one of them
-    needs to register a callable that takes a single argument to be run
-    before or after a certain phase. This callable is basically a method that
-    gets implicitly attached to the package class by calling the mixin.
-    """
-
-    _methods_to_be_added = {}  # type: Dict[str, Callable]
-    _add_method_before = collections.defaultdict(list)  # type: CallbackDict
-    _add_method_after = collections.defaultdict(list)  # type: CallbackDict
-
-    @staticmethod
-    def register_method_before(fn, phase):  # type: (Callable, str) -> None
-        """Registers a method to be run before a certain phase.
-
-        Args:
-            fn: function taking a single argument (self)
-            phase (str): phase before which fn must run
-        """
-        PackageMixinsMeta._methods_to_be_added[fn.__name__] = fn
-        PackageMixinsMeta._add_method_before[phase].append(fn)
-
-    @staticmethod
-    def register_method_after(fn, phase):  # type: (Callable, str) -> None
-        """Registers a method to be run after a certain phase.
-
-        Args:
-            fn: function taking a single argument (self)
-            phase (str): phase after which fn must run
-        """
-        PackageMixinsMeta._methods_to_be_added[fn.__name__] = fn
-        PackageMixinsMeta._add_method_after[phase].append(fn)
-
-    def __init__(cls, name, bases, attr_dict):
-
-        # Add the methods to the class being created
-        if PackageMixinsMeta._methods_to_be_added:
-            attr_dict.update(PackageMixinsMeta._methods_to_be_added)
-            PackageMixinsMeta._methods_to_be_added.clear()
-
-        attr_fmt = '_InstallPhase_{0}'
-
-        # Copy the phases that needs it to the most derived classes
-        # in order not to interfere with other packages in the hierarchy
-        phases_to_be_copied = list(
-            PackageMixinsMeta._add_method_before.keys()
-        )
-        phases_to_be_copied += list(
-            PackageMixinsMeta._add_method_after.keys()
-        )
-
-        for phase in phases_to_be_copied:
-
-            attr_name = attr_fmt.format(phase)
-
-            # Here we want to get the attribute directly from the class (not
-            # from the instance), so that we can modify it and add the mixin
-            # method to the pipeline.
-            phase = getattr(cls, attr_name)
-
-            # Due to MRO, we may have taken a method from a parent class
-            # and modifying it may influence other packages in unwanted
-            # manners. Solve the problem by copying the phase into the most
-            # derived class.
-            setattr(cls, attr_name, phase.copy())
-
-        # Insert the methods in the appropriate position
-        # in the installation pipeline.
-
-        for phase in PackageMixinsMeta._add_method_before:
-
-            attr_name = attr_fmt.format(phase)
-            phase_obj = getattr(cls, attr_name)
-            fn_list = PackageMixinsMeta._add_method_after[phase]
-
-            for f in fn_list:
-                phase_obj.run_before.append(f)
-
-        # Flush the dictionary for the next class
-        PackageMixinsMeta._add_method_before.clear()
-
-        for phase in PackageMixinsMeta._add_method_after:
-
-            attr_name = attr_fmt.format(phase)
-            phase_obj = getattr(cls, attr_name)
-            fn_list = PackageMixinsMeta._add_method_after[phase]
-
-            for f in fn_list:
-                phase_obj.run_after.append(f)
-
-        # Flush the dictionary for the next class
-        PackageMixinsMeta._add_method_after.clear()
-
-        super(PackageMixinsMeta, cls).__init__(name, bases, attr_dict)
+import spack.builder
 
 
 def filter_compiler_wrappers(*files, **kwargs):
@@ -226,6 +123,4 @@ def filter_compiler_wrappers(*files, **kwargs):
         if self.compiler.name == 'nag':
             x.filter('-Wl,--enable-new-dtags', '', **filter_kwargs)
 
-    PackageMixinsMeta.register_method_after(
-        _filter_compiler_wrappers_impl, after
-    )
+    spack.builder.run_after(after)(_filter_compiler_wrappers_impl)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2615,7 +2615,12 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     @property
     def builder(self):
-        key = self.spec.variants['buildsystem'].value
+        try:
+            key = self.spec.variants['buildsystem'].value
+        except KeyError:
+            # We are reading an old spec without the buildsystem variant
+            key = self.legacy_buildsystem
+
         return spack.builder.BUILDER_CLS[key](self)
 
     def _run_test_callbacks(self, method_names, callback_type='install'):

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -93,7 +93,7 @@ def preferred_version(pkg):
     Returns a sorted list of the preferred versions of the package.
 
     Arguments:
-        pkg (Package): The package whose versions are to be assessed.
+        pkg (PackageBase): The package whose versions are to be assessed.
     """
     # Here we sort first on the fact that a version is marked
     # as preferred in the package, then on the fact that the
@@ -1775,10 +1775,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 even with exceptions.
             restage (bool): Force spack to restage the package source.
             skip_patch (bool): Skip patch stage of build if True.
-            stop_before (InstallPhase): stop execution before this
-                installation phase (or None)
-            stop_at (InstallPhase): last installation phase to be executed
-                (or None)
+            stop_before (str): stop execution before this installation phase (or None)
+            stop_at (str): last installation phase to be executed (or None)
             tests (bool or list or set): False to run no tests, True to test
                 all packages, or a list of package names to run tests for some
             use_cache (bool): Install from binary package, if available.

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -2615,7 +2615,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
 
     @property
     def builder(self):
-        key = self.build_system
+        key = self.spec.variants['buildsystem'].value
         return spack.builder.BUILDER_CLS[key](self)
 
     def _run_test_callbacks(self, method_names, callback_type='install'):

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -356,7 +356,7 @@ class PatchCache(object):
 
         Arguments:
             sha256 (str): sha256 hash to look up
-            pkg (spack.package.Package): Package object to get patch for.
+            pkg (spack.package.PackageBase): Package object to get patch for.
 
         We build patch objects lazily because building them requires that
         we have information about the package's location in its repo.

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -38,7 +38,7 @@ from spack.build_systems.oneapi import (
     IntelOneApiStaticLibraryList,
 )
 from spack.build_systems.perl import PerlPackage
-from spack.build_systems.python import PythonPackage
+from spack.build_systems.python import PythonExtension, PythonPackage
 from spack.build_systems.qmake import QMakePackage
 from spack.build_systems.r import RPackage
 from spack.build_systems.racket import RacketPackage

--- a/lib/spack/spack/pkgkit.py
+++ b/lib/spack/spack/pkgkit.py
@@ -14,7 +14,8 @@ from llnl.util.filesystem import *
 import spack.directives
 import spack.util.executable
 from spack.build_systems.aspell_dict import AspellDictPackage
-from spack.build_systems.autotools import AutotoolsPackage
+from spack.build_systems.autotools import AutotoolsPackage, autotools
+from spack.build_systems.bundle import BundlePackage
 from spack.build_systems.cached_cmake import (
     CachedCMakePackage,
     cmake_cache_option,
@@ -23,6 +24,7 @@ from spack.build_systems.cached_cmake import (
 )
 from spack.build_systems.cmake import CMakePackage
 from spack.build_systems.cuda import CudaPackage
+from spack.build_systems.generic import Package, generic
 from spack.build_systems.gnu import GNUMirrorPackage
 from spack.build_systems.intel import IntelPackage
 from spack.build_systems.lua import LuaPackage
@@ -60,9 +62,7 @@ from spack.installer import (
 from spack.mixins import filter_compiler_wrappers
 from spack.multimethod import when
 from spack.package import (
-    BundlePackage,
     DependencyConflictError,
-    Package,
     build_system_flags,
     env_flags,
     flatten_dependencies,

--- a/lib/spack/spack/test/build_distribution.py
+++ b/lib/spack/spack/test/build_distribution.py
@@ -31,8 +31,9 @@ def test_build_tarball_overwrite(
         install_mockery, mock_fetch, monkeypatch, tmpdir):
 
     with tmpdir.as_cwd():
-        spec = spack.spec.Spec('trivial-install-test-package').concretized()
+        spec = spack.spec.Spec('trivial-install-test-package')
         install(str(spec))
+        spec.concretize()
 
         # Runs fine the first time, throws the second time
         spack.binary_distribution._build_tarball(spec, '.', unsigned=True)

--- a/lib/spack/spack/test/cmd/info.py
+++ b/lib/spack/spack/test/cmd/info.py
@@ -49,7 +49,7 @@ def test_it_just_runs(pkg):
 
 
 def test_info_noversion(mock_packages, print_buffer):
-    """Check that a mock package with no versions or variants outputs None."""
+    """Check that a mock package with no versions outputs None."""
     info('noversion')
 
     line_iter = iter(print_buffer)
@@ -58,7 +58,7 @@ def test_info_noversion(mock_packages, print_buffer):
             has = [desc in line for desc in ['Preferred', 'Safe', 'Deprecated']]
             if not any(has):
                 continue
-        elif 'Variants' not in line:
+        else:
             continue
 
         assert 'None' in next(line_iter).strip()

--- a/lib/spack/spack/test/concretize.py
+++ b/lib/spack/spack/test/concretize.py
@@ -237,7 +237,7 @@ class TestConcretize(object):
         check_concretize(spec)
 
     def test_concretize_mention_build_dep(self):
-        spec = check_concretize('cmake-client ^cmake@3.4.3')
+        spec = check_concretize('cmake-client ^cmake@3.21.3')
 
         # Check parent's perspective of child
         to_dependencies = spec.edges_to_dependencies(name='cmake')

--- a/lib/spack/spack/test/flag_handlers.py
+++ b/lib/spack/spack/test/flag_handlers.py
@@ -34,12 +34,12 @@ class TestFlagHandlers(object):
         # Test that both autotools and cmake work getting no build_system flags
         s1 = spack.spec.Spec('cmake-client')
         s1.concretize()
-        pkg1 = spack.repo.get(s1)
+        pkg1 = s1.package.builder.pkg
         spack.build_environment.setup_package(pkg1, False)
 
         s2 = spack.spec.Spec('patchelf')
         s2.concretize()
-        pkg2 = spack.repo.get(s2)
+        pkg2 = s2.package.builder.pkg
         spack.build_environment.setup_package(pkg2, False)
 
         # Use cppflags as a canary
@@ -51,7 +51,7 @@ class TestFlagHandlers(object):
         # This tests an unbound method in python2 (no change in python3).
         s = spack.spec.Spec('mpileaks cppflags=-g')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = pkg.__class__.inject_flags
         spack.build_environment.setup_package(pkg, False)
         assert os.environ['SPACK_CPPFLAGS'] == '-g'
@@ -60,7 +60,7 @@ class TestFlagHandlers(object):
     def test_inject_flags(self, temp_env):
         s = spack.spec.Spec('mpileaks cppflags=-g')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = inject_flags
         spack.build_environment.setup_package(pkg, False)
 
@@ -70,7 +70,7 @@ class TestFlagHandlers(object):
     def test_env_flags(self, temp_env):
         s = spack.spec.Spec('mpileaks cppflags=-g')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = env_flags
         spack.build_environment.setup_package(pkg, False)
 
@@ -80,7 +80,7 @@ class TestFlagHandlers(object):
     def test_build_system_flags_cmake(self, temp_env):
         s = spack.spec.Spec('cmake-client cppflags=-g')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = build_system_flags
         spack.build_environment.setup_package(pkg, False)
 
@@ -94,7 +94,7 @@ class TestFlagHandlers(object):
     def test_build_system_flags_autotools(self, temp_env):
         s = spack.spec.Spec('patchelf cppflags=-g')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = build_system_flags
         spack.build_environment.setup_package(pkg, False)
 
@@ -106,7 +106,7 @@ class TestFlagHandlers(object):
     def test_build_system_flags_not_implemented(self, temp_env):
         s = spack.spec.Spec('mpileaks cppflags=-g')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = build_system_flags
 
         # Test the command line flags method raises a NotImplementedError
@@ -119,7 +119,7 @@ class TestFlagHandlers(object):
     def test_add_build_system_flags_autotools(self, temp_env):
         s = spack.spec.Spec('patchelf cppflags=-g')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = add_o3_to_build_system_cflags
         spack.build_environment.setup_package(pkg, False)
 
@@ -131,7 +131,7 @@ class TestFlagHandlers(object):
     def test_add_build_system_flags_cmake(self, temp_env):
         s = spack.spec.Spec('cmake-client cppflags=-g')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = add_o3_to_build_system_cflags
         spack.build_environment.setup_package(pkg, False)
 
@@ -143,7 +143,7 @@ class TestFlagHandlers(object):
     def test_ld_flags_cmake(self, temp_env):
         s = spack.spec.Spec('cmake-client ldflags=-mthreads')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = build_system_flags
         spack.build_environment.setup_package(pkg, False)
 
@@ -159,7 +159,7 @@ class TestFlagHandlers(object):
     def test_ld_libs_cmake(self, temp_env):
         s = spack.spec.Spec('cmake-client ldlibs=-lfoo')
         s.concretize()
-        pkg = spack.repo.get(s)
+        pkg = s.package.builder.pkg
         pkg.flag_handler = build_system_flags
         spack.build_environment.setup_package(pkg, False)
 

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -107,7 +107,18 @@ o dyninst
 | o libdwarf
 |/
 o libelf
-'''
+''' or graph_str == r"""o mpileaks
+|\
+o | callpath
+|\|
+| o mpich
+|
+o dyninst
+|\
+o | libdwarf
+|/
+o libelf
+"""
 
 
 def test_topological_sort_filtering_dependency_types(config, mock_packages):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -215,7 +215,7 @@ def test_install_times(
     # The order should be maintained
     phases = [x['name'] for x in times['phases']]
     total = sum([x['seconds'] for x in times['phases']])
-    for name in ['one', 'two', 'three', 'install']:
+    for name in ['install']:
         assert name in phases
 
     # Give a generous difference threshold
@@ -322,7 +322,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch):
     # If remove_prefix is called at any point in this test, that is an
     # error
     pkg.succeed = False  # make the build fail
-    monkeypatch.setattr(spack.package.Package, 'remove_prefix', mock_remove_prefix)
+    monkeypatch.setattr(spack.package.PackageBase, 'remove_prefix', mock_remove_prefix)
     with pytest.raises(spack.build_environment.ChildError):
         pkg.do_install(keep_prefix=True)
     assert os.path.exists(pkg.prefix)
@@ -340,7 +340,7 @@ def test_partial_install_keep_prefix(install_mockery, mock_fetch, monkeypatch):
 def test_second_install_no_overwrite_first(install_mockery, mock_fetch, monkeypatch):
     spec = Spec('canfail').concretized()
     pkg = spack.repo.get(spec)
-    monkeypatch.setattr(spack.package.Package, 'remove_prefix', mock_remove_prefix)
+    monkeypatch.setattr(spack.package.PackageBase, 'remove_prefix', mock_remove_prefix)
 
     pkg.succeed = True
     pkg.do_install()

--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -7,6 +7,7 @@ import os
 
 import pytest
 
+import spack.build_systems.generic
 import spack.package
 import spack.paths
 import spack.repo
@@ -114,10 +115,11 @@ def test_absolute_import_spack_packages_as_python_modules(mock_packages):
     assert hasattr(spack.pkg.builtin.mock.mpileaks, 'Mpileaks')
     assert isinstance(spack.pkg.builtin.mock.mpileaks.Mpileaks,
                       spack.package.PackageMeta)
-    assert issubclass(spack.pkg.builtin.mock.mpileaks.Mpileaks, spack.package.Package)
+    assert issubclass(spack.pkg.builtin.mock.mpileaks.Mpileaks,
+                      spack.build_systems.generic.Package)
 
 
 def test_relative_import_spack_packages_as_python_modules(mock_packages):
     from spack.pkg.builtin.mock.mpileaks import Mpileaks
     assert isinstance(Mpileaks, spack.package.PackageMeta)
-    assert issubclass(Mpileaks, spack.package.Package)
+    assert issubclass(Mpileaks, spack.build_systems.generic.Package)

--- a/lib/spack/spack/util/package_hash.py
+++ b/lib/spack/spack/util/package_hash.py
@@ -14,6 +14,8 @@ import spack.util.hash
 import spack.util.naming
 from spack.util.unparse import unparse
 
+# FIXME: double check changes that are needed in this file
+
 
 class RemoveDocstrings(ast.NodeTransformer):
     """Transformer that removes docstrings from a Python AST.
@@ -63,7 +65,7 @@ class RemoveDirectives(ast.NodeTransformer):
         # list of URL attributes and metadata attributes
         # these will be removed from packages.
         self.metadata_attrs = [s.url_attr for s in spack.fetch_strategy.all_strategies]
-        self.metadata_attrs += spack.package.Package.metadata_attrs
+        self.metadata_attrs += spack.package.PackageBase.metadata_attrs
 
         self.spec = spec
         self.in_classdef = False  # used to avoid nested classdefs
@@ -146,8 +148,9 @@ class TagMultiMethods(ast.NodeVisitor):
 
     def visit_FunctionDef(self, func):
         conditions = []
+
         for dec in func.decorator_list:
-            if isinstance(dec, ast.Call) and dec.func.id == 'when':
+            if isinstance(dec, ast.Call) and getattr(dec.func, 'id', None) == 'when':
                 try:
                     # evaluate spec condition for any when's
                     cond = dec.args[0].s
@@ -281,7 +284,8 @@ class ResolveMultiMethods(ast.NodeTransformer):
         # strip the when decorators (preserve the rest)
         func.decorator_list = [
             dec for dec in func.decorator_list
-            if not (isinstance(dec, ast.Call) and dec.func.id == 'when')
+            if not (isinstance(dec, ast.Call) and
+                    getattr(dec.func, 'id', None) == 'when')
         ]
         return func
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -594,7 +594,7 @@ def find_versions_of_archive(
         list_depth (int): max depth to follow links on list_url pages.
             Defaults to 0.
         concurrency (int): maximum number of concurrent requests
-        reference_package (spack.package.Package or None): a spack package
+        reference_package (spack.package.PackageBase or None): a spack package
             used as a reference for url detection.  Uses the url_for_version
             method on the package to produce reference urls which, if found,
             are preferred.

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -886,7 +886,7 @@ class Value(object):
         return hash(self.value)
 
     def __eq__(self, other):
-        if isinstance(other, six.string_types):
+        if isinstance(other, (six.string_types, bool)):
             return self.value == other
         return self.value == other.value
 

--- a/lib/spack/spack/variant.py
+++ b/lib/spack/spack/variant.py
@@ -95,7 +95,7 @@ class Variant(object):
 
         Args:
             vspec (Variant): instance to be validated
-            pkg (spack.package.Package): the package that required the validation,
+            pkg (spack.package.PackageBase): the package that required the validation,
                 if available
 
         Raises:

--- a/var/spack/repos/builtin.mock/packages/cmake-client/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake-client/package.py
@@ -15,7 +15,7 @@ def check(condition, msg):
 
 
 class CmakeClient(CMakePackage):
-    """A dumy package that uses cmake."""
+    """A dummy package that uses cmake."""
     homepage  = 'https://www.example.com'
     url       = 'https://www.example.com/cmake-client-1.0.tar.gz'
 
@@ -37,7 +37,9 @@ class CmakeClient(CMakePackage):
     did_something = False
 
     @run_after('cmake')
-    @run_before('cmake', 'build', 'install')
+    @run_before('cmake')
+    @run_before('build')
+    @run_before('install')
     def increment(self):
         self.callback_counter += 1
 

--- a/var/spack/repos/builtin.mock/packages/cmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake/package.py
@@ -18,7 +18,7 @@ def check(condition, msg):
 
 
 class Cmake(Package):
-    """A dumy package for the cmake build system."""
+    """A dummy package for the cmake build system."""
     homepage  = 'https://www.cmake.org'
     url       = 'https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz'
 

--- a/var/spack/repos/builtin.mock/packages/cmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake/package.py
@@ -22,6 +22,8 @@ class Cmake(Package):
     homepage  = 'https://www.cmake.org'
     url       = 'https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz'
 
+    version('3.23.1',    '4cb3ff35b2472aae70f542116d616e63',
+            url='https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz')
     version('3.4.3',    '4cb3ff35b2472aae70f542116d616e63',
             url='https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz')
 

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-dependent/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-dependent/package.py
@@ -4,13 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-class DevBuildTestDependent(Package):
+class DevBuildTestDependent(MakefilePackage):
     homepage = "example.com"
     url = "fake.com"
 
     version('0.0.0', sha256='0123456789abcdef0123456789abcdef')
-
-    phases = ['edit', 'install']
 
     filename = 'dev-build-test-file.txt'
     original_string = "This file should be edited"
@@ -24,6 +22,9 @@ class DevBuildTestDependent(Package):
             f.seek(0)
             f.truncate()
             f.write(self.replacement_string)
+
+    def build(self, spec, prefix):
+        pass
 
     def install(self, spec, prefix):
         install(self.filename, prefix)

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-install-phases/package.py
@@ -2,29 +2,11 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-from time import sleep
-
-
 class DevBuildTestInstallPhases(Package):
     homepage = "example.com"
     url = "fake.com"
 
     version('0.0.0', sha256='0123456789abcdef0123456789abcdef')
-
-    phases = ['one', 'two', 'three', 'install']
-
-    def one(self, spec, prefix):
-        sleep(1)
-        print("One locomoco")
-
-    def two(self, spec, prefix):
-        sleep(2)
-        print("Two locomoco")
-
-    def three(self, spec, prefix):
-        sleep(3)
-        print("Three locomoco")
 
     def install(self, spec, prefix):
         print("install")

--- a/var/spack/repos/builtin.mock/packages/dev-build-test-install/package.py
+++ b/var/spack/repos/builtin.mock/packages/dev-build-test-install/package.py
@@ -4,13 +4,11 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-class DevBuildTestInstall(Package):
+class DevBuildTestInstall(MakefilePackage):
     homepage = "example.com"
     url = "fake.com"
 
     version('0.0.0', sha256='0123456789abcdef0123456789abcdef')
-
-    phases = ['edit', 'install']
 
     filename = 'dev-build-test-file.txt'
     original_string = "This file should be edited"
@@ -22,6 +20,9 @@ class DevBuildTestInstall(Package):
             f.seek(0)
             f.truncate()
             f.write(self.replacement_string)
+
+    def build(self, spec, prefix):
+        pass
 
     def install(self, spec, prefix):
         install(self.filename, prefix)

--- a/var/spack/repos/builtin.mock/packages/libtool-deletion/package.py
+++ b/var/spack/repos/builtin.mock/packages/libtool-deletion/package.py
@@ -13,6 +13,8 @@ class LibtoolDeletion(AutotoolsPackage):
     url = "http://www.example.com/libtool-deletion-1.0.tar.gz"
     version('4.2.1', sha256='e40b8f018c1da64edd1cc9a6fce5fa63b2e707e404e20cad91fbae337c98a5b7')
 
+    install_libtool_archives = False
+
     def do_stage(self):
         mkdirp(self.stage.source_path)
 

--- a/var/spack/repos/builtin.mock/packages/nosource-install/package.py
+++ b/var/spack/repos/builtin.mock/packages/nosource-install/package.py
@@ -16,9 +16,6 @@ class NosourceInstall(BundlePackage):
 
     depends_on('dependency-install')
 
-    # The install phase must be specified.
-    phases = ['install']
-
     # The install method must also be present.
     def install(self, spec, prefix):
         touch(join_path(self.prefix, 'install.txt'))

--- a/var/spack/repos/builtin.mock/packages/test-build-callbacks/package.py
+++ b/var/spack/repos/builtin.mock/packages/test-build-callbacks/package.py
@@ -2,12 +2,10 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 from spack import *
-from spack.package import run_after
 
 
-class TestBuildCallbacks(Package):
+class TestBuildCallbacks(MakefilePackage):
     """This package illustrates build callback test failure."""
 
     homepage = "http://www.example.com/test-build-callbacks"
@@ -15,10 +13,11 @@ class TestBuildCallbacks(Package):
 
     version('1.0', '0123456789abcdef0123456789abcdef')
 
-    phases = ['build', 'install']
     # Include undefined method (runtime failure) and 'test' (audit failure)
     build_time_test_callbacks = ['undefined-build-test', 'test']
-    run_after('build')(Package._run_default_build_time_test_callbacks)
+
+    def edit(self, spec, prefix):
+        pass
 
     def build(self, spec, prefix):
         pass

--- a/var/spack/repos/builtin.mock/packages/transitive-conditional-virtual-dependency/package.py
+++ b/var/spack/repos/builtin.mock/packages/transitive-conditional-virtual-dependency/package.py
@@ -2,11 +2,9 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-class TransitiveConditionalVirtualDependency(Package):
+class TransitiveConditionalVirtualDependency(BundlePackage):
     """Depends on a package with a conditional virtual dependency."""
     homepage = "https://dev.null"
-    has_code = False
-    phases = []
 
     version('1.0')
     depends_on('conditional-virtual-dependency')

--- a/var/spack/repos/builtin.mock/packages/trivial-install-test-package/package.py
+++ b/var/spack/repos/builtin.mock/packages/trivial-install-test-package/package.py
@@ -9,7 +9,7 @@ class TrivialInstallTestPackage(Package):
     """This package is a stub with a trivial install method.  It allows us
        to test the install and uninstall logic of spack."""
     homepage = "http://www.example.com/trivial_install"
-    url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
+    url = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
 
     version('1.0', '0123456789abcdef0123456789abcdef')
 

--- a/var/spack/repos/builtin.mock/packages/trivial-smoke-test/package.py
+++ b/var/spack/repos/builtin.mock/packages/trivial-smoke-test/package.py
@@ -15,6 +15,9 @@ class TrivialSmokeTest(Package):
 
     test_source_filename = 'cached_file.in'
 
+    def install(self, spec, prefix):
+        pass
+
     @run_before('install')
     def create_extra_test_source(self):
         mkdirp(self.install_test_root)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -251,8 +251,6 @@ class Cmake(Package):
              placement='cmake-bootstrap',
              when='@:2.8.10.2 platform=windows')
 
-    phases = ['bootstrap', 'build', 'install']
-
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('--version', output=str, error=str)
@@ -366,6 +364,8 @@ class Cmake(Package):
         self.generator('test')
 
     def install(self, spec, prefix):
+        self.bootstrap(spec, prefix)
+        self.build(spec, prefix)
         self.generator('install')
 
         if spec.satisfies('%fj'):

--- a/var/spack/repos/builtin/packages/genie/package.py
+++ b/var/spack/repos/builtin/packages/genie/package.py
@@ -2,14 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 import os
-
-from spack.directives import depends_on, patch, variant, version
-from spack.package import Package
-from spack.util.executable import Executable
-from spack.version import Version
 
 
 class Genie(Package):

--- a/var/spack/repos/builtin/packages/ibm-databroker/package.py
+++ b/var/spack/repos/builtin/packages/ibm-databroker/package.py
@@ -7,7 +7,7 @@
 from spack import *
 
 
-class IbmDatabroker(CMakePackage, PythonPackage):
+class IbmDatabroker(CMakePackage, PythonExtension):
     """The Data Broker (DBR) is a distributed, in-memory container of key-value
     stores enabling applications in a workflow to exchange data through one or
     more shared namespaces. Thanks to a small set of primitives, applications

--- a/var/spack/repos/builtin/packages/lua/package.py
+++ b/var/spack/repos/builtin/packages/lua/package.py
@@ -26,11 +26,6 @@ class LuaImplPackage(MakefilePackage):
         description="Fetcher to use in the LuaRocks package manager",
     )
 
-    phases = MakefilePackage.phases + ["add_luarocks"]
-    #: This attribute is used in UI queries that need to know the build
-    #: system base class
-    build_system_class = "LuaImplPackage"
-
     lua_version_override = None
 
     def __init__(self, *args, **kwargs):
@@ -107,7 +102,9 @@ class LuaImplPackage(MakefilePackage):
                 )
                 symlink(real_lib, "liblua" + ext)
 
-    def add_luarocks(self, spec, prefix):
+    @run_after('install')
+    def add_luarocks(self):
+        prefix = self.spec.prefix
         with working_dir(os.path.join("luarocks", "luarocks")):
             configure("--prefix=" + prefix, "--with-lua=" + prefix)
             make("build")

--- a/var/spack/repos/builtin/packages/nasm/package.py
+++ b/var/spack/repos/builtin/packages/nasm/package.py
@@ -8,14 +8,20 @@ import os
 from spack import *
 
 
-class Nasm(Package):
+class Nasm(AutotoolsPackage):
     """NASM (Netwide Assembler) is an 80x86 assembler designed for
     portability and modularity. It includes a disassembler as well."""
 
     homepage = "https://www.nasm.us"
-    url      = "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz"
+    url = "https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz"
     list_url = "https://www.nasm.us/pub/nasm/releasebuilds"
     list_depth = 1
+
+    buildsystem(
+        'autotools',
+        conditional('generic', when='platform=windows'),
+        default='autotools'
+    )
 
     version('2.15.05', sha256='9182a118244b058651c576baa9d0366ee05983c4d4ae1d9ddd3236a9f2304997')
     version('2.14.02', sha256='b34bae344a3f2ed93b2ca7bf25f1ed3fb12da89eeda6096e3551fd66adeae9fc')
@@ -26,12 +32,11 @@ class Nasm(Package):
     # https://bugzilla.nasm.us/show_bug.cgi?id=3392461
     patch('https://src.fedoraproject.org/rpms/nasm/raw/0cc3eb244bd971df81a7f02bc12c5ec259e1a5d6/f/0001-Remove-invalid-pure_func-qualifiers.patch', level=1, sha256='ac9f315d204afa6b99ceefa1fe46d4eed2b8a23c7315d32d33c0f378d930e950', when='@2.13.03 %gcc@8:')
 
-    patch('msvc.mak.patch', when='@2.15.05 platform=windows')
+    with when('platform=windows'):
+        depends_on('perl')
+        patch('msvc.mak.patch', when='@2.15.05')
 
-    conflicts('%intel@:14', when='@2.14:',
-              msg="Intel 14 has immature C11 support")
-
-    depends_on('perl', when='platform=windows')
+    conflicts('%intel@:14', when='@2.14:', msg="Intel <= 14 lacks support for C11")
 
     def patch(self):
         # Remove flags not recognized by the NVIDIA compiler
@@ -41,13 +46,7 @@ class Nasm(Package):
             filter_file(r'CFLAGS="\$pa_add_flags__old_flags -Werror=.*"',
                         'CFLAGS="$pa_add_flags__old_flags"', 'configure')
 
-    def install(self, spec, prefix):
-        with working_dir(self.stage.source_path, create=True):
-            configure(*['--prefix={0}'.format(self.prefix)])
-            make('V=1')
-            make('install')
-
-    @when('platform=windows')
+    @generic
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path, create=True):
             # build NASM with nmake

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -31,8 +31,6 @@ class Ninja(Package):
 
     depends_on('python', type='build')
 
-    phases = ['configure', 'install']
-
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('--version', output=str, error=str)
@@ -53,6 +51,7 @@ class Ninja(Package):
         env.prepend_path('PYTHONPATH', self.prefix.misc)
 
     def install(self, spec, prefix):
+        self.configure(spec, prefix)
         mkdir(prefix.bin)
         name = 'ninja'
         if sys.platform == 'win32':

--- a/var/spack/repos/builtin/packages/perl/package.py
+++ b/var/spack/repos/builtin/packages/perl/package.py
@@ -27,7 +27,7 @@ from spack.operating_systems.mac_os import macos_version
 is_windows = sys.platform == 'win32'
 
 
-class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
+class Perl(MakefilePackage):  # Perl doesn't use Autotools, it should subclass Package
     """Perl 5 is a highly capable, feature-rich programming language with over
        27 years of development."""
 
@@ -133,8 +133,6 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
         destination="cpanm",
         placement="cpanm"
     )
-
-    phases = ['configure', 'build', 'install']
 
     def patch(self):
         # https://github.com/Perl/perl5/issues/15544 long PATH(>1000 chars) fails a test
@@ -254,7 +252,7 @@ class Perl(Package):  # Perl doesn't use Autotools, it should subclass Package
 
         return config_args
 
-    def configure(self, spec, prefix):
+    def edit(self, spec, prefix):
         if is_windows:
             return
         configure = Executable('./Configure')

--- a/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx-runtime/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class PyOnnxRuntime(CMakePackage, PythonPackage):
+class PyOnnxRuntime(CMakePackage, PythonExtension):
     """ONNX Runtime is a performance-focused complete scoring
     engine for Open Neural Network Exchange (ONNX) models, with
     an open extensible architecture to continually address the

--- a/var/spack/repos/builtin/packages/py-pybind11/package.py
+++ b/var/spack/repos/builtin/packages/py-pybind11/package.py
@@ -8,7 +8,7 @@ import os
 from spack import *
 
 
-class PyPybind11(CMakePackage, PythonPackage):
+class PyPybind11(CMakePackage, PythonExtension):
     """pybind11 -- Seamless operability between C++11 and Python.
 
     pybind11 is a lightweight header-only library that exposes C++ types in

--- a/var/spack/repos/builtin/packages/py-pykokkos-base/package.py
+++ b/var/spack/repos/builtin/packages/py-pykokkos-base/package.py
@@ -8,7 +8,7 @@
 from spack import *
 
 
-class PyPykokkosBase(CMakePackage, PythonPackage):
+class PyPykokkosBase(CMakePackage, PythonExtension):
     '''Minimal set of bindings for Kokkos interoperability with Python
     (initialize, finalize, View, DynRankView, Kokkos-tools)'''
 

--- a/var/spack/repos/builtin/packages/py-tfdlpack/package.py
+++ b/var/spack/repos/builtin/packages/py-tfdlpack/package.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 
-class PyTfdlpack(CMakePackage, PythonPackage):
+class PyTfdlpack(CMakePackage, PythonExtension):
     """Tensorflow plugin for DLPack."""
 
     homepage = "https://github.com/VoVAllen/tf-dlpack"

--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -28,7 +28,7 @@ from spack.util.prefix import Prefix
 is_windows = sys.platform == 'win32'
 
 
-class Python(Package):
+class Python(AutotoolsPackage):
     """The Python programming language."""
 
     homepage = "https://www.python.org/"
@@ -37,8 +37,6 @@ class Python(Package):
     list_depth = 1
 
     maintainers = ['adamjstewart', 'skosukhin', 'scheibelp', 'varioustoxins']
-
-    phases = ['configure', 'build', 'install']
 
     #: phase
     install_targets = ['install']

--- a/var/spack/repos/builtin/packages/ruby/package.py
+++ b/var/spack/repos/builtin/packages/ruby/package.py
@@ -47,7 +47,6 @@ class Ruby(Package):
             depends_on('openssl@:1.0', when='@:2.3')
 
     extendable = True
-    phases = ['configure', 'build', 'install']
     build_targets = []
     install_targets = ['install']
     # Known build issues when Avira antivirus software is running:
@@ -142,6 +141,8 @@ class Ruby(Package):
                 make(*params)
 
     def install(self, spec, prefix):
+        self.configure(spec, prefix)
+        self.build(spec, prefix)
         with working_dir(self.stage.source_path):
             if is_windows:
                 nmake('install')

--- a/var/spack/repos/builtin/packages/samtools/package.py
+++ b/var/spack/repos/builtin/packages/samtools/package.py
@@ -50,15 +50,14 @@ class Samtools(Package):
 
     def install(self, spec, prefix):
         if '+termlib' in spec['ncurses']:
-            curses_lib = '-lncursesw -ltinfow'
+            curses_lib = '-lncurses -ltinfow'
         else:
-            curses_lib = '-lncursesw'
+            curses_lib = '-lncurses'
 
         if self.spec.version >= Version('1.3.1'):
             configure('--prefix={0}'.format(prefix),
                       '--with-htslib={0}'.format(self.spec['htslib'].prefix),
-                      '--with-ncurses',
-                      'CURSES_LIB={0}'.format(curses_lib))
+                      '--with-ncurses')
             make()
             make('install')
         else:

--- a/var/spack/repos/builtin/packages/timemory/package.py
+++ b/var/spack/repos/builtin/packages/timemory/package.py
@@ -8,7 +8,7 @@
 from spack import *
 
 
-class Timemory(CMakePackage, PythonPackage):
+class Timemory(CMakePackage, PythonExtension):
     '''Modular profiling toolkit and suite of libraries and tools
     for C/C++/Fortran/CUDA/Python'''
 

--- a/var/spack/repos/builtin/packages/uncrustify/package.py
+++ b/var/spack/repos/builtin/packages/uncrustify/package.py
@@ -6,12 +6,12 @@
 from spack import *
 
 
-class Uncrustify(Package):
+class Uncrustify(CMakePackage, AutotoolsPackage):
     """Source Code Beautifier for C, C++, C#, ObjectiveC, Java, and others."""
 
     homepage = "http://uncrustify.sourceforge.net/"
-    git      = "https://github.com/uncrustify/uncrustify"
-    url      = "https://sourceforge.net/projects/uncrustify/files/uncrustify/uncrustify-0.69/uncrustify-0.69.tar.gz"
+    git = "https://github.com/uncrustify/uncrustify"
+    url = "https://sourceforge.net/projects/uncrustify/files/uncrustify/uncrustify-0.69/uncrustify-0.69.tar.gz"
 
     maintainers = ['gmaurel']
 
@@ -31,28 +31,15 @@ class Uncrustify(Package):
     version('0.62', commit='5987f2')
     version('0.61', sha256='1df0e5a2716e256f0a4993db12f23d10195b3030326fdf2e07f8e6421e172df9')
 
-    depends_on('cmake', type='build', when='@0.64:')
-    depends_on('automake', type='build', when='@0.63')
-    depends_on('autoconf', type='build', when='@0.63')
+    buildsystem(
+        conditional('cmakelists', when='@0.64:'),
+        conditional('autotools', when='@:0.63'),
+        default='cmakelists'
+    )
 
-    @when('@0.64:')
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            cmake('..', *std_cmake_args)
-            make()
-            make('install')
-
-    @when('@0.63')
-    def install(self, spec, prefix):
-        which('bash')('autogen.sh')
-        configure('--prefix={0}'.format(self.prefix))
-        make()
-        make('install')
-
-    @when('@:0.62')
-    def install(self, spec, prefix):
-        configure('--prefix={0}'.format(self.prefix))
-        make()
-        make('install')
+    with when('buildsystem=autotools'):
+        depends_on('automake', type='build')
+        depends_on('autoconf', type='build')
+        depends_on('libtool', type='build', when='@0.63')
 
     patch('uncrustify-includes.patch', when='@0.73')


### PR DESCRIPTION
This PR extends the DSL that can be used in packages to allow declaring that a package uses different build-systems under different conditions. The main design decision both in here and in #30738 is to require each and every spec to have a `build_system` single valued variant. This variant can be used in many contexts to manipulate (force, query, display etc.) the build-system associated with a concrete spec.

## Expected backward incompatibilities

-  Packages that define their own `phases` need to be converted to some existing build-system

## Pros

- This PR is expected to be almost 100% backward compatible

## Cons

- The PR maintain the same single class approach for coding recipes. To do so, it complicates the MRO logic by injecting the appropriate base class at build-time. This might be beneficial in the short term (less breakages in package recipes), but might not be in the long term (single blob class for packages).

- As the package class responsibilities grow in numbers, so do the name clashes in different methods and attributes. In case an attribute defined for multiple build-systems used by the package needs customization, it's responsibility of the packager to distinguish all the different cases and return the appropriate value in each. For instance, a package buildable with both `cmake` and `autotools` that needs a custom `build_directory` for the latter, need to return in a property the default value for the former explicitly.

## The `buildsystem` directive

To make it easy to declare the build-system, a new directive has been created. This directive is essentially a wrapper around `variant`:

```python
def buildsystem(*values, **kwargs):
     default = kwargs.get('default', None) or values[0]
     return variant(
         'buildsystem',
         values=tuple(values),
         description='Build-systems supported by the package',
         default=default,
         multi=False
     )
```

For packages with a single buildsystem, the directive is already used in base classes - so no modifications are needed for packages in that sense.

## Decorators to customize phases

To be able to run certain functions before or after a phase, or to override a phase, there is one decorator for each build-system:
```python
class OpenJpeg(CMakePackage):
    @cmakelists
    def build(self, spec, prefix):
        pass

    @cmakelists.run_after('build')
    def foo(self):
        pass
```
The choice of the name to use, like `cmakelists`, have sometime been driven by the impossibility to use the most obvious choice (e.g. `cmake`) due to name clashes at the class scope.

## Injection of the base class

A package object in this implementation lacks the base class to call any of the methods needed during build. That base class is injected when the builder is retrieved, by using an object wrapper:
```python
class BuildWrapper(six.with_metaclass(BuilderMeta, object)):
    #: List of glob expressions. Each expression must either be
    #: absolute or relative to the package source path.
    #: Matching artifacts found at the end of the build process will be
    #: copied in the same directory tree as _spack_build_logfile and
    #: _spack_build_envfile.
    archive_files = []  # type: List[str]

    def __init__(self, package_object):
        package_cls = type(package_object)
        wrapper_cls = type(self)
        bases = (package_cls, wrapper_cls)
        new_cls_name = package_cls.__name__ + "BuildWrapper"
        new_cls = type(new_cls_name, bases, {})
        new_cls.__module__ = package_cls.__module__
        for attribute_name in (
            _RUN_BEFORE_PACKAGE_ATTRIBUTE,
            _RUN_AFTER_PACKAGE_ATTRIBUTE,
            _PHASE_OVERRIDE_PACKAGE_ATTRIBUTE,
        ):
            package_callbacks = getattr(package_cls, attribute_name, [])
            wrapper_callbacks = getattr(wrapper_cls, attribute_name, [])
            # FIXME: check that wrapper_cls has no phase overrides,
            # FIXME: they should be simple callbacks
            setattr(new_cls, attribute_name, package_callbacks + wrapper_callbacks)

        self.__class__ = new_cls
        self.__dict__ = package_object.__dict__
```
In the implementation above the relevant part is that `type(self)` will evaluate to specialized bases from different build-systems, and each builder must define a `PackageWrapper` which is effectively implementing the base class methods.

## Example of packages with multiple build-systems

- `arpack-ng`
- `nasm`
- `uncrustify`

```console
$ spack install -v arpack-ng~mpi buildsystem=cmakelists
[ ... ]
$ spack install -v arpack-ng~mpi buildsystem=autotools
[ ... ]
```