### PR TITLE
Staging: determine extensions from nonstandard URLs

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -521,7 +521,7 @@ class URLFetchStrategy(FetchStrategy):
                 "Failed on expand() for URL %s" % self.url)
 
         if not self.extension:
-            self.extension = extension(self.archive_file)
+            self.extension = extension(self.url)
 
         if self.stage.expanded:
             tty.debug('Source already staged to %s' % self.stage.source_path)

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -246,7 +246,7 @@ unable to extract %s files. 7z can be installed via Spack" % ext)
     return outfile
 
 
-def decompressor_for(path, ext=None):
+def decompressor_for(path, ext):
     """Returns a function pointer to appropriate decompression
     algorithm based on extension type.
 
@@ -254,9 +254,6 @@ def decompressor_for(path, ext=None):
         path (str): path of the archive file requiring decompression
         ext (str): Extension of archive file
     """
-    if not ext:
-        ext = extension(path)
-
     if not allowed_archive(ext):
         raise CommandNotFoundError("Cannot extract archive, \
 unrecognized file extension: '%s'" % ext)


### PR DESCRIPTION
Fixes https://github.com/spack/spack/issues/31021

With https://github.com/spack/spack/pull/25185, we no longer default to using `tar` when we can't determine the extension type, opting to fail instead.

This broke fetching for the `pcre` package, where we couldn't determine the extension. To determine the extension, we were attempting to extract it from the destination filename; however, this file name may omit details of the origin URL that are required to determine the extension, so instead we examine the URL directly.

This also updates the `decompressor_for` method not to set `ext=None` by default: it must now always be set by the caller.