### PR TITLE
sed: fix recursive symlink

### DIFF
--- a/var/spack/repos/builtin/packages/sed/package.py
+++ b/var/spack/repos/builtin/packages/sed/package.py
@@ -16,6 +16,9 @@ class Sed(AutotoolsPackage, GNUMirrorPackage):
     version('4.8', sha256='f79b0cfea71b37a8eeec8490db6c5f7ae7719c35587f21edb0617f370eeff633')
     version('4.2.2', sha256='f048d1838da284c8bc9753e4506b85a1e0cc1ea8999d36f6995bcb9460cddbd7')
 
+    # Avoid symlinking GNUMakefile to GNUMakefile
+    build_directory = 'spack-build'
+
     executables = ['^sed$']
 
     def url_for_version(self, version):


### PR DESCRIPTION
Fixes #30816 

```
config.status: linking /var/folders/fy/x2xtwh1n7fn0_0q2kk29xkv9vvmbqb/T/s3j/spack-stage/spack-stage-sed-4.8-wraqsot6ofzvr3vrgusx4mj4mya5xfux/spack-src/GNUmakefile to GNUmakefile
config.status: executing depfiles commands
config.status: executing po-directories commands
config.status: creating po/POTFILES
config.status: creating po/Makefile
==> sed: Executing phase: 'build'
==> [2022-05-25-14:15:51.310333] 'make' '-j8' 'V=1'
make: GNUmakefile: Too many levels of symbolic links
make: stat: GNUmakefile: Too many levels of symbolic links
make: *** No rule to make target `GNUmakefile'.  Stop.
```