### PR TITLE
Fix for sanity check failure in spack upstream code: atmi, hip-rocclr

### DIFF
--- a/var/spack/repos/builtin/packages/atmi/package.py
+++ b/var/spack/repos/builtin/packages/atmi/package.py
@@ -56,9 +56,9 @@ class Atmi(CMakePackage):
 
     def cmake_args(self):
         args = [
-            '-DROCM_VERSION={0}'.format(self.spec.version),
+            '-DROCM_VERSION={0}'.format(self.spec.version)
         ]
-        if '@5.0.0:' in self.spec:
+        if self.spec.satisfies('@5.0.2:'):
             args.append(self.define('FILE_REORG_BACKWARD_COMPATIBILITY', 'OFF'))
         return args
 

--- a/var/spack/repos/builtin/packages/atmi/package.py
+++ b/var/spack/repos/builtin/packages/atmi/package.py
@@ -55,9 +55,12 @@ class Atmi(CMakePackage):
     patch('0002-Remove-usr-bin-rsync-reference.patch', when='@4.0.0:')
 
     def cmake_args(self):
-        return [
-            '-DROCM_VERSION={0}'.format(self.spec.version)
+        args = [
+            '-DROCM_VERSION={0}'.format(self.spec.version),
         ]
+        if '@5.0.0:' in self.spec:
+            args.append(self.define('FILE_REORG_BACKWARD_COMPATIBILITY', 'OFF'))
+        return args
 
     @run_after('install')
     def install_stub(self):

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -129,7 +129,8 @@ class HipRocclr(CMakePackage):
             '-DOPENCL_DIR={0}/opencl-on-vdi'.format(self.stage.source_path)
         ]
         return args
+
     def __init__(self, spec):
         super(HipRocclr, self).__init__(spec)
         if '@4.5.0:' in self.spec:
-           self.phases = ['cmake', 'build']
+            self.phases = ['cmake', 'build']

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -132,5 +132,5 @@ class HipRocclr(CMakePackage):
 
     def __init__(self, spec):
         super(HipRocclr, self).__init__(spec)
-        if '@4.5.0:' in self.spec:
+        if self.spec.satisfies('@4.5.0:'):
             self.phases = ['cmake', 'build']

--- a/var/spack/repos/builtin/packages/hip-rocclr/package.py
+++ b/var/spack/repos/builtin/packages/hip-rocclr/package.py
@@ -107,12 +107,6 @@ class HipRocclr(CMakePackage):
         when='@master'
     )
 
-    @property
-    def install_targets(self):
-        if self.spec.satisfies('@4.5.0:'):
-            return []
-        return ['install']
-
     @run_after('install')
     def deploy_missing_files(self):
         if '@3.5.0' in self.spec:
@@ -135,3 +129,7 @@ class HipRocclr(CMakePackage):
             '-DOPENCL_DIR={0}/opencl-on-vdi'.format(self.stage.source_path)
         ]
         return args
+    def __init__(self, spec):
+        super(HipRocclr, self).__init__(spec)
+        if '@4.5.0:' in self.spec:
+           self.phases = ['cmake', 'build']


### PR DESCRIPTION
Setting flag FILE_REORG_BACKWARD_COMPATIBILITY OFF from 5.0.0 since the target install path need not to be modified for atmi in spack build.
Skipping install for hip-rocclr from 4.5.0 since there is nothing to be installed from 4.5.0
