### PR TITLE
keyutils: add macOS conflict

### DIFF
--- a/var/spack/repos/builtin/packages/keyutils/package.py
+++ b/var/spack/repos/builtin/packages/keyutils/package.py
@@ -19,6 +19,8 @@ class Keyutils(MakefilePackage):
     version('1.5.10', sha256='e1fdbde234c786b65609a4cf080a2c5fbdb57f049249c139160c85fc3dfa7da9')
     version('1.5.9',  sha256='2dc0bdb099ab8331e02e5dbbce320359bef76eda0a4ddbd2ba1d1b9d3a8cdff8')
 
+    conflicts('platform=darwin', msg='Linux-only')
+
     def install(self, spec, prefix):
         install_tree('.', prefix)
         mkdirp(prefix.include)

--- a/var/spack/repos/builtin/packages/py-kerberos/package.py
+++ b/var/spack/repos/builtin/packages/py-kerberos/package.py
@@ -21,5 +21,5 @@ class PyKerberos(PythonPackage):
     version('1.3.0', sha256='f039b7dd4746df56f6102097b3dc250fe0078be75130b9dc4211a85a3b1ec6a4')
 
     depends_on('py-setuptools', type='build')
-    depends_on('keyutils')
+    depends_on('keyutils', when='platform=linux')
     depends_on('krb5@1.3.0:')


### PR DESCRIPTION
`keyutils` is Linux-only. `py-kerberos` builds fine without it on macOS.