### PR TITLE
py-vermin: add latest version 1.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-vermin/package.py
+++ b/var/spack/repos/builtin/packages/py-vermin/package.py
@@ -11,10 +11,11 @@ class PyVermin(PythonPackage):
     """Concurrently detect the minimum Python versions needed to run code."""
 
     homepage = "https://github.com/netromdk/vermin"
-    url      = "https://github.com/netromdk/vermin/archive/v1.3.3.tar.gz"
+    url      = "https://github.com/netromdk/vermin/archive/v1.4.0.tar.gz"
 
     maintainers = ['netromdk']
 
+    version('1.4.0', sha256='984773ed6af60329e700b39c58b7584032acbc908a00b5a76d1ce5468c825c70')
     version('1.3.3', sha256='35cd8bc3f54f651dbb162a7b35b4b091409154ce6d565df043f7f04bf9401d7d')
     version('1.3.2', sha256='2818eaea24c5be5dae1f374ddb2377e9cfaad04d0a3372ad129cffc46cec5404')
     version('1.3.1', sha256='ddcdaad5a708a483af192075f5d2eaaaf3aa4661b5101ddafa40d7837eeb5368')


### PR DESCRIPTION
New release: [v1.4.0](https://github.com/netromdk/vermin/releases/tag/v1.4.0)
Removed deprecated lax mode entirely.
**Vermin 1.5 will end support for py2.7** (but will still retain 2.x rules, of course)

@adamjstewart @alalazo 