### PR TITLE
environment-modules: add version 5.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/environment-modules/package.py
+++ b/var/spack/repos/builtin/packages/environment-modules/package.py
@@ -10,10 +10,11 @@ class EnvironmentModules(Package):
     """
 
     homepage = 'https://cea-hpc.github.io/modules/'
-    url = 'https://github.com/cea-hpc/modules/releases/download/v5.0.1/modules-5.0.1.tar.gz'
+    url = 'https://github.com/cea-hpc/modules/releases/download/v5.1.0/modules-5.1.0.tar.gz'
 
     maintainers = ['xdelaruelle']
 
+    version('5.1.0', sha256='1ab1e859b9c8bca8a8d332945366567fae4cf8dd7e312a689daaff46e7ffa949')
     version('5.0.1', sha256='33a598eaff0713de09e479c2636ecde188b982584e56377f234e5065a61be7ba')
     version('5.0.0', sha256='428e23ac51a6006605de65ed9114d544a5506cb4b6bfb03d8522778f13e4f7ea')
     version('4.8.0', sha256='d6b45cadc2146ed5e0b25a96d44643ad516054eb7745acb14a1dc7bf30744f6e')


### PR DESCRIPTION
New feature release in the v5 series.

Major new features included: https://modules.readthedocs.io/en/stable/MIGRATING.html#v5-1
