### PR TITLE
bugfix: `spack pkg list` should be more picky about what's a package

### DIFF
--- a/lib/spack/spack/repo.py
+++ b/lib/spack/spack/repo.py
@@ -355,9 +355,17 @@ def list_packages(rev):
         ref = rev.replace('...', '')
         rev = git('merge-base', ref, 'HEAD', output=str).strip()
 
-    output = git('ls-tree', '--name-only', rev, output=str)
-    return sorted(line for line in output.split('\n')
-                  if line and not line.startswith('.'))
+    output = git('ls-tree', '-r', '--name-only', rev, output=str)
+
+    # recursively list the packages directory
+    package_paths = [
+        line.split(os.sep) for line in output.split("\n") if line.endswith("package.py")
+    ]
+
+    # take the directory names with one-level-deep package files
+    package_names = sorted(set([line[0] for line in package_paths if len(line) == 2]))
+
+    return package_names
 
 
 def diff_packages(rev1, rev2):


### PR DESCRIPTION
`spack pkg list` tests were broken by #29593 for cases when your `builtin.mock` repo still has stale backup files (or, really, stale directories) sitting around. This happens if you switch branches a lot.  In this case, things like this were causing erroneous packages in the mock listing:

```
var/spack/repos/builtin.mock/packages/
    foo/
        package.py~
```

Or, really, the test was already broken, but worked because Spack's `.gitignore` has `*~` in it.

- [x] make `list_packages` consider only directories with one-deep `package.py` files.