### PR TITLE
Fix for linking with BLIS library

### DIFF
--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import os
-
 from spack import *
 
 
@@ -57,10 +55,6 @@ class LibflameBase(AutotoolsPackage):
         # -std=gnu99 at least required, old versions of GCC default to -std=c90
         if self.spec.satisfies('%gcc@:5.1') and name == 'cflags':
             flags.append('-std=gnu99')
-        elif self.spec.satisfies('^blis') and name == 'ldflags':
-            lib = os.path.join(self.spec['blis'].prefix.lib, 'libblis.so')
-            flags.append(LibraryList(lib).ld_flags)
-            return (None, flags, None)
         return (flags, None, None)
 
     def enable_or_disable_threads(self):
@@ -104,6 +98,9 @@ class LibflameBase(AutotoolsPackage):
 
         # https://github.com/flame/libflame/issues/21
         config_args.append("--enable-max-arg-list-hack")
+
+        if self.spec.satisfies('^blis'):
+            config_args.append('LDFLAGS=-L{}'.format(self.spec['blis'].prefix.lib))
 
         return config_args
 

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -3,9 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
-
 import os
+
+from spack import *
 
 
 class LibflameBase(AutotoolsPackage):

--- a/var/spack/repos/builtin/packages/libflame/package.py
+++ b/var/spack/repos/builtin/packages/libflame/package.py
@@ -5,6 +5,8 @@
 
 from spack import *
 
+import os
+
 
 class LibflameBase(AutotoolsPackage):
     """Base class for building Libflame, shared with the AMD
@@ -55,6 +57,10 @@ class LibflameBase(AutotoolsPackage):
         # -std=gnu99 at least required, old versions of GCC default to -std=c90
         if self.spec.satisfies('%gcc@:5.1') and name == 'cflags':
             flags.append('-std=gnu99')
+        elif self.spec.satisfies('^blis') and name == 'ldflags':
+            lib = os.path.join(self.spec['blis'].prefix.lib, 'libblis.so')
+            flags.append(LibraryList(lib).ld_flags)
+            return (None, flags, None)
         return (flags, None, None)
 
     def enable_or_disable_threads(self):


### PR DESCRIPTION
For some reason libflame isn't picking up BLIS when building.
In libflame config.log:
```
/usr/bin/ld: cannot find -lblis:: No such file or directory
```

Command to reproduce:
```
spack install --fail-fast libflame%gcc ^blis ^python@3.10.4
```

This workaround manually adds the BLIS library as an ldflag, which seems to fix this issue.

