### PR TITLE
UPC++: minor packaging improvements

### DIFF
--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+import re
 
 from spack import *
 
@@ -213,3 +214,36 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
                       installed=True,
                       purpose='Checking UPC++ compile+link ' +
                               'for all installed backends')
+
+    # `spack external find` support
+    executables = ['^upcxx$']
+
+    @classmethod
+    def determine_version(cls, exe):
+        """Return either the version of the executable passed as argument
+           or ``None`` if the version cannot be determined.
+           exe (str): absolute path to the executable being examined
+        """
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r"UPC\+\+ version\s+(\S+)\s+(?:upcxx-(\S+))?", output)
+        if match is None:
+            return None
+        elif match.group(2):  # Git snapshot
+            return match.group(2)
+        else:  # official release
+            return match.group(1)
+
+    @classmethod
+    def determine_variants(cls, exes, version_str):
+        meta = exes[0] + "-meta"  # find upcxx-meta
+        output = Executable(meta)('CPPFLAGS', output=str, error=str)
+        variants = ""
+        if re.search(r"-DUPCXXI_CUDA_ENABLED=1", output):
+            variants += "+cuda"
+        else:
+            variants += "~cuda"
+        if re.search(r"-DUPCXXI_HIP_ENABLED=1", output):
+            variants += "+rocm"
+        else:
+            variants += "~rocm"
+        return variants

--- a/var/spack/repos/builtin/packages/upcxx/package.py
+++ b/var/spack/repos/builtin/packages/upcxx/package.py
@@ -94,6 +94,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
             env.set('UPCXX_NETWORK', 'aries')
         elif is_CrayEX():
             env.set('UPCXX_NETWORK', 'ofi')
+            env.set('GASNET_SPAWN_CONTROL', 'pmi')
 
     def setup_run_environment(self, env):
         self.set_variables(env)
@@ -159,6 +160,7 @@ class Upcxx(Package, CudaPackage, ROCmPackage):
             options.append('--with-pmi-runcmd=\'srun -n %N -- %C\'')
             options.append('--disable-ibv')
             options.append('--enable-ofi')
+            options.append('--with-default-network=ofi')
             options.append('--with-ofi-provider=' + provider)
             env['GASNET_CONFIGURE_ARGS'] = \
                 '--with-ofi-spawner=pmi ' + env['GASNET_CONFIGURE_ARGS']


### PR DESCRIPTION
This PR adds `spack external find` support for the upcxx package and polishes a few rough edges on the new Cray Shasta support.