### PR TITLE
rclone: add 1.58

### DIFF
--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -15,6 +15,8 @@ class Rclone(Package):
 
     maintainers = ['alecbcs']
 
+    version('1.58.1', sha256='4d1d50a5b4888aa8eca10624073759ab8376c8b1acb38a238831d40074792524')
+    version('1.58.0', sha256='8e0c49fad69525d1219415d2f0651fd243ddf02291fd95e91d2b074d4858c31f')
     version('1.57.0', sha256='3a762c02c202a9142c2d5c1a3927563a556d1683abadd25d2f695e237e4ea693')
     version('1.56.2', sha256='a8813d25c4640e52495fee83e525e76283c63f01d1cce8fbb58d8486b0c20c8a')
     version('1.56.1', sha256='090b4b082caa554812f341ae26ea6758b40338836122595d6283c60c39eb5a97')
@@ -29,7 +31,7 @@ class Rclone(Package):
     version('1.49.4', sha256='070afc85e4e9921151d7cb67247db8f0ff2f06fcf2652c43a42fa6e1e35847af')
     version('1.43', sha256='d30527b00cecb4e5e7188dddb78e5cec62d67cf2422dab82190db58512b5a4e3')
 
-    depends_on("go", type='build')
+    depends_on('go@1.15:', type='build')
 
     def setup_build_environment(self, env):
         # Point GOPATH at the top of the staging dir for the build step.

--- a/var/spack/repos/builtin/packages/rclone/package.py
+++ b/var/spack/repos/builtin/packages/rclone/package.py
@@ -11,7 +11,7 @@ class Rclone(Package):
        to and from various cloud storage providers"""
 
     homepage = "https://rclone.org"
-    url      = "https://github.com/ncw/rclone/releases/download/v1.57.0/rclone-v1.57.0.tar.gz"
+    url      = "https://github.com/rclone/rclone/releases/download/v1.57.0/rclone-v1.57.0.tar.gz"
 
     maintainers = ['alecbcs']
 


### PR DESCRIPTION
Adding latest releases of rclone.

Also, the rclone docs recommend a Go version of at least 1.15, so I added that to the dependency.