### PR TITLE
legion: add HIP support

### DIFF
--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -65,6 +65,11 @@ class Legion(CMakePackage, ROCmPackage):
             values=('ROCM', 'CUDA'),
             description="API used by HIP",
             multi=False)
+
+    for arch in ROCmPackage.amdgpu_targets:
+        depends_on('kokkos@3.3.01:+rocm amdgpu_target={0}'.format(arch),
+                   when='+rocm amdgpu_target={0}'.format(arch))
+
     depends_on('kokkos@3.3.01:+rocm', when='+kokkos+rocm')
 
     depends_on('python@3', when='+python')

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -60,11 +60,13 @@ class Legion(CMakePackage, ROCmPackage):
 
     # HIP specific
     variant('hip_hijack', default=False,
-            description="Hijack application calls into the HIP runtime (+rocm).")
+            description="Hijack application calls into the HIP runtime",
+            when='+rocm')
     variant('hip_target', default='ROCM',
             values=('ROCM', 'CUDA'),
             description="API used by HIP",
-            multi=False)
+            multi=False,
+            when='+rocm')
 
     for arch in ROCmPackage.amdgpu_targets:
         depends_on('kokkos@3.3.01:+rocm amdgpu_target={0}'.format(arch),

--- a/var/spack/repos/builtin/packages/legion/package.py
+++ b/var/spack/repos/builtin/packages/legion/package.py
@@ -50,13 +50,13 @@ class Legion(CMakePackage):
     # TODO: we could use a map here to clean up and use naming vs. numbers.
     cuda_arch_list = ('60', '70', '75', '80')
     for nvarch in cuda_arch_list:
-        depends_on('kokkos@3.3.01+cuda+cuda_lambda+wrapper cuda_arch={0}'.format(nvarch),
+        depends_on('kokkos@3.3.01:+cuda+cuda_lambda+wrapper cuda_arch={0}'.format(nvarch),
                    when='%gcc+kokkos+cuda cuda_arch={0}'.format(nvarch))
-        depends_on("kokkos@3.3.01+cuda+cuda_lambda~wrapper cuda_arch={0}".format(nvarch),
+        depends_on("kokkos@3.3.01:+cuda+cuda_lambda~wrapper cuda_arch={0}".format(nvarch),
                    when="%clang+kokkos+cuda cuda_arch={0}".format(nvarch))
 
-    depends_on('kokkos@3.3.01~cuda', when='+kokkos~cuda')
-    depends_on("kokkos@3.3.01~cuda+openmp", when='+kokkos+openmp')
+    depends_on('kokkos@3.3.01:~cuda', when='+kokkos~cuda')
+    depends_on("kokkos@3.3.01:~cuda+openmp", when='+kokkos+openmp')
 
     depends_on('python@3', when='+python')
     depends_on('papi', when='+papi')


### PR DESCRIPTION
This PR adds initial HIP support to the Legion spackage.

It also removes the restriction to one particular Kokkos version.

If this is acceptable, it should probably replace at least parts of #24088.
We were encouraged by @pmccormick to submit a new PR instead.