### PR TITLE
Use CMake in gperftools package

### DIFF
--- a/var/spack/repos/builtin/packages/gperftools/package.py
+++ b/var/spack/repos/builtin/packages/gperftools/package.py
@@ -37,7 +37,8 @@ class Gperftools(CMakePackage):
     def cmake_args(self):
         args = [
             self.define_from_variant("gperftools_sized_delete", "sized_delete"),
-            self.define_from_variant("gperftools_dynamic_sized_delete_support", "dynamic_sized_delete_support"),
+            self.define_from_variant("gperftools_dynamic_sized_delete_support",
+                                     "dynamic_sized_delete_support"),
             self.define_from_variant("GPERFTOOLS_BUILD_DEBUGALLOC", "debugalloc"),
             self.define_from_variant("gperftools_enable_libunwind", "libunwind"),
         ]
@@ -54,7 +55,8 @@ class Gperftools(CMakePackage):
     def configure_args(self):
         def enable_or_disable(option, variant):
             if variant not in self.variants:
-                raise KeyError("Invalid variant {} given for gperftools".format(variant))
+                raise KeyError("Invalid variant {} given for gperftools"
+                               .format(variant))
             if self.spec.variants[variant].value:
                 return "--enable-" + option
             else:
@@ -62,7 +64,8 @@ class Gperftools(CMakePackage):
 
         args = [
             enable_or_disable("sized-delete", "sized_delete"),
-            enable_or_disable("dynamic-sized-delete-support", "dynamic_sized_delete_support"),
+            enable_or_disable("dynamic-sized-delete-support",
+                              "dynamic_sized_delete_support"),
             enable_or_disable("debugalloc", "debugalloc"),
             enable_or_disable("libunwind", "debugalloc"),
         ]

--- a/var/spack/repos/builtin/packages/gperftools/package.py
+++ b/var/spack/repos/builtin/packages/gperftools/package.py
@@ -3,43 +3,80 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import os
+
 from spack.package import *
 
 
-class Gperftools(AutotoolsPackage):
+class Gperftools(CMakePackage):
     """Google's fast malloc/free implementation, especially for
        multi-threaded applications.  Contains tcmalloc, heap-checker,
        heap-profiler, and cpu-profiler.
 
     """
     homepage = "https://github.com/gperftools/gperftools"
-    url      = "https://github.com/gperftools/gperftools/releases/download/gperftools-2.7/gperftools-2.7.tar.gz"
-    maintainers = ['albestro', 'eschnett', 'msimberg', 'teonnik']
+    url = "https://github.com/gperftools/gperftools/archive/refs/tags/gperftools-0.0.tar.gz"
+    maintainers = ["albestro", "eschnett", "msimberg", "teonnik"]
 
     version('2.10', sha256='83e3bfdd28b8bcf53222c3798d4d395d52dadbbae59e8730c4a6d31a9c3732d8')
-    version('2.9.1', sha256='ea566e528605befb830671e359118c2da718f721c27225cbbc93858c7520fee3')
-    version('2.8.1', sha256='12f07a8ba447f12a3ae15e6e3a6ad74de35163b787c0c7b76288d7395f2f74e0')
-    version('2.7', sha256='1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9')
-    version('2.4', sha256='982a37226eb42f40714e26b8076815d5ea677a422fb52ff8bfca3704d9c30a2d')
-    version('2.3', sha256='093452ad45d639093c144b4ec732a3417e8ee1f3744f2b0f8d45c996223385ce')
+    version('2.9.1', sha256='484a88279d2fa5753d7e9dea5f86954b64975f20e796a6ffaf2f3426a674a06a')
+    version('2.8.1', sha256='260c510b742e44bc53465a1e9b3294f290525360658a6d1612019df2c2f7f307')
+    version('2.7', sha256='1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9', deprecated=True)
+    version('2.4', sha256='982a37226eb42f40714e26b8076815d5ea677a422fb52ff8bfca3704d9c30a2d', deprecated=True)
+    version('2.3', sha256='093452ad45d639093c144b4ec732a3417e8ee1f3744f2b0f8d45c996223385ce', deprecated=True)
 
-    variant('sized_delete', default=False, description="Build sized delete operator")
-    variant('dynamic_sized_delete_support', default=False, description="Try to build run-time switch for sized delete operator")
-    variant('debugalloc', default=True, description="Build versions of libs with debugalloc")
-    variant('libunwind', default=True, description="Enable libunwind linking")
+    variant("sized_delete", default=False, description="Build sized delete operator")
+    variant("dynamic_sized_delete_support", default=False, description="Try to build run-time switch for sized delete operator")
+    variant("debugalloc", default=True, description="Build versions of libs with debugalloc")
+    variant("libunwind", default=True, description="Enable libunwind linking")
 
     depends_on("unwind", when="+libunwind")
 
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("gperftools_sized_delete", "sized_delete"),
+            self.define_from_variant("gperftools_dynamic_sized_delete_support", "dynamic_sized_delete_support"),
+            self.define_from_variant("GPERFTOOLS_BUILD_DEBUGALLOC", "debugalloc"),
+            self.define_from_variant("gperftools_enable_libunwind", "libunwind"),
+        ]
+        return args
+
+    # All of the below can be removed when the deprecated Autotools-based
+    # versions are removed (2.7 and older)
+    def url_for_version(self, version):
+        if self.spec.satisfies("@2.8:"):
+            return "https://github.com/gperftools/gperftools/archive/refs/tags/gperftools-{}.tar.gz".format(version)
+        else:
+            return "https://github.com/gperftools/gperftools/releases/download/gperftools-{}/gperftools-{}.tar.gz".format(version, version)
+
     def configure_args(self):
