### PR TITLE
postgresql: add command property

### DIFF
--- a/var/spack/repos/builtin/packages/postgresql/package.py
+++ b/var/spack/repos/builtin/packages/postgresql/package.py
@@ -58,6 +58,10 @@ class Postgresql(AutotoolsPackage):
     depends_on('python', when='+python')
     depends_on('libxml2', when='+xml')
 
+    @property
+    def command(self):
+        return Exectuable(self.prefix.bin.pg_config)
+
     def configure_args(self):
         config_args = ["--with-openssl"]
 


### PR DESCRIPTION
Packages like GDAL need to be able to access this property to discover the appropriate configuration to use.