### PR TITLE
openssh: Provide support for Kerberos authentication

### DIFF
--- a/var/spack/repos/builtin/packages/openssh/package.py
+++ b/var/spack/repos/builtin/packages/openssh/package.py
@@ -45,6 +45,9 @@ class Openssh(AutotoolsPackage):
     version('6.7p1', sha256='b2f8394eae858dabbdef7dac10b99aec00c95462753e80342e530bbb6f725507')
     version('6.6p1', sha256='48c1f0664b4534875038004cc4f3555b8329c2a81c1df48db5c517800de203bb')
 
+    variant('gssapi', default=True, description='Enable authentication via Kerberos through GSSAPI')
+
+    depends_on('krb5', when='+gssapi')
     depends_on('openssl@:1.0', when='@:7.7p1')
     depends_on('openssl')
     depends_on('libedit')
@@ -67,6 +70,8 @@ class Openssh(AutotoolsPackage):
         # least newer versions want to create the directory during the
         # install step and fail if they cannot do so.
         args = ['--with-privsep-path={0}'.format(self.prefix.var.empty)]
+        if self.spec.satisfies('+gssapi'):
+            args.append('--with-kerberos5=' + self.spec['krb5'].prefix)
 
         # Somehow creating pie executables fails with nvhpc, not with gcc.
         if '%nvhpc' in self.spec:


### PR DESCRIPTION
`openssh` is a dependency of `git` and Paul Grosse-Bley reported that `ssh` logins were refused after building singularity/apptainer with spack: spack's openssh was activated by `apptainer -> go -> git -> openssh`

It was not obvious why `ssh` refused to login after building apptainer, so I propose to enable the new variant by default as well.

This fixes the missing Kerberos support for his environment (ZITI, Uni Heidelberg) using a new variant `^openssh+gssapi`.

Thanks to @[pauleonix](https://github.com/pauleonix) for the report and testing!