### PR TITLE
fix nmap build issue (https://github.com/nmap/nmap/issues/2144)

### DIFF
--- a/var/spack/repos/builtin/packages/nmap/package.py
+++ b/var/spack/repos/builtin/packages/nmap/package.py
@@ -43,6 +43,7 @@ class Nmap(AutotoolsPackage):
     def configure_args(self):
         args = []
 
+        args.append("--disable-rdma")
         args += self.with_or_without('liblua')
         args += self.with_or_without('ncat')
         args += self.with_or_without('ndiff')

--- a/var/spack/repos/builtin/packages/nmap/package.py
+++ b/var/spack/repos/builtin/packages/nmap/package.py
@@ -43,7 +43,9 @@ class Nmap(AutotoolsPackage):
     def configure_args(self):
         args = []
 
+        # https://github.com/nmap/nmap/issues/2144
         args.append("--disable-rdma")
+
         args += self.with_or_without('liblua')
         args += self.with_or_without('ncat')
         args += self.with_or_without('ndiff')


### PR DESCRIPTION
When I install nmap in my server using `spack install nmap`, I get these error :

```
==> Installing nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56
==> No binary for nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56 found: installing from source
==> Using cached archive: /home/wyf/share/spack/var/spack/cache/_source-cache/archive/a5/a5479f2f8a6b0b2516767d2f7189c386c1dc858d997167d7ec5cfc798c7571a1.tar.bz2
==> No patches needed for nmap
==> nmap: Executing phase: 'autoreconf'
==> nmap: Executing phase: 'configure'
==> nmap: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j16' 'V=1'

93 errors found in build log:
     1775    /home/wyf/share/spack/lib/spack/env/gcc/g++ -Wl,-E  -Lnbase -Lnsock/src/   -o nmap charpool.o FingerPrintResults.o FPEngine.o FPModel.o idle_scan.o MACLookup.o nmap_
             dns.o nmap_error.o nmap.o nmap_ftp.o NmapOps.o NmapOutputTable.o nmap_tty.o osscan2.o osscan.o output.o payload.o portlist.o portreasons.o protocols.o scan_engine.o 
             scan_engine_connect.o scan_engine_raw.o scan_lists.o service_scan.o services.o string_pool.o NewTargets.o TargetGroup.o Target.o targets.o tcpip.o timing.o tracerout
             e.o utils.o xml.o nse_main.o nse_utility.o nse_nsock.o nse_dnet.o nse_fs.o nse_nmaplib.o nse_debug.o nse_pcrelib.o nse_lpeg.o nse_openssl.o nse_ssl_cert.o nse_libssh
             2.o nse_zlib.o main.o -lnsock -lnbase -lpcre libpcap/libpcap.a libssh2/lib/libssh2.a -lssl -lcrypto -lz libnetutil/libnetutil.a ./libdnet-stripped/src/.libs/libdnet.
             a ./liblua/liblua.a ./liblinear/liblinear.a -ldl
     1776    make[1]: Entering directory `/tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/ncat'
     1777    /home/wyf/share/spack/lib/spack/env/gcc/gcc -MM -I./../liblua  -I../libpcap -DHAVE_CONFIG_H -DNCAT_DATADIR="\"/home/wyf/share/spack/opt/spack/linux-centos7-cascadela
             ke/gcc-9.4.0/nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/share/ncat\"" -D_FORTIFY_SOURCE=2 -I. -I.. -I../nsock/include/ -I../nbase ncat_main.c ncat_connect.c ncat_cor
             e.c ncat_posix.c ncat_listen.c ncat_proxy.c ncat_ssl.c base64.c http.c util.c sys_wrap.c http_digest.c ncat_lua.c > makefile.dep
     1778    make[1]: Entering directory `/tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/nping'
     1779    /home/wyf/share/spack/lib/spack/env/gcc/g++ -MM -I../libdnet-stripped/include  -I../libpcap -I../nbase -I../nsock/include ArgParser.cc common.cc common_modified.cc n
             ping.cc NpingOps.cc utils.cc utils_net.cc output.cc stats.cc NpingTargets.cc NpingTarget.cc EchoHeader.cc EchoServer.cc EchoClient.cc ProbeMode.cc NEPContext.cc Cryp
             to.cc > makefile.dep
     1780    libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_cleanup':
  >> 1781    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:82: undefined reference to `ibv_dereg_mr'
  >> 1782    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:84: undefined reference to `ibv_destroy_qp'
  >> 1783    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:85: undefined reference to `ibv_destroy_cq'
  >> 1784    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:86: undefined reference to `ibv_dealloc_pd'
  >> 1785    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:87: undefined reference to `ibv_destroy_comp_channel
             '
  >> 1786    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:88: undefined reference to `ibv_close_device'
     1787    libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_read':
  >> 1788    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:125: undefined reference to `ibv_get_cq_event'
  >> 1789    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:134: undefined reference to `ibv_ack_cq_events'
  >> 1790    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:146: undefined reference to `ibv_wc_status_str'
     1791    libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_activate':
  >> 1792    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:198: undefined reference to `ibv_open_device'
  >> 1793    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:205: undefined reference to `ibv_alloc_pd'
  >> 1794    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:212: undefined reference to `ibv_create_comp_channel
             '
  >> 1795    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:219: undefined reference to `ibv_create_cq'
  >> 1796    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:234: undefined reference to `ibv_create_qp'
  >> 1797    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:244: undefined reference to `ibv_modify_qp'
  >> 1798    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:252: undefined reference to `ibv_modify_qp'
     1799    libpcap/libpcap.a(pcap-rdmasniff.o): In function `__ibv_reg_mr':
  >> 1800    /usr/include/infiniband/verbs.h:2532: undefined reference to `ibv_reg_mr'
     1801    libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_activate':
  >> 1802    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:322: undefined reference to `ibv_dereg_mr'
  >> 1803    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:330: undefined reference to `ibv_destroy_qp'
  >> 1804    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:334: undefined reference to `ibv_destroy_cq'
  >> 1805    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:338: undefined reference to `ibv_destroy_comp_channe
             l'
  >> 1806    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:342: undefined reference to `ibv_dealloc_pd'
  >> 1807    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:346: undefined reference to `ibv_close_device'
     1808    libpcap/libpcap.a(pcap-rdmasniff.o): In function `___ibv_query_port':
  >> 1809    /usr/include/infiniband/verbs.h:2356: undefined reference to `ibv_query_port'
     1810    libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_create':
  >> 1811    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:370: undefined reference to `ibv_get_device_list'
  >> 1812    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:405: undefined reference to `ibv_free_device_list'
     1813    libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_findalldevs':
  >> 1814    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:417: undefined reference to `ibv_get_device_list'
  >> 1815    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:434: undefined reference to `ibv_free_device_list'
  >> 1816    collect2: error: ld returned 1 exit status
  >> 1817    make: *** [nmap] Error 1
     1818    make: *** Waiting for unfinished jobs....
     1819    make[1]: Leaving directory `/tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/ncat'
     1820    make[1]: Entering directory `/tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/ncat'
     1821    Compiling liblua
     1822    /home/wyf/share/spack/lib/spack/env/gcc/gcc -I./../liblua  -I../libpcap -DHAVE_CONFIG_H -DNCAT_DATADIR="\"/home/wyf/share/spack/opt/spack/linux-centos7-cascadelake/g
             cc-9.4.0/nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/share/ncat\"" -D_FORTIFY_SOURCE=2 -I. -I.. -I../nsock/include/ -I../nbase -DLUA_USE_POSIX -DLUA_USE_DLOPEN -DHAVE
             _LUA=1 -I../liblua -g -O2 -Wall -c ncat_main.c -o ncat_main.o
     1823    /home/wyf/share/spack/lib/spack/env/gcc/gcc -I./../liblua  -I../libpcap -DHAVE_CONFIG_H -DNCAT_DATADIR="\"/home/wyf/share/spack/opt/spack/linux-centos7-cascadelake/g
             cc-9.4.0/nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/share/ncat\"" -D_FORTIFY_SOURCE=2 -I. -I.. -I../nsock/include/ -I../nbase -DLUA_USE_POSIX -DLUA_USE_DLOPEN -DHAVE
             _LUA=1 -I../liblua -g -O2 -Wall -c ncat_connect.c -o ncat_connect.o

     ...

     1899    ../libpcap/pcap/pcap.h:328:16: note: declared here
     1900      328 | PCAP_API char *pcap_lookupdev(char *)
     1901          |                ^~~~~~~~~~~~~~
     1902    /home/wyf/share/spack/lib/spack/env/gcc/g++ -c -I../libdnet-stripped/include  -I../libpcap -I../nbase -I../nsock/include -g -O2 -Wall  -fno-strict-aliasing   -DHAVE_
             CONFIG_H -DNPING_NAME=\"Nping\" -DNPING_URL=\"https://nmap.org/nping\" -DNPING_PLATFORM=\"x86_64-unknown-linux-gnu\" -D_FORTIFY_SOURCE=2 Crypto.cc -o Crypto.o
     1903    /home/wyf/share/spack/lib/spack/env/gcc/gcc -o ncat -g -O2 -Wall  -L../libpcap  ncat_main.o ncat_connect.o ncat_core.o ncat_posix.o ncat_listen.o ncat_proxy.o ncat_s
             sl.o base64.o http.o util.o sys_wrap.o http_digest.o ncat_lua.o ../nsock/src/libnsock.a ../nbase/libnbase.a -lssl -lcrypto -lpcap ./../liblua/liblua.a -lm -ldl
     1904    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_cleanup':
  >> 1905    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:82: undefined reference to `ibv_dereg_mr'
  >> 1906    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:84: undefined reference to `ibv_destroy_qp'
  >> 1907    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:85: undefined reference to `ibv_destroy_cq'
  >> 1908    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:86: undefined reference to `ibv_dealloc_pd'
  >> 1909    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:87: undefined reference to `ibv_destroy_comp_channel
             '
  >> 1910    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:88: undefined reference to `ibv_close_device'
     1911    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_read':
  >> 1912    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:125: undefined reference to `ibv_get_cq_event'
  >> 1913    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:134: undefined reference to `ibv_ack_cq_events'
>> 1914    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:146: undefined reference to `ibv_wc_status_[276/1276]
     1915    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_activate':
  >> 1916    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:198: undefined reference to `ibv_open_device'
  >> 1917    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:205: undefined reference to `ibv_alloc_pd'
  >> 1918    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:212: undefined reference to `ibv_create_comp_channel
             '
  >> 1919    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:219: undefined reference to `ibv_create_cq'
  >> 1920    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:234: undefined reference to `ibv_create_qp'
  >> 1921    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:244: undefined reference to `ibv_modify_qp'
  >> 1922    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:252: undefined reference to `ibv_modify_qp'
     1923    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `__ibv_reg_mr':
  >> 1924    /usr/include/infiniband/verbs.h:2532: undefined reference to `ibv_reg_mr'
     1925    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_activate':
  >> 1926    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:322: undefined reference to `ibv_dereg_mr'
  >> 1927    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:330: undefined reference to `ibv_destroy_qp'
  >> 1928    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:334: undefined reference to `ibv_destroy_cq'
  >> 1929    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:338: undefined reference to `ibv_destroy_comp_channe
             l'
  >> 1930    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:342: undefined reference to `ibv_dealloc_pd'
  >> 1931    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:346: undefined reference to `ibv_close_device'
     1932    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `___ibv_query_port':
  >> 1933    /usr/include/infiniband/verbs.h:2356: undefined reference to `ibv_query_port'
     1934    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_create':
  >> 1935    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:370: undefined reference to `ibv_get_device_list'
  >> 1936    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:405: undefined reference to `ibv_free_device_list'
     1937    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_findalldevs':
  >> 1938    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:417: undefined reference to `ibv_get_device_list'
  >> 1939    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:434: undefined reference to `ibv_free_device_list'
  >> 1940    collect2: error: ld returned 1 exit status
  >> 1941    make[1]: *** [ncat] Error 1
     1942    make[1]: Leaving directory `/tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/ncat'
  >> 1943    make: *** [build-ncat] Error 2
     1944    In file included from /usr/include/string.h:638,
     1945                     from ../nbase/nbase.h:136,
     1946                     from nping.h:69,
     1947                     from EchoHeader.h:68,
     1948                     from EchoHeader.cc:65:
     1949    In function 'char* strncpy(char*, const char*, size_t)',

     ...

     1952      120 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
     1953          |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     1954    Compiling nping
     1955    rm -f nping
     1956    /home/wyf/share/spack/lib/spack/env/gcc/g++ -L../libpcap    -o nping ArgParser.o common.o common_modified.o nping.o NpingOps.o utils.o utils_net.o output.o stats.o N
             pingTargets.o NpingTarget.o EchoHeader.o EchoServer.o EchoClient.o ProbeMode.o NEPContext.o Crypto.o ../nsock/src/libnsock.a ../nbase/libnbase.a ../libnetutil/libnet
             util.a -lssl -lcrypto ../libpcap/libpcap.a ../libdnet-stripped/src/.libs/libdnet.a -ldl
     1957    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_cleanup':
  >> 1958    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:82: undefined reference to `ibv_dereg_mr'
  >> 1959    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:84: undefined reference to `ibv_destroy_qp'
  >> 1960    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:85: undefined reference to `ibv_destroy_cq'
  >> 1961    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:86: undefined reference to `ibv_dealloc_pd'
  >> 1962    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:87: undefined reference to `ibv_destroy_comp_channel
             '
  >> 1963    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:88: undefined reference to `ibv_close_device'
     1964    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_read':
  >> 1965    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:125: undefined reference to `ibv_get_cq_event'
  >> 1966    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:134: undefined reference to `ibv_ack_cq_events'
  >> 1967    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:146: undefined reference to `ibv_wc_status_str'
     1968    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_activate':
  >> 1969    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:198: undefined reference to `ibv_open_device'
  >> 1970    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:205: undefined reference to `ibv_alloc_pd'
  >> 1971    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:212: undefined reference to `ibv_create_comp_channel
             '
  >> 1972    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:219: undefined reference to `ibv_create_cq'
  >> 1973    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:234: undefined reference to `ibv_create_qp'
  >> 1974    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:244: undefined reference to `ibv_modify_qp'
  >> 1975    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:252: undefined reference to `ibv_modify_qp'
     1976    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `__ibv_reg_mr':
  >> 1977    /usr/include/infiniband/verbs.h:2532: undefined reference to `ibv_reg_mr'
     1978    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_activate':
  >> 1979    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:322: undefined reference to `ibv_dereg_mr'
  >> 1980    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:330: undefined reference to `ibv_destroy_qp'
  >> 1981    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:334: undefined reference to `ibv_destroy_cq'
  >> 1982    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:338: undefined reference to `ibv_destroy_comp_channe
             l'
  >> 1983    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:342: undefined reference to `ibv_dealloc_pd'
  >> 1984    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:346: undefined reference to `ibv_close_device'
     1985    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `___ibv_query_port':
  >> 1986    /usr/include/infiniband/verbs.h:2356: undefined reference to `ibv_query_port'
     1987    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_create':
  >> 1988    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:370: undefined reference to `ibv_get_device_list'
  >> 1989    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:405: undefined reference to `ibv_free_device_list'
     1990    ../libpcap/libpcap.a(pcap-rdmasniff.o): In function `rdmasniff_findalldevs':
  >> 1991    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:417: undefined reference to `ibv_get_device_list'
  >> 1992    /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/libpcap/./pcap-rdmasniff.c:434: undefined reference to `ibv_free_device_list'
  >> 1993    collect2: error: ld returned 1 exit status
  >> 1994    make[2]: *** [nping] Error 1
     1995    make[2]: Leaving directory `/tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/nping'
  >> 1996    make[1]: *** [all] Error 2
     1997    make[1]: Leaving directory `/tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-src/nping'
  >> 1998    make: *** [build-nping] Error 2
See build log for details:
  /tmp/wyf/spack-stage/spack-stage-nmap-7.92-dl6mhtxf4syxjb6e7em3mbnl576skl56/spack-build-out.txt
```

This issue is related the libpcap in the nmap, ref: https://github.com/nmap/nmap/issues/2144
And add "--disable-rdma" in the configure arguments can fix this issue.