### PR TITLE
bootstrap: account for disabled sources

### DIFF
--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -458,7 +458,7 @@ def _make_bootstrapper(conf):
 
 def _validate_source_is_trusted(conf):
     trusted, name = spack.config.get('bootstrap:trusted'), conf['name']
-    if name not in trusted:
+    if not trusted.get(name, False):
         raise ValueError('source is not trusted')
 
 

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -456,7 +456,8 @@ def _make_bootstrapper(conf):
     return _bootstrap_methods[btype](conf)
 
 
-def _validate_source_is_trusted(conf):
+def source_is_enabled_or_raise(conf):
+    """Raise ValueError if the source is not enabled for bootstrapping"""
     trusted, name = spack.config.get('bootstrap:trusted'), conf['name']
     if not trusted.get(name, False):
         raise ValueError('source is not trusted')
@@ -529,7 +530,7 @@ def ensure_module_importable_or_raise(module, abstract_spec=None):
 
     for current_config in bootstrapping_sources():
         with h.forward(current_config['name']):
-            _validate_source_is_trusted(current_config)
+            source_is_enabled_or_raise(current_config)
 
             b = _make_bootstrapper(current_config)
             if b.try_import(module, abstract_spec):
@@ -571,7 +572,7 @@ def ensure_executables_in_path_or_raise(executables, abstract_spec):
 
     for current_config in bootstrapping_sources():
         with h.forward(current_config['name']):
-            _validate_source_is_trusted(current_config)
+            source_is_enabled_or_raise(current_config)
 
             b = _make_bootstrapper(current_config)
             if b.try_search_path(executables, abstract_spec):

--- a/lib/spack/spack/test/bootstrap.py
+++ b/lib/spack/spack/test/bootstrap.py
@@ -180,3 +180,20 @@ def test_status_function_find_files(
 
     _, missing = spack.bootstrap.status_message('optional')
     assert missing is expected_missing
+
+
+@pytest.mark.regression('31042')
+def test_source_is_disabled(mutable_config):
+    # Get the configuration dictionary of the current bootstrapping source
+    conf = next(iter(spack.bootstrap.bootstrapping_sources()))
+
+    # The source is not explicitly enabled or disabled, so the following
+    # call should raise to skip using it for bootstrapping
+    with pytest.raises(ValueError):
+        spack.bootstrap.source_is_enabled_or_raise(conf)
+
+    # Try to explicitly disable the source and verify that the behavior
+    # is the same as above
+    spack.config.add('bootstrap:trusted:{0}:{1}'.format(conf['name'], False))
+    with pytest.raises(ValueError):
+        spack.bootstrap.source_is_enabled_or_raise(conf)


### PR DESCRIPTION
Fix a bug introduced in #30192, which effectively skips any prescription on disabled bootstrapping sources.

Modifications:
- [x] Fix a bug that prevents to explicitly disable bootstrapping sources
- [x] Add unit test to prevent regression
