### PR TITLE
quantum-espresso: add gipaw variant

### DIFF
--- a/var/spack/repos/builtin/packages/quantum-espresso/package.py
+++ b/var/spack/repos/builtin/packages/quantum-espresso/package.py
@@ -190,6 +190,12 @@ class QuantumEspresso(CMakePackage):
             'See http://quantum-environ.org/about.html')
     conflicts('+environ', when='+cmake', msg='environ doesn\'t work with CMake')
 
+    variant('gipaw', default=False,
+            description='Builds Gauge-Including Projector Augmented-Waves executable')
+    with when('+gipaw'):
+        conflicts('+cmake', msg='gipaw doesn\'t work with CMake')
+        conflicts('@:6.3', msg='gipaw standard support available for QE 6.3 or grater version only')
+
     # Dependencies not affected by variants
     depends_on('blas')
     depends_on('lapack')
@@ -527,6 +533,9 @@ class QuantumEspresso(CMakePackage):
             make('all', 'epw', parallel=parallel_build_on)
         else:
             make('all', parallel=parallel_build_on)
+
+        if '+gipaw' in spec:
+            make('gipaw', parallel=False)
 
         if '+environ' in spec:
             addsonpatch = Executable('./install/addsonpatch.sh')


### PR DESCRIPTION
Tested with %gcc@11.2.0 on AMD zen2