### PR TITLE
relocation: x-pie-executable's needs relocation

### DIFF
--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -433,8 +433,9 @@ def needs_binary_relocation(m_type, m_subtype):
         m_type (str): MIME type of the file
         m_subtype (str): MIME subtype of the file
     """
+    subtypes = ('x-executable', 'x-sharedlib', 'x-mach-binary', 'x-pie-executable')
     if m_type == 'application':
-        if m_subtype in ('x-executable', 'x-sharedlib', 'x-mach-binary'):
+        if m_subtype in subtypes:
             return True
     return False
 


### PR DESCRIPTION
`x-pie-executable`s need relocation.

`x-pie-executable` is one of the mime types returned by `file` on `Ubuntu 22.04` for some of the files that need to be marked as relocatable when creating a binary cache.

Without this PR:
```
$> spack python
>>> import spack.relocate as relocate
>>> m1, m2 = relocate.mime_type('.../pkgconf-1.8.0-6euhi2dwrqhctqjxmsg4na3yzrpka736/bin/pkgconf')
>>> (m1, m2)
('application', 'x-pie-executable')
>>> relocate.needs_binary_relocation(m1, m2)
False
```

With this PR:
```
$> spack python
>>> import spack.relocate as relocate
>>> m1, m2 = relocate.mime_type('.../pkgconf-1.8.0-6euhi2dwrqhctqjxmsg4na3yzrpka736/bin/pkgconf')
>>> relocate.needs_binary_relocation(m1, m2)
True
```

Will help or entirely fix https://github.com/spack/spack/issues/31241, to be determined if this PR alone is enough.

FYI @scottwittenburg @wspear @gartung 
