### PR TITLE
Limit Jasper version for WPS

### DIFF
--- a/var/spack/repos/builtin/packages/wps/package.py
+++ b/var/spack/repos/builtin/packages/wps/package.py
@@ -46,7 +46,7 @@ class Wps(Package):
     depends_on('time', type=('build'))
     depends_on('m4', type='build')
     depends_on('libtool', type='build')
-    depends_on('jasper')
+    depends_on('jasper@:2.0.32')
     phases = ['configure', 'build', 'install']
 
     patch('for_aarch64.patch', when='target=aarch64:')

--- a/var/spack/repos/builtin/packages/wps/package.py
+++ b/var/spack/repos/builtin/packages/wps/package.py
@@ -46,7 +46,7 @@ class Wps(Package):
     depends_on('time', type=('build'))
     depends_on('m4', type='build')
     depends_on('libtool', type='build')
-    depends_on('jasper@:2.0.32')
+    depends_on('jasper@:2')
     phases = ['configure', 'build', 'install']
 
     patch('for_aarch64.patch', when='target=aarch64:')


### PR DESCRIPTION
Jasper@3: changed API and does not support interfaces used by WPS.
This prevented ungrib.exe build and failed silently.