### PR TITLE
py-torchdata: add new package

### DIFF
--- a/var/spack/repos/builtin/packages/aws-sdk-cpp/package.py
+++ b/var/spack/repos/builtin/packages/aws-sdk-cpp/package.py
@@ -1,0 +1,30 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class AwsSdkCpp(CMakePackage):
+    """AWS SDK for C++.
+
+    The AWS SDK for C++ provides a modern C++ (version C++ 11 or later) interface for
+    Amazon Web Services (AWS). It is meant to be performant and fully functioning with
+    low- and high-level SDKs, while minimizing dependencies and providing platform
+    portability (Windows, OSX, Linux, and mobile).
+    """
+
+    homepage = "https://github.com/aws/aws-sdk-cpp"
+    git = "https://github.com/aws/aws-sdk-cpp.git"
+
+    version('1.9.247', tag='1.9.247', submodules=True)
+
+    depends_on('cmake@3.1:', type='build')
+    depends_on('zlib')
+    depends_on('curl')
+
+    # https://github.com/aws/aws-sdk-cpp/issues/1816
+    patch('https://github.com/aws/aws-sdk-cpp/pull/1937.patch?full_index=1',
+          sha256='ba86e0556322604fb4b70e2dd4f4fb874701868b07353fc1d5c329d90777bf45',
+          when='@1.9.247')

--- a/var/spack/repos/builtin/packages/py-portalocker/package.py
+++ b/var/spack/repos/builtin/packages/py-portalocker/package.py
@@ -7,12 +7,13 @@ from spack.package import *
 
 
 class PyPortalocker(PythonPackage):
-    """Portalocker is a library to provide an easy API to file
-    locking."""
+    """Portalocker is a library to provide an easy API to file locking."""
 
     homepage = "https://github.com/WoLpH/portalocker"
-    url      = "https://github.com/WoLpH/portalocker/archive/v1.6.0.tar.gz"
+    pypi = "portalocker/portalocker-2.5.1.tar.gz"
 
-    version('1.6.0', sha256='084ff315ccb9fb38a7c06155d409da5df29647da7c6d2bc2b24637f9f79001ff')
+    version('2.5.1', sha256='ae8e9cc2660da04bf41fa1a0eef7e300bb5e4a5869adfb1a6d8551632b559b2b')
+    version('1.6.0', sha256='4013e6d17123560178a5ba28cb6fdf13fd3079dee18571ff824e05b7abc97b94')
 
+    depends_on('python@3.5:', when='@2:', type=('build', 'run'))
     depends_on('py-setuptools@38.3.0:', type='build')

--- a/var/spack/repos/builtin/packages/py-torchdata/package.py
+++ b/var/spack/repos/builtin/packages/py-torchdata/package.py
@@ -32,8 +32,8 @@ class PyTorchdata(PythonPackage):
     depends_on('py-portalocker@2:', when='@0.4:', type=('build', 'run'))
 
     # third_party/CMakeLists.txt
-    depends_on('py-pybind11')
-    depends_on('aws-sdk-cpp')
+    depends_on('py-pybind11', when='@0.4:')
+    depends_on('aws-sdk-cpp', when='@0.4:')
 
     def setup_build_environment(self, env):
         env.set('USE_SYSTEM_LIBS', 'ON')

--- a/var/spack/repos/builtin/packages/py-torchdata/package.py
+++ b/var/spack/repos/builtin/packages/py-torchdata/package.py
@@ -1,0 +1,39 @@
+# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class PyTorchdata(PythonPackage):
+    """Composable data loading modules for PyTorch."""
+
+    homepage = "https://github.com/pytorch/data"
+    git = "https://github.com/pytorch/data.git"
+    url = "https://github.com/pytorch/data/archive/refs/tags/v0.4.0.tar.gz"
+
+    maintainers = ['adamjstewart']
+
+    version('main', branch='main')
+    version('0.4.0', sha256='b4ec446a701680faa620fcb828b98ba36a63fa79da62a1e568d4a683889172da')
+    version('0.3.0', sha256='ac36188bf133cf5f1041a28ccb3ee82ba52d4b5d99617be37d64d740acd6cfd4')
+
+    # https://github.com/pytorch/data#version-compatibility
+    depends_on('python@3.7:3.10', type=('build', 'run'))
+    depends_on('py-torch@master', when='@main', type=('build', 'run'))
+    depends_on('py-torch@1.12', when='@0.4', type=('build', 'run'))
+    depends_on('py-torch@1.11', when='@0.3', type=('build', 'run'))
+
+    # requirements.txt
+    depends_on('py-setuptools', type='build')
+    depends_on('py-urllib3@1.25:', type=('build', 'run'))
+    depends_on('py-requests', type=('build', 'run'))
+    depends_on('py-portalocker@2:', when='@0.4:', type=('build', 'run'))
+
+    # third_party/CMakeLists.txt
+    depends_on('py-pybind11')
+    depends_on('aws-sdk-cpp')
+
+    def setup_build_environment(self, env):
+        env.set('USE_SYSTEM_LIBS', 'ON')


### PR DESCRIPTION
Successfully builds on macOS 12.4 (Apple M1 Pro) with Python 3.9.13 and Apple Clang 13.1.6.