### PR TITLE
[py-numpy] Newer versions do not build with `icc`

### DIFF
--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -155,6 +155,9 @@ class PyNumpy(PythonPackage):
     # NVHPC support added in https://github.com/numpy/numpy/pull/17344
     conflicts('%nvhpc', when='@:1.19')
 
+    # Newer versions will not build with Intel https://github.com/numpy/numpy/issues/22011
+    conflicts('%intel', when='@1.23.0:')
+    
     def url_for_version(self, version):
         url = 'https://files.pythonhosted.org/packages/source/n/numpy/numpy-{}.{}'
         if version >= Version('1.23'):

--- a/var/spack/repos/builtin/packages/py-numpy/package.py
+++ b/var/spack/repos/builtin/packages/py-numpy/package.py
@@ -157,7 +157,7 @@ class PyNumpy(PythonPackage):
 
     # Newer versions will not build with Intel https://github.com/numpy/numpy/issues/22011
     conflicts('%intel', when='@1.23.0:')
-    
+
     def url_for_version(self, version):
         url = 'https://files.pythonhosted.org/packages/source/n/numpy/numpy-{}.{}'
         if version >= Version('1.23'):


### PR DESCRIPTION
Workaround until https://github.com/numpy/numpy/issues/22011 is solved.

Flagging maintainers @adamjstewart , @rgommers