### PR TITLE
Amrvis: Add configuration file and default color palette

### DIFF
--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -14,11 +14,9 @@ class Amrvis(MakefilePackage):
     """
 
     homepage = "https://github.com/AMReX-Codes/Amrvis"
-    git      = "https://github.com/etpalmer63/Amrvis.git"
-    #git      = "https://github.com/AMReX-Codes/Amrvis.git"
+    git      = "https://github.com/AMReX-Codes/Amrvis.git"
 
-    version('main', tag='for_spack')
-    #version('main', tag='main')
+    version('main', tag='main')
 
     variant(
         'dims',
@@ -160,13 +158,12 @@ class Amrvis(MakefilePackage):
             '# Spack removed INCLUDE_LOCATIONS and LIBRARY_LOCATIONS'
         )
 
-
         # Rewrite configuration file with location of
         # the color palette after install
         configfile = FileFilter("amrvis.defaults")
         configfile.filter(
-                r'^palette\s*Palette\s*',
-                'palette {0}/etc/Palette\n'.format(prefix)
+            r'^palette\s*Palette\s*',
+            'palette {0}/etc/Palette\n'.format(prefix)
         )
 
         # Read GNUmakefile into array
@@ -209,7 +206,6 @@ class Amrvis(MakefilePackage):
         # file, amrvis.defaults.
         env.set('CONFIG_FILEPATH', self.spec.prefix.etc)
 
-
     def install(self, spec, prefix):
         # Install exe manually
         mkdirp(prefix.bin)
@@ -218,5 +214,3 @@ class Amrvis(MakefilePackage):
         mkdirp(prefix.etc)
         install('amrvis.defaults', prefix.etc)
         install('Palette', prefix.etc)
-
-

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -16,6 +16,8 @@ class Amrvis(MakefilePackage):
     homepage = "https://github.com/AMReX-Codes/Amrvis"
     git      = "https://github.com/AMReX-Codes/Amrvis.git"
 
+    maintainers = ['etpalmer63']
+
     version('main', tag='main')
 
     variant(

--- a/var/spack/repos/builtin/packages/amrvis/package.py
+++ b/var/spack/repos/builtin/packages/amrvis/package.py
@@ -14,9 +14,11 @@ class Amrvis(MakefilePackage):
     """
 
     homepage = "https://github.com/AMReX-Codes/Amrvis"
-    git      = "https://github.com/AMReX-Codes/Amrvis.git"
+    git      = "https://github.com/etpalmer63/Amrvis.git"
+    #git      = "https://github.com/AMReX-Codes/Amrvis.git"
 
-    version('main', tag='main')
+    version('main', tag='for_spack')
+    #version('main', tag='main')
 
     variant(
         'dims',
@@ -158,6 +160,15 @@ class Amrvis(MakefilePackage):
             '# Spack removed INCLUDE_LOCATIONS and LIBRARY_LOCATIONS'
         )
 
+
+        # Rewrite configuration file with location of
+        # the color palette after install
+        configfile = FileFilter("amrvis.defaults")
+        configfile.filter(
+                r'^palette\s*Palette\s*',
+                'palette {0}/etc/Palette\n'.format(prefix)
+        )
+
         # Read GNUmakefile into array
         with open('GNUmakefile', 'r') as file:
             contents = file.readlines()
@@ -194,8 +205,18 @@ class Amrvis(MakefilePackage):
             env.set('CXX', self.spec['mpi'].mpicxx)
             env.set('F77', self.spec['mpi'].mpif77)
             env.set('FC', self.spec['mpi'].mpifc)
+        # Set CONFIG_FILEPATH so Amrvis can find the configuration
+        # file, amrvis.defaults.
+        env.set('CONFIG_FILEPATH', self.spec.prefix.etc)
+
 
     def install(self, spec, prefix):
         # Install exe manually
         mkdirp(prefix.bin)
         install('*.ex', prefix.bin)
+        # Install configuration file and default color Palette
+        mkdirp(prefix.etc)
+        install('amrvis.defaults', prefix.etc)
+        install('Palette', prefix.etc)
+
+


### PR DESCRIPTION
This change installs a configuration file `amrvis.defaults` and color palette `Palette` to an `etc` folder where they can be accessed by Amrvis. 