### PR TITLE
Ascent/Conduit: Guard against SPACK_FC possibly not being defined

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -303,7 +303,10 @@ class Ascent(CMakePackage, CudaPackage):
         #######################
         c_compiler = env["SPACK_CC"]
         cpp_compiler = env["SPACK_CXX"]
-        f_compiler = env["SPACK_FC"]
+        if "+fortran" in spec:
+            f_compiler = env["SPACK_FC"]
+        else:
+            f_compiler = None
 
         #######################################################################
         # Directly fetch the names of the actual compilers to create a

--- a/var/spack/repos/builtin/packages/conduit/package.py
+++ b/var/spack/repos/builtin/packages/conduit/package.py
@@ -287,7 +287,10 @@ class Conduit(CMakePackage):
         #######################
         c_compiler = env["SPACK_CC"]
         cpp_compiler = env["SPACK_CXX"]
-        f_compiler = env["SPACK_FC"]
+        if "+fortran" in spec:
+            f_compiler = env["SPACK_FC"]
+        else:
+            f_compiler = None
 
         #######################################################################
         # Directly fetch the names of the actual compilers to create a


### PR DESCRIPTION
Axom has a compiler spec (due to user request) that does not specify a fortran compiler.  This stops Conduit and Ascent from throwing a KeyError exception.