### PR TITLE
nfft, pnfft: fix detection of fftw variants (precision)

### DIFF
--- a/var/spack/repos/builtin/packages/nfft/package.py
+++ b/var/spack/repos/builtin/packages/nfft/package.py
@@ -19,51 +19,58 @@ class Nfft(AutotoolsPackage):
 
     depends_on('fftw')
 
+    _fftw_precisions = None
+
+    @property
+    def fftw_selected_precisions(self):
+        if not self._fftw_precisions:
+            self._fftw_precisions = self.spec['fftw'].package.selected_precisions
+        return self._fftw_precisions
+
     def configure(self, spec, prefix):
         options = ['--prefix={0}'.format(prefix)]
 
         configure = Executable('../configure')
 
-        if 'double' in spec['fftw'].variants.get('precision'):
+        if 'double' in self.fftw_selected_precisions:
             with working_dir('double', create=True):
                 configure(*options)
-        if 'float' in spec['fftw'].variants.get('precision'):
+        if 'float' in self.fftw_selected_precisions:
             with working_dir('float', create=True):
                 configure('--enable-float', *options)
-        if 'long_double' in spec['fftw'].variants.get('precision'):
+        if 'long_double' in self.fftw_selected_precisions:
             with working_dir('long-double', create=True):
                 configure('--enable-long-double', *options)
 
     def build(self, spec, prefix):
-        if 'double' in spec['fftw'].variants.get('precision'):
+        if 'double' in self.fftw_selected_precisions:
             with working_dir('double'):
                 make()
-        if 'float' in spec['fftw'].variants.get('precision'):
+        if 'float' in self.fftw_selected_precisions:
             with working_dir('float'):
                 make()
-        if 'long_double' in spec['fftw'].variants.get('precision'):
+        if 'long_double' in self.fftw_selected_precisions:
             with working_dir('long-double'):
                 make()
 
     def check(self):
-        spec = self.spec
-        if 'double' in spec['fftw'].variants.get('precision'):
+        if 'double' in self.fftw_selected_precisions:
             with working_dir('double'):
                 make("check")
-        if 'float' in spec['fftw'].variants.get('precision'):
+        if 'float' in self.fftw_selected_precisions:
             with working_dir('float'):
                 make("check")
-        if 'long_double' in spec['fftw'].variants.get('precision'):
+        if 'long_double' in self.fftw_selected_precisions:
             with working_dir('long-double'):
                 make("check")
 
     def install(self, spec, prefix):
-        if 'double' in spec['fftw'].variants.get('precision'):
+        if 'double' in self.fftw_selected_precisions:
             with working_dir('double'):
                 make("install")
-        if 'float' in spec['fftw'].variants.get('precision'):
+        if 'float' in self.fftw_selected_precisions:
             with working_dir('float'):
                 make("install")
-        if 'long_double' in spec['fftw'].variants.get('precision'):
+        if 'long_double' in self.fftw_selected_precisions:
             with working_dir('long-double'):
                 make("install")

--- a/var/spack/repos/builtin/packages/nfft/package.py
+++ b/var/spack/repos/builtin/packages/nfft/package.py
@@ -24,46 +24,46 @@ class Nfft(AutotoolsPackage):
 
         configure = Executable('../configure')
 
-        if '+double' in spec['fftw']:
+        if 'double' in spec['fftw'].variants.get('precision'):
             with working_dir('double', create=True):
                 configure(*options)
-        if '+float' in spec['fftw']:
+        if 'float' in spec['fftw'].variants.get('precision'):
             with working_dir('float', create=True):
                 configure('--enable-float', *options)
-        if '+long_double' in spec['fftw']:
+        if 'long_double' in spec['fftw'].variants.get('precision'):
             with working_dir('long-double', create=True):
                 configure('--enable-long-double', *options)
 
     def build(self, spec, prefix):
-        if '+double' in spec['fftw']:
+        if 'double' in spec['fftw'].variants.get('precision'):
             with working_dir('double'):
                 make()
-        if '+float' in spec['fftw']:
+        if 'float' in spec['fftw'].variants.get('precision'):
             with working_dir('float'):
                 make()
-        if '+long_double' in spec['fftw']:
+        if 'long_double' in spec['fftw'].variants.get('precision'):
             with working_dir('long-double'):
                 make()
 
     def check(self):
         spec = self.spec
-        if '+double' in spec['fftw']:
+        if 'double' in spec['fftw'].variants.get('precision'):
             with working_dir('double'):
                 make("check")
-        if '+float' in spec['fftw']:
+        if 'float' in spec['fftw'].variants.get('precision'):
             with working_dir('float'):
                 make("check")
-        if '+long_double' in spec['fftw']:
+        if 'long_double' in spec['fftw'].variants.get('precision'):
             with working_dir('long-double'):
                 make("check")
 
     def install(self, spec, prefix):
-        if '+double' in spec['fftw']:
+        if 'double' in spec['fftw'].variants.get('precision'):
             with working_dir('double'):
                 make("install")
-        if '+float' in spec['fftw']:
+        if 'float' in spec['fftw'].variants.get('precision'):
             with working_dir('float'):
                 make("install")
-        if '+long_double' in spec['fftw']:
+        if 'long_double' in spec['fftw'].variants.get('precision'):
             with working_dir('long-double'):
                 make("install")

--- a/var/spack/repos/builtin/packages/pnfft/package.py
+++ b/var/spack/repos/builtin/packages/pnfft/package.py
@@ -25,46 +25,46 @@ class Pnfft(AutotoolsPackage):
 
         configure = Executable('../configure')
 
