### PR TITLE
bugfix: preserve dict order for `Spec.dag_hash()` in Python 2

### DIFF
--- a/lib/spack/spack/util/spack_json.py
+++ b/lib/spack/spack/util/spack_json.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 """Simple wrapper around JSON to guarantee consistent use of load/dump. """
+import collections
 import json
 from typing import Any, Dict, Optional  # novm
 
@@ -72,9 +73,10 @@ def _strify(data, ignore_dicts=False):
     # if this is a dictionary, return dictionary of byteified keys and values
     # but only if we haven't already byteified it
     if isinstance(data, dict) and not ignore_dicts:
-        return dict((_strify(key, ignore_dicts=True),
-                     _strify(value, ignore_dicts=True)) for key, value in
-                    iteritems(data))
+        return collections.OrderedDict(
+            (_strify(key, ignore_dicts=True), _strify(value, ignore_dicts=True))
+            for key, value in iteritems(data)
+        )
 
     # if it's anything else, return it in its original form
     return data


### PR DESCRIPTION
Fix a bug introduced in #21720. `spack_json.dump()` calls `_strify()` on dictionaries to convert `unicode` to `str`, but it constructs `dict` objects instead of `collections.OrderedDict` objects, so in Python 2 (or earlier versions of 3) it can scramble dictionary order.

This can cause hashes to differ between Python 2 and Python 3, or between Python >3.6 and earlier Python 3's.

- [x] use `OrderedDict` in `_strify`
- [x] add a regression test