### PR TITLE
gosam-contrib: build static libs by default

### DIFF
--- a/var/spack/repos/builtin/packages/gosam-contrib/package.py
+++ b/var/spack/repos/builtin/packages/gosam-contrib/package.py
@@ -17,7 +17,7 @@ class GosamContrib(AutotoolsPackage):
     version('2.0', sha256='c05beceea74324eb51c1049773095e2cb0c09c8c909093ee913d8b0da659048d')
     version('1.0', sha256='a29d4232d9190710246abc2ed97fdcd8790ce83580f56a360f3456b0377c40ec')
 
-    variant('libs', default='shared,static', values=('shared', 'static'),
+    variant('libs', default='static', values=('shared', 'static'),
             multi=True, description='Build shared libs, static libs or both')
     variant('pic', default=False, description='Build position-independent code')
 


### PR DESCRIPTION
Enabling both static and shared libs in clang13 leads to this error:
```
     908    /usr/bin/ld: ./interface/.libs/libgolem95_interface.a(tool_lt_to_golem.o): unable to initialize decompress status for section .debug_info
     909    /usr/bin/ld: ./interface/.libs/libgolem95_interface.a(tool_lt_to_golem.o): unable to initialize decompress status for section .debug_info
     910    ./interface/.libs/libgolem95_interface.a: member ./interface/.libs/libgolem95_interface.a(tool_lt_to_golem.o) in archive is not an object
  >> 911    clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
```