### PR TITLE
py-botorch: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-botorch/package.py
+++ b/var/spack/repos/builtin/packages/py-botorch/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyBotorch(PythonPackage):
+    """BoTorch is a library for Bayesian Optimization built on PyTorch."""
+
+    homepage = "https://botorch.org/"
+    pypi     = "botorch/botorch-0.6.4.tar.gz"
+
+    maintainers = ['adamjstewart']
+
+    version('0.6.4', sha256='3fd28417f55749501a45378f72cd5ca7614e2e05b7b65c6b4eb9b72378bc665a')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    # TODO: replace this after concretizer learns how to concretize separate build deps
+    depends_on('py-setuptools', type='build')
+    # depends_on('py-setuptools@:47', type='build')
+    depends_on('py-setuptools-scm', type='build')
+    depends_on('py-torch@1.9:', type=('build', 'run'))
+    depends_on('py-gpytorch@1.6:', type=('build', 'run'))
+    depends_on('py-scipy', type=('build', 'run'))
+    depends_on('py-multipledispatch', type=('build', 'run'))
+    depends_on('py-pyro-ppl@1.8.0', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-gpytorch/package.py
+++ b/var/spack/repos/builtin/packages/py-gpytorch/package.py
@@ -17,12 +17,16 @@ class PyGpytorch(PythonPackage):
 
     maintainers = ['adamjstewart']
 
+    version('1.6.0', sha256='08e8f1a80669dc3eee5ba237fc00c867a8858f9b186bbec8571a8cf9af36f543')
     version('1.2.1', sha256='ddd746529863d5419872610af23b1a1b0e8a29742131c9d9d2b4f9cae3c90781')
     version('1.2.0', sha256='fcb216e0c1f128a41c91065766508e91e487d6ffadf212a51677d8014aefca84')
     version('1.1.1', sha256='76bd455db2f17af5425f73acfaa6d61b8adb1f07ad4881c0fa22673f84fb571a')
 
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-torch@1.9:', when='@1.6:', type=('build', 'run'))
+    depends_on('py-torch@1.8.1:', when='@1.5:', type=('build', 'run'))
+    depends_on('py-torch@1.7:', when='@1.3:', type=('build', 'run'))
     depends_on('py-torch@1.6:', when='@1.2:', type=('build', 'run'))
     depends_on('py-torch@1.5:', type=('build', 'run'))
     depends_on('py-scikit-learn', when='@1.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyro-api/package.py
+++ b/var/spack/repos/builtin/packages/py-pyro-api/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyroApi(PythonPackage):
+    """Generic API for dispatch to Pyro backends."""
+
+    homepage = "https://github.com/pyro-ppl/pyro-api"
+    pypi     = "pyro-api/pyro-api-0.1.2.tar.gz"
+
+    version('0.1.2', sha256='a1b900d9580aa1c2fab3b123ab7ff33413744da7c5f440bd4aadc4d40d14d920')
+
+    depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-pyro-ppl/package.py
+++ b/var/spack/repos/builtin/packages/py-pyro-ppl/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyroPpl(PythonPackage):
+    """A Python library for probabilistic modeling and inference."""
+
+    homepage = "https://pyro.ai/"
+    pypi     = "pyro-ppl/pyro-ppl-1.8.1.tar.gz"
+
+    maintainers = ['adamjstewart']
+
+    version('1.8.1', sha256='d7c049eb2e7485a612b4dd99c24c309cc860c7cbc6b1973387034f5436d1c8d6')
+    version('1.8.0', sha256='68e4ea30f219227dd88e55de2550d3f8c20a20adbdb67ad1e13b50868bb2ac0c')
+
+    depends_on('python@3.7:', when='@1.8.1:', type=('build', 'run'))
+    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('py-setuptools', type='build')
+    depends_on('py-numpy@1.7:', type=('build', 'run'))
+    depends_on('py-opt-einsum@2.3.2:', type=('build', 'run'))
+    depends_on('py-pyro-api@0.1.1:', type=('build', 'run'))
+    depends_on('py-torch@1.11:', when='@1.8.1:', type=('build', 'run'))
+    depends_on('py-torch@1.9:', type=('build', 'run'))
+    depends_on('py-tqdm@4.36:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 12.4 and Apple M1 Pro with Python 3.9.12 and Apple Clang 13.1.6.