### PR TITLE
Java extensions: jdk -> openjdk

### DIFF
--- a/var/spack/repos/builtin/packages/commons-lang/package.py
+++ b/var/spack/repos/builtin/packages/commons-lang/package.py
@@ -24,7 +24,7 @@ class CommonsLang(Package):
     version('2.6', sha256='ff6a244bb71a9a1c859e81cb744d0ce698c20e04f13a7ef7dbffb99c8122752c')
     version('2.4', sha256='00e6b3174e31196d726c14302c8e7e9ba9b8409d57a8a9821c7648beeda31c5e')
 
-    extends('jdk')
+    extends('openjdk')
     depends_on('java@2:', type='run')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/commons-lang3/package.py
+++ b/var/spack/repos/builtin/packages/commons-lang3/package.py
@@ -23,7 +23,7 @@ class CommonsLang3(Package):
 
     version('3.7', sha256='94dc8289ce90b77b507d9257784d9a43b402786de40c164f6e3990e221a2a4d2')
 
-    extends('jdk')
+    extends('openjdk')
     depends_on('java@7:', type='run')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/commons-logging/package.py
+++ b/var/spack/repos/builtin/packages/commons-logging/package.py
@@ -25,7 +25,7 @@ class CommonsLogging(Package):
     version('1.1.3', sha256='9e7093c93529792563b5c19ab5cccb73ef4ca7d82b886bdec6d0af182ba9908a')
     version('1.1.1', sha256='88c721d66f570a87f710a2449f0e3bffea86489d9dd2fa70b805104c4f8d69e6')
 
-    extends('jdk')
+    extends('openjdk')
     depends_on('java', type='run')
 
     def install(self, spec, prefix):

--- a/var/spack/repos/builtin/packages/jackcess/package.py
+++ b/var/spack/repos/builtin/packages/jackcess/package.py
@@ -17,7 +17,7 @@ class Jackcess(Package):
     version('1.2.14.3', sha256='a6fab0c4b5daf23dcf7fd309ee4ffc6df12ff982510c094e45442adf88712787', expand=False,
             url='https://sourceforge.net/projects/jackcess/files/jackcess/Older%20Releases/1.2.14.3/jackcess-1.2.14.3.jar')
 
-    extends('jdk')
+    extends('openjdk')
     depends_on('java', type='run')
     depends_on('commons-lang@2.6', when='@2.1.12', type='run')
     depends_on('commons-lang@2.4', when='@1.2.14.3', type='run')

--- a/var/spack/repos/builtin/packages/libkml/package.py
+++ b/var/spack/repos/builtin/packages/libkml/package.py
@@ -21,7 +21,7 @@ class Libkml(CMakePackage):
     variant('java', default=False, description='Build java bindings')
     variant('python', default=False, description='Build python bindings')
 
-    extends('jdk', when='+java')
+    extends('openjdk', when='+java')
     extends('python', when='+python')
 
     # See DEPENDENCIES


### PR DESCRIPTION
Once upon a time, jdk was our default java provider. Nowadays, every package uses openjdk instead. This PR switches the former to the latter.

Unfortunately it isn't yet possible to extend java directly: #17475