### PR TITLE
[petsc] fix an error about handling a provider of Scalapack.

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -442,7 +442,6 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         # Activates library support if needed (i.e. direct dependency)
         jpeg_sp = spec['jpeg'].name if 'jpeg' in spec else 'jpeg'
-        scalapack_sp = 'scalapack'
 
         # to be used in the list of libraries below
         if '+fortran' in spec:
@@ -489,7 +488,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 ('libyaml', 'yaml', True, True),
                 'hwloc',
                 (jpeg_sp, 'libjpeg', True, True),
-                (scalapack_sp, 'scalapack', False, True),
+                ('scalapack', 'scalapack', False, True),
                 'strumpack',
                 'mmg',
                 'parmmg',

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -442,7 +442,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
 
         # Activates library support if needed (i.e. direct dependency)
         jpeg_sp = spec['jpeg'].name if 'jpeg' in spec else 'jpeg'
-        scalapack_sp = spec['scalapack'].name if 'scalapack' in spec else 'scalapack'
+        scalapack_sp = 'scalapack'
 
         # to be used in the list of libraries below
         if '+fortran' in spec:


### PR DESCRIPTION
This PR fixes an error that occurs when a provider of "scalapack" implements `scalapack_libs` but not `libs`.
Discussed in https://github.com/spack/spack/pull/25074#discussion_r871131051