### PR TITLE
Fixed dependency on mesa so that it will be compatible with hip build

### DIFF
--- a/var/spack/repos/builtin/packages/hip/package.py
+++ b/var/spack/repos/builtin/packages/hip/package.py
@@ -44,6 +44,7 @@ class Hip(CMakePackage):
     depends_on('cmake@3.4.3:', type='build')
     depends_on('perl@5.10:', type=('build', 'run'))
     depends_on('gl@4.5:')
+    depends_on('mesa~llvm', when="^mesa")
 
     for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0', '4.0.0', '4.1.0',
                 '4.2.0', '4.3.0', '4.3.1']:


### PR DESCRIPTION
The hip package will only build against mesa when llvm variant is turned off in mesa.  This change makes this requirement automatic so that everyone doesn't have to discover it for themselves.