### PR TITLE
Fix qmcpack compilation for +cuda

### DIFF
--- a/var/spack/repos/builtin/packages/qmcpack/package.py
+++ b/var/spack/repos/builtin/packages/qmcpack/package.py
@@ -303,7 +303,10 @@ class Qmcpack(CMakePackage, CudaPackage):
                     'QMCPACK only supports compilation for a single '
                     'GPU architecture at a time'
                 )
-            args.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch))
+            if '@3.14.0:' in self.spec:
+                args.append('-DCMAKE_CUDA_ARCHITECTURES={0}'.format(cuda_arch))
+            else:
+                args.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch))
         else:
             args.append('-DQMC_CUDA=0')
 


### PR DESCRIPTION
The cmake in qmcpack has changed (for at least in 3.14.0, perhaps earlier). The cuda architecture must be passed using `-DCMAKE_CUDA_ARCHITECTURES` instead of `-DCUDA_ARCH`, see
https://github.com/QMCPACK/qmcpack/blob/develop/CMakeLists.txt#L90
