### PR TITLE
Fix gdal installation errors on NOAA RDHPC Gaea (64bit I/O) and invalid json-c library dir

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -99,7 +99,7 @@ class Gdal(AutotoolsPackage):
     variant('cryptopp',  default=False, description='Include cryptopp support')
     variant('crypto',    default=False, description='Include crypto (from openssl) support')
     variant('grib',      default=False, description='Include GRIB support')
-    variant('64bitIO',   default=True,  description='Enable 64-bit file I/O')
+    variant('unix_stdio_64', default=True, description='Enable 64-bit file I/O')
 
     # FIXME: Allow packages to extend multiple packages
     # See https://github.com/spack/spack/issues/987
@@ -252,8 +252,8 @@ class Gdal(AutotoolsPackage):
         ]
         # Fix for gdal always using suffix 'lib', even though libraries
         # like json-c might get installed in 'lib64'
-        #ldflags.append(self.spec['libtiff'].libs.search_flags)
-        #ldflags.append(self.spec['libgeotiff'].libs.search_flags)
+        # ldflags.append(self.spec['libtiff'].libs.search_flags)
+        # ldflags.append(self.spec['libgeotiff'].libs.search_flags)
         ldflags.append(self.spec['json-c'].libs.search_flags)
 
         # Optional dependencies
@@ -502,7 +502,7 @@ class Gdal(AutotoolsPackage):
         else:
             args.append('--with-armadillo=no')
 
-        if '+64bitIO' in spec:
+        if '+unix_stdio_64' in spec:
             args.append('--with-unix-stdio-64=yes')
         else:
             args.append('--with-unix-stdio-64=no')

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -99,7 +99,7 @@ class Gdal(AutotoolsPackage):
     variant('cryptopp',  default=False, description='Include cryptopp support')
     variant('crypto',    default=False, description='Include crypto (from openssl) support')
     variant('grib',      default=False, description='Include GRIB support')
-    variant('unix_stdio_64', default=True, description='Enable 64-bit file I/O')
+    variant('unix_stdio_64', default=True, description='Utilize 64 stdio api')
 
     # FIXME: Allow packages to extend multiple packages
     # See https://github.com/spack/spack/issues/987

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -99,6 +99,7 @@ class Gdal(AutotoolsPackage):
     variant('cryptopp',  default=False, description='Include cryptopp support')
     variant('crypto',    default=False, description='Include crypto (from openssl) support')
     variant('grib',      default=False, description='Include GRIB support')
+    variant('64bitIO',   default=True,  description='Enable 64-bit file I/O')
 
     # FIXME: Allow packages to extend multiple packages
     # See https://github.com/spack/spack/issues/987
@@ -494,6 +495,11 @@ class Gdal(AutotoolsPackage):
                 spec['armadillo'].prefix))
         else:
             args.append('--with-armadillo=no')
+
+        if '+64bitIO' in spec:
+            args.append('--with-unix-stdio-64=yes')
+        else:
+            args.append('--with-unix-stdio-64=no')
 
         # TODO: add packages for these dependencies
         args.extend([

--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -241,6 +241,7 @@ class Gdal(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         libs = []
+        ldflags = []
 
         # Required dependencies
         args = [
@@ -249,6 +250,11 @@ class Gdal(AutotoolsPackage):
             '--with-geotiff={0}'.format(spec['libgeotiff'].prefix),
             '--with-libjson-c={0}'.format(spec['json-c'].prefix),
         ]
+        # Fix for gdal always using suffix 'lib', even though libraries
+        # like json-c might get installed in 'lib64'
+        #ldflags.append(self.spec['libtiff'].libs.search_flags)
+        #ldflags.append(self.spec['libgeotiff'].libs.search_flags)
+        ldflags.append(self.spec['json-c'].libs.search_flags)
 
         # Optional dependencies
         if spec.satisfies('@3:'):
@@ -591,6 +597,8 @@ class Gdal(AutotoolsPackage):
         if libs:
             args.append('LIBS=' + ' '.join(libs))
 
+        if ldflags:
+            args.append('LDFLAGS=' + ' '.join(ldflags))
         return args
 
     # https://trac.osgeo.org/gdal/wiki/GdalOgrInJavaBuildInstructionsUnix


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/23943 by using the correct library directory name (`lib` or `lib64`, depending on the system) when looking for `json-c` libraries.

Fixes https://github.com/spack/spack/issues/30808 by adding a new variant `64bitIO`. Default is on, i.e. no change, turning it off on Gaea allows building `gdal@3.4.2` successfully.