### PR TITLE
Use stable URLs for patch-diff GitHub patches

### DIFF
--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -298,7 +298,7 @@ def _check_build_test_callbacks(pkgs, error_cls):
 def _check_patch_urls(pkgs, error_cls):
     """Ensure that patches fetched from GitHub have stable sha256 hashes."""
     github_patch_url_re = (
-        r"^https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)"
+        r"^https?://(?:patch-diff\.)?github(?:usercontent)?\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)"
     )
 
     errors = []

--- a/lib/spack/spack/audit.py
+++ b/lib/spack/spack/audit.py
@@ -298,7 +298,8 @@ def _check_build_test_callbacks(pkgs, error_cls):
 def _check_patch_urls(pkgs, error_cls):
     """Ensure that patches fetched from GitHub have stable sha256 hashes."""
     github_patch_url_re = (
-        r"^https?://(?:patch-diff\.)?github(?:usercontent)?\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)"
+        r"^https?://(?:patch-diff\.)?github(?:usercontent)?\.com/"
+        ".+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)"
     )
 
     errors = []

--- a/var/spack/repos/builtin/packages/assimp/package.py
+++ b/var/spack/repos/builtin/packages/assimp/package.py
@@ -26,8 +26,8 @@ class Assimp(CMakePackage):
     version('5.0.1', sha256='11310ec1f2ad2cd46b95ba88faca8f7aaa1efe9aa12605c55e3de2b977b3dbfc')
     version('4.0.1', sha256='60080d8ab4daaab309f65b3cffd99f19eb1af8d05623fff469b9b652818e286e')
 
-    patch('https://patch-diff.githubusercontent.com/raw/assimp/assimp/pull/4203.patch',
-          sha256='a227714a215023184536e38b4bc7f8341f635e16bfb3b0ea029d420c29aacd2d',
+    patch('https://patch-diff.githubusercontent.com/raw/assimp/assimp/pull/4203.patch?full_index=1',
+          sha256='24135e88bcef205e118f7a3f99948851c78d3f3e16684104dc603439dd790d74',
           when='@5.1:5.2.2')
 
     variant('shared',  default=True,

--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -391,8 +391,8 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
     patch('fix_clang_errors_12_18_1.patch', when='@12.18.1%clang')
     patch('cray_secas_12_12_1.patch', when='@12.12.1%cce')
     patch('cray_secas.patch', when='@12.14.1:12%cce')
-    patch('https://patch-diff.githubusercontent.com/raw/trilinos/Trilinos/pull/10545.patch',
-          sha256='7f446d8bdcdc7ec29e1caeb0faf8d9fd85bd470fc52d3a955c144ab14bb16b90',
+    patch('https://patch-diff.githubusercontent.com/raw/trilinos/Trilinos/pull/10545.patch?full_index=1',
+          sha256='62272054f7cc644583c269e692c69f0a26af19e5a5bd262db3ea3de3447b3358',
           when='@:13.2.0 +complex')
 
     # workaround an NVCC bug with c++14 (https://github.com/trilinos/Trilinos/issues/6954)


### PR DESCRIPTION
@tgamblin we missed a couple in #29239.