### PR TITLE
Don't use DESTDIR in man-db

### DIFF
--- a/var/spack/repos/builtin/packages/man-db/package.py
+++ b/var/spack/repos/builtin/packages/man-db/package.py
@@ -16,6 +16,7 @@ class ManDb(AutotoolsPackage):
     git      = "https://gitlab.com/cjwatson/man-db"
     url      = "https://download.savannah.nongnu.org/releases/man-db/man-db-2.10.1.tar.xz"
 
+    version('2.10.2', sha256='ee97954d492a13731903c9d0727b9b01e5089edbd695f0cdb58d405a5af5514d')
     version('2.10.1', sha256='2ffd8f2e80122fe72e60c740c851e6a3e15c9a7921185eb4752c1c672824bed6')
     version('2.7.6.1', sha256='08edbc52f24aca3eebac429b5444efd48b9b90b9b84ca0ed5507e5c13ed10f3f')
 
@@ -36,12 +37,9 @@ class ManDb(AutotoolsPackage):
     depends_on('xz',    type=('build', 'link', 'run'))
 
     def configure_args(self):
-        args = [
+        return [
             '--disable-setuid',
-            # defaults to a location that needs root privs to write in
-            '--with-systemdtmpfilesdir={0}/tmp'.format(self.prefix)
+            '--without-systemdsystemunitdir',
+            '--without-systemdtmpfilesdir'
         ]
-        return args
 
-    def install(self, spec, prefix):
-        make('install', 'DESTDIR=%s' % prefix)

--- a/var/spack/repos/builtin/packages/man-db/package.py
+++ b/var/spack/repos/builtin/packages/man-db/package.py
@@ -42,4 +42,3 @@ class ManDb(AutotoolsPackage):
             '--without-systemdsystemunitdir',
             '--without-systemdtmpfilesdir'
         ]
-


### PR DESCRIPTION
Autotools installs to `$DESTDIR/$prefix`, so using `DESTDIR` is a recipe for
disaster... the `man` executable was installed to `<install prefix>/<install
prefix>/bin/man`.

