### PR TITLE
Don't restage develop specs when a patch fails

### DIFF
--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1565,6 +1565,7 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
                 msg = ('A patch failure was detected in %s.' % self.name +
                        ' Build errors may occur due to this.')
                 tty.warn(msg)
+                return
 
         # If this file exists, then we already applied all the patches.
         if os.path.isfile(good_file):

--- a/lib/spack/spack/package_base.py
+++ b/lib/spack/spack/package_base.py
@@ -1556,8 +1556,15 @@ class PackageBase(six.with_metaclass(PackageMeta, PackageViewMixin, object)):
         # If we encounter an archive that failed to patch, restage it
         # so that we can apply all the patches again.
         if os.path.isfile(bad_file):
-            tty.debug('Patching failed last time. Restaging.')
-            self.stage.restage()
+            if self.stage.managed_by_spack:
+                tty.debug('Patching failed last time. Restaging.')
+                self.stage.restage()
+            else:
+                # develop specs/ DIYStages may have patch failures but
+                # should never be restaged
+                msg = ('A patch failure was detected in %s.' % self.name +
+                       ' Build errors may occur due to this.')
+                tty.warn(msg)
 
         # If this file exists, then we already applied all the patches.
         if os.path.isfile(good_file):

--- a/lib/spack/spack/test/patch.py
+++ b/lib/spack/spack/test/patch.py
@@ -214,6 +214,8 @@ def test_patched_dependency(
 
 
 def trigger_bad_patch(pkg):
+    if not os.path.isdir(pkg.stage.source_path):
+        os.makedirs(pkg.stage.source_path)
     bad_file = os.path.join(pkg.stage.source_path, '.spack_patch_failed')
     touch(bad_file)
 
@@ -230,8 +232,9 @@ def test_patch_failure_develop_spec_exits_gracefully(
     libelf = spec['libelf']
     assert 'patches' in list(libelf.variants.keys())
     pkg = libelf.package
-    trigger_bad_patch(pkg)
-    pkg.do_patch()
+    with pkg.stage:
+        trigger_bad_patch(pkg)
+        pkg.do_patch()
     # success if no exceptions raised
 
 
@@ -240,9 +243,10 @@ def test_patch_failure_restages(
     spec = Spec('patch-a-dependency')
     spec.concretize()
     pkg = spec['libelf'].package
-    trigger_bad_patch(pkg)
-    pkg.do_patch()
-    # TODO check that restage happend. not sure how to do
+    with pkg.stage:
+        trigger_bad_patch(pkg)
+        pkg.do_patch()
+        # TODO check that restage happend. not sure how to do
 
 
 def test_multiple_patched_dependencies(mock_packages, config):


### PR DESCRIPTION
If a patch fails for a develop spec a restage is attempted which results in an error.  The error message is not clear, and this is not always a desired behavior for develop specs.  For example, if you are doing a bisect and have to go back in the git history before the patch is valid.

This PR removes this behavior and instead prints a warning to let the user know the patch failed and it __could__ affect their build.