### PR TITLE
bugfix: handle new `dag_hash()` on old concrete specs gracefully.

### DIFF
--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -1714,7 +1714,10 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 hash_content.append(source_id.encode('utf-8'))
 
         # patch sha256's
-        if self.spec.concrete:
+        # Only include these if they've been assigned by the concretizer.
+        # We check spec._patches_assigned instead of spec.concrete because
+        # we have to call package_hash *before* marking specs concrete
+        if self.spec._patches_assigned():
             hash_content.extend(
                 ':'.join((p.sha256, str(p.level))).encode('utf-8')
                 for p in self.spec.patches

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2107,8 +2107,9 @@ class SpecBuilder(object):
         for s in self._specs.values():
             _develop_specs_from_env(s, ev.active_environment())
 
-        for s in self._specs.values():
-            s._mark_concrete()
+        # mark concrete and assign hashes to all specs in the solve
+        for root in roots.values():
+            root._finalize_concretization()
 
         for s in self._specs.values():
             spack.spec.Spec.ensure_no_deprecated(s)


### PR DESCRIPTION
bugfix: handle new `dag_hash()` on old concrete specs gracefully.

Trying to compute `dag_hash()` or `package_hash()` on a concrete spec that doesn't have a `_package_hash` attribute would attempt to recompute the package hash.

This most commonly manifests as a failed lookup of a namespace if you attempt to uninstall or compute the hashes of packages in exsternal repositories that aren't registered, e.g.:

```console
> spack spec --json c/htno
==> Error: Unknown namespace: myrepo
```

While it wouldn't change the already-assigned `dag_hash` value, this behavior is incorrect, since the package file for a previously concrete spec:
  1. might have changed since concretization,
  2. might not exist anymore, or
  3. might just not be findable by Spack.

This PR ensurs that the package hash can't be computed on older concrete specs. Instead of calling `package_hash()` from within `to_node_dict()`, we now check for the `_package_hash` attribute and only add the package_hash to the spec record if it's there.

This adds a new `_assign_hash()` method to `Spec` that handles these tricky semantics of There are special semantics for `package_hash`. Since we cannot compute the package hash lazily, so it *must* be computed at concretization time, so this PR also assigns both `package_hash` and `dag_hash` during concretization.

- [x] Add an assert to `package_hash()` so it can't be called on specs for which it would be wrong.
- [x] Add an `_assign_hash()` method to handle tricky semantics of `package_hash` and `dag_hash`.
- [x] Rework concretization to call `_assign_hash()` before and after marking specs concrete.
- [x] regression test