### PR TITLE
[mpas-model] Overwrite compiler args in Makefile

### DIFF
--- a/var/spack/repos/builtin/packages/mpas-model/package.py
+++ b/var/spack/repos/builtin/packages/mpas-model/package.py
@@ -59,10 +59,12 @@ class MpasModel(MakefilePackage):
             ])
         elif satisfies('%intel'):
             fflags.extend([
-                '-r8',
                 '-convert big_endian',
                 '-FR',
             ])
+            if satisfies('precision=double'):
+                fflags.extend(['-r8'])
+
             cppflags.append('-DUNDERSCORE')
         targets = [
             'FC_PARALLEL={0}'.format(spec['mpi'].mpifc),


### PR DESCRIPTION
Tagging maintainer @t-brown 

The pre-defined compilation targets do not follow the usual behavior of
Makefiles. Compiler flags are set as strings (not Makefile variables) and as
such are not able to be overridden by environment variables. This patch changes
the behavior to the expected behavior of a Makefile such that `fflags` etc have
the desired effect.

This is a necessary fix for https://github.com/spack/spack/pull/31388.

And another quick fix: Use 8 byte reals only when `precision=double` is set.