### PR TITLE
[py-pyworld] Limiting numpy version.

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyworld/package.py
+++ b/var/spack/repos/builtin/packages/py-pyworld/package.py
@@ -18,5 +18,5 @@ class PyPyworld(PythonPackage):
     version('0.3.0', sha256='e19b5d8445e0c4fc45ded71863aeaaf2680064b4626b0e7c90f72e9ace9f6b5b')
 
     depends_on('py-setuptools',     type='build')
-    depends_on('py-numpy',          type=('build', 'run'))
+    depends_on('py-numpy@:1.19',    type=('build', 'run'))
     depends_on('py-cython@0.24.0:', type='build')


### PR DESCRIPTION
@adamjstewart This was bugging me this morning. I double checked the commit log for py-pyworld and it pointed me towards https://zenn.dev/ymd_h/articles/934a90e1468a05. I think the reason we didn't get any complaints is that a dependent of py-pyworld was holding the numpy version down.