### PR TITLE
New packages: py-ford and dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -19,7 +19,7 @@ class PyFord(PythonPackage):
     depends_on('py-wheel@0.29:', type='build')
 
     depends_on('py-setuptools@48:', type='build')
-    depends_on('py-setuptools-scm@4:5', type='build')
+    depends_on('py-setuptools-scm@4:5+toml', type='build')
     depends_on('py-setuptools-scm-git-archive', type='build')
 
     depends_on('py-markdown', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -27,14 +27,14 @@ class PyFord(PythonPackage):
 
     # FIXME: Add additional dependencies if required.
     depends_on('py-markdown', type=('build', 'run'))
-    depends_on('py-markdown-include@0.5.1:', type=('build', 'run'))
+    depends_on('py-markdown-include@0.5.1:', type='run')
     # depends_on('py-md-environ', type=('build', 'run')) not in the setup...maybe no longer needed?
-    depends_on('py-python-markdown-math@0.8:0', type=('build', 'run'))
+    depends_on('py-python-markdown-math@0.8:0', type='run')
     depends_on('py-toposort', type=('build', 'run'))
     depends_on('py-jinja2@2.1:', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))
     depends_on('py-beautifulsoup4@4.5.1:', type=('build', 'run'))
-    depends_on('graphviz', type=('build', 'run'))
+    depends_on('py-graphviz', type=('build', 'run'))
     depends_on('py-tqdm', type=('build', 'run'))
     depends_on('py-importlib-metadata', type=('build', 'run'))
 

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -13,9 +13,7 @@ class PyFord(PythonPackage):
 
     pypi     = "FORD/FORD-6.1.11.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ['github_user1', 'github_user2']
+    maintainers = ['wscullin']
 
     version('6.1.11', sha256='feb9a88040e717e84c632e4b023904ab36a463fc9a8ff80c8c7f86454e5d8043')
 

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 
 
 class PyFord(PythonPackage):
