### PR TITLE
intel oneapi classic bootstrapping

### DIFF
--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -57,7 +57,7 @@ package_name_to_compiler_name = {
     "llvm": "clang",
     "intel-oneapi-compilers": "oneapi",
     "llvm-amdgpu": "rocmcc",
-    "intel-oneapi-compilers-classic": "intel"
+    "intel-oneapi-compilers-classic": "intel",
 }
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -52,6 +52,11 @@ _compiler_to_pkg = {
     "intel@2020:": "intel-oneapi-compilers-classic",
 }
 
+package_name_to_compiler_name = {
+    spack.spec.Spec(pspec).name: spack.spec.Spec(cspec).name
+    for cspec, pspec in _compiler_to_pkg.items()
+}
+
 
 def pkg_spec_for_compiler(cspec):
     """Return the spec of the package that provides the compiler."""

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -49,12 +49,18 @@ _compiler_to_pkg = {
     "clang": "llvm+clang",
     "oneapi": "intel-oneapi-compilers",
     "rocmcc": "llvm-amdgpu",
+    "intel@2020:": "intel-oneapi-compilers-classic"
 }
 
 
 def pkg_spec_for_compiler(cspec):
     """Return the spec of the package that provides the compiler."""
-    spec_str = "%s@%s" % (_compiler_to_pkg.get(cspec.name, cspec.name), cspec.versions)
+    for spec, package in _compiler_to_pkg.items():
+        if cspec.satisfies(spec):
+            spec_str = "%s@%s" % package, cspec.versions
+            break
+    else:
+        spec_str = str(cspec)
     return spack.spec.Spec(spec_str)
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -49,7 +49,7 @@ _compiler_to_pkg = {
     "clang": "llvm+clang",
     "oneapi": "intel-oneapi-compilers",
     "rocmcc": "llvm-amdgpu",
-    "intel@2020:": "intel-oneapi-compilers-classic"
+    "intel@2020:": "intel-oneapi-compilers-classic",
 }
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -52,9 +52,12 @@ _compiler_to_pkg = {
     "intel@2020:": "intel-oneapi-compilers-classic",
 }
 
+# TODO: generating this from the previous dict causes docs errors
 package_name_to_compiler_name = {
-    spack.spec.Spec(pspec).name: spack.spec.Spec(cspec).name
-    for cspec, pspec in _compiler_to_pkg.items()
+    "llvm": "clang",
+    "intel-oneapi-compilers": "oneapi",
+    "llvm-amdgpu": "rocmcc",
+    "intel-oneapi-compilers-classic": "intel"
 }
 
 

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -57,7 +57,7 @@ def pkg_spec_for_compiler(cspec):
     """Return the spec of the package that provides the compiler."""
     for spec, package in _compiler_to_pkg.items():
         if cspec.satisfies(spec):
-            spec_str = "%s@%s" % package, cspec.versions
+            spec_str = "%s@%s" % (package, cspec.versions)
             break
     else:
         spec_str = str(cspec)

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1241,6 +1241,12 @@ class PackageInstaller(object):
         fail_fast = request.install_args.get("fail_fast")
         self.fail_fast = self.fail_fast or fail_fast
 
