### PR TITLE
Don't try to mkdir upstream directory when nonexistent

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -356,7 +356,7 @@ class Database(object):
         self.prefix_fail_path = os.path.join(self._db_dir, 'prefix_failures')
 
         # Create needed directories and files
-        if not os.path.exists(self._db_dir):
+        if not os.path.exists(self._db_dir) and not is_upstream:
             fs.mkdirp(self._db_dir)
 
         if not os.path.exists(self._failure_dir) and not is_upstream:

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -356,10 +356,10 @@ class Database(object):
         self.prefix_fail_path = os.path.join(self._db_dir, 'prefix_failures')
 
         # Create needed directories and files
-        if not os.path.exists(self._db_dir) and not is_upstream:
+        if not is_upstream and not os.path.exists(self._db_dir):
             fs.mkdirp(self._db_dir)
 
-        if not os.path.exists(self._failure_dir) and not is_upstream:
+        if not is_upstream and not os.path.exists(self._failure_dir):
             fs.mkdirp(self._failure_dir)
 
         self.is_upstream = is_upstream


### PR DESCRIPTION
When an upstream is specified but the directory doesn't exist, don't try to create the directory for it, it might not be yours.

The same fix was done 2 lines below in 3df712a38.

Also added a cheap optimization to avoid unnecessary stat on upstream.
