### PR TITLE
lammps: updating googletest version to 1.11 to avoid GTEST_DISALLOW_ASSIGN_Error

### DIFF
--- a/var/spack/repos/builtin/packages/lammps/gtest_fix.patch
+++ b/var/spack/repos/builtin/packages/lammps/gtest_fix.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/Modules/GTest.cmake b/cmake/Modules/GTest1.cmake
+index 0c62291..e42137b 100644
+--- a/cmake/Modules/GTest.cmake
++++ b/cmake/Modules/GTest1.cmake
+@@ -7,11 +7,11 @@ else()
+ endif()
+ 
+ include(ExternalProject)
+-set(GTEST_URL "https://github.com/google/googletest/archive/release-1.10.0.tar.gz" CACHE STRING "URL for GTest tarball")
++set(GTEST_URL "https://github.com/google/googletest/archive/release-1.11.0.tar.gz" CACHE STRING "URL for GTest tarball")
+ mark_as_advanced(GTEST_URL)
+ ExternalProject_Add(googletest
+                     URL ${GTEST_URL}
+-                    URL_MD5         ecd1fa65e7de707cd5c00bdac56022cd
++                    URL_MD5         e8a8df240b6938bb6384155d4c37d937
+                     SOURCE_DIR      "${CMAKE_BINARY_DIR}/gtest-src"
+                     BINARY_DIR      "${CMAKE_BINARY_DIR}/gtest-build"
+                     CMAKE_ARGS      ${CMAKE_REQUEST_PIC} ${CMAKE_EXTRA_GTEST_OPTS}

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -175,6 +175,7 @@ class Lammps(CMakePackage, CudaPackage):
 
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")
+    patch("gtest_fix.patch", when="%aocc@3.2.0")
     patch("https://github.com/lammps/lammps/commit/562300996285fdec4ef74542383276898555af06.patch?full_index=1",
           sha256="e6f1b62bbfdc79d632f4cea98019202d0dd25aa4ae61a70df1164cb4f290df79",
           when="@20200721 +cuda")

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -175,7 +175,7 @@ class Lammps(CMakePackage, CudaPackage):
 
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")
-    patch("gtest_fix.patch", when="%aocc@3.2.0")
+    patch("gtest_fix.patch", when="@20210310 %aocc@3.2.0")
     patch("https://github.com/lammps/lammps/commit/562300996285fdec4ef74542383276898555af06.patch?full_index=1",
           sha256="e6f1b62bbfdc79d632f4cea98019202d0dd25aa4ae61a70df1164cb4f290df79",
           when="@20200721 +cuda")

--- a/var/spack/repos/builtin/packages/lammps/package.py
+++ b/var/spack/repos/builtin/packages/lammps/package.py
@@ -175,7 +175,7 @@ class Lammps(CMakePackage, CudaPackage):
 
     patch("lib.patch", when="@20170901")
     patch("660.patch", when="@20170922")
-    patch("gtest_fix.patch", when="@20210310 %aocc@3.2.0")
+    patch("gtest_fix.patch", when="@:20210310 %aocc@3.2.0")
     patch("https://github.com/lammps/lammps/commit/562300996285fdec4ef74542383276898555af06.patch?full_index=1",
           sha256="e6f1b62bbfdc79d632f4cea98019202d0dd25aa4ae61a70df1164cb4f290df79",
           when="@20200721 +cuda")


### PR DESCRIPTION
Observed lammps build failure with `AOCC 3.2` due to the error : 

```
In file included from tst.cpp:1:
In file included from googletest/googlemock/include/gmock/gmock.h:59:
googletest/googlemock/include/gmock/gmock-actions.h:455:3: warning: definition of implicit copy constructor for 'PolymorphicAction<testing::internal::ReturnNullAction>' is deprecated because it has a user-declared copy assignment operator
      [-Wdeprecated]
  GTEST_DISALLOW_ASSIGN_(PolymorphicAction);
  ^
googletest/googletest/include/gtest/internal/gtest-port.h:671:8: note: expanded from macro 'GTEST_DISALLOW_ASSIGN_'
  void operator=(type const &) = delete
       ^
googletest/googlemock/include/gmock/gmock-actions.h:1041:10: note: in implicit copy constructor for 'testing::PolymorphicAction<testing::internal::ReturnNullAction>' first required here
  return MakePolymorphicAction(internal::ReturnNullAction());
         ^

<snip>
```

Updating the  googletest version is solving the issue. hence raising the pull request.