### PR TITLE
py-numpy: add v1.22.4

### DIFF
--- a/var/spack/repos/builtin/packages/py-cython/package.py
+++ b/var/spack/repos/builtin/packages/py-cython/package.py
@@ -13,7 +13,8 @@ class PyCython(PythonPackage):
     pypi = "cython/Cython-0.29.21.tar.gz"
 
     version('3.0.0a9', sha256='23931c45877432097cef9de2db2dc66322cbc4fc3ebbb42c476bb2c768cecff0')
-    version('0.29.24', sha256='cdf04d07c3600860e8c2ebaad4e8f52ac3feb212453c1764a49ac08c827e8443', preferred=True)
+    version('0.29.30', sha256='2235b62da8fe6fa8b99422c8e583f2fb95e143867d337b5c75e4b9a1a865f9e3', preferred=True)
+    version('0.29.24', sha256='cdf04d07c3600860e8c2ebaad4e8f52ac3feb212453c1764a49ac08c827e8443')
     version('0.29.23', sha256='6a0d31452f0245daacb14c979c77e093eb1a546c760816b5eed0047686baad8e')
     version('0.29.22', sha256='df6b83c7a6d1d967ea89a2903e4a931377634a297459652e4551734c48195406')
     version('0.29.21', sha256='e57acb89bd55943c8d8bf813763d20b9099cc7165c0f16b707631a7654be9cad')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -23,6 +23,7 @@ class PyNumpy(PythonPackage):
     maintainers = ['adamjstewart', 'rgommers']
 
     version('main', branch='main')
+    version('1.22.4', sha256='425b390e4619f58d8526b3dcf656dde069133ae5c240229821f01b5f44ea07af')
     version('1.22.3', sha256='dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18')
     version('1.22.2', sha256='076aee5a3763d41da6bef9565fdf3cb987606f567cd8b104aded2b38b7b47abf')
     version('1.22.1', sha256='e348ccf5bc5235fc405ab19d53bec215bb373300e5523c7b476cc0da8a5e9973')
@@ -107,6 +108,7 @@ class PyNumpy(PythonPackage):
     depends_on('py-cython@0.29.14:2', when='@1.18.1:', type='build')
     depends_on('py-cython@0.29.21:2', when='@1.19.1:', type='build')
     depends_on('py-cython@0.29.24:2', when='@1.21.2:', type='build')
+    depends_on('py-cython@0.29.30:2', when='@1.22.4:', type='build')
     depends_on('blas',   when='+blas')
     depends_on('lapack', when='+lapack')
 


### PR DESCRIPTION
Requires new version of cython as well (although technically not required?)

Successfully builds on macOS 12.3.1 and Apple M1 Pro with Python 3.9.12 and Apple Clang 13.1.6.