### PR TITLE
Fix libunwind dependency fo py-py-spy

### DIFF
--- a/var/spack/repos/builtin/packages/py-py-spy/package.py
+++ b/var/spack/repos/builtin/packages/py-py-spy/package.py
@@ -19,7 +19,7 @@ class PyPySpy(Package):
     # Need to figure out how to manage these with Spack once we have a
     # CargoPackage base class.
     depends_on('rust', type='build')
-    depends_on('unwind')
+    depends_on('libunwind components=ptrace')
 
     def install(self, spec, prefix):
         cargo = which('cargo')

--- a/var/spack/repos/builtin/packages/py-py-spy/package.py
+++ b/var/spack/repos/builtin/packages/py-py-spy/package.py
@@ -19,7 +19,8 @@ class PyPySpy(Package):
     # Need to figure out how to manage these with Spack once we have a
     # CargoPackage base class.
     depends_on('rust', type='build')
-    depends_on('libunwind components=ptrace')
+    depends_on('unwind')
+    depends_on('libunwind components=ptrace', when='^libunwind')
 
     def install(self, spec, prefix):
         cargo = which('cargo')


### PR DESCRIPTION
The `py-py-spy` package is failing with a missing `-lunwind-ptrace` at link time.
This fixes the issue by building the missing `ptrace` component.