### PR TITLE
grid: Add new package

### DIFF
--- a/var/spack/repos/builtin/packages/grid/package.py
+++ b/var/spack/repos/builtin/packages/grid/package.py
@@ -13,6 +13,8 @@ class Grid(AutotoolsPackage):
     url      = "https://github.com/paboyle/Grid/archive/refs/tags/0.8.2.tar.gz"
     git      = "https://github.com/paboyle/Grid.git"
 
+    maintainers = ['giordano']
+
     version('develop', branch='develop')
 
     variant('comms', default='mpi',

--- a/var/spack/repos/builtin/packages/grid/package.py
+++ b/var/spack/repos/builtin/packages/grid/package.py
@@ -1,0 +1,149 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+# ----------------------------------------------------------------------------
+# If you submit this package back to Spack as a pull request,
+# please first remove this boilerplate and all FIXME comments.
+#
+# This is a template package file for Spack.  We've put "FIXME"
+# next to all the things you'll want to change. Once you've handled
+# them, you can save this file and test your package like this:
+#
+#     spack install grid
+#
+# You can edit this file again by typing:
+#
+#     spack edit grid
+#
+# See the Spack documentation for more information on packaging.
+# ----------------------------------------------------------------------------
+
+from spack.package import *
+
+
+class Grid(AutotoolsPackage):
+    """Data parallel C++ mathematical object library."""
+
+    homepage = "https://github.com/paboyle/Grid"
+    url      = "https://github.com/paboyle/Grid/archive/refs/tags/0.8.2.tar.gz"
+    git      = "https://github.com/paboyle/Grid.git"
+
+    version('develop', branch='develop')
+    # v0.8.2 is currently the latest "numbered" version, but it doesn't build
+    # because during bootstrap it automatically downloads Eigen, but it fetches
+    # it from the old Bitbucket repository which doesn't exist anymore.
+    version('0.8.2', sha256='2b3389a75dec78f154aa28c8828d81a251b0331284f37cede95747255adef13a', deprecated=True)
+
+    depends_on('autoconf', type='build')
+    depends_on('automake', type='build')
+    depends_on('libtool',  type='build')
+    depends_on('m4',       type='build')
+
+    depends_on('gmp')
+    depends_on('mpfr')
+
+    variant('comms', default='mpi',
+            values=('none', 'mpi', 'mpi3', conditional('shmem', when='^cray-mpich')),
+            description='Choose communication interface')
+    depends_on('mpi', when='comms=mpi')
+    depends_on('cray-mpich', when='comms=shmem')
+    depends_on('mpi@3:', when='comms=mpi3')
+
+    variant('fftw', default=True, description='Activate FFTW support')
+    depends_on('fftw-api@3', when='+fftw')
+
+    variant('lapack', default=False, description='Activate LAPACK support')
+    depends_on('lapack', when='+lapack')
+
+    variant('hdf5', default=False, description='Activate HDF5 support')
+    depends_on('hdf5', when='+hdf5')
+
+    variant('lime', default=False, description='Activate LIME support')
+    depends_on('c-lime', when='+lime')
+
+    variant('doc', default=False,
+            description='Build the documentation with doxygen')
+    depends_on("doxygen", type="build", when="+doc")
+
+    variant('gen-simd-width', default='64',
+            description='Size (in bytes) of the generic SIMD vector type')
+    variant('rng', default='sitmo', values=('sitmo', 'ranlux48', 'mt19937'),
+            multi=False, description='RNG setting')
+    variant('timers', default=True,
+            description='System dependent high-resolution timers')
+    variant('chroma', default=False,
+            description='Chroma regression tests')
+
+    def autoreconf(self, spec, prefix):
+        Executable('./bootstrap.sh')()
+
+    def configure_args(self):
+        spec = self.spec
+        args = ['--with-gmp', '--with-mpfr']
+
+        if spec.satisfies('^intel-mkl'):
+            if '+fftw' in spec or '+lapack' in spec:
+                args.append('--enable-mkl')
+        else:
+            if '+fftw' in spec:
+                args.append('--with-fftw={0}'.format(self.spec['fftw'].prefix))
+            if '+lapack' in spec:
+                args.append('--enable-lapack={0}'.format(self.spec['lapack'].prefix))
+                # lapack is searched only as `-llapack`, so anything else
+                # wouldn't be found, causing an error.
+                args.append('LIBS={0}'.format(self.spec['lapack'].libs.ld_flags))
+
+        if 'comms=none' not in spec:
+            # The build system can easily get very confused about MPI support
+            # and what linker to use.  In many case it'd end up building the
+            # code with support for MPI but without using `mpicxx` or linking to
+            # `-lmpi`, wreaking havoc.  Forcing `CXX` to be mpicxx should help.
+            args.extend([
+                "CC={0}".format(spec['mpi'].mpicc),
+                "CXX={0}".format(spec['mpi'].mpicxx),
+            ])
+
+        if '+timers' in spec:
+            args.append('--enable-timers')
+        else:
+            args.append('--disable-timers')
+
+        if '+chroma' in spec:
+            args.append('--enable-chroma')
+        else:
+            args.append('--disable-chroma')
+
+        if '+doc' in spec:
+            args.append('--enable-doxygen-doc')
+        else:
+            args.append('--disable-doxygen-doc')
+
+        if 'avx512' in spec.target:
+            args.append('--enable-simd=AVX512')
+        elif 'avx2' in spec.target:
+            args.append('--enable-simd=AVX2')
+        elif 'avx' in spec.target:
+            if 'fma4' in spec.target:
+                args.append('--enable-simd=AVXFMA4')
+            elif 'fma' in spec.target:
+                args.append('--enable-simd=AVXFMA')
+            else:
+                args.append('--enable-simd=AVX')
+        elif 'sse4_2' in spec.target:
+            args.append('--enable-simd=SSE4')
+        elif spec.target == 'a64fx':
+            args.append('--enable-simd=A64FX')
+        elif 'neon' in spec.target:
+            args.append('--enable-simd=NEONv8')
+        else:
+            args.extend([
+                '--enable-simd=GEN',
+                '--enable-gen-simd-width={0}'.format(spec.variants['gen-simd-width'].value)
+            ])
+
+        args.append('--enable-comms={0}'.format(spec.variants['comms'].value))
+        args.append('--enable-rng={0}'.format(spec.variants['rng'].value))
+
+        return args

--- a/var/spack/repos/builtin/packages/grid/package.py
+++ b/var/spack/repos/builtin/packages/grid/package.py
@@ -39,6 +39,7 @@ class Grid(AutotoolsPackage):
     depends_on('m4',       type='build')
     depends_on('gmp')
     depends_on('mpfr')
+    depends_on('openssl')
 
     depends_on('mpi', when='comms=mpi')
     depends_on('cray-mpich', when='comms=shmem')


### PR DESCRIPTION
For the time being I've successfully built this package on an avx512 machine with spec `grid@develop~lapack`.  I had to remove lapack because compilation of some tests (which can't be skipped) fails at the linking stage with undefined symbols:
```
     1632    /lustre/scratch/scratch/cceamgi/tmp/tmp2/opt/spack/linux-rhel7-skylake_avx512/gcc-10.2.0/openmpi-4.1.4-vr4kakg2vxezch4qy32o6mhrxyi4q3f3/bin/mpic++ -I/tmp/cceamgi/spack-stage/spack-stage-grid-devel
             op-q7htcwnjj6kr3emxbrz33rhzid3234y6/spack-src -mavx512f -mavx512cd -I/lustre/scratch/scratch/cceamgi/tmp/tmp2/opt/spack/linux-rhel7-skylake_avx512/gcc-10.2.0/openblas-0.3.20-wpcjgykadhedaye62xxcqy
             ghj36uk2uh/include -I/lustre/scratch/scratch/cceamgi/tmp/tmp2/opt/spack/linux-rhel7-skylake_avx512/gcc-10.2.0/fftw-3.3.10-bhurwbbqjtwv3nvnoy5koeg2cyinyo5j/include -Iyes/include -Iyes/include -fope
             nmp  -O3   -fno-strict-aliasing -L/tmp/cceamgi/spack-stage/spack-stage-grid-develop-q7htcwnjj6kr3emxbrz33rhzid3234y6/spack-src/Grid -L/lustre/scratch/scratch/cceamgi/tmp/tmp2/opt/spack/linux-rhel7
             -skylake_avx512/gcc-10.2.0/openblas-0.3.20-wpcjgykadhedaye62xxcqyghj36uk2uh/lib -L/lustre/scratch/scratch/cceamgi/tmp/tmp2/opt/spack/linux-rhel7-skylake_avx512/gcc-10.2.0/fftw-3.3.10-bhurwbbqjtwv3
             nvnoy5koeg2cyinyo5j/lib -Lyes/lib -Lyes/lib -fopenmp   -o Test_compressed_lanczos_hot_start Test_compressed_lanczos_hot_start.o ../Grid/libGrid.a -lz -lcrypto -lfftw3f -lfftw3 -lmpfr -lgmp -lstdc+
             + -lm -L/lustre/scratch/scratch/cceamgi/tmp/tmp2/opt/spack/linux-rhel7-skylake_avx512/gcc-10.2.0/openblas-0.3.20-wpcjgykadhedaye62xxcqyghj36uk2uh/lib -lopenblas -lz
     1633    Test_compressed_lanczos_hot_start.o: In function `Grid::ImplicitlyRestartedLanczos<Grid::Lattice<Grid::iScalar<Grid::iVector<Grid::iVector<Grid::Grid_simd<std::complex<double>, double __vector(8)>
             , 3>, 4> > > >::diagonalize(std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, int, int, Eigen::Matrix<double, -1, -1, 0, -1, -1>&, Grid::GridBase*)':
  >> 1634    Test_compressed_lanczos_hot_start.cc:(.text._ZN4Grid26ImplicitlyRestartedLanczosINS_7LatticeINS_7iScalarINS_7iVectorINS3_INS_9Grid_simdISt7complexIdEDv8_dEELi3EEELi4EEEEEEEE11diagonalizeERSt6vecto
             rIdSaIdEESH_iiRN5Eigen6MatrixIdLin1ELin1ELi0ELin1ELin1EEEPNS_8GridBaseE[_ZN4Grid26ImplicitlyRestartedLanczosINS_7LatticeINS_7iScalarINS_7iVectorINS3_INS_9Grid_simdISt7complexIdEDv8_dEELi3EEELi4EEE
             EEEEE11diagonalizeERSt6vectorIdSaIdEESH_iiRN5Eigen6MatrixIdLin1ELin1ELi0ELin1ELin1EEEPNS_8GridBaseE]+0x1589): undefined reference to `Grid::ImplicitlyRestartedLanczos<Grid::Lattice<Grid::iScalar<G
             rid::iVector<Grid::iVector<Grid::Grid_simd<std::complex<double>, double __vector(8)>, 3>, 4> > > >::LAPACK_dstegr(char*, char*, int*, double*, double*, double*, double*, int*, int*, double*, int*,
              double*, double*, int*, int*, double*, int*, int*, int*, int*)'
  >> 1635    collect2: error: ld returned 1 exit status
```

CC: @paboyle