### PR TITLE
fix bad type in wi4mpi package.py

### DIFF
--- a/var/spack/repos/builtin/packages/wi4mpi/package.py
+++ b/var/spack/repos/builtin/packages/wi4mpi/package.py
@@ -50,7 +50,7 @@ class Wi4mpi(CMakePackage):
 
     def setup_run_environment(self, env):
         env.set('WI4MPI_ROOT', self.prefix)
-        env.set('WI4MPI_VERSION', self.version)
+        env.set('WI4MPI_VERSION', str(self.version))
         env.set('WI4MPI_CC', self.compiler.cc)
         env.set('WI4MPI_CXX', self.compiler.cxx)
         env.set('WI4MPI_FC', self.compiler.fc)


### PR DESCRIPTION
line ```env.set('WI4MPI_VERSION', self.version)``` gives a descriptive but hard to localize error on feeding a wrong type to the env.set function (needs to be string, not numeric). I spent way too much time trying to figure this out :-(. Hopefully this saves someone else some time.