### PR TITLE
eagle: updating to version 1.1.3

### DIFF
--- a/var/spack/repos/builtin/packages/eagle/package.py
+++ b/var/spack/repos/builtin/packages/eagle/package.py
@@ -11,7 +11,9 @@ class Eagle(MakefilePackage):
 
     homepage = "https://github.com/tony-kuo/eagle"
     url      = "https://github.com/tony-kuo/eagle/archive/v1.1.2.tar.gz"
+    maintainers = ['snehring']
 
+    version('1.1.3', sha256='bd510b8eef2de14898cbf417e1c7a30b97ddaba24e5e2834da7b02767362fe3c')
     version('1.1.2', sha256='afe967560d1f8fdbd0caf4b93b5f2a86830e9e4d399fee4a526140431343045e')
 
     depends_on('curl')
@@ -36,9 +38,8 @@ class Eagle(MakefilePackage):
         # use spack C compiler
         filter_file('CC=.*', 'CC={0}'.format(spack_cc), 'Makefile')
 
-        # remove march=native %fj
-        if self.spec.satisfies('%fj'):
-            filter_file('-march=native', '', 'Makefile', string=True)
+        # let the user inject march if they want
+        filter_file('-march=native', '', 'Makefile', string=True)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
Updates package to 1.1.3, which fixes compilation issues on newer gccs among other things.

I've removed the conditional for removing the march flag, since that actually seems desirable everywhere to me. If people wanna go with march they can specify that in the cflags when compiling.