### PR TITLE
py-torch: use immutable URLs for open-ce patches

### DIFF
--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -156,7 +156,8 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('cudnn@6:7', when='@:1.0+cudnn')
     depends_on('cudnn@7.0:7', when='@1.1:1.5+cudnn')
     depends_on('cudnn@7:', when='@1.6:+cudnn')
-    depends_on('magma', when='+magma')
+    depends_on('magma+cuda~rocm', when='+magma+cuda')
+    depends_on('magma+rocm~cuda', when='+magma+rocm')
     depends_on('nccl', when='+nccl')
     depends_on('numactl', when='+numa')
     depends_on('llvm-openmp', when='%apple-clang +openmp')
@@ -253,17 +254,20 @@ class PyTorch(PythonPackage, CudaPackage):
 
     # Use patches from IBM's Open CE to enable building on Power systems
     # 03xx - patch temporary to fix a problem that when fixed upstream can be removed
-    patch('https://github.com/open-ce/pytorch-feedstock/raw/main/recipe/0302-cpp-extension.patch',
-          sha256='ecb3973fa7d0f4c8f8ae40433f3ca5622d730a7b16f6cb63325d1e95baff8aa2', when='@1.10.0: arch=ppc64le:')
+    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0302-cpp-extension.patch',
+          sha256='ecb3973fa7d0f4c8f8ae40433f3ca5622d730a7b16f6cb63325d1e95baff8aa2', when='@1.10.0:1.11.0 arch=ppc64le:')
 
-    patch('https://github.com/open-ce/pytorch-feedstock/raw/main/recipe/0311-PR66085-Remove-unused-dump-method-from-VSX-vec256-methods.patch',
-          sha256='f05db59f3def4c4215db7142d81029c73fe330c660492159b66d65ca5001f4d1', when='@1.10.0: arch=ppc64le:')
+    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0311-PR66085-Remove-unused-dump-method-from-VSX-vec256-methods.patch',
+          sha256='f05db59f3def4c4215db7142d81029c73fe330c660492159b66d65ca5001f4d1', when='@1.10.0:1.11.0 arch=ppc64le:')
 
-    patch('https://github.com/open-ce/pytorch-feedstock/raw/main/recipe/0312-PR67331-Dummpy-VSX-bfloat16-implementation.patch',
-          sha256='860b64afa85f5e6647ebc3c91d5a0bb258784770900c9302c3599c98d5cff1ee', when='@1.10.0: arch=ppc64le:')
+    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0312-PR67331-Dummpy-VSX-bfloat16-implementation.patch',
+          sha256='860b64afa85f5e6647ebc3c91d5a0bb258784770900c9302c3599c98d5cff1ee', when='@1.10.0:1.11.0 arch=ppc64le:')
 
-    patch('https://github.com/open-ce/pytorch-feedstock/raw/main/recipe/0313-add-missing-vsx-dispatch.patch',
-          sha256='7393c2bc0b6d41ecc813c829a1e517bee864686652e91f174cb7bcdfb10ba451', when='@1.10.0: arch=ppc64le:')
+    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0313-add-missing-vsx-dispatch.patch',
+          sha256='7393c2bc0b6d41ecc813c829a1e517bee864686652e91f174cb7bcdfb10ba451', when='@1.10.0:1.11.0 arch=ppc64le:')
+
+    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.12/recipe/0302-cpp-extension.patch',
+          sha256='2fac519cca8997f074c263505657ff867e7ba2d6637fc8bda99c70a99be0442a', when='@1.12.0: arch=ppc64le:')
 
     # Cherry-pick a patch to allow earlier versions of PyTorch to work with CUDA 11.4
     patch('https://github.com/pytorch/pytorch/commit/c74c0c571880df886474be297c556562e95c00e0.patch?full_index=1',

--- a/var/spack/repos/builtin/packages/py-torch/package.py
+++ b/var/spack/repos/builtin/packages/py-torch/package.py
@@ -156,8 +156,8 @@ class PyTorch(PythonPackage, CudaPackage):
     depends_on('cudnn@6:7', when='@:1.0+cudnn')
     depends_on('cudnn@7.0:7', when='@1.1:1.5+cudnn')
     depends_on('cudnn@7:', when='@1.6:+cudnn')
-    depends_on('magma+cuda~rocm', when='+magma+cuda')
-    depends_on('magma+rocm~cuda', when='+magma+rocm')
+    depends_on('magma+cuda', when='+magma+cuda')
+    depends_on('magma+rocm', when='+magma+rocm')
     depends_on('nccl', when='+nccl')
     depends_on('numactl', when='+numa')
     depends_on('llvm-openmp', when='%apple-clang +openmp')
@@ -254,20 +254,20 @@ class PyTorch(PythonPackage, CudaPackage):
 
     # Use patches from IBM's Open CE to enable building on Power systems
     # 03xx - patch temporary to fix a problem that when fixed upstream can be removed
-    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0302-cpp-extension.patch',
-          sha256='ecb3973fa7d0f4c8f8ae40433f3ca5622d730a7b16f6cb63325d1e95baff8aa2', when='@1.10.0:1.11.0 arch=ppc64le:')
+    patch('https://github.com/open-ce/pytorch-feedstock/raw/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0302-cpp-extension.patch',
+          sha256='ecb3973fa7d0f4c8f8ae40433f3ca5622d730a7b16f6cb63325d1e95baff8aa2', when='@1.10:1.11 arch=ppc64le:')
 
