### PR TITLE
Fixes for kallisto package

### DIFF
--- a/var/spack/repos/builtin/packages/kallisto/htslib_configure.patch
+++ b/var/spack/repos/builtin/packages/kallisto/htslib_configure.patch
@@ -1,0 +1,12 @@
+--- a/ext/htslib/configure.ac	2022-01-16 23:02:18.000000000 -0600
++++ b/ext/htslib/configure.ac	2022-07-16 18:45:33.283586367 -0500
+@@ -46,7 +46,9 @@
+    the PACKAGE_* defines are unused and are overridden by the more
+    accurate PACKAGE_VERSION as computed by the Makefile.  */])
+ 
++AC_CANONICAL_HOST
+ AC_PROG_CC
++AC_PROG_INSTALL
+ AC_PROG_RANLIB
+ 
+ dnl Avoid chicken-and-egg problem where pkg-config supplies the

--- a/var/spack/repos/builtin/packages/kallisto/limits.patch
+++ b/var/spack/repos/builtin/packages/kallisto/limits.patch
@@ -1,0 +1,9 @@
+--- a/src/MinCollector.cpp	2020-02-16 16:27:33.000000000 -0600
++++ b/src/MinCollector.cpp	2022-07-17 13:09:47.698229720 -0500
+@@ -1,5 +1,6 @@
+ #include "MinCollector.h"
+ #include <algorithm>
++#include <limits>
+ 
+ // utility functions
+ 

--- a/var/spack/repos/builtin/packages/kallisto/link_zlib.patch
+++ b/var/spack/repos/builtin/packages/kallisto/link_zlib.patch
@@ -1,0 +1,10 @@
+--- a/src/CMakeLists.txt	2017-03-20 05:38:35.000000000 -0500
++++ b/src/CMakeLists.txt	2022-07-17 12:56:04.456804708 -0500
+@@ -32,6 +32,7 @@
+ 
+ if ( ZLIB_FOUND )
+     include_directories( ${ZLIB_INCLUDE_DIRS} )
++    target_link_libraries(kallisto kallisto_core ${ZLIB_LIBRARIES})
+ else()
+     message(FATAL_ERROR "zlib not found. Required for to output files" )
+ endif( ZLIB_FOUND )

--- a/var/spack/repos/builtin/packages/kallisto/package.py
+++ b/var/spack/repos/builtin/packages/kallisto/package.py
@@ -17,8 +17,15 @@ class Kallisto(CMakePackage):
     version('0.46.2', sha256='c447ca8ddc40fcbd7d877d7c868bc8b72807aa8823a8a8d659e19bdd515baaf2')
     version('0.43.1', sha256='7baef1b3b67bcf81dc7c604db2ef30f5520b48d532bf28ec26331cb60ce69400')
 
+    # HDF5 support is optional beginning with version 0.46.2.
+    variant('hdf5',
+            when='@0.46.2:',
+            default=False,
+            description='Build with HDF5 support')
+
     depends_on('zlib')
-    depends_on('hdf5')
+    depends_on('hdf5', when='@:0.43')
+    depends_on('hdf5', when='+hdf5')
 
     # htslib isn't built in time to be used....
     parallel = False
@@ -29,6 +36,19 @@ class Kallisto(CMakePackage):
     depends_on('automake', type='build', when='@0.44.0:')
     depends_on('libtool',  type='build', when='@0.44.0:')
     depends_on('m4',       type='build', when='@0.44.0:')
+
+    patch('link_zlib.patch', when='@:0.43')
+    patch('limits.patch', when='@:0.46')
+    patch('htslib_configure.patch', when='@0.44.0:^autoconf@2.70:')
+
+    @run_before('cmake')
+    def autoreconf(self):
+        # Versions of autoconf greater than 2.69 need config.guess and
+        # config.sub in the tree.
+        if self.spec.satisfies('@0.44.0:^autoconf@2.70:'):
+            with working_dir(join_path(self.stage.source_path, 'ext', 'htslib')):
+                autoreconf = which('autoreconf')
+                autoreconf('--install')
 
     # Including '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON' in the cmake args
     # causes bits of cmake's output to end up in the autoconf-generated
@@ -41,8 +61,10 @@ class Kallisto(CMakePackage):
         setting.
         """
         a = super(Kallisto, self).std_cmake_args
-        if (self.spec.version >= Version('0.44.0')):
+        if self.spec.satisfies('@0.44.0:'):
             args = [i for i in a if i != '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON']
+            if self.spec.satisfies('@0.46.2:'):
+                args.append(self.define_from_variant('USE_HDF5', 'hdf5'))
         else:
             args = a
 


### PR DESCRIPTION
This PR contains several fixes for the kallisto package.

- create hdf5 variant as hdf5 is optional beginning with 0.46.2
- provide patch for 0.43 to link against libz
- provide patch for older versions to build again gcc-11 and up
- patch and code to use autoconf-2.70 and up