### PR TITLE
oracle-instant-client: add macOS conflict

### DIFF
--- a/var/spack/repos/builtin/packages/oracle-instant-client/package.py
+++ b/var/spack/repos/builtin/packages/oracle-instant-client/package.py
@@ -57,6 +57,10 @@ class OracleInstantClient(Package):
 
     depends_on('libaio', type='link')
 
+    # TODO: add URLs for macOS. Unfortunately still no native M1 support.
+    # https://www.oracle.com/database/technologies/instant-client/macos-intel-x86-downloads.html
+    conflicts('platform=darwin')
+
     def install(self, spec, prefix):
         mkdirp(prefix.bin)
         mkdirp(prefix.include)


### PR DESCRIPTION
Doesn't have M1 support yet so I didn't bother to add downloads/installs for macOS, but hopefully someday we will have them.