### PR TITLE
Add/packages nextflow tower

### DIFF
--- a/var/spack/repos/builtin/packages/nextflow/package.py
+++ b/var/spack/repos/builtin/packages/nextflow/package.py
@@ -14,6 +14,7 @@ class Nextflow(Package):
 
     maintainers = ['dialvarezs']
 
+    version('22.04.4', sha256='e5ebf9942af4569db9199e8528016d9a52f73010ed476049774a76b201cd4b10', expand=False)
     version('22.04.3', sha256='a1a79c619200b9f2719e8467cd5b8fbcb427f43adf945233ba9e03cd2f2d814e', expand=False)
     version('22.04.1', sha256='89ef482a53d2866a3cee84b3576053278b53507bde62db4ad05b1fcd63a9368a', expand=False)
     version('22.04.0', sha256='8eba475aa395438ed222ff14df8fbe93928c14ffc68727a15b8308178edf9056', expand=False)

--- a/var/spack/repos/builtin/packages/tower-agent/package.py
+++ b/var/spack/repos/builtin/packages/tower-agent/package.py
@@ -1,0 +1,23 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class TowerAgent(Package):
+    """Tower Agent allows Nextflow Tower to launch pipelines
+       on HPC clusters that do not allow direct access through
+       an SSH client.
+    """
+
+    homepage = "https://github.com/seqeralabs/tower-agent"
+    url      = "https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64"
+
+    version('0.4.3', sha256='1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0', expand=False)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install(self.stage.archive_file, join_path(prefix.bin, "tw-agent"))
+        set_executable(join_path(prefix.bin, "tw-agent"))

--- a/var/spack/repos/builtin/packages/tower-agent/package.py
+++ b/var/spack/repos/builtin/packages/tower-agent/package.py
@@ -19,8 +19,10 @@ class TowerAgent(Package):
 
     if platform.machine().startswith('x86_64'):
         if sys.platform.startswith('linux'):
