### PR TITLE
swiftsim: do not build with `-Werror`

### DIFF
--- a/var/spack/repos/builtin/packages/swiftsim/package.py
+++ b/var/spack/repos/builtin/packages/swiftsim/package.py
@@ -47,5 +47,6 @@ class Swiftsim(AutotoolsPackage):
             '--enable-mpi' if '+mpi' in self.spec else '--disable-mpi',
             '--with-metis={0}'.format(self.spec['metis'].prefix),
             '--disable-dependency-tracking',
-            '--enable-optimization'
+            '--enable-optimization',
+            '--enable-compiler-warnings=yes',
         ]


### PR DESCRIPTION
swiftsim builds with `-Werror` by default and when using new compilers there are some new warnings being issued, which conveniently cause the build to fail.  I believe at least some of the warnings have been already fixed in development version of the package, but last release is from over one year ago.