### PR TITLE
py-scikit-learn: add v1.1.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-scikit-learn/package.py
+++ b/var/spack/repos/builtin/packages/py-scikit-learn/package.py
@@ -13,6 +13,7 @@ class PyScikitLearn(PythonPackage):
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('1.1.1', sha256='3e77b71e8e644f86c8b5be7f1c285ef597de4c384961389ee3e9ca36c445b256')
     version('1.1.0', sha256='80f9904f5b1356adfc32406725dd94c8cc9c8d265047d98390033a6c238cbb29')
     version('1.0.2', sha256='b5870959a5484b614f26d31ca4c17524b1b0317522199dc985c3b4256e030767')
     version('1.0.1', sha256='ac2ca9dbb754d61cfe1c83ba8483498ef951d29b93ec09d6f002847f210a99da')


### PR DESCRIPTION
Successfully installs on macOS 12.3.1 and Apple M1 Pro with Python 3.9.12 and Apple Clang 13.1.6.