### PR TITLE
py-torchgeo: latest version of torchvision won't work

### DIFF
--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -56,7 +56,7 @@ class PyTorchgeo(PythonPackage):
     depends_on('py-torchmetrics@0.7:0.8', when='@0.2.1', type=('build', 'run'))
     depends_on('py-torchmetrics@:0.7', when='@:0.2.0', type=('build', 'run'))
     depends_on('py-torchvision@0.10:0.12', when='@0.2:', type=('build', 'run'))
-    depends_on('py-torchvision@0.3:', type=('build', 'run'))
+    depends_on('py-torchvision@0.3:0.12', type=('build', 'run'))
 
     # Optional dependencies
     with when('+datasets'):

--- a/var/spack/repos/builtin/packages/py-torchgeo/package.py
+++ b/var/spack/repos/builtin/packages/py-torchgeo/package.py
@@ -55,7 +55,7 @@ class PyTorchgeo(PythonPackage):
     depends_on('py-torchmetrics@0.7:', when='@0.2.2:', type=('build', 'run'))
     depends_on('py-torchmetrics@0.7:0.8', when='@0.2.1', type=('build', 'run'))
     depends_on('py-torchmetrics@:0.7', when='@:0.2.0', type=('build', 'run'))
-    depends_on('py-torchvision@0.10:', when='@0.2:', type=('build', 'run'))
+    depends_on('py-torchvision@0.10:0.12', when='@0.2:', type=('build', 'run'))
     depends_on('py-torchvision@0.3:', type=('build', 'run'))
 
     # Optional dependencies


### PR DESCRIPTION
`torchvision.utils.draw_bounding_boxes` changed its behavior. Now a list of empty bounding boxes causes the method to crash. This is fixed in https://github.com/microsoft/torchgeo/pull/631 which will be included in the new release. I'll likely lock down the upper bounds on all older versions once the next release is out but didn't want to forget that this one is even more restrictive than main.