### PR TITLE
llvm: Rework variant logic

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -7,13 +7,13 @@ import os.path
 import re
 import sys
 
+import archspec.cpu
+
 import llnl.util.tty as tty
 
-import archspec.cpu
 import spack.build_environment
 import spack.util.executable
 from spack.package import *
-
 
 target_variant_arch_map = {
     "aarch64": "AArch64",
@@ -35,6 +35,7 @@ target_variant_arch_map = {
     "x86": "X86",
     "xcore": "XCore",
 }
+
 
 def arch_family_to_variant_key(arch):
     if arch.startswith('ppc'):
@@ -754,7 +755,8 @@ def get_llvm_targets_to_build(spec):
 
     spec_target_variant_arch = arch_family_to_variant_key(str(spec.target.family))
     if spec_target_variant_arch not in variant_targets:
-        raise spack.error.SpecError("'targets' variant does not contain the spec target cpu.")
+        raise spack.error.SpecError(
+            "'targets' variant does not contain the spec target cpu.")
 
     cmake_targets = set(target_variant_arch_map[t] for t in variant_targets)
     return list(cmake_targets)


### PR DESCRIPTION
This makes two significant changes to llvm:

1. Expresses many of the variant-interaction conflicts as `when` clauses on the variants instead of as conflicts.  This creates an easier spec for the concertize to handle and simplifies the resulting spec by only showing variants that are valid to express.
2. Reworks how the `target` variant is handled.  `none` never made any sense here since the configure args always enabled the spec target arch regardless of whether it was specified or now.  This change ensures that the `target` variant will always reflect what the package is built with, giving dependents a reliable way to check the spec for how `llvm` is built instead of needing to interrogate with `llvm-config`