### PR TITLE
acts-dd4hep: new package; acts: new version

### DIFF
--- a/var/spack/repos/builtin/packages/acts-dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/acts-dd4hep/package.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class ActsDd4hep(CMakePackage):

--- a/var/spack/repos/builtin/packages/acts-dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/acts-dd4hep/package.py
@@ -10,10 +10,10 @@ class ActsDd4hep(CMakePackage):
     """Glue library to connect Acts to DD4hep"""
 
     homepage = "https://github.com/acts-project/acts-dd4hep"
-    url      = "https://github.com/acts-project/acts-dd4hep/archive/refs/tags/v1.tar.gz"
+    url      = "https://github.com/acts-project/acts-dd4hep/archive/refs/tags/v1.0.0.tar.gz"
 
     maintainers = ['HadrianG2', 'wdconinc']
 
-    version('1', sha256='a220d74933b8887ed8cc9be40c7645d5cb9e5eb4a4ac70d0170d8e2403f29a52')
+    version('1.0.0', sha256='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
 
     depends_on('dd4hep@1.11: +dddetectors')

--- a/var/spack/repos/builtin/packages/acts-dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/acts-dd4hep/package.py
@@ -1,0 +1,19 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+
+class ActsDd4hep(CMakePackage):
+    """Glue library to connect Acts to DD4hep"""
+
+    homepage = "https://github.com/acts-project/acts-dd4hep"
+    url      = "https://github.com/acts-project/acts-dd4hep/archive/refs/tags/v1.tar.gz"
+
+    maintainers = ['HadrianG2', 'wdconinc']
+
+    version('1', sha256='a220d74933b8887ed8cc9be40c7645d5cb9e5eb4a4ac70d0170d8e2403f29a52')
+
+    depends_on('dd4hep@1.11: +dddetectors')

--- a/var/spack/repos/builtin/packages/acts-dd4hep/package.py
+++ b/var/spack/repos/builtin/packages/acts-dd4hep/package.py
@@ -14,6 +14,6 @@ class ActsDd4hep(CMakePackage):
 
     maintainers = ['HadrianG2', 'wdconinc']
 
-    version('1.0.0', sha256='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+    version('1.0.0', sha256='991f996944c88efa837880f919239e50d12c5c9361e220bc9422438dd608308c')
 
     depends_on('dd4hep@1.11: +dddetectors')

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -138,6 +138,7 @@ class Acts(CMakePackage, CudaPackage):
     variant('json', default=False, description='Build the Json plugin')
     variant('legacy', default=False, description='Build the Legacy package')
     variant('onnx', default=False, description="Build ONNX plugin")
+    variant('odd', default=False, description='Build the Open Data Detector', when='@19.1:')
     # FIXME: Cannot build SyCL plugin yet as Spack doesn't have SyCL support
     variant('tgeo', default=False, description='Build the TGeo plugin', when='+identification')
 
@@ -224,6 +225,7 @@ class Acts(CMakePackage, CudaPackage):
             cmake_variant(integration_tests_label, "integration_tests"),
             plugin_cmake_variant("JSON", "json"),
             cmake_variant(legacy_plugin_label, "legacy"),
+            cmake_variant("ODD", "odd"),
             plugin_cmake_variant("ONNX", "onnx"),
             example_cmake_variant("PYTHIA8", "pythia8"),
             example_cmake_variant("PYTHON_BINDINGS", "python"),

--- a/var/spack/repos/builtin/packages/acts/package.py
+++ b/var/spack/repos/builtin/packages/acts/package.py
@@ -39,6 +39,7 @@ class Acts(CMakePackage, CudaPackage):
     # Supported Acts versions
     version('main', branch='main')
     version('master', branch='main', deprecated=True)  # For compatibility
+    version('19.1.0', commit='82f42a2cc80d4259db251275c09b84ee97a7bd22', submodules=True)
     version('19.0.0', commit='1ce9c583150060ba8388051685433899713d56d9', submodules=True)
     version('18.0.0', commit='fe03b5af6ca2b092dec87c4cef77dd552bbbe719', submodules=True)
     version('17.1.0', commit='0d9c3a6da022da48d6401e10c273896a1f775a9e', submodules=True)
@@ -150,6 +151,7 @@ class Acts(CMakePackage, CudaPackage):
     # Build dependencies
     # FIXME: Use spack's vecmem package once there is one
     # (https://github.com/acts-project/acts/pull/998)
+    depends_on('acts-dd4hep', when='@19.1: +dd4hep')
     depends_on('autodiff @0.6:', when='@17: +autodiff')
     depends_on('autodiff @0.5.11:0.5.99', when='@1.2:16 +autodiff')
     depends_on('boost @1.62:1.69 +program_options +test', when='@:0.10.3')
@@ -239,6 +241,9 @@ class Acts(CMakePackage, CudaPackage):
             cuda_arch = spec.variants['cuda_arch'].value
             if cuda_arch != 'none':
                 args.append('-DCUDA_FLAGS=-arch=sm_{0}'.format(cuda_arch[0]))
+
+        if spec.satisfies('@19.1: +dd4hep'):
+            args.append('-DACTS_USE_SYSTEM_ACTSDD4HEP=ON')
 
         if spec.satisfies('@:16'):
             args.append(plugin_cmake_variant("DIGITIZATION", "digitization"))


### PR DESCRIPTION
With `acts@19.1.0`, the `DD4hep` plugin in ACTS has been extracted into a separate project.

Added @HadrienG2 as maintainer since this may remain closely aligned to ACTS itself.