-    """FORD, standing for FORtran Documenter, is an automatic documentation generator 
+    """FORD, standing for FORtran Documenter, is an automatic documentation generator
     for modern Fortran programs."""
 
     pypi     = "FORD/FORD-6.1.11.tar.gz"

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -29,7 +29,7 @@ class PyFord(PythonPackage):
     depends_on('py-markdown', type=('build', 'run'))
     depends_on('py-markdown-include@0.5.1:', type=('build', 'run'))
     # depends_on('py-md-environ', type=('build', 'run')) not in the setup...maybe no longer needed?
-    # depends_on('py-python-markdown-math', type=('build', 'run')) ????? whats ~=
+    depends_on('py-python-markdown-math@0.8:0', type=('build', 'run'))
     depends_on('py-toposort', type=('build', 'run'))
     depends_on('py-jinja2@2.1:', type=('build', 'run'))
     depends_on('py-pygments', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -25,10 +25,9 @@ class PyFord(PythonPackage):
     depends_on('py-setuptools-scm@4:5', type='build')
     depends_on('py-setuptools-scm-git-archive', type='build')
 
-    # FIXME: Add additional dependencies if required.
     depends_on('py-markdown', type=('build', 'run'))
     depends_on('py-markdown-include@0.5.1:', type='run')
-    # depends_on('py-md-environ', type=('build', 'run')) not in the setup...maybe no longer needed?
+    depends_on('py-md-environ', type=('build', 'run'), when='@:6.1.8')
     depends_on('py-python-markdown-math@0.8:0', type='run')
     depends_on('py-toposort', type=('build', 'run'))
     depends_on('py-jinja2@2.1:', type=('build', 'run'))
@@ -39,15 +38,3 @@ class PyFord(PythonPackage):
     depends_on('py-importlib-metadata', type=('build', 'run'))
 
     depends_on('py-pytest@3.3.0:', type='test')
-
-    def global_options(self, spec, prefix):
-        # FIXME: Add options to pass to setup.py
-        # FIXME: If not needed, delete this function
-        options = []
-        return options
-
-    def install_options(self, spec, prefix):
-        # FIXME: Add options to pass to setup.py install
-        # FIXME: If not needed, delete this function
-        options = []
-        return options

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -26,6 +26,19 @@ class PyFord(PythonPackage):
     depends_on('py-setuptools-scm-git-archive', type='build')
 
     # FIXME: Add additional dependencies if required.
+    depends_on('py-markdown', type=('build', 'run'))
+    depends_on('py-markdown-include@0.5.1:', type=('build', 'run'))
+    # depends_on('py-md-environ', type=('build', 'run')) not in the setup...maybe no longer needed?
+    # depends_on('py-python-markdown-math', type=('build', 'run')) ????? whats ~=
+    depends_on('py-toposort', type=('build', 'run'))
+    depends_on('py-jinja2@2.1:', type=('build', 'run'))
+    depends_on('py-pygments', type=('build', 'run'))
+    depends_on('py-beautifulsoup4@4.5.1:', type=('build', 'run'))
+    depends_on('graphviz', type=('build', 'run'))
+    depends_on('py-tqdm', type=('build', 'run'))
+    depends_on('py-importlib-metadata', type=('build', 'run'))
+
+    depends_on('py-pytest@3.3.0:', type='test')
 
     def global_options(self, spec, prefix):
         # FIXME: Add options to pass to setup.py

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -19,21 +19,13 @@ class PyFord(PythonPackage):
 
     version('6.1.11', sha256='feb9a88040e717e84c632e4b023904ab36a463fc9a8ff80c8c7f86454e5d8043')
 
-    # FIXME: Only add the python/pip/wheel dependencies if you need specific versions
-    # or need to change the dependency type. Generic python/pip/wheel dependencies are
-    # added implicity by the PythonPackage base class.
-    # depends_on('python@2.X:2.Y,3.Z:', type=('build', 'run'))
-    # depends_on('py-pip@X.Y:', type='build')
-    # depends_on('py-wheel@X.Y:', type='build')
+    depends_on('py-wheel@0.29:', type='build')
 
-    # FIXME: Add a build backend, usually defined in pyproject.toml. If no such file
-    # exists, use setuptools.
-    # depends_on('py-setuptools', type='build')
-    # depends_on('py-flit-core', type='build')
-    # depends_on('py-poetry-core', type='build')
+    depends_on('py-setuptools@48:', type='build')
+    depends_on('py-setuptools-scm@4:5', type='build')
+    depends_on('py-setuptools-scm-git-archive', type='build')
 
     # FIXME: Add additional dependencies if required.
-    # depends_on('py-foo', type=('build', 'run'))
 
     def global_options(self, spec, prefix):
         # FIXME: Add options to pass to setup.py

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -32,6 +32,6 @@ class PyFord(PythonPackage):
     depends_on('py-beautifulsoup4@4.5.1:', type=('build', 'run'))
     depends_on('py-graphviz', type=('build', 'run'))
     depends_on('py-tqdm', type=('build', 'run'))
-    depends_on('py-importlib-metadata', type=('build', 'run'))
+    depends_on('py-importlib-metadata', when='^python@:3.7', type=('build', 'run'))
 
     depends_on('py-pytest@3.3.0:', type='test')

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -9,7 +9,8 @@ from spack.package import *
 
 
 class PyFord(PythonPackage):
-    """FORD, standing for FORtran Documenter, is an automatic documentation generator for modern Fortran programs."""
+    """FORD, standing for FORtran Documenter, is an automatic documentation generator 
+    for modern Fortran programs."""
 
     pypi     = "FORD/FORD-6.1.11.tar.gz"
 

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -14,6 +14,7 @@ class PyFord(PythonPackage):
 
     maintainers = ['wscullin']
 
+    version('6.1.12', sha256='101191e1aa33cfe780ea5b2d66d02c7281b9b314e82bb138d76809a49c08506a')
     version('6.1.11', sha256='feb9a88040e717e84c632e4b023904ab36a463fc9a8ff80c8c7f86454e5d8043')
 
     depends_on('py-wheel@0.29:', type='build')

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -33,5 +33,3 @@ class PyFord(PythonPackage):
     depends_on('py-graphviz', type=('build', 'run'))
     depends_on('py-tqdm', type=('build', 'run'))
     depends_on('py-importlib-metadata', when='^python@:3.7', type=('build', 'run'))
-
-    depends_on('py-pytest@3.3.0:', type='test')

--- a/var/spack/repos/builtin/packages/py-ford/package.py
+++ b/var/spack/repos/builtin/packages/py-ford/package.py
@@ -1,0 +1,48 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class PyFord(PythonPackage):
+    """FORD, standing for FORtran Documenter, is an automatic documentation generator for modern Fortran programs."""
+
+    pypi     = "FORD/FORD-6.1.11.tar.gz"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('6.1.11', sha256='feb9a88040e717e84c632e4b023904ab36a463fc9a8ff80c8c7f86454e5d8043')
+
+    # FIXME: Only add the python/pip/wheel dependencies if you need specific versions
+    # or need to change the dependency type. Generic python/pip/wheel dependencies are
+    # added implicity by the PythonPackage base class.
+    # depends_on('python@2.X:2.Y,3.Z:', type=('build', 'run'))
+    # depends_on('py-pip@X.Y:', type='build')
+    # depends_on('py-wheel@X.Y:', type='build')
+
+    # FIXME: Add a build backend, usually defined in pyproject.toml. If no such file
+    # exists, use setuptools.
+    # depends_on('py-setuptools', type='build')
+    # depends_on('py-flit-core', type='build')
+    # depends_on('py-poetry-core', type='build')
+
+    # FIXME: Add additional dependencies if required.
+    # depends_on('py-foo', type=('build', 'run'))
+
+    def global_options(self, spec, prefix):
+        # FIXME: Add options to pass to setup.py
+        # FIXME: If not needed, delete this function
+        options = []
+        return options
+
+    def install_options(self, spec, prefix):
+        # FIXME: Add options to pass to setup.py install
+        # FIXME: If not needed, delete this function
+        options = []
+        return options

--- a/var/spack/repos/builtin/packages/py-markdown-include/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown-include/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-markdown-include/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown-include/package.py
@@ -9,8 +9,9 @@ from spack.package import *
 
 
 class PyMarkdownInclude(PythonPackage):
-    """This is an extension to Python-Markdown which provides an “include” 
-    function, similar to that found in LaTeX (and also the C pre-processor and Fortran)."""
+    """This is an extension to Python-Markdown which provides an “include”
+    function, similar to that found in LaTeX (and also the
+    C pre-processor and Fortran)."""
 
     pypi     = "markdown-include/markdown-include-0.6.0.tar.gz"
 

--- a/var/spack/repos/builtin/packages/py-markdown-include/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown-include/package.py
@@ -13,9 +13,7 @@ class PyMarkdownInclude(PythonPackage):
 
     pypi     = "markdown-include/markdown-include-0.6.0.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ['github_user1', 'github_user2']
+    maintainers = ['wscullin']
 
     version('0.6.0', sha256='6f5d680e36f7780c7f0f61dca53ca581bd50d1b56137ddcd6353efafa0c3e4a2')
 

--- a/var/spack/repos/builtin/packages/py-markdown-include/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown-include/package.py
@@ -9,7 +9,8 @@ from spack.package import *
 
 
 class PyMarkdownInclude(PythonPackage):
-    """This is an extension to Python-Markdown which provides an “include” function, similar to that found in LaTeX (and also the C pre-processor and Fortran)."""
+    """This is an extension to Python-Markdown which provides an “include” 
+    function, similar to that found in LaTeX (and also the C pre-processor and Fortran)."""
 
     pypi     = "markdown-include/markdown-include-0.6.0.tar.gz"
 
@@ -18,5 +19,5 @@ class PyMarkdownInclude(PythonPackage):
     version('0.6.0', sha256='6f5d680e36f7780c7f0f61dca53ca581bd50d1b56137ddcd6353efafa0c3e4a2')
 
     depends_on('py-setuptools', type='build')
-    
+
     depends_on('py-markdown', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-markdown-include/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown-include/package.py
@@ -7,7 +7,7 @@ from spack.package import *
 
 
 class PyMarkdownInclude(PythonPackage):
-    """This is an extension to Python-Markdown which provides an “include”
+    """This is an extension to Python-Markdown which provides an "include"
     function, similar to that found in LaTeX (and also the
     C pre-processor and Fortran)."""
 

