### PR TITLE
Fix spack install missing chgrp on symlinks

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -367,7 +367,7 @@ def group_ids(uid=None):
 
 
 @system_path_filter(arg_slice=slice(1))
-def chgrp(path, group):
+def chgrp(path, group, follow_symlinks=True):
     """Implement the bash chgrp function on a single path"""
     if is_windows:
         raise OSError("Function 'chgrp' is not supported on Windows")
@@ -376,7 +376,10 @@ def chgrp(path, group):
         gid = grp.getgrnam(group).gr_gid
     else:
         gid = group
-    os.chown(path, -1, gid)
+    if follow_symlinks:
+        os.chown(path, -1, gid)
+    else:
+        os.lchown(path, -1, gid)
 
 
 @system_path_filter(arg_slice=slice(1))

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -820,7 +820,7 @@ def test_setup_install_dir_grp(install_mockery, monkeypatch, capfd):
     def _get_group(spec):
         return mock_group
 
-    def _chgrp(path, group):
+    def _chgrp(path, group, follow_symlinks=True):
         tty.msg(mock_chgrp_msg.format(path, group))
 
     monkeypatch.setattr(prefs, 'get_package_group', _get_group)

--- a/lib/spack/spack/util/file_permissions.py
+++ b/lib/spack/spack/util/file_permissions.py
@@ -44,7 +44,7 @@ def set_permissions(path, perms, group=None):
     fs.chmod_x(path, perms)
 
     if group:
-        fs.chgrp(path, group)
+        fs.chgrp(path, group, follow_symlinks=False)
 
 
 class InvalidPermissionsError(SpackError):


### PR DESCRIPTION
Fixes missing chgrp (`packages:*:permissions:group`) on symlinks in package installations, and errors on symlinks referencing non-existent or non-writable locations.

Note: `os.chown(.., follow_symlinks=False)` is not available on python2, but `os.lchown` is.