### PR TITLE
bugfix: use cmake version from dependency

### DIFF
--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -544,7 +544,6 @@ def _set_variables_for_single_module(pkg, module):
     m.configure = Executable("./configure")
 
     m.meson = Executable("meson")
-    m.cmake = Executable("cmake")
     m.ctest = MakeExecutable("ctest", jobs)
 
     if sys.platform == "win32":

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -533,8 +533,6 @@ def _set_variables_for_single_module(pkg, module):
     # TODO: make these build deps that can be installed if not found.
     m.make = MakeExecutable("make", jobs)
     m.gmake = MakeExecutable("gmake", jobs)
-    m.scons = MakeExecutable("scons", jobs)
-    m.ninja = MakeExecutable("ninja", jobs)
 
     # easy shortcut to os.environ
     m.env = os.environ
@@ -542,9 +540,6 @@ def _set_variables_for_single_module(pkg, module):
     # Find the configure script in the archive path
     # Don't use which for this; we want to find it in the current dir.
     m.configure = Executable("./configure")
-
-    m.meson = Executable("meson")
-    m.ctest = MakeExecutable("ctest", jobs)
 
     if sys.platform == "win32":
         m.nmake = Executable("nmake")

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -136,14 +136,16 @@ class MakeExecutable(Executable):
     -j).
     """
 
-    def __init__(self, name, jobs):
-        super(MakeExecutable, self).__init__(name)
+    def __init__(self, name, jobs, **kwargs):
+        super(MakeExecutable, self).__init__(name, **kwargs)
         self.jobs = jobs
 
     def __call__(self, *args, **kwargs):
         """parallel, and jobs_env from kwargs are swallowed and used here;
         remaining arguments are passed through to the superclass.
         """
+        # TODO: figure out how to check if we are using a jobserver-supporting ninja,
+        # the two split ninja packages make this very difficult right now
         parallel = should_set_parallel_jobs(jobserver_support=True) and kwargs.pop(
             "parallel", self.jobs > 1
         )
@@ -533,6 +535,7 @@ def _set_variables_for_single_module(pkg, module):
     # TODO: make these build deps that can be installed if not found.
     m.make = MakeExecutable("make", jobs)
     m.gmake = MakeExecutable("gmake", jobs)
+    m.ninja = MakeExecutable("ninja", jobs)
 
     # easy shortcut to os.environ
     m.env = os.environ

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -291,6 +291,13 @@ def which_string(*args, **kwargs):
             win_candidates = [name + ext for ext in [".exe", ".bat"]]
         candidate_names = [name] if not win_candidates else win_candidates
 
+        if sys.platform == "win32":
+            new_path = path[:]
+            for p in path:
+                if os.path.basename(p) == "bin":
+                    new_path.append(os.path.dirname(p))
+            path = new_path
+
         for candidate_name in candidate_names:
             if os.path.sep in candidate_name:
                 exe = os.path.abspath(candidate_name)

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -328,14 +328,12 @@ def which(*args, **kwargs):
     Keyword Arguments:
         path (list or str): The path to search. Defaults to ``PATH``
         required (bool): If set to True, raise an error if executable not found
-        exe_class (callable): If not None, used instead of Executable
 
     Returns:
         Executable: The first executable that is found in the path
     """
     exe = which_string(*args, **kwargs)
-    exe_class = kwargs.get("exe_class", Executable)
-    return exe_class(exe) if exe else None
+    return Executable(exe) if exe else None
 
 
 class ProcessError(spack.error.SpackError):

--- a/lib/spack/spack/util/executable.py
+++ b/lib/spack/spack/util/executable.py
@@ -328,12 +328,14 @@ def which(*args, **kwargs):
     Keyword Arguments:
         path (list or str): The path to search. Defaults to ``PATH``
         required (bool): If set to True, raise an error if executable not found
