### PR TITLE
Allow using mimalloc 2 in pika and HPX

### DIFF
--- a/var/spack/repos/builtin/packages/hpx/mimalloc_no_version_requirement.patch
+++ b/var/spack/repos/builtin/packages/hpx/mimalloc_no_version_requirement.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/HPX_SetupAllocator.cmake b/cmake/HPX_SetupAllocator.cmake
+index 221c988d997..2e9d760a778 100644
+--- a/cmake/HPX_SetupAllocator.cmake
++++ b/cmake/HPX_SetupAllocator.cmake
+@@ -78,6 +78,6 @@ if(NOT TARGET hpx_dependencies_allocator)
+     # ##########################################################################
+     # MIMALLOC
+     if("${HPX_WITH_MALLOC_UPPER}" STREQUAL "MIMALLOC")
+-      find_package(mimalloc 1.0)
++      find_package(mimalloc)
+       if(NOT mimalloc_FOUND)
+         hpx_error(${allocator_error})

--- a/var/spack/repos/builtin/packages/hpx/package.py
+++ b/var/spack/repos/builtin/packages/hpx/package.py
@@ -102,7 +102,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('gperftools', when='malloc=tcmalloc')
     depends_on('jemalloc', when='malloc=jemalloc')
-    depends_on('mimalloc@1', when='malloc=mimalloc')
+    depends_on('mimalloc', when='malloc=mimalloc')
     depends_on('tbb', when='malloc=tbbmalloc')
 
     depends_on('mpi', when='networking=mpi')
@@ -176,6 +176,7 @@ class Hpx(CMakePackage, CudaPackage, ROCmPackage):
 
     # Patches APEX
     patch('git_external.patch', when='@1.3.0 instrumentation=apex')
+    patch('mimalloc_no_version_requirement.patch', when='@:1.8 malloc=mimalloc')
 
     def instrumentation_args(self):
         args = []

--- a/var/spack/repos/builtin/packages/pika/mimalloc_no_version_requirement.patch
+++ b/var/spack/repos/builtin/packages/pika/mimalloc_no_version_requirement.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/pika_setup_allocator.cmake b/cmake/pika_setup_allocator.cmake
+index fdd75fa1..5e358edc 100644
+--- a/cmake/pika_setup_allocator.cmake
++++ b/cmake/pika_setup_allocator.cmake
+@@ -78,7 +78,7 @@ if(NOT TARGET pika_dependencies_allocator)
+     # ##########################################################################
+     # MIMALLOC
+     if("${PIKA_WITH_MALLOC_UPPER}" STREQUAL "MIMALLOC")
+-      find_package(mimalloc 1.0)
++      find_package(mimalloc)
+       if(NOT mimalloc_FOUND)
+         pika_error(${allocator_error})
+       endif()

--- a/var/spack/repos/builtin/packages/pika/package.py
+++ b/var/spack/repos/builtin/packages/pika/package.py
@@ -68,7 +68,7 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('gperftools', when='malloc=tcmalloc')
     depends_on('jemalloc', when='malloc=jemalloc')
-    depends_on('mimalloc@1', when='malloc=mimalloc')
+    depends_on('mimalloc', when='malloc=mimalloc')
     depends_on('tbb', when='malloc=tbbmalloc')
 
     depends_on('mpi', when='+mpi')
@@ -95,7 +95,8 @@ class Pika(CMakePackage, CudaPackage, ROCmPackage):
     conflicts('~generic_coroutines', when='platform=darwin', msg=_msg_generic_coroutines)
 
     # Patches
-    patch('transform_mpi_includes.patch', when="@0.3.0 +mpi")
+    patch('transform_mpi_includes.patch', when='@0.3.0 +mpi')
+    patch('mimalloc_no_version_requirement.patch', when='@:0.5 malloc=mimalloc')
 
     def cmake_args(self):
         spec, args = self.spec, []


### PR DESCRIPTION
Lifts an unnecessary requirement to use mimalloc 1 with pika and HPX. The patches have been submitted upstream and won't be required in the next releases.