### PR TITLE
VisIt: Update to VisIt 3.3.0.

### DIFF
--- a/var/spack/repos/builtin/packages/visit/package.py
+++ b/var/spack/repos/builtin/packages/visit/package.py
@@ -69,6 +69,7 @@ class Visit(CMakePackage):
     executables = ['^visit$']
 
     version('develop', branch='develop')
+    version('3.3.0', sha256='1a7485146133ac5f1e330d9029697750046ef8d9e9de23a6c2a3685c1c5f4aac')
     version('3.2.2', sha256='d19ac24c622a3bc0a71bc9cd6e5c9860e43f39e3279672129278b6ebce8d0ead')
     version('3.2.1', sha256='779d59564c63f31fcbfeff24b14ddd6ac941b3bb7d671d31765a770d193f02e8')
     version('3.1.1', sha256='0b60ac52fd00aff3cf212a310e36e32e13ae3ca0ddd1ea3f54f75e4d9b6c6cf0')
@@ -85,10 +86,11 @@ class Visit(CMakePackage):
     variant('python', default=True, description='Enable Python support')
     variant('mpi',    default=True, description='Enable parallel engine')
 
-    patch('spack-changes-3.1.patch', when="@3.1.0:,develop")
+    patch('spack-changes-3.1.patch', when="@3.1.0:3.2.2")
     patch('spack-changes-3.0.1.patch', when="@3.0.1")
     patch('nonframework-qwt.patch', when='^qt~framework platform=darwin')
-    patch('parallel-hdf5.patch', when='+hdf5+mpi')
+    patch('parallel-hdf5.patch', when='@3.0.1:3.2.2+hdf5+mpi')
+    patch('parallel-hdf5-3.3.patch', when='@3.3.0:+hdf5+mpi')
 
     # Exactly one of 'gui' or 'osmesa' has to be enabled
     conflicts('+gui', when='+osmesa')

--- a/var/spack/repos/builtin/packages/visit/parallel-hdf5-3.3.patch
+++ b/var/spack/repos/builtin/packages/visit/parallel-hdf5-3.3.patch
@@ -1,0 +1,20 @@
+diff -u ./src/CMake/FindHDF5.cmake.orig ./src/CMake/FindHDF5.cmake
+--- ./src/CMake/FindHDF5.cmake.orig	2022-07-19 10:58:59.764308000 -0700
++++ ./src/CMake/FindHDF5.cmake	2022-07-19 10:59:24.850296000 -0700
+@@ -15,7 +15,7 @@
+ #
+ #****************************************************************************/
+ 
+-# Use the HDF5_DIR hint from the config-site .cmake file 
++# Use the HDF5_DIR hint from the config-site .cmake file
+ 
+ INCLUDE(${VISIT_SOURCE_DIR}/CMake/SetUpThirdParty.cmake)
+ 
+@@ -42,6 +42,6 @@
+ ELSE()
+   SET_UP_THIRD_PARTY(HDF5 LIBS hdf5)
+   IF(VISIT_PARALLEL)
+-      SET_UP_THIRD_PARTY(HDF5_MPI LIBS hdf5_mpi)
++      SET_UP_THIRD_PARTY(HDF5_MPI LIBS hdf5)
+   ENDIF(VISIT_PARALLEL)
+ ENDIF()


### PR DESCRIPTION
Updated the VisIt spack package for VisIt 3.3.0.

I restricted an existing patch since it was no longer needed with 3.3.0.
I added a 3.3.0 and later variant of the parallel-hdf5 patch and made the parallel-hdf5 patch only apply to versions prior to 3.3.0 since the code changed slightly.

I tested this on "crusher.olcf.ornl.gov", an early access system for the Frontier exascale system at Oak Ridge National Lab. I successfully displayed images in the GUI.

