### PR TITLE
Fix older bazels on new GCCs

### DIFF
--- a/var/spack/repos/builtin/packages/bazel/ijar_limits_fix.patch
+++ b/var/spack/repos/builtin/packages/bazel/ijar_limits_fix.patch
@@ -1,0 +1,20 @@
+--- a/third_party/ijar/zlib_client.h
++++ b/third_party/ijar/zlib_client.h
+@@ -16,6 +16,7 @@
+ #define THIRD_PARTY_IJAR_ZLIB_CLIENT_H_
+ 
+ #include <limits.h>
++#include <limits>
+ 
+ #include "third_party/ijar/common.h"
+ 
+--- a/third_party/ijar/mapped_file_unix.cc
++++ b/third_party/ijar/mapped_file_unix.cc
+@@ -19,6 +19,7 @@
+ #include <sys/mman.h>
+ 
+ #include <algorithm>
++#include <limits>
+ 
+ #include "third_party/ijar/mapped_file.h"
+ 

--- a/var/spack/repos/builtin/packages/bazel/package.py
+++ b/var/spack/repos/builtin/packages/bazel/package.py
@@ -157,6 +157,9 @@ class Bazel(Package):
     patch('disabledepcheck.patch', when='@0.3.2:+nodepfail')
     patch('disabledepcheck_old.patch', when='@0.3.0:0.3.1+nodepfail')
 
+    # include-what-you-use violation that snuck under the radar until GCC 11
+    patch('ijar_limits_fix.patch', when='@0.3.2:5.0.0')
+
     executables = ['^bazel$']
 
     @classmethod


### PR DESCRIPTION
Looks like `<limits>` was being transitively included somewhere until GCC restructured its header files with GCC 11.