### PR TITLE
geant4: new version v11.0.2

### DIFF
--- a/var/spack/repos/builtin/packages/geant4/package.py
+++ b/var/spack/repos/builtin/packages/geant4/package.py
@@ -21,6 +21,7 @@ class Geant4(CMakePackage):
 
     maintainers = ['drbenmorgan']
 
+    version('11.0.2', sha256='661e1ab6f42e58910472d771e76ffd16a2b411398eed70f39808762db707799e')
     version('11.0.1', sha256='fa76d0774346b7347b1fb1424e1c1e0502264a83e185995f3c462372994f84fa')
     version('11.0.0', sha256='04d11d4d9041507e7f86f48eb45c36430f2b6544a74c0ccaff632ac51d9644f1')
     version('10.7.3', sha256='8615d93bd4178d34f31e19d67bc81720af67cdab1c8425af8523858dcddcf65b', preferred=True)


### PR DESCRIPTION
Simple version bump with new upstream patch release. No changes to options or dependencies such as `geant4-data`. Tested locally on a CentOS7 machine with `gcc@11.3.0`