### PR TITLE
soapdenovo-trans: adding patch for gcc10+ compat

### DIFF
--- a/var/spack/repos/builtin/packages/soapdenovo-trans/package.py
+++ b/var/spack/repos/builtin/packages/soapdenovo-trans/package.py
@@ -13,11 +13,13 @@ class SoapdenovoTrans(MakefilePackage):
 
     homepage = "https://github.com/aquaskyline/SOAPdenovo-Trans"
     url      = "https://github.com/aquaskyline/SOAPdenovo-Trans/archive/1.0.4.tar.gz"
+    maintainers = ['snehring']
 
+    version('1.0.5', sha256='c1903c0d81142270db95916e2833400f72c4841b5c9194f182c19ebda418936f')
     version('1.0.4', sha256='378a54cde0ebe240fb515ba67197c053cf95393645c1ae1399b3a611be2a9795')
 
     depends_on('zlib', type='link')
-    depends_on('samtools@0.1.8', type='link')
+    depends_on('samtools@0.1.8', type='link', when='target=aarch64:')
 
     build_directory = 'src'
 
@@ -35,4 +37,5 @@ class SoapdenovoTrans(MakefilePackage):
             make('127mer=1', parallel=False)
 
     def install(self, spec, prefix):
-        install_tree('.', prefix.bin)
+        mkdirp(prefix.bin)
+        install('SOAPdenovo-Trans-*mer', prefix.bin)


### PR DESCRIPTION
This fixes compilation issues with gcc10+, I put in a PR [upstream](https://github.com/aquaskyline/SOAPdenovo-Trans/pull/20) but I don't know if it'll be accepted or when another release will be cut.

This also cleans up the recipe a little.