### PR TITLE
Update containerize templates to account for view indirection

### DIFF
--- a/lib/spack/spack/container/writers/__init__.py
+++ b/lib/spack/spack/container/writers/__init__.py
@@ -171,11 +171,12 @@ class PathContext(tengine.Context):
     def paths(self):
         """Important paths in the image"""
         Paths = collections.namedtuple('Paths', [
-            'environment', 'store', 'view'
+            'environment', 'store', 'hidden_view', 'view'
         ])
         return Paths(
             environment='/opt/spack-environment',
             store='/opt/software',
+            hidden_view='/opt/._view',
             view='/opt/view'
         )
 

--- a/share/spack/templates/container/Dockerfile
+++ b/share/spack/templates/container/Dockerfile
@@ -47,6 +47,7 @@ FROM {{ run.image }}
 
 COPY --from=builder {{ paths.environment }} {{ paths.environment }}
 COPY --from=builder {{ paths.store }} {{ paths.store }}
+COPY --from=builder {{ paths.hidden_view }} {{ paths.hidden_view }}
 COPY --from=builder {{ paths.view }} {{ paths.view }}
 COPY --from=builder /etc/profile.d/z10_spack_environment.sh /etc/profile.d/z10_spack_environment.sh
 

--- a/share/spack/templates/container/singularity.def
+++ b/share/spack/templates/container/singularity.def
@@ -56,6 +56,7 @@ Stage: final
 %files from build
   {{ paths.environment }} /opt
   {{ paths.store }} /opt
+  {{ paths.hidden_view }} /opt
   {{ paths.view }} /opt
   {{ paths.environment }}/environment_modifications.sh {{ paths.environment }}/environment_modifications.sh
 


### PR DESCRIPTION
fixes #30965

Modifications:
- [x] Update both Docker and Singularity templates to copy `/opt/._view` to the last stage