### PR TITLE
autotools: add -I flag when non-standard libtool

### DIFF
--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -359,7 +359,7 @@ To resolve this problem, please try the following:
 
     @property
     def autoreconf_search_path_args(self):
-        """Search path includes for autoreconf: add an -I flag for all `aclocal` dirs
+        """Search path includes for autoreconf. Add an -I flag for all `aclocal` dirs
         of build deps, skips the default path of automake, move external include
         flags to the back, since they might pull in unrelated m4 files shadowing
         spack dependencies."""

--- a/lib/spack/spack/build_systems/autotools.py
+++ b/lib/spack/spack/build_systems/autotools.py
@@ -359,12 +359,15 @@ To resolve this problem, please try the following:
 
     @property
     def autoreconf_search_path_args(self):
-        """Arguments to autoreconf to modify the search paths"""
-        search_path_args = []
-        for dep in self.spec.dependencies(deptype='build'):
-            if os.path.exists(dep.prefix.share.aclocal):
-                search_path_args.extend(['-I', dep.prefix.share.aclocal])
-        return search_path_args
+        """Add include flags for libtool if in a different prefix than automake.
+        Precondition for this method is that automake and libtool are dependencies of
+        the current spec."""
+        automake = self.spec.dependencies(name='automake', deptype='build')[0].prefix
+        libtool = self.spec.dependencies(name='libtool', deptype='build')[0].prefix
+        if os.path.samefile(automake, libtool):
+            return []
+        else:
+            return ['-I', libtool.share.aclocal]
 
     @run_after('autoreconf')
     def set_configure_or_die(self):


### PR DESCRIPTION
Closes: #31095, #27063 (and also #17311, #16245 but they were closed because of a workaround, not a fix)

Fixes errors of the type:

```
libtool: Version mismatch error. This is libtool 2.4.7, but the
libtool: definition of this LT_INIT comes from libtool 2.4.2.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.7
libtool: and run autoconf again.
```

When
1. Spack installs libtool,
2. system libtool is installed too, and
3. system automake is used

Spack passes system automake's `-I <prefix>` flag to itself, even though
it's a default "3rd party" search path. This takes precedence over spack's libtool
prefix dir. This causes the wrong `libtool.m4` file to be used (since
system libtool is in the same prefix as system automake).

Since the [search order](https://www.gnu.org/software/automake/manual/html_node/Macro-Search-Path.html) is:
1. `-I` in order of appearance
2. [automake prefix acdir]-APIVERSION -- automakes own m4 files
3. [automake prefix acdir] -- third party m4 files

This PR
a. drops the `-I` we used to add for automake itself (which is in fact the third party m4 files dir).
b. partitions the remaining `-I` flags by Spack dep & external dep, to avoid shadowing (typically externals would also be in the third party m4 files dir...)