### PR TITLE
Add py-torch v1.12, py-torchvision v0.13

### DIFF
--- a/var/spack/repos/builtin/packages/gloo/package.py
+++ b/var/spack/repos/builtin/packages/gloo/package.py
@@ -13,6 +13,7 @@ class Gloo(CMakePackage, CudaPackage):
     git      = "https://github.com/facebookincubator/gloo.git"
 
     version('master', branch='master')
+    version('2021-05-21', commit='c22a5cfba94edf8ea4f53a174d38aa0c629d070f')  # py-torch@1.10:
     version('2021-05-04', commit='6f7095f6e9860ce4fd682a7894042e6eba0996f1')  # py-torch@1.9
     version('2020-09-18', commit='3dc0328fe6a9d47bd47c0c6ca145a0d8a21845c6')  # py-torch@1.7:1.8
     version('2020-03-17', commit='113bde13035594cafdca247be953610b53026553')  # py-torch@1.5:1.6

--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -18,7 +18,11 @@ class Onnx(CMakePackage):
     git      = "https://github.com/onnx/onnx.git"
 
     version('master', branch='master')
-    version('1.10.1', sha256='cb2fe3e0c9bba128a5790a565d81be30f4b5571eaca5418fb19df8d2d0f11ce2')
+    version('1.12.0', sha256='052ad3d5dad358a33606e0fc89483f8150bb0655c99b12a43aa58b5b7f0cc507')
+    version('1.11.0', sha256='a20f2d9df805b16ac75ab4da0a230d3d1c304127d719e5c66a4e6df514e7f6c0')  # py-torch@1.12:
+    version('1.10.2', sha256='520b3aa34272cc215e2eb41385f58adf01750d88858d4722563edca8410c5dc9')
+    version('1.10.1_2021-10-08', commit='85546f8c44e627f8ff1181725d03cc49f675e44f')  # py-torch@1.11
+    version('1.10.1', sha256='cb2fe3e0c9bba128a5790a565d81be30f4b5571eaca5418fb19df8d2d0f11ce2') # py-torch@1.10
     version('1.10.0', sha256='705a27ee076713b8c755911913c9ffa8f96b95fc3a8568ed0b8e1dd954d67147')
     version('1.9.0', sha256='61d459a5f30604cabec352574119a6685dfd43bfa757cfbff52be9471d5b8ea0')
     version('1.8.0_2020-11-03', commit='54c38e6eaf557b844e70cebc00f39ced3321e9ad')  # py-torch@1.8:1.9

--- a/var/spack/repos/builtin/packages/onnx/package.py
+++ b/var/spack/repos/builtin/packages/onnx/package.py
@@ -22,7 +22,7 @@ class Onnx(CMakePackage):
     version('1.11.0', sha256='a20f2d9df805b16ac75ab4da0a230d3d1c304127d719e5c66a4e6df514e7f6c0')  # py-torch@1.12:
     version('1.10.2', sha256='520b3aa34272cc215e2eb41385f58adf01750d88858d4722563edca8410c5dc9')
     version('1.10.1_2021-10-08', commit='85546f8c44e627f8ff1181725d03cc49f675e44f')  # py-torch@1.11
-    version('1.10.1', sha256='cb2fe3e0c9bba128a5790a565d81be30f4b5571eaca5418fb19df8d2d0f11ce2') # py-torch@1.10
+    version('1.10.1', sha256='cb2fe3e0c9bba128a5790a565d81be30f4b5571eaca5418fb19df8d2d0f11ce2')  # py-torch@1.10
     version('1.10.0', sha256='705a27ee076713b8c755911913c9ffa8f96b95fc3a8568ed0b8e1dd954d67147')
     version('1.9.0', sha256='61d459a5f30604cabec352574119a6685dfd43bfa757cfbff52be9471d5b8ea0')
     version('1.8.0_2020-11-03', commit='54c38e6eaf557b844e70cebc00f39ced3321e9ad')  # py-torch@1.8:1.9

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -24,6 +24,7 @@ class PyTorch(PythonPackage, CudaPackage):
     import_modules = ['torch', 'torch.autograd', 'torch.nn', 'torch.utils']
 
     version('master', branch='master', submodules=True)
+    version('1.12.0', tag='v1.12.0', submodules=True)
     version('1.11.0', tag='v1.11.0', submodules=True)
     version('1.10.2', tag='v1.10.2', submodules=True)
     version('1.10.1', tag='v1.10.1', submodules=True)
@@ -43,8 +44,8 @@ class PyTorch(PythonPackage, CudaPackage):
     version('1.3.0', tag='v1.3.0', submodules=True)
     version('1.2.0', tag='v1.2.0', submodules=True)
     version('1.1.0', tag='v1.1.0', submodules=True)
-    version('1.0.1', tag='v1.0.1', submodules=True, deprecated=True)
-    version('1.0.0', tag='v1.0.0', submodules=True, deprecated=True)
+    version('1.0.1', tag='v1.0.1', submodules=True)
+    version('1.0.0', tag='v1.0.0', submodules=True)
 
     is_darwin = sys.platform == 'darwin'
 
