### PR TITLE
add first version of py-pyrr package

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyrr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyrr/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/py-pyrr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyrr/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyPyrr(PythonPackage):
+    """3D mathematical functions using NumPy."""
+
+    homepage = "https://github.com/adamlwgriffiths/Pyrr"
+    pypi     = "pyrr/pyrr-0.10.3.tar.gz"
+    maintainers = ['JeromeDuboisPro']
+
+    version('0.10.3', sha256='3c0f7b20326e71f706a610d58f2190fff73af01eef60c19cb188b186f0ec7e1d', preferred=True)
+
+    depends_on('py-setuptools', type='build')
+    depends_on('py-numpy')
+    depends_on('py-multipledispatch')

--- a/var/spack/repos/builtin/packages/py-pyrr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyrr/package.py
@@ -14,7 +14,7 @@ class PyPyrr(PythonPackage):
     maintainers = ['JeromeDuboisPro']
     license = "BSD-2-Clause"
 
-    version('0.10.3', sha256='3c0f7b20326e71f706a610d58f2190fff73af01eef60c19cb188b186f0ec7e1d', preferred=True)
+    version('0.10.3', sha256='3c0f7b20326e71f706a610d58f2190fff73af01eef60c19cb188b186f0ec7e1d')
 
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy')

--- a/var/spack/repos/builtin/packages/py-pyrr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyrr/package.py
@@ -17,5 +17,5 @@ class PyPyrr(PythonPackage):
     version('0.10.3', sha256='3c0f7b20326e71f706a610d58f2190fff73af01eef60c19cb188b186f0ec7e1d')
 
     depends_on('py-setuptools', type='build')
-    depends_on('py-numpy')
-    depends_on('py-multipledispatch')
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-multipledispatch', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-pyrr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyrr/package.py
@@ -12,6 +12,7 @@ class PyPyrr(PythonPackage):
     homepage = "https://github.com/adamlwgriffiths/Pyrr"
     pypi     = "pyrr/pyrr-0.10.3.tar.gz"
     maintainers = ['JeromeDuboisPro']
+    license = "BSD-2-Clause"
 
     version('0.10.3', sha256='3c0f7b20326e71f706a610d58f2190fff73af01eef60c19cb188b186f0ec7e1d', preferred=True)
 

--- a/var/spack/repos/builtin/packages/py-pyrr/package.py
+++ b/var/spack/repos/builtin/packages/py-pyrr/package.py
@@ -12,7 +12,6 @@ class PyPyrr(PythonPackage):
     homepage = "https://github.com/adamlwgriffiths/Pyrr"
     pypi     = "pyrr/pyrr-0.10.3.tar.gz"
     maintainers = ['JeromeDuboisPro']
-    license = "BSD-2-Clause"
 
     version('0.10.3', sha256='3c0f7b20326e71f706a610d58f2190fff73af01eef60c19cb188b186f0ec7e1d')
 


### PR DESCRIPTION
Add py-pyrr package, useful for maths operations, rays and objects manipulations for raytracing.