### PR TITLE
screen: add v4.9.0, add required build deps

### DIFF
--- a/var/spack/repos/builtin/packages/screen/package.py
+++ b/var/spack/repos/builtin/packages/screen/package.py
@@ -14,6 +14,7 @@ class Screen(AutotoolsPackage, GNUMirrorPackage):
     homepage = "https://www.gnu.org/software/screen/"
     gnu_mirror_path = "screen/screen-4.3.1.tar.gz"
 
+    version('4.9.0', sha256='f9335281bb4d1538ed078df78a20c2f39d3af9a4e91c57d084271e0289c730f4')
     version('4.8.0', sha256='6e11b13d8489925fde25dfb0935bf6ed71f9eb47eff233a181e078fde5655aa1')
     version('4.6.2', sha256='1b6922520e6a0ce5e28768d620b0f640a6631397f95ccb043b70b91bb503fa3a')
     version('4.3.1', sha256='fa4049f8aee283de62e283d427f2cfd35d6c369b40f7f45f947dbfd915699d63')
@@ -34,3 +35,6 @@ class Screen(AutotoolsPackage, GNUMirrorPackage):
     version('3.7.1', sha256='0cd5b1a2cbba6bb2f2bc2145aec650abf02541fd3a2071117a99e4982f6e01da')
 
     depends_on('ncurses')
+    depends_on('autoconf', type='build', when='@4.9.0:')
+    depends_on('automake', type='build', when='@4.9.0:')
+    depends_on('libtool', type='build', when='@4.9.0:')


### PR DESCRIPTION
This PR adds the latest version of `screen`. In addition, it updates the build dependencies.