### PR TITLE
paml: updating to 4.10.3

### DIFF
--- a/var/spack/repos/builtin/packages/paml/package.py
+++ b/var/spack/repos/builtin/packages/paml/package.py
@@ -13,6 +13,7 @@ class Paml(MakefilePackage):
     homepage = "http://abacus.gene.ucl.ac.uk/software/paml.html"
     url      = "https://github.com/abacus-gene/paml/archive/refs/tags/v4.10.0.tar.gz"
     git      = "https://github.com/abacus-gene/paml.git"
+    maintainers = ['snehring']
 
     version('4.10.3', sha256='9b2a6e187e3f9f3bc55cd82db15eb701d43f031167d283a7c1b11c882b5d8a42',
             url='https://github.com/abacus-gene/paml/archive/refs/tags/untagged-a5659203e8ec0ddb58b8.tar.gz')

--- a/var/spack/repos/builtin/packages/paml/package.py
+++ b/var/spack/repos/builtin/packages/paml/package.py
@@ -11,9 +11,14 @@ class Paml(MakefilePackage):
        protein sewuences using maximum likelihood."""
 
     homepage = "http://abacus.gene.ucl.ac.uk/software/paml.html"
-    url      = "http://abacus.gene.ucl.ac.uk/software/paml4.9h.tgz"
+    url      = "https://github.com/abacus-gene/paml/archive/refs/tags/v4.10.0.tar.gz"
+    git      = "https://github.com/abacus-gene/paml.git"
 
-    version('4.9h', sha256='623bf6cf4a018a4e7b4dbba189c41d6c0c25fdca3a0ae24703b82965c772edb3')
+    version('4.10.3', sha256='9b2a6e187e3f9f3bc55cd82db15eb701d43f031167d283a7c1b11c882b5d8a42',
+            url='https://github.com/abacus-gene/paml/archive/refs/tags/untagged-a5659203e8ec0ddb58b8.tar.gz')
+    version('4.10.0', sha256='6ef6a116f254185eb1cf7a2b975946fc9179a4b7dcb60a82f8fa8bbe6931897c')
+    version('4.9h', sha256='623bf6cf4a018a4e7b4dbba189c41d6c0c25fdca3a0ae24703b82965c772edb3',
+            url='http://abacus.gene.ucl.ac.uk/software/SoftOld/paml4.9h.tgz')
 
     build_directory = 'src'
 


### PR DESCRIPTION
Newer development seems to be occurring on github. The current release tag situation is...weird so it has a version specific url. Old version also changed. New versions will hopefully follow the normal convention for github, so I've not made a url handler.