### PR TITLE
sfcgal: fix boost build issues

### DIFF
--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -24,12 +24,7 @@ class Sfcgal(CMakePackage):
     depends_on('cmake@2.8.6:', type='build')
     # Ref: https://oslandia.github.io/SFCGAL/installation.html, but starts to work @4.7:
     depends_on('cgal@4.7: +core')
-    depends_on('boost@1.54.0:')
-
-    # TODO: replace this with an explicit list of components of Boost,
-    # for instance depends_on('boost +filesystem')
-    # See https://github.com/spack/spack/pull/22303 for reference
-    depends_on(Boost.with_default_variants)
+    depends_on('boost@1.54.0:+chrono+filesystem+program_options+serialization+system+test+thread+timer')
     depends_on('mpfr@2.2.1:')
     depends_on('gmp@4.2:')
 
@@ -37,4 +32,7 @@ class Sfcgal(CMakePackage):
         # It seems viewer is discontinued as of v1.3.0
         # https://github.com/Oslandia/SFCGAL/releases/tag/v1.3.0
         # Also, see https://github.com/Oslandia/SFCGAL-viewer
-        return ['-DSFCGAL_BUILD_VIEWER=OFF']
+        return [
+            self.define('BUILD_SHARED_LIBS', True),
+            self.define('SFCGAL_BUILD_VIEWER', False),
+        ]

--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.pkg.builtin.boost import Boost
 
 
 class Sfcgal(CMakePackage):


### PR DESCRIPTION
Before this change:
```
-- Boost_USE_STATIC_LIBS=OFF
-- Boost_USE_MULTITHREAD=ON
-- Found Boost 1.70.0 at /Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/boost-1.70.0-mlzu6djbit2yjeiv76dlsbw3a4se62sm/lib/cmake/Boost-1.70.0
--   Requested configuration: QUIET REQUIRED COMPONENTS thread;system;serialization
-- Found boost_thread 1.70.0 at /Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/boost-1.70.0-mlzu6djbit2yjeiv76dlsbw3a4se62sm/lib/cmake/boost_thread-1.70.0
-- No suitable boost_thread variant has been identified!
--   libboost_thread.dylib (shared, BUILD_SHARED_LIBS not ON, set Boost_USE_STATIC_LIBS=OFF to override)
--   libboost_thread.a (static, Boost_USE_STATIC_LIBS=OFF)
CMake Error at /Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/boost-1.70.0-mlzu6djbit2yjeiv76dlsbw3a4se62sm/lib/cmake/Boost-1.70.0/BoostConfig.cmake:95 (find_package):
  Found package configuration file:

    /Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/boost-1.70.0-mlzu6djbit2yjeiv76dlsbw3a4se62sm/lib/cmake/boost_thread-1.70.0/boost_thread-config.cmake

  but it set boost_thread_FOUND to FALSE so package "boost_thread" is
  considered to be NOT FOUND.  Reason given by package:

  No suitable build variant has been found.

Call Stack (most recent call first):
  /Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/boost-1.70.0-mlzu6djbit2yjeiv76dlsbw3a4se62sm/lib/cmake/Boost-1.70.0/BoostConfig.cmake:124 (boost_find_dependency)
  /Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/cmake-3.23.1-2ipwayeri23f5s5wp4bpwmtmp3itsvlf/share/cmake-3.23/Modules/FindBoost.cmake:594 (find_package)
  CMakeLists.txt:107 (find_package)
```
Adding `-DBUILD_SHARED_LIBS=ON` solved the issue. Also clarified which boost variants are actually required.

Successfully builds on macOS 12.4 and Apple M1 Pro with Apple Clang 13.1.6.