### PR TITLE
exempi: add 2.6.1 and fix boost dependency

### DIFF
--- a/var/spack/repos/builtin/packages/exempi/package.py
+++ b/var/spack/repos/builtin/packages/exempi/package.py
@@ -15,24 +15,23 @@ class Exempi(AutotoolsPackage):
     """
 
     homepage = "https://libopenraw.freedesktop.org/wiki/Exempi"
-    url      = "https://libopenraw.freedesktop.org/download/exempi-2.5.2.tar.bz2"
+    url      = "https://libopenraw.freedesktop.org/download/exempi-2.6.1.tar.bz2"
 
+    version('2.6.1', sha256='072451ac1e0dc97ed69a2e5bfc235fd94fe093d837f65584d0e3581af5db18cd')
     version('2.5.2', sha256='52f54314aefd45945d47a6ecf4bd21f362e6467fa5d0538b0d45a06bc6eaaed5')
 
     depends_on('zlib')
     depends_on('iconv')
-    depends_on('boost@1.48.0:')
+    # needs +test variant to prevent following error:
+    # 118    checking for the Boost unit_test_framework library... no
+    # >> 119    configure: error: cannot find the flags to link with Boost
+    #           unit_test_framework
+    depends_on('boost+test@1.79.0:', when='@2.6.1:')
+    depends_on('boost+test@1.48.0:')
     depends_on('pkgconfig')
     depends_on('expat')
 
     conflicts('%gcc@:4.5')
-
-    def patch(self):
-        # fix make check: Fix undefined reference to `boost::unit_test::unit_test_main`:
-        # BOOST_TEST_DYN_LINK only works with shlib and when boost is linked after src:
-        # https://bugs.launchpad.net/widelands/+bug/662908
-        # https://github.com/bincrafters/community/issues/127
-        filter_file('#define BOOST_TEST_DYN_LINK', '', 'exempi/tests/test-adobesdk.cpp')
 
     def configure_args(self):
         args = ['--with-boost={0}'.format(self.spec['boost'].prefix)]


### PR DESCRIPTION
exempi did not build anymore with the error message:
```
==> Error: ProcessError: Command exited with status 1:
    '$spack-stage/spack-stage-exempi-2.6.1-54bayzvjabr44jnodiczpz4npqjmbv75/spack-src/configure' '--prefix=$spack/opt/spack/linux-fedora35-skylake/gcc-11.3.1/exempi-2.6.1-54bayzvjabr44jnodiczpz4npqjmbv75' '--with-boost=$spack/opt/spack/linux-fedora35-skylake/gcc-11.3.1/boost-1.79.0-mfdxxbu2mzgzuk6ztqoioxggrzzonslj'

1 error found in build log:
     113    checking for the toolset name used by Boost for $spack/lib/s
            pack/env/gcc/g++... configure: WARNING: could not figure out which toolset name to use for 
            $spack/lib/spack/env/gcc/g++
     114    
     115    checking boost/test/unit_test.hpp usability... yes
     116    checking boost/test/unit_test.hpp presence... yes
     117    checking for boost/test/unit_test.hpp... yes
     118    checking for the Boost unit_test_framework library... no
  >> 119    configure: error: cannot find the flags to link with Boost unit_test_framework
```
While fixing it, I also added the newer version (which also needed `boost+test`)