### PR TITLE
q-e-sirius: remove ~apps constraint

### DIFF
--- a/var/spack/repos/builtin/packages/q-e-sirius/package.py
+++ b/var/spack/repos/builtin/packages/q-e-sirius/package.py
@@ -23,8 +23,11 @@ class QESirius(CMakePackage):
     variant('elpa', default=False, description='Uses ELPA as an eigenvalue solver')
     variant('libxc', default=False, description='Support functionals through libxc')
     variant('hdf5', default=False, description='Enables HDF5 support')
+    variant('sirius_apps', default=False, description='Build SIRIUS standalone binaries')
 
-    depends_on('sirius +fortran ~apps')
+    depends_on('sirius +fortran')
+    depends_on('sirius +apps', when='+sirius_apps')
+    depends_on('sirius ~apps', when='~sirius_apps')
     depends_on('sirius +openmp', when='+openmp')
     depends_on('sirius@develop', when='@develop')
 


### PR DESCRIPTION
Allow q-sirius to be built with `sirius+apps` by adding the variant `sirius_apps` which toggles the `apps` variant of the sirius dependency.

@haampie 
Is there a better solution to achieve the same behavior?
The current `q-e-sirius` package cannot be built with `sirius+apps`. Removing `depends_on('sirius ~apps')` would fix this, but then by default, `q-e-sirius` would be built with `sirius+apps`. But for a regular user it would be more desirable to default to `q-e-sirius ^sirius~apps`.