### PR TITLE
deprecate spack.paths.default_fetch_cache_path and introduce .local_user_mirror

### DIFF
--- a/lib/spack/spack/caches.py
+++ b/lib/spack/spack/caches.py
@@ -40,12 +40,12 @@ misc_cache = llnl.util.lang.Singleton(_misc_cache)
 def fetch_cache_location():
     """Filesystem cache of downloaded archives.
 
-    This prevents Spack from repeatedly fetch the same files when
+    This prevents Spack from repeatedly fetching the same files when
     building the same package different ways or multiple times.
     """
     path = spack.config.get("config:source_cache")
     if not path:
-        path = spack.paths.default_fetch_cache_path
+        path = spack.paths.local_user_mirror
     path = spack.util.path.canonicalize_path(path)
     return path
 

--- a/lib/spack/spack/paths.py
+++ b/lib/spack/spack/paths.py
@@ -64,10 +64,6 @@ mock_packages_path = os.path.join(repos_path, "builtin.mock")
 # Writable things in $spack/var/spack
 # TODO: Deprecate these, as we want a read-only spack prefix by default.
 # TODO: These should probably move to user cache, or some other location.
-#
-# fetch cache for downloaded files
-default_fetch_cache_path = os.path.join(var_path, "cache")
-
 # GPG paths.
 gpg_keys_path = os.path.join(var_path, "gpg")
 mock_gpg_data_path = os.path.join(var_path, "gpg.mock", "data")
@@ -101,6 +97,9 @@ default_monitor_path = os.path.join(reports_path, "monitor")
 
 #: git repositories fetched to compare commits to versions
 user_repos_cache_path = os.path.join(user_cache_path, "git_repos")
+
+#: default location to fetch downloaded archives to.
+local_user_mirror = os.path.join(user_cache_path, "mirror")
 
 #: bootstrap store for bootstrapping clingo and other tools
 default_user_bootstrap_path = os.path.join(user_cache_path, "bootstrap")

--- a/lib/spack/spack/test/cache_fetch.py
+++ b/lib/spack/spack/test/cache_fetch.py
@@ -10,11 +10,24 @@ import pytest
 
 from llnl.util.filesystem import mkdirp, touch
 
+import spack.caches
 import spack.config
+import spack.paths
 from spack.fetch_strategy import CacheURLFetchStrategy, NoCacheError
 from spack.stage import Stage
 
 is_windows = sys.platform == "win32"
+
+
+def test_fetch_cache_location_override():
+    with spack.config.override("config:source_cache", ""):
+        assert spack.caches.fetch_cache_location() == spack.paths.local_user_mirror
+
+    source_cache = os.path.join("source-cache", "subdir", "..", "subdir2")
+    source_cache_canon = os.path.join("source-cache", "subdir2")
+    with spack.config.override("config:source_cache", source_cache):
+        full_cache_canon = os.path.join(os.getcwd(), source_cache_canon)
+        assert spack.caches.fetch_cache_location() == full_cache_canon
 
 
 @pytest.mark.parametrize("_fetch_method", ["curl", "urllib"])


### PR DESCRIPTION
*This was split out of #22235.*

### Problem

We want to remove writable areas in `$spack/var/spack`. See this TODO:
https://github.com/spack/spack/blob/516587a1da6266f517a83b73550728f204b242a8/lib/spack/spack/paths.py#L64-L69

### Solution

- Create a new location `spack.paths.local_user_mirror` to download archives into.
- Default `spack.caches.fetch_cache_location()` to `spack.paths.local_user_mirror`.
- Add a test.