### PR TITLE
py-geocube: add v0.3.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-geocube/package.py
+++ b/var/spack/repos/builtin/packages/py-geocube/package.py
@@ -14,15 +14,20 @@ class PyGeocube(PythonPackage):
 
     maintainers = ['adamjstewart']
 
+    version('0.3.1', sha256='5c97131010cd8d556a5fad2a3824452120640ac33a6a45b6ca9ee3c28f2e266f')
     version('0.0.17', sha256='bf8da0fa96d772ebaea0b98bafa0ba5b8639669d5feb07465d4255af177bddc0')
 
     depends_on('python@3.7:', type=('build', 'run'))
-    depends_on('py-setuptools', type=('build', 'run'))
+    depends_on('python@3.8:', when='@0.1.1:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
     depends_on('py-appdirs', type=('build', 'run'))
     depends_on('py-click@6.0:', type=('build', 'run'))
-    depends_on('py-datacube', type=('build', 'run'))
+    depends_on('py-datacube', when='@:0.1', type=('build', 'run'))
     depends_on('py-geopandas@0.7:', type=('build', 'run'))
+    depends_on('py-odc-geo', when='@0.2:', type=('build', 'run'))
     depends_on('py-rasterio', type=('build', 'run'))
     depends_on('py-rioxarray@0.4:', type=('build', 'run'))
+    depends_on('py-scipy', when='@0.0.18:', type=('build', 'run'))
     depends_on('py-xarray@0.17:', type=('build', 'run'))
     depends_on('py-pyproj@2:', type=('build', 'run'))
+    depends_on('py-numpy@1.20:', when='@0.3:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-odc-geo/package.py
+++ b/var/spack/repos/builtin/packages/py-odc-geo/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PyOdcGeo(PythonPackage):
+    """Geometry Classes and Operations (opendatacube)."""
+
+    homepage = "https://github.com/opendatacube/odc-geo/"
+    pypi     = "odc-geo/odc-geo-0.1.2.tar.gz"
+
+    version('0.1.2', sha256='c5ec3c66a326b138df5a28aa639b1c2c3c644093af463948255219bdc2513408')
+
+    depends_on('python@3.8:', type=('build', 'run'))
+    depends_on('py-setuptools@51:', type='build')
+    depends_on('py-affine', type=('build', 'run'))
+    depends_on('py-cachetools', type=('build', 'run'))
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-pyproj', type=('build', 'run'))
+    depends_on('py-shapely', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.9.12 and Apple Clang 12.0.0.