### PR TITLE
root: new version 6.26.02

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -31,6 +31,7 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version('6.26.02', sha256='7ba96772271a726079506c5bf629c3ceb21bf0682567ed6145be30606d7cd9bb')
     version('6.26.00', sha256='5fb9be71fdf0c0b5e5951f89c2f03fcb5e74291d043f6240fb86f5ca977d4b31')
     version('6.24.06', sha256='907f69f4baca1e4f30eeb4979598ca7599b6aa803ca046e80e25b6bbaa0ef522')
     version('6.24.02', sha256='0507e1095e279ccc7240f651d25966024325179fa85a1259b694b56723ad7c1c')


### PR DESCRIPTION
New ROOT bugfix version. Build confirmed with gcc@11.3.0. It also addresses a failing build test that was present (for some variant configurations, I think mainly `+veccore`) with 6.26.00 and which may affect others as well.

Maintainers: @HadrienG2  @chissg  @drbenmorgan  @vvolkl

Others: @joequant maybe fixes the issue that led to https://github.com/spack/spack/pull/30125