### PR TITLE
Fix py-ray dependencies and build system

### DIFF
--- a/var/spack/repos/builtin/packages/py-ray/package.py
+++ b/var/spack/repos/builtin/packages/py-ray/package.py
@@ -18,11 +18,12 @@ class PyRay(PythonPackage):
 
     build_directory = 'python'
 
-    depends_on('python@3.6:', type=('build', 'run'))
+    depends_on('python@3.6:3.8', type=('build', 'run'))
     depends_on('bazel@3.2.0', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-cython@0.29.14:', type='build')
     depends_on('py-wheel', type='build')
+    depends_on('npm', type='build')
     depends_on('py-aiohttp', type=('build', 'run'))
     depends_on('py-aioredis', type=('build', 'run'))
     depends_on('py-click@7.0:', type=('build', 'run'))
@@ -42,3 +43,15 @@ class PyRay(PythonPackage):
     depends_on('py-redis@3.3.2:3.4', type=('build', 'run'))
     depends_on('py-opencensus', type=('build', 'run'))
     depends_on('py-prometheus-client@0.7.1:', type=('build', 'run'))
+    depends_on('py-setproctitle', type=('build', 'run'))
+    depends_on('py-psutil', type=('build', 'run'))
+    depends_on('py-pickle5', type=('build', 'run'))
+
+    def setup_build_environment(self, env):
+        env.set('SKIP_THIRDPARTY_INSTALL', '1')
+
+    # Compile the dashboard npm modules included in the project
+    @run_before('install')
+    def build_dashboard(self):
+        sh = which('sh')
+        sh('-c', 'cd python/ray/dashboard/client && npm ci && npm run build')

--- a/var/spack/repos/builtin/packages/py-ray/package.py
+++ b/var/spack/repos/builtin/packages/py-ray/package.py
@@ -43,8 +43,12 @@ class PyRay(PythonPackage):
     depends_on('py-redis@3.3.2:3.4', type=('build', 'run'))
     depends_on('py-opencensus', type=('build', 'run'))
     depends_on('py-prometheus-client@0.7.1:', type=('build', 'run'))
+    # If not guarded by SKIP_THIRDPARTY_INSTALL, those dependencies
+    # would be automatically installed via pip by the setup.py script.
     depends_on('py-setproctitle', type=('build', 'run'))
     depends_on('py-psutil', type=('build', 'run'))
+    # If not detected during install, the following dependency would
+    # be automatically downloaded and installed by the setup.py script.
     depends_on('py-pickle5', when='^python@:3.8.1', type=('build', 'run'))
 
     def setup_build_environment(self, env):

--- a/var/spack/repos/builtin/packages/py-ray/package.py
+++ b/var/spack/repos/builtin/packages/py-ray/package.py
@@ -57,5 +57,7 @@ class PyRay(PythonPackage):
     # Compile the dashboard npm modules included in the project
     @run_before('install')
     def build_dashboard(self):
-        sh = which('sh')
-        sh('-c', 'cd python/ray/dashboard/client && npm ci && npm run build')
+        with working_dir(join_path('python', 'ray', 'dashboard', 'client')):
+            npm = which('npm')
+            npm('ci')
+            npm('run', 'build')

--- a/var/spack/repos/builtin/packages/py-ray/package.py
+++ b/var/spack/repos/builtin/packages/py-ray/package.py
@@ -45,7 +45,7 @@ class PyRay(PythonPackage):
     depends_on('py-prometheus-client@0.7.1:', type=('build', 'run'))
     depends_on('py-setproctitle', type=('build', 'run'))
     depends_on('py-psutil', type=('build', 'run'))
-    depends_on('py-pickle5', type=('build', 'run'))
+    depends_on('py-pickle5', when='^python@:3.8.1', type=('build', 'run'))
 
     def setup_build_environment(self, env):
         env.set('SKIP_THIRDPARTY_INSTALL', '1')


### PR DESCRIPTION
When installing `py-ray` on a recent spack release, I noted a few issues. I didn't want to open the rabbit hole of packaging all ulterior versions of `py-ray` and figuring out if and when the system changed, so this is a bugfix for the currently packaged version.

 * Only Python up to version 3.8 is supported for this version: https://github.com/ray-project/ray/blob/89fd21ff610f237691908997d12fa9ee465e68d4/python/setup.py#L30
 * Installing from source requires building the dashboard code prior to install using npm:  https://github.com/ray-project/ray/blob/89fd21ff610f237691908997d12fa9ee465e68d4/python/ray/dashboard/dashboard.py#L407-L414
 * `py-pickle5` backport is required when using older python versions: https://github.com/ray-project/ray/blob/89fd21ff610f237691908997d12fa9ee465e68d4/python/setup.py#L261-L270
 * `py-setproctitle` and `py-psutil` have a special install code path that needs to be bypassed in order to depend on their spack packaged versions: https://github.com/ray-project/ray/blob/89fd21ff610f237691908997d12fa9ee465e68d4/python/setup.py#L272-L283

I am unsure my dependency on `py-pickle5` is correct for all version of python as the installer seems to be testing for the python version to detect if it is already present, but I am unsure how to express this constraint correctly. I will add a suggestion to the PR with what I think should be the correct dependency. I may be wrong and maybe `py-pickle5` backport only presents a different interface when confronted with a recent python.