### PR TITLE
oneapi: refactoring and rpaths

### DIFF
--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -49,13 +49,11 @@ class IntelOneApiPackage(Package):
         """Path to component <prefix>/<component>/<version>."""
         return self.prefix.join(join_path(self.component_dir, self.spec.version))
 
-    def install(self, spec, prefix, installer_path=None):
-        """Shared install method for all oneapi packages."""
+    def install(self, spec, prefix):
+        self.install_component(basename(self.url_for_version(spec.version)))
 
-        # intel-oneapi-compilers overrides the installer_path when
-        # installing fortran, which comes from a spack resource
-        if installer_path is None:
-            installer_path = basename(self.url_for_version(spec.version))
+    def install_component(self, installer_path):
+        """Shared install method for all oneapi packages."""
 
         if platform.system() == 'Linux':
             # Intel installer assumes and enforces that all components
@@ -77,7 +75,7 @@ class IntelOneApiPackage(Package):
             bash = Executable('bash')
 
             # Installer writes files in ~/intel set HOME so it goes to prefix
-            bash.add_default_env('HOME', prefix)
+            bash.add_default_env('HOME', self.prefix)
             # Installer checks $XDG_RUNTIME_DIR/.bootstrapper_lock_file as well
             bash.add_default_env('XDG_RUNTIME_DIR',
                                  join_path(self.stage.path, 'runtime'))
@@ -85,13 +83,13 @@ class IntelOneApiPackage(Package):
             bash(installer_path,
                  '-s', '-a', '-s', '--action', 'install',
                  '--eula', 'accept',
-                 '--install-dir', prefix)
+                 '--install-dir', self.prefix)
 
             if getpass.getuser() == 'root':
                 shutil.rmtree('/var/intel/installercache', ignore_errors=True)
 
         # Some installers have a bug and do not return an error code when failing
-        if not isdir(join_path(prefix, self.component_dir)):
+        if not isdir(join_path(self.prefix, self.component_dir)):
             raise RuntimeError('install failed')
 
     def setup_run_environment(self, env):

--- a/lib/spack/spack/build_systems/oneapi.py
+++ b/lib/spack/spack/build_systems/oneapi.py
@@ -45,9 +45,9 @@ class IntelOneApiPackage(Package):
         raise NotImplementedError
 
     @property
-    def component_path(self):
+    def component_prefix(self):
         """Path to component <prefix>/<component>/<version>."""
-        return join_path(self.prefix, self.component_dir, str(self.spec.version))
+        return self.prefix.join(join_path(self.component_dir, self.spec.version))
 
     def install(self, spec, prefix, installer_path=None):
         """Shared install method for all oneapi packages."""
