### PR TITLE
Whats new in AOCL 3.2

### DIFF
--- a/var/spack/repos/builtin/packages/amd-aocl/package.py
+++ b/var/spack/repos/builtin/packages/amd-aocl/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)

--- a/var/spack/repos/builtin/packages/amd-aocl/package.py
+++ b/var/spack/repos/builtin/packages/amd-aocl/package.py
@@ -1,0 +1,36 @@
+# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class AmdAocl(BundlePackage):
+    """AMD Optimizing CPU Libraries (AOCL) - AOCL is a set of numerical
+       libraries tuned specifically for AMD EPYC processor family. They have a
+       simple interface to take advantage of the latest hardware innovations.
+       The tuned implementations of industry standard  math libraries enable
+       fast development of scientific and high performance computing projects"""
+
+    homepage = "https://developer.amd.com/amd-aocl/"
+
+    maintainers = ['amd-toolchain-support']
+
+    version('3.2')
+    version('3.1')
+    version('3.0')
+    version('2.2')
+
+    variant('openmp', default=False, description="Enable OpenMP support.")
+
+    for vers in ['2.2', '3.0', '3.1', '3.2']:
+        depends_on('amdblis@{0} threads=openmp'.format(vers), when='@{0} +openmp'.format(vers))
+        depends_on('amdblis@{0}'.format(vers), when='@{0} ~openmp'.format(vers))
+        depends_on('amdfftw@{0} +openmp'.format(vers), when='@{0} +openmp'.format(vers))
+        depends_on('amdfftw@{0}'.format(vers), when='@{0} ~openmp'.format(vers))
+        depends_on('amdlibflame@{0}'.format(vers), when='@{0}'.format(vers))
+        depends_on('amdlibm@{0}'.format(vers), when='@{0}'.format(vers))
+        depends_on('amdscalapack@{0}'.format(vers), when='@{0} ~openmp'.format(vers))
+        depends_on('amdscalapack@{0} ^amdblis@{0} threads=openmp'.format(vers), when='@{0} +openmp'.format(vers))
+        depends_on('aocl-sparse@{0}'.format(vers), when='@{0}'.format(vers))

--- a/var/spack/repos/builtin/packages/amd-aocl/package.py
+++ b/var/spack/repos/builtin/packages/amd-aocl/package.py
@@ -26,11 +26,11 @@ class AmdAocl(BundlePackage):
 
     for vers in ['2.2', '3.0', '3.1', '3.2']:
         depends_on('amdblis@{0} threads=openmp'.format(vers), when='@{0} +openmp'.format(vers))
-        depends_on('amdblis@{0}'.format(vers), when='@{0} ~openmp'.format(vers))
+        depends_on('amdblis@{0} threads=none'.format(vers), when='@{0} ~openmp'.format(vers))
         depends_on('amdfftw@{0} +openmp'.format(vers), when='@{0} +openmp'.format(vers))
-        depends_on('amdfftw@{0}'.format(vers), when='@{0} ~openmp'.format(vers))
+        depends_on('amdfftw@{0} ~openmp'.format(vers), when='@{0} ~openmp'.format(vers))
         depends_on('amdlibflame@{0}'.format(vers), when='@{0}'.format(vers))
         depends_on('amdlibm@{0}'.format(vers), when='@{0}'.format(vers))
-        depends_on('amdscalapack@{0}'.format(vers), when='@{0} ~openmp'.format(vers))
+        depends_on('amdscalapack@{0} ^amdblis@{0} threads=none'.format(vers), when='@{0} ~openmp'.format(vers))
         depends_on('amdscalapack@{0} ^amdblis@{0} threads=openmp'.format(vers), when='@{0} +openmp'.format(vers))
         depends_on('aocl-sparse@{0}'.format(vers), when='@{0}'.format(vers))

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -23,12 +23,18 @@ class Amdblis(BlisBase):
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.2', sha256='5a400ee4fc324e224e12f73cc37b915a00f92b400443b15ce3350278ad46fff6')
     version('3.1', sha256='2891948925b9db99eec02a1917d9887a7bee9ad2afc5421c9ba58602a620f2bf')
     version('3.0.1', sha256='dff643e6ef946846e91e8f81b75ff8fe21f1f2d227599aecd654d184d9beff3e')
     version('3.0', sha256='ac848c040cd6c3550fe49148dbdf109216cad72d3235763ee7ee8134e1528517')
     version('2.2', sha256='e1feb60ac919cf6d233c43c424f6a8a11eab2c62c2c6e3f2652c15ee9063c0c9')
 
     variant('ilp64', default=False, when='@3.0.1:', description='ILP64 support')
