### PR TITLE
Cray manifest file: accept "nvidia" as "nvhpc"

### DIFF
--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -3,14 +3,19 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+"""
+Note that where possible, this should produce specs using `entries_to_specs`
+rather than `spec_from_entry`, since the former does additional work to
+establish dependency relationships (and in general the manifest-parsing
+logic needs to consume all related specs in a single pass).
+"""
 import json
 
 import pytest
 
 import spack
 import spack.cray_manifest as cray_manifest
-from spack.cray_manifest import (
-    compiler_from_entry, spec_from_entry, entries_to_specs)
+from spack.cray_manifest import compiler_from_entry, entries_to_specs
 
 example_x_json_str = """\
 {
@@ -299,7 +304,7 @@ def test_failed_translate_compiler_name():
     ).to_dict()
 
     with pytest.raises(spack.compilers.UnknownCompilerError):
-        spec_from_entry(spec_json)
+        entries_to_specs([spec_json])
 
 
 def create_manifest_content():

--- a/lib/spack/spack/test/cray_manifest.py
+++ b/lib/spack/spack/test/cray_manifest.py
@@ -9,7 +9,8 @@ import pytest
 
 import spack
 import spack.cray_manifest as cray_manifest
-from spack.cray_manifest import compiler_from_entry, entries_to_specs
+from spack.cray_manifest import (
+    compiler_from_entry, spec_from_entry, entries_to_specs)
 
 example_x_json_str = """\
 {
@@ -106,14 +107,38 @@ class JsonArchEntry(object):
 
 
 class JsonCompilerEntry(object):
-    def __init__(self, name, version):
+    def __init__(self, name, version, arch=None, executables=None):
         self.name = name
         self.version = version
+        if not arch:
+            arch = {
+                "os": "centos8",
+                "target": "x86_64"
+            }
+        if not executables:
+            executables = {
+                "cc": "/path/to/compiler/cc",
+                "cxx": "/path/to/compiler/cxx",
+                "fc": "/path/to/compiler/fc"
+            }
+        self.arch = arch
+        self.executables = executables
 
-    def to_dict(self):
+    def compiler_json(self):
         return {
             'name': self.name,
-            'version': self.version
+            'version': self.version,
+            'arch': self.arch,
+            'executables': self.executables,
+        }
+
+    def spec_json(self):
+        """The compiler spec only lists the name/version, not
+           arch/executables.
+        """
+        return {
+            'name': self.name,
+            'version': self.version,
         }
 
 
@@ -123,11 +148,20 @@ _common_arch = JsonArchEntry(
     target='haswell'
 ).to_dict()
 
-
+# Intended to match example_compiler_entry above
 _common_compiler = JsonCompilerEntry(
     name='gcc',
-    version='10.2.0'
-).to_dict()
+    version='10.2.0',
+    arch={
+        "os": "centos8",
+        "target": "x86_64"
+    },
+    executables={
+        "cc": "/path/to/compiler/cc",
+        "cxx": "/path/to/compiler/cxx",
+        "fc": "/path/to/compiler/fc"
+    }
+)
 
 
 def test_compatibility():
@@ -142,7 +176,7 @@ def test_compatibility():
         prefix='/path/to/packagey-install/',
         version='1.0',
         arch=_common_arch,
-        compiler=_common_compiler,
+        compiler=_common_compiler.spec_json(),
         dependencies={},
         parameters={}
     )
@@ -153,7 +187,7 @@ def test_compatibility():
         prefix='/path/to/packagex-install/',
         version='1.0',
         arch=_common_arch,
-        compiler=_common_compiler,
+        compiler=_common_compiler.spec_json(),
         dependencies=dict([y.as_dependency(deptypes=['link'])]),
         parameters={'precision': ['double', 'float']}
     )
@@ -180,7 +214,7 @@ def generate_openmpi_entries():
         prefix='/path/to/hwloc-install/',
         version='2.0.3',
         arch=_common_arch,
-        compiler=_common_compiler,
+        compiler=_common_compiler.spec_json(),
         dependencies={},
         parameters={}
     )
@@ -194,7 +228,7 @@ def generate_openmpi_entries():
         prefix='/path/to/openmpi-install/',
         version='4.1.0',
         arch=_common_arch,
-        compiler=_common_compiler,
+        compiler=_common_compiler.spec_json(),
         dependencies=dict([hwloc.as_dependency(deptypes=['link'])]),
         parameters={
             'internal-hwloc': False,
@@ -206,7 +240,7 @@ def generate_openmpi_entries():
     return [openmpi, hwloc]
 
 
-def test_spec_conversion():
+def test_generate_specs_from_manifest():
     """Given JSON entries, check that we can form a set of Specs
        including dependency references.
     """
@@ -214,6 +248,58 @@ def test_spec_conversion():
     specs = entries_to_specs(entries)
     openmpi_spec, = list(x for x in specs.values() if x.name == 'openmpi')
     assert openmpi_spec['hwloc']
+
+
+def test_translate_compiler_name():
+    nvidia_compiler = JsonCompilerEntry(
+        name='nvidia',
+        version='19.1',
+        executables={
+            "cc": "/path/to/compiler/nvc",
+            "cxx": "/path/to/compiler/nvc++",
+        }
+    )
+
+    compiler = compiler_from_entry(nvidia_compiler.compiler_json())
+    assert compiler.name == 'nvhpc'
+
+    spec_json = JsonSpecEntry(
+        name='hwloc',
+        hash='hwlocfakehashaaa',
+        prefix='/path/to/hwloc-install/',
+        version='2.0.3',
+        arch=_common_arch,
+        compiler=nvidia_compiler.spec_json(),
+        dependencies={},
+        parameters={}
+    ).to_dict()
+
+    spec, = entries_to_specs([spec_json]).values()
+    assert spec.compiler.name == 'nvhpc'
+
+
+def test_failed_translate_compiler_name():
+    unknown_compiler = JsonCompilerEntry(
+        name='unknown',
+        version='1.0'
+    )
+
+    with pytest.raises(spack.compilers.UnknownCompilerError):
+        compiler_from_entry(unknown_compiler.compiler_json())
+
+    spec_json = JsonSpecEntry(
+        name='packagey',
+        hash='hash-of-y',
+        prefix='/path/to/packagey-install/',
+        version='1.0',
+        arch=_common_arch,
+        compiler=unknown_compiler.spec_json(),
+        dependencies={},
+        parameters={}
+    ).to_dict()
+
+    with pytest.raises(spack.compilers.UnknownCompilerError):
+        spec_from_entry(spec_json)
 
 
 def create_manifest_content():


### PR DESCRIPTION
Create function for translating compiler names on specs/compiler entries in a Cray manifest file when they don't match the name Spack expects.

A manifest file (see https://github.com/spack/spack/pull/29652) was referring to `nvc++` etc. as "nvidia", whereas Spack calls it "nvhpc". This PR creates a dictionary for translating these names (this only works when the only difference is in fact the name: it should not be used to force Spack to recognize compilers that it has no description for).

TODOs

- [x] Add test