### PR TITLE
py-numpy: add v1.23.0; py-typing-extensions: add 4.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-numexpr/package.py
+++ b/var/spack/repos/builtin/packages/py-numexpr/package.py
@@ -23,5 +23,6 @@ class PyNumexpr(PythonPackage):
 
     depends_on('python@2.7:', when='@2.7.3:', type=('build', 'run'))
     depends_on('python@2.6:', when='@:2.7.2', type=('build', 'run'))
-    depends_on('py-numpy@1.7:', type=('build', 'run'))
+    # https://github.com/pydata/numexpr/issues/397
+    depends_on('py-numpy@1.7:1.22', type=('build', 'run'))
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -17,12 +17,13 @@ class PyNumpy(PythonPackage):
     number capabilities"""
 
     homepage = "https://numpy.org/"
-    pypi = "numpy/numpy-1.19.4.zip"
+    pypi = "numpy/numpy-1.23.0.tar.gz"
     git      = "https://github.com/numpy/numpy.git"
 
     maintainers = ['adamjstewart', 'rgommers']
 
     version('main', branch='main')
+    version('1.23.0', sha256='bd3fa4fe2e38533d5336e1272fc4e765cabbbde144309ccee8675509d5cd7b05')
     version('1.22.4', sha256='425b390e4619f58d8526b3dcf656dde069133ae5c240229821f01b5f44ea07af')
     version('1.22.3', sha256='dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18')
     version('1.22.2', sha256='076aee5a3763d41da6bef9565fdf3cb987606f567cd8b104aded2b38b7b47abf')
@@ -115,6 +116,7 @@ class PyNumpy(PythonPackage):
     depends_on('py-nose@1.0.0:', when='@:1.14', type='test')
     depends_on('py-pytest', when='@1.15:', type='test')
     depends_on('py-hypothesis', when='@1.19:', type='test')
+    depends_on('py-typing-extensions@4.2:', when='@1.23:', type='test')
 
     # Allows you to specify order of BLAS/LAPACK preference
     # https://github.com/numpy/numpy/pull/13132
@@ -151,6 +153,14 @@ class PyNumpy(PythonPackage):
 
     # NVHPC support added in https://github.com/numpy/numpy/pull/17344
     conflicts('%nvhpc', when='@:1.19')
+
+    def url_for_version(self, version):
+        url = 'https://files.pythonhosted.org/packages/source/n/numpy/numpy-{}.{}'
+        if version >= Version('1.23'):
+            ext = 'tar.gz'
+        else:
+            ext = 'zip'
+        return url.format(version, ext)
 
     def flag_handler(self, name, flags):
         # -std=c99 at least required, old versions of GCC default to -std=c90

--- a/var/spack/repos/builtin/packages/py-typing-extensions/package.py
+++ b/var/spack/repos/builtin/packages/py-typing-extensions/package.py
@@ -15,6 +15,7 @@ class PyTypingExtensions(PythonPackage):
     homepage = "https://github.com/python/typing/tree/master/typing_extensions"
     pypi = "typing_extensions/typing_extensions-3.7.4.tar.gz"
 
+    version('4.2.0', sha256='f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376')
     version('4.1.1', sha256='1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42')
     version('3.10.0.2', sha256='49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e')
     version('3.10.0.0', sha256='50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342')
@@ -24,6 +25,7 @@ class PyTypingExtensions(PythonPackage):
     version('3.6.6', sha256='51e7b7f3dcabf9ad22eed61490f3b8d23d9922af400fe6656cb08e66656b701f')
 
     # typing-extensions 4+ uses flit
+    depends_on('python@3.7:', when='@4.2:', type=('build', 'run'))
     depends_on('python@3.6:', when='@4:', type=('build', 'run'))
     depends_on('py-flit-core@3.4:3', when='@4:', type='build')
 


### PR DESCRIPTION
https://github.com/numpy/numpy/releases/tag/v1.23.0

Successfully builds on macOS 12.4 and Apple M1 Pro with Python 3.9.12 and Apple Clang 13.1.6.

A few tests failed but nothing too alarming, mostly distutils vs. setuptools stuff.
```
=========================== short test summary info ============================
FAILED ../core/tests/test_mem_policy.py::test_new_policy - AssertionError: as...
FAILED ../f2py/tests/test_kind.py::TestKind::test_all - AssertionError: selec...
FAILED ../linalg/tests/test_linalg.py::TestDet::test_types[complex64] - Runti...
FAILED ../linalg/tests/test_linalg.py::TestDet::test_types[complex128] - Runt...
FAILED ../tests/test_public_api.py::test_api_importable - UserWarning: Distut...
ERROR ../core/tests/test_cython.py::test_is_timedelta64_object - subprocess.C...
ERROR ../core/tests/test_cython.py::test_is_datetime64_object - subprocess.Ca...
ERROR ../core/tests/test_cython.py::test_get_datetime64_value - subprocess.Ca...
ERROR ../core/tests/test_cython.py::test_get_timedelta64_value - subprocess.C...
ERROR ../core/tests/test_cython.py::test_get_datetime64_unit - subprocess.Cal...
ERROR ../core/tests/test_cython.py::test_abstract_scalars - subprocess.Called...
= 5 failed, 18781 passed, 372 skipped, 48 xfailed, 7 xpassed, 6 errors in 322.34s (0:05:22) =
```