### PR TITLE
py-pyfr: Add v1.14.0, add LIBXSMM variant

### DIFF
--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -64,8 +64,9 @@ class Libxsmm(MakefilePackage):
             description='With header-only installation')
     variant('generator', default=False,
             description='With generator executable(s)')
-    variant('noblas', default=False,
-            description='LIBXSMM without GEMM-related functionality')
+    variant('BLAS', default='default', multi=False,
+            description='Control behavior of BLAS calls',
+            values=('default', '0', '1', '2'))
     variant('CODE_BUF_MAXSIZE', default=0, multi=False,
             description='Max. size of JIT-buffer',
             values=('0', '262144'))
@@ -101,8 +102,9 @@ class Libxsmm(MakefilePackage):
             make_args += ['DBG=1']
             make_args += ['TRACE=1']
 
-        if '+noblas' in spec:
-            make_args += ['BLAS=0']
+        blas_val = spec.variants['BLAS'].value
+        if blas_val != 'default':
+            make_args += ['BLAS={0}'.format(blas_val)]
 
         if '+shared' in spec:
             make(*(make_args + ['STATIC=0']))

--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -64,6 +64,11 @@ class Libxsmm(MakefilePackage):
             description='With header-only installation')
     variant('generator', default=False,
             description='With generator executable(s)')
+    variant('noblas', default=False,
+            description='LIBXSMM without GEMM-related functionality')
+    variant('CODE_BUF_MAXSIZE', default=0, multi=False,
+            description='Max. size of JIT-buffer',
+            values=('0', '262144'))
     conflicts('+header-only', when='@:1.6.2',
               msg='Header-only is available since v1.6.2!')
     depends_on('python', type='build')
@@ -84,6 +89,7 @@ class Libxsmm(MakefilePackage):
             'CXX={0}'.format(spack_cxx),
             'FC={0}'.format(spack_fc),
             'PREFIX=%s' % prefix,
+            'CODE_BUF_MAXSIZE={0}'.format(spec.variants["CODE_BUF_MAXSIZE"].value),
             'SYM=1'
         ]
 
@@ -94,6 +100,9 @@ class Libxsmm(MakefilePackage):
         if '+debug' in spec:
             make_args += ['DBG=1']
             make_args += ['TRACE=1']
+
+        if '+noblas' in spec:
+            make_args += ['BLAS=0']
 
         if '+shared' in spec:
             make(*(make_args + ['STATIC=0']))

--- a/var/spack/repos/builtin/packages/libxsmm/package.py
+++ b/var/spack/repos/builtin/packages/libxsmm/package.py
@@ -60,19 +60,15 @@ class Libxsmm(MakefilePackage):
             description='With shared libraries (and static libraries).')
     variant('debug', default=False,
             description='With call-trace (LIBXSMM_TRACE); unoptimized.')
