### PR TITLE
ecp-data-vis-sdk: Drop fortran from ascent spec.

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
+++ b/var/spack/repos/builtin/packages/ecp-data-vis-sdk/package.py
@@ -125,7 +125,9 @@ class EcpDataVisSdk(BundlePackage, CudaPackage, ROCmPackage):
     dav_sdk_depends_on('sensei@develop +vtkio +python ~miniapps', when='+sensei',
                        propagate=dict(propagate_to_sensei))
 
-    dav_sdk_depends_on('ascent+mpi+fortran+openmp+python+shared+vtkh+dray~test',
+    # Fortran support with ascent is problematic on some Cray platforms so the
+    # SDK is explicitly disabling it until the issues are resolved.
+    dav_sdk_depends_on('ascent+mpi~fortran+openmp+python+shared+vtkh+dray~test',
                        when='+ascent',
                        propagate=['adios2', 'cuda'] + cuda_arch_variants)
     # Need to explicitly turn off conduit hdf5_compat in order to build


### PR DESCRIPTION
@chuckatkins @cyrush 