### PR TITLE
SDK: Remove extra specs from ascent.

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -125,7 +125,7 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     dav_sdk_depends_on('sensei@develop +vtkio +python ~miniapps', when='+sensei',
                        propagate=dict(propagate_to_sensei))
 
-    dav_sdk_depends_on('ascent+mpi+fortran+openmp+python+shared+vtkh+dray~test',
+    dav_sdk_depends_on('ascent+mpi+openmp+shared+vtkh+dray',
                        when='+ascent',
                        propagate=['adios2', 'cuda'] + cuda_arch_variants)
     # Need to explicitly turn off conduit hdf5_compat in order to build


### PR DESCRIPTION
Python and Fortran modules for ascent have issues on some systems (tested on crusher).

@cyrush FYI. I was testing on crusher and finding MPI's fortran module file failed. I think it is related to that BLT stuff, but I had forgotten about it until just now, so I will go back and verify tomorrow. The python module thing was failing from conduit. I didn't dig much into it, but I wonder if it is another one that is silently disabled somehow.