### PR TITLE
A spack update broke the build of openspeedshop. The import of the os…

### DIFF
--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -3,11 +3,11 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import spack
 import spack.store
 from spack import *
 from spack.pkg.builtin.boost import Boost
-import os
 
 
 class OpenspeedshopUtils(CMakePackage):

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -7,6 +7,7 @@ import spack
 import spack.store
 from spack import *
 from spack.pkg.builtin.boost import Boost
+import os
 
 
 class OpenspeedshopUtils(CMakePackage):

--- a/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop-utils/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 import spack
 import spack.store
 from spack import *

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -3,10 +3,10 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
 import spack.store
 from spack import *
 from spack.pkg.builtin.boost import Boost
-from os
 
 
 class Openspeedshop(CMakePackage):

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 import spack.store
 from spack import *
 from spack.pkg.builtin.boost import Boost

--- a/var/spack/repos/builtin/packages/openspeedshop/package.py
+++ b/var/spack/repos/builtin/packages/openspeedshop/package.py
@@ -6,6 +6,7 @@
 import spack.store
 from spack import *
 from spack.pkg.builtin.boost import Boost
+from os
 
 
 class Openspeedshop(CMakePackage):


### PR DESCRIPTION
A spack update broke the build of openspeedshop. The import of the os python module was removed.  openspeedshop fails to build w/o it.