### PR TITLE
Adding a libunwind variant to libzmq

### DIFF
--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -43,7 +43,7 @@ class Libzmq(AutotoolsPackage):
             description="Use strlcpy from libbsd " +
                         "(will use own implementation if false)")
 
-    variant("libunwind", default=False, 
+    variant("libunwind", default=False,
             description="Build with libunwind support")
 
     depends_on("libsodium", when='+libsodium')

--- a/var/spack/repos/builtin/packages/libzmq/package.py
+++ b/var/spack/repos/builtin/packages/libzmq/package.py
@@ -43,6 +43,9 @@ class Libzmq(AutotoolsPackage):
             description="Use strlcpy from libbsd " +
                         "(will use own implementation if false)")
 
+    variant("libunwind", default=False, 
+            description="Build with libunwind support")
+
     depends_on("libsodium", when='+libsodium')
     depends_on("libsodium@:1.0.3", when='+libsodium@:4.1.2')
 
@@ -54,6 +57,8 @@ class Libzmq(AutotoolsPackage):
     depends_on('docbook-xsl', type='build', when='+docs')
 
     depends_on('libbsd', when='+libbsd')
+
+    depends_on('libunwind', when='+libunwind')
 
     conflicts('%gcc@8:', when='@:4.2.2')
 
@@ -77,6 +82,7 @@ class Libzmq(AutotoolsPackage):
 
         config_args.extend(self.enable_or_disable("drafts"))
         config_args.extend(self.enable_or_disable("libbsd"))
+        config_args.extend(self.enable_or_disable("libunwind"))
 
         if '+libsodium' in self.spec:
             config_args.append('--with-libsodium')


### PR DESCRIPTION
Added a variant due to "Add new autoconf --disable-libunwind option to stop building with libunwind
even if it is available." (see https://github.com/zeromq/libzmq/releases/tag/v4.2.3). libzmq, by default, automatically uses libunwind if it finds it, but Spack does not know it so it doesn't add libunwind to the RPATH of libzmq so the build is inconsistent.