### PR TITLE
netpbm: run custom test command

### DIFF
--- a/var/spack/repos/builtin/packages/netpbm/package.py
+++ b/var/spack/repos/builtin/packages/netpbm/package.py
@@ -180,7 +180,6 @@ class Netpbm(MakefilePackage):
         # Run custom test command 'make check-tree'
         make('check-tree')
 
-
     def install(self, spec, prefix):
         bdir = join_path(self.build_directory, 'build')
         make('package', 'pkgdir={0}'.format(bdir), parallel=False)

--- a/var/spack/repos/builtin/packages/netpbm/package.py
+++ b/var/spack/repos/builtin/packages/netpbm/package.py
@@ -176,7 +176,7 @@ class Netpbm(MakefilePackage):
 
     @run_after('build')
     @on_package_attributes(run_tests=True)
-    def test(self):
+    def make_check_tree(self):
         # Run custom test command 'make check-tree'
         make('check-tree')
 

--- a/var/spack/repos/builtin/packages/netpbm/package.py
+++ b/var/spack/repos/builtin/packages/netpbm/package.py
@@ -170,6 +170,16 @@ class Netpbm(MakefilePackage):
 
     def build(self, spec, prefix):
         make()
+        if self.run_tests:
+            # Don't run the default command 'make check' for test
+            self.build_time_test_callbacks = []
+
+    @run_after('build')
+    @on_package_attributes(run_tests=True)
+    def test(self):
+        # Run custom test command 'make check-tree'
+        make('check-tree')
+
 
     def install(self, spec, prefix):
         bdir = join_path(self.build_directory, 'build')


### PR DESCRIPTION
Error message was shown as below when I run testcases with '--test' option.
      "Error: No directory named /tmp/netpbm/bin."

The reason is that the package in '/tmp/netpbm' should be maked using 'make package'  before running testcase with 'make check'.
Another test command 'make check-tree' is provided in spack-src/GNUmakefile without using 'make package'. 
So, this patch remove the default command 'make check' and run custum command 'make check-tree'.