### PR TITLE
Petsc: fix enable-x for virtuals

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -440,9 +440,6 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         else:
             options.append('--with-clanguage=C')
 
-        # Activates library support if needed (i.e. direct dependency)
-        jpeg_sp = spec['jpeg'].name if 'jpeg' in spec else 'jpeg'
-
         # to be used in the list of libraries below
         if '+fortran' in spec:
             hdf5libs = ':hl,fortran'
@@ -491,7 +488,7 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 ('saws', 'saws', False, False),
                 ('libyaml', 'yaml', True, True),
                 'hwloc',
-                (jpeg_sp, 'libjpeg', True, True),
+                ('jpeg', 'libjpeg', True, True),
                 ('scalapack', 'scalapack', False, True),
                 'strumpack',
                 'mmg',

--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -453,7 +453,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
         # default: 'gmp', => ('gmp', 'gmp', True, True)
         # any other combination needs a full tuple
         # if not (useinc || uselib): usedir - i.e (False, False)
-        direct_dependencies = [x.name for x in spec.dependencies()]
+        direct_dependencies = []
+        for dep in spec.dependencies():
+            direct_dependencies.append(dep.name)
+            direct_dependencies.extend(
+                set(vspec.name for vspec in dep.package.virtuals_provided))
         for library in (
                 ('cuda', 'cuda', False, False),
                 ('hip', 'hip', True, False),


### PR DESCRIPTION
@balay @wortiz @h-murai 

Fixes https://github.com/spack/spack/issues/30727

Providers of virtuals may implement multiple virtuals; when they do so, they can implement `x_libs` to return just the libraries associated with provided virtual `x`; to support this, they must be accessed as a virtual (e.g. `root_spec[x].libs). https://github.com/spack/spack/pull/30682 updated `petsc` to do this for scalapack to support use of `scalapack` providers that provide other virtuals.

However, in `petsc` there is: 

```
direct_dependencies = [x.name for x in spec.dependencies()]
...
library_requested = spacklibname.split(':')[0] in direct_dependencies
```

where `direct_dependencies` is the implementation name and, as of #30682, spacklibname may be the virtual name. This updates the logic to add virtual names to the set of direct_dependencies, so you can query `library_requested` using the virtual name.