### PR TITLE
geos: add command property

### DIFF
--- a/var/spack/repos/builtin/packages/geos/package.py
+++ b/var/spack/repos/builtin/packages/geos/package.py
@@ -47,6 +47,10 @@ class Geos(CMakePackage):
           sha256='ab78db7ff2e8fc89e899b8233cf77d90b24d88940dd202c4219decba479c8d35',
           when='@3.8:')
 
+    @property
+    def command(self):
+        return Executable(self.prefix.bin.join('geos-config'))
+
     def cmake_args(self):
         args = []
 


### PR DESCRIPTION
Packages like GDAL need to be able to access this property to discover the appropriate configuration to use.