### PR TITLE
py-gpytorch: add v1.7.0

### DIFF
--- a/var/spack/repos/builtin/packages/py-gpytorch/package.py
+++ b/var/spack/repos/builtin/packages/py-gpytorch/package.py
@@ -17,17 +17,21 @@ class PyGpytorch(PythonPackage):
 
     maintainers = ['adamjstewart']
 
+    version('1.7.0', sha256='e91cb8a1883d54f8f57cebbc0c61c227b3cd72528d8e90e770f971fc4e408538')
     version('1.6.0', sha256='08e8f1a80669dc3eee5ba237fc00c867a8858f9b186bbec8571a8cf9af36f543')
     version('1.2.1', sha256='ddd746529863d5419872610af23b1a1b0e8a29742131c9d9d2b4f9cae3c90781')
     version('1.2.0', sha256='fcb216e0c1f128a41c91065766508e91e487d6ffadf212a51677d8014aefca84')
     version('1.1.1', sha256='76bd455db2f17af5425f73acfaa6d61b8adb1f07ad4881c0fa22673f84fb571a')
 
+    depends_on('python@3.7:', when='@1.7:', type=('build', 'run'))
     depends_on('python@3.6:', type=('build', 'run'))
     depends_on('py-setuptools', type='build')
+    depends_on('py-torch@1.10:', when='@1.7:', type=('build', 'run'))
     depends_on('py-torch@1.9:', when='@1.6:', type=('build', 'run'))
     depends_on('py-torch@1.8.1:', when='@1.5:', type=('build', 'run'))
     depends_on('py-torch@1.7:', when='@1.3:', type=('build', 'run'))
     depends_on('py-torch@1.6:', when='@1.2:', type=('build', 'run'))
     depends_on('py-torch@1.5:', type=('build', 'run'))
+    depends_on('py-numpy', when='@1.7:', type=('build', 'run'))
     depends_on('py-scikit-learn', when='@1.2:', type=('build', 'run'))
     depends_on('py-scipy', when='@1.2:', type=('build', 'run'))


### PR DESCRIPTION
Successfully builds on macOS 12.4 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6.