### PR TITLE
Set R_LIBS_USER='' in dependent build environment

### DIFF
--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -210,6 +210,11 @@ class R(AutotoolsPackage):
 
         r_libs_path = ':'.join(r_libs_path)
         env.set('R_LIBS', r_libs_path)
+        # R_LIBS_USER gets set to a directory in HOME/R if it is not set, such as
+        # during package installation with the --vanilla flag. Set it to null
+        # to insure that it does not point to a directory that may contain R
+        # packages.
+        env.set('R_LIBS_USER', '')
         env.set('R_MAKEVARS_SITE',
                 join_path(self.etcdir, 'Makeconf.spack'))
 

--- a/var/spack/repos/builtin/packages/r/package.py
+++ b/var/spack/repos/builtin/packages/r/package.py
@@ -212,7 +212,7 @@ class R(AutotoolsPackage):
         env.set('R_LIBS', r_libs_path)
         # R_LIBS_USER gets set to a directory in HOME/R if it is not set, such as
         # during package installation with the --vanilla flag. Set it to null
-        # to insure that it does not point to a directory that may contain R
+        # to ensure that it does not point to a directory that may contain R
         # packages.
         env.set('R_LIBS_USER', '')
         env.set('R_MAKEVARS_SITE',


### PR DESCRIPTION
Despite R packages being installed with the --vanilla flag, which
ignores Rprofile and Renviron files, R will still set R_LIBS_USER if the
default directory exists. This could lead to pulling in packages from
that directory during the build which could cause the build to fail. To
avoid that, explicitly set R_LIB_USER='' to ensure that packages from
the HOME/R directory are not in the library path.