### PR TITLE
petsc: update rocrand location wrt rocm@5.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/petsc/package.py
+++ b/var/spack/repos/builtin/packages/petsc/package.py
@@ -545,7 +545,11 @@ class Petsc(Package, CudaPackage, ROCmPackage):
                 options.append('--with-hip-arch={0}'.format(hip_arch[0]))
             hip_pkgs = ['hipsparse', 'hipblas', 'rocsparse', 'rocsolver', 'rocblas']
             hip_ipkgs = hip_pkgs + ['rocthrust', 'rocprim']
-            hip_lpkgs = hip_pkgs + ['rocrand']
+            hip_lpkgs = hip_pkgs
+            if spec.satisfies('^rocrand@5.1:'):
+                hip_ipkgs.extend(['rocrand'])
+            else:
+                hip_lpkgs.extend(['rocrand'])
             hip_inc = ''
             hip_lib = ''
             for pkg in hip_ipkgs:


### PR DESCRIPTION
rocm-5.1.0 removed librocrand.so from ROCM_DIR/rocrand/lib location (but  includes are still at this location)

/opt/rocm-5.0.2/lib/librocrand.so
/opt/rocm-5.0.2/rocrand/lib/librocrand.so
/opt/rocm-5.1.0/lib/librocrand.so

drwxr-xr-x 2 root root 617 Mar  8 08:20 /opt/rocm-5.0.2/rocrand/include
drwxr-xr-x 2 root root 617 Mar 31 09:48 /opt/rocm-5.1.0/rocrand/include