### PR TITLE
root: new version 6.26.04

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -31,6 +31,7 @@ class Root(CMakePackage):
     # Development version (when more recent than production).
 
     # Production version
+    version('6.26.04', sha256='a271cf82782d6ed2c87ea5eef6681803f2e69e17b3036df9d863636e9358421e')
     version('6.26.02', sha256='7ba96772271a726079506c5bf629c3ceb21bf0682567ed6145be30606d7cd9bb')
     version('6.26.00', sha256='5fb9be71fdf0c0b5e5951f89c2f03fcb5e74291d043f6240fb86f5ca977d4b31')
     version('6.24.06', sha256='907f69f4baca1e4f30eeb4979598ca7599b6aa803ca046e80e25b6bbaa0ef522')


### PR DESCRIPTION
New bugfix release, release notes: https://root.cern/doc/v626/release-notes.html#release-6.2604

Maintainers: @HadrienG2  @chissg  @drbenmorgan  @vvolkl