### PR TITLE
node-js: fix build on macOS 12

### DIFF
--- a/var/spack/repos/builtin/packages/node-js/package.py
+++ b/var/spack/repos/builtin/packages/node-js/package.py
@@ -78,10 +78,10 @@ class NodeJs(Package):
         if sys.platform == 'darwin':
             process_pipe = subprocess.Popen(["which", "libtool"],
                                             stdout=subprocess.PIPE)
-            result_which = process_pipe.communicate()[0]
+            result_which = process_pipe.communicate()[0].strip()
             process_pipe = subprocess.Popen(["whereis", "libtool"],
                                             stdout=subprocess.PIPE)
-            result_whereis = process_pipe.communicate()[0]
+            result_whereis = process_pipe.communicate()[0].strip().split()[-1]
             assert result_which == result_whereis, (
                 'On OSX the system libtool must be used. Please'
                 '(temporarily) remove \n %s or its link to libtool from'


### PR DESCRIPTION
On macOS 10, `which` and `whereis` had the same output format:
```console
$ which libtool
/usr/bin/libtool
$ whereis libtool
/usr/bin/libtool
```
On macOS 12, the output format of `whereis` changed:
```console
$ which libtool
/usr/bin/libtool
$ whereis libtool
libtool: /usr/bin/libtool
```
This PR should correctly parse both formats. Tested on macOS 12.4.