### PR TITLE
[py-gevent] Fix: deprecated compiler flags

### DIFF
--- a/var/spack/repos/builtin/packages/py-gevent/icc.patch
+++ b/var/spack/repos/builtin/packages/py-gevent/icc.patch
@@ -1,0 +1,14 @@
+diff -Nur spack-src/deps/c-ares/configure spack-src.patched/deps/c-ares/configure
+--- spack-src/deps/c-ares/configure	2022-07-01 14:04:01.014254504 +0000
++++ spack-src.patched/deps/c-ares/configure	2022-07-01 14:02:33.518090648 +0000
+@@ -20480,8 +20480,8 @@
+       INTEL_UNIX_C)
+         #
+                         tmp_CFLAGS="$tmp_CFLAGS -std=gnu89"
+-                                                tmp_CPPFLAGS="$tmp_CPPFLAGS -we 140,147,165,266"
+-                                        tmp_CPPFLAGS="$tmp_CPPFLAGS -wd 279,981,1469"
++                                                tmp_CPPFLAGS="$tmp_CPPFLAGS -diag-error 140,147,165,266"
++                                        tmp_CPPFLAGS="$tmp_CPPFLAGS -diag-disable 279,981,1469"
+         ;;
+         #
+       INTEL_WINDOWS_C)

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -36,4 +36,5 @@ class PyGevent(PythonPackage):
     depends_on('py-zope-event', when='@20.5.1:', type=('build', 'run'))
     depends_on('py-zope-interface', when='@20.5.1:', type=('build', 'run'))
 
+    # Deprecated compiler options. upstream PR: https://github.com/gevent/gevent/pull/1896
     patch('icc.patch', when='%intel')

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -36,6 +36,4 @@ class PyGevent(PythonPackage):
     depends_on('py-zope-event', when='@20.5.1:', type=('build', 'run'))
     depends_on('py-zope-interface', when='@20.5.1:', type=('build', 'run'))
 
-    patch('icc.patch',
-          sha256='44a3aa7ec3a9f056145c25492012f494166dee4c816a3a998a7e3b2d85b57c77',
-          when='%intel')
+    patch('icc.patch', when='%intel')

--- a/var/spack/repos/builtin/packages/py-gevent/package.py
+++ b/var/spack/repos/builtin/packages/py-gevent/package.py
@@ -35,3 +35,7 @@ class PyGevent(PythonPackage):
     depends_on('py-greenlet@0.4.13:', when='@:1.4', type=('build', 'run'))
     depends_on('py-zope-event', when='@20.5.1:', type=('build', 'run'))
     depends_on('py-zope-interface', when='@20.5.1:', type=('build', 'run'))
+
+    patch('icc.patch',
+          sha256='44a3aa7ec3a9f056145c25492012f494166dee4c816a3a998a7e3b2d85b57c77',
+          when='%intel')


### PR DESCRIPTION
Upstream PR: https://github.com/gevent/gevent/pull/1896