### PR TITLE
py-kornia: add v0.6.3, 0.6.4, 0.6.5

### DIFF
--- a/var/spack/repos/builtin/packages/py-kornia/package.py
+++ b/var/spack/repos/builtin/packages/py-kornia/package.py
@@ -12,6 +12,9 @@ class PyKornia(PythonPackage):
     homepage = "https://www.kornia.org/"
     pypi     = "kornia/kornia-0.5.10.tar.gz"
 
+    version('0.6.5', sha256='14cbd8b4064b3d0fb5a8198d1b5fd9231bcd62b9039351641fca6b294b5069f0')
+    version('0.6.4', sha256='ff60307a7244b315db43bfc4d4d6769094cf7d7494cf367c1d71a56343e2c50f')
+    version('0.6.3', sha256='0b689b5a47f55f2b08f61e6731760542cc3e3c09c3f0498164b934a3aef0bab3')
     version('0.6.2', sha256='eea722b3ff2f227a9ef8088cdab480cd40dd91d9138649bfd92cfa668204eea9')
     version('0.6.1', sha256='f638fb3309f88666545866c162f510b6d485fd8f7131d5570d4e6c0d295fdcd6')
     version('0.5.10', sha256='428b4b934a2ba7360cc6cba051ed8fd96c2d0f66611fdca0834e82845f14f65d')


### PR DESCRIPTION
Successfully installs on macOS 12.4 (Apple M1 Pro) with Python 3.9.12 and Apple Clang 13.1.6.