+    def _add_compiler_package_to_config(self, pkg):
+        compiler_search_prefix = getattr(pkg, "compiler_search_prefix", pkg.spec.prefix)
+        spack.compilers.add_compilers_to_config(
+            spack.compilers.find_compilers([compiler_search_prefix])
+        )
+
     def _install_task(self, task):
         """
         Perform the installation of the requested spec and/or dependency
@@ -1266,10 +1272,7 @@ class PackageInstaller(object):
         if use_cache and _install_from_cache(pkg, cache_only, explicit, unsigned):
             self._update_installed(task)
             if task.compiler:
-                compiler_search_prefix = getattr(pkg, "compiler_search_prefix", pkg.spec.prefix)
-                spack.compilers.add_compilers_to_config(
-                    spack.compilers.find_compilers([compiler_search_prefix])
-                )
+                self._add_compiler_package_to_config(pkg)
             return
 
         pkg.run_tests = tests is True or tests and pkg.name in tests
@@ -1297,10 +1300,7 @@ class PackageInstaller(object):
 
             # If a compiler, ensure it is added to the configuration
             if task.compiler:
-                compiler_search_prefix = getattr(pkg, "compiler_search_prefix", pkg.spec.prefix)
-                spack.compilers.add_compilers_to_config(
-                    spack.compilers.find_compilers([compiler_search_prefix])
-                )
+                self._add_compiler_package_to_config(pkg)
         except spack.build_environment.StopPhase as e:
             # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
@@ -1719,12 +1719,7 @@ class PackageInstaller(object):
 
                     # It's an already installed compiler, add it to the config
                     if task.compiler:
-                        compiler_search_prefix = getattr(
-                            pkg, "compiler_search_prefix", pkg.spec.prefix
-                        )
-                        spack.compilers.add_compilers_to_config(
-                            spack.compilers.find_compilers([compiler_search_prefix])
-                        )
+                        self._add_compiler_package_to_config(pkg)
 
                 else:
                     # At this point we've failed to get a write or a read

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1266,9 +1266,11 @@ class PackageInstaller(object):
         if use_cache and _install_from_cache(pkg, cache_only, explicit, unsigned):
             self._update_installed(task)
             if task.compiler:
-                spack.compilers.add_compilers_to_config(
-                    spack.compilers.find_compilers([pkg.spec.prefix])
+                compiler_search_prefix = getattr(
+                    pkg, 'compiler_search_prefix', pkg.spec.prefix
                 )
+                spack.compilers.add_compilers_to_config(
+                    spack.compilers.find_compilers([compiler_search_prefix]))
             return
 
         pkg.run_tests = tests is True or tests and pkg.name in tests
@@ -1296,9 +1298,16 @@ class PackageInstaller(object):
 
             # If a compiler, ensure it is added to the configuration
             if task.compiler:
+                compiler_search_prefix = getattr(
+                    pkg, 'compiler_search_prefix', pkg.spec.prefix
+                )
                 spack.compilers.add_compilers_to_config(
+<<<<<<< HEAD
                     spack.compilers.find_compilers([pkg.spec.prefix])
                 )
+=======
+                    spack.compilers.find_compilers([compiler_search_prefix]))
+>>>>>>> make bootstrapped compilers detectable in non-standard locations
         except spack.build_environment.StopPhase as e:
             # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
@@ -1717,9 +1726,16 @@ class PackageInstaller(object):
 
                     # It's an already installed compiler, add it to the config
                     if task.compiler:
+                        compiler_search_prefix = getattr(
+                            pkg, 'compiler_search_prefix', pkg.spec.prefix
+                        )
                         spack.compilers.add_compilers_to_config(
+<<<<<<< HEAD
                             spack.compilers.find_compilers([pkg.spec.prefix])
                         )
+=======
+                            spack.compilers.find_compilers([compiler_search_prefix]))
+>>>>>>> make bootstrapped compilers detectable in non-standard locations
 
                 else:
                     # At this point we've failed to get a write or a read

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1266,11 +1266,10 @@ class PackageInstaller(object):
         if use_cache and _install_from_cache(pkg, cache_only, explicit, unsigned):
             self._update_installed(task)
             if task.compiler:
-                compiler_search_prefix = getattr(
-                    pkg, 'compiler_search_prefix', pkg.spec.prefix
-                )
+                compiler_search_prefix = getattr(pkg, "compiler_search_prefix", pkg.spec.prefix)
                 spack.compilers.add_compilers_to_config(
-                    spack.compilers.find_compilers([compiler_search_prefix]))
+                    spack.compilers.find_compilers([compiler_search_prefix])
+                )
             return
 
         pkg.run_tests = tests is True or tests and pkg.name in tests
@@ -1298,11 +1297,10 @@ class PackageInstaller(object):
 
             # If a compiler, ensure it is added to the configuration
             if task.compiler:
-                compiler_search_prefix = getattr(
-                    pkg, 'compiler_search_prefix', pkg.spec.prefix
-                )
+                compiler_search_prefix = getattr(pkg, "compiler_search_prefix", pkg.spec.prefix)
                 spack.compilers.add_compilers_to_config(
-                    spack.compilers.find_compilers([compiler_search_prefix]))
+                    spack.compilers.find_compilers([compiler_search_prefix])
+                )
         except spack.build_environment.StopPhase as e:
             # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
@@ -1722,10 +1720,11 @@ class PackageInstaller(object):
                     # It's an already installed compiler, add it to the config
                     if task.compiler:
                         compiler_search_prefix = getattr(
-                            pkg, 'compiler_search_prefix', pkg.spec.prefix
+                            pkg, "compiler_search_prefix", pkg.spec.prefix
                         )
                         spack.compilers.add_compilers_to_config(
-                            spack.compilers.find_compilers([compiler_search_prefix]))
+                            spack.compilers.find_compilers([compiler_search_prefix])
+                        )
 
                 else:
                     # At this point we've failed to get a write or a read

--- a/lib/spack/spack/installer.py
+++ b/lib/spack/spack/installer.py
@@ -1302,12 +1302,7 @@ class PackageInstaller(object):
                     pkg, 'compiler_search_prefix', pkg.spec.prefix
                 )
                 spack.compilers.add_compilers_to_config(
-<<<<<<< HEAD
-                    spack.compilers.find_compilers([pkg.spec.prefix])
-                )
-=======
                     spack.compilers.find_compilers([compiler_search_prefix]))
->>>>>>> make bootstrapped compilers detectable in non-standard locations
         except spack.build_environment.StopPhase as e:
             # A StopPhase exception means that do_install was asked to
             # stop early from clients, and is not an error at this point
@@ -1730,12 +1725,7 @@ class PackageInstaller(object):
                             pkg, 'compiler_search_prefix', pkg.spec.prefix
                         )
                         spack.compilers.add_compilers_to_config(
-<<<<<<< HEAD
-                            spack.compilers.find_compilers([pkg.spec.prefix])
-                        )
-=======
                             spack.compilers.find_compilers([compiler_search_prefix]))
->>>>>>> make bootstrapped compilers detectable in non-standard locations
 
                 else:
                     # At this point we've failed to get a write or a read

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -186,19 +186,19 @@ class LmodConfiguration(BaseConfiguration):
             provides["compiler"] = spack.spec.CompilerSpec(str(self.spec))
         # Special case for llvm
         if self.spec.name == "llvm":
-            provides["compiler"] = spack.spec.CompilerSpec(str(self.spec))
+            provides["compiler"] = spack.spec.CompilerSpec("clang@%s" % self.spec.version)
             provides["compiler"].name = "clang"
         # Special case for llvm-amdgpu
         if self.spec.name == "llvm-amdgpu":
-            provides["compiler"] = spack.spec.CompilerSpec(str(self.spec))
+            provides["compiler"] = spack.spec.CompilerSpec("rocmcc@%s" % self.spec.version)
             provides["compiler"].name = "rocmcc"
         # Special case for oneapi
         if self.spec.name == "intel-oneapi-compilers":
-            provides["compiler"] = spack.spec.CompilerSpec(str(self.spec))
+            provides["compiler"] = spack.spec.CompilerSpec("oneapi@%s" % self.spec.version)
             provides["compiler"].name = "oneapi"
         # Special case for oneapi classic
         if self.spec.name == "intel-oneapi-compilers-classic":
-            provides["compiler"] = spack.spec.CompilerSpec(str(self.spec))
+            provides["compiler"] = spack.spec.CompilerSpec("intel@%s" % self.spec.version)
             provides["compiler"].name = "intel"
 
         # All the other tokens in the hierarchy must be virtual dependencies

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -181,16 +181,13 @@ class LmodConfiguration(BaseConfiguration):
         # Treat the 'compiler' case in a special way, as compilers are not
         # virtual dependencies in spack
 
-
         # If it is in the list of supported compilers family -> compiler
         if self.spec.name in spack.compilers.supported_compilers():
             provides["compiler"] = spack.spec.CompilerSpec(str(self.spec))
         elif self.spec.name in spack.compilers.package_name_to_compiler_name:
             # If it is the package for a supported compiler, but of a different name
             cname = spack.compilers.package_name_to_compiler_name[self.spec.name]
-            provides["compiler"] = spack.spec.CompilerSpec(
-                "%s@%s" % (cname, self.spec.version)
-            )
+            provides["compiler"] = spack.spec.CompilerSpec("%s@%s" % (cname, self.spec.version))
 
         # All the other tokens in the hierarchy must be virtual dependencies
         for x in self.hierarchy_tokens:

--- a/lib/spack/spack/modules/lmod.py
+++ b/lib/spack/spack/modules/lmod.py
@@ -181,25 +181,16 @@ class LmodConfiguration(BaseConfiguration):
         # Treat the 'compiler' case in a special way, as compilers are not
         # virtual dependencies in spack
 
+
         # If it is in the list of supported compilers family -> compiler
         if self.spec.name in spack.compilers.supported_compilers():
             provides["compiler"] = spack.spec.CompilerSpec(str(self.spec))
-        # Special case for llvm
-        if self.spec.name == "llvm":
-            provides["compiler"] = spack.spec.CompilerSpec("clang@%s" % self.spec.version)
-            provides["compiler"].name = "clang"
-        # Special case for llvm-amdgpu
-        if self.spec.name == "llvm-amdgpu":
-            provides["compiler"] = spack.spec.CompilerSpec("rocmcc@%s" % self.spec.version)
-            provides["compiler"].name = "rocmcc"
-        # Special case for oneapi
-        if self.spec.name == "intel-oneapi-compilers":
-            provides["compiler"] = spack.spec.CompilerSpec("oneapi@%s" % self.spec.version)
-            provides["compiler"].name = "oneapi"
-        # Special case for oneapi classic
-        if self.spec.name == "intel-oneapi-compilers-classic":
-            provides["compiler"] = spack.spec.CompilerSpec("intel@%s" % self.spec.version)
-            provides["compiler"].name = "intel"
+        elif self.spec.name in spack.compilers.package_name_to_compiler_name:
+            # If it is the package for a supported compiler, but of a different name
+            cname = spack.compilers.package_name_to_compiler_name[self.spec.name]
+            provides["compiler"] = spack.spec.CompilerSpec(
+                "%s@%s" % (cname, self.spec.version)
+            )
 
         # All the other tokens in the hierarchy must be virtual dependencies
         for x in self.hierarchy_tokens:

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -96,7 +96,6 @@ import llnl.util.tty.color as clr
 from llnl.util.compat import Mapping
 
 import spack.compiler
-import spack.compilers
 import spack.config
 import spack.dependency as dp
 import spack.error
@@ -2859,6 +2858,7 @@ class Spec(object):
     @staticmethod
     def ensure_external_path_if_external(external_spec):
         if external_spec.external_modules and not external_spec.external_path:
+            import spack.compilers  # break cycle
             compiler = spack.compilers.compiler_for_spec(
                 external_spec.compiler, external_spec.architecture
             )
@@ -3381,6 +3381,7 @@ class Spec(object):
 
             # validate compiler in addition to the package name.
             if spec.compiler:
+                import spack.compilers  # break cycle
                 if not spack.compilers.supported(spec.compiler):
                     raise UnsupportedCompilerError(spec.compiler.name)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -2859,6 +2859,7 @@ class Spec(object):
     def ensure_external_path_if_external(external_spec):
         if external_spec.external_modules and not external_spec.external_path:
             import spack.compilers  # break cycle
+
             compiler = spack.compilers.compiler_for_spec(
                 external_spec.compiler, external_spec.architecture
             )
@@ -3382,6 +3383,7 @@ class Spec(object):
             # validate compiler in addition to the package name.
             if spec.compiler:
                 import spack.compilers  # break cycle
+
                 if not spack.compilers.supported(spec.compiler):
                     raise UnsupportedCompilerError(spec.compiler.name)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -96,6 +96,7 @@ import llnl.util.tty.color as clr
 from llnl.util.compat import Mapping
 
 import spack.compiler
+import spack.compilers
 import spack.config
 import spack.dependency as dp
 import spack.error
@@ -2858,8 +2859,6 @@ class Spec(object):
     @staticmethod
     def ensure_external_path_if_external(external_spec):
         if external_spec.external_modules and not external_spec.external_path:
-            import spack.compilers  # break cycle
-
             compiler = spack.compilers.compiler_for_spec(
                 external_spec.compiler, external_spec.architecture
             )
@@ -3382,8 +3381,6 @@ class Spec(object):
 
             # validate compiler in addition to the package name.
             if spec.compiler:
-                import spack.compilers  # break cycle
-
                 if not spack.compilers.supported(spec.compiler):
                     raise UnsupportedCompilerError(spec.compiler.name)
 

--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -487,6 +487,17 @@ def test_update_tasks_for_compiler_packages_as_compiler(mock_packages, config, m
     assert installer.build_pq[0][1].compiler
 
 
+def test_bootstrapping_compilers_with_different_names_from_spec(
+    install_mockery, mutable_config, mock_fetch
+):
+    with spack.config.override("config:install_missing_compilers", True):
+        with spack.concretize.disable_compiler_existence_check():
+            spec = spack.spec.Spec("trivial-install-test-package%oneapi@22.2.0").concretized()
+            spec.package.do_install()
+
+            assert spack.spec.CompilerSpec("oneapi@22.2.0") in spack.compilers.all_compiler_specs()
+
+
 def test_dump_packages_deps_ok(install_mockery, tmpdir, mock_packages):
     """Test happy path for dump_packages with dependencies."""
 

--- a/lib/spack/spack/test/modules/lmod.py
+++ b/lib/spack/spack/test/modules/lmod.py
@@ -81,6 +81,15 @@ class TestLmod(object):
         else:
             assert repetitions == 1
 
+    def test_compilers_provided_different_name(self, factory, module_configuration):
+        module_configuration("complex_hierarchy")
+        module, spec = factory("intel-oneapi-compilers%clang@3.3")
+
+        provides = module.conf.provides
+
+        assert "compiler" in provides
+        assert provides["compiler"] == spack.spec.CompilerSpec("oneapi@3.0")
+
     def test_simple_case(self, modulefile_content, module_configuration):
         """Tests the generation of a simple TCL module file."""
 

--- a/var/spack/repos/builtin.mock/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin.mock/packages/intel-oneapi-compilers/package.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class IntelOneapiCompilers(Package):
+    """Simple compiler package."""
+
+    homepage = "http://www.example.com"
+    url = "http://www.example.com/oneapi-1.0.tar.gz"
+
+    version("1.0", "0123456789abcdef0123456789abcdef")
+    version("2.0", "abcdef0123456789abcdef0123456789")
+    version("3.0", "def0123456789abcdef0123456789abc")
+
+    @property
+    def compiler_search_prefix(self):
+        return self.prefix.foo.bar.baz.bin
+
+    def install(self, spec, prefix):
+        # Create the minimal compiler that will fool `spack compiler find`
+        mkdirp(self.compiler_search_prefix)
+        with open(self.compiler_search_prefix.icx, "w") as f:
+            f.write('#!/bin/bash\necho "oneAPI DPC++ Compiler %s"' % str(spec.version))
+        set_executable(self.compiler_search_prefix.icx)

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -2,6 +2,7 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
+import os
 from spack.package import *
 
 
@@ -17,8 +18,6 @@ class IntelOneapiCompilersClassic(Package):
     homepage = "https://software.intel.com/content/www/us/en/develop/tools/oneapi.html"
 
     has_code = False
-
-    phases = []
 
     # Versions before 2021 are in the `intel` package
     # intel-oneapi versions before 2022 use intel@19.0.4

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -2,7 +2,6 @@
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -59,14 +59,7 @@ class IntelOneapiCompilersClassic(Package):
         env.set("FC", bin_prefix.ifort)
 
     def install(self, spec, prefix):
-        # We create a physical directory for binaries because they are more likely
-        # to be affected by being symlinked
-        mkdirp(prefix.bin)
-        for entry in os.listdir(self.oneapi_compiler_prefix.bin):
-            src = os.path.join(self.oneapi_compiler_prefix.bin, entry)
-            dst = prefix.bin.join(entry)
-            os.symlink(src, dst)
-
+        os.symlink(self.oneapi_compiler_prefix.bin.intel64, prefix.bin)
         os.symlink(self.oneapi_compiler_prefix.lib, prefix.lib)
         os.symlink(self.oneapi_compiler_prefix.include, prefix.include)
         os.symlink(self.oneapi_compiler_prefix.compiler, prefix.compiler)

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -38,7 +38,7 @@ class IntelOneapiCompilersClassic(Package):
     def oneapi_compiler_prefix(self):
         oneapi_version = self.spec["intel-oneapi-compilers"].version
         return self.spec["intel-oneapi-compilers"].prefix.compiler.join(
-            "%s" % oneapi_version).linux
+            str(oneapi_version))
 
     def setup_run_environment(self, env):
         """Adds environment variables to the generated module file.
