### PR TITLE
[ccls] Fix cmake version for existing versions

### DIFF
--- a/var/spack/repos/builtin/packages/ccls/package.py
+++ b/var/spack/repos/builtin/packages/ccls/package.py
@@ -21,6 +21,7 @@ class Ccls(CMakePackage):
     variant('build_type', default='Release', description='CMake build type',
             values=('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel'))
 
-    depends_on("cmake@3.8:", type="build")
+    depends_on("cmake@3.8:", type="build", when='@master')
+    depends_on("cmake@3.8", type="build", when='@0.20201025:0.20210330')
     depends_on('llvm@7:')
     depends_on('rapidjson')


### PR DESCRIPTION
Newer cmake fails to compile existing versions (language "c" is not enabled in the project).
The issue seems to be resolved in the git master but for now fix the cmake version for older
ccls versions.