### PR TITLE
Fix missing '*.spack*' files in views

### DIFF
--- a/lib/spack/spack/directory_layout.py
+++ b/lib/spack/spack/directory_layout.py
@@ -102,7 +102,7 @@ class DirectoryLayout(object):
 
     @property
     def hidden_file_regexes(self):
-        return (re.escape(self.metadata_dir),)
+        return ("^{0}$".format(re.escape(self.metadata_dir)),)
 
     def relative_path_for_spec(self, spec):
         _check_concrete(spec)

--- a/var/spack/repos/builtin.mock/packages/view-not-ignored/package.py
+++ b/var/spack/repos/builtin.mock/packages/view-not-ignored/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import os.path
+
+from spack.package import *
+
+
+class ViewNotIgnored(Package):
+    """Install files that should not be ignored by spack."""
+
+    homepage = "http://www.spack.org"
+    url = "http://www.spack.org/downloads/aml-1.0.tar.gz"
+    has_code = False
+
+    version("0.1.0", sha256="cc89a8768693f1f11539378b21cdca9f0ce3fc5cb564f9b3e4154a051dcea69b")
+
+    install_test_files = [
+        "foo.spack",
+        ".spack.bar",
+        "aspack",
+        "bin/foo.spack",
+        "bin/.spack.bar",
+        "bin/aspack",
+    ]
+
+    def install(self, spec, prefix):
+        for test_file in self.install_test_files:
+            path = os.path.join(prefix, test_file)
+            mkdirp(os.path.dirname(path))
+            with open(path, "w") as f:
+                f.write(test_file)
+
+    @classmethod
+    def assert_installed(cls, prefix):
+        for test_file in cls.install_test_files:
+            path = os.path.join(prefix, test_file)
+            assert os.path.exists(path), "Missing installed file: {}".format(path)
+
+    @classmethod
+    def assert_not_installed(cls, prefix):
+        for test_file in cls.install_test_files:
+            path = os.path.join(prefix, test_file)
+            assert not os.path.exists(path), "File was not uninstalled: {}".format(path)


### PR DESCRIPTION
Fix missing `*.spack*` files in views.

This PR makes spack-view only ignore the `.spack` dir at install prefix root.

For example, a spack-view of the `r` package was missing `rlib/R/etc/Makeconf.spack`. Comparing a view generated before and after this fix:

```sh
# Run before this patch
$ spack install r
$ spack view add -i ./view r
$ mv view view.before

# Run after this patch
$ spack view add -i ./view r
$ mv view view.after

# Comparison:
$ diff --no-dereference -r view.before view.after
Only in view.after/rlib/R/etc: Makeconf.spack
```

Note: Related fix #26374.