@@ -59,9 +59,8 @@ class IntelOneapiCompilersClassic(Package):
         env.set("FC", bin_prefix.ifort)
 
     def install(self, spec, prefix):
-        os.symlink(self.oneapi_compiler_prefix.bin.intel64, prefix.bin)
-        os.symlink(self.oneapi_compiler_prefix.lib, prefix.lib)
-        os.symlink(self.oneapi_compiler_prefix.include, prefix.include)
-        os.symlink(self.oneapi_compiler_prefix.compiler, prefix.compiler)
-        os.symlink(self.oneapi_compiler_prefix.man, prefix.man)
-        os.symlink(self.oneapi_compiler_prefix.share, prefix.share)
+        os.symlink(self.oneapi_compiler_prefix.linux.bin.intel64, prefix.bin)
+        os.symlink(self.oneapi_compiler_prefix.linux.lib, prefix.lib)
+        os.symlink(self.oneapi_compiler_prefix.linux.include, prefix.include)
+        os.symlink(self.oneapi_compiler_prefix.linux.compiler, prefix.compiler)
+        os.symlink(self.oneapi_compiler_prefix.documentation.en.man, prefix.man)

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import os
+
 from spack.package import *
 
 

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers-classic/package.py
@@ -39,8 +39,7 @@ class IntelOneapiCompilersClassic(Package):
     @property
     def oneapi_compiler_prefix(self):
         oneapi_version = self.spec["intel-oneapi-compilers"].version
