### PR TITLE
Make the IntelPackage fail successfully

### DIFF
--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1253,16 +1253,22 @@ class IntelPackage(PackageBase):
         # perform
         install_script('--silent', 'silent.cfg')
 
+        # Validate the install
+        installed_files = filter(lambda f: f != 'intel', os.listdir(prefix))
+        if len(installed_files) == 0:
+            raise InstallError('The installer has failed to install anything.')
+        #with os.scandir(prefix) as dir_iter:
+        #    for entry in dir_iter:
+        #        if entry.name.startswith('Intel'):
+        #           continue
+        #            break
+        #        raise InstallError('The installer has failed to install anything.')
+
         # preserve config and logs
         dst = os.path.join(self.prefix, '.spack')
         install('silent.cfg', dst)
         for f in glob.glob('%s/intel*log' % tmpdir):
             install(f, dst)
-
-    @run_after('install')
-    def validate_install(self):
-        if not os.path.exists(self.prefix.bin):
-            raise InstallError('The installer has failed to install anything.')
 
     @run_after('install')
     def configure_rpath(self):

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1260,6 +1260,11 @@ class IntelPackage(PackageBase):
             install(f, dst)
 
     @run_after('install')
+    def validate_install(self):
+        if not os.path.exists(self.prefix.bin):
+            raise InstallError('The installer has failed to install anything.')
+
+    @run_after('install')
     def configure_rpath(self):
         if '+rpath' not in self.spec:
             return

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1253,22 +1253,19 @@ class IntelPackage(PackageBase):
         # perform
         install_script('--silent', 'silent.cfg')
 
-        # Validate the install
-        installed_files = filter(lambda f: f != 'intel', os.listdir(prefix))
-        if len(installed_files) == 0:
-            raise InstallError('The installer has failed to install anything.')
-        #with os.scandir(prefix) as dir_iter:
-        #    for entry in dir_iter:
-        #        if entry.name.startswith('Intel'):
-        #           continue
-        #            break
-        #        raise InstallError('The installer has failed to install anything.')
-
         # preserve config and logs
         dst = os.path.join(self.prefix, '.spack')
         install('silent.cfg', dst)
         for f in glob.glob('%s/intel*log' % tmpdir):
             install(f, dst)
+
+    @run_aster('install')
+    def validate_install(self):
+        # Sometimes the installer exits with an error but doesn't pass a
+        # non-zero exit code to spack. Check for the existance of a 'bin'
+        # directory to catch this error condition.
+        if not exists(self.prefix.bin):
+            raise InstallError('The installer has failed to install anything.')
 
     @run_after('install')
     def configure_rpath(self):

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1259,12 +1259,12 @@ class IntelPackage(PackageBase):
         for f in glob.glob('%s/intel*log' % tmpdir):
             install(f, dst)
 
-    @run_aster('install')
+    @run_after('install')
     def validate_install(self):
         # Sometimes the installer exits with an error but doesn't pass a
         # non-zero exit code to spack. Check for the existance of a 'bin'
         # directory to catch this error condition.
-        if not exists(self.prefix.bin):
+        if not os.path.exists(self.prefix.bin):
             raise InstallError('The installer has failed to install anything.')
 
     @run_after('install')

--- a/lib/spack/spack/build_systems/intel.py
+++ b/lib/spack/spack/build_systems/intel.py
@@ -1262,7 +1262,7 @@ class IntelPackage(PackageBase):
     @run_after('install')
     def validate_install(self):
         # Sometimes the installer exits with an error but doesn't pass a
-        # non-zero exit code to spack. Check for the existance of a 'bin'
+        # non-zero exit code to spack. Check for the existence of a 'bin'
         # directory to catch this error condition.
         if not os.path.exists(self.prefix.bin):
             raise InstallError('The installer has failed to install anything.')


### PR DESCRIPTION
Sometime the intel installer script will fail to install anything but also not return a non-zero code back to spack.  This causes spack to think the install was successful even though there are not useful files put into the prefix.  The update will check for that condition and make sure that spack knows that the install failed.  All packages which inherit from IntelPackage have been verified to install a $prefix/bin upon correct installation.