### PR TITLE
Additional BLAS/LAPACK library configuration for Numpy

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -226,7 +226,7 @@ class PyNumpy(PythonPackage):
         # Tell numpy where to find BLAS/LAPACK libraries
         with open('site.cfg', 'w') as f:
             if '^intel-mkl' in spec or \
-               '^intel-parallel-studio+mkl' or \
+               '^intel-parallel-studio+mkl' in spec or \
                '^intel-oneapi-mkl' in spec:
                 f.write('[mkl]\n')
                 # FIXME: as of @1.11.2, numpy does not work with separately
@@ -245,7 +245,8 @@ class PyNumpy(PythonPackage):
                 write_library_dirs(f, lapackblas_lib_dirs)
                 f.write('include_dirs = {0}\n'.format(lapackblas_header_dirs))
 
-            if '^blis' in spec:
+            if '^blis' in spec or \
+               '^amdblis' in spec:
                 f.write('[blis]\n')
                 f.write('libraries = {0}\n'.format(blas_lib_names))
                 write_library_dirs(f, blas_lib_dirs)
@@ -257,7 +258,8 @@ class PyNumpy(PythonPackage):
                 write_library_dirs(f, lapackblas_lib_dirs)
                 f.write('include_dirs = {0}\n'.format(lapackblas_header_dirs))
 
-            if '^libflame' in spec:
+            if '^libflame' in spec or \
+               '^amdlibflame' in spec:
                 f.write('[flame]\n')
                 f.write('libraries = {0}\n'.format(lapack_lib_names))
                 write_library_dirs(f, lapack_lib_dirs)
@@ -315,7 +317,6 @@ class PyNumpy(PythonPackage):
         # https://github.com/numpy/numpy/pull/13132
         # https://numpy.org/devdocs/user/building.html#accelerated-blas-lapack-libraries
         spec = self.spec
-
         # https://numpy.org/devdocs/user/building.html#blas
         if 'blas' not in spec:
             blas = ''
@@ -323,7 +324,8 @@ class PyNumpy(PythonPackage):
                 spec['blas'].name == 'intel-parallel-studio' or \
                 spec['blas'].name == 'intel-oneapi-mkl':
             blas = 'mkl'
-        elif spec['blas'].name == 'blis':
+        elif spec['blas'].name == 'blis' or \
+                spec['blas'].name == 'amdblis':
             blas = 'blis'
         elif spec['blas'].name == 'openblas':
             blas = 'openblas'
@@ -345,7 +347,8 @@ class PyNumpy(PythonPackage):
             lapack = 'mkl'
         elif spec['lapack'].name == 'openblas':
             lapack = 'openblas'
-        elif spec['lapack'].name == 'libflame':
+        elif spec['lapack'].name == 'libflame' or \
+                spec['lapack'].name == 'amdlibflame':
             lapack = 'flame'
         elif spec['lapack'].name == 'atlas':
             lapack = 'atlas'

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -312,6 +312,18 @@ class PyNumpy(PythonPackage):
                         )
                     )
 
+            if '^cray-libsci' in spec:
+                if spec.satisfies('+blas'):
+                    f.write('[blas]\n')
+                    f.write('libraries = {0}\n'.format(spec['blas'].libs.names[0]))
+                    write_library_dirs(f, blas_lib_dirs)
+                    f.write('include_dirs = {0}\n'.format(blas_header_dirs))
+                if spec.satisfies('+lapack'):
+                    f.write('[lapack]\n')
+                    f.write('libraries = {0}\n'.format(spec['lapack'].libs.names[0]))
+                    write_library_dirs(f, lapack_lib_dirs)
+                    f.write('include_dirs = {0}\n'.format(lapack_header_dirs))
+
     def setup_build_environment(self, env):
         # Tell numpy which BLAS/LAPACK libraries we want to use.
         # https://github.com/numpy/numpy/pull/13132

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -276,8 +276,9 @@ class PyNumpy(PythonPackage):
                 f.write('libraries = {0}\n'.format(lapackblas_lib_names))
                 write_library_dirs(f, lapackblas_lib_dirs)
 
-            if '^netlib-lapack' in spec:
-                # netlib requires blas and lapack listed
+            if '^netlib-lapack' in spec or \
+               '^cray-libsci' in spec:
+                # netlib and Cray require blas and lapack listed
                 # separately so that scipy can find them
                 if spec.satisfies('+blas'):
                     f.write('[blas]\n')
@@ -311,18 +312,6 @@ class PyNumpy(PythonPackage):
                             self.spec["lapack"].libs.ld_flags
                         )
                     )
-
-            if '^cray-libsci' in spec:
-                if spec.satisfies('+blas'):
-                    f.write('[blas]\n')
-                    f.write('libraries = {0}\n'.format(spec['blas'].libs.names[0]))
-                    write_library_dirs(f, blas_lib_dirs)
-                    f.write('include_dirs = {0}\n'.format(blas_header_dirs))
-                if spec.satisfies('+lapack'):
-                    f.write('[lapack]\n')
-                    f.write('libraries = {0}\n'.format(spec['lapack'].libs.names[0]))
-                    write_library_dirs(f, lapack_lib_dirs)
-                    f.write('include_dirs = {0}\n'.format(lapack_header_dirs))
 
     def setup_build_environment(self, env):
         # Tell numpy which BLAS/LAPACK libraries we want to use.


### PR DESCRIPTION
Adds:
- amdblis/amdlibflame libraries as if they were BLIS/libflame
- Cray-libsci as an additional BLAS/LAPACK provider

Fixes:
- Error in conditional around MKL which resulted it being included in every configuration regardless of whether MKL was in the spec