### PR TITLE
Update fpm to version 0.6.0

### DIFF
--- a/var/spack/repos/builtin/packages/fpm/package.py
+++ b/var/spack/repos/builtin/packages/fpm/package.py
@@ -23,6 +23,7 @@ class Fpm(Package):
 
     maintainers = ["awvwgk"]
 
+    version("0.6.0", "365516f66b116a112746af043e8eccb3d854d6feb1fad0507c570433dacbf7be")
     version("0.5.0", "e4a06956d2300f9aa1d06bd3323670480e946549617582e32684ded6921a921e")
     version("0.4.0", "cd9b80b7f40d9cf357ca8d5d4fe289fd32dfccb729bad7d2a68f245e4cdd0045")
     version("0.3.0", "3368d1b17e2d1368559174c796ce0e184cb6bf79c939938c6d166fbd15959fa3")
@@ -36,8 +37,7 @@ class Fpm(Package):
         if "@0.4.0" in self.spec:
             env.set("FPM_C_COMPILER", self.compiler.cc)
 
-        if "@0.5.0" in self.spec:
-            env.set("FPM_CC", self.compiler.cc)
+        env.set("FPM_CC", self.compiler.cc)
 
         fflags = "-O3"
         if "+openmp" in self.spec:


### PR DESCRIPTION
Update for release at https://github.com/fortran-lang/fpm/releases/tag/v0.6.0