### PR TITLE
Fix pigz%nvhpc build

### DIFF
--- a/var/spack/repos/builtin/packages/pigz/package.py
+++ b/var/spack/repos/builtin/packages/pigz/package.py
@@ -23,7 +23,7 @@ class Pigz(MakefilePackage):
     def build(self, spec, prefix):
         # force makefile to use cc as C compiler which is set by
         # spack
-        make('CC=cc')
+        make('CC=cc', 'CFLAGS=-O3 -Wall')
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)


### PR DESCRIPTION
nvc doesn't know this flag: `-Wno-unknown-pragmas`, it doesn't hurt to
remove the specific warning flags, from:

```
-O3 -Wall -Wextra -Wno-unknown-pragmas -Wcast-qual
```

to:

```
-O3 -Wall
```
