### PR TITLE
Cancel running workflows automatically on PR update

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -20,7 +20,7 @@ on:
     - cron: '16 2 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -19,6 +19,10 @@ on:
     # nightly at 2:16 AM
     - cron: '16 2 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
 
   fedora-clingo-sources:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -20,7 +20,7 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -19,6 +19,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   deploy-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -17,7 +17,7 @@ on:
       # TODO: run if we touch any of the recipes involved in this
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
   cancel-in-progress: true
 
 # GitHub Action Limits

--- a/.github/workflows/macos_python.yml
+++ b/.github/workflows/macos_python.yml
@@ -16,6 +16,10 @@ on:
       - '.github/workflows/macos_python.yml'
       # TODO: run if we touch any of the recipes involved in this
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 # GitHub Action Limits
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
 

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -9,6 +9,11 @@ on:
     branches:
       - develop
       - releases/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   # Validate that the code can be run on all the Python versions
   # supported by Spack

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -11,7 +11,7 @@ on:
       - releases/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - develop
       - releases/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell:

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -11,7 +11,7 @@ on:
       - releases/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_number }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
With this PR workflows should cancel automatically on pull request updates, but should instead continue to run on pushes to develop or release branches.