### PR TITLE
grep: add +pcre variant

### DIFF
--- a/var/spack/repos/builtin/packages/grep/package.py
+++ b/var/spack/repos/builtin/packages/grep/package.py
@@ -15,4 +15,18 @@ class Grep(AutotoolsPackage):
     version('3.7', sha256='5c10da312460aec721984d5d83246d24520ec438dd48d7ab5a05dbc0d6d6823c')
     version('3.3', sha256='b960541c499619efd6afe1fa795402e4733c8e11ebf9fafccc0bb4bccdc5b514')
 
+    variant('pcre', default=False, description='Enable Perl Compatible Regular Expression support')
+
     build_directory = 'spack-build'
+
+    depends_on('pcre', when='+pcre')
+
+    def configure_args(self):
+        args = []
+
+        if '+pcre' in self.spec:
+            args.append('--enable-perl-regexp')
+        else:
+            args.append('--disable-perl-regexp')
+
+        return args


### PR DESCRIPTION
`grep -P` FTW!

Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0.