### PR TITLE
Update py-ytopt to package latest version

### DIFF
--- a/var/spack/repos/builtin/packages/py-ytopt/package.py
+++ b/var/spack/repos/builtin/packages/py-ytopt/package.py
@@ -15,6 +15,7 @@ class PyYtopt(PythonPackage):
     homepage = "https://github.com/ytopt-team/ytopt"
     url      = "https://github.com/ytopt-team/ytopt/archive/refs/tags/v0.0.1.tar.gz"
 
+    version('0.0.4', sha256='4e47315b658f1943f756816455ae491818c37b0f700dd895a97fb7792bb49e35')
     version('0.0.3', sha256='eac6ab87d4fd27517f136880016359c5b24836ec009e8cc9b4073a6c5edb17af')
     version('0.0.2', sha256='5a624aa678b976ff6ef867610bafcb0dfd5c8af0d880138ca5d56d3f776e6d71')
     version('0.0.1', sha256='3ca616922c8e76e73f695a5ddea5dd91b0103eada726185f008343cc5cbd7744')

--- a/var/spack/repos/builtin/packages/py-ytopt/package.py
+++ b/var/spack/repos/builtin/packages/py-ytopt/package.py
@@ -28,7 +28,7 @@ class PyYtopt(PythonPackage):
     depends_on('py-dh-scikit-optimize', type=('build', 'run'))
     depends_on('py-configspace', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
-    depends_on('py-ytopt-autotune@1.1:', type=('build', 'run'))
+    depends_on('py-ytopt-autotune@1.0.0', type=('build', 'run'))
     depends_on('py-joblib', type=('build', 'run'))
     depends_on('py-deap', type=('build', 'run'))
     depends_on('py-tqdm', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ytopt/package.py
+++ b/var/spack/repos/builtin/packages/py-ytopt/package.py
@@ -29,7 +29,7 @@ class PyYtopt(PythonPackage):
     depends_on('py-dh-scikit-optimize', type=('build', 'run'))
     depends_on('py-configspace', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
-    depends_on('py-ytopt-autotune@1.0.0', type=('build', 'run'))
+    depends_on('py-ytopt-autotune@1.0.0:1.0.999', type=('build', 'run'))
     depends_on('py-joblib', type=('build', 'run'))
     depends_on('py-deap', type=('build', 'run'))
     depends_on('py-tqdm', type=('build', 'run'))


### PR DESCRIPTION
This add support for `py-ytopt` v0.0.4, and rollbacks the required version of `py-ytopt-autotune` that was causing compatibility issues.