### PR TITLE
Add support for alternate boost-context backends

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -156,6 +156,13 @@ class Boost(Package):
             libraries, root=self.prefix, shared=shared, recursive=True
         )
 
+    variant('context-impl',
+            default='fcontext',
+            values=('fcontext','ucontext','winfib'),
+            multi=False,
+            description='Use the specified backend for boost-context',
+            when='+context')
+
     variant('cxxstd',
             default='98',
             values=(
@@ -480,6 +487,11 @@ class Boost(Package):
         if not threading_opts:
             raise RuntimeError("At least one of {singlethreaded, " +
                                "multithreaded} must be enabled")
+
+        # If we are building context using a non-fcontext backend, we need to tell b2
+        context_impl = spec.variants['context-impl'].value
+        if '+context' in spec and context_impl in {'ucontext', 'winfib'}:
+            options.extend(['context-impl=%s' % context_impl])
 
         if '+taggedlayout' in spec:
             layout = 'tagged'

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -488,10 +488,9 @@ class Boost(Package):
             raise RuntimeError("At least one of {singlethreaded, " +
                                "multithreaded} must be enabled")
 
-        # If we are building context using a non-fcontext backend, we need to tell b2
-        context_impl = spec.variants['context-impl'].value
-        if '+context' in spec and context_impl in {'ucontext', 'winfib'}:
-            options.extend(['context-impl=%s' % context_impl])
+        # If we are building context, tell b2 which backend to use
+        if '+context' in spec:
+            options.extend(['context-impl=%s' % spec.variants['context-impl'].value])
 
         if '+taggedlayout' in spec:
             layout = 'tagged'
@@ -683,6 +682,7 @@ class Boost(Package):
     def setup_dependent_build_environment(self, env, dependent_spec):
         if '+context' in self.spec:
             context_impl = self.spec.variants['context-impl'].value
+            # fcontext, as the default, has no corresponding macro
             if context_impl == 'ucontext':
                 env.append_flags('CXXFLAGS', '-DBOOST_USE_UCONTEXT')
             elif context_impl == 'winfib':

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -158,7 +158,7 @@ class Boost(Package):
 
     variant('context-impl',
             default='fcontext',
-            values=('fcontext','ucontext','winfib'),
+            values=('fcontext', 'ucontext', 'winfib'),
             multi=False,
             description='Use the specified backend for boost-context',
             when='+context')
@@ -679,3 +679,11 @@ class Boost(Package):
                 return ['-DBoost_NO_BOOST_CMAKE=ON'] + args_fn(self)
 
             type(dependent_spec.package).cmake_args = _cmake_args
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        if '+context' in self.spec:
+            context_impl = self.spec.variants['context-impl'].value
+            if context_impl == 'ucontext':
+                env.append_flags('CXXFLAGS', '-DBOOST_USE_UCONTEXT')
+            elif context_impl == 'winfib':
+                env.append_flags('CXXFLAGS', '-DBOOST_USE_WINFIB')


### PR DESCRIPTION
The fcontext backend is the default high-performance backend.
The ucontext backend is needed when using Boost context in conjunction with ASAN.
The WinFibers backend...also exists.

cf. https://www.boost.org/doc/libs/1_79_0/libs/context/doc/html/context/cc/implementations__fcontext_t__ucontext_t_and_winfiber.html