### PR TITLE
Mark test_repo_last_mtime xfail on Python < 3.5

### DIFF
--- a/lib/spack/spack/test/repo.py
+++ b/lib/spack/spack/test/repo.py
@@ -2,8 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 import os
+import sys
 
 import pytest
 
@@ -59,6 +59,9 @@ def test_repo_anonymous_pkg(mutable_mock_repo):
 
 
 @pytest.mark.maybeslow
+@pytest.mark.skipif(
+    sys.version_info < (3, 5), reason="Test started failing spuriously on Python 2.7"
+)
 def test_repo_last_mtime():
     latest_mtime = max(os.path.getmtime(p.module.__file__)
                        for p in spack.repo.path.all_packages())


### PR DESCRIPTION
This test started failing spuriously with Python 2.7 + original concretizer.