### PR TITLE
HDF: fix build with Apple Clang

### DIFF
--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -172,7 +172,7 @@ class Hdf(AutotoolsPackage):
             )
 
         # https://forum.hdfgroup.org/t/help-building-hdf4-with-clang-error-implicit-declaration-of-function-test-mgr-szip-is-invalid-in-c99/7680
-        if self.spec.satisfies('%apple-clang'):
+        if self.spec.satisfies('@:4.2.15 %apple-clang'):
             config_args.append('CFLAGS=-Wno-error=implicit-function-declaration')
 
         return config_args

--- a/var/spack/repos/builtin/packages/hdf/package.py
+++ b/var/spack/repos/builtin/packages/hdf/package.py
@@ -171,6 +171,10 @@ class Hdf(AutotoolsPackage):
                 'FCFLAGS=-fallow-argument-mismatch']
             )
 
+        # https://forum.hdfgroup.org/t/help-building-hdf4-with-clang-error-implicit-declaration-of-function-test-mgr-szip-is-invalid-in-c99/7680
+        if self.spec.satisfies('%apple-clang'):
+            config_args.append('CFLAGS=-Wno-error=implicit-function-declaration')
+
         return config_args
 
     # Otherwise, we randomly get:


### PR DESCRIPTION
### Things I'm not sure of

* What range of versions of Apple Clang require this?
* Is this required by LLVM Clang or other compilers?
* Should this and the existing flag stuff be moved to flag_handler?

### Things I'm sure of

* Fails to build without this flag
* Successfully builds on macOS 10.15.7 with Apple Clang 12.0.0 with this flag