### PR TITLE
Refactor archive ext parsing

### DIFF
--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -115,7 +115,7 @@ def path_contains_subdirectory(path, root):
 
 @memoized
 def file_command(*args):
-    file_cmd = which('file')
+    file_cmd = which("file")
     for arg in args:
         file_cmd.add_default_arg(arg)
     return file_cmd
@@ -123,7 +123,7 @@ def file_command(*args):
 
 @memoized
 def _get_mime_type():
-    return file_command('-b', '-h', '--mime-type')
+    return file_command("-b", "-h", "--mime-type")
 
 
 @memoized
@@ -132,11 +132,10 @@ def _get_mime_type_compressed():
     compression first
     """
     mime_uncompressed = _get_mime_type()
-    mime_uncompressed.add_default_arg('-Z')
+    mime_uncompressed.add_default_arg("-Z")
     return mime_uncompressed
 
 
-@memoized
 def mime_type(filename):
     """Returns the mime type and subtype of a file.
 
@@ -147,12 +146,11 @@ def mime_type(filename):
         Tuple containing the MIME type and subtype
     """
     output = _get_mime_type()(filename, output=str, error=str).strip()
-    tty.debug('==> ' + output)
-    type, _, subtype = output.partition('/')
+    tty.debug("==> " + output)
+    type, _, subtype = output.partition("/")
     return type, subtype
 
 
-@memoized
 def compressed_mime_type(filename):
     """Same as mime_type but checks for type that has been compressed
 
