### PR TITLE
Bug/fix credentials s3 buildcache update

### DIFF
--- a/lib/spack/spack/cmd/common/arguments.py
+++ b/lib/spack/spack/cmd/common/arguments.py
@@ -403,4 +403,4 @@ def add_s3_connection_args(subparser, add_help):
         default=None)
     subparser.add_argument(
         '--s3-endpoint-url',
-        help="Access Token to use to connect to this S3 mirror")
+        help="Endpoint URL to use to connect to this S3 mirror")

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -14,9 +14,17 @@ import spack.util.url as url_util
 def get_mirror_connection(url, url_type="push"):
     connection = {}
     # Try to find a mirror for potential connection information
-    for mirror in spack.mirror.MirrorCollection().values():
-        if "%s://%s" % (url.scheme, url.netloc) == mirror.push_url:
-            connection = mirror.to_dict()[url_type]
+    # Check to see if desired file starts with any of the mirror URLs
+    rebuilt_path = "%s://%s%s" % (url.scheme, url.netloc, url.path)
+    # Gather dict of push URLS point to the value of the whole mirror
+    mirror_dict =  {x.push_url: x for x in spack.mirror.MirrorCollection().values()}
+    # Ensure most specific URLs (longest) are presented first
+    mirror_url_keys = mirror_dict.keys()
+    mirror_url_keys = sorted(mirror_url_keys, key=len, reverse=True)
+    for mURL in mirror_url_keys:
+        # See if desired URL starts with the mirror's push URL
+        if rebuilt_path.startswith(mURL):
+            connection = mirror_dict[mURL].to_dict()[url_type]
     return connection
 
 

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -17,7 +17,7 @@ def get_mirror_connection(url, url_type="push"):
     # Check to see if desired file starts with any of the mirror URLs
     rebuilt_path = "%s://%s%s" % (url.scheme, url.netloc, url.path)
     # Gather dict of push URLS point to the value of the whole mirror
-    mirror_dict =  {x.push_url: x for x in spack.mirror.MirrorCollection().values()}
+    mirror_dict = {x.push_url: x for x in spack.mirror.MirrorCollection().values()}  # noqa: E501
     # Ensure most specific URLs (longest) are presented first
     mirror_url_keys = mirror_dict.keys()
     mirror_url_keys = sorted(mirror_url_keys, key=len, reverse=True)

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -15,7 +15,7 @@ def get_mirror_connection(url, url_type="push"):
     connection = {}
     # Try to find a mirror for potential connection information
     # Check to see if desired file starts with any of the mirror URLs
-    rebuilt_path = "%s://%s%s" % (url.scheme, url.netloc, url.path)
+    rebuilt_path = url_util.format(url)
     # Gather dict of push URLS point to the value of the whole mirror
     mirror_dict = {x.push_url: x for x in spack.mirror.MirrorCollection().values()}  # noqa: E501
     # Ensure most specific URLs (longest) are presented first

--- a/lib/spack/spack/util/s3.py
+++ b/lib/spack/spack/util/s3.py
@@ -25,6 +25,7 @@ def get_mirror_connection(url, url_type="push"):
         # See if desired URL starts with the mirror's push URL
         if rebuilt_path.startswith(mURL):
             connection = mirror_dict[mURL].to_dict()[url_type]
+            break
     return connection
 
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -391,7 +391,7 @@ def list_url(url, recursive=False):
                 if os.path.isfile(os.path.join(local_path, subpath))]
 
     if url.scheme == 's3':
-        s3 = s3_util.create_s3_session(url, connection=s3_util.get_mirror_connection(url))
+        s3 = s3_util.create_s3_session(url, connection=s3_util.get_mirror_connection(url))  # noqa: E501
         if recursive:
             return list(_iter_s3_prefix(s3, url))
 

--- a/lib/spack/spack/util/web.py
+++ b/lib/spack/spack/util/web.py
@@ -391,7 +391,7 @@ def list_url(url, recursive=False):
                 if os.path.isfile(os.path.join(local_path, subpath))]
 
     if url.scheme == 's3':
-        s3 = s3_util.create_s3_session(url)
+        s3 = s3_util.create_s3_session(url, connection=s3_util.get_mirror_connection(url))
         if recursive:
             return list(_iter_s3_prefix(s3, url))
 


### PR DESCRIPTION
A set of fixes for the S3 connection information found during the usage of a mirror and the buildcache command.  See https://spackpm.slack.com/archives/C01UZDL35C4/p1655420904901919 for initial issue and further discussion.