-        return self.spec["intel-oneapi-compilers"].prefix.compiler.join(
-            str(oneapi_version))
+        return self.spec["intel-oneapi-compilers"].prefix.compiler.join(str(oneapi_version))
 
     def setup_run_environment(self, env):
         """Adds environment variables to the generated module file.

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -138,6 +138,56 @@ class IntelOneapiCompilers(IntelOneApiPackage):
     def component_dir(self):
         return "compiler"
 
+    def _ld_library_path(self):
+        dirs = ["lib",
+                join_path("lib", "x64"),
+                join_path("lib", "emu"),
+                join_path("lib", "oclfpga", "host", "linux64", "lib"),
+                join_path("lib", "oclfpga", "linux64", "lib"),
+                join_path("compiler", "lib", "intel64_lin"),
+                join_path("compiler", "lib")]
+        for dir in dirs:
+            yield join_path(self.component_path, "linux", dir)
+
+    @property
+    def compiler_search_prefix(self):
+        return self.prefix.compiler.join(
+            str(self.version)).linux.bin
+
+    def install(self, spec, prefix):
+        # install cpp
+        # Copy instead of install to speed up debugging
+        # subprocess.run(f'cp -r /opt/intel/oneapi/compiler {prefix}', shell=True)
+        super(IntelOneapiCompilers, self).install(spec, prefix)
+
+        # install fortran
+        super(IntelOneapiCompilers, self).install(
+            spec,
+            prefix,
+            installer_path=glob.glob(join_path("fortran-installer", "*"))[0])
+
+        # Some installers have a bug and do not return an error code when failing
+        if not path.isfile(join_path(self.component_path, "linux",
+                                     "bin", "intel64", "ifort")):
+            raise RuntimeError("install failed")
+
+        # set rpath so "spack compiler add" can check version strings
+        # without setting LD_LIBRARY_PATH
+        rpath = ":".join(self._ld_library_path())
+        patch_dirs = [join_path("lib"),
+                      join_path("compiler", "lib", "intel64_lin"),
+                      join_path("compiler", "lib", "intel64"),
+                      "bin"]
+        for pd in patch_dirs:
+            patchables = glob.glob(join_path(self.component_path, "linux", pd, "*"))
+            patchables.append(join_path(self.component_path,
+                                        "linux", "lib", "icx-lto.so"))
+            for file in patchables:
+                # Try to patch all files, patchelf will do nothing if
+                # file should not be patched
+                subprocess.call(["patchelf", "--set-rpath", rpath, file])
+>>>>>>> make bootstrapped compilers detectable in non-standard locations
+
     def setup_run_environment(self, env):
         """Adds environment variables to the generated module file.
 
