### PR TITLE
speexdsp: add pkgconfig dependency

### DIFF
--- a/var/spack/repos/builtin/packages/speexdsp/package.py
+++ b/var/spack/repos/builtin/packages/speexdsp/package.py
@@ -18,6 +18,7 @@ class Speexdsp(AutotoolsPackage):
     depends_on('automake', type='build')
     depends_on('libtool',  type='build')
     depends_on('m4',       type='build')
+    depends_on('pkgconfig', type='build')
 
     depends_on('fftw-api')
 


### PR DESCRIPTION
`spack install speexdsp^fftw~mpi` fails with:

```console
...spack-stage/spack-stage-speexdsp-1.2.0-4wzngafryibbgqf6jpantknsf3pq7mfb/spack-src/configure: line 13607: syntax error near unexpected token `FFT,'
...spack-stage/spack-stage-speexdsp-1.2.0-4wzngafryibbgqf6jpantknsf3pq7mfb/spack-src/configure: line 13607: `  PKG_CHECK_MODULES(FFT, fftw3f)'
```

Googling the error leads to a [related issue](https://github.com/xiph/speexdsp/issues/31) in the speexdsp repo and the solution  is to install `pkg-config`.

Interestingly, `speexdsp` installs correctly in Spack v0.16. If I look at the build log I see:

```console
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
```

I admit that I did not look into the differences between Spack v0.16.0 and the develop branch to determine why the system `pkg-config` cannot be found by the current Spack logic, but depending on a system library seems like risky behavior.