### PR TITLE
libxml2: add command property

### DIFF
--- a/var/spack/repos/builtin/packages/libxml2/package.py
+++ b/var/spack/repos/builtin/packages/libxml2/package.py
@@ -55,6 +55,10 @@ class Libxml2(AutotoolsPackage):
     patch('nvhpc-elfgcchack.patch', when='%nvhpc')
 
     @property
+    def command(self):
+        return Executable(self.prefix.bin.join('xml2-config'))
+
+    @property
     def headers(self):
         include_dir = self.spec.prefix.include.libxml2
         hl = find_all_headers(include_dir)


### PR DESCRIPTION
Packages like GDAL need to be able to access this property to discover the appropriate configuration to use.