### PR TITLE
jellyfish: added variants for different bindings

### DIFF
--- a/var/spack/repos/builtin/packages/jellyfish/package.py
+++ b/var/spack/repos/builtin/packages/jellyfish/package.py
@@ -22,9 +22,9 @@ class Jellyfish(AutotoolsPackage):
     variant('rubybind', default=False, description='Enable ruby binding')
     variant('perlbind', default=False, description='Enable perl binding')
 
-    extends('perl', when='bindings=perlbind')
-    extends('python', when='bindings=pybind')
-    extends('ruby', when='bindings=rubybind')
+    extends('perl', when='+perlbind')
+    extends('python', when='+pybind')
+    extends('ruby', when='+rubybind')
 
     patch('dna_codes.patch', when='@1.1.11')
 

--- a/var/spack/repos/builtin/packages/jellyfish/package.py
+++ b/var/spack/repos/builtin/packages/jellyfish/package.py
@@ -28,6 +28,7 @@ class Jellyfish(AutotoolsPackage):
 
     patch('dna_codes.patch', when='@1.1.11')
 
+    # v1.1.11 does not support language bindings
     conflicts('+pybind', when='@1.1.11')
     conflicts('+rubybind', when='@1.1.11')
     conflicts('+perlbind', when='@1.1.11')

--- a/var/spack/repos/builtin/packages/jellyfish/package.py
+++ b/var/spack/repos/builtin/packages/jellyfish/package.py
@@ -18,27 +18,32 @@ class Jellyfish(AutotoolsPackage):
     version('1.1.11', sha256='496645d96b08ba35db1f856d857a159798c73cbc1eccb852ef1b253d1678c8e2',
             url='https://www.cbcb.umd.edu/software/jellyfish/jellyfish-1.1.11.tar.gz')
 
-    variant('pybind', default=False, description='Enable python binding')
-    variant('rubybind', default=False, description='Enable ruby binding')
-    variant('perlbind', default=False, description='Enable perl binding')
+    variant(
+        'bindings', default='none', description='Support for binding to Ruby, Python and Perl',
+        values=('pybind', 'rubybind', 'perlbind', 'none'), multi=True
+    )
 
-    depends_on('perl', type=('build', 'run'))
-    depends_on('python', type=('build', 'run'))
+    extends('perl', when='bindings=perlbind')
+    extends('python', when='bindings=pybind')
+    extends('ruby', when='bindings=rubybind')
 
     patch('dna_codes.patch', when='@1.1.11')
 
     def configure_args(self):
         spec = self.spec
-        if '+pybind' in spec:
-            args = [
+
+        args = []
+
+        if 'bindings=pybind' in spec:
+            args.append = [
                 '--enable-python-binding',
             ]
-        elif '+rubybind' in spec:
-            args = [
+        if 'bindings=rubybind' in spec:
+            args.append = [
                 '--enable-ruby-binding',
             ]
-        elif '+perlbind' in spec:
-            args = [
+        if 'bindings=perlbind' in spec:
+            args.append = [
                 '--enable-perl-binding'
             ]
         return args

--- a/var/spack/repos/builtin/packages/jellyfish/package.py
+++ b/var/spack/repos/builtin/packages/jellyfish/package.py
@@ -18,7 +18,27 @@ class Jellyfish(AutotoolsPackage):
     version('1.1.11', sha256='496645d96b08ba35db1f856d857a159798c73cbc1eccb852ef1b253d1678c8e2',
             url='https://www.cbcb.umd.edu/software/jellyfish/jellyfish-1.1.11.tar.gz')
 
+    variant('pybind', default=False, description='Enable python binding')
+    variant('rubybind', default=False, description='Enable ruby binding')
+    variant('perlbind', default=False, description='Enable perl binding')
+
     depends_on('perl', type=('build', 'run'))
     depends_on('python', type=('build', 'run'))
 
     patch('dna_codes.patch', when='@1.1.11')
+
+    def configure_args(self):
+        spec = self.spec
+        if '+pybind' in spec:
+            args = [
+                '--enable-python-binding',
+            ]
+        elif '+rubybind' in spec:
+            args = [
+                '--enable-ruby-binding',
+            ]
+        elif '+perlbind' in spec:
+            args = [
+                '--enable-perl-binding'
+            ]
+        return args

--- a/var/spack/repos/builtin/packages/jellyfish/package.py
+++ b/var/spack/repos/builtin/packages/jellyfish/package.py
@@ -18,10 +18,9 @@ class Jellyfish(AutotoolsPackage):
     version('1.1.11', sha256='496645d96b08ba35db1f856d857a159798c73cbc1eccb852ef1b253d1678c8e2',
             url='https://www.cbcb.umd.edu/software/jellyfish/jellyfish-1.1.11.tar.gz')
 
-    variant(
-        'bindings', default='none', description='Support for binding to Ruby, Python and Perl',
-        values=('pybind', 'rubybind', 'perlbind', 'none'), multi=True
-    )
+    variant('pybind', default=False, description='Enable python binding')
+    variant('rubybind', default=False, description='Enable ruby binding')
+    variant('perlbind', default=False, description='Enable perl binding')
 
     extends('perl', when='bindings=perlbind')
     extends('python', when='bindings=pybind')
@@ -32,18 +31,20 @@ class Jellyfish(AutotoolsPackage):
     def configure_args(self):
         spec = self.spec
 
-        args = []
+        # Can only specify one binding to build with using extends()
+        # see https://github.com/spack/spack/issues/987
 
-        if 'bindings=pybind' in spec:
-            args.append = [
+        if '+pybind' in spec:
+            args = [
                 '--enable-python-binding',
             ]
-        if 'bindings=rubybind' in spec:
-            args.append = [
+        elif '+rubybind' in spec:
+            args = [
                 '--enable-ruby-binding',
             ]
-        if 'bindings=perlbind' in spec:
-            args.append = [
+        elif '+perlbind' in spec:
+            args = [
                 '--enable-perl-binding'
             ]
+
         return args

--- a/var/spack/repos/builtin/packages/jellyfish/package.py
+++ b/var/spack/repos/builtin/packages/jellyfish/package.py
@@ -23,10 +23,14 @@ class Jellyfish(AutotoolsPackage):
     variant('perlbind', default=False, description='Enable perl binding')
 
     extends('perl', when='+perlbind')
-    extends('python', when='+pybind')
+    extends('python@:2.7.18', when='+pybind')
     extends('ruby', when='+rubybind')
 
     patch('dna_codes.patch', when='@1.1.11')
+
+    conflicts('+pybind', when='@1.1.11')
+    conflicts('+rubybind', when='@1.1.11')
+    conflicts('+perlbind', when='@1.1.11')
 
     def configure_args(self):
         spec = self.spec


### PR DESCRIPTION
jellyfish can make bindings available to perl, ruby and python.

This PR makes them available as variants in the jellyfish package.