### PR TITLE
python: more +optimizations

### DIFF
--- a/var/spack/repos/builtin/packages/python/package.py
+++ b/var/spack/repos/builtin/packages/python/package.py
@@ -578,6 +578,8 @@ class Python(Package):
         if spec.satisfies('@2.7.13:2.8,3.5.3:', strict=True) \
                 and '+optimizations' in spec:
             config_args.append('--enable-optimizations')
+            config_args.append('--with-lto')
+            config_args.append('--with-computed-gotos')
 
         if spec.satisfies('%gcc platform=darwin'):
             config_args.append('--disable-toolbox-glue')


### PR DESCRIPTION
Makes Spack's Python roughly on par with Debian's version. Although I had more
success changing `PROFILE_TASK` into doing a matrix-matrix multiplcation in
pure Python (which improved `spack unit-test` time too, apparently) instead of
the default of running some Python unit tests.

