### PR TITLE
py-setuptools: install setuptools from wheels directly 

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -44,7 +44,7 @@ jobs:
         python-version: '3.10'
     - name: Install Python packages
       run: |
-        pip install --upgrade pip six setuptools==62.3.4 types-six
+        pip install --upgrade pip six setuptools types-six
     - name: Setup git configuration
       run: |
         # Need this for the git tests to succeed.

--- a/.github/workflows/windows_python.yml
+++ b/.github/workflows/windows_python.yml
@@ -46,7 +46,7 @@ jobs:
         python-version: 3.9
     - name: Install Python packages
       run: |
-        python -m pip install --upgrade pip six setuptools==62.3.4 flake8 isort>=4.3.5 mypy>=0.800 black pywin32 types-python-dateutil
+        python -m pip install --upgrade pip six setuptools flake8 isort>=4.3.5 mypy>=0.800 black pywin32 types-python-dateutil
     - name: Create local develop
       run: |
         .\spack\.github\workflows\setup_git.ps1

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -47,6 +47,7 @@ class PySetuptools(Package):
     depends_on('python@3.5:', type=('build', 'run'), when='@45:50')
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@44')
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:43')
+    depends_on('py-pip', type='build')
 
     def url_for_version(self, version):
         url = "https://files.pythonhosted.org/packages/{0}/s/setuptools/setuptools-{1}-{0}-none-any.whl"
@@ -64,6 +65,8 @@ class PySetuptools(Package):
         # https://github.com/pypa/setuptools/issues/980#issuecomment-1154471423
         #
         # We work around this issue by installing setuptools from wheels
+        import os
+        raise RuntimeError(os.environ['PYTHONPATH'])
         whl = self.stage.archive_file
         args = ['-m', 'pip'] + std_pip_args + ['--prefix=' + prefix, whl]
         python(*args)

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -65,8 +65,6 @@ class PySetuptools(Package):
         # https://github.com/pypa/setuptools/issues/980#issuecomment-1154471423
         #
         # We work around this issue by installing setuptools from wheels
-        import os
-        raise RuntimeError(os.environ['PYTHONPATH'])
         whl = self.stage.archive_file
         args = ['-m', 'pip'] + std_pip_args + ['--prefix=' + prefix, whl]
         python(*args)

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -6,44 +6,42 @@
 from spack.package import *
 
 
-class PySetuptools(PythonPackage):
+class PySetuptools(Package):
     """A Python utility that aids in the process of downloading, building,
        upgrading, installing, and uninstalling Python packages."""
 
     homepage = "https://github.com/pypa/setuptools"
-    pypi = "setuptools/setuptools-57.4.0.tar.gz"
+    url = "https://files.pythonhosted.org/packages/py3/s/setuptools/setuptools-62.3.2-py3-none-any.whl"
+    list_url = "https://pypi.org/simple/setuptools/"
 
