### PR TITLE
new package: py-lark to replace py-lark-parser, add new versions

### DIFF
--- a/var/spack/repos/builtin/packages/charliecloud/package.py
+++ b/var/spack/repos/builtin/packages/charliecloud/package.py
@@ -34,7 +34,7 @@ class Charliecloud(AutotoolsPackage):
 
     depends_on('python@3.5:',    type='run')
     # Version 0.25+ bundle the preferred lark version.
-    depends_on('py-lark-parser', type='run', when='@:0.24')
+    depends_on('py-lark', type='run', when='@:0.24')
     depends_on('py-requests',    type='run')
     # autogen.sh requires pip and wheel (only needed for git checkouts)
     depends_on('py-pip@21.1.2:', type='build', when='@master')

--- a/var/spack/repos/builtin/packages/py-datacube/package.py
+++ b/var/spack/repos/builtin/packages/py-datacube/package.py
@@ -40,7 +40,7 @@ class PyDatacube(PythonPackage):
     depends_on('py-netcdf4', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-psycopg2', type=('build', 'run'))
-    depends_on('py-lark-parser@0.6.7:', type=('build', 'run'))
+    depends_on('py-lark@0.6.7:', type=('build', 'run'))
     depends_on('py-python-dateutil', type=('build', 'run'))
     depends_on('py-pyyaml', type=('build', 'run'))
     depends_on('py-rasterio@1.0.2:', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-lark-parser/package.py
+++ b/var/spack/repos/builtin/packages/py-lark-parser/package.py
@@ -12,8 +12,8 @@ class PyLarkParser(PythonPackage):
     homepage = "https://github.com/lark-parser/lark/"
     pypi = "lark-parser/lark-parser-0.6.2.tar.gz"
 
-    version('0.11.3', sha256='e29ca814a98bb0f81674617d878e5f611cb993c19ea47f22c80da3569425f9bd')
-    version('0.7.1', sha256='8455e05d062fa7f9d59a2735583cf02291545f944955c4056bf1144c4e625344')
-    version('0.6.2', sha256='7e2934371e0e3a5daf9afc2e3ddda76117cabcd3c3f2edf7987c1e4e9b9e503c')
+    version('0.11.3', sha256='e29ca814a98bb0f81674617d878e5f611cb993c19ea47f22c80da3569425f9bd', deprecated=True)
+    version('0.7.1', sha256='8455e05d062fa7f9d59a2735583cf02291545f944955c4056bf1144c4e625344', deprecated=True)
+    version('0.6.2', sha256='7e2934371e0e3a5daf9afc2e3ddda76117cabcd3c3f2edf7987c1e4e9b9e503c', deprecated=True)
 
     depends_on('py-setuptools', type='build')

--- a/var/spack/repos/builtin/packages/py-lark/package.py
+++ b/var/spack/repos/builtin/packages/py-lark/package.py
@@ -1,0 +1,26 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyLark(PythonPackage):
+    """Lark is a modern general-purpose parsing library for Python."""
+
+    homepage = "https://github.com/lark-parser/lark/"
+    pypi = "lark/lark-1.0.0.tar.gz"
+
+    version('1.1.2',  sha256='7a8d0c07d663da9391d7faee1bf1d7df4998c47ca43a593cbef5c7566acd057a')
+    version('1.1.1',  sha256='5115193433051f079374c4f81059fa4bf2afa78cc87dd87817ed4435e8647c82')
+    version('1.1.0',  sha256='669eab99a9627b2b9e0c6fb97f23113c64d673c93d804bca40b05b2a765f13c0')
+    version('1.0.0',  sha256='2269dee215e6c689d5ce9d34fdc6e749d0c1c763add3fc7935938ebd7da159cb')
+    version('0.12.0', sha256='7da76fcfddadabbbbfd949bbae221efd33938451d90b1fefbbc423c3cccf48ef')
+    version('0.11.3', sha256='3100d9749b5a85735ec428b83100876a5da664804579e729c23a36341f961e7e')
+    version('0.11.1', sha256='f2c6ed79ae128a89714bbaa4a6ecb61b6eec84d1b5d63b9195ad461762f96298')
+    version('0.11.0', sha256='29868417eb190fe7d6b1ff6bcd9446903e0c73a1ca69cec58c92a01cae0abc24')
+    version('0.10.1', sha256='98f2c6f8e41fe601fd103476eb759ac1ad4d3dc8094633133a16cef5a32b0f65')
+
+    depends_on('python@3.6:', when='@1.0.0:')
+    depends_on('py-setuptools', type='build')


### PR DESCRIPTION
* added new `py-lark` spackage to reflect changes in pypi
* deprecated all versions of `py-lark-parser`
* starting with `1.0.0` the `lark-parser` pypi package was replaced with `lark` (see release notes https://github.com/lark-parser/lark/releases/tag/1.0.0), new pypi package has history down to `0.10.1`
* starting with `1.0.0` python 3.6 or higher is required
* updated two dependent packages to use `py-lark` instead of `py-lark-parser`
* added missing releases

not sure what the proper procedure is when renaming packages. Since there was no maintainer I did a best estimate.