### PR TITLE
Update system_prerequisites.csv

### DIFF
--- a/lib/spack/docs/tables/system_prerequisites.csv
+++ b/lib/spack/docs/tables/system_prerequisites.csv
@@ -7,7 +7,7 @@ bash, , , Compiler wrappers
 tar, , , Extract/create archives
 gzip, , , Compress/Decompress archives
 unzip, , , Compress/Decompress archives
-bzip, , , Compress/Decompress archives
+bzip2, , , Compress/Decompress archives
 xz, , , Compress/Decompress archives
 zstd, , Optional, Compress/Decompress archives
 file, , , Create/Use Buildcaches


### PR DESCRIPTION
bzip2, since bzip was pulled due to patent issues.