### PR TITLE
compression.py: do not extract absolute & relative .. paths

### DIFF
--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -96,3 +96,9 @@ def test_get_bad_extension():
 @pytest.mark.parametrize('path', ext_archive.values())
 def test_allowed_archvie(path):
     assert scomp.allowed_archive(path)
+
+
+def test_is_trusted_tar_path():
+    assert not scomp.is_trusted_tar_path(os.path.abspath("."))
+    assert not scomp.is_trusted_tar_path(os.path.join("..", "a", "b"))
+    assert scomp.is_trusted_tar_path(os.path.join(".", "a", "b"))


### PR DESCRIPTION
Don't extract by absolute paths, and do not allow `..` path components.

Note that the latter is possibly more strict than `tar -x`, the alternative would be to add a depth counter and make sure it's never negative. Another way to handle the former would be to strip the root `/` and still extract, but I don't wanna think about windows drive prefixes etc. 

Fixes a regression caused by Windows support.
