### PR TITLE
Stricter compatibility rules for OS and compiler when reusing specs

### DIFF
--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -631,6 +631,7 @@ class PyclingoDriver(object):
 
         # Load the file itself
         self.control.load(os.path.join(parent_dir, 'concretize.lp'))
+        self.control.load(os.path.join(parent_dir, "os_facts.lp"))
         self.control.load(os.path.join(parent_dir, "display.lp"))
         timer.phase("load")
 

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -737,9 +737,14 @@ node_os_mismatch(Package, Dependency) :-
 % every OS is compatible with itself. We can use `os_compatible` to declare
 os_compatible(OS, OS) :- os(OS).
 
-% OS compatibility rules for reusing solves.
-% catalina binaries can be used on bigsur. Direction is package -> dependency.
-os_compatible("bigsur", "catalina").
+% Transitive compatibility among operating systems
+os_compatible(OS1, OS3) :- os_compatible(OS1, OS2), os_compatible(OS2, OS3).
+
+% We can select only operating systems compatible with the ones
+% for which we can build software. We need a cardinality constraint
+% since we might have more than one "buildable_os(OS)" fact.
+:- not 1 { os_compatible(CurrentOS, ReusedOS) : buildable_os(CurrentOS) },
+   node_os(Package, ReusedOS).
 
 % If an OS is set explicitly respect the value
 node_os(Package, OS) :- node_os_set(Package, OS), node(Package).
@@ -960,6 +965,9 @@ compiler_weight(Package, 100)
  :- node_compiler_version(Package, Compiler, Version),
     not node_compiler_preference(Package, Compiler, Version, _),
     not default_compiler_preference(Compiler, Version, _).
+
+% For the time being, be strict and reuse only if the compiler match one we have on the system
+:- node_compiler_version(Package, Compiler, Version), not compiler_version(Compiler, Version).
 
 #defined node_compiler_preference/4.
 #defined default_compiler_preference/3.
@@ -1269,6 +1277,7 @@ opt_criterion(1, "non-preferred targets").
 #heuristic variant_value(Package, Variant, Value) : variant_default_value(Package, Variant, Value), node(Package). [10, true]
 #heuristic provider(Package, Virtual) : possible_provider_weight(Package, Virtual, 0, _), virtual_node(Virtual). [10, true]
 #heuristic node(Package) : possible_provider_weight(Package, Virtual, 0, _), virtual_node(Virtual). [10, true]
+#heuristic node_os(Package, OS) : buildable_os(OS). [10, true]
 
 %-----------
 % Notes

--- a/lib/spack/spack/solver/os_facts.lp
+++ b/lib/spack/spack/solver/os_facts.lp
@@ -1,0 +1,22 @@
+% Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+% Spack Project Developers. See the top-level COPYRIGHT file for details.
+%
+% SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+% OS compatibility rules for reusing solves.
+% os_compatible(RecentOS, OlderOS)
+% OlderOS binaries can be used on RecentOS
+
+% macOS
+os_compatible("monterey", "bigsur").
+os_compatible("bigsur", "catalina").
+
+% Ubuntu
+os_compatible("ubuntu22.04", "ubuntu21.10").
+os_compatible("ubuntu21.10", "ubuntu21.04").
+os_compatible("ubuntu21.04", "ubuntu20.10").
+os_compatible("ubuntu20.10", "ubuntu20.04").
+os_compatible("ubuntu20.04", "ubuntu19.10").
+os_compatible("ubuntu19.10", "ubuntu19.04").
+os_compatible("ubuntu19.04", "ubuntu18.10").
+os_compatible("ubuntu18.10", "ubuntu18.04").


### PR DESCRIPTION
fixes #31169

Modifications:
- [x] Add compatibility rules for operating systems
- [x] Facts to feed compatibility rules for OS are in a separate `os_facts.lp` file
- [x] Allow, for the time being, to use only compilers that are available
- [x] Add unit tests