### PR TITLE
Fix APEX compilation with binutils

### DIFF
--- a/var/spack/repos/builtin/packages/apex/package.py
+++ b/var/spack/repos/builtin/packages/apex/package.py
@@ -55,6 +55,7 @@ class Apex(CMakePackage):
     depends_on('zlib')
     depends_on('cmake@3.10.0:', type='build')
     depends_on('binutils@2.33:+libiberty+headers', when='+binutils')
+    depends_on('gettext', when='+binutils ^binutils+nls')
     depends_on('activeharmony@4.6:', when='+activeharmony')
     depends_on('activeharmony@4.6:', when='+plugins')
     depends_on('otf2@2.1:', when='+otf2')
@@ -112,6 +113,9 @@ class Apex(CMakePackage):
 
         if '+binutils' in spec:
             args.append('-DBFD_ROOT={0}'.format(spec['binutils'].prefix))
+
+        if '+binutils ^binutils+nls' in spec:
+            args.append('-DCMAKE_SHARED_LINKER_FLAGS=-lintl')
 
         if '+otf2' in spec:
             args.append('-DOTF2_ROOT={0}'.format(spec['otf2'].prefix))


### PR DESCRIPTION
With `apex +binutils` APEX links to `libbfd` from `binutils`. If `binutils` has the `+nls` variant it itself depends on `gettext` and requires linking with `libintl`. When those conditions are true, these changes add `-lintl` to the linker flags and make APEX depend on `gettext`. If one doesn't do that compilation fails with multiple errors of this type:

```
    439    /apps/daint/SSL/pika/spack/lib/spack/env/gcc/gcc  -DAPEX_USE_CLOCK_TIMESTAMP -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -O2 -g -DNDEBUG -dynamic CMakeFiles/apex_set_state.dir/apex_set_state
            .c.o -o apex_set_state   -L/tmp/simbergm/spack-stage/spack-stage-apex-2.3.2-hjzap6fytj6saswy7uqkwowuolxhuapc/spack-build-hjzap6f/src/apex  -Wl,-rpath,/tmp/simbergm/spack-stage/spack-stage-apex-2.3.2-hjzap6fytj6saswy7uqkwowuol
            xhuapc/spack-build-hjzap6f/src/apex:/apps/daint/SSL/pika/spack/opt/spack/cray-cnl7-haswell/gcc-10.3.0/gperftools-2.9.1-tpnfazzoylvdtrquudrtalstgkzmhvra/lib:/apps/daint/SSL/pika/spack/opt/spack/cray-cnl7-haswell/gcc-10.3.0/otf
            2-2.3-he3jgyi2mvof6akbwae4g62vuatujlpb/lib:/apps/daint/SSL/pika/spack/opt/spack/cray-cnl7-haswell/gcc-10.3.0/zlib-1.2.12-lvaqdhcxpsnxnk7vt5gzjw263qt5zzxd/lib ../../apex/libapex.so /apps/daint/SSL/pika/spack/opt/spack/cray-cnl
            7-haswell/gcc-10.3.0/gperftools-2.9.1-tpnfazzoylvdtrquudrtalstgkzmhvra/lib/libtcmalloc.so /apps/daint/SSL/pika/spack/opt/spack/cray-cnl7-haswell/gcc-10.3.0/activeharmony-4.6.0-2rfbcrkwoyys7xbuubnouboorzo5zaly/lib/libharmony.a
             /apps/daint/SSL/pika/spack/opt/spack/cray-cnl7-haswell/gcc-10.3.0/otf2-2.3-he3jgyi2mvof6akbwae4g62vuatujlpb/lib/libotf2.so -lrt /apps/daint/SSL/pika/spack/opt/spack/cray-cnl7-haswell/gcc-10.3.0/binutils-2.38-sjwlwywwdoo56jxz
            3obrtzovnfhqqwo4/lib/libbfd.a /apps/daint/SSL/pika/spack/opt/spack/cray-cnl7-haswell/gcc-10.3.0/binutils-2.38-sjwlwywwdoo56jxz3obrtzovnfhqqwo4/lib64/libiberty.a /apps/daint/SSL/pika/spack/opt/spack/cray-cnl7-haswell/gcc-10.3.
            0/zlib-1.2.12-lvaqdhcxpsnxnk7vt5gzjw263qt5zzxd/lib/libz.so -ldl -lm -ldl -ldl -lstdc++ -lm ../../apex/libtaudummy.so
  >> 440    /usr/bin/ld: ../../apex/libapex.so: undefined reference to `libintl_dgettext'
  >> 441    /usr/bin/ld: ../../apex/libapex.so: undefined reference to `libintl_dngettext'
  >> 442    collect2: error: ld returned 1 exit status
  >> 443    make[2]: *** [src/unit_tests/C/CMakeFiles/apex_finalize.dir/build.make:112: src/unit_tests/C/apex_finalize] Error 1
     444    make[2]: Leaving directory '/tmp/simbergm/spack-stage/spack-stage-apex-2.3.2-hjzap6fytj6saswy7uqkwowuolxhuapc/spack-build-hjzap6f'
  >> 445    make[1]: *** [CMakeFiles/Makefile2:1386: src/unit_tests/C/CMakeFiles/apex_finalize.dir/all] Error 2
     446    make[1]: *** Waiting for unfinished jobs....
  >> 447    /usr/bin/ld: ../../apex/libapex.so: undefined reference to `libintl_dgettext'
  >> 448    /usr/bin/ld: ../../apex/libapex.so: undefined reference to `libintl_dngettext'
  >> 449    /usr/bin/ld: ../../apex/libapex.so: undefined reference to `libintl_dgettext'
  >> 450    /usr/bin/ld: ../../apex/libapex.so: undefined reference to `libintl_dngettext'
  >> 451    /usr/bin/ld: ../../apex/libapex.so: undefined reference to `libintl_dgettext'
  >> 452    /usr/bin/ld: ../../apex/libapex.so: undefined reference to `libintl_dngettext'
  >> 453    collect2: error: ld returned 1 exit status
```

