### PR TITLE
try bootstrap store python paths at start and end

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -83,7 +83,7 @@ def _try_import_from_store(module, query_spec, query_info=None):
         module_paths = [
             os.path.join(candidate_spec.prefix, pkg.purelib),
             os.path.join(candidate_spec.prefix, pkg.platlib),
-        ] # type: list[str]
+        ]  # type: list[str]
         path_before = list(sys.path)
         orders = [
             module_paths + sys.path,

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -80,10 +80,10 @@ def _try_import_from_store(module, query_spec, query_info=None):
 
     for candidate_spec in installed_specs:
         pkg = candidate_spec['python'].package
-        module_paths = {
+        module_paths = [
             os.path.join(candidate_spec.prefix, pkg.purelib),
             os.path.join(candidate_spec.prefix, pkg.platlib),
-        }
+        ] # type: list[str]
         path_before = list(sys.path)
         orders = [
             module_paths + sys.path,

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -85,6 +85,10 @@ def _try_import_from_store(module, query_spec, query_info=None):
             os.path.join(candidate_spec.prefix, pkg.platlib),
         ]  # type: list[str]
         path_before = list(sys.path)
+        # NOTE: try module_paths first and last, last allows an existing version in path
+        # to be picked up and used, possibly depending on something in the store, first
+        # allows the bootstrap version to work when an incompatible version is in
+        # sys.path
         orders = [
             module_paths + sys.path,
             sys.path + module_paths,


### PR DESCRIPTION
This allows bootstrapped modules to work when partial or incompatible modules exist in the module path.

Addresses point one in #31030 

