### PR TITLE
Fix compiler flags for oneapi and dpcpp

### DIFF
--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -18,7 +18,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.1.4 (commit 2ad44697e76468ac264fdbbb3b5e6e6a07ba0551)
+* Version: 0.1.4 (commit b8eea9df2b4204ff27d204452cd46f5199a0b423)
 
 argparse
 --------

--- a/lib/spack/external/__init__.py
+++ b/lib/spack/external/__init__.py
@@ -18,7 +18,7 @@ archspec
 
 * Homepage: https://pypi.python.org/pypi/archspec
 * Usage: Labeling, comparison and detection of microarchitectures
-* Version: 0.1.4 (commit 53fc4ac91e9b4c5e4079f15772503a80bece72ad)
+* Version: 0.1.4 (commit 2ad44697e76468ac264fdbbb3b5e6e6a07ba0551)
 
 argparse
 --------

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -146,14 +146,14 @@
         ],
         "oneapi": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v2",
             "flags": "-march={name} -mtune=generic"
           }
         ],
         "dpcpp": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v2",
             "flags": "-march={name} -mtune=generic"
           }
@@ -217,14 +217,14 @@
         ],
         "oneapi": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v3",
             "flags": "-march={name} -mtune=generic"
           }
         ],
         "dpcpp": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v3",
             "flags": "-march={name} -mtune=generic"
           }
@@ -293,14 +293,14 @@
         ],
         "oneapi": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v4",
             "flags": "-march={name} -mtune=generic"
           }
         ],
         "dpcpp": [
           {
-            "versions": ":",
+            "versions": "2021.2.0:",
             "name": "x86-64-v4",
             "flags": "-march={name} -mtune=generic"
           }

--- a/lib/spack/external/archspec/json/cpu/microarchitectures.json
+++ b/lib/spack/external/archspec/json/cpu/microarchitectures.json
@@ -85,21 +85,21 @@
         "intel": [
           {
             "versions": ":",
-            "name": "pentium4",
+            "name": "x86-64",
             "flags": "-march={name} -mtune=generic"
           }
         ],
         "oneapi": [
           {
             "versions": ":",
-            "name": "pentium4",
+            "name": "x86-64",
             "flags": "-march={name} -mtune=generic"
           }
         ],
         "dpcpp": [
           {
             "versions": ":",
-            "name": "pentium4",
+            "name": "x86-64",
             "flags": "-march={name} -mtune=generic"
           }
         ]
@@ -142,6 +142,20 @@
             "versions": "3.9:11.1",
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3"
+          }
+        ],
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "x86-64-v2",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ],
+        "dpcpp": [
+          {
+            "versions": ":",
+            "name": "x86-64-v2",
+            "flags": "-march={name} -mtune=generic"
           }
         ]
       }
@@ -199,6 +213,20 @@
             "versions": "8.0:",
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave"
+          }
+        ],
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "x86-64-v3",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ],
+        "dpcpp": [
+          {
+            "versions": ":",
+            "name": "x86-64-v3",
+            "flags": "-march={name} -mtune=generic"
           }
         ]
       }
@@ -262,6 +290,20 @@
             "name": "x86-64",
             "flags": "-march={name} -mtune=generic -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mavx -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -mxsave -mavx512f -mavx512bw -mavx512cd -mavx512dq -mavx512vl"
           }
+        ],
+        "oneapi": [
+          {
+            "versions": ":",
+            "name": "x86-64-v4",
+            "flags": "-march={name} -mtune=generic"
+          }
+        ],
+        "dpcpp": [
+          {
+            "versions": ":",
+            "name": "x86-64-v4",
+            "flags": "-march={name} -mtune=generic"
+          }
         ]
       }
     },
@@ -302,22 +344,19 @@
         "intel": [
           {
             "versions": "16.0:",
-            "name": "pentium4",
-            "flags": "-march={name} -mtune=generic"
+            "flags": "-march={name} -mtune={name}"
           }
         ],
         "oneapi": [
           {
             "versions": ":",
-            "name": "pentium4",
-            "flags": "-march={name} -mtune=generic"
+            "flags": "-march={name} -mtune={name}"
           }
         ],
         "dpcpp": [
           {
             "versions": ":",
-            "name": "pentium4",
-            "flags": "-march={name} -mtune=generic"
+            "flags": "-march={name} -mtune={name}"
           }
         ]
       }


### PR DESCRIPTION
The JSON file was missing some flag definitions for generic architectures, which were causing the concretizer to fail.