### PR TITLE
pass CC environment variable to make

### DIFF
--- a/var/spack/repos/builtin/packages/pigz/package.py
+++ b/var/spack/repos/builtin/packages/pigz/package.py
@@ -20,7 +20,7 @@ class Pigz(MakefilePackage):
     depends_on('zlib')
 
     def build(self, spec, prefix):
-        make()
+        make('CC=%s' % os.environ['CC'])
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/pigz/package.py
+++ b/var/spack/repos/builtin/packages/pigz/package.py
@@ -20,7 +20,9 @@ class Pigz(MakefilePackage):
     depends_on('zlib')
 
     def build(self, spec, prefix):
-        make('CC=%s' % os.environ['CC'])
+        # force makefile to use cc as C compiler which is set by
+        # spack
+        make('CC=cc')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
This patch passes the CC environment to the underlying make.  