### PR TITLE
`spack -e x config --scope=y add z` add to scope

### DIFF
--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -120,7 +120,7 @@ def _get_scope_and_section(args):
     path = getattr(args, "path", None)
 
     # w/no args and an active environment, point to env manifest
-    if not section and not path:
+    if not section and not scope:
         env = ev.active_environment()
         if env:
             scope = env.env_file_config_scope_name()

--- a/lib/spack/spack/cmd/config.py
+++ b/lib/spack/spack/cmd/config.py
@@ -120,7 +120,7 @@ def _get_scope_and_section(args):
     path = getattr(args, "path", None)
 
     # w/no args and an active environment, point to env manifest
-    if not section:
+    if not section and not path:
         env = ev.active_environment()
         if env:
             scope = env.env_file_config_scope_name()

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -118,6 +118,14 @@ def test_config_edit_edits_spack_yaml(mutable_mock_env_path):
         assert config("edit", "--print-file").strip() == env.manifest_path
 
 
+def test_config_add_with_scope_adds_to_scope(mutable_config, mutable_mock_env_path):
+    """Test adding to non-env config scope with an active environment"""
+    env = ev.create('test')
+    with env:
+        config('--scope=user', 'add', 'config:install_tree:root:/usr')
+    assert spack.config.get('config:install_tree:root', scope='user') == '/usr'
+
+
 def test_config_edit_fails_correctly_with_no_env(mutable_mock_env_path):
     output = config("edit", "--print-file", fail_on_error=False)
     assert "requires a section argument or an active environment" in output

--- a/lib/spack/spack/test/cmd/config.py
+++ b/lib/spack/spack/test/cmd/config.py
@@ -120,10 +120,10 @@ def test_config_edit_edits_spack_yaml(mutable_mock_env_path):
 
 def test_config_add_with_scope_adds_to_scope(mutable_config, mutable_mock_env_path):
     """Test adding to non-env config scope with an active environment"""
-    env = ev.create('test')
+    env = ev.create("test")
     with env:
-        config('--scope=user', 'add', 'config:install_tree:root:/usr')
-    assert spack.config.get('config:install_tree:root', scope='user') == '/usr'
+        config("--scope=user", "add", "config:install_tree:root:/usr")
+    assert spack.config.get("config:install_tree:root", scope="user") == "/usr"
 
 
 def test_config_edit_fails_correctly_with_no_env(mutable_mock_env_path):


### PR DESCRIPTION
Fixes a bug where `spack -e x config --scope=y add z` adds `z` to environment `x` instead of scope `y`.