+        exe_class (callable): If not None, used instead of Executable
 
     Returns:
         Executable: The first executable that is found in the path
     """
     exe = which_string(*args, **kwargs)
-    return Executable(exe) if exe else None
+    exe_class = kwargs.get("exe_class", Executable)
+    return exe_class(exe) if exe else None
 
 
 class ProcessError(spack.error.SpackError):

--- a/var/spack/repos/builtin.mock/packages/cmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake/package.py
@@ -41,6 +41,7 @@ class Cmake(Package):
         spack_cc  # Ensure spack module-scope variable is avaiable
 
         module.cmake = Executable(self.spec.prefix.bin.cmake)
+        module.ctest = Executable(self.spec.prefix.bin.ctest)
         self.spec.from_cmake = "from_cmake"
         module.from_cmake = "from_cmake"
 

--- a/var/spack/repos/builtin.mock/packages/cmake/package.py
+++ b/var/spack/repos/builtin.mock/packages/cmake/package.py
@@ -40,6 +40,7 @@ class Cmake(Package):
     def setup_dependent_package(self, module, dspec):
         spack_cc  # Ensure spack module-scope variable is avaiable
 
+        module.cmake = Executable(self.spec.prefix.bin.cmake)
         self.spec.from_cmake = "from_cmake"
         module.from_cmake = "from_cmake"
 

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
+from spack.util.executable import Executable
+
+ninja = Executable('ninja')  # to appease ninja test
 
 
 class Mpich(Package):

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -6,7 +6,7 @@
 from spack.package import *
 from spack.util.executable import Executable
 
-ninja = Executable('ninja')  # to appease ninja test
+ninja = Executable("ninja")  # to appease ninja test
 
 
 class Mpich(Package):

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack.package import *
-from spack.util.executable import Executable
 
 
 class Mpich(Package):

--- a/var/spack/repos/builtin.mock/packages/mpich/package.py
+++ b/var/spack/repos/builtin.mock/packages/mpich/package.py
@@ -6,8 +6,6 @@
 from spack.package import *
 from spack.util.executable import Executable
 
-ninja = Executable("ninja")  # to appease ninja test
-
 
 class Mpich(Package):
     homepage = "http://www.mpich.org"

--- a/var/spack/repos/builtin.mock/packages/ninja/package.py
+++ b/var/spack/repos/builtin.mock/packages/ninja/package.py
@@ -13,3 +13,6 @@ class Ninja(Package):
     url = "https://github.com/ninja-build/ninja/archive/v1.7.2.tar.gz"
 
     version("1.10.2", sha256="ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed")
+
+    def setup_dependent_package(self, module, dspec):
+        module.ninja = Executable(self.spec.prefix.bin.ninja)

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -403,6 +403,7 @@ class Cmake(Package):
         """Called before cmake packages's install() methods."""
 
         module.cmake = Executable(self.spec.prefix.bin.cmake)
+        module.ctest = Executable(self.spec.prefix.bin.ctest)
 
     def test(self):
         """Perform smoke tests on the installed package."""

--- a/var/spack/repos/builtin/packages/cmake/package.py
+++ b/var/spack/repos/builtin/packages/cmake/package.py
@@ -399,6 +399,11 @@ class Cmake(Package):
                 filter_file("mpc++_r)", "mpc++_r mpiFCC)", f, string=True)
                 filter_file("mpifc)", "mpifc mpifrt)", f, string=True)
 
+    def setup_dependent_package(self, module, dependent_spec):
+        """Called before cmake packages's install() methods."""
+
+        module.cmake = Executable(self.spec.prefix.bin.cmake)
+
     def test(self):
         """Perform smoke tests on the installed package."""
         spec_vers_str = "version {0}".format(self.spec.version)

--- a/var/spack/repos/builtin/packages/gmake/package.py
+++ b/var/spack/repos/builtin/packages/gmake/package.py
@@ -5,6 +5,7 @@
 
 import re
 
+from spack.build_environment import MakeExecutable
 from spack.package import *
 
 
@@ -71,3 +72,7 @@ class Gmake(AutotoolsPackage, GNUMirrorPackage):
     def symlink_gmake(self):
         with working_dir(self.prefix.bin):
             symlink("make", "gmake")
+
+    def setup_dependent_package(self, module, dspec):
+        module.make = MakeExecutable(self.spec.prefix.bin.make, make_jobs)
+        module.gmake = MakeExecutable(self.spec.prefix.bin.gmake, make_jobs)

--- a/var/spack/repos/builtin/packages/meson/package.py
+++ b/var/spack/repos/builtin/packages/meson/package.py
@@ -81,3 +81,6 @@ class Meson(PythonPackage):
         # https://github.com/pybind/pybind11/issues/595
         if self.spec.satisfies("platform=darwin"):
             env.set("STRIP", "strip -x")
+
+    def setup_dependent_package(self, module, dspec):
+        module.meson = Executable(self.spec.prefix.bin.meson)

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -6,6 +6,7 @@ import sys
 
 from spack.build_environment import MakeExecutable
 from spack.package import *
+from spack.util.executable import which_string
 
 
 class Ninja(Package):
@@ -73,6 +74,6 @@ class Ninja(Package):
 
     def setup_dependent_package(self, module, dspec):
         name = "ninja"
