### PR TITLE
concretize.lp: impose a lower bound on the number of version facts if a solution exists

### DIFF
--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -120,6 +120,11 @@ version_weight(Package, Weight)
 { version(Package, Version) : version_satisfies(Package, Constraint, Version) }
   :- node_version_satisfies(Package, Constraint).
 
+% If there is at least a version that satisfy the constraint, impose a lower
+% bound on the choice rule to avoid false positives with the error below
+1 { version(Package, Version) : version_satisfies(Package, Constraint, Version) }
+  :- node_version_satisfies(Package, Constraint), version_satisfies(Package, Constraint, _).
+
 % More specific error message if the version cannot satisfy some constraint
 % Otherwise covered by `no_version_error` and `versions_conflict_error`.
 error(1, "No valid version for '{0}' satisfies '@{1}'", Package, Constraint)

--- a/var/spack/repos/builtin.mock/packages/non-existing-conditional-dep/package.py
+++ b/var/spack/repos/builtin.mock/packages/non-existing-conditional-dep/package.py
@@ -1,0 +1,16 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+from spack.package import *
+
+
+class NonExistingConditionalDep(Package):
+    """Simple package with no source and one dependency"""
+
+    homepage = "http://www.example.com"
+
+    version('2.0')
+    version('1.0')
+
+    depends_on('dep-with-variants@999', when='@2.0')


### PR DESCRIPTION
fixes #30864

Modifications:
- [x] Add a rule to avoid hitting no-version errors where a version exists
- [x] Add a unit test