### PR TITLE
boost@1.78: fix %oneapi build

### DIFF
--- a/var/spack/repos/builtin/packages/boost/1.78-intel-linux-jam.patch
+++ b/var/spack/repos/builtin/packages/boost/1.78-intel-linux-jam.patch
@@ -1,0 +1,11 @@
+--- a/tools/build/src/tools/intel-linux.jam	2021-12-01 22:47:38.000000000 -0800
++++ b/tools/build/src/tools/intel-linux.jam	2022-05-03 13:40:41.569430070 -0700
+@@ -276,7 +276,7 @@
+ #
+ actions compile.c++.pch
+ {
+-    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -pch-create "$(<)" "$(>)"
++    rm -f "$(<)" && LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -Xclang -emit-pch -o "$(<)" "$(>)"
+ }
+ 
+ actions compile.fortran

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -344,6 +344,9 @@ class Boost(Package):
     # See https://github.com/spack/spack/issues/28273
     patch("pthread-stack-min-fix.patch", when="@1.69.0:1.72.0")
 
+    # https://www.intel.com/content/www/us/en/developer/articles/technical/building-boost-with-oneapi.html
+    patch("1.78-intel-linux-jam.patch", when="@1.78 %oneapi")
+
     def patch(self):
         # Disable SSSE3 and AVX2 when using the NVIDIA compiler
         if self.spec.satisfies('%nvhpc'):
@@ -356,6 +359,10 @@ class Boost(Package):
 
             filter_file('-fast', '-O1', 'tools/build/src/tools/pgi.jam')
             filter_file('-fast', '-O1', 'tools/build/src/engine/build.sh')
+
+        # Fixes https://github.com/spack/spack/issues/29352
+        if self.spec.satisfies('@1.78 %intel') or self.spec.satisfies('@1.78 %oneapi'):
+            filter_file('-static', '', 'tools/build/src/engine/build.sh')
 
     def url_for_version(self, version):
         if version >= Version('1.63.0'):


### PR DESCRIPTION
Implements the patch described by Intel in their official guide for building `boost@1.78 %oneapi`
https://www.intel.com/content/www/us/en/developer/articles/technical/building-boost-with-oneapi.html

Fixes  https://github.com/spack/spack/issues/29352
(Also described in Problem 1: https://github.com/boostorg/build/issues/739)

@wspear @hainest @pbrady