### PR TITLE
jasper: avoid --gc-sections / hidden symbols

### DIFF
--- a/var/spack/repos/builtin/packages/jasper/package.py
+++ b/var/spack/repos/builtin/packages/jasper/package.py
@@ -56,6 +56,11 @@ class Jasper(Package):
         else:
             args.append('-DJAS_ENABLE_SHARED=false')
 
+        # The default is ON from version 3.x, OFF for 2.x.
+        # packages like eccodes rely on those symbols.
+        # Force the same default here.
+        args.append('-DJAS_ENABLE_HIDDEN=OFF')
+
         return args
 
     def configure_args(self):


### PR DESCRIPTION
Jasper v3.x changed a default to hide hidden symbols, but apparently
eccodes relies on those symbols and fails to link otherwise.
