### PR TITLE
Fix external compiler detection for MPICH and OpenMPI

### DIFF
--- a/var/spack/repos/builtin/packages/mpich/package.py
+++ b/var/spack/repos/builtin/packages/mpich/package.py
@@ -267,13 +267,13 @@ with '-Wl,-commons,use_dylibs' and without
 
     @classmethod
     def determine_variants(cls, exes, version):
-        def get_spack_compiler_spec(path):
-            spack_compilers = spack.compilers.find_compilers([path])
+        def get_spack_compiler_spec(compiler):
+            spack_compilers = spack.compilers.find_compilers(
+                [os.path.dirname(compiler)])
             actual_compiler = None
             # check if the compiler actually matches the one we want
             for spack_compiler in spack_compilers:
-                if (spack_compiler.cc and
-                        os.path.dirname(spack_compiler.cc) == path):
+                if (spack_compiler.cc and spack_compiler.cc == compiler):
                     actual_compiler = spack_compiler
                     break
             return actual_compiler.spec if actual_compiler else None
@@ -356,10 +356,11 @@ with '-Wl,-commons,use_dylibs' and without
                 variants += '+hcoll'
 
             match = re.search(r'MPICH CC:\s+(\S+)', output)
-            compiler_spec = get_spack_compiler_spec(
-                os.path.dirname(match.group(1)))
-            if compiler_spec:
-                variants.append('%' + str(compiler_spec))
+            if match:
+                compiler = match.group(1)
+                compiler_spec = get_spack_compiler_spec(compiler)
+                if compiler_spec:
+                    variants.append('%' + str(compiler_spec))
             results.append(' '.join(variants))
         return results
 

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -520,8 +520,8 @@ class Openmpi(AutotoolsPackage, CudaPackage):
             # Get the appropriate compiler
             match = re.search(r'\bC compiler absolute: (\S+)', output)
             if match:
-                compiler_spec = get_spack_compiler_spec(
-                    os.path.dirname(match.group(1)))
+                compiler = match.group(1)
+                compiler_spec = get_spack_compiler_spec(compiler)
                 if compiler_spec:
                     variants.append("%" + str(compiler_spec))
             results.append(' '.join(variants))
@@ -1053,13 +1053,13 @@ class Openmpi(AutotoolsPackage, CudaPackage):
         self._test_examples()
 
 
-def get_spack_compiler_spec(path):
-    spack_compilers = spack.compilers.find_compilers([path])
+def get_spack_compiler_spec(compiler):
+    spack_compilers=spack.compilers.find_compilers(
+        [os.path.dirname(compiler)])
     actual_compiler = None
     # check if the compiler actually matches the one we want
     for spack_compiler in spack_compilers:
-        if (spack_compiler.cc and
-                os.path.dirname(spack_compiler.cc) == path):
+        if (spack_compiler.cc and spack_compiler.cc == compiler):
             actual_compiler = spack_compiler
             break
     return actual_compiler.spec if actual_compiler else None

--- a/var/spack/repos/builtin/packages/openmpi/package.py
+++ b/var/spack/repos/builtin/packages/openmpi/package.py
@@ -1054,7 +1054,7 @@ class Openmpi(AutotoolsPackage, CudaPackage):
 
 
 def get_spack_compiler_spec(compiler):
-    spack_compilers=spack.compilers.find_compilers(
+    spack_compilers = spack.compilers.find_compilers(
         [os.path.dirname(compiler)])
     actual_compiler = None
     # check if the compiler actually matches the one we want


### PR DESCRIPTION
os.path.dirname was being used to compare compilers. If two compilers are in the same directory then it will pick up the first one it encounters.

Compare the full compiler path instead.

I tested this and OpenMPI correctly had `%gcc` instead of `%clang`.