### PR TITLE
gcc: add `build_type` and `profiled` variants

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -115,6 +115,8 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             description='Enable Graphite loop optimizations (requires ISL)')
     variant('build_type', default='RelWithDebInfo', description='Build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+    variant('profiled', default=False, description='Use Profile Guided Optimization',
+            when='+bootstrap')
 
     depends_on('flex', type='build', when='@master')
 
@@ -723,6 +725,12 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             configure(*options)
             make()
             make('install')
+
+    @property
+    def build_targets(self):
+        if '+profiled' in self.spec:
+            return ['profiledbootstrap']
+        return []
 
     @property
     def install_targets(self):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -113,8 +113,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     variant('graphite',
             default=False,
             description='Enable Graphite loop optimizations (requires ISL)')
-    variant('build_type', default='RelWithDebInfo', description='Build type',
-            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+    variant('build_type', default='RelWithDebInfo',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'),
+            description='CMake-like build type. Debug: -O0 -g; Release: -O3; RelWithDebInfo: -O2 -g; MinSizeRel: -Os')
     variant('profiled', default=False, description='Use Profile Guided Optimization',
             when='+bootstrap %gcc')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -115,7 +115,9 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             description='Enable Graphite loop optimizations (requires ISL)')
     variant('build_type', default='RelWithDebInfo',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'),
-            description='CMake-like build type. Debug: -O0 -g; Release: -O3; RelWithDebInfo: -O2 -g; MinSizeRel: -Os')
+            description='CMake-like build type. '
+                        'Debug: -O0 -g; Release: -O3; '
+                        'RelWithDebInfo: -O2 -g; MinSizeRel: -Os''')
     variant('profiled', default=False, description='Use Profile Guided Optimization',
             when='+bootstrap %gcc')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -116,7 +116,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
     variant('build_type', default='RelWithDebInfo', description='Build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
     variant('profiled', default=False, description='Use Profile Guided Optimization',
-            when='+bootstrap')
+            when='+bootstrap %gcc')
 
     depends_on('flex', type='build', when='@master')
 

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -8,13 +8,14 @@ import os
 import re
 import sys
 
+from archspec.cpu import UnsupportedMicroarchitecture
+
 import llnl.util.tty as tty
 
 import spack.platforms
 import spack.util.executable
 from spack.build_environment import dso_suffix
 from spack.operating_systems.mac_os import macos_sdk_path, macos_version
-from archspec.cpu import UnsupportedMicroarchitecture
 
 
 class Gcc(AutotoolsPackage, GNUMirrorPackage):

--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -117,7 +117,7 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'),
             description='CMake-like build type. '
                         'Debug: -O0 -g; Release: -O3; '
-                        'RelWithDebInfo: -O2 -g; MinSizeRel: -Os''')
+                        'RelWithDebInfo: -O2 -g; MinSizeRel: -Os')
     variant('profiled', default=False, description='Use Profile Guided Optimization',
             when='+bootstrap %gcc')
 


### PR DESCRIPTION
Add a `build_type` variant, which allows building optimized compilers,
as well as target libraries (libstdc++ and friends).

The default is `build_type=RelWithDebInfo`, which corresponds to GCC's
default of `-O2 -g` (although we have `-O3` in LLVM)

When building with `+bootstrap %gcc`, also add Spack's arch specific
flags using the common denominator between host and new GCC*.

When building with `+bootstrap`, set `-O1` in the first stage, to significantly
speed up bootstrapping (about 1.5x). OpenSUSE does -O2 in this stage,
but on the internet I'm reading that it's safer to use -O1 in case the
host optimizer has bugs.

When setting `+profiled`, Spack will invoke `make profiledbootstrap`,
which uses Profile-guided Optimization in the 2nd/3rd phase of GCC,
which should improve performance by something like 5% according
to the internet.

The Spack flags are set by creating a `config/spack.mk` file in 
`def patch`, that looks as follows:

```Makefile
BOOT_CFLAGS := $(filter-out -O% -g%, $(BOOT_CFLAGS)) -O2 -g -march=znver2 -mtune=znver2
CFLAGS_FOR_TARGET := $(filter-out -O% -g%, $(CFLAGS_FOR_TARGET)) -O2 -g -march=znver2 -mtune=znver2
CXXFLAGS_FOR_TARGET := $(filter-out -O% -g%, $(CXXFLAGS_FOR_TARGET)) -O2 -g -march=znver2 -mtune=znver2
STAGE1_CFLAGS += -O1
```

\* So you still want to build e.g. `gcc@12~bootstrap %gcc@7` and then
`gcc@12+bootstrap %gcc@12` to get optimized libstdc++, just because
Spack fixes the target arch according to the host compiler.