### PR TITLE
xyce: remove python packages as +pymi dependencies and hdf5 from trilinos

### DIFF
--- a/var/spack/repos/builtin/packages/xyce/package.py
+++ b/var/spack/repos/builtin/packages/xyce/package.py
@@ -52,12 +52,10 @@ class Xyce(CMakePackage):
 
     variant('pymi', default=False, description='Enable Python Model Interpreter for Xyce')
     depends_on('python@3:', type=('build', 'link', 'run'), when='+pymi')
-    depends_on('py-numba@0.48.0:', type=('build', 'link', 'run'), when='+pymi')
-    depends_on('py-pycompadre+trilinos', type=('build', 'link', 'run'), when='+pymi')
     depends_on('py-pip', type='run', when='+pymi')
     depends_on('py-pybind11@2.6.1:', type=('build', 'link'), when='+pymi')
 
-    depends_on('trilinos +amesos+amesos2+anasazi+aztec+basker+belos+complex+epetra+epetraext+explicit_template_instantiation+fortran+hdf5+ifpack+isorropia+kokkos+nox+sacado+suite-sparse+trilinoscouplings+zoltan+stokhos+epetraextbtf+epetraextexperimental+epetraextgraphreorderings')
+    depends_on('trilinos +amesos+amesos2+anasazi+aztec+basker+belos+complex+epetra+epetraext+explicit_template_instantiation+fortran+ifpack+isorropia+kokkos+nox+sacado+suite-sparse+trilinoscouplings+zoltan+stokhos+epetraextbtf+epetraextexperimental+epetraextgraphreorderings')
     # tested versions of Trilinos for everything up to 7.4.0
     depends_on('trilinos@12.12.1:13.2.0', when='@:7.4.0')
     depends_on('trilinos gotype=all cxxstd=11', when='^trilinos@:12.15')


### PR DESCRIPTION
`+hdf5` is not needed in Xyce's Trilinos spec. py-compadre and py-numba can be installed separately and should not be included with the `+pymi` variant.