### PR TITLE
fix improper type for InvalidDependencyError argument

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1749,7 +1749,7 @@ class SpackSolverSetup(object):
 
         # Fail if we already know an unreachable node is requested
         for spec in specs:
-            missing_deps = [d for d in spec.traverse()
+            missing_deps = [str(d) for d in spec.traverse()
                             if d.name not in possible and not d.virtual]
             if missing_deps:
                 raise spack.spec.InvalidDependencyError(spec.name, missing_deps)

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -1546,8 +1546,10 @@ env:
 def test_stack_concretize_extraneous_deps(tmpdir, config, mock_packages):
     # FIXME: The new concretizer doesn't handle yet soft
     # FIXME: constraints for stacks
-    if spack.config.get('config:concretizer') == 'clingo':
-        pytest.skip('Clingo concretizer does not support soft constraints')
+    # FIXME: This now works for statically-determinable invalid deps
+    # FIXME: But it still does not work for dynamically determined invalid deps
+    # if spack.config.get('config:concretizer') == 'clingo':
+    #    pytest.skip('Clingo concretizer does not support soft constraints')
 
     filename = str(tmpdir.join('spack.yaml'))
     with open(filename, 'w') as f:


### PR DESCRIPTION
Fixes #30499 

With this PR, invalid matrix dependencies can be ignored by the clingo concretizer *iff* the dependency can be statically determined to be invalid. Partial improvement over previous behavior, and avoids the type error previously given.

Comment in test updated and test allowed to run for clingo.