### PR TITLE
flux-sched: add fix for signedness compare issue on gcc@9.40

### DIFF
--- a/var/spack/repos/builtin/packages/flux-sched/jobid-sign-compare-fix.patch
+++ b/var/spack/repos/builtin/packages/flux-sched/jobid-sign-compare-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/resource/hlapi/bindings/c++/reapi_cli_impl.hpp b/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+index 0b01b341..e0a91458 100644
+--- a/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
++++ b/resource/hlapi/bindings/c++/reapi_cli_impl.hpp
+@@ -594,7 +594,7 @@ int resource_query_t::remove_job (const uint64_t jobid)
+ {
+     int rc = -1;
+ 
+-    if (jobid > std::numeric_limits<int64_t>::max ()) {
++    if (jobid > (uint64_t) std::numeric_limits<int64_t>::max ()) {
+         errno = EOVERFLOW;
+         return rc;
+     }

--- a/var/spack/repos/builtin/packages/flux-sched/package.py
+++ b/var/spack/repos/builtin/packages/flux-sched/package.py
@@ -75,6 +75,7 @@ class FluxSched(AutotoolsPackage):
     # Disable t5000-valgrind.t by default due to false positives not yet
     # in the suppressions file. (This patch will be in v0.21.0)
     patch('no-valgrind.patch', when='@:0.20.0')
+    patch('jobid-sign-compare-fix.patch', when='@:0.22.0')
 
     def url_for_version(self, version):
         '''


### PR DESCRIPTION
Problem: GCC 9.4.0 catches a bad integer comparison in
resource/hlapi/bindings/c++/reapi_cli_impl.hpp.

Add a patch to work around the problem until an upstream fix is
available.

Fixes #30480