-            url      = "https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64"
-            version('0.4.3', sha256='1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0', expand=False)
+            version('0.4.3',
+                    sha256='1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0',
+                    url='https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64',
+                    expand=False)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/tower-agent/package.py
+++ b/var/spack/repos/builtin/packages/tower-agent/package.py
@@ -13,9 +13,10 @@ class TowerAgent(Package):
     """
 
     homepage = "https://github.com/seqeralabs/tower-agent"
-    url      = "https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64"
 
-    version('0.4.3', sha256='1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0', expand=False)
+    if sys.platform.startswith('linux'):
+        url      = "https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64"
+        version('0.4.3', sha256='1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0', expand=False)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/tower-agent/package.py
+++ b/var/spack/repos/builtin/packages/tower-agent/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 import platform
+import sys
 
 from spack.package import *
 

--- a/var/spack/repos/builtin/packages/tower-agent/package.py
+++ b/var/spack/repos/builtin/packages/tower-agent/package.py
@@ -3,6 +3,9 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
+import sys
+import platform
+
 from spack.package import *
 
 
@@ -14,9 +17,10 @@ class TowerAgent(Package):
 
     homepage = "https://github.com/seqeralabs/tower-agent"
 
-    if sys.platform.startswith('linux'):
-        url      = "https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64"
-        version('0.4.3', sha256='1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0', expand=False)
+    if platform.machine().startswith('x86_64'):
+        if sys.platform.startswith('linux'):
+            url      = "https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64"
+            version('0.4.3', sha256='1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0', expand=False)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/tower-agent/package.py
+++ b/var/spack/repos/builtin/packages/tower-agent/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import platform
-import sys
 
 from spack.package import *
 
@@ -17,8 +16,8 @@ class TowerAgent(Package):
 
     homepage = "https://github.com/seqeralabs/tower-agent"
 
-    if platform.machine().startswith('x86_64'):
-        if sys.platform.startswith('linux'):
+    if platform.machine() == 'x86_64':
+        if platform.system() == 'Linux':
             version('0.4.3',
                     sha256='1125e64d4e3342e77fcf7f6827f045e421084654fe8faafd5389e356e0613cc0',
                     url='https://github.com/seqeralabs/tower-agent/releases/download/v0.4.3/tw-agent-linux-x86_64',

--- a/var/spack/repos/builtin/packages/tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/tower-cli/package.py
@@ -19,11 +19,15 @@ class TowerCli(Package):
 
     if platform.machine().startswith('x86_64'):
         if sys.platform == 'darwin':
-            url      = "https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-osx-x86_64"
-            version('0.6.2', sha256='2bcc17687d58d4c888e8d57b7f2f769a2940afb3266dc3c6c48b0af0cb490d91', expand=False)
+            version('0.6.2',
+                    sha256='2bcc17687d58d4c888e8d57b7f2f769a2940afb3266dc3c6c48b0af0cb490d91',
+                    url='https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-osx-x86_64',
+                    expand=False)
         elif sys.platform.startswith('linux'):
-            url      = "https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-linux-x86_64"
-            version('0.6.2', sha256='02c6d141416b046b6e8b6f9723331fe0e39d37faa3561c47c152df4d33b37e50', expand=False)
+            version('0.6.2',
+                    sha256='02c6d141416b046b6e8b6f9723331fe0e39d37faa3561c47c152df4d33b37e50',
+                    url='https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-linux-x86_64',
+                    expand=False)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/tower-cli/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import platform
-import sys
 
 from spack.package import *
 
@@ -17,13 +16,13 @@ class TowerCli(Package):
 
     homepage = "https://github.com/seqeralabs/tower-cli"
 
-    if platform.machine().startswith('x86_64'):
-        if sys.platform == 'darwin':
+    if platform.machine() == 'x86_64':
+        if platform.system() == 'Darwin':
             version('0.6.2',
                     sha256='2bcc17687d58d4c888e8d57b7f2f769a2940afb3266dc3c6c48b0af0cb490d91',
                     url='https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-osx-x86_64',
                     expand=False)
-        elif sys.platform.startswith('linux'):
+        elif platform.system() == 'Linux':
             version('0.6.2',
                     sha256='02c6d141416b046b6e8b6f9723331fe0e39d37faa3561c47c152df4d33b37e50',
                     url='https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-linux-x86_64',

--- a/var/spack/repos/builtin/packages/tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/tower-cli/package.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+import sys
+
+from spack.package import *
+
+
+class TowerCli(Package):
+    """Tower on the Command Line brings Nextflow Tower concepts
+       including Pipelines, Actions and Compute Environments
+       to the terminal.
+    """
+
+    homepage = "https://github.com/seqeralabs/tower-cli"
+
+    if sys.platform == 'darwin':
+        url      = "https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-osx-x86_64"
+        version('0.6.2', sha256='2bcc17687d58d4c888e8d57b7f2f769a2940afb3266dc3c6c48b0af0cb490d91', expand=False)
+    elif sys.platform.startswith('linux'):
+        url      = "https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-linux-x86_64"
+        version('0.6.2', sha256='02c6d141416b046b6e8b6f9723331fe0e39d37faa3561c47c152df4d33b37e50', expand=False)
+
+    def install(self, spec, prefix):
+        mkdirp(prefix.bin)
+        install(self.stage.archive_file, join_path(prefix.bin, "tw"))
+        set_executable(join_path(prefix.bin, "tw"))

--- a/var/spack/repos/builtin/packages/tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/tower-cli/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 import sys
+import platform
 
 from spack.package import *
 
@@ -16,12 +17,13 @@ class TowerCli(Package):
 
     homepage = "https://github.com/seqeralabs/tower-cli"
 
-    if sys.platform == 'darwin':
-        url      = "https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-osx-x86_64"
-        version('0.6.2', sha256='2bcc17687d58d4c888e8d57b7f2f769a2940afb3266dc3c6c48b0af0cb490d91', expand=False)
-    elif sys.platform.startswith('linux'):
-        url      = "https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-linux-x86_64"
-        version('0.6.2', sha256='02c6d141416b046b6e8b6f9723331fe0e39d37faa3561c47c152df4d33b37e50', expand=False)
+    if platform.machine().startswith('x86_64'):
+        if sys.platform == 'darwin':
+            url      = "https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-osx-x86_64"
+            version('0.6.2', sha256='2bcc17687d58d4c888e8d57b7f2f769a2940afb3266dc3c6c48b0af0cb490d91', expand=False)
+        elif sys.platform.startswith('linux'):
+            url      = "https://github.com/seqeralabs/tower-cli/releases/download/v0.6.2/tw-0.6.2-linux-x86_64"
+            version('0.6.2', sha256='02c6d141416b046b6e8b6f9723331fe0e39d37faa3561c47c152df4d33b37e50', expand=False)
 
     def install(self, spec, prefix):
         mkdirp(prefix.bin)

--- a/var/spack/repos/builtin/packages/tower-cli/package.py
+++ b/var/spack/repos/builtin/packages/tower-cli/package.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-import sys
 import platform
+import sys
 
 from spack.package import *
 


### PR DESCRIPTION
This PR adds recipes for two very useful, official utilities that complement the Nextflow workflow manager:
* Tower Agent: https://github.com/seqeralabs/tower-agent
* Tower CLI: https://github.com/seqeralabs/tower-cli

On the side, I also added the most recent stable version of Nextflow in the corresponding recipe.

