### PR TITLE
podio: new variant cxxstd=(17,20)

### DIFF
--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -81,7 +81,7 @@ class Podio(CMakePackage):
     variant(
         "cxxstd",
         default="17",
-        values=("17", conditional("20", when="@0.14:")),
+        values=("17", conditional("20", when="@0.15:")),
         multi=False,
         description="Use the specified C++ standard when building.",
     )
@@ -103,7 +103,6 @@ class Podio(CMakePackage):
     depends_on("catch2@3.0.1:", type=("test"), when="@0.13:")
 
     conflicts("+sio", when="@:0.12", msg="sio support requires at least podio@0.13")
-    conflicts("cxxstd=20", when="@:0.14.0", msg="c++20 support was added in 0.14.1")
 
     def cmake_args(self):
         args = [

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -78,13 +78,14 @@ class Podio(CMakePackage):
         deprecated=True,
     )
 
-    variant("cxxstd",
-            default="17",
-            values=("17", "20"),
-            multi=False,
-            description="Use the specified C++ standard when building.")
-    variant("sio", default=False,
-            description="Build the SIO I/O backend")
+    variant(
+        "cxxstd",
+        default="17",
+        values=("17", conditional("20", when="@0.14:")),
+        multi=False,
+        description="Use the specified C++ standard when building.",
+    )
+    variant("sio", default=False, description="Build the SIO I/O backend")
 
     # cpack config throws an error on some systems
     patch("cpack.patch", when="@:0.10.0")
@@ -107,8 +108,7 @@ class Podio(CMakePackage):
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_SIO", "sio"),
-            self.define("CMAKE_CXX_STANDARD",
-                        self.spec.variants["cxxstd"].value),
+            self.define("CMAKE_CXX_STANDARD", self.spec.variants["cxxstd"].value),
             self.define("BUILD_TESTING", self.run_tests),
         ]
         return args

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -78,14 +78,21 @@ class Podio(CMakePackage):
         deprecated=True,
     )
 
-    variant("sio", default=False, description="Build the SIO I/O backend")
+    variant("cxxstd",
+            default="17",
+            values=("17", "20"),
+            multi=False,
+            description="Use the specified C++ standard when building.")
+    variant("sio", default=False,
+            description="Build the SIO I/O backend")
 
     # cpack config throws an error on some systems
     patch("cpack.patch", when="@:0.10.0")
     patch("dictloading.patch", when="@0.10.0")
     patch("python-tests.patch", when="@:0.14.0")
 
-    depends_on("root@6.08.06: cxxstd=17")
+    depends_on("root@6.08.06: cxxstd=17", when="cxxstd=17")
+    depends_on("root@6.25.02: cxxstd=20", when="cxxstd=20")
 
     depends_on("cmake@3.8:", type="build")
     depends_on("python", type=("build", "run"))
@@ -99,6 +106,8 @@ class Podio(CMakePackage):
     def cmake_args(self):
         args = [
             self.define_from_variant("ENABLE_SIO", "sio"),
+            self.define("CMAKE_CXX_STANDARD",
+                        self.spec.variants["cxxstd"].value),
             self.define("BUILD_TESTING", self.run_tests),
         ]
         return args

--- a/var/spack/repos/builtin/packages/podio/package.py
+++ b/var/spack/repos/builtin/packages/podio/package.py
@@ -102,6 +102,7 @@ class Podio(CMakePackage):
     depends_on("catch2@3.0.1:", type=("test"), when="@0.13:")
 
     conflicts("+sio", when="@:0.12", msg="sio support requires at least podio@0.13")
+    conflicts("cxxstd=20", when="@:0.14.0", msg="c++20 support was added in 0.14.1")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
This adds the variant cxxstd to podio, with support for 17 and 20, per the CMakeLists, with a conflict on cxxstd=20 for @:0.14.0. This depends_on root with corresponding cxxstd for versions that support it.

Maintainers: @drbenmorgan @vvolkl 

Discussion: Another option would be to use the cxxstd from root, but since the podio CMakeLists allows for independent specification of the cxxstd, it makes sense to allow spack users to specify this independently as well.