### PR TITLE
openblas %oneapi: link w/ libifcore explicitly via flag_handler

### DIFF
--- a/var/spack/repos/builtin/packages/openblas/package.py
+++ b/var/spack/repos/builtin/packages/openblas/package.py
@@ -149,6 +149,14 @@ class Openblas(MakefilePackage):
 
     depends_on('perl', type='build')
 
+    def flag_handler(self, name, flags):
+        spec = self.spec
+        iflags = []
+        if name == 'ldflags':
+            if spec.satisfies('@0.3.20 %oneapi'):
+                iflags.append('-lifcore')
+        return (iflags, None, flags)
+
     @classmethod
     def determine_version(cls, lib):
         ver = None


### PR DESCRIPTION
Explicitly link `openblas %oneapi` to `libifcore` via `flag_handler`

Fixes https://github.com/spack/spack/issues/31732

@becker33 @wspear 