### PR TITLE
rpcsvc-proto: add 'cpp' path for rpcgen

### DIFF
--- a/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
+++ b/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
@@ -18,3 +18,10 @@ class RpcsvcProto(AutotoolsPackage):
 
     def configure_args(self):
         return ['LIBS=-lintl']
+
+    @run_before('build')
+    def change_makefile(self):
+        # Add 'cpp' path for rpcgen
+        filter_file('rpcgen/rpcgen',
+                    'rpcgen/rpcgen -Y {0}/lib/spack/env'.format(spack.paths.spack_root),
+                    'rpcsvc/Makefile')


### PR DESCRIPTION
An error occurred when building with clang. 
Error message is "cpp: error trying to exec 'cc1': execvp: No such file or directory".

In fact, this error occurs with all compilers.
When compiling with gcc,  '/usr/bin/cpp' can be found because it is always in $PATH.

The PR fixes this bug by adding 'cpp' path for rpcgen.
