### PR TITLE
runc: fixed loading of binary to PATH

### DIFF
--- a/var/spack/repos/builtin/packages/runc/package.py
+++ b/var/spack/repos/builtin/packages/runc/package.py
@@ -22,3 +22,4 @@ class Runc(MakefilePackage):
 
     def install(self, spec, prefix):
         make('install', 'PREFIX=' + prefix)
+        symlink(prefix.sbin, prefix.bin)


### PR DESCRIPTION
This PR fixes the inclusion of the `runc` binary into `PATH` when using `spack load` or declaring the package as a dependency.

Right now, when installing and loading the `runc` package, the binary cannot be found:
```
$ docker run --rm -it --entrypoint="" spack/ubuntu-bionic bash
root@4a654d0b3e67:~# . /opt/spack/share/spack/setup-env.sh
root@4a654d0b3e67:~# spack install runc
[...]

root@4a654d0b3e67:~# spack load runc
root@4a654d0b3e67:~# which runc
root@4a654d0b3e67:~# echo $PATH | grep runc
```

I believe this is due to the fact that `spack` only adds `bin` directories to `PATH`, but `runc`'s own build scripts install the binary in an `sbin` directory:
```
root@4a654d0b3e67:~# spack cd -i runc 
root@4a654d0b3e67:/opt/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.5.0/runc-1.0.2-cdvyhjsup4x6mi7r7fhul2a3dsy3pcuo# ls -l
total 0
drwxr-sr-x 1 root root 6 May 16 20:21 pkg
drwxr-sr-x 1 root root 8 May 16 20:21 sbin
root@4a654d0b3e67:/opt/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.5.0/runc-1.0.2-cdvyhjsup4x6mi7r7fhul2a3dsy3pcuo# ll sbin
total 13028
drwxr-sr-x 1 root root        8 May 16 20:21 ./
drwxr-sr-x 1 root root       32 May 16 20:23 ../
-rwxr-xr-x 1 root root 13337312 May 16 20:21 runc*
```

Creating a symlink is sufficient to resolve the issue, and avoids arranging a Spack-specific build destination:
```
root@4a654d0b3e67:/opt/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.5.0/runc-1.0.2-cdvyhjsup4x6mi7r7fhul2a3dsy3pcuo# ln -s $(pwd)/sbin bin
root@4a654d0b3e67:/opt/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.5.0/runc-1.0.2-cdvyhjsup4x6mi7r7fhul2a3dsy3pcuo# ls -l
total 4
lrwxrwxrwx 1 root root 112 May 16 20:23 bin -> /opt/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.5.0/runc-1.0.2-cdvyhjsup4x6mi7r7fhul2a3dsy3pcuo/sbin
drwxr-sr-x 1 root root   6 May 16 20:21 pkg
drwxr-sr-x 1 root root   8 May 16 20:21 sbin
root@4a654d0b3e67:/opt/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.5.0/runc-1.0.2-cdvyhjsup4x6mi7r7fhul2a3dsy3pcuo# cd

root@4a654d0b3e67:~# spack unload runc
root@4a654d0b3e67:~# spack load runc
root@4a654d0b3e67:~# which runc
/opt/spack/opt/spack/linux-ubuntu18.04-skylake_avx512/gcc-7.5.0/runc-1.0.2-cdvyhjsup4x6mi7r7fhul2a3dsy3pcuo/bin/runc
root@4a654d0b3e67:~# runc --version
runc version 1.0.2
spec: 1.0.2-dev
go: go1.18
libseccomp: 2.5.3
```

This PR creates such symlink during the `install` phase.