### PR TITLE
py-mypy: add v0.961

### DIFF
--- a/var/spack/repos/builtin/packages/py-mypy/package.py
+++ b/var/spack/repos/builtin/packages/py-mypy/package.py
@@ -12,6 +12,14 @@ class PyMypy(PythonPackage):
     homepage = "http://www.mypy-lang.org/"
     pypi = "mypy/mypy-0.740.tar.gz"
 
+    maintainers = ['adamjstewart']
+
+    version('0.961', sha256='f730d56cb924d371c26b8eaddeea3cc07d78ff51c521c6d04899ac6904b75492')
+    version('0.960', sha256='d4fccf04c1acf750babd74252e0f2db6bd2ac3aa8fe960797d9f3ef41cf2bfd4')
+    version('0.950', sha256='1b333cfbca1762ff15808a0ef4f71b5d3eed8528b23ea1c3fb50543c867d68de')
+    version('0.942', sha256='17e44649fec92e9f82102b48a3bf7b4a5510ad0cd22fa21a104826b5db4903e2')
+    version('0.941', sha256='cbcc691d8b507d54cb2b8521f0a2a3d4daa477f62fe77f0abba41e5febb377b7')
+    version('0.940', sha256='71bec3d2782d0b1fecef7b1c436253544d81c1c0e9ca58190aed9befd8f081c5')
     version('0.931', sha256='0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce')
     version('0.930', sha256='51426262ae4714cc7dd5439814676e0992b55bcc0f6514eccb4cf8e0678962c2')
     version('0.921', sha256='eca089d7053dff45d6dcd5bf67f1cabc311591e85d378917d97363e7c13da088')
@@ -39,6 +47,7 @@ class PyMypy(PythonPackage):
     depends_on('py-mypy-extensions@0.4.3:', when='@0.930:', type=('build', 'run'))
     depends_on('py-mypy-extensions@0.4.3:0.4', when='@0.700:0.929', type=('build', 'run'))
     depends_on('py-mypy-extensions@0.4.0:0.4', when='@:0.699', type=('build', 'run'))
-    depends_on('py-tomli@1.1:', when='@0.930:', type=('build', 'run'))
+    depends_on('py-tomli@1.1:', when='@0.950: ^python@:3.10', type=('build', 'run'))
+    depends_on('py-tomli@1.1:', when='@0.930:0.949', type=('build', 'run'))
     depends_on('py-tomli@1.1:2', when='@0.920:0.929', type=('build', 'run'))
     depends_on('py-toml', when='@0.900:0.910', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 12.4 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6.