### PR TITLE
Windows: Support for Clingo and dependencies

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -46,6 +46,8 @@ import spack.version
 #: Name of the file containing metadata about the bootstrapping source
 METADATA_YAML_FILENAME = "metadata.yaml"
 
+is_windows = sys.platform == 'win32'
+
 #: Map a bootstrapper type to the corresponding class
 _bootstrap_methods = {}
 
@@ -655,6 +657,8 @@ def _add_externals_if_missing():
         # GnuPG
         spack.repo.path.get_pkg_class("gawk"),
     ]
+    if is_windows:
+        search_list.extend(spack.repo.path.get('winbison'))
     detected_packages = spack.detection.by_executable(search_list)
     spack.detection.update_configuration(detected_packages, scope="bootstrap")
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -46,7 +46,7 @@ import spack.version
 #: Name of the file containing metadata about the bootstrapping source
 METADATA_YAML_FILENAME = "metadata.yaml"
 
-is_windows = sys.platform == 'win32'
+is_windows = sys.platform == "win32"
 
 #: Map a bootstrapper type to the corresponding class
 _bootstrap_methods = {}
@@ -658,7 +658,7 @@ def _add_externals_if_missing():
         spack.repo.path.get_pkg_class("gawk"),
     ]
     if is_windows:
-        search_list.extend(spack.repo.path.get('winbison'))
+        search_list.extend(spack.repo.path.get_pkg_class("winbison"))
     detected_packages = spack.detection.by_executable(search_list)
     spack.detection.update_configuration(detected_packages, scope="bootstrap")
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -109,7 +109,8 @@ SPACK_SYSTEM_DIRS = "SPACK_SYSTEM_DIRS"
 
 
 # Platform-specific library suffix.
-dso_suffix = "dylib" if sys.platform == "darwin" else "so"
+dso_suffix = "dylib" if sys.platform == "darwin" else "dll" if sys.platform == "win32" else "so"
+stat_suffix = "lib" if sys.platform == "win32" else "a"
 
 
 def should_set_parallel_jobs(jobserver_support=False):

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -109,7 +109,13 @@ SPACK_SYSTEM_DIRS = "SPACK_SYSTEM_DIRS"
 
 
 # Platform-specific library suffix.
-dso_suffix = "dylib" if sys.platform == "darwin" else "dll" if sys.platform == "win32" else "so"
+if sys.platform == "darwin":
+    dso_suffix = "dylib"
+elif sys.platform == "win32":
+    dso_suffix = "dll"
+else:
+    dso_suffix = "so"
+
 stat_suffix = "lib" if sys.platform == "win32" else "a"
 
 

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -107,7 +107,7 @@ class AutotoolsPackage(PackageBase):
     depends_on("gnuconfig", type="build", when="target=ppc64le:")
     depends_on("gnuconfig", type="build", when="target=aarch64:")
     depends_on("gnuconfig", type="build", when="target=riscv64:")
-    conflicts('platform=windows')
+    conflicts("platform=windows")
 
     @property
     def _removed_la_files_log(self):

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -107,7 +107,7 @@ class AutotoolsPackage(PackageBase):
     depends_on("gnuconfig", type="build", when="target=ppc64le:")
     depends_on("gnuconfig", type="build", when="target=aarch64:")
     depends_on("gnuconfig", type="build", when="target=riscv64:")
-    conflicts("platform=windows")
+    conflicts('platform=windows')
 
     @property
     def _removed_la_files_log(self):

--- a/lib/spack/spack/build_systems/cmake.py
+++ b/lib/spack/spack/build_systems/cmake.py
@@ -19,7 +19,6 @@ from llnl.util.filesystem import working_dir
 import spack.build_environment
 from spack.directives import conflicts, depends_on, variant
 from spack.package_base import InstallError, PackageBase, run_after
-from spack.util.path import convert_to_posix_path
 
 # Regex to extract the primary generator from the CMake generator
 # string.
@@ -176,7 +175,7 @@ class CMakePackage(PackageBase):
         args = [
             "-G",
             generator,
-            define("CMAKE_INSTALL_PREFIX", convert_to_posix_path(pkg.prefix)),
+            define("CMAKE_INSTALL_PREFIX", pkg.prefix),
             define("CMAKE_BUILD_TYPE", build_type),
             define("BUILD_TESTING", pkg.run_tests),
         ]

