### PR TITLE
ROCmPackage: unify amdgpu_targets

### DIFF
--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -90,9 +90,10 @@ class ROCmPackage(PackageBase):
     # https://llvm.org/docs/AMDGPUUsage.html
     # Possible architectures
     amdgpu_targets = (
-        'gfx701', 'gfx801', 'gfx802', 'gfx803',
-        'gfx900', 'gfx906', 'gfx908', 'gfx90a', 'gfx1010',
-        'gfx1011', 'gfx1012'
+        'gfx701', 'gfx801', 'gfx802', 'gfx803', 'gfx900',
+        'gfx906', 'gfx908', 'gfx90a',
+        'gfx906:xnack-', 'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
+        'gfx1010', 'gfx1011', 'gfx1012', 'gfx1030',
     )
 
     variant('rocm', default=False, description='Enable ROCm support')

--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -90,10 +90,10 @@ class ROCmPackage(PackageBase):
     # https://llvm.org/docs/AMDGPUUsage.html
     # Possible architectures
     amdgpu_targets = (
-        'gfx701', 'gfx801', 'gfx802', 'gfx803', 'gfx900',
+        'gfx701', 'gfx801', 'gfx802', 'gfx803', 'gfx900', 'gfx900:xnack-',
         'gfx906', 'gfx908', 'gfx90a',
         'gfx906:xnack-', 'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
-        'gfx1010', 'gfx1011', 'gfx1012', 'gfx1030',
+        'gfx1010', 'gfx1011', 'gfx1012', 'gfx1030', 'gfx1031',
     )
 
     variant('rocm', default=False, description='Enable ROCm support')

--- a/var/spack/repos/builtin/packages/rccl/package.py
+++ b/var/spack/repos/builtin/packages/rccl/package.py
@@ -38,9 +38,7 @@ class Rccl(CMakePackage):
     version('3.7.0', sha256='8273878ff71aac2e7adf5cc8562d2933034c6c6b3652f88fbe3cd4f2691036e3', deprecated=True)
     version('3.5.0', sha256='290b57a66758dce47d0bfff3f5f8317df24764e858af67f60ddcdcadb9337253', deprecated=True)
 
-    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-',
-                      'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
-                      'gfx1030')
+    amdgpu_targets = ROCmPackage.amdgpu_targets
 
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -40,9 +40,7 @@ class Rocalution(CMakePackage):
     version('3.7.0', sha256='4d6b20aaaac3bafb7ec084d684417bf578349203b0f9f54168f669e3ec5699f8', deprecated=True)
     version('3.5.0', sha256='be2f78c10c100d7fd9df5dd2403a44700219c2cbabaacf2ea50a6e2241df7bfe', deprecated=True)
 
-    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-',
-                      'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
-                      'gfx1030')
+    amdgpu_targets = ROCmPackage.amdgpu_targets
 
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -6,7 +6,6 @@
 import re
 
 from spack.package import *
-from spack.build_systems.rocm import ROCmPackage
 
 
 class Rocblas(CMakePackage):

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -6,6 +6,7 @@
 import re
 
 from spack.package import *
+from spack.build_systems.rocm import ROCmPackage
 
 
 class Rocblas(CMakePackage):
@@ -37,10 +38,7 @@ class Rocblas(CMakePackage):
     version('3.7.0', sha256='9425db5f8e8b6f7fb172d09e2a360025b63a4e54414607709efc5acb28819642', deprecated=True)
     version('3.5.0', sha256='8560fabef7f13e8d67da997de2295399f6ec595edfd77e452978c140d5f936f0', deprecated=True)
 
-    amdgpu_targets = ('gfx906', 'gfx908', 'gfx803', 'gfx900',
-                      'gfx906:xnack-', 'gfx908:xnack-', 'gfx90a:xnack+',
-                      'gfx90a:xnack-', 'gfx1010', 'gfx1011',
-                      'gfx1012', 'gfx1030')
+    amdgpu_targets = ROCmPackage.amdgpu_targets
 
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('tensile', default=True, description='Use Tensile as a backend')

--- a/var/spack/repos/builtin/packages/rocfft/package.py
+++ b/var/spack/repos/builtin/packages/rocfft/package.py
@@ -35,11 +35,7 @@ class Rocfft(CMakePackage):
     version('3.7.0', sha256='94462e4bd19c2c749fcf6903adbee66d4d3bd345c0246861ff8f40b9d08a6ead', deprecated=True)
     version('3.5.0', sha256='629f02cfecb7de5ad2517b6a8aac6ed4de60d3a9c620413c4d9db46081ac2c88', deprecated=True)
 
