### PR TITLE
ome-files-cpp: add v0.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/ome-common-cpp/package.py
+++ b/var/spack/repos/builtin/packages/ome-common-cpp/package.py
@@ -1,0 +1,35 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class OmeCommonCpp(CMakePackage):
+    """Open Microscopy Environment: Common functionality for OME C++ libraries and
+    applications which is not readily available from the C++ Standard Library.
+    This includes basic portability functions, to wrapping other libraries to
+    make them usable with Modern C++ programming practices.
+
+    """
+
+    homepage = "https://gitlab.com/codelibre/ome/ome-common-cpp"
+    url = "https://gitlab.com/codelibre/ome/ome-common-cpp/-/archive/v6.0.0/ome-common-cpp-v6.0.0.tar.gz"
+    git = "https://gitlab.com/codelibre/ome/ome-common-cpp.git"
+
+    maintainers = ['omsai']
+
+    version('master', branch='master')
+    version('6.0.0', sha256='26f3ce6e0b9a022590eed2ade5519eca12a2507bb207cdfe9f29d360984a7e0d')
+
+    depends_on('fmt')
+    depends_on('spdlog')
+    depends_on('xalan-c')
+    depends_on('googletest', type='test')
+
+    def cmake_args(self):
+        return [
+            '-DCMAKE_CXX_STANDARD=17',
+            '-DCMAKE_CXX_STANDARD_REQUIRED=ON',
+        ]

--- a/var/spack/repos/builtin/packages/ome-files-cpp/package.py
+++ b/var/spack/repos/builtin/packages/ome-files-cpp/package.py
@@ -1,0 +1,34 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class OmeFilesCpp(CMakePackage):
+    """Open Microscopy Environment OME Files is a standalone C++ library for reading
+    and writing life sciences image file formats.  It is the reference
+    implementation of the OME-TIFF file format.
+
+    """
+
+    homepage = "https://codelibre.gitlab.io/ome/ome-files-cpp/doc/"
+    url = "https://gitlab.com/codelibre/ome/ome-files-cpp/-/archive/v0.6.0/ome-files-cpp-v0.6.0.tar.gz"
+    git = "https://gitlab.com/codelibre/ome/ome-files-cpp.git"
+
+    maintainers = ['omsai']
+
+    version('master', branch='master')
+    version('0.6.0', sha256='e0baf3eeb2ea639f426292a36b58adcaa42ce61a4a0f15f34690602f3f5d47c1')
+
+    depends_on('boost@1.53: +filesystem +program_options')
+    depends_on('ome-model')
+    depends_on('ome-model@master', when='@master')
+    depends_on('googletest', type='test')
+
+    def cmake_args(self):
+        return [
+            '-DCMAKE_CXX_STANDARD=17',
+            '-DCMAKE_CXX_STANDARD_REQUIRED=ON',
+        ]

--- a/var/spack/repos/builtin/packages/ome-model/package.py
+++ b/var/spack/repos/builtin/packages/ome-model/package.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class OmeModel(CMakePackage):
+    """Open Microscopy Environment data model specification, code generator and
+    implementation.
+
+    """
+
+    homepage = "https://codelibre.gitlab.io/ome/ome-model/doc/"
+    url = "https://gitlab.com/codelibre/ome/ome-model/-/archive/v6.0.0/ome-model-v6.0.0.tar.gz"
+    git = "https://gitlab.com/codelibre/ome/ome-model.git"
+
+    maintainers = ['omsai']
+
+    version('master', branch='master')
+    version('6.0.0', sha256='d6644ff722411d3a8ac9f26a49c1afda30e4d4102e37b31593d2a9fdc8f96700')
+
+    # Match version with ome-common-cpp.  It would be nice to match versions in a
+    # more automated way.
+    depends_on('ome-common-cpp')
+    depends_on('ome-common-cpp@master', when='@master')
+    depends_on('ome-common-cpp@6.0.0', when='@6.0.0')
+    # For running the xsd-fu bundled build tool.
+    depends_on('python@3', type='build')
+    # From the requirements.txt of xsd-fu
+    depends_on('py-genshi', type='build')
+    depends_on('py-six', type='build')
+    # Optional tests.
+    depends_on('googletest', type='test')
+
+    def cmake_args(self):
+        return [
+            '-DCMAKE_CXX_STANDARD=17',
+            '-DCMAKE_CXX_STANDARD_REQUIRED=ON',
+        ]