-    version('62.3.2', sha256='a43bdedf853c670e5fed28e5623403bad2f73cf02f9a2774e91def6bda8265a7')
-    version('59.4.0', sha256='b4c634615a0cf5b02cf83c7bedffc8da0ca439f00e79452699454da6fbd4153d')
-    version('58.2.0', sha256='2c55bdb85d5bb460bd2e3b12052b677879cffcf46c0c688f2e5bf51d36001145')
-    version('57.4.0', sha256='6bac238ffdf24e8806c61440e755192470352850f3419a52f26ffe0a1a64f465')
-    version('57.1.0', sha256='cfca9c97e7eebbc8abe18d5e5e962a08dcad55bb63afddd82d681de4d22a597b')
-    version('51.0.0', sha256='029c49fd713e9230f6a41c0298e6e1f5839f2cde7104c0ad5e053a37777e7688')
-    version('50.3.2', sha256='ed0519d27a243843b05d82a5e9d01b0b083d9934eaa3d02779a23da18077bd3c')
-    version('50.1.0', sha256='4a7708dafd2d360ce5e2ac7577374da9fb65fc867bc4cdaf461f9f834dfa6ac3')
-    version('49.6.0', sha256='46bd862894ed22c2edff033c758c2dc026324788d758e96788e8f7c11f4e9707')
-    version('49.2.0', sha256='afe9e81fee0270d3f60d52608549cc8ec4c46dada8c95640c1a00160f577acf2')
-    version('46.1.3', sha256='795e0475ba6cd7fa082b1ee6e90d552209995627a2a227a47c6ea93282f4bfb1')
-    version('44.1.1', sha256='c67aa55db532a0dadc4d2e20ba9961cbd3ccc84d544e9029699822542b5a476b')
-    version('44.1.0', sha256='794a96b0c1dc6f182c36b72ab70d7e90f1d59f7a132e6919bb37b4fd4d424aca')
-    version('43.0.0', sha256='db45ebb4a4b3b95ff0aca3ce5fe1e820ce17be393caf8902c78aa36240e8c378')
-    version('41.4.0', sha256='7eae782ccf36b790c21bde7d86a4f303a441cd77036b25c559a602cf5186ce4d')
-    version('41.3.0', sha256='9f5c54b529b2156c6f288e837e625581bb31ff94d4cfd116b8f271c589749556')
-    version('41.0.1', sha256='a222d126f5471598053c9a77f4b5d4f26eaa1f150ad6e01dcf1a42e185d05613')
-    version('41.0.0', sha256='79d30254b6fe7a8e672e43cd85f13a9f3f2a50080bc81d851143e2219ef0dcb1')
-    version('40.8.0', sha256='6e4eec90337e849ade7103723b9a99631c1f0d19990d6e8412dc42f5ae8b304d')
-    version('40.4.3', sha256='acbc5740dd63f243f46c2b4b8e2c7fd92259c2ddb55a4115b16418a2ed371b15')
-    version('40.2.0', sha256='47881d54ede4da9c15273bac65f9340f8929d4f0213193fa7894be384f2dcfa6')
-    version('39.2.0', sha256='f7cddbb5f5c640311eb00eab6e849f7701fa70bf6a183fc8a2c33dd1d1672fb2')
-    version('39.0.1', sha256='bec7badf0f60e7fc8153fac47836edc41b74e5d541d7692e614e635720d6a7c7')
-    version('25.2.0', sha256='b2757ddac2c41173140b111e246d200768f6dd314110e1e40661d0ecf9b4d6a6')
-    version('20.7.0', sha256='505cdf282c5f6e3a056e79f0244b8945f3632257bba8469386c6b9b396400233')
-    version('20.6.7', sha256='d20152ee6337323d3b6d95cd733fb719d6b4f3fbc40f61f7a48e5a1bb96478b2')
-    version('19.2',   sha256='f90ed8eb70b14b0594ba74e9de4ffca040c0ec8ee505cbf3570499467859f71a')
-    version('18.1',   sha256='ad52a9d5b3a6f39c2a1c2deb96cc4f6aff29d6511bdea2994322c40b60c9c36a')
-    version('16.0',   sha256='aa86255dee2c4a0056509750008007667c29306b7a6c13801468515b2c672845')
-    version('11.3.1', sha256='bd25f17de4ecf00116a9f7368b614a54ca1612d7945d2eafe5d97bc08c138bc5')
+    version('62.3.2', sha256='68e45d17c9281ba25dc0104eadd2647172b3472d9e01f911efa57965e8d51a36', expand=False)
+    version('59.4.0', sha256='feb5ff19b354cde9efd2344ef6d5e79880ce4be643037641b49508bbb850d060', expand=False)
+    version('58.2.0', sha256='2551203ae6955b9876741a26ab3e767bb3242dafe86a32a749ea0d78b6792f11', expand=False)
+    version('57.4.0', sha256='a49230977aa6cfb9d933614d2f7b79036e9945c4cdd7583163f4e920b83418d6', expand=False)
+    version('57.1.0', sha256='ddae4c1b9220daf1e32ba9d4e3714df6019c5b583755559be84ff8199f7e1fe3', expand=False)
+    version('51.0.0', sha256='8c177936215945c9a37ef809ada0fab365191952f7a123618432bbfac353c529', expand=False)
+    version('50.3.2', sha256='2c242a0856fbad7efbe560df4a7add9324f340cf48df43651e9604924466794a', expand=False)
+    version('50.1.0', sha256='4537c77e6e7dc170081f8547564551d4ff4e4999717434e1257600bbd3a23296', expand=False)
+    version('49.6.0', sha256='4dd5bb0a0a0cff77b46ca5dd3a84857ee48c83e8223886b556613c724994073f', expand=False)
+    version('49.2.0', sha256='272c7f48f5cddc5af5901f4265274c421c7eede5c8bc454ac2903d3f8fc365e9', expand=False)
+    version('46.1.3', sha256='4fe404eec2738c20ab5841fa2d791902d2a645f32318a7850ef26f8d7215a8ee', expand=False)
+    version('44.1.1', sha256='27a714c09253134e60a6fa68130f78c7037e5562c4f21f8f318f2ae900d152d5', expand=False)
+    version('44.1.0', sha256='992728077ca19db6598072414fb83e0a284aca1253aaf2e24bb1e55ee6db1a30', expand=False)
+    version('43.0.0', sha256='a67faa51519ef28cd8261aff0e221b6e4c370f8fb8bada8aa3e7ad8945199963', expand=False)
+    version('41.4.0', sha256='8d01f7ee4191d9fdcd9cc5796f75199deccb25b154eba82d44d6a042cf873670', expand=False)
+    version('41.3.0', sha256='e9832acd9be6f3174f4c34b40e7d913a146727920cbef6465c1c1bd2d21a4ec4', expand=False)
+    version('41.0.1', sha256='c7769ce668c7a333d84e17fe8b524b1c45e7ee9f7908ad0a73e1eda7e6a5aebf', expand=False)
+    version('41.0.0', sha256='e67486071cd5cdeba783bd0b64f5f30784ff855b35071c8670551fd7fc52d4a1', expand=False)
+    version('40.8.0', sha256='e8496c0079f3ac30052ffe69b679bd876c5265686127a3159cfa415669b7f9ab', expand=False)
+    version('40.4.3', sha256='ce4137d58b444bac11a31d4e0c1805c69d89e8ed4e91fde1999674ecc2f6f9ff', expand=False)
+    version('40.2.0', sha256='ea3796a48a207b46ea36a9d26de4d0cc87c953a683a7b314ea65d666930ea8e6', expand=False)
+    version('39.2.0', sha256='8fca9275c89964f13da985c3656cb00ba029d7f3916b37990927ffdf264e7926', expand=False)
+    version('39.0.1', sha256='8010754433e3211b9cdbbf784b50f30e80bf40fc6b05eb5f865fab83300599b8', expand=False)
+    version('25.2.0', sha256='2845247c359bb91097ccf8f6be8a69edfa44847f3d2d5def39aa43c3d7f615ca', expand=False)
+    version('20.7.0', sha256='8917a52aa3a389893221b173a89dae0471022d32bff3ebc31a1072988aa8039d', expand=False)
+    version('20.6.7', sha256='9982ee4d279a2541dc1a7efee994ff9c535cfc05315e121e09df7f93da48c442', expand=False)
 
