### PR TITLE
py-protobuf: pin dependents to @:3

### DIFF
--- a/var/spack/repos/builtin/packages/py-onnx/package.py
+++ b/var/spack/repos/builtin/packages/py-onnx/package.py
@@ -24,9 +24,17 @@ class PyOnnx(PythonPackage):
     version('1.5.0', sha256='1a584a4ef62a6db178c257fffb06a9d8e61b41c0a80bfd8bcd8a253d72c4b0b4')
 
     depends_on('py-setuptools', type='build')
-    # Protobuf version limit is due to https://github.com/protocolbuffers/protobuf/pull/8794
-    depends_on('protobuf@:3.17')
-    depends_on('py-protobuf+cpp@:3.17', type=('build', 'run'))
+    depends_on('protobuf')
+    depends_on('py-protobuf+cpp', type=('build', 'run'))
+    # Protobuf version limit is due to removal of SetTotalBytesLimit in
+    # https://github.com/protocolbuffers/protobuf/pull/8794, fixed in
+    # https://github.com/onnx/onnx/pull/3112
+    depends_on('protobuf@:3.17', when='@:1.8')
+    depends_on('py-protobuf@:3.17', when='@:1.8', type=('build', 'run'))
+    # https://github.com/protocolbuffers/protobuf/issues/10051
+    # https://github.com/onnx/onnx/issues/4222
+    depends_on('protobuf@:3')
+    depends_on('py-protobuf@:3', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-numpy@1.16.6:', type=('build', 'run'), when='@1.8.1:')
     depends_on('py-six', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-tensorboard/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorboard/package.py
@@ -43,6 +43,9 @@ class PyTensorboard(Package):
     depends_on('py-numpy@1.12.0:', type=('build', 'run'))
     depends_on('py-protobuf@3.6.0:', type=('build', 'run'))
     depends_on('py-protobuf@3.9.2:', type=('build', 'run'), when='@2.9:')
+    # https://github.com/protocolbuffers/protobuf/issues/10051
+    # https://github.com/PyTorchLightning/pytorch-lightning/issues/13159
+    depends_on('py-protobuf@:3', type=('build', 'run'))
     depends_on('py-requests@2.21.0:2', type=('build', 'run'))
     depends_on('py-setuptools@41.0.0:', type=('build', 'run'))
     depends_on('py-tensorboard-data-server@0.6', type=('build', 'run'), when='@2.5:')

--- a/var/spack/repos/builtin/packages/py-tensorflow/package.py
+++ b/var/spack/repos/builtin/packages/py-tensorflow/package.py
@@ -215,6 +215,10 @@ class PyTensorflow(Package, CudaPackage):
     depends_on('py-protobuf@3.0.0a3', type=('build', 'run'), when='@0.6:0.7.0')
     depends_on('protobuf@:3.12', when='@:2.4')
     depends_on('protobuf@:3.17')
+    # https://github.com/protocolbuffers/protobuf/issues/10051
+    # https://github.com/tensorflow/tensorflow/issues/56266
+    depends_on('py-protobuf@:3', when='@:2.7.2', type=('build', 'run'))
+    depends_on('protobuf@:3', when='@:2.7.2', type=('build', 'run'))
     depends_on('flatbuffers+python@1.12:2', type=('build', 'run'), when='@2.7:')
     depends_on('flatbuffers+python@1.12', type=('build', 'run'), when='@2.4:2.6')
 

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -117,6 +117,10 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('py-protobuf@:3.14', when='@:1.9', type=('build', 'run'))
     depends_on('protobuf@3.12.2:', when='@1.10:')
     depends_on('protobuf@:3.14', when='@:1.9')
+    # https://github.com/protocolbuffers/protobuf/issues/10051
+    # https://github.com/pytorch/pytorch/issues/78362
+    depends_on('py-protobuf@:3', type=('build', 'run'))
+    depends_on('protobuf@:3', type=('build', 'run'))
     depends_on('py-typing-extensions@3.6.2.1:', when='@1.7:', type=('build', 'run'))
     depends_on('blas')
     depends_on('lapack')


### PR DESCRIPTION
protobuf pushed out a new major version today, breaking almost every single library in existence that depends on it: https://github.com/protocolbuffers/protobuf/issues/10051

I only checked the packages I care about, but this may be needed for all packages. Would love it if someone could test some of the other packages:
```console
$ spack dependents py-protobuf
lbann           py-chainer                   py-grpcio-tools  py-mysql-connector-python  py-onnxconverter-common  py-ray          py-tensorboardx         py-tensorflow-hub
nanopb          py-google-api-core           py-keras2onnx    py-onnx                    py-or-tools              py-skl2onnx     py-tensorflow           py-tensorflow-metadata
py-apache-beam  py-googleapis-common-protos  py-labours       py-onnx-runtime            py-pytecplot             py-tensorboard  py-tensorflow-datasets  py-torch
$ spack dependents protobuf
brpc   cntk  hercules  libpulsar  mivisionx  nanopb  opencv    orc       protobuf-c  py-keras  py-onnx-runtime  py-protobuf    py-torch  rdc                        treelite
caffe  grpc  lbann     migraphx   mosh       onnx    or-tools  paraview  ps-lite     py-onnx   py-or-tools      py-tensorflow  qgis      tensorflow-serving-client
```