### PR TITLE
Feature: use git branches/tags as versions

### DIFF
--- a/lib/spack/spack/cmd/checksum.py
+++ b/lib/spack/spack/cmd/checksum.py
@@ -16,7 +16,7 @@ import spack.stage
 import spack.util.crypto
 from spack.package_base import preferred_version
 from spack.util.naming import valid_fully_qualified_module_name
-from spack.version import Version, ver
+from spack.version import VersionBase, ver
 
 description = "checksum available versions of a package"
 section = "packaging"
@@ -65,7 +65,7 @@ def checksum(parser, args):
         remote_versions = None
         for version in versions:
             version = ver(version)
-            if not isinstance(version, Version):
+            if not isinstance(version, VersionBase):
                 tty.die("Cannot generate checksums for version lists or "
                         "version ranges. Use unambiguous versions.")
             url = pkg.find_valid_url_for_version(version)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1584,7 +1584,7 @@ def for_package_version(pkg, version):
         version.generate_git_lookup(pkg.name)
         kwargs = {
             'git': pkg.git,
-            'commit': str(version)
+            'commit': version.ref # TODO: fix key
         }
         kwargs['submodules'] = getattr(pkg, 'submodules', False)
         fetcher = GitFetchStrategy(**kwargs)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1575,11 +1575,11 @@ def for_package_version(pkg, version):
 
     check_pkg_attributes(pkg)
 
-    if not isinstance(version, spack.version.Version):
+    if not isinstance(version, spack.version.VersionBase):
         version = spack.version.Version(version)
 
     # if it's a commit, we must use a GitFetchStrategy
-    if version.is_commit and hasattr(pkg, "git"):
+    if isinstance(version, spack.version.GitVersion) and hasattr(pkg, "git"):
         # Populate the version with comparisons to other commits
         version.generate_commit_lookup(pkg.name)
         kwargs = {

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1587,10 +1587,18 @@ def for_package_version(pkg, version):
             )
         # Populate the version with comparisons to other commits
         version.generate_git_lookup(pkg.name)
-        ref_type = 'commit' if version.is_commit else 'branch'
+
+        # For GitVersion, we have no way to determine whether a ref is a branch or tag
+        # Fortunately, we handle branches and tags identically, except tags are
+        # handled slightly more conservatively for older versions of git.
+        # We call all non-commit refs tags in this context, at the cost of a slight
+        # performance hit for branches on older versions of git.
+        # Branches cannot be cached, so we tell the fetcher not to cache tags/branches
+        ref_type = 'commit' if version.is_commit else 'tag'
         kwargs = {
             'git': pkg.git,
-            ref_type: version.ref
+            ref_type: version.ref,
+            'no_cache': True,
         }
         kwargs['submodules'] = getattr(pkg, 'submodules', False)
         fetcher = GitFetchStrategy(**kwargs)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1579,12 +1579,18 @@ def for_package_version(pkg, version):
         version = spack.version.Version(version)
 
     # if it's a commit, we must use a GitFetchStrategy
-    if isinstance(version, spack.version.GitVersion) and hasattr(pkg, "git"):
+    if isinstance(version, spack.version.GitVersion):
+        if not hasattr(pkg, "git"):
+            raise FetchError(
+                "Cannot fetch git version for %s. Package has no 'git' attribute" %
+                pkg.name
+            )
         # Populate the version with comparisons to other commits
         version.generate_git_lookup(pkg.name)
+        ref_type = 'commit' if version.is_commit else 'branch'
         kwargs = {
             'git': pkg.git,
-            'commit': version.ref # TODO: fix key
+            ref_type: version.ref
         }
         kwargs['submodules'] = getattr(pkg, 'submodules', False)
         fetcher = GitFetchStrategy(**kwargs)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -1581,7 +1581,7 @@ def for_package_version(pkg, version):
     # if it's a commit, we must use a GitFetchStrategy
     if isinstance(version, spack.version.GitVersion) and hasattr(pkg, "git"):
         # Populate the version with comparisons to other commits
