### PR TITLE
Add mimalloc variants

### DIFF
--- a/var/spack/repos/builtin/packages/mimalloc/package.py
+++ b/var/spack/repos/builtin/packages/mimalloc/package.py
@@ -21,3 +21,96 @@ class Mimalloc(CMakePackage):
     version('1.7.6', sha256='d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da')
 
     depends_on('cmake@3.0:', type='build')
+
+    libs_values = ("shared", "static", "object")
+    variant(
+        "libs",
+        default=",".join(libs_values),
+        values=libs_values,
+        multi=True,
+        description="Build shared, static, or object libraries",
+    )
+
+    mimalloc_options = {
+        "secure": (
+            False,
+            "Use full security mitigations (like guard pages, allocation "
+            "randomization, double-free mitigation, and free-list corruption "
+            "detection)",
+            None,
+        ),
+        "debug_full": (
+            False,
+            "Use full internal heap invariant checking in DEBUG mode (expensive)",
+            None,
+        ),
+        "padding": (
+            True,
+            "Enable padding to detect heap block overflow (used only in DEBUG mode)",
+            None,
+        ),
+        "override": (
+            True,
+            "Override the standard malloc interface (e.g. define entry points "
+            "for malloc() etc)",
+            None,
+        ),
+        "xmalloc": (
+            False,
+            "Enable abort() call on memory allocation failure by default",
+            None,
+        ),
+        "show_errors": (
+            False,
+            "Show error and warning messages by default (only enabled by default "
+            "in DEBUG mode)",
+            None,
+        ),
+        "use_cxx": (
+            False,
+            "Use the C++ compiler to compile the library (instead of the C compiler)",
+            None,
+        ),
+        "see_asm": (False, "Generate assembly files", None),
+        "osx_interpose": (
+            True,
+            "Use interpose to override standard malloc on macOS",
+            "platform=darwin",
+        ),
+        "osx_zone": (
+            True,
+            "Use malloc zone to override standard malloc on macOS",
+            "platform=darwin",
+        ),
+        "local_dynamic_tls": (
+            False,
+            "Use slightly slower, dlopen-compatible TLS mechanism (Unix)",
+            None,
+        ),
+        "build_tests": (False, "Build test executables", None),
+        "debug_tsan": (False, "Build with thread sanitizer (needs clang)", "%clang"),
+        "debug_ubsan": (
+            False,
+            "Build with undefined-behavior sanitizer (needs clang++)",
+            "%clang build_type=Debug +use_cxx",
+        ),
+        "skip_collect_on_exit": (False, "Skip collecting memory on program exit", None),
+    }
+
+    for k, v in mimalloc_options.items():
+        if v[2]:
+            variant(k, default=v[0], description=v[1], when=v[2])
+        else:
+            variant(k, default=v[0], description=v[1])
+
+    def cmake_args(self):
+        args = [
+            self.define("MI_BUILD_%s" % lib.upper(),
+                        lib in self.spec.variants["libs"].value)
+            for lib in self.libs_values
+        ]
+        args += [
+            self.define_from_variant("MI_%s" % k.upper(), k)
+            for k in self.mimalloc_options
+        ]
+        return args


### PR DESCRIPTION
The variants are a direct mapping to the corresponding CMake variables. I've tried to add constraints on the variants that don't apply everywhere. I can't test e.g. the `osx_x` variants since I'm not on macOS. However, they don't show up in a concretized spec on my machine so it seems to be doing the right thing though.