### PR TITLE
mpich: re-enable building of the older versions

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -192,6 +192,7 @@ with '-Wl,-commons,use_dylibs' and without
     depends_on('libfabric@:1.6', when='device=ch3 netmod=ofi')
 
     depends_on('ucx', when='netmod=ucx')
+    depends_on('mxm', when='netmod=mxm')
 
     # The dependencies on libpciaccess and libxml2 come from the embedded
     # hwloc, which, before version 3.3, was used only for Hydra.

--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -508,7 +508,12 @@ with '-Wl,-commons,use_dylibs' and without
         elif 'pmi=cray' in spec:
             config_args.append('--with-pmi=cray')
 
-        config_args += self.with_or_without('cuda', activation_value='prefix')
+        if '+cuda' in spec:
+            config_args.append('--with-cuda={0}'.format(spec['cuda'].prefix))
+        elif spec.satisfies('@:3.3,3.4.4:'):
+            # Versions from 3.4 to 3.4.3 cannot handle --without-cuda
+            # (see https://github.com/pmodels/mpich/pull/5060):
+            config_args.append('--without-cuda')
 
         if '+rocm' in spec:
             config_args.append('--with-hip={0}'.format(spec['hip'].prefix))


### PR DESCRIPTION
1. Do not specify `--without-cuda` when `@3.4:3.43 ~cuda`. The affected versions expect the argument to be a path to CUDA. Otherwise, the package is compiled with `-Ino/include` and `-Lno/include`, which leads to a build failure at some point.
2. Add dependency on `mxm` when `netmod=mxm`, which seems to be the right thing. However, I stumbled upon it when I tried to build `@3.1.4`, which, according to the `conflicts` directives can already be built with `netmod=mxm` but not with the default `netmod=ofi`. Without the dependency, this made `clingo` decide to build with `netmod=mxm`. With the dependency, `clingo` concretize `@3.1.4` with `netmod=tcp` like all other older versions.  It might make sense to make `netmod`and some other variants `sticky` but I will leave it to the package maintainers.

I miss the times when `spack install mpich` was a fast and easy way to get an MPI library.