There's a similar issue from a long time back: https://github.com/spack/spack/issues/2613.

From what I can tell binutils doesn't provide a pkgconfig file or similar, so there is no way for a consumer of `libbfd` to know if they should link to `libintl` or not, when `libbfd` is a static library. If `libbfd` were a shared library I suppose rpaths and other magic would make sure that `libintl` would get linked in (or it would already be part of `libbfd`). However, at least in my case even attempting to build `binutils libs=shared` still results in _only_ static libraries. I assume this is expected behaviour from binutils, but I'm not sure. Excerpt from the `binutils` configuration output (with `--enable-shared`):

```
checking whether the /apps/daint/SSL/pika/spack/lib/spack/env/gcc/gcc linker (ld -m elf_x86_64) supports shared libraries... no
checking if /apps/daint/SSL/pika/spack/lib/spack/env/gcc/gcc supports -c -o file.o... no
checking dynamic linker characteristics... yes
checking for vprintf... yes
checking if /apps/daint/SSL/pika/spack/lib/spack/env/gcc/gcc supports -c -o file.o... (cached) yes
checking whether the /apps/daint/SSL/pika/spack/lib/spack/env/gcc/gcc linker (ld -m elf_x86_64) supports shared libraries... no
checking dynamic linker characteristics... yes
checking for vsnprintf... GNU/Linux ld.so
checking how to hardcode library paths into programs... unsupported
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... no
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking for dlfcn.h... (cached) yes
checking for windows.h... yes
checking for vsprintf... no
checking for library containing dlsym... GNU/Linux ld.so
checking how to hardcode library paths into programs... unsupported
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... no
checking whether to build shared libraries... no
checking whether to build static libraries... yes
```

With this background I found it reasonable enough to depend on `gettext` in `apex` even though it's not really something `apex` should need to be concerned about.