### PR TITLE
gcc: inherit --build/--host/--target

### DIFF
--- a/var/spack/repos/builtin/packages/gcc/package.py
+++ b/var/spack/repos/builtin/packages/gcc/package.py
@@ -720,31 +720,33 @@ class Gcc(AutotoolsPackage, GNUMirrorPackage):
         options.append("--with-boot-ldflags=" + boot_ldflags)
         options.append("--with-build-config=spack")
 
-        if self.compiler.name == 'gcc':
-            # Inherit the value of the --target argument from gcc that we are building
-            # with. We need this to help the Intel Compiler Classic, which uses gcc
-            # under the hood, find target-specific headers residing in a subdirectory
-            # of /usr/include on Debian systems (e.g. /usr/include/x86_64-linux-gnu).
+        if self.compiler.name == "gcc":
+            # Inherit the value of the --target argument from gcc that we are building with. We
+            # need this to help the Intel Compiler Classic, which uses gcc under the hood, find
+            # target-specific headers residing in a subdirectory of /usr/include on Debian systems
+            # (e.g. /usr/include/x86_64-linux-gnu).
             # See https://community.intel.com/t5/Intel-C-Compiler/Intel-compiler-and-usr-include-target/m-p/1162649
             compiler = Executable(self.compiler.cc)
-            gcc_output = compiler('-v', output=str, error=str)
+            gcc_output = compiler("-v", output=str, error=str)
 
             system_args = {}
             for out_line in gcc_output.splitlines():
-                if out_line.startswith('Configured with: '):
-                    for arg, value in re.findall(r'\s--(:?build|target|host)=([^\s]+)',
-                                                 gcc_output):
+                if out_line.startswith("Configured with: "):
+                    for arg, value in re.findall(
+                        r"\s--(:?build|target|host)=([^\s]+)", gcc_output
+                    ):
                         system_args[arg] = value
 
             if system_args:
-                if 'target' not in system_args:
+                if "target" not in system_args:
                     # Cover the case when --target was inherited from --build or --host:
-                    if 'host' not in system_args:
-                        system_args['host'] = system_args['build']
-                    system_args['target'] = system_args['host']
+                    if "host" not in system_args:
+                        system_args["host"] = system_args["build"]
+                    system_args["target"] = system_args["host"]
 
-                options.extend(['--{0}={1}'.format(arg, value)
-                                for arg, value in system_args.items()])
+                options.extend(
+                    ["--{0}={1}".format(arg, value) for arg, value in system_args.items()]
+                )
 
         return options
 


### PR DESCRIPTION
The Intel C/C++ Compiler Classic cannot compile a simple program when used with a Spack-installed `gcc` on Debian:
```console
$ spack install gcc
$ spack install intel-oneapi-compilers
$ spack load gcc
$ spack load intel-oneapi-compilers
$ cat test.c
#include <stdio.h>
int main() { printf("Hello!\n"); return 0; }

$ icc test.c
In file included from /usr/include/stdio.h(27),
                 from ./test.c(1):
/usr/include/features.h(364): catastrophic error: cannot open source file "sys/cdefs.h"
  #  include <sys/cdefs.h>
                          ^

compilation aborted for ./test.c (code 4)
```

The required header resides in `/usr/include/x86_64-linux-gnu`, which the Intel compiler does not add to the list of the header search paths when using a Spack-installed `gcc`. It does with the system one though. I noticed that quite some time ago and described the problem and a possible solution [here](https://community.intel.com/t5/Intel-C-Compiler/Intel-compiler-and-usr-include-target/m-p/1162649). Recently, I finally got tired of adding the `-isystem/usr/include/x86_64-linux-gnu` compiler flag and decided to dig a bit deeper. It turns out that the real trigger for the Intel compiler to look into `/usr/include/x86_64-linux-gnu` is the presence of the the `--target` argument on the `Configured with:` line of the `gcc -v` output:
```console
$ /usr/bin/gcc -v
...
Target: x86_64-linux-gnu
Configured with: ../src/configure ... --target=x86_64-linux-gnu
...
```
Yes, the line `Target: x86_64-linux-gnu` does not play any role in this case. It's really the `--target` argument. This PR makes the Spack-installed `gcc` inherit the `--build/--host/--target` arguments from the system `gcc`. And Intel works with it without the additional header search flag.