-    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0311-PR66085-Remove-unused-dump-method-from-VSX-vec256-methods.patch',
-          sha256='f05db59f3def4c4215db7142d81029c73fe330c660492159b66d65ca5001f4d1', when='@1.10.0:1.11.0 arch=ppc64le:')
+    patch('https://github.com/open-ce/pytorch-feedstock/raw/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0311-PR66085-Remove-unused-dump-method-from-VSX-vec256-methods.patch',
+          sha256='f05db59f3def4c4215db7142d81029c73fe330c660492159b66d65ca5001f4d1', when='@1.10:1.11 arch=ppc64le:')
 
-    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0312-PR67331-Dummpy-VSX-bfloat16-implementation.patch',
-          sha256='860b64afa85f5e6647ebc3c91d5a0bb258784770900c9302c3599c98d5cff1ee', when='@1.10.0:1.11.0 arch=ppc64le:')
+    patch('https://github.com/open-ce/pytorch-feedstock/raw/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0312-PR67331-Dummpy-VSX-bfloat16-implementation.patch',
+          sha256='860b64afa85f5e6647ebc3c91d5a0bb258784770900c9302c3599c98d5cff1ee', when='@1.10:1.11 arch=ppc64le:')
 
-    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0313-add-missing-vsx-dispatch.patch',
-          sha256='7393c2bc0b6d41ecc813c829a1e517bee864686652e91f174cb7bcdfb10ba451', when='@1.10.0:1.11.0 arch=ppc64le:')
+    patch('https://github.com/open-ce/pytorch-feedstock/raw/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.10/recipe/0313-add-missing-vsx-dispatch.patch',
+          sha256='7393c2bc0b6d41ecc813c829a1e517bee864686652e91f174cb7bcdfb10ba451', when='@1.10:1.11 arch=ppc64le:')
 
-    patch('https://raw.githubusercontent.com/open-ce/pytorch-feedstock/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.12/recipe/0302-cpp-extension.patch',
-          sha256='2fac519cca8997f074c263505657ff867e7ba2d6637fc8bda99c70a99be0442a', when='@1.12.0: arch=ppc64le:')
+    patch('https://github.com/open-ce/pytorch-feedstock/raw/0a145060ca8523314ec3893af935c3b140e2d0b0/pytorch-1.12/recipe/0302-cpp-extension.patch',
+          sha256='2fac519cca8997f074c263505657ff867e7ba2d6637fc8bda99c70a99be0442a', when='@1.12: arch=ppc64le:')
 
     # Cherry-pick a patch to allow earlier versions of PyTorch to work with CUDA 11.4
     patch('https://github.com/pytorch/pytorch/commit/c74c0c571880df886474be297c556562e95c00e0.patch?full_index=1',


### PR DESCRIPTION
Also update magma dependency specs to be more explicit.

Previous patches were pointed at the main branch of the open-ce repository, which reorganized their directory layout and broke the links to these patches.  Also added a new patch for 1.12.0 (which was part of the reorganization).  The 1.12.0 build has been tested on Lassen at LLNL.