### PR TITLE
curl: tls=mbedtls requires fPIC

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -95,8 +95,8 @@ class Curl(AutotoolsPackage):
     conflicts('platform=linux', when='tls=secure_transport', msg='Only supported on macOS')
 
     depends_on('gnutls', when='tls=gnutls')
-    depends_on('mbedtls@3:', when='@7.79: tls=mbedtls')
-    depends_on('mbedtls@:2', when='@:7.78 tls=mbedtls')
+    depends_on('mbedtls@3: +pic', when='@7.79: tls=mbedtls')
+    depends_on('mbedtls@:2 +pic', when='@:7.78 tls=mbedtls')
     depends_on('nss', when='tls=nss')
     depends_on('openssl', when='tls=openssl')
     depends_on('libidn2', when='+libidn2')


### PR DESCRIPTION
`curl tls=mbedtls` doesn't build currently due to mbedtls' default lack of PIC.

```bash
==> Installing curl-7.82.0-v7wqf6fjgzqs3amer6kx5eynnpz6okav
==> No binary for curl-7.82.0-v7wqf6fjgzqs3amer6kx5eynnpz6okav found: installing from source
==> Using cached archive: /home/bc/spack/var/spack/cache/_source-cache/archive/46/46d9a0400a33408fd992770b04a44a7434b3036f2e8089ac28b57573d59d371f.tar.bz2
==> No patches needed for curl
==> curl: Executing phase: 'autoreconf'
==> curl: Executing phase: 'configure'
==> curl: Executing phase: 'build'
==> Error: ProcessError: Command exited with status 2:
    'make' '-j4' 'V=1'

4 errors found in build log:
     1350    /usr/bin/ld: /home/bc/spack/opt/spack/linux-ubuntu20.04-haswell/clang-11.0.0/mbedtls-3.1.0-tagq3rafw7je42rqirrgedtzhpvhzb2b/lib/libmbedcrypto.a(chacha20.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used whe
             n making a shared object; recompile with -fPIC
     1351    /usr/bin/ld: /home/bc/spack/opt/spack/linux-ubuntu20.04-haswell/clang-11.0.0/mbedtls-3.1.0-tagq3rafw7je42rqirrgedtzhpvhzb2b/lib/libmbedcrypto.a(chachapoly.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used w
             hen making a shared object; recompile with -fPIC
     1352    /usr/bin/ld: /home/bc/spack/opt/spack/linux-ubuntu20.04-haswell/clang-11.0.0/mbedtls-3.1.0-tagq3rafw7je42rqirrgedtzhpvhzb2b/lib/libmbedcrypto.a(ecdsa.o): relocation R_X86_64_32S against symbol `mbedtls_hmac_drbg_random' can 
             not be used when making a shared object; recompile with -fPIC
     1353    /usr/bin/ld: /home/bc/spack/opt/spack/linux-ubuntu20.04-haswell/clang-11.0.0/mbedtls-3.1.0-tagq3rafw7je42rqirrgedtzhpvhzb2b/lib/libmbedcrypto.a(hmac_drbg.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used wh
             en making a shared object; recompile with -fPIC
     1354    /usr/bin/ld: /home/bc/spack/opt/spack/linux-ubuntu20.04-haswell/clang-11.0.0/mbedtls-3.1.0-tagq3rafw7je42rqirrgedtzhpvhzb2b/lib/libmbedcrypto.a(pkcs5.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when m
             aking a shared object; recompile with -fPIC
     1355    /usr/bin/ld: /home/bc/spack/opt/spack/linux-ubuntu20.04-haswell/clang-11.0.0/mbedtls-3.1.0-tagq3rafw7je42rqirrgedtzhpvhzb2b/lib/libmbedcrypto.a(poly1305.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used whe
             n making a shared object; recompile with -fPIC
  >> 1356    clang: error: linker command failed with exit code 1 (use -v to see invocation)
  >> 1357    make[2]: *** [Makefile:1532: libcurl.la] Error 1
     1358    make[2]: Leaving directory '/tmp/bc/spack-stage/spack-stage-curl-7.82.0-v7wqf6fjgzqs3amer6kx5eynnpz6okav/spack-src/lib'
  >> 1359    make[1]: *** [Makefile:1339: all] Error 2
     1360    make[1]: Leaving directory '/tmp/bc/spack-stage/spack-stage-curl-7.82.0-v7wqf6fjgzqs3amer6kx5eynnpz6okav/spack-src/lib'
  >> 1361    make: *** [Makefile:1220: all-recursive] Error 1
```