### PR TITLE
e4s ci stack: add spec: hdf5-vol-async

### DIFF
--- a/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
+++ b/share/spack/gitlab/cloud_pipelines/stacks/e4s/spack.yaml
@@ -85,6 +85,7 @@ spack:
   - gmp
   - gptune
   - hdf5 +fortran +hl +shared
+  - hdf5-vol-async
   - heffte +fftw
   - hpctoolkit
   - hpx networking=mpi

--- a/var/spack/repos/builtin/packages/hdf5-vol-async/package.py
+++ b/var/spack/repos/builtin/packages/hdf5-vol-async/package.py
@@ -14,6 +14,8 @@ class Hdf5VolAsync(CMakePackage):
 
     maintainers = ['hyoklee', 'houjun', 'jeanbez']
 
+    tags = ['e4s']
+
     version('develop', branch='develop')
     version('1.2', tag='v1.2')
     version('1.1', tag='v1.1')


### PR DESCRIPTION
E4S CI stack: add new spec `hdf5-vol-async`

(In response to https://github.com/E4S-Project/e4s/issues/77)

FYI @houjun @hyoklee @jeanbez @wspear