### PR TITLE
Fix conditional dependencies for openCARP

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -14,7 +14,7 @@ class Meshtool(MakefilePackage):
 
     maintainers = ['MarieHouillon']
 
-    version('master', branch='master')
+    version('master', branch='master', preferred=True)
     # Version to use with openCARP releases
     version('oc10.0', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')
     version('oc9.0', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -40,8 +40,8 @@ class Opencarp(CMakePackage):
     depends_on('zlib')
     depends_on('perl')
 
-    depends_on('py-carputils')
-    depends_on('meshtool')
+    depends_on('py-carputils', when='+carputils')
+    depends_on('meshtool', when='+meshtool')
     # Use specific versions of carputils and meshtool for releases
     for ver in ['10.0', '9.0', '8.2', '7.0', '8.1']:
         depends_on('py-carputils@oc' + ver, when='@' + ver + ' +carputils')


### PR DESCRIPTION
- Fix meshtool and py-carputils inclusion as dependencies (included only if `+carputils +meshtool` variants are used)
- Set `master` branch as default version for meshtool