### PR TITLE
fix stage with uri params

### DIFF
--- a/lib/spack/spack/fetch_strategy.py
+++ b/lib/spack/spack/fetch_strategy.py
@@ -530,7 +530,7 @@ class URLFetchStrategy(FetchStrategy):
                 "Failed on expand() for URL %s" % self.url)
 
         if not self.extension:
-            self.extension = extension(self.url)
+            self.extension = extension(self.archive_file)
 
         if self.stage.expanded:
             tty.debug('Source already staged to %s' % self.stage.source_path)

--- a/lib/spack/spack/stage.py
+++ b/lib/spack/spack/stage.py
@@ -366,9 +366,9 @@ class Stage(object):
         fnames = []
         expanded = True
         if isinstance(self.default_fetcher, fs.URLFetchStrategy):
+            url_path = url_util.parse(self.default_fetcher.url).path
             expanded = self.default_fetcher.expand_archive
-            clean_url = os.path.basename(
-                sup.sanitize_file_path(self.default_fetcher.url))
+            clean_url = os.path.basename(sup.sanitize_file_path(url_path))
             fnames.append(clean_url)
 
         if self.mirror_paths:


### PR DESCRIPTION
Closes #31499.
 
- don't determine extension of a url
- parse url to drop query params from filename

Can you take over from here @scheibelp / @johnwparent, this regressed in the Windows related work, and I can't invest more time in it right now adding tests.

Reproducer:

```console
$ spack clean -sd && spack -d stage eccodes@2.25.0
```

[As mentioned in #31499, it's better to rely on [Content-Dispostion](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) when provided, since URLs are not file paths. This can be obtained from [get_filename](https://docs.python.org/3/library/email.message.html#email.message.EmailMessage.get_filename) (note that `http.client.HTTPMessage` is a subclass of `email.message.Message` on recent enough Pythons). Either that, or just fix the filename to `your-favorite-name` and detect the file type through magic bytes]