### PR TITLE
Add Teuchos patch that fixes implicit casting of complex numbers

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -394,6 +394,9 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     patch('fix_clang_errors_12_18_1.patch', when='@12.18.1%clang')
     patch('cray_secas_12_12_1.patch', when='@12.12.1%cce')
     patch('cray_secas.patch', when='@12.14.1:12%cce')
+    patch('https://patch-diff.githubusercontent.com/raw/trilinos/Trilinos/pull/10545.patch',
+          sha256='7f446d8bdcdc7ec29e1caeb0faf8d9fd85bd470fc52d3a955c144ab14bb16b90',
+          when='@:13.2.0 +complex')
 
     # workaround an NVCC bug with c++14 (https://github.com/trilinos/Trilinos/issues/6954)
     # avoid calling deprecated functions with CUDA-11


### PR DESCRIPTION
A recent bugfix in https://github.com/trilinos/Trilinos/pull/10545 affects all versions of Trilinos up to and including 13.2. This PR contains that bugfix as a patch. 