### PR TITLE
Build `llvm-amdgpu`'s libcxx with `cmake --build` instead of explicit `make`

### DIFF
--- a/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
+++ b/var/spack/repos/builtin/packages/llvm-amdgpu/package.py
@@ -202,4 +202,4 @@ class LlvmAmdgpu(CMakePackage):
                 ]
                 cmake_args.extend(self.cmake_args())
                 cmake(*cmake_args)
-                make()
+                cmake("--build", ".")


### PR DESCRIPTION
`CMAKE_GENERATOR` may be set to something other than `"Unix Makefiles"` in which case the build would fail because there is no `Makefile` for `make` to build.

The alternative is to add `-G"Unix Makefiles"` to `cmake_args`. I don't have a particular preference, so let me know if someone prefers it that way.