### PR TITLE
CI: test binary bootstrapping of clingo on all macOS versions

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -180,10 +180,11 @@ jobs:
           tree ~/.spack/bootstrap/store/
 
   macos-clingo-binaries:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.macos-version }}
     strategy:
       matrix:
         python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        macos-version: ['macos-10.15', 'macos-11', 'macos-12']
     if: github.repository == 'spack/spack'
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Modifications:
- [x] Check binary bootstrapping for macos-catalina and macos-monterey in addition to macos-bigsur