### PR TITLE
Mitigate consequences when package_hash cannot be computed

### DIFF
--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1924,7 +1924,10 @@ class Spec(object):
                 d['patches'] = variant._patches_in_order_of_appearance
 
         if self._concrete and hash.package_hash:
-            package_hash = self.package_hash()
+            try:
+                package_hash = self.package_hash()
+            except spack.repo.UnknownNamespaceError:
+                package_hash = None
 
             # Full hashes are in bytes
             if (not isinstance(package_hash, six.text_type)


### PR DESCRIPTION
This mitigates the issues that will be fixed by #30678 by catching exceptions that might be thrown when old concrete specs cannot compute the package hash, and setting it to None. It doesn't solve the bug.