### PR TITLE
Openfoam-org: support 3.0.1 version

### DIFF
--- a/var/spack/repos/builtin/packages/openfoam-org/301-code.patch
+++ b/var/spack/repos/builtin/packages/openfoam-org/301-code.patch
@@ -1,0 +1,141 @@
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L OpenFOAM-3.0.x-versionnew-3.0.1/applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L
+--- OpenFOAM-3.0.x-version-3.0.1/applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/applications/utilities/mesh/conversion/ansysToFoam/ansysToFoam.L	2021-06-29 16:52:53.468415395 +0800
+@@ -77,7 +77,7 @@
+ // Dummy yywrap to keep yylex happy at compile time.
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L OpenFOAM-3.0.x-versionnew-3.0.1/applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L
+--- OpenFOAM-3.0.x-version-3.0.1/applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/applications/utilities/mesh/conversion/fluent3DMeshToFoam/fluent3DMeshToFoam.L	2021-06-29 16:52:53.484415646 +0800
+@@ -123,7 +123,7 @@
+ // Dummy yywrap to keep yylex happy at compile time.
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L OpenFOAM-3.0.x-versionnew-3.0.1/applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L
+--- OpenFOAM-3.0.x-version-3.0.1/applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/applications/utilities/mesh/conversion/fluentMeshToFoam/fluentMeshToFoam.L	2021-06-29 16:52:53.514416116 +0800
+@@ -100,7 +100,7 @@
+ // Dummy yywrap to keep yylex happy at compile time.
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L OpenFOAM-3.0.x-versionnew-3.0.1/applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L
+--- OpenFOAM-3.0.x-version-3.0.1/applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/applications/utilities/mesh/conversion/gambitToFoam/gambitToFoam.L	2021-06-29 16:52:53.496415834 +0800
+@@ -80,7 +80,7 @@
+ // Dummy yywrap to keep yylex happy at compile time.
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L OpenFOAM-3.0.x-versionnew-3.0.1/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L
+--- OpenFOAM-3.0.x-version-3.0.1/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/src/surfMesh/surfaceFormats/stl/STLsurfaceFormatASCII.L	2021-06-29 16:52:53.460415270 +0800
+@@ -50,7 +50,7 @@
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+ //! \cond dummy
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L OpenFOAM-3.0.x-versionnew-3.0.1/src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L
+--- OpenFOAM-3.0.x-version-3.0.1/src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/src/thermophysicalModels/reactionThermo/chemistryReaders/chemkinReader/chemkinLexer.L	2021-06-29 16:52:53.449415097 +0800
+@@ -54,7 +54,7 @@
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+ //! \cond dummy
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/src/triSurface/triSurface/interfaces/STL/readSTLASCII.L OpenFOAM-3.0.x-versionnew-3.0.1/src/triSurface/triSurface/interfaces/STL/readSTLASCII.L
+--- OpenFOAM-3.0.x-version-3.0.1/src/triSurface/triSurface/interfaces/STL/readSTLASCII.L	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/src/triSurface/triSurface/interfaces/STL/readSTLASCII.L	2021-06-29 16:52:53.455415191 +0800
+@@ -55,7 +55,7 @@
+ // It is called by yylex but is not used as the mechanism to change file.
+ // See <<EOF>>
+ //! \cond dummy
+-#if YY_FLEX_SUBMINOR_VERSION < 34
++#if YY_FLEX_MINOR_VERSION < 6 && YY_FLEX_SUBMINOR_VERSION < 34
+ extern "C" int yywrap()
+ #else
+ int yyFlexLexer::yywrap()
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/src/finiteVolume/fields/fvPatchFields/derived/oscillatingFixedValue/oscillatingFixedValueFvPatchField.H OpenFOAM-3.0.x-versionnew-3.0.1/src/finiteVolume/fields/fvPatchFields/derived/oscillatingFixedValue/oscillatingFixedValueFvPatchField.H
+--- OpenFOAM-3.0.x-version-3.0.1/src/finiteVolume/fields/fvPatchFields/derived/oscillatingFixedValue/oscillatingFixedValueFvPatchField.H	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/src/finiteVolume/fields/fvPatchFields/derived/oscillatingFixedValue/oscillatingFixedValueFvPatchField.H	2021-06-29 13:16:28.289034866 +0800
+@@ -211,23 +211,23 @@
+             }
+ 
+             //- Return amplitude
+-            scalar amplitude() const
++            autoPtr<DataEntry<scalar> >  amplitude() const
+             {
+                 return amplitude_;
+             }
+ 
+-            scalar& amplitude()
++            autoPtr<DataEntry<scalar> >& amplitude()
+             {
+                 return amplitude_;
+             }
+ 
+             //- Return frequency
+-            scalar frequency() const
++            autoPtr<DataEntry<scalar> > frequency() const
+             {
+                 return frequency_;
+             }
+ 
+-            scalar& frequency()
++            autoPtr<DataEntry<scalar> >& frequency()
+             {
+                 return frequency_;
+             }
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/src/thermophysicalModels/specie/reaction/Reactions/Reaction/Reaction.H OpenFOAM-3.0.x-versionnew-3.0.1/src/thermophysicalModels/specie/reaction/Reactions/Reaction/Reaction.H
+--- OpenFOAM-3.0.x-version-3.0.1/src/thermophysicalModels/specie/reaction/Reactions/Reaction/Reaction.H	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/src/thermophysicalModels/specie/reaction/Reactions/Reaction/Reaction.H	2021-06-29 14:11:00.327268364 +0800
+@@ -301,7 +301,7 @@
+ 
+         // Access
+ 
+-            inline word& name();
++            inline const word& name();
+             inline const word& name() const;
+ 
+             // - Access to basic components of the reaction
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/src/thermophysicalModels/specie/reaction/Reactions/Reaction/ReactionI.H OpenFOAM-3.0.x-versionnew-3.0.1/src/thermophysicalModels/specie/reaction/Reactions/Reaction/ReactionI.H
+--- OpenFOAM-3.0.x-version-3.0.1/src/thermophysicalModels/specie/reaction/Reactions/Reaction/ReactionI.H	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/src/thermophysicalModels/specie/reaction/Reactions/Reaction/ReactionI.H	2021-06-29 14:10:35.017871966 +0800
+@@ -33,7 +33,7 @@
+ // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+ 
+ template<class ReactionThermo>
+-inline word& Reaction<ReactionThermo>::name()
++inline const word& Reaction<ReactionThermo>::name()
+ {
+     return name_;
+ }
+

