### PR TITLE
Extrae+intel oneapi mpi

### DIFF
--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -93,8 +93,8 @@ class Extrae(AutotoolsPackage):
 
         if '^intel-oneapi-mpi' in spec:
                 mpiroot = spec['mpi'].prefix
-                args += ["--with-mpi-headers=%s" % os.path.join(mpiroot, "include")]
-                args += ["--with-mpi-libs=%s" % os.path.join(mpiroot, "lib/release")]
+                args += ["--with-mpi-headers=%s" % os.path.join(mpiroot, "mpi/latest/include")]
+                args += ["--with-mpi-libs=%s" % os.path.join(mpiroot, "mpi/latest/lib/release")]
 
         args += (["--with-papi=%s" % spec['papi'].prefix]
                  if '+papi' in self.spec else

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -91,6 +91,11 @@ class Extrae(AutotoolsPackage):
                 "--with-xml-prefix=%s" % spec['libxml2'].prefix,
                 "--with-binutils=%s" % spec['binutils'].prefix]
 
+        if '^intel-oneapi-mpi' in spec:
+                mpiroot = spec['mpi'].prefix
+                args += ["--with-mpi-headers=%s" % os.path.join(mpiroot, "include")]
+                args += ["--with-mpi-libs=%s" % os.path.join(mpiroot, "lib/release")]
+
         args += (["--with-papi=%s" % spec['papi'].prefix]
                  if '+papi' in self.spec else
                  ["--without-papi"])

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -83,18 +83,18 @@ class Extrae(AutotoolsPackage):
 
     def configure_args(self):
         spec = self.spec
-        args = ["--with-mpi=%s" % spec['mpi'].prefix,
+        if '^intel-oneapi-mpi' in spec:
+            mpiroot = spec['mpi'].component_path
+        else:
+            mpiroot = spec['mpi'].prefix
+
+        args = ["--with-mpi=%s" % mpiroot,
                 "--with-unwind=%s" % spec['libunwind'].prefix,
                 "--with-boost=%s" % spec['boost'].prefix,
                 "--with-dwarf=%s" % spec['libdwarf'].prefix,
                 "--with-elf=%s" % spec['elf'].prefix,
                 "--with-xml-prefix=%s" % spec['libxml2'].prefix,
                 "--with-binutils=%s" % spec['binutils'].prefix]
-
-        if '^intel-oneapi-mpi' in spec:
-                mpiroot = spec['mpi'].prefix
-                args += ["--with-mpi-headers=%s" % os.path.join(mpiroot, "mpi/latest/include")]
-                args += ["--with-mpi-libs=%s" % os.path.join(mpiroot, "mpi/latest/lib/release")]
 
         args += (["--with-papi=%s" % spec['papi'].prefix]
                  if '+papi' in self.spec else


### PR DESCRIPTION
New PR that replaces #23956. Rebased on current develop.

I had removed my spack repo. GitHub complained about a non-existing source branch, hence the new PR.

This allows Extrae's configure to find intel oneAPI MPI libraries and headers.

@alalazo Please merge.