### PR TITLE
depend on gettext in subversion when +nls is enabled

### DIFF
--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -34,7 +34,7 @@ class Subversion(AutotoolsPackage):
 
     variant('serf', default=True,  description='Serf HTTP client library')
     variant('perl', default=False, description='Build with Perl bindings')
-    variant('gettext', default=True, description='Build with gettext functionality')
+    variant('nls', default=True, description='Enable Native Language Support')
 
     depends_on('apr')
     depends_on('apr-util')
@@ -44,7 +44,7 @@ class Subversion(AutotoolsPackage):
     depends_on('lz4', when='@1.10:')
     depends_on('utf8proc', when='@1.10:')
     depends_on('serf', when='+serf')
-    depends_on('gettext', when='+gettext')
+    depends_on('gettext', when='+nls')
 
     extends('perl', when='+perl')
     depends_on('swig@1.3.24:3.0.0', when='+perl')
@@ -95,10 +95,11 @@ class Subversion(AutotoolsPackage):
         if '+perl' in spec:
             args.append('PERL={0}'.format(spec['perl'].command.path))
 
-        if '+gettext' in spec:
+        if '+nls' in spec:
             args.extend([
                 'LDFLAGS=-L{0}'.format(spec['gettext'].prefix.lib),
                 'LIBS=-lintl',
+                '--enable-nls',
             ])
         else:
             args.append('--disable-nls')

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -32,6 +32,7 @@ class Subversion(AutotoolsPackage):
 
     variant('serf', default=True,  description='Serf HTTP client library')
     variant('perl', default=False, description='Build with Perl bindings')
+    variant('gettext', default=True, description='Build with gettext functionality')
 
     depends_on('apr')
     depends_on('apr-util')
@@ -41,6 +42,7 @@ class Subversion(AutotoolsPackage):
     depends_on('lz4', when='@1.10:')
     depends_on('utf8proc', when='@1.10:')
     depends_on('serf', when='+serf')
+    depends_on('gettext', when='+gettext')
 
     extends('perl', when='+perl')
     depends_on('swig@1.3.24:3.0.0', when='+perl')
@@ -90,6 +92,14 @@ class Subversion(AutotoolsPackage):
 
         if '+perl' in spec:
             args.append('PERL={0}'.format(spec['perl'].command.path))
+
+        if '+gettext' in spec:
+            args.extend([
+                'LDFLAGS=-L{0}'.format(spec['gettext'].prefix.lib),
+                'LIBS=-lintl',
+            ])
+        else:
+            args.append('--disable-nls')
 
         return args
 

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -17,6 +17,8 @@ class Subversion(AutotoolsPackage):
         'https://downloads.apache.org/subversion/subversion-1.13.0.tar.gz'
     ]
 
+    maintainers = ['cosmicexplorer']
+
     tags = ['build-tools']
 
     version('1.14.1', sha256='dee2796abaa1f5351e6cc2a60b1917beb8238af548b20d3e1ec22760ab2f0cad')

--- a/var/spack/repos/builtin/packages/subversion/package.py
+++ b/var/spack/repos/builtin/packages/subversion/package.py
@@ -97,7 +97,10 @@ class Subversion(AutotoolsPackage):
 
         if '+nls' in spec:
             args.extend([
-                'LDFLAGS=-L{0}'.format(spec['gettext'].prefix.lib),
+                'LDFLAGS={0}'.format(spec['gettext'].libs.search_flags),
+                # Using .libs.link_flags is the canonical way to add these arguments,
+                # but since libintl is much smaller than the rest and also the only
+                # necessary one, we specify it by hand here.
                 'LIBS=-lintl',
                 '--enable-nls',
             ])


### PR DESCRIPTION
### Problem

Subversion fails to link under my alpine linux installation:
```
> spack install --verbose subversion
...
  >> 844    /tmp/cosmicexplorer/spack-stage/spack-stage-subversion-1.14.1-vttdrtc4pe3rrzb3gykjhzhk57xinw2k/spack-src/subversion/libsvn_subr/opt.c:1
            77: undefined reference to `libintl_dgettext'
...
```

I would be surprised if this was a result of alpine using musl libc, so I'm not sure why this isn't failing already on other OSes.

### Solution
- Add `+nls` variant which adds `--disable-nls` to the configure args when disabled, and `--enable-nls LDFLAGS=-L... LDLIBS=-lintl` when enabled.

### Result
`spack install subversion` and `spack install subversion~nls` both work!