### PR TITLE
protobuf: patch build error when @3.20 %gcc@12.1.0

### DIFF
--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -89,8 +89,8 @@ class Protobuf(Package):
     patch('protoc2.5.0_aarch64.patch', sha256='7b44fcdb794f421174d619f83584e00a36012a16da09079e2fad9c12f7337451', when='@2.5.0 target=aarch64:')
 
     # See https://github.com/protocolbuffers/protobuf/issues/9916
-    patch('https://patch-diff.githubusercontent.com/raw/protocolbuffers/protobuf/pull/9936.diff', when='@3.20 %gcc@12.1.0',
-          sha256='00ed93ac8180916c0dff77afadf83e01c59a893e719aa657207fbe2a602cde8b')
+    patch('https://github.com/protocolbuffers/protobuf/pull/9936.patch?full_index=1', when='@3.20 %gcc@12.1.0',
+          sha256='fa1abf042eddc1b3b43875dc018c651c90cd1c0c5299975a818a1610bee54ab8')
 
     def fetch_remote_versions(self, *args, **kwargs):
         """Ignore additional source artifacts uploaded with releases,

--- a/var/spack/repos/builtin/packages/protobuf/package.py
+++ b/var/spack/repos/builtin/packages/protobuf/package.py
@@ -88,6 +88,10 @@ class Protobuf(Package):
 
     patch('protoc2.5.0_aarch64.patch', sha256='7b44fcdb794f421174d619f83584e00a36012a16da09079e2fad9c12f7337451', when='@2.5.0 target=aarch64:')
 
+    # See https://github.com/protocolbuffers/protobuf/issues/9916
+    patch('https://patch-diff.githubusercontent.com/raw/protocolbuffers/protobuf/pull/9936.diff', when='@3.20 %gcc@12.1.0',
+          sha256='00ed93ac8180916c0dff77afadf83e01c59a893e719aa657207fbe2a602cde8b')
+
     def fetch_remote_versions(self, *args, **kwargs):
         """Ignore additional source artifacts uploaded with releases,
            only keep known versions


### PR DESCRIPTION
`protobuf@3.20 %gcc@12.1.0` fails to build due to https://github.com/protocolbuffers/protobuf/issues/9916.
This PR patches it with https://github.com/protocolbuffers/protobuf/pull/9936.