### PR TITLE
Add hip dependency for roc-obj-ls + add perl-uri-encode

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -58,6 +58,10 @@ class Hip(CMakePackage):
     # ref https://github.com/ROCm-Developer-Tools/HIP/pull/2202
     depends_on('numactl', when='@3.7.0:')
 
+    # roc-obj-ls requirements
+    depends_on('perl-file-which')
+    depends_on('perl-uri-encode')
+
     # Add hip-amd sources thru the below
     for d_version, d_shasum in [
         ('5.0.2', '80e7268dd22eba0f2f9222932480dede1d80e56227c0168c6a0cc8e4f23d3b76'),

--- a/var/spack/repos/builtin/packages/perl-uri-encode/package.py
+++ b/var/spack/repos/builtin/packages/perl-uri-encode/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class PerlUriEncode(PerlPackage):
+    """This modules provides simple URI (Percent) encoding/decoding"""
+
+    homepage = "https://github.com/mithun/perl-uri-encode"
+    url      = "https://cpan.metacpan.org/authors/id/M/MI/MITHUN/URI-Encode-v1.1.1.tar.gz"
+
+    version('1.1.1', sha256='4bb9ce4e7016c0138cf9c2375508595286efa1c8dc15b45baa4c47281c08243b')
+
+    depends_on('perl-module-build', type='build')


### PR DESCRIPTION
`roc-obj-ls` provided by `hip` package complains that perl modules are not installed.

```console
$ spack load hip
$ roc-obj-ls --version
Can't locate File/Which.pm in @INC (you may need to install the File::Which module) (@INC contains: /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/perl5 /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/site_perl/5.34.1/x86_64-linux-thread-multi /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/site_perl/5.34.1 /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/5.34.1/x86_64-linux-thread-multi /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/5.34.1) at /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/hip-5.0.2-6aice6chwfuljyxapq6ladhywkbpa3nr/bin/roc-obj-ls line 26.
BEGIN failed--compilation aborted at /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/hip-5.0.2-6aice6chwfuljyxapq6ladhywkbpa3nr/bin/roc-obj-ls line 26.
$ spack load perl-file-which
$ roc-obj-ls --version
Can't locate URI/Encode.pm in @INC (you may need to install the URI::Encode module) (@INC contains: /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-10.2.0/perl-file-which-1.22-wtbrvfp65rf57u5witiombetabp33yjr/lib/perl5/x86_64-linux-thread-multi /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-10.2.0/perl-file-which-1.22-wtbrvfp65rf57u5witiombetabp33yjr/lib/perl5 /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/perl5 /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/site_perl/5.34.1/x86_64-linux-thread-multi /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/site_perl/5.34.1 /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/5.34.1/x86_64-linux-thread-multi /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/perl-5.34.1-w5hhq6psnelnvybfqnxqcf2dhko25heg/lib/5.34.1) at /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/hip-5.0.2-6aice6chwfuljyxapq6ladhywkbpa3nr/bin/roc-obj-ls line 30.
BEGIN failed--compilation aborted at /users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/hip-5.0.2-6aice6chwfuljyxapq6ladhywkbpa3nr/bin/roc-obj-ls line 30.
$ spack load perl-uri-encode
$ roc-obj-ls --version
/users/ialberto/spack/opt/spack/linux-centos8-zen/gcc-8.4.1/hip-5.0.2-6aice6chwfuljyxapq6ladhywkbpa3nr/bin/roc-obj-ls version [unknown] calling Getopt::Std::getopts (version 1.13 [paranoid]),
running under Perl version 5.34.1.
  [Now continuing due to backward compatibility and excessive paranoia.
   See 'perldoc Getopt::Std' about $Getopt::Std::STANDARD_HELP_VERSION.]
```

I don't have deep knowledge about this, it is just a quick fix.

It required adding `perl-uri-encode` perl module in Spack.