### PR TITLE
gplates: add v2.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/gplates/package.py
+++ b/var/spack/repos/builtin/packages/gplates/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import os
+
 from spack import *
 
 

--- a/var/spack/repos/builtin/packages/gplates/package.py
+++ b/var/spack/repos/builtin/packages/gplates/package.py
@@ -34,7 +34,7 @@ class Gplates(CMakePackage):
     depends_on('glew')
     depends_on('python@2:3', when='@2.3:')
     depends_on('python@2', when='@:2.1')
-    depends_on('boost@1.35:+program_options+python+system+thread', when='@2.3:')
+    depends_on('boost@1.35:1.75+program_options+python+system+thread', when='@2.3:')
     # Boost's Python library has a different name starting with 1.67.
     depends_on('boost@1.34:1.66+program_options+python+system+thread', when='@2.1')
     # There were changes to Boost's optional in 1.61 that make the build fail.


### PR DESCRIPTION
@michaelkuhn can you help test this? You're the only one who's ever contributed to this package. I especially want to see if the boost variants are sufficient and if the package can be built with the latest version of GDAL.

I'm deprecating GDAL 1 and 2 in #30668 and am trying to see if the latest version of gplates works with GDAL 3 yet. I tried compiling on macOS but QWT is built as a framework so gplates' cmake can't find it. I don't know enough about QMake to build a non-framework version of QWT.

P.S. Are you okay with removing the old gplates versions? The only disadvantage of the latest version is that it requires manual download now. But GDAL 1 and Python 2 are long since dead so modern version support is probably more important.