### PR TITLE
Add simple-dftd3 package and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/dftd4/package.py
+++ b/var/spack/repos/builtin/packages/dftd4/package.py
@@ -28,6 +28,7 @@ class Dftd4(MesonPackage):
     depends_on("blas")
     depends_on("cmake", type="build")
     depends_on("lapack")
+    depends_on("mctc-lib")
     depends_on("meson@0.57.1:", type="build")  # mesonbuild/meson#8377
     depends_on("pkgconfig", type="build")
     depends_on("py-cffi", when="+python")
@@ -43,6 +44,7 @@ class Dftd4(MesonPackage):
             lapack = "auto"
 
         return [
+            "--wrap-mode=nodownload",
             "-Dlapack={0}".format(lapack),
             "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
             "-Dpython={0}".format(str("+python" in self.spec).lower()),

--- a/var/spack/repos/builtin/packages/json-fortran/package.py
+++ b/var/spack/repos/builtin/packages/json-fortran/package.py
@@ -10,22 +10,34 @@ class JsonFortran(CMakePackage):
     """A Fortran 2008 JSON API"""
 
     homepage = "https://jacobwilliams.github.io/json-fortran/"
-    url      = "https://github.com/jacobwilliams/json-fortran/archive/7.0.0.tar.gz"
+    url = "https://github.com/jacobwilliams/json-fortran/archive/8.3.0.tar.gz"
+    git = "https://github.com/jacobwilliams"
 
-    version('7.1.0', sha256='e7aa1f6e09b25ebacb17188147380c3f8c0a254754cd24869c001745fcecc9e6')
-    version('7.0.0', sha256='9b5b6235489b27d572bbc7620ed8e039fa9d4d14d41b1581b279be9db499f32c')
-    version('6.11.0', sha256='0ce38236a0debcd775108684b835f9f92ca9d6594da714c0025014fe9f03eec3')
+    version("master", branch="master")
+    version("8.3.0", "5fe9ad709a726416cec986886503e0526419742e288c4e43f63c1c22026d1e8a")
+    version("8.2.5", "16eec827f64340c226ba9a8463f001901d469bc400a1e88b849f258f9ef0d100")
+    version("8.2.4", "7b4e0aecdb92705918f15e3094022325bb14c9ea620d7eba6a4facf9ef8f27f3")
+    version("8.2.3", "884ef4f955eecaf18d52e818738089ab3924981fb510ef3671ad3f62ac7c6af1")
+    version("8.2.2", "3228496c9a10aa01da7694196ec5cd8cd463099be734207dac93e2097ea5279d")
+    version("8.2.1", "428fb2e708cce3a29f9bbc84ce63f112a2eb44fd1b0d2a88d83c86583ca83ed4")
+    version("8.2.0", "df9986c4ecad996f3be3d6855397141e63721207fe90e1500ae0df587d46481f")
+    version("8.1.0", "4f4b3bf102d7e22327b0e4b8a3cadd8c3e453c969547ec21cd2429ed7d4c5404")
+    version("8.0.0", "2c9c62117a2548e2cddf55acf7b726b529c044ed0f1eefe14dc69910a54a7bfd")
+    version("7.1.0", "e7aa1f6e09b25ebacb17188147380c3f8c0a254754cd24869c001745fcecc9e6")
+    version("7.0.0", "9b5b6235489b27d572bbc7620ed8e039fa9d4d14d41b1581b279be9db499f32c")
+    version("6.11.0", "0ce38236a0debcd775108684b835f9f92ca9d6594da714c0025014fe9f03eec3")
 
-    depends_on('cmake@2.8.8:', type='build')
+    depends_on("cmake@2.8.8:", type="build")
 
     def cmake_args(self):
         return [
-            '-DSKIP_DOC_GEN:BOOL=ON',
-            '-DUSE_GNU_INSTALL_CONVENTION=ON',
+            "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+            "-DSKIP_DOC_GEN:BOOL=ON",
+            "-DUSE_GNU_INSTALL_CONVENTION=ON",
         ]
 
     def check(self):
         # `make check` works but `make test` doesn't:
         # https://github.com/jacobwilliams/json-fortran/issues/154
         with working_dir(self.build_directory):
-            make('check')
+            make("check")

--- a/var/spack/repos/builtin/packages/mctc-lib/package.py
+++ b/var/spack/repos/builtin/packages/mctc-lib/package.py
@@ -1,0 +1,31 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class MctcLib(MesonPackage):
+    """Modular computation toolchain library for quantum chemistry file IO"""
+
+    homepage = "https://github.com/grimme-lab/mctc-lib"
+    url      = "https://github.com/grimme-lab/mctc-lib/releases/download/v0.3.0/mctc-lib-0.3.0.tar.xz"
+    git = "https://github.com/grimme-lab/mctc-lib"
+
+    maintainers = ["awvwgk"]
+
+    version("main", branch="main")
+    version('0.3.0', '81f3edbf322e6e28e621730a796278498b84af0f221f785c537a315312059bf0')
+
+    variant("json", default=False, description="Enable support for JSON")
+
+    depends_on("meson@0.57.2:", type="build")
+    depends_on("json-fortran@8:", when="+json")
+    depends_on("pkgconfig", type="build")
+
+    def meson_args(self):
+        return [
+            "--wrap-mode=nodownload",
+            "-Djson={0}".format("enabled" if "+json" in self.spec else "disabled"),
+        ]

--- a/var/spack/repos/builtin/packages/simple-dftd3/package.py
+++ b/var/spack/repos/builtin/packages/simple-dftd3/package.py
@@ -1,0 +1,40 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class SimpleDftd3(MesonPackage):
+    """
+    Simple reimplementation of the DFT-D3 dispersion correction
+    """
+
+    homepage = "https://dftd3.readthedocs.io"
+    url      = "https://github.com/dftd3/simple-dftd3/releases/download/v0.6.0/s-dftd3-0.6.0-source.tar.xz"
+    git = "https://github.com/dftd3/simple-dftd3.git"
+
+    maintainers = ["awvwgk"]
+
+    version("main", branch="main")
+    version('0.6.0', 'c057361565f570cb128489c70131487f71b6891a40e5292dfe37041596810dfe')
+    version('0.5.1', '0411fdaebe438f652a970cb232ae3199c4cc840366ed05fda4c38e634632040d')
+
+    variant("openmp", default=True, description="Use OpenMP parallelisation")
+    variant("python", default=False, description="Build Python extension module")
+
+    depends_on("mctc-lib")
+    depends_on("meson@0.57.1:", type="build")  # mesonbuild/meson#8377
+    depends_on("pkgconfig", type="build")
+    depends_on("toml-f")
+    depends_on("py-cffi", when="+python")
+    depends_on("python@3.6:", when="+python")
+
+    def meson_args(self):
+
+        return [
+            "--wrap-mode=nodownload",
+            "-Dopenmp={0}".format(str("+openmp" in self.spec).lower()),
+            "-Dpython={0}".format(str("+python" in self.spec).lower()),
+        ]

--- a/var/spack/repos/builtin/packages/toml-f/package.py
+++ b/var/spack/repos/builtin/packages/toml-f/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class TomlF(MesonPackage):
+    """
+    TOML parser implementation for data serialization and deserialization in Fortran
+    """
+
+    homepage = "https://toml-f.readthedocs.io"
+    url = "https://github.com/toml-f/toml-f/releases/download/v0.2.3/toml-f-0.2.3.tar.xz"
+    git = "https://github.com/toml-f/toml-f.git"
+
+    maintainers = ["awvwgk"]
+
+    version("main", branch="main")
+    version("0.2.3", "2dca7ff6d3e35415cd92454c31560d2b656c014af8236be09c54c13452e4539c")
+
+    depends_on("meson@0.57.2:", type="build")
+
+    def meson_args(self):
+        return [
+            "--wrap-mode=nodownload",
+        ]


### PR DESCRIPTION
- add [simple-dftd3](https://github.com/dftd3/simple-dftd3) (version 0.6.0, 0.5.1)
- add [mctc-lib](https://github.com/grimme-lab/mctc-lib) (version 0.3.0)
- add [toml-f](https://github.com/toml-f/toml-f) (version 0.2.3)
- update [dftd4](https://github.com/dftd4/dftd4) (version 3.4.0, use mctc-lib as actual dependency)
- update [json-fortran](https://github.com/jacobwilliams/json-fortran) (version 8.*, make static library PIC)