### PR TITLE
r: Add hwloc dependency to find libhwloc

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -91,6 +91,7 @@ class R(AutotoolsPackage):
     depends_on('libxmu', when='+X')
     depends_on('libxt', when='+X')
     depends_on('tk', when='+X')
+    depends_on('hwloc')
 
     patch('zlib.patch', when='@:3.3.2')
 


### PR DESCRIPTION
Without dependency for version 4.1.3 with clang13:
```
error while loading shared libraries: libhwloc.so.15: cannot open shared object file: No such file or directory
```