### PR TITLE
Pin setuptools version in Github Action Workflows

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         python-version: '3.10'
     - name: Install Python packages
       run: |
-        pip install --upgrade pip six setuptools types-six
+        pip install --upgrade pip six setuptools==62.3.4 types-six
     - name: Setup git configuration
       run: |
         # Need this for the git tests to succeed.

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -46,7 +46,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-        python -m pip install --upgrade pip six setuptools flake8 isort>=4.3.5 mypy>=0.800 black pywin32 types-python-dateutil
+        python -m pip install --upgrade pip six setuptools==62.3.4 flake8 isort>=4.3.5 mypy>=0.800 black pywin32 types-python-dateutil
     - name: Create local develop
       run: |
         .\spack\.github\workflows\setup_git.ps1


### PR DESCRIPTION
fixes #31109

Since #31112 needs some fixing for pipelines, this can be a faster solution to keep CI on `develop` going