### PR TITLE
py-cryptography@3.4.7 depends on openssl@1.1:

### DIFF
--- a/var/spack/repos/builtin/packages/py-cryptography/package.py
+++ b/var/spack/repos/builtin/packages/py-cryptography/package.py
@@ -45,6 +45,8 @@ class PyCryptography(PythonPackage):
     depends_on('py-enum34',             type=('build', 'run'), when='^python@:3.4')
     depends_on('py-ipaddress',          type=('build', 'run'), when='^python@:3.3')
     depends_on('openssl@:1.0', when='@:1.8.1')
+    depends_on('openssl@1.0:', when='@2.0:')
+    depends_on('openssl@1.1:', when='@3.4:')
     depends_on('openssl')
 
     # To fix https://github.com/spack/spack/issues/29669


### PR DESCRIPTION
This is a problem on older RHEL systems where the system openssl is 1.0.2. In these cases, you need to pin py-cryptography to 3.2.1 or go through the hassle of rebuilding openssl.