### PR TITLE
py-shapely: add v1.8.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -18,6 +18,7 @@ class PyShapely(PythonPackage):
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('1.8.2', sha256='572af9d5006fd5e3213e37ee548912b0341fb26724d6dc8a4e3950c10197ebb6')
     version('1.8.1', sha256='0956a3aced40c31a957a52aa1935467334926844a6776b469acb0760a5e6aba8')
     version('1.8.0', sha256='f5307ee14ba4199f8bbcf6532ca33064661c1433960c432c84f0daa73b47ef9c')
     version('1.7.1', sha256='1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129')


### PR DESCRIPTION
https://github.com/shapely/shapely/releases/tag/1.8.2