### PR TITLE
Fix empty install prefix post-install sanity check

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -33,7 +33,7 @@ import six
 
 import llnl.util.filesystem as fsys
 import llnl.util.tty as tty
-from llnl.util.lang import memoized, nullcontext
+from llnl.util.lang import match_predicate, memoized, nullcontext
 from llnl.util.link_tree import LinkTree
 
 import spack.compilers
@@ -2178,10 +2178,8 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         check_paths(self.sanity_check_is_file, 'file', os.path.isfile)
         check_paths(self.sanity_check_is_dir, 'directory', os.path.isdir)
 
-        installed = set(os.listdir(self.prefix))
-        installed.difference_update(
-            spack.store.layout.hidden_file_regexes)
-        if not installed:
+        ignore_file = match_predicate(spack.store.layout.hidden_file_regexes)
+        if all(map(ignore_file, os.listdir(self.prefix))):
             raise InstallError(
                 "Install failed for %s.  Nothing was installed!" % self.name)
 

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -379,9 +379,8 @@ def test_failing_build(install_mockery, mock_fetch, capfd):
     spec = Spec('failing-build').concretized()
     pkg = spec.package
 
-    with pytest.raises(spack.build_environment.ChildError):
+    with pytest.raises(spack.build_environment.ChildError, match='Expected failure'):
         pkg.do_install()
-        assert 'InstallError: Expected Failure' in capfd.readouterr()[0]
 
 
 class MockInstallError(spack.error.SpackError):

--- a/lib/spack/spack/test/install.py
+++ b/lib/spack/spack/test/install.py
@@ -612,3 +612,16 @@ def test_install_error():
         assert exc.__class__.__name__ == 'InstallError'
         assert exc.message == msg
         assert exc.long_message == long_msg
+
+
+@pytest.mark.disable_clean_stage_check
+def test_empty_install_sanity_check_prefix(
+        monkeypatch, install_mockery, mock_fetch, mock_packages
+):
+    """Test empty install triggers sanity_check_prefix."""
+    spec = Spec('failing-empty-install').concretized()
+    with pytest.raises(
+        spack.build_environment.ChildError,
+        match='Nothing was installed'
+    ):
+        spec.package.do_install()

--- a/var/spack/repos/builtin.mock/packages/failing-empty-install/package.py
+++ b/var/spack/repos/builtin.mock/packages/failing-empty-install/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class FailingEmptyInstall(Package):
+    """This package installs nothing, install should fail."""
+    homepage = "http://www.example.com/trivial_install"
+    url      = "http://www.unit-test-should-replace-this-url/trivial_install-1.0.tar.gz"
+
+    version('1.0', '0123456789abcdef0123456789abcdef')
+
+    def install(self, spec, prefix):
+        pass


### PR DESCRIPTION
Regression since #26374: the post-install sanity check to raise an error if the install prefix is empty wasn't working anymore.