@@ -158,7 +208,7 @@ class IntelOneapiCompilers(IntelOneApiPackage):
 
     def install(self, spec, prefix):
         # Copy instead of install to speed up debugging
-        # install_tree('/opt/intel/oneapi/compiler', self.prefix)
+        # install_tree("/opt/intel/oneapi/compiler", self.prefix)
 
         # install cpp
         super(IntelOneapiCompilers, self).install(spec, prefix)

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -186,7 +186,6 @@ class IntelOneapiCompilers(IntelOneApiPackage):
                 # Try to patch all files, patchelf will do nothing if
                 # file should not be patched
                 subprocess.call(["patchelf", "--set-rpath", rpath, file])
->>>>>>> make bootstrapped compilers detectable in non-standard locations
 
     def setup_run_environment(self, env):
         """Adds environment variables to the generated module file.

--- a/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
+++ b/var/spack/repos/builtin/packages/intel-oneapi-compilers/package.py
@@ -139,20 +139,21 @@ class IntelOneapiCompilers(IntelOneApiPackage):
         return "compiler"
 
     def _ld_library_path(self):
-        dirs = ["lib",
-                join_path("lib", "x64"),
-                join_path("lib", "emu"),
-                join_path("lib", "oclfpga", "host", "linux64", "lib"),
-                join_path("lib", "oclfpga", "linux64", "lib"),
-                join_path("compiler", "lib", "intel64_lin"),
-                join_path("compiler", "lib")]
+        dirs = [
+            "lib",
+            join_path("lib", "x64"),
+            join_path("lib", "emu"),
+            join_path("lib", "oclfpga", "host", "linux64", "lib"),
+            join_path("lib", "oclfpga", "linux64", "lib"),
+            join_path("compiler", "lib", "intel64_lin"),
+            join_path("compiler", "lib"),
+        ]
         for dir in dirs:
             yield join_path(self.component_path, "linux", dir)
 
     @property
     def compiler_search_prefix(self):
-        return self.prefix.compiler.join(
-            str(self.version)).linux.bin
+        return self.prefix.compiler.join(str(self.version)).linux.bin
 
     def install(self, spec, prefix):
         # install cpp
@@ -162,26 +163,25 @@ class IntelOneapiCompilers(IntelOneApiPackage):
 
         # install fortran
         super(IntelOneapiCompilers, self).install(
-            spec,
-            prefix,
-            installer_path=glob.glob(join_path("fortran-installer", "*"))[0])
+            spec, prefix, installer_path=glob.glob(join_path("fortran-installer", "*"))[0]
+        )
 
         # Some installers have a bug and do not return an error code when failing
-        if not path.isfile(join_path(self.component_path, "linux",
-                                     "bin", "intel64", "ifort")):
+        if not path.isfile(join_path(self.component_path, "linux", "bin", "intel64", "ifort")):
             raise RuntimeError("install failed")
 
         # set rpath so "spack compiler add" can check version strings
         # without setting LD_LIBRARY_PATH
         rpath = ":".join(self._ld_library_path())
-        patch_dirs = [join_path("lib"),
-                      join_path("compiler", "lib", "intel64_lin"),
-                      join_path("compiler", "lib", "intel64"),
-                      "bin"]
+        patch_dirs = [
+            join_path("lib"),
+            join_path("compiler", "lib", "intel64_lin"),
+            join_path("compiler", "lib", "intel64"),
+            "bin",
+        ]
         for pd in patch_dirs:
             patchables = glob.glob(join_path(self.component_path, "linux", pd, "*"))
-            patchables.append(join_path(self.component_path,
-                                        "linux", "lib", "icx-lto.so"))
+            patchables.append(join_path(self.component_path, "linux", "lib", "icx-lto.so"))
             for file in patchables:
                 # Try to patch all files, patchelf will do nothing if
                 # file should not be patched


### PR DESCRIPTION
Closes #31278.

The `intel` compiler at versions > 20 is provided by the `intel-oneapi-compilers-classic` package (a thin wrapper around the `intel-oneapi-compilers` package), and the `oneapi` compiler is provided by the `intel-oneapi-compilers` package. 

Prior to this work, neither of these compilers could be bootstrapped by Spack as part of an install with `install_missing_compilers: True`.

Changes made to make these two packages bootstrappable:

1. The `intel-oneapi-compilers-classic` package includes a bin directory and symlinks to the compiler executables, not just logical pointers in Spack.
2. Spack can look for bootstrapped compilers in directories other than `$prefix/bin`, defined on a per-package basis
3. `intel-oneapi-compilers` specifies a non-default search directory for the compiler executables.
4. The `spack.compilers` module now can make more advanced associations between packages and compilers, not just simple name translations
5. Spack support for lmod hierarchies accounts for differences between package names and the associated compiler names for `intel-oneapi-compilers/oneapi`, `intel-oneapi-compilers-classic/intel@20:`, `llvm+clang/clang`, and `llvm-amdgpu/rocmcc`.

@rscohn2 do you see any issue with the particular choice of symlinks here?

@nicholas-sly @lee218llnl this is the PR for the work we've been discussing for intel compilers.

TODO:
- [x] full end-to-end testing
- [x] add unit tests