### PR TITLE
Use pkg_cls in spack.mirror.get_all_versions

### DIFF
--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -421,18 +421,16 @@ def get_all_versions(specs):
     version, this information will be omitted in the new set; for example; the
     new set of specs will not include variant settings.
     """
-
     version_specs = []
     for spec in specs:
-        pkg = spec.package
-
+        pkg_cls = spack.repo.path.get_pkg_class(spec.name)
         # Skip any package that has no known versions.
-        if not pkg.versions:
-            tty.msg("No safe (checksummed) versions for package %s" % pkg.name)
+        if not pkg_cls.versions:
+            tty.msg("No safe (checksummed) versions for package %s" % pkg_cls.name)
             continue
 
-        for version in pkg.versions:
-            version_spec = spack.spec.Spec(pkg.name)
+        for version in pkg_cls.versions:
+            version_spec = spack.spec.Spec(pkg_cls.name)
             version_spec.versions = VersionList([version])
             version_specs.append(version_spec)
 

--- a/lib/spack/spack/mirror.py
+++ b/lib/spack/spack/mirror.py
@@ -637,6 +637,10 @@ class MirrorStats(object):
 
 
 def _add_single_spec(spec, mirror, mirror_stats):
+    # Ensure that the spec is concrete, since we'll stage it later
+    if not spec.concrete:
+        spec = spec.concretized()
+
     tty.msg("Adding package {pkg} to mirror".format(
         pkg=spec.format("{name}{@version}")
     ))

--- a/lib/spack/spack/test/mirror.py
+++ b/lib/spack/spack/test/mirror.py
@@ -320,3 +320,16 @@ def test_mirror_cache_symlinks(tmpdir):
     assert os.path.exists(link_target)
     assert (os.path.normpath(link_target) ==
             os.path.join(cache.root, reference.storage_path))
+
+
+@pytest.mark.regression('31627')
+@pytest.mark.parametrize('specs,expected_specs', [
+    (['a'], ['a@1.0', 'a@2.0']),
+    (['a', 'brillig'], ['a@1.0', 'a@2.0', 'brillig@1.0.0', 'brillig@2.0.0']),
+])
+def test_get_all_versions(specs, expected_specs):
+    specs = [Spec(s) for s in specs]
+    output_list = spack.mirror.get_all_versions(specs)
+    output_list = [str(x) for x in output_list]
+    # Compare sets since order is not important
+    assert set(output_list) == set(expected_specs)


### PR DESCRIPTION
fixes #31627

Modifications:
- [x] `spack.mirror.get_all_versions` uses the package class instead of the package object in its implementation
- [x] Add a unit-test to verify function output