### PR TITLE
wget: fixing compilation issue with gcc11+ on rhel7

### DIFF
--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -56,8 +56,8 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
     def flag_handler(self, name, flags):
         older_glibc = self.spec.satisfies('os=rhel7') or \
             self.spec.satisfies('os=centos7')
-        if self.spec.satisfies('%gcc@12:') and older_glibc and name.lower() == 'cflags':
-            flags.append('-std=c11')
+        if self.spec.satisfies('%gcc@11:') and older_glibc and name.lower() == 'cflags':
+            flags.append(self.compiler.c11_flag)
         return (None, None, flags)
 
     def configure_args(self):

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -54,6 +54,9 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
     build_directory = 'spack-build'
 
     def flag_handler(self, name, flags):
+        # gcc11 defaults to c17, which breaks compilation with older
+        # glibc versions as shipped with rhel7 and likely other OS
+        # versions too, feel free to add as necessary
         older_glibc = self.spec.satisfies('os=rhel7') or \
             self.spec.satisfies('os=centos7')
         if self.spec.satisfies('%gcc@11:') and older_glibc and name.lower() == 'cflags':

--- a/var/spack/repos/builtin/packages/wget/package.py
+++ b/var/spack/repos/builtin/packages/wget/package.py
@@ -53,6 +53,13 @@ class Wget(AutotoolsPackage, GNUMirrorPackage):
 
     build_directory = 'spack-build'
 
+    def flag_handler(self, name, flags):
+        older_glibc = self.spec.satisfies('os=rhel7') or \
+            self.spec.satisfies('os=centos7')
+        if self.spec.satisfies('%gcc@12:') and older_glibc and name.lower() == 'cflags':
+            flags.append('-std=c11')
+        return (None, None, flags)
+
     def configure_args(self):
         spec = self.spec
 


### PR DESCRIPTION
gcc11 and 12 defaulting to c17 breaks compiling wget against older glibc versions with very helpful error messages such as:
```./string.h:1080:1: error: expected identifier or '(' before '__extension__'```. 

This is probably an issue with other older os versions beyond rhel/centos7, but I don't have any other hosts readily available to test against.