### PR TITLE
Fix toolchain detection for oneapi/dpcpp compilers

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -766,7 +766,8 @@ def is_mixed_toolchain(compiler):
             toolchains.add(compiler_cls.__name__)
 
     if len(toolchains) > 1:
-        if toolchains == set(['Clang', 'AppleClang', 'Aocc']):
+        if toolchains == set(['Clang', 'AppleClang', 'Aocc']) or \
+           toolchains == set(['Dpcpp', 'Oneapi']):
             return False
         tty.debug("[TOOLCHAINS] {0}".format(toolchains))
         return True


### PR DESCRIPTION
The oneapi and dpcpp compilers are essentially the same except for which
binary is used foc CXX. Spack will detect them as "mixed toolchain" and
not inject compiler optimization flags. This will be needed once
archspec has entries for the oneapi and dpcpp compilers. This PR detects
when dpcpp and oneapi are in the toolchains list and explicitly sets
`is_mixed_toolchain` to `False`.