### PR TITLE
py-scikit-learn: add v1.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -13,8 +13,8 @@ class PyScikitLearn(PythonPackage):
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
-    version('1.1.0rc1', sha256='f5b27a76d10d2673f7a899622d396eb5813fdbc7c05ca817bdd90121113e6555', deprecated=True)
-    version('1.0.2', sha256='b5870959a5484b614f26d31ca4c17524b1b0317522199dc985c3b4256e030767', preferred=True)
+    version('1.1.0', sha256='80f9904f5b1356adfc32406725dd94c8cc9c8d265047d98390033a6c238cbb29')
+    version('1.0.2', sha256='b5870959a5484b614f26d31ca4c17524b1b0317522199dc985c3b4256e030767')
     version('1.0.1', sha256='ac2ca9dbb754d61cfe1c83ba8483498ef951d29b93ec09d6f002847f210a99da')
     version('1.0', sha256='776800194e757cd212b47cd05907e0eb67a554ad333fe76776060dbb729e3427')
     version('0.24.2', sha256='d14701a12417930392cd3898e9646cf5670c190b933625ebe7511b1f7d7b8736')


### PR DESCRIPTION
https://github.com/scikit-learn/scikit-learn/releases/tag/1.1.0

Successfully builds on macOS 10.15.7 with Python 3.9.12 and Apple Clang 12.0.0.