### PR TITLE
Non-existent upstream is not fatal

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1064,9 +1064,7 @@ class Database(object):
                 self._state_is_inconsistent = False
             return
         elif self.is_upstream:
-            raise UpstreamDatabaseLockingError(
-                "No database index file is present, and upstream"
-                " databases cannot generate an index file")
+            tty.warn('upstream not found: {0}'.format(self._index_path))
 
     def _add(
             self,


### PR DESCRIPTION
A non-existent upstream should not be fatal: it could only mean the upstream is not deployed yet. In the meantime, it should not block the user to rebuild anything it needs.

A warning is still emitted, so the user can decide if this is an error or not.