-    amdgpu_targets = (
-        'gfx701', 'gfx801', 'gfx802', 'gfx803',
-        'gfx900', 'gfx906', 'gfx908', 'gfx1010',
-        'gfx1011', 'gfx1012'
-    )
+    amdgpu_targets = ROCmPackage.amdgpu_targets
 
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))

--- a/var/spack/repos/builtin/packages/rocprim/package.py
+++ b/var/spack/repos/builtin/packages/rocprim/package.py
@@ -32,9 +32,7 @@ class Rocprim(CMakePackage):
     version('3.7.0', sha256='225209a0cbd003c241821c8a9192cec5c07c7f1a6ab7da296305fc69f5f6d365', deprecated=True)
     version('3.5.0', sha256='29302dbeb27ae88632aa1be43a721f03e7e597c329602f9ca9c9c530c1def40d', deprecated=True)
 
-    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-',
-                      'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
-                      'gfx1030')
+    amdgpu_targets = ROCmPackage.amdgpu_targets
 
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')

--- a/var/spack/repos/builtin/packages/rocrand/package.py
+++ b/var/spack/repos/builtin/packages/rocrand/package.py
@@ -38,9 +38,7 @@ class Rocrand(CMakePackage):
     version('3.7.0', sha256='5e43fe07afe2c7327a692b3b580875bae6e6ee790e044c053fffafbfcbc14860', deprecated=True)
     version('3.5.0', sha256='592865a45e7ef55ad9d7eddc8082df69eacfd2c1f3e9c57810eb336b15cd5732', deprecated=True)
 
-    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-', 'gfx908:xnack-',
-                      'gfx90a:xnack-', 'gfx90a:xnack+',
-                      'gfx1030')
+    amdgpu_targets = ROCmPackage.amdgpu_targets
 
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -7,7 +7,6 @@ import itertools
 import re
 
 from spack.package import *
-from spack.build_systems.rocm import ROCmPackage
 
 
 class Rocsolver(CMakePackage):

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -7,6 +7,7 @@ import itertools
 import re
 
 from spack.package import *
+from spack.build_systems.rocm import ROCmPackage
 
 
 class Rocsolver(CMakePackage):
@@ -20,10 +21,8 @@ class Rocsolver(CMakePackage):
     maintainers = ['cgmb', 'srekolam', 'arjun-raj-kuppala', 'haampie']
     libraries = ['librocsolver']
 
-    amdgpu_targets = (
-        'gfx803', 'gfx900', 'gfx906:xnack-', 'gfx908:xnack-',
-        'gfx90a:xnack-', 'gfx90a:xnack+', 'gfx1010', 'gfx1011', 'gfx1012', 'gfx1030'
-    )
+    amdgpu_targets = ROCmPackage.amdgpu_targets
+
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('optimal', default=True,
             description='This option improves performance at the cost of increased binary \

--- a/var/spack/repos/builtin/packages/rocsparse/package.py
+++ b/var/spack/repos/builtin/packages/rocsparse/package.py
@@ -23,9 +23,7 @@ class Rocsparse(CMakePackage):
     maintainers = ['srekolam', 'arjun-raj-kuppala']
     libraries = ['librocsparse']
 
-    amdgpu_targets = ('gfx803', 'gfx900:xnack-', 'gfx906:xnack-', 'gfx908:xnack-',
-                      'gfx90a:xnack-', 'gfx90a:xnack+',
-                      'gfx1030')
+    amdgpu_targets = ROCmPackage.amdgpu_targets
 
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('build_type', default='Release', values=("Release", "Debug", "RelWithDebInfo"), description='CMake build type')


### PR DESCRIPTION
About ROCm packages, it is a good general practice to inherit from `ROCmPackage`, which provides `rocm` and `amdgpu_targets` variant. For the latter one it also provides a defined set of valid AMD GPU targets values.

In some packages like `rocblas` and `rocsolver`, the `rocm` variant does not make much sense, so they manually specify the other variant together with a set of valid AMD GPU targets.

This triggers a maintenance problem. Indeed, for these packages the set of valid architectures has to be maintained manually, which is costly and error-prone.

This PR is a proposal to do it in a slightly different way, so that the set of valid targets is defined in a single place. I started with just `rocblas` and `rocsolver`, but if you agree on this style, I can also adapt others