### PR TITLE
Fix unit-test checking two steps installation of specs with conflicting build-deps

### DIFF
--- a/lib/spack/spack/test/spec_dag.py
+++ b/lib/spack/spack/test/spec_dag.py
@@ -135,8 +135,6 @@ def test_installed_deps(monkeypatch, mock_packages):
     assert spack.version.Version('3') == a_spec[b][d].version
     assert spack.version.Version('3') == a_spec[d].version
 
-    # TODO: with reuse, this will be different -- verify the reuse case
-
 
 @pytest.mark.usefixtures('config')
 def test_specify_preinstalled_dep():

--- a/var/spack/repos/builtin.mock/packages/installed-deps-b/package.py
+++ b/var/spack/repos/builtin.mock/packages/installed-deps-b/package.py
@@ -22,5 +22,5 @@ class InstalledDepsB(Package):
     version("2", "abcdef0123456789abcdef0123456789")
     version("3", "def0123456789abcdef0123456789abc")
 
-    depends_on("installed-deps-d", type=("build", "link"))
+    depends_on("installed-deps-d@3:", type=("build", "link"))
     depends_on("installed-deps-e", type=("build", "link"))


### PR DESCRIPTION
Modifications:
- [x] Add a constraint to a mock package to model better the case tested (installation with conflicting build deps that require 2 steps)
- [x] Remove TODO at the end of the test

It is not fully clear to me why this test doesn't fail on `develop`, but was failing on #28941 after the rebase (commit cherry-picked from there)