### PR TITLE
py-hatchling: add new packages, document new build backend

### DIFF
--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -48,7 +48,7 @@ important to understand.
 **build backend**
    Libraries used to define how to build a wheel. Examples
    include `setuptools <https://setuptools.pypa.io/>`__,
-   `flit <https://flit.readthedocs.io/>`_, and
+   `flit <https://flit.readthedocs.io/>`_,
    `poetry <https://python-poetry.org/>`_, and
    `hatchling <https://hatch.pypa.io/latest/>`_.
 
@@ -348,7 +348,7 @@ dependencies under the following keys:
 
   This section includes keys with lists of optional dependencies
   needed to enable those features. You should add a variant that
-  optionally adds these dependencies. This variant should be False
+  optionally adds these dependencies. This variant should be ``False``
   by default.
 
 See https://hatch.pypa.io/latest/config/dependency/ for more

--- a/lib/spack/docs/build_systems/pythonpackage.rst
+++ b/lib/spack/docs/build_systems/pythonpackage.rst
@@ -49,7 +49,8 @@ important to understand.
    Libraries used to define how to build a wheel. Examples
    include `setuptools <https://setuptools.pypa.io/>`__,
    `flit <https://flit.readthedocs.io/>`_, and
-   `poetry <https://python-poetry.org/>`_.
+   `poetry <https://python-poetry.org/>`_, and
+   `hatchling <https://hatch.pypa.io/latest/>`_.
 
 ^^^^^^^^^^^
 Downloading
@@ -325,6 +326,33 @@ listed in a ``[tool.poetry.dependencies]`` section, and use a
 for specifying the version requirements. Note that ``~=`` works
 differently in poetry than in setuptools and flit for versions that
 start with a zero.
+
+"""""""""
+hatchling
+"""""""""
+
+If the ``pyproject.toml`` lists ``hatchling.build`` as the
+``build-backend``, it uses the hatchling build system. Look for
+dependencies under the following keys:
+
+* ``requires-python``
+
+  This specifies the version of Python that is required
+
+* ``project.dependencies``
+
+  These packages are required for building and installation. You can
+  add them with ``type=('build', 'run')``.
+
+* ``project.optional-dependencies``
+
+  This section includes keys with lists of optional dependencies
+  needed to enable those features. You should add a variant that
+  optionally adds these dependencies. This variant should be False
+  by default.
+
+See https://hatch.pypa.io/latest/config/dependency/ for more
+information.
 
 """"""
 wheels
@@ -666,3 +694,4 @@ For more information on build backend tools, see:
 * setuptools: https://setuptools.pypa.io/
 * flit: https://flit.readthedocs.io/
 * poetry: https://python-poetry.org/
+* hatchling: https://hatch.pypa.io/latest/

--- a/var/spack/repos/builtin/packages/py-editables/package.py
+++ b/var/spack/repos/builtin/packages/py-editables/package.py
@@ -1,0 +1,18 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyEditables(PythonPackage):
+    """A Python library for creating "editable wheels"."""
+
+    homepage = "https://github.com/pfmoore/editables"
+    pypi     = "editables/editables-0.3.tar.gz"
+
+    version('0.3', sha256='167524e377358ed1f1374e61c268f0d7a4bf7dbd046c656f7b410cde16161b1a')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-setuptools@42:', type='build')

--- a/var/spack/repos/builtin/packages/py-hatchling/package.py
+++ b/var/spack/repos/builtin/packages/py-hatchling/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyHatchling(PythonPackage):
+    """Modern, extensible Python build backend."""
+
+    homepage = "https://hatch.pypa.io/latest/"
+    pypi     = "hatchling/hatchling-1.4.1.tar.gz"
+
+    version('1.4.1', sha256='13461b42876ade4f75ee5d2a2c656b288ca0aab7f048ef66657ef166996b2118')
+
+    depends_on('python@3.7:', type=('build', 'run'))
+    depends_on('py-editables@0.3:', type=('build', 'run'))
+    depends_on('py-importlib-metadata', when='^python@:3.7', type=('build', 'run'))
+    depends_on('py-packaging@21.3:', type=('build', 'run'))
+    depends_on('py-pathspec@0.9:', type=('build', 'run'))
+    depends_on('py-pluggy@1:', type=('build', 'run'))
+    depends_on('py-tomli@1.2.2:', when='^python@:3.10', type=('build', 'run'))


### PR DESCRIPTION
Every 6 months or so, PyPA runs out of things to do and rewrites the entire Python build system from scratch. Most recently, they now recommend all new packages use hatchling instead of setuptools. This PR adds the hatchling package and documents it in our PythonPackage build systems guide.

Successfully installs on macOS 12.4 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6. Tested by building another package that uses the hatchling build backend (will add in a separate PR).