### PR TITLE
Build hdf on Ubuntu 20.04 aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -68,7 +68,7 @@ class Hdf(AutotoolsPackage):
     # TODO: '@:4.2.14 ~external-xdr' and the fact that we compile for 64 bit
     #  architecture should be in conflict
 
-    #https://github.com/knedlsepp/nixpkgs/commit/c1a2918c849a5bc766c6d55d96bc6cf85c9d27f4
+    # https://github.com/knedlsepp/nixpkgs/commit/c1a2918c849a5bc766c6d55d96bc6cf85c9d27f4
     patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-ppc.patch?full_index=1',
           sha256='5434f29a87856aa05124c7a9409b3ec3106c30b1ad722720773623190f6bfda8',
           when='@4.2.15:')

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -68,6 +68,23 @@ class Hdf(AutotoolsPackage):
     # TODO: '@:4.2.14 ~external-xdr' and the fact that we compile for 64 bit
     #  architecture should be in conflict
 
+    #https://github.com/knedlsepp/nixpkgs/commit/c1a2918c849a5bc766c6d55d96bc6cf85c9d27f4
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-ppc.patch?full_index=1',
+          sha256='5434f29a87856aa05124c7a9409b3ec3106c30b1ad722720773623190f6bfda8',
+          when='@4.2.15:')
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-4.2.4-sparc.patch?full_index=1',
+          sha256='ce75518cccbeb80ab976b299225ea6104c3eec1ec13c09e2289913279fcf1b39',
+          when='@4.2.15:')
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-s390.patch?full_index=1',
+          sha256='f7d67e8c3d0dad8bfca308936c6ac917cc0b63222c6339a29efdce14e8be6475',
+          when='@4.2.15:')
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-arm.patch?full_index=1',
+          sha256='d54592df281c92e7e655b8312d18bef9ed096848de9430510e0699e98246ccd3',
+          when='@4.2.15:')
+    patch('https://src.fedoraproject.org/rpms/hdf/raw/edbe5f49646b609f5bc9aeeee5a2be47e9556e8c/f/hdf-aarch64.patch?full_index=1',
+          sha256='49733dd6143be7b30a28d386701df64a72507974274f7e4c0a9e74205510ea72',
+          when='@4.2.15:')
+
     @property
     def libs(self):
         """HDF can be queried for the following parameters:


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/30521 (building hdf4 on Ubuntu 20.04 aarch64) by applying several patches in var/spack/repos/builtin/packages/hdf/package.py.

These patches were taken from here: https://github.com/knedlsepp/nixpkgs/commit/c1a2918c849a5bc766c6d55d96bc6cf85c9d27f4