### PR TITLE
m4: Add build dependency on diffutils

### DIFF
--- a/var/spack/repos/builtin/packages/m4/package.py
+++ b/var/spack/repos/builtin/packages/m4/package.py
@@ -44,6 +44,7 @@ class M4(AutotoolsPackage, GNUMirrorPackage):
     variant('sigsegv', default=True,
             description="Build the libsigsegv dependency")
 
+    depends_on('diffutils', type='build')
     depends_on('libsigsegv', when='+sigsegv')
 
     build_directory = 'spack-build'


### PR DESCRIPTION
The `m4` build script uses `cmp` as part of checking for updates to the documentation. In a barebones Fedora container where `cmp` is not available by default, this results in a build error:
```
... snip ...
Making all in doc
make[2]: Entering directory '/tmp/root/spack-stage/spack-stage-m4-1.4.19-cewr4i6lfiopriu5vi575i642ffrlhit/spack-src/spack-build/doc'
/bin/sh: line 7: cmp: command not found
Updating /tmp/root/spack-stage/spack-stage-m4-1.4.19-cewr4i6lfiopriu5vi575i642ffrlhit/spack-src/doc/version.texi
make[2]: Leaving directory '/tmp/root/spack-stage/spack-stage-m4-1.4.19-cewr4i6lfiopriu5vi575i642ffrlhit/spack-src/spack-build/doc
... snip ...
Making install in doc
make[2]: Entering directory '/tmp/root/spack-stage/spack-stage-m4-1.4.19-cewr4i6lfiopriu5vi575i642ffrlhit/spack-src/spack-build/doc'
  MAKEINFO /tmp/root/spack-stage/spack-stage-m4-1.4.19-cewr4i6lfiopriu5vi575i642ffrlhit/spack-src/doc/m4.info
/tmp/root/spack-stage/spack-stage-m4-1.4.19-cewr4i6lfiopriu5vi575i642ffrlhit/spack-src/build-aux/missing: line 81: makeinfo: command not found
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <https://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <https://www.gnu.org/software/make/>
make[2]: *** [Makefile:1979: /tmp/root/spack-stage/spack-stage-m4-1.4.19-cewr4i6lfiopriu5vi575i642ffrlhit/spack-src/doc/m4.info] Error 127
```

Fix by adding a build dependency on `diffutils`, which provides `cmp`.