### PR TITLE
gitlab: Fix mirror url to match stack name

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/radiuss-aws-aarch64/spack.yaml
@@ -40,7 +40,7 @@ spack:
     - mfem +cuda cuda_arch=70 ^hypre+cuda
     - raja
     - raja +cuda cuda_arch=70
-    - umpire 
+    - umpire
     - umpire +cuda
 
   - compiler:
@@ -57,7 +57,7 @@ spack:
     - - $compiler
     - - $target
 
-  mirrors: { "mirror": "s3://spack-binaries/develop/radiuss-aws" }
+  mirrors: { "mirror": "s3://spack-binaries/develop/radiuss-aws-aarch64" }
 
   gitlab-ci:
 


### PR DESCRIPTION
We adopted the convention of putting binaries for each stack into
a dedicated mirror named after the directory in which the stack
(spack.yaml file) resides.  This fixes the mirror url of the
radiuss-aws-aarch64 stack to follow that convention.