### PR TITLE
util-linux-uuid:  Fix icc build issue with @2.37.4.

### DIFF
--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -46,4 +46,6 @@ class UtilLinuxUuid(AutotoolsPackage):
             '--enable-libuuid',
             '--disable-bash-completion',
         ]
+        if self.spec.satisfies('%intel'):
+            config_args.append('CFLAGS=-restrict')
         return config_args

--- a/var/spack/repos/builtin/packages/util-linux-uuid/package.py
+++ b/var/spack/repos/builtin/packages/util-linux-uuid/package.py
@@ -46,6 +46,7 @@ class UtilLinuxUuid(AutotoolsPackage):
             '--enable-libuuid',
             '--disable-bash-completion',
         ]
+        # Fixes #31123.
         if self.spec.satisfies('%intel'):
             config_args.append('CFLAGS=-restrict')
         return config_args


### PR DESCRIPTION
Fixes #31123

Adds CFLAGS=-restrict when using %intel.  Not required for earlier
versions (@2.36.2, @2.36) but doesn't hurt.