### PR TITLE
py-pillow-simd: mark conflicts with aarch64

### DIFF
--- a/var/spack/repos/builtin/packages/py-pillow-simd/package.py
+++ b/var/spack/repos/builtin/packages/py-pillow-simd/package.py
@@ -21,3 +21,5 @@ class PyPillowSimd(PyPillowBase):
 
     for ver in ['6.2.2.post1', '7.0.0.post3', '9.0.0.post1']:
         provides('pil@' + ver, when='@' + ver)
+
+    conflicts('target=aarch64:')


### PR DESCRIPTION
@alalazo @becker33 question about microarches. From what I can tell, this is just a fork of `py-pillow` with SIMD stuff to make it faster. I believe the build error I got on Apple M1 was something about simd128? I know archspec can find microarch support like whether or not simd128 is supported by the hardware. Is that something we can access directly in the spec, or is something generic like `target=aarch64:` as close as we can get?