### PR TITLE
git-annex: fix source urls

### DIFF
--- a/var/spack/repos/builtin/packages/git-annex/package.py
+++ b/var/spack/repos/builtin/packages/git-annex/package.py
@@ -42,24 +42,33 @@ class GitAnnex(Package):
     # (meaning here: https://downloads.kitenet.net/git-annex/linux/current/) is
     # broken and always behind
 
+    # if for some reason the sources vanish from https://downloads.kitenet.net/
+    # an alternative source can be found with
+    # - $ git annex whereis git-annex/linux/current/git-annex-standalone-arm64.tar.gz
+    #     -> gives web url
+
     if platform.system() == "Linux" and platform.machine() == "aarch64":
         # git-annex-standalone-arm64.tar.gz
 
+        # release 10.20220223 was not properly updated for arm64 upstream
         version('10.20220121', sha256='3f8a50f61cb092e4e658a320b86ee7bd38238bbd1286fa462bb12797d36e1f25',
                 url="https://downloads.kitenet.net/.git/annex/objects/Kp/K5/SHA256E-s55243787--3f8a50f61cb092e4e658a320b86ee7bd38238bbd1286fa462bb12797d36e1f25.tar.gz/SHA256E-s55243787--3f8a50f61cb092e4e658a320b86ee7bd38238bbd1286fa462bb12797d36e1f25.tar.gz")
         # release 8.20210804 was not properly updated for arm64 upstream
         # the sha256sums of 8.20210622 and 8.20210804 were the same
         version('8.20210622', sha256='869f875e280db0cc3243d9d0d33492f1c3bc182053544c1d5eb0ec463125fe76',
-                url="https://downloads.kitenet.net/.git/annex/objects/MJ/p3/SHA256E-s55109776--869f875e280db0cc3243d9d0d33492f1c3bc182053544c1d5eb0ec463125fe76.tar.gz/SHA256E-s55109776--869f875e280db0cc3243d9d0d33492f1c3bc182053544c1d5eb0ec463125fe76.tar.gz")
+                # original link is broken
+                url="http://archive.org/download/git-annex-builds/SHA256E-s55109776--869f875e280db0cc3243d9d0d33492f1c3bc182053544c1d5eb0ec463125fe76.tar.gz")
 
     elif platform.system() == "Linux":
         # git-annex-standalone-amd64.tar.gz
+        version('10.20220223', sha256='498a877e040f20e032879d026a78aa86b74f2652774efe3e8b81f054ca1f4485',
+                url="http://archive.org/download/git-annex-builds/SHA256E-s52308746--498a877e040f20e032879d026a78aa86b74f2652774efe3e8b81f054ca1f4485.tar.gz")
         version('10.20220121', sha256='45cfaddc859d24f7e5e7eb3ab10c14a94d744705d365f26b54a50855ab1068f3',
-                url="https://downloads.kitenet.net/.git/annex/objects/M0/3z/SHA256E-s52034939--45cfaddc859d24f7e5e7eb3ab10c14a94d744705d365f26b54a50855ab1068f3.tar.gz/SHA256E-s52034939--45cfaddc859d24f7e5e7eb3ab10c14a94d744705d365f26b54a50855ab1068f3.tar.gz")
+                url="http://archive.org/download/git-annex-builds/SHA256E-s52034939--45cfaddc859d24f7e5e7eb3ab10c14a94d744705d365f26b54a50855ab1068f3.tar.gz")
         version('8.20210804', sha256='f9d4bec06dddaeced25eec5f46360223797363e608fe37cfa93b2481f0166e1f',
-                url="https://downloads.kitenet.net/.git/annex/objects/4M/J4/SHA256E-s51465538--f9d4bec06dddaeced25eec5f46360223797363e608fe37cfa93b2481f0166e1f.tar.gz/SHA256E-s51465538--f9d4bec06dddaeced25eec5f46360223797363e608fe37cfa93b2481f0166e1f.tar.gz")
+                url="http://archive.org/download/git-annex-builds/SHA256E-s51465538--f9d4bec06dddaeced25eec5f46360223797363e608fe37cfa93b2481f0166e1f.tar.gz")
         version('8.20210622', sha256='a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e',
-                url="https://downloads.kitenet.net/.git/annex/objects/KM/Ff/SHA256E-s51276461--a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e.tar.gz/SHA256E-s51276461--a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e.tar.gz")
+                url="http://archive.org/download/git-annex-builds/SHA256E-s51276461--a1cef631ef2cc0c977580eacaa1294d7617727df99214920ca6e8f3172bae03e.tar.gz")
 
     variant('standalone', default=False,
             description='Install git-annex fully standalone incl. git')


### PR DESCRIPTION
Most urls for the sources don't work anymore and have to be replaced.