### PR TITLE
openssh: don't suid-install ssh-keysign(not used by default)

### DIFF
--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -62,6 +62,10 @@ class Openssh(AutotoolsPackage):
         match = re.search(r'OpenSSH_([^, ]+)', output)
         return match.group(1) if match else None
 
+    def patch(self):
+        # #29938: skip set-suid (also see man ssh-key-sign: it's not enabled by default)
+        filter_file(r'\$\(INSTALL\) -m 4711', '$(INSTALL) -m711', 'Makefile.in')
+
     def configure_args(self):
         # OpenSSH's privilege separation path defaults to /var/empty. At
         # least newer versions want to create the directory during the


### PR DESCRIPTION
Fix #29938, which is reproduced by setting group permissions to writable:
```diff
--- spack/etc/spack/defaults/packages.yaml
+++ spack/etc/spack/packages.yaml
@@ -60,3 +60,3 @@
     permissions:
       read: world
-      write: user
+      write: group
```
which results in:
```js
==> Error: InvalidPermissionsError: Attempting to set suid with group writable
```
This is triggered by the `Makefile` installing `libexec/ssh-keysign` with mode `-m 4711` which results in the `InvalidPermissionsError` because **suid-user** with **group** **writeable** mode is rejected (ultimatively by the filesystem/OS).

Fix it by no longer installing `$D/libexec/ssh-keysign` suid-user: It is no problem because ssh-keysign is disabled by default as it is only used for host-based authentication (which is very rarely used).