### PR TITLE
fakexrandr: remove 'ldconfig'

### DIFF
--- a/var/spack/repos/builtin/packages/fakexrandr/package.py
+++ b/var/spack/repos/builtin/packages/fakexrandr/package.py
@@ -42,8 +42,8 @@ class Fakexrandr(MakefilePackage):
         # And tool used to generate skeleton
         filter_file('gcc', spack_cc, 'make_skeleton.py')
 
-        if 'platform=darwin' in spec:
-            makefile.filter('ldconfig', '')
+        # remove 'ldconfig' on all platforms
+        makefile.filter('ldconfig', '')
 
     # In Makefile, install commands check the target dir.
     # If it does not exist, process will stop.


### PR DESCRIPTION
This patch remove 'ldconfig' in Makefile to avoid an error as below:
  ldconfig: Can't create temporary cache file /etc/ld.so.cache~: Permission denied