### PR TITLE
updated stat build dep requirements

### DIFF
--- a/var/spack/repos/builtin/packages/stat/package.py
+++ b/var/spack/repos/builtin/packages/stat/package.py
@@ -44,9 +44,9 @@ class Stat(AutotoolsPackage):
     variant('gui', default=True, description="enable GUI")
 
     depends_on('autoconf', type='build')
-    depends_on('automake', type='build')
+    depends_on('automake@:1.15', type='build')
     depends_on('libtool', type='build')
-    depends_on('dyninst', when='~dysect')
+    depends_on('dyninst@:11.9', when='~dysect')
     depends_on('dyninst@:9', when='@:4.0.1')
     depends_on('dyninst@8.2.1+stat_dysect', when='+dysect')
     # we depend on fgfs@master to avoid seg faults with fgfs 1.1


### PR DESCRIPTION
Fixes https://github.com/LLNL/STAT/issues/42

STAT hasn't been ported to newer versions of DynInst yet. There is also an issue with automake-1.16 that causes the PYTHON_PREFIX macro to not get expanded at configure time.