### PR TITLE
tutorial stack: allow deprecated versions

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/tutorial/spack.yaml
@@ -9,6 +9,9 @@ spack:
       projections:
         all: '{architecture}/{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
 
+    # allow deprecated versions in concretizations
+    deprecated: true
+
   packages:
     all:
       target: [x86_64]


### PR DESCRIPTION
Closes #30148.

For tutorial builds, we should continue to allow deprecated builds to be installed. We can update them as needed when we update the tutorial, but we don't need to correct them immediately on deprecation in CI.

- [x] add `deprecated:true` to tutorial `spack.yaml` config.