### PR TITLE
protobuf: fix spack versions

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -82,7 +82,7 @@ class Protobuf(Package):
 
     patch('protoc2.5.0_aarch64.patch', sha256='7b44fcdb794f421174d619f83584e00a36012a16da09079e2fad9c12f7337451', when='@2.5.0 target=aarch64:')
 
-    def fetch_remote_versions(self):
+    def fetch_remote_versions(self, *args, **kwargs):
         """Ignore additional source artifacts uploaded with releases,
            only keep known versions
            fix for https://github.com/spack/spack/issues/5356"""


### PR DESCRIPTION
### Before

```console
$ spack -d versions protobuf
==> [2022-05-26-12:10:24.187660] Imported versions from built-in commands
==> [2022-05-26-12:10:24.188173] Imported versions from built-in commands
==> [2022-05-26-12:10:24.188624] Reading config file /Users/ajstewart/spack/etc/spack/defaults/repos.yaml
==> [2022-05-26-12:10:24.246111] Safe versions (already checksummed):
  3.18.0  3.17.0  3.15.7  3.15.4  3.15.1  3.14.0  3.12.3  3.12.1  3.11.4  3.11.2  3.11.0  3.10.0  3.9.1  3.7.0  3.5.2    3.5.1    3.5.0  3.4.0  3.2.0  3.0.2
  3.17.3  3.16.0  3.15.5  3.15.2  3.15.0  3.13.0  3.12.2  3.12.0  3.11.3  3.11.1  3.10.1  3.9.2   3.7.1  3.6.1  3.5.1.1  3.5.0.1  3.4.1  3.3.0  3.1.0  2.5.0
==> [2022-05-26-12:10:24.247106] Reading config file /Users/ajstewart/spack/etc/spack/defaults/config.yaml
Traceback (most recent call last):
  File "/Users/ajstewart/spack/bin/spack", line 98, in <module>
    sys.exit(spack.main.main())
  File "/Users/ajstewart/spack/lib/spack/spack/main.py", line 893, in main
    return _main(argv)
  File "/Users/ajstewart/spack/lib/spack/spack/main.py", line 848, in _main
    return finish_parse_and_run(parser, cmd_name, env_format_error)
  File "/Users/ajstewart/spack/lib/spack/spack/main.py", line 876, in finish_parse_and_run
    return _invoke_command(command, parser, args, unknown)
  File "/Users/ajstewart/spack/lib/spack/spack/main.py", line 533, in _invoke_command
    return_val = command(parser, args)
  File "/Users/ajstewart/spack/lib/spack/spack/cmd/versions.py", line 64, in versions
    fetched_versions = pkg.fetch_remote_versions(args.concurrency)
TypeError: fetch_remote_versions() takes 1 positional argument but 2 were given
```

### After

```console
$ spack versions protobuf
==> Safe versions (already checksummed):
  3.18.0  3.17.0  3.15.7  3.15.4  3.15.1  3.14.0  3.12.3  3.12.1  3.11.4  3.11.2  3.11.0  3.10.0  3.9.1  3.7.0  3.5.2    3.5.1    3.5.0  3.4.0  3.2.0  3.0.2
  3.17.3  3.16.0  3.15.5  3.15.2  3.15.0  3.13.0  3.12.2  3.12.0  3.11.3  3.11.1  3.10.1  3.9.2   3.7.1  3.6.1  3.5.1.1  3.5.0.1  3.4.1  3.3.0  3.1.0  2.5.0
==> Remote versions (not yet checksummed):
  21.0-rc2  21.0-rc1  21.0  4.21.0-rc-1  4.21.0  3.21.0-rc-2  3.21.0-rc-1  3.21.0  3.20.1-rc1  3.20.1  3.20.0-rc2  3.20.0-rc1  3.20.0  3.19.4  3.19.3  3.4.21.0-rc-2  3.3.21.0-rc-2
```

This function was added 5 years ago in #5373, and I think its usage was broken 2 years ago in #16749. I'm amazed no one noticed that it was broken until now. Unfortunately this hack is still necessary. If I remove this function, `spack checksum` uses the wrong URLs, thereby giving the wrong sha256sums.

@ax3l @alalazo 