### PR TITLE
oneAPI: support cxx17_flag and cxx20_flag

### DIFF
--- a/lib/spack/spack/compilers/oneapi.py
+++ b/lib/spack/spack/compilers/oneapi.py
@@ -82,6 +82,14 @@ class Oneapi(Compiler):
         return "-std=c++14"
 
     @property
+    def cxx17_flag(self):
+        return "-std=c++17"
+
+    @property
+    def cxx20_flag(self):
+        return "-std=c++20"
+
+    @property
     def c99_flag(self):
         return "-std=c99"
 


### PR DESCRIPTION
I was surprised to encounter
```
==> Installing xerces-c-3.2.3-wyma4m47xjm2xviiavqvpymrjw66vqth
==> No binary for xerces-c-3.2.3-wyma4m47xjm2xviiavqvpymrjw66vqth found: installing from source
==> Error: UnsupportedCompilerFlag: oneapi (2022.1.0) does not support the C++17 standard (as compiler.cxx17_flag).
    If you think it should, please edit the compiler.oneapi subclass to implement the cxx17_flag property and submit a pull request or issue.

/home/wdconinc/git/spack/var/spack/repos/builtin/packages/xerces-c/package.py:69, in flag_handler:
         66
         67        # Need to pass -std flag explicitly
         68        if name == 'cxxflags' and spec.variants['cxxstd'].value != 'default':
  >>     69            flags.append(getattr(self.compiler,
         70                         'cxx{0}_flag'.format(
         71                             spec.variants['cxxstd'].value)))
         72
```
but this seems simply a matter of implementing `oneapi.cxx17_flag` as indicated in the error message.

Tagging @rscohn2 who may have info on version ranges that should be used here (_if any_), e.g. something like this:
```
    def cxx20_flag(self):
        if self.real_version < ver('2021.1'):
            raise spack.compiler.UnsupportedCompilerFlag(
                self, "the C++20 standard", "cxx20_flag", "< 2021.1")
```