+    extends('python')
     depends_on('python@3.7:', type=('build', 'run'), when='@59.7:')
     depends_on('python@3.6:', type=('build', 'run'), when='@51:')
     depends_on('python@3.5:', type=('build', 'run'), when='@45:50')
@@ -51,11 +49,21 @@ class PySetuptools(PythonPackage):
     depends_on('python@2.7:2.8,3.4:', type=('build', 'run'), when='@:43')
 
     def url_for_version(self, version):
-        url = 'https://pypi.io/packages/source/s/setuptools/setuptools-{0}.{1}'
+        url = "https://files.pythonhosted.org/packages/{0}/s/setuptools/setuptools-{1}-{0}-none-any.whl"
 
-        if Version('32.1.2') <= version <= Version('51.0.0'):
-            ext = 'zip'
+        if version >= Version('45.1.0'):
+            python_tag = 'py3'
         else:
-            ext = 'tar.gz'
+            python_tag = 'py2.py3'
+        return url.format(python_tag, version)
 
-        return url.format(version, ext)
+    def install(self, spec, prefix):
+        # When setuptools changes its entry point we might get weird
+        # incompatibilities if building from sources in a non-isolated environment.
+        #
+        # https://github.com/pypa/setuptools/issues/980#issuecomment-1154471423
+        #
+        # We work around this issue by installing setuptools from wheels
+        whl = self.stage.archive_file
+        args = ['-m', 'pip'] + std_pip_args + ['--prefix=' + prefix, whl]
+        python(*args)


### PR DESCRIPTION
When installing setuptools from sources in Spack, we might get into weird failures due to the way we use pip.

In particular, for Spack it's necessary to install in a non-isolated pip environment to allow using PYTHONPATH as a selection method for all the build requirements of a Python package.

This can fail when installing setuptools since there might be a setuptools version already installed for the Python interpreter being used, with different entry points than the one we want to install. The failure encountered in that case is like the one shown [here](https://github.com/pypa/setuptools/issues/980#issuecomment-1154471423).

Installing from wheels _both_ `pip` and `setuptools` should harden our installation procedure in the context of:
- Bootstrapping Python dependencies of Spack
- Using external Python packages

This PR takes this approach and changes the way we install py-setuptools in Spack.