### PR TITLE
Remove redundent spec fetches for binary installation

### DIFF
--- a/lib/spack/spack/test/installer.py
+++ b/lib/spack/spack/test/installer.py
@@ -218,7 +218,7 @@ def test_process_binary_cache_tarball_none(install_mockery, monkeypatch, capfd):
 def test_process_binary_cache_tarball_tar(install_mockery, monkeypatch, capfd):
     """Tests of _process_binary_cache_tarball with a tar file."""
 
-    def _spec(spec, unsigned=False, mirrors_for_spec=None):
+    def _spec(spec, unsigned=False):
         return spec
 
     # Skip binary distribution functionality since assume tested elsewhere


### PR DESCRIPTION
installer: remove redundant fetch of spec files from mirror
    
Since binary_distribution::download_tarball() is going to iterate
over the mirrors fetching spec files anyway (as it will likely need
to verify the signature on a clear-signed spec), there should be no
need to first get_mirrors_for_spec() before calling download_tarball().
The result should be that for each spec we install from binary, we
fetch the associated spec file once instead of twice.
