### PR TITLE
sed: add v4.8.0, set gnu_mirror_path per version

### DIFF
--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -13,17 +13,17 @@ class Sed(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/sed/"
     gnu_mirror_path = "sed/sed-4.8.tar.xz"
 
+    version('4.8', sha256='f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633')
+    version('4.2.2', sha256='f048d1838da284c8bc9753e4506b85a1e0cc1ea8999d36f6995bcb9460cddbd7')
+
+    executables = ['^sed$']
+
     def url_for_version(self, version):
         if Version("4.2") <= version < Version("4.3.0"):
             self.gnu_mirror_path = "sed/sed-{0}.tar.bz2".format(version)
         elif version < Version("4.2"):
             self.gnu_mirror_path = "sed/sed-{0}.tar.gz".format(version)
         return super(Sed, self).url_for_version(version)
-
-    version('4.8', sha256='f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633')
-    version('4.2.2', sha256='f048d1838da284c8bc9753e4506b85a1e0cc1ea8999d36f6995bcb9460cddbd7')
-
-    executables = ['^sed$']
 
     @classmethod
     def determine_version(cls, exe):

--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -11,8 +11,16 @@ from spack import *
 class Sed(AutotoolsPackage, GNUMirrorPackage):
     """GNU implementation of the famous stream editor."""
     homepage = "https://www.gnu.org/software/sed/"
-    gnu_mirror_path = "sed/sed-4.2.2.tar.bz2"
+    gnu_mirror_path = "sed/sed-4.8.tar.xz"
 
+    def url_for_version(self, version):
+        if Version("4.2") <= version < Version("4.3.0"):
+            self.gnu_mirror_path = "sed/sed-{0}.tar.bz2".format(version)
+        elif version < Version("4.2"):
+            self.gnu_mirror_path = "sed/sed-{0}.tar.gz".format(version)
+        return super(Sed, self).url_for_version(version)
+
+    version('4.8', sha256='f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633')
     version('4.2.2', sha256='f048d1838da284c8bc9753e4506b85a1e0cc1ea8999d36f6995bcb9460cddbd7')
 
     executables = ['^sed$']


### PR DESCRIPTION
This PR adds the latest version of `sed`. In addition, it updates `gnu_mirror_path` to account for changes in the archive format used.