### PR TITLE
setuptools: add v62.4.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -14,6 +14,7 @@ class PySetuptools(Package):
     url = "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-62.3.2-py3-none-any.whl"
     list_url = "https://pypi.org/simple/setuptools/"
 
+    version('62.4.0', sha256='5a844ad6e190dccc67d6d7411d119c5152ce01f7c76be4d8a1eaa314501bba77', expand=False)
     version('62.3.2', sha256='68e45d17c9281ba25dc0104eadd2647172b3472d9e01f911efa57965e8d51a36', expand=False)
     version('59.4.0', sha256='feb5ff19b354cde9efd2344ef6d5e79880ce4be643037641b49508bbb850d060', expand=False)
     version('58.2.0', sha256='2551203ae6955b9876741a26ab3e767bb3242dafe86a32a749ea0d78b6792f11', expand=False)


### PR DESCRIPTION
EDIT: #31109 was fixed by installing setuptools from wheels. The PR has been updated accordingly, and now is just a version bump of setuptools.