-    variant('header-only', default=False,
+    variant('header-only', default=False, when='@1.6.2:',
             description='With header-only installation')
     variant('generator', default=False,
             description='With generator executable(s)')
     variant('blas', default='default', multi=False,
             description='Control behavior of BLAS calls',
             values=('default', '0', '1', '2'))
-    variant('large_jit_buffer', default=False,
+    variant('large_jit_buffer', default=False, when='@1.17:',
             description='Max. JIT buffer size increased to 256 KiB')
-    conflicts('+header-only', when='@:1.6.2',
-              msg='Header-only is available since v1.6.2!')
-    conflicts('+large_jit_buffer', when='@:1.17',
-              msg='large_jit_buffer is available since v1.17!')
     depends_on('python', type='build')
 
     @property

--- a/var/spack/repos/builtin/packages/py-gimmik/package.py
+++ b/var/spack/repos/builtin/packages/py-gimmik/package.py
@@ -15,7 +15,7 @@ class PyGimmik(PythonPackage):
     homepage = "https://github.com/PyFR/GiMMiK"
     pypi = "gimmik/gimmik-2.2.tar.gz"
 
-    maintainers = ["michaellaufer"]
+    maintainers = ["MichaelLaufer"]
 
     version(
         "2.3", sha256="c019c85316bcf0d5e84de9b7d10127355dfe8037c0e37f1880a9819ce92b74e1"

--- a/var/spack/repos/builtin/packages/py-gimmik/package.py
+++ b/var/spack/repos/builtin/packages/py-gimmik/package.py
@@ -18,6 +18,9 @@ class PyGimmik(PythonPackage):
     maintainers = ["michaellaufer"]
 
     version(
+        "2.3", sha256="c019c85316bcf0d5e84de9b7d10127355dfe8037c0e37f1880a9819ce92b74e1"
+    )
+    version(
         "2.2", sha256="9144640f94aab92f9c5dfcaf16885a79428ab97337cf503a4b2dddeb870f3cf0"
     )
 

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -23,6 +23,10 @@ class PyPyfr(PythonPackage):
 
     # pypi releases
     version(
+        "1.14.0",
+        sha256="ebf40ce0896cce9ac802e03fd9430b5be30ea837c31224531a6d5fd68f820766",
+    )
+    version(
         "1.13.0",
         sha256="ac6ecec738d4e23799ab8c50dea9bdbd7d37bc971bd33f22720c5a230b8e7b2f",
     )
@@ -31,11 +35,13 @@ class PyPyfr(PythonPackage):
     variant("scotch", default=False, description="Scotch for mesh partitioning")
     variant("cuda", default=False, description="CUDA backend support")
     variant("hip", default=False, description="HIP backend support")
+    variant("libxsmm", default=True, description="LIBXSMM for OpenMP backend")
 
     # Required dependencies
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-gimmik@2.2:2", type=('build', 'run'))
+    depends_on("py-gimmik@2.3:", when='@1.14.0:', type=('build', 'run'))
     depends_on("py-h5py@2.10:", type=('build', 'run'))
     depends_on("py-mako@1.0.0:", type=('build', 'run'))
     depends_on("py-mpi4py@3.1.0:", type=('build', 'run'))
@@ -44,8 +50,9 @@ class PyPyfr(PythonPackage):
     depends_on("py-pytools@2016.2.1:", type=('build', 'run'))
     depends_on("py-scipy", type=('build', 'run'))
 
-    # Optional  dependecies
+    # Optional dependecies
     depends_on("metis@5.0:", when="+metis", type=('run'))
     depends_on("scotch@6.0:", when="+scotch", type=('run'))
     depends_on("cuda@8.0:", when="+cuda", type=('run'))
     depends_on("rocblas@4.5.0:", when="+hip", type=('run'))
+    depends_on("libxsmm@master+shared +noblas CODE_BUF_MAXSIZE=262144", when="+libxsmm", type=('run'))

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -15,7 +15,7 @@ class PyPyfr(PythonPackage):
     homepage = "http://www.pyfr.org/"
     pypi = "pyfr/pyfr-1.13.0.tar.gz"
     git = "https://github.com/PyFR/PyFR/"
-    maintainers = ["michaellaufer"]
+    maintainers = ["MichaelLaufer"]
 
     # git branches
     version("develop", branch="develop")
@@ -36,23 +36,23 @@ class PyPyfr(PythonPackage):
     variant("cuda", default=False, description="CUDA backend support")
     variant("hip", default=False, description="HIP backend support")
     variant("libxsmm", default=True, description="LIBXSMM for OpenMP backend")
+    variant("scipy", default=True, description="Scipy acceleration for point sampling")
 
     # Required dependencies
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
     depends_on("py-gimmik@2.2:2", type=('build', 'run'))
-    depends_on("py-gimmik@2.3:", when='@1.14.0:', type=('build', 'run'))
+    depends_on("py-gimmik@2.3:2", when='@1.14.0:', type=('build', 'run'))
     depends_on("py-h5py@2.10:", type=('build', 'run'))
     depends_on("py-mako@1.0.0:", type=('build', 'run'))
     depends_on("py-mpi4py@3.1.0:", type=('build', 'run'))
     depends_on("py-numpy@1.20:+blas", type=('build', 'run'))
     depends_on("py-platformdirs@2.2.0:", type=('build', 'run'))
     depends_on("py-pytools@2016.2.1:", type=('build', 'run'))
-    depends_on("py-scipy", type=('build', 'run'))
 
-    # Optional dependecies
-    depends_on("metis@5.0:", when="+metis", type=('run'))
+    # Optional dependencies
+    depends_on("py-scipy", when="+scipy", type=('build', 'run'))
     depends_on("scotch@6.0:", when="+scotch", type=('run'))
     depends_on("cuda@8.0:", when="+cuda", type=('run'))
     depends_on("rocblas@4.5.0:", when="+hip", type=('run'))
-    depends_on("libxsmm@master+shared +noblas CODE_BUF_MAXSIZE=262144", when="+libxsmm", type=('run'))
+    depends_on("libxsmm@1.18:+shared BLAS=0 CODE_BUF_MAXSIZE=262144", when="+libxsmm", type=('run'))

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -41,8 +41,7 @@ class PyPyfr(PythonPackage):
     # Required dependencies
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-gimmik@2.2:2", type=('build', 'run'))
-    depends_on("py-gimmik@2.3:2", when='@1.14.0:', type=('build', 'run'))
+    depends_on("py-gimmik@2.3:2", type=('build', 'run'))
     depends_on("py-h5py@2.10:", type=('build', 'run'))
     depends_on("py-mako@1.0.0:", type=('build', 'run'))
     depends_on("py-mpi4py@3.1.0:", type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -55,4 +55,4 @@ class PyPyfr(PythonPackage):
     depends_on("scotch@6.0:", when="+scotch", type=('run'))
     depends_on("cuda@8.0:", when="+cuda", type=('run'))
     depends_on("rocblas@4.5.0:", when="+hip", type=('run'))
-    depends_on("libxsmm@1.18:+shared BLAS=0 CODE_BUF_MAXSIZE=262144", when="+libxsmm", type=('run'))
+    depends_on("libxsmm@1.18:+shared blas=0 +large_jit_buffer", when="+libxsmm", type=('run'))

--- a/var/spack/repos/builtin/packages/py-pyfr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyfr/package.py
@@ -41,7 +41,8 @@ class PyPyfr(PythonPackage):
     # Required dependencies
     depends_on("python@3.9:", type=("build", "run"))
     depends_on("py-setuptools", type="build")
-    depends_on("py-gimmik@2.3:2", type=('build', 'run'))
+    depends_on("py-gimmik@2.2:2", type=('build', 'run'))
+    depends_on("py-gimmik@2.3:2", when='@1.14.0:', type=('build', 'run'))
     depends_on("py-h5py@2.10:", type=('build', 'run'))
     depends_on("py-mako@1.0.0:", type=('build', 'run'))
     depends_on("py-mpi4py@3.1.0:", type=('build', 'run'))


### PR DESCRIPTION
This PR adds PyFR v1.14.0.

[v1.14.0](https://github.com/PyFR/PyFR/releases/tag/v1.14.0) introduces a requirement of LIBXSMM for the OpenMP backend.
LIBXSMM must be compiled with `BLAS=0 CODE_BUF_MAXSIZE=262144` for compatibility with PyFR. 
These build time options were added to the LIBXSMM package as optional variants.

Lastly, due to recent additions to LIBXSMM that are needed for PyFR, the LIBXSMM _master_ branch will be temporarily required in PyFR, until a new LIBXSMM version is released that includes the needed features from LIBXSMM/LIBXSMM@14b6cea61376653b2712e3eefa72b13c5e76e421. Once the new LIBXSMM version is released, the required version will be updated.
@FreddieWitherden @hfp  

