### PR TITLE
mpitrampoline: Correct build environment

### DIFF
--- a/var/spack/repos/builtin/packages/mpitrampoline/package.py
+++ b/var/spack/repos/builtin/packages/mpitrampoline/package.py
@@ -64,16 +64,6 @@ class Mpitrampoline(CMakePackage):
         libraries = ['libmpitrampoline']
         return find_libraries(libraries, root=self.prefix.lib, shared=True)
 
-    def setup_build_environment(self, env):
-        fflags = ['-fcray-pointer']
-        if self.spec.satisfies('%apple-clang@11:'):
-            fflags.append('-fallow-argument-mismatch')
-        if self.spec.satisfies('%clang@11:'):
-            fflags.append('-fallow-argument-mismatch')
-        if self.spec.satisfies('%gcc@10:'):
-            fflags.append('-fallow-argument-mismatch')
-        env.set('FFLAGS', ' '.join(fflags))
-
     def setup_run_environment(self, env):
         # Because MPI implementations provide compilers, they have to add to
         # their run environments the code to make the compilers available.
@@ -91,6 +81,16 @@ class Mpitrampoline(CMakePackage):
         env.set('MPITRAMPOLINE_CC', spack_cc)
         env.set('MPITRAMPOLINE_CXX', spack_cxx)
         env.set('MPITRAMPOLINE_FC', spack_fc)
+        fflags = []
+        if (self.spec.satisfies('%apple-clang') or
+            self.spec.satisfies('%clang') or
+            self.spec.satisfies('%gcc')):
+            fflags.append('-fcray-pointer')
+        if (self.spec.satisfies('%apple-clang@11:') or
+            self.spec.satisfies('%clang@11:') or
+            self.spec.satisfies('%gcc@10:')):
+            fflags.append('-fallow-argument-mismatch')
+        env.set('FFLAGS', ' '.join(fflags))
 
     def setup_dependent_package(self, module, dependent_spec):
         self.spec.mpicc = join_path(self.prefix.bin, 'mpicc')


### PR DESCRIPTION
- The build environment is intended to be set up for dependent packages, not for `mpitrampoline` itself.
- The compiler flag `-fcray-pointers` works only with Clang and GCC.