--- a/var/spack/repos/builtin/packages/openfoam-org/301-etc.patch
+++ b/var/spack/repos/builtin/packages/openfoam-org/301-etc.patch
@@ -1,0 +1,21 @@
+diff -Naur OpenFOAM-3.0.x-version-3.0.1/etc/bashrc OpenFOAM-3.0.x-versionnew-3.0.1/etc/bashrc
+--- OpenFOAM-3.0.x-version-3.0.1/etc/bashrc	2015-12-15 19:20:08.000000000 +0800
++++ OpenFOAM-3.0.x-versionnew-3.0.1/etc/bashrc	2021-06-30 10:01:08.270589612 +0800
+@@ -32,7 +32,7 @@
+ #------------------------------------------------------------------------------
+ 
+ export WM_PROJECT=OpenFOAM
+-export WM_PROJECT_VERSION=3.0.x
++export WM_PROJECT_VERSION=3.0.1
+ 
+ ################################################################################
+ # USER EDITABLE PART: Changes made here may be lost with the next upgrade
+@@ -55,6 +55,8 @@
+ # overridden from the prefs.sh file or from command-line specification
+ #
+ #- note the location for later use (eg, in job scripts)
++rc="${BASH_SOURCE:-${ZSH_NAME:+$0}}"
++[ -n "$rc" ] && FOAM_INST_DIR=$(\cd $(dirname $rc)/../.. && \pwd -L) || \
+ : ${FOAM_INST_DIR:=$foamInstall}; export FOAM_INST_DIR
+ 
+ #- Compiler location:

