### PR TITLE
GDAL: external LERC only available in 3.3+

### DIFF
--- a/var/spack/repos/builtin/packages/gdal/package.py
+++ b/var/spack/repos/builtin/packages/gdal/package.py
@@ -112,7 +112,7 @@ class Gdal(CMakePackage):
     variant('jxl', default=False, when='@3.4:', description='Required for JPEGXL driver')
     variant('kdu', default=False, description='Required for JP2KAK and JPIPKAK drivers')
     variant('kea', default=False, description='Required for KEA driver')
-    variant('lerc', default=True, when='@2.4:', description='Required for LERC compression')
+    variant('lerc', default=True, when='@3.3:', description='Required for LERC compression')
     variant('libcsf', default=False, description='Required for PCRaster driver')
     variant('libkml', default=False, description='Required for LIBKML driver')
     variant('liblzma', default=False, description='Required for Zarr driver')


### PR DESCRIPTION
User reported a build issue when linking to external LERC for older GDAL. According to https://gdal.org/drivers/raster/gtiff.html:

> `LERC` and `LERC_DEFLATE` are available only when using internal libtiff for GDAL < 3.3.0. Since GDAL 3.3.0, LERC compression is also available when building GDAL against external libtiff >= 4.3.0, built itself against https://github.com/esri/lerc

Actually, now that I look at this, I'm not sure if it even makes sense to have a `+lerc` variant/dependency. @rouault is LERC actually used in GDAL or is it only used when building the internal copy of libtiff? Since we don't use internal copies of any dependencies, we may be able to remove the `+lerc` variant. Are there any other dependencies listed at https://gdal.org/build_hints.html that are secretly dependencies of dependencies?