### PR TITLE
Optimize reuse from buildcaches

### DIFF
--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1525,9 +1525,14 @@ class Database(object):
     _query.__doc__ += _query_docstring
 
     def query_local(self, *args, **kwargs):
-        """Query only the local Spack database."""
+        """Query only the local Spack database.
+
+        This function doesn't guarantee any sorting of the returned
+        data for performance reason, since comparing specs for __eq__
+        may be an expensive operation.
+        """
         with self.read_transaction():
-            return sorted(self._query(*args, **kwargs))
+            return self._query(*args, **kwargs)
 
     if query_local.__doc__ is None:
         query_local.__doc__ = ""

--- a/lib/spack/spack/database.py
+++ b/lib/spack/spack/database.py
@@ -1528,7 +1528,7 @@ class Database(object):
         """Query only the local Spack database.
 
         This function doesn't guarantee any sorting of the returned
-        data for performance reason, since comparing specs for __eq__
+        data for performance reason, since comparing specs for __lt__
         may be an expensive operation.
         """
         with self.read_transaction():


### PR DESCRIPTION
On my laptop using e4s:
```console
$ spack mirror add E4S https://cache.e4s.io
$ spack buildcache keys -it
```
takes a very long time with reuse. This PR is an attempt at seeking small changes that might have some impact in this scenario.

Optimizations:
- [x] database: don't sort on return from query_local
- [x] don't build the hash-lookup dictionary twice for a solve with reuse
- [x] don't check if spec satisfies `dev_path=*` when retrieved from a buildcache