### PR TITLE
Add Tracy packages

### DIFF
--- a/var/spack/repos/builtin/packages/glfw/package.py
+++ b/var/spack/repos/builtin/packages/glfw/package.py
@@ -27,6 +27,7 @@ class Glfw(CMakePackage):
     version('3.0.3', sha256='7a182047ba6b1fdcda778b79aac249bb2328b6d141188cb5df29560715d01693')
 
     variant("doc", default=False, description="Build documentation")
+    variant("shared", default=False, description="Builds a shared version of the library")
 
     # dependencies
     depends_on('doxygen', type='build', when="+doc")
@@ -42,3 +43,6 @@ class Glfw(CMakePackage):
     depends_on('freetype', when='platform=linux')
     depends_on('fontconfig', when='platform=linux')
     depends_on('pkgconfig', type='build', when='platform=linux')
+
+    def cmake_args(self):
+        return [self.define_from_variant("BUILD_SHARED_LIBS", "shared")]

--- a/var/spack/repos/builtin/packages/tracy-client/package.py
+++ b/var/spack/repos/builtin/packages/tracy-client/package.py
@@ -1,0 +1,77 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class TracyClient(CMakePackage):
+    """A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling
+    profiler for games and other applications. Client library."""
+
+    homepage = "https://github.com/wolfpld/tracy"
+    url = "https://github.com/wolfpld/tracy/archive/v0.0.0.tar.gz"
+    maintainers = ["msimberg"]
+
+    version("master", git="https://github.com/wolfpld/tracy.git", branch="master")
+    version(
+        "0.8.1",
+        sha256="004992012b2dc879a9f6d143cbf94d7ea30e88135db3ef08951605d214892891",
+    )
+
+    variant(
+        "shared",
+        default=True,
+        description="Build the client library as a shared library",
+    )
+
+    variants = {
+        "enable": (True, "Enable profiling"),
+        "on_demand": (False, "On-demand profiling"),
+        "callstack": (False, "Enfore callstack collection for tracy regions"),
+        "no_callstack": (False, "Disable all callstack related functionality"),
+        "no_callstack_inlines": (False, "Disables the inline functions in callstacks"),
+        "only_localhost": (False, "Only listen on the localhost interface"),
+        "no_broadcast": (
+            False,
+            "Disable client discovery by broadcast to local network",
+        ),
+        "only_ipv4": (
+            False,
+            "Tracy will only accept connections on IPv4 addresses (disable IPv6)",
+        ),
+        "no_code_transfer": (False, "Disable collection of source code"),
+        "no_context_switch": (False, "Disable capture of context switches"),
+        "no_exit": (
+            False,
+            "Client executable does not exit until all profile data is sent to server",
+        ),
+        "no_sampling": (False, "Disable call stack sampling"),
+        "no_verify": (False, "Disable zone validation for C API"),
+        "no_vsync_capture": (False, "Disable capture of hardware Vsync events"),
+        "no_frame_image": (False, "Disable the frame image support and its thread"),
+        "no_system_tracing": (False, "Disable systrace sampling"),
+        "delayed_init": (
+            False,
+            "Enable delayed initialization of the library (init on first call)",
+        ),
+        "manual_lifetime": (
+            False,
+            "Enable the manual lifetime management of the profile",
+        ),
+        "fibers": (False, "Enable fibers support"),
+        "no_crash_handler": (False, "Disable crash handling"),
+        "timer_fallback": (False, "Use lower resolution timers"),
+    }
+
+    for k, v in variants.items():
+        variant(k, default=v[0], description=v[1])
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("TRACY_%s" + k.upper(), v[0])
+            for k, v in variants.items()
+        ]
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        return args

--- a/var/spack/repos/builtin/packages/tracy/package.py
+++ b/var/spack/repos/builtin/packages/tracy/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class Tracy(MakefilePackage):
+    """A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling
+    profiler for games and other applications. Server applications."""
+
+    homepage = "https://github.com/wolfpld/tracy"
+    url = "https://github.com/wolfpld/tracy/archive/v0.0.0.tar.gz"
+    maintainers = ["msimberg"]
+
+    version("master", git="https://github.com/wolfpld/tracy.git", branch="master")
+    version(
+        "0.8.1",
+        sha256="004992012b2dc879a9f6d143cbf94d7ea30e88135db3ef08951605d214892891",
+    )
+
+    depends_on("capstone")
+    depends_on("dbus")
+    depends_on("freetype")
+    # Linking fails unless glfw is built as a shared library:
+    # https://github.com/wolfpld/tracy/issues/110
+    depends_on("glfw +shared")
+
+    def build(self, spec, prefix):
+        with working_dir(join_path(self.build_directory, "capture/build/unix")):
+            make()
+
+        with working_dir(join_path(self.build_directory, "profiler/build/unix")):
+            make()
+
+    def install(self, spec, prefix):
+        mkdir(prefix.bin)
+        install(
+            join_path(self.build_directory, "capture/build/unix/capture-release"),
+            prefix.bin,
+        )
+        install(
+            join_path(self.build_directory, "profiler/build/unix/Tracy-release"),
+            prefix.bin,
+        )


### PR DESCRIPTION
This adds two packages for Tracy (https://github.com/wolfpld/tracy):

- `tracy-client` is the client-side integration library required for instrumenting an application. This has no dependencies and can be used without building the full GUI. This can be built with CMake.
- `tracy` is the GUI profiler application, and the command-line capture tool. This has a lot of dependencies so it's nice to have this separately. In addition, the server can run on another node and may never be built together with the client library. This is built with make.

For `tracy-client` I've added all the CMake options from https://github.com/wolfpld/tracy/blob/8af7060a691a6500afe5a9bd44c7dab80bd4a281/CMakeLists.txt#L36-L57, including the trivial `TRACY_ENABLE` option. I've kept the negation in the variants for the options that are negated just to keep things synchronized, though I don't necessarily love the `TRACY_NO_X` options. The defaults are the same as in Tracy's `CMakeLists.txt`.

I've also added a `shared` variant to `glfw` because of an issue in Tracy/glfw/something else (https://github.com/wolfpld/tracy/issues/110). I'm a bit unsure who is causing problems there... `tracy` uses `glfw +shared` because of this.

If someone wants to try this out keep in mind that an issue for `mesa` (https://github.com/spack/spack/issues/29994) means that `tracy` needs to be installed with `tracy ^mesa ~llvm`.