### PR TITLE
New version for openCARP packages, v11.0

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -16,6 +16,7 @@ class Meshtool(MakefilePackage):
 
     version('master', branch='master', preferred=True)
     # Version to use with openCARP releases
+    version('oc11.0', commit='867431d')
     version('oc10.0', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')
     version('oc9.0', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')
     version('oc8.2', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -18,7 +18,8 @@ class Opencarp(CMakePackage):
 
     maintainers = ['MarieHouillon']
 
-    version('10.0', commit='7aec7900', submodules=False, no_cache=True, preferred=True)
+    version('11.0', commit='97c18881', submodules=False, no_cache=True, preferred=True)
+    version('10.0', commit='7aec7900', submodules=False, no_cache=True)
     version('9.0', commit='c0167599', submodules=False, no_cache=True)
     version('8.2', commit='dbfd16fd', submodules=False, no_cache=True)
     version('8.1', commit='28eb2e97', submodules=False, no_cache=True)
@@ -43,7 +44,7 @@ class Opencarp(CMakePackage):
     depends_on('py-carputils', when='+carputils')
     depends_on('meshtool', when='+meshtool')
     # Use specific versions of carputils and meshtool for releases
-    for ver in ['10.0', '9.0', '8.2', '7.0', '8.1']:
+    for ver in ['11.0', '10.0', '9.0', '8.2', '7.0', '8.1']:
         depends_on('py-carputils@oc' + ver, when='@' + ver + ' +carputils')
         depends_on('meshtool@oc' + ver, when='@' + ver + ' +meshtool')
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -17,6 +17,7 @@ class PyCarputils(PythonPackage):
 
     version('master', branch='master')
     # Version to use with openCARP releases
+    version('oc11.0', commit='a02f9b846c6e852b7315b20e925d55c355f239b8')
     version('oc10.0', commit='a02f9b846c6e852b7315b20e925d55c355f239b8')
     version('oc9.0', commit='e79e66b25c7bfaf405fad595019594ab9aa83392')
     version('oc8.2', commit='e60f639c0f39ad71c8ae11814de1f3aa726e8352')


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py-carputils.