### PR TITLE
py-laspy: add v2.2.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-laspy/package.py
+++ b/var/spack/repos/builtin/packages/py-laspy/package.py
@@ -12,8 +12,10 @@ class PyLaspy(PythonPackage):
     homepage = "https://github.com/laspy/laspy"
     pypi     = "laspy/laspy-2.0.3.tar.gz"
 
+    version('2.2.0', sha256='69d36f01acecd719cbe3c3cf58353f247f391ccadb1da37731d45bfe919685df')
     version('2.0.3', sha256='95c6367bc3a7c1e0d8dc118ae4a6b038bf9e8ad3e60741ecb8d59c36d32f822a')
 
+    depends_on('python@3.7:', when='@2.2:', type=('build', 'run'))
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
     depends_on('py-numpy', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 12.4 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6.

https://github.com/laspy/laspy/releases/tag/2.2.0