@@ -163,8 +161,8 @@ def compressed_mime_type(filename):
         Tuple containing the MIME type and subtype
     """
     output = _get_mime_type_compressed()(filename, output=str, error=str).strip()
-    tty.debug('==> ' + output)
-    type, _, subtype = output.partition('/')
+    tty.debug("==> " + output)
+    type, _, subtype = output.partition("/")
     return type, subtype
 
 

--- a/lib/spack/llnl/util/filesystem.py
+++ b/lib/spack/llnl/util/filesystem.py
@@ -24,7 +24,7 @@ from llnl.util.compat import Sequence
 from llnl.util.lang import dedupe, memoized
 from llnl.util.symlink import islink, symlink
 
-from spack.util.executable import Executable
+from spack.util.executable import Executable, which
 from spack.util.path import path_to_os_path, system_path_filter
 
 is_windows = _platform == "win32"
@@ -111,6 +111,61 @@ def path_contains_subdirectory(path, root):
     norm_root = os.path.abspath(root).rstrip(os.path.sep) + os.path.sep
     norm_path = os.path.abspath(path).rstrip(os.path.sep) + os.path.sep
     return norm_path.startswith(norm_root)
+
+
+@memoized
+def file_command(*args):
+    file_cmd = which('file')
+    for arg in args:
+        file_cmd.add_default_arg(arg)
+    return file_cmd
+
+
+@memoized
+def _get_mime_type():
+    return file_command('-b', '-h', '--mime-type')
+
+
+@memoized
+def _get_mime_type_compressed():
+    """Same as _get_mime_type but attempts to check for
+    compression first
+    """
+    mime_uncompressed = _get_mime_type()
+    mime_uncompressed.add_default_arg('-Z')
+    return mime_uncompressed
+
+
+@memoized
+def mime_type(filename):
+    """Returns the mime type and subtype of a file.
+
+    Args:
+        filename: file to be analyzed
+
+    Returns:
+        Tuple containing the MIME type and subtype
+    """
+    output = _get_mime_type()(filename, output=str, error=str).strip()
+    tty.debug('==> ' + output)
+    type, _, subtype = output.partition('/')
+    return type, subtype
+
+
+@memoized
+def compressed_mime_type(filename):
+    """Same as mime_type but checks for type that has been compressed
+
+    Args:
+        filename (str): file to be analyzed
+
+    Returns:
+        Tuple containing the MIME type and subtype
+    """
+    output = _get_mime_type_compressed()(filename, output=str, error=str).strip()
+    tty.debug('==> ' + output)
+    type, _, subtype = output.partition('/')
+    return type, subtype
 
 
 #: This generates the library filenames that may appear on any OS.

--- a/lib/spack/spack/binary_distribution.py
+++ b/lib/spack/spack/binary_distribution.py
@@ -19,6 +19,7 @@ from contextlib import closing
 import ruamel.yaml as yaml
 from six.moves.urllib.error import HTTPError, URLError
 
+import llnl.util.filesystem as fsys
 import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.util.filesystem import mkdirp
@@ -653,7 +654,7 @@ def get_buildfile_manifest(spec):
 
         for filename in files:
             path_name = os.path.join(root, filename)
-            m_type, m_subtype = relocate.mime_type(path_name)
+            m_type, m_subtype = fsys.mime_type(path_name)
             rel_path_name = os.path.relpath(path_name, spec.prefix)
             added = False
 

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -54,7 +54,7 @@ import spack.util.pattern as pattern
 import spack.util.url as url_util
 import spack.util.web as web_util
 import spack.version
-from spack.util.compression import decompressor_for, extension
+from spack.util.compression import decompressor_for, extension_from_path
 from spack.util.executable import CommandNotFoundError, which
 from spack.util.string import comma_and, quote
 
@@ -613,7 +613,7 @@ class VCSFetchStrategy(FetchStrategy):
 
     @_needs_stage
     def archive(self, destination, **kwargs):
-        assert extension(destination) == "tar.gz"
+        assert extension_from_path(destination) == "tar.gz"
         assert self.stage.source_path.startswith(self.stage.path)
 
         tar = which("tar", required=True)

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -486,7 +486,7 @@ class URLFetchStrategy(FetchStrategy):
             tty.debug("Source already staged to %s" % self.stage.source_path)
             return
 
-        decompress = decompressor_for(self.archive_file, self.extension)
+        decompress = decompressor_for(self.archive_file)
 
         # Below we assume that the command to decompress expand the
         # archive in the current working directory

--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -486,7 +486,7 @@ class URLFetchStrategy(FetchStrategy):
             tty.debug("Source already staged to %s" % self.stage.source_path)
             return
 
-        decompress = decompressor_for(self.archive_file)
+        decompress = decompressor_for(self.archive_file, self.extension)
 
         # Below we assume that the command to decompress expand the
         # archive in the current working directory

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -12,6 +12,7 @@ import macholib.mach_o
 import macholib.MachO
 
 import llnl.util.lang
+import llnl.util.filesystem as fs
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
 from llnl.util.symlink import symlink
@@ -887,7 +888,7 @@ def file_is_relocatable(filename, paths_to_relocate=None):
     # Remove the RPATHS from the strings in the executable
     set_of_strings = set(strings(filename, output=str).split())
 
-    m_type, m_subtype = mime_type(filename)
+    m_type, m_subtype = fs.mime_type(filename)
     if m_type == "application":
         tty.debug("{0},{1}".format(m_type, m_subtype), level=2)
 
@@ -923,7 +924,7 @@ def is_binary(filename):
     Returns:
         True or False
     """
-    m_type, _ = mime_type(filename)
+    m_type, _ = fs.mime_type(filename)
 
     msg = "[{0}] -> ".format(filename)
     if m_type == "application":
@@ -932,30 +933,6 @@ def is_binary(filename):
 
     tty.debug(msg + "TEXT FILE")
     return False
-
-
-@llnl.util.lang.memoized
-def _get_mime_type():
-    file_cmd = executable.which("file")
-    for arg in ["-b", "-h", "--mime-type"]:
-        file_cmd.add_default_arg(arg)
-    return file_cmd
-
-
-@llnl.util.lang.memoized
-def mime_type(filename):
-    """Returns the mime type and subtype of a file.
-
-    Args:
-        filename: file to be analyzed
-
-    Returns:
-        Tuple containing the MIME type and subtype
-    """
-    output = _get_mime_type()(filename, output=str, error=str).strip()
-    tty.debug("==> " + output, level=2)
-    type, _, subtype = output.partition("/")
-    return type, subtype
 
 
 # Memoize this due to repeated calls to libraries in the same directory.
