### PR TITLE
rocalution: add spack build test

### DIFF
--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -53,16 +53,13 @@ class Rocalution(CMakePackage):
                 '4.2.0', '4.3.0', '4.3.1', '4.5.0', '4.5.2', '5.0.0',
                 '5.0.2', '5.1.0', '5.1.3']:
         depends_on('hip@' + ver, when='@' + ver)
+        depends_on('rocprim@' + ver, when='@' + ver)
         for tgt in itertools.chain(['auto'], amdgpu_targets):
             rocblas_tgt = tgt if tgt != 'gfx900:xnack-' else 'gfx900'
             depends_on('rocblas@{0} amdgpu_target={1}'.format(ver, rocblas_tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
-            depends_on('rocprim@{0} amdgpu_target={1}'.format(ver, tgt),
-                       when='@{0} amdgpu_target={1}'.format(ver, tgt))
             depends_on('rocsparse@{0} amdgpu_target={1}'.format(ver, tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
-        depends_on('comgr@' + ver, when='@' + ver)
-        depends_on('llvm-amdgpu@' + ver, type='build', when='@' + ver)
         depends_on('rocm-cmake@%s:' % ver, type='build', when='@' + ver)
 
     for ver in ['3.9.0', '3.10.0', '4.0.0', '4.1.0', '4.2.0',

--- a/var/spack/repos/builtin/packages/rocalution/package.py
+++ b/var/spack/repos/builtin/packages/rocalution/package.py
@@ -72,6 +72,12 @@ class Rocalution(CMakePackage):
             depends_on('rocrand@{0} amdgpu_target={1}'.format(ver, tgt),
                        when='@{0} amdgpu_target={1}'.format(ver, tgt))
 
+    depends_on('googletest@1.10.0:', type='test')
+
+    def check(self):
+        exe = join_path(self.build_directory, 'clients', 'staging', 'rocalution-test')
+        self.run_test(exe)
+
     def setup_build_environment(self, env):
         env.set('CXX', self.spec['hip'].hipcc)
 
@@ -102,7 +108,8 @@ class Rocalution(CMakePackage):
             self.define('CMAKE_MODULE_PATH', self.spec['hip'].prefix.cmake),
             self.define('SUPPORT_HIP', 'ON'),
             self.define('SUPPORT_MPI', 'OFF'),
-            self.define('BUILD_CLIENTS_SAMPLES', 'OFF')
+            self.define('BUILD_CLIENTS_SAMPLES', 'OFF'),
+            self.define('BUILD_CLIENTS_TESTS', self.run_tests),
         ]
 
         if 'auto' not in self.spec.variants['amdgpu_target']:


### PR DESCRIPTION
This change is mostly about cleaning up a mistake I made in specifying the dependency on rocprim. It adds support for building and running the rocalution tests because I needed some way to test that my changes were correct.

To give it a spin, try:
```
spack install --verbose --test=root rocalution
```

@srekolam @arjun-raj-kuppala