### PR TITLE
Manifest parsing: avoid irrelevant files

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -177,7 +177,10 @@ def _collect_and_consume_cray_manifest_files(
 
     for directory in manifest_dirs:
         for fname in os.listdir(directory):
-            manifest_files.append(os.path.join(directory, fname))
+            if fname.endswith('.json'):
+                fpath = os.path.join(directory, fname)
+                tty.debug("Adding manifest file: {0}".format(fpath))
+                manifest_files.append(os.path.join(directory, fpath))
 
     if not manifest_files:
         raise NoManifestFileError(
@@ -185,6 +188,7 @@ def _collect_and_consume_cray_manifest_files(
             .format(cray_manifest.default_path))
 
     for path in manifest_files:
+        tty.debug("Reading manifest file: " + path)
         try:
             cray_manifest.read(path, not dry_run)
         except (spack.compilers.UnknownCompilerError, spack.error.SpackError) as e:

--- a/lib/spack/spack/cray_manifest.py
+++ b/lib/spack/spack/cray_manifest.py
@@ -20,6 +20,7 @@ default_path = '/opt/cray/pe/cpe-descriptive-manifest/'
 
 compiler_name_translation = {
     'nvidia': 'nvhpc',
+    'rocm': 'rocmcc',
 }
 
 


### PR DESCRIPTION
The default manifest directory contains files that are not manifest files. This adds a simple filter to exclude non-manifest files (it is assumed that any file with a `.json` extension is a manifest files).

This also includes a separate commit to translate the manifest compiler ID "rocm" to "rocmcc" (which is Spack's name for the ROCm compiler).