### PR TITLE
Deprioritize system paths for -I, -L, -Wl,-rpath

### DIFF
--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -923,10 +923,17 @@ def uniq(sequence):
 
 
 def stable_partition(arr, pred):
-    """Reorders the elements in arr in such a way that all elements for which the
-    predicate `pred` returns true precede the elements for which predicate p returns
-    false. Relative order of the elements is preserved. Upon return, arr is not
-    modified, the algorith is out-of-place.
+    """Reorders the elements in `arr` in such a way that all elements for which the
+    predicate `pred` returns true precede the elements for which predicate `pred`
+    returns false. Relative order of the elements is preserved. Upon return, `arr` is
+    not modified, the algorithm is out-of-place.
+
+    Args:
+        arr (list): constant array to be partitioned
+        pred (function): unary function mapping to bool
+
+    Returns:
+        A stably ordered copy of arr partitioned by `pred`.
     """
     yes, no = [], []
     for item in arr:

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -930,7 +930,7 @@ def stable_partition(arr, pred):
 
     Args:
         arr (list): constant array to be partitioned
-        pred (function): unary function mapping to bool
+        pred: unary function mapping to bool
 
     Returns:
         A stably ordered copy of arr partitioned by `pred`.

--- a/lib/spack/llnl/util/lang.py
+++ b/lib/spack/llnl/util/lang.py
@@ -922,6 +922,21 @@ def uniq(sequence):
     return uniq_list
 
 
+def stable_partition(arr, pred):
+    """Reorders the elements in arr in such a way that all elements for which the
+    predicate `pred` returns true precede the elements for which predicate p returns
+    false. Relative order of the elements is preserved. Upon return, arr is not
+    modified, the algorith is out-of-place.
+    """
+    yes, no = [], []
+    for item in arr:
+        if pred(item):
+            yes.append(item)
+        else:
+            no.append(item)
+    return yes + no
+
+
 def star(func):
     """Unpacks arguments for use with Multiprocessing mapping functions"""
     def _wrapper(args):

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -301,15 +301,15 @@ def test_grouped_exception():
     due to the following failures:
     inner method raised ValueError: wow!
       File "{0}", \
-line 283, in test_grouped_exception
+line 290, in test_grouped_exception
         inner()
       File "{0}", \
-line 280, in inner
+line 287, in inner
         raise ValueError('wow!')
 
     top-level raised TypeError: ok
       File "{0}", \
-line 286, in test_grouped_exception
+line 293, in test_grouped_exception
         raise TypeError('ok')
     """).format(__file__)
 

--- a/lib/spack/spack/test/llnl/util/lang.py
+++ b/lib/spack/spack/test/llnl/util/lang.py
@@ -11,7 +11,14 @@ from textwrap import dedent
 import pytest
 
 import llnl.util.lang
-from llnl.util.lang import dedupe, match_predicate, memoized, pretty_date, stable_args
+from llnl.util.lang import (
+    dedupe,
+    match_predicate,
+    memoized,
+    pretty_date,
+    stable_args,
+    stable_partition,
+)
 
 
 @pytest.fixture()
@@ -305,3 +312,10 @@ line 280, in inner
 line 286, in test_grouped_exception
         raise TypeError('ok')
     """).format(__file__)
+
+
+def test_stable_partition():
+    stable_partition([1, 2, 3, 4, 5], lambda x: x % 2 == 0) == [2, 4, 1, 3, 5]
+    stable_partition([], lambda x: True) == []
+    stable_partition([1, 2, 3, 4, 5], lambda x: False) == [1, 2, 3, 4, 5]
+    stable_partition([1, 2, 3, 4, 5], lambda x: True) == [1, 2, 3, 4, 5]


### PR DESCRIPTION
Closes #31712

Dropping system paths is a bad idea, since it causes the linker and
dynamic linker to favor `ld.so.conf` paths over user-specified external
system paths.

For consistency, also include system paths in -I.

---

Edit: may be worth pointing out that this helps mostly on systems like
SUSE Linux that do not have "multi arch/lib" type library dirs
`/usr/lib{,64}/{i386,i686,x86_64}-linux-{gnu,musl}/`, but put almost
all system libs in `/usr/lib64`, which can be shadowed by ld.so.conf.

On distros that put almost all system libraries in a multiarch type dir,
this usually works by registering those paths in `/etc/ld.so.conf`. So,
if one library in `/usr/lib/x86_64-linux-gnu` is shadowed by
`/op/cray/lib64`, I guess it's not Spack's role to fix this, since it's
simply unclear what library should be picked up there.