### PR TITLE
r-httpuv: fix zlib dependency

### DIFF
--- a/var/spack/repos/builtin/packages/r-httpuv/package.py
+++ b/var/spack/repos/builtin/packages/r-httpuv/package.py
@@ -33,5 +33,6 @@ class RHttpuv(RPackage):
     depends_on('r-later@0.8.0:', type=('build', 'run'), when='@1.5.0:')
     depends_on('gmake', type='build')
     depends_on('zip')
+    depends_on('zlib', when='@1.6.4:')
 
     depends_on('r-bh', type=('build', 'run'), when='@1.5.5')


### PR DESCRIPTION
the package was missing a dependency on `zlib`, see https://cran.r-project.org/web/packages/httpuv/index.html