--- a/lib/spack/spack/test/conftest.py
+++ b/lib/spack/spack/test/conftest.py
@@ -634,12 +634,11 @@ def configuration_dir(tmpdir_factory, linux_os):
 
     # Slightly modify config.yaml and compilers.yaml
     if is_windows:
-        solver = "original"
         locks = False
     else:
-        solver = os.environ.get("SPACK_TEST_SOLVER", "clingo")
         locks = True
 
+    solver = os.environ.get("SPACK_TEST_SOLVER", "clingo")
     config_yaml = test_config.join("config.yaml")
     modules_root = tmpdir_factory.mktemp("share")
     tcl_root = modules_root.ensure("modules", dir=True)

--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -67,6 +67,8 @@ class ClingoBootstrap(Clingo):
             if "+static_libstdcpp" in self.spec:
                 # This is either linux or cray
                 opts = "-static-libstdc++ -static-libgcc -Wl,--exclude-libs,ALL"
+        elif "platform=windows" in self.spec:
+            pass
         else:
             msg = 'unexpected compiler for spec "{0}"'.format(self.spec)
             raise RuntimeError(msg)

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -8,7 +8,7 @@ import sys
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
 
-is_windows = sys.platform == 'win32'
+is_windows = sys.platform == "win32"
 
 
 class Clingo(CMakePackage):
@@ -49,24 +49,22 @@ class Clingo(CMakePackage):
 
     with when("@spack,master"):
         depends_on("re2c@0.13:", type="build")
-        depends_on("bison@2.5:", type="build", when='platform=linux')
-        depends_on('bison@2.5:', type="build", when='platform=darwin')
-        depends_on('bison@2.5:', type="build", when='platform=cray')
+        depends_on("bison@2.5:", type="build", when="platform=linux")
+        depends_on("bison@2.5:", type="build", when="platform=darwin")
+        depends_on("bison@2.5:", type="build", when="platform=cray")
 
-    with when('platform=windows'):
-        depends_on('re2c@0.13:', type="build")
-        depends_on('winbison@2.4.12:', when='platform=windows')
+    with when("platform=windows"):
+        depends_on("re2c@0.13:", type="build")
+        depends_on("winbison@2.4.12:")
 
     with when("+python"):
         extends("python")
         depends_on("python", type=("build", "link", "run"))
         # Clingo 5.5.0 supports Python 3.6 or later and needs CFFI
-        depends_on('python@3.6.0:', type=('build', 'link', 'run'), when='@5.5.0:')
-        depends_on('py-cffi', type=('build', 'run'), when='@5.5.0: platform=darwin')
-        depends_on('py-cffi', type=('build', 'run'), when='@5.5.0: platform=linux')
-        depends_on('py-cffi', type=('build', 'run'), when='@5.5.0: platform=cray')
-
-
+        depends_on("python@3.6.0:", type=("build", "link", "run"), when="@5.5.0:")
+        depends_on("py-cffi", type=("build", "run"), when="@5.5.0: platform=darwin")
+        depends_on("py-cffi", type=("build", "run"), when="@5.5.0: platform=linux")
+        depends_on("py-cffi", type=("build", "run"), when="@5.5.0: platform=cray")
 
     patch("python38.patch", when="@5.3:5.4.0")
 

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -3,12 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
-
-is_windows = sys.platform == "win32"
 
 
 class Clingo(CMakePackage):

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -3,8 +3,12 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 from spack.compiler import UnsupportedCompilerFlag
 from spack.package import *
+
+is_windows = sys.platform == 'win32'
 
 
 class Clingo(CMakePackage):
@@ -45,14 +49,24 @@ class Clingo(CMakePackage):
 
     with when("@spack,master"):
         depends_on("re2c@0.13:", type="build")
-        depends_on("bison@2.5:", type="build")
+        depends_on("bison@2.5:", type="build", when='platform=linux')
+        depends_on('bison@2.5:', type="build", when='platform=darwin')
+        depends_on('bison@2.5:', type="build", when='platform=cray')
+
+    with when('platform=windows'):
+        depends_on('re2c@0.13:', type="build")
+        depends_on('winbison@2.4.12:', when='platform=windows')
 
     with when("+python"):
         extends("python")
         depends_on("python", type=("build", "link", "run"))
         # Clingo 5.5.0 supports Python 3.6 or later and needs CFFI
