### PR TITLE
py-geocube: add v0.3.2

### DIFF
--- a/var/spack/repos/builtin/packages/py-geocube/package.py
+++ b/var/spack/repos/builtin/packages/py-geocube/package.py
@@ -14,6 +14,7 @@ class PyGeocube(PythonPackage):
 
     maintainers = ['adamjstewart']
 
+    version('0.3.2', sha256='71ff0228f1ef44e3a649d29a045ff7e2a2094a5cfca30fadab8f88f4ec23a41d')
     version('0.3.1', sha256='5c97131010cd8d556a5fad2a3824452120640ac33a6a45b6ca9ee3c28f2e266f')
     version('0.0.17', sha256='bf8da0fa96d772ebaea0b98bafa0ba5b8639669d5feb07465d4255af177bddc0')
 


### PR DESCRIPTION
Successfully builds on macOS 12.4 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6.