### PR TITLE
Add missing '?full_index=1' to meson 9850.patch URL

### DIFF
--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -66,7 +66,7 @@ class Meson(PythonPackage):
     patch('rpath-0.58.patch', when='@0.58:')
     # Help meson recognize Intel OneAPI compilers
     patch('https://patch-diff.githubusercontent.com/raw/mesonbuild/meson/pull/9850.patch?full_index=1',
-          sha256='72c77637f4dd5f8af5788dacf01c71d921cd4073af0aa0641a4b5111c50f59cb',
+          sha256='9c874726ce0a06922580d3e3d6adbe74e5144b3a661ef1059f32c9c1bc478b65',
           when='@0.60.0:')
 
     executables = ['^meson$']

--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -65,7 +65,7 @@ class Meson(PythonPackage):
     patch('rpath-0.56.patch', when='@0.56:0.57')
     patch('rpath-0.58.patch', when='@0.58:')
     # Help meson recognize Intel OneAPI compilers
-    patch('https://patch-diff.githubusercontent.com/raw/mesonbuild/meson/pull/9850.patch',
+    patch('https://patch-diff.githubusercontent.com/raw/mesonbuild/meson/pull/9850.patch?full_index=1',
           sha256='72c77637f4dd5f8af5788dacf01c71d921cd4073af0aa0641a4b5111c50f59cb',
           when='@0.60.0:')
 


### PR DESCRIPTION
closes #31223 

Should fix what appears to be a problematic audit check issue for multiple PRs.

Examples:
- #27877  https://github.com/spack/spack/runs/6994517716?check_suite_focus=true
- #31219  https://github.com/spack/spack/runs/6991150856?check_suite_focus=true
- #31220  https://github.com/spack/spack/runs/6992640357?check_suite_focus=true
- #31221  https://github.com/spack/spack/runs/6993351774?check_suite_focus=true