### PR TITLE
bugfix: unable to extract a module's path on some Cray systems.

### DIFF
--- a/lib/spack/spack/util/module_cmd.py
+++ b/lib/spack/spack/util/module_cmd.py
@@ -209,6 +209,10 @@ def get_path_from_module_contents(text, module_name):
         pattern = r'MANPATH'
         match_pattern_and_strip(line, pattern, man_endings)
 
+        # Check entries that update the MODULEPATH variable
+        pattern = r'\WMODULEPATH'
+        match_pattern_and_strip(line, pattern, bin_endings)
+
         # Check entries that add a `-rpath` flag to a variable
         match_flag_and_strip(line, '-rpath', lib_endings)
 


### PR DESCRIPTION
Found this while debugging a spack problem with @vsrana01. We have an instance of a module that only modifies MODULEPATH. The existing spack heuristics couldn't catch it and it was causing environments that use modules to fail.

