### PR TITLE
py-netcdf4: add v1.5.8

### DIFF
--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -14,17 +14,21 @@ class PyNetcdf4(PythonPackage):
 
     maintainers = ['skosukhin']
 
+    version('1.5.8',   sha256='ca3d468f4812c0999df86e3f428851fb0c17ac34ce0827115c246b0b690e4e84')
     version('1.5.3',   sha256='2a3ca855848f4bbf07fac366da77a681fcead18c0a8813d91d46302f562dc3be')
     version('1.4.2',   sha256='b934af350459cf9041bcdf5472e2aa56ed7321c018d918e9f325ec9a1f9d1a30')
     version('1.2.7',   sha256='0c449b60183ee06238a8f9a75de7b0eed3acaa7a374952ff9f1ff06beb8f94ba')
     version('1.2.3.1', sha256='55edd74ef9aabb1f7d1ea3ffbab9c555da2a95632a97f91c0242281dc5eb919f')
+
     variant("mpi", default=True, description="Parallel IO support")
 
     depends_on('py-setuptools',   type='build')
-    depends_on('py-cython@0.19:', type='build')
+    depends_on('py-setuptools@18:', when='@1.2.9:', type='build')
+    depends_on('py-cython@0.19:', when='@1.2.8:', type='build')
 
     depends_on('py-numpy@1.7:', type=('build', 'run'))
-    depends_on('py-cftime', type=('build', 'run'))
+    depends_on('py-numpy@1.9:', when='@1.5.4:', type=('build', 'run'))
+    depends_on('py-cftime', when='@1.4:', type=('build', 'run'))
     depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
 
     depends_on('netcdf-c', when='-mpi')

--- a/var/spack/repos/builtin/packages/py-netcdf4/package.py
+++ b/var/spack/repos/builtin/packages/py-netcdf4/package.py
@@ -22,12 +22,18 @@ class PyNetcdf4(PythonPackage):
 
     variant("mpi", default=True, description="Parallel IO support")
 
+    depends_on('python@:3.6', when='@:1.2.4', type=('build', 'link', 'run'))
+    depends_on('python@2.6:2.7,3.3:3.6', when='@1.2.5:1.2.7', type=('build', 'link', 'run'))
+    depends_on('python@2.6:2.7,3.3:', when='@1.2.8:1.5.1', type=('build', 'link', 'run'))
+    depends_on('python@2.7,3.5:', when='@1.5.2:1.5.3', type=('build', 'link', 'run'))
+    depends_on('python@3.6:', when='@1.5.4:', type=('build', 'link', 'run'))
+
     depends_on('py-setuptools',   type='build')
     depends_on('py-setuptools@18:', when='@1.2.9:', type='build')
     depends_on('py-cython@0.19:', when='@1.2.8:', type='build')
 
-    depends_on('py-numpy@1.7:', type=('build', 'run'))
-    depends_on('py-numpy@1.9:', when='@1.5.4:', type=('build', 'run'))
+    depends_on('py-numpy@1.7:', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.9:', when='@1.5.4:', type=('build', 'link', 'run'))
     depends_on('py-cftime', when='@1.4:', type=('build', 'run'))
     depends_on('py-mpi4py', when='+mpi', type=('build', 'run'))
 


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Python 3.9.12 and Apple Clang 12.0.0.