### PR TITLE
libxkbcommon: fixing compilation error with gcc12

### DIFF
--- a/var/spack/repos/builtin/packages/libxkbcommon/package.py
+++ b/var/spack/repos/builtin/packages/libxkbcommon/package.py
@@ -29,3 +29,9 @@ class Libxkbcommon(AutotoolsPackage):
         return [
             '--with-xkb-config-root={0}'.format(self.spec['xkbdata'].prefix)
         ]
+
+    def flag_handler(self, name, flags):
+        if self.spec.satisfies('%gcc@12.1.0') and name.lower() == 'cflags':
+            flags.append('-Wno-error=array-bounds')
+        print(flags)
+        return (None, None, flags)


### PR DESCRIPTION
Pretty sure this is bug in gcc12, but seeing a lot of the following in this with gcc12 (should have just stuck with 11)
```
>> 491    src/xkbcomp/ast-build.c:79:23: error: array subscript 'ExprDef[0]' is partly outside array bounds of 'unsigned char[32]' [-Werror=array-bounds]    
     492       79 |     expr->common.type = STMT_EXPR;                                                                                                         
     493          |     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~                                                                                                          
     494    src/xkbcomp/ast-build.c:75:21: note: object of size 32 allocated by 'malloc'
     495       75 |     ExprDef *expr = malloc(size);
```

These packages probably need updating too, but at the very least this one has switched to meson, so it'd be a little involved.