### PR TITLE
openssl: fix missing include in 1.1.1q

### DIFF
--- a/var/spack/repos/builtin/packages/openssl/package.py
+++ b/var/spack/repos/builtin/packages/openssl/package.py
@@ -110,6 +110,10 @@ class Openssl(Package):   # Uses Fake Autotools, should subclass Package
     depends_on('ca-certificates-mozilla', type=('build', 'run'), when='certs=mozilla')
     depends_on('nasm', when='platform=windows')
 
+    patch('v3ext_stringh_111q.patch',
+      sha256='5bce75d3bd482c793096a0ced4a9e273b08ebadd0b198638c7a9342a761234e7',
+      when='@1.1.1q')
+
     @classmethod
     def determine_version(cls, exe):
         output = Executable(exe)('version', output=str, error=str)

--- a/var/spack/repos/builtin/packages/openssl/v3ext_stringh_111q.patch
+++ b/var/spack/repos/builtin/packages/openssl/v3ext_stringh_111q.patch
@@ -1,0 +1,10 @@
+--- a/test/v3ext.c	2022-07-14 06:35:24.000000000 -0600
++++ b/test/v3ext.c	2022-07-14 06:33:22.000000000 -0600
+@@ -8,6 +8,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <string.h>
+ #include <openssl/x509.h>
+ #include <openssl/x509v3.h>
+ #include <openssl/pem.h>


### PR DESCRIPTION
Adds a missing `#include <string.h>` to test/v3ext.c that is caught when compiling with `-Werror`.