### PR TITLE
trilinos: modify fortran linking flags

### DIFF
--- a/var/spack/repos/builtin/packages/trilinos/package.py
+++ b/var/spack/repos/builtin/packages/trilinos/package.py
@@ -832,11 +832,18 @@ class Trilinos(CMakePackage, CudaPackage, ROCmPackage):
                 libgfortran = fc('--print-file-name',
                                  'libgfortran.a',
                                  output=str).strip()
-            # -L<libdir> -lgfortran required for OSX
-            # https://github.com/spack/spack/pull/25823#issuecomment-917231118
-            options.append(
-                define('Trilinos_EXTRA_LINK_FLAGS',
-                       '-L%s/ -lgfortran' % os.path.dirname(libgfortran)))
+            if spec.version < Version('14'):
+                # Trilinos_EXTRA_LINK_FLAGS do not correctly propagate to
+                # Kokkos-Kernels prior to version 14.0
+                options.append(
+                    define('CMAKE_SHARED_LINKER_FLAGS',
+                           '-L%s/ -lgfortran' % os.path.dirname(libgfortran)))
+            else:
+                # -L<libdir> -lgfortran required for OSX
+                # https://github.com/spack/spack/pull/25823#issuecomment-917231118
+                options.append(
+                    define('Trilinos_EXTRA_LINK_FLAGS',
+                           '-L%s/ -lgfortran' % os.path.dirname(libgfortran)))
 
         if sys.platform == 'darwin' and macos_version() >= Version('10.12'):
             # use @rpath on Sierra due to limit of dynamic loader


### PR DESCRIPTION
Past solutions https://github.com/spack/spack/pull/25823 for linking to gfortran made use of the `Trilinos_EXTRA_LINK_FLAGS`. However, these flags are not propagated to all Trilinos packages that need them (such as KokkosKernels). 

`CMAKE_SHARED_LINKER_FLAGS` is always propagated to all Trilinos packages, so this fix switches to using `CMAKE_SHARED_LINKER_FLAGS` instead of `Trilinos_EXTRA_LINK_FLAGS` for Trilinos versions less than 14.0.

Even though 14.0 is not released yet, it will be soon and will have modern CMake targets and will fix the propagation of `Trilinos_EXTRA_LINK_FLAGS` so we can continue to use this variable from version 14.0 onward.