### PR TITLE
[G2] Pinning Jasper to version 2.

### DIFF
--- a/var/spack/repos/builtin/packages/g2/package.py
+++ b/var/spack/repos/builtin/packages/g2/package.py
@@ -21,7 +21,7 @@ class G2(CMakePackage):
     version('3.4.5', sha256='c18e991c56964953d778632e2d74da13c4e78da35e8d04cb742a2ca4f52737b6')
     version('3.4.3', sha256='679ea99b225f08b168cbf10f4b29f529b5b011232f298a5442ce037ea84de17c')
 
-    depends_on('jasper')
+    depends_on('jasper@:2.0.32')
     depends_on('libpng')
 
     def setup_run_environment(self, env):


### PR DESCRIPTION
If we use v3 of Jasper, UPP fails to build due to not
finding jpc_encode and jpc_decode.