### PR TITLE
updated v2.11.7

### DIFF
--- a/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
+++ b/var/spack/repos/builtin/packages/aws-parallelcluster/package.py
@@ -13,13 +13,14 @@ class AwsParallelcluster(PythonPackage):
     tool to deploy and manage HPC clusters in the AWS cloud."""
 
     homepage = "https://github.com/aws/aws-parallelcluster"
-    pypi = "aws-parallelcluster/aws-parallelcluster-2.11.6.tar.gz"
+    pypi = "aws-parallelcluster/aws-parallelcluster-2.11.7.tar.gz"
 
     maintainers = [
         'charlesg3', 'chenwany', 'demartinofra', 'enrico-usai', 'francesco-giordano',
         'gmarciani', 'hanwen-pcluste', 'lukeseawalker',
     ]
 
+    version('2.11.7', sha256='f7c51cf1c94787f56e0661e39860ecc9275efeacc88716b7c9f14053ec7fbd35')
     version('2.11.6', sha256='4df4bcf966f523bcdf5b4f68ed0ef347eebae70a074cd098b15bc8a6be27217c')
     version('2.11.5', sha256='7499f88387cbe2cb73f9fddeee3363117f7ef1524d6a73e77bb07900040baebb')
     version('2.11.4', sha256='449537ccda57f91f4ec6ae0c94a8e2b1a789f08f80245fadb28f44a4351d5da4')


### PR DESCRIPTION
** Changes
Updated aws-parallelcluster to v2.11.7

** Tests
Local installation:
```
==> Installing aws-parallelcluster-2.11.7-pp42vkp7453burh5deuyefax2lofhvnk
==> No binary for aws-parallelcluster-2.11.7-pp42vkp7453burh5deuyefax2lofhvnk found: installing from source
==> Fetching https://files.pythonhosted.org/packages/source/a/aws-parallelcluster/aws-parallelcluster-2.11.7.tar.gz
==> No patches needed for aws-parallelcluster
==> aws-parallelcluster: Executing phase: 'install'
==> aws-parallelcluster: Successfully installed aws-parallelcluster-2.11.7-pp42vkp7453burh5deuyefax2lofhvnk
  Fetch: 3.20s.  Build: 1.51s.  Total: 4.71s.
[+] /Users/giordafr/spack/opt/spack/darwin-monterey-skylake/apple-clang-13.1.6/aws-parallelcluster-2.11.7-pp42vkp7453burh5deuyefax2lofhvnk
```