### PR TITLE
py-pyarrow: aarch64 patch no longer applies/required

### DIFF
--- a/var/spack/repos/builtin/packages/py-pyarrow/package.py
+++ b/var/spack/repos/builtin/packages/py-pyarrow/package.py
@@ -54,7 +54,7 @@ class PyPyarrow(PythonPackage, CudaPackage):
         depends_on('arrow+cuda' + v, when='+cuda' + v)
         depends_on('arrow+orc' + v, when='+orc' + v)
 
-    patch('for_aarch64.patch', when='target=aarch64:')
+    patch('for_aarch64.patch', when='@0 target=aarch64:')
 
     def install_options(self, spec, prefix):
         args = []


### PR DESCRIPTION
This patch does not apply correctly to pyarrow 1+, and doesn't seem to be needed anyway.

Without this patch, I'm able to build the latest version on Apple M1 Pro (arm64).