--- a/var/spack/repos/builtin/packages/py-markdown-include/package.py
+++ b/var/spack/repos/builtin/packages/py-markdown-include/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class PyMarkdownInclude(PythonPackage):
+    """This is an extension to Python-Markdown which provides an “include” function, similar to that found in LaTeX (and also the C pre-processor and Fortran)."""
+
+    pypi     = "markdown-include/markdown-include-0.6.0.tar.gz"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('0.6.0', sha256='6f5d680e36f7780c7f0f61dca53ca581bd50d1b56137ddcd6353efafa0c3e4a2')
+
+    depends_on('py-setuptools', type='build')
+    
+    depends_on('py-markdown', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-md-environ/package.py
+++ b/var/spack/repos/builtin/packages/py-md-environ/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-md-environ/package.py
+++ b/var/spack/repos/builtin/packages/py-md-environ/package.py
@@ -1,0 +1,24 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class PyMdEnviron(PythonPackage):
+    """This is an extension to Python-Markdown which allows environment variables to be used in the text."""
+
+    pypi     = "md-environ/md-environ-0.1.0.tar.gz"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('0.1.0', sha256='fe3c2a255af523d6f522831c699336cd71f9d543714067d93206ed35836f1793')
+
+    depends_on('py-setuptools', type='build')
+
+    depends_on('py-markdown', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-md-environ/package.py
+++ b/var/spack/repos/builtin/packages/py-md-environ/package.py
@@ -9,7 +9,8 @@ from spack.package import *
 
 
 class PyMdEnviron(PythonPackage):
-    """This is an extension to Python-Markdown which allows environment variables to be used in the text."""
+    """This is an extension to Python-Markdown which allows environment variables 
+    to be used in the text."""
 
     pypi     = "md-environ/md-environ-0.1.0.tar.gz"
 

--- a/var/spack/repos/builtin/packages/py-md-environ/package.py
+++ b/var/spack/repos/builtin/packages/py-md-environ/package.py
@@ -13,9 +13,7 @@ class PyMdEnviron(PythonPackage):
 
     pypi     = "md-environ/md-environ-0.1.0.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ['github_user1', 'github_user2']
+    maintainers = ['wscullin']
 
     version('0.1.0', sha256='fe3c2a255af523d6f522831c699336cd71f9d543714067d93206ed35836f1793')
 

--- a/var/spack/repos/builtin/packages/py-md-environ/package.py
+++ b/var/spack/repos/builtin/packages/py-md-environ/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 
 
 class PyMdEnviron(PythonPackage):
-    """This is an extension to Python-Markdown which allows environment variables 
+    """This is an extension to Python-Markdown which allows environment variables
     to be used in the text."""
 
     pypi     = "md-environ/md-environ-0.1.0.tar.gz"

--- a/var/spack/repos/builtin/packages/py-python-markdown-math/package.py
+++ b/var/spack/repos/builtin/packages/py-python-markdown-math/package.py
@@ -3,8 +3,6 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-# ----------------------------------------------------------------------------
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/py-python-markdown-math/package.py
+++ b/var/spack/repos/builtin/packages/py-python-markdown-math/package.py
@@ -13,9 +13,7 @@ class PyPythonMarkdownMath(PythonPackage):
 
     pypi     = "python-markdown-math/python-markdown-math-0.8.tar.gz"
 
-    # FIXME: Add a list of GitHub accounts to
-    # notify when the package is updated.
-    # maintainers = ['github_user1', 'github_user2']
+    maintainers = ['wscullin']
 
     version('0.8', sha256='8564212af679fc18d53f38681f16080fcd3d186073f23825c7ce86fadd3e3635')
 

--- a/var/spack/repos/builtin/packages/py-python-markdown-math/package.py
+++ b/var/spack/repos/builtin/packages/py-python-markdown-math/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class PyPythonMarkdownMath(PythonPackage):
+    """Math extension for Python-Markdown"""
+
+    pypi     = "python-markdown-math/python-markdown-math-0.8.tar.gz"
+
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ['github_user1', 'github_user2']
+
+    version('0.8', sha256='8564212af679fc18d53f38681f16080fcd3d186073f23825c7ce86fadd3e3635')
+
+    depends_on('python@3.6:', type=('build', 'run'))
+
+    depends_on('py-setuptools@30.3:', type='build')
+
+    depends_on('py-markdown@3.0:', type=('build', 'run'))


### PR DESCRIPTION
This PR adds the Ford documentation framework along with necessary dependencies that didn't already have spack packages:

- [ford](https://github.com/Fortran-FOSS-Programmers/ford) by @Fortran-FOSS-Programmers / @cmacmackin 
- [python-markdown-math](https://github.com/mitya57/python-markdown-math) by @mitya57
- [markdown-include](https://github.com/cmacmackin/markdown-include) by @cmacmackin 
- [md-environ](https://github.com/cmacmackin/md-environ) by @cmacmackin 

Leaving this as a draft PR until I get the maintainers squared away for the packages. In the meantime, for the tagged creators of these libraries/packages, please indicate if you are willing to be tagged as a maintainer for these spack packages.