### PR TITLE
Qhull: fix RPATH on macOS

### DIFF
--- a/var/spack/repos/builtin/packages/qhull/package.py
+++ b/var/spack/repos/builtin/packages/qhull/package.py
@@ -45,3 +45,9 @@ class Qhull(CMakePackage):
         else:
             return find_libraries('libqhull', self.prefix,
                                   shared=True, recursive=True)
+
+    @run_after('install')
+    def darwin_fix(self):
+        # The shared library is not installed correctly on Darwin; fix this
+        if self.spec.satisfies('platform=darwin'):
+            fix_darwin_install_name(self.prefix.lib)


### PR DESCRIPTION
### Before

```console
$ otool -L /Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/qhull-2020.2-6u4cqf2tnhosc5d3rgjcszajli4f4i5b/lib/libqhull_r.dylib 
/Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/qhull-2020.2-6u4cqf2tnhosc5d3rgjcszajli4f4i5b/lib/libqhull_r.dylib:
	lib/libqhull_r.8.0.dylib (compatibility version 8.0.0, current version 8.0.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```

### After

```console
$ otool -L /Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/qhull-2020.2-fjtrrujxaf26g6nnh5hmexujnvohqc2b/lib/libqhull_r.dylib 
/Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/qhull-2020.2-fjtrrujxaf26g6nnh5hmexujnvohqc2b/lib/libqhull_r.dylib:
	/Users/ajstewart/spack/opt/spack/darwin-monterey-m1/apple-clang-13.1.6/qhull-2020.2-fjtrrujxaf26g6nnh5hmexujnvohqc2b/lib/libqhull_r.8.0.dylib (compatibility version 8.0.0, current version 8.0.2)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```