### PR TITLE
usearch: adding in new version, updating checksums

### DIFF
--- a/var/spack/repos/builtin/packages/usearch/package.py
+++ b/var/spack/repos/builtin/packages/usearch/package.py
@@ -19,16 +19,18 @@ class Usearch(Package):
        https://spack.readthedocs.io/en/latest/mirrors.html"""
 
     homepage = "https://www.drive5.com/usearch/"
+    maintainers = ['snehring']
+
     manual_download = True
 
-    version('10.0.240', '05192b6d5e291530c190a19a3cc82b53', expand=False)
+    version('11.0.667', sha256='1be0faa1380100296029064e4cf9665d723d43f03c794da444c5b1a6b6799ac2')
+    version('10.0.240', sha256='297ba03cb5bdc60c9727b7949cc08bfeecad8b290c2844b5ad011f72a7e1399c')
 
     def url_for_version(self, version):
-        return "file://{0}/usearch{1}_i86linux32".format(os.getcwd(), version)
+        return "file://{0}/usearch{1}_i86linux32.gz".format(os.getcwd(), version)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         install('usearch{0}_i86linux32'.format(self.version),
                 prefix.bin.usearch)
-        chmod = which('chmod')
-        chmod('+x', prefix.bin.usearch)
+        set_executable(prefix.bin.usearch)


### PR DESCRIPTION
Updated the old checksum to sha256, and the url_for_version to reflect the fact that it's distributed as a gzipped file.