### PR TITLE
env depfile: add missing touch

### DIFF
--- a/lib/spack/spack/cmd/env.py
+++ b/lib/spack/spack/cmd/env.py
@@ -594,6 +594,7 @@ def env_depfile(args):
 {}: {}
 
 {}: {}
+\t@touch $@
 
 {}:
 \t@mkdir -p {}


### PR DESCRIPTION
Oversight in #31433, the non-phony `env` target was missing a file being
created for it, which can cause make to infinitely loop when including
multiple generated makefiles.

(Should just add an integration test for this soon :tm:)
