### PR TITLE
Compiler wrapper: fix globbing and debug out.log bell chars

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -f
 # shellcheck disable=SC2034  # evals in this script fool shellcheck
 #
 # Copyright 2013-2022 Lawrence Livermore National Security, LLC and other

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -768,7 +768,9 @@ if [ "$SPACK_DEBUG" = TRUE ]; then
     input_log="$SPACK_DEBUG_LOG_DIR/spack-cc-$SPACK_DEBUG_LOG_ID.in.log"
     output_log="$SPACK_DEBUG_LOG_DIR/spack-cc-$SPACK_DEBUG_LOG_ID.out.log"
     echo "[$mode] $command $input_command" >> "$input_log"
-    echo "[$mode] ${full_command_list}" >> "$output_log"
+    IFS="$lsep"
+    echo "[$mode] "$full_command_list >> "$output_log"
+    unset IFS
 fi
 
 # Execute the full command, preserving spaces with IFS set


### PR DESCRIPTION
Solves the following issues:

1. Globbing in various places

```console
$ echo 'int main(){return 0;}' > '*.c'
$ echo nope > nope.c
$ cc '*.c' # fine
$ spack build-env --fresh zlib%gcc -- cc '*.c'
nope.c:1:1: error: expected '=', ',', ';', 'asm' or '__attribute__' at end of input
    1 | nope
      | ^~~~
nope.c:1:1: error: expected '=', ',', ';', 'asm' or '__attribute__' at end of input
    1 | nope
      | ^~~~
nope.c:1:1: error: expected '=', ',', ';', 'asm' or '__attribute__' at end of input
    1 | nope
      | ^~~~
```

Apparently `*.c` is globbed three times in our `cc`. Since we run `exec $full_command_list`
and rely on bell character separators there, just disable globbing with `-f`.

2. Bell characters not replaced with whitespace in debug `out.log`:

```console
$ echo 'int main(){return 0;}' > example.c
$ spack build-env --fresh zlib%gcc -- env SPACK_DEBUG=TRUE SPACK_DEBUG_LOG_DIR=$PWD cc example.c
$ cat -v spack-cc-*.out.log
[ccld] /usr/bin/gcc-10^G-march=znver2^G-mtune=znver2^G-Wl,--disable-new-dtags^G-Wl,-rpath,/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.12-n7ppd6ykm3m2nbonioewoeholfwiinbr/lib^G-Wl,-rpath,/home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.3.0/zlib-1.2.12-n7ppd6ykm3m2nbonioewoeholfwiinbr/lib64^Gexample.c
```

(It would have been nice if we could shell escape the components after splitting on `^G` and print `'/usr/bin/gcc' '-march=znver2' ...` instead of effectively replacing `^G` with ` `, but well...)
