### PR TITLE
py-torch: Fix errors in third party repo for version 1.11.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -246,6 +246,32 @@ class PyTorch(PythonPackage, CudaPackage):
     patch('https://github.com/pytorch/pytorch/commit/c74c0c571880df886474be297c556562e95c00e0.patch?full_index=1',
           sha256='8ff7d285e52e4718bad1ca01ceb3bb6471d7828329036bb94222717fcaa237da', when='@:1.9.1 ^cuda@11.4.100:')
 
+    # Fixes errors in third-party repo
+    @when('@1.11.0')
+    def patch(self):
+        filter_file('inline RARegCount& operator=' +
+                    '(const RARegCount& other) noexcept = default;',
+                    '',
+                    'third_party/fbgemm/third_party/asmjit/src/asmjit/core/radefs_p.h',
+                    string=True)
+        filter_file('inline RARegMask& operator=' +
+                    '(const RARegMask& other) noexcept = default;',
+                    '',
+                    'third_party/fbgemm/third_party/asmjit/src/asmjit/core/radefs_p.h',
+                    string=True)
+        filter_file('size_t currentSize = sb.size();',
+                    '',
+                    'third_party/fbgemm/third_party/' +
+                    'asmjit/src/asmjit/core/emitterutils.cpp', string=True)
+        filter_file('currentSize += sb.size() - begin;',
+                    '',
+                    'third_party/fbgemm/third_party/' +
+                    'asmjit/src/asmjit/core/emitterutils.cpp', string=True)
+        filter_file('size_t begin = sb.size();',
+                    '',
+                    'third_party/fbgemm/third_party/' +
+                    'asmjit/src/asmjit/core/emitterutils.cpp', string=True)
+
     @property
     def libs(self):
         # TODO: why doesn't `python_platlib` work here?


