### PR TITLE
Add ignore_whitespace option for patching

### DIFF
--- a/lib/spack/spack/directives.py
+++ b/lib/spack/spack/directives.py
@@ -508,7 +508,8 @@ def provides(*specs, **kwargs):
 
 
 @directive('patches')
-def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
+def patch(url_or_filename, level=1, when=None, working_dir=".",
+          ignore_whitespace=False, **kwargs):
     """Packages can declare patches to apply to source.  You can
     optionally provide a when spec to indicate that a particular
     patch should only be applied when the package's spec meets
@@ -520,6 +521,8 @@ def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
         when (spack.spec.Spec): optional anonymous spec that specifies when to apply
             the patch
         working_dir (str): dir to change to before applying
+        ignore_whitespace (bool): if True, ignore whitespace differences
+            in patch
 
     Keyword Args:
         sha256 (str): sha256 sum of the patch, used to verify the patch
@@ -553,11 +556,11 @@ def patch(url_or_filename, level=1, when=None, working_dir=".", **kwargs):
         if '://' in url_or_filename:
             patch = spack.patch.UrlPatch(
                 pkg, url_or_filename, level, working_dir,
-                ordering_key=ordering_key, **kwargs)
+                ignore_whitespace, ordering_key=ordering_key, **kwargs)
         else:
             patch = spack.patch.FilePatch(
                 pkg, url_or_filename, level, working_dir,
-                ordering_key=ordering_key)
+                ignore_whitespace, ordering_key=ordering_key)
 
         cur_patches.append(patch)
 

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -75,7 +75,7 @@ class Patch(object):
 
     """
     def __init__(self, pkg, path_or_url, level,
-                 working_dir, ignore_whitespace):
+                 working_dir, ignore_whitespace=False):
         # validate level (must be an integer >= 0)
         if not isinstance(level, int) or not level >= 0:
             raise ValueError("Patch level needs to be a non-negative integer.")

--- a/lib/spack/spack/patch.py
+++ b/lib/spack/spack/patch.py
@@ -170,7 +170,8 @@ class FilePatch(Patch):
             msg += 'package %s.%s does not exist.' % (pkg.namespace, pkg.name)
             raise ValueError(msg)
 
-        super(FilePatch, self).__init__(pkg, abs_path, level, working_dir, ignore_whitespace)
+        super(FilePatch, self).__init__(pkg, abs_path, level,
+                                        working_dir, ignore_whitespace)
         self.path = abs_path
         self._sha256 = None
         self.ordering_key = ordering_key


### PR DESCRIPTION
Adding an ignore whitespace option for patches, partly inspired by https://github.com/spack/spack/pull/6985.

Tested in feynhiggs package: Added version 2.10.2 with patch https://gitlab.cern.ch/sft/lcgcmake/-/blob/master/generators/patches/feynhiggs-2.10.2-gcc10.patch locally. This fails due to the lack of ignored whitespaces:
```
$ spack install feynhiggs@2.10.2
==> Installing feynhiggs-2.10.2-foi6byjshhxzicbaalne526l6nicbtln
==> No binary for feynhiggs-2.10.2-foi6byjshhxzicbaalne526l6nicbtln found: installing from source
==> Fetching https://lcgpackages.web.cern.ch/tarFiles/sources/MCGeneratorsTarFiles/FeynHiggs-2.10.2.tar.gz
==> Fetching https://gitlab.cern.ch/sft/lcgcmake/-/raw/master/generators/patches/feynhiggs-2.10.2-gcc10.patch
1 out of 1 hunk FAILED -- saving rejects to file makefile.in.rej
==> Patch https://gitlab.cern.ch/sft/lcgcmake/-/raw/master/generators/patches/feynhiggs-2.10.2-gcc10.patch failed.
==> Error: ProcessError: Command exited with status 1:
    '/usr/bin/patch' '-s' '-p' '0' '-i' '/tmp/hahansen/spack-stage/spack-stage-_dgoklz2/feynhiggs-2.10.2-gcc10.patch' '-d' '.'
```
After I implemented the `ignore_whitespace` option, I got the same error as above when `ignore_whitespace` is set to `False`. When I set it to be `True`, `feynhiggs@2.10.2` patches and installs successfully.