### PR TITLE
environment.py: only acquire write lock when necessary

### DIFF
--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1612,9 +1612,10 @@ class Environment(object):
         # ensure specs already installed are marked explicit
         all_specs = specs or [cs for _, cs in self.concretized_specs()]
         specs_installed = [s for s in all_specs if s.installed]
-        with spack.store.db.write_transaction():  # do all in one transaction
-            for spec in specs_installed:
-                spack.store.db.update_explicit(spec, True)
+        if specs_installed:
+            with spack.store.db.write_transaction():  # do all in one transaction
+                for spec in specs_installed:
+                    spack.store.db.update_explicit(spec, True)
 
         if not specs_to_install:
             tty.msg('All of the packages are already installed')


### PR DESCRIPTION
This is a trivial change to make the lock timeout issue from #31387 unlikely to
happen.

The example https://github.com/spack/spack/issues/31387#issuecomment-1174741080
doesn't fail anymore in practice.

