### PR TITLE
rework handling of commit versions

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -588,8 +588,10 @@ class CompilerSpec(object):
                 'A spec cannot contain multiple version signifiers.'
                 ' Use a version list instead.')
         self.versions = vn.VersionList()
-        for version in version_list:
-            self.versions.add(version)
+        for v in version_list:
+            self.versions.add(v)
+        if self.name and self.versions.is_commit:
+            self.versions.generate_commit_lookup(self.name)
 
     def _autospec(self, compiler_spec_like):
         if isinstance(compiler_spec_like, CompilerSpec):
@@ -1386,8 +1388,10 @@ class Spec(object):
                 'A spec cannot contain multiple version signifiers.'
                 ' Use a version list instead.')
         self.versions = vn.VersionList()
-        for version in version_list:
-            self.versions.add(version)
+        for v in version_list:
+            self.versions.add(v)
+        if self.fullname and self.versions.is_commit:
+            self.versions.generate_commit_lookup(self.fullname)
 
     def _add_flag(self, name, value):
         """Called by the parser to add a known flag.
@@ -3653,6 +3657,8 @@ class Spec(object):
                 self.namespace != other.namespace):
             return False
         if self.versions and other.versions:
+            self.versions.generate_commit_lookup(self.fullname)
+            other.versions.generate_commit_lookup(self.fullname)
             if not self.versions.satisfies(other.versions, strict=strict):
                 return False
         elif strict and (self.versions or other.versions):

--- a/lib/spack/spack/test/cmd/install.py
+++ b/lib/spack/spack/test/cmd/install.py
@@ -273,7 +273,7 @@ def test_install_commit(
     assert filename in installed
     with open(spec.prefix.bin.join(filename), 'r') as f:
         content = f.read().strip()
-    assert content == '[]'  # contents are weird for another test
+    assert content == "['unknown_git_commit']"  # contents are weird for another test
 
 
 def test_install_overwrite_multiple(

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -132,14 +132,23 @@ def mock_git_version_info(tmpdir, override_git_repos_cache_path,
         def latest_commit():
             return git('rev-list', '-n1', 'HEAD', output=str, error=str).strip()
 
-        # Add two commits on main branch
-        write_file(filename, "['unknown_git_commit']")
+        # Add first commit on main branch
+        write_file(filename, "['git_commit_1_below_1.0']")
         git('add', filename)
         commit('first commit')
         commits.append(latest_commit())
 
         # Get name of default branch (differs by git version)
+        # NOTE: Must be after a commit
         main = git('rev-parse', '--abbrev-ref', 'HEAD', output=str, error=str).strip()
+
+        # Add commit on side branch, for unknown version
+        write_file(filename, "['unknown_git_commit', 1]")
+        git('checkout', '-b', 'dev-b')
+        git('add', filename)
+        commit('branch commit')
+        commits.append(latest_commit())
+        git('checkout', main)
 
         # Tag second commit as v1.0
         write_file(filename, "[1, 0]")

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -133,7 +133,7 @@ def mock_git_version_info(tmpdir, override_git_repos_cache_path,
             return git('rev-list', '-n1', 'HEAD', output=str, error=str).strip()
 
         # Add two commits on main branch
-        write_file(filename, '[]')
+        write_file(filename, "['unknown_git_commit']")
         git('add', filename)
         commit('first commit')
         commits.append(latest_commit())
@@ -1397,7 +1397,8 @@ def mock_git_repository(tmpdir_factory):
     }
 
     t = Bunch(checks=checks, url=url, hash=rev_hash,
-              path=str(repodir), git_exe=git, unversioned_commit=r2)
+              path=str(repodir), git_exe=git, unversioned_commit=r2,
+              default_branch=default_branch)
     yield t
 
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -621,7 +621,7 @@ def test_git_hash_comparisons(
     # Spec based on earliest commit
     spec0 = spack.spec.Spec('git-test-commit@%s' % commits[-1])
     spec0.concretize()
-    assert spec0.satisfies('@999:')
+    assert spec0.satisfies('@:0.1')
     assert not spec0.satisfies('@1.0')
 
     # Spec based on second commit (same as version 1.0)

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -597,7 +597,7 @@ def test_versions_from_git(mock_git_version_info, monkeypatch, mock_packages):
         spec = spack.spec.Spec('git-test-commit@%s' % commit)
         version = spec.version
         comparator = [str(v) if not isinstance(v, int) else v
-                      for v in version._cmp(version.commit_lookup)]
+                      for v in version.version]
 
         with working_dir(repo_path):
             which('git')('checkout', commit)

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -625,13 +625,13 @@ def test_git_hash_comparisons(
     assert not spec0.satisfies('@1.0')
 
     # Spec based on second commit (same as version 1.0)
-    spec1 = spack.spec.Spec('git-test-commit@%s' % commits[-2])
+    spec1 = spack.spec.Spec('git-test-commit@%s' % commits[-3])
     spec1.concretize()
     assert spec1.satisfies('@1.0')
     assert not spec1.satisfies('@1.1:')
 
-    # Spec based on 4th commit (in timestamp order)
-    spec4 = spack.spec.Spec('git-test-commit@%s' % commits[-4])
+    # Spec based on 5th commit (in timestamp order)
+    spec4 = spack.spec.Spec('git-test-commit@%s' % commits[-5])
     spec4.concretize()
     assert spec4.satisfies('@1.1')
     assert spec4.satisfies('@1.0:1.2')

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -621,7 +621,7 @@ def test_git_hash_comparisons(
     # Spec based on earliest commit
     spec0 = spack.spec.Spec('git-test-commit@%s' % commits[-1])
     spec0.concretize()
-    assert spec0.satisfies('@:0')
+    assert spec0.satisfies('@999:')
     assert not spec0.satisfies('@1.0')
 
     # Spec based on second commit (same as version 1.0)

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -226,8 +226,10 @@ class Version(object):
                     # Extend previous version by empty component and distance
                     # If commit is exactly a known version, no distance suffix
                     prev_tuple = Version(prev_version).version if prev_version else ()
-                    dist_suffix = (VersionStrComponent(''), distance) if distance else ()
-                    ret = prev_tuple + dist_suffix
+                    if distance:
+                        ret = prev_tuple + (VersionStrComponent(''), distance)
+                    else:
+                        ret = prev_tuple
                 else:
                     # This should only happen for a bottom version, using string
                     # component to make this clear

--- a/var/spack/repos/builtin.mock/packages/git-test-commit/package.py
+++ b/var/spack/repos/builtin.mock/packages/git-test-commit/package.py
@@ -18,8 +18,9 @@ class GitTestCommit(Package):
 
     def install(self, spec, prefix):
         # It is assumed for the test which installs this package, that it will
-        # be using the earliest commit, which is contained in the range @:0
-        assert spec.satisfies('@:0')
+        # be using the earliest commit, which does not resolve to a version and
+        # becomes an infinity version
+        assert spec.satisfies('@0:')
         mkdir(prefix.bin)
 
         # This will only exist for some second commit


### PR DESCRIPTION
This makes two main changes:

* Commit versions that have not been looked up, and those for which the
  lookup failed, are treated as having the version "unknown_git_commit"
  which is a new infinity version so they build with the newest build
  instructions in the package.
* Commit version lookups occur on call to `v.generate_commit_lookup()`
  rather than delaying until later.  This means both that it's eagerly
  evaluated and that there is no opportunity for the other side to
  provide a lookup object.  The latter may cause problems if the version
  object is replaced somewhere without having its package attached, but
  it never happens in the tests, or in any build I've tried with this
  branch.

There are a couple of additional changes to fix lingering git related
test issues here that are not directly related but were required to get
the test board green on my end.

It would be really good to get some testing with this on something like MARBL that makes heavy use of commit versions.

