### PR TITLE
Don't modify the path string on non-windows systems

### DIFF
--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -204,12 +204,8 @@ def format_os_path(path, mode=Path.unix):
         mode (Path): the path filesperator style to normalize the
             passed path to. Default is unix style, i.e. '/'
     """
-    if not path:
-        return path
     if mode == Path.windows:
-        path = path.replace('/', '\\')
-    else:
-        path = path.replace('\\', '/')
+        return path.replace('/', '\\')
     return path
 
 


### PR DESCRIPTION
This commit changes the behavior of `format_os_path` so that it only modifies the path string on windows systems (this fixes part of #31377)