### PR TITLE
py-rasterio: add v1.3.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-rasterio/package.py
+++ b/var/spack/repos/builtin/packages/py-rasterio/package.py
@@ -9,18 +9,18 @@ from spack.package import *
 class PyRasterio(PythonPackage):
     """Rasterio reads and writes geospatial raster data.
 
-    Geographic information systems use GeoTIFF and other formats to
-    organize and store gridded, or raster, datasets. Rasterio reads
-    and writes these formats and provides a Python API based on N-D
-    arrays."""
+    Geographic information systems use GeoTIFF and other formats to organize
+    and store gridded, or raster, datasets. Rasterio reads and writes these
+    formats and provides a Python API based on N-D arrays."""
 
-    homepage = "https://github.com/mapbox/rasterio"
+    homepage = "https://github.com/rasterio/rasterio"
     pypi = "rasterio/rasterio-1.1.8.tar.gz"
-    git      = "https://github.com/mapbox/rasterio.git"
+    git = "https://github.com/rasterio/rasterio.git"
 
     maintainers = ['adamjstewart']
 
     version('master', branch='master')
+    version('1.3.0', sha256='90171035e5b201cdb85a9abd60181426366040d4ca44706958db982a030f8dc4')
     version('1.2.10', sha256='6062456047ba6494fe18bd0da98a383b6fad5306b16cd52a22e76c59172a2b5f')
     version('1.2.3',  sha256='d8c345e01052b70ac3bbbe100c83def813c0ab19f7412c2c98e553d03720c1c5')
     version('1.1.8',  sha256='f7cac7e2ecf65b4b1eb78c994c63bd429b67dc679b0bc0ecfe487d3d5bf88fd5')
@@ -29,18 +29,23 @@ class PyRasterio(PythonPackage):
     version('1.0a12', sha256='47d460326e04c64590ff56952271a184a6307f814efc34fb319c12e690585f3c')
 
     # From README.rst
-    depends_on('python@3.6:3.9', type=('build', 'link', 'run'), when='@1.2:')
-    depends_on('python@2.7:2.8,3.5:3.8', type=('build', 'link', 'run'), when='@1.1.0:1.1')
-    depends_on('python@2.7:2.8,3.5:3.7', type=('build', 'link', 'run'), when='@:1.0')
-    depends_on('py-numpy@1.15:', type=('build', 'link', 'run'), when='@1.2:')
-    depends_on('gdal@2.4:3.3', when='@1.2.7:')
+    depends_on('python@3.8:', when='@1.3:', type=('build', 'link', 'run'))
+    depends_on('python@3.6:3.9', when='@1.2', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2.8,3.5:3.8', when='@1.1', type=('build', 'link', 'run'))
+    depends_on('python@2.7:2.8,3.5:3.7', when='@:1.0', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.18:', when='@1.3:', type=('build', 'link', 'run'))
+    depends_on('py-numpy@1.15:', when='@1.2:', type=('build', 'link', 'run'))
+    depends_on('gdal@3.1:', when='@1.3:')
+    depends_on('gdal@2.4:3.3', when='@1.2.7:1.2')
     depends_on('gdal@2.3:3.2', when='@1.2.0:1.2.6')
     depends_on('gdal@1.11:3.2', when='@1.1.0:1.1')
     depends_on('gdal@1.11:3.0', when='@1.0.25:1.0')
     depends_on('gdal@1.11:2', when='@:1.0.24')
 
+    # From pyproject.toml
+    depends_on('py-cython', type='build', when='@1.3:')
+
     # From setup.py
-    depends_on('py-cython', type='build', when='@master')
     depends_on('py-affine', type=('build', 'run'))
     depends_on('py-attrs', type=('build', 'run'))
     depends_on('py-certifi', when='@1.2:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 10.15.7 (x86_64) with Python 3.9.13 and Apple Clang 12.0.0.