### PR TITLE
compiler flags: imposed hashes impose the lack of additional compiler flags

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -119,6 +119,11 @@ attr(Name, A1, A2, A3) :- impose(ID), imposed_constraint(ID, Name, A1, A2, A3).
    variant_value(Package, Variant, Value),
    not imposed_constraint(Hash, "variant_value", Package, Variant, Value).
 
+% we cannot have additional flag values when we are working with concrete specs
+:- node(Package), hash(Package, Hash),
+   node_flag(Package, FlagType, Flag),
+   not imposed_constraint(Hash, "node_flag", Package, FlagType, Flag).
+
 #defined condition/2.
 #defined condition_requirement/3.
 #defined condition_requirement/4.


### PR DESCRIPTION
Currently, `spack spec --reuse zlib cflags=-O3` will reuse a concrete zlib without the `-O3` flag if it is otherwise satisfying.

This PR ensures that no hash can be used if it does not imply every compiler flag required by the input spec.