### PR TITLE
Add build-tools tag to git-lfs.

### DIFF
--- a/var/spack/repos/builtin/packages/git-lfs/package.py
+++ b/var/spack/repos/builtin/packages/git-lfs/package.py
@@ -18,6 +18,8 @@ class GitLfs(MakefilePackage):
     homepage = "https://git-lfs.github.com"
     url      = "https://github.com/git-lfs/git-lfs/archive/v2.6.1.tar.gz"
 
+    tags = ['build-tools']
+
     executables = ['^git-lfs$']
 
     maintainers = ['sethrj']


### PR DESCRIPTION
Let Spack find external git-lfs by default. 

There seemed to be agreement to add git-lfs to the build tools in https://github.com/spack/spack/pull/29031.