### PR TITLE
Fix `tracy-client` package

### DIFF
--- a/var/spack/repos/builtin/packages/tracy-client/package.py
+++ b/var/spack/repos/builtin/packages/tracy-client/package.py
@@ -26,7 +26,7 @@ class TracyClient(CMakePackage):
         description="Build the client library as a shared library",
     )
 
-    variants = {
+    tracy_options = {
         "enable": (True, "Enable profiling"),
         "on_demand": (False, "On-demand profiling"),
         "callstack": (False, "Enfore callstack collection for tracy regions"),
@@ -65,13 +65,13 @@ class TracyClient(CMakePackage):
         "timer_fallback": (False, "Use lower resolution timers"),
     }
 
-    for k, v in variants.items():
+    for k, v in tracy_options.items():
         variant(k, default=v[0], description=v[1])
 
     def cmake_args(self):
         args = [
-            self.define_from_variant("TRACY_%s" + k.upper(), v[0])
-            for k, v in variants.items()
+            self.define_from_variant("TRACY_%s" % k.upper(), k)
+            for k in self.tracy_options
         ]
         args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
         return args


### PR DESCRIPTION
I'm not sure how I got into this situation, but clearly I didn't test #30588 properly before the final version.

`variants` replaced `variants` in `CMakePackage` and the string formatting for the CMake options was just wrong. This fixes those.