### PR TITLE
libaec: Update fetching url

### DIFF
--- a/var/spack/repos/builtin/packages/libaec/package.py
+++ b/var/spack/repos/builtin/packages/libaec/package.py
@@ -14,7 +14,7 @@ class Libaec(CMakePackage):
     """
 
     homepage = 'https://gitlab.dkrz.de/k202009/libaec'
-    url = 'https://gitlab.dkrz.de/api/v4/projects/k202009%2Flibaec/repository/archive.tar.gz?sha=v1.0.2'
+    url = 'https://gitlab.dkrz.de/k202009/libaec/-/archive/v1.0.6/libaec-v1.0.6.tar.gz'
     list_url = 'https://gitlab.dkrz.de/k202009/libaec/tags'
 
     provides('szip')


### PR DESCRIPTION
Fixes "Error: CommandNotFoundError: Cannot extract archive, unrecognized file extension: 'None' "

```
~> spack install libaec
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/pkgconf-1.8.0-yqxzvyqv7lhwnq2acl55cyikozqgp4su
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/berkeley-db-18.1.40-edodxkqiwox5e4tg2mvmhybt5apewhzf
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/libiconv-1.16-wxsle6to5i3hjh2ftsdbfhvspclaqso2
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/zlib-1.2.12-vzgxdgpqcp6m6ifh5so3i5vogvozke2h
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/ncurses-6.2-vklfhfi77booblf2ldsjv2wegxob7g3f
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/diffutils-3.8-w33kkr7hqs77o5nbxyrrmedygcphe32m
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/readline-8.1-rkackfyyonhktztf3cq7aboz7kiispzc
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/bzip2-1.0.8-2u3k4bs3am2324fkyhh2sar4w4odhcql
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/gdbm-1.19-vrjlqrczcymdcffeq3us55o3yxilvmhu
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/perl-5.34.1-tjrn4gt57hlnerznn2hqnqebrdikb4do
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/openssl-1.1.1o-t73rgdcvju2vvdetaijgsj275gpvzv2j
[+] /dss/spack_original/opt/spack/linux-sles15-haswell/gcc-11.2.0/cmake-3.23.2-ldowipaajqg6syml3xrgyn3vqaxtyyae
==> Installing libaec-1.0.6-sxezmjpyedvhpdw2mr6tqxh36wdqw4gd
==> No binary for libaec-1.0.6-sxezmjpyedvhpdw2mr6tqxh36wdqw4gd found: installing from source
==> Using cached archive: /dss//spack_original/var/spack/cache/_source-cache/archive/ab/abab8c237d85c982bb4d6bde9b03c1f3d611dcacbd58bca55afac2496d61d4be.tar.gz
==> Error: CommandNotFoundError: Cannot extract archive, unrecognized file extension: 'None'

/dss/spack_original/lib/spack/spack/package_base.py:1570, in do_stage:
       1567
       1568        # Fetch/expand any associated code.
       1569        if self.has_code:
  >>   1570            self.do_fetch(mirror_only)
       1571            self.stage.expand_archive()
       1572
       1573            if not os.listdir(self.stage.path):
```