### PR TITLE
spack create: fix for no URL

### DIFF
--- a/lib/spack/spack/cmd/create.py
+++ b/lib/spack/spack/cmd/create.py
@@ -826,7 +826,7 @@ def get_versions(args, name):
         spack.util.url.require_url_format(args.url)
         if args.url.startswith('file://'):
             valid_url = False  # No point in spidering these
-    except ValueError:
+    except (ValueError, TypeError):
         valid_url = False
 
     if args.url is not None and args.template != 'bundle' and valid_url:

--- a/lib/spack/spack/test/cmd/create.py
+++ b/lib/spack/spack/test/cmd/create.py
@@ -160,3 +160,9 @@ def test_get_name_error(parser, monkeypatch, capsys):
         spack.cmd.create.get_name(args)
     captured = capsys.readouterr()
     assert "Couldn't guess a name" in str(captured)
+
+
+def test_no_url(parser):
+    """Test creation of package without a URL."""
+    args = parser.parse_args(['--skip-editor', '-n', 'create-new-package'])
+    spack.cmd.create.create(parser, args)


### PR DESCRIPTION
`spack create` without a URL was broken by #27021. I'm actually not sure why the `require_url_format` test was added, but it doesn't work when `args.url` is None. I'm also not sure why `file://` is being skipped in light of #2545.