### PR TITLE
bootstrap: search exes, rather than assuming they are in <prefix>/bin

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -60,6 +60,38 @@ jobs:
           spack -d solve zlib
           tree ~/.spack/bootstrap/store/
 
+  fedora-style:
+    runs-on: ubuntu-latest
+    container: "fedora:latest"
+    if: github.repository == 'spack/spack'
+    steps:
+      - name: Install dependencies
+        run: |
+          dnf install -y \
+              bzip2 curl file gcc-c++ gcc gcc-gfortran git gnupg2 gzip \
+              make patch unzip which xz python3 python3-devel tree \
+              cmake bison bison-devel libstdc++-static
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Setup non-root user
+        run: |
+          # See [1] below
+          git config --global --add safe.directory /__w/spack/spack
+          useradd spack-test && mkdir -p ~spack-test
+          chown -R spack-test . ~spack-test
+      - name: Setup repo
+        shell: runuser -u spack-test -- bash {0}
+        run: |
+          git --version
+          git fetch --unshallow
+          . .github/workflows/setup_git.sh
+      - name: Bootstrap Python dependencies for spack style
+        shell: runuser -u spack-test -- bash {0}
+        run: |
+          source share/spack/setup-env.sh
+          spack style
+          tree ~/.spack/bootstrap/store/
+
   ubuntu-clingo-sources:
     runs-on: ubuntu-latest
     container: "ubuntu:latest"

--- a/lib/spack/spack/bootstrap.py
+++ b/lib/spack/spack/bootstrap.py
@@ -204,11 +204,9 @@ def _executables_in_store(executables, query_spec, query_info=None):
     installed_specs = spack.store.db.query(query_spec, installed=True)
     if installed_specs:
         for concrete_spec in installed_specs:
-            bin_dir = concrete_spec.prefix.bin
-            # IF we have a "bin" directory and it contains
-            # the executables we are looking for
-            if (os.path.exists(bin_dir) and os.path.isdir(bin_dir) and
-                    spack.util.executable.which_string(*executables, path=bin_dir)):
+            execs = fs.find(concrete_spec.prefix, executables, recursive=True)
+            for exe in execs:
+                bin_dir = os.path.dirname(exe)
                 spack.util.environment.path_put_first('PATH', [bin_dir])
                 if query_info is not None:
                     query_info['command'] = spack.util.executable.which(


### PR DESCRIPTION
fixes #31265 

Modifications:
- [x] Bootstrap looks for executables in prefix, rather than assuming htey reside in `<prefix>/bin`
- [x] Add an integration test to avoid regression