### PR TITLE
gaudi: new version 36.5

### DIFF
--- a/var/spack/repos/builtin/packages/gaudi/package.py
+++ b/var/spack/repos/builtin/packages/gaudi/package.py
@@ -17,6 +17,7 @@ class Gaudi(CMakePackage):
     tags = ['hep']
 
     version('master', branch='master')
+    version('36.5', sha256='593e0316118411a5c5fde5d4d87cbfc3d2bb748a8c72a66f4025498fcbdb0f7e')
     version('36.4', sha256='1a5c27cdc21ec136b47f5805406c92268163393c821107a24dbb47bd88e4b97d')
     version('36.3', sha256='9ac228d8609416afe4dea6445c6b3ccebac6fab1e46121fcc3a056e24a5d6640')
     version('36.2', sha256='a1b4bb597941a7a5b8d60382674f0b4ca5349c540471cd3d4454efbe7b9a09b9')


### PR DESCRIPTION
No changes to build system. No other major changes (beside two minor issues below). Builds fine with gcc@11.3.0 on my system.

Maintainers: @drbenmorgan  @vvolkl

@joequant The issue in https://github.com/spack/spack/pull/30281 still applies and someone else with privileges to file an MR on the CERN gitlab instance could contribute that small patch and then we can pull it in as a url patch here rather than including a diff or filter_file.

@vvolkl This will break the DataObjectHandle setRead calls at e.g. https://github.com/key4hep/k4FWCore/blob/v01-00pre14/k4FWCore/include/k4FWCore/DataHandle.h#L148