### PR TITLE
Attempt to get spack working on nixos

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -239,6 +239,15 @@ To resolve this problem, please try the following:
             os.chmod(abs_path, mode)
 
     @run_before("configure")
+    def _patch_usr_bin_file(self):
+        """On NixOS file is not available in /usr/bin/file. Patch configure
+        scripts to use file from path."""
+
+        if self.spec.os.startswith("nixos"):
+            for configure_file in fs.find(".", files=["configure"], recursive=True):
+                fs.filter_file("/usr/bin/file", "file", configure_file, string=True)
+
+    @run_before("configure")
     def _set_autotools_environment_variables(self):
         """Many autotools builds use a version of mknod.m4 that fails when
         running as root unless FORCE_UNSAFE_CONFIGURE is set to 1.


### PR DESCRIPTION
Consider this as much an issue as it is a pull request. The changes here are not complete and definitely don't work in all situations, but I hope it can work as a starting point to get things working more comprehensively.

I've been attempting to get spack working on nixos (https://nixos.org/) where nearly nothing is available in the typical system directories. The only things visible in the typical system directories are `/usr/bin/env` and `/bin/sh`. Everything else is symlinked and put into `PATH`.

My test case is `spack install pika` so the dependencies of `pika` is all I've focused on for now, but the problems likely apply elsewhere as well.

There are two typical problems that I encountered so far:
- Hardcoded `/usr/bin/file` for which I've added `patch` functions to replace it to a plain `file`. Even better would probably be to depend on the `file` package, but I haven't tried that yet. (The patching needs to be done in any case since the binary wouldn't be in `/usr/bin`).
- Configuration scripts relying on various tools from `binutils`, typically `ar` and sometimes `nm`. Possibly others but `ar` and `nm` are the first ones to cause the scripts to fail. For this I've added `binutils` dependencies (with `type='build'`) to a few packages.

The first fix I think generally works. The second "fix" is fundamentally flawed though because `binutils` itself is an `AutotoolsPackage` and probably needs some of the tools provided by `binutils` to configure and build itself. However, I can't test this as it causes the obvious circular dependency. I can get past this by doing `spack external find` to use an external `binutils` and then things seem to work. Edit: since `binutils` depends on `zlib` even adding `binutils` as a build-time dependency to `zlib` causes a circular dependency.

Do you have any suggestions or ideas how to move forward with this? Are some of these things known issues?

For anyone wanting to try this on nixos you will at least need `bintools-unwrapped` (e.g. with `nix-shell -p bintools-unwrapped`) to get `strings` which is required for bootstrapping. I'm sure there are plenty more required dependencies that I already have implicitly available my environment (like python...).