### PR DESCRIPTION
With clang13:
```
==> Error: ProcessError: Command exited with status 1:
    '/build/hahansen/packages/python/3.9.12/x86_64-centos8-clang13.0.0-opt/6kdak/bin/python3.9' '-m' 'pip' '-vvv' '--no-input' '--no-cache-dir' '--disable-pip-version-check' 'install' '--no-deps' '--ignore-installed' '--no-build-isolation' '--no-warn-script-location' '--no-index' '--prefix=/build/hahansen/packages/py-torch/1.11.0/x86_64-centos8-clang13.0.0-opt/zih3g' '.'

6 errors found in build log:
     3054      [2351/5156] Building C object confu-deps/XNNPACK/CMakeFiles/XNNPACK.dir/src/qs8-igemm/gen/2x16c8-minmax-gemmlowp-avx512skx.c.o
     3055      [2352/5156] Building C object confu-deps/XNNPACK/CMakeFiles/XNNPACK.dir/src/qs8-igemm/gen/3x16c8-minmax-gemmlowp-avx512skx.c.o
     3056      [2353/5156] Building C object confu-deps/XNNPACK/CMakeFiles/XNNPACK.dir/src/qs8-igemm/gen/4x16c8-minmax-fp32-avx512skx.c.o
     3057      [2354/5156] Building C object confu-deps/XNNPACK/CMakeFiles/XNNPACK.dir/src/qs8-igemm/gen/4x16c8-minmax-gemmlowp-avx512skx.c.o
     3058      [2355/5156] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/codewriter.cpp.o
     3059      [2356/5156] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o
  >> 3060    FAILED: third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o
     3061      /build/hahansen/spack/lib/spack/env/clang/clang++  -isystem /build/hahansen/packages/protobuf/3.18.0/x86_64-centos8-clang13.0.0-opt/6b2p2/include -isystem /build/hahansen/packages/openblas/0.3.20
             /x86_64-centos8-clang13.0.0-opt/hhui6/include -isystem /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/gemmlowp -isystem /tmp/hahansen/s
             pack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/neon2sse -isystem /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl
             7/spack-src/third_party/XNNPACK/include -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -fopenmp=libomp -Wall -Wextra -Werror -Wno-deprecated-declarations -O3 -DNDEBUG -fPIC -fvisibil
             ity=hidden -Wall -Wextra -Wconversion -fno-math-errno -fno-threadsafe-statics -fno-semantic-interposition -DASMJIT_STATIC -O2 -fmerge-all-constants -std=c++14 -MD -MT third_party/fbgemm/asmjit/CMak
             eFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o -MF third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o.d -o third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/c
             ore/compiler.cpp.o -c /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/compiler.cpp
     3062      In file included from /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/compiler.cpp:31:
     3063      In file included from /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/../core/rapass_p.h:32:
     3064      In file included from /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/../core/raassignment_p
             .h:30:
  >> 3065      /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/../core/radefs_p.h:257:21: error: definition
              of implicit copy constructor for 'RARegMask' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
     3066        inline RARegMask& operator=(const RARegMask& other) noexcept = default;
     3067                          ^
     3068      /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/../core/rapass_p.h:701:28: note: in implicit
              copy constructor for 'asmjit::RARegMask' first required here
     3069        RARegMask _availableRegs = RARegMask();
     3070                                 ^
     3071      1 error generated.

     ...

     3092        Running command /build/hahansen/packages/python/3.9.12/x86_64-centos8-clang13.0.0-opt/6kdak/bin/python3.9 -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/hahansen/spack
             -stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/setup.py'"'"'; __file__='"'"'/tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spa
             ck-src/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"
             '\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-vkaq7wcc/install-record.txt --single-version-externally-managed --prefix /build/h
             ahansen/packages/py-torch/1.11.0/x86_64-centos8-clang13.0.0-opt/zih3g --compile --install-headers /build/hahansen/packages/py-torch/1.11.0/x86_64-centos8-clang13.0.0-opt/zih3g/include/python3.9/tor
             ch
     3093        Building wheel torch-1.11.0
     3094        -- Building version 1.11.0
     3095        cmake --build . --target install --config Release -- -j 4
     3096        [1/2798] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/environment.cpp.o
     3097        [2/2798] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/emitterutils.cpp.o
  >> 3098    FAILED: third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/emitterutils.cpp.o
     3099        /build/hahansen/spack/lib/spack/env/clang/clang++  -isystem /build/hahansen/packages/protobuf/3.18.0/x86_64-centos8-clang13.0.0-opt/6b2p2/include -isystem /build/hahansen/packages/openblas/0.3.
             20/x86_64-centos8-clang13.0.0-opt/hhui6/include -isystem /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/gemmlowp -isystem /tmp/hahansen
             /spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/neon2sse -isystem /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72r
             jl7/spack-src/third_party/XNNPACK/include -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -fopenmp=libomp -Wall -Wextra -Werror -Wno-deprecated-declarations -O3 -DNDEBUG -fPIC -fvisib
             ility=hidden -Wall -Wextra -Wconversion -fno-math-errno -fno-threadsafe-statics -fno-semantic-interposition -DASMJIT_STATIC -O2 -fmerge-all-constants -std=c++14 -MD -MT third_party/fbgemm/asmjit/CM
             akeFiles/asmjit.dir/src/asmjit/core/emitterutils.cpp.o -MF third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/emitterutils.cpp.o.d -o third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/sr
             c/asmjit/core/emitterutils.cpp.o -c /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/emitteruti
             ls.cpp
  >> 3100        /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/emitterutils.cpp:72:7: error: use of undec
             lared identifier 'currentSize'; did you mean 'commentSize'?
     3101              currentSize += sb.size() - begin;
     3102              ^~~~~~~~~~~
     3103              commentSize
     3104        /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/emitterutils.cpp:43:10: note: 'commentSize
             ' declared here
     3105          size_t commentSize = comment ? Support::strLen(comment, Globals::kMaxCommentSize) : 0;
     3106                 ^
     3107        1 error generated.
     3108        [3/2798] Building CXX object third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o
  >> 3109    FAILED: third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o
     3110        /build/hahansen/spack/lib/spack/env/clang/clang++  -isystem /build/hahansen/packages/protobuf/3.18.0/x86_64-centos8-clang13.0.0-opt/6b2p2/include -isystem /build/hahansen/packages/openblas/0.3.
             20/x86_64-centos8-clang13.0.0-opt/hhui6/include -isystem /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/gemmlowp -isystem /tmp/hahansen
             /spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/neon2sse -isystem /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72r
             jl7/spack-src/third_party/XNNPACK/include -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -fopenmp=libomp -Wall -Wextra -Werror -Wno-deprecated-declarations -O3 -DNDEBUG -fPIC -fvisib
             ility=hidden -Wall -Wextra -Wconversion -fno-math-errno -fno-threadsafe-statics -fno-semantic-interposition -DASMJIT_STATIC -O2 -fmerge-all-constants -std=c++14 -MD -MT third_party/fbgemm/asmjit/CM
             akeFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o -MF third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit/core/compiler.cpp.o.d -o third_party/fbgemm/asmjit/CMakeFiles/asmjit.dir/src/asmjit
             /core/compiler.cpp.o -c /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/compiler.cpp
     3111        In file included from /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/compiler.cpp:31:
     3112        In file included from /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/../core/rapass_p.h:3
             2:
     3113        In file included from /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/../core/raassignment
             _p.h:30:
  >> 3114        /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/../core/radefs_p.h:257:21: error: definiti
             on of implicit copy constructor for 'RARegMask' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
     3115          inline RARegMask& operator=(const RARegMask& other) noexcept = default;
     3116                            ^
     3117        /tmp/hahansen/spack-stage/spack-stage-py-torch-1.11.0-zih3g52twvbujdwpq5sdywdm6w72rjl7/spack-src/third_party/fbgemm/third_party/asmjit/src/asmjit/core/../core/rapass_p.h:701:28: note: in implic
             it copy constructor for 'asmjit::RARegMask' first required here
     3118          RARegMask _availableRegs = RARegMask();
     3119                                   ^
     3120        1 error generated.
```
The changes I've made in the patch function are also done on the master branch of asmjit. It looks for me like the implicit copy constructor can be moved. And the `currentSize` and `begin` vars seem to be unnecessary. The package installs successfully after the changes I made and I am able to run the binaries