### PR TITLE
use oneapi var.sh to setup dependent build environment

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -107,6 +107,10 @@ class IntelOneApiPackage(Package):
             join_path(self.component_path, 'env', 'vars.sh')))
 
 
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        env.extend(EnvironmentModifications.from_sourcing_file(
+            join_path(self.component_path, 'env', 'vars.sh')))
+
 class IntelOneApiLibraryPackage(IntelOneApiPackage):
     """Base class for Intel oneAPI library packages.
 

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -106,10 +106,10 @@ class IntelOneApiPackage(Package):
         env.extend(EnvironmentModifications.from_sourcing_file(
             join_path(self.component_path, 'env', 'vars.sh')))
 
-
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.extend(EnvironmentModifications.from_sourcing_file(
             join_path(self.component_path, 'env', 'vars.sh')))
+
 
 class IntelOneApiLibraryPackage(IntelOneApiPackage):
     """Base class for Intel oneAPI library packages.

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -102,6 +102,3 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
             return libs + system_libs
         else:
             return IntelOneApiStaticLibraryList(libs, system_libs)
-
-    def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set('MKLROOT', self.component_path)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -66,6 +66,8 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         self.spec.mpifc  = join_path(dir, 'mpifc')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
+        super(IntelOneapiMpi, self).setup_dependent_build_environment(env, dependent_spec)
+        
         env.set('MPICH_CC', spack_cc)
         env.set('MPICH_CXX', spack_cxx)
         env.set('MPICH_F77', spack_f77)
@@ -79,8 +81,6 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         env.set('MPIF77', join_path(dir, 'mpif77'))
         env.set('MPIF90', join_path(dir, 'mpif90'))
         env.set('MPIFC', join_path(dir, 'mpifc'))
-
-        env.set('I_MPI_ROOT', self.component_path)
 
     @property
     def headers(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -66,8 +66,9 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         self.spec.mpifc  = join_path(dir, 'mpifc')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        super(IntelOneapiMpi, self).setup_dependent_build_environment(env, dependent_spec)
-        
+        super(IntelOneapiMpi, self).setup_dependent_build_environment(env,
+                                                                      dependent_spec)
+
         env.set('MPICH_CC', spack_cc)
         env.set('MPICH_CXX', spack_cxx)
         env.set('MPICH_F77', spack_f77)


### PR DESCRIPTION
We were setting up dependent build environment piecemeal. Use the vars.sh scripts instead. Implemented in the base class so it is performed for all oneapi packages. Added a test that environment is set up: https://github.com/rscohn2/oneapi-spack-tests/blob/bee95031b1003f1d819fbcb1ddb1dc10bda87137/samples/Makefile#L71

Addresses #30747

@dmentock: Please let me know if this resolved the issue you are seeing