### PR TITLE
Fix CUB imports for CUDA and CMake

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1019,8 +1019,8 @@ def get_cmake_prefix_path(pkg):
     The goal of the order here is put everything provided by spack before everything
     that comes from externals provided to spack.
     """
-    build_deps = set(pkg.spec.dependencies(deptype=('build', 'test')))
-    link_deps = set(pkg.spec.traverse(root=False, deptype=('link')))
+    build_deps = set(pkg.spec.dependencies(deptype=("build", "test")))
+    link_deps = set(pkg.spec.traverse(root=False, deptype=("link")))
     build_link_deps = build_deps | link_deps
     spack_built = []
     externals = []
@@ -1045,16 +1045,15 @@ def get_cmake_prefix_path(pkg):
     # Since we are going to explicitly pass the CMAKE_PREFIX_PATH as a command line
     # argument (to make sure we include the spack prefixs), passing these via the
     # environment won't occur because CMake prefers the CLI argument
-    env_mod_list = modifications_from_dependencies(pkg.spec, 'build',
-                                                   custom_mods_only=True,
-                                                   set_package_py_globals=False)
+    env_mod_list = modifications_from_dependencies(
+        pkg.spec, "build", custom_mods_only=True, set_package_py_globals=False
+    )
     env_mod = {}
     env_mod_list.apply_modifications(env_mod)
     extra_prefix_paths = env_mod.get("CMAKE_PREFIX_PATH", "").split(";")
 
     ordered_build_link_deps = spack_built + extra_prefix_paths + externals
-    build_link_prefixes = filter_system_paths(x for x in
-                                              ordered_build_link_deps)
+    build_link_prefixes = filter_system_paths(x for x in ordered_build_link_deps)
     return build_link_prefixes
 
 

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1033,7 +1033,12 @@ def get_cmake_prefix_path(pkg):
                 externals.insert(0, dspec.prefix)
             else:
                 spack_built.insert(0, dspec.prefix)
-
+    # TODO: for the given arguments, modifications_from_dependencies has no
+    # side effects *other than* setup_dependent_package, which is expected
+    # to be idempotent (e.g. setting attributes on the module twice is not
+    # a problem). Currently the API doesn't strictly prevent that though, so
+    # it should be possible to all modifications_from_dependencies and ensure
+    # that there are *no* side effects.
     # CMAKE_PREFIX_PATH here cannot come from the outside spack under
     # normal circumstances, it has to come from per-package implementations of
     # `setup_build_environment` which modify the shell environment

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -1020,6 +1020,12 @@ def get_cmake_prefix_path(pkg):
     build_link_deps = build_deps | link_deps
     spack_built = []
     externals = []
+
+    env_mod_list = modifications_from_dependencies(pkg.spec, 'build', custom_mods_only=True)
+    env_mod = {}
+    env_mod_list.apply_modifications(env_mod)
+    extra_prefix_paths = env_mod.get("CMAKE_PREFIX_PATH", "").split(";")
+
     # modifications_from_dependencies updates CMAKE_PREFIX_PATH by first
     # prepending all externals and then all non-externals
     for dspec in pkg.spec.traverse(root=False, order="post"):
@@ -1030,8 +1036,9 @@ def get_cmake_prefix_path(pkg):
                 spack_built.insert(0, dspec)
 
     ordered_build_link_deps = spack_built + externals
-    build_link_prefixes = filter_system_paths(x.prefix for x in ordered_build_link_deps)
-    return build_link_prefixes
+    build_link_prefixes = filter_system_paths(
+        x.prefix for x in ordered_build_link_deps)
+    return build_link_prefixes + extra_prefix_paths
 
 
 def _setup_pkg_and_run(

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -465,7 +465,7 @@ class Cuda(Package):
     def setup_dependent_build_environment(self, env, dependent_spec):
         env.set('CUDAHOSTCXX', dependent_spec.package.compiler.cxx)
         if self.spec.satisfies("target=x86_64:"):
-            cub_path =  self.prefix.targets + "/x86_64-linux/lib/cmake"
+            cub_path = self.prefix.targets + "/x86_64-linux/lib/cmake"
             env.append_path("CMAKE_PREFIX_PATH", cub_path)
 
     def setup_run_environment(self, env):

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -463,7 +463,10 @@ class Cuda(Package):
             env.append_path("LD_LIBRARY_PATH", libxml2_home.lib)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set("CUDAHOSTCXX", dependent_spec.package.compiler.cxx)
+        env.set('CUDAHOSTCXX', dependent_spec.package.compiler.cxx)
+        if self.spec.satisfies("target=x86_64:"):
+            cub_path =  self.prefix.targets + "/x86_64-linux/lib/cmake"
+            env.append_path("CMAKE_PREFIX_PATH", cub_path)
 
     def setup_run_environment(self, env):
         env.set("CUDA_HOME", self.prefix)

--- a/var/spack/repos/builtin/packages/cuda/package.py
+++ b/var/spack/repos/builtin/packages/cuda/package.py
@@ -463,7 +463,7 @@ class Cuda(Package):
             env.append_path("LD_LIBRARY_PATH", libxml2_home.lib)
 
     def setup_dependent_build_environment(self, env, dependent_spec):
-        env.set('CUDAHOSTCXX', dependent_spec.package.compiler.cxx)
+        env.set("CUDAHOSTCXX", dependent_spec.package.compiler.cxx)
         if self.spec.satisfies("target=x86_64:"):
             cub_path = self.prefix.targets + "/x86_64-linux/lib/cmake"
             env.append_path("CMAKE_PREFIX_PATH", cub_path)


### PR DESCRIPTION
tl;dr Cuda installs CUB's (a cuda library) cmake files into a place where spack doesn't know about which means it can't tell cmake about it.  We provide a mechanism to tell spack where to find this additional path, and then use it in the cuda package.

fixes #31568

@scheibelp you were the last person to work on the CMAKE_PREFIX_PATH logic.  Could you please review this patch?

@ax3l @Rombur you two are the Cuda maintainers.  Could you please review the change the the Cuda package?