### PR TITLE
qt: Qt 5.15.0 requires OpenSSL 1.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -176,15 +176,17 @@ class Qt(Package):
     depends_on("zlib")
     depends_on("freetype", when='+gui')
     depends_on("gtkplus", when='+gtk')
-    depends_on("openssl", when='+ssl')
     depends_on("sqlite+column_metadata", when='+sql', type=('build', 'run'))
 
     depends_on("libpng@1.2.57", when='@3')
     depends_on("libsm", when='@3')
     depends_on("pcre+multibyte", when='@5.0:5.8')
     depends_on("inputproto", when='@:5.8')
-    depends_on("openssl@:1.0", when='@4:5.9+ssl')
-    depends_on("openssl@1.1.1:", when='@5.15.0:+ssl')
+
+    with when('+ssl'):
+        depends_on("openssl")
+        depends_on("openssl@:1.0", when='@4:5.9')
+        depends_on("openssl@1.1.1:", when='@5.15.0:')
 
     depends_on("glib", when='@4:')
     depends_on("libpng", when='@4:')

--- a/var/spack/repos/builtin/packages/qt/package.py
+++ b/var/spack/repos/builtin/packages/qt/package.py
@@ -184,6 +184,7 @@ class Qt(Package):
     depends_on("pcre+multibyte", when='@5.0:5.8')
     depends_on("inputproto", when='@:5.8')
     depends_on("openssl@:1.0", when='@4:5.9+ssl')
+    depends_on("openssl@1.1.1:", when='@5.15.0:+ssl')
 
     depends_on("glib", when='@4:')
     depends_on("libpng", when='@4:')


### PR DESCRIPTION
Fixes qt configure errors with external openssl on older systems (rhel7).

See [qt changelog](https://github.com/qt/qtbase/blob/efc02f9cc301f98c77079adae026ffd07f50d5ab/dist/changes-5.15.0#L346).

So now `spack spec qt ^openssl@1.0` gets you `qt@5.15.4 ~ssl`: clingo chooses latest qt version **but disables ssl support** by default.

(CC qt package maintainer @sethrj)