### PR TITLE
Sphinx 5.1.0 breaks doc builds

### DIFF
--- a/lib/spack/docs/requirements.txt
+++ b/lib/spack/docs/requirements.txt
@@ -1,7 +1,7 @@
 # These dependencies should be installed using pip in order
 # to build the documentation.
 
-sphinx>=3.4,!=4.1.2
+sphinx>=3.4,!=4.1.2,!=5.1.0
 sphinxcontrib-programoutput
 sphinx-rtd-theme
 python-levenshtein


### PR DESCRIPTION
Sphinx 5.1.0 contains a bug that breaks Napoleon docstrings under certain circumstances: https://github.com/sphinx-doc/sphinx/issues/10701

See https://readthedocs.org/projects/spack/builds/17523257/ for an example of this error message.

This PR prevents RtD from using Sphinx 5.1.0, hoping the bug is fixed in 5.1.1.