### PR TITLE
Add mimalloc package with use in HPX and pika

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -45,7 +45,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         'malloc', default='tcmalloc',
         description='Define which allocator will be linked in',
-        values=('system', 'tcmalloc', 'jemalloc', 'tbbmalloc')
+        values=('system', 'jemalloc', 'mimalloc', 'tbbmalloc', 'tcmalloc')
     )
 
     variant('max_cpu_count', default='64',
@@ -100,6 +100,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('gperftools', when='malloc=tcmalloc')
     depends_on('jemalloc', when='malloc=jemalloc')
+    depends_on('mimalloc@1', when='malloc=mimalloc')
     depends_on('tbb', when='malloc=tbbmalloc')
 
     depends_on('mpi', when='networking=mpi')

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -15,12 +15,13 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://hpx.stellar-group.org/"
     url = "https://github.com/STEllAR-GROUP/hpx/archive/1.2.1.tar.gz"
+    git = "https://github.com/STEllAR-GROUP/hpx.git"
     maintainers = ['msimberg', 'albestro', 'teonnik']
 
     tags = ['e4s']
 
-    version('master', git='https://github.com/STEllAR-GROUP/hpx.git', branch='master')
-    version('stable', git='https://github.com/STEllAR-GROUP/hpx.git', tag='stable')
+    version('master', branch='master')
+    version('stable', tag='stable')
     version('1.7.1', sha256='008a0335def3c551cba31452eda035d7e914e3e4f77eec679eea070ac71bd83b')
     version('1.7.0', sha256='05099b860410aa5d8a10d6915b1a8818733aa1aa2d5f2b9774730ca7e6de5fac')
     version('1.6.0', sha256='4ab715613c1e1808edc93451781cc9bc98feec4e422ccd4322858a680f6d9017')

--- a/var/spack/repos/builtin/packages/mimalloc/package.py
+++ b/var/spack/repos/builtin/packages/mimalloc/package.py
@@ -1,0 +1,22 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Mimalloc(CMakePackage):
+    """mimalloc is a compact general purpose allocator with excellent performance."""
+
+    homepage = "https://microsoft.github.io/mimalloc"
+    url = "https://github.com/microsoft/mimalloc/archive/v0.0.0.tar.gz"
+    maintainers = ['msimberg']
+
+    version('dev-slice', git='https://github.com/microsoft/mimalloc.git', branch='dev-slice')
+    version('dev', git='https://github.com/microsoft/mimalloc.git', branch='dev')
+    version('master', git='https://github.com/microsoft/mimalloc.git', branch='master')
+    version('2.0.6', sha256='9f05c94cc2b017ed13698834ac2a3567b6339a8bde27640df5a1581d49d05ce5')
+    version('1.7.6', sha256='d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da')
+
+    depends_on('cmake@3.0:', type='build')

--- a/var/spack/repos/builtin/packages/mimalloc/package.py
+++ b/var/spack/repos/builtin/packages/mimalloc/package.py
@@ -11,11 +11,12 @@ class Mimalloc(CMakePackage):
 
     homepage = "https://microsoft.github.io/mimalloc"
     url = "https://github.com/microsoft/mimalloc/archive/v0.0.0.tar.gz"
+    git = "https://github.com/microsoft/mimalloc.git"
     maintainers = ['msimberg']
 
-    version('dev-slice', git='https://github.com/microsoft/mimalloc.git', branch='dev-slice')
-    version('dev', git='https://github.com/microsoft/mimalloc.git', branch='dev')
-    version('master', git='https://github.com/microsoft/mimalloc.git', branch='master')
+    version('dev-slice', branch='dev-slice')
+    version('dev', branch='dev')
+    version('master', branch='master')
     version('2.0.6', sha256='9f05c94cc2b017ed13698834ac2a3567b6339a8bde27640df5a1581d49d05ce5')
     version('1.7.6', sha256='d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da')
 

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -14,12 +14,13 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     homepage = "https://github.com/pika-org/pika/"
     url = "https://github.com/pika-org/pika/archive/0.0.0.tar.gz"
+    git = "https://github.com/pika-org/pika.git"
     maintainers = ['msimberg', 'albestro', 'teonnik', 'aurianer']
 
     version('0.3.0', sha256='bbb89f9824c58154ed59e2e14276c0ad132fd7b90b2be64ddd0e284f3b57cc0f')
     version('0.2.0', sha256='712bb519f22bdc9d5ee4ac374d251a54a0af4c9e4e7f62760b8ab9a177613d12')
     version('0.1.0', sha256='aa0ae2396cd264d821a73c4c7ecb118729bb3de042920c9248909d33755e7327')
-    version('main', git='https://github.com/pika-org/pika.git', branch='main')
+    version('main', branch='main')
 
     generator = 'Ninja'
 

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -33,7 +33,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         'malloc', default='tcmalloc',
         description='Define which allocator will be linked in',
-        values=('system', 'tcmalloc', 'jemalloc', 'tbbmalloc')
+        values=('system', 'jemalloc', 'mimalloc', 'tbbmalloc', 'tcmalloc')
     )
 
     default_generic_coroutines = True
@@ -65,6 +65,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('gperftools', when='malloc=tcmalloc')
     depends_on('jemalloc', when='malloc=jemalloc')
+    depends_on('mimalloc@1', when='malloc=mimalloc')
     depends_on('tbb', when='malloc=tbbmalloc')
 
     depends_on('mpi', when='+mpi')


### PR DESCRIPTION
Adds a package for https://github.com/microsoft/mimalloc. I've added the two latest version of 1.X and 2.X, plus the three branches listed here: https://github.com/microsoft/mimalloc#branches.

I've also added `mimalloc` as an optional dependency to `pika` and `hpx` since they both support using `mimalloc`.

@daanx I'm pinging you mainly just to let you know that this exists (since you seem to be the most active `mimalloc` developer), but I'm not expecting any input or work from you. If you'd like to be listed as a maintainer I would obviously happily add you.

I haven't added any variants since I've never tweaked those myself and don't know which ones would be useful. I'll happily add variants on request.