### PR TITLE
Make ldflags pass flags to the compiler only

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -709,12 +709,10 @@ case "$mode" in
         ;;
 esac
 
-# Linker flags
-case "$mode" in
-    ld|ccld)
-        extend flags_list SPACK_LDFLAGS
-        ;;
-esac
+# Compiler flags used during linking
+if [ "$mode" == ccld ]; then
+    extend flags_list SPACK_LDFLAGS
+fi
 
 # On macOS insert headerpad_max_install_names linker flag
 if [ "$mode" = ld ] || [ "$mode" = ccld ]; then


### PR DESCRIPTION
Spack passes `ldflags` both in ccld and ld mode, which doesn't make
sense because linker flags aren't compiler flags, except maybe for -L
and -l.

Instead, always make ldflags mean compiler flags used in compiler link
mode, like in most makefiles.

So, `ldflags: -Wl,-z,linker_feature` is the way to pass linker flags,
not `ldflags: -z linker_feature`.