+
+    conflicts(
+        '+ilp64',
+        when='@:3.0.0',
+        msg='ilp64 is supported from amdblis 3.0.1 version onwards')
 
     def configure_args(self):
         spec = self.spec

--- a/var/spack/repos/builtin/packages/amdblis/package.py
+++ b/var/spack/repos/builtin/packages/amdblis/package.py
@@ -31,11 +31,6 @@ class Amdblis(BlisBase):
 
     variant('ilp64', default=False, when='@3.0.1:', description='ILP64 support')
 
-    conflicts(
-        '+ilp64',
-        when='@:3.0.0',
-        msg='ilp64 is supported from amdblis 3.0.1 version onwards')
-
     def configure_args(self):
         spec = self.spec
         args = super(Amdblis, self).configure_args()

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -74,6 +74,7 @@ class Amdfftw(FftwBase):
     variant(
         'amd-dynamic-dispatcher',
         default=False,
+        when='@3.2:',
         description='Single portable optimized library'
                     ' to execute on different x86 CPU architectures')
 
@@ -181,10 +182,6 @@ class Amdfftw(FftwBase):
         '+amd-dynamic-dispatcher',
         when='%aocc',
         msg='dynamic-dispatcher is not supported by AOCC clang compiler')
-    conflicts(
-        '+amd-dynamic-dispatcher',
-        when='@:3.1',
-        msg='dynamic-dispatcher is supported from 3.2 version onwards')
 
     def configure(self, spec, prefix):
         """Configure function"""

--- a/var/spack/repos/builtin/packages/amdfftw/package.py
+++ b/var/spack/repos/builtin/packages/amdfftw/package.py
@@ -31,6 +31,7 @@ class Amdfftw(FftwBase):
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.2', sha256='31cab17a93e03b5b606e88dd6116a1055b8f49542d7d0890dbfcca057087b8d0')
     version('3.1', sha256='3e777f3acef13fa1910db097e818b1d0d03a6a36ef41186247c6ab1ab0afc132')
     version('3.0.1', sha256='87030c6bbb9c710f0a64f4f306ba6aa91dc4b182bb804c9022b35aef274d1a4c')
     version('3.0', sha256='a69deaf45478a59a69f77c4f7e9872967f1cfe996592dd12beb6318f18ea0bcd')
@@ -70,6 +71,11 @@ class Amdfftw(FftwBase):
         'amd-app-opt',
         default=False,
         description='Build with amd-app-opt suppport')
+    variant(
+        'amd-dynamic-dispatcher',
+        default=False,
+        description='Single portable optimized library'
+                    ' to execute on different x86 CPU architectures')
 
     depends_on('texinfo')
 
@@ -87,10 +93,6 @@ class Amdfftw(FftwBase):
         '%gcc@:7.2',
         when='@2.2:',
         msg='GCC version above 7.2 is required for AMDFFTW')
-    conflicts(
-        '+amd-fast-planner ',
-        when='+mpi',
-        msg='mpi thread is not supported with amd-fast-planner')
     conflicts(
         '+amd-fast-planner',
         when='@2.2',
@@ -175,6 +177,14 @@ class Amdfftw(FftwBase):
         '+amd-app-opt',
         when='precision=quad',
         msg='Quad precision is not supported with amd-app-opt')
+    conflicts(
+        '+amd-dynamic-dispatcher',
+        when='%aocc',
+        msg='dynamic-dispatcher is not supported by AOCC clang compiler')
+    conflicts(
+        '+amd-dynamic-dispatcher',
+        when='@:3.1',
+        msg='dynamic-dispatcher is supported from 3.2 version onwards')
 
     def configure(self, spec, prefix):
         """Configure function"""
@@ -183,6 +193,12 @@ class Amdfftw(FftwBase):
             '--prefix={0}'.format(prefix),
             '--enable-amd-opt'
         ]
