### PR TITLE
atompaw: add v4.2.0.1

### DIFF
--- a/var/spack/repos/builtin/packages/atompaw/package.py
+++ b/var/spack/repos/builtin/packages/atompaw/package.py
@@ -18,6 +18,7 @@ class Atompaw(AutotoolsPackage):
     homepage = "https://users.wfu.edu/natalie/papers/pwpaw/man.html"
     url = "https://users.wfu.edu/natalie/papers/pwpaw/atompaw-4.0.0.13.tar.gz"
 
+    version('4.2.0.1', sha256='d3476a5aa5f80f9430b81f28273c2c2a9b6e7d9c3d08c65544247bb76cd5a114')
     version('4.2.0.0', sha256='9ab4f4ab78a720fbcd95bbbc1403e8ff348d15570e7c694932a56be15985e93d')
     version('4.1.1.0', sha256='b1ee2b53720066655d98523ef337e54850cb1e68b3a2da04ff5a1576d3893891')
     version('4.0.0.13', sha256='cbd73f11f3e9cc3ff2e5f3ec87498aeaf439555903d0b95a72f3b0a021902020')
@@ -30,7 +31,7 @@ class Atompaw(AutotoolsPackage):
     depends_on('libxc')
     depends_on('libxc@:2', when='@:4.0')
 
-    patch('atompaw-4.1.1.0-fix-ifort.patch', when='@4.1.1.0:')
+    patch('atompaw-4.1.1.0-fix-ifort.patch', when='@4.1.1.0:4.2.0.0')
     patch('atompaw-4.1.1.0-fix-fujitsu.patch', when='@4.1.1.0 %fj')
 
     parallel = False


### PR DESCRIPTION
Add atompaw `v4.2.0.1`.
Apply ifort patch including `v4.2.0.0`, but not for `4.2.0.1` anymore (intel compatibility has been fixed by the developers).