### PR TITLE
Visit: Allow building without gui or osmesa

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -92,7 +92,6 @@ class Visit(CMakePackage):
 
     # Exactly one of 'gui' or 'osmesa' has to be enabled
     conflicts('+gui', when='+osmesa')
-    conflicts('~gui', when='~osmesa')
 
     #############################################
     # Full List of dependencies from build_visit


### PR DESCRIPTION
This is important for HPC systems.