### PR TITLE
py-rnc2rng: fix 2.6.5 and add 2.6.6

### DIFF
--- a/var/spack/repos/builtin/packages/py-rnc2rng/package.py
+++ b/var/spack/repos/builtin/packages/py-rnc2rng/package.py
@@ -12,7 +12,10 @@ class PyRnc2rng(PythonPackage):
     homepage = "https://github.com/djc/rnc2rng"
     pypi     = "rnc2rng/rnc2rng-2.6.5.tar.gz"
 
+    version('2.6.6', sha256='5a01d157857b5f010a94167e7092cc49efe2531d58e013f12c4e60b8c4df78f1')
     version('2.6.5', sha256='d354afcf0bf8e3b1e8f8d37d71a8fe5b1c0cf75cbd4b71364a9d90b5108a16e5')
 
     depends_on('py-setuptools', type='build')
+    # rnc2rng@2.6.5 uses use_2to3 which was removed in py-setuptools@58
+    depends_on('py-setuptools@:57', when='@:2.6.5', type='build')
     depends_on('py-rply', type=('build', 'run'))


### PR DESCRIPTION
`py-rnc2rng@2.6.5` does not build with `py-setuptools@58:` because support for `use_2to3` was removed.

sources for version 2.6.6: https://github.com/djc/rnc2rng/tree/2.6.6

tested on fedora 35 with python 3.9.12 and gcc 11.3.1