+
+        # Dynamic dispatcher builds a single portable optimized library
+        # that can execute on different x86 CPU architectures.
+        # It is supported for GCC compiler and Linux based systems only.
+        if '+amd-dynamic-dispatcher' in self.spec:
+            options.append('--enable-dynamic-dispatcher')
 
         # Check if compiler is AOCC
         if '%aocc' in spec:

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -71,10 +71,10 @@ class Amdlibflame(LibflameBase):
         """configure_args function"""
         args = super(Amdlibflame, self).configure_args()
 
-        # 3.2.rc2 version onwards amd optimized flags are encapsulated under:
+        # From 3.2 version, amd optimized flags are encapsulated under:
         # enable-amd-flags for gcc compiler
         # enable-amd-aocc-flags for aocc compiler
-        if "@3.2.rc2:" in self.spec:
+        if "@3.2:" in self.spec:
             if "%gcc" in self.spec:
                 args.append("--enable-amd-flags")
             if "%aocc" in self.spec:

--- a/var/spack/repos/builtin/packages/amdlibflame/package.py
+++ b/var/spack/repos/builtin/packages/amdlibflame/package.py
@@ -37,6 +37,7 @@ class Amdlibflame(LibflameBase):
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.2', sha256='6b5337fb668b82d0ed0a4ab4b5af4e2f72e4cedbeeb4a8b6eb9a3ef057fb749a')
     version('3.1', sha256='4520fb93fcc89161f65a40810cae0fa1f87cecb242da4a69655f502545a53426')
     version('3.0.1', sha256='5859e7b39ffbe73115dd598b035f212d36310462cf3a45e555a5087301710776')
     version('3.0', sha256='d94e08b688539748571e6d4c1ec1ce42732eac18bd75de989234983c33f01ced')
@@ -69,21 +70,32 @@ class Amdlibflame(LibflameBase):
     def configure_args(self):
         """configure_args function"""
         args = super(Amdlibflame, self).configure_args()
-        args.append("--enable-external-lapack-interfaces")
 
-        """To enabled Fortran to C calling convention for
-        complex types when compiling with aocc flang"""
-        if "@3.0: %aocc" in self.spec:
+        # 3.2.rc2 version onwards amd optimized flags are encapsulated under:
+        # enable-amd-flags for gcc compiler
+        # enable-amd-aocc-flags for aocc compiler
+        if "@3.2.rc2:" in self.spec:
+            if "%gcc" in self.spec:
+                args.append("--enable-amd-flags")
+            if "%aocc" in self.spec:
+                args.append("--enable-amd-aocc-flags")
+
+        if "@:3.1" in self.spec:
+            args.append("--enable-external-lapack-interfaces")
+
+        if "@3.1" in self.spec:
+            args.append("--enable-blas-ext-gemmt")
+
+        if "@3.1 %aocc" in self.spec:
+            args.append("--enable-void-return-complex")
+
+        if "@3.0:3.1 %aocc" in self.spec:
+            """To enabled Fortran to C calling convention for
+            complex types when compiling with aocc flang"""
             args.append("--enable-f2c-dotc")
 
         if "@3.0.1: +ilp64" in self.spec:
             args.append("--enable-ilp64")
-
-        if "@3.1: %aocc" in self.spec:
-            args.append("--enable-void-return-complex")
-
-        if "@3.1: " in self.spec:
-            args.append("--enable-blas-ext-gemmt")
 
         return args
 

--- a/var/spack/repos/builtin/packages/amdlibm/package.py
+++ b/var/spack/repos/builtin/packages/amdlibm/package.py
@@ -25,6 +25,8 @@ class Amdlibm(SConsPackage):
     # of master branch.
     # To install amdlibm from latest master branch:
     # spack install amdlibm ^amdlibm@master
+
+    version("3.2", branch="aocl-3.2")
     version("3.1", branch="aocl-3.1")
     version("3.0", branch="aocl-3.0")
     version("2.2", commit="4033e022da428125747e118ccd6fdd9cee21c470")

