### PR TITLE
tar: add compress deps

### DIFF
--- a/var/spack/repos/builtin/packages/gzip/package.py
+++ b/var/spack/repos/builtin/packages/gzip/package.py
@@ -16,7 +16,5 @@ class Gzip(AutotoolsPackage):
     version('1.11', sha256='3e8a0e0c45bad3009341dce17d71536c4c655d9313039021ce7554a26cd50ed9')
     version('1.10', sha256='c91f74430bf7bc20402e1f657d0b252cb80aa66ba333a25704512af346633c68')
 
-    depends_on('gmake', type='build')
-
     # Gzip makes a recursive symlink if built in-source
     build_directory = 'spack-build'


### PR DESCRIPTION
The controversial bit here is to default to pigz instead of gzip, which is what pretty much all linux distro's default to.

The upside is it's fast. ~The downside is that pigz sets the timestamp header to "current time" on streamed data, whereas gzip sets it to 0 in that case. That means that output is not as deterministic as with gzip.~ (Apparently gzip before version 1.10 had the same behavior as pigz, so this is not an issue. To get consistency, you have to use `gzip/pigz --no-name ...`). 

```console
# System tar:
$ time /usr/bin/tar --totals -czf cuda.tar.gz -C /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-11.2.0/cuda-11.6.2-bv4n7thv2dm7a5e25txtrcsvagtc6lx7 .
Total bytes written: 5736120320 (5.4GiB, 27MiB/s)
real	3m25.849s
2.9G	cuda.tar.gz

# Spack tar (pigz default)
$ time tar --totals -czf cuda.tar.gz -C /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-11.2.0/cuda-11.6.2-bv4n7thv2dm7a5e25txtrcsvagtc6lx7 .
Total bytes written: 5736120320 (5.4GiB, 296MiB/s)
real	0m18.532s
2.9G	cuda.tar.gz
```

However, with this PR, you can more easily use zstd too, which gives another 4x speedup for me at better compression rate:

```console
# Spack tar --zstd:
$ time env ZSTD_NBTHREADS=16 tar --zstd --totals -cf cuda.tar.zst -C /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-11.2.0/cuda-11.6.2-bv4n7thv2dm7a5e25txtrcsvagtc6lx7 .
Total bytes written: 5736120320 (5.4GiB, 1.4GiB/s)
real	0m4.028s
2.6G	cuda.tar.zst
```

Similarly, you can do `env XZ_OPT=-T16 tar --xz ...`.

dep tree looks like:

```
tar@1.34%gcc@10.3.0 zip=pigz arch=linux-ubuntu20.04-zen2
    ^bzip2@1.0.8%gcc@10.3.0~debug~pic+shared arch=linux-ubuntu20.04-zen2
        ^diffutils@3.8%gcc@10.3.0 arch=linux-ubuntu20.04-zen2
            ^libiconv@1.16%gcc@10.3.0 libs=shared,static arch=linux-ubuntu20.04-zen2
    ^pigz@2.6%gcc@10.3.0 arch=linux-ubuntu20.04-zen2
        ^zlib@1.2.12%gcc@10.3.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu20.04-zen2
    ^xz@5.2.5%gcc@10.3.0~pic libs=shared,static arch=linux-ubuntu20.04-zen2
    ^zstd@1.5.2%gcc@10.3.0+programs compression=none libs=shared,static arch=linux-ubuntu20.04-zen2
```