### PR TITLE
keepassxc: adding version 2.7.1

### DIFF
--- a/var/spack/repos/builtin/packages/keepassxc/package.py
+++ b/var/spack/repos/builtin/packages/keepassxc/package.py
@@ -16,6 +16,7 @@ class Keepassxc(CMakePackage):
     maintainers = ['cessenat']
 
     version('master', branch='master')
+    version('2.7.1', sha256='6001ba626c35c316dbda6de35736f012a2264f95139fcb4a094b8eb49b15d3e7')
     version('2.7.0', sha256='83be76890904cd6703343fa097d68bcfdd99bb525cf518fa62a7df9293026aa7')
     version('2.6.6', sha256='3603b11ac39b289c47fac77fa150e05fd64b393d8cfdf5732dc3ef106650a4e2')
     version('2.6.4', sha256='e536e2a71c90fcf264eb831fb1a8b518ee1b03829828f862eeea748d3310f82b')


### PR DESCRIPTION
Mainly a bugs fix version, see
https://github.com/keepassxreboot/keepassxc/releases/tag/2.7.1
