### PR TITLE
Ensure same BLAS/LAPACK config from Numpy used in Scipy

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack.pkg.builtin.py_numpy import PyNumpy
-
 
 class PyScipy(PythonPackage):
     """SciPy (pronounced "Sigh Pie") is a Scientific Library for Python.
@@ -102,8 +100,7 @@ class PyScipy(PythonPackage):
     @run_before('install')
     def set_blas_lapack(self):
         # Pick up Blas/Lapack from numpy
-        numpy = PyNumpy(self.spec['py-numpy'])
-        numpy.set_blas_lapack()
+        self.spec['py-numpy'].package.set_blas_lapack()
 
     def setup_build_environment(self, env):
         # https://github.com/scipy/scipy/issues/9080
@@ -114,8 +111,7 @@ class PyScipy(PythonPackage):
             env.set('FFLAGS', '-fallow-argument-mismatch')
 
         # Pick up Blas/Lapack from numpy
-        numpy = PyNumpy(self.spec['py-numpy'])
-        numpy.setup_build_environment(env)
+        self.spec['py-numpy'].package.setup_build_environment(env)
 
     def install_options(self, spec, prefix):
         args = []

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -85,10 +85,9 @@ class PyScipy(PythonPackage):
     depends_on('python@3.8:3.10', when='@1.8:', type=('build', 'link', 'run'))
     depends_on('py-pytest', type='test')
 
-    # NOTE: scipy picks up Blas/Lapack from numpy, see
-    # http://www.scipy.org/scipylib/building/linux.html#step-4-build-numpy-1-5-0
+    # NOTE: scipy should use the same Blas/Lapack as numpy
     # This is achieved by calling the set_blas_lapack() and setup_build_environment()
-    # from numpy in the spec
+    # from numpy in the scipy spec
     depends_on('blas')
     depends_on('lapack')
     # https://github.com/scipy/scipy/wiki/Dropping-support-for-Accelerate

--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+from spack.pkg.builtin.py_numpy import PyNumpy
+
+
 class PyScipy(PythonPackage):
     """SciPy (pronounced "Sigh Pie") is a Scientific Library for Python.
     It provides many user-friendly and efficient numerical routines such
@@ -84,6 +87,8 @@ class PyScipy(PythonPackage):
 
     # NOTE: scipy picks up Blas/Lapack from numpy, see
     # http://www.scipy.org/scipylib/building/linux.html#step-4-build-numpy-1-5-0
+    # This is achieved by calling the set_blas_lapack() and setup_build_environment()
+    # from numpy in the spec
     depends_on('blas')
     depends_on('lapack')
     # https://github.com/scipy/scipy/wiki/Dropping-support-for-Accelerate
@@ -95,6 +100,12 @@ class PyScipy(PythonPackage):
 
     patch('scipy-clang.patch', when='@1.5.0:1.6.3 %clang')
 
+    @run_before('install')
+    def set_blas_lapack(self):
+        # Pick up Blas/Lapack from numpy
+        numpy = PyNumpy(self.spec['py-numpy'])
+        numpy.set_blas_lapack()
+
     def setup_build_environment(self, env):
         # https://github.com/scipy/scipy/issues/9080
         env.set('F90', spack_fc)
@@ -102,6 +113,10 @@ class PyScipy(PythonPackage):
         # https://github.com/scipy/scipy/issues/11611
         if self.spec.satisfies('@:1.4 %gcc@10:'):
             env.set('FFLAGS', '-fallow-argument-mismatch')
+
+        # Pick up Blas/Lapack from numpy
+        numpy = PyNumpy(self.spec['py-numpy'])
+        numpy.setup_build_environment(env)
 
     def install_options(self, spec, prefix):
         args = []


### PR DESCRIPTION
The comment `NOTE: scipy picks up Blas/Lapack from numpy` relies on `setup.py` picking up the correct BLAS/LAPACK configuration from Numpy, but this can fail.

Eg: Building Numpy with (amd)libflame does not get picked up by Scipy's `setup.py` and picks up a system LAPACK installation.

This change uses the spec of the installed Numpy to generate the same `site.cfg` for Scipy as was generated for Numpy and to set the `NPY_BLAS_ORDER` and `NPY_LAPACK_ORDER` environment variables, which seem to be respected by Scipy. Setting `BLAS` and `LAPACK` environment variables doesn't seem sufficient. This solution has the advantage of propagating any future BLAS/LAPACK config changes from Numpy into the Scipy package.