### PR TITLE
vtk-m: update to latest release

### DIFF
--- a/var/spack/repos/builtin/packages/ascent/package.py
+++ b/var/spack/repos/builtin/packages/ascent/package.py
@@ -176,7 +176,7 @@ class Ascent(CMakePackage, CudaPackage):
     depends_on("vtk-h+shared", when="+vtkh+shared")
     depends_on("vtk-h~shared", when="+vtkh~shared")
     # When using VTK-h ascent also needs VTK-m
-    depends_on("vtk-m", when="+vtkh")
+    depends_on("vtk-m@:1.7", when="+vtkh")
     depends_on("vtk-m+testlib", when="+vtkh+test^vtk-m")
 
     # mfem

--- a/var/spack/repos/builtin/packages/fides/package.py
+++ b/var/spack/repos/builtin/packages/fides/package.py
@@ -27,7 +27,7 @@ class Fides(CMakePackage):
 
     depends_on("mpi", when="+mpi")
     depends_on('adios2~zfp', when='+adios2')
-    depends_on("vtk-m", when="+vtk-m")
+    depends_on("vtk-m@:1.7", when="+vtk-m")
 
     # Fix missing implicit includes
     @when('%gcc@7:')

--- a/var/spack/repos/builtin/packages/vtk-h/package.py
+++ b/var/spack/repos/builtin/packages/vtk-h/package.py
@@ -78,7 +78,7 @@ class VtkH(CMakePackage, CudaPackage):
     depends_on("vtk-m+fpic")
 
     # use vtk-m 1.7 or newer for vtk-h 0.8 or newer
-    depends_on("vtk-m@1.7:", when="@0.8:")
+    depends_on("vtk-m@1.7", when="@0.8:")
 
     # use vtk-m 1.6 or lower for vtk-h 0.7 or lower
     depends_on("vtk-m@:1.6", when="@:0.7")

--- a/var/spack/repos/builtin/packages/vtk-m/package.py
+++ b/var/spack/repos/builtin/packages/vtk-m/package.py
@@ -29,8 +29,8 @@ class VtkM(CMakePackage, CudaPackage, ROCmPackage):
 
     version('master', branch='master')
     version('release', branch='release')
-    version('1.8.0-rc1', sha256="99e344c89ecb84b04cc0f0b9fdf042b9a4ae3144bb4deeca8e90f098ab8a569b")
-    version('1.7.1', sha256="7ea3e945110b837a8c2ba49b41e45e1a1d8d0029bb472b291f7674871dbbbb63", preferred=True)
+    version('1.8.0', sha256="fcedee6e8f4ac50dde56e8c533d48604dbfb663cea1561542a837e8e80ba8768", preferred=True)
+    version('1.7.1', sha256="7ea3e945110b837a8c2ba49b41e45e1a1d8d0029bb472b291f7674871dbbbb63")
     version('1.7.0', sha256="a86667ac22057462fc14495363cfdcc486da125b366cb568ec23c86946439be4")
     version('1.6.0', sha256="14e62d306dd33f82eb9ddb1d5cee987b7a0b91bf08a7a02ca3bce3968c95fd76")
     version('1.5.5', commit="d2d1c854adc8c0518802f153b48afd17646b6252")


### PR DESCRIPTION
Finally! After a quiet spring, VTK-m v1.8.0 is finally out :tada: :tada: :tada:

This bring exiting new features, and bugfixes, find the tentative release notes at https://gitlab.kitware.com/vtk/vtk-m/-/blob/master/docs/changelog/1.8/release-notes.md

Let me know if we need to change anything else in the package

ViB