### PR TITLE
spack-compiler-wrapper: new package

### DIFF
--- a/var/spack/repos/builtin/packages/spack-compiler-wrapper/package.py
+++ b/var/spack/repos/builtin/packages/spack-compiler-wrapper/package.py
@@ -1,0 +1,21 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class SpackCompilerWrapper(MakefilePackage):
+    """An LD_PRELOAD'able exec() family symbol intercepting compiler wrapper
+    for Spack on Linux."""
+
+    homepage = "https://github.com/haampie/spack-compiler-wrapper"
+    url      = "https://github.com/haampie/spack-compiler-wrapper/archive/refs/tags/v0.1.1.tar.gz"
+
+    maintainers = ['haampie']
+
+    version('0.1.1', sha256='66a0bf60a710236173823988294ef68419a73e63cea4a455a248b8faa506201b')
+
+    def install(self, spec, prefix):
+        make('install', 'prefix={}'.format(prefix))


### PR DESCRIPTION
`spack-compiler-wrapper` provides a library `spack-compiler-wrapper.so`, which
can be `LD_PRELOAD`'ed so that it intercepts libc's `exec()` family when the
executable has libc dynamically linked. This is more powerful than Spack's
current compiler wrapper, since Spack can't intercept calls to compilers or
linkers by absolute path.

Currently it intercepts:

```
$ nm --dynamic --defined-only <prefix>/libexec/spack-compiler-wrapper.so 
0000000000004fa2 T execl
00000000000052e0 T execle
0000000000005141 T execlp
00000000000054c6 T execv
0000000000004be2 T execve
00000000000054f9 T execvp
0000000000004d0a T execvpe
0000000000004e32 T posix_spawn
```