### PR TITLE
openexr: add v3.1.5, CMake support

### DIFF
--- a/var/spack/repos/builtin/packages/imath/package.py
+++ b/var/spack/repos/builtin/packages/imath/package.py
@@ -1,0 +1,20 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Imath(CMakePackage):
+    """Imath is a basic, light-weight, and efficient C++ representation of 2D and 3D
+    vectors and matrices and other simple but useful mathematical objects, functions,
+    and data types common in computer graphics applications, including the "half"
+    16-bit floating-point type."""
+
+    homepage = "https://github.com/AcademySoftwareFoundation/Imath"
+    url      = "https://github.com/AcademySoftwareFoundation/Imath/archive/refs/tags/v3.1.5.tar.gz"
+
+    version('3.1.5', sha256='1e9c7c94797cf7b7e61908aed1f80a331088cc7d8873318f70376e4aed5f25fb')
+
+    depends_on('cmake@3.12:', type='build')

--- a/var/spack/repos/builtin/packages/openexr/package.py
+++ b/var/spack/repos/builtin/packages/openexr/package.py
@@ -6,14 +6,16 @@
 from spack.package import *
 
 
-class Openexr(AutotoolsPackage):
+class Openexr(CMakePackage):
     """OpenEXR Graphics Tools (high dynamic-range image file format)"""
 
     homepage = "https://www.openexr.com/"
-    url = "https://github.com/openexr/openexr/releases/download/v2.3.0/openexr-2.3.0.tar.gz"
+    url = "https://github.com/AcademySoftwareFoundation/openexr/archive/refs/tags/v3.1.5.tar.gz"
 
     # New versions should come from github now
-    version('2.3.0', sha256='fd6cb3a87f8c1a233be17b94c74799e6241d50fc5efd4df75c7a4b9cf4e25ea6')
+    version('3.1.5', sha256='93925805c1fc4f8162b35f0ae109c4a75344e6decae5a240afdfce25f8a433ec')
+    version('2.3.0', sha256='fd6cb3a87f8c1a233be17b94c74799e6241d50fc5efd4df75c7a4b9cf4e25ea6',
+            url='https://github.com/AcademySoftwareFoundation/openexr/releases/download/v2.3.0/openexr-2.3.0.tar.gz')
 
     version('2.2.0', sha256='36a012f6c43213f840ce29a8b182700f6cf6b214bea0d5735594136b44914231',
             url="http://download.savannah.nongnu.org/releases/openexr/openexr-2.2.0.tar.gz")
@@ -35,13 +37,29 @@ class Openexr(AutotoolsPackage):
     variant('debug', default=False,
             description='Builds a debug version of the libraries')
 
-    depends_on('pkgconfig', type='build')
-    depends_on('ilmbase')
-    depends_on('zlib', type=('build', 'link'))
+    depends_on('cmake@3.12:', when='@3:', type='build')
+    depends_on('pkgconfig', when='@:2', type='build')
+    depends_on('imath', when='@3:')
+    depends_on('ilmbase', when='@:2')
+    depends_on('zlib')
+
+    @property
+    def build_directory(self):
+        if self.spec.satisfies('@3:'):
+            return super(Openexr, self).build_directory
+        else:
+            return '.'
 
     def configure_args(self):
-        configure_options = []
+        args = ['--prefix=' + self.prefix]
 
-        configure_options += self.enable_or_disable('debug')
+        if '+debug' in self.spec:
+            args.append('--enable-debug')
+        else:
+            args.append('--disable-debug')
 
-        return configure_options
+        return args
+
+    @when('@:2')
+    def cmake(self, spec, prefix):
+        configure(*self.configure_args())


### PR DESCRIPTION
Tested to make sure that both 2.3.0 and 3.1.5 successfully build on macOS 12.4 (Apple M1 Pro) with Apple Clang 13.1.6.