-        depends_on("python@3.6.0:", type=("build", "link", "run"), when="@5.5.0:")
-        depends_on("py-cffi", type=("build", "run"), when="@5.5.0:")
+        depends_on('python@3.6.0:', type=('build', 'link', 'run'), when='@5.5.0:')
+        depends_on('py-cffi', type=('build', 'run'), when='@5.5.0: platform=darwin')
+        depends_on('py-cffi', type=('build', 'run'), when='@5.5.0: platform=linux')
+        depends_on('py-cffi', type=('build', 'run'), when='@5.5.0: platform=cray')
+
+
 
     patch("python38.patch", when="@5.3:5.4.0")
 

--- a/var/spack/repos/builtin/packages/re2c/package.py
+++ b/var/spack/repos/builtin/packages/re2c/package.py
@@ -3,10 +3,14 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+
 from spack.package import *
 
+is_windows = sys.platform == 'win32'
 
-class Re2c(AutotoolsPackage):
+
+class Re2c(Package):
     """re2c: a free and open-source lexer generator for C and C++"""
 
     homepage = "https://re2c.org/index.html"
@@ -22,6 +26,15 @@ class Re2c(AutotoolsPackage):
     version("1.3", sha256="f37f25ff760e90088e7d03d1232002c2c2672646d5844fdf8e0d51a5cd75a503")
     version("1.2.1", sha256="1a4cd706b5b966aeffd78e3cf8b24239470ded30551e813610f9cd1a4e01b817")
 
+    phases = ['configure', 'build', 'install']
+
+    @property
+    def make(self):
+        if is_windows:
+            return ninja
+        else:
+            return make
+
     def configure_args(self):
         return [
             "--disable-benchmarks",
@@ -32,3 +45,21 @@ class Re2c(AutotoolsPackage):
             "--disable-libs",  # experimental
             "--enable-golang",
         ]
+
+    def configure(self, spec, prefix):
+        with working_dir(self.stage.source_path, create=True):
+            configure("--prefix=" + prefix, *self.configure_args())
+
+    @when('platform=windows')
+    def configure(self, spec, prefix):
+        with working_dir(self.stage.source_path, create=True):
+            args = ['-G', 'Ninja', '-DCMAKE_INSTALL_PREFIX=%s' % prefix]
+            cmake(*args)
+
+    def build(self, spec, prefix):
+        with working_dir(self.stage.source_path):
+            self.make()
+
+    def install(self, spec, prefix):
+        with working_dir(self.stage.source_path):
+            self.make('install')

--- a/var/spack/repos/builtin/packages/re2c/package.py
+++ b/var/spack/repos/builtin/packages/re2c/package.py
@@ -29,7 +29,7 @@ class Re2c(Package):
     phases = ["configure", "build", "install"]
 
     @property
-    def make(self):
+    def make_tool(self):
         if is_windows:
             return ninja
         else:
@@ -58,8 +58,8 @@ class Re2c(Package):
 
     def build(self, spec, prefix):
         with working_dir(self.stage.source_path):
-            self.make()
+            self.make_tool()
 
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path):
-            self.make("install")
+            self.make_tool("install")

--- a/var/spack/repos/builtin/packages/re2c/package.py
+++ b/var/spack/repos/builtin/packages/re2c/package.py
@@ -7,7 +7,7 @@ import sys
 
 from spack.package import *
 
-is_windows = sys.platform == 'win32'
+is_windows = sys.platform == "win32"
 
 
 class Re2c(Package):
@@ -26,7 +26,7 @@ class Re2c(Package):
     version("1.3", sha256="f37f25ff760e90088e7d03d1232002c2c2672646d5844fdf8e0d51a5cd75a503")
     version("1.2.1", sha256="1a4cd706b5b966aeffd78e3cf8b24239470ded30551e813610f9cd1a4e01b817")
 
-    phases = ['configure', 'build', 'install']
+    phases = ["configure", "build", "install"]
 
     @property
     def make(self):
@@ -50,10 +50,10 @@ class Re2c(Package):
         with working_dir(self.stage.source_path, create=True):
             configure("--prefix=" + prefix, *self.configure_args())
 
-    @when('platform=windows')
+    @when("platform=windows")
     def configure(self, spec, prefix):
         with working_dir(self.stage.source_path, create=True):
-            args = ['-G', 'Ninja', '-DCMAKE_INSTALL_PREFIX=%s' % prefix]
+            args = ["-G", "Ninja", "-DCMAKE_INSTALL_PREFIX=%s" % prefix]
             cmake(*args)
 
     def build(self, spec, prefix):
@@ -62,4 +62,4 @@ class Re2c(Package):
 
     def install(self, spec, prefix):
         with working_dir(self.stage.source_path):
