### PR TITLE
use GC64 on darwin in luajit

### DIFF
--- a/var/spack/repos/builtin/packages/lua-luajit-openresty/package.py
+++ b/var/spack/repos/builtin/packages/lua-luajit-openresty/package.py
@@ -43,6 +43,12 @@ class LuaLuajitOpenresty(LuaImplPackage):
         src_makefile.filter(
             '^DYNAMIC_CC = .*',
             'DYNAMIC_CC = $(CC) {0}'.format(self.compiler.cc_pic_flag))
+        # Catalina and higher produce a non-functional luajit unless this is set
+        if spec.satisfies("platform=darwin"):
+            src_makefile.filter(
+                '^.XCFLAGS.= -DLUAJIT_ENABLE_GC64',
+                'XCFLAGS+= -DLUAJIT_ENABLE_GC64',
+            )
         # Linking with the C++ compiler is a dirty hack to deal with the fact
         # that unwinding symbols are not included by libc, this is necessary
         # on some platforms for the final link stage to work

--- a/var/spack/repos/builtin/packages/lua-luajit/package.py
+++ b/var/spack/repos/builtin/packages/lua-luajit/package.py
@@ -26,6 +26,7 @@ class LuaLuajit(LuaImplPackage):
     conflicts("lua", when="+lualinks")
     provides("luajit")
     lua_version_override = "5.1"
+    conflicts('platform=darwin', msg='luajit not supported on MacOS, see lua-luajit-openresty')
 
     @run_after("install")
     def install_links(self):
@@ -47,12 +48,7 @@ class LuaLuajit(LuaImplPackage):
         src_makefile.filter(
             '^DYNAMIC_CC = .*',
             'DYNAMIC_CC = $(CC) {0}'.format(self.compiler.cc_pic_flag))
-        # Catalina and higher produce a non-functional luajit unless this is set
-        if spec.satisfies("platform=darwin"):
-            src_makefile.filter(
-                '^.XCFLAGS.= -DLUAJIT_ENABLE_GC64',
-                'XCFLAGS+= -DLUAJIT_ENABLE_GC64',
-            )
+
         # Linking with the C++ compiler is a dirty hack to deal with the fact
         # that unwinding symbols are not included by libc, this is necessary
         # on some platforms for the final link stage to work

--- a/var/spack/repos/builtin/packages/lua-luajit/package.py
+++ b/var/spack/repos/builtin/packages/lua-luajit/package.py
@@ -47,6 +47,12 @@ class LuaLuajit(LuaImplPackage):
         src_makefile.filter(
             '^DYNAMIC_CC = .*',
             'DYNAMIC_CC = $(CC) {0}'.format(self.compiler.cc_pic_flag))
+        # Catalina and higher produce a non-functional luajit unless this is set
+        if spec.satisfies("platform=darwin"):
+            src_makefile.filter(
+                '^.XCFLAGS.= -DLUAJIT_ENABLE_GC64',
+                'XCFLAGS+= -DLUAJIT_ENABLE_GC64',
+            )
         # Linking with the C++ compiler is a dirty hack to deal with the fact
         # that unwinding symbols are not included by libc, this is necessary
         # on some platforms for the final link stage to work


### PR DESCRIPTION
This should address the issues with initializing luajit on Mac since Catalina.  Mainly appears with neovim.

fixes #30952 