### PR TITLE
Eigen: Turn on BUILD_TESTING for build to complete

### DIFF
--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -57,12 +57,11 @@ class Eigen(CMakePackage):
         env.prepend_path('CPATH', self.prefix.include.eigen3)
 
     def cmake_args(self):
-        # CMake fails without this flag
-        # https://gitlab.com/libeigen/eigen/-/issues/1656
+        args = []
         if self.spec.satisfies('@:3.4'):
-            args = ['-DBUILD_TESTING:BOOL=ON']
-        else:
-            args = []
+            # CMake fails without this flag
+            # https://gitlab.com/libeigen/eigen/-/issues/1656
+            args += [self.define('BUILD_TESTING', 'ON')]
         return args
 
     @property

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -56,6 +56,10 @@ class Eigen(CMakePackage):
     def setup_run_environment(self, env):
         env.prepend_path('CPATH', self.prefix.include.eigen3)
 
+    def cmake_args(self):
+        # CMake fails without this flag
+        return ['-DBUILD_TESTING:BOOL=ON']
+
     @property
     def headers(self):
         headers = find_all_headers(self.prefix.include)

--- a/var/spack/repos/builtin/packages/eigen/package.py
+++ b/var/spack/repos/builtin/packages/eigen/package.py
@@ -58,7 +58,12 @@ class Eigen(CMakePackage):
 
     def cmake_args(self):
         # CMake fails without this flag
-        return ['-DBUILD_TESTING:BOOL=ON']
+        # https://gitlab.com/libeigen/eigen/-/issues/1656
+        if self.spec.satisfies('@:3.4'):
+            args = ['-DBUILD_TESTING:BOOL=ON']
+        else:
+            args = []
+        return args
 
     @property
     def headers(self):


### PR DESCRIPTION
Related to this bug: https://gitlab.com/libeigen/eigen/-/issues/1656

A recent change to spack's CMakePackage has caused CMake packages to default to using `-DBUILD_TESTING:BOOL=OFF`, which has caused this issue.