### PR TITLE
Liggghts: support lib installation

### DIFF
--- a/var/spack/repos/builtin/packages/liggghts/package.py
+++ b/var/spack/repos/builtin/packages/liggghts/package.py
@@ -118,7 +118,7 @@ class Liggghts(MakefilePackage):
         libs_in_spec = spec.variants['libs'].value
         if libs_in_spec != None:
             mkdir(prefix.lib)
-            if 'shared' in libs_in_spec:
+            if spec.satisfies("libs=shared"):
                 install(os.path.join('src', 'liblmp_auto.so'), prefix.lib)
             if 'static' in libs_in_spec:
                 install(os.path.join('src', 'liblmp_auto.a'), prefix.lib)

--- a/var/spack/repos/builtin/packages/liggghts/package.py
+++ b/var/spack/repos/builtin/packages/liggghts/package.py
@@ -94,16 +94,14 @@ class Liggghts(MakefilePackage):
             makefile.filter(r'^(USE_PROFILE = ).*', r'\1"ON"')
 
         # Determine how to build libs in LIGGGHTS way
-        libs_in_spec = spec.variants['libs'].value
-        if libs_in_spec != None:
-            if 'shared' in libs_in_spec and 'static' in libs_in_spec:
-                libs_in_makefile = 'ALL'
-            elif 'shared' in libs_in_spec:
-                libs_in_makefile = 'SHARED'
-            elif 'static' in libs_in_spec:
-                libs_in_makefile = 'STATIC'
-            makefile.filter(r'^(BUILD_LIBRARIES = ).*',
-                            r'\1"{0}"'.format(libs_in_makefile))
+        if spec.satisfies("libs=shared") and spec.satisfies("libs=static"):
+            libs_in_makefile = 'ALL'
+        elif spec.satisfies("libs=shared"):
+            libs_in_makefile = 'SHARED'
+        elif spec.satisfies("libs=static"):
+            libs_in_makefile = 'STATIC'
+        makefile.filter(r'^(BUILD_LIBRARIES = ).*',
+                        r'\1"{0}"'.format(libs_in_makefile))
 
         # Enable debug output of Makefile.auto in the log file
         # src/Obj_auto/make_auto.log to quickly troubleshoot if
@@ -115,12 +113,10 @@ class Liggghts(MakefilePackage):
         install(os.path.join('src', 'lmp_auto'), prefix.bin.liggghts)
 
         # Install libs
-        libs_in_spec = spec.variants['libs'].value
-        if libs_in_spec != None:
-            mkdir(prefix.lib)
-            if spec.satisfies("libs=shared"):
-                install(os.path.join('src', 'liblmp_auto.so'), prefix.lib)
-            if 'static' in libs_in_spec:
-                install(os.path.join('src', 'liblmp_auto.a'), prefix.lib)
+        mkdir(prefix.lib)
+        if spec.satisfies("libs=shared"):
+            install(os.path.join('src', 'liblmp_auto.so'), prefix.lib)
+        if spec.satisfies("libs=static"):
+            install(os.path.join('src', 'liblmp_auto.a'), prefix.lib)
 
         install_tree('src', prefix.src, symlinks=True)

--- a/var/spack/repos/builtin/packages/liggghts/package.py
+++ b/var/spack/repos/builtin/packages/liggghts/package.py
@@ -26,7 +26,7 @@ class Liggghts(MakefilePackage):
     variant('profile', default=False,
             description='Generate profiling code')
 
-    variant('libs', default='shared, static',
+    variant('libs', default='shared,static',
             description='Build shared or/and static libs',
             values=('shared', 'static'), multi=True)
 


### PR DESCRIPTION
> Thanks for bringing order to HPC software chaos. My organization have been using Spack since 2019 and thanks to Spack we could make software management in order without pain. During this period, we have extended Spack and now we are bringing them back to community. May our contributions be a small step in the great leap of HPC softwawre development.

This PR adds support for lib installation, which is needed by CFDEM software. See https://github.com/spack/spack/pull/31536