### PR TITLE
boost: do not add the context-impl option for version below 1.65.0

### DIFF
--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -489,7 +489,7 @@ class Boost(Package):
                                "multithreaded} must be enabled")
 
         # If we are building context, tell b2 which backend to use
-        if '+context' in spec and spec.version >= Version('1.65.0'):
+        if '+context' in spec and 'context-impl' in spec.variants:
             options.extend(['context-impl=%s' % spec.variants['context-impl'].value])
 
         if '+taggedlayout' in spec:
@@ -680,7 +680,7 @@ class Boost(Package):
             type(dependent_spec.package).cmake_args = _cmake_args
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        if '+context' in self.spec and self.spec.version >= Version('1.65.0'):
+        if '+context' in self.spec and 'context-impl' in self.spec.variants:
             context_impl = self.spec.variants['context-impl'].value
             # fcontext, as the default, has no corresponding macro
             if context_impl == 'ucontext':

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -215,6 +215,11 @@ class Boost(Package):
     depends_on('zlib', when='+iostreams')
     depends_on('py-numpy', when='+numpy', type=('build', 'run'))
 
+    # Improve the error message when the context-impl variant is conflicting
+    conflicts('context-impl=fcontext', when='@:1.65.0')
+    conflicts('context-impl=ucontext', when='@:1.65.0')
+    conflicts('context-impl=winfib', when='@:1.65.0')
+
     # Coroutine, Context, Fiber, etc., are not straightforward.
     conflicts('+context', when='@:1.50')  # Context since 1.51.0.
     conflicts('cxxstd=98', when='+context')  # Context requires >=C++11.

--- a/var/spack/repos/builtin/packages/boost/package.py
+++ b/var/spack/repos/builtin/packages/boost/package.py
@@ -489,7 +489,7 @@ class Boost(Package):
                                "multithreaded} must be enabled")
 
         # If we are building context, tell b2 which backend to use
-        if '+context' in spec:
+        if '+context' in spec and spec.version >= Version('1.65.0'):
             options.extend(['context-impl=%s' % spec.variants['context-impl'].value])
 
         if '+taggedlayout' in spec:
@@ -680,7 +680,7 @@ class Boost(Package):
             type(dependent_spec.package).cmake_args = _cmake_args
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        if '+context' in self.spec:
+        if '+context' in self.spec and self.spec.version >= Version('1.65.0'):
             context_impl = self.spec.variants['context-impl'].value
             # fcontext, as the default, has no corresponding macro
             if context_impl == 'ucontext':


### PR DESCRIPTION
https://github.com/spack/spack/pull/30654 doesn't prevent the addition of the b2 option `context-impl` when the variant is disabled.
This PR adds a version check to the corresponding if condition.