### PR TITLE
openssl: default to mozilla certs

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -85,7 +85,7 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
     version('1.0.1h', sha256='9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093', deprecated=True)
     version('1.0.1e', sha256='f74f15e8c8ff11aa3d5bb5f276d202ec18d7246e95f961db76054199c69c1ae3', deprecated=True)
 
-    variant('certs', default='system',
+    variant('certs', default='mozilla',
             values=('mozilla', 'system', 'none'), multi=False,
             description=('Use certificates from the ca-certificates-mozilla '
                          'package, symlink system certificates, or none'))

--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -85,10 +85,17 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
     version('1.0.1h', sha256='9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093', deprecated=True)
     version('1.0.1e', sha256='f74f15e8c8ff11aa3d5bb5f276d202ec18d7246e95f961db76054199c69c1ae3', deprecated=True)
 
+    # On Cray DVS mounts, we can't make symlinks to /etc/ssl/openssl.cnf,
+    # either due to a bug or because DVS is not intended to be POSIX compliant.
+    # Therefore, stick to system agnostic certs=mozilla.
     variant('certs', default='mozilla',
             values=('mozilla', 'system', 'none'), multi=False,
             description=('Use certificates from the ca-certificates-mozilla '
-                         'package, symlink system certificates, or none'))
+                         'package, symlink system certificates, or use none, '
+                         'respectively. The default is `mozilla`, since it is '
+                         'system agnostic. Instead of picking certs=system, '
+                         'one can mark openssl as an external package, to '
+                         'avoid compiling openssl entirely.'))
     variant('docs', default=False, description='Install docs and manpages')
     variant('shared', default=False, description="Build shared library version")
     with when('platform=windows'):


### PR DESCRIPTION
On Cray systems that use Cray Data Virtualization Service (DVS),
symlinks across filesystems are not allowed, either due to a bug, or
because they're simply not POSIX compliant [1].

Spack's OpenSSL package defaults to `certs=system` which comes down to
symlinking `/etc/ssl` in the Spack install prefix, triggering this
problem, resulting in mysterious installation failures.

Instead of relying on system certs, we can just use
`ca-certificates-mozilla`, and if users really need system certs, then
they're probably better off marking OpenSSL entirely as external.

[1] https://github.com/glennklockwood/cray-dvs in particular it's hitting
https://github.com/glennklockwood/cray-dvs/blob/e3da89b8a890cfd4881c6d5d3e75c7821e8f5f2c/kernel/dvscommon/dvscommon.c#L1805-L1811 this branch, in case any Cray folks are reading this...
