### PR TITLE
OpenCV: add v4.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/opencv/package.py
+++ b/var/spack/repos/builtin/packages/opencv/package.py
@@ -19,6 +19,7 @@ class Opencv(CMakePackage, CudaPackage):
     maintainers = ["bvanessen", "adamjstewart", "glennpj"]
 
     version("master", branch="master")
+    version('4.6.0', sha256='1ec1cba65f9f20fe5a41fda1586e01c70ea0c9a6d7b67c9e13edf0cfe2239277')
     version(
         "4.5.4",
         sha256="c20bb83dd790fc69df9f105477e24267706715a9d3c705ca1e7f613c7b3bad3d",
@@ -116,6 +117,7 @@ class Opencv(CMakePackage, CudaPackage):
         "4.5.1",
         "4.5.2",
         "4.5.4",
+        "4.6.0",
     ]
     for cv in contrib_vers:
         resource(
@@ -140,7 +142,7 @@ class Opencv(CMakePackage, CudaPackage):
     patch("opencv3.4.12_clp_cmake.patch", when="@3.4.12")
     patch("opencv3.3_clp_cmake.patch", when="@:3.4.6")
 
-    patch("opencv3.4.4_cvv_cmake.patch", when="@3.4.4:")
+    patch("opencv3.4.4_cvv_cmake.patch", when="@3.4.4:4.5")
     patch("opencv3.3_cvv_cmake.patch", when="@:3.4.3")
 
     # OpenCV prebuilt apps (variants)
@@ -809,6 +811,7 @@ class Opencv(CMakePackage, CudaPackage):
     depends_on("cudnn@:6", when="@:3.3.0+cudnn")
     depends_on("eigen", when="+eigen")
     depends_on("ffmpeg+avresample", when="+ffmpeg")
+    depends_on("ffmpeg@:4+avresample", when="@:4.5+ffmpeg")
     depends_on("gdal", when="+gdal")
     depends_on("gtkplus", when="+gtk")
     depends_on("hpx", when="+hpx")
@@ -882,6 +885,10 @@ class Opencv(CMakePackage, CudaPackage):
     conflicts("+win32ui", when="platform=darwin", msg="Windows only")
     conflicts("+win32ui", when="platform=linux", msg="Windows only")
     conflicts("+win32ui", when="platform=cray", msg="Windows only")
+
+    # https://github.com/opencv/opencv/wiki/ChangeLog#version460
+    conflicts('%gcc@12:', when='@:4.5')
+    conflicts('%clang@15:', when='@:4.5')
 
     @classmethod
     def determine_version(cls, lib):


### PR DESCRIPTION
Successfully installs on macOS 12.4 (Apple M1 Pro) with Apple Clang 13.1.6.

https://github.com/opencv/opencv/wiki/ChangeLog#version460