### PR TITLE
[WGRIB2] Pinning Jasper to v2.

### DIFF
--- a/var/spack/repos/builtin/packages/wgrib2/package.py
+++ b/var/spack/repos/builtin/packages/wgrib2/package.py
@@ -18,7 +18,7 @@ class Wgrib2(CMakePackage):
     version('2.0.8-cmake-v6', sha256='745cd008b4ce0245ea44247733e57e2b9ec6c5205d171d457e18d0ff8f87172d')
 
     depends_on('ip2')
-    depends_on('jasper')
+    depends_on('jasper@:2.0.32')
     depends_on('libpng')
     depends_on('netcdf-c')
     depends_on('netcdf-fortran')


### PR DESCRIPTION
If we use v3 of Jasper, WGRIB2 fails to build due to not
finding `jpc_encode` and `jpc_decode`.