@@ -975,7 +952,7 @@ def fixup_macos_rpath(root, filename):
         True if fixups were applied, else False
     """
     abspath = os.path.join(root, filename)
-    if mime_type(abspath) != ("application", "x-mach-binary"):
+    if fs.mime_type(abspath) != ('application', 'x-mach-binary'):
         return False
 
     # Get Mach-O header commands

--- a/lib/spack/spack/relocate.py
+++ b/lib/spack/spack/relocate.py
@@ -11,8 +11,8 @@ import shutil
 import macholib.mach_o
 import macholib.MachO
 
-import llnl.util.lang
 import llnl.util.filesystem as fs
+import llnl.util.lang
 import llnl.util.tty as tty
 from llnl.util.lang import memoized
 from llnl.util.symlink import symlink
@@ -952,7 +952,7 @@ def fixup_macos_rpath(root, filename):
         True if fixups were applied, else False
     """
     abspath = os.path.join(root, filename)
-    if fs.mime_type(abspath) != ('application', 'x-mach-binary'):
+    if fs.mime_type(abspath) != ("application", "x-mach-binary"):
         return False
 
     # Get Mach-O header commands

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -466,9 +466,11 @@ class Stage(object):
             # the checksum will be the same.
             digest = None
             expand = True
+            extension = None
             if isinstance(self.default_fetcher, fs.URLFetchStrategy):
                 digest = self.default_fetcher.digest
                 expand = self.default_fetcher.expand_archive
+                extension = self.default_fetcher.extension
 
             # Have to skip the checksum for things archived from
             # repositories.  How can this be made safer?

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -466,11 +466,9 @@ class Stage(object):
             # the checksum will be the same.
             digest = None
             expand = True
-            extension = None
             if isinstance(self.default_fetcher, fs.URLFetchStrategy):
                 digest = self.default_fetcher.digest
                 expand = self.default_fetcher.expand_archive
-                extension = self.default_fetcher.extension
 
             # Have to skip the checksum for things archived from
             # repositories.  How can this be made safer?

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -22,9 +22,9 @@ ext_archive = {}
     for ext in scomp.ALLOWED_ARCHIVE_TYPES
     if "TAR" not in ext
 ]
-# Spack does not use Python native handling for tarballs
-# Don't test tarballs in native test
-native_archive_list = [key for key in ext_archive.keys() if 'tar' not in key]
+# Spack does not use Python native handling for tarballs or zip
+# Don't test tarballs or zip in native test
+native_archive_list = [key for key in ext_archive.keys() if "tar" not in key and "zip" not in key]
 
 
 def support_stub():
@@ -33,9 +33,9 @@ def support_stub():
 
 @pytest.fixture
 def compr_support_check(monkeypatch):
-    monkeypatch.setattr(scomp, 'is_lzma_supported', support_stub)
-    monkeypatch.setattr(scomp, 'is_gzip_supported', support_stub)
-    monkeypatch.setattr(scomp, 'is_bz2_supported', support_stub)
+    monkeypatch.setattr(scomp, "is_lzma_supported", support_stub)
+    monkeypatch.setattr(scomp, "is_gzip_supported", support_stub)
+    monkeypatch.setattr(scomp, "is_bz2_supported", support_stub)
 
 
 @pytest.fixture
@@ -48,10 +48,9 @@ def archive_file(tmpdir_factory, request):
     return os.path.join(str(tmpdir), "Foo.%s" % extension)
 
 
