### PR TITLE
uninstall: fix dependency check

### DIFF
--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -235,7 +235,7 @@ def do_uninstall(env, specs, force):
 
         # If this spec is only used as a build dependency, we can uninstall
         return all(
-            dspec.deptypes == ("build",)
+            dspec.deptypes == ("build",) or not dspec.parent.installed
             for dspec in record.spec.edges_from_dependents()
         )
 


### PR DESCRIPTION
The dependency check currently checks whether there are only build dependencies left for a particular package. However, the database also contains uninstalled packages, which can cause the check to fail.

For instance, with `bison` and `flex` having already been uninstalled, `m4` will have the following dependents:
```
bison ('build', 'run')--> m4
flex ('build',)--> m4
libnl ('build',)--> m4
```
`bison` and `flex` should be ignored in this case because they are not installed anymore.

Fixes #30673

cc @tgamblin