### PR TITLE
Use lexists instead of exists

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -401,7 +401,7 @@ class URLFetchStrategy(FetchStrategy):
             # clean up archive on failure.
             if self.archive_file:
                 os.remove(self.archive_file)
-            if save_file and os.path.exists(save_file):
+            if save_file and os.path.lexists(save_file):
                 os.remove(save_file)
             msg = 'urllib failed to fetch with error {0}'.format(e)
             raise FailedDownloadError(url, msg)
@@ -471,7 +471,7 @@ class URLFetchStrategy(FetchStrategy):
             if self.archive_file:
                 os.remove(self.archive_file)
 
-            if partial_file and os.path.exists(partial_file):
+            if partial_file and os.path.lexists(partial_file):
                 os.remove(partial_file)
 
             if curl.returncode == 22:
@@ -613,7 +613,7 @@ class CacheURLFetchStrategy(URLFetchStrategy):
 
         # remove old symlink if one is there.
         filename = self.stage.save_filename
-        if os.path.exists(filename):
+        if os.path.lexists(filename):
             os.remove(filename)
 
         # Symlink to local cached archive.

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -397,7 +397,7 @@ class URLFetchStrategy(FetchStrategy):
             # clean up archive on failure.
             if self.archive_file:
                 os.remove(self.archive_file)
-            if save_file and os.path.lexists(save_file):
+            if os.path.lexists(save_file):
                 os.remove(save_file)
             msg = 'urllib failed to fetch with error {0}'.format(e)
             raise FailedDownloadError(url, msg)


### PR DESCRIPTION
Apparently the first time spack downloads sources it puts an archive as a file
in the stage dir, the second time it's cached, and then to save space only a
symlink is put in the stage dir instead.

When interrupting `spack install` of a package with sources cached, sometimes
a symlink to the archive remains in the stage dir, and the next time you
run `spack install` after `spack clean -d`, the symlink is dangling, so any
attempt to check for `os.path.exists` and `open` will fail. Instead, use 
`lexists` and remove a (possible) dangling symlink before `open`.

Reproducer:

```console
$ spack clean -sd && spack stage zlib && spack stage zlib && spack clean -d && spack -d stage zlib
==> Removing all temporary build stages
==> Removing cached downloads
==> Fetching https://mirror.spack.io/_source-cache/archive/91/91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9.tar.gz
==> Staged zlib in /tmp/harmen/spack-stage/spack-stage-zlib-1.2.12-hort4xovrsh6sg46q4tudbxscjwgnyrn
==> Using cached archive: /home/harmen/spack/var/spack/cache/_source-cache/archive/91/91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9.tar.gz
==> Staged zlib in /tmp/harmen/spack-stage/spack-stage-zlib-1.2.12-hort4xovrsh6sg46q4tudbxscjwgnyrn
==> Removing cached downloads
==> Fetching https://mirror.spack.io/_source-cache/archive/91/91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9.tar.gz
==> Error: [Errno 2] No such file or directory: '/tmp/harmen/spack-stage/spack-stage-zlib-1.2.12-hort4xovrsh6sg46q4tudbxscjwgnyrn/zlib-1.2.12.tar.gz'
```
