### PR TITLE
CUDA: make cuda_arch sticky

### DIFF
--- a/lib/spack/spack/build_systems/cuda.py
+++ b/lib/spack/spack/build_systems/cuda.py
@@ -37,6 +37,7 @@ class CudaPackage(PackageBase):
     variant('cuda_arch',
             description='CUDA architecture',
             values=spack.variant.any_combination_of(*cuda_arch_values),
+            sticky=True,
             when='+cuda')
 
     # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#nvcc-examples


### PR DESCRIPTION
Not sure if this was one of the motivating factors for https://spack.readthedocs.io/en/latest/packaging_guide.html#sticky-variants or not, but clingo currently chooses a random `cuda_arch` value if you don't specify one which is probably a bad idea. This causes concretization to fail unless `cuda_arch` is explicitly specified. For packages like `py-torch` which add a conflict for `+cuda cuda_arch=none`, this prints a message like:
```console
$ spack spec py-torch+cuda
==> Error: Must specify CUDA compute capabilities of your GPU, see https://developer.nvidia.com/cuda-gpus
```