### PR TITLE
darshan-runtime,darshan-util: add new 3.4.0 release

### DIFF
--- a/var/spack/repos/builtin/packages/darshan-runtime/package.py
+++ b/var/spack/repos/builtin/packages/darshan-runtime/package.py
@@ -25,8 +25,9 @@ class DarshanRuntime(AutotoolsPackage):
     test_requires_compiler = True
 
     version('main', branch='main', submodules=True)
+    version('3.4.0', sha256='7cc88b7c130ec3b574f6b73c63c3c05deec67b1350245de6d39ca91d4cff0842', preferred=True)
     version('3.4.0-pre1', sha256='57d0fd40329b9f8a51bdc9d7635b646692b341d80339115ab203357321706c09')
-    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7', preferred=True)
+    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7')
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')

--- a/var/spack/repos/builtin/packages/darshan-util/package.py
+++ b/var/spack/repos/builtin/packages/darshan-util/package.py
@@ -21,8 +21,9 @@ class DarshanUtil(AutotoolsPackage):
     tags = ['e4s']
 
     version('main', branch='main', submodules='True')
+    version('3.4.0', sha256='7cc88b7c130ec3b574f6b73c63c3c05deec67b1350245de6d39ca91d4cff0842', preferred=True)
     version('3.4.0-pre1', sha256='57d0fd40329b9f8a51bdc9d7635b646692b341d80339115ab203357321706c09')
-    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7', preferred=True)
+    version('3.3.1', sha256='281d871335977d0592a49d053df93d68ce1840f6fdec27fea7a59586a84395f7')
     version('3.3.0', sha256='2e8bccf28acfa9f9394f2084ec18122c66e45d966087fa2e533928e824fcb57a')
     version('3.3.0-pre2', sha256='0fc09f86f935132b7b05df981b05cdb3796a1ea02c7acd1905323691df65e761')
     version('3.3.0-pre1', sha256='1c655359455b5122921091bab9961491be58a5f0158f073d09fe8cc772bd0812')


### PR DESCRIPTION
- Add new 3.4.0 releases to darshan-runtime and darshan-util packages
- Make 3.4.0 release preferred over 3.4.0-pre1 release