### PR TITLE
xgboost: require llvm-openmp for clang as well as apple-clang

### DIFF
--- a/var/spack/repos/builtin/packages/xgboost/package.py
+++ b/var/spack/repos/builtin/packages/xgboost/package.py
@@ -34,6 +34,7 @@ class Xgboost(CMakePackage, CudaPackage):
     depends_on('cuda@10:11.4', when='@:1.5.0+cuda')
     depends_on('nccl', when='+nccl')
     depends_on('llvm-openmp', when='%apple-clang +openmp')
+    depends_on('llvm-openmp', when='%clang +openmp')
 
     conflicts('%gcc@:4', msg='GCC version must be at least 5.0!')
     conflicts('+nccl', when='~cuda', msg='NCCL requires CUDA')


### PR DESCRIPTION
Should probably be a compiler dependency, but I think that's not possible yet.