### PR TITLE
clingo: fix ~python build

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -12,6 +12,7 @@ on:
       # built-in repository or documentation
       - 'var/spack/repos/builtin/**'
       - '!var/spack/repos/builtin/packages/clingo-bootstrap/**'
+      - '!var/spack/repos/builtin/packages/clingo/**'
       - '!var/spack/repos/builtin/packages/python/**'
       - '!var/spack/repos/builtin/packages/re2c/**'
       - 'lib/spack/docs/**'

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -86,15 +86,16 @@ class Clingo(CMakePackage):
         except UnsupportedCompilerFlag:
             InstallError('clingo requires a C++14-compliant C++ compiler')
 
-        args = [
-            '-DCLINGO_REQUIRE_PYTHON=ON',
-            '-DCLINGO_BUILD_WITH_PYTHON=ON',
-            '-DPYCLINGO_USER_INSTALL=OFF',
-            '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
-            '-DCLINGO_BUILD_WITH_LUA=OFF',
-            self.cmake_py_shared
-        ]
-        if self.spec['cmake'].satisfies('@3.16.0:'):
-            args += self.cmake_python_hints
+        if '+python' in self.spec:
+            args = [
+                '-DCLINGO_REQUIRE_PYTHON=ON',
+                '-DCLINGO_BUILD_WITH_PYTHON=ON',
+                '-DPYCLINGO_USER_INSTALL=OFF',
+                '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
+                '-DCLINGO_BUILD_WITH_LUA=OFF',
+                self.cmake_py_shared
+            ]
+            if self.spec['cmake'].satisfies('@3.16.0:'):
+                args += self.cmake_python_hints
 
         return args

--- a/var/spack/repos/builtin/packages/clingo/package.py
+++ b/var/spack/repos/builtin/packages/clingo/package.py
@@ -86,16 +86,19 @@ class Clingo(CMakePackage):
         except UnsupportedCompilerFlag:
             InstallError('clingo requires a C++14-compliant C++ compiler')
 
+        args = ['-DCLINGO_BUILD_WITH_LUA=OFF']
+
         if '+python' in self.spec:
-            args = [
+            args += [
                 '-DCLINGO_REQUIRE_PYTHON=ON',
                 '-DCLINGO_BUILD_WITH_PYTHON=ON',
                 '-DPYCLINGO_USER_INSTALL=OFF',
                 '-DPYCLINGO_USE_INSTALL_PREFIX=ON',
-                '-DCLINGO_BUILD_WITH_LUA=OFF',
                 self.cmake_py_shared
             ]
             if self.spec['cmake'].satisfies('@3.16.0:'):
                 args += self.cmake_python_hints
+        else:
+            args += ['-DCLINGO_BUILD_WITH_PYTHON=OFF']
 
         return args


### PR DESCRIPTION
Haven't actually tried, but I'm pretty sure `clingo~python` build would fail since it assumes that `python` is always in the DAG and adds the flags to enable the Python build regardless of `+python`.