### PR TITLE
julia: 1.8.0-rc1

### DIFF
--- a/var/spack/repos/builtin/packages/julia/llvm-NDEBUG-1.8.patch
+++ b/var/spack/repos/builtin/packages/julia/llvm-NDEBUG-1.8.patch
@@ -1,0 +1,27 @@
+From c9c2082a162e916d0f86241453b30473dcd63044 Mon Sep 17 00:00:00 2001
+From: Harmen Stoppels <harmenstoppels@gmail.com>
+Date: Tue, 24 May 2022 14:03:48 +0200
+Subject: [PATCH] llvm: add NDEBUG when assertion mode is off
+
+`llvm-config --cxxflags` unfortunately does not set `-DNDEBUG`, which
+Julia needs to set correctly when including LLVM header files.
+---
+ src/Makefile | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/Makefile b/src/Makefile
+index e6d83b1e1f4e9..263a4b34155d6 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -110,6 +110,11 @@ PUBLIC_HEADER_TARGETS := $(addprefix $(build_includedir)/julia/,$(notdir $(PUBLI
+ LLVM_LDFLAGS := $(shell $(LLVM_CONFIG_HOST) --ldflags)
+ LLVM_CXXFLAGS := $(shell $(LLVM_CONFIG_HOST) --cxxflags)
+ 
++# llvm-config --cxxflags does not return -DNDEBUG
++ifeq ($(shell $(LLVM_CONFIG_HOST) --assertion-mode),OFF)
++LLVM_CXXFLAGS += -DNDEBUG
++endif
++
+ ifeq ($(JULIACODEGEN),LLVM)
+ ifneq ($(USE_SYSTEM_LLVM),0)
+ CG_LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs --system-libs)

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -151,6 +151,7 @@ class Julia(MakefilePackage):
 
     # Make sure Julia sets -DNDEBUG when including LLVM header files.
     patch('llvm-NDEBUG.patch', when='@1.7.0:1.7')
+    patch('llvm-NDEBUG-1.8.patch', when='@1.8.0:1.8')
 
     def patch(self):
         # The system-libwhich-libblastrampoline.patch causes a rebuild of docs as it

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -99,8 +99,8 @@ class Julia(MakefilePackage):
         'https://github.com/JuliaLang/llvm-project/compare/fed41342a82f5a3a9201819a82bf7a48313e296b...980d2f60a8524c5546397db9e8bbb7d6ea56c1b7.patch',
         sha256='10cb42f80c2eaad3e9c87cb818b6676f1be26737bdf972c77392d71707386aa4'))
     depends_on('llvm', when='^llvm@13.0.1', patches=patch(
-        'https://github.com/JuliaLang/llvm-project/compare/75e33f71c2dae584b13a7d1186ae0a038ba98838...5393efbd8a4c7555b9f9fdf185c486c6b05f0c19.patch',
-        sha256='ce34b78f97c15af0ffae8fdf42ab47bae39185a9d3f314432860209756a34a91'))
+        'https://github.com/JuliaLang/llvm-project/compare/75e33f71c2dae584b13a7d1186ae0a038ba98838...2f4460bd46aa80d4fe0d80c3dabcb10379e8d61b.patch',
+        sha256='45f72c59ae5cf45461e9cd8b224ca49b739d885c79b3786026433c6c22f83b5f'))
 
     # Patches for libuv
     depends_on('libuv', when='^libuv@1.39.0', patches=patch(

--- a/var/spack/repos/builtin/packages/julia/package.py
+++ b/var/spack/repos/builtin/packages/julia/package.py
@@ -26,6 +26,7 @@ class Julia(MakefilePackage):
     maintainers = ['glennpj', 'vchuravy', 'haampie']
 
     version('master', branch='master')
+    version('1.8.0-rc1', sha256='ed0395880c32c48a284b115279d27d79ab1ca6fb53a4b97a8d25eba54ec97306')
     version('1.7.3', sha256='06df2a81e6a18d0333ffa58d36f6eb84934c38984898f9e0c3072c8facaa7306', preferred=True)
     version('1.7.2', sha256='0847943dd65001f3322b00c7dc4e12f56e70e98c6b798ccbd4f02d27ce161fef')
     version('1.7.1', sha256='17d298e50e4e3dd897246ccebd9f40ce5b89077fa36217860efaec4576aa718e')
@@ -52,7 +53,21 @@ class Julia(MakefilePackage):
     # but also so that llvm-config --libfiles gives only the dylib. Without
     # it it also gives static libraries, and breaks Julia's build.
     depends_on('llvm targets=amdgpu,bpf,nvptx,webassembly version_suffix=jl +link_llvm_dylib ~internal_unwind')
-    depends_on('libuv')
+    depends_on('libuv', when='@:1.7')
+    depends_on('libuv-julia', when='@1.8:')
+
+    with when('@1.8.0:1.8'):
+        # libssh2.so.1, libpcre2-8.so.0, mbedtls.so.14, mbedcrypto.so.7, mbedx509.so.1
+        # openlibm.so.4, libblastrampoline.so.5, libgit2.so.1.3, libnghttp2.so.14,
+        # libcurl.so.4
+        depends_on('libblastrampoline@5.1.0:5')
+        depends_on('libgit2@1.3.0:1.3')
+        depends_on('libssh2@1.10.0:1.10')
+        depends_on('libuv-julia@1.44.1')
+        depends_on('llvm@13.0.1 shlib_symbol_version=jl')
+        depends_on('mbedtls@2.28.0:2.28')
+        depends_on('openlibm@0.8.1:0.8', when='+openlibm')
+        depends_on('nghttp2@1.47.0:1.47')
 
     with when('@1.7.0:1.7'):
         # libssh2.so.1, libpcre2-8.so.0, mbedtls.so.13, mbedcrypto.so.5, mbedx509.so.1
@@ -76,16 +91,16 @@ class Julia(MakefilePackage):
         depends_on('openlibm@0.7.0:0.7', when='+openlibm')
 
     # Patches for llvm
-    depends_on('llvm', patches='llvm7-symver-jlprefix.patch')
+    depends_on('llvm', patches='llvm7-symver-jlprefix.patch', when='@:1.7')
     depends_on('llvm', when='^llvm@11.0.1', patches=patch(
         'https://raw.githubusercontent.com/spack/patches/0b543955683a903d711a3e95ff29a4ce3951ca13/julia/llvm-11.0.1-julia-1.6.patch',
         sha256='8866ee0595272b826b72d173301a2e625855e80680a84af837f1ed6db4657f42'))
     depends_on('llvm', when='^llvm@12.0.1', patches=patch(
         'https://github.com/JuliaLang/llvm-project/compare/fed41342a82f5a3a9201819a82bf7a48313e296b...980d2f60a8524c5546397db9e8bbb7d6ea56c1b7.patch',
         sha256='10cb42f80c2eaad3e9c87cb818b6676f1be26737bdf972c77392d71707386aa4'))
-    depends_on('llvm', when='^llvm@13.0.0', patches=patch(
-        'https://github.com/JuliaLang/llvm-project/compare/d7b669b3a30345cfcdb2fde2af6f48aa4b94845d...6ced34d2b63487a88184c3c468ceda166d10abba.patch',
-        sha256='92f022176ab85ded517a9b7aa04df47e19a5def88f291e0c31100128823166c1'))
+    depends_on('llvm', when='^llvm@13.0.1', patches=patch(
+        'https://github.com/JuliaLang/llvm-project/compare/75e33f71c2dae584b13a7d1186ae0a038ba98838...5393efbd8a4c7555b9f9fdf185c486c6b05f0c19.patch',
+        sha256='ce34b78f97c15af0ffae8fdf42ab47bae39185a9d3f314432860209756a34a91'))
 
     # Patches for libuv
     depends_on('libuv', when='^libuv@1.39.0', patches=patch(
@@ -179,6 +194,8 @@ class Julia(MakefilePackage):
         # LLVM compatible name for the JIT
         julia_cpu_target = get_best_target(spec.target, 'clang', spec['llvm'].version)
 
+        libuv = 'libuv-julia' if '^libuv-julia' in spec else 'libuv'
+
         options = [
             'prefix:={0}'.format(prefix),
             'MARCH:={0}'.format(march),
@@ -214,8 +231,8 @@ class Julia(MakefilePackage):
             'USE_BLAS64:=1',
             'LIBBLASNAME:={0}'.format(libblas),
             'LIBLAPACKNAME:={0}'.format(liblapack),
-            'override LIBUV:={0}'.format(spec['libuv'].libs.libraries[0]),
-            'override LIBUV_INC:={0}'.format(spec['libuv'].headers.directories[0]),
+            'override LIBUV:={0}'.format(spec[libuv].libs.libraries[0]),
+            'override LIBUV_INC:={0}'.format(spec[libuv].headers.directories[0]),
             'override USE_LLVM_SHLIB:=1',
             # make rebuilds a bit faster for now, not sure if this should be kept
             'JULIA_PRECOMPILE:={0}'.format(

--- a/var/spack/repos/builtin/packages/libblastrampoline/package.py
+++ b/var/spack/repos/builtin/packages/libblastrampoline/package.py
@@ -15,6 +15,7 @@ class Libblastrampoline(MakefilePackage):
 
     maintainers = ['haampie', 'giordano']
 
+    version('5.1.0', sha256='55ac0c8f9cb91b2ed2db014be8394c9dadf3b5f26bd8af6dca9d6f20ca72b8fd')
     version('5.0.2', sha256='2e96fa62957719351da3e4dff8cd0949449073708f5564dae0a224a556432356')
     version('5.0.1', sha256='1066b4d157276e41ca66ca94f0f8c2900c221b49da2df3c410e6f8bf1ce9b488')
     # v5.0.0 contains a bug, fixed in v5.0.1, which causes segmentation faults

--- a/var/spack/repos/builtin/packages/libuv-julia/package.py
+++ b/var/spack/repos/builtin/packages/libuv-julia/package.py
@@ -1,0 +1,17 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class LibuvJulia(AutotoolsPackage):
+    """Multi-platform library with a focus on asynchronous IO"""
+    homepage = "https://libuv.org"
+    url      = "https://github.com/JuliaLang/libuv/archive/refs/heads/julia-uv2-1.44.1.tar.gz"
+
+    version('1.44.1', sha256='f931e7825702cbb6d07486d92e5436990cf20f91e2b56d6f759822c0f832b13e')
+
+    @property
+    def libs(self):
+        return find_libraries(['libuv'], root=self.prefix, recursive=True)

--- a/var/spack/repos/builtin/packages/libuv-julia/package.py
+++ b/var/spack/repos/builtin/packages/libuv-julia/package.py
@@ -10,7 +10,11 @@ class LibuvJulia(AutotoolsPackage):
     homepage = "https://libuv.org"
     url      = "https://github.com/JuliaLang/libuv/archive/refs/heads/julia-uv2-1.44.1.tar.gz"
 
-    version('1.44.1', sha256='f931e7825702cbb6d07486d92e5436990cf20f91e2b56d6f759822c0f832b13e')
+    # julia's libuv fork doesn't tag releases, only has release branches, so we
+    # fix commits.
+    version('1.44.1',
+            sha256='f931e7825702cbb6d07486d92e5436990cf20f91e2b56d6f759822c0f832b13e',
+            url="https://github.com/JuliaLang/libuv/archive/1b2d16477fe1142adea952168d828a066e03ee4c.tar.gz")
 
     @property
     def libs(self):

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -177,6 +177,7 @@ class Llvm(CMakePackage, CudaPackage):
     variant("python", default=False, description="Install python bindings")
 
     variant('version_suffix', default='none', description="Add a symbol suffix")
+    variant('shlib_symbol_version', default='none', description="Add shared library symbol version", when='@13:')
     variant('z3', default=False, description='Use Z3 for the clang static analyzer')
 
     provides('libllvm@14', when='@14.0.0:14')
@@ -575,6 +576,11 @@ class Llvm(CMakePackage, CudaPackage):
         version_suffix = spec.variants['version_suffix'].value
         if version_suffix != 'none':
             cmake_args.append(define('LLVM_VERSION_SUFFIX', version_suffix))
+
+        shlib_symbol_version = spec.variants.get('shlib_symbol_version', None)
+        if shlib_symbol_version is not None and shlib_symbol_version.value != 'none':
+            cmake_args.append(define('LLVM_SHLIB_SYMBOL_VERSION',
+                              shlib_symbol_version.value))
 
         if python.version >= Version("3"):
             cmake_args.append(define("Python3_EXECUTABLE", python.command.path))

--- a/var/spack/repos/builtin/packages/nghttp2/package.py
+++ b/var/spack/repos/builtin/packages/nghttp2/package.py
@@ -13,6 +13,7 @@ class Nghttp2(AutotoolsPackage):
     homepage = "https://nghttp2.org/"
     url      = "https://github.com/nghttp2/nghttp2/releases/download/v1.26.0/nghttp2-1.26.0.tar.gz"
 
+    version('1.47.0', sha256='62f50f0e9fc479e48b34e1526df8dd2e94136de4c426b7680048181606832b7c')
     version('1.44.0', sha256='3e4824d02ae27eca931e0bb9788df00a26e5fd8eb672cf52cbb89c1463ba16e9')
     version('1.26.0', sha256='daf7c0ca363efa25b2cbb1e4bd925ac4287b664c3d1465f6a390359daa3f0cf1')
 

--- a/var/spack/repos/builtin/packages/openlibm/package.py
+++ b/var/spack/repos/builtin/packages/openlibm/package.py
@@ -15,6 +15,7 @@ class Openlibm(MakefilePackage):
 
     maintainers = ['haampie']
 
+    version('0.8.1', sha256='ba8a282ecd92d0033f5656bb20dfc6ea3fb83f90ba69291ac8f7beba42dcffcf')
     version('0.8.0', sha256='03620768df4ca526a63dd675c6de95a5c9d167ff59555ce57a61c6bf49e400ee')
     version('0.7.5', sha256='be983b9e1e40e696e8bbb7eb8f6376d3ca0ae675ae6d82936540385b0eeec15b')
 


### PR DESCRIPTION
I'm giving up on trying to add patches to libuv and instead I'd just add
libuv-julia; I don't think we need a virtual dependency here, since julia can't
depend on both libuv and libuv-julia.

