### PR TITLE
bamutil: updating to 1.0.15

### DIFF
--- a/var/spack/repos/builtin/packages/bamutil/package.py
+++ b/var/spack/repos/builtin/packages/bamutil/package.py
@@ -14,22 +14,31 @@ class Bamutil(MakefilePackage):
 
     homepage = "https://genome.sph.umich.edu/wiki/BamUtil"
     url      = "https://genome.sph.umich.edu/w/images/7/70/BamUtilLibStatGen.1.0.13.tgz"
+    git      = "https://github.com/statgen/bamUtil.git"
+    maintainers = ['snehring']
 
+    version('1.0.15', commit='3ad3980a3a3a3fc35eca3636b7206676c8303ce6')
     version('1.0.13', sha256='16c1d01c37d1f98b98c144f3dd0fda6068c1902f06bd0989f36ce425eb0c592b')
 
-    depends_on('zlib', type=('build', 'link'))
+    depends_on('zlib')
+    depends_on('git', type='build', when='@1.0.15:')
 
-    # Looks like this will be fixed in 1.0.14.
-    # https://github.com/statgen/libStatGen/issues/9
-    patch('libstatgen-issue-9.patch', when='@1.0.13:')
-    # These are fixed in the standalone libStatGen,
-    # but bamutil@1.0.13 embeds its own copy, so fix 'em here.
+    patch('libstatgen-issue-9.patch', when='@1.0.13')
     patch('libstatgen-issue-19.patch', when='@1.0.13')
     patch('libstatgen-issue-17.patch', when='@1.0.13')
     patch('libstatgen-issue-7.patch', when='@1.0.13')
     patch('verifybamid-issue-8.patch', when='@1.0.13')
 
     parallel = False
+
+    @when('@1.0.15')
+    def edit(self, spec, prefix):
+        filter_file('git://', 'https://', 'Makefile.inc', String=True)
+
+    @when('@1.0.15:')
+    def build(self, spec, prefix):
+        make('cloneLib')
+        make()
 
     @property
     def install_targets(self):

--- a/var/spack/repos/builtin/packages/bamutil/package.py
+++ b/var/spack/repos/builtin/packages/bamutil/package.py
@@ -13,12 +13,13 @@ class Bamutil(MakefilePackage):
     """
 
     homepage = "https://genome.sph.umich.edu/wiki/BamUtil"
-    url      = "https://genome.sph.umich.edu/w/images/7/70/BamUtilLibStatGen.1.0.13.tgz"
+    url      = "https://github.com/statgen/bamUtil/archive/refs/tags/v1.0.15.tar.gz"
     git      = "https://github.com/statgen/bamUtil.git"
     maintainers = ['snehring']
 
-    version('1.0.15', commit='3ad3980a3a3a3fc35eca3636b7206676c8303ce6')
-    version('1.0.13', sha256='16c1d01c37d1f98b98c144f3dd0fda6068c1902f06bd0989f36ce425eb0c592b')
+    version('1.0.15', sha256='24ac4bdb81eded6e33f60dba85ec3d32ebdb06d42f75df775c2632bbfbd8cce9')
+    version('1.0.13', sha256='16c1d01c37d1f98b98c144f3dd0fda6068c1902f06bd0989f36ce425eb0c592b',
+            url='https://genome.sph.umich.edu/w/images/7/70/BamUtilLibStatGen.1.0.13.tgz')
 
     depends_on('zlib')
     depends_on('git', type='build', when='@1.0.15:')


### PR DESCRIPTION
Releases seem to have moved to github. The static lib it depends on now requires git to fetch it. I debated making this into a proper dep, but I don't know if anything else uses it. I don't think it's worth the effort to do it right in this case.

The edit fixes an issue that will be fixed as soon as they cut a new release, so it's only necessary for this version.

This also fixes a build issue with gcc 12 (in the static lib).