### PR TITLE
tbl2asn: adding currently available version

### DIFF
--- a/var/spack/repos/builtin/packages/tbl2asn/package.py
+++ b/var/spack/repos/builtin/packages/tbl2asn/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from os import chmod
-
 from spack import *
 
 
@@ -13,13 +11,18 @@ class Tbl2asn(Package):
        sequence records for submission to GenBank."""
 
     homepage = "https://www.ncbi.nlm.nih.gov/genbank/tbl2asn2/"
+    maintainers = ['snehring']
 
-    version('2020-03-01', sha256='7cc1119d3cfcbbffdbd4ecf33cef8bbdd44fc5625c72976bee08b1157625377e')
+    version('2022-04-26', sha256='c76481700e196ebd98a83f4174e0146569db9d6fe5753ac18691e9836d5c6a75')
+    version('2020-03-01', sha256='7cc1119d3cfcbbffdbd4ecf33cef8bbdd44fc5625c72976bee08b1157625377e', deprecated=True)
 
     def url_for_version(self, ver):
-        return "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux.tbl2asn.gz"
+        return "https://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux64.tbl2asn.gz"
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
-        install('../linux.tbl2asn', prefix.bin.tbl2asn)
-        chmod(prefix.bin.tbl2asn, 0o775)
+        if spec.satisfies('@2020-03-01'):
+            install('../linux.tbl2asn', prefix.bin.tbl2asn)
+        else:
+            install('linux64.tbl2asn', prefix.bin.tbl2asn)
+        set_executable(prefix.bin.tbl2asn)


### PR DESCRIPTION
Fetch fails because the previous version has apparently been removed. They don't have a real versioning scheme for this, so this is just based off the modification date of the file. I'm leaving the old version in on the off chance anyone has it in a mirror somewhere and still wants to use it, but marked it deprecated.