--- a/var/spack/repos/builtin/packages/py-genshi/package.py
+++ b/var/spack/repos/builtin/packages/py-genshi/package.py
@@ -21,12 +21,12 @@ class PyGenshi(PythonPackage):
     # with this ambiguity.
     #
     # Older version of python before support for Py_UNICODE->str in genshi/_speedup.c
-    depends_on('python@:3.2', when='@:0.7.0')
+    depends_on('python@:3.2', when='@:0.7.0', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     # setup.py of 0.7 uses setup(features = ...) which was removed in
     # setuptools 46.0.0.
-    depends_on('py-setuptools@:45.3.0', type='build', when='@:0.7.0')
-    depends_on('py-six', type=['build', 'run', 'test'])
+    depends_on('py-setuptools@:45', type='build', when='@:0.7.0')
+    depends_on('py-six', type=('build', 'run', 'test'))
 
     # Suite of unittests added in 0.6.1.
     @when('@0.6.1:')

--- a/var/spack/repos/builtin/packages/py-genshi/package.py
+++ b/var/spack/repos/builtin/packages/py-genshi/package.py
@@ -15,16 +15,21 @@ class PyGenshi(PythonPackage):
     version('0.6.1', sha256='fed947f11dbcb6792bb7161701ec3b9804055ad68c8af0ab4f0f9b25e9a18dbd')
     version('0.6', sha256='32aaf76a03f88efa04143bf80700399e6d84eead818fdd19d763fd76af972a4b')
 
+    # Unfortunately, upstream's versioning scheme neglected the trailing zero
+    # x.x.0 which means that the spec @:0.7 also includes @0.7.7 which in a few
+    # cases below is not what we want.  Therefore explicitly use @0.7.0 to deal
+    # with this ambiguity.
+    #
     # Older version of python before support for Py_UNICODE->str in genshi/_speedup.c
-    depends_on('python@:3.2', when='@:0.7')
+    depends_on('python@:3.2', when='@:0.7.0')
     depends_on('py-setuptools', type='build')
     # setup.py of 0.7 uses setup(features = ...) which was removed in
     # setuptools 46.0.0.
-    depends_on('py-setuptools@:45.3.0', type='build', when='@:0.7')
+    depends_on('py-setuptools@:45.3.0', type='build', when='@:0.7.0')
     depends_on('py-six', type=['build', 'run', 'test'])
 
     # Suite of unittests added in 0.6.1.
-    @when('@0.6.1')
+    @when('@0.6.1:')
     def test(self):
         # All the unittests pass for py-genshi@0.7.7 but 14 tests fail for
         # @0.6.1:0.7, many of them related to templates, likely because the

--- a/var/spack/repos/builtin/packages/py-genshi/package.py
+++ b/var/spack/repos/builtin/packages/py-genshi/package.py
@@ -8,11 +8,27 @@ from spack.package import *
 
 class PyGenshi(PythonPackage):
     """Python toolkit for generation of output for the web"""
-    homepage = "https://genshi.edgewall.org/"
-    url      = "http://ftp.edgewall.com/pub/genshi/Genshi-0.7.tar.gz"
+    pypi = "Genshi/Genshi-0.7.7.tar.gz"
 
+    version('0.7.7', sha256='c100520862cd69085d10ee1a87e91289e7f59f6b3d9bd622bf58b2804e6b9aab')
     version('0.7', sha256='1d154402e68bc444a55bcac101f96cb4e59373100cc7a2da07fbf3e5cc5d7352')
     version('0.6.1', sha256='fed947f11dbcb6792bb7161701ec3b9804055ad68c8af0ab4f0f9b25e9a18dbd')
     version('0.6', sha256='32aaf76a03f88efa04143bf80700399e6d84eead818fdd19d763fd76af972a4b')
 
-    depends_on("py-setuptools@:57", type='build')
+    # Older version of python before support for Py_UNICODE->str in genshi/_speedup.c
+    depends_on('python@:3.2', when='@:0.7')
+    depends_on('py-setuptools', type='build')
+    # setup.py of 0.7 uses setup(features = ...) which was removed in
+    # setuptools 46.0.0.
+    depends_on('py-setuptools@:45.3.0', type='build', when='@:0.7')
+    depends_on('py-six', type=['build', 'run', 'test'])
+
+    # Suite of unittests added in 0.6.1.
+    @when('@0.6.1')
+    def test(self):
+        # All the unittests pass for py-genshi@0.7.7 but 14 tests fail for
+        # @0.6.1:0.7, many of them related to templates, likely because the
+        # template path needs to be setup.  But those versions didn't use tox
+        # and setting up the test environment to find the template files doesn't
+        # seem to be documented.
+        python('-m', 'unittest', '-v', 'genshi.tests.suite')

--- a/var/spack/repos/builtin/packages/xalan-c/package.py
+++ b/var/spack/repos/builtin/packages/xalan-c/package.py
@@ -1,0 +1,37 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class XalanC(CMakePackage):
+    """Xalan-C++ version is a robust implementation of the W3C Recommendations for
+    XSL Transformations (XSLT) and the XML Path Language (XPath). It works with
+    the Xerces-C++ XML parser.
+
+    """
+
+    homepage = "https://xalan.apache.org"
+    url      = "https://dlcdn.apache.org/xalan/xalan-c/sources/xalan_c-1.12.tar.gz"
+
+    maintainers = ['omsai']
+
+    version('1.12', sha256='ee7d4b0b08c5676f5e586c7154d94a5b32b299ac3cbb946e24c4375a25552da7')
+
+    variant('transcoder', default='default',
+            values=('default', 'icu'),
+            multi=False,
+            description='Use the default UTF-16 transcoder or ICU')
+
+    depends_on('xerces-c@3:')
+    depends_on('icu4c', type='link', when='transcoder=icu')
+
+    def cmake_args(self):
+        args = []
+
+        if 'transcoder=icu' in self.spec:
+            args.append('-Dtranscoder=icu')
+
+        return args


### PR DESCRIPTION
New package for Open Microscopy Environment C++ implementation.

1. Background is originally this was commercially developed by Glenco software and distributed by https://www.openmicroscopy.org/ however the company decided to focus on their Java implementation (called Bioformats) instead of this C++ rewrite (called OME Files C++).  The C++ rewrite has since been community maintained by [codelibre](https://gitlab.com/codelibre/ome).
1. All the ome-* packages require C++17.
1. On my machines, only the master development versions work, so I've tested:
   ```console
   $ spack install --test root ome-common-cpp@master %gcc@11.3.0
   $ spack install --test root ome-model@master %gcc@11.3.0
   $ spack install --test root ome-files-cpp@master %gcc@11.3.0
   ```
1. I needed to update py-genshi version for the cmake stage to succeed for ome-model.  This required pointing py-genshi to the new download releases on GitHub.  I don't know why py-genshi was pinned to an ancient version of py-setuptools, and I don't see any such setuptools limitation with the newer versions of genshi.  I checked that no spack packages besides mine currently depend on py-genshi, so removing the old genshi versions won't have any impact I expect.  Perhaps someone added py-genshi to run a dev-build for themselves?
1. I've intentionally ignored some possible variants, to follow upstream's CI setup for both xerces-c and ome-* packages.   I'm happy to add variants and have added myself as maintainer to accommodate requests.
