### PR TITLE
slurm: add new versions to address CVEs 2022-2950[012]

### DIFF
--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -27,7 +27,8 @@ class Slurm(AutotoolsPackage):
     version('21-08-8-2', sha256='876d7dfa716990d7e579cfb9c6ffc123258e03a1450e993ade596d2ee90afcdd')
     version('21-08-8-1', sha256='47d4dd2f391abcb856ecfddb51145c86ead89554f24efb586c59f0e38491ff36')
     version('20-11-9-1', sha256='98d36f3487e95af610db305a3ee1c1a7d370a3e1efef9fabee8b0edb98a6604b')
-    # Due to CVE 2022-29500, CVE 2022-29501, and CVE 2022-29502, prior to 21.08.8 and 20.11.9 are deprecated
+    # Due to CVE 2022-29500, CVE 2022-29501, and CVE 2022-29502, prior to 21.08.8 and
+    # 20.11.9 are deprecated
     version('21-08-1-1', sha256='23321719101762b055a6b1da6ff4261f5e6c469bce038c6c23549840453862e7', deprecated=True)
     version('21-08-0-1', sha256='c8caf9b5f715c02b6f9e55e9737ee7b99f93c5efc8dcc34c2ce40bed0aea5402', deprecated=True)
     version('20-11-8-1', sha256='1cafed56ae9d90387a5dc6092090c174e144a6e5a31330f748d1fd3a616ae92f', deprecated=True)

--- a/var/spack/repos/builtin/packages/slurm/package.py
+++ b/var/spack/repos/builtin/packages/slurm/package.py
@@ -22,13 +22,17 @@ class Slurm(AutotoolsPackage):
     """
 
     homepage = 'https://slurm.schedmd.com'
-    url = 'https://github.com/SchedMD/slurm/archive/slurm-20-02-7-1.tar.gz'
+    url = 'https://github.com/SchedMD/slurm/archive/slurm-21-08-8-2.tar.gz'
 
-    version('21-08-1-1', sha256='23321719101762b055a6b1da6ff4261f5e6c469bce038c6c23549840453862e7')
-    version('21-08-0-1', sha256='c8caf9b5f715c02b6f9e55e9737ee7b99f93c5efc8dcc34c2ce40bed0aea5402')
-    version('20-11-8-1', sha256='1cafed56ae9d90387a5dc6092090c174e144a6e5a31330f748d1fd3a616ae92f')
-    version('20-11-7-1', sha256='7d92babd97d0b8750b8c25eced4507323aff32a9d85af3a644c1acedbddb9d2f')
-    version('20-02-7-1', sha256='060acf966af53e75c7eaae83c4f42abdcc60702838c2dcd35cb01468b45a68a1')
+    version('21-08-8-2', sha256='876d7dfa716990d7e579cfb9c6ffc123258e03a1450e993ade596d2ee90afcdd')
+    version('21-08-8-1', sha256='47d4dd2f391abcb856ecfddb51145c86ead89554f24efb586c59f0e38491ff36')
+    version('20-11-9-1', sha256='98d36f3487e95af610db305a3ee1c1a7d370a3e1efef9fabee8b0edb98a6604b')
+    # Due to CVE 2022-29500, CVE 2022-29501, and CVE 2022-29502, prior to 21.08.8 and 20.11.9 are deprecated
+    version('21-08-1-1', sha256='23321719101762b055a6b1da6ff4261f5e6c469bce038c6c23549840453862e7', deprecated=True)
+    version('21-08-0-1', sha256='c8caf9b5f715c02b6f9e55e9737ee7b99f93c5efc8dcc34c2ce40bed0aea5402', deprecated=True)
+    version('20-11-8-1', sha256='1cafed56ae9d90387a5dc6092090c174e144a6e5a31330f748d1fd3a616ae92f', deprecated=True)
+    version('20-11-7-1', sha256='7d92babd97d0b8750b8c25eced4507323aff32a9d85af3a644c1acedbddb9d2f', deprecated=True)
+    version('20-02-7-1', sha256='060acf966af53e75c7eaae83c4f42abdcc60702838c2dcd35cb01468b45a68a1', deprecated=True)
     # Due to CVE-2021-31215, all versions prior to 20.11.7 or 20.02.7 are deprecated.
     version('20-11-5-1', sha256='d0634c6c6cc79bde38d19f0ef0de0de3b07907830f5e45be6f4a9ca4259f8f67', deprecated=True)
     version('20-11-4-1', sha256='06c5333e85f531730bf1c6eb48a8d48a551d9090540ce37b78181024273fb6bd', deprecated=True)


### PR DESCRIPTION
Due to CVE 2022-29500, CVE 2022-29501, and CVE 2022-29502, SLURM versions prior to 21.08.8 and 20.11.9 are deprecated.

See:
* https://www.schedmd.com/news.php?id=260#OPT_260
* https://cve.report/CVE-2022-29500
* https://cve.report/CVE-2022-29501
* https://cve.report/CVE-2022-29502

- [x] Deprecate versions prior to 21.08.8 and 20.11.9
- [x] Add 21-08-8-1, 21-08-8-2, and 20-11-9-1