### PR TITLE
bugfix: do not compute `package_hash` for old concrete specs

### DIFF
--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1319,4 +1319,4 @@ def test_concretize_partial_old_dag_hash_spec(mock_packages, config):
     assert spec["dt-diamond-bottom"]._hash == dummy_hash
 
     # make sure package hash is NOT recomputed
-    assert not spec["dt-diamond-bottom"]._package_hash
+    assert not getattr(spec["dt-diamond-bottom"], '_package_hash', None)

--- a/lib/spack/spack/test/spec_semantics.py
+++ b/lib/spack/spack/test/spec_semantics.py
@@ -1293,3 +1293,30 @@ def test_call_dag_hash_on_old_dag_hash_spec(mock_packages, config):
 
         with pytest.raises(ValueError, match='Cannot call package_hash()'):
             spec.package_hash()
+
+
+@pytest.mark.regression('30861')
+def test_concretize_partial_old_dag_hash_spec(mock_packages, config):
+    # create an "old" spec with no package hash
+    bottom = Spec("dt-diamond-bottom").concretized()
+    delattr(bottom, "_package_hash")
+
+    dummy_hash = "zd4m26eis2wwbvtyfiliar27wkcv3ehk"
+    bottom._hash = dummy_hash
+
+    # add it to an abstract spec as a dependency
+    top = Spec("dt-diamond")
+    top.add_dependency_edge(bottom, ())
+
+    # concretize with the already-concrete dependency
+    top.concretize()
+
+    for spec in top.traverse():
+        assert spec.concrete
+
+    # make sure dag_hash is untouched
+    assert spec["dt-diamond-bottom"].dag_hash() == dummy_hash
+    assert spec["dt-diamond-bottom"]._hash == dummy_hash
+
+    # make sure package hash is NOT recomputed
+    assert not spec["dt-diamond-bottom"]._package_hash


### PR DESCRIPTION
Old concrete specs were slipping through in `_assign_hash`, and `package_hash` was attempting to recompute a package hash when we could not know the package a time of concretization.

Part of this was that the logic for `_assign_hash` was hard to understand -- it was called twice from `_finalize_concretization` and had special cases for both args it was called with. It's much easier to understand the logic here if we just inline it.

- [x] Get rid of `_assign_hash` and just integrate it with `_finalize_concretization`
- [x] Don't call `_package_hash` at all for already-concrete specs.
- [x] Add a regression test