### PR TITLE
llvm: Add missing include for version range 8 to 11.1

### DIFF
--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -369,6 +369,11 @@ class Llvm(CMakePackage, CudaPackage):
     # make libflags a list in openmp subproject when ~omp_as_runtime
     patch('libomp-libflags-as-list.patch', when='@3.7:14')
 
+    # Add missing include leading to build fail with clang
+    patch('https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1.patch',
+          sha256='151d0fb4c32933d224033c2fd855b28fe85c7d487307c6345c7074c19d77feb5',
+          when='@8.0.0:11.1.0')
+
     # The functions and attributes below implement external package
     # detection for LLVM. See:
     #

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -372,7 +372,7 @@ class Llvm(CMakePackage, CudaPackage):
     # Add missing include leading to build fail with clang
     patch('https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1.patch',
           sha256='151d0fb4c32933d224033c2fd855b28fe85c7d487307c6345c7074c19d77feb5',
-          when='@8.0.0:11.1.0')
+          when='@8:11')
 
     # The functions and attributes below implement external package
     # detection for LLVM. See:

--- a/var/spack/repos/builtin/packages/llvm/package.py
+++ b/var/spack/repos/builtin/packages/llvm/package.py
@@ -370,8 +370,8 @@ class Llvm(CMakePackage, CudaPackage):
     patch('libomp-libflags-as-list.patch', when='@3.7:14')
 
     # Add missing include leading to build fail with clang
-    patch('https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1.patch',
-          sha256='151d0fb4c32933d224033c2fd855b28fe85c7d487307c6345c7074c19d77feb5',
+    patch('https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1.patch?full_index=1',
+          sha256='514926d661635de47972c7d403c9c4669235aa51e22e56d44676d2a2709179b6',
           when='@8:11')
 
     # The functions and attributes below implement external package


### PR DESCRIPTION
The missing include causes this when built with clang 14.0.6:
```
  >> 15362    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:30: error: no member named 'numeric_limits' in namespa
              ce 'std'
     15363      static const T kmax = std::numeric_limits<T>::max();
     15364                            ~~~~~^
  >> 15365    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:45: error: 'T' does not refer to a value
     15366      static const T kmax = std::numeric_limits<T>::max();
     15367                                                ^
     15368    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.h:8:20: note: declared here
     15369    template <typename T>
     15370                       ^
  >> 15371    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:47: error: no member named 'max' in the global namespa
              ce; did you mean 'kmax'?
     15372      static const T kmax = std::numeric_limits<T>::max();
     15373                                                  ^~~~~
     15374                                                  kmax
     15375    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:18: note: 'kmax' declared here
     15376      static const T kmax = std::numeric_limits<T>::max();
     15377                     ^
  >> 15378    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:18: error: default initialization of an object of cons
              t type 'const long'
     15379      static const T kmax = std::numeric_limits<T>::max();
     15380                     ^
     15381                          = 0
     15382    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.cc:270:3: note: in instantiation of function template speci
              alization 'AddRange<long>' requested here
     15383      AddRange(&arglist, start, limit, range_multiplier_);
     15384      ^
     15385    In file included from /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.cc:15:
  >> 15386    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.h:17:18: error: default initialization of an object of cons
              t type 'const int'
     15387      static const T kmax = std::numeric_limits<T>::max();
     15388                     ^
     15389                          = 0
     15390    /tmp/hahansen/spack-stage/spack-stage-llvm-11.1.0-lnorvtce7t3z4iwsbvy7k7fkdw54f4iz/spack-src/llvm/utils/benchmark/src/benchmark_register.cc:417:3: note: in instantiation of function template speci
              alization 'AddRange<int>' requested here
     15391      AddRange(&thread_counts_, min_threads, max_threads, 2);
     15392      ^
```