-        module.ninja = which(
-            name, exe_class=MakeExecutable, path=[self.spec.prefix.bin], required=True
+        module.ninja = MakeExecutable(
+            which_string(name, path=[self.spec.prefix.bin], required=True), module.make_jobs
         )

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -69,3 +69,6 @@ class Ninja(Package):
         # instead of 'ninja'. Install both for uniformity.
         with working_dir(prefix.bin):
             symlink("ninja", "ninja-build")
+
+    def setup_dependent_package(self, module, dspec):
+        module.ninja = Executable(self.spec.prefix.bin.ninja)

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 import sys
 
+from spack.build_environment import MakeExecutable
 from spack.package import *
 
 
@@ -72,4 +73,6 @@ class Ninja(Package):
 
     def setup_dependent_package(self, module, dspec):
         name = "ninja"
-        module.ninja = which(name, path=[self.spec.prefix.bin], required=True)
+        module.ninja = which(
+            name, exe_class=MakeExecutable, path=[self.spec.prefix.bin], required=True
+        )

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -72,6 +72,4 @@ class Ninja(Package):
 
     def setup_dependent_package(self, module, dspec):
         name = "ninja"
-        if sys.platform == "win32":
-            name = name + ".exe"
         module.ninja = which(name, path=[self.spec.prefix.bin], required=True)

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -74,4 +74,4 @@ class Ninja(Package):
         name = "ninja"
         if sys.platform == "win32":
             name = name + ".exe"
-        module.ninja = which(name, path=[self.spec.prefix.bin])
+        module.ninja = which(name, path=[self.spec.prefix.bin], required=True)

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -71,4 +71,4 @@ class Ninja(Package):
             symlink("ninja", "ninja-build")
 
     def setup_dependent_package(self, module, dspec):
-        module.ninja = Executable(self.spec.prefix.bin.ninja)
+        module.ninja = which("ninja", path=[self.spec.prefix.bin])

--- a/var/spack/repos/builtin/packages/ninja/package.py
+++ b/var/spack/repos/builtin/packages/ninja/package.py
@@ -71,4 +71,7 @@ class Ninja(Package):
             symlink("ninja", "ninja-build")
 
     def setup_dependent_package(self, module, dspec):
-        module.ninja = which("ninja", path=[self.spec.prefix.bin])
+        name = "ninja"
+        if sys.platform == "win32":
+            name = name + ".exe"
+        module.ninja = which(name, path=[self.spec.prefix.bin])

--- a/var/spack/repos/builtin/packages/scons/package.py
+++ b/var/spack/repos/builtin/packages/scons/package.py
@@ -57,3 +57,6 @@ class Scons(PythonPackage):
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         env.prepend_path("PYTHONPATH", self.prefix.lib.scons)
+
+    def setup_dependent_package(self, module, dspec):
+        module.scons = Executable(self.spec.prefix.bin.scons)

--- a/var/spack/repos/builtin/packages/sqlite/package.py
+++ b/var/spack/repos/builtin/packages/sqlite/package.py
@@ -17,6 +17,7 @@ class Sqlite(AutotoolsPackage):
 
     homepage = "https://www.sqlite.org"
 
+    version("3.39.2", sha256="852be8a6183a17ba47cee0bbff7400b7aa5affd283bf3beefc34fcd088a239de")
     version("3.38.5", sha256="5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c")
     version("3.38.3", sha256="61f2dd93a2e38c33468b7125967c3218bf9f4dd8365def6025e314f905dc942e")
     version("3.37.2", sha256="4089a8d9b467537b3f246f217b84cd76e00b1d1a971fe5aca1e30e230e46b2d8")


### PR DESCRIPTION
Ensure that build tools with module-level commands in spack use the version built as part of their build graph if one exists.  This is now also required for mesa, scons, cmake and ctest, out of graph versions of these tools in path will not be found unless added as an external.  

This bug appeared because a new version of rocprim needs cmake 3.16, while I have 3.14 in my path I had added an external for cmake 3.20 to the dag, but 3.14 was still used to configure rocprim causing it to fail.  As far as I can tell, all the build tools added in build_environment.py had this problem, despite the fact that they should have been resolving these tools by name with a path search and find the one in the dag that way.  I'm still investigating why the path searching and Executable logic didn't do it, but this makes three of the build systems much more explicit, and leaves only gmake and ninja as dependencies from out in the system while ensuring the version in the dag is used if there is one.

The additional sqlite version is to perturb the hash of python to work around a relocation bug which will be fixed in a subsequent PR.