### PR TITLE
silo: more hdf5 version fixes

### DIFF
--- a/var/spack/repos/builtin/packages/silo/48-configure-f77.patch
+++ b/var/spack/repos/builtin/packages/silo/48-configure-f77.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 94e2a8a..fd7fbad 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -578,6 +578,7 @@ AC_PROG_CC
+ AC_PROG_CPP
+ if test -n "$FORTRAN"; then
+     AC_PROG_FC
++    AC_PROG_F77
+     AC_FC_LIBRARY_LDFLAGS
+     AC_FC_WRAPPERS
+ fi

--- a/var/spack/repos/builtin/packages/silo/H5FD_class_t-terminate.patch
+++ b/var/spack/repos/builtin/packages/silo/H5FD_class_t-terminate.patch
@@ -2,11 +2,13 @@ diff --git a/src/hdf5_drv/H5FDsilo.c b/src/hdf5_drv/H5FDsilo.c
 index 840dfd0..0d09147 100644
 --- a/src/hdf5_drv/H5FDsilo.c
 +++ b/src/hdf5_drv/H5FDsilo.c
-@@ -500,6 +500,7 @@ static const H5FD_class_t H5FD_silo_g = {
+@@ -500,6 +500,9 @@ static const H5FD_class_t H5FD_silo_g = {
      "silo",				        /*name			*/
      MAXADDR,				        /*maxaddr		*/
      H5F_CLOSE_WEAK,				/* fc_degree		*/
-+    NULL,                                       /*terminate             */
++#if HDF5_VERSION_GE(1,10,0)
++    0,                                          /* terminate            */
++#endif
      H5FD_silo_sb_size,                          /*sb_size               */
      H5FD_silo_sb_encode,                        /*sb_encode             */
      H5FD_silo_sb_decode,                        /*sb_decode             */

--- a/var/spack/repos/builtin/packages/silo/configure-AX_CHECK_COMPILE_FLAG.patch
+++ b/var/spack/repos/builtin/packages/silo/configure-AX_CHECK_COMPILE_FLAG.patch
@@ -1,0 +1,19 @@
+diff --git a/configure.ac b/configure.ac
+index 94e2a8a..3449233 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -762,10 +763,10 @@ dnl
+ # it is an argument to the -D argument. So, I think this is
+ # just totally bogus!
+ # Default to large file support
+-AX_CHECK_COMPILER_FLAGS("-D_LARGEFILE_SOURCE",CFLAGS="$CFLAGS -D_LARGEFILE_SOURCE";)
+-AX_CHECK_COMPILER_FLAGS("-D_LARGEFILE64_SOURCE",CFLAGS="$CFLAGS -D_LARGEFILE64_SOURCE";)
+-AX_CHECK_COMPILER_FLAGS("-D_FILE_OFFSET_BITS=64",CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64";)
+-AX_CHECK_COMPILER_FLAGS("-Wdeclaration-after-statement",CFLAGS="$CFLAGS -Wdeclaration-after-statement";)
++AX_CHECK_COMPILE_FLAG("-D_LARGEFILE_SOURCE",CFLAGS="$CFLAGS -D_LARGEFILE_SOURCE";)
++AX_CHECK_COMPILE_FLAG("-D_LARGEFILE64_SOURCE",CFLAGS="$CFLAGS -D_LARGEFILE64_SOURCE";)
++AX_CHECK_COMPILE_FLAG("-D_FILE_OFFSET_BITS=64",CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64";)
++AX_CHECK_COMPILE_FLAG("-Wdeclaration-after-statement",CFLAGS="$CFLAGS -Wdeclaration-after-statement";)
+ 
+ #
+ # Note: regardless of what the stuff above regarding large file support

--- a/var/spack/repos/builtin/packages/silo/package.py
+++ b/var/spack/repos/builtin/packages/silo/package.py
@@ -41,6 +41,7 @@ class Silo(AutotoolsPackage):
 
     depends_on('m4', type='build', when='+shared')
     depends_on('autoconf', type='build', when='+shared')
+    depends_on('autoconf-archive', type='build', when='+shared')
     depends_on('automake', type='build', when='+shared')
     depends_on('libtool', type='build', when='+shared')
     depends_on('mpi', when='+mpi')
@@ -53,16 +54,26 @@ class Silo(AutotoolsPackage):
     depends_on('zlib')
 
     patch('remove-mpiposix.patch', when='@4.8:4.10.2')
-    patch('H5FD_class_t-terminate.patch', when='@:4.10.2 ^hdf5@1.10.0:')
-    # H5EPR_SEMI_COLON.patch should be applied only to silo@4.11 when building
-    # with hdf5@1.10.8 or later 1.10 or with hdf5@1.12.1 or later
-    patch('H5EPR_SEMI_COLON.patch', when='@:4.11 ^hdf5@1.10.8:1.10,1.12.1:')
 
-    conflicts('^hdf5@1.13:', when="+hdf5")
-    conflicts('+hzip', when="@4.11-bsd")
-    conflicts('+fpzip', when="@4.11-bsd")
-    conflicts('+hzip', when="@4.10.2-bsd")
-    conflicts('+fpzip', when="@4.10.2-bsd")
+    # hdf5 1.10 added an additional field to the H5FD_class_t struct
+    patch('H5FD_class_t-terminate.patch', when='@:4.10.2-bsd')
+
+    # H5EPR_SEMI_COLON.patch was fixed in current dev
+    patch('H5EPR_SEMI_COLON.patch', when='@:4.11-bsd')
+
+    # Fix missing F77 init, fixed in 4.9
+    patch('48-configure-f77.patch', when='@:4.8')
+
+    # The previously used AX_CHECK_COMPILER_FLAGS macro was dropped from
+    # autoconf-archive in 2011
+    patch('configure-AX_CHECK_COMPILE_FLAG.patch')
+
+    # API changes in 1.13 cause breakage
+    conflicts('hdf5@1.13:', when='+hdf5')
+
+    # hzip and fpzip are not available in the BSD releases
+    conflicts('+hzip', when="@4.10.2-bsd,4.11-bsd")
+    conflicts('+fpzip', when="@4.10.2-bsd,4.11-bsd")
 
     def flag_handler(self, name, flags):
         spec = self.spec
@@ -79,12 +90,16 @@ class Silo(AutotoolsPackage):
                 flags.append(self.compiler.cxx_pic_flag)
             elif name == 'fcflags':
                 flags.append(self.compiler.fc_pic_flag)
-        if name == 'cflags':
+        if name == 'cflags' or name == 'cxxflags':
             if '+hdf5' in spec:
                 # @:4.10 can use up to the 1.10 API
                 if '@:4.10' in spec:
                     if '@1.10:' in spec['hdf5']:
                         flags.append('-DH5_USE_110_API')
+                    elif '@1.8:' in spec['hdf5']:
+                        # Just in case anytone is trying to force the 1.6 api for
+                        # some reason
+                        flags.append('-DH5_USE_18_API')
                 else:
                     # @4.11: can use newer HDF5 APIs, so this ensures silo is
                     # presented with an HDF5 API consistent with the HDF5 version.


### PR DESCRIPTION
This should address remaining HDF5 version constraints.

Tested with the Cartesian product of:

 - silo@4.{8,10.2,11}
   - +hdf5
   - ~hdf5
 - hdf5:
   - @1.8.0:1.8
   - @1.10.0
   - @1.10.0:1.10
   - @1.12.0:1.12