### PR TITLE
mysql: add 'cpp' path for rpcgen

### DIFF
--- a/var/spack/repos/builtin/packages/mysql/package.py
+++ b/var/spack/repos/builtin/packages/mysql/package.py
@@ -197,3 +197,18 @@ class Mysql(CMakePackage):
         if 'python' in self.spec.flat_dependencies() and \
            self.spec.satisfies('@:7'):
             self._fix_dtrace_shebang(env)
+
+    @run_before('build')
+    def change_makefile(self):
+        # Add 'cpp' path for rpcgen
+        mysqlgcs_path = join_path(self.build_directory,
+                                  'plugin/group_replication/libmysqlgcs/CMakeFiles/')
+        filter_file(r'rpcgen',
+                    'rpcgen -Y {0}/lib/spack/env'.format(spack.paths.spack_root),
+                    join_path(mysqlgcs_path, 'gen_xcom_vp_h.dir/build.make'))
+        filter_file(r'rpcgen',
+                    'rpcgen -Y {0}/lib/spack/env'.format(spack.paths.spack_root),
+                    join_path(mysqlgcs_path, 'gen_xcom_vp_c.dir/build.make'))
+        filter_file(r'rpcgen',
+                    'rpcgen -Y {0}/lib/spack/env'.format(spack.paths.spack_root),
+                    join_path(mysqlgcs_path, 'mysqlgcs.dir/build.make'))


### PR DESCRIPTION
An error occurred when building with clang.
Error message is "cpp: error trying to exec 'cc1': execvp: No such file or directory".

In fact, this error occurs with all compilers.
When compiling with gcc, '/usr/bin/cpp' can be found because it is always in $PATH.

The PR fixes this bug by adding 'cpp' path for rpcgen, such as https://github.com/spack/spack/pull/31157.