-            self.make('install')
+            self.make("install")

--- a/var/spack/repos/builtin/packages/winbison/package.py
+++ b/var/spack/repos/builtin/packages/winbison/package.py
@@ -1,0 +1,47 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os
+import re
+
+from spack.package import *
+
+
+class Winbison(CMakePackage):
+    """Bison is a general-purpose parser generator that converts
+    an annotated context-free grammar into a deterministic LR or
+    generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+    homepage = "https://github.com/lexxmark/winflexbison#readme"
+    url = "https://github.com/lexxmark/winflexbison/archive/v2.5.25.tar.gz"
+
+    executables = [r'^bison(.*)?$']
+
+    version('2.5.25', sha256='8e1b71e037b524ba3f576babb0cf59182061df1f19cd86112f085a882560f60b')
+    version('2.5.24', sha256='a49d6e310636e3487e1e066e411d908cfeae2d5b5fde1f3cf74fe1d6d4301062')
+    version('2.5.23', sha256='445bd1bcb90e0c84e97f6e44de76869f8e778c60ddbd7c39a7b2142f8ba43e61')
+    version('2.5.22', sha256='697c2c4af3308625605b75498bd63a9a294660f8e43a4c35452cf4334fa4a530')
+    version('2.5.21', sha256='41e31960cc7e8ccd4b95bd770a6279d31ab7dee156e6fb4e55834f8f220637f4')
+    version('2.5.20', sha256='cd29f888f167128c22211444c6e31b5f4823a7de0e23d8039559ee87b80349c9')
+    version('2.5.19', sha256='265f930e5b2e8e24d179d703668355550b226d033fdbe0a9232c671591ddfd0b')
+    version('2.5.18', sha256='1db991bebaded832427539b6b28a8f36948e5ce3db5701b5104f85b66b8484de')
+    version('2.5.17', sha256='2ab4c895f9baf03dfdfbb2dc4abe60e87bf46efe12ed1218c38fd7761f0f58fc')
+    version('2.5.16', sha256='39fe57de6a52dc83c8a9ece90b8484d8d2b764e24e22e30ba5dc018328019a4d')
+    version('2.5.15', sha256='a5ea5b98bb8d4054961f7bc82f458b4a9ef60c5e2dedcaba23a8e4363c2e6dfc')
+    version('2.5.14', sha256='2ace5c964fb4b45279544669950412dbe4e86908c03bd5ebc8c8d306e458e97d')
+    version('2.4.12', sha256='fcffc223897e14f2b5dce2db1c832f297cc43a1204e4b3fd713f1dc410e956e4')
+
+    build_directory = 'spack-build'
+    cmake_dir = os.path.join(build_directory, 'CMakeBuild')
+
+    variant('build_type', default='Release',
+            description='CMake build type',
+            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+
+    @classmethod
+    def determine_version(cls, exe):
+        output = Executable(exe)('--version', output=str, error=str)
+        match = re.search(r'bison )\s+(\S+)', output)
+        return match.group(1) if match else None

--- a/var/spack/repos/builtin/packages/winbison/package.py
+++ b/var/spack/repos/builtin/packages/winbison/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -17,31 +17,34 @@ class Winbison(CMakePackage):
     homepage = "https://github.com/lexxmark/winflexbison#readme"
     url = "https://github.com/lexxmark/winflexbison/archive/v2.5.25.tar.gz"
 
-    executables = [r'^bison(.*)?$']
+    executables = [r"^bison(.*)?$"]
 
-    version('2.5.25', sha256='8e1b71e037b524ba3f576babb0cf59182061df1f19cd86112f085a882560f60b')
-    version('2.5.24', sha256='a49d6e310636e3487e1e066e411d908cfeae2d5b5fde1f3cf74fe1d6d4301062')
-    version('2.5.23', sha256='445bd1bcb90e0c84e97f6e44de76869f8e778c60ddbd7c39a7b2142f8ba43e61')
-    version('2.5.22', sha256='697c2c4af3308625605b75498bd63a9a294660f8e43a4c35452cf4334fa4a530')
-    version('2.5.21', sha256='41e31960cc7e8ccd4b95bd770a6279d31ab7dee156e6fb4e55834f8f220637f4')
-    version('2.5.20', sha256='cd29f888f167128c22211444c6e31b5f4823a7de0e23d8039559ee87b80349c9')
-    version('2.5.19', sha256='265f930e5b2e8e24d179d703668355550b226d033fdbe0a9232c671591ddfd0b')
-    version('2.5.18', sha256='1db991bebaded832427539b6b28a8f36948e5ce3db5701b5104f85b66b8484de')
-    version('2.5.17', sha256='2ab4c895f9baf03dfdfbb2dc4abe60e87bf46efe12ed1218c38fd7761f0f58fc')
-    version('2.5.16', sha256='39fe57de6a52dc83c8a9ece90b8484d8d2b764e24e22e30ba5dc018328019a4d')
-    version('2.5.15', sha256='a5ea5b98bb8d4054961f7bc82f458b4a9ef60c5e2dedcaba23a8e4363c2e6dfc')
-    version('2.5.14', sha256='2ace5c964fb4b45279544669950412dbe4e86908c03bd5ebc8c8d306e458e97d')
-    version('2.4.12', sha256='fcffc223897e14f2b5dce2db1c832f297cc43a1204e4b3fd713f1dc410e956e4')
+    version("2.5.25", sha256="8e1b71e037b524ba3f576babb0cf59182061df1f19cd86112f085a882560f60b")
+    version("2.5.24", sha256="a49d6e310636e3487e1e066e411d908cfeae2d5b5fde1f3cf74fe1d6d4301062")
+    version("2.5.23", sha256="445bd1bcb90e0c84e97f6e44de76869f8e778c60ddbd7c39a7b2142f8ba43e61")
+    version("2.5.22", sha256="697c2c4af3308625605b75498bd63a9a294660f8e43a4c35452cf4334fa4a530")
+    version("2.5.21", sha256="41e31960cc7e8ccd4b95bd770a6279d31ab7dee156e6fb4e55834f8f220637f4")
+    version("2.5.20", sha256="cd29f888f167128c22211444c6e31b5f4823a7de0e23d8039559ee87b80349c9")
+    version("2.5.19", sha256="265f930e5b2e8e24d179d703668355550b226d033fdbe0a9232c671591ddfd0b")
+    version("2.5.18", sha256="1db991bebaded832427539b6b28a8f36948e5ce3db5701b5104f85b66b8484de")
+    version("2.5.17", sha256="2ab4c895f9baf03dfdfbb2dc4abe60e87bf46efe12ed1218c38fd7761f0f58fc")
+    version("2.5.16", sha256="39fe57de6a52dc83c8a9ece90b8484d8d2b764e24e22e30ba5dc018328019a4d")
+    version("2.5.15", sha256="a5ea5b98bb8d4054961f7bc82f458b4a9ef60c5e2dedcaba23a8e4363c2e6dfc")
+    version("2.5.14", sha256="2ace5c964fb4b45279544669950412dbe4e86908c03bd5ebc8c8d306e458e97d")
+    version("2.4.12", sha256="fcffc223897e14f2b5dce2db1c832f297cc43a1204e4b3fd713f1dc410e956e4")
 
-    build_directory = 'spack-build'
-    cmake_dir = os.path.join(build_directory, 'CMakeBuild')
+    build_directory = "spack-build"
+    cmake_dir = os.path.join(build_directory, "CMakeBuild")
 
-    variant('build_type', default='Release',
-            description='CMake build type',
-            values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
+    variant(
+        "build_type",
+        default="Release",
+        description="CMake build type",
+        values=("Debug", "Release", "RelWithDebInfo", "MinSizeRel"),
+    )
 
     @classmethod
     def determine_version(cls, exe):
-        output = Executable(exe)('--version', output=str, error=str)
-        match = re.search(r'bison )\s+(\S+)', output)
+        output = Executable(exe)("--version", output=str, error=str)
+        match = re.search(r"bison )\s+(\S+)", output)
         return match.group(1) if match else None


### PR DESCRIPTION
This PR ports Clingo, Bison, re2c, and other related components of Spack to function on Windows.

PR is currently draft pending discussion on Bison package implementation.

Clingo and re2c prove simple to port, however Bison has no official support for use of MSVC compilers, and so the port is more complex.

A project [winflexbison](https://github.com/lexxmark/winflexbison) vendors support for both Bison and Flex. This is currently introduced into Spack as a package named `winbison` and only support for the Bison components of the project is added.
Alternatively, this package could be introduced as a provider for Bison and Flex, packages which would then need to be made virtual, and exposed providers on a per platform basis. 

An additional alternative that has been proposed by @scheibelp is the creation of separate repositories for packages where support across Windows/Unix based platforms warrants the creation of a separate codebase. 