### PR TITLE
eccodes, fix jasper again

### DIFF
--- a/var/spack/repos/builtin/packages/ecbuild/package.py
+++ b/var/spack/repos/builtin/packages/ecbuild/package.py
@@ -8,19 +8,20 @@ from spack import *
 
 class Ecbuild(CMakePackage):
     """ecBuild is the ECMWF build system. It is built on top of CMake and
-    consists of a set of macros as well as a wrapper around CMake,"""
+    consists of a set of macros as well as a wrapper around CMake"""
 
     homepage = 'https://github.com/ecmwf/ecbuild'
     url = 'https://github.com/ecmwf/ecbuild/archive/refs/tags/3.6.1.tar.gz'
 
     maintainers = ['skosukhin']
 
+    version('3.6.5', sha256='98bff3d3c269f973f4bfbe29b4de834cd1d43f15b1c8d1941ee2bfe15e3d4f7f')
     version('3.6.1', sha256='796ccceeb7af01938c2f74eab0724b228e9bf1978e32484aa3e227510f69ac59')
 
-    # Some of the tests (ECBUILD-415 and test_ecbuild_regex_escape) fail with
-    # cmake@2.20.0 and it is not yet clear why. For now, we simply limit the
-    # version of cmake to the latest '3.19.x':
-    depends_on('cmake@3.11:3.19', type=('build', 'run'))
+    depends_on('cmake@3.11:', type=('build', 'run'))
+
+    # See https://github.com/ecmwf/ecbuild/issues/35
+    depends_on('cmake@:3.19', type=('build', 'run'), when='@:3.6.1')
 
     # Some of the installed scripts require running Perl:
     depends_on('perl', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -40,10 +40,12 @@ class Eccodes(CMakePackage):
 
     homepage = 'https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home'
     url = 'https://confluence.ecmwf.int/download/attachments/45757960/eccodes-2.2.0-Source.tar.gz?api=v2'
+    git = 'https://github.com/ecmwf/eccodes.git'
     list_url = 'https://confluence.ecmwf.int/display/ECC/Releases'
 
     maintainers = ['skosukhin']
 
+    version('develop', branch='develop')
     version('2.25.0', sha256='8975131aac54d406e5457706fd4e6ba46a8cc9c7dd817a41f2aa64ce1193c04e')
     version('2.24.2', sha256='c60ad0fd89e11918ace0d84c01489f21222b11d6cad3ff7495856a0add610403')
     version('2.23.0', sha256='cbdc8532537e9682f1a93ddb03440416b66906a4cc25dec3cbd73940d194bf0c')
@@ -95,7 +97,12 @@ class Eccodes(CMakePackage):
     depends_on('openjpeg@1.5.0:1.5,2.1.0:2.3', when='jp2k=openjpeg')
     # Additional constraint for older versions.
     depends_on('openjpeg@:2.1', when='@:2.16 jp2k=openjpeg')
-    depends_on('jasper', when='jp2k=jasper')
+
+    with when('jp2k=jasper'):
+        depends_on('jasper')
+        # jasper 3.x compat from commit 86f0b35f1a8492cb16f82fb976a0a5acd2986ac2
+        depends_on('jasper@:2', when='@:2.25.0')
+
     depends_on('libpng', when='+png')
     depends_on('libaec', when='+aec')
     # Can be built with Python 2 or Python 3.

--- a/var/spack/repos/builtin/packages/eccodes/package.py
+++ b/var/spack/repos/builtin/packages/eccodes/package.py
@@ -118,6 +118,8 @@ class Eccodes(CMakePackage):
     depends_on('cmake@3.6:', type='build')
     depends_on('cmake@3.12:', when='@2.19:', type='build')
 
+    depends_on('ecbuild', type='build', when='@develop')
+
     conflicts('+openmp', when='+pthreads',
               msg='Cannot enable both POSIX threads and OMP')
 

--- a/var/spack/repos/builtin/packages/jasper/package.py
+++ b/var/spack/repos/builtin/packages/jasper/package.py
@@ -57,11 +57,6 @@ class Jasper(Package):
         else:
             args.append('-DJAS_ENABLE_SHARED=false')
 
-        # The default is ON from version 3.x, OFF for 2.x.
-        # packages like eccodes rely on those symbols.
-        # Force the same default here.
-        args.append('-DJAS_ENABLE_HIDDEN=OFF')
-
         return args
 
     def configure_args(self):


### PR DESCRIPTION
- eccodes: jasper@:2 (their develop branch adds jasper@3 support)
- Revert "jasper: avoid --gc-sections / hidden symbols" (apparently eccodes used private api, so let's just revert...)
- bump ecbuild, drop cmake constraint for newer versions
- add ecbuild dep to eccodes@develop (supports jasper@3)
