### PR TITLE
fix for `spack stage` command not extracting packages in custom paths

### DIFF
--- a/lib/spack/spack/cmd/stage.py
+++ b/lib/spack/spack/cmd/stage.py
@@ -27,12 +27,6 @@ def setup_parser(subparser):
 
 
 def stage(parser, args):
-    # We temporarily modify the working directory when setting up a stage, so we need to
-    # convert this to an absolute path here in order for it to remain valid later.
-    custom_path = os.path.abspath(args.path) if args.path else None
-    if custom_path:
-        spack.stage.create_stage_root(custom_path)
-
     if not args.specs:
         env = ev.active_environment()
         if env:
@@ -53,6 +47,10 @@ def stage(parser, args):
         spack.config.set('config:deprecated', True, scope='command_line')
 
     specs = spack.cmd.parse_specs(args.specs, concretize=False)
+
+    # We temporarily modify the working directory when setting up a stage, so we need to
+    # convert this to an absolute path here in order for it to remain valid later.
+    custom_path = os.path.abspath(args.path) if args.path else None
 
     # prevent multiple specs from extracting in the same folder
     if len(specs) > 1 and custom_path:

--- a/lib/spack/spack/test/cmd/stage.py
+++ b/lib/spack/spack/test/cmd/stage.py
@@ -41,7 +41,6 @@ def check_stage_path(monkeypatch, tmpdir):
 
     def fake_stage(pkg, mirror_only=False):
         assert pkg.path == expected_path
-        assert os.path.isdir(expected_path), expected_path
 
     monkeypatch.setattr(spack.package.PackageBase, 'do_stage', fake_stage)
 


### PR DESCRIPTION
Using `spack stage -p`, i.e. specifying a custom path, the stage directory gets created but the package is not extracted.

Apparently, the problem is that the stage directory was getting created "manually" by the command, which alters the logic of the `do_stage()` command and the extraction itself.

I went for the more straightforward solution as far as I can understand, but I'm looking forward to feedbacks from more experienced and knowledged spack community members. Thanks in advance!