### PR TITLE
vim: add +gtk variant to pair with +gui

### DIFF
--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -42,13 +42,11 @@ class Vim(AutotoolsPackage):
     variant('python', default=False, description="build with Python")
     variant('ruby', default=False, description="build with Ruby")
     variant('x', default=False, description="use the X Window System")
-    variant('gtk3', default=False, description="use the GTKv3 gui.")
+    variant('gtk', default=False, when='+gui', description="use the GTKv3 gui.")
 
     for _f in _features[1:]:
         conflicts('+gui', when='features=' + _f,
                   msg='+gui requires features=huge')
-
-    conflicts('+gtk3', when='~gui', msg='+gtk3 requires +gui')
 
     depends_on('findutils', type='build')
     depends_on('ncurses', when='@7.4:')
@@ -64,7 +62,7 @@ class Vim(AutotoolsPackage):
     depends_on('libxpm', when="+x")
     depends_on('libxt', when="+x")
     depends_on('libxtst', when="+x")
-    depends_on('gtkplus@3:', when="+gtk3")
+    depends_on('gtkplus@3:', when="+gtk")
 
     provides('xxd')
 
@@ -93,7 +91,7 @@ class Vim(AutotoolsPackage):
             args.append("--enable-python3interp=no")
 
         if '+gui' in spec:
-            args.append("--enable-gui={}".format('gtk3' if '+gtk3' in spec else 'auto'))
+            args.append("--enable-gui={}".format('gtk3' if '+gtk' in spec else 'auto'))
         else:
             args.append("--enable-gui=no")
 

--- a/var/spack/repos/builtin/packages/vim/package.py
+++ b/var/spack/repos/builtin/packages/vim/package.py
@@ -42,10 +42,13 @@ class Vim(AutotoolsPackage):
     variant('python', default=False, description="build with Python")
     variant('ruby', default=False, description="build with Ruby")
     variant('x', default=False, description="use the X Window System")
+    variant('gtk3', default=False, description="use the GTKv3 gui.")
 
     for _f in _features[1:]:
         conflicts('+gui', when='features=' + _f,
                   msg='+gui requires features=huge')
+
+    conflicts('+gtk3', when='~gui', msg='+gtk3 requires +gui')
 
     depends_on('findutils', type='build')
     depends_on('ncurses', when='@7.4:')
@@ -61,6 +64,7 @@ class Vim(AutotoolsPackage):
     depends_on('libxpm', when="+x")
     depends_on('libxt', when="+x")
     depends_on('libxtst', when="+x")
+    depends_on('gtkplus@3:', when="+gtk3")
 
     provides('xxd')
 
@@ -88,8 +92,12 @@ class Vim(AutotoolsPackage):
         else:
             args.append("--enable-python3interp=no")
 
+        if '+gui' in spec:
+            args.append("--enable-gui={}".format('gtk3' if '+gtk3' in spec else 'auto'))
+        else:
+            args.append("--enable-gui=no")
+
         args.extend([
-            "--enable-gui=" + ('auto' if '+gui' in spec else 'no'),
             "--enable-luainterp=" + yes_or_no('lua'),
             "--enable-perlinterp=" + yes_or_no('perl'),
             "--enable-rubyinterp=" + yes_or_no('ruby'),


### PR DESCRIPTION
`vim+gui` does not produce a `<vim install>/bin/gvim` link on my CentOS 7 machine. I suspect that `--enable-gui=auto` assumes that some specific system libraries exist and those libraries are not present on my machine. Adding an explicit `gtkplus v3+` dependency and setting `--enable-gui=gtk3` was enough to make the `gvim` link consistently appear.