### PR TITLE
rocblas: tighten tensile dependencies

### DIFF
--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -95,16 +95,18 @@ class Rocblas(CMakePackage):
                 '5.0.0', '5.0.2', '5.1.0', '5.1.3']:
         depends_on('rocm-smi-lib@' + ver, type='build', when='@' + ver)
 
-    # This is the default library format since 3.7.0
-    depends_on('msgpack-c@3:', when='@3.7:')
-
     depends_on('python@3.6:', type='build')
-    depends_on('py-virtualenv', type='build')
-    depends_on('perl-file-which', type='build')
-    depends_on('py-pyyaml', type='build')
-    depends_on('py-wheel', type='build')
-    depends_on('py-msgpack', type='build')
-    depends_on('py-pip', type='build')
+
+    with when('+tensile'):
+        # default library format since 3.7.0
+        depends_on('msgpack-c@3:', when='@3.7:')
+
+        depends_on('py-virtualenv', type='build')
+        depends_on('perl-file-which', type='build')
+        depends_on('py-pyyaml', type='build')
+        depends_on('py-wheel', type='build')
+        depends_on('py-msgpack', type='build')
+        depends_on('py-pip', type='build')
 
     for t_version, t_commit in [
         ('@3.5.0',  'f842a1a4427624eff6cbddb2405c36dec9a210cd'),

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -88,13 +88,6 @@ class Rocblas(CMakePackage):
         depends_on('llvm-amdgpu@' + ver,  type='build',  when='@' + ver)
         depends_on('rocminfo@' + ver,     type='build',  when='@' + ver)
 
-    for ver in ['3.5.0', '3.7.0', '3.8.0', '3.9.0']:
-        depends_on('rocm-smi@' + ver, type='build', when='@' + ver)
-
-    for ver in ['4.0.0', '4.1.0', '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2',
-                '5.0.0', '5.0.2', '5.1.0', '5.1.3']:
-        depends_on('rocm-smi-lib@' + ver, type='build', when='@' + ver)
-
     depends_on('python@3.6:', type='build')
 
     with when('+tensile'):


### PR DESCRIPTION
This is a pair of changes related to Tensile:
* Make tensile dependencies conditional on `+tensile`.
* Remove rocm-smi from the rocblas dependency list.