### PR TITLE
libxkbcommon: new version 1.4.0, support for newer meson build system

### DIFF
--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -43,7 +43,7 @@ class Libxkbcommon(MesonPackage):
         ]
 
     @when('@:0.8')
-    def meson_args(self):
+    def configure_args(self):
         """Configure arguments are passed using meson_args functions"""
         return [
             '--with-xkb-config-root={0}'.format(self.spec['xkbdata'].prefix),
@@ -56,7 +56,7 @@ class Libxkbcommon(MesonPackage):
         """Run the AutotoolsPackage configure phase in source_path"""
         options = getattr(self, 'configure_flag_args', [])
         options += ['--prefix={0}'.format(prefix)]
-        options += self.meson_args()
+        options += self.configure_args()
         with working_dir(self.stage.source_path, create=True):
             configure(*options)
 

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -54,22 +54,14 @@ class Libxkbcommon(MesonPackage):
     @when('@:0.8')
     def meson(self, spec, prefix):
         """Run the AutotoolsPackage configure phase in source_path"""
-        options = getattr(self, 'configure_flag_args', [])
-        options += ['--prefix={0}'.format(prefix)]
-        options += self.configure_args()
-        with working_dir(self.stage.source_path, create=True):
-            configure(*options)
+        configure('--prefix=' + prefix, *self.configure_args())
 
     @when('@:0.8')
     def build(self, spec, prefix):
         """Run the AutotoolsPackage build phase in source_path"""
-        params = ['V=1']
-        params += self.build_targets
-        with working_dir(self.stage.source_path):
-            make(*params)
+        make()
 
     @when('@:0.8')
     def install(self, spec, prefix):
         """Run the AutotoolsPackage install phase in source_path"""
-        with working_dir(self.stage.source_path):
-            make(*self.install_targets)
+        make('install')

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import inspect
+
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -72,4 +72,4 @@ class Libxkbcommon(MesonPackage):
     def install(self, spec, prefix):
         """Run the AutotoolsPackage install phase in source_path"""
         with working_dir(self.stage.source_path):
-            inspect.getmodule(self).make(*self.install_targets)
+            make(*self.install_targets)

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -66,7 +66,7 @@ class Libxkbcommon(MesonPackage):
         params = ['V=1']
         params += self.build_targets
         with working_dir(self.stage.source_path):
-            inspect.getmodule(self).make(*params)
+            make(*params)
 
     @when('@:0.8')
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import inspect
-
 from spack import *
 
 
@@ -24,7 +22,6 @@ class Libxkbcommon(MesonPackage):
 
     variant('wayland', default=False, description='Enable Wayland support')
 
-    depends_on('meson', type='build', when='@0.9:')
     depends_on('pkgconfig@0.9.0:', type='build')
     depends_on('bison', type='build')
     depends_on('util-macros')

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Libxkbcommon(Package):
+class Libxkbcommon(MesonPackage):
     """xkbcommon is a library to handle keyboard descriptions, including
     loading them from disk, parsing them and handling their state. It's mainly
     meant for client toolkits, window systems, and other system
@@ -33,7 +33,6 @@ class Libxkbcommon(Package):
     depends_on('wayland@1.2.0:', when='+wayland')
     depends_on('wayland-protocols@1.7:', when='+wayland')
 
-    @when('@0.9:')
     def meson_args(self):
         return [
             '-Dxkb-config-root={0}'.format(self.spec['xkbdata'].prefix),
@@ -41,17 +40,13 @@ class Libxkbcommon(Package):
             '-Denable-wayland=' + str(self.spec.satisfies('+wayland'))
         ]
 
-    @when('@0.9:')
-    def install(self, spec, prefix):
-        with working_dir('spack-build', create=True):
-            args = []
-            args.extend(std_meson_args)
-            args.extend(self.meson_args())
-            meson('..', *args)
-            ninja('-v')
-            if self.run_tests:
-                ninja('test')
-            ninja('install')
+    @when('@:0.8')
+    def meson(self, spec, prefix):
+        return
+
+    @when('@:0.8')
+    def build(self, spec, prefix):
+        return
 
     @when('@:0.8')
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -70,4 +70,3 @@ class Libxkbcommon(Package):
         make('install')
         if self.run_tests:
             make('installcheck')
-

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -58,7 +58,7 @@ class Libxkbcommon(MesonPackage):
         options += ['--prefix={0}'.format(prefix)]
         options += self.meson_args()
         with working_dir(self.stage.source_path, create=True):
-            inspect.getmodule(self).configure(*options)
+            configure(*options)
 
     @when('@:0.8')
     def build(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -73,4 +73,3 @@ class Libxkbcommon(MesonPackage):
         """Run the AutotoolsPackage install phase in source_path"""
         with working_dir(self.stage.source_path):
             inspect.getmodule(self).make(*self.install_targets)
-

--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -16,9 +16,9 @@ class Libxkbcommon(Package):
     url      = "https://xkbcommon.org/download/libxkbcommon-0.8.2.tar.xz"
 
     version('1.4.0', sha256='106cec5263f9100a7e79b5f7220f889bc78e7d7ffc55d2b6fdb1efefb8024031')
-    version('0.8.2', sha256='7ab8c4b3403d89d01898066b72cb6069bddeb5af94905a65368f671a026ed58c')
-    version('0.8.0', sha256='e829265db04e0aebfb0591b6dc3377b64599558167846c3f5ee5c5e53641fe6d')
-    version('0.7.1', sha256='ba59305d2e19e47c27ea065c2e0df96ebac6a3c6e97e28ae5620073b6084e68b')
+    version('0.8.2', sha256='7ab8c4b3403d89d01898066b72cb6069bddeb5af94905a65368f671a026ed58c', deprecated=True)
+    version('0.8.0', sha256='e829265db04e0aebfb0591b6dc3377b64599558167846c3f5ee5c5e53641fe6d', deprecated=True)
+    version('0.7.1', sha256='ba59305d2e19e47c27ea065c2e0df96ebac6a3c6e97e28ae5620073b6084e68b', deprecated=True)
 
     variant('wayland', default=False, description='Enable Wayland support')
 
@@ -38,7 +38,7 @@ class Libxkbcommon(Package):
         return [
             '-Dxkb-config-root={0}'.format(self.spec['xkbdata'].prefix),
             '-Denable-docs=false',
-            '-Denable-wayland=' + ('true' if self.spec.satisfies('+wayland') else 'false')
+            '-Denable-wayland=' + str(self.spec.satisfies('+wayland'))
         ]
 
     @when('@0.9:')
@@ -56,7 +56,9 @@ class Libxkbcommon(Package):
     @when('@:0.8')
     def configure_args(self):
         return [
-            '--with-xkb-config-root={0}'.format(self.spec['xkbdata'].prefix)
+            '--with-xkb-config-root={0}'.format(self.spec['xkbdata'].prefix),
+            '--disable-docs',
+            '--' + ('en' if self.spec.satisfies('+wayland') else 'dis') + 'able-wayland'
         ]
 
     @when('@:0.8')


### PR DESCRIPTION
The latest autotools-based libxkbcommon@0.8.2 in spack (from 2018) fails to compile with gcc-12 due to -Werror=array-bounds. The autotools build system was removed in 0.9. Only later patches fix the underlying array-bounds issues. Instead of adding local backport patches to the autotools versions in spack, this PR adds support for the newer meson builds (both are now supported). Older autotools versions are marked as deprecated

A new variant was added to support wayland (which not everyone will want, and defaults to false).

Tagging @alalazo @adamjstewart since you've been keeping track of these multi-build system packages, https://github.com/spack/spack/pull/12941#issuecomment-538105434. I've followed the recommendations of marking the older build system versions as deprecated, but inheriting from the new build system (MesonPackage) causes the meson phase to be called for the autotools versions. To avoid that, this still inherits just from Package.

Tested against gcc@11 for all versions, gcc@12 for version 1.4.0. Confirmed that builds pick up the wayland variant in the build logs.