### PR TITLE
Tau must get GCC path from environment on Cray

### DIFF
--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -146,10 +146,16 @@ class Tau(Package):
         # 4 - if no -cc=<compiler> -cxx=<compiler> is passed tau is built with
         #     system compiler silently
         # (regardless of what %<compiler> is used in the spec)
+        # 5 - On cray gnu compilers are not provied by self.compilers
+        #     Checking GCC_PATH will work if spack loads the gcc module
         #
         # In the following we give TAU what he expects and put compilers into
         # PATH
         compiler_path = os.path.dirname(self.compiler.cc)
+        if not compiler_path and self.compiler.cc_names[0] == "gcc":
+            compiler_path=os.environ.get('GCC_PATH','')
+            if compiler_path:
+                compiler_path=compiler_path+"/bin/"
         os.environ['PATH'] = ':'.join([compiler_path, os.environ['PATH']])
 
         compiler_options = ['-c++=%s' % self.compiler.cxx_names[0],

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -155,7 +155,7 @@ class Tau(Package):
         if not compiler_path and self.compiler.cc_names[0] == "gcc":
             compiler_path = os.environ.get('GCC_PATH', '')
             if compiler_path:
-                compiler_path = compiler_path+"/bin/"
+                compiler_path = compiler_path + "/bin/"
         os.environ['PATH'] = ':'.join([compiler_path, os.environ['PATH']])
 
         compiler_options = ['-c++=%s' % self.compiler.cxx_names[0],

--- a/var/spack/repos/builtin/packages/tau/package.py
+++ b/var/spack/repos/builtin/packages/tau/package.py
@@ -153,9 +153,9 @@ class Tau(Package):
         # PATH
         compiler_path = os.path.dirname(self.compiler.cc)
         if not compiler_path and self.compiler.cc_names[0] == "gcc":
-            compiler_path=os.environ.get('GCC_PATH','')
+            compiler_path = os.environ.get('GCC_PATH', '')
             if compiler_path:
-                compiler_path=compiler_path+"/bin/"
+                compiler_path = compiler_path+"/bin/"
         os.environ['PATH'] = ':'.join([compiler_path, os.environ['PATH']])
 
         compiler_options = ['-c++=%s' % self.compiler.cxx_names[0],


### PR DESCRIPTION
self.compiler doesn't provide the path to the gcc compiler when using cray cc and the spack internal compiler overrides the location in PATH. If possible get the location from the GCC_PATH variable instead.