### PR TITLE
Fix hipsycl to build on OSX. Patch boost to be backward-compatible.

### DIFF
--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -134,10 +134,7 @@ class Hipsycl(CMakePackage):
         #    the libc++.so and libc++abi.so dyn linked to the sycl
         #    ptx backend
         rpaths = set()
-        so_paths = filesystem.find(
-                        self.spec["llvm"].prefix,
-                        "libc++.{0}".format(dso_suffix)
-                   )
+        so_paths = filesystem.find(self.spec["llvm"].prefix, "libc++.{0}".format(dso_suffix))
         if len(so_paths) != 1:
             raise InstallError(
                 "concretized llvm dependency must provide a "
@@ -145,10 +142,7 @@ class Hipsycl(CMakePackage):
                 "found: {0}".format(so_paths)
             )
         rpaths.add(path.dirname(so_paths[0]))
-        so_paths = filesystem.find(
-                        self.spec["llvm"].prefix,
-                        "libc++abi.{0}".format(dso_suffix)
-                   )
+        so_paths = filesystem.find(self.spec["llvm"].prefix, "libc++abi.{0}".format(dso_suffix))
         if len(so_paths) != 1:
             raise InstallError(
                 "concretized llvm dependency must provide a "

--- a/var/spack/repos/builtin/packages/hipsycl/package.py
+++ b/var/spack/repos/builtin/packages/hipsycl/package.py
@@ -117,6 +117,8 @@ class Hipsycl(CMakePackage):
 
     @run_after("install")
     def filter_config_file(self):
+        from spack.build_environment import dso_suffix
+
         config_file_paths = filesystem.find(self.prefix, "syclcc.json")
         if len(config_file_paths) != 1:
             raise InstallError(
@@ -132,7 +134,10 @@ class Hipsycl(CMakePackage):
         #    the libc++.so and libc++abi.so dyn linked to the sycl
         #    ptx backend
         rpaths = set()
-        so_paths = filesystem.find(self.spec["llvm"].prefix, "libc++.so")
+        so_paths = filesystem.find(
+                        self.spec["llvm"].prefix,
+                        "libc++.{0}".format(dso_suffix)
+                   )
         if len(so_paths) != 1:
             raise InstallError(
                 "concretized llvm dependency must provide a "
@@ -140,12 +145,15 @@ class Hipsycl(CMakePackage):
                 "found: {0}".format(so_paths)
             )
         rpaths.add(path.dirname(so_paths[0]))
-        so_paths = filesystem.find(self.spec["llvm"].prefix, "libc++abi.so")
+        so_paths = filesystem.find(
+                        self.spec["llvm"].prefix,
+                        "libc++abi.{0}".format(dso_suffix)
+                   )
         if len(so_paths) != 1:
             raise InstallError(
                 "concretized llvm dependency must provide a "
-                "unique directory containing libc++abi.so, "
-                "found: {0}".format(so_paths)
+                "unique directory containing libc++abi.{0}, "
+                "found: {1}".format(dso_suffix, so_paths)
             )
         rpaths.add(path.dirname(so_paths[0]))
         config["default-cuda-link-line"] += " " + " ".join("-rpath {0}".format(p) for p in rpaths)


### PR DESCRIPTION
This changes "so" in hipsycl to `spack.build_environment.dso_suffix`, allowing it to build on OSX.  Updating spack made more errors for me because of boost - so I also fixed that.