### PR TITLE
AMReX: Version updates for SUNDIALS and CUDA

### DIFF
--- a/var/spack/repos/builtin/packages/amrex/package.py
+++ b/var/spack/repos/builtin/packages/amrex/package.py
@@ -97,18 +97,24 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
     # Build dependencies
     depends_on('mpi', when='+mpi')
     depends_on('sundials@4.0.0:4.1.0 +ARKODE +CVODE', when='@19.08:20.11 +sundials')
-    depends_on('sundials@5.7.0: +ARKODE +CVODE', when='@21.07: +sundials')
+    depends_on('sundials@5.7.0: +ARKODE +CVODE', when='@21.07:22.04 +sundials')
+    depends_on('sundials@6.0.0: +ARKODE +CVODE', when='@22.05: +sundials')
     for arch in CudaPackage.cuda_arch_values:
-        depends_on('sundials@5.7.0: +ARKODE +CVODE +cuda cuda_arch=%s' % arch, when='@21.07: +sundials +cuda cuda_arch=%s' % arch)
+        depends_on('sundials@5.7.0: +ARKODE +CVODE +cuda cuda_arch=%s' % arch, when='@21.07:22.04 +sundials +cuda cuda_arch=%s' % arch)
+        depends_on('sundials@6.0.0: +ARKODE +CVODE +cuda cuda_arch=%s' % arch, when='@22.05: +sundials +cuda cuda_arch=%s' % arch)
     for tgt in ROCmPackage.amdgpu_targets:
-        depends_on('sundials@5.7.0: +ARKODE +CVODE +rocm amdgpu_target=%s' % tgt, when='@21.07: +sundials +rocm amdgpu_target=%s' % tgt)
-    depends_on('cuda@9.0.0:', when='+cuda')
+        depends_on('sundials@5.7.0: +ARKODE +CVODE +rocm amdgpu_target=%s' % tgt, when='@21.07:22.04 +sundials +rocm amdgpu_target=%s' % tgt)
+        depends_on('sundials@6.0.0: +ARKODE +CVODE +rocm amdgpu_target=%s' % tgt, when='@22.05: +sundials +rocm amdgpu_target=%s' % tgt)
+
+    depends_on('cuda@9.0.0:', when='@:22.04 +cuda')
+    depends_on('cuda@10.0.0:', when='@22.05: +cuda')
     depends_on('python@2.7:', type='build', when='@:20.04')
     depends_on('cmake@3.5:',  type='build', when='@:18.10')
-    depends_on('cmake@3.13:', type='build', when='@18.11:')
+    depends_on('cmake@3.13:', type='build', when='@18.11:19.03')
     depends_on('cmake@3.14:', type='build', when='@19.04:')
     # cmake @3.17: is necessary to handle cuda @11: correctly
     depends_on('cmake@3.17:', type='build', when='^cuda @11:')
+    depends_on('cmake@3.20:', type='build', when='+rocm')
     depends_on('hdf5@1.10.4: +mpi', when='+hdf5')
     depends_on('rocrand', type='build', when='+rocm')
     depends_on('rocprim', type='build', when='@21.05: +rocm')
@@ -187,8 +193,7 @@ class Amrex(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant('XSDK_ENABLE_Fortran', 'fortran'),
             self.define_from_variant('AMReX_FORTRAN_INTERFACES', 'fortran'),
             self.define_from_variant('AMReX_EB', 'eb'),
-            self.define_from_variant('AMReX_LINEAR_SOLVERS',
-                                     'linear_solvers'),
+            self.define_from_variant('AMReX_LINEAR_SOLVERS', 'linear_solvers'),
             self.define_from_variant('AMReX_AMRDATA', 'amrdata'),
             self.define_from_variant('AMReX_PARTICLES', 'particles'),
             self.define_from_variant('AMReX_PLOTFILE_TOOLS', 'plotfile_tools'),


### PR DESCRIPTION
For AMReX version 22.05 update version min requirements for SUNDIALS to 6.0 and CUDA to 10. 

See: 
https://github.com/AMReX-Codes/amrex/pull/2743
and
https://github.com/AMReX-Codes/amrex/pull/2736