-@pytest.mark.parametrize('archive_file', native_archive_list, indirect=True)
+@pytest.mark.parametrize("archive_file", native_archive_list, indirect=True)
 def test_native_unpacking(tmpdir_factory, archive_file):
-    extension = scomp.extension(archive_file)
-    util = scomp.decompressor_for(archive_file, extension)
+    util = scomp.decompressor_for(archive_file)
     tmpdir = tmpdir_factory.mktemp("comp_test")
     with working_dir(str(tmpdir)):
         assert not os.listdir(os.getcwd())
@@ -65,9 +64,8 @@ def test_native_unpacking(tmpdir_factory, archive_file):
 
 @pytest.mark.parametrize("archive_file", ext_archive.keys(), indirect=True)
 def test_system_unpacking(tmpdir_factory, archive_file, compr_support_check):
-    extension = scomp.extension(archive_file)
     # actually run test
-    util = scomp.decompressor_for(archive_file, extension)
+    util = scomp.decompressor_for(archive_file)
     tmpdir = tmpdir_factory.mktemp("system_comp_test")
     with working_dir(str(tmpdir)):
         assert not os.listdir(os.getcwd())
@@ -80,23 +78,23 @@ def test_system_unpacking(tmpdir_factory, archive_file, compr_support_check):
 
 
 def test_unallowed_extension():
-    bad_ext_archive = "Foo.py"
+    bad_ext_archive = "Foo.cxx"
     with pytest.raises(CommandNotFoundError):
-        scomp.decompressor_for(bad_ext_archive, "py")
+        scomp.decompressor_for(bad_ext_archive)
 
 
 @pytest.mark.parametrize("archive", ext_archive.values())
 def test_get_extension(archive):
-    ext = scomp.extension(archive)
+    ext = scomp.extension_from_path(archive)
     assert ext_archive[ext] == archive
 
 
 def test_get_bad_extension():
-    archive = "Foo.py"
-    ext = scomp.extension(archive)
+    archive = "Foo.cxx"
+    ext = scomp.extension_from_path(archive)
     assert ext is None
 
 
 @pytest.mark.parametrize("path", ext_archive.values())
-def test_allowed_archvie(path):
+def test_allowed_archive(path):
     assert scomp.allowed_archive(path)

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -22,6 +22,9 @@ ext_archive = {}
     for ext in scomp.ALLOWED_ARCHIVE_TYPES
     if "TAR" not in ext
 ]
+# Spack does not use Python native handling for tarballs
+# Don't test tarballs in native test
+native_archive_list = [key for key in ext_archive.keys() if 'tar' not in key]
 
 
 def support_stub():
@@ -30,10 +33,9 @@ def support_stub():
 
 @pytest.fixture
 def compr_support_check(monkeypatch):
-    monkeypatch.setattr(scomp, "lzma_support", support_stub)
-    monkeypatch.setattr(scomp, "tar_support", support_stub)
-    monkeypatch.setattr(scomp, "gzip_support", support_stub)
-    monkeypatch.setattr(scomp, "bz2_support", support_stub)
+    monkeypatch.setattr(scomp, 'is_lzma_supported', support_stub)
+    monkeypatch.setattr(scomp, 'is_gzip_supported', support_stub)
+    monkeypatch.setattr(scomp, 'is_bz2_supported', support_stub)
 
 
 @pytest.fixture
@@ -46,7 +48,7 @@ def archive_file(tmpdir_factory, request):
     return os.path.join(str(tmpdir), "Foo.%s" % extension)
 
 
-@pytest.mark.parametrize("archive_file", ext_archive.keys(), indirect=True)
+@pytest.mark.parametrize('archive_file', native_archive_list, indirect=True)
 def test_native_unpacking(tmpdir_factory, archive_file):
     extension = scomp.extension(archive_file)
     util = scomp.decompressor_for(archive_file, extension)

