### PR TITLE
pyscf: Add @2.0.1, update dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyscf/package.py
+++ b/var/spack/repos/builtin/packages/py-pyscf/package.py
@@ -16,6 +16,7 @@ class PyPyscf(PythonPackage):
 
     maintainers = ['naromero77']
 
+    version('2.0.1', tag='v2.0.1')
     version('1.7.5', tag='v1.7.5')
     version('1.7.3', tag='v1.7.3')
 
@@ -24,8 +25,12 @@ class PyPyscf(PythonPackage):
     depends_on('python@2.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy@1.8.0:', type=('build', 'run'))
+    depends_on('py-numpy@1.13.0:', type=('build', 'run'), when='@2:')
+    conflicts('py-numpy@1.16:1.17', when='@2:')
     depends_on('py-scipy@0.12:', type=('build', 'run'))
+    conflicts('py-scipy@1.5.0:1.5.1', when='@2:')
     depends_on('py-h5py@2.3.0:', type=('build', 'run'))
+    depends_on('py-h5py@2.7.0:', type=('build', 'run'), when='@2:')
     depends_on('blas')
     depends_on('libcint+coulomb_erf+f12')
     depends_on('libxc')


### PR DESCRIPTION
(Second attempt, hopefully cleaner)

Add latest version 2.0.1 released 4 November 2021. Also update python deps consistent with the setup.py for version >= 2.

This is a minimal update to get the current version working in spack. There are numerous options that could be added by someone who needs more than basic functionality and who has more time.
