### PR TITLE
Allow Kokkos with OpenMPTarget backend

### DIFF
--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -196,6 +196,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="std=17 ^cuda@:10")
     conflicts("+cuda", when="std=20")
 
+    # SYCL and OpenMPTarget require C++17
+    conflicts("+sycl", when="std=14")
+    conflicts("+openmptarget", when="std=14")
+
     # HPX should use the same C++ standard
     for std in stds:
         depends_on('hpx cxxstd={0}'.format(std), when='+hpx std={0}'.format(std))

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -196,9 +196,12 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
     conflicts("+cuda", when="std=17 ^cuda@:10")
     conflicts("+cuda", when="std=20")
 
-    # SYCL and OpenMPTarget require C++17
-    conflicts("+sycl", when="std=14")
-    conflicts("+openmptarget", when="std=14")
+    # SYCL and OpenMPTarget require C++17 or higher
+    for stdver in stds[:stds.index('17')]:
+      conflicts('+sycl', when='std={0}'.format(stdver),
+                msg='SYCL requires C++17 or higher')
+      conflicts("+openmptarget", when='std={0}'.format(stdver),
+                msg='OpenMPTarget requires C++17 or higher')
 
     # HPX should use the same C++ standard
     for std in stds:

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -46,9 +46,11 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
         'serial': [True,  'Whether to build serial backend'],
         'rocm': [False, 'Whether to build HIP backend'],
         'sycl': [False, 'Whether to build the SYCL backend'],
+        'openmptarget': [False, 'Whether to build the OpenMPTarget backend']
     }
     conflicts("+rocm", when="@:3.0")
     conflicts("+sycl", when="@:3.3")
+    conflicts("+openmptarget", when="@:3.5")
 
     # https://github.com/spack/spack/issues/29052
     conflicts("@:3.5.00 +sycl", when="%dpcpp@2022.0.0")

--- a/var/spack/repos/builtin/packages/kokkos/package.py
+++ b/var/spack/repos/builtin/packages/kokkos/package.py
@@ -198,10 +198,10 @@ class Kokkos(CMakePackage, CudaPackage, ROCmPackage):
 
     # SYCL and OpenMPTarget require C++17 or higher
     for stdver in stds[:stds.index('17')]:
-      conflicts('+sycl', when='std={0}'.format(stdver),
-                msg='SYCL requires C++17 or higher')
-      conflicts("+openmptarget", when='std={0}'.format(stdver),
-                msg='OpenMPTarget requires C++17 or higher')
+        conflicts('+sycl', when='std={0}'.format(stdver),
+                  msg='SYCL requires C++17 or higher')
+        conflicts("+openmptarget", when='std={0}'.format(stdver),
+                  msg='OpenMPTarget requires C++17 or higher')
 
     # HPX should use the same C++ standard
     for std in stds:


### PR DESCRIPTION
This pull request allows building `Kokkos` with `OpenMPTarget`. The restriction to Kokkos release 3.6.00 and higher is somewhat arbitrary but reflects that the option was added after the latest release.
