### PR TITLE
arborx: inherit from CudaPackage, ROCmPackage

### DIFF
--- a/var/spack/repos/builtin/packages/arborx/package.py
+++ b/var/spack/repos/builtin/packages/arborx/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Arborx(CMakePackage):
+class Arborx(CMakePackage, CudaPackage, ROCmPackage):
     """ArborX is a performance-portable library for geometric search"""
 
     homepage = "https://github.com/arborx/arborx"
@@ -28,9 +28,7 @@ class Arborx(CMakePackage):
     # does not provide them.
     kokkos_backends = {
         'serial': (True,  "enable Serial backend (default)"),
-        'cuda': (False,  "enable Cuda backend"),
         'openmp': (False,  "enable OpenMP backend"),
-        'rocm': (False,  "enable HIP backend"),
         'sycl': (False, "enable SYCL backend")
     }
 
@@ -51,6 +49,15 @@ class Arborx(CMakePackage):
     for backend in kokkos_backends:
         depends_on('kokkos+%s' % backend.lower(), when='~trilinos+%s' %
                    backend.lower())
+
+    for arch in CudaPackage.cuda_arch_values:
+        cuda_dep = "+cuda cuda_arch={0}".format(arch)
+        depends_on("kokkos {0}".format(cuda_dep), when=cuda_dep)
+
+    for arch in ROCmPackage.amdgpu_targets:
+        rocm_dep = "+rocm amdgpu_target={0}".format(arch)
+        depends_on("kokkos {0}".format(rocm_dep), when=rocm_dep)
+
     depends_on('kokkos+cuda_lambda', when='~trilinos+cuda')
 
     # Trilinos/Kokkos


### PR DESCRIPTION
Inherit from `CudaPackage` and `ROCmPackage` base classes.

Relay `cuda_arch` and `amdgpu_target` to `kokkos` where appropriate.

Does it make sense to do this for `arborx` ?
* https://spack.readthedocs.io/en/latest/build_systems/rocmpackage.html
* https://spack.readthedocs.io/en/latest/build_systems/cudapackage.html

@aprokop @masterleinad @alalazo 