### PR TITLE
krb5: Add build dependency on diffutils

### DIFF
--- a/var/spack/repos/builtin/packages/krb5/package.py
+++ b/var/spack/repos/builtin/packages/krb5/package.py
@@ -27,6 +27,7 @@ class Krb5(AutotoolsPackage):
     version('1.16.2', sha256='9f721e1fe593c219174740c71de514c7228a97d23eb7be7597b2ae14e487f027')
     version('1.16.1', sha256='214ffe394e3ad0c730564074ec44f1da119159d94281bbec541dc29168d21117')
 
+    depends_on('diffutils', type='build')
     depends_on('bison', type='build')
     depends_on('openssl@:1')
     depends_on('gettext')


### PR DESCRIPTION
The `krb5` build script uses `cmp` to check for updates to a generated header. In a barebones Fedora container where `cmp` is not available by default, this results in a build error:
```
... snip ...
making all in include...
make[1]: Entering directory '/tmp/root/spack-stage/spack-stage-krb5-1.19.3-qccrhmlvch3kdbz5b6mmxbe3d4jcdena/spack-src/src/include'
... snip ...
if test -r krb5.h; then \
  if cmp -s krb5.h ./krb5.h; then :; else rm -f krb5.h; fi; \
else :; fi
/bin/sh: line 2: cmp: command not found
echo "/* This file is generated, please don't edit it directly.  */" > krb5/krb5.new
echo "#ifndef KRB5_KRB5_H_INCLUDED" >> krb5/krb5.new
echo "#define KRB5_KRB5_H_INCLUDED" >> krb5/krb5.new
cat ./krb5/krb5.hin ../lib/krb5/error_tables/krb5_err.h ../lib/krb5/error_tables/k5e1_err.h ../lib/krb5/error_tables/kdb5_err.h ../lib/krb5/error_tables/kv5m_err.h ../lib/krb5/error_tables/krb524_err.h ../lib/krb5/error_tables/asn1_err.h >> krb5/krb5.new
echo "#endif /* KRB5_KRB5_H_INCLUDED */" >> krb5/krb5.new
../config/move-if-changed krb5/krb5.new krb5/krb5.h
touch krb5.stamp
: krb5.h
... snip ...
make[3]: Entering directory '/tmp/root/spack-stage/spack-stage-krb5-1.19.3-qccrhmlvch3kdbz5b6mmxbe3d4jcdena/spack-src/src/lib/crypto/krb'
make[3]: *** No rule to make target '../../../include/krb5.h', needed by 'aead.so'.  Stop.
```
Fix by adding a build dependency on `diffutils`, which provides `cmp`.