### PR TITLE
kealib: add command property

### DIFF
--- a/var/spack/repos/builtin/packages/kealib/package.py
+++ b/var/spack/repos/builtin/packages/kealib/package.py
@@ -42,6 +42,10 @@ class Kealib(CMakePackage):
     patch('cmake.patch', when='@1.4.7')
 
     @property
+    def command(self):
+        return Executable(self.prefix.bin.join('kea-config'))
+
+    @property
     def root_cmakelists_dir(self):
         if self.version >= Version('1.4.9'):
             return '.'

--- a/var/spack/repos/builtin/packages/kealib/package.py
+++ b/var/spack/repos/builtin/packages/kealib/package.py
@@ -43,7 +43,10 @@ class Kealib(CMakePackage):
 
     @property
     def command(self):
-        return Executable(self.prefix.bin.join('kea-config'))
+        exe = 'kea-config'
+        if self.spec.satisfies('platform=windows'):
+            exe += '.bat'
+        return Executable(self.prefix.bin.join(exe))
 
     @property
     def root_cmakelists_dir(self):


### PR DESCRIPTION
Packages like GDAL need to be able to access this property to discover the appropriate configuration to use.