### PR TITLE
Bugfix external find --all for libraries

### DIFF
--- a/lib/spack/spack/cmd/external.py
+++ b/lib/spack/spack/cmd/external.py
@@ -125,7 +125,7 @@ def external_find(args):
 
     # If the list of packages is empty, search for every possible package
     if not args.tags and not packages_to_check:
-        packages_to_check = spack.repo.path.all_packages()
+        packages_to_check = list(spack.repo.path.all_packages())
 
     detected_packages = spack.detection.by_executable(
         packages_to_check, path_hints=args.path)

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -110,7 +110,7 @@ config_defaults = {
 
 #: metavar to use for commands that accept scopes
 #: this is shorter and more readable than listing all choices
-scopes_metavar = '{defaults,system,site,user}[/PLATFORM]'
+scopes_metavar = '{defaults,system,site,user}[/PLATFORM] or env:ENVIRONMENT'
 
 #: Base name for the (internal) overrides scope.
 overrides_base_name = 'overrides-'


### PR DESCRIPTION
There was a bug in how the `packages_to_check` field was updated so that when looking for all packages it would never look for ones detected by library.  Additionally fixed the help message to indicate that the scope can be constrained to an environment.