--- a/var/spack/repos/builtin/packages/openfoam-org/50-code.patch
+++ b/var/spack/repos/builtin/packages/openfoam-org/50-code.patch
@@ -1,0 +1,33 @@
+--- a/src/OpenFOAM/containers/Lists/PackedList/PackedListI.old.H	2021-06-29 17:40:34.891266083 +0800
++++ b/src/OpenFOAM/containers/Lists/PackedList/PackedListI.H	2021-06-21 17:39:12.000000000 +0800
+@@ -547,7 +547,7 @@
+         this->index_ = this->list_->size_;
+     }
+ 
+-    return *this;
++    //return *this;
+ }
+ 
+ 
+--- a/src/thermophysicalModels/specie/reaction/Reactions/Reaction/Reaction.old.H	2021-06-29 17:48:09.254388320 +0800
++++ b/src/thermophysicalModels/specie/reaction/Reactions/Reaction/Reaction.H	2021-06-22 10:01:10.000000000 +0800
+@@ -242,7 +242,7 @@
+ 
+         // Access
+ 
+-            inline word& name();
++            inline const word& name();
+             inline const word& name() const;
+ 
+             // - Access to basic components of the reaction
+--- a/src/thermophysicalModels/specie/reaction/Reactions/Reaction/ReactionI.old.H	2021-06-29 17:47:54.633159095 +0800
++++ b/src/thermophysicalModels/specie/reaction/Reactions/Reaction/ReactionI.H	2021-06-21 22:01:23.000000000 +0800
+@@ -33,7 +33,7 @@
+ // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+ 
+ template<class ReactionThermo>
+-inline word& Reaction<ReactionThermo>::name()
++inline const word& Reaction<ReactionThermo>::name()
+ {
+     return name_;
+ }

--- a/var/spack/repos/builtin/packages/openfoam-org/package.py
+++ b/var/spack/repos/builtin/packages/openfoam-org/package.py
@@ -77,6 +77,8 @@ class OpenfoamOrg(Package):
             url=baseurl + '/OpenFOAM-5.x/archive/version-5.0.tar.gz')
     version('4.1', sha256='2de18de64e7abdb1b649ad8e9d2d58b77a2b188fb5bcb6f7c2a038282081fd31',
             url=baseurl + '/OpenFOAM-4.x/archive/version-4.1.tar.gz')
+    version('3.0.1', sha256='4b7d25a17f5fb075e206d7fbdf863253335f705538df6404c6ca44f6147953c3',
+            url=baseurl + '/OpenFOAM-3.0.x/archive/version-3.0.1.tar.gz')
     version('2.4.0', sha256='9529aa7441b64210c400c019dcb2e0410fcfd62a6f62d23b6c5994c4753c4465',
             url=baseurl + '/OpenFOAM-2.4.x/archive/version-2.4.0.tar.gz')
     version('2.3.1', sha256='2bbcf4d5932397c2087a9b6d7eeee6d2b1350c8ea4f455415f05e7cd94d9e5ba',
@@ -111,8 +113,13 @@ class OpenfoamOrg(Package):
     patch('https://github.com/OpenFOAM/OpenFOAM-7/commit/ef33cf38ac9b811072a8970c71fbda35a90f6641.patch?full_index=1',
           sha256='05d17e17f94e6fe8188a9c0b91ed34c9b62259414589d908c152a4c40fe6b7e2', when='@7')
     patch('50-etc.patch', when='@5.0:5.9')
+    ## Modify source code（version5.0） to adapt to higher versions of gcc compiler
+    patch('50-code.patch', when='@5.0')
     patch('41-etc.patch', when='@4.1')
     patch('41-site.patch', when='@4.1:')
+    # Modify code and configuration（version3.0.1）
+    patch('301-etc.patch', when='@3.0.1')
+    patch('301-code.patch', when='@3.0.1')
     patch('240-etc.patch', when='@:2.4.0')
     patch('isnan.patch', when='@:2.4.0')
     # Add support for SYSTEMMPI


### PR DESCRIPTION
> Thanks for bringing order to HPC software chaos. My organization have been using Spack since 2019 and thanks to Spack we could make software management in order without pain. During this period, we have extended Spack and now we are bringing them back to community. May our contributions be a small step in the great leap of HPC softwawre development.

This PR adds support for 3.0.1 version, which is needed by CFDEM software. See https://github.com/spack/spack/pull/31536