### PR TITLE
root: Make a variant of gnuinstall option

### DIFF
--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -117,6 +117,8 @@ class Root(CMakePackage):
     variant('gminimal', default=True,
             description='Ignore most of Root\'s feature defaults except for '
             'basic graphic options')
+    variant('gnuinstall', default=True,
+            description='Enable fixed location installation')
     variant('gsl', default=True,
             description='Enable linking against shared libraries for GSL')
     variant('http', default=False,
@@ -428,7 +430,7 @@ class Root(CMakePackage):
             define('fail-on-missing', True),
             define_from_variant('fortran'),
             define_from_variant('gminimal'),
-            define('gnuinstall', False),
+            define_from_variant('gnuinstall'),
             define('libcxx', False),
             define('pch', True),
             define('roottest', False),

--- a/var/spack/repos/builtin/packages/root/package.py
+++ b/var/spack/repos/builtin/packages/root/package.py
@@ -117,8 +117,6 @@ class Root(CMakePackage):
     variant('gminimal', default=True,
             description='Ignore most of Root\'s feature defaults except for '
             'basic graphic options')
-    variant('gnuinstall', default=True,
-            description='Enable fixed location installation')
     variant('gsl', default=True,
             description='Enable linking against shared libraries for GSL')
     variant('http', default=False,
@@ -430,7 +428,7 @@ class Root(CMakePackage):
             define('fail-on-missing', True),
             define_from_variant('fortran'),
             define_from_variant('gminimal'),
-            define_from_variant('gnuinstall'),
+            define('gnuinstall', True),
             define('libcxx', False),
             define('pch', True),
             define('roottest', False),


### PR DESCRIPTION
The README folder in the installation prefix triggers conflicts with README files installed in the installation prefix from other packages when creating a filesystem view. I would therefore argue it would be beneficial making the gnuinstall option a variant with True as default.