### PR TITLE
precice: release 2.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -21,6 +21,7 @@ class Precice(CMakePackage):
     tags = ['e4s']
 
     version('develop', branch='develop')
+    version('2.4.0', sha256='762e603fbcaa96c4fb0b378b7cb6789d09da0cf6193325603e5eeb13e4c7601c')
     version('2.3.0', sha256='57bab08e8b986f5faa364689d470940dbd9c138e5cfa7b861793e7db56b89da3')
     version('2.2.1', sha256='bca8cedfb5c86656e4fdfaca5cb982b861f9aba926538fa4411bc0d015e09c1f')
     version('2.2.0', sha256='f8c4e0810dcaeb6a40a0fcab64b95c899f0121c968e0730416d4d2a97d39d0c4')

--- a/var/spack/repos/builtin/packages/precice/package.py
+++ b/var/spack/repos/builtin/packages/precice/package.py
@@ -47,12 +47,23 @@ class Precice(CMakePackage):
 
     depends_on('cmake@3.5:', type='build')
     depends_on('cmake@3.10.2:', type='build', when='@1.4:')
+    depends_on('cmake@3.16.3:', type='build', when='@2.4:')
     depends_on('pkgconfig', type='build', when='@2.2:')
-    depends_on('boost@1.60.0:+program_options+chrono+locale+filesystem+system+log+exception+atomic+test+container+regex+math+thread')
-    depends_on('boost@1.65.1:+program_options+chrono+locale+filesystem+system+log+exception+atomic+test+container+regex+math+thread', when='@1.4:')
-    depends_on('boost@1.72:+program_options+chrono+locale+filesystem+system+log+exception+atomic+test+container+regex+math+thread', when='@:2.0.2')
-    depends_on('boost@1.74:+program_options+chrono+locale+filesystem+system+log+exception+atomic+test+container+regex+math+thread', when='@:2.1.1')
-    conflicts('boost@1.79.0')
+
+    # Boost components
+    depends_on('boost+filesystem+log+program_options+system+test+thread')
+    depends_on('boost+signals', when='@:2.3')
+
+    # Baseline versions
+    depends_on('boost@1.60.0:')
+    depends_on('boost@1.65.1:', when='@1.4:')
+    depends_on('boost@1.71.0:', when='@2.4:')
+
+    # Forward compatibility
+    depends_on('boost@:1.72', when='@:2.0.2')
+    depends_on('boost@:1.74', when='@:2.1.1')
+    depends_on('boost@:1.78', when='@:2.3.0')
+
     depends_on('eigen@3.2:')
     depends_on('eigen@:3.3.7', type='build', when='@:1.5')  # bug in prettyprint
     depends_on('libxml2')


### PR DESCRIPTION
This PR adds the preCICE release of 2.4.0 and updates the dependency constraints.

Specifies required boost components #22303
Resolves conflict with boost@1.79.0 #30179 