### PR TITLE
Add some GROMACS versions

### DIFF
--- a/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-chain-coordinate/package.py
@@ -14,15 +14,17 @@ class GromacsChainCoordinate(Gromacs):
     """
 
     homepage = 'https://gitlab.com/cbjh/gromacs-chain-coordinate/-/blob/main/README.md'
-    url = 'https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2'
+    url = 'https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.2/gromacs-chain-coordinate-release-2021.chaincoord-0.2.tar.bz2'
     git = 'https://gitlab.com/cbjh/gromacs-chain-coordinate.git'
     maintainers = ['w8jcik']
 
     version('main', branch='main')
 
-    version('2021.2-0.1', sha256="879fdd04662370a76408b72c9fbc4aff60a6387b459322ac2700d27359d0dd87",
-            url="https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2",
-            preferred=True)
+    version('2021.5-0.2', sha256='33dda1e39cd47c5ae32b5455af8534225d3888fd7e4968f499b8483620fa770a',
+            url='https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.2/gromacs-chain-coordinate-release-2021.chaincoord-0.2.tar.bz2')
+
+    version('2021.2-0.1', sha256='879fdd04662370a76408b72c9fbc4aff60a6387b459322ac2700d27359d0dd87',
+            url='https://gitlab.com/cbjh/gromacs-chain-coordinate/-/archive/release-2021.chaincoord-0.1/gromacs-chain-coordinate-release-2021.chaincoord-0.1.tar.bz2')
 
     conflicts('+plumed')
 

--- a/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs-swaxs/package.py
@@ -15,11 +15,23 @@ class GromacsSwaxs(Gromacs):
     git = 'https://gitlab.com/cbjh/gromacs-swaxs.git'
     maintainers = ['w8jcik']
 
+    version('2021.5-0.4', sha256='9f8ed6d448a04789d45e847cbbc706a07130377f578388220a9d5357fae9d1c3',
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2021.swaxs-0.4/gromacs-swaxs-release-2021.swaxs-0.4.tar.bz2')
+
+    version('2021.5-0.3', sha256='e05ea76610657e52e8293abff53ee9f16f4cffa508074e1e10132ed5fba97881',
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2021.swaxs-0.3/gromacs-swaxs-release-2021.swaxs-0.3.tar.bz2')
+
     version('2021.4-0.2', sha256='ea0dbe868d20e05c8fca337e0dddc16116a83fa7a6ac3a924942e9d00952ed62',
             url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2021.swaxs-0.2/gromacs-swaxs-release-2021.swaxs-0.2.tar.bz2')
 
     version('2021.4-0.1', sha256='eda1c8a7aae6001ef40480addf9fff9cdccc7e2b80480e36d069f50d6f2be26e', deprecated=True,
             url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2021.swaxs-0.1/gromacs-swaxs-release-2021.swaxs-0.1.tar.bz2')
+
+    version('2020.7-0.4', sha256='3eb0975ec92a89f6a3be548896307376974805ac685a9f776b0131a449a6b8a4',
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2020.swaxs-0.4/gromacs-swaxs-release-2020.swaxs-0.4.tar.bz2')
+
+    version('2020.7-0.3', sha256='eb5902df079b8f86c56b62be695c0d17307c195b2cdd7cefb7e117466be83211',
+            url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2020.swaxs-0.3/gromacs-swaxs-release-2020.swaxs-0.3.tar.bz2')
 
     version('2020.6-0.2', sha256='c22a7c6a0ee54eee1b3e224530f65e6f976a7aca5dc0f5ea22b2935a5a4357e9',
             url='https://gitlab.com/cbjh/gromacs-swaxs/-/archive/release-2020.swaxs-0.2/gromacs-swaxs-release-2020.swaxs-0.2.tar.bz2')

--- a/var/spack/repos/builtin/packages/gromacs/package.py
+++ b/var/spack/repos/builtin/packages/gromacs/package.py
@@ -22,13 +22,14 @@ class Gromacs(CMakePackage):
     """
 
     homepage = 'https://www.gromacs.org'
-    url      = 'https://ftp.gromacs.org/gromacs/gromacs-2022.1.tar.gz'
+    url      = 'https://ftp.gromacs.org/gromacs/gromacs-2022.2.tar.gz'
     list_url = 'https://ftp.gromacs.org/gromacs'
     git      = 'https://gitlab.com/gromacs/gromacs.git'
     maintainers = ['junghans', 'marvinbernhardt']
 
     version('main', branch='main')
     version('master', branch='main', deprecated=True)
+    version('2022.2', sha256='656404f884d2fa2244c97d2a5b92af148d0dbea94ad13004724b3fcbf45e01bf')
     version('2022.1', sha256='85ddab5197d79524a702c4959c2c43be875e0fc471df3a35224939dce8512450')
     version('2022', sha256='fad60d606c02e6164018692c6c9f2c159a9130c2bf32e8c5f4f1b6ba2dda2b68')
     version('2021.5', sha256='eba63fe6106812f72711ef7f76447b12dd1ee6c81b3d8d4d0e3098cd9ea009b6')


### PR DESCRIPTION
Tested by calling

```
spack install gromacs@2022.2+cuda~mpi
spack install gromacs-swaxs@2021.5-0.4+cuda~mpi
spack install gromacs-swaxs@2021.5-0.3+cuda~mpi
spack install gromacs-swaxs@2020.7-0.4+cuda~mpi
spack install gromacs-swaxs@2020.7-0.3+cuda~mpi
spack install gromacs-chain-coordinate@2021.5-0.2+cuda~mpi
```

They built successfully.
