### PR TITLE
Fix spack edit message when no editor installed

### DIFF
--- a/lib/spack/spack/test/util/editor.py
+++ b/lib/spack/spack/test/util/editor.py
@@ -144,5 +144,5 @@ def test_no_editor():
     def assert_exec(exe, args):
         assert False
 
-    with pytest.raises(EnvironmentError):
+    with pytest.raises(EnvironmentError, match=r'No text editor found.*'):
         ed.editor('/path/to/file', _exec_func=assert_exec)

--- a/lib/spack/spack/test/util/editor.py
+++ b/lib/spack/spack/test/util/editor.py
@@ -132,3 +132,17 @@ def test_editor_both_bad(nosuch_exe, vim_exe):
         assert args == [vim_exe, '/path/to/file']
 
     ed.editor('/path/to/file', _exec_func=assert_exec)
+
+
+def test_no_editor():
+    if 'VISUAL' in os.environ:
+        del os.environ['VISUAL']
+    if 'EDITOR' in os.environ:
+        del os.environ['EDITOR']
+    os.environ['PATH'] = ''
+
+    def assert_exec(exe, args):
+        assert False
+
+    with pytest.raises(EnvironmentError):
+        ed.editor('/path/to/file', _exec_func=assert_exec)

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -85,7 +85,7 @@ def editor(*args, **kwargs):
             _exec_func(exe, args)
             return True
 
-        except OSError as e:
+        except Exception as e:
             if spack.config.get('config:debug'):
                 raise
 
@@ -122,7 +122,7 @@ def editor(*args, **kwargs):
     # trying them all -- if we get here and one fails, something is
     # probably much more deeply wrong with the environment.
     exe = which_string(*_default_editors)
-    if try_exec(exe, [exe] + list(args)):
+    if exe and try_exec(exe, [exe] + list(args)):
         return
 
     # Fail if nothing could be found

--- a/lib/spack/spack/util/editor.py
+++ b/lib/spack/spack/util/editor.py
@@ -85,7 +85,7 @@ def editor(*args, **kwargs):
             _exec_func(exe, args)
             return True
 
-        except Exception as e:
+        except OSError as e:
             if spack.config.get('config:debug'):
                 raise
 


### PR DESCRIPTION
When no default editor is installed and no environment variable is set, `which_string` would return `None` and this would be passed to `os.execv`, resulting in a `TypeError`. The message presented to the user would be:

> Error: execv: path should be string, bytes or os.PathLike, not NoneType

This change checks that `which_string` has returned successfully before attempting to execute the result, thereby providing a better error message:

> Error: No text editor found! Please set the VISUAL and/or EDITOR environment variable(s) to your preferred text editor.

~It's not strictly necessary, but I've also changed `editor.try_exec` to catch all errors rather than just `OSError`. This would have provided more context for the original error message.~