### PR TITLE
Add conflict for ROCm and asio in HPX package

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -154,6 +154,9 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
     # C++17. Starting with CUDA 11.3 they compile again.
     conflicts("asio@1.17.0:", when="+cuda cxxstd=17 ^cuda@:11.2")
 
+    # Starting from ROCm 5.0.0 hipcc miscompiles asio 1.17.0 and newer
+    conflicts("asio@1.17.0:", when="+rocm ^hip@5:")
+
     # Boost and HIP don't work together in certain versions:
     # https://github.com/boostorg/config/issues/392. Boost 1.78.0 and HPX 1.8.0
     # both include a fix.


### PR DESCRIPTION
hipcc 5 miscompiles asio 1.17.0 and newer (i.e. does not compile it with unreasonable error messages). It smells a bit like a compiler bug as the previously added conflict for CUDA and asio, so I'm adding a conflict here. We currently don't know of a  workaround for it to patch HPX and/or asio.