-        args = []
-        args += self.enable_or_disable("sized-delete", variant='sized_delete')
-        args += self.enable_or_disable("dynamic-sized-delete-support",
-                                       variant='dynamic_sized_delete_support')
-        args += self.enable_or_disable("debugalloc")
-        args += self.enable_or_disable("libunwind")
+        def enable_or_disable(option, variant):
+            if variant not in self.variants:
+                raise KeyError("Invalid variant {} given for gperftools".format(variant))
+            if self.spec.variants[variant].value:
+                return "--enable-" + option
+            else:
+                return "--disable-" + option
+
+        args = [
+            enable_or_disable("sized-delete", "sized_delete"),
+            enable_or_disable("dynamic-sized-delete-support", "dynamic_sized_delete_support"),
+            enable_or_disable("debugalloc", "debugalloc"),
+            enable_or_disable("libunwind", "debugalloc"),
+        ]
         if self.spec.satisfies('+libunwind'):
             args += [
                 "LDFLAGS=-lunwind"
             ]
-
         return args
+
+    @property
+    def build_directory(self):
+        if self.spec.satisfies("@:2.7"):
+            return self.stage.source_path
+        else:
+            return os.path.join(self.stage.path, self.build_dirname)
+
+    @when("@:2.7")
+    def cmake(self, spec, prefix):
+        configure("--prefix={0}".format(self.prefix), *self.configure_args())

--- a/var/spack/repos/builtin/packages/gperftools/package.py
+++ b/var/spack/repos/builtin/packages/gperftools/package.py
@@ -32,6 +32,8 @@ class Gperftools(CMakePackage):
 
     depends_on("unwind", when="+libunwind")
 
+    conflicts("%gcc@11:", when="@:2.4")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("gperftools_sized_delete", "sized_delete"),

--- a/var/spack/repos/builtin/packages/gperftools/package.py
+++ b/var/spack/repos/builtin/packages/gperftools/package.py
@@ -18,7 +18,7 @@ class Gperftools(CMakePackage):
     url = "https://github.com/gperftools/gperftools/archive/refs/tags/gperftools-0.0.tar.gz"
     maintainers = ["albestro", "eschnett", "msimberg", "teonnik"]
 
-    version('2.10', sha256='83e3bfdd28b8bcf53222c3798d4d395d52dadbbae59e8730c4a6d31a9c3732d8')
+    version('2.10', sha256='b0dcfe3aca1a8355955f4b415ede43530e3bb91953b6ffdd75c45891070fe0f1')
     version('2.9.1', sha256='484a88279d2fa5753d7e9dea5f86954b64975f20e796a6ffaf2f3426a674a06a')
     version('2.8.1', sha256='260c510b742e44bc53465a1e9b3294f290525360658a6d1612019df2c2f7f307')
     version('2.7', sha256='1ee8c8699a0eff6b6a203e59b43330536b22bbcbe6448f54c7091e5efb0763c9', deprecated=True)


### PR DESCRIPTION
Hopefully fixes #25832.

- I've tried to follow https://spack.readthedocs.io/en/latest/build_systems/multiplepackage.html#autotools-cmake as much as possible. Improvements to the setup are most welcome.
- gperftools 2.3 and 2.4 don't compile with GCC 11 because the default C++ standard has been bumped to 17 and it fails with the following error. Since those gperftools versions are now deprecated I didn't bother trying to patch that up, but instead just added a conflict with GCC 11 and newer.
```
 >> 277    src/libc_override_gcc_and_weak.h:57:33: error: ISO C++17 does not allow dynamic exception specifications
     278       57 | void* operator new(size_t size) throw (std::bad_alloc)
```
- gperftools releases come in two flavours, one is directly a snapshot of the git repository and the other slightly modified and includes e.g. `configure` (see e.g. https://github.com/gperftools/gperftools/releases/tag/gperftools-2.10). For the old autotools versions I've kept the old url which contains `configure`. For the new CMake versions I'm using the snapshot because at least 2.8.1 did not include `CMakeLists.txt` in the non-snapshot archive (see https://github.com/gperftools/gperftools/issues/1321). Hence the need for a custom `url_for_version`. The hashes for 2.8.1 and 2.9.1 have also been changed because of this.
- Also adds gperftools 2.10.

Question regarding deprecated versions: will they be automatically removed when it's ok for them to be removed by someone or something or is it up to each individual package maintainer to remove them?