### PR TITLE
Proper escaping to prevent `spack env activate -p` from breaking terminals.

### DIFF
--- a/lib/spack/spack/environment/shell.py
+++ b/lib/spack/spack/environment/shell.py
@@ -26,7 +26,7 @@ def activate_header(env, shell, prompt=None):
             cmds += 'set prompt="%s ${prompt}";\n' % prompt
     elif shell == 'fish':
         if 'color' in os.getenv('TERM', '') and prompt:
-            prompt = colorize('@G{%s} ' % prompt, color=True)
+            prompt = colorize('@G{%s} ' % prompt, color=True).replace('\033','\\033')
 
         cmds += 'set -gx SPACK_ENV %s;\n' % env.path
         cmds += 'function despacktivate;\n'
@@ -44,7 +44,7 @@ def activate_header(env, shell, prompt=None):
         # TODO: prompt
     else:
         if 'color' in os.getenv('TERM', '') and prompt:
-            prompt = colorize('@G{%s}' % prompt, color=True)
+            prompt = colorize('@G{%s}' % prompt, color=True).replace('\033','\\033')
 
         cmds += 'export SPACK_ENV=%s;\n' % env.path
         cmds += "alias despacktivate='spack env deactivate';\n"


### PR DESCRIPTION
See notes from Slack conversation:
> I think there’s something weird about how `spack env activate -p` is handling color codes.
> The existing prompt’s color codes show up escaped if I `echo $PS1` or `echo $SPACK_OLD_PS1`, but Spack’s prefixed environment name shows up in bright green, and in fact, with, `spack env activate -p --sh` even the shell source being printed shows the environment name in bright green.
> This wouldn’t bother me, except in tandem, I can no longer properly scroll through or delete entries in the command history (fragments of old commands the same length as the environment name get “stuck”), running `export PS1=$SPACK_OLD_PS1` fixed the issue so I’m pretty sure it’s connected to the incorrect color code escaping