### PR TITLE
py-altair: new package

### DIFF
--- a/var/spack/repos/builtin/packages/py-altair/package.py
+++ b/var/spack/repos/builtin/packages/py-altair/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyAltair(PythonPackage):
+    """Declarative statistical visualization library for Python"""
+
+    homepage = "https://altair-viz.github.io/"
+    url = "https://github.com/altair-viz/altair/archive/refs/tags/v4.2.0.tar.gz"
+
+    version('4.2.0', sha256="ee28a56d4d7ef7a089d5b7f47f2555c66e5a47786d16df5b274648d25550e1ab")
+
+    depends_on('python@3.6:')
+    depends_on('py-entrypoints', type="run")
+    depends_on('py-jsonschema', type="run")
+    depends_on('py-numpy', type="run")
+    depends_on('py-pandas', type="run")
+    depends_on('py-toolz', type="run")
+    depends_on('py-jinja2', type="run")

--- a/var/spack/repos/builtin/packages/py-altair/package.py
+++ b/var/spack/repos/builtin/packages/py-altair/package.py
@@ -9,15 +9,15 @@ from spack.package import *
 class PyAltair(PythonPackage):
     """Declarative statistical visualization library for Python"""
 
-    homepage = "https://altair-viz.github.io/"
-    url = "https://github.com/altair-viz/altair/archive/refs/tags/v4.2.0.tar.gz"
+    pypi = 'altair/altair-4.2.0.tar.gz'
 
-    version('4.2.0', sha256="ee28a56d4d7ef7a089d5b7f47f2555c66e5a47786d16df5b274648d25550e1ab")
+    version('4.2.0', sha256="d87d9372e63b48cd96b2a6415f0cf9457f50162ab79dc7a31cd7e024dd840026")
 
     depends_on('python@3.7:')
+    depends_on('py-setuptools@40.6:', type='build')
     depends_on('py-entrypoints', type="run")
     depends_on('py-jsonschema@3:', type="run")
-    depends_on('py-numpy', type="run")
-    depends_on('py-pandas@0.18:', type="run")
-    depends_on('py-toolz', type="run")
-    depends_on('py-jinja2', type="run")
+    depends_on('py-numpy', type=('build', 'run'))
+    depends_on('py-pandas@0.18:', type=('build', 'run'))
+    depends_on('py-toolz', type=('build', 'run'))
+    depends_on('py-jinja2', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-altair/package.py
+++ b/var/spack/repos/builtin/packages/py-altair/package.py
@@ -13,10 +13,10 @@ class PyAltair(PythonPackage):
 
     version('4.2.0', sha256="d87d9372e63b48cd96b2a6415f0cf9457f50162ab79dc7a31cd7e024dd840026")
 
-    depends_on('python@3.7:')
+    depends_on('python@3.7:', type=('build', 'run'))
     depends_on('py-setuptools@40.6:', type='build')
-    depends_on('py-entrypoints', type="run")
-    depends_on('py-jsonschema@3:', type="run")
+    depends_on('py-entrypoints', type=('build', 'run'))
+    depends_on('py-jsonschema@3:', type=('build', 'run'))
     depends_on('py-numpy', type=('build', 'run'))
     depends_on('py-pandas@0.18:', type=('build', 'run'))
     depends_on('py-toolz', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-altair/package.py
+++ b/var/spack/repos/builtin/packages/py-altair/package.py
@@ -18,6 +18,6 @@ class PyAltair(PythonPackage):
     depends_on('py-entrypoints', type="run")
     depends_on('py-jsonschema@3:', type="run")
     depends_on('py-numpy', type="run")
-    depends_on('py-pandas', type="run")
+    depends_on('py-pandas@0.18:', type="run")
     depends_on('py-toolz', type="run")
     depends_on('py-jinja2', type="run")

--- a/var/spack/repos/builtin/packages/py-altair/package.py
+++ b/var/spack/repos/builtin/packages/py-altair/package.py
@@ -14,7 +14,7 @@ class PyAltair(PythonPackage):
 
     version('4.2.0', sha256="ee28a56d4d7ef7a089d5b7f47f2555c66e5a47786d16df5b274648d25550e1ab")
 
-    depends_on('python@3.6:')
+    depends_on('python@3.7:')
     depends_on('py-entrypoints', type="run")
     depends_on('py-jsonschema', type="run")
     depends_on('py-numpy', type="run")

--- a/var/spack/repos/builtin/packages/py-altair/package.py
+++ b/var/spack/repos/builtin/packages/py-altair/package.py
@@ -16,7 +16,7 @@ class PyAltair(PythonPackage):
 
     depends_on('python@3.7:')
     depends_on('py-entrypoints', type="run")
-    depends_on('py-jsonschema', type="run")
+    depends_on('py-jsonschema@3:', type="run")
     depends_on('py-numpy', type="run")
     depends_on('py-pandas', type="run")
     depends_on('py-toolz', type="run")


### PR DESCRIPTION
Successfully builds on Debian 11 (x86_64) with `gcc@7.5.0`, and tests with [example code](https://altair-viz.github.io/gallery/simple_bar_chart.html).

```python
import altair as alt
import pandas as pd

source = pd.DataFrame({
    'a': ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'],
    'b': [28, 55, 43, 91, 81, 53, 19, 87, 52]
})

alt.Chart(source).mark_bar().encode(
    x='a',
    y='b'
).save('chart.html')
```