@@ -104,7 +104,7 @@ class IntelOneApiPackage(Package):
            $ source {prefix}/{component}/{version}/env/vars.sh
         """
         env.extend(EnvironmentModifications.from_sourcing_file(
-            join_path(self.component_path, 'env', 'vars.sh')))
+            join_path(self.component_prefix, 'env', 'vars.sh')))
 
 
 class IntelOneApiLibraryPackage(IntelOneApiPackage):
@@ -118,12 +118,12 @@ class IntelOneApiLibraryPackage(IntelOneApiPackage):
 
     @property
     def headers(self):
-        include_path = join_path(self.component_path, 'include')
+        include_path = join_path(self.component_prefix, 'include')
         return find_headers('*', include_path, recursive=True)
 
     @property
     def libs(self):
-        lib_path = join_path(self.component_path, 'lib', 'intel64')
+        lib_path = join_path(self.component_prefix, 'lib', 'intel64')
         lib_path = lib_path if isdir(lib_path) else dirname(lib_path)
         return find_libraries('*', root=lib_path, shared=True, recursive=True)
 

--- a/var/spack/repos/builtin/packages/extrae/package.py
+++ b/var/spack/repos/builtin/packages/extrae/package.py
@@ -84,7 +84,7 @@ class Extrae(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
         if '^intel-oneapi-mpi' in spec:
-            mpiroot = spec['mpi'].component_path
+            mpiroot = spec['mpi'].component_prefix
         else:
             mpiroot = spec['mpi'].prefix
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -162,13 +162,17 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     @run_after('install')
     def extend_config_flags(self):
         # Extends compiler config files to inject additional compiler flags.
-        # Inject rpath flags to the runtime libraries. A pedantic implementation would
-        # use cc_rpath_arg, cxx_rpath_arg, f77_rpath_arg and fc_rpath_arg methods of
-        # spack.compilers.intel and spack.compilers.oneapi for the Classic and OneAPI
-        # compilers, respectively, but that looks like an overkill, given that all of
-        # them are the same. Also, it is unclear whether we should really
-        # use _ld_library_path because it looks like the only rpath that needs to be
-        # injected is self.component_prefix.linux.compiler.lib.intel64_lin.
+
+        # Inject rpath flags to the runtime libraries.
+        # TODO: this uses a static string for the rpath argument, but should actually
+        #  make sure that it matches the cc_rpath_arg etc. arguments defined in
+        #  spack.compilers.oneapi and spack.compilers.intel (for now, these are
+        #  inherited from spack.compilers.compiler.Compiler): these can theoretically be
+        #  different for different compiler versions and for different languages (C,
+        #  C++, and Fortran), but in practice are not.
+        # TODO: it is unclear whether we should really use all elements of
+        #  _ld_library_path because it looks like the only rpath that needs to be
+        #  injected is self.component_prefix.linux.compiler.lib.intel64_lin.
         flags = ' '.join(['-Wl,-rpath,{0}'.format(d) for d in self._ld_library_path()])
         for cmp in ['icx', 'icpx', 'ifx',
                     join_path('intel64', 'icc'),

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -148,18 +148,13 @@ class IntelOneapiCompilers(IntelOneApiPackage):
 
     @run_after('install')
     def inject_rpaths(self):
-        # set rpath so 'spack compiler add' can check version strings
-        # without setting LD_LIBRARY_PATH
+        # Sets rpath so the compilers can work without setting LD_LIBRARY_PATH.
         patchelf = which('patchelf')
         patchelf.add_default_arg('--set-rpath')
         patchelf.add_default_arg(':'.join(self._ld_library_path()))
-        for pd in ['bin', 'lib',
-                   join_path('compiler', 'lib', 'intel64_lin'),
-                   join_path('compiler', 'lib', 'intel64')]:
-            patchables = find(self.component_prefix.linux.join(pd), '*',
-                              recursive=False)
-            patchables.append(self.component_prefix.linux.lib.join('icx-lto.so'))
-            for file in patchables:
+        for pd in ['bin', 'lib', join_path('compiler', 'lib', 'intel64_lin')]:
+            for file in find(self.component_prefix.linux.join(pd), '*',
+                             recursive=False):
                 # Try to patch all files, patchelf will do nothing and fail if file
                 # should not be patched
                 patchelf(file, fail_on_error=False)

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -125,7 +125,7 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                 join_path('compiler', 'lib', 'intel64_lin'),
                 join_path('compiler', 'lib')]
         for d in dirs:
-            yield join_path(self.component_path, 'linux', d)
+            yield join_path(self.component_prefix, 'linux', d)
 
     def install(self, spec, prefix):
         # install cpp
@@ -140,7 +140,7 @@ class IntelOneapiCompilers(IntelOneApiPackage):
             installer_path=glob.glob(join_path('fortran-installer', '*'))[0])
 
         # Some installers have a bug and do not return an error code when failing
-        if not path.isfile(join_path(self.component_path, 'linux',
+        if not path.isfile(join_path(self.component_prefix, 'linux',
                                      'bin', 'intel64', 'ifort')):
             raise RuntimeError('install failed')
 
@@ -152,8 +152,8 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                       join_path('compiler', 'lib', 'intel64'),
                       'bin']
         for pd in patch_dirs:
-            patchables = glob.glob(join_path(self.component_path, 'linux', pd, '*'))
-            patchables.append(join_path(self.component_path,
+            patchables = glob.glob(join_path(self.component_prefix, 'linux', pd, '*'))
+            patchables.append(join_path(self.component_prefix,
                                         'linux', 'lib', 'icx-lto.so'))
             for file in patchables:
                 # Try to patch all files, patchelf will do nothing if

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -5,6 +5,7 @@
 
 import platform
 
+from spack.build_environment import dso_suffix
 from spack.package import *
 
 linux_versions = [
@@ -173,4 +174,6 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                   join_path('lib', 'oclfpga', 'linux64', 'lib'),
                   join_path('compiler', 'lib', 'intel64_lin'),
                   join_path('compiler', 'lib')]:
-            yield join_path(self.component_prefix, 'linux', d)
+            p = join_path(self.component_prefix.linux, d)
+            if find(p, '*.' + dso_suffix, recursive=False):
+                yield p

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -10,6 +10,88 @@ from os import path
 
 from spack.package import *
 
+linux_versions = [
+    {
+        'version': '2022.1.0',
+        'cpp': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh',
+            'sha256': '1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6'
+        },
+        'ftn': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18703/l_fortran-compiler_p_2022.1.0.134_offline.sh',
+            'sha256': '583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020'
+        }
+    },
+
+    {
+        'version': '2022.0.2',
+        'cpp': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh',
+            'sha256': 'ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3'
+        },
+        'ftn': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18481/l_fortran-compiler_p_2022.0.2.83_offline.sh',
+            'sha256': '78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c'
+        }
+    },
+
+    {
+        'version': '2022.0.1',
+        'cpp': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh',
+            'sha256': 'c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a'
+        },
+        'ftn': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18436/l_fortran-compiler_p_2022.0.1.70_offline.sh',
+            'sha256': '2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1'
+        }
+    },
+    {
+        'version': '2021.4.0',
+        'cpp': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh',
+            'sha256': '9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828'
+        },
+        'ftn': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh',
+            'sha256': 'de2fcf40e296c2e882e1ddf2c45bb8d25aecfbeff2f75fcd7494068d621eb7e0'
+        }
+    },
+    {
+        'version': '2021.3.0',
+        'cpp': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh',
+            'sha256': 'f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1'
+        },
+        'ftn': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh',
+            'sha256': 'c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c'
+        }
+    },
+    {
+        'version': '2021.2.0',
+        'cpp': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh',
+            'sha256': '5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59'
+        },
+        'ftn': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh',
+            'sha256': 'a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1'
+        }
+    },
+    {
+        'version': '2021.1.2',
+        'cpp': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh',
+            'sha256': '68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a'
+        },
+        'ftn': {
+            'url': 'https://registrationcenter-download.intel.com/akdlm/irc_nas/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh',
+            'sha256': '29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829'
+        }
+    }
+]
+
 
 @IntelOneApiPackage.update_description
 class IntelOneapiCompilers(IntelOneApiPackage):
@@ -25,76 +107,10 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     depends_on('patchelf', type='build')
 
     if platform.system() == 'Linux':
-        version('2022.1.0',
-                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18717/l_dpcpp-cpp-compiler_p_2022.1.0.137_offline.sh',
-                sha256='1027819581ba820470f351abfc2b2658ff2684ed8da9ed0e722a45774a2541d6',
-                expand=False)
-        resource(name='fortran-installer',
-                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18703/l_fortran-compiler_p_2022.1.0.134_offline.sh',
-                 sha256='583082abe54a657eb933ea4ba3e988eef892985316be13f3e23e18a3c9515020',
-                 expand=False,
-                 placement='fortran-installer',
-                 when='@2022.1.0')
-        version('2022.0.2',
-                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18478/l_dpcpp-cpp-compiler_p_2022.0.2.84_offline.sh',
-                sha256='ade5bbd203e7226ca096d7bf758dce07857252ec54e83908cac3849e6897b8f3',
-                expand=False)
-        resource(name='fortran-installer',
-                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18481/l_fortran-compiler_p_2022.0.2.83_offline.sh',
-                 sha256='78532b4118fc3d7afd44e679fc8e7aed1e84efec0d892908d9368e0c7c6b190c',
-                 expand=False,
-                 placement='fortran-installer',
-                 when='@2022.0.2')
-        version('2022.0.1',
-                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18435/l_dpcpp-cpp-compiler_p_2022.0.1.71_offline.sh',
-                sha256='c7cddc64c3040eece2dcaf48926ba197bb27e5a46588b1d7b3beddcdc379926a',
-                expand=False)
-        resource(name='fortran-installer',
-                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18436/l_fortran-compiler_p_2022.0.1.70_offline.sh',
-                 sha256='2cb28a04f93554bfeffd6cad8bd0e7082735f33d73430655dea86df8933f50d1',
-                 expand=False,
-                 placement='fortran-installer',
-                 when='@2022.0.1')
-        version('2021.4.0',
-                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh',
-                sha256='9206bff1c2fdeb1ca0d5f79def90dcf3e6c7d5711b9b5adecd96a2ba06503828',
-                expand=False)
-        resource(name='fortran-installer',
-                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/18210/l_fortran-compiler_p_2021.4.0.3224_offline.sh',
-                 sha256='de2fcf40e296c2e882e1ddf2c45bb8d25aecfbeff2f75fcd7494068d621eb7e0',
-                 expand=False,
-                 placement='fortran-installer',
-                 when='@2021.4.0')
-        version('2021.3.0',
-                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17928/l_dpcpp-cpp-compiler_p_2021.3.0.3168_offline.sh',
-                sha256='f848d81b7cabc76c2841c9757abb2290921efd7b82491d830605f5785600e7a1',
-                expand=False)
-        resource(name='fortran-installer',
-                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17959/l_fortran-compiler_p_2021.3.0.3168_offline.sh',
-                 sha256='c4553f7e707be8e8e196f625e4e7fbc8eff5474f64ab85fc7146b5ed53ebc87c',
-                 expand=False,
-                 placement='fortran-installer',
-                 when='@2021.3.0')
-        version('2021.2.0',
-                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17749/l_dpcpp-cpp-compiler_p_2021.2.0.118_offline.sh',
-                sha256='5d01cbff1a574c3775510cd97ffddd27fdf56d06a6b0c89a826fb23da4336d59',
-                expand=False)
-        resource(name='fortran-installer',
-                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17756/l_fortran-compiler_p_2021.2.0.136_offline.sh',
-                 sha256='a62e04a80f6d2f05e67cd5acb03fa58857ee22c6bd581ec0651c0ccd5bdec5a1',
-                 expand=False,
-                 placement='fortran-installer',
-                 when='@2021.2.0')
-        version('2021.1.2',
-                url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17513/l_dpcpp-cpp-compiler_p_2021.1.2.63_offline.sh',
-                sha256='68d6cb638091990e578e358131c859f3bbbbfbf975c581fd0b4b4d36476d6f0a',
-                expand=False)
-        resource(name='fortran-installer',
-                 url='https://registrationcenter-download.intel.com/akdlm/irc_nas/17508/l_fortran-compiler_p_2021.1.2.62_offline.sh',
-                 sha256='29345145268d08a59fa7eb6e58c7522768466dd98f6d9754540d1a0803596829',
-                 expand=False,
-                 placement='fortran-installer',
-                 when='@2021.1.2')
+        for v in linux_versions:
+            version(v['version'], expand=False, **v['cpp'])
+            resource(name='fortran-installer', placement='fortran-installer',
+                     when='@{0}'.format(v['version']), expand=False, **v['ftn'])
 
     @property
     def component_dir(self):

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -124,8 +124,8 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                 join_path('lib', 'oclfpga', 'linux64', 'lib'),
                 join_path('compiler', 'lib', 'intel64_lin'),
                 join_path('compiler', 'lib')]
-        for dir in dirs:
-            yield join_path(self.component_path, 'linux', dir)
+        for d in dirs:
+            yield join_path(self.component_path, 'linux', d)
 
     def install(self, spec, prefix):
         # install cpp

--- a/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dnn/package.py
@@ -64,10 +64,11 @@ class IntelOneapiDnn(IntelOneApiLibraryPackage):
 
     @property
     def headers(self):
-        include_path = join_path(self.component_path, 'cpu_dpcpp_gpu_dpcpp', 'include')
+        include_path = join_path(self.component_prefix,
+                                 'cpu_dpcpp_gpu_dpcpp', 'include')
         return find_headers('dnnl', include_path)
 
     @property
     def libs(self):
-        lib_path = join_path(self.component_path, 'cpu_dpcpp_gpu_dpcpp', 'lib')
+        lib_path = join_path(self.component_prefix, 'cpu_dpcpp_gpu_dpcpp', 'lib')
         return find_libraries(['libdnnl', 'libmkldnn'], root=lib_path, shared=True)

--- a/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-dpl/package.py
@@ -48,7 +48,7 @@ class IntelOneapiDpl(IntelOneApiLibraryPackage):
 
     @property
     def headers(self):
-        include_path = join_path(self.component_path, 'linux', 'include')
+        include_path = join_path(self.component_prefix, 'linux', 'include')
         headers = find_headers('*', include_path, recursive=True)
         # Force this directory to be added to include path, even
         # though no files are here because all includes are relative

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -81,7 +81,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
 
     @property
     def headers(self):
-        include_path = join_path(self.component_path, 'include')
+        include_path = join_path(self.component_prefix, 'include')
         return find_headers('*', include_path)
 
     # provide cluster libraries if +cluster variant is used or
@@ -102,7 +102,7 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         if self.cluster():
             mkl_libs += [self.xlp64_lib('libmkl_blacs_intelmpi')]
         libs = find_libraries(mkl_libs,
-                              join_path(self.component_path, 'lib', 'intel64'),
+                              join_path(self.component_prefix, 'lib', 'intel64'),
                               shared=shared)
         system_libs = find_system_libraries(['libpthread', 'libm', 'libdl'])
         if shared:
@@ -111,4 +111,4 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
             return IntelOneApiStaticLibraryList(libs, system_libs)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set('MKLROOT', self.component_path)
+        env.set('MKLROOT', self.component_prefix)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mkl/package.py
@@ -94,12 +94,12 @@ class IntelOneapiMkl(IntelOneApiLibraryPackage):
         super(IntelOneapiMkl, self).setup_run_environment(env)
 
         # Support RPATH injection to the library directories when the '-mkl' or '-qmkl'
-        # flag of the Intel compilers are used outside of the Spack build environment.
-        # We should not try to take care of other compilers because the users have to
+        # flag of the Intel compilers are used outside the Spack build environment. We
+        # should not try to take care of other compilers because the users have to
         # provide the linker flags anyway and are expected to take care of the RPATHs
-        # flags too. We prefer the POST flags over the PRE ones to allow for overriding
-        # of the injected RPATHs. Also, we use append_path instead of append_flags
-        # because the latter is not yet supported in the default modulefile templates.
+        # flags too. We prefer the __INTEL_POST_CFLAGS/__INTEL_POST_FFLAGS flags over
+        # the PRE ones so that any other RPATHs provided by the users on the command
+        # line come before and take precedence over the ones we inject here.
         for d in self._find_mkl_libs('+shared' in self.spec).directories:
             flag = '-Wl,-rpath,{0}'.format(d)
             env.append_path('__INTEL_POST_CFLAGS', flag, separator=' ')

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -68,7 +68,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         return 'mpi'
 
     def setup_dependent_package(self, module, dep_spec):
-        dir = join_path(self.component_path, 'bin')
+        dir = join_path(self.component_prefix, 'bin')
         if '+generic-names' in self.spec:
             self.spec.mpicc  = join_path(dir, 'mpicc')
             self.spec.mpicxx = join_path(dir, 'mpicxx')
@@ -88,7 +88,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         env.set('MPICH_FC', spack_fc)
 
         # Set compiler wrappers for dependent build stage
-        dir = join_path(self.component_path, 'bin')
+        dir = join_path(self.component_prefix, 'bin')
         if '+generic-names' in self.spec:
             env.set('MPICC', join_path(dir, 'mpicc'))
             env.set('MPICXX', join_path(dir, 'mpicxx'))
@@ -102,11 +102,11 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
             env.set('MPIF90', join_path(dir, 'mpiifort'))
             env.set('MPIFC', join_path(dir, 'mpiifort'))
 
-        env.set('I_MPI_ROOT', self.component_path)
+        env.set('I_MPI_ROOT', self.component_prefix)
 
     @property
     def headers(self):
-        include_path = join_path(self.component_path, 'include')
+        include_path = join_path(self.component_prefix, 'include')
         headers = find_headers('*', include_path)
         if '+ilp64' in self.spec:
             headers += find_headers('*', join_path(include_path, 'ilp64'))
@@ -114,7 +114,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
 
     @property
     def libs(self):
-        lib_dir = join_path(self.component_path, 'lib')
+        lib_dir = join_path(self.component_prefix, 'lib')
         release_lib_dir = join_path(lib_dir, 'release')
         libs = []
         if '+ilp64' in self.spec:
@@ -128,7 +128,7 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
             libs += self.spec['libfabric'].libs
         else:
             libs += find_libraries(['libfabric'],
-                                   join_path(self.component_path, 'libfabric', 'lib'))
+                                   join_path(self.component_prefix, 'libfabric', 'lib'))
 
         return libs
 
@@ -141,8 +141,8 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         scripts = ["mpif77", "mpif90", "mpigcc", "mpigxx", "mpiicc", "mpiicpc",
                    "mpiifort"]
         for script in scripts:
-            file = join_path(self.component_path, 'bin', script)
+            file = join_path(self.component_prefix, 'bin', script)
             filter_file('I_MPI_SUBSTITUTE_INSTALLDIR',
-                        self.component_path, file, backup=False)
+                        self.component_prefix, file, backup=False)
             filter_file('__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__',
-                        self.component_path, file, backup=False)
+                        self.component_prefix, file, backup=False)

--- a/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-mpi/package.py
@@ -68,17 +68,16 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         return 'mpi'
 
     def setup_dependent_package(self, module, dep_spec):
-        dir = join_path(self.component_prefix, 'bin')
         if '+generic-names' in self.spec:
-            self.spec.mpicc  = join_path(dir, 'mpicc')
-            self.spec.mpicxx = join_path(dir, 'mpicxx')
-            self.spec.mpif77 = join_path(dir, 'mpif77')
-            self.spec.mpifc  = join_path(dir, 'mpifc')
+            self.spec.mpicc  = join_path(self.component_prefix.bin, 'mpicc')
+            self.spec.mpicxx = join_path(self.component_prefix.bin, 'mpicxx')
+            self.spec.mpif77 = join_path(self.component_prefix.bin, 'mpif77')
+            self.spec.mpifc  = join_path(self.component_prefix.bin, 'mpifc')
         else:
-            self.spec.mpicc  = join_path(dir, 'mpiicc')
-            self.spec.mpicxx = join_path(dir, 'mpiicpc')
-            self.spec.mpif77 = join_path(dir, 'mpiifort')
-            self.spec.mpifc  = join_path(dir, 'mpiifort')
+            self.spec.mpicc  = join_path(self.component_prefix.bin, 'mpiicc')
+            self.spec.mpicxx = join_path(self.component_prefix.bin, 'mpiicpc')
+            self.spec.mpif77 = join_path(self.component_prefix.bin, 'mpiifort')
+            self.spec.mpifc  = join_path(self.component_prefix.bin, 'mpiifort')
 
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('MPICH_CC', spack_cc)
@@ -88,61 +87,54 @@ class IntelOneapiMpi(IntelOneApiLibraryPackage):
         env.set('MPICH_FC', spack_fc)
 
         # Set compiler wrappers for dependent build stage
-        dir = join_path(self.component_prefix, 'bin')
         if '+generic-names' in self.spec:
-            env.set('MPICC', join_path(dir, 'mpicc'))
-            env.set('MPICXX', join_path(dir, 'mpicxx'))
-            env.set('MPIF77', join_path(dir, 'mpif77'))
-            env.set('MPIF90', join_path(dir, 'mpif90'))
-            env.set('MPIFC', join_path(dir, 'mpifc'))
+            env.set('MPICC', join_path(self.component_prefix.bin, 'mpicc'))
+            env.set('MPICXX', join_path(self.component_prefix.bin, 'mpicxx'))
+            env.set('MPIF77', join_path(self.component_prefix.bin, 'mpif77'))
+            env.set('MPIF90', join_path(self.component_prefix.bin, 'mpif90'))
+            env.set('MPIFC', join_path(self.component_prefix.bin, 'mpifc'))
         else:
-            env.set('MPICC', join_path(dir, 'mpiicc'))
-            env.set('MPICXX', join_path(dir, 'mpiicpc'))
-            env.set('MPIF77', join_path(dir, 'mpiifort'))
-            env.set('MPIF90', join_path(dir, 'mpiifort'))
-            env.set('MPIFC', join_path(dir, 'mpiifort'))
+            env.set('MPICC', join_path(self.component_prefix.bin, 'mpiicc'))
+            env.set('MPICXX', join_path(self.component_prefix.bin, 'mpiicpc'))
+            env.set('MPIF77', join_path(self.component_prefix.bin, 'mpiifort'))
+            env.set('MPIF90', join_path(self.component_prefix.bin, 'mpiifort'))
+            env.set('MPIFC', join_path(self.component_prefix.bin, 'mpiifort'))
 
         env.set('I_MPI_ROOT', self.component_prefix)
 
     @property
     def headers(self):
-        include_path = join_path(self.component_prefix, 'include')
-        headers = find_headers('*', include_path)
+        headers = find_headers('*', self.component_prefix.include)
         if '+ilp64' in self.spec:
-            headers += find_headers('*', join_path(include_path, 'ilp64'))
+            headers += find_headers('*', self.component_prefix.include.ilp64)
         return headers
 
     @property
     def libs(self):
-        lib_dir = join_path(self.component_prefix, 'lib')
-        release_lib_dir = join_path(lib_dir, 'release')
         libs = []
         if '+ilp64' in self.spec:
-            libs += find_libraries('libmpi_ilp64', release_lib_dir)
-        libs += find_libraries(['libmpicxx', 'libmpifort'], lib_dir)
-        libs += find_libraries('libmpi', release_lib_dir)
+            libs += find_libraries('libmpi_ilp64', self.component_prefix.lib.release)
+        libs += find_libraries(['libmpicxx', 'libmpifort'], self.component_prefix.lib)
+        libs += find_libraries('libmpi', self.component_prefix.lib.release)
         libs += find_system_libraries(['libdl', 'librt', 'libpthread'])
 
         # Find libfabric for libmpi.so
         if '+external-libfabric' in self.spec:
             libs += self.spec['libfabric'].libs
         else:
-            libs += find_libraries(['libfabric'],
-                                   join_path(self.component_prefix, 'libfabric', 'lib'))
+            libs += find_libraries(['libfabric'], self.component_prefix.libfabric.lib)
 
         return libs
 
-    def install(self, spec, prefix):
-        super(IntelOneapiMpi, self).install(spec, prefix)
-
+    @run_after('install')
+    def fix_wrappers(self):
         # When spack builds from source
         # fix I_MPI_SUBSTITUTE_INSTALLDIR and
         #   __EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__
-        scripts = ["mpif77", "mpif90", "mpigcc", "mpigxx", "mpiicc", "mpiicpc",
-                   "mpiifort"]
-        for script in scripts:
-            file = join_path(self.component_prefix, 'bin', script)
-            filter_file('I_MPI_SUBSTITUTE_INSTALLDIR',
-                        self.component_prefix, file, backup=False)
-            filter_file('__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__',
-                        self.component_prefix, file, backup=False)
+        for wrapper in ['mpif77', 'mpif90', 'mpigcc', 'mpigxx', 'mpiicc',
+                        'mpiicpc', 'mpiifort']:
+            filter_file(r'I_MPI_SUBSTITUTE_INSTALLDIR|'
+                        r'__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__',
+                        self.component_prefix,
+                        self.component_prefix.bin.join(wrapper),
+                        backup=False)


### PR DESCRIPTION
The two main features of this PR are:
1. Generate `.cfg` files for the compilers that contain rpath flags for the directories with the runtime libraries. This way, executables that are generated by the compilers contain rpaths to the libraries they need (e.g. `libimf.so`, `libiomp5.so`, `libintlc.so`, etc.) and there is no need to load modules or set `LD_LIBRARY_PATH` to be able to run the executables. We do something similar for `gcc` (see [here](https://github.com/spack/spack/blob/1bd33d88bd5bdf6820800b71b2f5f798e857920b/var/spack/repos/builtin/packages/gcc/package.py#L753)).
2. Extend the module file generated for `intel-oneapi-mkl` so that an executable produced with `-mkl/-qmkl` Intel compiler flag contains rpaths to the MKL libraries.

The rest is refactoring. I tried to keep the history clean and the commit messages are hopefully informative enough (yes, I should have probably created a separate PR with the refactoring).

I also wanted to discuss one thing here. I don't remember where exactly, probably on a slide of a presentation about Spack, but there was one bullet point on the list of what Spack offers: "user can use environment modules but they do not have to". I try to follow and support that as much as possible. This is, for example, why I think we should generate the `.cfg` files (see above) under the default names and not under some other ones and set `ICXCFG` (and friends) in the module files. However, `intel-oneapi-compilers` are not there yet. For example, we get a failure when we call one of the compilers with the `-mkl/-qmkl` flag without setting `MKLROOT` or loading the `intel-oneapi-mkl` module first. By the way, I would not see any problem if the compilers didn't have the `-mkl/-qmkl` flag at all: there would not be any magic promised by the compiler and no magic would be expected by the users. However, the flags are there and we basically get a broken installation of Intel compilers. As far as I understand, the problem here is that we contradict the way intended by the compiler developers by following the Spack approach of installing everything to different prefixes. I don't mind that but I would like Spack to be able to produce a fully functional installation of the compiler toolchain. In particular, I would like the `-mkl/-qmkl` flags to work without any modules or additional environment variables that the users have to load/set. I see several possible solutions to that:
1. Introduce additional variants for `intel-oneapi-compilers` like `+mkl`, `+mpi`, etc. and install the respective components to the same prefix. This is probably the closest to how the compiler developers see it. The problem here is that we get duplicates in the installation tree: `intel-oneapi-mkl`, which we might want to install to use with other compilers, will be a subset of `intel-oneapi-compilers +mkl`.
2. Make `intel-oneapi-mkl` extend `intel-oneapi-compilers`, which would allow for `spack activate intel-oneapi-mkl. Two problems here: 
    a) according to how the extension are currently implemented in Spack, `intel-oneapi-compilers` becomes a dependency of `intel-oneapi-mkl`, which we don't really want since the user might want to install the MKL library only, without the compilers;
    b) we have to ensure correct file conflict resolution: there are files with the same names in the prefixes of `intel-oneapi-compilers` and `intel-oneapi-mkl`, which breaks the activation as it is currently implemented in Spack.
3. Introduce a meta-package `intel-oneapi-toolchain`, which would have variants `+mkl`, `+mpi`, etc,  have the respective components as conditional dependencies and install nothing but create a view (with symlinks) of all of the components in its prefix.

Different hybrid solutions of the three above are also possible, of course.

I now have a strong feeling that all of that has already been discussed somewhere. If that is really the case, please, point me to the discussion and I will try to join/revive it.