### PR TITLE
Package: Don't warn for missing source on bundle packages without code

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1721,7 +1721,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 # referenced by branch name rather than tag or commit ID.
                 env = spack.environment.active_environment()
                 from_local_sources = env and env.is_develop(self.spec)
-                if not self.spec.external and not from_local_sources:
+                if self.has_code and not self.spec.external and not from_local_sources:
                     message = 'Missing a source id for {s.name}@{s.version}'
                     tty.warn(message.format(s=self))
                 hash_content.append(''.encode('utf-8'))

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -414,7 +414,25 @@ def test_nosource_pkg_install(
     pkg.do_install()
     out = capfd.readouterr()
     assert "Installing dependency-install" in out[0]
+
+    # Make sure a warning for missing code is issued
     assert "Missing a source id for nosource" in out[1]
+
+
+@pytest.mark.disable_clean_stage_check
+def test_nosource_bundle_pkg_install(
+        install_mockery, mock_fetch, mock_packages, capfd):
+    """Test install phases with the nosource-bundle package."""
+    spec = Spec('nosource-bundle').concretized()
+    pkg = spec.package
+
+    # Make sure install works even though there is no associated code.
+    pkg.do_install()
+    out = capfd.readouterr()
+    assert "Installing dependency-install" in out[0]
+
+    # Make sure a warning for missing code is *not* issued
+    assert "Missing a source id for nosource" not in out[1]
 
 
 def test_nosource_pkg_install_post_install(

--- a/var/spack/repos/builtin.mock/packages/nosource-bundle/package.py
+++ b/var/spack/repos/builtin.mock/packages/nosource-bundle/package.py
@@ -7,8 +7,8 @@
 from spack.package import *
 
 
-class Nosource(Package):
-    """Simple package with no source and one dependency"""
+class NosourceBundle(BundlePackage):
+    """Simple bundle package with one dependency"""
 
     homepage = "http://www.example.com"
 


### PR DESCRIPTION
BundlePacakge classes intentionally do not have code and as such shouldn't issue a warning.  This still ensures that a warning is issued with no source present in non-bundle packages.