### PR TITLE
pmix: add explicit hwloc dependency

### DIFF
--- a/var/spack/repos/builtin/packages/pmix/package.py
+++ b/var/spack/repos/builtin/packages/pmix/package.py
@@ -62,6 +62,7 @@ class Pmix(AutotoolsPackage):
 
     variant('restful',
             default=False,
+            when='@4:',
             description="allow a PMIx server to request services from "
             "a system-level REST server")
 
@@ -69,18 +70,18 @@ class Pmix(AutotoolsPackage):
             default=False,
             description='Build manpages')
 
-    depends_on('libevent@2.0.20:')
-    depends_on('hwloc@1.11:1,2:', when='@3:')
-    depends_on("m4", type=("build"), when="@master")
-    depends_on("autoconf", type=("build"), when="@master")
-    depends_on("automake", type=("build"), when="@master")
-    depends_on("libtool", type=("build"), when="@master")
-    depends_on("perl", type=("build"), when="@master")
-    depends_on('curl', when="+restful")
-    depends_on('jansson@2.11:', when="+restful")
+    depends_on("m4", type="build", when="@master")
+    depends_on("autoconf", type="build", when="@master")
+    depends_on("automake", type="build", when="@master")
+    depends_on("libtool", type="build", when="@master")
+    depends_on("perl", type="build", when="@master")
     depends_on('pandoc', type='build', when='+docs')
 
-    conflicts('@:3', when='+restful')
+    depends_on('libevent@2.0.20:')
+    depends_on('hwloc@1.0:1', when='@:2')
+    depends_on('hwloc@1.11:1,2:', when='@3:')
+    depends_on('curl', when="+restful")
+    depends_on('jansson@2.11:', when="+restful")
 
     def autoreconf(self, spec, prefix):
         """Only needed when building from git checkout"""
@@ -92,34 +93,27 @@ class Pmix(AutotoolsPackage):
         perl('./autogen.pl')
 
     def configure_args(self):
-
         spec = self.spec
+
         config_args = [
             '--enable-shared',
             '--enable-static'
         ]
 
-        if '+pmi_backwards_compatibility' in self.spec:
-            config_args.append('--enable-pmi-backward-compatibility')
-        else:
-            config_args.append('--disable-pmi-backward-compatibility')
+        config_args.append('--with-libevent=' + spec['libevent'].prefix)
+        config_args.append('--with-hwloc=' + spec['hwloc'].prefix)
+
+        config_args.extend(self.enable_or_disable(
+            'pmi-backward-compatibility', variant='pmi_backwards_compatibility'
+        ))
 
         if '~docs' in self.spec:
             config_args.append('--disable-man-pages')
 
-        # libevent support
-        config_args.append(
-            '--with-libevent={0}'.format(spec['libevent'].prefix))
-
         # Versions < 2.1.1 have a bug in the test code that *sometimes*
         # causes problems on strict alignment architectures such as
         # aarch64.  Work-around is to just not build the test code.
-        if (self.spec.satisfies('target=aarch64:') and
-                self.spec.version < Version('2.1.1')):
+        if spec.satisfies('@:2.1.0 target=aarch64:'):
             config_args.append('--without-tests-examples')
-
-        # Versions >= 3.0 also use hwloc
-        if self.spec.version >= Version('3.0.0'):
-            config_args.append('--with-hwloc={0}'.format(spec['hwloc'].prefix))
 
         return config_args


### PR DESCRIPTION
pmix@:2 uses hwloc if it's available (e.g. from homebrew). Explicitly enable it and use version @1 for pmix:@2.