### PR TITLE
gitlab ci: do not override .generate tags for e4s

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
+++ b/share/spack/gitlab/cloud_pipelines/.gitlab-ci.yml
@@ -153,7 +153,6 @@ e4s-mac-develop-build:
 
 e4s-pr-generate:
   extends: [ ".e4s", ".pr-generate"]
-  tags:
 
 e4s-develop-generate:
   extends: [ ".e4s", ".develop-generate"]


### PR DESCRIPTION
This will restore the running e4s generate jobs on aws runners.