### PR TITLE
tests: fix references to hard-coded `master` branch in `git` tests

### DIFF
--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -1257,11 +1257,15 @@ def mock_git_repository(tmpdir_factory):
         |______/_____________________/
        c0 (r0)
 
-    There are two branches aside from 'master': 'test-branch' and 'tag-branch';
+    We used to test with 'master', but git has since developed the ability to
+    have differently named default branches, so now we query the user's config to
+    determine what the default branch should be.
+
+    There are two branches aside from 'default': 'test-branch' and 'tag-branch';
     each has one commit; the tag-branch has a tag referring to its commit
     (c2 in the diagram).
 
-    Two submodules are added as part of the very first commit on 'master'; each
+    Two submodules are added as part of the very first commit on 'default'; each
     of these refers to a repository with a single commit.
 
     c0, c1, and c2 include information to define explicit versions in the
@@ -1352,7 +1356,7 @@ def mock_git_repository(tmpdir_factory):
         git('-c', 'commit.gpgsign=false', 'commit', '-m', 'mock-git-repo r2')
 
         rev_hash = lambda x: git('rev-parse', x, output=str).strip()
-        r2 = rev_hash('master')
+        r2 = rev_hash(default_branch)
 
         # Record the commit hash of the (only) commit from test-branch and
         # the file added by that commit
@@ -1365,7 +1369,7 @@ def mock_git_repository(tmpdir_factory):
     # revision for the version; a file associated with (and particular to)
     # that revision/branch.
     checks = {
-        'master': Bunch(
+        'default': Bunch(
             revision=default_branch, file=r0_file, args={'git': url}
         ),
         'branch': Bunch(
@@ -1387,8 +1391,8 @@ def mock_git_repository(tmpdir_factory):
         # In this case, the version() args do not include a 'git' key:
         # this is the norm for packages, so this tests how the fetching logic
         # would most-commonly assemble a Git fetcher
-        'master-no-per-version-git': Bunch(
-            revision='master', file=r0_file, args={'branch': 'master'}
+        'default-no-per-version-git': Bunch(
+            revision=default_branch, file=r0_file, args={'branch': default_branch}
         )
     }
 

--- a/lib/spack/spack/test/git_fetch.py
+++ b/lib/spack/spack/test/git_fetch.py
@@ -83,7 +83,7 @@ def test_bad_git(tmpdir, mock_bad_git):
 
 
 @pytest.mark.parametrize("type_of_test",
-                         ['master', 'branch', 'tag', 'commit'])
+                         ['default', 'branch', 'tag', 'commit'])
 @pytest.mark.parametrize("secure", [True, False])
 def test_fetch(type_of_test,
                secure,
@@ -106,7 +106,7 @@ def test_fetch(type_of_test,
     h = mock_git_repository.hash
 
     pkg_class = spack.repo.path.get_pkg_class('git-test')
-    # This would fail using the master-no-per-version-git check but that
+    # This would fail using the default-no-per-version-git check but that
     # isn't included in this test
     monkeypatch.delattr(pkg_class, 'git')
 
@@ -156,7 +156,7 @@ def test_fetch_pkg_attr_submodule_init(
     expected branch file is present.
     """
 
-    t = mock_git_repository.checks['master-no-per-version-git']
+    t = mock_git_repository.checks['default-no-per-version-git']
     pkg_class = spack.repo.path.get_pkg_class('git-test')
     # For this test, the version args don't specify 'git' (which is
     # the majority of version specifications)


### PR DESCRIPTION
Some of our `git` tests still fail when `init.defaultBranch` is set to something other than `master`.

- [x] get rid of all hard-coded `master` refs
- [x] Use `'default'` to key tests that use the default branch