### PR TITLE
added libffi as dependence for gobject-introspection

### DIFF
--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -27,6 +27,9 @@ class GobjectIntrospection(Package):
     depends_on("bison", type="build")
     depends_on("flex", type="build")
     depends_on("pkgconfig", type="build")
+    depends_on('libffi')
+    depends_on('libffi@:3.3', when='@:1.70') # libffi 3.4 was causing seg faults
+    # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
 
     # GobjectIntrospection does not build with sed from darwin:
     depends_on('sed', when='platform=darwin', type='build')

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -28,8 +28,8 @@ class GobjectIntrospection(Package):
     depends_on("flex", type="build")
     depends_on("pkgconfig", type="build")
     depends_on('libffi')
-    depends_on('libffi@:3.3', when='@:1.70') # libffi 3.4 was causing seg faults
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
+    depends_on('libffi@:3.3', when='@:1.70') # libffi 3.4 was causing seg faults
 
     # GobjectIntrospection does not build with sed from darwin:
     depends_on('sed', when='platform=darwin', type='build')

--- a/var/spack/repos/builtin/packages/gobject-introspection/package.py
+++ b/var/spack/repos/builtin/packages/gobject-introspection/package.py
@@ -29,7 +29,7 @@ class GobjectIntrospection(Package):
     depends_on("pkgconfig", type="build")
     depends_on('libffi')
     # https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283
-    depends_on('libffi@:3.3', when='@:1.70') # libffi 3.4 was causing seg faults
+    depends_on('libffi@:3.3', when='@:1.70')  # libffi 3.4 caused seg faults
 
     # GobjectIntrospection does not build with sed from darwin:
     depends_on('sed', when='platform=darwin', type='build')


### PR DESCRIPTION
A more precise PR in lieu of https://github.com/spack/spack/pull/30595.

The Spack build of STAT's GUI was seg faulting. This is due to https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/283. Rolling back glib's dependence on libffi to version :3.3 resolves the seg fault.

Fixes https://github.com/LLNL/STAT/issues/42