### PR TITLE
CI: fix bootstrapping on Fedora

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -33,11 +33,9 @@ jobs:
               cmake bison bison-devel libstdc++-static
       - name: Work around CVE-2022-24765
         run: |
-          # Apparently Ubuntu patched git v2.25.1 with a security patch that introduces 
-          # a breaking behavior. See:
+          # See:
           # - https://github.blog/2022-04-12-git-security-vulnerability-announced/
           # - https://github.com/actions/checkout/issues/760
-          # - http://changelogs.ubuntu.com/changelogs/pool/main/g/git/git_2.25.1-1ubuntu3.3/changelog
           git config --global --add safe.directory /__w/spack/spack
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
       - name: Setup repo and non-root user

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -31,6 +31,14 @@ jobs:
               bzip2 curl file gcc-c++ gcc gcc-gfortran git gnupg2 gzip \
               make patch unzip which xz python3 python3-devel tree \
               cmake bison bison-devel libstdc++-static
+      - name: Work around CVE-2022-24765
+        run: |
+          # Apparently Ubuntu patched git v2.25.1 with a security patch that introduces 
+          # a breaking behavior. See:
+          # - https://github.blog/2022-04-12-git-security-vulnerability-announced/
+          # - https://github.com/actions/checkout/issues/760
+          # - http://changelogs.ubuntu.com/changelogs/pool/main/g/git/git_2.25.1-1ubuntu3.3/changelog
+          git config --global --add safe.directory /__w/spack/spack
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
       - name: Setup repo and non-root user
         run: |


### PR DESCRIPTION
Fedora updated git, so we need to apply, again, the workaround for CVE-2022-24765