### PR TITLE
OpenBabel: Make building with GUI an option

### DIFF
--- a/var/spack/repos/builtin/packages/openbabel/package.py
+++ b/var/spack/repos/builtin/packages/openbabel/package.py
@@ -23,6 +23,7 @@ class Openbabel(CMakePackage):
     version('2.4.0', tag='openbabel-2-4-0')
 
     variant('python', default=True, description='Build Python bindings')
+    variant('gui', default=True, description='Build with GUI')
 
     extends('python', when='+python')
 
@@ -62,6 +63,8 @@ class Openbabel(CMakePackage):
             ])
         else:
             args.append('-DPYTHON_BINDINGS=OFF')
+
+        args.append(self.define_from_variant('BUILD_GUI', 'gui'))
 
         args.append('-DWITH_MAEPARSER=OFF')  # maeparser is currently broken
 


### PR DESCRIPTION
Encountered issues with undefined `cairo` symbols when trying to build the package to test `improved-rdock`.  Although I investigated the problem and tried a few simple changes, I was not able to get the package to resolve the build issues.  (It's clear though that the required library was not being included in the build command.)

This PR supports optionally disabling building the gui by adding a variant.  With this change I was able to build and run the stand-alone tests for the aforementioned package (though no guarantee that is the desired `cairo` configuration).

@omsai Does this address the issue you raised in #18878?