--- a/lib/spack/spack/test/util/compression.py
+++ b/lib/spack/spack/test/util/compression.py
@@ -78,6 +78,8 @@ def test_system_unpacking(tmpdir_factory, archive_file, compr_support_check):
 
 
 def test_unallowed_extension():
+    # use a cxx file as python files included for the test
+    # are picked up by the linter and break style checks
     bad_ext_archive = "Foo.cxx"
     with pytest.raises(CommandNotFoundError):
         scomp.decompressor_for(bad_ext_archive)

--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -36,6 +36,7 @@ from llnl.util.tty.color import cescape, colorize
 
 import spack.error
 import spack.util.compression as comp
+import spack.util.path as spath
 import spack.version
 
 
@@ -366,17 +367,15 @@ def split_url_extension(path):
 
     # Strip off sourceforge download suffix.
     # e.g. https://sourceforge.net/projects/glew/files/glew/2.0.0/glew-2.0.0.tgz/download
-    match = re.search(r"(.*(?:sourceforge\.net|sf\.net)/.*)(/download)$", path)
-    if match:
-        prefix, suffix = match.groups()
+    prefix, suffix = spath.find_sourceforge_suffix(path)
 
-    ext = comp.extension(prefix)
+    ext = comp.extension_from_path(prefix)
     if ext is not None:
         prefix = comp.strip_extension(prefix)
 
     else:
         prefix, suf = strip_query_and_fragment(prefix)
-        ext = comp.extension(prefix)
+        ext = comp.extension_from_path(prefix)
         prefix = comp.strip_extension(prefix)
         suffix = suf + suffix
         if ext is None:

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -26,9 +26,7 @@ ALLOWED_ARCHIVE_TYPES = (
     [".".join(ext) for ext in product(PRE_EXTS, EXTS)] + PRE_EXTS + EXTS + NOTAR_EXTS
 )
 
-ALLOWED_SINGLE_EXT_ARCHIVE_TYPES = (
-    PRE_EXTS + EXTS + NOTAR_EXTS
-)
+ALLOWED_SINGLE_EXT_ARCHIVE_TYPES = PRE_EXTS + EXTS + NOTAR_EXTS
 
 is_windows = sys.platform == "win32"
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -11,7 +11,7 @@ from itertools import product
 
 from spack.util.executable import CommandNotFoundError, which
 
-import llnl.util.filesystem as fs
+from llnl.util.lang import memoized
 
 # Supported archive extensions.
 PRE_EXTS = ["tar", "TAR"]
