### PR TITLE
Bugfix: pcre download URL causes download type ambiguity

### DIFF
--- a/var/spack/repos/builtin/packages/pcre/package.py
+++ b/var/spack/repos/builtin/packages/pcre/package.py
@@ -12,7 +12,7 @@ class Pcre(AutotoolsPackage):
     pattern matching using the same syntax and semantics as Perl 5."""
 
     homepage = "https://www.pcre.org"
-    url      = "https://sourceforge.net/projects/pcre/files/pcre/8.42/pcre-8.42.tar.bz2/download"
+    url      = "https://sourceforge.net/projects/pcre/files/pcre/8.42/pcre-8.42.tar.bz2"
 
     version('8.45', sha256='4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8')
     version('8.44', sha256='19108658b23b3ec5058edc9f66ac545ea19f9537234be1ec62b714c84399366d')


### PR DESCRIPTION
This PR fixes a small bug found in the PCRE package recipe on certain machines. 

It seems like, on certain systems, the URL for the PCRE package was introducing ambiguity unnecessarily into the installation. On my machine (Ubuntu 22.04 LTS – Python 3.10.4), the package failed to download with the following error:
```
==> Installing pcre-8.45-fsrakjdbzjp4wizfn34bcjga3ug53zvk
==> No binary for pcre-8.45-fsrakjdbzjp4wizfn34bcjga3ug53zvk found: installing from source
==> Using cached archive: /home/cwwoods/spack/var/spack/cache/_source-cache/archive/4d/4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8.tar.bz2
==> Error: CommandNotFoundError: Cannot extract archive, unrecognized file extension: 'None'

/home/cwwoods/spack/lib/spack/spack/package_base.py:1570, in do_stage:
       1567
       1568        # Fetch/expand any associated code.
       1569        if self.has_code:
  >>   1570            self.do_fetch(mirror_only)
       1571            self.stage.expand_archive()
       1572
       1573            if not os.listdir(self.stage.path):
``` 
This was fixed by simply removing the `/download` at the end of the package URL, which is not required anyways when downloading from Sourceforge. 