### PR TITLE
frontier-client: Add openssl and zlib directories to search path

### DIFF
--- a/var/spack/repos/builtin/packages/frontier-client/package.py
+++ b/var/spack/repos/builtin/packages/frontier-client/package.py
@@ -23,6 +23,7 @@ class FrontierClient(MakefilePackage):
     depends_on('pacparser')
     depends_on('expat')
     depends_on('openssl')
+    depends_on('zlib')
 
     patch('frontier-client.patch', level=0)
 
@@ -53,7 +54,9 @@ class FrontierClient(MakefilePackage):
     def build(self, spec, prefix):
         with working_dir('client'):
             make('-j1', 'dist', 'PACPARSER_DIR=' + self.spec['pacparser'].prefix,
-                 'EXPAT_DIR=' + self.spec['expat'].prefix)
+                 'EXPAT_DIR=' + self.spec['expat'].prefix,
+                 'OPENSSL_DIR=' + self.spec['openssl'].prefix,
+                 'ZLIB_DIR=' + self.spec['zlib'].prefix)
 
     def install(self, spec, prefix):
         install_tree(join_path('client', 'dist'), prefix)


### PR DESCRIPTION
Without openssl dir added:
```
     10    In file included from fn-htclient.c:17:
  >> 11    ../fn-internal.h:27:10: fatal error: openssl/md5.h: No such file or directory
     12     #include "openssl/md5.h"
     13              ^~~~~~~~~~~~~~~
     14    compilation terminated.
  >> 15    make[1]: *** [Makefile:25: fn-htclient.o] Error 1
```
Without zlib dir added:
```
  >> 27    fn-zlib.c:19:10: fatal error: zlib.h: No such file or directory
     28     #include "zlib.h"
     29              ^~~~~~~~
     30    compilation terminated.
  >> 31    make: *** [Makefile:196: fn-zlib.o] Error 1
```