### PR TITLE
bugfix: use deterministic edge order for `spack graph`

### DIFF
--- a/lib/spack/spack/graph.py
+++ b/lib/spack/spack/graph.py
@@ -493,9 +493,11 @@ class AsciiGraph(object):
 
                 # Replace node with its dependencies
                 self._frontier.pop(i)
-                deps = node.dependencies(deptype=self.deptype)
-                if deps:
-                    deps = sorted((d.dag_hash() for d in deps), reverse=True)
+                edges = sorted(
+                    node.edges_to_dependencies(deptype=self.deptype), reverse=True
+                )
+                if edges:
+                    deps = [e.spec.dag_hash() for e in edges]
                     self._connect_deps(i, deps, "new-deps")  # anywhere.
 
                 elif self._frontier:

--- a/lib/spack/spack/test/graph.py
+++ b/lib/spack/spack/test/graph.py
@@ -104,7 +104,7 @@ o | mpich
  /
 o dyninst
 |\
-o | libdwarf
+| o libdwarf
 |/
 o libelf
 '''


### PR DESCRIPTION
Previously we sorted by hash values for `spack graph`, but changing hashes can make the test brittle and the node order seem nondeterministic to users.

- [x] Sort nodes in `spack graph` by the default edge order, which takes into account parent and child names as well as dependency types.
- [x] Update ASCII test output for new order.