### PR TITLE
bpp-suite and deps: urls to GitHub

### DIFF
--- a/var/spack/repos/builtin/packages/bpp-core/global-graph-limits.patch
+++ b/var/spack/repos/builtin/packages/bpp-core/global-graph-limits.patch
@@ -1,0 +1,21 @@
+diff --git a/src/Bpp/Graph/GlobalGraph.cpp b/src/Bpp/Graph/GlobalGraph.cpp
+index ca2d18f..d681314 100644
+--- a/src/Bpp/Graph/GlobalGraph.cpp
++++ b/src/Bpp/Graph/GlobalGraph.cpp
+@@ -42,6 +42,7 @@
+ #include <sstream>
+ #include <string>
+ #include <vector>
++#include <limits>
+ 
+ #include "../Exceptions.h"
+ #include "../Text/TextTools.h"
+@@ -751,7 +752,7 @@ void GlobalGraph::orientate()
+     // if none, look for node wih minimum number of fathers
+     if (it == nextNodes.end())
+     {
+-      size_t nbF = numeric_limits<size_t>::infinity();
++      size_t nbF = std::numeric_limits<size_t>::infinity();
+       it = nextNodes.begin();
+ 
+       for ( ; it != nextNodes.end(); it++)

--- a/var/spack/repos/builtin/packages/bpp-core/package.py
+++ b/var/spack/repos/builtin/packages/bpp-core/package.py
@@ -10,16 +10,21 @@ class BppCore(CMakePackage):
     """Bio++ core library."""
 
     homepage = "http://biopp.univ-montp2.fr/wiki/index.php/Installation"
-    url      = "http://biopp.univ-montp2.fr/repos/sources/bpp-core-2.2.0.tar.gz"
+    url      = "https://github.com/BioPP/bpp-core/archive/refs/tags/v2.4.1.tar.gz"
+
+    maintainers = ['snehring']
 
     version('2.4.1', sha256='1150b8ced22cff23dd4770d7c23fad11239070b44007740e77407f0d746c0af6')
-    version('2.2.0', sha256='aacd4afddd1584ab6bfa1ff6931259408f1d39958a0bdc5f78bf1f9ee4e98b79')
+    version('2.2.0', sha256='aacd4afddd1584ab6bfa1ff6931259408f1d39958a0bdc5f78bf1f9ee4e98b79', deprecated=True)
 
     depends_on('cmake@2.6:', type='build')
 
     # Clarify isnan's namespace, because Fujitsu compiler can't
     # resolve ambiguous of 'isnan' function.
     patch('clarify_isnan.patch', when='%fj')
+
+    # This is fixed in master, next release should be fine
+    patch('global-graph-limits.patch', when='@2.4.1')
 
     def cmake_args(self):
         return ['-DBUILD_TESTING=FALSE']

--- a/var/spack/repos/builtin/packages/bpp-phyl/package.py
+++ b/var/spack/repos/builtin/packages/bpp-phyl/package.py
@@ -10,9 +10,12 @@ class BppPhyl(CMakePackage):
     """Bio++ phylogeny library."""
 
     homepage = "http://biopp.univ-montp2.fr/wiki/index.php/Installation"
-    url      = "http://biopp.univ-montp2.fr/repos/sources/bpp-phyl-2.2.0.tar.gz"
+    url      = "https://github.com/BioPP/bpp-phyl/archive/refs/tags/v2.4.1.tar.gz"
 
-    version('2.2.0', sha256='f346d87bbc7858924f3c99d7d74eb4a1f7a1b926746c68d8c28e07396c64237b')
+    maintainers = ['snehring']
+
+    version('2.4.1', sha256='e7bf7d4570f756b7773904ffa600ffcd77c965553ddb5cbc252092d1da962ff2')
+    version('2.2.0', sha256='f346d87bbc7858924f3c99d7d74eb4a1f7a1b926746c68d8c28e07396c64237b', deprecated=True)
 
     depends_on('cmake@2.6:', type='build')
     depends_on('bpp-core')

--- a/var/spack/repos/builtin/packages/bpp-popgen/package.py
+++ b/var/spack/repos/builtin/packages/bpp-popgen/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class BppPopgen(CMakePackage):
+    """The Bio++ Population Genetics Library"""
+
+    homepage = "https://https://github.com/BioPP/bpp-popgen"
+    url      = "https://github.com/BioPP/bpp-popgen/archive/refs/tags/v2.4.1.tar.gz"
+
+    maintainers = ['snehring']
+
+    version('2.4.1', sha256='03b57d71a63c8fa7f11c085e531d0d691fc1d40d4ea541070dabde0ab3baf413')
+
+    depends_on('bpp-seq')
+
+    def cmake_args(self):
+        args = []
+        return args

--- a/var/spack/repos/builtin/packages/bpp-popgen/package.py
+++ b/var/spack/repos/builtin/packages/bpp-popgen/package.py
@@ -17,7 +17,3 @@ class BppPopgen(CMakePackage):
     version('2.4.1', sha256='03b57d71a63c8fa7f11c085e531d0d691fc1d40d4ea541070dabde0ab3baf413')
 
     depends_on('bpp-seq')
-
-    def cmake_args(self):
-        args = []
-        return args

--- a/var/spack/repos/builtin/packages/bpp-seq/package.py
+++ b/var/spack/repos/builtin/packages/bpp-seq/package.py
@@ -10,10 +10,12 @@ class BppSeq(CMakePackage):
     """Bio++ seq library."""
 
     homepage = "http://biopp.univ-montp2.fr/wiki/index.php/Installation"
-    url      = "http://biopp.univ-montp2.fr/repos/sources/bpp-seq-2.2.0.tar.gz"
+    url      = "https://github.com/BioPP/bpp-seq/archive/refs/tags/v2.4.1.tar.gz"
+
+    maintainers = ['snehring']
 
     version('2.4.1', sha256='dbfcb04803e4b7f08f9f159da8a947c91906c3ca8b20683ac193f6dc524d4655')
-    version('2.2.0', sha256='0927d7fb0301c1b99a7353d5876deadb4a3040776cc74e8fe1c366fe920e7b6b')
+    version('2.2.0', sha256='0927d7fb0301c1b99a7353d5876deadb4a3040776cc74e8fe1c366fe920e7b6b', deprecated=True)
 
     depends_on('cmake@2.6:', type='build')
     depends_on('bpp-core')

--- a/var/spack/repos/builtin/packages/bpp-suite/package.py
+++ b/var/spack/repos/builtin/packages/bpp-suite/package.py
@@ -11,15 +11,19 @@ class BppSuite(CMakePackage):
        sequence analysis."""
 
     homepage = "http://biopp.univ-montp2.fr/wiki/index.php/BppSuite"
-    url      = "http://biopp.univ-montp2.fr/repos/sources/bppsuite/bppsuite-2.2.0.tar.gz"
+    url      = "https://github.com/BioPP/bppsuite/archive/refs/tags/v2.4.1.tar.gz"
 
-    version('2.2.0', sha256='761fa5eec794af221d971ae70fd8c43171ad71a6bb5f20549263a1797b43f138')
+    maintainers = ['snehring']
+
+    version('2.4.1', sha256='0485adcc17e37439069d27e4fac144e5ae38036ba21f31e6d21f070ce4ea5199')
+    version('2.2.0', sha256='761fa5eec794af221d971ae70fd8c43171ad71a6bb5f20549263a1797b43f138', deprecated=True)
 
     depends_on('cmake@2.6:', type='build')
     depends_on('texinfo', type='build')
     depends_on('bpp-core')
     depends_on('bpp-seq')
     depends_on('bpp-phyl')
+    depends_on('bpp-popgen', when='@2.4.1:')
 
     # Clarify isinf's namespace, because Fujitsu compiler can't
     # resolve ambiguous of 'isinf' function.


### PR DESCRIPTION
The domain the bio++ packages were previously available at seems dead. Fortunately they've got the projects on github, so most of this is just changing urls and deprecating the no longer available versions.

Fixes a compilation issue with at least gcc12 in bpp-core.

Also updates bpp-suite and adds a package that that needs now.