### PR TITLE
rpcsvc-proto: add v1.4.1 through 1.4.3

### DIFF
--- a/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
+++ b/var/spack/repos/builtin/packages/rpcsvc-proto/package.py
@@ -10,9 +10,12 @@ class RpcsvcProto(AutotoolsPackage):
     """rpcsvc protocol definitions from glibc."""
 
     homepage = "https://github.com/thkukuk/rpcsvc-proto"
-    url      = "https://github.com/thkukuk/rpcsvc-proto/releases/download/v1.4/rpcsvc-proto-1.4.tar.gz"
+    url      = "https://github.com/thkukuk/rpcsvc-proto/releases/download/v1.4.3/rpcsvc-proto-1.4.3.tar.xz"
 
-    version('1.4', sha256='867e46767812784d8dda6d8d931d6fabb30168abb02d87a2a205be6d5a2934a7')
+    version('1.4.3', sha256='69315e94430f4e79c74d43422f4a36e6259e97e67e2677b2c7d7060436bd99b1')
+    version('1.4.2', sha256='678851b9f7ddf4410d2859c12016b65a6dd1a0728d478f18aeb54d165352f17c')
+    version('1.4.1', sha256='9429e143bb8dd33d34bf0663f571d4d4a1103e1afd7c49791b367b7ae1ef7f35')
+    version('1.4',   sha256='4149d5f05d8f7224a4d207362fdfe72420989dc1b028b28b7b62b6c2efe22345')
 
     depends_on('gettext')
 


### PR DESCRIPTION
Latest version fixes build issues on M1.

Successfully builds on macOS 12.4 and Apple M1 Pro with Apple Clang 13.1.6.