### PR TITLE
Bugfix hwloc find cuda

### DIFF
--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -168,4 +168,8 @@ class Hwloc(AutotoolsPackage):
         args.extend(self.enable_or_disable('pci'))
         args.extend(self.enable_or_disable('shared'))
 
+        if '+cuda' in self.spec:
+            args.append('--with-cuda={0}'.format(self.spec['cuda'].prefix))
+            args.append('--with-cuda-version={0}'.format(self.spec['cuda'].version))
+
         return args

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -155,6 +155,8 @@ class Hwloc(AutotoolsPackage):
         # OpenMPI due to lack of rpath to librocm_smi
         if '+rocm' not in self.spec:
             args.append('--disable-rsmi')
+
+        if '+rocm' in self.spec:
             args.append('--with-rocm={0}'.format(self.spec['rocm'].prefix))
             args.append('--with-rocm-version={0}'.format(
                 self.spec['rocm'].version))

--- a/var/spack/repos/builtin/packages/hwloc/package.py
+++ b/var/spack/repos/builtin/packages/hwloc/package.py
@@ -155,6 +155,9 @@ class Hwloc(AutotoolsPackage):
         # OpenMPI due to lack of rpath to librocm_smi
         if '+rocm' not in self.spec:
             args.append('--disable-rsmi')
+            args.append('--with-rocm={0}'.format(self.spec['rocm'].prefix))
+            args.append('--with-rocm-version={0}'.format(
+                self.spec['rocm'].version))
 
         if '+netloc' in self.spec:
             args.append('--enable-netloc')
@@ -170,6 +173,7 @@ class Hwloc(AutotoolsPackage):
 
         if '+cuda' in self.spec:
             args.append('--with-cuda={0}'.format(self.spec['cuda'].prefix))
-            args.append('--with-cuda-version={0}'.format(self.spec['cuda'].version))
+            args.append('--with-cuda-version={0}'.format(
+                self.spec['cuda'].version))
 
         return args


### PR DESCRIPTION
Added support for properly finding the correct version of CUDA or ROCm that the package was concretized against.  In the current incarnation hwloc will build and link against the first version that package config finds, which in a multi-CUDA installation could be incorrect.