### PR TITLE
json-glib depends on gobject-introspection

### DIFF
--- a/var/spack/repos/builtin/packages/json-glib/package.py
+++ b/var/spack/repos/builtin/packages/json-glib/package.py
@@ -22,6 +22,7 @@ class JsonGlib(MesonPackage):
     version('1.2.8', sha256='fd55a9037d39e7a10f0db64309f5f0265fa32ec962bf85066087b83a2807f40a', deprecated=True)
 
     depends_on('glib')
+    depends_on('gobject-introspection')
 
     @when('@:1.5')
     def meson(self, spec, prefix):


### PR DESCRIPTION
json-glib requires gobject-introspection. The build was running /usr/bin/g-ir-scanner and getting an import site error since that executable is a python script running a different python than the spack build environment.