### PR TITLE
Adding new package bricks for x86, cuda

### DIFF
--- a/var/spack/repos/builtin/packages/bricks/package.py
+++ b/var/spack/repos/builtin/packages/bricks/package.py
@@ -1,0 +1,79 @@
+from spack import *
+
+class Bricks(CMakePackage):
+
+    """Bricks is a data layout and code generation framework, enabling performance-portable stencil computations across a multitude of architectures."""
+
+    # url for your package's homepage here.
+    homepage = "https://bricks.run/"
+    git = 'https://github.com/CtopCsUtahEdu/bricklib.git'
+
+    test_requires_compiler = True
+
+    # List of GitHub accounts to notify when the package is updated.
+    maintainers = ['ztuowen', 'drhansj']
+
+    version('r0.1', branch='r0.1')
+
+    variant('cuda', default=False, description='Build bricks with CUDA enabled')
+
+    # Building a variant of cmake without openssl is to match how the
+    # ECP E4S project builds cmake in their e4s-base-cuda Docker image
+    depends_on('cmake', type='build')
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool', type='build')
+    depends_on('opencl-clhpp', when='+cuda')
+    depends_on('cuda', when='+cuda')
+    depends_on('mpi')
+
+    def cmake_args(self):
+        """CMake arguments for configure stage"""
+        args = []
+
+        return args
+
+    def flag_handler(self, name, flags):
+        """Set build flags as needed"""
+        if name in ['cflags', 'cxxflags', 'cppflags']:
+            # There are many vector instrinsics used in this package. If
+            # the package is built on a native architecture, then it likely
+            # will not run (illegal instruction fault) on a less feature-
+            # rich architecture.
+            # If you intend to use this package in an architecturally-
+            # heterogeneous environment, then the package should be build
+            # with "target=x86_64". This will ensure that all Intel
+            # architectures can use the libraries and tests in this
+            # project by forceing the AVX2 flag in gcc.
+            if name == 'cxxflags' and self.spec.target == 'x86_64':
+                flags.append('-mavx2')
+            return (None, flags, None)
+        return(flags, None, None)
+
+    @run_after('install')
+    def copy_test_sources(self):
+        """Files to copy into test cache"""
+        srcs = [ join_path('examples', 'external', 'CMakeLists.txt'),
+                 join_path('examples', 'external', 'main.cpp'),
+                 join_path('examples', 'external', '7pt.py') ]
+        self.cache_extra_test_sources(srcs)
+
+    def test(self):
+        """Test bricklib package"""
+        # Test prebuilt binary
+        source_dir = join_path(self.test_suite.current_test_cache_dir, 'examples', 'external')
+
+        self.run_test(exe='cmake',
+                      options=['.'],
+                      purpose='Configure bricklib example',
+                      work_dir=source_dir)
+
+        self.run_test(exe='cmake',
+                      options=['--build', '.'],
+                      purpose='Build bricklib example',
+                      work_dir=source_dir)
+
+        self.run_test(exe=join_path(source_dir, 'example'),
+                      options=[],
+                      purpose='Execute bricklib example',
+                      work_dir=source_dir)

--- a/var/spack/repos/builtin/packages/bricks/package.py
+++ b/var/spack/repos/builtin/packages/bricks/package.py
@@ -1,8 +1,11 @@
 from spack import *
 
+
 class Bricks(CMakePackage):
 
-    """Bricks is a data layout and code generation framework, enabling performance-portable stencil computations across a multitude of architectures."""
+    """Bricks is a data layout and code generation framework,
+       enabling performance-portable stencil computations across
+       a multitude of architectures."""
 
     # url for your package's homepage here.
     homepage = "https://bricks.run/"
@@ -53,15 +56,16 @@ class Bricks(CMakePackage):
     @run_after('install')
     def copy_test_sources(self):
         """Files to copy into test cache"""
-        srcs = [ join_path('examples', 'external', 'CMakeLists.txt'),
-                 join_path('examples', 'external', 'main.cpp'),
-                 join_path('examples', 'external', '7pt.py') ]
+        srcs = [join_path('examples', 'external', 'CMakeLists.txt'),
+                join_path('examples', 'external', 'main.cpp'),
+                join_path('examples', 'external', '7pt.py')]
         self.cache_extra_test_sources(srcs)
 
     def test(self):
         """Test bricklib package"""
         # Test prebuilt binary
-        source_dir = join_path(self.test_suite.current_test_cache_dir, 'examples', 'external')
+        source_dir = join_path(self.test_suite.current_test_cache_dir,
+                               'examples', 'external')
 
         self.run_test(exe='cmake',
                       options=['.'],

--- a/var/spack/repos/builtin/packages/bricks/package.py
+++ b/var/spack/repos/builtin/packages/bricks/package.py
@@ -1,3 +1,8 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 from spack import *
 
 


### PR DESCRIPTION
This is a new spack package for [Bricks.](https://github.com/CtopCsUtahEdu/bricklib)
to be included in spack / E4S. Being tested by @eugeneswalker for merge into E4S.

Bricks is a distributed performance-portable data layout and code generation framework,
to enable performance-portable stencil (and other kernels) across many architectures.
More information at https://bricks.run/

The Spack packaging system requires a `package.py` file in order to
build a package from source. This file:
- Identifies the source origin
- Specifies build and runtime dependencies
- Provides smoke test capabilities based on the project example code
- This Spack project file was originally developed for the ECP E4S project, 
but should be generic enough for any purpose.

The package has one variant: cuda. This will include extra files that
are needed for the CUDA variant of the bricks library