### PR TITLE
Adjust CI workflows for Spack forks

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -24,6 +24,7 @@ jobs:
   fedora-clingo-sources:
     runs-on: ubuntu-latest
     container: "fedora:latest"
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         run: |
@@ -57,6 +58,7 @@ jobs:
   ubuntu-clingo-sources:
     runs-on: ubuntu-latest
     container: "ubuntu:latest"
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         env:
@@ -93,6 +95,7 @@ jobs:
   ubuntu-clingo-binaries-and-patchelf:
     runs-on: ubuntu-latest
     container: "ubuntu:latest"
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         env:
@@ -126,6 +129,7 @@ jobs:
   opensuse-clingo-sources:
     runs-on: ubuntu-latest
     container: "opensuse/leap:latest"
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         run: |
@@ -154,6 +158,7 @@ jobs:
 
   macos-clingo-sources:
     runs-on: macos-latest
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         run: |
@@ -174,6 +179,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         run: |
@@ -195,6 +201,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+    if: github.repository == 'spack/spack'
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
@@ -216,6 +223,7 @@ jobs:
   ubuntu-gnupg-binaries:
     runs-on: ubuntu-latest
     container: "ubuntu:latest"
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         env:
@@ -250,6 +258,7 @@ jobs:
   ubuntu-gnupg-sources:
     runs-on: ubuntu-latest
     container: "ubuntu:latest"
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         env:
@@ -285,6 +294,7 @@ jobs:
 
   macos-gnupg-binaries:
     runs-on: macos-latest
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         run: |
@@ -302,6 +312,7 @@ jobs:
 
   macos-gnupg-sources:
     runs-on: macos-latest
+    if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -43,6 +43,7 @@ jobs:
                      [ubuntu-focal, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:20.04'],
                      [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04']]
     name: Build ${{ matrix.dockerfile[0] }}
+    if: github.action_repository == 'spack/spack' || github.event != 'schedule'
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
@@ -94,7 +95,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to DockerHub
-        if: ${{ github.event_name != 'pull_request' }}
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # @v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -43,7 +43,7 @@ jobs:
                      [ubuntu-focal, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:20.04'],
                      [ubuntu-jammy, 'linux/amd64,linux/arm64,linux/ppc64le', 'ubuntu:22.04']]
     name: Build ${{ matrix.dockerfile[0] }}
-    if: github.action_repository == 'spack/spack' || github.event != 'schedule'
+    if: github.repository == 'spack/spack'
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   install_gcc:
     name: gcc with clang
-    if: github.action_repository == 'spack/spack' || github.event != 'schedule'
+    if: github.repository == 'spack/spack'
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
@@ -37,7 +37,7 @@ jobs:
 
   install_jupyter_clang:
     name: jupyter
-    if: github.action_repository == 'spack/spack' || github.event != 'schedule'
+    if: github.repository == 'spack/spack'
     runs-on: macos-latest
     timeout-minutes: 700
     steps:
@@ -52,7 +52,7 @@ jobs:
 
   install_scipy_clang:
     name: scipy, mpl, pd
-    if: github.action_repository == 'spack/spack' || github.event != 'schedule'
+    if: github.repository == 'spack/spack'
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   install_gcc:
     name: gcc with clang
+    if: github.action_repository == 'spack/spack' || github.event != 'schedule'
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2
@@ -36,6 +37,7 @@ jobs:
 
   install_jupyter_clang:
     name: jupyter
+    if: github.action_repository == 'spack/spack' || github.event != 'schedule'
     runs-on: macos-latest
     timeout-minutes: 700
     steps:
@@ -50,6 +52,7 @@ jobs:
 
   install_scipy_clang:
     name: scipy, mpl, pd
+    if: github.action_repository == 'spack/spack' || github.event != 'schedule'
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # @v2


### PR DESCRIPTION
Changes the following CI workflows such that they only run for the main repo `spack/spack`:
- Containers `workflows/build-containers.yml`
- MacOS builds nightly `workflows/macos_python.yml`
- Bootstrap `workflows/bootstrap.yml`