### PR TITLE
oneapi 2022.2

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -31,8 +31,7 @@ class IntelOneApiPackage(Package):
     redistribute_source = False
 
     license_text = """ LICENSE INFORMATION: By downloading and using this software, you agree to the terms
-    and conditions of the software license agreements at
-    https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html."""
+    and conditions of the software license agreements at https://intel.ly/393CijO."""
 
     @property
     def component_dir(self):

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -30,8 +30,14 @@ class IntelOneApiPackage(Package):
     # organization (e.g. University/Company).
     redistribute_source = False
 
-    license_text = """ LICENSE INFORMATION: By downloading and using this software, you agree to the terms
-    and conditions of the software license agreements at https://intel.ly/393CijO."""
+    @staticmethod
+    def update_description(cls):
+        """Updates oneapi package descriptions with common text."""
+
+        text = """ LICENSE INFORMATION: By downloading and using this software, you agree to the terms
+        and conditions of the software license agreements at https://intel.ly/393CijO."""
+        cls.__doc__ = cls.__doc__ + text
+        return cls
 
     @property
     def component_dir(self):

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -30,6 +30,10 @@ class IntelOneApiPackage(Package):
     # organization (e.g. University/Company).
     redistribute_source = False
 
+    license_text = """ LICENSE INFORMATION: By downloading and using this software, you agree to the terms
+    and conditions of the software license agreements at
+    https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html."""
+
     @property
     def component_dir(self):
         """Subdirectory for this component in the install prefix."""

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -8,15 +8,17 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiAdvisor(IntelOneApiPackage):
-    __doc__ = ("""Intel Advisor is a design and analysis tool for developing
+    """Intel Advisor is a design and analysis tool for developing
     performant code. The tool supports C, C++, Fortran, SYCL, OpenMP,
     OpenCL code, and Python. It helps with the following: Performant
     CPU Code: Design your application for efficient threading,
     vectorization, and memory use. Efficient GPU Offload: Identify
     parts of the code that can be profitably offloaded. Optimize the
-    code for compute and memory."""
-               + IntelOneApiPackage.license_text)
+    code for compute and memory.
+
+    """
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -11,7 +11,7 @@ from spack import *
 class IntelOneapiAdvisor(IntelOneApiPackage):
     __doc__ = ("""Intel Advisor is a design and analysis tool for developing
     performant code. The tool supports C, C++, Fortran, SYCL*,
-    OpenMP*, OpenCL™ code, and Python*. It helps with the following:
+    OpenMP*, OpenCL code, and Python*. It helps with the following:
     Performant CPU Code: Design your application for efficient
     threading, vectorization, and memory use. Efficient GPU Offload:
     Identify parts of the code that can be profitably

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 
 class IntelOneapiAdvisor(IntelOneApiPackage):
-    __doc__ = ("""Intel® Advisor™ is a design and analysis tool for developing
+    __doc__ = ("""Intel Advisor is a design and analysis tool for developing
     performant code. The tool supports C, C++, Fortran, SYCL*,
     OpenMP*, OpenCL™ code, and Python*. It helps with the following:
     Performant CPU Code: Design your application for efficient

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -10,12 +10,12 @@ from spack import *
 
 class IntelOneapiAdvisor(IntelOneApiPackage):
     __doc__ = ("""Intel Advisor is a design and analysis tool for developing
-    performant code. The tool supports C, C++, Fortran, SYCL*,
-    OpenMP*, OpenCL code, and Python*. It helps with the following:
-    Performant CPU Code: Design your application for efficient
-    threading, vectorization, and memory use. Efficient GPU Offload:
-    Identify parts of the code that can be profitably
-    offloaded. Optimize the code for compute and memory."""
+    performant code. The tool supports C, C++, Fortran, SYCL, OpenMP,
+    OpenCL code, and Python. It helps with the following: Performant
+    CPU Code: Design your application for efficient threading,
+    vectorization, and memory use. Efficient GPU Offload: Identify
+    parts of the code that can be profitably offloaded. Optimize the
+    code for compute and memory."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-advisor/package.py
@@ -9,16 +9,24 @@ from spack import *
 
 
 class IntelOneapiAdvisor(IntelOneApiPackage):
-    """Intel Advisor is a design and analysis tool for achieving
-       high application performance. This is done through
-       efficient threading, vectorization, and memory use, and
-       GPU offload on current and future Intel hardware."""
+    __doc__ = ("""Intel® Advisor™ is a design and analysis tool for developing
+    performant code. The tool supports C, C++, Fortran, SYCL*,
+    OpenMP*, OpenCL™ code, and Python*. It helps with the following:
+    Performant CPU Code: Design your application for efficient
+    threading, vectorization, and memory use. Efficient GPU Offload:
+    Identify parts of the code that can be profitably
+    offloaded. Optimize the code for compute and memory."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/advisor.html'
 
     if platform.system() == 'Linux':
+        version('2022.1.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18730/l_oneapi_advisor_p_2022.1.0.171_offline.sh',
+                sha256='b627dbfefa779b44e7ab40dfa37614e56caa6e245feaed402d51826e6a7cb73b',
+                expand=False)
         version('2022.0.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18369/l_oneapi_advisor_p_2022.0.0.92_offline.sh',
                 sha256='f1c4317c2222c56fb2e292513f7eec7ec27eb1049d3600cb975bc08ed1477993',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -9,7 +9,8 @@ from spack import *
 
 
 class IntelOneapiCcl(IntelOneApiLibraryPackage):
-    """Intel oneAPI CCL."""
+    __doc__ = ("""Intel® oneAPI CCL."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 
 class IntelOneapiCcl(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI CCL."""
+    __doc__ = ("""Intel oneAPI CCL."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -19,6 +19,10 @@ class IntelOneapiCcl(IntelOneApiLibraryPackage):
     depends_on('intel-oneapi-mpi')
 
     if platform.system() == 'Linux':
+        version('2021.6.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18697/l_oneapi_ccl_p_2021.6.0.568.sh',
+                sha256='e3c50c9cbeb350e8f28488b2e8fee54156116548db8010bb2c2443048715d3ea',
+                expand=False)
         version('2021.5.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18472/l_oneapi_ccl_p_2021.5.1.494_offline.sh',
                 sha256='237f45d3c43447460e36eb7d68ae3bf611aa282015e57c7fe06c2004d368a68e',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ccl/package.py
@@ -8,9 +8,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiCcl(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel oneAPI CCL."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI CCL."""
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -12,8 +12,8 @@ from spack import *
 
 
 class IntelOneapiCompilers(IntelOneApiPackage):
-    __doc__ = ("""Intel oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx,
-    ifx, and dpcpp."""
+    __doc__ = ("""Intel oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx, ifx,
+    and dpcpp."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -11,10 +11,12 @@ from os import path
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiCompilers(IntelOneApiPackage):
-    __doc__ = ("""Intel oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx, ifx,
-    and dpcpp."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx, ifx,
+    and dpcpp.
+
+    """
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -12,9 +12,10 @@ from spack import *
 
 
 class IntelOneapiCompilers(IntelOneApiPackage):
-    """Intel OneAPI compilers
+    __doc__ = ("""Intel® oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx,
+    ifx, dpcpp"""
+               + IntelOneApiPackage.license_text)
 
-    Provides Classic and Beta compilers for: Fortran, C, C++"""
     maintainers = ['rscohn2']
 
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -13,7 +13,7 @@ from spack import *
 
 class IntelOneapiCompilers(IntelOneApiPackage):
     __doc__ = ("""Intel® oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx,
-    ifx, dpcpp"""
+    ifx, and dpcpp."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -12,7 +12,7 @@ from spack import *
 
 
 class IntelOneapiCompilers(IntelOneApiPackage):
-    __doc__ = ("""Intel® oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx,
+    __doc__ = ("""Intel oneAPI Compilers. Includes: icc, icpc, ifort, icx, icpx,
     ifx, and dpcpp."""
                + IntelOneApiPackage.license_text)
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -22,6 +22,16 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     depends_on('patchelf', type='build')
 
     if platform.system() == 'Linux':
+        version('2022.1.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh',
+                sha256='1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6',
+                expand=False)
+        resource(name='fortran-installer',
+                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18703/l_fortran-compiler_p_2022.1.0.134_offline.sh',
+                 sha256='583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020',
+                 expand=False,
+                 placement='fortran-installer',
+                 when='@2022.1.0')
         version('2022.0.2',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh',
                 sha256='ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -9,13 +9,15 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiDal(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel Data Analytics Library (DAL) provides the right tools to
+    """Intel Data Analytics Library (DAL) provides the right tools to
     build compute-intense applications that run fast on Intel
     architecture. It includes algorithms for analysis functions, math
     functions, training and library prediction functions for C++ and
-    Java."""
-               + IntelOneApiPackage.license_text)
+    Java.
+
+    """
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -10,8 +10,8 @@ from spack import *
 
 
 class IntelOneapiDal(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® Data Analytics Library (DAL) provides the right tools to
-    build compute-intense applications that run fast on Intel®
+    __doc__ = ("""Intel Data Analytics Library (DAL) provides the right tools to
+    build compute-intense applications that run fast on Intel
     architecture. It includes algorithms for analysis functions, math
     functions, training and library prediction functions for C++ and
     Java*."""

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -14,7 +14,7 @@ class IntelOneapiDal(IntelOneApiLibraryPackage):
     build compute-intense applications that run fast on Intel
     architecture. It includes algorithms for analysis functions, math
     functions, training and library prediction functions for C++ and
-    Java*."""
+    Java."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dal/package.py
@@ -10,13 +10,22 @@ from spack import *
 
 
 class IntelOneapiDal(IntelOneApiLibraryPackage):
-    """Intel oneAPI DAL."""
+    __doc__ = ("""Intel® Data Analytics Library (DAL) provides the right tools to
+    build compute-intense applications that run fast on Intel®
+    architecture. It includes algorithms for analysis functions, math
+    functions, training and library prediction functions for C++ and
+    Java*."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onedal.html'
 
     if platform.system() == 'Linux':
+        version('2021.6.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18698/l_daal_oneapi_p_2021.6.0.915_offline.sh',
+                sha256='bc9a430f372a5f9603c19ec25207c83ffd9d59fe517599c734d465e32afc9790',
+                expand=False)
         version('2021.5.3',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18480/l_daal_oneapi_p_2021.5.3.832_offline.sh',
                 sha256='6d3503cf7be2908bbb7bd18e67b8f2e96ad9aec53d4813c9be620adaa2db390f',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onednn.html'
 
     if platform.system() == 'Linux':
+        version('2022.1.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18725/l_onednn_p_2022.1.0.132_offline.sh',
+                sha256='0b9a7efe8dd0f0b5132b353a8ee99226f75bae4bab188a453817263a0684cc93',
+                expand=False)
         version('2022.0.2',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18476/l_onednn_p_2022.0.2.43_offline.sh',
                 sha256='a2a953542b4f632b51a2527d84bd76c3140a41c8085420da4237e2877c27c280',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -10,7 +10,8 @@ from spack import *
 
 
 class IntelOneapiDnn(IntelOneApiLibraryPackage):
-    """Intel oneAPI DNN."""
+    __doc__ = ("""Intel® oneAPI DNN."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -10,7 +10,7 @@ from spack import *
 
 
 class IntelOneapiDnn(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI DNN."""
+    __doc__ = ("""Intel oneAPI DNN."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -9,9 +9,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiDnn(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel oneAPI DNN."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI DNN."""
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -17,6 +17,10 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
     homepage = 'https://github.com/oneapi-src/oneDPL'
 
     if platform.system() == 'Linux':
+        version('2021.7.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18752/l_oneDPL_p_2021.7.0.631_offline.sh',
+                sha256='1e2d735d5eccfe8058e18f96d733eda8de5b7a07d613447b7d483fd3f9cec600',
+                expand=False)
         version('2021.6.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18372/l_oneDPL_p_2021.6.0.501_offline.sh',
                 sha256='0225f133a6c38b36d08635986870284a958e5286c55ca4b56a4058bd736f8f4f',

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -9,9 +9,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiDpl(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel oneAPI DPL."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI DPL."""
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -10,7 +10,8 @@ from spack import *
 
 
 class IntelOneapiDpl(IntelOneApiLibraryPackage):
-    """Intel oneAPI DPL."""
+    __doc__ = ("""Intel® oneAPI DPL."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -10,7 +10,7 @@ from spack import *
 
 
 class IntelOneapiDpl(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI DPL."""
+    __doc__ = ("""Intel oneAPI DPL."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -10,8 +10,8 @@ from spack import *
 
 class IntelOneapiInspector(IntelOneApiPackage):
     __doc__ = ("""Intel Inspector is a dynamic memory and threading error debugger
-    for C, C++, and Fortran applications that run on Windows* and
-    Linux* operating systems.  Save money: locate the root cause of
+    for C, C++, and Fortran applications that run on Windows and
+    Linux operating systems.  Save money: locate the root cause of
     memory, threading, and persistence errors before you release.
     Save time: simplify the diagnosis of difficult errors by breaking
     into the debugger just before the error occurs.  Save effort: use

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -8,17 +8,19 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiInspector(IntelOneApiPackage):
-    __doc__ = ("""Intel Inspector is a dynamic memory and threading error debugger
-    for C, C++, and Fortran applications that run on Windows and
-    Linux operating systems.  Save money: locate the root cause of
-    memory, threading, and persistence errors before you release.
-    Save time: simplify the diagnosis of difficult errors by breaking
-    into the debugger just before the error occurs.  Save effort: use
-    your normal debug or production build to catch and debug
-    errors. Check all code, including third-party libraries with
-    unavailable sources."""
-               + IntelOneApiPackage.license_text)
+    """Intel Inspector is a dynamic memory and threading error debugger
+    for C, C++, and Fortran applications that run on Windows and Linux
+    operating systems.  Save money: locate the root cause of memory,
+    threading, and persistence errors before you release.  Save time:
+    simplify the diagnosis of difficult errors by breaking into the
+    debugger just before the error occurs.  Save effort: use your
+    normal debug or production build to catch and debug errors. Check
+    all code, including third-party libraries with unavailable
+    sources.
+
+    """
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -9,14 +9,26 @@ from spack import *
 
 
 class IntelOneapiInspector(IntelOneApiPackage):
-    """Intel Inspector is a memory and thread checking and debugging tool to increase
-       the reliability, security, and accuracy of C/C++ and Fortran applications."""
+    __doc__ = ("""Intel® Inspector is a dynamic memory and threading error debugger
+    for C, C++, and Fortran applications that run on Windows* and
+    Linux* operating systems.  Save money: locate the root cause of
+    memory, threading, and persistence errors before you release.
+    Save time: simplify the diagnosis of difficult errors by breaking
+    into the debugger just before the error occurs.  Save effort: use
+    your normal debug or production build to catch and debug
+    errors. Check all code, including third-party libraries with
+    unavailable sources."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/inspector.html'
 
     if platform.system() == 'Linux':
+        version('2022.1.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18712/l_inspector_oneapi_p_2022.1.0.123_offline.sh',
+                sha256='8551180aa30be3abea11308fb11ea9a296f0e056ab07d9254585448a0b23333e',
+                expand=False)
         version('2022.0.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18363/l_inspector_oneapi_p_2022.0.0.56_offline.sh',
                 sha256='79a0eb2ae3f1de1e3456076685680c468702922469c3fda3e074718fb0bea741',

--- a/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-inspector/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 
 class IntelOneapiInspector(IntelOneApiPackage):
-    __doc__ = ("""Intel® Inspector is a dynamic memory and threading error debugger
+    __doc__ = ("""Intel Inspector is a dynamic memory and threading error debugger
     for C, C++, and Fortran applications that run on Windows* and
     Linux* operating systems.  Save money: locate the root cause of
     memory, threading, and persistence errors before you release.

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 
 class IntelOneapiIpp(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI IPP."""
+    __doc__ = ("""Intel oneAPI IPP."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -8,9 +8,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiIpp(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel oneAPI IPP."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI IPP."""
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -16,6 +16,10 @@ class IntelOneapiIpp(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform.system() == 'Linux':
+        version('2021.6.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18748/l_ipp_oneapi_p_2021.6.0.626_offline.sh',
+                sha256='cf09b5229dd38d75671fa1ab1af47e4d5f9f16dc7c9c22a4313a221a184774aa',
+                expand=False)
         version('2021.5.2',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18474/l_ipp_oneapi_p_2021.5.2.544_offline.sh',
                 sha256='ba48d91ab1447d0ae3d3a5448e3f08e460393258b60630c743be88281e51608e',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ipp/package.py
@@ -9,7 +9,8 @@ from spack import *
 
 
 class IntelOneapiIpp(IntelOneApiLibraryPackage):
-    """Intel oneAPI IPP."""
+    __doc__ = ("""Intel® oneAPI IPP."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -10,7 +10,7 @@ from spack import *
 
 
 class IntelOneapiIppcp(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI IPP Crypto."""
+    __doc__ = ("""Intel oneAPI IPP Crypto."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -17,6 +17,10 @@ class IntelOneapiIppcp(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/ipp.html'
 
     if platform.system() == 'Linux':
+        version('2021.6.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18709/l_ippcp_oneapi_p_2021.6.0.536_offline.sh',
+                sha256='dac90862b408a6418f3782a5c4bf940939b1307ff4841ecfc6a29322976a2d43',
+                expand=False)
         version('2021.5.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18470/l_ippcp_oneapi_p_2021.5.1.462_offline.sh',
                 sha256='7ec058abbc1cdfd240320228d6426c65e5a855fd3a27e11fbd1ad2523f64812a',

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -10,7 +10,8 @@ from spack import *
 
 
 class IntelOneapiIppcp(IntelOneApiLibraryPackage):
-    """Intel oneAPI IPP Crypto."""
+    __doc__ = ("""Intel® oneAPI IPP Crypto."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-ippcp/package.py
@@ -9,9 +9,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiIppcp(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel oneAPI IPP Crypto."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI IPP Crypto."""
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -9,9 +9,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiMkl(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel oneAPI MKL."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI MKL."""
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -10,7 +10,7 @@ from spack import *
 
 
 class IntelOneapiMkl(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI MKL."""
+    __doc__ = ("""Intel oneAPI MKL."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -10,7 +10,8 @@ from spack import *
 
 
 class IntelOneapiMkl(IntelOneApiLibraryPackage):
-    """Intel oneAPI MKL."""
+    __doc__ = ("""Intel® oneAPI DPL."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -10,7 +10,7 @@ from spack import *
 
 
 class IntelOneapiMkl(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI DPL."""
+    __doc__ = ("""Intel® oneAPI MKL."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -17,6 +17,10 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html'
 
     if platform.system() == 'Linux':
+        version('2022.1.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18721/l_onemkl_p_2022.1.0.223_offline.sh',
+                sha256='4b325a3c4c56e52f4ce6c8fbb55d7684adc16425000afc860464c0f29ea4563e',
+                expand=False)
         version('2022.0.2',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18483/l_onemkl_p_2022.0.2.136_offline.sh',
                 sha256='134b748825a474acc862bb4a7fada99741a15b7627cfaa6ba0fb05ec0b902b5e',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -10,7 +10,7 @@ from spack import *
 
 
 class IntelOneapiMpi(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI MPI."""
+    __doc__ = ("""Intel oneAPI MPI."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2', ]

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -10,7 +10,8 @@ from spack import *
 
 
 class IntelOneapiMpi(IntelOneApiLibraryPackage):
-    """Intel oneAPI MPI."""
+    __doc__ = ("""Intel® oneAPI MPI."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2', ]
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -17,6 +17,10 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/mpi-library.html'
 
     if platform.system() == 'Linux':
+        version('2021.6.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18714/l_mpi_oneapi_p_2021.6.0.602_offline.sh',
+                sha256='e85db63788c434d43c1378e5e2bf7927a75d11aee8e6b78ee0d933da920977a6',
+                expand=False)
         version('2021.5.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18471/l_mpi_oneapi_p_2021.5.1.515_offline.sh',
                 sha256='b992573959e39752e503e691564a0d876b099547c38b322d5775c5b06ec07a7f',

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -9,9 +9,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiMpi(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel oneAPI MPI."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI MPI."""
 
     maintainers = ['rscohn2', ]
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -10,7 +10,7 @@ from spack import *
 
 
 class IntelOneapiTbb(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel® oneAPI TBB."""
+    __doc__ = ("""Intel oneAPI TBB."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -10,7 +10,8 @@ from spack import *
 
 
 class IntelOneapiTbb(IntelOneApiLibraryPackage):
-    """Intel oneAPI TBB."""
+    __doc__ = ("""Intel® oneAPI TBB."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -17,6 +17,10 @@ class IntelOneapiTbb(IntelOneApiLibraryPackage):
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onetbb.html'
 
     if platform.system() == 'Linux':
+        version('2021.6.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18728/l_tbb_oneapi_p_2021.6.0.835_offline.sh',
+                sha256='e9ede40a3d7745de6d711d43818f820c8486ab544a45610a71118fbca20698e5',
+                expand=False)
         version('2021.5.1',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18473/l_tbb_oneapi_p_2021.5.1.738_offline.sh',
                 sha256='c154749f1f370e4cde11a0a7c80452d479e2dfa53ff2b1b97003d9c0d99c91e3',

--- a/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-tbb/package.py
@@ -9,9 +9,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiTbb(IntelOneApiLibraryPackage):
-    __doc__ = ("""Intel oneAPI TBB."""
-               + IntelOneApiPackage.license_text)
+    """Intel oneAPI TBB."""
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 
 class IntelOneapiVpl(IntelOneApiLibraryPackage):
-    __doc__ = ("""The Intel® oneAPI Video Processing Library (oneVPL) is the
+    __doc__ = ("""The Intel oneAPI Video Processing Library (oneVPL) is the
     successor to Intel® Media SDK. This library takes you from
     abstractions for integrated graphics to using oneVPL to unlock
     media features on a much broader range of accelerators.  oneVPL

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -9,13 +9,26 @@ from spack import *
 
 
 class IntelOneapiVpl(IntelOneApiLibraryPackage):
-    """Intel oneAPI VPL."""
+    __doc__ = ("""The Intel® oneAPI Video Processing Library (oneVPL) is the
+    successor to Intel® Media SDK. This library takes you from
+    abstractions for integrated graphics to using oneVPL to unlock
+    media features on a much broader range of accelerators.  oneVPL
+    provides a single, video-focused API for encoding, decoding, and
+    video processing that works across a wide range of
+    accelerators. The library is perfect for applications spanning
+    broadcasting, streaming, video on demand (VOD), in-cloud gaming,
+    and remote desktop solutions."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onevpl.html'
 
     if platform.system() == 'Linux':
+        version('2022.1.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18750/l_oneVPL_p_2022.1.0.154_offline.sh',
+                sha256='486cca918c9772a43f62da77e07cdf54dabb92ecebf494eb8c89c4492ab43447',
+                expand=False)
         version('2022.0.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18375/l_oneVPL_p_2022.0.0.58_offline.sh',
                 sha256='600b8566e1aa523b97291bed6b08f69a04bc7c4c75c035942a64a38f45a1a7f0',

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -8,16 +8,18 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiVpl(IntelOneApiLibraryPackage):
-    __doc__ = ("""The Intel oneAPI Video Processing Library (oneVPL) is the successor
+    """The Intel oneAPI Video Processing Library (oneVPL) is the successor
     to Intel Media SDK. This library takes you from abstractions for
     integrated graphics to using oneVPL to unlock media features on a
     much broader range of accelerators.  oneVPL provides a single,
     video-focused API for encoding, decoding, and video processing
     that works across a wide range of accelerators. The library is
     perfect for applications spanning broadcasting, streaming, video
-    on demand (VOD), in-cloud gaming, and remote desktop solutions."""
-               + IntelOneApiPackage.license_text)
+    on demand (VOD), in-cloud gaming, and remote desktop solutions.
+
+    """
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vpl/package.py
@@ -9,15 +9,14 @@ from spack import *
 
 
 class IntelOneapiVpl(IntelOneApiLibraryPackage):
-    __doc__ = ("""The Intel oneAPI Video Processing Library (oneVPL) is the
-    successor to Intel® Media SDK. This library takes you from
-    abstractions for integrated graphics to using oneVPL to unlock
-    media features on a much broader range of accelerators.  oneVPL
-    provides a single, video-focused API for encoding, decoding, and
-    video processing that works across a wide range of
-    accelerators. The library is perfect for applications spanning
-    broadcasting, streaming, video on demand (VOD), in-cloud gaming,
-    and remote desktop solutions."""
+    __doc__ = ("""The Intel oneAPI Video Processing Library (oneVPL) is the successor
+    to Intel Media SDK. This library takes you from abstractions for
+    integrated graphics to using oneVPL to unlock media features on a
+    much broader range of accelerators.  oneVPL provides a single,
+    video-focused API for encoding, decoding, and video processing
+    that works across a wide range of accelerators. The library is
+    perfect for applications spanning broadcasting, streaming, video
+    on demand (VOD), in-cloud gaming, and remote desktop solutions."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -13,8 +13,8 @@ class IntelOneapiVtune(IntelOneApiPackage):
     performance, system performance, and system configuration for HPC,
     cloud, IoT, media, storage, and more.  CPU, GPU, and FPGA: Tune
     the entire application's performance--not just the accelerated
-    portion. Multilingual: Profile SYCL*, C, C++, C#, Fortran, OpenCL
-    code, Python*, Google Go* programming language, Java*, .NET,
+    portion. Multilingual: Profile SYCL, C, C++, C#, Fortran, OpenCL
+    code, Python, Google Go programming language, Java, .NET,
     Assembly, or any combination of languages.  System or Application:
     Get coarse-grained system data for an extended period or detailed
     results mapped to source code. Power: Optimize performance while

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -9,7 +9,7 @@ from spack import *
 
 
 class IntelOneapiVtune(IntelOneApiPackage):
-    __doc__ = ("""Intel® VTune™ Profiler is a profiler to optimize application
+    __doc__ = ("""Intel VTune Profiler is a profiler to optimize application
     performance, system performance, and system configuration for HPC,
     cloud, IoT, media, storage, and more.  CPU, GPU, and FPGA: Tune
     the entire application’s performance―not just the accelerated

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -12,13 +12,13 @@ class IntelOneapiVtune(IntelOneApiPackage):
     __doc__ = ("""Intel VTune Profiler is a profiler to optimize application
     performance, system performance, and system configuration for HPC,
     cloud, IoT, media, storage, and more.  CPU, GPU, and FPGA: Tune
-    the entire application’s performance―not just the accelerated
+    the entire application's performance--not just the accelerated
     portion. Multilingual: Profile SYCL*, C, C++, C#, Fortran, OpenCL
     code, Python*, Google Go* programming language, Java*, .NET,
     Assembly, or any combination of languages.  System or Application:
     Get coarse-grained system data for an extended period or detailed
     results mapped to source code. Power: Optimize performance while
-    avoiding power- and thermal-related throttling."""
+    avoiding power and thermal-related throttling."""
                + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -8,8 +8,9 @@ import platform
 from spack import *
 
 
+@IntelOneApiPackage.update_description
 class IntelOneapiVtune(IntelOneApiPackage):
-    __doc__ = ("""Intel VTune Profiler is a profiler to optimize application
+    """Intel VTune Profiler is a profiler to optimize application
     performance, system performance, and system configuration for HPC,
     cloud, IoT, media, storage, and more.  CPU, GPU, and FPGA: Tune
     the entire application's performance--not just the accelerated
@@ -18,8 +19,9 @@ class IntelOneapiVtune(IntelOneApiPackage):
     Assembly, or any combination of languages.  System or Application:
     Get coarse-grained system data for an extended period or detailed
     results mapped to source code. Power: Optimize performance while
-    avoiding power and thermal-related throttling."""
-               + IntelOneApiPackage.license_text)
+    avoiding power and thermal-related throttling.
+
+    """
 
     maintainers = ['rscohn2']
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -9,16 +9,27 @@ from spack import *
 
 
 class IntelOneapiVtune(IntelOneApiPackage):
-    """Intel oneAPI VTune Profiler.
-    Installed in Perf driverless mode, detailed here: https://software.intel.com/content/www/us/en/develop/documentation/vtune-cookbook/top/configuration-recipes/profiling-hardware-without-sampling-drivers.html
-    Users can manually install drivers, please read the instructions here: https://software.intel.com/content/www/us/en/develop/documentation/vtune-help/top/set-up-analysis-target/linux-targets/building-and-installing-the-sampling-drivers-for-linux-targets.html
-    """
+    __doc__ = ("""Intel® VTune™ Profiler is a profiler to optimize application
+    performance, system performance, and system configuration for HPC,
+    cloud, IoT, media, storage, and more.  CPU, GPU, and FPGA: Tune
+    the entire application’s performance―not just the accelerated
+    portion. Multilingual: Profile SYCL*, C, C++, C#, Fortran, OpenCL™
+    code, Python*, Google Go* programming language, Java*, .NET,
+    Assembly, or any combination of languages.  System or Application:
+    Get coarse-grained system data for an extended period or detailed
+    results mapped to source code. Power: Optimize performance while
+    avoiding power- and thermal-related throttling."""
+               + IntelOneApiPackage.license_text)
 
     maintainers = ['rscohn2']
 
     homepage = 'https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/vtune-profiler.html'
 
     if platform.system() == 'Linux':
+        version('2022.3.0',
+                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18656/l_oneapi_vtune_p_2022.3.0.195_offline.sh',
+                sha256='7921fce7fcc3b82575be22d9c36beec961ba2a9fb5262ba16a04090bcbd2e1a6',
+                expand=False)
         version('2022.0.0',
                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18406/l_oneapi_vtune_p_2022.0.0.94_offline.sh',
                 sha256='aa4d575c22e7be0c950b87d67d9e371f470f682906864c4f9b68e530ecd22bd7',

--- a/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-vtune/package.py
@@ -13,7 +13,7 @@ class IntelOneapiVtune(IntelOneApiPackage):
     performance, system performance, and system configuration for HPC,
     cloud, IoT, media, storage, and more.  CPU, GPU, and FPGA: Tune
     the entire application’s performance―not just the accelerated
-    portion. Multilingual: Profile SYCL*, C, C++, C#, Fortran, OpenCL™
+    portion. Multilingual: Profile SYCL*, C, C++, C#, Fortran, OpenCL
     code, Python*, Google Go* programming language, Java*, .NET,
     Assembly, or any combination of languages.  System or Application:
     Get coarse-grained system data for an extended period or detailed


### PR DESCRIPTION
oneAPI 2022.2 release

Includes some updated descriptions and licensing information.

Testing is here: https://github.com/rscohn2/oneapi-spack-tests/actions/runs/2282150631

The ``__doc__ =`` is a little ugly, but it is the only way I found to make the ``spack info`` descriptions include a common piece of license text.