### PR TITLE
add darshan-3.4.0-pre1 release

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -25,7 +25,8 @@ class DarshanRuntime(AutotoolsPackage):
     test_requires_compiler = True
 
     version('main', branch='main', submodules=True)
-    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7')
+    version('3.4.0-pre1', sha256='57d0fd40329b9f8a51bdc9d7635b646692b341d80339115ab203357321706c09')
+    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7', preferred=True)
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')
@@ -45,6 +46,10 @@ class DarshanRuntime(AutotoolsPackage):
     depends_on('automake', type='build', when='@main')
     depends_on('libtool',  type='build', when='@main')
     depends_on('m4',       type='build', when='@main')
+    depends_on('autoconf', type='build', when='@3.4.0:')
+    depends_on('automake', type='build', when='@3.4.0:')
+    depends_on('libtool',  type='build', when='@3.4.0:')
+    depends_on('m4',       type='build', when='@3.4.0:')
 
     variant('mpi', default=True, description='Compile with MPI support')
     variant('hdf5', default=False, description='Compile with HDF5 module')

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -21,7 +21,8 @@ class DarshanUtil(AutotoolsPackage):
     tags = ['e4s']
 
     version('main', branch='main', submodules='True')
-    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7')
+    version('3.4.0-pre1', sha256='57d0fd40329b9f8a51bdc9d7635b646692b341d80339115ab203357321706c09')
+    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7', preferred=True)
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')
@@ -43,6 +44,10 @@ class DarshanUtil(AutotoolsPackage):
     depends_on('automake', type='build', when='@main')
     depends_on('libtool',  type='build', when='@main')
     depends_on('m4',       type='build', when='@main')
+    depends_on('autoconf', type='build', when='@3.4.0:')
+    depends_on('automake', type='build', when='@3.4.0:')
+    depends_on('libtool',  type='build', when='@3.4.0:')
+    depends_on('m4',       type='build', when='@3.4.0:')
 
     patch('retvoid.patch', when='@3.2.0:3.2.1')
 


### PR DESCRIPTION
This PR includes the following changes to darshan-runtime/darshan-util:

- new darshan-3.4.0-pre1 release
- making 3.3.1 preferred install for now, rather than a pre-release version of darshan
- add new autotools dependencies for all darshan versions 3.4.0+ (these mimic the dependencies we set for our `main` variant, maybe there is a way to combine them)