### PR TITLE
py-radiant-mlhub: add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/py-pystac/package.py
+++ b/var/spack/repos/builtin/packages/py-pystac/package.py
@@ -12,7 +12,14 @@ class PyPystac(PythonPackage):
     homepage = "https://github.com/azavea/pystac.git"
     pypi     = "pystac/pystac-0.5.4.tar.gz"
 
+    version('1.4.0', sha256='6ec43e1c6bec50fbfbdede49c3ccb83ecd112072a938001b5c9c581fc2945e83')
+    version('1.3.0', sha256='b0244641ef2a29a7b7929266b0d1eda2b0a0ef826dadb1aed93404a14e6e313b')
+    version('1.2.0', sha256='8a60be2a30e1e28f8617a88f9f8fddc00c519be494a02ec111dc8fba62bf26e7')
+    version('1.1.0', sha256='de42e1de5e8dc7a75b97feea0b660efdb5500ad8d7a892ff47fc9ed08c3bc2df')
+    version('1.0.1', sha256='3927f2104cd2077638e046b9c258d5e6b442bfabf2d179cbefbf10f509efae85')
     version('0.5.4', sha256='9fc3359364685adf54e3bc78c87550a8bc8b0a927405419bd8e4bbd42a8efc79')
 
+    depends_on('python@3.7:', when='@1:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-python-dateutil@2.7.0:', type=('build', 'run'))
+    depends_on('py-python-dateutil@2.7:', type=('build', 'run'))
+    depends_on('py-typing-extensions@3.7:', when='@1: ^python@:3.7', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-radiant-mlhub/package.py
+++ b/var/spack/repos/builtin/packages/py-radiant-mlhub/package.py
@@ -14,11 +14,22 @@ class PyRadiantMlhub(PythonPackage):
 
     maintainers = ['adamjstewart']
 
+    version('0.4.1', sha256='1d95475ec9d4cf460d5201425ba843523b1885a9384b9c1adb81a4a1088adb0f')
+    version('0.4.0', sha256='0208881601216f895a1c084a3ca9e5c46b09dbc09dca0447540192e4abb847b1')
+    version('0.3.1', sha256='3a5a8e971132d5b4cd9e412c7f6d87894fc588655ae0e93006646927b1ecb902')
+    version('0.3.0', sha256='dd66479f12317e7bf366abe8d692841485e9497918c30ab14cd6db9e69ce3dbb')
+    version('0.2.2', sha256='0d9f634b7e29c7f7294b81a10cf712ac63251949a9c5a07aa6c64c0d5b77e1ba')
     version('0.2.1', sha256='75a2f096b09a87191238fe557dc64dda8c44156351b4026c784c848c7d84b6fb')
 
     depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('python@3.7:', when='@0.3:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
-    depends_on('py-requests@2.25.1:2.25', type=('build', 'run'))
-    depends_on('py-pystac@0.5.4', type=('build', 'run'))
-    depends_on('py-click@7.1.2:7.1', type=('build', 'run'))
-    depends_on('py-tqdm@4.56.0:4.56', type=('build', 'run'))
+    depends_on('py-requests@2.25.1:2.25', when='@:0.2', type=('build', 'run'))
+    depends_on('py-requests@2.25:2', when='@0.3:', type=('build', 'run'))
+    depends_on('py-pystac@0.5.4', when='@:0.2', type=('build', 'run'))
+    depends_on('py-pystac@1.1:1', when='@0.3:', type=('build', 'run'))
+    depends_on('py-click@7.1.2:7.1', when='@:0.2', type=('build', 'run'))
+    depends_on('py-click@7.1.2:8', when='@0.3:', type=('build', 'run'))
+    depends_on('py-tqdm@4.56', when='@:0.2', type=('build', 'run'))
+    depends_on('py-tqdm@4.56:4', when='@0.3:', type=('build', 'run'))
+    depends_on('py-typing-extensions@3.7:', when='@0.4.1: ^python@:3.7', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.9.12 and Apple Clang 12.0.0.