### PR TITLE
Updated mfem constraints in laghos spackage

### DIFF
--- a/var/spack/repos/builtin/packages/laghos/package.py
+++ b/var/spack/repos/builtin/packages/laghos/package.py
@@ -37,9 +37,9 @@ class Laghos(MakefilePackage):
     depends_on('mfem@4.2.0', when='@3.1')
     depends_on('mfem@4.1.0:4.1', when='@3.0')
     # Recommended mfem version for laghos v2.0 is: ^mfem@3.4.1-laghos-v2.0
-    depends_on('mfem@3.4.0:', when='@2.0')
+    depends_on('mfem@3.4.1-laghos-v2.0', when='@2.0')
     # Recommended mfem version for laghos v1.x is: ^mfem@3.3.1-laghos-v1.0
-    depends_on('mfem@3.3.1-laghos-v1.0:', when='@1.0,1.1')
+    depends_on('mfem@3.3.1-laghos-v1.0', when='@1.0,1.1')
 
     @property
     def build_targets(self):


### PR DESCRIPTION
Updated mfem constraints in laghos spackage to better match comments and support legacy builds of `laghos@1.0:2.0`

Previously, both would result in laghos attempting to build against the newest version of mfem and erroring out due to API changes.