### PR TITLE
Cppcheck: fix install and convert to cmake build system

### DIFF
--- a/var/spack/repos/builtin/packages/cppcheck/package.py
+++ b/var/spack/repos/builtin/packages/cppcheck/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 
 
-class Cppcheck(MakefilePackage):
+class Cppcheck(CMakePackage):
     """A tool for static C/C++ code analysis."""
     homepage = "http://cppcheck.sourceforge.net/"
     url      = "https://downloads.sourceforge.net/project/cppcheck/cppcheck/1.78/cppcheck-1.78.tar.bz2"
@@ -24,17 +24,26 @@ class Cppcheck(MakefilePackage):
     version('1.72', sha256='9460b184ff2d8dd15344f3e2f42f634c86e4dd3303e1e9b3f13dc67536aab420')
     version('1.68', sha256='add6e5e12b05ca02b356cd0ec7420ae0dcafddeaef183b4dfbdef59c617349b1')
 
+    variant('rules', default=False, description="Enable rules (requires PCRE)")
     variant('htmlreport', default=False, description="Install cppcheck-htmlreport")
 
+    depends_on('pcre', when='+rules', type='build')
     depends_on('py-pygments', when='+htmlreport', type='run')
 
-    def build(self, spec, prefix):
-        make('CFGDIR={0}'.format(prefix.cfg))
+    def cmake_args(self):
+        args = []
+
+        if self.run_tests is False:
+            args.append('-DBUILD_TESTS=OFF')
+        else:
+            args.append('-DBUILD_TESTS=ON')
+
+        args.append(self.define_from_variant('HAVE_RULES', 'rules'))
+
+        return args
 
     def install(self, spec, prefix):
+        super(Cppcheck, self).install(spec, prefix)
         # Manually install the final cppcheck binary
-        mkdirp(prefix.bin)
-        install('cppcheck', prefix.bin)
-        install_tree('cfg', prefix.cfg)
         if spec.satisfies('+htmlreport'):
             install('htmlreport/cppcheck-htmlreport', prefix.bin)

--- a/var/spack/repos/builtin/packages/cppcheck/package.py
+++ b/var/spack/repos/builtin/packages/cppcheck/package.py
@@ -11,6 +11,8 @@ class Cppcheck(CMakePackage):
     homepage = "http://cppcheck.sourceforge.net/"
     url      = "https://downloads.sourceforge.net/project/cppcheck/cppcheck/1.78/cppcheck-1.78.tar.bz2"
 
+    maintainers = ['white238']
+
     version('2.8', sha256='a5ed97a99173d2952cd93fcb028a3405a7b3b992e7168e2ae9d527b991770203')
     version('2.7', sha256='ac74c0973c46a052760f4ff7ca6a84616ca5795510542d195a6f122c53079291')
     version('2.1', sha256='ab26eeef039e5b58aac01efb8cb664f2cc16bf9879c61bc93cd00c95be89a5f7')


### PR DESCRIPTION
I ran into a problem with building cppcheck.  It was installing the `cfg` directory at the same level as `bin` and got the following error:

```
[white238@rzgenie2:cppcheck-2.8]$ bin/cppcheck --check-config temp.cpp
cppcheck: Failed to load library configuration file 'std.cfg'. File not found
nofile:0:0: information: Failed to load std.cfg. Your Cppcheck installation is broken, please re-install. The Cppcheck binary was compiled without FILESDIR set. Either the std.cfg should be available in bin/cfg or the FILESDIR should be configured. [failedToLoadCfg]
```
I was able to move the `<install prefix>/cfg` to `<install prefix>/bin/cfg` manually and solve the problem.

I was going to just fix the package but after digging into their source realized they have a more maintained CMake build system. I also added a new variant for `rules`.

I tested this with a combination of the following specs on toss3:

- cppcheck
- cppcheck+rules
- cppcheck+htmlreport
- cppcheck+rules+htmlreport
