### PR TITLE
giflib: fix macOS build

### DIFF
--- a/var/spack/repos/builtin/packages/giflib/package.py
+++ b/var/spack/repos/builtin/packages/giflib/package.py
@@ -22,6 +22,10 @@ class Giflib(MakefilePackage, SourceforgePackage):
     depends_on('m4', type='build', when='@:5.2.0')
     depends_on('libtool', type='build', when='@:5.2.0')
 
+    # https://sourceforge.net/p/giflib/bugs/133/
+    patch('https://sourceforge.net/p/giflib/bugs/_discuss/thread/4e811ad29b/c323/attachment/Makefile.patch',
+          sha256='a94e7bdd8840a31cecacc301684dfdbf7b98773ad824aeaab611fabfdc513036',
+          level=0, when='@5.2:')
     patch('bsd-head.patch')
 
     def prefix_and_libversion_args(self):


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0.