--- a/var/spack/repos/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/builtin/packages/amdscalapack/package.py
@@ -24,6 +24,7 @@ class Amdscalapack(ScalapackBase):
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.2', sha256='9e00979bb1be39d627bdacb01774bc043029840d542fafc934d16fec3e3b0892')
     version('3.1', sha256='4c2ee2c44644a0feec0c6fc1b1a413fa9028f14d7035d43a398f5afcfdbacb98')
     version('3.0', sha256='6e6f3578f44a8e64518d276e7580530599ecfa8729f568303ed2590688e7096f')
     version('2.2', sha256='2d64926864fc6d12157b86e3f88eb1a5205e7fc157bf67e7577d0f18b9a7484c')
@@ -37,7 +38,9 @@ class Amdscalapack(ScalapackBase):
               msg="ILP64 is supported from 3.1 onwards")
 
     def url_for_version(self, version):
-        if version == Version('3.1'):
+        if version == Version('3.2'):
+            return "https://github.com/amd/aocl-scalapack/archive/3.2.tar.gz"
+        elif version == Version('3.1'):
             return "https://github.com/amd/aocl-scalapack/archive/3.1.tar.gz"
         elif version == Version('3.0'):
             return "https://github.com/amd/scalapack/archive/3.0.tar.gz"

--- a/var/spack/repos/builtin/packages/amdscalapack/package.py
+++ b/var/spack/repos/builtin/packages/amdscalapack/package.py
@@ -38,14 +38,11 @@ class Amdscalapack(ScalapackBase):
               msg="ILP64 is supported from 3.1 onwards")
 
     def url_for_version(self, version):
-        if version == Version('3.2'):
-            return "https://github.com/amd/aocl-scalapack/archive/3.2.tar.gz"
-        elif version == Version('3.1'):
-            return "https://github.com/amd/aocl-scalapack/archive/3.1.tar.gz"
-        elif version == Version('3.0'):
-            return "https://github.com/amd/scalapack/archive/3.0.tar.gz"
-        elif version == Version('2.2'):
-            return "https://github.com/amd/scalapack/archive/2.2.tar.gz"
+        vers = "https://github.com/amd/{0}/archive/{1}.tar.gz"
+        if version >= Version('3.1'):
+            return vers.format('aocl-scalapack', version)
+        else:
+            return vers.format('scalapack', version)
 
     def cmake_args(self):
         """ cmake_args function"""

--- a/var/spack/repos/builtin/packages/aocl-sparse/package.py
+++ b/var/spack/repos/builtin/packages/aocl-sparse/package.py
@@ -20,6 +20,7 @@ class AoclSparse(CMakePackage):
 
     maintainers = ['amd-toolchain-support']
 
+    version('3.2',  sha256='db7d681a8697d6ef49acf3e97e8bec35b048ce0ad74549c3b738bbdff496618f')
     version('3.1',  sha256='8536f06095c95074d4297a3d2910654085dd91bce82e116c10368a9f87e9c7b9')
     version('3.0',  sha256='1d04ba16e04c065051af916b1ed9afce50296edfa9b1513211a7378e1d6b952e')
     version('2.2',  sha256='33c2ed6622cda61d2613ee63ff12c116a6cd209c62e54307b8fde986cd65f664')


### PR DESCRIPTION
1) amdblis
    Progress feature for xGEMM and xTRSM APIs:
    Time taken to complete the mathematical operations tends to increase
    exponentially with large input problem sizes; this feature provides
    users a periodic update on the operation progress.
    Improvements in SGEMM, DGEMM, ZGEMM, DGEMV, Level-1 and Level-2
    routines
2) amdlibflame
    Improved SVD and Eigen Value routines
    New feature to track the computation progress of selected APIs
3) amdfftw
    Dynamic dispatcher for AOCL-FFTW
    Upgraded AOCL-FFTW to align with the reference FFTW 3.3.10
4) amdlibm
    New complex number variant functions – Most frequently used
    functions exp/log/pow
    Fast variants (with reduced precision – ULP up to 4) of the routines
    acos, asin, asinf, atan, atanf, expf, log, logf, powf, tan, and tanf
5) aocl-parse
    Two new APIs: One of them to multiply two sparse matrices and other
    an ILU based preconditioner API Sparsity pattern analysis framework for SPMV
6) amdscalapack
    New feature to track the computation progress of selected APIs
7) amd-aocl
    Bundle package for above libraries