### PR TITLE
environment.py: only install root specs explicitly

### DIFF
--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -131,8 +131,9 @@ which is useful for CI pipeline troubleshooting""")
         help='(with environment) only install already concretized specs')
     subparser.add_argument(
         '--no-add', action='store_true', default=False,
-        help="""(with environment) only install specs provided as argument
-if they are already in the concretized environment""")
+        help="""(with environment) partially install an environment, limiting
+to concrete specs in the environment matching the arguments.
+Non-roots remain installed implicitly.""")
     subparser.add_argument(
         '-f', '--file', action='append', default=[],
         dest='specfiles', metavar='SPEC_YAML_FILE',

--- a/lib/spack/spack/environment/environment.py
+++ b/lib/spack/spack/environment/environment.py
@@ -1643,7 +1643,9 @@ class Environment(object):
 
         installs = []
         for spec in specs_to_install:
-            installs.append((spec.package, install_args))
+            pkg_install_args = install_args.copy()
+            pkg_install_args['explicit'] = spec in self.roots()
+            installs.append((spec.package, pkg_install_args))
 
         try:
             builder = PackageInstaller(installs)


### PR DESCRIPTION
When doing a partial environment install (e.g. installing an individual package
`spack -e . install --no-add /<hash>`) spack marks this package as explicit.

This is a problem for `spack env depfile -o Makefile`, which generates a `spack`
`-e . install --no-add /<hash>` command for every spec in the environment, meaning one
ends up with all specs installed explicitly, which is undesirable.

Note that whenever `spack -e . install new-spec` is executed and `new-spec` is
not yet in the environment, it is added as a root spec, and therefore it will
still be marked explicit.

So, the environment install semantics are: root spec implies explicit,
and if you need a dependency to be installed explicitly, then you should add it
to the root specs and rely on `concretizer:unify:true`.

Requires #31646, cause installing a single package implicitly is broken right now.

