### PR TITLE
kealib: add version 1.4.15

### DIFF
--- a/var/spack/repos/builtin/packages/kealib/package.py
+++ b/var/spack/repos/builtin/packages/kealib/package.py
@@ -23,12 +23,13 @@ class Kealib(CMakePackage):
     Development work on this project has been funded by Landcare Research.
     """
     homepage = "http://www.kealib.org/"
-    url      = "https://github.com/ubarsc/kealib/releases/download/kealib-1.4.12/kealib-1.4.12.tar.gz"
+    url      = "https://github.com/ubarsc/kealib/releases/download/kealib-1.4.15/kealib-1.4.15.tar.gz"
     git      = "https://github.com/ubarsc/kealib"
 
-    maintainers = ['gillins']
+    maintainers = ['gillins', 'neilflood', 'petebunting']
 
     version('develop', git=git)
+    version('1.4.15', sha256='40f2573c00f005f93c1fa88f1f13bfbd485cbc7a9b3f1c706931e69bff17dae4')
     version('1.4.12', sha256='0b100e36b3e25e57487aa197d7be47f22e1b30afb16a57fdaa5f877696ec321e')
     version('1.4.11', sha256='3d64cdec560c7a338ccb38e3a456db4e3b176ac62f945daa6e332e60fe4eca90')
     version('1.4.10', sha256='b1bd2d6834d2fe09ba456fce77f7a9452b406dbe302f7ef1aabe924e45e6bb5e')


### PR DESCRIPTION
As promised in https://github.com/spack/spack/pull/31295 here is an update to the latest version of `kealib`. Apologies @adamjstewart if I have got something wrong in this PR - I'm not that familiar with Spack yet.

The most recent version previously was 1.4.12, I didn't see the point in putting all the intermediate versions in but let me know if this is incorrect. 1.4.15 had an important fix to `kea-config.bat` actually so if you are now targeting Windows this could be important.

@neilflood @petebunting are you guys also happy to be maintainers of this recipe?