### PR TITLE
curl: add command property

### DIFF
--- a/var/spack/repos/builtin/packages/curl/package.py
+++ b/var/spack/repos/builtin/packages/curl/package.py
@@ -139,6 +139,10 @@ class Curl(AutotoolsPackage):
             # TODO: Determine more variants.
             return variants
 
+    @property
+    def command(self):
+        return Executable(self.prefix.bin.join('curl-config'))
+
     def configure_args(self):
         spec = self.spec
 


### PR DESCRIPTION
Packages like GDAL need to be able to access this property to discover the appropriate configuration to use.