### PR TITLE
Boost: constrain context-impl variant

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -161,7 +161,7 @@ class Boost(Package):
             values=('fcontext', 'ucontext', 'winfib'),
             multi=False,
             description='Use the specified backend for boost-context',
-            when='+context')
+            when='@1.65.0: +context')
 
     variant('cxxstd',
             default='98',


### PR DESCRIPTION
It's only available after 1.65.0

Fixes https://github.com/spack/spack/issues/30642