### PR TITLE
py-scipy: add v1.8.1

### DIFF
--- a/var/spack/repos/builtin/packages/py-scipy/package.py
+++ b/var/spack/repos/builtin/packages/py-scipy/package.py
@@ -15,6 +15,7 @@ class PyScipy(PythonPackage):
     maintainers = ['adamjstewart', 'rgommers']
 
     version('master', branch='master')
+    version('1.8.1',  sha256='9e3fb1b0e896f14a85aa9a28d5f755daaeeb54c897b746df7a55ccb02b340f33')
     version('1.8.0',  sha256='31d4f2d6b724bc9a98e527b5849b8a7e589bf1ea630c33aa563eda912c9ff0bd')
     version('1.7.3',  sha256='ab5875facfdef77e0a47d5fd39ea178b58e60e454a4c85aa1e52fcb80db7babf')
     version('1.7.2',  sha256='fa2dbabaaecdb502641b0b3c00dec05fb475ae48655c66da16c9ed24eda1e711')
@@ -61,7 +62,7 @@ class PyScipy(PythonPackage):
     depends_on('py-pybind11@2.4.3:2.8', when='@1.8:', type=('build', 'link'))
     depends_on('py-pythran@0.9.11', when='@1.7.0:1.7.1', type=('build', 'link'))
     depends_on('py-pythran@0.9.12:0.9', when='@1.7.2:1.7', type=('build', 'link'))
-    depends_on('py-pythran@0.10', when='@1.8:', type=('build', 'link'))
+    depends_on('py-pythran@0.10:', when='@1.8:', type=('build', 'link'))
     # setup.py
     depends_on('py-numpy@1.5.1:+blas+lapack', when='@:0.15', type=('build', 'link', 'run'))
     depends_on('py-numpy@1.6.2:+blas+lapack', when='@0.16:0.17', type=('build', 'link', 'run'))


### PR DESCRIPTION
Successfully installs on macOS 12.3.1 and Apple M1 Pro with Python 3.9.12 and Apple Clang 13.1.6.

Apparently the build dep version pins in `pyproject.toml` aren't strict (https://github.com/spack/spack/issues/30734#issuecomment-1132672573). We should consider removing these entirely someday, but that would require me to test a wider range of versions than I have time for at the moment.