### PR TITLE
lhapdf: Add gettext libs explicitly

### DIFF
--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -34,9 +34,11 @@ class Lhapdf(AutotoolsPackage):
     extends('python', when='+python')
     depends_on('py-cython',     type='build', when='+python')
     depends_on('py-setuptools', type='build', when='+python')
+    depends_on('gettext',       type='build', when='+python')
 
     def configure_args(self):
         args = ['FCFLAGS=-O3', 'CFLAGS=-O3', 'CXXFLAGS=-O3',
-                'LIBS=-L' + self.spec['python'].prefix.lib]
+                'LIBS=-L' + self.spec['python'].prefix.lib +
+                ' -L' + self.spec['gettext'].prefix.lib + '']
         args.extend(self.enable_or_disable('python'))
         return args

--- a/var/spack/repos/builtin/packages/lhapdf/package.py
+++ b/var/spack/repos/builtin/packages/lhapdf/package.py
@@ -39,6 +39,6 @@ class Lhapdf(AutotoolsPackage):
     def configure_args(self):
         args = ['FCFLAGS=-O3', 'CFLAGS=-O3', 'CXXFLAGS=-O3',
                 'LIBS=-L' + self.spec['python'].prefix.lib +
-                ' -L' + self.spec['gettext'].prefix.lib + '']
+                ' -L' + self.spec['gettext'].prefix.lib]
         args.extend(self.enable_or_disable('python'))
         return args


### PR DESCRIPTION
Building with clang 14.0.6:
```
     138    checking for Python library path... -L/home/hahansen/spack/opt/spack/linux-centos7-cascadelake/clang-14.0.6/python-3.9.12-r7euo5znevyv5pklam2eh4vdk7nmyb7l/lib
     139    checking for Python site-packages path... /home/hahansen/spack/opt/spack/linux-centos7-cascadelake/clang-14.0.6/python-3.9.12-r7euo5znevyv5pklam2eh4vdk7nmyb7l/lib/python3.9/site-packages
     140    checking for Python platform specific site-packages path...
     141    checking python extra libraries... -lcrypt -lintl -lpthread -ldl  -lutil -lm -lm
     142    checking python extra linking flags... -Xlinker -export-dynamic
     143    checking consistency of all components of python development environment... no
  >> 144    configure: error: in `/tmp/hahansen/spack-stage/spack-stage-lhapdf-6.5.1-r7nqokjj5so6jpzlgf3nfxubr35zptez/spack-src':
  >> 145    configure: error:
     146      Could not link test program to Python. Maybe the main Python library has been
     147      installed in some non-standard library path. If so, pass it to configure,
     148      via the LIBS environment variable.
     149      Example: ./configure LIBS="-L/usr/non-standard-path/python/lib"
     150      ============================================================================
     151       ERROR!
```
Where the config.log file says `cannot find -lintl`, which resides in gettext.