-        if '+double' in spec['fftw']:
+        if 'double' in spec['fftw'].variants.get('precision'):
             with working_dir('double', create=True):
                 configure(*options)
-        if '+float' in spec['fftw']:
+        if 'float' in spec['fftw'].variants.get('precision'):
             with working_dir('float', create=True):
                 configure('--enable-float', *options)
-        if '+long_double' in spec['fftw']:
+        if 'long_double' in spec['fftw'].variants.get('precision'):
             with working_dir('long-double', create=True):
                 configure('--enable-long-double', *options)
 
     def build(self, spec, prefix):
-        if '+double' in spec['fftw']:
+        if 'double' in spec['fftw'].variants.get('precision'):
             with working_dir('double'):
                 make()
-        if '+float' in spec['fftw']:
+        if 'float' in spec['fftw'].variants.get('precision'):
             with working_dir('float'):
                 make()
-        if '+long_double' in spec['fftw']:
+        if 'long_double' in spec['fftw'].variants.get('precision'):
             with working_dir('long-double'):
                 make()
 
     def check(self):
         spec = self.spec
-        if '+double' in spec['fftw']:
+        if 'double' in spec['fftw'].variants.get('precision'):
             with working_dir('double'):
                 make("check")
-        if '+float' in spec['fftw']:
+        if 'float' in spec['fftw'].variants.get('precision'):
             with working_dir('float'):
                 make("check")
-        if '+long_double' in spec['fftw']:
+        if 'long_double' in spec['fftw'].variants.get('precision'):
             with working_dir('long-double'):
                 make("check")
 
     def install(self, spec, prefix):
-        if '+double' in spec['fftw']:
+        if 'double' in spec['fftw'].variants.get('precision'):
             with working_dir('double'):
                 make("install")
-        if '+float' in spec['fftw']:
+        if 'float' in spec['fftw'].variants.get('precision'):
             with working_dir('float'):
                 make("install")
-        if '+long_double' in spec['fftw']:
+        if 'long_double' in spec['fftw'].variants.get('precision'):
             with working_dir('long-double'):
                 make("install")

--- a/var/spack/repos/builtin/packages/pnfft/package.py
+++ b/var/spack/repos/builtin/packages/pnfft/package.py
@@ -18,6 +18,14 @@ class Pnfft(AutotoolsPackage):
     depends_on('pfft')
     depends_on('gsl')
 
+    _fftw_precisions = None
+
+    @property
+    def fftw_selected_precisions(self):
+        if not self._fftw_precisions:
+            self._fftw_precisions = self.spec['fftw'].package.selected_precisions
+        return self._fftw_precisions
+
     def configure(self, spec, prefix):
         options = ['--prefix={0}'.format(prefix)]
         if not self.compiler.f77 or not self.compiler.fc:
@@ -25,46 +33,45 @@ class Pnfft(AutotoolsPackage):
 
         configure = Executable('../configure')
 
-        if 'double' in spec['fftw'].variants.get('precision'):
+        if 'double' in self.fftw_selected_precisions:
             with working_dir('double', create=True):
                 configure(*options)
-        if 'float' in spec['fftw'].variants.get('precision'):
+        if 'float' in self.fftw_selected_precisions:
             with working_dir('float', create=True):
                 configure('--enable-float', *options)
-        if 'long_double' in spec['fftw'].variants.get('precision'):
+        if 'long_double' in self.fftw_selected_precisions:
             with working_dir('long-double', create=True):
                 configure('--enable-long-double', *options)
 
     def build(self, spec, prefix):
-        if 'double' in spec['fftw'].variants.get('precision'):
+        if 'double' in self.fftw_selected_precisions:
             with working_dir('double'):
                 make()
-        if 'float' in spec['fftw'].variants.get('precision'):
+        if 'float' in self.fftw_selected_precisions:
             with working_dir('float'):
                 make()
-        if 'long_double' in spec['fftw'].variants.get('precision'):
+        if 'long_double' in self.fftw_selected_precisions:
             with working_dir('long-double'):
                 make()
 
     def check(self):
-        spec = self.spec
-        if 'double' in spec['fftw'].variants.get('precision'):
+        if 'double' in self.fftw_selected_precisions:
             with working_dir('double'):
                 make("check")
-        if 'float' in spec['fftw'].variants.get('precision'):
+        if 'float' in self.fftw_selected_precisions:
             with working_dir('float'):
                 make("check")
-        if 'long_double' in spec['fftw'].variants.get('precision'):
+        if 'long_double' in self.fftw_selected_precisions:
             with working_dir('long-double'):
                 make("check")
 
     def install(self, spec, prefix):
-        if 'double' in spec['fftw'].variants.get('precision'):
+        if 'double' in self.fftw_selected_precisions:
             with working_dir('double'):
                 make("install")
-        if 'float' in spec['fftw'].variants.get('precision'):
+        if 'float' in self.fftw_selected_precisions:
             with working_dir('float'):
                 make("install")
-        if 'long_double' in spec['fftw'].variants.get('precision'):
+        if 'long_double' in self.fftw_selected_precisions:
             with working_dir('long-double'):
                 make("install")


### PR DESCRIPTION
Apparently the Python api for spack changed at some point in the past, rendering the packages `nfft` and `pnfft` useless: the resulting binary folders are empty. No `fftw` variants regarding precision are detected, so nothing is compiled.