### PR TITLE
py-torch: add M1 GPU support

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -6,6 +6,7 @@
 import os
 import sys
 
+from spack.operating_systems.mac_os import macos_version
 from spack.package import *
 
 
@@ -59,6 +60,7 @@ class PyTorch(PythonPackage, CudaPackage):
     variant('kineto', default=True, description='Use Kineto profiling library', when='@1.8:')
     variant('magma', default=not is_darwin, description='Use MAGMA', when='+cuda')
     variant('metal', default=is_darwin, description='Use Metal for Caffe2 iOS build')
+    variant('mps', default=is_darwin and macos_version() >= Version('12.3'), description='Use MPS for macOS build', when='@1.12: platform=darwin')
     variant('nccl', default=True, description='Use NCCL', when='+cuda platform=linux')
     variant('nccl', default=True, description='Use NCCL', when='+cuda platform=cray')
     variant('nccl', default=True, description='Use NCCL', when='+rocm platform=linux')
@@ -373,6 +375,7 @@ class PyTorch(PythonPackage, CudaPackage):
         enable_or_disable('kineto')
         enable_or_disable('magma')
         enable_or_disable('metal')
+        enable_or_disable('mps')
         enable_or_disable('breakpad')
 
         enable_or_disable('nccl')


### PR DESCRIPTION
Currently only available on the master branch, but PyTorch 1.12 will add support for using the new M1 GPUs. It's unclear to me if MPS is only for M1 or if it works for all GPUs with Metal support, so I would love to have this tested by someone with macOS 12.3+ and Intel (not Apple Silicon) hardware.

Successfully builds on macOS 12.4 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6.
```console
$ python
>>> torch.backends.mps.is_available()
True
```
References:

* https://pytorch.org/blog/introducing-accelerated-pytorch-training-on-mac/
* https://pytorch.org/docs/1.12/notes/mps.html