### PR TITLE
cpio:  fixes %intel@19 issue.

### DIFF
--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -21,6 +21,9 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
 
     build_directory = 'spack-build'
 
+    # See configure_args()
+    conflicts('%intel@19')
+
     def patch(self):
         """Fix mutiple definition of char *program_name for gcc@10: and clang"""
         filter_file(r'char \*program_name;', '', 'src/global.c')
@@ -42,3 +45,13 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
                 flags.append('--rtlib=compiler-rt')
 
         return (flags, None, None)
+
+    def configure_args(self):
+        args=[]
+        # See #31420 for discussion.
+        # For %intel@19 comment out the conflict() above and uncomment
+        # the next two lines.  Modify the path to point to a recent version
+        # of gcc on your machine.  gcc@4.9.3 is known not to work.
+        #if self.spec.satisfies('%intel@19'):
+        #    args.append('CFLAGS=-gcc-name=/usr/tce/packages/gcc/gcc-10.2.1/bin/gcc')
+        return args

--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -47,11 +47,11 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
         return (flags, None, None)
 
     def configure_args(self):
-        args=[]
+        args = []
         # See #31420 for discussion.
         # For %intel@19 comment out the conflict() above and uncomment
         # the next two lines.  Modify the path to point to a recent version
         # of gcc on your machine.  gcc@4.9.3 is known not to work.
-        #if self.spec.satisfies('%intel@19'):
+        # if self.spec.satisfies('%intel@19'):
         #    args.append('CFLAGS=-gcc-name=/usr/tce/packages/gcc/gcc-10.2.1/bin/gcc')
         return args

--- a/var/spack/repos/builtin/packages/cpio/package.py
+++ b/var/spack/repos/builtin/packages/cpio/package.py
@@ -22,7 +22,7 @@ class Cpio(AutotoolsPackage, GNUMirrorPackage):
     build_directory = 'spack-build'
 
     # See configure_args()
-    conflicts('%intel@19')
+    conflicts('%intel@19.0.0:19')
 
     def patch(self):
         """Fix mutiple definition of char *program_name for gcc@10: and clang"""


### PR DESCRIPTION
Fixes #31420

%intel@19 tries to find a local copy of gcc in $PATH.  If that version of gcc is <5.0, compilation fails.  The fix is to use `-gcc-name` to point the intel compiler to a more recent version of gcc, but that location will vary by site.  This patch sets a conflict with %intel@19 and provides a note on how to get that compiler working locally.