### PR TITLE
Apply dev specs for dependencies of roots

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1534,7 +1534,7 @@ class SpackSolverSetup(object):
 
         # enumerate so we can determine which list it came from
         # cast to list to ensure addable types
-        for i, spec in enumerate(specs + dev_specs):
+        for i, spec in enumerate(tuple(specs) + tuple(dev_specs)):
             for dep in spec.traverse():
                 if not dep.versions.concrete:
                     continue

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1962,7 +1962,7 @@ class SpackSolverSetup(object):
                 'dev_path=%s' % info['path']
             )
             for name, info in env.dev_specs.items()
-        ) if env else (,)
+        ) if env else tuple()
 
         # get possible compilers
         self.possible_compilers = self.generate_possible_compilers(specs)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1534,7 +1534,7 @@ class SpackSolverSetup(object):
 
         # enumerate so we can determine which list it came from
         # cast to list to ensure addable types
-        for i, spec in enumerate(tuple(specs) + tuple(dev_specs)):
+        for i, spec in enumerate(specs + dev_specs):
             for dep in spec.traverse():
                 if not dep.versions.concrete:
                     continue
@@ -1963,6 +1963,7 @@ class SpackSolverSetup(object):
             )
             for name, info in env.dev_specs.items()
         ) if env else tuple()
+        specs = tuple(specs)  # ensure compatible types to add
 
         # get possible compilers
         self.possible_compilers = self.generate_possible_compilers(specs)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1534,7 +1534,7 @@ class SpackSolverSetup(object):
 
         # enumerate so we can determine which list it came from
         # cast to list to ensure addable types
-        for i, spec in enumerate(list(specs) + dev_specs):
+        for i, spec in enumerate(specs + dev_specs):
             for dep in spec.traverse():
                 if not dep.versions.concrete:
                     continue
@@ -1957,12 +1957,12 @@ class SpackSolverSetup(object):
         # they will be used in addition to command line specs
         # in determining known versions/targets/os
         env = ev.active_environment()
-        dev_specs = [
+        dev_specs = tuple(
             spack.spec.Spec(info['spec']).constrained(
                 'dev_path=%s' % info['path']
             )
             for name, info in env.dev_specs.items()
-        ] if env else []
+        ) if env else (,)
 
         # get possible compilers
         self.possible_compilers = self.generate_possible_compilers(specs)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1980,9 +1980,14 @@ class SpackSolverSetup(object):
         # Inject dev_path from environment
         env = ev.active_environment()
         if env:
-            for spec in sorted(specs):
-                for dep in spec.traverse():
-                    _develop_specs_from_env(dep, env)
+            for name, info in env.dev_specs.items():
+                dev_spec = spack.spec.Spec(info['spec'])
+                dev_spec.constrain(
+                    'dev_path=%s' % spack.util.path.canonicalize_path(info['path'])
+                )
+
+                self.condition(spack.spec.Spec(name), dev_spec,
+                               msg="%s is a develop spec" % name)
 
         self.gen.h1("Spec Constraints")
         self.literal_specs(specs)

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1533,7 +1533,8 @@ class SpackSolverSetup(object):
                 )
 
         # enumerate so we can determine which list it came from
-        for i, spec in enumerate(specs + dev_specs):
+        # cast to list to ensure addable types
+        for i, spec in enumerate(list(specs) + dev_specs):
             for dep in spec.traverse():
                 if not dep.versions.concrete:
                     continue

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1959,7 +1959,10 @@ class SpackSolverSetup(object):
         env = ev.active_environment()
         dev_specs = (
             tuple(
-                spack.spec.Spec(info["spec"]).constrained("dev_path=%s" % info["path"])
+                spack.spec.Spec(info["spec"]).constrained(
+                    "dev_path=%s"
+                    % spack.util.path.canonicalize_path(info["path"], default_wd=env.path)
+                )
                 for name, info in env.dev_specs.items()
             )
             if env
@@ -2331,8 +2334,7 @@ def _develop_specs_from_env(spec, env):
             "Internal Error: The dev_path for spec {name} is not connected to a valid environment"
             "path. Please note that develop specs can only be used inside an environment"
             "These paths should be the same:\n\tdev_path:{dev_path}\n\tenv_based_path:{env_path}"
-        )
-        error_msg.format(name=spec.name, dev_path=spec.variants["dev_path"], env_path=path)
+        ).format(name=spec.name, dev_path=spec.variants["dev_path"], env_path=path)
 
         assert spec.variants["dev_path"].value == path, error_msg
     else:

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -108,7 +108,7 @@ version_origin_fields = [
     "external",
     "packages_yaml",
     "package_py",
-    "installed"
+    "installed",
 ]
 
 #: Look up version precedence strings by enum id
@@ -1957,12 +1957,14 @@ class SpackSolverSetup(object):
         # they will be used in addition to command line specs
         # in determining known versions/targets/os
         env = ev.active_environment()
-        dev_specs = tuple(
-            spack.spec.Spec(info['spec']).constrained(
-                'dev_path=%s' % info['path']
+        dev_specs = (
+            tuple(
+                spack.spec.Spec(info["spec"]).constrained("dev_path=%s" % info["path"])
+                for name, info in env.dev_specs.items()
             )
-            for name, info in env.dev_specs.items()
-        ) if env else tuple()
+            if env
+            else tuple()
+        )
         specs = tuple(specs)  # ensure compatible types to add
 
         # get possible compilers
@@ -2006,9 +2008,7 @@ class SpackSolverSetup(object):
 
         # Inject dev_path from environment
         for ds in dev_specs:
-            self.condition(
-                spack.spec.Spec(ds.name), ds, msg="%s is a develop spec" % ds.name
-            )
+            self.condition(spack.spec.Spec(ds.name), ds, msg="%s is a develop spec" % ds.name)
 
         self.gen.h1("Spec Constraints")
         self.literal_specs(specs)


### PR DESCRIPTION
Fixes a bug on develop and 0.18.0.

Currently, develop specs that are not roots and are not explicitly listed dependencies of the roots are not applied.