### PR TITLE
sfcgal: add command property

### DIFF
--- a/var/spack/repos/builtin/packages/sfcgal/package.py
+++ b/var/spack/repos/builtin/packages/sfcgal/package.py
@@ -27,6 +27,10 @@ class Sfcgal(CMakePackage):
     depends_on('mpfr@2.2.1:')
     depends_on('gmp@4.2:')
 
+    @property
+    def command(self):
+        return Executable(self.prefix.bin.join('sfcgal-config'))
+
     def cmake_args(self):
         # It seems viewer is discontinued as of v1.3.0
         # https://github.com/Oslandia/SFCGAL/releases/tag/v1.3.0


### PR DESCRIPTION
Packages like GDAL need to be able to access this property to discover the appropriate configuration to use.