### PR TITLE
e4s on mac ci: set SPACK_DISABLE_LOCAL_CONFIG=1

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -114,8 +114,7 @@ e4s-mac-pr-generate:
   extends: [".e4s-mac", ".pr"]
   stage: generate
   script:
-    - export SPACK_DISABLE_LOCAL_CONFIG=1
-    - export SPACK_USER_CACHE_PATH=$(pwd)
+    - tmp="$(mktemp -d)"; export SPACK_USER_CONFIG_PATH="$tmp"; export SPACK_USER_CACHE_PATH="$tmp"
     - . "./share/spack/setup-env.sh"
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
@@ -140,8 +139,7 @@ e4s-mac-develop-generate:
   extends: [".e4s-mac", ".develop"]
   stage: generate
   script:
-    - export SPACK_DISABLE_LOCAL_CONFIG=1
-    - export SPACK_USER_CACHE_PATH=$(pwd)
+    - tmp="$(mktemp -d)"; export SPACK_USER_CONFIG_PATH="$tmp"; export SPACK_USER_CACHE_PATH="$tmp"
     - . "./share/spack/setup-env.sh"
     - spack --version
     - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -115,12 +115,16 @@ e4s-mac-pr-generate:
   tags:
   - omicron
   timeout: 60 minutes
+  variables:
+    SPACK_DISABLE_LOCAL_CONFIG: 1
 
 e4s-mac-develop-generate:
   extends: [ ".e4s-mac", ".develop-generate"]
   tags:
   - omicron
   timeout: 60 minutes
+  variables:
+    SPACK_DISABLE_LOCAL_CONFIG: 1
 
 e4s-mac-pr-build:
   extends: [ ".e4s-mac", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -127,10 +127,6 @@ e4s-mac-pr-generate:
     paths:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags:
-  - spack
-  - public
-  - medium
-  - x86_64
   - omicron
   interruptible: true
   retry:
@@ -157,10 +153,6 @@ e4s-mac-develop-generate:
     paths:
       - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags:
-  - spack
-  - public
-  - medium
-  - x86_64
   - omicron
   interruptible: true
   retry:

--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -111,20 +111,64 @@ default:
   allow_failure: True
 
 e4s-mac-pr-generate:
-  extends: [ ".e4s-mac", ".pr-generate"]
+  extends: [".e4s-mac", ".pr"]
+  stage: generate
+  script:
+    - export SPACK_DISABLE_LOCAL_CONFIG=1
+    - export SPACK_USER_CACHE_PATH=$(pwd)
+    - . "./share/spack/setup-env.sh"
+    - spack --version
+    - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
+    - spack env activate --without-view .
+    - spack ci generate --check-index-only
+      --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
+      --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
+  artifacts:
+    paths:
+      - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags:
+  - spack
+  - public
+  - medium
+  - x86_64
   - omicron
+  interruptible: true
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
   timeout: 60 minutes
-  variables:
-    SPACK_DISABLE_LOCAL_CONFIG: 1
 
 e4s-mac-develop-generate:
-  extends: [ ".e4s-mac", ".develop-generate"]
+  extends: [".e4s-mac", ".develop"]
+  stage: generate
+  script:
+    - export SPACK_DISABLE_LOCAL_CONFIG=1
+    - export SPACK_USER_CACHE_PATH=$(pwd)
+    - . "./share/spack/setup-env.sh"
+    - spack --version
+    - cd share/spack/gitlab/cloud_pipelines/stacks/${SPACK_CI_STACK_NAME}
+    - spack env activate --without-view .
+    - spack ci generate --check-index-only
+      --artifacts-root "${CI_PROJECT_DIR}/jobs_scratch_dir"
+      --output-file "${CI_PROJECT_DIR}/jobs_scratch_dir/cloud-ci-pipeline.yml"
+  artifacts:
+    paths:
+      - "${CI_PROJECT_DIR}/jobs_scratch_dir"
   tags:
+  - spack
+  - public
+  - medium
+  - x86_64
   - omicron
+  interruptible: true
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
   timeout: 60 minutes
-  variables:
-    SPACK_DISABLE_LOCAL_CONFIG: 1
 
 e4s-mac-pr-build:
   extends: [ ".e4s-mac", ".pr-build" ]

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -35,6 +35,7 @@ spack:
 
     script:
       - export SPACK_DISABLE_LOCAL_CONFIG=1
+      - export SPACK_USER_CACHE_PATH=$(pwd)
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -17,8 +17,8 @@ spack:
 
   definitions:
   - easy_specs:
-    - kokkos +openmp
-    - kokkos-kernels +openmp
+    - berkeley-db
+    - ncurses
 
   - arch:
     - '%apple-clang@13.0.0 target=m1'

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -34,6 +34,7 @@ spack:
   gitlab-ci:
 
     script:
+      - export SPACK_DISABLE_LOCAL_CONFIG=1
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}

--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s-mac/spack.yaml
@@ -34,8 +34,7 @@ spack:
   gitlab-ci:
 
     script:
-      - export SPACK_DISABLE_LOCAL_CONFIG=1
-      - export SPACK_USER_CACHE_PATH=$(pwd)
+      - tmp="$(mktemp -d)"; export SPACK_USER_CONFIG_PATH="$tmp"; export SPACK_USER_CACHE_PATH="$tmp"
       - . "./share/spack/setup-env.sh"
       - spack --version
       - cd ${SPACK_CONCRETE_ENV_DIR}


### PR DESCRIPTION
E4S Mac jobs are run as the same user. We don't want state from one pipeline to leak into other pipelines via `~/.spack`.

@scottwittenburg @wspear