### PR TITLE
googletest: use URLs with `.tar.gz` extension

### DIFF
--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -9,13 +9,16 @@ from spack.package import *
 class Googletest(CMakePackage):
     """Google test framework for C++.  Also called gtest."""
     homepage = "https://github.com/google/googletest"
-    url      = "https://github.com/google/googletest/tarball/release-1.10.0"
-    git      = "https://github.com/google/googletest"
+    git      = "https://github.com/google/googletest
 
     version('main', branch='main')
-    version('1.11.0', sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
-    version('1.10.0', sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9', preferred=True)
-    version('1.8.1',  sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
+    version('1.11.0', url='https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz',
+                      sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
+    version('1.10.0', url='https://github.com/google/googletest/archive/refs/tags/release-1.10.0.tar.gz',
+                      sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9',
+                      preferred=True)
+    version('1.8.1',  url='https://github.com/google/googletest/archive/refs/tags/release-1.8.1.tar.gz',
+                      sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
     version('1.8.0',  sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')
     version('1.7.0',  sha256='9639cf8b7f37a4d0c6575f52c01ef167c5f11faee65252296b3ffc2d9acd421b')
     version('1.6.0',  sha256='a61e20c65819eb39a2da85c88622bac703b865ca7fe2bfdcd3da734d87d5521a')

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Googletest(CMakePackage):
     """Google test framework for C++.  Also called gtest."""
     homepage = "https://github.com/google/googletest"
-    git      = "https://github.com/google/googletest
+    git      = "https://github.com/google/googletest"
 
     version('main', branch='main')
     version('1.11.0', url='https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz',

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -8,12 +8,9 @@ from spack.package import *
 
 class Googletest(CMakePackage):
     """Google test framework for C++.  Also called gtest."""
-    homepage = "https://github.com/google/googletest
-    url = "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
+    homepage = "https://github.com/google/googletest"
+    url      = "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
     git      = "https://github.com/google/googletest"
-
-    def url_for_version(self, version):
-        return url.format(version)
 
     version('main', branch='main')
     version('1.11.0', sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -14,7 +14,7 @@ class Googletest(CMakePackage):
     def url_for_version(self, version):
         url = "https://github.com/google/googletest/archive/refs/tags/release-{0}.tar.gz"
         return url.format(version)
-    
+
     version('main', branch='main')
     version('1.11.0', sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
     version('1.10.0', sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9', preferred=True)

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -8,11 +8,11 @@ from spack.package import *
 
 class Googletest(CMakePackage):
     """Google test framework for C++.  Also called gtest."""
-    homepage = "https://github.com/google/googletest"
+    homepage = "https://github.com/google/googletest
+    url = "https://github.com/google/googletest/archive/release-1.11.0.tar.gz"
     git      = "https://github.com/google/googletest"
 
     def url_for_version(self, version):
-        url = "https://github.com/google/googletest/archive/refs/tags/release-{0}.tar.gz"
         return url.format(version)
 
     version('main', branch='main')

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -9,7 +9,7 @@ from spack.package import *
 class Googletest(CMakePackage):
     """Google test framework for C++.  Also called gtest."""
     homepage = "https://github.com/google/googletest
-    url = "https://github.com/google/googletest/archive/release-1.11.0.tar.gz"
+    url = "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
     git      = "https://github.com/google/googletest"
 
     def url_for_version(self, version):

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -11,20 +11,17 @@ class Googletest(CMakePackage):
     homepage = "https://github.com/google/googletest"
     git      = "https://github.com/google/googletest"
 
+    def url_for_version(self, version):
+        url = "https://github.com/google/googletest/archive/refs/tags/release-{0}.tar.gz"
+        return url.format(version)
+    
     version('main', branch='main')
-    version('1.11.0', url='https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz',
-            sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
-    version('1.10.0', url='https://github.com/google/googletest/archive/refs/tags/release-1.10.0.tar.gz',
-            sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9',
-            preferred=True)
-    version('1.8.1',  url='https://github.com/google/googletest/archive/refs/tags/release-1.8.1.tar.gz',
-            sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
-    version('1.8.0',  url='https://github.com/google/googletest/archive/refs/tags/release-1.8.0.tar.gz',
-            sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')
-    version('1.7.0',  url='https://github.com/google/googletest/archive/refs/tags/release-1.7.0.tar.gz',
-            sha256='9639cf8b7f37a4d0c6575f52c01ef167c5f11faee65252296b3ffc2d9acd421b')
-    version('1.6.0',  url='https://github.com/google/googletest/archive/refs/tags/release-1.6.0.tar.gz',
-            sha256='a61e20c65819eb39a2da85c88622bac703b865ca7fe2bfdcd3da734d87d5521a')
+    version('1.11.0', sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
+    version('1.10.0', sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9', preferred=True)
+    version('1.8.1',  sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
+    version('1.8.0',  sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')
+    version('1.7.0',  sha256='9639cf8b7f37a4d0c6575f52c01ef167c5f11faee65252296b3ffc2d9acd421b')
+    version('1.6.0',  sha256='a61e20c65819eb39a2da85c88622bac703b865ca7fe2bfdcd3da734d87d5521a')
 
     variant('gmock', default=False, description='Build with gmock')
     conflicts('+gmock', when='@:1.7.0')

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -19,9 +19,12 @@ class Googletest(CMakePackage):
             preferred=True)
     version('1.8.1',  url='https://github.com/google/googletest/archive/refs/tags/release-1.8.1.tar.gz',
             sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
-    version('1.8.0',  sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')
-    version('1.7.0',  sha256='9639cf8b7f37a4d0c6575f52c01ef167c5f11faee65252296b3ffc2d9acd421b')
-    version('1.6.0',  sha256='a61e20c65819eb39a2da85c88622bac703b865ca7fe2bfdcd3da734d87d5521a')
+    version('1.8.0',  url='https://github.com/google/googletest/archive/refs/tags/release-1.8.0.tar.gz',
+            sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')
+    version('1.7.0',  url='https://github.com/google/googletest/archive/refs/tags/release-1.7.0.tar.gz',
+            sha256='9639cf8b7f37a4d0c6575f52c01ef167c5f11faee65252296b3ffc2d9acd421b')
+    version('1.6.0',  url='https://github.com/google/googletest/archive/refs/tags/release-1.6.0.tar.gz',
+            sha256='a61e20c65819eb39a2da85c88622bac703b865ca7fe2bfdcd3da734d87d5521a')
 
     variant('gmock', default=False, description='Build with gmock')
     conflicts('+gmock', when='@:1.7.0')

--- a/var/spack/repos/builtin/packages/googletest/package.py
+++ b/var/spack/repos/builtin/packages/googletest/package.py
@@ -13,12 +13,12 @@ class Googletest(CMakePackage):
 
     version('main', branch='main')
     version('1.11.0', url='https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz',
-                      sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
+            sha256='07b0896360f8e14414a8419e35515da0be085c5b4547c914ab8f4684ef0a3a8e')
     version('1.10.0', url='https://github.com/google/googletest/archive/refs/tags/release-1.10.0.tar.gz',
-                      sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9',
-                      preferred=True)
+            sha256='e4a7cd97c903818abe7ddb129db9c41cc9fd9e2ded654be57ced26d45c72e4c9',
+            preferred=True)
     version('1.8.1',  url='https://github.com/google/googletest/archive/refs/tags/release-1.8.1.tar.gz',
-                      sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
+            sha256='8e40a005e098b1ba917d64104549e3da274e31261dedc57d6250fe91391b2e84')
     version('1.8.0',  sha256='d8c33605d23d303b08a912eaee7f84c4e091d6e3d90e9a8ec8aaf7450dfe2568')
     version('1.7.0',  sha256='9639cf8b7f37a4d0c6575f52c01ef167c5f11faee65252296b3ffc2d9acd421b')
     version('1.6.0',  sha256='a61e20c65819eb39a2da85c88622bac703b865ca7fe2bfdcd3da734d87d5521a')


### PR DESCRIPTION
Tested on Spack Ubuntu 22.04 docker container.
Summary:
- Replaces extensionless URL with one that has `.tar.gz` extension in it