### PR TITLE
Remove the warning about derecated buildcache format

### DIFF
--- a/lib/spack/docs/binary_caches.rst
+++ b/lib/spack/docs/binary_caches.rst
@@ -50,6 +50,13 @@ build cache files for the "ninja" spec:
 Note that the targeted spec must already be installed. Once you have a build cache,
 you can add it as a mirror, discussed next.
 
+.. warning::
+
+   Spack improved the format used for binary caches in v0.18. The entire v0.18 series
+   will be able to verify and install binary caches both in the new and in the old format.
+   Support for using the old format is expected to end in v0.19, so we advise users to
+   recreate relevant buildcaches using Spack v0.18 or higher.
+
 ---------------------------------------
 Finding or installing build cache files
 ---------------------------------------

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -1592,9 +1592,6 @@ def extract_tarball(spec, download_result, allow_root=False, unsigned=False,
         # Handle the older buildcache layout where the .spack file
         # contains a spec json/yaml, maybe an .asc file (signature),
         # and another tarball containing the actual install tree.
-        tty.warn("This binary package uses a deprecated layout, "
-                 "and support for it will eventually be removed "
-                 "from spack.")
         tmpdir = tempfile.mkdtemp()
         try:
             tarfile_path = _extract_inner_tarball(


### PR DESCRIPTION
Modifications:
- [x] Remove a warning shown at each installed spec on the command line
- [x] Add instead a warning box in the documentation

Here's the warning box:
![Screenshot from 2022-05-26 15-15-25](https://user-images.githubusercontent.com/4199709/170495416-1f8a52da-9781-489a-afc8-e2bbf180e427.png)
