### PR TITLE
add igc external package

### DIFF
--- a/var/spack/repos/builtin/packages/oneapi-igc-external/package.py
+++ b/var/spack/repos/builtin/packages/oneapi-igc-external/package.py
@@ -1,0 +1,33 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class OneapiIgcExternal(Package):
+    """The Intel Graphics Compiler for OpenCL is an LLVM based compiler
+    for OpenCL targeting Intel Gen graphics hardware architecture.
+
+    """
+
+    homepage = "https://github.com/intel/intel-graphics-compiler"
+    has_code = False
+
+    maintainers = ['rscohn2']
+
+    version('1.0.10409')
+    version('1.0.8744')
+    version('1.0.8517')
+
+    provides('igc')
+
+    def install(self, spec, prefix):
+        raise InstallError(
+            self.spec.format('{name} is not installable, you need to specify '
+                             'it as an external package in packages.yaml'))
+
+    @property
+    def libs(self):
+        return find_libraries(['libigc'], root=self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/oneapi-igc/package.py
+++ b/var/spack/repos/builtin/packages/oneapi-igc/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class OneapiIgcExternal(Package):
+class OneapiIgc(Package):
     """The Intel Graphics Compiler for OpenCL is an LLVM based compiler
     for OpenCL targeting Intel Gen graphics hardware architecture.
 
@@ -20,8 +20,6 @@ class OneapiIgcExternal(Package):
     version('1.0.10409')
     version('1.0.8744')
     version('1.0.8517')
-
-    provides('igc')
 
     def install(self, spec, prefix):
         raise InstallError(


### PR DESCRIPTION
Enabling linking with igc through a package that relies on an external installation.

@jmellorcrummey: Please try this.

You need to add a:
```
depends_on('igc')
```

and add this to your ``~/.spack/packages.yaml``
```
packages:
  oneapi-igc-external:
    externals:
    - spec: oneapi-igc-external@1.0.10409
      prefix: /usr
```