-        version.generate_commit_lookup(pkg.name)
+        version.generate_git_lookup(pkg.name)
         kwargs = {
             'git': pkg.git,
             'commit': str(version)

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -62,7 +62,7 @@ from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
 from spack.util.prefix import Prefix
-from spack.version import Version, VersionBase
+from spack.version import Version, VersionBase, GitVersion
 
 if sys.version_info[0] >= 3:
     FLAG_HANDLER_RETURN_TYPE = Tuple[
@@ -1501,7 +1501,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         checksum = spack.config.get('config:checksum')
         fetch = self.stage.managed_by_spack
         if checksum and fetch and (self.version not in self.versions) \
-                and (not self.version.is_commit):
+                and (not isinstance(self.version, GitVersion)):
             tty.warn("There is no checksum on file to fetch %s safely." %
                      self.spec.cformat('{name}{@version}'))
 

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -62,7 +62,7 @@ from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
 from spack.util.prefix import Prefix
-from spack.version import Version
+from spack.version import Version, VersionBase
 
 if sys.version_info[0] >= 3:
     FLAG_HANDLER_RETURN_TYPE = Tuple[
@@ -1041,7 +1041,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         return self._implement_all_urls_for_version(version, uf)
 
     def _implement_all_urls_for_version(self, version, custom_url_for_version=None):
-        if not isinstance(version, Version):
+        if not isinstance(version, VersionBase):
             version = Version(version)
 
         urls = []

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -62,7 +62,7 @@ from spack.stage import ResourceStage, Stage, StageComposite, stage_prefix
 from spack.util.executable import ProcessError, which
 from spack.util.package_hash import package_hash
 from spack.util.prefix import Prefix
-from spack.version import Version, VersionBase, GitVersion
+from spack.version import GitVersion, Version, VersionBase
 
 if sys.version_info[0] >= 3:
     FLAG_HANDLER_RETURN_TYPE = Tuple[

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1432,7 +1432,7 @@ class SpackSolverSetup(object):
                     continue
 
                 known_versions = self.possible_versions[dep.name]
-                if (not dep.version.is_commit and
+                if (not isinstance(dep.version, spack.version.GitVersion) and
                     any(v.satisfies(dep.version) for v in known_versions)):
                     # some version we know about satisfies this constraint, so we
                     # should use that one. e.g, if the user asks for qt@5 and we
@@ -2189,7 +2189,7 @@ class SpecBuilder(object):
         # concretization process)
         for root in self._specs.values():
             for spec in root.traverse():
-                if spec.version.is_commit:
+                if isinstance(spec.version, spack.version.GitVersion):
                     spec.version.generate_commit_lookup(spec.fullname)
 
         return self._specs

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -2194,7 +2194,7 @@ class SpecBuilder(object):
         for root in self._specs.values():
             for spec in root.traverse():
                 if isinstance(spec.version, spack.version.GitVersion):
-                    spec.version.generate_commit_lookup(spec.fullname)
+                    spec.version.generate_git_lookup(spec.fullname)
 
         return self._specs
 

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1440,7 +1440,8 @@ class SpackSolverSetup(object):
                     # versions to the solver
                     #
                     # For git versions, we know the version is already fully specified
-                    # so we don't have to worry about whether it's an under-specified version
+                    # so we don't have to worry about whether it's an under-specified
+                    # version
                     continue
 
                 # if there is a concrete version on the CLI *that we know nothing

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1436,7 +1436,11 @@ class SpackSolverSetup(object):
                     any(v.satisfies(dep.version) for v in known_versions)):
                     # some version we know about satisfies this constraint, so we
                     # should use that one. e.g, if the user asks for qt@5 and we
-                    # know about qt@5.5.
+                    # know about qt@5.5. This ensures we don't add under-specified
+                    # versions to the solver
+                    #
+                    # For git versions, we know the version is already fully specified
+                    # so we don't have to worry about whether it's an under-specified version
                     continue
 
                 # if there is a concrete version on the CLI *that we know nothing

--- a/lib/spack/spack/solver/asp.py
+++ b/lib/spack/spack/solver/asp.py
@@ -1680,7 +1680,7 @@ class SpackSolverSetup(object):
 
         # extract all the real versions mentioned in version ranges
         def versions_for(v):
-            if isinstance(v, spack.version.Version):
+            if isinstance(v, spack.version.VersionBase):
                 return [v]
             elif isinstance(v, spack.version.VersionRange):
                 result = [v.start] if v.start else []

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5148,7 +5148,7 @@ class SpecParser(spack.parse.Parser):
             # Note: VersionRange(x, x) is currently concrete, hence isinstance(...).
             if (
                 spec.name and spec.versions.concrete and
-                isinstance(spec.version, vn.Version) and spec.version.is_commit
+                isinstance(spec.version, vn.GitVersion)
             ):
                 spec.version.generate_commit_lookup(spec.fullname)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -5150,7 +5150,7 @@ class SpecParser(spack.parse.Parser):
                 spec.name and spec.versions.concrete and
                 isinstance(spec.version, vn.GitVersion)
             ):
-                spec.version.generate_commit_lookup(spec.fullname)
+                spec.version.generate_git_lookup(spec.fullname)
 
         return specs
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -21,6 +21,7 @@ from spack.version import (
     Version, VersionBase, GitVersion, VersionList, VersionRange, ver
 )
 
+
 def assert_ver_lt(a, b):
     """Asserts the results of comparisons when 'a' is less than 'b'."""
     a, b = ver(a), ver(b)

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -17,8 +17,9 @@ from llnl.util.filesystem import working_dir
 import spack.package_base
 import spack.spec
 from spack.util.executable import which
-from spack.version import Version, VersionBase, VersionList, VersionRange, ver
-
+from spack.version import (
+    Version, VersionBase, GitVersion, VersionList, VersionRange, ver
+)
 
 def assert_ver_lt(a, b):
     """Asserts the results of comparisons when 'a' is less than 'b'."""
@@ -661,6 +662,17 @@ def test_git_ref_comparisons(
     assert spec_branch.satisfies('@1.2')
     assert spec_branch.satisfies('@1.1:1.3')
     assert str(spec_branch.version) == 'git.1.x'
+
+
+@pytest.mark.parametrize('string,git', [
+    ('1.2.9', False),
+    ('gitmain', False),
+    ('git.foo', True),
+    ('git.abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd', True),
+    ('abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd', True),
+])
+def test_version_git_vs_base(string, git):
+    assert isinstance(Version(string), GitVersion) == git
 
 
 def test_version_range_nonempty():

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -662,6 +662,7 @@ def test_git_ref_comparisons(
     assert spec_branch.satisfies('@1.1:1.3')
     assert str(spec_branch.version) == 'git.1.x'
 
+
 def test_version_range_nonempty():
     assert Version('1.2.9') in VersionRange('1.2.0', '1.2')
     assert Version('1.1.1') in ver('1.0:1')

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -17,7 +17,7 @@ from llnl.util.filesystem import working_dir
 import spack.package_base
 import spack.spec
 from spack.util.executable import which
-from spack.version import Version, VersionList, VersionRange, ver
+from spack.version import Version, VersionBase, VersionList, VersionRange, ver
 
 
 def assert_ver_lt(a, b):
@@ -520,7 +520,7 @@ def test_repr_and_str():
 
     def check_repr_and_str(vrs):
         a = Version(vrs)
-        assert repr(a) == "Version('" + vrs + "')"
+        assert repr(a) == "VersionBase('" + vrs + "')"
         b = eval(repr(a))
         assert a == b
         assert str(a) == vrs
@@ -544,19 +544,19 @@ def test_get_item():
     assert isinstance(a[1], int)
     # Test slicing
     b = a[0:2]
-    assert isinstance(b, Version)
+    assert isinstance(b, VersionBase)
     assert b == Version('0.1')
-    assert repr(b) == "Version('0.1')"
+    assert repr(b) == "VersionBase('0.1')"
     assert str(b) == '0.1'
     b = a[0:3]
-    assert isinstance(b, Version)
+    assert isinstance(b, VersionBase)
     assert b == Version('0.1_2')
-    assert repr(b) == "Version('0.1_2')"
+    assert repr(b) == "VersionBase('0.1_2')"
     assert str(b) == '0.1_2'
     b = a[1:]
-    assert isinstance(b, Version)
+    assert isinstance(b, VersionBase)
     assert b == Version('1_2-3')
-    assert repr(b) == "Version('1_2-3')"
+    assert repr(b) == "VersionBase('1_2-3')"
     assert str(b) == '1_2-3'
     # Raise TypeError on tuples
     with pytest.raises(TypeError):

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -18,7 +18,12 @@ import spack.package_base
 import spack.spec
 from spack.util.executable import which
 from spack.version import (
-    GitVersion, Version, VersionBase, VersionList, VersionRange, ver
+    GitVersion,
+    Version,
+    VersionBase,
+    VersionList,
+    VersionRange,
+    ver,
 )
 
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -18,7 +18,7 @@ import spack.package_base
 import spack.spec
 from spack.util.executable import which
 from spack.version import (
-    Version, VersionBase, GitVersion, VersionList, VersionRange, ver
+    GitVersion, Version, VersionBase, VersionList, VersionRange, ver
 )
 
 

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -598,7 +598,7 @@ def test_versions_from_git(mock_git_version_info, monkeypatch, mock_packages):
         spec = spack.spec.Spec('git-test-commit@%s' % commit)
         version = spec.version
         comparator = [str(v) if not isinstance(v, int) else v
-                      for v in version._cmp(version.commit_lookup)]
+                      for v in version._cmp(version.ref_lookup)]
 
         with working_dir(repo_path):
             which('git')('checkout', commit)

--- a/lib/spack/spack/test/versions.py
+++ b/lib/spack/spack/test/versions.py
@@ -637,6 +637,31 @@ def test_git_hash_comparisons(
     assert spec4.satisfies('@1.0:1.2')
 
 
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="Not supported on Windows (yet)")
+def test_git_ref_comparisons(
+        mock_git_version_info, install_mockery, mock_packages, monkeypatch):
+    """Check that hashes compare properly to versions
+    """
+    repo_path, filename, commits = mock_git_version_info
+    monkeypatch.setattr(spack.package_base.PackageBase,
+                        'git', 'file://%s' % repo_path,
+                        raising=False)
+
+    # Spec based on tag v1.0
+    spec_tag = spack.spec.Spec('git-test-commit@git.v1.0')
+    spec_tag.concretize()
+    assert spec_tag.satisfies('@1.0')
+    assert not spec_tag.satisfies('@1.1:')
+    assert str(spec_tag.version) == 'git.v1.0'
+
+    # Spec based on branch 1.x
+    spec_branch = spack.spec.Spec('git-test-commit@git.1.x')
+    spec_branch.concretize()
+    assert spec_branch.satisfies('@1.2')
+    assert spec_branch.satisfies('@1.1:1.3')
+    assert str(spec_branch.version) == 'git.1.x'
+
 def test_version_range_nonempty():
     assert Version('1.2.9') in VersionRange('1.2.0', '1.2')
     assert Version('1.1.1') in ver('1.0:1')

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -465,10 +465,12 @@ class GitVersion(VersionBase):
         self.ref = string[4:] if git_prefix else string
 
         self.is_commit = len(self.ref) == 40 and COMMIT_VERSION.match(self.ref)
-        self.is_ref = git_prefix
+        self.is_ref = git_prefix  # is_ref False only for comparing to VersionBase
         self.is_ref |= bool(self.is_commit)
 
-        super(GitVersion, self).__init__(string)
+        # ensure git.<hash> and <hash> are treated the same by dropping 'git.'
+        canonical_string = self.ref if self.is_commit else string
+        super(GitVersion, self).__init__(canonical_string)
 
         # An object that can lookup git refs to compare them to versions
         self._ref_lookup = None

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -1095,8 +1095,8 @@ class CommitLookup(object):
     """An object for cached lookups of git commits
 
     CommitLookup objects delegate to the misc_cache for locking.
-    CommitLookup objects may be attached to a Version object for which
-    Version.is_commit returns True to allow for comparisons between git commits
+    CommitLookup objects may be attached to a GitVersion object for which
+    Version.is_ref returns True to allow for comparisons between git refs
     and versions as represented by tags in the git repository.
     """
     def __init__(self, pkg_name):

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -67,7 +67,7 @@ iv_min_len = min(len(s) for s in infinity_versions)
 def coerce_versions(a, b):
     """
     Convert both a and b to the 'greatest' type between them, in this order:
-           Version < VersionRange < VersionList
+           VersionBase < GitVersion < VersionRange < VersionList
     This is used to simplify comparison operations below so that we're always
     comparing things that are of the same type.
     """
@@ -453,6 +453,7 @@ class VersionBase(object):
 
 
 class GitVersion(VersionBase):
+    """Class to represent versions interpreted from git refs."""
     def __init__(self, string):
         if not isinstance(string, str):
             string = str(string)  # In case we got a VersionBase or GitVersion object

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -578,7 +578,7 @@ class GitVersion(VersionBase):
             self._commit_lookup.get(self.string)
             return self._commit_lookup
 
-    def generate_commit_lookup(self, pkg_name):
+    def generate_git_lookup(self, pkg_name):
         """
         Use the git fetcher to look up a version for a commit.
 

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -468,11 +468,17 @@ class GitVersion(VersionBase):
         self.commit_version = None
 
     def _cmp(self, other_lookups=None):
+        # No need to rely on git comparisons for develop-like refs
+        if len(self.version) == 1 and self.isdevelop():
+            return self.version
+
+        # If we've already looked this version up, return cached value
+        if self.commit_version is not None:
+            return self.commit_version
+
         commit_lookup = self.commit_lookup or other_lookups
 
         if self.is_ref and commit_lookup:
-            if self.commit_version is not None:
-                return self.commit_version
             commit_info = commit_lookup.get(self.string)
             if commit_info:
                 prev_version, distance = commit_info

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -178,7 +178,9 @@ def is_git_version(string):
 
 
 def Version(string):  # capitalized for backwards compatibility
-    string = str(string)  # to handle VersionBase and GitVersion types
+    if not isinstance(string, str):
+        string = str(string)  # to handle VersionBase and GitVersion types
+
     if is_git_version(string):
         return GitVersion(string)
     return VersionBase(string)
@@ -452,7 +454,8 @@ class VersionBase(object):
 
 class GitVersion(VersionBase):
     def __init__(self, string):
-        string = str(string)  # In case we got a VersionBase or GitVersion object
+        if not isinstance(string, str):
+            string = str(string)  # In case we got a VersionBase or GitVersion object
         self.is_ref = False
 
         if string.startswith('git.'):

--- a/lib/spack/spack/version.py
+++ b/lib/spack/spack/version.py
@@ -1270,7 +1270,7 @@ class CommitLookup(object):
                 # Get list of all commits, this is in reverse order
                 # We use this to get the first commit below
                 ref_info = self.fetcher.git("log", "--all", "--pretty=format:%H",
-                                               output=str)
+                                            output=str)
                 commits = [c for c in ref_info.split('\n') if c]
 
                 # No previous version and distance from first commit

--- a/var/spack/repos/builtin/packages/libcatalyst/package.py
+++ b/var/spack/repos/builtin/packages/libcatalyst/package.py
@@ -16,7 +16,7 @@ class Libcatalyst(CMakePackage):
     maintainers = ['mathstuf']
 
     # master as of 2021-05-12
-    version('8456ccd6015142b5a7705f79471361d4f5644fa7', sha256='5a01f12b271d9d9e9b89f31d45a5f4b8426904483639d38754893adfd3547bab')
+    version('2021-05-12', sha256='5a01f12b271d9d9e9b89f31d45a5f4b8426904483639d38754893adfd3547bab')
 
     variant('mpi', default=False, description='Enable MPI support')
     variant('python3', default=False, description='Enable Python3 support')


### PR DESCRIPTION
Building on #24639, this allows versions to be prefixed by `git.`. If a version begins `git.`, it is treated as a git ref, and handled as git commits are starting in the referenced PR.

An exception is made for versions that are `git.develop`, `git.main`, `git.master`, `git.head`, or `git.trunk`. Those are assumed to be greater than all other versions, as those prefixed strings are in other contexts.

TODO:
- [ ] docs (could be combined with the git commit docs PR)