@@ -80,7 +81,7 @@ class PyTorch(PythonPackage, CudaPackage):
     variant('gloo', default=not is_darwin, description='Use Gloo', when='+distributed')
     variant('tensorpipe', default=not is_darwin, description='Use TensorPipe', when='@1.6: +distributed')
     variant('onnx_ml', default=True, description='Enable traditional ONNX ML API', when='@1.5:')
-    variant('breakpad', default=True, description='Enable breakpad crash dump library', when='@1.9:')
+    variant('breakpad', default=True, description='Enable breakpad crash dump library', when='@1.9:1.11')
 
     conflicts('+cuda+rocm')
     conflicts('+breakpad', when='target=ppc64:')
@@ -175,15 +176,21 @@ class PyTorch(PythonPackage, CudaPackage):
         depends_on('rocblas')
         depends_on('miopen-hip')
     # https://github.com/pytorch/pytorch/issues/60332
-    # depends_on('xnnpack@2021-02-22', when='@1.8:+xnnpack')
+    # depends_on('xnnpack@2022-02-16', when='@1.12:+xnnpack')
+    # depends_on('xnnpack@2021-06-21', when='@1.10:1.11+xnnpack')
+    # depends_on('xnnpack@2021-02-22', when='@1.8:1.9+xnnpack')
     # depends_on('xnnpack@2020-03-23', when='@1.6:1.7+xnnpack')
     depends_on('mpi', when='+mpi')
     # https://github.com/pytorch/pytorch/issues/60270
-    # depends_on('gloo@2021-05-04', when='@1.9:+gloo')
+    # depends_on('gloo@2021-05-21', when='@1.10:+gloo')
+    # depends_on('gloo@2021-05-04', when='@1.9+gloo')
     # depends_on('gloo@2020-09-18', when='@1.7:1.8+gloo')
     # depends_on('gloo@2020-03-17', when='@1.6+gloo')
     # https://github.com/pytorch/pytorch/issues/60331
-    # depends_on('onnx@1.8.0_2020-11-03', when='@1.8:+onnx_ml')
+    # depends_on('onnx@1.11.0', when='@1.12:+onnx_ml')
+    # depends_on('onnx@1.10.1_2021-10-08', when='@1.11+onnx_ml')
+    # depends_on('onnx@1.10.1', when='@1.10+onnx_ml')
+    # depends_on('onnx@1.8.0_2020-11-03', when='@1.8:1.9+onnx_ml')
     # depends_on('onnx@1.7.0_2020-05-31', when='@1.6:1.7+onnx_ml')
     depends_on('mkl', when='+mkldnn')
 

--- a/var/spack/repos/builtin/packages/py-torchvision/package.py
+++ b/var/spack/repos/builtin/packages/py-torchvision/package.py
@@ -19,6 +19,7 @@ class PyTorchvision(PythonPackage):
 
     version('main', branch='main')
     version('master', branch='main', deprecated=True)
+    version('0.13.0', sha256='2fe9139150800820d02c867a0b64b7c7fbc964d48d76fae235d6ef9215eabcf4')
     version('0.12.0', sha256='99e6d3d304184895ff4f6152e2d2ec1cbec89b3e057d9c940ae0125546b04e91')
     version('0.11.3', sha256='b4c51d27589783e6e6941ecaa67b55f6f41633874ec37f80b64a0c92c3196e0c')
     version('0.11.2', sha256='55689c57c29f82438a133d0af3315991037be59c8e02471bdcaa31731154a714')
@@ -62,6 +63,7 @@ class PyTorchvision(PythonPackage):
 
     # https://github.com/pytorch/vision#installation
     depends_on('py-torch@master', when='@master', type=('build', 'link', 'run'))
+    depends_on('py-torch@1.12.0', when='@0.13.0', type=('build', 'link', 'run'))
     depends_on('py-torch@1.11.0', when='@0.12.0', type=('build', 'link', 'run'))
     depends_on('py-torch@1.10.2', when='@0.11.3', type=('build', 'link', 'run'))
     depends_on('py-torch@1.10.1', when='@0.11.2', type=('build', 'link', 'run'))

--- a/var/spack/repos/builtin/packages/xnnpack/package.py
+++ b/var/spack/repos/builtin/packages/xnnpack/package.py
@@ -14,6 +14,8 @@ class Xnnpack(CMakePackage):
     git      = "https://github.com/google/XNNPACK.git"
 
     version('master', branch='master')
+    version('2022-02-16', commit='ae108ef49aa5623b896fc93d4298c49d1750d9ba')  # py-torch@1.12
+    version('2021-06-21', commit='79cd5f9e18ad0925ac9a050b00ea5a36230072db')  # py-torch@1.10:1.11
     version('2021-02-22', commit='55d53a4e7079d38e90acd75dd9e4f9e781d2da35')  # py-torch@1.8:1.9
     version('2020-03-23', commit='1b354636b5942826547055252f3b359b54acff95')  # py-torch@1.6:1.7
     version('2020-02-24', commit='7493bfb9d412e59529bcbced6a902d44cfa8ea1c')  # py-torch@1.5


### PR DESCRIPTION
Successfully builds on macOS 12.4 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6.

https://github.com/pytorch/pytorch/releases/tag/v1.12.0
https://github.com/pytorch/vision/releases/tag/v0.13.0