### PR TITLE
lua-mpack: build with -fPIC always

### DIFF
--- a/var/spack/repos/builtin/packages/lua-mpack/package.py
+++ b/var/spack/repos/builtin/packages/lua-mpack/package.py
@@ -33,4 +33,4 @@ class LuaMpack(LuaPackage):
     )
 
     def luarocks_args(self):
-        return ["CFLAGS='-Wno-error=implicit-function-declaration'"]
+        return ["CFLAGS=-fPIC -Wno-error=implicit-function-declaration"]


### PR DESCRIPTION
lua-mpack fails to build on the following platform, this resolves it.

* **Spack:** 0.19.0.dev0 (fb173f80b2de32e158e2c3837f93d988266705a1)
* **Python:** 3.6.15
* **Platform:** cray-sles15-zen3
* **Concretizer:** clingo

@trws 