### PR TITLE
file_cache.py: idempotent remove without races

### DIFF
--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -99,6 +99,7 @@ def test_cache_write_readonly_cache_fails(file_cache):
         file_cache.write_transaction(filename)
 
 
+@pytest.mark.regression('31475')
 def test_delete_is_idempotent(file_cache):
     """Deleting a non-existent key should be idempotent, to simplify life when
     running delete with multiple processes"""

--- a/lib/spack/spack/test/util/file_cache.py
+++ b/lib/spack/spack/test/util/file_cache.py
@@ -58,11 +58,9 @@ def test_write_and_remove_cache_file(file_cache):
     # After removal the file should not exist
     assert not os.path.exists(file_cache.cache_path('test.yaml'))
 
-    # The lock file should exist, since during deletion, another process might
-    # acquire a write lock. At some point in time, Spack used to delete the lock
-    # file *after* releasing the lock, which is a race condition. The simplest
-    # solution is to keep the lock around.
-    assert os.path.exists(file_cache._lock_path('test.yaml'))
+    # Whether the lock file exists is more of an implementation detail, on Linux they
+    # continue to exist, on Windows they don't.
+    # assert os.path.exists(file_cache._lock_path('test.yaml'))
 
 
 @pytest.mark.skipif(sys.platform == 'win32',

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -170,13 +170,17 @@ class FileCache(object):
             return sinfo.st_mtime
 
     def remove(self, key):
+        file = self.cache_path(key)
         lock = self._get_lock(key)
         try:
             lock.acquire_write()
-            os.unlink(self.cache_path(key))
+            # Note: on newer Python we should run os.unlink
+            # and catch FileNotFoundError instead.
+            if not os.path.lexists(file):
+                return
+            os.unlink(file)
         finally:
             lock.release_write()
-            lock.cleanup()
 
 
 class CacheError(SpackError):

--- a/lib/spack/spack/util/file_cache.py
+++ b/lib/spack/spack/util/file_cache.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import errno
 import os
 import shutil
 
@@ -174,11 +175,11 @@ class FileCache(object):
         lock = self._get_lock(key)
         try:
             lock.acquire_write()
-            # Note: on newer Python we should run os.unlink
-            # and catch FileNotFoundError instead.
-            if not os.path.lexists(file):
-                return
             os.unlink(file)
+        except OSError as e:
+            # File not found is OK, so remove is idempotent.
+            if e.errno != errno.ENOENT:
+                raise
         finally:
             lock.release_write()
 


### PR DESCRIPTION
Closes #31475

There's a bunch of issues with `.remove()`:

- Deleting the lock file after releasing the lock implies race conditions (another process may have acquired it):
   ```
   ==> Error: Attempted to close non-existing lock path: /home/harmen/.spack/cache/indices/.62a4a153a8_c373ec5d29.json.lock
   ```
- When multiple processes call `remove` on the same file, all but one error because the file is not found, which happens during parallel spack install on a fresh spack (binary cache has some delayed call to remove() which almost always runs into this).
- ~Releasing and removing the lock file runs into issues when a single processes holds read/write locks.~ (Maybe this isn't so bad, cause on Windows you can't delete a file if you have an open file descriptor? On Linux the file is unlinked but the inode remains... so not a very portable use case I guess)

The simplest solution:
- make .remove() idempotent so multiple deletes don't error
- don't delete locks so there are no races