### PR TITLE
py-f90wrap: new version

### DIFF
--- a/var/spack/repos/builtin/packages/py-f90wrap/package.py
+++ b/var/spack/repos/builtin/packages/py-f90wrap/package.py
@@ -14,6 +14,7 @@ class PyF90wrap(PythonPackage):
     homepage = "https://github.com/jameskermode/f90wrap"
     pypi = "f90wrap/f90wrap-0.2.3.tar.gz"
 
+    version('0.2.6', sha256='e0748eb5e288be7f47829a272fc230373469fb40afccddf91e9973c56da43dd4')
     version('0.2.3', sha256='5577ea92934c5aad378df21fb0805b5fb433d6f2b8b9c1bf1a9ec1e3bf842cff')
 
     # TODO errors with python 3.6 due to UnicodeDecodeError


### PR DESCRIPTION
Could not build on the develop branch without being more specific about numpy versions. numpy versions taken from oldest-supported-numpy repo