### PR TITLE
py-shapely: env vars always needed

### DIFF
--- a/var/spack/repos/builtin/packages/py-shapely/package.py
+++ b/var/spack/repos/builtin/packages/py-shapely/package.py
@@ -66,6 +66,12 @@ class PyShapely(PythonPackage):
         else:
             env.prepend_path('LD_LIBRARY_PATH', libs)
 
+    def setup_run_environment(self, env):
+        self.setup_build_environment(env)
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        self.setup_build_environment(env)
+
     @run_after('install')
     @on_package_attributes(run_tests=True)
     def test_install(self):


### PR DESCRIPTION
`LD_LIBRARY_PATH` needs to be set to use `py-shapely`. This includes at run-time (aka during a `spack install --test=root py-shapely`), at run-time (aka during a `spack load py-shapely`), and at run-time (aka during a `spack install --test=root py-geopandas`). The fact that I need to set these 3 times instead of just once is related to https://github.com/spack/spack/discussions/13926.