@@ -25,41 +25,37 @@ ALLOWED_ARCHIVE_TYPES = (
 
 is_windows = sys.platform == "win32"
 
-
-def bz2_support():
-    try:
-        import bz2  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+try:
+    import bz2 # noqa
+    _bz2_support = True
+except ImportError:
+    _bz2_support = False
 
 
-def gzip_support():
-    try:
-        import gzip  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+try:
+    import gzip # noqa
+    _gzip_support = True
+except ImportError:
+    _gzip_support = False
 
 
-def lzma_support():
-    try:
-        import lzma  # noqa: F401 # novm
-
-        return True
-    except ImportError:
-        return False
+try:
+    import lzma  # noqa # novermin
+    _lzma_support = True
+except ImportError:
+    _lzma_support = False
 
 
-def tar_support():
-    try:
-        import tarfile  # noqa: F401
+def is_lzma_supported():
+    return _lzma_support
 
-        return True
-    except ImportError:
-        return False
+
+def is_gzip_supported():
+    return _gzip_support
+
+
+def is_bz2_supported():
+    return _bz2_support
 
 
 def allowed_archive(path):
@@ -99,11 +95,9 @@ def _bunzip2(archive_file):
     working_dir = os.getcwd()
     archive_out = os.path.join(working_dir, decompressed_file)
     copy_path = os.path.join(working_dir, compressed_file_name)
-    if bz2_support():
-        import bz2
-
-        f_bz = bz2.BZ2File(archive_file, mode="rb")
-        with open(archive_out, "wb") as ar:
+    if is_bz2_supported():
+        f_bz = bz2.BZ2File(archive_file, mode='rb')
+        with open(archive_out, 'wb') as ar:
             shutil.copyfileobj(f_bz, ar)
         f_bz.close()
     else:
@@ -127,9 +121,7 @@ def _gunzip(archive_file):
     decompressed_file = os.path.basename(archive_file.strip(ext))
     working_dir = os.getcwd()
     destination_abspath = os.path.join(working_dir, decompressed_file)
-    if gzip_support():
-        import gzip
-
+    if is_gzip_supported():
         f_in = gzip.open(archive_file, "rb")
         with open(destination_abspath, "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
@@ -187,9 +179,7 @@ def _lzma_decomp(archive_file):
     lzma module, but fall back on command line xz tooling
     to find available Python support. This is the xz command
     on Unix and 7z on Windows"""
-    if lzma_support():
-        import lzma  # novermin
-
+    if lzma_support:
         _, ext = os.path.splitext(archive_file)
         decompressed_file = os.path.basename(archive_file.strip(ext))
         archive_out = os.path.join(os.getcwd(), decompressed_file)
@@ -295,7 +285,7 @@ unrecognized file extension: '%s'"
 
 class FileType:
     _OFFSET = 0
-    _MAGIC_NUMBER = b'\x0000'
+    _MAGIC_NUMBER = b'\x00'
     _ext = ''
     _compressed = False
 
@@ -342,7 +332,7 @@ class CompressedFileType(FileType):
 
     @classmethod
     def decomp_in_memory(cls, filepath):
-        raise RuntimeError("Implementation required")
+        raise RuntimeError("Implementation by subclass required")
 
 
 class BZipFileType(CompressedFileType):
@@ -352,6 +342,7 @@ class BZipFileType(CompressedFileType):
     @classmethod
     def decomp_in_memory(cls, filepath):
         pass
+
 
 class ZCompressedFileType(CompressedFileType):
     _MAGIC_NUMBER_LZW = b'\x1f\x9d'

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -548,7 +548,7 @@ def extension_from_stream(stream, decompress=False):
                     )
                     return extension_from_path(stream.name)
             resultant_ext = suffix_ext if not prefix_ext else ".".join([prefix_ext, suffix_ext])
-            tty.debug("File extension %s successfully dervived by magic number." % resultant_ext)
+            tty.debug("File extension %s successfully derived by magic number." % resultant_ext)
             return resultant_ext
     return None
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -197,6 +197,15 @@ def _lzma_decomp(archive_file):
             return _xz(archive_file)
 
 
+def _win_compressed_tarball_handler(archive_file):
+    """Decompress and extract compressed tarballs on Windows.
+    This method uses 7zips in conjunction with the tar utility
+    to perform decompression and extraction in a two step process
+    first using 7zip to decompress, and tar to extract.
+    """
+    return _untar(_7zip(archive_file))
+
+
 def _xz(archive_file):
     """Decompress lzma compressed .xz files via xz command line
     tool. Available only on Unix
@@ -281,8 +290,11 @@ unrecognized file extension: '%s'"
     if re.match(r"xz", ext):
         return _lzma_decomp
 
+    # Catch tar.xz/tar.Z files here for Windows
+    # as the tar utility on Windows cannot handle such
+    # compression types directly
     if ("xz" in ext or "Z" in ext) and is_windows:
-        return _7zip
+        return _win_compressed_tarball_handler
 
     return _untar
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -415,11 +415,8 @@ class BZipFileType(CompressedFileTypeInterface):
     @classmethod
     def decomp_in_memory(cls, stream):
         if is_bz2_supported():
-            return io.BytesIO(
-                initial_bytes=bz2.BZ2Decompressor().decompress(
-                    stream.read(), max_length=TarFileType.offset() + TarFileType.header_size()
-                )
-            )
+            comp_stream = stream.read(TarFileType.offset() + TarFileType.header_size())
+            return io.BytesIO(initial_bytes=bz2.BZ2Decompressor().decompress(comp_stream))
         return None
 
 
@@ -449,7 +446,7 @@ class ZCompressedFileType(CompressedFileTypeInterface):
 
     @classmethod
     def decomp_in_memory(cls, stream):
-        # python has no method of decompressing `.Z` files
+        # python has no method of decompressing `.Z` files in memory
         return None
 
 

--- a/lib/spack/spack/util/compression.py
+++ b/lib/spack/spack/util/compression.py
@@ -212,14 +212,17 @@ def _win_compressed_tarball_handler(archive_file):
     # record name of new archive so we can extract
     # and later clean up
     decomped_tarball = _7zip(archive_file)
-
-    # run tar on newly decomped archive
-    outfile = _untar(decomped_tarball)
-
-    # clean intermediate archive to mimic end result
-    # produced by one shot decomp/extraction
-    os.remove(decomped_tarball)
-    return outfile
+    # 7zip is able to one shot extract compressed archives
+    # that have been named .txz. If that is the case, there will
+    # be no intermediate archvie to extract.
+    if os.path.exists(decomped_tarball):
+        # run tar on newly decomped archive
+        outfile = _untar(decomped_tarball)
+        # clean intermediate archive to mimic end result
+        # produced by one shot decomp/extraction
+        os.remove(decomped_tarball)
+        return outfile
+    return decomped_tarball
 
 
 def _xz(archive_file):

--- a/lib/spack/spack/util/path.py
+++ b/lib/spack/spack/util/path.py
@@ -71,6 +71,15 @@ def win_exe_ext():
     return ".exe"
 
 
+def find_sourceforge_suffix(path):
+    """find and match sourceforge filepath components
+    Return match object"""
+    match = re.search(r"(.*(?:sourceforge\.net|sf\.net)/.*)(/download)$", path)
+    if match:
+        return match.groups()
+    return path, ""
+
+
 def path_to_os_path(*pths):
     """
     Takes an arbitrary number of positional parameters


### PR DESCRIPTION
At the moment, Spack relies on string parsing to determine compression/archive file extension type when fetching/staging packages. Prior to #27021, if Spack was unable to successfully extract a Spack recognized archive/compression extension, it simply tried to use the `tar` system utility. This was generally successful, however with Windows support, a stricter requirement was needed, specifying that Spack be able to successfully parse the extension or raise and exception.  As has been pointed out by #31499 and a number of other issues, this can at times be fragile and occasionally breaks Spack installs. 

This PR resolves this issue in two ways:

- Improvements to the string parsing (minor)
- Magic number parsing

The magic number parsing is the focal point of this PR. Spack will, if file is on filesystem, read magic bytes from binary stream of file, determining filetype/extension from this information. For compressed file types i.e. `.gz` Spack will decompress and peek at the first bytes in order to determine if the underlying file is an archive type i.e. `.tar`. If Spack is unable to decompress the file in memory (if python version does not include LZMA support for example, or the compression is `LZW` or `LZH`), it falls back on simple filepath parsing to check if the file being compressed is an extractable archive.

This behavior is similar to the `file` command, or `libmagic` but is written in cross platform Python, and thus can be used on Windows. Other pure Python implementations of similar functionalities exist, but either have significant drawbacks that would limit their usage in Spack, are overkill, or produce results that are not consistent with what we need Spack to produce. 

Additional changes made in this PR:

- Python native compression utility importing has been refactored to minimize runtime impact of Python import system.
- Tarball handling and documentation updated to reflect transition away from native python module (see #31563)
- Compression test refactored to reflect impact of above changes
- Refactor `file` usage to a more accessible location within Spack
- `decompressor_for` no longer requires both an extension and a file argument as the extension was being derived from the path in all usages. 


