### PR TITLE
ASP: targets, compilers and providers soft-preferences are only global

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -407,7 +407,9 @@ def config_prefer_upstream(args):
     pkgs = {}
     for spec in pref_specs:
         # Collect all the upstream compilers and versions for this package.
-        pkg = pkgs.get(spec.name, {"version": [], "compiler": []})
+        pkg = pkgs.get(spec.name, {"version": []})
+        all = pkgs.get("all", {"compiler": []})
+        pkgs["all"] = all
         pkgs[spec.name] = pkg
 
         # We have no existing variant if this is our first added version.
@@ -418,8 +420,8 @@ def config_prefer_upstream(args):
             pkg["version"].append(version)
 
         compiler = str(spec.compiler)
-        if compiler not in pkg["compiler"]:
-            pkg["compiler"].append(compiler)
+        if compiler not in all["compiler"]:
+            all["compiler"].append(compiler)
 
         # Get and list all the variants that differ from the default.
         variants = []

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -116,7 +116,7 @@ properties = {
                 "deprecatedProperties": {
                     "properties": ["version"],
                     "message": "setting version preferences in the 'all' section of packages.yaml "
-                    "is deprecated and will be removed in v0.22\n\n\tCurrently, these preferences "
+                    "is deprecated and will be removed in v0.22\n\n\tThese preferences "
                     "will be ignored by Spack. You can set them only in package specific sections "
                     "of the same file.\n",
                     "error": False,
@@ -164,7 +164,7 @@ properties = {
                     "properties": ["target", "compiler", "providers"],
                     "message": "setting compiler, target or provider preferences in a package "
                     "specific section of packages.yaml is deprecated, and will be removed in "
-                    "v0.22.\n\n\tCurrently, these preferences will be ignored by Spack. You "
+                    "v0.22.\n\n\tThese preferences will be ignored by Spack. You "
                     "can set them only in the 'all' section of the same file.\n",
                     "error": False,
                 },

--- a/lib/spack/spack/schema/packages.py
+++ b/lib/spack/spack/schema/packages.py
@@ -8,6 +8,66 @@
    :lines: 13-
 """
 
+permissions = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "read": {"type": "string", "enum": ["user", "group", "world"]},
+        "write": {"type": "string", "enum": ["user", "group", "world"]},
+        "group": {"type": "string"},
+    },
+}
+
+variants = {"oneOf": [{"type": "string"}, {"type": "array", "items": {"type": "string"}}]}
+
+requirements = {
+    "oneOf": [
+        # 'require' can be a list of requirement_groups.
+        # each requirement group is a list of one or more
+        # specs. Either at least one or exactly one spec
+        # in the group must be satisfied (depending on
+        # whether you use "any_of" or "one_of",
+        # repectively)
+        {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "one_of": {"type": "array", "items": {"type": "string"}},
+                            "any_of": {"type": "array", "items": {"type": "string"}},
+                            "spec": {"type": "string"},
+                            "message": {"type": "string"},
+                            "when": {"type": "string"},
+                        },
+                    },
+                    {"type": "string"},
+                ]
+            },
+        },
+        # Shorthand for a single requirement group with
+        # one member
+        {"type": "string"},
+    ]
+}
+
+permissions = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "read": {"type": "string", "enum": ["user", "group", "world"]},
+        "write": {"type": "string", "enum": ["user", "group", "world"]},
+        "group": {"type": "string"},
+    },
+}
+
+package_attributes = {
+    "type": "object",
+    "additionalProperties": False,
+    "patternProperties": {r"\w+": {}},
+}
 
 #: Properties for inclusion in other schemas
 properties = {
@@ -15,57 +75,14 @@ properties = {
         "type": "object",
         "default": {},
         "additionalProperties": False,
-        "patternProperties": {
-            r"\w[\w-]*": {  # package name
+        "properties": {
+            "all": {  # package name
                 "type": "object",
                 "default": {},
                 "additionalProperties": False,
                 "properties": {
-                    "require": {
-                        "oneOf": [
-                            # 'require' can be a list of requirement_groups.
-                            # each requirement group is a list of one or more
-                            # specs. Either at least one or exactly one spec
-                            # in the group must be satisfied (depending on
-                            # whether you use "any_of" or "one_of",
-                            # repectively)
-                            {
-                                "type": "array",
-                                "items": {
-                                    "oneOf": [
-                                        {
-                                            "type": "object",
-                                            "additionalProperties": False,
-                                            "properties": {
-                                                "one_of": {
-                                                    "type": "array",
-                                                    "items": {"type": "string"},
-                                                },
-                                                "any_of": {
-                                                    "type": "array",
-                                                    "items": {"type": "string"},
-                                                },
-                                                "spec": {"type": "string"},
-                                                "message": {"type": "string"},
-                                                "when": {"type": "string"},
-                                            },
-                                        },
-                                        {"type": "string"},
-                                    ]
-                                },
-                            },
-                            # Shorthand for a single requirement group with
-                            # one member
-                            {"type": "string"},
-                        ]
-                    },
-                    "version": {
-                        "type": "array",
-                        "default": [],
-                        # version strings (type should be string, number is still possible
-                        # but deprecated. this is to avoid issues with e.g. 3.10 -> 3.1)
-                        "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
-                    },
+                    "require": requirements,
+                    "version": {},  # Here only to warn users on ignored properties
                     "target": {
                         "type": "array",
                         "default": [],
@@ -78,22 +95,10 @@ properties = {
                         "items": {"type": "string"},
                     },  # compiler specs
                     "buildable": {"type": "boolean", "default": True},
-                    "permissions": {
-                        "type": "object",
-                        "additionalProperties": False,
-                        "properties": {
-                            "read": {"type": "string", "enum": ["user", "group", "world"]},
-                            "write": {"type": "string", "enum": ["user", "group", "world"]},
-                            "group": {"type": "string"},
-                        },
-                    },
+                    "permissions": permissions,
                     # If 'get_full_repo' is promoted to a Package-level
                     # attribute, it could be useful to set it here
-                    "package_attributes": {
-                        "type": "object",
-                        "additionalProperties": False,
-                        "patternProperties": {r"\w+": {}},
-                    },
+                    "package_attributes": package_attributes,
                     "providers": {
                         "type": "object",
                         "default": {},
@@ -106,12 +111,40 @@ properties = {
                             }
                         },
                     },
-                    "variants": {
-                        "oneOf": [
-                            {"type": "string"},
-                            {"type": "array", "items": {"type": "string"}},
-                        ]
+                    "variants": variants,
+                },
+                "deprecatedProperties": {
+                    "properties": ["version"],
+                    "message": "setting version preferences in the 'all' section of packages.yaml "
+                    "is deprecated and will be removed in v0.22\n\n\tCurrently, these preferences "
+                    "will be ignored by Spack. You can set them only in package specific sections "
+                    "of the same file.\n",
+                    "error": False,
+                },
+            }
+        },
+        "patternProperties": {
+            r"(?!^all$)(^\w[\w-]*)": {  # package name
+                "type": "object",
+                "default": {},
+                "additionalProperties": False,
+                "properties": {
+                    "require": requirements,
+                    "version": {
+                        "type": "array",
+                        "default": [],
+                        # version strings
+                        "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     },
+                    "target": {},  # Here only to warn users on ignored properties
+                    "compiler": {},  # Here only to warn users on ignored properties
+                    "buildable": {"type": "boolean", "default": True},
+                    "permissions": permissions,
+                    # If 'get_full_repo' is promoted to a Package-level
+                    # attribute, it could be useful to set it here
+                    "package_attributes": package_attributes,
+                    "providers": {},  # Here only to warn users on ignored properties
+                    "variants": variants,
                     "externals": {
                         "type": "array",
                         "items": {
@@ -126,6 +159,14 @@ properties = {
                             "required": ["spec"],
                         },
                     },
+                },
+                "deprecatedProperties": {
+                    "properties": ["target", "compiler", "providers"],
+                    "message": "setting compiler, target or provider preferences in a package "
+                    "specific section of packages.yaml is deprecated, and will be removed in "
+                    "v0.22.\n\n\tCurrently, these preferences will be ignored by Spack. You "
+                    "can set them only in the 'all' section of the same file.\n",
+                    "error": False,
                 },
             }
         },

--- a/lib/spack/spack/solver/concretize.lp
+++ b/lib/spack/spack/solver/concretize.lp
@@ -589,21 +589,15 @@ possible_provider_weight(DependencyNode, VirtualNode, 0, "external")
   :- provider(DependencyNode, VirtualNode),
      external(DependencyNode).
 
-% A provider mentioned in packages.yaml can use a weight
-% according to its priority in the list of providers
-possible_provider_weight(node(DependencyID, Dependency), node(VirtualID, Virtual), Weight, "packages_yaml")
-  :- provider(node(DependencyID, Dependency), node(VirtualID, Virtual)),
-     depends_on(node(ID, Package), node(DependencyID, Dependency)),
-     pkg_fact(Package, provider_preference(Virtual, Dependency, Weight)).
-
 % A provider mentioned in the default configuration can use a weight
 % according to its priority in the list of providers
-possible_provider_weight(node(DependencyID, Dependency), node(VirtualID, Virtual), Weight, "default")
-  :- provider(node(DependencyID, Dependency), node(VirtualID, Virtual)),
-     default_provider_preference(Virtual, Dependency, Weight).
+possible_provider_weight(node(ProviderID, Provider), node(VirtualID, Virtual), Weight, "default")
+  :- provider(node(ProviderID, Provider), node(VirtualID, Virtual)),
+     default_provider_preference(Virtual, Provider, Weight).
 
 % Any provider can use 100 as a weight, which is very high and discourage its use
-possible_provider_weight(node(DependencyID, Dependency), VirtualNode, 100, "fallback") :- provider(node(DependencyID, Dependency), VirtualNode).
+possible_provider_weight(node(ProviderID, Provider), VirtualNode, 100, "fallback")
+  :- provider(node(ProviderID, Provider), VirtualNode).
 
 % do not warn if generated program contains none of these.
 #defined virtual/1.
@@ -1059,7 +1053,7 @@ attr("node_target", PackageNode, Target)
 node_target_weight(node(ID, Package), Weight)
  :- attr("node", node(ID, Package)),
     attr("node_target", node(ID, Package), Target),
-    pkg_fact(Package, target_weight(Target, Weight)).
+    target_weight(Target, Weight).
 
 % compatibility rules for targets among nodes
 node_target_match(ParentNode, DependencyNode)
@@ -1181,23 +1175,17 @@ compiler_mismatch_required(PackageNode, DependencyNode)
 #defined allow_compiler/2.
 
 % compilers weighted by preference according to packages.yaml
-compiler_weight(node(ID, Package), Weight)
+node_compiler_weight(node(ID, Package), Weight)
  :- node_compiler(node(ID, Package), CompilerID),
     compiler_name(CompilerID, Compiler),
     compiler_version(CompilerID, V),
-    pkg_fact(Package, node_compiler_preference(Compiler, V, Weight)).
-compiler_weight(node(ID, Package), Weight)
+    compiler_weight(CompilerID, Weight).
+
+node_compiler_weight(node(ID, Package), 100)
  :- node_compiler(node(ID, Package), CompilerID),
     compiler_name(CompilerID, Compiler),
     compiler_version(CompilerID, V),
-    not pkg_fact(Package, node_compiler_preference(Compiler, V, _)),
-    default_compiler_preference(CompilerID, Weight).
-compiler_weight(node(ID, Package), 100)
- :- node_compiler(node(ID, Package), CompilerID),
-    compiler_name(CompilerID, Compiler),
-    compiler_version(CompilerID, V),
-    not pkg_fact(Package, node_compiler_preference(Compiler, V, _)),
-    not default_compiler_preference(CompilerID, _).
+    not compiler_weight(CompilerID, _).
 
 % For the time being, be strict and reuse only if the compiler match one we have on the system
 error(100, "Compiler {1}@{2} requested for {0} cannot be found. Set install_missing_compilers:true if intended.", Package, Compiler, Version)
@@ -1205,7 +1193,7 @@ error(100, "Compiler {1}@{2} requested for {0} cannot be found. Set install_miss
     not node_compiler(node(ID, Package), _).
 
 #defined node_compiler_preference/4.
-#defined default_compiler_preference/3.
+#defined compiler_weight/3.
 
 %-----------------------------------------------------------------------------
 % Compiler flags
@@ -1529,7 +1517,7 @@ opt_criterion(15, "non-preferred compilers").
 #minimize{ 0@15: #true }.
 #minimize{
     Weight@15+Priority,PackageNode
-    : compiler_weight(PackageNode, Weight),
+    : node_compiler_weight(PackageNode, Weight),
       build_priority(PackageNode, Priority)
 }.
 

--- a/lib/spack/spack/solver/heuristic.lp
+++ b/lib/spack/spack/solver/heuristic.lp
@@ -16,9 +16,9 @@
 #heuristic attr("version", node(0, Package), Version) : pkg_fact(Package, version_declared(Version, 0)), attr("root", node(0, Package)). [35, true]
 #heuristic version_weight(node(0, Package), 0) : pkg_fact(Package, version_declared(Version, 0)), attr("root", node(0, Package)). [35, true]
 #heuristic attr("variant_value", node(0, Package), Variant, Value) : variant_default_value(Package, Variant, Value), attr("root", node(0, Package)). [35, true]
-#heuristic attr("node_target", node(0, Package), Target) : pkg_fact(Package, target_weight(Target, 0)), attr("root", node(0, Package)). [35, true]
+#heuristic attr("node_target", node(0, Package), Target) : target_weight(Target, 0), attr("root", node(0, Package)). [35, true]
 #heuristic node_target_weight(node(0, Package), 0) : attr("root", node(0, Package)). [35, true]
-#heuristic node_compiler(node(0, Package), CompilerID) : default_compiler_preference(ID, 0), compiler_id(ID), attr("root", node(0, Package)). [35, true]
+#heuristic node_compiler(node(0, Package), CompilerID) : compiler_weight(ID, 0), compiler_id(ID), attr("root", node(0, Package)). [35, true]
 
 % Providers
 #heuristic attr("node", node(0, Package)) : default_provider_preference(Virtual, Package, 0), possible_in_link_run(Package). [30, true]

--- a/lib/spack/spack/solver/heuristic_separate.lp
+++ b/lib/spack/spack/solver/heuristic_separate.lp
@@ -13,7 +13,7 @@
 #heuristic attr("variant_value", node(ID, Package), Variant, Value) : variant_default_value(Package, Variant, Value), attr("node", node(ID, Package)), ID > 0. [25-5*ID, true]
 #heuristic attr("node_target", node(ID, Package), Target) : pkg_fact(Package, target_weight(Target, 0)), attr("node", node(ID, Package)), ID > 0. [25-5*ID, true]
 #heuristic node_target_weight(node(ID, Package), 0) : attr("node", node(ID, Package)), ID > 0. [25-5*ID, true]
-#heuristic node_compiler(node(ID, Package), CompilerID) : default_compiler_preference(CompilerID, 0), compiler_id(CompilerID), attr("node", node(ID, Package)), ID > 0. [25-5*ID, true]
+#heuristic node_compiler(node(ID, Package), CompilerID) : compiler_weight(CompilerID, 0), compiler_id(CompilerID), attr("node", node(ID, Package)), ID > 0. [25-5*ID, true]
 
 % node(ID, _), split build dependencies
 #heuristic attr("version", node(ID, Package), Version) : pkg_fact(Package, version_declared(Version, 0)), attr("node", node(ID, Package)), multiple_unification_sets(Package), ID > 0. [25, true]
@@ -21,4 +21,4 @@
 #heuristic attr("variant_value", node(ID, Package), Variant, Value) : variant_default_value(Package, Variant, Value), attr("node", node(ID, Package)), multiple_unification_sets(Package), ID > 0. [25, true]
 #heuristic attr("node_target", node(ID, Package), Target) : pkg_fact(Package, target_weight(Target, 0)), attr("node", node(ID, Package)), multiple_unification_sets(Package), ID > 0. [25, true]
 #heuristic node_target_weight(node(ID, Package), 0) : attr("node", node(ID, Package)), multiple_unification_sets(Package), ID > 0. [25, true]
-#heuristic node_compiler(node(ID, Package), CompilerID) : default_compiler_preference(CompilerID, 0), compiler_id(CompilerID), attr("node", node(ID, Package)), multiple_unification_sets(Package), ID > 0. [25, true]
+#heuristic node_compiler(node(ID, Package), CompilerID) : compiler_weight(CompilerID, 0), compiler_id(CompilerID), attr("node", node(ID, Package)), multiple_unification_sets(Package), ID > 0. [25, true]

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -215,10 +215,10 @@ def test_config_add_override_leaf(mutable_empty_config):
 
 
 def test_config_add_update_dict(mutable_empty_config):
-    config("add", "packages:all:version:[1.0.0]")
+    config("add", "packages:hdf5:version:[1.0.0]")
     output = config("get", "packages")
 
-    expected = "packages:\n  all:\n    version: [1.0.0]\n"
+    expected = "packages:\n  hdf5:\n    version: [1.0.0]\n"
     assert output == expected
 
 
@@ -352,8 +352,7 @@ def test_config_add_update_dict_from_file(mutable_empty_config, tmpdir):
     contents = """spack:
   packages:
     all:
-      version:
-      - 1.0.0
+      target: [x86_64]
 """
 
     # create temp file and add it to config
@@ -368,8 +367,7 @@ def test_config_add_update_dict_from_file(mutable_empty_config, tmpdir):
     # added config comes before prior config
     expected = """packages:
   all:
-    version:
-    - 1.0.0
+    target: [x86_64]
     compiler: [gcc]
 """
 
@@ -381,7 +379,7 @@ def test_config_add_invalid_file_fails(tmpdir):
     # invalid because version requires a list
     contents = """spack:
   packages:
-    all:
+    hdf5:
       version: 1.0.0
 """
 
@@ -631,14 +629,11 @@ def test_config_prefer_upstream(
     packages = syaml.load(open(cfg_file))["packages"]
 
     # Make sure only the non-default variants are set.
-    assert packages["boost"] == {
-        "compiler": ["gcc@=10.2.1"],
-        "variants": "+debug +graph",
-        "version": ["1.63.0"],
-    }
-    assert packages["dependency-install"] == {"compiler": ["gcc@=10.2.1"], "version": ["2.0"]}
+    assert packages["all"] == {"compiler": ["gcc@=10.2.1"]}
+    assert packages["boost"] == {"variants": "+debug +graph", "version": ["1.63.0"]}
+    assert packages["dependency-install"] == {"version": ["2.0"]}
     # Ensure that neither variant gets listed for hdf5, since they conflict
-    assert packages["hdf5"] == {"compiler": ["gcc@=10.2.1"], "version": ["2.3"]}
+    assert packages["hdf5"] == {"version": ["2.3"]}
 
     # Make sure a message about the conflicting hdf5's was given.
     assert "- hdf5" in output

--- a/lib/spack/spack/test/cmd/env.py
+++ b/lib/spack/spack/test/cmd/env.py
@@ -2621,7 +2621,7 @@ spack:
   - matrix:
     - [mpileaks]
   packages:
-    mpileaks:
+    all:
       compiler: [gcc]
   view: true
 """

--- a/lib/spack/spack/test/concretize_preferences.py
+++ b/lib/spack/spack/test/concretize_preferences.py
@@ -105,17 +105,13 @@ class TestConcretizePreferences:
 
     @pytest.mark.parametrize(
         "compiler_str,spec_str",
-        [("gcc@4.5.0", "mpileaks"), ("clang@12.0.0", "mpileaks"), ("gcc@4.5.0", "openmpi")],
+        [("gcc@=4.5.0", "mpileaks"), ("clang@=12.0.0", "mpileaks"), ("gcc@=4.5.0", "openmpi")],
     )
     def test_preferred_compilers(self, compiler_str, spec_str):
         """Test preferred compilers are applied correctly"""
-        spec = Spec(spec_str)
-        update_packages(spec.name, "compiler", [compiler_str])
-        spec.concretize()
-        # note: lhs has concrete compiler version, rhs still abstract.
-        # Could be made more strict by checking for equality with `gcc@=4.5.0`
-        # etc.
-        assert spec.compiler.satisfies(CompilerSpec(compiler_str))
+        update_packages("all", "compiler", [compiler_str])
+        spec = spack.spec.Spec(spec_str).concretized()
+        assert spec.compiler == CompilerSpec(compiler_str)
 
     @pytest.mark.only_clingo("Use case not supported by the original concretizer")
     def test_preferred_target(self, mutable_mock_repo):
@@ -124,7 +120,7 @@ class TestConcretizePreferences:
         default = str(spec.target)
         preferred = str(spec.target.family)
 
-        update_packages("mpich", "target", [preferred])
+        update_packages("all", "target", [preferred])
         spec = concretize("mpich")
         assert str(spec.target) == preferred
 
@@ -132,7 +128,7 @@ class TestConcretizePreferences:
         assert str(spec["mpileaks"].target) == preferred
         assert str(spec["mpich"].target) == preferred
 
-        update_packages("mpileaks", "target", [default])
+        update_packages("all", "target", [default])
         spec = concretize("mpileaks")
         assert str(spec["mpileaks"].target) == default
         assert str(spec["mpich"].target) == default

--- a/lib/spack/spack/test/config.py
+++ b/lib/spack/spack/test/config.py
@@ -78,7 +78,7 @@ spack:
         verify_ssl: False
         dirty: False
     packages:
-        libelf:
+        all:
             compiler: [ 'gcc@4.5.3' ]
     repos:
         - /x/y/z
@@ -942,7 +942,7 @@ def test_single_file_scope(config, env_yaml):
         # from the single-file config
         assert spack.config.get("config:verify_ssl") is False
         assert spack.config.get("config:dirty") is False
-        assert spack.config.get("packages:libelf:compiler") == ["gcc@4.5.3"]
+        assert spack.config.get("packages:all:compiler") == ["gcc@4.5.3"]
 
         # from the lower config scopes
         assert spack.config.get("config:checksum") is True
@@ -965,7 +965,7 @@ spack:
     config:
         verify_ssl: False
     packages::
-        libelf:
+        all:
             compiler: [ 'gcc@4.5.3' ]
     repos:
         - /x/y/z
@@ -977,7 +977,7 @@ spack:
     with spack.config.override(scope):
         # from the single-file config
         assert spack.config.get("config:verify_ssl") is False
-        assert spack.config.get("packages:libelf:compiler") == ["gcc@4.5.3"]
+        assert spack.config.get("packages:all:compiler") == ["gcc@4.5.3"]
 
         # from the lower config scopes
         assert spack.config.get("config:checksum") is True


### PR DESCRIPTION
fixes #31199
fixes #27055

A number of our soft preferences are broken and hard to make sense of when specified at the package level.  Similarly, `version` when specified at the `all:` level is unintuitive -- there are very few situations where we'd want to universally prefer "1.0".

This PR disallows unintuitive per-package soft preferences in `packages.yaml`, and forces `compilers:`, `targets:`, and `providers:` to only appear at the `all:` level. Similarly, it disallows `version:` at the `all:` level and only allows it in per-package sections of `packages.yaml`.

The new `require:` style preferences are much more intuitive for setting one-off preferences in the DAG, and you can use them to force a node to use certain compilers, targets, or providers. Use `require:` instead of the preferences syntax if you need to be this specific.

Modifications:
- [x] `target`, `compiler` and `providers` soft-preferences can only be set under `all:` in `packages.yaml`
- [x] `version` can only be set under each specific package (and not under `all:`)
- [x] ASP code has a single set of weights for providers, targets and compilers (as opposed to different weights per package)
- [x] Modified documentation to reflect the change in `packages.yaml`
- [x] Added warnings to guide users if they have configurations which are not valid anymore