### PR TITLE
Fix spack style arbitrary git rev as base

### DIFF
--- a/lib/spack/spack/cmd/style.py
+++ b/lib/spack/spack/cmd/style.py
@@ -94,16 +94,16 @@ def changed_files(base="develop", untracked=True, all_files=False, root=None):
     git = which("git", required=True)
 
     # ensure base is in the repo
-    git("show-ref", "--verify", "--quiet", "refs/heads/%s" % base,
-        fail_on_error=False)
+    base_sha = git("rev-parse", "--quiet", "--verify", "--revs-only", base,
+                   fail_on_error=False, output=str)
     if git.returncode != 0:
         tty.die(
-            "This repository does not have a '%s' branch." % base,
+            "This repository does not have a '%s' revision." % base,
             "spack style needs this branch to determine which files changed.",
             "Ensure that '%s' exists, or specify files to check explicitly." % base
         )
 
-    range = "{0}...".format(base)
+    range = "{0}...".format(base_sha.strip())
 
     git_args = [
         # Add changed files committed since branching off of develop

--- a/lib/spack/spack/test/cmd/style.py
+++ b/lib/spack/spack/test/cmd/style.py
@@ -98,6 +98,26 @@ def test_changed_files(flake8_package):
     assert flake8_package in files
 
 
+def test_changed_files_from_git_rev_base(tmpdir, capfd):
+    """Test arbitrary git ref as base."""
+    git = which("git", required=True)
+    with tmpdir.as_cwd():
+        git("init")
+        git("checkout", "-b", "main")
+        git("config", "user.name", "test user")
+        git("config", "user.email", "test@user.com")
+        git("commit", "--allow-empty", "-m", "initial commit")
+
+        tmpdir.ensure('bin/spack')
+        assert changed_files(base="HEAD") == ['bin/spack']
+        assert changed_files(base="main") == ['bin/spack']
+
+        git("add", 'bin/spack')
+        git("commit", "-m", "v1")
+        assert changed_files(base="HEAD") == []
+        assert changed_files(base="HEAD~") == ["bin/spack"]
+
+
 def test_changed_no_base(tmpdir, capfd):
     """Ensure that we fail gracefully with no base branch."""
     tmpdir.join("bin").ensure("spack")
@@ -113,7 +133,7 @@ def test_changed_no_base(tmpdir, capfd):
             changed_files(base="foobar")
 
         out, err = capfd.readouterr()
-        assert "This repository does not have a 'foobar' branch." in err
+        assert "This repository does not have a 'foobar'" in err
 
 
 def test_changed_files_all_files(flake8_package):


### PR DESCRIPTION
Since spack 0.17 #25085, the `spack style -b <rev>` only supports local git branches.

This PR allows `spack style` argument `-b BASE, --base BASE` to support arbitrary git revisions again.

For example:

```sh
spack style -b HEAD  # Check working-copy changes only
spack style -b @~    # Check working-copy + last commit
spack style -b origin/develop
spack style -b $CI_MERGE_REQUEST_DIFF_BASE_SHA
```
