### PR TITLE
Fix clingo source bootstrapping on M1 macs

### DIFF
--- a/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
+++ b/var/spack/repos/builtin/packages/clingo-bootstrap/package.py
@@ -2,6 +2,8 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import sys
+
 import spack.compilers
 from spack.pkg.builtin.clingo import Clingo
 
@@ -57,6 +59,14 @@ class ClingoBootstrap(Clingo):
             self.define('CLINGO_BUILD_APPS', 'OFF'),
         ])
         return args
+
+    @property
+    def cmake_python_hints(self):
+        """Use host python configuration variables for bootstrapping clingo"""
+        return [
+            self.define('Python_EXECUTABLE', sys.executable),
+            self.define('Python_ROOT_DIR', sys.prefix),
+        ]
 
     def setup_build_environment(self, env):
         opts = None


### PR DESCRIPTION
Follow-on to #30834.

This tweaks the CMake arguments for `clingo-bootstrap` so that CMake finds the host python's `sys.executable` and `sys.prefix`. We know when bootstrapping that we are building against the host python.

One question I am not completely sure about is why the logic in the `python` package doesn't get this right already. We should probaby make that work rather than doing this, but I'm putting this up as a demonstrator.

@adamjstewart thoughts on that last point?