### PR TITLE
opa-psm2: New version 11.2.228

### DIFF
--- a/var/spack/repos/builtin/packages/opa-psm2/package.py
+++ b/var/spack/repos/builtin/packages/opa-psm2/package.py
@@ -12,6 +12,9 @@ class OpaPsm2(MakefilePackage):
     homepage = "https://github.com/cornelisnetworks/opa-psm2"
     url      = "https://github.com/cornelisnetworks/opa-psm2/archive/PSM2_10.3-8.tar.gz"
 
+    maintainers = ['jack-morrison']
+
+    version('11.2.228', sha256='e302afc8cd054409616d59b69e4d7f140278dc3815ae07f0fc14080fd860bd5c')
     version('11.2.206', sha256='08aa41f41bdb485ee037d3f7e32dd45e79858ce38e744d33b9db2af60e3c627a')
     version('11.2.185', sha256='8c0446e989feb4a3822791e4a3687060916f7c4612d1e8e493879be66f10db09')
     version('11.2.77', sha256='5cc33d1e19d871a5861efe0bb897526f404b4bf2b88ac58bb277db96ac5ecb54')


### PR DESCRIPTION
This is a small update to include the latest available version from https://github.com/cornelisnetworks/opa-psm2/releases.

I've also added myself as a maintainer from @cornelisnetworks. Happy to help resolve issues if they arise, and/or find other appropriate contacts as needed.