### PR TITLE
last: updating to 1282

### DIFF
--- a/var/spack/repos/builtin/packages/last/package.py
+++ b/var/spack/repos/builtin/packages/last/package.py
@@ -13,8 +13,19 @@ class Last(MakefilePackage):
 
     homepage = "http://last.cbrc.jp/"
     url      = "http://last.cbrc.jp/last-869.zip"
+    git      = "https://gitlab.com/mcfrith/last.git"
+    maintainers = ['snehring']
 
+    version('1282', commit='4368be912f4759e52b549940276f1adf087f489a')
     version('869', sha256='6371a6282bc1bb02a5e5013cc463625f2ce3e7746ff2ea0bdf9fe6b15605a67c')
+
+    def edit(self, spec, prefix):
+        files = ['mat-doc.sh', 'mat-inc.sh', 'seed-doc.sh', 'seed-inc.sh']
+        if spec.satisfies('@1282:'):
+            files.append('gc-inc.sh')
+        with working_dir('build'):
+            for f in files:
+                set_executable(f)
 
     def install(self, spec, prefix):
         make('install', 'prefix=%s' % prefix)


### PR DESCRIPTION
Updates to the latest release from the git repo, also explicitly sets some of the scripts that are called by the makefile executable so they'll run at install.