### PR TITLE
diffutils:  Fixes several Intel compiler builds.

### DIFF
--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -29,6 +29,8 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
     patch('intprops-workaround-nvc-22.1-bug.patch', sha256='146b7021bb0a304a3d1c0638956c4e735c2076d292d238f2806efadc972d99e5', when='@3.8 %nvhpc')
 
     conflicts('%nvhpc', when='@:3.6,3.8:')
+    # See configure_args() for details on %intel@19 compilers
+    conflicts('%intel@19')
 
     depends_on('iconv')
 
@@ -42,3 +44,15 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
         output = Executable(exe)('--version', output=str, error=str)
         match = re.search(r'diff \(GNU diffutils\) (\S+)', output)
         return match.group(1) if match else None
+
+    def configure_args(self):
+        args=[]
+        # See issue #31418.
+        if self.spec.satisfies('%intel@14:15'):
+            args.append('CFLAGS=-no-gcc')
+        # For %intel@19 comment out the conflict() above and uncomment
+        # the next two lines.  Modify the path to point to a recent version
+        # of gcc on your machine.  gcc@4.9.3 is known not to work.
+        #if self.spec.satisfies('%intel@19'):
+        #    args.append('CFLAGS=-gcc-name=/usr/tce/packages/gcc/gcc-10.2.1/bin/gcc')
+        return args

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -30,7 +30,7 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
 
     conflicts('%nvhpc', when='@:3.6,3.8:')
     # See configure_args() for details on %intel@19 compilers
-    conflicts('%intel@19')
+    conflicts('%intel@19.0.0:19')
 
     depends_on('iconv')
 

--- a/var/spack/repos/builtin/packages/diffutils/package.py
+++ b/var/spack/repos/builtin/packages/diffutils/package.py
@@ -46,13 +46,13 @@ class Diffutils(AutotoolsPackage, GNUMirrorPackage):
         return match.group(1) if match else None
 
     def configure_args(self):
-        args=[]
+        args = []
         # See issue #31418.
         if self.spec.satisfies('%intel@14:15'):
             args.append('CFLAGS=-no-gcc')
         # For %intel@19 comment out the conflict() above and uncomment
         # the next two lines.  Modify the path to point to a recent version
         # of gcc on your machine.  gcc@4.9.3 is known not to work.
-        #if self.spec.satisfies('%intel@19'):
+        # if self.spec.satisfies('%intel@19'):
         #    args.append('CFLAGS=-gcc-name=/usr/tce/packages/gcc/gcc-10.2.1/bin/gcc')
         return args


### PR DESCRIPTION
Fixes #31418

Intel compilers @14 and @15 require CFLAGS=-no-gcc

Intel compilers @19 require CFLAGS=-gcc-name=/path/to/recent/gcc
if the gcc in $PATH is older than gcc@5.  As this is a site-
specific fix I've made %intel@19 a conflict with a note as to
how it can be resolved.

Tested compilers:
    intel@14.0.3
    intel@15.0.6
    intel@16.0.4
    intel@17.0.2
    intel@18.0.2
    intel@19.1.2.254
    oneapi@2021.2.0
    oneapi@2022.1.0

Tested diffutils:
    3.8
    3.7
    3.6