### PR TITLE
openssl: add patch for @1.1.1q. fixed issues #31545

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -110,6 +110,10 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
     depends_on('ca-certificates-mozilla', type=('build', 'run'), when='certs=mozilla')
     depends_on('nasm', when='platform=windows')
 
+    patch('https://github.com/openssl/openssl/commit/f9e578e720bb35228948564192adbe3bc503d5fb.patch?full_index=1',
+          sha256='3fdcf2d1e47c34f3a012f23306322c5a35cad55b180c9b6fb34537b55884645c',
+          when='@1.1.1q')
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('version', output=str, error=str)


### PR DESCRIPTION
Fixes #31545 **openssl bootstrap error on Apple M1**

This issue is related to the following bug: https://github.com/openssl/openssl/issues/18720
OpenSSL has fixed it on the master branch: https://github.com/openssl/openssl/commit/f9e578e720bb35228948564192adbe3bc503d5fb